### PR TITLE
userspace: address some memory domain issues

### DIFF
--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -118,10 +118,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 	/* Apply memory domain configuration, if assigned. Threads that
 	 * started in user mode already had this done via z_setup_new_thread()
 	 */
-	if (_current->mem_domain_info.mem_domain != NULL) {
-		z_x86_apply_mem_domain(_current,
-				       _current->mem_domain_info.mem_domain);
-	}
+	z_x86_apply_mem_domain(_current, _current->mem_domain_info.mem_domain);
 	k_spin_unlock(&z_mem_domain_lock, key);
 
 #ifndef CONFIG_X86_KPTI

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -110,8 +110,11 @@ void *z_x86_userspace_prepare_thread(struct k_thread *thread)
 FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 					void *p1, void *p2, void *p3)
 {
+	k_spinlock_key_t key;
+
 	z_x86_thread_pt_init(_current);
 
+	key = k_spin_lock(&z_mem_domain_lock);
 	/* Apply memory domain configuration, if assigned. Threads that
 	 * started in user mode already had this done via z_setup_new_thread()
 	 */
@@ -119,6 +122,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 		z_x86_apply_mem_domain(_current,
 				       _current->mem_domain_info.mem_domain);
 	}
+	k_spin_unlock(&z_mem_domain_lock, key);
 
 #ifndef CONFIG_X86_KPTI
 	/* We're synchronously dropping into user mode from a thread that

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -119,7 +119,10 @@ extern uint8_t z_shared_kernel_page_start;
 /* Set up per-thread page tables just prior to entering user mode */
 void z_x86_thread_pt_init(struct k_thread *thread);
 
-/* Apply a memory domain policy to a set of thread page tables */
+/* Apply a memory domain policy to a set of thread page tables.
+ *
+ * Must be called with z_mem_domain_lock held.
+ */
 void z_x86_apply_mem_domain(struct k_thread *thread,
 			    struct k_mem_domain *mem_domain);
 #endif /* CONFIG_USERSPACE */

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -127,7 +127,12 @@ extern void k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 /**
  * @brief Destroy a memory domain.
  *
- * Destroy a memory domain.
+ * Destroy a memory domain. All member threads will be re-assigned to the
+ * default memory domain.
+ *
+ * The default memory domain may not be destroyed.
+ *
+ * This API is deprecated and will be removed in Zephyr 2.5.
  *
  * @param domain The memory domain to be destroyed.
  */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -126,6 +126,12 @@ extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
 
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);
+
+/* Memory domain setup hook, called from z_setup_new_thread() */
+void z_mem_domain_init_thread(struct k_thread *thread);
+
+/* Memory domain teardown hook, called from z_thread_single_abort() */
+void z_mem_domain_exit_thread(struct k_thread *thread);
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_GDBSTUB

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -132,6 +132,18 @@ void z_mem_domain_init_thread(struct k_thread *thread);
 
 /* Memory domain teardown hook, called from z_thread_single_abort() */
 void z_mem_domain_exit_thread(struct k_thread *thread);
+
+/* This spinlock:
+ *
+ * - Protects the full set of active k_mem_domain objects and their contents
+ * - Serializes calls to arch_mem_domain_* APIs
+ *
+ * If architecture code needs to access k_mem_domain structures or the
+ * partitions they contain at any other point, this spinlock should be held.
+ * Uniprocessor systems can get away with just locking interrupts but this is
+ * not recommended.
+ */
+extern struct k_spinlock z_mem_domain_lock;
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_GDBSTUB

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -137,30 +137,6 @@ void k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 	k_spin_unlock(&lock, key);
 }
 
-void k_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	k_spinlock_key_t key;
-	sys_dnode_t *node, *next_node;
-
-	__ASSERT_NO_MSG(domain != NULL);
-
-	key = k_spin_lock(&lock);
-
-#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
-	arch_mem_domain_destroy(domain);
-#endif
-
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
-		struct k_thread *thread =
-			CONTAINER_OF(node, struct k_thread, mem_domain_info);
-
-		sys_dlist_remove(&thread->mem_domain_info.mem_domain_q_node);
-		thread->mem_domain_info.mem_domain = NULL;
-	}
-
-	k_spin_unlock(&lock, key);
-}
-
 void k_mem_domain_add_partition(struct k_mem_domain *domain,
 				struct k_mem_partition *part)
 {
@@ -293,6 +269,32 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 void k_mem_domain_remove_thread(k_tid_t thread)
 {
 	k_mem_domain_add_thread(&k_mem_domain_default, thread);
+}
+
+void k_mem_domain_destroy(struct k_mem_domain *domain)
+{
+	k_spinlock_key_t key;
+	sys_dnode_t *node, *next_node;
+
+	__ASSERT_NO_MSG(domain != NULL);
+	__ASSERT(domain != &k_mem_domain_default,
+		 "cannot destroy default domain");
+
+	key = k_spin_lock(&lock);
+
+#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
+	arch_mem_domain_destroy(domain);
+#endif
+
+	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
+		struct k_thread *thread =
+			CONTAINER_OF(node, struct k_thread, mem_domain_info);
+
+		remove_thread_locked(thread);
+		add_thread_locked(&k_mem_domain_default, thread);
+	}
+
+	k_spin_unlock(&lock, key);
 }
 
 static int init_mem_domain_module(const struct device *arg)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -585,6 +585,12 @@ void z_thread_single_abort(struct k_thread *thread)
 		z_thread_monitor_exit(thread);
 
 #ifdef CONFIG_USERSPACE
+		/* Remove this thread from its memory domain, which takes
+		 * it off the domain's thread list and possibly also arch-
+		 * specific tasks.
+		 */
+		z_mem_domain_exit_thread(thread);
+
 		/* Revoke permissions on thread's ID so that it may be
 		 * recycled
 		 */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -616,10 +616,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	}
 #endif
 #ifdef CONFIG_USERSPACE
-	/* New threads inherit any memory domain membership by the parent */
-	new_thread->mem_domain_info.mem_domain = NULL;
-	k_mem_domain_add_thread(_current->mem_domain_info.mem_domain,
-				new_thread);
+	z_mem_domain_init_thread(new_thread);
 
 	if ((options & K_INHERIT_PERMS) != 0U) {
 		z_thread_perms_inherit(_current, new_thread);

--- a/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
+++ b/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
@@ -4,5 +4,10 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mem_protect)
 
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+  )
+
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -69,7 +69,8 @@ void test_main(void)
 			 ztest_unit_test(test_create_new_essential_thread_from_user),
 			 ztest_unit_test(test_create_new_higher_prio_thread_from_user),
 			 ztest_unit_test(test_inherit_resource_pool),
-			 ztest_unit_test(test_create_new_invalid_prio_thread_from_user)
+			 ztest_unit_test(test_create_new_invalid_prio_thread_from_user),
+			 ztest_unit_test(test_mem_domain_boot_threads)
 			 );
 	ztest_run_test_suite(memory_protection_test_suite);
 }

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -51,6 +51,7 @@ extern void test_create_new_higher_prio_thread_from_user(void);
 extern void test_create_new_invalid_prio_thread_from_user(void);
 extern void test_inherit_resource_pool(void);
 extern void test_mark_thread_exit_uninitialized(void);
+extern void test_mem_domain_boot_threads(void);
 
 /* Flag needed to figure out if the fault was expected or not. */
 extern volatile bool valid_fault;


### PR DESCRIPTION
The PR fixes some issues:

- When threads exit, they were not being removed from the list of threads in the memory domain they belonged to. This wasn't causing major issues yet, but will when we need to adjust shared page tables on thread exit.
- The spinlock for memory domains is no longer static and the x86 code was adjusted to hold it when a thread drops to user mode and needs to update its page tables
- `k_mem_domain_destroy()` no longer leaves threads without a memory domain assignment

Also:
- Remove an unnecessary NULL check in the x86 code
- Add a test to ensure the main and static threads properly get assigned to the default memory domain at boot

Fixes: #21991 