### PR TITLE
Bluetooth: controller: Fix missing auxiliary advertising start

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1172,10 +1172,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 			/* Keep aux interval equal or higher than primary PDU
 			 * interval.
 			 */
-			aux->interval =
-				adv->interval +
-				(HAL_TICKER_TICKS_TO_US(ULL_ADV_RANDOM_DELAY) /
-				 625U);
+			aux->interval = adv->interval +
+					(HAL_TICKER_TICKS_TO_US(
+						ULL_ADV_RANDOM_DELAY) / 625U);
 
 			ret = ull_adv_aux_start(aux, ticks_anchor_aux,
 						ticks_slot_overhead_aux,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1157,8 +1157,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 					HAL_TICKER_US_TO_TICKS(EVENT_MAFS_US);
 
 				ret = ull_adv_sync_start(sync,
-							 ticks_anchor_sync,
-							 &ret_cb);
+							 ticks_anchor_sync);
 				if (ret) {
 					goto failure_cleanup;
 				}
@@ -1177,8 +1176,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 						ULL_ADV_RANDOM_DELAY) / 625U);
 
 			ret = ull_adv_aux_start(aux, ticks_anchor_aux,
-						ticks_slot_overhead_aux,
-						&ret_cb);
+						ticks_slot_overhead_aux);
 			if (ret) {
 				goto failure_cleanup;
 			}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1156,8 +1156,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 					ticks_slot_aux +
 					HAL_TICKER_US_TO_TICKS(EVENT_MAFS_US);
 
-				ull_hdr_init(&sync->ull);
-
 				ret = ull_adv_sync_start(sync,
 							 ticks_anchor_sync,
 							 &ret_cb);
@@ -1170,9 +1168,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 				lll_adv_data_enqueue(lll, pri_idx);
 			}
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
-
-			/* Initialise ULL header */
-			ull_hdr_init(&aux->ull);
 
 			/* Keep aux interval equal or higher than primary PDU
 			 * interval.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1114,11 +1114,13 @@ uint8_t ll_adv_enable(uint8_t enable)
 		if (lll->sync) {
 			sync = (void *)HDR_LLL2EVT(lll->sync);
 			if (sync->is_enabled && !sync->is_started) {
-				ret = ull_adv_aux_hdr_set_clear(adv,
+				uint8_t err;
+
+				err = ull_adv_aux_hdr_set_clear(adv,
 					ULL_ADV_PDU_HDR_FIELD_SYNC_INFO,
 					0, NULL, NULL, &pri_idx);
-				if (ret) {
-					return ret;
+				if (err) {
+					return err;
 				}
 			} else {
 				/* Do not start periodic advertising */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -413,7 +413,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 			ad_len = *val_ptr;
 			val_ptr++;
 
-			ad_data = (void *)*((uint32_t *)val_ptr);
+			ad_data = (void *)sys_get_le32(val_ptr);
 
 			return ull_adv_data_set(adv, ad_len, ad_data);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -142,8 +142,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 
 			aux->interval =	adv->interval +
 					(HAL_TICKER_TICKS_TO_US(
-						ULL_ADV_RANDOM_DELAY
-					) / 625U);
+						ULL_ADV_RANDOM_DELAY) / 625U);
 
 			/* FIXME: Find absolute ticks until after primary PDU
 			 *        on air to place the auxiliary advertising PDU.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -140,8 +140,6 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 			uint32_t ticks_anchor;
 			uint32_t ret;
 
-			ull_hdr_init(&aux->ull);
-
 			aux->interval =	adv->interval +
 					(HAL_TICKER_TICKS_TO_US(
 						ULL_ADV_RANDOM_DELAY
@@ -820,6 +818,8 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 {
 	uint8_t aux_handle;
 	uint32_t ret;
+
+	ull_hdr_init(&aux->ull);
 
 	aux_handle = aux_handle_get(aux);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -68,8 +68,7 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux);
 
 /* helper function to start auxiliary advertising */
 uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
-			   uint32_t ticks_slot_overhead,
-			   uint32_t volatile *ret_cb);
+			   uint32_t ticks_slot_overhead);
 
 /* helper function to stop auxiliary advertising */
 uint8_t ull_adv_aux_stop(struct ll_adv_aux_set *aux);
@@ -124,8 +123,8 @@ int ull_adv_sync_init(void);
 int ull_adv_sync_reset(void);
 
 /* helper function to start periodic advertising */
-uint32_t ull_adv_sync_start(struct ll_adv_sync_set *sync, uint32_t ticks_anchor,
-			 uint32_t volatile *ret_cb);
+uint32_t ull_adv_sync_start(struct ll_adv_sync_set *sync,
+			    uint32_t ticks_anchor);
 
 /* helper function to schedule a mayfly to get sync offset */
 void ull_adv_sync_offset_get(struct ll_adv_set *adv);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -87,7 +87,9 @@ void ull_adv_aux_offset_get(struct ll_adv_set *adv);
 uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 				  uint16_t sec_hdr_add_fields,
 				  uint16_t sec_hdr_rem_fields,
-				  void *value, struct pdu_adv_adi *adi);
+				  void *value,
+				  struct pdu_adv_adi *adi,
+				  uint8_t *pri_idx);
 
 /* helper function to calculate common ext adv payload header length */
 static inline uint8_t

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -251,7 +251,6 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			return err;
 		}
 
-		ull_hdr_init(&sync->ull);
 
 		err = ull_adv_sync_start(sync, ticks_anc_sync, &ret_cb);
 		if (err) {
@@ -303,6 +302,8 @@ uint32_t ull_adv_sync_start(struct ll_adv_sync_set *sync, uint32_t ticks_anchor,
 	uint32_t interval_us;
 	uint8_t sync_handle;
 	uint32_t ret;
+
+	ull_hdr_init(&sync->ull);
 
 	/* TODO: Calc AUX_SYNC_IND slot_us */
 	slot_us += 1000;


### PR DESCRIPTION
Fix missing auxiliary channel advertising start when
starting Periodic Advertising.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>