### PR TITLE
Bluetooth: shell: Fix PER SYNC conditional compilation 

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1377,6 +1377,8 @@ static int cmd_per_adv_data(const struct shell *shell, size_t argc,
 	return 0;
 }
 #endif /* CONFIG_BT_PER_ADV */
+#endif /* CONFIG_BT_EXT_ADV */
+#endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 static struct bt_le_per_adv_sync *per_adv_syncs[CONFIG_BT_PER_ADV_SYNC_MAX];
@@ -1538,8 +1540,6 @@ static int cmd_per_adv_sync_delete(const struct shell *shell, size_t argc,
 	return 0;
 }
 #endif /* CONFIG_BT_PER_ADV_SYNC */
-#endif /* CONFIG_BT_EXT_ADV */
-#endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
@@ -2781,7 +2781,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      "[<interval-min> [<interval-max> [tx_power]]]",
 		      cmd_per_adv_param, 1, 3),
 	SHELL_CMD_ARG(per-adv-data, NULL, "<data>", cmd_per_adv_data, 2, 0),
-#endif
+#endif /* CONFIG_BT_PER_ADV */
+#endif /* CONFIG_BT_EXT_ADV */
+#endif /* CONFIG_BT_BROADCASTER */
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 	SHELL_CMD_ARG(per-adv-sync-create, NULL,
 		      HELP_ADDR_LE " <sid> [skip <count>] [timeout <ms>] [aoa] "
@@ -2790,8 +2792,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(per-adv-sync-delete, NULL, "[<index>]",
 		      cmd_per_adv_sync_delete, 1, 1),
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
-#endif
-#endif /* CONFIG_BT_BROADCASTER */
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
 	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE EXT_ADV_SCAN_OPT,


### PR DESCRIPTION
Fix conditional compilation to allow building test shell
with Periodic Advertising Sync alone.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>