### PR TITLE
Bluetooth: Kconfig: Default BT_TINYCRYPT_ECC only when not supported

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -72,6 +72,9 @@ config BT_CTLR_SMI_SUPPORT
 config BT_CTLR_CONN_RSSI_SUPPORT
 	bool
 
+config BT_CTLR_ECDH_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -265,6 +268,14 @@ config BT_CTLR_LE_ENC
 	help
 	  Enable support for Bluetooth v4.0 LE Encryption feature in the
 	  Controller.
+
+config BT_CTLR_ECDH
+	bool "Elliptic Curve Diffie-Hellman (ECDH)"
+	depends on BT_CTLR_ECDH_SUPPORT
+	default y
+	help
+	  Enable support for Bluetoooth v4.2 Elliptic Curve Diffie-Hellman
+	  feature in the controller.
 
 config BT_CTLR_CONN_PARAM_REQ
 	bool "Connection Parameter Request"

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -604,11 +604,11 @@ config BT_ECC
 	  This option adds support for ECDH HCI commands.
 
 config BT_TINYCRYPT_ECC
-	bool "Use TinyCrypt library for ECDH"
+	bool "Emulate ECDH in the Host using TinyCrypt library"
 	select TINYCRYPT
 	select TINYCRYPT_ECC_DH
 	depends on BT_ECC && (BT_HCI_RAW || BT_HCI_HOST)
-	default y if BT_CTLR
+	default y if BT_CTLR && !BT_CTLR_ECDH
 	help
 	  If this option is set TinyCrypt library is used for emulating the
 	  ECDH HCI commands and events needed by e.g. LE Secure Connections.


### PR DESCRIPTION
Introduce a support kconfig for controller ECDH command support.
Default to host ECDH emulation in combined host controller build
where the controller does not support these commands.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>