### PR TITLE
drivers: flash: Fix flash_write_protection_set usage

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -193,13 +193,13 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	flash_write_protection_set(flash_dev, false);
-
 	for (uint32_t i = 0; i < size; i++) {
 		test_arr[i] = (uint8_t)i;
 	}
 
 	while (repeat--) {
+		flash_write_protection_set(flash_dev, false);
+
 		result = flash_erase(flash_dev, addr, size);
 		if (result) {
 			shell_error(shell, "Erase Failed, code %d.", result);
@@ -207,6 +207,8 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 		}
 
 		shell_print(shell, "Erase OK.");
+
+		flash_write_protection_set(flash_dev, false);
 
 		if (flash_write(flash_dev, addr, test_arr, size) != 0) {
 			shell_error(shell, "Write internal ERROR!");

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -74,7 +74,7 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 		size = info.size;
 	}
 
-	flash_write_protection_set(flash_dev, 0);
+	flash_write_protection_set(flash_dev, false);
 
 	result = flash_erase(flash_dev, page_addr, size);
 
@@ -112,7 +112,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 		j++;
 	}
 
-	flash_write_protection_set(flash_dev, 0);
+	flash_write_protection_set(flash_dev, false);
 
 	if (flash_write(flash_dev, w_addr, buf_array,
 			sizeof(buf_array[0]) * j) != 0) {
@@ -193,7 +193,7 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	flash_write_protection_set(flash_dev, 0);
+	flash_write_protection_set(flash_dev, false);
 
 	for (uint32_t i = 0; i < size; i++) {
 		test_arr[i] = (uint8_t)i;

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -49,7 +49,7 @@ static int nvs_flash_al_wrt(struct nvs_fs *fs, uint32_t addr, const void *data,
 	offset += fs->sector_size * (addr >> ADDR_SECT_SHIFT);
 	offset += addr & ADDR_OFFS_MASK;
 
-	rc = flash_write_protection_set(fs->flash_device, 0);
+	rc = flash_write_protection_set(fs->flash_device, false);
 	if (rc) {
 		/* flash protection set error */
 		return rc;
@@ -79,7 +79,7 @@ static int nvs_flash_al_wrt(struct nvs_fs *fs, uint32_t addr, const void *data,
 	}
 
 end:
-	(void) flash_write_protection_set(fs->flash_device, 1);
+	(void) flash_write_protection_set(fs->flash_device, true);
 	return rc;
 }
 
@@ -239,7 +239,7 @@ static int nvs_flash_erase_sector(struct nvs_fs *fs, uint32_t addr)
 	offset = fs->offset;
 	offset += fs->sector_size * (addr >> ADDR_SECT_SHIFT);
 
-	rc = flash_write_protection_set(fs->flash_device, 0);
+	rc = flash_write_protection_set(fs->flash_device, false);
 	if (rc) {
 		/* flash protection set error */
 		return rc;
@@ -251,7 +251,7 @@ static int nvs_flash_erase_sector(struct nvs_fs *fs, uint32_t addr)
 		/* flash erase error */
 		return rc;
 	}
-	(void) flash_write_protection_set(fs->flash_device, 1);
+	(void) flash_write_protection_set(fs->flash_device, true);
 	return 0;
 }
 


### PR DESCRIPTION
This PR cleans up usage of `flash_write_protection_set()`. The second argument of this function as `bool` so passing 0 and 1 is not entirely correct. The PR also changes `flash_shell.c` so that flash protection is disabled before each flash erase or write operation because drivers may automatically enable flash protection once such operation is complete.