### PR TITLE
Bluetooth: controller: Make random force on lost anchor configurable

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -424,6 +424,20 @@ config BT_CTLR_FORCE_MD_AUTO
 	  Force MD bit in transmitted PDU based on runtime incoming transmit
 	  data throughput.
 
+config BT_CTLR_CONN_RANDOM_FORCE
+	bool "Enable random forced scheduling for peripheral on missed anchor point"
+	depends on BT_PERIPHERAL
+	default y
+	help
+	  When enabled, controller will have legacy behavior and randomly force
+	  priority at next ticker scheduling for peripheral role, if anchor point is
+	  missed.
+	  Two or more connections with similar interval on a device connected
+	  to a peer device having two or more connections at its end with same
+	  interval could lock to a round robin pattern where in neither of the central
+	  nor peripheral event would be in sync at either end. Randomness allows
+	  to break this locked round robin pattern permitting an anchor point sync.
+
 config BT_CTLR_CONN_RSSI_EVENT
 	bool "Connection RSSI event"
 	depends on BT_CTLR_CONN_RSSI

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1164,7 +1164,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 			if (conn->supervision_expire <= 6U) {
 				force = 1U;
 			}
-#if defined(CONFIG_BT_PERIPHERAL)
+#if defined(CONFIG_BT_CTLR_CONN_RANDOM_FORCE)
 			/* use randomness to force slave role when anchor
 			 * points are being missed.
 			 */
@@ -1181,7 +1181,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 					}
 				}
 			}
-#endif /* CONFIG_BT_PERIPHERAL */
+#endif /* CONFIG_BT_CTLR_CONN_RANDOM_FORCE */
 		} else {
 			conn_cleanup(conn, BT_HCI_ERR_CONN_TIMEOUT);
 


### PR DESCRIPTION
Legacy functionality in ull_conn will force scheduling of a connection
which has missed an anchor point due to lost RX. This kicks in either
for previously skipped events (latenzy_event != 0) or at random
depending on the randomness of the AA bit pattern.

This behavior is good at ensuring that a connection with errors or
aborted RX gets prioitized, and helps break locked round-robin
patterns with lost sync, but it also breaks the predictability of
the round-robin ticker scheduling.

With "must_expire" enabled, this feature also kicks in for scheduling
collisions, which may not be desirable.

This commit adds a configuration flag, BT_CTLR_CONN_RANDOM_FORCE, which
is default enabled (legacy behavior).

Signed-off-by: Morten Priess <mtpr@oticon.com>