### PR TITLE
drivers: usb_dc_nrfx: remove k_mem_pool_free for IN endpoints

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -690,7 +690,6 @@ static void eps_ctx_uninit(void)
 	for (i = 0U; i < CFG_EPIN_CNT; i++) {
 		ep_ctx = in_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
-		k_mem_pool_free(&ep_ctx->buf.block);
 		memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
@@ -704,7 +703,6 @@ static void eps_ctx_uninit(void)
 	if (CFG_EP_ISOIN_CNT) {
 		ep_ctx = in_endpoint_ctx(NRF_USBD_EPIN(8));
 		__ASSERT_NO_MSG(ep_ctx);
-		k_mem_pool_free(&ep_ctx->buf.block);
 		memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 


### PR DESCRIPTION
Usage of mem_pool for all IN endpoints was removed in
commit b3c63425a062 ("usb: driver: Reduce Endpoint buffer pool.")
Remove also k_mem_pool_free for all IN endpoints.

Fixes: #30213