### PR TITLE
include/devicetree.h: Add DT_ENUM_IDX_OR macro

### DIFF
--- a/dts/bindings/test/vnd,enum-int-required-false-holder.yaml
+++ b/dts/bindings/test/vnd,enum-int-required-false-holder.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container
+
+compatible: "vnd,enum-int-required-false-holder"
+
+include: [base.yaml]
+
+properties:
+  val:
+    type: int
+    required: false
+    enum:
+      - 5
+      - 6
+      - 7
+      - 8

--- a/dts/bindings/test/vnd,enum-required-false-holder.yaml
+++ b/dts/bindings/test/vnd,enum-required-false-holder.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container
+
+compatible: "vnd,enum-required-false-holder"
+
+include: [base.yaml]
+
+properties:
+  val:
+    type: string
+    required: false
+    enum:
+      - "zero"
+      - "one"
+      - "two"

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -531,6 +531,24 @@
  */
 #define DT_ENUM_IDX(node_id, prop) DT_PROP(node_id, prop##_ENUM_IDX)
 
+/**
+ * @brief Like DT_ENUM_IDX(), but with a fallback to a default enum index
+ *
+ * If the value exists, this expands to its zero based index value thanks to
+ * DT_ENUM_IDX(node_id, prop).
+ *
+ * Otherwise, this expands to provided default index enum value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param default_idx_value a fallback index value to expand to
+ * @return zero-based index of the property's value in its enum if present,
+ *         default_idx_value ohterwise
+ */
+#define DT_ENUM_IDX_OR(node_id, prop, default_idx_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		    (DT_ENUM_IDX(node_id, prop)), (default_idx_value))
+
 /*
  * phandle properties
  *

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -54,6 +54,24 @@
 			val = "two";
 		};
 
+		test_enum_default_0: enum-2 {
+			compatible = "vnd,enum-required-false-holder";
+			val = "one";
+		};
+
+		test_enum_default_1: enum-3 {
+			compatible = "vnd,enum-required-false-holder";
+		};
+
+		test_enum_int_default_0: enum-4 {
+			compatible = "vnd,enum-int-required-false-holder";
+			val = < 5 >;
+		};
+
+		test_enum_int_default_1: enum-5 {
+			compatible = "vnd,enum-int-required-false-holder";
+		};
+
 		/*
 		 * This should be the only node with this
 		 * compatible in the tree.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1396,6 +1396,22 @@ static void test_enums(void)
 	zassert_equal(DT_ENUM_IDX(DT_NODELABEL(test_enum_0), val), 0, "0");
 }
 
+static void test_enums_required_false(void)
+{
+	/* DT_ENUM_IDX_OR on string value */
+	zassert_equal(DT_ENUM_IDX_OR(DT_NODELABEL(test_enum_default_0), val, 2),
+		      1, "1");
+	zassert_equal(DT_ENUM_IDX_OR(DT_NODELABEL(test_enum_default_1), val, 2),
+		      2, "2");
+	/* DT_ENUM_IDX_OR on int value */
+	zassert_equal(DT_ENUM_IDX_OR(DT_NODELABEL(test_enum_int_default_0),
+				     val, 4),
+		      0, "0");
+	zassert_equal(DT_ENUM_IDX_OR(DT_NODELABEL(test_enum_int_default_1),
+				     val, 4),
+		      4, "4");
+}
+
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_adc_temp_sensor
 static void test_clocks(void)
@@ -1561,6 +1577,7 @@ void test_main(void)
 			 ztest_unit_test(test_cs_gpios),
 			 ztest_unit_test(test_chosen),
 			 ztest_unit_test(test_enums),
+			 ztest_unit_test(test_enums_required_false),
 			 ztest_unit_test(test_clocks),
 			 ztest_unit_test(test_parent),
 			 ztest_unit_test(test_child_nodes_list),


### PR DESCRIPTION
In case a "required: False" enum binding doesn't mention a
default value, but a default value makes sense to be set in the code,
DT_ENUM_IDX_OR could be used to provide the default value to be used.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>