### PR TITLE
kernel: support non-identity RAM mapping

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -574,6 +574,51 @@ config SRAM_REGION_PERMISSIONS
 	  If not enabled, all SRAM mappings will allow supervisor mode to
 	  read, write, and execute. User mode support requires this.
 
+config KERNEL_VM_BASE
+	hex "Base virtual address to link the kernel"
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))
+	help
+	  Define the base virtual memory address for the core kernel.
+
+	  The kernel expects a mappings for all physical RAM regions starting at
+	  this virtual address, with any unused space up to the size denoted by
+	  KERNEL_VM_SIZE available for memory mappings. This base address denotes
+	  the start of the RAM mapping and may not be the base address of the
+	  kernel itself, but the offset of the kernel here will be the same as the
+	  offset from the beginning of physical memory where it was loaded.
+
+	  If there are multiple physical RAM regions which are discontinuous in
+	  the physical memory map, they should all be mapped in a continuous
+	  virtual region, with bounds defined by KERNEL_RAM_SIZE.
+
+	  By default, this is the same as the DT_CHOSEN_Z_SRAM physical base SRAM
+	  address from DTS, in which case RAM will be identity-mapped. Some
+	  architectures may require RAM to be mapped in this way; they may have
+	  just one RAM region and doing this makes linking much simpler, as
+	  at least when the kernel boots all virtual RAM addresses are the same
+	  as their physical address (demand paging at runtime may later modify
+	  this for some subset of non-pinned pages).
+
+	  Otherwise, if RAM isn't identity-mapped:
+	  1. It is the architecture's responsibility to transition the
+	  instruction pointer to virtual addresses at early boot before
+	  entering the kernel at z_cstart().
+	  2. The underlying architecture may impose constraints on the bounds of
+	  the kernel's address space, such as not overlapping physical RAM
+	  regions if RAM is not identity-mapped, or the virtual and physical
+	  base addresses being aligned to some common value (which allows
+	  double-linking of paging structures to make the instruction pointer
+	  transition simpler).
+
+config KERNEL_RAM_SIZE
+	hex "Total size of RAM mappings in bytes"
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_SRAM))
+	help
+	  Indicates to the kernel the total size of RAM that is mapped. The
+	  kernel expects that all physical RAM has a memory mapping in the virtual
+	  address space, and that these RAM mappings are all within the virtual
+	  region [KERNEL_VM_BASE..KERNEL_VM_BASE + KERNEL_RAM_SIZE).
+
 config KERNEL_VM_SIZE
 	hex "Size of kernel address space in bytes"
 	default 0xC0000000
@@ -581,10 +626,17 @@ config KERNEL_VM_SIZE
 	  Size of the kernel's address space. Constraining this helps control
 	  how much total memory can be used for page tables.
 
-	  The area defined by SRAM_BASE_ADDRESS to SRAM_BASE_ADDRESS +
-	  KERNEL_VM_SIZE must have enough room to map system RAM, plus any driver
-	  mappings. Further mappings may be made at runtime depending on
-	  configuration options (such as memory-mapping stacks, VDSO pages, etc).
+	  The difference between KERNEL_RAM_SIZE and KERNEL_VM_SIZE indicates the
+	  size of the virtual region for runtime memory mappings. This is needed
+	  for mapping driver MMIO regions, as well as special RAM mapping use-cases
+	  such as VSDO pages, memory mapped thread stacks, and anonymous memory
+	  mappings.
+
+	  The system currently assumes all RAM can be mapped in the virtual address
+	  space. Systems with very large amounts of memory (such as 512M or more)
+	  will want to use a 64-bit build of Zephyr, there are no plans to
+	  implement a notion of "high" memory in Zephyr to work around physical
+	  RAM which can't have a boot-time mapping due to a too-small address space.
 
 endif   # MMU
 

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -61,13 +61,27 @@ MALLOC_BSS static unsigned char __aligned(CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE)
 #define HEAP_BASE	USED_RAM_END_ADDR
 #endif /* Z_MALLOC_PARTITION_EXISTS */
 
-#ifdef CONFIG_XTENSA
+#ifdef CONFIG_MMU
+/* Currently a placeholder, we're just setting up all unused RAM pages
+ * past the end of the kernel as the heap arena. SRAM_BASE_ADDRESS is
+ * a physical address so we can't use that.
+ *
+ * Later, we should do this much more like other VM-enabled operating systems:
+ * - Set up a core kernel ontology of free physical pages
+ * - Allow anonymous memoory mappings drawing from the pool of free physical
+ *   pages
+ * - Have _sbrk() map anonymous pages into the heap arena as needed
+ * - See: https://github.com/zephyrproject-rtos/zephyr/issues/29526
+ */
+#define MAX_HEAP_SIZE	(CONFIG_KERNEL_RAM_SIZE - (HEAP_BASE - \
+						   CONFIG_KERNEL_VM_BASE))
+#elif defined(CONFIG_XTENSA)
 extern void *_heap_sentry;
-#define MAX_HEAP_SIZE  (POINTER_TO_UINT(&_heap_sentry) - HEAP_BASE)
+#define MAX_HEAP_SIZE	(POINTER_TO_UINT(&_heap_sentry) - HEAP_BASE)
 #else
-#define MAX_HEAP_SIZE	(KB(CONFIG_SRAM_SIZE) - \
-			 (HEAP_BASE - CONFIG_SRAM_BASE_ADDRESS))
-#endif
+#define MAX_HEAP_SIZE	(KB(CONFIG_SRAM_SIZE) - (HEAP_BASE - \
+						 CONFIG_SRAM_BASE_ADDRESS))
+#endif /* CONFIG_MMU */
 
 #if Z_MALLOC_PARTITION_EXISTS
 struct k_mem_partition z_malloc_partition;

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -16,8 +16,8 @@
 #include <x86_mmu.h>
 #include <linker/linker-defs.h>
 
-#define VM_BASE		((uint8_t *)CONFIG_SRAM_BASE_ADDRESS)
-#define VM_LIMIT	(VM_BASE + KB((size_t)CONFIG_SRAM_SIZE))
+#define VM_BASE		((uint8_t *)CONFIG_KERNEL_VM_BASE)
+#define VM_LIMIT	(VM_BASE + CONFIG_KERNEL_RAM_SIZE)
 
 #ifdef CONFIG_X86_64
 #define PT_LEVEL	3

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -17,7 +17,7 @@
 #define FAULTY_ADDRESS 0x0FFFFFFF
 #elif CONFIG_MMU
 /* Just past the permanent RAM mapping should be a non-present page */
-#define FAULTY_ADDRESS (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL))
+#define FAULTY_ADDRESS (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_RAM_SIZE)
 #else
 #define FAULTY_ADDRESS 0xFFFFFFF0
 #endif


### PR DESCRIPTION
Some platforms may have multiple RAM regions which are
dis-continuous in the physical memory map. We really want
these to be in a continuous virtual region, and we need to
stop assuming that there is just one SRAM region that is
identity-mapped.

We no longer use CONFIG_SRAM_BASE_ADDRESS and CONFIG_SRAM_SIZE
as the bounds of kernel RAM, and no longer assume in the core
kernel that these are identity mapped at boot.

Two new Kconfigs, CONFIG_KERNEL_VM_BASE and
CONFIG_KERNEL_RAM_SIZE now indicate the bounds of this region
in virtual memory.

We are currently only memory-mapping physical device driver
MMIO regions so we do not need virtual-to-physical calculations
to re-map RAM yet. When the time comes an architecture interface
will be defined for this.

Platforms which just have one RAM region may continue to
identity-map it.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>