### PR TITLE
kernel: fix usage of KERNEL_COHERENCE macro

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -118,7 +118,7 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 
 #ifdef CONFIG_SPIN_VALIDATE
 	__ASSERT(z_spin_lock_valid(l), "Recursive spinlock %p", l);
-# ifdef KERNEL_COHERENCE
+# ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(l));
 # endif
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -842,7 +842,8 @@ config TRACE_SCHED_IPI
 
 config KERNEL_COHERENCE
 	bool "Place all shared data into coherent memory"
-	default y if ARCH_HAS_COHERENCE && SMP && MP_NUM_CPUS > 1
+	depends on ARCH_HAS_COHERENCE
+	default y if SMP && MP_NUM_CPUS > 1
 	select THREAD_STACK_INFO
 	help
 	  When available and selected, the kernel will build in a mode

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -157,7 +157,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 	z_init_static_threads();
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(_kernel));
 #endif
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -413,7 +413,7 @@ static void update_cache(int preempt_ok)
 
 static void ready_thread(struct k_thread *thread)
 {
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(thread));
 #endif
 
@@ -676,7 +676,7 @@ static void add_thread_timeout(struct k_thread *thread, k_timeout_t timeout)
 static void pend(struct k_thread *thread, _wait_q_t *wait_q,
 		 k_timeout_t timeout)
 {
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(wait_q));
 #endif
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -571,7 +571,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	z_init_thread_base(&new_thread->base, prio, _THREAD_PRESTART, options);
 	stack_ptr = setup_thread_stack(new_thread, stack, stack_size);
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	/* Check that the thread object is safe, but that the stack is
 	 * still cached!
 	 */

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -91,7 +91,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 		return;
 	}
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(to));
 #endif
 


### PR DESCRIPTION
Add missing CONFIG_ to KERNEL_COHERENCE usage in code.

Fixes #30380