### PR TITLE
samples: lorawan: class_a: fix selection of activation type

### DIFF
--- a/samples/lorawan/class_a/src/main.c
+++ b/samples/lorawan/class_a/src/main.c
@@ -53,7 +53,7 @@ void main(void)
 		return;
 	}
 
-	join_cfg.mode = LORAWAN_CLASS_A;
+	join_cfg.mode = LORAWAN_ACT_OTAA;
 	join_cfg.dev_eui = dev_eui;
 	join_cfg.otaa.join_eui = join_eui;
 	join_cfg.otaa.app_key = app_key;


### PR DESCRIPTION
LORAWAN_ACT_* should be assigned instead of LORAWAN_CLASS_*. Previously
used LORAWAN_CLASS_A has the same integer value as LORAWAN_ACT_OTAA, but
update code with the latter to use the proper type.