### PR TITLE
ci: handle checpatch warnings as errors and increase line limit to 100

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,7 +1,7 @@
 --emacs
 --summary-file
 --show-types
---max-line-length=80
+--max-line-length=100
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
 

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -213,11 +213,7 @@ class CheckPatch(ComplianceTest):
 
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
-            if re.search("[1-9][0-9]* errors,", output):
-                self.add_failure(output)
-            else:
-                # No errors found, but warnings. Show them.
-                self.add_info(output)
+            self.add_failure(output)
 
 
 class KconfigCheck(ComplianceTest):


### PR DESCRIPTION
Fail CI if we have both errors and warnings.

Fixes #29960
Closes #30426

Signed-off-by: Anas Nashif <anas.nashif@intel.com>