### PR TITLE
doc: restore sphinx-html and sphinx-latex shortcuts

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -259,10 +259,11 @@ set(SPHINX_BUILD_HTML_COMMAND
 add_custom_target(
   sphinx-html
   COMMAND ${SPHINX_BUILD_HTML_COMMAND}
-  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
   COMMENT "Just re-generating HTML (USE WITH CAUTION)"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   USES_TERMINAL
 )
+add_dependencies(sphinx-html content)
 
 # "breathe", the sphinx plugin that parses XML output from doxygen, has
 # an "everything on everything" dependency issue reported at:
@@ -294,10 +295,12 @@ set(SPHINX_BUILD_LATEX_COMMAND
 add_custom_target(
   sphinx-latex
   COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
-  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
   COMMENT "Just re-generating LaTeX (USE WITH CAUTION)"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   USES_TERMINAL
 )
+add_dependencies(sphinx-latex content)
+
 
 add_custom_command(
   OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex


### PR DESCRIPTION
Fixes commit 15fbf707ca77 ("doc: revert to copy files with
extract_content.py directly") that removed (2 years ago!) the definition
of EXTRACT_CONTENT_OUTPUTS while leaving it in use by sphinx-html and
sphinx-latex.

On my Linux box "make sphinx-html" is more than 5 times faster than
"htmldocs", likely because it does not build doxygen nor kconfig.

Also add missing WORKING_DIRECTORY for consistency with regular
targets and to fix this error:
```
Exception occurred:
  File "~/.local/lib/python3.8/site-packages/sphinx/
                   search/__init__.py", line 284, in __init__
    with open(scoring, 'rb') as fp:
FileNotFoundError: [Errno 2] No such file or directory: 'scorer.js'
```
I don't know when that second regression appeared.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>