### PR TITLE
linker: pre .text and .rodata snippets

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -905,6 +905,10 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    ROM_START    Inside the first output section of the image. This option is
 #                 currently only available on ARM Cortex-M, ARM Cortex-R,
 #                 x86, ARC, and openisa_rv32m1.
+#    PRE_TEXT     Immediately before the .text section inclusion. Use this to
+#                 control the order of libraries/code in the output binary.
+#    PRE_RODATA   Immediately before the .rodata section inclusion. Use this to
+#                 control the order of constants in the output binary.
 #    RAM_SECTIONS Inside the RAMABLE_REGION GROUP.
 #    SECTIONS     Near the end of the file. Don't use this when linking into
 #                 RAMABLE_REGION, use RAM_SECTIONS instead.
@@ -914,9 +918,9 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #
 # Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
-# When placing into NOINIT, RWDATA, RODATA, ROM_START, the contents of the files
-# will be placed inside an output section, so assume the section definition is
-# already present, e.g.:
+# When placing into NOINIT, RWDATA, RODATA, ROM_START, PRE_TEXT, PRE_RODATA the
+# contents of the files will be placed inside an output section, so assume the
+# section definition is already present, e.g.:
 #    _mysection_start = .;
 #    KEEP(*(.mysection));
 #    _mysection_end = .;
@@ -945,6 +949,8 @@ function(zephyr_linker_sources location)
   set(sections_path     "${snippet_base}/snippets-sections.ld")
   set(ram_sections_path "${snippet_base}/snippets-ram-sections.ld")
   set(rom_start_path    "${snippet_base}/snippets-rom-start.ld")
+  set(pre_text_path     "${snippet_base}/snippets-pre-text.ld")
+  set(pre_rodata_path   "${snippet_base}/snippets-pre-rodata.ld")
   set(noinit_path       "${snippet_base}/snippets-noinit.ld")
   set(rwdata_path       "${snippet_base}/snippets-rwdata.ld")
   set(rodata_path       "${snippet_base}/snippets-rodata.ld")
@@ -955,6 +961,8 @@ function(zephyr_linker_sources location)
     file(WRITE ${sections_path} "")
     file(WRITE ${ram_sections_path} "")
     file(WRITE ${rom_start_path} "")
+    file(WRITE ${pre_text_path} "")
+    file(WRITE ${pre_rodata_path} "")
     file(WRITE ${noinit_path} "")
     file(WRITE ${rwdata_path} "")
     file(WRITE ${rodata_path} "")
@@ -968,6 +976,10 @@ function(zephyr_linker_sources location)
     set(snippet_path "${ram_sections_path}")
   elseif("${location}" STREQUAL "ROM_START")
     set(snippet_path "${rom_start_path}")
+  elseif("${location}" STREQUAL "PRE_TEXT")
+    set(snippet_path "${pre_text_path}")
+  elseif("${location}" STREQUAL "PRE_RODATA")
+    set(snippet_path "${pre_rodata_path}")
   elseif("${location}" STREQUAL "NOINIT")
     set(snippet_path "${noinit_path}")
   elseif("${location}" STREQUAL "RWDATA")

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -130,6 +130,12 @@ SECTIONS
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
     {
         _image_text_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
         *(.text)
         *(".text.*")
         *(.gnu.linkonce.t.*)
@@ -178,6 +184,12 @@ SECTIONS
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
     {
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
         *(.rodata)
         *(".rodata.*")
         *(.gnu.linkonce.r.*)

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -158,6 +158,11 @@ SECTIONS
 
 #include <linker/kobject-text.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
 	*(.text)
 	*(".text.*")
 	*(".TEXT.*")
@@ -205,6 +210,12 @@ SECTIONS
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
 	*(.rodata)
 	*(".rodata.*")
 	*(.gnu.linkonce.r.*)

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -119,6 +119,11 @@ SECTIONS
 
         _vector_end = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
         *(.text)
         *(".text.*")
         *(.gnu.linkonce.t.*)
@@ -173,6 +178,11 @@ SECTIONS
 
         KEEP(*(.openocd_dbg))
         KEEP(*(".openocd_dbg.*"))
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
 
         *(.rodata)
         *(".rodata.*")

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -121,6 +121,11 @@ SECTIONS
 
         _image_text_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
         *(.text)
         *(".text.*")
         *(.gnu.linkonce.t.*)
@@ -140,6 +145,11 @@ SECTIONS
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
         {
         . = ALIGN(4);
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
 
         *(.rodata)
         *(".rodata.*")

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -102,6 +102,11 @@ SECTIONS
 
 		_image_text_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
 		*(.text)
 		*(".text.*")
 		*(.gnu.linkonce.t.*)
@@ -116,6 +121,12 @@ SECTIONS
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
 		 . = ALIGN(4);
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
 		 *(.srodata)
 		 *(".srodata.*")
 		 *(.rodata)

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -99,6 +99,12 @@ SECTIONS
 
 	*(.text_start)
 	*(".text_start.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
 	*(.text)
 	*(".text.*")
 	*(.gnu.linkonce.t.*)
@@ -124,6 +130,12 @@ SECTIONS
 
 	SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
 	*(.rodata)
 	*(".rodata.*")
 	*(.gnu.linkonce.r.*)

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -87,6 +87,12 @@ SECTIONS
 	{
 	_image_rom_start = .;
 	_image_text_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
 	*(.text)
 	*(.text.*)
 
@@ -104,6 +110,12 @@ SECTIONS
 
 	SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(16))
 	{
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
 	*(.rodata)
 	*(.rodata.*)
 

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -112,6 +112,11 @@ SECTIONS
 
 	_image_text_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-text.ld>
+
 	*(.text .text.*)
 	*(.gnu.linkonce.t.*)
 	*(.eh_frame)
@@ -127,6 +132,12 @@ SECTIONS
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
 	. = ALIGN(4);
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-pre-rodata.ld>
+
 	*(.srodata)
 	*(".srodata.*")
 	*(.rodata)


### PR DESCRIPTION
Adds the ability for applications to control the ordering of .text and .rodata sections if desired.

The `pre-` prefix was added as `rodata` is already used as a snippet.

Implements #29604