### PR TITLE
drivers: modem: constify modem_cmd and setup_cmd structures

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -102,7 +102,7 @@ MODEM_CMD_DEFINE(gsm_cmd_error)
 	return 0;
 }
 
-static struct modem_cmd response_cmds[] = {
+static const struct modem_cmd response_cmds[] = {
 	MODEM_CMD("OK", gsm_cmd_ok, 0U, ""),
 	MODEM_CMD("ERROR", gsm_cmd_error, 0U, ""),
 	MODEM_CMD("CONNECT", gsm_cmd_ok, 0U, ""),
@@ -230,7 +230,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_iccid)
 #endif /* CONFIG_MODEM_SIM_NUMBERS */
 #endif /* CONFIG_MODEM_SHELL */
 
-static struct setup_cmd setup_cmds[] = {
+static const struct setup_cmd setup_cmds[] = {
 	/* no echo */
 	SETUP_CMD_NOHANDLE("ATE0"),
 	/* hang up */
@@ -273,10 +273,10 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_attached)
 	return 0;
 }
 
-static struct modem_cmd check_attached_cmd =
+static const struct modem_cmd check_attached_cmd =
 	MODEM_CMD("+CGATT:", on_cmd_atcmdinfo_attached, 1U, ",");
 
-static struct setup_cmd connect_cmds[] = {
+static const struct setup_cmd connect_cmds[] = {
 	/* connect to network */
 	SETUP_CMD_NOHANDLE("ATD*99#"),
 };

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -107,7 +107,7 @@ static inline struct net_buf *read_rx_allocator(k_timeout_t timeout,
 
 /* return scanned length for params */
 static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
-			struct modem_cmd *cmd,
+			const struct modem_cmd *cmd,
 			uint8_t **argv, size_t argv_len, uint16_t *argc)
 {
 	int i, count = 0;
@@ -170,7 +170,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 }
 
 /* process a "matched" command */
-static int process_cmd(struct modem_cmd *cmd, size_t match_len,
+static int process_cmd(const struct modem_cmd *cmd, size_t match_len,
 			struct modem_cmd_handler_data *data)
 {
 	int parsed_len = 0, ret = 0;
@@ -212,7 +212,8 @@ static int process_cmd(struct modem_cmd *cmd, size_t match_len,
  * - unsolicited handlers[1]
  * - current assigned handlers[2]
  */
-static struct modem_cmd *find_cmd_match(struct modem_cmd_handler_data *data)
+static const struct modem_cmd *find_cmd_match(
+		struct modem_cmd_handler_data *data)
 {
 	int j, i;
 
@@ -234,7 +235,7 @@ static struct modem_cmd *find_cmd_match(struct modem_cmd_handler_data *data)
 	return NULL;
 }
 
-static struct modem_cmd *find_cmd_direct_match(
+static const struct modem_cmd *find_cmd_direct_match(
 		struct modem_cmd_handler_data *data)
 {
 	int j, i;
@@ -307,7 +308,7 @@ static int cmd_handler_process_iface_data(struct modem_cmd_handler_data *data,
 
 static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 {
-	struct modem_cmd *cmd;
+	const struct modem_cmd *cmd;
 	struct net_buf *frag = NULL;
 	size_t match_len;
 	int ret;
@@ -449,7 +450,7 @@ int modem_cmd_handler_set_error(struct modem_cmd_handler_data *data,
 }
 
 int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
-				  struct modem_cmd *handler_cmds,
+				  const struct modem_cmd *handler_cmds,
 				  size_t handler_cmds_len,
 				  bool reset_error_flag)
 {
@@ -468,7 +469,7 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 
 static int _modem_cmd_send(struct modem_iface *iface,
 			   struct modem_cmd_handler *handler,
-			   struct modem_cmd *handler_cmds,
+			   const struct modem_cmd *handler_cmds,
 			   size_t handler_cmds_len,
 			   const uint8_t *buf, struct k_sem *sem,
 			   k_timeout_t timeout, bool no_tx_lock)
@@ -539,7 +540,7 @@ exit:
 
 int modem_cmd_send_nolock(struct modem_iface *iface,
 			  struct modem_cmd_handler *handler,
-			  struct modem_cmd *handler_cmds,
+			  const struct modem_cmd *handler_cmds,
 			  size_t handler_cmds_len,
 			  const uint8_t *buf, struct k_sem *sem,
 			  k_timeout_t timeout)
@@ -550,8 +551,9 @@ int modem_cmd_send_nolock(struct modem_iface *iface,
 
 int modem_cmd_send(struct modem_iface *iface,
 		   struct modem_cmd_handler *handler,
-		   struct modem_cmd *handler_cmds, size_t handler_cmds_len,
-		   const uint8_t *buf, struct k_sem *sem, k_timeout_t timeout)
+		   const struct modem_cmd *handler_cmds,
+		   size_t handler_cmds_len, const uint8_t *buf,
+		   struct k_sem *sem, k_timeout_t timeout)
 {
 	return _modem_cmd_send(iface, handler, handler_cmds, handler_cmds_len,
 			       buf, sem, timeout, false);
@@ -560,7 +562,7 @@ int modem_cmd_send(struct modem_iface *iface,
 /* run a set of AT commands */
 int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 				 struct modem_cmd_handler *handler,
-				 struct setup_cmd *cmds, size_t cmds_len,
+				 const struct setup_cmd *cmds, size_t cmds_len,
 				 struct k_sem *sem, k_timeout_t timeout)
 {
 	int ret = 0, i;
@@ -594,8 +596,9 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 /* run a set of AT commands, without lock */
 int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
 					struct modem_cmd_handler *handler,
-					struct setup_cmd *cmds, size_t cmds_len,
-					struct k_sem *sem, k_timeout_t timeout)
+					const struct setup_cmd *cmds,
+					size_t cmds_len, struct k_sem *sem,
+					k_timeout_t timeout)
 {
 	int ret = 0, i;
 

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -77,7 +77,7 @@ struct setup_cmd {
 };
 
 struct modem_cmd_handler_data {
-	struct modem_cmd *cmds[CMD_MAX];
+	const struct modem_cmd *cmds[CMD_MAX];
 	size_t cmds_len[CMD_MAX];
 
 	char *match_buf;
@@ -131,7 +131,7 @@ int modem_cmd_handler_set_error(struct modem_cmd_handler_data *data,
  * @retval 0 if ok, < 0 if error.
  */
 int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
-				  struct modem_cmd *handler_cmds,
+				  const struct modem_cmd *handler_cmds,
 				  size_t handler_cmds_len,
 				  bool reset_error_flag);
 
@@ -148,7 +148,7 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
  */
 int modem_cmd_send_nolock(struct modem_iface *iface,
 			  struct modem_cmd_handler *handler,
-			  struct modem_cmd *handler_cmds,
+			  const struct modem_cmd *handler_cmds,
 			  size_t handler_cmds_len,
 			  const uint8_t *buf, struct k_sem *sem,
 			  k_timeout_t timeout);
@@ -166,8 +166,9 @@ int modem_cmd_send_nolock(struct modem_iface *iface,
  */
 int modem_cmd_send(struct modem_iface *iface,
 		   struct modem_cmd_handler *handler,
-		   struct modem_cmd *handler_cmds, size_t handler_cmds_len,
-		   const uint8_t *buf, struct k_sem *sem, k_timeout_t timeout);
+		   const struct modem_cmd *handler_cmds,
+		   size_t handler_cmds_len, const uint8_t *buf,
+		   struct k_sem *sem, k_timeout_t timeout);
 
 /**
  * @brief  send a series of AT commands w/ a TX lock
@@ -183,7 +184,7 @@ int modem_cmd_send(struct modem_iface *iface,
  */
 int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 				 struct modem_cmd_handler *handler,
-				 struct setup_cmd *cmds, size_t cmds_len,
+				 const struct setup_cmd *cmds, size_t cmds_len,
 				 struct k_sem *sem, k_timeout_t timeout);
 
 /**
@@ -200,8 +201,9 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
  */
 int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
 					struct modem_cmd_handler *handler,
-					struct setup_cmd *cmds, size_t cmds_len,
-					struct k_sem *sem, k_timeout_t timeout);
+					const struct setup_cmd *cmds,
+					size_t cmds_len, struct k_sem *sem,
+					k_timeout_t timeout);
 
 /**
  * @brief  Init command handler

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -294,7 +294,7 @@ int modem_detect_apn(const char *imsi)
 /* send binary data via the +USO[ST/WR] commands */
 static ssize_t send_socket_data(struct modem_socket *sock,
 				const struct sockaddr *dst_addr,
-				struct modem_cmd *handler_cmds,
+				const struct modem_cmd *handler_cmds,
 				size_t handler_cmds_len,
 				const char *buf, size_t buf_len,
 				k_timeout_t timeout)
@@ -824,7 +824,7 @@ static int pin_init(void)
 #if defined(CONFIG_MODEM_UBLOX_SARA_AUTODETECT_VARIANT)
 static void modem_rssi_query_work(struct k_work *work)
 {
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		  MODEM_CMD("+CSQ: ", on_cmd_atcmdinfo_rssi_csq, 2U, ","),
 		  MODEM_CMD("+CESQ: ", on_cmd_atcmdinfo_rssi_cesq, 6U, ","),
 	};
@@ -859,7 +859,7 @@ static void modem_rssi_query_work(struct k_work *work)
 #else
 static void modem_rssi_query_work(struct k_work *work)
 {
-	struct modem_cmd cmd =
+	static const struct modem_cmd cmd =
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
 		MODEM_CMD("+CSQ: ", on_cmd_atcmdinfo_rssi_csq, 2U, ",");
 	static char *send_cmd = "AT+CSQ";
@@ -889,7 +889,7 @@ static void modem_rssi_query_work(struct k_work *work)
 static void modem_reset(void)
 {
 	int ret = 0, retry_count = 0, counter = 0;
-	static struct setup_cmd setup_cmds[] = {
+	static const struct setup_cmd setup_cmds[] = {
 		/* turn off echo */
 		SETUP_CMD_NOHANDLE("ATE0"),
 		/* stop functionality */
@@ -924,7 +924,7 @@ static void modem_reset(void)
 	};
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_AUTODETECT_VARIANT)
-	static struct setup_cmd post_setup_cmds_u2[] = {
+	static const struct setup_cmd post_setup_cmds_u2[] = {
 #if !defined(CONFIG_MODEM_UBLOX_SARA_AUTODETECT_APN)
 		/* set the APN */
 		SETUP_CMD_NOHANDLE("AT+UPSD=0,1,\""
@@ -937,7 +937,7 @@ static void modem_reset(void)
 	};
 #endif
 
-	static struct setup_cmd post_setup_cmds[] = {
+	static const struct setup_cmd post_setup_cmds[] = {
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
 		/* set the APN */
 		SETUP_CMD_NOHANDLE("AT+UPSD=0,1,\""
@@ -1144,7 +1144,8 @@ error:
 static int create_socket(struct modem_socket *sock, const struct sockaddr *addr)
 {
 	int ret;
-	struct modem_cmd cmd = MODEM_CMD("+USOCR: ", on_cmd_sockcreate, 1U, "");
+	static const struct modem_cmd cmd =
+		MODEM_CMD("+USOCR: ", on_cmd_sockcreate, 1U, "");
 	char buf[sizeof("AT+USOCR=#,#####\r")];
 	uint16_t local_port = 0U, proto = 6U;
 
@@ -1336,7 +1337,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	int ret, next_packet_size;
-	struct modem_cmd cmd[] = {
+	static const struct modem_cmd cmd[] = {
 		MODEM_CMD("+USORF: ", on_cmd_sockreadfrom, 4U, ","),
 		MODEM_CMD("+USORD: ", on_cmd_sockread, 2U, ","),
 	};
@@ -1421,7 +1422,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 {
 	int ret;
 	struct modem_socket *sock = (struct modem_socket *)obj;
-	struct modem_cmd cmd[] = {
+	static const struct modem_cmd cmd[] = {
 		MODEM_CMD("+USOST: ", on_cmd_sockwrite, 2U, ","),
 		MODEM_CMD("+USOWR: ", on_cmd_sockwrite, 2U, ","),
 	};
@@ -1558,7 +1559,8 @@ static int offload_getaddrinfo(const char *node, const char *service,
 			       const struct zsock_addrinfo *hints,
 			       struct zsock_addrinfo **res)
 {
-	struct modem_cmd cmd = MODEM_CMD("+UDNSRN: ", on_cmd_dns, 1U, ",");
+	static const struct modem_cmd cmd =
+		MODEM_CMD("+UDNSRN: ", on_cmd_dns, 1U, ",");
 	uint32_t port = 0U;
 	int ret;
 	/* DNS command + 128 bytes for domain name parameter */
@@ -1696,13 +1698,13 @@ static struct net_if_api api_funcs = {
 	.init = modem_net_iface_init,
 };
 
-static struct modem_cmd response_cmds[] = {
+static const struct modem_cmd response_cmds[] = {
 	MODEM_CMD("OK", on_cmd_ok, 0U, ""), /* 3GPP */
 	MODEM_CMD("ERROR", on_cmd_error, 0U, ""), /* 3GPP */
 	MODEM_CMD("+CME ERROR: ", on_cmd_exterror, 1U, ""),
 };
 
-static struct modem_cmd unsol_cmds[] = {
+static const struct modem_cmd unsol_cmds[] = {
 	MODEM_CMD("+UUSOCL: ", on_cmd_socknotifyclose, 1U, ""),
 	MODEM_CMD("+UUSORD: ", on_cmd_socknotifydata, 2U, ","),
 	MODEM_CMD("+UUSORF: ", on_cmd_socknotifydata, 2U, ","),

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -175,7 +175,7 @@ MODEM_CMD_DEFINE(on_cmd_cwlap)
 	return 0;
 }
 
-static struct modem_cmd response_cmds[] = {
+static const struct modem_cmd response_cmds[] = {
 	MODEM_CMD("OK", on_cmd_ok, 0U, ""), /* 3GPP */
 	MODEM_CMD("ERROR", on_cmd_error, 0U, ""), /* 3GPP */
 };
@@ -243,7 +243,7 @@ static void esp_ip_addr_work(struct k_work *work)
 					    ip_addr_work);
 	int ret;
 
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		MODEM_CMD("+"_CIPSTA":", on_cmd_cipsta, 2U, ":"),
 	};
 
@@ -518,7 +518,7 @@ MODEM_CMD_DEFINE(on_cmd_ready)
 	return 0;
 }
 
-static struct modem_cmd unsol_cmds[] = {
+static const struct modem_cmd unsol_cmds[] = {
 	MODEM_CMD("WIFI CONNECTED", on_cmd_wifi_connected, 0U, ""),
 	MODEM_CMD("WIFI DISCONNECT", on_cmd_wifi_disconnected, 0U, ""),
 	MODEM_CMD("WIFI GOT IP", on_cmd_got_ip, 0U, ""),
@@ -542,7 +542,7 @@ static void esp_mgmt_scan_work(struct k_work *work)
 {
 	struct esp_data *dev;
 	int ret;
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		MODEM_CMD("+CWLAP:", on_cmd_cwlap, 4U, ","),
 	};
 
@@ -593,7 +593,7 @@ static void esp_mgmt_connect_work(struct k_work *work)
 {
 	struct esp_data *dev;
 	int ret;
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		MODEM_CMD("FAIL", on_cmd_fail, 0U, ""),
 	};
 
@@ -742,14 +742,14 @@ static void esp_init_work(struct k_work *work)
 {
 	struct esp_data *dev;
 	int ret;
-	static struct setup_cmd setup_cmds[] = {
+	static const struct setup_cmd setup_cmds[] = {
 		SETUP_CMD_NOHANDLE("AT"),
 		/* turn off echo */
 		SETUP_CMD_NOHANDLE("ATE0"),
 		SETUP_CMD_NOHANDLE("AT+UART_CUR="_UART_CUR),
 #if DT_INST_NODE_HAS_PROP(0, target_speed)
 	};
-	static struct setup_cmd setup_cmds_target_baudrate[] = {
+	static const struct setup_cmd setup_cmds_target_baudrate[] = {
 		SETUP_CMD_NOHANDLE("AT"),
 #endif
 		SETUP_CMD_NOHANDLE("AT+"_CWMODE"=1"),

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -206,7 +206,7 @@ static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 	char cmd_buf[64], addr_str[NET_IPV4_ADDR_LEN];
 	int ret, write_len, pkt_len;
 	struct net_buf *frag;
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		MODEM_CMD_DIRECT(">", on_cmd_tx_ready),
 		MODEM_CMD("SEND OK", on_cmd_send_ok, 0U, ""),
 		MODEM_CMD("SEND FAIL", on_cmd_send_fail, 0U, ""),
@@ -507,7 +507,7 @@ static void esp_recvdata_work(struct k_work *work)
 	struct esp_data *dev;
 	int len = CIPRECVDATA_MAX_LEN, ret;
 	char cmd[32];
-	struct modem_cmd cmds[] = {
+	static const struct modem_cmd cmds[] = {
 		MODEM_CMD_DIRECT(_CIPRECVDATA, on_cmd_ciprecvdata),
 	};
 


### PR DESCRIPTION
`modem_cmd` and `setup_cmd` structures are used only to store static
information about commands to be sent and replies to be
received. Reference it as const, so that it is possible to define const
instances and save some RAM space by placing those definitions entirely
in ROM.

Constifying global data allows to save lots of RAM. Defining data inside
function as 'static const' allows on the other hand to save stack usage
and reduced code size (because data doesn't have to be copied on stack
in runtime).

Update drivers that use modem framework. Some stats of memory
usage reduction:
- `wifi_esp`: 640 bytes RAM, 64 bytes ROM,
- `ublox-sara-r4`: 448 bytes RAM, 88 bytes ROM,
- `gsp_ppp`: 224 bytes RAM.