### PR TITLE
sanitycheck: Add Zephyr's version as a property to xml reports

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3109,7 +3109,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         return filtered_string
 
 
-    def xunit_report(self, filename, platform=None, full_report=False, append=False):
+    def xunit_report(self, filename, platform=None, full_report=False, append=False, version="NA"):
         total = 0
         if platform:
             selected = [platform]
@@ -3180,6 +3180,12 @@ class TestSuite(DisablePyTestCollectionMixin):
                                 tests="%d" % (total),
                                 failures="%d" % fails,
                                 errors="%d" % (errors), skipped="%s" % (skips))
+                    eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
+                    # Multiple 'property' can be added to 'properties'
+                    # differing by name and value
+                    eleTSPVerstion = ET.SubElement(eleTSPropetries, 'property',
+                                                   name="version",
+                                                   value=version)
 
             else:
                 eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
@@ -3187,6 +3193,12 @@ class TestSuite(DisablePyTestCollectionMixin):
                                              tests="%d" % (total),
                                              failures="%d" % fails,
                                              errors="%d" % (errors), skipped="%s" % (skips))
+                eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
+                # Multiple 'property' can be added to 'properties'
+                # differing by name and value
+                eleTSPVerstion = ET.SubElement(eleTSPropetries, 'property',
+                                               name="version",
+                                               value=version)
 
             for _, instance in inst.items():
                 if full_report:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -834,6 +834,9 @@ def main():
 
     suite = TestSuite(options.board_root, options.testcase_root, options.outdir)
 
+    # Check version of zephyr repo
+    suite.check_zephyr_version()
+
     # Set testsuite options from command line.
     suite.build_only = options.build_only
     suite.cmake_only = options.cmake_only

--- a/scripts/tests/sanitycheck/test_reporting_testsuite.py
+++ b/scripts/tests/sanitycheck/test_reporting_testsuite.py
@@ -111,7 +111,8 @@ def test_xunit_report(class_testsuite, test_data,
     assert int(tree.findall('testsuite')[0].attrib["errors"]) == int(errors)
     assert int(tree.findall('testsuite')[0].attrib["tests"]) == int(passes+fails+skips+errors)
 
-    for index in range(0, len(class_testsuite.instances)):
+    for index in range(1, len(class_testsuite.instances)+1):
+        # index=0 corresponds to 'properties'. Test cases start from index=1
         if len(list(tree.findall('testsuite')[0][index])) != 0:
             if tree.findall('testsuite')[0][index][0].attrib["type"] == "failure":
                 assert tree.findall('testsuite')[0][index].attrib["name"] == \


### PR DESCRIPTION
This PR adds checking and reporting the version of Zephyr used by sanitycheck (via `git describe`)