### PR TITLE
drivers: Bluetooth: rpmsg: Fix typo in BT_QUIRK_NO_AUTO_DLE use

### DIFF
--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -198,7 +198,7 @@ static const struct bt_hci_driver drv = {
 	.open		= bt_rpmsg_open,
 	.send		= bt_rpmsg_send,
 	.bus		= BT_HCI_DRIVER_BUS_IPM,
-#if defined(BT_DRIVER_QUIRK_NO_AUTO_DLE)
+#if defined(CONFIG_BT_DRIVER_QUIRK_NO_AUTO_DLE)
 	.quirks         = BT_QUIRK_NO_AUTO_DLE,
 #endif
 };


### PR DESCRIPTION
Use CONFIG_BT_QUIRK_NO_AUTO_DLE as quirk option's
conditional compilation check.

Regression introduced in commit bd7ee8649632 ("drivers:
Bluetooth: rpmsg: Add missing BT_QUIRK_NO_AUTO_DLE").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>