### PR TITLE
Add imgtool to requirements

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -14,3 +14,6 @@ lpc_checksum
 
 # used by scripts/gen_cfb_font_header.py - helper script for user
 Pillow
+
+# can be used to sign a Zephyr application binary for consumption by a bootloader
+imgtool


### PR DESCRIPTION
On Windows, west sign command fails when imgtool not installed
via 'pip3 install'
Bug https://github.com/zephyrproject-rtos/zephyr/issues/29842

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>