### PR TITLE
tests: work_queue: wait longer for expired triggering items

### DIFF
--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -771,7 +771,7 @@ static void test_triggered_wait_expired(void)
 	check_results(0);
 
 	/* Items should be executed when we will be sleeping here. */
-	k_msleep(SUBMIT_WAIT);
+	k_msleep(SUBMIT_WAIT * 2);
 	TC_PRINT(" - Checking results (after timeout)\n");
 	check_results(NUM_TEST_ITEMS);
 


### PR DESCRIPTION
The test_triggered_wait_expired test submits the items with
2*SUBMIT_WAIT timeout and waits for the timeout to expire
so the items are being worked on. It waits one SUBMIT_WAIT
and checks none of the items have started. Then waits
another SUBMIT_WAIT to check if they have all finished.
However, since the timeout is at 2*SUBMIT_WAIT, the work
queue may have just started going through the list of items.
This means some items may have started while others have not.
This results in the test failing as not all items have
finished. So lengthen the second sleep to allow items to
finish before checking.

Fixes #28589

Signed-off-by: Daniel Leung <daniel.leung@intel.com>