### PR TITLE
devicetree: rename header to reflect that io-channels are not ADC-only

### DIFF
--- a/doc/reference/devicetree/index.rst
+++ b/doc/reference/devicetree/index.rst
@@ -177,15 +177,6 @@ Hardware specific APIs
 The following APIs can also be used by including ``<devicetree.h>``;
 no additional include is needed.
 
-ADC
-===
-
-These are commonly used by sensor device drivers which need to use an ADC
-channel for conversion.
-
-.. doxygengroup:: devicetree-adc
-   :project: Zephyr
-
 Clocks
 ======
 
@@ -225,6 +216,15 @@ These conveniences may be used for nodes which describe GPIO controllers/pins,
 and properties related to them.
 
 .. doxygengroup:: devicetree-gpio
+   :project: Zephyr
+
+IO channels
+===========
+
+These are commonly used by device drivers which need to use IO
+channels (e.g. ADC or DAC channels) for conversion.
+
+.. doxygengroup:: devicetree-io-channels
    :project: Zephyr
 
 PWM

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -1921,7 +1921,7 @@
 	IS_ENABLED(UTIL_CAT(DT_CAT(DT_COMPAT_, compat), _BUS_##bus))
 
 /* have these last so they have access to all previously defined macros */
-#include <devicetree/adc.h>
+#include <devicetree/io-channels.h>
 #include <devicetree/clocks.h>
 #include <devicetree/gpio.h>
 #include <devicetree/spi.h>

--- a/include/devicetree/io-channels.h
+++ b/include/devicetree/io-channels.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief ADC Devicetree macro public API header file.
+ * @brief IO channels devicetree macro public API header file.
  */
 
 /*
@@ -9,15 +9,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DEVICETREE_ADC_H_
-#define ZEPHYR_INCLUDE_DEVICETREE_ADC_H_
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_IO_CHANNELS_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_IO_CHANNELS_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @defgroup devicetree-adc Devicetree ADC API
+ * @defgroup devicetree-io-channels Devicetree IO Channels API
  * @ingroup devicetree
  * @{
  */
@@ -255,4 +255,4 @@ extern "C" {
 }
 #endif
 
-#endif  /* ZEPHYR_INCLUDE_DEVICETREE_ADC_H_ */
+#endif  /* ZEPHYR_INCLUDE_DEVICETREE_IO_CHANNELS_H_ */


### PR DESCRIPTION
Rename the devicetree/adc.h header file to devicetree/io-channels.h to reflect that io-channels are used for both ADC and DAC devicetree phandles.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>