### PR TITLE
tests: arch: arm: arm_thread_swap: use memset() instead of memcpy()

### DIFF
--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -406,7 +406,7 @@ void test_arm_thread_swap(void)
 	/* Clear the thread's floating-point callee-saved registers' container.
 	 * The container will, later, be populated by the swap mechanism.
 	 */
-	memcpy(&_current->arch.preempt_float, 0,
+	memset(&_current->arch.preempt_float, 0,
 		sizeof(struct _preempt_float));
 
 	/* Randomize the FP callee-saved registers at test initialization */


### PR DESCRIPTION
tests: arch: arm: arm_thread_swap: use memset() instead of memcpy()

According to comment memset() should be used instead of memcpy().
There is no need to access to address 0x0.
Fixes #28691

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>