### PR TITLE
drivers: ethernet: eth_gecko: Fetch MAC address from device info

### DIFF
--- a/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
+++ b/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
@@ -114,8 +114,6 @@
 };
 
 &eth0 {
-	local-mac-address = [02 01 02 03 04 05];
-
 	/* PHY address = 0 */
 	phy-address = <0>;
 

--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
@@ -134,8 +134,6 @@
 };
 
 &eth0 {
-	/* local-mac-address = <>;*/
-
 	/* PHY address = 0 */
 	phy-address = <0>;
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -490,6 +490,13 @@ static void generate_mac(uint8_t mac_addr[6])
 {
 #if DT_INST_PROP(0, zephyr_random_mac_address)
 	gen_random_mac(mac_addr, SILABS_OUI_B0, SILABS_OUI_B1, SILABS_OUI_B2);
+#elif !NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
+	mac_addr[0] = DEVINFO->EUI48H >> 8;
+	mac_addr[1] = DEVINFO->EUI48H >> 0;
+	mac_addr[2] = DEVINFO->EUI48L >> 24;
+	mac_addr[3] = DEVINFO->EUI48L >> 16;
+	mac_addr[4] = DEVINFO->EUI48L >> 8;
+	mac_addr[5] = DEVINFO->EUI48L >> 0;
 #endif
 }
 


### PR DESCRIPTION
If neither a random address nor a specific local address is specified in the device tree, use the MAC address encoded on the device

Tested on WLSTK6121A and STK3701A. This change makes STK3701A work out-of-box -- the .dts does not specify a local-mac-address, so any network sample would previously use a MAC address of 00:00:00:00:00:00.
