### PR TITLE
net: tc: Remove not used field from net_traffic_class struct

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -392,9 +392,6 @@ struct net_traffic_class {
 
 	/** Stack for this work queue */
 	k_thread_stack_t *stack;
-
-	/** Traffic class value */
-	int tc;
 };
 
 /**

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -234,7 +234,6 @@ void net_tc_tx_init(void)
 		uint8_t thread_priority;
 
 		thread_priority = tx_tc2thread(i);
-		tx_classes[i].tc = thread_priority;
 
 		NET_DBG("[%d] Starting TX queue %p stack size %zd "
 			"prio %d (%d)", i,
@@ -264,7 +263,6 @@ void net_tc_rx_init(void)
 		uint8_t thread_priority;
 
 		thread_priority = rx_tc2thread(i);
-		rx_classes[i].tc = thread_priority;
 
 		NET_DBG("[%d] Starting RX queue %p stack size %zd "
 			"prio %d (%d)", i,


### PR DESCRIPTION
The "tc" field which was holding the traffic class thread
priority is not used nor needed so remove it from the struct
to save some space.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>