### PR TITLE
github: labeler: Add 'area: ARM_64' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,6 +55,9 @@
 "area: ARM":
   - "arch/arm/**/*"
   - "include/arch/arm/**/*"
+"area: ARM_64":
+  - "arch/arm/core/aarch64/**/*"
+  - "include/arch/arm/aarch64/**/*"
 "area: NIOS2":
   - "arch/nios2/**/*"
   - "include/arch/nios2/**/*"


### PR DESCRIPTION
As answered in [0] add a new label for the ARM64 code.

[0] https://github.com/zephyrproject-rtos/zephyr/discussions/28353