### PR TITLE
drivers: entropy: stm32: fix RNG clock source with all MSI frequencies

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -292,4 +292,24 @@ config CLOCK_STM32_MCO2_DIV
 	help
 	  allowed values: 1, 2, 3, 4, 5
 
+choice CLOCK_STM32_CLK48_SRC
+	prompt "STM32 48 MHz Clock to USB, RNG, SDMMC Source"
+
+config CLOCK_STM32_CLK48_SRC_HSI48
+	bool "HSI48"
+	help
+	  Use HSI48 as source of CLK48
+
+config CLOCK_STM32_CLK48_SRC_PLLSAI1Q
+	bool "PLLSAI1Q"
+	help
+	  Use PLLSAI1Q (PLL48M2CLK) as source of CLK48
+
+config CLOCK_STM32_CLK48_SRC_MSI
+	bool "MSI"
+	help
+	  Use MSI as source of CLK48
+
+endchoice #CLOCK_STM32_CLK48_SRC
+
 endif # CLOCK_CONTROL_STM32_CUBE

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -363,6 +363,17 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 #if CONFIG_SOC_SERIES_STM32L4X
 static int entropy_stm32_rng_init_l4(void)
 {
+#if defined(CONFIG_CLOCK_STM32_CLK48_SRC_HSI48)
+
+	/* Use the HSI48 for the RNG */
+	LL_RCC_HSI48_Enable();
+	while (!LL_RCC_HSI48_IsReady()) {
+		/* Wait for HSI48 to become ready */
+	}
+
+	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_HSI48);
+
+#elif defined(CONFIG_CLOCK_STM32_CLK48_SRC_PLLSAI1Q)
 	/*
 	 * PLL configuration table for all possible MSI input frequencies. Parameters
 	 * are chosen to obtain a 48 MHz clock for USB FS, SDMMC and RNG. For the
@@ -426,6 +437,11 @@ static int entropy_stm32_rng_init_l4(void)
 	 */
 	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_PLLSAI1);
 
+#elif defined(CONFIG_CLOCK_STM32_CLK48_SRC_MSI)
+
+	LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_MSI);
+
+#endif /* defined(CONFIG_CLOCK_STM32_CLK48_SRC_HSI48) */
 	return 0;
 }
 #endif /* CONFIG_SOC_SERIES_STM32L4X */


### PR DESCRIPTION
Take account of all possible configured MSI frequencies when configuring
PLLSAI1 with MSI input to get the 48 MHz output clock.
If MSI input frequency is too low to obtain 48 MHz output, the highest
output frequency is chosen to be used by RNG: such solution should be
valid when USB is not used.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>