### PR TITLE
mgmt: mcumgr: Remove log management support from Kconfig

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -166,44 +166,6 @@ config IMG_MGMT_DUMMY_HDR
 	  useful when there are no images present, Eg: unit tests.
 endif
 
-menuconfig MCUMGR_CMD_LOG_MGMT
-	bool "Enable mcumgr handlers for log management"
-	help
-	  Enables mcumgr handlers for log management
-
-if MCUMGR_CMD_LOG_MGMT
-config LOG_MGMT_CHUNK_LEN
-	int "Maximum chunk size for log downloads"
-	default 512
-	help
-	  Limits the maximum chunk size for log downloads, in bytes.  A buffer of
-	  this size gets allocated on the stack during handling of the log show
-	  command.
-
-config LOG_MGMT_NAME_LEN
-	int "Maximum log name length"
-	default 64
-	help
-	  Limits the maximum length of log names, in bytes.  If a log's name length
-	  exceeds this number, it gets truncated in management responses.  A buffer
-	  of this size gets allocated on the stack during handling of all log
-	  management commands.
-
-config LOG_MGMT_BODY_LEN
-	int "Maximum log body length"
-	default 128
-	help
-	  Limits the maximum length of log entry bodies, in bytes.  If a log
-	  entry's body length exceeds this number, it gets truncated in management
-	  responses. A buffer of this size gets allocated on the stack during
-	  handling of the log show command.
-
-config LOG_READ_WATERMARK_UPDATE
-	bool "Enable reading of log watermark update"
-	help
-	  Enables reading of log watermark update.
-
-endif
 
 menuconfig MCUMGR_CMD_OS_MGMT
 	bool "Enable mcumgr handlers for OS management"


### PR DESCRIPTION
The commit removes a leftover configuration of the log management that
has never worked and has been removed with the commit
0bb466c34e4fe863733a929baa8f51981263ce3d to apache/mynewt-mcumgr.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>