### PR TITLE
drivers: flash: flash_stm32g4x.c: manage bank1/2 discontinuity

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -70,6 +70,12 @@ static const struct flash_parameters flash_stm32_parameters = {
 #endif
 };
 
+
+int __weak flash_stm32_check_configuration(void)
+{
+	return 0;
+}
+
 #if defined(CONFIG_MULTITHREADING)
 /*
  * This is named flash_stm32_sem_take instead of flash_stm32_lock (and
@@ -346,6 +352,7 @@ static const struct flash_driver_api flash_stm32_api = {
 
 static int stm32_flash_init(const struct device *dev)
 {
+	int rc;
 #if defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32F1X) || \
@@ -382,6 +389,12 @@ static int stm32_flash_init(const struct device *dev)
 
 	LOG_DBG("Flash initialized. BS: %zu",
 		flash_stm32_parameters.write_block_size);
+
+	/* Check Flash configuration */
+	rc = flash_stm32_check_configuration();
+	if (rc < 0) {
+		return rc;
+	}
 
 #if ((CONFIG_FLASH_LOG_LEVEL >= LOG_LEVEL_DBG) && CONFIG_FLASH_PAGE_LAYOUT)
 	const struct flash_pages_layout *layout;

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -233,3 +233,16 @@ void flash_stm32_page_layout(const struct device *dev,
 	*layout = stm32g4_flash_layout;
 	*layout_size = ARRAY_SIZE(stm32g4_flash_layout);
 }
+
+/* Override weak function */
+int  flash_stm32_check_configuration(void)
+{
+#if defined(FLASH_OPTR_DBANK)
+	if (READ_BIT(FLASH->OPTR, FLASH_OPTR_DBANK) == 0U) {
+		/* Single bank not supported when dualbank is possible */
+		LOG_ERR("Single bank configuration not supported");
+		return -ENOTSUP;
+	}
+#endif
+	return 0;
+}


### PR DESCRIPTION
drivers: flash: flash_stm32g4x.c: manage bank1/2 discontinuity

When flash is Dualbank and flash size is lower than 512K,
then there is a discontinutity between bank1 and bank2.

Fixes #30148
