### PR TITLE
boards: arc: nsim_em7d_v22: switch to ns16550 UART model

### DIFF
--- a/boards/arc/nsim/support/mdb_em7d_v22.args
+++ b/boards/arc/nsim/support/mdb_em7d_v22.args
@@ -44,5 +44,5 @@
 	-dmac_registers=0
 	-dmac_fifo_depth=2
 	-dmac_int_config=single_internal
-	-prop=nsim_mem-dev=uart0,base=0xf0000000,irq=24
+	-prop=nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24
 	-noprofile

--- a/boards/arc/nsim/support/nsim_em7d_v22.props
+++ b/boards/arc/nsim/support/nsim_em7d_v22.props
@@ -49,5 +49,5 @@
 	nsim_isa_dmac_registers=0
 	nsim_isa_dmac_fifo_depth=2
 	nsim_isa_dmac_int_config=single_internal
-	nsim_mem-dev=uart0,base=0xf0000000,irq=24
+	nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24
 	nsim_isa_unaligned_option=1


### PR DESCRIPTION
In PR #26836, we switch nSIM from custom legacy ARC UART model
to ns16550 model, which will allow us to use zephyr images build for
nSIM on other platforms like HAPS, QEMU, etc...
In PR #27334, which introduce new board nsim_em7d_v22, has gone
parallel to the switch to dwuart, and is still using legacy model.
With wrong configuration, the uart for nsim_em7d_v22 has no output,
which cause all tests failure.

Fixes: #28976 

