### PR TITLE
drivers: flash: remove defaults from atmel,at45 dts binding

### DIFF
--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -48,7 +48,6 @@ properties:
   enter-dpd-delay:
     type: int
     required: false
-    default: 0
     description: |
       Time, in nanoseconds, needed by the chip to enter the Deep Power-Down
       mode (or Ultra-Deep Power-Down mode when the "use-udpd" property is set)
@@ -57,7 +56,6 @@ properties:
   exit-dpd-delay:
     type: int
     required: false
-    default: 0
     description: |
       Time, in nanoseconds, needed by the chip to exit from the Deep Power-Down
       mode (or Ultra-Deep Power-Down mode when the "use-udpd" property is set)


### PR DESCRIPTION
The defaults for enter-dpd-delay and exit-dpd-delay properties are not
needed as the code checks for the existence of these properties so
remove the use of defaults in the binding.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>