### PR TITLE
Bluetooth: controller: Use proper handle in advertising events

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5144,7 +5144,7 @@ static void le_adv_ext_terminate(struct pdu_data *pdu_data,
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_ADV_SET_TERMINATED, sizeof(*sep));
 	sep->status = node_rx->hdr.rx_ftr.param_adv_term.status;
-	sep->adv_handle = node_rx->hdr.handle & 0xff;
+	sep->adv_handle = ll_adv_set_hci_handle_get(node_rx->hdr.handle & 0xff);
 	sep->conn_handle =
 		sys_cpu_to_le16(node_rx->hdr.rx_ftr.param_adv_term.conn_handle);
 	sep->num_completed_ext_adv_evts =
@@ -5171,7 +5171,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 		uint8_t handle;
 		int8_t rssi;
 
-		handle = node_rx->hdr.handle & 0xff;
+		handle = ll_adv_set_hci_handle_get(node_rx->hdr.handle & 0xff);
 		addr.type = adv->tx_addr;
 		memcpy(&addr.a.val[0], &adv->scan_req.scan_addr[0],
 		       sizeof(bt_addr_t));
@@ -5186,7 +5186,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 	}
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_SCAN_REQ_RECEIVED, sizeof(*sep));
-	sep->handle = node_rx->hdr.handle & 0xff;
+	sep->handle = ll_adv_set_hci_handle_get(node_rx->hdr.handle & 0xff);
 	sep->addr.type = adv->tx_addr;
 	memcpy(&sep->addr.a.val[0], &adv->scan_req.scan_addr[0],
 	       sizeof(bt_addr_t));

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -21,6 +21,7 @@ uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const p_bdaddr);
 uint8_t ll_adv_set_by_hci_handle_get(uint8_t hci_handle, uint8_t *handle);
 uint8_t ll_adv_set_by_hci_handle_get_or_new(uint8_t hci_handle,
 					    uint8_t *handle);
+uint8_t ll_adv_set_hci_handle_get(uint8_t handle);
 uint8_t ll_adv_iso_by_hci_handle_get(uint8_t hci_handle, uint8_t *handle);
 uint8_t ll_adv_iso_by_hci_handle_new(uint8_t hci_handle, uint8_t *handle);
 #else
@@ -37,6 +38,12 @@ static inline uint8_t ll_adv_set_by_hci_handle_get_or_new(uint8_t hci_handle,
 	*handle = hci_handle;
 	return 0;
 }
+
+static inline uint8_t ll_adv_set_hci_handle_get(uint8_t handle)
+{
+	return handle;
+}
+
 static inline uint8_t ll_adv_iso_by_hci_handle_get(uint8_t hci_handle,
 						   uint8_t *handle)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -160,6 +160,16 @@ uint8_t ll_adv_set_by_hci_handle_get_or_new(uint8_t hci_handle, uint8_t *handle)
 
 	return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 }
+
+uint8_t ll_adv_set_hci_handle_get(uint8_t handle)
+{
+	struct ll_adv_set *adv;
+
+	adv = ull_adv_set_get(handle);
+	LL_ASSERT(adv && adv->is_created);
+
+	return adv->hci_handle;
+}
 #endif
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)


### PR DESCRIPTION
If handle mapping is enabled, we need to use proper advertising set
handle in HCI event.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>