### PR TITLE
isolated features used to support devicetree bindings

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -41,6 +41,15 @@
  * @}
  */
 
+/**
+ * @brief Name for an invalid node identifier
+ *
+ * This supports cases where factored macros can be invoked from paths where
+ * devicetree data may or may not be available.  It is a preprocessor identifier
+ * that does not match any valid devicetree node identifier.
+ */
+#define DT_INVALID_NODE _
+
 /*
  * Property suffixes
  * -----------------

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -545,6 +545,16 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
 #define EMPTY
 
 /**
+ * @brief Macro that expands to its argument
+ *
+ * This is useful in macros like @c FOR_EACH() when there is no
+ * transformation required on the list elements.
+ *
+ * @param V any value
+ */
+#define IDENTITY(V) V
+
+/**
  * @brief Get nth argument from argument list.
  *
  * @param N Argument index to fetch. Counter from 1.


### PR DESCRIPTION
These come from #26616:
* add a named token to represent a node handle that cannot be a valid node
* add an IDENTITY macro for preprocessor iterations that don't transform the iterator value