### PR TITLE
tests: fix accel abstraction violation

### DIFF
--- a/tests/drivers/sensor/accel/src/main.c
+++ b/tests/drivers/sensor/accel/src/main.c
@@ -65,7 +65,7 @@ void test_main(void)
 {
 	run_tests_on_accel(DT_LABEL(DT_ALIAS(accel_0)));
 
-#ifdef DT_N_ALIAS_accel_1
+#if DT_NODE_EXISTS(DT_ALIAS(accel_1))
 	run_tests_on_accel(DT_LABEL(DT_ALIAS(accel_1)));
 #endif
 }


### PR DESCRIPTION
As documented in doc/guides/dts/api-usage.rst, the generated
devicetree macros should be considered an implementation detail.

Replace direct usage of one with an equivalent that uses the API.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>