### PR TITLE
mmu: Fix mapping_pos calculation

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -56,8 +56,8 @@ static struct k_spinlock mm_lock;
   * beginning of system RAM.
   */
 static uint8_t *mapping_pos =
-		(uint8_t *)((uintptr_t)(CONFIG_SRAM_BASE_ADDRESS +
-					CONFIG_KERNEL_VM_SIZE));
+		(uint8_t *)((uintptr_t)CONFIG_SRAM_BASE_ADDRESS +
+			    (uintptr_t)CONFIG_KERNEL_VM_SIZE);
 
 /* Lower-limit of virtual address mapping. Immediately below this is the
  * permanent identity mapping for all SRAM.


### PR DESCRIPTION
In the MMU code mapping_pos is miscalculated when for example
SRAM_BASE_ADDRESS==0x40000000 and KERNEL_VM_SIZE==0xc0000000 getting a
mapping_pos of 0x0.

The problem is that we must cast the two values to uintptr_t before
casting the result to avoid the rollover to 0.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>