### PR TITLE
drivers: espi: xec: Avoid flash interrupt by ROM bootloader activity

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -710,6 +710,10 @@ static void espi_init_flash(const struct device *dev)
 
 	LOG_DBG("%s", __func__);
 
+	/* Need to clear status done when ROM boots in MAF */
+	LOG_DBG("%s ESPI_FC_REGS->CFG %X", __func__, ESPI_FC_REGS->CFG);
+	ESPI_FC_REGS->STS = MCHP_ESPI_FC_STS_DONE;
+
 	/* Enable interrupts */
 	MCHP_GIRQ_ENSET(config->bus_girq_id) = BIT(MCHP_ESPI_FC_GIRQ_POS);
 	ESPI_FC_REGS->IEN |= MCHP_ESPI_FC_IEN_CHG_EN;


### PR DESCRIPTION
When MEC15xx boots in MAFS, ROM bootloader performs activity over
eSPI flash channel prior to FW is loaded.
Need to clear STS_DONE during early eSPI driver initialization,
prior to enabling interrupts to avoid unexpected ISRs in FW.

Otherwise this would cause flash_lock semaphore to be incremented
due to ROM activity and result in FW's first espi flash request
to return immediately even before eSPI bus transaction completely

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>