### PR TITLE
fix various mis-use of work queue API

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -190,7 +190,7 @@ static void start(struct onoff_manager *mgr,
 		__ASSERT_NO_MSG(data->task == WORK_TASK_UNDEFINED);
 		data->task = WORK_TASK_ENABLE;
 		data->notify = notify;
-		k_work_submit(&data->delayed_work.work);
+		k_delayed_work_submit(&data->delayed_work, K_NO_WAIT);
 		return;
 	}
 #endif /* CONFIG_MULTITHREADING */
@@ -228,7 +228,7 @@ static void stop(struct onoff_manager *mgr,
 		__ASSERT_NO_MSG(data->task == WORK_TASK_UNDEFINED);
 		data->task = WORK_TASK_DISABLE;
 		data->notify = notify;
-		k_work_submit(&data->delayed_work.work);
+		k_delayed_work_submit(&data->delayed_work, K_NO_WAIT);
 		return;
 	}
 #endif /* CONFIG_MULTITHREADING */

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -438,7 +438,7 @@ void bt_mesh_beacon_ivu_initiator(bool enable)
 	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_INITIATOR, enable);
 
 	if (enable) {
-		k_work_submit(&beacon_timer.work);
+		k_delayed_work_submit(&beacon_timer, K_NO_WAIT);
 	} else if (!bt_mesh_beacon_enabled()) {
 		k_delayed_work_cancel(&beacon_timer);
 	}
@@ -455,13 +455,13 @@ static void subnet_beacon_enable(struct bt_mesh_subnet *sub)
 void bt_mesh_beacon_enable(void)
 {
 	if (!bt_mesh_is_provisioned()) {
-		k_work_submit(&beacon_timer.work);
+		k_delayed_work_submit(&beacon_timer, K_NO_WAIT);
 		return;
 	}
 
 	bt_mesh_subnet_foreach(subnet_beacon_enable);
 
-	k_work_submit(&beacon_timer.work);
+	k_delayed_work_submit(&beacon_timer, K_NO_WAIT);
 }
 
 void bt_mesh_beacon_disable(void)

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -239,7 +239,7 @@ uint8_t bt_mesh_hb_pub_set(struct bt_mesh_hb_pub *new_pub)
 	 * periodic publishing.
 	 */
 	if (pub.period && pub.count) {
-		k_work_submit(&pub_timer.work);
+		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
 	} else {
 		k_delayed_work_cancel(&pub_timer);
 	}
@@ -338,7 +338,7 @@ void bt_mesh_hb_start(void)
 {
 	if (pub.count && pub.period) {
 		BT_DBG("Starting heartbeat publication");
-		k_work_submit(&pub_timer.work);
+		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
 	}
 }
 
@@ -351,6 +351,6 @@ void bt_mesh_hb_resume(void)
 {
 	if (pub.period && pub.count) {
 		BT_DBG("Starting heartbeat publication");
-		k_work_submit(&pub_timer.work);
+		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
 	}
 }

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -221,7 +221,7 @@ void net_tc_tx_init(void)
 
 		NET_DBG("[%d] Starting TX queue %p stack size %zd "
 			"prio %d %s(%d)", i,
-			&tx_classes[i].work_q.queue,
+			&tx_classes[i].work_q,
 			K_KERNEL_STACK_SIZEOF(tx_stack[i]),
 			thread_priority,
 			IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE) ?
@@ -264,7 +264,7 @@ void net_tc_rx_init(void)
 
 		NET_DBG("[%d] Starting RX queue %p stack size %zd "
 			"prio %d %s(%d)", i,
-			&rx_classes[i].work_q.queue,
+			&rx_classes[i].work_q,
 			K_KERNEL_STACK_SIZEOF(rx_stack[i]),
 			thread_priority,
 			IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE) ?

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -75,7 +75,7 @@ static void delayed_test_items_init(void)
 
 	for (i = 0; i < NUM_TEST_ITEMS; i++) {
 		delayed_tests[i].key = i + 1;
-		k_work_init(&delayed_tests[i].work.work, work_handler);
+		k_delayed_work_init(&delayed_tests[i].work, work_handler);
 	}
 }
 
@@ -102,7 +102,7 @@ static void coop_work_main(int arg1, int arg2)
 
 	for (i = 1; i < NUM_TEST_ITEMS; i += 2) {
 		TC_PRINT(" - Submitting work %d from coop thread\n", i + 1);
-		k_work_submit(&delayed_tests[i].work.work);
+		k_delayed_work_submit(&delayed_tests[i].work, K_NO_WAIT);
 		k_msleep(SUBMIT_WAIT);
 	}
 }
@@ -121,7 +121,7 @@ static void delayed_test_items_submit(void)
 
 	for (i = 0; i < NUM_TEST_ITEMS; i += 2) {
 		TC_PRINT(" - Submitting work %d from preempt thread\n", i + 1);
-		k_work_submit(&delayed_tests[i].work.work);
+		k_delayed_work_submit(&delayed_tests[i].work, K_NO_WAIT);
 		k_msleep(SUBMIT_WAIT);
 	}
 }
@@ -194,10 +194,10 @@ static void test_resubmit(void)
 	TC_PRINT("Starting resubmit test\n");
 
 	delayed_tests[0].key = 1;
-	delayed_tests[0].work.work.handler = resubmit_work_handler;
+	k_delayed_work_init(&delayed_tests[0].work, resubmit_work_handler);
 
 	TC_PRINT(" - Submitting work\n");
-	k_work_submit(&delayed_tests[0].work.work);
+	k_delayed_work_submit(&delayed_tests[0].work, K_NO_WAIT);
 
 	TC_PRINT(" - Waiting for work to finish\n");
 	k_msleep(CHECK_WAIT);


### PR DESCRIPTION
Nothing in the API description of work structures sanctions direct reference to internal fields.  Do not assume that a delayed work item can be initialized in any way other than by invoking the delayed work item init function.  Do not assume that a delayed work item can be submitted without delay by invoking k_work_submit() with a reference to the contained work item.

Also do not directly reference the `k_queue` instance within the `k_work_q` object in diagnostic messages.

This is cleanup in support of #29618.