### PR TITLE
X86-64 exception stack rename and increase

### DIFF
--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -20,7 +20,7 @@ config TEST_EXTRA_STACKSIZE
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 8192
 
-config EXCEPTION_STACK_SIZE
+config X86_EXCEPTION_STACK_SIZE
 	int "Size of the exception stack(s)"
 	default 2048
 	help

--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -22,7 +22,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 
 config X86_EXCEPTION_STACK_SIZE
 	int "Size of the exception stack(s)"
-	default 2048
+	default 4096
 	help
 	  The exception stack(s) (one per CPU) are used both for exception
 	  processing and early kernel/CPU initialization. They need only

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -39,7 +39,7 @@ struct x86_tss64 tss0 = {
 #ifdef CONFIG_X86_KPTI
 	.ist2 = (uint64_t) z_x86_trampoline_stack + Z_X86_TRAMPOLINE_STACK_SIZE,
 #endif
-	.ist7 = (uint64_t) _exception_stack + CONFIG_EXCEPTION_STACK_SIZE,
+	.ist7 = (uint64_t) _exception_stack + CONFIG_X86_EXCEPTION_STACK_SIZE,
 	.iomapb = 0xFFFF,
 	.cpu = &(_kernel.cpus[0])
 };
@@ -50,7 +50,7 @@ struct x86_tss64 tss1 = {
 #ifdef CONFIG_X86_KPTI
 	.ist2 = (uint64_t) z_x86_trampoline_stack1 + Z_X86_TRAMPOLINE_STACK_SIZE,
 #endif
-	.ist7 = (uint64_t) _exception_stack1 + CONFIG_EXCEPTION_STACK_SIZE,
+	.ist7 = (uint64_t) _exception_stack1 + CONFIG_X86_EXCEPTION_STACK_SIZE,
 	.iomapb = 0xFFFF,
 	.cpu = &(_kernel.cpus[1])
 };
@@ -62,7 +62,7 @@ struct x86_tss64 tss2 = {
 #ifdef CONFIG_X86_KPTI
 	.ist2 = (uint64_t) z_x86_trampoline_stack2 + Z_X86_TRAMPOLINE_STACK_SIZE,
 #endif
-	.ist7 = (uint64_t) _exception_stack2 + CONFIG_EXCEPTION_STACK_SIZE,
+	.ist7 = (uint64_t) _exception_stack2 + CONFIG_X86_EXCEPTION_STACK_SIZE,
 	.iomapb = 0xFFFF,
 	.cpu = &(_kernel.cpus[2])
 };
@@ -74,7 +74,7 @@ struct x86_tss64 tss3 = {
 #ifdef CONFIG_X86_KPTI
 	.ist2 = (uint64_t) z_x86_trampoline_stack3 + Z_X86_TRAMPOLINE_STACK_SIZE,
 #endif
-	.ist7 = (uint64_t) _exception_stack3 + CONFIG_EXCEPTION_STACK_SIZE,
+	.ist7 = (uint64_t) _exception_stack3 + CONFIG_X86_EXCEPTION_STACK_SIZE,
 	.iomapb = 0xFFFF,
 	.cpu = &(_kernel.cpus[3])
 };

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -1022,27 +1022,27 @@ gdt80:  /* LGDT descriptor for long mode */
 .global _exception_stack
 .align 16
 _exception_stack:
-	.fill CONFIG_EXCEPTION_STACK_SIZE, 1, 0xAA
+	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
 
 #if CONFIG_MP_NUM_CPUS > 1
 .global _exception_stack1
 .align 16
 _exception_stack1:
-	.fill CONFIG_EXCEPTION_STACK_SIZE, 1, 0xAA
+	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
 #endif
 
 #if CONFIG_MP_NUM_CPUS > 2
 .global _exception_stack2
 .align 16
 _exception_stack2:
-	.fill CONFIG_EXCEPTION_STACK_SIZE, 1, 0xAA
+	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
 #endif
 
 #if CONFIG_MP_NUM_CPUS > 3
 .global _exception_stack3
 .align 16
 _exception_stack3:
-	.fill CONFIG_EXCEPTION_STACK_SIZE, 1, 0xAA
+	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
 #endif
 
 #ifdef CONFIG_X86_KPTI


### PR DESCRIPTION
- `CONFIG_EXCEPTION_STACK_SIZE` is specific to x86, rename it to `CONFIG_X86_EXCEPTION_STACK_SIZE`
- Default increased from 2048 to 4096. Still fits comfortably in the locore, and helps prevent mysterious issues stemming from https://github.com/zephyrproject-rtos/zephyr/issues/21462 in that exception stack overflows are not caught, such as when enabling `CONFIG_NO_OPTIMIZATIONS`