### PR TITLE
drivers: console: Fix path to mcumgr header

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -32,7 +32,7 @@
 #include <sys/atomic.h>
 #include <sys/printk.h>
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
-#include "mgmt/serial.h"
+#include "mgmt/mcumgr/serial.h"
 #endif
 
 static const struct device *uart_console_dev;


### PR DESCRIPTION
The mcumgr header files are now in include/mgmt/mcumgr/, so reflect this
change in the UART console implementation.

Fixes #30261.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>