### PR TITLE
include: kernel.h: correct cast in K_TIMEOUT_ABS_*

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1430,7 +1430,8 @@ const char *k_thread_state_str(k_tid_t thread_id);
  * @param t Tick uptime value
  * @return Timeout delay value
  */
-#define K_TIMEOUT_ABS_TICKS(t) Z_TIMEOUT_TICKS(Z_TICK_ABS(MAX(t, 0)))
+#define K_TIMEOUT_ABS_TICKS(t) \
+	Z_TIMEOUT_TICKS(Z_TICK_ABS((k_ticks_t)MAX(t, 0)))
 
 /**
  * @brief Generates an absolute/uptime timeout value from milliseconds


### PR DESCRIPTION
The macros `K_TIMEOUT_ABS_*` throw a compiler warning because of narrowing conversion. This PR adds a cast to `k_ticks_t` to eliminate the warning.

Example compiler warning:

```
/home/martin/.../zephyr/include/sys_clock.h:108:44: warning: narrowing conversion of '(((long long unsigned int)(-1 - 1)) - ((k_ms_to_ticks_ceil64(((uint64_t)t_start)) > 0) ? k_ms_to_ticks_ceil64(((uint64_t)t_start)) : 0))' from 'long long unsigned int' to 'k_ticks_t' {aka 'long long int'} [-Wnarrowing]
  108 | #define Z_TICK_ABS(t) (K_TICKS_FOREVER - 1 - (t))
      |                                            ^
/home/martin/.../zephyr/include/sys_clock.h:85:55: note: in definition of macro 'Z_TIMEOUT_TICKS'
   85 | #define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { .ticks = (t) })
      |                                                       ^
/home/martin/.../zephyr/include/kernel.h:1433:48: note: in expansion of macro 'Z_TICK_ABS'
 1433 | #define K_TIMEOUT_ABS_TICKS(t) Z_TIMEOUT_TICKS(Z_TICK_ABS(MAX(t, 0)))
      |                                                ^~~~~~~~~~
/home/martin/.../zephyr/include/kernel.h:1446:29: note: in expansion of macro 'K_TIMEOUT_ABS_TICKS'
 1446 | #define K_TIMEOUT_ABS_MS(t) K_TIMEOUT_ABS_TICKS(k_ms_to_ticks_ceil64(t))
      |                             ^~~~~~~~~~~~~~~~~~~
/home/martin/.../src/main.cpp:126:17: note: in expansion of macro 'K_TIMEOUT_ABS_MS'
  126 |         k_sleep(K_TIMEOUT_ABS_MS(t_start));
      |                 ^~~~~~~~~~~~~~~~
```