### PR TITLE
drivers: ieee802154: cc13xx_cc26xx: raw mode support

### DIFF
--- a/drivers/ieee802154/Kconfig.cc13xx_cc26xx
+++ b/drivers/ieee802154/Kconfig.cc13xx_cc26xx
@@ -20,11 +20,47 @@ config IEEE802154_CC13XX_CC26XX_INIT_PRIO
 	help
 	  Set the initialization priority number.
 
+config IEEE802154_CC13XX_CC26XX_RADIO_TX_RETRIES
+	int "Radio Transmission attempts"
+	default NET_L2_IEEE802154_RADIO_TX_RETRIES if NET_L2_IEEE802154
+	default 3
+	range 1 7
+	help
+	  Number of transmission attempts radio driver should do, before
+	  replying it could not send the packet.
+
+config IEEE802154_CC13XX_CC26XX_RADIO_CSMA_CA_MAX_BO
+	int "CSMA maximum backoffs"
+	default NET_L2_IEEE802154_RADIO_CSMA_CA_MAX_BO if NET_L2_IEEE802154_RADIO_CSMA_CA
+	default 4
+	range 1 5
+	help
+	  The maximum number of backoffs the CSMA-CA algorithm will attempt
+	  before declaring a channel access failure.
+
+config IEEE802154_CC13XX_CC26XX_RADIO_CSMA_CA_MIN_BE
+	int "CSMA MAC minimum backoff exponent"
+	default NET_L2_IEEE802154_RADIO_CSMA_CA_MIN_BE if NET_L2_IEEE802154_RADIO_CSMA_CA
+	default 3
+	range 1 8
+	help
+	  The minimum value of the backoff exponent (BE) in the CSMA-CA
+	  algorithm.
+
+config IEEE802154_CC13XX_CC26XX_RADIO_CSMA_CA_MAX_BE
+	int "CSMA MAC maximum backoff exponent"
+	default NET_L2_IEEE802154_RADIO_CSMA_CA_MAX_BE if NET_L2_IEEE802154_RADIO_CSMA_CA
+	default 5
+	range 1 8
+	help
+	  The maximum value of the backoff exponent (BE) in the CSMA-CA
+	  algorithm.
+
 endif # IEEE802154_CC13XX_CC26XX
 
 menuconfig IEEE802154_CC13XX_CC26XX_SUB_GHZ
 	bool "TI CC13xx / CC26xx IEEE 802.15.4g driver support"
-	select NET_L2_IEEE802154_SUB_GHZ
+	select NET_L2_IEEE802154_SUB_GHZ if NET_L2_IEEE802154
 
 if IEEE802154_CC13XX_CC26XX_SUB_GHZ
 
@@ -53,5 +89,14 @@ config IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO
 	default 80
 	help
 	  Set the initialization priority number.
+
+config IEEE802154_CC13XX_CC26XX_SUB_GHZ_RADIO_TX_RETRIES
+	int "Radio Transmission attempts"
+	default NET_L2_IEEE802154_RADIO_TX_RETRIES if NET_L2_IEEE802154
+	default 3
+	range 1 7
+	help
+	  Number of transmission attempts radio driver should do, before
+	  replying it could not send the packet.
 
 endif # IEEE802154_CC13XX_CC26XX_SUB_GHZ

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
@@ -51,8 +51,8 @@
 
 #define CC13XX_CC26XX_NUM_RX_BUF 2
 
-/* Two additional bytes for RSSI and correlation values from CPE. */
-#define CC13XX_CC26XX_RX_BUF_SIZE (IEEE802154_MAX_PHY_PACKET_SIZE + 2)
+/* Three additional bytes for length, RSSI and correlation values from CPE. */
+#define CC13XX_CC26XX_RX_BUF_SIZE (IEEE802154_MAX_PHY_PACKET_SIZE + 3)
 
 #define CC13XX_CC26XX_CPE0_IRQ (INT_RFC_CPE_0 - 16)
 #define CC13XX_CC26XX_CPE1_IRQ (INT_RFC_CPE_1 - 16)

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(ieee802154_cc13xx_cc26xx_subg);
 #include <random/rand32.h>
 #include <string.h>
 #include <sys/sys_io.h>
+#include <sys/crc.h>
 
 #include <driverlib/rf_mailbox.h>
 #include <driverlib/rf_prop_mailbox.h>
@@ -328,7 +329,7 @@ static int ieee802154_cc13xx_cc26xx_subg_tx(const struct device *dev,
 {
 	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data =
 		get_dev_data(dev);
-	int retry = CONFIG_NET_L2_IEEE802154_RADIO_TX_RETRIES;
+	int retry = CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_RADIO_TX_RETRIES;
 	RF_EventMask reason;
 	int r;
 
@@ -434,17 +435,27 @@ static void ieee802154_cc13xx_cc26xx_subg_rx_done(
 {
 	struct net_pkt *pkt;
 	uint8_t len;
-	int8_t rssi;
+	int8_t rssi, status;
 	uint8_t *sdu;
 
 	for (int i = 0; i < CC13XX_CC26XX_NUM_RX_BUF; i++) {
 		if (drv_data->rx_entry[i].status == DATA_ENTRY_FINISHED) {
-			len = drv_data->rx_data[i][1];
-			sdu = &drv_data->rx_data[i][3];
-			rssi = sdu[len - 2];
-			len -= 2;
+			len = drv_data->rx_data[i][0];
+			sdu = drv_data->rx_data[i] + 1;
+			status = drv_data->rx_data[i][len--];
+			rssi = drv_data->rx_data[i][len--];
 
-			LOG_DBG("Received: len = %u, rssi = %d", len, rssi);
+			if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE)) {
+				/* append CRC-16/CCITT */
+				uint16_t crc = 0;
+
+				crc = crc16_ccitt(0, sdu, len);
+				sdu[len++] = crc;
+				sdu[len++] = crc >> 8;
+			}
+
+			LOG_DBG("Received: len = %u, rssi = %d status = %u",
+				len, rssi, status);
 
 			pkt = net_pkt_rx_alloc_with_buffer(
 				drv_data->iface, len, AF_UNSPEC, 0, K_NO_WAIT);
@@ -697,8 +708,8 @@ static struct ieee802154_cc13xx_cc26xx_subg_data
 		.rxConf = {
 			.bAutoFlushIgnored = true,
 			.bAutoFlushCrcErr = true,
-			.bIncludeHdr = true,
 			.bAppendRssi = true,
+			.bAppendStatus = true,
 		},
 		/* Preamble & SFD for 2-FSK SUN PHY. 802.15.4-2015, 20.2.1 */
 		.syncWord0 = 0x0055904E,
@@ -745,6 +756,7 @@ static struct ieee802154_cc13xx_cc26xx_subg_data
 	},
 };
 
+#if defined(CONFIG_NET_L2_IEEE802154_SUB_GHZ)
 NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx_subg,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DRV_NAME,
 		ieee802154_cc13xx_cc26xx_subg_init, device_pm_control_nop,
@@ -752,3 +764,11 @@ NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx_subg,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_subg_radio_api, IEEE802154_L2,
 		NET_L2_GET_CTX_TYPE(IEEE802154_L2), IEEE802154_MTU);
+#else
+DEVICE_AND_API_INIT(ieee802154_cc13xx_cc26xx_subg,
+		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DRV_NAME,
+		ieee802154_cc13xx_cc26xx_subg_init,
+		&ieee802154_cc13xx_cc26xx_subg_data, NULL, POST_KERNEL,
+		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO,
+		&ieee802154_cc13xx_cc26xx_subg_radio_api);
+#endif

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.h
@@ -57,12 +57,8 @@
 #define CC13XX_CC26XX_NUM_RX_BUF \
 	CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_NUM_RX_BUF
 
-/*
- * Two additional bytes for the PHR in PROP mode
- * One additional byte for RSSI value from CPE
- */
-#define CC13XX_CC26XX_RX_BUF_SIZE (IEEE802154_MAX_PHY_PACKET_SIZE \
-		+ IEEE802154_SUN_PHY_FSK_PHR_LEN + 1)
+/* Three additional bytes for length, RSSI and status values from CPE */
+#define CC13XX_CC26XX_RX_BUF_SIZE (IEEE802154_MAX_PHY_PACKET_SIZE + 3)
 
 /*
  * Two additional bytes for the SUN FSK PHY HDR


### PR DESCRIPTION
This change adds IEEE802154_RAW_MODE support for the
cc1352r.

This allows using the cc1352r 2.4 GHz radio and Sub Ghz
radio as a transceiver (PHY) instead of using L2 networking.

Fixes #29951 

Signed-off-by: Erik Larson <erik@statropy.com>