### PR TITLE
settings_fcb: initialize rc variable

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -306,7 +306,7 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 	struct settings_fcb *cf = (struct settings_fcb *)cs;
 	struct fcb_entry_ctx loc;
 	int len;
-	int rc;
+	int rc = -EINVAL;
 	int i;
 	uint8_t wbs;
 


### PR DESCRIPTION
Avoid warning about uninitialized variable.
The for loop should do at least two iterations
in a valid execution, hence initialize to an
error value.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>