### PR TITLE
drivers: counter: stm32_rtc: misc cleanup

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -10,7 +10,6 @@ menuconfig COUNTER_RTC_STM32
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC
 	select USE_STM32_LL_EXTI
-	select REQUIRES_FULL_LIBC
 	help
 	  Build RTC driver for STM32 SoCs.
 	  Tested on STM32 F0, F2, F3, F4, L1, L4, F7, G4, H7 series

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -23,6 +23,7 @@
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_rtc.h>
 #include <drivers/counter.h>
+#include <sys/timeutil.h>
 
 #include <logging/log.h>
 
@@ -118,7 +119,7 @@ static uint32_t rtc_stm32_read(const struct device *dev)
 	now.tm_min = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_MINUTE(rtc_time));
 	now.tm_sec = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_SECOND(rtc_time));
 
-	ts = mktime(&now);
+	ts = timeutil_timegm(&now);
 
 	/* Return number of seconds since RTC init */
 	ts -= T_TIME_OFFSET;

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -30,6 +30,7 @@
 
 LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 
+/* Seconds from 1970-01-01T00:00:00 to 2000-01-01T00:00:00 */
 #define T_TIME_OFFSET 946684800
 
 #if defined(CONFIG_SOC_SERIES_STM32L4X)
@@ -106,7 +107,7 @@ static uint32_t rtc_stm32_read(const struct device *dev)
 
 	/* Convert calendar datetime to UNIX timestamp */
 	/* RTC start time: 1st, Jan, 2000 */
-	/* time_t start:   1st, Jan, 1900 */
+	/* time_t start:   1st, Jan, 1970 */
 	now.tm_year = 100 +
 			__LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_YEAR(rtc_date));
 	/* tm_mon allowed values are 0-11 */


### PR DESCRIPTION
time_t always measures as seconds since 1970-01-01T00:00:00Z.  Fix a comment that identified the wrong epoch year, and document what the value of the offset means.   From @noelleclement  on slack.

`mktime()` was being used to convert from `struct tm` to `time_t`, but Zephyr now has functions for that, so we don't need to require full libc just to translate representations in both directions (`gmtime()` works for the other way).
