### PR TITLE
boards: soc: arm: Set zephyr,sram and zephyr,dtcm chosen nodes for i.mx rt boards

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -12,10 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-choice DATA_LOCATION
-	default DATA_SEMC
-endchoice
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &sdram0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -12,10 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-choice DATA_LOCATION
-	default DATA_SEMC
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -19,6 +19,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &sdram0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -13,10 +13,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-choice DATA_LOCATION
-	default DATA_SEMC
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -19,6 +19,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &sdram0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -12,10 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI2
 endchoice
 
-choice DATA_LOCATION
-	default DATA_SEMC
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -20,6 +20,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &sdram0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;

--- a/boards/arm/mm_swiftio/Kconfig.defconfig
+++ b/boards/arm/mm_swiftio/Kconfig.defconfig
@@ -12,10 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-choice DATA_LOCATION
-	default DATA_SEMC
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -19,6 +19,7 @@
 	};
 
 	chosen {
+		zephyr,sram = &sdram0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -137,6 +137,12 @@ config HAS_MCUX_SCG
 	  Set if the system clock generator (SCG) module is present in the
 	  SoC.
 
+config HAS_MCUX_SEMC
+	bool
+	help
+	  Set if the smart external memory controller (SEMC) module is present
+	  in the SoC.
+
 config HAS_MCUX_SIM
 	bool
 	help

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -98,36 +98,6 @@ config FLASH_BASE_ADDRESS
 
 endif # CODE_FLEXSPI2
 
-if DATA_DTCM
-
-config SRAM_SIZE
-	default $(dt_node_reg_size_int,/soc/flexram@400b0000/dtcm@20000000,0,K)
-
-config SRAM_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/dtcm@20000000)
-
-endif # DATA_DTCM
-
-if DATA_SEMC
-
-config SRAM_SIZE
-	default $(dt_node_reg_size_int,/memory@80000000,0,K)
-
-config SRAM_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/memory@80000000)
-
-endif # DATA_SEMC
-
-if DATA_OCRAM
-
-config SRAM_SIZE
-	default $(dt_node_reg_size_int,/soc/flexram@400b0000/ocram@20200000,0,K)
-
-config SRAM_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/ocram@20200000)
-
-endif # DATA_OCRAM
-
 config USB_DC_NXP_EHCI
 	default y
 	depends on USB

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -413,19 +413,4 @@ config CODE_FLEXSPI2
 
 endchoice
 
-choice DATA_LOCATION
-	prompt "Data location selection"
-	default DATA_DTCM
-
-config DATA_DTCM
-	bool "Link data into internal data tightly coupled memory (DTCM)"
-
-config DATA_SEMC
-	bool "Link data into external SEMC-controlled memory"
-
-config DATA_OCRAM
-	bool "Link data into On-Chip RAM memory"
-
-endchoice
-
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -59,6 +59,7 @@ config SOC_MIMXRT1021
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -82,6 +83,7 @@ config SOC_MIMXRT1051
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -107,6 +109,7 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -133,6 +136,7 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -158,6 +162,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -185,6 +190,7 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
+	select HAS_MCUX_SEMC
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
@@ -380,6 +386,7 @@ config IMAGE_VECTOR_TABLE_OFFSET
 
 config DEVICE_CONFIGURATION_DATA
 	bool "Enable device configuration data"
+	default y if HAS_MCUX_SEMC
 	help
 	  Device configuration data (DCD) provides a sequence of commands to
 	  the boot ROM to initialize components such as an SDRAM.
@@ -415,7 +422,6 @@ config DATA_DTCM
 
 config DATA_SEMC
 	bool "Link data into external SEMC-controlled memory"
-	select DEVICE_CONFIGURATION_DATA if NXP_IMX_RT_BOOT_HEADER
 
 config DATA_OCRAM
 	bool "Link data into On-Chip RAM memory"

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -17,9 +17,6 @@ MEMORY
 #if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !IS_CHOSEN_SRAM(sdram0)
         SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_SIZE(DT_NODELABEL(sdram0))
 #endif
-#if (DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm)) > 0) && !IS_CHOSEN_SRAM(dtcm)
-        DTCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm))
-#endif
 #if (DT_REG_SIZE(DT_INST(0, nxp_imx_itcm)) > 0) && !defined(CONFIG_CODE_ITCM)
         ITCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_itcm))
 #endif

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -7,15 +7,17 @@
  #include <autoconf.h>
  #include <devicetree.h>
 
+#define IS_CHOSEN_SRAM(x) (DT_DEP_ORD(DT_NODELABEL(x)) == DT_DEP_ORD(DT_CHOSEN(zephyr_sram)))
+
 MEMORY
      {
-#if (DT_REG_SIZE(DT_NODELABEL(ocram)) > 0) && !defined(CONFIG_DATA_OCRAM)
+#if (DT_REG_SIZE(DT_NODELABEL(ocram)) > 0) && !IS_CHOSEN_SRAM(ocram)
         OCRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(ocram)), LENGTH = DT_REG_SIZE(DT_NODELABEL(ocram))
 #endif
-#if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !defined(CONFIG_DATA_SEMC)
+#if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !IS_CHOSEN_SRAM(sdram0)
         SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_SIZE(DT_NODELABEL(sdram0))
 #endif
-#if (DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm)) > 0) && !defined(CONFIG_DATA_DTCM)
+#if (DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm)) > 0) && !IS_CHOSEN_SRAM(dtcm)
         DTCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_dtcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_dtcm))
 #endif
 #if (DT_REG_SIZE(DT_INST(0, nxp_imx_itcm)) > 0) && !defined(CONFIG_CODE_ITCM)


### PR DESCRIPTION
Sets the device tree chosen nodes for SRAM and data tightly coupled memory (DTCM) on i.mx rt boards. The DTCM node is needed by https://github.com/zephyrproject-rtos/zephyr/pull/27412#issuecomment-690676013

Removes the DATA_LOCATION Kconfig symbol to avoid possible conflicts with the dts chosen node.