### PR TITLE
kernel: workq: introduce delayable work

### DIFF
--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -147,4 +147,85 @@ bool k_delayed_work_pending(struct k_delayed_work *work)
 	       k_work_pending(&work->work);
 }
 
+static void work_delayable_timeout(struct _timeout *t)
+{
+	struct k_work_delayable *w = CONTAINER_OF(t, struct k_work_delayable,
+						   timeout);
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	struct k_work_q *wq = w->work_q;
+
+	w->work_q = NULL;
+	k_spin_unlock(&lock, key);
+
+	/* submit work to workqueue */
+	k_work_submit_to_queue(wq, &w->work);
+}
+
+void k_work_delayable_init(struct k_work_delayable *work, k_work_handler_t handler)
+{
+	k_work_init(&work->work, handler);
+	z_init_timeout(&work->timeout);
+	work->work_q = NULL;
+}
+
+int k_work_schedule_for_queue(struct k_work_q *work_q,
+			      struct k_work_delayable *work,
+			      k_timeout_t delay)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	int err = 0;
+
+	/* Verify work queue validity and cancel any incomplete
+	 * timeout.
+	 */
+	if (work->work_q != NULL) {
+		/* Work cannot be active in multiple queues */
+		if (work->work_q != work_q) {
+			err = -EBUSY;
+			goto unlock;
+		}
+
+		/* Cancel any incomplete timeout. */
+		z_abort_timeout(&work->timeout);
+		work->work_q = NULL;
+	}
+
+	/* If the timeout is no-wait, just submit it.  If it's already
+	 * pending its position will be unchanged.
+	 */
+	if (K_TIMEOUT_EQ(delay, K_NO_WAIT)) {
+		k_spin_unlock(&lock, key);
+		k_work_submit_to_queue(work_q, &work->work);
+		goto out;
+	}
+
+	/* Attach workqueue so the timeout callback can submit it */
+	work->work_q = work_q;
+
+#ifdef CONFIG_LEGACY_TIMEOUT_API
+	delay = _TICK_ALIGN + k_ms_to_ticks_ceil32(delay);
+#endif
+
+	/* Add timeout */
+	z_add_timeout(&work->timeout, work_delayable_timeout, delay);
+
+unlock:
+	k_spin_unlock(&lock, key);
+out:
+	return err;
+}
+
+int k_work_cancel(struct k_work_delayable *work)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	int ret = z_abort_timeout(&work->timeout);
+
+	if (ret != 0) {
+		ret = k_work_pending(&work->work) ? -EINPROGRESS : -EINVAL;
+	}
+
+	k_spin_unlock(&lock, key);
+	return ret;
+}
+
 #endif /* CONFIG_SYS_CLOCK_EXISTS */


### PR DESCRIPTION
**Current plan is to replace this PR with one based on the discussion at https://github.com/zephyrproject-rtos/zephyr/pull/28891#issuecomment-711024794**

**DNM blocker**: The commits that change existing use are here as examples and need to be removed before merge, so that the affected maintainers can consider how they want to solve the problems.

As a follow-on to #28579 this PR introduces a new API to support delayed submission of a work item to a work queue.  It conforms more closely to the original documented behavior of `k_delayed_work`: it does not allow cancel or submit to affect the state of an item after the timeout expires and the item is made pending.

The semantics and documentation depends on a distinction between scheduling work item submission, and performing work item submission.  The naming follows: `k_work_schedule` allows a delayable work item to be scheduled after a (possibly no-wait) delay, and `k_work_cancel` stops timeout countdown and works until the timeout complex and the item is submitted, after which the schedule API knows nothing about its state.

Except for the periods when a scheduled work item has an incomplete delay the behavior of delayable work matches the behavior of undelayable work.  This extends to the semantics when a delayable item that is already pending is scheduled with `K_NO_WAIT` (i.e. the item does not get moved to the end of the queue as it does with `k_delayed_work()`).

This replaces #28579 in resolving #27356 without breaking anything that depends on the existing behavior of the delayed work API.

