### PR TITLE
drivers: wifi: esp: support hostname configuration

### DIFF
--- a/include/net/hostname.h
+++ b/include/net/hostname.h
@@ -22,6 +22,11 @@ extern "C" {
  * @{
  */
 
+#define NET_HOSTNAME_MAX_LEN				\
+	(sizeof(CONFIG_NET_HOSTNAME) - 1 +		\
+	 (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE) ?	\
+	  sizeof("0011223344556677") - 1 : 0))
+
 /**
  * @brief Get the device hostname
  *

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -13,16 +13,10 @@ LOG_MODULE_REGISTER(net_hostname, CONFIG_NET_HOSTNAME_LOG_LEVEL);
 
 #include <zephyr.h>
 
+#include <net/hostname.h>
 #include <net/net_core.h>
 
-#if defined(CONFIG_NET_HOSTNAME_UNIQUE)
-/* Allocate extra space to append MAC address to hostname */
-#define EXTRA_SPACE (8 * 2)
-#else
-#define EXTRA_SPACE 0
-#endif /* CONFIG_NET_HOSTNAME_UNIQUE */
-
-static char hostname[sizeof(CONFIG_NET_HOSTNAME) + EXTRA_SPACE];
+static char hostname[NET_HOSTNAME_MAX_LEN + 1];
 
 const char *net_hostname_get(void)
 {
@@ -45,7 +39,7 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 
 	/* Note that we convert the postfix to hex (2 chars / byte) */
 	if ((postfix_len * 2) >
-	    ((sizeof(hostname) - 1) - (sizeof(CONFIG_NET_HOSTNAME) - 1))) {
+	    (NET_HOSTNAME_MAX_LEN - (sizeof(CONFIG_NET_HOSTNAME) - 1))) {
 		return -EMSGSIZE;
 	}
 


### PR DESCRIPTION
Configure hostname by issuing AT+CWHOSTNAME="<hostname>" command. Do it
just after setting link address, which is used to generate hostname
postfix when CONFIG_NET_HOSTNAME_UNIQUE=y.