### PR TITLE
[Backport 27774 to v1.14] Possible read out of bounds in dns read

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -325,7 +325,7 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg)
 
 	/* 4 bytes more due to qtype and qclass */
 	offset += DNS_QTYPE_LEN + DNS_QCLASS_LEN;
-	if (offset > dns_msg->msg_size) {
+	if (offset >= dns_msg->msg_size) {
 		return -ENOMEM;
 	}
 

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -352,14 +352,10 @@ int dns_copy_qname(u8_t *buf, u16_t *len, u16_t size,
 	u8_t *msg = dns_msg->msg;
 	u16_t lb_size;
 	int rc = -EINVAL;
-	int i = 0;
 
 	*len = 0U;
 
-	/* Iterate ANCOUNT + 1 to allow the Query's QNAME to be parsed.
-	 * This is required to avoid 'alias loops'
-	 */
-	while (i++ < dns_header_ancount(dns_msg->msg) + 1) {
+	while (1) {
 		if (pos >= msg_size) {
 			rc = -ENOMEM;
 			break;

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -463,7 +463,8 @@ static int dns_read(struct dns_resolve_context *ctx,
 		}
 
 		/* Update the answer offset to point to the next RR (answer) */
-		dns_msg.answer_offset += DNS_ANSWER_PTR_LEN;
+		dns_msg.answer_offset += dns_msg.response_position -
+							dns_msg.answer_offset;
 		dns_msg.answer_offset += dns_msg.response_length;
 
 		server_idx++;

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -353,6 +353,12 @@ static int dns_read(struct dns_resolve_context *ctx,
 	dns_msg.msg = dns_data->data;
 	dns_msg.msg_size = data_len;
 
+	/* Make sure that we can read DNS id, flags and rcode */
+	if (dns_msg.msg_size < (sizeof(*dns_id) + sizeof(uint16_t))) {
+		ret = DNS_EAI_FAIL;
+		goto quit;
+	}
+
 	/* The dns_unpack_response_header() has design flaw as it expects
 	 * dns id to be given instead of returning the id to the caller.
 	 * In our case we would like to get it returned instead so that we

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -434,6 +434,13 @@ static int dns_read(struct dns_resolve_context *ctx,
 				goto quit;
 			}
 
+			if ((dns_msg.response_position + address_size) >
+			    dns_msg.msg_size) {
+				/* Too short message */
+				ret = DNS_EAI_FAIL;
+				goto quit;
+			}
+
 			src = dns_msg.msg + dns_msg.response_position;
 
 			memcpy(addr, src, address_size);


### PR DESCRIPTION
Backport of #27774 to v1.14. The last comit 6493af2714a5cb85911b46a10edd85c9267f704f has several conflicts and is not part of the backport. Though, this commit seems to be used for tests and is not part of the fix itself.