### PR TITLE
soc: mec1501: don't enable SoC timing funcs if CORTEX_M_DWT

### DIFF
--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -22,7 +22,7 @@ config MCHP_XEC_RTOS_TIMER
 	default y
 
 config SOC_HAS_TIMING_FUNCTIONS
-	default y
+	default y if !CORTEX_M_DWT
 
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y


### PR DESCRIPTION
In CMakeLists.txt, the MEC1501 specific timing functions are
only compiled if CONFIG_CORTEX_M_DWT=n. However, in SoC's
kconfig, CONFIG_SOC_HAS_TIMING_FUNCTIONS is defaulted to y
unconditionally. This results in the timing subsys looking
for SoC-based timing functions but those are not compiled.
So add a condition to kconfig similar to CMakeLists.txt where
SoC timing functions are only enabled when CONFIG_CORTEX_M_DWT=n.

Fixes #29969

Signed-off-by: Daniel Leung <daniel.leung@intel.com>