### PR TITLE
tests: fs: check for arguments NULLness

### DIFF
--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -295,11 +295,11 @@ static int temp_statvfs(struct fs_mount_t *mountp,
 
 static int temp_mount(struct fs_mount_t *mountp)
 {
-	size_t len = strlen(mountp->mnt_point);
-
 	if (mountp == NULL) {
 		return -EINVAL;
 	}
+
+	size_t len = strlen(mountp->mnt_point);
 
 	if (mountp->mnt_point[len - 1] != ':') {
 		return -EINVAL;


### PR DESCRIPTION
Before dereferencing mountp argument, check for it's NULLness

Fixes #29704

Signed-off-by: iva kik <megatheriumiva@gmail.com>