### PR TITLE
ci: run_ci.sh: retry failed west update for PR builds

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -146,7 +146,7 @@ function west_setup() {
 	pushd ..
 	if [ ! -d .west ]; then
 		west init -l ${git_dir}
-		west update 1> west.update.log
+		west update 1> west.update.log || west update 1> west.update-2.log
 		west forall -c 'git reset --hard HEAD'
 	fi
 	popd


### PR DESCRIPTION
We made a similar change for the nightly builds, but the PR builds
invoke run_ci.sh, so we need the same change here.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>