### PR TITLE
arch: posix: add missing include for cpuhalt.c

### DIFF
--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -21,6 +21,7 @@
  */
 
 #include "posix_core.h"
+#include "posix_board_if.h"
 #include <arch/posix/posix_soc_if.h>
 #include <tracing/tracing.h>
 


### PR DESCRIPTION
Add posix_board_if.h which declares posix_exit().

This fixes implicit declaration of function errors when running
sanitycheck on samples for native_posix that calls sys_reboot().

Signed-off-by: Mikkel Jakobsen <mikkel.aunsbjerg@prevas.dk>