### PR TITLE
gen_isr_tables: Function ptr instead of (void *)

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -139,6 +139,7 @@ source_header = """
 #define ISR_WRAPPER NULL
 #endif
 
+typedef void (* ISR)(const void *);
 """
 
 def write_source_file(fp, vt, swt, intlist, syms):
@@ -175,7 +176,7 @@ def write_source_file(fp, vt, swt, intlist, syms):
             fp.write("\t/* Level 3 interrupts start here (offset: {}) */\n".
                      format(level3_offset))
 
-        fp.write("\t{{(const void *){0:#x}, (void *){1}}},\n".format(param, func_as_string))
+        fp.write("\t{{(const void *){0:#x}, (ISR){1}}},\n".format(param, func_as_string))
     fp.write("};\n")
 
 def get_symbols(obj):


### PR DESCRIPTION
gen_isr_tables.py generates C-code which initializes a table with
values, and these values are structs with members cast to
`(const void *)` and `(void *)`, respectively.
    
The actual struct definition has a member of type `(const void *)`
and another of type `void (*)(const void *)`.
See: https://github.com/zephyrproject-rtos/zephyr/blob/master/include/sw_isr_table.h#L30-L33
    
In order to avoid a large amount of reported issues in Coverity,
cast this to the exact type.

The problem in its minimal form can be seen here: https://godbolt.org/z/W9Ma6b

The PR uses proposal 2, which is to use a local typedef in order to make the result look a bit nicer.
Don't mind changing to proposal 1 if the typedef is unwanted.