### PR TITLE
net: tls: fix tls_context leak in ztls_socket() error path

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1251,12 +1251,12 @@ static int ztls_socket(int family, int type, int proto)
 	ctx = tls_alloc();
 	if (ctx == NULL) {
 		errno = ENOMEM;
-		goto error;
+		goto free_fd;
 	}
 
 	sock = zsock_socket(family, type, proto);
 	if (sock < 0) {
-		goto error;
+		goto release_tls;
 	}
 
 	ctx->tls_version = tls_proto;
@@ -1268,7 +1268,10 @@ static int ztls_socket(int family, int type, int proto)
 
 	return fd;
 
-error:
+release_tls:
+	(void)tls_release(ctx);
+
+free_fd:
 	z_free_fd(fd);
 
 	return -1;


### PR DESCRIPTION
If there are enough tls_context objects in the system (configured by
CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS), but there are not enough file
descriptors (configured by CONFIG_POSIX_MAX_FDS) to create underneath
TCP/UDP socket, then TLS socket creation fails with leaked tls_context.

Call tls_release() in ztls_socket() error path whenever underneath
TCP/UDP socket creation fails.