### PR TITLE
arm64: mmu: Fix SMEM_PARTITION_ALIGN define

### DIFF
--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -223,7 +223,7 @@ SECTIONS
 
 #if defined(CONFIG_USERSPACE)
 #define APP_SHARED_ALIGN . = ALIGN(_region_min_align);
-#define SMEM_PARTITION_ALIGN MMU_ALIGN
+#define SMEM_PARTITION_ALIGN(size) MMU_ALIGN
 
 #include <app_smem.ld>
 


### PR DESCRIPTION
In the linker script SMEM_PARTITION_ALIGN is being redefined to be the same as MMU_ALIGN (in https://github.com/zephyrproject-rtos/zephyr/blob/master/include/arch/arm/aarch64/scripts/linker.ld#L226).

The problem is that SMEM_PARTITION_ALIGN __must__ take a parameter in input because this is being used by the scripts/gen_app_partitions.py script (in https://github.com/zephyrproject-rtos/zephyr/blob/master/scripts/gen_app_partitions.py#L53) passing a parameter as input.