### PR TITLE
scripts/west_commands: Don't demand non-empty output formats

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -173,11 +173,6 @@ class Sign(Forceable):
         elif args.gen_hex is None and hex_exists:
             formats.append('hex')
 
-        if not formats:
-            if not args.quiet:
-                log.dbg('nothing to do: no output files')
-            return
-
         # Delegate to the signer.
         if args.tool == 'imgtool':
             signer = ImgtoolSigner()


### PR DESCRIPTION
It's not clear why this error is here.  The "formats" array seems to
be limited to "bin" and "hex" only, but every signing tool is going to
have its own idea of what format to emit and what ingredients need to
be used to do that.

In particular, rimage (used for the Intel Audio DSPs) doesn't use nor
generate zephyr.bin (it's very large), so it trips over this failure.

Just present the possibly-empty list of output formats to the Signer
object and let it make the decision about whether an empty formats
list is an error.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>