### PR TITLE
net: tls: use Maximum Fragment Length (MFL) extension by default

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -54,6 +54,22 @@ config NET_SOCKETS_SOCKOPT_TLS
 	  Enable TLS socket option support which automatically establishes
 	  a TLS connection to the remote host.
 
+config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+	bool "Set Maximum Fragment Length (MFL)"
+	default y
+	help
+	  Call mbedtls_ssl_conf_max_frag_len() on created TLS context
+	  configuration, so that Maximum Fragment Length (MFL) will be sent to
+	  peer using RFC 6066 max_fragment_length extension.
+
+	  Maximum Fragment Length (MFL) value is automatically chosen based on
+	  MBEDTLS_SSL_OUT_CONTENT_LEN and MBEDTLS_SSL_IN_CONTENT_LEN mbed TLS
+	  macros (which are configured by CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN in
+	  case of default mbed TLS config).
+
+	  This is mostly useful for TLS client side to tell TLS server what is
+	  the maximum supported receive record length.
+
 config NET_SOCKETS_ENABLE_DTLS
 	bool "Enable DTLS socket support [EXPERIMENTAL]"
 	depends on NET_SOCKETS_SOCKOPT_TLS

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -323,6 +323,53 @@ static inline bool is_handshake_complete(struct tls_context *ctx)
 	return k_sem_count_get(&ctx->tls_established) != 0;
 }
 
+/*
+ * Copied from include/mbedtls/ssl_internal.h
+ *
+ * Maximum length we can advertise as our max content length for
+ * RFC 6066 max_fragment_length extension negotiation purposes
+ * (the lesser of both sizes, if they are unequal.)
+ */
+#define MBEDTLS_TLS_EXT_ADV_CONTENT_LEN (                            \
+	(MBEDTLS_SSL_IN_CONTENT_LEN > MBEDTLS_SSL_OUT_CONTENT_LEN)   \
+	? (MBEDTLS_SSL_OUT_CONTENT_LEN)				     \
+	: (MBEDTLS_SSL_IN_CONTENT_LEN)				     \
+	)
+
+#if defined(CONFIG_NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH) &&	\
+	defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) &&		\
+	(MBEDTLS_TLS_EXT_ADV_CONTENT_LEN < 16384)
+
+BUILD_ASSERT(MBEDTLS_TLS_EXT_ADV_CONTENT_LEN >= 512,
+	     "Too small content length!");
+
+static inline unsigned char tls_mfl_code_from_content_len(void)
+{
+	size_t len = MBEDTLS_TLS_EXT_ADV_CONTENT_LEN;
+
+	if (len >= 4096) {
+		return MBEDTLS_SSL_MAX_FRAG_LEN_4096;
+	} else if (len >= 2048) {
+		return MBEDTLS_SSL_MAX_FRAG_LEN_2048;
+	} else if (len >= 1024) {
+		return MBEDTLS_SSL_MAX_FRAG_LEN_1024;
+	} else if (len >= 512) {
+		return MBEDTLS_SSL_MAX_FRAG_LEN_512;
+	} else {
+		return MBEDTLS_SSL_MAX_FRAG_LEN_INVALID;
+	}
+}
+
+static inline void tls_set_max_frag_len(mbedtls_ssl_config *config)
+{
+	unsigned char mfl_code = tls_mfl_code_from_content_len();
+
+	mbedtls_ssl_conf_max_frag_len(config, mfl_code);
+}
+#else
+static inline void tls_set_max_frag_len(mbedtls_ssl_config *config) {}
+#endif
+
 /* Allocate TLS context. */
 static struct tls_context *tls_alloc(void)
 {
@@ -351,6 +398,7 @@ static struct tls_context *tls_alloc(void)
 
 		mbedtls_ssl_init(&tls->ssl);
 		mbedtls_ssl_config_init(&tls->config);
+		tls_set_max_frag_len(&tls->config);
 #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
 		mbedtls_ssl_cookie_init(&tls->cookie);
 #endif


### PR DESCRIPTION
Call mbedtls_ssl_conf_max_frag_len() on created TLS context
configuration, so that Maximum Fragment Length (MFL) will be sent to
peer using RFC 6066 max_fragment_length extension. MFL value is
automatically chosen based on MBEDTLS_SSL_OUT_CONTENT_LEN and
MBEDTLS_SSL_IN_CONTENT_LEN mbed TLS macros.

This extension is mostly useful for TLS client side to tell TLS server
what is the maximum supported receive record length.

Tested with simple Flask server serving files (few hundred KB in size):
```
#!/usr/bin/env python3

from errno import ENOENT
from flask import Flask

app = Flask(__name__)

@app.route('/file/<name>')
def file_get(name):
    try:
        with open(f'{name}', "rb") as fp:
            return fp.read()
    except FileNotFoundError as e:
        if e.errno != ENOENT:
            raise e

    return ("", 404)

if __name__ == '__main__':
    app.run(host="0.0.0.0", port=8080, threaded=True, ssl_context='adhoc')
```
Before that change `CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384` 
needed to be configured to successfully download file. Right now even
`CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=1024` is enough, which
saves a lot of RAM memory for other application features.