### PR TITLE
AArch64: Add support for recoverable faults

### DIFF
--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -89,6 +89,15 @@ config ARM_MMU
 	help
 	  Memory Management Unit support.
 
+config EXCEPTION_DEBUG
+	bool "Unhandled exception debugging information"
+	default y
+	depends on LOG
+	help
+	  Print human-readable information about exception vectors, cause codes,
+	  and parameters, at a cost of code/data size for the human-readable
+	  strings.
+
 if ARM_MMU
 
 config MAX_XLAT_TABLES

--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -169,7 +169,18 @@ static void esf_dump(const z_arch_esf_t *esf)
 		esf->basic.regs[0], esf->basic.regs[1]);
 }
 
-void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
+static bool is_recoverable(z_arch_esf_t *esf, uint64_t esr, uint64_t far,
+			   uint64_t elr)
+{
+	if (!esf)
+		return false;
+
+	/* Empty */
+
+	return false;
+}
+
+void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 {
 	uint64_t esr = 0;
 	uint64_t elr = 0;
@@ -201,6 +212,9 @@ void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 
 			if (dump_far)
 				LOG_ERR("FAR_ELn: 0x%016llx", far);
+
+			if (is_recoverable(esf, esr, far, elr))
+				return;
 		}
 	}
 

--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -17,6 +17,7 @@
 
 LOG_MODULE_DECLARE(os);
 
+#ifdef CONFIG_EXCEPTION_DEBUG
 static void dump_esr(uint64_t esr, bool *dump_far)
 {
 	const char *err;
@@ -168,6 +169,7 @@ static void esf_dump(const z_arch_esf_t *esf)
 	LOG_ERR("x18: 0x%016llx  x30: 0x%016llx",
 		esf->basic.regs[0], esf->basic.regs[1]);
 }
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 static bool is_recoverable(z_arch_esf_t *esf, uint64_t esr, uint64_t far,
 			   uint64_t elr)
@@ -204,6 +206,7 @@ void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 		}
 
 		if (GET_EL(el) != MODE_EL0) {
+#ifdef CONFIG_EXCEPTION_DEBUG
 			bool dump_far = false;
 
 			LOG_ERR("ELR_ELn: 0x%016llx", elr);
@@ -212,15 +215,19 @@ void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 
 			if (dump_far)
 				LOG_ERR("FAR_ELn: 0x%016llx", far);
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 			if (is_recoverable(esf, esr, far, elr))
 				return;
 		}
 	}
 
+#ifdef CONFIG_EXCEPTION_DEBUG
 	if (esf != NULL) {
 		esf_dump(esf);
 	}
+#endif /* CONFIG_EXCEPTION_DEBUG */
+
 	z_fatal_error(reason, esf);
 
 	CODE_UNREACHABLE;

--- a/arch/arm/core/aarch64/irq_manage.c
+++ b/arch/arm/core/aarch64/irq_manage.c
@@ -18,7 +18,7 @@
 #include <sw_isr_table.h>
 #include <drivers/interrupt_controller/gic.h>
 
-void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
+void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf);
 
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
 /*

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -144,7 +144,10 @@ exit:
 inv:
 	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */
 	mov	x1, sp
-	b	z_arm64_fatal_error
+	bl	z_arm64_fatal_error
+
+	/* Return here only in case of recoverable error */
+	z_arm64_exit_exc x0, x1
 
 GTEXT(z_arm64_call_svc)
 SECTION_FUNC(TEXT, z_arm64_call_svc)

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -136,4 +136,7 @@ SECTION_FUNC(TEXT, z_arm64_serror)
 	mov	x1, sp
 	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */
 
-	b	z_arm64_fatal_error
+	bl	z_arm64_fatal_error
+
+	/* Return here only in case of recoverable error */
+	z_arm64_exit_exc x0, x1

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -95,12 +95,7 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 
 	/* Current EL with SPx / SError */
 	.align 7
-	z_arm64_enter_exc x0, x1
-
-	mov	x1, sp
-	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */
-
-	b	z_arm64_fatal_error
+	b	z_arm64_serror
 
 	/* Lower EL using AArch64 / Synchronous */
 	.align 7
@@ -134,3 +129,11 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 	.align 7
 	b	.
 
+GTEXT(z_arm64_serror)
+SECTION_FUNC(TEXT, z_arm64_serror)
+	z_arm64_enter_exc x0, x1
+
+	mov	x1, sp
+	mov	x0, #0 /* K_ERR_CPU_EXCEPTION */
+
+	b	z_arm64_fatal_error

--- a/arch/arm/include/aarch64/kernel_arch_func.h
+++ b/arch/arm/include/aarch64/kernel_arch_func.h
@@ -39,7 +39,7 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 	return;
 }
 
-extern void z_arm64_fatal_error(const z_arch_esf_t *esf, unsigned int reason);
+extern void z_arm64_fatal_error(z_arch_esf_t *esf, unsigned int reason);
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/arm/aarch64/cpu.h
+++ b/include/arch/arm/aarch64/cpu.h
@@ -160,6 +160,10 @@
 
 #define GET_EL(_mode)		(((_mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
+#define ESR_EC(esr)		(((esr) >> 26) & BIT_MASK(6))
+#define ESR_IL(esr)		(((esr) >> 25) & BIT_MASK(1))
+#define ESR_ISS(esr)		((esr) & BIT_MASK(25))
+
 /* mpidr */
 #define MPIDR_AFFLVL_MASK	0xff
 


### PR DESCRIPTION
This patchset looks way bigger than it really is. It's basically addressing three things:
1. Only print `FAR_ELn` when needed (and prettify a bit the error output)
2. Add support for recoverable faults
3. Introduce CONFIG_EXCEPTION_DEBUG