### PR TITLE
lib/os/cbprintf_nano.c: simplifications and enhancements

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1601,6 +1601,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 		case 'X':
 			bps = encode_uint(value.uint, &conv, buf, bpe);
 
+		prec_int_pad0:
 			/* Update pad0 values based on precision and converted
 			 * length.  Note that a non-empty sign is not in the
 			 * converted sequence, but it does not affect the
@@ -1631,13 +1632,16 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			if (value.ptr != NULL) {
 				bps = encode_uint((uintptr_t)value.ptr, &conv,
 						  buf, bpe);
+
 				/* Use 0x prefix */
 				conv.altform_0c = true;
 				conv.specifier = 'x';
-			} else {
-				bps = "(nil)";
-				bpe = bps + 5;
+
+				goto prec_int_pad0;
 			}
+
+			bps = "(nil)";
+			bpe = bps + 5;
 
 			break;
 		case 'n':
@@ -1798,7 +1802,6 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			OUTC(' ');
 			--width;
 		}
-
 	}
 
 	return count;

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -924,8 +924,37 @@ static void test_p(void)
 	rc = TEST_PRF("%p", ptr);
 	PRF_CHECK("0xcafe21", rc);
 	rc = TEST_PRF("%p", NULL);
-	printf("buffer '%s'\n", buf);
 	PRF_CHECK("(nil)", rc);
+
+	/* Nano doesn't support left-justification of pointer
+	 * values.
+	 */
+	if (!IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
+		reset_out();
+		rc = rawprf("/%12p/", ptr);
+		zassert_equal(rc, 14, NULL);
+		zassert_equal(strncmp("/    0xcafe21/", buf, rc), 0, NULL);
+	}
+
+	reset_out();
+	rc = rawprf("/%-12p/", ptr);
+	if (IS_ENABLED(CONFIG_CBPRINTF_NANO)
+	    && !IS_ENABLED(CONFIG_CBPRINTF_LIBC_SUBSTS)) {
+		zassert_equal(rc, 0, NULL);
+		rc = 14;
+	} else {
+		zassert_equal(rc, 14, NULL);
+	}
+	zassert_equal(strncmp("/0xcafe21    /", buf, rc), 0, NULL);
+
+	/* Nano doesn't support zero-padding of pointer values.
+	 */
+	if (!IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
+		reset_out();
+		rc = rawprf("/%.8p/", ptr);
+		zassert_equal(rc, 12, NULL);
+		zassert_equal(strncmp("/0x00cafe21/", buf, rc), 0, NULL);
+	}
 }
 
 static int out_counter(int c,


### PR DESCRIPTION
Simplify the code to increase readability, and fix right-padding
for %p.

Also, the compiled code is smaller with those changes applied.