### PR TITLE
drivers: serial: stm32: set default parity in driver

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -826,7 +826,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 		    .enr = DT_INST_CLOCKS_CELL(index, bits)		\
 	},								\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
-	.parity = DT_INST_PROP(index, parity),				\
+	.parity = DT_INST_PROP_OR(index, parity, UART_CFG_PARITY_NONE),	\
 	.pinctrl_list = uart_pins_##index,				\
 	.pinctrl_list_size = ARRAY_SIZE(uart_pins_##index),		\
 };									\

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -17,8 +17,9 @@ properties:
     parity:
       required: false
       type: int
-      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
-      default: 0
+      description: |
+        Configures the parity of the adapter. Value 0 for none, 1 for odd
+        and 2 for even parity.  Default to none if not specified.
 
     pinctrl-0:
       type: phandles

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -14,8 +14,9 @@ properties:
     parity:
       required: false
       type: int
-      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
-      default: 0
+      description: |
+        Configures the parity of the adapter. Value 0 for none, 1 for odd
+        and 2 for even parity.  Default to none if not specified.
 
     pinctrl-0:
       type: phandles

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -14,8 +14,9 @@ properties:
     parity:
       required: false
       type: int
-      description: Configures the parity of the adapter. Value 0 for none, 1 for odd and 2 for even parity.
-      default: 0
+      description: |
+        Configures the parity of the adapter. Value 0 for none, 1 for odd
+        and 2 for even parity.  Default to none if not specified.
 
     pinctrl-0:
       type: phandles


### PR DESCRIPTION
Have the driver default to UART_CFG_PARITY_NONE if no parity property
exists rather than using default in binding.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>