### PR TITLE
Tests: mutex: develop the mutex's code coverage

### DIFF
--- a/tests/kernel/mutex/mutex_api/testcase.yaml
+++ b/tests/kernel/mutex/mutex_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.mutex:
-    tags: kernel userspace
+    tags: kernel userspace ignore_faults


### PR DESCRIPTION
Add some negative testcases for mutex  to check if the behavior of system is correct or not if 
a error is met.

This PR depends on the another PR: https://github.com/zephyrproject-rtos/zephyr/pull/30150 , 
because the handler functions need to integrate into our zephyr project, not here.

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>