### PR TITLE
kernel: sched: Use k_ticks_t in z_tick_sleep

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1240,7 +1240,7 @@ static inline void z_vrfy_k_yield(void)
 static int32_t z_tick_sleep(k_ticks_t ticks)
 {
 #ifdef CONFIG_MULTITHREADING
-	uint32_t expected_wakeup_time;
+	uint32_t expected_wakeup_ticks;
 
 	__ASSERT(!arch_is_in_isr(), "");
 
@@ -1266,7 +1266,7 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 	timeout = Z_TIMEOUT_TICKS(ticks);
 #endif
 
-	expected_wakeup_time = ticks + z_tick_get_32();
+	expected_wakeup_ticks = ticks + z_tick_get_32();
 
 	k_spinlock_key_t key = k_spin_lock(&sched_spinlock);
 
@@ -1281,7 +1281,7 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 
 	__ASSERT(!z_is_thread_state_set(_current, _THREAD_SUSPENDED), "");
 
-	ticks = (k_ticks_t)expected_wakeup_time - z_tick_get_32();
+	ticks = (k_ticks_t)expected_wakeup_ticks - z_tick_get_32();
 	if (ticks > 0) {
 		return ticks;
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1237,14 +1237,19 @@ static inline void z_vrfy_k_yield(void)
 #include <syscalls/k_yield_mrsh.c>
 #endif
 
-static int32_t z_tick_sleep(int32_t ticks)
+static int32_t z_tick_sleep(k_ticks_t ticks)
 {
 #ifdef CONFIG_MULTITHREADING
 	uint32_t expected_wakeup_time;
 
 	__ASSERT(!arch_is_in_isr(), "");
 
-	LOG_DBG("thread %p for %d ticks", _current, ticks);
+#ifndef CONFIG_TIMEOUT_64BIT
+	/* LOG subsys does not handle 64-bit values
+	 * https://github.com/zephyrproject-rtos/zephyr/issues/26246
+	 */
+	LOG_DBG("thread %p for %u ticks", _current, ticks);
+#endif
 
 	/* wait of 0 ms is treated as a 'yield' */
 	if (ticks == 0) {
@@ -1258,7 +1263,7 @@ static int32_t z_tick_sleep(int32_t ticks)
 	timeout = Z_TIMEOUT_TICKS(ticks);
 #else
 	ticks += _TICK_ALIGN;
-	timeout = (k_ticks_t) ticks;
+	timeout = Z_TIMEOUT_TICKS(ticks);
 #endif
 
 	expected_wakeup_time = ticks + z_tick_get_32();
@@ -1276,7 +1281,7 @@ static int32_t z_tick_sleep(int32_t ticks)
 
 	__ASSERT(!z_is_thread_state_set(_current, _THREAD_SUSPENDED), "");
 
-	ticks = expected_wakeup_time - z_tick_get_32();
+	ticks = (k_ticks_t)expected_wakeup_time - z_tick_get_32();
 	if (ticks > 0) {
 		return ticks;
 	}


### PR DESCRIPTION
z_tick_sleep was using int32_t what could cause a possible overflow
when converting from k_ticks_t.

Fixes #29066 
