### PR TITLE
samples: smp: pi: Fix path in build instructions

### DIFF
--- a/samples/smp/pi/README.rst
+++ b/samples/smp/pi/README.rst
@@ -26,7 +26,7 @@ required for all the calculation to be done. It can be built and executed
 on Synopsys ARC HSDK board as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/smp_pi
+   :zephyr-app: samples/smp/pi
    :host-os: unix
    :board: qemu_x86_64
    :goals: run


### PR DESCRIPTION
This fixes the documentation instructions for building the SMP Pi
sample program, which incorrectly listed an underscore instead of
a path separator slash.

Signed-off-by: Steve Winslow <steve@swinslow.net>