### PR TITLE
Bluetooth: controller: Fix corruption of footer auto-variable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -254,8 +254,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	/* Enqueue the rx in aux context */
 	if (aux->rx_last) {
-		ftr = &aux->rx_last->rx_ftr;
-		ftr->extra = rx;
+		aux->rx_last->rx_ftr.extra = rx;
 	} else {
 		aux->rx_head = rx;
 	}


### PR DESCRIPTION
Fix corruption of ftr auto-variable due to reuse to insert
new node rx into the received auxiliary PDU chain, which can
cause corrupt reference used later in the implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>