### PR TITLE
Bluetooth: host: Removed cb pointer from bt_le_per_adv_sync

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -167,9 +167,6 @@ struct bt_le_per_adv_sync {
 
 	/** Flags */
 	ATOMIC_DEFINE(flags, BT_PER_ADV_SYNC_NUM_FLAGS);
-
-	/** Callbacks */
-	const struct bt_le_per_adv_sync_cb *cb;
 };
 
 struct bt_dev_le {


### PR DESCRIPTION
The callbacks has been moved from being local to each
bt_le_per_adv_sync object, to being global. The
removal of the pointer in bt_le_per_adv_sync was
missing from that update.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>