### PR TITLE
aarch64: Use macro-generate absolute symbols where possible

### DIFF
--- a/arch/arm/core/aarch64/fatal.c
+++ b/arch/arm/core/aarch64/fatal.c
@@ -133,26 +133,16 @@ static void print_EC_cause(uint64_t esr)
 
 static void esf_dump(const z_arch_esf_t *esf)
 {
-	LOG_ERR("x0:  0x%016llx  x1:  0x%016llx",
-		esf->basic.regs[18], esf->basic.regs[19]);
-	LOG_ERR("x2:  0x%016llx  x3:  0x%016llx",
-		esf->basic.regs[16], esf->basic.regs[17]);
-	LOG_ERR("x4:  0x%016llx  x5:  0x%016llx",
-		esf->basic.regs[14], esf->basic.regs[15]);
-	LOG_ERR("x6:  0x%016llx  x7:  0x%016llx",
-		esf->basic.regs[12], esf->basic.regs[13]);
-	LOG_ERR("x8:  0x%016llx  x9:  0x%016llx",
-		esf->basic.regs[10], esf->basic.regs[11]);
-	LOG_ERR("x10: 0x%016llx  x11: 0x%016llx",
-		esf->basic.regs[8], esf->basic.regs[9]);
-	LOG_ERR("x12: 0x%016llx  x13: 0x%016llx",
-		esf->basic.regs[6], esf->basic.regs[7]);
-	LOG_ERR("x14: 0x%016llx  x15: 0x%016llx",
-		esf->basic.regs[4], esf->basic.regs[5]);
-	LOG_ERR("x16: 0x%016llx  x17: 0x%016llx",
-		esf->basic.regs[2], esf->basic.regs[3]);
-	LOG_ERR("x18: 0x%016llx  x30: 0x%016llx",
-		esf->basic.regs[0], esf->basic.regs[1]);
+	LOG_ERR("x0:  0x%016llx  x1:  0x%016llx", esf->x0, esf->x1);
+	LOG_ERR("x2:  0x%016llx  x3:  0x%016llx", esf->x2, esf->x3);
+	LOG_ERR("x4:  0x%016llx  x5:  0x%016llx", esf->x4, esf->x5);
+	LOG_ERR("x6:  0x%016llx  x7:  0x%016llx", esf->x6, esf->x7);
+	LOG_ERR("x8:  0x%016llx  x9:  0x%016llx", esf->x8, esf->x9);
+	LOG_ERR("x10: 0x%016llx  x11: 0x%016llx", esf->x10, esf->x11);
+	LOG_ERR("x12: 0x%016llx  x13: 0x%016llx", esf->x12, esf->x13);
+	LOG_ERR("x14: 0x%016llx  x15: 0x%016llx", esf->x14, esf->x15);
+	LOG_ERR("x16: 0x%016llx  x17: 0x%016llx", esf->x16, esf->x17);
+	LOG_ERR("x18: 0x%016llx  x30: 0x%016llx", esf->x18, esf->x30);
 }
 
 void z_arm64_fatal_error(unsigned int reason, const z_arch_esf_t *esf)

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -26,20 +26,23 @@
 	 * - Context-switch: the callee-saved registers are saved by
 	 *   z_arm64_context_switch() in the kernel structure.
 	 */
-	stp	x0, x1, [sp, #-16]!
-	stp	x2, x3, [sp, #-16]!
-	stp	x4, x5, [sp, #-16]!
-	stp	x6, x7, [sp, #-16]!
-	stp	x8, x9, [sp, #-16]!
-	stp	x10, x11, [sp, #-16]!
-	stp	x12, x13, [sp, #-16]!
-	stp	x14, x15, [sp, #-16]!
-	stp     x16, x17, [sp, #-16]!
-	stp     x18, x30, [sp, #-16]!
+
+	sub	sp, sp, ___esf_t_SIZEOF
+
+	stp	x0, x1, [sp, ___esf_t_x0_x1_OFFSET]
+	stp	x2, x3, [sp, ___esf_t_x2_x3_OFFSET]
+	stp	x4, x5, [sp, ___esf_t_x4_x5_OFFSET]
+	stp	x6, x7, [sp, ___esf_t_x6_x7_OFFSET]
+	stp	x8, x9, [sp, ___esf_t_x8_x9_OFFSET]
+	stp	x10, x11, [sp, ___esf_t_x10_x11_OFFSET]
+	stp	x12, x13, [sp, ___esf_t_x12_x13_OFFSET]
+	stp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
+	stp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]
+	stp	x18, x30, [sp, ___esf_t_x18_x30_OFFSET]
 
 	mrs	\xreg0, spsr_el1
 	mrs	\xreg1, elr_el1
-	stp	\xreg0, \xreg1, [sp, #-16]!
+	stp	\xreg0, \xreg1, [sp, ___esf_t_spsr_elr_OFFSET]
 .endm
 
 /*
@@ -49,21 +52,22 @@
  */
 
 .macro z_arm64_exit_exc xreg0, xreg1
-	ldp	\xreg0, \xreg1, [sp], #16
+	ldp	\xreg0, \xreg1, [sp, ___esf_t_spsr_elr_OFFSET]
 	msr	spsr_el1, \xreg0
 	msr	elr_el1, \xreg1
 
-	ldp	x18, x30, [sp], #16
-	ldp	x16, x17, [sp], #16
-	ldp	x14, x15, [sp], #16
-	ldp	x12, x13, [sp], #16
-	ldp	x10, x11, [sp], #16
-	ldp	x8, x9, [sp], #16
-	ldp	x6, x7, [sp], #16
-	ldp	x4, x5, [sp], #16
-	ldp	x2, x3, [sp], #16
-	ldp	x0, x1, [sp], #16
+	ldp	x18, x30, [sp, ___esf_t_x18_x30_OFFSET]
+	ldp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]
+	ldp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
+	ldp	x12, x13, [sp, ___esf_t_x12_x13_OFFSET]
+	ldp	x10, x11, [sp, ___esf_t_x10_x11_OFFSET]
+	ldp	x8, x9, [sp, ___esf_t_x8_x9_OFFSET]
+	ldp	x6, x7, [sp, ___esf_t_x6_x7_OFFSET]
+	ldp	x4, x5, [sp, ___esf_t_x4_x5_OFFSET]
+	ldp	x2, x3, [sp, ___esf_t_x2_x3_OFFSET]
+	ldp	x0, x1, [sp, ___esf_t_x0_x1_OFFSET]
 
+	add	sp, sp, ___esf_t_SIZEOF
 	/*
 	 * In general in the ELR_EL1 register we can find:
 	 *

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -126,7 +126,7 @@ context_switch:
 	 *  - x0 = new_thread->switch_handle = switch_to thread
 	 *  - x1 = &old_thread->switch_handle = current thread
 	 */
-	ldp	x0, x1, [sp, #(16 * 10)]
+	ldp	x0, x1, [sp, ___esf_t_x0_x1_OFFSET]
 
 	/* Get old thread from x1 */
 	sub	x1, x1, ___thread_t_switch_handle_OFFSET

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -35,17 +35,15 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldr	x2, =_thread_offset_to_callee_saved
 	add	x2, x2, x1
 
-	/* Store callee-saved registers */
-	stp	x19, x20, [x2], #16
-	stp	x21, x22, [x2], #16
-	stp	x23, x24, [x2], #16
-	stp	x25, x26, [x2], #16
-	stp	x27, x28, [x2], #16
-	stp	x29, xzr, [x2], #16
-
 	/* Save the current SP */
 	mov	x1, sp
-	str	x1, [x2]
+
+	stp	x19, x20, [x2, ___callee_saved_t_x19_x20_OFFSET]
+	stp	x21, x22, [x2, ___callee_saved_t_x21_x22_OFFSET]
+	stp	x23, x24, [x2, ___callee_saved_t_x23_x24_OFFSET]
+	stp	x25, x26, [x2, ___callee_saved_t_x25_x26_OFFSET]
+	stp	x27, x28, [x2, ___callee_saved_t_x27_x28_OFFSET]
+	stp	x29, x1, [x2, ___callee_saved_t_x29_sp_OFFSET]
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	/* Grab the TLS pointer */
@@ -64,15 +62,13 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldr	x2, =_thread_offset_to_callee_saved
 	add	x2, x2, x0
 
-	/* Restore x19-x29 */
-	ldp	x19, x20, [x2], #16
-	ldp	x21, x22, [x2], #16
-	ldp	x23, x24, [x2], #16
-	ldp	x25, x26, [x2], #16
-	ldp	x27, x28, [x2], #16
-	ldp	x29, xzr, [x2], #16
+	ldp	x19, x20, [x2, ___callee_saved_t_x19_x20_OFFSET]
+	ldp	x21, x22, [x2, ___callee_saved_t_x21_x22_OFFSET]
+	ldp	x23, x24, [x2, ___callee_saved_t_x23_x24_OFFSET]
+	ldp	x25, x26, [x2, ___callee_saved_t_x25_x26_OFFSET]
+	ldp	x27, x28, [x2, ___callee_saved_t_x27_x28_OFFSET]
+	ldp	x29, x1, [x2, ___callee_saved_t_x29_sp_OFFSET]
 
-	ldr	x1, [x2]
 	mov	sp, x1
 
 #ifdef CONFIG_TRACING

--- a/arch/arm/core/aarch64/thread.c
+++ b/arch/arm/core/aarch64/thread.c
@@ -16,35 +16,6 @@
 #include <wait_q.h>
 #include <arch/cpu.h>
 
-struct init_stack_frame {
-	/* top of the stack / most recently pushed */
-
-	/* SPSR_ELn and ELR_ELn */
-	uint64_t spsr;
-	uint64_t elr;
-
-	/*
-	 * Registers restored by z_arm64_exit_exc(). We are not interested in
-	 * registers x4 -> x18 + x30 but we need to account for those anyway
-	 */
-	uint64_t unused[16];
-
-	/*
-	 * z_arm64_exit_exc() pulls these off the stack and into argument
-	 * registers before calling z_thread_entry():
-	 * -  x2 <- arg2
-	 * -  x3 <- arg3
-	 * -  x0 <- entry_point
-	 * -  x1 <- arg1
-	 */
-	uint64_t arg2;
-	uint64_t arg3;
-	uint64_t entry_point;
-	uint64_t arg1;
-
-	/* least recently pushed */
-};
-
 /*
  * An initial context, to be "restored" by z_arm64_context_switch(), is put at
  * the other end of the stack, and thus reusable by the stack when not needed
@@ -54,14 +25,14 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		     char *stack_ptr, k_thread_entry_t entry,
 		     void *p1, void *p2, void *p3)
 {
-	struct init_stack_frame *pInitCtx;
+	z_arch_esf_t *pInitCtx;
 
-	pInitCtx = Z_STACK_PTR_TO_FRAME(struct init_stack_frame, stack_ptr);
+	pInitCtx = Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr);
 
-	pInitCtx->entry_point = (uint64_t)entry;
-	pInitCtx->arg1 = (uint64_t)p1;
-	pInitCtx->arg2 = (uint64_t)p2;
-	pInitCtx->arg3 = (uint64_t)p3;
+	pInitCtx->x0 = (uint64_t)entry;
+	pInitCtx->x1 = (uint64_t)p1;
+	pInitCtx->x2 = (uint64_t)p2;
+	pInitCtx->x3 = (uint64_t)p3;
 
 	/*
 	 * - ELR_ELn: to be used by eret in z_arm64_exit_exc() to return

--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -11,6 +11,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>
+#include <offsets_short.h>
 #include "vector_table.h"
 #include "macro_priv.inc"
 

--- a/arch/arm/core/offsets/offsets_aarch64.c
+++ b/arch/arm/core/offsets/offsets_aarch64.c
@@ -29,4 +29,13 @@
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
 
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x19, x19_x20);
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x21, x21_x22);
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x23, x23_x24);
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x25, x25_x26);
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x27, x27_x28);
+GEN_NAMED_OFFSET_SYM(_callee_saved_t, x29, x29_sp);
+
+GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
+
 #endif /* _ARM_OFFSETS_INC_ */

--- a/arch/arm/core/offsets/offsets_aarch64.c
+++ b/arch/arm/core/offsets/offsets_aarch64.c
@@ -38,4 +38,18 @@ GEN_NAMED_OFFSET_SYM(_callee_saved_t, x29, x29_sp);
 
 GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
 
+GEN_NAMED_OFFSET_SYM(_esf_t, spsr, spsr_elr);
+GEN_NAMED_OFFSET_SYM(_esf_t, x18, x18_x30);
+GEN_NAMED_OFFSET_SYM(_esf_t, x16, x16_x17);
+GEN_NAMED_OFFSET_SYM(_esf_t, x14, x14_x15);
+GEN_NAMED_OFFSET_SYM(_esf_t, x12, x12_x13);
+GEN_NAMED_OFFSET_SYM(_esf_t, x10, x10_x11);
+GEN_NAMED_OFFSET_SYM(_esf_t, x8, x8_x9);
+GEN_NAMED_OFFSET_SYM(_esf_t, x6, x6_x7);
+GEN_NAMED_OFFSET_SYM(_esf_t, x4, x4_x5);
+GEN_NAMED_OFFSET_SYM(_esf_t, x2, x2_x3);
+GEN_NAMED_OFFSET_SYM(_esf_t, x0, x0_x1);
+
+GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
+
 #endif /* _ARM_OFFSETS_INC_ */

--- a/include/arch/arm/aarch64/exc.h
+++ b/include/arch/arm/aarch64/exc.h
@@ -25,11 +25,28 @@ extern "C" {
 #endif
 
 struct __esf {
-	struct __basic_sf {
-		uint64_t spsr;
-		uint64_t elr;
-		uint64_t regs[20];
-	} basic;
+	uint64_t spsr;
+	uint64_t elr;
+	uint64_t x18;
+	uint64_t x30;
+	uint64_t x16;
+	uint64_t x17;
+	uint64_t x14;
+	uint64_t x15;
+	uint64_t x12;
+	uint64_t x13;
+	uint64_t x10;
+	uint64_t x11;
+	uint64_t x8;
+	uint64_t x9;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x0;
+	uint64_t x1;
 };
 
 typedef struct __esf z_arch_esf_t;

--- a/include/arch/arm/aarch64/thread.h
+++ b/include/arch/arm/aarch64/thread.h
@@ -34,7 +34,6 @@ struct _callee_saved {
 	uint64_t x27;
 	uint64_t x28;
 	uint64_t x29; /* FP */
-	uint64_t xzr;
 	uint64_t sp;
 };
 

--- a/kernel/include/gen_offset.h
+++ b/kernel/include/gen_offset.h
@@ -32,6 +32,11 @@
  *
  *    __<structure>_<member>_OFFSET
  *
+ * The macro "GEN_NAMED_OFFSET_SYM(structure, member, name)" is also provided
+ * to create the symbol with the following form:
+ *
+ *    __<structure>_<name>_OFFSET
+ *
  * This header also defines the GEN_ABSOLUTE_SYM macro to simply define an
  * absolute symbol, irrespective of whether the value represents a structure
  * or offset.
@@ -78,5 +83,8 @@
 
 #define GEN_OFFSET_SYM(S, M) \
 	GEN_ABSOLUTE_SYM(__##S##_##M##_##OFFSET, offsetof(S, M))
+
+#define GEN_NAMED_OFFSET_SYM(S, M, N) \
+	GEN_ABSOLUTE_SYM(__##S##_##N##_##OFFSET, offsetof(S, M))
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_GEN_OFFSET_H_ */


### PR DESCRIPTION
This is basically a patch to move to use `GEN_ABSOLUTE_SYM` when possible. This is actually something I need for my WiP work on userspace because some offsets are going to change whether we have userspace enabled or not.

The most notable thing in this set is probably the introduction of `GEN_NAMED_OFFSET_SYM` to create named absolute symbols. This makes my life a bit easier because I can create one single offset and use that offset with `ldp` and `stp` that act on two registers at the same time.