### PR TITLE
dts: boards: mm_swiftio: enable more devices

### DIFF
--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -67,6 +67,48 @@
 	current-speed = <115200>;
 };
 
+&lpuart2 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&lpuart4 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&lpuart6 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&lpuart8 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&lpi2c1 {
+	status = "okay";
+};
+
+&lpi2c3 {
+	status = "okay";
+};
+
+&lpspi3 {
+	status = "okay";
+	pcs-sck-delay = <50>;
+	sck-pcs-delay = <50>;
+	transfer-delay = <50>;
+};
+
+&lpspi4 {
+	status = "okay";
+	pcs-sck-delay = <50>;
+	sck-pcs-delay = <50>;
+	transfer-delay = <50>;
+};
+
 &usb1 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable i2c/spi/uart devices for mm_swiftio.

Signed-off-by: Frank Li <lgl88911@163.com>