### PR TITLE
nordic: documentation updates related to QSPI use

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -210,7 +210,9 @@ arduino_i2c: &i2c0 {
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;
+		/* MX24R64 supports only pp and pp4io */
 		writeoc = "pp4io";
+		/* MX24R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
 		label = "MX25R64";

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -27,7 +27,7 @@ properties:
     type: string
     required: false
     enum:
-      - "fastread"        # Single data line SPI, FAST_READ (0x08)
+      - "fastread"        # Single data line SPI, FAST_READ (0x0B)
       - "read2o"          # Dual data line SPI, READ2O (0x3B)
       - "read2io"         # Dual data line SPI, READ2IO (0xBB)
       - "read4o"          # Quad data line SPI, READ4O (0x6B)


### PR DESCRIPTION
Selection of certain opcode configurations will be successful only if the underlying device supports those opcodes.  Document the ones that work for the nrf52840dk_nrf52480 platform.

Also fix an error in identifying the fastread opcode.