### PR TITLE
fs: Make fs API callback runt-time check optional

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -13,6 +13,7 @@
 #include <init.h>
 #include <fs/fs.h>
 #include <fs/fs_sys.h>
+#include <sys/check.h>
 #include <sys/stat.h>
 
 
@@ -150,12 +151,14 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 
 	zfp->mp = mp;
 
-	if (zfp->mp->fs->open != NULL) {
-		rc = zfp->mp->fs->open(zfp, file_name, flags);
-		if (rc < 0) {
-			LOG_ERR("file open error (%d)", rc);
-			return rc;
-		}
+	CHECKIF(zfp->mp->fs->open == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->open(zfp, file_name, flags);
+	if (rc < 0) {
+		LOG_ERR("file open error (%d)", rc);
+		return rc;
 	}
 
 	return rc;
@@ -169,12 +172,14 @@ int fs_close(struct fs_file_t *zfp)
 		return 0;
 	}
 
-	if (zfp->mp->fs->close != NULL) {
-		rc = zfp->mp->fs->close(zfp);
-		if (rc < 0) {
-			LOG_ERR("file close error (%d)", rc);
-			return rc;
-		}
+	CHECKIF(zfp->mp->fs->close == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->close(zfp);
+	if (rc < 0) {
+		LOG_ERR("file close error (%d)", rc);
+		return rc;
 	}
 
 	zfp->mp = NULL;
@@ -190,11 +195,13 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->read != NULL) {
-		rc = zfp->mp->fs->read(zfp, ptr, size);
-		if (rc < 0) {
-			LOG_ERR("file read error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->read == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->read(zfp, ptr, size);
+	if (rc < 0) {
+		LOG_ERR("file read error (%d)", rc);
 	}
 
 	return rc;
@@ -208,11 +215,13 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->write != NULL) {
-		rc = zfp->mp->fs->write(zfp, ptr, size);
-		if (rc < 0) {
-			LOG_ERR("file write error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->write == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->write(zfp, ptr, size);
+	if (rc < 0) {
+		LOG_ERR("file write error (%d)", rc);
 	}
 
 	return rc;
@@ -226,11 +235,13 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->lseek != NULL) {
-		rc = zfp->mp->fs->lseek(zfp, offset, whence);
-		if (rc < 0) {
-			LOG_ERR("file seek error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->lseek == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->lseek(zfp, offset, whence);
+	if (rc < 0) {
+		LOG_ERR("file seek error (%d)", rc);
 	}
 
 	return rc;
@@ -244,11 +255,13 @@ off_t fs_tell(struct fs_file_t *zfp)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->tell != NULL) {
-		rc = zfp->mp->fs->tell(zfp);
-		if (rc < 0) {
-			LOG_ERR("file tell error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->tell == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->tell(zfp);
+	if (rc < 0) {
+		LOG_ERR("file tell error (%d)", rc);
 	}
 
 	return rc;
@@ -262,11 +275,13 @@ int fs_truncate(struct fs_file_t *zfp, off_t length)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->truncate != NULL) {
-		rc = zfp->mp->fs->truncate(zfp, length);
-		if (rc < 0) {
-			LOG_ERR("file truncate error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->truncate == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->truncate(zfp, length);
+	if (rc < 0) {
+		LOG_ERR("file truncate error (%d)", rc);
 	}
 
 	return rc;
@@ -280,11 +295,13 @@ int fs_sync(struct fs_file_t *zfp)
 		return -EBADF;
 	}
 
-	if (zfp->mp->fs->sync != NULL) {
-		rc = zfp->mp->fs->sync(zfp);
-		if (rc < 0) {
-			LOG_ERR("file sync error (%d)", rc);
-		}
+	CHECKIF(zfp->mp->fs->sync == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zfp->mp->fs->sync(zfp);
+	if (rc < 0) {
+		LOG_ERR("file sync error (%d)", rc);
 	}
 
 	return rc;
@@ -320,13 +337,14 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 		return rc;
 	}
 
-	zdp->mp = mp;
+	CHECKIF(mp->fs->opendir == NULL) {
+		return -ENOTSUP;
+	}
 
-	if (zdp->mp->fs->opendir != NULL) {
-		rc = zdp->mp->fs->opendir(zdp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("directory open error (%d)", rc);
-		}
+	zdp->mp = mp;
+	rc = zdp->mp->fs->opendir(zdp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("directory open error (%d)", rc);
 	}
 
 	return rc;
@@ -338,27 +356,29 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 		/* Delegate to mounted filesystem */
 		int rc = -EINVAL;
 
-		if (zdp->mp->fs->readdir != NULL) {
-			/* Loop until error or not special directory */
-			while (true) {
-				rc = zdp->mp->fs->readdir(zdp, entry);
-				if (rc < 0) {
-					break;
-				}
-				if (entry->name[0] == 0) {
-					break;
-				}
-				if (entry->type != FS_DIR_ENTRY_DIR) {
-					break;
-				}
-				if ((strcmp(entry->name, ".") != 0)
-				    && (strcmp(entry->name, "..") != 0)) {
-					break;
-				}
-			}
+		CHECKIF(zdp->mp->fs->readdir == NULL) {
+			return  -ENOTSUP;
+		}
+
+		/* Loop until error or not special directory */
+		while (true) {
+			rc = zdp->mp->fs->readdir(zdp, entry);
 			if (rc < 0) {
-				LOG_ERR("directory read error (%d)", rc);
+				break;
 			}
+			if (entry->name[0] == 0) {
+				break;
+			}
+			if (entry->type != FS_DIR_ENTRY_DIR) {
+				break;
+			}
+			if ((strcmp(entry->name, ".") != 0)
+			    && (strcmp(entry->name, "..") != 0)) {
+				break;
+			}
+		}
+		if (rc < 0) {
+			LOG_ERR("directory read error (%d)", rc);
 		}
 
 		return rc;
@@ -421,12 +441,14 @@ int fs_closedir(struct fs_dir_t *zdp)
 		return 0;
 	}
 
-	if (zdp->mp->fs->closedir != NULL) {
-		rc = zdp->mp->fs->closedir(zdp);
-		if (rc < 0) {
-			LOG_ERR("directory close error (%d)", rc);
-			return rc;
-		}
+	CHECKIF(zdp->mp->fs->closedir == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = zdp->mp->fs->closedir(zdp);
+	if (rc < 0) {
+		LOG_ERR("directory close error (%d)", rc);
+		return rc;
 	}
 
 	zdp->mp = NULL;
@@ -451,11 +473,13 @@ int fs_mkdir(const char *abs_path)
 		return rc;
 	}
 
-	if (mp->fs->mkdir != NULL) {
-		rc = mp->fs->mkdir(mp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("failed to create directory (%d)", rc);
-		}
+	CHECKIF(mp->fs->mkdir == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = mp->fs->mkdir(mp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("failed to create directory (%d)", rc);
 	}
 
 	return rc;
@@ -478,11 +502,13 @@ int fs_unlink(const char *abs_path)
 		return rc;
 	}
 
-	if (mp->fs->unlink != NULL) {
-		rc = mp->fs->unlink(mp, abs_path);
-		if (rc < 0) {
-			LOG_ERR("failed to unlink path (%d)", rc);
-		}
+	CHECKIF(mp->fs->unlink == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = mp->fs->unlink(mp, abs_path);
+	if (rc < 0) {
+		LOG_ERR("failed to unlink path (%d)", rc);
 	}
 
 	return rc;
@@ -512,11 +538,13 @@ int fs_rename(const char *from, const char *to)
 		return -EINVAL;
 	}
 
-	if (mp->fs->rename != NULL) {
-		rc = mp->fs->rename(mp, from, to);
-		if (rc < 0) {
-			LOG_ERR("failed to rename file or dir (%d)", rc);
-		}
+	CHECKIF(mp->fs->rename == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = mp->fs->rename(mp, from, to);
+	if (rc < 0) {
+		LOG_ERR("failed to rename file or dir (%d)", rc);
 	}
 
 	return rc;
@@ -539,11 +567,13 @@ int fs_stat(const char *abs_path, struct fs_dirent *entry)
 		return rc;
 	}
 
-	if (mp->fs->stat != NULL) {
-		rc = mp->fs->stat(mp, abs_path, entry);
-		if (rc < 0) {
-			LOG_ERR("failed get file or dir stat (%d)", rc);
-		}
+	CHECKIF(mp->fs->stat == NULL) {
+		return -ENOTSUP;
+	}
+
+	rc = mp->fs->stat(mp, abs_path, entry);
+	if (rc < 0) {
+		LOG_ERR("failed get file or dir stat (%d)", rc);
 	}
 	return rc;
 }
@@ -623,7 +653,7 @@ int fs_mount(struct fs_mount_t *mp)
 		goto mount_err;
 	}
 
-	if (fs->mount == NULL) {
+	CHECKIF(fs->mount == NULL) {
 		LOG_ERR("fs type %d does not support mounting", mp->type);
 		rc = -ENOTSUP;
 		goto mount_err;
@@ -668,9 +698,8 @@ int fs_unmount(struct fs_mount_t *mp)
 		goto unmount_err;
 	}
 
-	if (mp->fs->unmount == NULL) {
-		LOG_ERR("mount path %s is not unmountable",
-			log_strdup(mp->mnt_point));
+	CHECKIF(mp->fs->unmount == NULL) {
+		LOG_ERR("fs unmount not supported!!");
 		rc = -ENOTSUP;
 		goto unmount_err;
 	}


### PR DESCRIPTION
The commit changes run-time checks of file system driver's callbacks
pointers, against null, optional by replacing `if` with `CHECKIF` macro,
which means that they can be removed from compilation with Kconfig option
CONFIG_NO_RUNTIME_CHECKS.
Additionally the commit allows the same checks to fail hard, with
assertion, when CONFIG_ASSERT_ON_ERRORS option is selected.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

The review has been spun off from the https://github.com/zephyrproject-rtos/zephyr/pull/29396.