### PR TITLE
tfm: Configure TFM via Kconfig instead of Cmake

### DIFF
--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -19,5 +19,3 @@ board_runner_args(pyocd "--target=lpc55s69")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-
-set(TFM_TARGET_PLATFORM "nxp/lpcxpresso55s69")

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(EMU_PLATFORM qemu)
-set(TFM_TARGET_PLATFORM "mps2/an521")
 
 set(QEMU_CPU_TYPE_${ARCH} cortex-m33)
 set(QEMU_FLAGS_${ARCH}

--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Set the corresponding TF-M target platform when building for the Non-Secure
-# version of the board (Application MCU).
-if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS)
-  set(TFM_TARGET_PLATFORM "nordic_nrf/nrf5340pdk_nrf5340_cpuapp")
-  set(TFM_PUBLIC_KEY_FORMAT "full")
-endif()
-
-if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS)
-  set(TFM_TARGET_PLATFORM "nordic_nrf/nrf5340dk_nrf5340_cpuapp")
+if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS)
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 

--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Set the corresponding TF-M target platform when building for the Non-Secure
-# version of the board (Application MCU).
 if(CONFIG_BOARD_NRF9160DK_NRF9160NS)
-  set(TFM_TARGET_PLATFORM "nordic_nrf/nrf9160dk_nrf9160")
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 

--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -5,5 +5,3 @@ board_runner_args(pyocd "--target=stm32l552zetxq")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-
-set(TFM_TARGET_PLATFORM "stm/nucleo_l552ze_q")

--- a/boards/arm/v2m_musca_b1/board.cmake
+++ b/boards/arm/v2m_musca_b1/board.cmake
@@ -1,7 +1,5 @@
 #SPDX-License-Identifier: Apache-2.0
 
-set(TFM_TARGET_PLATFORM "musca_b1")
-
 board_set_debugger_ifnset(pyocd)
 board_set_flasher_ifnset(pyocd)
 

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -3,6 +3,20 @@
 # Copyright (c) 2019, 2020 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+
+config TFM_BOARD
+	string
+	default "nordic_nrf/nrf9160dk_nrf9160" if BOARD_NRF9160DK_NRF9160NS
+	default "nordic_nrf/nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPPNS
+	default "nordic_nrf/nrf5340pdk_nrf5340_cpuapp" if BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+	default "nxp/lpcxpresso55s69" if BOARD_LPCXPRESSO55S69_CPU0
+	default "mps2/an521" if BOARD_MPS2_AN521
+	default "stm/nucleo_l552ze_q" if BOARD_NUCLEO_L552ZE_Q
+	default "musca_b1" if BOARD_MUSCA_B1
+	help
+	  The board name used for building TFM. Building with TFM requires that
+	  TFM has been ported to the given board/SoC.
+
 menuconfig BUILD_WITH_TFM
 	bool "Build with TF-M as the Secure Execution Environment"
 	select CMSIS_RTOS_V2
@@ -12,6 +26,7 @@ menuconfig BUILD_WITH_TFM
 	imply INIT_STACKS
 	imply THREAD_MONITOR
 	depends on TRUSTED_EXECUTION_NONSECURE
+	depends on TFM_BOARD != ""
 	help
 	  When enabled, this option instructs the Zephyr build process to
 	  additionaly generate a TF-M image for the Secure Execution
@@ -65,6 +80,12 @@ config TFM_BL2_FALSE
         bool "TFM BL2 disabled"
 
 endchoice
+
+config TFM_IPC
+	bool "IPC"
+
+config TFM_REGRESSION
+	bool "Regression tests"
 
 if !TFM_BL2_FALSE
 

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -1,6 +1,7 @@
-# TF-M/PSA Related
+# Configuration for the TF-M Module
 
 # Copyright (c) 2019, 2020 Linaro Limited
+# Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -83,9 +84,16 @@ endchoice
 
 config TFM_IPC
 	bool "IPC"
+	help
+	  When enabled, this option signifies that the TF-M build supports
+	  the PSA API (IPC mode) instead of the secure library mode.
 
 config TFM_REGRESSION
 	bool "Regression tests"
+	help
+	  When enabled, this option signifies that the TF-M build includes
+	  the Secure and the Non-Secure regression tests.
+
 
 if !TFM_BL2_FALSE
 

--- a/samples/tfm_integration/psa_level_1/CMakeLists.txt
+++ b/samples/tfm_integration/psa_level_1/CMakeLists.txt
@@ -7,24 +7,7 @@ set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_qemu.hex")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-if (CONFIG_TFM_BL2_TRUE)
-    set(TFM_BL2_ARGUMENT BL2 True)
-elseif (CONFIG_TFM_BL2_FALSE)
-    set(TFM_BL2_ARGUMENT BL2 False)
-endif()
-
-# Add "tfm" as an external project via the TF-M module's cmake file
-trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
-                       BOARD ${TFM_TARGET_PLATFORM}
-                       IPC
-                       REGRESSION
-                       ${TFM_BL2_ARGUMENT}
-)
-
 project(tfm_psa_level_1)
-
-# Set "tfm" as a dependency so that it's built before the app
-add_dependencies(app tfm)
 
 # Source files in this sample
 target_sources(app PRIVATE src/main.c)
@@ -35,9 +18,3 @@ target_sources(app PRIVATE src/tfm_ipc.c)
 target_sources(app PRIVATE src/util_app_cfg.c)
 target_sources(app PRIVATE src/util_app_log.c)
 target_sources(app PRIVATE src/util_sformat.c)
-
-# Include TF-M secure service source files
-target_link_libraries(app PRIVATE tfm_api)
-
-# Link in veneer function locations
-target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${VENEERS_FILE})

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -7,39 +7,6 @@ set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_qemu.hex")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-if (CONFIG_TFM_BL2_TRUE)
-   set(TFM_BL2_ARGUMENT BL2 True)
-elseif (CONFIG_TFM_BL2_FALSE)
-   set(TFM_BL2_ARGUMENT BL2 False)
-endif()
-
-# Add "tfm" as an external project via the TF-M module's cmake file
-if("${TFM_TARGET_PLATFORM}" STREQUAL "stm/nucleo_l552ze_q")
-   trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
-                          BOARD ${TFM_TARGET_PLATFORM}
-                          IPC
-                          ISOLATION_LEVEL 2
-                          REGRESSION
-                          ${TFM_BL2_ARGUMENT}
-   )
-else()
-   trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
-                          BOARD ${TFM_TARGET_PLATFORM}
-                          IPC
-                          REGRESSION
-                          ${TFM_BL2_ARGUMENT}
-  )
-endif()
-
 project(tfm_ipc)
 
-# Set "tfm" as a dependency
-add_dependencies(app tfm)
-
 target_sources(app PRIVATE src/main.c)
-
-# Include TF-M secure service source files
-target_link_libraries(app PRIVATE tfm_api)
-
-# Link in veneer function locations
-target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${VENEERS_FILE})

--- a/samples/tfm_integration/tfm_ipc/prj.conf
+++ b/samples/tfm_integration/tfm_ipc/prj.conf
@@ -1,4 +1,6 @@
 CONFIG_BUILD_WITH_TFM=y
+CONFIG_TFM_IPC=y
+CONFIG_TFM_REGRESSION=y
 
 # The Zephyr CMSIS emulation assumes that ticks are ms, currently
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 83c964e51d62fa605e48a1a1461f7304548f4471
+      revision: 6edaaaaaa1a227cb1ccc9ef698a9d2e258a9bbd5
 
   self:
     path: zephyr


### PR DESCRIPTION
Add Kconfig options that will be used by the module to call the function
with the desired parameters. Refactor the tfm_integration samples and
the supported boards.

Update west.yml to bring in Cmake changes that use the new KConfigs.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

TFM PR: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/21