### PR TITLE
codeowners: Add myself to winc1500

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -281,6 +281,7 @@
 /drivers/watchdog/wdt_handlers.c          @andrewboie
 /drivers/wifi/                            @jukkar @tbursztyka @pfalcon
 /drivers/wifi/eswifi/                     @loicpoulain
+/drivers/wifi/winc1500/                   @kludentwo
 /dts/arc/                                 @abrodkin @ruuddw @iriszzw
 /dts/arm/atmel/sam4e*                     @nandojve
 /dts/arm/atmel/sam4l*                     @nandojve

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -728,6 +728,7 @@ Documentation:
         - tbursztyka
     collaborators:
         - jukkar
+        - kludentwo
     files:
         - drivers/wifi/
     labels:


### PR DESCRIPTION
Add myself as code owner for winc1500 driver.

Signed-off-by: Nicolai Glud <nicolai.glud@prevas.dk>