### PR TITLE
eth: mcux: Fix proper handling of the 'local-mac-address' property

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1291,7 +1291,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 	.generate_mac = generate_eth##n##_mac,
 
 #define ETH_MCUX_MAC_ADDR(n)						\
-	COND_CODE_1(NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(n)),		\
+	COND_CODE_1(ETH_MCUX_MAC_ADDR_TO_BOOL(n),			\
 		    (ETH_MCUX_MAC_ADDR_LOCAL(n)),			\
 		    (ETH_MCUX_MAC_ADDR_GENERATE(n)))
 
@@ -1302,9 +1302,26 @@ static void eth_mcux_err_isr(const struct device *dev)
 	COND_CODE_1(CONFIG_NET_POWER_MANAGEMENT,			\
 		    (ETH_MCUX_POWER_INIT(n)),				\
 		    (ETH_MCUX_NONE))
+#define ETH_MCUX_GEN_MAC(n)                                             \
+	COND_CODE_0(ETH_MCUX_MAC_ADDR_TO_BOOL(n),                       \
+		    (ETH_MCUX_GENERATE_MAC(n)),                         \
+		    (ETH_MCUX_NONE))
+
+/*
+ * In the below code we explicitly define
+ * ETH_MCUX_MAC_ADDR_TO_BOOL_0 for the '0' instance of enet driver.
+ *
+ * For instance N one shall add definition for ETH_MCUX_MAC_ADDR_TO_BOOL_N
+ */
+#if (NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))) == 0
+#define ETH_MCUX_MAC_ADDR_TO_BOOL_0 0
+#else
+#define ETH_MCUX_MAC_ADDR_TO_BOOL_0 1
+#endif
+#define ETH_MCUX_MAC_ADDR_TO_BOOL(n) ETH_MCUX_MAC_ADDR_TO_BOOL_##n
 
 #define ETH_MCUX_INIT(n)						\
-	ETH_MCUX_GENERATE_MAC(n)					\
+	ETH_MCUX_GEN_MAC(n)                                             \
 									\
 	static void eth##n##_config_func(void);				\
 									\


### PR DESCRIPTION
After the change SHA1: 3498d43784146ce5ffa17b2458eaed31 the
local-mac-address property is no longer parsed correctly when it is
defined in the '&enet` DTS node on k6x SoCs (e.g. frdm_k64f and ip_k66f).

The problem is with value to which the NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(n))
macro is resolved.

If the 'local-mac-address' is present it returns
'(!((0 == 0) && (0 == 0) && (18 == 0) && (19 == 0) && (0 == 0) && (16 == 0)))' [*],
otherwise it is 0.

As COND_CODE_{01} only accepts 0 or 1 as its first argument, it all worked
until the 'local-mac-address' was not defined. When present the first
argument to COND_CODE_{01} macro was [*] and it caused build break.

Fixes issue: #30354
https://github.com/zephyrproject-rtos/zephyr/issues/30354

Signed-off-by: Lukasz Majewski <lukma@denx.de>