### PR TITLE
usb: drivers: Clear STALL when enabling Endpoint

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1616,6 +1616,10 @@ int usb_dc_ep_enable(const uint8_t ep)
 		 * toggle sequencing and should only send DATA0 PID.
 		 */
 		nrfx_usbd_ep_dtoggle_clear(ep_addr_to_nrfx(ep));
+		/** Endpoint is enabled on SetInterface request.
+		 * This should also clear EP's halt status.
+		 */
+		nrfx_usbd_ep_stall_clear(ep_addr_to_nrfx(ep));
 	}
 	if (ep_ctx->cfg.en) {
 		return -EALREADY;


### PR DESCRIPTION
STALL should be cleared when endpoint is Enabled.
Even enabling already enabled endpoint should clear STALL,
because HOST may enable Endpoints by SetInterface request.

(This fix should be also applied to other drivers.)