### PR TITLE
drivers: wifi: esp: rename wifi-reset-gpios to reset-gpios and support power-gpios

### DIFF
--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -86,7 +86,7 @@
 	nina_prog {
 		compatible = "espressif,esp";
 		label = "NINA_PROG";
-		wifi-reset-gpios = <&porta 8 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&porta 8 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -28,6 +28,9 @@ LOG_MODULE_REGISTER(wifi_esp);
 
 /* pin settings */
 enum modem_control_pins {
+#if DT_INST_NODE_HAS_PROP(0, power_gpios)
+	ESP_POWER,
+#endif
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	ESP_RESET,
 #endif
@@ -35,10 +38,15 @@ enum modem_control_pins {
 };
 
 static struct modem_pin modem_pins[] = {
+#if DT_INST_NODE_HAS_PROP(0, power_gpios)
+	MODEM_PIN(DT_INST_GPIO_LABEL(0, power_gpios),
+		  DT_INST_GPIO_PIN(0, power_gpios),
+		  DT_INST_GPIO_FLAGS(0, power_gpios) | GPIO_OUTPUT_INACTIVE),
+#endif
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	MODEM_PIN(DT_INST_GPIO_LABEL(0, reset_gpios),
 		  DT_INST_GPIO_PIN(0, reset_gpios),
-		  DT_INST_GPIO_FLAGS(0, reset_gpios) | GPIO_OUTPUT),
+		  DT_INST_GPIO_FLAGS(0, reset_gpios) | GPIO_OUTPUT_INACTIVE),
 #endif
 };
 
@@ -750,7 +758,11 @@ static void esp_reset(struct esp_data *dev)
 		net_if_down(dev->net_iface);
 	}
 
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+#if DT_INST_NODE_HAS_PROP(0, power_gpios)
+	modem_pin_write(&dev->mctx, ESP_POWER, 0);
+	k_sleep(K_MSEC(100));
+	modem_pin_write(&dev->mctx, ESP_POWER, 1);
+#elif DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	modem_pin_write(&dev->mctx, ESP_RESET, 1);
 	k_sleep(K_MSEC(100));
 	modem_pin_write(&dev->mctx, ESP_RESET, 0);

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -28,17 +28,17 @@ LOG_MODULE_REGISTER(wifi_esp);
 
 /* pin settings */
 enum modem_control_pins {
-#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
-	WIFI_RESET,
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	ESP_RESET,
 #endif
 	NUM_PINS,
 };
 
 static struct modem_pin modem_pins[] = {
-#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
-	MODEM_PIN(DT_INST_GPIO_LABEL(0, wifi_reset_gpios),
-		  DT_INST_GPIO_PIN(0, wifi_reset_gpios),
-		  DT_INST_GPIO_FLAGS(0, wifi_reset_gpios) | GPIO_OUTPUT),
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	MODEM_PIN(DT_INST_GPIO_LABEL(0, reset_gpios),
+		  DT_INST_GPIO_PIN(0, reset_gpios),
+		  DT_INST_GPIO_FLAGS(0, reset_gpios) | GPIO_OUTPUT),
 #endif
 };
 
@@ -750,10 +750,10 @@ static void esp_reset(struct esp_data *dev)
 		net_if_down(dev->net_iface);
 	}
 
-#if DT_INST_NODE_HAS_PROP(0, wifi_reset_gpios)
-	modem_pin_write(&dev->mctx, WIFI_RESET, 1);
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	modem_pin_write(&dev->mctx, ESP_RESET, 1);
 	k_sleep(K_MSEC(100));
-	modem_pin_write(&dev->mctx, WIFI_RESET, 0);
+	modem_pin_write(&dev->mctx, ESP_RESET, 0);
 #else
 	int retries = 3;
 

--- a/dts/bindings/wifi/espressif,esp.yaml
+++ b/dts/bindings/wifi/espressif,esp.yaml
@@ -11,6 +11,10 @@ properties:
     label:
       required: true
 
+    power-gpios:
+      type: phandle-array
+      required: false
+
     reset-gpios:
       type: phandle-array
       required: false

--- a/dts/bindings/wifi/espressif,esp.yaml
+++ b/dts/bindings/wifi/espressif,esp.yaml
@@ -11,6 +11,6 @@ properties:
     label:
       required: true
 
-    wifi-reset-gpios:
+    reset-gpios:
       type: phandle-array
       required: false


### PR DESCRIPTION
Most DT bindings use reset-gpios name when there is a pin to reset whole
chip. Rename wifi-reset-gpios to reset-gpios to be more consistent
between various drivers. Additionally this prevents confusion, as
somebody might think that this pin resets only WiFi, which is not true.

Add power-gpios device-tree binding property to power on module before
communicating with it. This pin is called CHIP_PU in case of ESP32{,-S2}
and CHIP_EN in case of ESP8266. Dedicated reset pin is available only on
the latter, however Espressif recommends (in ESP8266 Hardware Design
Guidelines) to use CHIP_EN instead. Follow those recommendations and use
power-gpios to reset chip if that is provided over device-tree.

Configure power-gpios and reset-gpios as inactive by default, so that
chip becomes ready after executing esp_reset() function, either if one
or both are provided over device-tree.