### PR TITLE
Fix DHCPv4 message interval

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -282,6 +282,11 @@ static uint32_t dhcpv4_update_message_timeout(struct net_if_dhcpv4 *dhcpv4)
 
 	timeout = DHCPV4_INITIAL_RETRY_TIMEOUT << dhcpv4->attempts;
 
+	/* Max 64 seconds, see RFC 2131 chapter 4.1 */
+	if (timeout < DHCPV4_INITIAL_RETRY_TIMEOUT || timeout > 64) {
+		timeout = 64;
+	}
+
 	dhcpv4->attempts++;
 	dhcpv4->timer_start = k_uptime_get();
 	dhcpv4->request_time = timeout;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -287,6 +287,9 @@ static uint32_t dhcpv4_update_message_timeout(struct net_if_dhcpv4 *dhcpv4)
 		timeout = 64;
 	}
 
+	/* +1/-1 second randomization */
+	timeout += (sys_rand32_get() % 3U) - 1;
+
 	dhcpv4->attempts++;
 	dhcpv4->timer_start = k_uptime_get();
 	dhcpv4->request_time = timeout;


### PR DESCRIPTION
Fixes #29183.

Also adds delay randomization as per [RFC 2131](https://tools.ietf.org/html/rfc2131) chapter 4.1.