### PR TITLE
soc/intel_adsp: Suppress benign linker warnings out of objcopy

### DIFF
--- a/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
+++ b/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
@@ -37,6 +37,11 @@ with open(elffile, "rb") as fd:
             fixup.append(s.name)
 
 for s in fixup:
-    cmd = f"{objcopy_bin} --change-section-address {s}+0x20000000 {elffile}"
-    print(cmd)
+    # Note redirect: the sof-derived linker scripts currently emit
+    # some zero-length sections at address zero.  This is benign, and
+    # the linker is happy, but objcopy will emit an unsilenceable
+    # error (no --quiet option, no -Werror=no-whatever, nothing).
+    # Just swallow the error stream for now pending rework to the
+    # linker framework.
+    cmd = f"{objcopy_bin} --change-section-address {s}+0x20000000 {elffile} 2>/dev/null"
     os.system(cmd)


### PR DESCRIPTION
The fix_elf_addrs script runs objcopy over a binary that (due to some
legacy section definitions in a mildly complicated linker file) has a
few zero-length sections at address zero.  Objcopy considers this a
warning condition (though oddly the linker from the same version of
binutils which produced that binary does not!), which will be detected
as a CI failure.

Just eat the warnings.  Long term we should rework linkage to remove
the legacy stuff that is getting tripped over.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>