### PR TITLE
tests: add test to verify assertion catches overlapped partitions

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -33,6 +33,7 @@ void test_main(void)
 		ztest_unit_test(test_mem_domain_api_supervisor_only),
 		ztest_unit_test(test_mem_domain_boot_threads),
 		ztest_unit_test(test_mem_domain_migration),
+		ztest_unit_test(test_mem_part_overlap),
 
 		/* mem_partition.c */
 		ztest_unit_test(test_macros_obtain_names_data_bss),

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -50,6 +50,7 @@ extern void test_create_new_essential_thread_from_user(void);
 extern void test_create_new_higher_prio_thread_from_user(void);
 extern void test_create_new_invalid_prio_thread_from_user(void);
 extern void test_mark_thread_exit_uninitialized(void);
+extern void test_mem_part_overlap(void);
 
 /* Flag needed to figure out if the fault was expected or not. */
 extern volatile bool valid_fault;


### PR DESCRIPTION
1. When adding the new partition to a memory domain the system must
assert that it does not overlap with any other existing partitions
in the domain.
Test to add new partition which has same start address as an
existing one, after that must happen an assertion error indicating
that new partition overlaps existing one.

2. Also removed misprints.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>