### PR TITLE
lorawan,lora: fix C++ compilation/linking errors

### DIFF
--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -103,7 +103,8 @@ struct lora_driver_api {
 static inline int lora_config(const struct device *dev,
 			      struct lora_modem_config *config)
 {
-	const struct lora_driver_api *api = dev->api;
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
 
 	return api->config(dev, config);
 }
@@ -121,7 +122,8 @@ static inline int lora_config(const struct device *dev,
 static inline int lora_send(const struct device *dev,
 			    uint8_t *data, uint32_t data_len)
 {
-	const struct lora_driver_api *api = dev->api;
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
 
 	return api->send(dev, data, data_len);
 }
@@ -146,7 +148,8 @@ static inline int lora_recv(const struct device *dev, uint8_t *data,
 			    uint8_t size,
 			    k_timeout_t timeout, int16_t *rssi, int8_t *snr)
 {
-	const struct lora_driver_api *api = dev->api;
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
 
 	return api->recv(dev, data, size, timeout, rssi, snr);
 }
@@ -166,7 +169,8 @@ static inline int lora_recv(const struct device *dev, uint8_t *data,
 static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
 			       int8_t tx_power, uint16_t duration)
 {
-	const struct lora_driver_api *api = dev->api;
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
 
 	if (!api->test_cw) {
 		return -ENOTSUP;

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -14,6 +14,10 @@
 
 #include <device.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief LoRaWAN class types.
  */
@@ -182,5 +186,9 @@ void lorawan_enable_adr(bool enable);
  * @return 0 if successful, negative errno code if failure
  */
 int lorawan_set_datarate(enum lorawan_datarate dr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* ZEPHYR_INCLUDE_LORAWAN_LORAWAN_H_ */


### PR DESCRIPTION
The usual suspects: missing `extern` and assignments from `void *`.