### PR TITLE
boards: stm32h747i_disco: adjust openocd reset config and debug

### DIFF
--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
@@ -9,4 +9,4 @@ set DUAL_CORE 1
 
 source [find target/stm32h7x.cfg]
 
-reset_config srst_only
+reset_config srst_only srst_nogate connect_assert_srst

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
@@ -6,3 +6,14 @@ transport select hla_swd
 source [find target/stm32h7x.cfg]
 
 reset_config srst_only srst_nogate connect_assert_srst
+
+$_CHIPNAME.cpu0 configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+        gdb_breakpoint_override hard
+}
+
+$_CHIPNAME.cpu0 configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
@@ -5,5 +5,4 @@ transport select hla_swd
 
 source [find target/stm32h7x.cfg]
 
-reset_config srst_only
-
+reset_config srst_only srst_nogate connect_assert_srst


### PR DESCRIPTION
Summary:

- I have experienced some problems when flashing this board using OpenOCD. Adding `connect_assert_srst` forces reset assertion before any connection atempt (`srst_nogate` is required).
- Add necessary entries to debug CM7 core using OpenOCD.
