### PR TITLE
kernel: init: activate FPU for main thread

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -233,6 +233,7 @@ static void init_idle_thread(int i)
 static char *prepare_multithreading(void)
 {
 	char *stack_ptr;
+	uint32_t opt;
 
 	/* _kernel.ready_q is all zeroes */
 	z_sched_init();
@@ -249,11 +250,18 @@ static char *prepare_multithreading(void)
 	 */
 	_kernel.ready_q.cache = &z_main_thread;
 #endif
+
+	opt = K_ESSENTIAL;
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	/* Enable FPU in main thread */
+	opt |= K_FP_REGS;
+#endif
+
 	stack_ptr = z_setup_new_thread(&z_main_thread, z_main_stack,
 				       CONFIG_MAIN_STACK_SIZE, bg_thread_main,
 				       NULL, NULL, NULL,
 				       CONFIG_MAIN_THREAD_PRIORITY,
-				       K_ESSENTIAL, "main");
+				       opt, "main");
 	z_mark_thread_as_started(&z_main_thread);
 	z_ready_thread(&z_main_thread);
 


### PR DESCRIPTION
This patch activates FPU feature for main thread if FPU related
configs (FPU, FPU_SHARING) are enabled.

Signed-off-by: Katsuhiro Suzuki <katsuhiro@katsuster.net>

----

This PR will fix the problem of issue #29349.