### PR TITLE
drivers: uart_nrfx_uart: Replace k_delayed_work with k_timer

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -76,7 +76,7 @@ static struct {
 	volatile size_t rx_counter;
 	volatile size_t rx_offset;
 	int32_t rx_timeout;
-	struct k_delayed_work rx_timeout_work;
+	struct k_timer rx_timeout_timer;
 	bool rx_enabled;
 
 	bool tx_abort;
@@ -85,7 +85,7 @@ static struct {
 	volatile size_t tx_counter;
 #if HW_FLOW_CONTROL_AVAILABLE
 	int32_t tx_timeout;
-	struct k_delayed_work tx_timeout_work;
+	struct k_timer tx_timeout_timer;
 #endif
 } uart0_cb;
 #endif /* CONFIG_UART_0_ASYNC */
@@ -446,7 +446,7 @@ static int uart_nrfx_tx_abort(const struct device *dev)
 	}
 #if	HW_FLOW_CONTROL_AVAILABLE
 	if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
-		k_delayed_work_cancel(&uart0_cb.tx_timeout_work);
+		k_timer_stop(&uart0_cb.tx_timeout_timer);
 	}
 #endif
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPTX);
@@ -525,7 +525,7 @@ static int uart_nrfx_rx_disable(const struct device *dev)
 
 	uart0_cb.rx_enabled = 0;
 	if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
-		k_delayed_work_cancel(&uart0_cb.rx_timeout_work);
+		k_timer_stop(&uart0_cb.rx_timeout_timer);
 	}
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPRX);
 
@@ -597,14 +597,15 @@ static void rx_isr(const struct device *dev)
 		if (uart0_cb.rx_timeout == 0) {
 			rx_rdy_evt(dev);
 		} else if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
-			k_delayed_work_submit(&uart0_cb.rx_timeout_work,
-					      K_MSEC(uart0_cb.rx_timeout));
+			k_timer_start(&uart0_cb.rx_timeout_timer,
+				      K_MSEC(uart0_cb.rx_timeout),
+				      K_NO_WAIT);
 		}
 	}
 
 	if (uart0_cb.rx_buffer_length == uart0_cb.rx_counter) {
 		if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
-			k_delayed_work_cancel(&uart0_cb.rx_timeout_work);
+			k_timer_stop(&uart0_cb.rx_timeout_timer);
 		}
 		rx_rdy_evt(dev);
 
@@ -640,8 +641,9 @@ static void tx_isr(const struct device *dev)
 	    !uart0_cb.tx_abort) {
 #if	HW_FLOW_CONTROL_AVAILABLE
 		if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
-			k_delayed_work_submit(&uart0_cb.tx_timeout_work,
-					      K_MSEC(uart0_cb.tx_timeout));
+			k_timer_start(&uart0_cb.tx_timeout_timer,
+				      K_MSEC(uart0_cb.tx_timeout),
+				      K_NO_WAIT);
 		}
 #endif
 		nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_TXDRDY);
@@ -653,7 +655,7 @@ static void tx_isr(const struct device *dev)
 #if	HW_FLOW_CONTROL_AVAILABLE
 
 		if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
-			k_delayed_work_cancel(&uart0_cb.tx_timeout_work);
+			k_timer_stop(&uart0_cb.tx_timeout_timer);
 		}
 #endif
 		nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPTX);
@@ -682,7 +684,7 @@ static void tx_isr(const struct device *dev)
 static void error_isr(const struct device *dev)
 {
 	if (uart0_cb.rx_timeout != SYS_FOREVER_MS) {
-		k_delayed_work_cancel(&uart0_cb.rx_timeout_work);
+		k_timer_stop(&uart0_cb.rx_timeout_timer);
 	}
 	nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_ERROR);
 
@@ -751,18 +753,18 @@ void uart_nrfx_isr(const struct device *uart)
 	}
 }
 
-static void rx_timeout(struct k_work *work)
+static void rx_timeout(struct k_timer *timer)
 {
 	rx_rdy_evt(DEVICE_GET(uart_nrfx_uart0));
 }
 
 #if HW_FLOW_CONTROL_AVAILABLE
-static void tx_timeout(struct k_work *work)
+static void tx_timeout(struct k_timer *timer)
 {
 	struct uart_event evt;
 
 	if (uart0_cb.tx_timeout != SYS_FOREVER_MS) {
-		k_delayed_work_cancel(&uart0_cb.tx_timeout_work);
+		k_timer_stop(&uart0_cb.tx_timeout_timer);
 	}
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPTX);
 	evt.type = UART_TX_ABORTED;
@@ -771,7 +773,6 @@ static void tx_timeout(struct k_work *work)
 	uart0_cb.tx_buffer_length = 0;
 	uart0_cb.tx_counter = 0;
 	user_callback(DEVICE_GET(uart_nrfx_uart0), &evt);
-
 }
 #endif
 
@@ -1047,9 +1048,9 @@ static int uart_nrfx_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_UART_0_ASYNC
-	k_delayed_work_init(&uart0_cb.rx_timeout_work, rx_timeout);
+	k_timer_init(&uart0_cb.rx_timeout_timer, rx_timeout, NULL);
 #if HW_FLOW_CONTROL_AVAILABLE
-	k_delayed_work_init(&uart0_cb.tx_timeout_work, tx_timeout);
+	k_timer_init(&uart0_cb.tx_timeout_timer, tx_timeout, NULL);
 #endif
 #endif
 	return 0;

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -74,9 +74,14 @@ void test_single_read(void)
 			  "Initial buffer check failed");
 
 	uart_rx_enable(uart_dev, rx_buf, 10, 50);
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), -EAGAIN,
+		      "RX_RDY not expected at this point");
+
 	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), -EAGAIN,
+		      "Extra RX_RDY received");
 
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 	zassert_not_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
@@ -89,6 +94,9 @@ void test_single_read(void)
 		      "RX_BUF_RELEASED timeout");
 	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(1000)), 0,
 		      "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), -EAGAIN,
+		      "Extra RX_RDY received");
+
 	zassert_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
 	zassert_equal(tx_aborted_count, 0, "TX aborted triggered");
 }


### PR DESCRIPTION
There is no need to involve a work queue to control timeouts in
the uart_nrfx_uart driver. Kernel timers are sufficient for those
tasks, and the uart_nrfx_uarte driver may serve as a proof of this.
Replace then those uses of work queue with timers, for consistency
and simplicity, also to avoid potential issues with cancellation of
the delayed work queue items.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>