### PR TITLE
lib/os: fix ll format specifier in z_prf

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -112,13 +112,6 @@ config MINIMAL_LIBC_REALLOCARRAY
 	  Enable the minimal libc's trivial implementation of reallocarray, which
 	  forwards to realloc.
 
-config MINIMAL_LIBC_LL_PRINTF
-	bool "Build with minimal libc long long printf" if !64BIT
-	default y if 64BIT
-	help
-	  Build with long long printf enabled. This will increase the size of
-	  the image.
-
 endif # MINIMAL_LIBC
 
 config STDOUT_CONSOLE

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -72,4 +72,12 @@ config PRINTK_SYNC
 	  interleaving with concurrent usage from another CPU or an
 	  preempting interrupt.
 
+config LIB_OS_PRF_LL_SUPPORT
+	bool "Enable z_prf long long printf" if !64BIT
+	default y if 64BIT
+	help
+	  Build the z_prf utility function with long long format support
+	  enabled.  This will increase code size on systems with 32-bit long
+	  integers.
+
 endmenu

--- a/lib/os/prf.c
+++ b/lib/os/prf.c
@@ -20,7 +20,7 @@
 #define EOF  -1
 #endif
 
-#ifdef CONFIG_MINIMAL_LIBC_LL_PRINTF
+#ifdef CONFIG_LIB_OS_PRF_LL_SUPPORT
 #define VALTYPE long long
 #else
 #define VALTYPE long
@@ -531,7 +531,7 @@ int z_prf(int (*func)(), void *dest, const char *format, va_list vargs)
 			if (strchr("hlz", c) != NULL) {
 				i = c;
 				c = *format++;
-				if (IS_ENABLED(CONFIG_MINIMAL_LIBC_LL_PRINTF) &&
+				if (IS_ENABLED(CONFIG_LIB_OS_PRF_LL_SUPPORT) &&
 				    i == 'l' && c == 'l') {
 					i = 'L';
 					c = *format++;
@@ -558,7 +558,7 @@ int z_prf(int (*func)(), void *dest, const char *format, va_list vargs)
 				case 'l':
 					val = va_arg(vargs, long);
 					break;
-#ifdef CONFIG_MINIMAL_LIBC_LL_PRINTF
+#ifdef CONFIG_LIB_OS_PRF_LL_SUPPORT
 				case 'L':
 					val = va_arg(vargs, long long);
 					break;
@@ -622,7 +622,7 @@ int z_prf(int (*func)(), void *dest, const char *format, va_list vargs)
 				case 'l':
 					*va_arg(vargs, long *) = count;
 					break;
-#ifdef CONFIG_MINIMAL_LIBC_LL_PRINTF
+#ifdef CONFIG_LIB_OS_PRF_LL_SUPPORT
 				case 'L':
 					*va_arg(vargs, long long *) = count;
 					break;
@@ -664,7 +664,7 @@ int z_prf(int (*func)(), void *dest, const char *format, va_list vargs)
 				case 'l':
 					val = va_arg(vargs, unsigned long);
 					break;
-#ifdef CONFIG_MINIMAL_LIBC_LL_PRINTF
+#ifdef CONFIG_LIB_OS_PRF_LL_SUPPORT
 				case 'L':
 					val = va_arg(vargs, unsigned long long);
 					break;

--- a/tests/unit/prf/CMakeLists.txt
+++ b/tests/unit/prf/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+project(lib_os_prf)
+set(SOURCES main.c)
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/prf/main.c
+++ b/tests/unit/prf/main.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <limits.h>
+#include <stdarg.h>
+#include "../../../lib/os/prf.c"
+
+#if __WORDSIZE == 64
+#define M64_MODE 1
+#endif
+
+static char buf[128];
+static char *bp;
+
+static inline void reset_out(void)
+{
+	bp = buf;
+	*bp = 0;
+}
+
+static int out(int c, void *dest)
+{
+	int rv = EOF;
+
+	ARG_UNUSED(dest);
+	if (bp < (buf + ARRAY_SIZE(buf))) {
+		*bp++ = (char)(unsigned char)c;
+		rv = (int)(unsigned char)c;
+	}
+	return rv;
+}
+
+static int prf(const char *format, ...)
+{
+	va_list ap;
+	int rv;
+
+	reset_out();
+	va_start(ap, format);
+	rv = z_prf(out, buf, format, ap);
+	va_end(ap);
+	if (bp < (buf + ARRAY_SIZE(buf))) {
+		*bp = 0;
+	}
+	return rv;
+}
+
+static inline bool prf_check(const char *s)
+{
+	return strcmp(s, buf) == 0;
+}
+
+static void test_noarg(void)
+{
+	int rc;
+
+	rc = prf("noparams");
+	zassert_true(prf_check("noparams"), NULL);
+	zassert_equal(rc, sizeof("noparams") - 1U, "fail: %d", rc);
+
+	rc = prf("%%");
+	zassert_true(prf_check("%"), NULL);
+	zassert_equal(rc, 1, "fail: %d", rc);
+}
+
+static void test_c(void)
+{
+	int rc;
+
+	rc = prf("%c", 'a');
+	zassert_true(prf_check("a"), NULL);
+	zassert_equal(rc, 1, "fail: %d", rc);
+}
+
+static void test_d(void)
+{
+	int rc;
+
+	rc = prf("%d/%d", -23, 45);
+	zassert_true(prf_check("-23/45"), NULL);
+	zassert_equal(rc, 6, "fail: %d", rc);
+
+	rc = prf("%ld/%ld", -23L, 45L);
+	zassert_true(prf_check("-23/45"), NULL);
+	zassert_equal(rc, 6, "fail: %d", rc);
+
+	if (IS_ENABLED(CONFIG_LIB_OS_PRF_LL_SUPPORT)) {
+		rc = prf("%lld/%lld", -23LL, 45LL);
+		zassert_true(prf_check("-23/45"), "got %s", buf);
+		zassert_equal(rc, 6, "fail: %d", rc);
+	} else {
+		rc = prf("%lld/%lld", -23LL, 45LL);
+		zassert_true(prf_check("%ld/%ld"), "got %s", buf);
+		zassert_equal(rc, 7, "fail: %d", rc);
+	}
+}
+
+/*test case main entry*/
+void test_main(void)
+{
+	TC_PRINT("Opts: "
+		 COND_CODE_1(M64_MODE, ("m64"), ("m32"))
+		 COND_CODE_1(CONFIG_LIB_OS_PRF_LL_SUPPORT, (" LL"), ())
+		 "\n");
+	ztest_test_suite(test_prf,
+			 ztest_unit_test(test_noarg),
+			 ztest_unit_test(test_c),
+			 ztest_unit_test(test_d)
+			 );
+	ztest_run_test_suite(test_prf);
+}

--- a/tests/unit/prf/testcase.yaml
+++ b/tests/unit/prf/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  tags: prf
+  type: unit
+
+tests:
+  utilities.prf-m32:
+    extra_args: M64_MODE=0
+
+  utilities.prf.m32ll:
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DCONFIG_LIB_OS_PRF_LL_SUPPORT
+
+  utilities.prf.m64:
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DCONFIG_LIB_OS_PRF_LL_SUPPORT


### PR DESCRIPTION
Transfer the missed Kconfig that controls support for `%ll?` format specifier in `z_prf` out of minimal libc and into the lib/os Kconfig area.  Give it a better name, since it's not in minimal libc anymore.

Also add just enough of a test case to verify this works.

Fixes #29165
