### PR TITLE
Add support for describing file systems in devicetree

### DIFF
--- a/dts/bindings/fs/zephyr,fstab,littlefs.yaml
+++ b/dts/bindings/fs/zephyr,fstab,littlefs.yaml
@@ -1,0 +1,78 @@
+# Copyright (C) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Description of pre-defined file systems.
+
+compatible: "zephyr,fstab,littlefs"
+
+include: "zephyr,fstab-common.yaml"
+
+properties:
+  # num-files and num-dirs are not filesystem-specific.
+
+  read-size:
+    type: int
+    required: true
+    description: |
+      The size of file system read operations, in bytes.
+
+      All read operations will be a multiple of this value.  A
+      reasonable default is 16.
+
+      This corresponds to CONFIG_FS_LITTLEFS_READ_SIZE.
+
+  prog-size:
+    type: int
+    required: true
+    description: |
+      The size of file system program (write) operations, in bytes.
+
+      All program operations will be a multiple of this value.  A
+      reasonable default is 16.
+
+      This corresponds to CONFIG_FS_LITTLEFS_PROG_SIZE.
+
+  cache-size:
+    type: int
+    required: true
+    description: |
+      The size of block caches, in bytes.
+
+      Each cache buffers a portion of a block in RAM.  The littlefs
+      needs a read cache, a program cache, and one additional cache per
+      file. Larger caches can improve performance by storing more data
+      and reducing the number of disk accesses. Must be a multiple of
+      the read and program sizes of the underlying flash device, and a
+      factor of the block size.
+
+      A reasonable default is 64.
+
+      This corresponds to CONFIG_FS_LITTLEFS_CACHE_SIZE.
+
+  lookahead-size:
+    type: int
+    required: true
+    description: |
+      The size of the lookahead buffer, in bytes.
+
+      A larger lookahead buffer increases the number of blocks found
+      during an allocation pass. The lookahead buffer is stored as a
+      compact bitmap, so each byte of RAM can track 8 blocks. Must be a
+      multiple of 8.
+
+      A reasonable default is 32.
+
+      This corresponds to CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.
+
+  block-cycles:
+    type: int
+    required: true
+    description: |
+      The number of erase cycles before moving data to another block.
+
+      For dynamic wear leveling, the number of erase cycles before data
+      is moved to another block.  Set to a non-positive value to disable
+      leveling.
+
+      This corresponds to CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.

--- a/dts/bindings/fs/zephyr,fstab-common.yaml
+++ b/dts/bindings/fs/zephyr,fstab-common.yaml
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common properties for Zephyr filesystem compatibles
+
+include: base.yaml
+
+properties:
+  mount-point:
+    type: string
+    required: true
+    description: |
+      The absolute path used as the file system mount point.
+
+  partition:
+    type: phandle
+    required: true
+    description: |
+      A reference to the file system's partition.
+
+  automount:
+    type: boolean
+    description: |
+      Mount file system on boot if present.
+
+      During initialization the file system driver will attempt to mount
+      this partition.
+
+  read-only:
+    type: boolean
+    description: |
+      Mount file system read-only if present.
+
+      This adds the FS_MOUNT_FLAG_READ_ONLY option to be set in the
+      mount descriptor generated for the file system.
+
+  no-format:
+    type: boolean
+    description: |
+      Do not format file system if mount fails.
+
+      This causes the FS_MOUNT_FLAG_NO_FORMAT option to be set in the
+      mount descriptor generated for the file system.

--- a/dts/bindings/fs/zephyr,fstab.yaml
+++ b/dts/bindings/fs/zephyr,fstab.yaml
@@ -1,0 +1,12 @@
+# Copyright (C) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Description of pre-defined file systems.
+
+    This is a container for child nodes that provide at minimum the
+    properties described in zephyr,fstab-common.yaml.
+
+compatible: "zephyr,fstab"
+
+include: base.yaml

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -315,6 +315,27 @@
 #define DT_PARENT(node_id) UTIL_CAT(node_id, _PARENT)
 
 /**
+ * @brief Get a node identifier for a grandparent node
+ *
+ * Example devicetree fragment:
+ *
+ *     gparent: grandparent-node {
+ *             parent: parent-node {
+ *                     child: child-node { ... }
+ *             };
+ *     };
+ *
+ * The following are equivalent ways to get the same node identifier:
+ *
+ *     DT_GPARENT(DT_NODELABEL(child))
+ *     DT_PARENT(DT_PARENT(DT_NODELABEL(child))
+ *
+ * @param node_id node identifier
+ * @return a node identifier for the node's parent's parent
+ */
+#define DT_GPARENT(node_id) DT_PARENT(DT_PARENT(node_id))
+
+/**
  * @brief Get a node identifier for a child node
  *
  * Example devicetree fragment:

--- a/include/devicetree/fixed-partitions.h
+++ b/include/devicetree/fixed-partitions.h
@@ -69,6 +69,17 @@ extern "C" {
 #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
 
 /**
+ * @brief Get the node identifier of the flash device for a partition
+ * @param node_id node identifier for a fixed-partitions child node
+ * @return the node identifier of the memory technology device that
+ * contains the fixed-partitions node.
+ */
+#define DT_MTD_FROM_FIXED_PARTITION(node_id)				\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(node_id), soc_nv_flash), \
+		    (DT_PARENT(DT_GPARENT(node_id))),			\
+		    (DT_GPARENT(node_id)))
+
+/**
  * @}
  */
 

--- a/include/devicetree/fixed-partitions.h
+++ b/include/devicetree/fixed-partitions.h
@@ -79,6 +79,19 @@ extern "C" {
 		    (DT_PARENT(DT_GPARENT(node_id))),			\
 		    (DT_GPARENT(node_id)))
 
+/*
+ * @brief Get the common mount flags for an fstab entry.
+
+ * @param node_id the node identifier for a child entry in a
+ * zephyr,fstab node.
+ * @return a value suitable for initializing an fs_mount_t flags
+ * member.
+ */
+#define DT_FSTAB_ENTRY_MOUNT_FLAGS(node_id)				\
+	((DT_PROP(node_id, automount) ? FS_MOUNT_FLAG_AUTOMOUNT : 0)	\
+	 | (DT_PROP(node_id, read_only) ? FS_MOUNT_FLAG_READ_ONLY : 0)	\
+	 | (DT_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0))
+
 /**
  * @}
  */

--- a/include/devicetree/fixed-partitions.h
+++ b/include/devicetree/fixed-partitions.h
@@ -79,19 +79,6 @@ extern "C" {
 		    (DT_PARENT(DT_GPARENT(node_id))),			\
 		    (DT_GPARENT(node_id)))
 
-/*
- * @brief Get the common mount flags for an fstab entry.
-
- * @param node_id the node identifier for a child entry in a
- * zephyr,fstab node.
- * @return a value suitable for initializing an fs_mount_t flags
- * member.
- */
-#define DT_FSTAB_ENTRY_MOUNT_FLAGS(node_id)				\
-	((DT_PROP(node_id, automount) ? FS_MOUNT_FLAG_AUTOMOUNT : 0)	\
-	 | (DT_PROP(node_id, read_only) ? FS_MOUNT_FLAG_READ_ONLY : 0)	\
-	 | (DT_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0))
-
 /**
  * @}
  */

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -77,6 +77,13 @@ enum {
 #define FS_MOUNT_FLAG_NO_FORMAT BIT(0)
 /** Flag makes mounted file system read-only */
 #define FS_MOUNT_FLAG_READ_ONLY BIT(1)
+/** Flag used in pre-defined mount structures that are to be mounted
+ * on startup.
+ *
+ * This flag has no impact in user-defined mount structures.
+ */
+#define FS_MOUNT_FLAG_AUTOMOUNT BIT(2)
+
 
 /**
  * @brief File system mount info structure

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -192,6 +192,34 @@ struct fs_statvfs {
  * @}
  */
 
+/*
+ * @brief Get the common mount flags for an fstab entry.
+
+ * @param node_id the node identifier for a child entry in a
+ * zephyr,fstab node.
+ * @return a value suitable for initializing an fs_mount_t flags
+ * member.
+ */
+#define FSTAB_ENTRY_DT_MOUNT_FLAGS(node_id)				\
+	((DT_PROP(node_id, automount) ? FS_MOUNT_FLAG_AUTOMOUNT : 0)	\
+	 | (DT_PROP(node_id, read_only) ? FS_MOUNT_FLAG_READ_ONLY : 0)	\
+	 | (DT_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0))
+
+/**
+ * @brief The name under which a zephyr,fstab entry mount structure is
+ * defined.
+ */
+#define FS_FSTAB_ENTRY(node_id) _CONCAT(z_fsmp_, node_id)
+
+/**
+ * @brief Generate a declaration for the externally defined fstab
+ * entry.
+ *
+ * This will evaluate to the name of a struct fs_mount_t object.
+ */
+#define FS_FSTAB_DECLARE_ENTRY(node_id)		\
+	extern struct fs_mount_t FS_FSTAB_ENTRY(node_id)
+
 /**
  * @brief Open or create file
  *

--- a/samples/subsys/fs/littlefs/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/fs/littlefs/boards/nrf52840dk_nrf52840.overlay
@@ -6,13 +6,30 @@
 
 /delete-node/ &storage_partition;
 
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			mount-point = "/lfs1";
+			partition = <&lfs1_part>;
+			automount;
+			read-size = <16>;
+			prog-size = <16>;
+			cache-size = <64>;
+			lookahead-size = <32>;
+			block-cycles = <512>;
+		};
+	};
+};
+
 &mx25r64 {
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		partition@0 {
+		lfs1_part: partition@0 {
 			label = "storage";
 			reg = <0x00000000 0x00010000>;
 		};

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -17,6 +17,11 @@
 /* Matches LFS_NAME_MAX */
 #define MAX_PATH_LEN 255
 
+#define PARTITION_NODE DT_NODELABEL(lfs1)
+
+#if DT_NODE_EXISTS(PARTITION_NODE)
+FS_FSTAB_DECLARE_ENTRY(PARTITION_NODE);
+#else /* PARTITION_NODE */
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 static struct fs_mount_t lfs_storage_mnt = {
 	.type = FS_LITTLEFS,
@@ -24,10 +29,17 @@ static struct fs_mount_t lfs_storage_mnt = {
 	.storage_dev = (void *)FLASH_AREA_ID(storage),
 	.mnt_point = "/lfs",
 };
+#endif /* PARTITION_NODE */
 
 void main(void)
 {
-	struct fs_mount_t *mp = &lfs_storage_mnt;
+	struct fs_mount_t *mp =
+#if DT_NODE_EXISTS(PARTITION_NODE)
+		&FS_FSTAB_ENTRY(PARTITION_NODE)
+#else
+		&lfs_storage_mnt
+#endif
+		;
 	unsigned int id = (uintptr_t)mp->storage_dev;
 	char fname[MAX_PATH_LEN];
 	struct fs_statvfs sbuf;

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -10,19 +10,10 @@
 #include <zephyr.h>
 #include <storage/flash_map.h>
 
-/* Get the grand parent of a node */
-#define GPARENT(node_id) DT_PARENT(DT_PARENT(node_id))
-
-/* return great-grandparent label if 'soc-nv-flash' else grandparent label */
-#define DT_FLASH_DEV_FROM_PARTITION(part)				      \
-	DT_LABEL(COND_CODE_1(DT_NODE_HAS_COMPAT(GPARENT(part), soc_nv_flash), \
-			     (DT_PARENT(GPARENT(part))),		      \
-			     (GPARENT(part))))
-
-#define FLASH_AREA_FOO(part)					\
-	{.fa_id = DT_FIXED_PARTITION_ID(part),			\
-	 .fa_off = DT_REG_ADDR(part),				\
-	 .fa_dev_name = DT_FLASH_DEV_FROM_PARTITION(part),	\
+#define FLASH_AREA_FOO(part)						\
+	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
+	 .fa_off = DT_REG_ADDR(part),					\
+	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)


### PR DESCRIPTION
This PR adds devicetree bindings that allow [devicetree description](https://github.com/zephyrproject-rtos/zephyr/pull/28320#pullrequestreview-502138742) like this:

```
/ {
	fstab {
		compatible = "zephyr,fstab";
		lfs1: lfs1 {
			compatible = "zephyr,fstab,littlefs";
			mount-point = "/lfs1";
			partition = <&lfs1_part>;
			automount;
			read-size = <16>;
			prog-size = <16>;
			cache-size = <64>;
			lookahead-size = <32>;
			block-cycles = <512>;
		};
	};
};

&mx25r64 {
	partitions {
		compatible = "fixed-partitions";
		#address-cells = <1>;
		#size-cells = <1>;

		lfs1_part: partition@0 {
			label = "storage";
			reg = <0x00000000 0x00010000>;
		};
	};
};
```

which allows file system configuration and mount data to be associated with partitions so that the file systems can automatically be mounted as the system comes up.

At the moment this is blocked on dependency issues (file system initialization can occur before the flash device is ready to be used), and the test application is not appropriate, but it does automount.
