### PR TITLE
arm: aarch32: save/restore caller-save registers during syscalls

### DIFF
--- a/include/arch/arm/aarch32/syscall.h
+++ b/include/arch/arm/aarch32/syscall.h
@@ -49,12 +49,16 @@ static inline uintptr_t arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
 	register uint32_t r5 __asm__("r5") = arg6;
 	register uint32_t r6 __asm__("r6") = call_id;
 
+	__asm__ volatile("push {r1-r3}\n");
+
 	__asm__ volatile("svc %[svid]\n"
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r4), "r" (r5), "r" (r6)
 			 : "r8", "memory", "ip");
+
+	__asm__ volatile("pop {r1-r3}\n");
 
 	return ret;
 }
@@ -71,12 +75,16 @@ static inline uintptr_t arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
 	register uint32_t r4 __asm__("r4") = arg5;
 	register uint32_t r6 __asm__("r6") = call_id;
 
+	__asm__ volatile("push {r1-r3}\n");
+
 	__asm__ volatile("svc %[svid]\n"
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r4), "r" (r6)
 			 : "r8", "memory", "ip");
+
+	__asm__ volatile("pop {r1-r3}\n");
 
 	return ret;
 }
@@ -91,12 +99,16 @@ static inline uintptr_t arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
 	register uint32_t r3 __asm__("r3") = arg4;
 	register uint32_t r6 __asm__("r6") = call_id;
 
+	__asm__ volatile("push {r1-r3}\n");
+
 	__asm__ volatile("svc %[svid]\n"
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r6)
 			 : "r8", "memory", "ip");
+
+	__asm__ volatile("pop {r1-r3}\n");
 
 	return ret;
 }
@@ -110,11 +122,15 @@ static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 	register uint32_t r2 __asm__("r2") = arg3;
 	register uint32_t r6 __asm__("r6") = call_id;
 
+	__asm__ volatile("push {r1-r2}\n");
+
 	__asm__ volatile("svc %[svid]\n"
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r6)
 			 : "r8", "memory", "r3", "ip");
+
+	__asm__ volatile("pop {r1-r2}\n");
 
 	return ret;
 }
@@ -126,11 +142,15 @@ static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 	register uint32_t r1 __asm__("r1") = arg2;
 	register uint32_t r6 __asm__("r6") = call_id;
 
+	__asm__ volatile("push {r1}\n");
+
 	__asm__ volatile("svc %[svid]\n"
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r6)
 			 : "r8", "memory", "r2", "r3", "ip");
+
+	__asm__ volatile("pop {r1}\n");
 
 	return ret;
 }


### PR DESCRIPTION
According to GCC manual regarding input operands in extended asm:

    Warning: Do not modify the contents of input-only operands
    (except for inputs tied to outputs). The compiler assumes that
    on exit from the asm statement these operands contain the same
    values as they had before executing the statement. It is not
    possible to use clobbers to inform the compiler that the values
    in these inputs are changing.

This has been observed that after arch_syscall_invoke6(), r1 has
its value set to zero instead of the value before syscall. Given
the above warning, it seems that GCC does not automatically save
and restore r1-r3. Since arch_syscall_invoke*() can be inlined
without function prologue so r0-r3 may not be saved even though
they are caller-save registers. So save and restore them manually
on relevant arch_syscall_invoke*().

Fixes #30393

Signed-off-by: Daniel Leung <daniel.leung@intel.com>