### PR TITLE
boards: nucleo_h743zi: enable ethernet support

### DIFF
--- a/boards/arm/nucleo_h743zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_h743zi/Kconfig.defconfig
@@ -8,4 +8,11 @@ if BOARD_NUCLEO_H743ZI
 config BOARD
 	default "nucleo_h743zi"
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
 endif # BOARD_NUCLEO_H743ZI

--- a/boards/arm/nucleo_h743zi/doc/index.rst
+++ b/boards/arm/nucleo_h743zi/doc/index.rst
@@ -115,6 +115,8 @@ features:
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |
 +-----------+------------+-------------------------------------+
+| ETHERNET  | on-chip    | ethernet                            |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -136,6 +138,7 @@ and a ST morpho connector. Board is configured as follows:
 - LD3 : PB14
 - I2C : PB8, PB9
 - ADC1_INP15 : PA3
+- ETH : PA1, PA2, PA7, PB13, PC1, PC4, PC5, PG11, PG13
 
 System Clock
 ------------

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -90,3 +90,24 @@
 &rng {
 	status = "okay";
 };
+
+/*
+ * WARNING:
+ * Possible pin conflicts:
+ *          The pins PA2 and PB13 may conflict on selection of ETH_STM32_HAL,
+ *          since they are used in ST Zio or ST morpho connectors.
+ *          To avoid conflicting states the jumpers JP6 and JP7
+ *          must be in ON state.
+ */
+&mac {
+	status = "okay";
+	pinctrl-0 = <&eth_mdc_pc1
+		     &eth_rxd0_pc4
+		     &eth_rxd1_pc5
+		     &eth_ref_clk_pa1
+		     &eth_mdio_pa2
+		     &eth_crs_dv_pa7
+		     &eth_tx_en_pg11
+		     &eth_txd0_pg13
+		     &eth_txd1_pb13>;
+};

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
@@ -17,3 +17,4 @@ supported:
   - i2c
   - pwm
   - adc
+  - netif:eth


### PR DESCRIPTION
Since STM32H7 series now have a working ethernet driver,
nucleo_h743zi ethernet can be officially enabled.

That's now done and tested working with sample/dumb_http_server

Signed-off-by: Jeremy LOCHE <lochejeremy@gmail.com>