### PR TITLE
boards: arm: sam4e/s: Enable bossac bootloader runner

### DIFF
--- a/boards/arm/sam4e_xpro/board.cmake
+++ b/boards/arm/sam4e_xpro/board.cmake
@@ -2,3 +2,5 @@
 
 board_runner_args(openocd --cmd-post-verify "at91sam4 gpnvm set 1")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/boards/arm/sam4e_xpro/doc/index.rst
+++ b/boards/arm/sam4e_xpro/doc/index.rst
@@ -106,6 +106,43 @@ contents of the SAM4E flash memory:
 Flashing
 ========
 
+For flash the board Zephyr provides two paths.  One uses the default OpenOCD
+tool and the second one uses :ref:`atmel_sam_ba_bootloader`.
+
+Using OpenOCD
+-------------
+
+#. Connect the SAM4E Xplained Pro board to your host computer using the USB
+   debug port. Then build and flash the :ref:`hello_world` application.
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam4e_xpro
+      :goals: build flash
+
+Using SAM-BA bootloader
+-----------------------
+
+#. Close the ``ERASE`` jumper on the SAM4E Xplained Pro board.  Power on the
+   board for 10s.
+
+#. Open the ``ERASE`` jumper.
+
+#. Connect the SAM4E Xplained Pro board to your host computer using the SoC
+   USB port. Then build and flash the :ref:`hello_world` application.
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam4e_xpro
+      :goals: build
+
+   .. code-block:: console
+
+      $ west flash -r bossac
+
+Visualizing the message
+-----------------------
+
 #. Run your favorite terminal program to listen for output. Under Linux the
    terminal should be :code:`/dev/ttyACM0`. For example:
 
@@ -113,22 +150,15 @@ Flashing
 
       $ minicom -D /dev/ttyACM0 -o
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   The -o option tells minicom not to send the modem initialization string.
+   Connection should be configured as follows:
 
    - Speed: 115200
    - Data: 8 bits
    - Parity: None
    - Stop bits: 1
 
-#. Connect the SAM4E Xplained Pro board to your host computer using the
-   USB debug port. Then build and flash the :ref:`hello_world`
-   application.
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: sam4e_xpro
-      :goals: build flash
+#. Press reset button
 
    You should see "Hello World! arm" in your terminal.
 

--- a/boards/arm/sam4s_xplained/board.cmake
+++ b/boards/arm/sam4s_xplained/board.cmake
@@ -2,3 +2,5 @@
 
 board_runner_args(jlink "--device=atsam4s16c" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)

--- a/boards/arm/sam4s_xplained/doc/index.rst
+++ b/boards/arm/sam4s_xplained/doc/index.rst
@@ -89,10 +89,49 @@ the SAM4S16C.
 Flashing
 ========
 
+For flash the board Zephyr provides two paths.  One uses the default JLink
+tool and the second one uses :ref:`atmel_sam_ba_bootloader`.
+
+Using JLink
+-------------
+
 #. Download JLink from the Segger `JLink Downloads Page`_. Go to the section
-   "J-Link Software and Documentation Pack" and install the "J-Link Software and
-   Documentation pack for Linux". The application JLinkExe needs to be accessible
-   from your path.
+   "J-Link Software and Documentation Pack" and install the "J-Link Software
+   and Documentation pack for Linux". The application JLinkExe needs to be
+   accessible from your path.
+
+#. Connect the SAM4S Xplained board to your host computer using the USB debug
+   port. Then build and flash the :ref:`hello_world` application.
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam4s_xplained
+      :goals: build flash
+
+
+Using SAM-BA bootloader
+-----------------------
+
+#. Close the ``J25`` jumper on the SAM4S Xplained board.  Power on the board
+   for 10s.
+
+#. Open the ``J25`` jumper.
+
+#. Connect the SAM4S Xplained board to your host computer using the SoC USB
+   port. Then build and flash the :ref:`hello_world` application.
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam4s_xplained
+      :goals: build
+
+   .. code-block:: console
+
+      $ west flash -r bossac
+
+
+Visualizing the message
+-----------------------
 
 #. Run your favorite terminal program to listen for output. Under Linux the
    terminal should be :code:`/dev/ttyACM0`. For example:
@@ -101,24 +140,18 @@ Flashing
 
       $ minicom -D /dev/ttyACM0 -o
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   The -o option tells minicom not to send the modem initialization string.
+   Connection should be configured as follows:
 
    - Speed: 115200
    - Data: 8 bits
    - Parity: None
    - Stop bits: 1
 
-#. Connect the SAM4S Xplained board to your host computer using the
-   USB debug port. Then build and flash the :ref:`hello_world`
-   application.
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: sam4s_xplained
-      :goals: build flash
+#. Press reset button
 
    You should see "Hello World! arm" in your terminal.
+
 
 Debugging
 =========


### PR DESCRIPTION
The SAM4E/S SoC have a ROM bootloader named SAM-BA.  Add bossac to the board west runner list.  This requires Zephyr SDK 0.12.0.

Since SDK 0.12.0 is not yet released, the minimal version for tests is 0.12.0-beta-2.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>