### PR TITLE
CODEOWNERS: Update CoAP codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -434,7 +434,7 @@
 /samples/net/dns_resolve/                 @jukkar @tbursztyka @pfalcon
 /samples/net/lwm2m_client/                @rlubos
 /samples/net/mqtt_publisher/              @jukkar @tbursztyka
-/samples/net/sockets/coap_*/              @rveerama1
+/samples/net/sockets/coap_*/              @rlubos
 /samples/net/sockets/                     @jukkar @tbursztyka @pfalcon
 /samples/sensor/                          @MaureenHelm
 /samples/shields/                         @avisconti
@@ -515,7 +515,7 @@
 /subsys/net/lib/lwm2m/                    @rlubos
 /subsys/net/lib/config/                   @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/mqtt/                     @jukkar @tbursztyka @rlubos
-/subsys/net/lib/coap/                     @rveerama1
+/subsys/net/lib/coap/                     @rlubos
 /subsys/net/lib/sockets/socketpair.c      @cfriedt
 /subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/tls_credentials/          @rlubos
@@ -559,7 +559,7 @@
 /tests/net/lib/                           @jukkar @tbursztyka @pfalcon
 /tests/net/lib/http_header_fields/        @jukkar @tbursztyka
 /tests/net/lib/mqtt_packet/               @jukkar @tbursztyka
-/tests/net/lib/coap/                      @rveerama1
+/tests/net/lib/coap/                      @rlubos
 /tests/net/socket/socketpair/             @cfriedt
 /tests/net/socket/                        @jukkar @tbursztyka @pfalcon
 /tests/subsys/debug/coredump/             @dcpleung


### PR DESCRIPTION
Set myself as the codeowner of the CoAP library.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>