### PR TITLE
Bluetooth: Mesh: Correction of missing beacon auth generation

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -421,7 +421,7 @@ void bt_mesh_beacon_update(struct bt_mesh_subnet *sub)
 
 static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 {
-	if (evt == BT_MESH_KEY_ADDED || evt == BT_MESH_KEY_SWAPPED) {
+	if (evt != BT_MESH_KEY_DELETED) {
 		bt_mesh_beacon_update(sub);
 	}
 }


### PR DESCRIPTION
When kr phase to `BT_MESH_KEY_REVOKED`, should also call beacon
authentication, since beacon flag has change(0x01-->0x00).

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>