### PR TITLE
drivers: clock_control: Change clock_control_async_on parameters

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -39,6 +39,10 @@ API Changes
 * Changed vcnl4040 dts binding default for property 'proximity-trigger'.
   Changed the default to match the HW POR state for this property.
 
+* The :c:func:`clock_control_async_on` function will now take ``callback`` and
+  ``user_data`` as arguments instead of structure which contained list node,
+  callback and user data.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -155,7 +155,7 @@ static int set_starting_state(uint32_t *flags, uint32_t ctx)
 	} else if (current_ctx != ctx) {
 		err = -EPERM;
 	} else {
-		err = -EBUSY;
+		err = -EALREADY;
 	}
 
 	irq_unlock(key);

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -339,9 +339,8 @@ static int api_stop(const struct device *dev, clock_control_subsys_t subsys)
 	return stop(dev, subsys, CTX_API);
 }
 
-static int async_start(const struct device *dev,
-			clock_control_subsys_t subsys,
-			struct clock_control_async_data *data, uint32_t ctx)
+static int async_start(const struct device *dev, clock_control_subsys_t subsys,
+			clock_control_cb_t cb, void *user_data, uint32_t ctx)
 {
 	enum clock_control_nrf_type type = (enum clock_control_nrf_type)subsys;
 	struct nrf_clock_control_sub_data *subdata = get_sub_data(dev, type);
@@ -352,8 +351,8 @@ static int async_start(const struct device *dev,
 		return err;
 	}
 
-	subdata->cb = data->cb;
-	subdata->user_data = data->user_data;
+	subdata->cb = cb;
+	subdata->user_data = user_data;
 
 	 get_sub_config(dev, type)->start();
 
@@ -361,9 +360,9 @@ static int async_start(const struct device *dev,
 }
 
 static int api_start(const struct device *dev, clock_control_subsys_t subsys,
-			     struct clock_control_async_data *data)
+		     clock_control_cb_t cb, void *user_data)
 {
-	return async_start(dev, subsys, data, CTX_API);
+	return async_start(dev, subsys, cb, user_data, CTX_API);
 }
 
 static void blocking_start_callback(const struct device *dev,
@@ -379,17 +378,13 @@ static int api_blocking_start(const struct device *dev,
 			      clock_control_subsys_t subsys)
 {
 	struct k_sem sem = Z_SEM_INITIALIZER(sem, 0, 1);
-	struct clock_control_async_data data = {
-		.cb = blocking_start_callback,
-		.user_data = &sem
-	};
 	int err;
 
 	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
 		return -ENOTSUP;
 	}
 
-	err = api_start(dev, subsys, &data);
+	err = api_start(dev, subsys, blocking_start_callback, &sem);
 	if (err < 0) {
 		return err;
 	}
@@ -428,14 +423,10 @@ static void onoff_started_callback(const struct device *dev,
 static void onoff_start(struct onoff_manager *mgr,
 			onoff_notify_fn notify)
 {
-	struct clock_control_async_data data = {
-		.cb = onoff_started_callback,
-		.user_data = notify
-	};
 	int err;
 
 	err = async_start(DEVICE_GET(clock_nrf), get_subsys(mgr),
-			  &data, CTX_ONOFF);
+			  onoff_started_callback, notify, CTX_ONOFF);
 	if (err < 0) {
 		notify(mgr, err);
 	}

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -46,19 +46,6 @@ enum clock_control_status {
 	CLOCK_CONTROL_STATUS_UNKNOWN
 };
 
-
-/**
- * @cond INTERNAL_HIDDEN
- */
-#define Z_CLOCK_CONTROL_ASYNC_DATA_INITIALIZER(_cb, _user_data) \
-	{ \
-		.cb = cb, \
-		.user_data = _user_data \
-	}
-/**
- * INTERNAL_HIDDEN @endcond
- */
-
 /**
  * clock_control_subsys_t is a type to identify a clock controller sub-system.
  * Such data pointed is opaque and relevant only to the clock controller
@@ -76,30 +63,6 @@ typedef void (*clock_control_cb_t)(const struct device *dev,
 				   clock_control_subsys_t subsys,
 				   void *user_data);
 
-/**
- * Define and initialize clock_control async data.
- *
- * @param name		Name of the data.
- * @param cb		Callback.
- * @param user_data	User data
- */
-#define CLOCK_CONTROL_ASYNC_DATA_DEFINE(name, cb, user_data) \
-	struct clock_control_async_data name = \
-		Z_CLOCK_CONTROL_ASYNC_DATA_INITIALIZER(cb, user_data)
-
-/**
- * @brief Clock control data used for asynchronous clock enabling.
- *
- * @param node		Used internally for linking asynchronous requests.
- * @param cb		Callback called when clock is started.
- * @param user_data	User data passed as an argument in the callback.
- */
-struct clock_control_async_data {
-	sys_snode_t node;
-	clock_control_cb_t cb;
-	void *user_data;
-};
-
 typedef int (*clock_control)(const struct device *dev,
 			     clock_control_subsys_t sys);
 
@@ -109,10 +72,12 @@ typedef int (*clock_control_get)(const struct device *dev,
 
 typedef int (*clock_control_async_on_fn)(const struct device *dev,
 					 clock_control_subsys_t sys,
-					 struct clock_control_async_data *data);
+					 clock_control_cb_t cb,
+					 void *user_data);
 
-typedef enum clock_control_status (*clock_control_get_status_fn)(const struct device *dev,
-								 clock_control_subsys_t sys);
+typedef enum clock_control_status (*clock_control_get_status_fn)(
+						    const struct device *dev,
+						    clock_control_subsys_t sys);
 
 struct clock_control_driver_api {
 	clock_control			on;
@@ -166,24 +131,23 @@ static inline int clock_control_off(const struct device *dev,
 /**
  * @brief Request clock to start with notification when clock has been started.
  *
- * Function is non-blocking and can be called from any context.
- * When clock is already running user callback will be called from the context
- * of the function call else it is called from other context (e.g. clock
- * interrupt).
+ * Function is non-blocking and can be called from any context. User callback is
+ * called when clock is started.
  *
- * @param dev 	   Device.
- * @param sys	   A pointer to an opaque data representing the sub-system.
- * @param data	   Data structure containing a callback that is called when
- *		   action is performed. Structure content must be valid until
- *		   clock is started and user callback is called. Can be NULL.
+ * @param dev	    Device.
+ * @param sys	    A pointer to an opaque data representing the sub-system.
+ * @param cb	    Callback.
+ * @param user_data User context passed to the callback.
  *
- * @retval 0 if clock is started or already running.
- * @retval -EBUSY if same request already scheduled and not yet completed.
+ * @retval 0 if start is successfully initiated.
+ * @retval -EALREADY if clock was already started and is starting or running.
  * @retval -ENOTSUP if not supported.
+ * @retval other negative errno on vendor specific error.
  */
 static inline int clock_control_async_on(const struct device *dev,
 					 clock_control_subsys_t sys,
-					 struct clock_control_async_data *data)
+					 clock_control_cb_t cb,
+					 void *user_data)
 {
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
@@ -192,7 +156,7 @@ static inline int clock_control_async_on(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return api->async_on(dev, sys, data);
+	return api->async_on(dev, sys, cb, user_data);
 }
 
 /**

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -307,7 +307,7 @@ static void test_double_start_on_instance(const char *dev_name,
 	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	err = clock_control_on(dev, subsys);
-	zassert_equal(-EBUSY, err, "%s: Unexpected err (%d)", dev_name, err);
+	zassert_true(err < 0, "%s: Unexpected return value:%d", dev_name, err);
 }
 
 static void test_double_start(void)

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -184,12 +184,9 @@ static void async_capable_callback(const struct device *dev,
 static bool async_capable(const char *dev_name, clock_control_subsys_t subsys)
 {
 	const struct device *dev = device_get_binding(dev_name);
-	struct clock_control_async_data data = {
-		.cb = async_capable_callback
-	};
 	int err;
 
-	err = clock_control_async_on(dev, subsys, &data);
+	err = clock_control_async_on(dev, subsys, async_capable_callback, NULL);
 	if (err < 0) {
 		printk("failed %d", err);
 		return false;
@@ -229,16 +226,12 @@ static void test_async_on_instance(const char *dev_name,
 	enum clock_control_status status;
 	int err;
 	bool executed = false;
-	struct clock_control_async_data data = {
-		.cb = clock_on_callback,
-		.user_data = &executed
-	};
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
 			"%s: Unexpected status (%d)", dev_name, status);
 
-	err = clock_control_async_on(dev, subsys, &data);
+	err = clock_control_async_on(dev, subsys, clock_on_callback, &executed);
 	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	/* wait for clock started. */
@@ -269,10 +262,6 @@ static void test_async_on_stopped_on_instance(const char *dev_name,
 	int err;
 	int key;
 	bool executed = false;
-	struct clock_control_async_data data = {
-		.cb = clock_on_callback,
-		.user_data = &executed
-	};
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
@@ -280,7 +269,7 @@ static void test_async_on_stopped_on_instance(const char *dev_name,
 
 	/* lock to prevent clock interrupt for fast starting clocks.*/
 	key = irq_lock();
-	err = clock_control_async_on(dev, subsys, &data);
+	err = clock_control_async_on(dev, subsys, clock_on_callback, &executed);
 	zassert_equal(0, err, "%s: Unexpected err (%d)", dev_name, err);
 
 	/* Attempt to stop clock while it is being started. */


### PR DESCRIPTION
Stable API change: modify parameters of clock_control_async_on which
previously took a structure which contains list node, callback and user
context. Removing list node and replacing structure with two parameters:
callback and user context. List node is removed because it has no use
 in current API.

Fixes #27423.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
