### PR TITLE
disk: disk_access_flash: Make sector size configurable in Kconfig

### DIFF
--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -79,6 +79,12 @@ config DISK_ERASE_BLOCK_SIZE
 	  is erased at one time in flash storage.
 	  Typically it is equal to the flash memory page size.
 
+config DISK_FLASH_SECTOR_SIZE
+	int "Flash device sector size"
+	default 512
+	help
+	  This is the file system sector size in bytes.
+
 config DISK_VOLUME_SIZE
 	hex "Flash device volume size in hex"
 	help

--- a/subsys/disk/disk_access_flash.c
+++ b/subsys/disk/disk_access_flash.c
@@ -14,7 +14,7 @@
 #include <device.h>
 #include <drivers/flash.h>
 
-#define SECTOR_SIZE 512
+#define SECTOR_SIZE CONFIG_DISK_FLASH_SECTOR_SIZE
 
 static const struct device *flash_dev;
 

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -126,6 +126,11 @@ config FS_FATFS_CODEPAGE
 	  949 - Korean (DBCS)
 	  950 - Traditional Chinese (DBCS)
 
+config FS_FATFS_MAX_SS
+	int "Maximum supported sector size"
+	range 512 4096
+	default 512
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM


### PR DESCRIPTION
Make sector size used by flash disk configurable and expose new disk and
fatfs configurations to Kconfig.

This patch depends on zephyrproject-rtos/fatfs#5.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>