### PR TITLE
Bluetooth: Mesh: Fixes wrong app_key_idx parameters

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -394,7 +394,7 @@ static void app_key_del(struct bt_mesh_model *model,
 
 	BT_DBG("AppIdx 0x%04x NetIdx 0x%04x", key_app_idx, key_net_idx);
 
-	status = bt_mesh_app_key_del(key_net_idx, key_net_idx);
+	status = bt_mesh_app_key_del(key_app_idx, key_net_idx);
 
 	send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }


### PR DESCRIPTION
`app_key_del` first param should be key_app_idx,
not key_net_idx.

The effect is that app_key_del is broken.

It's a regression in eca0141
Bluetooth: Mesh: Isolate cryptographic material

Fixes: #30468

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>