### PR TITLE
Userspace samples updates

### DIFF
--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -24,9 +24,6 @@ K_MEM_POOL_DEFINE(app_b_resource_pool, 32, 256, 4, 4);
  */
 K_APPMEM_PARTITION_DEFINE(app_b_partition);
 
-/* Memory domain for application B, set up and installed in app_a_entry() */
-static struct k_mem_domain app_b_domain;
-
 /* Global data used by application B. By tagging with APP_B_BSS or APP_B_DATA,
  * we ensure all this gets linked into the continuous region denoted by
  * app_b_partition.
@@ -79,20 +76,12 @@ static void processor_thread(void *p1, void *p2, void *p3)
 
 void app_b_entry(void *p1, void *p2, void *p3)
 {
-	struct k_mem_partition *parts[] = {
-#if Z_LIBC_PARTITION_EXISTS
-		&z_libc_partition,
-#endif
-		&app_b_partition, &shared_partition
-	};
-
-	/* Initialize a memory domain with the specified partitions
-	 * and add ourself to this domain. We need access to our own
-	 * partition, the shared partition, and any common libc partition
-	 * if it exists.
+	/* Much like how we are reusing the main thread as this application's
+	 * processor thread, we will re-use the default memory domain as the
+	 * domain for application B.
 	 */
-	k_mem_domain_init(&app_b_domain, ARRAY_SIZE(parts), parts);
-	k_mem_domain_add_thread(&app_b_domain, k_current_get());
+	k_mem_domain_add_partition(&k_mem_domain_default, &app_b_partition);
+	k_mem_domain_add_partition(&k_mem_domain_default, &shared_partition);
 
 	/* Assign a resource pool to serve for kernel-side allocations on
 	 * behalf of application A. Needed for k_queue_alloc_append().

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -12,5 +12,4 @@ common:
 tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    # Until #21317 is fixed
-    platform_exclude: twr_ke18f qemu_x86_64
+    platform_exclude: twr_ke18f

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -29,7 +29,7 @@
 /* prepare the memory partition structures  */
 FOR_EACH(K_APPMEM_PARTITION_DEFINE, (;), user_part, red_part, enc_part, blk_part, ct_part);
 /* prepare the memory domain structures  */
-struct k_mem_domain pt_domain, enc_domain, ct_domain;
+struct k_mem_domain pt_domain, enc_domain;
 /* each variable starts with a name defined in main.h
  * the names are symbolic for the memory partitions
  * purpose.
@@ -99,7 +99,6 @@ _app_ct_d char ctMSG[] = "CT!\n";
 void main(void)
 {
 	struct k_mem_partition *enc_parts[] = {&enc_part, &red_part, &blk_part};
-	struct k_mem_partition *ct_parts[] = {&ct_part, &blk_part};
 	struct k_mem_partition *pt_parts[] = {&user_part, &red_part};
 	k_tid_t tPT, tENC, tCT;
 
@@ -147,9 +146,10 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tCT, &allforone);
 	printk("CT Thread Created %p\n", tCT);
-	k_mem_domain_init(&ct_domain, 2, ct_parts);
-	k_mem_domain_add_thread(&ct_domain, tCT);
-	printk("ct_domain Created\n");
+	/* Re-using the default memory domain for CT */
+	k_mem_domain_add_partition(&k_mem_domain_default, &ct_part);
+	k_mem_domain_add_partition(&k_mem_domain_default, &blk_part);
+	printk("ct partitions installed\n");
 
 	k_thread_start(&enc_thread);
 	/* need to start all three threads.  let enc go first to perform init step */

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -27,9 +27,9 @@
  */
 
 /* prepare the memory partition structures  */
-FOR_EACH(K_APPMEM_PARTITION_DEFINE, (;), part0, part1, part2, part3, part4);
+FOR_EACH(K_APPMEM_PARTITION_DEFINE, (;), user_part, red_part, enc_part, blk_part, ct_part);
 /* prepare the memory domain structures  */
-struct k_mem_domain dom0, dom1, dom2;
+struct k_mem_domain pt_domain, enc_domain, ct_domain;
 /* each variable starts with a name defined in main.h
  * the names are symbolic for the memory partitions
  * purpose.
@@ -98,9 +98,9 @@ _app_ct_d char ctMSG[] = "CT!\n";
 
 void main(void)
 {
-	struct k_mem_partition *dom1_parts[] = {&part2, &part1, &part3};
-	struct k_mem_partition *dom2_parts[] = {&part4, &part3};
-	struct k_mem_partition *dom0_parts[] = {&part0, &part1};
+	struct k_mem_partition *enc_parts[] = {&enc_part, &red_part, &blk_part};
+	struct k_mem_partition *ct_parts[] = {&ct_part, &blk_part};
+	struct k_mem_partition *pt_parts[] = {&user_part, &red_part};
 	k_tid_t tPT, tENC, tCT;
 
 	fBUFIN = 0; /* clear flags */
@@ -125,10 +125,10 @@ void main(void)
 	k_thread_access_grant(tENC, &allforone);
 	/* use K_FOREVER followed by k_thread_start*/
 	printk("ENC Thread Created %p\n", tENC);
-	k_mem_domain_init(&dom1, 3, dom1_parts);
-	printk("Partitions added to dom1\n");
-	k_mem_domain_add_thread(&dom1, tENC);
-	printk("dom1 Created\n");
+	k_mem_domain_init(&enc_domain, 3, enc_parts);
+	printk("Partitions added to enc_domain\n");
+	k_mem_domain_add_thread(&enc_domain, tENC);
+	printk("enc_domain Created\n");
 
 
 	tPT = k_thread_create(&pt_thread, pt_stack, STACKSIZE,
@@ -137,9 +137,9 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tPT, &allforone);
 	printk("PT Thread Created %p\n", tPT);
-	k_mem_domain_init(&dom0, 2, dom0_parts);
-	k_mem_domain_add_thread(&dom0, tPT);
-	printk("dom0 Created\n");
+	k_mem_domain_init(&pt_domain, 2, pt_parts);
+	k_mem_domain_add_thread(&pt_domain, tPT);
+	printk("pt_domain Created\n");
 
 	tCT = k_thread_create(&ct_thread, ct_stack, STACKSIZE,
 			(k_thread_entry_t)ct, NULL, NULL, NULL,
@@ -147,9 +147,9 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tCT, &allforone);
 	printk("CT Thread Created %p\n", tCT);
-	k_mem_domain_init(&dom2, 2, dom2_parts);
-	k_mem_domain_add_thread(&dom2, tCT);
-	printk("dom2 Created\n");
+	k_mem_domain_init(&ct_domain, 2, ct_parts);
+	k_mem_domain_add_thread(&ct_domain, tCT);
+	printk("ct_domain Created\n");
 
 	k_thread_start(&enc_thread);
 	/* need to start all three threads.  let enc go first to perform init step */

--- a/samples/userspace/shared_mem/src/main.h
+++ b/samples/userspace/shared_mem/src/main.h
@@ -24,20 +24,20 @@ void enc(void);
 void pt(void);
 void ct(void);
 
-#define _app_user_d K_APP_DMEM(part0)
-#define _app_user_b K_APP_BMEM(part0)
+#define _app_user_d K_APP_DMEM(user_part)
+#define _app_user_b K_APP_BMEM(user_part)
 
-#define _app_red_d K_APP_DMEM(part1)
-#define _app_red_b K_APP_BMEM(part1)
+#define _app_red_d K_APP_DMEM(red_part)
+#define _app_red_b K_APP_BMEM(red_part)
 
-#define _app_enc_d K_APP_DMEM(part2)
-#define _app_enc_b K_APP_BMEM(part2)
+#define _app_enc_d K_APP_DMEM(enc_part)
+#define _app_enc_b K_APP_BMEM(enc_part)
 
-#define _app_blk_d K_APP_DMEM(part3)
-#define _app_blk_b K_APP_BMEM(part3)
+#define _app_blk_d K_APP_DMEM(blk_part)
+#define _app_blk_b K_APP_BMEM(blk_part)
 
-#define _app_ct_d K_APP_DMEM(part4)
-#define _app_ct_b K_APP_BMEM(part4)
+#define _app_ct_d K_APP_DMEM(ct_part)
+#define _app_ct_b K_APP_BMEM(ct_part)
 
 /*
  * Constant


### PR DESCRIPTION
A few fixes to some user mode samples:

- Improved naming of memory domains and partitions in shared_mem sample
- shared_mem and prod_consumer samples now both re-use the default memory domain, saving a lot of RAM on some MMU devices