### PR TITLE
samples: nrf: battery: fix reference to ADC node

### DIFF
--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -73,7 +73,7 @@ static const struct divider_config divider_config = {
 	.full_ohm = DT_PROP(VBATT, full_ohms),
 #else /* /vbatt exists */
 	.io_channel = {
-		DT_LABEL(DT_ALIAS(adc_0)),
+		DT_LABEL(DT_NODELABEL(adc)),
 	},
 #endif /* /vbatt exists */
 };


### PR DESCRIPTION
The sample referenced the ADC through an alias that either never
existed or (more likely) has since been removed.  Use the node label
instead.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>