### PR TITLE
boards: esp32: use cmake to build ESP-IDF bootloader

### DIFF
--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -5,27 +5,38 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
   include(ExternalProject)
 
   ## we use hell-world project, but I think any can be used.
-  set(espidf_src_dir   ${ESP_IDF_PATH}/examples/get-started/hello_world/)
+  set(espidf_components_dir   ${ESP_IDF_PATH}/components)
   set(espidf_prefix    ${CMAKE_BINARY_DIR}/esp-idf)
   set(espidf_build_dir ${espidf_prefix}/build)
 
   ExternalProject_Add(
     EspIdfBootloader
     PREFIX ${espidf_prefix}
-    SOURCE_DIR ${espidf_src_dir}
-    BINARY_DIR ${espidf_src_dir}
+    SOURCE_DIR ${espidf_components_dir}/bootloader/subproject
+    BINARY_DIR ${espidf_build_dir}/bootloader
     CONFIGURE_COMMAND ""    # Skip configuring the project, e.g. with autoconf
     BUILD_COMMAND
-    PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin
-    make
-    IDF_PATH=${ESP_IDF_PATH}
-    BUILD_DIR_BASE=${espidf_build_dir}
-    SDKCONFIG=${espidf_build_dir}/sdkconfig
-    defconfig bootloader partition_table
+    cmake -GNinja
+    -S ${espidf_components_dir}/bootloader/subproject
+    -B ${espidf_build_dir}/bootloader -DSDKCONFIG=${espidf_build_dir}/sdkconfig
+    -DIDF_PATH=${ESP_IDF_PATH} -DIDF_TARGET=${CONFIG_BOARD}
+    -DPYTHON_DEPS_CHECKED=1
+    && cd ${espidf_build_dir}/bootloader && cmake --build .
     INSTALL_COMMAND ""      # This particular build system has no install command
     )
 
-  add_dependencies(app EspIdfBootloader)
+  ExternalProject_Add(
+    EspPartitionTable
+    SOURCE_DIR ${espidf_components_dir}/partition_table
+    BINARY_DIR ${espidf_build_dir}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND
+    python ${ESP_IDF_PATH}/components/partition_table/gen_esp32part.py -q
+    --offset 0x1000 --flash-size 4MB ${ESP_IDF_PATH}/components/partition_table/partitions_singleapp.csv ${espidf_build_dir}/partitions_singleapp.bin
+    INSTALL_COMMAND ""
+    )
+
+  add_dependencies(app EspIdfBootloader EspPartitionTable)
 
   board_finalize_runner_args(esp32 "--esp-flash-bootloader=${espidf_build_dir}/bootloader/bootloader.bin")
 


### PR DESCRIPTION
Make builds are not supported on Windows command prompt

Signed-off-by: Shubham Kulkarni <shubham.kulkarni@espressif.com>