### PR TITLE
Bluetooth: controller: Make WL size configurable

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -371,6 +371,17 @@ config BT_CTLR_PRIVACY
 	  Enable support for Bluetooth v4.2 LE Controller-based Privacy feature
 	  in the Controller.
 
+config BT_CTLR_WL_SIZE
+	int "LE Controller-based Privacy White List size"
+	depends on BT_CTLR_FILTER
+	default 8
+	range 1 8  if  (SOC_COMPATIBLE_NRF || SOC_OPENISA_RV32M1_RISCV32)
+	range 1 16 if !(SOC_COMPATIBLE_NRF || SOC_OPENISA_RV32M1_RISCV32)
+	help
+	  Set the size of the White List for LE Controller-based Privacy.
+	  On nRF5x-based controllers, the hardware imposes a limit of 8 devices.
+	  On OpenISA-based controllers, the hardware imposes a limit of 8 devices.
+
 config BT_CTLR_RL_SIZE
 	int "LE Controller-based Privacy Resolving List size"
 	depends on BT_CTLR_PRIVACY

--- a/subsys/bluetooth/controller/ll_sw/lll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_filter.h
@@ -4,12 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define WL_SIZE            8
-#define FILTER_IDX_NONE    0xFF
+#if defined(CONFIG_BT_CTLR_WL_SIZE)
+#define WL_SIZE CONFIG_BT_CTLR_WL_SIZE
+#else
+#define WL_SIZE 8
+#endif /* CONFIG_BT_CTLR_WL_SIZE */
+
+#define FILTER_IDX_NONE        0xFF
+#define LLL_FILTER_BITMASK_ALL (BIT(WL_SIZE) - 1)
 
 struct lll_filter {
+#if (WL_SIZE <= 8)
 	uint8_t  enable_bitmask;
 	uint8_t  addr_type_bitmask;
+#elif (WL_SIZE <= 16)
+	uint16_t enable_bitmask;
+	uint16_t addr_type_bitmask;
+#else
+#error WL_SIZE must be <= 16
+#endif
 	uint8_t  bdaddr[WL_SIZE][BDADDR_SIZE];
 };
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1052,7 +1052,7 @@ static uint32_t filter_add(struct lll_filter *filter, uint8_t addr_type,
 {
 	int index;
 
-	if (filter->enable_bitmask == 0xFF) {
+	if (filter->enable_bitmask == LLL_FILTER_BITMASK_ALL) {
 		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 	}
 
@@ -1074,7 +1074,7 @@ static uint32_t filter_remove(struct lll_filter *filter, uint8_t addr_type,
 		return BT_HCI_ERR_INVALID_PARAM;
 	}
 
-	index = 8;
+	index = WL_SIZE;
 	while (index--) {
 		if ((filter->enable_bitmask & BIT(index)) &&
 		    (((filter->addr_type_bitmask >> index) & 0x01) ==


### PR DESCRIPTION
In architectures supporting more than 8 WL entries, e.g. pure
software implementations, it is desirable to be able to increase the
WL size. This change increases the range to 1..16 for SOCs other than
nRF5x and OpenISA.

Signed-off-by: Morten Priess <mtpr@oticon.com>