### PR TITLE
ARC: runner: mdb: tweak searching for cld process pid

### DIFF
--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -37,8 +37,7 @@ def get_cld_pid(mdb_process):
 # process pid to file (mdb.pid) so this process can be terminated correctly by
 # sanitycheck infrastructure
 def record_cld_pid(mdb_runner, mdb_process):
-    for _i in range(20):
-        time.sleep(0.5)
+    for _i in range(100):
         found, pid = get_cld_pid(mdb_process)
         if found:
             mdb_pid_file = path.join(mdb_runner.build_dir, 'mdb.pid')
@@ -46,6 +45,7 @@ def record_cld_pid(mdb_runner, mdb_process):
             with open(mdb_pid_file, 'w') as f:
                 f.write(str(pid))
             return
+        time.sleep(0.05)
 
 def mdb_do_run(mdb_runner, command):
     commander = "mdb"


### PR DESCRIPTION
mdb binary starts several subproceses and one of them is cld process. In runners/mdb.py we record process id of cld on each mdb launch to terminate simulator correctly later. However we can finish test and terminate mdb before the cld process was found (so cld won't be terminated correctly by sanitycheck infrastructure). It may happen if we launch mdb on fast host machine.

That leads to several issues. First of all we get ugly error in sanitycheck output:
```
FileNotFoundError: [Errno 2] No such file or directory: '/xxxx/mdb.pid'
```

Secondly (and it's more important) we terminate simulator incorrectly. We terminate mdb leaving cld process alive, running and consuming one cpu core permanently (until we kill it manually)

So, let's don't wait extra 0.5 seconds before the first lookup (as test may finish before we start lookup) and increase granularity of lookups (so we won't have big delays where test can start and finish between lookups). It shouldn't affect host machine performance as we usually find `cld` (and hence exit lookup cycle) in 1-2 iterations (based on my tests on local machine and our servers)


