### PR TITLE
arc: cpu_idle: remove sleep workround for nsim_hs_smp

### DIFF
--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -43,20 +43,7 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 
 	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
-/*
- * It's found that (in nsim_hs_smp), when cpu
- * is sleeping, no response to inter-processor interrupt
- * although it's pending and interrupts are enabled.
- * (Here fire SNPS JIRA issue P10019563-41294 to trace)
- * here is a workround
- */
-#if defined(CONFIG_SOC_NSIM) && defined(CONFIG_SMP)
-	seti r1
-_z_arc_idle_loop:
-	b _z_arc_idle_loop
-#else
 	sleep r1
-#endif
 	j_s [blink]
 	nop
 


### PR DESCRIPTION
In old version nSIM, when cpu is sleeping, no response to inter-processor
interrupt although it's pending and interrupts are enabled(SNPS JIRA
issue P10019563-41294).
Now this has been fixed in nSIM version (2020.09), so we can safely remove it.
