### PR TITLE
drivers: clock: stm32: fix MSI PLL mode enabling

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -485,6 +485,11 @@ static int stm32_clock_control_init(const struct device *dev)
 	LL_RCC_MSI_EnableRangeSelection();
 	LL_RCC_MSI_SetRange(CONFIG_CLOCK_STM32_MSI_RANGE << RCC_CR_MSIRANGE_Pos);
 
+#if defined(CONFIG_CLOCK_STM32_MSI_PLL_MODE)
+	/* Enable MSI hardware auto calibration */
+	LL_RCC_MSI_EnablePLLMode();
+#endif
+
 	/* Enable MSI if not enabled */
 	if (LL_RCC_MSI_IsReady() != 1) {
 		/* Enable MSI */
@@ -492,10 +497,6 @@ static int stm32_clock_control_init(const struct device *dev)
 		while (LL_RCC_MSI_IsReady() != 1) {
 		/* Wait for HSI ready */
 		}
-#ifdef CONFIG_CLOCK_STM32_MSI_PLL_MODE
-		/* Enable MSI hardware auto calibration */
-		LL_RCC_MSI_EnablePLLMode();
-#endif
 	}
 
 	/* Set MSI as SYSCLCK source */

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -333,6 +333,11 @@ static int rtc_stm32_init(const struct device *dev)
 	while (LL_RCC_LSE_IsReady() != 1) {
 	}
 
+#if defined(CONFIG_CLOCK_STM32_MSI_PLL_MODE)
+	/* Enable MSI hardware auto calibration */
+	LL_RCC_MSI_EnablePLLMode();
+#endif
+
 	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSE);
 
 #endif /* CONFIG_COUNTER_RTC_STM32_CLOCK_SRC */


### PR DESCRIPTION
Move the call for MSI hardware auto calibration enabling out of the
control of MSI enable to ensure its execution in all cases.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>