### PR TITLE
Bluetooth: host: Periodic Advertising Sync Transfer

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -981,6 +981,21 @@ struct bt_le_per_adv_sync_synced_info {
 
 	/** True if receiving periodic advertisements, false otherwise. */
 	bool recv_enabled;
+
+	/**
+	 * @brief Service Data provided by the peer when sync is transferred
+	 *
+	 * Will always be 0 when the sync is locally created.
+	 */
+	uint16_t service_data;
+
+	/**
+	 * @brief Peer that transferred the periodic advertising sync
+	 *
+	 * Will always be 0 when the sync is locally created.
+	 *
+	 */
+	struct bt_conn *conn;
 };
 
 struct bt_le_per_adv_sync_term_info {
@@ -1219,6 +1234,124 @@ int bt_le_per_adv_sync_recv_enable(struct bt_le_per_adv_sync *per_adv_sync);
  * @return Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_sync_recv_disable(struct bt_le_per_adv_sync *per_adv_sync);
+
+/** Periodic Advertising Sync Transfer options */
+enum {
+	/** Convenience value when no options are specified. */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_NONE = 0,
+
+	/**
+	 * @brief No Angle of Arrival (AoA)
+	 *
+	 * Do not sync with Angle of Arrival (AoA) constant tone extension
+	 **/
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOA = BIT(0),
+
+	/**
+	 * @brief No Angle of Departure (AoD) 1 us
+	 *
+	 * Do not sync with Angle of Departure (AoD) 1 us
+	 * constant tone extension
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOD_1US = BIT(1),
+
+	/**
+	 * @brief No Angle of Departure (AoD) 2
+	 *
+	 * Do not sync with Angle of Departure (AoD) 2 us
+	 * constant tone extension
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOD_2US = BIT(2),
+
+	/** Only sync to packets with constant tone extension */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_ONLY_CTE = BIT(3),
+};
+
+struct bt_le_per_adv_sync_transfer_param {
+	/**
+	 * @brief Maximum event skip
+	 *
+	 * The number of periodic advertising packets that can be skipped
+	 * after a successful receive.
+	 */
+	uint16_t skip;
+
+	/**
+	 * @brief Synchronization timeout (N * 10 ms)
+	 *
+	 * Synchronization timeout for the periodic advertising sync.
+	 * Range 0x000A to 0x4000 (100 ms to 163840 ms)
+	 */
+	uint16_t timeout;
+
+	/** Periodic Advertising Sync Transfer options */
+	uint32_t options;
+};
+
+/**
+ * @brief Transfer the periodic advertising sync information to a peer device.
+ *
+ * This will allow another device to quickly synchronize to the same periodic
+ * advertising train that this device is currently synced to.
+ *
+ * @param per_adv_sync  The periodic advertising sync to transfer.
+ * @param conn          The peer device that will receive the sync information.
+ * @param service_data  Application service data provided to the remote host.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
+				const struct bt_conn *conn,
+				uint16_t service_data);
+
+
+/**
+ * @brief Transfer the information about a periodic advertising set.
+ *
+ * This will allow another device to quickly synchronize to periodic
+ * advertising set from this device.
+ *
+ * @param adv           The periodic advertising set to transfer info of.
+ * @param conn          The peer device that will receive the information.
+ * @param service_data  Application service data provided to the remote host.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
+				    const struct bt_conn *conn,
+				    uint16_t service_data);
+
+/**
+ * @brief Subscribe to periodic advertising sync transfers (PASTs).
+ *
+ * Sets the parameters and allow other devices to transfer periodic advertising
+ * syncs.
+ *
+ * @param conn    The connection to set the parameters for. If NULL default
+ *                parameters for all connections will be set. Parameters set
+ *                for specific connection will always have precedence.
+ * @param param   The periodic advertising sync transfer parameters.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_le_per_adv_sync_transfer_subscribe(
+	const struct bt_conn *conn,
+	const struct bt_le_per_adv_sync_transfer_param *param);
+
+/**
+ * @brief Unsubscribe from periodic advertising sync transfers (PASTs).
+ *
+ * Remove the parameters that allow other devices to transfer periodic
+ * advertising syncs.
+ *
+ * @param conn    The connection to remove the parameters for. If NULL default
+ *                parameters for all connections will be removed. Unsubscribing
+ *                for a specific device, will still allow other devices to
+ *                transfer periodic advertising syncs.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_le_per_adv_sync_transfer_unsubscribe(const struct bt_conn *conn);
 
 enum {
 	/** Convenience value when no options are specified. */

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -151,8 +151,8 @@ struct bt_hci_cmd_hdr {
 #define BT_LE_FEAT_BIT_ANT_SWITCH_TX_AOD        21
 #define BT_LE_FEAT_BIT_ANT_SWITCH_RX_AOA        22
 #define BT_LE_FEAT_BIT_RX_CTE                   23
-#define BT_LE_FEAT_BIT_PERIODIC_SYNC_XFER_SEND  24
-#define BT_LE_FEAT_BIT_PERIODIC_SYNC_XFER_RECV  25
+#define BT_LE_FEAT_BIT_PAST_SEND                24
+#define BT_LE_FEAT_BIT_PAST_RECV                25
 #define BT_LE_FEAT_BIT_SCA_UPDATE               26
 #define BT_LE_FEAT_BIT_REMOTE_PUB_KEY_VALIDATE  27
 #define BT_LE_FEAT_BIT_CIS_MASTER               28
@@ -185,6 +185,10 @@ struct bt_hci_cmd_hdr {
 						BT_LE_FEAT_BIT_EXT_ADV)
 #define BT_FEAT_LE_EXT_PER_ADV(feat)            BT_LE_FEAT_TEST(feat, \
 						BT_LE_FEAT_BIT_PER_ADV)
+#define BT_FEAT_LE_PAST_SEND(feat)              BT_LE_FEAT_TEST(feat, \
+						BT_LE_FEAT_BIT_PAST_SEND)
+#define BT_FEAT_LE_PAST_RECV(feat)              BT_LE_FEAT_TEST(feat, \
+						BT_LE_FEAT_BIT_PAST_RECV)
 #define BT_FEAT_LE_CIS_MASTER(feat)             BT_LE_FEAT_TEST(feat, \
 						BT_LE_FEAT_BIT_CIS_MASTER)
 #define BT_FEAT_LE_CIS_SLAVE(feat)              BT_LE_FEAT_TEST(feat, \
@@ -1341,6 +1345,66 @@ struct bt_hci_cp_le_set_per_adv_recv_enable {
 	uint8_t  enable;
 } __packed;
 
+#define BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER      BT_OP(BT_OGF_LE, 0x005a)
+struct bt_hci_cp_le_per_adv_sync_transfer {
+	uint16_t conn_handle;
+	uint16_t service_data;
+	uint16_t sync_handle;
+} __packed;
+
+struct bt_hci_rp_le_per_adv_sync_transfer {
+	uint8_t  status;
+	uint16_t conn_handle;
+} __packed;
+
+#define BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER  BT_OP(BT_OGF_LE, 0x005b)
+struct bt_hci_cp_le_per_adv_set_info_transfer {
+	uint16_t conn_handle;
+	uint16_t service_data;
+	uint8_t  adv_handle;
+} __packed;
+
+struct bt_hci_rp_le_per_adv_set_info_transfer {
+	uint8_t  status;
+	uint16_t conn_handle;
+} __packed;
+
+#define BT_HCI_LE_PAST_MODE_NO_SYNC              0x00
+#define BT_HCI_LE_PAST_MODE_NO_REPORTS           0x01
+#define BT_HCI_LE_PAST_MODE_SYNC                 0x02
+
+#define BT_HCI_LE_PAST_CTE_TYPE_NO_AOA           BIT(0)
+#define BT_HCI_LE_PAST_CTE_TYPE_NO_AOD_1US       BIT(1)
+#define BT_HCI_LE_PAST_CTE_TYPE_NO_AOD_2US       BIT(2)
+#define BT_HCI_LE_PAST_CTE_TYPE_NO_CTE           BIT(3)
+#define BT_HCI_LE_PAST_CTE_TYPE_ONLY_CTE         BIT(4)
+
+#define BT_HCI_OP_LE_PAST_PARAM                 BT_OP(BT_OGF_LE, 0x005c)
+struct bt_hci_cp_le_past_param {
+	uint16_t conn_handle;
+	uint8_t  mode;
+	uint16_t skip;
+	uint16_t timeout;
+	uint8_t  cte_type;
+} __packed;
+
+struct bt_hci_rp_le_past_param {
+	uint8_t  status;
+	uint16_t conn_handle;
+} __packed;
+
+#define BT_HCI_OP_LE_DEFAULT_PAST_PARAM         BT_OP(BT_OGF_LE, 0x005d)
+struct bt_hci_cp_le_default_past_param {
+	uint8_t  mode;
+	uint16_t skip;
+	uint16_t timeout;
+	uint8_t  cte_type;
+} __packed;
+
+struct bt_hci_rp_le_default_past_param {
+	uint8_t  status;
+} __packed;
+
 #define BT_HCI_OP_LE_READ_BUFFER_SIZE_V2        BT_OP(BT_OGF_LE, 0x0060)
 struct bt_hci_rp_le_read_buffer_size_v2 {
 	uint8_t  status;
@@ -2000,6 +2064,19 @@ struct bt_hci_evt_le_chan_sel_algo {
 	uint8_t  chan_sel_algo;
 } __packed;
 
+#define BT_HCI_EVT_LE_PAST_RECEIVED                0x18
+struct bt_hci_evt_le_past_received {
+	uint8_t      status;
+	uint16_t     conn_handle;
+	uint16_t     service_data;
+	uint16_t     sync_handle;
+	uint8_t      adv_sid;
+	bt_addr_le_t addr;
+	uint8_t      phy;
+	uint16_t     interval;
+	uint8_t      clock_accuracy;
+} __packed;
+
 #define BT_HCI_EVT_LE_CIS_ESTABLISHED           0x19
 struct bt_hci_evt_le_cis_established {
 	uint8_t  status;
@@ -2173,6 +2250,7 @@ struct bt_hci_evt_le_biginfo_adv_report {
 #define BT_EVT_MASK_LE_ADV_SET_TERMINATED        BT_EVT_BIT(17)
 #define BT_EVT_MASK_LE_SCAN_REQ_RECEIVED         BT_EVT_BIT(18)
 #define BT_EVT_MASK_LE_CHAN_SEL_ALGO             BT_EVT_BIT(19)
+#define BT_EVT_MASK_LE_PAST_RECEIVED             BT_EVT_BIT(23)
 #define BT_EVT_MASK_LE_CIS_ESTABLISHED           BT_EVT_BIT(24)
 #define BT_EVT_MASK_LE_CIS_REQ                   BT_EVT_BIT(25)
 #define BT_EVT_MASK_LE_BIG_COMPLETE              BT_EVT_BIT(26)


### PR DESCRIPTION
Adds support for the periodic advertising sync transfer
(PAST) feature, which allows a synced device, or an
advertiser, to transfer synchronization of a periodic
advertising train to a connected device.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>