### PR TITLE
net: lwm2m: Bootstrap procedure improvements

### DIFF
--- a/doc/reference/networking/lwm2m.rst
+++ b/doc/reference/networking/lwm2m.rst
@@ -361,7 +361,7 @@ endpoint name.  This is important as it needs to be unique per LwM2M server:
 .. code-block:: c
 
 	(void)memset(&client, 0x0, sizeof(client));
-	lwm2m_rd_client_start(&client, "unique-endpoint-name", rd_client_event);
+	lwm2m_rd_client_start(&client, "unique-endpoint-name", 0, rd_client_event);
 
 Using LwM2M library with DTLS
 *****************************
@@ -406,7 +406,7 @@ value of 1 is ok here).
 
 	(void)memset(&client, 0x0, sizeof(client));
 	client.tls_tag = 1; /* <---- */
-	lwm2m_rd_client_start(&client, "endpoint-name", rd_client_event);
+	lwm2m_rd_client_start(&client, "endpoint-name", 0, rd_client_event);
 
 For a more detailed LwM2M client sample see: :ref:`lwm2m-client-sample`.
 

--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -79,6 +79,21 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.4
 
+   * - :ref:`coap_sock_interface`
+     - Unstable
+     - 1.10
+     - 2.4
+
+   * - :ref:`lwm2m_interface`
+     - Unstable
+     - 1.9
+     - 2.5
+
+   * - :ref:`mqtt_socket_interface`
+     - Unstable
+     - 1.14
+     - 2.4
+
    * - :ref:`adc_api`
      - Stable
      - 1.0

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -32,6 +32,10 @@ API Changes
 * Removed SETTINGS_USE_BASE64 support as its been deprecated for more than
   two releases.
 
+* The :c:func:`lwm2m_rd_client_start` function now accepts an additional
+  ``flags`` parameter, which allows to configure current LwM2M client session,
+  for instance enable bootstrap procedure in the curent session.
+
 Deprecated in this release
 ==========================
 

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -850,6 +850,15 @@ enum lwm2m_rd_client_event {
 	LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF,
 };
 
+/*
+ * LwM2M RD client flags, used to configure LwM2M session.
+ */
+
+/**
+ * @brief Run bootstrap procedure in current session.
+ */
+#define LWM2M_RD_CLIENT_FLAG_BOOTSTRAP BIT(0)
+
 /**
  * @brief Asynchronous RD client event callback
  *
@@ -871,12 +880,13 @@ typedef void (*lwm2m_ctx_event_cb_t)(struct lwm2m_ctx *ctx,
  *
  * @param[in] client_ctx LwM2M context
  * @param[in] ep_name Registered endpoint name
+ * @param[in] flags Flags used to configure current LwM2M session.
  * @param[in] event_cb Client event callback function
  *
  * @return 0 for success or negative in case of error.
  */
 void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
-			   lwm2m_ctx_event_cb_t event_cb);
+			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb);
 
 /**
  * @brief Stop the LwM2M RD (De-register) Client

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -882,8 +882,6 @@ typedef void (*lwm2m_ctx_event_cb_t)(struct lwm2m_ctx *ctx,
  * @param[in] ep_name Registered endpoint name
  * @param[in] flags Flags used to configure current LwM2M session.
  * @param[in] event_cb Client event callback function
- *
- * @return 0 for success or negative in case of error.
  */
 void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb);
@@ -898,8 +896,6 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  *
  * @param[in] client_ctx LwM2M context
  * @param[in] event_cb Client event callback function
- *
- * @return 0 for success or negative in case of error.
  */
 void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			  lwm2m_ctx_event_cb_t event_cb);

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -423,6 +423,8 @@ static void rd_client_event(struct lwm2m_ctx *client,
 
 void main(void)
 {
+	uint32_t flags = IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) ?
+				LWM2M_RD_CLIENT_FLAG_BOOTSTRAP : 0;
 	int ret;
 
 	LOG_INF(APP_BANNER);
@@ -461,10 +463,10 @@ void main(void)
 		sprintf(&dev_str[i*2], "%02x", dev_id[i]);
 	}
 
-	lwm2m_rd_client_start(&client, dev_str, rd_client_event);
+	lwm2m_rd_client_start(&client, dev_str, flags, rd_client_event);
 #else
 	/* client.sec_obj_inst is 0 as a starting point */
-	lwm2m_rd_client_start(&client, CONFIG_BOARD, rd_client_event);
+	lwm2m_rd_client_start(&client, CONFIG_BOARD, flags, rd_client_event);
 #endif
 
 	k_sem_take(&quit_lock, K_FOREVER);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4255,11 +4255,6 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 		return ret;
 	}
 
-	/* Set correct PSK_ID length */
-	if (type == TLS_CREDENTIAL_PSK_ID) {
-		cred_len = strlen(cred);
-	}
-
 	ret = tls_credential_add(client_ctx->tls_tag, type, cred, cred_len);
 	if (ret < 0) {
 		LOG_ERR("Error setting cred tag %d type %d: Error %d",

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -314,7 +314,7 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 
 		/* get buffer data */
 		write_buf = res->res_instances->data_ptr;
-		write_buflen = res->res_instances->data_len;
+		write_buflen = res->res_instances->max_data_len;
 
 		/* check for user override to buffer */
 		if (res->pre_write_cb) {

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -214,6 +214,8 @@ struct lwm2m_engine_obj {
 			for (int _i = 0; _i < _ri_count; _i++) { \
 				_ri_ptr[_ri_idx + _i].data_ptr = \
 						(_data_ptr + _i); \
+				_ri_ptr[_ri_idx + _i].max_data_len = \
+						_data_len; \
 				_ri_ptr[_ri_idx + _i].data_len = \
 						_data_len; \
 				if (_ri_create) { \
@@ -233,6 +235,7 @@ struct lwm2m_engine_obj {
 		if (_ri_count > 0) { \
 			for (int _i = 0; _i < _ri_count; _i++) { \
 				_ri_ptr[_ri_idx + _i].data_ptr = NULL; \
+				_ri_ptr[_ri_idx + _i].max_data_len = 0; \
 				_ri_ptr[_ri_idx + _i].data_len = 0; \
 				if (_ri_create) { \
 					_ri_ptr[_ri_idx + _i].res_inst_id = \
@@ -323,6 +326,7 @@ struct lwm2m_attr {
 
 struct lwm2m_engine_res_inst {
 	void  *data_ptr;
+	uint16_t max_data_len;
 	uint16_t data_len;
 	uint16_t res_inst_id; /* 65535 == not "created" */
 	uint8_t  data_flags;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -128,7 +128,8 @@ static void set_sm_state(uint8_t sm_state)
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	if (sm_state == ENGINE_BOOTSTRAP_REG_DONE) {
 		event = LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_REG_COMPLETE;
-	} else if (sm_state == ENGINE_BOOTSTRAP_TRANS_DONE) {
+	} else if (client.engine_state == ENGINE_BOOTSTRAP_TRANS_DONE &&
+		   sm_state == ENGINE_DO_REGISTRATION) {
 		event = LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_TRANSFER_COMPLETE;
 	} else
 #endif

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -503,7 +503,11 @@ static int sm_do_init(void)
 
 	/* Do bootstrap or registration */
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
-	set_sm_state(ENGINE_DO_BOOTSTRAP_REG);
+	if (client.use_bootstrap) {
+		set_sm_state(ENGINE_DO_BOOTSTRAP_REG);
+	} else {
+		set_sm_state(ENGINE_DO_REGISTRATION);
+	}
 #else
 	set_sm_state(ENGINE_DO_REGISTRATION);
 #endif
@@ -926,11 +930,19 @@ static void lwm2m_rd_client_service(struct k_work *work)
 }
 
 void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
-			   lwm2m_ctx_event_cb_t event_cb)
+			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb)
 {
+	if (!IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) &&
+	    (flags & LWM2M_RD_CLIENT_FLAG_BOOTSTRAP)) {
+		LOG_ERR("Bootstrap support is disabled. Please enable "
+			"CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP.");
+		return;
+	}
+
 	client.ctx = client_ctx;
 	client.ctx->sock_fd = -1;
 	client.event_cb = event_cb;
+	client.use_bootstrap = flags & LWM2M_RD_CLIENT_FLAG_BOOTSTRAP;
 
 	set_sm_state(ENGINE_INIT);
 	strncpy(client.ep_name, ep_name, CLIENT_EP_LEN - 1);


### PR DESCRIPTION
This PR introduces several improvements and fixes for LwM2M bootstrap procedure. Detailed description of the changes can be found in the commit message, to summarize:

Improvements:
 * Introduced new state machine state, `ENGINE_IDLE`, which now is the default after boot and after LwM2M engine is stopped.
 * Allow to specify whether bootstrap procedure shall run in the current session, instead of relying on static configuration only.

Fixes:
 * Introduce new member in the resource instance structure, indicating actual data size stored (so far only the buffer size was kept, making it impossible to retrieve the actual opaque data size written by the bootstrap server).
 * Fix PSK ID provisioning, by using the actual data size instead of result of `strlen()` (the PSK ID written by the server is of opaque data type and is not NULL terminated).
 * Report Bootstrap Complete event only after all bootstrap transactions are done.

Based on https://github.com/zephyrproject-rtos/zephyr/pull/28592, marking DNM until it's merged.