### PR TITLE
bluetooth: host: Fix endianness issue in bt_uuid_to_str

### DIFF
--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -119,7 +119,9 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		memcpy(&tmp5, &BT_UUID_128(uuid)->val[12], sizeof(tmp5));
 
 		snprintk(str, len, "%08x-%04x-%04x-%04x-%08x%04x",
-			 tmp5, tmp4, tmp3, tmp2, tmp1, tmp0);
+			 sys_le32_to_cpu(tmp5), sys_le16_to_cpu(tmp4),
+			 sys_le16_to_cpu(tmp3), sys_le16_to_cpu(tmp2),
+			 sys_le32_to_cpu(tmp1), sys_le16_to_cpu(tmp0));
 		break;
 	default:
 		(void)memset(str, 0, len);


### PR DESCRIPTION
This commit makes sure the string generated by bt_uuid_to_str is correct
if the architecture is big-endian.

Signed-off-by: François Delawarde <fnde@demant.com>