### PR TITLE
OpenOCD configuration fixes for HSDK

### DIFF
--- a/boards/arc/hsdk/support/openocd-2-cores.cfg
+++ b/boards/arc/hsdk/support/openocd-2-cores.cfg
@@ -41,6 +41,10 @@ set _CHIPNAME arc-em
 
 # OpenOCD discovers JTAG TAPs in reverse order.
 
+set _TARGETNAME4 $_CHIPNAME.cpu4
+jtag newtap $_CHIPNAME cpu4 -irlen 4 -ircapture 0x1 -expected-id 0x200c24b1
+set _TARGETNAME3 $_CHIPNAME.cpu3
+jtag newtap $_CHIPNAME cpu3 -irlen 4 -ircapture 0x1 -expected-id 0x200824b1
 set _TARGETNAME2 $_CHIPNAME.cpu2
 jtag newtap $_CHIPNAME cpu2 -irlen 4 -ircapture 0x1 -expected-id 0x200424b1
 set _TARGETNAME1 $_CHIPNAME.cpu1

--- a/boards/arc/hsdk/support/openocd-2-cores.cfg
+++ b/boards/arc/hsdk/support/openocd-2-cores.cfg
@@ -5,7 +5,7 @@
 # Configure JTAG cable
 # SDP has built-in FT2232 chip, which is similar to Digilent HS-1, except that
 # it uses channgel B for JTAG, instead of channel A.
-interface ftdi
+adapter driver ftdi
 
 # Only specify FTDI serial number if it is specified via
 # "set _ZEPHYR_BOARD_SERIAL 12345" before reading this script
@@ -18,7 +18,7 @@ ftdi_layout_init 0x0088 0x008b
 ftdi_channel 1
 
 
-adapter_khz 10000
+adapter speed 10000
 
 # ARCs supports only JTAG.
 transport select jtag
@@ -59,7 +59,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 2.
-$_TARGETNAME2 arc has-l2cache true
+$_TARGETNAME2 arc cache l2 auto 1
 
 ################################
 # ARC HS38 core 1
@@ -74,7 +74,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 1.
-$_TARGETNAME1 arc has-l2cache true
+$_TARGETNAME1 arc cache l2 auto 1
 
 target smp $_TARGETNAME1 $_TARGETNAME2
 

--- a/boards/arc/hsdk/support/openocd.cfg
+++ b/boards/arc/hsdk/support/openocd.cfg
@@ -1,11 +1,11 @@
-#  Copyright (C) 2019 Synopsys, Inc.
+#  Copyright (C) 2019-2020 Synopsys, Inc.
 #  SPDX-License-Identifier: Apache-2.0
 #
 
 # Configure JTAG cable
 # SDP has built-in FT2232 chip, which is similar to Digilent HS-1, except that
 # it uses channgel B for JTAG, instead of channel A.
-interface ftdi
+adapter driver ftdi
 
 # Only specify FTDI serial number if it is specified via
 # "set _ZEPHYR_BOARD_SERIAL 12345" before reading this script
@@ -18,7 +18,7 @@ ftdi_layout_init 0x0088 0x008b
 ftdi_channel 1
 
 
-adapter_khz 10000
+adapter speed 10000
 
 # ARCs supports only JTAG.
 transport select jtag
@@ -63,8 +63,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 2.
-$_TARGETNAME2 arc has-l2cache true
-
+$_TARGETNAME2 arc cache l2 auto 1
 
 ################################
 # ARC HS38 core 3
@@ -79,7 +78,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 3.
-$_TARGETNAME3 arc has-l2cache true
+$_TARGETNAME3 arc cache l2 auto 1
 
 ################################
 # ARC HS38 core 4
@@ -95,7 +94,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 4.
-$_TARGETNAME4 arc has-l2cache true
+$_TARGETNAME4 arc cache l2 auto 1
 
 ################################
 # ARC HS38 core 1
@@ -110,7 +109,7 @@ set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
 # Enable L2 cache support for core 1.
-$_TARGETNAME1 arc has-l2cache true
+$_TARGETNAME1 arc cache l2 auto 1
 
 target smp $_TARGETNAME1 $_TARGETNAME2 $_TARGETNAME3 $_TARGETNAME4
 


### PR DESCRIPTION
This PR addresses 2 issues, both in OpenOCD configuration scripts:

1. Dual-core version of HSDK (though remember HW is still the same quad-core, we just use 2 of 4 cores) has incomplete JTAG chain description and most of tests won't print anything on console even because images are loaded into wrong cores.
2. With newer version of OpenOCD in Zephyr's SDK v0.12 ARC support was merged from upstream instead of old good pre-upstream fork, there some options were renamed so to make OpenOCD happy again we need to do corresponding fix-ups.

Well and with these changes in place we're getting very promising `sanitycheck` results:
| Board       	| Pass 	| Fail 	|
|-------------	|------	|------	|
| hsdk        	| 155  	| 7    	|
| hsdk_2cores 	| 160  	| 2    	|
