### PR TITLE
net: syslog: Make sure CONFIG_LOG_IMMEDIATE is not set

### DIFF
--- a/samples/net/syslog_net/prj.conf
+++ b/samples/net/syslog_net/prj.conf
@@ -14,6 +14,11 @@ CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=5
 CONFIG_NET_LOG=y
 CONFIG_LOG=y
 
+# Immediate logging does not work with network syslog as it would cause
+# the sent packet to be malformed (contains only 1 byte data)
+CONFIG_LOG_IMMEDIATE=n
+CONFIG_LOG_PROCESS_THREAD=y
+
 CONFIG_NET_IPV6=y
 CONFIG_NET_IPV4=y
 CONFIG_NET_DHCPV4=n

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -12,6 +12,8 @@ LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_LOG_BACKEND_NET), "syslog backend not enabled");
+
 #define SLEEP_BETWEEN_PRINTS 3
 
 void main(void)

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -465,9 +465,11 @@ config LOG_BACKEND_XTENSA_OUTPUT_BUFFER_SIZE
 	  Buffer is used by log_output module for preparing output data (e.g.
 	  string formatting).
 
+# Immediate mode cannot be used with network backend as it would cause the sent
+# rsyslog message to be malformed.
 config LOG_BACKEND_NET
 	bool "Enable networking backend"
-	depends on NETWORKING
+	depends on NETWORKING && NET_UDP && !LOG_IMMEDIATE
 	select NET_CONTEXT_NET_PKT_POOL
 	help
 	  Send syslog messages to network server.


### PR DESCRIPTION
The immediate logging option cannot be used with network logging
support CONFIG_LOG_BACKEND_NET as that would cause the generated
rsyslog messages to be malformed. The UDP packets would only have
one byte payloads which is not correct. So make sure that user is
not able to select a configuration with immediate mode and network
logging.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>