### PR TITLE
nucleo_h745zi_q enable connect under reset with OpenOCD

### DIFF
--- a/boards/arm/nucleo_h745zi_q/support/openocd.cfg
+++ b/boards/arm/nucleo_h745zi_q/support/openocd.cfg
@@ -1,4 +1,13 @@
+# STM32H745ZI Nucleo board OpenOCD ST-LINK V3 configuration
+#
+# Copyright (c) 2020 Alexander Kozhinov
+# AlexanderKozhinov@yandex.com
+# SPDX-License-Identifier: Apache-2.0
+#
+
 source [find board/st_nucleo_h745zi.cfg]
+
+reset_config srst_only srst_nogate connect_assert_srst
 
 $_CHIPNAME.cpu0 configure -event gdb-attach {
         echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Enabled and tested `connect under reset`functionality with onboard ST-LINK V3 debugger and OpenOCD latest dev version for mentioned board.

Previous configuration `openocd.cfg` was requiring pushing `RESET` button once after the board was firstly connected to host or host was just started.

**Tested with:**
```
Open On-Chip Debugger 0.10.0+dev-01404-g393448342-dirty (2020-11-01-22:54)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
```