### PR TITLE
doc: add HW stack protection enabling in the board porting guidelines

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -432,7 +432,10 @@ while porting.
 
 - It is recommended to enable the MPU by default, if there is support for it
   in hardware. For boards with limited memory resources it is acceptable to
-  disable it.
+  disable it. When the MPU is enabled, it is recommended to also enable
+  hardware stack protection (CONFIG_HW_STACK_PROTECTION=y) and, thus, allow the
+  kernel to detect stack overflows when the system is running in privileged
+  mode.
 
 .. _flash-and-debug-support:
 


### PR DESCRIPTION
Mention in the board porting guidelines the recommendation
to enable by default the HW Stack Protection feature, and
the rationale behind it.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Useful to add this recommendation, since we already migrated several boards/board families to respect this policy, see: #28470
#28575 #29028 and #29214 