### PR TITLE
cmake: Remove extra quote when exporting compile options

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -237,7 +237,7 @@ function(zephyr_get_compile_options_for_lang lang i)
 
   process_flags(${lang} flags output_list)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-  set(result_output_list " $<JOIN:${genexp_output_list}, >")
+  set(result_output_list "$<JOIN:${genexp_output_list}, >")
 
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Fix #28844

I'm not fluent enough in CMake to explain why this space lead to #28844 but removing it seems to fix the issue. Also all other similar function don't have it