### PR TITLE
manifest: update mcuboot

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -303,6 +303,8 @@ MCUBoot
     see ``CONFIG_MCUBOOT_CLEANUP_ARM_CORE``.
   * Allow the final data chunk in the image to be unaligned in
     the serial-recovery protocol.
+  * Added ``revert mechanism`` support to the direct-xip mode.
+    See ``CONFIG_MCUBOOT_DIRECT_XIP_REVERT`` option.
 
 * imgtool
 

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       revision: 13cf2e52024a144ecee9f37680681760a85febab
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6
+      revision: 6e3825f1309b34d3f5e5e1be8dd522cfe92e044b
       path: bootloader/mcuboot
     - name: mcumgr
       revision: f28a637db12c4b12fb2b18bddc6b2a0deaa95251


### PR DESCRIPTION
Synchronized up to:
https://github.com/mcu-tools/mcuboot/commit/d2122bc

- Added 'revert' support to direct-xip mode.

Introduces https://github.com/zephyrproject-rtos/mcuboot/pull/39

DNM until SHA is not in place.