### PR TITLE
CI: only release to AWS in the Zephyr repository

### DIFF
--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   get_version:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
     - name: Configure AWS Credentials

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
     - name: Update PATH for west

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
     - uses: actions/stale@v3
       with:


### PR DESCRIPTION
Currently, nightly releases are performed in Forks as well.
Since these fail due to missing AWS credentials this causes
a lot of messages about failing builds, this commit disables
them for Forks.