### PR TITLE
tests: kernel: timer: timer_api: tick align and reorder

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -610,14 +610,14 @@ void test_timer_remaining(void)
 	uint32_t slew_ticks;
 	uint64_t now;
 
-	k_usleep(1); /* align to tick */
 
 	init_timer_data();
+	k_usleep(1); /* align to tick */
 	k_timer_start(&remain_timer, K_MSEC(DURATION), K_NO_WAIT);
 	busy_wait_ms(DURATION / 2);
+	rem_ticks = k_timer_remaining_ticks(&remain_timer);
 	now = k_uptime_ticks();
 	rem_ms = k_timer_remaining_get(&remain_timer);
-	rem_ticks = k_timer_remaining_ticks(&remain_timer);
 	exp_ticks = k_timer_expires_ticks(&remain_timer);
 	k_timer_stop(&remain_timer);
 	TIMER_ASSERT(tdata.expire_cnt == 0, &remain_timer);

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -474,6 +474,7 @@ void test_timer_k_define(void)
 {
 	init_timer_data();
 	/** TESTPOINT: init timer via k_timer_init */
+	k_usleep(1); /* align to tick */
 	k_timer_start(&ktimer, K_MSEC(DURATION), K_MSEC(PERIOD));
 	tdata.timestamp = k_uptime_get();
 	busy_wait_ms(DURATION + PERIOD * EXPIRE_TIMES + PERIOD / 2);


### PR DESCRIPTION
tests: kernel: timer: timer_api: tick align and reorder

* Insert k_usleep(1) just before k_timer_start()
    to guaranty tick alignment for step "test_timer_k_define"

* Move init_timer_data() out of k_usleep() tick alignment.
   And compute rem_ticks just after busy_wait_ms() to avoid slew
    due to 'now' and 'rem_ms' computations.  With slow CPU 32MHz: -2 Ticks.

Fixes #28603