### PR TITLE
soc: intel_apl_adsp/intel_s1000: keep irq mask in smp entry

### DIFF
--- a/soc/xtensa/intel_apl_adsp/soc_mp.c
+++ b/soc/xtensa/intel_apl_adsp/soc_mp.c
@@ -86,7 +86,7 @@ static void mp_entry2(void)
 	 * later.
 	 */
 	__asm__ volatile("rsr.PS %0" : "=r"(ps));
-	ps &= ~(PS_EXCM_MASK | PS_INTLEVEL_MASK);
+	ps &= ~PS_EXCM_MASK;
 	__asm__ volatile("wsr.PS %0" : : "r"(ps));
 
 	ie = 0;

--- a/soc/xtensa/intel_s1000/soc_mp.c
+++ b/soc/xtensa/intel_s1000/soc_mp.c
@@ -53,7 +53,7 @@ static void mp_entry2(void)
 	 * later.
 	 */
 	__asm__ volatile("rsr.PS %0" : "=r"(ps));
-	ps &= ~(PS_EXCM_MASK | PS_INTLEVEL_MASK);
+	ps &= ~PS_EXCM_MASK;
 	__asm__ volatile("wsr.PS %0" : : "r"(ps));
 
 	ie = 0;


### PR DESCRIPTION
In smp_init_top(), it initializes a dummy thread and set it
to be the current thread. The _current_cpu macro asserts
on intel_apl_adsp since interrupts are unmasked at smp entry.
So don't unmask.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>