### PR TITLE
cmake: fix xcc not supporting -Wno-unsed-but-set-variable

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -89,7 +89,7 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
                             -Wvla
 )
 
-set_compiler_property(PROPERTY warning_extended -Wno-unused-but-set-variable)
+check_set_compiler_property(PROPERTY warning_extended -Wno-unused-but-set-variable)
 
 check_set_compiler_property(PROPERTY warning_error_implicit_int -Werror=implicit-int)
 


### PR DESCRIPTION
XCC does not support the compiler flag -Wno-unused-but-set-variable
so check for flag support before setting it in cmake.

Fixes #29707

Signed-off-by: Daniel Leung <daniel.leung@intel.com>