### PR TITLE
Doc: add test specifications into zephyr documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -118,6 +118,7 @@ licensing, as described in :ref:`Zephyr_Licensing`.
    security/index.rst
    samples/index.rst
    boards/index.rst
+   test_specification/index.rst
    releases/index.rst
 
 .. only:: html

--- a/doc/test_specification/index.rst
+++ b/doc/test_specification/index.rst
@@ -1,0 +1,11 @@
+Test specification
+####################
+
+Welcome to Zephyr RTOS Software test specification documentation!
+
+
+.. toctree::
+   :maxdepth: 2
+
+   integration_spec/index
+   module_spec/index

--- a/doc/test_specification/integration_spec/environment.rst
+++ b/doc/test_specification/integration_spec/environment.rst
@@ -1,0 +1,47 @@
+.. _integration_spec_environment:
+
+Environment
+############
+
+Description of intergration testing environment, including software, hardware environment.
+
+We use a script named sanitycheck to run intergration testcases.
+This script scans for the set of unit test applications in the git repository
+and attempts to execute them. By default, it tries to build each test
+case on boards marked as default in the board definition file.
+
+The default options will build the majority of the tests on a defined set of
+boards and will run in an emulated environment if available for the
+architecture or configuration being tested.
+
+In normal use, sanitycheck runs a limited set of kernel tests (inside
+an emulator).  Because of its limited test execution coverage, sanitycheck
+cannot guarantee local changes will succeed in the full build
+environment, but it does sufficient testing by building samples and
+tests for different boards and different configurations to help keep the
+complete code tree buildable.
+
+When using (at least) one ``-v`` option, sanitycheck's console output
+shows for every test how the test is run (qemu, native_posix, etc.) or
+whether the binary was just built.
+
+To run the script in the local tree, follow the steps below:
+
+::
+
+        $ source zephyr-env.sh
+        $ ./scripts/sanitycheck
+
+If you have a system with a large number of cores, you can build and run
+all possible tests using the following options:
+
+::
+
+        $ ./scripts/sanitycheck --all --enable-slow
+
+This will build for all available boards and run all applicable tests in
+a simulated (for example QEMU) environment.
+
+The list of command line options supported by sanitycheck can be viewed using::
+
+        $ ./scripts/sanitycheck --help

--- a/doc/test_specification/integration_spec/index.rst
+++ b/doc/test_specification/integration_spec/index.rst
@@ -1,0 +1,12 @@
+Integration test specification
+###############################
+
+Welcome to Zephyr RTOS Software integration test specification documentation!
+
+
+.. toctree::
+   :maxdepth: 2
+
+   overrall
+   environment
+   modules/index

--- a/doc/test_specification/integration_spec/modules/index.rst
+++ b/doc/test_specification/integration_spec/modules/index.rst
@@ -1,0 +1,10 @@
+.. _Integration_TestCases:
+
+Integration Test cases
+########################
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   smp

--- a/doc/test_specification/integration_spec/modules/smp.rst
+++ b/doc/test_specification/integration_spec/modules/smp.rst
@@ -1,0 +1,10 @@
+.. _integration_smp:
+
+smp
+############
+
+integration testcases
+======================
+
+.. doxygengroup:: kernel_smp_integration_tests
+    :project: Zephyr

--- a/doc/test_specification/integration_spec/overrall.rst
+++ b/doc/test_specification/integration_spec/overrall.rst
@@ -1,0 +1,6 @@
+.. _integration_overrall:
+
+Overrall
+#########
+
+This is a software integration test specification for zephyr RTOS prject. This document provides a generic verification specification suitable for use in developments.

--- a/doc/test_specification/module_spec/environment.rst
+++ b/doc/test_specification/module_spec/environment.rst
@@ -1,0 +1,47 @@
+.. _modue_spec_environment:
+
+Environment
+############
+
+Description of module testing environment, including software, hardware environment.
+
+We use a script named sanitycheck to run module testcases.
+This script scans for the set of unit test applications in the git repository
+and attempts to execute them. By default, it tries to build each test
+case on boards marked as default in the board definition file.
+
+The default options will build the majority of the tests on a defined set of
+boards and will run in an emulated environment if available for the
+architecture or configuration being tested.
+
+In normal use, sanitycheck runs a limited set of kernel tests (inside
+an emulator).  Because of its limited test execution coverage, sanitycheck
+cannot guarantee local changes will succeed in the full build
+environment, but it does sufficient testing by building samples and
+tests for different boards and different configurations to help keep the
+complete code tree buildable.
+
+When using (at least) one ``-v`` option, sanitycheck's console output
+shows for every test how the test is run (qemu, native_posix, etc.) or
+whether the binary was just built.
+
+To run the script in the local tree, follow the steps below:
+
+::
+
+        $ source zephyr-env.sh
+        $ ./scripts/sanitycheck
+
+If you have a system with a large number of cores, you can build and run
+all possible tests using the following options:
+
+::
+
+        $ ./scripts/sanitycheck --all --enable-slow
+
+This will build for all available boards and run all applicable tests in
+a simulated (for example QEMU) environment.
+
+The list of command line options supported by sanitycheck can be viewed using::
+
+        $ ./scripts/sanitycheck --help

--- a/doc/test_specification/module_spec/index.rst
+++ b/doc/test_specification/module_spec/index.rst
@@ -1,0 +1,12 @@
+Module test specification
+##########################
+
+Welcome to Zephyr RTOS Software module test specification documentation!
+
+
+.. toctree::
+   :maxdepth: 2
+
+   overrall
+   environment
+   modules/index

--- a/doc/test_specification/module_spec/modules/index.rst
+++ b/doc/test_specification/module_spec/modules/index.rst
@@ -1,0 +1,10 @@
+.. _module_TestCases:
+
+module Test cases
+##################
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   smp

--- a/doc/test_specification/module_spec/modules/smp.rst
+++ b/doc/test_specification/module_spec/modules/smp.rst
@@ -1,0 +1,10 @@
+.. _module_smp:
+
+Smp
+##########
+
+module testcases
+=================
+
+.. doxygengroup:: kernel_smp_module_tests
+    :project: Zephyr

--- a/doc/test_specification/module_spec/overrall.rst
+++ b/doc/test_specification/module_spec/overrall.rst
@@ -1,0 +1,6 @@
+.. _module_overrall:
+
+Overrall
+#########
+
+This is a software module test specification for zephyr RTOS prject. This document provides a generic verification specification suitable for use in developments.


### PR DESCRIPTION
Add test specifications into zephyr doc, this entry will show up in
left side navigation pane, and it contains two categories: integration
and module test specification.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>