### PR TITLE
drivers: modem: fix sending with zero timeout and no semaphore

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -477,7 +477,7 @@ static int _modem_cmd_send(struct modem_iface *iface,
 	struct modem_cmd_handler_data *data;
 	int ret;
 
-	if (!iface || !handler || !handler->cmd_handler_data || !buf || !sem) {
+	if (!iface || !handler || !handler->cmd_handler_data || !buf) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
There was a regression introduced when reordering function parameters
check. It is valid to pass NULL semaphore with zero timeout, so fix
parameter check to respect that.

Fixes: 67976f8686bb ("drivers: modem: verify send semaphore before
  taking any action")
