### PR TITLE
drivers: wifi: esp: control CWMODE depending on current needs

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -247,9 +247,8 @@ static void esp_ip_addr_work(struct k_work *work)
 		MODEM_CMD("+"_CIPSTA":", on_cmd_cipsta, 2U, ":"),
 	};
 
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     cmds, ARRAY_SIZE(cmds), "AT+"_CIPSTA"?",
-			     &dev->sem_response, ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(dev, cmds, ARRAY_SIZE(cmds), "AT+"_CIPSTA"?",
+			   ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		LOG_WRN("Failed to query IP settings: ret %d", ret);
 		k_delayed_work_submit_to_queue(&dev->workq, &dev->ip_addr_work,
@@ -548,9 +547,8 @@ static void esp_mgmt_scan_work(struct k_work *work)
 
 	dev = CONTAINER_OF(work, struct esp_data, scan_work);
 
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     cmds, ARRAY_SIZE(cmds), "AT+CWLAP",
-			     &dev->sem_response, ESP_SCAN_TIMEOUT);
+	ret = esp_cmd_send(dev, cmds, ARRAY_SIZE(cmds), "AT+CWLAP",
+			   ESP_SCAN_TIMEOUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to scan: ret %d", ret);
 	}
@@ -599,9 +597,8 @@ static void esp_mgmt_connect_work(struct k_work *work)
 
 	dev = CONTAINER_OF(work, struct esp_data, connect_work);
 
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     cmds, ARRAY_SIZE(cmds), dev->conn_cmd,
-			     &dev->sem_response, ESP_CONNECT_TIMEOUT);
+	ret = esp_cmd_send(dev, cmds, ARRAY_SIZE(cmds), dev->conn_cmd,
+			   ESP_CONNECT_TIMEOUT);
 
 	memset(dev->conn_cmd, 0, sizeof(dev->conn_cmd));
 
@@ -664,9 +661,7 @@ static int esp_mgmt_disconnect(const struct device *dev)
 	struct esp_data *data = dev->data;
 	int ret;
 
-	ret = modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
-			     NULL, 0, "AT+CWQAP", &data->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(data, NULL, 0, "AT+CWQAP", ESP_CMD_TIMEOUT);
 
 	return ret;
 }
@@ -679,9 +674,7 @@ static int esp_mgmt_ap_enable(const struct device *dev,
 	struct esp_data *data = dev->data;
 	int ecn = 0, len, ret;
 
-	ret = modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
-			     NULL, 0, "AT+"_CWMODE"=3", &data->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(data, NULL, 0, "AT+"_CWMODE"=3", ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to enable AP mode, ret %d", ret);
 		return ret;
@@ -703,9 +696,7 @@ static int esp_mgmt_ap_enable(const struct device *dev,
 	snprintk(&cmd[len], sizeof(cmd) - len, "\",%d,%d", params->channel,
 		 ecn);
 
-	ret = modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
-			     NULL, 0, cmd, &data->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(data, NULL, 0, cmd, ESP_CMD_TIMEOUT);
 
 	return ret;
 }
@@ -715,9 +706,7 @@ static int esp_mgmt_ap_disable(const struct device *dev)
 	struct esp_data *data = dev->data;
 	int ret;
 
-	ret = modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
-			     NULL, 0, "AT+"_CWMODE"=1", &data->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(data, NULL, 0, "AT+"_CWMODE"=1", ESP_CMD_TIMEOUT);
 
 	return ret;
 }
@@ -730,9 +719,7 @@ static void esp_configure_hostname(struct esp_data *data)
 	snprintk(cmd, sizeof(cmd), "AT+CWHOSTNAME=\"%s\"", net_hostname_get());
 	cmd[sizeof(cmd) - 1] = '\0';
 
-	modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
-		       NULL, 0, cmd, &data->sem_response,
-		       ESP_CMD_TIMEOUT);
+	esp_cmd_send(data, NULL, 0, cmd, ESP_CMD_TIMEOUT);
 #else
 	ARG_UNUSED(data);
 #endif

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -265,6 +265,16 @@ static inline bool esp_flag_is_set(struct esp_data *dev,
 	return (dev->flags & flag) != 0;
 }
 
+static inline int esp_cmd_send(struct esp_data *data,
+			       const struct modem_cmd *handlers,
+			       size_t handlers_len, const char *buf,
+			       k_timeout_t timeout)
+{
+	return modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
+			      handlers, handlers_len, buf, &data->sem_response,
+			      timeout);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -176,7 +176,9 @@ struct esp_socket {
 
 enum esp_data_flag {
 	EDF_STA_CONNECTING = BIT(1),
-	EDF_STA_CONNECTED  = BIT(2)
+	EDF_STA_CONNECTED  = BIT(2),
+	EDF_STA_LOCK       = BIT(3),
+	EDF_AP_ENABLED     = BIT(4),
 };
 
 /* driver data */
@@ -184,6 +186,7 @@ struct esp_data {
 	struct net_if *net_iface;
 
 	uint8_t flags;
+	uint8_t mode;
 
 	char conn_cmd[CONN_CMD_MAX_LEN];
 
@@ -214,6 +217,7 @@ struct esp_data {
 	struct k_delayed_work ip_addr_work;
 	struct k_work scan_work;
 	struct k_work connect_work;
+	struct k_work mode_switch_work;
 
 	scan_result_cb_t scan_cb;
 

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -95,6 +95,14 @@ extern "C" {
 #define ESP_CONNECT_TIMEOUT	K_SECONDS(20)
 #define ESP_INIT_TIMEOUT	K_SECONDS(10)
 
+#define ESP_MODE_NONE		0
+#define ESP_MODE_STA		1
+#define ESP_MODE_AP		2
+#define ESP_MODE_STA_AP		3
+
+#define ESP_CMD_CWMODE(mode) \
+	"AT+"_CWMODE"="STRINGIFY(_CONCAT(ESP_MODE_, mode))
+
 #define ESP_CWDHCP_MODE_STATION		"1"
 #if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
 #define ESP_CWDHCP_MODE_SOFTAP		"0"

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -247,22 +247,19 @@ static inline bool esp_socket_close_pending(struct esp_socket *sock)
 	return (sock->flags & ESP_SOCK_CLOSE_PENDING) != 0;
 }
 
-static inline void esp_flag_set(struct esp_data *dev,
-				enum esp_data_flag flag)
+static inline void esp_flags_set(struct esp_data *dev, uint8_t flags)
 {
-	dev->flags |= flag;
+	dev->flags |= flags;
 }
 
-static inline void esp_flag_clear(struct esp_data *dev,
-				  enum esp_data_flag flag)
+static inline void esp_flags_clear(struct esp_data *dev, uint8_t flags)
 {
-	dev->flags &= (~flag);
+	dev->flags &= (~flags);
 }
 
-static inline bool esp_flag_is_set(struct esp_data *dev,
-				   enum esp_data_flag flag)
+static inline bool esp_flags_are_set(struct esp_data *dev, uint8_t flags)
 {
-	return (dev->flags & flag) != 0;
+	return (dev->flags & flags) != 0;
 }
 
 static inline int esp_cmd_send(struct esp_data *data,

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -52,7 +52,7 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 	char connect_msg[100];
 	int ret;
 
-	if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)) {
+	if (!esp_flags_are_set(dev, EDF_STA_CONNECTED)) {
 		return -ENETUNREACH;
 	}
 
@@ -210,7 +210,7 @@ static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 		MODEM_CMD("SEND FAIL", on_cmd_send_fail, 0U, ""),
 	};
 
-	if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)) {
+	if (!esp_flags_are_set(dev, EDF_STA_CONNECTED)) {
 		return -ENETUNREACH;
 	}
 
@@ -337,7 +337,7 @@ static int esp_sendto(struct net_pkt *pkt,
 
 	LOG_DBG("link %d, timeout %d", sock->link_id, timeout);
 
-	if (!esp_flag_is_set(dev, EDF_STA_CONNECTED)) {
+	if (!esp_flags_are_set(dev, EDF_STA_CONNECTED)) {
 		return -ENETUNREACH;
 	}
 

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -78,9 +78,7 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 		sock->ip_proto == IPPROTO_TCP ? "TCP" : "UDP",
 		log_strdup(addr_str));
 
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     NULL, 0, connect_msg, &dev->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(dev, NULL, 0, connect_msg, ESP_CMD_TIMEOUT);
 	if (ret == 0) {
 		sock->flags |= ESP_SOCK_CONNECTED;
 	} else if (ret == -ETIMEDOUT) {
@@ -533,9 +531,7 @@ static void esp_recvdata_work(struct k_work *work)
 
 	snprintk(cmd, sizeof(cmd), "AT+CIPRECVDATA=%d,%d", sock->link_id, len);
 
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     cmds, ARRAY_SIZE(cmds), cmd, &dev->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(dev, cmds, ARRAY_SIZE(cmds), cmd, ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		LOG_ERR("Error during rx: link %d, ret %d", sock->link_id,
 			ret);

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -80,9 +80,7 @@ void esp_socket_close(struct esp_socket *sock)
 
 	snprintk(cmd_buf, sizeof(cmd_buf), "AT+CIPCLOSE=%d",
 		 sock->link_id);
-	ret = modem_cmd_send(&dev->mctx.iface, &dev->mctx.cmd_handler,
-			     NULL, 0, cmd_buf, &dev->sem_response,
-			     ESP_CMD_TIMEOUT);
+	ret = esp_cmd_send(dev, NULL, 0, cmd_buf, ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		/* FIXME:
 		 * If link doesn't close correctly here, esp_get could


### PR DESCRIPTION
So far ESP chip was configured directly into STA mode. This works fine,
but consumes lots of power because of enabled WiFi radio, even when it
is not actively used.

Enter NONE mode during initialization, so WiFi radio will be
disabled. Switch between NONE, STA, AP and STA+AP modes depending on
what driver is currently doing (e.g. enable STA only when scanning,
connecting and being connected to AP).

AT+CWAUTOCONN=0 command fails when in NONE mode, so workaround that by
entering temporarily into STA and then switching back to NONE.

Add also a warning log when switching mode was not successful, to ease
debugging possible issues.

Do also some cleanups and improvements in order to achieve above.