### PR TITLE
samples: flash_shell: skip boards without zephyr,flash-controller

### DIFF
--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -9,7 +9,6 @@
 / {
 	chosen {
 		zephyr,entropy = &trng;
-		zephyr,flash-controller = &ftfa;
 	};
 
 	cpus {

--- a/samples/drivers/flash_shell/prj.conf
+++ b/samples/drivers/flash_shell/prj.conf
@@ -1,6 +1,5 @@
 CONFIG_PRINTK=y
 CONFIG_SHELL=y
-CONFIG_SERIAL=y
 CONFIG_LOG=y
 CONFIG_FLASH=y
 # Your flash driver may not enable this, even if it's supported.

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -5,6 +5,6 @@ sample:
 tests:
   sample.drivers.flash.shell:
     tags: flash shell
-    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
+    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and dt_chosen_enabled("zephyr,flash-controller")
     harness: keyboard
     min_ram: 12

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -240,6 +240,12 @@ def ast_expr(ast, env, edt):
             if node.status == "okay" and alias in node.aliases and node.matching_compat == compat:
                 return True
         return False
+    elif ast[0] == "dt_chosen_enabled":
+        chosen = ast[1][0]
+        node = edt.chosen_node(chosen)
+        if node and node.status == "okay":
+            return True
+        return False
 
 mutex = threading.Lock()
 


### PR DESCRIPTION
Add a `dt_chosen_enabled(chosen)` filter function to sanitycheck. The function returns true if the devicetree /chosen node contains 'chosen' and the referenced node is enabled.

Adjust the sanitycheck filter of the flash shell sample to depend on the board having a chosen zephyr,flash-controller devicetree node (as this is what is referenced in `flash_shell.c`).

This fixes sanitycheck compilation failures for boards which has `CONFIG_FLASH_HAS_DRIVER_ENABLED=y` but no `zephyr,flash-controller` chosen node.