### PR TITLE
boards: mm_swiftio: enable pwm devices

### DIFF
--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -109,6 +109,42 @@
 	transfer-delay = <50>;
 };
 
+&flexpwm1_pwm3 {
+	status = "okay";
+};
+
+&flexpwm2_pwm0 {
+	status = "okay";
+};
+
+&flexpwm2_pwm1 {
+	status = "okay";
+};
+
+&flexpwm2_pwm2 {
+	status = "okay";
+};
+
+&flexpwm2_pwm3 {
+	status = "okay";
+};
+
+&flexpwm4_pwm0 {
+	status = "okay";
+};
+
+&flexpwm4_pwm1 {
+	status = "okay";
+};
+
+&flexpwm4_pwm2 {
+	status = "okay";
+};
+
+&flexpwm4_pwm3 {
+	status = "okay";
+};
+
 &usb1 {
 	status = "okay";
 };

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -121,6 +121,7 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_CSI
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_PWM
 
 config SOC_MIMXRT1061
 	bool "SOC_MIMXRT1061"


### PR DESCRIPTION
Enable pwm device for mm_swiftio.
select HAS_MCUX_PWM for rt1052.

Signed-off-by: Frank Li <lgl88911@163.com>