### PR TITLE
Bluetooth: controller: Fix cond. compile of conn window offset calc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -597,9 +597,7 @@ static void isr_done(void *param)
 
 static void isr_window(void *param)
 {
-	uint32_t ticks_anchor_prev;
 	uint32_t ticks_at_start;
-	bool is_sched_advanced;
 	uint32_t remainder_us;
 	struct lll_scan *lll;
 
@@ -613,8 +611,11 @@ static void isr_window(void *param)
 	}
 	lll_chan_set(37 + lll->chan);
 
-	is_sched_advanced = IS_ENABLED(CONFIG_BT_CTLR_SCHED_ADVANCED) &&
-			    lll->conn && lll->conn_win_offset_us;
+#if defined(CONFIG_BT_CENTRAL)
+	bool is_sched_advanced = IS_ENABLED(CONFIG_BT_CTLR_SCHED_ADVANCED) &&
+				 lll->conn && lll->conn_win_offset_us;
+	uint32_t ticks_anchor_prev;
+
 	if (is_sched_advanced) {
 		/* Get the ticks_anchor when the offset to free time space for
 		 * a new central event was last calculated at the start of the
@@ -626,6 +627,7 @@ static void isr_window(void *param)
 	} else {
 		ticks_anchor_prev = 0U;
 	}
+#endif /* CONFIG_BT_CENTRAL */
 
 	ticks_at_start = ticker_ticks_now_get() +
 			 HAL_TICKER_CNTR_CMP_OFFSET_MIN;
@@ -645,6 +647,7 @@ static void isr_window(void *param)
 	ARG_UNUSED(remainder_us);
 #endif /* !CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
+#if defined(CONFIG_BT_CENTRAL)
 	if (is_sched_advanced) {
 		uint32_t ticks_anchor_new, ticks_delta, ticks_delta_us;
 
@@ -663,6 +666,7 @@ static void isr_window(void *param)
 		 */
 		lll->conn_win_offset_us -= ticks_delta_us;
 	}
+#endif /* CONFIG_BT_CENTRAL */
 }
 
 static void isr_abort(void *param)


### PR DESCRIPTION
Fix missing conditional compilation of connection window
offset calculations.

Regression introduced in commit 467173a5664

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>