### PR TITLE
boards: shields: Introduce Semtech SX1272 shield

### DIFF
--- a/boards/shields/semtech_sx1272mb2das/Kconfig.defconfig
+++ b/boards/shields/semtech_sx1272mb2das/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 Lemonbeat GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_SEMTECH_SX1272MB2DAS
+
+if LORA
+
+config SPI
+	default y
+
+endif # LORA
+
+endif # SHIELD_SEMTECH_SX1272MB2DAS

--- a/boards/shields/semtech_sx1272mb2das/Kconfig.shield
+++ b/boards/shields/semtech_sx1272mb2das/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 Lemonbeat GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_SEMTECH_SX1272MB2DAS
+	def_bool $(shields_list_contains,semtech_sx1272mb2das)

--- a/boards/shields/semtech_sx1272mb2das/doc/index.rst
+++ b/boards/shields/semtech_sx1272mb2das/doc/index.rst
@@ -1,0 +1,68 @@
+.. _semtech_sx1272mb2das:
+
+Semtech SX1272MB2DAS LoRa Shield
+################################
+
+Overview
+********
+
+The Semtech SX1272MB2DAS LoRa shield is an Arduino
+compatible shield based on the SX1272 LoRa transceiver
+from Semtech.
+
+More information about the shield can be found
+at the `mbed SX1272MB2xAS website`_.
+
+Pins Assignment of the Semtech SX1272MB2DAS LoRa Shield
+=======================================================
+
++-----------------------+-----------------+
+| Shield Connector Pin  | Function        |
++=======================+=================+
+| A0                    | SX1272 RESET    |
++-----------------------+-----------------+
+| D2                    | SX1272 DIO0     |
++-----------------------+-----------------+
+| D3                    | SX1272 DIO1     |
++-----------------------+-----------------+
+| D4                    | SX1272 DIO2     |
++-----------------------+-----------------+
+| D5                    | SX1272 DIO3     |
++-----------------------+-----------------+
+| D10                   | SX1272 SPI NSS  |
++-----------------------+-----------------+
+| D11                   | SX1272 SPI MOSI |
++-----------------------+-----------------+
+| D12                   | SX1272 SPI MISO |
++-----------------------+-----------------+
+| D13                   | SX1272 SPI SCK  |
++-----------------------+-----------------+
+
+The SX1272 signals DIO4 and DIO5 are not available at the shield connector.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``-DSHIELD=semtech_sx1272mb2das`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/lorawan/class_a
+   :board: nucleo_f429zi
+   :shield: semtech_sx1272mb2das
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _mbed SX1272MB2xAS website:
+   https://os.mbed.com/components/SX1272MB2xAS/

--- a/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
+++ b/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Lemonbeat GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		lora0 = &lora;
+	};
+};
+
+&arduino_spi {
+	status = "okay";
+
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+
+	lora: sx1272@0 {
+		compatible = "semtech,sx1272";
+		reg = <0x0>;
+		label = "sx1272";
+		spi-max-frequency = <3000000>;
+
+		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_HIGH>;   /* A0 */
+
+		dio-gpios = <&arduino_header 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO0 is D2 */
+		            <&arduino_header 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO1 is D3 */
+			    <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO2 is D4 */
+			    <&arduino_header 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;	   /* DIO3 is D5 */
+
+		power-amplifier-output = "rfo";
+	};
+};


### PR DESCRIPTION
The Semtech SX1272MB2DAS shield is populated with a SX1272 LoRa
transceiver. The base board must provide Arduino header pins definitions.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>