### PR TITLE
arch: arm64: correct vector_table alignment

### DIFF
--- a/arch/arm/core/aarch64/vector_table.S
+++ b/arch/arm/core/aarch64/vector_table.S
@@ -57,9 +57,8 @@ _ASM_FILE_PROLOGUE
  */
 
 	/* The whole table must be 2K aligned */
-	.align 11
-
 SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
+	.align 11
 
 	/* Current EL with SP0 / Synchronous */
 	.align 7


### PR DESCRIPTION
The 2K alignment assembler directives should be under
'SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)'
Otherwise the _vector_table is actually 0x80 bytes aligned.

Signed-off-by: Peng Fan <peng.fan@nxp.com>