### PR TITLE
net: websocket: Fix conflict flag

### DIFF
--- a/include/net/websocket.h
+++ b/include/net/websocket.h
@@ -36,7 +36,7 @@ extern "C" {
 #define WEBSOCKET_FLAG_BINARY 0x00000004 /**< Binary data        */
 #define WEBSOCKET_FLAG_CLOSE  0x00000008 /**< Closing connection */
 #define WEBSOCKET_FLAG_PING   0x00000010 /**< Ping message       */
-#define WEBSOCKET_FLAG_PONG   0x00000011 /**< Pong message       */
+#define WEBSOCKET_FLAG_PONG   0x00000020 /**< Pong message       */
 
 enum websocket_opcode  {
 	WEBSOCKET_OPCODE_CONTINUE     = 0x00,


### PR DESCRIPTION
The message type flag will be set to
0x11(WEBSOCKET_FLAG_FINAL(0x01) | WEBSOCKET_FLAG_PING(0x10)) when
receiv PING with final fragment, it conficts with
WEBSOCKET_FLAG_PONG(0x11)

The WEBSOCKET_FLAG_PONG should be 0x20