### PR TITLE
test: power: Remove frdm_k64f platform from allowed list

### DIFF
--- a/tests/subsys/power/power_mgmt/testcase.yaml
+++ b/tests/subsys/power/power_mgmt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   subsys.power.device_pm:
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 frdm_k64f qemu_cortex_m0
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 qemu_cortex_m0
     tags: power


### PR DESCRIPTION
Removing frdm_k64f from the allowed list of platforms to test.

Fixes: #27821

Signed-off-by: David Leach <david.leach@nxp.com>