### PR TITLE
net: lwm2m: Improve token generation

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -188,7 +188,7 @@ static char *sprint_token(const uint8_t *token, uint8_t tkl)
 	static char buf[32];
 	char *ptr = buf;
 
-	if (token && tkl != LWM2M_MSG_TOKEN_LEN_SKIP) {
+	if (token && tkl != 0) {
 		int i;
 
 		tkl = MIN(tkl, sizeof(buf) / 2 - 1);
@@ -199,8 +199,6 @@ static char *sprint_token(const uint8_t *token, uint8_t tkl)
 		}
 
 		*ptr = '\0';
-	} else if (tkl == LWM2M_MSG_TOKEN_LEN_SKIP) {
-		strcpy(buf, "[skip-token]");
 	} else {
 		strcpy(buf, "[no-token]");
 	}
@@ -923,14 +921,10 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		return -EINVAL;
 	}
 
-	/*
-	 * msg->tkl == 0 is for a new TOKEN
-	 * msg->tkl == LWM2M_MSG_TOKEN_LEN_SKIP means dont set
-	 */
 	if (msg->tkl == LWM2M_MSG_TOKEN_GENERATE_NEW) {
-		tokenlen = 0U;
+		tokenlen = 8U;
 		token = coap_next_token();
-	} else if (msg->token && msg->tkl != LWM2M_MSG_TOKEN_LEN_SKIP) {
+	} else if (msg->token && msg->tkl != 0) {
 		tokenlen = msg->tkl;
 		token = msg->token;
 	}
@@ -3753,7 +3747,7 @@ static void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 		msg->code = coap_header_get_code(&response);
 		msg->mid = coap_header_get_id(&response);
 		/* skip token generation by default */
-		msg->tkl = LWM2M_MSG_TOKEN_LEN_SKIP;
+		msg->tkl = 0;
 
 		/* process the response to this request */
 		r = udp_request_handler(&response, msg);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -36,10 +36,7 @@
 #define NOTIFY_OBSERVER_PATH(path)	lwm2m_notify_observer_path(path)
 
 /* Use this value to generate new token */
-#define LWM2M_MSG_TOKEN_GENERATE_NEW 0U
-
-/* Use this value to skip token generation */
-#define LWM2M_MSG_TOKEN_LEN_SKIP	0xFF
+#define LWM2M_MSG_TOKEN_GENERATE_NEW 0xFFU
 
 /* length of time in milliseconds to wait for buffer allocations */
 #define BUF_ALLOC_TIMEOUT K_SECONDS(1)

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -555,6 +555,7 @@ static int sm_do_bootstrap_reg(void)
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_POST;
 	msg->mid = coap_next_id();
+	msg->tkl = LWM2M_MSG_TOKEN_GENERATE_NEW;
 	msg->reply_cb = do_bootstrap_reply_cb;
 	msg->message_timeout_cb = do_bootstrap_reg_timeout_cb;
 
@@ -635,6 +636,7 @@ static int sm_send_registration(bool send_obj_support_data,
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_POST;
 	msg->mid = coap_next_id();
+	msg->tkl = LWM2M_MSG_TOKEN_GENERATE_NEW;
 	msg->reply_cb = reply_cb;
 	msg->message_timeout_cb = timeout_cb;
 
@@ -827,6 +829,7 @@ static int sm_do_deregister(void)
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_DELETE;
 	msg->mid = coap_next_id();
+	msg->tkl = LWM2M_MSG_TOKEN_GENERATE_NEW;
 	msg->reply_cb = do_deregister_reply_cb;
 	msg->message_timeout_cb = do_deregister_timeout_cb;
 


### PR DESCRIPTION
Improve token handling by removing special meaning of tokenlen == 0,
which allows to handle server requests w/o a token (so far such
requests would cause the lwm2m engine to autogenerate token in the
response).

In order to autogenerate token during message initialization, use
special symbol `LWM2M_MSG_TOKEN_GENERATE_NEW`. If no token is wished to
be used, simply set the tokenlen to 0.

Additionally, fix an issue with token autogeneration, where invalid
token len was used (0 instead of 8).

Fixes #28299

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>