### PR TITLE
Bluetooth: host: Document security changed and no security level change

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -696,14 +696,15 @@ typedef enum __packed {
 
 /** @brief Set security level for a connection.
  *
- *  This function enable security (encryption) for a connection. If device is
- *  already paired with sufficiently strong key encryption will be enabled. If
- *  link is already encrypted with sufficiently strong key this function does
- *  nothing.
+ *  This function enable security (encryption) for a connection. If the device
+ *  has bond information for the peer with sufficiently strong key encryption
+ *  will be enabled. If the connection is already encrypted with sufficiently
+ *  strong key this function does nothing.
  *
- *  If device is not paired pairing will be initiated. If device is paired and
- *  keys are too weak but input output capabilities allow for strong enough keys
- *  pairing will be initiated.
+ *  If the device has no bond information for the peer and is not already paired
+ *  then the pairing procedure will be initiated. If the device has bond
+ *  information or is already paired and the keys are too weak then the pairing
+ *  procedure will be initiated.
  *
  *  This function may return error if required level of security is not possible
  *  to achieve due to local or remote device limitation (e.g., input output
@@ -881,8 +882,15 @@ struct bt_conn_cb {
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 	/** @brief The security level of a connection has changed.
 	 *
-	 *  This callback notifies the application that the security level
-	 *  of a connection has changed.
+	 *  This callback notifies the application that the security of a
+	 *  connection has changed.
+	 *
+	 *  The security level of the connection can either have been increased
+	 *  or remain unchanged. An increased security level means that the
+	 *  pairing procedure has been performed or the bond information from
+	 *  a previous connection has been applied. If the security level
+	 *  remains unchanged this means that the encryption key has been
+	 *  refreshed for the connection.
 	 *
 	 *  @param conn Connection object.
 	 *  @param level New security level of the connection.
@@ -1276,13 +1284,14 @@ struct bt_conn_auth_cb {
 	void (*pincode_entry)(struct bt_conn *conn, bool highsec);
 #endif
 
-	/** @brief notify that pairing process was complete.
+	/** @brief notify that pairing procedure was complete.
 	 *
-	 *  This callback notifies the application that the pairing process
+	 *  This callback notifies the application that the pairing procedure
 	 *  has been completed.
 	 *
 	 *  @param conn Connection object.
-	 *  @param bonded pairing is bonded or not.
+	 *  @param bonded Bond information has been distributed during the
+	 *                pairing procedure.
 	 */
 	void (*pairing_complete)(struct bt_conn *conn, bool bonded);
 


### PR DESCRIPTION
Document the security changed callback can be called with no change
in the security level when the encryption key has been changed
in the link-layer.

Also update the documentation for set security function to include
the bond information so that it matches the documentation for security
changed callback.

Update pairing process to pairing procedure for consistency.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>