### PR TITLE
net: tcp2: Local accepted socket was not bound

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1151,6 +1151,14 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 		}
 	}
 
+	ret = net_context_bind(context, &local_addr, sizeof(local_addr));
+	if (ret < 0) {
+		NET_DBG("Cannot bind accepted context, connection reset");
+		net_context_unref(context);
+		conn = NULL;
+		goto err;
+	}
+
 	NET_DBG("context: local: %s, remote: %s",
 		log_strdup(net_sprint_addr(
 		      local_addr.sa_family,

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -424,7 +424,9 @@ out:
 
 static void tcp_send_timer_cancel(struct tcp *conn)
 {
-	NET_ASSERT(conn->in_retransmission == true, "Not in retransmission");
+	if (conn->in_retransmission == false) {
+		return;
+	}
 
 	k_delayed_work_cancel(&conn->send_timer);
 


### PR DESCRIPTION
The local and accepted socket was not bound which caused the
local address to be set as NULL. This then caused issues when
zsock_getsockname() was called by the application.

Fixes #28735

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>