### PR TITLE
bluetooth: clarify the ownership expectations of data passed by pointer

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -660,6 +660,10 @@ struct bt_le_per_adv_param {
  * response data parameters are ignored. If the mode is high duty cycle
  * the timeout will be @ref BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT.
  *
+ * @note This function copies parameters and data from the objects
+ * passed by pointer into internal storage: the objects pointed to by
+ * arguments need not persist past the function return.
+ *
  * @param param Advertising parameters.
  * @param ad Data to be used in advertisement packets.
  * @param ad_len Number of elements in ad
@@ -684,6 +688,10 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
  * @brief Update advertising
  *
  * Update advertisement and scan response data.
+ *
+ * @note This function copies data from the objects passed by pointer
+ * into internal storage: the objects pointed to by arguments need not
+ * persist past the function return.
  *
  * @param ad Data to be used in advertisement packets.
  * @param ad_len Number of elements in ad


### PR DESCRIPTION
The API documentation does not specify whether provided references to advertising parameters and data are retained by the infrastructure, or used transiently to initialize internal state.  It appears the latter is the case.  Document this so callers aren't misled into believing they must allocate the parameter storage in static memory.

**NOTE** I've done this only for two functions where I needed to know this behavior.  It would be nice to have the API clarified throughout. 

If *nothing* in the Bluetooth API retains pointers to objects passed by pointer, and that fact is documented somewhere then maybe this isn't necessary.