### PR TITLE
x86: pcie: Fix calling pcie_mm_init()

### DIFF
--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -61,14 +61,6 @@ static void pcie_mm_init(void)
 static inline void pcie_mm_conf(pcie_bdf_t bdf, unsigned int reg,
 				bool write, uint32_t *data)
 {
-	if (bus_segs[0].mmio == NULL) {
-		pcie_mm_init();
-	}
-
-	if (do_pcie_mmio_cfg == false) {
-		return;
-	}
-
 	for (int i = 0; i < ARRAY_SIZE(bus_segs); i++) {
 		int off = PCIE_BDF_TO_BUS(bdf) - bus_segs[i].start_bus;
 
@@ -133,6 +125,10 @@ static inline void pcie_conf(pcie_bdf_t bdf, unsigned int reg,
 
 {
 #ifdef CONFIG_PCIE_MMIO_CFG
+	if (bus_segs[0].mmio == NULL) {
+		pcie_mm_init();
+	}
+
 	if (do_pcie_mmio_cfg) {
 		pcie_mm_conf(bdf, reg, write, data);
 	} else


### PR DESCRIPTION
Commit 5632ee26f37 introduced an issue where in order to use MMIO configuration:

 - do_pcie_mmio_cfg is required to be true
 - It's only set to true in pcie_mm_init()
 - Which is only called from pcie_mm_conf()
 - Which is only called from pcie_conf() if do_pcie_mmio_cfg is already true!

The end result is that MMIO configuration will never be used.

Fix the situation by moving the initialization check to pcie_conf().

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>