### PR TITLE
userspace: Fix thread index type in z_thread_perms_all_clear()

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -508,7 +508,7 @@ void z_thread_perms_all_clear(struct k_thread *thread)
 {
 	uintptr_t index = thread_index_get(thread);
 
-	if (index != -1) {
+	if ((int)index != -1) {
 		z_object_wordlist_foreach(clear_perms_cb, (void *)index);
 	}
 }


### PR DESCRIPTION
The type for the thread index returned by thread_index_get() must be
casted to int when comparing with (-1). Directly using uintptr_t is
breaking the ARMv8 implementation where where the check (index != -1) is
verified also when no thread index is returned.