### PR TITLE
kernel: fix fencepost bug in z_x86_check_stack_bounds

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -92,7 +92,7 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 					_current->stack_info.size);
 	}
 
-	return (addr <= start) || (addr + size > end);
+	return (addr < start) || (addr + size > end);
 }
 #endif
 


### PR DESCRIPTION
Found through code inspection. It looks like the intent is to return
true if the range [addr, addr+size) is not a subset of [start, end), the
stack bounds. `start == addr` should be legal?