### PR TITLE
tfm_integration: Use common routine for post-build commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1248,6 +1248,14 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
 endif()
 
+if(CONFIG_BUILD_WITH_TFM)
+  trusted_firmware_get_post_build_commands(TFM_POST_BUILD_COMMANDS)
+  list(APPEND
+    post_build_commands
+    ${TFM_POST_BUILD_COMMANDS}
+    )
+endif()
+
 get_property(extra_post_build_commands
   GLOBAL PROPERTY
   extra_post_build_commands

--- a/boards/arm/lpcxpresso55s69/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s69/CMakeLists.txt
@@ -10,27 +10,3 @@ if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()
-
-if (CONFIG_BUILD_WITH_TFM)
-	# Set default image versions if not defined elsewhere
-	if (NOT DEFINED TFM_IMAGE_VERSION_S)
-		set(TFM_IMAGE_VERSION_S 0.0.0+0)
-	endif()
-
-	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
-		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
-	endif()
-
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
-
-	# Configure which format (full or hash) to include the public key in
-	# the image manifest
-	set(TFM_PUBLIC_KEY_FORMAT "full")
-
-	# Set srec_cat binary name
-	find_program(SREC_CAT srec_cat)
-	if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
-		message(FATAL_ERROR "'srec_cat' not found. Please install it, or add it to $PATH.")
-	endif()
-endif()

--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -21,3 +21,4 @@ include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 
 set(TFM_TARGET_PLATFORM "LPC55S69")
+set(TFM_PUBLIC_KEY_FORMAT "full")

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -9,22 +9,6 @@ zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 if (CONFIG_BUILD_WITH_TFM)
-	# Set default image versions if not defined elsewhere
-	if (NOT DEFINED TFM_IMAGE_VERSION_S)
-		set(TFM_IMAGE_VERSION_S 0.0.0+0)
-	endif()
-
-	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
-		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
-	endif()
-
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
-
-	# Configure which format (full or hash) to include the public key in
-	# the image manifest
-	set(TFM_PUBLIC_KEY_FORMAT "full")
-
 	# Set srec_cat binary name
 	find_program(SREC_CAT srec_cat)
 	if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
@@ -33,45 +17,6 @@ if (CONFIG_BUILD_WITH_TFM)
 
 	#Create and sign for concatenated binary image, should align with the TF-M BL2
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-
-		#Sign secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_s.c
-			 -k ${CONFIG_TFM_KEY_FILE_S}
-			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
-			 --align 1
-			 -v ${TFM_IMAGE_VERSION_S}
-			 ${ADD_NS_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_S}
-			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/AN521/tfm_s.bin
-			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
-
-		#Sign non-secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_ns.c
-			 -k ${CONFIG_TFM_KEY_FILE_NS}
-			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
-			 --align 1
-			 -v ${TFM_IMAGE_VERSION_NS}
-			 ${ADD_S_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_NS}
-			 -H 0x400
-			 --included-header
-			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
-			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
-
-		#Create concatenated binary image from the two independently signed binary file
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
-		ARGS --layout ${PREPROCESSED_FILE}_s.c
-			 -s ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
-			 -n ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
-			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
-
-		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/mcuboot.bin ${CMAKE_BINARY_DIR}
 
 		#Merge mcuboot.bin and tfm_sign.bin for QEMU
 		COMMAND ${SREC_CAT}

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -2,6 +2,7 @@
 
 set(EMU_PLATFORM qemu)
 set(TFM_TARGET_PLATFORM "AN521")
+set(TFM_PUBLIC_KEY_FORMAT "full")
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m33)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/nucleo_l552ze_q/CMakeLists.txt
+++ b/boards/arm/nucleo_l552ze_q/CMakeLists.txt
@@ -7,57 +7,7 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()
 
 if (CONFIG_BUILD_WITH_TFM)
-	# Set default image versions if not defined elsewhere
-	if (NOT DEFINED TFM_IMAGE_VERSION_S)
-		set(TFM_IMAGE_VERSION_S 0.0.0+0)
-	endif()
-
-	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
-		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
-	endif()
-
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
-
-	# Configure which format (full or hash) to include the public key in
-	# the image manifest
-	set(TFM_PUBLIC_KEY_FORMAT "hash")
-
-	#Create and sign for concatenated binary image, should align with the TF-M BL2
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-
-		#Sign secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_s.c
-			 -k ${CONFIG_TFM_KEY_FILE_S}
-			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
-			 --align 1
-			 -v ${TFM_IMAGE_VERSION_S}
-			 ${ADD_NS_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_S}
-			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/STM_NUCLEO_L552ZE_Q/tfm_s.bin
-			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
-
-		#Sign non-secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_ns.c
-			 -k ${CONFIG_TFM_KEY_FILE_NS}
-			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
-			 --align 1
-			 -v ${TFM_IMAGE_VERSION_NS}
-			 ${ADD_S_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_NS}
-			 -H 0x400
-			 --included-header
-			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
-			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
-
-		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/mcuboot.bin ${CMAKE_BINARY_DIR}
-
 		#Execute post build script postbuild.sh
 		COMMAND ${CMAKE_BINARY_DIR}/tfm/install/postbuild.sh
       )

--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -7,3 +7,4 @@ include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
 set(TFM_TARGET_PLATFORM "STM_NUCLEO_L552ZE_Q")
+set(TFM_PUBLIC_KEY_FORMAT "hash")

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -9,22 +9,6 @@ zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 if (CONFIG_BUILD_WITH_TFM)
-	# Set default image versions if not defined elsewhere
-	if (NOT DEFINED TFM_IMAGE_VERSION_S)
-		set(TFM_IMAGE_VERSION_S 0.0.0+0)
-	endif()
-
-	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
-		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
-	endif()
-
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
-
-	# Configure which format (full or hash) to include the public key in
-	# the image manifest
-	set(TFM_PUBLIC_KEY_FORMAT "full")
-
 	# Set srec_cat binary name
 	find_program(SREC_CAT srec_cat)
 	if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
@@ -33,27 +17,6 @@ if (CONFIG_BUILD_WITH_TFM)
 
 	#Create and sign for concatenated binary image should align with the TF-M BL2
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-
-		#Create concatenated binary image from the two binary file
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
-		ARGS --layout ${PREPROCESSED_FILE}.c
-			-s ${CMAKE_BINARY_DIR}/tfm/install/outputs/MUSCA_B1/tfm_s.bin
-			-n ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
-			-o ${CMAKE_BINARY_DIR}/tfm_full.bin
-
-		#Sign concatenated binary image with default public key in mcuboot folder
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			--layout ${PREPROCESSED_FILE}.c
-			-k ${CONFIG_TFM_KEY_FILE_S}
-			--public-key-format ${TFM_PUBLIC_KEY_FORMAT}
-			--align 1
-			-v ${TFM_IMAGE_VERSION_S}
-			${ADD_SECURITY_COUNTER}
-			-H 0x400
-			--included-header
-			${CMAKE_BINARY_DIR}/tfm_full.bin
-			${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 		#srec_cat to combine images into hex for drag and drop
 		COMMAND ${SREC_CAT}

--- a/boards/arm/v2m_musca_b1/board.cmake
+++ b/boards/arm/v2m_musca_b1/board.cmake
@@ -1,6 +1,7 @@
 #SPDX-License-Identifier: Apache-2.0
 
 set(TFM_TARGET_PLATFORM "MUSCA_B1")
+set(TFM_PUBLIC_KEY_FORMAT "full")
 
 board_set_debugger_ifnset(pyocd)
 board_set_flasher_ifnset(pyocd)

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 143df675557305b61f7930a50459a53a8d2bb097
+      revision: pull/14/head
 
   self:
     path: zephyr


### PR DESCRIPTION
Provide in the tfm module a cmake function that will return commands
to be executed after a successful build with the CONFIG_BUILD_WITH_TFM
option enabled, and place there operations (signing and merging of
binary images when BL2 is used) that are currently present separately
in particular boards that support building with TF-M.

---

https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/14 needs to go in first.