### PR TITLE
drivers: sensor: lis2mdl: Add direct trigger option

### DIFF
--- a/drivers/sensor/lis2mdl/Kconfig
+++ b/drivers/sensor/lis2mdl/Kconfig
@@ -30,6 +30,11 @@ config LIS2MDL_TRIGGER_OWN_THREAD
 	depends on GPIO
 	select LIS2MDL_TRIGGER
 
+config LIS2MDL_TRIGGER_DIRECT
+	bool "Use interrupt handler"
+	depends on GPIO
+	select LIS2MDL_TRIGGER
+
 endchoice # LIS2MDL_TRIGGER_MODE
 
 config LIS2MDL_TRIGGER

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -81,6 +81,8 @@ static void lis2mdl_gpio_callback(const struct device *dev,
 	k_sem_give(&lis2mdl->gpio_sem);
 #elif defined(CONFIG_LIS2MDL_TRIGGER_GLOBAL_THREAD)
 	k_work_submit(&lis2mdl->work);
+#elif defined(CONFIG_LIS2MDL_TRIGGER_DIRECT)
+	lis2mdl_handle_interrupt(lis2mdl->dev);
 #endif
 }
 


### PR DESCRIPTION
Allows data ready trigger to be called directly from interrupt
context.

Signed-off-by: Corey Wharton <coreyw7@fb.com>