### PR TITLE
doc: Add SPARC to the list of supported archs

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -226,9 +226,11 @@ following target architectures:
 
 * :abbr:`Nios II`
 
-* :abbr:`Xtensa`
-
 * :abbr:`RISC-V`
+
+* :abbr:`SPARC`
+
+* :abbr:`Xtensa`
 
 Follow these steps to install the Zephyr SDK:
 

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -16,6 +16,7 @@ The Zephyr kernel supports multiple architectures, including:
  - Intel x86 (32- and 64-bit)
  - NIOS II Gen 2
  - RISC-V (32- and 64-bit)
+ - SPARC V8
  - Tensilica Xtensa
 
 The full list of supported boards based on these architectures can be found :ref:`here <boards>`.


### PR DESCRIPTION
The introduction page lists all the architectures supported by Zephyr.
Now that SPARC V8 support has been merged, add it to the list. Also list
it in the set of architectures supported by the SDK.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>