### PR TITLE
shell: increase stack size for OpenThread

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -19,6 +19,7 @@ source "subsys/shell/Kconfig.backends"
 
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
+	default 2520 if OPENTHREAD_SHELL
 	default 2048 if MULTITHREADING
 	default 0 if !MULTITHREADING
 	help


### PR DESCRIPTION
Default shell stack size is not always enough when used with
OpenThread. Increasing it to the found adequate value.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>