### PR TITLE
net: lib: sockets: added ALPN extension option to TLS

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -119,6 +119,12 @@ struct zsock_pollfd {
  *    - 1 - server
  */
 #define TLS_DTLS_ROLE 6
+/** Socket option for setting the supported Application Layer Protocols.
+ *  It accepts and returns a const char array of NULL terminated strings
+ *  representing the supported application layer protocols listed during
+ *  the TLS handshake.
+ */
+#define TLS_ALPN_LIST 7
 
 /** @} */
 

--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -37,6 +37,10 @@ config MBEDTLS_SSL_EXPORT_KEYS
 	bool "Enable support for exporting SSL key block and master secret"
 	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
+config MBEDTLS_SSL_ALPN
+	bool "Enable support for setting the supported Application Layer Protocols"
+	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
+
 endmenu
 
 menu "Ciphersuite configuration"

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -100,6 +100,15 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
 	  By default, all ciphersuites that are available in the system are
 	  available to the socket.
 
+config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
+	int "Maximum number of supported application layer protocols"
+	default 2
+	depends on NET_SOCKETS_SOCKOPT_TLS && MBEDTLS_SSL_ALPN
+	help
+	  This variable sets maximum number of supported application layer
+	  protocols over TLS/DTL that can be set explicitly by a socket option.
+	  By default, no supported application layer protocol is set.
+
 config NET_SOCKETS_OFFLOAD
 	bool "Offload Socket APIs [EXPERIMENTAL]"
 	help


### PR DESCRIPTION
Adds the socket option TLS_ALPN_LIST for SOL_TLS sockets

Passes the configured alpn list to the mbedtls config
on mbedtls init

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>

edit: related https://github.com/zephyrproject-rtos/mbedtls/pull/16