### PR TITLE
include/posix: restrict is no C++ keyword

### DIFF
--- a/include/posix/semaphore.h
+++ b/include/posix/semaphore.h
@@ -13,13 +13,27 @@
 extern "C" {
 #endif
 
+#ifdef __cplusplus
+#  if defined(__GNUC__) || defined(__clang__)
+#    define RESTRICT __restrict__
+#  elif defined(_MSC_VER)
+#    define RESTRICT  __restrict
+#  endif
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+#  define RESTRICT restrict
+#else
+#  define RESTRICT   /* disable restrict */
+#endif
+
 int sem_destroy(sem_t *semaphore);
-int sem_getvalue(sem_t *restrict semaphore, int *restrict value);
+int sem_getvalue(sem_t *RESTRICT semaphore, int *RESTRICT value);
 int sem_init(sem_t *semaphore, int pshared, unsigned int value);
 int sem_post(sem_t *semaphore);
-int sem_timedwait(sem_t *restrict semaphore, struct timespec *restrict abstime);
+int sem_timedwait(sem_t *RESTRICT semaphore, struct timespec *RESTRICT abstime);
 int sem_trywait(sem_t *semaphore);
 int sem_wait(sem_t *semaphore);
+
+#undef RESTRICT
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Many compilers provide a similar feature as extensions.
Therefore, the restrict keyword is replaced by these extensions
in C++.