### PR TITLE
frdm_k22f FXOS8700

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -99,9 +99,9 @@
 &i2c0 {
 	status = "okay";
 
-	fxos8700@1d {
+	fxos8700@1c {
 		compatible = "nxp,fxos8700";
-		reg = <0x1d>;
+		reg = <0x1c>;
 		label = "FXOS8700";
 		int1-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpiod 1 GPIO_ACTIVE_LOW>;

--- a/samples/sensor/fxos8700/README.rst
+++ b/samples/sensor/fxos8700/README.rst
@@ -14,8 +14,8 @@ Building and Running
 ********************
 
 This project outputs sensor data to the console. FXOS8700
-sensor is present on the :ref:`frdm_k64f`, :ref:`frdm_kw41z`,
-:ref:`hexiwear_k64`, and :ref:`twr_ke18f` boards.
+sensor is present on the :ref:`frdm_k64f`, :ref:`frdm_k22f`,
+:ref:`frdm_kw41z`, :ref:`hexiwear_k64`, and :ref:`twr_ke18f` boards.
 Accelerometer only devices are present on the :ref:`frdm_kl25z`,
 :ref:`bbc_microbit`, and :ref:`reel_board` boards. It does not work on
 QEMU.
@@ -36,6 +36,26 @@ Example building for the FRDM-K64F with motion detection support:
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/fxos8700
    :board: frdm_k64f
+   :conf: "prj.conf overlay-motion.conf"
+   :goals: build flash
+   :compact:
+
+Building and Running for FRDM-K22F
+==================================
+FRDM-K22F is equipped with FXOS8700CQ accelerometer and magnetometer.
+Sample can be built and executed for the FRDM-K22F as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/fxos8700
+   :board: frdm_k22f
+   :goals: build flash
+   :compact:
+
+Example building for the FRDM-K22F with motion detection support:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/fxos8700
+   :board: frdm_k22f
    :conf: "prj.conf overlay-motion.conf"
    :goals: build flash
    :compact:

--- a/samples/sensor/fxos8700/sample.yaml
+++ b/samples/sensor/fxos8700/sample.yaml
@@ -8,7 +8,7 @@ tests:
   sample.sensor.fxos8700.hybrid:
     platform_allow: frdm_k64f hexiwear_k64 warp7_m4 frdm_kw41z
                         rv32m1_vega_ri5cy twr_ke18f lpcxpresso55s16_ns
-                        mimxrt685_evk_cm33
+                        mimxrt685_evk_cm33 frdm_k22f
     extra_configs:
       - CONFIG_FXOS8700_PULSE=y
       - CONFIG_FXOS8700_PULSE_INT1=y


### PR DESCRIPTION
Fixes up the i2c address of the FXOS8700 in the frdm_k22f device tree source and adds documentation and support for the frdm_k22f in the FXOS8700 sample application.