### PR TITLE
x86-64: fix data corruption with tracing enabled

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -324,17 +324,23 @@ z_x86_switch:
  */
 
 __resume:
-#ifdef CONFIG_USERSPACE
-#ifndef CONFIG_X86_KPTI
+#if (!defined(CONFIG_X86_KPTI) && defined(CONFIG_USERSPACE)) \
+		|| defined(CONFIG_TRACING)
+	pushq %rdi	/* Caller-saved, stash it */
+#if !defined(CONFIG_X86_KPTI) && defined(CONFIG_USERSPACE)
 	/* If KPTI is enabled we're always on the kernel's page tables in
 	 * this context and the appropriate page table switch takes place
 	 * when trampolining back to user mode
 	 */
-	pushq %rdi	/* Caller-saved, stash it */
 	call z_x86_swap_update_page_tables
+#endif
+#ifdef CONFIG_TRACING
+	call sys_trace_thread_switched_in
+#endif
 	popq %rdi
-#endif /* CONFIG_X86_KPTI */
+#endif /* (!CONFIG_X86_KPTI && CONFIG_USERSPACE) || CONFIG_TRACING */
 
+#ifdef CONFIG_USERSPACE
 	/* Set up exception return stack frame */
 	pushq _thread_offset_to_ss(%rdi)	/* SS */
 #else
@@ -402,12 +408,6 @@ __resume:
 	/* swapgs variant of Spectre V1. Disable speculation past this point */
 	lfence
 #endif /* CONFIG_X86_BOUNDS_CHECK_BYPASS_MITIGATION */
-
-#ifdef CONFIG_TRACING
-	pushq %rdi
-	call sys_trace_thread_switched_in
-	popq %rdi
-#endif
 	iretq
 
 


### PR DESCRIPTION
The arch_switch() instrumentation point for `CONFIG_TRACING` added in
PR #28512 had two problems:

- If userspace and KPTI are enabled, the tracing point is simply
  never run if we are resuming a user thread as the
  `z_x86_trampoline_to_user` function is jumped to and calls
  'iret' from there

- Only %rdi is being saved. However, at that location, *all*
  caller-saved registers are in use as they contain the
  resumed thread's context, which the call to the tracing code
  was corrupting

Simplest solution is to move this up near where we update page
tables. The #ifdefs are used to make sure we don't push/pop
%rdi more than once. At that point in the code only %rdi
is in use among the volatile registers.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>