### PR TITLE
drivers: modem: cmd_handler: rework reading from interface

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -46,7 +46,6 @@ static struct gsm_modem {
 	struct modem_context context;
 
 	struct modem_cmd_handler_data cmd_handler_data;
-	uint8_t cmd_read_buf[GSM_CMD_READ_BUF];
 	uint8_t cmd_match_buf[GSM_CMD_READ_BUF];
 	struct k_sem sem_response;
 
@@ -728,8 +727,6 @@ static int gsm_init(const struct device *device)
 
 	gsm->cmd_handler_data.cmds[CMD_RESP] = response_cmds;
 	gsm->cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
-	gsm->cmd_handler_data.read_buf = &gsm->cmd_read_buf[0];
-	gsm->cmd_handler_data.read_buf_len = sizeof(gsm->cmd_read_buf);
 	gsm->cmd_handler_data.match_buf = &gsm->cmd_match_buf[0];
 	gsm->cmd_handler_data.match_buf_len = sizeof(gsm->cmd_match_buf);
 	gsm->cmd_handler_data.buf_pool = &gsm_recv_pool;

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -80,9 +80,6 @@ struct modem_cmd_handler_data {
 	struct modem_cmd *cmds[CMD_MAX];
 	size_t cmds_len[CMD_MAX];
 
-	char *read_buf;
-	size_t read_buf_len;
-
 	char *match_buf;
 	size_t match_buf_len;
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -136,7 +136,6 @@ struct modem_data {
 
 	/* modem cmds */
 	struct modem_cmd_handler_data cmd_handler_data;
-	uint8_t cmd_read_buf[MDM_RECV_BUF_SIZE];
 	uint8_t cmd_match_buf[MDM_RECV_BUF_SIZE + 1];
 
 	/* socket data */
@@ -1741,8 +1740,6 @@ static int modem_init(const struct device *dev)
 	mdata.cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
 	mdata.cmd_handler_data.cmds[CMD_UNSOL] = unsol_cmds;
 	mdata.cmd_handler_data.cmds_len[CMD_UNSOL] = ARRAY_SIZE(unsol_cmds);
-	mdata.cmd_handler_data.read_buf = &mdata.cmd_read_buf[0];
-	mdata.cmd_handler_data.read_buf_len = sizeof(mdata.cmd_read_buf);
 	mdata.cmd_handler_data.match_buf = &mdata.cmd_match_buf[0];
 	mdata.cmd_handler_data.match_buf_len = sizeof(mdata.cmd_match_buf);
 	mdata.cmd_handler_data.buf_pool = &mdm_recv_pool;

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -878,8 +878,6 @@ static int esp_init(const struct device *dev)
 	data->cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
 	data->cmd_handler_data.cmds[CMD_UNSOL] = unsol_cmds;
 	data->cmd_handler_data.cmds_len[CMD_UNSOL] = ARRAY_SIZE(unsol_cmds);
-	data->cmd_handler_data.read_buf = &data->cmd_read_buf[0];
-	data->cmd_handler_data.read_buf_len = sizeof(data->cmd_read_buf);
 	data->cmd_handler_data.match_buf = &data->cmd_match_buf[0];
 	data->cmd_handler_data.match_buf_len = sizeof(data->cmd_match_buf);
 	data->cmd_handler_data.buf_pool = &mdm_recv_pool;

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -173,7 +173,6 @@ struct esp_data {
 
 	/* modem cmds */
 	struct modem_cmd_handler_data cmd_handler_data;
-	uint8_t cmd_read_buf[MDM_RECV_BUF_SIZE];
 	uint8_t cmd_match_buf[MDM_RECV_BUF_SIZE];
 
 	/* socket data */


### PR DESCRIPTION
So far a dedicated buffer was used for data read from modem
interface. New net_bufs were allocated later, which means that data was
lost when no more net_bufs were available.

Prevent data loss by allocating net_buf before attempting any read on
modem interface. Process incoming data in a loop as long as reading from
interface results in new data. Also remove dedicated buffer
(data->read_buf) and directly fill net_buf content instead. As a side
effect there are less memory copy operations and RAM usage is reduced.

Pre-allocated net_buf is now always appended to data->rx_buf. When there
was no (more) data read from interface to such net_buf, then this empty
net_buf will be on the end of data->rx_buf fragment list. Update
skipcrlf() and findcrlf() implementations to explicitly check for each
net_buf length, instead of blindly assuming them to have at least single
byte.

Tested with esp8266 with 1Mbps UART baudrate and HW flow control.