### PR TITLE
boards: arm: stm32: review joystick and wakeup pin polarity and pull up/down

### DIFF
--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -46,23 +46,23 @@
 		};
 		joy_sel: joystick_selection {
 			label = "joystick selection";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpiof 10 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpiof 9 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpiof 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpioe 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 	};
 

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -42,23 +42,23 @@
 		compatible = "gpio-keys";
 		joy_sel: joystick_selection {
 			label = "joystick selection";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpiog 1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiog 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpiog 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiog 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpiof 15 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiof 14 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiof 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 	};
 

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -40,27 +40,27 @@
 		};
 		joy_center: joystick_center {
 			label = "joystick center";
-			gpios = <&gpiok 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiok 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpiok 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiok 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpiok 6 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiok 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpiok 4 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiok 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiok 5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpiok 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 	};

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -35,7 +35,7 @@
 		compatible = "gpio-keys";
 		wake_up: button {
 			label = "Wakeup";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			status = "disabled";
 		};
 		joy_center: joystick_center {

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -38,23 +38,23 @@
 		compatible = "gpio-keys";
 		joy_center: joystick_center {
 			label = "joystick center";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpioa 1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		};
 	};
 


### PR DESCRIPTION
boards: arm: stm32: review joystick and wakeup pin polarity and pull up/down

Complementary to #28676, other STM32 boards need a review of joystick/ wakeup pin polarity as well as Pull up/down.
