### PR TITLE
doc: coverage: document unit test coverage

### DIFF
--- a/doc/guides/coverage.rst
+++ b/doc/guides/coverage.rst
@@ -146,5 +146,12 @@ or::
 
 which will produce ``sanity-out/coverage/index.html`` with the report.
 
+The process differs for unit tests, which are built with the host
+toolchain and require a different board::
+
+    $ sanitycheck --coverage -p unit_testing -T tests/unit
+
+which produces a report in the same location as non-unit testing.
+
 .. _gcov:
    https://gcc.gnu.org/onlinedocs/gcc/Gcov.html


### PR DESCRIPTION
Unit tests require a special board and use the host toolchain.

Closes #28935.