### PR TITLE
boards: stm3f4_disco: Fix button gpio config

### DIFF
--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -45,7 +45,7 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
 


### PR DESCRIPTION
According to boards schematics, user button is pulled down by
external resistor when not pressed and pushing the button sets
it to high.

Fixes #30224

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>


Follows closing of https://github.com/zephyrproject-rtos/zephyr/pull/30225