### PR TITLE
drivers: modem: ublox-sara-r4: fix socket descriptor leak

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1216,15 +1216,13 @@ static int offload_close(void *obj)
 		return 0;
 	}
 
-	if (sock->is_connected || sock->ip_proto == IPPROTO_UDP) {
-		snprintk(buf, sizeof(buf), "AT+USOCL=%d", sock->id);
+	snprintk(buf, sizeof(buf), "AT+USOCL=%d", sock->id);
 
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
-				     NULL, 0U, buf,
-				     &mdata.sem_response, MDM_CMD_TIMEOUT);
-		if (ret < 0) {
-			LOG_ERR("%s ret:%d", log_strdup(buf), ret);
-		}
+	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
+			     NULL, 0U, buf,
+			     &mdata.sem_response, MDM_CMD_TIMEOUT);
+	if (ret < 0) {
+		LOG_WRN("%s ret:%d", log_strdup(buf), ret);
 	}
 
 	modem_socket_put(&mdata.socket_config, sock->sock_fd);


### PR DESCRIPTION
A TCP socket is only closed with +USOCL if the socket is in the
connected state. It is valid to call `close()` on a socket which is
not connected, but in this case the underlying descriptor in the modem
will not be released. This leads to a leak in sockets and eventual
exhaustion.

Issuing the +USOCL command unconditionally lets us avoid corner cases
and allows for the module to check validity.

Addresses #26819

Signed-off-by: Adam Porter <porter.adam@gmail.com>