### PR TITLE
net: websocket: Fix websocket loop close call

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -399,17 +399,18 @@ out:
 
 int websocket_disconnect(int ws_sock)
 {
-	struct websocket_context *ctx;
+	return close(ws_sock);
+}
+
+static int websocket_interal_disconnect(struct websocket_context *ctx)
+{
 	int ret;
 
-	ctx = z_get_fd_obj(ws_sock, NULL, 0);
 	if (ctx == NULL) {
 		return -ENOENT;
 	}
 
 	NET_DBG("[%p] Disconnecting", ctx);
-
-	(void)close(ctx->sock);
 
 	ret = close(ctx->real_sock);
 
@@ -423,7 +424,7 @@ static int websocket_close_vmeth(void *obj)
 	struct websocket_context *ctx = obj;
 	int ret;
 
-	ret = websocket_disconnect(ctx->sock);
+	ret = websocket_interal_disconnect(ctx);
 	if (ret < 0) {
 		NET_DBG("[%p] Cannot close (%d)", obj, ret);
 


### PR DESCRIPTION
A normal websocket close sequence:
  close(websock) ->
    websocket_close_vmeth() ->
      websocket_disconnect()

close(ctx->sock) called in the function websocket_disconnect()
and cause websocket_close_vmeth() called again.
Finally stack overflow by loop close call.

It's maybe a side-effect by PR #27485