### PR TITLE
Zephyr board revision feature

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -397,7 +397,7 @@ if(DEFINED CONF_FILE)
     # Need path in order to check if it is absolute.
     get_filename_component(CONF_FILE_NAME ${CONF_FILE} NAME)
     get_filename_component(CONF_FILE_DIR ${CONF_FILE} DIRECTORY)
-    if(${CONF_FILE} MATCHES "prj_(.*).conf")
+    if(${CONF_FILE_NAME} MATCHES "prj_(.*).conf")
       if(NOT IS_ABSOLUTE ${CONF_FILE_DIR})
         set(CONF_FILE_DIR ${APPLICATION_SOURCE_DIR}/${CONF_FILE_DIR})
       endif()

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -182,66 +182,9 @@ add_custom_target(
 # Dummy add to generate files.
 zephyr_linker_sources(SECTIONS)
 
-# The BOARD can be set by 3 sources. Through environment variables,
-# through the cmake CLI, and through CMakeLists.txt.
-#
-# CLI has the highest precedence, then comes environment variables,
-# and then finally CMakeLists.txt.
-#
-# A user can ignore all the precedence rules if he simply always uses
-# the same source. E.g. always specifies -DBOARD= on the command line,
-# always has an environment variable set, or always has a set(BOARD
-# foo) line in his CMakeLists.txt and avoids mixing sources.
-#
-# The selected BOARD can be accessed through the variable 'BOARD'.
+# Check that BOARD has been provided, and that it has not changed.
+zephyr_check_cache(BOARD REQUIRED)
 
-# Read out the cached board value if present
-get_property(cached_board_value CACHE BOARD PROPERTY VALUE)
-
-# There are actually 4 sources, the three user input sources, and the
-# previously used value (CACHED_BOARD). The previously used value has
-# precedence, and if we detect that the user is trying to change the
-# value we give him a warning about needing to clean the build
-# directory to be able to change boards.
-
-set(board_cli_argument ${cached_board_value}) # Either new or old
-if(board_cli_argument STREQUAL CACHED_BOARD)
-  # We already have a CACHED_BOARD so there is no new input on the CLI
-  unset(board_cli_argument)
-endif()
-
-set(board_app_cmake_lists ${BOARD})
-if(cached_board_value STREQUAL BOARD)
-  # The app build scripts did not set a default, The BOARD we are
-  # reading is the cached value from the CLI
-  unset(board_app_cmake_lists)
-endif()
-
-if(CACHED_BOARD)
-  # Warn the user if it looks like he is trying to change the board
-  # without cleaning first
-  if(board_cli_argument)
-    if(NOT ((CACHED_BOARD STREQUAL board_cli_argument) OR (BOARD_DEPRECATED STREQUAL board_cli_argument)))
-      message(WARNING "The build directory must be cleaned pristinely when changing boards")
-      # TODO: Support changing boards without requiring a clean build
-    endif()
-  endif()
-
-  set(BOARD ${CACHED_BOARD})
-elseif(board_cli_argument)
-  set(BOARD ${board_cli_argument})
-
-elseif(DEFINED ENV{BOARD})
-  set(BOARD $ENV{BOARD})
-
-elseif(board_app_cmake_lists)
-  set(BOARD ${board_app_cmake_lists})
-
-else()
-  message(FATAL_ERROR "BOARD is not being defined on the CMake command-line in the environment or by the app.")
-endif()
-
-assert(BOARD "BOARD not set")
 message(STATUS "Board: ${BOARD}")
 
 if(DEFINED ENV{ZEPHYR_BOARD_ALIASES})
@@ -259,67 +202,8 @@ if(${BOARD}_DEPRECATED)
   message(WARNING "Deprecated BOARD=${BOARD_DEPRECATED} name specified, board automatically changed to: ${BOARD}.")
 endif()
 
-# Store the selected board in the cache
-set(CACHED_BOARD ${BOARD} CACHE STRING "Selected board")
-
-# The SHIELD can be set by 3 sources. Through environment variables,
-# through the cmake CLI, and through CMakeLists.txt.
-#
-# CLI has the highest precedence, then comes environment variables,
-# and then finally CMakeLists.txt.
-#
-# A user can ignore all the precedence rules if he simply always uses
-# the same source. E.g. always specifies -DSHIELD= on the command line,
-# always has an environment variable set, or always has a set(SHIELD
-# foo) line in his CMakeLists.txt and avoids mixing sources.
-#
-# The selected SHIELD can be accessed through the variable 'SHIELD'.
-
-# Read out the cached shield value if present
-get_property(cached_shield_value CACHE SHIELD PROPERTY VALUE)
-
-# There are actually 4 sources, the three user input sources, and the
-# previously used value (CACHED_SHIELD). The previously used value has
-# precedence, and if we detect that the user is trying to change the
-# value we give him a warning about needing to clean the build
-# directory to be able to change shields.
-
-set(shield_cli_argument ${cached_shield_value}) # Either new or old
-if(shield_cli_argument STREQUAL CACHED_SHIELD)
-  # We already have a CACHED_SHIELD so there is no new input on the CLI
-  unset(shield_cli_argument)
-endif()
-
-set(shield_app_cmake_lists ${SHIELD})
-if(cached_shield_value STREQUAL SHIELD)
-  # The app build scripts did not set a default, The SHIELD we are
-  # reading is the cached value from the CLI
-  unset(shield_app_cmake_lists)
-endif()
-
-if(CACHED_SHIELD)
-  # Warn the user if it looks like he is trying to change the shield
-  # without cleaning first
-  if(shield_cli_argument)
-    if(NOT (CACHED_SHIELD STREQUAL shield_cli_argument))
-      message(WARNING "The build directory must be cleaned pristinely when changing shields")
-      # TODO: Support changing shields without requiring a clean build
-    endif()
-  endif()
-
-  set(SHIELD ${CACHED_SHIELD})
-elseif(shield_cli_argument)
-  set(SHIELD ${shield_cli_argument})
-
-elseif(DEFINED ENV{SHIELD})
-  set(SHIELD $ENV{SHIELD})
-
-elseif(shield_app_cmake_lists)
-  set(SHIELD ${shield_app_cmake_lists})
-endif()
-
-# Store the selected shield in the cache
-set(CACHED_SHIELD ${SHIELD} CACHE STRING "Selected shield")
+# Check that SHIELD has not changed.
+zephyr_check_cache(SHIELD)
 
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority.

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -294,28 +294,11 @@ foreach(root ${BOARD_ROOT})
         shield_dts_files
         ${shield_dir}/${s_path}
         )
+
       list(APPEND
         shield_dts_fixups
         ${shield_dir}/${s_dir}/dts_fixup.h
         )
-
-      # search for shield/boards/board.overlay file
-      if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.overlay)
-        # add shield/board overlay to the shield overlays list
-        list(APPEND
-          shield_dts_files
-          ${shield_dir}/${s_dir}/boards/${BOARD}.overlay
-          )
-      endif()
-
-      # search for shield/boards/shield/board.overlay file
-      if(EXISTS ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay)
-        # add shield/board overlay to the shield overlays list
-        list(APPEND
-          shield_dts_files
-          ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay
-          )
-      endif()
 
       # search for shield/shield.conf file
       if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)
@@ -326,23 +309,14 @@ foreach(root ${BOARD_ROOT})
           )
       endif()
 
-      # search for shield/boards/board.conf file
-      if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.conf)
-        # add HW specific board.conf to the shield config list
-        list(APPEND
-          shield_conf_files
-          ${shield_dir}/${s_dir}/boards/${BOARD}.conf
-          )
-      endif()
-
-      # search for shield/boards/shield/board.conf file
-      if(EXISTS ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.conf)
-        # add HW specific board.conf to the shield config list
-        list(APPEND
-          shield_conf_files
-          ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.conf
-          )
-      endif()
+      zephyr_file(CONF_FILES ${shield_dir}/${s_dir}/boards
+                  DTS   shield_dts_files
+                  KCONF shield_conf_files
+      )
+      zephyr_file(CONF_FILES ${shield_dir}/${s_dir}/boards/${s}
+                  DTS   shield_dts_files
+                  KCONF shield_conf_files
+      )
     endforeach()
   endif()
 endforeach()
@@ -401,9 +375,7 @@ if(DEFINED CONF_FILE)
       if(NOT IS_ABSOLUTE ${CONF_FILE_DIR})
         set(CONF_FILE_DIR ${APPLICATION_SOURCE_DIR}/${CONF_FILE_DIR})
       endif()
-      if(EXISTS ${CONF_FILE_DIR}/boards/${BOARD}_${CMAKE_MATCH_1}.conf)
-        list(APPEND CONF_FILE ${CONF_FILE_DIR}/boards/${BOARD}_${CMAKE_MATCH_1}.conf)
-      endif()
+      zephyr_file(CONF_FILES ${CONF_FILE_DIR}/boards KCONF CONF_FILE BUILD ${CMAKE_MATCH_1})
     endif()
   endif()
 elseif(CACHED_CONF_FILE)

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -182,8 +182,30 @@ add_custom_target(
 # Dummy add to generate files.
 zephyr_linker_sources(SECTIONS)
 
+# 'BOARD_ROOT' is a prioritized list of directories where boards may
+# be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+zephyr_file(APPLICATION_ROOT BOARD_ROOT)
+list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
+
+# 'SOC_ROOT' is a prioritized list of directories where socs may be
+# found. It always includes ${ZEPHYR_BASE}/soc at the lowest priority.
+zephyr_file(APPLICATION_ROOT SOC_ROOT)
+list(APPEND SOC_ROOT ${ZEPHYR_BASE})
+
+# 'ARCH_ROOT' is a prioritized list of directories where archs may be
+# found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+zephyr_file(APPLICATION_ROOT ARCH_ROOT)
+list(APPEND ARCH_ROOT ${ZEPHYR_BASE})
+
 # Check that BOARD has been provided, and that it has not changed.
 zephyr_check_cache(BOARD REQUIRED)
+
+string(FIND "${BOARD}" "@" REVIVISION_SEPARATOR_INDEX)
+if(NOT (REVIVISION_SEPARATOR_INDEX EQUAL -1))
+  math(EXPR BOARD_REVISION_INDEX "${REVIVISION_SEPARATOR_INDEX} + 1")
+  string(SUBSTRING ${BOARD} ${BOARD_REVISION_INDEX} -1 BOARD_REVISION)
+  string(SUBSTRING ${BOARD} 0 ${REVIVISION_SEPARATOR_INDEX} BOARD)
+endif()
 
 set(BOARD_MESSAGE "Board: ${BOARD}")
 
@@ -202,40 +224,6 @@ if(${BOARD}_DEPRECATED)
   message(WARNING "Deprecated BOARD=${BOARD_DEPRECATED} name specified, board automatically changed to: ${BOARD}.")
 endif()
 
-# Check that SHIELD has not changed.
-zephyr_check_cache(SHIELD)
-
-if(SHIELD)
-  set(BOARD_MESSAGE "${BOARD_MESSAGE}, Shield(s): ${SHIELD}")
-endif()
-
-message(STATUS "${BOARD_MESSAGE}")
-
-# 'BOARD_ROOT' is a prioritized list of directories where boards may
-# be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
-zephyr_file(APPLICATION_ROOT BOARD_ROOT)
-list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
-
-# 'SOC_ROOT' is a prioritized list of directories where socs may be
-# found. It always includes ${ZEPHYR_BASE}/soc at the lowest priority.
-zephyr_file(APPLICATION_ROOT SOC_ROOT)
-list(APPEND SOC_ROOT ${ZEPHYR_BASE})
-
-# 'ARCH_ROOT' is a prioritized list of directories where archs may be
-# found. It always includes ${ZEPHYR_BASE} at the lowest priority.
-zephyr_file(APPLICATION_ROOT ARCH_ROOT)
-list(APPEND ARCH_ROOT ${ZEPHYR_BASE})
-
-if(DEFINED SHIELD)
-  string(REPLACE " " ";" SHIELD_AS_LIST "${SHIELD}")
-endif()
-# SHIELD-NOTFOUND is a real CMake list, from which valid shields can be popped.
-# After processing all shields, only invalid shields will be left in this list.
-set(SHIELD-NOTFOUND ${SHIELD_AS_LIST})
-
-# Use BOARD to search for a '_defconfig' file.
-# e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig.
-# When found, use that path to infer the ARCH we are building for.
 foreach(root ${BOARD_ROOT})
   # NB: find_path will return immediately if the output variable is
   # already set
@@ -257,7 +245,46 @@ foreach(root ${BOARD_ROOT})
   if(BOARD_DIR AND NOT (${root} STREQUAL ${ZEPHYR_BASE}))
     set(USING_OUT_OF_TREE_BOARD 1)
   endif()
+endforeach()
 
+if(EXISTS ${BOARD_DIR}/revision.cmake)
+  # Board provides revision handling.
+  include(${BOARD_DIR}/revision.cmake)
+elseif(BOARD_REVISION)
+  message(WARNING "Board revision ${BOARD_REVISION} specified for ${BOARD}, \
+                   but board has no revision so revision will be ignored.")
+endif()
+
+if(DEFINED BOARD_REVISION)
+  set(BOARD_MESSAGE "${BOARD_MESSAGE}, Revision: ${BOARD_REVISION}")
+  if(DEFINED ACTIVE_BOARD_REVISION)
+    set(BOARD_MESSAGE "${BOARD_MESSAGE} (Active: ${ACTIVE_BOARD_REVISION})")
+    set(BOARD_REVISION ${ACTIVE_BOARD_REVISION})
+  endif()
+
+  string(REPLACE "." "_" BOARD_REVISION_STRING ${BOARD_REVISION})
+endif()
+
+# Check that SHIELD has not changed.
+zephyr_check_cache(SHIELD)
+
+if(SHIELD)
+  set(BOARD_MESSAGE "${BOARD_MESSAGE}, Shield(s): ${SHIELD}")
+endif()
+
+message(STATUS "${BOARD_MESSAGE}")
+
+if(DEFINED SHIELD)
+  string(REPLACE " " ";" SHIELD_AS_LIST "${SHIELD}")
+endif()
+# SHIELD-NOTFOUND is a real CMake list, from which valid shields can be popped.
+# After processing all shields, only invalid shields will be left in this list.
+set(SHIELD-NOTFOUND ${SHIELD_AS_LIST})
+
+# Use BOARD to search for a '_defconfig' file.
+# e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig.
+# When found, use that path to infer the ARCH we are building for.
+foreach(root ${BOARD_ROOT})
   set(shield_dir ${root}/boards/shields)
   # Match the .overlay files in the shield directories to make sure we are
   # finding shields, e.g. x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -372,10 +399,12 @@ if(DEFINED CONF_FILE)
     get_filename_component(CONF_FILE_NAME ${CONF_FILE} NAME)
     get_filename_component(CONF_FILE_DIR ${CONF_FILE} DIRECTORY)
     if(${CONF_FILE_NAME} MATCHES "prj_(.*).conf")
+      set(CONF_FILE_BUILD_TYPE ${CMAKE_MATCH_1})
+      set(CONF_FILE_INCLUDE_FRAGMENTS true)
+
       if(NOT IS_ABSOLUTE ${CONF_FILE_DIR})
         set(CONF_FILE_DIR ${APPLICATION_SOURCE_DIR}/${CONF_FILE_DIR})
       endif()
-      zephyr_file(CONF_FILES ${CONF_FILE_DIR}/boards KCONF CONF_FILE BUILD ${CMAKE_MATCH_1})
     endif()
   endif()
 elseif(CACHED_CONF_FILE)
@@ -393,11 +422,16 @@ elseif(COMMAND set_conf_file)
 elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
   set(CONF_FILE ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
 
-elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
-  set(CONF_FILE ${APPLICATION_SOURCE_DIR}/prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
-
 elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/prj.conf)
   set(CONF_FILE ${APPLICATION_SOURCE_DIR}/prj.conf)
+  set(CONF_FILE_INCLUDE_FRAGMENTS true)
+endif()
+
+if(CONF_FILE_INCLUDE_FRAGMENTS)
+  if(NOT CONF_FILE_DIR)
+     set(CONF_FILE_DIR ${APPLICATION_SOURCE_DIR})
+  endif()
+  zephyr_file(CONF_FILES ${CONF_FILE_DIR}/boards KCONF CONF_FILE BUILD ${CONF_FILE_BUILD_TYPE})
 endif()
 
 set(CACHED_CONF_FILE ${CONF_FILE} CACHE STRING "If desired, you can build the application using\
@@ -424,6 +458,9 @@ elseif(DEFINED ENV{DTC_OVERLAY_FILE})
   set(DTC_OVERLAY_FILE $ENV{DTC_OVERLAY_FILE})
 elseif(EXISTS          ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.overlay)
   set(DTC_OVERLAY_FILE ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.overlay)
+elseif((DEFINED BOARD_REVISION) AND
+       EXISTS          ${APPLICATION_SOURCE_DIR}/${BOARD}_${BOARD_REVISION_STRING}.overlay)
+  set(DTC_OVERLAY_FILE ${APPLICATION_SOURCE_DIR}/${BOARD}_${BOARD_REVISION_STRING}.overlay)
 elseif(EXISTS          ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)
   set(DTC_OVERLAY_FILE ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)
 elseif(EXISTS          ${APPLICATION_SOURCE_DIR}/app.overlay)

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -185,7 +185,7 @@ zephyr_linker_sources(SECTIONS)
 # Check that BOARD has been provided, and that it has not changed.
 zephyr_check_cache(BOARD REQUIRED)
 
-message(STATUS "Board: ${BOARD}")
+set(BOARD_MESSAGE "Board: ${BOARD}")
 
 if(DEFINED ENV{ZEPHYR_BOARD_ALIASES})
   include($ENV{ZEPHYR_BOARD_ALIASES})
@@ -204,6 +204,12 @@ endif()
 
 # Check that SHIELD has not changed.
 zephyr_check_cache(SHIELD)
+
+if(SHIELD)
+  set(BOARD_MESSAGE "${BOARD_MESSAGE}, Shield(s): ${SHIELD}")
+endif()
+
+message(STATUS "${BOARD_MESSAGE}")
 
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority.

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -45,18 +45,21 @@ list(REMOVE_DUPLICATES
   DTS_ROOT
   )
 
-set(dts_files
-  ${DTS_SOURCE}
-  ${shield_dts_files}
-  )
-
 # TODO: What to do about non-posix platforms where NOT CONFIG_HAS_DTS (xtensa)?
 # Drop support for NOT CONFIG_HAS_DTS perhaps?
 if(EXISTS ${DTS_SOURCE})
   set(SUPPORTS_DTS 1)
+  if(BOARD_REVISION AND EXISTS ${BOARD_DIR}/${BOARD}_${BOARD_REVISION_STRING}.overlay)
+    list(APPEND DTS_SOURCE ${BOARD_DIR}/${BOARD}_${BOARD_REVISION_STRING}.overlay)
+  endif()
 else()
   set(SUPPORTS_DTS 0)
 endif()
+
+set(dts_files
+  ${DTS_SOURCE}
+  ${shield_dts_files}
+  )
 
 if(SUPPORTS_DTS)
   if(DTC_OVERLAY_FILE)

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -55,6 +55,10 @@ if(OVERLAY_CONFIG)
   string(REPLACE " " ";" OVERLAY_CONFIG_AS_LIST "${OVERLAY_CONFIG}")
 endif()
 
+if((DEFINED BOARD_REVISION) AND EXISTS ${BOARD_DIR}/${BOARD}_${BOARD_REVISION_STRING}.conf)
+  list(INSERT CONF_FILE_AS_LIST 0 ${BOARD_DIR}/${BOARD}_${BOARD_REVISION_STRING}.conf)
+endif()
+
 # DTS_ROOT_BINDINGS is a semicolon separated list, this causes
 # problems when invoking kconfig_target since semicolon is a special
 # character in the C shell, so we make it into a question-mark

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -486,6 +486,36 @@ following procedure:
 #. Rebuild the application normally following the steps specified
    in :ref:`build_an_application` above.
 
+.. _application_board_version:
+
+Building for a board revision
+=============================
+
+The Zephyr build system has support for specifying multiple hardware revisions
+of a single board with small variations. Using revisions allows the board
+support files to make minor adjustments to a board configuration without
+duplicating all the files described in :ref:`create-your-board-directory` for
+each revision.
+
+To build for a particular revision, use ``<board>@<revision>`` instead of plain
+``<board>``. For example:
+
+.. zephyr-app-commands::
+   :tool: all
+   :cd-into:
+   :board: <board>@<revision>
+   :goals: build
+   :compact:
+
+Check your board's documentation for details on whether it has multiple
+revisions, and what revisions are supported.
+
+When targeting a board revision, the active revision will be printed at CMake
+configure time, like this:
+
+.. code-block:: console
+
+   -- Board: plank, Revision: 1.5.0
 
 .. _application_run:
 

--- a/doc/guides/kconfig/setting.rst
+++ b/doc/guides/kconfig/setting.rst
@@ -159,7 +159,12 @@ The application configuration can come from the sources below. By default,
 4. Otherwise, if :file:`boards/<BOARD>.conf` exists in the application
    directory, the result of merging it with :file:`prj.conf` is used.
 
-5. Otherwise, :file:`prj.conf` is used if it exists in the application
+5. Otherwise, if board revisions are used and
+   :file:`boards/<BOARD>_<revision>.conf` exists in the application
+   directory, the result of merging it with :file:`prj.conf` and
+   :file:`boards/<BOARD>.conf` is used.
+
+6. Otherwise, :file:`prj.conf` is used if it exists in the application
    directory
 
 If a symbol is assigned both in :file:`<BOARD>_defconfig` and in the

--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -379,6 +379,11 @@ named ``plank``:
      CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=120000000   /* set up your clock, etc */
      CONFIG_SERIAL=y
 
+:file:`plank_x_y_z.conf`
+  A Kconfig fragment that is merged as-is into the final build directory
+  :file:`.config` whenever an application is compiled for your board revision
+  ``x.y.z``.
+
 Build, test, and fix
 ********************
 
@@ -502,6 +507,202 @@ first ``include`` sets the default runner if it's not already set. For example,
 including ``nrfjprog.board.cmake`` first means that ``nrjfprog`` is the default
 flash runner for this board. Since ``nrfjprog`` does not support debugging,
 ``jlink`` is the default debug runner.
+
+.. _porting_board_revisions:
+
+Multiple board revisions
+************************
+
+See :ref:`application_board_version` for basics on this feature from the user
+perspective.
+
+To create a new board revision for the ``plank`` board, create these additional
+files in the board folder:
+
+.. code-block:: none
+
+   boards/<ARCH>/plank
+   ├── plank_<revision>.conf
+   ├── plank_<revision>.overlay  # optional
+   └── revision.cmake
+
+When the user builds for board ``plank@<revision>``:
+
+- Additional Kconfig settings specified in the file
+  :file:`plank_<revision>.conf` will be merged into the board's default Kconfig
+  configuration.
+
+- The optional devicetree overlay :file:`plank_<revision>.overlay` will be added
+  to the common :file:`plank.dts` devicetree file
+
+- The :file:`revision.cmake` file controls how the Zephyr build system matches
+  the ``<board>@<revision>`` string specified by the user when building an
+  application for the board.
+
+.. important::
+
+   If you only need a devicetree overlay, you must still create an empty
+   :file:`<board>_<revision>.conf` file.
+
+Currently, ``<revision>`` can be either a numeric ``MAJOR.MINOR.PATCH`` style
+revision like ``1.5.0``, or single letter like ``A``, ``B``, etc. Zephyr
+provides a CMake board extension function, ``board_check_revision()``, to make
+it easy to match either style from :file:`revision.cmake`.
+
+The following sections describe how to support these styles of revision
+numbers.
+
+Numeric revisions
+=================
+
+Let's say you want to add support for revisions ``0.5.0``, ``1.0.0``, and
+``1.5.0`` of the ``plank`` board. Create :file:`revision.cmake` with
+``board_check_revision(FORMAT MAJOR.MINOR.PATCH)``, and create the following
+additional files in the board directory:
+
+.. code-block:: none
+
+   boards/<ARCH>/plank
+   ├── plank_0_5_0.conf
+   ├── plank_0_5_0.overlay  # optional
+   ├── plank_1_0_0.conf
+   ├── plank_1_0_0.overlay  # optional
+   ├── plank_1_5_0.conf
+   ├── plank_1_5_0.overlay  # optional
+   └── revision.cmake
+
+Notice how the board files have changed periods (".") in the revision number to
+underscores ("_").
+
+Fuzzy numeric revision matching
+===============================
+
+To support "fuzzy" ``MAJOR.MINOR.PATCH`` revision matching for the ``plank``
+board, use the following code in :file:`revision.cmake`:
+
+.. code-block:: cmake
+
+   board_check_revision(FORMAT MAJOR.MINOR.PATCH)
+
+If the user selects a revision between those available, the closest revision
+number that is not larger than the user's choice is used. For example, if the
+user builds for ``plank@0.7.0``, the build system will target revision
+``0.5.0``.
+
+The build system will print this at CMake configuration time:
+
+.. code-block:: console
+
+   -- Board: plank, Revision: 0.7.0 (Active: 0.5.0)
+
+This allows you to only create revision configuration files for board revision
+numbers that introduce incompatible changes.
+
+Any revision less than the minimum defined will be treated as an error.
+
+You may use ``0.0.0`` as a minimum revision to build for by creating the file
+:file:`plank_0_0_0.conf` in the board directory. This will be used for any
+revision lower than ``0.5.0``, for example if the user builds for
+``plank@0.1.0``.
+
+Exact numeric revision matching
+===============================
+
+Alternatively, the ``EXACT`` keyword can be given to ``board_check_revision()``
+in :file:`revision.cmake` to allow exact matches only, like this:
+
+.. code-block:: cmake
+
+   board_check_revision(FORMAT MAJOR.MINOR.PATCH EXACT)
+
+With this :file:`revision.cmake`, building for ``plank@0.7.0`` in the above
+example will result in the following error message:
+
+.. code-block:: console
+
+   Board revision `0.7.0` not found.  Please specify a valid board revision.
+
+Letter revision matching
+========================
+
+Let's say instead that you need to support revisions ``A``, ``B``, and ``C`` of
+the ``plank`` board. Create the following additional files in the board
+directory:
+
+.. code-block:: none
+
+   boards/<ARCH>/plank
+   ├── plank_A.conf
+   ├── plank_A.overlay  # optional
+   ├── plank_B.conf
+   ├── plank_B.overlay  # optional
+   ├── plank_C.conf
+   ├── plank_C.overlay  # optional
+   └── revision.cmake
+
+And add the following to :file:`revision.cmake`:
+
+.. code-block:: cmake
+
+   board_check_revision(FORMAT LETTER)
+
+board_check_revision() details
+==============================
+
+.. code-block:: cmake
+
+   board_check_revision(FORMAT <LETTER | MAJOR.MINOR.PATCH>
+                        [EXACT]
+                        [DEFAULT_REVISION <revision>]
+                        [HIGHEST_REVISION <revision>]
+   )
+
+This function supports the following arguments:
+
+* ``FORMAT LETTER``: matches single letter revisions from ``A`` to ``Z`` only
+* ``FORMAT MAJOR.MINOR.PATCH``: matches exactly three digits. The command line
+  allows for loose typing, that is ``-DBOARD=<board>@1`` and
+  ``-DBOARD=<board>@1.0`` will be handled as ``-DBOARD=<board>@1.0.0``.
+  Kconfig fragment and devicetree overlay files must use full numbering to avoid
+  ambiguity, so only :file:`<board>_1_0_0.conf` and
+  :file:`<board>_1_0_0.overlay` are allowed.
+
+* ``EXACT``: if given, the revision is required to be an exact match.
+  Otherwise, the closest matching revision not greater than the user's choice
+  will be selected.
+
+* ``DEFAULT_REVISION <revision>``: if given, ``<revision>`` is the default
+  revision to use when user has not selected a revision number. If not given,
+  the build system prints an error when the user does not specify a board
+  revision.
+
+* ``HIGHEST_REVISION``: if given, specifies the highest valid revision for a
+  board. This can be used to ensure that a newer board cannot be used with an
+  older Zephyr. For example, if the current board directory supports revisions
+  0.x.0-0.99.99 and 1.0.0-1.99.99, and it is expected that the implementation
+  will not work with board revision 2.0.0, then giving ``HIGHEST_REVISION
+  1.99.99`` causes an error if the user builds using ``<board>@2.0.0``.
+
+.. _porting_custom_board_revisions:
+
+Custom revision.cmake files
+***************************
+
+Some boards may not use board revisions supported by
+``board_check_revision()``. To support revisions of any type, the file
+:file:`revision.cmake` can implement custom revision matching without calling
+``board_check_revision()``.
+
+To signal to the build system that it should use a different revision than the
+one specified by the user, :file:`revision.cmake` can set the variable
+``ACTIVE_BOARD_REVISION`` to the revision to use instead. The corresponding
+Kconfig files and devicetree overlays must be named
+:file:`<board>_<ACTIVE_BOARD_REVISION>.conf` and
+:file:`<board>_<ACTIVE_BOARD_REVISION>.overlay`.
+
+For example, if the user builds for ``plank@zero``, :file:`revision.cmake` can
+set ``ACTIVE_BOARD_REVISION`` to ``one`` to use the files
+:file:`plank_one.conf` and :file:`plank_one.overlay`.
 
 .. _contributing-your-board:
 


### PR DESCRIPTION
First 4 commits are general cleanup and fixes in existing CMake board code, before introducing board revision.

-------

This PR introduces revisions for Zephyr board.

This can be controlled using: `-DBOARD=<board>@<revision>`.
Today, a user must duplicate several files, even for changing just a single Kconfig default value, if wanting to introduce a new revision of existing board.

Also, this means that multiple boards, that are basically just variants of each other, will show up in the `west boards` list.

Using `-BOARD=<board>@<revision>` provides a uniform way of making minor adjustment to a board.
Also it allows a sample to just make one board adjustment.

As example, the reel board could have reused the same `reel_board_defconfig` and `reel_board.dts` and just supplied a `reel_board_2_0_0.overlay` file.

With today's solution, it means that a new board revision also requires new Kconfig fragments, as seen:
https://github.com/zephyrproject-rtos/zephyr/blob/master/samples/display/cfb/boards/reel_board.conf
https://github.com/zephyrproject-rtos/zephyr/blob/master/samples/display/cfb/boards/reel_board_v2.conf

even if they are identical.

With this PR, those two files would become a single file, and only if two revision requires different values, then user can create a 
`boards/reel_board.conf` and `boards/reel_board_2_0_0.conf`

To use the new revision scheme, a `revision.cmake` must be placed in the boards folder.
A `board_check_revision` extension function is available to facilitate revision handling for common use-case.
For special use-cases a board maintainer can decide to implement custom revision handling directly in the `<board>/revision.cmake` file.

------

    This commit introduces support for versioning of boards.
    The existing board handling is limited in such a way that it is not
    possible to support a specific board in multiple variants.
    
    This commit introduces versioning of board revisions so that it is
    possible to support minor variations to a board without having to
    defining a completely new board.
    
    This can be done by adding a revision.cmake file in the board folder:
    `boards/<arch>/<board-dir>/revision.cmake`
    
    Depending on the revision format chosen, additional configuration files
    for each revision available must also be added, those have the form:
    `boards/<arch>/<board-dir>/<board>_<revision>.conf`
    
    Examples:
    `boards/<arch>/<board-dir>/<board>_defconfig`:  Common board settings
    
    Revision format: MAJOR.MINOR.PATCH
    `boards/<arch>/<board-dir>/<board>_0_5_0.conf`: Revision 0.5.0
    `boards/<arch>/<board-dir>/<board>_1_0_0.conf`: Revision 1.0.0
    `boards/<arch>/<board-dir>/<board>_1_5_0.conf`: Revision 1.5.0
    
    Revision format: LETTER
    `boards/<arch>/<board-dir>/<board>_A.conf`:     Revision A
    `boards/<arch>/<board-dir>/<board>_B.conf`:     Revision B
    
    The `board_check_revision` function is available in `extensions.cmake`
    to facilitate board revision handling in `revision.cmake`.
    
    User select the board revision using: `-DBOARD=<board>@<revision>`, as
    example `-DBOARD=plank@0.5.0`.
    
    If a shield, test, sample, or application needs to specify DTS overlay
    or Kconfig fragments, this can be done by adding revision specific
    configuration files in the sample/test/shield folder, like this:
    `<shield/sample-path>/boards/<board>.conf`
    `<shield/sample-path>/boards/<board>_<revision>.conf`
    
    or if there is there is only a need for adjusting on a given board
    revision:
    `<shield/sample-path>/boards/<board>_<revision>.conf`
    
    Similar for DTS overlay files:
    `<shield-path>/boards/<board>.overlay`
    `<shield-path>/boards/<board>_<revision>.overlay`
    
    or:
    `<shield-path>/boards/<board>_<revision>.conf`
    
    For test/samples/apps:
    `<sample-path>/<board>.overlay`
    `<sample-path>/<board>_<revision>.overlay`
   
    or:
    `<sample-path>/<board>_<revision>.overlay`

**edit** Description update according to latest changes wrt. review feedback