### PR TITLE
linker: rename the section for emulators

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -126,7 +126,7 @@
 #endif
 
 #if defined(CONFIG_EMUL)
-	SECTION_DATA_PROLOGUE(log_const_sections,,)
+	SECTION_DATA_PROLOGUE(emulators_section,,)
 	{
 		__emul_list_start = .;
 		KEEP(*(SORT_BY_NAME(".emulators")));


### PR DESCRIPTION
The linker section for emulators (emulation drivers) is
incorrectly named "log_const_sections" possibly due to
simply copy-and-paste error. This section has nothing to
do with logging, so rename the emulators section.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>