### PR TITLE
sanitycheck: Fix results for --cmake-only

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2082,6 +2082,8 @@ class ProjectBuilder(FilterBuilder):
             if self.instance.status in ["failed", "error"]:
                 pipeline.put({"op": "report", "test": self.instance})
             elif self.cmake_only:
+                if self.instance.status is None:
+                    self.instance.status = "passed"
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 if self.instance.name in results['filter'] and results['filter'][self.instance.name]:


### PR DESCRIPTION
If we run with --cmake-only we get the following:

`ERROR   - Unknown status None`

Fix this by treating no status set as "passed" for the --cmake-only
case.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>