### PR TITLE
Bluetooth: controller: Fixes for scan response data handing in ext adv

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -617,6 +617,14 @@ uint8_t ll_adv_enable(uint8_t enable)
 		pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
 		pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 
+		if (pri_com_hdr->adv_mode & BT_HCI_LE_ADV_PROP_SCAN) {
+			struct pdu_adv *sr = lll_adv_scan_rsp_peek(lll);
+
+			if (!sr->len) {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+		}
+
 		/* AdvA, fill here at enable */
 		if (pri_hdr->adv_addr) {
 			uint8_t const *tx_addr =

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -212,12 +212,6 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 		return ull_scan_rsp_set(adv, len, data);
 	}
 
-	/* Can only set complete data and cannot discard data on enabled set */
-	if (adv->is_enabled && ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) ||
-				(len == 0))) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
-	}
-
 	LL_ASSERT(lll->aux);
 	aux_pdu = lll_adv_aux_data_peek(lll->aux);
 	sr_prev = lll_adv_scan_rsp_peek(lll);
@@ -225,6 +219,22 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	/* Can only discard data on non-scannable instances */
 	if (!(aux_pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) && len) {
 		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
+	/* Data can be discarded only using 0x03 op */
+	if ((op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA) && !len) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
+	/* Can only set complete data if advertising is enabled */
+	if (adv->is_enabled && (op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	/* Cannot discard scan response if scannable advertising is enabled */
+	if (adv->is_enabled &&
+	    (aux_pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) && !len) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	/* Update scan response PDU fields. */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -237,6 +237,17 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+	/* If no length is provided, discard data */
+	if (!len) {
+		sr_pdu = lll_adv_scan_rsp_alloc(lll, &idx);
+		sr_pdu->type = PDU_ADV_TYPE_AUX_SCAN_RSP;
+		sr_pdu->len = 0;
+
+		lll_adv_scan_rsp_enqueue(&adv->lll, idx);
+
+		return 0;
+	}
+
 	/* Update scan response PDU fields. */
 	sr_pdu = lll_adv_scan_rsp_alloc(lll, &idx);
 	sr_pdu->type = PDU_ADV_TYPE_AUX_SCAN_RSP;


### PR DESCRIPTION
Few fixes for handling of scan response data in ext adv sets.