### PR TITLE
boards: arm: b_l4s5i_iot01a: leds are active high

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -22,11 +22,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
 		green_led_2: led_2 {
-			gpios = <&gpiob 14 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
 	};


### PR DESCRIPTION
boards: arm: b_l4s5i_iot01a: leds are active high

See schematics of the board: MB1297
both user leds LD1 and LD2 are active high.

Fixes #28665

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>