### PR TITLE
lib: posix: eventfd: Fix use of 'struct k_spinlock_key'

### DIFF
--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -84,7 +84,7 @@ static ssize_t eventfd_read_op(void *obj, void *buf, size_t sz)
 	struct eventfd *efd = obj;
 	int result = 0;
 	eventfd_t count = 0;
-	struct k_spinlock_key key;
+	k_spinlock_key_t key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;
@@ -130,7 +130,7 @@ static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 	int result = 0;
 	eventfd_t count;
 	bool overflow;
-	struct k_spinlock_key key;
+	k_spinlock_key_t key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;


### PR DESCRIPTION
Code should be using k_spinlock_key_t and not 'struct k_spinlock_key'.
With recent change to redefine struct k_spinlock_key we see this code
break because it wasn't using the correct type.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>