### PR TITLE
soc: nrf53: Add enabling of LFXO pins (XL1 and XL2)

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -605,23 +605,6 @@ static int clk_init(const struct device *dev)
 		    nrfx_isr, nrfx_power_clock_irq_handler, 0);
 	irq_enable(DT_INST_IRQN(0));
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && \
-	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-
-	#define PIN_XL1 0
-	#define PIN_XL2 1
-
-	bool ext_clk = IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL) ||
-		    IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_EXT_LOW_SWING) ||
-		    IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_EXT_FULL_SWING);
-
-	if (ext_clk) {
-		nrf_gpio_pin_mcu_select(PIN_XL1,
-					NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-		nrf_gpio_pin_mcu_select(PIN_XL2,
-					NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-	}
-#endif
 	nrfx_err = nrfx_clock_init(clock_event_handler);
 	if (nrfx_err != NRFX_SUCCESS) {
 		return -EIO;

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -129,6 +129,16 @@ config SOC_DCDC_NRF53X_HV
 	help
 	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
 
+config SOC_ENABLE_LFXO
+	bool "Enable LFXO"
+	default y
+	help
+	  Enable the low-frequency oscillator (LFXO) functionality on XL1 and
+	  XL2 pins.
+	  This option must be enabled if either application or network core is
+	  to use the LFXO. Otherwise, XL1 and XL2 pins will behave as regular
+	  GPIOs.
+
 endif # SOC_NRF5340_CPUAPP
 
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -20,11 +20,15 @@
 #include <nrf_erratas.h>
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <hal/nrf_cache.h>
+#include <hal/nrf_gpio.h>
 #include <hal/nrf_oscillators.h>
 #include <hal/nrf_regulators.h>
 #elif defined(CONFIG_SOC_NRF5340_CPUNET)
 #include <hal/nrf_nvmc.h>
 #endif
+
+#define PIN_XL1 0
+#define PIN_XL2 1
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);
@@ -60,9 +64,12 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 #endif
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && \
-	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && \
+	defined(CONFIG_SOC_ENABLE_LFXO)
 	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS,
 				     NRF_OSCILLATORS_LFXO_CAP_6PF);
+	nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+	nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
 #endif
 
 #if defined(CONFIG_SOC_DCDC_NRF53X_APP)

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -18,6 +18,13 @@
 #include <soc/nrfx_coredep.h>
 #include <logging/log.h>
 #include <nrf_erratas.h>
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#include <hal/nrf_cache.h>
+#include <hal/nrf_oscillators.h>
+#include <hal/nrf_regulators.h>
+#elif defined(CONFIG_SOC_NRF5340_CPUNET)
+#include <hal/nrf_nvmc.h>
+#endif
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);
@@ -45,29 +52,27 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 
 	key = irq_lock();
 
-#ifdef CONFIG_NRF_ENABLE_CACHE
-#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF_ENABLE_CACHE)
 	/* Enable the instruction & data cache */
-	NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Msk;
-#endif /* CONFIG_SOC_NRF5340_CPUAPP */
-#ifdef CONFIG_SOC_NRF5340_CPUNET
-	NRF_NVMC->ICACHECNF |= NVMC_ICACHECNF_CACHEEN_Enabled;
-#endif /* CONFIG_SOC_NRF5340_CPUNET */
+	nrf_cache_enable(NRF_CACHE);
+#elif defined(CONFIG_SOC_NRF5340_CPUNET) && defined(CONFIG_NRF_ENABLE_CACHE)
+	nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
 #endif
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && \
 	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-	*((uint32_t *)0x500046D0) = 0x1;
+	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS,
+				     NRF_OSCILLATORS_LFXO_CAP_6PF);
 #endif
 
 #if defined(CONFIG_SOC_DCDC_NRF53X_APP)
-	NRF_REGULATORS->VREGMAIN.DCDCEN = 1;
+	nrf_regulators_dcdcen_set(NRF_REGULATORS, true);
 #endif
 #if defined(CONFIG_SOC_DCDC_NRF53X_NET)
-	NRF_REGULATORS->VREGRADIO.DCDCEN = 1;
+	nrf_regulators_dcdcen_radio_set(NRF_REGULATORS, true);
 #endif
 #if defined(CONFIG_SOC_DCDC_NRF53X_HV)
-	NRF_REGULATORS->VREGH.DCDCEN = 1;
+	nrf_regulators_dcdcen_vddh_set(NRF_REGULATORS, true);
 #endif
 
 	/* Install default handler that simply resets the CPU


### PR DESCRIPTION
Add a Kconfig option (enabled by default) the enables the low-frequency
oscillator (LFXO) functionality on the XL1 and XL2 pins in the nRF53
SoC initialization routine. This cannot be done in the clock control
driver, as it was done so far, because that won't work in a setup where
the application core image does not use the system clock at all.

Fixes #29762.