### PR TITLE
Bluetooth: Mesh: Only block mod_sub if status was requested

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1527,6 +1527,11 @@ static int mod_sub(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t elem_a
 		return err;
 	}
 
+	if (!status) {
+		cli_reset();
+		return 0;
+	}
+
 	return cli_wait();
 }
 


### PR DESCRIPTION
Adds a cli_reset to mod_sub if no status response was requested. This
adds a non-blocking mode to the mod_sub calls, matching the behavior of
other cfg_cli functions.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>