### PR TITLE
stm32: Configure DAC using new pinctrl via DT

### DIFF
--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -103,4 +103,5 @@
 
 &dac1 {
 	status = "okay";
+	pinctrl-0 = <&dac_out1_pa4>;
 };

--- a/boards/arm/nucleo_f091rc/pinmux.c
+++ b/boards/arm/nucleo_f091rc/pinmux.c
@@ -35,9 +35,6 @@ static const struct pin_config pinconf[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay) && CONFIG_ADC
 	{STM32_PIN_PA0, STM32F0_PINMUX_FUNC_PA0_ADC_IN0},
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(dac1), okay) && CONFIG_DAC
-	{STM32_PIN_PA4, STM32F0_PINMUX_FUNC_PA4_DAC_OUT1},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -86,4 +86,5 @@
 
 &dac1 {
 	status = "okay";
+	pinctrl-0 = <&dac_out1_pa4>;
 };

--- a/boards/arm/nucleo_f207zg/pinmux.c
+++ b/boards/arm/nucleo_f207zg/pinmux.c
@@ -34,9 +34,6 @@ static const struct pin_config pinconf[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay) && CONFIG_ADC
 	{STM32_PIN_PA0, STM32F2_PINMUX_FUNC_PA0_ADC123_IN0},
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(dac1), okay) && CONFIG_DAC
-	{STM32_PIN_PA4, STM32F2_PINMUX_FUNC_PA4_DAC_OUT1},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -112,4 +112,5 @@
 
 &dac1 {
 	status = "okay";
+	pinctrl-0 = <&dac1_out1_pa4>;
 };

--- a/boards/arm/nucleo_g431rb/pinmux.c
+++ b/boards/arm/nucleo_g431rb/pinmux.c
@@ -50,9 +50,6 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PA11, STM32G4X_PINMUX_FUNC_PA11_USB_DM},
 	{STM32_PIN_PA12, STM32G4X_PINMUX_FUNC_PA12_USB_DP},
 #endif	/* CONFIG_USB_DC_STM32 */
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(dac1), okay) && CONFIG_DAC
-	{STM32_PIN_PA4, STM32G4X_PINMUX_FUNC_PA4_DAC1_OUT1},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -72,4 +72,5 @@
 
 &dac1 {
 	status = "okay";
+	pinctrl-0 = <&dac_out1_pa4>;
 };

--- a/boards/arm/nucleo_l073rz/pinmux.c
+++ b/boards/arm/nucleo_l073rz/pinmux.c
@@ -26,9 +26,6 @@ static const struct pin_config pinconf[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay) && CONFIG_ADC
 	{STM32_PIN_PA0, STM32L0_PINMUX_FUNC_PA0_ADC_IN0},
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(dac1), okay) && CONFIG_DAC
-	{STM32_PIN_PA4, STM32L0_PINMUX_FUNC_PA4_DAC_OUT1},
-#endif /* dac1 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -71,4 +71,5 @@
 
 &dac1 {
 	status = "okay";
+	pinctrl-0 = <&dac_out1_pa4>;
 };

--- a/boards/arm/nucleo_l152re/pinmux.c
+++ b/boards/arm/nucleo_l152re/pinmux.c
@@ -20,9 +20,6 @@ static const struct pin_config pinconf[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay) && CONFIG_ADC
 	{STM32_PIN_PA0, STM32L1X_PINMUX_FUNC_PA0_ADC1_IN0},
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(dac1), okay) && CONFIG_DAC
-	{STM32_PIN_PA4, STM32L1X_PINMUX_FUNC_PA4_DAC_OUT1},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/dts/bindings/dac/st,stm32-dac.yaml
+++ b/dts/bindings/dac/st,stm32-dac.yaml
@@ -14,6 +14,15 @@ properties:
     clocks:
       required: true
 
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        GPIO pin configuration for DAC output. The phandles are
+        expected to reference pinctrl nodes, e.g.
+
+           pinctrl-0 = <&dac_out1_pa4 &dac_out2_pa5>;
+
     "#io-channel-cells":
       const: 1
 


### PR DESCRIPTION
1. Add support for DT based pinmux configurations to the DAC driver.
2. Use the new DT facilities to configure DAC pinmux on all STM32 nucleo boards currently supporting the DAC.

Tested with `nucleo_l073rz`. However, pins are configured in analog mode by default anyway.