### PR TITLE
NUCLEO-H745ZI-Q move to device pinconfig

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -49,6 +49,7 @@
 };
 
 &i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -7,7 +7,6 @@
 
 /dts-v1/;
 #include <st/h7/stm32h745Xi_m7.dtsi>
-#include <st/h7/stm32h745zitx-pinctrl.dtsi>
 #include "nucleo_h745zi_q.dtsi"
 
 / {

--- a/boards/arm/nucleo_h745zi_q/pinmux.c
+++ b/boards/arm/nucleo_h745zi_q/pinmux.c
@@ -34,10 +34,6 @@ static const struct pin_config pinconf[] = {
 	{ STM32_PIN_PG13, STM32H7_PINMUX_FUNC_PG13_ETH_TXD0 },
 	{ STM32_PIN_PB13, STM32H7_PINMUX_FUNC_PB13_ETH_TXD1 },
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay) && CONFIG_I2C
-	{ STM32_PIN_PB8, STM32H7_PINMUX_FUNC_PB8_I2C1_SCL },
-	{ STM32_PIN_PB9, STM32H7_PINMUX_FUNC_PB9_I2C1_SDA },
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)


### PR DESCRIPTION
Move whole board to device-tree pin config approach.