### PR TITLE
logging: fix cmd_log_self_disable argc checker

### DIFF
--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -441,7 +441,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_stat,
 	SHELL_CMD_ARG(disable, &dsub_module_name,
 	"'log disable <module_0> .. <module_n>' disables logs in specified "
 	"modules (all if no modules specified).",
-	cmd_log_self_disable, 2, 255),
+	cmd_log_self_disable, 1, 255),
 	SHELL_CMD_ARG(enable, &dsub_severity_lvl,
 	"'log enable <level> <module_0> ...  <module_n>' enables logs up to"
 	" given level in specified modules (all if no modules specified).",


### PR DESCRIPTION
according to the comment "all if no modules specified"
reducing to 1 number of parameters to support "all" state

Signed-off-by: Ehud Naim <ehudn@marvell.com>