### PR TITLE
userspace: do nothing if thread is added to a domain it belongs to

### DIFF
--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -547,8 +547,9 @@ int arch_mem_domain_init(struct k_mem_domain *domain);
  * Architecture-specific hook to manage internal data structures or hardware
  * state when the provided thread has been added to a memory domain.
  *
- * The thread's memory domain pointer will be set to the domain to be added
- * to.
+ * The thread->mem_domain_info.mem_domain pointer will be set to the domain to
+ * be added to before this is called. Implementations may assume that the
+ * thread is not already a member of this domain.
  *
  * @param thread Thread which needs to be configured.
  */

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -261,8 +261,10 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 	k_spinlock_key_t key;
 
 	key = k_spin_lock(&z_mem_domain_lock);
-	remove_thread_locked(thread);
-	add_thread_locked(domain, thread);
+	if (thread->mem_domain_info.mem_domain != domain) {
+		remove_thread_locked(thread);
+		add_thread_locked(domain, thread);
+	}
 	k_spin_unlock(&z_mem_domain_lock, key);
 }
 

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -423,13 +423,6 @@ void test_main(void)
 #ifdef CONFIG_USERSPACE
 	k_thread_access_grant(k_current_get(),
 			      &thread_12_thread_data, &thread_12_stack_area);
-
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_05);
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_06);
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_07);
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_08);
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_09);
-	k_mem_domain_add_thread(&k_mem_domain_default, THREAD_11);
 #endif
 	rv = sys_mutex_lock(&not_my_mutex, K_NO_WAIT);
 	if (rv != 0) {


### PR DESCRIPTION
There's no need to do anything if the target thread is already a member of the specified domain, and it can make the arch code simpler if it can assume we are always migrating the thread to some other domain.

I couldn't decide whether to make the check a no-op or a failed assertion, I went with a no-op since the check is very cheap.