### PR TITLE
kernel: limit thread local storage to Zephyr SDK

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -861,9 +861,16 @@ config TICKLESS_KERNEL
 	  This option enables a fully event driven kernel. Periodic system
 	  clock interrupt generation would be stopped at all times.
 
+config TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+	bool
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
+	help
+	  Hidden option to signal that toolchain supports generating code
+	  with thread local storage.
+
 config THREAD_LOCAL_STORAGE
 	bool "Thread Local Storage (TLS)"
-	depends on ARCH_HAS_THREAD_LOCAL_STORAGE
+	depends on ARCH_HAS_THREAD_LOCAL_STORAGE && TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
 	select NEED_LIBC_MEM_PARTITION if (CPU_CORTEX_M && USERSPACE)
 	help
 	  This option enables thread local storage (TLS) support in kernel.


### PR DESCRIPTION
Toolchains other than Zephyr SDK may not support generating
code with thread local storage. So limit TLS to Zephyr SDK
for now, and only enable TLS on other toolchains as needed.

Fixes #29541

Signed-off-by: Daniel Leung <daniel.leung@intel.com>