### PR TITLE
net: lib: http: chunked encoding body support

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -314,12 +314,6 @@ static int on_headers_complete(struct http_parser *parser)
 		return 1;
 	}
 
-	if ((req->method == HTTP_PUT || req->method == HTTP_POST) &&
-	    req->internal.response.content_length == 0) {
-		NET_DBG("No body expected");
-		return 1;
-	}
-
 	NET_DBG("Headers complete");
 
 	return 0;


### PR DESCRIPTION
The body shouldn't be ignore when the Transfer-Encoding is chunked

Signed-off-by: Jackie Ja <qazq.jackie@gmail.com>