### PR TITLE
west build: fix --pristine on early build system failure

### DIFF
--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -111,18 +111,25 @@ def is_zephyr_build(path):
     build directory.
 
     "Valid" means the given path is a directory which contains a CMake
-    cache with a 'ZEPHYR_TOOLCHAIN_VARIANT' key.
+    cache with a 'ZEPHYR_BASE' or 'ZEPHYR_TOOLCHAIN_VARIANT' variable.
+
+    (The check for ZEPHYR_BASE introduced sometime after Zephyr 2.4 to
+    fix https://github.com/zephyrproject-rtos/zephyr/issues/28876; we
+    keep support for the second variable around for compatibility with
+    versions 2.2 and earlier, which didn't have ZEPHYR_BASE in cache.
+    The cached ZEPHYR_BASE was added in
+    https://github.com/zephyrproject-rtos/zephyr/pull/23054.)
     '''
     try:
         cache = zcmake.CMakeCache.from_build_dir(path)
     except FileNotFoundError:
         cache = {}
 
-    if 'ZEPHYR_TOOLCHAIN_VARIANT' in cache:
-        log.dbg('{} is a zephyr build directory'.format(path),
+    if 'ZEPHYR_BASE' in cache or 'ZEPHYR_TOOLCHAIN_VARIANT' in cache:
+        log.dbg(f'{path} is a zephyr build directory',
                 level=log.VERBOSE_EXTREME)
         return True
-    else:
-        log.dbg('{} is NOT a valid zephyr build directory'.format(path),
-                level=log.VERBOSE_EXTREME)
-        return False
+
+    log.dbg(f'{path} is NOT a valid zephyr build directory',
+            level=log.VERBOSE_EXTREME)
+    return False


### PR DESCRIPTION
The west build command has historically tried not to rm -rf
directories that don't look like zephyr build directories. The way it
does this is by checking for the presence of a CMake cache
with a Zephyr-specific variable (ZEPHYR_TOOLCHAIN_VARIANT) in it.

The problem with this approach is that if the build system fails
before this cache variable is set, the directory doesn't look like a
zephyr build directory, and therefore west build won't make it
pristine even with --pristine=always, even though build directories
resulting from failed runs like that are almost certainly
irrecoverably broken and need to be made pristine before anything will
work.

This leads to users having to rm -rf their directories manually, which
is not so nice.

To avoid this from happening, just set a new cache variable we use for
the express purpose of indicating a zephyr build directory at the top
of boilerplate.cmake instead.

We could consider being less selective and just using shutil.rmtree()
whenever we have --pristine=always, but that would be a bigger
behavioral change than I'm comfortable doing without a good reason.

Fixes: #28876
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>