### PR TITLE
End time comparison is wrong in my_wait_for_event sample code

### DIFF
--- a/doc/reference/kernel/timing/clocks.rst
+++ b/doc/reference/kernel/timing/clocks.rst
@@ -352,13 +352,13 @@ expire.  So such a loop might look like:
         /* Compute the end time from the timeout */
         uint64_t end = z_timeout_end_calc(timeout_in_ms);
 
-        while (end < k_uptime_ticks()) {
-                if (is_event_complete(obj)) {
-                    return;
-                }
+        while (end > k_uptime_ticks()) {
+            if (is_event_complete(obj)) {
+                return;
+            }
 
-                /* Wait for notification of state change */
-                k_sem_take(obj->sem, timeout_in_ms);
+            /* Wait for notification of state change */
+            k_sem_take(obj->sem, timeout_in_ms);
         }
     }
 


### PR DESCRIPTION
We need to loop while `end` is still in the future and thus larger than the current uptime, not smaller.
Also fix indentation.

Signed-off-by: Stephan Walter <stephan@walter.name>