### PR TITLE
tests: benchmarks: sys_kernel: Add mem_slab benchmark and changed checking for pending threads algo

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4186,6 +4186,7 @@ struct k_mem_slab {
 	char *free_list;
 	uint32_t num_used;
 
+	bool is_out_of_mem;
 	_OBJECT_TRACING_NEXT_PTR(k_mem_slab)
 	_OBJECT_TRACING_LINKED_FLAG
 };

--- a/tests/benchmarks/sys_kernel/README.txt
+++ b/tests/benchmarks/sys_kernel/README.txt
@@ -3,7 +3,7 @@ Title: kernel Object Performance
 Description:
 
 The SysKernel test measures the performance of semaphore,
-lifo, fifo and stack objects.
+lifo, fifo, stack and memslab objects.
 
 --------------------------------------------------------------------------------
 
@@ -167,6 +167,22 @@ TEST COVERAGE:
         k_stack_push
         k_stack_pop(K_FOREVER)
         k_stack_push
+Starting test. Please wait...
+TEST RESULT: SUCCESSFUL
+DETAILS: Average time for 1 iteration: NNNN nSec
+END TEST CASE
+
+TEST CASE: Memslab #1
+TEST COVERAGE:
+        k_mem_slab_alloc
+Starting test. Please wait...
+TEST RESULT: SUCCESSFUL
+DETAILS: Average time for 1 iteration: NNNN nSec
+END TEST CASE
+
+TEST CASE: Memslab #2
+TEST COVERAGE:
+        k_mem_slab_free
 Starting test. Please wait...
 TEST RESULT: SUCCESSFUL
 DETAILS: Average time for 1 iteration: NNNN nSec

--- a/tests/benchmarks/sys_kernel/src/mem_slab.c
+++ b/tests/benchmarks/sys_kernel/src/mem_slab.c
@@ -1,0 +1,115 @@
+/* memslab.c */
+
+/*
+ * Copyright (c) 2020, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "syskernel.h"
+
+#define MEM_SLAB_BLOCK_SIZE  (32)
+#define MEM_SLAB_BLOCK_CNT   (10240)
+#define MEM_SLAB_BLOCK_ALIGN (4)
+
+K_MEM_SLAB_DEFINE(my_slab,
+		  MEM_SLAB_BLOCK_SIZE,
+		  MEM_SLAB_BLOCK_CNT,
+		  MEM_SLAB_BLOCK_ALIGN);
+
+/* Array contains pointers to allocated regions. */
+void *slab_array[MEM_SLAB_BLOCK_CNT];
+
+/**
+ *
+ * @brief Memslab allocation test function.
+ *		  This test allocates available memory space.
+ *
+ * @param no_of_loops  Amount of loops to run.
+ * @param test_repeats Amount of test repeats per loop.
+ *
+ * @return NUmber of done loops.
+ */
+static int mem_slab_alloc_test(int no_of_loops, int test_repeats)
+{
+	int slab_no = 0;
+	int i;
+
+	for (i = 0; i < no_of_loops; i++) {
+		for (int idx = 0; idx < test_repeats; idx++) {
+			if (k_mem_slab_alloc(&my_slab, &slab_array[slab_no++], K_MSEC(100))
+			    != 0) {
+				return i;
+			}
+		}
+	}
+	return i;
+}
+
+/**
+ *
+ * @brief Memslab free test function.
+ *		  This test frees memory previously allocated in
+ *		  @ref mem_slab_alloc_test.
+ *
+ * @param no_of_loops  Amount of loops to run.
+ * @param test_repeats Amount of test repeats per loop.
+ *
+ * @return NUmber of done loops.
+ */
+static int mem_slab_free_test(int no_of_loops, int test_repeats)
+{
+	int slab_no = 0;
+	int i;
+
+	for (i = 0; i < no_of_loops; i++) {
+		for (int idx = 0; idx < test_repeats; idx++) {
+			k_mem_slab_free(&my_slab, &slab_array[slab_no++]);
+		}
+	}
+
+	return i;
+}
+
+int mem_slab_test(void)
+{
+	u32_t t;
+	int i = 0;
+	int return_value = 0;
+
+	/* Divide number of available blocks by number of loops to provide
+	 * maximum allowable number of slabs per loop to test. */
+	int test_repeats = MEM_SLAB_BLOCK_CNT / number_of_loops;
+
+	/* Test k_mem_slab_alloc. */
+	fprintf(output_file, sz_test_case_fmt,
+		"Memslab #1");
+	fprintf(output_file, sz_description,
+		"\n\tk_mem_slab_alloc");
+	printf(sz_test_start_fmt);
+
+	t = BENCH_START();
+	i = mem_slab_alloc_test(number_of_loops, test_repeats);
+	t = TIME_STAMP_DELTA_GET(t);
+
+	return_value += check_result(i, t);
+
+	/* Test k_mem_slab_free. */
+	fprintf(output_file, sz_test_case_fmt,
+		"Memslab #2");
+	fprintf(output_file, sz_description,
+		"\n\tk_mem_slab_free");
+	printf(sz_test_start_fmt);
+
+	t = BENCH_START();
+	i = mem_slab_free_test(number_of_loops, test_repeats);
+	t = TIME_STAMP_DELTA_GET(t);
+
+	/* Check if all slabs were freed. */
+	if (k_mem_slab_num_used_get(&my_slab) != 0) {
+		i = 0;
+	}
+	return_value += check_result(i, t);
+
+	return return_value;
+}

--- a/tests/benchmarks/sys_kernel/src/syskernel.c
+++ b/tests/benchmarks/sys_kernel/src/syskernel.c
@@ -165,6 +165,7 @@ void main(void)
 		test_result += lifo_test();
 		test_result += fifo_test();
 		test_result += stack_test();
+		test_result += mem_slab_test();
 
 		if (test_result) {
 			/* sema/lifo/fifo/stack account for 12 tests in total */

--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -51,6 +51,7 @@ int sema_test(void);
 int lifo_test(void);
 int fifo_test(void);
 int stack_test(void);
+int mem_slab_test(void);
 void begin_test(void);
 
 static inline uint32_t BENCH_START(void)


### PR DESCRIPTION
In single-thread applications or when mem_slab is used only by one thread,
there is no need to check if any therad is pending during freeing the slab.
In multithreading application this can be optimized - check for
pending threads (in k_mem_slab_free) could be done only if there is no memory
to allocate.
This change introduces significant time savings.
Execution mem_slab benchmark on nrf5340 (App core @64MHz)  gives results:
Feature enabled:  1846313 [ns]
Feature disabled: 1068115 [ns]

Difference is significant: 778198[ns], which is almost 1[ms].