### PR TITLE
bluetooth: host: Disallow directed adv options on undirected adv

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7946,6 +7946,12 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 		}
 	}
 
+	if ((param->options & (BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY |
+			       BT_LE_ADV_OPT_DIR_ADDR_RPA)) &&
+	    !param->peer) {
+		return false;
+	}
+
 	if ((param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY) ||
 	    !param->peer) {
 		if (param->interval_min > param->interval_max ||


### PR DESCRIPTION
Previously, if the peer address was not set, the host would
do undirected advertising even if the application instructed
the stack to do directed advertising.

Adding this additional parameter validation reduces the confusion
of application developers when they have configured something wrong.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>