### PR TITLE
Tfm update for new build system

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -53,6 +53,10 @@ ccache -s
 # lpcxpresso11u68 boards
 pip3 install lpc_checksum
 
+# Temporary fix: Install imgtool, needed for MCUboot to sign images
+# when builindg the TF-M integration samples
+pip3 install imgtool
+
 if [ -n "${DAILY_BUILD}" ]; then
    SANITYCHECK_OPTIONS=" --inline-logs -N --build-only --all --retry-failed 3 -v "
    echo "--- DAILY BUILD"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -454,6 +454,7 @@
 /samples/subsys/mgmt/osdp/                @cbsiddharth
 /samples/subsys/usb/                      @jfischer-phytec-iot @finikorg
 /samples/subsys/power/                    @wentongwu @pabigot @ceolin
+/samples/tfm_integration/                 @ioannisg @microbuilder
 /samples/userspace/                       @andrewboie
 /scripts/coccicheck                       @himanshujha199640 @JuliaLawall
 /scripts/coccinelle/                      @himanshujha199640 @JuliaLawall

--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -20,4 +20,4 @@ board_runner_args(pyocd "--target=lpc55s69")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 
-set(TFM_TARGET_PLATFORM "LPC55S69")
+set(TFM_TARGET_PLATFORM "nxp/lpcxpresso55s69")

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -18,8 +18,9 @@ if (CONFIG_BUILD_WITH_TFM)
 		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
 	endif()
 
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
+	set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+	set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
 
 	# Configure which format (full or hash) to include the public key in
 	# the image manifest
@@ -35,43 +36,42 @@ if (CONFIG_BUILD_WITH_TFM)
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 
 		#Sign secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_s.c
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_S}
 			 -k ${CONFIG_TFM_KEY_FILE_S}
 			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
 			 --align 1
 			 -v ${TFM_IMAGE_VERSION_S}
+			 --pad
+			 --pad-header
 			 ${ADD_NS_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_S}
+			 -s auto
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/AN521/tfm_s.bin
+			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/MPS2/AN521/tfm_s.bin
 			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 		#Sign non-secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_ns.c
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_NS}
 			 -k ${CONFIG_TFM_KEY_FILE_NS}
 			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
 			 --align 1
 			 -v ${TFM_IMAGE_VERSION_NS}
+			 -s auto
 			 ${ADD_S_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_NS}
 			 -H 0x400
-			 --included-header
 			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 
 		#Create concatenated binary image from the two independently signed binary file
 		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
-		ARGS --layout ${PREPROCESSED_FILE}_s.c
+		     --layout ${PREPROCESSED_FILE_S}
 			 -s ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 			 -n ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/mcuboot.bin ${CMAKE_BINARY_DIR}
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#Merge mcuboot.bin and tfm_sign.bin for QEMU
 		COMMAND ${SREC_CAT}

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(EMU_PLATFORM qemu)
-set(TFM_TARGET_PLATFORM "AN521")
+set(TFM_TARGET_PLATFORM "mps2/an521")
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m33)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -7,3 +7,82 @@ if (((CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340PDK_NRF5340_
 zephyr_library()
 zephyr_library_sources(nrf5340_cpunet_reset.c)
 endif()
+
+if (CONFIG_BUILD_WITH_TFM)
+	# Set default image versions if not defined elsewhere
+	if (NOT DEFINED TFM_IMAGE_VERSION_S)
+		set(TFM_IMAGE_VERSION_S 0.0.0+0)
+	endif()
+
+	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
+		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
+	endif()
+
+	set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+	set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
+
+	# Configure which format (full or hash) to include the public key in
+	# the image manifest
+	if(NOT DEFINED TFM_PUBLIC_KEY_FORMAT)
+		set(TFM_PUBLIC_KEY_FORMAT "full")
+	endif()
+
+	# Set srec_cat binary name
+	find_program(SREC_CAT srec_cat)
+	if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
+	    message(FATAL_ERROR "'srec_cat' not found. Please install it, or add it to $PATH.")
+	endif()
+
+	#Create and sign for concatenated binary image, should align with the TF-M BL2
+	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+
+		#Sign secure binary image with public key
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_S}
+			 -k ${CONFIG_TFM_KEY_FILE_S}
+			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
+			 --align 1
+			 -v ${TFM_IMAGE_VERSION_S}
+			 --pad
+			 --pad-header
+			 ${ADD_NS_IMAGE_MIN_VER}
+			 -s auto
+			 -H 0x400
+			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/NORDIC_NRF/NRF5340PDK_NRF5340_CPUAPP/tfm_s.bin
+			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+
+		#Sign non-secure binary image with public key
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_NS}
+			 -k ${CONFIG_TFM_KEY_FILE_NS}
+			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
+			 --align 1
+			 -v ${TFM_IMAGE_VERSION_NS}
+			 -s auto
+			 ${ADD_S_IMAGE_MIN_VER}
+			 -H 0x400
+			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+
+		#Create concatenated binary image from the two independently signed binary files
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
+		     --layout ${PREPROCESSED_FILE_S}
+			 -s ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+			 -n ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
+
+		#Copy mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+
+		# Generate an intel hex file from the signed output binary
+		COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin
+			-binary
+			-offset 0x10000
+			-o ${CMAKE_BINARY_DIR}/tfm_sign.hex
+			-intel
+
+		# Copy tfm_sign.hex to zephyr
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm_sign.hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+	)
+endif()

--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Set the corresponding TF-M target platform when building for the Non-Secure
+# version of the board (Application MCU).
+if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS)
+  set(TFM_TARGET_PLATFORM "nordic_nrf/nrf5340pdk_nrf5340_cpuapp")
+  set(TFM_PUBLIC_KEY_FORMAT "full")
+endif()
+
 if((CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS) OR
   (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS))
 board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_APPLICATION")

--- a/boards/arm/nrf5340dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340dk_nrf5340/doc/index.rst
@@ -185,10 +185,19 @@ nRF5340 IDAU may configure bus accesses by the nRF5340 Network MCU
 to have Secure attribute set; the latter allows to build and run
 Secure only applications on the nRF5340 SoC.
 
-Building Secure/Non-Secure Zephyr applications
-==============================================
+Building Secure/Non-Secure Zephyr applications with Arm |reg| TrustZone |reg|
+=============================================================================
 
-The process requires the following steps:
+Applications on the nRF5340 may contain a Secure and a Non-Secure firmware
+image for the Application MCU. The Secure image can be built using either
+Zephyr or `Trusted Firmware M`_ (TF-M). Non-Secure firmware
+images are always built using Zephyr. The two alternatives are described below.
+
+Building the Secure firmware using Zephyr
+-----------------------------------------
+
+The process to build the Secure and the Non-Secure firmware images
+using Zephyr requires the following steps:
 
 1. Build the Secure Zephyr application for the Application MCU
    using ``-DBOARD=nrf5340pdk_nrf5340_cpuapp`` and
@@ -199,6 +208,33 @@ The process requires the following steps:
 3. Merge the two binaries together.
 4. Build the application firmware for the Network MCU using
    ``-DBOARD=nrf5340pdk_nrf5340_cpunet``.
+
+
+Building the Secure firmware with TF-M
+--------------------------------------
+
+The process to build the Secure firmware image using TF-M and the Non-Secure
+firmware image using Zephyr requires the following steps:
+
+1. Build the Non-Secure Zephyr application
+   for the Application MCU using ``-DBOARD=nrf5340pdk_nrf5340_cpuappns`` and
+   ``CONFIG_BUILD_WITH_TFM=y`` in the application project configuration file.
+   The Zephyr build system will perform the following steps automatically:
+
+      * Build the Non-Secure firmware image as a regular Zephyr application
+      * Build a TF-M (secure) firmware image
+      * Merge the output binaries together
+      * Optionally build a bootloader image (MCUboot)
+
+.. note::
+
+   Depending on the TF-M configuration, an application DTS overlay may be
+   required, to adjust the Non-Secure image Flash and SRAM starting address
+   and sizes.
+
+2. Build the application firmware for the Network MCU using
+   ``-DBOARD=nrf5340pdk_nrf5340_cpunet``.
+
 
 When building a Secure/Non-Secure application for the nRF5340 Application MCU,
 the Secure application will have to set the IDAU (SPU) configuration to allow
@@ -273,3 +309,4 @@ References
 .. _nRF5340 PDK website:
    https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
+++ b/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
@@ -5,3 +5,82 @@ if(CONFIG_BOARD_NRF52840_GPIO_RESET)
   zephyr_library()
   zephyr_library_sources(nrf52840_reset.c)
 endif()
+
+if (CONFIG_BUILD_WITH_TFM)
+	# Set default image versions if not defined elsewhere
+	if (NOT DEFINED TFM_IMAGE_VERSION_S)
+		set(TFM_IMAGE_VERSION_S 0.0.0+0)
+	endif()
+
+	if (NOT DEFINED TFM_IMAGE_VERSION_NS)
+		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
+	endif()
+
+	set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+	set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
+
+	# Configure which format (full or hash) to include the public key in
+	# the image manifest
+	if(NOT DEFINED TFM_PUBLIC_KEY_FORMAT)
+		set(TFM_PUBLIC_KEY_FORMAT "full")
+	endif()
+
+	# Set srec_cat binary name
+	find_program(SREC_CAT srec_cat)
+	if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
+	    message(FATAL_ERROR "'srec_cat' not found. Please install it, or add it to $PATH.")
+	endif()
+
+	#Create and sign for concatenated binary image, should align with the TF-M BL2
+	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+
+		#Sign secure binary image with public key
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_S}
+			 -k ${CONFIG_TFM_KEY_FILE_S}
+			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
+			 --align 1
+			 -v ${TFM_IMAGE_VERSION_S}
+			 --pad
+			 --pad-header
+			 ${ADD_NS_IMAGE_MIN_VER}
+			 -s auto
+			 -H 0x400
+			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/NORDIC_NRF/NRF9160DK_NRF9160/tfm_s.bin
+			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+
+		#Sign non-secure binary image with public key
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_NS}
+			 -k ${CONFIG_TFM_KEY_FILE_NS}
+			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
+			 --align 1
+			 -v ${TFM_IMAGE_VERSION_NS}
+			 -s auto
+			 ${ADD_S_IMAGE_MIN_VER}
+			 -H 0x400
+			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
+			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+
+		#Create concatenated binary image from the two independently signed binary files
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
+		     --layout ${PREPROCESSED_FILE_S}
+			 -s ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+			 -n ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
+
+		#Copy mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+
+		# Generate an intel hex file from the signed output binary
+		COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin
+		-binary
+		-offset 0x10000
+		-o ${CMAKE_BINARY_DIR}/tfm_sign.hex
+		-intel
+
+		# Copy tfm_sign.hex to zephyr
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm_sign.hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+	)
+endif()

--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Set the corresponding TF-M target platform when building for the Non-Secure
+# version of the board (Application MCU).
+if(CONFIG_BOARD_NRF9160DK_NRF9160NS)
+  set(TFM_TARGET_PLATFORM "nordic_nrf/nrf9160dk_nrf9160")
+  set(TFM_PUBLIC_KEY_FORMAT "full")
+endif()
+
 board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf9160dk_nrf9160/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf9160/doc/index.rst
@@ -126,8 +126,16 @@ Programming and Debugging
 nrf9160dk_nrf9160 supports the Armv8m Security Extension, and by default boots
 in the Secure state.
 
-Building Secure/Non-Secure Zephyr applications
-==============================================
+Building Secure/Non-Secure Zephyr applications with Arm |reg| TrustZone |reg|
+=============================================================================
+
+Applications on the nRF9160 may contain a Secure and a Non-Secure firmware
+image. The Secure image can be built using either Zephyr or
+`Trusted Firmware M`_ (TF-M). Non-Secure firmware images are always built
+using Zephyr. The two alternatives are described below.
+
+Building the Secure firmware using Zephyr
+-----------------------------------------
 
 The process requires the following steps:
 
@@ -135,6 +143,28 @@ The process requires the following steps:
    ``CONFIG_TRUSTED_EXECUTION_SECURE=y`` in the the application project configuration file.
 2. Build the Non-Secure Zephyr application using ``-DBOARD=nrf9160dk_nrf9160ns``.
 3. Merge the two binaries together.
+
+Building the Secure firmware with TF-M
+--------------------------------------
+
+The process to build the Secure firmware image using TF-M and the Non-Secure
+firmware image using Zephyr requires the following action:
+
+* Build the Non-Secure Zephyr application
+   using ``-DBOARD=nrf9160dk_nrf9160ns`` and
+   ``CONFIG_BUILD_WITH_TFM=y`` in the application project configuration file.
+   The Zephyr build system will perform the following steps automatically:
+
+      * Build the Non-Secure firmware image as a regular Zephyr application
+      * Build a TF-M (secure) firmware image
+      * Merge the output binaries together
+      * Optionally build a bootloader image (MCUboot)
+
+.. note::
+
+   Depending on the TF-M configuration, an application DTS overlay may be
+   required, to adjust the Non-Secure image Flash and SRAM starting address
+   and sizes.
 
 When building a Secure/Non-Secure application, the Secure application will
 have to set the IDAU (SPU) configuration to allow Non-Secure access to all
@@ -204,3 +234,4 @@ References
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF9160 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/arm/nucleo_l552ze_q/CMakeLists.txt
+++ b/boards/arm/nucleo_l552ze_q/CMakeLists.txt
@@ -16,49 +16,49 @@ if (CONFIG_BUILD_WITH_TFM)
 		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
 	endif()
 
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
+	set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+	set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
 
 	# Configure which format (full or hash) to include the public key in
 	# the image manifest
-	set(TFM_PUBLIC_KEY_FORMAT "hash")
+	set(TFM_PUBLIC_KEY_FORMAT "full")
 
 	#Create and sign for concatenated binary image, should align with the TF-M BL2
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 
 		#Sign secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_s.c
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_S}
 			 -k ${CONFIG_TFM_KEY_FILE_S}
 			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
 			 --align 1
 			 -v ${TFM_IMAGE_VERSION_S}
+			 --pad
+			 --pad-header
 			 ${ADD_NS_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_S}
+			 -s auto
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/STM_NUCLEO_L552ZE_Q/tfm_s.bin
+			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/STM/NUCLEO_L552ZE_Q/tfm_s.bin
 			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 		#Sign non-secure binary image with public key
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			 --layout ${PREPROCESSED_FILE}_ns.c
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			 --layout ${PREPROCESSED_FILE_NS}
 			 -k ${CONFIG_TFM_KEY_FILE_NS}
 			 --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
 			 --align 1
 			 -v ${TFM_IMAGE_VERSION_NS}
+			 -s auto
 			 ${ADD_S_IMAGE_MIN_VER}
-			 ${ADD_SECURITY_COUNTER_NS}
 			 -H 0x400
-			 --included-header
 			 ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/mcuboot.bin ${CMAKE_BINARY_DIR}
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#Execute post build script postbuild.sh
-		COMMAND ${CMAKE_BINARY_DIR}/tfm/install/postbuild.sh
+		COMMAND ${CMAKE_BINARY_DIR}/tfm/postbuild.sh
       )
 endif()

--- a/boards/arm/nucleo_l552ze_q/CMakeLists.txt
+++ b/boards/arm/nucleo_l552ze_q/CMakeLists.txt
@@ -6,6 +6,12 @@ zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()
 
+if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "zephyr")
+	set(COMPILER_FULL_PATH ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc)
+elseif(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "gnuarmemb")
+	set(COMPILER_FULL_PATH ${GNUARMEMB_TOOLCHAIN_PATH}/bin/arm-none-eabi-gcc)
+endif()
+
 if (CONFIG_BUILD_WITH_TFM)
 	# Set default image versions if not defined elsewhere
 	if (NOT DEFINED TFM_IMAGE_VERSION_S)
@@ -59,6 +65,6 @@ if (CONFIG_BUILD_WITH_TFM)
 		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#Execute post build script postbuild.sh
-		COMMAND ${CMAKE_BINARY_DIR}/tfm/postbuild.sh
+		COMMAND ${CMAKE_BINARY_DIR}/tfm/postbuild.sh ${COMPILER_FULL_PATH}
       )
 endif()

--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -6,4 +6,4 @@ board_runner_args(pyocd "--target=stm32l552zetxq")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
-set(TFM_TARGET_PLATFORM "STM_NUCLEO_L552ZE_Q")
+set(TFM_TARGET_PLATFORM "stm/nucleo_l552ze_q")

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -18,8 +18,9 @@ if (CONFIG_BUILD_WITH_TFM)
 		set(TFM_IMAGE_VERSION_NS 0.0.0+0)
 	endif()
 
-	set(PREPROCESSED_FILE "${CMAKE_BINARY_DIR}/tfm/image_macros_preprocessed")
-	set(TFM_MCUBOOT_DIR "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot")
+	set(PREPROCESSED_FILE_S "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+	set(PREPROCESSED_FILE_NS "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
+	set(TFM_MCUBOOT_DIR "${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/bl2/ext/mcuboot")
 
 	# Configure which format (full or hash) to include the public key in
 	# the image manifest
@@ -31,36 +32,40 @@ if (CONFIG_BUILD_WITH_TFM)
 	    message(FATAL_ERROR "'srec_cat' not found. Please install it, or add it to $PATH.")
 	endif()
 
-	#Create and sign for concatenated binary image should align with the TF-M BL2
+	# Create and sign for concatenated binary image should align with the TF-M BL2
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 
-		#Create concatenated binary image from the two binary file
+		# Create concatenated binary image from the two binary files
 		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
-		ARGS --layout ${PREPROCESSED_FILE}.c
+		    --layout ${PREPROCESSED_FILE_NS}
 			-s ${CMAKE_BINARY_DIR}/tfm/install/outputs/MUSCA_B1/tfm_s.bin
 			-n ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			-o ${CMAKE_BINARY_DIR}/tfm_full.bin
 
 		#Sign concatenated binary image with default public key in mcuboot folder
-		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/imgtool.py
-		ARGS sign
-			--layout ${PREPROCESSED_FILE}.c
-			-k ${CONFIG_TFM_KEY_FILE_S}
+		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
+			--layout ${PREPROCESSED_FILE_NS}
+			-k ${CONFIG_TFM_KEY_FILE_NS}
 			--public-key-format ${TFM_PUBLIC_KEY_FORMAT}
 			--align 1
-			-v ${TFM_IMAGE_VERSION_S}
-			${ADD_SECURITY_COUNTER}
+			-v ${TFM_IMAGE_VERSION_NS}
+			--pad
+			--pad-header
+			${ADD_NS_IMAGE_MIN_VER}
+			-s auto
 			-H 0x400
-			--included-header
 			${CMAKE_BINARY_DIR}/tfm_full.bin
 			${CMAKE_BINARY_DIR}/tfm_sign.bin
 
+		#Copy mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+
 		#srec_cat to combine images into hex for drag and drop
 		COMMAND ${SREC_CAT}
-		ARGS ${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/mcuboot.bin -binary
+		ARGS ${CMAKE_BINARY_DIR}/mcuboot.bin -Binary
 			-offset 0xA000000
-			${CMAKE_BINARY_DIR}/tfm_sign.bin -binary
+			${CMAKE_BINARY_DIR}/tfm_sign.bin -Binary
 			-offset 0xA020000
-			-o ${CMAKE_BINARY_DIR}/tfm_zephyr.hex -Intel --line-length=44
+			-o ${CMAKE_BINARY_DIR}/tfm_zephyr.hex -intel --line-length=44
 	)
 endif()

--- a/boards/arm/v2m_musca_b1/board.cmake
+++ b/boards/arm/v2m_musca_b1/board.cmake
@@ -1,6 +1,6 @@
 #SPDX-License-Identifier: Apache-2.0
 
-set(TFM_TARGET_PLATFORM "MUSCA_B1")
+set(TFM_TARGET_PLATFORM "musca_b1")
 
 board_set_debugger_ifnset(pyocd)
 board_set_flasher_ifnset(pyocd)

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -26,7 +26,7 @@ if BUILD_WITH_TFM
 config TFM_KEY_FILE_S
 	string "Path to private key used to sign secure firmware images."
 	depends on BUILD_WITH_TFM
-	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-rsa-3072.pem"
+	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-RSA-3072.pem"
 	help
 	  The path and filename for the .pem file containing the private key
 	  that should be used by the BL2 bootloader when signing secure
@@ -35,7 +35,7 @@ config TFM_KEY_FILE_S
 config TFM_KEY_FILE_NS
 	string "Path to private key used to sign non-secure firmware images."
 	depends on BUILD_WITH_TFM
-	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-rsa-3072_1.pem"
+	default "${ZEPHYR_BASE}/../modules/tee/tfm/trusted-firmware-m/bl2/ext/mcuboot/root-RSA-3072_1.pem"
 	help
 	  The path and filename for the .pem file containing the private key
 	  that should be used by the BL2 bootloader when signing non-secure

--- a/samples/tfm_integration/psa_level_1/CMakeLists.txt
+++ b/samples/tfm_integration/psa_level_1/CMakeLists.txt
@@ -17,8 +17,7 @@ endif()
 trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
                        BOARD ${TFM_TARGET_PLATFORM}
                        IPC
-                       CFGFILE "ConfigRegressionIPC"
-                       OUT_VENEERS_FILE VENEERS_FILE
+                       REGRESSION
                        ${TFM_BL2_ARGUMENT}
 )
 
@@ -38,7 +37,7 @@ target_sources(app PRIVATE src/util_app_log.c)
 target_sources(app PRIVATE src/util_sformat.c)
 
 # Include TF-M secure service source files
-target_link_libraries(app PRIVATE tfm_ipc_psa_api)
+target_link_libraries(app PRIVATE tfm_api)
 
 # Link in veneer function locations
 target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${VENEERS_FILE})

--- a/samples/tfm_integration/psa_level_1/README.rst
+++ b/samples/tfm_integration/psa_level_1/README.rst
@@ -140,12 +140,45 @@ and non-secure (``zephyr.hex``) images wth a J-Link as follows:
    .. code-block:: console
 
       JLinkExe -device lpc55s69 -if swd -speed 2000 -autoconnect 1
-      J-Link>loadfile build/tfm/install/outputs/LPC55S69/tfm_s.hex
+      J-Link>loadfile build/tfm/install/outputs/NXP/LPCXPRESSO55S69/tfm_s.hex
       J-Link>loadfile build/zephyr/zephyr.hex
 
 NOTE: At present, the LPC55S69 doesn't include support for the MCUBoot bootloader.
 
 We need to reset the board manually after flashing the image to run this code.
+
+On nRF5340 and nRF9160:
+=======================
+
+Build Zephyr with a non-secure configuration
+(``-DBOARD=nrf5340pdk_nrf5340_cpuappns`` or ``-DBOARD=nrf9160dk_nrf9160ns``).
+
+   Example, for nRF9160, using ``cmake`` and ``ninja``
+
+   .. code-block:: bash
+
+      cd <ZEPHYR_ROOT>/samples/tfm_integration/psa_level_1/
+      rm -rf build
+      mkdir build && cd build
+      cmake -GNinja -DBOARD=nrf9160dk_nrf9160ns ..
+
+If building with BL2 (MCUboot bootloader) enabled, manually flash
+the MCUboot bootloader image binary (``bl2.hex``).
+
+   Example, using ``nrfjprog`` on nRF9160:
+
+   .. code-block:: bash
+
+      nrfjprg -f NRF91 --program tfm/bin/bl2.hex --sectorerase
+
+Finally, flash the concatenated TF-M + Zephyr binary.
+
+   Example, for nRF9160, using ``cmake`` and ``ninja``
+
+   .. code-block:: bash
+
+      ninja flash
+
 
 Sample Output
 =============

--- a/samples/tfm_integration/psa_level_1/boards/nrf5340pdk_nrf5340_cpuappns.overlay
+++ b/samples/tfm_integration/psa_level_1/boards/nrf5340pdk_nrf5340_cpuappns.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Modify the SRAM partitioning to accommodate the requirements
+ * for the Secure (TF-M) firmware for the configuration that is
+ * used in this sample.
+ */
+
+/* Increase the size of the Secure Firmware (TF-M).
+ * This modification is not required at the moment,
+ * since TF-M region definitions are configured
+ * statically in the TF-M project.
+ */
+&sram0_s {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+};
+
+/* Decrease the size of the Non-Secure Firmware (Zephyr),
+ * and move its starting address to the offset expected by
+ * TF-M.
+ */
+/delete-node/ &sram0_ns;
+/ {
+	reserved-memory {
+		sram0_ns: image_ns@20040000 {
+			reg = <0x20040000 DT_SIZE_K(192)>;
+		};
+	};
+};

--- a/samples/tfm_integration/psa_level_1/boards/nrf9160dk_nrf9160ns.overlay
+++ b/samples/tfm_integration/psa_level_1/boards/nrf9160dk_nrf9160ns.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Modify the SRAM partitioning to accommodate the requirements
+ * for the Secure (TF-M) firmware for the configuration that is
+ * used in this sample.
+ */
+
+/* Increase the size of the Secure Firmware (TF-M).
+ * This modification is not required at the moment,
+ * since TF-M region definitions are configured
+ * statically in the TF-M project.
+ */
+&sram0_s {
+	reg = <0x20000000 DT_SIZE_K(88)>;
+};
+
+/* Decrease the size of the Non-Secure Firmware (Zephyr),
+ * and move its starting address to the offset expected by
+ * TF-M.
+ */
+/delete-node/ &sram0_ns;
+/ {
+	reserved-memory {
+		sram0_ns: image_ns@20016000 {
+			reg = <0x20016000 DT_SIZE_K(168)>;
+		};
+	};
+};
+
+/* Disable UART1, because it is used by default in TF-M */
+&uart1 {
+	status = "disabled";
+};

--- a/samples/tfm_integration/psa_level_1/sample.yaml
+++ b/samples/tfm_integration/psa_level_1/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
     sample.tfm_ipc:
         tags: introduction
-        platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns
+        platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/psa_level_1/sample.yaml
+++ b/samples/tfm_integration/psa_level_1/sample.yaml
@@ -6,6 +6,7 @@ tests:
     sample.tfm_ipc:
         tags: introduction
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
+          nrf9160dk_nrf9160ns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/psa_level_1/sample.yaml
+++ b/samples/tfm_integration/psa_level_1/sample.yaml
@@ -3,7 +3,7 @@ sample:
         side, with Zephyr on the NS side, using IPC mode.
     name: TF-M PSA Level 1 example
 tests:
-    sample.tfm_ipc:
+    sample.psa_level_1:
         tags: introduction
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
           nrf9160dk_nrf9160ns

--- a/samples/tfm_integration/tfm_integration.rst
+++ b/samples/tfm_integration/tfm_integration.rst
@@ -63,12 +63,15 @@ The following Python modules are required when building TF-M binaries:
 * pyasn1
 * pyyaml
 * cbor>=1.0.0
+* imgtool>=1.6.0
+* jinja2
+* click
 
 You can install them via:
 
    .. code-block:: bash
 
-      $ pip3 install --user cryptography pyasn1 pyyaml cbor>=1.0.0
+      $ pip3 install --user cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.6.0 jinja2 click
 
 They are used by TF-M's signing utility to prepare firmware images for
 validation by the bootloader.
@@ -106,7 +109,7 @@ images, and ``tfm/bl2/ext/mcuboot/root-rsa-3072_1.pem`` is used to sign
 non-secure images. Theses default .pem keys keys can be overridden using the
 ``CONFIG_TFM_KEY_FILE_S`` and ``CONFIG_TFM_KEY_FILE_NS`` values.
 
-The ``imgtool.py`` script from TF-M signs the TF-M + Zephyr binary using the
+The ``wrapper.py`` script from TF-M signs the TF-M + Zephyr binary using the
 .pem private key..
 
 To satisfy `PSA Certified Level 1`_ requirements, **You MUST replace

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif (CONFIG_TFM_BL2_FALSE)
 endif()
 
 # Add "tfm" as an external project via the TF-M module's cmake file
-if(${TFM_TARGET_PLATFORM} STREQUAL "STM_NUCLEO_L552ZE_Q")
+if(${TFM_TARGET_PLATFORM} STREQUAL "stm/nucleo_l552ze_q")
    trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
                           BOARD ${TFM_TARGET_PLATFORM}
                           IPC

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -14,20 +14,19 @@ elseif (CONFIG_TFM_BL2_FALSE)
 endif()
 
 # Add "tfm" as an external project via the TF-M module's cmake file
-if(${TFM_TARGET_PLATFORM} STREQUAL "stm/nucleo_l552ze_q")
+if("${TFM_TARGET_PLATFORM}" STREQUAL "stm/nucleo_l552ze_q")
    trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
                           BOARD ${TFM_TARGET_PLATFORM}
                           IPC
-                          CFGFILE "ConfigRegressionIPCTfmLevel2"
-                          OUT_VENEERS_FILE VENEERS_FILE
+                          ISOLATION_LEVEL 2
+                          REGRESSION
                           ${TFM_BL2_ARGUMENT}
    )
 else()
    trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
                           BOARD ${TFM_TARGET_PLATFORM}
                           IPC
-                          CFGFILE "ConfigRegressionIPC"
-                          OUT_VENEERS_FILE VENEERS_FILE
+                          REGRESSION
                           ${TFM_BL2_ARGUMENT}
   )
 endif()
@@ -40,7 +39,7 @@ add_dependencies(app tfm)
 target_sources(app PRIVATE src/main.c)
 
 # Include TF-M secure service source files
-target_link_libraries(app PRIVATE tfm_ipc_psa_api)
+target_link_libraries(app PRIVATE tfm_api)
 
 # Link in veneer function locations
 target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${VENEERS_FILE})

--- a/samples/tfm_integration/tfm_ipc/README.rst
+++ b/samples/tfm_integration/tfm_ipc/README.rst
@@ -114,7 +114,7 @@ Build Zephyr with a non-secure configuration:
 
       $ west build -b nucleo_l552ze_q_ns samples/tfm_integration/tfm_ipc/
 
-Two scripts are avalaible in the ``build/tfm/install`` folder:
+Two scripts are avalaible in the ``build/tfm`` folder:
 
   - ``regression.sh``: Sets platform option bytes config and erase platform.
   - ``TFM_UPDATE.sh``: Writes bl2, secure, and non secure image in target.
@@ -123,8 +123,8 @@ Run them in the following order to flash the board:
 
    .. code-block:: bash
 
-      $ ./build/tfm/install/regression.sh
-      $ ./build/tfm/install/TFM_UPDATE.sh
+      $ ./build/tfm/regression.sh
+      $ ./build/tfm/TFM_UPDATE.sh
 
 Reset the board.
 
@@ -146,12 +146,45 @@ and non-secure (``zephyr.hex``) images wth a J-Link as follows:
    .. code-block:: console
 
       JLinkExe -device lpc55s69 -if swd -speed 2000 -autoconnect 1
-      J-Link>loadfile build/tfm/install/outputs/LPC55S69/tfm_s.hex
+      J-Link>loadfile build/tfm/install/outputs/NXP/LPCXPRESSO55S69/tfm_s.hex
       J-Link>loadfile build/zephyr/zephyr.hex
 
 NOTE: At present, the LPC55S69 doesn't include support for the MCUBoot bootloader.
 
 We need to reset the board manually after flashing the image to run this code.
+
+On nRF5340 and nRF9160:
+=======================
+
+Build Zephyr with a non-secure configuration
+(``-DBOARD=nrf5340pdk_nrf5340_cpuappns`` or ``-DBOARD=nrf9160dk_nrf9160ns``).
+
+   Example, for nRF9160, using ``cmake`` and ``ninja``
+
+   .. code-block:: bash
+
+      cd <ZEPHYR_ROOT>/samples/tfm_integration/psa_level_1/
+      rm -rf build
+      mkdir build && cd build
+      cmake -GNinja -DBOARD=nrf9160dk_nrf9160ns ..
+
+If building with BL2 (MCUboot bootloader) enabled, manually flash
+the MCUboot bootloader image binary (``bl2.hex``).
+
+   Example, using ``nrfjprog`` on nRF9160:
+
+   .. code-block:: bash
+
+      nrfjprg -f NRF91 --program tfm/bin/bl2.hex --sectorerase
+
+Finally, flash the concatenated TF-M + Zephyr binary.
+
+   Example, for nRF9160, using ``cmake`` and ``ninja``
+
+   .. code-block:: bash
+
+      ninja flash
+
 
 Sample Output
 =============

--- a/samples/tfm_integration/tfm_ipc/boards/nrf5340pdk_nrf5340_cpuappns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nrf5340pdk_nrf5340_cpuappns.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Modify the SRAM partitioning to accommodate the requirements
+ * for the Secure (TF-M) firmware for the configuration that is
+ * used in this sample.
+ */
+
+/* Increase the size of the Secure Firmware (TF-M).
+ * This modification is not required at the moment,
+ * since TF-M region definitions are configured
+ * statically in the TF-M project.
+ */
+&sram0_s {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+};
+
+/* Decrease the size of the Non-Secure Firmware (Zephyr),
+ * and move its starting address to the offset expected by
+ * TF-M.
+ */
+/delete-node/ &sram0_ns;
+/ {
+	reserved-memory {
+		sram0_ns: image_ns@20040000 {
+			reg = <0x20040000 DT_SIZE_K(192)>;
+		};
+	};
+};

--- a/samples/tfm_integration/tfm_ipc/boards/nrf9160dk_nrf9160ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nrf9160dk_nrf9160ns.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Modify the SRAM partitioning to accommodate the requirements
+ * for the Secure (TF-M) firmware for the configuration that is
+ * used in this sample.
+ */
+
+/* Increase the size of the Secure Firmware (TF-M).
+ * This modification is not required at the moment,
+ * since TF-M region definitions are configured
+ * statically in the TF-M project.
+ */
+&sram0_s {
+	reg = <0x20000000 DT_SIZE_K(88)>;
+};
+
+/* Decrease the size of the Non-Secure Firmware (Zephyr),
+ * and move its starting address to the offset expected by
+ * TF-M.
+ */
+/delete-node/ &sram0_ns;
+/ {
+	reserved-memory {
+		sram0_ns: image_ns@20016000 {
+			reg = <0x20016000 DT_SIZE_K(168)>;
+		};
+	};
+};
+
+/* Disable UART1, because it is used by default in TF-M */
+&uart1 {
+	status = "disabled";
+};

--- a/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
@@ -6,7 +6,10 @@
 
 
  /* This partition table should be used along with TFM configuration:
-  * ConfigRegressionIPCTfmLevel2
+  * - TFM_PSA_API=ON (IPC)
+  * - ISOLATION_LEVEL 2
+  * - TEST_S=ON (REGRESSION)
+  * - TEST_NS=ON (REGRESSION)
   *
   * In this configuration, TFM binary includes tests. As a consequence,
   * its size is bloated and it is not possible to set secondary partitions
@@ -28,18 +31,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00011000>;
+			reg = <0x00000000 0x00013000>;
 			read-only;
 		};
 		/* Secure image primary slot */
-		slot0_partition: partition@00011000 {
+		slot0_partition: partition@00013000 {
 			label = "image-0";
-			reg = <0x00011000 0x00040000>;
+			reg = <0x00013000 0x00038000>;
 		};
 		/* Non-secure image primary slot */
-		slot1_partition: partition@00051000 {
+		slot1_partition: partition@0004B000 {
 			label = "image-1";
-			reg = <0x00051000 0x0002E000>;
+			reg = <0x0004B000 0x0002A000>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
     sample.tfm_ipc:
         tags: introduction
-        platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns
+        platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -6,6 +6,7 @@ tests:
     sample.tfm_ipc:
         tags: introduction
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
+          nrf9160dk_nrf9160ns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -6,7 +6,7 @@ tests:
     sample.tfm_ipc:
         tags: introduction
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
-          nrf9160dk_nrf9160ns
+          nrf9160dk_nrf9160ns nucleo_l552ze_q_ns
         harness: console
         harness_config:
           type: multi_line

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 143df675557305b61f7930a50459a53a8d2bb097
+      revision: bb15a511a509c81135af61e02f9f4bfaf86d7fde
 
   self:
     path: zephyr


### PR DESCRIPTION
Required fixes in Zephyr in the wake of upgrading TF-M to the new build system (+ getting support for nRF devices).

The upmerge is present in: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/15

The following platforms can currently build and run the TFM Integration samples successfully:
- mps2_an521_nonsecure
- nrf5340pdk_nrf5340_cpuappns
- nrf9160dk_nrf9160ns
- nucleo_l552ze_q_ns

The following platforms now also build successfully (but I have no HW to test)
- lpcxpresso55s69
- musca_b1

The PR also contains the required doc changes for samples and boards.