### PR TITLE
push ssf to thread privileged stack to complete stack frame

### DIFF
--- a/arch/arm/core/aarch32/userspace.S
+++ b/arch/arm/core/aarch32/userspace.S
@@ -374,6 +374,9 @@ SECTION_FUNC(TEXT, z_arm_do_syscall)
     mov r1, lr
     b dispatch_syscall
 valid_syscall:
+    /* push ssf to privileged stack */
+    mov r1, sp
+    push {r1}
     /* push args to complete stack frame */
     push {r4,r5}
 
@@ -396,8 +399,7 @@ dispatch_syscall:
      */
     mov ip, r0
     mov r0, sp
-    adds r0, #12
-    ldr r0, [r0]
+    ldr r0, [r0,#16]
     mov lr, r0
     /* Restore r0 */
     mov r0, ip
@@ -415,7 +417,8 @@ dispatch_syscall:
 
 valid_syscall:
     /* push args to complete stack frame */
-    push {r4,r5}
+    mov ip, sp
+    push {r4,r5,ip}
 
 dispatch_syscall:
     ldr ip, =_k_syscall_table
@@ -426,7 +429,7 @@ dispatch_syscall:
     blx ip
 
     /* restore LR */
-    ldr lr, [sp,#12]
+    ldr lr, [sp,#16]
 #endif
 
 
@@ -467,14 +470,14 @@ dispatch_syscall:
     /* set stack back to unprivileged stack */
     mov ip, r0
     mov r0, sp
-    ldr r0, [r0,#8]
+    ldr r0, [r0,#12]
     msr PSP, r0
     /* Restore r0 */
     mov r0, ip
 
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     /* set stack back to unprivileged stack */
-    ldr ip, [sp,#8]
+    ldr ip, [sp,#12]
     msr PSP, ip
 #endif
 

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -150,6 +150,30 @@ static inline uint64_t z_vrfy_syscall_arg64_big(uint32_t arg1, uint32_t arg2,
 }
 #include <syscalls/syscall_arg64_big_mrsh.c>
 
+uint32_t z_impl_more_args(uint32_t arg1, uint32_t arg2, uint32_t arg3,
+			  uint32_t arg4, uint32_t arg5, uint32_t arg6,
+			  uint32_t arg7)
+{
+	uint32_t ret = 0x4ef464cc;
+	uint32_t args[] = { arg1, arg2, arg3, arg4, arg5, arg6, arg7 };
+
+	for (int i = 0; i < ARRAY_SIZE(args); i++) {
+		ret += args[i];
+		ret = (ret << 11) | (ret >> 5);
+	}
+
+	return ret;
+}
+
+static inline uint32_t z_vrfy_more_args(uint32_t arg1, uint32_t arg2,
+					uint32_t arg3, uint32_t arg4,
+					uint32_t arg5, uint32_t arg6,
+					uint32_t arg7)
+{
+	return z_impl_more_args(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+}
+#include <syscalls/more_args_mrsh.c>
+
 /**
  * @brief Test to demonstrate usage of z_user_string_nlen()
  *
@@ -271,6 +295,13 @@ void test_arg64(void)
 
 	zassert_equal(syscall_arg64_big(1, 2, 3, 4, 5, 6),
 		      z_impl_syscall_arg64_big(1, 2, 3, 4, 5, 6),
+		      "syscall didn't match impl");
+}
+
+void test_more_args(void)
+{
+	zassert_equal(more_args(1, 2, 3, 4, 5, 6, 7),
+		      z_impl_more_args(1, 2, 3, 4, 5, 6, 7),
 		      "syscall didn't match impl");
 }
 
@@ -398,6 +429,7 @@ void test_main(void)
 			 ztest_user_unit_test(test_user_string_copy),
 			 ztest_user_unit_test(test_user_string_alloc_copy),
 			 ztest_user_unit_test(test_arg64),
+			 ztest_user_unit_test(test_more_args),
 			 ztest_unit_test(test_syscall_torture),
 			 ztest_unit_test(test_syscall_context)
 			 );

--- a/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
+++ b/tests/kernel/mem_protect/syscalls/src/test_syscalls.h
@@ -23,6 +23,10 @@ __syscall uint64_t syscall_arg64_big(uint32_t arg1, uint32_t arg2, uint64_t arg3
 
 __syscall bool syscall_context(void);
 
+__syscall uint32_t more_args(uint32_t arg1, uint32_t arg2, uint32_t arg3,
+			     uint32_t arg4, uint32_t arg5, uint32_t arg6,
+			     uint32_t arg7);
+
 #include <syscalls/test_syscalls.h>
 
 #endif /* _TEST_SYSCALLS_H_ */


### PR DESCRIPTION
1. push ssf to thread privileged stack to complete stack frame
2. add more than 6 arguments syscall test case. The handle for more
than 6 arguments case is slightly different between master branch and
v1.14 branch, no mpu fault happen on master branch, but I still put the
test case here.
  
Fixes: #29386.