### PR TITLE
cmake: dts: getting realpath for system includes for dts.

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -95,7 +95,7 @@ if(SUPPORTS_DTS)
         dts/${ARCH}
         dts
         )
-      set(full_path ${dts_root}/${dts_root_path})
+      get_filename_component(full_path ${dts_root}/${dts_root_path} REALPATH)
       if(EXISTS ${full_path})
         list(APPEND
           DTS_ROOT_SYSTEM_INCLUDE_DIRS


### PR DESCRIPTION
Fixes: #28893

Now using get_filename_component(REALPATH) to ensure full path with
symlinks and `..` resolved.

Having `..` in path causes the gcc generated dependency file to contain
`\` in path on windows. This confuses ninja.
The result is that ninja consider the file missing, and thus invokes a
CMake run to create the file, resulting in endless loop.

By ensuring that full path (containing `/` which is already ensured)
when calling gcc, then all paths will be posix style, making ninja
happy.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>