### PR TITLE
Driver Imx6sx: Enable I2C

### DIFF
--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT fsl_imx7d_i2c
+#define DT_DRV_COMPAT fsl_imx21_i2c
 
 #include <errno.h>
 #include <drivers/i2c.h>

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/rdc/imx_rdc.h>
+#include <dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -276,6 +277,66 @@
 			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW))>;
 			label = "EPIT_2";
+			status = "disabled";
+		};
+
+		i2c1: i2c@421a0000 {
+			compatible = "fsl,imx6sx-i2c", "fsl,imx21-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x421a0000 0x4000>;
+			interrupts = <36 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "I2C_1";
+			status = "disabled";
+		};
+
+		i2c2: i2c@421a4000 {
+			compatible = "fsl,imx6sx-i2c", "fsl,imx21-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x421a4000 0x4000>;
+			interrupts = <37 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "I2C_2";
+			status = "disabled";
+		};
+
+		i2c3: i2c@421a8000 {
+			compatible = "fsl,imx6sx-i2c", "fsl,imx21-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x421a8000 0x4000>;
+			interrupts = <38 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "I2C_3";
+			status = "disabled";
+		};
+
+		i2c4: i2c@421f8000 {
+			compatible = "fsl,imx6sx-i2c", "fsl,imx21-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x421f8000 0x4000>;
+			interrupts = <35 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			label = "I2C_4";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -271,7 +271,7 @@
 		};
 
 		i2c1: i2c@30a20000 {
-			compatible = "fsl,imx7d-i2c";
+			compatible = "fsl,imx7d-i2c", "fsl,imx21-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -286,7 +286,7 @@
 		};
 
 		i2c2: i2c@30a30000 {
-			compatible = "fsl,imx7d-i2c";
+			compatible = "fsl,imx7d-i2c", "fsl,imx21-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -301,7 +301,7 @@
 		};
 
 		i2c3: i2c@30a40000 {
-			compatible = "fsl,imx7d-i2c";
+			compatible = "fsl,imx7d-i2c", "fsl,imx21-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -316,7 +316,7 @@
 		};
 
 		i2c4: i2c@30a50000 {
-			compatible = "fsl,imx7d-i2c";
+			compatible = "fsl,imx7d-i2c", "fsl,imx21-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/i2c/fsl,imx21-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx21-i2c.yaml
@@ -3,7 +3,7 @@
 
 description: i.MX I2C node
 
-compatible: "fsl,imx7d-i2c"
+compatible: "fsl,imx21-i2c"
 
 include: i2c-controller.yaml
 

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -19,6 +19,10 @@ config UART_IMX
 	default y
 	depends on SERIAL
 
+config I2C_IMX
+	default y
+	depends on I2C
+
 config IPM_IMX
 	default y
 	depends on IPM

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.soc
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.soc
@@ -12,6 +12,7 @@ config SOC_MCIMX6X_M4
 	select HAS_IMX_HAL
 	select HAS_IMX_GPIO
 	select HAS_IMX_EPIT
+	select HAS_IMX_I2C
 
 endchoice
 

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -87,6 +87,23 @@ static void SOC_RdcInit(void)
 	/* Set access to EPIT_2 for M4 core */
 	RDC_SetPdapAccess(RDC, rdcPdapEpit2, RDC_DT_VAL(epit2), false, false);
 #endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay)
+	/* Set access to I2C-1 for M4 core */
+	RDC_SetPdapAccess(RDC, rdcPdapI2c1, RDC_DT_VAL(i2c1), false, false);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c2), okay)
+	/* Set access to I2C-2 for M4 core */
+	RDC_SetPdapAccess(RDC, rdcPdapI2c2, RDC_DT_VAL(i2c2), false, false);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c3), okay)
+	/* Set access to I2C-3 for M4 core */
+	RDC_SetPdapAccess(RDC, rdcPdapI2c3, RDC_DT_VAL(i2c3), false, false);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c4), okay)
+	/* Set access to I2C-4 for M4 core */
+	RDC_SetPdapAccess(RDC, rdcPdapI2c4, RDC_DT_VAL(i2c4), false, false);
+#endif
 }
 
 /* Initialize cache. */
@@ -158,6 +175,28 @@ static void SOC_ClockInit(void)
 	CCM_ControlGate(CCM, ccmCcgrGateEpit2Clk, ccmClockNeededAll);
 #endif
 #endif /* CONFIG_COUNTER_IMX_EPIT */
+
+#ifdef CONFIG_I2C_IMX
+	/* Select I2C clock is derived from OSC (24M) */
+	CCM_SetRootMux(CCM, ccmRootPerclkClkSel, ccmRootmuxPerclkClkOsc24m);
+
+	/* Set relevant divider = 1. */
+	CCM_SetRootDivider(CCM, ccmRootPerclkPodf, 0);
+
+	/* Enable I2C clock */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay)
+	CCM_ControlGate(CCM, ccmCcgrGateI2c1Serialclk, ccmClockNeededAll);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c2), okay)
+	CCM_ControlGate(CCM, ccmCcgrGateI2c2Serialclk, ccmClockNeededAll);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c3), okay)
+	CCM_ControlGate(CCM, ccmCcgrGateI2c3Serialclk, ccmClockNeededAll);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c4), okay)
+	CCM_ControlGate(CCM, ccmCcgrGateI2c4Serialclk, ccmClockNeededAll);
+#endif
+#endif
 }
 
 /**


### PR DESCRIPTION
This commit add support for i2c on imx6sx. I2C support is based on imx7d and requires NXP HAL.
The Device Tree binding is also changed to better reflect that i2c driver support both imx6sx and imx7d.