### PR TITLE
samples: cloud: tagoio_http_post: Force pinmux config

### DIFF
--- a/samples/net/cloud/tagoio_http_post/README.rst
+++ b/samples/net/cloud/tagoio_http_post/README.rst
@@ -1,7 +1,7 @@
 .. _cloud-tagoio-http-post-sample:
 
-Socket TagoIO HTTP Client
-#########################
+TagoIO IoT Cloud HTTP Sample
+############################
 
 Overview
 ********

--- a/samples/net/cloud/tagoio_http_post/prj.conf
+++ b/samples/net/cloud/tagoio_http_post/prj.conf
@@ -42,3 +42,6 @@ CONFIG_NET_HTTP_LOG_LEVEL_DBG=n
 # TagoIO API
 CONFIG_TAGOIO_DEVICE_TOKEN="<your device token API>"
 CONFIG_CBPRINTF_FP_SUPPORT=y
+
+# Fix #30029 - Undefined initialization levels used
+CONFIG_PINMUX=y


### PR DESCRIPTION
There are some hardware combinations (board/shields) that report the error undefined initialization levels used at link phase.  Add pinmux Kconfig at project configuration to fix the issue.

Fixes #30029.

This rename from **Socket TagoIO HTTP Client** to **TagoIO IoT Cloud HTTP Sample** the documentation topic to reflect better the sample application intention.