### PR TITLE
modules: mbedtls: introduce MBEDTLS_MEMORY_DEBUG option

### DIFF
--- a/modules/Kconfig.mbedtls
+++ b/modules/Kconfig.mbedtls
@@ -86,6 +86,14 @@ config MBEDTLS_DEBUG_LEVEL
 	  3 Information
 	  4 Verbose
 
+config MBEDTLS_MEMORY_DEBUG
+	bool "mbed TLS memory debug activation"
+	depends on MBEDTLS_BUILTIN
+	help
+	  Enable debugging of buffer allocator memory issues. Automatically
+	  prints (to stderr) all (fatal) messages on memory allocation
+	  issues. Enables function for 'debug output' of allocated memory.
+
 config MBEDTLS_TEST
 	bool "Compile internal self test functions"
 	depends on MBEDTLS_BUILTIN

--- a/west.yml
+++ b/west.yml
@@ -90,7 +90,7 @@ manifest:
       revision: 31acbaa36e9e74ab88ac81e3d21e7f1d00a71136
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: e3e135f89693a0342bbc72f31a4e00cdf36c3977
+      revision: 13cf2e52024a144ecee9f37680681760a85febab
       path: modules/crypto/mbedtls
     - name: mcuboot
       revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6


### PR DESCRIPTION
This option allows enable mbed TLS debugging of buffer allocator memory
issues.

There is a mbedtls reporitory PR that select proper macro here: https://github.com/zephyrproject-rtos/mbedtls/pull/17