### PR TITLE
minimal libc: close gap in functionality for integer types

### DIFF
--- a/lib/libc/minimal/include/stdint.h
+++ b/lib/libc/minimal/include/stdint.h
@@ -74,6 +74,24 @@ typedef __UINT_LEAST64_TYPE__	uint_least64_t;
 typedef __INTPTR_TYPE__		intptr_t;
 typedef __UINTPTR_TYPE__	uintptr_t;
 
+#ifdef __GNUC__
+/* These macros must produce constant integer expressions, which can't
+ * be done in the preprocessor (casts aren't allowed).  Defer to the
+ * GCC internal functions where they're available.
+ */
+#define INT8_C(_v) __INT8_C(_v)
+#define INT16_C(_v) __INT16_C(_v)
+#define INT32_C(_v) __INT32_C(_v)
+#define INT64_C(_v) __INT64_C(_v)
+#define INTMAX_C(_v) __INTMAX_C(_v)
+
+#define UINT8_C(_v) __UINT8_C(_v)
+#define UINT16_C(_v) __UINT16_C(_v)
+#define UINT32_C(_v) __UINT32_C(_v)
+#define UINT64_C(_v) __UINT64_C(_v)
+#define UINTMAX_C(_v) __UINTMAX_C(_v)
+#endif /* __GNUC__ */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -123,6 +123,20 @@ void test_stdint(void)
 {
 	zassert_true((unsigned_int + unsigned_byte + 1u == 0U), NULL);
 
+#if (UINT8_C(1) == 1)			\
+	&& (INT8_C(-1) == -1)		\
+	&& (UINT16_C(2) == 2)		\
+	&& (INT16_C(-2) == -2)		\
+	&& (UINT32_C(4) == 4)		\
+	&& (INT32_C(-4) == -4)		\
+	&& (UINT64_C(8) == 8)		\
+	&& (INT64_C(-8) == -8)		\
+	&& (UINTMAX_C(11) == 11)	\
+	&& (INTMAX_C(-11) == -11)
+	zassert_true(true, NULL);
+#else
+	zassert_true(false, "const int expr values ...");
+#endif
 }
 
 /*

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <zephyr/types.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Add the macros `INTn_C()` which expand to constant integer expressions of the appropriate type.  E.g. `INT64_C(1)` should become `1`, `1L`, or `1LL` depending on host capabilities.

This will currently only work if a toolchain that supports the GNUC intrinsic `__INTn_C()` functions is used.

Also fix a problem with the c_lib test, and correct the values of the `PRI?64/MAX` macros to use length modifiers that are more correct.

Fixes #30117