### PR TITLE
checkpatch: Remove ENOSYS check

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4255,14 +4255,6 @@ sub process {
 			     "Prefer dev_$level(... to dev_printk(KERN_$orig, ...\n" . $herecurr);
 		}
 
-# ENOSYS means "bad syscall nr" and nothing else.  This will have a small
-# number of false positives, but assembly files are not checked, so at
-# least the arch entry code will not trigger this warning.
-		if ($line =~ /\bENOSYS\b/) {
-			WARN("ENOSYS",
-			     "ENOSYS means 'invalid syscall nr' and nothing else\n" . $herecurr);
-		}
-
 # ENOTSUPP is not a standard error code and should be avoided in new patches.
 # Folks usually mean EOPNOTSUPP (also called ENOTSUP), when they type ENOTSUPP.
 # Similarly to ENOSYS warning a small number of false positives is expected.


### PR DESCRIPTION
Zephyr uses ENOSYS for all not implemented functions and not only for
syscalls. So checkpatch generates invalid warnings about it.

https://github.com/zephyrproject-rtos/zephyr/wiki/Naming-Conventions#return-codes

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>