### PR TITLE
samples: cmsis_rtos_v1: philosophers: skip up_squared

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -5,7 +5,10 @@ common:
   tags: cmsis_rtos
   min_ram: 32
   min_flash: 34
-  platform_exclude: qemu_xtensa qemu_x86_64
+  # qemu_x86_64 and up_squared need bigger stack
+  # but CMSIS limits the stack size, resulting
+  # in stack overflow.
+  platform_exclude: qemu_xtensa qemu_x86_64 up_squared
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
The up_squared board suffers the same issue as qemu_x86_64
where a bigger stack is needed but CMSIS has a limit on
how big the stack can be. This results in stack overflow.

So exclude up_squared in samples.yaml.

Fixes #28552

Signed-off-by: Daniel Leung <daniel.leung@intel.com>