### PR TITLE
[backport v2.4] Bluetooth: Mesh: Move RPL clear to bt_mesh_reset

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -178,6 +178,12 @@ void bt_mesh_reset(void)
 	bt_mesh_rx_reset();
 	bt_mesh_tx_reset();
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_clear_rpl();
+	} else {
+		(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+	}
+
 	bt_mesh_net_loopback_clear(BT_MESH_KEY_ANY);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1821,12 +1821,6 @@ void bt_mesh_rx_reset(void)
 	for (i = 0; i < ARRAY_SIZE(seg_rx); i++) {
 		seg_rx_reset(&seg_rx[i], true);
 	}
-
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		bt_mesh_clear_rpl();
-	} else {
-		(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
-	}
 }
 
 void bt_mesh_tx_reset(void)


### PR DESCRIPTION
Moves the clearing of RPL out of the bt_mesh_rx_reset() to avoid it
being called outside of the node reset procedure.

Fixes #29858 for v2.4.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>