### PR TITLE
Bluetooth: controller: Fix latency cancel on LLCP initiation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -55,6 +55,7 @@ static int init_reset(void);
 #if defined(CONFIG_BT_PERIPHERAL)
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 					       void *params);
+static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle);
 #endif /* CONFIG_BT_PERIPHERAL */
 
 static void ticker_update_conn_op_cb(uint32_t status, void *param);
@@ -274,25 +275,9 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 #endif /* CONFIG_BT_CTLR_FORCE_MD_AUTO */
 	}
 
-#if defined(CONFIG_BT_PERIPHERAL)
-	/* break slave latency */
-	if (conn->lll.role && conn->lll.latency_event &&
-	    !conn->slave.latency_cancel) {
-		uint32_t ticker_status;
-
-		conn->slave.latency_cancel = 1U;
-
-		ticker_status =
-			ticker_update(TICKER_INSTANCE_ID_CTLR,
-				      TICKER_USER_ID_THREAD,
-				      (TICKER_ID_CONN_BASE + handle),
-				      0, 0, 0, 0, 1, 0,
-				      ticker_update_latency_cancel_op_cb,
-				      (void *)conn);
-		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
-			  (ticker_status == TICKER_STATUS_BUSY));
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
 	}
-#endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_THROUGHPUT)
 	static uint32_t last_cycle_stamp;
@@ -391,6 +376,11 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 			conn->llcp_conn_param.state = cmd;
 			conn->llcp_conn_param.cmd = 1U;
 			conn->llcp_conn_param.req++;
+
+			if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+			    conn->lll.role) {
+				peripheral_latency_cancel(conn, handle);
+			}
 		}
 
 #else /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
@@ -436,6 +426,10 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 
 	conn->llcp_terminate.req++;
 
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
+
 	return 0;
 }
 
@@ -454,6 +448,12 @@ uint8_t ll_feature_req_send(uint16_t handle)
 
 	conn->llcp_feature.req++;
 
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+	    IS_ENABLED(CONFIG_BT_CTLR_SLAVE_FEAT_REQ) &&
+	    conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
+
 	return 0;
 }
 
@@ -471,6 +471,10 @@ uint8_t ll_version_ind_send(uint16_t handle)
 	}
 
 	conn->llcp_version.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -520,6 +524,10 @@ uint32_t ll_length_req_send(uint16_t handle, uint16_t tx_octets, uint16_t tx_tim
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	conn->llcp_length.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -611,6 +619,10 @@ uint8_t ll_phy_req_send(uint16_t handle, uint8_t tx, uint8_t flags, uint8_t rx)
 	conn->llcp_phy.flags = flags;
 	conn->llcp_phy.rx = rx;
 	conn->llcp_phy.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -1629,6 +1641,26 @@ static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 	LL_ASSERT(ticker_status == TICKER_STATUS_SUCCESS);
 
 	conn->slave.latency_cancel = 0U;
+}
+
+static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle)
+{
+	/* break peripheral latency */
+	if (conn->lll.latency_event && !conn->slave.latency_cancel) {
+		uint32_t ticker_status;
+
+		conn->slave.latency_cancel = 1U;
+
+		ticker_status =
+			ticker_update(TICKER_INSTANCE_ID_CTLR,
+				      TICKER_USER_ID_THREAD,
+				      (TICKER_ID_CONN_BASE + handle),
+				      0, 0, 0, 0, 1, 0,
+				      ticker_update_latency_cancel_op_cb,
+				      (void *)conn);
+		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+			  (ticker_status == TICKER_STATUS_BUSY));
+	}
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 


### PR DESCRIPTION
Fix controller implementation to cancel peripheral latency
when initiating new control procedures.

Fixes #28699.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>