### PR TITLE
kernel/init.c cleanup: move banner and XIP code out

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND kernel_files
   version.c
   work_q.c
   smp.c
+  banner.c
   )
 
 if(CONFIG_XIP)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 # kernel is a normal CMake library and not a zephyr_library because it
 # should not be --whole-archive'd
-add_library(kernel
+
+list(APPEND kernel_files
   device.c
   errno.c
   fatal.c
@@ -25,6 +26,13 @@ add_library(kernel
   work_q.c
   smp.c
   )
+
+if(CONFIG_XIP)
+list(APPEND kernel_files
+     xip.c)
+endif()
+
+add_library(kernel ${kernel_files})
 
 # Kernel files has the macro __ZEPHYR_SUPERVISOR__ set so that it
 # optimizes the code when userspace is enabled.

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <sys/util.h>
+#include <init.h>
+#include <device.h>
+#include <version.h>
+
+/* boot banner items */
+#if defined(CONFIG_MULTITHREADING) && defined(CONFIG_BOOT_DELAY) &&            \
+	CONFIG_BOOT_DELAY > 0
+#define BOOT_DELAY_BANNER " (delayed boot " STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
+#else
+#define BOOT_DELAY_BANNER ""
+#endif
+
+#if defined(CONFIG_BOOT_DELAY) || CONFIG_BOOT_DELAY > 0
+void boot_banner(void)
+{
+#if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
+	static const unsigned int boot_delay = CONFIG_BOOT_DELAY;
+#else
+	static const unsigned int boot_delay;
+#endif
+
+	if (boot_delay > 0 && IS_ENABLED(CONFIG_MULTITHREADING)) {
+		printk("***** delaying boot " STRINGIFY(
+			CONFIG_BOOT_DELAY) "ms (per build configuration) *****\n");
+		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
+	}
+
+#if defined(CONFIG_BOOT_BANNER)
+#ifdef BUILD_VERSION
+	printk("*** Booting Zephyr OS build %s %s ***\n",
+	       STRINGIFY(BUILD_VERSION), BOOT_DELAY_BANNER);
+#else
+	printk("*** Booting Zephyr OS version %s %s ***\n",
+	       KERNEL_VERSION_STRING, BOOT_DELAY_BANNER);
+#endif
+#endif
+}
+#else
+void boot_banner(void)
+{
+	/* do nothing */
+}
+#endif

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -129,64 +129,6 @@ void z_bss_zero(void)
 extern volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES */
 
-
-#ifdef CONFIG_XIP
-/**
- *
- * @brief Copy the data section from ROM to RAM
- *
- * This routine copies the data section from ROM to RAM.
- *
- * @return N/A
- */
-void z_data_copy(void)
-{
-	(void)memcpy(&__data_ram_start, &__data_rom_start,
-		 __data_ram_end - __data_ram_start);
-#ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
-	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
-		 (uintptr_t) &_ramfunc_ram_size);
-#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
-#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
-	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
-		 __ccm_data_end - __ccm_data_start);
-#endif
-#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
-	(void)memcpy(&__dtcm_data_start, &__dtcm_data_rom_start,
-		 __dtcm_data_end - __dtcm_data_start);
-#endif
-#ifdef CONFIG_CODE_DATA_RELOCATION
-	extern void data_copy_xip_relocation(void);
-
-	data_copy_xip_relocation();
-#endif	/* CONFIG_CODE_DATA_RELOCATION */
-#ifdef CONFIG_USERSPACE
-#ifdef CONFIG_STACK_CANARIES
-	/* stack canary checking is active for all C functions.
-	 * __stack_chk_guard is some uninitialized value living in the
-	 * app shared memory sections. Preserve it, and don't make any
-	 * function calls to perform the memory copy. The true canary
-	 * value gets set later in z_cstart().
-	 */
-	uintptr_t guard_copy = __stack_chk_guard;
-	uint8_t *src = (uint8_t *)&_app_smem_rom_start;
-	uint8_t *dst = (uint8_t *)&_app_smem_start;
-	uint32_t count = _app_smem_end - _app_smem_start;
-
-	guard_copy = __stack_chk_guard;
-	while (count > 0) {
-		*(dst++) = *(src++);
-		count--;
-	}
-	__stack_chk_guard = guard_copy;
-#else
-	(void)memcpy(&_app_smem_start, &_app_smem_rom_start,
-		 _app_smem_end - _app_smem_start);
-#endif /* CONFIG_STACK_CANARIES */
-#endif /* CONFIG_USERSPACE */
-}
-#endif /* CONFIG_XIP */
-
 /* LCOV_EXCL_STOP */
 
 bool z_sys_post_kernel;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -24,7 +24,6 @@
 #include <init.h>
 #include <linker/linker-defs.h>
 #include <ksched.h>
-#include <version.h>
 #include <string.h>
 #include <sys/dlist.h>
 #include <kernel_internal.h>
@@ -40,17 +39,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(os);
 
-/* boot banner items */
-#if defined(CONFIG_MULTITHREADING) && defined(CONFIG_BOOT_DELAY) \
-	&& CONFIG_BOOT_DELAY > 0
-#define BOOT_DELAY_BANNER " (delayed boot "	\
-	STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
-#else
-#define BOOT_DELAY_BANNER ""
-#endif
-
 /* boot time measurement items */
-
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 uint32_t __noinit z_timestamp_main;  /* timestamp when main task starts */
 uint32_t __noinit z_timestamp_idle;  /* timestamp when CPU goes idle */
@@ -132,6 +121,7 @@ extern volatile uintptr_t __stack_chk_guard;
 /* LCOV_EXCL_STOP */
 
 bool z_sys_post_kernel;
+extern void boot_banner(void);
 
 /**
  *
@@ -148,33 +138,13 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	ARG_UNUSED(unused2);
 	ARG_UNUSED(unused3);
 
-#if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
-	static const unsigned int boot_delay = CONFIG_BOOT_DELAY;
-#else
-	static const unsigned int boot_delay;
-#endif
-
 	z_sys_post_kernel = true;
 
 	z_sys_init_run_level(_SYS_INIT_LEVEL_POST_KERNEL);
 #if CONFIG_STACK_POINTER_RANDOM
 	z_stack_adjust_initialized = 1;
 #endif
-	if (boot_delay > 0 && IS_ENABLED(CONFIG_MULTITHREADING)) {
-		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
-		       "ms (per build configuration) *****\n");
-		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
-	}
-
-#if defined(CONFIG_BOOT_BANNER)
-#ifdef BUILD_VERSION
-	printk("*** Booting Zephyr OS build %s %s ***\n",
-			STRINGIFY(BUILD_VERSION), BOOT_DELAY_BANNER);
-#else
-	printk("*** Booting Zephyr OS version %s %s ***\n",
-			KERNEL_VERSION_STRING, BOOT_DELAY_BANNER);
-#endif
-#endif
+	boot_banner();
 
 #ifdef CONFIG_CPLUSPLUS
 	/* Process the .ctors and .init_array sections */
@@ -249,7 +219,6 @@ static void init_idle_thread(int i)
 	thread->base.is_idle = 1U;
 #endif
 }
-#endif /* CONFIG_MULTITHREADING */
 
 /**
  *
@@ -263,7 +232,6 @@ static void init_idle_thread(int i)
  *
  * @return initial stack pointer for the main thread
  */
-#ifdef CONFIG_MULTITHREADING
 static char *prepare_multithreading(void)
 {
 	char *stack_ptr;

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2014 Wind River Systems, Inc.
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <zephyr.h>
+#include <kernel.h>
+#include <string.h>
+#include <linker/linker-defs.h>
+
+#ifdef CONFIG_STACK_CANARIES
+extern volatile uintptr_t __stack_chk_guard;
+#endif /* CONFIG_STACK_CANARIES */
+
+/**
+ *
+ * @brief Copy the data section from ROM to RAM
+ *
+ * This routine copies the data section from ROM to RAM.
+ *
+ * @return N/A
+ */
+void z_data_copy(void)
+{
+	(void)memcpy(&__data_ram_start, &__data_rom_start,
+		 __data_ram_end - __data_ram_start);
+#ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
+	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
+		 (uintptr_t) &_ramfunc_ram_size);
+#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
+	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
+		 __ccm_data_end - __ccm_data_start);
+#endif
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
+	(void)memcpy(&__dtcm_data_start, &__dtcm_data_rom_start,
+		 __dtcm_data_end - __dtcm_data_start);
+#endif
+#ifdef CONFIG_CODE_DATA_RELOCATION
+	extern void data_copy_xip_relocation(void);
+
+	data_copy_xip_relocation();
+#endif	/* CONFIG_CODE_DATA_RELOCATION */
+#ifdef CONFIG_USERSPACE
+#ifdef CONFIG_STACK_CANARIES
+	/* stack canary checking is active for all C functions.
+	 * __stack_chk_guard is some uninitialized value living in the
+	 * app shared memory sections. Preserve it, and don't make any
+	 * function calls to perform the memory copy. The true canary
+	 * value gets set later in z_cstart().
+	 */
+	uintptr_t guard_copy = __stack_chk_guard;
+	uint8_t *src = (uint8_t *)&_app_smem_rom_start;
+	uint8_t *dst = (uint8_t *)&_app_smem_start;
+	uint32_t count = _app_smem_end - _app_smem_start;
+
+	guard_copy = __stack_chk_guard;
+	while (count > 0) {
+		*(dst++) = *(src++);
+		count--;
+	}
+	__stack_chk_guard = guard_copy;
+#else
+	(void)memcpy(&_app_smem_start, &_app_smem_rom_start,
+		 _app_smem_end - _app_smem_start);
+#endif /* CONFIG_STACK_CANARIES */
+#endif /* CONFIG_USERSPACE */
+}


### PR DESCRIPTION
Banner: Move banner and boot delay handling out of init.c The code for banner was
all over the place in init.c making it unreadable.

XIP: No functional changes, just moving the XIP code out and build it only when
XIP is enabled.