### PR TITLE
cmake: fix DTS handling of multiple overlay files

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -61,7 +61,7 @@ endif()
 if(SUPPORTS_DTS)
   if(DTC_OVERLAY_FILE)
     # Convert from space-separated files into file list
-    string(REPLACE " " ";" DTC_OVERLAY_FILE_RAW_LIST ${DTC_OVERLAY_FILE})
+    string(REPLACE " " ";" DTC_OVERLAY_FILE_RAW_LIST "${DTC_OVERLAY_FILE}")
     foreach(file ${DTC_OVERLAY_FILE_RAW_LIST})
       file(TO_CMAKE_PATH "${file}" cmake_path_file)
       list(APPEND DTC_OVERLAY_FILE_AS_LIST ${cmake_path_file})


### PR DESCRIPTION
This commit fixes an issue where providing a list of overlay files for
dts was not handled correctly.
The means that using `-DDTC_OVERLAY_FILE="file1.overlay;file2.overlay"`
would fail as those two file names would be concatenated into a single
file name.

This is fixed by properly quote the `DTC_OVERLAY_FILE` variable.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>