### PR TITLE
nRF SoCs: Power consumption related fixes

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1950,8 +1950,13 @@ static int usb_init(const struct device *arg)
 	irq_enable(USBREGULATOR_IRQn);
 #endif
 
-	/* Use default configuration of the nrfx_power driver. */
-	static const nrfx_power_config_t power_config = { 0 };
+	static const nrfx_power_config_t power_config = {
+		.dcdcen = IS_ENABLED(CONFIG_SOC_DCDC_NRF52X) ||
+			  IS_ENABLED(CONFIG_SOC_DCDC_NRF53X_APP),
+#if NRFX_POWER_SUPPORTS_DCDCEN_VDDH
+		.dcdcenhv = IS_ENABLED(CONFIG_SOC_DCDC_NRF53X_HV),
+#endif
+	};
 
 	static const nrfx_power_usbevt_config_t usbevt_config = {
 		.handler = usb_dc_power_event_handler

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 8c45524fb7b0742f46b41b0c9e65a46a8e0eae29
+      revision: 6038f912fd34fdd46dbf017057908f979e298341
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
*drivers: usb_dc_nrfx: Correct the nrfx_power driver configuration*

The initial configuration provided for the nrfx_power driver cannot
contain just default values, as that mean that DC/DC converters are
to be disabled, while those converters may be (and they actually are
by default for many boards) enabled through Kconfig.

Update hal_nordic module to:
*nrf_power: Fix implementation of workaround for nRF52 anomaly 197*

The initial configuration provided for the nrfx_power driver cannot
contain just default values, as that mean that DC/DC converters are
to be disabled, while those converters may be (and they actually are
by default for many boards) enabled through Kconfig.

See https://github.com/zephyrproject-rtos/hal_nordic/pull/62