### PR TITLE
boards: nulceo_l552ze_q: Enable MPU on ns target

### DIFF
--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns_defconfig
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns_defconfig
@@ -38,12 +38,7 @@ CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
 # Enable MPU
-# Issue #27809
-# TFM integration sample tfm_ipc doesn't work when the MPU is enabled.
-# In TF-M, for the nucleo_l552ze_q, TFM_BOOT_MPU_PROTECTION configures and
-# enables a secure MPU and a non secure MPU. Either CONFIG_ARM_MPU or
-# TFM_BOOT_MPU_PROTECTION must be disabled.
-#CONFIG_ARM_MPU=y
+CONFIG_ARM_MPU=y
 
 CONFIG_ARM_TRUSTZONE_M=y
 CONFIG_CORTEX_M_SYSTICK=y


### PR DESCRIPTION
The bug on TFM that prevented to enable MPU on NS side is
fixed on TFM current version.
MPU can now be safely enabled on NS target.

Fixes: #27809

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>