### PR TITLE
Bluetooth: controller: Fix missing return on Auxiliary PDU abort

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -191,7 +191,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 		lll_done(NULL);
 
-		DEBUG_RADIO_START_A(0);
+		DEBUG_RADIO_CLOSE_A(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -138,9 +138,16 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	aux_ptr = (void *)pri_dptr;
 
 	/* Abort if no aux_ptr filled */
-	if (!pri_hdr->aux_ptr || !aux_ptr->offs) {
-		radio_isr_set(lll_isr_abort, lll);
-		radio_disable();
+	if (unlikely(!pri_hdr->aux_ptr || !aux_ptr->offs)) {
+		int err;
+
+		err = lll_hfclock_off();
+		LL_ASSERT(err >= 0);
+
+		lll_done(NULL);
+
+		DEBUG_RADIO_START_A(0);
+		return 0;
 	}
 
 #if !defined(BT_CTLR_ADV_EXT_PBACK)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -146,7 +146,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 		lll_done(NULL);
 
-		DEBUG_RADIO_START_A(0);
+		DEBUG_RADIO_CLOSE_A(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -110,7 +110,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 		lll_done(NULL);
 
-		DEBUG_RADIO_START_M(0);
+		DEBUG_RADIO_CLOSE_M(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -140,7 +140,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 		lll_done(NULL);
 
-		DEBUG_RADIO_START_O(0);
+		DEBUG_RADIO_CLOSE_O(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -119,7 +119,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 		lll_done(NULL);
 
-		DEBUG_RADIO_START_S(0);
+		DEBUG_RADIO_CLOSE_S(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -739,7 +739,7 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 	/* Check if stopping ticker (on disconnection, race with ticker expiry)
 	 */
 	if (unlikely(conn->lll.handle == 0xFFFF)) {
-		DEBUG_RADIO_PREPARE_M(0);
+		DEBUG_RADIO_CLOSE_M(0);
 		return;
 	}
 
@@ -753,7 +753,7 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 		/* Handle any LL Control Procedures */
 		ret = ull_conn_llcp(conn, ticks_at_expire, lazy);
 		if (ret) {
-			DEBUG_RADIO_PREPARE_M(0);
+			DEBUG_RADIO_CLOSE_M(0);
 			return;
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -366,7 +366,7 @@ void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	/* Check if stopping ticker (on disconnection, race with ticker expiry)
 	 */
 	if (unlikely(conn->lll.handle == 0xFFFF)) {
-		DEBUG_RADIO_PREPARE_S(0);
+		DEBUG_RADIO_CLOSE_S(0);
 		return;
 	}
 
@@ -380,7 +380,7 @@ void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 		/* Handle any LL Control Procedures */
 		ret = ull_conn_llcp(conn, ticks_at_expire, lazy);
 		if (ret) {
-			DEBUG_RADIO_PREPARE_S(0);
+			DEBUG_RADIO_CLOSE_S(0);
 			return;
 		}
 	}


### PR DESCRIPTION
Fix the missing return statement when Auxiliary PDU
transmission is aborted because Primary PDU does not have
the aux pointer setup.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>