### PR TITLE
Bluetooth: Mesh: Provisioning: Reject identical random

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -884,6 +884,12 @@ static void prov_random(const uint8_t *data)
 
 	BT_DBG("Remote Random: %s", bt_hex(data, 16));
 
+	if (!memcmp(data, link.rand, 16)) {
+		BT_ERR("Random value is identical to ours, rejecting.");
+		prov_fail(PROV_ERR_CFM_FAILED);
+		return;
+	}
+
 	if (bt_mesh_prov_conf(link.conf_key, data, link.auth, conf_verify)) {
 		BT_ERR("Unable to calculate confirmation verification");
 		prov_fail(PROV_ERR_UNEXP_ERR);


### PR DESCRIPTION
Adds check for provisioning random values that are identical to our own,
and terminates the provisioning procedure.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>