### PR TITLE
drivers: pwm: stm32: fix timer instance access

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -453,8 +453,8 @@ static int pwm_stm32_init(const struct device *dev)
 
 #define DT_INST_CLK(index, inst)                                               \
 	{                                                                      \
-		.bus = DT_CLOCKS_CELL(DT_INST(index, st_stm32_timers), bus),   \
-		.enr = DT_CLOCKS_CELL(DT_INST(index, st_stm32_timers), bits)   \
+		.bus = DT_CLOCKS_CELL(DT_PARENT(DT_DRV_INST(index)), bus),     \
+		.enr = DT_CLOCKS_CELL(DT_PARENT(DT_DRV_INST(index)), bits)     \
 	}
 
 #define PWM_DEVICE_INIT(index)                                                 \
@@ -465,7 +465,7 @@ static int pwm_stm32_init(const struct device *dev)
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(                           \
-			DT_INST(index, st_stm32_timers)),                      \
+			DT_PARENT(DT_DRV_INST(index))),                        \
 		.prescaler = DT_INST_PROP(index, st_prescaler),                \
 		.pclken = DT_INST_CLK(index, timer),                           \
 		.pinctrl = pwm_pins_##index,                                   \


### PR DESCRIPTION
The parameters of the associated PWM timer were not being picked up
properly, as it was assumed that parent index is the same as the child
index. This is not necessarily true if other timer nodes are active and
not being used for PWM.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>