### PR TITLE
drivers: modem: gsm: Fix DEVICE_DEFINE() data ptr

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -789,5 +789,5 @@ static int gsm_init(const struct device *device)
 	return 0;
 }
 
-DEVICE_DEFINE(gsm_ppp, GSM_MODEM_DEVICE_NAME, gsm_init, &gsm, NULL, NULL,
+DEVICE_DEFINE(gsm_ppp, GSM_MODEM_DEVICE_NAME, gsm_init, NULL, &gsm, NULL,
 	      POST_KERNEL, CONFIG_MODEM_GSM_INIT_PRIORITY, NULL);


### PR DESCRIPTION
The commit 5e97d779bba7 ("device: convert DEVICE_INIT to DEVICE_DEFINE
or SYS_DEVICE_DEFINE") did not convert the gsm_ppp.c properly. The
power management parameter was not set to NULL but was pointing to
the data pointer.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>