### PR TITLE
net: openthread: Increase the number of allowed children

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -52,3 +52,13 @@ config OPENTHREAD_POLL_PERIOD
 	int "Poll period for sleepy end devices [ms]"
 	default 236000
 	depends on OPENTHREAD_MTD_SED
+
+config OPENTHREAD_MAX_CHILDREN
+	int "The maximum number of children"
+	range 10 512
+	default 32
+
+config OPENTHREAD_MAX_IP_ADDR_PER_CHILD
+	int "The maximum number of IPv6 address registrations per child."
+	range 4 255
+	default 6

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -132,6 +132,27 @@
 #define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 0
 
 /**
+ * @def OPENTHREAD_CONFIG_MLE_MAX_CHILDREN
+ *
+ * The maximum number of children.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_MAX_CHILDREN
+#define OPENTHREAD_CONFIG_MLE_MAX_CHILDREN CONFIG_OPENTHREAD_MAX_CHILDREN
+#endif /* CONFIG_OPENTHREAD_MAX_CHILDREN */
+
+/**
+ * @def OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD
+ *
+ * The maximum number of supported IPv6 address registrations per child.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_MAX_IP_ADDR_PER_CHILD
+#define OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD \
+	CONFIG_OPENTHREAD_MAX_IP_ADDR_PER_CHILD
+#endif /* CONFIG_OPENTHREAD_MAX_IP_ADDR_PER_CHILD */
+
+/**
  * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
  *
  * The number of extended source address table entries.


### PR DESCRIPTION
Another team reported that current default values for number of allowed
IP addresses per child (4) and and max number of children (10) are too
small for some customers.
Increased the values allowed configuring child count.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>