### PR TITLE
Bluetooth: host: Fix peripheral conn param update ignored

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -396,6 +396,10 @@ int bt_conn_get_remote_info(struct bt_conn *conn,
 
 /** @brief Update the connection parameters.
  *
+ *  If the local device is in the peripheral role then updating the connection
+ *  parameters will be delayed. This delay can be configured by through the
+ *  @option{CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT} option.
+ *
  *  @param conn Connection object.
  *  @param param Updated connection parameters.
  *

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -530,9 +530,15 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 
 	help
 	  The value is a timeout used by peripheral device to wait until it
-	  starts the connection parameters update procedure to change default
-	  connection parameters. The default value is set to 5s, to comply
-	  with BT protocol specification: Core 4.2 Vol 3, Part C, 9.3.12.2
+	  starts the first connection parameters update procedure after a
+	  connection has been established.
+	  The connection parameters requested will be the parameters set by the
+	  application, or the peripheral preferred connection parameters if
+	  configured.
+	  The default value is set to 5 seconds, to comply with the Bluetooth
+	  Core specification: Core 4.2 Vol 3, Part C, 9.3.12.2:
+	  "The Peripheral device should not perform a Connection Parameter
+	  Update procedure within 5 seconds after establishing a connection."
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -526,7 +526,7 @@ config BT_CREATE_CONN_TIMEOUT
 config BT_CONN_PARAM_UPDATE_TIMEOUT
 	int "Peripheral connection parameter update timeout in milliseconds"
 	default 5000
-	range 1 65535
+	range 0 65535
 
 	help
 	  The value is a timeout used by peripheral device to wait until it

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -376,27 +376,23 @@ static void deferred_work(struct k_work *work)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS)) {
-		/* if application set own params use those, otherwise
-		 * use defaults.
-		 */
-		if (atomic_test_and_clear_bit(conn->flags,
-					      BT_CONN_SLAVE_PARAM_SET)) {
-			param = BT_LE_CONN_PARAM(conn->le.interval_min,
-						conn->le.interval_max,
-						conn->le.pending_latency,
-						conn->le.pending_timeout);
-			send_conn_le_param_update(conn, param);
-		} else {
+	/* if application set own params use those, otherwise use defaults. */
+	if (atomic_test_and_clear_bit(conn->flags,
+				      BT_CONN_SLAVE_PARAM_SET)) {
+		param = BT_LE_CONN_PARAM(conn->le.interval_min,
+					 conn->le.interval_max,
+					 conn->le.pending_latency,
+					 conn->le.pending_timeout);
+		send_conn_le_param_update(conn, param);
+	} else if (IS_ENABLED(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS)) {
 #if defined(CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS)
-			param = BT_LE_CONN_PARAM(
-					CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
-					CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
-					CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY,
-					CONFIG_BT_PERIPHERAL_PREF_TIMEOUT);
-			send_conn_le_param_update(conn, param);
+		param = BT_LE_CONN_PARAM(
+				CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
+				CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
+				CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY,
+				CONFIG_BT_PERIPHERAL_PREF_TIMEOUT);
+		send_conn_le_param_update(conn, param);
 #endif
-		}
 	}
 
 	atomic_set_bit(conn->flags, BT_CONN_SLAVE_PARAM_UPDATE);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -344,9 +344,9 @@ static void tx_complete_work(struct k_work *work)
 	tx_notify(conn);
 }
 
-static void conn_update_timeout(struct k_work *work)
+static void deferred_work(struct k_work *work)
 {
-	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn, update_work);
+	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn, deferred_work);
 	const struct bt_le_conn_param *param;
 
 	BT_DBG("conn %p", conn);
@@ -434,7 +434,7 @@ static struct bt_conn *acl_conn_new(void)
 		return conn;
 	}
 
-	k_delayed_work_init(&conn->update_work, conn_update_timeout);
+	k_delayed_work_init(&conn->deferred_work, deferred_work);
 
 	k_work_init(&conn->tx_complete_work, tx_complete_work);
 
@@ -1288,7 +1288,7 @@ static void conn_cleanup(struct bt_conn *conn)
 
 	bt_conn_reset_rx_state(conn);
 
-	k_delayed_work_submit(&conn->update_work, K_NO_WAIT);
+	k_delayed_work_submit(&conn->deferred_work, K_NO_WAIT);
 }
 
 static int conn_prepare_events(struct bt_conn *conn,
@@ -1525,7 +1525,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 	case BT_CONN_CONNECT:
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
-			k_delayed_work_cancel(&conn->update_work);
+			k_delayed_work_cancel(&conn->deferred_work);
 		}
 		break;
 	default:
@@ -1555,7 +1555,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 		    conn->role == BT_CONN_ROLE_SLAVE) {
-			k_delayed_work_submit(&conn->update_work,
+			k_delayed_work_submit(&conn->deferred_work,
 					      CONN_UPDATE_TIMEOUT);
 		}
 
@@ -1589,7 +1589,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			/* Cancel Connection Update if it is pending */
 			if (conn->type == BT_CONN_TYPE_LE) {
-				k_delayed_work_cancel(&conn->update_work);
+				k_delayed_work_cancel(&conn->deferred_work);
 			}
 
 			atomic_set_bit(conn->flags, BT_CONN_CLEANUP);
@@ -1666,7 +1666,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		 */
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
-			k_delayed_work_submit(&conn->update_work,
+			k_delayed_work_submit(
+				&conn->deferred_work,
 				K_MSEC(10 * bt_dev.create_param.timeout));
 		}
 
@@ -2065,7 +2066,7 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 #endif /* CONFIG_BT_BREDR */
 
 		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-			k_delayed_work_cancel(&conn->update_work);
+			k_delayed_work_cancel(&conn->deferred_work);
 			return bt_le_create_conn_cancel();
 		}
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -160,8 +160,12 @@ struct bt_conn {
 
 	atomic_t		ref;
 
-	/* Delayed work for connection update and other deferred tasks */
-	struct k_delayed_work	update_work;
+	/* Delayed work deferred tasks:
+	 * - Peripheral delayed connection update.
+	 * - Initiator connect create cancel.
+	 * - Connection cleanup.
+	 */
+	struct k_delayed_work	deferred_work;
 
 	union {
 		struct bt_conn_le	le;


### PR DESCRIPTION
Fix application conn param update submitted before the timeout of
CONFIG_BT_CONN_PARAM_UPDATE has expired being ignored when
CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n.

Document the behavior of the bt_conn_le_conn_update API when the
local device is the peripheral role.

Fixes: #28870