### PR TITLE
Bluetooth: controller: Fix Coded PHY S2 S8 coding use

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -885,7 +885,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_phy.pause_tx = 0U;
 		conn->phy_pref_tx = ull_conn_default_phy_tx_get();
 		conn->phy_pref_rx = ull_conn_default_phy_rx_get();
-		conn->phy_pref_flags = 0;
 #endif /* CONFIG_BT_CTLR_PHY */
 
 		conn->tx_head = conn->tx_ctrl = conn->tx_ctrl_last =

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3448,7 +3448,7 @@ static inline void event_phy_req_prep(struct ll_conn *conn)
 		/* update preferred phy */
 		conn->phy_pref_tx = conn->llcp_phy.tx;
 		conn->phy_pref_rx = conn->llcp_phy.rx;
-		conn->phy_pref_flags = conn->llcp_phy.flags;
+		conn->lll.phy_flags = conn->llcp_phy.flags;
 
 		/* place the phy req packet as next in tx queue */
 		pdu_ctrl_tx = (void *)tx->pdu;
@@ -3666,7 +3666,6 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 		}
-		lll->phy_flags = conn->phy_pref_flags;
 
 		/* Acquire Rx node */
 		rx = conn->llcp_rx;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -265,7 +265,6 @@ struct ll_conn {
 	} llcp_phy;
 
 	uint8_t phy_pref_tx:3;
-	uint8_t phy_pref_flags:1;
 	uint8_t phy_pref_rx:3;
 #endif /* CONFIG_BT_CTLR_PHY */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -287,7 +287,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_phy.pause_tx = 0U;
 	conn->phy_pref_tx = ull_conn_default_phy_tx_get();
 	conn->phy_pref_rx = ull_conn_default_phy_rx_get();
-	conn->phy_pref_flags = 0U;
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	conn->tx_head = conn->tx_ctrl = conn->tx_ctrl_last =


### PR DESCRIPTION
Fix PHY Update control procedure to accept the preferred Tx
coding options (S2 or S8) requested even if there is no
actual PHY change happening on procedure completion.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>