### PR TITLE
cmake: adding $<SEMICOLON> instead of space on zephyr_get_compile_<type>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,7 +754,7 @@ if(CONFIG_CODE_DATA_RELOCATION)
 endif()
 
 if(CONFIG_USERSPACE)
-  zephyr_get_compile_options_for_lang(C compiler_flags_priv)
+  zephyr_get_compile_options_for_lang_as_string(C compiler_flags_priv)
   string(REPLACE "$<TARGET_PROPERTY:compiler,coverage>" ""
          NO_COVERAGE_FLAGS "${compiler_flags_priv}"
   )

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -202,7 +202,7 @@ function(zephyr_get_include_directories_for_lang lang i)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
 
   if(NOT ARGN)
-    set(result_output_list "-I$<JOIN:${genexp_output_list}, -I>")
+    set(result_output_list "-I$<JOIN:${genexp_output_list},$<SEMICOLON>-I>")
   elseif(args_STRIP_PREFIX)
     # The list has no prefix, so don't add it.
     set(result_output_list ${output_list})
@@ -217,7 +217,7 @@ function(zephyr_get_system_include_directories_for_lang lang i)
 
   process_flags(${lang} flags output_list)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-  set(result_output_list "$<$<BOOL:${genexp_output_list}>:-isystem$<JOIN:${genexp_output_list}, -isystem>>")
+  set(result_output_list "$<$<BOOL:${genexp_output_list}>:-isystem$<JOIN:${genexp_output_list},$<SEMICOLON>-isystem>>")
 
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
@@ -227,7 +227,7 @@ function(zephyr_get_compile_definitions_for_lang lang i)
 
   process_flags(${lang} flags output_list)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-  set(result_output_list "-D$<JOIN:${genexp_output_list}, -D>")
+  set(result_output_list "-D$<JOIN:${genexp_output_list},$<SEMICOLON>-D>")
 
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
@@ -237,7 +237,7 @@ function(zephyr_get_compile_options_for_lang lang i)
 
   process_flags(${lang} flags output_list)
   string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-  set(result_output_list " $<JOIN:${genexp_output_list}, >")
+  set(result_output_list "$<JOIN:${genexp_output_list},$<SEMICOLON>>")
 
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -26,7 +26,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     set(linker_script_dep "")
   endif()
 
-  zephyr_get_include_directories_for_lang(C current_includes "$<SEMICOLON>")
+  zephyr_get_include_directories_for_lang(C current_includes)
   get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -26,7 +26,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     set(linker_script_dep "")
   endif()
 
-  zephyr_get_include_directories_for_lang(C current_includes "$<SEMICOLON>")
+  zephyr_get_include_directories_for_lang(C current_includes)
   get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 


### PR DESCRIPTION
The current `zephyr_get_compile_<type>` flags returns compile / include
flags based on generator expressions.

But they also included a space.

This have the unintended side-effect that when the properties are
fetched into another variable and later appended to lists in order to
finally be used in a CMake target function / custom command, then CMake
in some cases will quote the string, creating a quoted argument like:
"arg0 arg1 arg2": instead of individual arguments like: "arg0" "arg1"
"arg2".

By using `$<SEMICOLON>`, then arguments are separated correctly.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>