### PR TITLE
net: eth: support same ip to root and vlan ifaces

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -1535,6 +1535,16 @@ static inline uint8_t net_if_ipv4_get_ttl(struct net_if *iface)
 }
 
 /**
+ * @brief Check if this IPv4 address belongs to this specific interfaces.
+ *
+ * @param iface Network interface
+ * @param addr IPv4 address
+ *
+ * @return Pointer to interface address, NULL if not found.
+ */
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface(struct net_if *iface,
+						     struct in_addr *addr);
+/**
  * @brief Check if this IPv4 address belongs to one of the interfaces.
  *
  * @param addr IPv4 address

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2940,6 +2940,32 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 	return NULL;
 }
 
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface(struct net_if *iface,
+						     struct in_addr *addr)
+{
+	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+	int i;
+
+	if (!ipv4) {
+		return NULL;
+	}
+
+	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].is_used ||
+			ipv4->unicast[i].address.family != AF_INET) {
+			continue;
+		}
+
+		if (UNALIGNED_GET(&addr->s4_addr32[0]) ==
+			ipv4->unicast[i].address.in_addr.s_addr) {
+
+			return &ipv4->unicast[i];
+		}
+	}
+
+	return NULL;
+}
+
 int z_impl_net_if_ipv4_addr_lookup_by_index(const struct in_addr *addr)
 {
 	struct net_if_addr *if_addr;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -417,31 +417,22 @@ static enum net_verdict set_vlan_tag(struct ethernet_context *ctx,
 
 #if defined(CONFIG_NET_IPV6)
 	if (net_pkt_family(pkt) == AF_INET6) {
-		struct net_if *target;
-
-		if (net_if_ipv6_addr_lookup(&NET_IPV6_HDR(pkt)->src,
-					    &target)) {
-			if (target != iface) {
-				NET_DBG("Iface %p should be %p", iface,
-					target);
-
-				iface = target;
-			}
+		if (!net_if_ipv6_addr_lookup_by_iface(iface,
+			&NET_IPV6_HDR(pkt)->src)) {
+			NET_DBG("Iface %p doesn't have src ip %s", iface,
+			log_strdup(net_sprint_ipv6_addr(NET_IPV6_HDR(pkt)->src)));
+			return NET_DROP;
 		}
 	}
 #endif
 
 #if defined(CONFIG_NET_IPV4)
 	if (net_pkt_family(pkt) == AF_INET) {
-		struct net_if *target;
-
-		if (net_if_ipv4_addr_lookup(&NET_IPV4_HDR(pkt)->src,
-					    &target)) {
-			if (target != iface) {
-				NET_DBG("Iface %p should be %p", iface,
-					target);
-				iface = target;
-			}
+		if (!net_if_ipv4_addr_lookup_by_iface(iface,
+			&NET_IPV4_HDR(pkt)->src)) {
+			NET_DBG("Iface %p doesn't have src ip %s", iface,
+			log_strdup(net_sprint_ipv4_addr(NET_IPV4_HDR(pkt)->src)));
+			return NET_DROP;
 		}
 	}
 #endif


### PR DESCRIPTION
with the current net stack, if root iface and vlan iface
had the same ip and ping will send to the iface which
its number is bigger the packet will be drop.

the patch will check if the iface had the src ip
otherwise it will drop

Signed-off-by: Ehud Naim <ehudn@marvell.com>