### PR TITLE
drivers: adc: Improve the default routine providing sampling intervals

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -92,10 +92,7 @@ static inline void adc_context_request_next_sampling(struct adc_context *ctx)
 #ifdef ADC_CONTEXT_USES_KERNEL_TIMER
 static inline void adc_context_enable_timer(struct adc_context *ctx)
 {
-	uint32_t interval_us = ctx->options.interval_us;
-	uint32_t interval_ms = ceiling_fraction(interval_us, 1000UL);
-
-	k_timer_start(&ctx->timer, K_NO_WAIT, K_MSEC(interval_ms));
+	k_timer_start(&ctx->timer, K_NO_WAIT, K_USEC(ctx->options.interval_us));
 }
 
 static inline void adc_context_disable_timer(struct adc_context *ctx)


### PR DESCRIPTION
This part of common code for ADC drivers, the adc_context_enable_timer()
function, was still converting sampling interval values to milliseconds
(the only option available at the time this code has been created) when
setting up the kernel timer, consequently limiting the maximum sampling
frequency to 1000 samples per second. This patch switches the routine
to specifying the interval in microseconds, to remove this limitation.

Addresses #28469.