### PR TITLE
aarch64 Interrupt timer fix and NS-EL1 support

### DIFF
--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -58,6 +58,12 @@ config IPM_CONSOLE_STACK_SIZE
 
 if CPU_CORTEX_A
 
+config ARMV8_A_NS
+	bool "ARMv8-A Normal World (Non-Secure world of Trustzone)"
+	help
+	  This option signifies that Zephyr is entered in TrustZone
+	  Non-Secure state
+
 config ARMV8_A
 	bool
 	select ATOMIC_OPERATIONS_BUILTIN

--- a/arch/arm/core/aarch64/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch64/mmu/arm_mmu.c
@@ -265,7 +265,7 @@ static const struct arm_mmu_region mmu_zephyr_regions[] = {
 	MMU_REGION_FLAT_ENTRY("SRAM",
 			      (uintptr_t)CONFIG_SRAM_BASE_ADDRESS,
 			      (uintptr_t)KB(CONFIG_SRAM_SIZE),
-			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	/* Mark rest of the zephyr execution regions (data, bss, noinit, etc.)
 	 * cacheable, read-write
@@ -274,19 +274,19 @@ static const struct arm_mmu_region mmu_zephyr_regions[] = {
 	MMU_REGION_FLAT_ENTRY("zephyr_data",
 			      (uintptr_t)__kernel_ram_start,
 			      (uintptr_t)__kernel_ram_size,
-			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	/* Mark text segment cacheable,read only and executable */
 	MMU_REGION_FLAT_ENTRY("zephyr_code",
 			      (uintptr_t)_image_text_start,
 			      (uintptr_t)_image_text_size,
-			      MT_NORMAL | MT_P_RX_U_NA | MT_SECURE),
+			      MT_NORMAL | MT_P_RX_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	/* Mark rodata segment cacheable, read only and execute-never */
 	MMU_REGION_FLAT_ENTRY("zephyr_rodata",
 			      (uintptr_t)_image_rodata_start,
 			      (uintptr_t)_image_rodata_size,
-			      MT_NORMAL | MT_P_RO_U_NA | MT_SECURE),
+			      MT_NORMAL | MT_P_RO_U_NA | MT_DEFAULT_SECURE_STATE),
 };
 
 static void setup_page_tables(void)

--- a/boards/arm/qemu_cortex_a53/board.cmake
+++ b/boards/arm/qemu_cortex_a53/board.cmake
@@ -5,9 +5,16 @@ set(EMU_PLATFORM qemu)
 set(QEMU_ARCH aarch64)
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-a53)
+
+if(CONFIG_ARMV8_A_NS)
+set(QEMU_MACH virt,gic-version=3)
+else()
+set(QEMU_MACH virt,secure=on,gic-version=3)
+endif()
+
 set(QEMU_FLAGS_${ARCH}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -nographic
-  -machine virt,secure=on,gic-version=3
+  -machine ${QEMU_MACH}
   )
 board_set_debugger_ifnset(qemu)

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -14,6 +14,11 @@
 /* Redistributor base addresses for each core */
 mem_addr_t gic_rdists[GIC_NUM_CPU_IF];
 
+#ifdef CONFIG_ARMV8_A_NS
+#define IGROUPR_VAL	0xFFFFFFFFU
+#else
+#define IGROUPR_VAL	0x0U
+#endif
 /*
  * Wait for register write pending
  * TODO: add timed wait
@@ -180,12 +185,11 @@ static void gicv3_cpuif_init(void)
 	/* Clear pending */
 	sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG), ICPENDR(base, 0));
 
-	/* Configure all SGIs/PPIs as G1S.
-	 * TODO: G1S or G1NS dependending on Zephyr is run in EL1S
-	 * or EL1NS respectively.
+	/* Configure all SGIs/PPIs as G1S or G1NS depending on Zephyr
+	 * is run in EL1S or EL1NS respectively.
 	 * All interrupts will be delivered as irq
 	 */
-	sys_write32(0, IGROUPR(base, 0));
+	sys_write32(IGROUPR_VAL, IGROUPR(base, 0));
 	sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG), IGROUPMODR(base, 0));
 
 	/*
@@ -236,6 +240,10 @@ static void gicv3_dist_init(void)
 	num_ints &= GICD_TYPER_ITLINESNUM_MASK;
 	num_ints = (num_ints + 1) << 5;
 
+	/* Disable the distributor */
+	sys_write32(0, GICD_CTLR);
+	gic_wait_rwp(GIC_SPI_INT_BASE);
+
 	/*
 	 * Default configuration of all SPIs
 	 */
@@ -248,8 +256,7 @@ static void gicv3_dist_init(void)
 		/* Clear pending */
 		sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG),
 			    ICPENDR(base, idx));
-		/* All SPIs are G1S and owned by Zephyr */
-		sys_write32(0, IGROUPR(base, idx));
+		sys_write32(IGROUPR_VAL, IGROUPR(base, idx));
 		sys_write32(BIT_MASK(GIC_NUM_INTR_PER_REG),
 			    IGROUPMODR(base, idx));
 
@@ -270,8 +277,14 @@ static void gicv3_dist_init(void)
 		sys_write32(0, ICFGR(base, idx));
 	}
 
+#ifdef CONFIG_ARMV8_A_NS
+	/* Enable distributor with ARE */
+	sys_write32(BIT(GICD_CTRL_ARE_NS) | BIT(GICD_CTLR_ENABLE_G1NS),
+		    GICD_CTLR);
+#else
 	/* enable Group 1 secure interrupts */
 	sys_set_bit(GICD_CTLR, GICD_CTLR_ENABLE_G1S);
+#endif
 }
 
 /* TODO: add arm_gic_secondary_init() for multicore support */

--- a/drivers/interrupt_controller/intc_gicv3_priv.h
+++ b/drivers/interrupt_controller/intc_gicv3_priv.h
@@ -34,6 +34,10 @@
 #define GICD_CTLR_ENABLE_G0		0
 #define GICD_CTLR_ENABLE_G1NS		1
 #define GICD_CTLR_ENABLE_G1S		2
+#define GICD_CTRL_ARE_S			4
+#define GICD_CTRL_ARE_NS		5
+#define GICD_CTRL_NS			6
+#define GICD_CGRL_E1NWF			7
 
 /* GICD_CTLR Register write progress bit */
 #define GICD_CTLR_RWP			31

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -36,6 +36,9 @@ static void arm_arch_timer_compare_isr(const void *arg)
 			next_cycle += CYC_PER_TICK;
 		}
 		arm_arch_timer_set_compare(next_cycle);
+		arm_arch_timer_set_irq_mask(false);
+	} else {
+		arm_arch_timer_set_irq_mask(true);
 	}
 
 	k_spin_unlock(&lock, key);
@@ -52,6 +55,7 @@ int z_clock_driver_init(const struct device *device)
 	arm_arch_timer_set_compare(arm_arch_timer_count() + CYC_PER_TICK);
 	arm_arch_timer_enable(true);
 	irq_enable(ARM_ARCH_TIMER_IRQ);
+	arm_arch_timer_set_irq_mask(false);
 
 	return 0;
 }
@@ -83,6 +87,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	arm_arch_timer_set_compare(req_cycle + last_cycle);
+	arm_arch_timer_set_irq_mask(false);
 	k_spin_unlock(&lock, key);
 
 #endif

--- a/include/arch/arm/aarch64/arm_mmu.h
+++ b/include/arch/arm/aarch64/arm_mmu.h
@@ -67,6 +67,12 @@
 #define MT_P_RX_U_RX		(MT_RO | MT_RW_AP_ELx | MT_P_EXECUTE | MT_U_EXECUTE)
 #define MT_P_RX_U_NA		(MT_RO | MT_RW_AP_EL_HIGHER  | MT_P_EXECUTE | MT_U_EXECUTE_NEVER)
 
+#ifdef CONFIG_ARMV8_A_NS
+#define MT_DEFAULT_SECURE_STATE	MT_NS
+#else
+#define MT_DEFAULT_SECURE_STATE	MT_SECURE
+#endif
+
 /*
  * PTE descriptor can be Block descriptor or Table descriptor
  * or Page descriptor.

--- a/include/arch/arm/aarch64/timer.h
+++ b/include/arch/arm/aarch64/timer.h
@@ -21,6 +21,7 @@ extern "C" {
 #define ARM_ARCH_TIMER_FLAGS	ARM_TIMER_VIRTUAL_FLAGS
 
 #define CNTV_CTL_ENABLE		((1) << 0)
+#define CNTV_CTL_IMASK			((1) << 1)
 
 
 static ALWAYS_INLINE void arm_arch_timer_set_compare(uint64_t val)
@@ -36,10 +37,28 @@ static ALWAYS_INLINE void arm_arch_timer_enable(unsigned char enable)
 	__asm__ volatile("mrs %0, cntv_ctl_el0\n\t"
 			 : "=r" (cntv_ctl) :  : "memory");
 
-	if (enable)
+	if (enable) {
 		cntv_ctl |= CNTV_CTL_ENABLE;
-	else
+	} else {
 		cntv_ctl &= ~CNTV_CTL_ENABLE;
+	}
+
+	__asm__ volatile("msr cntv_ctl_el0, %0\n\t"
+			 : : "r" (cntv_ctl) : "memory");
+}
+
+static ALWAYS_INLINE void arm_arch_timer_set_irq_mask(bool mask)
+{
+	uint32_t cntv_ctl;
+
+	__asm__ volatile("mrs %0, cntv_ctl_el0\n\t"
+			 : "=r" (cntv_ctl) :  : "memory");
+
+	if (mask) {
+		cntv_ctl |= CNTV_CTL_IMASK;
+	} else {
+		cntv_ctl &= ~CNTV_CTL_IMASK;
+	}
 
 	__asm__ volatile("msr cntv_ctl_el0, %0\n\t"
 			 : : "r" (cntv_ctl) : "memory");

--- a/soc/arm/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a53/mmu_regions.c
@@ -14,17 +14,17 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_SECURE),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_SECURE),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	MMU_REGION_FLAT_ENTRY("UART",
 			      DT_REG_ADDR(DT_INST(0, arm_pl011)),
 			      DT_REG_SIZE(DT_INST(0, arm_pl011)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_SECURE),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
This is to unmask aarch64 generic timer interrupt and make it could work in NS-EL1.

For the SPI part, I am not sure it might break your current settings. I kick zephyr in NS-EL1 state, not in EL3.