### PR TITLE
MAINTAINERS: Remove myself as modem drivers maintainer.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -228,7 +228,6 @@
 /drivers/led_strip/                       @mbolivar-nordic
 /drivers/lora/                            @Mani-Sadhasivam
 /drivers/memc/                            @gmarull
-/drivers/modem/                           @mike-scott
 /drivers/modem/*gsm*                      @jukkar
 /drivers/modem/hl7800.c                   @rerickson1
 /drivers/modem/Kconfig.hl7800             @rerickson1

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -577,9 +577,7 @@ Documentation:
         - samples/drivers/lora/
 
 "Drivers: Modem":
-    status: maintained
-    maintainers:
-        - mike-scott
+    status: orphaned
     files:
         - drivers/modem/
     labels:


### PR DESCRIPTION
- Status is now orphaned.
- There has been a bit of activity in this area over the last
  few months and I'm sure one or more of these new stake holders
  would make a fine maintainer.

Signed-off-by: Michael Scott <mike@foundries.io>