### PR TITLE
Bluetooth: DIS: drop dependency on BT_SETTINGS and select SETTINGS

### DIFF
--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -10,6 +10,7 @@ if BT_DIS
 
 config BT_DIS_SETTINGS
 	bool "Enable Settings usage in Device Information Service"
+	select SETTINGS
 	help
 	  Enable Settings usage in Device Information Service.
 

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -141,7 +141,7 @@ BT_GATT_SERVICE_DEFINE(dis_svc,
 
 );
 
-#if defined(CONFIG_BT_SETTINGS) && defined(CONFIG_BT_DIS_SETTINGS)
+#if defined(CONFIG_BT_DIS_SETTINGS)
 static int dis_set(const char *name, size_t len_rd,
 		   settings_read_cb read_cb, void *store)
 {
@@ -236,4 +236,4 @@ static int dis_set(const char *name, size_t len_rd,
 
 SETTINGS_STATIC_HANDLER_DEFINE(bt_dis, "bt/dis", NULL, dis_set, NULL, NULL);
 
-#endif /* CONFIG_BT_DIS_SETTINGS && CONFIG_BT_SETTINGS*/
+#endif /* CONFIG_BT_DIS_SETTINGS*/


### PR DESCRIPTION
Currently BT_DIS_SETTINGS and BT_SETTINGS are independent in
Kconfig. This seems fine, because BT_SETTINGS pulls a lot of
functionality, which is not really needed to implement DIS with values
configured in runtime (from settings subsystem).

Drop BT_SETTINGS conditional compilation and leave check on
BT_DIS_SETTINGS only.

DIS module builts fine when BT_DIS_SETTINGS is selected, but SETTINGS is
not. However no settings handlers are executed, just like with
BT_DIS_SETTINGS disabled, which might confuse user.

Select SETTINGS, so settings handlers are properly selected and executed
in runtime.