### PR TITLE
[RFC] fs: Add fs_unmount_path function

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -451,6 +451,21 @@ int fs_mount(struct fs_mount_t *mp);
 int fs_unmount(struct fs_mount_t *mp);
 
 /**
+ * @brief Unmount filesystem by mount point path
+ *
+ * Searches list of mount points for mount point that matches given path
+ * and unmounts it.
+ *
+ * @param mnt_point Pointer to a path representing mount point
+ *
+ * @retval 0 on success;
+ * @retval -ENOENT if no system has been mounted at given mount point;
+ * @retval -ENOTSUP when not supported by underlying file system driver;
+ * @retval <0 an other negative errno code on error.
+ */
+int fs_unmount_path(const char *mnt_point);
+
+/**
  * @brief Get path of mount point at index
  *
  * This function iterates through the list of mount points and returns


### PR DESCRIPTION
The fs_unmount_path function allows to unmount mount point by mount
point path rather than by contents of fs_mount_t structure.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

**Rationale**: With the implementation of `fs_unmount` provided by #29229, the unmount no longer relies on `fs_mount_t` data type variable setup by `fs_mount`, e.g. setting the `fs` to point to mounted fs API, and now uses only the `mnt_point` member of structure to search list of mounted file systems. This means that to unmount the file system user still needs the `fs_mount_t` structure only to provide the mount point, which is redundant; the `fs_ubmount_path` function improves user experience by directly taking path to mount point, with no need on the user side to define the variable of `fs_unmount_t` to do so or invoke
```
fs_unmount(&(struct fs_mount_t)({ .mnt_point = "sth"});
```
instead:
```
fs_unmount_path("sth");
```
does the same job.

- [ ] Missing test case