### PR TITLE
Bluetooth: controller: Fix arguments unused without Extended Scanning

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -118,16 +118,17 @@ uint8_t ll_scan_params_set(uint8_t type, uint16_t interval, uint16_t window,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 uint8_t ll_scan_enable(uint8_t enable, uint16_t duration, uint16_t period)
-#else /* !CONFIG_BT_CTLR_ADV_EXT */
-uint8_t ll_scan_enable(uint8_t enable)
-#endif /* !CONFIG_BT_CTLR_ADV_EXT */
 {
 	struct node_rx_pdu *node_rx_scan_term = NULL;
-	struct ll_scan_set *scan_coded = NULL;
 	uint8_t is_update_coded = 0U;
+	uint8_t is_update_1m = 0U;
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
+uint8_t ll_scan_enable(uint8_t enable)
+{
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
+	struct ll_scan_set *scan_coded = NULL;
 	uint8_t own_addr_type = 0U;
 	uint8_t is_coded_phy = 0U;
-	uint8_t is_update_1m = 0U;
 	struct ll_scan_set *scan;
 	uint8_t err;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -163,13 +163,10 @@ uint8_t ll_scan_enable(uint8_t enable)
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
 	scan_coded = ull_scan_is_disabled_get(SCAN_HANDLE_PHY_CODED);
 	if (!scan_coded) {
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
 		is_update_coded = is_scan_update(SCAN_HANDLE_PHY_CODED,
 						 duration, period, &scan_coded,
 						 &node_rx_scan_term);
-		if (!is_update_coded)
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
-		{
+		if (!is_update_coded) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 	}


### PR DESCRIPTION
Fix arguments unused when not enabling Extended Scanning which
was introduced in commit 0cef1e43c9

Fixes #29442.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>