### PR TITLE
net: IPv4 bcast address recognized as multicast

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -695,7 +695,7 @@ static inline bool net_ipv4_is_addr_unspecified(const struct in_addr *addr)
  */
 static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
 {
-	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xE0000000) == 0xE0000000;
+	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xF0000000) == 0xE0000000;
 }
 
 /**

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -483,6 +483,8 @@ static void test_ipv4_addresses(void)
 
 	zassert_false(net_ipv4_is_addr_mcast(&addr4), "IPv4 address");
 
+	zassert_false(net_ipv4_is_addr_mcast(&bcast_addr1), "IPv4 broadcast address");
+
 	ifmaddr1 = net_if_ipv4_maddr_add(net_if_get_default(), &maddr4a);
 	zassert_not_null(ifmaddr1, "IPv4 multicast address add failed");
 


### PR DESCRIPTION
The current implementation of `net_ipv4_is_addr_mcast()` is flawed. It recognizes an IPv4 broadcast address as a multicast address. This causes traffic to 255.255.255.255 to be sent to the multicast MAC address range (e.g. the `DHCPDISCOVER` packet).

This PR fixes this problem and adds a test to cover that situation.