### PR TITLE
net: context: Release lock before passing RX data to socket

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1786,13 +1786,17 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 					  net_pkt_remaining_data(pkt));
 	}
 
-	context->recv_cb(context, pkt, ip_hdr, proto_hdr, 0, user_data);
-
 #if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
 	k_sem_give(&context->recv_data_wait);
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
+	k_mutex_unlock(&context->lock);
+
+	context->recv_cb(context, pkt, ip_hdr, proto_hdr, 0, user_data);
+
 	verdict = NET_OK;
+
+	return verdict;
 
 unlock:
 	k_mutex_unlock(&context->lock);

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -191,6 +191,7 @@ struct tcp { /* TCP connection */
 	};
 	struct k_mutex lock;
 	struct k_sem connect_sem; /* semaphore for blocking connect */
+	struct k_fifo recv_data;  /* temp queue before passing data to app */
 	struct tcp_options recv_options;
 	struct k_delayed_work send_timer;
 	struct k_delayed_work send_data_timer;


### PR DESCRIPTION
Release the context lock before passing data to the application
socket as that might cause deadlock if the application is run
before the RX thread and it starts to send data and if the RX
thread is never able to run (because of priorities etc).

Fixes #29347

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>