### PR TITLE
modem: fix socket descriptor leak

### DIFF
--- a/drivers/modem/modem_socket.c
+++ b/drivers/modem/modem_socket.c
@@ -233,7 +233,6 @@ void modem_socket_put(struct modem_socket_config *cfg, int sock_fd)
 
 	k_sem_take(&cfg->sem_lock, K_FOREVER);
 
-	z_free_fd(sock->sock_fd);
 	sock->id = cfg->base_socket_num - 1;
 	sock->sock_fd = -1;
 	sock->is_waiting = false;


### PR DESCRIPTION
`z_free_fd()` is called twice then you `close()`. For example in ublox sara r4 driver `offload_close()` calls  `modem_socket_put()` where `z_free_fd()` is called first time. Then this same function is called another time in socket.c in `z_impl_zsock_close()` after this function has called `offload_close()` in ublox sara r4 driver. This causes socket descriptor leak. 

Fixes #26819

Signed-off-by: peltsu1324@gmail.com