### PR TITLE
Bluetooth: tester: Fix an error response in tester

### DIFF
--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -927,7 +927,7 @@ static void conn_param_update(const uint8_t *data, uint16_t len)
 	status = err < 0 ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS;
 
 rsp:
-	tester_rsp(BTP_SERVICE_ID_GAP, GAP_PASSKEY_ENTRY, CONTROLLER_INDEX,
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_CONN_PARAM_UPDATE, CONTROLLER_INDEX,
 		   status);
 }
 


### PR DESCRIPTION
In the function conn_param_update, it should send the opcode
GAP_CONN_PARAM_UPDATE, instead, it sends GAP_PASSKEY_ENTRY.

Signed-off-by: Jun Huang <huangjun6@xiaomi.com>