### PR TITLE
drivers: sensors: vcnl4040: Remove dts defaults

### DIFF
--- a/dts/bindings/sensor/vishay,vcnl4040.yaml
+++ b/dts/bindings/sensor/vishay,vcnl4040.yaml
@@ -19,8 +19,7 @@ properties:
 
     led-current:
       type: int
-      required: false
-      default: 50
+      required: true
       description: LED current in mA
       enum:
         - 50
@@ -34,8 +33,7 @@ properties:
 
     led-duty-cycle:
       type: int
-      required: false
-      default: 40
+      required: true
       description: LED duty cycle in Hz
       enum:
         - 40
@@ -45,8 +43,7 @@ properties:
 
     proximity-it:
       type: string
-      required: false
-      default: "1"
+      required: true
       description: Proximity integration time in T
       enum:
         - "1"
@@ -60,8 +57,7 @@ properties:
 
     proximity-trigger:
       type: string
-      required: false
-      default: "close-away"
+      required: true
       description: Proximity trigger type
       enum:
         - "disabled"
@@ -71,8 +67,7 @@ properties:
 
     als-it:
       type: int
-      required: false
-      default: 80
+      required: true
       description: ALS integration time in ms
       enum:
         - 80

--- a/tests/drivers/build_all/i2c.dtsi
+++ b/tests/drivers/build_all/i2c.dtsi
@@ -565,4 +565,9 @@ test_i2c_vcnl4040: vcnl4040@60 {
 	label = "VCNL4040";
 	reg = <0x60>;
 	int-gpios = <&test_gpio 0 0>;
+	led-current = <50>;
+	led-duty-cycle = <40>;
+	proximity-it = "1";
+	proximity-trigger = "close-away";
+	als-it = <80>;
 };


### PR DESCRIPTION
We should not be using defaults for enum properties, this should be
required: true instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>