### PR TITLE
PCIe endpoint and System DMA driver integration

### DIFF
--- a/drivers/pcie/endpoint/pcie_ep_common.c
+++ b/drivers/pcie/endpoint/pcie_ep_common.c
@@ -9,6 +9,53 @@
 #include <string.h>
 #include <sys/util.h>
 
+/*
+ * During DEVICE_TO_HOST data transfer, in order to make sure that all
+ * PCIe writes (posted) have reached Host, i.e. to flush PCIe writes,
+ * we need to add a dummy PCIe read (non posted transaction) after each
+ * DEVICE_TO_HOST data transfer.
+ *
+ * There are a few possible scenarios, where we need to *place*
+ * a dummy PCIe read.
+ * All possible scenarios are captured in the table below.
+ *
+ * As can be seen in the table, for 64-bit systems, we could just do sys_read8
+ * on mapped Host address to generate a dummy PCIe read, before unmapping the
+ * address - irrespective of low/high outbound memory usage as core is capable
+ * of accessing highmem.
+ * Basically, we issue single byte PCIe read with sys_read8.
+ *
+ * For 32-bit systems, if using low outbound memory for memcpy/DMA,
+ * we could do sys_read8 on the mapped address.
+ * But, for 32-bit systems using high outbound memory for DMA operation,
+ * sys_read8 is not possible, as the core cannot access highmem.
+ * In this case, we need to *explicitly* perform PCIe read.
+ *
+ * +-------------+----------------------+-------------------------------------+
+ * |     Core    |  Data transfer with  | OB memory type | Dummy PCIe read    |
+ * +-------------+----------------------+----------------+--------------------+
+ * | 64-bit      |                      |    highmem     |     sys_read8      |
+ * |             |       memcpy         |----------------+--------------------+
+ * |             |                      |    lowmem      |     sys_read8      |
+ * | (e.g.       +----------------------+----------------+--------------------+
+ * | Cortex-A72) |                      |    highmem     |     sys_read8      |
+ * |             |       DMA            |----------------+--------------------+
+ * |             |                      |    lowmem      |     sys_read8      |
+ * +-------------+----------------------+----------------+--------------------+
+ * | 32-bit      |                      |    highmem     |        NA          |
+ * |             |       memcpy         |----------------+--------------------+
+ * |             |                      |    lowmem      |     sys_read8      |
+ * | (e.g.       +----------------------+----------------+--------------------+
+ * | Cortex-M7)  |                      |    highmem     | Explicit PCIe read |
+ * |             |       DMA            |----------------+--------------------+
+ * |             |                      |    lowmem      |     sys_read8      |
+ * +-------------+----------------------+----------------+--------------------+
+ *
+ * Based on this explanation, the 2 common APIs below, namely
+ * pcie_ep_xfer_data_memcpy and pcie_ep_xfer_data_dma
+ * are implemented with dummy PCIe read, phew!
+ */
+
 static int pcie_ep_mapped_copy(uint64_t mapped_addr, uintptr_t local_addr,
 			       const uint32_t size,
 			       const enum xfer_direction dir)
@@ -45,9 +92,9 @@ int pcie_ep_xfer_data_memcpy(const struct device *dev, uint64_t pcie_addr,
 	int mapped_size, ret;
 	uint32_t xfer_size, unmapped_size;
 
+	/* Map pcie_addr to outbound memory */
 	mapped_size = pcie_ep_map_addr(dev, pcie_addr, &mapped_addr,
 				       size, ob_mem_type);
-
 	/* Check if outbound memory mapping succeeded */
 	if (mapped_size < 0) {
 		return mapped_size;
@@ -56,16 +103,20 @@ int pcie_ep_xfer_data_memcpy(const struct device *dev, uint64_t pcie_addr,
 	ret = pcie_ep_mapped_copy(mapped_addr, (uintptr_t)local_addr,
 				  mapped_size, dir);
 
-	pcie_ep_unmap_addr(dev, mapped_addr);
-
 	/* Check if mapped_copy succeeded */
 	if (ret < 0) {
-		return ret;
+		goto out_unmap;
+	}
+
+	/* Flush the PCIe writes upon successful memcpy */
+	if (dir == DEVICE_TO_HOST) {
+		sys_read8(mapped_addr);
 	}
 
 	/* Check if we achieved data transfer for given size */
 	if (mapped_size == size) {
-		return 0;
+		ret = 0;
+		goto out_unmap;
 	}
 
 	/*
@@ -78,33 +129,151 @@ int pcie_ep_xfer_data_memcpy(const struct device *dev, uint64_t pcie_addr,
 	 * ramaining size and complete remaining data transfer
 	 */
 
+	pcie_ep_unmap_addr(dev, mapped_addr); /* unmap previous Host buffer */
 	xfer_size = mapped_size; /* save already tranferred data size */
 
 	unmapped_size = size - mapped_size;
 	mapped_size = pcie_ep_map_addr(dev, pcie_addr + xfer_size,
 				       &mapped_addr, unmapped_size,
 				       ob_mem_type);
-
 	/* Check if outbound memory mapping succeeded */
 	if (mapped_size < 0) {
 		return mapped_size;
 	}
 
+	/*
+	 * In second attempt, we must have mapped entire size,
+	 * if not just quit here before attempting memcpy
+	 */
+	if (mapped_size != unmapped_size) {
+		ret = -EIO;
+		goto out_unmap;
+	}
+
 	ret = pcie_ep_mapped_copy(mapped_addr,
 				  ((uintptr_t)local_addr) + xfer_size,
 				  mapped_size, dir);
+	/* Flush the PCIe writes upon successful memcpy */
+	if (!ret && (dir == DEVICE_TO_HOST)) {
+		sys_read8(mapped_addr);
+	}
+out_unmap:
+	pcie_ep_unmap_addr(dev, mapped_addr);
+	return ret;
+}
+
+/*
+ * Helper API to achieve data transfer with DMA operation through
+ * PCIe outbound memory, this API is based off pcie_ep_xfer_data_memcpy,
+ * here we use "system dma" instead of memcpy
+ */
+int pcie_ep_xfer_data_dma(const struct device *dev, uint64_t pcie_addr,
+			  uintptr_t *local_addr, uint32_t size,
+			  enum pcie_ob_mem_type ob_mem_type,
+			  enum xfer_direction dir)
+{
+	uint64_t mapped_addr;
+	int mapped_size, ret;
+	uint32_t xfer_size, unmapped_size;
+	uint32_t dummy_data;	/* For explicit dummy PCIe read */
+
+	/* Map pcie_addr to outbound memory */
+	mapped_size = pcie_ep_map_addr(dev, pcie_addr, &mapped_addr,
+				       size, ob_mem_type);
+	/* Check if outbound memory mapping succeeded */
+	if (mapped_size < 0) {
+		return mapped_size;
+	}
+
+	ret = pcie_ep_dma_xfer(dev, mapped_addr, (uintptr_t)local_addr,
+			       mapped_size, dir);
+	/* Check if dma succeeded */
+	if (ret < 0) {
+		goto out_unmap;
+	}
+
+	/* Flush the PCIe writes upon successful DMA */
+	if (dir == DEVICE_TO_HOST) {
+		if (IS_ENABLED(CONFIG_64BIT) || !(mapped_addr >> 32)) {
+			sys_read8(mapped_addr);
+		}
+	}
 
 	pcie_ep_unmap_addr(dev, mapped_addr);
 
-	/* Check if mapped_copy succeeded */
-	if (ret < 0) {
-		return ret;
+	/*
+	 * Explicit PCIe read to flush PCIe writes for 32-bit system
+	 * using high outbound memory for DMA operation
+	 */
+	if (dir == DEVICE_TO_HOST && (!IS_ENABLED(CONFIG_64BIT)) &&
+	    (mapped_addr >> 32)) {
+		ret = pcie_ep_xfer_data_memcpy(dev, pcie_addr,
+					       (uintptr_t *)&dummy_data,
+					       sizeof(dummy_data),
+					       PCIE_OB_LOWMEM, HOST_TO_DEVICE);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
-	/* In second attempt, we must have completed data transfer */
+	/* Check if we achieved data transfer for given size */
+	if (mapped_size == size) {
+		return 0;
+	}
+
+	/* map ramaining size and complete remaining data transfer */
+
+	xfer_size = mapped_size; /* save already tranferred data size */
+
+	unmapped_size = size - mapped_size;
+	mapped_size = pcie_ep_map_addr(dev, pcie_addr + xfer_size,
+				       &mapped_addr, unmapped_size,
+				       ob_mem_type);
+	/* Check if outbound memory mapping succeeded */
+	if (mapped_size < 0) {
+		return mapped_size;
+	}
+
+	/*
+	 * In second attempt, we must have mapped entire size,
+	 * if not just quit here before attempting dma
+	 */
 	if (mapped_size != unmapped_size) {
-		return -EIO;
+		ret = -EIO;
+		goto out_unmap;
 	}
 
-	return 0;
+	ret = pcie_ep_dma_xfer(dev, mapped_addr,
+			       ((uintptr_t)local_addr) + xfer_size,
+			       mapped_size, dir);
+	/* Check if dma copy succeeded */
+	if (ret < 0) {
+		goto out_unmap;
+	}
+
+	/* Flush the PCIe writes upon successful DMA */
+	if (dir == DEVICE_TO_HOST) {
+		if (IS_ENABLED(CONFIG_64BIT) || !(mapped_addr >> 32)) {
+			sys_read8(mapped_addr);
+		}
+	}
+
+	pcie_ep_unmap_addr(dev, mapped_addr);
+
+	/*
+	 * Explicit PCIe read to flush PCIe writes for 32-bit system
+	 * using high outbound memory for DMA operation
+	 */
+	if (dir == DEVICE_TO_HOST && (!IS_ENABLED(CONFIG_64BIT)) &&
+	    (mapped_addr >> 32)) {
+		ret = pcie_ep_xfer_data_memcpy(dev, pcie_addr,
+					       (uintptr_t *)&dummy_data,
+					       sizeof(dummy_data),
+					       PCIE_OB_LOWMEM, HOST_TO_DEVICE);
+	}
+
+	return ret;
+out_unmap:
+	pcie_ep_unmap_addr(dev, mapped_addr);
+	return ret;
 }

--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -119,18 +119,6 @@ static void iproc_pcie_unmap_addr(const struct device *dev,
 
 	key = k_spin_lock(&ctx->ob_map_lock);
 
-	/*
-	 * When doing Host writes using PCIe outbound window, it is seen
-	 * that before the writes gets completed using the existing outbound
-	 * window mapping, next mapping is overwriting it, causing few bytes
-	 * write failure with former mapping.
-	 *
-	 * To safeguard outbound window mapping, perform PCIe read in unmap,
-	 * which ensures that all PCIe writes before the read
-	 * are completed with this window.
-	 */
-	sys_read8(mapped_addr);
-
 	if (mapped_addr >> 32) {
 		ctx->highmem_in_use = false;
 	} else {

--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <drivers/dma.h>
 #include <drivers/pcie/endpoint/pcie_ep.h>
 
 #define LOG_LEVEL CONFIG_PCIE_EP_LOG_LEVEL
@@ -182,6 +183,55 @@ static int iproc_pcie_register_reset_cb(const struct device *dev,
 	ctx->reset_data[reset] = arg;
 
 	return 0;
+}
+
+static int iproc_pcie_pl330_dma_xfer(const struct device *dev,
+				     uint64_t mapped_addr,
+				     uintptr_t local_addr, uint32_t size,
+				     const enum xfer_direction dir)
+{
+	const struct iproc_pcie_ep_config *cfg = dev->config;
+	struct dma_config dma_cfg = { 0 };
+	struct dma_block_config dma_block_cfg = { 0 };
+	const struct device *pl330_dev;
+	uint32_t chan_id;
+	int ret = -EINVAL;
+
+	pl330_dev = device_get_binding(cfg->pl330_dev_name);
+	if (!pl330_dev) {
+		LOG_ERR("Cannot get dma controller\n");
+		goto out;
+	}
+
+	/* configure DMA */
+	dma_cfg.channel_direction = MEMORY_TO_MEMORY;
+	dma_cfg.block_count = 1U;
+	dma_cfg.head_block = &dma_block_cfg;
+
+	dma_block_cfg.block_size = size;
+	if (dir == DEVICE_TO_HOST) {
+		dma_block_cfg.source_address = local_addr;
+		dma_block_cfg.dest_address = mapped_addr;
+		chan_id = cfg->pl330_tx_chan_id;
+	} else {
+		dma_block_cfg.source_address = mapped_addr;
+		dma_block_cfg.dest_address = local_addr;
+		chan_id = cfg->pl330_rx_chan_id;
+	}
+
+	ret = dma_config(pl330_dev, chan_id,  &dma_cfg);
+	if (ret) {
+		LOG_ERR("DMA config failed\n");
+		goto out;
+	}
+
+	/* start DMA */
+	ret = dma_start(pl330_dev, chan_id);
+	if (ret) {
+		LOG_ERR("DMA transfer failed\n");
+	}
+out:
+	return ret;
 }
 
 #if DT_INST_IRQ_HAS_NAME(0, perst)
@@ -440,6 +490,9 @@ static struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
 	.map_low_size = DT_INST_REG_SIZE_BY_NAME(0, map_lowmem),
 	.map_high_base = DT_INST_REG_ADDR_BY_NAME(0, map_highmem),
 	.map_high_size = DT_INST_REG_SIZE_BY_NAME(0, map_highmem),
+	.pl330_dev_name = DT_INST_DMAS_LABEL_BY_IDX(0, 0),
+	.pl330_tx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, txdma, channel),
+	.pl330_rx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, rxdma, channel),
 };
 
 static struct pcie_ep_driver_api iproc_pcie_ep_api = {
@@ -449,6 +502,7 @@ static struct pcie_ep_driver_api iproc_pcie_ep_api = {
 	.unmap_addr = iproc_pcie_unmap_addr,
 	.raise_irq = iproc_pcie_raise_irq,
 	.register_reset_cb = iproc_pcie_register_reset_cb,
+	.dma_xfer = iproc_pcie_pl330_dma_xfer,
 };
 
 DEVICE_AND_API_INIT(iproc_pcie_ep_0, DT_INST_LABEL(0),

--- a/drivers/pcie/endpoint/pcie_ep_iproc.h
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.h
@@ -104,6 +104,9 @@ struct iproc_pcie_ep_config {
 	uint64_t map_high_base;	/* Base addr of outbound mapping at highmem */
 	uint32_t map_high_size;
 	unsigned int id;
+	const char *pl330_dev_name; /* pl330 device's "label" property */
+	uint32_t pl330_tx_chan_id;  /* channel used for Device to Host write */
+	uint32_t pl330_rx_chan_id;  /* channel used for Host to Device read  */
 };
 
 struct iproc_pcie_ep_ctx {

--- a/dts/arm/broadcom/viper-common.dtsi
+++ b/dts/arm/broadcom/viper-common.dtsi
@@ -35,7 +35,7 @@
 				    "control_regs";
 			microcode = <0x63b00000  0x1000>;
 			dma-channels = <8>;
-			#dma-cells = <0>;
+			#dma-cells = <1>;
 			label = "PL330";
 		};
 	};
@@ -52,6 +52,8 @@
 			reg-names = "iproc_pcie_regs", "map_lowmem",
 				    "map_highmem";
 			label = "PCIE_0";
+			dmas = <&pl330 0>, <&pl330 1>;
+			dma-names = "txdma", "rxdma";
 		};
 	};
 };

--- a/dts/bindings/dma/arm,dma-pl330.yaml
+++ b/dts/bindings/dma/arm,dma-pl330.yaml
@@ -16,3 +16,31 @@ properties:
       description: microcode's physical memory address
     label:
       required: true
+    "#dma-cells":
+      const: 1
+
+# Parameter syntax
+dma-cells:
+  - channel
+
+description: |
+  A phandle to the DMA controller plus "channel" integer cell specifying
+  channel to be used for data transfer
+
+  Example for pl330 DMA Controller
+     pl330: pl330@48300000 {
+                  compatible = "arm,dma-pl330";
+                  ...
+                  dma-channels = <8>;
+                  #dma-cells = <1>;
+                  label = "PL330";
+            };
+
+  If PCIe EP client uses channel 0 for Tx DMA and channel 1 for Rx DMA
+     pcie0_ep: pcie@4e100000 {
+                  compatible = "brcm,iproc-pcie-ep";
+                  ...
+                  dmas = <&pl330 0>, <&pl330 1>;
+                  dma-names = "txdma", "rxdma";
+                  label = "PCIE_0";
+            };

--- a/include/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/drivers/pcie/endpoint/pcie_ep.h
@@ -267,10 +267,44 @@ static inline int pcie_ep_dma_xfer(const struct device *dev,
  *
  * @details Helper API to achieve data transfer with memcpy
  *          through PCIe outbound memory
+ *
+ * @param dev         Pointer to the device structure for the driver instance
+ * @param pcie_addr   Host memory buffer address
+ * @param local_addr  Local memory buffer address
+ * @param size        Data transfer size (bytes)
+ * @param ob_mem_type Hint if lowmem/highmem outbound region has to be used
+ *                    (PCIE_OB_LOWMEM / PCIE_OB_HIGHMEM / PCIE_OB_ANYMEM),
+ *                    should be PCIE_OB_LOWMEM if bus master cannot generate
+ *                    more than 32-bit address
+ * @param dir         Data transfer direction (HOST_TO_DEVICE / DEVICE_TO_HOST)
+ *
+ * @return 0 if successful, negative errno code if failure.
  */
 int pcie_ep_xfer_data_memcpy(const struct device *dev, uint64_t pcie_addr,
 			     uintptr_t *local_addr, uint32_t size,
 			     enum pcie_ob_mem_type ob_mem_type,
 			     enum xfer_direction dir);
+
+/**
+ * @brief Data transfer using system DMA
+ *
+ * @details Helper API to achieve data transfer with system DMA through PCIe
+ *          outbound memory, this API is based off pcie_ep_xfer_data_memcpy,
+ *          here we use "system dma" instead of memcpy
+ *
+ * @param dev         Pointer to the device structure for the driver instance
+ * @param pcie_addr   Host memory buffer address
+ * @param local_addr  Local memory buffer address
+ * @param size        Data transfer size (bytes)
+ * @param ob_mem_type Hint if lowmem/highmem outbound region has to be used
+ *                    (PCIE_OB_LOWMEM / PCIE_OB_HIGHMEM / PCIE_OB_ANYMEM)
+ * @param dir         Data transfer direction (HOST_TO_DEVICE / DEVICE_TO_HOST)
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+int pcie_ep_xfer_data_dma(const struct device *dev, uint64_t pcie_addr,
+			  uintptr_t *local_addr, uint32_t size,
+			  enum pcie_ob_mem_type ob_mem_type,
+			  enum xfer_direction dir);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_EP_H_ */


### PR DESCRIPTION
pcie: endpoint: Add public API for data transfer with System DMA

For a given PCIe EP device, till now, we were supporting data transfer to/from Host memory
through memcpy between mapped Host memory (PCIe outbound memory) and EP device's local memory.
The same can also be achieved with "System DMA" if EP is equipped with a "System DMA controller".
Add public API to enable such DMA transfers.

The term "System DMA" is used to clarify that we are not talking about
dedicated "PCIe DMA"; rather the one which does not understand PCIe
address directly, and uses the mapped Host memory.

This API is used in iProc PCIe driver, which integrates PL330 "System DMA" support.
PL330 is used for DMA between Host memory (which is mapped to PCIe outbound memory)
and EP device's local memory.