### PR TITLE
manifest: synch MCUBoot to upstream of 21.10.2020

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -258,6 +258,8 @@ MCUBoot
   * Added reset of Cortex SPLIM registers before boot.
   * Fixesd build issue that occurs if CONF_FILE contains multiple file paths
     instead of single file path.
+  * Added watchdog feed on nRF devices. See ``CONFIG_BOOT_WATCHDOG_FEED`` option.
+  * Removed the flash_area_read_is_empty() port implementation function.
 
 * imgtool
 

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: aef137b1af8aa7a0f43345c82459254b8832262e
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: e312fa2cec3e8440bf484d7da3443e149b7eb9d8
+      revision: e64c5f00d67cf858d1fdead7135f5d61de2a4c68
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5051f9d900bbb194a23d4ce80f3c6dc6d6780cc2


### PR DESCRIPTION
MCUBoot was synchronized up to:
https://github.com/JuulLabs-OSS/mcuboot/commit/c625da4 

Introduces https://github.com/zephyrproject-rtos/mcuboot/pull/37

- Removed the flash_area_read_is_empty() port implementation
function
- Added watchdog feed on nRF dvices.
See CONFIG BOOT_WATCHDOG_FEED option.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>