### PR TITLE
tests: access kernel object with private data using system call

### DIFF
--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -45,6 +45,8 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_queue_loop),
 			 ztest_unit_test(test_queue_alloc),
 			 ztest_1cpu_unit_test(test_queue_poll_race),
-			 ztest_unit_test(test_multiple_queues));
+			 ztest_unit_test(test_multiple_queues),
+			 ztest_unit_test(test_access_kernel_obj_with_priv_data)
+			 );
 	ztest_run_test_suite(queue_api);
 }

--- a/tests/kernel/queue/src/test_queue.h
+++ b/tests/kernel/queue/src/test_queue.h
@@ -25,6 +25,7 @@ extern void test_queue_alloc_append_user(void);
 extern void test_queue_alloc(void);
 extern void test_queue_poll_race(void);
 extern void test_multiple_queues(void);
+extern void test_access_kernel_obj_with_priv_data(void);
 
 extern struct k_mem_pool test_pool;
 

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.queue:
-    tags: kernel userspace
+    tags: kernel userspace ignore_faults


### PR DESCRIPTION
When defining system calls, it is very important to ensure that
access to the API’s private data is done exclusively through system
call interfaces. Private kernel data should never be made available
to user mode threads directly. For example, the k_queue APIs were
intentionally not made available as they store bookkeeping
information about the queue directly in the queue buffers which are
visible from user mode.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>