### PR TITLE
net: tcp2: Fix build failures on 64-bit platforms

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1450,7 +1450,7 @@ int net_tcp_put(struct net_context *context)
 	if (conn && conn->state == TCP_ESTABLISHED) {
 		/* Send all remaining data if possible. */
 		if (conn->send_data_total > 0) {
-			NET_DBG("conn %p pending %u bytes", conn,
+			NET_DBG("conn %p pending %zu bytes", conn,
 				conn->send_data_total);
 			conn->in_close = true;
 


### PR DESCRIPTION
Since conn->send_data_total is of time size_t we need to use %zu or
we'll get build errors in sanitycheck on 64-bit platforms

Fixes #28605

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>