### PR TITLE
STM32H745 SRAM Sections Definition

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
@@ -16,7 +16,7 @@
 	chosen {
 		zephyr,console = &uart8;
 		zephyr,shell-uart = &uart8;
-		zephyr,sram = &sram1;
+		zephyr,sram = &ahb_sram1;
 		zephyr,flash = &flash1;
 	};
 

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -25,7 +25,7 @@
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,dtcm = &dtcm;
-		zephyr,sram = &sram0;
+		zephyr,sram = &axi_sram;
 		zephyr,flash = &flash0;
 	};
 

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
@@ -17,7 +17,7 @@
 	chosen {
 		/* zephyr,console = &usart1; */
 		/* zephyr,shell-uart = &usart1; */
-		zephyr,sram = &sram1;
+		zephyr,sram = &ahb_sram1;
 		zephyr,flash = &flash1;
 	};
 

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -17,7 +17,7 @@
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
-		zephyr,sram = &sram0;
+		zephyr,sram = &axi_sram;
 		zephyr,flash = &flash0;
 	};
 

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -27,21 +27,64 @@
 	* (RM0399 Rev 3)
 	*/
 
-	/* System data RAM accessible over AXI bus: AXI SRAM in D1 domain */
 	sram0: memory@24000000 {
-		reg = <0x24000000 DT_SIZE_K(512)>;
+		reg = <0x24000000 DT_SIZE_K(864)>;
 		compatible = "mmio-sram";
-	};
 
-	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
-	sram1: memory@30000000 {
-		reg = <0x30000000 DT_SIZE_K(288)>;
-		compatible = "mmio-sram";
-	};
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	/* System data RAM accessible over AHB bus: SRAM4 in D2 domain  */
-	sram4: memory@38000000 {
-		reg = <0x38000000 DT_SIZE_K(64)>;
-		compatible = "mmio-sram";
+		ranges = <
+			0x0		0x24000000 DT_SIZE_K(512)  // axi_sram
+			0xC000000	0x30000000 DT_SIZE_K(128)  // ahb_sram1
+			0xC020000	0x30020000 DT_SIZE_K(128)  // ahb_sram2
+			0xC040000	0x30040000 DT_SIZE_K(32)   // ahb_sram3
+			0x14000000	0x38000000 DT_SIZE_K(64)   // ahb_sram4
+			>;
+
+		/*
+		 * System data RAM accessible over AXI bus:
+		 * AXI SRAM in D1 domain
+		 */
+		axi_sram: memory@0 {
+			label = "axi_sram";
+			reg = <0x0 DT_SIZE_K(512)>;
+		};
+
+		/*
+		 * System data RAM accessible over AHB bus:
+		 * SRAM1 in D2 domain
+		 */
+		ahb_sram1: memory@C000000{
+			label = "ahb_sram1";
+			reg = <0xC000000 DT_SIZE_K(128)>;
+		};
+
+		/*
+		 * System data RAM accessible over AHB bus:
+		 * SRAM2 in D2 domain
+		 */
+		ahb_sram2: memory@C020000 {
+			label = "ahb_sram2";
+			reg = <0xC020000 DT_SIZE_K(128)>;
+		};
+
+		/*
+		 * System data RAM accessible over AHB bus:
+		 * SRAM3 in D2 domain
+		 */
+		ahb_sram3: memory@C040000 {
+			label = "ahb_sram3";
+			reg = <0xC040000 DT_SIZE_K(32)>;
+		};
+
+		/*
+		 * System data RAM accessible over AHB bus:
+		 * SRAM4 in D3 domain
+		 */
+		ahb_sram4: memory@14000000 {
+			label = "ahb_sram4";
+			reg = <0x14000000 DT_SIZE_K(64)>;
+		};
 	};
 };


### PR DESCRIPTION
Define multiple SRAM sections within `sram0`. With this PR each stm32h745 based board can use either whole `sram0` (choose **zephyr,sram = &sram0;**) or only parts of it (choose **zephyr,sram = &ahb_sram1;** for example).
This step is necessary toward whole SRAM utilization for projects.

Same behavior for SRAM [realized in linux kernel](https://www.kernel.org/doc/Documentation/devicetree/bindings/sram/sram.txt).