### PR TITLE
Bluetooth: conn: Fix not cleanup properly if ACL is disconnected

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1565,7 +1565,11 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 				bt_iso_disconnected(iso);
 				bt_iso_cleanup(iso);
 				bt_conn_unref(iso);
-				break;
+
+				/* Stop if only ISO was Disconnected */
+				if (iso == conn) {
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
If an ACL connection is disconnected while there is an ISO connection
associated with it the ACL connection will not be cleanup properly as
the code attempt to cleanup the ISO connection and breaks without
proceeding to cleanup the ACL as well.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>