### PR TITLE
runners: bossac: fix offset argument being wrongly provided

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -95,9 +95,11 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         if self.offset is not None:
             self.logger.warning(
                 'This version of BOSSA does not support the --offset flag.' +
+                'Offset information will not be delivered to BOSSAC.' +
                 ' Please see' +
                 ' https://github.com/zephyrproject-rtos/sdk-ng/issues/234' +
                 ' which tracks updating the Zephyr SDK.')
+            return None
 
         return self.offset
 


### PR DESCRIPTION
Older versions of bossac (including the one used in current SDK 11.4) don't
support the offset argument and the runner used to omit it if offset is not
provided to the runner. However a recent change means that the runner always has
some sort of offset. This fix makes sure its nullified if offset-less bossac is
in use.

Signed-off-by: Kuba Sanak <contact@kuba.fyi>