### PR TITLE
dfu: mcuboot: allow only to erase secondary slot

### DIFF
--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -728,6 +728,10 @@ int boot_erase_img_bank(uint8_t area_id)
 	const struct flash_area *fa;
 	int rc;
 
+	if (area_id != FLASH_AREA_IMAGE_SECONDARY) {
+		return -EINVAL;
+	}
+
 	rc = flash_area_open(area_id, &fa);
 	if (rc) {
 		return rc;


### PR DESCRIPTION
So far calling boot_erase_img_bank() allowed us to erase any flash area
defined in device-tree. This function should be used only for erasing
mcuboot related partitions, which are FLASH_AREA_IMAGE_PRIMARY,
FLASH_AREA_IMAGE_SECONDARY and FLASH_AREA_IMAGE_SCRATCH. Out of them
only FLASH_AREA_IMAGE_SECONDARY makes sense to be erased, because it is
the place where new firmware is going to be flashed.

Verify that FLASH_AREA_IMAGE_SECONDARY area id is used in
boot_erase_img_bank() implementation, return -EINVAL otherwise.