### PR TITLE
west.yml: update TF-M module manifest pointer

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 6edaaaaaa1a227cb1ccc9ef698a9d2e258a9bbd5
+      revision: a6e0516f8e04f6ac65b01f4fb3255122a1eb4453
 
   self:
     path: zephyr


### PR DESCRIPTION
Update manifest pointer for the TF-M module,
so it picks the bug fix for nRF5340 debug
authentication initialization.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

TF-M patch: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/32