### PR TITLE
dts: boards: arm: Use DT_SIZE macros for nxp memories 

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -42,7 +42,7 @@
 arduino_serial: &lpuart1 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x1000000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -71,7 +71,7 @@
 arduino_serial: &lpuart4 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x1000000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -25,7 +25,7 @@
 	sdram0: memory@80000000 {
 		/* ISSI IS42S16160J-6TLI */
 		device_type = "memory";
-		reg = <0x80000000 0x2000000>;
+		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
 	leds {
@@ -77,7 +77,7 @@
 arduino_serial: &lpuart2 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -26,7 +26,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		reg = <0x80000000 0x2000000>;
+		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
 	leds {
@@ -87,7 +87,7 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x4000000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	hyperflash0: hyperflash@0 {
 		compatible = "cypress,s26ks512s";
 		reg = <0>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -9,7 +9,7 @@
 /delete-node/ &hyperflash0;
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -27,7 +27,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		reg = <0x80000000 0x2000000>;
+		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
 	leds {
@@ -88,7 +88,7 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -8,7 +8,7 @@
 
 /delete-node/ &is25wp064;
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x4000000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	hyperflash0: hyperflash@0 {
 		compatible = "cypress,s26ks512s";
 		reg = <0>;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -28,7 +28,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		reg = <0x80000000 0x2000000>;
+		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
 	leds {

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -26,7 +26,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
-		reg = <0x80000000 0x2000000>;
+		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
 	leds {
@@ -50,7 +50,7 @@
 
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/rdc/imx_rdc.h>
@@ -48,27 +49,27 @@
 
 	tcml:memory@1fff8000 {
 		compatible = "nxp,imx-itcm";
-		reg = <0x1fff8000 0x00008000>;
+		reg = <0x1fff8000 DT_SIZE_K(32)>;
 		label = "TCML";
 	};
 
 	tcmu:memory@20000000 {
 		compatible = "nxp,imx-dtcm";
-		reg = <0x20000000 0x00008000>;
+		reg = <0x20000000 DT_SIZE_K(32)>;
 		label = "TCMU";
 	};
 
 	ocram_s:memory@208f8000 {
 		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
-		reg = <0x208f8000 0x00004000>;
+		reg = <0x208f8000 DT_SIZE_K(16)>;
 		label = "OCRAM_S";
 	};
 
 	ocram:memory@20900000 {
 		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
-		reg = <0x20900000 0x00020000>;
+		reg = <0x20900000 DT_SIZE_K(128)>;
 		label = "OCRAM";
 	};
 

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
@@ -64,39 +65,39 @@
 
 		tcml_code: code@1fff8000 {
 			compatible = "nxp,imx-itcm";
-			reg = <0x1fff8000 0x8000>;
+			reg = <0x1fff8000 DT_SIZE_K(32)>;
 			label = "TCML CODE";
 		};
 
 		tcmu_sys: memory@20000000 {
 			compatible = "nxp,imx-dtcm";
-			reg = <0x20000000 0x8000>;
+			reg = <0x20000000 DT_SIZE_K(32)>;
 			label = "TCMU SYSTEM";
 		};
 
 		ocram_code: code@900000 {
 			compatible = "nxp,imx-code-bus";
-			reg = <0x00900000 0x20000>;
+			reg = <0x00900000 DT_SIZE_K(128)>;
 			label = "OCRAM CODE";
 		};
 
 		ocram_sys: memory@20200000 {
 			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
-			reg = <0x20200000 0x20000>;
+			reg = <0x20200000 DT_SIZE_K(128)>;
 			label = "OCRAM SYSTEM";
 		};
 
 		ocram_s_code: code@20180000 {
 			compatible = "nxp,imx-code-bus";
-			reg = <0x20180000 0x8000>;
+			reg = <0x20180000 DT_SIZE_K(32)>;
 			label = "OCRAM_S CODE";
 		};
 
 		ocram_s_sys: memory@180000 {
 			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
-			reg = <0x00180000 0x8000>;
+			reg = <0x00180000 DT_SIZE_K(32)>;
 			label = "OCRAM_S SYSTEM";
 		};
 

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/clock/kinetis_mcg.h>
@@ -57,12 +58,12 @@
 	 */
 	sram_l: memory@1fff0000 {
 		compatible = "mmio-sram";
-		reg = <0x1fff0000 0x10000>;
+		reg = <0x1fff0000 DT_SIZE_K(64)>;
 	};
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x10000>;
+		reg = <0x20000000 DT_SIZE_K(64)>;
 	};
 
 	soc {
@@ -115,7 +116,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x100000>;
+				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <2048>;
 				write-block-size = <8>;
 			};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/clock/kinetis_mcg.h>
@@ -65,12 +66,12 @@
 	 */
 	sram_l: memory@1fff0000 {
 		compatible = "mmio-sram";
-		reg = <0x1fff0000 0x10000>;
+		reg = <0x1fff0000 DT_SIZE_K(64)>;
 	};
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x30000>;
+		reg = <0x20000000 DT_SIZE_K(192)>;
 	};
 
 	temp0: temp0 {
@@ -150,7 +151,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x100000>;
+				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <4096>;
 				write-block-size = <8>;
 			};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <mem.h>
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -31,7 +32,7 @@
 
 	sram0: memory@1FFFF000 {
 		compatible = "mmio-sram";
-		reg = <0x1FFFF000 0x4000>;
+		reg = <0x1FFFF000 DT_SIZE_K(16)>;
 	};
 
 	soc {
@@ -47,7 +48,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x20000>;
+				reg = <0 DT_SIZE_K(128)>;
 				erase-block-size = <1024>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/clock/kinetis_mcg.h>
@@ -43,7 +44,7 @@
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x8000>;
+		reg = <0x20000000 DT_SIZE_K(32)>;
 	};
 
 	soc {
@@ -89,7 +90,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x80000>;
+				reg = <0 DT_SIZE_K(512)>;
 				erase-block-size = <2048>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <mem.h>
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -39,7 +40,7 @@
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x4000>;
+		reg = <0x20000000 DT_SIZE_K(16)>;
 	};
 
 	soc {
@@ -80,7 +81,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x80000>;
+				reg = <0 DT_SIZE_K(512)>;
 				erase-block-size = <1024>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/clock/kinetis_mcg.h>
@@ -44,7 +45,7 @@
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x20000>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
 	};
 
 	soc {
@@ -90,7 +91,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
-				reg = <0 0x80000>;
+				reg = <0 DT_SIZE_K(512)>;
 				erase-block-size = <2048>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
@@ -40,27 +41,27 @@
 
 		sram0:memory@20000000 {
 			compatible = "mmio-sram";
-			reg = <0x20000000 0x10000>;
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 
 		sram1:memory@20010000 {
 			compatible = "mmio-sram";
-			reg = <0x20010000 0x10000>;
+			reg = <0x20010000 DT_SIZE_K(64)>;
 		};
 
 		sram2:memory@20020000 {
 			compatible = "mmio-sram";
-			reg = <0x20020000 0x8000>;
+			reg = <0x20020000 DT_SIZE_K(32)>;
 		};
 
 		sramx:memory@4000000{
 			compatible = "mmio-sram";
-			reg = <0x4000000 0x8000>;
+			reg = <0x4000000 DT_SIZE_K(32)>;
 		};
 
 		flash0:flash@0 {
 			compatible = "soc-nv-flash";
-			reg = <0 0x40000>;
+			reg = <0 DT_SIZE_K(256)>;
 		};
 
 		gpio0: gpio@0 {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/imx_ccm.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -77,17 +78,17 @@
 
 			itcm: itcm@0 {
 				compatible = "nxp,imx-itcm";
-				reg = <0x00000000 0x20000>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
 
 			dtcm: dtcm@20000000 {
 				compatible = "nxp,imx-dtcm";
-				reg = <0x20000000 0x20000>;
+				reg = <0x20000000 DT_SIZE_K(128)>;
 			};
 
 			ocram: ocram@20200000 {
 				compatible = "mmio-sram";
-				reg = <0x20200000 0x40000>;
+				reg = <0x20200000 DT_SIZE_K(256)>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -10,21 +10,16 @@
 	clock-frequency = <500000000>;
 };
 
-/* i.MX rt1010 default FlexRAM partition:
- * ITCM: 32KB
- * DTCM: 32KB
- * OCRAM: 64KB
- */
 &itcm {
-	reg = <0x00000000 0x8000>;
+	reg = <0x00000000 DT_SIZE_K(32)>;
 };
 
 &dtcm {
-	reg = <0x20000000 0x8000>;
+	reg = <0x20000000 DT_SIZE_K(32)>;
 };
 
 &ocram {
-	reg = <0x20200000 0x10000>;
+	reg = <0x20200000 DT_SIZE_K(64)>;
 };
 
 &gpio1 {

--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -10,19 +10,14 @@
 	clock-frequency = <500000000>;
 };
 
-/* i.MX rt1015 default FlexRAM partition:
- * ITCM: 32KB
- * DTCM: 32KB
- * OCRAM: 64KB
- */
 &itcm {
-	reg = <0x00000000 0x8000>;
+	reg = <0x00000000 DT_SIZE_K(32)>;
 };
 
 &dtcm {
-	reg = <0x20000000 0x8000>;
+	reg = <0x20000000 DT_SIZE_K(32)>;
 };
 
 &ocram {
-	reg = <0x20200000 0x10000>;
+	reg = <0x20200000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -10,19 +10,14 @@
 	clock-frequency = <500000000>;
 };
 
-/* i.MX rt1020 default FlexRAM partition:
- * ITCM: 64KB
- * DTCM: 64KB
- * OCRAM: 128KB
- */
 &itcm {
-	reg = <0x00000000 0x10000>;
+	reg = <0x00000000 DT_SIZE_K(64)>;
 };
 
 &dtcm {
-	reg = <0x20000000 0x10000>;
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 
 &ocram {
-	reg = <0x20200000 0x20000>;
+	reg = <0x20200000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -14,7 +14,7 @@
  */
 &ocram {
 	compatible = "mmio-sram";
-	reg = <0x20200000 0xC0000>;
+	reg = <0x20200000 DT_SIZE_K(768)>;
 };
 
 /* i.MX rt1060 has a second Ethernet controller. */

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -7,7 +7,7 @@
 #include <nxp/nxp_rt1060.dtsi>
 
 &flexspi2 {
-	reg = <0x402a4000 0x4000>, <0x70000000 0x400000>;
+	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
 	/* WINBOND */
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";


### PR DESCRIPTION
Refactors nxp i.mx, kinetis, and lpc device trees to use DT_SIZE_K and DT_SIZE_M macros to define memory sizes. This is self documenting and easier to read.