### PR TITLE
cavs: fix clock frequencies for cAVS v1.8, v2.0 and v2.5

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -13,7 +13,7 @@ config SOC
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
-	default 19200000 if CAVS_TIMER
+	default 24000000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -13,7 +13,7 @@ config SOC
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
-	default 19200000 if CAVS_TIMER
+	default 38400000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000

--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -13,7 +13,7 @@ config SOC
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
-	default 19200000 if CAVS_TIMER
+	default 38400000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000


### PR DESCRIPTION
SOF uses different SSP clock rates on different cAVS versions. Frequency tables are provided in platform_ssp_freq[] arrays in clk.c for each version and the default entry is selected by the SSP_DEFAULT_IDX index.