### PR TITLE
documents: update the pyocd required version

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -6,7 +6,7 @@
 pyserial
 
 # used to flash & debug various boards
-pyocd>=0.24.0
+pyocd>=0.28.0
 
 # used by sanitycheck for board/hardware map
 tabulate


### PR DESCRIPTION
pyocd 0.28 can support rt1xxx series board well

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>