### PR TITLE
Bluetooth: controller: Fix build without BT_CENTRAL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sched.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sched.h
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#if defined(CONFIG_BT_CENTRAL)
 extern void ull_sched_mfy_after_mstr_offset_get(void *param);
+#endif

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -142,6 +142,7 @@ void ull_sched_after_mstr_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 	}
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 void ull_sched_mfy_after_mstr_offset_get(void *param)
 {
 	struct lll_prepare_param *p = param;
@@ -160,6 +161,7 @@ void ull_sched_mfy_after_mstr_offset_get(void *param)
 			      (ticks_slot_overhead + conn_evt->ticks_slot),
 			      p->ticks_at_expire, &lll->conn_win_offset_us);
 }
+#endif /* CONFIG_BT_CENTRAL */
 
 void ull_sched_mfy_win_offset_use(void *param)
 {


### PR DESCRIPTION
lll->conn is only defined valid when BT_CENTRAL is enabled.
Also ull_sched_mfy_after_mstr_offset_get is only used when BT_CENTRAL
is enabled.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>