### PR TITLE
samples: sockets: dumb_http_server: If send() fails, print errno

### DIFF
--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -119,7 +119,7 @@ void main(void)
 			int sent_len = send(client, data, len, 0);
 
 			if (sent_len == -1) {
-				printf("Error sending data to peer\n");
+				printf("Error sending data to peer, errno: %d\n", errno);
 				break;
 			}
 			data += sent_len;


### PR DESCRIPTION
Helps with debugging TCP stack issues.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>