### PR TITLE
drivers: pwm: stm32: control update event when updating values

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -212,6 +212,8 @@ static int pwm_stm32_pin_set(const struct device *dev, uint32_t pwm,
 		return 0;
 	}
 
+	LL_TIM_DisableUpdateEvent(cfg->timer);
+
 	if (!LL_TIM_CC_IsEnabledChannel(cfg->timer, channel)) {
 		LL_TIM_OC_InitTypeDef oc_init;
 
@@ -235,6 +237,9 @@ static int pwm_stm32_pin_set(const struct device *dev, uint32_t pwm,
 	}
 
 	LL_TIM_SetAutoReload(cfg->timer, period_cycles - 1u);
+
+	LL_TIM_EnableUpdateEvent(cfg->timer);
+	LL_TIM_GenerateEvent_UPDATE(cfg->timer);
 
 	return 0;
 }


### PR DESCRIPTION
With this commit the update event is disabled prior to the update of
ARR/CCR registers so that written values are kept in the shadow
registers. Once both are updated, the update event is enabled again and
forced so that transfer of the new values occurs.

Fixes #29446

Tested using the following sample code (thanks @simonguinot):
```c
while (1) {
        pwm_pin_set_cycles(pwm, ch, 100, 0);
        k_sleep(K_MSEC(1000));
        pwm_pin_set_cycles(pwm, ch, 100, 100);                 
        k_sleep(K_MSEC(1000));
	pwm_pin_set_usec(pwm, ch, 1000000, 500000, 0);
	k_sleep(K_MSEC(5000));
	pwm_pin_set_usec(pwm, ch, 100000, 50000, 0);
	k_sleep(K_MSEC(5000));
}
```

Waveforms before fix:
![image](https://user-images.githubusercontent.com/25011557/96981115-d5cbba00-151f-11eb-9947-916fb70344be.png)

Waveforms after fix:
![image](https://user-images.githubusercontent.com/25011557/96981254-de23f500-151f-11eb-9dd3-c6eee17a8098.png)


Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>