### PR TITLE
FS: improvements to fs_mount and fs_unmount

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -416,7 +416,9 @@ int fs_mount(struct fs_mount_t *mp);
  * @param mp Pointer to the fs_mount_t structure
  *
  * @retval 0 on success;
- * @retval <0 negative errno code on error.
+ * @retval -EINVAL if no system has been mounted at given mount point;
+ * @retval -ENOTSUP when not supported by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
  */
 int fs_unmount(struct fs_mount_t *mp);
 

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -392,10 +392,17 @@ int fs_closedir(struct fs_dir_t *zdp);
  * calling the file system specific mount function and adding
  * the mount point to mounted file system list.
  *
- * @param mp Pointer to the fs_mount_t structure
+ * @param mp Pointer to the fs_mount_t structure.  Referenced object
+ *	     is not changed if the mount operation failed.
+ *	     A reference is captured in the fs infrastructure if the
+ *	     mount operation succeeds, and the application must not
+ *	     mutate the structure contents until fs_unmount is
+ *	     successfully invoked on the same pointer.
  *
  * @retval 0 on success;
- * @retval <0 a negative errno code on error.
+ * @retval -ENOENT when file system type has not been registered;
+ * @retval -ENOTSUP when not supported by underlying file system driver;
+ * @retval <0 a other negative errno code on error.
  */
 int fs_mount(struct fs_mount_t *mp);
 

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -657,16 +657,21 @@ int fs_unmount(struct fs_mount_t *mp)
 {
 	int rc = -EINVAL;
 
-	if ((mp == NULL) || (mp->mnt_point == NULL) ||
-				(strlen(mp->mnt_point) <= 1)) {
-		LOG_ERR("invalid mount point!!");
-		return -EINVAL;
+	if (mp == NULL) {
+		return rc;
 	}
 
 	k_mutex_lock(&mutex, K_FOREVER);
-	if ((mp->fs == NULL) || mp->fs->unmount == NULL) {
-		LOG_ERR("fs ops functions not set!!");
-		rc = -EINVAL;
+
+	if (mp->fs == NULL) {
+		LOG_ERR("fs not mounted (mp == %p)", mp);
+		goto unmount_err;
+	}
+
+	if (mp->fs->unmount == NULL) {
+		LOG_ERR("mount path %s is not unmountable",
+			log_strdup(mp->mnt_point));
+		rc = -ENOTSUP;
 		goto unmount_err;
 	}
 

--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -295,11 +295,13 @@ static int temp_statvfs(struct fs_mount_t *mountp,
 
 static int temp_mount(struct fs_mount_t *mountp)
 {
+	size_t len = strlen(mountp->mnt_point);
+
 	if (mountp == NULL) {
 		return -EINVAL;
 	}
 
-	if (mountp->mnt_point[mountp->mountp_len - 1] != ':') {
+	if (mountp->mnt_point[len - 1] != ':') {
 		return -EINVAL;
 	}
 	mp[mountp->type] = mountp;

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -119,7 +119,7 @@ void test_unmount(void)
 
 	TC_PRINT("\nunmount file system that has never been mounted:\n");
 	ret = fs_unmount(&test_fs_mnt_unsupported_fs);
-	zassert_not_equal(ret, 0, "Unmount a never mounted fs");
+	zassert_equal(ret, -EINVAL, "Unmount a never mounted fs");
 
 	TC_PRINT("\nunmount file system multiple times:\n");
 	ret = fs_unmount(&test_fs_mnt_1);
@@ -127,7 +127,7 @@ void test_unmount(void)
 
 	test_fs_mnt_1.fs = &temp_fs;
 	ret = fs_unmount(&test_fs_mnt_1);
-	zassert_not_equal(ret, 0, "Unmount a unmounted fs");
+	zassert_equal(ret, -EINVAL, "Unmount a unmounted fs");
 }
 
 /**


### PR DESCRIPTION
The PR introduces changes to `fs_mount`:
 - move function parameter verification outside of the mutex locked block;
 - check list of mount points first for already mounted file system at given mount point;
 - return `-ENOTSUP` when file system does not support mounting;
 - modify the `mp` pointed `fs_mount_t` structure only after successful in all other required steps and immediately before adding to mount point list.
 - documentation has been updated with note that warns about modification of mp pointed structure after giving it to `fs_mount`

The changes to `fs_unmount` are:
 - move function parameter verification outside of the mutex locked block;
 - ~~**unmount is based on mount point rather than `mp->fs` member, and API is obtained by mount point from the mount point list;**~~
 - return `-ENOTSUP` when file system does not support unmounting;
 - return ~~`-ENOENT`~~`EINVAL` if mount point is not mounted.
 - removed checks for `mnt_point` being correct as it has no meaning while unmounting; only the fs_mount_t->mp is useful to determine whether system is mounted or not.