### PR TITLE
drivers: ethernet: e1000: Use DT instead of hard coding values

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <mem.h>
+#include <dt-bindings/pcie/pcie.h>
 
 #ifndef DT_DRAM_SIZE
 #define DT_DRAM_SIZE		DT_SIZE_K(4096)
@@ -39,9 +40,12 @@
 	};
 
 	soc {
-		eth0: eth@febc0000 {
+		eth0: eth@1800 {
 			compatible = "intel,e1000";
-			reg = <0xfebc0000 0x100>;
+
+			pcie;
+			reg = <PCIE_BDF(0,0x03,0) PCIE_ID(0x8086,0x100e)>;
+
 			label = "eth0";
 			interrupts = <11 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -207,20 +207,16 @@ static void e1000_isr(const struct device *device)
 	}
 }
 
-#define PCI_VENDOR_ID_INTEL	0x8086
-#define PCI_DEVICE_ID_I82540EM	0x100e
-
 DEVICE_DECLARE(eth_e1000);
 
 int e1000_probe(const struct device *device)
 {
-	const pcie_bdf_t bdf = PCIE_BDF(0, 3, 0);
+	const pcie_bdf_t bdf = DT_INST_REG_ADDR(0);
 	struct e1000_dev *dev = device->data;
 	uint32_t ral, rah;
 	struct pcie_mbar mbar;
 
-	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_I82540EM))) {
+	if (!pcie_probe(bdf, DT_INST_REG_SIZE(0))) {
 		return -ENODEV;
 	}
 
@@ -282,7 +278,8 @@ static void e1000_iface_init(struct net_if *iface)
 			e1000_isr, DEVICE_GET(eth_e1000),
 			DT_INST_IRQ(0, sense));
 
-		irq_enable(DT_INST_IRQN(0));
+		pcie_irq_enable(DT_INST_REG_ADDR(0), DT_INST_IRQN(0));
+
 		iow32(dev, CTRL, CTRL_SLU); /* Set link up */
 		iow32(dev, RCTL, RCTL_EN | RCTL_MPE);
 	}

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -13,3 +13,8 @@ properties:
 
     interrupts:
       required: true
+
+    pcie:
+      type: boolean
+      required: false
+      description: attached via PCI(e) bus


### PR DESCRIPTION
The PCIe values were hard coded in the e1000 Ethernet driver.
Move the values to device tree and use them in the driver.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>