### PR TITLE
lvgl: kscan: Only process prev state if it has been updated

### DIFF
--- a/lib/gui/lvgl/lvgl.c
+++ b/lib/gui/lvgl/lvgl.c
@@ -206,9 +206,11 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		.state = LV_INDEV_STATE_REL,
 	};
 
-	if (k_msgq_get(&kscan_msgq, &curr, K_NO_WAIT) == 0) {
-		prev = curr;
+	if (k_msgq_get(&kscan_msgq, &curr, K_NO_WAIT) != 0) {
+		goto set_and_release;
 	}
+
+	prev = curr;
 
 	disp = lv_disp_get_default();
 	disp_dev = disp->driver.user_data;
@@ -260,6 +262,7 @@ static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		prev.point.y = x;
 	}
 
+set_and_release:
 	*data = prev;
 
 	return k_msgq_num_used_get(&kscan_msgq) > 0;


### PR DESCRIPTION
When no message was get from kscan_msgq queue, the prev state (x/y point) was processed as a new state.
During process its coordinates could be inverted or modified, depending on the LVGL_POINTER_KSCAN_SWAP_XY, LVGL_POINTER_KSCAN_INVERT_X, LVGL_POINTER_KSCAN_INVERT_Y or display orientation configuration.
In these cases, it could cause wrong input data.