### PR TITLE
dts: arm: riscv: Remove peripheral aliases from NXP and OpenISA SoCs 

### DIFF
--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -10,25 +10,6 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
-	aliases {
-		epit-1 = &epit1;
-		epit-2 = &epit2;
-		gpio-1 = &gpio1;
-		gpio-2 = &gpio2;
-		gpio-3 = &gpio3;
-		gpio-4 = &gpio4;
-		gpio-5 = &gpio5;
-		gpio-6 = &gpio6;
-		gpio-7 = &gpio7;
-		mu-b = &mub;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		uart-4 = &uart4;
-		uart-5 = &uart5;
-		uart-6 = &uart6;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -11,32 +11,6 @@
 #include <dt-bindings/rdc/imx_rdc.h>
 
 / {
-	aliases {
-		gpio-1 = &gpio1;
-		gpio-2 = &gpio2;
-		gpio-3 = &gpio3;
-		gpio-4 = &gpio4;
-		gpio-5 = &gpio5;
-		gpio-6 = &gpio6;
-		gpio-7 = &gpio7;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		i2c-4 = &i2c4;
-		mu-b   = &mub;
-		pwm-1 = &pwm1;
-		pwm-2 = &pwm2;
-		pwm-3 = &pwm3;
-		pwm-4 = &pwm4;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		uart-4 = &uart4;
-		uart-5 = &uart5;
-		uart-6 = &uart6;
-		uart-7 = &uart7;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -18,21 +18,6 @@
 	};
 
 	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		usbd-0 = &usbotg;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -9,33 +9,6 @@
 
 / {
 	aliases {
-		adc-0 = &adc0;
-		adc-1 = &adc1;
-		can-0 = &flexcan0;
-		eth = &enet;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		uart-4 = &uart4;
-		uart-5 = &uart5;
-		usbd-0 = &usbotg;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -12,25 +12,6 @@
 
 / {
 	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		i2c-2 = &i2c2;
-		i2c-3 = &i2c3;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		uart-0 = &lpuart0;
-		uart-1 = &lpuart1;
-		uart-2 = &lpuart2;
-		uart-3 = &lpuart3;
-		uart-4 = &lpuart4;
-		usbd-0 = &usbotg;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_ke16f256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke16f256vlx16.dtsi
@@ -7,9 +7,3 @@
 #include <nxp/nxp_ke1xf256vlx16.dtsi>
 
 /delete-node/ &flexcan1;
-
-/ {
-	aliases {
-		can-0 = &flexcan0;
-	};
-};

--- a/dts/arm/nxp/nxp_ke16f512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke16f512vlx16.dtsi
@@ -7,9 +7,3 @@
 #include <nxp/nxp_ke1xf512vlx16.dtsi>
 
 /delete-node/ &flexcan1;
-
-/ {
-	aliases {
-		can-0 = &flexcan0;
-	};
-};

--- a/dts/arm/nxp/nxp_ke18f256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke18f256vlx16.dtsi
@@ -5,10 +5,3 @@
  */
 
 #include <nxp/nxp_ke1xf256vlx16.dtsi>
-
-/ {
-	aliases {
-		can-0 = &flexcan0;
-		can-1 = &flexcan1;
-	};
-};

--- a/dts/arm/nxp/nxp_ke18f512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke18f512vlx16.dtsi
@@ -5,10 +5,3 @@
  */
 
 #include <nxp/nxp_ke1xf512vlx16.dtsi>
-
-/ {
-	aliases {
-		can-0 = &flexcan0;
-		can-1 = &flexcan1;
-	};
-};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -13,26 +13,6 @@
 / {
 	aliases {
 		watchdog0 = &wdog;
-		uart-0 = &lpuart0;
-		uart-1 = &lpuart1;
-		uart-2 = &lpuart2;
-		i2c-0 = &lpi2c0;
-		i2c-1 = &lpi2c1;
-		spi-0 = &lpspi0;
-		spi-1 = &lpspi1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		adc-0 = &adc0;
-		adc-1 = &adc1;
-		adc-2 = &adc2;
 	};
 
 	chosen {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -7,14 +7,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		uart-0 = &uart0;
-		usbd-0 = &usbotg;
-	};
-
 	chosen {
 		zephyr,flash-controller = &ftfa;
 	};

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -10,26 +10,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		spi-2 = &spi2;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		uart-3 = &uart3;
-		uart-4 = &uart4;
-		uart-5 = &uart5;
-	};
-
 	chosen {
 		zephyr,flash-controller = &ftfe;
 	};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -9,20 +9,6 @@
 
 / {
 	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-		pinmux-e = &pinmux_e;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &uart0;
-		uart-1 = &uart1;
-		uart-2 = &uart2;
-		usbd-0 = &usbd;
 		watchdog0 = &wdog;
 	};
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -7,21 +7,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pwm-0 = &tpm0;
-		pwm-1 = &tpm1;
-		pwm-2 = &tpm2;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &lpuart0;
-	};
-
 	chosen {
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &ftfa;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -12,21 +12,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		adc-0 = &adc0;
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pwm-0 = &tpm0;
-		pwm-1 = &tpm1;
-		pwm-2 = &tpm2;
-		spi-0 = &spi0;
-		spi-1 = &spi1;
-		uart-0 = &lpuart0;
-	};
-
 	chosen {
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &ftfa;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -10,12 +10,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases{
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-		mailbox-0 = &mailbox0;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -11,11 +11,6 @@
 #include <mem.h>
 
 / {
-	aliases {
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -12,8 +12,6 @@
 
 / {
 	aliases {
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
 		watchdog0 = &wwdt0;
 	};
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -11,33 +11,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		eth = &enet;
-		gpio-1 = &gpio1;
-		gpio-2 = &gpio2;
-		gpio-3 = &gpio3;
-		gpio-4 = &gpio4;
-		gpio-5 = &gpio5;
-		i2c-1 = &lpi2c1;
-		i2c-2 = &lpi2c2;
-		i2c-3 = &lpi2c3;
-		i2c-4 = &lpi2c4;
-		spi-1 = &lpspi1;
-		spi-2 = &lpspi2;
-		spi-3 = &lpspi3;
-		spi-4 = &lpspi4;
-		uart-1 = &lpuart1;
-		uart-2 = &lpuart2;
-		uart-3 = &lpuart3;
-		uart-4 = &lpuart4;
-		uart-5 = &lpuart5;
-		uart-6 = &lpuart6;
-		uart-7 = &lpuart7;
-		uart-8 = &lpuart8;
-		usbd-1 = &usb1;
-		usbd-2 = &usb2;
-	};
-
 	chosen {
 		zephyr,entropy = &trng;
 	};

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -67,11 +67,6 @@
 };
 
 / {
-	aliases {
-		/delete-property/ gpio-3;
-		/delete-property/ gpio-4;
-	};
-
 	soc {
 		/* Fixup GPIO2 its a different location on RT1010 */
 		/delete-node/ gpio@401bc000;

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -19,10 +19,6 @@
 
 /* i.MX rt1060 has a second Ethernet controller. */
 / {
-	aliases {
-		enet2 = &enet2;
-	};
-
 	soc {
 		enet2: ethernet@402d4000 {
 			compatible = "nxp,kinetis-ethernet";

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -11,11 +11,6 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
-	aliases {
-		gpio-0 = &gpio0;
-		gpio-1 = &gpio1;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -11,37 +11,6 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	aliases {
-		pcc-0 = &pcc0;
-		pcc-1 = &pcc1;
-		pinmux-a = &porta;
-		pinmux-b = &portb;
-		pinmux-c = &portc;
-		pinmux-d = &portd;
-		pinmux-e = &porte;
-		gpio-a = &gpioa;
-		gpio-b = &gpiob;
-		gpio-c = &gpioc;
-		gpio-d = &gpiod;
-		gpio-e = &gpioe;
-		uart-0 = &lpuart0;
-		uart-1 = &lpuart1;
-		uart-2 = &lpuart2;
-		uart-3 = &lpuart3;
-		i2c-0 = &lpi2c0;
-		i2c-1 = &lpi2c1;
-		i2c-2 = &lpi2c2;
-		i2c-3 = &lpi2c3;
-		spi-0 = &lpspi0;
-		spi-1 = &lpspi1;
-		spi-2 = &lpspi2;
-		spi-3 = &lpspi3;
-		pwm-0 = &tpm0;
-		pwm-1 = &tpm1;
-		pwm-2 = &tpm2;
-		pwm-3 = &tpm3;
-	};
-
 	chosen {
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &ftfe;


### PR DESCRIPTION
Removes peripheral aliases from all NXP and OpenISA SoCs (Kinetis, LPC, i.MX, and RV32M1),
which are no longer being used after converting their associated drivers
to use DT_INST macros. The watchdog alias remains because it is used by
tests/drivers/watchdog/wdt_basic_api/

Follow up to #26274