### PR TITLE
uart: native_posix: Add support for pts readiness

### DIFF
--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -39,6 +39,16 @@ config NATIVE_UART_0_ON_STDINOUT
 
 endchoice
 
+config UART_NATIVE_WAIT_PTS_READY_ENABLE
+	bool "Support waiting for pseudo terminal client readiness"
+	depends on NATIVE_UART_0_ON_OWN_PTY || UART_NATIVE_POSIX_PORT_1_ENABLE
+	help
+	  When this option is selected a new command line switch is provided:
+	  `--wait_uart`
+	  When `--wait_uart` is used, writes to the UART will be held until a
+	  client has connected to the slave side of the pseudoterminal.
+	  Otherwise writes are sent irrespectively.
+
 config UART_NATIVE_POSIX_PORT_1_ENABLE
 	bool "Enable second UART port"
 	help

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <sys/select.h>
 #include <unistd.h>
+#include <poll.h>
 
 #include <drivers/uart.h>
 #include "cmdline.h" /* native_posix command line options header */
@@ -46,6 +47,7 @@ static void np_uart_poll_out(const struct device *dev,
 				      unsigned char out_char);
 
 static bool auto_attach;
+static bool wait_pts;
 static const char default_cmd[] = CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD;
 static char *auto_attach_cmd;
 
@@ -184,6 +186,15 @@ static int open_tty(struct native_uart_status *driver_data,
 	posix_print_trace("%s connected to pseudotty: %s\n",
 			  uart_name, slave_pty_name);
 
+	if (wait_pts) {
+		/*
+		 * This trick sets the HUP flag on the tty master, making it
+		 * possible to detect a client connection using poll.
+		 * The connection of the client would cause the HUP flag to be
+		 * cleared, and in turn set again at disconnect.
+		 */
+		close(open(slave_pty_name, O_RDWR | O_NOCTTY));
+	}
 	if (do_auto_attach) {
 		attach_to_tty(slave_pty_name);
 	}
@@ -261,9 +272,21 @@ static void np_uart_poll_out(const struct device *dev,
 				      unsigned char out_char)
 {
 	int ret;
-	struct native_uart_status *d;
+	struct native_uart_status *d = (struct native_uart_status *)dev->data;
 
-	d = (struct native_uart_status *)dev->data;
+	if (wait_pts) {
+		struct pollfd pfd = { .fd = d->out_fd, .events = POLLHUP };
+
+		while (1) {
+			poll(&pfd, 1, 0);
+			if (!(pfd.revents & POLLHUP)) {
+				/* There is now a reader on the slave side */
+				break;
+			}
+			k_sleep(K_MSEC(100));
+		}
+	}
+
 	ret = write(d->out_fd, &out_char, 1);
 
 	if (ret != 1) {
@@ -379,7 +402,13 @@ static void np_add_uart_options(void)
 		(void *)&auto_attach_cmd, NULL,
 		"Command used to automatically attach to the terminal, by "
 		"default: '" CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD "'"},
-
+		IF_ENABLED(CONFIG_UART_NATIVE_WAIT_PTS_READY_ENABLE, (
+			{false, false, true,
+			"wait_uart", "", 'b',
+			(void *)&wait_pts, NULL,
+			"Hold writes to the uart/pts until a client is "
+			"connected/ready"},)
+		)
 		ARG_TABLE_ENDMARKER
 	};
 


### PR DESCRIPTION
Option to pause writing to the pseudo terminal until it is ready to
receive data. Useful for pseudo terminal synchronization with other
host processes.