### PR TITLE
include/posix: fix extern "C" placement

### DIFF
--- a/include/posix/pthread_key.h
+++ b/include/posix/pthread_key.h
@@ -43,10 +43,10 @@ typedef struct pthread_key_data {
 	pthread_thread_data thread_data;
 } pthread_key_data;
 
-#endif /* CONFIG_PTHREAD_IPC */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* CONFIG_PTHREAD_IPC */
 
 #endif /* ZEPHYR_INCLUDE_POSIX_PTHREAD_KEY_H_*/


### PR DESCRIPTION
both parts of extern "C" should be placed inside #ifdef CONFIG_PTHREAD_IPC