### PR TITLE
drivers: nrf_qspi: use DT_INST_PROP_OR over binding default

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -424,7 +424,7 @@ static inline void qspi_fill_init_struct(nrfx_qspi_config_t *initstruct)
 	/* Configure physical interface */
 	initstruct->phy_if.sck_freq =
 		get_nrf_qspi_prescaler(DT_INST_PROP(0, sck_frequency));
-	initstruct->phy_if.sck_delay = DT_INST_PROP(0, sck_delay);
+	initstruct->phy_if.sck_delay = DT_INST_PROP_OR(0, sck_delay, 0);
 	initstruct->phy_if.spi_mode = qspi_get_mode(DT_INST_PROP(0, cpol),
 						    DT_INST_PROP(0, cpha));
 

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -65,7 +65,6 @@ properties:
   sck-delay:
     type: int
     required: false
-    default: 0
     description: |
       Number of clock cycles CSn must be asserted before it can go low
       again, specified in nanoseconds.


### PR DESCRIPTION
Switch driver to use DT_INST_PROP_OR for sck-delay default instead of
specifying in binding.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>