### PR TITLE
Fix access to already unref'ed packet data

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -298,7 +298,10 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	switch (hdr->proto) {
 	case IPPROTO_ICMP:
 		verdict = net_icmpv4_input(pkt, hdr);
-		break;
+		if (verdict == NET_DROP) {
+			goto drop;
+		}
+		return verdict;
 	case IPPROTO_TCP:
 		proto_hdr.tcp = net_tcp_input(pkt, &tcp_access);
 		if (proto_hdr.tcp) {
@@ -315,8 +318,6 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 
 	if (verdict == NET_DROP) {
 		goto drop;
-	} else if (hdr->proto == IPPROTO_ICMP) {
-		return verdict;
 	}
 
 	ip.ipv4 = hdr;


### PR DESCRIPTION
This fixes an access to the header of an already freed packet. This may cause a crash if a system is under heavy ICMP traffic and has to do TCP at the same time.

The crash can be reproduced with the `samples/net/sockets/echo_server` example. "Flood ping" the system in question with `sudo ping -f <ip>` while accessing the echo server in a different window (`telnet <ip> 4242`). At some point the system will crash.