### PR TITLE
PM - Get rid of some weak functions

### DIFF
--- a/include/power/pm_policy.h
+++ b/include/power/pm_policy.h
@@ -8,16 +8,56 @@
 #define ZEPHYR_INCLUDE_POWER_PM_POLICY_H_
 
 #include <power/power.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief Function to get the next PM state based on the ticks
+ * @brief PM Policy definition
+ *
+ * Store information about a power management policy.
  */
-struct pm_state_info pm_policy_next_state(int32_t ticks);
+struct pm_policy {
+	int (*next_state_get)(struct pm_policy *policy,
+			      int32_t ticks, struct pm_state_info *info);
+};
 
+/**
+ * @brief Statically define and register a power management policy
+ *
+ * @param policy_name The name of this policy
+ * @param policy_next_state_get Callback to get the next PM state
+ */
+#define PM_POLICY_DEFINE(policy_name, policy_next_state_get)		\
+	static const struct pm_policy policy_name = {			\
+		.next_state_get = policy_next_state_get,		\
+	};								\
+	const struct pm_policy *z_sys_pm_policy = &policy_name
+
+/**
+ * @brief Function to get the next PM state based on the ticks
+ *
+ * @return
+ *   - 0 in case of success
+ *   - -ENOTSUP if there is no policy or the policy does not support
+ *              next-state capability
+ *   - A negative value indicating a specific failure
+ */
+static inline int pm_policy_next_state(int32_t ticks,
+				       struct pm_state_info *info)
+{
+	extern const struct pm_policy *z_sys_pm_policy;
+
+	if ((z_sys_pm_policy) == NULL ||
+	    (z_sys_pm_policy->next_state_get == NULL)) {
+		return -ENOTSUP;
+	}
+
+	return z_sys_pm_policy->next_state_get(
+		(struct pm_policy *)z_sys_pm_policy, ticks, info);
+}
 
 #ifdef __cplusplus
 }

--- a/include/power/pm_policy.h
+++ b/include/power/pm_policy.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _PM_POLICY_H_
-#define _PM_POLICY_H_
+#ifndef ZEPHYR_INCLUDE_POWER_PM_POLICY_H_
+#define ZEPHYR_INCLUDE_POWER_PM_POLICY_H_
 
 #include <power/power.h>
 
@@ -23,4 +23,4 @@ struct pm_state_info pm_policy_next_state(int32_t ticks);
 }
 #endif
 
-#endif /* _PM_POLICY_H_ */
+#endif /* ZEPHYR_INCLUDE_POWER_PM_POLICY_H_ */

--- a/include/power/power.h
+++ b/include/power/power.h
@@ -182,6 +182,31 @@ void pm_notifier_register(struct pm_notifier *notifier);
 int pm_notifier_unregister(struct pm_notifier *notifier);
 
 /**
+ * @brief Function to create device PM list
+ */
+void pm_create_device_list(void);
+
+/**
+ * @brief Function to suspend the devices in PM device list
+ */
+int pm_suspend_devices(void);
+
+/**
+ * @brief Function to put the devices in PM device list in low power state
+ */
+int pm_low_power_devices(void);
+
+/**
+ * @brief Function to force suspend the devices in PM device list
+ */
+int pm_force_suspend_devices(void);
+
+/**
+ * @brief Function to resume the devices in PM device list
+ */
+void pm_resume_devices(void);
+
+/**
  * @}
  */
 

--- a/include/power/power.h
+++ b/include/power/power.h
@@ -10,6 +10,7 @@
 #include <zephyr/types.h>
 #include <sys/slist.h>
 #include <power/power_state.h>
+#include <power/pm_policy.h>
 #include <toolchain.h>
 #include <stdbool.h>
 

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -8,7 +8,7 @@
 #include <kernel.h>
 #include <string.h>
 #include <device.h>
-#include "policy/pm_policy.h"
+#include <power/pm_policy.h>
 
 #if defined(CONFIG_PM)
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */

--- a/subsys/power/pm_ctrl.c
+++ b/subsys/power/pm_ctrl.c
@@ -9,7 +9,7 @@
 #include <device.h>
 #include <sys/atomic.h>
 #include <power/power_state.h>
-#include "policy/pm_policy.h"
+#include <power/pm_policy.h>
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -14,31 +14,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Function to create device PM list
- */
-void pm_create_device_list(void);
-
-/**
- * @brief Function to suspend the devices in PM device list
- */
-int pm_suspend_devices(void);
-
-/**
- * @brief Function to put the devices in PM device list in low power state
- */
-int pm_low_power_devices(void);
-
-/**
- * @brief Function to force suspend the devices in PM device list
- */
-int pm_force_suspend_devices(void);
-
-/**
- * @brief Function to resume the devices in PM device list
- */
-void pm_resume_devices(void);
-
-/**
  * @brief Function to get the next PM state based on the ticks
  */
 struct pm_state_info pm_policy_next_state(int32_t ticks);

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <power/power.h>
 #include <power/power_state.h>
-#include "policy/pm_policy.h"
+#include <power/pm_policy.h>
 
 #define PM_STATES_LEN (1 + PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -147,7 +147,13 @@ static enum pm_state _handle_device_abort(struct pm_state_info info)
 
 enum pm_state pm_system_suspend(int32_t ticks)
 {
-	z_power_state = pm_policy_next_state(ticks);
+	int ret = pm_policy_next_state(ticks, &z_power_state);
+
+	if (ret < 0) {
+		z_power_state.state = PM_STATE_ACTIVE;
+		LOG_WRN("pm_policy_next_state returned: %d\n", ret);
+	}
+
 	if (z_power_state.state == PM_STATE_ACTIVE) {
 		LOG_DBG("No PM operations done.");
 		return z_power_state.state;

--- a/tests/subsys/power/power_mgmt/src/main.c
+++ b/tests/subsys/power/power_mgmt/src/main.c
@@ -60,9 +60,14 @@ __weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 }
 
 /* Our PM policy handler */
-struct pm_state_info pm_policy_next_state(int ticks)
+static int test_pm_policy_next_state(struct pm_policy *policy,
+			     int ticks, struct pm_state_info *info)
 {
-	struct pm_state_info info = {};
+	ARG_UNUSED(policy);
+
+	if (info == NULL) {
+		return -EINVAL;
+	}
 
 	/* make sure this is idle thread */
 	zassert_true(z_is_idle_thread_object(_current), NULL);
@@ -72,17 +77,19 @@ struct pm_state_info pm_policy_next_state(int ticks)
 	if (enter_low_power) {
 		enter_low_power = false;
 		notify_app_entry = true;
-		info.state = PM_STATE_RUNTIME_IDLE;
+		info->state = PM_STATE_RUNTIME_IDLE;
 	} else {
 		/* only test pm_policy_next_state()
 		 * no PM operation done
 		 */
-		info.state = PM_STATE_ACTIVE;
+		info->state = PM_STATE_ACTIVE;
 	}
-	return info;
+	return 0;
 }
 
-/* implement in application, called by idle thread */
+PM_POLICY_DEFINE(test_policy, test_pm_policy_next_state);
+
+/* implement in application, callted by idle thread */
 static void notify_pm_state_entry(enum pm_state state)
 {
 	uint32_t device_power_state;


### PR DESCRIPTION
This pr changes how pm policies and notifications are done. Instead of using weak functions that can be override by the application this pr defines new types and APIs for that. I kept the same behavior and name conventions for now, the idea is to do incremental steps. Currently I took slightly different approaches between the notification and policy API. For the policy, the API allows application to extend the basic policy, that is a little bit different from what we have being done so, any feedback is welcome here.

The next step, is to define a better name convention for power management, organize headers, power states, ... (ensure that points agreed in https://github.com/zephyrproject-rtos/zephyr/pull/27315 are addressed)