### PR TITLE
Add the SPI support for STM32H7 Series

### DIFF
--- a/boards/arm/nucleo_h743zi/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_h743zi/arduino_r3_connector.dtsi
@@ -37,3 +37,4 @@
 };
 
 arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_h743zi/doc/index.rst
+++ b/boards/arm/nucleo_h743zi/doc/index.rst
@@ -117,6 +117,8 @@ features:
 +-----------+------------+-------------------------------------+
 | ETHERNET  | on-chip    | ethernet                            |
 +-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -139,6 +141,7 @@ and a ST morpho connector. Board is configured as follows:
 - I2C : PB8, PB9
 - ADC1_INP15 : PA3
 - ETH : PA1, PA2, PA7, PB13, PC1, PC4, PC5, PG11, PG13
+- SPI1 SCK/MISO/MOSI : PA5/PA6/PB5 (Arduino SPI)
 
 System Clock
 ------------

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -111,3 +111,8 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 };
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+};

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
@@ -18,3 +18,4 @@ supported:
   - pwm
   - adc
   - netif:eth
+  - spi

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -502,6 +502,13 @@ static int spi_stm32_configure(const struct device *dev,
 	LL_SPI_DisableCRC(spi);
 
 	if (config->cs || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
+		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+			if (LL_SPI_GetNSSPolarity(spi) == LL_SPI_NSS_POLARITY_LOW)
+				LL_SPI_SetInternalSSLevel(spi, LL_SPI_SS_LEVEL_HIGH);
+		}
+#endif
 		LL_SPI_SetNSSMode(spi, LL_SPI_NSS_SOFT);
 	} else {
 		if (config->operation & SPI_OP_MODE_SLAVE) {

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -37,7 +37,8 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
  * error flag, because STM32F1 SoCs do not support it and  STM32CUBE
  * for F1 family defines an unused LL_SPI_SR_FRE.
  */
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 #define SPI_STM32_ERR_MSK (LL_SPI_SR_UDR | LL_SPI_SR_CRCE | LL_SPI_SR_MODF | \
 			   LL_SPI_SR_OVR | LL_SPI_SR_TIFRE)
 #else
@@ -262,9 +263,11 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		/* NOP */
 	}
 
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
-	/* With the STM32MP1, if the device is the SPI master, we need to enable
-	 * the start of the transfer with LL_SPI_StartMasterTransfer(spi)
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
+	/* With the STM32MP1 and the STM32H7, if the device is the SPI master,
+	 * we need to enable the start of the transfer with
+	 * LL_SPI_StartMasterTransfer(spi)
 	 */
 	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
 		LL_SPI_StartMasterTransfer(spi);

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -54,7 +54,8 @@ struct spi_stm32_data {
 
 static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	return LL_SPI_IsActiveFlag_TXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_TXE(spi);
@@ -63,7 +64,8 @@ static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
 
 static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	return LL_SPI_IsActiveFlag_RXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_RXNE(spi);
@@ -72,7 +74,8 @@ static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_EnableIT_TXP(spi);
 #else
 	LL_SPI_EnableIT_TXE(spi);
@@ -81,7 +84,8 @@ static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_EnableIT_RXP(spi);
 #else
 	LL_SPI_EnableIT_RXNE(spi);
@@ -90,7 +94,8 @@ static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_EnableIT_UDR(spi);
 	LL_SPI_EnableIT_OVR(spi);
 	LL_SPI_EnableIT_CRCERR(spi);
@@ -103,7 +108,8 @@ static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_DisableIT_TXP(spi);
 #else
 	LL_SPI_DisableIT_TXE(spi);
@@ -112,7 +118,8 @@ static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_DisableIT_RXP(spi);
 #else
 	LL_SPI_DisableIT_RXNE(spi);
@@ -121,7 +128,8 @@ static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_DisableIT_UDR(spi);
 	LL_SPI_DisableIT_OVR(spi);
 	LL_SPI_DisableIT_CRCERR(spi);
@@ -134,7 +142,8 @@ static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 
 static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	return (!LL_SPI_IsActiveFlag_MODF(spi) &&
 		!LL_SPI_IsActiveFlag_TXC(spi));
 #else
@@ -148,7 +157,8 @@ static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_01DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_QUARTER);
@@ -157,7 +167,8 @@ static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 
 static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_02DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_HALF);
@@ -167,7 +178,8 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 {
-#ifdef CONFIG_SOC_SERIES_STM32MP1X
+#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
+    defined(CONFIG_SOC_SERIES_STM32H7X)
 	if (LL_SPI_IsActiveMasterTransfer(spi)) {
 		LL_SPI_SuspendMasterTransfer(spi);
 		while (LL_SPI_IsActiveMasterTransfer(spi)) {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -297,6 +297,72 @@
 			label = "I2C_4";
 		};
 
+		spi1: spi@40013000 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			interrupts = <35 0>;
+			status = "disabled";
+			label = "SPI_1";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			interrupts = <36 0>;
+			status = "disabled";
+			label = "SPI_2";
+		};
+
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <51 0>;
+			status = "disabled";
+			label = "SPI_3";
+		};
+
+		spi4: spi@40013400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
+			interrupts = <84 0>;
+			status = "disabled";
+			label = "SPI_4";
+		};
+
+		spi5: spi@40015000 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
+			interrupts = <85 0>;
+			status = "disabled";
+			label = "SPI_5";
+		};
+
+		spi6: spi@58001400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000020>;
+			interrupts = <86 0>;
+			status = "disabled";
+			label = "SPI_6";
+		};
+
 		timers1: timers@40010000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40010000 0x400>;

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -68,6 +68,10 @@
 #include <stm32h7xx_ll_i2c.h>
 #endif /* CONFIG_I2C_STM32 */
 
+#ifdef CONFIG_SPI_STM32
+#include <stm32h7xx_ll_spi.h>
+#endif /* CONFIG_SPI_STM32 */
+
 #ifdef CONFIG_ADC_STM32
 #include <stm32h7xx_ll_adc.h>
 #endif /* CONFIG_ADC_STM32 */


### PR DESCRIPTION
Hi, this PR add the SPI support for STM32H7 Series and enable on NUCLEO-H743ZI board. 

The STM32H7's SPI register is very similar to the STM32MP1, so i assume they have the same behavior and use the same code, hope i didn't miss something and give me any suggestions.

I found an issue during development this driver, that if CS pin is control by software should set SSIOP to high level before transmission, or you will got the MODF error and nothing output from the SPI bus. The NUCLEO-H743ZI SPI1's CS pin is control by software, so we must have this fix.

I think the STM32MP1 also have this issue, but i don't have STM32MP157C-DK2 to test, hope somebody can help me to verify it.