### PR TITLE
Refactor locking in TCP2

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -234,6 +234,8 @@ static int process_tcp(struct data *data)
 
 	LOG_INF("TCP (%s): Accepted connection", data->proto);
 
+#define MAX_NAME_LEN sizeof("tcp6[0]")
+
 #if defined(CONFIG_NET_IPV6)
 	if (client_addr.sin_family == AF_INET6) {
 		tcp6_handler_in_use[slot] = true;
@@ -248,6 +250,13 @@ static int process_tcp(struct data *data)
 			IS_ENABLED(CONFIG_USERSPACE) ? K_USER |
 						       K_INHERIT_PERMS : 0,
 			K_NO_WAIT);
+
+		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			char name[MAX_NAME_LEN];
+
+			snprintk(name, sizeof(name), "tcp6[%d]", slot);
+			k_thread_name_set(&tcp6_handler_thread[slot], name);
+		}
 	}
 #endif
 
@@ -265,6 +274,13 @@ static int process_tcp(struct data *data)
 			IS_ENABLED(CONFIG_USERSPACE) ? K_USER |
 						       K_INHERIT_PERMS : 0,
 			K_NO_WAIT);
+
+		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			char name[MAX_NAME_LEN];
+
+			snprintk(name, sizeof(name), "tcp4[%d]", slot);
+			k_thread_name_set(&tcp4_handler_thread[slot], name);
+		}
 	}
 #endif
 

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -193,6 +193,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp6_thread_id);
 #endif
 
+		k_thread_name_set(udp6_thread_id, "udp6");
 		k_thread_start(udp6_thread_id);
 	}
 
@@ -201,6 +202,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp4_thread_id);
 #endif
 
+		k_thread_name_set(udp4_thread_id, "udp4");
 		k_thread_start(udp4_thread_id);
 	}
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -489,6 +489,8 @@ static int bind_default(struct net_context *context)
 int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		     socklen_t addrlen)
 {
+	int ret;
+
 	NET_ASSERT(addr);
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
@@ -506,7 +508,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		struct net_if *iface = NULL;
 		struct in6_addr *ptr;
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
-		int ret;
 
 		if (addrlen < sizeof(struct sockaddr_in6)) {
 			return -EINVAL;
@@ -558,6 +559,10 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
+		ret = 0;
+
 		net_context_set_iface(context, iface);
 
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
@@ -571,7 +576,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			} else {
 				NET_ERR("Port %d is in use!",
 					ntohs(addr6->sin6_port));
-				return ret;
+				goto unlock_ipv6;
 			}
 		} else {
 			addr6->sin6_port =
@@ -585,7 +590,10 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ipv6_addr(ptr)),
 			ntohs(addr6->sin6_port), iface);
 
-		return 0;
+	unlock_ipv6:
+		k_mutex_unlock(&context->lock);
+
+		return ret;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->sa_family == AF_INET) {
@@ -593,7 +601,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		struct net_if *iface = NULL;
 		struct net_if_addr *ifaddr;
 		struct in_addr *ptr;
-		int ret;
 
 		if (addrlen < sizeof(struct sockaddr_in)) {
 			return -EINVAL;
@@ -660,7 +667,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			} else {
 				NET_ERR("Port %d is in use!",
 					ntohs(addr4->sin_port));
-				goto unlock;
+				goto unlock_ipv4;
 			}
 		} else {
 			addr4->sin_port =
@@ -674,7 +681,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ipv4_addr(ptr)),
 			ntohs(addr4->sin_port), iface);
 
-	unlock:
+	unlock_ipv4:
 		k_mutex_unlock(&context->lock);
 
 		return ret;
@@ -710,6 +717,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
 		net_context_set_iface(context, iface);
 
 		net_sll_ptr(&context->local)->sll_family = AF_PACKET;
@@ -728,6 +737,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			log_strdup(net_sprint_ll_addr(
 				net_sll_ptr(&context->local)->sll_addr,
 				net_sll_ptr(&context->local)->sll_halen)));
+
+		k_mutex_unlock(&context->lock);
 
 		return 0;
 	}
@@ -761,6 +772,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
+		k_mutex_lock(&context->lock, K_FOREVER);
+
 		net_context_set_iface(context, iface);
 		net_context_set_family(context, AF_CAN);
 
@@ -771,6 +784,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		NET_DBG("Context %p binding to %d iface[%d] %p",
 			context, net_context_get_ip_proto(context),
 			can_addr->can_ifindex, iface);
+
+		k_mutex_unlock(&context->lock);
 
 		return 0;
 	}

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -341,7 +341,7 @@ int net_context_unref(struct net_context *context)
 		return old_rc - 1;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	net_tcp_unref(context);
 
@@ -360,7 +360,7 @@ int net_context_unref(struct net_context *context)
 
 	NET_DBG("Context %p released", context);
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return 0;
 }
@@ -375,7 +375,7 @@ int net_context_put(struct net_context *context)
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
 	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
@@ -395,7 +395,7 @@ int net_context_put(struct net_context *context)
 	net_tcp_put(context);
 
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -559,7 +559,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
-		k_mutex_lock(&context->lock, K_FOREVER);
+		NET_MUTEX_LOCK(&context->lock);
 
 		ret = 0;
 
@@ -591,7 +591,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			ntohs(addr6->sin6_port), iface);
 
 	unlock_ipv6:
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 
 		return ret;
 	}
@@ -650,7 +650,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
-		k_mutex_lock(&context->lock, K_FOREVER);
+		NET_MUTEX_LOCK(&context->lock);
 
 		ret = 0;
 
@@ -682,7 +682,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			ntohs(addr4->sin_port), iface);
 
 	unlock_ipv4:
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 
 		return ret;
 	}
@@ -717,7 +717,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
-		k_mutex_lock(&context->lock, K_FOREVER);
+		NET_MUTEX_LOCK(&context->lock);
 
 		net_context_set_iface(context, iface);
 
@@ -738,7 +738,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 				net_sll_ptr(&context->local)->sll_addr,
 				net_sll_ptr(&context->local)->sll_halen)));
 
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 
 		return 0;
 	}
@@ -772,7 +772,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addrlen);
 		}
 
-		k_mutex_lock(&context->lock, K_FOREVER);
+		NET_MUTEX_LOCK(&context->lock);
 
 		net_context_set_iface(context, iface);
 		net_context_set_family(context, AF_CAN);
@@ -785,7 +785,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			context, net_context_get_ip_proto(context),
 			can_addr->can_ifindex, iface);
 
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 
 		return 0;
 	}
@@ -826,14 +826,14 @@ int net_context_listen(struct net_context *context, int backlog)
 					  context, backlog);
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (net_tcp_listen(context) >= 0) {
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 		return 0;
 	}
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return -EOPNOTSUPP;
 }
@@ -909,7 +909,7 @@ int net_context_connect(struct net_context *context,
 	NET_ASSERT(addr);
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (!net_context_is_used(context)) {
 		ret = -EBADF;
@@ -1066,7 +1066,7 @@ int net_context_connect(struct net_context *context,
 	}
 
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -1084,7 +1084,7 @@ int net_context_accept(struct net_context *context,
 		return -EBADF;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
 	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
@@ -1112,7 +1112,7 @@ int net_context_accept(struct net_context *context,
 	}
 
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -1699,7 +1699,7 @@ int net_context_send(struct net_context *context,
 	socklen_t addrlen;
 	int ret = 0;
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (!(context->flags & NET_CONTEXT_REMOTE_ADDR_SET) ||
 	    !net_sin(&context->remote)->sin_port) {
@@ -1727,7 +1727,7 @@ int net_context_send(struct net_context *context,
 	ret = context_sendto(context, buf, len, &context->remote,
 			     addrlen, cb, timeout, user_data, false);
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -1741,12 +1741,12 @@ int net_context_sendmsg(struct net_context *context,
 {
 	int ret;
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	ret = context_sendto(context, msghdr, 0, NULL, 0,
 			     cb, timeout, user_data, true);
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -1762,12 +1762,12 @@ int net_context_sendto(struct net_context *context,
 {
 	int ret;
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	ret = context_sendto(context, buf, len, dst_addr, addrlen,
 			     cb, timeout, user_data, true);
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -1784,7 +1784,7 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 	NET_ASSERT(context);
 	NET_ASSERT(net_pkt_iface(pkt));
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	net_context_set_iface(context, net_pkt_iface(pkt));
 	net_pkt_set_context(pkt, context);
@@ -1805,7 +1805,7 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 	k_sem_give(&context->recv_data_wait);
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	context->recv_cb(context, pkt, ip_hdr, proto_hdr, 0, user_data);
 
@@ -1814,7 +1814,7 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 	return verdict;
 
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return verdict;
 }
@@ -1963,7 +1963,7 @@ int net_context_recv(struct net_context *context,
 		return -EBADF;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
 	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
@@ -2033,11 +2033,11 @@ int net_context_recv(struct net_context *context,
 		 */
 		k_sem_reset(&context->recv_data_wait);
 
-		k_mutex_unlock(&context->lock);
+		NET_MUTEX_UNLOCK(&context->lock);
 
 		ret = k_sem_take(&context->recv_data_wait, timeout);
 
-		k_mutex_lock(&context->lock, K_FOREVER);
+		NET_MUTEX_LOCK(&context->lock);
 
 		if (ret == -EAGAIN) {
 			ret = -ETIMEDOUT;
@@ -2047,7 +2047,7 @@ int net_context_recv(struct net_context *context,
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
 unlock:
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -2062,11 +2062,11 @@ int net_context_update_recv_wnd(struct net_context *context,
 		return 0;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	ret = net_tcp_update_recv_wnd(context, delta);
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -2154,7 +2154,7 @@ int net_context_set_option(struct net_context *context,
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	switch (option) {
 	case NET_OPT_PRIORITY:
@@ -2171,7 +2171,7 @@ int net_context_set_option(struct net_context *context,
 		break;
 	}
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }
@@ -2188,7 +2188,7 @@ int net_context_get_option(struct net_context *context,
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&context->lock, K_FOREVER);
+	NET_MUTEX_LOCK(&context->lock);
 
 	switch (option) {
 	case NET_OPT_PRIORITY:
@@ -2205,7 +2205,7 @@ int net_context_get_option(struct net_context *context,
 		break;
 	}
 
-	k_mutex_unlock(&context->lock);
+	NET_MUTEX_UNLOCK(&context->lock);
 
 	return ret;
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -272,3 +272,20 @@ static inline void net_pkt_print_buffer_info(struct net_pkt *pkt, const char *st
 
 	printk("\n");
 }
+
+/* Only enable mutex lock/unlock debugging when needed as it will print
+ * lot of data which is not normally needed.
+ */
+#if 0
+#define NET_MUTEX_LOCK(mtx) do {					\
+		NET_DBG("%d: lock %p", __LINE__, mtx);			\
+		k_mutex_lock(mtx, K_FOREVER);				\
+	} while (0)
+#define NET_MUTEX_UNLOCK(mtx) do {					\
+		NET_DBG("%d: unlock %p", __LINE__, mtx);		\
+		k_mutex_unlock(mtx);					\
+	} while (0)
+#else
+#define NET_MUTEX_LOCK(mtx) k_mutex_lock(mtx, K_FOREVER)
+#define NET_MUTEX_UNLOCK(mtx) k_mutex_unlock(mtx)
+#endif

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -189,7 +189,7 @@ struct tcp { /* TCP connection */
 		net_tcp_accept_cb_t accept_cb;
 		struct tcp *accepted_conn;
 	};
-	struct k_mutex lock;
+	struct k_mutex *lock;
 	struct k_sem connect_sem; /* semaphore for blocking connect */
 	struct k_fifo recv_data;  /* temp queue before passing data to app */
 	struct tcp_options recv_options;


### PR DESCRIPTION
This one removes a separate lock in TCP2 and starts to use the same lock as in net_context. This hopefully will get rid of deadlocks in heavy load. See also #29444 