### PR TITLE
modules: hal_nordic: Update nrfx to version 2.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 844f117c70ffdd5c119b33731ab4fd285e524aee
+      revision: pull/66/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
Update the hal_nordic module revision, to switch to nrfx v2.4.0.

See https://github.com/zephyrproject-rtos/hal_nordic/pull/66.