### PR TITLE
tests: kernel: mem_protect: syscalls: FAULTY_ADDRESS for nucleo_l073rz

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -12,7 +12,8 @@
 #define BUF_SIZE	32
 #define SLEEP_MS_LONG	15000
 
-#if defined(CONFIG_BOARD_NUCLEO_F429ZI) || defined(CONFIG_BOARD_NUCLEO_F207ZG)
+#if defined(CONFIG_BOARD_NUCLEO_F429ZI) || defined(CONFIG_BOARD_NUCLEO_F207ZG) \
+	|| defined(CONFIG_BOARD_NUCLEO_L073RZ)
 #define FAULTY_ADDRESS 0x0FFFFFFF
 #elif CONFIG_MMU
 /* Just past the permanent RAM mapping should be a non-present page */


### PR DESCRIPTION
tests: kernel: mem_protect: syscalls: FAULTY_ADDRESS for nucleo_l073rz

Configure faulty address for nucleo_l073rz to 0x0FFFFFFF
Fixes #28621

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>