### PR TITLE
net: lwm2m: Pack TLV integers more efficiently

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -423,6 +423,10 @@ static size_t put_s16(struct lwm2m_output_context *out,
 	struct oma_tlv tlv;
 	int16_t net_value;
 
+	if (INT8_MIN <= value && value <= INT8_MAX) {
+		return put_s8(out, path, (int8_t)value);
+	}
+
 	fd = engine_get_out_user_data(out);
 	if (!fd) {
 		return 0;
@@ -437,12 +441,16 @@ static size_t put_s16(struct lwm2m_output_context *out,
 }
 
 static size_t put_s32(struct lwm2m_output_context *out,
-			struct lwm2m_obj_path *path, int32_t value)
+		      struct lwm2m_obj_path *path, int32_t value)
 {
 	struct tlv_out_formatter_data *fd;
 	size_t len;
 	struct oma_tlv tlv;
 	int32_t net_value;
+
+	if (INT16_MIN <= value && value <= INT16_MAX) {
+		return put_s16(out, path, (int16_t)value);
+	}
 
 	fd = engine_get_out_user_data(out);
 	if (!fd) {
@@ -454,16 +462,21 @@ static size_t put_s32(struct lwm2m_output_context *out,
 		  tlv_calc_id(fd->writer_flags, path), sizeof(net_value));
 
 	len = oma_tlv_put(&tlv, out, (uint8_t *)&net_value, false);
+
 	return len;
 }
 
 static size_t put_s64(struct lwm2m_output_context *out,
-			struct lwm2m_obj_path *path, int64_t value)
+		      struct lwm2m_obj_path *path, int64_t value)
 {
 	struct tlv_out_formatter_data *fd;
 	size_t len;
 	struct oma_tlv tlv;
 	int64_t net_value;
+
+	if (INT32_MIN <= value && value <= INT32_MAX) {
+		return put_s32(out, path, (int32_t)value);
+	}
 
 	fd = engine_get_out_user_data(out);
 	if (!fd) {


### PR DESCRIPTION
Prior to this commit, the LwM2M stack would TLV-encode integers
depending on their internal storage size. An integer with value 5 stored
in an int8_t would be encoded with length 1, but an integer stored in an
int32_t would be encoded as "00 00 00 05" with length 4.

This commit checks if the value is castable to a smaller int and encodes
it as such if so. This is cascading, so even a 64 bit integer with value
5 will be encoded with length 1.

Note that this does not seem to be required by the specification, but
this is how Anjay and the other LwM2M stack seem to do it.