### PR TITLE
aarch64: mmu: Avoid creating a new table when not needed

### DIFF
--- a/arch/arm/core/aarch64/mmu/arm_mmu.h
+++ b/arch/arm/core/aarch64/mmu/arm_mmu.h
@@ -109,3 +109,9 @@
 #else
 #define TCR_PS_BITS TCR_PS_BITS_4GB
 #endif
+
+/* Upper and lower attributes mask for page/block descriptor */
+#define DESC_ATTRS_UPPER_MASK	GENMASK(63, 51)
+#define DESC_ATTRS_LOWER_MASK	GENMASK(11, 2)
+
+#define DESC_ATTRS_MASK		(DESC_ATTRS_UPPER_MASK | DESC_ATTRS_UPPER_MASK)


### PR DESCRIPTION
In the current MMU code a new table is created when mapping a memory region that is overlapping with a block already mapped. The problem is that the new table is created also when the new and old mappings have the same attributes.

To avoid using a new table when not needed the attributes of the two mappings are compared before creating the new table.

You can reproduce the problem of table exhaustion for example trying to map several times the same region where with the current code several tables are created until saturation. This patch can possibly fix the issue of using an high number of tables in some tests (see for example #29551).