### PR TITLE
drivers: counter: Add alarm channels in counter_native_posix

### DIFF
--- a/boards/posix/native_posix/hw_counter.c
+++ b/boards/posix/native_posix/hw_counter.c
@@ -83,6 +83,14 @@ void hw_counter_stop(void)
 }
 
 /**
+ * Resets the counter value.
+ */
+void hw_counter_reset(void)
+{
+	counter_value = 0;
+}
+
+/**
  * Returns the current counter value.
  */
 uint64_t hw_counter_get_value(void)

--- a/boards/posix/native_posix/hw_counter.h
+++ b/boards/posix/native_posix/hw_counter.h
@@ -20,6 +20,7 @@ void hw_counter_set_period(uint64_t period);
 void hw_counter_set_target(uint64_t counter_target);
 void hw_counter_start(void);
 void hw_counter_stop(void);
+void hw_counter_reset(void);
 uint64_t hw_counter_get_value(void);
 
 #ifdef __cplusplus

--- a/drivers/counter/Kconfig.native_posix
+++ b/drivers/counter/Kconfig.native_posix
@@ -10,3 +10,11 @@ config COUNTER_NATIVE_POSIX_FREQUENCY
     int "native_posix counter frequency in Hz"
     default 1000
     depends on COUNTER_NATIVE_POSIX
+
+config COUNTER_NATIVE_POSIX_CHANNELS_NUMBER
+    int "native_posix counter channels number"
+    range 1 16
+    default 4
+    depends on COUNTER_NATIVE_POSIX
+    help
+      Set the number of available alarm channels.


### PR DESCRIPTION
Extend functionality of native_posix counter by adding ability
to set alarms on multiple channels. This is done to have more
functional counter on native_posix board which is needed to
measure time more precisely than k_timer.
Tested against tests/drivers/counter/counter_basic_api.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>