### PR TITLE
Bluetooth: ISO: Fix crash when channel has already been disconnected

### DIFF
--- a/subsys/bluetooth/host/audio/iso.c
+++ b/subsys/bluetooth/host/audio/iso.c
@@ -742,8 +742,11 @@ void bt_iso_disconnected(struct bt_conn *conn)
 			chan->ops->disconnected(chan);
 		}
 
-		bt_conn_unref(chan->conn);
-		chan->conn = NULL;
+		if (chan->conn) {
+			bt_conn_unref(chan->conn);
+			chan->conn = NULL;
+		}
+
 		bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
 	}
 }
@@ -930,6 +933,7 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 
 	if (chan->state == BT_ISO_BOUND) {
 		bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
+		bt_iso_chan_remove(chan->conn, chan);
 		bt_conn_unref(chan->conn);
 		chan->conn = NULL;
 		return 0;


### PR DESCRIPTION
If chan->conn is already NULL do not call bt_conn_unref as that will
likely cause a crash, also this make sure that if channel has been
disconnected using bt_iso_chan_disconnect it removes the channel from
connection list before setting the chan->conn to NULL.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>