### PR TITLE
net: ping: add warning if ping is not supported

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3782,6 +3782,8 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 				PR_WARNING("Cannot send IPv4 ping\n");
 			} else if (ret == -EINVAL) {
 				PR_WARNING("Invalid IP address\n");
+			} else if (ret == -ENOTSUP) {
+				PR_WARNING("Feature is not supported\n");
 			}
 
 			return -ENOEXEC;


### PR DESCRIPTION
Warn the user that "ping" is not supported in case of offloaded
driver is being used.

Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>