### PR TITLE
Bluetooth: Controller: Add common ULL ticker stop with mark function

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1675,30 +1675,16 @@ static void ticker_op_stop_cb(uint32_t status, void *param)
 
 static inline void disable(uint16_t handle)
 {
-	uint32_t volatile ret_cb;
 	struct ll_conn *conn;
-	void *mark;
-	uint32_t ret;
+	int err;
 
 	conn = ll_conn_get(handle);
 
-	mark = ull_disable_mark(conn);
-	LL_ASSERT(mark == conn);
-
-	ret_cb = TICKER_STATUS_BUSY;
-	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_CONN_BASE + handle,
-			  ull_ticker_status_give, (void *)&ret_cb);
-	ret = ull_ticker_status_take(ret, &ret_cb);
-	if (!ret) {
-		ret = ull_disable(&conn->lll);
-		LL_ASSERT(!ret);
-	}
+	err = ull_ticker_stop_with_mark(TICKER_ID_CONN_BASE + handle,
+					conn, &conn->lll);
+	LL_ASSERT(err == 0 || err == -EALREADY);
 
 	conn->lll.link_tx_free = NULL;
-
-	mark = ull_disable_unmark(conn);
-	LL_ASSERT(mark == conn);
 }
 
 static void conn_cleanup(struct ll_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -43,6 +43,8 @@ uint32_t ull_ticker_status_take(uint32_t ret, uint32_t volatile *ret_cb);
 void *ull_disable_mark(void *param);
 void *ull_disable_unmark(void *param);
 void *ull_disable_mark_get(void);
+int ull_ticker_stop_with_mark(uint8_t ticker_handle, void *param,
+			      void *lll_disable);
 void *ull_update_mark(void *param);
 void *ull_update_unmark(void *param);
 void *ull_update_mark_get(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -448,30 +448,14 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 
 uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 {
-	uint32_t volatile ret_cb;
-	void *mark;
-	uint32_t ret;
+	int err;
 
-	mark = ull_disable_mark(scan);
-	LL_ASSERT(mark == scan);
-
-	ret_cb = TICKER_STATUS_BUSY;
-	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			  TICKER_ID_SCAN_BASE + handle,
-			  ull_ticker_status_give, (void *)&ret_cb);
-	ret = ull_ticker_status_take(ret, &ret_cb);
-	if (ret) {
-		mark = ull_disable_unmark(scan);
-		LL_ASSERT(mark == scan);
-
+	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_BASE + handle,
+					scan, &scan->lll);
+	LL_ASSERT(err == 0 || err == -EALREADY);
+	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
-
-	ret = ull_disable(&scan->lll);
-	LL_ASSERT(!ret);
-
-	mark = ull_disable_unmark(scan);
-	LL_ASSERT(mark == scan);
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -259,6 +259,9 @@ uint8_t ll_sync_terminate(uint16_t handle)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+	ret = ull_disable(&sync->lll);
+	LL_ASSERT(!ret);
+
 	mark = ull_disable_unmark(sync);
 	LL_ASSERT(mark == sync);
 


### PR DESCRIPTION
The same code block for marking an object with
ull_disable_mark, stopping the ticker and then unmarking
the object appeared multiple places; often with a regression
bug where instread of unmarking it in case of error, it would
be "remarked".

This commit fixes the bug, and moves the functionality to
a common function.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>