### PR TITLE
Missing dependency in Windows instructions

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -148,7 +148,7 @@ Next, you'll install some host dependencies using your package manager.
          .. code-block:: console
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-            choco install ninja gperf python git
+            choco install ninja gperf python git nrfjprog
 
       #. Open a new ``cmd.exe`` window **as a regular user** to continue.
 


### PR DESCRIPTION
I needed to run `choco install nrfjprog` before `west flash` worked on my Windows 10 machine. This dependency is missing in the instructions.

It takes a while to parse the error message given by CMake when `west flash` is run. It would make it easier to get started for people not experienced with CMake and Chocolatey to have this instruction written out.