### PR TITLE
dt: child binding compatibles should match their parents

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1390,9 +1390,10 @@ class Binding:
       The free-form description of the binding.
 
     compatible:
-      The compatible string the binding matches. This may be None if the
-      Binding object is a child binding or if it's inferred from node
-      properties.
+      The compatible string the binding matches. This is None if the Binding is
+      inferred from node properties. If the Binding is a child binding, then
+      this will be inherited from the parent binding unless the child binding
+      explicitly sets its own compatible.
 
     prop2specs:
       A collections.OrderedDict mapping property names to PropertySpec objects
@@ -1508,6 +1509,14 @@ class Binding:
             if key.endswith("-cells"):
                 self.specifier2cells[key[:-len("-cells")]] = val
 
+        # Make child binding compatibles match ours if they are missing.
+        if self.compatible is not None:
+            child = self.child_binding
+            while child is not None:
+                if child.compatible is None:
+                    child.compatible = self.compatible
+                child = child.child_binding
+
         # Drop the reference to the open warn file. This is necessary
         # to make this object pickleable, but also allows it to get
         # garbage collected and closed if nobody else is using it.
@@ -1528,7 +1537,14 @@ class Binding:
     @property
     def compatible(self):
         "See the class docstring"
+        if hasattr(self, '_compatible'):
+            return self._compatible
         return self.raw.get('compatible')
+
+    @compatible.setter
+    def compatible(self, compatible):
+        "See the class docstring"
+        self._compatible = compatible
 
     @property
     def bus(self):

--- a/scripts/dts/test-bindings/child-binding-with-compat.yaml
+++ b/scripts/dts/test-bindings/child-binding-with-compat.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: child-binding with separate compatible than the parent
+
+compatible: "child-binding-with-compat"
+
+child-binding:
+    compatible: child-compat
+    description: child node
+    properties:
+        child-prop:
+            type: int
+            required: true
+
+    child-binding:
+        description: grandchild node
+        properties:
+            grandchild-prop:
+                type: int
+                required: true

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -137,7 +137,6 @@ def test_bus():
     assert str(edt.get_node("/buses/foo-bus/node/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
 
-@pytest.mark.xfail
 def test_child_binding():
     '''Test 'child-binding:' in bindings'''
     edt = edtlib.EDT("test.dts", ["test-bindings"])

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -137,6 +137,7 @@ def test_bus():
     assert str(edt.get_node("/buses/foo-bus/node/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
 
+@pytest.mark.xfail
 def test_child_binding():
     '''Test 'child-binding:' in bindings'''
     edt = edtlib.EDT("test.dts", ["test-bindings"])
@@ -155,6 +156,22 @@ def test_child_binding():
     assert str(grandchild.binding_path) == hpath("test-bindings/child-binding.yaml")
     assert str(grandchild.description) == "grandchild node"
     assert str(grandchild.props) == "OrderedDict([('grandchild-prop', <Property, name: grandchild-prop, type: int, value: 2>)])"
+
+    binding_file = Path("test-bindings/child-binding.yaml").resolve()
+    top = edtlib.Binding(binding_file, {})
+    child = top.child_binding
+    assert Path(top.path) == binding_file
+    assert Path(child.path) == binding_file
+    assert top.compatible == 'child-binding'
+    assert child.compatible == 'child-binding'
+
+    binding_file = Path("test-bindings/child-binding-with-compat.yaml").resolve()
+    top = edtlib.Binding(binding_file, {})
+    child = top.child_binding
+    assert Path(top.path) == binding_file
+    assert Path(child.path) == binding_file
+    assert top.compatible == 'child-binding-with-compat'
+    assert child.compatible == 'child-compat'
 
 def test_props():
     '''Test Node.props (derived from DT and 'properties:' in the binding)'''


### PR DESCRIPTION
Fixes: #29758

See commit log in the second patch for details.