### PR TITLE
W5500: Coverity and time computation fix

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -161,10 +161,13 @@ static int w5500_command(const struct device *dev, uint8_t cmd)
 
 	w5500_spi_write(dev, W5500_S0_CR, &cmd, 1);
 	do {
-		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
-		if (end - z_tick_get() <= 0) {
+		int64_t remaining = end - z_tick_get();
+
+		if (remaining <= 0) {
 			return -EIO;
 		}
+
+		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
 
 		k_msleep(1);
 	} while (reg != 0);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -346,14 +346,14 @@ static int w5500_set_config(const struct device *dev,
 	if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE) &&
 	    type == ETHERNET_CONFIG_TYPE_PROMISC_MODE) {
 		if (config->promisc_mode) {
-			if (!(mode & W5500_S0_MR_MF))
+			if (!(mode & BIT(mr)))
 				return -EALREADY;
 			}
 
 			/* clear */
 			WRITE_BIT(mode, mr, 0);
 	} else {
-		if (mode & mr) {
+		if (mode & BIT(mr)) {
 			return -EALREADY;
 		}
 

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -55,7 +55,7 @@
 #define W5500_S0_RX_RD		(W5500_S0_REGS + W5500_Sn_RX_RD)
 #define W5500_S0_IMR		(W5500_S0_REGS + W5500_Sn_IMR)
 
-#define W5500_S0_MR_MF		BIT(7) /* MAC Filter for W5500 */
+#define W5500_S0_MR_MF		7 /* MAC Filter for W5500 */
 #define W5500_Sn_REGS_LEN	0x0040
 #define W5500_SIMR		0x0018 /* Socket Interrupt Mask Register */
 #define IR_S0			0x01


### PR DESCRIPTION
Following two fixes included,

1. w5500_command processing time computation fix for comparing unsigned and singed int
2. Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/29014