### PR TITLE
doc: add kernel stack macros to stack apis

### DIFF
--- a/include/sys/thread_stack.h
+++ b/include/sys/thread_stack.h
@@ -103,6 +103,11 @@ static inline char *z_stack_ptr_align(char *ptr)
 #define K_KERNEL_STACK_EXTERN(sym) extern k_thread_stack_t sym[]
 
 /**
+ * @addtogroup stack_apis
+ * @{
+ */
+
+/**
  * @def K_KERNEL_STACK_DEFINE
  * @brief Define a toplevel kernel stack memory region
  *
@@ -163,6 +168,8 @@ static inline char *z_stack_ptr_align(char *ptr)
 		sym[Z_KERNEL_STACK_SIZE_ADJUST(size)]
 
 #define K_KERNEL_STACK_SIZEOF(sym) (sizeof(sym) - K_KERNEL_STACK_RESERVED)
+
+/** @} */
 
 static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 {
@@ -277,6 +284,11 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 #define K_THREAD_STACK_EXTERN(sym) extern k_thread_stack_t sym[]
 
 /**
+ * @addtogroup stack_apis
+ * @{
+ */
+
+/**
  * @brief Return the size in bytes of a stack memory region
  *
  * Convenience macro for passing the desired stack size to k_thread_create()
@@ -380,6 +392,8 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 	struct z_thread_stack_element \
 		__aligned(Z_THREAD_STACK_OBJ_ALIGN(size)) \
 		sym[Z_THREAD_STACK_SIZE_ADJUST(size)]
+
+/** @} */
 
 /**
  * @brief Get a pointer to the physical stack buffer


### PR DESCRIPTION
Fix broken references to K_THREAD_STACK_* and K_KERNEL_STACK_* macros by adding those to the existing stack_apis group.