### PR TITLE
Acpi cleanups and up_squared celeron fix (via properly using apic_id from acpi)

### DIFF
--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -34,6 +34,7 @@ static bool check_sum(struct acpi_sdt *t)
 	for (int i = 0; i < t->length; i++) {
 		sum += p[i];
 	}
+
 	return sum == 0;
 }
 
@@ -74,6 +75,7 @@ static struct acpi_rsdp *find_rsdp(void)
 	 * real mode memory.
 	 */
 	search = (uint64_t *)0xe0000;
+
 	for (int i = 0; i < 128*1024/8; i++) {
 		if (search[i] == magic) {
 			return (void *)&search[i];
@@ -126,6 +128,7 @@ void *z_acpi_find_table(uint32_t signature)
 			}
 		}
 	}
+
 	return NULL;
 }
 
@@ -145,14 +148,13 @@ struct acpi_cpu *z_acpi_get_cpu(int n)
 		while (offset < madt->sdt.length) {
 			struct acpi_madt_entry *entry;
 
-			entry = (struct acpi_madt_entry *) (offset + base);
-
+			entry = (struct acpi_madt_entry *)(offset + base);
 			if (entry->type == ACPI_MADT_ENTRY_CPU) {
-				if (n) {
-					--n;
-				} else {
+				if (n == 0) {
 					return (struct acpi_cpu *) entry;
 				}
+
+				--n;
 			}
 
 			offset += entry->length;

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -31,7 +31,7 @@ static bool check_sum(struct acpi_sdt *t)
 {
 	uint8_t sum = 0, *p = (uint8_t *)t;
 
-	for (int i = 0; i < t->len; i++) {
+	for (int i = 0; i < t->length; i++) {
 		sum += p[i];
 	}
 	return sum == 0;
@@ -98,12 +98,12 @@ void *z_acpi_find_table(uint32_t signature)
 	struct acpi_rsdt *rsdt = (void *)(long)rsdp->rsdt_ptr;
 
 	if (rsdt && check_sum(&rsdt->sdt)) {
-		uint32_t *end = (uint32_t *)((char *)rsdt + rsdt->sdt.len);
+		uint32_t *end = (uint32_t *)((char *)rsdt + rsdt->sdt.length);
 
 		for (uint32_t *tp = &rsdt->table_ptrs[0]; tp < end; tp++) {
 			struct acpi_sdt *t = (void *)(long)*tp;
 
-			if (t->sig == signature && check_sum(t)) {
+			if (t->signature == signature && check_sum(t)) {
 				return t;
 			}
 		}
@@ -116,12 +116,12 @@ void *z_acpi_find_table(uint32_t signature)
 	struct acpi_xsdt *xsdt = (void *)(long)rsdp->xsdt_ptr;
 
 	if (xsdt && check_sum(&xsdt->sdt)) {
-		uint64_t *end = (uint64_t *)((char *)xsdt + xsdt->sdt.len);
+		uint64_t *end = (uint64_t *)((char *)xsdt + xsdt->sdt.length);
 
 		for (uint64_t *tp = &xsdt->table_ptrs[0]; tp < end; tp++) {
 			struct acpi_sdt *t = (void *)(long)*tp;
 
-			if (t->sig == signature && check_sum(t)) {
+			if (t->signature == signature && check_sum(t)) {
 				return t;
 			}
 		}
@@ -142,7 +142,7 @@ struct acpi_cpu *z_acpi_get_cpu(int n)
 	if (madt) {
 		offset = POINTER_TO_UINT(madt->entries) - base;
 
-		while (offset < madt->sdt.len) {
+		while (offset < madt->sdt.length) {
 			struct acpi_madt_entry *entry;
 
 			entry = (struct acpi_madt_entry *) (offset + base);

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -5,28 +5,6 @@
 #include <kernel.h>
 #include <arch/x86/acpi.h>
 
-struct acpi_rsdp {
-	char     sig[8];
-	uint8_t  csum;
-	char     oemid[6];
-	uint8_t  rev;
-	uint32_t rsdt_ptr;
-	uint32_t len;
-	uint64_t xsdt_ptr;
-	uint8_t  ext_csum;
-	uint8_t  _rsvd[3];
-} __packed;
-
-struct acpi_rsdt {
-	struct acpi_sdt sdt;
-	uint32_t table_ptrs[];
-} __packed;
-
-struct acpi_xsdt {
-	struct acpi_sdt sdt;
-	uint64_t table_ptrs[];
-} __packed;
-
 static bool check_sum(struct acpi_sdt *t)
 {
 	uint8_t sum = 0, *p = (uint8_t *)t;
@@ -111,7 +89,7 @@ void *z_acpi_find_table(uint32_t signature)
 		}
 	}
 
-	if (rsdp->rev < 2) {
+	if (rsdp->revision < 2) {
 		return NULL;
 	}
 

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -132,23 +132,29 @@ struct acpi_cpu *z_acpi_get_cpu(int n)
 	uintptr_t base = POINTER_TO_UINT(madt);
 	uintptr_t offset;
 
-	if (madt) {
-		offset = POINTER_TO_UINT(madt->entries) - base;
+	if (!madt) {
+		return NULL;
+	}
 
-		while (offset < madt->sdt.length) {
-			struct acpi_madt_entry *entry;
+	offset = POINTER_TO_UINT(madt->entries) - base;
 
-			entry = (struct acpi_madt_entry *)(offset + base);
-			if (entry->type == ACPI_MADT_ENTRY_CPU) {
+	while (offset < madt->sdt.length) {
+		struct acpi_madt_entry *entry;
+
+		entry = (struct acpi_madt_entry *)(offset + base);
+		if (entry->type == ACPI_MADT_ENTRY_CPU) {
+			struct acpi_cpu *cpu = (struct acpi_cpu *)entry;
+
+			if (cpu->flags & ACPI_CPU_FLAGS_ENABLED) {
 				if (n == 0) {
-					return (struct acpi_cpu *) entry;
+					return cpu;
 				}
 
 				--n;
 			}
-
-			offset += entry->length;
 		}
+
+		offset += entry->length;
 	}
 
 	return NULL;

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -35,7 +35,7 @@ static void pcie_mm_init(void)
 	struct acpi_mcfg *m = z_acpi_find_table(ACPI_MCFG_SIGNATURE);
 
 	if (m != NULL) {
-		int n = (m->sdt.len - sizeof(*m)) / sizeof(m->pci_segs[0]);
+		int n = (m->sdt.length - sizeof(*m)) / sizeof(m->pci_segs[0]);
 
 		for (int i = 0; i < n && i < MAX_PCI_BUS_SEGMENTS; i++) {
 			size_t size;

--- a/include/arch/x86/acpi.h
+++ b/include/arch/x86/acpi.h
@@ -8,6 +8,8 @@
 
 #ifndef _ASMLANGUAGE
 
+#define ACPI_RSDP_SIGNATURE 0x2052545020445352 /* == "RSD PTR " */
+
 /* Root System Description Pointer */
 struct acpi_rsdp {
 	char     signature[8];

--- a/include/arch/x86/acpi.h
+++ b/include/arch/x86/acpi.h
@@ -8,19 +8,17 @@
 
 #ifndef _ASMLANGUAGE
 
-extern void *z_acpi_find_table(uint32_t signature);
-
 /* Standard table header */
 struct acpi_sdt {
-	uint32_t sig;
-	uint32_t len;
-	uint8_t rev;
-	uint8_t csum;
-	char oemid[6];
+	uint32_t signature;
+	uint32_t length;
+	uint8_t revision;
+	uint8_t chksum;
+	char oem_id[6];
 	char oem_table_id[8];
-	uint32_t oemrevision;
+	uint32_t oem_revision;
 	uint32_t creator_id;
-	uint32_t creator_rev;
+	uint32_t creator_revision;
 } __packed;
 
 /* MCFG table storing MMIO addresses for PCI configuration space */
@@ -29,7 +27,7 @@ struct acpi_sdt {
 
 struct acpi_mcfg {
 	struct acpi_sdt sdt;
-	uint64_t _rsvd;
+	uint64_t _reserved;
 	struct {
 		uint64_t base_addr;
 		uint16_t seg_group_num;
@@ -42,31 +40,43 @@ struct acpi_mcfg {
 
 #define ACPI_MADT_SIGNATURE 0x43495041	/* 'APIC' */
 
-#define ACPI_MADT_FLAGS_PICS 0x01	/* legacy 8259s installed */
-#define ACPI_MADT_ENTRY_CPU	0
-
 struct acpi_madt_entry {
-	uint8_t type;
+	uint8_t type;	/* See ACPI_MADT_ENTRY_* below */
 	uint8_t length;
 } __packed;
 
+#define ACPI_MADT_ENTRY_CPU 0
+
 struct acpi_madt {
 	struct acpi_sdt sdt;
-	uint32_t lapic; /* local APIC MMIO address */
+	uint32_t loapic; /* local APIC MMIO address */
 	uint32_t flags; /* see ACPI_MADT_FLAGS_* below */
 	struct acpi_madt_entry entries[];
 } __packed;
 
+#define ACPI_MADT_FLAGS_PICS 0x01	/* legacy 8259s installed */
+
 struct acpi_cpu {
 	struct acpi_madt_entry entry;
-	uint8_t dontcare;
-	uint8_t id;	/* local APIC ID */
-	uint8_t flags;	/* see ACPI_MADT_CPU_FLAGS_* */
+	uint8_t acpi_id;
+	uint8_t apic_id; /* local APIC ID */
+	uint8_t flags;   /* see ACPI_CPU_FLAGS_* below */
 } __packed;
+
+#define ACPI_CPU_FLAGS_ENABLED 0x01
+
+#if defined(CONFIG_ACPI)
+
+void *z_acpi_find_table(uint32_t signature);
 
 struct acpi_cpu *z_acpi_get_cpu(int n);
 
-#define ACPI_CPU_FLAGS_ENABLED 0x01
+#else /* CONFIG_ACPI */
+
+#define z_acpi_find_table(...) NULL
+#define z_acpi_get_cpu(...) NULL
+
+#endif /* CONFIG_ACPI */
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/x86/acpi.h
+++ b/include/arch/x86/acpi.h
@@ -8,6 +8,19 @@
 
 #ifndef _ASMLANGUAGE
 
+/* Root System Description Pointer */
+struct acpi_rsdp {
+	char     signature[8];
+	uint8_t  chksum;
+	char     oem_id[6];
+	uint8_t  revision;
+	uint32_t rsdt_ptr;
+	uint32_t length;
+	uint64_t xsdt_ptr;
+	uint8_t  ext_chksum;
+	uint8_t  _reserved[3];
+} __packed;
+
 /* Standard table header */
 struct acpi_sdt {
 	uint32_t signature;
@@ -19,6 +32,18 @@ struct acpi_sdt {
 	uint32_t oem_revision;
 	uint32_t creator_id;
 	uint32_t creator_revision;
+} __packed;
+
+/* Root System Description Table */
+struct acpi_rsdt {
+	struct acpi_sdt sdt;
+	uint32_t table_ptrs[];
+} __packed;
+
+/* eXtended System Descriptor Table */
+struct acpi_xsdt {
+	struct acpi_sdt sdt;
+	uint64_t table_ptrs[];
 } __packed;
 
 /* MCFG table storing MMIO addresses for PCI configuration space */

--- a/tests/arch/x86/info/src/acpi.c
+++ b/tests/arch/x86/info/src/acpi.c
@@ -21,7 +21,7 @@ void acpi(void)
 
 		for (int i = 0; i < nr_cpus; ++i) {
 			struct acpi_cpu *cpu = z_acpi_get_cpu(i);
-			printk("\tCPU #%d: APIC ID 0x%02x\n", i, cpu->id);
+			printk("\tCPU #%d: APIC ID 0x%02x\n", i, cpu->apic_id);
 		}
 	}
 


### PR DESCRIPTION
Various patches to clean a bit ACPI, before expanding its usage.

Note that latest patch fixes up_squared board made of Celeron CPU (the Atom version worked perfectly well without it)

So there are slight differences on how up_squared boards behave depending on their CPU flavor. Can anyone test for the Pentium one?