### PR TITLE
drivers: wifi: Add DHCP/Static IP Support for ESP wifi driver

### DIFF
--- a/drivers/wifi/esp/Kconfig.esp
+++ b/drivers/wifi/esp/Kconfig.esp
@@ -81,6 +81,38 @@ config WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT
 	help
 	  Network interface RX net_pkt allocation timeout in milliseconds.
 
+choice
+	prompt "ESP IP Address configuration"
+	default WIFI_ESP_IP_DHCP
+	help
+	  Choose whether to use an IP assigned by DHCP Server or
+	  configure a static IP Address.
+
+config WIFI_ESP_IP_DHCP
+	bool "DHCP"
+	help
+	  Use DHCP to get an IP Address.
+
+config WIFI_ESP_IP_STATIC
+	bool "Static"
+	help
+	  Setup Static IP Address.
+
+endchoice
+
+if WIFI_ESP_IP_STATIC
+
+config WIFI_ESP_IP_ADDRESS
+	string "ESP Station mode IP Address"
+
+config WIFI_ESP_IP_GATEWAY
+	string "Gateway Address"
+
+config WIFI_ESP_IP_MASK
+	string "Network Mask"
+
+endif
+
 choice WIFI_ESP_AT_VERSION
 	prompt "AT version"
 	default WIFI_ESP_AT_VERSION_2_0

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -260,7 +260,11 @@ static void esp_ip_addr_work(struct k_work *work)
 	/* update interface addresses */
 	net_if_ipv4_set_gw(dev->net_iface, &dev->gw);
 	net_if_ipv4_set_netmask(dev->net_iface, &dev->nm);
+#if defined(CONFIG_WIFI_ESP_IP_STATIC)
+	net_if_ipv4_addr_add(dev->net_iface, &dev->ip, NET_ADDR_MANUAL, 0);
+#else
 	net_if_ipv4_addr_add(dev->net_iface, &dev->ip, NET_ADDR_DHCP, 0);
+#endif
 }
 
 MODEM_CMD_DEFINE(on_cmd_got_ip)
@@ -733,6 +737,16 @@ static void esp_init_work(struct k_work *work)
 		SETUP_CMD_NOHANDLE("AT"),
 #endif
 		SETUP_CMD_NOHANDLE("AT+"_CWMODE"=1"),
+#if defined(CONFIG_WIFI_ESP_IP_STATIC)
+		/* enable Static IP Config */
+		SETUP_CMD_NOHANDLE(ESP_CMD_DHCP_ENABLE(STATION, 0)),
+		SETUP_CMD_NOHANDLE(ESP_CMD_SET_IP(CONFIG_WIFI_ESP_IP_ADDRESS,
+						  CONFIG_WIFI_ESP_IP_GATEWAY,
+						  CONFIG_WIFI_ESP_IP_MASK)),
+#else
+		/* enable DHCP */
+		SETUP_CMD_NOHANDLE(ESP_CMD_DHCP_ENABLE(STATION, 1)),
+#endif
 		/* enable multiple socket support */
 		SETUP_CMD_NOHANDLE("AT+CIPMUX=1"),
 		/* only need ecn,ssid,rssi,channel */

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -95,6 +95,27 @@ extern "C" {
 #define ESP_CONNECT_TIMEOUT	K_SECONDS(20)
 #define ESP_INIT_TIMEOUT	K_SECONDS(10)
 
+#define ESP_CWDHCP_MODE_STATION		"1"
+#if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
+#define ESP_CWDHCP_MODE_SOFTAP		"0"
+#else
+#define ESP_CWDHCP_MODE_SOFTAP		"2"
+#endif
+
+#if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
+#define _ESP_CMD_DHCP_ENABLE(mode, enable) \
+			  "AT+CWDHCP_CUR=" mode "," STRINGIFY(enable)
+#else
+#define _ESP_CMD_DHCP_ENABLE(mode, enable) \
+			  "AT+CWDHCP=" STRINGIFY(enable) "," mode
+#endif
+
+#define ESP_CMD_DHCP_ENABLE(mode, enable) \
+	_ESP_CMD_DHCP_ENABLE(_CONCAT(ESP_CWDHCP_MODE_, mode), enable)
+
+#define ESP_CMD_SET_IP(ip, gateway, mask) "AT+"_CIPSTA"=\"" \
+			  ip "\",\""  gateway  "\",\""  mask "\""
+
 extern struct esp_data esp_driver_data;
 
 enum esp_socket_flags {


### PR DESCRIPTION
Add ESP DHCP/StaticIP Support including kconfig entries.

#### Other minor fixes included:
- ~~Print a warning message on shell when user executes `net ping xxx.xxx.xxx.xxx` in case of offloaded driver is being used.~~
- ~~Rename kconfig prompt `add support for Wi-Fi Drivers` to `Wi-Fi Drivers`~~