### PR TITLE
arch: arm: cortex-m: Don't enable IRQs before main() when no IRQ table is present

### DIFF
--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -582,6 +582,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 	"msr  PSPLIM, %[_psplim]\n\t"
 #endif
 	"msr  PSP, %[_psp]\n\t"       /* __set_PSP(psp) */
+#if defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	"cpsie i\n\t"         /* enable_irq() */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -590,6 +591,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 	"msr   BASEPRI, r3\n\t"	/* __set_BASEPRI(0) */
 #endif
 	"isb\n\t"
+#endif
 	"blx  %[_main_entry]\n\t"     /* main_entry(p1, p2, p3) */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	"cpsid i\n\t"         /* disable_irq() */


### PR DESCRIPTION

Don't enable IRQs before main() when no vector table is present in cortex-m
builds in single-thread mode
(CONFIG_GEN_IRQ_VECTOR_TABLE=n)
(CONFIG_MULTITHREADING=n).

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>