### PR TITLE
drivers: spi: mcux_flexcomm: Fix build failure

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -544,7 +544,7 @@ static int transceive_dma(const struct device *dev,
 	int ret;
 	uint32_t word_size;
 
-	spi_context_lock(&data->ctx, asynchronous, signal);
+	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {


### PR DESCRIPTION
Change to spi_context_lock missed one spot in the flexcomm driver and
this causes a build issue.  Pass spi_cfg to spi_context_lock to fix
the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>