### PR TITLE
x86_64: disable shared_mem test until bugs fixed

### DIFF
--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -11,5 +11,6 @@ common:
         - "MSG"
 tests:
   sample.kernel.memory_protection.shared_mem:
-    filter: CONFIG_ARCH_HAS_USERSPACE
+    # x86_64 excluded due to #29594 and #28105
+    filter: CONFIG_ARCH_HAS_USERSPACE and not CONFIG_X86_64
     platform_exclude: twr_ke18f


### PR DESCRIPTION
re-enabling this test was premature, it still crashes very often
due to two known issues affecting x86 64-bit. Filter out for
every 64-bit x86 platform until those bugs are solved, which
will reduce CI failure noise.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>