### PR TITLE
MAINTAINERS: add RISCV related directories

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -987,7 +987,10 @@ RISCV arch:
         - katsuster
     files:
         - arch/riscv/
+        - boards/riscv/
+        - dts/bindings/riscv/
         - include/arch/riscv/
+        - soc/riscv/
     labels:
         - "area: RISCV"
 


### PR DESCRIPTION
This patch gathers and adds all RISCV related directories into
'RISCV arch' entry.
It is preliminary modification until suitable maintainer (or entry)
for each RISCV boards or sub-architecture appears in the future.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>