### PR TITLE
ci: github: reduce when we do doc builds

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -3,7 +3,16 @@
 
 name: Documentation GitHub Workflow
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+    - 'doc/**'
+    - '**.rst'
+    - 'include/**'
+    - 'kernel/include/kernel_arch_interface.h'
+    - 'lib/libc/**'
+    - 'subsys/testsuite/ztest/include/**'
+    - 'tests/**'
 
 jobs:
   build:

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -140,6 +140,8 @@ add_custom_target(
 
 # For incremental builds not to miss any source change this MUST be kept
 # a superset of INPUT= and FILE_PATTERNS= in zephyr.doxyfile.in
+#
+# NOTE: any changes here should be reflected in .github/workflows/doc-build.yml
 file(GLOB_RECURSE  DOXY_SOURCES
   ${ZEPHYR_BASE}/include/*.[c,h,S]
   ${ZEPHYR_BASE}/kernel/include/kernel_arch_interface.h


### PR DESCRIPTION
Rather than doing a doc build on every PR, limit it to PRs that either
touch a file in doc/, include/ or *.rst.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>