### PR TITLE
samples: display: cfb_custom_font: add support for ssd1306fb

### DIFF
--- a/samples/display/cfb_custom_font/src/main.c
+++ b/samples/display/cfb_custom_font/src/main.c
@@ -11,8 +11,10 @@
 
 #include "cfb_font_dice.h"
 
-#if defined(CONFIG_SSD16XX)
-#define DISPLAY_DRIVER "SSD16XX"
+#if defined(CONFIG_SSD1306)
+#define DISPLAY_NAME DT_LABEL(DT_INST(0, solomon_ssd1306fb))
+#elif defined(CONFIG_SSD16XX)
+#define DISPLAY_NAME DT_LABEL(DT_INST(0, solomon_ssd16xxfb))
 #else
 #error Unsupported board
 #endif
@@ -23,7 +25,7 @@ void main(void)
 {
 	int err;
 
-	display = device_get_binding(DISPLAY_DRIVER);
+	display = device_get_binding(DISPLAY_NAME);
 	if (!display) {
 		printk("Could not get device binding for display device\n");
 	}


### PR DESCRIPTION
Add support for the Solomon SSD1306FB device to the CFB custom font sample.

Convert sample to use DT_LABEL() for obtaining the device label instead of hardcoding it.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>