### PR TITLE
arch: arm: cortex-m: enable IRQs before main() in single-thread mode

### DIFF
--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -477,6 +477,14 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 	"msr  PSPLIM, %[_psplim]\n\t"
 #endif
 	"msr  PSP, %[_psp]\n\t"       /* __set_PSP(psp) */
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	"cpsie i\n\t"         /* enable_irq() */
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	"cpsie if\n\t"		/* __enable_irq(); __enable_fault_irq() */
+	"mov r3, #0\n\t"
+	"msr   BASEPRI, r3\n\t"	/* __set_BASEPRI(0) */
+#endif
+	"isb\n\t"
 	"blx  %[_main_entry]\n\t"     /* main_entry(p1, p2, p3) */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	"cpsid i\n\t"         /* disable_irq() */

--- a/tests/arch/arm/arm_no_multithreading/README.txt
+++ b/tests/arch/arm/arm_no_multithreading/README.txt
@@ -9,7 +9,7 @@ ARM Cortex-M targets. In detail the test verifies that
 - PSP points to the main stack
 - PSPLIM is set to the main stack base (if applicable)
 - FPU state is reset (if applicable)
-- Interrupts are disabled when switching to main()
+- Interrupts are enabled when switching to main()
 - Interrupts may be registerd and serviced
 
 ---------------------------------------------------------------------------

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -52,11 +52,10 @@ void test_main(void)
 #endif
 
 	int key = arch_irq_lock();
-	__ASSERT(!arch_irq_unlocked(key),
-		"IRQs unlocked in main()");
+	__ASSERT(arch_irq_unlocked(key),
+		"IRQs locked in main()");
 
-	/* Enable interrupts unconditionally */
-	arch_irq_unlock(0);
+	arch_irq_unlock(key);
 
 	/* Determine an NVIC IRQ line that is not currently in use. */
 	int i, flag = test_flag;


### PR DESCRIPTION
Enable interrupts before switching to main()
in cortex-m builds with single-thread mode
(CONFIG_MULTITHREADING=n).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes issue #8393 for Cortex-M.
