### PR TITLE
soc: arm: cypress: psoc6: Add Cortex-M0+ interrupt mux support

### DIFF
--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -86,7 +86,3 @@
 		};
 	};
 };
-
-&nvic {
-	arm,num-irq-priority-bits = <2>;
-};

--- a/dts/arm/cypress/psoc6_cm0.dtsi
+++ b/dts/arm/cypress/psoc6_cm0.dtsi
@@ -15,6 +15,308 @@
 
 		/delete-node/ cpu@1;
 	};
+
+	soc {
+		intmux: intmux@40210020 {
+			/* see cypress,psoc6-int-mux.yaml */
+			compatible = "cypress,psoc6-intmux";
+			reg = <0x40210020 0x20>;
+			ranges = <0x0 0x40210020 0x20>;
+			label = "INTMUX";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			intmux_ch0: interrupt-controller@0 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x0 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <0 3>;
+				label = "INTMUX_CH0";
+				status = "okay";
+			};
+			intmux_ch1: interrupt-controller@1 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <1 3>;
+				label = "INTMUX_CH1";
+				status = "okay";
+			};
+			intmux_ch2: interrupt-controller@2 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x2 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <2 3>;
+				label = "INTMUX_CH2";
+				status = "okay";
+			};
+			intmux_ch3: interrupt-controller@3 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x3 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <3 3>;
+				label = "INTMUX_CH3";
+				status = "okay";
+			};
+			intmux_ch4: interrupt-controller@4 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x4 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <4 3>;
+				label = "INTMUX_CH4";
+				status = "okay";
+			};
+			intmux_ch5: interrupt-controller@5 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x5 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <5 3>;
+				label = "INTMUX_CH5";
+				status = "okay";
+			};
+			intmux_ch6: interrupt-controller@6 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x6 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <6 3>;
+				label = "INTMUX_CH6";
+				status = "okay";
+			};
+			intmux_ch7: interrupt-controller@7 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x7 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <7 3>;
+				label = "INTMUX_CH7";
+				status = "okay";
+			};
+			intmux_ch8: interrupt-controller@8 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x8 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <8 3>;
+				label = "INTMUX_CH8";
+				status = "okay";
+			};
+			intmux_ch9: interrupt-controller@9 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x9 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <9 3>;
+				label = "INTMUX_CH9";
+				status = "okay";
+			};
+			intmux_ch10: interrupt-controller@a {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xa 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <10 3>;
+				label = "INTMUX_CH10";
+				status = "okay";
+			};
+			intmux_ch11: interrupt-controller@b {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xb 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <11 3>;
+				label = "INTMUX_CH11";
+				status = "okay";
+			};
+			intmux_ch12: interrupt-controller@c {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xc 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <12 3>;
+				label = "INTMUX_CH12";
+				status = "okay";
+			};
+			intmux_ch13: interrupt-controller@d {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xd 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <13 3>;
+				label = "INTMUX_CH13";
+				status = "okay";
+			};
+			intmux_ch14: interrupt-controller@e {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xe 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <14 3>;
+				label = "INTMUX_CH14";
+				status = "okay";
+			};
+			intmux_ch15: interrupt-controller@f {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0xf 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <15 3>;
+				label = "INTMUX_CH15";
+				status = "okay";
+			};
+			intmux_ch16: interrupt-controller@10 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x10 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <16 3>;
+				label = "INTMUX_CH16";
+				status = "okay";
+			};
+			intmux_ch17: interrupt-controller@11 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x11 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <17 3>;
+				label = "INTMUX_CH17";
+				status = "okay";
+			};
+			intmux_ch18: interrupt-controller@12 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x12 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <18 3>;
+				label = "INTMUX_CH18";
+				status = "okay";
+			};
+			intmux_ch19: interrupt-controller@13 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x13 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <19 3>;
+				label = "INTMUX_CH19";
+				status = "okay";
+			};
+			intmux_ch20: interrupt-controller@14 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x14 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <20 3>;
+				label = "INTMUX_CH20";
+				status = "okay";
+			};
+			intmux_ch21: interrupt-controller@15 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x15 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <21 3>;
+				label = "INTMUX_CH21";
+				status = "okay";
+			};
+			intmux_ch22: interrupt-controller@16 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x16 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <22 3>;
+				label = "INTMUX_CH22";
+				status = "okay";
+			};
+			intmux_ch23: interrupt-controller@17 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x17 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <23 3>;
+				label = "INTMUX_CH23";
+				status = "okay";
+			};
+			intmux_ch24: interrupt-controller@18 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x18 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <24 3>;
+				label = "INTMUX_CH24";
+				status = "okay";
+			};
+			intmux_ch25: interrupt-controller@19 {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x19 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <25 3>;
+				label = "INTMUX_CH25";
+				status = "okay";
+			};
+			intmux_ch26: interrupt-controller@1a {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1a 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <26 3>;
+				label = "INTMUX_CH26";
+				status = "okay";
+			};
+			intmux_ch27: interrupt-controller@1b {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1b 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <27 3>;
+				label = "INTMUX_CH27";
+				status = "okay";
+			};
+			intmux_ch28: interrupt-controller@1c {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1c 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <28 3>;
+				label = "INTMUX_CH28";
+				status = "okay";
+			};
+			intmux_ch29: interrupt-controller@1d {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1d 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <29 3>;
+				label = "INTMUX_CH29";
+				status = "okay";
+			};
+			intmux_ch30: interrupt-controller@1e {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1e 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <30 3>;
+				label = "INTMUX_CH30";
+				status = "okay";
+			};
+			intmux_ch31: interrupt-controller@1f {
+				compatible = "cypress,psoc6-intmux-ch";
+				reg = <0x1f 1>;
+				#interrupt-cells = <2>;
+				interrupt-controller;
+				interrupts = <31 3>;
+				label = "INTMUX_CH31";
+				status = "okay";
+			};
+		};
+	};
 };
 
 &nvic {

--- a/dts/bindings/interrupt-controller/cypress,psoc6-int-mux.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-int-mux.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2018 Foundries.io
+# Copyright (c) 2020 ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Cypress Interrupt Multiplex
+
+  The PSoC-6 Cortex-M0+ NVIC can handle up to 32 interrupts. This means that
+  user can select up to 32 interrupts sources from the 240 possible vectors
+  to be processed in the Cortex-M0+ CPU.
+
+  At CPU Sub System (CPUSS) there are 8 special registers (intmux[0~7]) to
+  configure the 32 NVIC lines for Cortex-M0+ CPU. Each register handles up to
+  4 interrupt sources by grouping intmux channels. These means that each byte
+  from intmux[0~7] store a 'vector number' which selects the peripheral
+  interrupt source in the multiplexer. The multiplexer is placed before
+  Cortex-M0+ NVIC controller. Note that Cortex-M4 have all interrupt sources
+  directly connected to NVIC and doesn't require any special configuration.
+
+  On a general view, the below represents the Interrupt Multiplexer
+  configuration and how the Cortex-M0+ NVIC sources are organized. Each
+  channel chX represents a Cortex-M0+ NVIC line and it stores a vector number.
+  The vector number selects the PSoC-6 peripheral interrupt source for the
+  Cortex-M0+ NVIC controller line.
+
+  intmux[0] = {ch03, ch02, ch01, ch00}
+  intmux[1] = {ch07, ch06, ch05, ch04}
+  ...
+  intmux[7] = {ch31, ch30, ch29, ch28}
+
+  In pratical terms, the Cortex-M0+ requires user to define all NVIC interrupt
+  sources and the proper NVIC interrupt order. With that, the system configures
+  the Cortex-M0+ Interrupt Multiplexer and interrupts can be processed.
+  More information about it at PSoC-6 Architecture Technical Reference Manual,
+  section CPU Sub System (CPUSS) Registers.
+
+
+  The below fragment configure the GPIO Port 0 to generate an interrupt at
+  Cortex-M0+ NVIC:
+
+  At psoc6.dtsi file the gpio_prt0 peripheral had the interrupt source 2:
+
+  gpio_prt0: gpio@40320100 {
+    interrupts = <2 1>;
+  };
+
+  In order to enable gpio_prt0 interrupt at Cortex-M0+ an interrupt parent
+  must be defined at gpio_prt0 node selecting the Interrupt Multiplex Channel.
+  This can be defined at <board>_m0.dts file:
+
+  &gpio_prt0 {
+    interrupt-parent = <&intmux_ch20>;
+  };
+
+  The translation of these two definitions is:
+         CH   REGS  INT NUM    CH   CH/REG
+  intmux[20 mod 8] |= 0x02 << (20 mod 4);
+
+  These results in Cortex-M0+ NVIC line 20 handling PSoC-6 interrupt source 2.
+  The interrupt can be enabled/disable at NVIC at line 20 as usual.
+
+  Notes:
+  1) Multiple definitions will generate multiple interrutps
+  2) The interrupt sources are shared between Cortex-M0+/M4. These means, can
+     trigger action in parallel in both processors.
+  3) User can change priority at Cortex-M0+ NVIC by changing interrupt channels
+     at interrupt-parent properties.
+  4) Only the peripherals used by Cortex-M0+ should be configured.
+
+compatible: "cypress,psoc6-intmux"
+
+include: base.yaml
+
+properties:
+  reg:
+      required: true
+
+  label:
+      required: true

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux-ch.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2019, Linaro Limited
+# Copyright (c) 2020, ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Cypress Interrupt Multiplex Channel
+
+  see cypress,psoc6-intmux
+
+compatible: "cypress,psoc6-intmux-ch"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+      required: true
+
+  label:
+      required: true
+
+  interrupts:
+      required: true
+
+interrupt-cells:
+  - irq
+  - priority

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Linaro Ltd.
+ * Copyright (c) 2020 ATL Electronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Cypress PSoC-6 MCU family devicetree helper macros
+ */
+
+#ifndef _CYPRESS_PSOC6_DT_H_
+#define _CYPRESS_PSOC6_DT_H_
+
+#include <devicetree.h>
+
+/*
+ * Devicetree macros related to interrupt
+ *
+ * The main "API" macro is CY_PSOC6_IRQ_CONFIG. It is an internal definition
+ * used to configure the PSoC-6 interrupts in a generic way. This is necessary
+ * because Cortex-M0+ can handle a limited number of interrupts and have
+ * multiplexers in front of any NVIC interrupt line.
+ *
+ * The CY_PSOC6_IRQ_CONFIG expands from CY_PSOC6_DT_INST_NVIC_INSTALL, the
+ * public API used by drivers. See below code fragment:
+ *
+ * static void <driver>_psoc6_isr(const struct device *dev)
+ * {
+ *     ...
+ * }
+ *
+ * #define <DRIVER>_PSOC6_INIT(n)					\
+ *    ...								\
+ * static void <driver>_psoc6_irq_config(const struct device *port)	\
+ * {									\
+ *      CY_PSOC6_DT_INST_NVIC_INSTALL(n,				\
+ *                                    <driver>_psoc6_isr);		\
+ *      };								\
+ * };
+ *
+ * where:
+ *   n   - driver instance number
+ *   isr - isr function to be called
+ *
+ * Cortex-M4 simple pass the parameter and constructs an usual NVIC
+ * configuration code.
+ *
+ * The Cortex-M0+ must get from interrupt parent the interrupt line and
+ * configure the interrupt channel to connect PSoC-6 peripheral interrupt to
+ * Cortex-M0+ NVIC. The multiplexer is configured by CY_PSOC6_DT_NVIC_MUX_MAP
+ * using the interrupt value from the interrupt parent.
+ *
+ * see cypress,psoc6-int-mux.yaml for devicetree documentation.
+ */
+#ifdef CONFIG_CPU_CORTEX_M0PLUS
+/* Cortex-M0+
+ * - install config only when exists an interrupt_parent property
+ * - get peripheral irq using PROP_BY_INDEX, to avoid translation from
+ *   interrupt-parent node property.
+ * - configure interrupt channel using the channel number register value from
+ *   interrupt-parent node.
+ */
+#define CY_PSOC6_DT_INST_NVIC_INSTALL(n, isr)	              \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, interrupt_parent),\
+		(CY_PSOC6_IRQ_CONFIG(n, isr)))
+#define CY_PSOC6_NVIC_MUX_IRQN(n) DT_IRQN(DT_INST_PHANDLE_BY_IDX(n,\
+						interrupt_parent, 0))
+/*
+ * DT_INST_PROP_BY_IDX should be used get interrupt and configure, instead
+ * DT_INST_IRQN. The DT_INST_IRQN return IRQ number with level translation,
+ * since it uses interrupt-parent, and the value at Cortex-M0 NVIC multiplexers
+ * will be wrong.
+ *
+ * See multi-level-interrupt-handling.
+ */
+#define CY_PSOC6_NVIC_MUX_MAP(n) Cy_SysInt_SetInterruptSource( \
+					DT_IRQN(DT_INST_PHANDLE_BY_IDX(n,\
+						interrupt_parent, 0)), \
+					DT_INST_PROP_BY_IDX(n, interrupts, 0))
+#else
+/* Cortex-M4
+ * - bypass config
+ * - uses irq directly from peripheral devicetree definition
+ * - no map/translations
+ */
+#define CY_PSOC6_DT_INST_NVIC_INSTALL(n, isr) CY_PSOC6_IRQ_CONFIG(n, isr)
+#define CY_PSOC6_NVIC_MUX_IRQN(n) DT_INST_IRQN(n)
+#define CY_PSOC6_NVIC_MUX_MAP(n)
+#endif
+
+#define CY_PSOC6_IRQ_CONFIG(n, isr)			\
+	do {						\
+		IRQ_CONNECT(CY_PSOC6_NVIC_MUX_IRQN(n),	\
+			    DT_INST_IRQ(n, priority),	\
+			    isr, DEVICE_DT_INST_GET(n), 0);\
+		CY_PSOC6_NVIC_MUX_MAP(n);		\
+		irq_enable(CY_PSOC6_NVIC_MUX_IRQN(n));	\
+	} while (0)
+
+#endif /* _CYPRESS_PSOC6_SOC_DT_H_ */

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -24,6 +24,8 @@
 
 #include <cy_device_headers.h>
 
+#include "../common/cypress_psoc6_dt.h"
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _SOC__H_ */

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Cypress
+ * Copyright (c) 2020, ATL Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,14 +15,14 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#ifndef _ASMLANGUAGE
-#include <cy_device_headers.h>
+#include <sys/util.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+#ifndef _ASMLANGUAGE
+
+/* Add include for DTS generated information */
+#include <devicetree.h>
+
+#include <cy_device_headers.h>
 
 #endif /* !_ASMLANGUAGE */
 


### PR DESCRIPTION
PSoC-6 SoC needs that user define the nvic interrupt number to bind with the peripheral interrupt line for the Cortex-M0+ CPU.  It uses a multiplex before any NVIC interrupt line.  The minimal support was added to allow interrupts be available for both CPUs.

Note: The PSoC-6 SoC allows that both CPUs receive the same interrupt. A tipical use is GPIO interrupt handle and user is responsable to define interrupt line, priority and take care of enable same peripheral instance on both CPUs only when appropriated.

This update <soc.h> include files removing the unnecessary <kernel_includes.h> file. In addition, add <sys/util.h> to expose macros and <devicetree.h> following general standards.

This solves #28442 and allows development of drivers that can be shared between SoC cores including, external interrupts by GPIO, serial, spi etc.