### PR TITLE
drivers: wifi: rename WiFi kconfig prompt

### DIFF
--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig WIFI
-	bool "add support for Wi-Fi Drivers"
+	bool "Wi-Fi Drivers"
 
 if WIFI
 


### PR DESCRIPTION
Use the same naming convention for WIFI kconfig drivers

Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>