### PR TITLE
cleanup of work queue API documentation and minor behavior changes

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3336,9 +3336,9 @@ extern void k_delayed_work_init(struct k_delayed_work *work,
  *
  * @retval 0 Work item countdown started.
  * @retval -EINVAL
- *    @li if a previously submitted work item had to be cancelled,
- *        and the cancellation failed; or
- *    @li Work item is being processed or has completed its work.
+ *    * if a previously submitted work item had to be cancelled and the
+ *      cancellation failed; or
+ *    * Work item is being processed or has completed its work.
  * @retval -EADDRINUSE Work item was submitted to a different workqueue.
  */
 extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
@@ -3360,21 +3360,21 @@ extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
  * @param work Address of delayed work item.
  *
  * @retval 0
- *   @li Work item countdown cancelled before the item was submitted to its
- *       queue; or
- *   @li Work item was removed from its queue before it was processed.
+ *   * Work item countdown cancelled before the item was submitted to its
+ *     queue; or
+ *   * Work item was removed from its queue before it was processed.
  * @retval -EINVAL
- *   @li Work item has never been submitted; or
- *   @li Work item has been successfully cancelled; or
- *   @li Timeout handler is in the process of submitting the work item to its
- *       queue; or
- *   @li Work queue thread has removed the work item from the queue but has
- *       not called its handler.
+ *   * Work item has never been submitted; or
+ *   * Work item has been successfully cancelled; or
+ *   * Timeout handler is in the process of submitting the work item to its
+ *     queue; or
+ *   * Work queue thread has removed the work item from the queue but has not
+ *     called its handler.
  * @retval -EALREADY
- *   @li Work queue thread has removed the work item from the queue and
- *       cleared its pending flag; or
- *   @li Work queue thread is invoking the item handler; or
- *   @li Work item handler has completed.
+ *   * Work queue thread has removed the work item from the queue and cleared
+ *     its pending flag; or
+ *   * Work queue thread is invoking the item handler; or
+ *   * Work item handler has completed.
  */
 extern int k_delayed_work_cancel(struct k_delayed_work *work);
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3314,16 +3314,15 @@ extern void k_delayed_work_init(struct k_delayed_work *work,
  * Only when the countdown completes is the work item actually submitted to
  * the workqueue and becomes pending.
  *
- * Submitting a previously submitted delayed work item that is still
- * counting down cancels the existing submission and restarts the
- * countdown using the new delay.  Note that this behavior is
- * inherently subject to race conditions with the pre-existing
- * timeouts and work queue, so care must be taken to synchronize such
- * resubmissions externally.
+ * Submitting a previously submitted delayed work item that is still counting
+ * down or is pending cancels the existing submission and restarts the
+ * countdown using the new delay.  Note that this behavior is inherently
+ * subject to race conditions with the pre-existing timeouts and work queue,
+ * so care must be taken to synchronize such resubmissions externally.
  *
  * Attempts to submit a work item to a queue after it has been submitted to a
  * different queue will fail with @c -EALREADY until k_delayed_work_cancel()
- * is invoked on the work item to clear its internal state.
+ * is successfully invoked on the work item to clear its internal state.
  *
  * @warning
  * A delayed work item must not be modified until it has been processed
@@ -3336,7 +3335,10 @@ extern void k_delayed_work_init(struct k_delayed_work *work,
  * @param delay Delay before submitting the work item
  *
  * @retval 0 Work item countdown started.
- * @retval -EINVAL Work item is being processed or has completed its work.
+ * @retval -EINVAL
+ *    @li if a previously submitted work item had to be cancelled,
+ *        and the cancellation failed; or
+ *    @li Work item is being processed or has completed its work.
  * @retval -EADDRINUSE Work item was submitted to a different workqueue.
  */
 extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
@@ -3346,21 +3348,33 @@ extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
 /**
  * @brief Cancel a delayed work item.
  *
- * This routine cancels the submission of delayed work item @a work.
- * A delayed work item can only be canceled while its countdown is still
- * underway.
+ * This routine cancels the submission of delayed work item @a work.  Whether
+ * the work item can be successfully cancelled depends on its state.
  *
  * @note Can be called by ISRs.
  *
- * @note The result of calling this on a k_delayed_work item that has
- * not been submitted (i.e. before the return of the
- * k_delayed_work_submit_to_queue() call) is undefined.
+ * @note When @c -EALREADY is returned the caller cannot distinguish whether
+ * the work item handler is still being invoked by the work queue thread or
+ * has completed.
  *
  * @param work Address of delayed work item.
  *
- * @retval 0 Work item countdown canceled.
- * @retval -EINVAL Work item is being processed.
- * @retval -EALREADY Work item has already been completed.
+ * @retval 0
+ *   @li Work item countdown cancelled before the item was submitted to its
+ *       queue; or
+ *   @li Work item was removed from its queue before it was processed.
+ * @retval -EINVAL
+ *   @li Work item has never been submitted; or
+ *   @li Work item has been successfully cancelled; or
+ *   @li Timeout handler is in the process of submitting the work item to its
+ *       queue; or
+ *   @li Work queue thread has removed the work item from the queue but has
+ *       not called its handler.
+ * @retval -EALREADY
+ *   @li Work queue thread has removed the work item from the queue and
+ *       cleared its pending flag; or
+ *   @li Work queue thread is invoking the item handler; or
+ *   @li Work item handler has completed.
  */
 extern int k_delayed_work_cancel(struct k_delayed_work *work);
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3143,12 +3143,12 @@ static inline void k_work_init(struct k_work *work, k_work_handler_t handler)
 /**
  * @brief Submit a work item.
  *
- * This routine submits work item @a work to be processed by workqueue
- * @a work_q. If the work item is already pending in the workqueue's queue
- * as a result of an earlier submission, this routine has no effect on the
- * work item. If the work item has already been processed, or is currently
- * being processed, its work is considered complete and the work item can be
- * resubmitted.
+ * This routine submits work item @p work to be processed by workqueue @p
+ * work_q. If the work item is already pending in @p work_q or any other
+ * workqueue as a result of an earlier submission, this routine has no
+ * effect on the work item. If the work item has already been processed, or
+ * is currently being processed, its work is considered complete and the
+ * work item can be resubmitted.
  *
  * @warning
  * A submitted work item must not be modified until it has been processed
@@ -3364,11 +3364,11 @@ extern int k_delayed_work_cancel(struct k_delayed_work *work);
  * @brief Submit a work item to the system workqueue.
  *
  * This routine submits work item @a work to be processed by the system
- * workqueue. If the work item is already pending in the workqueue's queue
- * as a result of an earlier submission, this routine has no effect on the
- * work item. If the work item has already been processed, or is currently
- * being processed, its work is considered complete and the work item can be
- * resubmitted.
+ * workqueue. If the work item is already pending in the system workqueue or
+ * any other workqueue as a result of an earlier submission, this routine
+ * has no effect on the work item. If the work item has already been
+ * processed, or is currently being processed, its work is considered
+ * complete and the work item can be resubmitted.
  *
  * @warning
  * Work items submitted to the system workqueue should avoid using handlers

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3321,6 +3321,10 @@ extern void k_delayed_work_init(struct k_delayed_work *work,
  * timeouts and work queue, so care must be taken to synchronize such
  * resubmissions externally.
  *
+ * Attempts to submit a work item to a queue after it has been submitted to a
+ * different queue will fail with @c -EALREADY until k_delayed_work_cancel()
+ * is invoked on the work item to clear its internal state.
+ *
  * @warning
  * A delayed work item must not be modified until it has been processed
  * by the workqueue.
@@ -3333,7 +3337,7 @@ extern void k_delayed_work_init(struct k_delayed_work *work,
  *
  * @retval 0 Work item countdown started.
  * @retval -EINVAL Work item is being processed or has completed its work.
- * @retval -EADDRINUSE Work item is pending on a different workqueue.
+ * @retval -EADDRINUSE Work item was submitted to a different workqueue.
  */
 extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
 					  struct k_delayed_work *work,
@@ -3403,6 +3407,10 @@ static inline void k_work_submit(struct k_work *work)
  * If the work item has already been processed, or is currently being processed,
  * its work is considered complete and the work item can be resubmitted.
  *
+ * Attempts to submit a work item to a queue after it has been submitted to a
+ * different queue will fail with @c -EALREADY until k_delayed_work_cancel()
+ * is invoked on the work item to clear its internal state.
+ *
  * @warning
  * Work items submitted to the system workqueue should avoid using handlers
  * that block or yield since this may prevent the system workqueue from
@@ -3415,7 +3423,7 @@ static inline void k_work_submit(struct k_work *work)
  *
  * @retval 0 Work item countdown started.
  * @retval -EINVAL Work item is being processed or has completed its work.
- * @retval -EADDRINUSE Work item is pending on a different workqueue.
+ * @retval -EADDRINUSE Work item was submitted to a different workqueue.
  */
 static inline int k_delayed_work_submit(struct k_delayed_work *work,
 					k_timeout_t delay)

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -55,10 +55,6 @@ void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
 
 static int work_cancel(struct k_delayed_work *work)
 {
-	CHECKIF(work->work_q == NULL) {
-		return -EALREADY;
-	}
-
 	if (k_work_pending(&work->work)) {
 		/* Remove from the queue if already submitted */
 		if (!k_queue_remove(&work->work_q->queue, &work->work)) {
@@ -132,12 +128,12 @@ done:
 
 int k_delayed_work_cancel(struct k_delayed_work *work)
 {
-	if (!work->work_q) {
-		return -EINVAL;
-	}
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	int ret = work_cancel(work);
+	int ret = -EINVAL;
+
+	if (work->work_q != NULL) {
+		ret = work_cancel(work);
+	}
 
 	k_spin_unlock(&lock, key);
 	return ret;

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -92,8 +92,10 @@ int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
 	/* Cancel if work has been submitted */
 	if (work->work_q == work_q) {
 		err = work_cancel(work);
-		/* -EALREADY indicates the work has already completed so this
-		 * is likely a recurring work.
+		/* -EALREADY may indicate the work has already completed so
+		 * this is likely a recurring work.  It may also indicate that
+		 * the work handler is still executing.  But it's neither
+		 * delayed nor pending, so it can be rescheduled.
 		 */
 		if (err == -EALREADY) {
 			err = 0;

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -293,7 +293,7 @@ static void tdelayed_work_submit_1(struct k_work_q *work_q,
 	/**TESTPOINT: init via k_delayed_work_init*/
 	k_delayed_work_init(w, handler);
 	/**TESTPOINT: check pending after delayed work init*/
-	zassert_false(k_work_pending((struct k_work *)w), NULL);
+	zassert_false(k_work_pending(&w->work), NULL);
 	/**TESTPOINT: check remaining timeout before submit*/
 	zassert_equal(k_delayed_work_remaining_get(w), 0, NULL);
 
@@ -319,7 +319,7 @@ static void tdelayed_work_submit_1(struct k_work_q *work_q,
 	zassert_true(time_remaining >= tick_to_ms, NULL);
 
 	/**TESTPOINT: check pending after delayed work submit*/
-	zassert_true(k_work_pending((struct k_work *)w) == 0, NULL);
+	zassert_false(k_work_pending(&w->work), NULL);
 }
 
 static void tdelayed_work_submit(const void *data)
@@ -368,12 +368,12 @@ static void tdelayed_work_cancel(const void *data)
 	ret = k_delayed_work_cancel(&delayed_work[0]);
 	zassert_true(ret == 0, NULL);
 	/**TESTPOINT: check pending after delayed work cancel*/
-	zassert_false(k_work_pending((struct k_work *)&delayed_work[0]), NULL);
+	zassert_false(k_work_pending(&delayed_work[0].work), NULL);
 	if (!k_is_in_isr()) {
 		/*wait for handling work_sleepy*/
 		k_sleep(TIMEOUT);
 		/**TESTPOINT: check pending when work pending*/
-		zassert_true(k_work_pending((struct k_work *)&delayed_work[1]),
+		zassert_true(k_work_pending(&delayed_work[1].work),
 			     NULL);
 		/**TESTPOINT: delayed work cancel when pending*/
 		ret = k_delayed_work_cancel(&delayed_work[1]);
@@ -382,8 +382,7 @@ static void tdelayed_work_cancel(const void *data)
 		/*wait for completed work_sleepy and delayed_work[1]*/
 		k_sleep(TIMEOUT);
 		/**TESTPOINT: check pending when work completed*/
-		zassert_false(k_work_pending(
-					(struct k_work *)&delayed_work_sleepy),
+		zassert_false(k_work_pending(&delayed_work_sleepy.work),
 					NULL);
 		/**TESTPOINT: delayed work cancel when completed*/
 		ret = k_delayed_work_cancel(&delayed_work_sleepy);
@@ -406,8 +405,7 @@ static void ttriggered_work_submit(const void *data)
 		/**TESTPOINT: init via k_work_poll_init*/
 		k_work_poll_init(&triggered_work[i], work_handler);
 		/**TESTPOINT: check pending after triggered work init*/
-		zassert_false(k_work_pending(
-					(struct k_work *)&triggered_work[i]),
+		zassert_false(k_work_pending(&triggered_work[i].work),
 					NULL);
 		if (work_q) {
 			/**TESTPOINT: triggered work submit to queue*/
@@ -425,8 +423,7 @@ static void ttriggered_work_submit(const void *data)
 		}
 
 		/**TESTPOINT: check pending after triggered work submit*/
-		zassert_true(k_work_pending(
-				(struct k_work *)&triggered_work[i]) == 0,
+		zassert_false(k_work_pending(&triggered_work[i].work),
 				NULL);
 	}
 
@@ -436,8 +433,7 @@ static void ttriggered_work_submit(const void *data)
 				&triggered_work_signal[i], 1) == 0,
 				NULL);
 		/**TESTPOINT: check pending after sending signal */
-		zassert_true(k_work_pending(
-				(struct k_work *)&triggered_work[i]) != 0,
+		zassert_true(k_work_pending(&triggered_work[i].work) != 0,
 				NULL);
 	}
 }
@@ -497,7 +493,7 @@ static void ttriggered_work_cancel(const void *data)
 	zassert_true(ret == 0, NULL);
 
 	/**TESTPOINT: check pending after triggerd work cancel*/
-	ret = k_work_pending((struct k_work *)&triggered_work[0]);
+	ret = k_work_pending(&triggered_work[0].work);
 	zassert_true(ret == 0, NULL);
 
 	/* Trigger work #1 */
@@ -505,7 +501,7 @@ static void ttriggered_work_cancel(const void *data)
 	zassert_true(ret == 0, NULL);
 
 	/**TESTPOINT: check pending after sending signal */
-	ret = k_work_pending((struct k_work *)&triggered_work[1]);
+	ret = k_work_pending(&triggered_work[1].work);
 	zassert_true(ret != 0, NULL);
 
 	/**TESTPOINT: triggered work cancel when pending for event*/
@@ -521,7 +517,7 @@ static void ttriggered_work_cancel(const void *data)
 		k_msleep(2 * TIMEOUT_MS);
 
 		/**TESTPOINT: check pending when work completed*/
-		ret = k_work_pending((struct k_work *)&triggered_work_sleepy);
+		ret = k_work_pending(&triggered_work_sleepy.work);
 		zassert_true(ret == 0, NULL);
 
 		/**TESTPOINT: delayed work cancel when completed*/

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -161,6 +161,8 @@ void test_sched_delayed_work_item(void)
 	 * only after specific period of time
 	 */
 	k_delayed_work_init(&work_item_delayed, common_work_handler);
+	/* align to tick before schedule */
+	k_usleep(1);
 	start_time = k_cycle_get_32();
 	k_delayed_work_submit_to_queue(&workq, &work_item_delayed, TIMEOUT);
 	ms_remain = k_delayed_work_remaining_get(&work_item_delayed);
@@ -262,6 +264,8 @@ static void twork_submit_multipleq(void *data)
 	zassert_equal(k_delayed_work_cancel(&new_work),
 		      -EINVAL, NULL);
 
+	/* align to tick before schedule */
+	k_usleep(1);
 	k_delayed_work_submit_to_queue(work_q, &new_work, TIMEOUT);
 	zassert_true(k_delayed_work_pending(&new_work), NULL);
 
@@ -388,6 +392,10 @@ static void tdelayed_work_submit_1(struct k_work_q *work_q,
 	/**TESTPOINT: check remaining timeout before submit*/
 	zassert_equal(k_delayed_work_remaining_get(w), 0, NULL);
 
+	/* align to tick before schedule */
+	if (!k_is_in_isr()) {
+		k_usleep(1);
+	}
 	if (work_q) {
 		/**TESTPOINT: delayed work submit to queue*/
 		zassert_true(k_delayed_work_submit_to_queue(work_q, w, TIMEOUT)
@@ -434,6 +442,10 @@ static void tdelayed_work_cancel(const void *data)
 	k_delayed_work_init(&delayed_work[0], work_handler);
 	k_delayed_work_init(&delayed_work[1], work_handler);
 
+	/* align to tick before schedule */
+	if (!k_is_in_isr()) {
+		k_usleep(1);
+	}
 	if (work_q) {
 		ret = k_delayed_work_submit_to_queue(work_q,
 						     &delayed_work_sleepy,


### PR DESCRIPTION
This is an alternative to #28579 that does not change the existing behavior related to cancelling delayed work items, but does update the documentation to describe that behavior as accurately as possible, including more about its limitations.

It also fixes a minor race condition and extends the tests to improve coverage and verify the return values in cases where the states can be observed.  This increases coverage of kernel/work_q to 100%.