### PR TITLE
x86: fix QEMU accessing ACPI tables

### DIFF
--- a/arch/x86/core/CMakeLists.txt
+++ b/arch/x86/core/CMakeLists.txt
@@ -20,6 +20,7 @@ zephyr_library_sources_ifdef(CONFIG_MULTIBOOT multiboot.c)
 zephyr_library_sources_ifdef(CONFIG_ACPI acpi.c)
 zephyr_library_sources_ifdef(CONFIG_X86_MMU x86_mmu.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.c)
+zephyr_library_sources_ifdef(CONFIG_NEWLIB_LIBC heap.c)
 
 zephyr_library_sources_ifdef(CONFIG_X86_VERY_EARLY_CONSOLE early_serial.c)
 

--- a/arch/x86/core/heap.c
+++ b/arch/x86/core/heap.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <device.h>
+#include <app_memory/app_memdomain.h>
+#include <arch/x86/memmap.h>
+#include <linker/linker-defs.h>
+#include <sys/sem.h>
+#include <sys/util.h>
+
+#define USED_RAM_END_ADDR	POINTER_TO_UINT(&_end)
+
+static K_APP_DMEM(z_libc_partition) SYS_SEM_DEFINE(heap_sem, 1, 1);
+
+/* Start of heap area */
+static K_APP_BMEM(z_libc_partition) uintptr_t heap_start;
+
+/* End of heap area */
+static K_APP_BMEM(z_libc_partition) uintptr_t heap_end;
+
+/* Current heap pointer used as needed for sbrk() */
+static K_APP_BMEM(z_libc_partition) intptr_t heap_cur_ptr;
+
+void *sbrk(int count)
+{
+	void *ret;
+	intptr_t ptr;
+
+	/* coverity[CHECKED_RETURN] */
+	sys_sem_take(&heap_sem, K_FOREVER);
+
+	ptr = heap_cur_ptr + count;
+
+	if ((ptr >= heap_start) && (ptr < heap_end)) {
+		heap_cur_ptr = ptr;
+		ret = INT_TO_POINTER(ptr);
+	} else {
+		ret = INT_TO_POINTER(-1);
+	}
+
+	/* coverity[CHECKED_RETURN] */
+	sys_sem_give(&heap_sem);
+
+	return ret;
+}
+
+static int z_x86_heap_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#ifdef CONFIG_MMU
+	heap_start = ROUND_UP(USED_RAM_END_ADDR, CONFIG_MMU_PAGE_SIZE);
+#else
+	heap_start = USED_RAM_END_ADDR;
+#endif
+
+	heap_cur_ptr = heap_start;
+
+#ifndef CONFIG_MULTIBOOT_MEMMAP
+	/*
+	 * Without memory map from multiboot, we don't know where
+	 * reserved memory areas are. So, by default, use the whole
+	 * remaining SRAM area as heap.
+	 */
+
+	uintptr_t heap_size = (KB(CONFIG_SRAM_SIZE) -
+			       (heap_start - CONFIG_SRAM_BASE_ADDRESS));
+
+	heap_end = heap_start + heap_size;
+#else
+	/*
+	 * Use multiboot memory map to figure out the range of memory
+	 * that can be used for heap.
+	 */
+
+	int i;
+	uintptr_t mem_start, mem_end;
+
+	/* By default, no heap area  */
+	heap_end = heap_start;
+
+	/*
+	 * Go through all entry in memory map to figure out where
+	 * the heap can be.
+	 */
+	for (i = 0; i < CONFIG_X86_MEMMAP_ENTRIES; ++i) {
+		struct x86_memmap_entry *entry = &x86_memmap[i];
+
+		if (entry->type == X86_MEMMAP_ENTRY_RAM) {
+			mem_start = entry->base;
+			mem_end = entry->base + entry->length;
+
+			/*
+			 * The start of heap is within in this memory
+			 * region. Heap can extend to end of this
+			 * region.
+			 */
+			if ((heap_start >= mem_start) &&
+			    (heap_start < mem_end)) {
+				heap_end = mem_end;
+				break;
+			}
+		}
+	}
+
+#endif
+
+	return 0;
+}
+
+SYS_INIT(z_x86_heap_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -19,8 +19,16 @@ else()
   set(QEMU_CPU_TYPE_${ARCH} qemu32,+nx,+pae)
 endif()
 
+if(CONFIG_XIP)
+  # 4MB RAM + 4MB Flash
+  set(QEMU_MEMORY_SIZE 8)
+else()
+  # 4MB RAM
+  set(QEMU_MEMORY_SIZE 4)
+endif()
+
 set(QEMU_FLAGS_${ARCH}
-  -m 9
+  -m ${QEMU_MEMORY_SIZE}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}

--- a/include/arch/x86/memory.ld
+++ b/include/arch/x86/memory.ld
@@ -48,6 +48,24 @@
 #define LOCORE_SIZE         (0x10000 - LOCORE_BASE)
 #endif
 
+#ifdef CONFIG_QEMU_TARGET
+/*
+ * QEMU reserves the last 128K for ACPI tables so we need to avoid
+ * them.
+ * With XIP, QEMU memory is split in 4MB SRAM + 4MB Flash.
+ * Without XIP, QEMU memory is simply 4MB SRAM.
+ */
+#ifdef CONFIG_XIP
+  #undef FLASH_ROM_SIZE
+  #define FLASH_ROM_SIZE \
+	  (DT_REG_SIZE(DT_CHOSEN(zephyr_flash)) - 131072)
+#else
+  #undef KERNEL_RAM_SIZE
+  #define KERNEL_RAM_SIZE \
+	  (PHYS_RAM_SIZE - CONFIG_X86_KERNEL_OFFSET - 131072)
+#endif
+#endif
+
 MEMORY
     {
 #if defined(CONFIG_XIP)

--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   arch.x86.info:
     arch_allow: x86
-    platform_allow: up_squared up_squared_32
+    platform_allow: qemu_x86 qemu_x86_64 up_squared up_squared_32
     harness: console
     harness_config:
         type: one_line

--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -7,3 +7,13 @@ tests:
         type: one_line
         regex:
           - "info: complete"
+  arch.x86.info.userspace:
+    arch_allow: x86
+    platform_allow: qemu_x86 qemu_x86_64 up_squared up_squared_32
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y
+    harness: console
+    harness_config:
+        type: one_line
+        regex:
+          - "info: complete"


### PR DESCRIPTION
On QEMU with x86 and x86-64, there is a 1MB area immediately following SRAM where ACPI tables are stored. This area is not mapped by default and results in ACPI non-functional on QEMU. This PR maps this area by default so ACPI can be used on QEMU.