### PR TITLE
soc: arm: sam4e/s: Add common Kconfig defines

### DIFF
--- a/boards/arm/sam4e_xpro/Kconfig.defconfig
+++ b/boards/arm/sam4e_xpro/Kconfig.defconfig
@@ -8,26 +8,4 @@ if BOARD_SAM4E_XPRO
 config BOARD
 	default "sam4e_xpro"
 
-config GPIO_SAM
-	default y
-	depends on GPIO
-
-config I2C_SAM_TWI
-	default y
-	depends on I2C
-
-config SPI_SAM
-	default y
-	depends on SPI
-
-if NETWORKING
-
-config NET_L2_ETHERNET
-	default y
-
-config ETH_SAM_GMAC
-	default y if NET_L2_ETHERNET
-
-endif # NETWORKING
-
 endif # BOARD_SAM4E_XPRO

--- a/boards/arm/sam4s_xplained/Kconfig.defconfig
+++ b/boards/arm/sam4s_xplained/Kconfig.defconfig
@@ -8,11 +8,4 @@ if BOARD_SAM4S_XPLAINED
 config BOARD
 	default "sam4s_xplained"
 
-if I2C
-
-config I2C_SAM_TWI
-	default y
-
-endif # I2C
-
 endif # BOARD_SAM4S_XPLAINED

--- a/soc/arm/atmel_sam/sam4e/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4e/Kconfig.defconfig.series
@@ -26,4 +26,26 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 120000000
 
+config GPIO_SAM
+	default y
+	depends on GPIO
+
+config I2C_SAM_TWI
+	default y
+	depends on I2C
+
+config SPI_SAM
+	default y
+	depends on SPI
+
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+config ETH_SAM_GMAC
+	default y if NET_L2_ETHERNET
+
+endif # NETWORKING
+
 endif # SOC_SERIES_SAM4E

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -31,4 +31,16 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 120000000
 
+config GPIO_SAM
+	default y
+	depends on GPIO
+
+config I2C_SAM_TWI
+	default y
+	depends on I2C
+
+config SPI_SAM
+	default y
+	depends on SPI
+
 endif # SOC_SERIES_SAM4S


### PR DESCRIPTION
The current SAM4E/S define at board level common Kconfig flags that should be on /soc. Add common flags at SoC Kconfig define and drop the correspondent at board define file.
