### PR TITLE
Net context locking missing for IPv6, CAN and packet sockets

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -234,6 +234,8 @@ static int process_tcp(struct data *data)
 
 	LOG_INF("TCP (%s): Accepted connection", data->proto);
 
+#define MAX_NAME_LEN sizeof("tcp6[0]")
+
 #if defined(CONFIG_NET_IPV6)
 	if (client_addr.sin_family == AF_INET6) {
 		tcp6_handler_in_use[slot] = true;
@@ -248,6 +250,13 @@ static int process_tcp(struct data *data)
 			IS_ENABLED(CONFIG_USERSPACE) ? K_USER |
 						       K_INHERIT_PERMS : 0,
 			K_NO_WAIT);
+
+		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			char name[MAX_NAME_LEN];
+
+			snprintk(name, sizeof(name), "tcp6[%d]", slot);
+			k_thread_name_set(&tcp6_handler_thread[slot], name);
+		}
 	}
 #endif
 
@@ -265,6 +274,13 @@ static int process_tcp(struct data *data)
 			IS_ENABLED(CONFIG_USERSPACE) ? K_USER |
 						       K_INHERIT_PERMS : 0,
 			K_NO_WAIT);
+
+		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			char name[MAX_NAME_LEN];
+
+			snprintk(name, sizeof(name), "tcp4[%d]", slot);
+			k_thread_name_set(&tcp4_handler_thread[slot], name);
+		}
 	}
 #endif
 

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -193,6 +193,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp6_thread_id);
 #endif
 
+		k_thread_name_set(udp6_thread_id, "udp6");
 		k_thread_start(udp6_thread_id);
 	}
 
@@ -201,6 +202,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp4_thread_id);
 #endif
 
+		k_thread_name_set(udp4_thread_id, "udp4");
 		k_thread_start(udp4_thread_id);
 	}
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -489,6 +489,8 @@ static int bind_default(struct net_context *context)
 int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		     socklen_t addrlen)
 {
+	int ret;
+
 	NET_ASSERT(addr);
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
@@ -506,7 +508,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		struct net_if *iface = NULL;
 		struct in6_addr *ptr;
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
-		int ret;
 
 		if (addrlen < sizeof(struct sockaddr_in6)) {
 			return -EINVAL;
@@ -558,6 +559,10 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
+		ret = 0;
+
 		net_context_set_iface(context, iface);
 
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
@@ -571,7 +576,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			} else {
 				NET_ERR("Port %d is in use!",
 					ntohs(addr6->sin6_port));
-				return ret;
+				goto unlock_ipv6;
 			}
 		} else {
 			addr6->sin6_port =
@@ -585,7 +590,10 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ipv6_addr(ptr)),
 			ntohs(addr6->sin6_port), iface);
 
-		return 0;
+	unlock_ipv6:
+		k_mutex_unlock(&context->lock);
+
+		return ret;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->sa_family == AF_INET) {
@@ -593,7 +601,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		struct net_if *iface = NULL;
 		struct net_if_addr *ifaddr;
 		struct in_addr *ptr;
-		int ret;
 
 		if (addrlen < sizeof(struct sockaddr_in)) {
 			return -EINVAL;
@@ -660,7 +667,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			} else {
 				NET_ERR("Port %d is in use!",
 					ntohs(addr4->sin_port));
-				goto unlock;
+				goto unlock_ipv4;
 			}
 		} else {
 			addr4->sin_port =
@@ -674,7 +681,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ipv4_addr(ptr)),
 			ntohs(addr4->sin_port), iface);
 
-	unlock:
+	unlock_ipv4:
 		k_mutex_unlock(&context->lock);
 
 		return ret;
@@ -710,6 +717,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
 		net_context_set_iface(context, iface);
 
 		net_sll_ptr(&context->local)->sll_family = AF_PACKET;
@@ -728,6 +737,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ll_addr(
 				net_sll_ptr(&context->local)->sll_addr,
 				net_sll_ptr(&context->local)->sll_halen)));
+
+		k_mutex_unlock(&context->lock);
 
 		return 0;
 	}
@@ -761,6 +772,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
 		net_context_set_iface(context, iface);
 		net_context_set_family(context, AF_CAN);
 
@@ -771,6 +784,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		NET_DBG("Context %p binding to %d iface[%d] %p",
 			context, net_context_get_ip_proto(context),
 			can_addr->can_ifindex, iface);
+
+		k_mutex_unlock(&context->lock);
 
 		return 0;
 	}


### PR DESCRIPTION
While investigating #29444 I noticed one locking missing from net_context. Also added some way to debug locking in net_context.c and tcp2.c
