### PR TITLE
Deprecate DEVICE_INIT

### DIFF
--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -52,8 +52,10 @@ static const struct pwr_ctrl_cfg vdd_pwr_ctrl_cfg = {
 	.pin = VDD_PWR_CTRL_GPIO_PIN,
 };
 
-DEVICE_INIT(vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, &vdd_pwr_ctrl_cfg,
-	    POST_KERNEL, CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY);
+DEVICE_DEFINE(vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
+	      &vdd_pwr_ctrl_cfg,
+	      POST_KERNEL, CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY,
+	      NULL);
 
 #ifdef CONFIG_SENSOR
 
@@ -70,8 +72,8 @@ static const struct pwr_ctrl_cfg ccs_vdd_pwr_ctrl_cfg = {
 	.pin = CCS_VDD_PWR_CTRL_GPIO_PIN,
 };
 
-DEVICE_INIT(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL,
-	    &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
-	    CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY);
+DEVICE_DEFINE(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
+	      &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
+	      CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY, NULL);
 
 #endif

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -76,10 +76,6 @@ applications.
    Like :c:func:`DEVICE_DEFINE()` but without support for device power
    management.
 
-:c:func:`DEVICE_INIT()`
-   Like :c:func:`DEVICE_AND_API_INIT()` but without providing an API
-   pointer.
-
 :c:func:`DEVICE_NAME_GET()`
    Converts a device identifier to the global identifier for a device
    object.

--- a/doc/reference/terminology.rst
+++ b/doc/reference/terminology.rst
@@ -154,7 +154,7 @@ Explanation
 -----------
 
 This attribute is similar to **isr-ok** in function, but is intended for
-use by any API that is expected to be called in :c:macro:`DEVICE_INIT()`
+use by any API that is expected to be called in :c:macro:`DEVICE_DEFINE()`
 or :c:macro:`SYS_INIT()` calls that may be invoked with ``PRE_KERNEL_1``
 or ``PRE_KERNEL_2`` initialization levels.
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -48,6 +48,8 @@ Deprecated in this release
 
 * ARM Musca-A board and SoC support deprecated and planned to be removed in 2.6.0.
 
+* DEVICE_INIT was deprecated in favor of utilizing DEVICE_DEFINE directly.
+
 Removed APIs in this release
 ============================
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -649,6 +649,6 @@ static int gpio_stm32_afio_init(const struct device *device)
 	return 0;
 }
 
-DEVICE_INIT(gpio_stm32_afio, "", gpio_stm32_afio_init, NULL, NULL, PRE_KERNEL_2, 0);
+SYS_DEVICE_DEFINE("gpio_stm32_afio", gpio_stm32_afio_init, NULL, PRE_KERNEL_2, 0);
 
 #endif /* CONFIG_SOC_SERIES_STM32F1X */

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -402,9 +402,10 @@ static int stm32_exti_init(const struct device *dev)
 }
 
 static struct stm32_exti_data exti_data;
-DEVICE_INIT(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
-	    &exti_data, NULL,
-	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+DEVICE_DEFINE(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
+	      NULL, &exti_data, NULL,
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+	      NULL);
 
 /**
  * @brief set & unset for the interrupt callbacks

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -413,6 +413,7 @@ static int sam0_eic_init(const struct device *dev)
 }
 
 static struct sam0_eic_data eic_data;
-DEVICE_INIT(sam0_eic, DT_INST_LABEL(0), sam0_eic_init,
-	    &eic_data, NULL,
-	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+DEVICE_DEFINE(sam0_eic, DT_INST_LABEL(0), sam0_eic_init,
+	      NULL, &eic_data, NULL,
+	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+	      NULL);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -789,5 +789,5 @@ static int gsm_init(const struct device *device)
 	return 0;
 }
 
-DEVICE_INIT(gsm_ppp, GSM_MODEM_DEVICE_NAME, gsm_init, &gsm, NULL, POST_KERNEL,
-	    CONFIG_MODEM_GSM_INIT_PRIORITY);
+DEVICE_DEFINE(gsm_ppp, GSM_MODEM_DEVICE_NAME, gsm_init, &gsm, NULL, NULL,
+	      POST_KERNEL, CONFIG_MODEM_GSM_INIT_PRIORITY, NULL);

--- a/include/device.h
+++ b/include/device.h
@@ -68,8 +68,7 @@ extern "C" {
  */
 #define DEVICE_INIT(dev_name, drv_name, init_fn,			\
 		    data_ptr, cfg_ptr, level, prio)			\
-	DEVICE_DEFINE(dev_name, drv_name, init_fn,			\
-		      device_pm_control_nop,				\
+	DEVICE_DEFINE(dev_name, drv_name, init_fn, NULL,		\
 		      data_ptr, cfg_ptr, level, prio, NULL)
 
 /**
@@ -81,7 +80,7 @@ extern "C" {
 #define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,		\
 			    data_ptr, cfg_ptr, level, prio, api_ptr)	\
 	DEVICE_DEFINE(dev_name, drv_name, init_fn,			\
-		      device_pm_control_nop,				\
+		      NULL,						\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
@@ -383,9 +382,15 @@ static inline int device_set_power_state(const struct device *dev,
 					 uint32_t device_power_state,
 					 device_pm_cb cb, void *arg)
 {
-	return dev->device_pm_control(dev,
-					 DEVICE_PM_SET_POWER_STATE,
-					 &device_power_state, cb, arg);
+	if (dev->device_pm_control) {
+		return dev->device_pm_control(dev,
+						 DEVICE_PM_SET_POWER_STATE,
+						 &device_power_state, cb, arg);
+	} else {
+		return device_pm_control_nop(dev,
+						 DEVICE_PM_SET_POWER_STATE,
+						 &device_power_state, cb, arg);
+	}
 }
 
 /**
@@ -404,10 +409,15 @@ static inline int device_set_power_state(const struct device *dev,
 static inline int device_get_power_state(const struct device *dev,
 					 uint32_t *device_power_state)
 {
-	return dev->device_pm_control(dev,
-					 DEVICE_PM_GET_POWER_STATE,
-					 device_power_state,
-					 NULL, NULL);
+	if (dev->device_pm_control) {
+		return dev->device_pm_control(dev,
+						 DEVICE_PM_GET_POWER_STATE,
+						 device_power_state, NULL, NULL);
+	} else {
+		return device_pm_control_nop(dev,
+						 DEVICE_PM_GET_POWER_STATE,
+						 device_power_state, NULL, NULL);
+	}
 }
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -68,6 +68,7 @@ extern "C" {
  */
 #define DEVICE_INIT(dev_name, drv_name, init_fn,			\
 		    data_ptr, cfg_ptr, level, prio)			\
+	__DEPRECATED_MACRO						\
 	DEVICE_DEFINE(dev_name, drv_name, init_fn, NULL,		\
 		      data_ptr, cfg_ptr, level, prio, NULL)
 
@@ -143,11 +144,11 @@ extern "C" {
  * @brief Obtain a pointer to a device object by name
  *
  * @details Return the address of a device object created by
- * DEVICE_INIT(), using the dev_name provided to DEVICE_INIT().
+ * DEVICE_DEFINE(), using the dev_name provided to DEVICE_DEFINE().
  *
- * @param name The same as dev_name provided to DEVICE_INIT()
+ * @param name The same as dev_name provided to DEVICE_DEFINE()
  *
- * @return A pointer to the device object created by DEVICE_INIT()
+ * @return A pointer to the device object created by DEVICE_DEFINE()
  */
 #define DEVICE_GET(name) (&DEVICE_NAME_GET(name))
 
@@ -157,11 +158,11 @@ extern "C" {
  *
  * This macro can be used at the top-level to declare a device, such
  * that DEVICE_GET() may be used before the full declaration in
- * DEVICE_INIT().
+ * DEVICE_DEFINE().
  *
  * This is often useful when configuring interrupts statically in a
  * device's init or per-instance config function, as the init function
- * itself is required by DEVICE_INIT() and use of DEVICE_GET()
+ * itself is required by DEVICE_DEFINE() and use of DEVICE_GET()
  * inside it creates a circular dependency.
  *
  * @param name Device name
@@ -217,7 +218,7 @@ struct device {
 /**
  * @brief Retrieve the device structure for a driver by name
  *
- * @details Device objects are created via the DEVICE_INIT() macro and
+ * @details Device objects are created via the DEVICE_DEFINE() macro and
  * placed in memory by the linker. If a driver needs to bind to another driver
  * it can use this function to retrieve the device structure of the lower level
  * driver by the name the driver exposes to the system.

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -263,8 +263,8 @@ static int hci_spi_init(const struct device *unused)
 	return 0;
 }
 
-DEVICE_INIT(hci_spi, "hci_spi", &hci_spi_init, NULL, NULL,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_DEVICE_DEFINE("hci_spi", hci_spi_init, NULL,
+		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)
 {

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -323,8 +323,8 @@ static int hci_uart_init(const struct device *unused)
 	return 0;
 }
 
-DEVICE_INIT(hci_uart, "hci_uart", &hci_uart_init, NULL, NULL,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_DEVICE_DEFINE("hci_uart", hci_uart_init, NULL,
+		  APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 void main(void)
 {

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -160,7 +160,8 @@ void sys_pm_create_device_list(void)
 		const struct device *dev = &all_devices[pmi];
 
 		/* Ignore "device"s that don't support PM */
-		if (dev->device_pm_control == device_pm_control_nop) {
+		if ((dev->device_pm_control == NULL) ||
+		    (dev->device_pm_control == device_pm_control_nop)) {
 			continue;
 		}
 

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -41,9 +41,9 @@ static struct ipm_console_sender_config_info sender_config = {
 	.bind_to = "ipm_dummy0",
 	.flags = SOURCE
 };
-DEVICE_INIT(ipm_console_send0, "ipm_send0", ipm_console_sender_init,
-	    NULL, &sender_config,
-	    APPLICATION, INIT_PRIO_IPM_SEND);
+DEVICE_DEFINE(ipm_console_send0, "ipm_send0", ipm_console_sender_init,
+	      NULL, NULL, &sender_config,
+	      APPLICATION, INIT_PRIO_IPM_SEND, NULL);
 
 /* Receiving side of the console IPM driver. These numbers are
  * more or less arbitrary
@@ -67,9 +67,9 @@ static struct ipm_console_receiver_config_info receiver_config = {
 };
 
 struct ipm_console_receiver_runtime_data receiver_data;
-DEVICE_INIT(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
-	    &receiver_data, &receiver_config,
-	    APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+DEVICE_DEFINE(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
+	      NULL, &receiver_data, &receiver_config,
+	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 static const char thestr[] = "everything is awesome\n";
 


### PR DESCRIPTION
There are only a small handful of DEVICE_INIT users so lets just use DEVICE_DEFINE/SYS_DEVICE_DEFINE in those places and reduce one macro.