### PR TITLE
queue: Fixed using incorrect init macro

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2194,7 +2194,7 @@ struct k_queue {
 
 #define Z_QUEUE_INITIALIZER(obj) \
 	{ \
-	.data_q = SYS_SLIST_STATIC_INIT(&obj.data_q), \
+	.data_q = SYS_SFLIST_STATIC_INIT(&obj.data_q), \
 	.lock = { }, \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q),	\
 	_POLL_EVENT_OBJ_INIT(obj)		\


### PR DESCRIPTION
k_queue uses a sflist.
The macro used for initialising the list is the slist not sflist macro.
This commit just changes the macro to use the sflist init macro.

Fixes #28912

Signed-off-by: Toby Firth <tobyjfirth@gmail.com>