### PR TITLE
pm-states: Add power management state in DTS

### DIFF
--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -10,3 +10,7 @@ properties:
       type: int
       required: false
       description: Clock frequency in Hz
+    pm-states:
+       type: phandles
+       required: false
+       description: List of power management states supported by this cpu

--- a/dts/bindings/power/state.yaml
+++ b/dts/bindings/power/state.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2020, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Properties for power management state
+
+compatible: "pm-state"
+
+properties:
+    pm-state:
+        type: string
+        required: true
+        description: indicates a power state
+        enum:
+            - "active"
+            - "runtime-idle"
+            - "suspend-to-idle"
+            - "standby"
+            - "suspend-to-ram"
+            - "suspend-to-disk"
+            - "soft-off"
+    min-residency-us:
+        type: int
+        required: false
+        description: |
+            Minimum residency duration in microseconds. It is the minimum time for a
+            given idle state to be worthwhile energywise.

--- a/dts/bindings/test/vnd,phandle-holder.yaml
+++ b/dts/bindings/test/vnd,phandle-holder.yaml
@@ -10,6 +10,7 @@ include: [base.yaml]
 properties:
   ph: {type: "phandle"}
   phs: {type: "phandles"}
+  phs-or: {type: "phandles"}
   pha-gpios: {type: "phandle-array"}
   gpios: {type: "phandle-array"}
   foos: {type: "phandle-array"}

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -597,6 +597,28 @@
 	DT_PROP(DT_PHANDLE_BY_IDX(node_id, phs, idx), prop)
 
 /**
+ * @brief Like DT_PROP_BY_PHANDLE_IDX(), but with a fallback to
+ * default_value.
+ *
+ * If the value exists, this expands to DT_PROP_BY_PHANDLE_IDX(node_id, phs,
+ * idx, prop). The default_value parameter is not expanded in this
+ * case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param phs lowercase-and-underscores property with type "phandle",
+ *            "phandles", or "phandle-array"
+ * @param idx logical index into "phs", which must be zero if "phs"
+ *            has type "phandle"
+ * @param prop lowercase-and-underscores property of the phandle's node
+ * @param default_value a fallback value to expand to
+ * @return the property's value
+ */
+#define DT_PROP_BY_PHANDLE_IDX_OR(node_id, phs, idx, prop, default_value) \
+	DT_PROP_OR(DT_PHANDLE_BY_IDX(node_id, phs, idx), prop, default_value)
+
+/**
  * @brief Get a property value from a phandle's node
  *
  * This is equivalent to DT_PROP_BY_PHANDLE_IDX(node_id, ph, 0, prop).

--- a/include/power/power_state.h
+++ b/include/power/power_state.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_POWER_POWER_STATE_H_
 
 #include <sys/util.h>
+#include <devicetree.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -102,6 +103,156 @@ enum pm_state {
 	 */
 	PM_STATE_SOFT_OFF
 };
+
+/**
+ * Information about a power management state
+ */
+struct pm_state_info {
+	enum pm_state state;
+	/**
+	 * Minimum residency duration in microseconds. It is the minimum
+	 * time for a given idle state to be worthwhile energywise.
+	 *
+	 * @note 0 means that this property is not available for this state.
+	 */
+	uint32_t min_residency_us;
+};
+
+/**
+ * @brief Construct a pm_state_info from 'pm_states' property at index 'i'
+ *
+ * @param node_id A node identifier compatible with pm-states
+ * @param i index of pm_states prop which type is 'phandles'
+ * @return pm_state_info item from 'pm_states' property at index 'i'
+ */
+#define PM_STATE_INFO_DT_ITEM_BY_IDX(node_id, i)                    \
+	{                                                           \
+		.state = DT_ENUM_IDX(DT_PHANDLE_BY_IDX(node_id,     \
+					pm_states, i), pm_state),    \
+		.min_residency_us = DT_PROP_BY_PHANDLE_IDX_OR(node_id, \
+				pm_states, i, min_residency_us, 0),   \
+	},
+
+/**
+ * @brief Length of 'pm-states' property which type is 'phandles'
+ *
+ * @param node_id A node identifier compatible with pm-states
+ * @return length of 'pm-states' property which type is 'phandles'
+ */
+#define PM_STATE_DT_ITEMS_LEN(node_id) DT_PROP_LEN(node_id, pm_states)
+
+/**
+ * @brief Macro function to construct enum pm_state item in UTIL_LISTIFY
+ * extension.
+ *
+ * @param child child index in UTIL_LISTIFY extension.
+ * @param node_id A node identifier compatible with pm-states
+ * @return macro function to construct a pm_state_info
+ */
+#define PM_STATE_INFO_DT_ITEMS_LISTIFY_FUNC(child, node_id) \
+	PM_STATE_INFO_DT_ITEM_BY_IDX(node_id, child)
+
+/**
+ * @brief Macro function to construct a list of 'pm_state_info' items by
+ * UTIL_LISTIFY func
+ *
+ * Example devicetree fragment:
+ *	cpus {
+ *		...
+ *		cpu0: cpu@0 {
+ *			device_type = "cpu";
+ *			...
+ *			pm-states = <&state0 &state1>;
+ *		};
+ *	};
+ *
+ *	...
+ *	state0: state0 {
+ *		compatible = "pm-state";
+ *		pm-state = "suspend-to-idle";
+ *		min-residency-us = <1>;
+ *	};
+ *
+ *	state1: state1 {
+ *		compatible = "pm-state";
+ *		pm-state = "suspend-to-ram";
+ *		min-residency-us = <5>;
+ *	};
+ *
+ * Example usage: *
+ *    const enum pm_state states[] =
+ *		PM_STATE_DT_INFO_ITEMS_LIST(DT_NODELABEL(cpu0));
+ *
+ * @param node_id A node identifier compatible with pm-states
+ * @return an array of struct pm_state_info.
+ */
+#define PM_STATE_INFO_DT_ITEMS_LIST(node_id) {         \
+	UTIL_LISTIFY(PM_STATE_DT_ITEMS_LEN(node_id),   \
+		     PM_STATE_INFO_DT_ITEMS_LISTIFY_FUNC,\
+		     node_id)                          \
+	}
+
+/**
+ * @brief Construct a pm_state enum from 'pm_states' property at index 'i'
+ *
+ * @param node_id A node identifier compatible with pm-states
+ * @param i index of pm_states prop which type is 'phandles'
+ * @return pm_state item from 'pm_states' property at index 'i'
+ */
+#define PM_STATE_DT_ITEM_BY_IDX(node_id, i)                \
+		DT_ENUM_IDX(DT_PHANDLE_BY_IDX(node_id,     \
+				pm_states, i), pm_state),
+
+
+/**
+ * @brief Macro function to construct enum pm_state item in UTIL_LISTIFY
+ * extension.
+ *
+ * @param child child index in UTIL_LISTIFY extension.
+ * @param node_id A node identifier compatible with pm-states
+ * @return macro function to construct a pm_state enum
+ */
+#define PM_STATE_DT_ITEMS_LISTIFY_FUNC(child, node_id) \
+	PM_STATE_DT_ITEM_BY_IDX(node_id, child)
+
+/**
+ * @brief Macro function to construct a list of enum pm_state items by
+ * UTIL_LISTIFY func
+ *
+ * Example devicetree fragment:
+ *	cpus {
+ *		...
+ *		cpu0: cpu@0 {
+ *			device_type = "cpu";
+ *			...
+ *			pm-states = <&state0 &state1>;
+ *		};
+ *	};
+ *
+ *	...
+ *	state0: state0 {
+ *		compatible = "pm-state";
+ *		pm-state = "suspend-to-idle";
+ *		min-residency-us = <1>;
+ *	};
+ *
+ *	state1: state1 {
+ *		compatible = "pm-state";
+ *		pm-state = "suspend-to-ram";
+ *		min-residency-us = <5>;
+ *	};
+ *
+ * Example usage: *
+ *    const enum pm_state states[] = PM_STATE_DT_ITEMS_LIST(DT_NODELABEL(cpu0));
+ *
+ * @param node_id A node identifier compatible with pm-states
+ * @return an array of enum pm_state items.
+ */
+#define PM_STATE_DT_ITEMS_LIST(node_id) {           \
+	UTIL_LISTIFY(PM_STATE_DT_ITEMS_LEN(node_id),\
+		     PM_STATE_DT_ITEMS_LISTIFY_FUNC,\
+		     node_id)                       \
+	}
 
 /**
  * @}

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -40,6 +40,7 @@
 			 */
 			ph = <&test_gpio_1>;
 			phs = <&test_gpio_1 &test_gpio_2 &test_i2c>;
+			phs-or = <&test_enum_default_0 &test_enum_default_1>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
 			pha-gpios = <&test_gpio_1 50 60>, <&test_gpio_3 70>, <&test_gpio_2 80 90>;
 			foos = <&test_gpio_1 100>, <&test_gpio_2 110>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -678,6 +678,14 @@ static void test_phandles(void)
 			     "TEST_GPIO_2"),
 		     "gpios[1].label");
 
+	/* DT_PROP_BY_PHANDLE_IDX_OR */
+	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX_OR(TEST_PH, phs_or, 0,
+						val, "zero"), "one"),
+		     "phs-or 0");
+	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX_OR(TEST_PH, phs_or, 1,
+						val, "zero"), "zero"),
+		     "phs-or 1");
+
 	/* phandle-array */
 	zassert_true(DT_NODE_HAS_PROP(TEST_PH, gpios), "gpios");
 	zassert_equal(ARRAY_SIZE(gps), 2, "gpios size");

--- a/tests/subsys/power/power_states_api/CMakeLists.txt
+++ b/tests/subsys/power/power_states_api/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pm-states-test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/power/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/power/power_states_api/boards/native_posix.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	power_states: power_states {
+		compatible = "test,power_states_api";
+		pm-states = <&state0 &state1 &state2>;
+	};
+
+	state0: state0 {
+		compatible = "pm-state";
+		pm-state = "suspend-to-idle";
+		min-residency-us = <1>;
+	};
+
+	state1: state1 {
+		compatible = "pm-state";
+		pm-state = "suspend-to-ram";
+		min-residency-us = <5>;
+	};
+
+	state2: state2 {
+		compatible = "pm-state";
+		pm-state = "standby";
+	};
+};

--- a/tests/subsys/power/power_states_api/dts/bindings/test,power_states_api.yaml
+++ b/tests/subsys/power/power_states_api/dts/bindings/test,power_states_api.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This binding provides resources required to build and run the
+    tests/subsys/power/power_states_api test in Zephyr.
+
+compatible: "test,power_states_api"
+
+properties:
+    pm-states:
+       type: phandles
+       required: false
+       description: List of power management states supported by this cpu.

--- a/tests/subsys/power/power_states_api/prj.conf
+++ b/tests/subsys/power/power_states_api/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/subsys/power/power_states_api/src/main.c
+++ b/tests/subsys/power/power_states_api/src/main.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <power/power.h>
+
+/* Last state has not declared a minimum residency, so it should be
+ * set the default 0 value
+ */
+static struct pm_state_info infos[] = {{PM_STATE_SUSPEND_TO_IDLE, 1},
+			{PM_STATE_SUSPEND_TO_RAM, 5}, {PM_STATE_STANDBY, 0}};
+static enum pm_state states[] = {PM_STATE_SUSPEND_TO_IDLE,
+				PM_STATE_SUSPEND_TO_RAM, PM_STATE_STANDBY};
+static enum pm_state wrong_states[] = {PM_STATE_SUSPEND_TO_DISK,
+			PM_STATE_SUSPEND_TO_RAM, PM_STATE_SUSPEND_TO_RAM};
+
+void test_power_states(void)
+{
+	enum pm_state dts_states[] =
+		PM_STATE_DT_ITEMS_LIST(DT_NODELABEL(power_states));
+	struct pm_state_info dts_infos[] =
+		PM_STATE_INFO_DT_ITEMS_LIST(DT_NODELABEL(power_states));
+	uint32_t dts_states_len =
+		PM_STATE_DT_ITEMS_LEN(DT_NODELABEL(power_states));
+
+	zassert_true(ARRAY_SIZE(states) == dts_states_len,
+		     "Invalid number of pm states");
+	zassert_true(memcmp(infos, dts_infos, sizeof(dts_infos)) == 0,
+		     "Invalid pm_state_info array");
+	zassert_true(memcmp(states, dts_states, sizeof(dts_states)) == 0,
+		     "Invalid pm-states array");
+
+	zassert_false(memcmp(wrong_states, dts_states, sizeof(dts_states)) == 0,
+		     "Invalid pm-states array");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(power_states_test,
+			 ztest_1cpu_unit_test(test_power_states));
+	ztest_run_test_suite(power_states_test);
+}

--- a/tests/subsys/power/power_states_api/testcase.yaml
+++ b/tests/subsys/power/power_states_api/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  pm-states-api.dts:
+    tags: power
+    platform_allow: native_posix


### PR DESCRIPTION
- Add information about supported power management in device tree
- Add a couple of macros to extract this information