### PR TITLE
STM32: Convert boards to devicetree for USB pins configuration

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -106,6 +106,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/96b_aerocore2/pinmux.c
+++ b/boards/arm/96b_aerocore2/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for  board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -107,6 +107,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/96b_carbon/pinmux.c
+++ b/boards/arm/96b_carbon/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for 96boards Carbon board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -77,5 +77,6 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };

--- a/boards/arm/adafruit_feather_stm32f405/pinmux.c
+++ b/boards/arm/adafruit_feather_stm32f405/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for Feather STM32F405 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -190,6 +190,8 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12
+		     &usb_otg_fs_id_pa10>;
 	status = "okay";
 };
 

--- a/boards/arm/b_l4s5i_iot01a/pinmux.c
+++ b/boards/arm/b_l4s5i_iot01a/pinmux.c
@@ -14,11 +14,6 @@
 
 /* pin assignments for B_L4S5I_IOT01A board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA10, STM32L4X_PINMUX_FUNC_PA10_OTG_FS_ID},
-	{STM32_PIN_PA11, STM32L4X_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32L4X_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -82,6 +82,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/black_f407ve/pinmux.c
+++ b/boards/arm/black_f407ve/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for black_f407ve board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_black_f407ve_init(const struct device *port)

--- a/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
+++ b/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
@@ -82,6 +82,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/black_f407zg_pro/pinmux.c
+++ b/boards/arm/black_f407zg_pro/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignment for black_f407zg_pro board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -107,6 +107,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f411ce/pinmux.c
+++ b/boards/arm/blackpill_f411ce/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for Black Pill V2.0 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -65,6 +65,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/mikroe_mini_m4_for_stm32/pinmux.c
+++ b/boards/arm/mikroe_mini_m4_for_stm32/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for MINI-M4 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -65,6 +65,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f207zg/pinmux.c
+++ b/boards/arm/nucleo_f207zg/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for NUCLEO-F207ZG board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F2_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F2_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -77,6 +77,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f412zg/pinmux.c
+++ b/boards/arm/nucleo_f412zg/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for NUCLEO-F412ZG board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -77,6 +77,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f413zh/pinmux.c
+++ b/boards/arm/nucleo_f413zh/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for NUCLEO-F413ZH board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -83,6 +83,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f429zi/pinmux.c
+++ b/boards/arm/nucleo_f429zi/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for NUCLEO-F429ZI board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -80,6 +80,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f746zg/pinmux.c
+++ b/boards/arm/nucleo_f746zg/pinmux.c
@@ -14,10 +14,6 @@
 
 /* NUCLEO-F746ZG pin configurations */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{ STM32_PIN_PA11, STM32F7_PINMUX_FUNC_PA11_OTG_FS_DM },
-	{ STM32_PIN_PA12, STM32F7_PINMUX_FUNC_PA12_OTG_FS_DP },
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -80,6 +80,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f756zg/pinmux.c
+++ b/boards/arm/nucleo_f756zg/pinmux.c
@@ -14,10 +14,6 @@
 
 /* NUCLEO-F756ZG pin configurations */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{ STM32_PIN_PA11, STM32F7_PINMUX_FUNC_PA11_OTG_FS_DM },
-	{ STM32_PIN_PA12, STM32F7_PINMUX_FUNC_PA12_OTG_FS_DP },
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -83,6 +83,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f767zi/pinmux.c
+++ b/boards/arm/nucleo_f767zi/pinmux.c
@@ -14,10 +14,6 @@
 
 /* NUCLEO-F767ZI pin configurations */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{ STM32_PIN_PA11, STM32F7_PINMUX_FUNC_PA11_OTG_FS_DM },
-	{ STM32_PIN_PA12, STM32F7_PINMUX_FUNC_PA12_OTG_FS_DP },
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -103,6 +103,8 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12
+		     &usb_otg_fs_id_pa10>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l4r5zi/pinmux.c
+++ b/boards/arm/nucleo_l4r5zi/pinmux.c
@@ -14,11 +14,6 @@
 
 /* pin assignments for NUCLEO-L4R5ZI board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA10, STM32L4X_PINMUX_FUNC_PA10_OTG_FS_ID},
-	{STM32_PIN_PA11, STM32L4X_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32L4X_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -70,10 +70,12 @@
 
 /* Only one interface should be enabled at a time: usbotg_fs or usbotg_hs */
 usb_otg1: &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "disabled";
 };
 
 usb_otg2: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pb14 &usb_otg_hs_dp_pb15>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_e407/pinmux.c
+++ b/boards/arm/olimex_stm32_e407/pinmux.c
@@ -14,16 +14,6 @@
 
 /* pin assignments for OLIMEX-STM32-E407 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-#if DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_otgfs), okay)
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif /* DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_otgfs), okay) */
-#if DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_otghs), okay)
-	{STM32_PIN_PB14, STM32F4_PINMUX_FUNC_PB14_OTG_HS_DM},
-	{STM32_PIN_PB15, STM32F4_PINMUX_FUNC_PB15_OTG_HS_DP},
-#endif /* DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_otghs), okay) */
-#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -101,5 +101,6 @@
 };
 
 &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	disconnect-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>;
 };

--- a/boards/arm/olimex_stm32_h103/pinmux.c
+++ b/boards/arm/olimex_stm32_h103/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for OLIMEX-STM32-H103 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -67,3 +67,7 @@
 &rng {
 	status = "okay";
 };
+
+&usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+};

--- a/boards/arm/olimex_stm32_h407/pinmux.c
+++ b/boards/arm/olimex_stm32_h407/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for OLIMEX-STM32-H407 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -103,6 +103,7 @@ uext_serial: &usart1 {};
 &usb {
 	status = "okay";
 	disconnect-gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 };
 
 &timers1 {

--- a/boards/arm/olimexino_stm32/pinmux.c
+++ b/boards/arm/olimexino_stm32/pinmux.c
@@ -15,10 +15,6 @@
 
 /* pin assignments for OLIMEXINO-STM32 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/sensortile_box/pinmux.c
+++ b/boards/arm/sensortile_box/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for SensorTile.box board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32L4X_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32L4X_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -140,6 +140,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32_MIN_DEV board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
-#endif /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -85,6 +85,7 @@
 };
 
 &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f3_disco/pinmux.c
+++ b/boards/arm/stm32f3_disco/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32F3DISCOVERY board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F3_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32F3_PINMUX_FUNC_PA12_USB_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -122,6 +122,7 @@
 };
 
 &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f411e_disco/pinmux.c
+++ b/boards/arm/stm32f411e_disco/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32F411E-DISCO board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -84,5 +84,6 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };

--- a/boards/arm/stm32f469i_disco/pinmux.c
+++ b/boards/arm/stm32f469i_disco/pinmux.c
@@ -14,11 +14,6 @@
 
 /* pin assignments for STM32F469I-DISCO board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif  /* CONFIG_USB_DC_STM32 */
-
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -84,6 +84,7 @@ arduino_serial: &usart6 {};
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f4_disco/pinmux.c
+++ b/boards/arm/stm32f4_disco/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32F4DISCOVERY board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -84,6 +84,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f723e_disco/pinmux.c
+++ b/boards/arm/stm32f723e_disco/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32F723E-DISCO board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F7_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F7_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -88,5 +88,6 @@ arduino_serial: &usart2 {};
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };

--- a/boards/arm/stm32f746g_disco/pinmux.c
+++ b/boards/arm/stm32f746g_disco/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for STM32F746G-DISCO board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_USB_DC_STM32
-	{STM32_PIN_PA11, STM32F7_PINMUX_FUNC_PA11_OTG_FS_DM},
-	{STM32_PIN_PA12, STM32F7_PINMUX_FUNC_PA12_OTG_FS_DP},
-#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -82,6 +82,7 @@
 };
 
 &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	status = "okay";
 };
 

--- a/boards/arm/waveshare_open103z/pinmux.c
+++ b/boards/arm/waveshare_open103z/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for waveshre_open103z board */
 static const struct pin_config pinconf[] = {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb), okay) && CONFIG_USB
-	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
-	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -134,6 +134,7 @@
 	 * because they share interrupts 19, 20 (stm32f103Xb.dtsi)
 	 * reference: RM0008 rev20 page 205
 	 */
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	status = "okay";
 	disconnect-gpios = <&gpiog 15 GPIO_ACTIVE_HIGH>;
 };


### PR DESCRIPTION
Based on https://github.com/zephyrproject-rtos/zephyr/pull/29403 