### PR TITLE
doc: ext: link-roles: fix crash when west is available but not used

### DIFF
--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -10,9 +10,13 @@ import re
 from docutils import nodes
 from local_util import run_cmd_get_output
 try:
-    from west.manifest import Manifest as WestManifest
+    import west.manifest
+    try:
+        west_manifest = west.manifest.Manifest.from_file()
+    except west.util.WestNotFound:
+        west_manifest = None
 except ImportError:
-    WestManifest = None
+    west_manifest = None
 
 
 def get_github_rev():
@@ -28,8 +32,8 @@ def setup(app):
 
     # try to get url from West; this adds compatibility with repos
     # located elsewhere
-    if WestManifest is not None:
-        baseurl = WestManifest.from_file().get_projects(['zephyr'])[0].url
+    if west_manifest is not None:
+        baseurl = west_manifest.get_projects(['zephyr'])[0].url
     else:
         baseurl = None
 


### PR DESCRIPTION
It should be possible to submit quick documentation fixes without
depending on a complete west workspace. Fixes the following crash:
```
Exception occurred:
  File "west/src/west/util.py", line 82, in west_topdir
    raise WestNotFound('Could not find a West workspace '
west.util.WestNotFound: Could not find a West workspace in this
                        or any parent directory
```
Fixes ae8dd148874a ("doc: ext: link-roles: allow non-default baseurl")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>