### PR TITLE
drivers/sensor: lsm6dsl: Fix build when irq_gpios is not in DT

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -875,23 +875,22 @@ static int lsm6dsl_init(const struct device *dev)
 	})
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
+#define LSM6DSL_CFG_IRQ(inst) \
+		.irq_dev_name = DT_INST_GPIO_LABEL(inst, irq_gpios),	\
+		.irq_pin = DT_INST_GPIO_PIN(inst, irq_gpios),		\
+		.irq_flags = DT_INST_GPIO_FLAGS(inst, irq_gpios),
+#else
+#define LSM6DSL_CFG_IRQ(inst)
+#endif /* CONFIG_LSM6DSL_TRIGGER */
+
 #define LSM6DSL_CONFIG_SPI(inst)					\
 	{								\
 		.bus_name = DT_INST_BUS_LABEL(inst),			\
 		.bus_init = lsm6dsl_spi_init,				\
 		.bus_cfg = { .spi_cfg = LSM6DSL_SPI_CFG(inst)	},	\
-		.irq_dev_name = DT_INST_GPIO_LABEL(inst, irq_gpios),	\
-		.irq_pin = DT_INST_GPIO_PIN(inst, irq_gpios),		\
-		.irq_flags = DT_INST_GPIO_FLAGS(inst, irq_gpios),	\
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
+		(LSM6DSL_CFG_IRQ(inst)), ())				\
 	}
-#else
-#define LSM6DSL_CONFIG_SPI(inst)					\
-	{								\
-		.bus_name = DT_INST_BUS_LABEL(inst),			\
-		.bus_init = lsm6dsl_spi_init,				\
-		.bus_cfg = { .spi_cfg = LSM6DSL_SPI_CFG(inst)	}	\
-	}
-#endif /* CONFIG_LSM6DSL_TRIGGER */
 
 #define LSM6DSL_DEFINE_SPI(inst)					\
 	static struct lsm6dsl_data lsm6dsl_data_##inst =		\
@@ -904,24 +903,14 @@ static int lsm6dsl_init(const struct device *dev)
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#ifdef CONFIG_LSM6DSL_TRIGGER
 #define LSM6DSL_CONFIG_I2C(inst)					\
 	{								\
 		.bus_name = DT_INST_BUS_LABEL(inst),			\
 		.bus_init = lsm6dsl_i2c_init,				\
 		.bus_cfg = { .i2c_slv_addr = DT_INST_REG_ADDR(inst), },	\
-		.irq_dev_name = DT_INST_GPIO_LABEL(inst, irq_gpios),	\
-		.irq_pin = DT_INST_GPIO_PIN(inst, irq_gpios),		\
-		.irq_flags = DT_INST_GPIO_FLAGS(inst, irq_gpios),	\
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
+		(LSM6DSL_CFG_IRQ(inst)), ())				\
 	}
-#else
-#define LSM6DSL_CONFIG_I2C(inst)					\
-	{								\
-		.bus_name = DT_INST_BUS_LABEL(inst),			\
-		.bus_init = lsm6dsl_i2c_init,				\
-		.bus_cfg = { .i2c_slv_addr = DT_INST_REG_ADDR(inst), }	\
-	}
-#endif /* CONFIG_LSM6DSL_TRIGGER */
 
 #define LSM6DSL_DEFINE_I2C(inst)					\
 	static struct lsm6dsl_data lsm6dsl_data_##inst;			\

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -49,6 +49,12 @@ int lsm6dsl_trigger_set(const struct device *dev,
 
 	__ASSERT_NO_MSG(trig->type == SENSOR_TRIG_DATA_READY);
 
+	/* If irq_gpio is not configured in DT just return error */
+	if (!drv_data->gpio) {
+		LOG_ERR("triggers not supported");
+		return -ENOTSUP;
+	}
+
 	setup_irq(drv_data, config->irq_pin, false);
 
 	drv_data->data_ready_handler = handler;
@@ -119,8 +125,8 @@ int lsm6dsl_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt */
 	drv_data->gpio = device_get_binding(config->irq_dev_name);
 	if (drv_data->gpio == NULL) {
-		LOG_ERR("Cannot get pointer to %s.", config->irq_dev_name);
-		return -EINVAL;
+		LOG_INF("Cannot get pointer for irq_dev_name");
+		goto end;
 	}
 
 	gpio_pin_configure(drv_data->gpio, config->irq_pin,
@@ -161,5 +167,6 @@ int lsm6dsl_init_interrupt(const struct device *dev)
 
 	setup_irq(drv_data, config->irq_pin, true);
 
+end:
 	return 0;
 }


### PR DESCRIPTION
In case of h/w setup with multiples device instances it is possible
that some of them wants to use triggers but not the others (no
interrupt line.

Since Kconfig configuration is the same way for all the instances
(CONFIG_LSM6DSL_TRIGGER=y), the driver behaves differently according
to how the device instance has been configured in the DT.
If irq-gpios is present, then the driver initialize the interrupt
part and enables irq_inited flag to true. Else, it sets the flag to
false but the interrupt init routine does not fail anymore.

Signed-off-by: Armando Visconti <armando.visconti@st.com>