### PR TITLE
drivers/flash/nrf_qspi_nor: check SRAM source using nrfx + DT sram nodes visible for both nrf53 cores

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -699,7 +699,7 @@ static int qspi_nor_write(const struct device *dev, off_t addr,
 
 	if (size < 4U) {
 		res = write_sub_word(dev, addr, src, size);
-	} else if (((uintptr_t)src < CONFIG_SRAM_BASE_ADDRESS)) {
+	} else if (!nrfx_is_in_ram(src)) {
 		res = write_from_nvmc(dev, addr, src, size);
 	} else {
 		res = nrfx_qspi_write(src, size, addr);

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -36,6 +36,10 @@
 			compatible = "mmio-sram";
 		};
 
+		sram1: memory@21000000 {
+			compatible = "mmio-sram";
+		};
+
 		peripheral@50000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -15,6 +15,10 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
+&sram1 {
+	reg = <0x21000000 DT_SIZE_K(64)>;
+};
+
 &mpu {
 	arm,num-mpu-regions = <8>;
 };

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa_eng_a.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa_eng_a.dtsi
@@ -15,6 +15,10 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
+&sram1 {
+	reg = <0x21000000 DT_SIZE_K(64)>;
+};
+
 &mpu {
 	arm,num-mpu-regions = <16>;
 };

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -38,6 +38,10 @@
 			compatible = "mmio-sram";
 		};
 
+		sram1: memory@21000000 {
+			compatible = "mmio-sram";
+		};
+
 		peripheral@40000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -15,6 +15,10 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
+&sram1 {
+	reg = <0x21000000 DT_SIZE_K(64)>;
+};
+
 &mpu {
 	arm,num-mpu-regions = <8>;
 };

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa_eng_a.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa_eng_a.dtsi
@@ -15,6 +15,10 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
+&sram1 {
+	reg = <0x21000000 DT_SIZE_K(64)>;
+};
+
 &mpu {
 	arm,num-mpu-regions = <16>;
 };

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -50,6 +50,10 @@
 	};
 
 	soc {
+		sram0: memory@20000000 {
+			compatible = "mmio-sram";
+		};
+
 		sram1: memory@21000000 {
 			compatible = "mmio-sram";
 		};

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -11,6 +11,10 @@
 	reg = <0x01000000 DT_SIZE_K(256)>;
 };
 
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(512)>;
+};
+
 &sram1 {
 	reg = <0x21000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa_eng_a.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa_eng_a.dtsi
@@ -11,6 +11,10 @@
 	reg = <0x01000000 DT_SIZE_K(256)>;
 };
 
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(512)>;
+};
+
 &sram1 {
 	reg = <0x21000000 DT_SIZE_K(64)>;
 };


### PR DESCRIPTION
The driver was using CONFIG_SRAM_BASE_ADDRESS as the value used to
recognize whether source bufer is in RAM. This label provide the
base address of the image SRAM, and not the base of actual HW SRAM.

This patch uses sram0 DTS node register address instead which is
proper way to obtain the SRAM beginning address.

fixes #29467

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>