### PR TITLE
west.yml: Update TFM module SHA to bring in the TFM MCUboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,8 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 4544ab9fc4d5305ae5de97c73a9356ef0f342f7a
+      revision: 867d714099168481d8ca4ff9de9bfa7c27a0ec63
+      import: true
 
   self:
     path: zephyr


### PR DESCRIPTION
To bring in TFM MCUboot update.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

TFM PR: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/19