### PR TITLE
drivers/serial: stm32f1: REMAP_FULL is not a possible remap value

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -696,7 +696,7 @@ static int uart_stm32_init(const struct device *dev)
 		switch ((uint32_t)UART_STRUCT(dev)) {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usart1), okay)
 		case DT_REG_ADDR(DT_NODELABEL(usart1)):
-			if (remap == REMAP_FULL) {
+			if (remap == REMAP_1) {
 				LL_GPIO_AF_EnableRemap_USART1();
 			} else {
 				LL_GPIO_AF_DisableRemap_USART1();
@@ -705,7 +705,7 @@ static int uart_stm32_init(const struct device *dev)
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usart2), okay)
 		case DT_REG_ADDR(DT_NODELABEL(usart2)):
-			if (remap == REMAP_FULL) {
+			if (remap == REMAP_1) {
 				LL_GPIO_AF_EnableRemap_USART2();
 			} else {
 				LL_GPIO_AF_DisableRemap_USART2();
@@ -714,7 +714,7 @@ static int uart_stm32_init(const struct device *dev)
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usart3), okay)
 		case DT_REG_ADDR(DT_NODELABEL(usart3)):
-			if (remap == REMAP_FULL) {
+			if (remap == REMAP_2) {
 				LL_GPIO_AF_EnableRemap_USART3();
 			} else if (remap == REMAP_1) {
 				LL_GPIO_AF_RemapPartial_USART3();


### PR DESCRIPTION
'remap' value can never be REMAP_FULL for usart.
Fix this value depending on the usart instance.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>