### PR TITLE
drivers: wifi: esp: increase default RX net_pkt allocation timeout

### DIFF
--- a/drivers/wifi/esp/Kconfig.esp
+++ b/drivers/wifi/esp/Kconfig.esp
@@ -77,7 +77,7 @@ config WIFI_ESP_RESET_TIMEOUT
 
 config WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT
 	int "Network interface RX packet allocation timeout"
-	default 100
+	default 5000
 	help
 	  Network interface RX net_pkt allocation timeout in milliseconds.
 

--- a/drivers/wifi/esp/Kconfig.esp
+++ b/drivers/wifi/esp/Kconfig.esp
@@ -75,6 +75,12 @@ config WIFI_ESP_RESET_TIMEOUT
 	  sent. This can vary with chipset (ESP8266/ESP32) and firmware
 	  version. This is ignored if a reset pin is configured.
 
+config WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT
+	int "Network interface RX packet allocation timeout"
+	default 100
+	help
+	  Network interface RX net_pkt allocation timeout in milliseconds.
+
 choice WIFI_ESP_AT_VERSION
 	prompt "AT version"
 	default WIFI_ESP_AT_VERSION_2_0

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -27,6 +27,9 @@ LOG_MODULE_REGISTER(wifi_esp);
 
 #include "esp.h"
 
+#define RX_NET_PKT_ALLOC_TIMEOUT				\
+	K_MSEC(CONFIG_WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT)
+
 /* pin settings */
 enum modem_control_pins {
 #if DT_INST_NODE_HAS_PROP(0, power_gpios)
@@ -322,7 +325,7 @@ struct net_pkt *esp_prepare_pkt(struct esp_data *dev, struct net_buf *src,
 	size_t to_copy;
 
 	pkt = net_pkt_rx_alloc_with_buffer(dev->net_iface, len, AF_UNSPEC,
-					   0, K_MSEC(100));
+					   0, RX_NET_PKT_ALLOC_TIMEOUT);
 	if (!pkt) {
 		return NULL;
 	}


### PR DESCRIPTION
There is now a hardcoded 100ms timeout on allocating new net_pkt for
received data. Move that configuration to Kconfig, so that value can be
tuned according to application needs.

This 100ms is too little for cases when lots of data are incoming on pretty
fast (e.g. 1Mbps) UART interface and application layer does not consume
received network packets fast enough. Up to now in such cases all
incoming data was processed from UART and there was no data loss when
utilizing hardware flow control. However there was high chance that data
processed from UART could not be passed further to network stack,
because of the 100ms net_pkt allocation timeout. This happens for
example when low priority application does not have enough time to run.

Increase default RX net_pkt allocation timeout from 100ms to 5s, so
there is much more time to process network packets. Such timeout should
not harm, because only a dedicated RX thread will be suspended for that
time, resulting in suspending UART traffic if hardware flow control is
supported.