### PR TITLE
sanitycheck: Fix bug with -M option

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2144,7 +2144,7 @@ class ProjectBuilder(FilterBuilder):
             else:
                 self.cleanup_artifacts()
 
-    def cleanup_artifacts(self, additional_keep=None):
+    def cleanup_artifacts(self, additional_keep=[]):
         logger.debug("Cleaning up {}".format(self.instance.build_dir))
         allow = [
             'zephyr/.config',


### PR DESCRIPTION
If we get a build failure with the -M option we get the following:

TypeError: 'NoneType' object is not iterable

This was due to having the default value of additional_keep in
cleanup_artifacts being None instead of an empty array.

Fixes #29376

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>