### PR TITLE
dts: bindings: add IRQ priority support for SiFive PLIC

### DIFF
--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -15,7 +15,8 @@ properties:
       required: true
 
   "#interrupt-cells":
-      const: 1
+      const: 2
 
 interrupt-cells:
   - irq
+  - priority

--- a/dts/riscv/microsemi-miv.dtsi
+++ b/dts/riscv/microsemi-miv.dtsi
@@ -42,7 +42,7 @@
 		};
 
 		plic: interrupt-controller@40000000 {
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -40,7 +40,7 @@
 		aon: aon@10000000 {
 			compatible = "sifive,aon0";
 			interrupt-parent = <&plic>;
-			interrupts = <1 2>;
+			interrupts = <1 1>, <2 1>;
 			reg = <0x10000000 0x1000>;
 			reg-names = "control";
 		};
@@ -72,8 +72,14 @@
 			compatible = "sifive,gpio0";
 			gpio-controller;
 			interrupt-parent = <&plic>;
-			interrupts = <8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
-				26 27 28 29 30 31 32 33 34 35 36 37 38 39>;
+			interrupts = <8 1>, <9 1>, <10 1>, <11 1>,
+				<12 1>, <13 1>, <14 1>, <15 1>,
+				<16 1>, <17 1>, <18 1>, <19 1>,
+				<20 1>, <21 1>, <22 1>, <23 1>,
+				<24 1>, <25 1>, <26 1>, <27 1>,
+				<28 1>, <29 1>, <30 1>, <31 1>,
+				<32 1>, <33 1>, <34 1>, <35 1>,
+				<36 1>, <37 1>, <38 1>, <39 1>;
 			reg = <0x10012000 0x1000>;
 			reg-names = "control";
 			label = "gpio_0";
@@ -83,7 +89,7 @@
 		i2c0: i2c@10016000 {
 			compatible = "sifive,i2c0";
 			interrupt-parent = <&plic>;
-			interrupts = <52>;
+			interrupts = <52 1>;
 			reg = <0x10016000 0x1000>;
 			reg-names = "control";
 			label = "i2c_0";
@@ -92,7 +98,7 @@
 			#size-cells = <0>;
 		};
 		plic: interrupt-controller@c000000 {
-			#interrupt-cells = <1>;
+			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
@@ -121,7 +127,7 @@
 		pwm0: pwm@10015000 {
 			compatible = "sifive,pwm0";
 			interrupt-parent = <&plic>;
-			interrupts = <40 41 42 43>;
+			interrupts = <40 1>, <41 1>, <42 1>, <43 1>;
 			reg = <0x10015000 0x1000>;
 			reg-names = "control";
 			label = "pwm_0";
@@ -132,7 +138,7 @@
 		pwm1: pwm@10025000 {
 			compatible = "sifive,pwm0";
 			interrupt-parent = <&plic>;
-			interrupts = <44 45 46 47>;
+			interrupts = <44 1>, <45 1>, <46 1>, <47 1>;
 			reg = <0x10025000 0x1000>;
 			reg-names = "control";
 			label = "pwm_1";
@@ -143,7 +149,7 @@
 		pwm2: pwm@10035000 {
 			compatible = "sifive,pwm0";
 			interrupt-parent = <&plic>;
-			interrupts = <48 49 50 51>;
+			interrupts = <48 1>, <49 1>, <50 1>, <51 1>;
 			reg = <0x10035000 0x1000>;
 			reg-names = "control";
 			label = "pwm_2";
@@ -164,7 +170,7 @@
 		uart0: serial@10013000 {
 			compatible = "sifive,uart0";
 			interrupt-parent = <&plic>;
-			interrupts = <3>;
+			interrupts = <3 1>;
 			reg = <0x10013000 0x1000>;
 			reg-names = "control";
 			label = "uart_0";
@@ -173,7 +179,7 @@
 		uart1: serial@10023000 {
 			compatible = "sifive,uart0";
 			interrupt-parent = <&plic>;
-			interrupts = <4>;
+			interrupts = <4 1>;
 			reg = <0x10023000 0x1000>;
 			reg-names = "control";
 			label = "uart_1";
@@ -182,7 +188,7 @@
 		spi0: spi@10014000 {
 			compatible = "sifive,spi0";
 			interrupt-parent = <&plic>;
-			interrupts = <5>;
+			interrupts = <5 1>;
 			reg = <0x10014000 0x1000 0x20000000 0x20000000>;
 			reg-names = "control", "mem";
 			label = "spi_0";
@@ -193,7 +199,7 @@
 		spi1: spi@10024000 {
 			compatible = "sifive,spi0";
 			interrupt-parent = <&plic>;
-			interrupts = <6>;
+			interrupts = <6 1>;
 			reg = <0x10024000 0x1000>;
 			reg-names = "control";
 			label = "spi_1";
@@ -204,7 +210,7 @@
 		spi2: spi@10034000 {
 			compatible = "sifive,spi0";
 			interrupt-parent = <&plic>;
-			interrupts = <7>;
+			interrupts = <7 1>;
 			reg = <0x10034000 0x1000>;
 			reg-names = "control";
 			label = "spi_2";


### PR DESCRIPTION
This patch adds IRQ priority support for SiFive PLIC by device-tree.
Some IRQ sources of plic use Kconfig to set priority of their IRQ.

- AON: no driver
- I2C, SPI, PWM: not use IRQ
- GPIO, UART: default 1

So this patch specifies IRQ priority 1 for all sources.

Currently these drivers (gpio and uart) do not support that they get
and use IRQ priority from device-tree. We need more patches.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>