### PR TITLE
usb/class/usb_dfu: give wait_for_usb_dfu an argument.

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -29,6 +29,9 @@ interface and listing all issues with the `bug label
 API Changes
 ***********
 
+* The :c:func:`wait_for_usb_dfu` function now accepts a ``k_timeout_t`` argument instead of
+  using the ``CONFIG_USB_DFU_WAIT_DELAY_MS`` macro.
+
 Deprecated in this release
 
 * :c:macro:`DT_CLOCKS_LABEL_BY_IDX`, :c:macro:`DT_CLOCKS_LABEL_BY_NAME`,

--- a/include/usb/class/usb_dfu.h
+++ b/include/usb/class/usb_dfu.h
@@ -44,6 +44,8 @@
 #ifndef ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_
 #define ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_
 
+#include <sys_clock.h>
+
 /** DFU Class Subclass */
 #define DFU_SUBCLASS			0x01
 
@@ -121,6 +123,6 @@ enum dfu_state {
 	dfuERROR,
 };
 
-void wait_for_usb_dfu(void);
+void wait_for_usb_dfu(k_timeout_t delay);
 
 #endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_ */

--- a/subsys/usb/class/dfu/Kconfig
+++ b/subsys/usb/class/dfu/Kconfig
@@ -18,14 +18,6 @@ config USB_DEVICE_DFU_PID
 	help
 	  USB device product ID in DFU mode. MUST be configured by vendor.
 
-config USB_DFU_WAIT_DELAY_MS
-	int "wait_for_usb_dfu() timeout"
-	default 12000
-	range 1000 120000
-	help
-	  A thread can use wait_for_usb_dfu() call for wait a prescribed
-	  time (in ms) for DFU to begin
-
 config USB_DFU_DETACH_TIMEOUT
 	int
 	default 1000

--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -64,10 +64,6 @@ LOG_MODULE_REGISTER(usb_dfu);
 #define FIRMWARE_IMAGE_0_LABEL "image-0"
 #define FIRMWARE_IMAGE_1_LABEL "image-1"
 
-/* MCUBoot waits for CONFIG_USB_DFU_WAIT_DELAY_MS time in total to let DFU to
- * be commenced. It intermittently checks every INTERMITTENT_CHECK_DELAY
- * milliseconds to see if DFU has started.
- */
 #define INTERMITTENT_CHECK_DELAY	50
 
 static struct k_poll_event dfu_event;
@@ -829,14 +825,14 @@ static bool is_dfu_started(void)
  *
  * @return  N/A
  */
-void wait_for_usb_dfu(void)
+void wait_for_usb_dfu(k_timeout_t delay)
 {
+	uint64_t end = z_timeout_end_calc(delay);
+
 	/* Wait for a prescribed duration of time. If DFU hasn't started within
 	 * that time, stop waiting and proceed further.
 	 */
-	for (int time = 0;
-		time < (CONFIG_USB_DFU_WAIT_DELAY_MS/INTERMITTENT_CHECK_DELAY);
-		time++) {
+	while (end > k_uptime_ticks()) {
 		if (is_dfu_started()) {
 			k_poll_event_init(&dfu_event, K_POLL_TYPE_SIGNAL,
 				K_POLL_MODE_NOTIFY_ONLY, &dfu_signal);


### PR DESCRIPTION
Allow callers to wait for an arbitrary amount of time, instead of always
waiting for a compile-time fixed period.

Signed-off-by: Josh Gao <josh@jmgao.dev>