### PR TITLE
drivers: gpio: npcx7: change default pinmux of functional pads to GPIO 

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
@@ -12,6 +12,8 @@
 		/* SCFG DEVALT 0 */
 		alt0_spip_sl:      alt00     { alts = <&scfg 0x00 0x0 0>; };
 		alt0_gpio_no_spip: alt03_inv { alts = <&scfg 0x00 0x3 1>; };
+		/* FPIP (FIU SPI Interface Peripheral) for external flash. */
+		alt0_gpio_no_fpip: alt07_inv { alts = <&scfg 0x00 0x7 1>; };
 
 		/* SCFG DEVALT 1 */
 		alt1_kbrst_sl:     alt10     { alts = <&scfg 0x01 0x0 0>; };
@@ -127,9 +129,9 @@
 
 		/* SCFG DEVALT D */
 		altd_psl_in1_ahi:  altd0     { alts = <&scfg 0x0D 0x0 0>; };
-		altd_npsl_in1_sl:  altd1     { alts = <&scfg 0x0D 0x1 0>; };
+		altd_npsl_in1_sl:  altd1_inv { alts = <&scfg 0x0D 0x1 1>; };
 		altd_psl_in2_ahi:  altd2     { alts = <&scfg 0x0D 0x2 0>; };
-		altd_npsl_in2_sl:  altd3     { alts = <&scfg 0x0D 0x3 0>; };
+		altd_npsl_in2_sl:  altd3_inv { alts = <&scfg 0x0D 0x3 1>; };
 		altd_psl_in3_ahi:  altd4     { alts = <&scfg 0x0D 0x4 0>; };
 		altd_psl_in3_sl:   altd5     { alts = <&scfg 0x0D 0x5 0>; };
 		altd_psl_in4_ahi:  altd6     { alts = <&scfg 0x0D 0x6 0>; };
@@ -146,6 +148,6 @@
 		altf_adc7_sl:      altf2     { alts = <&scfg 0x0F 0x2 0>; };
 		altf_adc8_sl:      altf3     { alts = <&scfg 0x0F 0x3 0>; };
 		altf_adc9_sl:      altf4     { alts = <&scfg 0x0F 0x4 0>; };
-		altf_f_shi_new:    altf7     { alts = <&scfg 0x0F 0x7 0>; };
+		altf_shi_new:      altf7     { alts = <&scfg 0x0F 0x7 0>; };
 	};
 };

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -39,10 +39,51 @@
 
 	def_io_conf: def_io_conf_list {
 		compatible = "nuvoton,npcx-pinctrl-def";
+		/* Change default functional pads to GPIOs
+		 * no_spip - PIN95.97.A1.A3
+		 * no_fpip - PIN96.A0.A2.A4 - Internal flash only
+		 * no_pwrgd - PIN72
+		 * no_lpc_espi - PIN46.47.51.52.53.54.55.57
+		 * no_peci_en - PIN81
+		 * npsl_in1_sl - PIND2
+		 * npsl_in2_sl - PIN00
+		 * no_ksi0-7 - PIN31.30.27.26.25.24.23.22
+		 * no_ks000-17 - PIN21.20.17.16.15.14.13.12.11.10.07.06.05.04.
+		 *                  82.83.03.B1
+		 */
 		pinctrl = <&alt0_gpio_no_spip
+			   &alt0_gpio_no_fpip
 			   &alt1_no_pwrgd
 			   &alt1_no_lpc_espi
-			   &alta_no_peci_en>;
+			   &alta_no_peci_en
+			   &altd_npsl_in1_sl
+			   &altd_npsl_in2_sl
+			   &alt7_no_ksi0_sl
+			   &alt7_no_ksi1_sl
+			   &alt7_no_ksi2_sl
+			   &alt7_no_ksi3_sl
+			   &alt7_no_ksi4_sl
+			   &alt7_no_ksi5_sl
+			   &alt7_no_ksi6_sl
+			   &alt7_no_ksi7_sl
+			   &alt8_no_kso00_sl
+			   &alt8_no_kso01_sl
+			   &alt8_no_kso02_sl
+			   &alt8_no_kso03_sl
+			   &alt8_no_kso04_sl
+			   &alt8_no_kso05_sl
+			   &alt8_no_kso06_sl
+			   &alt8_no_kso07_sl
+			   &alt9_no_kso08_sl
+			   &alt9_no_kso09_sl
+			   &alt9_no_kso10_sl
+			   &alt9_no_kso11_sl
+			   &alt9_no_kso12_sl
+			   &alt9_no_kso13_sl
+			   &alt9_no_kso14_sl
+			   &alt9_no_kso15_sl
+			   &alta_no_kso16_sl
+			   &alta_no_kso17_sl>;
 	};
 
 	soc {

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -26,6 +26,32 @@ struct npcx_alt {
 /**
  * @brief Select device pin-mux to I/O or its alternative functionality
  *
+ * Example devicetree fragment:
+ *    / {
+ *		uart1: serial@400c4000 {
+ *			//altfunc 0: PIN64.65, otherwise CR_SIN1 CR_SOUT1
+ *			pinctrl = <&altc_uart1_sl2>;
+ *			...
+ *		};
+ *
+ *		kscan0: kscan@400a3000 {
+ *			//altfunc 0: PIN31.xx PIN21.xx, otherwise KSO0-x KSI0-x
+ *			pinctrl = <&alt7_no_ksi0_sl ...
+ *			           &alt8_no_kso00_sl ...>;
+ *			...
+ *		};
+ *	};
+ *
+ * Example usage:
+ *    - Pinmux configuration list
+ *         const struct npcx_alt alts_list[] = DT_NPCX_ALT_ITEMS_LIST(inst);
+ *    - Change pinmux to UART:
+ *         soc_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 1);
+ *    - Change pinmux back to GPIO64.65:
+ *         soc_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 0);
+ *
+ * Please refer more details in Table 3. (Pin Multiplexing Configuration).
+ *
  * @param alts_list Pointer to pin-mux configuration list for specific device
  * @param alts_size Pin-mux configuration list size
  * @param altfunc 0: set pin-mux to GPIO, otherwise specific functionality


### PR DESCRIPTION
Fix default pinmux of functional pads to GPIOs. It includes:
1. PIN96.A0.A2.A4 - If internal flash is supported
2. PIND2.00 - Default PSL inputs
3. PIN31.30.27.26.25.24.23.22 - Keyboard inputs
4. PIN21.20.17.16.15.14.13.12.11.10.07.06.05.04.82.83.03.B1 - Keyboard
   outputs

This PR changes all pads' pinmux to GPIO besides VCC1_RST.