### PR TITLE
dts: Fix altera vendor prefix

### DIFF
--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "altera_max10";
-	compatible = "altera,nios2-max10";
+	compatible = "altr,nios2-max10";
 
 	aliases {
 		uart-0 = &uart0;

--- a/dts/bindings/cpu/altera,nios2f.yaml
+++ b/dts/bindings/cpu/altera,nios2f.yaml
@@ -3,7 +3,7 @@
 
 description: Altera NIOS-2F CPU
 
-compatible: "altera,nios2f"
+compatible: "altr,nios2f"
 
 include: [interrupt-controller.yaml, base.yaml]
 

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,6 +1,6 @@
 description: Altera JTAG UART
 
-compatible: "altera,jtag-uart"
+compatible: "altr,jtag-uart"
 
 include: uart-controller.yaml
 

--- a/dts/nios2/nios2-qemu.dtsi
+++ b/dts/nios2/nios2-qemu.dtsi
@@ -34,7 +34,7 @@
 		ranges;
 
 		jtag_uart: uart@201000 {
-			compatible = "altera,jtag-uart";
+			compatible = "altr,jtag-uart";
 			reg = <0x201000 0x400>;
 			label = "jtag_uart0";
 

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -10,7 +10,7 @@
 
 		cpu: cpu@0 {
 			device_type = "cpu";
-			compatible = "altera,nios2f";
+			compatible = "altr,nios2f";
 			reg = <0>;
 			interrupt-controller;
 			#interrupt-cells = <1>;


### PR DESCRIPTION
There are a few cases in which "altera" was used instead of "altr" as
the vendor prefix.  Update DTS and bindings in those cases to use "altr"

Fixes #29373

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>