### PR TITLE
buf: change avail_count variable to atomic type

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -818,7 +818,7 @@ struct net_buf_pool {
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
 	/** Amount of available buffers in the pool. */
-	int16_t avail_count;
+	atomic_t avail_count;
 
 	/** Total size of the pool. */
 	const uint16_t pool_size;
@@ -844,7 +844,7 @@ struct net_buf_pool {
 		.free = Z_LIFO_INITIALIZER(_pool.free),                      \
 		.buf_count = _count,                                         \
 		.uninit_count = _count,                                      \
-		.avail_count = _count,                                       \
+		.avail_count = ATOMIC_INIT(_count),                          \
 		.name = STRINGIFY(_pool),                                    \
 		.destroy = _destroy,                                         \
 		.alloc = _alloc,                                             \

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -141,7 +141,7 @@ close_client:
 
 		net_pkt_get_info(&rx, &tx, &rx_data, &tx_data);
 		printf("rx buf: %d, tx buf: %d\n",
-		       rx_data->avail_count, tx_data->avail_count);
+		       atomic_get(&rx_data->avail_count), atomic_get(&tx_data->avail_count));
 #endif
 
 	}

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -346,8 +346,8 @@ success:
 	net_buf_reset(buf);
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-	pool->avail_count--;
-	__ASSERT_NO_MSG(pool->avail_count >= 0);
+	atomic_dec(&pool->avail_count);
+	__ASSERT_NO_MSG(atomic_get(&pool->avail_count) >= 0);
 #endif
 	return buf;
 }
@@ -552,8 +552,8 @@ void net_buf_unref(struct net_buf *buf)
 		pool = net_buf_pool_get(buf->pool_id);
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-		pool->avail_count++;
-		__ASSERT_NO_MSG(pool->avail_count <= pool->buf_count);
+		atomic_inc(&pool->avail_count);
+		__ASSERT_NO_MSG(atomic_get(&pool->avail_count) <= pool->buf_count);
 #endif
 
 		if (pool->destroy) {

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -286,7 +286,7 @@ const char *net_pkt_pool2str(struct net_buf_pool *pool)
 static inline int16_t get_frees(struct net_buf_pool *pool)
 {
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-	return pool->avail_count;
+	return atomic_get(&pool->avail_count);
 #else
 	return 0;
 #endif

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3226,7 +3226,7 @@ static void context_info(struct net_context *context, void *user_data)
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
 		PR("%p\t%d\t%d\tEDATA (%s)\n",
 		   pool, pool->buf_count,
-		   pool->avail_count, pool->name);
+		   atomic_get(&pool->avail_count), pool->name);
 #else
 		PR("%p\t%d\tEDATA\n", pool, pool->buf_count);
 #endif
@@ -3265,11 +3265,11 @@ static int cmd_net_mem(const struct shell *shell, size_t argc, char *argv[])
 
 	PR("%p\t%d\t%d\tRX DATA (%s)\n",
 	       rx_data, rx_data->buf_count,
-	       rx_data->avail_count, rx_data->name);
+	       atomic_get(&rx_data->avail_count), rx_data->name);
 
 	PR("%p\t%d\t%d\tTX DATA (%s)\n",
 	       tx_data, tx_data->buf_count,
-	       tx_data->avail_count, tx_data->name);
+	       atomic_get(&tx_data->avail_count), tx_data->name);
 #else
 	PR("Address\t\tTotal\tName\n");
 


### PR DESCRIPTION
using CONFIG_NET_BUF_POOL_USAGE monitor avail_count,
this variable should be protect.
Protecting it by using atomic variable

Signed-off-by: Ehud Naim <ehudn@marvell.com>