### PR TITLE
samples: bluetooth: hci_rpmsg: change the allowed platform to nRF5340 DK

### DIFF
--- a/samples/bluetooth/hci_rpmsg/sample.yaml
+++ b/samples/bluetooth/hci_rpmsg/sample.yaml
@@ -5,5 +5,5 @@ sample:
 tests:
   sample.bluetooth.hci_rpmsg:
     harness: bluetooth
-    platform_allow: nrf5340pdk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet
     tags: bluetooth


### PR DESCRIPTION
We have deprecated nRF5340 PDK so change the platform
to nrf5340 DK.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>