### PR TITLE
drivers: fix gpio_mcux_lpc_port_set_masked_raw

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -143,7 +143,7 @@ static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
 
 	/* Writing 0 allows R+W, 1 disables the pin */
 	gpio_base->MASK[port] = ~mask;
-	gpio_base->PIN[port] = value;
+	gpio_base->MPIN[port] = value;
 	/* Enable back the pins, user won't assume pins remain masked*/
 	gpio_base->MASK[port] = 0U;
 

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -183,6 +183,12 @@ static int bits_physical(void)
 	zassert_equal(raw_in(), true,
 		      "set_masked_raw high mismatch");
 
+	rc = gpio_port_set_masked_raw(dev, BIT(PIN_IN), 0);
+	zassert_equal(rc, 0,
+		      "set_masked_raw low failed");
+	zassert_equal(raw_in(), true,
+		      "set_masked_raw low affected other pins");
+
 	rc = gpio_port_set_clr_bits_raw(dev, BIT(PIN_IN), BIT(PIN_OUT));
 	zassert_equal(rc, 0,
 		      "set in clear out failed");


### PR DESCRIPTION
Fixes gpio_mcux_lpc_port_set_masked_raw function inside gpio_mcux_lpc
driver. Writing masked data is correctly done using device registers.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>

Fixes #29070