### PR TITLE
ARC: nSIM: DTS: switch UART clock-frequency to 50MHz to satisfy HAPS requirements

### DIFF
--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -49,7 +49,7 @@
 
 	uart0: uart@f0000000 {
 		compatible = "ns16550";
-		clock-frequency = <10000000>;
+		clock-frequency = <50000000>;
 		reg = <0xf0000000 0x400>;
 		current-speed = <115200>;
 		label = "UART_0";


### PR DESCRIPTION
UART IP is clocked with 50MHz on HAPS by default. So switch UART clock-frequency from 100MHz to 50MHz for nsim_* boards
so the binaries can be run on HAPS as well.

This property is dummy in case run in simulator (nSIM) so we don't need to change anything in nSIM configuration files.

NOTE: the UART speed remains the same, this change is related to internal clock infrastructure.
