### PR TITLE
boards: arm: nrf: remove note about board name change

### DIFF
--- a/boards/arm/nrf51dk_nrf51422/doc/index.rst
+++ b/boards/arm/nrf51dk_nrf51422/doc/index.rst
@@ -33,9 +33,6 @@ More information about the board can be found at the
 `nRF51 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf51_pca10028*.
 
 Hardware
 ********

--- a/boards/arm/nrf51dongle_nrf51422/doc/index.rst
+++ b/boards/arm/nrf51dongle_nrf51422/doc/index.rst
@@ -33,9 +33,6 @@ More information about the board can be found at the
 `nRF51 Dongle website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf51_pca10031*.
 
 Hardware
 ********

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -30,9 +30,6 @@ More information about the board can be found at the
 `nRF52833 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52833_pca10100*.
 
 Hardware
 ********

--- a/boards/arm/nrf52840dk_nrf52811/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52811/doc/index.rst
@@ -15,9 +15,6 @@ while using the nRF52840 Development Kit (PCA10056).
 See :ref:`nrf52840dk_nrf52840` for more information about the development board
 and `nRF52811 website`_ for the official reference on the IC itself.
 
-.. note::
-
-   In earlier Zephyr releases this board was known as ``nrf52811_pca10056``.
 
 References
 **********

--- a/boards/arm/nrf52840dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52840/doc/index.rst
@@ -36,9 +36,6 @@ More information about the board can be found at the `nRF52840 DK website`_.
 The `Nordic Semiconductor Infocenter`_ contains the processor's information
 and the datasheet.
 
-.. note::
-
-   In earlier Zephyr releases this board was known as ``nrf52840_pca10056``.
 
 Hardware
 ********

--- a/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
@@ -35,9 +35,6 @@ More information about the board can be found at the
 `nRF52840 Dongle website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52840_pca10059*.
 
 Hardware
 ********

--- a/boards/arm/nrf52dk_nrf52810/doc/index.rst
+++ b/boards/arm/nrf52dk_nrf52810/doc/index.rst
@@ -15,9 +15,6 @@ IC while using the nRF52 Development Kit (PCA10040).
 See :ref:`nrf52dk_nrf52832` for more information about the development board and
 `nRF52810 website`_ for the official reference on the IC itself.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52810_pca10040*.
 
 References
 **********

--- a/boards/arm/nrf52dk_nrf52832/doc/index.rst
+++ b/boards/arm/nrf52dk_nrf52832/doc/index.rst
@@ -36,9 +36,6 @@ More information about the board can be found at the
 `nRF52 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52_pca10040*.
 
 Hardware
 ********

--- a/boards/arm/nrf9160dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf52840/doc/index.rst
@@ -31,9 +31,6 @@ the `Nordic Low power cellular IoT`_ website.
 The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52840_pca10090*.
 
 Hardware
 ********

--- a/boards/arm/nrf9160dk_nrf9160/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf9160/doc/index.rst
@@ -37,9 +37,6 @@ More information about the board can be found at the
 `nRF9160 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf9160_pca10090*.
 
 Hardware
 ********

--- a/boards/arm/thingy52_nrf52832/doc/index.rst
+++ b/boards/arm/thingy52_nrf52832/doc/index.rst
@@ -40,9 +40,6 @@ More information about the board can be found at the `nRF52 DK website`_. The
 `Nordic Semiconductor Infocenter`_ contains the processor's information and the
 datasheet.
 
-.. note::
-
-   In previous Zephyr releases this board was named *nrf52_pca20020*.
 
 Hardware
 ********


### PR DESCRIPTION
Nordic Dev Kit board names were changed in Zephyr
v2.3 release, following the standard Board deprecation
policy. Two releases later we do not need to keep
references to the old names in the boards' documentation.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>