### PR TITLE
Bluetooth: shell: Fix ifdef order in command inclusion

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2883,8 +2883,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	SHELL_CMD(mesh_adv, NULL, "<on, off>", cmd_mesh_adv),
 #endif /* CONFIG_BT_HCI_MESH_EXT */
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
+
 #if defined(CONFIG_BT_LL_SW_SPLIT)
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL,
 		      "<on hdcd ldcd off> [coded] [anon] [txp] [ad]",
@@ -2903,6 +2904,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_DTM */
 #endif /* CONFIG_BT_LL_SW_SPLIT */
+
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Fix ifdef in command inclusion, in practice this meant that
CONFIG_BT_LL_SW_SPLIT and CONFIG_BT_CTLR_ADV_EXT switched meaning.
Added blank lines so that the commands in shell/ll.c are more
easily visible as group.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>