### PR TITLE
drivers: sensors: itds: Remove dts defaults

### DIFF
--- a/dts/bindings/sensor/we,wsen-itds.yaml
+++ b/dts/bindings/sensor/we,wsen-itds.yaml
@@ -18,8 +18,7 @@ properties:
 
     odr:
       type: string
-      required: false
-      default: "800"
+      required: true
       description: Output data rate in Hz
       enum:
         - "1.6"
@@ -34,8 +33,7 @@ properties:
 
     op-mode:
       type: string
-      required: false
-      default: "high-perf"
+      required: true
       description: Operating mode of sensor
       enum:
         - "low-power"

--- a/samples/sensor/wsen_itds/boards/disco_l475_iot1.overlay
+++ b/samples/sensor/wsen_itds/boards/disco_l475_iot1.overlay
@@ -10,5 +10,7 @@
 		reg = <0x18>;
 		label = "WSEN-ITDS";
 		int-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+		odr = "800";
+		op-mode = "high-perf";
 	};
 };

--- a/tests/drivers/build_all/i2c.dtsi
+++ b/tests/drivers/build_all/i2c.dtsi
@@ -548,6 +548,8 @@ test_i2c_itds: itds@18 {
 	label = "WSEN-ITDS";
 	reg = <0x18>;
 	int-gpios = <&test_gpio 0 0>;
+	odr = "800";
+	op-mode = "high-perf";
 };
 
 test_i2c_max17055: max17055@49 {


### PR DESCRIPTION
We should not be using defaults for enum properties, this should be
required: true instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>