### PR TITLE
test:schedule_api: add ram filter

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -3,7 +3,9 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
     tags: kernel security userspace ignore_faults
+    min_ram: 36
   kernel.memory_protection.gap_filling:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     extra_args: CONFIG_MPU_GAP_FILLING=y
     tags: kernel security userspace ignore_faults
+    min_ram: 36

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -4,18 +4,22 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=y
     tags: kernel threads sched userspace
+    min_ram: 36
   kernel.scheduler.no_timeslicing:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=n
     tags: kernel threads sched userspace
+    min_ram: 36
   kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
     tags: kernel threads sched userspace
+    min_ram: 36
   kernel.scheduler.multiq_no_timeslicing:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=n
     tags: kernel threads sched userspace
+    min_ram: 36

--- a/tests/kernel/workq/work_queue_api/testcase.yaml
+++ b/tests/kernel/workq/work_queue_api/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.workqueue.api:
     min_flash: 34
+    min_ram: 34
     tags: kernel userspace


### PR DESCRIPTION
the min_ram is about: 33KBytes and set to 36KBytes

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>