### PR TITLE
net: lwm2m: Fix bootstrap finish response code

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3354,6 +3354,8 @@ static int handle_request(struct coap_packet *request,
 		   strncmp(options[0].value, "bs", options[0].len) == 0) {
 		engine_bootstrap_finish();
 
+		msg->code = COAP_RESPONSE_CODE_CHANGED;
+
 		r = lwm2m_init_message(msg);
 		if (r < 0) {
 			goto error;


### PR DESCRIPTION
LwM2M engine did not set response code for the Bootstrap-finish message,
hence it replied with the code copied from the request which is not
correct. Fix this by setting correct code for the Bootstrap-finish
reply.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>