### PR TITLE
Bluetooth: Mesh: Fixes wrong prov process

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -460,7 +460,7 @@ static void gen_prov_start(struct prov_rx *rx, struct net_buf_simple *buf)
 	link.rx.last_seg = START_LAST_SEG(rx->gpc);
 
 	if ((link.rx.seg & BIT(0)) &&
-	    (find_msb_set(~link.rx.seg) >= link.rx.last_seg)) {
+	    (find_msb_set((~link.rx.seg) & SEG_NVAL) - 1 > link.rx.last_seg)) {
 		BT_ERR("Invalid segment index %u", seg);
 		prov_failed(PROV_ERR_NVAL_FMT);
 		return;

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -223,7 +223,7 @@ int bt_mesh_input_number(uint32_t num)
 
 int bt_mesh_input_string(const char *str)
 {
-	BT_DBG("%s", str);
+	BT_DBG("%s", log_strdup(str));
 
 	if (!atomic_test_and_clear_bit(bt_mesh_prov_link.flags, WAIT_STRING)) {
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -59,6 +59,7 @@ int bt_mesh_prov_reset_state(void (*func)(const uint8_t key[64]))
 		bt_mesh_attention(NULL, 0);
 	}
 
+	atomic_clear(bt_mesh_prov_link.flags);
 	(void)memset((uint8_t *)&bt_mesh_prov_link + offset, 0,
 		     sizeof(bt_mesh_prov_link) - offset);
 

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -91,6 +91,11 @@ struct bt_mesh_prov_role {
 };
 
 struct bt_mesh_prov_link {
+	ATOMIC_DEFINE(flags, NUM_FLAGS);
+
+	const struct prov_bearer *bearer;
+	const struct bt_mesh_prov_role *role;
+
 	uint8_t oob_method;             /* Authen method */
 	uint8_t oob_action;             /* Authen action */
 	uint8_t oob_size;               /* Authen size */
@@ -106,11 +111,6 @@ struct bt_mesh_prov_link {
 	uint8_t conf_key[16];           /* ConfirmationKey */
 	uint8_t conf_inputs[145];       /* ConfirmationInputs */
 	uint8_t prov_salt[16];          /* Provisioning Salt */
-
-	const struct prov_bearer *bearer;
-	const struct bt_mesh_prov_role *role;
-
-	ATOMIC_DEFINE(flags, NUM_FLAGS);
 };
 
 extern struct bt_mesh_prov_link bt_mesh_prov_link;


### PR DESCRIPTION
When link close, Wrong clear pointer, resulting
in illegal pointer access.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>