### PR TITLE
boards: stm32f769i_disco: Add SDMMC support

### DIFF
--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -96,3 +96,11 @@ arduino_serial: &usart6 {};
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 };
+
+&sdmmc2 {
+	status = "okay";
+	pinctrl-0 = <&sdmmc2_d0_pg9 &sdmmc2_d1_pg10
+		     &sdmmc2_d2_pb3 &sdmmc2_d3_pb4
+		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
+	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
+};

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -31,6 +31,14 @@
 			phys = <&usbphyc>;
 			maximum-speed = "high-speed";
 		};
+
+		sdmmc2: sdmmc@40011c00 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x40011c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			status = "disabled";
+			label = "SDMMC_2";
+		};
 	};
 
 };

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -81,5 +81,13 @@
 				 <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
 			status = "disabled";
 		};
+
+		sdmmc2: sdmmc@40011c00 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x40011c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			status = "disabled";
+			label = "SDMMC_2";
+		};
 	};
 };


### PR DESCRIPTION
- Define sdmmc2 for stm32f7 series.
- Define board specific config for sdmmc2 module.

Tested using `zephyr/samples/subsys/fs/fat_fs/` and MicroSD Card formatted as FAT32.
 
Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>