### PR TITLE
drivers: sensors: bmi160: Fix issue with sample read

### DIFF
--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -468,7 +468,6 @@ union bmi160_pmu_status {
 union bmi160_sample {
 	uint8_t raw[BMI160_BUF_SIZE];
 	struct {
-		uint8_t dummy_byte;
 #if !defined(CONFIG_BMI160_GYRO_PMU_SUSPEND)
 		uint16_t gyr[BMI160_AXES];
 #endif

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -60,18 +60,21 @@ static const char *const pmu_name[] = {"acc", "gyr", "mag", "INV"};
 
 static void sample_read(struct bmi160_emul_data *data, union bmi160_sample *buf)
 {
-	int i;
+	/*
+	 * Use hard-coded scales to get values just above 0, 1, 2 and
+	 * 3, 4, 5. Values are stored in little endianess.
+	 * gyr[x] = 0x0b01  // 3 * 1000000 / BMI160_GYR_SCALE(2000) + 1
+	 * gyr[y] = 0x0eac  // 4 * 1000000 / BMI160_GYR_SCALE(2000) + 1
+	 * gyr[z] = 0x1257  // 5 * 1000000 / BMI160_GYR_SCALE(2000) + 1
+	 * acc[x] = 0x0001  // 0 * 1000000 / BMI160_ACC_SCALE(2) + 1
+	 * acc[y] = 0x0689  // 1 * 1000000 / BMI160_ACC_SCALE(2) + 1
+	 * acc[z] = 0x0d11  // 2 * 1000000 / BMI160_ACC_SCALE(2) + 1
+	 */
+	static uint8_t raw_data[] = { 0x01, 0x0b, 0xac, 0x0e, 0x57, 0x12, 0x01, 0x00,
+							0x89, 0x06, 0x11, 0x0d };
 
 	LOG_INF("Sample read");
-	buf->dummy_byte = 0;
-	for (i = 0; i < BMI160_AXES; i++) {
-		/*
-		 * Use hard-coded scales to get values just above 0, 1, 2 and
-		 * 3, 4, 5.
-		  */
-		buf->acc[i] = sys_cpu_to_le16(i * 1000000 / 598 + 1);
-		buf->gyr[i] = sys_cpu_to_le16((i + 3) * 1000000 / 1065 + 1);
-	}
+	memcpy(buf->raw, raw_data, ARRAY_SIZE(raw_data));
 }
 
 static void reg_write(const struct bmi160_emul_cfg *cfg, int regn, int val)
@@ -160,6 +163,12 @@ static int reg_read(const struct bmi160_emul_cfg *cfg, int regn)
 		break;
 	case BMI160_SPI_START:
 		LOG_INF("   * Bus start");
+		break;
+	case BMI160_REG_ACC_RANGE:
+		LOG_INF("   * acc range");
+		break;
+	case BMI160_REG_GYR_RANGE:
+		LOG_INF("   * gyr range");
 		break;
 	default:
 		LOG_INF("Unknown read %x", regn);


### PR DESCRIPTION
When testing the bmi160 I've come across an issue where the readings
didn't make sense to me. The issue comes from reading the
BMI160_SAMPLE_BURST_READ_ADDR which is 0x0C assuming both accelerometer
and gyroscope. At this point we would normally read 12 bytes
(2 bytes per sample * 3 axes * 2 sensors). This reading takes place in
bmi160_sample_fetch and begins writing to data->sample.raw

Without this change, the first byte written is actually to the dummy
byte which effectively gets tossed. The issue is that this is the
GYR_X<7:0>(LSB) according to the BMI160 data sheet. When we later call
either bmi160_gyr_channel_get or bmi160_acc_channel_get we're looking
at sample.gyr and sample.acc (which is effectively shiften by 1 byte).

This change gets rid of the dummy byte which re-alignes gyr with the
start of the raw buffer.

Signed-off-by: Yuval Peress <peress@chromium.org>