### PR TITLE
drivers: ethernet: stm32: Add missing net_if_set_link_addr() call

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -836,6 +836,9 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 			(dev_data->mac_addr[2] << 16) |
 			(dev_data->mac_addr[1] << 8) |
 			dev_data->mac_addr[0];
+		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
+				     sizeof(dev_data->mac_addr),
+				     NET_LINK_ETHERNET);
 		return 0;
 	default:
 		break;


### PR DESCRIPTION
When setting the MAC address, the ethernet driver has to call
net_if_set_link_addr() with the updated address. This was missing and is
added now.
See e.g.
https://github.com/zephyrproject-rtos/zephyr/pull/28874

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>