### PR TITLE
arch: arc: add support of ARConnect inter-core debug unit

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -131,6 +131,17 @@ static int arc_smp_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (bcr.dbg) {
+	/* configure inter-core debug unit if available */
+		uint32_t core_mask = (1 << CONFIG_MP_NUM_CPUS) - 1;
+		z_arc_connect_debug_select_set(core_mask);
+		/* Debugger halt cores at conditions */
+		z_arc_connect_debug_mask_set(core_mask,	(ARC_CONNECT_CMD_DEBUG_MASK_SH
+			| ARC_CONNECT_CMD_DEBUG_MASK_BH | ARC_CONNECT_CMD_DEBUG_MASK_AH
+			| ARC_CONNECT_CMD_DEBUG_MASK_H));
+
+	}
+
 	if (bcr.gfrc) {
 		/* global free running count init */
 		z_arc_connect_gfrc_enable();

--- a/include/arch/arc/v2/arc_connect.h
+++ b/include/arch/arc/v2/arc_connect.h
@@ -64,6 +64,11 @@ extern "C" {
 #define ARC_CONNECT_CMD_DEBUG_READ_CMD			0x39
 #define ARC_CONNECT_CMD_DEBUG_READ_CORE			0x3a
 
+#define ARC_CONNECT_CMD_DEBUG_MASK_SH			0x08    /* if a self-halt occurs, a global halt is triggered */
+#define ARC_CONNECT_CMD_DEBUG_MASK_BH			0x04    /* if a breakpoint caused halt occurs, a global halt is triggered */
+#define ARC_CONNECT_CMD_DEBUG_MASK_AH			0x02    /* if an actionpoint caused halt occurs, a global halt is triggered */
+#define ARC_CONNECT_CMD_DEBUG_MASK_H			0x01    /* whenever the core is halted, a global halt is triggered */
+
 #define ARC_CONNECT_CMD_GFRC_CLEAR			0x41
 #define ARC_CONNECT_CMD_GFRC_READ_LO			0x42
 #define ARC_CONNECT_CMD_GFRC_READ_HI			0x43


### PR DESCRIPTION
The Inter-core Debug Unit provides additional debug assist features in multi-core scenarios. 
This PR allows ARConnect to conditionally halt cores during debugging.
The conditions are: whenever any core hits actionpoint, breakpoint, or being halted by debugger, or self-halt itself, the debuger shall halt other cores. 

Fixes #23212 