### PR TITLE
sanitycheck: key error issue while trying to access the key in dict

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3502,7 +3502,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                 for i in data["test_suite"]:
                     test_details = i["test_details"]
                     for test_data in test_details:
-                        if not (test_data["status"]) == "failed":
+                        if not (test_data.get("status")) == "failed":
                             new_dict = test_data
                             results_dict["test_details"].append(new_dict)
 


### PR DESCRIPTION
While generating json report, status key does not exist and throws
keyerror in some specific scenarios.get() method is used to avoid
error.

Signed-off-by: Spoorthy Priya Yerabolu <spoorthy.priya.yerabolu@intel.com>