### PR TITLE
Bluetooth: Mesh: Fix rpl clear in rx_reset

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -179,6 +179,8 @@ void bt_mesh_reset(void)
 	bt_mesh_rx_reset();
 	bt_mesh_tx_reset();
 
+	bt_mesh_rpl_clear();
+
 	bt_mesh_net_loopback_clear(BT_MESH_KEY_ANY);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1753,8 +1753,6 @@ void bt_mesh_rx_reset(void)
 	for (i = 0; i < ARRAY_SIZE(seg_rx); i++) {
 		seg_rx_reset(&seg_rx[i], true);
 	}
-
-	bt_mesh_rpl_clear();
 }
 
 void bt_mesh_tx_reset(void)


### PR DESCRIPTION
`bt_mesh_rx_reset` should only process segment messages,
not clear the RPL, which will cause potential security problems,
because this function will also be called when terminate friendship.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>