### PR TITLE
Adding ability to change resolution on mcp9808 sensor driver

### DIFF
--- a/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
+++ b/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ &i2c1 {
+ 	mcp9808@18 {
+ 		compatible = "microchip,mcp9808";
+ 		reg = <0x18>;
+ 		int-gpios = <&gpioa 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+ 		label = "MCP9808";
+ 	};
+ };


### PR DESCRIPTION
The current MCP9808 driver does not set the resolution for the sensor, instead using the default resolution of 0.0625C.

In some cases, it is better to use a lower resolution (for example to reduce the time required to acquire a new sample).

This PR adds the ability to change the resolution of the temperature measurements at compile time.

As the resolution is set during the MCP9808 init function, the i2c write functions have been moved from mcp9808_trigger.c to mcp9808.c.

Since the resolution register is only 8 bits, an 8bit write function has been created, and the original 16bit write function renamed to show the difference.