### PR TITLE
ci: github: Update for deprecation of add-path

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Update PATH for west
       run: |
-        echo "::add-path::$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Update PATH for west
       run: |
-        echo "::add-path::$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Determine tag
       id: tag


### PR DESCRIPTION
Github has deprecated add-path, so update the workflows that use it to
the new method of setting the PATH.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>