### PR TITLE
net: DHCPv4 needs UDP to work properly

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -48,6 +48,7 @@ config NET_IPV4_ACCEPT_ZERO_BROADCAST
 
 config NET_DHCPV4
 	bool "Enable DHCPv4 client"
+	depends on NET_UDP
 
 config NET_DHCPV4_INITIAL_DELAY_MAX
 	int "Maximum time out for initial discover request"


### PR DESCRIPTION
Add dependency to UDP in DHCPv4 Kconfig option as UDP is needed
in DHPCv4 to work properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>