### PR TITLE
modules/Kconfig.nordic: Do not select HAS_CMSIS_CORE through HAS_NRFX

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -75,7 +75,6 @@ endmenu
 
 config HAS_NRFX
 	bool
-	select HAS_CMSIS_CORE
 
 menu "nrfx drivers"
 	depends on HAS_NRFX


### PR DESCRIPTION
The HAS_NRFX Kconfig option is selected also for the nrf52_bsim board,
where the nrfx drivers are compiled for a simulated target, without
CMSIS. Thus, selecting HAS_CMSIS_CORE in such case is inappropriate.
This patch removes then the selection of the HAS_CMSIS_CORE option from
HAS_NRFX. When the nrfx drivers are built for a real SoC, where CMSIS
is actually used, the option will get selected by the CPU_CORTEX_M one.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>