### PR TITLE
lib: posix: Make exited pthread slots reusable

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -417,6 +417,7 @@ int pthread_join(pthread_t thread, void **status)
 		if (status != NULL) {
 			*status = pthread->retval;
 		}
+		pthread->state = PTHREAD_TERMINATED;
 	} else if (pthread->state == PTHREAD_DETACHED) {
 		ret = EINVAL;
 	} else {


### PR DESCRIPTION
This change modifies `pthread_join()` to change the state of `EXITED` pthread slots to `TERMINATED` state so they can be reused by `pthread_create()`.