### PR TITLE
doc: fix Kconfig.shield sourcing build issue

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -213,6 +213,12 @@ file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc.defconfig
 file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc
      "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.soc\"\n"
 )
+file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.shield.defconfig
+     "osource \"${ZEPHYR_BASE}/boards/shields/*/Kconfig.defconfig\"\n"
+)
+file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.shield
+     "osource \"${ZEPHYR_BASE}/boards/shields/*/Kconfig.shield\"\n"
+)
 file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc.arch
      "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/Kconfig\"\n"
      "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig\"\n"


### PR DESCRIPTION
Fix documentation build issue where generating the kconfig rST was failing due to missing Kconfig.shield* files. Add an extra step in CMakeLists.txt to properly generate them, similarly to what is already done for Kconfig.soc*.