### PR TITLE
cmake: ensure shields can be placed in other BOARD_ROOTs

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -20,7 +20,7 @@ endmenu
 # precedence over SoC defaults, so include them in that order.
 #
 # $ARCH and $BOARD_DIR will be glob patterns when building documentation.
-source "boards/shields/*/Kconfig.defconfig"
+source "$(KCONFIG_BINARY_DIR)/Kconfig.shield.defconfig"
 source "$(BOARD_DIR)/Kconfig.defconfig"
 source "$(KCONFIG_BINARY_DIR)/Kconfig.soc.defconfig"
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -25,7 +25,7 @@ endchoice
 
 # Parse shields references
 # Don't do it as a menuconfig, as shield selection is a CMake feature.
-rsource "shields/*/Kconfig.shield"
+source "$(KCONFIG_BINARY_DIR)/Kconfig.shield"
 
 menu "Board Options"
 config QEMU_ICOUNT

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -21,6 +21,18 @@ foreach(root ${SOC_ROOT})
   set(OPERATION APPEND)
 endforeach()
 
+# Support multiple shields in BOARD_ROOT
+set(OPERATION WRITE)
+foreach(root ${BOARD_ROOT})
+  file(${OPERATION} ${KCONFIG_BINARY_DIR}/Kconfig.shield.defconfig
+       "osource \"${root}/boards/shields/*/Kconfig.defconfig\"\n"
+  )
+  file(${OPERATION} ${KCONFIG_BINARY_DIR}/Kconfig.shield
+       "osource \"${root}/boards/shields/*/Kconfig.shield\"\n"
+  )
+  set(OPERATION APPEND)
+endforeach()
+
 if(KCONFIG_ROOT)
   zephyr_file(APPLICATION_ROOT KCONFIG_ROOT)
   # KCONFIG_ROOT has either been specified as a CMake variable or is

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -265,6 +265,8 @@ class KconfigCheck(ComplianceTest):
         soc_defconfig_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc.defconfig")
         soc_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc")
         soc_arch_file = os.path.join(tempfile.gettempdir(), "Kconfig.soc.arch")
+        shield_defconfig_file = os.path.join(tempfile.gettempdir(), "Kconfig.shield.defconfig")
+        shield_file = os.path.join(tempfile.gettempdir(), "Kconfig.shield")
         try:
             with open(soc_defconfig_file, 'w', encoding="utf-8") as fp:
                 fp.write(f'osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.defconfig"\n')
@@ -275,6 +277,12 @@ class KconfigCheck(ComplianceTest):
             with open(soc_arch_file, 'w', encoding="utf-8") as fp:
                 fp.write(f'osource "{ZEPHYR_BASE}/soc/$(ARCH)/Kconfig"\n\
 osource "{ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig"\n')
+
+            with open(shield_defconfig_file, 'w', encoding="utf-8") as fp:
+                fp.write(f'osource "{ZEPHYR_BASE}/boards/shields/*/Kconfig.defconfig"\n')
+
+            with open(shield_file, 'w', encoding="utf-8") as fp:
+                fp.write(f'osource "{ZEPHYR_BASE}/boards/shields/*/Kconfig.shield"\n')
         except IOError as ex:
             self.error(ex.output)
 


### PR DESCRIPTION
Fixes: #28462

This commit allows shields to be defined in other BOARD_ROOTs, either
using `-DBOARD_ROOT=<path>` or a Zephyr moduled defined BOARD_ROOT.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>