### PR TITLE
Align ST sensor to stmemsc HAL v1.03

### DIFF
--- a/drivers/sensor/iis2dh/iis2dh.c
+++ b/drivers/sensor/iis2dh/iis2dh.c
@@ -204,17 +204,17 @@ static int iis2dh_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
 	struct iis2dh_data *iis2dh = dev->data;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
 	/* fetch raw data sample */
-	if (iis2dh_acceleration_raw_get(iis2dh->ctx, buf.u8bit) < 0) {
+	if (iis2dh_acceleration_raw_get(iis2dh->ctx, buf) < 0) {
 		LOG_DBG("Failed to fetch raw data sample");
 		return -EIO;
 	}
 
-	iis2dh->acc[0] = sys_le16_to_cpu(buf.i16bit[0]);
-	iis2dh->acc[1] = sys_le16_to_cpu(buf.i16bit[1]);
-	iis2dh->acc[2] = sys_le16_to_cpu(buf.i16bit[2]);
+	iis2dh->acc[0] = sys_le16_to_cpu(buf[0]);
+	iis2dh->acc[1] = sys_le16_to_cpu(buf[1]);
+	iis2dh->acc[2] = sys_le16_to_cpu(buf[2]);
 
 	return 0;
 }

--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -42,7 +42,7 @@ int iis2dh_trigger_set(const struct device *dev,
 		       sensor_trigger_handler_t handler)
 {
 	struct iis2dh_data *iis2dh = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 	int state = (handler != NULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 	switch (trig->type) {
@@ -50,7 +50,7 @@ int iis2dh_trigger_set(const struct device *dev,
 		iis2dh->drdy_handler = handler;
 		if (state) {
 			/* dummy read: re-trigger interrupt */
-			iis2dh_acceleration_raw_get(iis2dh->ctx, raw.u8bit);
+			iis2dh_acceleration_raw_get(iis2dh->ctx, raw);
 		}
 		return iis2dh_enable_drdy(dev, SENSOR_TRIG_DATA_READY, state);
 	default:

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -182,10 +182,10 @@ static int iis2dlpc_sample_fetch(const struct device *dev,
 	struct iis2dlpc_data *iis2dlpc = dev->data;
 	const struct iis2dlpc_device_config *cfg = dev->config;
 	uint8_t shift;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
 	/* fetch raw data sample */
-	if (iis2dlpc_acceleration_raw_get(iis2dlpc->ctx, buf.u8bit) < 0) {
+	if (iis2dlpc_acceleration_raw_get(iis2dlpc->ctx, buf) < 0) {
 		LOG_DBG("Failed to fetch raw data sample");
 		return -EIO;
 	}
@@ -197,9 +197,9 @@ static int iis2dlpc_sample_fetch(const struct device *dev,
 		shift = IIS2DLPC_SHIFT_PMOTHER;
 	}
 
-	iis2dlpc->acc[0] = sys_le16_to_cpu(buf.i16bit[0]) >> shift;
-	iis2dlpc->acc[1] = sys_le16_to_cpu(buf.i16bit[1]) >> shift;
-	iis2dlpc->acc[2] = sys_le16_to_cpu(buf.i16bit[2]) >> shift;
+	iis2dlpc->acc[0] = sys_le16_to_cpu(buf[0]) >> shift;
+	iis2dlpc->acc[1] = sys_le16_to_cpu(buf[1]) >> shift;
+	iis2dlpc->acc[2] = sys_le16_to_cpu(buf[2]) >> shift;
 
 	return 0;
 }

--- a/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
@@ -80,7 +80,7 @@ int iis2dlpc_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct iis2dlpc_data *iis2dlpc = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 	int state = (handler != NULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 	switch (trig->type) {
@@ -88,7 +88,7 @@ int iis2dlpc_trigger_set(const struct device *dev,
 		iis2dlpc->drdy_handler = handler;
 		if (state) {
 			/* dummy read: re-trigger interrupt */
-			iis2dlpc_acceleration_raw_get(iis2dlpc->ctx, raw.u8bit);
+			iis2dlpc_acceleration_raw_get(iis2dlpc->ctx, raw);
 		}
 		return iis2dlpc_enable_int(dev, SENSOR_TRIG_DATA_READY, state);
 #ifdef CONFIG_IIS2DLPC_PULSE

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -60,14 +60,14 @@ static int iis2mdc_set_hard_iron(const struct device *dev,
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
 	uint8_t i;
-	union axis3bit16_t offset;
+	int16_t offset[3];
 
 	for (i = 0U; i < 3; i++) {
-		offset.i16bit[i] = sys_cpu_to_le16(val->val1);
+		offset[i] = sys_cpu_to_le16(val->val1);
 		val++;
 	}
 
-	return iis2mdc_mag_user_offset_set(iis2mdc->ctx, offset.u8bit);
+	return iis2mdc_mag_user_offset_set(iis2mdc->ctx, offset);
 }
 
 static void iis2mdc_channel_get_mag(const struct device *dev,
@@ -177,17 +177,17 @@ static int iis2mdc_attr_set(const struct device *dev,
 static int iis2mdc_sample_fetch_mag(const struct device *dev)
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
-	union axis3bit16_t raw_mag;
+	int16_t raw_mag[3];
 
 	/* fetch raw data sample */
-	if (iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw_mag.u8bit) < 0) {
+	if (iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw_mag) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	iis2mdc->mag[0] = sys_le16_to_cpu(raw_mag.i16bit[0]);
-	iis2mdc->mag[1] = sys_le16_to_cpu(raw_mag.i16bit[1]);
-	iis2mdc->mag[2] = sys_le16_to_cpu(raw_mag.i16bit[2]);
+	iis2mdc->mag[0] = sys_le16_to_cpu(raw_mag[0]);
+	iis2mdc->mag[1] = sys_le16_to_cpu(raw_mag[1]);
+	iis2mdc->mag[2] = sys_le16_to_cpu(raw_mag[2]);
 
 	return 0;
 }
@@ -195,17 +195,17 @@ static int iis2mdc_sample_fetch_mag(const struct device *dev)
 static int iis2mdc_sample_fetch_temp(const struct device *dev)
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
-	union axis1bit16_t raw_temp;
+	int16_t raw_temp;
 	int32_t temp;
 
 	/* fetch raw temperature sample */
-	if (iis2mdc_temperature_raw_get(iis2mdc->ctx, raw_temp.u8bit) < 0) {
+	if (iis2mdc_temperature_raw_get(iis2mdc->ctx, &raw_temp) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
 	/* formula is temp = 25 + (temp / 8) C */
-	temp = sys_le16_to_cpu(raw_temp.i16bit);
+	temp = sys_le16_to_cpu(raw_temp);
 	iis2mdc->temp_sample = 2500 + (temp * 100) / 8;
 
 	return 0;

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -205,7 +205,7 @@ static int iis2mdc_sample_fetch_temp(const struct device *dev)
 	}
 
 	/* formula is temp = 25 + (temp / 8) C */
-	temp = (sys_le16_to_cpu(raw_temp.i16bit) & 0x8FFF);
+	temp = sys_le16_to_cpu(raw_temp.i16bit);
 	iis2mdc->temp_sample = 2500 + (temp * 100) / 8;
 
 	return 0;

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -32,13 +32,13 @@ int iis2mdc_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		iis2mdc->handler_drdy = handler;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
-			iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw.u8bit);
+			iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw);
 
 			return iis2mdc_enable_int(dev, 1);
 		} else {

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -25,14 +25,14 @@ static int iis3dhhc_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
 {
 	struct iis3dhhc_data *data = dev->data;
-	union axis3bit16_t raw_accel;
+	int16_t raw_accel[3];
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-	iis3dhhc_acceleration_raw_get(data->ctx, raw_accel.u8bit);
-	data->acc[0] = sys_le16_to_cpu(raw_accel.i16bit[0]);
-	data->acc[1] = sys_le16_to_cpu(raw_accel.i16bit[1]);
-	data->acc[2] = sys_le16_to_cpu(raw_accel.i16bit[2]);
+	iis3dhhc_acceleration_raw_get(data->ctx, raw_accel);
+	data->acc[0] = sys_le16_to_cpu(raw_accel[0]);
+	data->acc[1] = sys_le16_to_cpu(raw_accel[1]);
+	data->acc[2] = sys_le16_to_cpu(raw_accel[2]);
 
 	return 0;
 }

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -42,13 +42,13 @@ int iis3dhhc_trigger_set(const struct device *dev,
 			 sensor_trigger_handler_t handler)
 {
 	struct iis3dhhc_data *iis3dhhc = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		iis3dhhc->handler_drdy = handler;
 		if (handler) {
 			/* dummy read: re-trigger interrupt */
-			iis3dhhc_acceleration_raw_get(iis3dhhc->ctx, raw.u8bit);
+			iis3dhhc_acceleration_raw_get(iis3dhhc->ctx, raw);
 			return iis3dhhc_enable_int(dev, PROPERTY_ENABLE);
 		} else {
 			return iis3dhhc_enable_int(dev, PROPERTY_DISABLE);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -823,17 +823,17 @@ static int ism330dhcx_init(const struct device *dev)
 
 	config->bus_init(dev);
 
+	if (ism330dhcx_init_chip(dev) < 0) {
+		LOG_DBG("failed to initialize chip");
+		return -EIO;
+	}
+
 #ifdef CONFIG_ISM330DHCX_TRIGGER
 	if (ism330dhcx_init_interrupt(dev) < 0) {
 		LOG_ERR("Failed to initialize interrupt.");
 		return -EIO;
 	}
 #endif
-
-	if (ism330dhcx_init_chip(dev) < 0) {
-		LOG_DBG("failed to initialize chip");
-		return -EIO;
-	}
 
 #ifdef CONFIG_ISM330DHCX_SENSORHUB
 	if (ism330dhcx_shub_init(dev) < 0) {

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -301,16 +301,16 @@ static int ism330dhcx_attr_set(const struct device *dev,
 static int ism330dhcx_sample_fetch_accel(const struct device *dev)
 {
 	struct ism330dhcx_data *data = dev->data;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
-	if (ism330dhcx_acceleration_raw_get(data->ctx, buf.u8bit) < 0) {
+	if (ism330dhcx_acceleration_raw_get(data->ctx, buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->acc[0] = sys_le16_to_cpu(buf.i16bit[0]);
-	data->acc[1] = sys_le16_to_cpu(buf.i16bit[1]);
-	data->acc[2] = sys_le16_to_cpu(buf.i16bit[2]);
+	data->acc[0] = sys_le16_to_cpu(buf[0]);
+	data->acc[1] = sys_le16_to_cpu(buf[1]);
+	data->acc[2] = sys_le16_to_cpu(buf[2]);
 
 	return 0;
 }
@@ -318,16 +318,16 @@ static int ism330dhcx_sample_fetch_accel(const struct device *dev)
 static int ism330dhcx_sample_fetch_gyro(const struct device *dev)
 {
 	struct ism330dhcx_data *data = dev->data;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
-	if (ism330dhcx_angular_rate_raw_get(data->ctx, buf.u8bit) < 0) {
+	if (ism330dhcx_angular_rate_raw_get(data->ctx, buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->gyro[0] = sys_le16_to_cpu(buf.i16bit[0]);
-	data->gyro[1] = sys_le16_to_cpu(buf.i16bit[1]);
-	data->gyro[2] = sys_le16_to_cpu(buf.i16bit[2]);
+	data->gyro[0] = sys_le16_to_cpu(buf[0]);
+	data->gyro[1] = sys_le16_to_cpu(buf[1]);
+	data->gyro[2] = sys_le16_to_cpu(buf[2]);
 
 	return 0;
 }
@@ -336,14 +336,14 @@ static int ism330dhcx_sample_fetch_gyro(const struct device *dev)
 static int ism330dhcx_sample_fetch_temp(const struct device *dev)
 {
 	struct ism330dhcx_data *data = dev->data;
-	union axis1bit16_t buf;
+	int16_t buf;
 
-	if (ism330dhcx_temperature_raw_get(data->ctx, buf.u8bit) < 0) {
+	if (ism330dhcx_temperature_raw_get(data->ctx, &buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->temp_sample = sys_le16_to_cpu(buf.i16bit);
+	data->temp_sample = sys_le16_to_cpu(buf);
 
 	return 0;
 }

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -30,10 +30,10 @@ static int ism330dhcx_enable_t_int(const struct device *dev, int enable)
 	ism330dhcx_pin_int2_route_t int2_route;
 
 	if (enable) {
-		union axis1bit16_t buf;
+		int16_t buf;
 
 		/* dummy read: re-trigger interrupt */
-		ism330dhcx_temperature_raw_get(ism330dhcx->ctx, buf.u8bit);
+		ism330dhcx_temperature_raw_get(ism330dhcx->ctx, &buf);
 	}
 
 	/* set interrupt (TEMP DRDY interrupt is only on INT2) */
@@ -57,10 +57,10 @@ static int ism330dhcx_enable_xl_int(const struct device *dev, int enable)
 	struct ism330dhcx_data *ism330dhcx = dev->data;
 
 	if (enable) {
-		union axis3bit16_t buf;
+		int16_t buf[3];
 
 		/* dummy read: re-trigger interrupt */
-		ism330dhcx_acceleration_raw_get(ism330dhcx->ctx, buf.u8bit);
+		ism330dhcx_acceleration_raw_get(ism330dhcx->ctx, buf);
 	}
 
 	/* set interrupt */
@@ -93,10 +93,10 @@ static int ism330dhcx_enable_g_int(const struct device *dev, int enable)
 	struct ism330dhcx_data *ism330dhcx = dev->data;
 
 	if (enable) {
-		union axis3bit16_t buf;
+		int16_t buf[3];
 
 		/* dummy read: re-trigger interrupt */
-		ism330dhcx_angular_rate_raw_get(ism330dhcx->ctx, buf.u8bit);
+		ism330dhcx_angular_rate_raw_get(ism330dhcx->ctx, buf);
 	}
 
 	/* set interrupt */

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -182,10 +182,10 @@ static int lis2dw12_sample_fetch(const struct device *dev,
 	struct lis2dw12_data *lis2dw12 = dev->data;
 	const struct lis2dw12_device_config *cfg = dev->config;
 	uint8_t shift;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
 	/* fetch raw data sample */
-	if (lis2dw12_acceleration_raw_get(lis2dw12->ctx, buf.u8bit) < 0) {
+	if (lis2dw12_acceleration_raw_get(lis2dw12->ctx, buf) < 0) {
 		LOG_DBG("Failed to fetch raw data sample");
 		return -EIO;
 	}
@@ -197,9 +197,9 @@ static int lis2dw12_sample_fetch(const struct device *dev,
 		shift = LIS2DW12_SHIFT_PMOTHER;
 	}
 
-	lis2dw12->acc[0] = sys_le16_to_cpu(buf.i16bit[0]) >> shift;
-	lis2dw12->acc[1] = sys_le16_to_cpu(buf.i16bit[1]) >> shift;
-	lis2dw12->acc[2] = sys_le16_to_cpu(buf.i16bit[2]) >> shift;
+	lis2dw12->acc[0] = sys_le16_to_cpu(buf[0]) >> shift;
+	lis2dw12->acc[1] = sys_le16_to_cpu(buf[1]) >> shift;
+	lis2dw12->acc[2] = sys_le16_to_cpu(buf[2]) >> shift;
 
 	return 0;
 }

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -80,7 +80,7 @@ int lis2dw12_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lis2dw12_data *lis2dw12 = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 	int state = (handler != NULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 	switch (trig->type) {
@@ -88,7 +88,7 @@ int lis2dw12_trigger_set(const struct device *dev,
 		lis2dw12->drdy_handler = handler;
 		if (state) {
 			/* dummy read: re-trigger interrupt */
-			lis2dw12_acceleration_raw_get(lis2dw12->ctx, raw.u8bit);
+			lis2dw12_acceleration_raw_get(lis2dw12->ctx, raw);
 		}
 		return lis2dw12_enable_int(dev, SENSOR_TRIG_DATA_READY, state);
 		break;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -60,14 +60,14 @@ static int lis2mdl_set_hard_iron(const struct device *dev,
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	uint8_t i;
-	union axis3bit16_t offset;
+	int16_t offset[3];
 
 	for (i = 0U; i < 3; i++) {
-		offset.i16bit[i] = sys_cpu_to_le16(val->val1);
+		offset[i] = sys_cpu_to_le16(val->val1);
 		val++;
 	}
 
-	return lis2mdl_mag_user_offset_set(lis2mdl->ctx, offset.u8bit);
+	return lis2mdl_mag_user_offset_set(lis2mdl->ctx, offset);
 }
 
 static void lis2mdl_channel_get_mag(const struct device *dev,
@@ -177,17 +177,17 @@ static int lis2mdl_attr_set(const struct device *dev,
 static int lis2mdl_sample_fetch_mag(const struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
-	union axis3bit16_t raw_mag;
+	int16_t raw_mag[3];
 
 	/* fetch raw data sample */
-	if (lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag.u8bit) < 0) {
+	if (lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag.i16bit[0]);
-	lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag.i16bit[1]);
-	lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag.i16bit[2]);
+	lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
+	lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
+	lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
 
 	return 0;
 }
@@ -195,17 +195,17 @@ static int lis2mdl_sample_fetch_mag(const struct device *dev)
 static int lis2mdl_sample_fetch_temp(const struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
-	union axis1bit16_t raw_temp;
+	int16_t raw_temp;
 	int32_t temp;
 
 	/* fetch raw temperature sample */
-	if (lis2mdl_temperature_raw_get(lis2mdl->ctx, raw_temp.u8bit) < 0) {
+	if (lis2mdl_temperature_raw_get(lis2mdl->ctx, &raw_temp) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
 	/* formula is temp = 25 + (temp / 8) C */
-	temp = (sys_le16_to_cpu(raw_temp.i16bit) & 0x8FFF);
+	temp = (sys_le16_to_cpu(raw_temp) & 0x8FFF);
 	lis2mdl->temp_sample = 2500 + (temp * 100) / 8;
 
 	return 0;

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -32,13 +32,13 @@ int lis2mdl_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
-	union axis3bit16_t raw;
+	int16_t raw[3];
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		lis2mdl->handler_drdy = handler;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
-			lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw.u8bit);
+			lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw);
 
 			return lis2mdl_enable_int(dev, 1);
 		} else {

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -33,22 +33,22 @@ static int lps22hh_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct lps22hh_data *data = dev->data;
-	union axis1bit32_t raw_press;
-	union axis1bit16_t raw_temp;
+	uint32_t raw_press;
+	int16_t raw_temp;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-	if (lps22hh_pressure_raw_get(data->ctx, raw_press.u8bit) < 0) {
+	if (lps22hh_pressure_raw_get(data->ctx, &raw_press) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
-	if (lps22hh_temperature_raw_get(data->ctx, raw_temp.u8bit) < 0) {
+	if (lps22hh_temperature_raw_get(data->ctx, &raw_temp) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->sample_press = raw_press.i32bit;
-	data->sample_temp = raw_temp.i16bit;
+	data->sample_press = raw_press;
+	data->sample_temp = raw_temp;
 
 	return 0;
 }

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -43,14 +43,14 @@ int lps22hh_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lps22hh_data *lps22hh = dev->data;
-	union axis1bit32_t raw_press;
+	uint32_t raw_press;
 
 	if (trig->chan == SENSOR_CHAN_ALL) {
 		lps22hh->handler_drdy = handler;
 		if (handler) {
 			/* dummy read: re-trigger interrupt */
 			if (lps22hh_pressure_raw_get(lps22hh->ctx,
-			    raw_press.u8bit) < 0) {
+			    &raw_press) < 0) {
 				LOG_DBG("Failed to read sample");
 				return -EIO;
 			}

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -27,7 +27,7 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 {
 	const struct lsm6dso_config *cfg = dev->config;
 	struct lsm6dso_data *lsm6dso = dev->data;
-	lsm6dso_pin_int2_route_t int2_route;
+	lsm6dso_int2_ctrl_t int2_ctrl;
 
 	if (enable) {
 		union axis1bit16_t buf;
@@ -41,10 +41,10 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 		return -EIO;
 
 	lsm6dso_read_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-			 (uint8_t *)&int2_route.int2_ctrl, 1);
+			 (uint8_t *)&int2_ctrl, 1);
 	int2_route.int2_ctrl.int2_drdy_temp = enable;
 	return lsm6dso_write_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-				 (uint8_t *)&int2_route.int2_ctrl, 1);
+				 (uint8_t *)&int2_ctrl, 1);
 }
 #endif
 
@@ -65,22 +65,22 @@ static int lsm6dso_enable_xl_int(const struct device *dev, int enable)
 
 	/* set interrupt */
 	if (cfg->int_pin == 1) {
-		lsm6dso_pin_int1_route_t int1_route;
+		lsm6dso_int1_ctrl_t int1_ctrl;
 
 		lsm6dso_read_reg(lsm6dso->ctx, LSM6DSO_INT1_CTRL,
-				 (uint8_t *)&int1_route.int1_ctrl, 1);
+				 (uint8_t *)&int1_ctrl, 1);
 
-		int1_route.int1_ctrl.int1_drdy_xl = enable;
+		int1_ctrl.int1_drdy_xl = enable;
 		return lsm6dso_write_reg(lsm6dso->ctx, LSM6DSO_INT1_CTRL,
-					 (uint8_t *)&int1_route.int1_ctrl, 1);
+					 (uint8_t *)&int1_ctrl, 1);
 	} else {
-		lsm6dso_pin_int2_route_t int2_route;
+		lsm6dso_int2_ctrl_t int2_ctrl;
 
 		lsm6dso_read_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-				 (uint8_t *)&int2_route.int2_ctrl, 1);
-		int2_route.int2_ctrl.int2_drdy_xl = enable;
+				 (uint8_t *)&int2_ctrl, 1);
+		int2_ctrl.int2_drdy_xl = enable;
 		return lsm6dso_write_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-					 (uint8_t *)&int2_route.int2_ctrl, 1);
+					 (uint8_t *)&int2_ctrl, 1);
 	}
 }
 
@@ -101,21 +101,21 @@ static int lsm6dso_enable_g_int(const struct device *dev, int enable)
 
 	/* set interrupt */
 	if (cfg->int_pin == 1) {
-		lsm6dso_pin_int1_route_t int1_route;
+		lsm6dso_int1_ctrl_t int1_ctrl;
 
 		lsm6dso_read_reg(lsm6dso->ctx, LSM6DSO_INT1_CTRL,
-				 (uint8_t *)&int1_route.int1_ctrl, 1);
-		int1_route.int1_ctrl.int1_drdy_g = enable;
+				 (uint8_t *)&int1_ctrl, 1);
+		int1_ctrl.int1_drdy_g = enable;
 		return lsm6dso_write_reg(lsm6dso->ctx, LSM6DSO_INT1_CTRL,
-					 (uint8_t *)&int1_route.int1_ctrl, 1);
+					 (uint8_t *)&int1_ctrl, 1);
 	} else {
-		lsm6dso_pin_int2_route_t int2_route;
+		lsm6dso_int2_ctrl_t int2_ctrl;
 
 		lsm6dso_read_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-				 (uint8_t *)&int2_route.int2_ctrl, 1);
-		int2_route.int2_ctrl.int2_drdy_g = enable;
+				 (uint8_t *)&int2_ctrl, 1);
+		int2_ctrl.int2_drdy_g = enable;
 		return lsm6dso_write_reg(lsm6dso->ctx, LSM6DSO_INT2_CTRL,
-					 (uint8_t *)&int2_route.int2_ctrl, 1);
+					 (uint8_t *)&int2_ctrl, 1);
 	}
 }
 

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -33,16 +33,16 @@ static int stts751_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct stts751_data *data = dev->data;
-	union axis1bit16_t raw_temp;
+	int16_t raw_temp;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-	if (stts751_temperature_raw_get(data->ctx, &raw_temp.i16bit) < 0) {
+	if (stts751_temperature_raw_get(data->ctx, &raw_temp) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->sample_temp = raw_temp.i16bit;
+	data->sample_temp = raw_temp;
 
 	return 0;
 }

--- a/modules/Kconfig.st
+++ b/modules/Kconfig.st
@@ -22,6 +22,9 @@ config USE_STDC_AIS328DQ
 config USE_STDC_AIS3624DQ
 	bool
 
+config USE_STDC_H3LIS100DL
+	bool
+
 config USE_STDC_H3LIS331DL
 	bool
 
@@ -35,6 +38,9 @@ config USE_STDC_IIS2DH
 	bool
 
 config USE_STDC_IIS2DLPC
+	bool
+
+config USE_STDC_IIS2ICLX
 	bool
 
 config USE_STDC_IIS2MDC
@@ -62,6 +68,9 @@ config USE_STDC_L20G20IS
 	bool
 
 config USE_STDC_L3GD20H
+	bool
+
+config USE_STDC_LIS25BA
 	bool
 
 config USE_STDC_LIS2DE12
@@ -97,6 +106,9 @@ config USE_STDC_LIS3DHH
 config USE_STDC_LIS3DH
 	bool
 
+config USE_STDC_LIS3DSH
+	bool
+
 config USE_STDC_LIS3MDL
 	bool
 
@@ -113,6 +125,9 @@ config USE_STDC_LPS27HHW
 	bool
 
 config USE_STDC_LPS33HW
+	bool
+
+config USE_STDC_LPS33K
 	bool
 
 config USE_STDC_LPS33W
@@ -139,13 +154,22 @@ config USE_STDC_LSM6DSM
 config USE_STDC_LSM6DSO
 	bool
 
+config USE_STDC_LSM6DSO32
+	bool
+
 config USE_STDC_LSM6DSOX
 	bool
 
 config USE_STDC_LSM6DSR
 	bool
 
+config USE_STDC_LSM6DSRX
+	bool
+
 config USE_STDC_LSM9DS1
+	bool
+
+config USE_STDC_STTS22H
 	bool
 
 config USE_STDC_STTS751

--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       revision: 69c3e1e6e167767cb75aa2b468df4ade05988cdb
       path: modules/hal/silabs
     - name: hal_st
-      revision: 5b3ec3e182d4310e8943cc34c6c70ae57d9711da
+      revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
       revision: 385b36674e6a77357b8c69a129c77421c593a3f8


### PR DESCRIPTION
Requires: https://github.com/zephyrproject-rtos/hal_st/pull/5

Upgrading stmemsc HAL module to v1.03 requires to align all sensor drivers using it.
Drivers have been tested on:
 - x_nucleo_iks02a1 shield
 - sensortile_box board

This PR includes also two drivers fixes found during tests:
 - drivers/sensor: iis2mdc: Fix the temperature in celsius
 - drivers/sensor: ism330dhcx: Fix init routines order
