### PR TITLE
sanitycheck: Add device tree query function dt_chosen_enabled()

### DIFF
--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -240,6 +240,12 @@ def ast_expr(ast, env, edt):
             if node.status == "okay" and alias in node.aliases and node.matching_compat == compat:
                 return True
         return False
+    elif ast[0] == "dt_chosen_enabled":
+        name = ast[1][0]
+        if edt.chosen_node(name):
+            return True
+        return False
+
 
 mutex = threading.Lock()
 


### PR DESCRIPTION
To filter by device tree chosen property, add device tree query function
dt_chosen_enabled(name) that returns true if there is a device tree
chosen property for the given name.

Signed-off-by: Siddharth Chandrasekaran <siddharth@embedjournal.com>