### PR TITLE
ec_host_cmd: Fix unused return value from k_sem_take call

### DIFF
--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -69,7 +69,13 @@ static void handle_host_cmds_entry(void *arg1, void *arg2, void *arg3)
 		k_sem_give(rx.dev_owns);
 
 		/* Wait until and RX messages is received on host interace */
-		k_sem_take(rx.handler_owns, K_FOREVER);
+		if (k_sem_take(rx.handler_owns, K_FOREVER) < 0) {
+			/* This code path should never occur due to the nature of
+			 * k_sem_take with K_FOREVER
+			 */
+			send_error_response(ec_host_cmd_dev,
+					    EC_HOST_CMD_ERROR);
+		}
 		/* rx buf and len now have valid incoming data */
 
 		if (*rx.len < RX_HEADER_SIZE) {


### PR DESCRIPTION
Fixes Coverity issue 214881.

Fixes #29018

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>