### PR TITLE
tls: reset TLS region when dropping to user mode

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -558,6 +558,19 @@ __syscall k_tid_t k_thread_create(struct k_thread *new_thread,
 /**
  * @brief Drop a thread's privileges permanently to user mode
  *
+ * This allows a supervisor thread to be re-used as a user thread.
+ * This function does not return, but control will transfer to the provided
+ * entry point as if this was a new user thread.
+ *
+ * The implementation ensures that the stack buffer contents are erased.
+ * Any thread-local storage will be reverted to a pristine state.
+ *
+ * Memory domain membership, resource pool assignment, kernel object
+ * permissions, priority, and thread options are preserved.
+ *
+ * A common use of this function is to re-use the main thread as a user thread
+ * once all supervisor mode-only tasks have been completed.
+ *
  * @param entry Function to start executing from
  * @param p1 1st entry point parameter
  * @param p2 2nd entry point parameter


### PR DESCRIPTION
For threads that run in supervisor mode for some time before synchronously dropping to user mode, re-initialize the TLS area to prevent leakage of potentially sensitive information.

We did this already for CONFIG_THREAD_USERSPACE_LOCAL_DATA but not the new CONFIG_THREAD_LOCAL_STORAGE.

Add some notes to `k_thread_user_mode_enter()` documentation about this policy.