### PR TITLE
kernel: fatal: check if _current is NULL

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -48,7 +48,7 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 
 static const char *thread_name_get(struct k_thread *thread)
 {
-	const char *thread_name = k_thread_name_get(thread);
+	const char *thread_name = thread ? k_thread_name_get(thread) : NULL;
 
 	if (thread_name == NULL || thread_name[0] == '\0') {
 		thread_name = "unknown";


### PR DESCRIPTION
Arches which have custom swap to main can have _current be
NULL very, very early in the boot process. Check this to
avoid an infinite loop of fatal errors.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>