### PR TITLE
west: update revision for mcumgr library

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -244,6 +244,8 @@ Libraries / Subsystems
 
   * MCUmgr
 
+    * Added support for flash devices that have non-0xff erase value.
+
   * updatehub
 
 * Settings

--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
       revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: f28a637db12c4b12fb2b18bddc6b2a0deaa95251
+      revision: 697e145d5ee5e4b400e9d7bceaec79f6ac29df7c
       path: modules/lib/mcumgr
     - name: net-tools
       revision: dcfa04f4aaf30ae7c2dbf34a05a569ca1c04b2ce


### PR DESCRIPTION
The snapshot update adds support for flash devices that have 0
as the erase value.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>