### PR TITLE
lorawan: Add application-defined battery level callback API

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -100,6 +100,24 @@ struct lorawan_join_config {
 };
 
 /**
+ * @brief Add battery level callback function.
+ *
+ * Provide the LoRaWAN stack with a function to be called whenever a battery
+ * level needs to be read. As per LoRaWAN specification the callback needs to
+ * return "0:      node is connected to an external power source,
+ *         1..254: battery level, where 1 is the minimum and 254 is the maximum
+ *                 value,
+ *         255: the node was not able to measure the battery level"
+ *
+ * Should no callback be provided the lorawan backend will report 255.
+ *
+ * @param battery_lvl_cb Pointer to the battery level function
+ *
+ * @return 0 if successful, negative errno code if failure
+ */
+int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
+
+/**
  * @brief Join the LoRaWAN network
  *
  * Join the LoRaWAN network using OTAA or AWB.

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -67,6 +67,17 @@ static LoRaMacEventInfoStatus_t last_mlme_confirm_status;
 static LoRaMacEventInfoStatus_t last_mcps_indication_status;
 static LoRaMacEventInfoStatus_t last_mlme_indication_status;
 
+static uint8_t (*getBatteryLevelUser)(void);
+
+static uint8_t getBatteryLevelLocal(void)
+{
+	if (getBatteryLevelUser != NULL) {
+		return getBatteryLevelUser();
+	}
+
+	return 255;
+}
+
 static void OnMacProcessNotify(void)
 {
 	LoRaMacProcess();
@@ -407,6 +418,17 @@ out:
 	return ret;
 }
 
+int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void))
+{
+	if (battery_lvl_cb == NULL) {
+		return -EINVAL;
+	}
+
+	getBatteryLevelUser = battery_lvl_cb;
+
+	return 0;
+}
+
 int lorawan_start(void)
 {
 	LoRaMacStatus_t status;
@@ -439,7 +461,7 @@ static int lorawan_init(const struct device *dev)
 	macPrimitives.MacMcpsIndication = McpsIndication;
 	macPrimitives.MacMlmeConfirm = MlmeConfirm;
 	macPrimitives.MacMlmeIndication = MlmeIndication;
-	macCallbacks.GetBatteryLevel = NULL;
+	macCallbacks.GetBatteryLevel = getBatteryLevelLocal;
 	macCallbacks.GetTemperatureLevel = NULL;
 	macCallbacks.NvmContextChange = NULL;
 	macCallbacks.MacProcessNotify = OnMacProcessNotify;


### PR DESCRIPTION
Provides the LoRaWAN stack with an optional callback to be
called whenever the battery level needs to be read.

In the case of callback not being provided, the LoRaWAN
stack will report 255 (battery level unavailable) as per
the LoRaWAN spec.

Signed-off-by: Kuba Sanak <contact@kuba.fyi>