### PR TITLE
sanitycheck: fix FileNotFoundError

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -348,7 +348,7 @@ class BinaryHandler(Handler):
         self.coverage = False
 
     def try_kill_process_by_pid(self):
-        if self.pid_fn:
+        if self.pid_fn and os.path.exists(self.pid_fn):
             pid = int(open(self.pid_fn).read())
             os.unlink(self.pid_fn)
             self.pid_fn = None  # clear so we don't try to kill the binary twice


### PR DESCRIPTION
When platform is nsim_hs_smp, if testcase timeout, the sanitycheck may not be able to find mdb.pid

https://github.com/zephyrproject-rtos/zephyr/issues/30276

Signed-off-by: Jingru Wang <jingru@synopsys.com>