### PR TITLE
Bluetooth: host: Change PA sync callbacks to global callbacks

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -1026,6 +1026,8 @@ struct bt_le_per_adv_sync_cb {
 	void (*recv)(struct bt_le_per_adv_sync *sync,
 		     const struct bt_le_per_adv_sync_recv_info *info,
 		     struct net_buf_simple *buf);
+
+	sys_snode_t node;
 };
 
 /** Periodic advertising sync options */
@@ -1116,14 +1118,12 @@ uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync);
  * to periodic advertising reports from an advertiser. Scan shall either be
  * disabled or extended scan shall be enabled.
  *
- * @param[in] param     Periodic advertising sync parameters.
- * @param[in] cb        Periodic advertising callbacks.
- * @param[out] out_sync Periodic advertising sync object on.
+ * @param[in]  param     Periodic advertising sync parameters.
+ * @param[out] out_sync  Periodic advertising sync object on.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
-			      const struct bt_le_per_adv_sync_cb *cb,
 			      struct bt_le_per_adv_sync **out_sync);
 
 /**
@@ -1139,6 +1139,19 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
  * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync);
+
+/**
+ * @brief Register periodic advertising sync callbacks.
+ *
+ * Adds the callback structure to the list of callback structures for periodic
+ * adverising syncs.
+ *
+ * This callback will be called for all periodic advertising sync activity,
+ * such as synced, terminated and when data is received.
+ *
+ * @param cb Callback struct. Must point to memory that remains valid.
+ */
+void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb);
 
 enum {
 	/** Convenience value when no options are specified. */
@@ -1365,7 +1378,7 @@ int bt_le_scan_stop(void);
  * This callback will be called for all scanner activity, regardless of what
  * API was used to start the scanner.
  *
- * @param cb Callback struct. Must point to static memory.
+ * @param cb Callback struct. Must point to memory that remains valid.
  */
 void bt_le_scan_cb_register(struct bt_le_scan_cb *cb);
 

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -934,7 +934,7 @@ struct bt_conn_cb {
  *
  *  Register callbacks to monitor the state of connections.
  *
- *  @param cb Callback struct.
+ *  @param cb Callback struct. Must point to memory that remains valid.
  */
 void bt_conn_cb_register(struct bt_conn_cb *cb);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -101,7 +101,8 @@ static struct bt_le_ext_adv adv_pool[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 static struct bt_le_per_adv_sync *get_pending_per_adv_sync(void);
 static struct bt_le_per_adv_sync per_adv_sync_pool[CONFIG_BT_PER_ADV_SYNC_MAX];
-#endif /* defined(CONFIG_BT_PER_ADV) */
+static sys_slist_t pa_sync_cbs = SYS_SLIST_STATIC_INIT(&pa_sync_cbs);
+#endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 #if defined(CONFIG_BT_HCI_VS_EVT_USER)
@@ -4593,6 +4594,8 @@ static void le_per_adv_report(struct net_buf *buf)
 	struct bt_hci_evt_le_per_advertising_report *evt;
 	struct bt_le_per_adv_sync *per_adv_sync;
 	struct bt_le_per_adv_sync_recv_info info;
+	struct bt_le_per_adv_sync_cb *listener;
+	struct net_buf_simple_state state;
 
 	if (buf->len < sizeof(*evt)) {
 		BT_ERR("Unexpected end of buffer");
@@ -4614,8 +4617,15 @@ static void le_per_adv_report(struct net_buf *buf)
 	info.cte_type = evt->cte_type;
 	info.addr = &per_adv_sync->addr;
 
-	if (per_adv_sync->cb && per_adv_sync->cb->recv) {
-		per_adv_sync->cb->recv(per_adv_sync, &info, &buf->b);
+	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+		if (listener->recv) {
+			net_buf_simple_save(&buf->b, &state);
+
+			buf->len = evt->length;
+			listener->recv(per_adv_sync, &info, &buf->b);
+
+			net_buf_simple_restore(&buf->b, &state);
+		}
 	}
 }
 
@@ -4645,6 +4655,7 @@ static void le_per_adv_sync_established(struct net_buf *buf)
 		(struct bt_hci_evt_le_per_adv_sync_established *)buf->data;
 	struct bt_le_per_adv_sync_synced_info sync_info;
 	struct bt_le_per_adv_sync *pending_per_adv_sync;
+	struct bt_le_per_adv_sync_cb *listener;
 	int err;
 
 	pending_per_adv_sync = get_pending_per_adv_sync();
@@ -4677,10 +4688,14 @@ static void le_per_adv_sync_established(struct net_buf *buf)
 			 */
 			per_adv_sync_delete(pending_per_adv_sync);
 
-			if (pending_per_adv_sync->cb &&
-			    pending_per_adv_sync->cb->term) {
-				pending_per_adv_sync->cb->term(
-					pending_per_adv_sync, &term_info);
+
+			SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs,
+						     listener,
+						     node) {
+				if (listener->term) {
+					listener->term(pending_per_adv_sync,
+						       &term_info);
+				}
 			}
 		}
 		return;
@@ -4704,9 +4719,10 @@ static void le_per_adv_sync_established(struct net_buf *buf)
 	sync_info.addr = &pending_per_adv_sync->addr;
 	sync_info.sid = pending_per_adv_sync->sid;
 
-	if (pending_per_adv_sync->cb && pending_per_adv_sync->cb->synced) {
-		pending_per_adv_sync->cb->synced(pending_per_adv_sync,
-						 &sync_info);
+	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+		if (listener->synced) {
+			listener->synced(pending_per_adv_sync, &sync_info);
+		}
 	}
 }
 
@@ -4716,6 +4732,7 @@ static void le_per_adv_sync_lost(struct net_buf *buf)
 		(struct bt_hci_evt_le_per_adv_sync_lost *)buf->data;
 	struct bt_le_per_adv_sync_term_info term_info;
 	struct bt_le_per_adv_sync *per_adv_sync;
+	struct bt_le_per_adv_sync_cb *listener;
 
 	per_adv_sync = get_per_adv_sync(sys_le16_to_cpu(evt->handle));
 
@@ -4733,8 +4750,11 @@ static void le_per_adv_sync_lost(struct net_buf *buf)
 	 */
 	per_adv_sync_delete(per_adv_sync);
 
-	if (per_adv_sync->cb && per_adv_sync->cb->term) {
-		per_adv_sync->cb->term(per_adv_sync, &term_info);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+		if (listener->term) {
+			listener->term(per_adv_sync, &term_info);
+		}
 	}
 }
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
@@ -7317,7 +7337,6 @@ static struct bt_le_per_adv_sync *per_adv_sync_new(void)
 }
 
 int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
-			      const struct bt_le_per_adv_sync_cb *cb,
 			      struct bt_le_per_adv_sync **out_sync)
 {
 	struct bt_hci_cp_le_per_adv_create_sync *cp;
@@ -7407,7 +7426,6 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	*out_sync = per_adv_sync;
 	bt_addr_le_copy(&per_adv_sync->addr, &param->addr);
 	per_adv_sync->sid = param->sid;
-	per_adv_sync->cb = cb;
 
 	return 0;
 }
@@ -7469,6 +7487,11 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 
 	per_adv_sync_delete(per_adv_sync);
 	return err;
+}
+
+void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
+{
+	sys_slist_append(&pa_sync_cbs, &cb->node);
 }
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1498,8 +1498,9 @@ static int cmd_per_adv_sync_create(const struct shell *shell, size_t argc,
 
 	create_params.options = options;
 
-	err = bt_le_per_adv_sync_create(&create_params, &per_adv_sync_cb,
-					free_per_adv_sync);
+	bt_le_per_adv_sync_cb_register(&per_adv_sync_cb);
+
+	err = bt_le_per_adv_sync_create(&create_params, free_per_adv_sync);
 	if (err) {
 		shell_error(shell, "Per adv sync failed (%d)", err);
 	} else {


### PR DESCRIPTION
Changes the callbacks for periodic sync callbacks such that multiple
applications can register callbacks, similar to the connection and
scan callbacks.

This change will make it easier to support the PAST feature, as
PA syncs make be created by the controller which then notifies
the host, and thus the application (if callback registered).

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>