### PR TITLE
runners: nrfjprog: boilerplate and erase rework

### DIFF
--- a/boards/arm/actinius_icarus/board.cmake
+++ b/boards/arm/actinius_icarus/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bbc_microbit/board.cmake
+++ b/boards/arm/bbc_microbit/board.cmake
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf51")
-board_runner_args(nrfjprog "--nrf-family=NRF51")
 board_runner_args(jlink "--device=nrf51" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/bl652_dvk/board.cmake
+++ b/boards/arm/bl652_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bl653_dvk/board.cmake
+++ b/boards/arm/bl653_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/bl654_dvk/board.cmake
+++ b/boards/arm/bl654_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bt510/board.cmake
+++ b/boards/arm/bt510/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/circuitdojo_feather_nrf9160/board.cmake
+++ b/boards/arm/circuitdojo_feather_nrf9160/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/degu_evk/board.cmake
+++ b/boards/arm/degu_evk/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2019 Atmark Techno, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/holyiot_yj16019/board.cmake
+++ b/boards/arm/holyiot_yj16019/board.cmake
@@ -1,4 +1,4 @@
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf21540dk_nrf52840/board.cmake
+++ b/boards/arm/nrf21540dk_nrf52840/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf51_ble400/board.cmake
+++ b/boards/arm/nrf51_ble400/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF51")
 board_runner_args(jlink "--device=nrf51" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf51dk_nrf51422/board.cmake
+++ b/boards/arm/nrf51dk_nrf51422/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF51")
 board_runner_args(jlink "--device=nrf51" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf51dongle_nrf51422/board.cmake
+++ b/boards/arm/nrf51dongle_nrf51422/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF51")
 board_runner_args(jlink "--device=nrf51" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52833dk_nrf52820/board.cmake
+++ b/boards/arm/nrf52833dk_nrf52820/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52820" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52833dk_nrf52833/board.cmake
+++ b/boards/arm/nrf52833dk_nrf52833/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52840_papyr/board.cmake
+++ b/boards/arm/nrf52840_papyr/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52840dk_nrf52811/board.cmake
+++ b/boards/arm/nrf52840dk_nrf52811/board.cmake
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52840dk_nrf52840/board.cmake
+++ b/boards/arm/nrf52840dk_nrf52840/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52840dongle_nrf52840/board.cmake
+++ b/boards/arm/nrf52840dongle_nrf52840/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52_adafruit_feather/board.cmake
+++ b/boards/arm/nrf52_adafruit_feather/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf52dk_nrf52805/board.cmake
+++ b/boards/arm/nrf52dk_nrf52805/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52dk_nrf52810/board.cmake
+++ b/boards/arm/nrf52dk_nrf52810/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52dk_nrf52832/board.cmake
+++ b/boards/arm/nrf52dk_nrf52832/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -6,12 +6,10 @@ endif()
 
 if((CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPPNS) OR
   (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPPNS))
-board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_APPLICATION")
 board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
 if(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUNET OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
-board_runner_args(nrfjprog "--nrf-family=NRF53" "--tool-opt=--coprocessor CP_NETWORK")
 board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()
 

--- a/boards/arm/nrf5340dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340dk_nrf5340/doc/index.rst
@@ -255,9 +255,20 @@ Flashing
 
 Follow the instructions in the :ref:`nordic_segger` page to install
 and configure all the necessary software. Further information can be
-found in :ref:`nordic_segger_flashing`. Then build and flash
-applications as usual (see :ref:`build_an_application` and
+found in :ref:`nordic_segger_flashing`. Then you can build and flash
+applications as usual (:ref:`build_an_application` and
 :ref:`application_run` for more details).
+
+.. warning::
+
+   The nRF5340 has a flash read-back protection feature. When flash read-back
+   protection is active, you will need to recover the chip before reflashing.
+   If you are flashing with :ref:`west <west-build-flash-debug>`, run
+   this command for more details on the related ``--recover`` option:
+
+   .. code-block:: console
+
+      west flash -H -r nrfjprog --skip-rebuild
 
 .. note::
 

--- a/boards/arm/nrf9160_innblue21/board.cmake
+++ b/boards/arm/nrf9160_innblue21/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 InnBlue
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160_innblue22/board.cmake
+++ b/boards/arm/nrf9160_innblue22/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 InnBlue
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160dk_nrf52840/board.cmake
+++ b/boards/arm/nrf9160dk_nrf52840/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -4,7 +4,6 @@ if(CONFIG_BOARD_NRF9160DK_NRF9160NS)
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/particle_argon/board.cmake
+++ b/boards/arm/particle_argon/board.cmake
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/particle_boron/board.cmake
+++ b/boards/arm/particle_boron/board.cmake
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/particle_xenon/board.cmake
+++ b/boards/arm/particle_xenon/board.cmake
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/pinnacle_100_dvk/board.cmake
+++ b/boards/arm/pinnacle_100_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/ruuvi_ruuvitag/board.cmake
+++ b/boards/arm/ruuvi_ruuvitag/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 Ruuvi Innovations Ltd (Oy)
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/thingy52_nrf52832/board.cmake
+++ b/boards/arm/thingy52_nrf52832/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Rework the runner to improve various issues.

Every board.cmake file for an nRF SoC target is repeating boilerplate
needed for the nrfjprog runner's --nrf-family argument. The
information we need to decide the --nrf-family is already available in
Kconfig, so just get it from there instead. Keep the --nrf-family
argument around for compatibility, though.

This cuts boilerplate burden for board maintainers.

We also need to revisit how this runner handles recovery to fix it
in nRF53 and keep things consistent everywhere else.

To cleanly handle additional readback protection features in nRF53,
add a --recover option that does an 'nrfjprog --recover' before
flashing. Keep the behavior consistent across SoCs by supporting it on
those too. Because this is expected to be a bit tricky for users to
understand, check if a --recover is needed if the 'nrfjprog --program'
fails because of protection, and tell the user how to fix it.

Finally, instead of performing a separate 'nrfjprog --eraseall', just
give --chiperase to 'nrfjprog --program' process's arguments instead
of --sectorerase. This is cleaner, resulting in fewer subprocesses and
avoiding an extra chip reset.

Having a separate 'west flash --recover' option doubles the number of
test cases if we want to keep exhaustively enumerating them. That
doesn't feel worthwhile, so update the test cases by picking a
representative subset of the possibilities. Each test now has enough
state that it's worth wrapping it up in a named tuple for readability.
