### PR TITLE
modules/Kconfig.nordic: Allow using direct 802.15.4 calls for nRF53

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -110,7 +110,7 @@ config NRF_802154_SER_HOST
 	select IPM_MSG_CH_0_TX
 	select IPM_MSG_CH_1_RX
 	select OPENAMP
-	select IEEE802154_NRF5_EXT_IRQ_MGMT
+	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
 	help
 	  Enable serialization of nRF IEEE 802.15.4 Driver. This option is to be
 	  used if radio is not available in the core, but radio services are


### PR DESCRIPTION
This PR allows the use of direct IEEE 802.15.4 nRF Driver calls
in case a serialized (nRF53) version of the Radio Driver is used.

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>