### PR TITLE
drivers: sensor: lis2mdl: Add single mode operation

### DIFF
--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -18,6 +18,14 @@
 #include <logging/log.h>
 #include "lis2mdl.h"
 
+/* Based on the data sheet, the maximum turn-on time is ("9.4 ms + 1/ODR") when
+ * offset cancellation is on. But in the single mode the ODR is not dependent on
+ * the configured value in Reg A. It is dependent on the frequency of the I2C
+ * signal. The slowest value we could measure by I2C frequency of 100000HZ was
+ * 13 ms. So we chose 20 ms.
+ */
+#define SAMPLE_FETCH_TIMEOUT_MS 20
+
 struct lis2mdl_data lis2mdl_data;
 
 LOG_MODULE_REGISTER(LIS2MDL, CONFIG_SENSOR_LOG_LEVEL);
@@ -174,21 +182,83 @@ static int lis2mdl_attr_set(const struct device *dev,
 	return 0;
 }
 
-static int lis2mdl_sample_fetch_mag(const struct device *dev)
+static int get_single_mode_raw_data(const struct device *dev,
+				    int16_t *raw_mag)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
-	int16_t raw_mag[3];
+	int rc = 0;
 
-	/* fetch raw data sample */
-	if (lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag) < 0) {
-		LOG_ERR("Failed to read sample");
+	rc = lis2mdl_operating_mode_set(lis2mdl->ctx, LIS2MDL_SINGLE_TRIGGER);
+	if (rc) {
+		LOG_ERR("set single mode failed");
+		return rc;
+	}
+
+	if (k_sem_take(&lis2mdl->fetch_sem, K_MSEC(SAMPLE_FETCH_TIMEOUT_MS))) {
+		LOG_ERR("Magnetometer data not ready within %d ms",
+			SAMPLE_FETCH_TIMEOUT_MS);
 		return -EIO;
 	}
 
-	lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
-	lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
-	lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+	/* fetch raw data sample */
+	rc = lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag);
+	if (rc) {
+		LOG_ERR("Failed to read sample");
+		return rc;
+	}
+	return 0;
+}
 
+static int lis2mdl_sample_fetch_mag(const struct device *dev)
+{
+	struct lis2mdl_data *lis2mdl = dev->data;
+	const struct lis2mdl_config *const config = dev->config;
+	int16_t raw_mag[3];
+	int rc = 0;
+
+	if (config->single_mode) {
+		rc = get_single_mode_raw_data(dev, raw_mag);
+		if (rc) {
+			LOG_ERR("Failed to read raw data");
+			return rc;
+		}
+		lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
+		lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
+		lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+
+		if (config->cancel_offset) {
+			/* The second measurement is needed when offset
+			 * cancellation is enabled in the single mode. Then the
+			 * average of the first measurement done above and this
+			 * one would be the final value. This process is not
+			 * needed in continuous mode since it has beed taken
+			 * care by lis2mdl itself automatically. Please refer
+			 * to the application note for more details.
+			 */
+			rc = get_single_mode_raw_data(dev, raw_mag);
+			if (rc) {
+				LOG_ERR("Failed to read raw data");
+				return rc;
+			}
+			lis2mdl->mag[0] += sys_le16_to_cpu(raw_mag[0]);
+			lis2mdl->mag[1] += sys_le16_to_cpu(raw_mag[1]);
+			lis2mdl->mag[2] += sys_le16_to_cpu(raw_mag[2]);
+			lis2mdl->mag[0] /= 2;
+			lis2mdl->mag[1] /= 2;
+			lis2mdl->mag[2] /= 2;
+		}
+
+	} else {
+		/* fetch raw data sample */
+		rc = lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag);
+		if (rc) {
+			LOG_ERR("Failed to read sample");
+			return rc;
+		}
+		lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
+		lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
+		lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+	}
 	return 0;
 }
 
@@ -261,6 +331,9 @@ static int lis2mdl_init_interface(const struct device *dev)
 
 static const struct lis2mdl_config lis2mdl_dev_config = {
 	.master_dev_name = DT_INST_BUS_LABEL(0),
+	.single_mode = DT_INST_PROP(0, single_mode),
+	.cancel_offset = DT_INST_PROP(0, cancel_offset),
+
 #ifdef CONFIG_LIS2MDL_TRIGGER
 	.gpio_name = DT_INST_GPIO_LABEL(0, irq_gpios),
 	.gpio_pin = DT_INST_GPIO_PIN(0, irq_gpios),
@@ -293,7 +366,9 @@ static const struct lis2mdl_config lis2mdl_dev_config = {
 static int lis2mdl_init(const struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
+	const struct lis2mdl_config *const config = dev->config;
 	uint8_t wai;
+	int rc = 0;
 
 	lis2mdl->dev = dev;
 
@@ -338,11 +413,15 @@ static int lis2mdl_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/* Set / Reset sensor mode */
-	if (lis2mdl_set_rst_mode_set(lis2mdl->ctx,
-				     LIS2MDL_SENS_OFF_CANC_EVERY_ODR)) {
-		LOG_ERR("reset sensor mode failed");
-		return -EIO;
+	if (config->cancel_offset) {
+		/* Set offset cancellation, common for both single and
+		 * and continuous mode.
+		 */
+		if (lis2mdl_set_rst_mode_set(lis2mdl->ctx,
+					LIS2MDL_SENS_OFF_CANC_EVERY_ODR)) {
+			LOG_ERR("reset sensor mode failed");
+			return -EIO;
+		}
 	}
 
 	/* Enable temperature compensation */
@@ -351,10 +430,43 @@ static int lis2mdl_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/* Set device in continuous mode */
-	if (lis2mdl_operating_mode_set(lis2mdl->ctx, LIS2MDL_CONTINUOUS_MODE)) {
-		LOG_ERR("set continuos mode failed");
-		return -EIO;
+	if (config->cancel_offset && config->single_mode) {
+		/* Set OFF_CANC_ONE_SHOT bit. This setting is only needed in
+		 * the single-mode when offset cancellation is enabled.
+		 */
+		rc = lis2mdl_set_rst_sensor_single_set(lis2mdl->ctx,
+							PROPERTY_ENABLE);
+		if (rc) {
+			LOG_ERR("Set offset cancelaltion failed");
+			return rc;
+		}
+	}
+
+	if (config->single_mode) {
+		/* Set drdy on pin 7 */
+		rc = lis2mdl_drdy_on_pin_set(lis2mdl->ctx, 1);
+		if (rc) {
+			LOG_ERR("set drdy on pin failed!");
+			return rc;
+		}
+
+		/* Reboot sensor after setting the configuration registers */
+		rc = lis2mdl_boot_set(lis2mdl->ctx, 1);
+		if (rc) {
+			LOG_ERR("Reboot failed.");
+			return rc;
+		}
+
+		k_sem_init(&lis2mdl->fetch_sem, 0, 1);
+
+	} else {
+		/* Set device in continuous mode */
+		rc = lis2mdl_operating_mode_set(lis2mdl->ctx,
+						LIS2MDL_CONTINUOUS_MODE);
+		if (rc) {
+			LOG_ERR("set continuos mode failed");
+			return rc;
+		}
 	}
 
 #ifdef CONFIG_PM_DEVICE
@@ -373,13 +485,19 @@ static int lis2mdl_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
+		const struct lis2mdl_config *const config,
 		uint32_t new_state)
 {
 	int status = 0;
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
-		status = lis2mdl_operating_mode_set(lis2mdl->ctx,
-				LIS2MDL_CONTINUOUS_MODE);
+		if (config->single_mode) {
+			status = lis2mdl_operating_mode_set(lis2mdl->ctx,
+						LIS2MDL_SINGLE_TRIGGER);
+		} else {
+			status = lis2mdl_operating_mode_set(lis2mdl->ctx,
+						LIS2MDL_CONTINUOUS_MODE);
+		}
 		if (status) {
 			LOG_ERR("Power up failed");
 		}
@@ -405,6 +523,7 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 				void *context, device_pm_cb cb, void *arg)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
+	const struct lis2mdl_config *const config = dev->config;
 	uint32_t current_state = lis2mdl->power_state;
 	int status = 0;
 	uint32_t new_state;
@@ -413,7 +532,8 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 	case DEVICE_PM_SET_POWER_STATE:
 		new_state = *((const uint32_t *)context);
 		if (new_state != current_state) {
-			status = lis2mdl_set_power_state(lis2mdl, new_state);
+			status = lis2mdl_set_power_state(lis2mdl, config,
+							new_state);
 		}
 		break;
 	case DEVICE_PM_GET_POWER_STATE:

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -128,7 +128,7 @@ static int lis2mdl_channel_get(const struct device *dev,
 		lis2mdl_channel_get_temp(dev, val);
 		break;
 	default:
-		LOG_DBG("Channel not supported");
+		LOG_ERR("Channel not supported");
 		return -ENOTSUP;
 	}
 
@@ -147,7 +147,7 @@ static int lis2mdl_config(const struct device *dev, enum sensor_channel chan,
 	case SENSOR_ATTR_OFFSET:
 		return lis2mdl_set_hard_iron(dev, chan, val);
 	default:
-		LOG_DBG("Mag attribute not supported");
+		LOG_ERR("Mag attribute not supported");
 		return -ENOTSUP;
 	}
 
@@ -167,7 +167,7 @@ static int lis2mdl_attr_set(const struct device *dev,
 	case SENSOR_CHAN_MAGN_XYZ:
 		return lis2mdl_config(dev, chan, attr, val);
 	default:
-		LOG_DBG("attr_set() not supported on %d channel", chan);
+		LOG_ERR("attr_set() not supported on %d channel", chan);
 		return -ENOTSUP;
 	}
 
@@ -181,7 +181,7 @@ static int lis2mdl_sample_fetch_mag(const struct device *dev)
 
 	/* fetch raw data sample */
 	if (lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag) < 0) {
-		LOG_DBG("Failed to read sample");
+		LOG_ERR("Failed to read sample");
 		return -EIO;
 	}
 
@@ -200,7 +200,7 @@ static int lis2mdl_sample_fetch_temp(const struct device *dev)
 
 	/* fetch raw temperature sample */
 	if (lis2mdl_temperature_raw_get(lis2mdl->ctx, &raw_temp) < 0) {
-		LOG_DBG("Failed to read sample");
+		LOG_ERR("Failed to read sample");
 		return -EIO;
 	}
 
@@ -251,7 +251,7 @@ static int lis2mdl_init_interface(const struct device *dev)
 
 	lis2mdl->bus = device_get_binding(config->master_dev_name);
 	if (!lis2mdl->bus) {
-		LOG_DBG("Could not get pointer to %s device",
+		LOG_ERR("Could not get pointer to %s device",
 			    config->master_dev_name);
 		return -EINVAL;
 	}
@@ -307,13 +307,13 @@ static int lis2mdl_init(const struct device *dev)
 	}
 
 	if (wai != LIS2MDL_ID) {
-		LOG_DBG("Invalid chip ID: %02x\n", wai);
+		LOG_ERR("Invalid chip ID: %02x", wai);
 		return -EINVAL;
 	}
 
 	/* reset sensor configuration */
 	if (lis2mdl_reset_set(lis2mdl->ctx, PROPERTY_ENABLE) < 0) {
-		LOG_DBG("s/w reset failed\n");
+		LOG_ERR("s/w reset failed");
 		return -EIO;
 	}
 
@@ -328,32 +328,32 @@ static int lis2mdl_init(const struct device *dev)
 
 	/* enable BDU */
 	if (lis2mdl_block_data_update_set(lis2mdl->ctx, PROPERTY_ENABLE) < 0) {
-		LOG_DBG("setting bdu failed\n");
+		LOG_ERR("setting bdu failed");
 		return -EIO;
 	}
 
 	/* Set Output Data Rate */
 	if (lis2mdl_data_rate_set(lis2mdl->ctx, LIS2MDL_ODR_10Hz)) {
-		LOG_DBG("set odr failed\n");
+		LOG_ERR("set odr failed");
 		return -EIO;
 	}
 
 	/* Set / Reset sensor mode */
 	if (lis2mdl_set_rst_mode_set(lis2mdl->ctx,
 				     LIS2MDL_SENS_OFF_CANC_EVERY_ODR)) {
-		LOG_DBG("reset sensor mode failed\n");
+		LOG_ERR("reset sensor mode failed");
 		return -EIO;
 	}
 
 	/* Enable temperature compensation */
 	if (lis2mdl_offset_temp_comp_set(lis2mdl->ctx, PROPERTY_ENABLE)) {
-		LOG_DBG("enable temp compensation failed\n");
+		LOG_ERR("enable temp compensation failed");
 		return -EIO;
 	}
 
 	/* Set device in continuous mode */
 	if (lis2mdl_operating_mode_set(lis2mdl->ctx, LIS2MDL_CONTINUOUS_MODE)) {
-		LOG_DBG("set continuos mode failed\n");
+		LOG_ERR("set continuos mode failed");
 		return -EIO;
 	}
 
@@ -363,7 +363,7 @@ static int lis2mdl_init(const struct device *dev)
 
 #ifdef CONFIG_LIS2MDL_TRIGGER
 	if (lis2mdl_init_interrupt(dev) < 0) {
-		LOG_DBG("Failed to initialize interrupts");
+		LOG_ERR("Failed to initialize interrupts");
 		return -EIO;
 	}
 #endif

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -30,6 +30,9 @@ union axis1bit16_t {
 struct lis2mdl_config {
 	char *master_dev_name;
 	int (*bus_init)(const struct device *dev);
+	bool cancel_offset;
+	bool single_mode;
+
 #ifdef CONFIG_LIS2MDL_TRIGGER
 	char *gpio_name;
 	uint32_t gpio_pin;
@@ -60,6 +63,8 @@ struct lis2mdl_data {
 #ifdef CONFIG_PM_DEVICE
 	uint32_t power_state;
 #endif
+
+	struct k_sem fetch_sem;
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	stmdev_ctx_t ctx_i2c;

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -112,7 +112,7 @@ int lis2mdl_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt */
 	lis2mdl->gpio = device_get_binding(config->gpio_name);
 	if (lis2mdl->gpio == NULL) {
-		LOG_DBG("Cannot get pointer to %s device",
+		LOG_ERR("Cannot get pointer to %s device",
 			    config->gpio_name);
 		return -EINVAL;
 	}
@@ -136,7 +136,7 @@ int lis2mdl_init_interrupt(const struct device *dev)
 			   BIT(config->gpio_pin));
 
 	if (gpio_add_callback(lis2mdl->gpio, &lis2mdl->gpio_cb) < 0) {
-		LOG_DBG("Could not set gpio callback");
+		LOG_ERR("Could not set gpio callback");
 		return -EIO;
 	}
 

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -62,6 +62,10 @@ static void lis2mdl_handle_interrupt(const struct device *dev)
 		lis2mdl->handler_drdy(dev, &drdy_trigger);
 	}
 
+	if (config->single_mode) {
+		k_sem_give(&lis2mdl->fetch_sem);
+	}
+
 	gpio_pin_interrupt_configure(lis2mdl->gpio, config->gpio_pin,
 				     GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/dts/bindings/sensor/st,lis2mdl-common.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-common.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2018 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+properties:
+    irq-gpios:
+      type: phandle-array
+      required: false
+      description: IRQ pin
+
+        This pin defaults to active high when produced by the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.
+
+    single-mode:
+      type: boolean
+      required: false
+      description: |
+        Set to config the sensor in single measurement mode. Leave
+        unset to configure the sensor in continious measurement mode.
+
+    cancel-offset:
+      type: boolean
+      required: false
+      description: |
+        Set to enable the offset cancellation. Otherwise it would be
+        disabled as default.

--- a/dts/bindings/sensor/st,lis2mdl-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-i2c.yaml
@@ -6,14 +6,4 @@ description: |
 
 compatible: "st,lis2mdl"
 
-include: i2c-device.yaml
-
-properties:
-    irq-gpios:
-      type: phandle-array
-      required: false
-      description: IRQ pin
-
-        This pin defaults to active high when produced by the sensor.
-        The property value should ensure the flags properly describe
-        the signal that is presented to the driver.
+include: ["i2c-device.yaml", "st,lis2mdl-common.yaml"]

--- a/dts/bindings/sensor/st,lis2mdl-spi.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-spi.yaml
@@ -6,14 +6,4 @@ description: |
 
 compatible: "st,lis2mdl"
 
-include: spi-device.yaml
-
-properties:
-    irq-gpios:
-      type: phandle-array
-      required: false
-      description: IRQ pin
-
-        This pin defaults to active high when produced by the sensor.
-        The property value should ensure the flags properly describe
-        the signal that is presented to the driver.
+include: ["spi-device.yaml", "st,lis2mdl-common.yaml"]


### PR DESCRIPTION
Support single mode operation by enabling it and
making the driver to use the interrupt to findout
when the data is ready for fetch.
The sample fetch will be blocked for a specified
maximum time untill the interrupt happens.

Signed-off-by: Masoud Shiroei <masoud.shiroei@assaabloy.com>