### PR TITLE
kernel/sys_clock.h: Remove deprecated macros

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -168,20 +168,8 @@ extern void z_enable_sys_clock(void);
 
 #endif
 
-#define __ticks_to_ms(t) __DEPRECATED_MACRO \
-	k_ticks_to_ms_floor64((uint64_t)(t))
 #define z_ms_to_ticks(t) \
 	((int32_t)k_ms_to_ticks_ceil32((uint32_t)(t)))
-#define __ticks_to_us(t) __DEPRECATED_MACRO \
-	((int32_t)k_ticks_to_us_floor32((uint32_t)(t)))
-#define z_us_to_ticks(t) __DEPRECATED_MACRO \
-	((int32_t)k_us_to_ticks_ceil32((uint32_t)(t)))
-#define sys_clock_hw_cycles_per_tick() __DEPRECATED_MACRO \
-	((int)k_ticks_to_cyc_floor32(1U))
-#define SYS_CLOCK_HW_CYCLES_TO_NS64(t) __DEPRECATED_MACRO \
-	k_cyc_to_ns_floor64((uint64_t)(t))
-#define SYS_CLOCK_HW_CYCLES_TO_NS(t) __DEPRECATED_MACRO \
-	((uint32_t)k_cyc_to_ns_floor64(t))
 
 /* added tick needed to account for tick in progress */
 #define _TICK_ALIGN 1


### PR DESCRIPTION
Removed the following macros as they have been marked deprecated for at
least 2 releases:

__ticks_to_ms()
__ticks_to_us()
z_us_to_ticks()
sys_clock_hw_cycles_per_tick()
SYS_CLOCK_HW_CYCLES_TO_NS64()
SYS_CLOCK_HW_CYCLES_TO_NS()

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>