### PR TITLE
cmake: remove BOARD_FAMILY variable

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -456,7 +456,6 @@ if(DEFINED SHIELD AND NOT (SHIELD-NOTFOUND STREQUAL ""))
 endif()
 
 get_filename_component(BOARD_ARCH_DIR ${BOARD_DIR}      DIRECTORY)
-get_filename_component(BOARD_FAMILY   ${BOARD_DIR}      NAME)
 get_filename_component(ARCH           ${BOARD_ARCH_DIR} NAME)
 
 foreach(root ${ARCH_ROOT})


### PR DESCRIPTION
BOARD_FAMILY isn't used anywhere so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>