### PR TITLE
[TOPIC-BLE-LLCP] bluetooth: controller: llcp: Terminate procedure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -196,6 +196,9 @@ struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc)
 	case PROC_PHY_UPDATE:
 		lp_pu_init_proc(ctx);
 		break;
+	case PROC_TERMINATE:
+		lp_comm_init_proc(ctx);
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -231,6 +234,9 @@ struct proc_ctx *ull_cp_priv_create_remote_procedure(enum llcp_proc proc)
 		break;
 	case PROC_PHY_UPDATE:
 		rp_pu_init_proc(ctx);
+		break;
+	case PROC_TERMINATE:
+		rp_comm_init_proc(ctx);
 		break;
 	default:
 		/* Unknown procedure */
@@ -408,6 +414,26 @@ uint8_t ull_cp_phy_update(struct ull_cp_conn *conn)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+	lr_enqueue(conn, ctx);
+
+	return BT_HCI_ERR_SUCCESS;
+}
+
+uint8_t ull_cp_terminate(struct ull_cp_conn *conn, uint8_t error_code)
+{
+	struct proc_ctx *ctx;
+
+	ctx = create_local_procedure(PROC_TERMINATE);
+	if (!ctx) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	ctx->data.term.error_code = error_code;
+
+	/* TODO
+	 * Termination procedure may be initiated at any time, even if other
+	 * LLCP is active.
+	 */
 	lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -53,7 +53,6 @@ struct ull_cp_conn {
 			uint8_t phys;
 			uint8_t min_used_chans;
 		} muc;
-
 	} llcp;
 
 	struct mocked_lll_conn {
@@ -152,3 +151,8 @@ void ull_cp_ltk_req_neq_reply(struct ull_cp_conn *conn);
  * @brief Initiate a PHY Update Procedure.
  */
 uint8_t ull_cp_phy_update(struct ull_cp_conn *conn);
+
+/**
+ * @brief Initiate a Termination Procedure.
+ */
+uint8_t ull_cp_terminate(struct ull_cp_conn *conn, uint8_t error_code);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -13,6 +13,7 @@ enum llcp_proc {
 	PROC_VERSION_EXCHANGE,
 	PROC_ENCRYPTION_START,
 	PROC_PHY_UPDATE,
+	PROC_TERMINATE,
 };
 
 /* LLCP Procedure Context */
@@ -61,6 +62,11 @@ struct proc_ctx {
 			uint8_t error;
 			uint16_t instant;
 		} pu;
+
+		/* Use by ACL Termination Procedure */
+		struct {
+			uint8_t error_code;
+		} term;
 
 	} data;
 	struct {
@@ -321,6 +327,29 @@ static inline void rp_pu_run(struct ull_cp_conn *conn, struct proc_ctx *ctx, voi
 	return ull_cp_priv_rp_pu_run(conn, ctx, param);
 }
 
+/*
+ * Terminate Helper
+ */
+void ull_cp_priv_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+
+static inline void pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_encode_terminate_ind(ctx, pdu);
+}
+
+void ull_cp_priv_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+
+static inline void ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	return ull_cp_priv_ntf_encode_terminate_ind(ctx, pdu);
+}
+
+void ull_cp_priv_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+
+static inline void pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_decode_terminate_ind(ctx, pdu);
+}
 
 /*
  * LLCP Local Request

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -107,6 +107,9 @@ void ull_cp_priv_lr_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, struct no
 	case PROC_PHY_UPDATE:
 		lp_pu_rx(conn, ctx, rx);
 		break;
+	case PROC_TERMINATE:
+		lp_comm_rx(conn, ctx, rx);
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -117,6 +120,9 @@ void ull_cp_priv_lr_tx_ack(struct ull_cp_conn *conn, struct proc_ctx *ctx, struc
 {
 	switch (ctx->proc) {
 	case PROC_MIN_USED_CHANS:
+		lp_comm_tx_ack(conn, ctx, tx);
+		break;
+	case PROC_TERMINATE:
 		lp_comm_tx_ack(conn, ctx, tx);
 		break;
 	default:
@@ -149,6 +155,9 @@ static void lr_act_run(struct ull_cp_conn *conn)
 		break;
 	case PROC_PHY_UPDATE:
 		lp_pu_run(conn, ctx, NULL);
+		break;
+	case PROC_TERMINATE:
+		lp_comm_run(conn, ctx, NULL);
 		break;
 	default:
 		/* Unknown procedure */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -204,6 +204,36 @@ void ull_cp_priv_pdu_decode_min_used_chans_ind(struct ull_cp_conn *conn, struct 
 }
 
 /*
+ * Termination Procedure Helper
+ */
+void ull_cp_priv_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_terminate_ind *p;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, terminate_ind) + sizeof(struct pdu_data_llctrl_terminate_ind);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
+	p = &pdu->llctrl.terminate_ind;
+	p->error_code = ctx->data.term.error_code;
+}
+
+void ull_cp_priv_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_terminate_ind *p;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, terminate_ind) + sizeof(struct pdu_data_llctrl_terminate_ind);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
+	p = &pdu->llctrl.terminate_ind;
+	p->error_code = ctx->data.term.error_code;
+}
+
+void ull_cp_priv_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	ctx->data.term.error_code = pdu->llctrl.terminate_ind.error_code;
+}
+
+/*
  * Version Exchange Procedure Helper
  */
 void ull_cp_priv_pdu_encode_version_ind(struct pdu_data *pdu)
@@ -230,7 +260,6 @@ void ull_cp_priv_ntf_encode_version_ind(struct ull_cp_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_version_ind *p;
-
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, version_ind) +

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -81,6 +81,8 @@ static bool proc_with_instant(struct proc_ctx *ctx)
 	case PROC_PHY_UPDATE:
 		return 1U;
 		break;
+	case PROC_TERMINATE:
+		return 0U;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -160,6 +162,9 @@ void ull_cp_priv_rr_rx(struct ull_cp_conn *conn, struct proc_ctx *ctx, struct no
 	case PROC_PHY_UPDATE:
 		rp_pu_rx(conn, ctx, rx);
 		break;
+	case PROC_TERMINATE:
+		rp_comm_rx(conn, ctx, rx);
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -199,6 +204,9 @@ static void rr_act_run(struct ull_cp_conn *conn)
 		break;
 	case PROC_PHY_UPDATE:
 		rp_pu_run(conn, ctx, NULL);
+		break;
+	case PROC_TERMINATE:
+		rp_comm_run(conn, ctx, NULL);
 		break;
 	default:
 		/* Unknown procedure */
@@ -457,6 +465,9 @@ void ull_cp_priv_rr_new(struct ull_cp_conn *conn, struct node_rx_pdu *rx)
 		break;
 	case PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND:
 		proc = PROC_MIN_USED_CHANS;
+		break;
+	case PDU_DATA_LLCTRL_TYPE_TERMINATE_IND:
+		proc = PROC_TERMINATE;
 		break;
 	default:
 		/* Unknown opcode */

--- a/tests/bluetooth/controller/common/include/helper_pdu.h
+++ b/tests/bluetooth/controller/common/include/helper_pdu.h
@@ -31,9 +31,10 @@ void helper_pdu_encode_phy_rsp(struct pdu_data *pdu, void *param);
 void helper_pdu_encode_phy_update_ind(struct pdu_data *pdu, void *param);
 void helper_pdu_encode_unknown_rsp(struct pdu_data *pdu, void *param);
 
+void helper_pdu_encode_terminate_ind(struct pdu_data *pdu, void *param);
+
 void helper_pdu_verify_ping_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 void helper_pdu_verify_ping_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
-
 
 void helper_pdu_verify_feature_req(const char *file, uint32_t line,
 				   struct pdu_data *pdu, void *param);
@@ -63,10 +64,10 @@ void helper_pdu_verify_phy_rsp(const char *file, uint32_t line, struct pdu_data 
 void helper_pdu_verify_phy_update_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 void helper_pdu_verify_unknown_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
+void helper_pdu_verify_terminate_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+
 void helper_node_verify_phy_update(const char *file, uint32_t line,
 				   struct node_rx_pdu *rx, void *param);
-
-
 
 typedef enum {
 	LL_VERSION_IND,
@@ -86,6 +87,7 @@ typedef enum {
 	LL_PHY_RSP,
 	LL_PHY_UPDATE_IND,
 	LL_UNKNOWN_RSP,
+	LL_TERMINATE_IND,
 } helper_pdu_opcode_t;
 
 typedef enum {

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -198,6 +198,16 @@ void helper_pdu_encode_unknown_rsp(struct pdu_data *pdu, void *param)
 	pdu->llctrl.unknown_rsp.type = p->type;
 }
 
+void helper_pdu_encode_terminate_ind(struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_terminate_ind *p = param;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, terminate_ind) + sizeof(struct pdu_data_llctrl_terminate_ind);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
+	pdu->llctrl.terminate_ind.error_code = p->error_code;
+}
+
 void helper_pdu_verify_version_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_version_ind *p = param;
@@ -372,4 +382,14 @@ void helper_pdu_verify_unknown_rsp(const char *file, uint32_t line, struct pdu_d
 	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, unknown_rsp) + sizeof(struct pdu_data_llctrl_unknown_rsp), "Wrong length.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP, "Not a LL_UNKNOWN_RSP.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.unknown_rsp.type, p->type, "Type mismatch.\nCalled at %s:%d\n", file, line);
+}
+
+void helper_pdu_verify_terminate_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_terminate_ind *p = param;
+
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, terminate_ind) + sizeof(struct pdu_data_llctrl_terminate_ind), "Wrong length.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_TERMINATE_IND, "Not a LL_TERMINATE_IND.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.terminate_ind.error_code, p->error_code, "Error code mismatch.\nCalled at %s:%d\n", file, line);
 }

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -64,6 +64,7 @@ helper_pdu_encode_func_t * const helper_pdu_encode[] = {
 	helper_pdu_encode_phy_rsp,
 	helper_pdu_encode_phy_update_ind,
 	helper_pdu_encode_unknown_rsp,
+	helper_pdu_encode_terminate_ind,
 };
 
 helper_pdu_verify_func_t *const helper_pdu_verify[] = {
@@ -84,6 +85,7 @@ helper_pdu_verify_func_t *const helper_pdu_verify[] = {
 	helper_pdu_verify_phy_rsp,
 	helper_pdu_verify_phy_update_ind,
 	helper_pdu_verify_unknown_rsp,
+	helper_pdu_verify_terminate_ind,
 };
 
 
@@ -225,7 +227,6 @@ void lt_tx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, str
 
 	sys_slist_append(&lt_tx_q, (sys_snode_t *) rx);
 }
-
 
 void lt_rx_real(const char *file, uint32_t line, helper_pdu_opcode_t opcode, struct ull_cp_conn *conn, struct node_tx **tx_ref, void *param)
 {

--- a/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+if (NOT BOARD STREQUAL unit_testing)
+	message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES
+	src/*.c
+)
+
+project(bluetooth_ull_llcp_terminate)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
+target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})

--- a/tests/bluetooth/controller/ctrl_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_terminate/src/main.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020 Demant
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <ztest.h>
+#include "kconfig.h"
+
+/* Kconfig Cheats */
+
+#include <bluetooth/hci.h>
+#include <sys/byteorder.h>
+#include <sys/slist.h>
+#include <sys/util.h>
+#include "hal/ccm.h"
+
+#include "util/mem.h"
+#include "util/memq.h"
+
+#include "pdu.h"
+#include "ll.h"
+#include "ll_settings.h"
+
+#include "lll.h"
+#include "lll_conn.h"
+
+#include "ull_conn_types.h"
+#include "ull_tx_queue.h"
+#include "ull_llcp.h"
+#include "ull_llcp_internal.h"
+
+#include "helper_pdu.h"
+#include "helper_util.h"
+
+struct ull_cp_conn conn;
+
+static void setup(void)
+{
+	test_setup(&conn);
+}
+
+static void test_terminate_rem(uint8_t role)
+{
+	struct pdu_data_llctrl_terminate_ind remote_terminate_ind = {
+		.error_code = 0x05,
+	};
+	struct node_rx_pdu *ntf;
+
+	/* Role */
+	test_set_role(&conn, role);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_TERMINATE_IND, &conn, &remote_terminate_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_TERMINATE_IND, &ntf, &remote_terminate_ind);
+	ut_rx_q_is_empty();
+}
+
+void test_terminate_mas_rem(void)
+{
+	test_terminate_rem(BT_HCI_ROLE_MASTER);
+}
+
+void test_terminate_sla_rem(void)
+{
+	test_terminate_rem(BT_HCI_ROLE_SLAVE);
+}
+
+void test_terminate_loc(uint8_t role)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+
+	struct pdu_data_llctrl_terminate_ind local_terminate_ind = {
+		.error_code = 0x06,
+	};
+
+	/* Role */
+	test_set_role(&conn, role);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate an LE Ping Procedure */
+	err = ull_cp_terminate(&conn, 0x06);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_TERMINATE_IND, &conn, &tx, &local_terminate_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* RX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(tx);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_TERMINATE_IND, &ntf, &local_terminate_ind);
+}
+
+void test_terminate_mas_loc(void)
+{
+	test_terminate_loc(BT_HCI_ROLE_MASTER);
+}
+
+void test_terminate_sla_loc(void)
+{
+	test_terminate_loc(BT_HCI_ROLE_SLAVE);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(term,
+			ztest_unit_test_setup_teardown(test_terminate_mas_rem, setup, unit_test_noop),
+			ztest_unit_test_setup_teardown(test_terminate_sla_rem, setup, unit_test_noop),
+			ztest_unit_test_setup_teardown(test_terminate_mas_loc, setup, unit_test_noop),
+			ztest_unit_test_setup_teardown(test_terminate_sla_loc, setup, unit_test_noop)
+			);
+
+	ztest_run_test_suite(term);
+}

--- a/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
@@ -1,0 +1,5 @@
+common:
+    tags: test_framework bluetooth bt_terminate bt_ull_llcp
+tests:
+  bluetooth.controller.ctrl_terminate.test:
+     type: unit


### PR DESCRIPTION
This implementes initial support for link termination procedure and
unit tests.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>