### PR TITLE
doc: kernel: add sleep as a defined term

### DIFF
--- a/doc/reference/kernel/scheduling/index.rst
+++ b/doc/reference/kernel/scheduling/index.rst
@@ -16,12 +16,15 @@ There are various points in time when the scheduler is given an
 opportunity to change the identity of the current thread.  These points
 are called **reschedule points**. Some potential reschedule points are:
 
+- transition of a thread from running state to a suspended or waiting
+  state, for example by :c:func:`k_sem_take` or :c:func:`k_sleep`.
 - transition of a thread to the :ref:`ready state <thread_states>`, for
   example by :c:func:`k_sem_give` or :c:func:`k_thread_start`
-- transition of a thread from running state to a suspended or waiting
-  state, for example by :c:func:`k_sem_take` or :c:func:`k_sleep`
 - return to thread context after processing an interrupt
 - when a running thread invokes :c:func:`k_yield`
+
+A thread **sleeps** when it voluntarily initiates an operation that
+transitions itself to a suspended or waiting state.
 
 Whenever the scheduler changes the identity of the current thread,
 or when execution of the current thread is replaced by an ISR,

--- a/doc/reference/terminology.rst
+++ b/doc/reference/terminology.rst
@@ -67,7 +67,7 @@ sleep
 =====
 
 The sleep attribute is used on a function that can cause the invoking
-thread to sleep.
+thread to :ref:`sleep <scheduling_v2>`.
 
 Explanation
 -----------


### PR DESCRIPTION
The scheduler documentation was updated before to define a reschedule
point, but the related term sleep was not clearly described.  Add a
definition, and link to it from the API terminology.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>