### PR TITLE
dts: arm: Fix k6x ethernet base address

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -471,9 +471,9 @@
 			label = "USBD";
 		};
 
-		enet: ethernet@400c0004 {
+		enet: ethernet@400c0000 {
 			compatible = "nxp,kinetis-ethernet";
-			reg = <0x400c0004 0x620>;
+			reg = <0x400c0000 0x620>;
 			interrupts = <83 0>, <84 0>, <85 0>;
 			interrupt-names = "TX", "RX", "ERR_MISC";
 			status = "disabled";


### PR DESCRIPTION
Commit ac31c4e458c7a5930479b297e8f3bcd5c8b002ed updated the mcux
ethernet driver to get the ethernet peripheral base address from device
tree instead of an nxp hal preprocessor macro. This exposed an error in
the k6x device tree and caused a runtime assertion in networking
applications on the frdm_k64f board:

ASSERTION FAIL [instance < (sizeof(s_enetBases) / sizeof((s_enetBases)[0]))] @ WEST_TOPDIR/modules/hal/nxp/mcux/drivers/kinetis/fsl_enet.c:323

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #29145