### PR TITLE
doc: fix broken link-roles on west>=0.8

### DIFF
--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -34,7 +34,7 @@ def setup(app):
         baseurl = None
 
     # or fallback to default
-    if baseurl is None:
+    if baseurl is None or baseurl == '':
         baseurl = 'https://github.com/zephyrproject-rtos/zephyr'
 
     app.add_role('zephyr_file', autolink('{}/blob/{}/%s'.format(baseurl, rev)))


### PR DESCRIPTION
Fix broken links generated by link-roles after west was upgrade to 0.8.0. `url` was previously `None` and now returns an empty str.

Fixes #28990