### PR TITLE
kernel: return error instead of misaligned k_thread object

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -289,6 +289,13 @@ void *z_impl_k_object_alloc(enum k_objects otype)
 
 	switch (otype) {
 	case K_OBJ_THREAD:
+		/* aligned allocator required for X86 and X86_64 */
+		if (IS_ENABLED(CONFIG_X86) || IS_ENABLED(CONFIG_X86_64)) {
+			LOG_ERR("object type '%s' forbidden on x86 and x86_64",
+				otype_to_str(otype));
+			return NULL;
+		}
+
 		if (!thread_idx_alloc(&tidx)) {
 			LOG_ERR("out of free thread indexes");
 			return NULL;


### PR DESCRIPTION
k_object_alloc(K_OBJ_THREAD) returns a usable struct k_thread pointer.
This pointer is 4 byte aligned. On x86 and x86_64 struct _thread_arch
has a member which requires alignment. Since this is currently not
supported k_object_alloc(K_OBJ_THREAD) now returns an error instead of
a misaligned pointer.

Relevant issues: #17893 and #29589 

Returning an error makes it more clear, that this is currently not supported on x86 and x86_64 than an access error due to a misaligned pointer.