### PR TITLE
include: remove enum build assert

### DIFF
--- a/include/ec_host_cmd.h
+++ b/include/ec_host_cmd.h
@@ -192,6 +192,5 @@ enum ec_host_cmd_status {
 
 	EC_HOST_CMD_MAX = UINT16_MAX /* Force enum to be 16 bits */
 } __packed;
-BUILD_ASSERT(sizeof(enum ec_host_cmd_status) == sizeof(uint16_t));
 
 #endif /* ZEPHYR_INCLUDE_EC_HOST_CMD_H_ */


### PR DESCRIPTION
Remove BUILD_ASSERT that is causing coverity error. This fixes #28170. The enum is always serialized at 16 bits, and it is documented in the comments.