### PR TITLE
(WIP) lib/os/heap: add heap usage statistics

### DIFF
--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -61,6 +61,13 @@ struct z_heap_stress_result {
 	uint64_t accumulated_in_use_bytes;
 };
 
+struct sys_heap_stats {
+	uint32_t avail_chunks;
+	uint32_t avail_chunks_min;
+	uint32_t avail_contig;
+	uint32_t avail_contig_min;
+};
+
 /** @brief Initialize sys_heap
  *
  * Initializes a sys_heap struct to manage the specified memory.
@@ -178,5 +185,24 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
  * @param h Heap to print information about
  */
 void sys_heap_dump(struct sys_heap *h);
+
+/** @brief Print heap structure availability statistics to the console
+ *
+ * Prints a line detailing available heap memory and contiguous available heap
+ * memory, including historical minimums.
+ *
+ * @param h Heap to print information about
+ */
+void sys_heap_print_stats(struct sys_heap *h);
+
+/** @brief Write heap structure availability statistics to a struct
+ *
+ * Fills a struct detailing available heap memory and contiguous available heap
+ * memory, including historical minimums.
+ *
+ * @param h Heap to get information about
+ * @param stats struct to fill
+ */
+void sys_heap_get_stats(struct sys_heap *h, struct sys_heap_stats *stats);
 
 #endif /* ZEPHYR_INCLUDE_SYS_SYS_HEAP_H_ */

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -123,6 +123,11 @@ static void free_chunk(struct z_heap *h, chunkid_t c)
 		c = left_chunk(h, c);
 	}
 
+	if (chunk_size(h, c) > h->avail_contig) {
+		h->top_available = c;
+		h->avail_contig = chunk_size(h, c);
+	}
+
 	free_list_add(h, c);
 }
 
@@ -220,6 +225,33 @@ static chunkid_t alloc_chunk(struct z_heap *h, size_t sz)
 	return 0;
 }
 
+/* O(n) with chunks in the top bucket.*/
+static void update_top_available(struct z_heap *h)
+{
+	CHECK(h->avail_buckets);
+
+	/* Find the bucket for the largest available chunks*/
+	int bi_max = 8 * sizeof(int) - __builtin_clz(h->avail_buckets) - 1;
+	struct z_heap_bucket *b = &h->buckets[bi_max];
+
+	/* Iterate through the bucket to identify the largest chunk */
+	h->avail_contig = 0;
+	chunkid_t first = b->next;
+	do {
+		if (chunk_size(h, b->next) > h->avail_contig) {
+			h->top_available = b->next;
+			h->avail_contig = chunk_size(h, b->next);
+		}
+		b->next = next_free_chunk(h, b->next);
+		CHECK(b->next != 0);
+	} while (b->next != first);
+
+	/* Update minimum free chunk size */
+	if (h->avail_contig < h->avail_contig_min) {
+		h->avail_contig_min = h->avail_contig;
+	}
+}
+
 void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 {
 	if (bytes == 0U) {
@@ -239,7 +271,14 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 		free_list_add(h, c + chunk_sz);
 	}
 
+	if (c == h->top_available) {
+		update_top_available(h);
+	}
+
 	set_chunk_used(h, c, true);
+
+	sys_heap_print_stats(heap);
+
 	return chunk_mem(h, c);
 }
 
@@ -290,7 +329,38 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 	}
 
 	set_chunk_used(h, c, true);
+
+	if (c0 == h->top_available) {
+		update_top_available(h);
+	}
+
+	sys_heap_print_stats(heap);
+
 	return mem;
+}
+
+void heap_print_stats(struct z_heap *h)
+{
+	printk("Heap stats for %p | Free: %u (min %u) "
+	       "| Contiguous: %u (min %u) | Total: %u\n", h,
+	       h->avail_chunks * CHUNK_UNIT,
+	       h->avail_chunks_min * CHUNK_UNIT,
+	       h->avail_contig * CHUNK_UNIT,
+	       h->avail_contig_min * CHUNK_UNIT,
+	       h->len * CHUNK_UNIT);
+}
+
+void sys_heap_print_stats(struct sys_heap *heap)
+{
+	heap_print_stats(heap->heap);
+}
+
+void sys_heap_get_stats(struct sys_heap *h, struct sys_heap_stats *stats)
+{
+	stats->avail_chunks = h->heap->avail_chunks;
+	stats->avail_chunks_min = h->heap->avail_chunks_min;
+	stats->avail_contig = h->heap->avail_contig;
+	stats->avail_contig_min = h->heap->avail_contig_min;
 }
 
 void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
@@ -316,11 +386,18 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	h->len = buf_sz;
 	h->avail_buckets = 0;
 
+	h->avail_chunks = buf_sz;
+	h->avail_chunks_min = buf_sz;
+
 	int nb_buckets = bucket_idx(h, buf_sz) + 1;
 	size_t chunk0_size = chunksz(sizeof(struct z_heap) +
 				     nb_buckets * sizeof(struct z_heap_bucket));
 
 	__ASSERT(chunk0_size + min_chunk_size(h) < buf_sz, "heap size is too small");
+
+	h->top_available = chunk0_size;
+	h->avail_contig = buf_sz - chunk0_size;
+	h->avail_contig_min = buf_sz - chunk0_size;
 
 	for (int i = 0; i < nb_buckets; i++) {
 		h->buckets[i].next = 0;

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -61,6 +61,14 @@ struct z_heap {
 	uint64_t chunk0_hdr_area;  /* matches the largest header */
 	uint32_t len;
 	uint32_t avail_buckets;
+
+	uint32_t avail_chunks;
+	uint32_t avail_chunks_min;
+
+	chunkid_t top_available;
+	uint32_t avail_contig;
+	uint32_t avail_contig_min;
+
 	struct z_heap_bucket buckets[0];
 };
 
@@ -129,6 +137,15 @@ static inline void set_chunk_used(struct z_heap *h, chunkid_t c, bool used)
 {
 	chunk_unit_t *buf = chunk_buf(h);
 	void *cmem = &buf[c];
+
+	if (used) {
+		h->avail_chunks -= chunk_size(h, c);
+		if (h->avail_chunks < h->avail_chunks_min) {
+			h->avail_chunks_min = h->avail_chunks;
+		}
+	} else {
+		h->avail_chunks += chunk_size(h, c);
+	}
 
 	if (big_heap(h)) {
 		if (used) {
@@ -231,5 +248,6 @@ static inline int bucket_idx(struct z_heap *h, size_t sz)
 
 /* For debugging */
 void heap_dump(struct z_heap *h);
+void heap_print_stats(struct z_heap *h);
 
 #endif /* ZEPHYR_INCLUDE_LIB_OS_HEAP_H_ */


### PR DESCRIPTION
Adds tracking of available heap memory and contiguous available heap
memory, including historical minimums, for use in development, debugging
and testing.

Other than general feedback, ideas on the best way to slice this up and make it configurable is appreciated. IMO, the tracking of unused space is very cheap and can probably be enabled all the time, but tracking the largest contiguous unused area, while useful to account for fragmentation, could get a lot more expensive in some cases (many similar small free areas).