### PR TITLE
[RFC] drivers: flash: stm32: Clear error before flash operation

### DIFF
--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -66,6 +66,11 @@ int flash_stm32_block_erase_loop(const struct device *dev,
 				 unsigned int offset,
 				 unsigned int len);
 
+/* Check and clear error flags ins Status Register (SR)*/
+#if !defined(CONFIG_SOC_SERIES_STM32WBX)
+int flash_stm32_check_status(const struct device *dev);
+#endif
+
 int flash_stm32_wait_flash_idle(const struct device *dev);
 
 #ifdef CONFIG_SOC_SERIES_STM32WBX

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -53,9 +53,19 @@ static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 		return -EIO;
 	}
 
+	rc = flash_stm32_check_status(dev);
+	if (rc) {
+		LOG_DBG("Try to clear flash ERR");
+		rc = flash_stm32_check_status(dev);
+		if (rc) {
+			LOG_ERR("Persistent flash error before write");
+			return rc;
+		}
+	}
 	/* Check that no Flash main memory operation is ongoing */
 	rc = flash_stm32_wait_flash_idle(dev);
 	if (rc < 0) {
+		LOG_ERR("Not in idle before write");
 		return rc;
 	}
 
@@ -74,10 +84,14 @@ static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 
 	/* Perform the data write operation at the desired memory address */
 	flash[0] = (uint32_t)val;
+	__ISB();
 	flash[1] = (uint32_t)(val >> 32);
 
 	/* Wait until the BSY bit is cleared */
-	rc = flash_stm32_wait_flash_idle(dev);
+	rc = flash_stm32_check_status(dev);
+	if (!rc) {
+		rc = flash_stm32_wait_flash_idle(dev);
+	}
 
 	/* Clear the PG bit */
 	regs->CR &= (~FLASH_CR_PG);
@@ -97,9 +111,19 @@ static int erase_page(const struct device *dev, unsigned int page)
 		return -EIO;
 	}
 
+	rc = flash_stm32_check_status(dev);
+	if (rc) {
+		LOG_DBG("Try to clear flash ERR");
+		rc = flash_stm32_check_status(dev);
+		if (rc) {
+			LOG_ERR("Persistent flash error before write");
+			return rc;
+		}
+	}
 	/* Check that no Flash memory operation is ongoing */
 	rc = flash_stm32_wait_flash_idle(dev);
 	if (rc < 0) {
+		LOG_ERR("Not in idle before erase");
 		return rc;
 	}
 
@@ -113,13 +137,13 @@ static int erase_page(const struct device *dev, unsigned int page)
 		/* The pages to be erased is in bank 2*/
 		regs->CR |= FLASH_CR_BKER;
 		page = page - 128;
-		LOG_DBG("Erase page %d on bank 2", page);
+		LOG_DBG("Erase page 0x%zx on bank 2", page);
 	} else {
-		LOG_DBG("Erase page %d on bank 1", page);
+		LOG_DBG("Erase page 0x%zx on bank 1", page);
 	}
 
 
-	__ASSERT(page <= 127, "There are only 127 pages, but page is %d", page);
+	__ASSERT(page <= 127, "There are only 127 pages, but page is 0x%zx", page);
 #endif
 
 	/* Set the PER bit and select the page you wish to erase */
@@ -134,7 +158,14 @@ static int erase_page(const struct device *dev, unsigned int page)
 	tmp = regs->CR;
 
 	/* Wait for the BSY bit */
-	rc = flash_stm32_wait_flash_idle(dev);
+	rc = flash_stm32_check_status(dev);
+	if (!rc) {
+		rc = flash_stm32_wait_flash_idle(dev);
+	}
+
+	if (rc) {
+		LOG_ERR("erase %08x failed", page);
+	}
 
 #ifdef FLASH_OPTR_DBANK
 	regs->CR &= ~(FLASH_CR_PER | FLASH_CR_BKER);
@@ -176,6 +207,29 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 
 	return rc;
 }
+#ifdef FLASH_OPTR_DBANK
+void flash_stm32_page_layout(const struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
+
+	static struct flash_pages_layout stm32g4_flash_layout;
+
+	if (regs->OPTR & FLASH_OPTR_DBANK) {
+		stm32g4_flash_layout.pages_count = FLASH_SIZE / FLASH_PAGE_SIZE;
+		stm32g4_flash_layout.pages_size = FLASH_PAGE_SIZE;
+	} else {
+		stm32g4_flash_layout.pages_count = FLASH_SIZE /
+						   FLASH_PAGE_SIZE_128_BITS;
+		stm32g4_flash_layout.pages_size = FLASH_PAGE_SIZE_128_BITS;
+	}
+
+	*layout = &stm32g4_flash_layout;
+	*layout_size = 1;
+}
+
+#else
 
 void flash_stm32_page_layout(const struct device *dev,
 			     const struct flash_pages_layout **layout,
@@ -196,3 +250,4 @@ void flash_stm32_page_layout(const struct device *dev,
 	*layout = &stm32g4_flash_layout;
 	*layout_size = 1;
 }
+#endif

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -61,9 +61,19 @@ static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 		return -EIO;
 	}
 
-	/* Check that no Flash main memory operation is ongoing */
+	rc = flash_stm32_check_status(dev);
+	if (rc) {
+		LOG_DBG("Try to clear flash ERR");
+		rc = flash_stm32_check_status(dev);
+		if (rc) {
+			LOG_ERR("Persistent flash error before write");
+			return rc;
+		}
+	}
+	/* Check that no Flash memory operation is ongoing */
 	rc = flash_stm32_wait_flash_idle(dev);
 	if (rc < 0) {
+		LOG_ERR("Not in idle before erase");
 		return rc;
 	}
 
@@ -94,8 +104,10 @@ static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 	flash[0] = (uint32_t)val;
 	flash[1] = (uint32_t)(val >> 32);
 
-	/* Wait until the BSY bit is cleared */
-	rc = flash_stm32_wait_flash_idle(dev);
+	rc = flash_stm32_check_status(dev);
+	if (!rc) {
+		rc = flash_stm32_wait_flash_idle(dev);
+	}
 
 	/* Clear the PG bit */
 	regs->CR &= (~FLASH_CR_PG);
@@ -153,9 +165,19 @@ static int erase_page(const struct device *dev, unsigned int page)
 		return -EIO;
 	}
 
+	rc = flash_stm32_check_status(dev);
+	if (rc) {
+		LOG_DBG("Try to clear flash ERR");
+		rc = flash_stm32_check_status(dev);
+		if (rc) {
+			LOG_ERR("Persistent flash error before write");
+			return rc;
+		}
+	}
 	/* Check that no Flash memory operation is ongoing */
 	rc = flash_stm32_wait_flash_idle(dev);
 	if (rc < 0) {
+		LOG_ERR("Not in idle before erase");
 		return rc;
 	}
 
@@ -176,8 +198,10 @@ static int erase_page(const struct device *dev, unsigned int page)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	/* Wait for the BSY bit */
-	rc = flash_stm32_wait_flash_idle(dev);
+	rc = flash_stm32_check_status(dev);
+	if (!rc) {
+		rc = flash_stm32_wait_flash_idle(dev);
+	}
 
 	regs->CR &= ~FLASH_CR_PER;
 


### PR DESCRIPTION
Not sure if this makes sense.

Split flash_stm32_wait_flash_idle into two parts.
flash_stm32_check_status: check status register and clear errors
flash_stm32_wait_flash_idle: wait for idle flag

The flash driver now checks the statuflag before any operation and tries
to reset the error once. After the reset it checks and clears the
SR again.

Signed-off-by: Alexander Wachter <alexander.wachter@leica-geosystems.com>