### PR TITLE
tests: fs: Add tests for fs_tell/fs_seek ENOTSUP error

### DIFF
--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -80,6 +80,7 @@ void test_main(void)
 			 ztest_unit_test(test_file_open),
 			 ztest_unit_test(test_file_write),
 			 ztest_unit_test(test_file_read),
+			 ztest_unit_test(test_file_seek),
 			 ztest_unit_test(test_file_truncate),
 			 ztest_unit_test(test_file_close),
 			 ztest_unit_test(test_file_sync),

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -41,6 +41,7 @@ void test_lsdir(void);
 void test_file_open(void);
 void test_file_write(void);
 void test_file_read(void);
+void test_file_seek(void);
 void test_file_truncate(void);
 void test_file_close(void);
 void test_file_sync(void);

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Intel Corporation.
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -482,6 +483,30 @@ void test_file_read(void)
 		    "Error - Data read does not match data written");
 
 	TC_PRINT("Data read matches data written\n");
+}
+
+/**
+ * @brief fs_seek tests for expected ENOTSUP
+ *
+ * @ingroup filesystem_api
+ */
+void test_file_seek(void)
+{
+	struct fs_file_system_t backup = temp_fs;
+
+	/* Simulate tell and lseek not implemented */
+	temp_fs.lseek = NULL;
+	temp_fs.tell = NULL;
+
+	zassert_equal(fs_seek(&filep, 0, FS_SEEK_CUR),
+		      -ENOTSUP,
+		      "fs_seek not expected to be implemented");
+	zassert_equal(fs_tell(&filep),
+		      -ENOTSUP,
+		      "fs_tell not expected to be implemented");
+
+	/* Restore fs API interface */
+	temp_fs = backup;
 }
 
 static int _test_file_truncate(void)


### PR DESCRIPTION
The fs_seek and fs_tell are expected to return -ENOTUSP if file system
driver lacks implementation of said funcions.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>