### PR TITLE
Bluetooth: controller: Properly guards calls to ull_adv_sync

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -119,7 +119,6 @@ ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
 /* helper function to fill the aux ptr structure in common ext adv payload */
 void ull_adv_aux_ptr_fill(uint8_t **dptr, uint8_t phy_s);
 
-#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int ull_adv_sync_init(void);
 int ull_adv_sync_reset(void);
 
@@ -129,5 +128,4 @@ uint32_t ull_adv_sync_start(struct ll_adv_sync_set *sync,
 
 /* helper function to schedule a mayfly to get sync offset */
 void ull_adv_sync_offset_get(struct ll_adv_set *adv);
-#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -49,7 +49,6 @@ struct ll_adv_aux_set {
 	uint8_t is_started:1;
 };
 
-#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 struct ll_adv_sync_set {
 	struct evt_hdr      evt;
 	struct ull_hdr      ull;
@@ -60,5 +59,4 @@ struct ll_adv_sync_set {
 	uint8_t is_enabled:1;
 	uint8_t is_started:1;
 };
-#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */


### PR DESCRIPTION
Two ull_adv_sync functions calls, ull_adv_sync_reset and
ull_adv_sync_init was not properly guarded by a #if.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>