### PR TITLE
WIP: drivers: espi: xec: Add missing callback when OOB event is received

### DIFF
--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -25,6 +25,11 @@
 #define SKIP_EXECUTE_TESTS
 #endif
 
+/* RISC-V have no mechanism to restrict execution */
+#if defined(CONFIG_RISCV)
+#define SKIP_EXECUTE_TESTS
+#endif
+
 #define INFO(fmt, ...) printk(fmt, ##__VA_ARGS__)
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)


### PR DESCRIPTION
Fixes #28249

Not all OOB transactions are initiated by eSPI slave, such that OOB_RX is not always preceded by OOB_Tx.
Need to keep OOB Rx interrupts always and indicate OOB Rx channel is free when required.
For now master-initiated OOB packets are simple discarded.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>