### PR TITLE
microchip xec: Introduce I2c slave support

### DIFF
--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -619,9 +619,19 @@ static int i2c_xec_init(const struct device *dev)
 {
 	struct i2c_xec_data *data =
 		(struct i2c_xec_data *const) (dev->data);
+	int ret;
 
 	data->pending_stop = 0;
 	data->slave_attached = false;
+
+	/* Default configuration */
+	ret = i2c_xec_configure(dev,
+				I2C_MODE_MASTER |
+				I2C_SPEED_SET(I2C_SPEED_STANDARD));
+	if (ret) {
+		LOG_ERR("i2c configure failed %d", ret);
+		return ret;
+	}
 
 #ifdef CONFIG_I2C_SLAVE
 	const struct i2c_xec_config *config =

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -168,6 +168,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			girq = <13>;
+			girq-bit = <0>;
 		};
 
 		i2c_smb_1: i2c@40004400 {
@@ -178,6 +180,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			girq = <13>;
+			girq-bit = <1>;
 		};
 
 		i2c_smb_2: i2c@40004800 {
@@ -188,6 +192,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			girq = <13>;
+			girq-bit = <2>;
 		};
 
 		i2c_smb_3: i2c@40004c00 {
@@ -198,6 +204,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			girq = <13>;
+			girq-bit = <3>;
 		};
 
 		i2c_smb_4: i2c@40005000 {
@@ -208,6 +216,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			girq = <13>;
+			girq-bit = <4>;
 		};
 
 		espi0: espi@400f3400 {

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -164,6 +164,7 @@
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <20 1>;
 			label = "I2C_SMB_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -176,6 +177,7 @@
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004400 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <21 1>;
 			label = "I2C_SMB_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -188,6 +190,7 @@
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004800 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <22 1>;
 			label = "I2C_SMB_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -200,6 +203,7 @@
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004C00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <23 1>;
 			label = "I2C_SMB_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -212,6 +216,7 @@
 			compatible = "microchip,xec-i2c";
 			reg = <0x40005000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <158 1>;
 			label = "I2C_SMB_4";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -15,3 +15,13 @@ properties:
       type: int
       description: soc block mapping to pin
       required: true
+
+    girq:
+      type: int
+      required: true
+      description: GIRQ for this device
+
+    girq-bit:
+      type: int
+      required: true
+      description: Bit position in GIRQ for this device

--- a/tests/drivers/i2c/i2c_slave_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/boards/mec1501modular_assy6885.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c_smb_0 {
+	eeprom0: eeprom@54 {
+		compatible = "atmel,at24";
+		reg = <0x54>;
+		label = "EEPROM_0";
+		size = <1024>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
+};
+
+
+&i2c_smb_1 {
+	eeprom1: eeprom@56 {
+		compatible = "atmel,at24";
+		reg = <0x56>;
+		label = "EEPROM_1";
+		size = <1024>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
+};


### PR DESCRIPTION
This patchset introduces i2c_slave support for microchip i2c driver