### PR TITLE
lib: posix: eventfd: fix usage of struct k_spinlock_key

### DIFF
--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -84,7 +84,7 @@ static ssize_t eventfd_read_op(void *obj, void *buf, size_t sz)
 	struct eventfd *efd = obj;
 	int result = 0;
 	eventfd_t count = 0;
-	struct k_spinlock_key key;
+	k_spinlock_key_t key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;
@@ -130,7 +130,7 @@ static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 	int result = 0;
 	eventfd_t count;
 	bool overflow;
-	struct k_spinlock_key key;
+	k_spinlock_key_t key;
 
 	if (sz < sizeof(eventfd_t)) {
 		errno = EINVAL;


### PR DESCRIPTION
Convert eventfd from using struct k_spinlock_key to using the opaque k_spinlock_key_t.

Fixes: b7e1e21b3c2aa7b894b3de2fe252d9a1497840b4

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>