### PR TITLE
drivers: bluetooth: Add timeout to rpmsg init

### DIFF
--- a/drivers/bluetooth/hci/rpmsg_nrf53.c
+++ b/drivers/bluetooth/hci/rpmsg_nrf53.c
@@ -263,7 +263,11 @@ int bt_rpmsg_platform_init(void)
 	}
 
 	/* Wait til nameservice ep is setup */
-	k_sem_take(&ready_sem, K_FOREVER);
+	err = k_sem_take(&ready_sem, K_SECONDS(3));
+	if (err) {
+		BT_ERR("No contact with network core EP (err %d)", err);
+		return err;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Previously, when opening the Bluetooth driver on the app core of
nRF53, the application could hang forever. This would happen if
the network core was not flashed or flashed with the wrong firmware.

This commit improves the user experience timing out if the net core
is not replying. 3 seconds is considered to be more than enough to boot
the network core.

Before:
```
*** Booting Zephyr OS build v2.4.0-ncs1-1710-g5a7b4eb71047  ***
```
After:
```
*** Booting Zephyr OS build v2.4.0-ncs1-1710-g5a7b4eb71047  ***
Bluetooth init failed (err -11)
[00:00:03.448,913] <err> bt_hci_driver_nrf53: No contact with network core EP (err -11)
[00:00:03.448,913] <err> bt_hci_core: HCI driver open failed (-11)
```


