### PR TITLE
drivers: modem: don't cleanup net_context members

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -4583,9 +4583,6 @@ static int offload_put(struct net_context *context)
 	}
 	allow_sleep(true);
 
-	sock->context->connect_cb = NULL;
-	sock->context->recv_cb = NULL;
-	sock->context->send_cb = NULL;
 	socket_put(sock);
 	net_context_unref(context);
 	if (sock->type == SOCK_STREAM) {

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1791,9 +1791,6 @@ static int offload_put(struct net_context *context)
 	/* clear last_socket_id */
 	ictx.last_socket_id = 0;
 
-	sock->context->connect_cb = NULL;
-	sock->context->recv_cb = NULL;
-	sock->context->send_cb = NULL;
 	socket_put(sock);
 	net_context_unref(context);
 	if (sock->type == SOCK_STREAM) {


### PR DESCRIPTION
There is no reason to clenaup members of net_context structure, as those
should be (and are) managed by net_context_put() implementation.