### PR TITLE
Sanitycheck: don't remove "test_" from test case name.

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -1549,7 +1549,7 @@ Tests should reference the category and subsystem with a dot as a separator.
                 for match in _matches:
                     if not match.decode().startswith("test_"):
                         warnings = "Found a test that does not start with test_"
-                matches = [match.decode().replace("test_", "", 1) for match in _matches]
+                matches = [match.decode() for match in _matches]
                 return matches, warnings
 
     def scan_path(self, path):


### PR DESCRIPTION
Add "test_" back to test case name so that test case name is same
as "c" function name. It allows us to easily find code of a test
case with test case name shown with sanitycheck.

For example:

- kernel.fifo.usage.test_single_fifo_play

Signed-off-by: Steven Wang <steven.l.wang@linux.intel.com>