### PR TITLE
actions: Add labels for Bluetooth Controller/Host

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -100,6 +100,11 @@
   - "**/*bluetooth*"
 "area: Bluetooth Mesh":
   - "subsys/bluetooth/mesh/**/*"
+"area: Bluetooth Controller":
+  - "subsys/bluetooth/controller/**/*"
+"area: Bluetooth Host":
+  - "subsys/bluetooth/host/**/*"
+  - "subsys/bluetooth/services/**/*"
 "area: API":
   - "include/**/*"
 "area: Samples":


### PR DESCRIPTION
Automatically assign the Bluetooth Controller and
Bluetooth Host labels to changes in the controller and
host respecitvely. For this, both Mesh and the Gatt services
will be considered part of the host.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>