### PR TITLE
Print TCP2 info in net-shell

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1315,6 +1315,14 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 }
 #endif /* CONFIG_NET_CONN_LOG_LEVEL >= LOG_LEVEL_DBG */
 
+#if CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG
+struct tcp2_detail_info {
+	int printed_send_queue_header;
+	int printed_details;
+	int count;
+};
+#endif
+
 #if defined(CONFIG_NET_TCP1) && \
 	(defined(CONFIG_NET_OFFLOAD) || defined(CONFIG_NET_NATIVE))
 static void tcp_cb(struct net_tcp *tcp, void *user_data)
@@ -1388,7 +1396,98 @@ static void tcp_sent_list_cb(struct net_tcp *tcp, void *user_data)
 	*printed = true;
 }
 #endif /* CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG */
-#endif
+#endif /* TCP1 */
+
+#if defined(CONFIG_NET_TCP2) && \
+	(defined(CONFIG_NET_OFFLOAD) || defined(CONFIG_NET_NATIVE))
+static void tcp_cb(struct tcp *conn, void *user_data)
+{
+	struct net_shell_user_data *data = user_data;
+	const struct shell *shell = data->shell;
+	int *count = data->user_data;
+	uint16_t recv_mss = net_tcp_get_recv_mss(conn);
+
+	PR("%p %p   %5u    %5u %10u %10u %5u   %s\n",
+	   conn, conn->context,
+	   ntohs(net_sin6_ptr(&conn->context->local)->sin6_port),
+	   ntohs(net_sin6(&conn->context->remote)->sin6_port),
+	   conn->seq, conn->ack, recv_mss,
+	   net_tcp_state_str(net_tcp_get_state(conn)));
+
+	(*count)++;
+}
+
+#if CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG
+static void tcp_sent_list_cb(struct tcp *conn, void *user_data)
+{
+	struct net_shell_user_data *data = user_data;
+	const struct shell *shell = data->shell;
+	struct tcp2_detail_info *details = data->user_data;
+	struct net_pkt *pkt;
+	struct net_pkt *tmp;
+
+	if (conn->state != TCP_LISTEN) {
+		if (!details->printed_details) {
+			PR("\nTCP        Ref  Recv_win Send_win Pending "
+			   "Unacked Flags Queue\n");
+			details->printed_details = true;
+		}
+
+		PR("%p   %d    %u\t %u\t  %zd\t  %d\t  %d/%d/%d %s\n",
+		   conn, atomic_get(&conn->ref_count), conn->recv_win,
+		   conn->send_win, conn->send_data_total, conn->unacked_len,
+		   conn->in_retransmission, conn->in_connect, conn->in_close,
+		   sys_slist_is_empty(&conn->send_queue) ? "empty" : "data");
+
+		details->count++;
+	}
+
+	if (sys_slist_is_empty(&conn->send_queue)) {
+		return;
+	}
+
+	if (!details->printed_send_queue_header) {
+		PR("\nTCP packets waiting ACK:\n");
+		PR("TCP             net_pkt[ref/totlen]->net_buf[ref/len]..."
+		   "\n");
+	}
+
+	PR("%p      ", conn);
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->send_queue, pkt, tmp,
+					  sent_list) {
+		struct net_buf *frag = pkt->frags;
+
+		if (!details->printed_send_queue_header) {
+			PR("%p[%d/%zd]", pkt, atomic_get(&pkt->atomic_ref),
+			       net_pkt_get_len(pkt));
+			details->printed_send_queue_header = true;
+		} else {
+			PR("                %p[%d/%zd]",
+			   pkt, atomic_get(&pkt->atomic_ref),
+			   net_pkt_get_len(pkt));
+		}
+
+		if (frag) {
+			PR("->");
+		}
+
+		while (frag) {
+			PR("%p[%d/%d]", frag, frag->ref, frag->len);
+
+			frag = frag->frags;
+			if (frag) {
+				PR("->");
+			}
+		}
+
+		PR("\n");
+	}
+
+	details->printed_send_queue_header = true;
+}
+#endif /* CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG */
+#endif /* TCP2 */
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
 static void ipv6_frag_cb(struct net_ipv6_reassembly *reass,
@@ -1626,7 +1725,7 @@ static int cmd_net_conn(const struct shell *shell, size_t argc, char *argv[])
 	}
 #endif
 
-#if defined(CONFIG_NET_TCP1)
+#if defined(CONFIG_NET_TCP)
 	PR("\nTCP        Context   Src port Dst port   "
 	   "Send-Seq   Send-Ack  MSS    State\n");
 
@@ -1639,8 +1738,22 @@ static int cmd_net_conn(const struct shell *shell, size_t argc, char *argv[])
 	} else {
 #if CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG
 		/* Print information about pending packets */
+		struct tcp2_detail_info details;
+
 		count = 0;
+
+		if (IS_ENABLED(CONFIG_NET_TCP2)) {
+			memset(&details, 0, sizeof(details));
+			user_data.user_data = &details;
+		}
+
 		net_tcp_foreach(tcp_sent_list_cb, &user_data);
+
+		if (IS_ENABLED(CONFIG_NET_TCP2)) {
+			if (details.count == 0) {
+				PR("No active connections.\n");
+			}
+		}
 #endif /* CONFIG_NET_TCP_LOG_LEVEL >= LOG_LEVEL_DBG */
 	}
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -2176,6 +2176,72 @@ static void test_cb_register(sa_family_t family, uint8_t proto, uint16_t remote_
 }
 #endif /* CONFIG_NET_TEST_PROTOCOL */
 
+void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
+{
+	struct tcp *conn;
+	struct tcp *tmp;
+	int key;
+
+	key = irq_lock();
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&tcp_conns, conn, tmp, next) {
+
+		if (atomic_get(&conn->ref_count) > 0) {
+			irq_unlock(key);
+			cb(conn, user_data);
+			key = irq_lock();
+		}
+	}
+
+	irq_unlock(key);
+}
+
+uint16_t net_tcp_get_recv_mss(const struct tcp *conn)
+{
+	sa_family_t family = net_context_get_family(conn->context);
+
+	if (family == AF_INET) {
+#if defined(CONFIG_NET_IPV4)
+		struct net_if *iface = net_context_get_iface(conn->context);
+
+		if (iface && net_if_get_mtu(iface) >= NET_IPV4TCPH_LEN) {
+			/* Detect MSS based on interface MTU minus "TCP,IP
+			 * header size"
+			 */
+			return net_if_get_mtu(iface) - NET_IPV4TCPH_LEN;
+		}
+#else
+		return 0;
+#endif /* CONFIG_NET_IPV4 */
+	}
+#if defined(CONFIG_NET_IPV6)
+	else if (family == AF_INET6) {
+		struct net_if *iface = net_context_get_iface(conn->context);
+		int mss = 0;
+
+		if (iface && net_if_get_mtu(iface) >= NET_IPV6TCPH_LEN) {
+			/* Detect MSS based on interface MTU minus "TCP,IP
+			 * header size"
+			 */
+			mss = net_if_get_mtu(iface) - NET_IPV6TCPH_LEN;
+		}
+
+		if (mss < NET_IPV6_MTU) {
+			mss = NET_IPV6_MTU;
+		}
+
+		return mss;
+	}
+#endif /* CONFIG_NET_IPV6 */
+
+	return 0;
+}
+
+const char *net_tcp_state_str(enum tcp_state state)
+{
+	return tcp_state_to_str(state, false);
+}
+
 void net_tcp_init(void)
 {
 #if defined(CONFIG_NET_TEST_PROTOCOL)

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -230,3 +230,5 @@ struct tcp { /* TCP connection */
 
 #define FL(_fl, _op, _mask, _args...)					\
 	_flags(_fl, _op, _mask, strlen("" #_args) ? _args : true)
+
+typedef void (*net_tcp_cb_t)(struct tcp *conn, void *user_data);


### PR DESCRIPTION
If user has enabled TCP debugging, print additional information when TCP2 is in use.