### PR TITLE
kernel: add k_heap_aligned_alloc

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4433,6 +4433,25 @@ struct k_heap {
  */
 void k_heap_init(struct k_heap *h, void *mem, size_t bytes);
 
+/** @brief Allocate aligned memory from a k_heap
+ *
+ * Behaves in all ways like k_heap_alloc(), except that the returned
+ * memory (if available) will have a starting address in memory which
+ * is a multiple of the specified power-of-two alignment value in
+ * bytes.  The resulting memory can be returned to the heap using
+ * k_heap_free().
+ *
+ * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
+ *
+ * @param h Heap from which to allocate
+ * @param align Alignment in bytes, must be a power of two
+ * @param bytes Number of bytes requested
+ * @param timeout How long to wait, or K_NO_WAIT
+ * @return Pointer to memory the caller can now use
+ */
+void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
+			k_timeout_t timeout);
+
 /**
  * @brief Allocate memory from a k_heap
  *
@@ -4450,7 +4469,11 @@ void k_heap_init(struct k_heap *h, void *mem, size_t bytes);
  * @param timeout How long to wait, or K_NO_WAIT
  * @return A pointer to valid heap memory, or NULL
  */
-void *k_heap_alloc(struct k_heap *h, size_t bytes, k_timeout_t timeout);
+static inline void *k_heap_alloc(struct k_heap *h, size_t bytes,
+				 k_timeout_t timeout)
+{
+	return k_heap_aligned_alloc(h, sizeof(void *), bytes, timeout);
+}
 
 /**
  * @brief Free memory allocated by k_heap_alloc()

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -26,7 +26,8 @@ static int statics_init(const struct device *unused)
 
 SYS_INIT(statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
-void *k_heap_alloc(struct k_heap *h, size_t bytes, k_timeout_t timeout)
+void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
+			k_timeout_t timeout)
 {
 	int64_t now, end = z_timeout_end_calc(timeout);
 	void *ret = NULL;
@@ -35,7 +36,7 @@ void *k_heap_alloc(struct k_heap *h, size_t bytes, k_timeout_t timeout)
 	__ASSERT(!arch_is_in_isr() || K_TIMEOUT_EQ(timeout, K_NO_WAIT), "");
 
 	while (ret == NULL) {
-		ret = sys_heap_alloc(&h->heap, bytes);
+		ret = sys_heap_aligned_alloc(&h->heap, align, bytes);
 
 		now = z_tick_get();
 		if ((ret != NULL) || ((end - now) <= 0)) {


### PR DESCRIPTION
k_heap did not have an aligned alloc function, even though
this is supported by the internal sys_heap. (implements #29631)

@andrewboie in #29029  you wrote that ` k_heap has a facility for aligned allocations you should use that instead of k_malloc to reserve memory`, but apparently this is not possible for k_heap yet