### PR TITLE
Revert "shields: Modify overlay file order"

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -380,6 +380,17 @@ foreach(root ${BOARD_ROOT})
       list(GET shields_refs_list ${_idx} s_path)
       get_filename_component(s_dir ${s_path} DIRECTORY)
 
+      # if shield config flag is on, add shield overlay to the shield overlays
+      # list and dts_fixup file to the shield fixup file
+      list(APPEND
+        shield_dts_files
+        ${shield_dir}/${s_path}
+        )
+      list(APPEND
+        shield_dts_fixups
+        ${shield_dir}/${s_dir}/dts_fixup.h
+        )
+
       # search for shield/boards/board.overlay file
       if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.overlay)
         # add shield/board overlay to the shield overlays list
@@ -397,17 +408,6 @@ foreach(root ${BOARD_ROOT})
           ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay
           )
       endif()
-
-      # if shield config flag is on, add shield overlay to the shield overlays
-      # list and dts_fixup file to the shield fixup file
-      list(APPEND
-        shield_dts_files
-        ${shield_dir}/${s_path}
-        )
-      list(APPEND
-        shield_dts_fixups
-        ${shield_dir}/${s_dir}/dts_fixup.h
-        )
 
       # search for shield/shield.conf file
       if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)


### PR DESCRIPTION
Fixes: #29074

This reverts commit fc8f639b9a6df12a024b0ee5b452db06d7b72609.

The suggestion provided in #27901 is impacting processing order of
overlay files in a non-logical way, see #29074 discussion for details.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>