### PR TITLE
Bluetooth: remove unused extern z_prf

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -66,9 +66,6 @@ static struct {
 	atomic_t other;
 } drops;
 
-extern int z_prf(int (*func)(), void *dest,
-		const char *format, va_list vargs);
-
 static void monitor_send(const void *data, size_t len)
 {
 	const uint8_t *buf = data;


### PR DESCRIPTION
z_prf is not being used in the monitor code, so remove it.