### PR TITLE
bluetooth: att: provide named constant for successful result

### DIFF
--- a/include/bluetooth/att.h
+++ b/include/bluetooth/att.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 /* Error codes for Error response PDU */
+#define BT_ATT_ERR_SUCCESS			0x00
 #define BT_ATT_ERR_INVALID_HANDLE		0x01
 #define BT_ATT_ERR_READ_NOT_PERMITTED		0x02
 #define BT_ATT_ERR_WRITE_NOT_PERMITTED		0x03


### PR DESCRIPTION
BT_HCI_ERR and BT_SECURITY_ERR both define success constants which can
be used to check the results and make the intended value domain clear.
Add the same for ATT error values.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>