### PR TITLE
qemu_cortex_a53: Switch to GICv3

### DIFF
--- a/boards/arm/qemu_cortex_a53/board.cmake
+++ b/boards/arm/qemu_cortex_a53/board.cmake
@@ -8,6 +8,6 @@ set(QEMU_CPU_TYPE_${ARCH} cortex-a53)
 set(QEMU_FLAGS_${ARCH}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -nographic
-  -machine virt,secure=on
+  -machine virt,secure=on,gic-version=3
   )
 board_set_debugger_ifnset(qemu)

--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -40,8 +40,8 @@
 
 		gic: interrupt-controller@8000000 {
 			compatible = "arm,gic";
-			reg = <0x8000000 0x10000>,
-			      <0x8010000 0x10000>;
+			reg = <0x8000000 0x010000>,
+			      <0x80a0000 0xf60000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
 			label = "GIC";

--- a/soc/arm/qemu_cortex_a53/CMakeLists.txt
+++ b/soc/arm/qemu_cortex_a53/CMakeLists.txt
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+zephyr_sources_ifdef(CONFIG_SOC_QEMU_CORTEX_A53    plat_core.S)

--- a/soc/arm/qemu_cortex_a53/Kconfig.soc
+++ b/soc/arm/qemu_cortex_a53/Kconfig.soc
@@ -5,4 +5,4 @@ config SOC_QEMU_CORTEX_A53
 	bool "QEMU virt platform (cortex-a53)"
 	select ARM
 	select CPU_CORTEX_A53
-	select GIC_V2
+	select GIC_V3

--- a/soc/arm/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a53/mmu_regions.c
@@ -13,7 +13,12 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
-			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0) * 2,
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_RW | MT_SECURE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 			      MT_DEVICE_nGnRnE | MT_RW | MT_SECURE),
 
 	MMU_REGION_FLAT_ENTRY("UART",

--- a/soc/arm/qemu_cortex_a53/plat_core.S
+++ b/soc/arm/qemu_cortex_a53/plat_core.S
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ *@file
+ *@brief plat/core specific init
+*/
+
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <arch/cpu.h>
+
+_ASM_FILE_PROLOGUE
+
+GTEXT(z_arch_el3_plat_init)
+
+SECTION_FUNC(TEXT, z_arch_el3_plat_init)
+
+	mov	x20, x30
+
+#ifdef CONFIG_GIC_V3
+	/* Enable GIC v3 system interface */
+	mov_imm	x0, (ICC_SRE_ELx_DFB | ICC_SRE_ELx_DIB | \
+		     ICC_SRE_ELx_SRE | ICC_SRE_EL3_EN)
+	msr	ICC_SRE_EL3, x0
+#endif
+
+	mov	x30, x20
+	ret


### PR DESCRIPTION
We can switch to GICv3 by default for QEMU virt platforms. This is because the vast majority of the ARM64 platforms out there are supporting GICv3 and not GICv2.