### PR TITLE
Bluetooth: shell: Fix shell build with out-of-tree controller

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2884,6 +2884,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD(mesh_adv, NULL, "<on, off>", cmd_mesh_adv),
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_LL_SW_SPLIT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL,
 		      "<on hdcd ldcd off> [coded] [anon] [txp] [ad]",
@@ -2901,6 +2902,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      4, 0),
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_DTM */
+#endif /* CONFIG_BT_LL_SW_SPLIT */
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Fix shell build errors when building with combined host and controller
but the selected controller is not the in-tree zephyr controller, i.e
CONFIG_BT_CTLR=y, CONFIG_BT_LL_SW_SPLIT=n and cmd_scanx and others
are not defined.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>