### PR TITLE
Cleanup gpio dt

### DIFF
--- a/dts/bindings/gpio/gpio-controller.yaml
+++ b/dts/bindings/gpio/gpio-controller.yaml
@@ -16,4 +16,13 @@ properties:
       type: int
       required: false
       default: 32
-      description: Number of gpios supported
+      description: |
+          This property indicates the number of in-use slots of available slots
+          for GPIOs. The typical example is something like this: the hardware
+          register is 32 bits wide, but only 18 of the bits have a physical
+          counterpart. The driver is generally written so that all 32 bits can
+          be used, but the IP block is reused in a lot of designs, some using
+          all 32 bits, some using 18 and some using 12. In this case, setting
+          "ngpios = <18>;" informs the driver that only the first 18 GPIOs, at
+          local offset 0 .. 17, are in use.  For cases in which there might be
+          holes in the slot range, this value should be the max slot number-1.

--- a/dts/bindings/gpio/gpio-controller.yaml
+++ b/dts/bindings/gpio/gpio-controller.yaml
@@ -26,3 +26,20 @@ properties:
           "ngpios = <18>;" informs the driver that only the first 18 GPIOs, at
           local offset 0 .. 17, are in use.  For cases in which there might be
           holes in the slot range, this value should be the max slot number-1.
+    gpio-reserved-ranges:
+      type: array
+      required: false
+      description: |
+          If not all the GPIOs at offsets 0...N-1 are usable for ngpios = <N>, then
+          this property contains an additional set of tuples which specify which GPIOs
+          are unusable. This property indicates the start and size of the GPIOs
+          that can't be used.
+
+          For example, setting "gpio-reserved-ranges = <3 2>, <10 1>;" means that
+          GPIO offsets 3, 4, and 10 are not usable, even if ngpios = <18>.
+    gpio-line-names:
+      type: string-array
+      required: false
+      description: |
+          This is an array of strings defining the names of the GPIO lines
+          going out of the GPIO controller


### PR DESCRIPTION
* Update description of `nr-gpios`
* Added `gpio-reserved-ranges` and `gpio-line-names` in prep of support in EDT for them.