### PR TITLE
FS: Add missing ingroup tag to fs_interface.h and note on ELM FAT limitations regarding mount points

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -392,6 +392,10 @@ int fs_closedir(struct fs_dir_t *zdp);
  * calling the file system specific mount function and adding
  * the mount point to mounted file system list.
  *
+ * @note Current implementation of ELM FAT driver allows only following mount
+ * points: "/RAM:","/NAND:","/CF:","/SD:","/SD2:","/USB:","/USB2:","/USB3:"
+ * or mount points that consist of single digit, e.g: "/0:", "/1:" and so forth.
+ *
  * @param mp Pointer to the fs_mount_t structure.  Referenced object
  *	     is not changed if the mount operation failed.
  *	     A reference is captured in the fs infrastructure if the

--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -31,10 +31,16 @@ extern "C" {
 #endif /* filesystem selection */
 #endif /* CONFIG_FILE_SYSTEM_MAX_FILE_NAME */
 
+
 /* Type for fs_open flags */
 typedef uint8_t fs_mode_t;
 
 struct fs_mount_t;
+
+/**
+ * @addtogroup file_system_api
+ * @{
+ */
 
 /**
  * @brief File object representing an open file
@@ -58,6 +64,10 @@ struct fs_dir_t {
 	void *dirp;
 	const struct fs_mount_t *mp;
 };
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The PR consists of two commits that:
 - add `ingroup file_system_api` doxygen tag to `fs_interface.h`
 - add note on limitations of ELM FAT file system driver regarding allowed mount points.
