### PR TITLE
net: openthread: fix unwanted 802.15.4 radio up

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -330,6 +330,8 @@ int openthread_start(struct openthread_context *ot_context)
 
 	openthread_api_mutex_lock(ot_context);
 
+	otIp6SetEnabled(ot_context->instance, true);
+
 	/* Sleepy End Device specific configuration. */
 	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
 		otLinkModeConfig ot_mode = otThreadGetLinkMode(ot_instance);
@@ -431,8 +433,6 @@ static int openthread_init(struct net_if *iface)
 	if (IS_ENABLED(CONFIG_OPENTHREAD_NCP)) {
 		otNcpInit(ot_context->instance);
 	}
-
-	otIp6SetEnabled(ot_context->instance, true);
 
 	if (!IS_ENABLED(CONFIG_OPENTHREAD_NCP)) {
 		otIp6SetReceiveFilterEnabled(ot_context->instance, true);


### PR DESCRIPTION
This commit moves IPv6 initialization from OT init to OT start to avoid unwantedly bringing 802.15.4 radio up.

Previously, even when OT manual start was enabled, the radio would be receiving frames resulting in unnecessary power consumption and causing issues for instance when the device just wants to use Bluetooth for provisioning before moving to Thread.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>