### PR TITLE
tests: sched_api remove misprints and etc

### DIFF
--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -37,7 +37,7 @@ void spin_for_ms(int ms)
  * @{
  * @}
  */
-/*test case main entry*/
+/* test case main entry */
 void test_main(void)
 {
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
@@ -21,10 +21,10 @@
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
-/* Semaphore on which Ztest thread wait*/
+/* Semaphore on which Ztest thread wait */
 static K_SEM_DEFINE(sema2, 0, NUM_THREAD);
 
-/* Semaphore on which application threads wait*/
+/* Semaphore on which application threads wait */
 static K_SEM_DEFINE(sema3, 0, NUM_THREAD);
 
 static int thread_idx;
@@ -40,24 +40,23 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 			       (idx + 'A');
 
 	while (1) {
-		/* Prining alphabet corresponding to thread*/
+		/* Printing alphabet corresponding to thread */
 		TC_PRINT("%c", thread_parameter);
-		/* Testing if threads are execueted as per priority*/
+		/* Testing if threads are executed as per priority */
 		zassert_true((idx == thread_idx), NULL);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
 
-		/* Realease CPU and give chance to Ztest thread to run*/
+		/* Release CPU and give chance to Ztest thread to run */
 		k_sem_give(&sema2);
-		/*Wait for relase of semaphore from Ztest thread*/
+		/* Wait for release of semaphore from Ztest thread */
 		k_sem_take(&sema3, K_FOREVER);
 	}
 
 }
 
-/*test cases*/
+/* test cases */
 
 /**
- *
  * @brief Check the behavior of preemptive threads with different priorities
  *
  * @details Create multiple threads of different priorities - all are preemptive,
@@ -72,11 +71,11 @@ void test_priority_scheduling(void)
 	int old_prio = k_thread_priority_get(k_current_get());
 	int count = 0;
 
-	/* update priority for current thread*/
+	/* update priority for current thread */
 	k_thread_priority_set(k_current_get(),
 			      K_PRIO_PREEMPT(BASE_PRIORITY - 1));
 
-	/* Create Threads with different Priority*/
+	/* Create Threads with different Priority */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 					 thread_tslice, INT_TO_POINTER(i), NULL, NULL,
@@ -101,7 +100,7 @@ void test_priority_scheduling(void)
 	}
 
 
-	/* test case teardown*/
+	/* test case teardown */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		k_thread_abort(tid[i]);
 	}

--- a/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
@@ -8,49 +8,49 @@
 #include <irq_offload.h>
 #include "test_sched.h"
 
-/*local variables*/
+/* local variables */
 static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tIsr(const void *data)
 {
-	/** TESTPOINT: The code is running at ISR.*/
+	/** TESTPOINT: The code is running at ISR. */
 	zassert_false(k_is_preempt_thread(), NULL);
 }
 
 static void tpreempt_ctx(void *p1, void *p2, void *p3)
 {
-	/** TESTPOINT: The thread's priority is in the preemptible range.*/
+	/** TESTPOINT: The thread's priority is in the preemptible range. */
 	zassert_true(k_is_preempt_thread(), NULL);
 	k_sched_lock();
-	/** TESTPOINT: The thread has locked the scheduler.*/
+	/** TESTPOINT: The thread has locked the scheduler. */
 	zassert_false(k_is_preempt_thread(), NULL);
 	k_sched_unlock();
-	/** TESTPOINT: The thread has not locked the scheduler.*/
+	/** TESTPOINT: The thread has not locked the scheduler. */
 	zassert_true(k_is_preempt_thread(), NULL);
 	k_thread_priority_set(k_current_get(), K_PRIO_COOP(1));
-	/** TESTPOINT: The thread's priority is in the cooperative range.*/
+	/** TESTPOINT: The thread's priority is in the cooperative range. */
 	zassert_false(k_is_preempt_thread(), NULL);
 	k_sem_give(&end_sema);
 }
 
 static void tcoop_ctx(void *p1, void *p2, void *p3)
 {
-	/** TESTPOINT: The thread's priority is in the cooperative range.*/
+	/** TESTPOINT: The thread's priority is in the cooperative range. */
 	zassert_false(k_is_preempt_thread(), NULL);
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(1));
-	/** TESTPOINT: The thread's priority is in the preemptible range.*/
+	/** TESTPOINT: The thread's priority is in the preemptible range. */
 	zassert_true(k_is_preempt_thread(), NULL);
 	k_sched_lock();
-	/** TESTPOINT: The thread has locked the scheduler.*/
+	/** TESTPOINT: The thread has locked the scheduler. */
 	zassert_false(k_is_preempt_thread(), NULL);
 	k_sched_unlock();
-	/** TESTPOINT: The thread has not locked the scheduler.*/
+	/** TESTPOINT: The thread has not locked the scheduler. */
 	zassert_true(k_is_preempt_thread(), NULL);
 	k_sem_give(&end_sema);
 }
 
-/*test cases*/
+/* test cases */
 
 /**
  * @brief Validate the correctness of k_is_preempt_thread()
@@ -69,20 +69,20 @@ void test_sched_is_preempt_thread(void)
 {
 	k_sem_init(&end_sema, 0, 1);
 
-	/*create preempt thread*/
+	/* create preempt thread */
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 				      tpreempt_ctx, NULL, NULL, NULL,
 				      K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);
 
-	/*create coop thread*/
+	/* create coop thread */
 	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 			      tcoop_ctx, NULL, NULL, NULL,
 			      K_PRIO_COOP(1), 0, K_NO_WAIT);
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);
 
-	/*invoke isr*/
+	/* invoke isr */
 	irq_offload(tIsr, NULL);
 }

--- a/tests/kernel/sched/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_priority.c
@@ -31,7 +31,7 @@ static void thread_entry_prio(void *p1, void *p2, void *p3)
 }
 
 
-/*test cases*/
+/* test cases */
 
 /**
  * @brief Validate that the cooperative thread will

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -84,7 +84,7 @@ static void thread_handler(void *p1, void *p2, void *p3)
 	k_timer_start(&timer, DURATION, K_NO_WAIT);
 }
 
-/*test cases*/
+/* test cases */
 
 /**
  * @brief Validate the behavior of cooperative thread

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -13,11 +13,11 @@
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
-/* slice size in millisecond*/
+/* slice size in millisecond */
 #define SLICE_SIZE 200
-/* busy for more than one slice*/
+/* busy for more than one slice */
 #define BUSY_MS (SLICE_SIZE + 20)
-/* a half timeslice*/
+/* a half timeslice */
 #define HALF_SLICE_SIZE (SLICE_SIZE >> 1)
 #define HALF_SLICE_SIZE_CYCLES                                                 \
 	((uint64_t)(HALF_SLICE_SIZE)*sys_clock_hw_cycles_per_sec() / 1000)
@@ -32,7 +32,7 @@ BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 #endif
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-/*elapsed_slice taken by last thread*/
+/* elapsed_slice taken by last thread */
 static uint32_t elapsed_slice;
 static int thread_idx;
 
@@ -83,7 +83,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 thread_idx, t, expected_slice_min, expected_slice_max);
 #endif
 
-	/** TESTPOINT: timeslice should be reset for each preemptive thread*/
+	/** TESTPOINT: timeslice should be reset for each preemptive thread */
 #ifndef CONFIG_COVERAGE
 	zassert_true(t >= expected_slice_min,
 		     "timeslice too small, expected %u got %u",
@@ -103,7 +103,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	k_sem_give(&sema);
 }
 
-/*test cases*/
+/* test cases */
 /**
  * @brief Check the behavior of preemptive threads when the
  * time slice is disabled and enabled
@@ -125,26 +125,26 @@ void test_slice_reset(void)
 	int old_prio = k_thread_priority_get(k_current_get());
 
 	thread_idx = 0;
-	/*disable timeslice*/
+	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);
 
-		/* update priority for current thread*/
+		/* update priority for current thread */
 		k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(j));
 
-		/* create delayed threads with equal preemptive priority*/
+		/* create delayed threads with equal preemptive priority */
 		for (int i = 0; i < NUM_THREAD; i++) {
 			tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 						 thread_time_slice, NULL, NULL,
 						 NULL, K_PRIO_PREEMPT(j), 0,
 						 K_NO_WAIT);
 		}
-		/* enable time slice*/
+		/* enable time slice */
 		k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
 
-		/*synchronize to tick boundary*/
+		/* synchronize to tick boundary */
 		t32 = k_uptime_get_32();
 		while (k_uptime_get_32() == t32) {
 #if defined(CONFIG_ARCH_POSIX)
@@ -152,10 +152,10 @@ void test_slice_reset(void)
 #endif
 		}
 
-		/*set reference time*/
+		/* set reference time */
 		cycles_delta(&elapsed_slice);
 
-		/* current thread (ztest native) consumed a half timeslice*/
+		/* current thread (ztest native) consumed a half timeslice */
 		t32 = k_cycle_get_32();
 		while (k_cycle_get_32() - t32 < HALF_SLICE_SIZE_CYCLES) {
 #if defined(CONFIG_ARCH_POSIX)
@@ -163,16 +163,16 @@ void test_slice_reset(void)
 #endif
 		}
 
-		/* relinquish CPU and wait for each thread to complete*/
+		/* relinquish CPU and wait for each thread to complete */
 		for (int i = 0; i < NUM_THREAD; i++) {
 			k_sem_take(&sema, K_FOREVER);
 		}
 
-		/* test case teardown*/
+		/* test case teardown */
 		for (int i = 0; i < NUM_THREAD; i++) {
 			k_thread_abort(tid[i]);
 		}
-		/* disable time slice*/
+		/* disable time slice */
 		k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 	}
 	k_thread_priority_set(k_current_get(), old_prio);

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -21,14 +21,14 @@
 #define BASE_PRIORITY 0
 #define ITRERATION_COUNT 5
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
-/* slice size in millisecond*/
+/* slice size in millisecond */
 #define SLICE_SIZE 200
-/* busy for more than one slice*/
+/* busy for more than one slice */
 #define BUSY_MS (SLICE_SIZE + 20)
 static struct k_thread t[NUM_THREAD];
 
 static K_SEM_DEFINE(sema1, 0, NUM_THREAD);
-/*elapsed_slice taken by last thread*/
+/* elapsed_slice taken by last thread */
 static int64_t elapsed_slice;
 
 static int thread_idx;
@@ -37,7 +37,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 {
 	int idx = POINTER_TO_INT(p1);
 
-	/*Print New line for last thread*/
+	/* Print New line for last thread */
 	int thread_parameter = (idx == (NUM_THREAD - 1)) ? '\n' :
 			       (idx + 'A');
 
@@ -72,14 +72,14 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	}
 }
 
-/*test cases*/
+/* test cases */
 
 /**
  * @brief Check the behavior of preemptive threads when the
  * time slice is disabled and enabled
  *
  * @details Create multiple preemptive threads with same priorities
- * priorities and few with same priorities and enable the time slice.
+ * and few with same priorities and enable the time slice.
  * Ensure that each thread is given the time slice period to execute.
  *
  * @ingroup kernel_sched_tests
@@ -90,13 +90,13 @@ void test_slice_scheduling(void)
 	int old_prio = k_thread_priority_get(k_current_get());
 	int count = 0;
 
-	/*disable timeslice*/
+	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
-	/* update priority for current thread*/
+	/* update priority for current thread */
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(BASE_PRIORITY));
 
-	/* create threads with equal preemptive priority*/
+	/* create threads with equal preemptive priority */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 					 thread_tslice,
@@ -105,7 +105,7 @@ void test_slice_scheduling(void)
 					 K_NO_WAIT);
 	}
 
-	/* enable time slice*/
+	/* enable time slice */
 	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(BASE_PRIORITY));
 
 	while (count < ITRERATION_COUNT) {
@@ -117,7 +117,7 @@ void test_slice_scheduling(void)
 		 */
 		spin_for_ms(BUSY_MS);
 
-		/* relinquish CPU and wait for each thread to complete*/
+		/* relinquish CPU and wait for each thread to complete */
 		for (int i = 0; i < NUM_THREAD; i++) {
 			k_sem_take(&sema1, K_FOREVER);
 		}
@@ -125,12 +125,12 @@ void test_slice_scheduling(void)
 	}
 
 
-	/* test case teardown*/
+	/* test case teardown */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		k_thread_abort(tid[i]);
 	}
 
-	/* disable time slice*/
+	/* disable time slice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
 	k_thread_priority_set(k_current_get(), old_prio);


### PR DESCRIPTION
I reviewed that test to find a bug root cause, unfortunately,
bug dissapeared, so nothing to fix, but I noticed several
misprints and wrong comment styles. It's something at least.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>