### PR TITLE
include: net: fix k_timeout_t translation in net_offload

### DIFF
--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -29,6 +29,25 @@ extern "C" {
 
 #if defined(CONFIG_NET_OFFLOAD)
 
+#ifndef CONFIG_LEGACY_TIMEOUT_API
+
+/** @cond INTERNAL_HIDDEN */
+
+static inline int32_t timeout_to_int32(k_timeout_t timeout)
+{
+	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		return 0;
+	} else if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		return -1;
+	} else {
+		return k_ticks_to_ms_floor32(timeout.ticks);
+	}
+}
+
+/** @endcond */
+
+#endif /* CONFIG_LEGACY_TIMEOUT_API */
+
 /** For return parameters and return values of the elements in this
  * struct, see similarly named functions in net_context.h
  */
@@ -231,7 +250,7 @@ static inline int net_offload_connect(struct net_if *iface,
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 		Z_TIMEOUT_MS(timeout),
 #else
-		k_ticks_to_ms_floor64(timeout.ticks),
+		timeout_to_int32(timeout),
 #endif
 		user_data);
 }
@@ -278,7 +297,7 @@ static inline int net_offload_accept(struct net_if *iface,
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 		Z_TIMEOUT_MS(timeout),
 #else
-		k_ticks_to_ms_floor64(timeout.ticks),
+		timeout_to_int32(timeout),
 #endif
 		user_data);
 }
@@ -324,7 +343,7 @@ static inline int net_offload_send(struct net_if *iface,
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 		Z_TIMEOUT_MS(timeout),
 #else
-		k_ticks_to_ms_floor64(timeout.ticks),
+		timeout_to_int32(timeout),
 #endif
 		user_data);
 }
@@ -374,7 +393,7 @@ static inline int net_offload_sendto(struct net_if *iface,
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 		Z_TIMEOUT_MS(timeout),
 #else
-		k_ticks_to_ms_floor64(timeout.ticks),
+		timeout_to_int32(timeout),
 #endif
 		user_data);
 }
@@ -427,7 +446,7 @@ static inline int net_offload_recv(struct net_if *iface,
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 		Z_TIMEOUT_MS(timeout),
 #else
-		k_ticks_to_ms_floor64(timeout.ticks),
+		timeout_to_int32(timeout),
 #endif
 		user_data);
 }


### PR DESCRIPTION
Previously blocking calls would be translated to
non-blocking calls.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>

related: https://github.com/zephyrproject-rtos/zephyr/pull/29321