### PR TITLE
Update i2c_gpio.c

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -142,7 +142,7 @@ static int i2c_gpio_init(const struct device *dev)
 	}
 
 	err = gpio_config(context->sda_gpio, config->sda_pin,
-			  config->sda_flags | GPIO_INPUT | GPIO_OUTPUT_HIGH);
+			  config->sda_flags | GPIO_OPEN_DRAIN | GPIO_OUTPUT_HIGH);
 	if (err == -ENOTSUP) {
 		err = gpio_config(context->sda_gpio, config->sda_pin,
 				  config->sda_flags | GPIO_OUTPUT_HIGH);
@@ -186,6 +186,6 @@ DEVICE_AND_API_INIT(i2c_gpio_##_num, DT_INST_LABEL(_num),		\
 	    i2c_gpio_init,						\
 	    &i2c_gpio_dev_data_##_num,					\
 	    &i2c_gpio_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
+	    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_I2C_GPIO)


### PR DESCRIPTION
Fix bug#29308 
let i2c init at POST_KERNEL
sda gpio should init as open drain.