### PR TITLE
TCP2 update connection statistics

### DIFF
--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -129,6 +129,9 @@ struct net_stats_tcp {
 	/** Amount of retransmitted data. */
 	net_stats_t resent;
 
+	/** Number of dropped packets at the TCP layer. */
+	net_stats_t drop;
+
 	/** Number of received TCP segments. */
 	net_stats_t recv;
 
@@ -136,7 +139,7 @@ struct net_stats_tcp {
 	net_stats_t sent;
 
 	/** Number of dropped TCP segments. */
-	net_stats_t drop;
+	net_stats_t seg_drop;
 
 	/** Number of TCP segments with a bad checksum. */
 	net_stats_t chkerr;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1110,24 +1110,25 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
-	PR("TCP bytes recv %u\tsent\t%d\n",
+	PR("TCP bytes recv %u\tsent\t%d\tresent\t%d\n",
 	   GET_STAT(iface, tcp.bytes.received),
-	   GET_STAT(iface, tcp.bytes.sent));
+	   GET_STAT(iface, tcp.bytes.sent),
+	   GET_STAT(iface, tcp.resent));
 	PR("TCP seg recv   %d\tsent\t%d\tdrop\t%d\n",
 	   GET_STAT(iface, tcp.recv),
 	   GET_STAT(iface, tcp.sent),
-	   GET_STAT(iface, tcp.drop));
+	   GET_STAT(iface, tcp.seg_drop));
 	PR("TCP seg resent %d\tchkerr\t%d\tackerr\t%d\n",
-	   GET_STAT(iface, tcp.resent),
+	   GET_STAT(iface, tcp.rexmit),
 	   GET_STAT(iface, tcp.chkerr),
 	   GET_STAT(iface, tcp.ackerr));
-	PR("TCP seg rsterr %d\trst\t%d\tre-xmit\t%d\n",
+	PR("TCP seg rsterr %d\trst\t%d\n",
 	   GET_STAT(iface, tcp.rsterr),
-	   GET_STAT(iface, tcp.rst),
-	   GET_STAT(iface, tcp.rexmit));
+	   GET_STAT(iface, tcp.rst));
 	PR("TCP conn drop  %d\tconnrst\t%d\n",
 	   GET_STAT(iface, tcp.conndrop),
 	   GET_STAT(iface, tcp.connrst));
+	PR("TCP pkt drop   %d\n", GET_STAT(iface, tcp.drop));
 #endif
 
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMP) && defined(CONFIG_NET_NATIVE)

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -204,6 +204,11 @@ static inline void net_stats_update_tcp_resent(struct net_if *iface,
 	UPDATE_STAT(iface, stats.tcp.resent += bytes);
 }
 
+static inline void net_stats_update_tcp_drop(struct net_if *iface)
+{
+	UPDATE_STAT(iface, stats.tcp.drop++);
+}
+
 static inline void net_stats_update_tcp_seg_sent(struct net_if *iface)
 {
 	UPDATE_STAT(iface, stats.tcp.sent++);
@@ -216,7 +221,7 @@ static inline void net_stats_update_tcp_seg_recv(struct net_if *iface)
 
 static inline void net_stats_update_tcp_seg_drop(struct net_if *iface)
 {
-	UPDATE_STAT(iface, stats.tcp.drop++);
+	UPDATE_STAT(iface, stats.tcp.seg_drop++);
 }
 
 static inline void net_stats_update_tcp_seg_rst(struct net_if *iface)
@@ -257,6 +262,7 @@ static inline void net_stats_update_tcp_seg_rexmit(struct net_if *iface)
 #define net_stats_update_tcp_sent(iface, bytes)
 #define net_stats_update_tcp_resent(iface, bytes)
 #define net_stats_update_tcp_recv(iface, bytes)
+#define net_stats_update_tcp_drop(iface)
 #define net_stats_update_tcp_seg_sent(iface)
 #define net_stats_update_tcp_seg_recv(iface)
 #define net_stats_update_tcp_seg_drop(iface)
@@ -293,7 +299,7 @@ static inline void net_stats_update_per_proto_drop(struct net_if *iface,
 	if (IS_ENABLED(CONFIG_NET_UDP) && proto == IPPROTO_UDP) {
 		net_stats_update_udp_drop(iface);
 	} else if (IS_ENABLED(CONFIG_NET_TCP) && proto == IPPROTO_TCP) {
-		net_stats_update_tcp_seg_drop(iface);
+		net_stats_update_tcp_drop(iface);
 	}
 }
 


### PR DESCRIPTION
Noticed that we did not update TCP statistics properly in TCP2. Fixed also the net-shell to print the statistics correctly.