### PR TITLE
samples: add capture output for the mec15xxevb_assy6853 pm sample

### DIFF
--- a/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
+++ b/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
@@ -3,4 +3,12 @@ sample:
 tests:
   sample.board.mec15xxevb_assy6853.pm:
     platform_allow: mec15xxevb_assy6853
-    tags: board
+    tags: board pm
+    harness: console
+    harness_config:
+        type: multi_line
+        ordered: False
+        regex:
+            - "Wake from Light Sleep"
+            - "Wake from Deep Sleep"
+        repeat: 3


### PR DESCRIPTION
To make it runnable in the sanitycheck necessary to add
capture output, because that sample runs infinite period of time
and can not finished by itself. To avoid timeout error
in the sanitycheck I added capture output for a several times.
Also added one more tag to describe that it is a power
management sample.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>