### PR TITLE
Shell enhance help command

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -49,8 +49,9 @@ static void shell_internal_help_print(const struct shell *shell)
 		return;
 	}
 
-	shell_help_cmd_print(shell);
-	shell_help_subcmd_print(shell);
+	shell_help_cmd_print(shell, &shell->ctx->active_cmd);
+	shell_help_subcmd_print(shell, &shell->ctx->active_cmd,
+				"Subcommands:\n");
 }
 
 /**

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -5,6 +5,7 @@
  */
 #include <shell/shell.h>
 #include "shell_utils.h"
+#include "shell_help.h"
 #include "shell_ops.h"
 #include "shell_vt100.h"
 
@@ -290,11 +291,14 @@ static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 		" for more information.");
 #if defined(CONFIG_SHELL_METAKEYS)
 	shell_print(shell,
-		"Shell supports following meta-keys:\n"
+		"\nShell supports following meta-keys:\n"
 		"Ctrl+a, Ctrl+b, Ctrl+c, Ctrl+d, Ctrl+e, Ctrl+f, Ctrl+k,"
 		" Ctrl+l, Ctrl+n, Ctrl+p, Ctrl+u, Ctrl+w\nAlt+b, Alt+f.\n"
 		"Please refer to shell documentation for more details.");
 #endif
+
+	/* For NULL argument function will print all root commands */
+	shell_help_subcmd_print(shell, NULL, "\nAvailable commands:\n");
 
 	return 0;
 }

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -142,13 +142,14 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	formatted_text_print(shell, item_help, offset, false);
 }
 
-/* Function is printing command help, its subcommands name and subcommands
- * help string.
+/* Function prints all subcommands of the parent command together with their
+ * help string
  */
-void shell_help_subcmd_print(const struct shell *shell)
+void shell_help_subcmd_print(const struct shell *shell,
+			     const struct shell_static_entry *parent,
+			     const char *description)
 {
 	const struct shell_static_entry *entry = NULL;
-	const struct shell_static_entry *parent = &shell->ctx->active_cmd;
 	struct shell_static_entry dloc;
 	uint16_t longest = 0U;
 	size_t idx = 0;
@@ -163,7 +164,9 @@ void shell_help_subcmd_print(const struct shell *shell)
 		return;
 	}
 
-	shell_internal_fprintf(shell, SHELL_NORMAL, "Subcommands:\n");
+	if (description != NULL) {
+		shell_internal_fprintf(shell, SHELL_NORMAL, description);
+	}
 
 	/* Printing subcommands and help string (if exists). */
 	idx = 0;
@@ -173,16 +176,16 @@ void shell_help_subcmd_print(const struct shell *shell)
 	}
 }
 
-void shell_help_cmd_print(const struct shell *shell)
+void shell_help_cmd_print(const struct shell *shell,
+			  const struct shell_static_entry *cmd)
 {
-	static const char cmd_sep[] = " - ";	/* commands separator */
+	static const char cmd_sep[] = " - "; /* commands separator */
+	uint16_t field_width;
 
-	uint16_t field_width = shell_strlen(shell->ctx->active_cmd.syntax) +
-							  shell_strlen(cmd_sep);
+	field_width = shell_strlen(cmd->syntax) + shell_strlen(cmd_sep);
 
 	shell_internal_fprintf(shell, SHELL_NORMAL, "%s%s",
-			       shell->ctx->active_cmd.syntax, cmd_sep);
+				cmd->syntax, cmd_sep);
 
-	formatted_text_print(shell, shell->ctx->active_cmd.help,
-			     field_width, false);
+	formatted_text_print(shell, cmd->help, field_width, false);
 }

--- a/subsys/shell/shell_help.h
+++ b/subsys/shell/shell_help.h
@@ -14,10 +14,13 @@ extern "C" {
 #endif
 
 /* Function is printing command help string. */
-void shell_help_cmd_print(const struct shell *shell);
+void shell_help_cmd_print(const struct shell *shell,
+			  const struct shell_static_entry *cmd);
 
-/* Function is printing subcommands help string. */
-void shell_help_subcmd_print(const struct shell *shell);
+/* Function is printing subcommands and help string. */
+void shell_help_subcmd_print(const struct shell *shell,
+			     const struct shell_static_entry *cmd,
+			     const char *description);
 
 /**
  * @}

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -248,13 +248,14 @@ const struct shell_static_entry *shell_cmd_get(
 					size_t idx,
 					struct shell_static_entry *dloc)
 {
-	__ASSERT_NO_MSG(dloc != NULL);
 	const struct shell_static_entry *res = NULL;
 
 	if (parent == NULL) {
 		return  (idx < shell_root_cmd_count()) ?
 				shell_root_cmd_get(idx)->u.entry : NULL;
 	}
+
+	__ASSERT_NO_MSG(dloc != NULL);
 
 	if (parent->subcmd) {
 		if (parent->subcmd->is_dynamic) {


### PR DESCRIPTION
To get a list of all supported shell commands user must hit the TAB button. It may be awkward on some terminal emulators.
This change enhances the help command in a way it will in addition print all supported commands.

Fixes: #28785
