### PR TITLE
dts: riscv32-fe310: add missing clint properties

### DIFF
--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -45,7 +45,9 @@
 			reg-names = "control";
 		};
 		clint: clint@2000000 {
+			#interrupt-cells = <1>;
 			compatible = "riscv,clint0";
+			interrupt-controller;
 			interrupts-extended = <&hlic 3 &hlic 7>;
 			reg = <0x2000000 0x10000>;
 			reg-names = "control";


### PR DESCRIPTION
RISC-V clint is an interrupt controller but it has no required
properties (#interrupt-cells and interrupt-controller).
This patch just adds missing properties.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>