### PR TITLE
samples: change name for the mec15xxevb_assy6853 pm sample

### DIFF
--- a/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
+++ b/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: MEC150x board sample power management tests
 tests:
-  sample.board.mec15xxevb_assy6853:
+  sample.board.mec15xxevb_assy6853.pm:
     platform_allow: mec15xxevb_assy6853
     tags: board


### PR DESCRIPTION
Power management sample for that board has very
confusing name that should be changed to something
more understandable.
Current name sample.board.sample.board.mec15xxevb_assy6853
I suggest to have new name
sample.board.power_management.mec15xxevb_assy6853

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>