### PR TITLE
devicetree: generate tokens for suitable string-valued enums

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -49,6 +49,9 @@
  * are missing from this list, please add them. It should be complete.
  *
  * _ENUM_IDX: property's value as an index into bindings enum
+ * _ENUM_TOKEN: property's value as a token into bindings enum (string
+ *              enum values are identifiers)
+ * _ENUM_UPPER_TOKEN: like _ENUM_TOKEN, but uppercased
  * _EXISTS: property is defined
  * _IDX_<i>: logical index into property
  * _IDX_<i>_EXISTS: logical index into property is defined
@@ -545,6 +548,129 @@
 #define DT_ENUM_IDX_OR(node_id, prop, default_idx_value) \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
 		    (DT_ENUM_IDX(node_id, prop)), (default_idx_value))
+
+/**
+ * @brief Get an enumeration property's value as a token.
+ *
+ * This allows you to "remove the quotes" from some string-valued
+ * properties. That can be useful, for example, when pasting the
+ * values onto some other token to form an enum in C using the @p ##
+ * preprocessor operator.
+ *
+ * DT_ENUM_TOKEN() can only be used for properties with string type
+ * whose binding has an "enum:". The values in the binding's "enum:"
+ * list must be unique after converting non-alphanumeric characters to
+ * underscores.
+ *
+ * It is an error to use DT_ENUM_TOKEN() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "FOO";
+ *     }
+ *     n3: node-3 {
+ *             prop = "123 foo";
+ *     };
+ *
+ * Example bindings fragment:
+ *
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *            - "foo"
+ *            - "FOO"
+ *            - "123 foo"
+ *
+ * Example usage:
+ *
+ *     DT_ENUM_TOKEN((DT_NODELABEL(n1), prop) // foo
+ *     DT_ENUM_TOKEN((DT_NODELABEL(n2), prop) // FOO
+ *     DT_ENUM_TOKEN((DT_NODELABEL(n3), prop) // 123_foo
+ *
+ * Notice how:
+ *
+ * - Unlike C identifiers, the property values may begin with a
+ *   number. It's the user's responsibility not to use such values as
+ *   the name of a C identifier.
+ *
+ * - The uppercased "FOO" in the DTS remains @p FOO as a token. It is
+     *not* converted to @p foo.
+ *
+ * - The whitespace in the DTS "123 foo" string is converted to @p
+ *   123_foo as a token.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name with suitable
+ *             enumeration of values in its binding
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_ENUM_TOKEN(node_id, prop) \
+	DT_CAT4(node_id, _P_, prop, _ENUM_TOKEN)
+
+/**
+ * @brief Like DT_ENUM_TOKEN(), but uppercased
+ *
+ * This allows you to "remove the quotes and capitalize" some string-valued
+ * properties.
+ *
+ * DT_ENUM_UPPER_TOKEN() can only be used for properties with string type
+ * whose binding has an "enum:". The values in the binding's "enum:"
+ * list must be unique after converting non-alphanumeric characters to
+ * underscores and capitalizating any letters.
+ *
+ * It is an error to use DT_ENUM_UPPER_TOKEN() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "123 foo";
+ *     };
+ *
+ * Example bindings fragment:
+ *
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *            - "foo"
+ *            - "123 foo"
+ *
+ * Example usage:
+ *
+ *     DT_ENUM_TOKEN((DT_NODELABEL(n1), prop) // FOO
+ *     DT_ENUM_TOKEN((DT_NODELABEL(n2), prop) // 123_FOO
+ *
+ * Notice how:
+ *
+ * - Unlike C identifiers, the property values may begin with a
+ *   number. It's the user's responsibility not to use such values as
+ *   the name of a C identifier.
+ *
+ * - The lowercased "foo" in the DTS becomes @p FOO as a token, i.e.
+ *   it is uppercased.
+ *
+ * - The whitespace in the DTS "123 foo" string is converted to @p
+ *   123_FOO as a token, i.e. it is uppercased and whitespace becomes
+ *   an underscore.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name with suitable
+ *             enumeration of values in its binding
+ * @return the value of @p prop as a capitalized token, i.e. upper case,
+ *         without any quotes, and with special characters converted to
+ *         underscores
+ */
+#define DT_ENUM_UPPER_TOKEN(node_id, prop) \
+	DT_CAT4(node_id, _P_, prop, _ENUM_UPPER_TOKEN)
 
 /*
  * phandle properties

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -195,6 +195,8 @@ class EDT:
         self._init_graph()
         self._init_luts()
 
+        self._check()
+
     def get_node(self, path):
         """
         Returns the Node at the DT path or alias 'path'. Raises EDTError if the
@@ -442,6 +444,27 @@ class EDT:
             node = nodeset[0]
             self.dep_ord2node[node.dep_ordinal] = node
 
+    def _check(self):
+        # Tree-wide checks and warnings.
+
+        for binding in self._compat2binding.values():
+            for spec in binding.prop2specs.values():
+                if not spec.enum or spec.type != 'string':
+                    continue
+
+                if not spec.enum_tokenizable:
+                    _LOG.warning(
+                        f"compatible '{binding.compatible}' "
+                        f"in binding '{binding.path}' has non-tokenizable enum "
+                        f"for property '{spec.name}': " +
+                        ', '.join(repr(x) for x in spec.enum))
+                elif not spec.enum_upper_tokenizable:
+                    _LOG.warning(
+                        f"compatible '{binding.compatible}' "
+                        f"in binding '{binding.path}' has enum for property "
+                        f"'{spec.name}' that is only tokenizable "
+                        'in lowercase: ' +
+                        ', '.join(repr(x) for x in spec.enum))
 
 class Node:
     """

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -423,6 +423,17 @@ def write_vanilla_props(node):
         if prop.enum_index is not None:
             # DT_N_<node-id>_P_<prop-id>_ENUM_IDX
             macro2val[macro + "_ENUM_IDX"] = prop.enum_index
+            spec = prop.spec
+
+            if spec.enum_tokenizable:
+                as_token = prop.val_as_token
+
+                # DT_N_<node-id>_P_<prop-id>_ENUM_TOKEN
+                macro2val[macro + "_ENUM_TOKEN"] = as_token
+
+                if spec.enum_upper_tokenizable:
+                    # DT_N_<node-id>_P_<prop-id>_ENUM_UPPER_TOKEN
+                    macro2val[macro + "_ENUM_UPPER_TOKEN"] = as_token.upper()
 
         if "phandle" in prop.type:
             macro2val.update(phandle_macros(prop, macro))

--- a/scripts/dts/test-bindings/enums.yaml
+++ b/scripts/dts/test-bindings/enums.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Property enum test
+
+compatible: "enums"
+
+properties:
+  int-enum:
+    type: int
+    enum:
+      - 1
+      - 2
+      - 3
+
+  string-enum:                  # not tokenizable
+    type: string
+    enum:
+      - foo bar
+      - foo_bar
+
+  tokenizable-lower-enum:       # tokenizable in lowercase only
+    type: string
+    enum:
+      - bar
+      - BAR
+
+  tokenizable-enum:             # tokenizable in lower and uppercase
+    type: string
+    enum:
+      - bar
+      - whitespace is ok
+      - 123 is ok
+
+  no-enum:
+    type: string

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -312,6 +312,19 @@
 	};
 
 	//
+	// For testing 'enum:'
+	//
+
+	enums {
+		compatible = "enums";
+		int-enum = <1>;
+		string-enum = "foo_bar";
+		tokenizable-enum = "123 is ok";
+		tokenizable-lower-enum = "bar";
+		no-enum = "baz";
+	};
+
+	//
 	// For testing 'bus:' and 'on-bus:'
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -31,12 +31,17 @@ def test_warnings(caplog):
 
     edtlib.EDT("test.dts", ["test-bindings"])
 
-    assert caplog.record_tuples == [
-        ('edtlib', WARNING, f"'oldprop' is marked as deprecated in 'properties:' in {hpath('test-bindings/deprecated.yaml')} for node /test-deprecated."),
-        ('edtlib', WARNING, "unit address and first address in 'reg' (0x1) don't match for /reg-zero-size-cells/node"),
-        ('edtlib', WARNING, "unit address and first address in 'reg' (0x5) don't match for /reg-ranges/parent/node"),
-        ('edtlib', WARNING, "unit address and first address in 'reg' (0x30000000200000001) don't match for /reg-nested-ranges/grandparent/parent/node"),
+    enums_hpath = hpath('test-bindings/enums.yaml')
+    expected_warnings = [
+        f"'oldprop' is marked as deprecated in 'properties:' in {hpath('test-bindings/deprecated.yaml')} for node /test-deprecated.",
+        "unit address and first address in 'reg' (0x1) don't match for /reg-zero-size-cells/node",
+        "unit address and first address in 'reg' (0x5) don't match for /reg-ranges/parent/node",
+        "unit address and first address in 'reg' (0x30000000200000001) don't match for /reg-nested-ranges/grandparent/parent/node",
+        f"compatible 'enums' in binding '{enums_hpath}' has non-tokenizable enum for property 'string-enum': 'foo bar', 'foo_bar'",
+        f"compatible 'enums' in binding '{enums_hpath}' has enum for property 'tokenizable-lower-enum' that is only tokenizable in lowercase: 'bar', 'BAR'",
     ]
+    assert caplog.record_tuples == [('edtlib', WARNING, warning_message)
+                                    for warning_message in expected_warnings]
 
 def test_interrupts():
     '''Tests for the interrupts property.'''

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -232,6 +232,43 @@ def test_prop_defaults():
     assert str(edt.get_node("/defaults").props) == \
         r"OrderedDict([('int', <Property, name: int, type: int, value: 123>), ('array', <Property, name: array, type: array, value: [1, 2, 3]>), ('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), ('string', <Property, name: string, type: string, value: 'hello'>), ('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), ('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])"
 
+def test_prop_enums():
+    '''test properties with enum: in the binding'''
+
+    edt = edtlib.EDT("test.dts", ["test-bindings"])
+    props = edt.get_node('/enums').props
+    int_enum = props['int-enum']
+    string_enum = props['string-enum']
+    tokenizable_enum = props['tokenizable-enum']
+    tokenizable_lower_enum = props['tokenizable-lower-enum']
+    no_enum = props['no-enum']
+
+    assert int_enum.val == 1
+    assert int_enum.enum_index == 0
+    assert not int_enum.spec.enum_tokenizable
+    assert not int_enum.spec.enum_upper_tokenizable
+
+    assert string_enum.val == 'foo_bar'
+    assert string_enum.enum_index == 1
+    assert not string_enum.spec.enum_tokenizable
+    assert not string_enum.spec.enum_upper_tokenizable
+
+    assert tokenizable_enum.val == '123 is ok'
+    assert tokenizable_enum.val_as_token == '123_is_ok'
+    assert tokenizable_enum.enum_index == 2
+    assert tokenizable_enum.spec.enum_tokenizable
+    assert tokenizable_enum.spec.enum_upper_tokenizable
+
+    assert tokenizable_lower_enum.val == 'bar'
+    assert tokenizable_lower_enum.val_as_token == 'bar'
+    assert tokenizable_lower_enum.enum_index == 0
+    assert tokenizable_lower_enum.spec.enum_tokenizable
+    assert not tokenizable_lower_enum.spec.enum_upper_tokenizable
+
+    assert no_enum.enum_index is None
+    assert not no_enum.spec.enum_tokenizable
+    assert not no_enum.spec.enum_upper_tokenizable
+
 def test_binding_inference():
     '''Test inferred bindings for special zephyr-specific nodes.'''
     warnings = io.StringIO()

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import io
+from logging import WARNING
 import os
 from pathlib import Path
 
@@ -25,17 +26,17 @@ def hpath(filename):
     '''Convert 'filename' to the host path syntax.'''
     return os.fspath(Path(filename))
 
-def test_warnings():
+def test_warnings(caplog):
     '''Tests for situations that should cause warnings.'''
-    warnings = io.StringIO()
-    edtlib.EDT("test.dts", ["test-bindings"], warnings)
 
-    assert warnings.getvalue() == f"""\
-warning: 'oldprop' is marked as deprecated in 'properties:' in {hpath('test-bindings/deprecated.yaml')} for node /test-deprecated.
-warning: unit address and first address in 'reg' (0x1) don't match for /reg-zero-size-cells/node
-warning: unit address and first address in 'reg' (0x5) don't match for /reg-ranges/parent/node
-warning: unit address and first address in 'reg' (0x30000000200000001) don't match for /reg-nested-ranges/grandparent/parent/node
-"""
+    edtlib.EDT("test.dts", ["test-bindings"])
+
+    assert caplog.record_tuples == [
+        ('edtlib', WARNING, f"'oldprop' is marked as deprecated in 'properties:' in {hpath('test-bindings/deprecated.yaml')} for node /test-deprecated."),
+        ('edtlib', WARNING, "unit address and first address in 'reg' (0x1) don't match for /reg-zero-size-cells/node"),
+        ('edtlib', WARNING, "unit address and first address in 'reg' (0x5) don't match for /reg-ranges/parent/node"),
+        ('edtlib', WARNING, "unit address and first address in 'reg' (0x30000000200000001) don't match for /reg-nested-ranges/grandparent/parent/node"),
+    ]
 
 def test_interrupts():
     '''Tests for the interrupts property.'''

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -20,6 +20,7 @@
 #define TEST_IRQ	DT_NODELABEL(test_irq)
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
 #define TEST_REG	DT_NODELABEL(test_reg)
+#define TEST_ENUM_0	DT_NODELABEL(test_enum_0)
 
 #define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
 #define TEST_I2C_BUS DT_BUS(TEST_I2C_DEV)
@@ -1418,10 +1419,23 @@ static void test_chosen(void)
 		     "chosen");
 }
 
+#define TO_MY_ENUM(token) TO_MY_ENUM_2(token) /* force another expansion */
+#define TO_MY_ENUM_2(token) MY_ENUM_ ## token
 static void test_enums(void)
 {
-	zassert_equal(DT_ENUM_IDX(DT_NODELABEL(test_enum_0), val), 0, "0");
+	enum {
+		MY_ENUM_zero = 0xff,
+		MY_ENUM_ZERO = 0xaa,
+	};
+
+	zassert_equal(DT_ENUM_IDX(TEST_ENUM_0, val), 0, "0");
+	zassert_equal(TO_MY_ENUM(DT_ENUM_TOKEN(TEST_ENUM_0, val)),
+		      0xff, "zero as token");
+	zassert_equal(TO_MY_ENUM(DT_ENUM_UPPER_TOKEN(TEST_ENUM_0, val)),
+		      0xaa, "zero as uppercase token");
 }
+#undef TO_MY_ENUM
+#undef TO_MY_ENUM_2
 
 static void test_enums_required_false(void)
 {


### PR DESCRIPTION
This PR makes it possible to generate DT macros for string type properties "with the quotes stripped off". This requires that the property has an `enum:` in the binding, and has some additional restrictions.

Example bindings fragment:

```yaml
properties:
  val:
    type: string
    enum:
      - "zero"
      - "one"
      - "two"
```

Example devicetree node:

```
n: node {
	val = "zero";
};
```

With this PR, `DT_ENUM_TOKEN(DT_NODELABEL(n), val)` expands to the token `zero`, without any quotes.

This currently only applies to properties with type "string" and an `enum:` in the binding.

Additionally, all the `enum:` values must be "tokenizable", with a definition given in the commit logs.

Based on a proof of concept by @pabigot .

Fixes: #21273
