### PR TITLE
decawave_dwm1001_dev:  use of openocd-nrf5.cmake

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/board.cmake
+++ b/boards/arm/decawave_dwm1001_dev/board.cmake
@@ -2,6 +2,7 @@
 
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52")
+set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/decawave_dwm1001_dev/support/openocd.cfg
+++ b/boards/arm/decawave_dwm1001_dev/support/openocd.cfg
@@ -1,4 +1,0 @@
-source [find interface/jlink.cfg]
-adapter_khz 1000
-transport select swd
-source [find target/nrf52.cfg]


### PR DESCRIPTION
Using flash support provided by openocd-nrf5.

Signed-off-by: Stephane D'Alu <sdalu@sdalu.com>