### PR TITLE
kernel: const-qualify objects used to calculate delay values

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -856,10 +856,10 @@ extern k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
  * executes, in units of system ticks.  If the thread is not waiting,
  * it returns current system time.
  */
-__syscall k_ticks_t k_thread_timeout_expires_ticks(struct k_thread *t);
+__syscall k_ticks_t k_thread_timeout_expires_ticks(const struct k_thread *t);
 
 static inline k_ticks_t z_impl_k_thread_timeout_expires_ticks(
-						struct k_thread *t)
+						const struct k_thread *t)
 {
 	return z_timeout_expires(&t->base.timeout);
 }
@@ -871,10 +871,10 @@ static inline k_ticks_t z_impl_k_thread_timeout_expires_ticks(
  * next executes, in units of system ticks.  If the thread is not
  * waiting, it returns zero.
  */
-__syscall k_ticks_t k_thread_timeout_remaining_ticks(struct k_thread *t);
+__syscall k_ticks_t k_thread_timeout_remaining_ticks(const struct k_thread *t);
 
 static inline k_ticks_t z_impl_k_thread_timeout_remaining_ticks(
-						struct k_thread *t)
+						const struct k_thread *t)
 {
 	return z_timeout_remaining(&t->base.timeout);
 }
@@ -1741,9 +1741,10 @@ __syscall uint32_t k_timer_status_sync(struct k_timer *timer);
  * @param timer The timer object
  * @return Uptime of expiration, in ticks
  */
-__syscall k_ticks_t k_timer_expires_ticks(struct k_timer *timer);
+__syscall k_ticks_t k_timer_expires_ticks(const struct k_timer *timer);
 
-static inline k_ticks_t z_impl_k_timer_expires_ticks(struct k_timer *timer)
+static inline k_ticks_t z_impl_k_timer_expires_ticks(
+				       const struct k_timer *timer)
 {
 	return z_timeout_expires(&timer->timeout);
 }
@@ -1755,9 +1756,10 @@ static inline k_ticks_t z_impl_k_timer_expires_ticks(struct k_timer *timer)
  * next expires, in units of system ticks.  If the timer is not
  * running, it returns zero.
  */
-__syscall k_ticks_t k_timer_remaining_ticks(struct k_timer *timer);
+__syscall k_ticks_t k_timer_remaining_ticks(const struct k_timer *timer);
 
-static inline k_ticks_t z_impl_k_timer_remaining_ticks(struct k_timer *timer)
+static inline k_ticks_t z_impl_k_timer_remaining_ticks(
+				       const struct k_timer *timer)
 {
 	return z_timeout_remaining(&timer->timeout);
 }
@@ -3169,7 +3171,7 @@ static inline int k_delayed_work_submit(struct k_delayed_work *work,
  * @return Uptime of execution (in ticks).
  */
 static inline k_ticks_t k_delayed_work_expires_ticks(
-				       struct k_delayed_work *work)
+				       const struct k_delayed_work *work)
 {
 	return z_timeout_expires(&work->timeout);
 }
@@ -3187,7 +3189,7 @@ static inline k_ticks_t k_delayed_work_expires_ticks(
  * @return Remaining time (in ticks).
  */
 static inline k_ticks_t k_delayed_work_remaining_ticks(
-				       struct k_delayed_work *work)
+				       const struct k_delayed_work *work)
 {
 	return z_timeout_remaining(&work->timeout);
 }
@@ -3203,7 +3205,7 @@ static inline k_ticks_t k_delayed_work_remaining_ticks(
  *
  * @return Remaining time (in milliseconds).
  */
-static inline int32_t k_delayed_work_remaining_get(struct k_delayed_work *work)
+static inline int32_t k_delayed_work_remaining_get(const struct k_delayed_work *work)
 {
 	return k_ticks_to_ms_floor32(z_timeout_remaining(&work->timeout));
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1009,7 +1009,7 @@ int z_vrfy_k_thread_stack_space_get(const struct k_thread *thread,
 
 #ifdef CONFIG_USERSPACE
 static inline k_ticks_t z_vrfy_k_thread_timeout_remaining_ticks(
-						    struct k_thread *t)
+						    const struct k_thread *t)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(t, K_OBJ_THREAD));
 	return z_impl_k_thread_timeout_remaining_ticks(t);
@@ -1017,7 +1017,7 @@ static inline k_ticks_t z_vrfy_k_thread_timeout_remaining_ticks(
 #include <syscalls/k_thread_timeout_remaining_ticks_mrsh.c>
 
 static inline k_ticks_t z_vrfy_k_thread_timeout_expires_ticks(
-						  struct k_thread *t)
+						  const struct k_thread *t)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(t, K_OBJ_THREAD));
 	return z_impl_k_thread_timeout_expires_ticks(t);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -242,14 +242,16 @@ static inline uint32_t z_vrfy_k_timer_status_sync(struct k_timer *timer)
 }
 #include <syscalls/k_timer_status_sync_mrsh.c>
 
-static inline k_ticks_t z_vrfy_k_timer_remaining_ticks(struct k_timer *timer)
+static inline k_ticks_t z_vrfy_k_timer_remaining_ticks(
+						const struct k_timer *timer)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(timer, K_OBJ_TIMER));
 	return z_impl_k_timer_remaining_ticks(timer);
 }
 #include <syscalls/k_timer_remaining_ticks_mrsh.c>
 
-static inline k_ticks_t z_vrfy_k_timer_expires_ticks(struct k_timer *timer)
+static inline k_ticks_t z_vrfy_k_timer_expires_ticks(
+						const struct k_timer *timer)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(timer, K_OBJ_TIMER));
 	return z_impl_k_timer_expires_ticks(timer);


### PR DESCRIPTION
The internal API to measure time until a delay expires does not modify
the referenced timeout.  Make the functions that call it take pointers
to const objects, so that they can be used with pointer to
const-qualified containers.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>