### PR TITLE
RISC-V: Round up pre-populated stack frame to arch stack alignment

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -23,7 +23,9 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif
 
 	/* Initial stack frame for thread */
-	stack_init = Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr);
+	stack_init = (struct __esf *)Z_STACK_PTR_ALIGN(
+				Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr)
+				);
 
 	/* Setup the initial stack frame */
 	stack_init->a0 = (ulong_t)entry;


### PR DESCRIPTION
The stack frame size, used for context switch, is rounded up to 16-bytes
alignment. Therefore, we need round down the pointer of top of the
pre-populated stack frame so that the preserved stack frame size is also
rounded up to 16-bytes alignment.

Fixes #29535

Signed-off-by: Shih-Wei Teng <swteng@andestech.com>