### PR TITLE
arch: arm64: GICv2/v3 handling causes abort on spurious interrupt

### DIFF
--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -13,6 +13,7 @@
 #include <offsets_short.h>
 #include <arch/cpu.h>
 #include <sw_isr_table.h>
+#include <drivers/interrupt_controller/gic.h>
 #include "macro_priv.inc"
 
 _ASM_FILE_PROLOGUE
@@ -45,6 +46,11 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #else
 	bl	z_soc_irq_get_active
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
+
+	/* Spurious */
+	cmp	x0, #(GIC_INTID_SPURIOUS)
+	beq	spurious_continue
+
 	stp	x0, x1, [sp, #-16]!
 	lsl	x0, x0, #4 /* table is 16-byte wide */
 
@@ -63,6 +69,8 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 
 	/* Signal end-of-interrupt */
 	ldp	x0, x1, [sp], #16
+
+spurious_continue:
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
 	bl	arm_gic_eoi
 #else

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -16,9 +16,6 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GIC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GIC_H_
 
-#include <zephyr/types.h>
-#include <device.h>
-
 /*
  * GIC Register Interface Base Addresses
  */
@@ -210,18 +207,6 @@
 
 #endif /* CONFIG_GIC_VER <= 2 */
 
-#if defined(CONFIG_GIC_V3)
-/**
- * @brief raise SGI to target cores
- *
- * @param sgi_id      SGI ID 0 to 15
- * @param target_aff  target affinity in mpidr form.
- *                    Aff level 1 2 3 will be extracted by api.
- * @param target_list bitmask of target cores
- */
-void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
-		   uint16_t target_list);
-#endif
 
 /* GICD_ICFGR */
 #define GICD_ICFGR_MASK			BIT_MASK(2)
@@ -273,6 +258,9 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 
 #ifndef _ASMLANGUAGE
 
+#include <zephyr/types.h>
+#include <device.h>
+
 /*
  * GIC Driver Interface Functions
  */
@@ -323,6 +311,19 @@ unsigned int arm_gic_get_active(void);
  */
 void arm_gic_eoi(unsigned int irq);
 
+#if defined(CONFIG_GIC_V3)
+/**
+ * @brief raise SGI to target cores
+ *
+ * @param sgi_id      SGI ID 0 to 15
+ * @param target_aff  target affinity in mpidr form.
+ *                    Aff level 1 2 3 will be extracted by api.
+ * @param target_list bitmask of target cores
+ */
+void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
+		   uint16_t target_list);
+
+#endif /* CONFIG_GIC_V3 */
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GIC_H_ */


### PR DESCRIPTION
In _isr_wrapper, the interrupt ID read from the GIC is blindly used to
index into _sw_isr_table, which is only sized based on CONFIG_NUM_IRQ.

It is possible for both GICv2 and GICv3 to return 1023 for a handful
of scenarios, the simplest of which is a level sensitive interrupt
which has subsequently become de-asserted.  Borrowing from the Linux
GIC implementation, reads that return an interrupt ID of 1023 are
simply ignored.

Minor collateral changes to gic.h to group !_ASMLANGUAGE content together.

Signed-off-by: Luke Starrett <luke.starrett@gmail.com>