### PR TITLE
net: tcp2: Socket was accepted too early

### DIFF
--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -183,7 +183,10 @@ struct tcp { /* TCP connection */
 	struct net_if *iface;
 	void *recv_user_data;
 	sys_slist_t send_queue;
-	net_tcp_accept_cb_t accept_cb;
+	union {
+		net_tcp_accept_cb_t accept_cb;
+		struct tcp *accepted_conn;
+	};
 	struct k_mutex lock;
 	struct k_sem connect_sem; /* semaphore for blocking connect */
 	struct tcp_options recv_options;


### PR DESCRIPTION
The TCP2 was calling accept callback before actually finalizing
the connection attempt.

Fixes #29164

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>