### PR TITLE
P4 Work Queue: Pooled Parallel Preemptible Priority-based

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1018,11 +1018,12 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * static priority.  Threads at different priorities will be scheduled
  * according to their static priority.
  *
- * @note Deadlines that are negative (i.e. in the past) are still seen
- * as higher priority than others, even if the thread has "finished"
- * its work.  If you don't want it scheduled anymore, you have to
- * reset the deadline into the future, block/pend the thread, or
- * modify its priority with k_thread_priority_set().
+ * @note Deadlines are stored internally using 32 bit unsigned
+ * integers.  The number of cycles between the "first" deadline in the
+ * scheduler queue and the "last" deadline must be less than 2^31 (i.e
+ * a signed non-negative quantity).  Failure to adhere to this rule
+ * may result in scheduled threads running in an incorrect dealine
+ * order.
  *
  * @note Despite the API naming, the scheduler makes no guarantees the
  * the thread WILL be scheduled within that deadline, nor does it take

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -125,6 +125,8 @@
 	Z_ITERABLE_SECTION_ROM(settings_handler_static, 4)
 #endif
 
+	Z_ITERABLE_SECTION_ROM(k_p4wq_initparam, 4)
+
 #if defined(CONFIG_EMUL)
 	SECTION_DATA_PROLOGUE(emulators_section,,)
 	{

--- a/include/sys/p4wq.h
+++ b/include/sys/p4wq.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_SYS_P4WQ_H_
+#define ZEPHYR_INCLUDE_SYS_P4WQ_H_
+
+#include <kernel.h>
+
+/* Zephyr Pooled Parallel Preemptible Priority-based Work Queues */
+
+struct k_p4wq_work;
+
+/**
+ * P4 Queue handler callback
+ */
+typedef void (*k_p4wq_handler_t)(struct k_p4wq_work *work);
+
+/**
+ * @brief P4 Queue Work Item
+ *
+ * User-populated struct representing a single work item.  The
+ * priority and deadline fields are interpreted as thread scheduling
+ * priorities, exactly as per k_thread_priority_set() and
+ * k_thread_deadline_set().
+ */
+struct k_p4wq_work {
+	/* Filled out by submitting code */
+	int32_t priority;
+	int32_t deadline;
+	k_p4wq_handler_t handler;
+
+	/* reserved for implementation */
+	union {
+		struct rbnode rbnode;
+		sys_dlist_t dlnode;
+	};
+	struct k_thread *thread;
+};
+
+/**
+ * @brief P4 Queue
+ *
+ * Kernel pooled parallel preemptible priority-based work queue
+ */
+struct k_p4wq {
+	struct k_spinlock lock;
+
+	/* Pending threads waiting for work items
+	 *
+	 * FIXME: a waitq isn't really the right data structure here.
+	 * Wait queues are priority-sorted, but we don't want that
+	 * sorting overhead since we're effectively doing it ourselves
+	 * by directly mutating the priority when a thread is
+	 * unpended.  We just want "blocked threads on a list", but
+	 * there's no clean scheduler API for that.
+	 */
+	_wait_q_t waitq;
+
+	/* Work items waiting for processing */
+	struct rbtree queue;
+
+	/* Work items in progress */
+	sys_dlist_t active;
+};
+
+struct k_p4wq_initparam {
+	uint32_t num;
+	uintptr_t stack_size;
+	struct k_p4wq *queue;
+	struct k_thread *threads;
+	struct z_thread_stack_element *stacks;
+};
+
+/**
+ * @brief Statically initialize a P4 Work Queue
+ *
+ * Statically defines a struct k_p4wq object with the specified number
+ * of threads which will be initialized at boot and ready for use on
+ * entry to main().
+ *
+ * @param name Symbol name of the struct k_p4wq that will be defined
+ * @param n_threads Number of threads in the work queue pool
+ * @param stack_sz Requested stack size of each thread, in bytes
+ */
+#define K_P4WQ_DEFINE(name, n_threads, stack_sz)			\
+	static K_THREAD_STACK_ARRAY_DEFINE(_p4stacks_##name,		\
+					   n_threads, stack_sz);	\
+	static struct k_thread _p4threads_##name[n_threads];		\
+	static struct k_p4wq name;					\
+	static const Z_STRUCT_SECTION_ITERABLE(k_p4wq_initparam,	\
+					       _init_##name) = {	\
+		.num = n_threads,					\
+		.stack_size = stack_sz,					\
+		.threads = _p4threads_##name,				\
+		.stacks = &(_p4stacks_##name[0][0]),			\
+		.queue = &name,						\
+	}
+
+/**
+ * @brief Initialize P4 Queue
+ *
+ * Initializes a P4 Queue object.  These objects much be initialized
+ * via this function (or statically using K_P4WQ_DEFINE) before any
+ * other API calls are made on it.
+ *
+ * @param queue P4 Queue to initialize
+ */
+void k_p4wq_init(struct k_p4wq *queue);
+
+/**
+ * @brief Dynamically add a thread object to a P4 Queue pool
+ *
+ * Adds a thread to the pool managed by a P4 queue.  The thread object
+ * must not be in use.  If k_thread_create() has previously been
+ * called on it, it must be aborted before being given to the queue.
+ *
+ * @param queue P4 Queue to which to add the thread
+ * @param thread Uninitialized/aborted thread object to add
+ * @param stack Thread stack memory
+ * @param stack_size Thread stack size
+ */
+void k_p4wq_add_thread(struct k_p4wq *queue, struct k_thread *thread,
+		       k_thread_stack_t *stack,
+		       size_t stack_size);
+
+/**
+ * @brief Submit work item to a P4 queue
+ *
+ * Submits the specified work item to the queue.  The caller must have
+ * already initialized the relevant fields of the struct.  The queue
+ * will execute the handler when CPU time is available and when no
+ * higher-priority work items are available.  The handler may be
+ * invoked on any CPU.
+ *
+ * The caller must not mutate the struct while it is stored in the
+ * queue.  The memory should remain unchanged until k_p4wq_cancel() is
+ * called or until the entry to the handler function.
+ *
+ * @note This call is a scheduling point, so if the submitted item (or
+ * any other ready thread) has a higher priority than the current
+ * thread and the current thread has a preemptible priority then the
+ * caller will yield.
+ *
+ * @param queue P4 Queue to which to submit
+ * @param item P4 work item to be submitted
+ */
+void k_p4wq_submit(struct k_p4wq *queue, struct k_p4wq_work *item);
+
+/**
+ * @brief Cancel submitted P4 work item
+ *
+ * Cancels a previously-submitted work item and removes it from the
+ * queue.  Returns true if the item was found in the queue and
+ * removed.  If the function returns false, either the item was never
+ * submitted, has already been executed, or is still running.
+ *
+ * @return true if the item was successfully removed, otherwise false
+ */
+bool k_p4wq_cancel(struct k_p4wq *queue, struct k_p4wq_work *item);
+
+#endif /* ZEPHYR_INCLUDE_SYS_P4WQ_H_ */

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -33,3 +33,10 @@ zephyr_sources_ifdef(CONFIG_RING_BUFFER ring_buffer.c)
 zephyr_sources_ifdef(CONFIG_ASSERT assert.c)
 
 zephyr_sources_ifdef(CONFIG_USERSPACE mutex.c)
+
+zephyr_sources_ifdef(CONFIG_SCHED_DEADLINE p4wq.c)
+
+zephyr_library_include_directories(
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+)

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <logging/log.h>
+#include <sys/p4wq.h>
+#include <wait_q.h>
+#include <ksched.h>
+#include <init.h>
+
+LOG_MODULE_REGISTER(p4wq);
+
+struct device;
+
+static void set_prio(struct k_thread *th, struct k_p4wq_work *item)
+{
+	__ASSERT_NO_MSG(!IS_ENABLED(CONFIG_SMP) || !z_is_thread_queued(th));
+	th->base.prio = item->priority;
+	th->base.prio_deadline = item->deadline;
+}
+
+static bool rb_lessthan(struct rbnode *a, struct rbnode *b)
+{
+	struct k_p4wq_work *aw = CONTAINER_OF(a, struct k_p4wq_work, rbnode);
+	struct k_p4wq_work *bw = CONTAINER_OF(b, struct k_p4wq_work, rbnode);
+
+	if (aw->priority != bw->priority) {
+		return aw->priority > bw->priority;
+	}
+
+	if (aw->deadline != bw->deadline) {
+		return aw->deadline - bw->deadline > 0;
+	}
+
+	return (uintptr_t)a < (uintptr_t)b;
+}
+
+/* Slightly different semantics: rb_lessthan must be perfectly
+ * symmetric (to produce a single tree structure) and will use the
+ * pointer value to break ties where priorities are equal, here we
+ * tolerate equality as meaning "not lessthan"
+ */
+static inline bool item_lessthan(struct k_p4wq_work *a, struct k_p4wq_work *b)
+{
+	if (a->priority > b->priority) {
+		return true;
+	} else if ((a->priority == b->priority) &&
+		   (a->deadline != b->deadline)) {
+		return a->deadline - b->deadline > 0;
+	}
+	return false;
+}
+
+static FUNC_NORETURN void p4wq_loop(void *p0, void *p1, void *p2)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	struct k_p4wq *queue = p0;
+	k_spinlock_key_t k = k_spin_lock(&queue->lock);
+
+	while (true) {
+		struct rbnode *r = rb_get_max(&queue->queue);
+
+		if (r) {
+			struct k_p4wq_work *w
+				= CONTAINER_OF(r, struct k_p4wq_work, rbnode);
+
+			rb_remove(&queue->queue, r);
+			w->thread = _current;
+			sys_dlist_append(&queue->active, &w->dlnode);
+			set_prio(_current, w);
+
+			k_spin_unlock(&queue->lock, k);
+			w->handler(w);
+			k = k_spin_lock(&queue->lock);
+
+			/* Remove from the active list only if it
+			 * wasn't resubmitted already
+			 */
+			if (w->thread == _current) {
+				sys_dlist_remove(&w->dlnode);
+				w->thread = NULL;
+			}
+		} else {
+			z_pend_curr(&queue->lock, k, &queue->waitq, K_FOREVER);
+			k = k_spin_lock(&queue->lock);
+		}
+	}
+}
+
+void k_p4wq_init(struct k_p4wq *queue)
+{
+	memset(queue, 0, sizeof(*queue));
+	z_waitq_init(&queue->waitq);
+	queue->queue.lessthan_fn = rb_lessthan;
+	sys_dlist_init(&queue->active);
+}
+
+void k_p4wq_add_thread(struct k_p4wq *queue, struct k_thread *thread,
+			k_thread_stack_t *stack,
+			size_t stack_size)
+{
+	k_thread_create(thread, stack, stack_size,
+			p4wq_loop, queue, NULL, NULL,
+			K_HIGHEST_THREAD_PRIO, 0, K_NO_WAIT);
+}
+
+static int static_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	Z_STRUCT_SECTION_FOREACH(k_p4wq_initparam, pp) {
+		k_p4wq_init(pp->queue);
+		for (int i = 0; i < pp->num; i++) {
+			uintptr_t ssz = K_THREAD_STACK_LEN(pp->stack_size);
+
+			k_p4wq_add_thread(pp->queue, &pp->threads[i],
+					  &pp->stacks[ssz * i],
+					  pp->stack_size);
+		}
+	}
+	return 0;
+}
+
+/* We spawn a bunch of high priority threads, use the "SMP" initlevel
+ * so they can initialize in parallel instead of serially on the main
+ * CPU.
+ */
+SYS_INIT(static_init, SMP, 99);
+
+void k_p4wq_submit(struct k_p4wq *queue, struct k_p4wq_work *item)
+{
+	k_spinlock_key_t k = k_spin_lock(&queue->lock);
+
+	/* Input is a delta time from now (to match
+	 * k_thread_deadline_set()), but we store and use the absolute
+	 * cycle count.
+	 */
+	item->deadline += k_cycle_get_32();
+
+	/* Resubmission from within handler?  Remove from active list */
+	if (item->thread == _current) {
+		sys_dlist_remove(&item->dlnode);
+		item->thread = NULL;
+	}
+	__ASSERT_NO_MSG(item->thread == NULL);
+
+	rb_insert(&queue->queue, &item->rbnode);
+
+	/* If there were other items already ahead of it in the queue,
+	 * then we don't need to revisit active thread state and can
+	 * return.
+	 */
+	if (rb_get_max(&queue->queue) != &item->rbnode) {
+		goto out;
+	}
+
+	/* Check the list of active (running or preempted) items, if
+	 * there are at least an "active target" of those that are
+	 * higher priority than the new item, then no one needs to be
+	 * preempted and we can return.
+	 */
+	struct k_p4wq_work *wi;
+	uint32_t n_beaten_by = 0, active_target = CONFIG_MP_NUM_CPUS;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(&queue->active, wi, dlnode) {
+		if (!item_lessthan(wi, item)) {
+			n_beaten_by++;
+		}
+	}
+
+	if (n_beaten_by >= active_target) {
+		goto out;
+	}
+
+	/* Grab a thread, set its priority and queue it.  If there are
+	 * no threads available to unpend, this is a soft runtime
+	 * error: we are breaking our promise about run order.
+	 * Complain.
+	 */
+	struct k_thread *th = z_unpend_first_thread(&queue->waitq);
+
+	if (th == NULL) {
+		LOG_WRN("Out of worker threads, priority guarantee violated");
+		goto out;
+	}
+
+	set_prio(th, item);
+	z_ready_thread(th);
+	z_reschedule(&queue->lock, k);
+	return;
+
+out:
+	k_spin_unlock(&queue->lock, k);
+}
+
+bool k_p4wq_cancel(struct k_p4wq *queue, struct k_p4wq_work *item)
+{
+	k_spinlock_key_t k = k_spin_lock(&queue->lock);
+	bool ret = rb_contains(&queue->queue, &item->rbnode);
+
+	if (ret) {
+		rb_remove(&queue->queue, &item->rbnode);
+	}
+
+	k_spin_unlock(&queue->lock, k);
+	return ret;
+}

--- a/tests/lib/p4workq/CMakeLists.txt
+++ b/tests/lib/p4workq/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(p4workq)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/p4workq/prj.conf
+++ b/tests/lib/p4workq/prj.conf
@@ -1,0 +1,7 @@
+CONFIG_TEST_RANDOM_GENERATOR=y
+CONFIG_ZTEST=y
+CONFIG_SCHED_DEADLINE=y
+
+# Test whiteboxes the wait_q and expects it to be a dlist
+CONFIG_WAITQ_SCALABLE=n
+CONFIG_WAITQ_DUMB=y

--- a/tests/lib/p4workq/src/main.c
+++ b/tests/lib/p4workq/src/main.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <random/rand32.h>
+#include <ztest.h>
+#include <sys/p4wq.h>
+
+#define NUM_THREADS (CONFIG_MP_NUM_CPUS * 2)
+#define MAX_ITEMS (NUM_THREADS * 8)
+#define MAX_EVENTS 1024
+
+K_P4WQ_DEFINE(wq, NUM_THREADS, 2048);
+
+static struct k_p4wq_work simple_item;
+static volatile int has_run;
+static volatile int run_count;
+static volatile int spin_release;
+
+struct test_item {
+	struct k_p4wq_work item;
+	bool active;
+	bool running;
+};
+
+static struct k_spinlock lock;
+static struct test_item items[MAX_ITEMS];
+static int active_items;
+static int event_count;
+static bool stress_complete;
+
+static void stress_handler(struct k_p4wq_work *item);
+
+static void stress_sub(struct test_item *item)
+{
+	/* Choose a random preemptible priority higher than the idle
+	 * priority, and a random deadline sometime within the next
+	 * 2ms
+	 */
+	item->item.priority = sys_rand32_get() % (K_LOWEST_THREAD_PRIO - 1);
+	item->item.deadline = sys_rand32_get() % k_ms_to_cyc_ceil32(2);
+	item->item.handler = stress_handler;
+	item->running = false;
+	item->active = true;
+	active_items++;
+	k_p4wq_submit(&wq, &item->item);
+}
+
+static void stress_handler(struct k_p4wq_work *item)
+{
+	k_spinlock_key_t k = k_spin_lock(&lock);
+	struct test_item *titem = CONTAINER_OF(item, struct test_item, item);
+
+	titem->running = true;
+
+	int curr_pri = k_thread_priority_get(k_current_get());
+
+	zassert_true(curr_pri == item->priority,
+		     "item ran with wrong priority: want %d have %d",
+		     item->priority, curr_pri);
+
+	if (stress_complete) {
+		k_spin_unlock(&lock, k);
+		return;
+	}
+
+	active_items--;
+
+	/* Pick 0-3 random item slots and submit them if they aren't
+	 * already.  Make sure we always have at least one active.
+	 */
+	int num_tries = sys_rand32_get() % 4;
+
+	for (int i = 0; (active_items == 0) || (i < num_tries); i++) {
+		int ii = sys_rand32_get() % MAX_ITEMS;
+
+		if (items[ii].item.thread == NULL &&
+		    &items[ii] != titem && !items[ii].active) {
+			stress_sub(&items[ii]);
+		}
+	}
+
+	if (event_count++ >= MAX_EVENTS) {
+		stress_complete = true;
+	}
+
+	titem->active = false;
+	k_spin_unlock(&lock, k);
+}
+
+/* Simple stress test designed to flood the queue and retires as many
+ * items of random priority as possible.  Note that because of the
+ * random priorities, this tends to produce a lot of "out of worker
+ * threads" warnings from the queue as we randomly try to submit more
+ * schedulable (i.e. high priority) items than there are threads to
+ * run them.
+ */
+static void test_stress(void)
+{
+	k_thread_priority_set(k_current_get(), -1);
+	memset(items, 0, sizeof(items));
+
+	stress_complete = false;
+	active_items = 1;
+	items[0].item.priority = -1;
+	stress_handler(&items[0].item);
+
+	while (!stress_complete) {
+		k_msleep(100);
+	}
+	k_msleep(10);
+
+	zassert_true(event_count > 1, "stress tests didn't run");
+}
+
+static int active_count(void)
+{
+	/* Whitebox: count the number of BLOCKED threads, because the
+	 * queue will unpend them synchronously in submit but the
+	 * "active" list is maintained from the thread itself against
+	 * which we can't synchronize easily.
+	 */
+	int count = 0;
+	sys_dnode_t *dummy;
+
+	SYS_DLIST_FOR_EACH_NODE(&wq.waitq.waitq, dummy) {
+		count++;
+	}
+
+	count = NUM_THREADS - count;
+	return count;
+}
+
+static void spin_handler(struct k_p4wq_work *item)
+{
+	while (!spin_release) {
+		k_busy_wait(10);
+	}
+}
+
+/* Selects and adds a new item to the queue, returns an indication of
+ * whether the item changed the number of active threads.  Does not
+ * return the item itself, not needed.
+ */
+static bool add_new_item(int pri)
+{
+	static int num_items;
+	int n0 = active_count();
+	struct k_p4wq_work *item = &items[num_items++].item;
+
+	__ASSERT_NO_MSG(num_items < MAX_ITEMS);
+	item->priority = pri;
+	item->deadline = k_us_to_cyc_ceil32(100);
+	item->handler = spin_handler;
+	k_p4wq_submit(&wq, item);
+	k_usleep(1);
+
+	return (active_count() != n0);
+}
+
+/* Whitebox test of thread state: make sure that as we add threads
+ * they get scheduled as needed, up to NUM_CPUS (at which point the
+ * queue should STOP scheduling new threads).  Then add more at higher
+ * priorities and verify that they get scheduled too (to allow
+ * preemption), up to the maximum number of threads that we created.
+ */
+static void test_fill_queue(void)
+{
+	int p0 = 4;
+
+	/* The work item priorities are 0-4, this thread should be -1
+	 * so it's guaranteed not to be preempted
+	 */
+	k_thread_priority_set(k_current_get(), -1);
+
+	/* Spawn enough threads so the queue saturates the CPU count
+	 * (note they have lower priority than the current thread so
+	 * we can be sure to run).  They should all be made active
+	 * when added.
+	 */
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		zassert_true(add_new_item(p0), "thread should be active");
+	}
+
+	/* Add one more, it should NOT be scheduled */
+	zassert_false(add_new_item(p0), "thread should not be active");
+
+	/* Now add more at higher priorities, they should get
+	 * scheduled (so that they can preempt the running ones) until
+	 * we run out of threads.
+	 */
+	for (int pri = p0 - 1; pri >= p0 - 4; pri++) {
+		for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+			bool active = add_new_item(pri);
+
+			if (!active) {
+				zassert_equal(active_count(), NUM_THREADS,
+					      "thread max not reached");
+				goto done;
+			}
+		}
+	}
+
+ done:
+	/* Clean up and wait for the threads to be idle */
+	spin_release = 1;
+	do {
+		k_msleep(1);
+	} while (active_count() != 0);
+	k_msleep(1);
+}
+
+static void resubmit_handler(struct k_p4wq_work *item)
+{
+	if (run_count++ == 0) {
+		k_p4wq_submit(&wq, item);
+	} else {
+		/* While we're here: validate that it doesn't show
+		 * itself as "live" while executing
+		 */
+		zassert_false(k_p4wq_cancel(&wq, item),
+			      "item should not be cancelable while running");
+	}
+}
+
+/* Validate item can be resubmitted from its own handler */
+static void test_resubmit(void)
+{
+	run_count = 0;
+	simple_item = (struct k_p4wq_work){};
+	simple_item.handler = resubmit_handler;
+	k_p4wq_submit(&wq, &simple_item);
+
+	k_msleep(100);
+	zassert_equal(run_count, 2, "Wrong run count: %d\n", run_count);
+}
+
+void simple_handler(struct k_p4wq_work *work)
+{
+	zassert_equal(work, &simple_item, "bad work item pointer");
+	zassert_false(has_run, "ran twice");
+	has_run = true;
+}
+
+/* Simple test that submited items run, and at the correct priority */
+static void test_p4wq_simple(void)
+{
+	int prio = 2;
+
+	k_thread_priority_set(k_current_get(), prio);
+
+	/* Lower priority item, should not run until we yield */
+	simple_item.priority = prio + 1;
+	simple_item.deadline = 0;
+	simple_item.handler = simple_handler;
+
+	has_run = false;
+	k_p4wq_submit(&wq, &simple_item);
+	zassert_false(has_run, "ran too early");
+
+	k_sleep(K_TICKS(1));
+	zassert_true(has_run, "low-priority item didn't run");
+
+	/* Higher priority, should preempt us */
+	has_run = false;
+	simple_item.priority = prio - 1;
+	k_p4wq_submit(&wq, &simple_item);
+	zassert_true(has_run, "high-priority item didn't run");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(lib_p4wq_test,
+			 ztest_1cpu_unit_test(test_p4wq_simple),
+			 ztest_unit_test(test_resubmit),
+			 ztest_unit_test(test_fill_queue),
+			 ztest_unit_test(test_stress));
+
+	ztest_run_test_suite(lib_p4wq_test);
+}

--- a/tests/lib/p4workq/testcase.yaml
+++ b/tests/lib/p4workq/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  lib.p4wq:
+      tags: p4wq


### PR DESCRIPTION
[This is a gadget written specifically for the SOF work.  General applications probably will never care about it, but it's likely to be useful for CPU-bound real time apps on SMP systems like audio DSPs.  Despite the name and the general operation of the API, it's very much **not** expected to be a replacement for the existing k_work_queue utility.]

It should be ready to go, the stress test is pleasingly exhaustive. And it's really not that complicated.  It does need some proper documentation written beyond the doxygen stuff in the header though.

And obviously I'd consider the API to be in flux until the SOF layers that are going to want to use this get ported over and we discover the warts.]

lib/os: P4 Work Queue: Pooled Parallel Preemptible Priority-based

This adds a somewhat special purpose IPC mechanism.  It's intended for
applications which have a "work queue" like architecture of discrete
callback items, but which need the ability to schedule those items
independently in separate threads across multiple CPUs.  So P4 Work
items:

1. Can run at any Zephyr scheduler priority and with any deadline
   (this feature assumes EDF scheduling is enabled)

2. Can be submitted at any time and from any context, including being
   resubmitted from within their own handler.

3. Will preempt any lower priority work as soon as they are runnable,
   according to the standard rules of Zephyr priority scheduling.

4. Run from a pool of worker threads that can be allocated efficiently
   (i.e. you need as many as the number of CPUs plus the number of
   preempted in-progress items, but no more).
