### PR TITLE
runners: nrfjprog: tweak nRF53 flash commands

### DIFF
--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -115,39 +115,39 @@ EXPECTED_COMMANDS = {
 
     # NRF53:
     '3NNN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--sectorerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
     '3NNY':
     (['nrfjprog', '--eraseall', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
-     ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
     '3NYN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--sectorerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     '3NYY':
     (['nrfjprog', '--eraseall', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
-     ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     '3YNN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--sectorerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
     '3YNY':
     (['nrfjprog', '--eraseall', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
-     ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
     '3YYN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--sectorerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     '3YYY':
     (['nrfjprog', '--eraseall', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
-     ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     # NRF91:


### PR DESCRIPTION
On nRF53, the network core should have --recover added to its nrfjprog
options. For consistency, apply the same change to the application
core. This implies not using --sectorerase on that family, since it
cannot be combined with --recover.

Additionally, commit d6c30eead0 ("nrfjprog.py: Fail if hex file has
UICR data and no --erase") broke the guarantee that --tool-opt is
provided last on the command which is used for flashing. This is
important to make sure that the user's wish overrides the settings in
the runner file and is a general practice within the flash/debug
runners. Restore the desired behavior.