### PR TITLE
Bluetooth: controller: Initialize close to locality of reference

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -220,9 +220,10 @@ int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 void lll_resume(void *param)
 {
-	struct lll_event *next = param;
+	struct lll_event *next;
 	int ret;
 
+	next = param;
 	ret = prepare(next->is_abort_cb, next->abort_cb, next->prepare_cb,
 		      next->prio, &next->prepare_param, next->is_resume);
 	LL_ASSERT(!ret || ret == -EINPROGRESS);
@@ -240,8 +241,9 @@ void lll_disable(void *param)
 	}
 	{
 		struct lll_event *next;
-		uint8_t idx = UINT8_MAX;
+		uint8_t idx;
 
+		idx = UINT8_MAX;
 		next = ull_prepare_dequeue_iter(&idx);
 		while (next) {
 			if (!next->is_aborted &&
@@ -278,15 +280,17 @@ int lll_prepare_done(void *param)
 
 int lll_done(void *param)
 {
-	struct lll_event *next = ull_prepare_dequeue_get();
-	struct ull_hdr *ull = NULL;
+	struct lll_event *next;
+	struct ull_hdr *ull;
 	void *evdone;
 	int ret = 0;
 
 	/* Assert if param supplied without a pending prepare to cancel. */
+	next = ull_prepare_dequeue_get();
 	LL_ASSERT(!param || next);
 
 	/* check if current LLL event is done */
+	ull = NULL;
 	if (!param) {
 		/* Reset current event instance */
 		LL_ASSERT(event.curr.abort_cb);
@@ -371,9 +375,10 @@ uint32_t lll_evt_offset_get(struct evt_hdr *evt)
 uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 		       uint32_t ticks_at_event)
 {
-	uint32_t ticks_now = ticker_ticks_now_get();
+	uint32_t ticks_now;
 	uint32_t diff;
 
+	ticks_now = ticker_ticks_now_get();
 	diff = ticker_ticks_diff_get(ticks_now, ticks_at_event);
 	diff += HAL_TICKER_CNTR_CMP_OFFSET_MIN;
 	if (!(diff & BIT(HAL_TICKER_CNTR_MSBIT)) &&
@@ -524,11 +529,12 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		   lll_prepare_cb_t prepare_cb, int prio,
 		   struct lll_prepare_param *prepare_param, uint8_t is_resume)
 {
-	uint8_t idx = UINT8_MAX;
 	struct lll_event *p;
+	uint8_t idx;
 	int err;
 
 	/* Find the ready prepare in the pipeline */
+	idx = UINT8_MAX;
 	p = ull_prepare_dequeue_iter(&idx);
 	while (p && (p->is_aborted || p->is_resume)) {
 		p = ull_prepare_dequeue_iter(&idx);
@@ -701,16 +707,17 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 
 static void preempt(void *param)
 {
-	struct lll_event *next = ull_prepare_dequeue_get();
 	lll_prepare_cb_t resume_cb;
-	uint8_t idx = UINT8_MAX;
+	struct lll_event *next;
 	int resume_prio;
+	uint8_t idx;
 	int ret;
 
 	if (!event.curr.abort_cb || !event.curr.param) {
 		return;
 	}
 
+	idx = UINT8_MAX;
 	next = ull_prepare_dequeue_iter(&idx);
 	if (!next) {
 		return;
@@ -739,8 +746,9 @@ static void preempt(void *param)
 
 	if (ret == -EAGAIN) {
 		struct lll_event *iter;
-		uint8_t iter_idx = UINT8_MAX;
+		uint8_t iter_idx;
 
+		iter_idx = UINT8_MAX;
 		iter = ull_prepare_dequeue_iter(&iter_idx);
 		while (iter) {
 			if (!iter->is_aborted &&

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -44,7 +44,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 static int is_abort_cb(void *next, int prio, void *curr,
 		       lll_prepare_cb_t *resume_cb, int *resume_prio);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
@@ -97,13 +97,12 @@ int lll_adv_reset(void)
 
 void lll_adv_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
-	err = lll_prepare(is_abort_cb, abort_cb, prepare_cb, 0, p);
+	err = lll_prepare(is_abort_cb, abort_cb, prepare_cb, 0, param);
 	LL_ASSERT(!err || err == -EINPROGRESS);
 }
 
@@ -168,17 +167,20 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare_cb(struct lll_prepare_param *prepare_param)
+static int prepare_cb(struct lll_prepare_param *p)
 {
-	struct lll_adv *lll = prepare_param->param;
-	uint32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
-	uint32_t ticks_at_event, ticks_at_start;
+	uint32_t ticks_at_event;
+	uint32_t ticks_at_start;
 	struct pdu_adv *pdu;
 	struct evt_hdr *evt;
+	struct lll_adv *lll;
 	uint32_t remainder;
 	uint32_t start_us;
+	uint32_t aa;
 
 	DEBUG_RADIO_START_A(1);
+
+	lll = p->param;
 
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
@@ -196,6 +198,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	}
 
 	radio_reset();
+
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	radio_tx_power_set(lll->tx_pwr_lvl);
 #else
@@ -211,6 +214,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, 0);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
+	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
 			    0x555555);
@@ -245,14 +249,14 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 				       (uint8_t *)wl->bdaddr);
 	}
 
-	ticks_at_event = prepare_param->ticks_at_expire;
+	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	remainder = prepare_param->remainder;
+	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);
 
 	/* capture end of Tx-ed PDU, used to calculate HCTO. */
@@ -291,8 +295,9 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_PERIPHERAL)
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt = HDR_LLL2EVT(p->param);
+	struct evt_hdr *evt;
 
+	evt = HDR_LLL2EVT(p->param);
 	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
 	p->remainder = 0;
 	p->lazy = 0;
@@ -439,13 +444,13 @@ static void isr_tx(void *param)
 
 static void isr_rx(void *param)
 {
-	uint8_t trx_done;
-	uint8_t crc_ok;
 	uint8_t devmatch_ok;
 	uint8_t devmatch_id;
 	uint8_t irkmatch_ok;
 	uint8_t irkmatch_id;
 	uint8_t rssi_ready;
+	uint8_t trx_done;
+	uint8_t crc_ok;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -495,7 +500,7 @@ isr_rx_do_close:
 static void isr_done(void *param)
 {
 	struct node_rx_hdr *node_rx;
-	struct lll_adv *lll = param;
+	struct lll_adv *lll;
 
 	/* Clear radio status and events */
 	lll_isr_status_reset();
@@ -506,6 +511,8 @@ static void isr_done(void *param)
 		_radio.mesh_adv_end_us = radio_tmr_end_get();
 	}
 #endif /* CONFIG_BT_HCI_MESH_EXT */
+
+	lll = param;
 
 #if defined(CONFIG_BT_PERIPHERAL)
 	if (!IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && lll->is_hdcd &&
@@ -627,8 +634,8 @@ static void isr_abort(void *param)
 static struct pdu_adv *chan_prepare(struct lll_adv *lll)
 {
 	struct pdu_adv *pdu;
-	uint8_t upd = 0U;
 	uint8_t chan;
+	uint8_t upd;
 
 	chan = find_lsb_set(lll->chan_map_curr);
 	LL_ASSERT(chan);
@@ -638,6 +645,7 @@ static struct pdu_adv *chan_prepare(struct lll_adv *lll)
 	lll_chan_set(36 + chan);
 
 	/* FIXME: get latest only when primary PDU without Aux PDUs */
+	upd = 0U;
 	pdu = lll_adv_data_latest_get(lll, &upd);
 
 	radio_pkt_tx_set(pdu);
@@ -678,7 +686,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready)
 {
-	struct pdu_adv *pdu_rx, *pdu_adv;
+	struct pdu_adv *pdu_adv;
+	struct pdu_adv *pdu_rx;
 	uint8_t tx_addr;
 	uint8_t *addr;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -40,7 +40,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 static void isr_tx(void *param);
 static void isr_rx(void *param);
 static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
@@ -74,13 +74,12 @@ int lll_adv_aux_reset(void)
 
 void lll_adv_aux_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
-	err = lll_prepare(lll_is_abort_cb, lll_abort_cb, prepare_cb, 0, p);
+	err = lll_prepare(lll_is_abort_cb, lll_abort_cb, prepare_cb, 0, param);
 	LL_ASSERT(!err || err == -EINPROGRESS);
 }
 
@@ -93,15 +92,14 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare_cb(struct lll_prepare_param *prepare_param)
+static int prepare_cb(struct lll_prepare_param *p)
 {
-	struct lll_adv_aux *lll = prepare_param->param;
-	uint32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	struct pdu_adv_com_ext_adv *pri_com_hdr;
 	uint32_t ticks_at_event, ticks_at_start;
 	struct pdu_adv *pri_pdu, *sec_pdu;
 	struct pdu_adv_aux_ptr *aux_ptr;
 	struct pdu_adv_hdr *pri_hdr;
+	struct lll_adv_aux *lll;
 	struct lll_adv *lll_adv;
 	struct evt_hdr *evt;
 	uint32_t remainder;
@@ -109,8 +107,16 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	uint8_t *pri_dptr;
 	uint8_t phy_s;
 	uint8_t upd;
+	uint32_t aa;
 
 	DEBUG_RADIO_START_A(1);
+
+#if !defined(BT_CTLR_ADV_EXT_PBACK)
+	/* Set up Radio H/W */
+	radio_reset();
+#endif  /* !BT_CTLR_ADV_EXT_PBACK */
+
+	lll = p->param;
 
 	/* FIXME: get latest only when primary PDU without Aux PDUs */
 	sec_pdu = lll_adv_aux_data_latest_get(lll, &upd);
@@ -143,10 +149,6 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		radio_disable();
 	}
 
-#if !defined(BT_CTLR_ADV_EXT_PBACK)
-	/* Set up Radio H/W */
-	radio_reset();
-#endif  /* !BT_CTLR_ADV_EXT_PBACK */
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	radio_tx_power_set(lll->tx_pwr_lvl);
@@ -162,6 +164,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if !defined(BT_CTLR_ADV_EXT_PBACK)
 	/* Access address and CRC */
+	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
 			    0x555555);
@@ -208,14 +211,14 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_tmr_start_us(1, start_us);
 #else /* !BT_CTLR_ADV_EXT_PBACK */
 
-	ticks_at_event = prepare_param->ticks_at_expire;
+	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	remainder = prepare_param->remainder;
+	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);
 #endif /* !BT_CTLR_ADV_EXT_PBACK */
 
@@ -254,8 +257,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 static void isr_tx(void *param)
 {
-	struct lll_adv_aux *lll_aux = param;
-	struct lll_adv *lll = lll_aux->adv;
+	struct lll_adv_aux *lll_aux;
+	struct lll_adv *lll;
 	uint32_t hcto;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
@@ -264,6 +267,9 @@ static void isr_tx(void *param)
 
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
+
+	lll_aux = param;
+	lll = lll_aux->adv;
 
 	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
@@ -328,13 +334,13 @@ static void isr_tx(void *param)
 
 static void isr_rx(void *param)
 {
-	uint8_t trx_done;
-	uint8_t crc_ok;
 	uint8_t devmatch_ok;
 	uint8_t devmatch_id;
 	uint8_t irkmatch_ok;
 	uint8_t irkmatch_id;
 	uint8_t rssi_ready;
+	uint8_t trx_done;
+	uint8_t crc_ok;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -386,8 +392,10 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready)
 {
-	struct pdu_adv *pdu_rx, *pdu_adv, *pdu_aux;
-	struct lll_adv *lll = lll_aux->adv;
+	struct pdu_adv *pdu_adv;
+	struct pdu_adv *pdu_aux;
+	struct pdu_adv *pdu_rx;
+	struct lll_adv *lll;
 	uint8_t tx_addr;
 	uint8_t *addr;
 	uint8_t upd;
@@ -399,6 +407,8 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 #else
 	uint8_t rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+	lll = lll_aux->adv;
 
 	pdu_rx = (void *)radio_pkt_scratch_get();
 	pdu_adv = lll_adv_data_curr_get(lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -36,7 +36,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 
 int lll_adv_sync_init(void)
 {
@@ -64,16 +64,20 @@ int lll_adv_sync_reset(void)
 
 void lll_adv_sync_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
-	struct lll_adv_sync *lll = p->param;
+	struct lll_prepare_param *p;
+	struct lll_adv_sync *lll;
 	uint16_t elapsed;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
+	p = param;
+
 	/* Instants elapsed */
 	elapsed = p->lazy + 1;
+
+	lll = p->param;
 
 	/* Save the (latency + 1) for use in event */
 	lll->latency_prepare += elapsed;
@@ -88,20 +92,23 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare_cb(struct lll_prepare_param *prepare_param)
+static int prepare_cb(struct lll_prepare_param *p)
 {
-	struct lll_adv_sync *lll = prepare_param->param;
-	uint32_t ticks_at_event, ticks_at_start;
-	struct pdu_adv *pdu;
-	struct evt_hdr *evt;
+	struct lll_adv_sync *lll;
+	uint32_t ticks_at_event;
+	uint32_t ticks_at_start;
 	uint16_t event_counter;
 	uint8_t data_chan_use;
+	struct pdu_adv *pdu;
+	struct evt_hdr *evt;
 	uint32_t remainder;
 	uint32_t start_us;
 	uint8_t phy_s;
 	uint8_t upd;
 
 	DEBUG_RADIO_START_A(1);
+
+	lll = p->param;
 
 	/* Deduce the latency */
 	lll->latency_event = lll->latency_prepare - 1;
@@ -147,14 +154,14 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_isr_set(lll_isr_done, lll);
 	radio_switch_complete_and_disable();
 
-	ticks_at_event = prepare_param->ticks_at_expire;
+	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	remainder = prepare_param->remainder;
+	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -35,7 +35,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 
 int lll_master_init(void)
 {
@@ -63,16 +63,20 @@ int lll_master_reset(void)
 
 void lll_master_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
-	struct lll_conn *lll = p->param;
+	struct lll_prepare_param *p;
+	struct lll_conn *lll;
 	uint16_t elapsed;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
+	p = param;
+
 	/* Instants elapsed */
 	elapsed = p->lazy + 1;
+
+	lll = p->param;
 
 	/* Save the (latency + 1) for use in event */
 	lll->latency_prepare += elapsed;
@@ -87,18 +91,21 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare_cb(struct lll_prepare_param *prepare_param)
+static int prepare_cb(struct lll_prepare_param *p)
 {
-	struct lll_conn *lll = prepare_param->param;
-	uint32_t ticks_at_event, ticks_at_start;
 	struct pdu_data *pdu_data_tx;
-	struct evt_hdr *evt;
+	uint32_t ticks_at_event;
+	uint32_t ticks_at_start;
 	uint16_t event_counter;
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
+	struct lll_conn *lll;
+	struct evt_hdr *evt;
 	uint32_t remainder;
 
 	DEBUG_RADIO_START_M(1);
+
+	lll = p->param;
 
 	/* Check if stopped (on disconnection between prepare and pre-empt)
 	 */
@@ -179,14 +186,14 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_switch_complete_and_rx(0);
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	ticks_at_event = prepare_param->ticks_at_expire;
+	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	remainder = prepare_param->remainder;
+	remainder = p->remainder;
 	remainder_us = radio_tmr_start(1, ticks_at_start, remainder);
 
 	/* capture end of Tx-ed PDU, used to calculate HCTO. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -42,7 +42,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 static int is_abort_cb(void *next, int prio, void *curr,
 		       lll_prepare_cb_t *resume_cb, int *resume_prio);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
@@ -102,13 +102,12 @@ int lll_scan_reset(void)
 
 void lll_scan_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
-	err = lll_prepare(is_abort_cb, abort_cb, prepare_cb, 0, p);
+	err = lll_prepare(is_abort_cb, abort_cb, prepare_cb, 0, param);
 	LL_ASSERT(!err || err == -EINPROGRESS);
 }
 
@@ -119,15 +118,17 @@ static int init_reset(void)
 
 static int prepare_cb(struct lll_prepare_param *p)
 {
-	uint32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	uint32_t ticks_at_event, ticks_at_start;
-	struct lll_scan *lll = p->param;
 	struct node_rx_pdu *node_rx;
-	struct evt_hdr *evt;
 	uint32_t remainder_us;
+	struct lll_scan *lll;
+	struct evt_hdr *evt;
 	uint32_t remainder;
+	uint32_t aa;
 
 	DEBUG_RADIO_START_O(1);
+
+	lll = p->param;
 
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
@@ -170,6 +171,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	radio_pkt_rx_set(node_rx->pdu);
 
+	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
 			    0x555555);
@@ -198,7 +200,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) && lll->filter_policy) {
 		/* Setup Radio Filter */
-
 		struct lll_filter *wl = ull_filter_lll_get(true);
 
 		radio_filter_configure(wl->enable_bitmask,
@@ -294,8 +295,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt = HDR_LLL2EVT(p->param);
+	struct evt_hdr *evt;
 
+	evt = HDR_LLL2EVT(p->param);
 	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
 	p->remainder = 0;
 	p->lazy = 0;
@@ -381,14 +383,14 @@ static void ticker_op_start_cb(uint32_t status, void *param)
 
 static void isr_rx(void *param)
 {
-	struct lll_scan *lll = (void *)param;
-	uint8_t trx_done;
-	uint8_t crc_ok;
+	struct lll_scan *lll;
 	uint8_t devmatch_ok;
 	uint8_t devmatch_id;
 	uint8_t irkmatch_ok;
 	uint8_t irkmatch_id;
 	uint8_t rssi_ready;
+	uint8_t trx_done;
+	uint8_t crc_ok;
 	uint8_t rl_idx;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
@@ -411,6 +413,8 @@ static void isr_rx(void *param)
 
 	/* Clear radio status and events */
 	lll_isr_status_reset();
+
+	lll = param;
 
 	/* No Rx */
 	if (!trx_done) {
@@ -523,11 +527,12 @@ static void isr_common_done(void *param)
 
 static void isr_done(void *param)
 {
-	struct lll_scan *lll = param;
+	struct lll_scan *lll;
 	uint32_t start_us;
 
 	isr_common_done(param);
 
+	lll = param;
 	lll->state = 0U;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -555,7 +560,8 @@ static void isr_done(void *param)
 
 static void isr_window(void *param)
 {
-	uint32_t ticks_at_start, remainder_us;
+	uint32_t ticks_at_start;
+	uint32_t remainder_us;
 
 	isr_common_done(param);
 
@@ -598,8 +604,8 @@ static void isr_abort(void *param)
 
 static void isr_cleanup(void *param)
 {
-	struct lll_scan *lll = param;
 	struct node_rx_hdr *node_rx;
+	struct lll_scan *lll;
 
 	if (lll_is_done(param)) {
 		return;
@@ -607,6 +613,7 @@ static void isr_cleanup(void *param)
 
 	radio_filter_disable();
 
+	lll = param;
 	if (++lll->chan == 3U) {
 		lll->chan = 0U;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -35,7 +35,7 @@
 #include "hal/debug.h"
 
 static int init_reset(void);
-static int prepare_cb(struct lll_prepare_param *prepare_param);
+static int prepare_cb(struct lll_prepare_param *p);
 
 int lll_slave_init(void)
 {
@@ -63,16 +63,20 @@ int lll_slave_reset(void)
 
 void lll_slave_prepare(void *param)
 {
-	struct lll_prepare_param *p = param;
-	struct lll_conn *lll = p->param;
+	struct lll_prepare_param *p;
+	struct lll_conn *lll;
 	uint16_t elapsed;
 	int err;
 
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
+	p = param;
+
 	/* Instants elapsed */
 	elapsed = p->lazy + 1;
+
+	lll = p->param;
 
 	/* Save the (latency + 1) for use in event */
 	lll->latency_prepare += elapsed;
@@ -96,18 +100,21 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare_cb(struct lll_prepare_param *prepare_param)
+static int prepare_cb(struct lll_prepare_param *p)
 {
-	struct lll_conn *lll = prepare_param->param;
-	uint32_t ticks_at_event, ticks_at_start;
-	struct evt_hdr *evt;
+	uint32_t ticks_at_event;
+	uint32_t ticks_at_start;
 	uint16_t event_counter;
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
+	struct lll_conn *lll;
+	struct evt_hdr *evt;
 	uint32_t remainder;
 	uint32_t hcto;
 
 	DEBUG_RADIO_START_S(1);
+
+	lll = p->param;
 
 	/* Check if stopped (on disconnection between prepare and pre-empt)
 	 */
@@ -199,14 +206,14 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 #endif /* !CONFIG_BT_CTLR_PHY */
 
-	ticks_at_event = prepare_param->ticks_at_expire;
+	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	remainder = prepare_param->remainder;
+	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);
 
 	radio_tmr_aa_capture();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -68,15 +68,16 @@ void lll_sync_prepare(void *param)
 	uint16_t elapsed;
 	int err;
 
-	p = param;
-	lll = p->param;
-
 	/* Request to start HF Clock */
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
 
+	p = param;
+
 	/* Instants elapsed */
 	elapsed = p->lazy + 1;
+
+	lll = p->param;
 
 	/* Save the (skip + 1) for use in event */
 	lll->skip_prepare += elapsed;
@@ -238,8 +239,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static void isr_rx(void *param)
 {
-	struct lll_sync *lll = param;
 	struct event_done_extra *e;
+	struct lll_sync *lll;
 	uint8_t rssi_ready;
 	uint8_t trx_done;
 	uint8_t trx_cnt;
@@ -256,6 +257,8 @@ static void isr_rx(void *param)
 
 	/* Clear radio rx status and events */
 	lll_isr_rx_status_reset();
+
+	lll = param;
 
 	/* No Rx */
 	trx_cnt = 0U;


### PR DESCRIPTION
Initialize auto variables close to locality of reference.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>