### PR TITLE
doc: kernel: expose function

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1973,6 +1973,7 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_FLASH_PAGE_LAYOUT" \
                          "CONFIG_FPU" \
                          "CONFIG_FPU_SHARING" \
+                         "CONFIG_HEAP_MEM_POOL_SIZE" \
                          "CONFIG_MMU" \
                          "CONFIG_NET_L2_ETHERNET_MGMT" \
                          "CONFIG_NET_MGMT_EVENT" \


### PR DESCRIPTION
k_thread_system_pool_assign() is referenced  in the [memory pool API documentation](https://docs.zephyrproject.org/latest/reference/kernel/memory/pools.html#thread-resource-pools) and used in multiple tests, but generated documentation was excluded by preprocessor condition.  Add a PREDEFINED to expose it.