### PR TITLE
drivers: eth: sam_gmac: remove dts defaults

### DIFF
--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -194,7 +194,8 @@ enum queue_idx {
 	GMAC_QUE_5,  /** Priority queue 5 */
 };
 
-#if (DT_INST_PROP(0, max_frame_size) == 1518)
+#if (!DT_INST_HAS_PROP(0, max_frame_size)) || \
+    (DT_INST_PROP(0, max_frame_size) == 1518)
 	/* Maximum frame length is 1518 bytes */
 #define GMAC_MAX_FRAME_SIZE 0
 #elif (DT_INST_PROP(0, max_frame_size) == 1536)

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -24,13 +24,11 @@ properties:
           maximum frame size (there\'s contradiction in the Devicetree
           Specification). The current supported values are 1518, 1536
           and 10240 (jumbo frames).
-        default: 1518
 
     max-speed:
         type: int
         description:
           Specifies maximum speed in Mbit/s supported by the device.
-        default: 100
 
     phy-connection-type:
         type: string
@@ -39,7 +37,6 @@ properties:
         enum:
           - "rmii"
           - "mii"
-        default: "rmii"
 
     pinctrl-0:
       type: phandles


### PR DESCRIPTION
The use of defaults isn't really needed for the properties that
specified them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>