### PR TITLE
dts: bindings: Fix duplicate description in STM32 DMA bindings

### DIFF
--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -1,38 +1,9 @@
 # Copyright (c) 2019, Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 DMA controller
-
-compatible: "st,stm32-dma"
-
-include: dma-controller.yaml
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    st,mem2mem:
-      type: boolean
-      description: If the DMA controller V1 supports memory to memory transfer
-
-    "#dma-cells":
-      const: 4
-
-# Parameter syntax of stm32 follows the dma client dts syntax
-# in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
-#
-
-dma-cells:
-  - channel
-  - slot
-  - channel-config
-  - features
-
 description: |
+  STM32 DMA controller
+
   The STM32 DMA is a general-purpose direct memory access controller
   capable of supporting 5 or 6 or 7 or 8 independent DMA channels.
   Each channel can have up to 8 requests.
@@ -106,3 +77,31 @@ description: |
            <&dma1 2 1 0x20480 0x04>;
      dma-names = "tx", "rx";
    };
+
+compatible: "st,stm32-dma"
+
+include: dma-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    st,mem2mem:
+      type: boolean
+      description: If the DMA controller V1 supports memory to memory transfer
+
+    "#dma-cells":
+      const: 4
+
+# Parameter syntax of stm32 follows the dma client dts syntax
+# in the Linux kernel declared in
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+
+dma-cells:
+  - channel
+  - slot
+  - channel-config
+  - features

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -1,34 +1,9 @@
 # Copyright (c) 2019, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 DMAMUX controller
-
-compatible: "st,stm32-dmamux"
-
-include: dmamux-controller.yaml
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    "#dma-cells":
-      const: 4
-
-# Parameter syntax of stm32 follows the dma client dts syntax
-# in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dmamux.yaml
-#
-
-dma-cells:
-  - channel
-  - slot
-  - channel-config
-  - features
-
 description: |
+  STM32 DMAMUX controller
+
   The STM32 DMAMUX is a direct memory access multiplexer
   capable of supporting independent DMA channels.
   DMAMUX clients connected to the STM32 DMA ultiplexer must use a two-cell specifier
@@ -84,3 +59,26 @@ description: |
          &dmamux1 1 6 0x20480 0>;
          dma-names = "tx", "rx";
         };
+compatible: "st,stm32-dmamux"
+
+include: dmamux-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    "#dma-cells":
+      const: 4
+
+# Parameter syntax of stm32 follows the dma client dts syntax
+# in the Linux kernel declared in
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dmamux.yaml
+
+dma-cells:
+  - channel
+  - slot
+  - channel-config
+  - features


### PR DESCRIPTION
The DMA bindings had duplicate description: keys.  Merge the two
descriptions into one to fix the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>