### PR TITLE
net: l2: ppp: Remove ipcp address on network down

### DIFF
--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -366,6 +366,10 @@ static void ipcp_down(struct ppp_fsm *fsm)
 
 	ctx->is_ipcp_up = false;
 
+	if (!net_if_ipv4_addr_rm(ctx->iface, &ctx->ipcp.my_options.address)) {
+		NET_ERR("Failed removing address");
+	}
+
 	ppp_network_down(ctx, PPP_IP);
 }
 


### PR DESCRIPTION
Without removing the stale address obtained during IPCP, it will still
be present the next time we do IPCP, marked as "in use" by the network
stack even if it is stale. This turned out to be a showstopper for
restarting the PPP stack on devices without static IP.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>