### PR TITLE
Zephyr: re-work DT flash partitioning for Nordic nRF boards in the tree

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -80,9 +81,15 @@ config HAS_FLASH_LOAD_OFFSET
 
 if HAS_FLASH_LOAD_OFFSET
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION := zephyr,single-image-code-partition
+
 config HAS_DT_CODE_PARTITION
 	bool
 	default y if MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_PARTITION)) if IS_CHAIN_LOADABLE_APPLICATION
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 	help
 	  This hidden option signifies that the platform DeviceTree:
 	  1. defines a flash partition layout, specifying the default
@@ -106,13 +113,11 @@ config USE_DT_CODE_PARTITION
 	  When this is disabled, the flash load offset and size can be set manually
 	  below.
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
 config FLASH_LOAD_OFFSET
 	# Only user-configurable when USE_DT_CODE_PARTITION is disabled
 	hex "Kernel load offset" if !USE_DT_CODE_PARTITION
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION && IS_CHAIN_LOADABLE_APPLICATION
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION)) if USE_DT_CODE_PARTITION
 	default 0
 	help
 	  This option specifies the byte offset from the beginning of flash that
@@ -125,7 +130,8 @@ config FLASH_LOAD_OFFSET
 config FLASH_LOAD_SIZE
 	# Only user-configurable when USE_DT_CODE_PARTITION is disabled
 	hex "Kernel load size" if !USE_DT_CODE_PARTITION
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION && IS_CHAIN_LOADABLE_APPLICATION
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION)) if USE_DT_CODE_PARTITION
 	default 0
 	help
 	  If non-zero, this option specifies the size, in bytes, of the flash

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -444,6 +444,12 @@ config BOOTLOADER_MCUBOOT
 	  the application. This removes the need by MCUboot to reset
 	  the core registers' state itself.
 
+	  This option instructs Zephyr to link the image code into the code
+	  partition specified by the zephyr,code-partition property in
+	  /chosen in DeviceTree. The existence of such a code partition is
+	  a required dependency for allowing the Zephyr image to be built as
+	  application that is chain-loadable by MCUboot.
+
 if BOOTLOADER_MCUBOOT
 
 config MCUBOOT_SIGNATURE_KEY_FILE
@@ -509,6 +515,12 @@ config BOOTLOADER_BOSSA
 	  Signifies that the target uses a BOSSA compatible bootloader.  If CDC
 	  ACM USB support is also enabled then the board will reboot into the
 	  bootloader automatically when bossac is run.
+	  This option instructs Zephyr to link the image code into the code
+	  partition specified by the zephyr,code-partition property in
+	  /chosen in DeviceTree. The existence of such a code partition is
+	  a required dependency for allowing the Zephyr image to be built as
+	  application that is chain-loadable by the BOSSA bootloader.
+
 
 config BOOTLOADER_BOSSA_DEVICE_NAME
 	string "BOSSA CDC ACM device name"

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -80,8 +80,26 @@ config HAS_FLASH_LOAD_OFFSET
 
 if HAS_FLASH_LOAD_OFFSET
 
+config HAS_DT_CODE_PARTITION
+	bool
+	default y if MCUBOOT
+	help
+	  This hidden option signifies that the platform DeviceTree:
+	  1. defines a flash partition layout, specifying the default
+	  code partition to be used when linking the image, and
+	  2. selects this code partition by chosing the appropriate
+	  code-partition symbol in the device tree configuration.
+	  The existence of the code partition is a required dependency
+	  for USE_DT_CODE_PARTITION.
+	  To be able to select the code partition using device tree,
+	  a platform definition needs to have a zephyr,code-partition
+	  symbol chosen by DT configuration.
+	  MCUboot application chooses the code partition independently,
+	  therefore, the dependency is always satisfied.
+
 config USE_DT_CODE_PARTITION
 	bool "Link application into /chosen/zephyr,code-partition from devicetree"
+	depends on HAS_DT_CODE_PARTITION
 	help
 	  When enabled, the application will be linked into the flash partition
 	  selected by the zephyr,code-partition property in /chosen in devicetree.

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -362,6 +362,16 @@ endmenu
 
 menu "Boot Options"
 
+config IS_CHAIN_LOADABLE_APPLICATION
+	bool
+	select USE_DT_CODE_PARTITION
+	help
+	  This option indicates that the Zephyr application
+	  image is chain-loadable by a bootloader image. The
+	  option selects USE_DT_CODE_PARTITION, indicating
+	  that the chain-loadable image will be placed to a
+	  code partition specified by Device Tree.
+
 config IS_BOOTLOADER
 	bool "Act as a bootloader"
 	depends on XIP
@@ -389,7 +399,7 @@ config MCUBOOT
 
 config BOOTLOADER_MCUBOOT
 	bool "MCUboot bootloader support"
-	select USE_DT_CODE_PARTITION
+	select IS_CHAIN_LOADABLE_APPLICATION
 	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
 	depends on !MCUBOOT
 	help
@@ -469,9 +479,8 @@ config BOOTLOADER_ESP_IDF
 
 config BOOTLOADER_BOSSA
 	bool "BOSSA bootloader support"
-	select USE_DT_CODE_PARTITION
+	select IS_CHAIN_LOADABLE_APPLICATION
 	depends on SOC_FAMILY_SAM0
-
 	help
 	  Signifies that the target uses a BOSSA compatible bootloader.  If CDC
 	  ACM USB support is also enabled then the board will reboot into the

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -20,6 +20,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -231,12 +232,18 @@ fem_spi: &spi3 {
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x0000C000>;
 		};
@@ -253,15 +260,13 @@ fem_spi: &spi3 {
 			reg = <0x000da000 0x0001e000>;
 		};
 
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
 
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
+	/* Common to both layouts */
 		storage_partition: partition@f8000 {
 			label = "storage";
 			reg = <0x000f8000 0x00008000>;

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840_defconfig
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840_defconfig
@@ -25,3 +25,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -135,12 +136,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0x8000>;
 		};
@@ -156,6 +163,14 @@
 			label = "image-scratch";
 			reg = <0x0003c000 0x2000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0003e000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422_defconfig
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422_defconfig
@@ -13,3 +13,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -77,12 +78,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0x8000>;
 		};
@@ -98,6 +105,14 @@
 			label = "image-scratch";
 			reg = <0x0003c000 0x2000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0003e000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422_defconfig
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422_defconfig
@@ -13,3 +13,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -128,12 +129,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xC000>;
 		};
@@ -145,6 +152,14 @@
 			label = "image-1";
 			reg = <0x00023000 0x17000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0003a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@3a000 {
 			label = "storage";
 			reg = <0x0003a000 0x00006000>;

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820_defconfig
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820_defconfig
@@ -25,3 +25,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -193,12 +194,18 @@ arduino_spi: &spi3 {
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0xC000>;
 		};
@@ -214,6 +221,14 @@ arduino_spi: &spi3 {
 			label = "image-scratch";
 			reg = <0x00070000 0xA000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0007a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007A000 0x00006000>;

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833_defconfig
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833_defconfig
@@ -25,3 +25,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -137,12 +138,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -158,6 +165,14 @@
 			label = "image-scratch";
 			reg = <0x00026000 0x3000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x00029000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@29000 {
 			label = "storage";
 			reg = <0x00029000 0x00007000>;

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811_defconfig
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811_defconfig
@@ -28,3 +28,6 @@ CONFIG_GPIO_AS_PINRESET=y
 # Bluetooth not enabled by default on nRF52811 due to RAM limitations when
 # running the default set of kernel tests.
 # Enable this on your prj.conf to include Bluetooth support
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -240,12 +241,18 @@ arduino_spi: &spi3 {
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x0000C000>;
 		};
@@ -262,15 +269,13 @@ arduino_spi: &spi3 {
 			reg = <0x000da000 0x0001e000>;
 		};
 
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
 
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
+	/* Common to both layouts */
 		storage_partition: partition@f8000 {
 			label = "storage";
 			reg = <0x000f8000 0x00008000>;

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
@@ -25,3 +25,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
@@ -7,19 +7,24 @@
 /* Flash partition table without support for Nordic nRF5 bootloader */
 
 &flash0 {
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+	/* Flash layout with MCUboot */
 		/* The size of this partition ensures that MCUBoot can be built
 		 * with an RTT console, CDC ACM support, and w/o optimizations.
 		 */
-		boot_partition: partition@0 {
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x00012000>;
 		};
-
 		slot0_partition: partition@12000 {
 			label = "image-0";
 			reg = <0x00012000 0x000069000>;
@@ -32,6 +37,14 @@
 			label = "image-scratch";
 			reg = <0x000e4000 0x00018000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0000fc000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
@@ -7,6 +7,14 @@
 /* Flash partition table compatible with Nordic nRF5 bootloader */
 
 &flash0 {
+
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
+
+	/* Flash layout with MCUboot */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -16,7 +24,7 @@
 		 * The size of this partition ensures that MCUBoot
 		 * can be built with CDC ACM support and w/o optimizations.
 		 */
-		boot_partition: partition@1000 {
+		boot_partition: partition_boot@1000 {
 			label = "mcuboot";
 			reg = <0x00001000 0x000f000>;
 		};
@@ -36,6 +44,28 @@
 		scratch_partition: partition@d0000 {
 			label = "image-scratch";
 			reg = <0x000d0000 0x00010000>;
+		};
+
+		/* Nordic nRF5 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the nRF5 bootloader and MBR to store settings.
+		 */
+	};
+
+	/* Flash layout without MCUboot */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x000cc000>;
+		};
+		storage_partition: partition@cc000 {
+			label = "storage";
+			reg = <0x000cc000 0x00014000>;
 		};
 
 		/* Nordic nRF5 bootloader <0xe0000 0x1c000>

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -20,6 +20,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
@@ -19,3 +19,6 @@ CONFIG_CONSOLE=y
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
 CONFIG_NFCT_PINS_AS_GPIOS=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -113,16 +114,19 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
 	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -138,6 +142,14 @@
 			label = "image-scratch";
 			reg = <0x00026000 0x3000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x00029000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@29000 {
 			label = "storage";
 			reg = <0x00029000 0x00007000>;

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805_defconfig
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805_defconfig
@@ -25,3 +25,6 @@ CONFIG_GPIO_AS_PINRESET=y
 
 # Bluetooth not enabled by default on nRF52805 due to RAM limitations when
 # running the default set of kernel tests.
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -21,6 +21,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -116,12 +117,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -137,6 +144,14 @@
 			label = "image-scratch";
 			reg = <0x00026000 0x3000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x00029000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@29000 {
 			label = "storage";
 			reg = <0x00029000 0x00007000>;

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810_defconfig
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810_defconfig
@@ -26,3 +26,6 @@ CONFIG_GPIO_AS_PINRESET=y
 # Bluetooth not enabled by default on nRF52810 due to RAM limitations when
 # running the default set of kernel tests.
 # Enable this on your prj.conf to include Bluetooth support
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -20,6 +20,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -195,12 +196,18 @@ arduino_spi: &spi2 {
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -216,6 +223,14 @@ arduino_spi: &spi2 {
 			label = "image-scratch";
 			reg = <0x00070000 0xa000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0007a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832_defconfig
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832_defconfig
@@ -25,3 +25,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -59,26 +59,53 @@ endif # BUILD_WITH_TFM
 # always restricted to the allocated non-secure SRAM partition.
 #
 # Workaround for not being able to have commas in macro arguments
+# Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION := zephyr,single-image-code-partition
+DT_CHOSEN_Z_CODE_S_PARTITION := zephyr,code-s-partition
+DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION := zephyr,single-image-code-s-partition
 DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
-if (BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP) && TRUSTED_EXECUTION_SECURE
+if (BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP)
+
+config HAS_DT_CODE_PARTITION
+	bool
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION)) if TRUSTED_EXECUTION_SECURE
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 config SRAM_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K) if TRUSTED_EXECUTION_SECURE
 
-endif # (BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP) && TRUSTED_EXECUTION_SECURE
+endif # (BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP)
 
 if BOARD_NRF5340PDK_NRF5340_CPUAPPNS || BOARD_NRF5340DK_NRF5340_CPUAPPNS
 
+config HAS_DT_CODE_PARTITION
+	bool
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
+
 config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 endif # BOARD_NRF5340PDK_NRF5340_CPUAPPNS || BOARD_NRF5340DK_NRF5340_CPUAPPNS
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -145,36 +145,81 @@
 };
 
 &flash0 {
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* MCUboot partition, common to both layouts with MCUboot,
+	 * Secure-only and Secure/Non-Secure.
+	 */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x000000000 0x00010000>;
 		};
+
+	/* Secure-only flash layout with MCUboot */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-		};
-		slot0_ns_partition: partition@50000 {
-			label = "image-0-nonsecure";
+			reg = <0x00010000 0x00070000>;
 		};
 		slot1_partition: partition@80000 {
 			label = "image-1";
+			reg = <0x00080000 0x00070000>;
 		};
-		slot1_ns_partition: partition@c0000 {
+
+	/* Secure-only flash layout without MCUboot */
+		code_partition: partition_code@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
+
+	/* Secure/Non-Secure flash layout with MCUboot */
+		slot0_s_partition: partition_s@10000 {
+			label = "image-0-secure";
+			reg = <0x00010000 0x40000>;
+		};
+		slot0_ns_partition: partition_ns@50000 {
+			label = "image-0-nonsecure";
+			reg = <0x00050000 0x30000>;
+		};
+		slot1_s_partition: partition_s@80000 {
+			label = "image-1-secure";
+			reg = <0x00080000 0x40000>;
+		};
+		slot1_ns_partition: partition_ns@c0000 {
 			label = "image-1-nonsecure";
+			reg = <0x000c0000 0x30000>;
 		};
+
+	/* Secure/Non-Secure flash layout without MCUboot */
+		code_s_partition: partition_code_s@0 {
+			label = "code-secure";
+			reg = <0x00000000 0x00040000>;
+		};
+		code_ns_partition: partition_code_ns@40000 {
+			label = "code-nonsecure";
+			reg = <0x00040000 0x000b8000>;
+		};
+
+	/* Common to layouts with MCUboot */
 		scratch_partition: partition@f0000 {
 			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
+			reg = <0x000f0000 0x8000>;
 		};
-		storage_partition: partition@fa000 {
+
+	/* Common to all layouts */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
+
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_partition_conf.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_partition_conf.dts
@@ -5,37 +5,28 @@
  */
 
 /*
- * Default Flash planning for nrf5340pdk_nrf5340 CPUAPP (Application MCU).
+ * Default Flash planning for nrf5340(p)dk_nrf5340 CPUAPP (Application MCU).
  *
- * Zephyr build for nRF5340 with ARM TrustZone-M support,
- * implies building Secure and Non-Secure Zephyr images.
+ * Zephyr build for nRF5340 with ARM TrustZone-M support, and either
+ * CONFIG_TRUSTED_EXECUTION_SECURE=y or CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+ * implies building Secure and Non-Secure images.
  *
- * Secure image will be placed, by default, in flash0
- * (or in slot0, if MCUboot is present).
+ * Secure image will be placed in the following code partition:
+ * - slot0_s_partition, when building with MCUboot support
+ * - code_s_partition, when building without MCUboot support
+ *
  * Secure image will use sram0 for system memory.
  *
- * Non-Secure image will be placed in slot0_ns, and use
- * sram0_ns for system memory.
+ * Non-Secure image will be placed in the following code partition:
+ * - slot0_ns_partition, when building with MCUboot support
+ * - code_ns_partition, when building without MCUboot support
+ *
+ * Non-Secure image will use sram0_ns for system memory.
  *
  * Note that the Secure image only requires knowledge of
  * the beginning of the Non-Secure image (not its size).
  */
 
-&slot0_partition {
-	reg = <0x00010000 0x40000>;
-};
-
-&slot0_ns_partition {
-	reg = <0x00050000 0x30000>;
-};
-
-&slot1_partition {
-	reg = <0x00080000 0x40000>;
-};
-
-&slot1_ns_partition {
-	reg = <0x000c0000 0x30000>;
-};
 
 /* Default SRAM planning when building for nRF5340 with
  * ARM TrustZone-M support

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.dts
@@ -16,6 +16,9 @@
 		zephyr,sram = &sram0_image;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,single-image-code-partition = &code_partition;
+		zephyr,code-s-partition = &slot0_s_partition;
+		zephyr,single-image-code-s-partition = &code_s_partition;
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_defconfig
@@ -22,3 +22,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0_ns;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
+		zephyr,single-image-code-partition = &code_ns_partition;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuappns_defconfig
@@ -25,3 +25,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,single-image-code-partition = &code_partition;
 	};
 
 	leds {
@@ -110,12 +111,18 @@
 
 &flash1 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -131,6 +138,14 @@
 			label = "image-scratch";
 			reg = <0x00030000 0xa000>;
 		};
+
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x3a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@3a000 {
 			label = "storage";
 			reg = <0x0003a000 0x6000>;

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet_defconfig
@@ -19,3 +19,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp.dts
@@ -16,6 +16,9 @@
 		zephyr,sram = &sram0_image;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,single-image-code-partition = &code_partition;
+		zephyr,code-s-partition = &slot0_s_partition;
+		zephyr,single-image-code-s-partition = &code_s_partition;
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuapp_defconfig
@@ -24,3 +24,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns.dts
@@ -16,5 +16,6 @@
 		zephyr,sram = &sram0_ns;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
+		zephyr,single-image-code-partition = &code_ns_partition;
 	};
 };

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpuappns_defconfig
@@ -25,3 +25,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,single-image-code-partition = &code_partition;
 	};
 
 	leds {
@@ -110,12 +111,18 @@
 
 &flash1 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -131,6 +138,14 @@
 			label = "image-scratch";
 			reg = <0x00030000 0xa000>;
 		};
+
+	/* Flash layout without MCUboot */
+	code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x3a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@3a000 {
 			label = "storage";
 			reg = <0x0003a000 0x6000>;

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340pdk_nrf5340_cpunet_defconfig
@@ -19,3 +19,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -19,6 +19,8 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
@@ -50,12 +52,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x0000C000>;
 		};
@@ -72,15 +80,13 @@
 			reg = <0x000da000 0x0001e000>;
 		};
 
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
 
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
+	/* Common to both layouts */
 		storage_partition: partition@f8000 {
 			label = "storage";
 			reg = <0x000f8000 0x00008000>;

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_defconfig
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_defconfig
@@ -20,3 +20,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -13,6 +13,7 @@ config BOARD
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-
 # secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
 # be restricted to the size of its code partition.
+#
 # For the non-secure version of the board, the firmware
 # must be linked into the code-partition (non-secure) defined in DT, regardless.
 # Apply this configuration below by setting the Kconfig symbols used by
@@ -20,18 +21,47 @@ config BOARD
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION := zephyr,single-image-code-partition
+DT_CHOSEN_Z_CODE_S_PARTITION := zephyr,code-s-partition
+DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION := zephyr,single-image-code-s-partition
+
+if BOARD_NRF9160DK_NRF9160
+
+config HAS_DT_CODE_PARTITION
+	bool
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION)) if TRUSTED_EXECUTION_SECURE
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_NRF9160DK_NRF9160 && TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE && BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_S_PARTITION)) if TRUSTED_EXECUTION_SECURE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
+
+endif # BOARD_NRF9160DK_NRF9160
 
 if BOARD_NRF9160DK_NRF9160NS
 
+config HAS_DT_CODE_PARTITION
+	bool
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_enabled,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
+
 config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if BOOTLOADER_MCUBOOT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SINGLE_IMAGE_CODE_PARTITION))
 
 endif # BOARD_NRF9160DK_NRF9160NS
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.dts
@@ -13,6 +13,9 @@
 		zephyr,sram = &sram0_s;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,single-image-code-partition = &code_partition;
+		zephyr,code-s-partition = &slot0_s_partition;
+		zephyr,single-image-code-s-partition = &code_s_partition;
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -143,36 +143,81 @@
 };
 
 &flash0 {
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* MCUboot partition, common to both layouts with MCUboot,
+	 * Secure-only and Secure/Non-Secure.
+	 */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x000000000 0x00010000>;
 		};
+
+	/* Secure-only flash layout with MCUboot */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-		};
-		slot0_ns_partition: partition@50000 {
-			label = "image-0-nonsecure";
+			reg = <0x00010000 0x00070000>;
 		};
 		slot1_partition: partition@80000 {
 			label = "image-1";
+			reg = <0x00080000 0x00070000>;
 		};
-		slot1_ns_partition: partition@c0000 {
+
+	/* Secure-only flash layout without MCUboot */
+		code_partition: partition_code@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
+
+	/* Secure/Non-Secure flash layout with MCUboot */
+		slot0_s_partition: partition_s@10000 {
+			label = "image-0-secure";
+			reg = <0x00010000 0x40000>;
+		};
+		slot0_ns_partition: partition_ns@50000 {
+			label = "image-0-nonsecure";
+			reg = <0x00050000 0x30000>;
+		};
+		slot1_s_partition: partition_s@80000 {
+			label = "image-1-secure";
+			reg = <0x00080000 0x40000>;
+		};
+		slot1_ns_partition: partition_ns@c0000 {
 			label = "image-1-nonsecure";
+			reg = <0x000c0000 0x30000>;
 		};
+
+	/* Secure/Non-Secure flash layout without MCUboot */
+		code_s_partition: partition_code_s@0 {
+			label = "code-secure";
+			reg = <0x00000000 0x00040000>;
+		};
+		code_ns_partition: partition_code_ns@40000 {
+			label = "code-nonsecure";
+			reg = <0x00040000 0x000b8000>;
+		};
+
+	/* Common to layouts with MCUboot */
 		scratch_partition: partition@f0000 {
 			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
+			reg = <0x000f0000 0x8000>;
 		};
-		storage_partition: partition@fa000 {
+
+	/* Common to all layouts */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
+
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_defconfig
@@ -22,3 +22,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -7,35 +7,26 @@
 /*
  * Default Flash planning for nRF9160dk_nrf9160.
  *
- * Zephyr build for nRF9160 with ARM TrustZone-M support,
- * implies building Secure and Non-Secure Zephyr images.
+ * Zephyr build for nRF9160 with ARM TrustZone-M support, and either
+ * CONFIG_TRUSTED_EXECUTION_SECURE=y or CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+ * implies building Secure and Non-Secure images.
  *
- * Secure image will be placed, by default, in flash0
- * (or in slot0, if MCUboot is present).
+ * Secure image will be placed in the following code partition:
+ * - slot0_s_partition, when building with MCUboot support
+ * - code_s_partition, when building without MCUboot support
+ *
  * Secure image will use sram0 for system memory.
  *
- * Non-Secure image will be placed in slot0_ns, and use
- * sram0_ns for system memory.
+ * Non-Secure image will be placed in the following code partition:
+ * - slot0_ns_partition, when building with MCUboot support
+ * - code_ns_partition, when building without MCUboot support
+ *
+ * Non-Secure image will use sram0_ns for system memory.
  *
  * Note that the Secure image only requires knowledge of
  * the beginning of the Non-Secure image (not its size).
  */
 
-&slot0_partition {
-	reg = <0x00010000 0x40000>;
-};
-
-&slot0_ns_partition {
-	reg = <0x00050000 0x30000>;
-};
-
-&slot1_partition {
-	reg = <0x00080000 0x40000>;
-};
-
-&slot1_ns_partition {
-	reg = <0x000c0000 0x30000>;
-};
 
 /* Default SRAM planning when building for nRF9160 with
  * ARM TrustZone-M support

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.dts
@@ -13,5 +13,6 @@
 		zephyr,flash = &flash0;
 		zephyr,sram = &sram0_ns;
 		zephyr,code-partition = &slot0_ns_partition;
+		zephyr,single-image-code-partition = &code_ns_partition;
 	};
 };

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_defconfig
@@ -25,3 +25,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -20,6 +20,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -185,12 +186,18 @@
 };
 
 &flash0 {
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
@@ -207,13 +214,13 @@
 			reg = <0x00070000 0xa000>;
 		};
 
-		/*
-		 * The flash starting at 0x0007a000 and ending at
-		 * 0x0007ffff (sectors 122-127) is reserved for use
-		 * by the application.
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x0007a000>;
+		};
+
+	/* Common to both layouts */
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
@@ -23,3 +23,6 @@ CONFIG_SERIAL=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840_pca10056_defconfig
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840_pca10056_defconfig
@@ -23,3 +23,6 @@ CONFIG_GPIO_AS_PINRESET=y
 # bluetooth
 CONFIG_BT=y
 CONFIG_BT_CTLR=y
+
+# Link application into a code-partition from devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -16,6 +16,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,single-image-code-partition = &code_partition;
 		zephyr,code-partition = &slot0_partition;
 	};
 };
@@ -44,12 +45,18 @@
 
 &flash0 {
 
+	/* Default flash partitioning.
+	 *
+	 * Note: A Zephyr build should use partitions belonging
+	 * to the same flash layout.
+	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+	/* Flash layout with MCUboot */
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x0000C000>;
 		};
@@ -66,15 +73,13 @@
 			reg = <0x000da000 0x0001e000>;
 		};
 
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
+	/* Flash layout without MCUboot */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 0x000f8000>;
+		};
 
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
+	/* Common to both layouts */
 		storage_partition: partition@f8000 {
 			label = "storage";
 			reg = <0x000f8000 0x00008000>;

--- a/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot/nrf52840dk_nrf52840.overlay
@@ -10,7 +10,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
+		boot_partition: partition_boot@0 {
 			label = "mcuboot";
 			reg = <0x000000000 0x0000E000>;
 		};


### PR DESCRIPTION
The purpose of this PR is to address #27471 which is a rather serious bug: the ARM linker is not aware of the storage partition, when the flash partitioning layout - defined in board DeviceTree - is not used by the linker. If the Zephyr firmware is relatively large, it may overflow into the storage partition, with unpredictable behavior.

To solve the problem, we need to always use the Device Tree-defined partition layout information for the Zephyr application code partition, in the cases when there are parts of flash (e.g. the storage partition) that cannot be available for code. So we need to enforce USE_DT_CODE_PARTITION at all times.

This PR shows how this can be done and actually applies this for the Nordic-maintained nRF-based platforms in the tree. 

This PR is an alternative to #29749. It is aligned with the constructive feedback by @nvlsianpu and @Laczen .

The main design idea is that most platforms would need to have **two alternative flash partitioning layouts to be used when building with or without bootloader, respectively.** The generic logic to pick the right layout is done in Kconfig.zephyr. Platforms where more alternative layouts make sense would need to define a more complex logic (in the board definition)


In brief, this PR - consisting of several patches - does the following:
1. Adds a dependency to `config USE_DT_CODE_PARTITION`, so it cannot be selected if the device tree does not define the corresponding "chosen" `code-partition` symbols.
2. Instructs the linker to use the `zephyr,code-partition` when building a chain-loadable image (loadable by MCUboot) and `zephyr,single-image-code-partition` when building a standalone image . How?  Kconfig.zephyr will modify the defaults for FLASH_LOAD_OFFSET and FLASH_LOAD_SIZE, to pick either the single-image-code-partition, when we build a standalone image, or pick code-partition, when we build a chain-loadable image (with MCUboot support).
4. For all Nordic nRF based boards, the PR defines two alternative flash layouts (with and without MCUboot) and defines the chosen symbols, for code partitions with and without BL. The PR forces using the DT Code Partition by default in Nordic DKs, regardless of MCUBoot, **effectively solving #27471 for them**.
5. For Trustzone-enabled Nordic platforms (nrf5340 APP and nRF9160) the flash layouts also depend on the security domain we build for (Secure or Non-Secure), therefore the default mechanism we implement in Kconfig.zephyr is overridden locally in the nrf53 and nrf91 board definitions.


