### PR TITLE
net: context: move send_cb from net_context to net_pkt

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -165,12 +165,10 @@ struct esp_socket {
 	/* net context */
 	struct net_context *context;
 	net_context_connect_cb_t connect_cb;
-	net_context_send_cb_t send_cb;
 	net_context_recv_cb_t recv_cb;
 
 	/* callback data */
 	void *conn_user_data;
-	void *send_user_data;
 	void *recv_user_data;
 };
 

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -311,12 +311,13 @@ static void esp_send_work(struct k_work *work)
 			ret);
 	}
 
+	if (sock->tx_pkt->send_cb) {
+		sock->tx_pkt->send_cb(sock->context, ret,
+				      sock->tx_pkt->user_data);
+	}
+
 	net_pkt_unref(sock->tx_pkt);
 	sock->tx_pkt = NULL;
-
-	if (sock->send_cb) {
-		sock->send_cb(sock->context, ret, sock->send_user_data);
-	}
 }
 
 static int esp_sendto(struct net_pkt *pkt,
@@ -373,8 +374,6 @@ static int esp_sendto(struct net_pkt *pkt,
 	}
 
 	sock->tx_pkt = pkt;
-	sock->send_cb = cb;
-	sock->send_user_data = user_data;
 
 	if (timeout == 0) {
 		k_work_submit_to_queue(&dev->workq, &sock->send_work);
@@ -617,7 +616,6 @@ static int esp_put(struct net_context *context)
 
 	sock->connect_cb = NULL;
 	sock->recv_cb = NULL;
-	sock->send_cb = NULL;
 	sock->tx_pkt = NULL;
 
 	/* Drain rxfifo */

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -232,8 +232,8 @@ static void eswifi_off_send_work(struct k_work *work)
 
 	eswifi_lock(eswifi);
 
-	user_data = socket->send_data;
-	cb = socket->send_cb;
+	user_data = socket->tx_pkt->user_data;
+	cb = socket->tx_pkt->send_cb;
 	context = socket->context;
 
 	err = __eswifi_off_send_pkt(eswifi, socket);
@@ -271,9 +271,6 @@ static int eswifi_off_send(struct net_pkt *pkt,
 	socket->tx_pkt = pkt;
 
 	if (timeout == 0) {
-		socket->send_data = user_data;
-		socket->send_cb = cb;
-
 		k_work_submit_to_queue(&eswifi->work_q, &socket->send_work);
 
 		eswifi_unlock(eswifi);
@@ -327,9 +324,6 @@ static int eswifi_off_sendto(struct net_pkt *pkt,
 	}
 
 	if (timeout == 0) {
-		socket->send_data = user_data;
-		socket->send_cb = cb;
-
 		k_work_submit_to_queue(&eswifi->work_q, &socket->send_work);
 
 		eswifi_unlock(eswifi);

--- a/drivers/wifi/eswifi/eswifi_offload.h
+++ b/drivers/wifi/eswifi/eswifi_offload.h
@@ -33,11 +33,9 @@ struct eswifi_off_socket {
 	struct net_context *context;
 	net_context_recv_cb_t recv_cb;
 	net_context_connect_cb_t conn_cb;
-	net_context_send_cb_t send_cb;
 	net_tcp_accept_cb_t accept_cb;
 	void *recv_data;
 	void *conn_data;
-	void *send_data;
 	void *accept_data;
 	struct net_pkt *tx_pkt;
 	struct k_work connect_work;

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -228,11 +228,6 @@ __net_socket struct net_context {
 	 */
 	net_context_recv_cb_t recv_cb;
 
-	/** Send callback to be called when the packet has been sent
-	 * successfully.
-	 */
-	net_context_send_cb_t send_cb;
-
 	/** Connect callback to be called when a connection has been
 	 *  established.
 	 */

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -88,6 +88,14 @@ struct net_pkt {
 	/** Network connection context */
 	struct net_context *context;
 
+	/** Network context send callback to be called when the packet has been
+	 * sent successfully
+	 */
+	net_context_send_cb_t send_cb;
+
+	/** Network context send user data */
+	void *user_data;
+
 	/** Network interface */
 	struct net_if *iface;
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -393,7 +393,6 @@ int net_context_put(struct net_context *context)
 
 	context->connect_cb = NULL;
 	context->recv_cb = NULL;
-	context->send_cb = NULL;
 
 	/* Decrement refcount on user app's behalf */
 	net_context_unref(context);
@@ -1561,8 +1560,8 @@ static int context_sendto(struct net_context *context,
 		len = tmp_len;
 	}
 
-	context->send_cb = cb;
-	context->user_data = user_data;
+	pkt->send_cb = cb;
+	pkt->user_data = user_data;
 
 	if (IS_ENABLED(CONFIG_NET_CONTEXT_PRIORITY)) {
 		uint8_t priority;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -163,15 +163,16 @@ struct net_if *z_vrfy_net_if_get_by_index(int index)
 #include <syscalls/net_if_get_by_index_mrsh.c>
 #endif
 
-static inline void net_context_send_cb(struct net_context *context,
-				       int status)
+static inline void net_pkt_send_cb(struct net_pkt *pkt, int status)
 {
+	struct net_context *context = net_pkt_context(pkt);
+
 	if (!context) {
 		return;
 	}
 
-	if (context->send_cb) {
-		context->send_cb(context, status, context->user_data);
+	if (pkt->send_cb) {
+		pkt->send_cb(context, status, pkt->user_data);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_UDP) &&
@@ -322,7 +323,7 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 		NET_DBG("Calling context send cb %p status %d",
 			context, status);
 
-		net_context_send_cb(context, status);
+		net_pkt_send_cb(pkt, status);
 
 		if (IS_ENABLED(CONFIG_NET_CONTEXT_TIMESTAMP) && status >= 0 &&
 		    start_timestamp.nanosecond && curr_time > 0) {
@@ -494,7 +495,7 @@ done:
 		if (context) {
 			NET_DBG("Calling ctx send cb %p verdict %d",
 				context, verdict);
-			net_context_send_cb(context, status);
+			net_pkt_send_cb(pkt, status);
 		}
 
 		if (dst->addr) {

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -606,10 +606,10 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 		if (dest_addr) {
 			status = net_context_sendto(ctx, buf, len, dest_addr,
 						    addrlen, NULL, timeout,
-						    ctx->user_data);
+						    NULL);
 		} else {
 			status = net_context_send(ctx, buf, len, NULL, timeout,
-						  ctx->user_data);
+						  NULL);
 		}
 
 		if (status < 0) {

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -241,7 +241,7 @@ ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 
 	ret = net_context_sendto(ctx, (void *)&zframe, sizeof(zframe),
 				 dest_addr, addrlen, NULL, timeout,
-				 ctx->user_data);
+				 NULL);
 	if (ret < 0) {
 		errno = -ret;
 		return -1;

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -163,7 +163,7 @@ ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	}
 
 	status = net_context_sendto(ctx, buf, len, dest_addr, addrlen,
-				    NULL, timeout, ctx->user_data);
+				    NULL, timeout, NULL);
 	if (status < 0) {
 		errno = -status;
 		return -1;

--- a/subsys/net/lib/socks/socks.c
+++ b/subsys/net/lib/socks/socks.c
@@ -93,7 +93,7 @@ static int socks5_tcp_connect(struct net_context *ctx,
 
 	ret = net_context_sendto(ctx, (uint8_t *)&method_req, size,
 				 proxy, proxy_len, NULL, K_NO_WAIT,
-				 ctx->user_data);
+				 NULL);
 	if (ret < 0) {
 		LOG_ERR("Could not send negotiation packet");
 		return ret;
@@ -154,7 +154,7 @@ static int socks5_tcp_connect(struct net_context *ctx,
 
 	ret = net_context_sendto(ctx, (uint8_t *)&cmd_req, size,
 				 proxy, proxy_len, NULL, K_NO_WAIT,
-				 ctx->user_data);
+				 NULL);
 	if (ret < 0) {
 		LOG_ERR("Could not send CONNECT command");
 		return ret;


### PR DESCRIPTION
Each net_context_send*() call accepts send_cb and user_data as
parameters. Those parameters were saved in net_context structure during
each send request. There were two problems related to such behavior:

 * 'user_data' is shared for connect_cb and recv_cb, which means that
   it got overwritten during each net_context_send*() call. This means
   that net_context API consumer needed (in most cases) to always pass
   user_data that was previously used for net_context_recv(), even when
   send_cb was NULL.
 * 'send_cb' together with 'user_data' got overwritten during each
   net_context_send*() call, so there was no way of keeping track which
   packet was actually sent and which was not.

Move send_cb and user_data to net_pkt structure, so no undesirable
overwriting happens. This allows to keep track of each data portion that
is requested to be sent with net_context_send*() APIs. Additionally
user_data is no longer shared with the one passed to net_context_recv(),
which means that the same pointer doesn't have to be passed during each
subsequent net_context_send() call.

Simplify and cleanup code assuming previous behavior.