### PR TITLE
libc/minimal: provide aligned allocators

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -98,6 +98,17 @@ config MINIMAL_LIBC_MALLOC_ARENA_SIZE
 	  malloc() implementation. This size value must be compatible with
 	  a sys_mem_pool definition with nmax of 1 and minsz of 16.
 
+config MINIMAL_LIBC_POSIX_MEMALIGN
+	bool "Enable minimal libc trivial posix_memalign implementation"
+	help
+	  Enable the minimal libc's trivial implementation of posix_memalign.
+
+config MINIMAL_LIBC_ALIGNED_ALLOC
+	bool "Enable minimal libc trivial aligned_alloc implementation"
+	default y
+	help
+	  Enable the minimal libc's trivial implementation of aligned_alloc.
+
 config MINIMAL_LIBC_CALLOC
 	bool "Enable minimal libc trivial calloc implementation"
 	default y

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -23,6 +23,8 @@ void free(void *ptr);
 void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);
 void *reallocarray(void *ptr, size_t nmemb, size_t size);
+int posix_memalign(void **memptr, size_t alignment, size_t size);
+void *aligned_alloc(size_t alignment, size_t size);
 
 void *bsearch(const void *key, const void *array,
 	      size_t count, size_t size,

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -131,3 +131,80 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size)
 	return realloc(ptr, size);
 }
 #endif /* CONFIG_MINIMAL_LIBC_REALLOCARRAY */
+
+#if defined(CONFIG_MINIMAL_LIBC_POSIX_MEMALIGN) \
+	|| defined(CONFIG_MINIMAL_LIBC_ALIGNED_ALLOC)
+
+/* common backend for both posix_memalign(3) and aligned_alloc(3) */
+static int memalign_common(void **memptr, size_t alignment, size_t size)
+{
+	void *p;
+
+	/* alignment must be a power of two */
+	if (popcount(alignment) != 1) {
+		return EINVAL;
+	}
+
+	/* alignment must be multiple of sizeof(void *) */
+	if (alignment < sizeof(void *)) {
+		return EINVAL;
+	}
+
+	/* alignment must be multiple of sizeof(void *) */
+	if ((alignment % sizeof(void *)) != 0) {
+		return EINVAL;
+	}
+
+	/* shall not attempt to allocate any space, .. zero shall be
+	 * returned with a null pointer returned in *memptr
+	 */
+	if (size == 0) {
+		*memptr = NULL;
+		return 0;
+	}
+
+#if (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE > 0)
+	p = sys_heap_aligned_alloc(&z_malloc_heap, alignment, size);
+	if (p == NULL) {
+		return ENOMEM;
+	}
+#else
+	LOG_ERR("CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE is 0");
+	return ENOMEM;
+#endif
+
+	*memptr = p;
+	return 0;
+}
+#endif
+
+#ifdef CONFIG_MINIMAL_LIBC_POSIX_MEMALIGN
+int posix_memalign(void **memptr, size_t alignment, size_t size)
+{
+	return memalign_common(memptr, alignment, size);
+}
+#endif /* CONFIG_MINIMAL_LIBC_POSIX_MEMALIGN */
+
+#ifdef CONFIG_MINIMAL_LIBC_ALIGNED_ALLOC
+void *aligned_alloc(size_t alignment, size_t size)
+{
+	void *r = NULL;
+
+	/* check alignment is "supported by the implementation" */
+	if (memalign_common(&r, alignment, 0) != 0) {
+		return NULL;
+	}
+
+	/* size must be an integral multiple of alignment */
+	if ((size % alignment) != 0) {
+		return NULL;
+	}
+
+	/* likely ENOMEM */
+	if (posix_memalign(&r, alignment, size) != 0) {
+		return NULL;
+	}
+
+	return r;
+}
+#endif /* CONFIG_MINIMAL_LIBC_ALIGNED_ALLOC */

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,3 +1,9 @@
 tests:
   libraries.libc:
     tags: clib
+  libraries.libc.alloc:
+    tags: clib
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE=16384
+      - CONFIG_MINIMAL_LIBC_POSIX_MEMALIGN=y
+      - CONFIG_MINIMAL_LIBC_ALIGNED_ALLOC=y


### PR DESCRIPTION
This change adds support for standardized aligned allocation APIs via `posix_memalign(3)` and `aligned_alloc(3)` in the minimal libc.

Fixes #29519