### PR TITLE
logging: add padding for RISC-V 64bits environment

### DIFF
--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -35,6 +35,10 @@ struct log_source_dynamic_data {
 	 */
 	uint32_t dummy[2];
 #endif
+#if defined(CONFIG_RISCV) && defined(CONFIG_64BIT)
+	/* Workaround: RV64 needs to ensure that structure is just 8 bytes. */
+	uint32_t dummy;
+#endif
 };
 
 /** @brief Creates name of variable and section for constant log data.


### PR DESCRIPTION
This patch add padding in filter structure of log system.
In RISCV && 64BIT environment. Log system is facing alignment bug.

struct log_source_dynamic_data {
	uint32_t filters;
};

static inline uint32_t *log_dynamic_filters_get(uint32_t source_id)
{
	return &__log_dynamic_start[source_id].filters;
}

A sizeof(log_source_dynamic_data) = 4, address offset of
&__log_dynamic_start[] are:
  - &__log_dynamic_start[0]: +0
  - &__log_dynamic_start[1]: +4
  - &__log_dynamic_start[2]: +8

But RISCV 64bit gcc/ld places each log_dynamic_log, log_dynamic_os
and log_dynamic_test per 8bytes alignment. So address offset of
log_dynamic_* are:
  - &log_dynamic_log : +0
  - &log_dynamic_os  : +8
  - &log_dynamic_test: +16

tests/subsys/logging/log_core cannot set correct log filters in
RISCV && 64BIT environment, so test is always going to fail.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>