### PR TITLE
modem: uart: use ring_buf_{claim,finish} API and improve behavior with HW flow control

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -50,7 +50,6 @@ static struct gsm_modem {
 
 	struct modem_iface_uart_data gsm_data;
 	struct k_delayed_work gsm_configure_work;
-	char gsm_isr_buf[PPP_MRU];
 	char gsm_rx_rb_buf[PPP_MRU * 3];
 
 	uint8_t *ppp_recv_buf;
@@ -647,8 +646,6 @@ static int gsm_init(const struct device *device)
 #endif	/* CONFIG_MODEM_SIM_NUMBERS */
 #endif	/* CONFIG_MODEM_SHELL */
 
-	gsm->gsm_data.isr_buf = &gsm->gsm_isr_buf[0];
-	gsm->gsm_data.isr_buf_len = sizeof(gsm->gsm_isr_buf);
 	gsm->gsm_data.rx_rb_buf = &gsm->gsm_rx_rb_buf[0];
 	gsm->gsm_data.rx_rb_buf_len = sizeof(gsm->gsm_rx_rb_buf);
 

--- a/drivers/modem/modem_iface_uart.c
+++ b/drivers/modem/modem_iface_uart.c
@@ -53,6 +53,9 @@ static void modem_iface_uart_isr(const struct device *uart_dev,
 	struct modem_context *ctx;
 	struct modem_iface_uart_data *data;
 	int rx = 0, ret;
+	uint8_t *dst;
+	uint32_t partial_size = 0;
+	uint32_t total_size = 0;
 
 	ARG_UNUSED(user_data);
 
@@ -66,22 +69,30 @@ static void modem_iface_uart_isr(const struct device *uart_dev,
 	/* get all of the data off UART as fast as we can */
 	while (uart_irq_update(ctx->iface.dev) &&
 	       uart_irq_rx_ready(ctx->iface.dev)) {
-		rx = uart_fifo_read(ctx->iface.dev,
-				    data->isr_buf, data->isr_buf_len);
+		if (!partial_size) {
+			partial_size = ring_buf_put_claim(&data->rx_rb, &dst,
+							  UINT32_MAX);
+		}
+		if (!partial_size) {
+			LOG_ERR("Rx buffer doesn't have enough space");
+			modem_iface_uart_flush(&ctx->iface);
+			break;
+		}
+
+		rx = uart_fifo_read(ctx->iface.dev, dst, partial_size);
 		if (rx <= 0) {
 			continue;
 		}
 
-		ret = ring_buf_put(&data->rx_rb, data->isr_buf, rx);
-		if (ret != rx) {
-			LOG_ERR("Rx buffer doesn't have enough space. "
-				"Bytes pending: %d, written: %d",
-				rx, ret);
-			modem_iface_uart_flush(&ctx->iface);
-			k_sem_give(&data->rx_sem);
-			break;
-		}
+		dst += rx;
+		total_size += rx;
+		partial_size -= rx;
+	}
 
+	ret = ring_buf_put_finish(&data->rx_rb, total_size);
+	__ASSERT_NO_MSG(ret == 0);
+
+	if (total_size > 0) {
 		k_sem_give(&data->rx_sem);
 	}
 }

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -20,6 +20,9 @@ extern "C" {
 #endif
 
 struct modem_iface_uart_data {
+	/* HW flow control */
+	bool hw_flow_control;
+
 	/* ring buffer char buffer */
 	char *rx_rb_buf;
 	size_t rx_rb_buf_len;

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -20,10 +20,6 @@ extern "C" {
 #endif
 
 struct modem_iface_uart_data {
-	/* ISR char buffer */
-	char *isr_buf;
-	size_t isr_buf_len;
-
 	/* ring buffer char buffer */
 	char *rx_rb_buf;
 	size_t rx_rb_buf_len;

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -63,6 +63,7 @@ static struct modem_pin modem_pins[] = {
 };
 
 #define MDM_UART_DEV_NAME		DT_INST_BUS_LABEL(0)
+#define MDM_UART_NODE			DT_BUS(DT_DRV_INST(0))
 
 #define MDM_POWER_ENABLE		1
 #define MDM_POWER_DISABLE		0
@@ -1754,6 +1755,8 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* modem interface */
+	mdata.iface_data.hw_flow_control = DT_PROP(MDM_UART_NODE,
+						   hw_flow_control);
 	mdata.iface_data.rx_rb_buf = &mdata.iface_rb_buf[0];
 	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
 	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -131,7 +131,6 @@ struct modem_data {
 
 	/* modem interface */
 	struct modem_iface_uart_data iface_data;
-	uint8_t iface_isr_buf[MDM_RECV_BUF_SIZE];
 	uint8_t iface_rb_buf[MDM_MAX_DATA_LENGTH];
 
 	/* modem cmds */
@@ -1755,8 +1754,6 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* modem interface */
-	mdata.iface_data.isr_buf = &mdata.iface_isr_buf[0];
-	mdata.iface_data.isr_buf_len = sizeof(mdata.iface_isr_buf);
 	mdata.iface_data.rx_rb_buf = &mdata.iface_rb_buf[0];
 	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
 	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -842,6 +842,7 @@ static int esp_init(const struct device *dev)
 	}
 
 	/* modem interface */
+	data->iface_data.hw_flow_control = DT_PROP(ESP_BUS, hw_flow_control);
 	data->iface_data.rx_rb_buf = &data->iface_rb_buf[0];
 	data->iface_data.rx_rb_buf_len = sizeof(data->iface_rb_buf);
 	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data,

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -842,8 +842,6 @@ static int esp_init(const struct device *dev)
 	}
 
 	/* modem interface */
-	data->iface_data.isr_buf = &data->iface_isr_buf[0];
-	data->iface_data.isr_buf_len = sizeof(data->iface_isr_buf);
 	data->iface_data.rx_rb_buf = &data->iface_rb_buf[0];
 	data->iface_data.rx_rb_buf_len = sizeof(data->iface_rb_buf);
 	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data,

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -163,7 +163,6 @@ struct esp_data {
 
 	/* modem interface */
 	struct modem_iface_uart_data iface_data;
-	uint8_t iface_isr_buf[MDM_RECV_BUF_SIZE];
 	uint8_t iface_rb_buf[MDM_RING_BUF_SIZE];
 
 	/* modem cmds */


### PR DESCRIPTION
This API allows to drop use of preallocated isr_buf. Most importantly as
a result RAM usage is reduced for each driver utilizing modem_context
framework. Additionally there is less copying done in ISR context, as
data is direcly read from UART FIFO to ring_buf.

So far all received bytes over UART where blindly drained and pushed to
ring_buf. This approach is okay for UART devices without configured HW
flow control, as it basically decouples data processing from ISR handler
and gives more time before data overrun. However when HW flow control
is enabled, such behavior somehow suppresses UART flow control
advantage, because data can overrun when pushing to ring_buf.

Allow drivers utilizing modem_context framework to pass information
about whether HW flow control is enabled or not. If it is enabled, then
read data from UART FIFO to the point when RX ring_buf is totally filled
and follow such situation by disabling RX interrupt. Incoming data will
be paused on HW level, so there is lots of time for RX thread to process
ring_buf content. Reenable RX interrupts after all data in ring_buf is
processed, so that number of context switches is kept at minimum level.