### PR TITLE
scripts: make building possible with custom west.yml

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -233,7 +233,8 @@ def main():
         from west.util import WestNotFound
         try:
             manifest = Manifest.from_file()
-            projects = [p.posixpath for p in manifest.get_projects([])]
+            projects = [p.posixpath for p in manifest.get_projects([])
+                        if p.posixpath]
         except WestNotFound:
             # Only accept WestNotFound, meaning we are not in a west
             # workspace. Such setup is allowed, as west may be installed


### PR DESCRIPTION
Without this fix, an additional "None" got prepended to the projects
list when building with a custom manifest. This was nothing we noticed
with Zephyr v.2.3.0, so perhaps a regression.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>