### PR TITLE
scripts: edt: Add support for include property filtering

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -60,7 +60,50 @@ compatible: "manufacturer,device"
 # When including multiple files, any overlapping 'required' keys on properties
 # in the included files are ORed together. This makes sure that a
 # 'required: true' is always respected.
-include: other.yaml # or [other1.yaml, other2.yaml]
+#
+# When 'include:' is a list, its elements can be either filenames as
+# strings, or maps. Each map element must have a 'name' key which is
+# the filename to include, and may have 'property-allowlist' and
+# 'property-blocklist' keys that filter which properties are included.
+# You can freely intermix strings and maps in a single 'include:' list.
+# You cannot have a single map element with both 'property-allowlist' and
+# 'property-blocklist' keys. A map element with neither 'property-allowlist'
+# nor 'property-blocklist' is valid; no additional filtering is done.
+include: other.yaml
+# To include multiple files:
+#
+# include:
+#   - other1.yaml
+#   - other2.yaml
+#
+# To filter the included properties:
+#
+# include:
+#   - name: other1.yaml
+#     property-allowlist:
+#       - i-want-this-one
+#       - and-this-one
+#   - other2.yaml
+#     property-blocklist:
+#       - do-not-include-this-one
+#       - or-this-one
+#
+# You can intermix these types of includes:
+#
+# include:
+#   - other1.yaml
+#   - other2.yaml
+#     property-blocklist:
+#       - do-not-include-this-one
+#       - or-this-one
+#
+# And you can filter from a child binding like this:
+#
+# include:
+#   - name: bar.yaml
+#     child-binding:
+#       property-allowlist:
+#         - child-prop-to-allow
 
 # If the node describes a bus, then the bus type should be given, like below
 bus: <string describing bus type, e.g. "i2c">

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/README.rst
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/README.rst
@@ -1,0 +1,1 @@
+This directory contains bindings used to test the 'include:' feature.

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/allow-and-blocklist-child.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/allow-and-blocklist-child.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  An include must not give both an allowlist and a blocklist in a
+  child binding. This binding should cause an error.
+compatible: allow-and-blocklist-child
+include:
+  - name: include.yaml
+    child-binding:
+      property-blocklist: [x]
+      property-allowlist: [y]

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/allow-and-blocklist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/allow-and-blocklist.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  An include must not give both an allowlist and a blocklist.
+  This binding should cause an error.
+compatible: allow-and-blocklist
+include:
+  - name: include.yaml
+    property-blocklist: [x]
+    property-allowlist: [y]

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/allow-not-list.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/allow-not-list.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  A property-allowlist, if given, must be a list. This binding should
+  cause an error.
+compatible: allow-not-list
+include:
+  - name: include.yaml
+    property-allowlist:
+      foo:

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/allowlist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/allowlist.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Valid property-allowlist.
+compatible: allowlist
+include:
+  - name: include.yaml
+    property-allowlist: [x]

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/block-not-list.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/block-not-list.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  A property-blocklist, if given, must be a list. This binding should
+  cause an error.
+compatible: block-not-list
+include:
+  - name: include.yaml
+    property-blocklist:
+      foo:

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/blocklist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/blocklist.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Valid property-blocklist.
+compatible: blocklist
+include:
+  - name: include.yaml
+    property-blocklist: [x]

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/empty-allowlist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/empty-allowlist.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: An empty property-allowlist is valid.
+compatible: empty-allowlist
+include:
+  - name: include.yaml
+    property-allowlist: []

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/empty-blocklist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/empty-blocklist.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: An empty property-blocklist is valid.
+compatible: empty-blocklist
+include:
+  - name: include.yaml
+    property-blocklist: []

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/filter-child-bindings.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/filter-child-bindings.yaml
@@ -1,0 +1,11 @@
+description: Test binding for filtering 'child-binding' properties
+
+include:
+  - name: include.yaml
+    property-allowlist: [x]
+    child-binding:
+      property-blocklist: [child-prop-1]
+      child-binding:
+        property-allowlist: [grandchild-prop-1]
+
+compatible: filter-child-bindings

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include-2.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include-2.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Second file for testing "intermixed" includes.
+compatible: include-2
+properties:
+  a:
+    type: int

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include-invalid-keys.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include-invalid-keys.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  Invalid include element: invalid keys are present.
+compatible: include-invalid-keys
+include:
+  - name: include.yaml
+    property-allowlist: [x]
+    bad-key-1: 3
+    bad-key-2: 3

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include-invalid-type.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include-invalid-type.yaml
@@ -1,0 +1,5 @@
+description: |
+  Invalid include: wrong top level type.
+compatible: include-invalid-type
+include:
+  a-map-is-not-allowed-here: 3

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include-no-list.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include-no-list.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: A map element with just a name is valid, and has no filters.
+compatible: include-no-list
+include:
+  - name: include.yaml

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include-no-name.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include-no-name.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: |
+  Invalid include element: no name key is present.
+compatible: include-no-name
+include:
+  - property-allowlist: [x]

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/include.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/include.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Test file for including other bindings
+compatible: include
+properties:
+  x:
+    type: int
+  y:
+    type: int
+  z:
+    type: int
+child-binding:
+  properties:
+    child-prop-1:
+      type: int
+    child-prop-2:
+      type: int
+
+  child-binding:
+    properties:
+      grandchild-prop-1:
+        type: int
+      grandchild-prop-2:
+        type: int

--- a/scripts/dts/python-devicetree/tests/test-bindings-include/intermixed.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-include/intermixed.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Including intermixed file names and maps is valid.
+compatible: intermixed
+include:
+  - name: include.yaml
+    property-allowlist: [x]
+  - include-2.yaml


### PR DESCRIPTION
Add the ability to filter which properties get imported when we do an
include.  We add a new YAML form for this:

include:
  - name: other.yaml
    property-blocklist:
      - prop-to-block

or

include:
  - name: other.yaml
    property-allowlist:
      - prop-to-allow

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>

TODO:
- [x] implement more tests
- [x] update dts/binding-template.yaml