### PR TITLE
dts/bindings/pinctrl: Remove usage of c comments within bindings

### DIFF
--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -37,11 +37,11 @@ child-binding:
             This macro is available here:
               -include/dt-bindings/pinctrl/stm32-pinctrl-common.h
             Some examples of macro usage:
-            /* GPIO A9 set as alernate function 2 */
+               GPIO A9 set as alernate function 2
             ... {
                      pinmux = <STM32_PINMUX('A', 9, AF2)>;
             };
-            /* GPIO A9 set as analog */
+               GPIO A9 set as analog
             ... {
                      pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
             };

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -41,15 +41,15 @@ child-binding:
             This macro is available here:
               -include/dt-bindings/pinctrl/stm32f1-pinctrl.h
             Some examples of macro usage:
-            /* GPIO A9 set as alernate with no remap */
+               GPIO A9 set as alernate with no remap
             ... {
                      pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_NO)>;
             };
-            /* GPIO A9 set as alernate with full remap */
+               GPIO A9 set as alernate with full remap
             ... {
                      pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_FULL)>;
             };
-            /* GPIO A9 set as input */
+               GPIO A9 set as input
             ... {
                      pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, REMAP_NO)>;
             };


### PR DESCRIPTION
Reused Linux bindings were using /*  */ in some property description
fields.
This is not compatible with legacy device tree api which expands
these fields in commented sections of generated file
devicetree_legacy_unfixed.h resulting in compilation issue.
Seen when running tests/lib/devicetree/legacy_api.

Remove /* */ for now waiting legacy api to be removed.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>