### PR TITLE
drivers: wifi: fix simplelink driver to use ENOTSOCK

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -58,7 +58,7 @@ static int getErrno(_i32 error)
 		error = EBADF;
 		break;
 #endif
-#if ENSOCK !=  SL_ERROR_BSD_ENSOCK
+#if ENOTSOCK !=  SL_ERROR_BSD_ENSOCK
 	case SL_ERROR_BSD_ENSOCK:
 		/* The limit on total # of open sockets has been reached */
 		error = ENSOCK;


### PR DESCRIPTION
ENSOCK seems to have been a typo or possibly copy / paste error introduced in 2e15b0f6118ce0414666873bcec5ecfc2cbe5cb0.

ENOTSOCK seems to be the Zephyr equivalent.

Fixes #29805