### PR TITLE
boards: shields: ssd1306_128x64_spi: fix GPIO usage

### DIFF
--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -21,6 +21,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
-		data_cmd-gpios = <&arduino_header 16 0>;
+		data_cmd-gpios = <&arduino_header 15 0>;
+		/* reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; */
 	};
 };


### PR DESCRIPTION
Move the data/command GPIO from Arduino header 16 (D10), which collides with Arduino SPI SS, to Arduino header 15 (D9).

Add commented example for specifying a reset GPIO on Arduino header 14 (D8).

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>