### PR TITLE
usb: hci: Handle Suspend->Resume events properly.

### DIFF
--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -205,37 +205,37 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:
-		LOG_DBG("USB device error");
+		LOG_DBG("Device error");
 		break;
 	case USB_DC_RESET:
-		LOG_DBG("USB device reset detected");
+		LOG_DBG("Device reset detected");
 		break;
 	case USB_DC_CONNECTED:
-		LOG_DBG("USB device connected");
+		LOG_DBG("Device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		LOG_DBG("USB device configured");
+		LOG_DBG("Device configured");
 		/* Start reading */
 		acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr, 0, NULL);
 		break;
 	case USB_DC_DISCONNECTED:
-		LOG_DBG("USB device disconnected");
+		LOG_DBG("Device disconnected");
 		/* Cancel any transfer */
 		usb_cancel_transfer(bluetooth_ep_data[HCI_INT_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr);
 		break;
 	case USB_DC_SUSPEND:
-		LOG_DBG("USB device suspended");
+		LOG_DBG("Device suspended");
 		break;
 	case USB_DC_RESUME:
-		LOG_DBG("USB device resumed");
+		LOG_DBG("Device resumed");
 		break;
 	case USB_DC_SOF:
 		break;
 	case USB_DC_UNKNOWN:
 	default:
-		LOG_DBG("USB unknown state");
+		LOG_DBG("Unknown state");
 		break;
 	}
 }

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -208,16 +208,10 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
-	case USB_DC_ERROR:
-		LOG_DBG("Device error");
-		break;
 	case USB_DC_RESET:
 		LOG_DBG("Device reset detected");
 		configured = false;
 		suspended = false;
-		break;
-	case USB_DC_CONNECTED:
-		LOG_DBG("Device connected");
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("Device configured");
@@ -254,8 +248,6 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		} else {
 			LOG_DBG("Spurious resume event");
 		}
-		break;
-	case USB_DC_SOF:
 		break;
 	case USB_DC_UNKNOWN:
 	default:

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -43,6 +43,10 @@ static struct k_thread rx_thread_data;
 static K_KERNEL_STACK_DEFINE(tx_thread_stack, 512);
 static struct k_thread tx_thread_data;
 
+/* HCI USB state flags */
+static bool configured;
+static bool suspended;
+
 struct usb_bluetooth_config {
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_int_ep;
@@ -209,14 +213,20 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		break;
 	case USB_DC_RESET:
 		LOG_DBG("Device reset detected");
+		configured = false;
+		suspended = false;
 		break;
 	case USB_DC_CONNECTED:
 		LOG_DBG("Device connected");
 		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("Device configured");
-		/* Start reading */
-		acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr, 0, NULL);
+		if (!configured) {
+			configured = true;
+			/* Start reading */
+			acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr,
+				    0, NULL);
+		}
 		break;
 	case USB_DC_DISCONNECTED:
 		LOG_DBG("Device disconnected");
@@ -224,12 +234,26 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		usb_cancel_transfer(bluetooth_ep_data[HCI_INT_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr);
+		configured = false;
+		suspended = false;
 		break;
 	case USB_DC_SUSPEND:
 		LOG_DBG("Device suspended");
+		suspended = true;
 		break;
 	case USB_DC_RESUME:
 		LOG_DBG("Device resumed");
+		if (suspended) {
+			LOG_DBG("from suspend");
+			suspended = false;
+			if (configured) {
+				/* Start reading */
+				acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr,
+					    0, NULL);
+			}
+		} else {
+			LOG_DBG("Spurious resume event");
+		}
 		break;
 	case USB_DC_SOF:
 		break;

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -40,6 +40,10 @@ static struct k_thread rx_thread_data;
 static K_KERNEL_STACK_DEFINE(tx_thread_stack, 512);
 static struct k_thread tx_thread_data;
 
+/* HCI USB state flags */
+static bool configured;
+static bool suspended;
+
 struct usb_bt_h4_config {
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_out_ep;
@@ -149,22 +153,47 @@ static void bt_h4_status_cb(struct usb_cfg_data *cfg,
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {
+	case USB_DC_RESET:
+		LOG_DBG("Device reset detected");
+		suspended = false;
+		configured = false;
+		break;
 	case USB_DC_CONFIGURED:
 		LOG_DBG("Device configured");
-		/* Start reading */
-		bt_h4_read(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr, 0, NULL);
+		if (!configured) {
+			configured = true;
+			/* Start reading */
+			bt_h4_read(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr,
+				   0, NULL);
+		}
 		break;
 	case USB_DC_DISCONNECTED:
 		LOG_DBG("Device disconnected");
 		/* Cancel any transfer */
 		usb_cancel_transfer(bt_h4_ep_data[BT_H4_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr);
+		suspended = false;
+		configured = false;
+		break;
+	case USB_DC_SUSPEND:
+		suspended = true;
+		break;
+	case USB_DC_RESUME:
+		LOG_DBG("Device resumed");
+		if (suspended) {
+			LOG_DBG("from suspend");
+			suspended = false;
+			if (configured) {
+				/* Start reading */
+				bt_h4_read(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr,
+					   0, NULL);
+			}
+		} else {
+			LOG_DBG("Spurious resume event");
+		}
 		break;
 	case USB_DC_CONNECTED:
 	case USB_DC_ERROR:
-	case USB_DC_RESET:
-	case USB_DC_SUSPEND:
-	case USB_DC_RESUME:
 	case USB_DC_SOF:
 	case USB_DC_UNKNOWN:
 	default:

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -150,12 +150,12 @@ static void bt_h4_status_cb(struct usb_cfg_data *cfg,
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_CONFIGURED:
-		LOG_DBG("USB device configured");
+		LOG_DBG("Device configured");
 		/* Start reading */
 		bt_h4_read(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr, 0, NULL);
 		break;
 	case USB_DC_DISCONNECTED:
-		LOG_DBG("USB device disconnected");
+		LOG_DBG("Device disconnected");
 		/* Cancel any transfer */
 		usb_cancel_transfer(bt_h4_ep_data[BT_H4_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr);
@@ -168,7 +168,7 @@ static void bt_h4_status_cb(struct usb_cfg_data *cfg,
 	case USB_DC_SOF:
 	case USB_DC_UNKNOWN:
 	default:
-		LOG_DBG("USB unhandled status: %u", status);
+		LOG_DBG("Unhandled status: %u", status);
 		break;
 	}
 }

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -192,9 +192,6 @@ static void bt_h4_status_cb(struct usb_cfg_data *cfg,
 			LOG_DBG("Spurious resume event");
 		}
 		break;
-	case USB_DC_CONNECTED:
-	case USB_DC_ERROR:
-	case USB_DC_SOF:
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("Unhandled status: %u", status);


### PR DESCRIPTION
USB bus might be suspended to save power. After the device
is Resumed from Suspended state there is a need to restart
OUT transfers for Endpoints used by HCI class. The transfers
shall be restarted only if the device was Resumed after Suspend
from Configured state. This patch applies the fix.

Fixes #28948

Reference: #26725