### PR TITLE
samples: sensor: bme680: Add overlay for adafruit_feather_nrf52840

### DIFF
--- a/samples/sensor/bme680/boards/adafruit_feather_nrf52840.overlay
+++ b/samples/sensor/bme680/boards/adafruit_feather_nrf52840.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020, Patrick Moffitt <patrick@moffitt.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * i2c interface for the Feather nRF52840 Express and the
+ * Adafruit BME680.
+ */
+
+&i2c0 {
+	compatible = "nordic,nrf-twi";
+	bme680: bme680@77 {
+		compatible = "bosch,bme680";
+		reg = <0x77>;
+		label = "BME680";
+	};
+};

--- a/samples/sensor/bme680/sample.yaml
+++ b/samples/sensor/bme680/sample.yaml
@@ -4,4 +4,4 @@ tests:
   sample.sensor.bme680:
     harness: sensor
     tags: samples sensor
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 adafruit_feather_nrf52840


### PR DESCRIPTION
The overlay file defines an i2c interface for the
Feather nRF52840 Express and the Adafruit BME680.

Also adds the platform to the test build configuration.

Signed-off-by: Patrick K. Moffitt <patrick@moffitt.com>