### PR TITLE
ci: double number of builders for daily build

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
-    parallelism: 120
+    parallelism: 240
     timeout_in_minutes: 210
     retry:
       manual: true


### PR DESCRIPTION
To get the daily build to hopefully run completely w/o timeouts lets
double the number of builders.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>