### PR TITLE
drivers: wifi: esp: signal blocking behavior on busy device

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -126,6 +126,7 @@ struct esp_socket {
 
 	/* sem */
 	struct k_sem sem_data_ready;
+	struct k_sem sem_tx_pkt;
 
 	/* work */
 	struct k_work connect_work;

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -65,6 +65,7 @@ void esp_socket_init(struct esp_data *data)
 		sock->link_id = INVALID_LINK_ID;
 		sock->flags = 0;
 		k_sem_init(&sock->sem_data_ready, 0, 1);
+		k_sem_init(&sock->sem_tx_pkt, 1, 1);
 		k_fifo_init(&sock->fifo_rx_pkt);
 	}
 }


### PR DESCRIPTION
Implementations such as the TLS sockets depend on the
EAGAIN signal when requesting a non-blocking sendto that would
block.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>

I do not have any hardware to test this PR, but I noticed this when working on
another net_offloaded driver that also returned -EBUSY on [sendto](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html) with K_NO_WAIT.

```
static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
{
	struct net_context *net_ctx = ctx;
	ssize_t sent;

	sent = sock_fd_op_vtable.sendto(ctx, buf, len,
					net_ctx->tls->flags, NULL, 0);
	if (sent < 0) {
		if (errno == EAGAIN) {
			return MBEDTLS_ERR_SSL_WANT_WRITE;
		}

		return MBEDTLS_ERR_NET_SEND_FAILED;
	}

	return sent;
}
```