### PR TITLE
Add USB extension descriptor to web USB sample.

### DIFF
--- a/include/usb/bos.h
+++ b/include/usb/bos.h
@@ -16,6 +16,7 @@
 /* BOS descriptor type */
 #define DESCRIPTOR_TYPE_BOS		0x0F
 
+#define USB_BOS_CAPABILITY_EXTENSION	0x02
 #define USB_BOS_CAPABILITY_PLATFORM	0x05
 
 /* BOS Capability Descriptor */
@@ -48,6 +49,13 @@ struct usb_bos_capability_msos {
 	uint16_t wMSOSDescriptorSetTotalLength;
 	uint8_t bMS_VendorCode;
 	uint8_t bAltEnumCode;
+} __packed;
+
+struct usb_bos_capability_lpm {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bDevCapabilityType;
+	uint32_t bmAttributes;
 } __packed;
 
 size_t usb_bos_get_length(void);

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -287,6 +287,9 @@ void main(void)
 
 	LOG_DBG("");
 
+	usb_bos_register_cap((void *)&bos_cap_webusb);
+	usb_bos_register_cap((void *)&bos_cap_msosv2);
+
 	/* Set the custom and vendor request handlers */
 	webusb_register_request_handlers(&req_handlers);
 
@@ -295,7 +298,4 @@ void main(void)
 		LOG_ERR("Failed to enable USB");
 		return;
 	}
-
-	usb_bos_register_cap((void *)&bos_cap_webusb);
-	usb_bos_register_cap((void *)&bos_cap_msosv2);
 }

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -120,6 +120,17 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_msosv2_desc {
 	},
 };
 
+USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_capability_lpm bos_cap_lpm = {
+	.bLength = sizeof(struct usb_bos_capability_lpm),
+	.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+	.bDevCapabilityType = USB_BOS_CAPABILITY_EXTENSION,
+	/**
+	 * BIT(1) - LPM support
+	 * BIT(2) - BESL support
+	 */
+	.bmAttributes = BIT(1) | BIT(2),
+};
+
 /* WebUSB Device Requests */
 static const uint8_t webusb_allowed_origins[] = {
 	/* Allowed Origins Header:
@@ -289,6 +300,7 @@ void main(void)
 
 	usb_bos_register_cap((void *)&bos_cap_webusb);
 	usb_bos_register_cap((void *)&bos_cap_msosv2);
+	usb_bos_register_cap((void *)&bos_cap_lpm);
 
 	/* Set the custom and vendor request handlers */
 	webusb_register_request_handlers(&req_handlers);


### PR DESCRIPTION
WebUSB sample is using BOS descriptor. Because of that
the bcdUSB field of device descriptor is set to 0x0210.
This requires for the BOS descriptor to have LPM support.
LPM support use additional descriptor that the HOST can
read by requesting BOS desc. The descriptor is called
Extension descriptor and is specified in `USB Link Power
Management ECN`
document considered a part of USB 2.0 spec.

This patch adds missing part of the BOS descriptor and
fixes issue with webUSB sample not passing i'LPM L1 Suspend
Resume Test' from USB3CV test tool.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>

Fixes: #29491