### PR TITLE
tests: benchmarks: sys_kernel: Add mem_slab benchmark and changed checking for pending threads algo

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -133,16 +133,19 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
 
-	if (pending_thread != NULL) {
-		z_thread_return_value_set_with_data(pending_thread, 0, *mem);
-		z_ready_thread(pending_thread);
-		z_reschedule(&lock, key);
-	} else {
-		**(char ***)mem = slab->free_list;
-		slab->free_list = *(char **)mem;
-		slab->num_used--;
-		k_spin_unlock(&lock, key);
+	if (slab->free_list == NULL) {
+		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
+
+		if (pending_thread != NULL) {
+			z_thread_return_value_set_with_data(pending_thread, 0, *mem);
+			z_ready_thread(pending_thread);
+			z_reschedule(&lock, key);
+			return;
+		}
 	}
+	**(char ***) mem = slab->free_list;
+	slab->free_list = *(char **) mem;
+	slab->num_used--;
+	k_spin_unlock(&lock, key);
 }

--- a/tests/benchmarks/sys_kernel/README.txt
+++ b/tests/benchmarks/sys_kernel/README.txt
@@ -3,7 +3,7 @@ Title: kernel Object Performance
 Description:
 
 The SysKernel test measures the performance of semaphore,
-lifo, fifo and stack objects.
+lifo, fifo, stack and memslab objects.
 
 --------------------------------------------------------------------------------
 
@@ -172,6 +172,21 @@ TEST RESULT: SUCCESSFUL
 DETAILS: Average time for 1 iteration: NNNN nSec
 END TEST CASE
 
+TEST CASE: Memslab #1
+TEST COVERAGE:
+        k_mem_slab_alloc
+Starting test. Please wait...
+TEST RESULT: SUCCESSFUL
+DETAILS: Average time for 1 iteration: NNNN nSec
+END TEST CASE
+
+TEST CASE: Memslab #2
+TEST COVERAGE:
+        k_mem_slab_free
+Starting test. Please wait...
+TEST RESULT: SUCCESSFUL
+DETAILS: Average time for 1 iteration: NNNN nSec
+END TEST CASE
+
 PROJECT EXECUTION SUCCESSFUL
 QEMU: Terminated
-

--- a/tests/benchmarks/sys_kernel/src/mem_slab.c
+++ b/tests/benchmarks/sys_kernel/src/mem_slab.c
@@ -1,0 +1,107 @@
+/* memslab.c */
+
+/*
+ * Copyright (c) 2020, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "syskernel.h"
+
+#define MEM_SLAB_BLOCK_SIZE  (8)
+#define MEM_SLAB_BLOCK_CNT   (NUMBER_OF_LOOPS)
+#define MEM_SLAB_BLOCK_ALIGN (4)
+
+static K_MEM_SLAB_DEFINE(my_slab,
+		  MEM_SLAB_BLOCK_SIZE,
+		  MEM_SLAB_BLOCK_CNT,
+		  MEM_SLAB_BLOCK_ALIGN);
+
+/* Array contains pointers to allocated regions. */
+static void *slab_array[MEM_SLAB_BLOCK_CNT];
+
+/**
+ *
+ * @brief Memslab allocation test function.
+ *		  This test allocates available memory space.
+ *
+ * @param no_of_loops  Amount of loops to run.
+ * @param test_repeats Amount of test repeats per loop.
+ *
+ * @return NUmber of done loops.
+ */
+static int mem_slab_alloc_test(int no_of_loops)
+{
+	int i;
+
+	for (i = 0; i < no_of_loops; i++) {
+		if (k_mem_slab_alloc(&my_slab, &slab_array[i], K_NO_WAIT)
+		    != 0) {
+			return i;
+		}
+	}
+
+	return i;
+}
+
+/**
+ *
+ * @brief Memslab free test function.
+ *		  This test frees memory previously allocated in
+ *		  @ref mem_slab_alloc_test.
+ *
+ * @param no_of_loops  Amount of loops to run.
+ * @param test_repeats Amount of test repeats per loop.
+ *
+ * @return NUmber of done loops.
+ */
+static int mem_slab_free_test(int no_of_loops)
+{
+	int i;
+
+	for (i = 0; i < no_of_loops; i++) {
+		k_mem_slab_free(&my_slab, &slab_array[i]);
+	}
+
+	return i;
+}
+
+int mem_slab_test(void)
+{
+	uint32_t t;
+	int i = 0;
+	int return_value = 0;
+
+	/* Test k_mem_slab_alloc. */
+	fprintf(output_file, sz_test_case_fmt,
+		"Memslab #1");
+	fprintf(output_file, sz_description,
+		"\n\tk_mem_slab_alloc");
+	printf(sz_test_start_fmt);
+
+	t = BENCH_START();
+	i = mem_slab_alloc_test(number_of_loops);
+	t = TIME_STAMP_DELTA_GET(t);
+
+	return_value += check_result(i, t);
+
+	/* Test k_mem_slab_free. */
+	fprintf(output_file, sz_test_case_fmt,
+		"Memslab #2");
+	fprintf(output_file, sz_description,
+		"\n\tk_mem_slab_free");
+	printf(sz_test_start_fmt);
+
+	t = BENCH_START();
+	i = mem_slab_free_test(number_of_loops);
+	t = TIME_STAMP_DELTA_GET(t);
+
+	/* Check if all slabs were freed. */
+	if (k_mem_slab_num_used_get(&my_slab) != 0) {
+		i = 0;
+	}
+
+	return_value += check_result(i, t);
+
+	return return_value;
+}

--- a/tests/benchmarks/sys_kernel/src/syskernel.c
+++ b/tests/benchmarks/sys_kernel/src/syskernel.c
@@ -165,10 +165,11 @@ void main(void)
 		test_result += lifo_test();
 		test_result += fifo_test();
 		test_result += stack_test();
+		test_result += mem_slab_test();
 
 		if (test_result) {
-			/* sema/lifo/fifo/stack account for 12 tests in total */
-			if (test_result == 12) {
+			/* sema/lifo/fifo/stack/mem_slab account for 14 tests in total */
+			if (test_result == 14) {
 				fprintf(output_file, sz_module_result_fmt,
 					sz_success);
 			} else {

--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -51,6 +51,7 @@ int sema_test(void);
 int lifo_test(void);
 int fifo_test(void);
 int stack_test(void);
+int mem_slab_test(void);
 void begin_test(void);
 
 static inline uint32_t BENCH_START(void)


### PR DESCRIPTION
In single-thread applications or when mem_slab is used only by one thread,
there is no need to check if any therad is pending during freeing the slab.
In multithreading application this can be optimized - check for
pending threads (in k_mem_slab_free) could be done only if there is no memory
to allocate.
This change introduces significant time savings.
Execution mem_slab benchmark on nrf5340 (App core @64MHz), 1000 iterations.
Times per single alloc/free:
Without optimization:
Alloc: 1068 [ns]
Free: 1617 [ns]

With optimization
Alloc: 1068 [ns]
Free: 915 [ns]

Difference is significant: 702[ns].