### PR TITLE
drivers: flash: spi_nor: fix bound for parameter headers

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -704,10 +704,10 @@ static int spi_nor_process_sfdp(const struct device *dev)
 	}
 
 	LOG_INF("%s: SFDP v %u.%u AP %x with %u PH", dev->name,
-		hp->rev_major, hp->rev_minor, hp->access, hp->nph);
+		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;
-	const struct jesd216_param_header *phpe = php + MIN(decl_nph, hp->nph);
+	const struct jesd216_param_header *phpe = php + MIN(decl_nph, 1 + hp->nph);
 
 	while (php != phpe) {
 		uint16_t id = jesd216_param_id(php);


### PR DESCRIPTION
The exclusive bound for parameter headers needs to be incremented as the nph parameter is not the number of parameter headers: 0 means one header.

This was fixed in the sample in #27629, but didn't make it to the driver.

Fixes #30211.