### PR TITLE
doc: use latest label instead of version in docs

### DIFF
--- a/doc/_templates/zversions.html
+++ b/doc/_templates/zversions.html
@@ -2,7 +2,7 @@
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"> Zephyr Project</span>
-      v: {{ current_version }}
+      v: <a href="/latest/">latest</a>
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">


### PR DESCRIPTION
Instead of having a .99 version, use latest and link to the lates
documentation on the left side bar.

The version number has been confusing users where it was difficult to
determine if they were looking at the development tree or some released
version.

Fixes #24453