### PR TITLE
STM32: Convert USB driver to device tree pinctrl

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -212,6 +212,8 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12
+		     &usb_otg_fs_id_pa10>;
 	status = "okay";
 };
 

--- a/boards/arm/disco_l475_iot1/pinmux.c
+++ b/boards/arm/disco_l475_iot1/pinmux.c
@@ -14,11 +14,6 @@
 
 /* pin assignments for Disco L475 IOT1 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA10, STM32L4X_PINMUX_FUNC_PA10_OTG_FS_ID},
-	{STM32_PIN_PA11, STM32L4X_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32L4X_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -119,6 +119,7 @@
 
 &usb {
 	status = "okay";
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 };
 
 &flash0 {

--- a/boards/arm/nucleo_wb55rg/pinmux.c
+++ b/boards/arm/nucleo_wb55rg/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for NUCLEO-WB55RG board */
 static const struct pin_config pinconf[] = {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb), okay)
-	{STM32_PIN_PA11, STM32WBX_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32WBX_PINMUX_FUNC_PA12_USB_DP},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1,7 +1,5 @@
 /* USB device controller driver for STM32 devices */
 
-#define DT_DRV_COMPAT st_stm32_usb
-
 /*
  * Copyright (c) 2017 Christer Weinigel.
  * Copyright (c) 2017, I-SENSE group of ICCS
@@ -63,42 +61,32 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
-#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_otghs))
-#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, irq)
-#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otghs), otghs, priority)
-#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otghs), num_bidir_endpoints)
-#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_otghs), ram_size)
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_otghs), maximum_speed)
-#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_otghs), maximum_speed)
-#endif
-#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bits)
-#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otghs), bus)
+#define DT_DRV_COMPAT st_stm32_otghs
+#define USB_IRQ_NAME  otghs
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)
-#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_otgfs))
-#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, irq)
-#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_otgfs), otgfs, priority)
-#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_otgfs), num_bidir_endpoints)
-#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_otgfs), ram_size)
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_otgfs), maximum_speed)
-#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_otgfs), maximum_speed)
-#endif
-#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bits)
-#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_otgfs), bus)
+#define DT_DRV_COMPAT st_stm32_otgfs
+#define USB_IRQ_NAME  otgfs
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
-#define USB_BASE_ADDRESS	DT_REG_ADDR(DT_INST(0, st_stm32_usb))
-#define USB_IRQ			DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, irq)
-#define USB_IRQ_PRI		DT_IRQ_BY_NAME(DT_INST(0, st_stm32_usb), usb, priority)
-#define USB_NUM_BIDIR_ENDPOINTS	DT_PROP(DT_INST(0, st_stm32_usb), num_bidir_endpoints)
-#define USB_RAM_SIZE		DT_PROP(DT_INST(0, st_stm32_usb), ram_size)
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_usb), maximum_speed)
-#define USB_MAXIMUM_SPEED	DT_PROP(DT_INST(0, st_stm32_usb), maximum_speed)
-#endif
-#define USB_CLOCK_BITS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bits)
-#define USB_CLOCK_BUS		DT_CLOCKS_CELL(DT_INST(0, st_stm32_usb), bus)
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_usb), enable_pin_remap)
-#define USB_ENABLE_PIN_REMAP	DT_PROP(DT_INST(0, st_stm32_usb), enable_pin_remap)
+#define DT_DRV_COMPAT st_stm32_usb
+#define USB_IRQ_NAME  usb
+#if DT_INST_NODE_HAS_PROP(0, enable_pin_remap)
+#define USB_ENABLE_PIN_REMAP	DT_INST_PROP(0, enable_pin_remap)
 #endif
 #endif
+
+#define USB_BASE_ADDRESS	DT_INST_REG_ADDR(0)
+#define USB_IRQ			DT_INST_IRQ_BY_NAME(0, USB_IRQ_NAME, irq)
+#define USB_IRQ_PRI		DT_INST_IRQ_BY_NAME(0, USB_IRQ_NAME, priority)
+#define USB_NUM_BIDIR_ENDPOINTS	DT_INST_PROP(0, num_bidir_endpoints)
+#define USB_RAM_SIZE		DT_INST_PROP(0, ram_size)
+#define USB_CLOCK_BITS		DT_INST_CLOCKS_CELL(0, bits)
+#define USB_CLOCK_BUS		DT_INST_CLOCKS_CELL(0, bus)
+#if DT_INST_NODE_HAS_PROP(0, maximum_speed)
+#define USB_MAXIMUM_SPEED	DT_INST_PROP(0, maximum_speed)
+#endif
+
+#define USB_OTG_HS_EMB_PHY (DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && \
+			   DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs))
 
 /*
  * USB and USB_OTG_FS are defined in STM32Cube HAL and allows to distinguish
@@ -317,7 +305,7 @@ static uint32_t usb_dc_stm32_get_maximum_speed(void)
 	 * If max-speed is not passed via DT, set it to USB controller's
 	 * maximum hardware capability.
 	 */
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
+#if USB_OTG_HS_EMB_PHY
 	uint32_t speed = USB_OTG_SPEED_HIGH;
 #else
 	uint32_t speed = USB_OTG_SPEED_FULL;
@@ -328,7 +316,7 @@ static uint32_t usb_dc_stm32_get_maximum_speed(void)
 	if (!strncmp(USB_MAXIMUM_SPEED, "high-speed", 10)) {
 		speed = USB_OTG_SPEED_HIGH;
 	} else if (!strncmp(USB_MAXIMUM_SPEED, "full-speed", 10)) {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
+#if USB_OTG_HS_EMB_PHY
 		speed = USB_OTG_SPEED_HIGH_IN_FULL;
 #else
 		speed = USB_OTG_SPEED_FULL;
@@ -364,7 +352,7 @@ static int usb_dc_stm32_init(void)
 #endif
 	usb_dc_stm32_state.pcd.Init.dev_endpoints = USB_NUM_BIDIR_ENDPOINTS;
 	usb_dc_stm32_state.pcd.Init.speed = usb_dc_stm32_get_maximum_speed();
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
+#if USB_OTG_HS_EMB_PHY
 	usb_dc_stm32_state.pcd.Init.phy_itface = USB_OTG_HS_EMBEDDED_PHY;
 #else
 	usb_dc_stm32_state.pcd.Init.phy_itface = PCD_PHY_EMBEDDED;

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -50,6 +50,7 @@
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <sys/util.h>
 #include <drivers/gpio.h>
+#include <pinmux/stm32/pinmux_stm32.h>
 #include "stm32_hsem.h"
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
@@ -84,9 +85,12 @@ LOG_MODULE_REGISTER(usb_dc_stm32);
 #if DT_INST_NODE_HAS_PROP(0, maximum_speed)
 #define USB_MAXIMUM_SPEED	DT_INST_PROP(0, maximum_speed)
 #endif
+static const struct soc_gpio_pinctrl usb_pinctrl[] =
+						ST_STM32_DT_INST_PINCTRL(0, 0);
+
 
 #define USB_OTG_HS_EMB_PHY (DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && \
-			   DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs))
+			    DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs))
 
 /*
  * USB and USB_OTG_FS are defined in STM32Cube HAL and allows to distinguish
@@ -369,6 +373,15 @@ static int usb_dc_stm32_init(void)
 #ifdef CONFIG_USB_DEVICE_SOF
 	usb_dc_stm32_state.pcd.Init.Sof_enable = 1;
 #endif /* CONFIG_USB_DEVICE_SOF */
+
+	LOG_DBG("Pinctrl signals configuration");
+	status = stm32_dt_pinctrl_configure(usb_pinctrl,
+				     ARRAY_SIZE(usb_pinctrl),
+				     (uint32_t)usb_dc_stm32_state.pcd.Instance);
+	if (status < 0) {
+		LOG_ERR("USB pinctrl setup failed (%d)", status);
+		return status;
+	}
 
 	LOG_DBG("HAL_PCD_Init");
 	status = HAL_PCD_Init(&usb_dc_stm32_state.pcd);

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -27,3 +27,13 @@ properties:
 
     clocks:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        Pin configuration for USB OTG FS signals (DM/DP/SOF/ID/VBUS).
+        We expect that the phandles will reference pinctrl nodes.
+
+        For example:
+           <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -27,3 +27,14 @@ properties:
 
     clocks:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        Pin configuration for USB OTG HS signals (DM/DP/SOF/ID/VBUS and
+        ULPI_DIR/ULPI_STP/ULPI_NXT/ULPI_D[0-7]).
+        We expect that the phandles will reference pinctrl nodes.
+
+        For example:
+           <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -39,3 +39,13 @@ properties:
 
     clocks:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        Pin configuration for USB signals (DM/DP/NOE).
+        We expect that the phandles will reference pinctrl nodes.
+
+        For example:
+           <&usb_dm_pa11 &usb_dp_pa12>;

--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: 8895167f757275a2dbfbb1e6762d71c140e4103c
+      revision: 2b123553b84cfe9e5a28078355774b636c475da0
       path: modules/hal/stm32
     - name: hal_ti
       revision: 405dfc8faba13e01c1cb9e29e70b31b50f71d117


### PR DESCRIPTION
This adds support for device tree pinctrl in STM32 USB driver

Makes use of https://github.com/zephyrproject-rtos/hal_stm32/pull/76