### PR TITLE
kernel/k_malloc: provide aligned allocators

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4540,7 +4540,27 @@ extern void z_mem_pool_free_id(struct k_mem_block_id *id);
  */
 
 /**
- * @brief Allocate memory from heap.
+ * @brief Allocate memory from the heap with a specified alignment.
+ *
+ * This routine provides semantics similar to aligned_alloc(); memory is
+ * allocated from the heap with a specified alignment. However, one minor
+ * difference is that k_aligned_alloc() accepts any non-zero @p size,
+ * wherase aligned_alloc() only accepts a @p size that is an integral
+ * multiple of @p align.
+ *
+ * Above, aligned_alloc() refers to:
+ * C11 standard (ISO/IEC 9899:2011): 7.22.3.1
+ * The aligned_alloc function (p: 347-348)
+ *
+ * @param align Alignment of memory requested (in bytes).
+ * @param size Amount of memory requested (in bytes).
+ *
+ * @return Address of the allocated memory if successful; otherwise NULL.
+ */
+extern void *k_aligned_alloc(size_t align, size_t size);
+
+/**
+ * @brief Allocate memory from the heap.
  *
  * This routine provides traditional malloc() semantics. Memory is
  * allocated from the heap memory pool.
@@ -4549,7 +4569,10 @@ extern void z_mem_pool_free_id(struct k_mem_block_id *id);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
-extern void *k_malloc(size_t size);
+static inline void *k_malloc(size_t size)
+{
+	return k_aligned_alloc(sizeof(void *), size);
+}
 
 /**
  * @brief Free memory allocated from heap.

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -7,37 +7,53 @@
 #include <kernel.h>
 #include <string.h>
 #include <sys/math_extras.h>
+#include <sys/util.h>
 
-void *z_heap_malloc(struct k_heap *heap, size_t size)
+static void *z_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t size)
 {
+	uint8_t *mem;
+	struct k_heap **heap_ref;
+	size_t excess = MAX(sizeof(struct k_heap *), align);
+
 	/*
-	 * get a block large enough to hold an initial (hidden) heap
+	 * get a block large enough to hold an initial (aligned and hidden) heap
 	 * pointer, as well as the space the caller requested
 	 */
-	if (size_add_overflow(size, sizeof(struct k_heap *),
-			      &size)) {
+	if (size_add_overflow(size, excess, &size)) {
 		return NULL;
 	}
 
-	struct k_heap **blk = k_heap_alloc(heap, size, K_NO_WAIT);
-
-	if (blk == NULL) {
+	mem = k_heap_aligned_alloc(heap, align, size, K_NO_WAIT);
+	if (mem == NULL) {
 		return NULL;
 	}
 
-	blk[0] = heap;
+	/* create (void *) values in the excess equal to (void *) -1 */
+	memset(mem, 0xff, excess);
+	heap_ref = (struct k_heap **)mem;
+	*heap_ref = heap;
 
 	/* return address of the user area part of the block to the caller */
-	return (char *)&blk[1];
+	return mem + excess;
+}
+
+static void *z_heap_malloc(struct k_heap *heap, size_t size)
+{
+	return z_heap_aligned_alloc(heap, sizeof(void *), size);
 }
 
 void k_free(void *ptr)
 {
-	if (ptr != NULL) {
-		struct k_heap **blk = &((struct k_heap **)ptr)[-1];
-		struct k_heap *heap = *blk;
+	struct k_heap **heap_ref;
 
-		k_heap_free(heap, blk);
+	if (ptr != NULL) {
+		for (heap_ref = &((struct k_heap **)ptr)[-1];
+			*heap_ref == (struct k_heap *)-1; --heap_ref) {
+			/* no-op */
+		}
+
+		ptr = (uint8_t *)heap_ref;
+		k_heap_free(*heap_ref, ptr);
 	}
 }
 
@@ -46,9 +62,16 @@ void k_free(void *ptr)
 K_HEAP_DEFINE(_system_heap, CONFIG_HEAP_MEM_POOL_SIZE);
 #define _SYSTEM_HEAP (&_system_heap)
 
-void *k_malloc(size_t size)
+void *k_aligned_alloc(size_t align, size_t size)
 {
-	return z_heap_malloc(_SYSTEM_HEAP, size);
+	__ASSERT(align / sizeof(void *) >= 1
+		&& (align % sizeof(void *)) == 0,
+		"align must be a multiple of sizeof(void *)");
+
+	__ASSERT((align & (align - 1)) == 0,
+		"align must be a power of 2");
+
+	return z_heap_aligned_alloc(_SYSTEM_HEAP, align, size);
 }
 
 void *k_calloc(size_t nmemb, size_t size)

--- a/tests/kernel/mem_heap/mheap_api_concept/src/main.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/main.c
@@ -11,6 +11,7 @@ extern void test_mheap_min_block_size(void);
 extern void test_mheap_block_desc(void);
 extern void test_mheap_calloc(void);
 extern void test_mheap_block_release(void);
+extern void test_k_aligned_alloc(void);
 
 /**
  * @brief Heap tests
@@ -27,6 +28,7 @@ void test_main(void)
 	ztest_test_suite(mheap_api,
 			 ztest_unit_test(test_mheap_malloc_free),
 			 ztest_unit_test(test_mheap_calloc),
-			 ztest_unit_test(test_mheap_malloc_align4));
+			 ztest_unit_test(test_mheap_malloc_align4),
+			 ztest_unit_test(test_k_aligned_alloc));
 	ztest_run_test_suite(mheap_api);
 }

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
@@ -87,3 +87,34 @@ void test_mheap_calloc(void)
 
 	k_free(mem);
 }
+
+void test_k_aligned_alloc(void)
+{
+	void *r;
+
+	/*
+	 * Allow sizes that are not necessarily a multiple of the
+	 * alignment. The backing allocator would naturally round up to
+	 * some minimal block size. This would make k_aligned_alloc()
+	 * more like posix_memalign() instead of aligned_alloc(), but
+	 * the benefit is that k_malloc() can then just be a wrapper
+	 * around k_aligned_alloc().
+	 */
+	r = k_aligned_alloc(sizeof(void *), 1);
+	/* allocation succeeds */
+	zassert_not_equal(NULL, r, "aligned alloc of 1 byte failed");
+	/* r is suitably aligned */
+	zassert_equal(0, (uintptr_t)r % sizeof(void *),
+		"%p not %u-byte-aligned",
+		r, sizeof(void *));
+	k_free(r);
+
+	/* allocate with > 8 byte alignment */
+	r = k_aligned_alloc(16, 1);
+	/* allocation succeeds */
+	zassert_not_equal(NULL, r, "16-byte-aligned alloc failed");
+	/* r is suitably aligned */
+	zassert_equal(0, (uintptr_t)r % 16,
+		"%p not 16-byte-aligned", r);
+	k_free(r);
+}


### PR DESCRIPTION
kernel/k_malloc: provided aligned allocators

This change adds z_heap_aligned_alloc() and k_aligned_alloc() and changes z_heap_malloc() and k_malloc() to be small wrappers around the aligned variants.

Fixes #29519