### PR TITLE
include/storage/flash_map: describe return values of flash_area_open()

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -111,6 +111,9 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
  * @param[in]  id ID of the flash partition.
  * @param[out] fa Pointer which has to reference flash_area. If
  * @p ID is unknown, it will be NULL on output.
+ *
+ * @return  0 on success, -EACCES if the flash_map is not available ,
+ * -ENOENT if @p ID is unknown.
  */
 int flash_area_open(uint8_t id, const struct flash_area **fa);
 


### PR DESCRIPTION
This patch adds description for possible flash_area_open()
return values.

Missing of this description can be treat as a bug.