### PR TITLE
net: tcp2: added struct const to *net_context_state()

### DIFF
--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -55,7 +55,7 @@ static inline void net_context_init(void) { }
 static inline void net_pkt_init(void) { }
 static inline void net_tc_tx_init(void) { }
 static inline void net_tc_rx_init(void) { }
-static inline const char *net_context_state(context)
+static inline const char *net_context_state(struct net_context *context)
 {
 	ARG_UNUSED(context);
 	return NULL;


### PR DESCRIPTION
When compiling with CONFIG_NET_NATIVE=n and CONFIG_NET_OFFLOAD=n
then the following error is printed.

```
In file included from zephyr/subsys/net/ip/ net_if.c:23:0:
zephyr/subsys/net/ip/net_private.h: In function 'net_context_state':
zephyr/subsys/net/ip/net_private.h:58:27:
error: type of 'context' defaults to 'int' [-Werror=implicit-int]
 static inline const char *net_context_state(context)
```

This add `struct net_context *` as type for context.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>