### PR TITLE
libc: minimal: Implement abort().

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_system_include_directories(include)
 
 zephyr_library()
 zephyr_library_sources(
+  source/stdlib/abort.c
   source/stdlib/atoi.c
   source/stdlib/strtol.c
   source/stdlib/strtoul.c

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -35,6 +35,7 @@ static inline void exit(int status)
 {
 	_exit(status);
 }
+void abort(void);
 
 int rand(void);
 

--- a/lib/libc/minimal/source/stdlib/abort.c
+++ b/lib/libc/minimal/source/stdlib/abort.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr.h>
+
+void abort(void)
+{
+	printk("abort()\n");
+	k_panic();
+}


### PR DESCRIPTION
abort() is an important runtime function, oftentimes used to signal
abnormal execution conditions in generic applications. Worse, they
may be used under such circumstances in e.g. compiler support
libraries, in which case lack of implementation of this function
will lead to link error.

Fixes: #29541

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>