### PR TITLE
Bluetooth: Mesh: light_vnd sample: Remove button text

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/README.rst
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/README.rst
@@ -32,8 +32,7 @@ And Secondary element has following models
 
 Prior to provisioning, an unprovisioned beacon is broadcast that contains
 a unique UUID. It is obtained from the device address set by Nordic in the
-Factory information configuration register (FICR). Each button controls the state of its
-corresponding LED and does not initiate any mesh activity
+Factory information configuration register (FICR).
 
 Associations of Models with hardware
 ************************************


### PR DESCRIPTION
Removes text from the readme of the onoff_level_lighting_vnd_app
claiming buttons control the LEDs before provisioning, as it's not
accurate.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>