### PR TITLE
shell: examples cleanup

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -10,7 +10,6 @@
 #include <sys/printk.h>
 #include <logging/log.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 #include <drivers/flash.h>
 #include <device.h>
 #include <soc.h>

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -14,7 +14,6 @@ LOG_MODULE_REGISTER(net_zperf_sample, LOG_LEVEL_DBG);
 #include <zephyr.h>
 #include <sys/printk.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 
 #include <net/net_ip.h>
 #include <net/net_core.h>

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -7,7 +7,6 @@
 #include <zephyr.h>
 #include <sys/printk.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 #include <version.h>
 #include <logging/log.h>
 #include <stdlib.h>

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -19,7 +19,6 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 #include <stdlib.h>
 #include <stdio.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 
 #include <net/net_if.h>
 #include <net/dns_resolve.h>

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -14,7 +14,6 @@ LOG_MODULE_REGISTER(net_bt_shell, CONFIG_NET_L2_BT_LOG_LEVEL);
 #include <errno.h>
 
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 #include <sys/printk.h>
 
 #include <net/net_core.h>

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -15,7 +15,6 @@ LOG_MODULE_REGISTER(net_ieee802154_shell, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <stdio.h>
 #include <stdlib.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 #include <sys/printk.h>
 
 #include <net/net_if.h>

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -15,7 +15,6 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #include <stdio.h>
 #include <stdlib.h>
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 #include <sys/printk.h>
 #include <init.h>
 


### PR DESCRIPTION
Remove obsolete include of the shell_uart.h file. It is sufficient to include the shell.h file.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordisemi.no>