### PR TITLE
Bluetooth: Mesh: Disable network_id beacon when proxy disabled

### DIFF
--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -1135,7 +1135,7 @@ static bool advertise_subnet(struct bt_mesh_subnet *sub)
 	}
 
 	return (sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING ||
-		bt_mesh_gatt_proxy_get() != BT_MESH_GATT_PROXY_NOT_SUPPORTED);
+		bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED);
 }
 
 static struct bt_mesh_subnet *next_sub(void)


### PR DESCRIPTION
According Mesh Spec 1.0.1 Section 7.2.2.2.1 Advertising

A node that does not support the Proxy feature or has the Proxy
feature disabled shall not advertise with Network ID.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>