### PR TITLE
SPI: Do not disable SPI peripheral while switching DMA buffers

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -730,7 +730,6 @@ static int transceive_dma(const struct device *dev,
 		while (LL_SPI_IsActiveFlag_BSY(spi) == 1) {
 		}
 
-		LL_SPI_Disable(spi);
 		LL_SPI_DisableDMAReq_TX(spi);
 		LL_SPI_DisableDMAReq_RX(spi);
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -686,9 +686,7 @@ static int transceive_dma(const struct device *dev,
 	/* This is turned off in spi_stm32_complete(). */
 	spi_context_cs_control(&data->ctx, true);
 
-	LL_SPI_DisableDMAReq_TX(spi);
-	LL_SPI_DisableDMAReq_RX(spi);
-	LL_SPI_Disable(spi);
+	LL_SPI_Enable(spi);
 
 	while (data->ctx.rx_len > 0 || data->ctx.tx_len > 0) {
 		size_t dma_len;
@@ -710,7 +708,6 @@ static int transceive_dma(const struct device *dev,
 
 		LL_SPI_EnableDMAReq_RX(spi);
 		LL_SPI_EnableDMAReq_TX(spi);
-		LL_SPI_Enable(spi);
 
 		ret = wait_dma_rx_tx_done(dev);
 		if (ret != 0) {


### PR DESCRIPTION
Removed SPI peripheral disabling when switching DMA to another buffer. When using hardware chip select this would cause to stop driving CS pin when swhitching buffers. This is different (and wrong) than when used software CS.

Fixes #28833

Signed-off-by: Łukasz Mazur <lukasz.mazur@hidglobal.com>