### PR TITLE
dts: nordic: add CC count to RTC and TIMER nodes

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -156,6 +156,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -166,6 +167,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -177,6 +179,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -186,6 +189,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -195,6 +199,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -122,6 +122,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -132,6 +133,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -159,6 +161,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -168,6 +171,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -177,6 +181,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -149,6 +149,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -159,6 +160,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -170,6 +172,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -179,6 +182,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -188,6 +192,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -172,6 +172,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -182,6 +183,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -193,6 +195,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -202,6 +205,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -211,6 +215,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -170,6 +170,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -180,6 +181,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -191,6 +193,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -200,6 +203,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -209,6 +213,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -216,6 +216,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -226,6 +227,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -236,6 +238,7 @@
 		rtc2: rtc@40024000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
+			cc-num = <4>;
 			interrupts = <36 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -247,6 +250,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -256,6 +260,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -265,6 +270,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";
@@ -274,6 +280,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001a000 0x1000>;
+			cc-num = <6>;
 			interrupts = <26 1>;
 			prescaler = <0>;
 			label = "TIMER_3";
@@ -283,6 +290,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001b000 0x1000>;
+			cc-num = <6>;
 			interrupts = <27 1>;
 			prescaler = <0>;
 			label = "TIMER_4";

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -259,6 +259,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -269,6 +270,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -279,6 +281,7 @@
 		rtc2: rtc@40024000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
+			cc-num = <4>;
 			interrupts = <36 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -290,6 +293,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -299,6 +303,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -308,6 +313,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";
@@ -317,6 +323,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001a000 0x1000>;
+			cc-num = <6>;
 			interrupts = <26 1>;
 			prescaler = <0>;
 			label = "TIMER_3";
@@ -326,6 +333,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001b000 0x1000>;
+			cc-num = <6>;
 			interrupts = <27 1>;
 			prescaler = <0>;
 			label = "TIMER_4";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -265,6 +265,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
+			cc-num = <3>;
 			interrupts = <11 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -275,6 +276,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -285,6 +287,7 @@
 		rtc2: rtc@40024000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
+			cc-num = <4>;
 			interrupts = <36 1>;
 			status = "okay";
 			clock-frequency = <32768>;
@@ -296,6 +299,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
+			cc-num = <4>;
 			interrupts = <8 1>;
 			prescaler = <0>;
 			label = "TIMER_0";
@@ -305,6 +309,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
+			cc-num = <4>;
 			interrupts = <9 1>;
 			prescaler = <0>;
 			label = "TIMER_1";
@@ -314,6 +319,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
+			cc-num = <4>;
 			interrupts = <10 1>;
 			prescaler = <0>;
 			label = "TIMER_2";
@@ -323,6 +329,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001a000 0x1000>;
+			cc-num = <6>;
 			interrupts = <26 1>;
 			prescaler = <0>;
 			label = "TIMER_3";
@@ -332,6 +339,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001b000 0x1000>;
+			cc-num = <6>;
 			interrupts = <27 1>;
 			prescaler = <0>;
 			label = "TIMER_4";

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -347,6 +347,7 @@ gpio1: gpio@842800 {
 rtc0: rtc@14000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x14000 0x1000>;
+	cc-num = <4>;
 	interrupts = <20 1>;
 	status = "okay";
 	clock-frequency = <32768>;
@@ -357,6 +358,7 @@ rtc0: rtc@14000 {
 rtc1: rtc@15000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x15000 0x1000>;
+	cc-num = <4>;
 	interrupts = <21 1>;
 	status = "okay";
 	clock-frequency = <32768>;
@@ -399,6 +401,7 @@ timer0: timer@f000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0xf000 0x1000>;
+	cc-num = <6>;
 	interrupts = <15 1>;
 	prescaler = <0>;
 	label = "TIMER_0";
@@ -408,6 +411,7 @@ timer1: timer@10000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x10000 0x1000>;
+	cc-num = <6>;
 	interrupts = <16 1>;
 	prescaler = <0>;
 	label = "TIMER_1";
@@ -417,6 +421,7 @@ timer2: timer@11000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x11000 0x1000>;
+	cc-num = <6>;
 	interrupts = <17 1>;
 	prescaler = <0>;
 	label = "TIMER_2";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -152,6 +152,7 @@
 		rtc0: rtc@41011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x41011000 0x1000>;
+			cc-num = <4>;
 			interrupts = <17 1>;
 			status = "okay";
 			label = "RTC_0";
@@ -160,6 +161,7 @@
 		rtc1: rtc@41016000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x41016000 0x1000>;
+			cc-num = <4>;
 			interrupts = <22 1>;
 			status = "okay";
 			label = "RTC_1";
@@ -192,6 +194,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "disabled";
 			reg = <0x4100c000 0x1000>;
+			cc-num = <8>;
 			interrupts = <12 1>;
 			prescaler = <0>;
 			label = "TIMER0";
@@ -201,6 +204,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "disabled";
 			reg = <0x41018000 0x1000>;
+			cc-num = <8>;
 			interrupts = <24 1>;
 			prescaler = <0>;
 			label = "TIMER1";
@@ -210,6 +214,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "disabled";
 			reg = <0x41019000 0x1000>;
+			cc-num = <8>;
 			interrupts = <25 1>;
 			prescaler = <0>;
 			label = "TIMER2";

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -312,6 +312,7 @@ gpio0: gpio@842500 {
 rtc0: rtc@14000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x14000 0x1000>;
+	cc-num = <4>;
 	interrupts = <20 1>;
 	status = "okay";
 	clock-frequency = <32768>;
@@ -322,6 +323,7 @@ rtc0: rtc@14000 {
 rtc1: rtc@15000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x15000 0x1000>;
+	cc-num = <4>;
 	interrupts = <21 1>;
 	status = "okay";
 	clock-frequency = <32768>;
@@ -356,6 +358,7 @@ timer0: timer@f000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0xf000 0x1000>;
+	cc-num = <6>;
 	interrupts = <15 1>;
 	prescaler = <0>;
 	label = "TIMER_0";
@@ -365,6 +368,7 @@ timer1: timer@10000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x10000 0x1000>;
+	cc-num = <6>;
 	interrupts = <16 1>;
 	prescaler = <0>;
 	label = "TIMER_1";
@@ -374,6 +378,7 @@ timer2: timer@11000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x11000 0x1000>;
+	cc-num = <6>;
 	interrupts = <17 1>;
 	prescaler = <0>;
 	label = "TIMER_2";

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -11,6 +11,14 @@ properties:
     reg:
       required: true
 
+    cc-num:
+      type: int
+      required: true
+      description: |
+        Number of compare (CC) registers available.
+
+        On nRF53 these registers can also be used for capture.
+
     # If enabled, overflow different than full range (24 bits) is handled
     # through PPI channel which ensures precise timing. If disabled then
     # counter is cleared in the interrupt which results in accumulative error

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -11,6 +11,11 @@ properties:
     reg:
       required: true
 
+    cc-num:
+      type: int
+      required: true
+      description: Number of capture/compare (CC) registers available
+
     interrupts:
       required: true
 


### PR DESCRIPTION
The number of capture/compare registers available on a peripheral
should be exposed in devicetree.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>