### PR TITLE
doc: api: sort the API overview alphabetically

### DIFF
--- a/doc/reference/audio/dmic.rst
+++ b/doc/reference/audio/dmic.rst
@@ -1,7 +1,7 @@
 .. _audio_dmic_api:
 
-DMIC
-####
+Audio DMIC
+##########
 
 Overview
 ********

--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -6,6 +6,9 @@ API Overview
 The table lists Zephyr's APIs and information about them, including their
 current :ref:`stability level <api_lifecycle>`.
 
+.. Keep this list sorted by the name of the API as it appears
+   in the HTML, *NOT* the :ref: label
+
 .. list-table::
    :header-rows: 1
 
@@ -13,6 +16,11 @@ current :ref:`stability level <api_lifecycle>`.
      - Status
      - Version Introduced
      - Version Modified
+
+   * - :ref:`adc_api`
+     - Stable
+     - 1.0
+     - 2.2
 
    * - :ref:`audio_codec_api`
      - Experimental
@@ -29,15 +37,40 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.4
 
+   * - :ref:`clock_control_api`
+     - Stable
+     - 1.0
+     - 2.2
+
+   * - :ref:`coap_sock_interface`
+     - Unstable
+     - 1.10
+     - 2.4
+
    * - :ref:`can_api`
      - Experimental
      - 1.14
      - 2.1
 
+   * - :ref:`counter_api`
+     - Unstable
+     - 1.14
+     - 2.2
+
    * - :ref:`crypto_api`
      - Stable
      - 1.7
      - 2.2
+
+   * - :ref:`dac_api`
+     - Experimental
+     - 2.3
+     - 2.3
+
+   * - :ref:`dma_api`
+     - Stable
+     - 1.5
+     - 2.4
 
    * - :ref:`device_model_api`
      - Stable
@@ -49,75 +82,15 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.2
      - 2.4
 
+   * - :ref:`disk_access_api`
+     - Stable
+     - 1.6
+     - 2.0
+
    * - :ref:`display_api`
      - Unstable
      - 1.14
      - 2.2
-
-   * - :ref:`file_system_api`
-     - Stable
-     - 1.5
-     - 2.4
-
-   * - :ref:`kernel_api`
-     - Stable
-     - 1.0
-     - 2.4
-
-   * - :ref:`logging_api`
-     - Stable
-     - 1.13
-     - 1.14
-
-   * - :ref:`misc_api`
-     - Stable
-     - 1.0
-     - 2.2
-
-   * - :ref:`networking_api`
-     - Stable
-     - 1.0
-     - 2.4
-
-   * - :ref:`coap_sock_interface`
-     - Unstable
-     - 1.10
-     - 2.4
-
-   * - :ref:`lwm2m_interface`
-     - Unstable
-     - 1.9
-     - 2.5
-
-   * - :ref:`mqtt_socket_interface`
-     - Unstable
-     - 1.14
-     - 2.4
-
-   * - :ref:`adc_api`
-     - Stable
-     - 1.0
-     - 2.2
-
-   * - :ref:`clock_control_api`
-     - Stable
-     - 1.0
-     - 2.2
-
-   * - :ref:`counter_api`
-     - Unstable
-     - 1.14
-     - 2.2
-
-   * - :ref:`dma_api`
-     - Stable
-     - 1.5
-     - 2.4
-
-   * - :ref:`dac_api`
-     - Experimental
-     - 2.3
-     - 2.3
 
    * - :ref:`ec_host_cmd_periph_api`
      - Experimental
@@ -134,10 +107,25 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.10
      - 1.12
 
+   * - :ref:`file_system_api`
+     - Stable
+     - 1.5
+     - 2.4
+
    * - :ref:`flash_api`
      - Stable
      - 1.2
      - 2.4
+
+   * - :ref:`fcb_api`
+     - Stable
+     - 1.11
+     - 2.1
+
+   * - :ref:`flash_map_api`
+     - Stable
+     - 1.11
+     - 2.3
 
    * - :ref:`gna_api`
      - Experimental
@@ -169,25 +157,55 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.4
 
-   * - :ref:`led_api`
-     - Stable
-     - 1.12
-     - 2.4
-
    * - :ref:`kscan_api`
      - Stable
      - 2.1
      - 2.2
 
+   * - :ref:`kernel_api`
+     - Stable
+     - 1.0
+     - 2.4
+
+   * - :ref:`led_api`
+     - Stable
+     - 1.12
+     - 2.4
+
+   * - :ref:`lwm2m_interface`
+     - Unstable
+     - 1.9
+     - 2.5
+
+   * - :ref:`logging_api`
+     - Stable
+     - 1.13
+     - 1.14
+
+   * - :ref:`mqtt_socket_interface`
+     - Unstable
+     - 1.14
+     - 2.4
+
+   * - :ref:`misc_api`
+     - Stable
+     - 1.0
+     - 2.2
+
+   * - :ref:`networking_api`
+     - Stable
+     - 1.0
+     - 2.4
+
+   * - :ref:`nvs_api`
+     - Stable
+     - 1.12
+     - 1.14
+
    * - :ref:`peci_api`
      - Stable
      - 2.1
      - 2.4
-
-   * - :ref:`pinmux_api`
-     - Stable
-     - 1.0
-     - 1.11
 
    * - :ref:`ps2_api`
      - Stable
@@ -199,40 +217,10 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.2
 
-   * - :ref:`regulator_api`
-     - Experimental
-     - 2.4
-     - 2.4
-
-   * - :ref:`sensor_api`
-     - Stable
-     - 1.2
-     - 2.4
-
-   * - :ref:`spi_api`
+   * - :ref:`pinmux_api`
      - Stable
      - 1.0
-     - 1.12
-
-   * - :ref:`uart_api`
-     - Stable
-     - 1.0
-     - 2.4
-
-   * - :ref:`UART async <uart_api>`
-     - Unstable
-     - 1.14
-     - 2.2
-
-   * - :ref:`video_api`
-     - Stable
-     - 2.1
-     - 2.1
-
-   * - :ref:`watchdog_api`
-     - Stable
-     - 1.0
-     - 2.0
+     - 1.11
 
    * - :ref:`power_management_api`
      - Experimental
@@ -244,6 +232,26 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.0
      - 2.1
 
+   * - :ref:`regulator_api`
+     - Experimental
+     - 2.4
+     - 2.4
+
+   * - :ref:`sdhc_api`
+     - Stable
+     - 1.14
+     - 2.0
+
+   * - :ref:`spi_api`
+     - Stable
+     - 1.0
+     - 1.12
+
+   * - :ref:`sensor_api`
+     - Stable
+     - 1.2
+     - 2.4
+
    * - :ref:`settings_api`
      - Stable
      - 1.12
@@ -254,35 +262,20 @@ current :ref:`stability level <api_lifecycle>`.
      - 1.14
      - 2.4
 
-   * - :ref:`disk_access_api`
-     - Stable
-     - 1.6
-     - 2.0
-
-   * - :ref:`sdhc_api`
-     - Stable
-     - 1.14
-     - 2.0
-
-   * - :ref:`fcb_api`
-     - Stable
-     - 1.11
-     - 2.1
-
    * - :ref:`stream_flash`
      - Experimental
      - 2.3
      - 2.3
 
-   * - :ref:`flash_map_api`
+   * - :ref:`uart_api`
      - Stable
-     - 1.11
-     - 2.3
+     - 1.0
+     - 2.4
 
-   * - :ref:`nvs_api`
-     - Stable
-     - 1.12
+   * - :ref:`UART async <uart_api>`
+     - Unstable
      - 1.14
+     - 2.2
 
    * - :ref:`usb_api`
      - Stable
@@ -298,3 +291,13 @@ current :ref:`stability level <api_lifecycle>`.
      - Experimental
      - 2.4
      - 2.4
+
+   * - :ref:`video_api`
+     - Stable
+     - 2.1
+     - 2.1
+
+   * - :ref:`watchdog_api`
+     - Stable
+     - 1.0
+     - 2.0


### PR DESCRIPTION
This makes it easier to scan. The sorting is done based on the text
that appears in the HTML, not the :ref: label name.

In the case of the DMIC API, change the title of the document to match
the "Audio Codec" document so we can keep those together.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>