### PR TITLE
driver: host_uart: Add host-uart device in npcx.

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -307,11 +307,11 @@ static const struct adc_driver_api adc_npcx_driver_api = {
 
 static int adc_npcx_init(const struct device *dev);
 
-static const struct npcx_alt adc_alts[] = DT_NPCX_ALT_ITEMS_LIST(0);
+static const struct npcx_alt adc_alts[] = NPCX_DT_ALT_ITEMS_LIST(0);
 
 static const struct adc_npcx_config adc_npcx_cfg_0 = {
 	.base = DT_INST_REG_ADDR(0),
-	.clk_cfg = DT_NPCX_CLK_CFG_ITEM(0),
+	.clk_cfg = NPCX_DT_CLK_CFG_ITEM(0),
 	.alts_list = adc_alts,
 };
 

--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -25,7 +25,4 @@ config ESPI_PERIPHERAL_HOST_IO
 config ESPI_PERIPHERAL_DEBUG_PORT_80
 	default y
 
-config ESPI_PERIPHERAL_UART
-	default y
-
 endif #ESPI_NPCX

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -113,41 +113,41 @@ struct npcx_vw_out_config {
  */
 static const struct npcx_vw_in_config vw_in_tbl[] = {
 	/* index 02h (In)  */
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S3, vw_slp_s3),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S4, vw_slp_s4),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S5, vw_slp_s5),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S3, vw_slp_s3),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S4, vw_slp_s4),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_S5, vw_slp_s5),
 	/* index 03h (In)  */
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_STAT, vw_sus_stat),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_PLTRST, vw_plt_rst),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_OOB_RST_WARN, vw_oob_rst_warn),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_STAT, vw_sus_stat),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_PLTRST, vw_plt_rst),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_OOB_RST_WARN, vw_oob_rst_warn),
 	/* index 07h (In)  */
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_HOST_RST_WARN, vw_host_rst_warn),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_HOST_RST_WARN, vw_host_rst_warn),
 	/* index 41h (In)  */
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_WARN, vw_sus_warn),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, vw_sus_pwrdn_ack),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_A, vw_slp_a),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_WARN, vw_sus_warn),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, vw_sus_pwrdn_ack),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_A, vw_slp_a),
 	/* index 42h (In)  */
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_LAN, vw_slp_lan),
-	DT_NPCX_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_WLAN, vw_slp_wlan),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_LAN, vw_slp_lan),
+	NPCX_DT_VW_IN_CONF(ESPI_VWIRE_SIGNAL_SLP_WLAN, vw_slp_wlan),
 };
 
 static const struct npcx_vw_out_config vw_out_tbl[] = {
 	/* index 04h (Out) */
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_OOB_RST_ACK, vw_oob_rst_ack),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_WAKE, vw_wake),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_PME, vw_pme),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_OOB_RST_ACK, vw_oob_rst_ack),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_WAKE, vw_wake),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_PME, vw_pme),
 	/* index 05h (Out) */
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE, vw_slv_boot_done),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_ERR_FATAL, vw_err_fatal),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_ERR_NON_FATAL, vw_err_non_fatal),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_BOOT_STS,
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE, vw_slv_boot_done),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_ERR_FATAL, vw_err_fatal),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_ERR_NON_FATAL, vw_err_non_fatal),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_BOOT_STS,
 						vw_slv_boot_sts_with_done),
 	/* index 06h (Out) */
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SCI, vw_sci),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SMI, vw_smi),
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_HOST_RST_ACK, vw_host_rst_ack),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SCI, vw_sci),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SMI, vw_smi),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_HOST_RST_ACK, vw_host_rst_ack),
 	/* index 40h (Out) */
-	DT_NPCX_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SUS_ACK, vw_sus_ack),
+	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SUS_ACK, vw_sus_ack),
 };
 
 /* Callbacks for eSPI bus reset and Virtual Wire signals. */
@@ -806,12 +806,12 @@ static const struct espi_driver_api espi_npcx_driver_api = {
 
 static struct espi_npcx_data espi_npcx_data;
 
-static const struct npcx_alt espi_alts[] = DT_NPCX_ALT_ITEMS_LIST(0);
+static const struct npcx_alt espi_alts[] = NPCX_DT_ALT_ITEMS_LIST(0);
 
 static const struct espi_npcx_config espi_npcx_config = {
 	.base = DT_INST_REG_ADDR(0),
-	.espi_rst_wui = DT_NPCX_WUI_ITEM_BY_NAME(0, espi_rst_wui),
-	.clk_cfg = DT_NPCX_CLK_CFG_ITEM(0),
+	.espi_rst_wui = NPCX_DT_WUI_ITEM_BY_NAME(0, espi_rst_wui),
+	.clk_cfg = NPCX_DT_CLK_CFG_ITEM(0),
 	.alts_size = ARRAY_SIZE(espi_alts),
 	.alts_list = espi_alts,
 };

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -148,7 +148,7 @@ struct host_sub_npcx_data {
 };
 
 static const struct npcx_clk_cfg host_dev_clk_cfg[] =
-					DT_NPCX_CLK_CFG_ITEMS_LIST(0);
+					NPCX_DT_CLK_CFG_ITEMS_LIST(0);
 
 struct host_sub_npcx_config host_sub_cfg = {
 	.inst_mswc = (struct mswc_reg *)DT_INST_REG_ADDR_BY_NAME(0, mswc),
@@ -157,7 +157,7 @@ struct host_sub_npcx_config host_sub_cfg = {
 	.inst_kbc = (struct kbc_reg *)DT_INST_REG_ADDR_BY_NAME(0, kbc),
 	.inst_pm_acpi = (struct pmch_reg *)DT_INST_REG_ADDR_BY_NAME(0, pm_acpi),
 	.inst_pm_hcmd = (struct pmch_reg *)DT_INST_REG_ADDR_BY_NAME(0, pm_hcmd),
-	.host_acc_wui = DT_NPCX_WUI_ITEM_BY_NAME(0, host_acc_wui),
+	.host_acc_wui = NPCX_DT_WUI_ITEM_BY_NAME(0, host_acc_wui),
 	.clks_size = ARRAY_SIZE(host_dev_clk_cfg),
 	.clks_list = host_dev_clk_cfg,
 };
@@ -440,7 +440,7 @@ static void host_port80_init(void)
 #if defined(CONFIG_ESPI_PERIPHERAL_UART)
 /* host uart pinmux configuration */
 static const struct npcx_alt host_uart_alts[] =
-					DT_NPCX_ALT_ITEMS_LIST(0);
+			NPCX_DT_IO_ALT_ITEMS_LIST(nuvoton_npcx_host_uart, 0);
 /* Host UART sub-device local functions */
 void host_uart_init(void)
 {

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -273,8 +273,8 @@ int gpio_npcx_init(const struct device *dev)
 		},                                                             \
 		.base = DT_INST_REG_ADDR(inst),                                \
 		.port = inst,                                                  \
-		.wui_size = DT_NPCX_WUI_ITEMS_LEN(inst),                       \
-		.wui_maps = DT_NPCX_WUI_ITEMS_LIST(inst)                       \
+		.wui_size = NPCX_DT_WUI_ITEMS_LEN(inst),                       \
+		.wui_maps = NPCX_DT_WUI_ITEMS_LIST(inst)                       \
 	};                                                                     \
 									       \
 	static struct gpio_npcx_data gpio_npcx_data_##inst;	               \

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -338,8 +338,8 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 		}                                                              \
 									       \
 		/* Config IRQ and MWIU group directly */                       \
-		DT_FOREACH_CHILD(DT_NODE_FROM_MIWU_MAP(inst),                  \
-			DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC)                   \
+		DT_FOREACH_CHILD(NPCX_DT_NODE_FROM_MIWU_MAP(inst),             \
+			NPCX_DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC)              \
 		return 0;                                                      \
 	}                                                                      \
 

--- a/drivers/pinmux/pinmux_npcx.c
+++ b/drivers/pinmux/pinmux_npcx.c
@@ -19,7 +19,7 @@ struct npcx_pinctrl_config {
 
 /* Default io list which default functionality are not IOs */
 #define DT_DRV_COMPAT nuvoton_npcx_pinctrl_def
-static const struct npcx_alt def_alts[] = DT_NPCX_ALT_ITEMS_LIST(0);
+static const struct npcx_alt def_alts[] = NPCX_DT_ALT_ITEMS_LIST(0);
 
 static const struct npcx_pinctrl_config npcx_pinctrl_cfg = {
 	.base = DT_REG_ADDR(DT_NODELABEL(scfg)),

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -197,11 +197,11 @@ static int pwm_npcx_init(const struct device *dev)
 
 #define NPCX_PWM_INIT(inst)                                                    \
 	static const struct npcx_alt pwm_alts##inst[] =			       \
-					DT_NPCX_ALT_ITEMS_LIST(inst);          \
+					NPCX_DT_ALT_ITEMS_LIST(inst);          \
 									       \
 	static const struct pwm_npcx_config pwm_npcx_cfg_##inst = {            \
 		.base = DT_INST_REG_ADDR(inst),                                \
-		.clk_cfg = DT_NPCX_CLK_CFG_ITEM(inst),                         \
+		.clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst),                         \
 		.alts_size = ARRAY_SIZE(pwm_alts##inst),                       \
 		.alts_list = pwm_alts##inst,                                   \
 	};                                                                     \

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -388,15 +388,15 @@ static int uart_npcx_init(const struct device *dev)
 	NPCX_UART_IRQ_CONFIG_FUNC_DECL(inst);	                               \
 									       \
 	static const struct npcx_alt uart_alts##inst[] =		       \
-					DT_NPCX_ALT_ITEMS_LIST(inst);	       \
+					NPCX_DT_ALT_ITEMS_LIST(inst);	       \
 									       \
 	static const struct uart_npcx_config uart_npcx_cfg_##inst = {	       \
 		.uconf = {                                                     \
 			.base = (uint8_t *)DT_INST_REG_ADDR(inst),             \
 			NPCX_UART_IRQ_CONFIG_FUNC_INIT(inst)                   \
 		},                                                             \
-		.clk_cfg = DT_NPCX_CLK_CFG_ITEM(inst),                         \
-		.uart_rx_wui = DT_NPCX_WUI_ITEM_BY_NAME(0, uart_rx),           \
+		.clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst),                         \
+		.uart_rx_wui = NPCX_DT_WUI_ITEM_BY_NAME(0, uart_rx),           \
 		.alts_size = ARRAY_SIZE(uart_alts##inst),                      \
 		.alts_list = uart_alts##inst,                                  \
 	};                                                                     \

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -474,12 +474,6 @@
 			interrupt-names = "kbc_ibf", "kbc_obe", "pmch_ibf",
 					  "pmch_obe", "p80_fifo";
 
-			/* Host serial port pinmux PIN75 86 36 33 42 C7 B3 B2 */
-			pinctrl-0 = <&altb_rxd_sl &altb_txd_sl
-						&altb_rts_sl &altb_cts_sl
-						&altb_ri_sl &altb_dtr_bout_sl
-						&altb_dcd_sl &altb_dsr_sl>;
-
 			/* WUI map for accessing host sub-modules */
 			host_acc_wui = <&wui_host_acc>;
 
@@ -490,6 +484,17 @@
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 6>,
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 7>;
 			label = "HOST_SUBS";
+		};
+
+		host_uart: io_host_uart {
+			compatible = "nuvoton,npcx-host-uart";
+			/* Host serial port pinmux PIN75 86 36 33 42 C7 B3 B2 */
+			pinctrl-0 = <&altb_rxd_sl &altb_txd_sl
+						&altb_rts_sl &altb_cts_sl
+						&altb_ri_sl &altb_dtr_bout_sl
+						&altb_dcd_sl &altb_dsr_sl>;
+			label = "HOST_UART_IO";
+			status = "disabled";
 		};
 	};
 };

--- a/dts/bindings/espi/nuvoton,npcx-host-sub.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-host-sub.yaml
@@ -16,11 +16,6 @@ properties:
         required: true
         description: configurations of device source clock controller
 
-    pinctrl-0:
-        type: phandles
-        required: true
-        description: configurations of host uart pinmux controllers
-
     host_acc_wui:
         type: phandle
         required: true

--- a/dts/bindings/espi/nuvoton,npcx-host-uart.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-host-uart.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX-Host UART IO node
+
+compatible: "nuvoton,npcx-host-uart"
+
+include: [base.yaml]
+
+properties:
+    pinctrl-0:
+        type: phandles
+        required: true
+        description: configurations of host uart pinmux controllers

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -20,12 +20,12 @@
  *	};
  *
  * Example usage: *
- *      const struct npcx_clk_cfg clk_cfg = DT_NPCX_CLK_CFG_ITEM(inst);
+ *      const struct npcx_clk_cfg clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return npcx_clk_cfg item.
  */
-#define DT_NPCX_CLK_CFG_ITEM(inst)                                             \
+#define NPCX_DT_CLK_CFG_ITEM(inst)                                             \
 	{                                                                      \
 	  .bus  = DT_PHA(DT_DRV_INST(inst), clocks, bus),                      \
 	  .ctrl = DT_PHA(DT_DRV_INST(inst), clocks, ctl),                      \
@@ -39,7 +39,7 @@
  * @param i index of clocks prop which type is 'phandle-array'
  * @return npcx_clk_cfg item from 'clocks' property at index 'i'
  */
-#define DT_NPCX_CLK_CFG_ITEM_BY_IDX(inst, i)                                   \
+#define NPCX_DT_CLK_CFG_ITEM_BY_IDX(inst, i)                                   \
 	{                                                                      \
 	  .bus  = DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), i, bus),            \
 	  .ctrl = DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(inst), i, ctl),            \
@@ -52,7 +52,7 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return length of 'clocks' property which type is 'phandle-array'
  */
-#define DT_NPCX_CLK_CFG_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, clocks)
+#define NPCX_DT_CLK_CFG_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, clocks)
 
 /**
  * @brief Macro function to construct npcx_clk_cfg item in UTIL_LISTIFY
@@ -62,8 +62,8 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return macro function to construct a npcx_clk_cfg structure.
  */
-#define DT_NPCX_CLK_CFG_ITEMS_FUNC(child, inst) \
-					DT_NPCX_CLK_CFG_ITEM_BY_IDX(inst, child)
+#define NPCX_DT_CLK_CFG_ITEMS_FUNC(child, inst) \
+					NPCX_DT_CLK_CFG_ITEM_BY_IDX(inst, child)
 
 /**
  * @brief Macro function to construct a list of npcx_clk_cfg items by
@@ -80,14 +80,14 @@
  *			...
  *		};
  * Example usage: *
- *	const struct npcx_clk_cfg clk_cfg[] = DT_NPCX_CLK_CFG_ITEMS_LIST(0);
+ *	const struct npcx_clk_cfg clk_cfg[] = NPCX_DT_CLK_CFG_ITEMS_LIST(0);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return an array of npcx_clk_cfg items.
  */
-#define DT_NPCX_CLK_CFG_ITEMS_LIST(inst) {             \
-	UTIL_LISTIFY(DT_NPCX_CLK_CFG_ITEMS_LEN(inst),  \
-		     DT_NPCX_CLK_CFG_ITEMS_FUNC,       \
+#define NPCX_DT_CLK_CFG_ITEMS_LIST(inst) {             \
+	UTIL_LISTIFY(NPCX_DT_CLK_CFG_ITEMS_LEN(inst),  \
+		     NPCX_DT_CLK_CFG_ITEMS_FUNC,       \
 		     inst)                             \
 	}
 
@@ -96,24 +96,24 @@
  *        'i'
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @param i index of pinctrl-0 prop which type is 'phandles'
+ * @param i index of 'pinctrl-0' prop which type is 'phandles'
  * @return phandle from 'pinctrl-0' prop at index 'i'
  */
-#define DT_PHANDLE_FROM_PINCTRL(inst, i) \
+#define NPCX_DT_PHANDLE_FROM_PINCTRL(inst, i) \
 	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_0, i)
 
 /**
  * @brief Construct a npcx_alt structure from 'pinctrl-0' property at index 'i'
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @param i index of pinctrl-0 prop which type is 'phandles'
+ * @param i index of 'pinctrl-0' prop which type is 'phandles'
  * @return npcx_alt item from 'pinctrl-0' property at index 'i'
  */
-#define DT_NPCX_ALT_ITEM_BY_IDX(inst, i)                                       \
+#define NPCX_DT_ALT_ITEM_BY_IDX(inst, i)                                       \
 	{                                                                      \
-	  .group    = DT_PHA(DT_PHANDLE_FROM_PINCTRL(inst, i), alts, group),   \
-	  .bit      = DT_PHA(DT_PHANDLE_FROM_PINCTRL(inst, i), alts, bit),     \
-	  .inverted = DT_PHA(DT_PHANDLE_FROM_PINCTRL(inst, i), alts, inv),     \
+	 .group = DT_PHA(NPCX_DT_PHANDLE_FROM_PINCTRL(inst, i), alts, group),  \
+	  .bit = DT_PHA(NPCX_DT_PHANDLE_FROM_PINCTRL(inst, i), alts, bit),     \
+	  .inverted = DT_PHA(NPCX_DT_PHANDLE_FROM_PINCTRL(inst, i), alts, inv),\
 	},
 
 /**
@@ -122,7 +122,7 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return length of 'pinctrl-0' property which type is 'phandles'
  */
-#define DT_NPCX_ALT_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, pinctrl_0)
+#define NPCX_DT_ALT_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, pinctrl_0)
 
 /**
  * @brief Macro function to construct npcx_alt item in UTIL_LISTIFY extension.
@@ -131,11 +131,11 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return macro function to construct a npcx_alt structure.
  */
-#define DT_NPCX_ALT_ITEMS_FUNC(child, inst) DT_NPCX_ALT_ITEM_BY_IDX(inst, child)
+#define NPCX_DT_ALT_ITEMS_FUNC(child, inst) NPCX_DT_ALT_ITEM_BY_IDX(inst, child)
 
 /**
- * @brief Macro function to construct a list of npcx_alt items by UTIL_LISTIFY
- * func
+ * @brief Macro function to construct a list of npcx_alt items with compatible
+ * defined in DT_DRV_COMPAT by UTIL_LISTIFY func
  *
  * Example devicetree fragment:
  *    / {
@@ -143,8 +143,107 @@
  *			pinctrl-0 = <&alta_uart1_sl1>;
  *			...
  *		};
+ *	};
  *
- *		host_sub: lpc@400c1000 {
+ * Example usage: *
+ *      const struct npcx_alt uart_alts[] = NPCX_DT_ALT_ITEMS_LIST(inst);
+ *
+ * @param inst instance number for compatible defined in DT_DRV_COMPAT.
+ * @return an array of npcx_alt items.
+ */
+#define NPCX_DT_ALT_ITEMS_LIST(inst) {             \
+	UTIL_LISTIFY(NPCX_DT_ALT_ITEMS_LEN(inst),  \
+		     NPCX_DT_ALT_ITEMS_FUNC,       \
+		     inst)                         \
+	}
+
+/**
+ * @brief Node identifier for an instance of a specific compatible
+ *
+ * @param compat specific compatible of devices in device-tree file
+ * @param inst instance number
+ * @return a node identifier for the node with "io_comp" compatible and
+ *         instance number "inst"
+ */
+#define NPCX_DT_COMP_INST(compat, inst) DT_INST(inst, compat)
+
+/**
+ * @brief Get a specific compatible instance's node identifier for a phandle in
+ * a property.
+ *
+ * @param compat specific compatible of devices in device-tree file
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name in "inst"
+ *             with type "phandle", "phandles" or "phandle-array"
+ * @param idx index into "prop"
+ * @return a node identifier for the phandle at index "idx" in "prop"
+ */
+#define NPCX_DT_COMP_INST_PHANDLE_BY_IDX(compat, inst, prop, idx) \
+	DT_PHANDLE_BY_IDX(NPCX_DT_COMP_INST(compat, inst), prop, idx)
+
+/**
+ * @brief Get phandle from 'pinctrl-0' prop which type is 'phandles' at index
+ *        'i' from io-pads device with specific compatible.
+ *
+ * @param io_comp compatible string in devicetree file for io-pads device
+ * @param inst instance number for compatible defined in io_comp.
+ * @param i index of 'pinctrl-0' prop which type is 'phandles'
+ * @return phandle from 'pinctrl-0' prop at index 'i'
+ */
+#define NPCX_DT_IO_PHANDLE_FROM_PINCTRL(io_comp, inst, i) \
+	NPCX_DT_COMP_INST_PHANDLE_BY_IDX(io_comp, inst, pinctrl_0, i)
+
+/**
+ * @brief Construct a npcx_alt structure from 'pinctrl-0' property at index 'i'
+ *        from io-pads device with specific compatible.
+ *
+ * @param io_comp compatible string in devicetree file for io-pads device
+ * @param inst instance number for compatible defined in io_comp.
+ * @param i index of 'pinctrl_0' prop which type is 'phandles'
+ * @return npcx_alt item from 'pinctrl-0' property at index 'i'
+ */
+#define NPCX_DT_IO_ALT_ITEM_BY_IDX(io_comp, inst, i)                           \
+	{                                                                      \
+	  .group = DT_PHA(NPCX_DT_IO_PHANDLE_FROM_PINCTRL(io_comp, inst, i),   \
+								alts, group),  \
+	  .bit = DT_PHA(NPCX_DT_IO_PHANDLE_FROM_PINCTRL(io_comp, inst, i),     \
+								alts, bit),    \
+	  .inverted = DT_PHA(NPCX_DT_IO_PHANDLE_FROM_PINCTRL(io_comp, inst, i),\
+								alts, inv),    \
+	},
+
+/**
+ * @brief Length of npcx_alt structures in 'pinctrl-0' property of specific
+ *        compatible io-pads device
+ *
+ * @param io_comp compatible string in devicetree file for io-pads device
+ * @param inst instance number for compatible defined in io_comp.
+ * @return length of 'pinctrl-0' property which type is 'phandles'
+ */
+#define NPCX_DT_IO_ALT_ITEMS_LEN(io_comp, inst) \
+			DT_PROP_LEN(NPCX_DT_COMP_INST(io_comp, inst), pinctrl_0)
+
+/**
+ * @brief Macro function to construct npcx_alt item with specific compatible
+ *        string in UTIL_LISTIFY extension.
+ *
+ * @param child child index in UTIL_LISTIFY extension.
+ * @param inst instance number for compatible defined in io_comp.
+ * @param io_comp compatible string in devicetree file for io-pads device
+ * @return macro function to construct a npcx_alt structure.
+ */
+#define NPCX_DT_IO_ALT_ITEMS_FUNC(child, inst, io_comp) \
+			NPCX_DT_IO_ALT_ITEM_BY_IDX(io_comp, inst, child)
+
+/**
+ * @brief Macro function to construct a list of npcx_alt items with specific
+ *        compatible string by UTIL_LISTIFY func
+ *
+ * Example devicetree fragment:
+ *    / {
+ *		host_uart: io_host_uart {
+ *			compatible = "nuvoton,npcx-host-uart";
+ *
  *			pinctrl-0 = <&altb_rxd_sl &altb_txd_sl
  *				   &altb_rts_sl &altb_cts_sl
  *				   &altb_ri_sl &altb_dtr_bout_sl
@@ -154,16 +253,16 @@
  *	};
  *
  * Example usage: *
- *      const struct npcx_alt uart_alts[] = DT_NPCX_ALT_ITEMS_LIST(inst);
- *      const struct npcx_alt host_uart_alts[] = DT_NPCX_ALT_ITEMS_LIST(inst);
- *
- * @param inst instance number for compatible defined in DT_DRV_COMPAT.
+ *      const struct npcx_alt host_uart_alts[] =
+ *                   NPCX_DT_IO_ALT_ITEMS_LIST(nuvoton_npcx_host_uart, 0);
+ * @param io_comp compatible string in devicetree file for io-pads device
+ * @param inst instance number for compatible defined in io_comp.
  * @return an array of npcx_alt items.
  */
-#define DT_NPCX_ALT_ITEMS_LIST(inst) {             \
-	UTIL_LISTIFY(DT_NPCX_ALT_ITEMS_LEN(inst),  \
-		     DT_NPCX_ALT_ITEMS_FUNC,       \
-		     inst)                         \
+#define NPCX_DT_IO_ALT_ITEMS_LIST(io_comp, inst) {             \
+	UTIL_LISTIFY(NPCX_DT_IO_ALT_ITEMS_LEN(io_comp, inst),  \
+		     NPCX_DT_IO_ALT_ITEMS_FUNC,                \
+		     inst, io_comp)                            \
 	}
 
 /**
@@ -173,7 +272,7 @@
  * @param name property 'name' which type is 'phandle' and contains wui info.
  * @return phandle from 'name' property.
  */
-#define DT_PHANDLE_FROM_WUI_NAME(inst, name) \
+#define NPCX_DT_PHANDLE_FROM_WUI_NAME(inst, name) \
 	DT_INST_PHANDLE(inst, name)
 
 /**
@@ -183,12 +282,14 @@
  * @param name property 'name'which type is 'phandle' and contains wui info.
  * @return npcx_wui item from 'name' property.
  */
-#define DT_NPCX_WUI_ITEM_BY_NAME(inst, name)				       \
+#define NPCX_DT_WUI_ITEM_BY_NAME(inst, name)				       \
 	{                                                                      \
-	  .table = DT_PROP(DT_PHANDLE(DT_PHANDLE_FROM_WUI_NAME(inst, name),    \
-					miwus), index),                        \
-	  .group = DT_PHA(DT_PHANDLE_FROM_WUI_NAME(inst, name), miwus, group), \
-	  .bit   = DT_PHA(DT_PHANDLE_FROM_WUI_NAME(inst, name), miwus, bit),   \
+	  .table = DT_PROP(DT_PHANDLE(NPCX_DT_PHANDLE_FROM_WUI_NAME(inst,      \
+					name), miwus), index),                 \
+	  .group = DT_PHA(NPCX_DT_PHANDLE_FROM_WUI_NAME(inst, name), miwus,    \
+					group),                                \
+	  .bit   = DT_PHA(NPCX_DT_PHANDLE_FROM_WUI_NAME(inst, name), miwus,    \
+					bit),                                  \
 	}
 
 /**
@@ -198,7 +299,7 @@
  * @param i index of 'wui_maps' prop which type is 'phandles'
  * @return phandle from 'wui_maps' prop at index 'i'
  */
-#define DT_PHANDLE_FROM_WUI_MAPS(inst, i) \
+#define NPCX_DT_PHANDLE_FROM_WUI_MAPS(inst, i) \
 	DT_INST_PHANDLE_BY_IDX(inst, wui_maps, i)
 
 /**
@@ -208,12 +309,13 @@
  * @param i index of 'wui_maps' prop which type is 'phandles'
  * @return npcx_wui item at index 'i'
  */
-#define DT_NPCX_WUI_ITEM_BY_IDX(inst, i) \
+#define NPCX_DT_WUI_ITEM_BY_IDX(inst, i) \
 	{                                                                      \
-	  .table = DT_PROP(DT_PHANDLE(DT_PHANDLE_FROM_WUI_MAPS(inst, i),       \
+	  .table = DT_PROP(DT_PHANDLE(NPCX_DT_PHANDLE_FROM_WUI_MAPS(inst, i),  \
 					miwus), index),                        \
-	  .group = DT_PHA(DT_PHANDLE_FROM_WUI_MAPS(inst, i), miwus, group),    \
-	  .bit   = DT_PHA(DT_PHANDLE_FROM_WUI_MAPS(inst, i), miwus, bit),      \
+	  .group = DT_PHA(NPCX_DT_PHANDLE_FROM_WUI_MAPS(inst, i), miwus,       \
+							group),                \
+	  .bit = DT_PHA(NPCX_DT_PHANDLE_FROM_WUI_MAPS(inst, i), miwus, bit),   \
 	},
 
 /**
@@ -222,7 +324,7 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return length of 'wui_maps' prop which type is 'phandles'
  */
-#define DT_NPCX_WUI_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, wui_maps)
+#define NPCX_DT_WUI_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, wui_maps)
 
 /**
  * @brief Macro function to construct a list of npcx_wui items by UTIL_LISTIFY
@@ -231,7 +333,7 @@
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return macro function to construct a npcx_wui structure.
  */
-#define DT_NPCX_WUI_ITEMS_FUNC(child, inst) DT_NPCX_WUI_ITEM_BY_IDX(inst, child)
+#define NPCX_DT_WUI_ITEMS_FUNC(child, inst) NPCX_DT_WUI_ITEM_BY_IDX(inst, child)
 
 /**
  * @brief Macro function to construct a list of npcx_wui items by UTIL_LISTIFY
@@ -252,15 +354,15 @@
  *	};
  *
  * Example usage: *
- *      const struct npcx_wui wui_map = DT_PHANDLE_FROM_WUI_NAME(inst, uart_rx);
- *      const struct npcx_wui wui_maps[] = DT_NPCX_WUI_ITEMS_LIST(inst);
+ * const struct npcx_wui wui_map = NPCX_DT_PHANDLE_FROM_WUI_NAME(inst, uart_rx);
+ * const struct npcx_wui wui_maps[] = NPCX_DT_WUI_ITEMS_LIST(inst);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
  * @return an array of npcx_wui items.
  */
-#define DT_NPCX_WUI_ITEMS_LIST(inst) {             \
-	UTIL_LISTIFY(DT_NPCX_WUI_ITEMS_LEN(inst),  \
-		     DT_NPCX_WUI_ITEMS_FUNC,       \
+#define NPCX_DT_WUI_ITEMS_LIST(inst) {             \
+	UTIL_LISTIFY(NPCX_DT_WUI_ITEMS_LEN(inst),  \
+		     NPCX_DT_WUI_ITEMS_FUNC,       \
 		     inst)                         \
 	}
 
@@ -270,8 +372,8 @@
  * @param i index of npcx miwu devices
  * @return node identifier with that path.
  */
-#define DT_NODE_FROM_MIWU_MAP(i)  DT_PATH(npcx7_miwus_int_map, \
-					  map_miwu##i##_groups)
+#define NPCX_DT_NODE_FROM_MIWU_MAP(i)  DT_PATH(npcx7_miwus_int_map, \
+						map_miwu##i##_groups)
 /**
  * @brief Get the index prop from parent MIWU device node.
  *
@@ -279,7 +381,7 @@
  * @return 'index' prop value of the node which compatible type is
  * "nuvoton,npcx-miwu".
  */
-#define DT_MIWU_IRQ_TABLE_IDX(child) \
+#define NPCX_DT_MIWU_IRQ_TABLE_IDX(child) \
 	DT_PROP(DT_PHANDLE(DT_PARENT(child), parent), index)
 
 /**
@@ -290,15 +392,18 @@
  * @return implementation to initialize interrupts of MIWU groups and enable
  * them.
  */
-#define DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC(child) \
-	{                                                                      \
+#define NPCX_DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC(child) \
+	NPCX_DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC_OBJ(child);
+
+#define NPCX_DT_MIWU_IRQ_CONNECT_IMPL_CHILD_FUNC_OBJ(child) \
+	do {                                                                   \
 		IRQ_CONNECT(DT_PROP(child, irq),		               \
 			DT_PROP(child, irq_prio),		               \
-			NPCX_MIWU_ISR_FUNC(DT_MIWU_IRQ_TABLE_IDX(child)),      \
+			NPCX_MIWU_ISR_FUNC(NPCX_DT_MIWU_IRQ_TABLE_IDX(child)), \
 			DT_PROP(child, group_mask),                            \
 			0);						       \
 		irq_enable(DT_PROP(child, irq));                               \
-	}
+	} while (0)
 
 /**
  * @brief Get a child node from path '/npcx7_espi_vws_map/name'.
@@ -306,7 +411,8 @@
  * @param name a path which name is /npcx7_espi_vws_map/'name'.
  * @return child node identifier with that path.
  */
-#define DT_NODE_FROM_VWTABLE(name) DT_CHILD(DT_PATH(npcx7_espi_vws_map), name)
+#define NPCX_DT_NODE_FROM_VWTABLE(name) DT_CHILD(DT_PATH(npcx7_espi_vws_map),  \
+									name)
 
 /**
  * @brief Get phandle from wui_map property of child node with that path.
@@ -314,7 +420,8 @@
  * @param name path which name is /npcx7_espi_vws_map/'name'.
  * @return phandle from "wui_map" prop of child node with that path.
  */
-#define DT_PHANDLE_VW_WUI(name) DT_PHANDLE(DT_NODE_FROM_VWTABLE(name), wui_map)
+#define NPCX_DT_PHANDLE_VW_WUI(name) DT_PHANDLE(NPCX_DT_NODE_FROM_VWTABLE(     \
+								name), wui_map)
 
 /**
  * @brief Construct a npcx_wui structure from wui_map property of a child node
@@ -323,11 +430,12 @@
  * @param name a path which name is /npcx7_espi_vws_map/'name'.
  * @return npcx_wui item with that path.
  */
-#define DT_NPCX_VW_WUI_ITEM(name)			                       \
+#define NPCX_DT_VW_WUI_ITEM(name)			                       \
 	{                                                                      \
-	  .table = DT_PROP(DT_PHANDLE(DT_PHANDLE_VW_WUI(name), miwus),  index),\
-	  .group = DT_PHA(DT_PHANDLE_VW_WUI(name), miwus, group),              \
-	  .bit   = DT_PHA(DT_PHANDLE_VW_WUI(name), miwus, bit),                \
+	  .table = DT_PROP(DT_PHANDLE(NPCX_DT_PHANDLE_VW_WUI(name), miwus),    \
+									index),\
+	  .group = DT_PHA(NPCX_DT_PHANDLE_VW_WUI(name), miwus, group),         \
+	  .bit = DT_PHA(NPCX_DT_PHANDLE_VW_WUI(name), miwus, bit),             \
 	}
 
 /**
@@ -338,12 +446,14 @@
  * @param name a path which name is /npcx7_espi_vws_map/'name'.
  * @return npcx_vw_in_config item with that path.
  */
-#define DT_NPCX_VW_IN_CONF(signal, name)                                       \
+#define NPCX_DT_VW_IN_CONF(signal, name)                                       \
 	{                                                                      \
 	  .sig = signal,                                                       \
-	  .reg_idx = DT_PROP_BY_IDX(DT_NODE_FROM_VWTABLE(name), vw_reg, 0),    \
-	  .bitmask = DT_PROP_BY_IDX(DT_NODE_FROM_VWTABLE(name), vw_reg, 1),    \
-	  .vw_wui  = DT_NPCX_VW_WUI_ITEM(name),                                \
+	  .reg_idx = DT_PROP_BY_IDX(NPCX_DT_NODE_FROM_VWTABLE(name), vw_reg,   \
+									0),    \
+	  .bitmask = DT_PROP_BY_IDX(NPCX_DT_NODE_FROM_VWTABLE(name), vw_reg,   \
+									1),    \
+	  .vw_wui  = NPCX_DT_VW_WUI_ITEM(name),                                \
 	}
 
 /**
@@ -354,11 +464,13 @@
  * @param name a path which name is /npcx7_espi_vws_map/'name'.
  * @return npcx_vw_in_config item with that path.
  */
-#define DT_NPCX_VW_OUT_CONF(signal, name)                                      \
+#define NPCX_DT_VW_OUT_CONF(signal, name)                                      \
 	{                                                                      \
 	  .sig = signal,                                                       \
-	  .reg_idx = DT_PROP_BY_IDX(DT_NODE_FROM_VWTABLE(name), vw_reg, 0),    \
-	  .bitmask = DT_PROP_BY_IDX(DT_NODE_FROM_VWTABLE(name), vw_reg, 1),    \
+	  .reg_idx = DT_PROP_BY_IDX(NPCX_DT_NODE_FROM_VWTABLE(name), vw_reg,   \
+									0),    \
+	  .bitmask = DT_PROP_BY_IDX(NPCX_DT_NODE_FROM_VWTABLE(name), vw_reg,   \
+									1),    \
 	}
 
 #endif /* _NUVOTON_NPCX_SOC_DT_H_ */

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -44,7 +44,7 @@ struct npcx_alt {
  *
  * Example usage:
  *    - Pinmux configuration list
- *         const struct npcx_alt alts_list[] = DT_NPCX_ALT_ITEMS_LIST(inst);
+ *         const struct npcx_alt alts_list[] = NPCX_DT_ALT_ITEMS_LIST(inst);
  *    - Change pinmux to UART:
  *         npcx_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 1);
  *    - Change pinmux back to GPIO64.65:


### PR DESCRIPTION
In order to prevent user turns on the pin-mux of devices has io-pads unexpectedly, this CL added a new device definition for host uart device. The pin-mux of host uart interface is enabled only if we set its status as "okay" in dts file of board folder.

The following npcx7 drivers will meet:
1. Default status property of all npcx devices with io-pads such as espi, pwm, uart, host uart and so on should be "disabled".
2. Switch pin-mux by changing status property to "okay" in dts file of board folder.
3. Add necessary definitions in prj file of board or the other application folder.

Signed-off-by: Mulin Chao <MLChao@nuvoton.com>