### PR TITLE
modules: nordic: Fix race condition in 802.15.4 Timer Coordinator

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: d8a6ea9695ddf792bb18bb6035c13b1daac5d79c
+      revision: pull/57/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This commit fixes the race condition in the 802.15.4 Timer Coordinator
which can result in writing to the peripherals registers beyond the
timeslot.

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>