### PR TITLE
Add mcumgr shell management

### DIFF
--- a/doc/guides/device_mgmt/index.rst
+++ b/doc/guides/device_mgmt/index.rst
@@ -13,6 +13,7 @@ The following management operations are available:
 * File System management
 * Log management (currently disabled)
 * OS management
+* Shell management
 
 over the following transports:
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -22,6 +22,7 @@ This sample application supports the following mcumgr transports by default:
     * ``img_mgmt``
     * ``os_mgmt``
     * ``stat_mgmt``
+    * ``shell_mgmt``
 
 Caveats
 *******
@@ -109,7 +110,7 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
    .. group-tab:: Serial
 
-      To build the serial sample with file-system support:
+      To build the serial sample with file-system and shell management support:
 
       .. code-block:: console
 
@@ -117,7 +118,7 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             -b frdm_k64f \
             samples/subsys/mgmt/mcumgr/smp_svr \
             -- \
-            -DOVERLAY_CONFIG='overlay-serial.conf;overlay-fs.conf'
+            -DOVERLAY_CONFIG='overlay-serial.conf;overlay-fs.conf;overlay-shell-mgmt.conf'
 
    .. group-tab:: USB CDC_ACM
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell-mgmt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell-mgmt.conf
@@ -1,0 +1,3 @@
+# Enable shell commands.
+CONFIG_SHELL=y
+CONFIG_MCUMGR_CMD_SHELL_MGMT=y

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -24,6 +24,9 @@
 #ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
 #include "stat_mgmt/stat_mgmt.h"
 #endif
+#ifdef CONFIG_MCUMGR_CMD_SHELL_MGMT
+#include "shell_mgmt/shell_mgmt.h"
+#endif
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 #include <logging/log.h>
@@ -80,6 +83,9 @@ void main(void)
 #endif
 #ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
 	stat_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_SHELL_MGMT
+	shell_mgmt_register_group();
 #endif
 #ifdef CONFIG_MCUMGR_SMP_BT
 	start_smp_bluetooth();

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -123,6 +123,18 @@ config FS_MGMT_PATH_SIZE
 	  and download commands.
 endif
 
+config MCUMGR_CMD_SHELL_MGMT
+	bool "Enable mcumgr handlers for shell management"
+	depends on SHELL
+	select SHELL_BACKEND_DUMMY
+	help
+	  Enables mcumgr handlers for shell management. The handler will utilize
+	  the dummy backend to execute shell commands and capture the output to
+	  an internal memory buffer. This way, there is no interaction with
+	  physical interfaces outside of the scope of the user.
+	  It is possible to use additional shell backends in coordination
+	  with this handler and they will not interfere.
+
 menuconfig MCUMGR_CMD_IMG_MGMT
 	bool "Enable mcumgr handlers for image management"
 	select FLASH

--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
       revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 1e5e3ecd5b836183e9970991ab2c8f38c5e60298
+      revision: f28a637db12c4b12fb2b18bddc6b2a0deaa95251
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a


### PR DESCRIPTION
I just submitted a PR to the upstream mcumgr repo (https://github.com/apache/mynewt-mcumgr/pull/99) which implements the shell command handler for mcumgr.

I am preparing this PR in hopes that it gets merged, and also to get feedback on the implementation. Included in this PR is a change to the mcumgr smp_srv sample which includes an additional overlay allowing this handler to be enabled.

**To test:**

1. `west update` (to update the mcumgr lib to the one pointed to by my PR in the upstream repo)
1. Build and flash mcuboot
1. Build, sign, and flash smp_srv sample with `OVERLAY_CONFIG=overlay-shell-mgmt.conf`. ~~**Note:** Don't use the shell as a backend, as this won't work without changing the shell-mgmt overlay. Details on this below.~~
1. Test shell management feature with mcumgr-cli.

An example test with mcumgr-cli would be: `mcumgr -c <connection profile> shell exec "kernel cycles"`

To be done:

- [x] Update west.yml to point to the official commit if / when the PR is merged

- [x] Update docs to show that this command handler is supported?

Edit: I forgot to mention that in order to use this you need to perform a `west update` so that the intended mcumgr source is used.

Edit 2: After some feedback I have decided to remove the support for serial backend for this feature to prevent sending anything to the output of another interface. The dummy backend is now enforced.

Edit 3: I realized that with the dummy backend enforced and fully isolated from any physical transport layer for the shell, there is no reason to require that shell transport is disabled. It is possible now to have this work safely in coordination with a serial shell, and it will even work with shell as the transport layer for mcumgr.