### PR TITLE
boards: arm: adafruit_feather_nrf52840: use dual mode for QSPI NOR

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -95,10 +95,13 @@
 	io-pins = <17>, <22>, <23>, <21>;
 	csn-pins = <20>;
 	gd25q16: gd25q16@0 {
+		/* NOTE: Quad mode not supported as driver does not handle
+		 * QE bit setting in SR2. Ref. GD25Q16C, Rev 3.0, p. 12.
+		 */
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
-		writeoc = "pp4io";
-		readoc = "read4io";
+		writeoc = "pp2o";
+		readoc = "read2io";
 		sck-frequency = <16000000>;
 		label = "GD25Q16";
 		jedec-id = [c8 40 15];


### PR DESCRIPTION
Right before #28631 was merged the writeoc/readoc settings were ignored,
so the flash was actually working in single line mode. In turns out that
quad mode can't be used with this flash without setting the QE bit in
the status register, so until this is supported fall back to dual mode.

Fixes #28826 

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>