### PR TITLE
boards: arm: update pwm signals on all STM32 based boards

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -115,10 +115,10 @@
 
 	pwm4: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim4_ch1_pwm_pd12
-			     &tim4_ch2_pwm_pd13
-			     &tim4_ch3_pwm_pd14
-			     &tim4_ch4_pwm_pd15>;
+		pinctrl-0 = <&tim4_ch1_pd12
+			     &tim4_ch2_pd13
+			     &tim4_ch3_pd14
+			     &tim4_ch4_pd15>;
 	};
 };
 
@@ -127,10 +127,10 @@
 
 	pwm5: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim5_ch1_pwm_pa0
-			     &tim5_ch2_pwm_pa1
-			     &tim5_ch3_pwm_pa2
-			     &tim5_ch4_pwm_pa3>;
+		pinctrl-0 = <&tim5_ch1_pa0
+			     &tim5_ch2_pa1
+			     &tim5_ch3_pa2
+			     &tim5_ch4_pa3>;
 	};
 };
 

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -125,7 +125,7 @@
 
 	pwm3: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim3_ch1_pwm_pb4 &tim3_ch3_pwm_pc8>;
+		pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch3_pc8>;
 	};
 };
 
@@ -134,7 +134,7 @@
 
 	pwm4: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim4_ch3_pwm_pd14 &tim4_ch4_pwm_pd15>;
+		pinctrl-0 = <&tim4_ch3_pd14 &tim4_ch4_pd15>;
 	};
 };
 
@@ -143,7 +143,7 @@
 
 	pwm9: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim9_ch1_pwm_pe5 &tim9_ch2_pwm_pe6>;
+		pinctrl-0 = <&tim9_ch1_pe5 &tim9_ch2_pe6>;
 	};
 };
 

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -177,7 +177,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa15>;
+		pinctrl-0 = <&tim2_ch1_pa15>;
 	};
 };
 

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -73,7 +73,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
+++ b/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
@@ -73,7 +73,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -80,7 +80,7 @@
 
 	pwm4: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim4_ch1_pwm_pb6 &tim4_ch2_pwm_pb7>;
+		pinctrl-0 = <&tim4_ch1_pb6 &tim4_ch2_pb7>;
 	};
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -196,7 +196,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa15>;
+		pinctrl-0 = <&tim2_ch1_pa15>;
 	};
 };
 

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -60,7 +60,7 @@
 
 	pwm3: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim3_ch1_pwm_pb4>;
+		pinctrl-0 = <&tim3_ch1_pb4>;
 	};
 };
 

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -75,7 +75,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -76,7 +76,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pa8>;
 	};
 };
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -120,7 +120,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa5>;
+		pinctrl-0 = <&tim2_ch1_pa5>;
 	};
 };
 

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -86,7 +86,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -86,7 +86,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -92,7 +92,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3_pwm_pe13>;
+		pinctrl-0 = <&tim1_ch3_pe13>;
 	};
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -95,7 +95,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3_pwm_pe13>;
+		pinctrl-0 = <&tim1_ch3_pe13>;
 	};
 };
 

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -95,7 +95,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3_pwm_pe13>;
+		pinctrl-0 = <&tim1_ch3_pe13>;
 	};
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -98,7 +98,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3_pwm_pe13>;
+		pinctrl-0 = <&tim1_ch3_pe13>;
 	};
 };
 

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -57,6 +57,6 @@
 	status = "okay";
 	pwm3: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim3_ch1_pwm_pa6>;
+		pinctrl-0 = <&tim3_ch1_pa6>;
 	};
 };

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -92,7 +92,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa5>;
+		pinctrl-0 = <&tim2_ch1_pa5>;
 	};
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -92,7 +92,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa5>;
+		pinctrl-0 = <&tim2_ch1_pa5>;
 	};
 };
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -78,7 +78,7 @@
 
 	pwm12: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim12_ch1_pwm_pb14>;
+		pinctrl-0 = <&tim12_ch1_pb14>;
 	};
 };
 

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -67,7 +67,7 @@
 
 	pwm12: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim12_ch1_pwm_pb14>;
+		pinctrl-0 = <&tim12_ch1_pb14>;
 	};
 };
 

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -61,7 +61,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -62,7 +62,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -96,7 +96,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -83,9 +83,9 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pe9
-			     &tim1_ch2_pwm_pe11
-			     &tim1_ch3_pwm_pe13>;
+		pinctrl-0 = <&tim1_ch1_pe9
+			     &tim1_ch2_pe11
+			     &tim1_ch3_pe13>;
 	};
 };
 
@@ -94,7 +94,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 
@@ -103,7 +103,7 @@
 
 	pwm15: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim15_ch1_pwm_pb14>;
+		pinctrl-0 = <&tim15_ch1_pb14>;
 	};
 };
 

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -113,7 +113,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -94,7 +94,7 @@
 	status = "okay";
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
@@ -55,7 +55,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -158,7 +158,7 @@
 	status = "okay";
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pa8>;
 	};
 };
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -69,7 +69,7 @@
 
 	pwm4: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim4_ch1_pwm_pd12>;
+		pinctrl-0 = <&tim4_ch1_pd12>;
 	};
 };
 

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -75,7 +75,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -91,7 +91,7 @@
 
 	pwm3: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim3_ch1_pwm_pb4>;
+		pinctrl-0 = <&tim3_ch1_pb4>;
 	};
 };
 

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -84,7 +84,7 @@ arduino_serial: &lpuart1 {};
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pwm_pa0>;
+		pinctrl-0 = <&tim2_ch1_pa0>;
 	};
 };
 

--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: a0267470e786019e378be18f5786e53ef307497f
+      revision: 80cd7b0d956ca778bd7acf1d9465b44d25e62d57
       path: modules/hal/stm32
     - name: hal_ti
       revision: 405dfc8faba13e01c1cb9e29e70b31b50f71d117


### PR DESCRIPTION
Update PWM pinctrl signal names of all non-F1 STM32 boards.

STM32 timers are multi-purpose peripherals ranging from PWM, Input
capture, encoder, HALL sensor... In all series except F1 the timer pins
will always be configured in the same mode, i.e. alternate. So using a
variant for each functionality is not necessary. When working with F1
series mode is still required because the pin may operate in either
alternate or input mode depending on the assigned functionality.

Companion PR: https://github.com/zephyrproject-rtos/hal_stm32/pull/80