### PR TITLE
Revert "zephyr: maintainers:"

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -959,17 +959,6 @@ Networking:
         - tests/net/lib/mqtt_packet/
         - samples/net/mqtt_publisher/
 
-"Networking: CivetWeb":
-    status: maintained
-    maintainers:
-        - Nukersson
-    collaborators:
-        - jukkar
-    files:
-        - samples/net/sockets/*civetweb*
-    labels:
-        - "area: CivetWeb"
-
 NIOS-2 arch:
     status: maintained
     maintainers:


### PR DESCRIPTION
This reverts commit c45ac06f08cd9fa2cef758b7c7ef90707403a4a8, part of #28795

This requires TSC approval, was merged by mistake.