### PR TITLE
mipi-sys-t: move platform.h to zephyr tree

### DIFF
--- a/subsys/logging/mipi_syst/platform.h
+++ b/subsys/logging/mipi_syst/platform.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MIPI_SYST_PLATFORM_INCLUDED
+#define MIPI_SYST_PLATFORM_INCLUDED
+
+#include <logging/log_output.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_STATE_DATA)
+/*
+ * Platform specific SyS-T global state extension
+ */
+struct mipi_syst_platform_state {
+	void (*write_d8)(struct mipi_syst_handle *systh, mipi_syst_u8 v);
+	void (*write_d16)(struct mipi_syst_handle *systh, mipi_syst_u16 v);
+	void (*write_d32)(struct mipi_syst_handle *systh, mipi_syst_u32 v);
+#if defined(MIPI_SYST_PCFG_ENABLE_64BIT_IO)
+	void (*write_d64)(struct mipi_syst_handle *systh, mipi_syst_u64 v);
+#endif
+	void (*write_d32ts)(struct mipi_syst_handle *systh, mipi_syst_u32 v);
+	void (*write_flag)(struct mipi_syst_handle *systh);
+};
+
+/*
+ * Platform specific SyS-T handle state extension
+ */
+struct mipi_syst_platform_handle {
+	mipi_syst_u32 flag;
+	struct log_output *log_output;
+};
+
+/*
+ * IO output routine mapping
+ * Call the function pointers in the global state
+ */
+#define MIPI_SYST_OUTPUT_D8(syst_handle, data) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_d8((syst_handle), (data)))
+#define MIPI_SYST_OUTPUT_D16(syst_handle, data) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_d16((syst_handle), (data)))
+#define MIPI_SYST_OUTPUT_D32(syst_handle, data) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_d32((syst_handle), (data)))
+#if defined(MIPI_SYST_PCFG_ENABLE_64BIT_IO)
+#define MIPI_SYST_OUTPUT_D64(syst_handle, data) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_d64((syst_handle), (data)))
+#endif
+#define MIPI_SYST_OUTPUT_D32TS(syst_handle, data) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_d32ts((syst_handle), (data)))
+#define MIPI_SYST_OUTPUT_FLAG(syst_handle) \
+	((syst_handle)->systh_header-> \
+		systh_platform.write_flag((syst_handle)))
+
+#else
+
+#define MIPI_SYST_OUTPUT_D8(syst_handle, data)
+#define MIPI_SYST_OUTPUT_D16(syst_handle, data)
+#define MIPI_SYST_OUTPUT_D32(syst_handle, data)
+#if defined(MIPI_SYST_PCFG_ENABLE_64BIT_IO)
+#define MIPI_SYST_OUTPUT_D64(syst_handle, data)
+#endif
+#define MIPI_SYST_OUTPUT_D32TS(syst_handle, data)
+#define MIPI_SYST_OUTPUT_FLAG(syst_handle)
+
+#endif
+
+#if defined(MIPI_SYST_PCFG_ENABLE_HEAP_MEMORY)
+#define MIPI_SYST_HEAP_MALLOC(s)
+#define MIPI_SYST_HEAP_FREE(p)
+#endif
+
+#if defined(MIPI_SYST_PCFG_ENABLE_TIMESTAMP)
+#define MIPI_SYST_PLATFORM_CLOCK() mipi_syst_get_epoch()
+#define MIPI_SYST_PLATFORM_FREQ()  CONFIG_SYS_CLOCK_TICKS_PER_SEC
+
+mipi_syst_u64 mipi_syst_get_epoch(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
       revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
-      revision: 957d46bc3ce0d5f628f0d525196bb4db207672ee
+      revision: 75e671550ac1acb502f315fe4952514dc73f7bfb
     - name: nrf_hw_models
       path: modules/bsim_hw_models/nrf_hw_models
       revision: 71a8a9ef086d57ff5f3974138b0951f24c2017ad


### PR DESCRIPTION
platform.h is zephyr specific, so move it to the zephyr tree.