### PR TITLE
net: lwm2m: Verify if block transfer is used before skipping TLV parsing

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -946,7 +946,8 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 	 * message processing - consecutive blocks will not carry the TLV
 	 * header.
 	 */
-	if (msg->path.obj_id == 5 && msg->path.res_id == 0) {
+	if (msg->in.block_ctx != NULL && msg->in.block_ctx->ctx.current > 0 &&
+	    msg->path.obj_id == 5 && msg->path.res_id == 0) {
 		ret = do_write_op_tlv_item(msg);
 		if (ret < 0) {
 			return ret;


### PR DESCRIPTION
Verify if block tranfer is used and not an initial block when skipping
directly to data processing during FW update in PUSH mode.

This fixes a bug, which caused TLV not to be processed when the FW
object was updated as a whole, and actual resource number was encoded in
a TLV (for instance when writing FW Update URI).

Fixes #30135

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>