### PR TITLE
sanitycheck: do not try platforms not in hardware map

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -2796,7 +2796,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                 break
         return selected_platform
 
-    def load_from_file(self, file, filter_status=[]):
+    def load_from_file(self, file, filter_status=[], filter_platform=[]):
         try:
             with open(file, "r") as fp:
                 cr = csv.DictReader(fp)
@@ -2807,6 +2807,8 @@ class TestSuite(DisablePyTestCollectionMixin):
                     test = row["test"]
 
                     platform = self.get_platform(row["platform"])
+                    if filter_platform and platform.name not in filter_platform:
+                        continue
                     instance = TestInstance(self.testcases[test], platform, self.outdir)
                     if self.device_testing:
                         tfilter = 'runnable'
@@ -3226,7 +3228,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                     elif instance.status == 'passed':
                         passes += 1
                     else:
-                        logger.error(f"Unknown status {instance.status}")
+                        logger.debug(f"Unknown status {instance.status}")
 
             total = (errors + passes + fails + skips)
             # do not produce a report if no tests were actually run (only built)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1013,11 +1013,24 @@ def main():
         suite.load_from_file(last_run, filter_status=['skipped', 'passed'])
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.load_tests:
-        suite.load_from_file(options.load_tests, filter_status=['skipped'])
+        suite.load_from_file(options.load_tests, filter_status=['skipped', 'error'])
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
     elif options.test_only:
-        suite.load_from_file(last_run, filter_status=['skipped'])
+        # Get list of connected hardware and filter tests to only be run on connected hardware
+        # in cases where no platform was specified when runn the tests.
+        # If the platform does not exist in the hardware map, just skip it.
+        connected_list = []
+        if not options.platform:
+            for connected in hwm.connected_hardware:
+                if connected['connected']:
+                    connected_list.append(connected['platform'])
+
+        suite.load_from_file(last_run, filter_status=['skipped', 'error'],
+                             filter_platform=connected_list)
         suite.selected_platforms = set(p.platform.name for p in suite.instances.values())
+
+
+
     else:
         discards = suite.apply_filters(
             enable_slow=options.enable_slow,


### PR DESCRIPTION
Get list of connected hardware and filter tests to only be run on connected
hardware in cases where no platform was specified when runn the tests.  If the
platform does not exist in the hardware map, just skip it.

Fixes #29166