### PR TITLE
libc: disable CONFIG_ERRNO when using newlib or newlib-nano

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -197,9 +197,17 @@ config THREAD_USERSPACE_LOCAL_DATA
 	depends on USERSPACE
 	default y if ERRNO && !ERRNO_IN_TLS
 
+config LIBC_ERRNO
+	bool
+	help
+	  Use external libc errno, not the internal one. This makes sure that
+	  ERRNO is not set for libc configurations that provide their own
+	  implementation.
+
 config ERRNO
 	bool "Enable errno support"
 	default y
+	depends on !LIBC_ERRNO
 	help
 	  Enable per-thread errno in the kernel. Application and library code must
 	  include errno.h provided by the C library (libc) to use the errno

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -27,6 +27,7 @@ config MINIMAL_LIBC
 config NEWLIB_LIBC
 	bool "Newlib C library"
 	depends on !NATIVE_APPLICATION
+	select LIBC_ERRNO
 	help
 	  Build with newlib library. The newlib library is expected to be
 	  part of the SDK in this case.
@@ -46,6 +47,7 @@ if NEWLIB_LIBC
 config NEWLIB_LIBC_NANO
 	bool "Build with newlib-nano C library"
 	depends on HAS_NEWLIB_LIBC_NANO
+	select LIBC_ERRNO
 	default y
 	help
 	  Build with newlib-nano library, for small embedded apps.


### PR DESCRIPTION
Neither of these libraries can support the built-in Zephyr errno code,
so make sure it gets disabled when either are selected

Signed-off-by: Keith Packard <keithp@keithp.com>

I suspect that Zephyr should tie CONFIG_ERRNO and CONFIG_ERRNO_IN_TLS to only be used with the built-in minimal C library as both of these require Zephyr-specific support.