### PR TITLE
drivers: sensor: Use macro parameter to dereference device

### DIFF
--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -39,7 +39,7 @@ struct tach_xec_data {
 	  _dev->config))
 
 #define TACH_XEC_DATA(_dev)				\
-	((struct tach_xec_data *)dev->data)
+	((struct tach_xec_data *)_dev->data)
 
 
 int tach_xec_sample_fetch(struct device *dev, enum sensor_channel chan)


### PR DESCRIPTION
The TACH_XEC_DATA macro was not using its parameter
to retrieve the data structure.
It was working by chance so far.

Signed-off-by: Philémon Jaermann <p.jaermann@gmail.com>