### PR TITLE
dts: arm: stm32g474: add Xb and Xc variants

### DIFF
--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -5,3 +5,25 @@
  */
 
 #include <st/g4/stm32g431.dtsi>
+
+/ {
+	soc {
+		dac2: dac@50000c00 {
+			compatible = "st,stm32-dac";
+			reg = <0x50000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00020000>;
+			status = "disabled";
+			label = "DAC_2";
+			#io-channel-cells = <1>;
+		};
+
+		dac4: dac@50001400 {
+			compatible = "st,stm32-dac";
+			reg = <0x50001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00080000>;
+			status = "disabled";
+			label = "DAC_4";
+			#io-channel-cells = <1>;
+		};
+	};
+};

--- a/dts/arm/st/g4/stm32g474Xb.dtsi
+++ b/dts/arm/st/g4/stm32g474Xb.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 STMicroelectronics.
+ * Copyright (c) 2020 Libre Solar Technologies GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,7 @@
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
+				reg = <0x08000000 DT_SIZE_K(128)>;
 			};
 		};
 	};

--- a/dts/arm/st/g4/stm32g474Xc.dtsi
+++ b/dts/arm/st/g4/stm32g474Xc.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 STMicroelectronics.
+ * Copyright (c) 2020 Libre Solar Technologies GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,7 @@
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
+				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
 	};


### PR DESCRIPTION
Only difference compared to existing Xe variant is less flash memory.

Existing nodes for DAC were moved up one level to stm32g474.dtsi