### PR TITLE
STM32: Convert I2S to devicetree pinctrl configuration

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -83,6 +83,7 @@
 
 &i2s5 {
 	status = "okay";
+	pinctrl-0 = <&i2s5_ck_pb0 &i2s5_sd_pb8>;
 
 	mp34dt05@0 {
 		compatible = "st,mpxxdtyy";

--- a/boards/arm/96b_argonkey/pinmux.c
+++ b/boards/arm/96b_argonkey/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for 96boards Argonkey board */
 static const struct pin_config pinconf[] = {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2s5), okay) && CONFIG_I2S
-	{STM32_PIN_PB0, STM32F4_PINMUX_FUNC_PB0_I2S5_CK},
-	{STM32_PIN_PB8, STM32F4_PINMUX_FUNC_PB8_I2S5_SD},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -92,6 +92,7 @@
 };
 
 &i2s2 {
+	pinctrl-0 = <&i2s2_ck_pc7 &i2s2_sd_pc1>;
 	status = "okay";
 };
 

--- a/boards/arm/96b_stm32_sensor_mez/pinmux.c
+++ b/boards/arm/96b_stm32_sensor_mez/pinmux.c
@@ -14,10 +14,6 @@
 
 /* pin assignments for 96b_stm32_sensor_mez board */
 static const struct pin_config pinconf[] = {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2s2), okay) && CONFIG_I2S
-	{STM32_PIN_PC7, STM32F4_PINMUX_FUNC_PC7_I2S2_CK},
-	{STM32_PIN_PC1, STM32F4_PINMUX_FUNC_PC1_I2S2_SD},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -70,6 +70,10 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&i2s1 {
+	pinctrl-0 = <&i2s1_ck_pa5 &i2s1_sd_pa7>;
+};
+
 &spi1 {
 	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
 		     &spi1_miso_pa6 &spi1_mosi_pa7>;

--- a/boards/arm/nucleo_f411re/pinmux.c
+++ b/boards/arm/nucleo_f411re/pinmux.c
@@ -14,13 +14,6 @@
 
 /* pin assignments for NUCLEO-F411RE board */
 static const struct pin_config pinconf[] = {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2s1), okay) && CONFIG_I2S
-	{STM32_PIN_PA4, STM32F4_PINMUX_FUNC_PA4_SPI1_NSS},
-
-	{STM32_PIN_PA5, STM32F4_PINMUX_FUNC_PA5_SPI1_SCK},
-	{STM32_PIN_PA6, STM32F4_PINMUX_FUNC_PA6_SPI1_MISO},
-	{STM32_PIN_PA7, STM32F4_PINMUX_FUNC_PA7_SPI1_MOSI},
-#endif
 };
 
 static int pinmux_stm32_init(const struct device *port)

--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -72,6 +72,8 @@ struct i2s_stm32_cfg {
 	SPI_TypeDef *i2s;
 	struct stm32_pclken pclken;
 	uint32_t i2s_clk_sel;
+	const struct soc_gpio_pinctrl *pinctrl_list;
+	size_t pinctrl_list_size;
 	void (*irq_config)(const struct device *dev);
 };
 

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -19,3 +19,13 @@ properties:
 
     dma-names:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        Pin configuration for I2S signals.
+        We expect that the phandles will reference pinctrl nodes.
+
+        For example the I2S1 would be:
+        pinctrl-0 = <&i2s1_ck_pa5 &i2s1_sd_pa7>;

--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: 2b123553b84cfe9e5a28078355774b636c475da0
+      revision: a0267470e786019e378be18f5786e53ef307497f
       path: modules/hal/stm32
     - name: hal_ti
       revision: 405dfc8faba13e01c1cb9e29e70b31b50f71d117


### PR DESCRIPTION
Last STM32 driver to be converted to  device tree based pinctrl configuration