### PR TITLE
arch: arc: fix for hs eret has no copy of pc in interrupt entry

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -220,8 +220,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	_create_irq_stack_frame
 	lr r0, [_ARC_V2_STATUS32_P0]
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
-	lr r0, [_ARC_V2_ERET]
-	st_s r0, [sp, ___isf_t_pc_OFFSET]
+	st ilink, [sp, ___isf_t_pc_OFFSET]
 
 	mov_s r3, _firq_exit
 	mov_s r2, _firq_enter


### PR DESCRIPTION
According to he Programmer's Reference Manual for ARC EM and HS,
there are some inconsistent performace between EM and HS in interrupt
entry. eret has copy of PC in interrupt entry in EM while not in HS,
so we should rely on eret register in interrupt entry, which will cause
carash for HS.

```
+----+---------------+---------------+--------------+
|    | FIRQ          | RIRQ          | RIRQ(Secure) |
+----+---------------+---------------+--------------+
| HS | ILINK=PC      | ILINK=PC      | NULL         |
+----+---------------+---------------+--------------+
| EM | ILINK=ERET=PC | ILINK=ERET=PC | ILINK=PC     |
+----+---------------+---------------+--------------+
```

similar fix: [arch: arc: for fast irq ERET has no copy of ilink](https://github.com/zephyrproject-rtos/zephyr/pull/18288/commits/7ccabd16b3aa6baa91b0d63a5224588e38802001)

Fixes: #29916 
 