### PR TITLE
OpenThread rx failed implemented

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -48,7 +48,15 @@ enum ieee802154_filter_type {
 };
 
 enum ieee802154_event {
-	IEEE802154_EVENT_TX_STARTED /* Data transmission started */
+	IEEE802154_EVENT_TX_STARTED, /* Data transmission started */
+	IEEE802154_EVENT_RX_FAILED   /* Data reception failed */
+};
+
+enum ieee802154_rx_fail_reason {
+	IEEE802154_RX_FAIL_NOT_RECEIVED,  /* Nothing received */
+	IEEE802154_RX_FAIL_INVALID_FCS,   /* Frame had invalid checksum */
+	IEEE802154_RX_FAIL_ADDR_FILTERED, /* Address did not match */
+	IEEE802154_RX_FAIL_OTHER	  /* General reason */
 };
 
 typedef void (*energy_scan_done_cb_t)(const struct device *dev,

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -50,6 +50,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 enum pending_events {
 	PENDING_EVENT_FRAME_TO_SEND, /* There is a tx frame to send  */
 	PENDING_EVENT_FRAME_RECEIVED, /* Radio has received new frame */
+	PENDING_EVENT_RX_FAILED, /* The RX failed */
 	PENDING_EVENT_TX_STARTED, /* Radio has started transmitting */
 	PENDING_EVENT_TX_DONE, /* Radio transmission finished */
 	PENDING_EVENT_DETECT_ENERGY, /* Requested to start Energy Detection
@@ -84,7 +85,7 @@ static int16_t energy_detected_value;
 ATOMIC_DEFINE(pending_events, PENDING_EVENT_COUNT);
 K_KERNEL_STACK_DEFINE(ot_task_stack, OT_WORKER_STACK_SIZE);
 static struct k_work_q ot_work_q;
-static otError tx_result;
+static otError tx_rx_result;
 
 K_FIFO_DEFINE(rx_pkt_fifo);
 K_FIFO_DEFINE(tx_pkt_fifo);
@@ -161,6 +162,30 @@ void handle_radio_event(const struct device *dev, enum ieee802154_event evt,
 			set_pending_event(PENDING_EVENT_TX_STARTED);
 		}
 		break;
+	case IEEE802154_EVENT_RX_FAILED:
+		if (sState == OT_RADIO_STATE_RECEIVE) {
+			switch (*(enum ieee802154_rx_fail_reason *)
+				event_params) {
+			case IEEE802154_RX_FAIL_NOT_RECEIVED:
+				tx_rx_result = OT_ERROR_NO_FRAME_RECEIVED;
+				break;
+
+			case IEEE802154_RX_FAIL_INVALID_FCS:
+				tx_rx_result = OT_ERROR_FCS;
+				break;
+
+			case IEEE802154_RX_FAIL_ADDR_FILTERED:
+				tx_rx_result
+					= OT_ERROR_DESTINATION_ADDRESS_FILTERED;
+				break;
+
+			case IEEE802154_RX_FAIL_OTHER:
+			default:
+				tx_rx_result = OT_ERROR_FAILED;
+				break;
+			}
+			set_pending_event(PENDING_EVENT_RX_FAILED);
+		}
 	default:
 		/* do nothing - ignore event */
 		break;
@@ -213,7 +238,7 @@ void transmit_message(struct k_work *tx_job)
 {
 	ARG_UNUSED(tx_job);
 
-	tx_result = OT_ERROR_NONE;
+	tx_rx_result = OT_ERROR_NONE;
 	/*
 	 * The payload is already in tx_payload->data,
 	 * but we need to set the length field
@@ -234,17 +259,17 @@ void transmit_message(struct k_work *tx_job)
 			if (radio_api->tx(radio_dev,
 					  IEEE802154_TX_MODE_CSMA_CA,
 					  tx_pkt, tx_payload) != 0) {
-				tx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
+				tx_rx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 			}
 		} else if (radio_api->cca(radio_dev) != 0 ||
 			   radio_api->tx(radio_dev, IEEE802154_TX_MODE_DIRECT,
 					 tx_pkt, tx_payload) != 0) {
-			tx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
+			tx_rx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 		}
 	} else {
 		if (radio_api->tx(radio_dev, IEEE802154_TX_MODE_DIRECT,
 				  tx_pkt, tx_payload)) {
-			tx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
+			tx_rx_result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
 		}
 	}
 
@@ -255,7 +280,7 @@ static inline void handle_tx_done(otInstance *aInstance)
 {
 	if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame,
-					    tx_result);
+					    tx_rx_result);
 	} else {
 		if (sTransmitFrame.mPsdu[0] & IEEE802154_AR_FLAG_SET) {
 			if (ack_frame.mLength == 0) {
@@ -264,11 +289,11 @@ static inline void handle_tx_done(otInstance *aInstance)
 						  NULL, OT_ERROR_NO_ACK);
 			} else {
 				otPlatRadioTxDone(aInstance, &sTransmitFrame,
-						  &ack_frame, tx_result);
+						  &ack_frame, tx_rx_result);
 			}
 		} else {
 			otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL,
-					  tx_result);
+					  tx_rx_result);
 		}
 		ack_frame.mLength = 0;
 	}
@@ -396,6 +421,17 @@ void platformRadioProcess(otInstance *aInstance)
 							      K_NO_WAIT))
 		      != NULL) {
 			openthread_handle_received_frame(aInstance, rx_pkt);
+		}
+	}
+
+	if (is_pending_event_set(PENDING_EVENT_RX_FAILED)) {
+		reset_pending_event(PENDING_EVENT_RX_FAILED);
+		if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
+			otPlatDiagRadioReceiveDone(aInstance,
+						   NULL, tx_rx_result);
+		} else {
+			otPlatRadioReceiveDone(aInstance,
+					       NULL, tx_rx_result);
 		}
 	}
 


### PR DESCRIPTION
Rx failed event is used by thread for gathering statistical data.