### PR TITLE
Bluetooth: Mesh: Add build of provisioner sample to CI

### DIFF
--- a/samples/bluetooth/mesh_provisioner/sample.yaml
+++ b/samples/bluetooth/mesh_provisioner/sample.yaml
@@ -1,2 +1,7 @@
 sample:
   name: Bluetooth Mesh Provisioner
+tests:
+  sample.bluetooth.mesh_provisioner:
+    harness: bluetooth
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422
+    tags: bluetooth


### PR DESCRIPTION
Adds a test case listing in sample.yaml of the mesh_provisioner sample,
building on qemu and the Nordic nRF51 DK to ensure that the provisioner
role is built in PRs.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>