### PR TITLE
doc: fix broken rST syntax in Kconfig help

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -14,6 +14,7 @@ on:
     - 'subsys/testsuite/ztest/include/**'
     - 'tests/**'
     - '.known-issues/doc/**'
+    - '**/Kconfig*'
 
 jobs:
   build:

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -44,8 +44,8 @@ config UART_NATIVE_WAIT_PTS_READY_ENABLE
 	depends on NATIVE_UART_0_ON_OWN_PTY || UART_NATIVE_POSIX_PORT_1_ENABLE
 	help
 	  When this option is selected a new command line switch is provided:
-	  `--wait_uart`
-	  When `--wait_uart` is used, writes to the UART will be held until a
+	  ``--wait_uart``
+	  When ``--wait_uart`` is used, writes to the UART will be held until a
 	  client has connected to the slave side of the pseudoterminal.
 	  Otherwise writes are sent irrespectively.
 


### PR DESCRIPTION
Update usage of literal syntax in Kconfig file from markdown to proper rST.

Fixes #29853 