### PR TITLE
Bluetooth: Mesh: Fix friend node establishment and message

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1250,9 +1250,9 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 				BT_ERR("Failed updating friend cred for 0x%04x",
 				       frnd->lpn);
 				friend_clear(frnd);
-				break;
 			}
-
+			break;
+		case BT_MESH_KEY_SWAPPED:
 			enqueue_update(frnd, 0);
 			break;
 		case BT_MESH_KEY_REVOKED:

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -615,10 +615,6 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
 
-		if (!frnd->established) {
-			continue;
-		}
-
 		if (!frnd->subnet) {
 			continue;
 		}

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -727,7 +727,7 @@ static int sdu_recv(struct bt_mesh_net_rx *rx, uint8_t hdr, uint8_t aszmic,
 			.aszmic = aszmic,
 			.src = rx->ctx.addr,
 			.dst = rx->ctx.recv_dst,
-			.seq_num = rx->seq,
+			.seq_num = seg ? (seg->seq_auth & 0xffffff) : rx->seq,
 			.iv_index = BT_MESH_NET_IVI_RX(rx),
 		},
 		.buf = buf,
@@ -1442,9 +1442,6 @@ found_rx:
 	k_delayed_work_cancel(&rx->ack);
 	send_ack(net_rx->sub, net_rx->ctx.recv_dst, net_rx->ctx.addr,
 		 net_rx->ctx.send_ttl, seq_auth, rx->block, rx->obo);
-
-	/* Decrypt with seqAuth */
-	net_rx->seq = (rx->seq_auth & 0xffffff);
 
 	if (net_rx->ctl) {
 		NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_RX_CTL_MAX);


### PR DESCRIPTION
Fix friend node unable decrypt friend_cred encrypt poll message
when friendship not establishment.

Fix friend node cache segment message for given lpn with same
sequence number, cause to lpn replay attack.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>