### PR TITLE
Bluetooth: controller: Fix regression in central event close

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -710,7 +710,8 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 			lll->empty = 0;
 
 			pdu_data_tx = (void *)radio_pkt_empty_get();
-			if (IS_ENABLED(CONFIG_BT_CENTRAL) && !lll->role) {
+			if (IS_ENABLED(CONFIG_BT_CENTRAL) && !lll->role &&
+			    !pdu_data_rx->md) {
 				*is_done = !pdu_data_tx->md;
 			}
 
@@ -755,7 +756,8 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 				FORCE_MD_CNT_SET();
 			}
 
-			if (IS_ENABLED(CONFIG_BT_CENTRAL) && !lll->role) {
+			if (IS_ENABLED(CONFIG_BT_CENTRAL) && !lll->role &&
+			    !pdu_data_rx->md) {
 				*is_done = !pdu_data_tx->md;
 			}
 		}


### PR DESCRIPTION
Fix regression in connection radio event close in central
role introduced in commit 222dca55981

Fixes #29957.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>