### PR TITLE
Bluetooth: controller: Improve pdu_adv structures

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4519,7 +4519,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			goto no_ext_hdr;
 		}
 
-		ptr += sizeof(*h);
+		ptr = h->data;
 
 		if (h->adv_addr) {
 			bt_addr_le_t addr;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4504,7 +4504,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		       adv->rx_addr, rssi);
 
 		p = (void *)&adv->adv_ext_ind;
-		h = (void *)p->ext_hdr_adi_adv_data;
+		h = (void *)p->ext_hdr_adv_data;
 		ptr = (void *)h;
 
 		BT_DBG("    Ext. adv mode= 0x%x, hdr len= %u", p->adv_mode,
@@ -4514,7 +4514,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 
 		if (!p->ext_hdr_len) {
 			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adi_adv_data);
+					   ext_hdr_adv_data);
 
 			goto no_ext_hdr;
 		}
@@ -4605,22 +4605,22 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 
 		hdr_len = ptr - (uint8_t *)p;
 		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
-					 ext_hdr_adi_adv_data) +
+					 ext_hdr_adv_data) +
 				sizeof(struct pdu_adv_hdr))) {
 			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adi_adv_data);
+					   ext_hdr_adv_data);
 			ptr = (uint8_t *)h;
 		}
 
 		if (hdr_len > (p->ext_hdr_len +
 			       offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adi_adv_data))) {
+					ext_hdr_adv_data))) {
 			BT_WARN("    Header length %u/%u, INVALID.", hdr_len,
 				p->ext_hdr_len);
 		} else {
 			uint8_t acad_len = p->ext_hdr_len +
 					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adi_adv_data) -
+						    ext_hdr_adv_data) -
 					   hdr_len;
 
 			if (acad_len) {
@@ -4908,7 +4908,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		BT_DBG("len = %u, rssi = %d", adv->len, rssi);
 
 		p = (void *)&adv->adv_ext_ind;
-		h = (void *)p->ext_hdr_adi_adv_data;
+		h = (void *)p->ext_hdr_adv_data;
 		ptr = (void *)h;
 
 		BT_DBG("    Ext. adv mode= 0x%x, hdr len= %u", p->adv_mode,
@@ -4955,22 +4955,22 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 
 		hdr_len = ptr - (uint8_t *)p;
 		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
-					 ext_hdr_adi_adv_data) +
+					 ext_hdr_adv_data) +
 				sizeof(struct pdu_adv_hdr))) {
 			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adi_adv_data);
+					   ext_hdr_adv_data);
 			ptr = (uint8_t *)h;
 		}
 
 		if (hdr_len > (p->ext_hdr_len +
 			       offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adi_adv_data))) {
+					ext_hdr_adv_data))) {
 			BT_WARN("    Header length %u/%u, INVALID.", hdr_len,
 				p->ext_hdr_len);
 		} else {
 			uint8_t acad_len = p->ext_hdr_len +
 					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adi_adv_data) -
+						    ext_hdr_adv_data) -
 					   hdr_len;
 
 			if (acad_len) {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4486,7 +4486,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		uint8_t *adv_addr_curr = NULL;
 		uint8_t data_len_curr = 0U;
 		uint8_t *data_curr = NULL;
-		struct pdu_adv_hdr *h;
+		struct pdu_adv_ext_hdr *h;
 		uint8_t sec_phy_curr = 0U;
 		uint8_t evt_type_curr;
 		uint8_t hdr_len;
@@ -4606,7 +4606,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		hdr_len = ptr - (uint8_t *)p;
 		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
 					 ext_hdr_adv_data) +
-				sizeof(struct pdu_adv_hdr))) {
+				sizeof(struct pdu_adv_ext_hdr))) {
 			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
 					   ext_hdr_adv_data);
 			ptr = (uint8_t *)h;
@@ -4898,7 +4898,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		uint8_t data_len_curr = 0U;
 		uint8_t *data_curr = NULL;
 		uint8_t sec_phy_curr = 0U;
-		struct pdu_adv_hdr *h;
+		struct pdu_adv_ext_hdr *h;
 		uint8_t hdr_len;
 		uint8_t *ptr;
 
@@ -4956,7 +4956,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		hdr_len = ptr - (uint8_t *)p;
 		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
 					 ext_hdr_adv_data) +
-				sizeof(struct pdu_adv_hdr))) {
+				sizeof(struct pdu_adv_ext_hdr))) {
 			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
 					   ext_hdr_adv_data);
 			ptr = (uint8_t *)h;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -773,7 +773,7 @@ static void isr_done(void *param)
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(BT_CTLR_ADV_EXT_PBACK)
 	} else {
 		struct pdu_adv_com_ext_adv *p;
-		struct pdu_adv_hdr *h;
+		struct pdu_adv_ext_hdr *h;
 		struct pdu_adv *pdu;
 
 		pdu = lll_adv_data_curr_get(lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -778,7 +778,7 @@ static void isr_done(void *param)
 
 		pdu = lll_adv_data_curr_get(lll);
 		p = (void *)&pdu->adv_ext_ind;
-		h = (void *)p->ext_hdr_adi_adv_data;
+		h = (void *)p->ext_hdr_adv_data;
 
 		if ((pdu->type == PDU_ADV_TYPE_EXT_IND) && h->aux_ptr) {
 			radio_filter_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -98,7 +98,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t ticks_at_event, ticks_at_start;
 	struct pdu_adv *pri_pdu, *sec_pdu;
 	struct pdu_adv_aux_ptr *aux_ptr;
-	struct pdu_adv_hdr *pri_hdr;
+	struct pdu_adv_ext_hdr *pri_hdr;
 	struct lll_adv_aux *lll;
 	struct lll_adv *lll_adv;
 	struct evt_hdr *evt;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -196,8 +196,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 			/* Copy the address from the adv packet we will send
 			 * into the scan response.
 			 */
-			memcpy(&scan_pdu->adv_ext_ind.ext_hdr.data[0],
-			       &sec_pdu->adv_ext_ind.ext_hdr.data[0],
+			memcpy(&scan_pdu->adv_ext_ind.ext_hdr.data[ADVA_OFFSET],
+			       &sec_pdu->adv_ext_ind.ext_hdr.data[ADVA_OFFSET],
 			       BDADDR_SIZE);
 		}
 #else
@@ -421,8 +421,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 	pdu_adv = lll_adv_data_curr_get(lll);
 	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
 
-	/* AdvA is placed at the beginning of extended header data */
-	addr = pdu_aux->adv_ext_ind.ext_hdr.data;
+	addr = &pdu_aux->adv_ext_ind.ext_hdr.data[ADVA_OFFSET];
 	tx_addr = pdu_aux->tx_addr;
 
 	if ((pdu_rx->type == PDU_ADV_TYPE_AUX_SCAN_REQ) &&

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -129,7 +129,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Get reference to extended header */
 	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
 	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
-	pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+	pri_dptr = pri_hdr->data;
 
 	/* traverse through adv_addr, if present */
 	if (pri_hdr->adv_addr) {
@@ -196,8 +196,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 			/* Copy the address from the adv packet we will send
 			 * into the scan response.
 			 */
-			memcpy(&scan_pdu->adv_ext_ind.ext_hdr_adv_data[1],
-			       &sec_pdu->adv_ext_ind.ext_hdr_adv_data[1],
+			memcpy(&scan_pdu->adv_ext_ind.ext_hdr.data[0],
+			       &sec_pdu->adv_ext_ind.ext_hdr.data[0],
 			       BDADDR_SIZE);
 		}
 #else
@@ -421,8 +421,8 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 	pdu_adv = lll_adv_data_curr_get(lll);
 	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
 
-	/* AdvA is placed at 2nd byte of ext hdr data */
-	addr = &pdu_aux->adv_ext_ind.ext_hdr_adv_data[1];
+	/* AdvA is placed at the beginning of extended header data */
+	addr = pdu_aux->adv_ext_ind.ext_hdr.data;
 	tx_addr = pdu_aux->tx_addr;
 
 	if ((pdu_rx->type == PDU_ADV_TYPE_AUX_SCAN_REQ) &&

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -128,7 +128,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	/* Get reference to extended header */
 	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
-	pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
 	pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 
 	/* traverse through adv_addr, if present */
@@ -196,8 +196,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 			/* Copy the address from the adv packet we will send
 			 * into the scan response.
 			 */
-			memcpy(&scan_pdu->adv_ext_ind.ext_hdr_adi_adv_data[1],
-			       &sec_pdu->adv_ext_ind.ext_hdr_adi_adv_data[1],
+			memcpy(&scan_pdu->adv_ext_ind.ext_hdr_adv_data[1],
+			       &sec_pdu->adv_ext_ind.ext_hdr_adv_data[1],
 			       BDADDR_SIZE);
 		}
 #else
@@ -422,7 +422,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 	pdu_aux = lll_adv_aux_data_latest_get(lll_aux, &upd);
 
 	/* AdvA is placed at 2nd byte of ext hdr data */
-	addr = &pdu_aux->adv_ext_ind.ext_hdr_adi_adv_data[1];
+	addr = &pdu_aux->adv_ext_ind.ext_hdr_adv_data[1];
 	tx_addr = pdu_aux->tx_addr;
 
 	if ((pdu_rx->type == PDU_ADV_TYPE_AUX_SCAN_REQ) &&

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -213,25 +213,6 @@ struct pdu_adv_connect_ind {
 	} __packed;
 } __packed;
 
-struct pdu_adv_com_ext_adv {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	uint8_t ext_hdr_len:6;
-	uint8_t adv_mode:2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t adv_mode:2;
-	uint8_t ext_hdr_len:6;
-#else
-#error "Unsupported endianness"
-#endif
-	uint8_t ext_hdr_adv_data[254];
-} __packed;
-
-enum pdu_adv_mode {
-	EXT_ADV_MODE_NON_CONN_NON_SCAN = 0x00,
-	EXT_ADV_MODE_CONN_NON_SCAN = 0x01,
-	EXT_ADV_MODE_NON_CONN_SCAN = 0x02,
-};
-
 struct pdu_adv_ext_hdr {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint8_t adv_addr:1;
@@ -254,7 +235,30 @@ struct pdu_adv_ext_hdr {
 #else
 #error "Unsupported endianness"
 #endif
+	uint8_t data[0];
 } __packed;
+
+struct pdu_adv_com_ext_adv {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	uint8_t ext_hdr_len:6;
+	uint8_t adv_mode:2;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	uint8_t adv_mode:2;
+	uint8_t ext_hdr_len:6;
+#else
+#error "Unsupported endianness"
+#endif
+	union {
+		struct pdu_adv_ext_hdr ext_hdr;
+		uint8_t ext_hdr_adv_data[254];
+	};
+} __packed;
+
+enum pdu_adv_mode {
+	EXT_ADV_MODE_NON_CONN_NON_SCAN = 0x00,
+	EXT_ADV_MODE_CONN_NON_SCAN = 0x01,
+	EXT_ADV_MODE_NON_CONN_SCAN = 0x02,
+};
 
 struct pdu_adv_adi {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -232,7 +232,7 @@ enum pdu_adv_mode {
 	EXT_ADV_MODE_NON_CONN_SCAN = 0x02,
 };
 
-struct pdu_adv_hdr {
+struct pdu_adv_ext_hdr {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint8_t adv_addr:1;
 	uint8_t tgt_addr:1;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -28,6 +28,10 @@
 #define TARGETA_SIZE  BDADDR_SIZE
 #define LLDATA_SIZE   22
 
+/* Constant offsets in extended header (TargetA is present in PDUs with AdvA) */
+#define ADVA_OFFSET   0
+#define TGTA_OFFSET   (ADVA_OFFSET + BDADDR_SIZE)
+
 #define BYTES2US(bytes, phy) (((bytes)<<3)/BIT((phy&0x3)>>1))
 
 /* Advertisement channel maximum legacy payload size */

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -43,7 +43,7 @@
  *       18 octets in the Common Extended Advertising Payload Format.
  */
 #define PDU_AC_EXT_PAYLOAD_OVERHEAD (offsetof(struct pdu_adv_com_ext_adv, \
-					      ext_hdr_adi_adv_data) + \
+					      ext_hdr_adv_data) + \
 				     PDU_AC_EXT_HEADER_SIZE_MAX)
 #define PDU_AC_PAYLOAD_SIZE_MAX     MAX(MIN((PDU_AC_EXT_PAYLOAD_OVERHEAD + \
 					     CONFIG_BT_CTLR_ADV_DATA_LEN_MAX), \
@@ -223,7 +223,7 @@ struct pdu_adv_com_ext_adv {
 #else
 #error "Unsupported endianness"
 #endif
-	uint8_t ext_hdr_adi_adv_data[254];
+	uint8_t ext_hdr_adv_data[254];
 } __packed;
 
 enum pdu_adv_mode {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -351,7 +351,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
-		struct pdu_adv_hdr *pri_hdr, pri_hdr_prev;
+		struct pdu_adv_ext_hdr *pri_hdr, pri_hdr_prev;
 		struct pdu_adv_com_ext_adv *pri_com_hdr;
 		uint8_t *pri_dptr_prev, *pri_dptr;
 		uint8_t len;
@@ -645,7 +645,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
 		struct pdu_adv_com_ext_adv *pri_com_hdr;
-		struct pdu_adv_hdr *pri_hdr;
+		struct pdu_adv_ext_hdr *pri_hdr;
 
 		pri_com_hdr = (void *)&pdu_adv->adv_ext_ind;
 		pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
@@ -664,7 +664,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 		} else if (pri_hdr->aux_ptr) {
 			struct pdu_adv_com_ext_adv *sec_com_hdr;
-			struct pdu_adv_hdr *sec_hdr;
+			struct pdu_adv_ext_hdr *sec_hdr;
 			struct pdu_adv *sec_pdu;
 
 			sec_pdu = lll_adv_aux_data_peek(lll->aux);
@@ -1565,7 +1565,7 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 					struct pdu_adv *pdu)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
+	struct pdu_adv_ext_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
 #endif
 	const uint8_t *adv_addr;
 
@@ -1975,7 +1975,7 @@ static inline uint8_t disable(uint8_t handle)
 static inline uint8_t *adv_pdu_adva_get(struct pdu_adv *pdu)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
+	struct pdu_adv_ext_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
 
 	/* All extended PDUs have AdvA at the same offset in common header */
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -357,7 +357,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 		uint8_t len;
 
 		pri_com_hdr = (void *)&pdu->adv_ext_ind;
-		pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+		pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
 		pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 		pri_dptr_prev = pri_dptr;
 
@@ -648,7 +648,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		struct pdu_adv_hdr *pri_hdr;
 
 		pri_com_hdr = (void *)&pdu_adv->adv_ext_ind;
-		pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+		pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
 
 		if (pri_com_hdr->adv_mode & BT_HCI_LE_ADV_PROP_SCAN) {
 			struct pdu_adv *sr = lll_adv_scan_rsp_peek(lll);
@@ -670,7 +670,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 			sec_pdu = lll_adv_aux_data_peek(lll->aux);
 
 			sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
-			sec_hdr = (void *)sec_com_hdr->ext_hdr_adi_adv_data;
+			sec_hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
 
 			if (sec_hdr->adv_addr) {
 				pdu_adv_to_update = sec_pdu;
@@ -1565,7 +1565,7 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 					struct pdu_adv *pdu)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adi_adv_data;
+	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
 #endif
 	const uint8_t *adv_addr;
 
@@ -1975,12 +1975,12 @@ static inline uint8_t disable(uint8_t handle)
 static inline uint8_t *adv_pdu_adva_get(struct pdu_adv *pdu)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adi_adv_data;
+	struct pdu_adv_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
 
 	/* All extended PDUs have AdvA at the same offset in common header */
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
 		LL_ASSERT(hdr->adv_addr);
-		return &pdu->adv_ext_ind.ext_hdr_adi_adv_data[1];
+		return &pdu->adv_ext_ind.ext_hdr_adv_data[1];
 	}
 #endif
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -358,7 +358,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 
 		pri_com_hdr = (void *)&pdu->adv_ext_ind;
 		pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
-		pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+		pri_dptr = pri_hdr->data;
 		pri_dptr_prev = pri_dptr;
 
 		/* No ACAD and no AdvData */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -273,7 +273,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	sr_prev = lll_adv_scan_rsp_peek(lll);
 
 	/* AdvA */
-	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr.data[0],
+	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr.data[ADVA_OFFSET],
 	       BDADDR_SIZE);
 	sr_dptr += BDADDR_SIZE;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -174,7 +174,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 {
 	struct pdu_adv_com_ext_adv *sr_com_hdr;
 	struct pdu_adv *pri_pdu_prev;
-	struct pdu_adv_hdr *sr_hdr;
+	struct pdu_adv_ext_hdr *sr_hdr;
 	struct pdu_adv_adi *sr_adi;
 	struct pdu_adv *sr_prev;
 	struct pdu_adv *aux_pdu;
@@ -419,8 +419,8 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 {
 	struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
 	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
-	struct pdu_adv_hdr *pri_hdr, pri_hdr_prev;
-	struct pdu_adv_hdr *sec_hdr, sec_hdr_prev;
+	struct pdu_adv_ext_hdr *pri_hdr, pri_hdr_prev;
+	struct pdu_adv_ext_hdr *sec_hdr, sec_hdr_prev;
 	uint16_t pri_len, sec_len, sec_len_prev;
 	struct pdu_adv *pri_pdu, *pri_pdu_prev;
 	struct pdu_adv *sec_pdu_prev, *sec_pdu;
@@ -934,7 +934,7 @@ struct pdu_adv_aux_ptr *ull_adv_aux_lll_offset_fill(uint32_t ticks_offset,
 {
 	struct pdu_adv_com_ext_adv *pri_com_hdr;
 	struct pdu_adv_aux_ptr *aux;
-	struct pdu_adv_hdr *h;
+	struct pdu_adv_ext_hdr *h;
 	uint32_t offs;
 	uint8_t *ptr;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -273,7 +273,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	sr_prev = lll_adv_scan_rsp_peek(lll);
 
 	/* AdvA */
-	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr_adv_data[1],
+	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr.data[0],
 	       BDADDR_SIZE);
 	sr_dptr += BDADDR_SIZE;
 
@@ -459,7 +459,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
 	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adv_data;
 	pri_hdr_prev = *pri_hdr;
-	pri_dptr_prev = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+	pri_dptr_prev = pri_hdr->data;
 
 	/* Advertising data are not supported by scannable instances */
 	if ((sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AD_DATA) &&
@@ -475,7 +475,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
 	pri_com_hdr->adv_mode = pri_com_hdr_prev->adv_mode;
 	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
-	pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
+	pri_dptr = pri_hdr->data;
 	*(uint8_t *)pri_hdr = 0U;
 
 	/* Get the reference to aux instance */
@@ -511,7 +511,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 					     ext_hdr_adv_data);
 		*(uint8_t *)&sec_hdr_prev = 0U;
 	}
-	sec_dptr_prev = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
+	sec_dptr_prev = sec_hdr->data;
 
 	/* Get reference to new secondary PDU data buffer */
 	sec_pdu = lll_adv_aux_data_alloc(lll_aux, &sec_idx);
@@ -525,7 +525,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
 	sec_com_hdr->adv_mode = pri_com_hdr->adv_mode;
 	sec_hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
-	sec_dptr = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
+	sec_dptr = sec_hdr->data;
 	*(uint8_t *)sec_hdr = 0U;
 
 	/* AdvA flag */
@@ -940,7 +940,7 @@ struct pdu_adv_aux_ptr *ull_adv_aux_lll_offset_fill(uint32_t ticks_offset,
 
 	pri_com_hdr = (void *)&pdu->adv_ext_ind;
 	h = (void *)pri_com_hdr->ext_hdr_adv_data;
-	ptr = (uint8_t *)h + sizeof(*h);
+	ptr = h->data;
 
 	if (h->adv_addr) {
 		ptr += BDADDR_SIZE;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -259,7 +259,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	sr_pdu->len = 0;
 
 	sr_com_hdr = &sr_pdu->adv_ext_ind;
-	sr_hdr = (void *)&sr_com_hdr->ext_hdr_adi_adv_data[0];
+	sr_hdr = (void *)&sr_com_hdr->ext_hdr_adv_data[0];
 	sr_dptr = (void *)sr_hdr;
 
 	/* Flags */
@@ -273,7 +273,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	sr_prev = lll_adv_scan_rsp_peek(lll);
 
 	/* AdvA */
-	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr_adi_adv_data[1],
+	memcpy(sr_dptr, &sr_prev->adv_ext_ind.ext_hdr_adv_data[1],
 	       BDADDR_SIZE);
 	sr_dptr += BDADDR_SIZE;
 
@@ -287,8 +287,8 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 
 	/* Check if data will fit in remaining space */
 	/* TODO: need aux_chain_ind support */
-	ext_hdr_len = sr_dptr - &sr_com_hdr->ext_hdr_adi_adv_data[0];
-	if (sizeof(sr_com_hdr->ext_hdr_adi_adv_data) -
+	ext_hdr_len = sr_dptr - &sr_com_hdr->ext_hdr_adv_data[0];
+	if (sizeof(sr_com_hdr->ext_hdr_adv_data) -
 	    sr_com_hdr->ext_hdr_len < len) {
 		return BT_HCI_ERR_PACKET_TOO_LONG;
 	}
@@ -457,7 +457,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	}
 
 	pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
-	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adi_adv_data;
+	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adv_data;
 	pri_hdr_prev = *pri_hdr;
 	pri_dptr_prev = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 
@@ -474,7 +474,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_pdu->chan_sel = 0U;
 	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
 	pri_com_hdr->adv_mode = pri_com_hdr_prev->adv_mode;
-	pri_hdr = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
 	pri_dptr = (uint8_t *)pri_hdr + sizeof(*pri_hdr);
 	*(uint8_t *)pri_hdr = 0U;
 
@@ -498,7 +498,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* Get reference to previous secondary PDU data */
 	sec_pdu_prev = lll_adv_aux_data_peek(lll_aux);
 	sec_com_hdr_prev = (void *)&sec_pdu_prev->adv_ext_ind;
-	sec_hdr = (void *)sec_com_hdr_prev->ext_hdr_adi_adv_data;
+	sec_hdr = (void *)sec_com_hdr_prev->ext_hdr_adv_data;
 	if (!is_aux_new) {
 		sec_hdr_prev = *sec_hdr;
 	} else {
@@ -508,7 +508,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		sec_pdu_prev->tx_addr = 0U;
 		sec_pdu_prev->rx_addr = 0U;
 		sec_pdu_prev->len = offsetof(struct pdu_adv_com_ext_adv,
-					     ext_hdr_adi_adv_data);
+					     ext_hdr_adv_data);
 		*(uint8_t *)&sec_hdr_prev = 0U;
 	}
 	sec_dptr_prev = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
@@ -524,7 +524,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
 	sec_com_hdr->adv_mode = pri_com_hdr->adv_mode;
-	sec_hdr = (void *)sec_com_hdr->ext_hdr_adi_adv_data;
+	sec_hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
 	sec_dptr = (uint8_t *)sec_hdr + sizeof(*sec_hdr);
 	*(uint8_t *)sec_hdr = 0U;
 
@@ -939,7 +939,7 @@ struct pdu_adv_aux_ptr *ull_adv_aux_lll_offset_fill(uint32_t ticks_offset,
 	uint8_t *ptr;
 
 	pri_com_hdr = (void *)&pdu->adv_ext_ind;
-	h = (void *)pri_com_hdr->ext_hdr_adi_adv_data;
+	h = (void *)pri_com_hdr->ext_hdr_adv_data;
 	ptr = (uint8_t *)h + sizeof(*h);
 
 	if (h->adv_addr) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -100,10 +100,10 @@ ull_adv_aux_hdr_len_calc(struct pdu_adv_com_ext_adv *com_hdr, uint8_t **dptr)
 	uint8_t len;
 
 	len = *dptr - (uint8_t *)com_hdr;
-	if (len <= (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adi_adv_data) +
+	if (len <= (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adv_data) +
 		    sizeof(struct pdu_adv_hdr))) {
 		len = offsetof(struct pdu_adv_com_ext_adv,
-			       ext_hdr_adi_adv_data);
+			       ext_hdr_adv_data);
 		*dptr = (uint8_t *)com_hdr + len;
 	}
 
@@ -115,7 +115,7 @@ static inline void
 ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
 {
 	com_hdr->ext_hdr_len = len - offsetof(struct pdu_adv_com_ext_adv,
-					      ext_hdr_adi_adv_data);
+					      ext_hdr_adv_data);
 
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -101,7 +101,7 @@ ull_adv_aux_hdr_len_calc(struct pdu_adv_com_ext_adv *com_hdr, uint8_t **dptr)
 
 	len = *dptr - (uint8_t *)com_hdr;
 	if (len <= (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adv_data) +
-		    sizeof(struct pdu_adv_hdr))) {
+		    sizeof(struct pdu_adv_ext_hdr))) {
 		len = offsetof(struct pdu_adv_com_ext_adv,
 			       ext_hdr_adv_data);
 		*dptr = (uint8_t *)com_hdr + len;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -126,7 +126,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 	ter_com_hdr = (void *)&ter_pdu->adv_ext_ind;
 	ter_hdr = (void *)ter_com_hdr->ext_hdr_adv_data;
-	ter_dptr = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
+	ter_dptr = ter_hdr->data;
 	ter_hdr_prev = *ter_hdr;
 	*(uint8_t *)ter_hdr = 0U;
 	ter_dptr_prev = ter_dptr;
@@ -191,7 +191,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	ter_com_hdr_prev = (void *)&ter_pdu_prev->adv_ext_ind;
 	ter_hdr = (void *)ter_com_hdr_prev->ext_hdr_adv_data;
 	ter_hdr_prev = *ter_hdr;
-	ter_dptr_prev = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
+	ter_dptr_prev = ter_hdr->data;
 
 	/* Get reference to new tertiary PDU data buffer */
 	ter_pdu = lll_adv_sync_data_alloc(lll_sync, &ter_idx);
@@ -201,7 +201,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	ter_com_hdr = (void *)&ter_pdu->adv_ext_ind;
 	ter_com_hdr->adv_mode = ter_com_hdr_prev->adv_mode;
 	ter_hdr = (void *)ter_com_hdr->ext_hdr_adv_data;
-	ter_dptr = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
+	ter_dptr = ter_hdr->data;
 	*(uint8_t *)ter_hdr = 0U;
 
 	/* No AdvA */
@@ -652,7 +652,7 @@ static inline struct pdu_adv_sync_info *sync_info_get(struct pdu_adv *pdu)
 
 	p = (void *)&pdu->adv_ext_ind;
 	h = (void *)p->ext_hdr_adv_data;
-	ptr = (uint8_t *)h + sizeof(*h);
+	ptr = h->data;
 
 	if (h->adv_addr) {
 		ptr += BDADDR_SIZE;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -125,7 +125,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 	ter_pdu->rx_addr = 0U;
 
 	ter_com_hdr = (void *)&ter_pdu->adv_ext_ind;
-	ter_hdr = (void *)ter_com_hdr->ext_hdr_adi_adv_data;
+	ter_hdr = (void *)ter_com_hdr->ext_hdr_adv_data;
 	ter_dptr = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
 	ter_hdr_prev = *ter_hdr;
 	*(uint8_t *)ter_hdr = 0U;
@@ -189,7 +189,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	/* Get reference to previous tertiary PDU data */
 	ter_pdu_prev = lll_adv_sync_data_peek(lll_sync);
 	ter_com_hdr_prev = (void *)&ter_pdu_prev->adv_ext_ind;
-	ter_hdr = (void *)ter_com_hdr_prev->ext_hdr_adi_adv_data;
+	ter_hdr = (void *)ter_com_hdr_prev->ext_hdr_adv_data;
 	ter_hdr_prev = *ter_hdr;
 	ter_dptr_prev = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
 
@@ -200,7 +200,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	ter_pdu->chan_sel = 0U;
 	ter_com_hdr = (void *)&ter_pdu->adv_ext_ind;
 	ter_com_hdr->adv_mode = ter_com_hdr_prev->adv_mode;
-	ter_hdr = (void *)ter_com_hdr->ext_hdr_adi_adv_data;
+	ter_hdr = (void *)ter_com_hdr->ext_hdr_adv_data;
 	ter_dptr = (uint8_t *)ter_hdr + sizeof(*ter_hdr);
 	*(uint8_t *)ter_hdr = 0U;
 
@@ -651,7 +651,7 @@ static inline struct pdu_adv_sync_info *sync_info_get(struct pdu_adv *pdu)
 	uint8_t *ptr;
 
 	p = (void *)&pdu->adv_ext_ind;
-	h = (void *)p->ext_hdr_adi_adv_data;
+	h = (void *)p->ext_hdr_adv_data;
 	ptr = (uint8_t *)h + sizeof(*h);
 
 	if (h->adv_addr) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -58,7 +58,7 @@ static void *adv_sync_free;
 
 uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 {
-	struct pdu_adv_hdr *ter_hdr, ter_hdr_prev;
+	struct pdu_adv_ext_hdr *ter_hdr, ter_hdr_prev;
 	struct pdu_adv_com_ext_adv *ter_com_hdr;
 	uint8_t *ter_dptr_prev, *ter_dptr;
 	struct lll_adv_sync *lll_sync;
@@ -168,7 +168,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 				uint8_t const *const data)
 {
 	struct pdu_adv_com_ext_adv *ter_com_hdr, *ter_com_hdr_prev;
-	struct pdu_adv_hdr *ter_hdr, ter_hdr_prev;
+	struct pdu_adv_ext_hdr *ter_hdr, ter_hdr_prev;
 	struct pdu_adv *ter_pdu, *ter_pdu_prev;
 	uint8_t *ter_dptr, *ter_dptr_prev;
 	uint16_t ter_len, ter_len_prev;
@@ -647,7 +647,7 @@ static void mfy_sync_offset_get(void *param)
 static inline struct pdu_adv_sync_info *sync_info_get(struct pdu_adv *pdu)
 {
 	struct pdu_adv_com_ext_adv *p;
-	struct pdu_adv_hdr *h;
+	struct pdu_adv_ext_hdr *h;
 	uint8_t *ptr;
 
 	p = (void *)&pdu->adv_ext_ind;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -90,7 +90,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	uint32_t ready_delay_us;
 	uint32_t aux_offset_us;
 	uint32_t ticker_status;
-	struct pdu_adv_hdr *h;
+	struct pdu_adv_ext_hdr *h;
 	struct pdu_adv *pdu;
 	uint8_t aux_handle;
 	uint8_t *ptr;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -187,7 +187,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		goto ull_scan_aux_rx_flush;
 	}
 
-	h = (void *)p->ext_hdr_adi_adv_data;
+	h = (void *)p->ext_hdr_adv_data;
 	if (!h->aux_ptr && !sync) {
 		goto ull_scan_aux_rx_flush;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -192,7 +192,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		goto ull_scan_aux_rx_flush;
 	}
 
-	ptr = (uint8_t *)h + sizeof(*h);
+	ptr = h->data;
 
 	if (h->adv_addr) {
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)


### PR DESCRIPTION
Structures and members are renamed to make it more semantically correct.
Structure of common extended advertising payload was extended to allow more direct access to extended header contents.

I also changes code in few places to make use of new extended struct, probably there are some more places to update although they are not obvious at first glance.