### PR TITLE
Generated device driver docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -148,6 +148,7 @@ file(GLOB_RECURSE  DOXY_SOURCES
   ${ZEPHYR_BASE}/lib/libc/*.[c,h,S]
   ${ZEPHYR_BASE}/subsys/testsuite/ztest/include/*.[h,c,S]
   ${ZEPHYR_BASE}/tests/*.[h,c,S]
+  ${ZEPHYR_BASE}/drivers/*.[c,h,S]
   )
 # For debug. Also find generated list in doc/_build/(build.ninja|CMakeFiles/)
 # message("DOXY_SOURCES= " ${DOXY_SOURCES})

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -92,6 +92,7 @@ set(I18NSPHINXOPTS  ${SPHINXOPTS})
 set(DOXYFILE_IN ${CMAKE_CURRENT_LIST_DIR}/zephyr.doxyfile.in)
 set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/zephyr.doxyfile)
 set(DOXY_OUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
+set(DOXY_XML_OUT ${DOXY_OUT}/xml)
 set(RST_OUT ${CMAKE_CURRENT_BINARY_DIR}/rst)
 set(DOC_LOG ${CMAKE_CURRENT_BINARY_DIR}/doc.log)
 set(DOXY_LOG ${CMAKE_CURRENT_BINARY_DIR}/doxy.log)
@@ -99,6 +100,8 @@ set(SPHINX_LOG ${CMAKE_CURRENT_BINARY_DIR}/sphinx.log)
 set(DOC_WARN ${CMAKE_CURRENT_BINARY_DIR}/doc.warnings)
 set(CONTENT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/extracted-content.txt)
 
+# TODO: need to pass all the modules which have drivers/
+# subdirectories in here too
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
 # This command is used to copy all documentation source files from the
@@ -301,6 +304,48 @@ add_custom_target(
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${GEN_DEVICETREE_REST_SCRIPT})
 
 #
+# Generated device driver .rst documents.
+#
+# The device drivers discovered in ${DRIVER_MODULES} are parsed and
+# documentation for them is generated in the directory ${DRIVERS_RST_OUT}.
+# Defaults:
+#
+# - DRIVER_MODULES: ZEPHYR_BASE
+# - DRIVERS_RST_OUT: ${RST_OUT}/doc/drivers
+
+set(GEN_DRIVER_REST_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/scripts/gen_driver_rest.py)
+
+if(NOT DRIVER_MODULES)
+  set(DRIVER_MODULES ${ZEPHYR_BASE})
+endif()
+
+set(DRIVER_MODULES_ARGS)
+foreach(module ${DRIVER_MODULES})
+  list(APPEND DRIVER_MODULES_ARGS --module ${module})
+endforeach()
+
+if(NOT DRIVERS_RST_OUT)
+  set(DRIVERS_RST_OUT ${RST_OUT}/doc/drivers)
+endif()
+
+add_custom_target(
+  drivers
+  COMMAND ${CMAKE_COMMAND} -E env
+  ${PYTHON_EXECUTABLE} ${GEN_DRIVER_REST_SCRIPT}
+    --doxygen-xml ${DOXY_XML_OUT}
+    ${DRIVER_MODULES_ARGS}
+    ${DRIVERS_RST_OUT}
+  VERBATIM
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  COMMENT "Running gen_drivers_rest.py ${DRIVERS_RST_OUT}"
+  USES_TERMINAL
+)
+
+add_dependencies(drivers doxy_real_modified_times)
+
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${GEN_DRIVER_REST_SCRIPT})
+
+#
 # HTML section
 #
 set(SPHINX_BUILD_HTML_COMMAND
@@ -414,7 +459,7 @@ endif()
 #
 # Dependencies and final targets
 #
-add_dependencies(html content doxy_real_modified_times kconfig devicetree)
+add_dependencies(html content doxy_real_modified_times kconfig devicetree drivers)
 
 add_custom_target(
   htmldocs
@@ -427,7 +472,7 @@ add_custom_target(
 )
 add_dependencies(doxygen doxy_real_modified_times)
 
-add_dependencies(latex content doxy_real_modified_times kconfig devicetree)
+add_dependencies(latex content doxy_real_modified_times kconfig devicetree drivers)
 
 add_custom_target(
   latexdocs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'zephyr.application',
     'zephyr.html_redirects',
     'only.eager_only',
+    'zephyr.dtcompatible-role',
     'zephyr.link-roles',
     'sphinx_tabs.tabs'
 ]

--- a/doc/drivers/index.rst
+++ b/doc/drivers/index.rst
@@ -1,0 +1,44 @@
+.. _device_drivers:
+
+Device Drivers
+##############
+
+This page is an index of device drivers. Each device driver implements a Zephyr
+:ref:`API <api_overview>`. Device drivers are responsible for creating the
+:c:struct:`device` structures at the heart of Zephyr's :ref:`device and driver
+model <device_model_api>`.
+
+To enable a device driver -- i.e. compile and link the driver source code into
+your Zephyr :ref:`application <application>` -- you will typically need to:
+
+- enable the driver using :ref:`Kconfig <kconfig>`
+- configure one or more devices using :ref:`devicetree <dt-guide>`
+
+In order to use the device driver, you will need a pointer to a ``struct
+device`` created by the driver source. This is done with the
+:c:func:`device_get_binding` function, which requires the name of the device.
+For help getting a pointer to a device configured in the devicetree, see
+:ref:`dt-get-device`.
+
+.. Note: there's nothing else in this directory because the toctree is pulling
+   in files created by gen_driver_rest.py.
+
+.. TODO: figure out how to glob this; "*/index.rst" didn't work with plain :glob:
+
+.. toctree::
+
+   adc/index.rst
+   clock_control/index.rst
+   counter/index.rst
+   entropy/index.rst
+   flash/index.rst
+   gpio/index.rst
+   hwinfo/index.rst
+   i2c/index.rst
+   ipm/index.rst
+   pwm/index.rst
+   sensor/index.rst
+   serial/index.rst
+   spi/index.rst
+   usb/index.rst
+   watchdog/index.rst

--- a/doc/extensions/zephyr/dtcompatible-role.py
+++ b/doc/extensions/zephyr/dtcompatible-role.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A Sphinx extension for documenting devicetree content. It adds a role and a
+directive with the same name, 'dtcompatible'.
+
+:dtcompatible:`vnd,foo`
+
+  This role can be used inline to make a reference to the generated
+  documentation for a devicetree
+  compatible given as argument.
+
+  For example, :dtcompatible:`vnd,foo` would create a reference to the
+  generated documentation page for the devicetree binding handling
+  compatible "vnd,foo".
+
+  There may be more than page for a single compatible. For example,
+  that happens if a binding behaves differently depending on the bus the
+  node is on. If that occurs, the reference points at a "disambiguation"
+  page which links out to all the possibilities, similarly to how Wikipedia
+  disambiguation pages work.
+
+  The Zephyr documentation uses the standard :option: role to refer
+  to Kconfig options. The :dtcompatible: option is like that, except
+  using its own role to avoid using one that already has a standard meaning.
+  (The :option: role is meant for documenting options to command-line programs,
+  not Kconfig symbols.)
+
+.. dtcompatible:: vnd,foo
+
+  This directive marks the page where the :dtcompatible: role link goes.
+  Users should not use it directly. The generated bindings documentation will
+  define these in the right places.
+"""
+
+def setup(app):
+    app.add_crossref_type('dtcompatible', 'dtcompatible')
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -4,6 +4,25 @@
 
 # based on http://protips.readthedocs.io/link-roles.html
 
+"""
+This file contains Sphinx extensions for the following Zephyr-specific
+documentation roles:
+
+:zephyr_file:
+  Create a link to a file within the zephyr repository tree.
+  The link is to an HTML view of the file as a blob on a Git forge.
+
+  The version displayed corresponds to the current tag if
+  HEAD points at a tag, or the 'master' branch otherwise.
+
+  For example, :zephyr_file:`doc/extensions/zephyr/link-roles.py`
+  creates a link to this file on GitHub by default.
+
+:zephyr_raw:
+  Like ``:zephyr_file:``, but for "raw" output, rather than
+  the usual fancy UI for viewing a git blob's contents.
+"""
+
 from __future__ import print_function
 from __future__ import unicode_literals
 import re

--- a/doc/guides/dts/bindings.rst
+++ b/doc/guides/dts/bindings.rst
@@ -15,6 +15,11 @@ dt-schema tools used by the Linux kernel). With one exception in
 :ref:`dt-inferred-bindings` the build system uses bindings when generating
 code for :ref:`dt-from-c`.
 
+.. note::
+
+   See the :ref:`devicetree_binding_index` for information on existing
+   bindings.
+
 .. _dt-binding-compat:
 
 Mapping nodes to bindings

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -114,6 +114,7 @@ licensing, as described in :ref:`Zephyr_Licensing`.
    development_process/index.rst
    application/index.rst
    reference/index.rst
+   drivers/index.rst
    guides/index.rst
    security/index.rst
    samples/index.rst

--- a/doc/scripts/gen_devicetree_rest.py
+++ b/doc/scripts/gen_devicetree_rest.py
@@ -256,11 +256,11 @@ def dump_content(bindings, base_binding, vnd_lookup, out_dir):
 
     setup_bindings_dir(bindings, out_dir)
     write_bindings_rst(vnd_lookup, out_dir)
-    write_per_compatible_orphans(bindings, base_binding, vnd_lookup, out_dir)
+    write_orphans(bindings, base_binding, vnd_lookup, out_dir)
 
 def setup_bindings_dir(bindings, out_dir):
     # Make a set of all the Path objects we will be creating for
-    # out_dir / bindings / {compatible}.rst. Delete all the ones that
+    # out_dir / bindings / {binding_path}.rst. Delete all the ones that
     # shouldn't be there. Make sure the bindings output directory
     # exists.
 
@@ -272,10 +272,12 @@ def setup_bindings_dir(bindings, out_dir):
     for binding in bindings:
         paths.add(bindings_dir / binding_filename(binding))
 
-    for path in bindings_dir.iterdir():
-        if path not in paths:
-            logger.info('removing unexpected file %s', path)
-            path.unlink()
+    for dirpath, _, filenames in os.walk(bindings_dir):
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path not in paths:
+                logger.info('removing unexpected file %s', path)
+                path.unlink()
 
 def write_bindings_rst(vnd_lookup, out_dir):
     # Write out_dir / bindings.rst, the top level index of bindings.
@@ -352,80 +354,40 @@ def write_bindings_rst(vnd_lookup, out_dir):
 
     write_if_updated(out_dir / 'bindings.rst', string_io.getvalue())
 
-def write_per_compatible_orphans(bindings, base_binding, vnd_lookup, out_dir):
-    # For each compatible in vnd2bindings, write the corresponding
-    # out_dir / bindings / {binding.compatible}.rst file, if its
-    # content needs updating. This file is an 'orphan' because it's not
-    # in any toctree.
+def write_orphans(bindings, base_binding, vnd_lookup, out_dir):
+    # Write out_dir / bindings / foo / binding_page.rst for each binding
+    # in 'bindings', along with any "disambiguation" pages needed when a
+    # single compatible string can be handled by multiple bindings.
+    #
+    # These files are 'orphans' in the Sphinx sense: they are not in
+    # any toctree.
 
-    logging.info('updating up to %d :orphan: files', len(bindings))
+    logging.info('updating :orphan: files for %d bindings', len(bindings))
     num_written = 0
+
+    # First, figure out which compatibles map to multiple bindings. We
+    # need this information to decide which of the generated files for
+    # a compatible are "disambiguation" pages that point to per-bus
+    # binding pages, and which ones aren't.
+
+    compat2bindings = defaultdict(list)
+    for binding in bindings:
+        compat2bindings[binding.compatible].append(binding)
+    dup_compat2bindings = {compatible: bindings for compatible, bindings
+                           in compat2bindings.items() if len(bindings) > 1}
+
+    # Next, write the per-binding pages. These contain the
+    # per-compatible targets for compatibles not in 'dup_compats'.
+    # We'll finish up by writing per-compatible "disambiguation" pages
+    # for copmatibles in 'dup_compats'.
+
     # Names of properties in base.yaml.
     base_names = set(base_binding.prop2specs.keys())
     for binding in bindings:
         string_io = io.StringIO()
 
-        # :orphan:
-        #
-        # .. ref_target:
-        #
-        # Title [(on <bus> bus)]
-        # ######################
-        if binding.on_bus:
-            on_bus_title = f' (on {binding.on_bus} bus)'
-        else:
-            on_bus_title = ''
-        compatible = binding.compatible
-        title = f'{compatible}{on_bus_title}'
-        underline = '#' * len(title)
-        print_block(f'''\
-        :orphan:
-
-        .. _{binding_ref_target(binding)}:
-
-        {title}
-        {underline}
-        ''', string_io)
-
-        # Vendor: <link-to-vendor-section>
-        vnd = compatible_vnd(compatible)
-        print('Vendor: '
-              f':ref:`{vnd_lookup.vendor(vnd)} <{vnd_lookup.target(vnd)}>`\n',
-              file=string_io)
-
-        # Binding description.
-        if binding.bus:
-            bus_help = f'These nodes are "{binding.bus}" bus nodes.'
-        else:
-            bus_help = ''
-        print_block(f'''\
-        Description
-        ***********
-
-        {bus_help}
-        ''', string_io)
-        print(to_code_block(binding.description.strip()), file=string_io)
-
-        # Properties.
-        print_block('''\
-        Properties
-        **********
-        ''', string_io)
-        print_top_level_properties(binding, base_names, string_io)
-        print_child_binding_properties(binding, string_io)
-
-        # Specifier cells.
-        #
-        # This presentation isn't particularly nice. Perhaps something
-        # better can be done for future work.
-        if binding.specifier2cells:
-            print_block('''\
-            Specifier cell names
-            ********************
-            ''', string_io)
-            for specifier, cells in binding.specifier2cells.items():
-                print(f'- {specifier} cells: {", ".join(cells)}',
-                      file=string_io)
+        print_binding_page(binding, base_names, vnd_lookup,
+                           dup_compat2bindings, string_io)
 
         written = write_if_updated(out_dir / 'bindings' /
                                    binding_filename(binding),
@@ -434,8 +396,107 @@ def write_per_compatible_orphans(bindings, base_binding, vnd_lookup, out_dir):
         if written:
             num_written += 1
 
+    # Generate disambiguation pages for dup_compats.
+    compatibles_dir = out_dir / 'compatibles'
+    setup_compatibles_dir(dup_compat2bindings.keys(), compatibles_dir)
+    for compatible in dup_compat2bindings:
+        string_io = io.StringIO()
+
+        print_compatible_disambiguation_page(
+            compatible, dup_compat2bindings[compatible], string_io)
+
+        written = write_if_updated(compatibles_dir /
+                                   compatible_filename(compatible),
+                                   string_io.getvalue())
+
+        if written:
+            num_written += 1
+
     logging.info('done writing :orphan: files; %d files needed updates',
                  num_written)
+
+def print_binding_page(binding, base_names, vnd_lookup, dup_compats,
+                       string_io):
+    # Print the rst content for 'binding' to 'string_io'. The
+    # 'dup_compats' argument should support membership testing for
+    # compatibles which have multiple associated bindings; if
+    # 'binding.compatible' is not in it, then the ref target for the
+    # entire compatible is generated in this page as well.
+
+    # :orphan:
+    #
+    # .. ref_target:
+    #
+    # Title [(on <bus> bus)]
+    # ######################
+    if binding.on_bus:
+        on_bus_title = f' (on {binding.on_bus} bus)'
+    else:
+        on_bus_title = ''
+    compatible = binding.compatible
+
+    title = f'{compatible}{on_bus_title}'
+    underline = '#' * len(title)
+    if compatible not in dup_compats:
+        # If this binding is the only one that handles this
+        # compatible, point the ".. dtcompatible:" directive straight
+        # to this page. There's no need for disambiguation.
+        dtcompatible = f'.. dtcompatible:: {binding.compatible}'
+    else:
+        # This compatible is handled by multiple bindings;
+        # its ".. dtcompatible::" should be in a disambiguation page
+        # instead.
+        dtcompatible = ''
+
+    print_block(f'''\
+    :orphan:
+
+    {dtcompatible}
+    .. _{binding_ref_target(binding)}:
+
+    {title}
+    {underline}
+    ''', string_io)
+
+    # Vendor: <link-to-vendor-section>
+    vnd = compatible_vnd(compatible)
+    print('Vendor: '
+          f':ref:`{vnd_lookup.vendor(vnd)} <{vnd_lookup.target(vnd)}>`\n',
+          file=string_io)
+
+    # Binding description.
+    if binding.bus:
+        bus_help = f'These nodes are "{binding.bus}" bus nodes.'
+    else:
+        bus_help = ''
+    print_block(f'''\
+    Description
+    ***********
+
+    {bus_help}
+    ''', string_io)
+    print(to_code_block(binding.description.strip()), file=string_io)
+
+    # Properties.
+    print_block('''\
+    Properties
+    **********
+    ''', string_io)
+    print_top_level_properties(binding, base_names, string_io)
+    print_child_binding_properties(binding, string_io)
+
+    # Specifier cells.
+    #
+    # This presentation isn't particularly nice. Perhaps something
+    # better can be done for future work.
+    if binding.specifier2cells:
+        print_block('''\
+        Specifier cell names
+        ********************
+        ''', string_io)
+        for specifier, cells in binding.specifier2cells.items():
+            print(f'- {specifier} cells: {", ".join(cells)}',
+                  file=string_io)
 
 def print_top_level_properties(binding, base_names, string_io):
     # Print the RST for top level properties for 'binding' to 'string_io'.
@@ -565,6 +626,48 @@ def print_property_table(prop_specs, string_io):
     for prop_spec in prop_specs:
         print(to_prop_table_row(prop_spec), file=string_io)
 
+def setup_compatibles_dir(compatibles, compatibles_dir):
+    # Make a set of all the Path objects we will be creating for
+    # out_dir / copmatibles / {compatible_path}.rst. Delete all the ones that
+    # shouldn't be there. Make sure the compatibles output directory
+    # exists.
+
+    logger.info('making output subdirectory %s', compatibles_dir)
+    compatibles_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = set(compatibles_dir / compatible_filename(compatible)
+                for compatible in compatibles)
+
+    for path in compatibles_dir.iterdir():
+        if path not in paths:
+            logger.info('removing unexpected file %s', path)
+            path.unlink()
+
+
+def print_compatible_disambiguation_page(compatible, bindings, string_io):
+    # Print the disambiguation page for 'compatible', which can be
+    # handled by any of the bindings in 'bindings', to 'string_io'.
+
+    assert len(bindings) > 1, (compatible, bindings)
+
+    underline = '#' * len(compatible)
+    output_list = '\n    '.join(f'- :ref:`{binding_ref_target(binding)}`'
+                                for binding in bindings)
+
+    print_block(f'''\
+    :orphan:
+
+    .. dtcompatible:: {compatible}
+
+    {compatible}
+    {underline}
+
+    The devicetree compatible ``{compatible}`` may be handled by any
+    of the following bindings:
+
+    {output_list}
+    ''', string_io)
+
 def print_block(block, string_io):
     # Helper for dedenting and printing a triple-quoted RST block.
     # (Just a block of text, not necessarily just a 'code-block'
@@ -592,13 +695,11 @@ def compatible_vnd(compatible):
 
     return compatible.split(',', 1)[0]
 
-def binding_ref_target(binding):
-    # Return the sphinx ':ref:' target name for a binding.
+def compatible_filename(compatible):
+    # Name of the per-compatible disambiguation page within the
+    # out_dir / compatibles directory.
 
-    ret = re.sub('[,-]', '_', binding.compatible)
-    if binding.on_bus is not None:
-        ret += f'_{binding.on_bus}'
-    return ret
+    return f'{compatible}.rst'
 
 def zref(target, text=None):
     # Make an appropriate RST :ref:`text <target>` or :ref:`target`
@@ -626,14 +727,40 @@ def zref(target, text=None):
     return f':ref:`{target}`'
 
 def binding_filename(binding):
-    if binding.on_bus is None:
-        return f'{binding.compatible}.rst'
+    # Returns the output file name for a binding relative to the
+    # directory containing documentation for all bindings. It does
+    # this by stripping off the '.../dts/bindings/' prefix common to
+    # all bindings files in a DTS_ROOT directory.
+    #
+    # For example, for .../zephyr/dts/bindings/base/base.yaml, this
+    # would return 'base/base.yaml'.
+    #
+    # Hopefully that's unique across roots. If not, we'll need to
+    # update this function.
 
-    return f'{binding.compatible}-{binding.on_bus}.rst'
+    as_posix = Path(binding.path).as_posix()
+    dts_bindings = 'dts/bindings/'
+    idx = as_posix.rfind(dts_bindings)
+
+    if idx == -1:
+        raise ValueError(f'binding path has no {dts_bindings}: {binding.path}')
+
+    # Cut past dts/bindings, strip off the .yaml, and replace with
+    # .rst.
+    return as_posix[idx + len(dts_bindings):-4] + 'rst'
+
+def binding_ref_target(binding):
+    # Return the sphinx ':ref:' target name for a binding.
+
+    stem = Path(binding.path).stem
+    return 'dtbinding_' + re.sub('[/,-]', '_', stem)
 
 def write_if_updated(path, s):
-    # gen_helpers.write_if_updated() wrapper that handles logging.
+    # gen_helpers.write_if_updated() wrapper that handles logging and
+    # creating missing parents, as needed.
 
+    if not path.parent.is_dir():
+        path.parent.mkdir(parents=True)
     written = gen_helpers.write_if_updated(path, s)
     logger.debug('%s %s', 'wrote' if written else 'did NOT write', path)
     return written

--- a/doc/scripts/gen_driver_rest.py
+++ b/doc/scripts/gen_driver_rest.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Like gen_kconfig_rest.py, but for generating an index of existing
+devicetree drivers.
+"""
+
+import argparse
+from collections import defaultdict
+import glob
+import io
+import itertools
+import logging
+from pathlib import Path
+import re
+import shutil
+import textwrap
+from typing import Dict, List, NamedTuple
+import xml.etree.ElementTree as ET
+
+import gen_helpers
+
+ZEPHYR_BASE = Path(__file__).parents[2]
+
+logger = logging.getLogger('gen_driver_rest')
+
+class DriverXmlEntry(NamedTuple):
+    '''Represents an element of the zephyrdriver.xml file.
+
+    For our purposes, this file contains a sequence of
+    (name, filename, refid) tuples:
+
+    - 'name' is the human-readable driver name
+    - 'filename' is the basename of the driver source file
+    - 'refid' is enough to find the path to the driver XML file
+      in the doxygen XML directory
+    '''
+
+    name: str
+    filename: str
+    xml: Path
+
+class CompatibleXmlEntry(NamedTuple):
+    '''Represents an element of the dtcompatible.xml file.
+
+    For our purposes, this file contains a sequence of
+    (compatibles, filename, refid) tuples:
+
+    - 'compatibles' is the list of devicetree compatibles as they
+      appear in DTS
+    - 'filename' is the basename of the driver source file which
+      claims to create struct devices from nodes of this compatible
+    - 'refid' is enough to find the path to the driver XML file
+      in the doxygen XML directory
+    '''
+
+    compatibles: str
+    filename: str
+    xml: Path
+
+class Driver(NamedTuple):
+    '''
+    Driver metadata, created by cross-referencing the data in the
+    various DriverXmlEntry and CompatibleXmlEntry tuples we create,
+    along with additional information in the driver XML files.
+    '''
+
+    name: str                   # human-readable name
+    compatibles: List[str]      # devicetree compatible(s) handled
+    path: Path                  # absolute path to driver
+    api: str                    # zephyr API name
+
+# A map from API names (like 'i2c', 'spi') to the list of drivers
+# within that API.
+DriverMap = Dict[str, List[Driver]]
+
+def main():
+    args = parse_args()
+    xml_dir = Path(args.doxygen_xml)
+
+    setup_logging(args.verbose)
+
+    drv_entries: List[DriverXmlEntry] = load_zephyrdriver_xml(xml_dir)
+    cmpt_entries: List[CompatibleXmlEntry] = load_dtcompatible_xml(xml_dir)
+
+    driver_dirs = [ZEPHYR_BASE]
+    for module in args.modules:
+        driver_dirs.append(Path(module))
+    api2drivers: DriverMap = resolve_drivers(driver_dirs,
+                                             drv_entries,
+                                             cmpt_entries)
+
+    dump_content(api2drivers, Path(args.out_dir))
+
+def parse_args():
+    # Parse command line arguments from sys.argv.
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', default=0, action='count',
+                        help='increase verbosity; may be given multiple times')
+    parser.add_argument('--doxygen-xml', required=True,
+                        help='doxygen xml output directory')
+    parser.add_argument('--module', dest='modules', action='append',
+                        default=[],
+                        help='''additional module to search in;
+                        ZEPHYR_BASE is included by default''')
+    parser.add_argument('out_dir', help='output files are generated here')
+
+    return parser.parse_args()
+
+def setup_logging(verbose):
+    if verbose >= 2:
+        log_level = logging.DEBUG
+    elif verbose == 1:
+        log_level = logging.INFO
+    else:
+        log_level = logging.ERROR
+    logging.basicConfig(format='%(filename)s:%(levelname)s: %(message)s',
+                        level=log_level)
+
+def load_zephyrdriver_xml(doxygen_xml: Path) -> List[DriverXmlEntry]:
+    # Load the zephyrdriver.xml file from the Doxygen output. This
+    # contains the index of driver files which used the
+    # "@zephyrdriver{Driver name}" doxygen alias to declare that they
+    # are a driver implementation.
+    #
+    # Return a view of the relevant files and their compatibles.
+    # This drives generation of the driver RST files.
+
+    zephyrdriver_xml = doxygen_xml / 'zephyrdriver.xml'
+    if not zephyrdriver_xml.is_file():
+        raise RuntimeError(f'expected to find file {zephyrdriver_xml}')
+
+    zephyrdriver_xml_tree = ET.parse(zephyrdriver_xml)
+    ret = []
+    for entry, items in varlist_entry_items(zephyrdriver_xml_tree):
+        assert len(items) == 1
+        name = "".join(items[0].itertext()).strip()
+        ref = entry[0][0]
+        filename = ref.text
+        xml = doxygen_xml / f"{ref.attrib['refid']}.xml"
+
+        logger.debug('driver name="%s", filename="%s", xml="%s"' ,
+                     name, filename, xml)
+
+        ret.append(DriverXmlEntry(name, filename, xml))
+
+    logger.info('found %d entries in %s', len(ret), zephyrdriver_xml)
+
+    return ret
+
+def load_dtcompatible_xml(doxygen_xml: Path) -> List[CompatibleXmlEntry]:
+
+    dtcompatible_xml = doxygen_xml / 'dtcompatible.xml'
+    if not dtcompatible_xml.is_file():
+        raise RuntimeError(f'expected to find file {dtcompatible_xml}')
+
+    dtcompatible_xml_tree = ET.parse(dtcompatible_xml)
+    ret = []
+    for entry, items in varlist_entry_items(dtcompatible_xml_tree):
+        compatibles = ["".join(item.itertext()).strip() for item in items]
+        ref = entry[0][0]
+        filename = ref.text
+        xml = doxygen_xml / f"{ref.attrib['refid']}.xml"
+
+        logger.debug('compatibles="%s", filename="%s", xml="%s"',
+                     compatibles, filename, xml)
+
+        ret.append(CompatibleXmlEntry(compatibles, filename, xml))
+
+    logger.info('found %d entries in %s', len(ret), dtcompatible_xml)
+
+    return ret
+
+def varlist_entry_items(tree):
+    # The doxygen XML files for each type of \xrefitem contain a
+    # 'variablelist' element which is a sequence of pairs. The
+    # elements of each pair are a 'varlistentry' and a 'listitem':
+    #
+    # - the 'varlistentry' contains the reference data we need to find
+    #   the file which used the \xrefitem
+    #
+    # - the 'listitem' contains the argument to the \xrefitem
+    #
+    # This function find the variablelist, checks that its length is
+    # well-formed (i.e. contains a whole number of pairs), and returns
+    # an iterator for each (varlistentry, listitem) pair.
+
+    iterator = tree.getroot().iter('variablelist')
+    vlist = list(next(iterator))
+    assert len(vlist) % 2 == 0
+
+    for i in range(len(vlist) // 2):
+        entry, items = vlist[2 * i], vlist[2 * i + 1]
+        yield (entry, items)
+
+def resolve_drivers(
+        driver_dirs: List[Path],
+        drv_entries: List[DriverXmlEntry],
+        cmpt_entries: List[CompatibleXmlEntry]
+) -> DriverMap:
+    # Figure out the Driver objects we really care about by
+    # cross-referencing the data from zephyrdriver.xml and
+    # dtcompatible.xml with the 'module/drivers' directory for each
+    # 'module' in 'modules.
+    #
+    # Return a dictionary mapping APIs to lists of Driver
+
+    def path_api(path):
+        # get the API from the path. The path should end in
+        # 'drivers/the_api/.../filename.c'. The return value is 'the_api'.
+        maybe_api = None
+        for part in reversed(path.parts):
+            if part == 'drivers':
+                return maybe_api
+            maybe_api = part
+
+    globs = (glob.glob(f'{driver_dir}/drivers/*/**/*.c', recursive=True)
+             for driver_dir in driver_dirs)
+    all_paths = [Path(abspath) for abspath in itertools.chain(*globs)]
+    driver_filenames = set(drv_entry.filename for drv_entry in drv_entries)
+    driver_paths = set(path for path in all_paths
+                       if path.name in driver_filenames)
+
+    filename2drv_entry = {entry.filename: entry for entry in drv_entries}
+    filename2cmpt_entry = {entry.filename: entry for entry in cmpt_entries}
+    filename2api = {path.name: path_api(path) for path in driver_paths}
+    filename2path = {path.name: path for path in driver_paths}
+
+    api2filenames = defaultdict(list)
+    for filename, api in filename2api.items():
+        api2filenames[api].append(filename)
+
+    api2drivers: DriverMap = defaultdict(list)
+    for api, filenames in api2filenames.items():
+        for fn in filenames:
+            api2drivers[api].append(
+                Driver(name=filename2drv_entry[fn].name,
+                       compatibles=filename2cmpt_entry[fn].compatibles,
+                       path=filename2path[fn],
+                       api=api))
+
+    return api2drivers
+
+def dump_content(api2drivers: DriverMap, out_dir: Path):
+    setup_out_dir(api2drivers, out_dir)
+
+    for api, drivers in api2drivers.items():
+        api_dir = api_out_dir(api, out_dir)
+        write_api_index(api, drivers, api_dir)
+        write_per_driver_orphans(drivers, api_dir)
+
+def setup_out_dir(api2drivers: DriverMap, out_dir: Path):
+    out_dir.mkdir(exist_ok=True)
+
+    api_dirs = set()
+
+    for api in api2drivers:
+        api_dir = api_out_dir(api, out_dir)
+        api_dir.mkdir(exist_ok=True)
+        api_dirs.add(api_dir)
+
+        api_drivers = api2drivers[api]
+        for child in api_dir.iterdir():
+            if child.is_dir():
+                logger.debug('removing unexpected subdirectory %s', child)
+                shutil.rmtree(child)
+            if not (child.name == 'index.rst' or
+                    any(child.name == driver_rst_name(driver)
+                        for driver in api_drivers)):
+                logger.debug('removing unexpected file %s', child)
+                child.unlink()
+
+    for child in out_dir.iterdir():
+        if child.is_dir() and child not in api_dirs:
+            logger.debug('removing unexpected directory %s', child)
+            shutil.rmtree(child)
+
+    logger.debug('set up output directory %s', out_dir)
+
+def write_api_index(api: str, drivers: List[Driver], api_dir: Path) -> None:
+    # Write the f'{api_dir}/index.rst' file, which links to the
+    # per-driver orphan pages for that API.
+
+    string_io = io.StringIO()
+    api_name = api_full_name(api)
+    title = f'{api_name} device drivers'
+    underline = '#' * len(title)
+
+    print_block(f'''\
+    .. _{api}_device_drivers:
+
+    {title}
+    {underline}
+
+    This is an automatically generated [#footnote]_ index of
+    {api_name} drivers.
+
+    .. rst-class:: rst-columns
+    ''', string_io)
+
+    for driver in sorted(drivers, key=lambda driver: driver.name):
+        print(f'- :ref:`{driver_ref_target(driver)}`', file=string_io)
+
+    print_block('''\
+
+    .. rubric:: Footnotes
+
+    .. [#footnote]
+       The drivers in the list were discovered, and their documentation
+       created, via Doxygen comments in driver source code.
+    ''', string_io)
+
+    write_if_updated(api_dir / 'index.rst', string_io.getvalue())
+
+def write_per_driver_orphans(drivers: List[Driver], api_dir: Path) -> None:
+    # Write the f'{api_dir}/{driver}.rst' orphan files for each 'driver'
+    # in 'drivers'.
+    api = drivers[0].api
+
+    logging.debug('%s: updating :orphan: files for %d drivers',
+                  api, len(drivers))
+
+    num_written = 0
+    for driver in drivers:
+        string_io = io.StringIO()
+        print_driver_page(driver, string_io)
+        written = write_if_updated(api_dir / driver_rst_name(driver),
+                                   string_io.getvalue())
+        if written:
+            num_written += 1
+
+    logging.debug('%s: done writing :orphan: files, %d files needed updates',
+                  api, num_written)
+
+def print_driver_page(driver: Driver, string_io: io.StringIO) -> None:
+    # Print the per-driver content for 'driver' to 'string_io'.
+    # The caller is responsible for saving to disk.
+
+    title = driver_title(driver)
+    underline = '#' * len(title)
+
+    # TODO: link to the API reference page for the API. Requires
+    # hand-rolling and maintaining a map or ensuring the ref targets
+    # match the directory names.
+    print_block(f'''\
+    :orphan:
+
+    .. _{driver_ref_target(driver)}:
+
+    {title}
+    {underline}
+
+    Driver API: {api_full_name(driver.api)}.
+
+    Device instances
+    ****************
+    ''', string_io)
+
+    ncompatibles = len(driver.compatibles)
+    if ncompatibles == 0:
+        print_block('''\
+        This driver does not create ``struct device`` instances from
+        nodes in the :ref:`devicetree <dt-guide>`. Information on how to get
+        device pointers may be available below.
+        ''', string_io)
+    elif ncompatibles == 1:
+        print_block(f'''\
+        This driver creates ``struct device`` instances from nodes in the
+        :ref:`devicetree <dt-guide>` with compatible
+        :dtcompatible:`{driver.compatibles[0]}`.
+        ''', string_io)
+    elif ncompatibles > 1:
+        compatibles_list = '\n'.join(f'- :dtcompatible:`{compatible}`'
+                                     for compatible in driver.compatibles)
+        print_block(f'''\
+        This driver creates ``struct device`` instances from nodes in the
+        :ref:`devicetree <dt-guide>` with the following compatibles:
+
+        {compatibles_list}
+        ''', string_io)
+
+    print_block(f'''\
+    Description
+    ***********
+
+    .. doxygenfile:: {driver.path.name}
+       :sections: detaileddescription
+    ''', string_io)
+
+def api_full_name(api: str) -> str:
+    # Full, human readable name for an API (TODO)
+
+    return api
+
+def api_out_dir(api: str, out_dir: Path) -> Path:
+    # Where should drivers for API 'api' go underneath 'out_dir'?
+
+    return out_dir / api
+
+def driver_title(driver: Driver) -> str:
+    # What is the title of the .rst page for 'driver'?
+
+    return f'{driver.name} ({driver.path.name})'
+
+def driver_rst_name(driver: Driver) -> str:
+    # What is the name of the .rst file corresponding to 'driver'?
+
+    return f'{driver.path.stem}.rst'
+
+def driver_ref_target(driver: Driver) -> str:
+    # Return the sphinx ':ref:' target name for a driver.
+
+    stem = Path(driver.path).stem
+    return 'driver_' + re.sub('[^a-z0-9]', '_', stem.lower())
+
+def write_if_updated(path: Path, s: str) -> bool:
+    # gen_helpers.write_if_updated() wrapper that handles logging and
+    # creating missing parents, as needed.
+
+    if not path.parent.is_dir():
+        path.parent.mkdir(parents=True)
+    written = gen_helpers.write_if_updated(path, s)
+    logger.debug('%s %s', 'wrote' if written else 'did NOT write', path)
+    return written
+
+def print_block(block: str, string_io: io.StringIO) -> None:
+    # Helper for dedenting and printing a triple-quoted RST block.
+    # (Just a block of text, not necessarily just a 'code-block'
+    # directive.)
+
+    print(textwrap.dedent(block), file=string_io)
+
+if __name__ == '__main__':
+    main()

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -227,6 +227,7 @@ ALIASES += option{1}="\verbatim embed:rst:inline :option:`\1` \endverbatim"
 ALIASES += req{1}="\ref ZEPH_\1 \"ZEPH-\1\" "
 ALIASES += satisfy{1}="\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1"
 ALIASES += verify{1}="\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1"
+ALIASES += dtcompatible{1}="\xrefitem dtcompatible \"Handles devicetree compatible\" \"Devicetree compatible to driver index\" \1"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2006,7 +2006,12 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "__printf_like(x, y)=" \
                          "__attribute__(x)=" \
                          "__syscall=" \
-                         "DT_DOXYGEN"
+                         "DT_DOXYGEN" \
+                         "LOG_MODULE_REGISTER(...)=" \
+                         "DEVICE_DECLARE(...)=" \
+                         "DEVICE_AND_API_INIT(...)=" \
+                         "DT_INST_FOREACH_STATUS_OKAY(...)=" \
+                         "SHELL_STATIC_SUBCMD_SET_CREATE(...)="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -751,7 +751,8 @@ INPUT                  = custom-doxygen/mainpage.md \
                          @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \
                          @ZEPHYR_BASE@/subsys/testsuite/ztest/include/ \
-                         @ZEPHYR_BASE@/tests/kernel/
+                         @ZEPHYR_BASE@/tests/kernel/ \
+                         @ZEPHYR_BASE@/drivers/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -228,6 +228,7 @@ ALIASES += req{1}="\ref ZEPH_\1 \"ZEPH-\1\" "
 ALIASES += satisfy{1}="\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1"
 ALIASES += verify{1}="\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1"
 ALIASES += dtcompatible{1}="\xrefitem dtcompatible \"Handles devicetree compatible\" \"Devicetree compatible to driver index\" \1"
+ALIASES += zephyrdriver{1}="\xrefitem zephyrdriver \"Driver for\" \"Device drivers\" \1"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF51x ADC}
+ * @dtcompatible{nordic,nrf-adc}
+ */
+
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <nrfx_adc.h>

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF SAADC}
+ * @dtcompatible{nordic,nrf-saadc}
+ */
+
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <hal/nrf_saadc.h>

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF CLOCK}
+ * @dtcompatible{nordic,nrf-clock}
+ */
+
 #include <soc.h>
 #include <sys/onoff.h>
 #include <drivers/clock_control.h>

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF RTC}
+ * @dtcompatible{nordic,nrf-rtc}
+ */
+
 #include <drivers/counter.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/nrf_clock_control.h>

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF TIMER}
+ * @dtcompatible{nordic,nrf-timer}
+ */
+
 #include <drivers/counter.h>
 #include <hal/nrf_timer.h>
 #include <sys/atomic.h>

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF RNG}
+ * @dtcompatible{nordic,nrf-rng}
+ */
+
 #include <drivers/entropy.h>
 #include <sys/atomic.h>
 #include <soc.h>

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{QSPI NOR on Nordic Semiconductor nRF}
+ * @dtcompatible{nordic,qspi-nor}
+ */
+
 #define DT_DRV_COMPAT nordic_qspi_nor
 
 #include <errno.h>

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -6,6 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF NVMC}
+ * @dtcompatible{nordic,nrf51-flash-controller}
+ * @dtcompatible{nordic,nrf52-flash-controller}
+ * @dtcompatible{nordic,nrf53-flash-controller}
+ * @dtcompatible{nordic,nrf91-flash-controller}
+ */
+
 #include <errno.h>
 
 #include <kernel.h>

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF GPIO}
+ * @dtcompatible{nordic,nrf-gpio}
+ */
+
 #include <drivers/gpio.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_gpiote.h>

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -10,6 +10,15 @@
 #include <hal/nrf_ficr.h>
 #include <sys/byteorder.h>
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF SoCs}
+ * @dtcompatible{nordic,nrf-ficr}
+ *
+ * This driver implements HWINFO via the nRF FICR device identifier
+ * registers.
+ */
+
 struct nrf_uid {
 	uint32_t id[2];
 };

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -4,6 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X TWI}
+ * @dtcompatible{nordic,nrf-twi}
+ *
+ * \rst
+ *
+ * To enable this driver, set :option:`CONFIG_I2C`\ ``=y`` via Kconfig,
+ * and make sure you have at least one :dtcompatible:`nordic,nrf-twi` node
+ * in your devicetree with ``status = "okay";`` and other properties
+ * configured as needed.
+ *
+ * \endrst
+ */
 
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -4,6 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF TWIM}
+ * @dtcompatible{nordic,nrf-twim}
+ *
+ * \rst
+ *
+ * To enable this driver, set :option:`CONFIG_I2C`\ ``=y`` via Kconfig,
+ * and make sure you have at least one :dtcompatible:`nordic,nrf-twim` node
+ * in your devicetree with ``status = "okay";`` and other properties
+ * configured as needed.
+ *
+ * \endrst
+ */
 
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF IPC}
+ * @dtcompatible{nordic,nrf-ipc}
+ */
+
 #define DT_DRV_COMPAT nordic_nrf_ipc
 
 #include <string.h>

--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -11,4 +11,4 @@ config PWM_NRFX
 	select NRFX_PWM2 if "$(dt_nodelabel_enabled,pwm2)"
 	select NRFX_PWM3 if "$(dt_nodelabel_enabled,pwm3)"
 	help
-	  Enable support for nrfx Hardware PWM driver for nRF52 MCU series.
+	  Enable support for nrfx Hardware PWM driver for nRF MCU series.

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X GPIOTE based PWM}
+ * @dtcompatible{nordic,nrf-sw-pwm}
+ */
+
 #define DT_DRV_COMPAT nordic_nrf_sw_pwm
 
 #include <soc.h>

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF PWM}
+ * @dtcompatible{nordic,nrf-pwm}
+ */
+
 #include <nrfx_pwm.h>
 #include <drivers/pwm.h>
 #include <hal/nrf_gpio.h>

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X TEMP}
+ * @dtcompatible{nordic,nrf-temp}
+ */
+
 #define DT_DRV_COMPAT nordic_nrf_temp
 
 #include <device.h>

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X QDEC}
+ * @dtcompatible{nordic,nrf-qdec}
+ *
+ * \rst
+ * This driver implements the ``SENSOR_CHAN_ROTATION`` channel
+ * using the QDEC peripheral.
+ * \endrst
+ */
+
 #include <drivers/sensor.h>
 
 #include <nrfx_qdec.h>

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -5,7 +5,9 @@
  */
 
 /**
- * @brief Driver for Nordic Semiconductor nRF5X UART
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X UART}
+ * @dtcompatible{nordic,nrf-uart}
  */
 
 #include <drivers/uart.h>

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -5,7 +5,9 @@
  */
 
 /**
- * @brief Driver for Nordic Semiconductor nRF UARTE
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF UARTE}
+ * @dtcompatible{nordic,nrf-uarte}
  */
 
 #include <drivers/uart.h>

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X SPI}
+ * @dtcompatible{nordic,nrf-spi}
+ */
+
 #include <drivers/spi.h>
 #include <nrfx_spi.h>
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X SPIM}
+ * @dtcompatible{nordic,nrf-spim}
+ */
+
 #include <drivers/spi.h>
 #include <nrfx_spim.h>
 #include <string.h>

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF5X SPIS}
+ * @dtcompatible{nordic,nrf-spis}
+ */
+
 #include <drivers/spi.h>
 #include <nrfx_spis.h>
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -6,11 +6,9 @@
  */
 
 /**
- * @file  usb_dc_nrfx.c
- * @brief Nordic USB device controller driver
- *
- * The driver implements the interface between the USBD peripheral
- * driver from nrfx package and the operating system.
+ * @file
+ * @zephyrdriver{Nordic Semiconductor USBD}
+ * @dtcompatible{nordic,nrf-usbd}
  */
 
 #include <soc.h>

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @zephyrdriver{Nordic Semiconductor nRF WDT}
+ * @dtcompatible{nordic,nrf-watchdog}
+ */
+
 #include <nrfx_wdt.h>
 #include <drivers/watchdog.h>
 

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -16,9 +16,22 @@ properties:
     sda-pin:
       type: int
       required: true
-      description: SDA pin
+      description: |
+        The SDA pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for SDA, set:
+
+            sda-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for SDA, set:
+
+            sda-pin = <34>;  /* 32 + 2 */
 
     scl-pin:
       type: int
       required: true
-      description: SCL pin
+      description: |
+        The SCL pin to use. The pin numbering scheme is the same as
+        the sda-pin property's.

--- a/dts/bindings/i2c/nordic,nrf-twi.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi.yaml
@@ -1,7 +1,44 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWI (TWI master)
+description: |
+  Nordic nRF family TWI (TWI master).
+
+  This binding can be used for nodes which can represent TWI
+  peripherals. When a single SoC peripheral ID corresponds to multiple
+  I2C peripherals (like TWI or TWIM), the corresponding devicetree
+  nodes must be set up to select TWI before use.
+
+  To select TWI, set the node's "compatible" to "nordic,nrf-twi" and
+  its "status" to "okay", e.g. using an overlay file like this:
+
+      /* This is for TWI0 -- change to "i2c1" for TWI1. */
+      &i2c0 {
+              compatible = "nordic,nrf-twi";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  You can use either of these options to check TWI availability on
+  your SoC:
+
+      1. Check the peripheral Instantiation table in the Memory
+         section of your SoC's Product Specification document.
+         A "TWI0" instance in the table means "i2c0" in the devicetree
+         can be used with this binding, and similarly for "TWI1".
+
+      2. Open your SoC's .dtsi file and look for a node definition that
+         documents TWI support, like this:
+
+             i2c0: i2c@40003000 {
+                     /*
+                      * This i2c node can be TWI, [...].
+                      */
+                     ...
+             };
+
+   If your SoC only has TWIM and TWIS I2C peripherals, you cannot use
+   this binding. See the "nordic,nrf-twim" binding instead.
 
 compatible: "nordic,nrf-twi"
 

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -1,7 +1,25 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWIM (TWI master with EasyDMA)
+description: |
+  Nordic nRF family TWIM (TWI master with EasyDMA).
+
+  This binding can be used for nodes which can represent TWIM
+  peripherals. A single SoC peripheral ID is often associated with
+  multiple I2C peripherals, like a TWIM and a TWIS. You can choose
+  TWIM by setting the node's "compatible" to "nordic,nrf-twim"
+  and "status" to "okay", e.g. using an overlay file like this one:
+
+      /* This is for TWIM0 -- change to "i2c1" for TWIM1, etc. */
+      &i2c0 {
+              compatible = "nordic,nrf-twim";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  This works on any supported SoC, for all TWIM instances.
+
+  Note: on nRF51 SoCs, use the "nordic,nrf-twi" binding instead.
 
 compatible: "nordic,nrf-twim"
 

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -1,7 +1,29 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWIS (TWI slave with EasyDMA)
+description: |
+  Nordic nRF family TWIS (TWI slave with EasyDMA).
+
+  Note: for Zephyr users, the I2C slave API is not available for
+  these devices. See this issue for more details and a HAL-based
+  workaround:
+
+      https://github.com/zephyrproject-rtos/zephyr/issues/21445
+
+  This binding can be used for nodes which can represent TWIS
+  peripherals. A single SoC peripheral ID is often associated with
+  multiple I2C peripherals, like a TWIM and a TWIS. You can choose
+  TWIS by setting the node's "compatible" to "nordic,nrf-twis"
+  and its "status" to "okay", e.g. using an overlay file like this:
+
+      /* This is for TWIS0 -- change to "i2c1" for TWIS1, etc. */
+      &i2c0 {
+              compatible = "nordic,nrf-twis";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  This works on any supported SoC, for all TWIS instances.
 
 compatible: "nordic,nrf-twis"
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -192,11 +192,19 @@ Binding (compatible = {node.matching_compat}):
 """
 
     if node.description:
-        # Indent description by two spaces
-        s += "\nDescription:\n" + \
-            "\n".join("  " + line for line in
-                      node.description.splitlines()) + \
-            "\n"
+        # We used to put descriptions in the generated file, but
+        # devicetree bindings now have pages in the HTML
+        # documentation. Let users who are accustomed to digging
+        # around in the generated file where to find the descriptions
+        # now.
+        #
+        # Keeping them here would mean that the descriptions
+        # themselves couldn't contain C multi-line comments, which is
+        # inconvenient when we want to do things like quote snippets
+        # of .dtsi files within the snippets themselves, or otherwise
+        # include the characters "*/" in order.
+        s += ("\n(Descriptions have moved to the Devicetree Bindings Index\n"
+              "in the documentation.)\n")
 
     out_comment(s)
 


### PR DESCRIPTION
We have thorough existing documentation on the abstract driver model.

We have some documentation on individual APIs (though the generated
content is not very useful and should probably be looked at; I suspect
99.9% of users are just reading the doxygen comments in the source
code instead of looking at these pages).

We do not, however, have documentation for actual device drivers, or
information about what devicetree compatibles and Kconfig options they
are associated with.

This PR is a proof of concept showing how an index of existing drivers
that cross-references DT and Kconfig as needed, with content
coming from the sources, can be made.
