### PR TITLE
boards: nrf5340dk_nrf5340: Fix arguments for jlink runners

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -10,11 +10,12 @@ endif()
 if((CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS) OR
   (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS))
 board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_APPLICATION")
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
 if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
 board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_NETWORK")
+board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
For the application core, the `--device` parameter specifies only
the generic `cortex-m33`, so it is impossible for the debugger to
flash the target.
For the network core, the `--device` parameter is not present at all,
so it is even impossible to run the `debug` command.

This commit fixes the above issues by specifying the proper devices.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>