### PR TITLE
actions: Enable new manifest workflow

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,18 @@
+name: Manifest
+on:
+  - pull_request_target
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    name: Manifest
+    steps:
+      - name: Manifest
+        uses: zephyrproject-rtos/action-manifest@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          manifest-path: 'west.yml'
+          label-prefix: 'manifest-'
+          verbosity-level: '1'
+          labels: 'manifest, west'
+          dnm-labels: 'DNM'


### PR DESCRIPTION
The manifest workflow uses the manifest action to detect changes in the
west manifest. It then analyzes the changes and posts labels and a
comment in table format accordingly.

It is meant to be used as a helper bot for developers submitting changes
to modules, reducing the need for manual work and oversight and
automating common operations.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>