### PR TITLE
misc: Replace assert include and calls by sys/__assert.h equivalent

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(adc_mchp_xec);
 #include <drivers/adc.h>
 #include <soc.h>
 #include <errno.h>
-#include <assert.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -9,7 +9,6 @@
  * @brief A driver for sending and receiving mcumgr packets over UART.
  */
 
-#include <assert.h>
 #include <string.h>
 #include <kernel.h>
 #include <drivers/uart.h>

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <device.h>
 #include <drivers/i2c.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <crypto/cipher.h>
 
 #include "crypto_ataes132a_priv.h"
@@ -675,7 +675,7 @@ static int do_ccm_encrypt_mac(struct cipher_ctx *ctx,
 
 	key_id = state->key_id;
 
-	assert(*(uint8_t *)ctx->key.handle == key_id);
+	__ASSERT_NO_MSG(*(uint8_t *)ctx->key.handle == key_id);
 
 	/* Removing all this salt from the MAC reduces the protection
 	 * but allows any other crypto implementations to authorize
@@ -724,7 +724,7 @@ static int do_ccm_decrypt_auth(struct cipher_ctx *ctx,
 
 	key_id = state->key_id;
 
-	assert(*(uint8_t *)ctx->key.handle == key_id);
+	__ASSERT_NO_MSG(*(uint8_t *)ctx->key.handle == key_id);
 
 	/* Removing all this salt from the MAC reduces the protection
 	 * but allows any other crypto implementations to authorize
@@ -768,7 +768,7 @@ static int do_block(struct cipher_ctx *ctx, struct cipher_pkt *pkt)
 
 	key_id = state->key_id;
 
-	assert(*(uint8_t *)ctx->key.handle == key_id);
+	__ASSERT_NO_MSG(*(uint8_t *)ctx->key.handle == key_id);
 
 	if (pkt->out_buf_max < 16) {
 		LOG_ERR("Not enough space available in out buffer.");

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -9,7 +9,7 @@
 #include <init.h>
 #include <kernel.h>
 #include <device.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <crypto/cipher.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/clock_control.h>

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <device.h>
 #include <sys/util.h>
 #include <kernel.h>
+#include <sys/__assert.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>
 #include <net/ethernet.h>
@@ -882,7 +883,7 @@ flush:
 	 * which cannot happen in this context.
 	 */
 	status = ENET_ReadFrame(context->base, &context->enet_handle, NULL, 0);
-	assert(status == kStatus_Success);
+	__ASSERT_NO_MSG(status == kStatus_Success);
 error:
 	eth_stats_update_errors_rx(get_iface(context, vlan_tag));
 }

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -9,7 +9,7 @@
 #include <sys/byteorder.h>
 #include <soc.h>
 #include <sys/util.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include "i2s_litex.h"
 #include <logging/log.h>
 
@@ -125,7 +125,7 @@ static uint32_t i2s_get_audio_freq(uintptr_t reg)
  */
 static void i2s_irq_enable(uintptr_t reg, int irq_type)
 {
-	assert(irq_type == I2S_EV_READY || irq_type == I2S_EV_ERROR);
+	__ASSERT_NO_MSG(irq_type == I2S_EV_READY || irq_type == I2S_EV_ERROR);
 
 	uint8_t reg_data = litex_read8(reg + I2S_EV_ENABLE_REG_OFFSET);
 
@@ -142,7 +142,7 @@ static void i2s_irq_enable(uintptr_t reg, int irq_type)
  */
 static void i2s_irq_disable(uintptr_t reg, int irq_type)
 {
-	assert(irq_type == I2S_EV_READY || irq_type == I2S_EV_ERROR);
+	__ASSERT_NO_MSG(irq_type == I2S_EV_READY || irq_type == I2S_EV_ERROR);
 
 	uint8_t reg_data = litex_read8(reg + I2S_EV_ENABLE_REG_OFFSET);
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -15,7 +15,6 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <errno.h>
-#include <assert.h>
 #include <stdio.h>
 
 #include <kernel.h>

--- a/drivers/ieee802154/ieee802154_rf2xx_iface.c
+++ b/drivers/ieee802154/ieee802154_rf2xx_iface.c
@@ -13,7 +13,6 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <errno.h>
-#include <assert.h>
 
 #include <device.h>
 #include <drivers/spi.h>

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
+#include <sys/__assert.h>
 #include <sw_isr_table.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <drivers/interrupt_controller/gic.h>
@@ -131,7 +131,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 	uint32_t aff3, aff2, aff1;
 	uint64_t sgi_val;
 
-	assert(GIC_IS_SGI(sgi_id));
+	__ASSERT_NO_MSG(GIC_IS_SGI(sgi_id));
 
 	/* Extract affinity fields from target */
 	aff1 = MPIDR_AFFLVL(target_aff, 1);
@@ -213,7 +213,7 @@ static void gicv3_cpuif_init(void)
 		write_sysreg(icc_sre, ICC_SRE_EL1);
 		icc_sre = read_sysreg(ICC_SRE_EL1);
 
-		assert(icc_sre & ICC_SRE_ELx_SRE);
+		__ASSERT_NO_MSG(icc_sre & ICC_SRE_ELx_SRE);
 	}
 
 	write_sysreg(GIC_IDLE_PRIO, ICC_PMR_EL1);

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -46,10 +46,10 @@
  *
  */
 
-#include <assert.h>
 #include <device.h>
 #include <kernel.h>
 #include <soc.h>
+#include <sys/__assert.h>
 #include <irq_nextlevel.h>
 #include <drivers/gpio.h>
 

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -258,7 +258,7 @@ static int pwm_led_esp32_timer_set(int speed_mode, int timer,
 	int tick_sel = PWM_LED_ESP32_APB_CLK_FREQ;
 	uint32_t precision = (0x1 << bit_num);
 
-	assert(frequency > 0);
+	__ASSERT_NO_MSG(frequency > 0);
 
 	/* This expression comes from ESP32 Espressif's Technical Reference
 	 * Manual chapter 13.2.2 Timers.

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT nuvoton_npcx_uart
 
-#include <assert.h>
+#include <sys/__assert.h>
 #include <drivers/gpio.h>
 #include <drivers/uart.h>
 #include <drivers/clock_control.h>

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -11,7 +11,6 @@
 #include <drivers/watchdog.h>
 #include <soc.h>
 #include <errno.h>
-#include <assert.h>
 
 #include "wdt_iwdg_stm32.h"
 

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -15,7 +15,6 @@ LOG_MODULE_REGISTER(wdt_mchp_xec);
 #include <drivers/watchdog.h>
 #include <soc.h>
 #include <errno.h>
-#include <assert.h>
 
 #define WDT_XEC_REG_BASE						\
 	((WDT_Type *)(DT_INST_REG_ADDR(0)))

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -9,7 +9,7 @@
 #include <drivers/watchdog.h>
 #include <soc.h>
 #include <errno.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/clock_control.h>
 

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
+#include <sys/__assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
@@ -512,7 +512,7 @@ static int arr_parse(struct json_obj *obj,
 	size_t *elements = (size_t *)((char *)val + elem_descr->offset);
 	struct token value;
 
-	assert(elem_size > 0);
+	__ASSERT_NO_MSG(elem_size > 0);
 
 	*elements = 0;
 
@@ -589,7 +589,7 @@ int json_obj_parse(char *payload, size_t len,
 	struct json_obj obj;
 	int ret;
 
-	assert(descr_len < (sizeof(ret) * CHAR_BIT - 1));
+	__ASSERT_NO_MSG(descr_len < (sizeof(ret) * CHAR_BIT - 1));
 
 	ret = obj_init(&obj, payload, len);
 	if (ret < 0) {

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
+#include <sys/__assert.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/gatt.h>
@@ -44,7 +44,7 @@ void smp_svr_init(void)
 	int rc;
 
 	rc = STATS_INIT_AND_REG(smp_svr_stats, STATS_SIZE_32, "smp_svr_stats");
-	assert(rc == 0);
+	__ASSERT_NO_MSG(rc == 0);
 
 	/* Register the built-in mcumgr command handlers. */
 #ifdef CONFIG_MCUMGR_CMD_FS_MGMT

--- a/samples/net/sockets/socketpair/src/socketpair_example.c
+++ b/samples/net/sockets/socketpair/src/socketpair_example.c
@@ -24,7 +24,6 @@
 
 #endif
 
-#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/subsys/bluetooth/host/a2dp.c
+++ b/subsys/bluetooth/host/a2dp.c
@@ -15,7 +15,6 @@
 #include <sys/byteorder.h>
 #include <sys/util.h>
 #include <sys/printk.h>
-#include <assert.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
 #include <stddef.h>
 #include <errno.h>
 #include <string.h>
@@ -298,7 +297,7 @@ static int boot_write_trailer_byte(const struct flash_area *fa, uint32_t off,
 	int rc;
 
 	align = flash_area_align(fa);
-	assert(align <= BOOT_MAX_ALIGN);
+	__ASSERT_NO_MSG(align <= BOOT_MAX_ALIGN);
 	erased_val = flash_area_erased_val(fa);
 	memset(buf, erased_val, BOOT_MAX_ALIGN);
 	buf[0] = val;
@@ -640,9 +639,9 @@ int mcuboot_swap_type(void)
 		    (table->copy_done_primary_slot == BOOT_FLAG_ANY  ||
 		     table->copy_done_primary_slot == primary_slot.copy_done)) {
 
-			assert(table->swap_type == BOOT_SWAP_TYPE_TEST ||
-			       table->swap_type == BOOT_SWAP_TYPE_PERM ||
-			       table->swap_type == BOOT_SWAP_TYPE_REVERT);
+			__ASSERT_NO_MSG(table->swap_type == BOOT_SWAP_TYPE_TEST ||
+					table->swap_type == BOOT_SWAP_TYPE_PERM ||
+					table->swap_type == BOOT_SWAP_TYPE_REVERT);
 			return table->swap_type;
 		}
 	}

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -8,6 +8,7 @@
 
 #define DT_DRV_COMPAT nxp_imx_usdhc
 
+#include <sys/__assert.h>
 #include <disk/disk_access.h>
 #include <drivers/gpio.h>
 #include <sys/byteorder.h>
@@ -1783,8 +1784,8 @@ uint32_t usdhc_set_sd_clk(USDHC_Type *base, uint32_t src_clk_hz, uint32_t sd_clk
 	uint32_t sysctl = 0U;
 	uint32_t nearest_freq = 0U;
 
-	assert(src_clk_hz != 0U);
-	assert((sd_clk_hz != 0U) && (sd_clk_hz <= src_clk_hz));
+	__ASSERT_NO_MSG(src_clk_hz != 0U);
+	__ASSERT_NO_MSG((sd_clk_hz != 0U) && (sd_clk_hz <= src_clk_hz));
 
 	/* calculate total divisor first */
 	total_div = src_clk_hz / sd_clk_hz;
@@ -2175,12 +2176,12 @@ static void usdhc_host_hw_init(USDHC_Type *base,
 	uint32_t proctl, sysctl, wml;
 	uint32_t int_mask;
 
-	assert(config);
-	assert((config->write_watermark >= 1U) &&
-		(config->write_watermark <= 128U));
-	assert((config->read_watermark >= 1U) &&
-		(config->read_watermark <= 128U));
-	assert(config->write_burst_len <= 16U);
+	__ASSERT_NO_MSG(config);
+	__ASSERT_NO_MSG((config->write_watermark >= 1U) &&
+			(config->write_watermark <= 128U));
+	__ASSERT_NO_MSG((config->read_watermark >= 1U) &&
+			(config->read_watermark <= 128U));
+	__ASSERT_NO_MSG(config->write_burst_len <= 16U);
 
 	/* Reset USDHC. */
 	usdhc_hw_reset(base, USDHC_RESET_ALL, 100U);

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -11,7 +11,7 @@
 #include "log_backend_std.h"
 #include <device.h>
 #include <drivers/uart.h>
-#include <assert.h>
+#include <sys/__assert.h>
 
 static const struct device *uart_dev;
 
@@ -42,7 +42,7 @@ static void put(const struct log_backend *const backend,
 static void log_backend_uart_init(void)
 {
 	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
-	assert((void *)uart_dev);
+	__ASSERT_NO_MSG((void *)uart_dev);
 }
 
 static void panic(struct log_backend const *const backend)

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -11,7 +11,7 @@
 #include <logging/log_output.h>
 #include <sys/printk.h>
 #include <init.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <sys/atomic.h>
 #include <ctype.h>
 #include <logging/log_frontend.h>
@@ -520,7 +520,7 @@ void log_core_init(void)
 
 void log_init(void)
 {
-	assert(log_backend_count_get() < LOG_FILTERS_NUM_OF_SLOTS);
+	__ASSERT_NO_MSG(log_backend_count_get() < LOG_FILTERS_NUM_OF_SLOTS);
 	int i;
 
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
@@ -563,7 +563,7 @@ static void thread_set(k_tid_t process_tid)
 void log_thread_set(k_tid_t process_tid)
 {
 	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
-		assert(0);
+		__ASSERT_NO_MSG(0);
 	} else {
 		thread_set(process_tid);
 	}
@@ -756,7 +756,7 @@ uint32_t z_impl_log_filter_set(struct log_backend const *const backend,
 			    uint32_t src_id,
 			    uint32_t level)
 {
-	assert(src_id < log_sources_count());
+	__ASSERT_NO_MSG(src_id < log_sources_count());
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
 		uint32_t new_aggr_filter;
@@ -866,7 +866,7 @@ uint32_t log_filter_get(struct log_backend const *const backend,
 		     uint32_t src_id,
 		     bool runtime)
 {
-	assert(src_id < log_sources_count());
+	__ASSERT_NO_MSG(src_id < log_sources_count());
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && runtime) {
 		uint32_t *filters = log_dynamic_filters_get(src_id);

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -8,8 +8,8 @@
 #include <logging/log_msg.h>
 #include <logging/log_ctrl.h>
 #include <logging/log_core.h>
+#include <sys/__assert.h>
 #include <string.h>
-#include <assert.h>
 
 BUILD_ASSERT((sizeof(struct log_msg_ids) == sizeof(uint16_t)),
 	     "Structure must fit in 2 bytes");

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -7,7 +7,7 @@
 #include <logging/log_output.h>
 #include <logging/log_ctrl.h>
 #include <logging/log.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <ctype.h>
 #include <time.h>
 #include <stdio.h>

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -7,9 +7,9 @@
 #include <init.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <assert.h>
 #include <kernel.h>
 #include <mipi_syst.h>
+#include <sys/__assert.h>
 #include <logging/log.h>
 #include <logging/log_ctrl.h>
 #include <logging/log_output.h>

--- a/subsys/mgmt/mcumgr/buf.c
+++ b/subsys/mgmt/mcumgr/buf.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
 #include <string.h>
 #include "net/buf.h"
 #include "mgmt/mcumgr/buf.h"

--- a/subsys/mgmt/mcumgr/serial_util.c
+++ b/subsys/mgmt/mcumgr/serial_util.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
+#include <sys/__assert.h>
 #include <string.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -167,8 +167,8 @@ static int mcumgr_serial_tx_small(const void *data, int len,
 	int rc;
 
 	rc = base64_encode(b64, sizeof(b64), &dst_len, data, len);
-	assert(rc == 0);
-	assert(dst_len == 4);
+	__ASSERT_NO_MSG(rc == 0);
+	__ASSERT_NO_MSG(dst_len == 4);
 
 	return cb(b64, 4, arg);
 }

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -8,7 +8,7 @@
 #define _OSDP_COMMON_H_
 
 #include <mgmt/osdp.h>
-#include <assert.h>
+#include <sys/__assert.h>
 
 #define OSDP_RESP_TOUT_MS              (200)
 

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  */
 #include <net/http_parser.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <stddef.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -204,7 +204,7 @@ static inline
 int cb_notify(struct http_parser *parser, enum state *current_state, http_cb cb,
 	      int cb_error, size_t *parsed, size_t already_parsed)
 {
-	assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);
+	__ASSERT_NO_MSG(HTTP_PARSER_ERRNO(parser) == HPE_OK);
 
 	if (cb == NULL) {
 		return 0;
@@ -231,7 +231,7 @@ int cb_data(struct http_parser *parser, http_data_cb cb, int cb_error,
 {
 	int rc;
 
-	assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);
+	__ASSERT_NO_MSG(HTTP_PARSER_ERRNO(parser) == HPE_OK);
 	if (*mark == NULL) {
 		return 0;
 	}
@@ -468,7 +468,7 @@ int parser_header_state(struct http_parser *parser, char ch, char c)
 		break;
 
 	default:
-		assert(0 && "Unknown header_state");
+		__ASSERT_NO_MSG(0 && "Unknown header_state");
 		break;
 	}
 	return 0;
@@ -510,7 +510,7 @@ int header_states(struct http_parser *parser, const char *data, size_t len,
 
 	case h_connection:
 	case h_transfer_encoding:
-		assert(0 && "Shouldn't get here.");
+		__ASSERT_NO_MSG(0 && "Shouldn't get here.");
 		break;
 
 	case h_content_length: {
@@ -1948,7 +1948,7 @@ reexecute:
 			uint64_t to_read = MIN(parser->content_length,
 					       (uint64_t) ((data + len) - p));
 
-			assert(parser->content_length != 0U
+			__ASSERT_NO_MSG(parser->content_length != 0U
 			       && parser->content_length != ULLONG_MAX);
 
 			/* The difference between advancing content_length and
@@ -2026,8 +2026,8 @@ reexecute:
 			break;
 
 		case s_chunk_size_start: {
-			assert(parser->nread == 1U);
-			assert(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->nread == 1U);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
 
 			unhex_val = unhex[(unsigned char)ch];
 			if (UNLIKELY(unhex_val == -1)) {
@@ -2043,7 +2043,7 @@ reexecute:
 		case s_chunk_size: {
 			uint64_t t;
 
-			assert(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
 
 			if (ch == CR) {
 				UPDATE_STATE(s_chunk_size_almost_done);
@@ -2081,7 +2081,7 @@ reexecute:
 		}
 
 		case s_chunk_parameters: {
-			assert(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
 			/* just ignore this shit. TODO check for overflow */
 			if (ch == CR) {
 				UPDATE_STATE(s_chunk_size_almost_done);
@@ -2091,7 +2091,7 @@ reexecute:
 		}
 
 		case s_chunk_size_almost_done: {
-			assert(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
 
 			rc = strict_check(parser, ch != LF);
 			if (rc != 0) {
@@ -2121,9 +2121,9 @@ reexecute:
 			uint64_t to_read = MIN(parser->content_length,
 					       (uint64_t) ((data + len) - p));
 
-			assert(parser->flags & F_CHUNKED);
-			assert(parser->content_length != 0U
-			       && parser->content_length != ULLONG_MAX);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->content_length != 0U
+					&& parser->content_length != ULLONG_MAX);
 
 			/* See the explanation in s_body_identity for why the
 			 * content
@@ -2141,8 +2141,8 @@ reexecute:
 		}
 
 		case s_chunk_data_almost_done:
-			assert(parser->flags & F_CHUNKED);
-			assert(parser->content_length == 0U);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->content_length == 0U);
 			rc = strict_check(parser, ch != CR);
 			if (rc != 0) {
 				goto error;
@@ -2158,7 +2158,7 @@ reexecute:
 			break;
 
 		case s_chunk_data_done:
-			assert(parser->flags & F_CHUNKED);
+			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
 			rc = strict_check(parser, ch != LF);
 			if (rc != 0) {
 				goto error;
@@ -2176,7 +2176,7 @@ reexecute:
 			break;
 
 		default:
-			assert(0 && "unhandled state");
+			__ASSERT_NO_MSG(0 && "unhandled state");
 			SET_ERRNO(HPE_INVALID_INTERNAL_STATE);
 			goto error;
 		}
@@ -2195,11 +2195,11 @@ reexecute:
 	 * value that's in-bounds).
 	 */
 
-	assert(((header_field_mark ? 1 : 0) +
-		(header_value_mark ? 1 : 0) +
-		(url_mark ? 1 : 0)  +
-		(body_mark ? 1 : 0) +
-		(status_mark ? 1 : 0)) <= 1);
+	__ASSERT_NO_MSG(((header_field_mark ? 1 : 0) +
+			(header_value_mark ? 1 : 0) +
+			(url_mark ? 1 : 0)  +
+			(body_mark ? 1 : 0) +
+			(status_mark ? 1 : 0)) <= 1);
 
 	rc = cb_data(parser, settings->on_header_field, HPE_CB_header_field,
 		     &p_state, parsed, p - data, &header_field_mark,
@@ -2323,14 +2323,14 @@ void http_parser_settings_init(struct http_parser_settings *settings)
 
 const char *http_errno_name(enum http_errno err)
 {
-	assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+	__ASSERT_NO_MSG(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
 
 	return http_strerror_tab[err].name;
 }
 
 const char *http_errno_description(enum http_errno err)
 {
-	assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+	__ASSERT_NO_MSG(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
 
 	return http_strerror_tab[err].description;
 }
@@ -2347,7 +2347,7 @@ void http_parser_pause(struct http_parser *parser, int paused)
 			HTTP_PARSER_ERRNO(parser) == HPE_PAUSED) {
 		SET_ERRNO((paused) ? HPE_PAUSED : HPE_OK);
 	} else {
-		assert(0 && "Attempting to pause parser in error state");
+		__ASSERT_NO_MSG(0 && "Attempting to pause parser in error state");
 	}
 }
 

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include <assert.h>
+#include <sys/__assert.h>
 #include <stddef.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -385,7 +385,7 @@ int http_parse_host(const char *buf, struct http_parser_url *u,
 	const char *p;
 
 	buflen = u->field_data[UF_HOST].off + u->field_data[UF_HOST].len;
-	assert(u->field_set & (1 << UF_HOST));
+	__ASSERT_NO_MSG(u->field_set & (1 << UF_HOST));
 
 	u->field_data[UF_HOST].len = 0U;
 
@@ -521,7 +521,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 			break;
 
 		default:
-			assert(!"Unexpected state");
+			__ASSERT_NO_MSG(!"Unexpected state");
 			return 1;
 		}
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -9,7 +9,6 @@
 #include <stdbool.h>
 #include <fs/fcb.h>
 #include <string.h>
-#include <assert.h>
 
 #include "settings/settings.h"
 #include "settings/settings_fcb.h"

--- a/subsys/stats/stats.c
+++ b/subsys/stats/stats.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -9,7 +9,6 @@
 #include <zephyr/types.h>
 #include <string.h>
 #include <errno.h>
-#include <assert.h>
 
 #include <toolchain.h>
 #include <bluetooth/bluetooth.h>
@@ -18,6 +17,7 @@
 #include <bluetooth/uuid.h>
 #include <sys/byteorder.h>
 #include <sys/printk.h>
+#include <sys/__assert.h>
 #include <net/buf.h>
 
 #include <logging/log.h>
@@ -357,7 +357,7 @@ static ssize_t write_value(struct bt_conn *conn,
 	memcpy(value->data + offset, buf, len);
 
 	/* Maximum attribute value size is 512 bytes */
-	assert(value->len < 512);
+	__ASSERT_NO_MSG(value->len < 512);
 
 	attr_value_changed_ev(attr->handle, value->data, value->len);
 

--- a/tests/subsys/fs/multi-fs/src/test_common_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_dir.c
@@ -7,7 +7,7 @@
 #include <ztest.h>
 #include <stdio.h>
 #include <limits.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <fs/fs.h>
 #include "test_common.h"
 
@@ -20,7 +20,7 @@ int test_mkdir(const char *dir_path, const char *file)
 	char file_path[PATH_MAX] = { 0 };
 
 	res = sprintf(file_path, "%s/%s", dir_path, file);
-	assert(res < sizeof(file_path));
+	__ASSERT_NO_MSG(res < sizeof(file_path));
 
 	if (check_file_dir_exists(dir_path)) {
 		TC_PRINT("[%s] exists, delete it\n", dir_path);
@@ -131,7 +131,7 @@ int test_rmdir(const char *dir_path)
 
 		/* Delete file or sub directory */
 		sprintf(file_path, "%s/%s", dir_path, entry.name);
-		assert(res < sizeof(file_path));
+		__ASSERT_NO_MSG(res < sizeof(file_path));
 		TC_PRINT("Removing %s\n", file_path);
 
 		res = fs_unlink(file_path);


### PR DESCRIPTION
Replace all calls to the assert macro that comes from libc by calls to
__ASSERT_NO_MSG(). This is usefull as the former might be different
depending on the libc used and the later can be customized to reduce
flash footprint.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>