### PR TITLE
x86: pcie: Fix array index for bus_segs

### DIFF
--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -70,7 +70,7 @@ static inline void pcie_mm_conf(pcie_bdf_t bdf, unsigned int reg,
 				       PCIE_BDF_TO_FUNC(bdf));
 
 			volatile uint32_t *regs
-				= (void *)&bus_segs[0].mmio[bdf << 4];
+				= (void *)&bus_segs[i].mmio[bdf << 4];
 
 			if (write) {
 				regs[reg] = *data;


### PR DESCRIPTION
This seems like a typo since all other places accessing bus_segs in
this context use i as the index.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>