### PR TITLE
doc: extract_content.py: support multiple build directories

### DIFF
--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -125,6 +125,11 @@ def find_content(zephyr_base, src, dest, fnfilter, ignore, src_root):
         dirnames[:] = [d for d in dirnames if not
                        path.normpath(path.join(dirpath, d)).startswith(ignore)]
 
+        # Exclude (other) build directories. They may contain previous
+        # output from ourselves!
+        dirnames[:] = [d for d in dirnames if not
+                       path.exists(path.join(dirpath, d, 'CMakeCache.txt'))]
+
         # If the current directory contains no matching files, keep going.
         sources = fnmatch.filter(filenames, fnfilter)
         if not sources:


### PR DESCRIPTION
Exclude (other) build directories with a `CMakeCache.txt` file as they
typically contain previous output from ourselves.

One key feature of 'out of source" builds offered by CMake is allowing
multiple build directories. For instance to build different
configurations without starting from scratch. Unfortunately, the
extract_content.py code had a severe issue with multiple build
directories with an interesting effect on build times, see simple
reproduction below:
```
cd doc/
cmake -B _build/
cmake -B _b2

 # Repeat these a couple times
make -C _build content
make -C _b2 content

find -name rst
./_b2/rst
./_b2/rst/doc/_build/rst
./_b2/rst/doc/_build/rst/doc/_b2/rst
./_b2/rst/doc/_build/rst/doc/_b2/rst/doc/_build/rst
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>