### PR TITLE
drivers: pinmux: stm32 Fix return stm32_dt_pinctrl_remap value

### DIFF
--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -139,7 +139,7 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl)
-	if (!stm32_dt_pinctrl_remap(pinctrl, list_size, base)) {
+	if (stm32_dt_pinctrl_remap(pinctrl, list_size, base)) {
 		/* Wrong remap config. Exit */
 		return -EINVAL;
 	}


### PR DESCRIPTION
Fix incorrect return value check when converting pinctrl format to existing pin config
format

Signed-off-by: Marin Jurjevic <marin.jurjevic@hotmail.com>