### PR TITLE
boards: x86: disable werror for grub build

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -34,7 +34,7 @@ build() {
 
   ./bootstrap
   ./autogen.sh
-  ./configure --with-platform=efi --target=${TARGET_ARCH}
+  ./configure --with-platform=efi --target=${TARGET_ARCH} --disable-werror
 
   make -j${JOBS}
 


### PR DESCRIPTION
There is a warning because of some pointer arithmetics in Grub, that makes the build fail.
Since the build works fine without -Werror, this PR disables it.
