### PR TITLE
sys: util: Add clamp macro 

### DIFF
--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -195,7 +195,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	uint32_t unannounced = counter_sub(counter(), last_count);
 

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -574,7 +574,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 		/* 2:1 low:high ratio */
 		baud_high = baud;
 		baud_high /= 3U;
-		baud_high = MAX(MIN(baud_high, 255U), 1U);
+		baud_high = CLAMP(baud_high, 1U, 255U);
 		baud_low = baud - baud_high;
 		if (baud_low < 1U && baud_high > 1U) {
 			--baud_high;
@@ -605,7 +605,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 		/* 2:1 low:high ratio */
 		baud_high = baud;
 		baud_high /= 3U;
-		baud_high = MAX(MIN(baud_high, 255U), 1U);
+		baud_high = CLAMP(baud_high, 1U, 255U);
 		baud_low = baud - baud_high;
 		if (baud_low < 1U && baud_high > 1U) {
 			--baud_high;

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1654,7 +1654,7 @@ static int offload_connect(struct net_context *context,
 	 * AT@SOCKCONN timeout param has minimum value of 30 seconds and
 	 * maximum value of 360 seconds, otherwise an error is generated
 	 */
-	timeout_sec = MIN(360, MAX(timeout_sec, 30));
+	timeout_sec = CLAMP(timeout_sec, 30, 360);
 
 	snprintk(buf, sizeof(buf), "AT@SOCKCONN=%d,\"%s\",%d,%d",
 		 sock->socket_id, wncm14a2a_sprint_ip_addr(addr),

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -94,7 +94,7 @@ static int spi_sam_configure(const struct device *dev,
 
 	/* Use the requested or next highest possible frequency */
 	div = SOC_ATMEL_SAM_MCK_FREQ_HZ / config->frequency;
-	div = MAX(1, MIN(UINT8_MAX, div));
+	div = CLAMP(div, 1, UINT8_MAX);
 	spi_csr |= SPI_CSR_SCBR(div);
 
 	regs->SPI_CR = SPI_CR_SPIDIS; /* Disable SPI */

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -119,7 +119,7 @@ static int spi_sam0_configure(const struct device *dev,
 
 	/* Use the requested or next highest possible frequency */
 	div = (SOC_ATMEL_SAM0_GCLK0_FREQ_HZ / config->frequency) / 2U - 1;
-	div = MAX(0, MIN(UINT8_MAX, div));
+	div = CLAMP(div, 0, UINT8_MAX);
 
 	/* Update the configuration only if it has changed */
 	if (regs->CTRLA.reg != ctrla.reg || regs->CTRLB.reg != ctrlb.reg ||

--- a/drivers/timer/cavs_timer.c
+++ b/drivers/timer/cavs_timer.c
@@ -124,7 +124,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 
 #ifdef CONFIG_TICKLESS_KERNEL
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t curr = count();

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -208,7 +208,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 #ifdef CONFIG_TICKLESS_KERNEL
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t) MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -183,7 +183,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	uint32_t delay;
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -165,7 +165,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = ticks == K_TICKS_FOREVER ? max_ticks : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)max_ticks), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)max_ticks);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t now = MAIN_COUNTER_REG, cyc, adj;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -229,7 +229,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	uint32_t unannounced = counter_sub(counter(), last_count);
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -106,7 +106,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = mtime();

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -259,7 +259,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 #ifdef CONFIG_TICKLESS_KERNEL
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t) MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t) MAX_TICKS);
 
 	/* Compute number of RTC cycles until the next timeout. */
 	uint32_t count = rtc_count();

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -210,7 +210,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	 * treated identically: it simply indicates the kernel would like the
 	 * next tick announcement as soon as possible.
 	 */
-	ticks = MAX(MIN(ticks - 1, (int32_t)LPTIM_TIMEBASE), 1);
+	ticks = CLAMP(ticks - 1, 1, (int32_t)LPTIM_TIMEBASE);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -73,7 +73,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
-	ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t curr = ccount(), cyc, adj;

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -179,6 +179,16 @@ extern "C" {
 #endif
 
 /**
+ * @def CLAMP
+ * @brief Clamp a value to a given range.
+ * @note Arguments are evaluated multiple times.
+ */
+#ifndef CLAMP
+/* Use Z_CLAMP for a GCC-only, single evaluation version */
+#define CLAMP(val, low, high) (((val) <= (low)) ? (low) : MIN(val, high))
+#endif
+
+/**
  * @brief Is @p x a power of two?
  * @param x value to check
  * @return true if @p x is a power of two, false otherwise

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -474,6 +474,21 @@ do {                                                                    \
 		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
 	})
 
+/** @brief Return a value clamped to a given range.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * macro limitations.
+ */
+#define Z_CLAMP(val, low, high) ({                                             \
+		/* random suffix to avoid naming conflict */                   \
+		__typeof__(val) _value_val_ = (val);                           \
+		__typeof__(low) _value_low_ = (low);                           \
+		__typeof__(high) _value_high_ = (high);                        \
+		(_value_val_ < _value_low_)  ? _value_low_ :                   \
+		(_value_val_ > _value_high_) ? _value_high_ :                  \
+					       _value_val_;                    \
+	})
+
 /**
  * @brief Calculate power of two ceiling for some nonzero value
  *

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -74,7 +74,7 @@ static int32_t next_timeout(void)
 	struct _timeout *to = first();
 	int32_t ticks_elapsed = elapsed();
 	int32_t ret = to == NULL ? MAX_WAIT
-		: MIN(MAX_WAIT, MAX(0, to->dticks - ticks_elapsed));
+		: CLAMP(to->dticks - ticks_elapsed, 0, MAX_WAIT);
 
 #ifdef CONFIG_TIMESLICING
 	if (_current_cpu->slice_ticks && _current_cpu->slice_ticks < ret) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3235,9 +3235,9 @@ static inline void dle_max_time_get(const struct ll_conn *conn,
 	    (!feature_coded_phy && !feature_phy_2m)) {
 		rx_time = PKT_US(LL_LENGTH_OCTETS_RX_MAX, PHY_1M);
 #if defined(CONFIG_BT_CTLR_PHY)
-		tx_time = MAX(MIN(PKT_US(LL_LENGTH_OCTETS_RX_MAX, PHY_1M),
-				  conn->default_tx_time),
-			      PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M));
+		tx_time = CLAMP(conn->default_tx_time,
+				PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M),
+				PKT_US(LL_LENGTH_OCTETS_RX_MAX, PHY_1M));
 #else /* !CONFIG_BT_CTLR_PHY */
 		tx_time = PKT_US(conn->default_tx_octets, PHY_1M);
 #endif /* !CONFIG_BT_CTLR_PHY */

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -203,10 +203,10 @@ static int inc_func(void)
 	return a++;
 }
 
-/* Test checks if @ref Z_MAX and @ref Z_MIN return correct result and perform
- * single evaluation of input arguments.
+/* Test checks if @ref Z_MAX, @ref Z_MIN and @ref Z_CLAMP return correct result
+ * and perform single evaluation of input arguments.
  */
-static void test_z_max_z_min(void)
+static void test_z_max_z_min_z_clamp(void)
 {
 	zassert_equal(Z_MAX(inc_func(), 0), 1, "Unexpected macro result");
 	/* Z_MAX should have call inc_func only once */
@@ -215,6 +215,31 @@ static void test_z_max_z_min(void)
 	zassert_equal(Z_MIN(inc_func(), 2), 2, "Unexpected macro result");
 	/* Z_MIN should have call inc_func only once */
 	zassert_equal(inc_func(), 4, "Unexpected return value");
+
+	zassert_equal(Z_CLAMP(inc_func(), 1, 3), 3, "Unexpected macro result");
+	/* Z_CLAMP should have call inc_func only once */
+	zassert_equal(inc_func(), 6, "Unexpected return value");
+
+	zassert_equal(Z_CLAMP(inc_func(), 10, 15), 10,
+		      "Unexpected macro result");
+	/* Z_CLAMP should have call inc_func only once */
+	zassert_equal(inc_func(), 8, "Unexpected return value");
+}
+
+static void test_CLAMP(void)
+{
+	zassert_equal(CLAMP(5, 3, 7), 5, "Unexpected clamp result");
+	zassert_equal(CLAMP(3, 3, 7), 3, "Unexpected clamp result");
+	zassert_equal(CLAMP(7, 3, 7), 7, "Unexpected clamp result");
+	zassert_equal(CLAMP(1, 3, 7), 3, "Unexpected clamp result");
+	zassert_equal(CLAMP(8, 3, 7), 7, "Unexpected clamp result");
+
+	zassert_equal(CLAMP(-5, -7, -3), -5, "Unexpected clamp result");
+	zassert_equal(CLAMP(-9, -7, -3), -7, "Unexpected clamp result");
+	zassert_equal(CLAMP(1, -7, -3), -3, "Unexpected clamp result");
+
+	zassert_equal(CLAMP(0xffffffffaULL, 0xffffffff0ULL, 0xfffffffffULL),
+		      0xffffffffaULL, "Unexpected clamp result");
 }
 
 static void test_FOR_EACH(void)
@@ -433,7 +458,8 @@ void test_cc(void)
 			 ztest_unit_test(test_IF_ENABLED),
 			 ztest_unit_test(test_UTIL_LISTIFY),
 			 ztest_unit_test(test_MACRO_MAP_CAT),
-			 ztest_unit_test(test_z_max_z_min),
+			 ztest_unit_test(test_z_max_z_min_z_clamp),
+			 ztest_unit_test(test_CLAMP),
 			 ztest_unit_test(test_FOR_EACH),
 			 ztest_unit_test(test_FOR_EACH_NONEMPTY_TERM),
 			 ztest_unit_test(test_FOR_EACH_FIXED_ARG),


### PR DESCRIPTION
Adds CLAMP macro to complement the current min/max macros, as well as a
gcc specific Z_CLAMP macro for single-evaluation expansion.

CLAMP is a combination of MIN and MAX that eliminates the bug-prone
usage of MIN(MAX(value, FLOOR), CEIL) found throughout the codebase in
every possible combination. This definition of CLAMP matches the Linux
kernel definition, but strips the internal typecast, like the MIN/MAX
macros do.

Replaces all existing variants of value clamping with the MIN and MAX
macros with the CLAMP macro.