### PR TITLE
eth: mcux: Replace CONFIG_ETH_MCUX_NO_PHY_SMI by devicetree "no-phy-smi"

### DIFF
--- a/boards/arm/ip_k66f/Kconfig.defconfig
+++ b/boards/arm/ip_k66f/Kconfig.defconfig
@@ -31,9 +31,6 @@ config ETH_MCUX
 config ETH_MCUX_RMII_EXT_CLK
 	default y if ETH_MCUX
 
-config ETH_MCUX_NO_PHY_SMI
-	default y if ETH_MCUX
-
 endif # NETWORKING
 
 if PINMUX_MCUX

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -99,6 +99,7 @@
 &enet {
 	status = "okay";
 
+	no-phy-smi;
 	fixed-link {
 		speed = <100>;
 		full-duplex;

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -28,13 +28,6 @@ config ETH_MCUX_RMII_EXT_CLK
 	  Setting this option will configure MCUX clock block to feed RMII
 	  reference clock from external source (ENET_1588_CLKIN)
 
-config ETH_MCUX_NO_PHY_SMI
-	bool "Do not use SMI for PHY communication"
-	help
-	  Some PHY devices, with DSA capabilities do not use SMI for
-	  communication with MAC ENET controller. Other busses - like SPI
-	  or I2C are used instead.
-
 config ETH_MCUX_PHY_TICK_MS
 	int "PHY poll period (ms)"
 	default 1000

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -47,6 +47,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "eth.h"
 
+#if !DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) && \
+	!DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay)
+#warning "ETH_MCUX driver enabled but neither enet nor enet2 is enabled"
+#endif
+
 #define FREESCALE_OUI_B0 0x00
 #define FREESCALE_OUI_B1 0x04
 #define FREESCALE_OUI_B2 0x9f
@@ -1211,6 +1216,15 @@ static void eth_mcux_error_isr(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay)
 
+#if DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(0), fixed_link)) && \
+	!defined(CONFIG_ETH_MCUX_NO_PHY_SMI)
+#error "fixed-link can only but used with CONFIG_ETH_MCUX_NO_PHY_SMI"
+#endif
+#if defined(CONFIG_ETH_MCUX_NO_PHY_SMI) && \
+	!DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(0), fixed_link))
+#error "fixed-link must be used when CONFIG_ETH_MCUX_NO_PHY_SMI is set"
+#endif
+
 #if DT_INST_PROP(0, zephyr_random_mac_address) && \
 	NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
 #error Conflict between 'local-mac-address' and 'zephyr,random-mac-address'
@@ -1372,6 +1386,15 @@ static void eth0_config_func(void)
 #endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) */
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay)
+
+#if DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(1), fixed_link)) && \
+	!defined(CONFIG_ETH_MCUX_NO_PHY_SMI)
+#error "fixed-link can only but used with CONFIG_ETH_MCUX_NO_PHY_SMI"
+#endif
+#if defined(CONFIG_ETH_MCUX_NO_PHY_SMI) && \
+	!DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(1), fixed_link))
+#error "fixed-link must be used when CONFIG_ETH_MCUX_NO_PHY_SMI is set"
+#endif
 
 #if DT_INST_PROP(1, zephyr_random_mac_address) && \
 	NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(1))

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -411,13 +411,13 @@ static void eth_mcux_phy_event(struct eth_context *context)
 			/*
 			 * When the iface is available proceed with
 			 * the eth link setup, otherwise reschedule the
-			 * eth_mcux_phy_event and check after 1ms
+			 * eth_mcux_phy_event and check after 50ms
 			 */
 			if (context->iface) {
 				context->phy_state = eth_mcux_phy_state_reset;
 			}
 			k_delayed_work_submit(&context->delayed_phy_work,
-					      K_MSEC(1));
+					      K_MSEC(50));
 		}
 #endif /* CONFIG_SOC_SERIES_IMX_RT */
 		break;

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -12,3 +12,12 @@ properties:
       required: true
     interrupts:
       required: true
+
+    no-phy-smi:
+      type: boolean
+      required: false
+      description:
+        Disable the SMI PHY management interface.
+        Some PHY devices, with DSA capabilities do not use SMI for
+        communication with MAC ENET controller. Other busses - like SPI
+        or I2C are used instead.


### PR DESCRIPTION
This allows configuring the management interface independently for each interface.

Also fixes how "fixed-link" is handled to have it applied independently for each interface.