### PR TITLE
drivers: gpio: lpc11u6x: remove unused dts property

### DIFF
--- a/dts/arm/nxp/nxp_lpc11u6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc11u6x.dtsi
@@ -122,7 +122,6 @@
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
-			base = <2>;
 			ngpios = <22>;
 
 			clocks = <&syscon LPC11U6X_CLOCK_GPIO>;

--- a/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
@@ -20,12 +20,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-    base:
-      type: int
-      required: false
-      default: 0
-      description: index of the first GPIO for this port.
-
     clocks:
       required: true
 


### PR DESCRIPTION
The 'base' property is not used by the lpc11u6x driver so remove it
from the dts and binding.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>