### PR TITLE
arm: v2m_musca: Mark Musca-A board support deprecated for 2.6.0

### DIFF
--- a/boards/arm/v2m_musca/Kconfig.defconfig
+++ b/boards/arm/v2m_musca/Kconfig.defconfig
@@ -7,6 +7,9 @@ config BOARD
 	default "musca_a" if TRUSTED_EXECUTION_SECURE || !TRUSTED_EXECUTION_NONSECURE
 	default "musca_a_nonsecure"
 
+config BOARD_DEPRECATED_RELEASE
+	default "v2.6.0"
+
 if GPIO
 
 config GPIO_CMSDK_AHB

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -46,6 +46,8 @@ API Changes
 Deprecated in this release
 ==========================
 
+* ARM Musca-A board and SoC support deprecated and planned to be removed in 2.6.0.
+
 Removed APIs in this release
 ============================
 

--- a/soc/arm/arm/musca_a/Kconfig.defconfig.musca_a
+++ b/soc/arm/arm/musca_a/Kconfig.defconfig.musca_a
@@ -3,6 +3,9 @@
 
 if SOC_V2M_MUSCA_A
 
+config SOC_DEPRECATED_RELEASE
+	default "v2.6.0"
+
 config SOC
 	default "musca_a"
 


### PR DESCRIPTION
Deprecate the Musca-A board and SoC support to be removed in 2.6.0

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>