### PR TITLE
drivers: flash: stm32f4: Don't invert an already inverted mask

### DIFF
--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -51,7 +51,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 		return rc;
 	}
 
-	regs->CR &= ~CR_PSIZE_MASK;
+	regs->CR &= CR_PSIZE_MASK;
 	regs->CR |= FLASH_PSIZE_BYTE;
 	regs->CR |= FLASH_CR_PG;
 


### PR DESCRIPTION
Signed-off-by: Justin Brederveld <12084952+jmbrederveld@users.noreply.github.com>