### PR TITLE
boards: stm32l496g_disco: Fix joystick pins polarity

### DIFF
--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -30,23 +30,23 @@
 		compatible = "gpio-keys";
 		joy_sel: joystick_select {
 			label = "joystick select";
-			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpioi 10 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioi 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpioi 8 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioi 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpioi 9 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioi 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiof 11 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpiof 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 	};
 

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -30,23 +30,23 @@
 		compatible = "gpio-keys";
 		joy_sel: joystick_select {
 			label = "joystick select";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpioi 10 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioi 10 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioi 8 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpioi 9 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioi 9 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiof 11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 11 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 		};
 	};
 


### PR DESCRIPTION
While testing ZephyrRTOS with a ```STM32L496g_disco``` kit, I noticed that the ```samples/basic/button``` wasn't working, and basically anything joystick-related wasn't working (wasn't entering the callback declared).

After some research, I found that there was a problem with the GPIO pins declaration for the Joystick. They were declared by defaults as pull-up instead of pull-down.

This should fix the issue.