### PR TITLE
Bluetooth: host: Fix data type of advertising set handle

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7140,7 +7140,7 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 	cp = net_buf_add(buf, sizeof(*cp));
 	(void)memset(cp, 0, sizeof(*cp));
 
-	cp->handle = sys_cpu_to_le16(adv->handle);
+	cp->handle = adv->handle;
 	cp->min_interval = sys_cpu_to_le16(param->interval_min);
 	cp->max_interval = sys_cpu_to_le16(param->interval_max);
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -111,13 +111,13 @@ enum {
 
 struct bt_le_ext_adv {
 	/* ID Address used for advertising */
-	uint8_t                    id;
+	uint8_t                 id;
 
 	/* Advertising handle */
-	uint16_t			handle;
+	uint8_t                 handle;
 
 	/* Current local Random Address */
-	bt_addr_le_t		random_addr;
+	bt_addr_le_t            random_addr;
 
 	/* Current target address */
 	bt_addr_le_t            target_addr;


### PR DESCRIPTION
Change type of advertising set handle to 8 bit to comply with
Bluetooth Core spec. type.
Fixes wrong usage of adv. set handle variable in function
bt_le_per_adv_set_param.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>