### PR TITLE
manifest: mcuboot: allow to build nRF52840 targets in CI

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -91,7 +91,7 @@ manifest:
       revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 2fce9769b191411d580bbc65b043956c2ae9307e
+      revision: 7a5196820ba48a6ad7e7d573c9048c021960677c
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e


### PR DESCRIPTION
MCUboot was build only for frdm_k64f in zephyr CI.
Extended Zephyr-RTOS integration platform by nrf52840dk_nrf52840
and nrf52840dongle_nrf52840 which allow to build MCUBoot on
these platform in Zephyr-RTOS CI.

https://github.com/mcu-tools/mcuboot/pull/890

Also other improvements within the mcuboot synchronization:

* Added AES256 support for image encryption
* zephyr: serial: Remove unnecessary call to irq_unlock
* boot_serial: Port encoding to use cddl-gen
* bootutil_public: Make boot_read_swap_state declaration public

fixes #29397