### PR TITLE
random: xoroshiro128: fix buffer overflow

### DIFF
--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -106,7 +106,7 @@ void z_impl_sys_rand_get(void *dst, size_t outlen)
 	while (len < outlen) {
 		ret = xoroshiro128_next();
 		if ((outlen-len) < sizeof(ret)) {
-			blocksize = len;
+			blocksize = outlen - len;
 			(void)memcpy(udst, &ret, blocksize);
 		} else {
 			(*udst++) = ret;


### PR DESCRIPTION
If rand32_xoroshiro128::z_impl_sys_rand_get is called with outlen
not divisible by 4, it will overflow the dst buffer. This happens
because blocksize is not changed from 4 to the difference between
outlen and len. If outlen is < 4, z_impl_sys_rand_get will be stuck
in an infinite loop that keeps writing random bytes outside the buffer.
If outlen is > 4, z_impl_sys_rand_get returns after the correct number
of loops, but it writes every byte to the buffer, not just outlen number
of bytes. This causes the buffer to be overflowed with up to and
including 3 bytes.

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>