### PR TITLE
[LVLG][CI] Added support to run lvgl sample on native_posix with sanitycheck

### DIFF
--- a/samples/display/lvgl/sample.yaml
+++ b/samples/display/lvgl/sample.yaml
@@ -30,3 +30,12 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=buydisplay_2_8_tft_touch_arduino
     tags: shield
+  sample.display.dummy:
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_DUMMY_DISPLAY=y
+      - CONFIG_DUMMY_DISPLAY_DEV_NAME="DISPLAY"
+      - CONFIG_KSCAN=n
+      - CONFIG_SDL_DISPLAY=n
+    tags: samples display gui


### PR DESCRIPTION
Added support to the lvgl sample so that it can build ~~and run~~ on the native_posix board with sanitycheck without requiring that the SDL library is installed on the host system.

This should prevent that build problems with the lvgl sample are only detected during the nightly CI run as flagged in #29720

~~Added DNM label as CI will/should fail as first the above mentioned issue needs to be fixed.~~