### PR TITLE
modem: verify send semaphore before taking any action and fix race condition waiting on reply

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -476,7 +476,15 @@ static int _modem_cmd_send(struct modem_iface *iface,
 	struct modem_cmd_handler_data *data;
 	int ret;
 
-	if (!iface || !handler || !handler->cmd_handler_data || !buf) {
+	if (!iface || !handler || !handler->cmd_handler_data || !buf || !sem) {
+		return -EINVAL;
+	}
+
+	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		/* semaphore is not needed if there is no timeout */
+		sem = NULL;
+	} else if (!sem) {
+		/* cannot respect timeout without semaphore */
 		return -EINVAL;
 	}
 
@@ -508,23 +516,15 @@ static int _modem_cmd_send(struct modem_iface *iface,
 	iface->write(iface, buf, strlen(buf));
 	iface->write(iface, data->eol, data->eol_len);
 
-	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
-		ret = 0;
-		goto exit;
-	}
+	if (sem) {
+		k_sem_reset(sem);
+		ret = k_sem_take(sem, timeout);
 
-	if (!sem) {
-		ret = -EINVAL;
-		goto exit;
-	}
-
-	k_sem_reset(sem);
-	ret = k_sem_take(sem, timeout);
-
-	if (ret == 0) {
-		ret = data->last_error;
-	} else if (ret == -EAGAIN) {
-		ret = -ETIMEDOUT;
+		if (ret == 0) {
+			ret = data->last_error;
+		} else if (ret == -EAGAIN) {
+			ret = -ETIMEDOUT;
+		}
 	}
 
 exit:

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -496,7 +496,7 @@ static int _modem_cmd_send(struct modem_iface *iface,
 	ret = modem_cmd_handler_update_cmds(data, handler_cmds,
 					    handler_cmds_len, true);
 	if (ret < 0) {
-		goto exit;
+		goto unlock_tx_lock;
 	}
 
 #if defined(CONFIG_MODEM_CONTEXT_VERBOSE_DEBUG)
@@ -530,9 +530,10 @@ static int _modem_cmd_send(struct modem_iface *iface,
 		}
 	}
 
-exit:
 	/* unset handlers and ignore any errors */
 	(void)modem_cmd_handler_update_cmds(data, NULL, 0U, false);
+
+unlock_tx_lock:
 	if (!no_tx_lock) {
 		k_sem_give(&data->sem_tx_lock);
 	}

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -513,11 +513,14 @@ static int _modem_cmd_send(struct modem_iface *iface,
 		LOG_DBG("EOL not set!!!");
 	}
 #endif
+	if (sem) {
+		k_sem_reset(sem);
+	}
+
 	iface->write(iface, buf, strlen(buf));
 	iface->write(iface, data->eol, data->eol_len);
 
 	if (sem) {
-		k_sem_reset(sem);
 		ret = k_sem_take(sem, timeout);
 
 		if (ret == 0) {

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -383,19 +383,7 @@ static int esp_sendto(struct net_pkt *pkt,
 		return 0;
 	}
 
-	/*
-	 * FIXME:
-	 * In _modem_cmd_send() in modem_cmd_handler.c it can happen that a
-	 * response, eg 'OK', is received before k_sem_reset(sem) is called.
-	 * If the sending thread can be preempted, the command handler could
-	 * run and call k_sem_give(). This will cause a timeout and the send
-	 * will fail. This can be avoided by locking the scheduler. Maybe this
-	 * should be done in _modem_cmd_send() instead.
-	 */
-	k_sched_lock();
 	ret = _sock_send(dev, sock);
-	k_sched_unlock();
-
 	if (ret == 0) {
 		net_pkt_unref(sock->tx_pkt);
 	} else {


### PR DESCRIPTION
Check function arguments on the beginning of function, so that -EINVAL is
returned before taking any actions, such as sending data over modem interface.

Fix race condition, by first reseting semaphore, then sending command over modem
interface, then waiting on reply by taking semaphore.

Add minor improvement to handling error when setting up command handlers - there
is no need to clear them out in that case.