### PR TITLE
nrf52840_mdk: support qspi flash

### DIFF
--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -130,6 +130,32 @@
 	ch2-inverted;
 };
 
+&qspi {
+	status = "okay";
+	sck-pin = <35>;
+	io-pins = <37>, <36>, <34>, <33>;
+	csn-pins = <38>;
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		writeoc = "pp4io";
+		readoc = "read4io";
+		sck-frequency = <8000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/samples/drivers/spi_flash/boards/nrf52840_mdk.conf
+++ b/samples/drivers/spi_flash/boards/nrf52840_mdk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Stephane D'Alu
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI=n
+CONFIG_NORDIC_QSPI_NOR=y


### PR DESCRIPTION
Added support for installed MX25R64 QSPI NOR flash.

Fixes #29248

Signed-off-by: Stephane D'Alu <sdalu@sdalu.com>