### PR TITLE
arch: arm64: Fix arm64 crash dump output

### DIFF
--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -133,25 +133,25 @@ static void print_EC_cause(uint64_t esr)
 
 static void esf_dump(const z_arch_esf_t *esf)
 {
-	LOG_ERR("x0:  %-8llx  x1:  %llx",
+	LOG_ERR("x0:  0x%016llx  x1:  0x%016llx",
 		esf->basic.regs[18], esf->basic.regs[19]);
-	LOG_ERR("x2:  %-8llx  x3:  %llx",
+	LOG_ERR("x2:  0x%016llx  x3:  0x%016llx",
 		esf->basic.regs[16], esf->basic.regs[17]);
-	LOG_ERR("x4:  %-8llx  x5:  %llx",
+	LOG_ERR("x4:  0x%016llx  x5:  0x%016llx",
 		esf->basic.regs[14], esf->basic.regs[15]);
-	LOG_ERR("x6:  %-8llx  x7:  %llx",
+	LOG_ERR("x6:  0x%016llx  x7:  0x%016llx",
 		esf->basic.regs[12], esf->basic.regs[13]);
-	LOG_ERR("x8:  %-8llx  x9:  %llx",
+	LOG_ERR("x8:  0x%016llx  x9:  0x%016llx",
 		esf->basic.regs[10], esf->basic.regs[11]);
-	LOG_ERR("x10: %-8llx  x11: %llx",
+	LOG_ERR("x10: 0x%016llx  x11: 0x%016llx",
 		esf->basic.regs[8], esf->basic.regs[9]);
-	LOG_ERR("x12: %-8llx  x13: %llx",
+	LOG_ERR("x12: 0x%016llx  x13: 0x%016llx",
 		esf->basic.regs[6], esf->basic.regs[7]);
-	LOG_ERR("x14: %-8llx  x15: %llx",
+	LOG_ERR("x14: 0x%016llx  x15: 0x%016llx",
 		esf->basic.regs[4], esf->basic.regs[5]);
-	LOG_ERR("x16: %-8llx  x17: %llx",
+	LOG_ERR("x16: 0x%016llx  x17: 0x%016llx",
 		esf->basic.regs[2], esf->basic.regs[3]);
-	LOG_ERR("x18: %-8llx  x30: %llx",
+	LOG_ERR("x18: 0x%016llx  x30: 0x%016llx",
 		esf->basic.regs[0], esf->basic.regs[1]);
 }
 
@@ -185,9 +185,9 @@ void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 		}
 
 		if (GET_EL(el) != MODE_EL0) {
-			LOG_ERR("ESR_ELn: %llx", esr);
-			LOG_ERR("FAR_ELn: %llx", far);
-			LOG_ERR("ELR_ELn: %llx", elr);
+			LOG_ERR("ESR_ELn: 0x%016llx", esr);
+			LOG_ERR("FAR_ELn: 0x%016llx", far);
+			LOG_ERR("ELR_ELn: 0x%016llx", elr);
 
 			print_EC_cause(esr);
 		}

--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -133,7 +133,7 @@ static void print_EC_cause(uint64_t esr)
 
 static void esf_dump(const z_arch_esf_t *esf)
 {
-	LOG_ERR("x1:  %-8llx  x0:  %llx",
+	LOG_ERR("x0:  %-8llx  x1:  %llx",
 		esf->basic.regs[18], esf->basic.regs[19]);
 	LOG_ERR("x2:  %-8llx  x3:  %llx",
 		esf->basic.regs[16], esf->basic.regs[17]);

--- a/include/arch/arm/aarch64/exc.h
+++ b/include/arch/arm/aarch64/exc.h
@@ -26,9 +26,9 @@ extern "C" {
 
 struct __esf {
 	struct __basic_sf {
-		uint64_t regs[20];
 		uint64_t spsr;
 		uint64_t elr;
+		uint64_t regs[20];
 	} basic;
 };
 


### PR DESCRIPTION
- x0/x1 register printing is reversed
- The error stack frame struct (z_arch_esf_t) had the SPSR and ELR in
  the wrong position, inconsistent with the order these regs are pushed
  to the stack in z_arm64_svc.  This caused all register printing to be
  skewed by two.
- Verified by writing known values (abcd0000 -> abcd000f) to x0 - x15
  and then forcing a data abort.

Signed-off-by: Luke Starrett <luke.starrett@gmail.com>