### PR TITLE
Add gptp sample to Docker testing

### DIFF
--- a/samples/net/gptp/CMakeLists.txt
+++ b/samples/net/gptp/CMakeLists.txt
@@ -5,4 +5,4 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gptp)
 
-target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main.c src/gptp.c)

--- a/samples/net/gptp/Kconfig
+++ b/samples/net/gptp/Kconfig
@@ -52,6 +52,12 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
+config NET_SAMPLE_RUN_DURATION
+	int "Run the application this many seconds"
+	default 0
+	help
+	  A value of zero means that the sample application is run forever.
+
 endif
 
 

--- a/samples/net/gptp/src/gptp.c
+++ b/samples/net/gptp/src/gptp.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(net_gptp_sample);
+
+#include <zephyr.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include <net/net_core.h>
+#include <net/gptp.h>
+
+#include "ethernet/gptp/gptp_messages.h"
+#include "ethernet/gptp/gptp_data_set.h"
+
+static int run_duration = CONFIG_NET_SAMPLE_RUN_DURATION;
+static struct k_delayed_work stop_sample;
+static struct k_sem quit_lock;
+
+static void stop_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	k_sem_give(&quit_lock);
+}
+
+static int get_current_status(void)
+{
+	struct gptp_domain *domain;
+	struct gptp_port_ds *port_ds;
+	int ret, port;
+
+	port = 1;
+
+	domain = gptp_get_domain();
+
+	ret = gptp_get_port_data(domain, port, &port_ds,
+				 NULL, NULL, NULL, NULL);
+	if (ret < 0) {
+		LOG_WRN("Cannot get gPTP information for port %d (%d)",
+			port, ret);
+		return ret;
+	}
+
+	if (port != port_ds->port_id.port_number) {
+		return -EINVAL;
+	}
+
+	switch (GPTP_GLOBAL_DS()->selected_role[port]) {
+	case GPTP_PORT_INITIALIZING:
+	case GPTP_PORT_FAULTY:
+	case GPTP_PORT_DISABLED:
+	case GPTP_PORT_LISTENING:
+	case GPTP_PORT_PRE_MASTER:
+	case GPTP_PORT_PASSIVE:
+	case GPTP_PORT_UNCALIBRATED:
+		printk("FAIL\n");
+		return 0;
+	case GPTP_PORT_MASTER:
+		printk("MASTER\n");
+		return 1;
+	case GPTP_PORT_SLAVE:
+		printk("SLAVE\n");
+		return 2;
+	}
+
+	return -1;
+}
+
+void init_testing(void)
+{
+	uint32_t uptime = k_uptime_get_32();
+	int ret;
+
+	if (run_duration == 0) {
+		return;
+	}
+
+	k_sem_init(&quit_lock, 0, UINT_MAX);
+
+	k_delayed_work_init(&stop_sample, stop_handler);
+	k_delayed_work_submit(&stop_sample, K_SECONDS(run_duration));
+
+	k_sem_take(&quit_lock, K_FOREVER);
+
+	LOG_INF("Stopping after %u seconds",
+		(k_uptime_get_32() - uptime) / 1000);
+
+	/* Try to figure out what is the sync state.
+	 * Return:
+	 *  <0 - configuration error
+	 *   0 - not time sync
+	 *   1 - we are MASTER
+	 *   2 - we are SLAVE
+	 */
+	ret = get_current_status();
+
+	exit(ret);
+}

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -16,6 +16,8 @@ LOG_MODULE_REGISTER(net_gptp_sample, LOG_LEVEL_DBG);
 #include <net/ethernet.h>
 #include <net/gptp.h>
 
+extern void init_testing(void);
+
 static struct gptp_phase_dis_cb phase_dis;
 
 #if defined(CONFIG_NET_GPTP_VLAN)
@@ -158,4 +160,6 @@ static int init_app(void)
 void main(void)
 {
 	init_app();
+
+	init_testing();
 }

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
       revision: f28a637db12c4b12fb2b18bddc6b2a0deaa95251
       path: modules/lib/mcumgr
     - name: net-tools
-      revision: e53774b71288a85f7321bfbfa57cae6d3419f022
+      revision: c72fbf3300264a8a4bb48be314ca93765c863a19
       path: tools/net-tools
     - name: hal_nxp
       revision: 56915d2942a3af7205b3c4991a8b87e915de7f59


### PR DESCRIPTION
Run linuxptp in docker and Zephyr gptp sample in host. The test verifies that the time sync works ok.
This requires also https://github.com/zephyrproject-rtos/net-tools/pull/48 from net-tools.
