### PR TITLE
Bluetooth: ATT: Handle encrypt change event unrelated to current req

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2694,7 +2694,7 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 	 * outstanding request about security failure.
 	 */
 	if (hci_status) {
-		if (att_chan->req) {
+		if (att_chan->req && att_chan->req->retrying) {
 			att_handle_rsp(att_chan, NULL, 0,
 				       BT_ATT_ERR_AUTHENTICATION);
 		}
@@ -2708,7 +2708,7 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 		return;
 	}
 
-	if (!att_chan->req || !att_chan->req->retrying) {
+	if (!(att_chan->req && att_chan->req->retrying)) {
 		return;
 	}
 


### PR DESCRIPTION
Fix issue where the encrypt change has an error code, but the
encrypt change request was unrelated to the current ATT request.

This lead to the current ATT transaction being interpreted as finished
an the ATT client would proceed with the next ATT request, which would
fail since the ATT client is now violating the ATT single transaction
rule.

Updated similar if statement checking for the opposite to improve
readability.

Fixes: #29639