### PR TITLE
drivers: pwm: stm32: fix timer clock calculation

### DIFF
--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -7,6 +7,7 @@ config PWM_STM32
 	bool "STM32 MCU PWM driver"
 	depends on SOC_FAMILY_STM32
 	select USE_STM32_LL_TIM
+	select USE_STM32_LL_RCC if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 	help
 	  This option enables the PWM driver for STM32 family of
 	  processors. Say y if you wish to use PWM port on STM32


### PR DESCRIPTION
Calculation of the timer clock was wrong for some F4/F7/H7 series.

NOTE: I tried to create a common code covering all series having TIMPRE. I hope provided documentation helps to clarify how is timer clock calculated.

Tested changes on NUCLEO-H743ZI.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>