### PR TITLE
tests: improve test case descriptions of irq offload function

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -35,10 +35,93 @@ static void offload_function(const void *param)
  *
  * @ingroup kernel_interrupt_tests
  *
- * @details Check whether offloaded running function is in interrupt
- * context, on the IRQ stack or not.
+ * @details
+ * Test Objective:
+ * - To verify the kernel architecture layer shall provide a means to raise an
+ *   interrupt from thread code that will run a user-provided C function under
+ *   the interrupt context.
+ * - We check whether offloaded running function is in interrupt context, on
+ *   the IRQ stack or not.
+ *
+ * Testing techniques:
+ * - Interface testing, function and black box testing,
+ *   dynamic analysis and testing
+ *
+ * Prerequisite Conditions:
+ * - CONFIG_IRQ_OFFLOAD=y
+ *
+ * Input Specifications:
+ * - A pointer of C offload function
+ * - A pointer of passing parameter
+ *
+ * Test Procedure:
+ * -# Call irq_offload with parameter offload_function and SENTINEL_VALUE.
+ * -# In the C offload_function handler, call k_is_in_isr() to check if it is
+ *  in interrupt context currently.
+ * -# Store the passing argument into global variable sentinel.
+ * -# In main thread, check if the global variable sentinel equals to
+ *  SENTINEL_VALUE.
+ *
+ * Expected Test Result:
+ * - The running function is running on interrupt context.
+ *
+ * Pass/Fail Criteria:
+ * - Successful if check points in test procedure are all passed, otherwise
+ *   failure.
+ *
+ * Assumptions and Constraints:
+ * - N/A.
  */
 void test_irq_offload(void)
+{
+	/**TESTPOINT: Offload to IRQ context*/
+	irq_offload(offload_function, (const void *)SENTINEL_VALUE);
+
+	zassert_equal(sentinel, SENTINEL_VALUE,
+		      "irq_offload() didn't work properly");
+}
+
+/**
+ * @brief Verify nested irq lock
+ *
+ * @ingroup kernel_interrupt_tests
+ *
+ * @details
+ * Test Objective:
+ * - The kernel architecture layer shall provide a mechanism to restore the
+ *   local interrupt state saved prior to a mask operation.
+ * - We simply check lock function twice to make it is nested, then check if
+ *   unlock function works properly.
+ *
+ * Testing techniques:
+ * - Interface testing, function and black box testing,
+ *   dynamic analysis and testing
+ *
+ * Prerequisite Conditions:
+ * - N/A
+ *
+ * Input Specifications:
+ * - N/A
+ *
+ * Test Procedure:
+ * -# In main thread, call arch_irq_lock() and store it's return value in key1.
+ * -# Call arch_irq_unlocked(key1), and check if it returns true.
+ * -# call arch_irq_lock() and store it's return value in key2.
+ * -# Call arch_irq_unlocked(key2), and check if it returns false.
+ * -# Call arch_irq_unlocked(key2).
+ * -# Call arch_irq_unlocked(key1).
+ *
+ * Expected Test Result:
+ * - The nested lock and unlock works well as expected.
+ *
+ * Pass/Fail Criteria:
+ * - Successful if check points in test procedure are all passed, otherwise
+ *   failure.
+ *
+ * Assumptions and Constraints:
+ * - N/A.
+ */
+void test_nested_locking(void)
 {
 	/* Simple validation of nested locking. */
 	unsigned int key1, key2;
@@ -53,10 +136,4 @@ void test_irq_offload(void)
 		      key2);
 	arch_irq_unlock(key2);
 	arch_irq_unlock(key1);
-
-	/**TESTPOINT: Offload to IRQ context*/
-	irq_offload(offload_function, (const void *)SENTINEL_VALUE);
-
-	zassert_equal(sentinel, SENTINEL_VALUE,
-		      "irq_offload() didn't work properly");
 }

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -42,6 +42,7 @@ extern void test_multilib(void);
 extern void test_thread_context(void);
 extern void test_bootdelay(void);
 extern void test_irq_offload(void);
+extern void test_nested_locking(void);
 
 /**
  * @defgroup kernel_common_tests Common Tests
@@ -109,6 +110,7 @@ void test_main(void)
 {
 	ztest_test_suite(common,
 			 ztest_unit_test(test_bootdelay),
+			 ztest_unit_test(test_nested_locking),
 			 ztest_unit_test(test_irq_offload),
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),


### PR DESCRIPTION
To separate test case for irq_offload() and arch_irq_lock() for purpose of making these two test case more clear, then add test case descriptions for them. 
And add doxygen contain description, test step and pass criteria, etc.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>