### PR TITLE
Bluetooth: l2cap: Reduce size of disconnect pool

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -54,13 +54,15 @@
 #define L2CAP_DISC_TIMEOUT	K_SECONDS(2)
 #define L2CAP_RTX_TIMEOUT	K_SECONDS(2)
 
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 /* Dedicated pool for disconnect buffers so they are guaranteed to be send
  * even in case of data congestion due to flooding.
  */
 NET_BUF_POOL_FIXED_DEFINE(disc_pool, 1,
-			  BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU), NULL);
+			  BT_L2CAP_BUF_SIZE(
+				sizeof(struct bt_l2cap_disconn_req)),
+			  NULL);
 
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 #define L2CAP_MAX_LE_MPS	CONFIG_BT_L2CAP_RX_MTU
 /* For now use MPS - SDU length to disable segmentation */
 #define L2CAP_MAX_LE_MTU	(L2CAP_MAX_LE_MPS - 2)
@@ -401,10 +403,11 @@ static struct net_buf *l2cap_create_le_sig_pdu(struct net_buf *buf,
 	struct bt_l2cap_sig_hdr *hdr;
 	struct net_buf_pool *pool = NULL;
 
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	if (code == BT_L2CAP_DISCONN_REQ) {
 		pool = &disc_pool;
 	}
-
+#endif
 	/* Don't wait more than the minimum RTX timeout of 2 seconds */
 	buf = bt_l2cap_create_pdu_timeout(pool, 0, L2CAP_RTX_TIMEOUT);
 	if (!buf) {


### PR DESCRIPTION
Reduce the size of the disconnect pool required the full MTU
for a disconnect request.
Also completely remove the pool when not needed.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>