### PR TITLE
[RFC]: Macro for defining file system API with default function assigned

### DIFF
--- a/include/fs/fs_sys.h
+++ b/include/fs/fs_sys.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_FS_FS_SYS_H_
+#define ZEPHYR_INCLUDE_FS_FS_SYS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @ingroup file_system_api
+ * @{
+ */
+
+#define FILE_SYSTEM_DEFINE_UNSUPPORTED_OPERATION(type) 			\
+	static type file_system_unsupported_operation_##type(void)	\
+	{								\
+		return -ENOTSUP;					\
+	}
+
+FILE_SYSTEM_DEFINE_UNSUPPORTED_OPERATION(off_t);
+FILE_SYSTEM_DEFINE_UNSUPPORTED_OPERATION(ssize_t);
+FILE_SYSTEM_DEFINE_UNSUPPORTED_OPERATION(int);
+
+#define FILE_SYSTEM_UNSUPPORTED_OPERATION(type)				\
+	(void *)file_system_unsupported_operation_##type
+
+/**
+ * @brief Define file_system_t API callback table for file system
+ *
+ * The macro defines static file_system_t object, and assigns provided
+ * callback functions to operations; operations that are not assigned
+ * any function will be assigned default function returning -ENOTSUP
+ * with exception to mount and unmount which are assigned NULL.
+ *
+ * @param name name of file_system_t object
+ * @param ... list of designated member initializers of file_system_t
+ */
+#define FILE_SYSTEM_DEFINE(name, ...)					\
+	static struct fs_file_system_t name = {				\
+		.open = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),		\
+		.read = FILE_SYSTEM_UNSUPPORTED_OPERATION(ssize_t),	\
+		.write = FILE_SYSTEM_UNSUPPORTED_OPERATION(ssize_t),	\
+		.lseek = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.tell = FILE_SYSTEM_UNSUPPORTED_OPERATION(off_t),	\
+		.truncate = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.sync = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),		\
+		.close = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.opendir = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.readdir = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.closedir = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.mount = NULL,						\
+		.unmount = NULL,					\
+		.unlink = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.rename = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.mkdir = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		.stat = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),		\
+		.statvfs = FILE_SYSTEM_UNSUPPORTED_OPERATION(int),	\
+		__VA_ARGS__						\
+	}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_FS_FS_SYS_H_ */

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -57,6 +57,16 @@ config FUSE_FS_ACCESS
 	help
 	  Expose file system partitions to the host system through FUSE.
 
+config FILE_SYSTEM_NOTSUP_CHECK
+	bool "Check if driver implements operation before invoking it"
+	default y
+	help
+	  This will cause additional code to be present in fs_* functions,
+	  that checks whether driver implements operation, by comparing
+	  operation pointer to NULL, before invoking the operation.
+	  This is REQUIRED if file system driver inferface has not been
+	  defined with FILE_SYSTEM_DEFINE macro.
+
 source "subsys/fs/Kconfig.fatfs"
 source "subsys/fs/Kconfig.littlefs"
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -13,6 +13,7 @@
 #include <fs/fs.h>
 #include <sys/__assert.h>
 #include <ff.h>
+#include <fs/fs_sys.h>
 
 #define FATFS_MAX_FILE_NAME 12 /* Uses 8.3 SFN */
 
@@ -407,7 +408,7 @@ static int fatfs_unmount(struct fs_mount_t *mountp)
 }
 
 /* File system interface */
-static const struct fs_file_system_t fatfs_fs = {
+const FILE_SYSTEM_DEFINE(fatfs_fs,
 	.open = fatfs_open,
 	.close = fatfs_close,
 	.read = fatfs_read,
@@ -426,7 +427,7 @@ static const struct fs_file_system_t fatfs_fs = {
 	.mkdir = fatfs_mkdir,
 	.stat = fatfs_stat,
 	.statvfs = fatfs_statvfs,
-};
+);
 
 static int fatfs_init(const struct device *dev)
 {

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -149,12 +149,16 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 
 	zfp->mp = mp;
 
-	if (zfp->mp->fs->open != NULL) {
-		rc = zfp->mp->fs->open(zfp, file_name, flags);
-		if (rc < 0) {
-			LOG_ERR("file open error (%d)", rc);
-			return rc;
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->open == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->open(zfp, file_name, flags);
+	if (rc < 0) {
+		LOG_ERR("file open error (%d)", rc);
+		return rc;
 	}
 
 	return rc;
@@ -164,16 +168,21 @@ int fs_close(struct fs_file_t *zfp)
 {
 	int rc = -EINVAL;
 
+
 	if (zfp->mp == NULL) {
 		return 0;
 	}
 
-	if (zfp->mp->fs->close != NULL) {
-		rc = zfp->mp->fs->close(zfp);
-		if (rc < 0) {
-			LOG_ERR("file close error (%d)", rc);
-			return rc;
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->close == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->close(zfp);
+	if (rc < 0) {
+		LOG_ERR("file close error (%d)", rc);
+		return rc;
 	}
 
 	zfp->mp = NULL;
@@ -189,11 +198,15 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->read != NULL) {
-		rc = zfp->mp->fs->read(zfp, ptr, size);
-		if (rc < 0) {
-			LOG_ERR("file read error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->read == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->read(zfp, ptr, size);
+	if (rc < 0) {
+		LOG_ERR("file read error (%d)", rc);
 	}
 
 	return rc;
@@ -207,11 +220,15 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->write != NULL) {
-		rc = zfp->mp->fs->write(zfp, ptr, size);
-		if (rc < 0) {
-			LOG_ERR("file write error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->write == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->write(zfp, ptr, size);
+	if (rc < 0) {
+		LOG_ERR("file write error (%d)", rc);
 	}
 
 	return rc;
@@ -225,11 +242,15 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->lseek != NULL) {
-		rc = zfp->mp->fs->lseek(zfp, offset, whence);
-		if (rc < 0) {
-			LOG_ERR("file seek error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->lseek == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->lseek(zfp, offset, whence);
+	if (rc < 0) {
+		LOG_ERR("file seek error (%d)", rc);
 	}
 
 	return rc;
@@ -243,11 +264,15 @@ off_t fs_tell(struct fs_file_t *zfp)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->tell != NULL) {
-		rc = zfp->mp->fs->tell(zfp);
-		if (rc < 0) {
-			LOG_ERR("file tell error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->tell == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->tell(zfp);
+	if (rc < 0) {
+		LOG_ERR("file tell error (%d)", rc);
 	}
 
 	return rc;
@@ -261,11 +286,15 @@ int fs_truncate(struct fs_file_t *zfp, off_t length)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->truncate != NULL) {
-		rc = zfp->mp->fs->truncate(zfp, length);
-		if (rc < 0) {
-			LOG_ERR("file truncate error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->truncate == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->truncate(zfp, length);
+	if (rc < 0) {
+		LOG_ERR("file truncate error (%d)", rc);
 	}
 
 	return rc;
@@ -279,11 +308,15 @@ int fs_sync(struct fs_file_t *zfp)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->sync != NULL) {
-		rc = zfp->mp->fs->sync(zfp);
-		if (rc < 0) {
-			LOG_ERR("file sync error (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zfp->mp->fs->sync == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zfp->mp->fs->sync(zfp);
+	if (rc < 0) {
+		LOG_ERR("file sync error (%d)", rc);
 	}
 
 	return rc;
@@ -319,13 +352,16 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 		return rc;
 	}
 
-	zdp->mp = mp;
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (mp->fs->opendir == NULL) {
+		return -ENOTSUP;
+	}
+#endif
 
-	if (zdp->mp->fs->opendir != NULL) {
-		rc = zdp->mp->fs->opendir(zdp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("directory open error (%d)", rc);
-		}
+	zdp->mp = mp;
+	rc = zdp->mp->fs->opendir(zdp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("directory open error (%d)", rc);
 	}
 
 	return rc;
@@ -337,27 +373,31 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 		/* Delegate to mounted filesystem */
 		int rc = -EINVAL;
 
-		if (zdp->mp->fs->readdir != NULL) {
-			/* Loop until error or not special directory */
-			while (true) {
-				rc = zdp->mp->fs->readdir(zdp, entry);
-				if (rc < 0) {
-					break;
-				}
-				if (entry->name[0] == 0) {
-					break;
-				}
-				if (entry->type != FS_DIR_ENTRY_DIR) {
-					break;
-				}
-				if ((strcmp(entry->name, ".") != 0)
-				    && (strcmp(entry->name, "..") != 0)) {
-					break;
-				}
-			}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+		if (zdp->mp->fs->readdir == NULL) {
+			return  -ENOTSUP;
+		}
+#endif
+
+		/* Loop until error or not special directory */
+		while (true) {
+			rc = zdp->mp->fs->readdir(zdp, entry);
 			if (rc < 0) {
-				LOG_ERR("directory read error (%d)", rc);
+				break;
 			}
+			if (entry->name[0] == 0) {
+				break;
+			}
+			if (entry->type != FS_DIR_ENTRY_DIR) {
+				break;
+			}
+			if ((strcmp(entry->name, ".") != 0)
+			    && (strcmp(entry->name, "..") != 0)) {
+				break;
+			}
+		}
+		if (rc < 0) {
+			LOG_ERR("directory read error (%d)", rc);
 		}
 
 		return rc;
@@ -420,12 +460,16 @@ int fs_closedir(struct fs_dir_t *zdp)
 		return 0;
 	}
 
-	if (zdp->mp->fs->closedir != NULL) {
-		rc = zdp->mp->fs->closedir(zdp);
-		if (rc < 0) {
-			LOG_ERR("directory close error (%d)", rc);
-			return rc;
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (zdp->mp->fs->closedir == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = zdp->mp->fs->closedir(zdp);
+	if (rc < 0) {
+		LOG_ERR("directory close error (%d)", rc);
+		return rc;
 	}
 
 	zdp->mp = NULL;
@@ -450,11 +494,15 @@ int fs_mkdir(const char *abs_path)
 		return rc;
 	}
 
-	if (mp->fs->mkdir != NULL) {
-		rc = mp->fs->mkdir(mp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("failed to create directory (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (mp->fs->mkdir == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = mp->fs->mkdir(mp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("failed to create directory (%d)", rc);
 	}
 
 	return rc;
@@ -477,11 +525,15 @@ int fs_unlink(const char *abs_path)
 		return rc;
 	}
 
-	if (mp->fs->unlink != NULL) {
-		rc = mp->fs->unlink(mp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("failed to unlink path (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (mp->fs->unlink == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = mp->fs->unlink(mp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("failed to unlink path (%d)", rc);
 	}
 
 	return rc;
@@ -511,11 +563,15 @@ int fs_rename(const char *from, const char *to)
 		return -EINVAL;
 	}
 
-	if (mp->fs->rename != NULL) {
-		rc = mp->fs->rename(mp, from, to);
-		if (rc < 0) {
-			LOG_ERR("failed to rename file or dir (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (mp->fs->rename == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = mp->fs->rename(mp, from, to);
+	if (rc < 0) {
+		LOG_ERR("failed to rename file or dir (%d)", rc);
 	}
 
 	return rc;
@@ -538,11 +594,15 @@ int fs_stat(const char *abs_path, struct fs_dirent *entry)
 		return rc;
 	}
 
-	if (mp->fs->stat != NULL) {
-		rc = mp->fs->stat(mp, abs_path, entry);
-		if (rc < 0) {
-			LOG_ERR("failed get file or dir stat (%d)", rc);
-		}
+#ifdef CONFIG_FILE_SYSTEM_NOTSUP_CHECK
+	if (mp->fs->stat == NULL) {
+		return -ENOTSUP;
+	}
+#endif
+
+	rc = mp->fs->stat(mp, abs_path, entry);
+	if (rc < 0) {
+		LOG_ERR("failed get file or dir stat (%d)", rc);
 	}
 	return rc;
 }

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <init.h>
 #include <fs/fs.h>
+#include <fs/fs_sys.h>
 
 #define LFS_LOG_REGISTER
 #include <lfs_util.h>
@@ -722,7 +723,7 @@ static int littlefs_unmount(struct fs_mount_t *mountp)
 }
 
 /* File system interface */
-static const struct fs_file_system_t littlefs_fs = {
+const FILE_SYSTEM_DEFINE(littlefs_fs,
 	.open = littlefs_open,
 	.close = littlefs_close,
 	.read = littlefs_read,
@@ -741,7 +742,7 @@ static const struct fs_file_system_t littlefs_fs = {
 	.mkdir = littlefs_mkdir,
 	.stat = littlefs_stat,
 	.statvfs = littlefs_statvfs,
-};
+);
 
 static int littlefs_init(const struct device *dev)
 {


### PR DESCRIPTION
The PR is proposal of `DEFINE_FILE_SYSTEM` macro that could be used to define file system driver interface

and assign default function, returning `-ENOTSUP`, for all functions that the drivers fails to implement/provide.

NOTE 2020-10-28:
The run-time NULL-check changes have been moved to another review: https://github.com/zephyrproject-rtos/zephyr/pull/29613.

TODO:
- [ ] Tests
- [ ] Update to documentation