### PR TITLE
CODEOWNERS: Remove comma

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -183,7 +183,7 @@
 /drivers/espi/                            @albertofloyd @franciscomunoz @scottwcpg
 /drivers/espi/*npcx*                      @MulinChao
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
-/drivers/ethernet/*stm32*                 @Nukersson, @lochej
+/drivers/ethernet/*stm32*                 @Nukersson @lochej
 /drivers/ethernet/*w5500*                 @parthitce
 /drivers/flash/                           @nashif @nvlsianpu
 /drivers/flash/*nrf*                      @nvlsianpu


### PR DESCRIPTION
Fixes incorrect syntax in CODEOWNERS file to restore automatic GitHub
reviewer assignments.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>