### PR TITLE
maintainers: remove obsolete path

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1027,7 +1027,6 @@ Shell:
         - include/shell/
         - samples/subsys/shell/
         - subsys/shell/
-        - tests/shell/
         - tests/subsys/shell/
     labels:
         - "area: Shell"


### PR DESCRIPTION
Commit: 11de84a6b4ec4be23bed92bf2d8d36f3876189b6 moved shell core tests from tests/shell to tests/subsys/shell. Remove obsolete path from MAINTAINERS.yml accordingly.

Related PR: #30389 

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>