### PR TITLE
Driver i2c_imx: Fix system fault when there is no data to send

### DIFF
--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -233,13 +233,15 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 		}
 
 		/* Transfer data */
-		buf = msgs->buf;
-		buf_end = buf + msgs->len;
-		if ((msgs->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
-			i2c_imx_read(dev, msgs->buf, msgs->len);
-		} else {
-			if (!i2c_imx_write(dev, msgs->buf, msgs->len)) {
-				goto finish; /* No ACK received */
+		if (msgs->len) {
+			buf = msgs->buf;
+			buf_end = buf + msgs->len;
+			if ((msgs->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
+				i2c_imx_read(dev, msgs->buf, msgs->len);
+			} else {
+				if (!i2c_imx_write(dev, msgs->buf, msgs->len)) {
+					goto finish; /* No ACK received */
+				}
 			}
 		}
 

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -48,7 +48,7 @@ struct i2c_imx_data {
 };
 
 static bool i2c_imx_write(const struct device *dev, uint8_t *txBuffer,
-			  uint8_t txSize)
+			  uint32_t txSize)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = DEV_DATA(dev);
@@ -82,7 +82,7 @@ static bool i2c_imx_write(const struct device *dev, uint8_t *txBuffer,
 }
 
 static void i2c_imx_read(const struct device *dev, uint8_t *rxBuffer,
-			 uint8_t rxSize)
+			 uint32_t rxSize)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = DEV_DATA(dev);
@@ -191,7 +191,6 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_imx_data *data = DEV_DATA(dev);
 	struct i2c_master_transfer *transfer = &data->transfer;
-	uint8_t *buf, *buf_end;
 	uint16_t timeout = UINT16_MAX;
 	int result = -EIO;
 
@@ -234,8 +233,6 @@ static int i2c_imx_transfer(const struct device *dev, struct i2c_msg *msgs,
 
 		/* Transfer data */
 		if (msgs->len) {
-			buf = msgs->buf;
-			buf_end = buf + msgs->len;
 			if ((msgs->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
 				i2c_imx_read(dev, msgs->buf, msgs->len);
 			} else {


### PR DESCRIPTION
When there is no data to send (e.g. i2c message with NULL buffer and len=0), i2c_imx driver locks itself in isr handling forever.
So if there is no data to send, only device's address must be written on bus. This fixes i2c_shell's **scan** command on both imx7 and imx6sx.