### PR TITLE
ethernet: stm32h7: fix tx semaphore timeout bug

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -227,10 +227,17 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	/* Reset TX complete interrupt semaphore before TX request*/
 	k_sem_reset(&dev_data->tx_int_sem);
 
+	/* Memory barriers (e.g. __DSB()) should flush Tx descriptors
+	 * into memory. Incomplete writing of Tx descriptors may occur
+	 * with different compilation levels
+	 */
+	__DSB();
+
 	/* tx_buffer is allocated on function stack, we need */
 	/* to wait for the transfer to complete */
 	/* So it is not freed before the interrupt happens */
 	hal_ret = HAL_ETH_Transmit_IT(heth, &tx_config);
+	__DSB();
 
 	if (hal_ret != HAL_OK) {
 		LOG_ERR("HAL_ETH_Transmit: failed!");


### PR DESCRIPTION
Incomplete memory write causes issues with ethernet
transmission on stm32h747_disco_m7 board.
TxCpltCallback is never called, causing waiting for
tx_int_sem to timeout, and occationally hangs
ethernet communication.

Tested with 700 000 connections on dumb http server,
as well as 5min continuous MCU reset every 7s with
continuous GET requests.

Fixes issue https://github.com/zephyrproject-rtos/zephyr/issues/29915