### PR TITLE
Bluetooth: host: Remove the need to wrap conn lookup in IRQ lock.

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -197,9 +197,12 @@ struct bt_conn_le_data_len_param {
  *
  *  Increment the reference count of a connection object.
  *
+ *  @note Will return NULL if the reference count is zero.
+ *
  *  @param conn Connection object.
  *
- *  @return Connection object with incremented reference count.
+ *  @return Connection object with incremented reference count, or NULL if the
+ *          reference count is zero.
  */
 struct bt_conn *bt_conn_ref(struct bt_conn *conn);
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -169,8 +169,6 @@ struct bt_conn {
 	/* Active L2CAP/ISO channels */
 	sys_slist_t		channels;
 
-	atomic_t		ref;
-
 	/* Delayed work deferred tasks:
 	 * - Peripheral delayed connection update.
 	 * - Initiator connect create cancel.
@@ -196,6 +194,10 @@ struct bt_conn {
 		uint16_t subversion;
 	} rv;
 #endif
+	/* Must be at the end so that everything else in the structure can be
+	 * memset to zero without affecting the ref.
+	 */
+	atomic_t		ref;
 };
 
 void bt_conn_reset_rx_state(struct bt_conn *conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1244,27 +1244,22 @@ static void hci_num_completed_packets(struct net_buf *buf)
 	for (i = 0; i < evt->num_handles; i++) {
 		uint16_t handle, count;
 		struct bt_conn *conn;
-		unsigned int key;
 
 		handle = sys_le16_to_cpu(evt->h[i].handle);
 		count = sys_le16_to_cpu(evt->h[i].count);
 
 		BT_DBG("handle %u count %u", handle, count);
 
-		key = irq_lock();
-
 		conn = bt_conn_lookup_handle(handle);
 		if (!conn) {
-			irq_unlock(key);
 			BT_ERR("No connection for handle %u", handle);
 			continue;
 		}
 
-		irq_unlock(key);
-
 		while (count--) {
 			struct bt_conn_tx *tx;
 			sys_snode_t *node;
+			unsigned int key;
 
 			key = irq_lock();
 


### PR DESCRIPTION
Remove the need to wrap connection lookup functions in IRQ lock by rewriting bt_conn_ref so that it returns NULL if the reference count is zero.
Then bt_conn_ref can be used internally to perform an atomic reference check and increment, so that the lookup handle has either a valid reference, or the reference has been released.