### PR TITLE
Bluetooth: controller: Fix missing storage for sync cancel reason

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4076,16 +4076,16 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 static void le_conn_complete(struct pdu_data *pdu_data, uint16_t handle,
 			     struct net_buf *buf)
 {
-	struct node_rx_cc *node_rx = (void *)pdu_data;
+	struct node_rx_cc *cc = (void *)pdu_data;
 	struct bt_hci_evt_le_conn_complete *lecc;
-	uint8_t status = node_rx->status;
+	uint8_t status = cc->status;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	if (!status) {
 		/* Update current RPA */
-		ll_rl_crpa_set(node_rx->peer_addr_type,
-			       &node_rx->peer_addr[0], 0xff,
-			       &node_rx->peer_rpa[0]);
+		ll_rl_crpa_set(cc->peer_addr_type,
+			       &cc->peer_addr[0], 0xff,
+			       &cc->peer_rpa[0]);
 	}
 #endif
 
@@ -4118,26 +4118,26 @@ static void le_conn_complete(struct pdu_data *pdu_data, uint16_t handle,
 
 		leecc->status = 0x00;
 		leecc->handle = sys_cpu_to_le16(handle);
-		leecc->role = node_rx->role;
+		leecc->role = cc->role;
 
-		leecc->peer_addr.type = node_rx->peer_addr_type;
-		memcpy(&leecc->peer_addr.a.val[0], &node_rx->peer_addr[0],
+		leecc->peer_addr.type = cc->peer_addr_type;
+		memcpy(&leecc->peer_addr.a.val[0], &cc->peer_addr[0],
 		       BDADDR_SIZE);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-		memcpy(&leecc->local_rpa.val[0], &node_rx->local_rpa[0],
+		memcpy(&leecc->local_rpa.val[0], &cc->local_rpa[0],
 		       BDADDR_SIZE);
-		memcpy(&leecc->peer_rpa.val[0], &node_rx->peer_rpa[0],
+		memcpy(&leecc->peer_rpa.val[0], &cc->peer_rpa[0],
 		       BDADDR_SIZE);
 #else /* !CONFIG_BT_CTLR_PRIVACY */
 		memset(&leecc->local_rpa.val[0], 0, BDADDR_SIZE);
 		memset(&leecc->peer_rpa.val[0], 0, BDADDR_SIZE);
 #endif /* !CONFIG_BT_CTLR_PRIVACY */
 
-		leecc->interval = sys_cpu_to_le16(node_rx->interval);
-		leecc->latency = sys_cpu_to_le16(node_rx->latency);
-		leecc->supv_timeout = sys_cpu_to_le16(node_rx->timeout);
-		leecc->clock_accuracy = node_rx->sca;
+		leecc->interval = sys_cpu_to_le16(cc->interval);
+		leecc->latency = sys_cpu_to_le16(cc->latency);
+		leecc->supv_timeout = sys_cpu_to_le16(cc->timeout);
+		leecc->clock_accuracy = cc->sca;
 		return;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY || CONFIG_BT_CTLR_ADV_EXT */
@@ -4152,13 +4152,13 @@ static void le_conn_complete(struct pdu_data *pdu_data, uint16_t handle,
 
 	lecc->status = 0x00;
 	lecc->handle = sys_cpu_to_le16(handle);
-	lecc->role = node_rx->role;
-	lecc->peer_addr.type = node_rx->peer_addr_type & 0x1;
-	memcpy(&lecc->peer_addr.a.val[0], &node_rx->peer_addr[0], BDADDR_SIZE);
-	lecc->interval = sys_cpu_to_le16(node_rx->interval);
-	lecc->latency = sys_cpu_to_le16(node_rx->latency);
-	lecc->supv_timeout = sys_cpu_to_le16(node_rx->timeout);
-	lecc->clock_accuracy = node_rx->sca;
+	lecc->role = cc->role;
+	lecc->peer_addr.type = cc->peer_addr_type & 0x1;
+	memcpy(&lecc->peer_addr.a.val[0], &cc->peer_addr[0], BDADDR_SIZE);
+	lecc->interval = sys_cpu_to_le16(cc->interval);
+	lecc->latency = sys_cpu_to_le16(cc->latency);
+	lecc->supv_timeout = sys_cpu_to_le16(cc->timeout);
+	lecc->clock_accuracy = cc->sca;
 }
 
 void hci_disconn_complete_encode(struct pdu_data *pdu_data, uint16_t handle,

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -281,9 +281,16 @@ struct node_rx_hdr {
 	};
 };
 
+/* Template node rx type with memory aligned offset to PDU buffer.
+ * NOTE: offset to memory aligned pdu buffer location is used to reference
+ *       node rx type specific information, like, terminate or sync lost reason
+ *       from a dedicated node rx structure storage location.
+ */
 struct node_rx_pdu {
 	struct node_rx_hdr hdr;
-	uint8_t               pdu[0];
+	union {
+		uint8_t    pdu[0] __aligned(4);
+	};
 };
 
 enum {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -159,9 +159,17 @@ struct ll_conn {
 		uint8_t ack;
 		uint8_t reason_own;
 		uint8_t reason_peer;
+		/* node rx type with memory aligned storage for terminate
+		 * reason.
+		 * HCI will reference the value using the pdu member of
+		 * struct node_rx_pdu.
+		 */
 		struct {
 			struct node_rx_hdr hdr;
-			uint8_t reason;
+			union {
+				uint8_t    pdu[0] __aligned(4);
+				uint8_t    reason;
+			};
 		} node_rx;
 	} llcp_terminate;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -153,7 +153,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	lll_sync->is_enabled = options & BIT(1);
 
 	/* sync_lost node_rx */
-	sync->node_rx_lost.link = link_sync_lost;
+	sync->node_rx_lost.hdr.link = link_sync_lost;
 
 	/* Initialise ULL and LLL headers */
 	ull_hdr_init(&sync->ull);
@@ -205,17 +205,17 @@ uint8_t ll_sync_create_cancel(void **rx)
 
 	node_rx = (void *)scan->per_scan.node_rx_estab;
 	link_sync_estab = node_rx->hdr.link;
-	link_sync_lost = sync->node_rx_lost.link;
+	link_sync_lost = sync->node_rx_lost.hdr.link;
 
 	ll_rx_link_release(link_sync_lost);
 	ll_rx_link_release(link_sync_estab);
 	ll_rx_release(node_rx);
 
-	node_rx = (void *)&sync->node_rx_lost;
+	node_rx = (void *)&sync->node_rx_lost.hdr;
 	node_rx->hdr.type = NODE_RX_TYPE_SYNC;
 	node_rx->hdr.handle = 0xffff;
 	node_rx->hdr.rx_ftr.param = sync;
-	se = (void *)node_rx->pdu;
+	se = (void *)&sync->node_rx_lost.reason;
 	se->status = BT_HCI_ERR_OP_CANCELLED_BY_HOST;
 
 	*rx = node_rx;
@@ -254,7 +254,7 @@ uint8_t ll_sync_terminate(uint16_t handle)
 	mark = ull_disable_unmark(sync);
 	LL_ASSERT(mark == sync);
 
-	link_sync_lost = sync->node_rx_lost.link;
+	link_sync_lost = sync->node_rx_lost.hdr.link;
 	ll_rx_link_release(link_sync_lost);
 
 	ull_sync_release(sync);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -211,12 +211,20 @@ uint8_t ll_sync_create_cancel(void **rx)
 	ll_rx_link_release(link_sync_estab);
 	ll_rx_release(node_rx);
 
-	node_rx = (void *)&sync->node_rx_lost.hdr;
+	node_rx = (void *)&sync->node_rx_lost;
 	node_rx->hdr.type = NODE_RX_TYPE_SYNC;
 	node_rx->hdr.handle = 0xffff;
-	node_rx->hdr.rx_ftr.param = sync;
-	se = (void *)&sync->node_rx_lost.reason;
+
+	/* NOTE: struct node_rx_lost has uint8_t member following the
+	 *       struct node_rx_hdr to store the reason.
+	 */
+	se = (void *)node_rx->pdu;
 	se->status = BT_HCI_ERR_OP_CANCELLED_BY_HOST;
+
+	/* NOTE: Since NODE_RX_TYPE_SYNC is only generated from ULL context,
+	 *       pass ULL context as parameter.
+	 */
+	node_rx->hdr.rx_ftr.param = sync;
 
 	*rx = node_rx;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -18,7 +18,10 @@ struct ll_sync_set {
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */
 	uint16_t timeout_expire;
 
-	struct node_rx_hdr node_rx_lost;
+	struct {
+		struct node_rx_hdr hdr;
+		uint8_t reason;
+	} node_rx_lost;
 };
 
 struct node_rx_sync {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -18,9 +18,16 @@ struct ll_sync_set {
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */
 	uint16_t timeout_expire;
 
+	/* node rx type with memory aligned storage for sync lost reason.
+	 * HCI will reference the value using the pdu member of
+	 * struct node_rx_pdu.
+	 */
 	struct {
 		struct node_rx_hdr hdr;
-		uint8_t reason;
+		union {
+			uint8_t    pdu[0] __aligned(4);
+			uint8_t    reason;
+		};
 	} node_rx_lost;
 };
 


### PR DESCRIPTION
Fix missing storage allocation in ll_sync_set structure for
storing the sync cancel reason.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>