### PR TITLE
drivers: uart: Remove extra warn prints from native_posix

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -287,11 +287,10 @@ static void np_uart_poll_out(const struct device *dev,
 		}
 	}
 
+	/* The return value of write() cannot be ignored (there is a warning)
+	 * but we do not need the return value for anything.
+	 */
 	ret = write(d->out_fd, &out_char, 1);
-
-	if (ret != 1) {
-		WARN("%s: a character could not be output\n", __func__);
-	}
 }
 
 /**


### PR DESCRIPTION
Sometimes native_posix UART driver starts to flood the output
by printing hundreds of lines like this

    np_uart_poll_out: a character could not be output

Remove the warning as it makes the output very hard to read
without giving much useful information.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>