### PR TITLE
west.yml: Pull in build fix for NXP IAP flash driver from HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
       revision: 1c4fdba512b268033a4cf926bddd323866c3261a
       path: tools/net-tools
     - name: hal_nxp
-      revision: 960930271323f9bb3c9e65560b686da1833d8ade
+      revision: 10c2089ed5e4694d74cd5f2cb417bc6af11d17e2
       path: modules/hal/nxp
     - name: open-amp
       revision: de1b85a13032a2de1d8b6695ae5f800b613e739d


### PR DESCRIPTION
The HAL was missing some new files for the IAP driver which causes build
failures.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>