### PR TITLE
Sanitycheck device-testing & CI related enhancements

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2139,9 +2139,12 @@ class ProjectBuilder(FilterBuilder):
                 })
 
         elif op == "cleanup":
-            self.cleanup_artifacts()
+            if self.device_testing:
+                self.cleanup_device_testing_artifacts()
+            else:
+                self.cleanup_artifacts()
 
-    def cleanup_artifacts(self):
+    def cleanup_artifacts(self, additional_keep=None):
         logger.debug("Cleaning up {}".format(self.instance.build_dir))
         allow = [
             'zephyr/.config',
@@ -2150,6 +2153,9 @@ class ProjectBuilder(FilterBuilder):
             'device.log',
             'recording.csv',
             ]
+
+        allow += additional_keep
+
         allow = [os.path.join(self.instance.build_dir, file) for file in allow]
 
         for dirpath, dirnames, filenames in os.walk(self.instance.build_dir, topdown=False):
@@ -2164,6 +2170,19 @@ class ProjectBuilder(FilterBuilder):
                     os.remove(path)
                 elif not os.listdir(path):
                     os.rmdir(path)
+
+    def cleanup_device_testing_artifacts(self):
+        logger.debug("Cleaning up for Device Testing {}".format(self.instance.build_dir))
+
+        keep = [
+            'CMakeCache.txt',
+            'zephyr/runners.yaml',
+            'zephyr/zephyr.hex',
+            'zephyr/zephyr.bin',
+            'zephyr/zephyr.elf',
+            ]
+
+        self.cleanup_artifacts(keep)
 
     def report_out(self):
         total_tests_width = len(str(self.suite.total_to_do))

--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2174,15 +2174,30 @@ class ProjectBuilder(FilterBuilder):
     def cleanup_device_testing_artifacts(self):
         logger.debug("Cleaning up for Device Testing {}".format(self.instance.build_dir))
 
-        keep = [
+        sanitizelist = [
             'CMakeCache.txt',
             'zephyr/runners.yaml',
+        ]
+        keep = [
             'zephyr/zephyr.hex',
             'zephyr/zephyr.bin',
             'zephyr/zephyr.elf',
             ]
 
+        keep += sanitizelist
+
         self.cleanup_artifacts(keep)
+
+        # sanitize paths so files are relocatable
+        for file in sanitizelist:
+            file = os.path.join(self.instance.build_dir, file)
+
+            with open(file, "rt") as fin:
+                data = fin.read()
+                data = data.replace(canonical_zephyr_base+"/", "")
+
+            with open(file, "wt") as fin:
+                fin.write(data)
 
     def report_out(self):
         total_tests_width = len(str(self.suite.total_to_do))

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1116,7 +1116,7 @@ def main():
     logger.info("%d test configurations selected, %d configurations discarded due to filters." %
                 (len(suite.instances), len(discards)))
 
-    if options.device_testing:
+    if options.device_testing and not options.build_only:
         print("\nDevice testing on:")
         hwm.dump(suite.connected_hardware, suite.selected_platforms)
         print("")
@@ -1191,7 +1191,7 @@ def main():
         coverage_tool.add_ignore_directory('samples')
         coverage_tool.generate(options.outdir)
 
-    if options.device_testing:
+    if options.device_testing and not options.build_only:
         print("\nHardware distribution summary:\n")
         table = []
         header = ['Board', 'ID', 'Counter']


### PR DESCRIPTION
Some enhancements related to using sanitycheck for device-testing and CI systems.

The idea here is that we'd have a builder CI system that only builds what tests are runnable via (`--device-testing --build-only -M`).  The `-M` will keep the minimal artifacts that we need to allow `--device-testing --test-only` to function on another system that has the HW/boards connected to it.