### PR TITLE
Bluetooth: controller: Add connectable extended advertising

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -162,12 +162,12 @@ struct lll_event {
 enum node_rx_type {
 	/* Unused */
 	NODE_RX_TYPE_NONE = 0x00,
+	/* Signals release of node */
+	NODE_RX_TYPE_RELEASE,
 	/* Signals completion of RX event */
 	NODE_RX_TYPE_EVENT_DONE,
 	/* Signals arrival of RX Data Channel payload */
 	NODE_RX_TYPE_DC_PDU,
-	/* Signals release of RX Data Channel payload */
-	NODE_RX_TYPE_DC_PDU_RELEASE,
 	/* Advertisement report from scanning */
 	NODE_RX_TYPE_REPORT,
 	NODE_RX_TYPE_EXT_1M_REPORT,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -114,6 +114,15 @@ int lll_adv_init(void)
 {
 	int err;
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if (BT_CTLR_ADV_AUX_SET > 0)
+	err = lll_adv_aux_init();
+	if (err) {
+		return err;
+	}
+#endif /* BT_CTLR_ADV_AUX_SET > 0 */
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
 	err = init_reset();
 	if (err) {
 		return err;
@@ -125,6 +134,15 @@ int lll_adv_init(void)
 int lll_adv_reset(void)
 {
 	int err;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if (BT_CTLR_ADV_AUX_SET > 0)
+	err = lll_adv_aux_reset();
+	if (err) {
+		return err;
+	}
+#endif /* BT_CTLR_ADV_AUX_SET > 0 */
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	err = init_reset();
 	if (err) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -65,9 +65,9 @@ static bool isr_rx_sr_adva_check(uint8_t tx_addr, uint8_t *addr,
 
 
 static inline bool isr_rx_ci_tgta_check(struct lll_adv *lll,
-					struct pdu_adv *adv, struct pdu_adv *ci,
-					uint8_t rl_idx);
-static inline bool isr_rx_ci_adva_check(struct pdu_adv *adv,
+					uint8_t rx_addr, uint8_t *tgt_addr,
+					struct pdu_adv *ci, uint8_t rl_idx);
+static inline bool isr_rx_ci_adva_check(uint8_t tx_addr, uint8_t *addr,
 					struct pdu_adv *ci);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -354,12 +354,13 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 }
 #endif /* CONFIG_BT_CTLR_SCAN_REQ_NOTIFY */
 
-bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *adv,
-			       struct pdu_adv *ci, uint8_t devmatch_ok,
-			       uint8_t *rl_idx)
+bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *ci,
+			       uint8_t tx_addr, uint8_t *addr,
+			       uint8_t rx_addr, uint8_t *tgt_addr,
+			       uint8_t devmatch_ok, uint8_t *rl_idx)
 {
 	/* LL 4.3.2: filter policy shall be ignored for directed adv */
-	if (adv->type == PDU_ADV_TYPE_DIRECT_IND) {
+	if (tgt_addr) {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		return ull_filter_lll_rl_addr_allowed(ci->tx_addr,
 						      ci->connect_ind.init_addr,
@@ -367,8 +368,9 @@ bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *adv,
 #else
 		return (1) &&
 #endif
-		       isr_rx_ci_adva_check(adv, ci) &&
-		       isr_rx_ci_tgta_check(lll, adv, ci, *rl_idx);
+		       isr_rx_ci_adva_check(tx_addr, addr, ci) &&
+		       isr_rx_ci_tgta_check(lll, rx_addr, tgt_addr, ci,
+					    *rl_idx);
 	}
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -378,11 +380,11 @@ bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *adv,
 						rl_idx)) ||
 		(((lll->filter_policy & 0x02) != 0) &&
 		 (devmatch_ok || ull_filter_lll_irk_whitelisted(*rl_idx)))) &&
-	       isr_rx_ci_adva_check(adv, ci);
+	       isr_rx_ci_adva_check(tx_addr, addr, ci);
 #else
 	return (((lll->filter_policy & 0x02) == 0) ||
 		(devmatch_ok)) &&
-	       isr_rx_ci_adva_check(adv, ci);
+	       isr_rx_ci_adva_check(tx_addr, addr, ci);
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 }
 
@@ -931,6 +933,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 	struct pdu_adv *pdu_rx;
 	uint8_t tx_addr;
 	uint8_t *addr;
+	uint8_t rx_addr;
+	uint8_t *tgt_addr;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* An IRK match implies address resolution enabled */
@@ -946,9 +950,16 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 	addr = pdu_adv->adv_ind.addr;
 	tx_addr = pdu_adv->tx_addr;
 
+	if (pdu_adv->type == PDU_ADV_TYPE_DIRECT_IND) {
+		tgt_addr = pdu_adv->direct_ind.tgt_addr;
+	} else {
+		tgt_addr = NULL;
+	}
+	rx_addr = pdu_adv->rx_addr;
+
 	if ((pdu_rx->type == PDU_ADV_TYPE_SCAN_REQ) &&
 	    (pdu_rx->len == sizeof(struct pdu_adv_scan_req)) &&
-	    (pdu_adv->type != PDU_ADV_TYPE_DIRECT_IND) &&
+	    (tgt_addr == NULL) &&
 	    lll_adv_scan_req_check(lll, pdu_rx, tx_addr, addr, devmatch_ok,
 				    &rl_idx)) {
 		radio_isr_set(isr_done, lll);
@@ -996,8 +1007,9 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 #if defined(CONFIG_BT_PERIPHERAL)
 	} else if ((pdu_rx->type == PDU_ADV_TYPE_CONNECT_IND) &&
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
-		   lll_adv_connect_ind_check(lll, pdu_adv, pdu_rx, devmatch_ok,
-					     &rl_idx) &&
+		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
+					     rx_addr, tgt_addr,
+					     devmatch_ok, &rl_idx) &&
 		   lll->conn) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
@@ -1073,26 +1085,21 @@ static bool isr_rx_sr_adva_check(uint8_t tx_addr, uint8_t *addr,
 }
 
 static inline bool isr_rx_ci_tgta_check(struct lll_adv *lll,
-					struct pdu_adv *adv, struct pdu_adv *ci,
-					uint8_t rl_idx)
+					uint8_t rx_addr, uint8_t *tgt_addr,
+					struct pdu_adv *ci, uint8_t rl_idx)
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	if (rl_idx != FILTER_IDX_NONE && lll->rl_idx != FILTER_IDX_NONE) {
 		return rl_idx == lll->rl_idx;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-	return (adv->rx_addr == ci->tx_addr) &&
-	       !memcmp(adv->direct_ind.tgt_addr, ci->connect_ind.init_addr,
-		       BDADDR_SIZE);
+	return (rx_addr == ci->tx_addr) &&
+	       !memcmp(tgt_addr, ci->connect_ind.init_addr, BDADDR_SIZE);
 }
 
-static inline bool isr_rx_ci_adva_check(struct pdu_adv *adv,
+static inline bool isr_rx_ci_adva_check(uint8_t tx_addr, uint8_t *addr,
 					struct pdu_adv *ci)
 {
-	return (adv->tx_addr == ci->rx_addr) &&
-		(((adv->type == PDU_ADV_TYPE_DIRECT_IND) &&
-		 !memcmp(adv->direct_ind.adv_addr, ci->connect_ind.adv_addr,
-			 BDADDR_SIZE)) ||
-		 (!memcmp(adv->adv_ind.addr, ci->connect_ind.adv_addr,
-			  BDADDR_SIZE)));
+	return (tx_addr == ci->rx_addr) &&
+		!memcmp(addr, ci->connect_ind.adv_addr, BDADDR_SIZE);
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -39,6 +39,11 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+static uint8_t lll_adv_connect_rsp_pdu[PDU_AC_LL_HEADER_SIZE +
+				       offsetof(struct pdu_adv_com_ext_adv,
+						ext_hdr_adv_data) +
+				       ADVA_SIZE + TARGETA_SIZE];
+
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static void isr_tx(void *param);
@@ -47,10 +52,83 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready);
+static void isr_tx_connect_rsp(void *param);
+
+static struct pdu_adv *init_connect_rsp_pdu(void)
+{
+	struct pdu_adv_com_ext_adv *com_hdr;
+	struct pdu_adv_ext_hdr *hdr;
+	struct pdu_adv *pdu;
+	uint8_t ext_hdr_len;
+	uint8_t *dptr;
+
+	pdu = (void *)lll_adv_connect_rsp_pdu;
+	pdu->type = PDU_ADV_TYPE_AUX_CONNECT_RSP;
+	pdu->rfu = 0;
+	pdu->chan_sel = 0;
+	pdu->tx_addr = 0;
+	pdu->rx_addr = 0;
+	pdu->len = 0;
+
+	com_hdr = &pdu->adv_ext_ind;
+	hdr = &com_hdr->ext_hdr;
+	dptr = (void *)hdr;
+
+	/* Flags */
+	*dptr = 0;
+	hdr->adv_addr = 1;
+	hdr->tgt_addr = 1;
+	dptr++;
+
+	/* Note: AdvA and InitA are updated before transmitting PDU */
+
+	/* AdvA */
+	dptr += BDADDR_SIZE;
+	/* InitA */
+	dptr += BDADDR_SIZE;
+
+	ext_hdr_len = dptr - (uint8_t *)&com_hdr->ext_hdr;
+
+	/* Finish Common ExtAdv Payload header */
+	com_hdr->adv_mode = 0;
+	com_hdr->ext_hdr_len = ext_hdr_len;
+
+	/* Finish PDU */
+	pdu->len = dptr - &pdu->payload[0];
+
+	return pdu;
+}
+
+static struct pdu_adv *update_connect_rsp_pdu(struct pdu_adv *pdu_ci)
+{
+	struct pdu_adv_com_ext_adv *cr_com_hdr;
+	struct pdu_adv_ext_hdr *cr_hdr;
+	struct pdu_adv *pdu_cr;
+	uint8_t *cr_dptr;
+
+	pdu_cr = (void *)lll_adv_connect_rsp_pdu;
+	pdu_cr->tx_addr = pdu_ci->rx_addr;
+	pdu_cr->rx_addr = pdu_ci->tx_addr;
+
+	cr_com_hdr = &pdu_cr->adv_ext_ind;
+	cr_hdr = &cr_com_hdr->ext_hdr;
+	/* Skip flags */
+	cr_dptr = cr_hdr->data;
+
+	/* AdvA */
+	memcpy(cr_dptr, &pdu_ci->connect_ind.adv_addr, BDADDR_SIZE);
+	cr_dptr += BDADDR_SIZE;
+	/* InitA */
+	memcpy(cr_dptr, &pdu_ci->connect_ind.init_addr, BDADDR_SIZE);
+
+	return pdu_cr;
+}
 
 int lll_adv_aux_init(void)
 {
 	int err;
+
+	init_connect_rsp_pdu();
 
 	err = init_reset();
 	if (err) {
@@ -399,11 +477,15 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready)
 {
+	struct pdu_adv_ext_hdr *hdr;
 	struct pdu_adv *pdu_adv;
 	struct pdu_adv *pdu_aux;
 	struct pdu_adv *pdu_rx;
+	struct pdu_adv *pdu_tx;
 	struct lll_adv *lll;
+	uint8_t *tgt_addr;
 	uint8_t tx_addr;
+	uint8_t rx_addr;
 	uint8_t *addr;
 	uint8_t upd;
 
@@ -421,8 +503,17 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 	pdu_adv = lll_adv_data_curr_get(lll);
 	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
 
+	hdr = &pdu_aux->adv_ext_ind.ext_hdr;
+
 	addr = &pdu_aux->adv_ext_ind.ext_hdr.data[ADVA_OFFSET];
 	tx_addr = pdu_aux->tx_addr;
+
+	if (hdr->tgt_addr) {
+		tgt_addr = &pdu_aux->adv_ext_ind.ext_hdr.data[TGTA_OFFSET];
+	} else {
+		tgt_addr = NULL;
+	}
+	rx_addr = pdu_aux->rx_addr;
 
 	if ((pdu_rx->type == PDU_ADV_TYPE_AUX_SCAN_REQ) &&
 	    (pdu_rx->len == sizeof(struct pdu_adv_scan_req)) &&
@@ -468,9 +559,106 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 		return 0;
+	} else if ((pdu_rx->type == PDU_ADV_TYPE_AUX_CONNECT_REQ) &&
+		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
+		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
+					     rx_addr, tgt_addr,
+					     devmatch_ok, &rl_idx)) {
+		struct node_rx_ftr *ftr;
+		struct node_rx_pdu *rx;
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
+			rx = ull_pdu_rx_alloc_peek(4);
+		} else {
+			rx = ull_pdu_rx_alloc_peek(3);
+		}
+
+		if (!rx) {
+			return -ENOBUFS;
+		}
+
+		/* rx is effectively allocated later, after critical isr steps
+		 * are done */
+		radio_isr_set(isr_tx_connect_rsp, rx);
+		radio_switch_complete_and_disable();
+		pdu_tx = update_connect_rsp_pdu(pdu_rx);
+		radio_pkt_tx_set(pdu_tx);
+
+		/* assert if radio packet ptr is not set and radio started tx */
+		LL_ASSERT(!radio_is_ready());
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			lll_prof_cputime_capture();
+		}
+
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			/* PA/LNA enable is overwriting packet end used in ISR
+			 * profiling, hence back it up for later use.
+			 */
+			lll_prof_radio_end_backup();
+		}
+
+		radio_gpio_pa_setup();
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
+					 radio_rx_chain_delay_get(lll->phy_s,
+								  0) -
+					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
+
+		/* Note: this is the same as previous result from alloc_peek */
+		rx = ull_pdu_rx_alloc();
+
+		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
+		rx->hdr.handle = 0xffff;
+
+		memcpy(rx->pdu, pdu_rx, (offsetof(struct pdu_adv, connect_ind) +
+					 sizeof(struct pdu_adv_connect_ind)));
+		ftr = &(rx->hdr.rx_ftr);
+		ftr->param = lll;
+		ftr->ticks_anchor = radio_tmr_start_get();
+		ftr->radio_end_us = radio_tmr_end_get() -
+				    radio_tx_chain_delay_get(lll->phy_s, 0);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
+			ftr->extra = ull_pdu_rx_alloc();
+		}
+
+		return 0;
 	}
 
-	/* TODO: add handling for AUX_CONNECT_REQ */
-
 	return -EINVAL;
+}
+
+static void isr_tx_connect_rsp(void *param)
+{
+	struct node_rx_ftr *ftr;
+	struct node_rx_pdu *rx;
+	struct lll_adv *lll;
+	int ret;
+
+	rx = param;
+	ftr = &(rx->hdr.rx_ftr);
+	lll = ftr->param;
+
+	if (!radio_is_done()) {
+		/* TODO: release node_rx somehow */
+		return;
+	}
+
+	/* Clear radio status and events */
+	lll_isr_status_reset();
+	lll_isr_cleanup(lll);
+
+	/* Stop further LLL radio events */
+	ret = lll_stop(lll);
+	LL_ASSERT(!ret);
+
+	ull_rx_put(rx->hdr.link, rx);
+	ull_rx_sched();
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -64,3 +64,7 @@ bool lll_adv_scan_req_check(struct lll_adv *lll, struct pdu_adv *sr,
 int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 			    uint8_t rl_idx, uint8_t rssi_ready);
 #endif
+
+bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *adv,
+			       struct pdu_adv *ci, uint8_t devmatch_ok,
+			       uint8_t *rl_idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -65,6 +65,7 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 			    uint8_t rl_idx, uint8_t rssi_ready);
 #endif
 
-bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *adv,
-			       struct pdu_adv *ci, uint8_t devmatch_ok,
-			       uint8_t *rl_idx);
+bool lll_adv_connect_ind_check(struct lll_adv *lll, struct pdu_adv *ci,
+			       uint8_t tx_addr, uint8_t *addr,
+			       uint8_t rx_addr, uint8_t *tgt_addr,
+			       uint8_t devmatch_ok, uint8_t *rl_idx);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -92,6 +92,11 @@
 #define OFFS_UNIT_30_US         30
 #define OFFS_UNIT_300_US        300
 
+/* transmitWindowDelay times (us) */
+#define WIN_DELAY_LEGACY     1250
+#define WIN_DELAY_UNCODED    2500
+#define WIN_DELAY_CODED      3750
+
 /*
  * Macros to return correct Data Channel PDU time
  * Note: formula is valid for 1M, 2M and Coded S8

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -785,6 +785,15 @@ void ll_rx_dequeue(void)
 				}
 			}
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+			if (lll->aux) {
+				struct ll_adv_aux_set *aux;
+
+				aux = (void *)HDR_LLL2EVT(lll->aux);
+				aux->is_started = 0U;
+			}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
 			adv->is_enabled = 0U;
 #else /* !CONFIG_BT_PERIPHERAL */
 			ARG_UNUSED(cc);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -621,7 +621,7 @@ ll_rx_get_again:
 			/* Do not send up buffers to Host thread that are
 			 * marked for release
 			 */
-			if (rx->type == NODE_RX_TYPE_DC_PDU_RELEASE) {
+			if (rx->type == NODE_RX_TYPE_RELEASE) {
 				(void)memq_dequeue(memq_ll_rx.tail,
 						   &memq_ll_rx.head, NULL);
 				mem_release(link, &mem_link_rx.free);
@@ -1990,6 +1990,8 @@ static inline int rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx)
 #if defined(CONFIG_BT_CTLR_SCAN_INDICATION)
 	case NODE_RX_TYPE_SCAN_INDICATION:
 #endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
+
+	case NODE_RX_TYPE_RELEASE:
 	{
 		memq_dequeue(memq_ull_rx.tail, &memq_ull_rx.head, NULL);
 		ll_rx_put(link, rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -752,7 +752,14 @@ uint8_t ll_adv_enable(uint8_t enable)
 #if defined(CONFIG_BT_PERIPHERAL)
 	/* prepare connectable advertising */
 	if ((pdu_adv->type == PDU_ADV_TYPE_ADV_IND) ||
-	    (pdu_adv->type == PDU_ADV_TYPE_DIRECT_IND)) {
+	    (pdu_adv->type == PDU_ADV_TYPE_DIRECT_IND) ||
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	    ((pdu_adv->type == PDU_ADV_TYPE_EXT_IND) &&
+	     (pdu_adv->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_CONN))
+#else
+	    0
+#endif
+	     ) {
 		struct node_rx_pdu *node_rx;
 		struct ll_conn *conn;
 		struct lll_conn *conn_lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -806,19 +806,32 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 
 #if defined(CONFIG_BT_CTLR_PHY)
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN,
+					       lll->phy_s);
+		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN,
+					       lll->phy_s);
+#else
 		/* Use the default 1M packet max time. Value of 0 is
 		 * equivalent to using BIT(0).
 		 */
 		conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_PHY)
-		conn_lll->phy_tx = BIT(0);
 		conn_lll->phy_flags = 0;
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		conn_lll->phy_tx = lll->phy_s;
+		conn_lll->phy_tx_time = lll->phy_s;
+		conn_lll->phy_rx = lll->phy_s;
+#else
+		conn_lll->phy_tx = BIT(0);
 		conn_lll->phy_tx_time = BIT(0);
 		conn_lll->phy_rx = BIT(0);
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -830,15 +830,18 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 		conn_lll->phy_flags = 0;
+		if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		conn_lll->phy_tx = lll->phy_s;
-		conn_lll->phy_tx_time = lll->phy_s;
-		conn_lll->phy_rx = lll->phy_s;
-#else
-		conn_lll->phy_tx = BIT(0);
-		conn_lll->phy_tx_time = BIT(0);
-		conn_lll->phy_rx = BIT(0);
+		} else if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
+			conn_lll->phy_tx = lll->phy_s;
+			conn_lll->phy_tx_time = lll->phy_s;
+			conn_lll->phy_rx = lll->phy_s;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+		} else {
+			conn_lll->phy_tx = BIT(0);
+			conn_lll->phy_tx_time = BIT(0);
+			conn_lll->phy_rx = BIT(0);
+		}
 #endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -43,7 +43,6 @@ static int init_reset(void);
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 static inline struct ll_adv_aux_set *aux_acquire(void);
 static inline void aux_release(struct ll_adv_aux_set *aux);
-static inline uint8_t aux_handle_get(struct ll_adv_aux_set *aux);
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 static inline void sync_info_fill(struct lll_adv_sync *lll_sync,
 				  uint8_t **dptr);
@@ -807,7 +806,7 @@ void ull_adv_aux_ptr_fill(uint8_t **dptr, uint8_t phy_s)
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 uint8_t ull_adv_aux_lll_handle_get(struct lll_adv_aux *lll)
 {
-	return aux_handle_get((void *)lll->hdr.parent);
+	return ull_adv_aux_handle_get((void *)lll->hdr.parent);
 }
 
 uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux)
@@ -844,8 +843,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 	uint32_t ret;
 
 	ull_hdr_init(&aux->ull);
-
-	aux_handle = aux_handle_get(aux);
+	aux_handle = ull_adv_aux_handle_get(aux);
 
 	ret_cb = TICKER_STATUS_BUSY;
 	ret = ticker_start(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
@@ -867,7 +865,7 @@ uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux)
 	uint8_t aux_handle;
 	int err;
 
-	aux_handle = aux_handle_get(aux);
+	aux_handle = ull_adv_aux_handle_get(aux);
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_ADV_AUX_BASE + aux_handle,
 					aux, &aux->lll);
@@ -984,7 +982,7 @@ static inline void aux_release(struct ll_adv_aux_set *aux)
 	mem_release(aux, &adv_aux_free);
 }
 
-static inline uint8_t aux_handle_get(struct ll_adv_aux_set *aux)
+inline uint8_t ull_adv_aux_handle_get(struct ll_adv_aux_set *aux)
 {
 	return mem_index_get(aux, ll_adv_aux_pool,
 			     sizeof(struct ll_adv_aux_set));
@@ -1029,7 +1027,7 @@ static void mfy_aux_offset_get(void *param)
 	uint8_t id;
 
 	aux = (void *)HDR_LLL2EVT(adv->lll.aux);
-	ticker_id = TICKER_ID_ADV_AUX_BASE + aux_handle_get(aux);
+	ticker_id = TICKER_ID_ADV_AUX_BASE + ull_adv_aux_handle_get(aux);
 
 	id = TICKER_NULL;
 	ticks_to_expire = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -57,6 +57,9 @@ void ull_adv_done(struct node_rx_event_done *done);
 int ull_adv_aux_init(void);
 int ull_adv_aux_reset(void);
 
+/* Return the aux set handle given the aux set instance */
+uint8_t ull_adv_aux_handle_get(struct ll_adv_aux_set *aux);
+
 /* Helper to read back random address */
 uint8_t const *ll_adv_aux_random_addr_get(struct ll_adv_set const *const adv,
 				       uint8_t *const addr);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -772,7 +772,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 	conn = ll_connected_get((*rx)->hdr.handle);
 	if (!conn) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return 0;
 	}
@@ -796,7 +796,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 				BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL;
 
 			/* Mark for buffer for release */
-			(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 		}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 		break;
@@ -813,7 +813,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 		/* Invalid LL id, drop it. */
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 	}
@@ -1721,7 +1721,7 @@ static void conn_cleanup(struct ll_conn *conn, uint8_t reason)
 		rx = hdr->link->mem;
 
 		/* Mark for buffer for release */
-		hdr->type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		hdr->type = NODE_RX_TYPE_RELEASE;
 
 		/* enqueue rx node towards Thread */
 		ll_rx_put(hdr->link, hdr);
@@ -2298,7 +2298,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 			cu->timeout = conn->llcp_cu.timeout;
 		} else {
 			/* Mark for buffer for release */
-			rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
 		}
 
 		/* enqueue rx node towards Thread */
@@ -3683,7 +3683,7 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 		if (!conn->llcp.phy_upd_ind.cmd && (lll->phy_tx == old_tx) &&
 		    (lll->phy_rx == old_rx)) {
 			/* Mark for buffer for release */
-			rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 			/* enqueue rx node towards Thread */
 			ll_rx_put(rx->hdr.link, rx);
@@ -3695,7 +3695,7 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 				conn->llcp_rx = rx->hdr.link->mem;
 
 				/* Mark for buffer for release */
-				rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 				/* enqueue rx node towards Thread */
 				ll_rx_put(rx->hdr.link, rx);
@@ -3729,7 +3729,7 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 		    (eff_rx_time <= lll->max_rx_time) &&
 		    (lll->max_rx_time <= max_rx_time)) {
 			/* Mark buffer for release */
-			rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 			/* enqueue rx node towards Thread */
 			ll_rx_put(rx->hdr.link, rx);
@@ -3775,7 +3775,7 @@ static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 	instant = sys_le16_to_cpu(pdu->llctrl.conn_update_ind.instant);
 	if (((instant - conn->lll.event_counter) & 0xFFFF) > 0x7FFF) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return BT_HCI_ERR_INSTANT_PASSED;
 	}
@@ -3783,7 +3783,7 @@ static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 	/* different transaction collision */
 	if (((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return BT_HCI_ERR_DIFF_TRANS_COLLISION;
 	}
@@ -3857,7 +3857,7 @@ static uint8_t chan_map_upd_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 
 chan_map_upd_recv_exit:
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return err;
 }
@@ -3869,7 +3869,7 @@ static void terminate_ind_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 	conn->llcp_terminate.reason_peer = pdu->llctrl.terminate_ind.error_code;
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 }
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
@@ -4035,7 +4035,7 @@ static int unknown_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	ctrl_tx_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4112,7 +4112,7 @@ static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	ctrl_tx_sec_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4189,7 +4189,7 @@ static int pause_enc_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 
 pause_enc_rsp_send_exit:
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4224,7 +4224,7 @@ static int version_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 		ctrl_tx_sec_enqueue(conn, tx);
 
 		/* Mark for buffer for release */
-		rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 	} else if (!conn->llcp_version.rx) {
 		/* procedure request acked */
 		conn->llcp_version.ack = conn->llcp_version.req;
@@ -4235,7 +4235,7 @@ static int version_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 		/* Tx-ed and Rx-ed before, ignore this invalid Rx. */
 
 		/* Mark for buffer for release */
-		rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return 0;
 	}
@@ -4274,7 +4274,7 @@ static int reject_ext_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	ctrl_tx_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4512,7 +4512,7 @@ static inline void reject_ind_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 
 	if (err) {
 		/* Mark for buffer for release */
-		rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 	}
 }
 
@@ -4565,7 +4565,7 @@ static inline void reject_ext_ind_recv(struct ll_conn *conn,
 
 	if (err) {
 		/* Mark for buffer for release */
-		rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 	}
 }
 
@@ -4760,7 +4760,7 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 #endif /* CONFIG_BT_CTLR_PHY */
 			    (1)) {
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 				goto send_length_resp;
 			}
@@ -4868,7 +4868,7 @@ static int ping_resp_send(struct ll_conn *conn, struct node_rx_pdu *rx)
 	ctrl_tx_sec_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4924,7 +4924,7 @@ static int phy_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	ctrl_tx_enqueue(conn, tx);
 
 	/* Mark for buffer for release */
-	rx->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+	rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 	return 0;
 }
@@ -4944,7 +4944,7 @@ static inline uint8_t phy_upd_ind_recv(struct ll_conn *conn, memq_link_t *link,
 		if ((conn->llcp_phy.ack == conn->llcp_phy.req) ||
 		    (conn->llcp_phy.state != LLCP_PHY_STATE_RSP_WAIT)) {
 			/* Mark for buffer for release */
-			(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 			return 0;
 		}
@@ -4960,7 +4960,7 @@ static inline uint8_t phy_upd_ind_recv(struct ll_conn *conn, memq_link_t *link,
 		/* Ignore event generation if not local cmd initiated */
 		if (!conn->llcp_phy.cmd) {
 			/* Mark for buffer for release */
-			(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 			return 0;
 		}
@@ -4980,7 +4980,7 @@ static inline uint8_t phy_upd_ind_recv(struct ll_conn *conn, memq_link_t *link,
 	instant = sys_le16_to_cpu(ind->instant);
 	if (((instant - conn->lll.event_counter) & 0xffff) > 0x7fff) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return BT_HCI_ERR_INSTANT_PASSED;
 	}
@@ -4988,7 +4988,7 @@ static inline uint8_t phy_upd_ind_recv(struct ll_conn *conn, memq_link_t *link,
 	/* different transaction collision */
 	if (((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return BT_HCI_ERR_DIFF_TRANS_COLLISION;
 	}
@@ -5328,7 +5328,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL;
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return 0;
 	}
@@ -5413,7 +5413,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		conn->llcp.encryption.state = LLCP_ENC_STATE_INIT;
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 #endif /* CONFIG_BT_CTLR_FAST_ENC */
 
 		/* Enc Setup state machine active */
@@ -5452,7 +5452,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		conn->llcp_enc.pause_rx = 1U;
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 
@@ -5468,7 +5468,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		conn->llcp.encryption.state = LLCP_ENC_STATE_INPROG;
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 
@@ -5732,7 +5732,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 							LLCP_CPR_STATE_APP_REQ;
 
 						/* Mark for buffer for release */
-						(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+						(*rx)->hdr.type =
+							NODE_RX_TYPE_RELEASE;
 					} else
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 					{
@@ -5747,7 +5748,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 					/* Mark for buffer for release */
 					(*rx)->hdr.type =
-						NODE_RX_TYPE_DC_PDU_RELEASE;
+						NODE_RX_TYPE_RELEASE;
 				}
 
 				conn->llcp_conn_param.ack--;
@@ -5834,7 +5835,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 					LLCP_CPR_STATE_RSP;
 
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 			}
 
 			conn->llcp_conn_param.ack--;
@@ -5917,7 +5918,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
@@ -5949,7 +5950,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		conn->procedure_expire = 0U;
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
@@ -5995,7 +5996,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn->llcp_cu.ack--;
 
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 				break;
 			}
@@ -6011,7 +6012,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			/* skip event generation if not cmd initiated */
 			if (!conn->llcp_conn_param.cmd) {
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 				break;
 			}
@@ -6072,7 +6073,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				p->rx = lll->phy_rx;
 			} else {
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 			}
 #endif /* CONFIG_BT_CTLR_PHY */
 
@@ -6086,7 +6087,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				 */
 
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 				break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
@@ -6194,7 +6195,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn->llcp_phy.pause_tx = 1U;
 
 				/* Mark for buffer for release */
-				(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 			}
 		} else {
 			nack = phy_rsp_send(conn, *rx, pdu_rx);
@@ -6231,7 +6232,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 
@@ -6288,7 +6289,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -67,6 +67,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	uint32_t ticker_status;
 	uint8_t peer_addr_type;
 	uint16_t win_offset;
+	uint16_t win_delay_us;
 	uint16_t timeout;
 	uint16_t interval;
 	uint8_t chan_sel;
@@ -98,6 +99,19 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 
 	win_offset = sys_le16_to_cpu(pdu_adv->connect_ind.win_offset);
 	conn_interval_us = interval * 1250U;
+
+	if (0) {
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	} else if (adv->lll.aux) {
+		if (adv->lll.phy_s & BIT(2)) {
+			win_delay_us = WIN_DELAY_CODED;
+		} else {
+			win_delay_us = WIN_DELAY_UNCODED;
+		}
+#endif
+	} else {
+		win_delay_us = WIN_DELAY_LEGACY;
+	}
 
 	/* calculate the window widening */
 	conn->slave.sca = pdu_adv->connect_ind.sca;
@@ -275,7 +289,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_interval_us -= lll->slave.window_widening_periodic_us;
 
 	conn_offset_us = ftr->radio_end_us;
-	conn_offset_us += ((uint64_t)win_offset + 1) * 1250U;
+	conn_offset_us += win_offset * 1250U;
+	conn_offset_us += win_delay_us;
 	conn_offset_us -= EVENT_OVERHEAD_START_US;
 	conn_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	conn_offset_us -= EVENT_JITTER_US;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -149,7 +149,14 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	peer_addr_type = pdu_adv->tx_addr;
 	memcpy(peer_addr, pdu_adv->connect_ind.init_addr, BDADDR_SIZE);
 
-	chan_sel = pdu_adv->chan_sel;
+	if (0) {
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	} else if (adv->lll.aux) {
+		chan_sel = 1U;
+#endif
+	} else {
+		chan_sel = pdu_adv->chan_sel;
+	}
 
 	cc = (void *)pdu_adv;
 	cc->status = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -310,6 +310,26 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	mayfly_enable(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_ULL_LOW, 0);
 #endif
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
+	struct lll_adv_aux *lll_aux = adv->lll.aux;
+
+	if (lll_aux) {
+		struct ll_adv_aux_set *aux;
+
+		aux = (void *)HDR_LLL2EVT(lll_aux);
+
+		ticker_id_adv = TICKER_ID_ADV_AUX_BASE +
+				ull_adv_aux_handle_get(aux);
+		ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
+					    TICKER_USER_ID_ULL_HIGH,
+					    ticker_id_adv,
+					    ticker_op_stop_adv_cb, aux);
+		ticker_op_stop_adv_cb(ticker_status, aux);
+
+		aux->is_started = 0U;
+	}
+#endif
+
 	/* Stop Advertiser */
 	ticker_id_adv = TICKER_ID_ADV_BASE + ull_adv_handle_get(adv);
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,


### PR DESCRIPTION
This adds support for connectable extended advertising instance.

- [x] process AUX_CONNECT_REQ and send back AUX_CONNECT_RSP
- [x] establish connection
- [x] stop aux ticker on connection created
- [x] free resources if AUX_CONNECT_RSP failed to be sent

update:
babblesim testcases will not be added here since we do not support connecting to extended instances thus such testcase will always fail