### PR TITLE
Fix rand32_ctr_drbg error handling

### DIFF
--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -130,8 +130,12 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 		ret = 0;
 	} else if (ret == TC_CTR_PRNG_RESEED_REQ) {
 
-		entropy_get_entropy(entropy_driver,
+		ret = entropy_get_entropy(entropy_driver,
 				    (void *)&entropy, sizeof(entropy));
+		if (ret != 0) {
+			ret = -EIO;
+			goto end;
+		}
 
 		ret = tc_ctr_prng_reseed(&ctr_ctx,
 					entropy,
@@ -146,6 +150,7 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 	} else {
 		ret = -EIO;
 	}
+end:
 #endif
 	irq_unlock(key);
 

--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -112,7 +112,8 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 	if (unlikely(!entropy_driver)) {
 		ret = ctr_drbg_initialize();
 		if (ret != 0) {
-			return ret;
+			ret = -EIO;
+			goto end;
 		}
 	}
 
@@ -150,8 +151,8 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
 	} else {
 		ret = -EIO;
 	}
-end:
 #endif
+end:
 	irq_unlock(key);
 
 	return ret;


### PR DESCRIPTION
Address two issues in the error path of rand32_ctr_drbg:

- Release previously locked IRQ
- Check entropy_get_entropy error
