### PR TITLE
bluetooth: make beacon samples more usable

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -612,12 +612,20 @@ struct bt_le_per_adv_param {
 			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, \
 			_peer)
 
+/** Non-connectable advertising with private address */
 #define BT_LE_ADV_NCONN BT_LE_ADV_PARAM(0, BT_GAP_ADV_FAST_INT_MIN_2, \
 					BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
+/** Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_NAME */
 #define BT_LE_ADV_NCONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_NAME, \
 					     BT_GAP_ADV_FAST_INT_MIN_2, \
 					     BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+
+/** Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
+#define BT_LE_ADV_NCONN_IDENTITY BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_IDENTITY, \
+						 BT_GAP_ADV_FAST_INT_MIN_2, \
+						 BT_GAP_ADV_FAST_INT_MAX_2, \
+						 NULL)
 
 /**
  * Helper to declare periodic advertising parameters inline

--- a/samples/bluetooth/beacon/src/main.c
+++ b/samples/bluetooth/beacon/src/main.c
@@ -42,6 +42,10 @@ static const struct bt_data sd[] = {
 
 static void bt_ready(int err)
 {
+	char addr_s[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t addr = {0};
+	size_t count = 1;
+
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
@@ -50,14 +54,24 @@ static void bt_ready(int err)
 	printk("Bluetooth initialized\n");
 
 	/* Start advertising */
-	err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad),
+	err = bt_le_adv_start(BT_LE_ADV_NCONN_IDENTITY, ad, ARRAY_SIZE(ad),
 			      sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;
 	}
 
-	printk("Beacon started\n");
+
+	/* For connectable advertising you would use
+	 * bt_le_oob_get_local().  For non-connectable non-identity
+	 * advertising an non-resolvable private address is used;
+	 * there is no API to retrieve that.
+	 */
+
+	bt_id_get(&addr, &count);
+	bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
+
+	printk("Beacon started, advertising as %s\n", addr_s);
 }
 
 void main(void)


### PR DESCRIPTION
As noted on slack the beacon examples currently appear to transmit using an NRPA that can't be retrieved, which makes confirming that the beacons work difficult.  Add an advertising configuration that uses the identity address, which is appropriate for sensor beacons, and display the address that will be used on the console output.