### PR TITLE
storage/stream: elimination of usage of the flash API internals

### DIFF
--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -181,6 +181,27 @@ size_t stream_flash_bytes_written(struct stream_flash_ctx *ctx)
 	return ctx->bytes_written;
 }
 
+struct _inspect_flash {
+	size_t buf_len;
+	size_t total_size;
+};
+
+static bool find_flash_total_size(const struct flash_pages_info *info,
+				  void *data)
+{
+	struct _inspect_flash *ctx = (struct _inspect_flash *) data;
+
+	if (ctx->buf_len > info->size) {
+		LOG_ERR("Buffer size is bigger than page");
+		ctx->total_size = 0;
+		return false;
+	}
+
+	ctx->total_size += info->size;
+
+	return true;
+}
+
 int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 		      uint8_t *buf, size_t buf_len, size_t offset, size_t size,
 		      stream_flash_callback_t cb)
@@ -189,10 +210,10 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 		return -EFAULT;
 	}
 
-	size_t layout_size = 0;
-	size_t total_size = 0;
-	const struct flash_pages_layout *layout;
-	const struct flash_driver_api *api = fdev->api;
+	struct _inspect_flash inspect_flash_ctx = {
+		.buf_len = buf_len,
+		.total_size = 0
+	};
 
 	if (buf_len % flash_get_write_block_size(fdev)) {
 		LOG_ERR("Buffer size is not aligned to minimal write-block-size");
@@ -200,21 +221,14 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 	}
 
 	/* Calculate the total size of the flash device */
-	api->page_layout(fdev, &layout, &layout_size);
-	for (int i = 0; i < layout_size; i++) {
+	flash_page_foreach(fdev, find_flash_total_size, &inspect_flash_ctx);
 
-		total_size += layout->pages_count * layout->pages_size;
-
-		if (buf_len > layout->pages_size) {
-			LOG_ERR("Buffer size is bigger than page");
-			return -EFAULT;
-		}
-
-		layout++;
-
+	/* The flash size counted should never be equal zero */
+	if (inspect_flash_ctx.total_size == 0) {
+		return -EFAULT;
 	}
 
-	if ((offset + size) > total_size ||
+	if ((offset + size) > inspect_flash_ctx.total_size ||
 	    offset % flash_get_write_block_size(fdev)) {
 		LOG_ERR("Incorrect parameter");
 		return -EFAULT;
@@ -226,7 +240,8 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 	ctx->bytes_written = 0;
 	ctx->buf_bytes = 0U;
 	ctx->offset = offset;
-	ctx->available = (size == 0 ? total_size - offset : size);
+	ctx->available = (size == 0 ? inspect_flash_ctx.total_size - offset :
+				      size);
 	ctx->callback = cb;
 
 #ifdef CONFIG_STREAM_FLASH_ERASE


### PR DESCRIPTION
Module was using flash driver implementation API call
`page_layout()` which is a part of driver implementation
interface API.

This patch re-implements this part of code using
`flash_page_foreach()` public API function.

fixes #27487