### PR TITLE
bluetooth: add dep on !SMP

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -5,6 +5,9 @@
 
 menuconfig BT
 	bool "Bluetooth"
+	# Some BT threads use co-op priorities to implement critical sections,
+	# will need some refactoring to work on SMP systems.
+	depends on !SMP
 	select NET_BUF
 	help
 	  This option enables Bluetooth support.


### PR DESCRIPTION
The BT code uses co-op thread priorities to implement some
critical sections. This won't work with SMP turned on.
Express this in our configuration ontology, so that it's
not possible for the end user to set up the system in this
way and get crashes or odd behavior.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>