### PR TITLE
drivers: ieee802154: cc13xx_cc26xx: use multi-protocol radio patch

### DIFF
--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(ieee802154_cc13xx_cc26xx);
 #include <driverlib/rfc.h>
 #include <inc/hw_ccfg.h>
 #include <inc/hw_fcfg1.h>
-#include <rf_patches/rf_patch_cpe_ieee_802_15_4.h>
+#include <rf_patches/rf_patch_cpe_multi_protocol.h>
 
 #include <ti/drivers/rf/RF.h>
 
@@ -536,8 +536,8 @@ static int ieee802154_cc13xx_cc26xx_init(const struct device *dev)
 	RF_Params rf_params;
 	RF_EventMask reason;
 	RF_Mode rf_mode = {
-		.rfMode      = RF_MODE_IEEE_15_4,
-		.cpePatchFxn = &rf_patch_cpe_ieee_802_15_4,
+		.rfMode      = RF_MODE_MULTIPLE,
+		.cpePatchFxn = &rf_patch_cpe_multi_protocol,
 	};
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = get_dev_data(dev);
 

--- a/west.yml
+++ b/west.yml
@@ -77,7 +77,7 @@ manifest:
       revision: a0267470e786019e378be18f5786e53ef307497f
       path: modules/hal/stm32
     - name: hal_ti
-      revision: 405dfc8faba13e01c1cb9e29e70b31b50f71d117
+      revision: 277d70a65ab14d46bf1ec0935cf9bb28bbaa8ab9
       path: modules/hal/ti
     - name: libmetal
       revision: 9d4ee2c3cfd5f49861939447990f3b7d7bf9bf94


### PR DESCRIPTION
This change enables the multi-protocol RF patch to be used for the cc13xx_cc26xx IEEE 802.15.4 2.4 GHz PHY, which allows both the 2.4 GHz and Sub GHz PHY to be used simultaneously.

Eventually, BLE will also work simultaneously on 2.4 GHz (with arbitration).

Fixes #29883