### PR TITLE
net: openthread: allow to configure platform info

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -59,6 +59,10 @@ config OPENTHREAD_MAX_CHILDREN
 	default 32
 
 config OPENTHREAD_MAX_IP_ADDR_PER_CHILD
-	int "The maximum number of IPv6 address registrations per child."
+	int "The maximum number of IPv6 address registrations per child"
 	range 4 255
 	default 6
+
+config OPENTHREAD_CONFIG_PLATFORM_INFO
+	string "The platform-specific string to insert into the OpenThread version string"
+	default "Zephyr"

--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -55,7 +55,7 @@ config OPENTHREAD_POLL_PERIOD
 
 config OPENTHREAD_MAX_CHILDREN
 	int "The maximum number of children"
-	range 10 512
+	range 10 511
 	default 32
 
 config OPENTHREAD_MAX_IP_ADDR_PER_CHILD

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -123,6 +123,16 @@
 #define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 0
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_INFO
+ *
+ * The platform-specific string to insert into the OpenThread version string.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_CONFIG_PLATFORM_INFO
+#define OPENTHREAD_CONFIG_PLATFORM_INFO CONFIG_OPENTHREAD_CONFIG_PLATFORM_INFO
+#endif /* CONFIG_OPENTHREAD_CONFIG_PLATFORM_INFO */
+
+/**
  * @def OPENTHREAD_CONFIG_MLE_MAX_CHILDREN
  *
  * The maximum number of children.


### PR DESCRIPTION
This commit adds the option to configure the platform information string of OpenThread.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>