### PR TITLE
samples: drivers: add platform filtering for led pwm

### DIFF
--- a/samples/drivers/led_pwm/sample.yaml
+++ b/samples/drivers/led_pwm/sample.yaml
@@ -6,3 +6,4 @@ tests:
     filter: dt_compat_enabled("pwm-leds")
     tags: LED
     depends_on: pwm
+    platform_exclude: reel_board


### PR DESCRIPTION
The sanity check on this sample gives timeout failure on reel board because of bad filtering. As the sample does not adopt ztest framework, sanity check in the daily test will wait for tests until timeout and report this as failure, which lowers our passrate but this is not a sample with errors. It's valid and only tested on STM32F070-based boards per [29401](https://github.com/zephyrproject-rtos/zephyr/pull/29401), but its only filter is "pwm" dependency. Reel board is the only board in the daily test that supports pwm, so a single platform exclusion is added. 

Signed-off-by: Shihao Shen <shihao.shen@intel.com>