### PR TITLE
Bluetooth: host: Don't use struct with zero size

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1231,7 +1231,6 @@ struct read_data {
 	struct bt_att_chan *chan;
 	uint16_t offset;
 	struct net_buf *buf;
-	struct bt_att_read_rsp *rsp;
 	uint8_t err;
 };
 
@@ -1244,8 +1243,6 @@ static uint8_t read_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	int ret;
 
 	BT_DBG("handle 0x%04x", handle);
-
-	data->rsp = net_buf_add(data->buf, sizeof(*data->rsp));
 
 	/*
 	 * If any attribute is founded in handle range it means that error
@@ -1400,8 +1397,6 @@ static uint8_t read_vl_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	int read;
 
 	BT_DBG("handle 0x%04x", handle);
-
-	data->rsp = net_buf_add(data->buf, sizeof(*data->rsp));
 
 	/*
 	 * If any attribute is founded in handle range it means that error
@@ -2316,7 +2311,7 @@ static const struct att_handler {
 		ATT_RESPONSE,
 		att_handle_find_info_rsp },
 	{ BT_ATT_OP_FIND_TYPE_RSP,
-		sizeof(struct bt_att_find_type_rsp),
+		sizeof(struct bt_att_handle_group),
 		ATT_RESPONSE,
 		att_handle_find_type_rsp },
 	{ BT_ATT_OP_READ_TYPE_RSP,
@@ -2324,16 +2319,16 @@ static const struct att_handler {
 		ATT_RESPONSE,
 		att_handle_read_type_rsp },
 	{ BT_ATT_OP_READ_RSP,
-		sizeof(struct bt_att_read_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_rsp },
 	{ BT_ATT_OP_READ_BLOB_RSP,
-		sizeof(struct bt_att_read_blob_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_blob_rsp },
 #if defined(CONFIG_BT_GATT_READ_MULTIPLE)
 	{ BT_ATT_OP_READ_MULT_RSP,
-		sizeof(struct bt_att_read_mult_rsp),
+		0,
 		ATT_RESPONSE,
 		att_handle_read_mult_rsp },
 #if defined(CONFIG_BT_EATT)

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -139,7 +139,7 @@ struct bt_att_read_mult_req {
 	uint16_t handles[0];
 } __packed;
 
-/* Read Multiple Respose */
+/* Read Multiple Response */
 #define BT_ATT_OP_READ_MULT_RSP			0x0f
 struct bt_att_read_mult_rsp {
 	uint8_t  value[0];


### PR DESCRIPTION
Don't use the ATT structs that has contains only a flexible array
member. This is not supported by C99 standard, only through GNU C
extension with zero length array.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>