### PR TITLE
net: lwm2m: Add a callback to notify socket errors to engine users

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -63,6 +63,8 @@
 #define IPSO_OBJECT_PUSH_BUTTON_ID          3347
 /* clang-format on */
 
+typedef void (*lwm2m_socket_fault_cb_t)(int error);
+
 /**
  * @brief LwM2M context structure to maintain information for a single
  * LwM2M connection.
@@ -109,6 +111,11 @@ struct lwm2m_ctx {
 
 	/** Socket File Descriptor */
 	int sock_fd;
+
+	/** Socket fault callback. LwM2M processing thread will call this
+	 *  callback in case of socket errors on receive.
+	 */
+	lwm2m_socket_fault_cb_t fault_cb;
 };
 
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4234,9 +4234,10 @@ static void socket_receive_loop(void)
 			    (sock_fds[i].revents & POLLHUP)) {
 				LOG_ERR("Poll reported a socket error, %02x.",
 					sock_fds[i].revents);
-#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
-				engine_trigger_restart();
-#endif
+				if (sock_ctx[i] != NULL &&
+				    sock_ctx[i]->fault_cb != NULL) {
+					sock_ctx[i]->fault_cb(EIO);
+				}
 				continue;
 			}
 
@@ -4254,9 +4255,9 @@ static void socket_receive_loop(void)
 
 			if (len < 0) {
 				LOG_ERR("Error reading response: %d", errno);
-#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
-				engine_trigger_restart();
-#endif
+				if (sock_ctx[i]->fault_cb != NULL) {
+					sock_ctx[i]->fault_cb(errno);
+				}
 				continue;
 			}
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -197,8 +197,10 @@ static void sm_handle_timeout_state(struct lwm2m_message *msg,
 }
 
 /* force state machine restart */
-void engine_trigger_restart(void)
+static void socket_fault_cb(int error)
 {
+	LOG_ERR("RD Client socket error: %d", error);
+
 	lwm2m_engine_context_close(client.ctx);
 
 	client.ctx->sec_obj_inst = -1;
@@ -983,6 +985,7 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 
 	client.ctx = client_ctx;
 	client.ctx->sock_fd = -1;
+	client.ctx->fault_cb = socket_fault_cb;
 	client.event_cb = event_cb;
 	client.use_bootstrap = flags & LWM2M_RD_CLIENT_FLAG_BOOTSTRAP;
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -38,7 +38,6 @@
 #ifndef LWM2M_RD_CLIENT_H
 #define LWM2M_RD_CLIENT_H
 
-void engine_trigger_restart(void);
 void engine_trigger_update(bool update_objects);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);


### PR DESCRIPTION
Currently, when socket errors occur during receive, the LwM2M engine
restarts the state machine and registers again to the server. While this
works in simple use case (only RD client socket open), it's not a valid
approach when more sockets are open (FW update socket).

Fix this by introducing socket fault callback, which is registered by
the LwM2M engine users. This way, a proper socket owner is notified on
error and can pertake appropriate action.

For RD socket errors the behaviour remains the same - the state machine
is reset and the client registers again to the server. For FW update
socket, handle the error by reopening the socket and retransmitting the
last request. This allows to resume the download from the point the
error occured, w/o a need to start from scratch.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>