### PR TITLE
boards: soc: Set zephyr,flash chosen node for i.MX RT boards

### DIFF
--- a/boards/arm/mimxrt1010_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1010_evk/Kconfig.defconfig
@@ -8,8 +8,4 @@ if BOARD_MIMXRT1010_EVK
 config BOARD
 	default "mimxrt1010_evk" if BOARD_MIMXRT1010_EVK
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 endif # BOARD_MIMXRT1010_EVK

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -44,11 +44,11 @@ arduino_serial: &lpuart1 {};
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
-	at25sf128a: at25sf128a@0 {
+	at25sf128a: at25sf128a@60000000 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;
 		label = "AT25SF128A";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(16)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
+		zephyr,flash = &at25sf128a;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
@@ -43,7 +44,6 @@
 arduino_serial: &lpuart1 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@60000000 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1015_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1015_evk/Kconfig.defconfig
@@ -8,8 +8,4 @@ if BOARD_MIMXRT1015_EVK
 config BOARD
 	default "mimxrt1015_evk" if BOARD_MIMXRT1015_EVK
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 endif # BOARD_MIMXRT1015_EVK

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
+		zephyr,flash = &at25sf128a;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
@@ -72,7 +73,6 @@
 arduino_serial: &lpuart4 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@60000000 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -73,11 +73,11 @@ arduino_serial: &lpuart4 {};
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
-	at25sf128a: at25sf128a@0 {
+	at25sf128a: at25sf128a@60000000 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		size = <134217728>;
 		label = "AT25SF128A";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(16)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_MIMXRT1020_EVK
 config BOARD
 	default "mimxrt1020_evk" if BOARD_MIMXRT1020_EVK
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -80,11 +80,11 @@ arduino_serial: &lpuart2 {};
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
-	is25wp064: is25wp064@0 {
+	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -20,6 +20,7 @@
 	chosen {
 		zephyr,sram = &sdram0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash = &is25wp064;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
@@ -79,7 +80,6 @@
 arduino_serial: &lpuart2 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_MIMXRT1050_EVK || BOARD_MIMXRT1050_EVK_QSPI
 config BOARD
 	default "mimxrt1050_evk"
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -22,6 +22,7 @@
 	chosen {
 		zephyr,sram = &sdram0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash = &hyperflash0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
@@ -90,7 +91,6 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	hyperflash0: hyperflash@60000000 {
 		compatible = "cypress,s26ks512s";
 		reg = <0x60000000 DT_SIZE_M(64)>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -91,9 +91,9 @@ arduino_serial: &lpuart3 {};
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
-	hyperflash0: hyperflash@0 {
+	hyperflash0: hyperflash@60000000 {
 		compatible = "cypress,s26ks512s";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(64)>;
 		status = "okay";
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -8,8 +8,13 @@
 
 /delete-node/ &hyperflash0;
 
+/ {
+	chosen {
+		zephyr,flash = &is25wp064;
+	};
+};
+
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -10,11 +10,11 @@
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
-	is25wp064: is25wp064@0 {
+	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -9,10 +9,6 @@ config BOARD
 	default "mimxrt1060_evk" if BOARD_MIMXRT1060_EVK
 	default "mimxrt1060_evk_hyperflash" if BOARD_MIMXRT1060_EVK_HYPERFLASH
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -22,6 +22,7 @@
 	chosen {
 		zephyr,sram = &sdram0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash = &is25wp064;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;
@@ -91,7 +92,6 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -92,11 +92,11 @@ arduino_serial: &lpuart3 {};
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
-	is25wp064: is25wp064@0 {
+	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -7,8 +7,14 @@
 #include "mimxrt1060_evk.dts"
 
 /delete-node/ &is25wp064;
+
+/ {
+	chosen {
+		zephyr,flash = &hyperflash0;
+	};
+};
+
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	hyperflash0: hyperflash@60000000 {
 		compatible = "cypress,s26ks512s";
 		reg = <0x60000000 DT_SIZE_M(64)>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -9,9 +9,9 @@
 /delete-node/ &is25wp064;
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
-	hyperflash0: hyperflash@0 {
+	hyperflash0: hyperflash@60000000 {
 		compatible = "cypress,s26ks512s";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(64)>;
 		status = "okay";
 	};
 };

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_MIMXRT1064_EVK
 config BOARD
 	default "mimxrt1064_evk"
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI2
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -22,6 +22,7 @@
 	chosen {
 		zephyr,sram = &sdram0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash = &w25q32jvwj0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,can-primary = &flexcan2;

--- a/boards/arm/mm_swiftio/Kconfig.defconfig
+++ b/boards/arm/mm_swiftio/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_MM_SWIFTIO
 config BOARD
 	default "mm_swiftio"
 
-choice CODE_LOCATION
-	default CODE_FLEXSPI
-endchoice
-
 config DISK_ACCESS_USDHC1
 	default y
 	depends on DISK_ACCESS_USDHC

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sdram0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash = &is25wp064;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
@@ -52,7 +53,6 @@
 
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -53,11 +53,11 @@
 
 &flexspi {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
-	is25wp064: is25wp064@0 {
+	is25wp064: is25wp064@60000000 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -92,22 +92,22 @@
 			};
 		};
 
-		flexspi: spi@402a8000 {
+		flexspi: flash-controller@402a8000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x402a8000 0x4000>;
 			interrupts = <108 0>;
 			label = "FLEXSPI";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 		};
 
-		flexspi2: spi@402a4000 {
+		flexspi2: flash-controller@402a4000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x402a4000 0x4000>;
 			interrupts = <107 0>;
 			label = "FLEXSPI1";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 		};
 
 		semc: semc0@402f0000 {

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -7,7 +7,6 @@
 #include <nxp/nxp_rt1060.dtsi>
 
 &flexspi2 {
-	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
 	/* WINBOND */
 	w25q32jvwj0: w25q32jvwj@70000000 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -9,11 +9,11 @@
 &flexspi2 {
 	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
 	/* WINBOND */
-	w25q32jvwj0: w25q32jvwj@0 {
+	w25q32jvwj0: w25q32jvwj@70000000 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
 		size = <33554432>;
 		label = "W25Q32JVWJ0";
-		reg = <0>;
+		reg = <0x70000000 DT_SIZE_M(4)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [ef 40 16];

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -81,13 +81,13 @@
 		#gpio-cells = <2>;
 	};
 
-	flexspi: spi@134000 {
+	flexspi: flash-controller@134000 {
 		compatible = "nxp,imx-flexspi";
 		reg = <0x134000 0x1000>;
 		interrupts = <42 0>;
 		label = "FLEXSPI";
 		#address-cells = <1>;
-		#size-cells = <0>;
+		#size-cells = <1>;
 	};
 
 	flexcomm0: flexcomm@106000 {

--- a/dts/bindings/flash_controller/nxp,imx-flexspi.yaml
+++ b/dts/bindings/flash_controller/nxp,imx-flexspi.yaml
@@ -5,7 +5,7 @@ description: NXP FlexSPI controller
 
 compatible: "nxp,imx-flexspi"
 
-include: spi-controller.yaml
+include: flash-controller.yaml
 
 properties:
     reg:
@@ -13,3 +13,11 @@ properties:
 
     interrupts:
       required: true
+
+    "#address-cells":
+      required: true
+      const: 1
+
+    "#size-cells":
+      required: true
+      const: 1

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -66,46 +66,6 @@ config WDT_MCUX_IMX_WDOG
 	default y
 	depends on WATCHDOG
 
-if CODE_SEMC
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/memory@80000000,0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/memory@80000000)
-
-endif # CODE_SEMC
-
-if CODE_ITCM
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flexram@400b0000/itcm@0,0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/itcm@0)
-
-endif # CODE_ITCM
-
-if CODE_FLEXSPI
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@402a8000,1,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@402a8000,1)
-
-endif # CODE_FLEXSPI
-
-if CODE_FLEXSPI2
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@402a4000,1,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@402a4000,1)
-
-endif # CODE_FLEXSPI2
-
 config USB_DC_NXP_EHCI
 	default y
 	depends on USB

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -342,6 +342,7 @@ config IPG_DIV
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
 	bool "Enable the boot header"
+	default y
 	help
 	  Enable data structures required by the boot ROM to boot the
 	  application from an external flash device.
@@ -392,25 +393,5 @@ config DEVICE_CONFIGURATION_DATA
 	  the boot ROM to initialize components such as an SDRAM.
 
 endif # NXP_IMX_RT_BOOT_HEADER
-
-choice CODE_LOCATION
-	prompt "Code location selection"
-	default CODE_ITCM
-
-config CODE_SEMC
-	bool "Link code into external SEMC-controlled memory"
-
-config CODE_ITCM
-	bool "Link code into internal instruction tightly coupled memory (ITCM)"
-
-config CODE_FLEXSPI
-	bool "Link code into external FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER
-
-config CODE_FLEXSPI2
-	bool "Link code into internal FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER
-
-endchoice
 
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -8,6 +8,7 @@
  #include <devicetree.h>
 
 #define IS_CHOSEN_SRAM(x) (DT_DEP_ORD(DT_NODELABEL(x)) == DT_DEP_ORD(DT_CHOSEN(zephyr_sram)))
+#define IS_CHOSEN_FLASH(x) (DT_DEP_ORD(DT_NODELABEL(x)) == DT_DEP_ORD(DT_CHOSEN(zephyr_flash)))
 
 MEMORY
      {
@@ -17,7 +18,7 @@ MEMORY
 #if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !IS_CHOSEN_SRAM(sdram0)
         SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_SIZE(DT_NODELABEL(sdram0))
 #endif
-#if (DT_REG_SIZE(DT_INST(0, nxp_imx_itcm)) > 0) && !defined(CONFIG_CODE_ITCM)
+#if (DT_REG_SIZE(DT_NODELABEL(itcm)) > 0) && !IS_CHOSEN_FLASH(itcm)
         ITCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_itcm))
 #endif
      }


### PR DESCRIPTION
Removes the CODE_LOCATION Kconfig symbol from the i.MX RT SoC series and
refactors the corresponding boards to use a device tree chosen node
zephyr,flash instead. This is similar to commit
0797602 which did the same for
DATA_LOCATION and zephyr,sram.