### PR TITLE
dts/bindings: Add binding for riscv,clint0

### DIFF
--- a/dts/bindings/interrupt-controller/riscv,clint0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,clint0.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020, Katsuhiro Suzuki.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Common fields for the RISC-V Core-Local interruptor.
+
+include: [interrupt-controller.yaml, base.yaml]
+
+compatible: "riscv,clint0"
+
+properties:
+  reg:
+      required: true
+
+  "#interrupt-cells":
+      const: 1
+
+interrupt-cells:
+  - irq


### PR DESCRIPTION
Currently there is no binding for RISC-V Core-Local Interruptor.
This patch add a simple binding.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>