### PR TITLE
include: drivers: add missing extern "C" in led.h and lora.h

### DIFF
--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -22,6 +22,10 @@
 #include <zephyr/types.h>
 #include <device.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief LED information structure
  *
@@ -322,6 +326,10 @@ static inline int z_impl_led_off(const struct device *dev, uint32_t led)
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <syscalls/led.h>
 

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -15,6 +15,10 @@
 #include <zephyr/types.h>
 #include <device.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum lora_signal_bandwidth {
 	BW_125_KHZ = 0,
 	BW_250_KHZ,
@@ -178,5 +182,9 @@ static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
 
 	return api->test_cw(dev, frequency, tx_power, duration);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* ZEPHYR_INCLUDE_DRIVERS_LORA_H_ */


### PR DESCRIPTION
The following lines are missing:
#ifdef __cplusplus
extern "C" {
#endif

and

#ifdef __cplusplus
}
#endif

Signed-off-by: Patrick Morger patrick.morger@leica-geosystems.com