### PR TITLE
Bump QuickLogic HAL PR module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -84,7 +84,7 @@ manifest:
       path: modules/hal/libmetal
     - name: hal_quicklogic
       repo-path: hal_quicklogic
-      revision: 7deb3aab1cc430a7650143f9833cfc8ddad76eb5
+      revision: b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0
       path: modules/hal/quicklogic
     - name: lvgl
       revision: 928b61c7c8ef5f770f10e6fd36d4fea0cf375b5e


### PR DESCRIPTION
This PR is just for testing purposes to prove the QuickLogic HAL PR will not break the Zephyr build. To do so, I changed the remote and commit in the west manifest to use HAL with changes planned to be merged to HAL repository.

The HAL PR: https://github.com/zephyrproject-rtos/hal_quicklogic/pull/2

EDIT: I transformed this PR from `test` to `bump` PR