### PR TITLE
Target properties for paths to TFM executables

### DIFF
--- a/boards/arm/lpcxpresso55s69/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s69/CMakeLists.txt
@@ -42,7 +42,7 @@ if (CONFIG_BUILD_WITH_TFM)
 		#offset needs to be the same value as flash_layout.h in TFM
 		set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 			COMMAND ${SREC_CAT}
-			ARGS ${CMAKE_BINARY_DIR}/tfm/bin/tfm_s.bin -Binary
+			ARGS $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE> -Binary
 				${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME} -Binary
 				-offset ${CONFIG_FLASH_LOAD_OFFSET}
 				-o ${CMAKE_BINARY_DIR}/tfm_merged.bin -Binary
@@ -63,7 +63,7 @@ if (CONFIG_BUILD_WITH_TFM)
 				${ADD_NS_IMAGE_MIN_VER}
 				-s auto
 				-H ${CONFIG_ROM_START_OFFSET}
-				${CMAKE_BINARY_DIR}/tfm/bin/tfm_s.bin
+				$<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 				${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 			#Sign non-secure binary image with public key
@@ -87,7 +87,7 @@ if (CONFIG_BUILD_WITH_TFM)
 				-o ${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 			#Copy mcuboot.bin
-			COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 			#Merge mcuboot.bin and tfm_sign.bin for flashing
 			COMMAND ${SREC_CAT}

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -47,7 +47,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 ${ADD_NS_IMAGE_MIN_VER}
 			 -s auto
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/MPS2/AN521/tfm_s.bin
+			 $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 		#Sign non-secure binary image with public key
@@ -71,7 +71,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#Merge mcuboot.bin and tfm_sign.bin for QEMU
 		COMMAND ${SREC_CAT}

--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -70,7 +70,7 @@ if (CONFIG_BUILD_WITH_TFM)
 				${ADD_NS_IMAGE_MIN_VER}
 				-s auto
 				-H 0x400
-				${TFM_INSTALL_DIR}/tfm_s.bin
+				$<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 				${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 			#Sign non-secure binary image with public key
@@ -94,7 +94,7 @@ if (CONFIG_BUILD_WITH_TFM)
 				-o ${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 			#Copy mcuboot.bin
-			COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 			# Generate an intel hex file from the signed output binary
 			COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin

--- a/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
+++ b/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
@@ -47,7 +47,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 ${ADD_NS_IMAGE_MIN_VER}
 			 -s auto
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/NORDIC_NRF/NRF9160DK_NRF9160/tfm_s.bin
+			 $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 		#Sign non-secure binary image with public key
@@ -71,7 +71,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		# Generate an intel hex file from the signed output binary
 		COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin

--- a/boards/arm/nucleo_l552ze_q/CMakeLists.txt
+++ b/boards/arm/nucleo_l552ze_q/CMakeLists.txt
@@ -43,7 +43,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 ${ADD_NS_IMAGE_MIN_VER}
 			 -s auto
 			 -H 0x400
-			 ${CMAKE_BINARY_DIR}/tfm/install/outputs/STM/NUCLEO_L552ZE_Q/tfm_s.bin
+			 $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 			 ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 
 		#Sign non-secure binary image with public key
@@ -60,7 +60,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			 ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#Execute post build script postbuild.sh
 		COMMAND ${CMAKE_BINARY_DIR}/tfm/postbuild.sh ${COMPILER_FULL_PATH}

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -38,7 +38,7 @@ if (CONFIG_BUILD_WITH_TFM)
 		# Create concatenated binary image from the two binary files
 		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
 		    --layout ${PREPROCESSED_FILE_NS}
-			-s ${CMAKE_BINARY_DIR}/tfm/install/outputs/MUSCA_B1/tfm_s.bin
+			-s $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE>
 			-n ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
 			-o ${CMAKE_BINARY_DIR}/tfm_full.bin
 
@@ -58,7 +58,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			${CMAKE_BINARY_DIR}/tfm_sign.bin
 
 		#Copy mcuboot.bin
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm/bin/bl2.bin ${CMAKE_BINARY_DIR}/mcuboot.bin
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		#srec_cat to combine images into hex for drag and drop
 		COMMAND ${SREC_CAT}

--- a/samples/tfm_integration/tfm_integration.rst
+++ b/samples/tfm_integration/tfm_integration.rst
@@ -96,6 +96,35 @@ For Windows-based systems, please make sure you have a copy of the utility
 available on your system path. See, for example:
 `SRecord for Windows <http://srecord.sourceforge.net/windows.html>`_
 
+Images Created by the TF-M Build
+================================
+
+The TF-M build system creates executable files:
+
+* tfm_s - the secure firmware
+* tfm_ns - a nonsecure app which is discarded in favor of the Zephyr app
+* bl2 - mcuboot, if enabled
+
+For each of these, it creates .bin, .hex, .elf, and .axf files.
+
+The TF-M build system also creates signed variants of tfm_s and tfm_ns, and a file which combines them:
+
+* tfm_s_signed
+* tfm_ns_signed
+* tfm_s_ns_signed
+
+For each of these, only .bin files are created.
+The Zephyr build system usually signs both tfm_s and the Zephyr app itself, see below.
+
+The 'tfm' target contains properties for all these paths.
+For example, the following will resolve to ``<path>/tfm_s.hex``:
+
+   .. code-block::
+
+      $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
+
+See the top level CMakeLists.txt file in the tfm module for an overview of all the properties.
+
 Signing Images
 ==============
 


### PR DESCRIPTION
Exposes paths to TFM executables as target properties on the `tfm` target, so that knowledge about these paths is centralized.

TFM PR: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/34