### PR TITLE
tests: net: socketpair: fix user work queue initialization

### DIFF
--- a/tests/net/socket/socketpair/src/main.c
+++ b/tests/net/socket/socketpair/src/main.c
@@ -44,20 +44,9 @@ extern void test_socketpair_poll_delayed_data(void);
 extern void test_socketpair_poll_close_remote_end_POLLIN(void);
 extern void test_socketpair_poll_close_remote_end_POLLOUT(void);
 
-/* work queue for tests that need an async event */
-static K_THREAD_STACK_DEFINE(test_socketpair_work_q_stack, 512);
-struct k_work_q test_socketpair_work_q;
-
 void test_main(void)
 {
 	k_thread_system_pool_assign(k_current_get());
-
-	k_thread_access_grant(k_current_get(),
-		&test_socketpair_work_q.queue);
-
-	k_work_q_start(&test_socketpair_work_q, test_socketpair_work_q_stack,
-		K_THREAD_STACK_SIZEOF(test_socketpair_work_q_stack),
-		CONFIG_MAIN_THREAD_PRIORITY);
 
 	ztest_test_suite(
 		socketpair,
@@ -73,8 +62,8 @@ void test_main(void)
 		ztest_user_unit_test(test_socketpair_read_nonblock),
 		ztest_user_unit_test(test_socketpair_write_nonblock),
 
-		ztest_user_unit_test(test_socketpair_read_block),
-		ztest_user_unit_test(test_socketpair_write_block),
+		ztest_unit_test(test_socketpair_read_block),
+		ztest_unit_test(test_socketpair_write_block),
 
 		ztest_user_unit_test(
 			test_socketpair_close_one_end_and_read_from_the_other),
@@ -85,12 +74,10 @@ void test_main(void)
 		ztest_user_unit_test(
 			test_socketpair_poll_timeout_nonblocking),
 		ztest_user_unit_test(test_socketpair_poll_immediate_data),
-		ztest_user_unit_test(test_socketpair_poll_delayed_data),
+		ztest_unit_test(test_socketpair_poll_delayed_data),
 
-		ztest_user_unit_test(
-			test_socketpair_poll_close_remote_end_POLLIN),
-		ztest_user_unit_test(
-			test_socketpair_poll_close_remote_end_POLLOUT)
+		ztest_unit_test(test_socketpair_poll_close_remote_end_POLLIN),
+		ztest_unit_test(test_socketpair_poll_close_remote_end_POLLOUT)
 	);
 
 	ztest_run_test_suite(socketpair);

--- a/tests/net/socket/socketpair/src/test_socketpair_block.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_block.c
@@ -93,10 +93,7 @@ void test_socketpair_write_block(void)
 
 		LOG_DBG("queueing work");
 		k_work_init(&work, work_handler);
-		res = k_work_submit_to_user_queue(&test_socketpair_work_q,
-			&work);
-		zassert_equal(res, 0,
-			"k_work_submit_to_user_queue() failed: %d", res);
+		k_work_submit(&work);
 
 		/* fill up the buffer */
 		for (ctx.m = 0; atomic_get(&ctx.m)
@@ -146,10 +143,7 @@ void test_socketpair_read_block(void)
 
 		LOG_DBG("queueing work");
 		k_work_init(&work, work_handler);
-		res = k_work_submit_to_user_queue(&test_socketpair_work_q,
-			&work);
-		zassert_equal(res, 0,
-			"k_work_submit_to_user_queue() failed: %d", res);
+		k_work_submit(&work);
 
 		/* try to read one byte */
 		LOG_DBG("reading from fd %d", sv[i]);

--- a/tests/net/socket/socketpair/src/test_socketpair_poll.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_poll.c
@@ -144,8 +144,7 @@ void test_socketpair_poll_close_remote_end_POLLIN(void)
 
 	LOG_DBG("scheduling work");
 	k_work_init(&work, close_fun);
-	res = k_work_submit_to_user_queue(&test_socketpair_work_q, &work);
-	zassert_equal(res, 0, "k_work_submit_to_user_queue() failed: %d", res);
+	k_work_submit(&work);
 
 	res = poll(fds, 1, -1);
 	zassert_equal(res, 1, "poll(2) failed: %d", res);
@@ -187,8 +186,7 @@ void test_socketpair_poll_close_remote_end_POLLOUT(void)
 
 	LOG_DBG("scheduling work");
 	k_work_init(&work, close_fun);
-	res = k_work_submit_to_user_queue(&test_socketpair_work_q, &work);
-	zassert_equal(res, 0, "k_work_submit_to_user_queue() failed: %d", res);
+	k_work_submit(&work);
 
 	res = poll(fds, 1, -1);
 	zassert_equal(res, 1, "poll(2) failed: %d", res);
@@ -310,8 +308,7 @@ void test_socketpair_poll_delayed_data(void)
 
 	LOG_DBG("scheduling work");
 	k_work_init(&work, rw_fun);
-	res = k_work_submit_to_user_queue(&test_socketpair_work_q, &work);
-	zassert_equal(res, 0, "k_work_submit_to_user_queue() failed: %d", res);
+	k_work_submit(&work);
 
 	res = poll(fds, 1, 5000);
 	zassert_not_equal(res, -1, "poll(2) failed: %d", errno);
@@ -334,8 +331,7 @@ void test_socketpair_poll_delayed_data(void)
 
 	LOG_DBG("scheduling work");
 	k_work_init(&work, rw_fun);
-	res = k_work_submit_to_user_queue(&test_socketpair_work_q, &work);
-	zassert_equal(res, 0, "k_work_submit_to_user_queue() failed: %d", res);
+	k_work_submit(&work);
 
 	res = poll(fds, 1, 5000);
 	zassert_not_equal(res, -1, "poll(2) failed: %d", errno);


### PR DESCRIPTION
The socket pairs created for this test when run under user mode are accessible only from the thread that created them.  Although it is possible for that thread to grant access to another thread:

* there does not appear to be a way to do that when referencing a descriptor rather than a pointer to a kernel object;
* there is no public API that supports granting the object rights to a  user thread that animates a work queue.

Until these gaps are addressed use the system work queue run supervisor-mode threads to verify the asynchronous behavior of the API.

Fixes #30072

(NB: This is a first step to trying to clean up the concept of work queues that can be submitted to from userspace.)