### PR TITLE
Stm32 cube updates pr75

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -10,7 +10,6 @@ menuconfig ETH_STM32_HAL
 	bool "STM32 HAL Ethernet driver"
 	default y if $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_ETHERNET))
 	select USE_STM32_HAL_ETH
-	select USE_STM32_HAL_RCC_EX if SOC_SERIES_STM32H7X
 	select NOCACHE_MEMORY if SOC_SERIES_STM32H7X && CPU_CORTEX_M7
 	help
 	  Enable STM32 HAL based Ethernet driver. It is available for

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -376,17 +376,6 @@ config USE_STM32_HAL_RAMECC
 	help
 	  Enable STM32Cube RAM ECC monitoring (RAMECC) HAL module driver
 
-config USE_STM32_HAL_RCC
-	bool
-	help
-	  Enable STM32Cube Reset and Clock Control (RCC) HAL module driver
-
-config USE_STM32_HAL_RCC_EX
-	bool
-	help
-	  Enable STM32Cube Extended Reset and Clock Control (RCC) HAL module
-	  driver
-
 config USE_STM32_HAL_RNG
 	bool
 	help

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -12,7 +12,6 @@ config SOC_SERIES_STM32H7X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
-	select USE_STM32_HAL_RCC_EX if CPU_CORTEX_M4
 	select USE_STM32_HAL_CORTEX
 	help
 	  Enable support for STM32H7 MCU series

--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: 2b123553b84cfe9e5a28078355774b636c475da0
+      revision: a0267470e786019e378be18f5786e53ef307497f
       path: modules/hal/stm32
     - name: hal_ti
       revision: 405dfc8faba13e01c1cb9e29e70b31b50f71d117


### PR DESCRIPTION
 *  west.yml: update revision  modules/hal/stm32/hal_stm32
    Point to PR 75 of modules/hal/stm32/hal_stm32
    stm32cube: update stm32f0 to version V1.11.1
    stm32cube: update stm32f1 to version V1.8.2
    stm32cube: update stm32f2 to version V1.9.1
    stm32cube: update stm32f3 to version V1.11.1
    stm32cube: update stm32f4 to version V1.25.1
    stm32cube: update stm32f7 to version V1.16.0
    stm32cube: update stm32g4 to version V1.3.0
    stm32cube: update stm32h7 to version V1.8.0
    stm32cube: update stm32l0 to version V1.11.3
    stm32cube: update stm32l4 to version V1.16.0
    stm32cube: update stm32l5 to version V1.3.1
    stm32cube: update stm32wb to version V1.9.0

* Delete switches USE_STM32_HAL_RCC and USE_STM32_HAL_RCC_EX
With STM32Cube updates https://github.com/zephyrproject-rtos/hal_stm32/pull/75
'..._hal_rcc.c' and '..._hal_rcc_ex.c' are now systematically
compiled, due to more and more dependencies from HAL IP on rcc.
So USE_STM32_HAL_RCC and USE_STM32_HAL_RCC_EX becomes useless.