### PR TITLE
Bluetooth: host: Document and check for disallowed directed advertising

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -534,6 +534,8 @@ struct bt_le_adv_param {
 	 *
 	 * The advertising type will either be high duty cycle, or low duty
 	 * cycle if the BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY option is enabled.
+	 * When using @ref BT_LE_ADV_OPT_EXT_ADV then only low duty cycle is
+	 * allowed.
 	 *
 	 * In case of connectable high duty cycle if the connection could not
 	 * be established within the timeout the connected() callback will be

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7606,6 +7606,15 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 			return false;
 		}
 
+		if (param->peer &&
+		    (param->options & BT_LE_ADV_OPT_EXT_ADV) &&
+		    !(param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY)) {
+			/* High duty cycle directed connectable advertising
+			 * shall not be used with Extended Advertising.
+			 */
+			return false;
+		}
+
 		if (!(param->options & BT_LE_ADV_OPT_EXT_ADV) &&
 		    param->options & (BT_LE_ADV_OPT_EXT_ADV |
 				      BT_LE_ADV_OPT_NO_2M |


### PR DESCRIPTION
Document and validate advertising parameters for the disallowed
advertising mode high duty cycle directed connectable advertising
using extended advertising PDUs.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>