### PR TITLE
STM32 generic LL headers for further peripherals

### DIFF
--- a/boards/arm/stm32g0316_disco/pinmux.c
+++ b/boards/arm/stm32g0316_disco/pinmux.c
@@ -6,6 +6,8 @@
 
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_system.h>
 
 #include <pinmux/stm32/pinmux_stm32.h>
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -16,6 +16,7 @@
 #include <kernel.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_adc.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -7,6 +7,11 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <sys/__assert.h>
@@ -43,7 +48,7 @@
  * So, changing this prescaler is not allowed until it is made possible to
  * use them independently in zephyr clock subsystem.
  */
-#error "AHB presacler can't be higher than 1"
+#error "AHB prescaler can't be higher than 1"
 #endif
 
 /**

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -7,6 +7,10 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -5,6 +5,8 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -7,6 +7,9 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -7,6 +7,9 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -7,6 +7,9 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -8,6 +8,9 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -6,6 +6,10 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -7,6 +7,9 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/clock_control/clock_stm32l4_l5_wb.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb.c
@@ -7,6 +7,10 @@
 
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/clock_control.h>
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -18,6 +18,10 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
+#include <stm32_ll_exti.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_rtc.h>
 #include <drivers/counter.h>
 
 #include <logging/log.h>

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -13,6 +13,7 @@
 #include <kernel.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_dac.h>
 
 #define LOG_LEVEL CONFIG_DAC_LOG_LEVEL
 #include <logging/log.h>

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -8,6 +8,7 @@
 #define DMA_STM32_H_
 
 #include <soc.h>
+#include <stm32_ll_dma.h>
 #include <drivers/dma.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -12,6 +12,7 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_dmamux.h>
 #include <init.h>
 #include <drivers/dma.h>
 #include <drivers/clock_control.h>

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -18,6 +18,10 @@
 #include <sys/util.h>
 #include <errno.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_rng.h>
+#include <stm32_ll_system.h>
 #include <sys/printk.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -15,6 +15,8 @@
 #include <drivers/flash.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
 #include <logging/log.h>
 
 #include "flash_stm32.h"

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -11,6 +11,11 @@
 #include <kernel.h>
 #include <device.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_exti.h>
+#include <stm32_ll_gpio.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 #include <drivers/gpio.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <pinmux/stm32/pinmux_stm32.h>

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -5,6 +5,7 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_utils.h>
 #include <drivers/hwinfo.h>
 #include <string.h>
 #include <sys/byteorder.h>

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -10,6 +10,8 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_rcc.h>
 #include <errno.h>
 #include <drivers/i2c.h>
 #include <drivers/pinmux.h>

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -13,6 +13,7 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
+#include <stm32_ll_i2c.h>
 #include <errno.h>
 #include <drivers/i2c.h>
 #include "i2c_ll_stm32.h"

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -13,6 +13,7 @@
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
+#include <stm32_ll_i2c.h>
 #include <errno.h>
 #include <drivers/i2c.h>
 #include "i2c_ll_stm32.h"

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -11,6 +11,8 @@
 #include <drivers/i2s.h>
 #include <dt-bindings/dma/stm32_dma.h>
 #include <soc.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_spi.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/clock_control.h>
 #include <pinmux/stm32/pinmux_stm32.h>

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -19,6 +19,7 @@
  */
 #include <device.h>
 #include <soc.h>
+#include <stm32_ll_exti.h>
 #include <sys/__assert.h>
 #include <drivers/interrupt_controller/exti_stm32.h>
 

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <drivers/ipm.h>
 #include <soc.h>
+#include <stm32_ll_ipcc.h>
 
 #include <drivers/clock_control/stm32_clock_control.h>
 

--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -16,6 +16,8 @@
 #include <kernel.h>
 #include <device.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_gpio.h>
 #include <drivers/pinmux.h>
 #include <gpio/gpio_stm32.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -10,6 +10,8 @@
 #include <errno.h>
 
 #include <soc.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_tim.h>
 #include <drivers/pwm.h>
 #include <device.h>
 #include <kernel.h>

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #include <sys/util.h>
 #include <kernel.h>
 #include <soc.h>
+#include <stm32_ll_spi.h>
 #include <errno.h>
 #include <drivers/spi.h>
 #include <toolchain.h>

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -6,6 +6,8 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_lptim.h>
+#include <stm32_ll_system.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/timer/system_timer.h>

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -45,6 +45,10 @@
  */
 
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <string.h>
 #include <usb/usb_device.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -10,6 +10,9 @@
 
 #include <drivers/watchdog.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_iwdg.h>
+#include <stm32_ll_system.h>
 #include <errno.h>
 
 #include "wdt_iwdg_stm32.h"

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -8,6 +8,9 @@
 
 #include <drivers/watchdog.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_wwdg.h>
+#include <stm32_ll_system.h>
 #include <errno.h>
 #include <sys/__assert.h>
 #include <drivers/clock_control/stm32_clock_control.h>

--- a/soc/arm/st_stm32/common/stm32_hsem.h
+++ b/soc/arm/st_stm32/common/stm32_hsem.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_HSEM_STM32_HSEM_H_
 
 #include <soc.h>
+#include <stm32_ll_hsem.h>
 #include <kernel.h>
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -11,6 +11,7 @@
 
 #include <device.h>
 #include <init.h>
+#include <stm32_ll_system.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <linker/linker-defs.h>

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -61,10 +61,6 @@
 #include <stm32f0xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_DAC_STM32
-#include <stm32f0xx_ll_dac.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32f0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f0xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_I2C_STM32
 #include <stm32f0xx_ll_i2c.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -35,10 +35,6 @@
 #include <stm32f0xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32f0xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -57,10 +57,6 @@
 #include <stm32f0xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f0xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32f0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32f0xx_ll_i2c.h>
-#endif
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32f0xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -57,10 +57,6 @@
 #include <stm32f0xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f0xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f0xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -61,10 +61,6 @@
 #include <stm32f0xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f0xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DAC_STM32
 #include <stm32f0xx_ll_dac.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -45,10 +45,6 @@
 #include <stm32f0xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f0xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_I2C_STM32
 #include <stm32f0xx_ll_i2c.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32f0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f0xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -24,10 +24,6 @@
 
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f0xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -28,13 +28,6 @@
 #include <stm32f0xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f0xx_ll_utils.h>
-#include <stm32f0xx_ll_bus.h>
-#include <stm32f0xx_ll_rcc.h>
-#include <stm32f0xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -35,12 +35,6 @@
 #include <stm32f0xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32f0xx_ll_rtc.h>
-#include <stm32f0xx_ll_exti.h>
-#include <stm32f0xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -22,6 +22,7 @@
 
 #include <stm32f0xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32f0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32f0xx_ll_spi.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32f0xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -22,6 +22,7 @@
 
 #include <stm32f1xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -28,13 +28,6 @@
 #include <stm32f1xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f1xx_ll_utils.h>
-#include <stm32f1xx_ll_bus.h>
-#include <stm32f1xx_ll_rcc.h>
-#include <stm32f1xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -51,10 +51,6 @@
 #include <stm32f1xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f1xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f1xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -35,10 +35,6 @@
 #include <stm32f1xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32f1xx_ll_spi.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32f1xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -43,10 +43,6 @@
 #include <stm32f1xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f1xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32f1xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -35,9 +35,6 @@
 #include <stm32f1xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f1xx_ll_gpio.h>
-#endif
 
 #ifdef CONFIG_DMA_STM32
 #include <stm32f1xx_ll_dma.h>

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -35,10 +35,6 @@
 #include <stm32f1xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32f1xx_ll_i2c.h>
-#endif
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32f1xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -55,10 +55,6 @@
 #include <stm32f1xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f1xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f1xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -24,10 +24,6 @@
 
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f1xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -35,11 +35,6 @@
 #include <stm32f1xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-
-#ifdef CONFIG_DMA_STM32
-#include <stm32f1xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -47,10 +47,6 @@
 #include <stm32f1xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f1xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32f1xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -51,10 +51,6 @@
 #include <stm32f1xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f1xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f2xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f2xx_ll_iwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f2xx_ll_rtc.h>
 #include <stm32f2xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -52,10 +52,6 @@
 #include <stm32f2xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_DAC_STM32
-#include <stm32f2xx_ll_dac.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f2xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -23,10 +23,6 @@
 
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f2xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F2_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -21,6 +21,7 @@
 
 #include <stm32f2xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -48,10 +48,6 @@
 #include <stm32f2xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f2xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f2xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -34,10 +34,6 @@
 #include <stm32f2xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f2xx_ll_gpio.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f2xx_ll_rtc.h>
 #include <stm32f2xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -42,10 +42,6 @@
 #include <stm32f2xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f2xx_ll_wwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f2xx_ll_rtc.h>
 #include <stm32f2xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -48,10 +48,6 @@
 #include <stm32f2xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f2xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F2_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -34,10 +34,6 @@
 #include <stm32f2xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32f2xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F2_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -52,10 +52,6 @@
 #include <stm32f2xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f2xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DAC_STM32
 #include <stm32f2xx_ll_dac.h>
 #endif

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -27,13 +27,6 @@
 #include <stm32f2xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f2xx_ll_utils.h>
-#include <stm32f2xx_ll_bus.h>
-#include <stm32f2xx_ll_rcc.h>
-#include <stm32f2xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F2_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -34,12 +34,6 @@
 #include <stm32f2xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32f2xx_ll_rtc.h>
-#include <stm32f2xx_ll_exti.h>
-#include <stm32f2xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f2xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -23,6 +23,7 @@
 
 #include <stm32f3xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -36,10 +36,6 @@
 #include <stm32f3xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32f3xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F3_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -62,10 +62,6 @@
 #include <stm32f3xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f3xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f3xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -44,10 +44,6 @@
 #include <stm32f3xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f3xx_ll_iwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f3xx_ll_rtc.h>
 #include <stm32f3xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -58,10 +58,6 @@
 #include <stm32f3xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f3xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f3xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -25,10 +25,6 @@
 
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f3xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F3_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -42,10 +42,6 @@
 #include <stm32f3xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f3xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f3xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -36,10 +36,6 @@
 #include <stm32f3xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32f3xx_ll_spi.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f3xx_ll_rtc.h>
 #include <stm32f3xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -36,10 +36,6 @@
 #include <stm32f3xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32f3xx_ll_i2c.h>
-#endif
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32f3xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -36,12 +36,6 @@
 #include <stm32f3xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32f3xx_ll_rtc.h>
-#include <stm32f3xx_ll_exti.h>
-#include <stm32f3xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f3xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -29,13 +29,6 @@
 #include <stm32f3xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f3xx_ll_utils.h>
-#include <stm32f3xx_ll_bus.h>
-#include <stm32f3xx_ll_rcc.h>
-#include <stm32f3xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F3_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -48,10 +48,6 @@
 #include <stm32f3xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f3xx_ll_wwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f3xx_ll_rtc.h>
 #include <stm32f3xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -58,10 +58,6 @@
 #include <stm32f3xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f3xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F3_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -60,10 +60,6 @@
 #include <stm32f4xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f4xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -60,10 +60,6 @@
 #include <stm32f4xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f4xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f4xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f4xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32f4xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -68,10 +68,6 @@
 #include <stm32f4xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f4xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f4xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f4xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
-#include <stm32f4xx_ll_spi.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f4xx_ll_rtc.h>
 #include <stm32f4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -38,12 +38,6 @@
 #include <stm32f4xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32f4xx_ll_rtc.h>
-#include <stm32f4xx_ll_exti.h>
-#include <stm32f4xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f4xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -27,10 +27,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f4xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -46,10 +46,6 @@
 #include <stm32f4xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32f4xx_ll_rng.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f4xx_ll_rtc.h>
 #include <stm32f4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -44,10 +44,6 @@
 #include <stm32f4xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f4xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f4xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -31,13 +31,6 @@
 #include <stm32f4xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f4xx_ll_utils.h>
-#include <stm32f4xx_ll_bus.h>
-#include <stm32f4xx_ll_rcc.h>
-#include <stm32f4xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -54,10 +54,6 @@
 #include <stm32f4xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f4xx_ll_wwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f4xx_ll_rtc.h>
 #include <stm32f4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -50,10 +50,6 @@
 #include <stm32f4xx_ll_rng.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f4xx_ll_iwdg.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f4xx_ll_rtc.h>
 #include <stm32f4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -18,13 +18,11 @@
 #ifndef _STM32F4_SOC_H_
 #define _STM32F4_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f4xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f4xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32f4xx_ll_i2c.h>
-#endif
-
 #if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f4xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -17,13 +17,11 @@
 #ifndef _STM32F7_SOC_H_
 #define _STM32F7_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f7xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -64,10 +64,6 @@
 #include <stm32f7xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32f7xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f7xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -60,10 +60,6 @@
 #include <stm32f7xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32f7xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -30,14 +30,6 @@
 #include <stm32f7xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32f7xx_ll_utils.h>
-#include <stm32f7xx_ll_bus.h>
-#include <stm32f7xx_ll_rcc.h>
-#include <stm32f7xx_ll_system.h>
-#include <stm32f7xx_ll_pwr.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32f7xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H_ */

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
-#include <stm32f7xx_ll_spi.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f7xx_ll_rtc.h>
 #include <stm32f7xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -60,10 +60,6 @@
 #include <stm32f7xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32f7xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f7xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -38,12 +38,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32f7xx_ll_rtc.h>
-#include <stm32f7xx_ll_exti.h>
-#include <stm32f7xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f7xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -60,10 +60,6 @@
 #include <stm32f7xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32f7xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32f7xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -38,10 +38,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32f7xx_ll_i2c.h>
-#endif
-
 #if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f7xx_ll_spi.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -44,10 +44,6 @@
 #include <stm32f7xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32f7xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f7xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -46,10 +46,6 @@
 #include <stm32f7xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32f7xx_ll_rng.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32f7xx_ll_rtc.h>
 #include <stm32f7xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -68,10 +68,6 @@
 #include <stm32f7xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32f7xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32f7xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -26,10 +26,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32f7xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H_ */

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -18,19 +18,12 @@
 #ifndef _STM32G0_SOC_H_
 #define _STM32G0_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32g0xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
-
-#include <stm32g0xx_ll_system.h>
-
-/* Add include for DTS generated information */
-#include <devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -47,10 +47,6 @@
 #include <stm32g0xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32g0xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32g0xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -43,10 +43,6 @@
 #include <stm32g0xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_I2C
-#include <stm32g0xx_ll_i2c.h>
-#endif
-
 /* Add include for DTS generated information */
 #include <devicetree.h>
 

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -51,10 +51,6 @@
 #include <stm32g0xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32g0xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_HWINFO_STM32
 #include <stm32g0xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -47,10 +47,6 @@
 #include <stm32g0xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32g0xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 /* Add include for DTS generated information */
 #include <devicetree.h>
 

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -29,12 +29,6 @@
 
 #include <stm32g0xx_ll_system.h>
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32g0xx_ll_utils.h>
-#include <stm32g0xx_ll_bus.h>
-#include <stm32g0xx_ll_rcc.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32g0xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -39,10 +39,6 @@
 #include <stm32g0xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32g0xx_ll_gpio.h>
-#endif
-
 /* Add include for DTS generated information */
 #include <devicetree.h>
 

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -47,10 +47,6 @@
 #include <stm32g0xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32g0xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_HWINFO_STM32
 #include <stm32g0xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32g0/soc.h
+++ b/soc/arm/st_stm32/stm32g0/soc.h
@@ -29,10 +29,6 @@
 
 #include <stm32g0xx_ll_system.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32g0xx_ll_exti.h>
-#endif
-
 /* Add include for DTS generated information */
 #include <devicetree.h>
 

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -11,6 +11,7 @@
 
 #include <device.h>
 #include <init.h>
+#include <stm32_ll_system.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -27,14 +27,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32g4xx_ll_utils.h>
-#include <stm32g4xx_ll_bus.h>
-#include <stm32g4xx_ll_rcc.h>
-#include <stm32g4xx_ll_system.h>
-#include <stm32g4xx_ll_pwr.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32g4xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -51,10 +51,6 @@
 #include <stm32g4xx_ll_i2c.h>
 #endif /* CONFIG_I2C */
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32g4xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DAC_STM32
 #include <stm32g4xx_ll_dac.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -47,10 +47,6 @@
 #include <stm32g4xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_I2C
-#include <stm32g4xx_ll_i2c.h>
-#endif /* CONFIG_I2C */
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32g4xx_ll_rtc.h>
 #include <stm32g4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -27,10 +27,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32g4xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32G4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -39,12 +39,6 @@
 #include <stm32g4xx_ll_exti.h>
 #endif
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32g4xx_ll_rtc.h>
-#include <stm32g4xx_ll_exti.h>
-#include <stm32g4xx_ll_pwr.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32G4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -51,10 +51,6 @@
 #include <stm32g4xx_ll_i2c.h>
 #endif /* CONFIG_I2C */
 
-#ifdef CONFIG_DAC_STM32
-#include <stm32g4xx_ll_dac.h>
-#endif
-
 #ifdef CONFIG_IWDG_STM32
 #include <stm32g4xx_ll_iwdg.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -55,10 +55,6 @@
 #include <stm32g4xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32g4xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_ENTROPY_STM32_RNG
 #include <stm32g4xx_ll_rng.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -57,10 +57,6 @@
 #include <stm32g4xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32g4xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32G4_SOC_H_ */

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -43,10 +43,6 @@
 #include <stm32g4xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32g4xx_ll_spi.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32g4xx_ll_rtc.h>
 #include <stm32g4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -39,10 +39,6 @@
 #include <stm32g4xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32g4xx_ll_gpio.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32g4xx_ll_rtc.h>
 #include <stm32g4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -51,10 +51,6 @@
 #include <stm32g4xx_ll_i2c.h>
 #endif /* CONFIG_I2C */
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32g4xx_ll_rng.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32g4xx_ll_rtc.h>
 #include <stm32g4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -51,10 +51,6 @@
 #include <stm32g4xx_ll_i2c.h>
 #endif /* CONFIG_I2C */
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32g4xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_ENTROPY_STM32_RNG
 #include <stm32g4xx_ll_rng.h>
 #endif

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -57,10 +57,6 @@
 #include <stm32g4xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_HWINFO_STM32
-#include <stm32g4xx_ll_utils.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32g4xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32g4/soc.h
+++ b/soc/arm/st_stm32/stm32g4/soc.h
@@ -17,14 +17,11 @@
 #ifndef _STM32G4_SOC_H_
 #define _STM32G4_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <stm32g4xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -40,11 +40,6 @@
 #include <stm32h7xx_ll_exti.h>
 #endif /* CONFIG_EXTI_STM32 */
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32h7xx_ll_gpio.h>
-#include <stm32h7xx_ll_system.h>
-#endif /* CONFIG_GPIO_STM32 */
-
 #if defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
 #include <stm32h7xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -29,20 +29,9 @@
 
 #endif /* CONFIG_STM32H7_DUAL_CORE */
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_rcc.h>
-#include <stm32h7xx_ll_pwr.h>
-#include <stm32h7xx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32h7xx_ll_exti.h>
 #endif /* CONFIG_EXTI_STM32 */
-
-#if defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
-#include <stm32h7xx_ll_utils.h>
-#endif
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -68,10 +68,6 @@
 #include <stm32h7xx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32h7xx_ll_adc.h>
-#endif /* CONFIG_ADC_STM32 */
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32h7xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -29,10 +29,6 @@
 
 #endif /* CONFIG_STM32H7_DUAL_CORE */
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32h7xx_ll_exti.h>
-#endif /* CONFIG_EXTI_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -55,10 +55,6 @@
 #include <stm32h7xx_ll_pwr.h>
 #endif /* CONFIG_COUNTER_RTC_STM32 */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32h7xx_ll_i2c.h>
-#endif /* CONFIG_I2C_STM32 */
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32h7xx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -44,12 +44,6 @@
 #include <stm32h7xx_ll_utils.h>
 #endif
 
-#ifdef CONFIG_COUNTER_RTC_STM32
-#include <stm32h7xx_ll_rtc.h>
-#include <stm32h7xx_ll_exti.h>
-#include <stm32h7xx_ll_pwr.h>
-#endif /* CONFIG_COUNTER_RTC_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -63,10 +63,6 @@
 #include <stm32h7xx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32h7xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -45,7 +45,7 @@
 #include <stm32h7xx_ll_system.h>
 #endif /* CONFIG_GPIO_STM32 */
 
-#if defined(CONFIG_HWINFO_STM32) || defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
+#if defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
 #include <stm32h7xx_ll_utils.h>
 #endif
 

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -18,7 +18,6 @@
 #include <st_stm32_dt.h>
 
 #ifdef CONFIG_STM32H7_DUAL_CORE
-#include <stm32h7xx_ll_hsem.h>
 
 #ifdef CONFIG_CPU_CORTEX_M4
 

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -7,27 +7,12 @@
 #ifndef _STM32F7_SOC_H_
 #define _STM32F7_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <stm32h7xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
-
-#ifdef CONFIG_STM32H7_DUAL_CORE
-
-#ifdef CONFIG_CPU_CORTEX_M4
-
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_pwr.h>
-#include <stm32h7xx_ll_cortex.h>
-
-#endif /* CONFIG_CPU_CORTEX_M4 */
-
-#endif /* CONFIG_STM32H7_DUAL_CORE */
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -55,10 +55,6 @@
 #include <stm32h7xx_ll_pwr.h>
 #endif /* CONFIG_COUNTER_RTC_STM32 */
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32h7xx_ll_spi.h>
-#endif /* CONFIG_SPI_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -67,10 +67,6 @@
 #include <stm32h7xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32h7xx_ll_rng.h>
-#endif /* CONFIG_ENTROPY_STM32_RNG */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H7_ */

--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -46,10 +46,6 @@
 #include <stm32h7xx_ll_system.h>
 #endif /* CONFIG_GPIO_STM32 */
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32h7xx_ll_wwdg.h>
-#endif
-
 #if defined(CONFIG_HWINFO_STM32) || defined(CONFIG_CLOCK_CONTROL_STM32_CUBE)
 #include <stm32h7xx_ll_utils.h>
 #endif

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -13,6 +13,11 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include "stm32_hsem.h"

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -13,6 +13,10 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include "stm32_hsem.h"

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32l0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32l0xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -57,10 +57,6 @@
 #include <stm32l0xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32l0xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -21,9 +21,8 @@
 
 #include <stm32l0xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
-
-#include <stm32l0xx_ll_system.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -35,10 +35,6 @@
 #include <stm32l0xx_ll_rcc.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32l0xx_ll_dma.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -35,12 +35,6 @@
 #include <stm32l0xx_ll_rcc.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32l0xx_ll_rtc.h>
-#include <stm32l0xx_ll_exti.h>
-#include <stm32l0xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -25,10 +25,6 @@
 
 #include <stm32l0xx_ll_system.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32l0xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -57,9 +57,6 @@
 #include <stm32l0xx_ll_dma.h>
 #endif
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32l0xx_ll_rng.h>
-#endif
 #ifdef CONFIG_PWM_STM32
 #include <stm32l0xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -35,10 +35,6 @@
 #include <stm32l0xx_ll_rcc.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32l0xx_ll_i2c.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l0xx_ll_rtc.h>
 #include <stm32l0xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -41,10 +41,6 @@
 #include <stm32l0xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32l0xx_ll_spi.h>
-#endif
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32l0xx_ll_gpio.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -61,10 +61,6 @@
 #include <stm32l0xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32l0xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DAC_STM32
 #include <stm32l0xx_ll_dac.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -57,10 +57,6 @@
 #include <stm32l0xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32l0xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -29,12 +29,6 @@
 #include <stm32l0xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32l0xx_ll_utils.h>
-#include <stm32l0xx_ll_bus.h>
-#include <stm32l0xx_ll_rcc.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -61,10 +61,6 @@
 #include <stm32l0xx_ll_wwdg.h>
 #endif
 
-#ifdef CONFIG_DAC_STM32
-#include <stm32l0xx_ll_dac.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -53,10 +53,6 @@
 #include <stm32l0xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32l0xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l0xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -25,10 +25,6 @@
 
 #include <stm32l1xx_ll_system.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32l1xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -53,10 +53,6 @@
 #include <stm32l1xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32l1xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32l1xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -45,10 +45,6 @@
 #include <stm32l1xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32l1xx_ll_spi.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -21,9 +21,8 @@
 
 #include <stm32l1xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
-
-#include <stm32l1xx_ll_system.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -43,10 +43,6 @@
 #include <stm32l1xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_DAC_STM32
-#include <stm32l1xx_ll_dac.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l1xx_ll_rtc.h>
 #include <stm32l1xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -39,10 +39,6 @@
 #include <stm32l1xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32l1xx_ll_i2c.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l1xx_ll_rtc.h>
 #include <stm32l1xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -31,10 +31,6 @@
 #include <stm32l1xx_ll_rcc.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32l1xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32l1xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -25,12 +25,6 @@
 
 #include <stm32l1xx_ll_system.h>
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32l1xx_ll_utils.h>
-#include <stm32l1xx_ll_bus.h>
-#include <stm32l1xx_ll_rcc.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32l1xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -43,10 +43,6 @@
 #include <stm32l1xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32l1xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DAC_STM32
 #include <stm32l1xx_ll_dac.h>
 #endif

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -53,10 +53,6 @@
 #include <stm32l1xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32l1xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -35,12 +35,6 @@
 #include <stm32l1xx_ll_exti.h>
 #endif
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32l1xx_ll_rtc.h>
-#include <stm32l1xx_ll_exti.h>
-#include <stm32l1xx_ll_pwr.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L1_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l1/soc.h
+++ b/soc/arm/st_stm32/stm32l1/soc.h
@@ -57,10 +57,6 @@
 #include <stm32l1xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32l1xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32l1xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -41,12 +41,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32l4xx_ll_rtc.h>
-#include <stm32l4xx_ll_exti.h>
-#include <stm32l4xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_USB
 /* Required to remove USB transceiver supply isolation */
 #include <stm32l4xx_ll_pwr.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -53,10 +53,6 @@
 #include <stm32l4xx_ll_iwdg.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32l4xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_ENTROPY_STM32_RNG
 #include <stm32l4xx_ll_rng.h>
 #endif

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -33,14 +33,6 @@
 #include <stm32l4xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32l4xx_ll_utils.h>
-#include <stm32l4xx_ll_bus.h>
-#include <stm32l4xx_ll_rcc.h>
-#include <stm32l4xx_ll_system.h>
-#include <stm32l4xx_ll_pwr.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L4X_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -45,10 +45,6 @@
 #include <stm32l4xx_ll_spi.h>
 #endif
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32l4xx_ll_i2c.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l4xx_ll_rtc.h>
 #include <stm32l4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -49,10 +49,6 @@
 #include <stm32l4xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32l4xx_ll_iwdg.h>
-#endif
-
 #ifdef CONFIG_ENTROPY_STM32_RNG
 #include <stm32l4xx_ll_rng.h>
 #endif

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -19,14 +19,11 @@
 #ifndef _STM32L4X_SOC_H_
 #define _STM32L4X_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <stm32l4xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -78,10 +78,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32l4xx_ll_adc.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l4xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -41,10 +41,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32l4xx_ll_spi.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l4xx_ll_rtc.h>
 #include <stm32l4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -29,10 +29,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32l4xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L4X_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -46,10 +46,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_USB */
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32l4xx_ll_dma.h>
-#endif
-
 #ifdef CONFIG_STM32_LPTIM_TIMER
 #include <stm32l4xx_ll_lptim.h>
 #include <stm32l4xx_ll_system.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -49,10 +49,6 @@
 #include <stm32l4xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_ENTROPY_STM32_RNG
-#include <stm32l4xx_ll_rng.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32l4xx_ll_rtc.h>
 #include <stm32l4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -75,10 +75,6 @@
 #include <stm32l4xx_ll_system.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32l4xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L4X_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -46,11 +46,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_USB */
 
-#ifdef CONFIG_STM32_LPTIM_TIMER
-#include <stm32l4xx_ll_lptim.h>
-#include <stm32l4xx_ll_system.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L4X_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -41,11 +41,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_USB
-/* Required to remove USB transceiver supply isolation */
-#include <stm32l4xx_ll_pwr.h>
-#endif /* CONFIG_USB */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L4X_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -52,12 +52,6 @@
 #include <stm32l4xx_ll_pwr.h>
 #endif /* CONFIG_USB */
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32l4xx_ll_gpio.h>
-/* Required to enable VDDio2 for port G */
-#include <stm32l4xx_ll_pwr.h>
-#endif
-
 #ifdef CONFIG_DMA_STM32
 #include <stm32l4xx_ll_dma.h>
 #endif

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -11,6 +11,8 @@
 
 #include <device.h>
 #include <init.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -39,10 +39,6 @@
 #include <stm32l5xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32l5xx_ll_gpio.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L5_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -27,10 +27,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32l5xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L5_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -27,14 +27,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32l5xx_ll_utils.h>
-#include <stm32l5xx_ll_bus.h>
-#include <stm32l5xx_ll_rcc.h>
-#include <stm32l5xx_ll_system.h>
-#include <stm32l5xx_ll_pwr.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32l5xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -43,10 +43,6 @@
 #include <stm32l5xx_ll_gpio.h>
 #endif
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32l5xx_ll_i2c.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L5_SOC_H_ */

--- a/soc/arm/st_stm32/stm32l5/soc.h
+++ b/soc/arm/st_stm32/stm32l5/soc.h
@@ -17,14 +17,11 @@
 #ifndef _STM32L5_SOC_H_
 #define _STM32L5_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <stm32l5xx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -13,6 +13,7 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_bus.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -50,10 +50,6 @@
 #include <stm32mp1xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32mp1xx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -46,10 +46,6 @@
 #include <stm32mp1xx_ll_ipcc.h>
 #endif
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32mp1xx_ll_i2c.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -27,10 +27,6 @@
 #include <stm32mp1xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32mp1xx_ll_gpio.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32mp1xx_ll_utils.h>
 #include <stm32mp1xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -23,10 +23,6 @@
 
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_EXTI_STM32
-#include <stm32mp1xx_ll_exti.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -52,10 +52,6 @@
 #include <stm32mp1xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32mp1xx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_PWM_STM32
 #include <stm32mp1xx_ll_tim.h>
 #endif /* CONFIG_PWM_STM32 */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -38,10 +38,6 @@
 #include <stm32mp1xx_ll_system.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32mp1xx_ll_spi.h>
-#endif
-
 #ifdef CONFIG_IPM_STM32_IPCC
 #include <stm32mp1xx_ll_ipcc.h>
 #endif

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -27,13 +27,6 @@
 #include <stm32mp1xx_ll_exti.h>
 #endif
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32mp1xx_ll_utils.h>
-#include <stm32mp1xx_ll_bus.h>
-#include <stm32mp1xx_ll_rcc.h>
-#include <stm32mp1xx_ll_system.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -13,14 +13,15 @@
  * Chapter 2.2.2: Memory map and register boundary addresses
  */
 
+
 #ifndef _STM32MP1SOC_H_
 #define _STM32MP1SOC_H_
 
 #ifndef _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <stm32mp1xx.h>
 
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -23,8 +23,6 @@
 
 #include <st_stm32_dt.h>
 
-#include <stm32mp1xx_ll_hsem.h>
-
 #ifdef CONFIG_EXTI_STM32
 #include <stm32mp1xx_ll_exti.h>
 #endif

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -34,10 +34,6 @@
 #include <stm32mp1xx_ll_system.h>
 #endif
 
-#ifdef CONFIG_IPM_STM32_IPCC
-#include <stm32mp1xx_ll_ipcc.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -58,10 +58,6 @@
 #include <stm32wbxx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */
 
-#ifdef CONFIG_IWDG_STM32
-#include <stm32wbxx_ll_iwdg.h>
-#endif /* CONFIG_IWDG_STM32 */
-
 #ifdef CONFIG_STM32_LPTIM_TIMER
 #include <stm32wbxx_ll_lptim.h>
 #include <stm32wbxx_ll_system.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -62,10 +62,6 @@
 #include <stm32wbxx_ll_iwdg.h>
 #endif /* CONFIG_IWDG_STM32 */
 
-#ifdef CONFIG_WWDG_STM32
-#include <stm32wbxx_ll_wwdg.h>
-#endif
-
 #ifdef CONFIG_STM32_LPTIM_TIMER
 #include <stm32wbxx_ll_lptim.h>
 #include <stm32wbxx_ll_system.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -26,13 +26,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
-#include <stm32wbxx_ll_utils.h>
-#include <stm32wbxx_ll_bus.h>
-#include <stm32wbxx_ll_rcc.h>
-#include <stm32wbxx_ll_system.h>
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WBX_SOC_H_ */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -26,13 +26,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#if defined(CONFIG_COUNTER_RTC_STM32)
-#include <stm32wbxx_ll_rtc.h>
-#include <stm32wbxx_ll_exti.h>
-#include <stm32wbxx_ll_pwr.h>
-#include <stm32wbxx_ll_bus.h>
-#endif
-
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32wbxx_ll_utils.h>
 #include <stm32wbxx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -26,10 +26,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#ifdef CONFIG_GPIO_STM32
-#include <stm32wbxx_ll_gpio.h>
-#endif
-
 #if defined(CONFIG_COUNTER_RTC_STM32)
 #include <stm32wbxx_ll_rtc.h>
 #include <stm32wbxx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -58,10 +58,6 @@
 #include <stm32wbxx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */
 
-#ifdef CONFIG_ADC_STM32
-#include <stm32wbxx_ll_adc.h>
-#endif /* CONFIG_ADC_STM32 */
-
 #ifdef CONFIG_IWDG_STM32
 #include <stm32wbxx_ll_iwdg.h>
 #endif /* CONFIG_IWDG_STM32 */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -65,10 +65,6 @@
 #include <stm32wbxx_ll_dmamux.h>
 #endif
 
-#ifdef CONFIG_PWM_STM32
-#include <stm32wbxx_ll_tim.h>
-#endif /* CONFIG_PWM_STM32 */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WBX_SOC_H_ */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -17,13 +17,11 @@
 #ifndef _STM32WBX_SOC_H_
 #define _STM32WBX_SOC_H_
 
-#include <sys/util.h>
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32wbxx.h>
 
-/* Add include for DTS generated information */
+/* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -26,8 +26,6 @@
 /* Add include for DTS generated information */
 #include <st_stm32_dt.h>
 
-#include <stm32wbxx_ll_hsem.h>
-
 #ifdef CONFIG_GPIO_STM32
 #include <stm32wbxx_ll_gpio.h>
 #endif
@@ -45,10 +43,6 @@
 #include <stm32wbxx_ll_rcc.h>
 #include <stm32wbxx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
-
-#if defined(CONFIG_FLASH) || defined(CONFIG_USB)
-#include <stm32wbxx_ll_hsem.h>
-#endif /* CONFIG_FLASH || CONFIG_USB */
 
 #ifdef CONFIG_I2C_STM32
 #include <stm32wbxx_ll_i2c.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -44,10 +44,6 @@
 #include <stm32wbxx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_I2C_STM32
-#include <stm32wbxx_ll_i2c.h>
-#endif /* CONFIG_I2C_STM32 */
-
 #ifdef CONFIG_SPI_STM32
 #include <stm32wbxx_ll_spi.h>
 #endif /* CONFIG_SPI_STM32 */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -38,14 +38,6 @@
 #include <stm32wbxx_ll_system.h>
 #endif
 
-#ifdef CONFIG_DMA_STM32
-#include <stm32wbxx_ll_dma.h>
-#endif
-
-#ifdef CONFIG_DMAMUX_STM32
-#include <stm32wbxx_ll_dmamux.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WBX_SOC_H_ */

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -44,10 +44,6 @@
 #include <stm32wbxx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_SPI_STM32
-#include <stm32wbxx_ll_spi.h>
-#endif /* CONFIG_SPI_STM32 */
-
 #ifdef CONFIG_STM32_LPTIM_TIMER
 #include <stm32wbxx_ll_lptim.h>
 #include <stm32wbxx_ll_system.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -33,11 +33,6 @@
 #include <stm32wbxx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
-#ifdef CONFIG_STM32_LPTIM_TIMER
-#include <stm32wbxx_ll_lptim.h>
-#include <stm32wbxx_ll_system.h>
-#endif
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WBX_SOC_H_ */

--- a/subsys/disk/disk_access_stm32_sdmmc.c
+++ b/subsys/disk/disk_access_stm32_sdmmc.c
@@ -14,6 +14,7 @@
 #include <drivers/gpio.h>
 #include <logging/log.h>
 #include <soc.h>
+#include <stm32_ll_rcc.h>
 
 LOG_MODULE_REGISTER(stm32_sdmmc);
 


### PR DESCRIPTION
Based on @gmarull's work in #28894, this PR adds support for the generic LL headers for a all other drivers.

I ran lots of sanitychecks for `tests/drivers`, `tests/subsys` and `samples/drivers` locally, so I hope I didn't forget to include the new LL headers anywhere.

The remaining content of `soc.h` is the MCU-specific register map file (e.g. `stm32l1xx.h`) and the generated devicetree including STM-specific macros.