### PR TITLE
Fix timeouts tests

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  timeout: 120
 tests:
   kernel.common:
     tags: kernel userspace

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -10,3 +10,4 @@ tests:
     platform_exclude: mec15xxevb_assy6853
     extra_configs:
       - CONFIG_DEVICE_POWER_MANAGEMENT=y
+    timeout: 120

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
     tags: kernel security userspace ignore_faults
+    timeout: 120
   kernel.memory_protection.gap_filling:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     extra_args: CONFIG_MPU_GAP_FILLING=y


### PR DESCRIPTION
**Descrition with context**
Sanitycheck uses a default timeout for these tests (listed below).
On emulator (qemu) the tests work well during default time.
On physical hardware (up2) using sanitycheck yields timeout
errors and appears to clip the results. See #30275 for more detail. 

This occurs in the following:
- tests/kernel/common (all of the test_sys_put_)
- tests/kernel/mem_protect/mem_protect (including test_permission_inheritance, test_mem_domain_remove_add_partition)
- tests/kernel/device (pm - test_dummy_device)

Using west to build and flash a test instead of sanitycheck,
on Up2 it is observed by manual inspection using
stopwatch that several tests each need more time
to complete (START to PASS/FAIL).

This commit adds a timeout sufficient to prevent
sanitycheck from moving on to the next test too quickly.
This PR includes a commit to fix #30275. The others have
not yet been reported as bugs but suggest to address them here if agreed appropriate.

This is happening for many tests in these specific test suites (above) on this platform. This does not appear to be due to setup/flashing/teardown/bootup time between tests, it is time during each test (after starting the suite, and then for a test between 'START - test_mem_domain_remove_add_partition' prints and 'PASS- test_mem_domain_remove_add_partition').

**Why now?**
This is yielding errors (see #30275) despite passing tests if relieved of default timeout. This is a workaround to inform sanitycheck to run long enough to observe the full duration of the test case and reflect passing tests correctly in sanitycheck reports.

**What platforms might be affected?**
This is intended for x86/up2, however currently not aware of a way to do board level timeout. So, the change (extended test timeout) will apply across all platforms that use the tests. If the tests pass, there is no observed effect, but if the tests do not complete sanitycheck will take the longer timeout to report the fail.

**Continued work:**
This is a workaround for sanitycheck to observe the full results of a test in the suite. Don't want to hide a potential bug. Kicking off investigation to verify that the added delay is not due to some bug or issue in the test or the platform itself.