### PR TITLE
Tfm clean up kconfig

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -443,6 +443,7 @@
 /lib/cmsis_rtos_v1/                       @nashif
 /lib/libc/                                @nashif @andrewboie
 /modules/                                 @nashif
+/modules/Kconfig.tfm                      @ioannisg @microbuilder
 /kernel/device.c                          @andrewboie @andyross @nashif
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/                                 @nashif

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -20,12 +20,6 @@ config TFM_BOARD
 
 menuconfig BUILD_WITH_TFM
 	bool "Build with TF-M as the Secure Execution Environment"
-	select CMSIS_RTOS_V2
-	imply POLL
-	imply THREAD_NAME
-	imply THREAD_STACK_INFO
-	imply INIT_STACKS
-	imply THREAD_MONITOR
 	depends on TRUSTED_EXECUTION_NONSECURE
 	depends on TFM_BOARD != ""
 	help
@@ -44,10 +38,6 @@ menuconfig BUILD_WITH_TFM
 	    CONFIG_TRUSTED_EXECUTION_NONSECURE ie enabled.
 
 if BUILD_WITH_TFM
-
-config NUM_PREEMPT_PRIORITIES
-	int
-	default 56
 
 config TFM_KEY_FILE_S
 	string "Path to private key used to sign secure firmware images."

--- a/modules/Kconfig.tfm
+++ b/modules/Kconfig.tfm
@@ -22,6 +22,8 @@ menuconfig BUILD_WITH_TFM
 	bool "Build with TF-M as the Secure Execution Environment"
 	depends on TRUSTED_EXECUTION_NONSECURE
 	depends on TFM_BOARD != ""
+	depends on ARM_TRUSTZONE_M
+	imply INIT_ARCH_HW_AT_BOOT
 	help
 	  When enabled, this option instructs the Zephyr build process to
 	  additionaly generate a TF-M image for the Secure Execution


### PR DESCRIPTION
- Cleanup the BUILD_WITH_TFM option definition in Kconfig.tfm removing redundant options
- Remove the overriding of NUM_PRIORITIES which is not needed.
- Add proper dependencies and imply statements on BUILD_WITH_TFM
- Code Owners for Kconfig.tfm (module)