### PR TITLE
Bluetooth: controller: hci: Fix naming for ISO path setup parameters

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1781,21 +1781,23 @@ static void le_setup_iso_path(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_setup_iso_path *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_setup_iso_path *rp;
-	uint8_t status;
-	uint16_t handle;
-	uint16_t company_id;
-	uint16_t vendor_id;
 	uint32_t controller_delay;
 	uint8_t *codec_config;
+	uint8_t coding_format;
+	uint16_t vs_codec_id;
+	uint16_t company_id;
+	uint16_t handle;
+	uint8_t status;
 
-	handle     = sys_le16_to_cpu(cmd->handle);
-	company_id = sys_le16_to_cpu(cmd->company_id);
-	vendor_id  = sys_le16_to_cpu(cmd->vendor_id);
+	handle = sys_le16_to_cpu(cmd->handle);
+	coding_format = cmd->codec_id.coding_format;
+	company_id = sys_le16_to_cpu(cmd->codec_id.company_id);
+	vs_codec_id = sys_le16_to_cpu(cmd->codec_id.vs_codec_id);
 	controller_delay = sys_get_le24(cmd->controller_delay);
 	codec_config = &cmd->codec_config[0];
 
 	status = ll_setup_iso_path(handle, cmd->path_dir, cmd->path_id,
-				   cmd->coding_format, company_id, vendor_id,
+				   coding_format, company_id, vs_codec_id,
 				   controller_delay, cmd->codec_config_len,
 				   codec_config);
 

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -159,7 +159,7 @@ uint8_t ll_configure_data_path(uint8_t data_path_dir,
 			       uint8_t  *vs_config);
 uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 			  uint8_t coding_format, uint16_t company_id,
-			  uint16_t vendor_id, uint32_t controller_delay,
+			  uint16_t vs_codec_id, uint32_t controller_delay,
 			  uint8_t codec_config_len, uint8_t *codec_config);
 uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir);
 uint8_t ll_iso_receive_test(uint16_t handle, uint8_t payload_type);

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -27,7 +27,7 @@ __weak uint8_t ll_configure_data_path(uint8_t data_path_dir,
 
 uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 			  uint8_t coding_format, uint16_t company_id,
-			  uint16_t vendor_id, uint32_t controller_delay,
+			  uint16_t vs_codec_id, uint32_t controller_delay,
 			  uint8_t codec_config_len, uint8_t *codec_config)
 {
 	ARG_UNUSED(handle);
@@ -35,7 +35,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	ARG_UNUSED(path_id);
 	ARG_UNUSED(coding_format);
 	ARG_UNUSED(company_id);
-	ARG_UNUSED(vendor_id);
+	ARG_UNUSED(vs_codec_id);
 	ARG_UNUSED(controller_delay);
 	ARG_UNUSED(codec_config_len);
 	ARG_UNUSED(codec_config);


### PR DESCRIPTION
Fix field names of bt_hci_cp_le_setup_iso_path in le_setup_iso_path to
make CIS central/periphal compile and adjust parameter names for
ll_setup_iso_path accordingly.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>