### PR TITLE
drivers: modem: hl7800: only set DNS addr if not set

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1486,7 +1486,7 @@ done:
 
 static void dns_work_cb(struct k_work *work)
 {
-#ifdef CONFIG_DNS_RESOLVER
+#if defined(CONFIG_DNS_RESOLVER) && !defined(CONFIG_DNS_SERVER_IP_ADDRESSES)
 	int ret;
 	struct dns_resolve_context *dnsCtx;
 	const char *dns_servers_str[] = { ictx.dns_string };


### PR DESCRIPTION
Only set the DNS resolver server address if one has not been specified.