### PR TITLE
force i2c reset on certain stm32 device

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -229,6 +229,18 @@ static int i2c_stm32_init(const struct device *dev)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
+#if defined(CONFIG_SOC_STM32F103X8) || defined(CONFIG_SOC_STM32F103XB)
+	/*
+	 * Force i2c reset for STM32 (F101X8/B, F102X8/B), F103X8/B.
+	 * So that they can enter master mode properly.
+	 * Issue described in ES096 2.14.7
+	 */
+	I2C_TypeDef * i2c = cfg->i2c;
+
+	LL_I2C_EnableReset(i2c);
+	LL_I2C_DisableReset(i2c);
+#endif
+
 	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
 	ret = i2c_stm32_runtime_configure(dev, I2C_MODE_MASTER | bitrate_cfg);


### PR DESCRIPTION
According to [ES096](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/7d/02/75/64/17/fc/4d/fd/CD00190234.pdf/files/CD00190234.pdf/jcr:content/translations/en.CD00190234.pdf) 2.14.7, i2c on stm32 F101X8/B, F102X8/B, and F103X8/B might not be able to enter master mode on start up. This will prevent other drivers from loading. Adding a reset seems to fix this issue.

The issue is discovered when I used a STM32F103RB board + MPU6050, and issued two i2c reads back to back.
The first one will time out and reset the bus. Then, the second one will success.
