### PR TITLE
boards: share the leftover mcuboot scratch flash between image 0 and image 1 for nRF devices

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -203,13 +203,9 @@
 		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		storage_partition: partition@f0000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f0000 0x00010000>;
 		};
 	};
 };

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -146,15 +146,11 @@
 		};
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00008000 0x1a000>;
+			reg = <0x00008000 0x1b000>;
 		};
-		slot1_partition: partition@22000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x00022000 0x1a000>;
-		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x0003c000 0x2000>;
+			reg = <0x00023000 0x1b000>;
 		};
 		storage_partition: partition@3e000 {
 			label = "storage";

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -88,15 +88,11 @@
 		};
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00008000 0x1a000>;
+			reg = <0x00008000 0x1b000>;
 		};
-		slot1_partition: partition@22000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x00022000 0x1a000>;
-		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x0003c000 0x2000>;
+			reg = <0x00023000 0x1b000>;
 		};
 		storage_partition: partition@3e000 {
 			label = "storage";

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -137,15 +137,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -200,23 +200,19 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0xC000>;
+			reg = <0x00000000 0xc000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xA000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";
-			reg = <0x0007A000 0x00006000>;
+			reg = <0x0007a000 0x00006000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -143,21 +143,12 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -169,21 +169,12 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -141,21 +141,12 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -148,19 +148,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0xd000>;
+			reg = <0x0000C000 0xe000>;
 		};
-		slot1_partition: partition@19000 {
+		slot1_partition: partition@1a000 {
 			label = "image-1";
-			reg = <0x00019000 0xd000>;
+			reg = <0x0001a000 0xe000>;
 		};
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x00026000 0x3000>;
-		};
-		storage_partition: partition@29000 {
+		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00029000 0x00007000>;
+			reg = <0x00028000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -251,21 +251,12 @@ arduino_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
@@ -22,15 +22,11 @@
 
 		slot0_partition: partition@12000 {
 			label = "image-0";
-			reg = <0x00012000 0x000069000>;
+			reg = <0x00012000 0x00075000>;
 		};
-		slot1_partition: partition@7b000 {
+		slot1_partition: partition@87000 {
 			label = "image-1";
-			reg = <0x0007b000 0x000069000>;
-		};
-		scratch_partition: partition@e4000 {
-			label = "image-scratch";
-			reg = <0x000e4000 0x00018000>;
+			reg = <0x00087000 0x00075000>;
 		};
 		storage_partition: partition@fc000 {
 			label = "storage";

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
@@ -23,19 +23,15 @@
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00005e000>;
+			reg = <0x00010000 0x000066000>;
 		};
-		slot1_partition: partition@6e000 {
+		slot1_partition: partition@76000 {
 			label = "image-1";
-			reg = <0x006e000 0x00005e000>;
+			reg = <0x0076000 0x000066000>;
 		};
-		storage_partition: partition@cc000 {
+		storage_partition: partition@dc000 {
 			label = "storage";
-			reg = <0x000cc000 0x00004000>;
-		};
-		scratch_partition: partition@d0000 {
-			label = "image-scratch";
-			reg = <0x000d0000 0x00010000>;
+			reg = <0x000dc000 0x00004000>;
 		};
 
 		/* Nordic nRF5 bootloader <0xe0000 0x1c000>

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -101,15 +101,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -69,19 +69,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x8000>;
+			reg = <0x00000000 0xc000>;
 		};
-		slot0_partition: partition@8000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x00008000 0x34000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3c000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003c000 0x34000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 
 		/*

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -75,15 +75,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000c000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003e000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -127,19 +127,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0xd000>;
+			reg = <0x0000C000 0xe000>;
 		};
-		slot1_partition: partition@19000 {
+		slot1_partition: partition@1a000 {
 			label = "image-1";
-			reg = <0x00019000 0xd000>;
+			reg = <0x0001a000 0xe000>;
 		};
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x00026000 0x3000>;
-		};
-		storage_partition: partition@29000 {
+		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00029000 0x00007000>;
+			reg = <0x00028000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -206,15 +206,11 @@ arduino_spi: &spi2 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -139,13 +139,9 @@
 		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		storage_partition: partition@f0000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f0000 0x00010000>;
 		};
 	};
 };

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
@@ -121,19 +121,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x12000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@1e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0001E000 0x12000>;
+			reg = <0x00043000 0x37000>;
 		};
-		scratch_partition: partition@30000 {
-			label = "image-scratch";
-			reg = <0x00030000 0xa000>;
-		};
-		storage_partition: partition@3a000 {
+		storage_partition: partition@7a000 {
 			label = "storage";
-			reg = <0x0003a000 0x6000>;
+			reg = <0x0007a000 0x00006000>;
 		};
 	};
 };

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -61,21 +61,12 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -165,13 +165,9 @@
 		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		storage_partition: partition@f0000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f0000 0x00010000>;
 		};
 	};
 };

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -196,15 +196,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 
 		/*

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -51,25 +51,16 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
-		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
 
 		/*
 		 * Storage partition will be used by FCB/LittleFS/NVS

--- a/samples/subsys/settings/boards/native_posix.overlay
+++ b/samples/subsys/settings/boards/native_posix.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
@@ -12,19 +12,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000E000>;
+			reg = <0x00000000 0x0000E000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000E000 0x000066000>;
+			reg = <0x0000E000 0x00075000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@83000 {
 			label = "image-1";
-			reg = <0x00074000 0x000066000>;
-		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
+			reg = <0x00083000 0x00075000>;
 		};
 	};
 };

--- a/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
 &flash0 {
 
 	partitions {

--- a/tests/subsys/settings/fcb/raw/native_posix.overlay
+++ b/tests/subsys/settings/fcb/raw/native_posix.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/fcb/raw/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/fcb/raw/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/fcb/raw/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/fcb/raw/nrf52dk_nrf52832.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/fcb/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/functional/fcb/boards/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/fcb/boards/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/functional/fcb/boards/nrf52dk_nrf52832.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/file/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/functional/file/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/file/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/functional/file/nrf52dk_nrf52832.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 


### PR DESCRIPTION
Newest mcuboot uses move swap instead of scratch
for nRF devices

Share the leftover scratch flash between image 0 and image 1, or the storage partition.
For trustzone enabled devices, give the non secure
partitions the extra space.

Adjusted test overlays to above changes.

This PR supersedes #22228 as due the push to its branch during it was closed, GH GUI disallow to reopen it.