### PR TITLE
drivers: serial: stm32: use generic LL headers 

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -28,6 +28,9 @@
 #include <drivers/clock_control/stm32_clock_control.h>
 #include "uart_stm32.h"
 
+#include <stm32_ll_usart.h>
+#include <stm32_ll_lpuart.h>
+
 #include <logging/log.h>
 LOG_MODULE_REGISTER(uart_stm32);
 

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -28,10 +28,6 @@
 #include <stm32f0xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f0xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f0xx_ll_utils.h>
 #include <stm32f0xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -28,10 +28,6 @@
 #include <stm32f1xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f1xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f1xx_ll_utils.h>
 #include <stm32f1xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -34,10 +34,6 @@
 #include <stm32f2xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f2xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32f2xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -29,10 +29,6 @@
 #include <stm32f3xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f3xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f3xx_ll_utils.h>
 #include <stm32f3xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f4xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f4xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_I2C_STM32
 #include <stm32f4xx_ll_i2c.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32f7xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_I2C_STM32
 #include <stm32f7xx_ll_i2c.h>
 #endif

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -55,11 +55,6 @@
 #include <stm32g0xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32g0xx_ll_usart.h>
-#include <stm32g0xx_ll_lpuart.h>
-#endif
-
 #ifdef CONFIG_HWINFO_STM32
 #include <stm32g0xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -43,11 +43,6 @@
 #include <stm32g4xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32g4xx_ll_usart.h>
-#include <stm32g4xx_ll_lpuart.h>
-#endif /* CONFIG_SERIAL_HAS_DRIVER */
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32g4xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -50,10 +50,6 @@
 #include <stm32h7xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32h7xx_ll_usart.h>
-#endif /* CONFIG_SERIAL_HAS_DRIVER */
-
 #if defined(CONFIG_HWINFO_STM32) || defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
 #include <stm32h7xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -29,11 +29,6 @@
 #include <stm32l0xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32l0xx_ll_usart.h>
-#include <stm32l0xx_ll_lpuart.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32l0xx_ll_utils.h>
 #include <stm32l0xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -31,10 +31,6 @@
 #include <stm32l1xx_ll_rcc.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32l1xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32l1xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -33,11 +33,6 @@
 #include <stm32l4xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32l4xx_ll_usart.h>
-#include <stm32l4xx_ll_lpuart.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32l4xx_ll_utils.h>
 #include <stm32l4xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -47,11 +47,6 @@
 #include <stm32l5xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32l5xx_ll_usart.h>
-#include <stm32l5xx_ll_lpuart.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L5_SOC_H_ */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -40,10 +40,6 @@
 #include <stm32mp1xx_ll_system.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32mp1xx_ll_usart.h>
-#endif
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32mp1xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -32,11 +32,6 @@
 #include <stm32wbxx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_SERIAL_HAS_DRIVER
-#include <stm32wbxx_ll_usart.h>
-#include <stm32wbxx_ll_lpuart.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32wbxx_ll_rtc.h>
 #include <stm32wbxx_ll_exti.h>


### PR DESCRIPTION
This PR is a proposal to improve LL HAL API usage by introducing generic LL headers. The full details of the proposal can be found in #28822. Companion PR: https://github.com/zephyrproject-rtos/hal_stm32/pull/68

Resolves #28822 