### PR TITLE
boards: arty: document source for fpga bitstream partition size

### DIFF
--- a/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
+++ b/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
@@ -275,6 +275,12 @@
 
 					fpga_bitstream_partition: partition@0 {
 						label = "fpga_bitstream";
+						/* From Xilinx 7 Series FPGA User Guide (UG470)
+						 * Table 1-1: Bitstream Length
+						 *           Bits    Bytes (sector multiple)
+						 * A35T:  17,536,096     0x218000
+						 * A100T: 30,606,304     0x3a8000
+						 */
 						reg = <0x00000000 0x218000>;
 					};
 				};


### PR DESCRIPTION
At this time there's no clear need to support anything other than the A35T variant, but to simplify future extension show where the partition size came from and document the corresponding parameter for the A100T variant.