### PR TITLE
net: tcp2: Use proper int type for connection MSS

### DIFF
--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -83,7 +83,7 @@
 
 #define conn_mss(_conn)					\
 	((_conn)->recv_options.mss_found ?		\
-	 (_conn)->recv_options.mss : NET_IPV6_MTU)
+	 (_conn)->recv_options.mss : (uint16_t)NET_IPV6_MTU)
 
 #define conn_state(_conn, _s)						\
 ({									\


### PR DESCRIPTION
When printing MSS (Maximum Segment Size) value, use uint16_t
always.

Fixes #29997

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>