### PR TITLE
tests: uart_async_api: fix fault accessing cached device pointer

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -13,7 +13,7 @@ K_SEM_DEFINE(rx_buf_released, 0, 1);
 K_SEM_DEFINE(rx_disabled, 0, 1);
 
 ZTEST_BMEM volatile bool failed_in_isr;
-static const struct device *uart_dev;
+ZTEST_BMEM static const struct device *uart_dev;
 
 void init_test(void)
 {


### PR DESCRIPTION
The cached device pointer must be placed in memory that allows user
mode invocation of the test functions to access it.

Fixes #29092