### PR TITLE
sys_clock: k_ticks_t: fix the type of 64 bit k_ticks_t

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -43,7 +43,7 @@ extern "C" {
  * is always a 64 bit count of ticks.
  */
 #ifdef CONFIG_TIMEOUT_64BIT
-typedef int64_t k_ticks_t;
+typedef uint64_t k_ticks_t;
 #else
 typedef uint32_t k_ticks_t;
 #endif


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/blob/cd68e5819f164362f582ae16067042bacf44e25d/include/sys_clock.h#L45-L51

https://github.com/zephyrproject-rtos/zephyr/blob/cd68e5819f164362f582ae16067042bacf44e25d/kernel/timeout.c#L26-L27

https://github.com/zephyrproject-rtos/zephyr/blob/cd68e5819f164362f582ae16067042bacf44e25d/kernel/timeout.c#L76-L77

When the `MAX_WAIT` equal to `K_TICKS_FOREVER ((k_ticks_t) -1)`, and `k_ticks_t` is `int64_t`,
`MIN(MAX_WAIT, MAX(0, to->dticks - ticks_elapsed))` will always return the value `-1`.