### PR TITLE
Bluetooth: host: Fix missing BT_DEV_EXPLICIT_SCAN flag clear

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -8635,6 +8635,7 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 		err = start_le_scan_ext(phy_1m, phy_coded, param->timeout);
 	} else {
 		if (param->timeout) {
+			atomic_clear_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN);
 			return -ENOTSUP;
 		}
 


### PR DESCRIPTION
Fix missing BT_DEV_EXPLICIT_SCAN flag clear on error
return.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>