### PR TITLE
drivers/timer: stm32_lptim: Fix stm32 ll header list

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -7,7 +7,9 @@
 
 #include <soc.h>
 #include <stm32_ll_lptim.h>
-#include <stm32_ll_system.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_pwr.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/timer/system_timer.h>


### PR DESCRIPTION
LPTIM stm32 ll header list was not adequate.
Remove _system and add _bus, _rcc and _pwr.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>