### PR TITLE
west.yml: tfm: add BUILD_PROFILE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 8e2f6a851a3787b2a86c6606df1333b407324c31
+      revision: a683f7359f0ea2551da7d11509589fcef0dc8a78
 
   self:
     path: zephyr


### PR DESCRIPTION
Updates trusted-firmware-m to pull 29, which enables BUILD_PROFILE
parameter.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>

Updates to https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/29 triggers CI.