### PR TITLE
net: hostname: fix logging hostname string

### DIFF
--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -54,7 +54,7 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 			 2 + 1, "%02x", hostname_postfix[i]);
 	}
 
-	NET_DBG("New hostname %s", hostname);
+	NET_DBG("New hostname %s", log_strdup(hostname));
 
 	postfix_set = true;
 
@@ -66,5 +66,5 @@ void net_hostname_init(void)
 {
 	memcpy(hostname, CONFIG_NET_HOSTNAME, sizeof(CONFIG_NET_HOSTNAME) - 1);
 
-	NET_DBG("Hostname set to %s", hostname);
+	NET_DBG("Hostname set to %s", CONFIG_NET_HOSTNAME);
 }


### PR DESCRIPTION
Following errors occuring after enabling debug logs:

```
  log: argument 2 in source net_hostname log message "%s: (%s): \
    Hostname set to %s" missinglog_strdup().
  log: argument 2 in source net_hostname log message "%s: (%s): \
    New hostname %s" missinglog_strdup().
```

Fix that by printing CONFIG_NET_HOSTNAME directly in the first case and
using log_strdup() in the second.