### PR TITLE
Bluetooth: controller: HCI stubs for BIG commands

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1450,6 +1450,24 @@ struct bt_hci_cp_le_create_big {
 } __packed;
 
 #define BT_HCI_OP_LE_CREATE_BIG_TEST            BT_OP(BT_OGF_LE, 0x0069)
+struct bt_hci_cp_le_create_big_test {
+	uint8_t  big_handle;
+	uint8_t  adv_handle;
+	uint8_t  num_bis;
+	uint8_t  sdu_interval[3];
+	uint16_t iso_interval;
+	uint8_t  nse;
+	uint16_t max_sdu;
+	uint16_t max_pdu;
+	uint8_t  phy;
+	uint8_t  packing;
+	uint8_t  framing;
+	uint8_t  bn;
+	uint8_t  irc;
+	uint8_t  pto;
+	uint8_t  encryption;
+	uint8_t  bcode[16];
+} __packed;
 
 #define BT_HCI_OP_LE_TERMINATE_BIG              BT_OP(BT_OGF_LE, 0x006a)
 struct bt_hci_cp_le_terminate_big {
@@ -2059,6 +2077,23 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  sca;
 } __packed;
 
+#define BT_HCI_EVT_LE_BIGINFO_ADV_REPORT        0x22
+struct bt_hci_evt_le_biginfo_adv_report {
+	uint16_t sync_handle;
+	uint8_t  num_bis;
+	uint8_t  nse;
+	uint16_t iso_interval;
+	uint8_t  bn;
+	uint8_t  pto;
+	uint8_t  irc;
+	uint16_t max_pdu;
+	uint8_t  sdu_interval[3];
+	uint16_t max_sdu;
+	uint8_t  phy;
+	uint8_t  framing;
+	uint8_t  encryption;
+} __packed;
+
 /* Event mask bits */
 
 #define BT_EVT_BIT(n) (1ULL << (n))
@@ -2141,8 +2176,13 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 #define BT_EVT_MASK_LE_CIS_ESTABLISHED           BT_EVT_BIT(24)
 #define BT_EVT_MASK_LE_CIS_REQ                   BT_EVT_BIT(25)
 #define BT_EVT_MASK_LE_BIG_COMPLETE              BT_EVT_BIT(26)
-#define BT_EVT_MASK_LE_BIG_SYNC_LOST             BT_EVT_BIT(27)
-#define BT_EVT_MASK_LE_REQ_PEER_SCA_COMPLETE     BT_EVT_BIT(28)
+#define BT_EVT_MASK_LE_BIG_TERMINATED            BT_EVT_BIT(27)
+#define BT_EVT_MASK_LE_BIG_SYNC_ESTABLISHED      BT_EVT_BIT(28)
+#define BT_EVT_MASK_LE_BIG_SYNC_LOST             BT_EVT_BIT(29)
+#define BT_EVT_MASK_LE_REQ_PEER_SCA_COMPLETE     BT_EVT_BIT(30)
+#define BT_EVT_MASK_LE_PATH_LOSS_THRESHOLD       BT_EVT_BIT(31)
+#define BT_EVT_MASK_LE_TRANSMIT_POWER_REPORTING  BT_EVT_BIT(32)
+#define BT_EVT_MASK_LE_BIGINFO_ADV_REPORT        BT_EVT_BIT(33)
 
 /** Allocate a HCI command buffer.
   *

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -34,6 +34,9 @@ if(CONFIG_BT_LL_SW_SPLIT)
       CONFIG_BT_CTLR_ADV_PERIODIC
       ll_sw/ull_adv_sync.c
       )
+    zephyr_library_sources(
+      ll_sw/ull_adv_iso.c
+      )
   endif()
   if(CONFIG_BT_OBSERVER)
     zephyr_library_sources(
@@ -46,6 +49,9 @@ if(CONFIG_BT_LL_SW_SPLIT)
     zephyr_library_sources_ifdef(
       CONFIG_BT_CTLR_SYNC_PERIODIC
       ll_sw/ull_sync.c
+      )
+    zephyr_library_sources(
+      ll_sw/ull_sync_iso.c
       )
   endif()
   if(CONFIG_BT_CONN)

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -34,7 +34,8 @@ if(CONFIG_BT_LL_SW_SPLIT)
       CONFIG_BT_CTLR_ADV_PERIODIC
       ll_sw/ull_adv_sync.c
       )
-    zephyr_library_sources(
+    zephyr_library_sources_ifdef(
+      CONFIG_BT_CTLR_ADV_ISO
       ll_sw/ull_adv_iso.c
       )
   endif()
@@ -50,7 +51,8 @@ if(CONFIG_BT_LL_SW_SPLIT)
       CONFIG_BT_CTLR_SYNC_PERIODIC
       ll_sw/ull_sync.c
       )
-    zephyr_library_sources(
+    zephyr_library_sources_ifdef(
+      CONFIG_BT_CTLR_SYNC_ISO
       ll_sw/ull_sync_iso.c
       )
   endif()

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -49,6 +49,14 @@ config BT_CTLR_SYNC_PERIODIC_SUPPORT
 	depends on BT_CTLR_ADV_EXT_SUPPORT
 	bool
 
+config BT_CTLR_ADV_ISO_SUPPORT
+	depends on BT_CTLR_ADV_PERIODIC_SUPPORT
+	bool
+
+config BT_CTLR_SYNC_ISO_SUPPORT
+	depends on BT_CTLR_SYNC_PERIODIC_SUPPORT
+	bool
+
 config BT_CTLR_CHAN_SEL_2_SUPPORT
 	bool
 
@@ -427,6 +435,28 @@ config BT_CTLR_SYNC_PERIODIC
 
 config BT_CTLR_SYNC_PERIODIC
 	bool "LE Periodic Advertising in Synchronization State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+
+config BT_CTLR_ADV_ISO
+	bool "LE Broadcast Isochronous Channel advertising" if !BT_LL_SW_SPLIT
+	depends on BT_BROADCASTER && BT_CTLR_ADV_ISO_SUPPORT
+	select BT_CTLR_ADV_PERIODIC
+	help
+	  Enable support for Bluetooth 5.2 LE Isochronous Advertising in the
+	  Controller.
+
+config BT_CTLR_ADV_ISO
+	bool "LE Broadcast Isochronous Channel advertising [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+
+config BT_CTLR_SYNC_ISO
+	bool "LE Broadcast Isochronous Channel advertising sync" if !BT_LL_SW_SPLIT
+	depends on BT_BROADCASTER && BT_CTLR_ADV_ISO_SUPPORT
+	select BT_CTLR_SYNC_PERIODIC
+	help
+	  Enable support for Bluetooth 5.2 LE Isochronous Advertising sync in
+	  the Controller.
+
+config BT_CTLR_SYNC_ISO
+	bool "LE Broadcast Isochronous Channel advertising sync [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 
 config BT_CTLR_ADV_DATA_LEN_MAX
 	int "Maximum Advertising Data Length"

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1067,6 +1067,7 @@ static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	*evt = cmd_complete_status(status);
 }
 
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
 static void le_create_big(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_create_big *cmd = (void *)buf->data;
@@ -1120,6 +1121,7 @@ static void le_terminate_big(struct net_buf *buf, struct net_buf **evt)
 
 	*evt = cmd_status(status);
 }
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -1167,6 +1169,7 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 	*evt = cmd_complete_status(status);
 }
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
 static void le_big_create_sync(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_big_create_sync *cmd = (void *)buf->data;
@@ -1194,6 +1197,7 @@ static void le_big_terminate_sync(struct net_buf *buf, struct net_buf **evt)
 
 	*evt = cmd_complete_status(status);
 }
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_CONN)
@@ -2355,6 +2359,7 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 		le_set_adv_enable(cmd, evt);
 		break;
 
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
 	case BT_OCF(BT_HCI_OP_LE_CREATE_BIG):
 		le_create_big(cmd, evt);
 		break;
@@ -2366,6 +2371,7 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 	case BT_OCF(BT_HCI_OP_LE_TERMINATE_BIG):
 		le_terminate_big(cmd, evt);
 		break;
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -2377,6 +2383,7 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 		le_set_scan_enable(cmd, evt);
 		break;
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
 	case BT_OCF(BT_HCI_OP_LE_BIG_CREATE_SYNC):
 		le_big_create_sync(cmd, evt);
 		break;
@@ -2384,6 +2391,7 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 	case BT_OCF(BT_HCI_OP_LE_BIG_TERMINATE_SYNC):
 		le_big_terminate_sync(cmd, evt);
 		break;
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 #endif /* CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -94,8 +94,21 @@ uint8_t ll_adv_enable(uint8_t handle, uint8_t enable,
 uint8_t ll_adv_enable(uint8_t enable);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_HCI_MESH_EXT */
 
+uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
+		      uint32_t sdu_interval, uint16_t max_sdu,
+		      uint16_t max_latency, uint8_t rtn, uint8_t phy,
+		      uint8_t packing, uint8_t framing, uint8_t encryption,
+		      uint8_t *bcode);
+uint8_t ll_big_test_create(uint8_t big_handle, uint8_t adv_handle,
+			   uint8_t num_bis, uint32_t sdu_interval,
+			   uint16_t iso_interval, uint8_t nse, uint16_t max_sdu,
+			   uint16_t max_pdu, uint8_t phy, uint8_t packing,
+			   uint8_t framing, uint8_t bn, uint8_t irc,
+			   uint8_t pto, uint8_t encryption, uint8_t *bcode);
+uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason);
+
 uint8_t ll_scan_params_set(uint8_t type, uint16_t interval, uint16_t window,
-			uint8_t own_addr_type, uint8_t filter_policy);
+		uint8_t own_addr_type, uint8_t filter_policy);
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 uint8_t ll_scan_enable(uint8_t enable); /* TODO: add duration and period */
 uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
@@ -104,6 +117,11 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 uint8_t ll_sync_create_cancel(void **rx);
 uint8_t ll_sync_terminate(uint16_t handle);
 uint8_t ll_sync_recv_enable(uint16_t handle, uint8_t enable);
+uint8_t ll_big_sync_create(uint8_t big_handle, uint16_t sync_handle,
+			   uint8_t encryption, uint8_t *bcode, uint8_t mse,
+			   uint16_t sync_timeout, uint8_t num_bis,
+			   uint8_t *bis);
+uint8_t ll_big_sync_terminate(uint8_t big_handle);
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 uint8_t ll_scan_enable(uint8_t enable);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_adv_iso
+#include "common/log.h"
+#include "hal/debug.h"
+
+uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
+		      uint32_t sdu_interval, uint16_t max_sdu,
+		      uint16_t max_latency, uint8_t rtn, uint8_t phy,
+		      uint8_t packing, uint8_t framing, uint8_t encryption,
+		      uint8_t *bcode)
+{
+	/* TODO: Implement */
+	ARG_UNUSED(big_handle);
+	ARG_UNUSED(adv_handle);
+	ARG_UNUSED(num_bis);
+	ARG_UNUSED(sdu_interval);
+	ARG_UNUSED(max_sdu);
+	ARG_UNUSED(max_latency);
+	ARG_UNUSED(rtn);
+	ARG_UNUSED(phy);
+	ARG_UNUSED(packing);
+	ARG_UNUSED(framing);
+	ARG_UNUSED(encryption);
+	ARG_UNUSED(bcode[16]);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+
+uint8_t ll_big_test_create(uint8_t big_handle, uint8_t adv_handle,
+			   uint8_t num_bis, uint32_t sdu_interval,
+			   uint16_t iso_interval, uint8_t nse, uint16_t max_sdu,
+			   uint16_t max_pdu, uint8_t phy, uint8_t packing,
+			   uint8_t framing, uint8_t bn, uint8_t irc,
+			   uint8_t pto, uint8_t encryption, uint8_t *bcode)
+{
+	/* TODO: Implement */
+	ARG_UNUSED(big_handle);
+	ARG_UNUSED(adv_handle);
+	ARG_UNUSED(num_bis);
+	ARG_UNUSED(sdu_interval);
+	ARG_UNUSED(iso_interval);
+	ARG_UNUSED(nse);
+	ARG_UNUSED(max_sdu);
+	ARG_UNUSED(max_pdu);
+	ARG_UNUSED(phy);
+	ARG_UNUSED(packing);
+	ARG_UNUSED(framing);
+	ARG_UNUSED(bn);
+	ARG_UNUSED(irc);
+	ARG_UNUSED(pto);
+	ARG_UNUSED(encryption);
+	ARG_UNUSED(bcode);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+
+uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
+{
+	/* TODO: Implement */
+	ARG_UNUSED(big_handle);
+	ARG_UNUSED(reason);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_sync_iso
+#include "common/log.h"
+#include "hal/debug.h"
+
+uint8_t ll_big_sync_create(uint8_t big_handle, uint16_t sync_handle,
+			   uint8_t encryption, uint8_t *bcode, uint8_t mse,
+			   uint16_t sync_timeout, uint8_t num_bis,
+			   uint8_t *bis)
+{
+	/* TODO: Implement */
+	ARG_UNUSED(big_handle);
+	ARG_UNUSED(sync_handle);
+	ARG_UNUSED(encryption);
+	ARG_UNUSED(bcode);
+	ARG_UNUSED(mse);
+	ARG_UNUSED(sync_timeout);
+	ARG_UNUSED(num_bis);
+	ARG_UNUSED(bis);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+
+
+uint8_t ll_big_sync_terminate(uint8_t big_handle)
+{
+	/* TODO: Implement */
+	ARG_UNUSED(big_handle);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}


### PR DESCRIPTION
Adds initial HCI stubs for the BIG commands to be used for
broadcast isochronous channels.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>