### PR TITLE
libc: minimal: print stderr just like stdout

### DIFF
--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -27,7 +27,7 @@ void __stdout_hook_install(int (*hook)(int))
 
 int z_impl_zephyr_fputc(int c, FILE *stream)
 {
-	return (stdout == stream) ? _stdout_hook(c) : EOF;
+	return (stream == stdout || stream == stderr) ? _stdout_hook(c) : EOF;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -60,7 +60,8 @@ size_t z_impl_zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 	size_t j;
 	const unsigned char *p;
 
-	if ((stream != stdout) || (nitems == 0) || (size == 0)) {
+	if ((stream != stdout && stream != stderr) ||
+	    (nitems == 0) || (size == 0)) {
 		return 0;
 	}
 


### PR DESCRIPTION
So far data that went to stderr was simply dropped in case of minimal
libc. In case of newlib stderr was treated same like stdout
(e.g. fprintf(stderr, ...) was equivalent to fprintf(stdout, ...).

Extend filter on stream pointer to allow both stdout and stderr to pass
data to stdout hook (which is Zephyr console backend in most cases).