### PR TITLE
doc: script: Default to empty string in DT docset env var

### DIFF
--- a/doc/scripts/gen_devicetree_rest.py
+++ b/doc/scripts/gen_devicetree_rest.py
@@ -615,7 +615,7 @@ def zref(target, text=None):
     # This relies on intersphinx:
     # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 
-    docset = os.environ.get('GEN_DEVICETREE_REST_ZEPHYR_DOCSET')
+    docset = os.environ.get('GEN_DEVICETREE_REST_ZEPHYR_DOCSET', '')
 
     if docset.strip():
         target = f'{docset}:{target}'


### PR DESCRIPTION
Windows does not default to an empty string when an env var is not
declared, like Linux does. Instead, explicitly default to one in order
for the .strip() call to work properly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>