### PR TITLE
Bluetooth: indication callback signature update

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -996,15 +996,18 @@ static inline int bt_gatt_notify_uuid(struct bt_conn *conn,
 	return bt_gatt_notify_cb(conn, &params);
 }
 
+/* Forward declaration of the bt_gatt_indicate_params structure */
+struct bt_gatt_indicate_params;
+
 /** @typedef bt_gatt_indicate_func_t
  *  @brief Indication complete result callback.
  *
  *  @param conn Connection object.
- *  @param attr Attribute object.
+ *  @param params Indication params object.
  *  @param err ATT error code
  */
 typedef void (*bt_gatt_indicate_func_t)(struct bt_conn *conn,
-					const struct bt_gatt_attr *attr,
+					struct bt_gatt_indicate_params *params,
 					uint8_t err);
 
 /** @brief GATT Indicate Value parameters */

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -74,8 +74,8 @@ static void vnd_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	simulate_vnd = (value == BT_GATT_CCC_INDICATE) ? 1 : 0;
 }
 
-static void indicate_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			uint8_t err)
+static void indicate_cb(struct bt_conn *conn,
+			struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	printk("Indication %s\n", err != 0U ? "fail" : "success");
 	indicating = 0U;

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -37,8 +37,8 @@ static void htmc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
 	simulate_htm = (value == BT_GATT_CCC_INDICATE) ? 1 : 0;
 }
 
-static void indicate_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			uint8_t err)
+static void indicate_cb(struct bt_conn *conn,
+			struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	printk("Indication %s\n", err != 0U ? "fail" : "success");
 	indicating = 0U;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -889,7 +889,7 @@ static struct gatt_sc {
 } gatt_sc;
 
 static void sc_indicate_rsp(struct bt_conn *conn,
-			    const struct bt_gatt_attr *attr, uint8_t err)
+			    struct bt_gatt_indicate_params *params, uint8_t err)
 {
 #if defined(CONFIG_BT_GATT_CACHING)
 	struct gatt_cf_cfg *cfg;
@@ -1866,7 +1866,7 @@ static void gatt_indicate_rsp(struct bt_conn *conn, uint8_t err,
 {
 	struct bt_gatt_indicate_params *params = user_data;
 
-	params->func(conn, params->attr, err);
+	params->func(conn, params, err);
 }
 
 static int gatt_send(struct bt_conn *conn, struct net_buf *buf,
@@ -2234,7 +2234,7 @@ uint8_t bt_gatt_check_perm(struct bt_conn *conn, const struct bt_gatt_attr *attr
 }
 
 static void sc_restore_rsp(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr, uint8_t err)
+			   struct bt_gatt_indicate_params *params, uint8_t err)
 {
 #if defined(CONFIG_BT_GATT_CACHING)
 	struct gatt_cf_cfg *cfg;

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -241,10 +241,10 @@ static void oacp_read_proc_execute(struct bt_ots *ots,
 }
 
 static void oacp_ind_cb(struct bt_conn *conn,
-			const struct bt_gatt_attr *attr,
+			struct bt_gatt_indicate_params *params,
 			uint8_t err)
 {
-	struct bt_ots *ots = (struct bt_ots *) attr->user_data;
+	struct bt_ots *ots = (struct bt_ots *) params->attr->user_data;
 
 	LOG_DBG("Received OACP Indication ACK with status: 0x%04X", err);
 

--- a/subsys/bluetooth/services/ots/ots_olcp.c
+++ b/subsys/bluetooth/services/ots/ots_olcp.c
@@ -206,7 +206,7 @@ static bool olcp_command_len_verify(enum bt_gatt_ots_olcp_proc_type type,
 }
 
 static void olcp_ind_cb(struct bt_conn *conn,
-		const struct bt_gatt_attr *attr,
+		struct bt_gatt_indicate_params *params,
 		uint8_t err)
 {
 	LOG_DBG("Received OLCP Indication ACK with status: 0x%04X", err);

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
@@ -147,7 +147,8 @@ void service_b_3_2_value_v6_notify(void)
  *             BT_GATT_ERR() with a specific ATT error code.
  */
 static void value_v6_indicate_cb(struct bt_conn *conn,
-				 const struct bt_gatt_attr *attr, uint8_t err)
+				 struct bt_gatt_indicate_params *params,
+				 uint8_t err)
 {
 	printk("Indication for attribute 'Value V6' %s\n",
 	       (err) ? "failed" : "succeded");

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
@@ -147,7 +147,8 @@ void service_b_3_3_value_v6_notify(void)
  *             BT_GATT_ERR() with a specific ATT error code.
  */
 static void value_v6_indicate_cb(struct bt_conn *conn,
-				 const struct bt_gatt_attr *attr, uint8_t err)
+				 struct bt_gatt_indicate_params *params,
+				 uint8_t err)
 {
 	printk("Indication for attribute 'Value V6' %s\n",
 	       (err) ? "failed" : "succeded");

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -734,8 +734,8 @@ struct set_value {
 
 struct bt_gatt_indicate_params indicate_params;
 
-static void indicate_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			uint8_t err)
+static void indicate_cb(struct bt_conn *conn,
+			struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	if (err != 0U) {
 		LOG_ERR("Indication fail");


### PR DESCRIPTION
Update the signature of the `bt_gatt_indicate_func_t` callback type by
replacing the attr pointer with a pointer to the
`bt_gatt_indicate_params` struct that was used to start the indication.

This allows the callback to free the `bt_gatt_indicate_params` instance
if it was allocated from storage, while still allowing the
`bt_gatt_attr` value to be accessed through `params->attr`.

Allocating the `bt_gatt_indicate_params` instance from storage is
desirable as multiple indications can be queued, however each instance
must be valid until the callback is run.

Fixes #28688

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>