### PR TITLE
Doc/flash: offsets clarification and designation of what belongs to the flash zephyr-internal interface API 

### DIFF
--- a/doc/reference/peripherals/flash.rst
+++ b/doc/reference/peripherals/flash.rst
@@ -18,8 +18,13 @@ dedicated-purpose region (such a region obviously can't be covered under
 API for retrieving the layout of pages).
 
 
-API Reference
-*************
 
+User API Reference
+******************
 .. doxygengroup:: flash_interface
+   :project: Zephyr
+
+Implementation interface API Reference
+**************************************
+.. doxygengroup:: flash_internal_interface
    :project: Zephyr

--- a/doc/reference/peripherals/flash.rst
+++ b/doc/reference/peripherals/flash.rst
@@ -6,6 +6,17 @@ Flash
 Overview
 ********
 
+**Flash offset concept**
+
+Offsets used by the user API are expressed in relation to
+the flash memory beginning address. This rule shall be applied to
+all flash controller regular memory that layout is accessible via
+API for retrieving the layout of pages (see option:`CONFIG_FLASH_PAGE_LAYOUT`).
+
+An exception from the rule may be applied to a vendor-specific flash
+dedicated-purpose region (such a region obviously can't be covered under
+API for retrieving the layout of pages).
+
 
 API Reference
 *************

--- a/doc/reference/storage/flash_map/flash_map.rst
+++ b/doc/reference/storage/flash_map/flash_map.rst
@@ -47,6 +47,9 @@ both MCUboot and a storage partition. Some details were left out for clarity.
    :language: DTS
    :start-after: start-after-here
 
+Rule for offsets is that each partition offset shall be expressed in relation to
+the flash memory beginning address to which the partition belong.
+
 The ``boot_partition``, ``slot0_partition``, ``slot1_partition``, and
 ``scratch_partition`` nodes are defined for MCUboot, though not all MCUboot
 configurations require all of them to be defined. See the `MCUboot

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_FLASH_H_
 
 /**
- * @brief FLASH Interface
- * @defgroup flash_interface FLASH Interface
+ * @brief FLASH internal Interface
+ * @defgroup flash_internal_interface FLASH internal Interface
  * @ingroup io_interfaces
  * @{
  */
@@ -37,6 +37,17 @@ struct flash_pages_layout {
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 /**
+ * @}
+ */
+
+/**
+ * @brief FLASH Interface
+ * @defgroup flash_interface FLASH Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
  * Flash memory parameters. Contents of this structure suppose to be
  * filled in during flash device initialization and stay constant
  * through a runtime.
@@ -45,6 +56,15 @@ struct flash_parameters {
 	const size_t write_block_size;
 	uint8_t erase_value; /* Byte value of erased flash */
 };
+
+/**
+ * @}
+ */
+
+/**
+ * @addtogroup flash_internal_interface
+ * @{
+ */
 
 typedef int (*flash_api_read)(const struct device *dev, off_t offset,
 			      void *data,
@@ -102,6 +122,15 @@ __subsystem struct flash_driver_api {
 	flash_api_read_jedec_id read_jedec_id;
 #endif /* CONFIG_FLASH_JESD216_API */
 };
+
+/**
+ * @}
+ */
+
+/**
+ * @addtogroup flash_interface
+ * @{
+ */
 
 /**
  *  @brief  Read data from flash


### PR DESCRIPTION
- 1
Added information about that offsets are expressed in relation to
the flash memory beginning address.
Pleas note that this is description for the current state - **not a change,**

This info was missing which cause misunderstanding of the concept
while contributing.

- 2
Divided doxygen API documentation into zephyr-internal API and
user API.
This make sense as user shall not use zephyr-internal API.

![image](https://user-images.githubusercontent.com/17042885/96864460-bc1b6b80-1468-11eb-8080-cbd0e7a7943e.png)

...
...
![image](https://user-images.githubusercontent.com/17042885/96863753-a22d5900-1467-11eb-94c6-fd63072bb230.png)

