### PR TITLE
Bluetooth: controller: Fix AdvA/TgtA for extended adv PDUs

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -40,6 +40,9 @@ uint8_t ull_adv_data_set(struct ll_adv_set *adv, uint8_t len,
 uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 			 uint8_t const *const data);
 
+/* Update AdvA and TgtA (if application) in advertising PDU */
+const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
+					struct pdu_adv *pdu);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.h
@@ -8,7 +8,8 @@ void ull_filter_adv_scan_state_cb(uint8_t bm);
 void ull_filter_adv_update(uint8_t adv_fp);
 void ull_filter_scan_update(uint8_t scan_fp);
 void ull_filter_rpa_update(bool timeout);
-void ull_filter_adv_pdu_update(struct ll_adv_set *adv, struct pdu_adv *pdu);
 uint8_t ull_filter_rl_find(uint8_t id_addr_type, uint8_t const *const id_addr,
 			uint8_t *const free);
 void ull_filter_reset(bool init);
+const uint8_t *ull_filter_adva_get(struct ll_adv_set *adv);
+const uint8_t *ull_filter_tgta_get(struct ll_adv_set *adv);


### PR DESCRIPTION
AdvA in extended advertising PDUs was only set if random address was
used. This patch enables proper support for AdvA/TgtA in those PDUs
also with LL Privacy enabled.

On enable, we always update advertising PDU (i.e. ADV_IND, ADV_EXT_IND
or ADV_AUX_IND, depending on advertising set parameters) as well as
scan response PDU.

On RPA timeout, we simply copy old PDU as-is and update AdvA in new
PDU, since both PDUs are exactly the same (except AdvA) so no need to
recreate it step-by-step.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>