### PR TITLE
dts: bindings: move io-channels and io-channel-names to base.yaml

### DIFF
--- a/dts/bindings/adc/voltage-divider.yaml
+++ b/dts/bindings/adc/voltage-divider.yaml
@@ -7,9 +7,10 @@ description: |
 
 compatible: "voltage-divider"
 
+include: base.yaml
+
 properties:
     io-channels:
-      type: phandle-array
       required: true
       description: |
         Channels available with this divider configuration.

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -85,3 +85,13 @@ properties:
       required: false
       type: string-array
       description: Provided names of DMA channel specifiers
+
+    io-channels:
+      required: false
+      type: phandle-array
+      description: IO channels specifiers
+
+    io-channel-names:
+      required: false
+      type: string-array
+      description: Provided names of IO channel specifiers

--- a/dts/bindings/sensor/grove,light.yaml
+++ b/dts/bindings/sensor/grove,light.yaml
@@ -9,7 +9,6 @@ include: base.yaml
 
 properties:
   io-channels:
-    type: phandle-array
     required: true
     description: |
       IO channel associated with the resistor voltage divider.

--- a/dts/bindings/sensor/grove,temperature.yaml
+++ b/dts/bindings/sensor/grove,temperature.yaml
@@ -9,7 +9,6 @@ include: base.yaml
 
 properties:
   io-channels:
-    type: phandle-array
     required: true
     description: |
       IO channel associated with the NTC voltage

--- a/dts/bindings/sensor/nxp,kinetis-temperature.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-temperature.yaml
@@ -12,12 +12,10 @@ properties:
       required: true
 
     io-channels:
-      type: phandle-array
       required: true
       description: ADC channels for temperature sensor and bandgap voltage
 
     io-channel-names:
-      type: string-array
       required: true
       description: name of each ADC channel (SENSOR or BANDGAP)
 

--- a/dts/bindings/test/vnd,temperature-sensor.yaml
+++ b/dts/bindings/test/vnd,temperature-sensor.yaml
@@ -12,12 +12,10 @@ properties:
       required: true
 
     io-channels:
-      type: phandle-array
       required: true
       description: ADC conversion channels
 
     io-channel-names:
-      type: string-array
       required: true
       description: conversion channel names
 


### PR DESCRIPTION
Generalize io-channels and io-channel-names devicetree node properties and move their definitions to base.yaml. Keep binding specific description where relevant.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>