### PR TITLE
tests: enable the code coverage for qemu_x86_64

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.board
+++ b/boards/x86/qemu_x86/Kconfig.board
@@ -12,3 +12,4 @@ config BOARD_QEMU_X86_64
 	depends on SOC_IA32
 	select QEMU_TARGET
 	select X86_64
+	select HAS_COVERAGE_SUPPORT

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -107,6 +107,7 @@ SECTIONS
 	*(.rodata)
 	*(.rodata.*)
 
+	MMU_PAGE_ALIGN
 	#include <snippets-rodata.ld>
 
 #ifdef CONFIG_X86_MMU
@@ -140,6 +141,10 @@ SECTIONS
 	_app_smem_num_words = _app_smem_size >> 2;
 #endif /* CONFIG_USERSPACE */
 
+/* This should be put here before BSS section, otherwise the .bss.__gcov will
+ * be put in BSS section. That causes gcov not work properly */
+#include <snippets-ram-sections.ld>
+
 	SECTION_PROLOGUE(_BSS_SECTION_NAME, (NOLOAD), ALIGN(16))
 	{
 	MMU_PAGE_ALIGN
@@ -168,7 +173,6 @@ SECTIONS
 	#include <snippets-rwdata.ld>
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#include <snippets-ram-sections.ld>
 #include <linker/common-ram.ld>
 #include <linker/cplusplus-ram.ld>
 #include <arch/x86/pagetables.ld>

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -108,7 +108,7 @@ void z_bss_zero(void)
 #endif	/* CONFIG_CODE_DATA_RELOCATION */
 #ifdef CONFIG_COVERAGE_GCOV
 	(void)memset(&__gcov_bss_start, 0,
-		 ((uint32_t) &__gcov_bss_end - (uint32_t) &__gcov_bss_start));
+		 ((uintptr_t) &__gcov_bss_end - (uintptr_t) &__gcov_bss_start));
 #endif
 }
 

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -258,9 +258,9 @@ coverage_dump_end:
 /* Initialize the gcov by calling the required constructors */
 void gcov_static_init(void)
 {
-	extern uint32_t __init_array_start, __init_array_end;
-	uint32_t func_pointer_start = (uint32_t) &__init_array_start;
-	uint32_t func_pointer_end = (uint32_t) &__init_array_end;
+	extern uintptr_t __init_array_start, __init_array_end;
+	uintptr_t func_pointer_start = (uintptr_t) &__init_array_start;
+	uintptr_t func_pointer_end = (uintptr_t) &__init_array_end;
 
 	while (func_pointer_start < func_pointer_end) {
 		void (**p)(void);

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -31,7 +31,21 @@ __gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
 __gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 #endif
 
-#ifdef CONFIG_X86
+#ifdef CONFIG_X86_64
+SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD), ALIGN(16))
+{
+	MMU_PAGE_ALIGN
+	__gcov_bss_start = .;
+	*(".bss.__gcov0.*");
+	. = ALIGN(8);
+	MMU_PAGE_ALIGN
+	__gcov_bss_end = .;
+}GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
+__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
+
+#elif CONFIG_X86
 SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 {
 	MMU_PAGE_ALIGN

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -12,6 +12,15 @@
 #define SKIP_EXECUTE_TESTS
 #endif
 
+/* Skip the memory map executing case when coverage enabled in x86_64,
+ * because it will crash due to incorrect address accessing for gcov variables.
+ * See issue#30434 for more details.
+ */
+#if defined(CONFIG_X86_64) && defined(CONFIG_COVERAGE)
+#define SKIP_EXECUTE_TESTS
+#endif
+
+
 #define BASE_FLAGS	(K_MEM_CACHE_WB)
 volatile bool expect_fault;
 


### PR DESCRIPTION
Enable the code coverage report for qemu_x86_64. See issue #17991.
In order to make this work, do some order change in linking file (include/arch/x86/intel64/linker.ld ).

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>