### PR TITLE
include: net: Fix incorrect casting of timeval on zsock_timeval.

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -16,15 +16,36 @@
 
 #include <zephyr/types.h>
 
+#ifdef CONFIG_POSIX_API
+#ifdef __NEWLIB__
+#include <sys/_timeval.h>
+#else
+#include <sys/types.h>
+#endif /* __NEWLIB__ */
+#endif /* CONFIG_POSIX_API */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifdef CONFIG_POSIX_API
+/* Rely on the underlying libc definition */
+#ifdef __NEWLIB__
+#define zsock_timeval timeval
+#else
+/* workaround for older Newlib 2.x, as it lacks sys/_timeval.h */
+struct zsock_timeval {
+	time_t tv_sec;
+	suseconds_t tv_usec;
+};
+#endif /* __NEWLIB__ */
+#else
 struct zsock_timeval {
 	/* Using longs, as many (?) implementations seem to use it. */
 	long tv_sec;
 	long tv_usec;
 };
+#endif /* CONFIG_POSIX_API */
 
 typedef struct zsock_fd_set {
 	uint32_t bitset[(CONFIG_POSIX_MAX_FDS + 31) / 32];


### PR DESCRIPTION
Currently zsock_timeval implementation uses long type for both
tv_sec and tv_usec fields. In the select method timeval type is
directly casted on zsock_timeval, but in some cases (e.g. when
using CONFIG_POSIX_API and some specific libc version) both types
have fields of different sizes, what may lead to assigning them
incorrect values.
Using types declared by the used libc in the CONFIG_POSIX_API=y
case will let to keep timeval and zsock_timeval types compatible.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>