### PR TITLE
logging: make log_backend_std header public

### DIFF
--- a/include/logging/log_backend_std.h
+++ b/include/logging/log_backend_std.h
@@ -14,6 +14,13 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Logger backend interface for forwarding to standard backend
+ * @defgroup log_backend_std Logger backend standard interface
+ * @ingroup logger
+ * @{
+ */
+
 /** @brief Put log message to a standard logger backend.
  *
  * @param log_output	Log output instance.
@@ -146,6 +153,10 @@ log_backend_std_sync_hexdump(const struct log_output *const log_output,
 		irq_unlock(key);
 	}
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -8,7 +8,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
-#include "log_backend_std.h"
+#include <logging/log_backend_std.h>
 #include <SEGGER_RTT.h>
 
 #ifndef CONFIG_LOG_BACKEND_RTT_BUFFER_SIZE

--- a/subsys/logging/log_backend_spinel.c
+++ b/subsys/logging/log_backend_spinel.c
@@ -5,11 +5,11 @@
  */
 
 #include <logging/log_backend.h>
+#include <logging/log_backend_std.h>
 #include <logging/log_output.h>
 #include <openthread/platform/logging.h>
 #include <openthread/platform/uart.h>
 #include <platform-zephyr.h>
-#include "log_backend_std.h"
 
 #ifndef CONFIG_LOG_BACKEND_SPINEL_BUFFER_SIZE
 #define CONFIG_LOG_BACKEND_SPINEL_BUFFER_SIZE 0

--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -26,7 +26,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
-#include "log_backend_std.h"
+#include <logging/log_backend_std.h>
 #include <soc.h>
 
 /** The stimulus port from which SWO data is received and displayed */

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -8,7 +8,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
-#include "log_backend_std.h"
+#include <logging/log_backend_std.h>
 #include <device.h>
 #include <drivers/uart.h>
 #include <assert.h>

--- a/subsys/logging/log_backend_xtensa_sim.c
+++ b/subsys/logging/log_backend_xtensa_sim.c
@@ -12,7 +12,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
-#include "log_backend_std.h"
+#include <logging/log_backend_std.h>
 #include <xtensa/simcall.h>
 
 #define CHAR_BUF_SIZE (IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? \


### PR DESCRIPTION
Exported header oftenly used when creating a logging
backend that inpects the log 'stream'.
Enables use in external Zephyr modules implementing the
logging backend interface.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>