### PR TITLE
tests: mem_protect: major updates

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -36,13 +36,12 @@ void test_main(void)
 		ztest_unit_test(test_mem_domain_remove_partitions),
 		ztest_unit_test(test_mem_domain_api_kernel_thread_only),
 		ztest_user_unit_test(test_mem_domain_api_kernel_thread_only),
-		ztest_unit_test(test_mem_part_auto_determ_size),
 		ztest_unit_test(test_mem_domain_boot_threads),
 
 		/* mem_partition.c */
 		ztest_unit_test(test_macros_obtain_names_data_bss),
 		ztest_user_unit_test(test_mem_part_assign_bss_vars_zero),
-		ztest_unit_test(test_mem_part_auto_determ_size_per_mpu),
+		ztest_unit_test(test_mem_part_auto_determ_size),
 
 		/* kobject.c */
 		ztest_unit_test(test_kobject_access_grant),

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -20,57 +20,56 @@ void test_main(void)
 	k_thread_priority_set(k_current_get(), -1);
 
 	ztest_test_suite(memory_protection_test_suite,
-			 ztest_unit_test(test_permission_inheritance),
-			 ztest_unit_test(test_mem_domain_valid_access),
-			 ztest_unit_test(test_mem_domain_invalid_access),
-			 ztest_unit_test(test_mem_domain_partitions_user_rw),
-			 ztest_unit_test(test_mem_domain_partitions_supervisor_rw),
-			 ztest_unit_test(test_mem_domain_partitions_user_ro),
-			 ztest_unit_test(test_mem_domain_add_partitions_invalid),
-			 ztest_unit_test(test_mem_domain_add_partitions_simple),
-			 ztest_unit_test(test_mem_domain_remove_partitions_simple),
-			 ztest_unit_test(test_mem_domain_remove_partitions),
-			 ztest_unit_test(test_mark_thread_exit_uninitialized),
-			 ztest_unit_test(
-				 test_mem_domain_api_kernel_thread_only),
-			 ztest_user_unit_test(
-				 test_mem_domain_api_kernel_thread_only),
-			 ztest_unit_test(test_mem_part_auto_determ_size),
-			 ztest_unit_test(
-				 test_mem_part_auto_determ_size_per_mpu),
-			 ztest_unit_test(test_mem_part_inherit_by_child_thr),
-			 ztest_unit_test(test_macros_obtain_names_data_bss),
-			 ztest_user_unit_test(test_mem_part_assign_bss_vars_zero),
-			 ztest_unit_test(test_kobject_access_grant),
-			 ztest_unit_test(test_syscall_invalid_kobject),
-			 ztest_unit_test(test_thread_without_kobject_permission),
-			 ztest_unit_test(test_kobject_revoke_access),
-			 ztest_unit_test(test_kobject_grant_access_kobj),
-			 ztest_unit_test(test_kobject_grant_access_kobj_invalid),
-			 ztest_unit_test(test_kobject_release_from_user),
-			 ztest_unit_test(test_kobject_access_all_grant),
-			 ztest_unit_test(test_thread_has_residual_permissions),
-			 ztest_unit_test(test_kobject_access_grant_to_invalid_thread),
-			 ztest_user_unit_test(test_kobject_access_invalid_kobject),
-			 ztest_user_unit_test(test_access_kobject_without_init_access),
-			 ztest_unit_test(test_access_kobject_without_init_with_access),
-			 ztest_unit_test(test_kobject_reinitialize_thread_kobj),
-			 ztest_unit_test(test_create_new_thread_from_user),
-			 ztest_unit_test(test_mark_thread_exit_uninitialized),
-			 ztest_unit_test(
-				 test_new_user_thread_with_in_use_stack_obj),
-			 ztest_unit_test(
-				 test_create_new_thread_from_user_no_access_stack),
-			 ztest_unit_test(
-				 test_create_new_thread_from_user_invalid_stacksize),
-			 ztest_unit_test(
-				 test_create_new_thread_from_user_huge_stacksize),
-			 ztest_unit_test(test_create_new_supervisor_thread_from_user),
-			 ztest_unit_test(test_create_new_essential_thread_from_user),
-			 ztest_unit_test(test_create_new_higher_prio_thread_from_user),
-			 ztest_unit_test(test_inherit_resource_pool),
-			 ztest_unit_test(test_create_new_invalid_prio_thread_from_user),
-			 ztest_unit_test(test_mem_domain_boot_threads)
-			 );
+		/* inherit.c */
+		ztest_unit_test(test_permission_inheritance),
+		ztest_unit_test(test_inherit_resource_pool),
+
+		/* mem_domain.c */
+		ztest_unit_test(test_mem_domain_valid_access),
+		ztest_unit_test(test_mem_domain_invalid_access),
+		ztest_unit_test(test_mem_domain_partitions_user_rw),
+		ztest_unit_test(test_mem_domain_partitions_user_ro),
+		ztest_unit_test(test_mem_domain_partitions_supervisor_rw),
+		ztest_unit_test(test_mem_domain_add_partitions_invalid),
+		ztest_unit_test(test_mem_domain_add_partitions_simple),
+		ztest_unit_test(test_mem_domain_remove_partitions_simple),
+		ztest_unit_test(test_mem_domain_remove_partitions),
+		ztest_unit_test(test_mem_domain_api_kernel_thread_only),
+		ztest_user_unit_test(test_mem_domain_api_kernel_thread_only),
+		ztest_unit_test(test_mem_part_auto_determ_size),
+		ztest_unit_test(test_mem_part_inherit_by_child_thr),
+		ztest_unit_test(test_mem_domain_boot_threads),
+
+		/* mem_partition.c */
+		ztest_unit_test(test_macros_obtain_names_data_bss),
+		ztest_user_unit_test(test_mem_part_assign_bss_vars_zero),
+		ztest_unit_test(test_mem_part_auto_determ_size_per_mpu),
+
+		/* kobject.c */
+		ztest_unit_test(test_kobject_access_grant),
+		ztest_unit_test(test_syscall_invalid_kobject),
+		ztest_unit_test(test_thread_without_kobject_permission),
+		ztest_unit_test(test_kobject_revoke_access),
+		ztest_unit_test(test_kobject_grant_access_kobj),
+		ztest_unit_test(test_kobject_grant_access_kobj_invalid),
+		ztest_unit_test(test_kobject_release_from_user),
+		ztest_unit_test(test_kobject_access_all_grant),
+		ztest_unit_test(test_thread_has_residual_permissions),
+		ztest_unit_test(test_kobject_access_grant_to_invalid_thread),
+		ztest_user_unit_test(test_kobject_access_invalid_kobject),
+		ztest_user_unit_test(test_access_kobject_without_init_access),
+		ztest_unit_test(test_access_kobject_without_init_with_access),
+		ztest_unit_test(test_kobject_reinitialize_thread_kobj),
+		ztest_unit_test(test_create_new_thread_from_user),
+		ztest_unit_test(test_new_user_thread_with_in_use_stack_obj),
+		ztest_unit_test(test_create_new_thread_from_user_no_access_stack),
+		ztest_unit_test(test_create_new_thread_from_user_invalid_stacksize),
+		ztest_unit_test(test_create_new_thread_from_user_huge_stacksize),
+		ztest_unit_test(test_create_new_supervisor_thread_from_user),
+		ztest_unit_test(test_create_new_essential_thread_from_user),
+		ztest_unit_test(test_create_new_higher_prio_thread_from_user),
+		ztest_unit_test(test_create_new_invalid_prio_thread_from_user),
+		ztest_unit_test(test_mark_thread_exit_uninitialized));
+
 	ztest_run_test_suite(memory_protection_test_suite);
 }

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -25,17 +25,12 @@ void test_main(void)
 		ztest_unit_test(test_inherit_resource_pool),
 
 		/* mem_domain.c */
+		ztest_unit_test(test_mem_domain_setup),
 		ztest_unit_test(test_mem_domain_valid_access),
 		ztest_unit_test(test_mem_domain_invalid_access),
-		ztest_unit_test(test_mem_domain_partitions_user_rw),
-		ztest_unit_test(test_mem_domain_partitions_user_ro),
-		ztest_unit_test(test_mem_domain_partitions_supervisor_rw),
-		ztest_unit_test(test_mem_domain_add_partitions_invalid),
-		ztest_unit_test(test_mem_domain_add_partitions_simple),
-		ztest_unit_test(test_mem_domain_remove_partitions_simple),
-		ztest_unit_test(test_mem_domain_remove_partitions),
-		ztest_unit_test(test_mem_domain_api_kernel_thread_only),
-		ztest_user_unit_test(test_mem_domain_api_kernel_thread_only),
+		ztest_unit_test(test_mem_domain_no_writes_to_ro),
+		ztest_unit_test(test_mem_domain_remove_add_partition),
+		ztest_unit_test(test_mem_domain_api_supervisor_only),
 		ztest_unit_test(test_mem_domain_boot_threads),
 
 		/* mem_partition.c */
@@ -67,7 +62,8 @@ void test_main(void)
 		ztest_unit_test(test_create_new_essential_thread_from_user),
 		ztest_unit_test(test_create_new_higher_prio_thread_from_user),
 		ztest_unit_test(test_create_new_invalid_prio_thread_from_user),
-		ztest_unit_test(test_mark_thread_exit_uninitialized));
+		ztest_unit_test(test_mark_thread_exit_uninitialized)
+		);
 
 	ztest_run_test_suite(memory_protection_test_suite);
 }

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -40,7 +40,7 @@ void test_main(void)
 				 test_mem_part_auto_determ_size_per_mpu),
 			 ztest_unit_test(test_mem_part_inherit_by_child_thr),
 			 ztest_unit_test(test_macros_obtain_names_data_bss),
-			 ztest_unit_test(test_mem_part_assign_bss_vars_zero),
+			 ztest_user_unit_test(test_mem_part_assign_bss_vars_zero),
 			 ztest_unit_test(test_kobject_access_grant),
 			 ztest_unit_test(test_syscall_invalid_kobject),
 			 ztest_unit_test(test_thread_without_kobject_permission),

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -37,7 +37,6 @@ void test_main(void)
 		ztest_unit_test(test_mem_domain_api_kernel_thread_only),
 		ztest_user_unit_test(test_mem_domain_api_kernel_thread_only),
 		ztest_unit_test(test_mem_part_auto_determ_size),
-		ztest_unit_test(test_mem_part_inherit_by_child_thr),
 		ztest_unit_test(test_mem_domain_boot_threads),
 
 		/* mem_partition.c */

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -641,63 +641,6 @@ void test_mem_part_auto_determ_size(void)
 	k_mem_domain_add_thread(&domain1, usr_tid0);
 }
 
-static void child_thr_handler(void *p1, void *p2, void *p3)
-{
-	ARG_UNUSED(p1);
-	ARG_UNUSED(p2);
-	ARG_UNUSED(p3);
-}
-
-static void parent_thr_handler(void *p1, void *p2, void *p3)
-{
-	k_tid_t child_tid = k_thread_create(&child_thr_md, child_thr_stack_md,
-					K_THREAD_STACK_SIZEOF(child_thr_stack_md),
-					child_thr_handler,
-					NULL, NULL, NULL,
-					PRIORITY_MD, 0, K_NO_WAIT);
-	struct k_thread *thread = child_tid;
-
-	zassert_true(thread->mem_domain_info.mem_domain == &domain4, NULL);
-	k_sem_give(&sync_sem_md);
-}
-
-/**
- * @brief Test memory partition is inherited by the child thread
- *
- * @details
- * - Define memory partition and add it to the parent thread.
- * - Parent thread creates a child thread. That child thread should be already
- *   added to the parent's memory domain too.
- * - It will be checked by using thread->mem_domain_info.mem_domain
- * - If that child thread structure is equal to the current
- *   memory domain address, then pass the test. It means child thread inherited
- *   the memory domain assignment of their parent.
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_add_thread(), k_mem_remove_thread()
- */
-void test_mem_part_inherit_by_child_thr(void)
-{
-	k_sem_reset(&sync_sem_md);
-	k_mem_domain_init(&domain4, 0, NULL);
-	k_mem_domain_add_partition(&domain4, &part0);
-	/* that line below is a replacament for
-	 * k_mem_domain_remove_thread(k_current_get())
-	 */
-	k_mem_domain_add_thread(&domain0, k_current_get());
-
-	k_tid_t parent_tid = k_thread_create(&parent_thr_md, parent_thr_stack_md,
-					K_THREAD_STACK_SIZEOF(parent_thr_stack_md),
-					parent_thr_handler,
-					NULL, NULL, NULL,
-					PRIORITY_MD, 0, K_NO_WAIT);
-	k_mem_domain_add_thread(&domain4, parent_tid);
-	k_sem_take(&sync_sem_md, K_FOREVER);
-}
-
-
-
 static void zzz_entry(void *p1, void *p2, void *p3)
 {
 	k_sleep(K_FOREVER);

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -7,556 +7,30 @@
 #include "mem_protect.h"
 #include <kernel_internal.h> /* For z_main_thread */
 
-#define ERROR_STR \
-	("Fault didn't occur when we accessed a unassigned memory domain.")
+static struct k_thread child_thread;
+static K_THREAD_STACK_DEFINE(child_stack, 512 + CONFIG_TEST_EXTRA_STACKSIZE);
 
-/****************************************************************************/
-static K_THREAD_STACK_DEFINE(mem_domain_1_stack, MEM_DOMAIN_STACK_SIZE);
-static K_THREAD_STACK_DEFINE(mem_domain_2_stack, MEM_DOMAIN_STACK_SIZE);
-static K_THREAD_STACK_DEFINE(mem_domain_6_stack, MEM_DOMAIN_STACK_SIZE);
-static struct k_thread mem_domain_1_tid, mem_domain_2_tid, mem_domain_6_tid;
-static struct k_mem_domain domain0;
+/* Special memory domain for test case purposes */
+static struct k_mem_domain test_domain;
 
-static uint8_t __aligned(MEM_REGION_ALLOC) buf0[MEM_REGION_ALLOC];
-static K_MEM_PARTITION_DEFINE(part0, buf0, sizeof(buf0),
-			      K_MEM_PARTITION_P_RW_U_RW);
+#define PARTS_USED	2
+/* Maximum number of alloable memory partitions defined by the build */
+#define NUM_RW_PARTS	(CONFIG_MAX_DOMAIN_PARTITIONS - PARTS_USED)
 
-/****************************************************************************/
-/* The mem domains needed.*/
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf1[MEM_REGION_ALLOC];
+/* Max number of allowable partitions, derived at runtime. Might be less. */
+ZTEST_BMEM int num_rw_parts;
 
-/* partitions added later in the test cases.*/
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part1[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part2[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part3[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part4[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part5[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part6[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part7[MEM_REGION_ALLOC];
-static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part8[MEM_REGION_ALLOC];
+/* Set of read-write buffers each in their own partrition */
+static volatile uint8_t __aligned(MEM_REGION_ALLOC)
+	rw_bufs[NUM_RW_PARTS][MEM_REGION_ALLOC];
+static struct k_mem_partition rw_parts[NUM_RW_PARTS];
 
-static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition,
-			      mem_domain_buf,
-			      sizeof(mem_domain_buf),
-			      K_MEM_PARTITION_P_RW_U_RW);
+/* A single read-only partition */
+static volatile uint8_t __aligned(MEM_REGION_ALLOC) ro_buf[MEM_REGION_ALLOC];
+K_MEM_PARTITION_DEFINE(ro_part, ro_buf, sizeof(ro_buf),
+		       K_MEM_PARTITION_P_RO_U_RO);
 
-#if defined(CONFIG_X86) || \
-	((defined(CONFIG_ARMV8_M_BASELINE) || \
-		defined(CONFIG_ARMV8_M_MAINLINE)) \
-		&& defined(CONFIG_CPU_HAS_ARM_MPU))
-static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
-			      mem_domain_buf1,
-			      sizeof(mem_domain_buf1),
-			      K_MEM_PARTITION_P_RO_U_RO);
-#else
-static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
-			      mem_domain_buf1,
-			      sizeof(mem_domain_buf1),
-			      K_MEM_PARTITION_P_RW_U_RO);
-#endif
-
-static struct k_mem_partition *mem_domain_memory_partition_array[] = {
-	&mem_domain_memory_partition,
-	&ztest_mem_partition
-};
-
-static struct k_mem_partition *mem_domain_memory_partition_array1[] = {
-	&mem_domain_memory_partition1,
-	&ztest_mem_partition
-};
-static struct k_mem_domain mem_domain_mem_domain;
-static struct k_mem_domain mem_domain1;
-
-/****************************************************************************/
-/* Common init functions */
-static inline void mem_domain_init(void)
-{
-	k_mem_domain_init(&mem_domain_mem_domain,
-			  ARRAY_SIZE(mem_domain_memory_partition_array),
-			  mem_domain_memory_partition_array);
-}
-
-static inline void set_valid_fault_value(int test_case_number)
-{
-	switch (test_case_number) {
-	case 1:
-		set_fault_valid(false);
-		break;
-	case 2:
-		set_fault_valid(true);
-		break;
-	default:
-		set_fault_valid(false);
-		break;
-	}
-}
-
-/****************************************************************************/
-/* Userspace function */
-static void mem_domain_for_user(void *tc_number, void *p2, void *p3)
-{
-	set_valid_fault_value((int)(uintptr_t)tc_number);
-
-	mem_domain_buf[0] = 10U;
-	if (valid_fault == false) {
-		ztest_test_pass();
-	} else {
-		ztest_test_fail();
-	}
-}
-
-static void mem_domain_test_1(void *tc_number, void *p2, void *p3)
-{
-	if ((uintptr_t)tc_number == 1U) {
-		mem_domain_buf[0] = 10U;
-		k_mem_domain_add_thread(&mem_domain_mem_domain,
-					k_current_get());
-	}
-
-	k_thread_user_mode_enter(mem_domain_for_user, tc_number, NULL, NULL);
-
-}
-
-/****************************************************************************/
-/**
- * @brief Check if the mem_domain is configured and accessible for userspace
- *
- * @ingroup kernel_memgroup_tests
- *
- * @see k_mem_domain_init()
- */
-void test_mem_domain_valid_access(void)
-{
-	uintptr_t tc_number = 1U;
-
-	mem_domain_init();
-
-	k_thread_create(&mem_domain_1_tid,
-			mem_domain_1_stack,
-			MEM_DOMAIN_STACK_SIZE,
-			mem_domain_test_1,
-			(void *)tc_number, NULL, NULL,
-			10, 0, K_NO_WAIT);
-
-	k_thread_join(&mem_domain_1_tid, K_FOREVER);
-}
-
-/****************************************************************************/
-/**
- * @brief Test to check memory domain invalid access
- *
- * @details If mem domain was not added to the thread and a access to it should
- * cause a fault.
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_domain_invalid_access(void)
-{
-	uintptr_t tc_number = 2U;
-
-	k_thread_create(&mem_domain_2_tid,
-			mem_domain_2_stack,
-			MEM_DOMAIN_STACK_SIZE,
-			mem_domain_test_1,
-			(void *)tc_number, NULL, NULL,
-			10, 0, K_NO_WAIT);
-
-	k_thread_join(&mem_domain_2_tid, K_FOREVER);
-}
-/***************************************************************************/
-static void thread_entry_rw(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(false);
-
-	uint8_t read_data = mem_domain_buf[0];
-
-	/* Just to avoid compiler warnings */
-	(void) read_data;
-
-	/* Write to the partition */
-	mem_domain_buf[0] = 99U;
-
-	ztest_test_pass();
-}
-/**
- * @brief Test memory domain read/write access
- *
- * @details Provide read/write access to a partition
- * and verify access from a user thread added to it
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_domain_partitions_user_rw(void)
-{
-	/* Initialize the memory domain */
-	k_mem_domain_init(&mem_domain_mem_domain,
-			  ARRAY_SIZE(mem_domain_memory_partition_array),
-			  mem_domain_memory_partition_array);
-
-	k_mem_domain_add_thread(&mem_domain_mem_domain,
-				k_current_get());
-
-	k_thread_user_mode_enter(thread_entry_rw, NULL, NULL, NULL);
-}
-/****************************************************************************/
-static void user_thread_entry_ro(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(true);
-
-	/* Read the partition */
-	uint8_t read_data = mem_domain_buf1[0];
-
-	/* Just to avoid compiler warning */
-	(void) read_data;
-
-	/* Writing to the partition, this should generate fault
-	 * as the partition has read only permission for
-	 * user threads
-	 */
-	mem_domain_buf1[0] = 10U;
-
-	zassert_unreachable("The user thread is allowed to access a read only"
-			    " partition of a memory domain");
-}
-/**
- * @brief Test memory domain read/write access for user thread
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_add_thread()
- */
-void test_mem_domain_partitions_user_ro(void)
-{
-	/* Initialize the memory domain containing the partition
-	 * with read only access privilege
-	 */
-	k_mem_domain_init(&mem_domain1,
-			  ARRAY_SIZE(mem_domain_memory_partition_array1),
-			  mem_domain_memory_partition_array1);
-
-	k_mem_domain_add_thread(&mem_domain1, k_current_get());
-
-	k_thread_user_mode_enter(user_thread_entry_ro, NULL, NULL, NULL);
-}
-
-/****************************************************************************/
-/**
- * @brief Test memory domain read/write access for kernel thread
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_domain_partitions_supervisor_rw(void)
-{
-	k_mem_domain_init(&mem_domain_mem_domain,
-			  ARRAY_SIZE(mem_domain_memory_partition_array1),
-			  mem_domain_memory_partition_array1);
-
-	k_mem_domain_add_thread(&mem_domain_mem_domain, k_current_get());
-
-	/* Create a supervisor thread */
-	k_thread_create(&mem_domain_1_tid, mem_domain_1_stack,
-			MEM_DOMAIN_STACK_SIZE, (k_thread_entry_t)thread_entry_rw,
-			NULL, NULL, NULL, 10, K_INHERIT_PERMS, K_NO_WAIT);
-
-	k_thread_join(&mem_domain_1_tid, K_FOREVER);
-}
-
-/****************************************************************************/
-
-/* add partitions */
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part1_struct,
-			      mem_domain_tc3_part1,
-			      sizeof(mem_domain_tc3_part1),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part2_struct,
-			      mem_domain_tc3_part2,
-			      sizeof(mem_domain_tc3_part2),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part3_struct,
-			      mem_domain_tc3_part3,
-			      sizeof(mem_domain_tc3_part3),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part4_struct,
-			      mem_domain_tc3_part4,
-			      sizeof(mem_domain_tc3_part4),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part5_struct,
-			      mem_domain_tc3_part5,
-			      sizeof(mem_domain_tc3_part5),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part6_struct,
-			      mem_domain_tc3_part6,
-			      sizeof(mem_domain_tc3_part6),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part7_struct,
-			      mem_domain_tc3_part7,
-			      sizeof(mem_domain_tc3_part7),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part8_struct,
-			      mem_domain_tc3_part8,
-			      sizeof(mem_domain_tc3_part8),
-			      K_MEM_PARTITION_P_RW_U_RW);
-
-static struct k_mem_partition *mem_domain_tc3_partition_array[] = {
-	&ztest_mem_partition,
-	&mem_domain_tc3_part1_struct,
-	&mem_domain_tc3_part2_struct,
-	&mem_domain_tc3_part3_struct,
-	&mem_domain_tc3_part4_struct,
-	&mem_domain_tc3_part5_struct,
-	&mem_domain_tc3_part6_struct,
-	&mem_domain_tc3_part7_struct,
-	&mem_domain_tc3_part8_struct
-};
-
-static struct k_mem_domain mem_domain_tc3_mem_domain;
-
-static void mem_domain_for_user_tc3(void *max_partitions, void *p2, void *p3)
-{
-	uintptr_t index;
-
-	set_fault_valid(true);
-
-	/* fault should be hit on the first index itself. */
-	for (index = 0U;
-	     (index < (uintptr_t)max_partitions) && (index < 8);
-	     index++) {
-		*(uintptr_t *)mem_domain_tc3_partition_array[index]->start =
-			10U;
-	}
-
-	zassert_unreachable(ERROR_STR);
-	ztest_test_fail();
-}
-
-/**
- * @brief Test to check addition of partitions into a mem domain.
- *
- * @details If the access to any of the partitions are denied
- * it will cause failure. The memory domain is not added to
- * the thread and fault occurs when the user tries to access
- * that region.
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_domain_add_partitions_invalid(void)
-{
-	/* Subtract one since the domain is initialized with one partition
-	 * already present.
-	 */
-	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get() - 1;
-	uint8_t index;
-
-	mem_domain_init();
-	k_mem_domain_init(&mem_domain_tc3_mem_domain,
-			  1,
-			  mem_domain_memory_partition_array);
-
-	for (index = 0U; (index < max_partitions) && (index < 8); index++) {
-		k_mem_domain_add_partition(&mem_domain_tc3_mem_domain,
-					   mem_domain_tc3_partition_array \
-					   [index]);
-
-	}
-	/* The next add_thread is done so that the
-	 * memory domain for mem_domain_tc3_mem_domain partitions are
-	 * initialized. Because the pages/regions will not be configuired for
-	 * the partitions in mem_domain_tc3_mem_domain when do a add_partition.
-	 */
-	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
-				k_current_get());
-
-	/* configure a different memory domain for the current thread. */
-	k_mem_domain_add_thread(&mem_domain_mem_domain,
-				k_current_get());
-
-	k_thread_user_mode_enter(mem_domain_for_user_tc3,
-				 (void *)(uintptr_t)max_partitions,
-				 NULL,
-				 NULL);
-
-}
-
-/****************************************************************************/
-static void mem_domain_for_user_tc4(void *max_partitions, void *p2, void *p3)
-{
-	uintptr_t index;
-
-	set_fault_valid(false);
-
-	for (index = 0U; (index < (uintptr_t)p2) && (index < 8); index++) {
-		*(uintptr_t *)mem_domain_tc3_partition_array[index]->start =
-			10U;
-	}
-
-	ztest_test_pass();
-}
-
-/**
- * @brief Test case to check addition of parititions into a mem domain.
- *
- * @details If the access to any of the partitions are denied
- * it will cause failure.
- *
- * @see k_mem_domain_init(), k_mem_domain_add_partition(),
- * k_mem_domain_add_thread(), k_thread_user_mode_enter()
- */
-void test_mem_domain_add_partitions_simple(void)
-{
-
-	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get();
-	uint8_t index;
-
-	k_mem_domain_init(&mem_domain_tc3_mem_domain,
-			  1,
-			  mem_domain_tc3_partition_array);
-
-	/* Add additional partitions up to the max permitted number. */
-	for (index = 1U; (index < max_partitions) && (index < 8); index++) {
-		k_mem_domain_add_partition(&mem_domain_tc3_mem_domain,
-					   mem_domain_tc3_partition_array \
-					   [index]);
-
-	}
-
-	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
-				k_current_get());
-
-	k_thread_user_mode_enter(mem_domain_for_user_tc4,
-				 (void *)(uintptr_t)max_partitions,
-				 NULL,
-				 NULL);
-
-}
-
-/****************************************************************************/
-/* Test removal of a partition. */
-static void mem_domain_for_user_tc5(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(true);
-
-	/* will generate a fault */
-	mem_domain_tc3_part1[0] = 10U;
-	zassert_unreachable(ERROR_STR);
-}
-/**
- * @brief Test the removal of the partition
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_remove_partition(),
- * k_mem_domain_add_thread(), k_thread_user_mode_enter()
- */
-void test_mem_domain_remove_partitions_simple(void)
-{
-	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
-				k_current_get());
-
-	k_mem_domain_remove_partition(&mem_domain_tc3_mem_domain,
-				      &mem_domain_tc3_part1_struct);
-
-
-	k_thread_user_mode_enter(mem_domain_for_user_tc5,
-				 NULL, NULL, NULL);
-
-}
-
-/****************************************************************************/
-static void mem_domain_test_6_1(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(false);
-
-	mem_domain_tc3_part1[0] = 10U;
-	k_thread_abort(k_current_get());
-}
-
-static void mem_domain_test_6_2(void *p1, void *p2, void *p3)
-{
-	set_fault_valid(true);
-
-	mem_domain_tc3_part1[0] = 10U;
-	zassert_unreachable(ERROR_STR);
-}
-
-/**
- * @brief Test the removal of partitions with inheritance check
- *
- * @details First check if the memory domain is inherited.
- * After that remove a partition then again check access to it.
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_remove_partition()
- */
-void test_mem_domain_remove_partitions(void)
-{
-	uint8_t max_partitions = (uint8_t)arch_mem_domain_max_partitions_get();
-
-	/* Re-initialize domain with the max permitted number of partitions */
-	k_mem_domain_init(&mem_domain_tc3_mem_domain,
-			  MIN(max_partitions,
-			    ARRAY_SIZE(mem_domain_tc3_partition_array)),
-			  mem_domain_tc3_partition_array);
-
-	k_mem_domain_add_thread(&mem_domain_tc3_mem_domain,
-				k_current_get());
-
-	mem_domain_tc3_part1[0] = 10U;
-	mem_domain_tc3_part2[0] = 10U;
-
-	k_thread_create(&mem_domain_6_tid,
-			mem_domain_6_stack,
-			MEM_DOMAIN_STACK_SIZE,
-			mem_domain_test_6_1,
-			NULL, NULL, NULL,
-			-1, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
-
-	k_thread_join(&mem_domain_6_tid, K_FOREVER);
-
-	k_mem_domain_remove_partition(&mem_domain_tc3_mem_domain,
-				      &mem_domain_tc3_part1_struct);
-
-	k_thread_create(&mem_domain_6_tid,
-			mem_domain_6_stack,
-			MEM_DOMAIN_STACK_SIZE,
-			mem_domain_test_6_2,
-			NULL, NULL, NULL,
-			-1, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
-
-	k_thread_join(&mem_domain_6_tid, K_FOREVER);
-}
-
-/**
- * @brief Test access memory domain APIs allowed to supervisor threads only
- *
- * @details
- * - Create a test case to use a memory domain APIs k_mem_domain_init()
- *   and k_mem_domain_add_partition()
- * - Run that test in kernel mode -no errors should happen.
- * - Run that test in user mode -Zephyr fatal error will happen (reason 0),
- *   because user threads can't use memory domain APIs.
- * - At the same time test that system support the definition of memory domains.
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see k_mem_domain_init(), k_mem_domain_add_partition()
- */
-void test_mem_domain_api_kernel_thread_only(void)
-{
-	set_fault_valid(true);
-
-	k_mem_domain_init(&domain0, 0, NULL);
-	k_mem_domain_add_partition(&domain0, &part0);
-}
-
+/* Static thread, used by a couple tests */
 static void zzz_entry(void *p1, void *p2, void *p3)
 {
 	k_sleep(K_FOREVER);
@@ -565,6 +39,218 @@ static void zzz_entry(void *p1, void *p2, void *p3)
 static K_THREAD_DEFINE(zzz_thread, 256 + CONFIG_TEST_EXTRA_STACKSIZE,
 		       zzz_entry, NULL, NULL, NULL, 0, 0, 0);
 
+void test_mem_domain_setup(void)
+{
+	int max_parts = arch_mem_domain_max_partitions_get();
+	struct k_mem_partition *parts[] = { &ro_part, &ztest_mem_partition };
+
+	num_rw_parts = max_parts - PARTS_USED;
+	zassert_true(NUM_RW_PARTS >= num_rw_parts,
+		     "CONFIG_MAX_DOMAIN_PARTITIONS incorrectly tuned, %d should be at least %d",
+		     CONFIG_MAX_DOMAIN_PARTITIONS, max_parts);
+	zassert_true(num_rw_parts > 0, "no free memory partitions");
+
+	k_mem_domain_init(&test_domain, ARRAY_SIZE(parts), parts);
+
+	for (unsigned int i = 0; i < num_rw_parts; i++) {
+		rw_parts[i].start = (uintptr_t)&rw_bufs[i];
+		rw_parts[i].size = MEM_REGION_ALLOC;
+		rw_parts[i].attr = K_MEM_PARTITION_P_RW_U_RW;
+
+		for (unsigned int j = 0; j < MEM_REGION_ALLOC; j++) {
+			rw_bufs[i][j] = (j % 256U);
+		}
+
+		k_mem_domain_add_partition(&test_domain, &rw_parts[i]);
+	}
+
+	for (unsigned int j = 0; j < MEM_REGION_ALLOC; j++) {
+		ro_buf[j] = (j % 256U);
+	}
+}
+
+/* Helper function; run a function under a child user thread.
+ * If domain is not NULL, add the child thread to that domain, instead of
+ * whatever it would inherit.
+ */
+static void spawn_child_thread(k_thread_entry_t entry,
+			       struct k_mem_domain *domain, bool should_fault)
+{
+	set_fault_valid(should_fault);
+
+	k_thread_create(&child_thread, child_stack,
+			K_THREAD_STACK_SIZEOF(child_stack), entry,
+			NULL, NULL, NULL, 0, K_USER, K_FOREVER);
+	k_thread_name_set(&child_thread, "child_thread");
+	if (domain != NULL) {
+		k_mem_domain_add_thread(domain, &child_thread);
+	}
+	k_thread_start(&child_thread);
+	k_thread_join(&child_thread, K_FOREVER);
+
+	if (should_fault && valid_fault) {
+		/* valid_fault gets cleared if an expected exception
+		 * took place
+		 */
+		printk("test function %p was supposed to fault but didn't\n",
+		       entry);
+		ztest_test_fail();
+	}
+}
+
+/* read and write to all the rw_parts */
+static void rw_part_access(void *p1, void *p2, void *p3)
+{
+	for (unsigned int i = 0; i < num_rw_parts; i++) {
+		for (unsigned int j = 0; j < MEM_REGION_ALLOC; j++) {
+			/* Test read */
+			zassert_equal(rw_bufs[i][j], j % 256U,
+				      "bad data in rw_buf[%d][%d]", i, j);
+			/* Test writes */
+			rw_bufs[i][j]++;
+			rw_bufs[i][j]--;
+		}
+	}
+}
+
+/* read the ro_part */
+static void ro_part_access(void *p1, void *p2, void *p3)
+{
+	for (unsigned int i = 0; i < MEM_REGION_ALLOC; i++) {
+		zassert_equal(ro_buf[i], i % 256U,
+			      "bad data in ro_buf[%d]", i);
+	}
+}
+
+/* attempt to write to ro_part */
+static void ro_write_entry(void *p1, void *p2, void *p3)
+{
+	/* Should fault here */
+	ro_buf[0] = 200;
+}
+
+/**
+ * @brief Check if the mem_domain is configured and accessible for userspace
+ *
+ * Join a memory domain with a read-write memory partition and a read-only
+ * partition within it, and show that the data in the partition is accessible
+ * as expected by the permissions provided.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_mem_domain_valid_access(void)
+{
+	spawn_child_thread(rw_part_access, &test_domain, false);
+	spawn_child_thread(ro_part_access, &test_domain, false);
+}
+
+/**
+ * @brief Show that a user thread can't touch partitions not in its domain
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_mem_domain_invalid_access(void)
+{
+	/* child not added to test_domain, will fault for both */
+	spawn_child_thread(rw_part_access, NULL, true);
+	spawn_child_thread(ro_part_access, NULL, true);
+}
+
+/**
+ * @brief Show that a read-only partition can't be written to
+ *
+ * @ingroup kernel_memgroup_tests
+ */
+void test_mem_domain_no_writes_to_ro(void)
+{
+	/* Show that trying to write to a read-only partition causes a fault */
+	spawn_child_thread(ro_write_entry, &test_domain, true);
+}
+
+/**
+ * @brief Show that adding/removing partitions works
+ *
+ * Show that removing a partition doesn't affect access to other partitions.
+ * Show that removing a partition generates a fault if its data is accessed.
+ * Show that adding a partition back restores access from a user thread.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_mem_domain_remove_add_partition(void)
+{
+	k_mem_domain_remove_partition(&test_domain, &rw_parts[0]);
+
+	/* Should still work, we didn't remove ro_part */
+	spawn_child_thread(ro_part_access, &test_domain, false);
+
+	/* This will fault, we removed one of the rw_part from the domain */
+	spawn_child_thread(rw_part_access, &test_domain, true);
+
+	/* Restore test_domain contents so we don't mess up other tests */
+	k_mem_domain_add_partition(&test_domain, &rw_parts[0]);
+
+	/* Should work again */
+	spawn_child_thread(rw_part_access, &test_domain, false);
+}
+
+/* user mode will attempt to initialize this and fail */
+static struct k_mem_domain no_access_domain;
+
+/* Extra partition that a user thread can't add to a domain */
+static volatile uint8_t __aligned(MEM_REGION_ALLOC)
+	no_access_buf[MEM_REGION_ALLOC];
+K_MEM_PARTITION_DEFINE(no_access_part, no_access_buf, sizeof(no_access_buf),
+		       K_MEM_PARTITION_P_RW_U_RW);
+
+static void mem_domain_init_entry(void *p1, void *p2, void *p3)
+{
+	k_mem_domain_init(&no_access_domain, 0, NULL);
+}
+
+static void mem_domain_add_partition_entry(void *p1, void *p2, void *p3)
+{
+	k_mem_domain_add_partition(&test_domain, &no_access_part);
+}
+
+static void mem_domain_remove_partition_entry(void *p1, void *p2, void *p3)
+{
+	k_mem_domain_remove_partition(&test_domain, &ro_part);
+}
+
+static void mem_domain_add_thread_entry(void *p1, void *p2, void *p3)
+{
+	k_mem_domain_add_thread(&test_domain, zzz_thread);
+}
+
+/**
+ * @brief Test access memory domain APIs allowed to supervisor threads only
+ *
+ * Show that invoking any of the memory domain APIs from user mode leads to
+ * a fault.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @see k_mem_domain_init(), k_mem_domain_add_partition(),
+ *	k_mem_domain_remove_partition(), k_mem_domain_add_thread()
+ */
+void test_mem_domain_api_supervisor_only(void)
+{
+	/* All of these should fault when invoked from a user thread */
+	spawn_child_thread(mem_domain_init_entry, NULL, true);
+	spawn_child_thread(mem_domain_add_partition_entry, NULL, true);
+	spawn_child_thread(mem_domain_remove_partition_entry, NULL, true);
+	spawn_child_thread(mem_domain_add_thread_entry, NULL, true);
+}
+
+/**
+ * @brief Show that boot threads belong to the default memory domain
+ *
+ * Static threads and the main thread are supposed to start as members of
+ * the default memory domain. Prove this is the case by examining the
+ * memory domain membership of z_main_thread and a static thread.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_mem_domain_boot_threads(void)
 {
 	/* Check that a static thread got put in the default memory domain */

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -12,27 +12,27 @@
 	("Fault didn't occur when we accessed a unassigned memory domain.")
 
 /****************************************************************************/
-K_THREAD_STACK_DEFINE(mem_domain_1_stack, MEM_DOMAIN_STACK_SIZE);
-K_THREAD_STACK_DEFINE(mem_domain_2_stack, MEM_DOMAIN_STACK_SIZE);
-K_THREAD_STACK_DEFINE(mem_domain_6_stack, MEM_DOMAIN_STACK_SIZE);
-struct k_thread mem_domain_1_tid, mem_domain_2_tid, mem_domain_6_tid;
-struct k_mem_domain domain0, domain1, domain4, name_domain, overlap_domain;
+static K_THREAD_STACK_DEFINE(mem_domain_1_stack, MEM_DOMAIN_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(mem_domain_2_stack, MEM_DOMAIN_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(mem_domain_6_stack, MEM_DOMAIN_STACK_SIZE);
+static struct k_thread mem_domain_1_tid, mem_domain_2_tid, mem_domain_6_tid;
+static struct k_mem_domain domain0, domain1, domain4;
 
-struct k_thread user_thread0, parent_thr_md, child_thr_md;
-k_tid_t usr_tid0, usr_tid1, child_tid;
-K_THREAD_STACK_DEFINE(user_thread0_stack, STACK_SIZE_MD);
-K_THREAD_STACK_DEFINE(child_thr_stack_md, STACK_SIZE_MD);
-K_THREAD_STACK_DEFINE(parent_thr_stack_md, STACK_SIZE_MD);
+static struct k_thread user_thread0, parent_thr_md, child_thr_md;
+static k_tid_t usr_tid0;
+static K_THREAD_STACK_DEFINE(user_thread0_stack, STACK_SIZE_MD);
+static K_THREAD_STACK_DEFINE(child_thr_stack_md, STACK_SIZE_MD);
+static K_THREAD_STACK_DEFINE(parent_thr_stack_md, STACK_SIZE_MD);
 
-struct k_sem sync_sem_md;
+static struct k_sem sync_sem_md;
 
-uint8_t __aligned(MEM_REGION_ALLOC) buf0[MEM_REGION_ALLOC];
-K_MEM_PARTITION_DEFINE(part0, buf0, sizeof(buf0),
-		K_MEM_PARTITION_P_RW_U_RW);
+static uint8_t __aligned(MEM_REGION_ALLOC) buf0[MEM_REGION_ALLOC];
+static K_MEM_PARTITION_DEFINE(part0, buf0, sizeof(buf0),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
 K_APPMEM_PARTITION_DEFINE(part1);
-K_APP_BMEM(part1) uint8_t __aligned(MEM_REGION_ALLOC) buf1[MEM_REGION_ALLOC];
-struct k_mem_partition *app1_parts[] = {
+static K_APP_BMEM(part1) uint8_t __aligned(MEM_REGION_ALLOC) buf1[MEM_REGION_ALLOC];
+static struct k_mem_partition *app1_parts[] = {
 	&part1
 };
 K_APPMEM_PARTITION_DEFINE(part_arch);
@@ -40,59 +40,59 @@ K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC) \
 buf_arc[MEM_REGION_ALLOC];
 
 K_APPMEM_PARTITION_DEFINE(part2);
-K_APP_DMEM(part2) int part2_var = 1356;
-K_APP_BMEM(part2) int part2_zeroed_var = 20420;
-K_APP_BMEM(part2) int part2_bss_var;
+static K_APP_DMEM(part2) int part2_var = 1356;
+static K_APP_BMEM(part2) int part2_zeroed_var = 20420;
+static K_APP_BMEM(part2) int part2_bss_var;
 
 SYS_MEM_POOL_DEFINE(data_pool, NULL, BLK_SIZE_MIN_MD, BLK_SIZE_MAX_MD,
 		BLK_NUM_MAX_MD, BLK_ALIGN_MD, K_APP_DMEM_SECTION(part2));
 
 /****************************************************************************/
 /* The mem domains needed.*/
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf1[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_buf1[MEM_REGION_ALLOC];
 
 /* partitions added later in the test cases.*/
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part1[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part2[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part3[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part4[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part5[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part6[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part7[MEM_REGION_ALLOC];
-uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part8[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part1[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part2[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part3[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part4[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part5[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part6[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part7[MEM_REGION_ALLOC];
+static uint8_t MEM_DOMAIN_ALIGNMENT mem_domain_tc3_part8[MEM_REGION_ALLOC];
 
-K_MEM_PARTITION_DEFINE(mem_domain_memory_partition,
-		       mem_domain_buf,
-		       sizeof(mem_domain_buf),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition,
+			      mem_domain_buf,
+			      sizeof(mem_domain_buf),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
 #if defined(CONFIG_X86) || \
 	((defined(CONFIG_ARMV8_M_BASELINE) || \
 		defined(CONFIG_ARMV8_M_MAINLINE)) \
 		&& defined(CONFIG_CPU_HAS_ARM_MPU))
-K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
-		       mem_domain_buf1,
-		       sizeof(mem_domain_buf1),
-		       K_MEM_PARTITION_P_RO_U_RO);
+static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
+			      mem_domain_buf1,
+			      sizeof(mem_domain_buf1),
+			      K_MEM_PARTITION_P_RO_U_RO);
 #else
-K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
-		       mem_domain_buf1,
-		       sizeof(mem_domain_buf1),
-		       K_MEM_PARTITION_P_RW_U_RO);
+static K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
+			      mem_domain_buf1,
+			      sizeof(mem_domain_buf1),
+			      K_MEM_PARTITION_P_RW_U_RO);
 #endif
 
-struct k_mem_partition *mem_domain_memory_partition_array[] = {
+static struct k_mem_partition *mem_domain_memory_partition_array[] = {
 	&mem_domain_memory_partition,
 	&ztest_mem_partition
 };
 
-struct k_mem_partition *mem_domain_memory_partition_array1[] = {
+static struct k_mem_partition *mem_domain_memory_partition_array1[] = {
 	&mem_domain_memory_partition1,
 	&ztest_mem_partition
 };
-struct k_mem_domain mem_domain_mem_domain;
-struct k_mem_domain mem_domain1;
+static struct k_mem_domain mem_domain_mem_domain;
+static struct k_mem_domain mem_domain1;
 
 /****************************************************************************/
 /* Common init functions */
@@ -291,46 +291,45 @@ void test_mem_domain_partitions_supervisor_rw(void)
 /****************************************************************************/
 
 /* add partitions */
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part1_struct,
-		       mem_domain_tc3_part1,
-		       sizeof(mem_domain_tc3_part1),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part1_struct,
+			      mem_domain_tc3_part1,
+			      sizeof(mem_domain_tc3_part1),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part2_struct,
-		       mem_domain_tc3_part2,
-		       sizeof(mem_domain_tc3_part2),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part2_struct,
+			      mem_domain_tc3_part2,
+			      sizeof(mem_domain_tc3_part2),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part3_struct,
-		       mem_domain_tc3_part3,
-		       sizeof(mem_domain_tc3_part3),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part3_struct,
+			      mem_domain_tc3_part3,
+			      sizeof(mem_domain_tc3_part3),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part4_struct,
-		       mem_domain_tc3_part4,
-		       sizeof(mem_domain_tc3_part4),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part4_struct,
+			      mem_domain_tc3_part4,
+			      sizeof(mem_domain_tc3_part4),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part5_struct,
-		       mem_domain_tc3_part5,
-		       sizeof(mem_domain_tc3_part5),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part5_struct,
+			      mem_domain_tc3_part5,
+			      sizeof(mem_domain_tc3_part5),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part6_struct,
-		       mem_domain_tc3_part6,
-		       sizeof(mem_domain_tc3_part6),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part6_struct,
+			      mem_domain_tc3_part6,
+			      sizeof(mem_domain_tc3_part6),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part7_struct,
-		       mem_domain_tc3_part7,
-		       sizeof(mem_domain_tc3_part7),
-		       K_MEM_PARTITION_P_RW_U_RW);
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part7_struct,
+			      mem_domain_tc3_part7,
+			      sizeof(mem_domain_tc3_part7),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
-K_MEM_PARTITION_DEFINE(mem_domain_tc3_part8_struct,
-		       mem_domain_tc3_part8,
-		       sizeof(mem_domain_tc3_part8),
-		       K_MEM_PARTITION_P_RW_U_RW);
-
+static K_MEM_PARTITION_DEFINE(mem_domain_tc3_part8_struct,
+			      mem_domain_tc3_part8,
+			      sizeof(mem_domain_tc3_part8),
+			      K_MEM_PARTITION_P_RW_U_RW);
 
 static struct k_mem_partition *mem_domain_tc3_partition_array[] = {
 	&ztest_mem_partition,
@@ -584,7 +583,7 @@ void test_mem_domain_api_kernel_thread_only(void)
 	k_mem_domain_add_partition(&domain0, &part0);
 }
 
-void user_handler_func(void *p1, void *p2, void *p3)
+static void user_handler_func(void *p1, void *p2, void *p3)
 {
 	/* Read the partition */
 	uint8_t read_data = buf1[0];
@@ -671,14 +670,14 @@ void test_mem_part_auto_determ_size_per_mpu(void)
 	zassert_true(part_arch.size == MEM_REGION_ALLOC, NULL);
 }
 
-void child_thr_handler(void *p1, void *p2, void *p3)
+static void child_thr_handler(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 }
 
-void parent_thr_handler(void *p1, void *p2, void *p3)
+static void parent_thr_handler(void *p1, void *p2, void *p3)
 {
 	k_tid_t child_tid = k_thread_create(&child_thr_md, child_thr_stack_md,
 					K_THREAD_STACK_SIZEOF(child_thr_stack_md),
@@ -788,8 +787,8 @@ static void zzz_entry(void *p1, void *p2, void *p3)
 	k_sleep(K_FOREVER);
 }
 
-K_THREAD_DEFINE(zzz_thread, 256 + CONFIG_TEST_EXTRA_STACKSIZE, zzz_entry,
-		NULL, NULL, NULL, 0, 0, 0);
+static K_THREAD_DEFINE(zzz_thread, 256 + CONFIG_TEST_EXTRA_STACKSIZE,
+		       zzz_entry, NULL, NULL, NULL, 0, 0, 0);
 
 void test_mem_domain_boot_threads(void)
 {

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -5,7 +5,6 @@
  */
 
 #include "mem_protect.h"
-#include <sys/mempool.h>
 #include <kernel_internal.h> /* For z_main_thread */
 
 #define ERROR_STR \
@@ -35,17 +34,7 @@ static K_APP_BMEM(part1) uint8_t __aligned(MEM_REGION_ALLOC) buf1[MEM_REGION_ALL
 static struct k_mem_partition *app1_parts[] = {
 	&part1
 };
-K_APPMEM_PARTITION_DEFINE(part_arch);
-K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC) \
-buf_arc[MEM_REGION_ALLOC];
 
-K_APPMEM_PARTITION_DEFINE(part2);
-static K_APP_DMEM(part2) int part2_var = 1356;
-static K_APP_BMEM(part2) int part2_zeroed_var = 20420;
-static K_APP_BMEM(part2) int part2_bss_var;
-
-SYS_MEM_POOL_DEFINE(data_pool, NULL, BLK_SIZE_MIN_MD, BLK_SIZE_MAX_MD,
-		BLK_NUM_MAX_MD, BLK_ALIGN_MD, K_APP_DMEM_SECTION(part2));
 
 /****************************************************************************/
 /* The mem domains needed.*/
@@ -652,24 +641,6 @@ void test_mem_part_auto_determ_size(void)
 	k_mem_domain_add_thread(&domain1, usr_tid0);
 }
 
-/**
- * @brief Test partitions sized per the constraints of the MPU hardware
- *
- * @details
- * - Test that system automatically determine memory partition size according
- *   to the constraints of the platform's MPU hardware.
- * - Different platforms like x86, ARM and ARC have different MPU hardware for
- *   memory management.
- * - That test checks that MPU hardware works as expected and gives for the
- *   memory partition the most suitable and possible size.
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_part_auto_determ_size_per_mpu(void)
-{
-	zassert_true(part_arch.size == MEM_REGION_ALLOC, NULL);
-}
-
 static void child_thr_handler(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
@@ -725,62 +696,7 @@ void test_mem_part_inherit_by_child_thr(void)
 	k_sem_take(&sync_sem_md, K_FOREVER);
 }
 
-/**
- * @brief Test system provide means to obtain names of the data and BSS sections
- *
- * @details
- * - Define memory partition and define system memory pool using macros
- *   SYS_MEM_POOL_DEFINE
- * - Section name of the destination binary section for pool data will be
- *   obtained at build time by macros K_APP_DMEM_SECTION() which obtaines
- *   a section name.
- * - Then to check that system memory pool initialized correctly by allocating
- *   a block from it and check that it is not NULL.
- *
- * @ingroup kernel_memprotect_tests
- *
- * @see K_APP_DMEM_SECTION()
- */
-void test_macros_obtain_names_data_bss(void)
-{
-	sys_mem_pool_init(&data_pool);
-	void *block;
 
-	block = sys_mem_pool_alloc(&data_pool, BLK_SIZE_MAX_MD - DESC_SIZE);
-	zassert_not_null(block, NULL);
-}
-
-/**
- * @brief Test assigning global data and BSS variables to memory partitions
- *
- * @details Test that system supports application assigning global data and BSS
- * variables using macros K_APP_BMEM() and K_APP_DMEM
- *
- * @ingroup kernel_memprotect_tests
- */
-void test_mem_part_assign_bss_vars_zero(void)
-{
-	uint32_t read_data;
-	/* The global variable part2_var will be inside the bounds of part2
-	 * and be initialized with 1356 at boot.
-	 */
-	read_data = part2_var;
-	zassert_true(read_data == 1356, NULL);
-
-	/* The global variable part2_zeroed_var will be inside the bounds of
-	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
-	 * indicating a BSS variable.
-	 */
-	read_data = part2_zeroed_var;
-	zassert_true(read_data == 0, NULL);
-
-	/* The global variable part2_var will be inside the bounds of
-	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
-	 * indicating a BSS variable.
-	 */
-	read_data = part2_bss_var;
-	zassert_true(read_data == 0, NULL);
-}
 
 static void zzz_entry(void *p1, void *p2, void *p3)
 {

--- a/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <sys/mempool.h>
+#include "mem_protect.h"
+
+K_APPMEM_PARTITION_DEFINE(part2);
+static K_APP_DMEM(part2) int part2_var = 1356;
+static K_APP_BMEM(part2) int part2_zeroed_var = 20420;
+static K_APP_BMEM(part2) int part2_bss_var;
+
+SYS_MEM_POOL_DEFINE(data_pool, NULL, BLK_SIZE_MIN_MD, BLK_SIZE_MAX_MD,
+		    BLK_NUM_MAX_MD, BLK_ALIGN_MD, K_APP_DMEM_SECTION(part2));
+
+/**
+ * @brief Test system provide means to obtain names of the data and BSS sections
+ *
+ * @details
+ * - Define memory partition and define system memory pool using macros
+ *   SYS_MEM_POOL_DEFINE
+ * - Section name of the destination binary section for pool data will be
+ *   obtained at build time by macros K_APP_DMEM_SECTION() which obtaines
+ *   a section name.
+ * - Then to check that system memory pool initialized correctly by allocating
+ *   a block from it and check that it is not NULL.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @see K_APP_DMEM_SECTION()
+ */
+void test_macros_obtain_names_data_bss(void)
+{
+	sys_mem_pool_init(&data_pool);
+	void *block;
+
+	block = sys_mem_pool_alloc(&data_pool, BLK_SIZE_MAX_MD - DESC_SIZE);
+	zassert_not_null(block, NULL);
+}
+
+/**
+ * @brief Test assigning global data and BSS variables to memory partitions
+ *
+ * @details Test that system supports application assigning global data and BSS
+ * variables using macros K_APP_BMEM() and K_APP_DMEM
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_mem_part_assign_bss_vars_zero(void)
+{
+	uint32_t read_data;
+	/* The global variable part2_var will be inside the bounds of part2
+	 * and be initialized with 1356 at boot.
+	 */
+	read_data = part2_var;
+	zassert_true(read_data == 1356, NULL);
+
+	/* The global variable part2_zeroed_var will be inside the bounds of
+	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
+	 * indicating a BSS variable.
+	 */
+	read_data = part2_zeroed_var;
+	zassert_true(read_data == 0, NULL);
+
+	/* The global variable part2_var will be inside the bounds of
+	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
+	 * indicating a BSS variable.
+	 */
+	read_data = part2_bss_var;
+	zassert_true(read_data == 0, NULL);
+}
+
+K_APPMEM_PARTITION_DEFINE(part_arch);
+K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC) \
+buf_arc[MEM_REGION_ALLOC];
+
+/**
+ * @brief Test partitions sized per the constraints of the MPU hardware
+ *
+ * @details
+ * - Test that system automatically determine memory partition size according
+ *   to the constraints of the platform's MPU hardware.
+ * - Different platforms like x86, ARM and ARC have different MPU hardware for
+ *   memory management.
+ * - That test checks that MPU hardware works as expected and gives for the
+ *   memory partition the most suitable and possible size.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_mem_part_auto_determ_size_per_mpu(void)
+{
+	zassert_true(part_arch.size == MEM_REGION_ALLOC, NULL);
+}

--- a/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
@@ -8,13 +8,13 @@
 #include <sys/mempool.h>
 #include "mem_protect.h"
 
-K_APPMEM_PARTITION_DEFINE(part2);
-static K_APP_DMEM(part2) int part2_var = 1356;
-static K_APP_BMEM(part2) int part2_zeroed_var = 20420;
-static K_APP_BMEM(part2) int part2_bss_var;
+static K_APP_DMEM(ztest_mem_partition) int var = 1356;
+static K_APP_BMEM(ztest_mem_partition) int zeroed_var = 20420;
+static K_APP_BMEM(ztest_mem_partition) int bss_var;
 
 SYS_MEM_POOL_DEFINE(data_pool, NULL, BLK_SIZE_MIN_MD, BLK_SIZE_MAX_MD,
-		    BLK_NUM_MAX_MD, BLK_ALIGN_MD, K_APP_DMEM_SECTION(part2));
+		    BLK_NUM_MAX_MD, BLK_ALIGN_MD,
+		    K_APP_DMEM_SECTION(ztest_mem_partition));
 
 /**
  * @brief Test system provide means to obtain names of the data and BSS sections
@@ -51,26 +51,22 @@ void test_macros_obtain_names_data_bss(void)
  */
 void test_mem_part_assign_bss_vars_zero(void)
 {
-	uint32_t read_data;
-	/* The global variable part2_var will be inside the bounds of part2
-	 * and be initialized with 1356 at boot.
+	/* The global variable var will be inside the bounds of
+	 * ztest_mem_partition and be initialized with 1356 at boot.
 	 */
-	read_data = part2_var;
-	zassert_true(read_data == 1356, NULL);
+	zassert_true(var == 1356, NULL);
 
-	/* The global variable part2_zeroed_var will be inside the bounds of
-	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
-	 * indicating a BSS variable.
+	/* The global variable zeroed_var will be inside the bounds of
+	 * ztest_mem_partition and must be zeroed at boot size K_APP_BMEM() was
+	 * used, indicating a BSS variable.
 	 */
-	read_data = part2_zeroed_var;
-	zassert_true(read_data == 0, NULL);
+	zassert_true(zeroed_var == 0, NULL);
 
-	/* The global variable part2_var will be inside the bounds of
-	 * part2 and must be zeroed at boot size K_APP_BMEM() was used,
-	 * indicating a BSS variable.
+	/* The global variable var will be inside the bounds of
+	 * ztest_mem_partition and must be zeroed at boot size K_APP_BMEM() was
+	 * used, indicating a BSS variable.
 	 */
-	read_data = part2_bss_var;
-	zassert_true(read_data == 0, NULL);
+	zassert_true(bss_var == 0, NULL);
 }
 
 K_APPMEM_PARTITION_DEFINE(part_arch);

--- a/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
@@ -70,23 +70,23 @@ void test_mem_part_assign_bss_vars_zero(void)
 }
 
 K_APPMEM_PARTITION_DEFINE(part_arch);
-K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC) \
-buf_arc[MEM_REGION_ALLOC];
+K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC)
+	buf_arc[MEM_REGION_ALLOC];
 
 /**
  * @brief Test partitions sized per the constraints of the MPU hardware
  *
  * @details
- * - Test that system automatically determine memory partition size according
- *   to the constraints of the platform's MPU hardware.
- * - Different platforms like x86, ARM and ARC have different MPU hardware for
- *   memory management.
- * - That test checks that MPU hardware works as expected and gives for the
- *   memory partition the most suitable and possible size.
+ * - MEM_REGION_ALLOC is pre-sized to naturally fit in the target hardware's
+ *   memory management granularity. Show that the partition size matches.
+ * - Show that the base address of the partition is properly set, it should
+ *   match the base address of buf_arc.
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_mem_part_auto_determ_size_per_mpu(void)
+void test_mem_part_auto_determ_size(void)
 {
 	zassert_true(part_arch.size == MEM_REGION_ALLOC, NULL);
+	zassert_true(part_arch.start == (uintptr_t)buf_arc,
+	   "Base address of memory partition not determined at build time");
 }

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -11,21 +11,20 @@
 #include <stdlib.h>
 
 extern void test_permission_inheritance(void);
+extern void test_inherit_resource_pool(void);
+
+extern void test_mem_domain_setup(void);
 extern void test_mem_domain_valid_access(void);
 extern void test_mem_domain_invalid_access(void);
-extern void test_mem_domain_partitions_user_rw(void);
-extern void test_mem_domain_partitions_user_ro(void);
-extern void test_mem_domain_partitions_supervisor_rw(void);
-extern void test_mem_domain_add_partitions_invalid(void);
-extern void test_mem_domain_add_partitions_simple(void);
-extern void test_mem_domain_remove_partitions_simple(void);
-extern void test_mem_domain_remove_partitions(void);
-extern void test_mem_domain_api_kernel_thread_only(void);
-extern void test_mem_part_auto_determ_size(void);
-extern void test_mem_part_auto_determ_size_per_mpu(void);
-extern void test_mem_part_inherit_by_child_thr(void);
+extern void test_mem_domain_no_writes_to_ro(void);
+extern void test_mem_domain_remove_add_partition(void);
+extern void test_mem_domain_api_supervisor_only(void);
+extern void test_mem_domain_boot_threads(void);
+
 extern void test_macros_obtain_names_data_bss(void);
 extern void test_mem_part_assign_bss_vars_zero(void);
+extern void test_mem_part_auto_determ_size(void);
+
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -49,9 +48,7 @@ extern void test_create_new_supervisor_thread_from_user(void);
 extern void test_create_new_essential_thread_from_user(void);
 extern void test_create_new_higher_prio_thread_from_user(void);
 extern void test_create_new_invalid_prio_thread_from_user(void);
-extern void test_inherit_resource_pool(void);
 extern void test_mark_thread_exit_uninitialized(void);
-extern void test_mem_domain_boot_threads(void);
 
 /* Flag needed to figure out if the fault was expected or not. */
 extern volatile bool valid_fault;


### PR DESCRIPTION
This PR does some much-needed cleanup to the mem_protect test suite.

- Some tests only were testing memory partitions. They have been simplified and moved to a new c file mem_partition.c
- The remaining tests in mem_domain.c have been rewritten for conciseness, footprint, clarity, and to not call `k_mem_domain_init()` on the same memory domain more than once. There are now far fewer memory domains, test buffers, and threads instantiated. There is much less repeated boilerplate. Duplicate scenarios have been removed.
- Code organization cleanups
- The whole suite now uses less than 16K of SRAM