### PR TITLE
drivers/flash/nrf_qspi_nor: Add support for nRF53 Series SoCs

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -104,6 +104,34 @@
 	ch0-pin = <28>;
 };
 
+&qspi {
+	status = "okay";
+	sck-pin = <17>;
+	io-pins = <13>, <14>, <15>, <16>;
+	csn-pins = <18>;
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		/* MX24R64 supports only pp and pp4io */
+		writeoc = "pp4io";
+		/* MX24R64 supports all readoc options */
+		readoc = "read4io";
+		sck-frequency = <8000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
 &timer0 {
 	status = "okay";
 };

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -344,6 +344,16 @@ gpio1: gpio@842800 {
 	status = "disabled";
 };
 
+qspi: qspi@2b000 {
+	compatible = "nordic,nrf-qspi";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	reg = <0x2b000 0x1000>;
+	interrupts = <43 1>;
+	status = "disabled";
+	label = "QSPI";
+};
+
 rtc0: rtc@14000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x14000 0x1000>;

--- a/samples/drivers/spi_flash/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/drivers/spi_flash/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI=n
+CONFIG_NORDIC_QSPI_NOR=y

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -32,6 +32,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_PWM1
 	select HAS_HW_NRF_PWM2
 	select HAS_HW_NRF_PWM3
+	select HAS_HW_NRF_QSPI
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1
 	select HAS_HW_NRF_SAADC


### PR DESCRIPTION
Improve the way the nrf_qspi_nor driver configures the SCK frequency,
to properly support QSPI also on nRF53 Series SoCs that use a different
base clock frequency (96 MHz).
Add also a relevant configuration in the spi_flash sample so that it
can run on the nRF5340 DK. This DK is equipped with the MX25R64
flash memory, so add a dts node for that chip in the board definition,
as well as the missing QSPI node in the nRF5340 SoC definition.

Relevant page in the nRF5340 (P)DK documentation can be found [here](https://infocenter.nordicsemi.com/topic/ug_nrf5340_pdk/UG/nrf5340_PDK/hw_external_memory.html).