### PR TITLE
Bluetooth: controller: Fix advertising initialization on reset

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -810,6 +810,15 @@ struct bt_hci_cp_le_set_random_address {
 #define BT_HCI_ADV_DIRECT_IND_LOW_DUTY          0x04
 #define BT_HCI_ADV_SCAN_RSP                     0x04
 
+#define BT_LE_ADV_INTERVAL_MIN                  0x0020
+#define BT_LE_ADV_INTERVAL_MAX                  0x4000
+#define BT_LE_ADV_INTERVAL_DEFAULT              0x0800
+
+#define BT_LE_ADV_CHAN_MAP_CHAN_37              0x01
+#define BT_LE_ADV_CHAN_MAP_CHAN_38              0x02
+#define BT_LE_ADV_CHAN_MAP_CHAN_39              0x04
+#define BT_LE_ADV_CHAN_MAP_ALL                  0x07
+
 #define BT_LE_ADV_FP_NO_WHITELIST               0x00
 #define BT_LE_ADV_FP_WHITELIST_SCAN_REQ         0x01
 #define BT_LE_ADV_FP_WHITELIST_CONN_IND         0x02

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1409,6 +1409,7 @@ int ull_adv_reset_finalize(void)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		adv->is_created = 0;
+		lll->aux = NULL;
 #endif
 		lll_adv_data_reset(&lll->adv_data);
 		lll_adv_data_reset(&lll->scan_rsp);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -78,6 +78,9 @@ static inline uint8_t disable(uint8_t handle);
 static const uint8_t *adva_update(struct ll_adv_set *adv, struct pdu_adv *pdu);
 static void tgta_update(struct ll_adv_set *adv, struct pdu_adv *pdu);
 
+static void init_pdu(struct pdu_adv *pdu, uint8_t pdu_type);
+static void init_set(struct ll_adv_set *adv);
+
 static struct ll_adv_set ll_adv[BT_CTLR_ADV_SET];
 
 #if defined(CONFIG_BT_TICKER_EXT)
@@ -1639,6 +1642,13 @@ static int init_reset(void)
 		lll_adv_data_init(&ll_adv[handle].lll.scan_rsp);
 	}
 
+	/* Make sure that set #0 is initialized with empty legacy PDUs. This is
+	 * especially important if legacy HCI interface is used for advertising
+	 * because it allows to enable advertising without any configuration,
+	 * thus we need to have PDUs already initialized.
+	 */
+	init_set(&ll_adv[0]);
+
 	return 0;
 }
 
@@ -2071,4 +2081,28 @@ static void tgta_update(struct ll_adv_set *adv, struct pdu_adv *pdu)
 	/* NOTE: identity TargetA is set when configuring advertising set, no
 	 *       need to update if LL Privacy is not supported.
 	 */
+}
+
+static void init_pdu(struct pdu_adv *pdu, uint8_t pdu_type)
+{
+	/* TODO: Add support for extended advertising PDU if needed */
+	pdu->type = pdu_type;
+	pdu->rfu = 0;
+	pdu->chan_sel = 0;
+	pdu->tx_addr = 0;
+	pdu->rx_addr = 0;
+	pdu->len = BDADDR_SIZE;
+}
+
+static void init_set(struct ll_adv_set *adv)
+{
+	adv->interval = BT_LE_ADV_INTERVAL_DEFAULT;
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	adv->own_addr_type = BT_ADDR_LE_PUBLIC;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+	adv->lll.chan_map = BT_LE_ADV_CHAN_MAP_ALL;
+	adv->lll.filter_policy = BT_LE_ADV_FP_NO_WHITELIST;
+
+	init_pdu(lll_adv_data_peek(&ll_adv[0].lll), PDU_ADV_TYPE_ADV_IND);
+	init_pdu(lll_adv_scan_rsp_peek(&ll_adv[0].lll), PDU_ADV_TYPE_SCAN_RSP);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1404,11 +1404,14 @@ int ull_adv_reset_finalize(void)
 	int err;
 
 	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
+		struct ll_adv_set *adv = &ll_adv[handle];
+		struct lll_adv *lll = &adv->lll;
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		ll_adv[handle].is_created = 0;
+		adv->is_created = 0;
 #endif
-		lll_adv_data_reset(&ll_adv[handle].lll.adv_data);
-		lll_adv_data_reset(&ll_adv[handle].lll.scan_rsp);
+		lll_adv_data_reset(&lll->adv_data);
+		lll_adv_data_reset(&lll->scan_rsp);
 	}
 
 	err = init_reset();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1360,6 +1360,10 @@ int ull_adv_reset(void)
 {
 	uint8_t handle;
 
+	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
+		(void)disable(handle);
+	}
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_HCI_RAW)
 	ll_adv_cmds = LL_ADV_CMDS_ANY;
@@ -1387,10 +1391,6 @@ int ull_adv_reset(void)
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_AUX_SET */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
-
-	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
-		(void)disable(handle);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1401,6 +1401,9 @@ int ull_adv_reset_finalize(void)
 	int err;
 
 	for (handle = 0U; handle < BT_CTLR_ADV_SET; handle++) {
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		ll_adv[handle].is_created = 0;
+#endif
 		lll_adv_data_reset(&ll_adv[handle].lll.adv_data);
 		lll_adv_data_reset(&ll_adv[handle].lll.scan_rsp);
 	}


### PR DESCRIPTION
This fixes advertising initialization on reset:
- all sets are disabled prior to cleanup
- all sets are removed after reset
- set #0 is initialized with default legacy PDUs