### PR TITLE
Bluetooth: controller: Fix ull_conn LSTO for must_expire

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1084,7 +1084,14 @@ void ull_conn_done(struct node_rx_event_done *done)
 	}
 
 	/* Events elapsed used in timeout checks below */
+#if defined(CONFIG_BT_CTLR_CONN_META)
+	/* If event has shallow expiry do not add latency, but rely on
+	 * accumulated lazy count.
+	 */
+	latency_event = conn->common.is_must_expire ? 0 : lll->latency_event;
+#else
 	latency_event = lll->latency_event;
+#endif
 	elapsed_event = latency_event + 1;
 
 	/* Slave drift compensation calc and new latency or

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -59,6 +59,9 @@ struct ll_conn {
 	union {
 		struct {
 			uint8_t fex_valid:1;
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 		} common;
 
 #if defined(CONFIG_BT_PERIPHERAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -751,6 +751,9 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 		return;
 	}
 
+#if defined(CONFIG_BT_CTLR_CONN_META)
+	conn->common.is_must_expire = (lazy == TICKER_LAZY_MUST_EXPIRE);
+#endif
 	/* If this is a must-expire callback, LLCP state machine does not need
 	 * to know. Will be called with lazy > 0 when scheduled in air.
 	 */

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -375,6 +375,9 @@ void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 		return;
 	}
 
+#if defined(CONFIG_BT_CTLR_CONN_META)
+	conn->common.is_must_expire = (lazy == TICKER_LAZY_MUST_EXPIRE);
+#endif
 	/* If this is a must-expire callback, LLCP state machine does not need
 	 * to know. Will be called with lazy > 0 when scheduled in air.
 	 */


### PR DESCRIPTION
When CONFIG_BT_CTLR_CONN_META is enabled and the ticker "must_expire"
feature is used, collisions may cause incorrect decrement of the
supervision_expire counter, resulting in a too early link supervision
timeout.