### PR TITLE
Bluetooth: mesh: Fix use of deprecated scan parameter filter_dup

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -299,7 +299,7 @@ int bt_mesh_scan_enable(void)
 {
 	struct bt_le_scan_param scan_param = {
 			.type       = BT_HCI_LE_SCAN_PASSIVE,
-			.filter_dup = BT_LE_SCAN_OPT_NONE,
+			.options    = BT_LE_SCAN_OPT_NONE,
 			.interval   = MESH_SCAN_INTERVAL,
 			.window     = MESH_SCAN_WINDOW };
 	int err;


### PR DESCRIPTION
Fix use of deprecated scan parameter filter_dup.
Should have been changed to options as part of:
be57dfbe2a57afb6c1533e0ded0d27f9690c1bb7

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>