### PR TITLE
net: lwm2m: Fix PULL FW update in case of URI parse errors

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -421,6 +421,7 @@ static void firmware_transfer(struct k_work *work)
 	ret = lwm2m_parse_peerinfo(server_addr, &firmware_ctx.remote_addr,
 				   &firmware_ctx.use_dtls);
 	if (ret < 0) {
+		LOG_ERR("Failed to parse server URI.");
 		goto error;
 	}
 
@@ -464,6 +465,7 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 	}
 
 	(void)memset(&firmware_ctx, 0, sizeof(struct lwm2m_ctx));
+	firmware_ctx.sock_fd = -1;
 	firmware_retry = 0;
 	k_work_init(&firmware_work, firmware_transfer);
 	lwm2m_firmware_set_update_state(STATE_DOWNLOADING);


### PR DESCRIPTION
The memset on firmware_ctx during PULL FW update initialization will
set the socket descriptor to a valid value of 0. This leads to an error
if parsing of the URI provided by the server fails, and the firware_ctx
is closed - the socket with a descriptor 0 will be accidently closed.
Fix this by invalidating the socket FD after the memset on
initialization.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>