### PR TITLE
drivers: clock_control: Fix missing ifdefs for stm32wb, stm32g0

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -150,6 +150,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	defined(CONFIG_SOC_SERIES_STM32F4X) || \
 	defined(CONFIG_SOC_SERIES_STM32F7X) || \
 	defined(CONFIG_SOC_SERIES_STM32F2X) || \
+	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X)
 	case STM32_CLOCK_BUS_AHB2:
 		LL_AHB2_GRP1_DisableClock(pclken->enr);
@@ -172,11 +173,11 @@ static inline int stm32_clock_control_off(const struct device *dev,
 		LL_APB2_GRP1_DisableClock(pclken->enr);
 		break;
 #endif /* CONFIG_SOC_SERIES_STM32F0X */
-#ifdef CONFIG_SOC_SERIES_STM32L0X
+#if defined (CONFIG_SOC_SERIES_STM32L0X) || defined (CONFIG_SOC_SERIES_STM32G0X)
 	case STM32_CLOCK_BUS_IOP:
 		LL_IOP_GRP1_DisableClock(pclken->enr);
 		break;
-#endif /* CONFIG_SOC_SERIES_STM32L0X */
+#endif /* CONFIG_SOC_SERIES_STM32L0X || CONFIG_SOC_SERIES_STM32G0X */
 	default:
 		return -ENOTSUP;
 	}
@@ -209,9 +210,9 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	switch (pclken->bus) {
 	case STM32_CLOCK_BUS_AHB1:
 	case STM32_CLOCK_BUS_AHB2:
-#ifdef CONFIG_SOC_SERIES_STM32L0X
+#if defined (CONFIG_SOC_SERIES_STM32L0X) || defined (CONFIG_SOC_SERIES_STM32G0X)
 	case STM32_CLOCK_BUS_IOP:
-#endif /* CONFIG_SOC_SERIES_STM32L0X */
+#endif /* (CONFIG_SOC_SERIES_STM32L0X) || defined (CONFIG_SOC_SERIES_STM32G0X) */
 		*rate = ahb_clock;
 		break;
 	case STM32_CLOCK_BUS_APB1:


### PR DESCRIPTION
Some Clocks have ifdefs only for clock_control_on but are missing them for
clock_control_off.
Additionally return ahb_clock clock frequency for stm32g0
STM32_CLOCK_BUS_IOP in stm32_clock_control_get_subsys_rate.

Signed-off-by: Thomas Stranger <thomas.stranger@outlook.com>