### PR TITLE
BuildConfiguration.get() now returns string type value for string options, instead of array of sub-strings

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -128,6 +128,7 @@ class BuildConfiguration:
     def __init__(self, build_dir: str):
         self.build_dir = build_dir
         self.options: Dict[str, Union[str, int]] = {}
+        self.path = os.path.join(self.build_dir, 'zephyr', '.config')
         self._init()
 
     def __contains__(self, item):
@@ -140,7 +141,7 @@ class BuildConfiguration:
         return self.options.get(option, *args)
 
     def _init(self):
-        self._parse(os.path.join(self.build_dir, 'zephyr', '.config'))
+        self._parse(self.path)
 
     def _parse(self, filename: str):
         with open(filename, 'r') as f:

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -21,6 +21,7 @@ import shlex
 import shutil
 import signal
 import subprocess
+import re
 from typing import Dict, List, NamedTuple, NoReturn, Optional, Set, Type, \
     Union
 
@@ -144,23 +145,32 @@ class BuildConfiguration:
         self._parse(self.path)
 
     def _parse(self, filename: str):
+        opt_value = re.compile('^(?P<option>CONFIG_[A-Za-z0-9_]+)=(?P<value>.*)$')
+        not_set = re.compile('^# (?P<option>CONFIG_[A-Za-z0-9_]+) is not set$')
+
         with open(filename, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith('#'):
-                    continue
-                option, value = line.split('=', 1)
-                self.options[option] = self._parse_value(value)
+            lines = f.readlines()
 
-    @staticmethod
-    def _parse_value(value):
-        if value.startswith('"') or value.startswith("'"):
-            return value.split()
-        try:
-            return int(value, 0)
-        except ValueError:
-            return value
+        for line in lines:
+            match = opt_value.match(line)
+            if match:
+                value = match.group('value').rstrip()
+                if value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                else:
+                    try:
+                        base = 16 if value.startswith('0x') else 10
+                        self.options[match.group('option')] = int(value, base=base)
+                        continue
+                    except ValueError:
+                        pass
 
+                self.options[match.group('option')] = value
+                continue
+
+            match = not_set.match(line)
+            if match:
+                self.options[match.group('option')] = 'n'
 
 class MissingProgram(FileNotFoundError):
     '''FileNotFoundError subclass for missing program dependencies.

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -19,8 +19,7 @@ from build_helpers import find_build_dir, is_zephyr_build, \
     FIND_BUILD_DIR_DESCRIPTION
 from runners.core import BuildConfiguration
 from zcmake import CMakeCache
-from zephyr_ext_common import Forceable, load_dot_config, \
-    ZEPHYR_SCRIPTS
+from zephyr_ext_common import Forceable, ZEPHYR_SCRIPTS
 
 # This is needed to load edt.pickle files.
 sys.path.append(str(ZEPHYR_SCRIPTS / 'dts'))
@@ -222,17 +221,11 @@ class ImgtoolSigner(Signer):
         flash = self.edt_flash_node(b, args.quiet)
         align, addr, size = self.edt_flash_params(flash)
 
-        dot_config_file = b / 'zephyr' / '.config'
-        if not dot_config_file.is_file():
-            log.die(f"no .config found at {dot_config_file}")
-
-        dot_config = load_dot_config(dot_config_file)
-
-        if dot_config.get('CONFIG_BOOTLOADER_MCUBOOT', 'n') != 'y':
+        if bcfg.get('CONFIG_BOOTLOADER_MCUBOOT', 'n') != 'y':
             log.wrn("CONFIG_BOOTLOADER_MCUBOOT is not set to y in "
-                    f"{dot_config_file}; this probably won't work")
+                    f"{bcfg.path}; this probably won't work")
 
-        kernel = dot_config.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
+        kernel = bcfg.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         if 'bin' in formats:
             in_bin = b / 'zephyr' / f'{kernel}.bin'


### PR DESCRIPTION
The PR contains two changes:
1) changes the behavior of the `BuildConfiguration.get()` method that now returns strings instead of lists of sub-strings;
the real change has been done to `_parse_value()` method, which used to split found string into list of sub-strings, with a white-space being the split point, but the visibility is at the level of `BuildConfiguration.get()`;
2) ImgtoolSigner.sign() method has been altered to use `BuildConfiguration.get()` to obtain Kconfig options in places where `load_dot_config` obtained values have been used; this allowed to remove `load_dot_config` from the method and as a result prevented `.config` file from being loaded and parsed second time.