### PR TITLE
boards: stm32l562e_dk: add support for SPI

### DIFF
--- a/boards/arm/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/arm/stm32l562e_dk/Kconfig.defconfig
@@ -8,4 +8,28 @@ if BOARD_STM32L562E_DK
 config BOARD
 	default "stm32l562e_dk"
 
+if BT
+
+config SPI
+	default y
+
+choice BT_HCI_BUS_TYPE
+	default BT_SPI
+endchoice
+
+config BT_SPI_BLUENRG
+	default y
+
+config BT_BLUENRG_ACI
+	default y
+
+# Disable Flow control
+config BT_HCI_ACL_FLOW_CONTROL
+	default n
+
+config BT_HCI_VS_EXT
+	default n
+
+endif # BT
+
 endif # BOARD_STM32L562E_DK

--- a/boards/arm/stm32l562e_dk/doc/index.rst
+++ b/boards/arm/stm32l562e_dk/doc/index.rst
@@ -164,6 +164,8 @@ The Zephyr stm32l562e_dk board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -184,6 +186,7 @@ Default Zephyr Peripheral Mapping:
 
 - USART_1 TX/RX : PA9/PA10
 - I2C_1 SCL/SDA : PB6/PB7
+- SPI_1 SCK/MISO/MOSI : PG2/PG3/PG4 (BT SPI bus)
 - USER_PB : PC13
 - LD10 : PG12
 

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -12,11 +12,11 @@
 	leds {
 		compatible = "gpio-leds";
 		red_led_9: led_9 {
-			gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
 			label = "User LD9";
 		};
 		green_led_10: led_10 {
-			gpios = <&gpiog 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiog 12 GPIO_ACTIVE_LOW>;
 			label = "User LD10";
 		};
 	};

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -48,3 +48,18 @@
 		label = "LSM6DSO";
 	};
 };
+
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pg2 &spi1_miso_pg3 &spi1_mosi_pg4>;
+	cs-gpios = <&gpiog 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	status = "okay";
+
+	spbtle-rf@0 {
+		compatible = "zephyr,bt-hci-spi";
+		reg = <0>;
+		irq-gpios = <&gpiog 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		reset-gpios = <&gpiog 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		spi-max-frequency = <2000000>;
+		label = "SPBTLE-RF";
+	};
+};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -204,6 +204,17 @@
 			status = "disabled";
 			label= "I2C_1";
 		};
+
+		spi1: spi@40013000 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			interrupts = <59 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			status = "disabled";
+			label = "SPI_1";
+		};
 	};
 };
 


### PR DESCRIPTION
Add spi1 interface for stm32l552xx and stm32l562xx microcontrollers
and enable spi1 that connects to STM module SPBTLE-RFTR on the
stm32l562e_dk board.

Tested the configuration with st_ble_sensor sample + ST BLE Sensor
app on Android phone.

Signed-off-by: Yestin Sun <sunyi0804@gmail.com>