### PR TITLE
x86_64: fix RBX clobber in nested IRQ case

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -707,9 +707,9 @@ irq_enter_unnested: /* Not nested: dump state to thread struct for __resume */
 #endif
 
 irq_dispatch:
-	movq x86_irq_funcs(,%rcx,8), %rbx
+	movq x86_irq_funcs(,%rcx,8), %rax
 	movq x86_irq_args(,%rcx,8), %rdi
-	call *%rbx
+	call *%rax
 
 	xorq %rax, %rax
 #ifdef CONFIG_X2APIC


### PR DESCRIPTION
In the code path for nested interrupts, we are not saving
RBX, yet the assembly code is using it as a storage location
for the ISR.

Use RAX. It is backed up in both the nested and non-nested
cases, and the ASM code is not currently using it at that
point.

Fixes: #29594

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>