### PR TITLE
manifest: synch MCUBoot to upstream of 7 10 2020

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -225,6 +225,35 @@ HALs
 * HALs are now moved out of the main tree as external modules and reside in
   their own standalone repositories.
 
+MCUBoot
+*******
+
+* bootloader
+
+  * Added hardening against hardware level fault injection and timing attacks,
+    see ``CONFIG_BOOT_FIH_PROFILE_HIGH`` and similar kconfig options.
+  * Introduced Abstract crypto primitives to simplify porting.
+  * Added ram-load upgrade mode (not enabled for zephy-rtos yet).
+  * Renamed single-image mode to single-slot mode,
+    see ``CONFIG_SINGLE_APPLICATION_SLOT``.
+  * Added patch for turning off cache for Cortex M7 before chain-loading.
+  * Fixed boostrapping in swap-move mode.
+  * Fixed issue causing that interrupted swap-move operation might brick device
+    if the primary image was padded.
+  * Fixed issue causing that HW stack protection catches the chain-loaded
+    application during its early ini, by disableing HW stack protection
+    (temporary hack).
+  * Added reset of Cortex SPLIM registers before boot.
+  * Fixesd build issue that occurs if CONF_FILE contains multiple file paths
+    instead of single file path.
+
+* imgtool
+
+  * Print image digest during verify.
+  * Add possibility to set confirm flag for hex files as well.
+  * Usage of --confirm implies --pad.
+  * Fixed 'custom_tlvs' argument handling.
+
 Documentation
 *************
 

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: aef137b1af8aa7a0f43345c82459254b8832262e
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: a5d79cf8ccb2c71e68ef32a71d6a2716e831d12e
+      revision: e312fa2cec3e8440bf484d7da3443e149b7eb9d8
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
Introduces what is in https://github.com/zephyrproject-rtos/mcuboot/pull/36

MCUBoot was synchronized up to:
https://github.com/JuulLabs-OSS/mcuboot/commit/296949e

Improvements:
- hardening against hardware level fault injection and timing attacks
- Abstract crypto primitives to simplify porting.
- boot: Add ram-load upgrade mode
- renamed single-image mode to single-slot mode

- kconfig: provide logic for setting key file, simplify prj.conf

- imgtool: Print image digest during verify
- imgtool: Add possibility to set confirm flag for hex files as well
- imgtool: --confirm implies --pad

- Added single-slot Zephyr-RTOS test build

fixes:
- bootutil: fix boostrapping in swap-move
- Disable HW stack protection (temporary hack)
- reset SPLIM registers before boot
- fixes build issue that occurs if CONF_FILE contains
multiple file paths instead of single file path.
- imgtool: Fix 'custom_tlvs' argument handling
- Turn off cache for Cortex M7 before chain-loading.
- hardening against hardware level fault injection and timing attacks

Fixes: #28921
Fixes: #28933
Fixes: #28898