### PR TITLE
[RFC] FS_SEEK_RET_POS flag added to allow fs_seek returning new position on success

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -131,7 +131,6 @@ struct fs_statvfs {
 	unsigned long f_bfree;
 };
 
-
 /**
  * @name fs_open open and creation mode flags
  * @{
@@ -173,6 +172,10 @@ struct fs_statvfs {
 #ifndef FS_SEEK_END
 /** Seek from the end of file */
 #define FS_SEEK_END	2
+#endif
+#ifndef FS_SEEK_RET_POS
+/** Return new file positoin on success; should be combined with other flags */
+#define FS_SEEK_RET_POS	8
 #endif
 /**
  * @}
@@ -295,16 +298,19 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
  *
  * @param zfp Pointer to the file object
  * @param offset Relative location to move the file pointer to
- * @param whence Relative location from where offset is to be calculated.
+ * @param whence Relative location from where offset is to be calculated:
  * - @c FS_SEEK_SET for the beginning of the file;
  * - @c FS_SEEK_CUR for the current position;
- * - @c FS_SEEK_END for the end of the file.
+ * - @c FS_SEEK_END for the end of the file;
  *
- * @retval 0 on success;
+ * When @p whence is combined with @c FS_SEEK_RET_POS flag, the function returns
+ * new position within file on success.
+ *
+ * @retval >=0 on success;
  * @retval -ENOTSUP if not supported by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
-int fs_seek(struct fs_file_t *zfp, off_t offset, int whence);
+off_t fs_seek(struct fs_file_t *zfp, off_t offset, int whence);
 
 /**
  * @brief Get current file position.

--- a/include/fs/fs_sys.h
+++ b/include/fs/fs_sys.h
@@ -46,7 +46,7 @@ struct fs_file_system_t {
 	ssize_t (*read)(struct fs_file_t *filp, void *dest, size_t nbytes);
 	ssize_t (*write)(struct fs_file_t *filp,
 					const void *src, size_t nbytes);
-	int (*lseek)(struct fs_file_t *filp, off_t off, int whence);
+	off_t (*lseek)(struct fs_file_t *filp, off_t off, int whence);
 	off_t (*tell)(struct fs_file_t *filp);
 	int (*truncate)(struct fs_file_t *filp, off_t length);
 	int (*sync)(struct fs_file_t *filp);

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -186,7 +186,7 @@ static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return bw;
 }
 
-static int fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
+static off_t fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 {
 	FRESULT res = FR_OK;
 	off_t pos;
@@ -210,6 +210,13 @@ static int fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 	}
 
 	res = f_lseek(zfp->filep, pos);
+	if (res >= 0) {
+		pos = f_tell((FIL *)zfp->filep);
+		if (pos < 0) {
+			return translate_error(pos);
+		}
+		return pos;
+	}
 
 	return translate_error(res);
 }

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -227,9 +227,9 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return rc;
 }
 
-int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
+off_t fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 {
-	int rc = -ENOTSUP;
+	off_t rc = -ENOTSUP;
 
 	if (zfp->mp == NULL) {
 		return -EBADF;
@@ -241,7 +241,11 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 
 	rc = zfp->mp->fs->lseek(zfp, offset, whence);
 	if (rc < 0) {
-		LOG_ERR("file seek error (%d)", rc);
+		LOG_ERR("file seek error (%ld)", (long)rc);
+	}
+
+	if (!(whence & FS_SEEK_RET_POS) && (rc > 0)) {
+		return 0;
 	}
 
 	return rc;

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -310,19 +310,19 @@ BUILD_ASSERT((FS_SEEK_SET == LFS_SEEK_SET)
 	     && (FS_SEEK_CUR == LFS_SEEK_CUR)
 	     && (FS_SEEK_END == LFS_SEEK_END));
 
-static int littlefs_seek(struct fs_file_t *fp, off_t off, int whence)
+static off_t littlefs_seek(struct fs_file_t *fp, off_t off, int whence)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
+
+	/* Remove FS_SEEK_RET_POS flag as it measn nothing for the LittleFS */
+	whence &= ~FS_SEEK_RET_POS;
 
 	fs_lock(fs);
 
 	off_t ret = lfs_file_seek(&fs->lfs, LFS_FILEP(fp), off, whence);
 
 	fs_unlock(fs);
-
-	if (ret >= 0) {
-		ret = 0;
-	}
+	printk("%lx %lx\n", off, ret);
 
 	return lfs_to_errno(ret);
 }

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -80,6 +80,7 @@ void test_main(void)
 			 ztest_unit_test(test_file_open),
 			 ztest_unit_test(test_file_write),
 			 ztest_unit_test(test_file_read),
+			 ztest_unit_test(test_file_seek),
 			 ztest_unit_test(test_file_truncate),
 			 ztest_unit_test(test_file_close),
 			 ztest_unit_test(test_file_sync),

--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -129,14 +129,14 @@ static ssize_t temp_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return bw;
 }
 
-static int temp_seek(struct fs_file_t *zfp, off_t offset, int whence)
+static off_t temp_seek(struct fs_file_t *zfp, off_t offset, int whence)
 {
 
 	if (!zfp) {
 		return -EINVAL;
 	}
 
-	switch (whence) {
+	switch (whence & ~FS_SEEK_RET_POS) {
 	case FS_SEEK_SET:
 		cur = buffer + offset;
 		break;
@@ -152,6 +152,10 @@ static int temp_seek(struct fs_file_t *zfp, off_t offset, int whence)
 
 	if ((cur < buffer) || (cur > buffer + file_length)) {
 		return -EINVAL;
+	}
+
+	if (whence & FS_SEEK_RET_POS) {
+		return cur - buffer;
 	}
 
 	return 0;

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -42,6 +42,7 @@ void test_lsdir(void);
 void test_file_open(void);
 void test_file_write(void);
 void test_file_read(void);
+void test_file_seek(void);
 void test_file_truncate(void);
 void test_file_close(void);
 void test_file_sync(void);

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -717,3 +717,50 @@ void test_file_unlink(void)
 
 	TC_PRINT("File (%s) deleted successfully!\n", TEST_FILE_RN);
 }
+
+/**
+ * @brief Check if fs_seek behaves as expected
+ *
+ * @ingroup filesystem_api
+ */
+void test_file_seek(void)
+{
+	off_t ret_s;
+	off_t ret_t;
+	off_t end;
+
+	TC_PRINT("\nSeek tests:\n");
+
+	ret_s = fs_seek(&filep, 0, FS_SEEK_SET | FS_SEEK_RET_POS);
+	zassert_true(ret_s == 0, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+
+	ret_s = fs_seek(&filep, 0, FS_SEEK_END | FS_SEEK_RET_POS);
+	zassert_true(ret_s > 0, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+	end = ret_t;
+
+	ret_s = fs_seek(&filep, -ret_t / 2, FS_SEEK_END | FS_SEEK_RET_POS);
+	zassert_true(ret_s > 0, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+
+	ret_s = fs_seek(&filep, -ret_t / 2, FS_SEEK_END | FS_SEEK_RET_POS);
+	zassert_true(ret_s > 0, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+
+	ret_s = fs_seek(&filep, end, FS_SEEK_SET | FS_SEEK_RET_POS);
+	zassert_true(ret_s == end, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+
+	ret_s = fs_seek(&filep, 0, FS_SEEK_SET | FS_SEEK_RET_POS);
+	zassert_true(ret_s == 0, "Failed to seek");
+	ret_s = fs_seek(&filep, end / 2, FS_SEEK_CUR | FS_SEEK_RET_POS);
+	zassert_true(ret_s == end / 2, "Failed to seek");
+	ret_t = fs_tell(&filep);
+	zassert_true(ret_t == ret_s, "Tell does not config seek");
+}


### PR DESCRIPTION
This is RFC to gather some input on the idea of adding `FS_SEEK_RET_POS` flag to `fs_seek`, that combined with other `FS_SEEK_* `identifier will make `fs_seek` return new position within file on success instead of 0.

The change unfortunately modifies API, because the return type of `fs_seek` needs to be changed from int to `off_t`.

