### PR TITLE
Bluetooth: Mesh: Fixes missing set virtual addr

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1667,6 +1667,8 @@ uint8_t bt_mesh_va_add(uint8_t uuid[16], uint16_t *addr)
 	va->ref = 1;
 	va_store(va);
 
+	*addr = va->addr;
+
 	return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes missing virtual address set

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>