### PR TITLE
net: tcp2: Fix TCP connection from Windows 10

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1186,10 +1186,15 @@ err:
 static void tcp_in(struct tcp *conn, struct net_pkt *pkt)
 {
 	struct tcphdr *th = pkt ? th_get(pkt) : NULL;
-	uint8_t next = 0, fl = th ? th->th_flags : 0;
+	uint8_t next = 0, fl = 0;
 	size_t tcp_options_len = th ? (th->th_off - 5) * 4 : 0;
 	size_t len;
 	int ret;
+
+	if (th) {
+		/* Currently we ignore ECN and CWR flags */
+		fl = th->th_flags & ~(ECN | CWR);
+	}
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -142,6 +142,8 @@ enum th_flags {
 	PSH = 1 << 3,
 	ACK = 1 << 4,
 	URG = 1 << 5,
+	ECN = 1 << 6,
+	CWR = 1 << 7,
 };
 
 enum tcp_state {


### PR DESCRIPTION
Windows 10 sends ECN-Echo and Congestion Window Reduced (CWR) flags
together with SYN flag in the connection establishment but the code
did not ignore these flags and send just SYN back (instead of SYN|ACK).
This caused the connection establishement in application level to
fail as the application was never notified about it.

Fixes #29258

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>