### PR TITLE
drivers: sensor: Fix fxas21002 gyro units

### DIFF
--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -64,8 +64,10 @@ static void fxas21002_convert(struct sensor_value *val, int16_t raw,
 {
 	int32_t micro_rad;
 
-	/* Convert units to micro radians per second.*/
-	micro_rad = (raw * 62500) >> range;
+	/* Convert units to micro radians per second.
+	 * 62500 micro dps * 2*pi/360 = 1091 micro radians per second
+	 */
+	micro_rad = (raw * 1091) >> range;
 
 	val->val1 = micro_rad / 1000000;
 	val->val2 = micro_rad % 1000000;


### PR DESCRIPTION
Fixes the fxas21002 sensor driver to provide gyro channel data in
radians/sec instead of degrees/sec.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #30446

cc: @aloebs29