### PR TITLE
Bluetooth: DIS: support user function read handlers

### DIFF
--- a/include/bluetooth/dis.h
+++ b/include/bluetooth/dis.h
@@ -1,0 +1,39 @@
+/** @file
+ *  @brief DIS user function prototypes.
+ */
+
+/*
+ * Copyright (c) 2020 Grinn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_DIS_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_DIS_H_
+
+#include <bluetooth/gatt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ssize_t bt_dis_serial_number(struct bt_conn *conn,
+		const struct bt_gatt_attr *attr, void *buf,
+		uint16_t len, uint16_t offset);
+
+ssize_t bt_dis_fw_rev(struct bt_conn *conn,
+		const struct bt_gatt_attr *attr, void *buf,
+		uint16_t len, uint16_t offset);
+
+ssize_t bt_dis_hw_rev(struct bt_conn *conn,
+		const struct bt_gatt_attr *attr, void *buf,
+		uint16_t len, uint16_t offset);
+
+ssize_t bt_dis_sw_rev(struct bt_conn *conn,
+		const struct bt_gatt_attr *attr, void *buf,
+		uint16_t len, uint16_t offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_DIS_H_ */

--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -108,6 +108,13 @@ config BT_DIS_SERIAL_NUMBER_STR
 	help
 	  Enable Serial Number characteristic in Device Information Service.
 
+config BT_DIS_SERIAL_NUMBER_USER_FN
+	bool "Serial Number user function"
+	depends on BT_DIS_SERIAL_NUMBER
+	help
+	  Enable Serial Number characteristic by implementing
+	  bt_dis_serial_number().
+
 config BT_DIS_FW_REV
 	bool "Enable DIS Firmware Revision characteristic"
 	help
@@ -118,6 +125,13 @@ config BT_DIS_FW_REV_STR
 	depends on BT_DIS_FW_REV
 	help
 	  Enable firmware revision characteristic in Device Information Service.
+
+config BT_DIS_FW_REV_USER_FN
+	bool "Firmware revision user function"
+	depends on BT_DIS_FW_REV
+	help
+	  Enable firmware revision characteristic by implementing
+	  bt_dis_fw_rev().
 
 config BT_DIS_HW_REV
 	bool "Enable DIS Hardware Revision characteristic"
@@ -130,6 +144,13 @@ config BT_DIS_HW_REV_STR
 	help
 	  Enable hardware revision characteristic in Device Information Service.
 
+config BT_DIS_HW_REV_USER_FN
+	bool "Hardware revision user function"
+	depends on BT_DIS_HW_REV
+	help
+	  Enable hardware revision characteristic by implementing
+	  bt_dis_hw_rev().
+
 config BT_DIS_SW_REV
 	bool "Enable DIS Software Revision characteristic"
 	help
@@ -140,5 +161,12 @@ config BT_DIS_SW_REV_STR
 	depends on BT_DIS_SW_REV
 	help
 	  Enable software revision characteristic in Device Information Service.
+
+config BT_DIS_SW_REV_USER_FN
+	bool "Software revision user function"
+	depends on BT_DIS_SW_REV
+	help
+	  Enable software revision characteristic by implementing
+	  bt_dis_sw_rev().
 
 endif # BT_DIS

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -20,6 +20,7 @@
 #include <settings/settings.h>
 
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/dis.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
@@ -83,6 +84,30 @@ static uint8_t dis_sw_rev[CONFIG_BT_DIS_STR_MAX] =
 
 #endif /* CONFIG_BT_DIS_SETTINGS */
 
+#if defined(CONFIG_BT_DIS_SERIAL_NUMBER_USER_FN)
+#define BT_DIS_SERIAL_NUMBER_FN	bt_dis_serial_number
+#else
+#define BT_DIS_SERIAL_NUMBER_FN	read_str
+#endif
+
+#if defined(CONFIG_BT_DIS_FW_REV_USER_FN)
+#define BT_DIS_FW_REV_FN	bt_dis_fw_rev
+#else
+#define BT_DIS_FW_REV_FN	read_str
+#endif
+
+#if defined(CONFIG_BT_DIS_HW_REV_USER_FN)
+#define BT_DIS_HW_REV_FN	bt_dis_hw_rev
+#else
+#define BT_DIS_HW_REV_FN	read_str
+#endif
+
+#if defined(CONFIG_BT_DIS_SW_REV_USER_FN)
+#define BT_DIS_SW_REV_FN	bt_dis_sw_rev
+#else
+#define BT_DIS_SW_REV_FN	read_str
+#endif
+
 static ssize_t read_str(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, void *buf,
 			  uint16_t len, uint16_t offset)
@@ -120,23 +145,23 @@ BT_GATT_SERVICE_DEFINE(dis_svc,
 #if defined(CONFIG_BT_DIS_SERIAL_NUMBER)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_SERIAL_NUMBER,
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
-			       read_str, NULL,
+			       BT_DIS_SERIAL_NUMBER_FN, NULL,
 			       BT_DIS_SERIAL_NUMBER_STR_REF),
 #endif
 #if defined(CONFIG_BT_DIS_FW_REV)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_FIRMWARE_REVISION,
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
-			       read_str, NULL, BT_DIS_FW_REV_STR_REF),
+			       BT_DIS_FW_REV_FN, NULL, BT_DIS_FW_REV_STR_REF),
 #endif
 #if defined(CONFIG_BT_DIS_HW_REV)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_HARDWARE_REVISION,
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
-			       read_str, NULL, BT_DIS_HW_REV_STR_REF),
+			       BT_DIS_HW_REV_FN, NULL, BT_DIS_HW_REV_STR_REF),
 #endif
 #if defined(CONFIG_BT_DIS_SW_REV)
 	BT_GATT_CHARACTERISTIC(BT_UUID_DIS_SOFTWARE_REVISION,
 			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
-			       read_str, NULL, BT_DIS_SW_REV_STR_REF),
+			       BT_DIS_SW_REV_FN, NULL, BT_DIS_SW_REV_STR_REF),
 #endif
 
 );


### PR DESCRIPTION
So far there were two possibilities to provide values for DIS
characteristics:
 - set string via Kconfig,
 - read in runtime from settings subsystem.

Those mechanisms do not cover a case when a value is provided in build
time, but is not accessible over Kconfig. Additionally those do not
cover case when serial number is something read in runtime, such as
MCU's or some other chip unique id.

Add configurable options to provide DIS characteristic values by
implementing proper functions by user / application.

This allows things like:
```
ssize_t bt_dis_serial_number(struct bt_conn *conn,
			     const struct bt_gatt_attr *attr, void *buf,
			     uint16_t len, uint16_t offset)
{
	char serial_number[32];
	int ret;

	ret = get_unique_id(serial_number);
	if (ret < 0) {
		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
	}

	return bt_gatt_attr_read(conn, attr, buf, len, offset, serial_number,
				 ret);
}
```