### PR TITLE
log_backend_fcb: Flash logging backend

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -15,6 +15,11 @@ if(NOT CONFIG_LOG_MINIMAL)
   )
 
   zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_FCB
+    log_backend_fcb.c
+  )
+
+  zephyr_sources_ifdef(
     CONFIG_LOG_CMDS
     log_cmds.c
   )

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -286,6 +286,62 @@ config LOG_BACKEND_UART
 	help
 	  When enabled backend is using UART to output logs.
 
+config LOG_BACKEND_FCB
+	bool "Enable flash backend"
+	depends on FCB
+	help
+	  When enabled backend is storing logs to flash.
+
+if LOG_BACKEND_FCB
+
+config LOG_BACKEND_FCB_FLASH_AREA_ID
+       int "The flash area used for logging"
+
+config LOG_BACKEND_FCB_SECTOR_COUNT
+       int "Number of flash sectors used for log"
+       help
+         Set number of flash sectors to be used by the log. Use more than one
+         to ensure latest log lines are always kept.
+
+config LOG_BACKEND_FCB_SECTOR1_OFFSET
+       int "Offset from start of flash area to sector 1"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR1_SIZE
+       int "Size of sector 1"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR2_OFFSET
+       int "Offset from start of flash area to sector 2"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR2_SIZE
+       int "Size of sector 2"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR3_OFFSET
+       int "Offset from start of flash area to sector 3"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR3_SIZE
+       int "Size of sector 3"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR4_OFFSET
+       int "Offset from start of flash area to sector 4"
+       default 0
+
+config LOG_BACKEND_FCB_SECTOR4_SIZE
+       int "Size of sector 4"
+       default 0
+
+config LOG_BACKEND_FCB_LINE_LEN
+       int "Max log line length. Longer lines are truncated in log."
+       default 128
+
+endif # LOG_BACKEND_FCB
+
+
 config LOG_BACKEND_UART_SYST_ENABLE
 	bool "Enable UART syst backend"
 	depends on LOG_BACKEND_UART

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -295,49 +295,49 @@ config LOG_BACKEND_FCB
 if LOG_BACKEND_FCB
 
 config LOG_BACKEND_FCB_FLASH_AREA_ID
-       int "The flash area used for logging"
+	int "The flash area used for logging"
 
 config LOG_BACKEND_FCB_SECTOR_COUNT
-       int "Number of flash sectors used for log"
-       help
-	 Set number of flash sectors to be used by the log. Use more than one
-	 to ensure latest log lines are always kept.
+	int "Number of flash sectors used for log"
+	help
+	  Set number of flash sectors to be used by the log. Use more than one
+	  to ensure latest log lines are always kept.
 
 config LOG_BACKEND_FCB_SECTOR1_OFFSET
-       int "Offset from start of flash area to sector 1"
-       default 0
+	int "Offset from start of flash area to sector 1"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR1_SIZE
-       int "Size of sector 1"
-       default 0
+	int "Size of sector 1"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR2_OFFSET
-       int "Offset from start of flash area to sector 2"
-       default 0
+	int "Offset from start of flash area to sector 2"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR2_SIZE
-       int "Size of sector 2"
-       default 0
+	int "Size of sector 2"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR3_OFFSET
-       int "Offset from start of flash area to sector 3"
-       default 0
+	int "Offset from start of flash area to sector 3"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR3_SIZE
-       int "Size of sector 3"
-       default 0
+	int "Size of sector 3"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR4_OFFSET
-       int "Offset from start of flash area to sector 4"
-       default 0
+	int "Offset from start of flash area to sector 4"
+	default 0
 
 config LOG_BACKEND_FCB_SECTOR4_SIZE
-       int "Size of sector 4"
-       default 0
+	int "Size of sector 4"
+	default 0
 
 config LOG_BACKEND_FCB_LINE_LEN
-       int "Max log line length. Longer lines are truncated in log."
-       default 128
+	int "Max log line length. Longer lines are truncated in log."
+	default 128
 
 endif # LOG_BACKEND_FCB
 

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -300,8 +300,8 @@ config LOG_BACKEND_FCB_FLASH_AREA_ID
 config LOG_BACKEND_FCB_SECTOR_COUNT
        int "Number of flash sectors used for log"
        help
-         Set number of flash sectors to be used by the log. Use more than one
-         to ensure latest log lines are always kept.
+	 Set number of flash sectors to be used by the log. Use more than one
+	 to ensure latest log lines are always kept.
 
 config LOG_BACKEND_FCB_SECTOR1_OFFSET
        int "Offset from start of flash area to sector 1"

--- a/subsys/logging/log_backend_fcb.c
+++ b/subsys/logging/log_backend_fcb.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2020 Xylem Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log_backend.h>
+#include <logging/log_core.h>
+#include <logging/log_msg.h>
+#include <logging/log_output.h>
+#include "log_backend_std.h"
+#include <fs/fcb.h>
+#include <assert.h>
+
+static struct flash_sector sectors[CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT] = {
+        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR1_OFFSET,
+          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR1_SIZE },
+#if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 2
+        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR2_OFFSET,
+          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR2_SIZE },
+#endif
+#if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 3
+        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR3_OFFSET,
+          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR3_SIZE },
+#endif
+#if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 4
+        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR4_OFFSET,
+          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR4_SIZE },
+#endif
+#if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 5
+#error "Max 4 log sectors are supported"
+#endif
+};
+
+static uint8_t buf[CONFIG_LOG_BACKEND_FCB_LINE_LEN];
+static struct fcb fcb = {
+        .f_magic = 0xfcb00106, /* "fcb log" */
+        .f_version = 1,
+        .f_sector_cnt = CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT,
+        .f_sectors = sectors,
+};
+
+static int store_line(uint8_t *data, size_t length, void *ctx)
+{
+        struct fcb_entry loc;
+        int rc;
+
+        /* format: [00:00:04.388,000] <inf> this is a log line */
+        /* store only <wrn> and <err> lines. */
+        /* search for < to manage with and without colours */
+        char *p = memchr(data, '<', length);
+        if (!p || (p[1] != 'e' && p[1] != 'w'))
+                return length;
+
+        while (1) {
+                rc = fcb_append(&fcb, length, &loc);
+                if (!rc) {
+                        break;
+                }
+                else if (rc == -ENOSPC) {
+                        rc = fcb_rotate(&fcb);
+                        if (rc) {
+                                printk("fcb_rotate() returned %d\n", rc);
+                                return length;
+                        }
+                }
+                else {
+                        printk("fcb_append() returned %d\n", rc);
+                        return length;
+                }
+        }
+        rc = flash_area_write(fcb.fap, FCB_ENTRY_FA_DATA_OFF(loc),
+                              data, length);
+        if (rc) {
+                printk("flash_area_write() returned %d\n", rc);
+                return length;
+        }
+
+        rc = fcb_append_finish(&fcb, &loc);
+        if (rc) {
+                printk("fcb_append_finish() returned %d\n", rc);
+                return length;
+        }
+
+        return length;
+}
+
+LOG_OUTPUT_DEFINE(log_output, store_line, buf, sizeof(buf));
+
+static void put(const struct log_backend *const backend,
+		struct log_msg *msg)
+{
+        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+
+        log_backend_std_put(&log_output, flag, msg);
+}
+
+static void print_old_lines(void)
+{
+        int corrupted = 0;
+        struct fcb_entry loc = {.fe_sector = NULL};
+        while (1) {
+                int rc;
+                rc = fcb_getnext(&fcb, &loc);
+                if (rc < 0) {
+                        if (rc == -ENOTSUP)
+                                break;
+                        printk("fcb_getnext() failed with rc %d\n", rc);
+                        break;
+                }
+
+                int len = MIN(sizeof(buf), loc.fe_data_len);
+                rc = flash_area_read(fcb.fap, loc.fe_data_off, buf, len);
+                if (rc < 0) {
+                        printk("flash_read_area(%d, %d) failed with rc %d\n",
+                               loc.fe_data_off, len, rc);
+                        break;
+                }
+                buf[len] = 0;
+                if (buf[0] == '[' && buf[3] == ':' && buf[17] == ']')
+                        printk("flog: %s", buf);
+                else
+                        corrupted++;
+        }
+        if (corrupted)
+                printk("flog: discarded %d corrupt log lines\n", corrupted);
+}
+
+static void log_backend_fcb_init(void)
+{
+        int rc;
+        struct fcb* fcbp = &fcb;
+
+        rc = fcb_init(CONFIG_LOG_BACKEND_FCB_FLASH_AREA_ID, fcbp);
+        if (rc && rc != -ENOMSG) {
+                printk("fcb_init() failed with rc %d\n", rc);
+                return;
+        }
+
+        print_old_lines();
+}
+
+static void panic(struct log_backend const *const backend)
+{
+        log_backend_std_panic(&log_output);
+}
+
+static void dropped(const struct log_backend *const backend, uint32_t cnt)
+{
+        ARG_UNUSED(backend);
+
+        log_backend_std_dropped(&log_output, cnt);
+}
+
+static void sync_string(const struct log_backend *const backend,
+                        struct log_msg_ids src_level, uint32_t timestamp,
+                        const char *fmt, va_list ap)
+{
+        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+
+        log_backend_std_sync_string(&log_output, flag, src_level,
+                                    timestamp, fmt, ap);
+}
+
+static void sync_hexdump(const struct log_backend *const backend,
+			 struct log_msg_ids src_level, uint32_t timestamp,
+			 const char *metadata, const uint8_t *data, uint32_t length)
+{
+        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+
+        log_backend_std_sync_hexdump(&log_output, flag, src_level,
+                                     timestamp, metadata, data, length);
+}
+
+const struct log_backend_api log_backend_fcb_api = {
+        .put = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : put,
+        .put_sync_string = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+        sync_string : NULL,
+        .put_sync_hexdump = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+        sync_hexdump : NULL,
+        .panic = panic,
+        .init = log_backend_fcb_init,
+        .dropped = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : dropped,
+};
+
+LOG_BACKEND_DEFINE(log_backend_fcb, log_backend_fcb_api, true);

--- a/subsys/logging/log_backend_fcb.c
+++ b/subsys/logging/log_backend_fcb.c
@@ -13,19 +13,19 @@
 #include <assert.h>
 
 static struct flash_sector sectors[CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT] = {
-        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR1_OFFSET,
-          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR1_SIZE },
+	{ .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR1_OFFSET,
+	  .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR1_SIZE },
 #if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 2
-        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR2_OFFSET,
-          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR2_SIZE },
+	{ .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR2_OFFSET,
+	  .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR2_SIZE },
 #endif
 #if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 3
-        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR3_OFFSET,
-          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR3_SIZE },
+	{ .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR3_OFFSET,
+	  .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR3_SIZE },
 #endif
 #if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 4
-        { .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR4_OFFSET,
-          .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR4_SIZE },
+	{ .fs_off = CONFIG_LOG_BACKEND_FCB_SECTOR4_OFFSET,
+	  .fs_size = CONFIG_LOG_BACKEND_FCB_SECTOR4_SIZE },
 #endif
 #if CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT >= 5
 #error "Max 4 log sectors are supported"
@@ -34,55 +34,55 @@ static struct flash_sector sectors[CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT] = {
 
 static uint8_t buf[CONFIG_LOG_BACKEND_FCB_LINE_LEN];
 static struct fcb fcb = {
-        .f_magic = 0xfcb00106, /* "fcb log" */
-        .f_version = 1,
-        .f_sector_cnt = CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT,
-        .f_sectors = sectors,
+	.f_magic = 0xfcb00106, /* "fcb log" */
+	.f_version = 1,
+	.f_sector_cnt = CONFIG_LOG_BACKEND_FCB_SECTOR_COUNT,
+	.f_sectors = sectors,
 };
 
 static int store_line(uint8_t *data, size_t length, void *ctx)
 {
-        struct fcb_entry loc;
-        int rc;
+	struct fcb_entry loc;
+	int rc;
 
-        /* format: [00:00:04.388,000] <inf> this is a log line */
-        /* store only <wrn> and <err> lines. */
-        /* search for < to manage with and without colours */
-        char *p = memchr(data, '<', length);
-        if (!p || (p[1] != 'e' && p[1] != 'w'))
-                return length;
+	/* format: [00:00:04.388,000] <inf> this is a log line */
+	/* store only <wrn> and <err> lines. */
+	/* search for < to manage with and without colours */
+	char *p = memchr(data, '<', length);
+	if (!p || (p[1] != 'e' && p[1] != 'w'))
+		return length;
 
-        while (1) {
-                rc = fcb_append(&fcb, length, &loc);
-                if (!rc) {
-                        break;
-                }
-                else if (rc == -ENOSPC) {
-                        rc = fcb_rotate(&fcb);
-                        if (rc) {
-                                printk("fcb_rotate() returned %d\n", rc);
-                                return length;
-                        }
-                }
-                else {
-                        printk("fcb_append() returned %d\n", rc);
-                        return length;
-                }
-        }
-        rc = flash_area_write(fcb.fap, FCB_ENTRY_FA_DATA_OFF(loc),
-                              data, length);
-        if (rc) {
-                printk("flash_area_write() returned %d\n", rc);
-                return length;
-        }
+	while (1) {
+		rc = fcb_append(&fcb, length, &loc);
+		if (!rc) {
+			break;
+		}
+		else if (rc == -ENOSPC) {
+			rc = fcb_rotate(&fcb);
+			if (rc) {
+				printk("fcb_rotate() returned %d\n", rc);
+				return length;
+			}
+		}
+		else {
+			printk("fcb_append() returned %d\n", rc);
+			return length;
+		}
+	}
+	rc = flash_area_write(fcb.fap, FCB_ENTRY_FA_DATA_OFF(loc),
+			      data, length);
+	if (rc) {
+		printk("flash_area_write() returned %d\n", rc);
+		return length;
+	}
 
-        rc = fcb_append_finish(&fcb, &loc);
-        if (rc) {
-                printk("fcb_append_finish() returned %d\n", rc);
-                return length;
-        }
+	rc = fcb_append_finish(&fcb, &loc);
+	if (rc) {
+		printk("fcb_append_finish() returned %d\n", rc);
+		return length;
+	}
 
-        return length;
+	return length;
 }
 
 LOG_OUTPUT_DEFINE(log_output, store_line, buf, sizeof(buf));
@@ -90,97 +90,97 @@ LOG_OUTPUT_DEFINE(log_output, store_line, buf, sizeof(buf));
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)
 {
-        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+	uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
 
-        log_backend_std_put(&log_output, flag, msg);
+	log_backend_std_put(&log_output, flag, msg);
 }
 
 static void print_old_lines(void)
 {
-        int corrupted = 0;
-        struct fcb_entry loc = {.fe_sector = NULL};
-        while (1) {
-                int rc;
-                rc = fcb_getnext(&fcb, &loc);
-                if (rc < 0) {
-                        if (rc == -ENOTSUP)
-                                break;
-                        printk("fcb_getnext() failed with rc %d\n", rc);
-                        break;
-                }
+	int corrupted = 0;
+	struct fcb_entry loc = {.fe_sector = NULL};
+	while (1) {
+		int rc;
+		rc = fcb_getnext(&fcb, &loc);
+		if (rc < 0) {
+			if (rc == -ENOTSUP)
+				break;
+			printk("fcb_getnext() failed with rc %d\n", rc);
+			break;
+		}
 
-                int len = MIN(sizeof(buf), loc.fe_data_len);
-                rc = flash_area_read(fcb.fap, loc.fe_data_off, buf, len);
-                if (rc < 0) {
-                        printk("flash_read_area(%d, %d) failed with rc %d\n",
-                               loc.fe_data_off, len, rc);
-                        break;
-                }
-                buf[len] = 0;
-                if (buf[0] == '[' && buf[3] == ':' && buf[17] == ']')
-                        printk("flog: %s", buf);
-                else
-                        corrupted++;
-        }
-        if (corrupted)
-                printk("flog: discarded %d corrupt log lines\n", corrupted);
+		int len = MIN(sizeof(buf), loc.fe_data_len);
+		rc = flash_area_read(fcb.fap, loc.fe_data_off, buf, len);
+		if (rc < 0) {
+			printk("flash_read_area(%d, %d) failed with rc %d\n",
+			       loc.fe_data_off, len, rc);
+			break;
+		}
+		buf[len] = 0;
+		if (buf[0] == '[' && buf[3] == ':' && buf[17] == ']')
+			printk("flog: %s", buf);
+		else
+			corrupted++;
+	}
+	if (corrupted)
+		printk("flog: discarded %d corrupt log lines\n", corrupted);
 }
 
 static void log_backend_fcb_init(void)
 {
-        int rc;
-        struct fcb* fcbp = &fcb;
+	int rc;
+	struct fcb* fcbp = &fcb;
 
-        rc = fcb_init(CONFIG_LOG_BACKEND_FCB_FLASH_AREA_ID, fcbp);
-        if (rc && rc != -ENOMSG) {
-                printk("fcb_init() failed with rc %d\n", rc);
-                return;
-        }
+	rc = fcb_init(CONFIG_LOG_BACKEND_FCB_FLASH_AREA_ID, fcbp);
+	if (rc && rc != -ENOMSG) {
+		printk("fcb_init() failed with rc %d\n", rc);
+		return;
+	}
 
-        print_old_lines();
+	print_old_lines();
 }
 
 static void panic(struct log_backend const *const backend)
 {
-        log_backend_std_panic(&log_output);
+	log_backend_std_panic(&log_output);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
-        ARG_UNUSED(backend);
+	ARG_UNUSED(backend);
 
-        log_backend_std_dropped(&log_output, cnt);
+	log_backend_std_dropped(&log_output, cnt);
 }
 
 static void sync_string(const struct log_backend *const backend,
-                        struct log_msg_ids src_level, uint32_t timestamp,
-                        const char *fmt, va_list ap)
+			struct log_msg_ids src_level, uint32_t timestamp,
+			const char *fmt, va_list ap)
 {
-        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+	uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
 
-        log_backend_std_sync_string(&log_output, flag, src_level,
-                                    timestamp, fmt, ap);
+	log_backend_std_sync_string(&log_output, flag, src_level,
+				    timestamp, fmt, ap);
 }
 
 static void sync_hexdump(const struct log_backend *const backend,
 			 struct log_msg_ids src_level, uint32_t timestamp,
 			 const char *metadata, const uint8_t *data, uint32_t length)
 {
-        uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
+	uint32_t flag = LOG_OUTPUT_FLAG_FORMAT_SYST;
 
-        log_backend_std_sync_hexdump(&log_output, flag, src_level,
-                                     timestamp, metadata, data, length);
+	log_backend_std_sync_hexdump(&log_output, flag, src_level,
+				     timestamp, metadata, data, length);
 }
 
 const struct log_backend_api log_backend_fcb_api = {
-        .put = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : put,
-        .put_sync_string = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
-        sync_string : NULL,
-        .put_sync_hexdump = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
-        sync_hexdump : NULL,
-        .panic = panic,
-        .init = log_backend_fcb_init,
-        .dropped = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : dropped,
+	.put = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : put,
+	.put_sync_string = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+		sync_string : NULL,
+	.put_sync_hexdump = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
+		sync_hexdump : NULL,
+	.panic = panic,
+	.init = log_backend_fcb_init,
+	.dropped = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ? NULL : dropped,
 };
 
 LOG_BACKEND_DEFINE(log_backend_fcb, log_backend_fcb_api, true);


### PR DESCRIPTION
# Flash logging backend

This is a flash logging backend. It uses FCB to write log entries in a circular flash buffer using a configurable number of flash sectors. It partially answers #25907.

The code works, but it raises some questions that need to be answered before it can be merged:

## Filtering
Flash is a limited medium, in storage capacity but especially in lifetime. Users of a flash log probably don't want to waste it on verbose logging, but rather save it for important log entries. The log backend therefore needs to be able to filter log entries on severity and possibly other factors. The below code includes rather a hacky filter based on looking for the `<wrn>` and `<err>` tokens in each log line. We should find a better way.

## Retrieval
A flash log differs from many other logs in that it is read at a differnt time and place than it is written. This means there needs to be an API for accessing the log at a future date. The below code simply prints all the stored log entries at each boot, prefixed with "flog:". This is obviously not perfect, and we need to think of a better way.

