### PR TITLE
Bluetooth: Mesh: Fix set friend_cred flag incorrectly

### DIFF
--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -587,7 +587,6 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 
 	BT_DBG("");
 
-	rx->friend_cred = 1U;
 #if defined(CONFIG_BT_MESH_LOW_POWER)
 	if (bt_mesh_lpn_established()) {
 		rx->sub = bt_mesh.lpn.sub;
@@ -599,6 +598,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 
 			if (cb(rx, in, out, &bt_mesh.lpn.cred[j])) {
 				rx->new_key = (j > 0);
+				rx->friend_cred = 1U;
 				return true;
 			}
 		}
@@ -632,6 +632,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 
 			if (cb(rx, in, out, &frnd->cred[j])) {
 				rx->new_key = (j > 0);
+				rx->friend_cred = 1U;
 				return true;
 			}
 		}
@@ -651,6 +652,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 
 			if (cb(rx, in, out, &rx->sub->keys[j].msg)) {
 				rx->new_key = (j > 0);
+				rx->friend_cred = 0U;
 				return true;
 			}
 		}


### PR DESCRIPTION
Only set friend_cred to true when friendship established and
use friend cred security material decryption successfully.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>