### PR TITLE
gen_defines: add _RAWSTRING suffix for non-quoted string

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -380,6 +380,24 @@
 #define DT_PROP(node_id, prop) DT_CAT(node_id, _P_##prop)
 
 /**
+ * @brief Get a string property without quotes
+ *
+ * All non-C-token characters will be converted to '_'.
+ *
+ * For example if
+ *   DT_PROP(node, label) => "Label with space"
+ * Then
+ *   DT_PROP_RAWSTRING(node, label) => Label_with_space
+ *
+ * For non-string properties, this will be undefined.
+ *
+ * @param node_id node identifier
+ * @param prop a lowercase-and-underscores string property
+ * @return the string without quotes or invalid C token characters
+ */
+#define DT_PROP_RAWSTRING(node_id, prop) DT_PROP(node_id, prop##_RAWSTRING)
+
+/**
  * @brief Get a property's logical length
  *
  * Here, "length" is a number of elements, which may differ from the

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -420,6 +420,11 @@ def write_vanilla_props(node):
             # DT_N_<node-id>_P_<prop-id>
             macro2val[macro] = val
 
+            # All string types create an extra non-quoted string with the
+            # _RAWSTRING suffix
+            if prop.type == 'string':
+                macro2val[macro + f"_RAWSTRING"] = str2c_style(prop.val)
+
         if prop.enum_index is not None:
             # DT_N_<node-id>_P_<prop-id>_ENUM_IDX
             macro2val[macro + "_ENUM_IDX"] = prop.enum_index
@@ -739,6 +744,12 @@ def quote_str(s):
     # backslashes within it
 
     return f'"{escape(s)}"'
+
+
+def str2c_style(s):
+    # Converts all non-C-token characters to '_'. Leaves others unchanged
+
+    return re.sub(r'\W', '_', s)
 
 
 def write_pickled_edt(edt, out_file):

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -102,6 +102,7 @@
 			reg = <0x0 0x1000>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			label = "Test No+Status!@#$%^&*()1";
 		};
 
 		test_nodelabel: TEST_NODELABEL_ALLCAPS: test_gpio_1: gpio@deadbeef {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -116,6 +116,14 @@ static void test_nodelabel_props(void)
 		     "compatible[0]");
 }
 
+static void test_rawstring(void)
+{
+	/* Ensure that non word characters are translated to '_' */
+	zassert_equal(TO_STRING(DT_PROP_RAWSTRING(DT_NODELABEL(test_no_status),
+						  label)),
+		      "Test_No_Status__________1", "test_no_status");
+}
+
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_gpio
 static void test_inst_props(void)
@@ -1722,6 +1730,7 @@ void test_main(void)
 			 ztest_unit_test(test_path_props),
 			 ztest_unit_test(test_alias_props),
 			 ztest_unit_test(test_nodelabel_props),
+			 ztest_unit_test(test_rawstring),
 			 ztest_unit_test(test_inst_props),
 			 ztest_unit_test(test_default_prop_access),
 			 ztest_unit_test(test_has_path),


### PR DESCRIPTION
It is useful in certain scenarios to generated C identifiers from the
labels of devices. For example, one could create an enum of gpios
from their labels in the device tree.

The existing label property is already a string (which is very useful),
but there is no good way to remove the quotes from that string.

Below is an example code snippet that can use the labelraw property:
```
#define GPIO_CONCAT(id) _CONCAT(GPIO_, DT_PROP(id, labelraw)),
enum gpio_signal {
	DT_FOREACH_CHILD(DT_PATH(named_gpios), GPIO_CONCAT)
	GPIO_COUNT
};
```