### PR TITLE
boards: pinetime_devkit0: fix documentation and sample

### DIFF
--- a/boards/arm/pinetime_devkit0/doc/index.rst
+++ b/boards/arm/pinetime_devkit0/doc/index.rst
@@ -11,10 +11,10 @@ Overview
    :align: center
    :alt: Pine64 PineTime
 
-   Board Name (Credit: <owner>)
+   PineTime leaflet (Credit: Pine64)
 
 
-The PINE64 SmartWatch, dubbed "PineTime", is a product of a community effort
+The Pine64 smartwatch, dubbed "PineTime", is a product of a community effort
 for an open source smartwatch in collaboration with wearable RTOS and Linux
 app developers/communities.
 
@@ -23,102 +23,131 @@ app developers/communities.
    :align: center
    :alt: Pine64 PineTime
 
-   Board Name (Credit: <owner>)
+   PineTime Dev Kit (Credit: Pine64)
 
 Hardware
 ********
 
-The Pinetime is based on a Nordic NRF52832 chip and features:
+The PineTime is based on a Nordic NRF52832 chip and features:
 
 - 64 MHz Cortex-M4 with FPU
 - 64KB SRAM
 - 512KB on board Flash
 - 1.3 inches (33mm), 240x240 pixels display with ST7789 driver
 - 170-180mAh LiPo battery
-- XT25F32B 32Mb(4MB) SPI NOR Flash
+- XT25F32B 32Mb (4MB) SPI NOR Flash
 - CST816S Capacitive Touch
-- BMA421 Triaxial VAcceleration Sensor
+- BMA421 Triaxial Acceleration Sensor
 - HRS3300 PPG Heart Rate Sensor
 
 PineTime Port Assignment
 ========================
 
-See `Pinetime schematics`_
+See `PineTime schematics`_
 +----------------------+---------------------------------+-----------+
 | NRF52 pins           | Function                        | Direction |
 +======================+=================================+===========+
-| P0.00/XL1            | 32.768KHz –XL1                  |           |
-| P0.01/XL2            | 32.768KHz –XL1                  |           |
+| P0.00/XL1            | 32.768 kHz –XL1                 |           |
++----------------------+---------------------------------+-----------+
+| P0.01/XL2            | 32.768 kHz –XL2                 |           |
++----------------------+---------------------------------+-----------+
 | P0.02/AIN0           | SPI-SCK, LCD_SCK                | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.03/AIN1           | SPI-MOSI, LCD_SDI               | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.04/AIN2           | SPI-MISO                        | IN        |
++----------------------+---------------------------------+-----------+
 | P0.05/AIN3           | SPI-CE# (SPI-NOR)               | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.06                | BMA421-SDA, HRS3300-SDA, TP-SDA | I/O       |
++----------------------+---------------------------------+-----------+
 | P0.07                | BMA421-SCL, HRS3300-SCL, TP-SCL | OUT       |
-| P0.08                | BMA421-INT                      | IN        |
++----------------------+---------------------------------+-----------+
+| P0.08                | BMA421-INT                      | IN        |
++----------------------+---------------------------------+-----------+
 | P0.09/NFC1           | LCD_DET                         | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.10/NFC2           | TP_RESET                        | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.11                |                                 |           |
++----------------------+---------------------------------+-----------+
 | P0.12                | CHARGE INDICATION               | IN        |
++----------------------+---------------------------------+-----------+
 | P0.13                | PUSH BUTTON_IN                  | IN        |
++----------------------+---------------------------------+-----------+
 | P0.14/TRACEDATA3     | LCD_BACKLIGHT_LOW               | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.15/TRACEDATA2     | PUSH BUTTON_OUT                 | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.16/TRACEDATA1     | VIBRATOR OUT                    | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.17                |                                 |           |
++----------------------+---------------------------------+-----------+
 | P0.18/TRACEDATA0/SWO | LCD_RS OUT                      |           |
++----------------------+---------------------------------+-----------+
 | P0.19                | POWER PRESENCE INDICATION       | IN        |
++----------------------+---------------------------------+-----------+
 | P0.20/TRACECLK       |                                 |           |
++----------------------+---------------------------------+-----------+
 | P0.21/nRESET         |                                 |           |
++----------------------+---------------------------------+-----------+
 | P0.22                | LCD_BACKLIGHT_MID               | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.23                | LCD_BACKLIGHT_HIGH              | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.24                | 3V3 POWER CONTROL               | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.25                | LCD_CS                          | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.26                | LCD_RESET                       | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.27                | STATUS LED (NOT STAFF)          | OUT       |
++----------------------+---------------------------------+-----------+
 | P0.28/AIN4           | TP_INT                          | IN        |
++----------------------+---------------------------------+-----------+
 | P0.29/AIN5           |                                 |           |
++----------------------+---------------------------------+-----------+
 | P0.30/AIN6           | HRS3300-TEST                    | IN        |
++----------------------+---------------------------------+-----------+
 | P0.31/AIN7           | BATTERY VOLTAGE (Analog)        | IN        |
 +----------------------+---------------------------------+-----------+
 
 Building
 ********
 
-In order to build Zephyr for the Pinetime, you can specify the pinetime board
-using the -b option:
+In order to get started with Zephyr on the PineTime, you can use the
+board-specific sample:
 
-.. code-block:: console
-
-   $ west build -b pinetime
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/pine64_pinetime
+   :board: pinetime_devkit0
+   :goals: build
 
 Programming and Debugging
 *************************
 
-More infos to be found there:
-      - `Wiki Regrogramming the PineTime`_
-
 The PineTime Dev Kit comes with the back not glued down to allow it to be
-easily reprogrammed, however the kit does not include an hardware
-/debugger.
-There is a bewildering variety of different hardware programmers available
-but whatever programmer you have there are only a few tasks you will have to
-learn about:
+easily reprogrammed.
+
+The kit does not include a hardware programmer, but existing debuggers
+supporting SWD can be used.
+
+These are the necessary steps for debugging:
+
 - Unlock the device
 - Upload new software
 - Run a debugger
 
-Unlocking the device is a one-time action that is needed to enable to debug
-port and provide full access to the device. Unlocking the device will erase
-all existing software from the internal flash.
+More infos to be found in the `Wiki Reprogramming the PineTime`_ page.
 
 Debugger connection
 ===================
 
-The devkits have exposed SWD pins for flashing and debugging.
+The dev kits have exposed SWD pins for flashing and debugging.
 
 Only a few devs have soldered to these pins, most just use friction to make
 contact with the programming cable.
+
 The pinout is:
 
 .. figure:: img/PineTime_SWD_location.jpg
@@ -129,10 +158,9 @@ The pinout is:
 Unlocking the Flash memory
 ==========================
 
-Unlocking the device and erase the memory.
-
-You need to execute this step only once, to remove the read protection on the
-memory. Note that it will erase the whole flash memory of the MCU!:
+Unlocking the device is a one-time action that is needed to enable to debug
+port and provide full access to the device. This will erase all existing
+software from the internal flash.
 
 .. code-block:: console
 
@@ -141,7 +169,7 @@ memory. Note that it will erase the whole flash memory of the MCU!:
 Flashing
 ========
 
-Using nrfjprog, flashing the Pinetime is done wit hthe command:
+Using nrfjprog, flashing the PineTime is done with the command:
 
 .. code-block:: console
 
@@ -149,12 +177,13 @@ Using nrfjprog, flashing the Pinetime is done wit hthe command:
 
 Debugging
 =========
+
 Using Segger Ozone debugger, debugging and flashing is made easy.
 
 Simply load the .elf file containing the final firmware and
-setup the debbuger to use SWD ober USB for the chip nRF52832_xxAA.
-This setup can be done using the menu Tools/J-Link Settings. or directly type
-in the debugger console the folowing:
+setup the debbuger to use SWD over USB for the chip nRF52832_xxAA.
+This setup can be done using the menu Tools/J-Link Settings. or by directly
+typing the following in the debugger console:
 
 .. code-block:: console
 
@@ -162,17 +191,24 @@ in the debugger console the folowing:
    $ Project.SetHostIF ("USB", "");
    $ Project.SetTargetIF ("SWD");
    $ Project.SetTIFSpeed ("4 MHz");
-   $ File.Open ("/Users/sdorre/dev/nrf52/pinetine-hypnos/pinetime/build/zephyr/zephyr.elf");
+   $ File.Open ("path/to/your/build/zephyr/zephyr.elf");
 
 References
 **********
 
 .. target-notes::
 
-.. _Pine64 Pinetime presentation: https://www.pine64.org/pinetime
-.. _Pine64 wiki: https://wiki.pine64.org/index.php/PineTime
-.. _Pine64 forum: https://forum.pine64.org
-.. _Pinetime schematics:
+.. _Pine64 PineTime presentation:
+   https://www.pine64.org/pinetime
+
+.. _Pine64 PineTime wiki page:
+   https://wiki.pine64.org/index.php/PineTime
+
+.. _Pine64 forum:
+   https://forum.pine64.org
+
+.. _PineTime schematics:
    http://files.pine64.org/doc/PineTime/PineTime%20Schematic-V1.0a-20191103.pdf
-.. _Wiki Regrogramming the PineTime:
+
+.. _Wiki Reprogramming the PineTime:
    https://wiki.pine64.org/index.php/Reprogramming_the_PineTime

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0_defconfig
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0_defconfig
@@ -6,25 +6,21 @@ CONFIG_BOARD_PINETIME_DEVKIT0=y
 CONFIG_HWINFO=y
 CONFIG_HWINFO_NRF=y
 
-# enable MPU
 CONFIG_ARM_MPU=y
 
-# enable GPIO
 CONFIG_GPIO=y
 
-# enable UART driver
 CONFIG_SERIAL=y
 
-# enable I2C0 driver
 CONFIG_I2C=y
 
-# enable SPI1 driver
 CONFIG_SPI=y
 
-# enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# additional board options
-# enable P0_21 as RST
+# use P0.09 and P0.10 as GPIOs
+CONFIG_NFCT_PINS_AS_GPIOS=y
+
+# use P0.21 as RST
 CONFIG_GPIO_AS_PINRESET=y

--- a/samples/boards/pine64_pinetime/sample.yaml
+++ b/samples/boards/pine64_pinetime/sample.yaml
@@ -1,0 +1,6 @@
+sample:
+  name: Pine64 PineTime board testing
+tests:
+  sample.board.pinetime_devkit0:
+    platform_allow: pinetime_devkit0
+    tags: samples board

--- a/samples/boards/pine64_pinetime/src/main.c
+++ b/samples/boards/pine64_pinetime/src/main.c
@@ -8,8 +8,8 @@
 #include <zephyr.h>
 #include <drivers/gpio.h>
 
-static void button_pressed(struct device *dev,
-			   struct gpio_callback *cb, u32_t pins)
+static void button_pressed(const struct device *dev,
+			   struct gpio_callback *cb, uint32_t pins)
 {
 	printk("Button pressed at %" PRIu32 "\n", k_cycle_get_32());
 }
@@ -19,7 +19,7 @@ static struct gpio_callback button_cb;
 int main(void)
 {
 	int ret = 0;
-	struct device *dev_gpio = NULL;
+	const struct device *dev_gpio = NULL;
 
 	/* Only one GPIO peripheral in nRF52832 */
 	/* So let's take the same for led AND button */
@@ -65,8 +65,8 @@ int main(void)
 
 	while (1) {
 		/* button is pressed ==> turn on status LED */
-		u32_t val = 0u;
-		u8_t new_val = 0u;
+		uint32_t val = 0u;
+		uint8_t new_val = 0u;
 
 		new_val = gpio_pin_get(dev_gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios));
 		if (new_val != val) {


### PR DESCRIPTION
The documentation had several typos, inconsistent naming and formatting issues, which are fixed in the first commit.

The sample does not compile because of leftovers from older Zephyr versions (non-const device * and deprecated int types). These issues were not detected because the sample.yaml is missing, so it was not integrated in CI builds. 

My initial idea was to fix the sample that it compiles. But I realized that it does almost exactly the same as samples/basic/button and does not demonstrate any special features of the PineTime. So I suggest to remove it.