### PR TITLE
arc: defconfig: remove SYSTEM_CLOCK_SLOPPY_IDLE option

### DIFF
--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -36,12 +36,6 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 4
 
-# When SMP is enabled, use gfrc as wall clock, so sloppy
-# idle should be y
-config SYSTEM_CLOCK_SLOPPY_IDLE
-	default y
-	depends on SMP
-
 config UART_NS16550
 	default y
 	depends on SERIAL

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
@@ -34,10 +34,4 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 2
 
-# When SMP is enabled, use gfrc as wall clock, so sloppy
-# idle should be y
-config SYSTEM_CLOCK_SLOPPY_IDLE
-	default y
-	depends on SMP
-
 endif # SOC_NSIM_HS_SMP


### PR DESCRIPTION
As discuss in PR #28805, sloppy idle function still has some bug and
barely used, so we can remove it safely.