### PR TITLE
samples: net: zperf: Fix timeout value for native_posix

### DIFF
--- a/samples/net/zperf/src/zperf_tcp_uploader.c
+++ b/samples/net/zperf/src/zperf_tcp_uploader.c
@@ -99,7 +99,7 @@ void zperf_tcp_upload(const struct shell *shell,
 		}
 
 #if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(K_MSEC(100) * USEC_PER_MSEC);
+		k_busy_wait(100 * USEC_PER_MSEC);
 #else
 		k_yield();
 #endif

--- a/samples/net/zperf/src/zperf_udp_uploader.c
+++ b/samples/net/zperf/src/zperf_udp_uploader.c
@@ -260,7 +260,7 @@ void zperf_udp_upload(const struct shell *shell,
 
 		/* Wait */
 #if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(K_MSEC(100) * USEC_PER_MSEC);
+		k_busy_wait(USEC_PER_MSEC);
 #else
 		while (time_delta(loop_time, k_cycle_get_32()) < delay) {
 			k_yield();


### PR DESCRIPTION
In native_posix, the code calls k_busy_wait() but with wrong
value (k_timeout_t instead of int).

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>