### PR TITLE
usb: drivers: Fix Nordic driver ZLP handling.

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -54,7 +54,6 @@ menuconfig USB_NRFX
 	select USB_DEVICE_DRIVER
 	select NRFX_USBD
 	select NRFX_POWER
-	select USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
 	help
 	  nRF USB Device Controller Driver
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -237,6 +237,7 @@ K_MEM_POOL_DEFINE(ep_buf_pool, EP_BUF_POOL_BLOCK_MIN_SZ,
  * @brief USBD control structure
  *
  * @param status_cb	Status callback for USB DC notifications
+ * @param setup		Setup packet for Control requests
  * @param hfxo_cli	Onoff client used to control HFXO
  * @param hfxo_mgr	Pointer to onoff manager associated with HFXO.
  * @param clk_requested	Flag used to protect against double stop.
@@ -249,6 +250,7 @@ K_MEM_POOL_DEFINE(ep_buf_pool, EP_BUF_POOL_BLOCK_MIN_SZ,
  */
 struct nrf_usbd_ctx {
 	usb_dc_status_callback status_cb;
+	struct usb_setup_packet setup;
 	struct onoff_client hfxo_cli;
 	struct onoff_manager *hfxo_mgr;
 	atomic_t clk_requested;
@@ -795,6 +797,9 @@ static inline void usbd_work_process_setup(struct nrf_usbd_ep_ctx *ep_ctx)
 	usbd_setup->wIndex = nrf_usbd_setup_windex_get(NRF_USBD);
 	usbd_setup->wLength = nrf_usbd_setup_wlength_get(NRF_USBD);
 	ep_ctx->buf.len = sizeof(struct usb_setup_packet);
+
+	/* Copy setup packet to driver internal structure */
+	memcpy(&usbd_ctx.setup, usbd_setup, sizeof(struct usb_setup_packet));
 
 	LOG_DBG("SETUP: bR:0x%02x bmRT:0x%02x wV:0x%04x wI:0x%04x wL:%d",
 		(uint32_t)usbd_setup->bRequest,

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -219,9 +219,7 @@ K_MEM_POOL_DEFINE(fifo_elem_pool, FIFO_ELEM_MIN_SZ, FIFO_ELEM_MAX_SZ,
 		    CFG_EPOUT_CNT + CFG_EP_ISOOUT_CNT)
 
 /** Total buffer size for all endpoints */
-#define EP_BUF_TOTAL ((CFG_EPIN_CNT * EP_BUF_MAX_SZ) +	       \
-		      (CFG_EPOUT_CNT * EP_BUF_MAX_SZ) +	       \
-		      (CFG_EP_ISOIN_CNT * ISO_EP_BUF_MAX_SZ) + \
+#define EP_BUF_TOTAL ((CFG_EPOUT_CNT * EP_BUF_MAX_SZ) +	       \
 		      (CFG_EP_ISOOUT_CNT * ISO_EP_BUF_MAX_SZ))
 
 /** Total number of maximum sized buffers needed */
@@ -631,15 +629,6 @@ static int eps_ctx_init(void)
 		ep_ctx = in_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
 
-		if (!ep_ctx->buf.block.data) {
-			err = k_mem_pool_alloc(&ep_buf_pool, &ep_ctx->buf.block,
-					       EP_BUF_MAX_SZ, K_NO_WAIT);
-			if (err < 0) {
-				LOG_ERR("Buffer alloc failed for EP 0x%02x", i);
-				return -ENOMEM;
-			}
-		}
-
 		ep_ctx_reset(ep_ctx);
 	}
 
@@ -662,16 +651,6 @@ static int eps_ctx_init(void)
 	if (CFG_EP_ISOIN_CNT) {
 		ep_ctx = in_endpoint_ctx(NRF_USBD_EPIN(8));
 		__ASSERT_NO_MSG(ep_ctx);
-
-		if (!ep_ctx->buf.block.data) {
-			err = k_mem_pool_alloc(&ep_buf_pool, &ep_ctx->buf.block,
-					       ISO_EP_BUF_MAX_SZ,
-					       K_NO_WAIT);
-			if (err < 0) {
-				LOG_ERR("EP buffer alloc failed for ISOIN");
-				return -ENOMEM;
-			}
-		}
 
 		ep_ctx_reset(ep_ctx);
 	}

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -88,12 +88,6 @@ config USB_DEVICE_REMOTE_WAKEUP
 	help
 	  This option requires USBD peripheral driver to also support remote wakeup.
 
-config USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
-	bool
-	help
-	  Stack should not handle ZLP for Variable-length Data Stage
-	  because it is taken over by the hardware.
-
 config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -227,7 +227,6 @@ static void usb_data_to_host(uint16_t len)
 		usb_dev.data_buf += chunk;
 		usb_dev.data_buf_residue -= chunk;
 
-#ifndef CONFIG_USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
 		/*
 		 * Set ZLP flag when host asks for a bigger length and the
 		 * last chunk is wMaxPacketSize long, to indicate the last
@@ -242,7 +241,6 @@ static void usb_data_to_host(uint16_t len)
 				usb_dev.zlp_flag = true;
 			}
 		}
-#endif
 
 	} else {
 		usb_dev.zlp_flag = false;


### PR DESCRIPTION
This PR contains more than just a fix for ZLP handling as it was required to achieve the ZLP fix goal.

This PR removes fragmentation of IN transfers. Fragmentation made proper ZLP handling impossible.
If, for example, hosts requires 255 Bytes but only 64 Bytes are possible to send (#29364) then there is
no good way to guess where the ZLP flag should be added as the last write will be 64 Bytes long and
the driver does not know which chunk is being send in the current `usb_dc_ep_write'. Could be 2nd/3rd
if the whole data size is 128 or 192.

#18646 PR description says: 
_"ZLP flag should only be set if less data is sent
than requested by host and the length is a multiple
of wMaxPacketSize. Current implementation does not
check it correctly._

_For some platforms like nRF52, this patch will not
be enough to fix the problem. The driver must be informed
about the transfer type before sending the last packet,
without changing the API it is not possible."_

I guess the author was thinking about adding `bool zlp` to `usb_dc_ep_write()` function parameters.
This PR workarounds this issue and fixes that without changing of the API.

The PR removes `USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING` config option which was
introduced only for Nordic driver. I think that it was incorrect assumption that nordic usbd hardware
sends ZLP by itself. Its not true - the **driver** has possibility to do so, not the **hardware**.
This possibility is not used in this PR because of the Zephyr USB stack compatibility
(refer to commit message).

Explanation for adding this option (provided in #19272 description) assumes that Linux Gadget zero
tests shall return _`Broken Pipe`_ if below patch applied:
``` diff
diff --git a/subsys/usb/class/loopback.c b/subsys/usb/class/loopback.c
index a49c51e691..fd6361f658 100644
--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -143,6 +143,9 @@ static int loopback_vendor_handler(struct usb_setup_packet *setup,
 	    (setup->bRequest == 0x5c)) {
 		LOG_DBG("Device-to-Host, wLength %d, data %p",
 			setup->wLength, *data);
+		if (setup->wLength == 1024) {
+			*len = 512;
+		}
 		return 0;
 	}
```
This is not true. The test output shall be: _`Bad message`_ meaning that the device returned less data than expected.

This PR resolves issues for both Linux Gadget zero tests as well as USB3CV tests.

Pros of this PR:
1. much better performance compared to previous solution with internal buffers for IN endpoints.
    - uses less RAM memory (at least less than 1024 Bytes - depends on classes used).
    - avoid copies to internal Endpoint buffers in the device driver controller (usb_dc_nrfx.c).
2. Uses Nordic LL driver (usbd_nrfx.c) more efficient (without braking the main stack requirements).
    - Does not fragment the data in the device driver controller (usb_dc_nrfx.c).

Fixes: #29364 