### PR TITLE
Bluetooth: host: Change directed advertising to privacy-enabled peer 

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -182,6 +182,10 @@ Bluetooth
 
 * Host
 
+  * When privacy has been enabled in order to advertise towards a
+    privacy-enabled peer the BT_LE_ADV_OPT_DIR_ADDR_RPA option must now
+    be set, same as when privacy has been disabled.
+
 * Mesh
 
 * BLE split software Controller

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -379,8 +379,7 @@ enum {
 	 * @brief Directed advertising to privacy-enabled peer.
 	 *
 	 * Enable use of Resolvable Private Address (RPA) as the target address
-	 * in directed advertisements when @option{CONFIG_BT_PRIVACY} is not
-	 * enabled.
+	 * in directed advertisements.
 	 * This is required if the remote device is privacy-enabled and
 	 * supports address resolution of the target address in directed
 	 * advertisement.

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -665,7 +665,7 @@ static int cmd_active_scan_on(const struct shell *shell, uint32_t options,
 	int err;
 	struct bt_le_scan_param param = {
 			.type       = BT_LE_SCAN_TYPE_ACTIVE,
-			.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+			.options    = BT_LE_SCAN_OPT_NONE,
 			.interval   = BT_GAP_SCAN_FAST_INTERVAL,
 			.window     = BT_GAP_SCAN_FAST_WINDOW,
 			.timeout    = timeout, };


### PR DESCRIPTION
Change the advertising option that controls if the directed advertiser
will use an RPA or the identity address of the peer for the initiator
address.
This option currently has two issues:
 - It behaves differently if the privacy feature has been enabled,
   which can be confusing for application to use.
 - It cannot start a directed advertiser towards a peer that is not
   privacy-enabled and has distributed an IRK.

This commit includes the following changes:
 - When privacy has been enabled in order to advertise towards a
   privacy-enabled peer the BT_LE_ADV_OPT_DIR_ADDR_RPA option must now
   be set (same as when privacy has been disabled).
 - It is now possible to start a directed advertiser using the identity
   address of the peer when privacy is enabled.
 - When privacy has been enabled the advertising option combination
   of using the local identity address and an RPA as the initiator
   address is now disallowed and will return an error code.
   This is done because this combination did not actually work and would
   have used the identity address of the peer instead.
 - If the controller does not support controller-based privacy then
   using the option BT_LE_ADV_OPT_DIR_ADDR_RPA will return ENOTSUP
   because this behavior cannot be done with host-based privacy.