### PR TITLE
arch/x86: Make EFI copies bytewise

### DIFF
--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -72,24 +72,24 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 	printf("*** Zephyr EFI Loader ***\n");
 
 	for (int i = 0; i < sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0]); i++) {
-		int nwords = zefi_zsegs[i].sz;
-		uint32_t *dst = (uint32_t *)zefi_zsegs[i].addr;
+		int bytes = zefi_zsegs[i].sz;
+		uint8_t *dst = (uint8_t *)zefi_zsegs[i].addr;
 
-		printf("Zeroing %d bytes of memory at %p\n", 4 * nwords, dst);
-		for (int j = 0; j < nwords; j++) {
+		printf("Zeroing %d bytes of memory at %p\n", bytes, dst);
+		for (int j = 0; j < bytes; j++) {
 			dst[j] = 0;
 		}
 	}
 
 	for (int i = 0; i < sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0]); i++) {
-		int nwords = zefi_dsegs[i].sz;
+		int bytes = zefi_dsegs[i].sz;
 		int off = zefi_dsegs[i].off;
-		uint32_t *dst = (uint32_t *)zefi_dsegs[i].addr;
-		uint32_t *src = &((uint32_t *)EXT_DATA_START)[off];
+		uint8_t *dst = (uint8_t *)zefi_dsegs[i].addr;
+		uint8_t *src = &((uint8_t *)EXT_DATA_START)[off];
 
 		printf("Copying %d data bytes to %p from image offset %d\n",
-		       4 * nwords, dst, zefi_dsegs[i].off);
-		for (int j = 0; j < nwords; j++) {
+		       bytes, dst, zefi_dsegs[i].off);
+		for (int j = 0; j < bytes; j++) {
 			dst[j] = src[j];
 		}
 	}

--- a/arch/x86/zefi/zefi.py
+++ b/arch/x86/zefi/zefi.py
@@ -49,24 +49,20 @@ def build_elf(elf_file):
             continue
 
         assert h.p_memsz >= h.p_filesz
-        assert (h.p_vaddr % 8) == 0
-        assert (h.p_filesz % 4) == 0
         assert len(seg.data()) == h.p_filesz
 
         if h.p_filesz > 0:
             sd = seg.data()
             verbose("%d bytes of data at 0x%x, data offset %d"
                 % (len(sd), h.p_vaddr, len(data_blob)))
-            data_segs.append((h.p_vaddr, len(sd) / 4, len(data_blob) / 4))
+            data_segs.append((h.p_vaddr, len(sd), len(data_blob)))
             data_blob = data_blob + sd
 
         if h.p_memsz > h.p_filesz:
             bytesz = h.p_memsz - h.p_filesz
-            if bytesz % 4:
-                bytesz += 4 - (bytesz % 4)
             addr = h.p_vaddr + h.p_filesz
             verbose("%d bytes of zero-fill at 0x%x" % (bytesz, addr))
-            zero_segs.append((addr, bytesz / 4))
+            zero_segs.append((addr, bytesz))
 
     verbose(f"{len(data_blob)} bytes of data to include in image")
 


### PR DESCRIPTION
Originally the EFI boot code was written to assume that all sections
in the ELF file were 8-byte aligned and sized (because I thought this
was part of some platform spec somewhere).  This turned out to be
wrong in practice (at least for section sizes), so the requirement was
reduced to 4 bytes.  But now we have a section being generated
somewhere that turns out to violate even that.

There's no particular value in doing those copies in big chunks.
There's at best a mild performance benefit, but if we really cared
we'd be using a more complicated memcpy() implementation anyway.
Replace the loop in the C code with a bytewise copy, change the size
field in the generated header to store bytes, and remove the
assertions (which were the failuers actually being seen in practice)
in the script that were there to detect this misalignment.

Fixes #29095

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>