### PR TITLE
openthread: add openthread_api_mutex_try_lock()

### DIFF
--- a/include/net/openthread.h
+++ b/include/net/openthread.h
@@ -119,6 +119,19 @@ int openthread_start(struct openthread_context *ot_context);
 void openthread_api_mutex_lock(struct openthread_context *ot_context);
 
 /**
+ * @brief Try to lock internal mutex before accessing OT API.
+ *
+ * @details This function behaves like openthread_api_mutex_lock() provided that
+ * the internal mutex is unlocked. Otherwise, it exists immediately and returns
+ * a negative value.
+ *
+ * @param ot_context Context to lock.
+ * @retval 0  On success.
+ * @retval <0 On failure.
+ */
+int openthread_api_mutex_try_lock(struct openthread_context *ot_context);
+
+/**
  * @brief Unlock internal mutex after accessing OT API.
  *
  * @param ot_context Context to unlock.

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -531,6 +531,11 @@ void openthread_api_mutex_lock(struct openthread_context *ot_context)
 	(void)k_mutex_lock(&ot_context->api_lock, K_FOREVER);
 }
 
+int openthread_api_mutex_try_lock(struct openthread_context *ot_context)
+{
+	return k_mutex_lock(&ot_context->api_lock, K_NO_WAIT);
+}
+
 void openthread_api_mutex_unlock(struct openthread_context *ot_context)
 {
 	(void)k_mutex_unlock(&ot_context->api_lock);


### PR DESCRIPTION
Existing openthread_api_mutex_lock()/unlock() functions are
crucial to assure thread safety of an application which
needs to use OT API directly, but some applications may also
require a non-blocking version of the former for less critical
OT-related tasks.

Add openthread_api_mutex_try_lock() which never waits and
exits immediately if the mutex is held by another thread.

The change is actually inspired by Connected Home over IP 
project which defines TryLockThreadStack() method in its 
platform layer: 
https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/ThreadStackManager.h

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>