### PR TITLE
doc: bump sphinx>=3.3.0

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,7 +2,7 @@
 
 breathe>=4.23.0
 docutils>=0.16
-sphinx>=3.2.0,<4.0
+sphinx>=3.3.0,<4.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
The filters were updated to match the 3.3.0 generated text, so update
the sphinx requirement to exclude versions that use different text.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>