### PR TITLE
net: lwm2m: Fix separate response handling

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -107,13 +107,6 @@ struct lwm2m_ctx {
 	 */
 	bool bootstrap_mode;
 
-	/** This flag enables the context to handle an initial ACK after
-	 *  requesting a block of data, but a follow-up packet will contain
-	 *  actual data block.
-	 *  NOTE: This is required for CoAP proxy use-case.
-	 */
-	bool handle_separate_response;
-
 	/** Socket File Descriptor */
 	int sock_fd;
 };

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3709,14 +3709,30 @@ static void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 	tkl = coap_header_get_token(&response, token);
 	pending = coap_pending_received(&response, client_ctx->pendings,
 					CONFIG_LWM2M_ENGINE_MAX_PENDING);
-	/*
-	 * Clear pending pointer because coap_pending_received() calls
-	 * coap_pending_clear, and later when we call lwm2m_reset_message()
-	 * it will try and call coap_pending_clear() again if msg->pending
-	 * is != NULL.
-	 */
-	if (pending) {
+	if (pending && coap_header_get_type(&response) == COAP_TYPE_ACK) {
 		msg = find_msg(pending, NULL);
+		if (msg == NULL) {
+			LOG_DBG("Orphaned pending %p.", pending);
+			return;
+		}
+
+		msg->acknowledged = true;
+
+		if (msg->reply == NULL) {
+			/* No response expected, release the message. */
+			lwm2m_reset_message(msg, true);
+			return;
+		}
+
+		/* If the original message was a request and an empty
+		 * ACK was received, expect separate response later.
+		 */
+		if ((msg->code >= COAP_METHOD_GET) &&
+			(msg->code <= COAP_METHOD_DELETE) &&
+			(coap_header_get_code(&response) == COAP_CODE_EMPTY)) {
+			LOG_DBG("Empty ACK, expect separate response.");
+			return;
+		}
 	}
 
 	LOG_DBG("checking for reply from [%s]",
@@ -3725,28 +3741,16 @@ static void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 				       client_ctx->replies,
 				       CONFIG_LWM2M_ENGINE_MAX_REPLIES);
 	if (reply) {
-		/*
-		 * Separate response is composed of 2 messages, empty ACK with
-		 * no token and an additional message with a matching token id
-		 * (based on the token used by the CON request).
-		 *
-		 * Since the ACK received by the notify CON messages are also
-		 * empty with no token (consequence of always using the same
-		 * token id for all notifications), we have to use an
-		 * additional flag to decide when to clear the reply callback.
-		 */
-		if (client_ctx->handle_separate_response && !tkl &&
-			coap_header_get_type(&response) == COAP_TYPE_ACK) {
-			LOG_DBG("separated response, not removing reply");
-			return;
+		msg = find_msg(NULL, reply);
+
+		if (coap_header_get_type(&response) == COAP_TYPE_CON) {
+			r = lwm2m_send_empty_ack(client_ctx,
+						 coap_header_get_id(&response));
+			if (r < 0) {
+				LOG_ERR("Error transmitting ACK");
+			}
 		}
 
-		if (!msg) {
-			msg = find_msg(pending, reply);
-		}
-	}
-
-	if (reply || pending) {
 		/* skip release if reply->user_data has error condition */
 		if (reply && reply->user_data != COAP_REPLY_STATUS_NONE) {
 			/* reset reply->user_data for next time */
@@ -3841,6 +3845,13 @@ static void retransmit_request(struct k_work *work)
 		 * which balances the ref we made in coap_pending_cycle()
 		 */
 		lwm2m_reset_message(msg, true);
+		goto next;
+	}
+
+	if (msg->acknowledged) {
+		/* No need to retransmit, just keep the timer running to
+		 * timeout in case no response arrives.
+		 */
 		goto next;
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1035,6 +1035,39 @@ int lwm2m_send_message(struct lwm2m_message *msg)
 	return 0;
 }
 
+int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid)
+{
+	struct lwm2m_message *msg;
+	int ret;
+
+	msg = lwm2m_get_message(client_ctx);
+	if (!msg) {
+		LOG_ERR("Unable to get a lwm2m message!");
+		return -ENOMEM;
+	}
+
+	msg->type = COAP_TYPE_ACK;
+	msg->code = COAP_CODE_EMPTY;
+	msg->mid = mid;
+
+	ret = lwm2m_init_message(msg);
+	if (ret) {
+		goto cleanup;
+	}
+
+	ret = lwm2m_send_message(msg);
+	if (ret < 0) {
+		LOG_ERR("Error sending LWM2M packet (err:%d).", ret);
+		goto cleanup;
+	}
+
+	return 0;
+
+cleanup:
+	lwm2m_reset_message(msg, true);
+	return ret;
+}
+
 uint16_t lwm2m_get_rd_data(uint8_t *client_data, uint16_t size)
 {
 	struct lwm2m_engine_obj *obj;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -78,6 +78,7 @@ struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
 void lwm2m_reset_message(struct lwm2m_message *msg, bool release);
 int lwm2m_init_message(struct lwm2m_message *msg);
 int lwm2m_send_message(struct lwm2m_message *msg);
+int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid);
 
 uint16_t lwm2m_get_rd_data(uint8_t *client_data, uint16_t size);
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -393,7 +393,6 @@ static void firmware_transfer(struct k_work *work)
 	}
 
 	lwm2m_engine_context_init(&firmware_ctx);
-	firmware_ctx.handle_separate_response = true;
 	ret = lwm2m_socket_start(&firmware_ctx);
 	if (ret < 0) {
 		LOG_ERR("Cannot start a firmware-pull connection:%d", ret);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -196,39 +196,6 @@ cleanup:
 	return ret;
 }
 
-static int transfer_empty_ack(uint16_t mid)
-{
-	struct lwm2m_message *msg;
-	int ret;
-
-	msg = lwm2m_get_message(&firmware_ctx);
-	if (!msg) {
-		LOG_ERR("Unable to get a lwm2m message!");
-		return -ENOMEM;
-	}
-
-	msg->type = COAP_TYPE_ACK;
-	msg->code = COAP_CODE_EMPTY;
-	msg->mid = mid;
-
-	ret = lwm2m_init_message(msg);
-	if (ret) {
-		goto cleanup;
-	}
-
-	ret = lwm2m_send_message(msg);
-	if (ret < 0) {
-		LOG_ERR("Error sending LWM2M packet (err:%d).", ret);
-		goto cleanup;
-	}
-
-	return 0;
-
-cleanup:
-	lwm2m_reset_message(msg, true);
-	return ret;
-}
-
 static int
 do_firmware_transfer_reply_cb(const struct coap_packet *response,
 			      struct coap_reply *reply,
@@ -254,7 +221,8 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 		return 0;
 	} else if (coap_header_get_type(response) == COAP_TYPE_CON) {
 		/* Send back ACK so the server knows we received the pkt */
-		ret = transfer_empty_ack(coap_header_get_id(check_response));
+		ret = lwm2m_send_empty_ack(&firmware_ctx,
+					   coap_header_get_id(check_response));
 		if (ret < 0) {
 			LOG_ERR("Error transmitting ACK");
 			goto error;

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -443,6 +443,9 @@ struct lwm2m_message {
 
 	/** Counter for message re-send / abort handling */
 	uint8_t send_attempts;
+
+	/* Information whether the message was acknowledged. */
+	bool acknowledged : 1;
 };
 
 /* LWM2M format writer for the various formats supported */


### PR DESCRIPTION
Separate response handling was not working properly in the LWM2M engine. Since it's perfectly valid for a server to send a response separately from ACK, and some LwM2M servers actually use this possibility, it's important to handle separate responses correctly.

This PR addresses this issue and provides fixes for separate response handling in the LwM2M engine.