### PR TITLE
driver: npcx7: replace platform specific functions with 'npcx_' prefix.

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -171,13 +171,13 @@ static void espi_init_wui_callback(const struct device *dev,
 		return;
 
 	/* Install callback function */
-	soc_miwu_init_dev_callback(callback, wui, handler, dev);
-	soc_miwu_manage_dev_callback(callback, 1);
+	npcx_miwu_init_dev_callback(callback, wui, handler, dev);
+	npcx_miwu_manage_dev_callback(callback, 1);
 
 	/* Congiure MIWU setting and enable its interrupt */
-	soc_miwu_interrupt_configure(wui, NPCX_MIWU_MODE_EDGE,
+	npcx_miwu_interrupt_configure(wui, NPCX_MIWU_MODE_EDGE,
 							NPCX_MIWU_TRIG_BOTH);
-	soc_miwu_irq_enable(wui);
+	npcx_miwu_irq_enable(wui);
 }
 
 /* eSPI local bus interrupt service functions */
@@ -388,7 +388,7 @@ static void espi_vw_notify_plt_rst(const struct device *dev)
 		/* Set Peripheral Channel ready when PLTRST is de-asserted */
 		inst->ESPICFG |= BIT(NPCX_ESPICFG_PCHANEN);
 		/* Configure all host sub-modules in host doamin */
-		soc_host_init_subs_host_domain();
+		npcx_host_init_subs_host_domain();
 	}
 
 	/* PLT_RST will be received several times */
@@ -633,7 +633,7 @@ static int espi_npcx_read_lpc_request(const struct device *dev,
 	if (!IS_BIT_SET(inst->ESPICFG, NPCX_ESPICFG_PCHANEN))
 		return -ENOTSUP;
 
-	return soc_host_periph_read_request(op, data);
+	return npcx_host_periph_read_request(op, data);
 }
 
 static int espi_npcx_write_lpc_request(const struct device *dev,
@@ -646,7 +646,7 @@ static int espi_npcx_write_lpc_request(const struct device *dev,
 	if (!IS_BIT_SET(inst->ESPICFG, NPCX_ESPICFG_PCHANEN))
 		return -ENOTSUP;
 
-	return soc_host_periph_write_request(op, data);
+	return npcx_host_periph_write_request(op, data);
 }
 
 #if defined(CONFIG_ESPI_OOB_CHANNEL)
@@ -863,10 +863,10 @@ static int espi_npcx_init(const struct device *dev)
 				&config->espi_rst_wui, espi_vw_espi_rst_isr);
 
 	/* Configure pin-mux for eSPI bus device */
-	soc_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
+	npcx_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
 
 	/* Configure host sub-modules which HW blocks belong to core domain */
-	soc_host_init_subs_core_domain(dev, &data->callbacks);
+	npcx_host_init_subs_core_domain(dev, &data->callbacks);
 
 	/* eSPI Bus interrupt installation */
 	IRQ_CONNECT(DT_INST_IRQN(0),

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -447,7 +447,7 @@ void host_uart_init(void)
 	struct c2h_reg *const inst_c2h = host_sub_cfg.inst_c2h;
 
 	/* Configure pin-mux for serial port device */
-	soc_pinctrl_mux_configure(host_uart_alts, ARRAY_SIZE(host_uart_alts),
+	npcx_pinctrl_mux_configure(host_uart_alts, ARRAY_SIZE(host_uart_alts),
 									1);
 	/* Make sure unlock host access of serial port */
 	inst_c2h->LKSIOHA &= ~BIT(NPCX_LKSIOHA_LKSPHA);
@@ -582,8 +582,8 @@ uint8_t host_c2h_read_io_cfg_reg(uint8_t reg_index)
 	return data_val;
 }
 
-/* Soc specific host sub modules functions */
-int soc_host_periph_read_request(enum lpc_peripheral_opcode op,
+/* Platform specific host sub modules functions */
+int npcx_host_periph_read_request(enum lpc_peripheral_opcode op,
 								uint32_t *data)
 {
 	struct kbc_reg *const inst_kbc = host_sub_cfg.inst_kbc;
@@ -620,7 +620,7 @@ int soc_host_periph_read_request(enum lpc_peripheral_opcode op,
 	return 0;
 }
 
-int soc_host_periph_write_request(enum lpc_peripheral_opcode op,
+int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
 								uint32_t *data)
 {
 	volatile uint32_t __attribute__((unused)) dummy;
@@ -687,7 +687,7 @@ int soc_host_periph_write_request(enum lpc_peripheral_opcode op,
 	return 0;
 }
 
-void soc_host_init_subs_host_domain(void)
+void npcx_host_init_subs_host_domain(void)
 {
 	struct c2h_reg *const inst_c2h = host_sub_cfg.inst_c2h;
 
@@ -744,7 +744,7 @@ void soc_host_init_subs_host_domain(void)
 	LOG_DBG("Hos sub-modules configurations are done!");
 }
 
-int soc_host_init_subs_core_domain(const struct device *host_bus_dev,
+int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 							sys_slist_t *callbacks)
 {
 	struct mswc_reg *const inst_mswc = host_sub_cfg.inst_mswc;

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -49,8 +49,8 @@ struct gpio_npcx_data {
 
 #define HAL_INSTANCE(dev) (struct gpio_reg *)(DRV_CONFIG(dev)->base)
 
-/* Soc specific GPIO functions */
-const struct device *soc_get_gpio_dev(int port)
+/* Platform specific GPIO functions */
+const struct device *npcx_get_gpio_dev(int port)
 {
 	if (port >= gpio_devs_count)
 		return NULL;
@@ -205,14 +205,14 @@ static int gpio_npcx_pin_interrupt_configure(const struct device *dev,
 		miwu_trig = NPCX_MIWU_TRIG_BOTH;
 
 	/* Call MIWU routine to setup interrupt configuration */
-	soc_miwu_interrupt_configure(&config->wui_maps[pin],
+	npcx_miwu_interrupt_configure(&config->wui_maps[pin],
 					miwu_mode, miwu_trig);
 
 	/* Enable/Disable irq of wake-up input sources */
 	if (mode == GPIO_INT_MODE_DISABLED) {
-		soc_miwu_irq_disable(&config->wui_maps[pin]);
+		npcx_miwu_irq_disable(&config->wui_maps[pin]);
 	} else {
-		soc_miwu_irq_enable(&config->wui_maps[pin]);
+		npcx_miwu_irq_enable(&config->wui_maps[pin]);
 	}
 
 	return 0;
@@ -237,11 +237,11 @@ static int gpio_npcx_manage_callback(const struct device *dev,
 	}
 
 	/* Initialize WUI information in unused bits field */
-	soc_miwu_init_gpio_callback(miwu_cb, &config->wui_maps[pin],
+	npcx_miwu_init_gpio_callback(miwu_cb, &config->wui_maps[pin],
 			config->port);
 
 	/* Insert or remove a IO callback which being called in MIWU ISRs */
-	return soc_miwu_manage_gpio_callback(miwu_cb, set);
+	return npcx_miwu_manage_gpio_callback(miwu_cb, set);
 }
 
 /* GPIO driver registration */

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -105,7 +105,7 @@ static void intc_miwu_dispatch_gpio_isr(uint8_t wui_table,
 			 * Execute GPIO callback and the other callback might
 			 * match the same wui item.
 			 */
-			cb->handler(soc_get_gpio_dev(cb->params.gpio_port),
+			cb->handler(npcx_get_gpio_dev(cb->params.gpio_port),
 					(struct gpio_callback *)cb,
 					cb->params.pin_mask);
 		}
@@ -155,22 +155,22 @@ static void intc_miwu_isr_pri(int wui_table, int wui_group)
 	}
 }
 
-/* Soc specific MIWU functions */
-void soc_miwu_irq_enable(const struct npcx_wui *wui)
+/* Platform specific MIWU functions */
+void npcx_miwu_irq_enable(const struct npcx_wui *wui)
 {
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
 
 	NPCX_WKEN(base, wui->group) |= BIT(wui->bit);
 }
 
-void soc_miwu_irq_disable(const struct npcx_wui *wui)
+void npcx_miwu_irq_disable(const struct npcx_wui *wui)
 {
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
 
 	NPCX_WKEN(base, wui->group) &= ~BIT(wui->bit);
 }
 
-unsigned int soc_miwu_irq_get_state(const struct npcx_wui *wui)
+unsigned int npcx_miwu_irq_get_state(const struct npcx_wui *wui)
 {
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
 
@@ -180,7 +180,7 @@ unsigned int soc_miwu_irq_get_state(const struct npcx_wui *wui)
 		return 0;
 }
 
-int soc_miwu_interrupt_configure(const struct npcx_wui *wui,
+int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
 		enum miwu_int_mode mode, enum miwu_int_trig trig)
 {
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
@@ -244,7 +244,7 @@ int soc_miwu_interrupt_configure(const struct npcx_wui *wui,
 	return 0;
 }
 
-void soc_miwu_init_gpio_callback(struct miwu_io_callback *callback,
+void npcx_miwu_init_gpio_callback(struct miwu_io_callback *callback,
 				const struct npcx_wui *io_wui, int port)
 {
 	/* Initialize WUI and GPIO settings in unused bits field */
@@ -254,7 +254,7 @@ void soc_miwu_init_gpio_callback(struct miwu_io_callback *callback,
 	callback->params.gpio_port = port;
 }
 
-void soc_miwu_init_dev_callback(struct miwu_dev_callback *callback,
+void npcx_miwu_init_dev_callback(struct miwu_dev_callback *callback,
 				const struct npcx_wui *dev_wui,
 				miwu_dev_callback_handler_t handler,
 				const struct device *source)
@@ -267,7 +267,7 @@ void soc_miwu_init_dev_callback(struct miwu_dev_callback *callback,
 	callback->source = source;
 }
 
-int soc_miwu_manage_gpio_callback(struct miwu_io_callback *cb, bool set)
+int npcx_miwu_manage_gpio_callback(struct miwu_io_callback *cb, bool set)
 {
 	if (!sys_slist_is_empty(&cb_list_gpio)) {
 		if (!sys_slist_find_and_remove(&cb_list_gpio, &cb->node)) {
@@ -284,7 +284,7 @@ int soc_miwu_manage_gpio_callback(struct miwu_io_callback *cb, bool set)
 	return 0;
 }
 
-int soc_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
+int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 {
 	if (!sys_slist_is_empty(&cb_list_generic)) {
 		if (!sys_slist_find_and_remove(&cb_list_generic, &cb->node)) {

--- a/drivers/pinmux/pinmux_npcx.c
+++ b/drivers/pinmux/pinmux_npcx.c
@@ -51,8 +51,8 @@ static void npcx_pinctrl_alt_sel(const struct npcx_alt *alt, int alt_func)
 		NPCX_DEVALT(scfg_base, alt->group) &= ~alt_mask;
 }
 
-/* Soc specific pin-control functions */
-void soc_pinctrl_mux_configure(const struct npcx_alt *alts_list,
+/* Platform specific pin-control functions */
+void npcx_pinctrl_mux_configure(const struct npcx_alt *alts_list,
 		      uint8_t alts_size, int altfunc)
 {
 	int i;
@@ -76,7 +76,7 @@ static int npcx_pinctrl_init(const struct device *dev)
 #endif
 
 	/* Change all pads whose default functionality isn't IO to GPIO */
-	soc_pinctrl_mux_configure(def_alts, ARRAY_SIZE(def_alts), 0);
+	npcx_pinctrl_mux_configure(def_alts, ARRAY_SIZE(def_alts), 0);
 
 	return 0;
 }

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -186,7 +186,7 @@ static int pwm_npcx_init(const struct device *dev)
 	pwm_npcx_configure(dev, config->clk_cfg.bus);
 
 	/* Configure pin-mux for PWM device */
-	soc_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
+	npcx_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
 
 	return 0;
 }

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -344,16 +344,16 @@ static int uart_npcx_init(const struct device *dev)
 	 * Configure the UART wake-up event triggered from a falling edge
 	 * on CR_SIN pin. No need for callback function.
 	 */
-	soc_miwu_interrupt_configure(&config->uart_rx_wui,
+	npcx_miwu_interrupt_configure(&config->uart_rx_wui,
 			NPCX_MIWU_MODE_EDGE, NPCX_MIWU_TRIG_LOW);
 
 	/* Enable irq of interrupt-input module */
-	soc_miwu_irq_enable(&config->uart_rx_wui);
+	npcx_miwu_irq_enable(&config->uart_rx_wui);
 #endif
 
 
 	/* Configure pin-mux for uart device */
-	soc_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
+	npcx_pinctrl_mux_configure(config->alts_list, config->alts_size, 1);
 
 	return 0;
 }

--- a/soc/arm/nuvoton_npcx/common/soc_gpio.h
+++ b/soc/arm/nuvoton_npcx/common/soc_gpio.h
@@ -22,7 +22,7 @@ extern "C" {
  * @retval Pointer to structure device
  * @retval NULL Invalid parameter of GPIO port index
  */
-const struct device *soc_get_gpio_dev(int port);
+const struct device *npcx_get_gpio_dev(int port);
 
 #ifdef __cplusplus
 }

--- a/soc/arm/nuvoton_npcx/common/soc_host.h
+++ b/soc/arm/nuvoton_npcx/common/soc_host.h
@@ -24,7 +24,7 @@ extern "C" {
  * @retval 0 If successful.
  * @retval -EIO if cannot turn on host sub-module source clocks in core domain.
  */
-int soc_host_init_subs_core_domain(const struct device *host_bus_dev,
+int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 							sys_slist_t *callbacks);
 
 /**
@@ -34,7 +34,7 @@ int soc_host_init_subs_core_domain(const struct device *host_bus_dev,
  * Host domain. Please notcie it must be executed after receiving PLT_RST
  * de-asserted signal and eSPI peripheral channel is enabled and ready.
  */
-void soc_host_init_subs_host_domain(void);
+void npcx_host_init_subs_host_domain(void);
 
 /**
  * @brief Reads data from a host sub-module which is updated via eSPI.
@@ -49,7 +49,7 @@ void soc_host_init_subs_host_domain(void);
  * @retval -ENOTSUP if eSPI peripheral is off or not supported.
  * @retval -EINVAL for unimplemented lpc opcode, but in range.
  */
-int soc_host_periph_read_request(enum lpc_peripheral_opcode op,
+int npcx_host_periph_read_request(enum lpc_peripheral_opcode op,
 								uint32_t *data);
 
 /**
@@ -65,7 +65,7 @@ int soc_host_periph_read_request(enum lpc_peripheral_opcode op,
  * @retval -ENOTSUP if eSPI peripheral is off or not supported.
  * @retval -EINVAL for unimplemented lpc opcode, but in range.
  */
-int soc_host_periph_write_request(enum lpc_peripheral_opcode op,
+int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
 								uint32_t *data);
 
 #ifdef __cplusplus

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -89,7 +89,7 @@ struct miwu_io_params {
  * Beware such structure should not be allocated on stack and its size must
  * equal struct gpio_callback.
  *
- * Note: To help setting it, see soc_miwu_init_gpio_callback() below
+ * Note: To help setting it, see npcx_miwu_init_gpio_callback() below
  */
 struct miwu_io_callback {
 	/** Node of single-linked list */
@@ -106,7 +106,7 @@ struct miwu_io_callback {
  * Used to register a generic hardware device callback in the driver instance
  * callback list. Beware such structure should not be allocated on stack.
  *
- * Note: To help setting it, see soc_miwu_init_dev_callback() below
+ * Note: To help setting it, see npcx_miwu_init_dev_callback() below
  */
 struct miwu_dev_callback {
 	/** Node of single-linked list */
@@ -124,14 +124,14 @@ struct miwu_dev_callback {
  *
  * @param A pointer on wake-up input source
  */
-void soc_miwu_irq_enable(const struct npcx_wui *wui);
+void npcx_miwu_irq_enable(const struct npcx_wui *wui);
 
 /**
  * @brief Disable interrupt of the wake-up input source
  *
  * @param wui A pointer on wake-up input source
  */
-void soc_miwu_irq_disable(const struct npcx_wui *wui);
+void npcx_miwu_irq_disable(const struct npcx_wui *wui);
 
 /**
  * @brief Get interrupt state of the wake-up input source
@@ -140,7 +140,7 @@ void soc_miwu_irq_disable(const struct npcx_wui *wui);
  *
  * @retval 0 if interrupt is disabled, otherwise interrupt is enabled
  */
-unsigned int soc_miwu_irq_get_state(const struct npcx_wui *wui);
+unsigned int npcx_miwu_irq_get_state(const struct npcx_wui *wui);
 
 /**
  * @brief Configure interrupt type of the wake-up input source
@@ -152,7 +152,7 @@ unsigned int soc_miwu_irq_get_state(const struct npcx_wui *wui);
  * @retval 0 If successful
  * @retval -EINVAL Invalid parameters
  */
-int soc_miwu_interrupt_configure(const struct npcx_wui *wui,
+int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
 		enum miwu_int_mode mode, enum miwu_int_trig trig);
 
 /**
@@ -162,7 +162,7 @@ int soc_miwu_interrupt_configure(const struct npcx_wui *wui,
  * @param io_wui Pointer to wake-up input IO source
  * @param port GPIO port issued a callback function
  */
-void soc_miwu_init_gpio_callback(struct miwu_io_callback *callback,
+void npcx_miwu_init_gpio_callback(struct miwu_io_callback *callback,
 				const struct npcx_wui *io_wui, int port);
 
 /**
@@ -173,7 +173,7 @@ void soc_miwu_init_gpio_callback(struct miwu_io_callback *callback,
  * @param handler A function called when its device input event issued
  * @param source Pointer to device instance issued a callback function
  */
-void soc_miwu_init_dev_callback(struct miwu_dev_callback *callback,
+void npcx_miwu_init_dev_callback(struct miwu_dev_callback *callback,
 				const struct npcx_wui *dev_wui,
 				miwu_dev_callback_handler_t handler,
 				const struct device *source);
@@ -187,7 +187,7 @@ void soc_miwu_init_dev_callback(struct miwu_dev_callback *callback,
  * @retval 0 If successful.
  * @retval -EINVAL Invalid parameters
  */
-int soc_miwu_manage_gpio_callback(struct miwu_io_callback *callback, bool set);
+int npcx_miwu_manage_gpio_callback(struct miwu_io_callback *callback, bool set);
 
 
 /**
@@ -199,7 +199,7 @@ int soc_miwu_manage_gpio_callback(struct miwu_io_callback *callback, bool set);
  * @retval 0 If successful.
  * @retval -EINVAL Invalid parameters
  */
-int soc_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set);
+int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set);
 
 #ifdef __cplusplus
 }

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -46,9 +46,9 @@ struct npcx_alt {
  *    - Pinmux configuration list
  *         const struct npcx_alt alts_list[] = DT_NPCX_ALT_ITEMS_LIST(inst);
  *    - Change pinmux to UART:
- *         soc_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 1);
+ *         npcx_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 1);
  *    - Change pinmux back to GPIO64.65:
- *         soc_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 0);
+ *         npcx_pinctrl_mux_configure(alts_list, ARRAY_SIZE(alts_list), 0);
  *
  * Please refer more details in Table 3. (Pin Multiplexing Configuration).
  *
@@ -56,7 +56,7 @@ struct npcx_alt {
  * @param alts_size Pin-mux configuration list size
  * @param altfunc 0: set pin-mux to GPIO, otherwise specific functionality
  */
-void soc_pinctrl_mux_configure(const struct npcx_alt *alts_list,
+void npcx_pinctrl_mux_configure(const struct npcx_alt *alts_list,
 			uint8_t alts_size, int altfunc);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Replace all platform specific functions with 'npcx_' prefix.

Signed-off-by: Mulin Chao <MLChao@nuvoton.com>