### PR TITLE
Bluetooth: Mesh: Fix build warning with Warray-bounds

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -50,6 +50,7 @@ int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[64]))
 {
 	int err;
 	static struct bt_pub_key_cb pub_key_cb;
+	const size_t offset = offsetof(struct bt_mesh_prov_link, dhkey);
 
 	pub_key_cb.func = func ? func : pub_key_ready;
 
@@ -58,8 +59,8 @@ int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[64]))
 		bt_mesh_attention(NULL, 0);
 	}
 
-	memset(&bt_mesh_prov_link.dhkey, 0,
-	       sizeof(bt_mesh_prov_link) - offsetof(struct bt_mesh_prov_link, dhkey));
+	(void)memset((uint8_t *)&bt_mesh_prov_link + offset, 0,
+		     sizeof(bt_mesh_prov_link) - offset);
 
 	err = bt_pub_key_gen(&pub_key_cb);
 	if (err) {


### PR DESCRIPTION
../zephyrNew/subsys/bluetooth/mesh/prov.c: In function
'bt_mesh_prov_reset_state': ../zephyrNew/subsys/bluetooth/mesh/prov.c:61:2:
warning: '__builtin_memset' offset [52, 292] from the object at
'bt_mesh_prov_link' is out of the bounds of referenced subobject 'dhkey'
with type 'uint8_t[32]' {aka 'unsigned char[32]'} at offset 19 [-Warray-bounds]
61 | memset(&bt_mesh_prov_link.dhkey, 0,

Fixes: #29634

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>