### PR TITLE
MAINTAINERS: cleanup inline comments

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -172,7 +172,6 @@ Bluetooth controller:
         - subsys/bluetooth/controller/
 
 Bluetooth Mesh:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - trond-snekvik
@@ -227,7 +226,6 @@ Common arch:
         - "area: Architectures"
 
 Console:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - pfalcon
@@ -295,7 +293,6 @@ Display drivers:
         - "area: Display"
 
 Documentation:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - carlescufi
@@ -310,7 +307,6 @@ Documentation:
         - "area: Documentation"
 
 "Drivers: ADC":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - anangl
@@ -346,7 +342,6 @@ Documentation:
         - "area: CAN"
 
 "Drivers: Clock control":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
        - nordic-krch
@@ -392,7 +387,6 @@ Documentation:
         - "area: Crypto / RNG"
 
 "Drivers: DAC":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - martinjaeger
@@ -413,7 +407,6 @@ Documentation:
         - "area: DMA"
 
 "Drivers: EEPROM":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - henrikbrixandersen
@@ -426,7 +419,6 @@ Documentation:
         - "area: EEPROM"
 
 "Drivers: Entropy":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - ceolin
@@ -485,7 +477,6 @@ Documentation:
         - "area: GPIO"
 
 "Drivers: HW Info":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - alexanderwachter
@@ -498,7 +489,6 @@ Documentation:
         - "area: HWINFO"
 
 "Drivers: I2C":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - pabigot
@@ -510,7 +500,6 @@ Documentation:
         - "area: I2C"
 
 "Drivers: I2S":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - anangl
@@ -558,7 +547,6 @@ Documentation:
         - tests/drivers/kscan/
 
 "Drivers: LED":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - Mani-Sadhasivam
@@ -580,7 +568,6 @@ Documentation:
         - include/drivers/led_strip.h
 
 "Drivers: lora":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - Mani-Sadhasivam
@@ -634,7 +621,6 @@ Documentation:
         - "area: Pinmux"
 
 "Drivers: PTP Clock":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - jukkar
@@ -643,7 +629,6 @@ Documentation:
         - include/ptp_clock.h
 
 "Drivers: PWM":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - anangl
@@ -744,7 +729,6 @@ Documentation:
         Inventek es-WiFi
 
 Filesystems:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - nvlsianpu
@@ -771,7 +755,6 @@ JSON Web Token:
         - subsys/jwt/
 
 Kconfig:
-    # Provisional entry, subject to approval
     status: orphaned
     files:
         - scripts/kconfig/
@@ -798,7 +781,6 @@ Kernel:
         - "area: Kernel"
 
 Little FS:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - pabigot
@@ -822,7 +804,6 @@ Logging:
         - "area: Logging"
 
 MAINTAINERS file:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - MaureenHelm
@@ -836,7 +817,6 @@ MAINTAINERS file:
         Zephyr Maintainers File
 
 MCU Manager:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - de-nordic
@@ -925,7 +905,6 @@ Networking:
         - tests/net/buf/
 
 "Networking: CoAP":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - rlubos
@@ -937,7 +916,6 @@ Networking:
         - tests/net/lib/coap/
 
 "Networking: LWM2M":
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - rlubos
@@ -991,7 +969,6 @@ POSIX API layer:
         - "area: POSIX"
 
 Power management:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - wentongwu
@@ -1003,7 +980,6 @@ Power management:
         - "area: Power Management"
 
 RISCV arch:
-    # Provisional entry, subject to approval
     status: orphaned
     collaborators:
         - mgielda
@@ -1093,7 +1069,6 @@ STM32:
         boards.
 
 Storage:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - nvlsianpu
@@ -1105,7 +1080,6 @@ Storage:
         - "area: Storage"
 
 TF-M Integration:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - microbuilder
@@ -1129,7 +1103,6 @@ Tracing:
         - "area: tracing"
 
 USB:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - jfischer-no
@@ -1158,7 +1131,6 @@ Userspace:
         - "area: Userspace"
 
 VFS:
-    # Provisional entry, subject to approval
     status: maintained
     maintainers:
         - de-nordic


### PR DESCRIPTION
Cleanup comments: # Provisional entry, subject to approval
That's because the MAINTAINERS file was reviewed in the
last TSC F2F and the entries are not provisional any more.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>