### PR TITLE
device: refactor declare/define macros to support device definition and reference from devicetree nodes

### DIFF
--- a/doc/guides/dts/api-usage.rst
+++ b/doc/guides/dts/api-usage.rst
@@ -303,8 +303,9 @@ See :ref:`dt-get-device` for ways to do that.
 
 Another common use case is accessing specifier values in a phandle array. The
 general purpose APIs for this are :c:func:`DT_PHA_BY_IDX` and :c:func:`DT_PHA`.
-There are also hardware-specific shorthands like :c:func:`DT_GPIO_LABEL_BY_IDX`,
-:c:func:`DT_GPIO_LABEL`, :c:func:`DT_GPIO_PIN_BY_IDX`, :c:func:`DT_GPIO_PIN`,
+There are also hardware-specific shorthands like :c:func:`DT_GPIO_CTLR_BY_IDX`,
+:c:func:`DT_GPIO_CTLR`, :c:func:`DT_GPIO_LABEL_BY_IDX`, :c:func:`DT_GPIO_LABEL`,
+:c:func:`DT_GPIO_PIN_BY_IDX`, :c:func:`DT_GPIO_PIN`,
 :c:func:`DT_GPIO_FLAGS_BY_IDX`, and :c:func:`DT_GPIO_FLAGS`.
 
 See :c:func:`DT_PHA_HAS_CELL_AT_IDX` and :c:func:`DT_PROP_HAS_IDX` for ways to

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -109,11 +109,14 @@ static struct onoff_manager *get_onoff_manager(const struct device *dev,
 	return &data->mgr[type];
 }
 
-DEVICE_DECLARE(clock_nrf);
+
+DEVICE_DT_DECLARE(DT_NODELABEL(clock));
+
+#define CLOCK_DEVICE DEVICE_DT_GET(DT_NODELABEL(clock))
 
 struct onoff_manager *z_nrf_clock_control_get_onoff(clock_control_subsys_t sys)
 {
-	return get_onoff_manager(DEVICE_GET(clock_nrf),
+	return get_onoff_manager(CLOCK_DEVICE,
 				(enum clock_control_nrf_type)sys);
 }
 
@@ -249,7 +252,7 @@ static void hfclk192m_stop(void)
 
 static uint32_t *get_hf_flags(void)
 {
-	struct nrf_clock_control_data *data = DEVICE_GET(clock_nrf)->data;
+	struct nrf_clock_control_data *data = CLOCK_DEVICE->data;
 
 	return &data->subsys[CLOCK_CONTROL_NRF_TYPE_HFCLK].flags;
 }
@@ -276,7 +279,7 @@ static void generic_hfclk_start(void)
 
 	if (already_started) {
 		/* Clock already started by z_nrf_clock_bt_ctlr_hf_request */
-		clkstarted_handle(DEVICE_GET(clock_nrf),
+		clkstarted_handle(CLOCK_DEVICE,
 				  CLOCK_CONTROL_NRF_TYPE_HFCLK);
 		return;
 	}
@@ -394,7 +397,7 @@ static int api_blocking_start(const struct device *dev,
 
 static clock_control_subsys_t get_subsys(struct onoff_manager *mgr)
 {
-	struct nrf_clock_control_data *data = DEVICE_GET(clock_nrf)->data;
+	struct nrf_clock_control_data *data = CLOCK_DEVICE->data;
 	size_t offset = (size_t)(mgr - data->mgr);
 
 	return (clock_control_subsys_t)offset;
@@ -405,7 +408,7 @@ static void onoff_stop(struct onoff_manager *mgr,
 {
 	int res;
 
-	res = stop(DEVICE_GET(clock_nrf), get_subsys(mgr), CTX_ONOFF);
+	res = stop(CLOCK_DEVICE, get_subsys(mgr), CTX_ONOFF);
 	notify(mgr, res);
 }
 
@@ -425,7 +428,7 @@ static void onoff_start(struct onoff_manager *mgr,
 {
 	int err;
 
-	err = async_start(DEVICE_GET(clock_nrf), get_subsys(mgr),
+	err = async_start(CLOCK_DEVICE, get_subsys(mgr),
 			  onoff_started_callback, notify, CTX_ONOFF);
 	if (err < 0) {
 		notify(mgr, err);
@@ -528,7 +531,7 @@ void z_nrf_clock_control_lf_on(enum nrf_lfclk_start_mode start_mode)
 	if (atomic_set(&on, 1) == 0) {
 		int err;
 		struct onoff_manager *mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_LFCLK);
 
 		sys_notify_init_spinwait(&cli.notify);
@@ -557,7 +560,7 @@ void z_nrf_clock_control_lf_on(enum nrf_lfclk_start_mode start_mode)
 
 static void clock_event_handler(nrfx_clock_evt_type_t event)
 {
-	const struct device *dev = DEVICE_GET(clock_nrf);
+	const struct device *dev = CLOCK_DEVICE;
 
 	switch (event) {
 	case NRFX_CLOCK_EVT_HFCLK_STARTED:
@@ -671,10 +674,10 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_AND_API_INIT(clock_nrf, DT_INST_LABEL(0),
-		    clk_init, &data, &config, PRE_KERNEL_1,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &clock_control_api);
+DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, device_pm_control_nop,
+		 &data, &config,
+		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 &clock_control_api);
 
 static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 {
@@ -682,10 +685,10 @@ static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 	bool hf_status;
 	bool lf_status = nrfx_clock_is_running(NRF_CLOCK_DOMAIN_LFCLK, NULL);
 	struct onoff_manager *hf_mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_HFCLK);
 	struct onoff_manager *lf_mgr =
-				get_onoff_manager(DEVICE_GET(clock_nrf),
+				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_LFCLK);
 	uint32_t abs_start, abs_stop;
 	int key = irq_lock();

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -883,7 +883,7 @@ static const struct qspi_nor_config flash_id = {
 	.size = INST_0_BYTES,
 };
 
-DEVICE_AND_API_INIT(qspi_flash_memory, DT_INST_LABEL(0),
-		    &qspi_nor_init, &qspi_nor_memory_data,
-		    &flash_id, POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
-		    &qspi_nor_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), &qspi_nor_init, device_pm_control_nop,
+		 &qspi_nor_memory_data, &flash_id,
+		 POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
+		 &qspi_nor_api);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -281,9 +281,10 @@ static int nrf_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(nrf_flash, DT_INST_LABEL(0), nrf_flash_init,
-		NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		&flash_nrf_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), nrf_flash_init, device_pm_control_nop,
+		 NULL, NULL,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 &flash_nrf_api);
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1039,7 +1039,7 @@ static const struct spi_nor_config spi_nor_config_0 = {
 
 static struct spi_nor_data spi_nor_data_0;
 
-DEVICE_AND_API_INIT(spi_flash_memory, DT_INST_LABEL(0),
-		    &spi_nor_init, &spi_nor_data_0, &spi_nor_config_0,
-		    POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
-		    &spi_nor_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), &spi_nor_init, device_pm_control_nop,
+		 &spi_nor_data_0, &spi_nor_config_0,
+		 POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
+		 &spi_nor_api);

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -666,7 +666,7 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 	.lock = Z_SEM_INITIALIZER(sx1509b_drvdata.lock, 1, 1),
 };
 
-DEVICE_AND_API_INIT(sx1509b, DT_INST_LABEL(0),
-		    sx1509b_init, &sx1509b_drvdata, &sx1509b_cfg,
-		    POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
-		    &api_table);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), sx1509b_init, device_pm_control_nop,
+		 &sx1509b_drvdata, &sx1509b_cfg,
+		 POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
+		 &api_table);

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -296,8 +296,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(twi_##idx,					       \
-		      DT_LABEL(I2C(idx)),				       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twi_##idx##_init,					       \
 		      twi_nrfx_pm_control,				       \
 		      &twi_##idx##_data,				       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -349,8 +349,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(twim_##idx,					       \
-		      DT_LABEL(I2C(idx)),				       \
+	DEVICE_DT_DEFINE(I2C(idx),					       \
 		      twim_##idx##_init,				       \
 		      twim_nrfx_pm_control,				       \
 		      &twim_##idx##_data,				       \

--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -386,10 +386,9 @@ static const struct driver_config regulator_##id##_cfg = { \
 \
 static struct REG_DATA_TAG(id) regulator_##id##_data; \
 \
-DEVICE_AND_API_INIT(regulator_##id, DT_INST_LABEL(id), \
-		    REG_INIT(id), \
-		    &regulator_##id##_data, &regulator_##id##_cfg, \
-		    POST_KERNEL, CONFIG_REGULATOR_FIXED_INIT_PRIORITY, \
-		    &REG_API(id));
+DEVICE_DT_DEFINE(DT_DRV_INST(id), REG_INIT(id), device_pm_control_nop, \
+		 &regulator_##id##_data, &regulator_##id##_cfg,	       \
+		 POST_KERNEL, CONFIG_REGULATOR_FIXED_INIT_PRIORITY,    \
+		 &REG_API(id));
 
 DT_INST_FOREACH_STATUS_OKAY(REGULATOR_DEVICE)

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -593,6 +593,7 @@ out:
 
 static struct ccs811_data ccs811_driver;
 
-DEVICE_AND_API_INIT(ccs811, DT_INST_LABEL(0), ccs811_init, &ccs811_driver,
-		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &ccs811_driver_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), ccs811_init, device_pm_control_nop,
+		 &ccs811_driver, NULL,
+		 POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		 &ccs811_driver_api);

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -52,7 +52,7 @@ BUILD_ASSERT((PROP(hw_flow_control) && HW_FLOW_CONTROL_AVAILABLE) ||
 
 static NRF_UART_Type *const uart0_addr = (NRF_UART_Type *)DT_INST_REG_ADDR(0);
 
-DEVICE_DECLARE(uart_nrfx_uart0);
+DEVICE_DT_DECLARE(DT_DRV_INST(0));
 
 /* Device data structure */
 struct uart_nrfx_data {
@@ -755,7 +755,7 @@ void uart_nrfx_isr(const struct device *uart)
 
 static void rx_timeout(struct k_timer *timer)
 {
-	rx_rdy_evt(DEVICE_GET(uart_nrfx_uart0));
+	rx_rdy_evt(DEVICE_DT_GET(DT_DRV_INST(0)));
 }
 
 #if HW_FLOW_CONTROL_AVAILABLE
@@ -772,7 +772,7 @@ static void tx_timeout(struct k_timer *timer)
 	evt.data.tx.len = uart0_cb.tx_buffer_length;
 	uart0_cb.tx_buffer_length = 0;
 	uart0_cb.tx_counter = 0;
-	user_callback(DEVICE_GET(uart_nrfx_uart0), &evt);
+	user_callback(DEVICE_DT_GET(DT_DRV_INST(0)), &evt);
 }
 #endif
 
@@ -1042,7 +1042,7 @@ static int uart_nrfx_init(const struct device *dev)
 	IRQ_CONNECT(IRQN,
 		    IRQ_PRIO,
 		    uart_nrfx_isr,
-		    DEVICE_GET(uart_nrfx_uart0),
+		    DEVICE_DT_GET(DT_DRV_INST(0)),
 		    0);
 	irq_enable(IRQN);
 #endif
@@ -1195,8 +1195,7 @@ static struct uart_nrfx_data uart_nrfx_uart0_data = {
 	}
 };
 
-DEVICE_DEFINE(uart_nrfx_uart0,
-	      DT_INST_LABEL(0),
+DEVICE_DT_DEFINE(DT_DRV_INST(0),
 	      uart_nrfx_init,
 	      uart_nrfx_pm_control,
 	      &uart_nrfx_uart0_data,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1625,7 +1625,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 #define UARTE_IRQ_CONFIGURE(idx, isr_handler)				       \
 	do {								       \
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
-			    isr_handler, DEVICE_GET(uart_nrfx_uarte##idx), 0); \
+			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0); \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
 	} while (0)
 
@@ -1638,7 +1638,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 
 #define UART_NRF_UARTE_DEVICE(idx)					       \
 	HWFC_CONFIG_CHECK(idx);						       \
-	DEVICE_DECLARE(uart_nrfx_uarte##idx);				       \
+	DEVICE_DT_DECLARE(UARTE(idx));					       \
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
 	static struct uarte_nrfx_data uarte_##idx##_data = {		       \
@@ -1675,8 +1675,7 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 			&init_config,					       \
 			IS_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN));     \
 	}								       \
-	DEVICE_DEFINE(uart_nrfx_uarte##idx,				       \
-		      DT_LABEL(UARTE(idx)),				       \
+	DEVICE_DT_DEFINE(UARTE(idx),					       \
 		      uarte_##idx##_init,				       \
 		      uarte_nrfx_pm_control,				       \
 		      &uarte_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -383,7 +383,7 @@ static int spi_nrfx_pm_control(const struct device *dev,
 			.miso_pull = SPI_NRFX_MISO_PULL(idx),		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(spi_##idx, DT_LABEL(SPI(idx)),			       \
+	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_##idx##_init,					       \
 		      spi_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -436,8 +436,7 @@ static int spim_nrfx_pm_control(const struct device *dev,
 			SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)		       \
 		}							       \
 	};								       \
-	DEVICE_DEFINE(spi_##idx,					       \
-		      SPIM_PROP(idx, label),				       \
+	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_##idx##_init,					       \
 		      spim_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/include/device.h
+++ b/include/device.h
@@ -139,6 +139,96 @@ extern "C" {
 			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 /**
+ * @def DEVICE_DT_DEFINE
+ *
+ * @brief Like DEVICE_DEFINE but taking metadata from a devicetree node
+ *
+ * @details This macro defines a device object that is automatically
+ * configured by the kernel during system initialization.  The device
+ * object name is derived from the node identifier (encoding the
+ * devicetree path to the node), and the driver name is from the @p
+ * label property of the devicetree node.
+ *
+ * Device objects defined through this API can be obtained directly
+ * through DEVICE_DT_GET() using @p node_id.
+ *
+ * @param node_id The devicetree node identifier.
+ *
+ * @param init_fn Address to the init function of the driver.
+ *
+ * @param pm_control_fn Pointer to device_pm_control function.
+ * Can be empty function (device_pm_control_nop) if not implemented.
+ *
+ * @param data_ptr Pointer to the device's private data.
+ *
+ * @param cfg_ptr The address to the structure containing the
+ * configuration information for this instance of the driver.
+ *
+ * @param level The initialization level.  See SYS_INIT() for
+ * details.
+ *
+ * @param prio Priority within the selected initialization level. See
+ * SYS_INIT() for details.
+ *
+ * @param api_ptr Provides an initial pointer to the API function struct
+ * used by the driver. Can be NULL.
+ */
+#define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
+			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
+	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
+		      data_ptr, cfg_ptr, level, prio, api_ptr)
+
+/**
+ * @def DEVICE_DT_NAME_GET
+ *
+ * @brief The name of the struct device object for @p node_id
+ *
+ * @details Return the full name of a device object symbol created by
+ * DEVICE_DT_DEFINE(), using the dev_name derived from @p node_id
+ *
+ * It is meant to be used for declaring extern symbols pointing on device
+ * objects before using the DEVICE_DT_GET macro to get the device object.
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ *
+ * @return The expanded name of the device object created by
+ * DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(node_id)
+
+/**
+ * @def DEVICE_DT_GET
+ *
+ * @brief Obtain a pointer to a device object by @p node_id
+ *
+ * @details Return the address of a device object created by
+ * DEVICE_DT_INIT(), using the dev_name derived from @p node_id
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ *
+ * @return A pointer to the device object created by DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
+
+/** @def DEVICE_DT_DECLARE
+ *
+ * @brief Declare a device object associated with @p node_id
+ *
+ * This macro can be used at the top-level to declare a device, such
+ * that DEVICE_DT_GET() may be used before the full declaration in
+ * DEVICE_DT_DEFINE().
+ *
+ * This is often useful when configuring interrupts statically in a
+ * device's init or per-instance config function, as the init function
+ * itself is required by DEVICE_DT_DEFINE() and use of DEVICE_DT_GET()
+ * inside it creates a circular dependency.
+ *
+ * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
+ */
+#define DEVICE_DT_DECLARE(node_id)				\
+	static const struct device DEVICE_DT_NAME_GET(node_id)
+
+/**
  * @def DEVICE_GET
  *
  * @brief Obtain a pointer to a device object by name

--- a/include/device.h
+++ b/include/device.h
@@ -125,18 +125,9 @@ extern "C" {
  */
 #define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_control_fn,	\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)		\
-	Z_DEVICE_DEFINE_PM(dev_name)					\
-	static const Z_DECL_ALIGN(struct device)			\
-		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
-		.name = drv_name,					\
-		.config = (cfg_ptr),					\
-		.api = (api_ptr),					\
-		.data = (data_ptr),					\
-		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
-	};								\
-	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
-			    (&_CONCAT(__device_, dev_name)), level, prio)
+	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
+			pm_control_fn,					\
+			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
  * @def DEVICE_DT_DEFINE
@@ -175,8 +166,9 @@ extern "C" {
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
 			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
-	DEVICE_DEFINE(node_id, DT_LABEL(node_id), init_fn, pm_control_fn, \
-		      data_ptr, cfg_ptr, level, prio, api_ptr)
+	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+			pm_control_fn,					\
+			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
  * @def DEVICE_DT_NAME_GET
@@ -663,6 +655,21 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 /**
  * @}
  */
+
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_control_fn, \
+			data_ptr, cfg_ptr, level, prio, api_ptr)	\
+	Z_DEVICE_DEFINE_PM(dev_name)					\
+	static const Z_DECL_ALIGN(struct device)			\
+		DEVICE_NAME_GET(dev_name) __used			\
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+		.name = drv_name,					\
+		.config = (cfg_ptr),					\
+		.api = (api_ptr),					\
+		.data = (data_ptr),					\
+		Z_DEVICE_DEFINE_PM_INIT(dev_name, pm_control_fn)	\
+	};								\
+	Z_INIT_ENTRY_DEFINE(_CONCAT(__device_, dev_name), init_fn,	\
+			    (&_CONCAT(__device_, dev_name)), level, prio)
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define Z_DEVICE_DEFINE_PM(dev_name)					\

--- a/include/devicetree/gpio.h
+++ b/include/devicetree/gpio.h
@@ -24,6 +24,47 @@ extern "C" {
  */
 
 /**
+ * @brief Get the node identifier for the controller phandle from a
+ *        gpio phandle-array property at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     gpio1: gpio@... { };
+ *
+ *     gpio2: gpio@... { };
+ *
+ *     n: node {
+ *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
+ *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_GPIO_CTLR_BY_IDX(DT_NODELABEL(n), gpios, 1) // DT_NODELABEL(gpio2)
+ *
+ * @param node_id node identifier
+ * @param gpio_pha lowercase-and-underscores GPIO property with
+ *        type "phandle-array"
+ * @param idx logical index into "gpio_pha"
+ * @return the node identifier for the gpio controller referenced at
+ *         index "idx"
+ * @see DT_PHANDLE_BY_IDX()
+ */
+#define DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx) \
+	DT_PHANDLE_BY_IDX(node_id, gpio_pha, idx)
+
+/**
+ * @brief Equivalent to DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, 0)
+ * @param node_id node identifier
+ * @param gpio_pha lowercase-and-underscores GPIO property with
+ *        type "phandle-array"
+ * @return the label property of the node referenced at index 0
+ * @see DT_GPIO_CTLR_BY_IDX()
+ */
+#define DT_GPIO_CTLR(node_id, gpio_pha) \
+	DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, 0)
+
+/**
  * @brief Get a label property from a gpio phandle-array property
  *        at an index
  *
@@ -58,7 +99,7 @@ extern "C" {
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, idx) \
-	DT_PROP_BY_PHANDLE_IDX(node_id, gpio_pha, idx, label)
+	DT_PROP(DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx), label)
 
 /**
  * @brief Equivalent to DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0)

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -39,7 +39,7 @@ static bool device_get_config_level(const struct shell *shell, int level)
 	bool devices = false;
 
 	for (dev = levels[level]; dev < levels[level+1]; dev++) {
-		if (z_device_ready(dev)) {
+		if (device_is_ready(dev)) {
 			devices = true;
 
 			shell_fprintf(shell, SHELL_NORMAL, "- %s\n", dev->name);
@@ -92,7 +92,7 @@ static int cmd_device_list(const struct shell *shell,
 	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (!z_device_ready(dev)) {
+		if (!device_is_ready(dev)) {
 			continue;
 		}
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -469,7 +469,7 @@ const struct device *shell_device_lookup(size_t idx,
 	const struct device *dev_end = dev + len;
 
 	while (dev < dev_end) {
-		if (z_device_ready(dev)
+		if (device_is_ready(dev)
 		    && (dev->name != NULL)
 		    && (strlen(dev->name) != 0)
 		    && ((prefix == NULL)

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -856,6 +856,18 @@ static void test_phandles(void)
 #define DT_DRV_COMPAT vnd_phandle_holder
 static void test_gpio(void)
 {
+	/* DT_GPIO_CTLR_BY_IDX */
+	zassert_true(!strcmp(TO_STRING(DT_GPIO_CTLR_BY_IDX(TEST_PH, gpios, 0)),
+			     TO_STRING(DT_NODELABEL(test_gpio_1))),
+		     "gpio 0 ctlr idx");
+	zassert_true(!strcmp(TO_STRING(DT_GPIO_CTLR_BY_IDX(TEST_PH, gpios, 1)),
+			     TO_STRING(DT_NODELABEL(test_gpio_2))),
+		     "gpio 1 ctlr idx");
+
+	/* DT_GPIO_CTLR */
+	zassert_true(!strcmp(TO_STRING(DT_GPIO_CTLR(TEST_PH, gpios)),
+			     TO_STRING(DT_NODELABEL(test_gpio_1))),
+		     "gpio 0 ctlr");
 
 	/* DT_GPIO_LABEL_BY_IDX */
 	zassert_true(!strcmp(DT_GPIO_LABEL_BY_IDX(TEST_PH, gpios, 0),


### PR DESCRIPTION
This pulls the macro refactorization out of #29644, allow driver implementations to define devices using information from devicetree nodes directly.  Ultimately this will enable storing device dependencies and other metadata inferred from the devicetree source.

Now it allows a well-defined unique public identifier for device structures that can be used to reference the device object at build time, avoiding the need for `device_get_binding()` and ultimately eliminating many uses of the `label` property as a device identifier.

The devicetree binding API for gpio has been updated to support this, and the blinky example to use the new capability.