### PR TITLE
stm32h7: Misc fixes (openocd related mainly)

### DIFF
--- a/boards/arm/nucleo_h723zg/board.cmake
+++ b/boards/arm/nucleo_h723zg/board.cmake
@@ -4,6 +4,6 @@ board_runner_args(openocd "--use-elf")
 board_runner_args(jlink "--device=STM32H723ZG" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
-include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/arm/nucleo_h723zg/board.cmake
+++ b/boards/arm/nucleo_h723zg/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf")
 board_runner_args(jlink "--device=STM32H723ZG" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 

--- a/boards/arm/nucleo_h723zg/support/openocd.cfg
+++ b/boards/arm/nucleo_h723zg/support/openocd.cfg
@@ -13,15 +13,24 @@ set BOARDNAME NUCLEO-H723ZG
 
 source [find target/stm32h7x.cfg]
 
+# Use connect_assert_srst here to be able to programm
+# even when core is in sleep mode
 reset_config srst_only srst_nogate connect_assert_srst
 
 $_CHIPNAME.cpu0 configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
-        reset halt
         gdb_breakpoint_override hard
 }
 
 $_CHIPNAME.cpu0 configure -event gdb-detach {
         echo "Debugger detaching: resuming execution"
         resume
+}
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
 }

--- a/boards/arm/nucleo_h743zi/support/openocd.cfg
+++ b/boards/arm/nucleo_h743zi/support/openocd.cfg
@@ -1,12 +1,21 @@
 source [find board/st_nucleo_h743zi.cfg]
 
+reset_config srst_only srst_nogate connect_assert_srst
+
 $_CHIPNAME.cpu0 configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
-        reset halt
         gdb_breakpoint_override hard
 }
 
 $_CHIPNAME.cpu0 configure -event gdb-detach {
         echo "Debugger detaching: resuming execution"
         resume
+}
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+       reset halt
 }

--- a/boards/arm/nucleo_h745zi_q/board.cmake
+++ b/boards/arm/nucleo_h745zi_q/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf")
 board_runner_args(jlink "--device=STM32H745ZI" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_h745zi_q/support/openocd.cfg
+++ b/boards/arm/nucleo_h745zi_q/support/openocd.cfg
@@ -6,15 +6,24 @@
 
 source [find board/st_nucleo_h745zi.cfg]
 
+# Use connect_assert_srst here to be able to programm
+# even when core is in sleep mode
 reset_config srst_only srst_nogate connect_assert_srst
 
 $_CHIPNAME.cpu0 configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
-        reset halt
         gdb_breakpoint_override hard
 }
 
 $_CHIPNAME.cpu0 configure -event gdb-detach {
         echo "Debugger detaching: resuming execution"
         resume
+}
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
 }

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
@@ -52,5 +52,5 @@
 &uart8 {
 	pinctrl-0 = <&uart8_tx_pj8 &uart8_rx_pj9>;
 	current-speed = <115200>;
-	/* status = "okay"; */
+	status = "okay";
 };

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4_defconfig
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4_defconfig
@@ -21,10 +21,9 @@ CONFIG_ARM_MPU=y
 # Enable HW stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# By default SERIAL peripherals are assigned to m7
-
 # enable uart driver
-#CONFIG_SERIAL=y
-# console
+CONFIG_SERIAL=y
+
+# By default CONSOLE is assigned to m7
 #CONFIG_CONSOLE=y
 #CONFIG_UART_CONSOLE=y

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -60,10 +60,16 @@
 	status = "okay";
 };
 
-/* From UM2411 Rev 4:
-   With the default setting, the Ethernet feature is not working because of
-   a conflict between ETH_MDC and SAI4_D1 of the MEMs digital microphone */
-   &mac {
+
+&mac {
+	/*
+	 * From UM2411 Rev 4:
+	 * With the default setting, the Ethernet feature is not working due
+	 * of a pin conflict between ETH_MDC and SAI4_D1 of the MEMs digital
+	 * microphone.
+	 * Cf Ethernet section in board documentation for more information on
+	 * the hw modification to be done to enable it.
+	 */
 	status = "okay";
 	pinctrl-0 = <&eth_ref_clk_pa1
 		     &eth_mdio_pa2

--- a/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
+++ b/boards/arm/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
@@ -5,15 +5,24 @@ transport select hla_swd
 
 source [find target/stm32h7x.cfg]
 
+# Use connect_assert_srst here to be able to programm
+# even when core is in sleep mode
 reset_config srst_only srst_nogate connect_assert_srst
 
 $_CHIPNAME.cpu0 configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
-        reset halt
         gdb_breakpoint_override hard
 }
 
 $_CHIPNAME.cpu0 configure -event gdb-detach {
         echo "Debugger detaching: resuming execution"
         resume
+}
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
 }


### PR DESCRIPTION
Miscellaneous fixes on STM32H7 based boards.

Most changes were around use of openocd as I was facing random issues in flash and debugging.
I've not been able to test change on nucleo_h743zi, but said changes were reported working [here](https://github.com/zephyrproject-rtos/zephyr/issues/29732#issuecomment-721010184).
