### PR TITLE
boards: arm: nRF5340: add a note about required nRF CL tools

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340dk_nrf5340/doc/index.rst
@@ -259,6 +259,13 @@ found in :ref:`nordic_segger_flashing`. Then build and flash
 applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
+.. note::
+
+   Flashing and debugging applications on the nRF5340 DK requires
+   upgrading the nRF Command Line Tools to version 10.12.0. Further
+   information on how to install the nRF Command Line Tools can be
+   found in :ref:`nordic_segger_flashing`.
+
 Here is an example for the :ref:`hello_world` application running on the
 nRF5340 application core.
 


### PR DESCRIPTION
Add a note in the documentation regarding the required
nRF Command Line Tools for properly working with the
nRF5340 DK.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>