### PR TITLE
actions: manifest: Update to latest action revision

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -7,11 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Manifest
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          path: zephyrproject/zephyr
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'
+          checkout-path: 'zephyrproject/zephyr'
           label-prefix: 'manifest-'
           verbosity-level: '1'
           labels: 'manifest, west'


### PR DESCRIPTION
The manifest GitHub action now optionally takes a checked out tree in
order to find the merge base of the pull request branch. Provide this to
avoid artifacts in edge cases.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>