### PR TITLE
buildkite: update pipeline to use new dockerfiles release

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.4"
     parallelism: 240
     timeout_in_minutes: 210
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.11.8"
+          image: "zephyrprojectrtos/ci:v0.11.10"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.3"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.4"
     parallelism: 50
     timeout_in_minutes: 180
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.11.8"
+          image: "zephyrprojectrtos/ci:v0.11.10"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -49,13 +49,6 @@ echo ""
 echo "--- ccache stats at start"
 ccache -s
 
-# Temporary fix: Install lpc_checksum, needed to build images for
-# lpcxpresso11u68 boards
-pip3 install lpc_checksum
-
-# Temporary fix: Install imgtool, needed for MCUboot to sign images
-# when builindg the TF-M integration samples
-pip3 install imgtool
 
 if [ -n "${DAILY_BUILD}" ]; then
    SANITYCHECK_OPTIONS=" --inline-logs -N --build-only --all --retry-failed 3 -v "


### PR DESCRIPTION
Update buildkite to use dockerfiles release 0.11.10.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

This bumps cmake version to 3.15.7