### PR TITLE
Bluetooth: controller: nRF5x: Fix lll LF clock wait

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -66,9 +66,15 @@ int lll_clock_init(void)
 
 int lll_clock_wait(void)
 {
-	struct onoff_manager *mgr =
-		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
+	struct onoff_manager *mgr;
+	static bool done;
 
+	if (done) {
+		return 0;
+	}
+	done = true;
+
+	mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
 	return blocking_on(mgr, LFCLOCK_TIMEOUT_MS);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -68,6 +68,7 @@ int lll_clock_wait(void)
 {
 	struct onoff_manager *mgr;
 	static bool done;
+	int err;
 
 	if (done) {
 		return 0;
@@ -75,7 +76,17 @@ int lll_clock_wait(void)
 	done = true;
 
 	mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
-	return blocking_on(mgr, LFCLOCK_TIMEOUT_MS);
+	err = blocking_on(mgr, LFCLOCK_TIMEOUT_MS);
+	if (err) {
+		return err;
+	}
+
+	err = onoff_release(mgr);
+	if (err != ONOFF_STATE_ON) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int lll_hfclock_on(void)


### PR DESCRIPTION
Fix lll_clock_wait function to wait for LF clock to settle
only once after power up.

Regression introduced in commit 2b4763076eab ("bluetooth:
controller: Adapt to onoff clock control").

Fixes #30480.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>