### PR TITLE
kernel: Add K_DELAYED_WORK_DEFINE

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3004,6 +3004,31 @@ extern void k_work_q_user_start(struct k_work_q *work_q,
 				k_thread_stack_t *stack,
 				size_t stack_size, int prio);
 
+#define Z_DELAYED_WORK_INITIALIZER(work_handler) \
+	{ \
+		.work = Z_WORK_INITIALIZER(work_handler), \
+		.timeout = { \
+			.node = {},\
+			.fn = NULL, \
+			.dticks = 0, \
+		}, \
+		.work_q = NULL, \
+	}
+
+/**
+ * @brief Initialize a statically-defined delayed work item.
+ *
+ * This macro can be used to initialize a statically-defined workqueue
+ * delayed work item, prior to its first use. For example,
+ *
+ * @code static K_DELAYED_WORK_DEFINE(<work>, <work_handler>); @endcode
+ *
+ * @param work Symbol name for delayed work item object
+ * @param work_handler Function to invoke each time work item is processed.
+ */
+#define K_DELAYED_WORK_DEFINE(work, work_handler) \
+	struct k_delayed_work work = Z_DELAYED_WORK_INITIALIZER(work_handler)
+
 /**
  * @brief Initialize a delayed work item.
  *
@@ -3015,8 +3040,11 @@ extern void k_work_q_user_start(struct k_work_q *work_q,
  *
  * @return N/A
  */
-extern void k_delayed_work_init(struct k_delayed_work *work,
-				k_work_handler_t handler);
+static inline void k_delayed_work_init(struct k_delayed_work *work,
+				       k_work_handler_t handler)
+{
+	*work = (struct k_delayed_work)Z_DELAYED_WORK_INITIALIZER(handler);
+}
 
 /**
  * @brief Submit a delayed work item.

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -46,13 +46,6 @@ static void work_timeout(struct _timeout *t)
 	k_work_submit_to_queue(w->work_q, &w->work);
 }
 
-void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
-{
-	k_work_init(&work->work, handler);
-	z_init_timeout(&work->timeout);
-	work->work_q = NULL;
-}
-
 static int work_cancel(struct k_delayed_work *work)
 {
 	if (k_work_pending(&work->work)) {

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -778,6 +778,27 @@ static void test_triggered_wait_expired(void)
 	reset_results();
 }
 
+/**
+ * @brief Test delayed work queue define macro.
+ *
+ * The macro should initialize the k_delayed_work exactly the same as
+ * @ref k_delayed_work_init does.
+ *
+ * @ingroup kernel_workqueue_tests
+ *
+ * @see K_DELAYED_WORK_DEFINE()
+ */
+void test_delayed_work_define(void)
+{
+	struct k_delayed_work initialized_by_function = { 0 };
+	K_DELAYED_WORK_DEFINE(initialized_by_macro, delayed_work_handler);
+
+	k_delayed_work_init(&initialized_by_function, delayed_work_handler);
+
+	zassert_mem_equal(&initialized_by_function, &initialized_by_macro,
+			  sizeof(struct k_delayed_work), NULL);
+}
+
 /*test case main entry*/
 void test_main(void)
 {
@@ -796,7 +817,8 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_triggered_no_wait),
 			 ztest_1cpu_unit_test(test_triggered_no_wait_expired),
 			 ztest_1cpu_unit_test(test_triggered_wait),
-			 ztest_1cpu_unit_test(test_triggered_wait_expired)
+			 ztest_1cpu_unit_test(test_triggered_wait_expired),
+			 ztest_1cpu_unit_test(test_delayed_work_define)
 			 );
 	ztest_run_test_suite(workqueue);
 }


### PR DESCRIPTION
Adds a K_DELAYED_WORK_DEFINE, matching the K_WORK_DEFINE macro, with
accompanying Z_DELAYED_WORK_INITIALIZER macro.

Makes k_delayed_work_init a static inline function, like its K_WORK
counterpart.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>