### PR TITLE
boards: Added cmsis-dap interface to openocd runner for NRF5

### DIFF
--- a/boards/arm/nrf52840_mdk/board.cmake
+++ b/boards/arm/nrf52840_mdk/board.cmake
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840")
+set(OPENOCD_NRF5_INTERFACE "cmsis-dap")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/common/openocd-nrf5.board.cmake
+++ b/boards/common/openocd-nrf5.board.cmake
@@ -15,12 +15,16 @@ if("${OPENOCD_NRF5_SUBFAMILY}" STREQUAL "")
     "To fix, set CMake variable OPENOCD_NRF5_SUBFAMILY.")
 endif()
 
+if (NOT DEFINED OPENOCD_NRF5_INTERFACE)
+  set(OPENOCD_NRF5_INTERFACE "jlink")
+endif()
+
 # We can do the right thing for supported subfamilies using a generic
 # script, at least for openocd 0.10.0 and the openocd shipped with
 # Zephyr SDK 0.10.3.
 set(pre_init_cmds
   "set WORKAREASIZE 0x4000"	# 16 kB RAM used for flashing
-  "source [find interface/jlink.cfg]"
+  "source [find interface/${OPENOCD_NRF5_INTERFACE}.cfg]"
   "transport select swd"
   "source [find target/${OPENOCD_NRF5_SUBFAMILY}.cfg]"
   "$_TARGETNAME configure -rtos auto"


### PR DESCRIPTION
Added openocd runner with cmsis-dap interface.
Apply to nrf52840_mdk board.

Signed-off-by: Stephane D'Alu <sdalu@sdalu.com>