### PR TITLE
Bluetooth: controller: Reduce use of ARG_UNUSED on auto variables

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -499,7 +499,6 @@ isr_rx_do_close:
 
 static void isr_done(void *param)
 {
-	struct node_rx_hdr *node_rx;
 	struct lll_adv *lll;
 
 	/* Clear radio status and events */
@@ -595,7 +594,8 @@ static void isr_done(void *param)
 	}
 
 #if defined(CONFIG_BT_CTLR_ADV_INDICATION)
-	node_rx = ull_pdu_rx_alloc_peek(3);
+	struct node_rx_hdr *node_rx = ull_pdu_rx_alloc_peek(3);
+
 	if (node_rx) {
 		ull_pdu_rx_alloc();
 
@@ -605,9 +605,7 @@ static void isr_done(void *param)
 		ull_rx_put(node_rx->link, node_rx);
 		ull_rx_sched();
 	}
-#else /* !CONFIG_BT_CTLR_ADV_INDICATION */
-	ARG_UNUSED(node_rx);
-#endif /* !CONFIG_BT_CTLR_ADV_INDICATION */
+#endif /* CONFIG_BT_CTLR_ADV_INDICATION */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	struct event_done_extra *extra;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -545,20 +545,16 @@ static void isr_common_done(void *param)
 
 static void isr_done(void *param)
 {
-	uint32_t start_us;
-
 	isr_common_done(param);
 
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
-	start_us = radio_tmr_start_now(0);
+	uint32_t start_us = radio_tmr_start_now(0);
 
 	radio_gpio_lna_setup();
 	radio_gpio_pa_lna_enable(start_us +
 				 radio_rx_ready_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #else /* !CONFIG_BT_CTLR_GPIO_LNA_PIN */
-	ARG_UNUSED(start_us);
-
 	radio_rx_enable();
 #endif /* !CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
@@ -641,7 +637,6 @@ static void isr_done_cleanup(void *param)
 
 static void isr_cleanup(void *param)
 {
-	struct node_rx_hdr *node_rx;
 	struct lll_scan *lll;
 
 	radio_filter_disable();
@@ -659,7 +654,8 @@ static void isr_cleanup(void *param)
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_CTLR_SCAN_INDICATION)
-	node_rx = ull_pdu_rx_alloc_peek(3);
+	struct node_rx_hdr *node_rx = ull_pdu_rx_alloc_peek(3);
+
 	if (node_rx) {
 		ull_pdu_rx_alloc();
 
@@ -669,9 +665,7 @@ static void isr_cleanup(void *param)
 		ull_rx_put(node_rx->link, node_rx);
 		ull_rx_sched();
 	}
-#else /* !CONFIG_BT_CTLR_SCAN_INDICATION */
-	ARG_UNUSED(node_rx);
-#endif /* !CONFIG_BT_CTLR_SCAN_INDICATION */
+#endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
 
 	lll_isr_cleanup(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1088,16 +1088,14 @@ void ll_rx_release(void *node_rx)
 
 void ll_rx_put(memq_link_t *link, void *rx)
 {
+#if defined(CONFIG_BT_CONN)
 	struct node_rx_hdr *rx_hdr = rx;
 
 	/* Serialize Tx ack with Rx enqueue by storing reference to
 	 * last element index in Tx ack FIFO.
 	 */
-#if defined(CONFIG_BT_CONN)
 	rx_hdr->ack_last = mfifo_tx_ack.l;
-#else /* !CONFIG_BT_CONN */
-	ARG_UNUSED(rx_hdr);
-#endif /* !CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN */
 
 	/* Enqueue the Rx object */
 	memq_enqueue(link, rx, &memq_ll_rx.tail);
@@ -1280,16 +1278,14 @@ void *ull_pdu_rx_alloc(void)
 
 void ull_rx_put(memq_link_t *link, void *rx)
 {
+#if defined(CONFIG_BT_CONN)
 	struct node_rx_hdr *rx_hdr = rx;
 
 	/* Serialize Tx ack with Rx enqueue by storing reference to
 	 * last element index in Tx ack FIFO.
 	 */
-#if defined(CONFIG_BT_CONN)
 	rx_hdr->ack_last = ull_conn_ack_last_idx_get();
-#else
-	ARG_UNUSED(rx_hdr);
-#endif
+#endif /* CONFIG_BT_CONN */
 
 	/* Enqueue the Rx object */
 	memq_enqueue(link, rx, &memq_ull_rx.tail);


### PR DESCRIPTION
Reduce the use of ARG_UNUSED on auto variables and try to
use conditional compilation where appropriate.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>