### PR TITLE
drivers: pcie_ep: iproc: clear pvm interrupts before handling

### DIFF
--- a/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
@@ -181,11 +181,13 @@ void iproc_pcie_func_mask_isr(void *arg)
 
 	LOG_DBG("%s: %x\n", __func__, data);
 
-	if ((data & SNOOP_VALID_INTR) && !is_pcie_function_mask(dev)) {
-		generate_all_pending_msix(dev);
+	if (data & SNOOP_VALID_INTR) {
+		pcie_write32(SNOOP_VALID_INTR,
+			     &cfg->base->paxb_pcie_cfg_intr_clear);
+		if (!is_pcie_function_mask(dev)) {
+			generate_all_pending_msix(dev);
+		}
 	}
-
-	pcie_write32(SNOOP_VALID_INTR, &cfg->base->paxb_pcie_cfg_intr_clear);
 }
 
 void iproc_pcie_vector_mask_isr(void *arg)
@@ -198,9 +200,9 @@ void iproc_pcie_vector_mask_isr(void *arg)
 		sys_read32(PMON_LITE_PCIE_INTERRUPT_STATUS));
 
 	if (msix_table_update) {
-		generate_all_pending_msix(dev);
 		sys_write32(BIT(WR_ADDR_CHK_INTR_EN),
 			    PMON_LITE_PCIE_INTERRUPT_CLEAR);
+		generate_all_pending_msix(dev);
 	}
 }
 #endif


### PR DESCRIPTION
We should clear the pvm interrupts (snoop and pcie pmon lite interrupt)
at source before handling them.

This will make sure that we do not lose any interrupts that may have been
asserted to interrupt controller during the handling routine.

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>