### PR TITLE
doc: release-notes: document DT_ENUM_IDX_OR

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -182,6 +182,8 @@ Build and Infrastructure
 
 * Devicetree
 
+  * :c:macro:`DT_ENUM_IDX_OR`: new macro
+
 Libraries / Subsystems
 **********************
 


### PR DESCRIPTION
This is a new DT macro which was added in
c3eef7744aa9f43452ad2f88427406db9bf0fe70 ("include/devicetree.h: Add
DT_ENUM_IDX_OR macro")

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>