### PR TITLE
fs: introduce FS_O_TRUNC fs_open flag

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -188,7 +188,8 @@ struct fs_file_system_t {
 
 #define FS_O_CREATE     0x10
 #define FS_O_APPEND     0x20
-#define FS_O_FLAGS_MASK 0x30
+#define FS_O_TRUNC      0x40
+#define FS_O_FLAGS_MASK 0x70
 
 #define FS_O_MASK       (FS_O_MODE_MASK | FS_O_FLAGS_MASK)
 
@@ -214,6 +215,7 @@ struct fs_file_system_t {
  *   - @c FS_O_WRITE open for write
  *   - @c FS_O_RDWR open for read/write (<tt>FS_O_READ | FS_O_WRITE</tt>)
  *   - @c FS_O_CREATE create file if it does not exist
+ *   - @c FS_O_TRUNC file is truncated to length zero
  *   - @c FS_O_APPEND move to end of file before each write
  *
  * If @p flags are set to 0 the function will attempt to open an existing file

--- a/lib/libc/minimal/include/fcntl.h
+++ b/lib/libc/minimal/include/fcntl.h
@@ -10,6 +10,7 @@
 #define O_CREAT    0x0200
 #define O_APPEND   0x0400
 #define O_EXCL     0x0800
+#define O_TRUNC    0x1000
 #define O_NONBLOCK 0x4000
 
 #define F_DUPFD 0

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -62,6 +62,7 @@ static int posix_mode_to_zephyr(int mf)
 	int mode = (mf & O_CREAT) ? FS_O_CREATE : 0;
 
 	mode |= (mf & O_APPEND) ? FS_O_APPEND : 0;
+	mode |= (mf & O_TRUNC) ? FS_O_TRUNC : 0;
 
 	switch (mf & O_ACCMODE) {
 	case O_RDONLY:

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -70,6 +70,8 @@ static uint8_t translate_flags(fs_mode_t flags)
 	fat_mode |= (flags & FS_O_READ) ? FA_READ : 0;
 	fat_mode |= (flags & FS_O_WRITE) ? FA_WRITE : 0;
 	fat_mode |= (flags & FS_O_CREATE) ? FA_OPEN_ALWAYS : 0;
+	fat_mode |= ((flags & (FS_O_CREATE | FS_O_TRUNC)) ==
+		(FS_O_CREATE | FS_O_TRUNC)) ? FA_CREATE_ALWAYS : 0;
 	/* NOTE: FA_APPEND is not translated because FAT FS does not
 	 * support append semantics of the Zephyr, where file position
 	 * is forwarded to the end before each write, the fatfs_write

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -192,6 +192,7 @@ static int lfs_flags_from_zephyr(unsigned int zflags)
 	flags |= (zflags & FS_O_WRITE) ? LFS_O_WRONLY : 0;
 
 	flags |= (zflags & FS_O_APPEND) ? LFS_O_APPEND : 0;
+	flags |= (zflags & FS_O_TRUNC) ? LFS_O_TRUNC : 0;
 
 	return flags;
 }


### PR DESCRIPTION
Let's add LFS_O_TRUNC has a supported flag for fs_open.
=> aligned with the open() usage
=> most FS already support a similar translation of this flag
=> provide a proper support for fopen("path", "w") which is a common pattern to create fresh file when using posix API