### PR TITLE
scripts: dts: fix handling for phandle-arrays with *-cells=0

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1223,11 +1223,11 @@ class Node:
             # This type is a bit high-level for dtlib as it involves
             # information from bindings and *-names properties, so there's no
             # to_phandle_array() in dtlib. Do the type check ourselves.
-            if prop.type not in (TYPE_PHANDLE, TYPE_PHANDLES_AND_NUMS):
-                _err("expected property '{0}' in {1} in {2} to be assigned "
-                     "with '{0} = < &foo 1 2 ... &bar 3 4 ... >' (a mix of "
-                     "phandles and numbers), not '{3}'"
-                     .format(name, node.path, node.dt.filename, prop))
+            if prop.type not in (TYPE_PHANDLE, TYPE_PHANDLES, TYPE_PHANDLES_AND_NUMS):
+                _err(f"expected property '{name}' in {node.path} in "
+                     f"{node.dt.filename} to be assigned "
+                     f"with '{name} = < &foo ... &bar 1 ... &baz 2 3 >' "
+                     f"(a mix of phandles and numbers), not '{prop}'")
 
             return self._standard_phandle_val_list(prop)
 

--- a/scripts/dts/test-bindings/phandle-array-controller-0.yaml
+++ b/scripts/dts/test-bindings/phandle-array-controller-0.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Controller with zero data values
+
+compatible: "phandle-array-controller-0"
+
+phandle-array-foo-cells: []

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -260,6 +260,22 @@
 		};
 	};
 
+	props-2 {
+		compatible = "props";
+		phandle-array-foos = < &{/ctrl-0-1} &{/ctrl-0-2} >;
+	};
+
+
+	ctrl-0-1 {
+		compatible = "phandle-array-controller-0";
+		#phandle-array-foo-cells = <0>;
+	};
+
+	ctrl-0-2 {
+		compatible = "phandle-array-controller-0";
+		#phandle-array-foo-cells = <0>;
+	};
+
 	//
 	// Test <prefix>-map, via gpio-map
 	//

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -168,7 +168,7 @@ def test_props():
     '''Test Node.props (derived from DT and 'properties:' in the binding)'''
     edt = edtlib.EDT("test.dts", ["test-bindings"])
     filenames = {i: hpath(f'test-bindings/phandle-array-controller-{i}.yaml')
-                 for i in range(1, 4)}
+                 for i in range(0, 4)}
 
     assert str(edt.get_node("/props").props["int"]) == \
         "<Property, name: int, type: int, value: 1>"
@@ -199,6 +199,9 @@ def test_props():
 
     assert str(edt.get_node("/props").props["phandle-array-foos"]) == \
         f"<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('one', 1)])>, <ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding {filenames[2]}>, data: OrderedDict([('one', 2), ('two', 3)])>]>"
+
+    assert str(edt.get_node("/props-2").props["phandle-array-foos"]) == \
+        f"<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /ctrl-0-1 in 'test.dts', binding {filenames[0]}>, data: OrderedDict()>, <ControllerAndData, controller: <Node /ctrl-0-2 in 'test.dts', binding {filenames[0]}>, data: OrderedDict()>]>"
 
     assert str(edt.get_node("/props").props["foo-gpios"]) == \
         f"<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding {filenames[1]}>, data: OrderedDict([('gpio-one', 1)])>]>"


### PR DESCRIPTION
Each controller node in a phandle-array may set the number of cells in
a specifier as any nonnegative integer. Currently, we don't allow
this in edtlib in the case where there are multiple controllers in a
phandle-array property all of which have 0 cells in the relevant
specifier, which is not correct. Fix this, add a regression test, and
improve the error message while we are here.

Fixes: #28709
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>