### PR TITLE
Bluetooth: kconfig: Remove the range on BT_RX_STACK_SIZE

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -142,9 +142,6 @@ config BT_RX_STACK_SIZE
 	default 2048 if BT_MESH
 	default 2200 if BT_SETTINGS
 	default 1024
-	range 512 65536 if BT_HCI_RAW
-	range 1100 65536 if BT_MESH
-	range 1024 65536
 	help
 	  Size of the receiving thread stack. This is the context from
 	  which all event callbacks to the application occur. The


### PR DESCRIPTION
Remove the range on the setting the bluetooth BT_RX_STACK_SIZE.
This range prevents setting the RX stack size lower than 1024,
which depending on the application is too high.

The other Bluetooth threads don't have ranges set either, having the
ranges correct adds additional maintenance.
For my application the thread analyzer reported a usage of 416 bytes.
