### PR TITLE
manifest: mcuboot update - Added watchdog feed on nRF dvices 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: aef137b1af8aa7a0f43345c82459254b8832262e
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e312fa2cec3e8440bf484d7da3443e149b7eb9d8
+      revision: pull/34/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
introduces: https://github.com/zephyrproject-rtos/mcuboot/pull/34

- Added watchdog feed on nRF dvices during boot region copy.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>