### PR TITLE
sanitycheck: actually allow empty west-flash without parameter

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -798,7 +798,7 @@ def main():
         hwm.dump(hwmap=hwm.connected_hardware, connected_only=True)
         return
 
-    if options.west_runner and not options.west_flash:
+    if options.west_runner and options.west_flash is None:
         logger.error("west-runner requires west-flash to be enabled")
         sys.exit(1)
 


### PR DESCRIPTION
According to west-flash option description it's allowed to use west-flash without parameter:
> There are three ways this option is used.
> 1) bare: --west-flash
> 2) with a value: --west-flash="--board-id=42"
> 3) Multiple values: --west-flash="--board-id=42,--erase"

However, we don't allow to west-flash to be without parameter when we verify sanitycheck arguments, so sanitycheck options `--west-runner=mdb --west-flash` still cause error:
```
ERROR   - west-runner requires west-flash to be enabled
```

 Fix that.

The checks in the place there west-flash is used (in DeviceHandler) are done correctly.