### PR TITLE
include: sys: use C linkage

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -16,6 +16,10 @@
  * FUTEX_LOCK_PI and FUTEX_UNLOCK_PI
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef CONFIG_USERSPACE
 #include <sys/atomic.h>
 #include <zephyr/types.h>
@@ -148,4 +152,9 @@ static inline int sys_mutex_unlock(struct sys_mutex *mutex)
 }
 
 #endif /* CONFIG_USERSPACE */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZEPHYR_INCLUDE_SYS_MUTEX_H_ */


### PR DESCRIPTION
This fixes the following compiler error in C++

```
/mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/EcMaster/build/zephyr/include/generated/syscalls/mutex.h:25:19: error: conflicting declaration of 'int z_sys_mutex_kernel_lock(sys_mutex*, k_timeout_t)' with 'C' linkage
   25 | static inline int z_sys_mutex_kernel_lock(struct sys_mutex * mutex, k_timeout_t timeout)
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mempool.h:12,
                 from /mnt/d/Proj/Latest/ATEM/Sources/LinkOsLayer/Zephyr/LinkOsLayer.cpp:18:
/mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mutex.h:63:15: note: previous declaration with 'C++' linkage
   63 | __syscall int z_sys_mutex_kernel_lock(struct sys_mutex *mutex,
      |               ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mutex.h:120,
                 from /mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mempool.h:12,
                 from /mnt/d/Proj/Latest/ATEM/Sources/LinkOsLayer/Zephyr/LinkOsLayer.cpp:18:
/mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/EcMaster/build/zephyr/include/generated/syscalls/mutex.h:38:19: error: conflicting declaration of 'int z_sys_mutex_kernel_unlock(sys_mutex*)' with 'C' linkage
   38 | static inline int z_sys_mutex_kernel_unlock(struct sys_mutex * mutex)
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mempool.h:12,
                 from /mnt/d/Proj/Latest/ATEM/Sources/LinkOsLayer/Zephyr/LinkOsLayer.cpp:18:
/mnt/d/Proj/Latest/ATEM/Workspace/Zephyr/zephyr/include/sys/mutex.h:66:15: note: previous declaration with 'C++' linkage
   66 | __syscall int z_sys_mutex_kernel_unlock(struct sys_mutex *mutex);
```