### PR TITLE
stm32: Configure I2C using new pinctrl via DT

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -352,7 +352,7 @@ STM32_I2C_IRQ_HANDLER_DECL(name);					\
 DEFINE_TIMINGS(name)							\
 									\
 static const struct soc_gpio_pinctrl i2c_pins_##name[] =		\
-					ST_STM32_DT_PINCTRL(0, name);	\
+					ST_STM32_DT_PINCTRL(name, 0);	\
 									\
 static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		\

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -12,6 +12,8 @@
 #include <soc.h>
 #include <errno.h>
 #include <drivers/i2c.h>
+#include <drivers/pinmux.h>
+#include <pinmux/stm32/pinmux_stm32.h>
 #include "i2c_ll_stm32.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
@@ -186,6 +188,37 @@ static int i2c_stm32_init(const struct device *dev)
 	cfg->irq_config_func(dev);
 #endif
 
+	if (cfg->pinctrl_list_size != 0) {
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl)
+		int remap;
+		/* Check that remap configuration is coherent across pins */
+		remap = stm32_dt_pinctrl_remap_check(cfg->pinctrl_list,
+						     cfg->pinctrl_list_size);
+		if (remap < 0) {
+			return remap;
+		}
+
+		/* A valid remapping configuration is provided */
+		/* Apply remapping before proceeding with pin configuration */
+		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
+
+		switch ((uint32_t)cfg->i2c) {
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay)
+		case DT_REG_ADDR(DT_NODELABEL(i2c1)):
+			if (remap == REMAP_1) {
+				LL_GPIO_AF_EnableRemap_I2C1();
+			} else {
+				LL_GPIO_AF_DisableRemap_I2C1();
+			}
+			break;
+#endif
+		}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl) */
+
+		stm32_dt_pinctrl_configure(cfg->pinctrl_list,
+					   cfg->pinctrl_list_size);
+	}
+
 	/*
 	 * initialize mutex used when multiple transfers
 	 * are taking place to guarantee that each one is
@@ -318,6 +351,9 @@ STM32_I2C_IRQ_HANDLER_DECL(name);					\
 									\
 DEFINE_TIMINGS(name)							\
 									\
+static const struct soc_gpio_pinctrl i2c_pins_##name[] =		\
+					ST_STM32_DT_PINCTRL(0, name);	\
+									\
 static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	.i2c = (I2C_TypeDef *)DT_REG_ADDR(DT_NODELABEL(name)),		\
 	.pclken = {							\
@@ -326,6 +362,8 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 	},								\
 	STM32_I2C_IRQ_HANDLER_FUNCTION(name)				\
 	.bitrate = DT_PROP(DT_NODELABEL(name), clock_frequency),	\
+	.pinctrl_list = i2c_pins_##name,				\
+	.pinctrl_list_size = ARRAY_SIZE(i2c_pins_##name),		\
 	USE_TIMINGS(name)						\
 };									\
 									\

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -32,6 +32,8 @@ struct i2c_stm32_config {
 	struct stm32_pclken pclken;
 	I2C_TypeDef *i2c;
 	uint32_t bitrate;
+	const struct soc_gpio_pinctrl *pinctrl_list;
+	size_t pinctrl_list_size;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
 	const struct i2c_config_timing *timings;
 	size_t n_timings;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -461,7 +461,7 @@ static int pwm_stm32_init(const struct device *dev)
 	static struct pwm_stm32_data pwm_stm32_data_##index;                   \
 									       \
 	static const struct soc_gpio_pinctrl pwm_pins_##index[] =	       \
-		ST_STM32_DT_INST_PINCTRL(0, index);			       \
+		ST_STM32_DT_INST_PINCTRL(index, 0);			       \
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(                           \

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -461,7 +461,7 @@ static int pwm_stm32_init(const struct device *dev)
 	static struct pwm_stm32_data pwm_stm32_data_##index;                   \
 									       \
 	static const struct soc_gpio_pinctrl pwm_pins_##index[] =	       \
-		ST_STM32_DT_PINCTRL(0, index);				       \
+		ST_STM32_DT_INST_PINCTRL(0, index);			       \
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(                           \

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -815,7 +815,7 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 STM32_UART_IRQ_HANDLER_DECL(index);					\
 									\
 static const struct soc_gpio_pinctrl uart_pins_##index[] =		\
-					ST_STM32_DT_PINCTRL(0, index);	\
+				ST_STM32_DT_INST_PINCTRL(0, index);	\
 									\
 static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.uconf = {							\

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -815,7 +815,7 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 STM32_UART_IRQ_HANDLER_DECL(index);					\
 									\
 static const struct soc_gpio_pinctrl uart_pins_##index[] =		\
-				ST_STM32_DT_INST_PINCTRL(0, index);	\
+				ST_STM32_DT_INST_PINCTRL(index, 0);	\
 									\
 static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.uconf = {							\

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -13,3 +13,13 @@ properties:
 
     interrupts:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        GPIO pin configuration for serial signals (SDA, SCL).  We expect
+        that the phandles will reference pinctrl nodes.
+
+        For example the I2C1 would be
+           pinctrl-0 = <&i2c1_sda_pb11 &i2c1_scl_pb10>;

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -14,6 +14,16 @@ properties:
     interrupts:
       required: true
 
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        GPIO pin configuration for serial signals (SDA, SCL).  We expect
+        that the phandles will reference pinctrl nodes.
+
+        For example the I2C1 would be
+           pinctrl-0 = <&i2c1_sda_pb11 &i2c1_scl_pb10>;
+
     timings:
         type: array
         required: false

--- a/soc/arm/st_stm32/common/st_stm32_dt.h
+++ b/soc/arm/st_stm32/common/st_stm32_dt.h
@@ -21,67 +21,138 @@
 #define STM32_PUSH_PULL  0x0
 #define STM32_OPEN_DRAIN 0x1
 
-/* Get a node id from a pinctrl-0 prop at index 'i' */
-#define NODE_ID_FROM_PINCTRL_0(inst, i) \
-	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_0, i)
 
-/* Get PIN associated with pinctrl-0 pin at index 'i' */
+/**
+ * @brief Internal: Get a node indentifier for an element in a
+ *        pinctrl-x property for a given device instance inst
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @return elements's node identifier
+ */
+#define NODE_ID_FROM_PINCTRL(inst, x, i) \
+	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_##x, i)
 
-#define ST_STM32_PINMUX(inst, i) \
-	DT_PROP(NODE_ID_FROM_PINCTRL_0(inst, i), pinmux)
+/**
+ * @brief Internal: Get pinmux property of a node indentifier for an element
+ *        in a pinctrl-x property for a given device instance inst
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @return pinmux property value
+ */
+#define ST_STM32_PINMUX(inst, x, i) \
+	DT_PROP(NODE_ID_FROM_PINCTRL(inst, x, i), pinmux)
 
-#define ST_STM32_FUNC(inst, i, function) \
-	DT_PROP(NODE_ID_FROM_PINCTRL_0(inst, i), function)
+/**
+ * @brief Internal: Get <function> property of a node indentifier for an element
+ *        in a pinctrl-x property for a given device instance inst
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @param function property of a targeted element
+ * @return <function> property value
+ */
+#define ST_STM32_FUNC(inst, x, i, function) \
+	DT_PROP(NODE_ID_FROM_PINCTRL(inst, x, i), function)
 
-#define ST_STM32_SLEW_RATE(inst, i) \
-	DT_ENUM_IDX(NODE_ID_FROM_PINCTRL_0(inst, i), slew_rate)
+/**
+ * @brief Internal: Provide slew-rate value for a pin with index i of a
+ *        pinctrl-x property for a given device instance inst
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @return slew rate value
+ */
+#define ST_STM32_SLEW_RATE(inst, x, i) \
+	DT_ENUM_IDX(NODE_ID_FROM_PINCTRL(inst, x, i), slew_rate)
 
+/**
+ * @brief Internal: Contruct a pincfg field of a soc_gpio_pinctrl element
+ *        with index i of a pinctrl-x property for a given device instance inst
+ *
+ * @param i index of soc_gpio_pinctrl element
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param inst device instance number
+ * @return pincfg field
+ */
 #ifndef CONFIG_SOC_SERIES_STM32F1X
-#define ST_STM32_PINCFG(inst, i) \
-	(((STM32_NO_PULL * ST_STM32_FUNC(inst, i, bias_disable))	 \
+#define ST_STM32_PINCFG(inst, x, i) \
+	(((STM32_NO_PULL * ST_STM32_FUNC(inst, x, i, bias_disable))	 \
 						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PULL_UP * ST_STM32_FUNC(inst, i, bias_pull_up))		 \
+	((STM32_PULL_UP * ST_STM32_FUNC(inst, x, i, bias_pull_up))	 \
 						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, i, bias_pull_down))	 \
+	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, x, i, bias_pull_down))	 \
 						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, i, drive_push_pull))	 \
+	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, x, i, drive_push_pull))	 \
 						<< STM32_OTYPER_SHIFT) | \
-	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, i, drive_open_drain))	 \
+	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, x, i, drive_open_drain))\
 						<< STM32_OTYPER_SHIFT) | \
-	(ST_STM32_SLEW_RATE(inst, i) << STM32_OSPEEDR_SHIFT))
+	(ST_STM32_SLEW_RATE(inst, x, i) << STM32_OSPEEDR_SHIFT))
 #else
-#define ST_STM32_PINCFG(inst, i) \
-	(((STM32_NO_PULL * ST_STM32_FUNC(inst, i, bias_disable))	 \
+#define ST_STM32_PINCFG(inst, x, i) \
+	(((STM32_NO_PULL * ST_STM32_FUNC(inst, x, i, bias_disable))	 \
 						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PULL_UP * ST_STM32_FUNC(inst, i, bias_pull_up))		 \
+	((STM32_PULL_UP * ST_STM32_FUNC(inst, x, i, bias_pull_up))	 \
 						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, i, bias_pull_down))	 \
+	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, x, i, bias_pull_down))	 \
 						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, i, drive_push_pull))	 \
+	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, x, i, drive_push_pull))	 \
 						<< STM32_CNF_OUT_0_SHIFT) | \
-	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, i, drive_open_drain))	 \
+	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, x, i, drive_open_drain))   \
 						<< STM32_CNF_OUT_0_SHIFT) | \
-	(ST_STM32_SLEW_RATE(inst, i) << STM32_MODE_OSPEED_SHIFT))
+	(ST_STM32_SLEW_RATE(inst, x, i) << STM32_MODE_OSPEED_SHIFT))
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
-/* Construct a soc_gpio_pinctrl element for pin cfg */
-#define ST_STM32_DT_PIN(inst, idx)				\
+/**
+ * @brief Internal: Contruct a soc_gpio_pinctrl element index i of
+ *        a pinctrl-x property for a given device instance inst
+ *
+ * @param i element index
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param inst device instance number
+ * @return soc_gpio_pinctrl element
+ */
+#define ST_STM32_DT_PIN_ELEM(i, x, inst)			\
 	{							\
-		ST_STM32_PINMUX(inst, idx),			\
-		ST_STM32_PINCFG(inst, idx)			\
-	}
+		ST_STM32_PINMUX(inst, x, i),			\
+		ST_STM32_PINCFG(inst, x, i)			\
+	},
 
-/* Get the number of pins for pinctrl-0 */
-#define ST_STM32_DT_NUM_PINS(inst) DT_INST_PROP_LEN(inst, pinctrl_0)
+/**
+ * @brief Internal: Return the number of elements of a pinctrl-x property
+ *        for a given device instance
+ *
+ * This macro returns the number of element in property pcintrl-<x> of
+ * device instance <inst>
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @return number of element in property
+ */
+#define ST_STM32_DT_NUM_PINS(inst, x) DT_INST_PROP_LEN(inst, pinctrl_##x)
 
-/* internal macro to structure things for use with UTIL_LISTIFY */
-#define ST_STM32_DT_PIN_ELEM(idx, inst) ST_STM32_DT_PIN(inst, idx),
 
-/* Construct an array intializer for soc_gpio_pinctrl for a device instance */
-#define ST_STM32_DT_PINCTRL(pinctrl_idx, inst)				\
-	{ COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinctrl_##pinctrl_idx),\
-		      (UTIL_LISTIFY(ST_STM32_DT_NUM_PINS(inst),		\
+/**
+ * @brief Construct a soc_gpio_pinctrl array of a specific pcintrl property
+ *        for a given device instance
+ *
+ * This macro returns an array of soc_gpio_pinctrl, each line matching a pinctrl
+ * configuration provived in property pcintrl-<x> of device instance <inst>
+ *
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param inst device instance number
+ * @return array of soc_gpio_pinctrl
+ */
+#define ST_STM32_DT_PINCTRL(x, inst)					\
+	{ COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinctrl_##x),	\
+		      (UTIL_LISTIFY(ST_STM32_DT_NUM_PINS(inst, x),	\
 				   ST_STM32_DT_PIN_ELEM,		\
+				   x,					\
 				   inst)),				\
 		      ())						\
 	}

--- a/soc/arm/st_stm32/common/st_stm32_dt.h
+++ b/soc/arm/st_stm32/common/st_stm32_dt.h
@@ -261,11 +261,11 @@
  * This macro returns an array of soc_gpio_pinctrl, each line matching a pinctrl
  * configuration provived in property pcintrl-<x> of device instance <inst>
  *
- * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
  * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
  * @return array of soc_gpio_pinctrl
  */
-#define ST_STM32_DT_INST_PINCTRL(x, inst)				\
+#define ST_STM32_DT_INST_PINCTRL(inst, x)				\
 	{ COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinctrl_##x),		\
 		      (UTIL_LISTIFY(ST_STM32_DT_INST_NUM_PINS(inst, x),	\
 				   ST_STM32_DT_INST_PIN_ELEM,		\
@@ -282,11 +282,11 @@
  * configuration provived in property pcintrl-<x> of a device referenced by
  * its node label identifier.
  *
- * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
  * @param name device node label identifier
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
  * @return array of soc_gpio_pinctrl
  */
-#define ST_STM32_DT_PINCTRL(x, name)					\
+#define ST_STM32_DT_PINCTRL(name, x)					\
 	{ COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(name), pinctrl_##x),\
 		      (UTIL_LISTIFY(ST_STM32_DT_NUM_PINS(name, x),	\
 				   ST_STM32_DT_PIN_ELEM,		\

--- a/soc/arm/st_stm32/common/st_stm32_dt.h
+++ b/soc/arm/st_stm32/common/st_stm32_dt.h
@@ -31,7 +31,7 @@
  * @param i index of soc_gpio_pinctrl element
  * @return elements's node identifier
  */
-#define NODE_ID_FROM_PINCTRL(inst, x, i) \
+#define ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i) \
 	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_##x, i)
 
 /**
@@ -43,8 +43,8 @@
  * @param i index of soc_gpio_pinctrl element
  * @return pinmux property value
  */
-#define ST_STM32_PINMUX(inst, x, i) \
-	DT_PROP(NODE_ID_FROM_PINCTRL(inst, x, i), pinmux)
+#define ST_STM32_DT_INST_PINMUX(inst, x, i) \
+	DT_PROP(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), pinmux)
 
 /**
  * @brief Internal: Get <function> property of a node indentifier for an element
@@ -56,8 +56,8 @@
  * @param function property of a targeted element
  * @return <function> property value
  */
-#define ST_STM32_FUNC(inst, x, i, function) \
-	DT_PROP(NODE_ID_FROM_PINCTRL(inst, x, i), function)
+#define ST_STM32_DT_INST_FUNC(inst, x, i, function) \
+	DT_PROP(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), function)
 
 /**
  * @brief Internal: Provide slew-rate value for a pin with index i of a
@@ -68,8 +68,9 @@
  * @param i index of soc_gpio_pinctrl element
  * @return slew rate value
  */
-#define ST_STM32_SLEW_RATE(inst, x, i) \
-	DT_ENUM_IDX(NODE_ID_FROM_PINCTRL(inst, x, i), slew_rate)
+#define ST_STM32_DT_INST_SLEW_RATE(inst, x, i) \
+	DT_ENUM_IDX(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), \
+								slew_rate)
 
 /**
  * @brief Internal: Contruct a pincfg field of a soc_gpio_pinctrl element
@@ -81,31 +82,33 @@
  * @return pincfg field
  */
 #ifndef CONFIG_SOC_SERIES_STM32F1X
-#define ST_STM32_PINCFG(inst, x, i) \
-	(((STM32_NO_PULL * ST_STM32_FUNC(inst, x, i, bias_disable))	 \
-						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PULL_UP * ST_STM32_FUNC(inst, x, i, bias_pull_up))	 \
-						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, x, i, bias_pull_down))	 \
-						<< STM32_PUPDR_SHIFT) |	 \
-	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, x, i, drive_push_pull))	 \
-						<< STM32_OTYPER_SHIFT) | \
-	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, x, i, drive_open_drain))\
-						<< STM32_OTYPER_SHIFT) | \
-	(ST_STM32_SLEW_RATE(inst, x, i) << STM32_OSPEEDR_SHIFT))
+#define ST_STM32_DT_INST_PINCFG(inst, x, i)				       \
+	(((STM32_NO_PULL * ST_STM32_DT_INST_FUNC(inst, x, i, bias_disable))    \
+						<< STM32_PUPDR_SHIFT) |	       \
+	((STM32_PULL_UP * ST_STM32_DT_INST_FUNC(inst, x, i, bias_pull_up))     \
+						<< STM32_PUPDR_SHIFT) |        \
+	((STM32_PULL_DOWN * ST_STM32_DT_INST_FUNC(inst, x, i, bias_pull_down)) \
+						<< STM32_PUPDR_SHIFT) |        \
+	((STM32_PUSH_PULL * ST_STM32_DT_INST_FUNC(inst, x, i, drive_push_pull))\
+						<< STM32_OTYPER_SHIFT) |       \
+	((STM32_OPEN_DRAIN * ST_STM32_DT_INST_FUNC(inst, x, i,		       \
+							drive_open_drain))     \
+						<< STM32_OTYPER_SHIFT) |       \
+	(ST_STM32_DT_INST_SLEW_RATE(inst, x, i) << STM32_OSPEEDR_SHIFT))
 #else
-#define ST_STM32_PINCFG(inst, x, i) \
-	(((STM32_NO_PULL * ST_STM32_FUNC(inst, x, i, bias_disable))	 \
-						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PULL_UP * ST_STM32_FUNC(inst, x, i, bias_pull_up))	 \
-						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PULL_DOWN * ST_STM32_FUNC(inst, x, i, bias_pull_down))	 \
-						<< STM32_PUPD_SHIFT) |	 \
-	((STM32_PUSH_PULL * ST_STM32_FUNC(inst, x, i, drive_push_pull))	 \
-						<< STM32_CNF_OUT_0_SHIFT) | \
-	((STM32_OPEN_DRAIN * ST_STM32_FUNC(inst, x, i, drive_open_drain))   \
-						<< STM32_CNF_OUT_0_SHIFT) | \
-	(ST_STM32_SLEW_RATE(inst, x, i) << STM32_MODE_OSPEED_SHIFT))
+#define ST_STM32_DT_INST_PINCFG(inst, x, i)				       \
+	(((STM32_NO_PULL * ST_STM32_DT_INST_FUNC(inst, x, i, bias_disable))    \
+						<< STM32_PUPD_SHIFT) |         \
+	((STM32_PULL_UP * ST_STM32_DT_INST_FUNC(inst, x, i, bias_pull_up))     \
+						<< STM32_PUPD_SHIFT) |         \
+	((STM32_PULL_DOWN * ST_STM32_DT_INST_FUNC(inst, x, i, bias_pull_down)) \
+						<< STM32_PUPD_SHIFT) |         \
+	((STM32_PUSH_PULL * ST_STM32_DT_INST_FUNC(inst, x, i, drive_push_pull))\
+						<< STM32_CNF_OUT_0_SHIFT) |    \
+	((STM32_OPEN_DRAIN * ST_STM32_DT_INST_FUNC(inst, x, i,		       \
+							drive_open_drain))     \
+						<< STM32_CNF_OUT_0_SHIFT) |    \
+	(ST_STM32_DT_INST_SLEW_RATE(inst, x, i) << STM32_MODE_OSPEED_SHIFT))
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
 /**
@@ -117,10 +120,10 @@
  * @param inst device instance number
  * @return soc_gpio_pinctrl element
  */
-#define ST_STM32_DT_PIN_ELEM(i, x, inst)			\
+#define ST_STM32_DT_INST_PIN_ELEM(i, x, inst)			\
 	{							\
-		ST_STM32_PINMUX(inst, x, i),			\
-		ST_STM32_PINCFG(inst, x, i)			\
+		ST_STM32_DT_INST_PINMUX(inst, x, i),		\
+		ST_STM32_DT_INST_PINCFG(inst, x, i)		\
 	},
 
 /**
@@ -134,7 +137,7 @@
  * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
  * @return number of element in property
  */
-#define ST_STM32_DT_NUM_PINS(inst, x) DT_INST_PROP_LEN(inst, pinctrl_##x)
+#define ST_STM32_DT_INST_NUM_PINS(inst, x) DT_INST_PROP_LEN(inst, pinctrl_##x)
 
 
 /**
@@ -148,10 +151,10 @@
  * @param inst device instance number
  * @return array of soc_gpio_pinctrl
  */
-#define ST_STM32_DT_PINCTRL(x, inst)					\
-	{ COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinctrl_##x),	\
-		      (UTIL_LISTIFY(ST_STM32_DT_NUM_PINS(inst, x),	\
-				   ST_STM32_DT_PIN_ELEM,		\
+#define ST_STM32_DT_INST_PINCTRL(x, inst)				\
+	{ COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinctrl_##x),		\
+		      (UTIL_LISTIFY(ST_STM32_DT_INST_NUM_PINS(inst, x),	\
+				   ST_STM32_DT_INST_PIN_ELEM,		\
 				   x,					\
 				   inst)),				\
 		      ())						\

--- a/soc/arm/st_stm32/common/st_stm32_dt.h
+++ b/soc/arm/st_stm32/common/st_stm32_dt.h
@@ -35,6 +35,18 @@
 	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_##x, i)
 
 /**
+ * @brief Internal: Get a node indentifier for an element in a
+ *        pinctrl-x property for a given device
+ *
+ * @param name device node label identifier
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @return elements's node identifier
+ */
+#define ST_STM32_DT_NODE_ID_FROM_PINCTRL(name, x, i) \
+	DT_PHANDLE_BY_IDX(DT_NODELABEL(name), pinctrl_##x, i)
+
+/**
  * @brief Internal: Get pinmux property of a node indentifier for an element
  *        in a pinctrl-x property for a given device instance inst
  *
@@ -45,6 +57,18 @@
  */
 #define ST_STM32_DT_INST_PINMUX(inst, x, i) \
 	DT_PROP(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), pinmux)
+
+/**
+ * @brief Internal: Get pinmux property of a node indentifier for an element
+ *        in a pinctrl-x property for a given device
+ *
+ * @param name device node label identifier
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param i index of soc_gpio_pinctrl element
+ * @return pinmux property value
+ */
+#define ST_STM32_DT_PINMUX(name, x, i) \
+	DT_PROP(ST_STM32_DT_NODE_ID_FROM_PINCTRL(name, x, i), pinmux)
 
 /**
  * @brief Internal: Get <function> property of a node indentifier for an element
@@ -60,6 +84,19 @@
 	DT_PROP(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), function)
 
 /**
+ * @brief Internal: Get <function> property of a node indentifier for an element
+ *        in a pinctrl-x property for a given device
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param name device node label identifier
+ * @param function property of a targeted element
+ * @return <function> property value
+ */
+#define ST_STM32_DT_FUNC(name, x, i, function) \
+	DT_PROP(ST_STM32_DT_NODE_ID_FROM_PINCTRL(name, x, i), function)
+
+/**
  * @brief Internal: Provide slew-rate value for a pin with index i of a
  *        pinctrl-x property for a given device instance inst
  *
@@ -71,6 +108,18 @@
 #define ST_STM32_DT_INST_SLEW_RATE(inst, x, i) \
 	DT_ENUM_IDX(ST_STM32_DT_INST_NODE_ID_FROM_PINCTRL(inst, x, i), \
 								slew_rate)
+
+/**
+ * @brief Internal: Provide slew-rate value for a pin with index i of a
+ *        pinctrl-x property for a given device
+ *
+ * @param inst device instance number
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param name device node label identifier
+ * @return slew rate value
+ */
+#define ST_STM32_DT_SLEW_RATE(name, x, i) \
+	DT_ENUM_IDX(ST_STM32_DT_NODE_ID_FROM_PINCTRL(name, x, i), slew_rate)
 
 /**
  * @brief Internal: Contruct a pincfg field of a soc_gpio_pinctrl element
@@ -112,6 +161,43 @@
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
 /**
+ * @brief Internal: Contruct a pincfg field of a soc_gpio_pinctrl element
+ *        with index i of a pinctrl-x property for a given device
+ *
+ * @param i index of soc_gpio_pinctrl element
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param name device node label identifier
+ * @return pincfg field
+ */
+#ifndef CONFIG_SOC_SERIES_STM32F1X
+#define ST_STM32_DT_PINCFG(name, x, i)					    \
+	(((STM32_NO_PULL * ST_STM32_DT_FUNC(name, x, i, bias_disable))      \
+						<< STM32_PUPDR_SHIFT) |     \
+	((STM32_PULL_UP * ST_STM32_DT_FUNC(name, x, i, bias_pull_up))       \
+						<< STM32_PUPDR_SHIFT) |     \
+	((STM32_PULL_DOWN * ST_STM32_DT_FUNC(name, x, i, bias_pull_down))   \
+						<< STM32_PUPDR_SHIFT) |     \
+	((STM32_PUSH_PULL * ST_STM32_DT_FUNC(name, x, i, drive_push_pull))  \
+						<< STM32_OTYPER_SHIFT) |    \
+	((STM32_OPEN_DRAIN * ST_STM32_DT_FUNC(name, x, i, drive_open_drain))\
+						<< STM32_OTYPER_SHIFT) |    \
+	(ST_STM32_DT_SLEW_RATE(name, x, i) << STM32_OSPEEDR_SHIFT))
+#else
+#define ST_STM32_DT_PINCFG(name, x, i)				            \
+	(((STM32_NO_PULL * ST_STM32_DT_FUNC(name, x, i, bias_disable))      \
+						<< STM32_PUPD_SHIFT) |      \
+	((STM32_PULL_UP * ST_STM32_DT_FUNC(name, x, i, bias_pull_up))       \
+						<< STM32_PUPD_SHIFT) |      \
+	((STM32_PULL_DOWN * ST_STM32_DT_FUNC(name, x, i, bias_pull_down))   \
+						<< STM32_PUPD_SHIFT) |      \
+	((STM32_PUSH_PULL * ST_STM32_DT_FUNC(name, x, i, drive_push_pull))  \
+						<< STM32_CNF_OUT_0_SHIFT) | \
+	((STM32_OPEN_DRAIN * ST_STM32_DT_FUNC(name, x, i, drive_open_drain))\
+						<< STM32_CNF_OUT_0_SHIFT) | \
+	(ST_STM32_DT_SLEW_RATE(name, x, i) << STM32_MODE_OSPEED_SHIFT))
+#endif /* CONFIG_SOC_SERIES_STM32F1X */
+
+/**
  * @brief Internal: Contruct a soc_gpio_pinctrl element index i of
  *        a pinctrl-x property for a given device instance inst
  *
@@ -127,6 +213,21 @@
 	},
 
 /**
+ * @brief Internal: Contruct a soc_gpio_pinctrl element index i of
+ *        a pinctrl-x property for a given device
+ *
+ * @param i element index
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param name device node label identifier
+ * @return soc_gpio_pinctrl element
+ */
+#define ST_STM32_DT_PIN_ELEM(i, x, name)		\
+	{						\
+		ST_STM32_DT_PINMUX(name, x, i),		\
+		ST_STM32_DT_PINCFG(name, x, i)		\
+	},
+
+/**
  * @brief Internal: Return the number of elements of a pinctrl-x property
  *        for a given device instance
  *
@@ -139,6 +240,19 @@
  */
 #define ST_STM32_DT_INST_NUM_PINS(inst, x) DT_INST_PROP_LEN(inst, pinctrl_##x)
 
+/**
+ * @brief Internal: Return the number of elements of a pinctrl-x property
+ *        for a given device
+ *
+ * This macro returns the number of element in property pcintrl-<x> of
+ * device "name"
+ *
+ * @param name device node label identifier
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @return number of element in property
+ */
+#define ST_STM32_DT_NUM_PINS(name, x) \
+				DT_PROP_LEN(DT_NODELABEL(name), pinctrl_##x)
 
 /**
  * @brief Construct a soc_gpio_pinctrl array of a specific pcintrl property
@@ -157,6 +271,27 @@
 				   ST_STM32_DT_INST_PIN_ELEM,		\
 				   x,					\
 				   inst)),				\
+		      ())						\
+	}
+
+/**
+ * @brief Construct a soc_gpio_pinctrl array of a specific pcintrl property
+ *        for a given device name
+ *
+ * This macro returns an array of soc_gpio_pinctrl, each line matching a pinctrl
+ * configuration provived in property pcintrl-<x> of a device referenced by
+ * its node label identifier.
+ *
+ * @param x index of targeted pinctrl- property (eg: pinctrl-<x>)
+ * @param name device node label identifier
+ * @return array of soc_gpio_pinctrl
+ */
+#define ST_STM32_DT_PINCTRL(x, name)					\
+	{ COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(name), pinctrl_##x),\
+		      (UTIL_LISTIFY(ST_STM32_DT_NUM_PINS(name, x),	\
+				   ST_STM32_DT_PIN_ELEM,		\
+				   x,					\
+				   name)),				\
 		      ())						\
 	}
 


### PR DESCRIPTION
This PR converts I2C driver to devicetree pin configuration.

To achieve this, it was required to introduce a new pinctrl helper macro in order
to be able to access pcintrl-x property of a device using its node label (i2c1 for instance)
instead of its instance number as it is done until now in other drivers.

To conform with zephyr devicetree usual helper macro naming scheme:
* Instance based macro was renamed from ST_STM32_DT_PINCTRL to
ST_STM32_DT_INST_PINCTRL (along with its set of internal macros)
* New nodelabel based macro was introduced ST_STM32_DT_PINCTRL

Additionally, to reinforce consistency with other DT_INST macros from zephyr codebase,
I reversed order of arguments in these macros (cf https://github.com/zephyrproject-rtos/zephyr/pull/29057#discussion_r501813511).

Along with this change, existing users of ST_STM32_DT_PINCTRL were updated.

Last, helper macros were provided lengthy documentation.  