### PR TITLE
soc: arm: Enable mcux flexcan driver on i.mx rt socs

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -11,6 +11,10 @@ config SOC_SERIES
 config ROM_START_OFFSET
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
+config CAN_MCUX_FLEXCAN
+	default y if HAS_MCUX_FLEXCAN
+	depends on CAN
+
 config CLOCK_CONTROL_MCUX_CCM
 	default y if HAS_MCUX_CCM
 	depends on CLOCK_CONTROL

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: 83e5a13640417a2efb26a31f88b232e4dac31fb2
+      revision: a84cb7fecd88767849f6e3e37b5b91a87662bf40
       path: modules/hal/nxp
     - name: open-amp
       revision: 724f7e2a4519d7e1d40ef330042682dea950c991


### PR DESCRIPTION
Enables the mcux flexcan driver on i.mx rt socs by default when
CONFIG_CAN=y.

This fixes a runtime failure in tests/subsys/canbus/isotp/conformance on
the mimxrt1064_evk board:

Assertion failed at WEST_TOPDIR/zephyr/tests/subsys/canbus/isotp/conformance/src/main.c:883: test_main: (can_dev is NULL)
    CAN device not not found

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Depends on zephyrproject-rtos/hal_nxp#62
Fixes #29146