### PR TITLE
samples: net: syslog: Add Docker based testing support

### DIFF
--- a/samples/net/syslog_net/Kconfig
+++ b/samples/net/syslog_net/Kconfig
@@ -1,0 +1,15 @@
+# Private config options for syslog-net sample app
+
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Networking syslog sample application"
+
+config NET_SAMPLE_SEND_ITERATIONS
+	int "Send sample data this many times"
+	default 0
+	help
+	  Send sample data this many times before exiting. A value of
+	  zero means that the defaults in the application are used.
+
+source "Kconfig.zephyr"

--- a/samples/net/syslog_net/boards/native_posix.conf
+++ b/samples/net/syslog_net/boards/native_posix.conf
@@ -1,0 +1,2 @@
+# To avoid flood of missing log_strdup messages
+CONFIG_LOG_DETECT_MISSED_STRDUP=n

--- a/samples/net/syslog_net/docker-test.sh
+++ b/samples/net/syslog_net/docker-test.sh
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if [ -z "$RUNNING_FROM_MAIN_SCRIPT" ]; then
+    echo "Do not run this script directly!"
+    echo "Run $ZEPHYR_BASE/scripts/net/run-sample-tests.sh instead."
+    exit 1
+fi
+
+MSG_COUNT=5
+
+start_configuration || return $?
+
+# First IPv6
+start_docker "/usr/local/bin/syslog-receiver.py 2001:db8::2" || return $?
+start_zephyr "$overlay" "-DCONFIG_LOG_BACKEND_NET_SERVER=\"[2001:db8::2]:514\"" \
+             "-DCONFIG_NET_SAMPLE_SEND_ITERATIONS=$MSG_COUNT"
+wait $docker_pid
+docker_result=$?
+wait_zephyr
+result=$?
+stop_docker
+if [ $result -ne 0 ] || [ $docker_result -ne 0 ]; then
+    return ${result}${docker_result}
+fi
+
+# Then IPv4
+start_docker "/usr/local/bin/syslog-receiver.py 192.0.2.2" || return $?
+start_zephyr "$overlay" "-DCONFIG_LOG_BACKEND_NET_SERVER=\"192.0.2.2:514\"" \
+             "-DCONFIG_NET_SAMPLE_SEND_ITERATIONS=$MSG_COUNT"
+wait $docker_pid
+docker_result=$?
+wait_zephyr
+result=$?
+stop_docker
+if [ $result -ne 0 ] || [ $docker_result -ne 0 ]; then
+    return ${result}${docker_result}
+fi
+
+return 0

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -12,28 +12,51 @@ LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 
+#include <stdlib.h>
+
 BUILD_ASSERT(IS_ENABLED(CONFIG_LOG_BACKEND_NET), "syslog backend not enabled");
 
 #define SLEEP_BETWEEN_PRINTS 3
 
 void main(void)
 {
-	int count = 60 / SLEEP_BETWEEN_PRINTS;
-
-	/* Allow some setup time before starting to send data */
-	k_sleep(K_SECONDS(SLEEP_BETWEEN_PRINTS));
+	int i, count, sleep;
 
 	LOG_DBG("Starting");
 
+	if (CONFIG_NET_SAMPLE_SEND_ITERATIONS) {
+		count = CONFIG_NET_SAMPLE_SEND_ITERATIONS;
+		sleep = 500;
+
+		/* This will let the Docker process to start listening */
+		k_msleep(1500);
+
+		LOG_DBG("Sending total %d messages", 4 * count);
+	} else {
+		count = 60 / SLEEP_BETWEEN_PRINTS;
+		sleep = SLEEP_BETWEEN_PRINTS * MSEC_PER_SEC;
+	}
+
+	/* Allow some setup time before starting to send data */
+	k_msleep(sleep);
+
+	i = count;
+
 	do {
-		LOG_ERR("Error message");
-		LOG_WRN("Warning message");
-		LOG_INF("Info message");
-		LOG_DBG("Debug message");
+		LOG_ERR("Error message (%d)", i);
+		LOG_WRN("Warning message (%d)", i);
+		LOG_INF("Info message (%d)", i);
+		LOG_DBG("Debug message (%d)", i);
 
-		k_sleep(K_SECONDS(SLEEP_BETWEEN_PRINTS));
+		k_msleep(sleep);
 
-	} while (count--);
+	} while (--i);
 
-	LOG_DBG("Stopping");
+	LOG_DBG("Stopped after %d msg", count);
+
+	if (CONFIG_NET_SAMPLE_SEND_ITERATIONS) {
+		/* We get here when doing Docker based testing */
+		k_msleep(1000);
+		exit(0);
+	}
 }

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
       revision: 697e145d5ee5e4b400e9d7bceaec79f6ac29df7c
       path: modules/lib/mcumgr
     - name: net-tools
-      revision: dcfa04f4aaf30ae7c2dbf34a05a569ca1c04b2ce
+      revision: 41132e9220f8bc1223084975350c5e5f3b492afe
       path: tools/net-tools
     - name: hal_nxp
       revision: 56915d2942a3af7205b3c4991a8b87e915de7f59


### PR DESCRIPTION
Allow the sample to be run against a rsyslog listener running
inside Docker.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>