### PR TITLE
TESTS: workaround aggressive optimization

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -194,6 +194,10 @@ do {                                                                    \
 
 #define popcount(x) __builtin_popcount(x)
 
+#ifndef __no_optimization
+#define __no_optimization __attribute__((optimize("-O0")))
+#endif
+
 #ifndef __weak
 #define __weak __attribute__((__weak__))
 #endif

--- a/include/toolchain/mwdt.h
+++ b/include/toolchain/mwdt.h
@@ -61,6 +61,8 @@
 
 #else /* defined(_ASMLANGUAGE) */
 
+#define __no_optimization __attribute__((optnone))
+
 #include <toolchain/gcc.h>
 
 /* Metaware toolchain has _Static_assert. However it not able to calculate

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -139,7 +139,7 @@ void alt_thread5(void)
 
 #ifndef CONFIG_ARCH_POSIX
 #ifdef CONFIG_STACK_SENTINEL
-void blow_up_stack(void)
+__no_optimization void blow_up_stack(void)
 {
 	char buf[OVERFLOW_STACKSIZE];
 
@@ -150,7 +150,7 @@ void blow_up_stack(void)
 #else
 /* stack sentinel doesn't catch it in time before it trashes the entire kernel
  */
-int stack_smasher(int val)
+__no_optimization int stack_smasher(int val)
 {
 	return stack_smasher(val * 2) + stack_smasher(val * 3);
 }

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -160,7 +160,7 @@ void isr6(const void *param)
  * doesn't support this; we need to tell the compiler not to reorder memory
  * accesses to trigger_check around calls to trigger_irq.
  */
-__attribute__((optimize("-O0")))
+__no_optimization
 #endif
 int test_irq(int offset)
 {

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -83,7 +83,7 @@ static void execute_from_buffer(uint8_t *dst)
  */
 static void test_write_ro(void)
 {
-	uint32_t *ptr = (uint32_t *)&rodata_var;
+	volatile uint32_t *ptr = (volatile uint32_t *)&rodata_var;
 
 	/*
 	 * Try writing to rodata.  Optimally, this triggers a fault.

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -68,21 +68,23 @@ struct k_sem worker_sems[NUM_THREADS];
 int target;
 
 /* Command to worker: use a sched_lock()? */
-int do_lock;
+volatile int do_lock;
 
 /* Command to worker: use irq_offload() to indirect the wakeup? */
-int do_irq;
+volatile int do_irq;
 
 /* Command to worker: sleep after wakeup? */
-int do_sleep;
+volatile int do_sleep;
 
 /* Command to worker: yield after wakeup? */
-int do_yield;
+volatile int do_yield;
 
 K_SEM_DEFINE(main_sem, 0, 1);
 
 void wakeup_src_thread(int id)
 {
+	volatile k_tid_t src_thread = &worker_threads[id];
+
 	zassert_true(k_current_get() == &manager_thread, "");
 
 	/* irq_offload() on ARM appears not to do what we want.  It
@@ -110,8 +112,7 @@ void wakeup_src_thread(int id)
 	last_thread = NULL;
 	k_sem_give(&worker_sems[id]);
 
-	while (do_sleep
-	       && !(worker_threads[id].base.thread_state & _THREAD_PENDING)) {
+	while (do_sleep && !(src_thread->base.thread_state & _THREAD_PENDING)) {
 		/* spin, waiting on the sleep timeout */
 #if defined(CONFIG_ARCH_POSIX)
 		/**

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -186,7 +186,7 @@ void test_memalloc_all(void)
  *
  */
 
-void test_memalloc_max(void)
+__no_optimization void test_memalloc_max(void)
 {
 	char *ptr = NULL;
 


### PR DESCRIPTION
Workaround aggressive optimization of following tests by MWDT toolchain. Although we've faced with this issues with ARC MWDT toolchain such optimization are possible by any other toolchain.

Affected tests:
```
kernel.common.stack_protection
kernel.common.stack_sentinel
kernel.scheduler.preempt
kernel.memory_protection.protection
libraries.libc.minimal.mem_alloc
```

### kernel.common.stack_protection
The 'stack_smasher' call can be optimized away as its results isn't used anywhere and stack_smasher function has no visible side effects.


### kernel.common.stack_sentinel
The memset in the 'blow_up_stack' function can be optimized away as it is called in the end of the function on the buffer
allocated on the stack (so it has 'no' effect on program execution):

```
void blow_up_stack(void)
{
	char buf[OVERFLOW_STACKSIZE];

	expected_reason = K_ERR_STACK_CHK_FAIL;
	TC_PRINT("posting %zu bytes of junk to stack...\n", sizeof(buf));
	(void)memset(buf, 0xbb, sizeof(buf));
}
```

### kernel.scheduler.preempt
We use several variables (like do_sleep, etc...) to share statuses between threads, however they are not marked as volatile. That may lead to their unexpected optimization (which really happens with ARC MWDT when loop with waiting on the sleep timeout in 'wakeup_src_thread' is optimized away).

### kernel.memory_protection.protection
Compiler may optimize away write to address with following readback so we won't trigger fault (that actually happens with arc MWDT toolchain).

### libraries.libc.minimal.mem_alloc
As we don't use memory allocated in test_memalloc_max the malloc call can be optimized away.
```
void test_memalloc_max(void)
{
	char *ptr = NULL;

	ptr = malloc(0x7fffffff);
	zassert_is_null(ptr, "malloc passed unexpectedly");
	free(ptr);
	ptr = NULL;
}
```
ARC MWDT toolchain optimize it to zassert_ trigger with "malloc passed unexpectedly" message. That breaks the test.
