### PR TITLE
uart: Remove deprecated defines

### DIFF
--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -161,16 +161,6 @@ enum uart_rx_stop_reason {
 	UART_BREAK = (1 << 3),
 };
 
-
-/** @brief Backward compatibility defines, deprecated */
-#define UART_ERROR_BREAK __DEPRECATED_MACRO UART_BREAK
-#define LINE_CTRL_BAUD_RATE __DEPRECATED_MACRO UART_LINE_CTRL_BAUD_RATE
-#define LINE_CTRL_RTS __DEPRECATED_MACRO UART_LINE_CTRL_RTS
-#define LINE_CTRL_DTR __DEPRECATED_MACRO UART_LINE_CTRL_DTR
-#define LINE_CTRL_DCD __DEPRECATED_MACRO UART_LINE_CTRL_DCD
-#define LINE_CTRL_DSR __DEPRECATED_MACRO UART_LINE_CTRL_DSR
-
-
 /** @brief UART TX event data. */
 struct uart_event_tx {
 	/** @brief Pointer to current buffer. */


### PR DESCRIPTION
The following defines have been deprecated for at least 2 releases so
remove them:

UART_ERROR_BREAK
LINE_CTRL_BAUD_RATE
LINE_CTRL_RTS
LINE_CTRL_DTR
LINE_CTRL_DCD
LINE_CTRL_DSR

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>