### PR TITLE
drivers: spi: Set the spi_config before calling Chip select configure

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -183,6 +183,7 @@ static int spi_mcux_configure(const struct device *dev,
 
 		SPI_SetDummyData(base, 0);
 
+		data->ctx.config = spi_cfg;
 		spi_context_cs_configure(&data->ctx);
 	} else {
 		spi_slave_config_t slave_config;
@@ -213,8 +214,6 @@ static int spi_mcux_configure(const struct device *dev,
 		SPI_SlaveTransferCreateHandle(base, &data->handle,
 					      spi_mcux_transfer_callback, data);
 	}
-
-	data->ctx.config = spi_cfg;
 
 	return 0;
 }


### PR DESCRIPTION
This was accidentally moved to after calling chip select configure

