### PR TITLE
net: mqtt: Return -1 if keepalive messages are disabled.

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -46,6 +46,9 @@ API Changes
   ``user_data`` as arguments instead of structure which contained list node,
   callback and user data.
 
+* The :c:func:`mqtt_keepalive_time_left` function now returns -1 if keep alive
+  messages are disabled by setting ``CONFIG_MQTT_KEEPALIVE`` to 0.
+
 Deprecated in this release
 ==========================
 

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -727,10 +727,10 @@ int mqtt_live(struct mqtt_client *client);
  * @param[in] client Client instance for which the procedure is requested.
  *
  * @return Time in milliseconds until next keep alive message is expected to
- *         be sent. Function will return UINT32_MAX if keep alive messages are
+ *         be sent. Function will return -1 if keep alive messages are
  *         not enabled.
  */
-uint32_t mqtt_keepalive_time_left(const struct mqtt_client *client);
+int mqtt_keepalive_time_left(const struct mqtt_client *client);
 
 /**
  * @brief Receive an incoming MQTT packet. The registered callback will be

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -618,7 +618,7 @@ int mqtt_live(struct mqtt_client *client)
 	}
 }
 
-uint32_t mqtt_keepalive_time_left(const struct mqtt_client *client)
+int mqtt_keepalive_time_left(const struct mqtt_client *client)
 {
 	uint32_t elapsed_time = mqtt_elapsed_time_in_ms_get(
 					client->internal.last_activity);
@@ -626,7 +626,7 @@ uint32_t mqtt_keepalive_time_left(const struct mqtt_client *client)
 
 	if (client->keepalive == 0) {
 		/* Keep alive not enabled. */
-		return UINT32_MAX;
+		return -1;
 	}
 
 	if (keepalive_ms <= elapsed_time) {


### PR DESCRIPTION
In mqtt_keepalive_time_left(), return -1 if keep alive messages are
disabled by setting CONFIG_MQTT_KEEPALIVE=0.

This allows to use mqtt_keepalive_time_left() directly as an input
for poll(). If no keep-alive is expected, -1 would indicate
that poll() can block until new data is available on the socket.