### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: Fix build with legacy LLCP

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -415,7 +415,7 @@ void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	DEBUG_RADIO_PREPARE_S(1);
 }
 
-#if defined(BT_LL_SW_SPLIT_LLCP_LEGACY)
+#if defined(CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY)
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 uint8_t ll_start_enc_req_send(uint16_t handle, uint8_t error_code,
 			    uint8_t const *const ltk)
@@ -462,7 +462,7 @@ uint8_t ll_start_enc_req_send(uint16_t handle, uint8_t error_code,
 	return 0;
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
-#endif /* BT_LL_SW_SPLIT_LLCP_LEGACY */
+#endif /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 
 static void ticker_op_stop_adv_cb(uint32_t status, void *param)
 {


### PR DESCRIPTION
__controller.a(hci.c.obj): in function `le_ltk_req_reply':
zephyr/subsys/bluetooth/controller/hci/hci.c:1305: undefined reference to `ll_start_enc_req_send'
collect2: error: ld returned 1 exit status

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>