### PR TITLE
debugger: rt1xxx series pyocd supporting update

### DIFF
--- a/boards/arm/mimxrt1010_evk/board.cmake
+++ b/boards/arm/mimxrt1010_evk/board.cmake
@@ -4,5 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(pyocd "--target=mimxrt1010")
 board_runner_args(jlink "--device=MIMXRT1011")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1015_evk/board.cmake
+++ b/boards/arm/mimxrt1015_evk/board.cmake
@@ -4,5 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(pyocd "--target=mimxrt1015")
 board_runner_args(jlink "--device=MIMXRT1015")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(pyocd "--target=cortex_m")
+board_runner_args(pyocd "--target=mimxrt1060")
 board_runner_args(jlink "--device=MIMXRT1062xxx6A")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1064_evk/board.cmake
+++ b/boards/arm/mimxrt1064_evk/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(pyocd "--target=cortex_m")
+board_runner_args(pyocd "--target=mimxrt1064")
 board_runner_args(jlink "--device=MIMXRT1064")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
in pyocd-0.28 release pyocd can support below NXP rt1xxx
mimxrt1010
mimxrt1015
mimxrt1060
mimxrt1064

user can upgrade latest pyocd with
pip3 install pyocd -U

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>