### PR TITLE
tests: coverage: GCOV counter value changed in GCC10.

### DIFF
--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -30,7 +30,9 @@
 #ifndef _COVERAGE_H_
 #define _COVERAGE_H_
 
-#if (__GNUC__ >= 8)
+#if (__GNUC__ >= 10)
+#define GCOV_COUNTERS 8U
+#elif (__GNUC__ >= 8)
 #define GCOV_COUNTERS 9U
 #else
 #define GCOV_COUNTERS 10U


### PR DESCRIPTION
Updated the GCOV_COUNTERS value, without which the coverage data
was corrupted when gcc 10.2 was used.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>