### PR TITLE
soc: arm: stm32l4: wakeup from stop clock selection based on sysclk

### DIFF
--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -16,6 +16,13 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
+/* select MSI as wake-up system clock if configured, HSI otherwise */
+#if defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_MSI)
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_MSI
+#else
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_HSI
+#endif
+
 /* Invoke Low Power/System Off specific Tasks */
 void pm_power_state_set(struct pm_state_info info)
 {
@@ -32,8 +39,8 @@ void pm_power_state_set(struct pm_state_info info)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* ensure HSI is the wake-up system clock */
-		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* ensure the proper wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP0 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
 		LL_LPM_EnableDeepSleep();
@@ -46,8 +53,8 @@ void pm_power_state_set(struct pm_state_info info)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* ensure HSI is the wake-up system clock */
-		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* ensure the proper wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP1 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
 		LL_LPM_EnableDeepSleep();
@@ -59,8 +66,8 @@ void pm_power_state_set(struct pm_state_info info)
 		/* Enable the Debug Module during STOP mode */
 		LL_DBGMCU_EnableDBGStopMode();
 #endif /* CONFIG_DEBUG */
-		/* ensure HSI is the wake-up system clock */
-		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* ensure the proper wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 #ifdef PWR_CR1_RRSTP
 		LL_PWR_DisableSRAM3Retention();
 #endif /* PWR_CR1_RRSTP */


### PR DESCRIPTION
When exiting Stop mode, if system clock is MSI , MSI oscillator is
selected as wakeup from stop clock; otherwise HSI16 oscillator is
selected.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>