### PR TITLE
drivers: remove unnecessary use of DEVICE_AND_API_INIT

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -460,12 +460,6 @@ static struct st7789v_data st7789v_data = {
 	.y_offset = DT_INST_PROP(0, y_offset),
 };
 
-#ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_AND_API_INIT(st7789v, DT_INST_LABEL(0), &st7789v_init,
-		    &st7789v_data, NULL, APPLICATION,
-		    CONFIG_APPLICATION_INIT_PRIORITY, &st7789v_api);
-#else
 DEVICE_DEFINE(st7789v, DT_INST_LABEL(0), &st7789v_init,
 	      st7789v_pm_control, &st7789v_data, NULL, APPLICATION,
 	      CONFIG_APPLICATION_INIT_PRIORITY, &st7789v_api);
-#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -392,16 +392,9 @@ static struct entropy_cc13xx_cc26xx_data entropy_cc13xx_cc26xx_data = {
 	.sync = Z_SEM_INITIALIZER(entropy_cc13xx_cc26xx_data.sync, 0, 1),
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(entropy_cc13xx_cc26xx, DT_INST_LABEL(0),
 		entropy_cc13xx_cc26xx_init,
 		entropy_cc13xx_cc26xx_pm_control,
 		&entropy_cc13xx_cc26xx_data, NULL,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&entropy_cc13xx_cc26xx_driver_api);
-#else
-DEVICE_AND_API_INIT(entropy_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    entropy_cc13xx_cc26xx_init, &entropy_cc13xx_cc26xx_data,
-		    NULL, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &entropy_cc13xx_cc26xx_driver_api);
-#endif

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -574,18 +574,10 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 	.base_addr = DT_INST_REG_ADDR(0),
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-
 DEVICE_DEFINE(gpio_dw_0, DT_INST_LABEL(0),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_0_runtime,
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
-#else
-DEVICE_AND_API_INIT(gpio_dw_0, DT_INST_LABEL(0),
-		    gpio_dw_initialize, &gpio_0_runtime, &gpio_config_0,
-		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
-		    &api_funcs);
-#endif
 
 #if DT_INST_IRQ_HAS_CELL(0, flags)
 #define INST_0_IRQ_FLAGS DT_INST_IRQ(0, flags)
@@ -644,18 +636,10 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 	.base_addr = DT_INST_REG_ADDR(1),
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(gpio_dw_1, DT_INST_LABEL(1),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_1_runtime,
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
-#else
-DEVICE_AND_API_INIT(gpio_dw_1, DT_INST_LABEL(1),
-		    gpio_dw_initialize, &gpio_1_runtime, &gpio_dw_config_1,
-		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
-		    &api_funcs);
-#endif
-
 
 #if DT_INST_IRQ_HAS_CELL(1, flags)
 #define INST_1_IRQ_FLAGS DT_INST_IRQ(1, flags)
@@ -713,17 +697,10 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 	.base_addr = DT_INST_REG_ADDR(2),
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(gpio_dw_2, DT_INST_LABEL(2),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_2_runtime,
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
-#else
-DEVICE_AND_API_INIT(gpio_dw_2, DT_INST_LABEL(2),
-		    gpio_dw_initialize, &gpio_2_runtime, &gpio_dw_config_2,
-		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
-		    &api_funcs);
-#endif
 
 #if DT_INST_IRQ_HAS_CELL(2, flags)
 #define INST_2_IRQ_FLAGS DT_INST_IRQ(2, flags)
@@ -781,17 +758,10 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 	.base_addr = DT_INST_REG_ADDR(3),
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(gpio_dw_3, DT_INST_LABEL(3),
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_3_runtime,
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
-#else
-DEVICE_AND_API_INIT(gpio_dw_3, DT_INST_LABEL(3),
-		    gpio_dw_initialize, &gpio_3_runtime, &gpio_dw_config_3,
-		    POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
-		    &api_funcs);
-#endif
 
 #if DT_INST_IRQ_HAS_CELL(3, flags)
 #define INST_3_IRQ_FLAGS DT_INST_IRQ(3, flags)

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -475,16 +475,9 @@ static struct i2c_cc13xx_cc26xx_data i2c_cc13xx_cc26xx_data = {
 	.error = I2C_MASTER_ERR_NONE
 };
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(i2c_cc13xx_cc26xx, DT_INST_LABEL(0),
 		i2c_cc13xx_cc26xx_init,
 		i2c_cc13xx_cc26xx_pm_control,
 		&i2c_cc13xx_cc26xx_data, &i2c_cc13xx_cc26xx_config,
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		&i2c_cc13xx_cc26xx_driver_api);
-#else
-DEVICE_AND_API_INIT(i2c_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    i2c_cc13xx_cc26xx_init, &i2c_cc13xx_cc26xx_data,
-		    &i2c_cc13xx_cc26xx_config, POST_KERNEL,
-		    CONFIG_I2C_INIT_PRIORITY, &i2c_cc13xx_cc26xx_driver_api);
-#endif

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -543,12 +543,6 @@ static const struct apds9960_config apds9960_config = {
 
 static struct apds9960_data apds9960_data;
 
-#ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_AND_API_INIT(apds9960, DT_INST_LABEL(0), &apds9960_init,
-		    &apds9960_data, &apds9960_config, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);
-#else
 DEVICE_DEFINE(apds9960, DT_INST_LABEL(0), apds9960_init,
 	      apds9960_device_ctrl, &apds9960_data, &apds9960_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);
-#endif

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -370,13 +370,6 @@ static const struct vcnl4040_config vcnl4040_config = {
 
 static struct vcnl4040_data vcnl4040_data;
 
-#ifndef CONFIG_DEVICE_POWER_MANAGEMENT
-DEVICE_AND_API_INIT(vcnl4040, DT_INST_LABEL(0), vcnl4040_init,
-		    &vcnl4040_data, &vcnl4040_config,
-		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &vcnl4040_driver_api);
-#else
 DEVICE_DEFINE(vcnl4040, DT_INST_LABEL(0), vcnl4040_init,
 	      vcnl4040_device_ctrl, &vcnl4040_data, &vcnl4040_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);
-#endif

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -579,25 +579,12 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	     \
 		&uart_cc13xx_cc26xx_driver_api)
 
-#define UART_CC13XX_CC26XX_DEVICE_API_INIT(n)				     \
-	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	     \
-		uart_cc13xx_cc26xx_init_##n, &uart_cc13xx_cc26xx_data_##n,   \
-		&uart_cc13xx_cc26xx_config_##n, PRE_KERNEL_1,		     \
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			     \
-		&uart_cc13xx_cc26xx_driver_api)
-
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-#define UART_CC13XX_CC26XX_DEVICE_INIT(n)				\
-	UART_CC13XX_CC26XX_DEVICE_DEFINE(n)
-
 #define UART_CC13XX_CC26XX_INIT_PM_STATE				\
 	do {								\
 		get_dev_data(dev)->pm_state = DEVICE_PM_ACTIVE_STATE;	\
 	} while (0)
 #else
-#define UART_CC13XX_CC26XX_DEVICE_INIT(n)				\
-	UART_CC13XX_CC26XX_DEVICE_API_INIT(n)
-
 #define UART_CC13XX_CC26XX_INIT_PM_STATE
 #endif
 
@@ -651,6 +638,6 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		UART_CC13XX_CC26XX_INT_FIELDS			     \
 	};							     \
 								     \
-	UART_CC13XX_CC26XX_DEVICE_INIT(n);
+	UART_CC13XX_CC26XX_DEVICE_DEFINE(n);
 
 DT_INST_FOREACH_STATUS_OKAY(UART_CC13XX_CC26XX_INIT)

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -329,7 +329,6 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 	} while (0)
 #endif
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
 	DEVICE_DEFINE(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		    \
 		spi_cc13xx_cc26xx_init_##n,				    \
@@ -338,18 +337,12 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			    \
 		&spi_cc13xx_cc26xx_driver_api)
 
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define SPI_CC13XX_CC26XX_INIT_PM_STATE					    \
 	do {								    \
 		get_dev_data(dev)->pm_state = DEVICE_PM_ACTIVE_STATE;	    \
 	} while (0)
 #else
-#define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
-	DEVICE_AND_API_INIT(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	    \
-		    spi_cc13xx_cc26xx_init_##n, &spi_cc13xx_cc26xx_data_##n,\
-		    &spi_cc13xx_cc26xx_config_##n, POST_KERNEL,		    \
-		    CONFIG_SPI_INIT_PRIORITY,				    \
-		    &spi_cc13xx_cc26xx_driver_api)
-
 #define SPI_CC13XX_CC26XX_INIT_PM_STATE
 #endif
 


### PR DESCRIPTION
For drivers that support CONFIG_DEVICE_POWER_MANAGEMENT there are some
cases that look like:

  #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
    DEVICE_DEFINE()
  #else
    DEVICE_AND_API_INIT()
  #endif

There is no need to special case this as the pm_control_fn argument to
DEVICE_DEFINE will just be ignored in the
!CONFIG_DEVICE_POWER_MANAGEMENT case.  So we can cleanup the code a
little and remove the #else cases for the drivers that do this.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>