### PR TITLE
trusted-firmware-m: update manifest to get v1.2.0 release

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -311,6 +311,12 @@ MCUBoot
   * Usage of --confirm implies --pad.
   * Fixed 'custom_tlvs' argument handling.
 
+
+Trusted-Firmware-M
+******************
+
+* Synchronized Trusted-Firmware-M module to the upstream v1.2.0 release.
+
 Documentation
 *************
 

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: dfc26a443c43514867090fee2ff82be809ae40b0
+      revision: f3476cc16053f567eb07886db11e32505c25d097
 
   self:
     path: zephyr


### PR DESCRIPTION
Update manifest for tf-m module to upgrade
trusted-firmware-m to v1.2.0 release from upstream.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>