### PR TITLE
drivers: clock_control: nrf: Add audio clock support to nrf53

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -250,6 +250,18 @@ static void hfclk192m_stop(void)
 }
 #endif
 
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+static void hfclkaudio_start(void)
+{
+	nrfx_clock_start(NRF_CLOCK_DOMAIN_HFCLKAUDIO);
+}
+
+static void hfclkaudio_stop(void)
+{
+	nrfx_clock_stop(NRF_CLOCK_DOMAIN_HFCLKAUDIO);
+}
+#endif
+
 static uint32_t *get_hf_flags(void)
 {
 	struct nrf_clock_control_data *data = CLOCK_DEVICE->data;
@@ -582,6 +594,11 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 		clkstarted_handle(dev, CLOCK_CONTROL_NRF_TYPE_HFCLK192M);
 		break;
 #endif
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+	case NRFX_CLOCK_EVT_HFCLKAUDIO_STARTED:
+		clkstarted_handle(dev, CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO);
+		break;
+#endif
 	case NRFX_CLOCK_EVT_LFCLK_STARTED:
 		if (IS_ENABLED(
 			CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION)) {
@@ -669,6 +686,13 @@ static const struct nrf_clock_control_config config = {
 			.start = hfclk192m_start,
 			.stop = hfclk192m_stop,
 			IF_ENABLED(CONFIG_LOG, (.name = "hfclk192m",))
+		},
+#endif
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+		[CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO] = {
+			.start = hfclkaudio_start,
+			.stop = hfclkaudio_stop,
+			IF_ENABLED(CONFIG_LOG, (.name = "hfclkaudio",))
 		},
 #endif
 	}

--- a/include/drivers/clock_control/nrf_clock_control.h
+++ b/include/drivers/clock_control/nrf_clock_control.h
@@ -22,6 +22,9 @@ enum clock_control_nrf_type {
 #if NRF_CLOCK_HAS_HFCLK192M
 	CLOCK_CONTROL_NRF_TYPE_HFCLK192M,
 #endif
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+	CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO,
+#endif
 	CLOCK_CONTROL_NRF_TYPE_COUNT
 };
 
@@ -34,6 +37,8 @@ enum clock_control_nrf_type {
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_LFCLK)
 #define CLOCK_CONTROL_NRF_SUBSYS_HF192M \
 	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK192M)
+#define CLOCK_CONTROL_NRF_SUBSYS_HFAUDIO \
+	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO)
 
 /** @brief LF clock start modes. */
 enum nrf_lfclk_start_mode {


### PR DESCRIPTION
Added support for audio clock in nrf53.

Fixes #30435 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>