### PR TITLE
Add FMC support to STM32F429i_disc1 board

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -20,6 +20,12 @@
 		zephyr,ccm = &ccm0;
 	};
 
+	sdram2: sdram@d0000000 {
+		device_type = "memory";
+		status = "okay";
+		reg = <0xd0000000 DT_SIZE_M(8)>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		orange_led_3: led_3 {
@@ -43,6 +49,83 @@
 	aliases {
 		led0 = &green_led_4;
 		sw0 = &user_button;
+	};
+
+	fmc: memory-controller@A0000000 {
+		compatible = "st,stm32-fmc";
+		reg = <0xA0000000 0x1000>;
+		clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+		label = "STM32_FMC";
+		status = "disabled";
+
+		pinctrl-0 = <
+			&fmc_sdcke1_pb5
+			&fmc_sdne1_pb6
+			&fmc_sdclk_pg8
+			&fmc_sdnwe_pc0
+			&fmc_sdnras_pf11
+			&fmc_sdncas_pg15
+			&fmc_a0_pf0
+			&fmc_a1_pf1
+			&fmc_a2_pf2
+			&fmc_a3_pf3
+			&fmc_a4_pf4
+			&fmc_a5_pf5
+			&fmc_a6_pf12
+			&fmc_a7_pf13
+			&fmc_a8_pf14
+			&fmc_a9_pf15
+			&fmc_a10_pg0
+			&fmc_a11_pg1
+			&fmc_a14_pg4
+			&fmc_a15_pg5
+			&fmc_nbl0_pe0
+			&fmc_nbl1_pe1
+			&fmc_d0_pd14
+			&fmc_d1_pd15
+			&fmc_d2_pd0
+			&fmc_d3_pd1
+			&fmc_d4_pe7
+			&fmc_d5_pe8
+			&fmc_d6_pe9
+			&fmc_d7_pe10
+			&fmc_d8_pe11
+			&fmc_d9_pe12
+			&fmc_d10_pe13
+			&fmc_d11_pe14
+			&fmc_d12_pe15
+			&fmc_d13_pd8
+			&fmc_d14_pd9
+			&fmc_d15_pd10
+		>;
+
+		sdram {
+			compatible = "st,stm32-fmc-sdram";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			label = "STM32_FMC_SDRAM";
+			status = "disabled";
+
+			power-up-delay = <100>;
+			num-auto-refresh = <8>;
+			mode-register = <0x220>;
+			refresh-rate = <1386>;
+
+			bank@1 {
+				reg = <1>;
+
+				st,sdram-control = <STM32_FMC_SDRAM_NC_8
+							STM32_FMC_SDRAM_NR_12
+							STM32_FMC_SDRAM_MWID_16
+							STM32_FMC_SDRAM_NB_4
+							STM32_FMC_SDRAM_CAS_2
+							STM32_FMC_SDRAM_SDCLK_PERIOD_2
+							STM32_FMC_SDRAM_RBURST_ENABLE
+							STM32_FMC_SDRAM_RPIPE_0>;
+				st,sdram-timing = <2 7 4 7 2 2 2>;
+			};
+
+		};
 	};
 };
 

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -103,6 +103,9 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	case STM32_CLOCK_BUS_AHB2:
 		LL_AHB2_GRP1_EnableClock(pclken->enr);
 		break;
+	case STM32_CLOCK_BUS_AHB3:
+        LL_AHB3_GRP1_EnableClock(pclken->enr);
+        break; 
 #endif /* CONFIG_SOC_SERIES_STM32_* */
 	case STM32_CLOCK_BUS_APB1:
 		LL_APB1_GRP1_EnableClock(pclken->enr);

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -3,7 +3,7 @@
 
 config MEMC_STM32
 	bool "Enable STM32 Flexible Memory Controller (FMC)"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X
 	help
 	  Enable STM32 Flexible Memory Controller.
 


### PR DESCRIPTION
Use the H7 driver and add device tree node for STM32F429. Other F4 chips not tested. 