### PR TITLE
drivers/gpio: stm32f1: Revert gpio register programming re-ordering

### DIFF
--- a/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
@@ -36,3 +36,4 @@
 };
 
 arduino_spi: &spi1 {};
+arduino_i2c: &i2c1 {};

--- a/boards/arm/nucleo_f103rb/doc/index.rst
+++ b/boards/arm/nucleo_f103rb/doc/index.rst
@@ -124,6 +124,7 @@ Default Zephyr Peripheral Mapping:
 - UART_2 TX/RX : PA2/PA3 (ST-Link Virtual COM Port)
 - SPI1 NSS/SCK/MISO/MOSI : PA4/PA5/PA6/PA7 (Arduino SPI)
 - SPI2 SCK/MISO/MOSI : PB12/PB13/PB14/PB15
+- I2C1 SDA/SCL: PB9/PB8 (Arduino I2C)
 - PWM1_CH1: PA8
 - USER_PB : PC13
 - LD1 : PA5

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -58,6 +58,12 @@
 	current-speed = <115200>;
 };
 
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 &spi1 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
@@ -11,6 +11,7 @@ flash: 128
 supported:
   - arduino_gpio
   - arduino_spi
+  - arduino_i2c
   - gpio
   - spi
   - pwm

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -138,6 +138,14 @@ int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
 		}
 
 	} else {
+		temp = conf & (STM32_CNF_OUT_1_MASK << STM32_CNF_OUT_1_SHIFT);
+
+		if (temp == STM32_CNF_GP_OUTPUT) {
+			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_OUTPUT);
+		} else {
+			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_ALTERNATE);
+		}
+
 		temp = conf & (STM32_CNF_OUT_0_MASK << STM32_CNF_OUT_0_SHIFT);
 
 		if (temp == STM32_CNF_PUSH_PULL) {
@@ -154,14 +162,6 @@ int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
 			LL_GPIO_SetPinSpeed(gpio, pin_ll, LL_GPIO_SPEED_FREQ_MEDIUM);
 		} else {
 			LL_GPIO_SetPinSpeed(gpio, pin_ll, LL_GPIO_SPEED_FREQ_HIGH);
-		}
-
-		temp = conf & (STM32_CNF_OUT_1_MASK << STM32_CNF_OUT_1_SHIFT);
-
-		if (temp == STM32_CNF_GP_OUTPUT) {
-			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_OUTPUT);
-		} else {
-			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_ALTERNATE);
 		}
 	}
 #else

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -116,7 +116,8 @@ int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 	ARG_UNUSED(altf);
 
-	uint32_t temp = conf & (STM32_MODE_INOUT_MASK << STM32_MODE_INOUT_SHIFT);
+	uint32_t temp = conf &
+			      (STM32_MODE_INOUT_MASK << STM32_MODE_INOUT_SHIFT);
 
 	if (temp == STM32_MODE_INPUT) {
 		temp = conf & (STM32_CNF_IN_MASK << STM32_CNF_IN_SHIFT);
@@ -129,9 +130,11 @@ int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
 			temp = conf & (STM32_PUPD_MASK << STM32_PUPD_SHIFT);
 
 			if (temp == STM32_PUPD_PULL_UP) {
-				LL_GPIO_SetPinPull(gpio, pin_ll, LL_GPIO_PULL_UP);
+				LL_GPIO_SetPinPull(gpio, pin_ll,
+							       LL_GPIO_PULL_UP);
 			} else {
-				LL_GPIO_SetPinPull(gpio, pin_ll, LL_GPIO_PULL_DOWN);
+				LL_GPIO_SetPinPull(gpio, pin_ll,
+							     LL_GPIO_PULL_DOWN);
 			}
 
 			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_INPUT);
@@ -143,25 +146,32 @@ int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
 		if (temp == STM32_CNF_GP_OUTPUT) {
 			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_OUTPUT);
 		} else {
-			LL_GPIO_SetPinMode(gpio, pin_ll, LL_GPIO_MODE_ALTERNATE);
+			LL_GPIO_SetPinMode(gpio, pin_ll,
+							LL_GPIO_MODE_ALTERNATE);
 		}
 
 		temp = conf & (STM32_CNF_OUT_0_MASK << STM32_CNF_OUT_0_SHIFT);
 
 		if (temp == STM32_CNF_PUSH_PULL) {
-			LL_GPIO_SetPinOutputType(gpio, pin_ll, LL_GPIO_OUTPUT_PUSHPULL);
+			LL_GPIO_SetPinOutputType(gpio, pin_ll,
+						       LL_GPIO_OUTPUT_PUSHPULL);
 		} else {
-			LL_GPIO_SetPinOutputType(gpio, pin_ll, LL_GPIO_OUTPUT_OPENDRAIN);
+			LL_GPIO_SetPinOutputType(gpio, pin_ll,
+						      LL_GPIO_OUTPUT_OPENDRAIN);
 		}
 
-		temp = conf & (STM32_MODE_OSPEED_MASK << STM32_MODE_OSPEED_SHIFT);
+		temp = conf &
+			    (STM32_MODE_OSPEED_MASK << STM32_MODE_OSPEED_SHIFT);
 
 		if (temp == STM32_MODE_OUTPUT_MAX_2) {
-			LL_GPIO_SetPinSpeed(gpio, pin_ll, LL_GPIO_SPEED_FREQ_LOW);
+			LL_GPIO_SetPinSpeed(gpio, pin_ll,
+							LL_GPIO_SPEED_FREQ_LOW);
 		} else if (temp == STM32_MODE_OUTPUT_MAX_10) {
-			LL_GPIO_SetPinSpeed(gpio, pin_ll, LL_GPIO_SPEED_FREQ_MEDIUM);
+			LL_GPIO_SetPinSpeed(gpio, pin_ll,
+						     LL_GPIO_SPEED_FREQ_MEDIUM);
 		} else {
-			LL_GPIO_SetPinSpeed(gpio, pin_ll, LL_GPIO_SPEED_FREQ_HIGH);
+			LL_GPIO_SetPinSpeed(gpio, pin_ll,
+						       LL_GPIO_SPEED_FREQ_HIGH);
 		}
 	}
 #else


### PR DESCRIPTION
In #29055, GPIO registers programming order was modified in order
to avoid late glitch generation when programming pins at device
driver init.
The issue had been seen on non F1 device, but it made sense
to be applied on F1 series as well.
After test, it appears that it doesn't and initial F1 code was fine.
New code is generating glitch on I2C bus.
Revert the change for F1 series.

Additionally, enable arduino I2C on nucleo_f103rb in order to enable I2C testing on shields.
This is also interesting to test remap function


