### PR TITLE
ci: restore number of builders to 20

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.11.4"
-    parallelism: 50
+    parallelism: 20
     timeout_in_minutes: 180
     retry:
       manual: true


### PR DESCRIPTION
We accidently merged a PR that had bumped the number of builders to 50.
Set it back to 20.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>