### PR TITLE
Hello World Sample - fix cmake multithreading warning

### DIFF
--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,2 +1,1 @@
 # nothing here
-CONFIG_MULTITHREADING=n


### PR DESCRIPTION
fixes following cmake warning:
CMake Warning at ../../kernel/CMakeLists.txt:54 (message):
  Single threaded mode (CONFIG_MULTITHREADING=n) is deprecated