### PR TITLE
Bluetooth: controller: Fix missing handle in ext adv terminate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1511,12 +1511,13 @@ void ull_adv_done(struct node_rx_event_done *done)
 		return;
 	}
 
-	rx_hdr->type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
-	rx_hdr->rx_ftr.param_adv_term.conn_handle = 0xffff;
-	rx_hdr->rx_ftr.param_adv_term.num_events = adv->event_counter;
-
 	handle = ull_adv_handle_get(adv);
 	LL_ASSERT(handle < BT_CTLR_ADV_SET);
+
+	rx_hdr->type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
+	rx_hdr->handle = handle;
+	rx_hdr->rx_ftr.param_adv_term.conn_handle = 0xffff;
+	rx_hdr->rx_ftr.param_adv_term.num_events = adv->event_counter;
 
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
 			  (TICKER_ID_ADV_BASE + handle), ticker_op_ext_stop_cb,

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -221,6 +221,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (ll_adv_cmds_is_ext()) {
+		uint8_t handle;
+
 		/* Enqueue connection or CSA event */
 		ll_rx_put(link, rx);
 
@@ -230,8 +232,11 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		rx = adv->lll.node_rx_adv_term;
 		link = rx->link;
 
-		rx->handle = ull_adv_handle_get(adv);
+		handle = ull_adv_handle_get(adv);
+		LL_ASSERT(handle < BT_CTLR_ADV_SET);
+
 		rx->type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
+		rx->handle = handle;
 		rx->rx_ftr.param_adv_term.status = 0U;
 		rx->rx_ftr.param_adv_term.conn_handle = lll->handle;
 		rx->rx_ftr.param_adv_term.num_events = 0U;


### PR DESCRIPTION
Fix missing advertising handle value in the extended
advertising terminate event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>