### PR TITLE
mgmt/osdp: Fix build issue

### DIFF
--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -989,8 +989,10 @@ int osdp_cp_send_command(int pd, struct osdp_cmd *cmd)
 	case OSDP_CMD_COMSET:
 		cmd_id = CMD_COMSET;
 		break;
+#ifdef CONFIG_OSDP_SC_ENABLED
 	case OSDP_CMD_KEYSET:
 		return osdp_cp_send_command_keyset(&cmd->keyset);
+#endif
 	default:
 		LOG_ERR(TAG "Invalid command ID %d", cmd->id);
 		return -1;


### PR DESCRIPTION
When building the osdsp control_panel sample we get the following
compile error:

subsys/mgmt/osdp/src/osdp_cp.c:993:10: error: implicit declaration of
function 'osdp_cp_send_command_keyset'

Fix by adding ifdef protection around the call to
osdp_cp_send_command_keyset

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>