### PR TITLE
tests: net: tcp2: Fix crash in frdm_k64f

### DIFF
--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -909,7 +909,7 @@ static void test_client_syn_resend(void)
 	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
 				  sizeof(struct sockaddr_in),
 				  NULL,
-				  K_MSEC(1000), NULL);
+				  K_MSEC(300), NULL);
 
 	zassert_true(ret < 0, "Connect on no response from peer");
 


### PR DESCRIPTION
Lowering the connection timeout in order to avoid spin lock assert
in frdm_k64f device. This error was seen with this device

ASSERTION FAIL [z_spin_lock_valid(l)] @ zephyr/include/spinlock.h:92
        Recursive spinlock 0x20003590

Fixes #28602

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>