### PR TITLE
[backport v1.14] push ssf to thread privileged stack to complete stack frame

### DIFF
--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -232,8 +232,9 @@ SECTION_FUNC(TEXT, z_arm_do_syscall)
     b dispatch_syscall
 
 valid_syscall:
+    mov ip, sp
     /* push args to complete stack frame */
-    push {r4,r5}
+    push {r4,r5,ip}
 
 dispatch_syscall:
     ldr ip, =_k_syscall_table
@@ -244,7 +245,7 @@ dispatch_syscall:
     blx ip
 
     /* restore LR */
-    ldr lr, [sp,#12]
+    ldr lr, [sp,#16]
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
     /* clear stack limit (stack protection not required in user mode) */
@@ -253,7 +254,7 @@ dispatch_syscall:
 #endif
 
     /* set stack back to unprivileged stack */
-    ldr ip, [sp,#8]
+    ldr ip, [sp,#12]
     msr PSP, ip
 
     push {r0, r1}

--- a/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
+++ b/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
@@ -16,6 +16,11 @@ __syscall int to_copy(char *dest);
 
 __syscall size_t string_nlen(char *src, size_t maxlen, int *err);
 
+__syscall unsigned int more_args(unsigned int arg1, unsigned int arg2,
+				 unsigned int arg3, unsigned int arg4,
+				 unsigned int arg5, unsigned int arg6,
+				 unsigned int arg7);
+
 #include <syscalls/test_syscalls.h>
 
 #endif /* _TEST_SYSCALLS_H_ */


### PR DESCRIPTION
1. push ssf to thread privileged stack to complete stack frame
2. add more than 6 arguments syscall test case

Fixes: #29386.