### PR TITLE
usb: netusb: make ECM MAC address user-configurable

### DIFF
--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -47,7 +47,7 @@ config CDC_ECM_BULK_EP_MPS
 	  CDC ECM class bulk endpoint size
 
 config USB_DEVICE_NETWORK_ECM_MAC
-	string
+	string "USB ECM Host OS MAC Address"
 	default "00005E005301"
 	help
 	  MAC Host OS Address string.


### PR DESCRIPTION
Add prompt to USB_DEVICE_NETWORK_ECM_MAC Kconfig option to allow users to change it.
The current default value is assigned for documentation purposes in RFC 7042.

Signed-off-by: Joakim Algrøy <joakimalgroy@gmail.com>