### PR TITLE
Bluetooth: controller: Silence unused variable warning with non-AE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -372,9 +372,9 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 static void isr_tx(void *param)
 {
-	struct lll_adv *lll = param;
 	uint32_t hcto;
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+	struct lll_adv *lll = param;
 	uint8_t phy_p = lll->phy_p;
 #else
 	uint8_t phy_p = 0;


### PR DESCRIPTION
Places definition of lll under the ADV_EXT #ifdef in lll_adv.c:isr_tx,
to silence build warnings for non-AE builds.

Follow-up from #29753.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>