### PR TITLE
devicetree-based device definitions and dependency representations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,19 @@ if(CONFIG_GEN_ISR_TABLES)
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)
 endif()
 
+# dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+# gen_handles.py
+add_custom_command(
+  OUTPUT dev_handles.c
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/gen_handles.py
+  --output-source dev_handles.c
+  --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+  )
+set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+
 if(CONFIG_CODE_DATA_RELOCATION)
   # @Intent: Linker script to relocate .text, data and .bss sections
   toolchain_ld_relocation()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -503,6 +503,7 @@
 /scripts/pylib/twister/expr_parser.py     @nashif
 /scripts/schemas/twister/                 @nashif
 /scripts/gen_app_partitions.py            @andrewboie
+/scripts/gen_handles.py                   @pabigot
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif

--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -151,9 +151,16 @@ is skipped.
 Final binary
 ============
 
-In some configurations, the binary from the previous stage is
-incomplete, with empty and/or placeholder sections that must be filled
-in by, essentially, reflection. When :ref:`usermode_api` is enabled:
+The binary from the prevoius tage is incomplete, with empty and/or
+placeholder sections that must be filled in by, essentially, reflection.
+
+Device dependencies
+   The *gen_handles.py* script scans the first-pass binary to determine
+   relationships between devices that were recorded from devicetree data,
+   and replaces the encoded relationships with values that are optimized to
+   locate the devices actually present in the application.
+
+When :ref:`usermode_api` is enabled:
 
 Kernel object hashing
    The *gen_kobject_list.py* scans the *ELF DWARF*
@@ -199,6 +206,15 @@ The following is a detailed description of the scripts used during the build pro
 ========================================
 
 .. include:: ../../../scripts/gen_syscalls.py
+   :start-after: """
+   :end-before: """
+
+.. _gen_handles.py:
+
+:zephyr_file:`scripts/gen_handles.py`
+==========================================
+
+.. include:: ../../../scripts/gen_handles.py
    :start-after: """
    :end-before: """
 

--- a/dts/bindings/test/vnd,gpio-expander-common.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-common.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test GPIO node
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    "#gpio-cells":
+      const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/test/vnd,gpio-expander-i2c.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-i2c.yaml
@@ -5,4 +5,4 @@ description: GPIO expander via I2C
 
 compatible: "vnd,gpio-expander"
 
-include: i2c-device.yaml
+include: ["vnd,gpio-expander-common.yaml", i2c-device.yaml]

--- a/dts/bindings/test/vnd,gpio-expander-spi.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-spi.yaml
@@ -5,4 +5,4 @@ description: GPIO expander via SPI
 
 compatible: "vnd,gpio-expander"
 
-include: spi-device.yaml
+include: ["vnd,gpio-expander-common.yaml", spi-device.yaml]

--- a/include/device.h
+++ b/include/device.h
@@ -21,10 +21,36 @@
 
 #include <init.h>
 #include <sys/device_mmio.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @brief Type used to represent devices and functions.
+ *
+ * The extreme values and zero have special significance.  Negative
+ * values identify functionality that does not correspond to a Zephyr
+ * device, such as the system clock or a SYS_INIT() function.
+ */
+typedef int16_t device_handle_t;
+
+/** @brief Flag value used in lists of device handles to separate
+ * distinct groups.
+ *
+ * This is the minimum value for the device_handle_t type.
+ */
+#define DEVICE_HANDLE_SEP INT16_MIN
+
+/** @brief Flag value used in lists of device handles to indicate the
+ * end of the list.
+ *
+ * This is the maximum value for the device_handle_t type.
+ */
+#define DEVICE_HANDLE_ENDS INT16_MAX
+
+/** @brief Flag value used to identify an unknown device. */
+#define DEVICE_HANDLE_NULL 0
 
 #define Z_DEVICE_MAX_NAME_LEN	48
 
@@ -167,11 +193,13 @@ extern "C" {
  * used by the driver. Can be NULL.
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
-			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
+			 data_ptr, cfg_ptr, level, prio,		\
+			 api_ptr, ...)					\
 	Z_DEVICE_DEFINE(node_id, node_id,				\
 			DT_PROP_OR(node_id, label, NULL), init_fn,	\
 			pm_control_fn,					\
-			data_ptr, cfg_ptr, level, prio, api_ptr)
+			data_ptr, cfg_ptr, level, prio,			\
+			api_ptr, __VA_ARGS__)
 
 /**
  * @def DEVICE_DT_INST_DEFINE
@@ -287,7 +315,7 @@ struct device_pm {
 };
 
 /**
- * @brief Runtime device structure (in memory) per driver instance
+ * @brief Immutable device structure per driver instance
  */
 struct device {
 	/** Name of the device instance */
@@ -298,6 +326,14 @@ struct device {
 	const void *api;
 	/** Address of the device instance private data */
 	void * const data;
+	/** optional pointer to handles associated with the device.
+	 *
+	 * This encodes a sequence of sets of device handles that have
+	 * some relationship to this node.  The individual sets are
+	 * extracted with dedicated API, such as
+	 * device_get_requires_handles().
+	 */
+	const device_handle_t *const handles;
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
 	int (*device_pm_control)(const struct device *dev, uint32_t command,
@@ -306,6 +342,78 @@ struct device {
 	struct device_pm * const pm;
 #endif
 };
+
+/**
+ * @brief Get the handle for a given device
+ *
+ * @param dev the device for which a handle is desired.
+ *
+ * @return the handle for the device.
+ */
+static inline device_handle_t
+device_handle_get(const struct device *dev)
+{
+	extern const struct device __device_start[];
+
+	/* TODO: If/when devices can be constructed that are not part of the
+	 * fixed we'll need another solution.
+	 */
+	return (device_handle_t)(dev - __device_start);
+}
+
+/**
+ * @brief Get the device corresponding to a handle.
+ *
+ * @param dev_handle the device handle
+ *
+ * @return the device that has that handle, or a null pointer if @p
+ * dev_handle does not identify a device.
+ */
+static inline const struct device *
+device_from_handle(device_handle_t dev_handle)
+{
+	extern const struct device __device_start[];
+	extern const struct device __device_end[];
+	const struct device *dev = NULL;
+	size_t numdev = __device_end - __device_start;
+
+	if (dev_handle < numdev) {
+		dev = &__device_start[dev_handle];
+	}
+
+	return dev;
+}
+
+/**
+ * @brief Get the set of devices on which a given device depends
+ *
+ * @param dev the device for which dependencies are desired.
+ *
+ * @param count pointer to a place to store the number of devices provided at
+ * the returned pointer.  The value is not set if the call returns a null
+ * pointer.  The value may be set to zero.
+ *
+ * @return a pointer to a sequence of @p *count device handles, or a null
+ * pointer if @p dh does not provide dependency information.
+ */
+static inline const device_handle_t *
+device_get_requires_handles(const struct device *dev,
+			    size_t *count)
+{
+	const device_handle_t *rv = dev->handles;
+
+	if (rv != NULL) {
+		size_t i = 0;
+
+		while ((rv[i] != DEVICE_HANDLE_ENDS)
+		       && (rv[i] != DEVICE_HANDLE_SEP)) {
+			++i;
+		}
+		*count = i;
+	}
+
+	return rv;
+}
 
 /**
  * @brief Retrieve the device structure for a driver by name
@@ -688,10 +796,50 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
  * @}
  */
 
-#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
-			data_ptr, cfg_ptr, level, prio, api_ptr)	\
+/** Synthesize the name of the object that holds device ordinal and
+ * dependency data.  If the object doesn't come from a devicetree
+ * node, use dev_name.
+ */
+#define Z_DEVICE_HANDLE_NAME(node_id, dev_name)				\
+	_CONCAT(__devicehdl_,						\
+		COND_CODE_1(DT_NODE_EXISTS(node_id),			\
+			    (node_id),					\
+			    (dev_name)))
+
+#define Z_DEVICE_EXTRA_HANDLES(...)				\
+	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
+
+/* Construct objects that are referenced from struct device.  These
+ * include power management and dependency handles.
+ */
+#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
 	Z_DEVICE_DEFINE_PM(dev_name)					\
-	COND_CODE_1(DT_NODE_EXISTS(dev_name), (), (static))		\
+	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
+
+#define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
+	static const device_handle_t Z_DEVICE_HANDLE_NAME(node_id,dev_name)[] = { \
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
+			DT_DEP_ORD(node_id),				\
+			DT_REQUIRES_DEP_ORDS(node_id)			\
+		),(							\
+			DEVICE_HANDLE_NULL,				\
+		))							\
+			DEVICE_HANDLE_SEP,				\
+			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
+			DEVICE_HANDLE_ENDS,				\
+		};
+
+#define Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)		\
+		.handles = Z_DEVICE_HANDLE_NAME(node_id, dev_name),	\
+		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)
+
+/* Like DEVICE_DEFINE but takes a node_id AND a dev_name, and trailing
+ * dependency handles that come from outside devicetree.
+ */
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
+			data_ptr, cfg_ptr, level, prio, api_ptr, ...)	\
+	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
 	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
@@ -699,7 +847,7 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\
 		.data = (data_ptr),					\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
+		Z_DEVICE_DEFINE_INIT(node_id, dev_name, pm_control_fn)	\
 	};								\
 	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
 			    (&_CONCAT(__device_, dev_name)), level, prio)

--- a/include/device.h
+++ b/include/device.h
@@ -817,11 +817,16 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
 
 #define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
-	static const device_handle_t Z_DEVICE_HANDLE_NAME(node_id,dev_name)[] = { \
+	extern const device_handle_t					\
+		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
+	const device_handle_t						\
+	__attribute__((__weak__,					\
+		       __section__(".__device_handles_pass1")))		\
+	Z_DEVICE_HANDLE_NAME(node_id, dev_name)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
 			DT_REQUIRES_DEP_ORDS(node_id)			\
-		),(							\
+		), (							\
 			DEVICE_HANDLE_NULL,				\
 		))							\
 			DEVICE_HANDLE_SEP,				\

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -37,6 +37,17 @@
 	}
 	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 
+	SECTION_DATA_PROLOGUE(device_handles,,)
+	{
+		__device_handles_start = .;
+#ifdef LINKER_PASS2
+		KEEP(*(SORT(.__device_handles_pass2)));
+#else /* LINKER_PASS2 */
+		KEEP(*(SORT(.__device_handles_pass1)));
+#endif /* LINKER_PASS2 */
+		__device_handles_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 #ifdef CONFIG_CPLUSPLUS
 	SECTION_PROLOGUE(_CTOR_SECTION_NAME,,)
 	{

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -86,5 +86,9 @@ GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 /* size of the device structure. Used by linker scripts */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(const struct device));
 
+/* member offsets in the device structure. Used in image post-processing */
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,
+		 offsetof(struct device, handles));
+
 /* LCOV_EXCL_STOP */
 #endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_ */

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2020 Nordic Semiconductor NA
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Translate generic handles into ones optimized for the application.
+
+Immutable device data includes information about dependencies,
+e.g. that a particular sensor is controlled through a specific I2C bus
+and that it signals event on a pin on a specific GPIO controller.
+This information is encoded in the first-pass binary using identifiers
+derived from the devicetree.  This script extracts those identifiers
+and replaces them with ones optimized for use with the devices
+actually present.
+
+For example the sensor might have a first-pass handle defined by its
+devicetree ordinal 52, with the I2C driver having ordinal 24 and the
+GPIO controller ordinal 14.  The runtime ordinal is the index of the
+corresponding device in the static devicetree array, which might be 6,
+5, and 3, respectively.
+
+The output is a C source file that provides alternative definitions
+for the array contents referenced from the immutable device objects.
+In the final link these definitions supersede the ones in the
+driver-specific object file.
+"""
+
+import sys
+import argparse
+import os
+import struct
+import pickle
+from distutils.version import LooseVersion
+
+import elftools
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+import elftools.elf.enums
+
+if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
+
+scr = os.path.basename(sys.argv[0])
+
+def debug(text):
+    if not args.verbose:
+        return
+    sys.stdout.write(scr + ": " + text + "\n")
+
+def parse_args():
+    global args
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-k", "--kernel", required=True,
+                        help="Input zephyr ELF binary")
+    parser.add_argument("-o", "--output-source", required=True,
+            help="Output source file")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print extra debugging information")
+    args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
+
+
+def symbol_data(elf, sym):
+    addr = sym.entry.st_value
+    len = sym.entry.st_size
+    for section in elf.iter_sections():
+        start = section['sh_addr']
+        end = start + section['sh_size']
+
+        if (start <= addr) and (addr + len) <= end:
+            offset = addr - section['sh_addr']
+            return bytes(section.data()[offset:offset + len])
+
+def symbol_handle_data(elf, sym):
+    data = symbol_data(elf, sym)
+    if data:
+        format = "<" if elf.little_endian else ">"
+        format += "%uh" % (len(data) / 2)
+        return struct.unpack(format, data)
+
+# These match the corresponding constants in <device.h>
+DEVICE_HANDLE_SEP = -32768
+DEVICE_HANDLE_ENDS = 32767
+def handle_name(hdl):
+    if hdl == DEVICE_HANDLE_SEP:
+        return "DEVICE_HANDLE_SEP"
+    if hdl == DEVICE_HANDLE_ENDS:
+        return "DEVICE_HANDLE_ENDS"
+    if hdl == 0:
+        return "DEVICE_HANDLE_NULL"
+    return str(int(hdl))
+
+class Device:
+    """
+    Represents information about a device object and its references to other objects.
+    """
+    def __init__(self, elf, ld_constants, sym, addr):
+        self.elf = elf
+        self.ld_constants = ld_constants
+        self.sym = sym
+        self.addr = addr
+        # Point to the handles instance associated with the device;
+        # assigned by correlating the device struct handles pointer
+        # value with the addr of a Handles instance.
+        self.__handles = None
+
+    @property
+    def obj_handles(self):
+        """
+        Returns the value from the device struct handles field, pointing to the
+        array of handles for devices this device depends on.
+        """
+        if self.__handles is None:
+            data = symbol_data(self.elf, self.sym)
+            format = "<" if self.elf.little_endian else ">"
+            if self.elf.elfclass == 32:
+                format += "I"
+                size = 4
+            else:
+                format += "Q"
+                size = 8
+            offset = self.ld_constants["DEVICE_STRUCT_HANDLES_OFFSET"]
+            self.__handles = struct.unpack(format, data[offset:offset + size])[0]
+        return self.__handles
+
+class Handles:
+    def __init__(self, sym, addr, handles, node):
+        self.sym = sym
+        self.addr = addr
+        self.handles = handles
+        self.node = node
+        self.dep_ord = None
+        self.dev_deps = None
+        self.ext_deps = None
+
+def main():
+    parse_args()
+
+    assert args.kernel, "--kernel ELF required to extract data"
+    elf = ELFFile(open(args.kernel, "rb"))
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
+
+    devices = []
+    handles = []
+    # Leading _ are stripped from the stored constant key
+    want_constants = set(["__device_start",
+                          "_DEVICE_STRUCT_SIZEOF",
+                          "_DEVICE_STRUCT_HANDLES_OFFSET"])
+    ld_constants = dict()
+
+    for section in elf.iter_sections():
+        if isinstance(section, SymbolTableSection):
+            for sym in section.iter_symbols():
+                if sym.name in want_constants:
+                    ld_constants[sym.name.lstrip("_")] = sym.entry.st_value
+                    continue
+                if sym.entry.st_info.type != 'STT_OBJECT':
+                    continue
+                if sym.name.startswith("__device"):
+                    addr = sym.entry.st_value
+                    if sym.name.startswith("__device_"):
+                        devices.append(Device(elf, ld_constants, sym, addr))
+                        debug("device %s" % (sym.name,))
+                    elif sym.name.startswith("__devicehdl_"):
+                        hdls = symbol_handle_data(elf, sym)
+
+                        # The first element of the hdls array is the dependency
+                        # ordinal of the device, which identifies the devicetree
+                        # node.
+                        node = edt.dep_ord2node[hdls[0]] if (hdls and hdls[0] != 0) else None
+                        handles.append(Handles(sym, addr, hdls, node))
+                        debug("handles %s %d %s" % (sym.name, hdls[0] if hdls else -1, node))
+
+    assert len(want_constants) == len(ld_constants), "linker map data incomplete"
+
+    devices = sorted(devices, key = lambda k: k.sym.entry.st_value)
+
+    device_start_addr = ld_constants["device_start"]
+    device_size = 0
+
+    assert len(devices) == len(handles), 'mismatch devices and handles'
+
+    used_nodes = set()
+    for handle in handles:
+        for device in devices:
+            if handle.addr == device.obj_handles:
+                handle.device = device
+                break
+        device = handle.device
+        assert device, 'no device for %s' % (handle.sym.name,)
+
+        device.handle = handle
+
+        if device_size == 0:
+            device_size = device.sym.entry.st_size
+
+        # Where in the sequence of devices this particular node occurs
+        device.dev_ordinal = (device.sym.entry.st_value - device_start_addr) / device_size
+        debug("%s dev ordinal %d" % (device.sym.name, device.dev_ordinal))
+
+        n = handle.node
+        if n is not None:
+            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_ordinal, ' ; '.join(str(_) for _ in handle.handles)))
+            used_nodes.add(n)
+            n.__device = device
+        else:
+            debug("orphan %d" % (device.dev_ordinal,))
+        hv = handle.handles
+        hvi = 1
+        handle.dev_deps = []
+        handle.ext_deps = []
+        deps = handle.dev_deps
+        while True:
+            h = hv[hvi]
+            if h == DEVICE_HANDLE_ENDS:
+                break
+            if h == DEVICE_HANDLE_SEP:
+                deps = handle.ext_deps
+            else:
+                deps.append(h)
+                n = edt
+            hvi += 1
+
+    # Compute the dependency graph induced from the full graph restricted to the
+    # the nodes that exist in the application.  Note that the edges in the
+    # induced graph correspond to paths in the full graph.
+    root = edt.dep_ord2node[0]
+    assert root not in used_nodes
+
+    for sn in used_nodes:
+        # Where we're storing the final set of nodes: these are all used
+        sn.__depends = set()
+
+        deps = set(sn.depends_on)
+        debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
+        while len(deps) > 0:
+            dn = deps.pop()
+            if dn in used_nodes:
+                # this is used
+                sn.__depends.add(dn)
+            elif dn != root:
+                # forward the dependency up one level
+                for ddn in dn.depends_on:
+                    deps.add(ddn)
+        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+
+    with open(args.output_source, "w") as fp:
+        fp.write('#include <device.h>\n')
+
+        for dev in devices:
+            hs = dev.handle
+            assert hs, "no hs for %s" % (dev.sym.name,)
+            dep_paths = []
+            ext_paths = []
+            hdls = []
+
+            sn = hs.node
+            if sn:
+                hdls.extend(dn.__device.dev_ordinal for dn in sn.__depends)
+                for dn in sn.depends_on:
+                    if dn in sn.__depends:
+                        dep_paths.append(dn.path)
+                    else:
+                        dep_paths.append('(%s)' % dn.path)
+            if len(hs.ext_deps) > 0:
+                # TODO: map these to something smaller?
+                ext_paths.extend(map(str, hs.ext_deps))
+                hdls.append(DEVICE_HANDLE_SEP)
+                hdls.extend(hs.ext_deps)
+
+            # When CONFIG_USERSPACE is enabled the pre-built elf is
+            # also used to get hashes that identify kernel objects by
+            # address.  We can't allow the size of any object in the
+            # final elf to change.
+            while len(hdls) < len(hs.handles):
+                hdls.append(DEVICE_HANDLE_ENDS)
+            assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)
+
+            lines = [
+                '',
+                '/* %d : %s:' % (dev.dev_ordinal, (sn and sn.path) or "sysinit"),
+            ]
+
+            if len(dep_paths) > 0:
+                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
+            if len(ext_paths) > 0:
+                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
+
+            lines.extend([
+                ' */',
+                'const device_handle_t __attribute__((__section__(".__device_handles_pass2")))',
+                '%s[] = { %s };' % (hs.sym.name, ', '.join([handle_name(_h) for _h in hdls])),
+                '',
+            ])
+
+            fp.write('\n'.join(lines))
+
+if __name__ == "__main__":
+    main()

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -8,9 +8,9 @@
 #include <shell/shell.h>
 #include <init.h>
 #include <string.h>
+#include <stdio.h>
 #include <device.h>
 
-extern const struct device __device_start[];
 extern const struct device __device_PRE_KERNEL_1_start[];
 extern const struct device __device_PRE_KERNEL_2_start[];
 extern const struct device __device_POST_KERNEL_start[];
@@ -82,33 +82,62 @@ static int cmd_device_levels(const struct shell *shell,
 	return 0;
 }
 
+static const char *get_device_name(const struct device *dev,
+				   char *buf,
+				   size_t len)
+{
+	const char *name = dev->name;
+
+	if ((name == NULL) || (name[0] == 0)) {
+		snprintf(buf, len, "[%p]", dev);
+		name = buf;
+	}
+
+	return name;
+}
+
 static int cmd_device_list(const struct shell *shell,
 			      size_t argc, char **argv)
 {
+	const struct device *devlist;
+	size_t devcnt = z_device_get_all_static(&devlist);
+	const struct device *devlist_end = devlist + devcnt;
 	const struct device *dev;
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
 
-	for (dev = __device_start; dev != __device_end; dev++) {
+	for (dev = devlist; dev < devlist_end; dev++) {
+		char buf[20];
+		const char *name = get_device_name(dev, buf, sizeof(buf));
+		const char *state = "READY";
+		size_t nhdls = 0;
+		const device_handle_t *hdls =
+			device_get_requires_handles(dev, &nhdls);
+
+		shell_fprintf(shell, SHELL_NORMAL, "- %s", name);
 		if (!device_is_ready(dev)) {
-			continue;
-		}
-
-		shell_fprintf(shell, SHELL_NORMAL, "- %s", dev->name);
-
+			state = "DISABLED";
+		} else {
 #ifdef CONFIG_PM_DEVICE
-		uint32_t state = DEVICE_PM_ACTIVE_STATE;
-		int err;
+			uint32_t st = DEVICE_PM_ACTIVE_STATE;
+			int err = device_get_power_state(dev, &st);
 
-		err = device_get_power_state(dev, &state);
-		if (!err) {
-			shell_fprintf(shell, SHELL_NORMAL, " (%s)",
-				      device_pm_state_str(state));
-		}
+			if (!err) {
+				state = device_pm_state_str(st);
+			}
 #endif /* CONFIG_PM_DEVICE */
-		shell_fprintf(shell, SHELL_NORMAL, "\n");
+		}
+
+		shell_fprintf(shell, SHELL_NORMAL, " (%s)\n", state);
+		for (size_t di = 0; di < nhdls; ++di) {
+			device_handle_t dh = hdls[di];
+			const struct device *rdp = device_from_handle(dh);
+
+			shell_fprintf(shell, SHELL_NORMAL, "  requires: %s\n",
+				      get_device_name(rdp, buf, sizeof(buf)));
+		}
 	}
 
 	return 0;

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -155,6 +155,8 @@
 			};
 
 			gpio@11 {
+				gpio-controller;
+				#gpio-cells = <2>;
 				compatible = "vnd,gpio-expander";
 				reg = <0x11>;
 				label = "TEST_EXPANDER_I2C";
@@ -207,6 +209,8 @@
 			};
 
 			gpio@2 {
+				gpio-controller;
+				#gpio-cells = <2>;
 				compatible = "vnd,gpio-expander";
 				reg = <2>;
 				label = "TEST_EXPANDER_SPI";

--- a/tests/lib/devicetree/devices/CMakeLists.txt
+++ b/tests/lib/devicetree/devices/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(devicetree_devices)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/devicetree/devices/README
+++ b/tests/lib/devicetree/devices/README
@@ -1,0 +1,1 @@
+Test cases for the device API devicetree data.

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for testing the devicetree.h API.
+ *
+ * Names in this file should be chosen in a way that won't conflict
+ * with real-world devicetree nodes, to allow these tests to run on
+ * (and be extended to test) real hardware.
+ */
+
+/ {
+	test {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		test_gpio_0: gpio@0 {
+			gpio-controller;
+			#gpio-cells = <0x2>;
+			compatible = "vnd,gpio";
+			status = "okay";
+			reg = <0x0 0x1000>;
+			label = "TEST_GPIO_0";
+		};
+
+		test_i2c: i2c@11112222 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			status = "okay";
+			reg = <0x11112222 0x1000>;
+			clock-frequency = <100000>;
+			label = "TEST_I2C_CTLR";
+
+			test_dev_a: test-i2c-dev@10 {
+				compatible = "vnd,i2c-device";
+				status = "okay";
+				reg = <0x10>;
+				supply-gpios = <&test_gpio_0 1 0>;
+				label = "TEST_I2C_DEV_10";
+			};
+
+			test_gpiox: test-i2c-dev@11 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				compatible = "vnd,gpio-expander";
+				status = "okay";
+				reg = <0x11>;
+				label = "TEST_I2C_GPIO";
+			};
+
+			test_dev_b: test-i2c-dev@12 {
+				compatible = "vnd,i2c-device";
+				status = "okay";
+				reg = <0x12>;
+				supply-gpios = <&test_gpiox 2 0>;
+				label = "TEST_I2C_DEV_12";
+			};
+		};
+	};
+};

--- a/tests/lib/devicetree/devices/prj.conf
+++ b/tests/lib/devicetree/devices/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <devicetree.h>
+#include <device.h>
+#include <drivers/gpio.h>
+
+#define GPIO DT_NODELABEL(test_gpio_0)
+#define I2C DT_NODELABEL(test_i2c)
+#define DEVA DT_NODELABEL(test_dev_a)
+#define GPIOX DT_NODELABEL(test_gpiox)
+#define DEVB DT_NODELABEL(test_dev_b)
+
+static const struct device *devlist;
+static const struct device *devlist_end;
+
+static device_handle_t init_order[10];
+
+static int dev_init(const struct device *dev)
+{
+	static uint8_t init_idx;
+
+	__ASSERT_NO_MSG(init_idx < ARRAY_SIZE(init_order));
+	init_order[init_idx++] = device_handle_get(dev);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(GPIO, dev_init, device_pm_control_nop,
+		 NULL, NULL, PRE_KERNEL_1, 90, NULL);
+DEVICE_DT_DEFINE(I2C, dev_init, device_pm_control_nop,
+		 NULL, NULL, POST_KERNEL, 10, NULL);
+DEVICE_DT_DEFINE(DEVA, dev_init, device_pm_control_nop,
+		 NULL, NULL, POST_KERNEL, 20, NULL);
+/* NB: Intentional init devb before required gpiox */
+DEVICE_DT_DEFINE(DEVB, dev_init, device_pm_control_nop,
+		 NULL, NULL, POST_KERNEL, 30, NULL);
+DEVICE_DT_DEFINE(GPIOX, dev_init, device_pm_control_nop,
+		 NULL, NULL, POST_KERNEL, 40, NULL);
+
+#define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
+
+static void test_init_order(void)
+{
+	zassert_equal(init_order[0], DEV_HDL(GPIO),
+		      NULL);
+	zassert_equal(init_order[1], DEV_HDL(I2C),
+		      NULL);
+	zassert_equal(init_order[2], DEV_HDL(DEVA),
+		      NULL);
+	zassert_equal(init_order[3], DEV_HDL(DEVB),
+		      NULL);
+	zassert_equal(init_order[4], DEV_HDL(GPIOX),
+		      NULL);
+}
+
+static bool check_handle(device_handle_t hdl,
+			 const device_handle_t *hdls,
+			 size_t nhdls)
+{
+	const device_handle_t *hdle = hdls + nhdls;
+
+	while (hdls < hdle) {
+		if (*hdls == hdl) {
+			return true;
+		}
+		++hdls;
+	}
+
+	return false;
+}
+
+static void test_requires(void)
+{
+	size_t nhdls = 0;
+	const device_handle_t *hdls;
+	const struct device *dev;
+
+	/* GPIO: no req */
+	dev = device_get_binding(DT_LABEL(GPIO));
+	zassert_equal(dev, DEVICE_DT_GET(GPIO), NULL);
+	hdls = device_get_requires_handles(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* I2C: no req */
+	dev = device_get_binding(DT_LABEL(I2C));
+	zassert_equal(dev, DEVICE_DT_GET(I2C), NULL);
+	hdls = device_get_requires_handles(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* DEVA: I2C GPIO */
+	dev = device_get_binding(DT_LABEL(DEVA));
+	zassert_equal(dev, DEVICE_DT_GET(DEVA), NULL);
+	hdls = device_get_requires_handles(dev, &nhdls);
+	zassert_equal(nhdls, 2, NULL);
+	zassert_true(check_handle(DEV_HDL(I2C), hdls, nhdls), NULL);
+	zassert_true(check_handle(DEV_HDL(GPIO), hdls, nhdls), NULL);
+
+	/* GPIOX: I2C */
+	dev = device_get_binding(DT_LABEL(GPIOX));
+	zassert_equal(dev, DEVICE_DT_GET(GPIOX), NULL);
+	hdls = device_get_requires_handles(dev, &nhdls);
+	zassert_equal(nhdls, 1, NULL);
+	zassert_true(check_handle(DEV_HDL(I2C), hdls, nhdls), NULL);
+
+	/* DEVB: I2C GPIOX */
+	dev = device_get_binding(DT_LABEL(DEVB));
+	zassert_equal(dev, DEVICE_DT_GET(DEVB), NULL);
+	hdls = device_get_requires_handles(dev, &nhdls);
+	zassert_equal(nhdls, 2, NULL);
+	zassert_true(check_handle(DEV_HDL(I2C), hdls, nhdls), NULL);
+	zassert_true(check_handle(DEV_HDL(GPIOX), hdls, nhdls), NULL);
+}
+
+void test_main(void)
+{
+	size_t ndevs;
+
+	ndevs = z_device_get_all_static(&devlist);
+	devlist_end = devlist + ndevs;
+
+	ztest_test_suite(devicetree_driver,
+			 ztest_unit_test(test_init_order),
+			 ztest_unit_test(test_requires)
+		);
+	ztest_run_test_suite(devicetree_driver);
+}

--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  libraries.devicetree:
+    tags: devicetree
+    # We only need this to run on one platform so use native_posix as it
+    # will mostly likely be the fastest.
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
This PR uses the `DEVICE_DT_DEFINE()` infrastructure from #30196 to extract information about dependencies between devices from devicetree and encode it into the device structure using an integral type with unique values per device.

This is accomplished using the same two-pass model used for kernel objects: generate an initial object record using the raw data from the devicetree (handles are devicetree ordinals), then replace the handles with ones corresponding to the index of each device in the static device table.

The API supports recording additional dependencies on specific devices that do not have devicetree entries, such as the system clock.

A test is included, as well as an extension to the shell device module to display more information about devices, including initialization success and dependency data.

A commit from #30401 is replicated here.