### PR TITLE
NXP: LPC11U6x: fix GPIO base DT property

### DIFF
--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -97,6 +97,7 @@ struct gpio_lpc11u6x_config {
 	const struct gpio_lpc11u6x_shared *shared;
 	char *pinmux_name;
 	uint8_t port_num;
+	uint8_t base;
 	uint8_t ngpios;
 };
 
@@ -118,7 +119,7 @@ static int gpio_lpc11u6x_pin_configure(const struct device *port,
 	uint32_t func;
 	int ret;
 
-	if (pin >= config->ngpios) {
+	if (pin < config->base || pin >= config->ngpios) {
 		return -EINVAL;
 	}
 
@@ -329,7 +330,7 @@ static int gpio_lpc11u6x_pin_interrupt_configure(const struct device *port,
 	uint8_t intpin;
 	int irq;
 
-	if (pin >= config->ngpios) {
+	if (pin < config->base || pin >= config->ngpios) {
 		return -EINVAL;
 	}
 
@@ -593,6 +594,7 @@ static const struct gpio_lpc11u6x_config				\
 	.port_num = id,							\
 	.pinmux_name = DT_LABEL(DT_PHANDLE(DT_NODELABEL(gpio##id),	\
 				pinmux_port)),				\
+	.base = DT_PROP(DT_NODELABEL(gpio##id), base),			\
 	.ngpios = DT_PROP(DT_NODELABEL(gpio##id), ngpios),		\
 };									\
 									\

--- a/dts/arm/nxp/nxp_lpc11u6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc11u6x.dtsi
@@ -87,6 +87,7 @@
 			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
+			base = <0>;
 			ngpios = <24>;
 
 			clocks = <&syscon LPC11U6X_CLOCK_GPIO>;
@@ -105,6 +106,7 @@
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
+			base = <0>;
 
 			clocks = <&syscon LPC11U6X_CLOCK_GPIO>;
 			pinmux-port = <&pinmux1>;

--- a/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
@@ -22,8 +22,7 @@ properties:
 
     base:
       type: int
-      required: false
-      default: 0
+      required: true
       description: index of the first GPIO for this port.
 
     clocks:


### PR DESCRIPTION
This patch series:
- fixes the gpio_lpc11u6x driver to actually makes use of the GPIO "base" property.
- fixes the GPIO "base" DT property definition following the recommendation of @galak in [#PR28818](https://github.com/zephyrproject-rtos/zephyr/pull/28818).