### PR TITLE
logging: fix if else if constructs missing final else

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -282,7 +282,8 @@ static inline char z_log_minimal_level_to_char(int level)
 						       src_level,	       \
 						       __VA_ARGS__);	       \
 				}					       \
-			}						       \
+			} else {						       \
+			}					       \
 		}							       \
 		if (false) {						       \
 			/* Arguments checker present but never evaluated.*/    \
@@ -341,6 +342,7 @@ static inline char z_log_minimal_level_to_char(int level)
 						    _length,		       \
 						    src_level);		       \
 				}					       \
+			} else {				       \
 			}						       \
 		}							       \
 	} while (false)
@@ -738,6 +740,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 						src_level,		       \
 						_str, _valist, _argnum,        \
 						_strdup_action);	       \
+			} else {				       \
 			}						       \
 		}							       \
 	} while (false)

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -222,6 +222,7 @@ static int data_out_block_mode(uint8_t *data, size_t length, void *ctx)
 		} else if (host_present) {
 			retry_cnt--;
 			on_failed_write(retry_cnt);
+		} else {
 		}
 	} while ((ret == 0) && host_present);
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -99,6 +99,7 @@ uint32_t z_log_get_s_mask(const char *str, uint32_t nargs)
 			}
 			arm = false;
 			arg++;
+		} else {
 		}
 	}
 
@@ -210,6 +211,7 @@ static inline void msg_finalize(struct log_msg *msg,
 			k_timer_stop(&log_process_thread_timer);
 			k_sem_give(&log_process_thread_sem);
 		}
+	} else {
 	}
 }
 
@@ -370,6 +372,7 @@ uint32_t log_count_args(const char *fmt)
 		} else if (prev) {
 			args++;
 			prev = false;
+		} else {
 		}
 		fmt++;
 	}

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -149,6 +149,7 @@ static void msg_free(struct log_msg *msg)
 		if (log_is_strdup(str)) {
 			log_free((void *)(str));
 		}
+	} else {
 	}
 
 	if (msg->hdr.params.generic.ext == 1) {


### PR DESCRIPTION
The logging subsytsem had if else if constructs without final
else statement. This commit adds else {} to comply with
coding guideline 15.7.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>