### PR TITLE
some fixes for arc smp

### DIFF
--- a/boards/arc/nsim/board.cmake
+++ b/boards/arc/nsim/board.cmake
@@ -19,7 +19,7 @@ elseif(${CONFIG_SOC_NSIM_HS})
 board_runner_args(arc-nsim "--props=nsim_hs.props")
 board_runner_args(mdb-nsim "--nsim_args=mdb_hs.args")
 elseif(${CONFIG_SOC_NSIM_HS_SMP})
-board_runner_args(mdb-nsim "--cores=2" "--nsim_args=mdb_hs_smp.args")
+board_runner_args(mdb-nsim "--cores=${CONFIG_MP_NUM_CPUS}" "--nsim_args=mdb_hs_smp.args")
 endif()
 
 board_finalize_runner_args(arc-nsim)

--- a/boards/arc/nsim/support/mdb_hs_smp.args
+++ b/boards/arc/nsim/support/mdb_hs_smp.args
@@ -49,4 +49,4 @@
 	-on=nsim_print-sys-arch
 	-noprofile
 	-nogoifmain
-	-instrs_per_pass=10
+	-instrs_per_pass=512


### PR DESCRIPTION
- arc: mdb-nsim runner: launch cores according CONFIG_MP_NUM_CPUS

nsim_hs_smp has 2 cores, and CONFIG_MP_NUM_CPUS defalut value is 2. But some tests will have extra config: CONFIG_MP_NUM_CPUS=1, so we need to launch cores according CONFIG_MP_NUM_CPUS, not using a fix number 2.

- arc: nsim_hs_smp: use the default value of mdb `instrs_per_pass` option

`instrs_per_pass` option specify the number of instructions executed before simulator switches operations. the default value is 512. If we specify a small value for it the debugger's overhead will increase significantly for simulation because of the time taken to rapidly switch operations. And the overhead will cause some time critical task failure. Restore `instrs_per_pass` value from 10 to default 512, we will have a good sanitycheck result for nsim_hs_smp.

sanitycheck result:

Target | Runner | Passed | Failed | Skipped | Only built
-- | -- | -- | -- | -- | --
nsim_hs_smp | arc-nsim | 176 | 1 | 818 | 17


