### PR TITLE
Bluetooth: Mesh: Fixes missing recv net_idx copy to context

### DIFF
--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -599,6 +599,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 			if (cb(rx, in, out, &bt_mesh.lpn.cred[j])) {
 				rx->new_key = (j > 0);
 				rx->friend_cred = 1U;
+				rx->ctx.net_idx = rx->sub->net_idx;
 				return true;
 			}
 		}
@@ -633,6 +634,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 			if (cb(rx, in, out, &frnd->cred[j])) {
 				rx->new_key = (j > 0);
 				rx->friend_cred = 1U;
+				rx->ctx.net_idx = rx->sub->net_idx;
 				return true;
 			}
 		}
@@ -653,6 +655,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 			if (cb(rx, in, out, &rx->sub->keys[j].msg)) {
 				rx->new_key = (j > 0);
 				rx->friend_cred = 0U;
+				rx->ctx.net_idx = rx->sub->net_idx;
 				return true;
 			}
 		}

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -82,6 +82,10 @@ static void key_refresh(struct bt_mesh_subnet *sub, uint8_t new_phase)
 		break;
 	/* Revoking keys */
 	case BT_MESH_KR_PHASE_3:
+		if (sub->kr_phase == BT_MESH_KR_NORMAL) {
+			return;
+		}
+		__fallthrough;
 	case BT_MESH_KR_NORMAL:
 		sub->kr_phase = BT_MESH_KR_NORMAL;
 		memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
@@ -330,7 +334,7 @@ uint8_t bt_mesh_subnet_kr_phase_set(uint16_t net_idx, uint8_t *phase)
 {
 	/* Table in Bluetooth Mesh Profile Specification Section 4.2.14: */
 	const uint8_t valid_transitions[] = {
-		0x00, /* Normal phase: KR is started by key update */
+		BIT(BT_MESH_KR_PHASE_3), /* Normal phase: KR is started by key update */
 		BIT(BT_MESH_KR_PHASE_2) | BIT(BT_MESH_KR_PHASE_3), /* Phase 1 */
 		BIT(BT_MESH_KR_PHASE_3), /* Phase 2 */
 		/* Subnet is never in Phase 3 */


### PR DESCRIPTION
Missing copy net_idx to ctx, this cause tx subnet not found
or different with rx subnet, when rx subnet net_idx not zero.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>