### PR TITLE
kernel: atomic: atomic ptr cleanup and documentation clarifications

### DIFF
--- a/doc/reference/kernel/other/atomic.rst
+++ b/doc/reference/kernel/other/atomic.rst
@@ -16,11 +16,17 @@ Concepts
 Any number of atomic variables can be defined.
 
 Using the kernel's atomic APIs to manipulate an atomic variable
-guarantees that the desired operation occurs correctly,
-even if higher priority contexts also manipulate the same variable.
+guarantees that the desired operation will have `sequentially-consistent
+ordering`_ with respect to all other atomic operations.  This means that
+even if atomic variables are accessed from different priority threads,
+interrupts, or (for SMP) other cores, the observable values and
+behaviors will be consistently ordered.
+
+.. _sequentially-consistent ordering:
+   https://en.cppreference.com/w/c/atomic/memory_order#Sequentially-consistent_ordering
 
 The kernel also supports the atomic manipulation of a single bit
-in an array of atomic variables.
+in an array of atomic variables with the same order guarantee.
 
 Implementation
 **************
@@ -28,7 +34,9 @@ Implementation
 Defining an Atomic Variable
 ===========================
 
-An atomic variable is defined using a variable of type :c:type:`atomic_t`.
+An atomic variable is defined using a variable of type
+:c:type:`atomic_t`.  The corresponding non-atomic value type is
+:c:type:`atomic_val_t`.
 
 By default an atomic variable is initialized to zero. However, it can be given
 a different value using :c:macro:`ATOMIC_INIT`:
@@ -36,6 +44,16 @@ a different value using :c:macro:`ATOMIC_INIT`:
 .. code-block:: c
 
     atomic_t flags = ATOMIC_INIT(0xFF);
+
+
+Zephyr also supports atomic values that store pointers, with atomic
+variable type :c:type:`atomic_ptr_t` and value type
+:c:type:`atomic_ptr_val_t` and initialization with
+:c:macro:`ATOMIC_PTR_INIT`:
+
+.. code-block:: c
+
+    atomic_ptr_t data = ATOMIC_PTR_INIT(&val1);
 
 Manipulating an Atomic Variable
 ===============================

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -22,6 +22,7 @@ extern "C" {
 typedef int atomic_t;
 typedef atomic_t atomic_val_t;
 typedef void *atomic_ptr_t;
+typedef atomic_ptr_t atomic_ptr_val_t;
 
 /**
  * @defgroup atomic_apis Atomic Services APIs
@@ -73,19 +74,20 @@ extern bool atomic_cas(atomic_t *target, atomic_val_t old_value,
  * @return true if @a new_value is written, false otherwise.
  */
 #ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
-static inline bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-				  void *new_value)
+static inline bool atomic_ptr_cas(atomic_ptr_t *target,
+				  atomic_ptr_val_t old_value,
+				  atomic_ptr_val_t new_value)
 {
 	return __atomic_compare_exchange_n(target, &old_value, new_value,
 					   0, __ATOMIC_SEQ_CST,
 					   __ATOMIC_SEQ_CST);
 }
 #elif defined(CONFIG_ATOMIC_OPERATIONS_C)
-__syscall bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-			      void *new_value);
+__syscall bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
+			      atomic_ptr_val_t new_value);
 #else
-extern bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-			   void *new_value);
+extern bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
+			   atomic_ptr_val_t new_value);
 #endif
 
 /**
@@ -200,12 +202,12 @@ extern atomic_val_t atomic_get(const atomic_t *target);
  * @return Value of @a target.
  */
 #ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
-static inline void *atomic_ptr_get(const atomic_ptr_t *target)
+static inline atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
 {
 	return __atomic_load_n(target, __ATOMIC_SEQ_CST);
 }
 #else
-extern void *atomic_ptr_get(const atomic_ptr_t *target);
+extern atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
 #endif
 
 /**
@@ -248,14 +250,17 @@ extern atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
  * @return Previous value of @a target.
  */
 #ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
-static inline void *atomic_ptr_set(atomic_ptr_t *target, void *value)
+static inline atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target,
+					      atomic_ptr_val_t value)
 {
 	return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
 }
 #elif defined(CONFIG_ATOMIC_OPERATIONS_C)
-__syscall void *atomic_ptr_set(atomic_ptr_t *target, void *value);
+__syscall atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target,
+					  atomic_ptr_val_t value);
 #else
-extern void *atomic_ptr_set(atomic_ptr_t *target, void *value);
+extern atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target,
+				       atomic_ptr_val_t value);
 #endif
 
 /**
@@ -291,12 +296,12 @@ extern atomic_val_t atomic_clear(atomic_t *target);
  */
 #if defined(CONFIG_ATOMIC_OPERATIONS_BUILTIN) || \
 	defined (CONFIG_ATOMIC_OPERATIONS_C)
-static inline void *atomic_ptr_clear(atomic_ptr_t *target)
+static inline atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target)
 {
 	return atomic_ptr_set(target, NULL);
 }
 #else
-extern void *atomic_ptr_clear(atomic_ptr_t *target);
+extern atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target);
 #endif
 
 /**
@@ -402,6 +407,17 @@ extern atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
  * @param i Value to assign to atomic variable.
  */
 #define ATOMIC_INIT(i) (i)
+
+/**
+ * @brief Initialize an atomic pointer variable.
+ *
+ * This macro can be used to initialize an atomic pointer variable. For
+ * example,
+ * @code atomic_ptr_t my_ptr = ATOMIC_PTR_INIT(&data); @endcode
+ *
+ * @param p Pointer value to assign to atomic pointer variable.
+ */
+#define ATOMIC_PTR_INIT(p) (p)
 
 /**
  * @cond INTERNAL_HIDDEN

--- a/kernel/atomic_c.c
+++ b/kernel/atomic_c.c
@@ -107,8 +107,8 @@ bool z_vrfy_atomic_cas(atomic_t *target, atomic_val_t old_value,
 #include <syscalls/atomic_cas_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-bool z_impl_atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-			   void *new_value)
+bool z_impl_atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
+			   atomic_ptr_val_t new_value)
 {
 	k_spinlock_key_t key;
 	int ret = false;
@@ -126,8 +126,9 @@ bool z_impl_atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
 }
 
 #ifdef CONFIG_USERSPACE
-static inline bool z_vrfy_atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-					 void *new_value)
+static inline bool z_vrfy_atomic_ptr_cas(atomic_ptr_t *target,
+					 atomic_ptr_val_t old_value,
+					 atomic_ptr_val_t new_value)
 {
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(target, sizeof(atomic_ptr_t)));
 
@@ -213,7 +214,7 @@ atomic_val_t atomic_get(const atomic_t *target)
 	return *target;
 }
 
-void *atomic_ptr_get(const atomic_ptr_t *target)
+atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
 {
 	return *target;
 }
@@ -247,10 +248,11 @@ atomic_val_t z_impl_atomic_set(atomic_t *target, atomic_val_t value)
 
 ATOMIC_SYSCALL_HANDLER_TARGET_VALUE(atomic_set);
 
-void *z_impl_atomic_ptr_set(atomic_ptr_t *target, void *value)
+atomic_ptr_val_t z_impl_atomic_ptr_set(atomic_ptr_t *target,
+				       atomic_ptr_val_t value)
 {
 	k_spinlock_key_t key;
-	void *ret;
+	atomic_ptr_val_t ret;
 
 	key = k_spin_lock(&lock);
 
@@ -263,7 +265,8 @@ void *z_impl_atomic_ptr_set(atomic_ptr_t *target, void *value)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void *z_vrfy_atomic_ptr_set(atomic_ptr_t *target, void *value)
+static inline atomic_ptr_val_t z_vrfy_atomic_ptr_set(atomic_ptr_t *target,
+						     atomic_ptr_val_t value)
 {
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(target, sizeof(atomic_ptr_t)));
 

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -47,12 +47,12 @@ void test_atomic(void)
 	zassert_true((target == value), "atomic_cas");
 
 	/* atomic_ptr_cas() */
-	ptr_target = (atomic_ptr_t)4;
-	ptr_value = (void *)5;
-	old_ptr_value = (void *)6;
+	ptr_target = ATOMIC_PTR_INIT((void *)4);
+	ptr_value = (atomic_ptr_val_t)5;
+	old_ptr_value = (atomic_ptr_val_t)6;
 	zassert_false(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
 		      "atomic_ptr_cas");
-	ptr_target = (void *)6;
+	ptr_target = (atomic_ptr_val_t)6;
 	zassert_true(atomic_ptr_cas(&ptr_target, old_ptr_value, ptr_value),
 		     "atomic_ptr_cas");
 	zassert_true((ptr_target == ptr_value), "atomic_ptr_cas");
@@ -84,8 +84,8 @@ void test_atomic(void)
 	zassert_true((atomic_get(&target) == 50), "atomic_get");
 
 	/* atomic_ptr_get() */
-	ptr_target = (atomic_ptr_t)50;
-	zassert_true((atomic_ptr_get(&ptr_target) == (void *)50),
+	ptr_target = ATOMIC_PTR_INIT((void *)50);
+	zassert_true((atomic_ptr_get(&ptr_target) == (atomic_ptr_val_t)50),
 		     "atomic_ptr_get");
 
 	/* atomic_set() */
@@ -95,9 +95,9 @@ void test_atomic(void)
 	zassert_true((target == value), "atomic_set");
 
 	/* atomic_ptr_set() */
-	ptr_target = (atomic_ptr_t)42;
-	ptr_value = (void *)77;
-	zassert_true((atomic_ptr_set(&ptr_target, ptr_value) == (void *)42),
+	ptr_target = ATOMIC_PTR_INIT((void *)42);
+	ptr_value = (atomic_ptr_val_t)77;
+	zassert_true((atomic_ptr_set(&ptr_target, ptr_value) == (atomic_ptr_val_t)42),
 		     "atomic_ptr_set");
 	zassert_true((ptr_target == ptr_value), "atomic_ptr_set");
 
@@ -107,8 +107,8 @@ void test_atomic(void)
 	zassert_true((target == 0), "atomic_clear");
 
 	/* atomic_ptr_clear() */
-	ptr_target = (atomic_ptr_t)100;
-	zassert_true((atomic_ptr_clear(&ptr_target) == (void *)100),
+	ptr_target = ATOMIC_PTR_INIT((void *)100);
+	zassert_true((atomic_ptr_clear(&ptr_target) == (atomic_ptr_val_t)100),
 		     "atomic_ptr_clear");
 	zassert_true((ptr_target == NULL), "atomic_ptr_clear");
 


### PR DESCRIPTION
Make atomic pointers parallel to atomic non-pointers by giving them a named type for the compatible non-atomic value and an init macro.

Update the user documentation to include the memory order consistency promise and note the existence of support for atomic pointers.

Closes  #28819