### PR TITLE
userspace: fix dependency to memory protection

### DIFF
--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -23,7 +23,7 @@ typedef struct k_thread *k_tid_t;
  * @{
  */
 
-#ifdef CONFIG_MEMORY_PROTECTION
+#if defined(CONFIG_MEMORY_PROTECTION) || defined(CONFIG_USERSPACE)
 /**
  * @def K_MEM_PARTITION_DEFINE
  *
@@ -62,7 +62,7 @@ struct k_mem_partition {
 #else
 /* To support use of IS_ENABLED for the APIs below */
 struct k_mem_partition;
-#endif /* CONFIG_MEMORY_PROTECTION */
+#endif /* CONFIG_MEMORY_PROTECTION || CONFIG_USERSPACE*/
 
 #ifdef CONFIG_USERSPACE
 /**


### PR DESCRIPTION
This issue force to enable CONFIG_MEMORY_PROTECTION to use userspace
feature whereas they shouldn't be dependent (Kconfig and CMakeLists
files going this way).

Signed-off-by: Alexandre Mergnat <amergnat@baylibre.com>