### PR TITLE
doc: dts: update design goals document

### DIFF
--- a/doc/guides/dts/design.rst
+++ b/doc/guides/dts/design.rst
@@ -24,6 +24,8 @@ Examples
   used in the current build. For example, the :ref:`blinky-sample` uses this to
   determine the LED to blink.
 
+- Boot-time pin muxing and pin control can be accomplished via devicetree.
+
 Example remaining work
 ======================
 
@@ -41,9 +43,6 @@ Example remaining work
 
 - Runtime determination of ``struct device`` relationships should be done using
   information obtained from devicetree, e.g. for device power management.
-
-- Pin muxing and pin control, at least at boot time, should be accomplished via
-  devicetree.
 
 Source compatibility with other operating systems
 *************************************************
@@ -82,10 +81,3 @@ Example remaining work
   set of bindings supported by Linux.
 
 - Devicetree source sharing between Zephyr and Linux is not done.
-
-To be determined
-****************
-
-The scope and amount of code generation for device instantiation has been the
-subject of extended discussion and prototyping without reaching a firm
-conclusion.


### PR DESCRIPTION
Some information on design goals can be updated:

- we have decided against code generation for the time being (https://github.com/zephyrproject-rtos/zephyr/issues/8499#issuecomment-713667735)
- we can do pin muxing via devicetree (this requires soc.dtsi   support, but the necessary devicetree infrastructure exists)
