### PR TITLE
cmake: Only use freestanding flag on non-posix platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,9 @@ endif()
 zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${AUTOCONF_H}")
 
 # @Intent: Set compiler specific flag for bare metal freestanding option
-zephyr_compile_options($<TARGET_PROPERTY:compiler,freestanding>)
+if(NOT CONFIG_SOC_POSIX)
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,freestanding>)
+endif()
 
 # @Intent: Set compiler specific flag for tentative definitions, no-common
 zephyr_compile_options($<TARGET_PROPERTY:compiler,no_common>)

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -8,7 +8,7 @@ set_compiler_property(PROPERTY security_fortify)
 
 # No property flag, this is used by the native_posix, clang has problems
 # compiling the native_posix with -fno-freestanding.
-check_set_compiler_property(PROPERTY hosted)
+set_compiler_property(PROPERTY hosted)
 
 # clang flags for coverage generation
 set_property(TARGET compiler PROPERTY coverage --coverage -fno-inline)


### PR DESCRIPTION
Zephyr build system has always added `-ffreestanding` got gcc based
compilers, and then arch/posix/CMakeLists.txt would append
`-fno-freestanding` to Zephyr compile options.

This works well for gcc based toolchains as flags where a later
`-fno-freestanding` would overrule an earlier `-ffreestanding` flag.

With LLVM support, this is no longer possible, as clang doesn't support
a `-fhosted` / `-fno-freestanding` flag, and thus `-ffreestanding` would
always be added as compile flag when using clang for native_posix
builds.

This is now fix by only setting the freestanding compilation flag on
non posix SoCs.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>