### PR TITLE
tests: kernel: timer_api: align tick for duration period test

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -165,6 +165,7 @@ void test_timer_duration_period(void)
 {
 	init_timer_data();
 	/** TESTPOINT: init timer via k_timer_init */
+	k_usleep(1); /* align to tick */
 	k_timer_start(&duration_timer, K_MSEC(DURATION), K_MSEC(PERIOD));
 	tdata.timestamp = k_uptime_get();
 	busy_wait_ms(DURATION + PERIOD * EXPIRE_TIMES + PERIOD / 2);


### PR DESCRIPTION
Add a k_usleep() in test_timer_duration_period test to align ticks
before starting the timer. This fixes some rare off-by-1 failures.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>