### PR TITLE
drivers/nrf_qspi: fix devicetree opcode references 

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -403,16 +403,16 @@ static inline void qspi_fill_init_struct(nrfx_qspi_config_t *initstruct)
 #endif
 
 	/* Configure Protocol interface */
-#if DT_INST_NODE_HAS_PROP(0, readoc_enum)
+#if DT_INST_NODE_HAS_PROP(0, readoc)
 	initstruct->prot_if.readoc =
-		(nrf_qspi_writeoc_t)qspi_get_lines_read(DT_INST_PROP(0, readoc_enum));
+		(nrf_qspi_writeoc_t)qspi_get_lines_read(DT_ENUM_IDX(DT_DRV_INST(0), readoc));
 #else
 	initstruct->prot_if.readoc = NRF_QSPI_READOC_FASTREAD;
 #endif
 
-#if DT_INST_NODE_HAS_PROP(0, writeoc_enum)
+#if DT_INST_NODE_HAS_PROP(0, writeoc)
 	initstruct->prot_if.writeoc =
-		(nrf_qspi_writeoc_t)qspi_get_lines_write(DT_INST_PROP(0, writeoc_enum));
+		(nrf_qspi_writeoc_t)qspi_get_lines_write(DT_ENUM_IDX(DT_DRV_INST(0), writeoc));
 #else
 	initstruct->prot_if.writeoc = NRF_QSPI_WRITEOC_PP;
 #endif


### PR DESCRIPTION
This makes the driver compile for nRF5340 and it seems to work, but I did not do extensive tests.

I am not at all confident in my understanding of the Devicetree, so I may have gotten something wrong.

To make the driver work on nRF5340, there are changes required to the DTS files:

```
	soc {
		peripheral@50000000 {
			qspi: qspi@2B000 {
				compatible = "nordic,nrf-qspi";
				#address-cells = <1>;
				#size-cells = <0>;
				reg = <0x2B000 0x1000>;
				interrupts = <43 1>;
				status = "disabled";
				label = "QSPI";
			};
		};
	};
```

```
&qspi {
	status = "okay";
	sck-pin = <17>;
	io-pins = <13>, <14>, <15>, <16>;
	csn-pins = <18>;
	mx25r64: mx25r6435f@0 {
		compatible = "nordic,qspi-nor";
		reg = <0>;
		writeoc = "pp4io";
		readoc = "read4io";
		sck-frequency = <8000000>;
		label = "MX25R64";
		jedec-id = [c2 28 17];
		size = <67108864>;
		has-be32k;
		has-dpd;
		t-enter-dpd = <10000>;
		t-exit-dpd = <35000>;
	};
};
```
And to Kconfig somewhere(?):
```
config SOC_NRF5340_CPUAPP
	select HAS_HW_NRF_QSPI
```
Again I'm not sure if I got this right. Can anyone from Nordic or a Devicetree expert try to implement this for nRF5340? Thanks.

Fixes  #28635