### PR TITLE
emul: spi: bmi160: Add a check for a missing rx buffer

### DIFF
--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -197,6 +197,10 @@ static int bmi160_emul_io_spi(struct spi_emul *emul,
 		switch (tx->len) {
 		case 1:
 			regn = *(uint8_t *)tx->buf;
+			if ((regn & BMI160_REG_READ) && rxd == NULL) {
+				LOG_ERR("Cannot read without rxd");
+				return -EPERM;
+			}
 			switch (txd->len) {
 			case 1:
 				if (regn & BMI160_REG_READ) {


### PR DESCRIPTION
If a read is requested without a read buffer, the emulator currently
crashes. Fix this by adding a check.

Fixes: #29703
Fixes: #29702
Fixes: #29017
Fixes: #29016

Signed-off-by: Simon Glass <sjg@chromium.org>