### PR TITLE
samples: led_ws2812: force SPIM on nRF52-DK

### DIFF
--- a/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.conf
+++ b/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,5 @@
+CONFIG_SPI=y
+
+# This driver only uses spi_write() with the SPIM instance it allocates,
+# so PAN 58 doesn't matter, because the RX length is always 0.
+CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58=y

--- a/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
+++ b/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
@@ -7,6 +7,7 @@
 #include "../nrf52-bindings.h"
 
 &arduino_spi { /* MOSI on D11 / P0.23 */
+	compatible = "nordic,nrf-spim";
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
 		label = "WS2812";


### PR DESCRIPTION
The WS2812 SPI driver needs the pixel data to be clocked out on time,
with no gaps between SPI frames. This makes the nordic,nrf-spi
compatible unsuitable for use, since the corresponding driver doesn't
use EasyDMA to clock out the tx buffers.

Force the arduino_spi node in the DT to SPIM mode by setting its
compatible to nordic,nrf-spim. On nRF52832, this driver is disabled by
default due to Product Anomaly Notice (PAN) 58.

We happen to not be affected by PAN 58 in this instance, because we
never read data over the SPIM, only write it. So it's safe to enable
the SPIM driver. This requires a board-specific Kconfig fragment for
nRF52-DK to enable CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58.

Fixes: #29877
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>