### PR TITLE
mem: mem_slab: check alloc mem ptr after swap and fix return value

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -122,7 +122,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 		if (result == 0) {
 			*mem = _current->base.swap_data;
 		}
-		return result;
+		return *mem ? result : -EAGAIN;
 	}
 
 	k_spin_unlock(&lock, key);


### PR DESCRIPTION
while no memory exist k_mem_slab_alloc is calling z_pend_curr.
z_pend_curr return swap return value but it isn't depend if
mem free occured or not.
So it may return 0 while mem still zero, if no free occurred.
And most of the code assume that if return value is '0'
the ptr is also fine.

Signed-off-by: Ehud Naim <ehudn@marvell.com>