### PR TITLE
shields: enable SD card support on Adafruit 2.8 TFT Touch v2 and Waveshare Epaper

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -71,4 +71,11 @@ endif # LVGL
 
 endif # DISPLAY
 
+if DISK_ACCESS_SDHC
+
+config DISK_ACCESS_SPI_SDHC
+	default y
+
+endif # DISK_ACCESS_SDHC
+
 endif # SHIELD_ADAFRUIT_2_8_TFT_TOUCH_V2

--- a/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
@@ -8,7 +8,8 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
+		   <&arduino_header 12 GPIO_ACTIVE_LOW>;	/* D04 */
 
 
 	ili9340@0 {
@@ -25,6 +26,14 @@
 		vmctrl2 = [86];
 		pgamctrl = [0f 31 2b 0c 0e 08 4e f1 37 07 10 03 0e 09 00];
 		ngamctrl = [00 0e 14 03 11 07 31 c1 48 08 0f 0c 31 36 0f];
+	};
+
+	sdhc0: sdhc@1 {
+		compatible = "zephyr,mmc-spi-slot";
+		reg = <1>;
+		status = "okay";
+		label = "SDHC0";
+		spi-max-frequency = <24000000>;
 	};
 };
 

--- a/boards/shields/waveshare_epaper/Kconfig.defconfig
+++ b/boards/shields/waveshare_epaper/Kconfig.defconfig
@@ -61,4 +61,11 @@ endif # LVGL
 
 endif # DISPLAY
 
+if DISK_ACCESS_SDHC
+
+config DISK_ACCESS_SPI_SDHC
+	default y
+
+endif # DISK_ACCESS_SDHC
+
 endif # SHIELD_WAVESHARE_EPAPER_GDEH02

--- a/boards/shields/waveshare_epaper/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_common.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
+		   <&arduino_header 12 GPIO_ACTIVE_LOW>;	/* D04 */
+
+	sdhc0: sdhc@1 {
+		compatible = "zephyr,mmc-spi-slot";
+		reg = <1>;
+		status = "okay";
+		label = "SDHC0";
+		spi-max-frequency = <24000000>;
+	};
+};

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+#include "waveshare_epaper_common.dtsi"
 
+&arduino_spi {
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0154a07";
 		label = "SSD16XX";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+#include "waveshare_epaper_common.dtsi"
 
+&arduino_spi {
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b1";
 		label = "SSD16XX";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+#include "waveshare_epaper_common.dtsi"
 
+&arduino_spi {
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b72";
 		label = "SSD16XX";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+#include "waveshare_epaper_common.dtsi"
 
+&arduino_spi {
 	ssd16xxfb@0 {
 		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh029a1";
 		label = "SSD16XX";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&arduino_spi {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+#include "waveshare_epaper_common.dtsi"
 
+&arduino_spi {
 	gd7965@0 {
 		compatible = "gooddisplay,gd7965";
 		label = "GD7965";


### PR DESCRIPTION
Enable SD card support on Adafruit 2.8 TFT Touch v2 and Waveshare Epaper shields.