### PR TITLE
boards: nrf52840_mdk: Added openocd runner support

### DIFF
--- a/boards/arm/nrf52840_mdk/board.cmake
+++ b/boards/arm/nrf52840_mdk/board.cmake
@@ -2,3 +2,4 @@
 
 board_runner_args(pyocd "--target=nrf52840")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nrf52840_mdk/support/openocd.cfg
+++ b/boards/arm/nrf52840_mdk/support/openocd.cfg
@@ -1,0 +1,4 @@
+source [find interface/cmsis-dap.cfg]
+adapter_khz 1000
+transport select swd
+source [find target/nrf52.cfg]


### PR DESCRIPTION
Added openocd runner with cmsis-dap interface.

Signed-off-by: Stephane D'Alu <sdalu@sdalu.com>