### PR TITLE
CODEOWNERS: add Andries to bluetooth/controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -478,7 +478,7 @@
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
-/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
+/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/canbus/                           @alexanderwachter
 /subsys/cpp/                              @pabigot @vanwinkeljan


### PR DESCRIPTION
Added myself as codeowner to the bluetooth/controller project so that I get automatically added as reviewer

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>