### PR TITLE
x86: misc paging improvements

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -298,13 +298,12 @@ static void log_exception(uintptr_t vector, uintptr_t code)
 
 static void dump_page_fault(z_arch_esf_t *esf)
 {
-	uintptr_t err, cr2;
+	uintptr_t err;
+	void *cr2;
 
-	/* See Section 6.15 of the IA32 Software Developer's Manual vol 3 */
-	__asm__ ("mov %%cr2, %0" : "=r" (cr2));
-
+	cr2 = z_x86_cr2_get();
 	err = esf_get_code(esf);
-	LOG_ERR("Page fault at address 0x%lx (error code 0x%lx)", cr2, err);
+	LOG_ERR("Page fault at address %p (error code 0x%lx)", cr2, err);
 
 	if ((err & RSVD) != 0) {
 		LOG_ERR("Reserved bits set in page tables");
@@ -325,7 +324,7 @@ static void dump_page_fault(z_arch_esf_t *esf)
 	}
 
 #ifdef CONFIG_X86_MMU
-	z_x86_dump_mmu_flags(get_ptables(esf), (void *)cr2);
+	z_x86_dump_mmu_flags(get_ptables(esf), cr2);
 #endif /* CONFIG_X86_MMU */
 }
 #endif /* CONFIG_EXCEPTION_DEBUG */

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -32,7 +32,6 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 }
 #endif
 
-#ifdef CONFIG_THREAD_STACK_INFO
 static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64
@@ -41,9 +40,7 @@ static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
 	return esf->esp;
 #endif
 }
-#endif
 
-#ifdef CONFIG_EXCEPTION_DEBUG
 static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64
@@ -52,7 +49,6 @@ static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 	return esf->errorCode;
 #endif
 }
-#endif
 
 #ifdef CONFIG_THREAD_STACK_INFO
 bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -56,6 +56,15 @@
 #define MMU_IGNORED1	BITL(10)
 #define MMU_IGNORED2	BITL(11)
 
+/* Page fault error code flags. See Chapter 4.7 of the Intel SDM vol. 3A. */
+#define PF_P		BIT(0)	/* 0 Non-present page  1 Protection violation */
+#define PF_WR		BIT(1)  /* 0 Read              1 Write */
+#define PF_US		BIT(2)  /* 0 Supervisor mode   1 User mode */
+#define PF_RSVD		BIT(3)  /* 1 reserved bit set */
+#define PF_ID		BIT(4)  /* 1 instruction fetch */
+#define PF_PK		BIT(5)  /* 1 protection-key violation */
+#define PF_SGX		BIT(15) /* 1 SGX-specific access control requirements */
+
 #ifdef CONFIG_EXCEPTION_DEBUG
 /**
  * Dump out page table entries for a particular virtual memory address

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -166,6 +166,21 @@ static inline pentry_t *z_x86_page_tables_get(void)
 	return (pentry_t *)z_x86_cr3_get();
 }
 
+/* Return cr2 value, which contains the page fault linear address.
+ * See Section 6.15 of the IA32 Software Developer's Manual vol 3.
+ * Used by page fault handling code.
+ */
+static inline void *z_x86_cr2_get(void)
+{
+	void *cr2;
+#ifdef CONFIG_X86_64
+	__asm__ volatile("movq %%cr2, %0\n\t" : "=r" (cr2));
+#else
+	__asm__ volatile("movl %%cr2, %0\n\t" : "=r" (cr2));
+#endif
+	return cr2;
+}
+
 /* Kernel's page table. This is in CR3 for all supervisor threads.
  * if KPTI is enabled, we switch to this when handling exceptions or syscalls
  */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -165,7 +165,7 @@ config IDLE_STACK_SIZE
 	default 1024 if XTENSA
 	default 512 if RISCV
 	default 384 if DYNAMIC_OBJECTS
-	default 320 if ARC || (ARM && CPU_HAS_FPU)
+	default 320 if ARC || (ARM && CPU_HAS_FPU) || (X86 && MMU)
 	default 256
 	help
 	  Depending on the work that the idle task must do, most likely due to


### PR DESCRIPTION
A few changes that will be useful for forthcoming demand paging implementation:

- Increase default idle stack size for x86 if the MMU is turned on, as thread exit logic invoked from idle may need to un-map memory
- inline function added to fetch cr2 value
- page fault reason codes moved from C fatal error handling code to private arch header
- un-ifdef a couple inlines that didn't need it
- updating page table entries is now atomic
- page_validate() should do the right thing even if a virtual page is paged-out