### PR TITLE
driver: gpio: proper Kconfig shell dependency

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -17,6 +17,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config GPIO_SHELL
 	bool "Enable GPIO Shell"
+	depends on SHELL
 	help
 	  Enable GPIO Shell for testing.
 


### PR DESCRIPTION
make gpio shell depend on main shell to prevent misconfigurations