### PR TITLE
scripts: menuconfig: revoke official Windows support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -468,7 +468,6 @@
 /scripts/coccicheck                       @himanshujha199640 @JuliaLawall
 /scripts/coccinelle/                      @himanshujha199640 @JuliaLawall
 /scripts/coredump/                        @dcpleung
-/scripts/kconfig/                         @ulfalizer
 /scripts/sanity_chk/expr_parser.py        @nashif
 /scripts/gen_app_partitions.py            @andrewboie
 /scripts/get_maintainer.py                @nashif

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -177,11 +177,18 @@ Other features
 Limitations
 ===========
 
-Doesn't work out of the box on Windows, but can be made to work with
+Doesn't work out of the box on Windows, where there is no 'curses' module
+in the Python standard library.
+
+On Python versions up to 3.9, you can get a Windows version of 'curses' with:
 
     pip install windows-curses
 
-See the https://github.com/zephyrproject-rtos/windows-curses repository.
+However, this is no longer maintained and won't work for future versions
+of Python unless a maintainer volunteers.
+
+See the https://github.com/zephyrproject-rtos/windows-curses repository
+for more information.
 """
 from __future__ import print_function
 
@@ -193,22 +200,12 @@ _IS_WINDOWS = os.name == "nt"  # Are we running on Windows?
 try:
     import curses
 except ImportError as e:
-    if not _IS_WINDOWS:
-        raise
-    sys.exit("""\
-menuconfig failed to import the standard Python 'curses' library. Try
-installing a package like windows-curses
-(https://github.com/zephyrproject-rtos/windows-curses) by running this command
-in cmd.exe:
-
-    pip install windows-curses
-
-Starting with Kconfiglib 13.0.0, windows-curses is no longer automatically
-installed when installing Kconfiglib via pip on Windows (because it breaks
-installation on MSYS2).
-
-Exception:
-{}: {}""".format(type(e).__name__, e))
+    sys.exit(
+        "error: 'menuconfig' failed to import the 'curses' module; "
+        "try running 'guiconfig' instead\n" +
+        ("note: the Zephyr Project no longer maintains a Windows port "
+         "of 'curses'\n" if _IS_WINDOWS else "") +
+        f"exception: {type(e).__name__}: {e}")
 
 import errno
 import locale

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -23,7 +23,3 @@ intelhex
 
 # it's west
 west>=0.7.2
-
-# used for windows based 'menuconfig'
-# "win32" is used for 64-bit Windows as well
-windows-curses; sys_platform == "win32"

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -14,3 +14,9 @@ lpc_checksum
 
 # used by scripts/gen_cfb_font_header.py - helper script for user
 Pillow
+
+# Used for windows based 'menuconfig' on Python up to 3.9.
+# No longer maintained. Windows users should use 'guiconfig' from now on.
+#
+# "win32" is used for 64-bit Windows as well
+windows-curses; sys_platform == "win32" and python_version <= "3.9"


### PR DESCRIPTION
The windows-curses library that has been provided for Windows
compatibility is now unmaintained. Unless a new maintainer volunteers,
Python 3.9 is the last version that has a wheel for this package on
PyPI.

Move the requirement from requirements-base.txt to
requirements-extras.txt as a result, and make sure this will not cause
any errors on Python 3.10 and beyond by restricting the environment
even further.

Update the menuconfig.py program itself to make users aware of these
changes (which should be noticeable in late 2021, when the Python 3.10
release is expected.)
