### PR TITLE
drivers: wifi: esp: support reconfiguration of UART baudrate

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -66,8 +66,14 @@ extern "C" {
 #define _FLOW_CONTROL "0"
 #endif
 
+#if DT_INST_NODE_HAS_PROP(0, target_speed)
+#define _UART_BAUD	DT_INST_PROP(0, target_speed)
+#else
+#define _UART_BAUD	DT_PROP(ESP_BUS, current_speed)
+#endif
+
 #define _UART_CUR \
-	STRINGIFY(DT_PROP(ESP_BUS, current_speed))",8,1,0,"_FLOW_CONTROL
+	STRINGIFY(_UART_BAUD)",8,1,0,"_FLOW_CONTROL
 
 #define CONN_CMD_MAX_LEN (sizeof("AT+"_CWJAP"=\"\",\"\"") + \
 			  WIFI_SSID_MAX_LEN + WIFI_PSK_MAX_LEN)

--- a/dts/bindings/wifi/espressif,esp.yaml
+++ b/dts/bindings/wifi/espressif,esp.yaml
@@ -14,3 +14,10 @@ properties:
     wifi-reset-gpios:
       type: phandle-array
       required: false
+
+    target-speed:
+      type: int
+      required: false
+      description:
+        UART baudrate which will be requested using AT commands and to which
+        UART interface will be reconfigured during initialization phase.


### PR DESCRIPTION
Allow to reconfigure UART baudrate on ESP and on host MCU, so a
non-default baudrate can be used for communication. This option helps
for example to increase network bandwidth without touching ESP chip
firmware.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>