### PR TITLE
Fixed linker error in drivers/ipm/ipm_handlers.c, caused by typo.

### DIFF
--- a/drivers/ipm/ipm_handlers.c
+++ b/drivers/ipm/ipm_handlers.c
@@ -21,7 +21,7 @@ static inline int z_vrfy_ipm_send(const struct device *dev, int wait,
 static inline int z_vrfy_ipm_max_data_size_get(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_IPM(dev, max_data_size_get));
-	return z_impl_max_data_size_get((const struct device *)dev);
+	return z_impl_ipm_max_data_size_get((const struct device *)dev);
 }
 #include <syscalls/ipm_max_data_size_get_mrsh.c>
 


### PR DESCRIPTION
The error shows when having `CONFIG_BT=y` and `CONFIG_USERSPACE=y`.

`/home/humanentity/zephyr/drivers/ipm/ipm_handlers.c:23: undefined reference to 'z_impl_max_data_size_get'`

It is easily reproduced by adding
```C
CONFIG_USERSPACE=y
```
to `samples/bluetooth/peripheral/prj.conf` and building it, e.g.
```
west build -p auto -b nrf5340pdk_nrf5340_cpuapp samples/bluetooth/peripheral
```

Signed-off-by: Peter Andersson <pelleplutt1976@gmail.com>