### PR TITLE
arch: arm64: mmu: Restore SRAM region

### DIFF
--- a/arch/arm/core/aarch64/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch64/mmu/arm_mmu.c
@@ -261,6 +261,21 @@ static void init_xlat_tables(const struct arm_mmu_region *region)
 /* zephyr execution regions with appropriate attributes */
 static const struct arm_mmu_region mmu_zephyr_regions[] = {
 
+	/* Mark the whole SRAM as read-write */
+	MMU_REGION_FLAT_ENTRY("SRAM",
+			      (uintptr_t)CONFIG_SRAM_BASE_ADDRESS,
+			      (uintptr_t)KB(CONFIG_SRAM_SIZE),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
+
+	/* Mark rest of the zephyr execution regions (data, bss, noinit, etc.)
+	 * cacheable, read-write
+	 * Note: read-write region is marked execute-ever internally
+	 */
+	MMU_REGION_FLAT_ENTRY("zephyr_data",
+			      (uintptr_t)__kernel_ram_start,
+			      (uintptr_t)__kernel_ram_size,
+			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
+
 	/* Mark text segment cacheable,read only and executable */
 	MMU_REGION_FLAT_ENTRY("zephyr_code",
 			      (uintptr_t)_image_text_start,
@@ -272,15 +287,6 @@ static const struct arm_mmu_region mmu_zephyr_regions[] = {
 			      (uintptr_t)_image_rodata_start,
 			      (uintptr_t)_image_rodata_size,
 			      MT_NORMAL | MT_P_RO_U_NA | MT_SECURE),
-
-	/* Mark rest of the zephyr execution regions (data, bss, noinit, etc.)
-	 * cacheable, read-write
-	 * Note: read-write region is marked execute-ever internally
-	 */
-	MMU_REGION_FLAT_ENTRY("zephyr_data",
-			      (uintptr_t)__kernel_ram_start,
-			      (uintptr_t)__kernel_ram_size,
-			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
 };
 
 static void setup_page_tables(void)


### PR DESCRIPTION
In a5f34d85c2e3 ("soc: arm: qemu_cortex_a53: Remove SRAM region") the
SRAM memory region was removed.

While this is correct when userspace is not enabled, when userspace is
enabled new regions are introduced outside the boundaries of
the mapped [__kernel_ram_start,__kernel_ram_end] region. This means that
we need to map again the whole SRAM to include all the needed regions.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>