### PR TITLE
kernel: Remove deprecated APIs and MACROs from 2.3

### DIFF
--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -64,8 +64,7 @@ extern int z_clock_device_ctrl(const struct device *device,
  * indicating that no future timer interrupts are expected or required
  * and that the system is permitted to enter an indefinite sleep even
  * if this could cause rollover of the internal counter (i.e. the
- * system uptime counter is allowed to be wrong, see
- * k_enable_sys_clock_always_on()).
+ * system uptime counter is allowed to be wrong
  *
  * Note also that it is conventional for the kernel to pass INT_MAX
  * for ticks if it wants to preserve the uptime tick count but doesn't

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1795,8 +1795,6 @@ struct k_timer {
 	_OBJECT_TRACING_INIT \
 	}
 
-#define K_TIMER_INITIALIZER __DEPRECATED_MACRO Z_TIMER_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -2062,40 +2060,6 @@ static inline int64_t k_uptime_get(void)
 }
 
 /**
- * @brief Enable clock always on in tickless kernel
- *
- * Deprecated.  This does nothing (it was always just a hint).  This
- * functionality has been migrated to the
- * @option{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} config option.
- *
- * @retval prev_status Previous status of always on flag
- */
-/* LCOV_EXCL_START */
-__deprecated static inline int k_enable_sys_clock_always_on(void)
-{
-	__ASSERT(IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE),
-		 "Please use CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE instead");
-
-	return !IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE);
-}
-/* LCOV_EXCL_STOP */
-
-/**
- * @brief Disable clock always on in tickless kernel
- *
- * Deprecated.  This does nothing (it was always just a hint).  This
- * functionality has been migrated to the
- * @option{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} config option.
- */
-/* LCOV_EXCL_START */
-__deprecated static inline void k_disable_sys_clock_always_on(void)
-{
-	__ASSERT(!IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE),
-		 "Please use CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE instead");
-}
-/* LCOV_EXCL_STOP */
-
-/**
  * @brief Get system uptime (32-bit version).
  *
  * This routine returns the lower 32 bits of the system uptime in
@@ -2142,26 +2106,6 @@ static inline int64_t k_uptime_delta(int64_t *reftime)
 }
 
 /**
- * @brief Get elapsed time (32-bit version).
- *
- * This routine computes the elapsed time between the current system uptime
- * and an earlier reference time, in milliseconds.
- *
- * This is a wrapper around k_uptime_delta().
- *
- * @param reftime Pointer to a reference time, which is updated to the current
- *                uptime upon return.
- *
- * @return Elapsed time.
- *
- * @deprecated in 2.3 release, replace with k_uptime_delta()
- */
-__deprecated static inline uint32_t k_uptime_delta_32(int64_t *reftime)
-{
-	return (uint32_t)k_uptime_delta(reftime);
-}
-
-/**
  * @brief Read the hardware clock.
  *
  * This routine returns the current time, as measured by the system's hardware
@@ -2200,8 +2144,6 @@ struct k_queue {
 	_POLL_EVENT_OBJ_INIT(obj)		\
 	_OBJECT_TRACING_INIT \
 	}
-
-#define K_QUEUE_INITIALIZER __DEPRECATED_MACRO Z_QUEUE_INITIALIZER
 
 extern void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free);
 
@@ -2587,8 +2529,6 @@ struct k_fifo {
 	._queue = Z_QUEUE_INITIALIZER(obj._queue) \
 	}
 
-#define K_FIFO_INITIALIZER __DEPRECATED_MACRO Z_FIFO_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -2792,8 +2732,6 @@ struct k_lifo {
 	._queue = Z_QUEUE_INITIALIZER(obj._queue) \
 	}
 
-#define K_LIFO_INITIALIZER __DEPRECATED_MACRO Z_LIFO_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -2910,8 +2848,6 @@ struct k_stack {
 	.top = stack_buffer + stack_num_entries, \
 	_OBJECT_TRACING_INIT \
 	}
-
-#define K_STACK_INITIALIZER __DEPRECATED_MACRO Z_STACK_INITIALIZER
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -3099,8 +3035,6 @@ extern struct k_work_q k_sys_work_q;
 	.handler = work_handler, \
 	.flags = { 0 } \
 	}
-
-#define K_WORK_INITIALIZER __DEPRECATED_MACRO Z_WORK_INITIALIZER
 
 /**
  * @brief Initialize a statically-defined work item.
@@ -3614,8 +3548,6 @@ struct k_mutex {
 	_OBJECT_TRACING_INIT \
 	}
 
-#define K_MUTEX_INITIALIZER __DEPRECATED_MACRO Z_MUTEX_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -3719,8 +3651,6 @@ struct k_sem {
 	_POLL_EVENT_OBJ_INIT(obj) \
 	_OBJECT_TRACING_INIT \
 	}
-
-#define K_SEM_INITIALIZER __DEPRECATED_MACRO Z_SEM_INITIALIZER
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -3888,7 +3818,7 @@ struct k_msgq {
 	.used_msgs = 0, \
 	_OBJECT_TRACING_INIT \
 	}
-#define K_MSGQ_INITIALIZER __DEPRECATED_MACRO Z_MSGQ_INITIALIZER
+
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -4170,8 +4100,6 @@ struct k_mbox {
 	_OBJECT_TRACING_INIT \
 	}
 
-#define K_MBOX_INITIALIZER __DEPRECATED_MACRO Z_MBOX_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -4360,8 +4288,6 @@ struct k_pipe {
 	.flags = 0                                                  \
 	}
 
-#define K_PIPE_INITIALIZER __DEPRECATED_MACRO Z_PIPE_INITIALIZER
-
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -4541,8 +4467,6 @@ struct k_mem_slab {
 	.num_used = 0, \
 	_OBJECT_TRACING_INIT \
 	}
-
-#define K_MEM_SLAB_INITIALIZER __DEPRECATED_MACRO Z_MEM_SLAB_INITIALIZER
 
 
 /**


### PR DESCRIPTION
Remove old K_ prefixed macros defined in kernel.h as well as the
following APIs:

k_uptime_delta_32
k_enable_sys_clock_always_on
k_disable_sys_clock_always_on

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>