### PR TITLE
boards: mec: mec15xxevb, mec1501modular: Update documentation

### DIFF
--- a/boards/arm/mec1501modular_assy6885/doc/index.rst
+++ b/boards/arm/mec1501modular_assy6885/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The MEC1501 Modular card ASSY6885 is a development board to evaluate the Microchip
-MEC15XX series microcontrollers. This board can work standalone or be mated with
+MEC152X series microcontrollers. This board can work standalone or be mated with
 any platform that complies with MECC specification.
 
 .. image:: ./mec1501modular_assy6885.png
@@ -18,7 +18,7 @@ any platform that complies with MECC specification.
 Hardware
 ********
 
-- MEC1501HB0SZ ARM Cortex-M4 Processor
+- MEC1521HA0SZ ARM Cortex-M4 Processor
 - 256 KB RAM and 64 KB boot ROM
 - GPIO headers
 - UART1 using microUSB
@@ -28,7 +28,7 @@ Hardware
 - VCI interface
 - Independent Hardware Driven PS/2 Ports
 
-At difference from MEC15xx evaluation board, modular MEC1501 exposes the pins
+At difference from MEC15xx evaluation board, modular MEC1521 exposes the pins
 in 2 different ways:
 
 1) Standalone mode via headers
@@ -48,7 +48,7 @@ in 2 different ways:
 The board is powered through the +5V USB Micro A connector or from the MECC connector.
 
 
-For more information about the SOC please see the `MEC1501 Reference Manual`_
+For more information about the SOC please see the `MEC152x Reference Manual`_
 
 Supported Features
 ==================
@@ -236,8 +236,9 @@ Programming and Debugging
 Setup
 =====
 
-#. Clone the `SPI Image Gen`_ repository or download the files within
-   that directory.
+#. Clone the `MEC152x SPI Image Gen`_ repository or download the files within
+   that directory. For the pre-production MEC150x use the `MEC150x SPI Image Gen`_
+   repository.
 
 #. Make the image generation available for Zephyr, by making the tool
    searchable by path, or by setting an environment variable
@@ -245,9 +246,10 @@ Setup
 
    .. code-block:: console
 
-      export EVERGLADES_SPI_GEN=<path to tool>/everglades_spi_gen_lin64
+      export EVERGLADES_SPI_GEN=<path to tool>/everglades_spi_gen_RomE
 
    Note that the tools for Linux and Windows have different file names.
+   For the pre-production MEC1501 SOC use everglades_spi_gen_lin64.
 
 #. If needed, a custom SPI image configuration file can be specified
    to override the default one.
@@ -259,10 +261,9 @@ Setup
 
 Building
 ==========
-
 #. Build :ref:`hello_world` application as you would normally do.
 
-#. Once you have ``zephyr.bin``, use the `SPI Image Gen`_ microchip tool
+#. Once you have ``zephyr.bin``, use the `MEC152x SPI Image Gen`_ microchip tool
    to create the final binary. You need the output from this tool to flash
    in the SHD SPI memory.
 
@@ -309,11 +310,13 @@ References
 **********
 .. target-notes::
 
-.. _MEC1501 Preliminary Data Sheet:
-    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1501_Datasheet.pdf
-.. _MEC1501 Reference Manual:
-    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1501_Datasheet.pdf
+.. _MEC152x Preliminary Data Sheet:
+    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC152x/MEC152x_Datasheet.pdf
+.. _MEC152x Reference Manual:
+    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC152x/MEC152x_Datasheet.pdf
 .. _MEC1501 Modular EC Card - Assy_6885 Rev A0p1:
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1501%20Modular%20EC%20Card%20-%20Assy_6885%20Rev%20A0p1%20-%20SCH.pdf
-.. _SPI Image Gen:
+.. _MEC152x SPI Image Gen:
+    https://github.com/MicrochipTech/CPGZephyrDocs/tree/master/MEC152x/SPI_image_gen
+.. _MEC150x SPI Image Gen:
     https://github.com/MicrochipTech/CPGZephyrDocs/tree/master/MEC1501/SPI_image_gen

--- a/boards/arm/mec15xxevb_assy6853/doc/index.rst
+++ b/boards/arm/mec15xxevb_assy6853/doc/index.rst
@@ -9,6 +9,11 @@ Overview
 The MEC15xxEVB_ASSY6853 kit is a future development platform to evaluate the
 Microchip MEC15XX series microcontrollers. This board needs to be mated with
 part number MEC1501 144WFBA SOLDER DC ASSY 6860(cpu board) in order to operate.
+The MEC152x has superceded the MEC1501 in production. MEC152x is identical to
+MEC150x except for an enhanced Boot-ROM SPI loader. The SPI image format has
+been updated requiring a new SPI image tool. MEC1501 and MEC152x SPI image
+formats are not compatible with each other. Evaluation and cpu boards are
+compatible.
 
 .. image:: ./mec15xxevb_assy6853.png
      :width: 600px
@@ -18,7 +23,7 @@ part number MEC1501 144WFBA SOLDER DC ASSY 6860(cpu board) in order to operate.
 Hardware
 ********
 
-- MEC1501HB0SZ ARM Cortex-M4 Processor
+- MEC1521HA0SZ ARM Cortex-M4 Processor
 - 256 KB RAM and 64 KB boot ROM
 - Keyboard interface
 - ADC & GPIO headers
@@ -40,7 +45,7 @@ Hardware
 - One external LTC2489 delta-sigma ADC with jumper selectable I2C address.
 - Board power jumper selectable from +5V 2.1mm/5.5mm barrel connector or USB Micro A connector.
 
-For more information about the SOC please see the `MEC1501 Reference Manual`_
+For more information about the SOC's please see `MEC152x Reference Manual`_
 
 Supported Features
 ==================
@@ -84,13 +89,13 @@ Connections and IOs
 This evaluation board kit is comprised of the following HW blocks:
 
 - MEC15xx EVB ASSY 6853 Rev A `MEC15xx EVB Schematic`_
-- MEC1501 144WFBA SOLDER DC ASSY 6860 `MEC1501 Daughter Card Schematic`_
+- MEC1501 144WFBA SOLDER DC ASSY 6883 with MEC152x silicon `MEC1501 Daughter Card Schematic`_
 - SPI DONGLE ASSY 6791 `SPI Dongle Schematic`_
 
 System Clock
 ============
 
-The MEC1501 MCU is configured to use the 48Mhz internal oscillator with the
+The MEC1521 MCU is configured to use the 48Mhz internal oscillator with the
 on-chip PLL to generate a resulting EC clock rate of 12 MHz. See Processor clock
 control register in chapter 4 "4.0 POWER, CLOCKS, and RESETS" of the data sheet in
 the references at the end of this document.
@@ -256,8 +261,9 @@ Setup
    Add directory with program ``dpcmd`` (on Linux)
    or ``dpcmd.exe`` (on Windows) to your ``PATH``.
 
-#. Clone the `SPI Image Gen`_ repository or download the files within
-   that directory.
+#. Clone the `MEC152x SPI Image Gen`_ repository or download the files within
+   that directory. For the pre-production MEC150x use `MEC150x SPI Image Gen`_
+   repository.
 
 #. Make the image generation available for Zephyr, by making the tool
    searchable by path, or by setting an environment variable
@@ -265,9 +271,10 @@ Setup
 
    .. code-block:: console
 
-      export EVERGLADES_SPI_GEN=<path to tool>/everglades_spi_gen_lin64
+      export EVERGLADES_SPI_GEN=<path to tool>/everglades_spi_gen_RomE
 
    Note that the tools for Linux and Windows have different file names.
+   For the pre-production MEC1501 SOC use everglades_spi_gen_lin64.
 
 #. If needed, a custom SPI image configuration file can be specified
    to override the default one.
@@ -427,6 +434,10 @@ References
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1501_Datasheet.pdf
 .. _MEC1501 Reference Manual:
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1501_Datasheet.pdf
+.. _MEC152x Preliminary Data Sheet:
+    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC152x/MEC152x_Datasheet.pdf
+.. _MEC152x Reference Manual:
+    https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC152x/MEC152x_Datasheet.pdf
 .. _MEC15xx EVB Schematic:
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/Everglades%20EVB%20-%20Assy_6853%20Rev%20A1p1%20-%20SCH.pdf
 .. _MEC1501 Daughter Card Schematic:
@@ -435,7 +446,9 @@ References
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/MEC1503%20Socket%20DC%20for%20EVERGLADES%20EVB%20-%20Assy_6856%20Rev%20A1p0%20-%20SCH.pdf
 .. _SPI Dongle Schematic:
     https://github.com/MicrochipTech/CPGZephyrDocs/blob/master/MEC1501/SPI%20Dongles%20and%20Aardvark%20Interposer%20Assy%206791%20Rev%20A1p1%20-%20SCH.pdf
-.. _SPI Image Gen:
+.. _MEC152x SPI Image Gen:
+    https://github.com/MicrochipTech/CPGZephyrDocs/tree/master/MEC152x/SPI_image_gen
+.. _MEC150x SPI Image Gen:
     https://github.com/MicrochipTech/CPGZephyrDocs/tree/master/MEC1501/SPI_image_gen
 .. _SF100 Linux GitHub:
     https://github.com/DediProgSW/SF100Linux


### PR DESCRIPTION
Update documention to refer to MEC152x specifications and
SPI image generator. MEC152x is the actual production SOC.
The only difference is the Boot-ROM loader SPI image layout.

Signed-off-by: Scott Worley <scott.worley@microchip.com>