### PR TITLE
boards/arm: Remove soc compatible from board compatible

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "96Boards Gumstix AeroCore 2";
-	compatible = "gumstix,aerocore2", "st,stm32f427";
+	compatible = "gumstix,aerocore2";
 
 	chosen {
 		zephyr,console = &uart7;

--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Tocoding Argonkey 96boards";
-	compatible = "tocoding,argonkey", "st,stm32f412";
+	compatible = "tocoding,argonkey";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/96b_avenger96/96b_avenger96.dts
+++ b/boards/arm/96b_avenger96/96b_avenger96.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Arrow Electronics STM32MP157A Avenger96 board";
-	compatible = "arrow,stm32mp157a-avenger96", "st,stm32mp15";
+	compatible = "arrow,stm32mp157a-avenger96";
 
 	chosen {
 		/*

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "Seeed Studio Carbon 96boards";
-	compatible = "seeed,carbon", "st,stm32f401";
+	compatible = "seeed,carbon";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Tocoding Neonkey 96boards";
-	compatible = "tocoding,neonkey", "st,stm32f411";
+	compatible = "tocoding,neonkey";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics 96Boards STM32 Sensor Mezzanine board";
-	compatible = "st,stm32f446-b96b-f446ve", "st,stm32f446";
+	compatible = "st,stm32f446-b96b-f446ve";
 
 	chosen {
 		zephyr,console = &uart4;

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "RAKWireless 96boards WisTrio board";
-	compatible = "rak,wistrio", "st,stm32l151";
+	compatible = "rak,wistrio";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics B-L072Z-LRWAN1 Discovery kit";
-	compatible = "st,stm32l072z-lrwan1", "st,stm32l072";
+	compatible = "st,stm32l072z-lrwan1";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics B-L4S5I-IOT01A discovery kit";
-	compatible = "st,b-l4s5i-iot01a", "st,stm32l4s5";
+	compatible = "st,b-l4s5i-iot01a";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics B-L475E-IOT01Ax board";
-	compatible = "st,stm32l475-disco-iot", "st,stm32l475";
+	compatible = "st,stm32l475-disco-iot";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/dragino_lsn50/dragino_lsn50.dts
+++ b/boards/arm/dragino_lsn50/dragino_lsn50.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Dragino LSN50 LoRA Sensor Node";
-	compatible = "vendor,dragino", "st,stm32l072";
+	compatible = "vendor,dragino";
 
 	chosen {
 		zephyr,console = &usart1;
@@ -23,4 +23,3 @@
 	current-speed = <115200>;
 	status = "okay";
 };
-

--- a/boards/arm/google_kukui/google_kukui.dts
+++ b/boards/arm/google_kukui/google_kukui.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Google Kukui EC";
-	compatible = "st,stm32f098rc", "st,stm32f098";
+	compatible = "google,kukui-ec", "st,stm32f098";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Mikroe MINI-M4 for STM32 board";
-	compatible = "mikroe,mini-m4-for-stm32", "st,stm32f415rg";
+	compatible = "mikroe,mini-m4-for-stm32";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F030R8-NUCLEO board";
-	compatible = "st,stm32f030r8-nucleo", "st,stm32f030";
+	compatible = "st,stm32f030r8-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics NUCLEO-F070RB board";
-	compatible = "st,stm32f070rb-nucleo", "st,stm32f070";
+	compatible = "st,stm32f070rb-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F091RC-NUCLEO board";
-	compatible = "st,stm32f091rc-nucleo", "st,stm32f091";
+	compatible = "st,stm32f091rc-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F103RB-NUCLEO board";
-	compatible = "st,stm32f103rb-nucleo", "st,stm32f103rb";
+	compatible = "st,stm32f103rb-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F207ZG-NUCLEO board";
-	compatible = "st,stm32f207zg-nucleo", "st,stm32f207";
+	compatible = "st,stm32f207zg-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F302R8-NUCLEO board";
-	compatible = "st,stm32f302r8-nucleo", "st,stm32f302";
+	compatible = "st,stm32f302r8-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F303RE-NUCLEO board";
-	compatible = "st,stm32f303re-nucleo", "st,stm32f303";
+	compatible = "st,stm32f303re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F334R8-NUCLEO board";
-	compatible = "st,stm32f334r8-nucleo", "st,stm32f334";
+	compatible = "st,stm32f334r8-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32F401RE-NUCLEO board";
-	compatible = "st,stm32f401re-nucleo", "st,stm32f401";
+	compatible = "st,stm32f401re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F411RE-NUCLEO board";
-	compatible = "st,stm32f411re-nucleo", "st,stm32f411";
+	compatible = "st,stm32f411re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F412ZG-NUCLEO board";
-	compatible = "st,stm32f412zg-nucleo", "st,stm32f412";
+	compatible = "st,stm32f412zg-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F413ZH-NUCLEO board";
-	compatible = "st,stm32f413zh-nucleo", "st,stm32f413";
+	compatible = "st,stm32f413zh-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F429ZI-NUCLEO board";
-	compatible = "st,stm32f429zi-nucleo", "st,stm32f429";
+	compatible = "st,stm32f429zi-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F446RE-NUCLEO board";
-	compatible = "st,stm32f446re-nucleo", "st,stm32f446";
+	compatible = "st,stm32f446re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F746ZG-NUCLEO board";
-	compatible = "st,stm32f746zg-nucleo", "st,stm32f746";
+	compatible = "st,stm32f746zg-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F756ZG-NUCLEO board";
-	compatible = "st,stm32f756zg-nucleo", "st,stm32f756";
+	compatible = "st,stm32f756zg-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F767ZI-NUCLEO board";
-	compatible = "st,stm32f767zi-nucleo", "st,stm32f767";
+	compatible = "st,stm32f767zi-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32G071RB-NUCLEO board";
-	compatible = "st,stm32g071rb-nucleo", "st,stm32g071";
+	compatible = "st,stm32g071rb-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32G431RB-NUCLEO board";
-	compatible = "st,stm32g431rb-nucleo", "st,stm32g431";
+	compatible = "st,stm32g431rb-nucleo";
 
 	chosen {
 		zephyr,console = &lpuart1;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32G474RE-NUCLEO board";
-	compatible = "st,stm32g474re-nucleo", "st,stm32g474";
+	compatible = "st,stm32g474re-nucleo";
 
 	chosen {
 		zephyr,console = &lpuart1;

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32H743ZI-NUCLEO board";
-	compatible = "st,stm32h743zi-nucleo", "st,stm32h743";
+	compatible = "st,stm32h743zi-nucleo";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32H745ZI-Q-NUCLEO board";
-	compatible = "st,stm32h745zi-q-nucleo", "st,stm32h745";
+	compatible = "st,stm32h745zi-q-nucleo";
 
 	/* HW resources belonging to CM4 */
 	chosen {

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32H745ZI-Q-NUCLEO board";
-	compatible = "st,stm32h745zi-q-nucleo", "st,stm32h745";
+	compatible = "st,stm32h745zi-q-nucleo";
 
 	/* HW resources belonging to CM7 */
 	chosen {

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L053R8-NUCLEO board";
-	compatible = "st,stm32l053r8-nucleo", "st,stm32l053";
+	compatible = "st,stm32l053r8-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L073RZ-NUCLEO board";
-	compatible = "st,stm32l073rz-nucleo", "st,stm32l073";
+	compatible = "st,stm32l073rz-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L152RE-NUCLEO board";
-	compatible = "st,stm32l152re-nucleo", "st,stm32l152";
+	compatible = "st,stm32l152re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32L432KC-NUCLEO board";
-	compatible = "st,stm32l432kc-nucleo", "st,stm32l432";
+	compatible = "st,stm32l432kc-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l452re/nucleo_l452re.dts
+++ b/boards/arm/nucleo_l452re/nucleo_l452re.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32L452RE-NUCLEO board";
-	compatible = "st,stm32l452re-nucleo", "st,stm32l452";
+	compatible = "st,stm32l452re-nucleo";
 
 	leds {
 		compatible = "gpio-leds";

--- a/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32L452RE-NUCLEO board";
-	compatible = "st,stm32l452re-nucleo", "st,stm32l452";
+	compatible = "st,stm32l452re-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l452re/nucleo_l452re_p.dts
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_p.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "STMicroelectronics STM32L452RE-P-NUCLEO board";
-	compatible = "st,stm32l452re-nucleo", "st,stm32l452";
+	compatible = "st,stm32l452re-nucleo";
 
 	leds {
 		compatible = "gpio-leds";

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L476RG-NUCLEO board";
-	compatible = "st,stm32l476rg-nucleo", "st,stm32l476";
+	compatible = "st,stm32l476rg-nucleo";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L496ZG-NUCLEO board";
-	compatible = "st,stm32l496zg-nucleo", "st,stm32l496";
+	compatible = "st,stm32l496zg-nucleo";
 
 	chosen {
 		zephyr,console = &lpuart1;

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32L4R5ZI-NUCLEO board";
-	compatible = "st,stm32l4r5zi-nucleo", "st,stm32l4r5";
+	compatible = "st,stm32l4r5zi-nucleo";
 
 	chosen {
 		zephyr,console = &lpuart1;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q.dts
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32L552ZE-NUCLEO-Q board";
-	compatible = "st,stm32l552ze-nucleo-q", "st,stm32l552";
+	compatible = "st,stm32l552ze-nucleo-q";
 
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns.dts
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32L552ZE-NUCLEO-Q board";
-	compatible = "st,stm32l552ze-nucleo-q", "st,stm32l552";
+	compatible = "st,stm32l552ze-nucleo-q";
 
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32WB55RG-NUCLEO board";
-	compatible = "st,stm32wb55rg-nucleo", "st,stm32wb55rg";
+	compatible = "st,stm32wb55rg-nucleo";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Olimex STM32-E407 board";
-	compatible = "olimex,stm32-e407", "st,stm32f407";
+	compatible = "olimex,stm32-e407";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Olimex STM32-H103 board";
-	compatible = "olimex,stm32-h103", "st,stm32f103rb";
+	compatible = "olimex,stm32-h103";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Olimex STM32-H407 board";
-	compatible = "olimex,stm32-h407", "st,stm32f407";
+	compatible = "olimex,stm32-h407";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Olimex STM32-P405 board";
-	compatible = "olimex,stm32-p405", "st,stm32f405";
+	compatible = "olimex,stm32-p405";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics SensorTile.box board";
-	compatible = "st,sensortile-box", "st,stm32l4r9";
+	compatible = "st,sensortile-box";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics Flight Controller Board";
-	compatible = "st,flight-controller-board", "st,stm32f401";
+	compatible = "st,flight-controller-board";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM3210C-EVAL board";
-	compatible = "st,stm3210c-eval", "st,stm32f107";
+	compatible = "st,stm3210c-eval";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32373C-EVAL board";
-	compatible = "st,stm32373c-eval", "st,stm32f373";
+	compatible = "st,stm32373c-eval";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32f030_demo/stm32f030_demo.dts
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STM32F030 DEMO board";
-	compatible = "st,stm32f030-demo", "st,stm32f030f4p6", "st,stm32f030";
+	compatible = "st,stm32f030-demo";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F072-EVAL board";
-	compatible = "st,stm32f072-eval", "st,stm32f072";
+	compatible = "st,stm32f072-eval";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F072B-DISCO board";
-	compatible = "st,stm32f072b-disco", "st,stm32f072";
+	compatible = "st,stm32f072b-disco";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F0DISCOVERY board";
-	compatible = "st,stm32f058r8-discovery", "st,stm32f051";
+	compatible = "st,stm32f058r8-discovery";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F3DISCOVERY board";
-	compatible = "st,stm32f3discovery", "st,stm32f303";
+	compatible = "st,stm32f3discovery";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F411E-DISCO board";
-	compatible = "st,stm32f411e-disco", "st,stm32f411";
+	compatible = "st,stm32f411e-disco";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F412G-DISCO board";
-	compatible = "st,stm32f412g-disco", "st,stm32f412";
+	compatible = "st,stm32f412g-disco";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F429I_DISC1 board";
-	compatible = "st,stm32f4discovery", "st,stm32f429";
+	compatible = "st,stm32f4discovery";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F469I-DISCO board";
-	compatible = "st,stm32f469i-disco", "st,stm32f469";
+	compatible = "st,stm32f469i-disco";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F4DISCOVERY board";
-	compatible = "st,stm32f4discovery", "st,stm32f407";
+	compatible = "st,stm32f4discovery";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F723E DISCOVERY board";
-	compatible = "st,stm32f723e-disco", "st,stm32f723";
+	compatible = "st,stm32f723e-disco";
 
 	chosen {
 		zephyr,console = &usart6;

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32F746G DISCOVERY board";
-	compatible = "st,stm32f746g-disco", "st,stm32f746";
+	compatible = "st,stm32f746g-disco";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32F769I DISCOVERY board";
-	compatible = "st,stm32f769I-disco", "st,stm32f769";
+	compatible = "st,stm32f769I-disco";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
+++ b/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32G0316 Discovery board";
-	compatible = "st,stm32g0316-disco", "st,stm32g031";
+	compatible = "st,stm32g0316-disco";
 
 	aliases {
 		led0 = &green_led_1;

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32H747I DISCOVERY board";
-	compatible = "st,stm32h747i-disco", "st,stm32h747";
+	compatible = "st,stm32h747i-disco";
 
 	/* HW resources are split between CM7 and CM4 */
 	chosen {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32H747I DISCOVERY board";
-	compatible = "st,stm32h747i-disco", "st,stm32h747";
+	compatible = "st,stm32h747i-disco";
 
 	/* HW resources are split between CM7 and CM4 */
 	chosen {

--- a/boards/arm/stm32l1_disco/stm32l1_disco.dts
+++ b/boards/arm/stm32l1_disco/stm32l1_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32L1DISCOVERY board";
-	compatible = "st,stm32l1discovery", "st,stm32l151";
+	compatible = "st,stm32l1discovery";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -13,7 +13,7 @@
 
 / {
 	model = "STMicroelectronics STM32L476G-DISCO board";
-	compatible = "st,stm32l476g-disco", "st,stm32l476";
+	compatible = "st,stm32l476g-disco";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32L496G-DISCO board";
-	compatible = "st,stm32l496g-disco", "st,stm32l496";
+	compatible = "st,stm32l496g-disco";
 
 	chosen {
 		zephyr,console = &usart2;

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STMicroelectronics STM32MP157-DK2 board";
-	compatible = "st,stm32mp157c-dk2", "st,stm32mp15";
+	compatible = "st,stm32mp157c-dk2";
 	chosen {
 		/*
 		 * By default, Zephyr console and shell are assigned to

--- a/boards/arm/stm32vl_disco/stm32vl_disco.dts
+++ b/boards/arm/stm32vl_disco/stm32vl_disco.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STMicroelectronics STM32VLDISCOVERY board";
-	compatible = "st,stm32vldiscovery", "st,stm32f100";
+	compatible = "st,stm32vldiscovery";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Waveshare Open103Z";
-	compatible = "waveshare,open103z", "st,stm32f103ze";
+	compatible = "waveshare,open103z";
 
 	chosen {
 		zephyr,console = &usart1;


### PR DESCRIPTION
There's no reason to add soc compatible at this level.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/25592

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>