### PR TITLE
tests: kernel/sleep: increase maximum threshold for nRF51

### DIFF
--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -25,7 +25,10 @@
  */
 
 #if defined(CONFIG_NRF_RTC_TIMER) && (CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
-#define MAXIMUM_SHORTEST_TICKS 3
+/* The overhead of k_usleep() adds three ticks per loop iteration on
+ * nRF51, which has a slow CPU clock.
+ */
+#define MAXIMUM_SHORTEST_TICKS (IS_ENABLED(CONFIG_SOC_SERIES_NRF51X) ? 6 : 3)
 /*
  * Similar situation for TI CC13X2/CC26X2 RTC due to the limitation
  * that a value too close to the current time cannot be loaded to


### PR DESCRIPTION
nRF51 MCUs are Cortex-M0 running with a 16 MHz clock.  The overhead of work done in k_usleep() requires adding three more ticks (92 us) to the expected loop iteration time.  (Two ticks is enough on most boards, but some require a little more time.)

Fixes #28639 