### PR TITLE
drivers: modem: cmd_handler: Allow locking TX

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -289,21 +289,21 @@ static int gsm_setup_mccmno(struct gsm_modem *gsm)
 
 	if (CONFIG_MODEM_GSM_MANUAL_MCCMNO[0]) {
 		/* use manual MCC/MNO entry */
-		ret = modem_cmd_send(&gsm->context.iface,
-				     &gsm->context.cmd_handler,
-				     NULL, 0,
-				     "AT+COPS=1,2,\""
-				     CONFIG_MODEM_GSM_MANUAL_MCCMNO
-				     "\"",
-				     &gsm->sem_response,
-				     GSM_CMD_AT_TIMEOUT);
+		ret = modem_cmd_send_nolock(&gsm->context.iface,
+					    &gsm->context.cmd_handler,
+					    NULL, 0,
+					    "AT+COPS=1,2,\""
+					    CONFIG_MODEM_GSM_MANUAL_MCCMNO
+					    "\"",
+					    &gsm->sem_response,
+					    GSM_CMD_AT_TIMEOUT);
 	} else {
 		/* register operator automatically */
-		ret = modem_cmd_send(&gsm->context.iface,
-				     &gsm->context.cmd_handler,
-				     NULL, 0, "AT+COPS=0,0",
-				     &gsm->sem_response,
-				     GSM_CMD_AT_TIMEOUT);
+		ret = modem_cmd_send_nolock(&gsm->context.iface,
+					    &gsm->context.cmd_handler,
+					    NULL, 0, "AT+COPS=0,0",
+					    &gsm->sem_response,
+					    GSM_CMD_AT_TIMEOUT);
 	}
 
 	if (ret < 0) {
@@ -353,12 +353,12 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 	int ret;
 
 	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
-		ret = modem_cmd_send(&gsm->context.iface,
-				     &gsm->context.cmd_handler,
-				     &response_cmds[0],
-				     ARRAY_SIZE(response_cmds),
-				     "AT", &gsm->sem_response,
-				     GSM_CMD_AT_TIMEOUT);
+		ret = modem_cmd_send_nolock(&gsm->context.iface,
+					    &gsm->context.cmd_handler,
+					    &response_cmds[0],
+					    ARRAY_SIZE(response_cmds),
+					    "AT", &gsm->sem_response,
+					    GSM_CMD_AT_TIMEOUT);
 		if (ret < 0) {
 			LOG_ERR("modem setup returned %d, %s",
 				ret, "retrying...");
@@ -370,12 +370,12 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 
 	(void)gsm_setup_mccmno(gsm);
 
-	ret = modem_cmd_handler_setup_cmds(&gsm->context.iface,
-					   &gsm->context.cmd_handler,
-					   setup_cmds,
-					   ARRAY_SIZE(setup_cmds),
-					   &gsm->sem_response,
-					   GSM_CMD_SETUP_TIMEOUT);
+	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
+						  &gsm->context.cmd_handler,
+						  setup_cmds,
+						  ARRAY_SIZE(setup_cmds),
+						  &gsm->sem_response,
+						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
 		LOG_DBG("modem setup returned %d, %s",
 			ret, "retrying...");
@@ -401,12 +401,12 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 
 	LOG_DBG("modem setup returned %d, %s", ret, "enable PPP");
 
-	ret = modem_cmd_handler_setup_cmds(&gsm->context.iface,
-					   &gsm->context.cmd_handler,
-					   connect_cmds,
-					   ARRAY_SIZE(connect_cmds),
-					   &gsm->sem_response,
-					   GSM_CMD_SETUP_TIMEOUT);
+	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
+						  &gsm->context.cmd_handler,
+						  connect_cmds,
+						  ARRAY_SIZE(connect_cmds),
+						  &gsm->sem_response,
+						  GSM_CMD_SETUP_TIMEOUT);
 	if (ret < 0) {
 		LOG_DBG("modem setup returned %d, %s",
 			ret, "retrying...");
@@ -427,20 +427,22 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 			LOG_DBG("iface %suart error %d", "AT ", ret);
 		} else {
 			/* Do a test and try to send AT command to modem */
-			ret = modem_cmd_send(&gsm->context.iface,
-					     &gsm->context.cmd_handler,
-					     &response_cmds[0],
-					     ARRAY_SIZE(response_cmds),
-					     "AT", &gsm->sem_response,
-					     GSM_CMD_AT_TIMEOUT);
+			ret = modem_cmd_send_nolock(
+				&gsm->context.iface,
+				&gsm->context.cmd_handler,
+				&response_cmds[0],
+				ARRAY_SIZE(response_cmds),
+				"AT", &gsm->sem_response,
+				GSM_CMD_AT_TIMEOUT);
 			if (ret < 0) {
-				LOG_DBG("modem setup returned %d, %s",
+				LOG_WRN("modem setup returned %d, %s",
 					ret, "AT cmds failed");
 			} else {
 				LOG_INF("AT channel %d connected to %s",
 					DLCI_AT, gsm->at_dev->name);
 			}
 		}
+		modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
 	}
 }
 
@@ -450,7 +452,7 @@ static int mux_enable(struct gsm_modem *gsm)
 
 	/* Turn on muxing */
 	if (IS_ENABLED(CONFIG_MODEM_GSM_SIMCOM)) {
-		ret = modem_cmd_send(
+		ret = modem_cmd_send_nolock(
 			&gsm->context.iface,
 			&gsm->context.cmd_handler,
 			&response_cmds[0],
@@ -473,7 +475,7 @@ static int mux_enable(struct gsm_modem *gsm)
 			GSM_CMD_AT_TIMEOUT);
 	} else {
 		/* Generic GSM modem */
-		ret = modem_cmd_send(&gsm->context.iface,
+		ret = modem_cmd_send_nolock(&gsm->context.iface,
 				     &gsm->context.cmd_handler,
 				     &response_cmds[0],
 				     ARRAY_SIZE(response_cmds),
@@ -632,12 +634,12 @@ static void gsm_configure(struct k_work *work)
 
 	LOG_DBG("Starting modem %p configuration", gsm);
 
-	ret = modem_cmd_send(&gsm->context.iface,
-			     &gsm->context.cmd_handler,
-			     &response_cmds[0],
-			     ARRAY_SIZE(response_cmds),
-			     "AT", &gsm->sem_response,
-			     GSM_CMD_AT_TIMEOUT);
+	ret = modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    &response_cmds[0],
+				    ARRAY_SIZE(response_cmds),
+				    "AT", &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
 	if (ret < 0) {
 		LOG_DBG("modem not ready %d", ret);
 
@@ -709,6 +711,11 @@ void gsm_ppp_stop(const struct device *device)
 		if (gsm->ppp_dev) {
 			uart_mux_disable(gsm->ppp_dev);
 		}
+	}
+
+	if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
+				      K_SECONDS(10))) {
+		LOG_WRN("Failed locking modem cmds!");
 	}
 }
 

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -173,7 +173,7 @@ int modem_cmd_send(struct modem_iface *iface,
 		   const uint8_t *buf, struct k_sem *sem, k_timeout_t timeout);
 
 /**
- * @brief  send a series of AT commands
+ * @brief  send a series of AT commands w/ a TX lock
  *
  * @param  *iface: interface to use
  * @param  *handler: command handler to use
@@ -190,6 +190,23 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 				 struct k_sem *sem, k_timeout_t timeout);
 
 /**
+ * @brief  send a series of AT commands w/o locking TX
+ *
+ * @param  *iface: interface to use
+ * @param  *handler: command handler to use
+ * @param  *cmds: array of setup commands to send
+ * @param  cmds_len: size of the setup command array
+ * @param  *sem: wait for response semaphore
+ * @param  timeout: timeout of command
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
+int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
+					struct modem_cmd_handler *handler,
+					struct setup_cmd *cmds, size_t cmds_len,
+					struct k_sem *sem, k_timeout_t timeout);
+
+/**
  * @brief  Init command handler
  *
  * @param  *handler: command handler to initialize
@@ -199,6 +216,25 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
  */
 int modem_cmd_handler_init(struct modem_cmd_handler *handler,
 			   struct modem_cmd_handler_data *data);
+
+/**
+ * @brief  Lock the modem for sending cmds
+ *
+ * This is semaphore-based rather than mutex based, which means there's no
+ * requirements of thread ownership for the user. These functions are useful
+ * when one needs to prevent threads from sending UART data to the modem for an
+ * extended period of time (for example during modem reset).
+ *
+ * @param  *handler: command handler to lock
+ * @param  lock: set true to lock, false to unlock
+ * @param  timeout: give up after timeout
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
+int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
+			      k_timeout_t timeout);
+void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Note: this depends on #28475 

PR #28475 required user to explicitly ensure there was no concurrent modem UART access before restarting gsm_ppp stack. This PR fixes this and adds a generally useful method of blocking access to modem UART via modem_cmd_send which is useful for things other than gsm_ppp.