### PR TITLE
net: sntp: Remove deprecated API function

### DIFF
--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -61,18 +61,6 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
 	      socklen_t addr_len);
 
 /**
- * @brief SNTP query with seconds precision (deprecated)
- *
- * @param ctx Address of sntp context.
- * @param timeout Timeout of waiting for sntp response (in milliseconds).
- * @param epoch_time Seconds since 1 January 1970 (output).
- *
- * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
- */
-__deprecated int sntp_request(struct sntp_ctx *ctx, uint32_t timeout,
-			      uint64_t *epoch_time);
-
-/**
  * @brief Perform SNTP query
  *
  * @param ctx Address of sntp context.

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -170,16 +170,6 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_len)
 	return 0;
 }
 
-int sntp_request(struct sntp_ctx *ctx, uint32_t timeout, uint64_t *epoch_time)
-{
-	struct sntp_time time;
-	int res = sntp_query(ctx, timeout, &time);
-
-	*epoch_time = time.seconds;
-
-	return res;
-}
-
 int sntp_query(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *time)
 {
 	struct sntp_pkt tx_pkt = { 0 };


### PR DESCRIPTION
Remove sntp_request as its been marked deprecated since at least Zephyr
2.3 release.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>