### PR TITLE
userspace: always use TLS for errno

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -214,8 +214,10 @@ config HW_STACK_PROTECTION
 config USERSPACE
 	bool "User mode threads"
 	depends on ARCH_HAS_USERSPACE
+	depends on ARCH_HAS_THREAD_LOCAL_STORAGE
 	depends on RUNTIME_ERROR_CHECKS
 	select SRAM_REGION_PERMISSIONS if MMU
+	select THREAD_LOCAL_STORAGE if ERRNO
 	help
 	  When enabled, threads may be created or dropped down to user mode,
 	  which has significantly restricted permissions and must interact

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -264,14 +264,6 @@ struct _mem_domain_info {
 
 #endif /* CONFIG_USERSPACE */
 
-#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
-struct _thread_userspace_local_data {
-#if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS)
-	int errno_var;
-#endif
-};
-#endif
-
 /**
  * @ingroup thread_apis
  * Thread Structure
@@ -327,15 +319,9 @@ struct k_thread {
 	void *custom_data;
 #endif
 
-#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
-	struct _thread_userspace_local_data *userspace_local_data;
-#endif
-
 #if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS)
-#ifndef CONFIG_USERSPACE
-	/** per-thread errno variable */
+	/** per-thread errno variable, for systems without TLS support */
 	int errno_var;
-#endif
 #endif
 
 #if defined(CONFIG_THREAD_STACK_INFO)

--- a/include/sys/errno_private.h
+++ b/include/sys/errno_private.h
@@ -13,36 +13,13 @@
 extern "C" {
 #endif
 
-/* NOTE: located here to avoid include dependency loops between errno.h
- * and kernel.h
- */
-
-#ifdef CONFIG_ERRNO_IN_TLS
-extern __thread int z_errno_var;
-
-static inline int *z_errno(void)
-{
-	return &z_errno_var;
-}
-#else
-/**
- * return a pointer to a memory location containing errno
- *
- * errno is thread-specific, and can't just be a global. This pointer
- * is guaranteed to be read/writable from user mode.
- *
- * @return Memory location of errno data for current thread
- */
-__syscall int *z_errno(void);
-
-#endif /* CONFIG_ERRNO_IN_TLS */
+/* XXX: Make this inline after sorting out dependency loops */
+#ifdef CONFIG_ERRNO
+int *z_errno(void);
+#endif
 
 #ifdef __cplusplus
 }
 #endif
-
-#ifndef CONFIG_ERRNO_IN_TLS
-#include <syscalls/errno_private.h>
-#endif /* CONFIG_ERRNO_IN_TLS */
 
 #endif /* ZEPHYR_INCLUDE_SYS_ERRNO_PRIVATE_H_ */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -192,11 +192,6 @@ config THREAD_CUSTOM_DATA
 	  This option allows each thread to store 32 bits of custom data,
 	  which can be accessed using the k_thread_custom_data_xxx() APIs.
 
-config THREAD_USERSPACE_LOCAL_DATA
-	bool
-	depends on USERSPACE
-	default y if ERRNO && !ERRNO_IN_TLS
-
 config ERRNO
 	bool "Enable errno support"
 	default y
@@ -865,6 +860,7 @@ config THREAD_LOCAL_STORAGE
 	bool "Thread Local Storage (TLS)"
 	depends on ARCH_HAS_THREAD_LOCAL_STORAGE
 	select NEED_LIBC_MEM_PARTITION if (CPU_CORTEX_M && USERSPACE)
+	default y if USERSPACE
 	help
 	  This option enables thread local storage (TLS) support in kernel.
 

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -11,9 +11,8 @@
  * Allow accessing the errno for the current thread without involving the
  * context switching.
  */
-
 #include <kernel.h>
-#include <syscall_handler.h>
+#include <errno.h>
 
 /*
  * Define _k_neg_eagain for use in assembly files as errno.h is
@@ -22,34 +21,18 @@
  */
 const int _k_neg_eagain = -EAGAIN;
 
-#ifdef CONFIG_ERRNO
-
-#ifdef CONFIG_ERRNO_IN_TLS
+#if defined(CONFIG_ERRNO) && defined (CONFIG_ERRNO_IN_TLS)
 __thread int z_errno_var;
+#endif
+
+/* NOTE: located here to avoid include dependency loops between errno.h
+ * and kernel.h
+ */
+int *z_errno(void)
+{
+#ifdef CONFIG_ERRNO_IN_TLS
+	return &z_errno_var;
 #else
-
-#ifdef CONFIG_USERSPACE
-int *z_impl_z_errno(void)
-{
-	/* Initialized to the lowest address in the stack so the thread can
-	 * directly read/write it
-	 */
-	return &_current->userspace_local_data->errno_var;
-}
-
-static inline int *z_vrfy_z_errno(void)
-{
-	return z_impl_z_errno();
-}
-#include <syscalls/z_errno_mrsh.c>
-
-#else
-int *z_impl_z_errno(void)
-{
 	return &_current->errno_var;
+#endif
 }
-#endif /* CONFIG_USERSPACE */
-
-#endif /* CONFIG_ERRNO_IN_TLS */
-
-#endif /* CONFIG_ERRNO */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -495,14 +495,6 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	delta += arch_tls_stack_setup(new_thread, (stack_ptr - delta));
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
-#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
-	size_t tls_size = sizeof(struct _thread_userspace_local_data);
-
-	/* reserve space on highest memory of stack buffer for local data */
-	delta += tls_size;
-	new_thread->userspace_local_data =
-		(struct _thread_userspace_local_data *)(stack_ptr - delta);
-#endif
 #if CONFIG_STACK_POINTER_RANDOM
 	delta += random_offset(stack_buf_size);
 #endif
@@ -835,10 +827,6 @@ FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 #ifdef CONFIG_USERSPACE
 	__ASSERT(z_stack_is_user_capable(_current->stack_obj),
 		 "dropping to user mode with kernel-only stack object");
-#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
-	memset(_current->userspace_local_data, 0,
-	       sizeof(struct _thread_userspace_local_data));
-#endif
 	arch_user_mode_enter(entry, p1, p2, p3);
 #else
 	/* XXX In this case we do not reset the stack */


### PR DESCRIPTION
This patch removes CONFIG_THREAD_USERSPACE_LOCAL_DATA.
We will now use thread-local storage for these purposes.

Fixes: #29521

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>