### PR TITLE
doc: fix reference/util after sys/util.h split

### DIFF
--- a/include/sys/util_macro.h
+++ b/include/sys/util_macro.h
@@ -21,6 +21,11 @@
 extern "C" {
 #endif
 
+/**
+ * @addtogroup sys-util
+ * @{
+ */
+
 /*
  * Most of the eldritch implementation details for all the macrobatics
  * below (APIs like IS_ENABLED(), COND_CODE_1(), etc.) are hidden away


### PR DESCRIPTION
Add back Doxygen documentation that previously existed in sys/util.h and was moved to sys/util_macro.h.

Also fixes #29896