### PR TITLE
Bluetooth: Controller: Some Kconfig fixes

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -286,35 +286,6 @@ config BT_CTLR_LE_PING
 	help
 	  Enable support for Bluetooth v4.1 LE Ping feature in the Controller.
 
-config BT_CTLR_PRIVACY
-	bool "LE Controller-based Privacy"
-	depends on BT_CTLR_PRIVACY_SUPPORT
-	default y
-	select BT_CTLR_FILTER if BT_LL_SW_SPLIT
-	select BT_RPA
-	help
-	  Enable support for Bluetooth v4.2 LE Controller-based Privacy feature
-	  in the Controller.
-
-config BT_CTLR_RL_SIZE
-	int "LE Controller-based Privacy Resolving List size"
-	depends on BT_CTLR_PRIVACY
-	default 8
-	range 1 8 if SOC_COMPATIBLE_NRF
-	range 1 8 if SOC_OPENISA_RV32M1_RISCV32
-	help
-	  Set the size of the Resolving List for LE Controller-based Privacy.
-	  On nRF5x-based controllers, the hardware imposes a limit of 8 devices.
-	  On OpenISA-based controllers, the hardware imposes a limit of 8 devices.
-
-config BT_CTLR_EXT_SCAN_FP
-	bool "LE Extended Scanner Filter Policies"
-	depends on BT_OBSERVER && BT_CTLR_EXT_SCAN_FP_SUPPORT
-	default y
-	help
-	  Enable support for Bluetooth v4.2 LE Extended Scanner Filter Policies
-	  in the Controller.
-
 config BT_CTLR_DATA_LENGTH
 	# Hidden option to enable support for Bluetooth v4.2 LE Data Length
 	# Update procedure in the Controller.
@@ -360,6 +331,35 @@ config BT_CTLR_FILTER
 	default y
 	help
 	  Enable support for controller device whitelist feature
+
+config BT_CTLR_PRIVACY
+	bool "LE Controller-based Privacy"
+	depends on BT_CTLR_PRIVACY_SUPPORT
+	default y
+	select BT_CTLR_FILTER if BT_LL_SW_SPLIT
+	select BT_RPA
+	help
+	  Enable support for Bluetooth v4.2 LE Controller-based Privacy feature
+	  in the Controller.
+
+config BT_CTLR_RL_SIZE
+	int "LE Controller-based Privacy Resolving List size"
+	depends on BT_CTLR_PRIVACY
+	default 8
+	range 1 8 if SOC_COMPATIBLE_NRF
+	range 1 8 if SOC_OPENISA_RV32M1_RISCV32
+	help
+	  Set the size of the Resolving List for LE Controller-based Privacy.
+	  On nRF5x-based controllers, the hardware imposes a limit of 8 devices.
+	  On OpenISA-based controllers, the hardware imposes a limit of 8 devices.
+
+config BT_CTLR_EXT_SCAN_FP
+	bool "LE Extended Scanner Filter Policies"
+	depends on BT_OBSERVER && BT_CTLR_EXT_SCAN_FP_SUPPORT
+	default y
+	help
+	  Enable support for Bluetooth v4.2 LE Extended Scanner Filter Policies
+	  in the Controller.
 
 config BT_CTLR_PHY_2M
 	bool "2Mbps PHY Support"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -355,6 +355,12 @@ config BT_CTLR_CONN_RSSI
 
 endif # BT_CONN
 
+config BT_CTLR_FILTER
+	bool "Device Whitelist Support"
+	default y
+	help
+	  Enable support for controller device whitelist feature
+
 config BT_CTLR_PHY_2M
 	bool "2Mbps PHY Support"
 	depends on (BT_CTLR_PHY || BT_CTLR_ADV_EXT) && BT_CTLR_PHY_2M_SUPPORT

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -106,12 +106,6 @@ config BT_CTLR_ADVANCED_FEATURES
 menu "Advanced features"
 	visible if BT_CTLR_ADVANCED_FEATURES
 
-config BT_CTLR_FILTER
-	bool "Device Whitelist Support"
-	default y
-	help
-	  Enable support for controller device whitelist feature
-
 config BT_CTLR_SW_DEFERRED_PRIVACY
 	bool "LE Controller-based Software Privacy"
 	depends on BT_CTLR_PRIVACY


### PR DESCRIPTION
* Allow all controllers to use BT_CTLR_FILTER.
* Allow using privacy when not in non-connected state.
* Allow using extended filter policies when in non-connected state.