### PR TITLE
usb: mass: Fix main thread stack size overflow.

### DIFF
--- a/samples/subsys/usb/mass/prj.conf
+++ b/samples/subsys/usb/mass/prj.conf
@@ -14,3 +14,4 @@ CONFIG_USB_MASS_STORAGE_LOG_LEVEL_ERR=y
 # If the target's code needs to do file operations, enable target's
 # FAT FS code. (Without this only the host can access the fs contents)
 #CONFIG_FILE_SYSTEM=y
+CONFIG_MAIN_STACK_SIZE=1536


### PR DESCRIPTION
After HW stack protection option was globally enabled for
nRF SoCs (#28470) turned out main stack size is too small for
USB mass storage sample. Increase to avoid overflow.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>

Without this patch running the sample for nRF SoCs leads to MPU Fault: stack overflow.
```
*** Booting Zephyr OS build zephyr-v2.4.0-1-g76981d9706fd  ***
Area 4 at 0x0 on MX25R64 for 65536 bytes
[00:00:00.369,812] <inf> littlefs: LittleFS version 2.2, disk version 2.0
[00:00:00.369,842] <inf> littlefs: FS at MX25R64:0x0 is 16 0x1000-byte blocks with 512 cycle
[00:00:00.369,873] <inf> littlefs: sizes: rd 16 ; pr 16 ; ca 64 ; la 32
[00:00:00.370,239] <inf> littlefs: /lfs mounted
Mount /lfs: 0
/lfs: bsize = 16 ; frsize = 4096 ; blocks = 16 ; bfree = 14
/lfs opendir: 0
[00:00:00.429,199] <err> os: ***** MPU FAULT *****
[00:00:00.429,199] <err> os:   Stacking error (context area might be not valid)
[00:00:00.429,229] <err> os:   Data Access Violation
[00:00:00.429,229] <err> os:   MMFAR Address: 0x20004698
[00:00:00.429,229] <err> os: r0/a1:  0x200000f8  r1/a2:  0x00000004  r2/a3:  0x00000004
[00:00:00.429,229] <err> os: r3/a4:  0x00000004 r12/ip:  0x000058d5 r14/lr:  0x0000d6f1
[00:00:00.429,229] <err> os:  xpsr:  0x20000000
[00:00:00.429,260] <err> os: Faulting instruction address (r15/pc): 0x00000010
[00:00:00.429,260] <err> os: >>> ZEPHYR FATAL ERROR 2: Stack overflow on CPU 0
[00:00:00.429,260] <err> os: Current thread: 0x200005e8 (unknown)
[00:00:01.481,506] <err> os: Halting system

```