### PR TITLE
Shell mark internal api with `z_` prefix

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -20,8 +20,6 @@
 extern "C" {
 #endif
 
-#define SHELL_RX_BUFF_SIZE 16
-
 #ifndef CONFIG_SHELL_CMD_BUFF_SIZE
 #define CONFIG_SHELL_CMD_BUFF_SIZE 0
 #endif
@@ -34,7 +32,7 @@ extern "C" {
 #define CONFIG_SHELL_HISTORY_BUFFER 0
 #endif
 
-#define SHELL_CMD_ROOT_LVL		(0u)
+#define Z_SHELL_CMD_ROOT_LVL		(0u)
 
 #define SHELL_HEXDUMP_BYTES_IN_LINE	16
 
@@ -413,7 +411,7 @@ struct shell_static_entry {
 	SHELL_EXPR_CMD_ARG(_expr, _syntax, _subcmd, _help, _handler, 0, 0)
 
 /* Internal macro used for creating handlers for dictionary commands. */
-#define SHELL_CMD_DICT_HANDLER_CREATE(_data, _handler)		\
+#define Z_SHELL_CMD_DICT_HANDLER_CREATE(_data, _handler)		\
 static int UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data))(	\
 		const struct shell *shell, size_t argc, char **argv)	\
 {									\
@@ -457,7 +455,7 @@ static int UTIL_CAT(cmd_dict_, GET_ARG_N(1, __DEBRACKET _data))(	\
  *	SHELL_CMD_REGISTER(dictionary, &sub_dict_cmds, NULL, NULL);
  */
 #define SHELL_SUBCMD_DICT_SET_CREATE(_name, _handler, ...)		\
-	FOR_EACH_FIXED_ARG(SHELL_CMD_DICT_HANDLER_CREATE, (),		\
+	FOR_EACH_FIXED_ARG(Z_SHELL_CMD_DICT_HANDLER_CREATE, (),		\
 			   _handler, __VA_ARGS__)			\
 	SHELL_STATIC_SUBCMD_SET_CREATE(_name,				\
 		FOR_EACH(SHELL_CMD_DICT_CREATE, (,), __VA_ARGS__),	\
@@ -591,11 +589,11 @@ struct shell_stats {
 };
 
 #ifdef CONFIG_SHELL_STATS
-#define SHELL_STATS_DEFINE(_name) static struct shell_stats _name##_stats
-#define SHELL_STATS_PTR(_name) (&(_name##_stats))
+#define Z_SHELL_STATS_DEFINE(_name) static struct shell_stats _name##_stats
+#define Z_SHELL_STATS_PTR(_name) (&(_name##_stats))
 #else
-#define SHELL_STATS_DEFINE(_name)
-#define SHELL_STATS_PTR(_name) NULL
+#define Z_SHELL_STATS_DEFINE(_name)
+#define Z_SHELL_STATS_PTR(_name) NULL
 #endif /* CONFIG_SHELL_STATS */
 
 /**
@@ -616,7 +614,6 @@ struct shell_flags {
 
 BUILD_ASSERT((sizeof(struct shell_flags) == sizeof(uint32_t)),
 	     "Structure must fit in 4 bytes");
-
 
 /**
  * @internal @brief Union for internal shell usage.
@@ -739,7 +736,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 			     true, z_shell_print_stream);		      \
 	LOG_INSTANCE_REGISTER(shell, _name, CONFIG_SHELL_LOG_LEVEL);	      \
-	SHELL_STATS_DEFINE(_name);					      \
+	Z_SHELL_STATS_DEFINE(_name);					      \
 	static K_KERNEL_STACK_DEFINE(_name##_stack, CONFIG_SHELL_STACK_SIZE); \
 	static struct k_thread _name##_thread;				      \
 	static const Z_STRUCT_SECTION_ITERABLE(shell, _name) = {	      \
@@ -750,7 +747,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 				&_name##_history : NULL,		      \
 		.shell_flag = _shell_flag,				      \
 		.fprintf_ctx = &_name##_fprintf,			      \
-		.stats = SHELL_STATS_PTR(_name),			      \
+		.stats = Z_SHELL_STATS_PTR(_name),			      \
 		.log_backend = Z_SHELL_LOG_BACKEND_PTR(_name),		      \
 		LOG_INSTANCE_PTR_INIT(log, shell, _name)		      \
 		.thread_name = STRINGIFY(_name),			      \

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -731,7 +731,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 	static const struct shell _name;				      \
 	static struct shell_ctx UTIL_CAT(_name, _ctx);			      \
 	static uint8_t _name##_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];     \
-	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
+	Z_SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
 				 CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 				 _log_queue_size, _log_timeout);	      \
 	Z_SHELL_HISTORY_DEFINE(_name##_history, CONFIG_SHELL_HISTORY_BUFFER); \
@@ -751,7 +751,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 		.shell_flag = _shell_flag,				      \
 		.fprintf_ctx = &_name##_fprintf,			      \
 		.stats = SHELL_STATS_PTR(_name),			      \
-		.log_backend = SHELL_LOG_BACKEND_PTR(_name),		      \
+		.log_backend = Z_SHELL_LOG_BACKEND_PTR(_name),		      \
 		LOG_INSTANCE_PTR_INIT(log, shell, _name)		      \
 		.thread_name = STRINGIFY(_name),			      \
 		.thread = &_name##_thread,				      \

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -734,7 +734,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
 				 CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 				 _log_queue_size, _log_timeout);	      \
-	SHELL_HISTORY_DEFINE(_name##_history, CONFIG_SHELL_HISTORY_BUFFER);   \
+	Z_SHELL_HISTORY_DEFINE(_name##_history, CONFIG_SHELL_HISTORY_BUFFER); \
 	Z_SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,   \
 			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 			     true, z_shell_print_stream);		      \

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -711,8 +711,8 @@ struct shell {
 	k_thread_stack_t *stack;
 };
 
-extern void shell_print_stream(const void *user_ctx, const char *data,
-			       size_t data_len);
+extern void z_shell_print_stream(const void *user_ctx, const char *data,
+				 size_t data_len);
 /**
  * @brief Macro for defining a shell instance.
  *
@@ -730,14 +730,14 @@ extern void shell_print_stream(const void *user_ctx, const char *data,
 		     _log_queue_size, _log_timeout, _shell_flag)	      \
 	static const struct shell _name;				      \
 	static struct shell_ctx UTIL_CAT(_name, _ctx);			      \
-	static uint8_t _name##_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];	      \
+	static uint8_t _name##_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];     \
 	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
 				 CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 				 _log_queue_size, _log_timeout);	      \
 	SHELL_HISTORY_DEFINE(_name##_history, CONFIG_SHELL_HISTORY_BUFFER);   \
-	SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,     \
+	Z_SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,   \
 			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
-			     true, shell_print_stream);			      \
+			     true, z_shell_print_stream);		      \
 	LOG_INSTANCE_REGISTER(shell, _name, CONFIG_SHELL_LOG_LEVEL);	      \
 	SHELL_STATS_DEFINE(_name);					      \
 	static K_KERNEL_STACK_DEFINE(_name##_stack, CONFIG_SHELL_STACK_SIZE); \

--- a/include/shell/shell_fprintf.h
+++ b/include/shell/shell_fprintf.h
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 
 typedef void (*shell_fprintf_fwrite)(const void *user_ctx,
-				      const char *data,
-				      size_t length);
+				     const char *data,
+				     size_t length);
 
 struct shell_fprintf_control_block {
 	size_t buffer_cnt;
@@ -44,7 +44,7 @@ struct shell_fprintf {
  * @param _autoflush	Indicator if buffer shall be automatically flush.
  * @param _fwrite	Pointer to function sending data stream.
  */
-#define SHELL_FPRINTF_DEFINE(_name, _user_ctx, _buf, _size,	\
+#define Z_SHELL_FPRINTF_DEFINE(_name, _user_ctx, _buf, _size,	\
 			    _autoflush, _fwrite)		\
 	static struct shell_fprintf_control_block		\
 				_name##_shell_fprintf_ctx = {	\
@@ -66,15 +66,15 @@ struct shell_fprintf {
  * @param fmt		Format string.
  * @param args		List of parameters to print.
  */
-void shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
-		       char const *fmt, va_list args);
+void z_shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
+			 char const *fmt, va_list args);
 
 /**
  * @brief function flushing data stored in io_buffer.
  *
  * @param sh_fprintf	fprintf instance
  */
-void shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf);
+void z_shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf);
 
 #ifdef __cplusplus
 }

--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -30,16 +30,16 @@ struct shell_history {
  * @param _name History instance name.
  * @param _size Memory dedicated for shell history.
  */
-#define SHELL_HISTORY_DEFINE(_name, _size) \
-	static uint8_t __noinit __aligned(sizeof(void *)) \
-			_name##_ring_buf_data[_size]; \
-	static struct ring_buf _name##_ring_buf = \
-		{ \
-			.size = _size, \
+#define Z_SHELL_HISTORY_DEFINE(_name, _size)			  \
+	static uint8_t __noinit __aligned(sizeof(void *))	  \
+			_name##_ring_buf_data[_size];		  \
+	static struct ring_buf _name##_ring_buf =		  \
+		{						  \
+			.size = _size,				  \
 			.buf =  { .buf8 = _name##_ring_buf_data } \
-		}; \
-	static struct shell_history _name = { \
-		.ring_buf = &_name##_ring_buf \
+		};						  \
+	static struct shell_history _name = {			  \
+		.ring_buf = &_name##_ring_buf			  \
 	}
 
 
@@ -48,7 +48,7 @@ struct shell_history {
  *
  * @param history Shell history instance.
  */
-void shell_history_init(struct shell_history *history);
+void z_shell_history_init(struct shell_history *history);
 
 /**
  * @brief Purge shell history.
@@ -58,14 +58,14 @@ void shell_history_init(struct shell_history *history);
  * @param history Shell history instance.
  *
  */
-void shell_history_purge(struct shell_history *history);
+void z_shell_history_purge(struct shell_history *history);
 
 /**
  * @brief Exit history browsing mode.
  *
  * @param history Shell history instance.
  */
-void shell_history_mode_exit(struct shell_history *history);
+void z_shell_history_mode_exit(struct shell_history *history);
 
 /**
  * @brief Get next entry in shell command history.
@@ -79,8 +79,8 @@ void shell_history_mode_exit(struct shell_history *history);
  *				data (output).
  * @return True if remains in history mode.
  */
-bool shell_history_get(struct shell_history *history, bool up,
-		       uint8_t *dst, uint16_t *len);
+bool z_shell_history_get(struct shell_history *history, bool up,
+			 uint8_t *dst, uint16_t *len);
 
 /**
  * @brief Put line into shell command history.
@@ -92,7 +92,8 @@ bool shell_history_get(struct shell_history *history, bool up,
  * @param len		Data length.
  *
  */
-void shell_history_put(struct shell_history *history, uint8_t *line, size_t len);
+void z_shell_history_put(struct shell_history *history, uint8_t *line,
+			 size_t len);
 
 /**
  * @brief Get state of shell history.
@@ -101,7 +102,7 @@ void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
  *
  * @return True if in browsing mode.
  */
-static inline bool shell_history_active(struct shell_history *history)
+static inline bool z_shell_history_active(struct shell_history *history)
 {
 	return (history->current) ? true : false;
 }

--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -47,9 +47,9 @@ struct shell_log_backend_msg {
 };
 
 /** @brief Prototype of function outputing processed data. */
-int shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
+int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
 
-/** @def SHELL_LOG_BACKEND_DEFINE
+/** @def Z_SHELL_LOG_BACKEND_DEFINE
  *  @brief Macro for creating instance of shell log backend.
  *
  *  @param _name	Shell name.
@@ -59,31 +59,31 @@ int shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
  *  @param _timeout	Timeout in milliseconds for pending on queue full.
  *			Message is dropped on timeout.
  */
-/** @def SHELL_LOG_BACKEND_PTR
+/** @def Z_SHELL_LOG_BACKEND_PTR
  *  @brief Macro for retrieving pointer to the instance of shell log backend.
  *
  *  @param _name Shell name.
  */
 #ifdef CONFIG_SHELL_LOG_BACKEND
-#define SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)  \
-	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api, false);   \
-	K_MSGQ_DEFINE(_name##_msgq, sizeof(struct shell_log_backend_msg),    \
-			_queue_size, sizeof(void *));			     \
-	LOG_OUTPUT_DEFINE(_name##_log_output, shell_log_backend_output_func, \
-			  _buf, _size);					     \
-	static struct shell_log_backend_control_block _name##_control_block; \
-	static const struct shell_log_backend _name##_log_backend = {	     \
-		.backend = &_name##_backend,				     \
-		.msgq = &_name##_msgq,					     \
-		.log_output = &_name##_log_output,			     \
-		.control_block = &_name##_control_block,		     \
-		.timeout = _timeout					     \
+#define Z_SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)  \
+	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api, false);     \
+	K_MSGQ_DEFINE(_name##_msgq, sizeof(struct shell_log_backend_msg),      \
+			_queue_size, sizeof(void *));			       \
+	LOG_OUTPUT_DEFINE(_name##_log_output, z_shell_log_backend_output_func, \
+			  _buf, _size);					       \
+	static struct shell_log_backend_control_block _name##_control_block;   \
+	static const struct shell_log_backend _name##_log_backend = {	       \
+		.backend = &_name##_backend,				       \
+		.msgq = &_name##_msgq,					       \
+		.log_output = &_name##_log_output,			       \
+		.control_block = &_name##_control_block,		       \
+		.timeout = _timeout					       \
 	}
 
-#define SHELL_LOG_BACKEND_PTR(_name) (&_name##_log_backend)
+#define Z_SHELL_LOG_BACKEND_PTR(_name) (&_name##_log_backend)
 #else /* CONFIG_LOG */
-#define SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)
-#define SHELL_LOG_BACKEND_PTR(_name) NULL
+#define Z_SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)
+#define Z_SHELL_LOG_BACKEND_PTR(_name) NULL
 #endif /* CONFIG_LOG */
 
 /** @brief Enable shell log backend.
@@ -92,14 +92,14 @@ int shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
  * @param ctx			Pointer to shell instance.
  * @param init_log_level	Initial log level set to all logging sources.
  */
-void shell_log_backend_enable(const struct shell_log_backend *backend,
-			      void *ctx, uint32_t init_log_level);
+void z_shell_log_backend_enable(const struct shell_log_backend *backend,
+				void *ctx, uint32_t init_log_level);
 
 /** @brief Disable shell log backend.
  *
  * @param backend Shell log backend instance.
  */
-void shell_log_backend_disable(const struct shell_log_backend *backend);
+void z_shell_log_backend_disable(const struct shell_log_backend *backend);
 
 /** @brief Trigger processing of one log entry.
  *
@@ -107,7 +107,7 @@ void shell_log_backend_disable(const struct shell_log_backend *backend);
  *
  * @return True if message was processed, false if FIFO was empty
  */
-bool shell_log_backend_process(const struct shell_log_backend *backend);
+bool z_shell_log_backend_process(const struct shell_log_backend *backend);
 
 #ifdef __cplusplus
 }

--- a/include/shell/shell_uart.h
+++ b/include/shell/shell_uart.h
@@ -31,24 +31,19 @@ struct shell_uart_ctrl_blk {
 };
 
 #ifdef CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
-#define UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) \
+#define Z_UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) \
 	RING_BUF_DECLARE(_name##_tx_ringbuf, _size)
 
-#define UART_SHELL_TX_BUF_DECLARE(_name) \
-	uint8_t _name##_txbuf[SHELL_UART_TX_BUF_SIZE]
+#define Z_UART_SHELL_RX_TIMER_DECLARE(_name) /* Empty */
+#define Z_UART_SHELL_TX_RINGBUF_PTR(_name) (&_name##_tx_ringbuf)
 
-#define UART_SHELL_RX_TIMER_DECLARE(_name) /* Empty */
-
-#define UART_SHELL_TX_RINGBUF_PTR(_name) (&_name##_tx_ringbuf)
-
-#define UART_SHELL_RX_TIMER_PTR(_name) NULL
+#define Z_UART_SHELL_RX_TIMER_PTR(_name) NULL
 
 #else /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
-#define UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) /* Empty */
-#define UART_SHELL_TX_BUF_DECLARE(_name) /* Empty */
-#define UART_SHELL_RX_TIMER_DECLARE(_name) static struct k_timer _name##_timer
-#define UART_SHELL_TX_RINGBUF_PTR(_name) NULL
-#define UART_SHELL_RX_TIMER_PTR(_name) (&_name##_timer)
+#define Z_UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) /* Empty */
+#define Z_UART_SHELL_RX_TIMER_DECLARE(_name) static struct k_timer _name##_timer
+#define Z_UART_SHELL_TX_RINGBUF_PTR(_name) NULL
+#define Z_UART_SHELL_RX_TIMER_PTR(_name) (&_name##_timer)
 #endif /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
 
 /** @brief Shell UART transport instance structure. */
@@ -62,13 +57,13 @@ struct shell_uart {
 /** @brief Macro for creating shell UART transport instance. */
 #define SHELL_UART_DEFINE(_name, _tx_ringbuf_size, _rx_ringbuf_size)	\
 	static struct shell_uart_ctrl_blk _name##_ctrl_blk;		\
-	UART_SHELL_RX_TIMER_DECLARE(_name);				\
-	UART_SHELL_TX_RINGBUF_DECLARE(_name, _tx_ringbuf_size);		\
+	Z_UART_SHELL_RX_TIMER_DECLARE(_name);				\
+	Z_UART_SHELL_TX_RINGBUF_DECLARE(_name, _tx_ringbuf_size);	\
 	RING_BUF_DECLARE(_name##_rx_ringbuf, _rx_ringbuf_size);		\
 	static const struct shell_uart _name##_shell_uart = {		\
 		.ctrl_blk = &_name##_ctrl_blk,				\
-		.timer = UART_SHELL_RX_TIMER_PTR(_name),		\
-		.tx_ringbuf = UART_SHELL_TX_RINGBUF_PTR(_name),		\
+		.timer = Z_UART_SHELL_RX_TIMER_PTR(_name),		\
+		.tx_ringbuf = Z_UART_SHELL_TX_RINGBUF_PTR(_name),	\
 		.rx_ringbuf = &_name##_rx_ringbuf,			\
 	};								\
 	struct shell_transport _name = {				\

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1114,7 +1114,8 @@ static void shell_log_process(const struct shell *shell)
 		if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
 			shell_cmd_line_erase(shell);
 
-			processed = shell_log_backend_process(shell->log_backend);
+			processed = z_shell_log_backend_process(
+					shell->log_backend);
 		}
 
 		struct k_poll_signal *signal =
@@ -1193,7 +1194,7 @@ static int instance_uninit(const struct shell *shell)
 
 	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		/* todo purge log queue */
-		shell_log_backend_disable(shell->log_backend);
+		z_shell_log_backend_disable(shell->log_backend);
 	}
 
 	err = shell->iface->api->uninit(shell->iface);
@@ -1245,8 +1246,8 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 	}
 
 	if (log_backend && IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
-		shell_log_backend_enable(shell->log_backend, (void *)shell,
-					 log_level);
+		z_shell_log_backend_enable(shell->log_backend, (void *)shell,
+					   log_level);
 	}
 
 	/* Enable shell and print prompt. */

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -280,7 +280,7 @@ static bool tab_prepare(const struct shell *shell,
 
 	/* root command completion */
 	if ((*argc == 0) || ((space == 0) && (*argc == 1))) {
-		*complete_arg_idx = SHELL_CMD_ROOT_LVL;
+		*complete_arg_idx = Z_SHELL_CMD_ROOT_LVL;
 		*cmd = selected_cmd_get(shell);
 		return true;
 	}

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -630,7 +630,7 @@ static int execute(const struct shell *shell)
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
-		shell_wildcard_prepare(shell);
+		z_shell_wildcard_prepare(shell);
 	}
 
 	/* Parent present means we are in select mode. */
@@ -680,8 +680,8 @@ static int execute(const struct shell *shell)
 		if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && (cmd_lvl > 0)) {
 			enum shell_wildcard_status status;
 
-			status = shell_wildcard_process(shell, entry,
-							argvp[0]);
+			status = z_shell_wildcard_process(shell, entry,
+							  argvp[0]);
 			/* Wildcard character found but there is no matching
 			 * command.
 			 */
@@ -747,7 +747,7 @@ static int execute(const struct shell *shell)
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && wildcard_found) {
-		shell_wildcard_finalize(shell);
+		z_shell_wildcard_finalize(shell);
 		/* cmd_buffer has been overwritten by function finalize function
 		 * with all expanded commands. Hence shell_make_argv needs to
 		 * be called again.

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -146,7 +146,7 @@ static void history_init(const struct shell *shell)
 		return;
 	}
 
-	shell_history_init(shell->history);
+	z_shell_history_init(shell->history);
 }
 
 static void history_purge(const struct shell *shell)
@@ -155,7 +155,7 @@ static void history_purge(const struct shell *shell)
 		return;
 	}
 
-	shell_history_purge(shell->history);
+	z_shell_history_purge(shell->history);
 }
 
 static void history_mode_exit(const struct shell *shell)
@@ -165,7 +165,7 @@ static void history_mode_exit(const struct shell *shell)
 	}
 
 	flag_history_exit_set(shell, false);
-	shell_history_mode_exit(shell->history);
+	z_shell_history_mode_exit(shell->history);
 }
 
 static void history_put(const struct shell *shell, uint8_t *line, size_t length)
@@ -174,7 +174,7 @@ static void history_put(const struct shell *shell, uint8_t *line, size_t length)
 		return;
 	}
 
-	shell_history_put(shell->history, line, length);
+	z_shell_history_put(shell->history, line, length);
 }
 
 static void history_handle(const struct shell *shell, bool up)
@@ -190,11 +190,11 @@ static void history_handle(const struct shell *shell, bool up)
 	/* Checking if history process has been stopped */
 	if (flag_history_exit_get(shell)) {
 		flag_history_exit_set(shell, false);
-		shell_history_mode_exit(shell->history);
+		z_shell_history_mode_exit(shell->history);
 	}
 
 	/* Backup command if history is entered */
-	if (!shell_history_active(shell->history)) {
+	if (!z_shell_history_active(shell->history)) {
 		if (up) {
 			uint16_t cmd_len = shell_strlen(shell->ctx->cmd_buff);
 
@@ -211,8 +211,8 @@ static void history_handle(const struct shell *shell, bool up)
 	}
 
 	/* Start by checking if history is not empty. */
-	history_mode = shell_history_get(shell->history, up,
-					 shell->ctx->cmd_buff, &len);
+	history_mode = z_shell_history_get(shell->history, up,
+					   shell->ctx->cmd_buff, &len);
 
 	/* On exiting history mode print backed up command. */
 	if (!history_mode) {

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -68,9 +68,9 @@ static int cmd_precheck(const struct shell *shell,
 			bool arg_cnt_ok)
 {
 	if (!arg_cnt_ok) {
-		shell_internal_fprintf(shell, SHELL_ERROR,
-				       "%s: wrong parameter count\n",
-				       shell->ctx->active_cmd.syntax);
+		z_shell_fprintf(shell, SHELL_ERROR,
+				"%s: wrong parameter count\n",
+				shell->ctx->active_cmd.syntax);
 
 		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
 			shell_internal_help_print(shell);
@@ -89,8 +89,8 @@ static inline void state_set(const struct shell *shell, enum shell_state state)
 	if (state == SHELL_STATE_ACTIVE) {
 		cmd_buffer_clear(shell);
 		if (flag_print_noinit_get(shell)) {
-			shell_internal_fprintf(shell, SHELL_WARNING, "%s",
-					       SHELL_MSG_BACKEND_NOT_ACTIVE);
+			z_shell_fprintf(shell, SHELL_WARNING, "%s",
+					SHELL_MSG_BACKEND_NOT_ACTIVE);
 			flag_print_noinit_set(shell, false);
 		}
 		shell_print_prompt_and_cmd(shell);
@@ -132,10 +132,9 @@ static void tab_item_print(const struct shell *shell, const char *option,
 	diff = longest_option - shell_strlen(option);
 
 	if (shell->ctx->vt100_ctx.printed_cmd++ % columns == 0U) {
-		shell_internal_fprintf(shell, SHELL_OPTION, "\n%s%s", tab,
-				       option);
+		z_shell_fprintf(shell, SHELL_OPTION, "\n%s%s", tab, option);
 	} else {
-		shell_internal_fprintf(shell, SHELL_OPTION, "%s", option);
+		z_shell_fprintf(shell, SHELL_OPTION, "%s", option);
 	}
 
 	shell_op_cursor_horiz_move(shell, diff);
@@ -515,8 +514,8 @@ static int exec_cmd(const struct shell *shell, size_t argc, const char **argv,
 			shell_internal_help_print(shell);
 			return SHELL_CMD_HELP_PRINTED;
 		} else {
-			shell_internal_fprintf(shell, SHELL_ERROR,
-					       SHELL_MSG_SPECIFY_SUBCOMMAND);
+			z_shell_fprintf(shell, SHELL_ERROR,
+					SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
 	}
@@ -578,7 +577,7 @@ static bool wildcard_check_report(const struct shell *shell, bool found,
 		shell_op_cursor_end_move(shell);
 		shell_op_cond_next_line(shell);
 
-		shell_internal_fprintf(shell, SHELL_ERROR,
+		z_shell_fprintf(shell, SHELL_ERROR,
 			"Error: requested multiple function executions\n");
 		return false;
 	}
@@ -656,9 +655,8 @@ static int execute(const struct shell *shell)
 		if (argc == 0) {
 			return -ENOEXEC;
 		} else if ((argc == 1) && (quote != 0)) {
-			shell_internal_fprintf(shell, SHELL_ERROR,
-					"not terminated: %c\n",
-					quote);
+			z_shell_fprintf(shell, SHELL_ERROR,
+					"not terminated: %c\n", quote);
 			return -ENOEXEC;
 		}
 
@@ -674,8 +672,8 @@ static int execute(const struct shell *shell)
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			shell_internal_fprintf(shell, SHELL_ERROR,
-					       SHELL_MSG_SPECIFY_SUBCOMMAND);
+			z_shell_fprintf(shell, SHELL_ERROR,
+					SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
 
@@ -721,9 +719,9 @@ static int execute(const struct shell *shell)
 			if (cmd_lvl == 0 &&
 				(!shell_in_select_mode(shell) ||
 				 shell->ctx->selected_cmd->handler == NULL)) {
-				shell_internal_fprintf(shell, SHELL_ERROR,
-						       "%s%s\n", argv[0],
-						       SHELL_MSG_CMD_NOT_FOUND);
+				z_shell_fprintf(shell, SHELL_ERROR,
+						"%s%s\n", argv[0],
+						SHELL_MSG_CMD_NOT_FOUND);
 			}
 
 			/* last handler found - no need to search commands in
@@ -743,8 +741,8 @@ static int execute(const struct shell *shell)
 		 * there was more characters remaining. It means that number of
 		 * arguments exceeds the limit.
 		 */
-		shell_internal_fprintf(shell, SHELL_ERROR,
-				       "%s\n", SHELL_MSG_TOO_MANY_ARGS);
+		z_shell_fprintf(shell, SHELL_ERROR, "%s\n",
+				SHELL_MSG_TOO_MANY_ARGS);
 		return -ENOEXEC;
 	}
 
@@ -821,7 +819,7 @@ static void alt_metakeys_handle(const struct shell *shell, char data)
 		   IS_ENABLED(CONFIG_SHELL_CMDS_SELECT)) {
 		if (selected_cmd_get(shell) != NULL) {
 			shell_cmd_line_erase(shell);
-			shell_internal_fprintf(shell, SHELL_WARNING,
+			z_shell_fprintf(shell, SHELL_WARNING,
 					"Restored default root commands\n");
 			shell->ctx->selected_cmd = NULL;
 			shell_print_prompt_and_cmd(shell);
@@ -1264,8 +1262,8 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 
 		if (err != 0) {
 			k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
-			shell_internal_fprintf(shell, SHELL_ERROR,
-					       "Shell thread error: %d", err);
+			z_shell_fprintf(shell, SHELL_ERROR,
+					"Shell thread error: %d", err);
 			k_mutex_unlock(&shell->ctx->wr_mtx);
 			return;
 		}
@@ -1424,7 +1422,7 @@ void shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 	if (!flag_cmd_ctx_get(shell)) {
 		shell_cmd_line_erase(shell);
 	}
-	shell_internal_vfprintf(shell, color, fmt, args);
+	z_shell_vfprintf(shell, color, fmt, args);
 	if (!flag_cmd_ctx_get(shell)) {
 		shell_print_prompt_and_cmd(shell);
 	}

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -49,9 +49,9 @@ static void shell_internal_help_print(const struct shell *shell)
 		return;
 	}
 
-	shell_help_cmd_print(shell, &shell->ctx->active_cmd);
-	shell_help_subcmd_print(shell, &shell->ctx->active_cmd,
-				"Subcommands:\n");
+	z_shell_help_cmd_print(shell, &shell->ctx->active_cmd);
+	z_shell_help_subcmd_print(shell, &shell->ctx->active_cmd,
+				  "Subcommands:\n");
 }
 
 /**
@@ -1586,7 +1586,8 @@ static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 
 	if (IS_ENABLED(CONFIG_SHELL_HELP)) {
 		/* For NULL argument function will print all root commands */
-		shell_help_subcmd_print(shell, NULL, "\nAvailable commands:\n");
+		z_shell_help_subcmd_print(shell, NULL,
+					 "\nAvailable commands:\n");
 	} else {
 		const struct shell_static_entry *entry;
 		size_t idx = 0;

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -76,7 +76,7 @@ static int cursor_position_get(const struct shell *shell, uint16_t *x, uint16_t 
 	/* escape code asking terminal about its size */
 	static char const cmd_get_terminal_size[] = "\033[6n";
 
-	shell_raw_fprintf(shell->fprintf_ctx, cmd_get_terminal_size);
+	z_shell_raw_fprintf(shell->fprintf_ctx, cmd_get_terminal_size);
 
 	/* fprintf buffer needs to be flushed to start sending prepared
 	 * escape code to the terminal.
@@ -173,13 +173,13 @@ static int terminal_size_get(const struct shell *shell)
 	uint16_t y; /* vertical position */
 	int ret_val = 0;
 
-	cursor_save(shell);
+	z_cursor_save(shell);
 
 	/* Assumption: terminal width and height < 999. */
 	/* Move to last column. */
-	shell_op_cursor_vert_move(shell, -SHELL_MAX_TERMINAL_SIZE);
+	z_shell_op_cursor_vert_move(shell, -SHELL_MAX_TERMINAL_SIZE);
 	/* Move to last row. */
-	shell_op_cursor_horiz_move(shell, SHELL_MAX_TERMINAL_SIZE);
+	z_shell_op_cursor_horiz_move(shell, SHELL_MAX_TERMINAL_SIZE);
 
 	if (cursor_position_get(shell, &x, &y) == 0) {
 		shell->ctx->vt100_ctx.cons.terminal_wid = x;
@@ -188,7 +188,7 @@ static int terminal_size_get(const struct shell *shell)
 		ret_val = -ENOTSUP;
 	}
 
-	cursor_restore(shell);
+	z_cursor_restore(shell);
 	return ret_val;
 }
 
@@ -196,8 +196,8 @@ static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	SHELL_VT100_CMD(shell, SHELL_VT100_CURSORHOME);
-	SHELL_VT100_CMD(shell, SHELL_VT100_CLEARSCREEN);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_CURSORHOME);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_CLEARSCREEN);
 
 	return 0;
 }
@@ -208,7 +208,7 @@ static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	flag_mode_delete_set(shell, false);
+	z_flag_mode_delete_set(shell, false);
 
 	return 0;
 }
@@ -219,7 +219,7 @@ static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	flag_mode_delete_set(shell, true);
+	z_flag_mode_delete_set(shell, true);
 
 	return 0;
 }
@@ -229,7 +229,7 @@ static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	flag_use_colors_set(shell, false);
+	z_flag_use_colors_set(shell, false);
 
 	return 0;
 }
@@ -239,7 +239,7 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 	ARG_UNUSED(argv);
 
-	flag_use_colors_set(shell, true);
+	z_flag_use_colors_set(shell, true);
 
 	return 0;
 }
@@ -249,7 +249,7 @@ static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	flag_echo_set(shell, false);
+	z_flag_echo_set(shell, false);
 
 	return 0;
 }
@@ -259,7 +259,7 @@ static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	flag_echo_set(shell, true);
+	z_flag_echo_set(shell, true);
 
 	return 0;
 }
@@ -273,7 +273,7 @@ static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell_print(shell, "Echo status: %s",
-		    flag_echo_get(shell) ? "on" : "off");
+		    z_flag_echo_get(shell) ? "on" : "off");
 
 	return 0;
 }
@@ -332,7 +332,7 @@ static int cmd_resize_default(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
 	shell->ctx->vt100_ctx.cons.terminal_wid = SHELL_DEFAULT_TERMINAL_WIDTH;
 	shell->ctx->vt100_ctx.cons.terminal_hei = SHELL_DEFAULT_TERMINAL_HEIGHT;
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -287,8 +287,8 @@ static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 	uint16_t len;
 
 	while (1) {
-		shell_history_get(shell->history, true,
-				  shell->ctx->temp_buff, &len);
+		z_shell_history_get(shell->history, true,
+				    shell->ctx->temp_buff, &len);
 
 		if (len) {
 			shell_print(shell, "[%3d] %s",

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -81,7 +81,7 @@ static int cursor_position_get(const struct shell *shell, uint16_t *x, uint16_t 
 	/* fprintf buffer needs to be flushed to start sending prepared
 	 * escape code to the terminal.
 	 */
-	transport_buffer_flush(shell);
+	z_transport_buffer_flush(shell);
 
 	/* timeout for terminal response = ~1s */
 	for (uint16_t i = 0; i < 1000; i++) {
@@ -376,9 +376,9 @@ static int cmd_select(const struct shell *shell, size_t argc, char **argv)
 
 	argc--;
 	argv = argv + 1;
-	candidate = shell_get_last_command(shell->ctx->selected_cmd,
-					   argc, (const char **)argv,
-					   &matching_argc, &entry, true);
+	candidate = z_shell_get_last_command(shell->ctx->selected_cmd,
+					     argc, (const char **)argv,
+					     &matching_argc, &entry, true);
 
 	if ((candidate != NULL) && !no_args(candidate)
 	    && (argc == matching_argc)) {

--- a/subsys/shell/shell_fprintf.c
+++ b/subsys/shell/shell_fprintf.c
@@ -24,24 +24,24 @@ static int out_func(int c, void *ctx)
 	sh_fprintf->ctrl_blk->buffer_cnt++;
 
 	if (sh_fprintf->ctrl_blk->buffer_cnt == sh_fprintf->buffer_size) {
-		shell_fprintf_buffer_flush(sh_fprintf);
+		z_shell_fprintf_buffer_flush(sh_fprintf);
 	}
 
 	return 0;
 }
 
-void shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
-		       const char *fmt, va_list args)
+void z_shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
+			 const char *fmt, va_list args)
 {
 	(void)cbvprintf(out_func, (void *)sh_fprintf, fmt, args);
 
 	if (sh_fprintf->ctrl_blk->autoflush) {
-		shell_fprintf_buffer_flush(sh_fprintf);
+		z_shell_fprintf_buffer_flush(sh_fprintf);
 	}
 }
 
 
-void shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf)
+void z_shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf)
 {
 	sh_fprintf->fwrite(sh_fprintf->user_ctx, sh_fprintf->buffer,
 			   sh_fprintf->ctrl_blk->buffer_cnt);

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -145,9 +145,9 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 /* Function prints all subcommands of the parent command together with their
  * help string
  */
-void shell_help_subcmd_print(const struct shell *shell,
-			     const struct shell_static_entry *parent,
-			     const char *description)
+void z_shell_help_subcmd_print(const struct shell *shell,
+			       const struct shell_static_entry *parent,
+			       const char *description)
 {
 	const struct shell_static_entry *entry = NULL;
 	struct shell_static_entry dloc;
@@ -176,8 +176,8 @@ void shell_help_subcmd_print(const struct shell *shell,
 	}
 }
 
-void shell_help_cmd_print(const struct shell *shell,
-			  const struct shell_static_entry *cmd)
+void z_shell_help_cmd_print(const struct shell *shell,
+			    const struct shell_static_entry *cmd)
 {
 	static const char cmd_sep[] = " - "; /* commands separator */
 	uint16_t field_width;

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -120,20 +120,18 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	    !IS_ENABLED(CONFIG_ARCH_POSIX)  &&
 	    !IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
 		/* print option name */
-		shell_internal_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
-				       tabulator,
-				       item_name_width, item_name,
-				       tabulator);
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:", tabulator,
+				item_name_width, item_name, tabulator);
 	} else {
 		uint16_t tmp = item_name_width - strlen(item_name);
 		char space = ' ';
 
-		shell_internal_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
-				       item_name);
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
+				item_name);
 		for (uint16_t i = 0; i < tmp; i++) {
 			shell_write(shell, &space, 1);
 		}
-		shell_internal_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
+		z_shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
 	}
 
 	if (item_help == NULL) {
@@ -167,7 +165,7 @@ void shell_help_subcmd_print(const struct shell *shell,
 	}
 
 	if (description != NULL) {
-		shell_internal_fprintf(shell, SHELL_NORMAL, description);
+		z_shell_fprintf(shell, SHELL_NORMAL, description);
 	}
 
 	/* Printing subcommands and help string (if exists). */
@@ -186,8 +184,7 @@ void shell_help_cmd_print(const struct shell *shell,
 
 	field_width = shell_strlen(cmd->syntax) + shell_strlen(cmd_sep);
 
-	shell_internal_fprintf(shell, SHELL_NORMAL, "%s%s",
-				cmd->syntax, cmd_sep);
+	z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", cmd->syntax, cmd_sep);
 
 	formatted_text_print(shell, cmd->help, field_width, false);
 }

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -39,13 +39,13 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 	while (true) {
 		size_t idx = 0;
 
-		length = shell_strlen(str) - offset;
+		length = z_shell_strlen(str) - offset;
 
 		if (length <=
 		    shell->ctx->vt100_ctx.cons.terminal_wid - terminal_offset) {
 			for (idx = 0; idx < length; idx++) {
 				if (*(str + offset + idx) == '\n') {
-					transport_buffer_flush(shell);
+					z_transport_buffer_flush(shell);
 					z_shell_write(shell, str + offset, idx);
 					offset += idx + 1;
 					z_cursor_next_line_move(shell);
@@ -88,7 +88,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		/* Writing one line, fprintf IO buffer must be flushed
 		 * before calling shell_write.
 		 */
-		transport_buffer_flush(shell);
+		z_transport_buffer_flush(shell);
 		z_shell_write(shell, str + offset, length);
 		offset += length;
 
@@ -155,8 +155,8 @@ void z_shell_help_subcmd_print(const struct shell *shell,
 	size_t idx = 0;
 
 	/* Searching for the longest subcommand to print. */
-	while ((entry = shell_cmd_get(parent, idx++, &dloc)) != NULL) {
-		longest = Z_MAX(longest, shell_strlen(entry->syntax));
+	while ((entry = z_shell_cmd_get(parent, idx++, &dloc)) != NULL) {
+		longest = Z_MAX(longest, z_shell_strlen(entry->syntax));
 	};
 
 	/* No help to print */
@@ -171,7 +171,7 @@ void z_shell_help_subcmd_print(const struct shell *shell,
 	/* Printing subcommands and help string (if exists). */
 	idx = 0;
 
-	while ((entry = shell_cmd_get(parent, idx++, &dloc)) != NULL) {
+	while ((entry = z_shell_cmd_get(parent, idx++, &dloc)) != NULL) {
 		help_item_print(shell, entry->syntax, longest, entry->help);
 	}
 }
@@ -182,7 +182,7 @@ void z_shell_help_cmd_print(const struct shell *shell,
 	static const char cmd_sep[] = " - "; /* commands separator */
 	uint16_t field_width;
 
-	field_width = shell_strlen(cmd->syntax) + shell_strlen(cmd_sep);
+	field_width = z_shell_strlen(cmd->syntax) + z_shell_strlen(cmd_sep);
 
 	z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", cmd->syntax, cmd_sep);
 

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -27,7 +27,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 	}
 
 	if (offset_first_line) {
-		shell_op_cursor_horiz_move(shell, terminal_offset);
+		z_shell_op_cursor_horiz_move(shell, terminal_offset);
 	}
 
 
@@ -46,17 +46,17 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 			for (idx = 0; idx < length; idx++) {
 				if (*(str + offset + idx) == '\n') {
 					transport_buffer_flush(shell);
-					shell_write(shell, str + offset, idx);
+					z_shell_write(shell, str + offset, idx);
 					offset += idx + 1;
-					cursor_next_line_move(shell);
-					shell_op_cursor_horiz_move(shell,
+					z_cursor_next_line_move(shell);
+					z_shell_op_cursor_horiz_move(shell,
 							terminal_offset);
 					break;
 				}
 			}
 
 			/* String will fit in one line. */
-			shell_raw_fprintf(shell->fprintf_ctx, str + offset);
+			z_shell_raw_fprintf(shell->fprintf_ctx, str + offset);
 
 			break;
 		}
@@ -89,7 +89,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		 * before calling shell_write.
 		 */
 		transport_buffer_flush(shell);
-		shell_write(shell, str + offset, length);
+		z_shell_write(shell, str + offset, length);
 		offset += length;
 
 		/* Calculating text offset to ensure that next line will
@@ -99,11 +99,11 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 			++offset;
 		}
 
-		cursor_next_line_move(shell);
-		shell_op_cursor_horiz_move(shell, terminal_offset);
+		z_cursor_next_line_move(shell);
+		z_shell_op_cursor_horiz_move(shell, terminal_offset);
 
 	}
-	cursor_next_line_move(shell);
+	z_cursor_next_line_move(shell);
 }
 
 static void help_item_print(const struct shell *shell, const char *item_name,
@@ -129,13 +129,13 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 		z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
 				item_name);
 		for (uint16_t i = 0; i < tmp; i++) {
-			shell_write(shell, &space, 1);
+			z_shell_write(shell, &space, 1);
 		}
 		z_shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
 	}
 
 	if (item_help == NULL) {
-		cursor_next_line_move(shell);
+		z_cursor_next_line_move(shell);
 		return;
 	}
 	/* print option help */

--- a/subsys/shell/shell_help.h
+++ b/subsys/shell/shell_help.h
@@ -14,13 +14,13 @@ extern "C" {
 #endif
 
 /* Function is printing command help string. */
-void shell_help_cmd_print(const struct shell *shell,
-			  const struct shell_static_entry *cmd);
+void z_shell_help_cmd_print(const struct shell *shell,
+			    const struct shell_static_entry *cmd);
 
 /* Function is printing subcommands and help string. */
-void shell_help_subcmd_print(const struct shell *shell,
-			     const struct shell_static_entry *cmd,
-			     const char *description);
+void z_shell_help_subcmd_print(const struct shell *shell,
+			       const struct shell_static_entry *cmd,
+			       const char *description);
 
 /**
  * @}

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -41,13 +41,13 @@ struct shell_history_item {
 	char data[0];
 };
 
-void shell_history_mode_exit(struct shell_history *history)
+void z_shell_history_mode_exit(struct shell_history *history)
 {
 	history->current = NULL;
 }
 
-bool shell_history_get(struct shell_history *history, bool up,
-		       uint8_t *dst, uint16_t *len)
+bool z_shell_history_get(struct shell_history *history, bool up,
+			 uint8_t *dst, uint16_t *len)
 {
 	struct shell_history_item *h_item; /* history item */
 	sys_dnode_t *l_item; /* list item */
@@ -121,13 +121,14 @@ static bool remove_from_tail(struct shell_history *history)
 	return true;
 }
 
-void shell_history_purge(struct shell_history *history)
+void z_shell_history_purge(struct shell_history *history)
 {
 	while (remove_from_tail(history)) {
 	}
 }
 
-void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
+void z_shell_history_put(struct shell_history *history, uint8_t *line,
+			 size_t len)
 {
 	sys_dnode_t *l_item; /* list item */
 	struct shell_history_item *h_item;
@@ -143,7 +144,7 @@ void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
 		return;
 	}
 
-	shell_history_mode_exit(history);
+	z_shell_history_mode_exit(history);
 
 	if (len == 0) {
 		return;
@@ -198,7 +199,7 @@ void shell_history_put(struct shell_history *history, uint8_t *line, size_t len)
 	} while (1);
 }
 
-void shell_history_init(struct shell_history *history)
+void z_shell_history_init(struct shell_history *history)
 {
 	sys_dlist_init(&history->list);
 	history->current = NULL;

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -9,14 +9,14 @@
 #include "shell_ops.h"
 #include <logging/log_ctrl.h>
 
-int shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx)
+int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx)
 {
 	z_shell_print_stream(ctx, data, length);
 	return length;
 }
 
-void shell_log_backend_enable(const struct shell_log_backend *backend,
-			      void *ctx, uint32_t init_log_level)
+void z_shell_log_backend_enable(const struct shell_log_backend *backend,
+				void *ctx, uint32_t init_log_level)
 {
 	int err = 0;
 
@@ -117,7 +117,7 @@ static void msg_to_fifo(const struct shell *shell,
 	}
 }
 
-void shell_log_backend_disable(const struct shell_log_backend *backend)
+void z_shell_log_backend_disable(const struct shell_log_backend *backend)
 {
 	fifo_flush(backend);
 	log_backend_disable(backend->backend);
@@ -139,7 +139,7 @@ static void msg_process(const struct log_output *log_output,
 	log_msg_put(msg);
 }
 
-bool shell_log_backend_process(const struct shell_log_backend *backend)
+bool z_shell_log_backend_process(const struct shell_log_backend *backend)
 {
 	uint32_t dropped;
 	const struct shell *shell =
@@ -281,11 +281,11 @@ static void panic(const struct log_backend *const backend)
 		shell_op_cursor_horiz_move(shell,
 					   -shell->ctx->vt100_ctx.cons.cur_x);
 
-		while (shell_log_backend_process(shell->log_backend)) {
+		while (z_shell_log_backend_process(shell->log_backend)) {
 			/* empty */
 		}
 	} else {
-		shell_log_backend_disable(shell->log_backend);
+		z_shell_log_backend_disable(shell->log_backend);
 	}
 }
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -11,7 +11,7 @@
 
 int shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx)
 {
-	shell_print_stream(ctx, data, length);
+	z_shell_print_stream(ctx, data, length);
 	return length;
 }
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -274,9 +274,9 @@ static void panic(const struct log_backend *const backend)
 							SHELL_LOG_BACKEND_PANIC;
 
 		/* Move to the start of next line. */
-		shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
-						  shell->ctx->cmd_buff_pos,
-						  shell->ctx->cmd_buff_len);
+		z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
+					    shell->ctx->cmd_buff_pos,
+					    shell->ctx->cmd_buff_len);
 		z_shell_op_cursor_vert_move(shell, -1);
 		z_shell_op_cursor_horiz_move(shell,
 					   -shell->ctx->vt100_ctx.cons.cur_x);

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -157,14 +157,14 @@ bool z_shell_log_backend_process(const struct shell_log_backend *backend)
 		struct shell_vt100_colors col;
 
 		if (colors) {
-			shell_vt100_colors_store(shell, &col);
-			shell_vt100_color_set(shell, SHELL_VT100_COLOR_RED);
+			z_shell_vt100_colors_store(shell, &col);
+			z_shell_vt100_color_set(shell, SHELL_VT100_COLOR_RED);
 		}
 
 		log_output_dropped_process(backend->log_output, dropped);
 
 		if (colors) {
-			shell_vt100_colors_restore(shell, &col);
+			z_shell_vt100_colors_restore(shell, &col);
 		}
 	}
 
@@ -193,7 +193,7 @@ static void put(const struct log_backend *const backend, struct log_msg *msg)
 
 		break;
 	case SHELL_LOG_BACKEND_PANIC:
-		shell_cmd_line_erase(shell);
+		z_shell_cmd_line_erase(shell);
 		msg_process(shell->log_backend->log_output, msg, colors);
 
 		break;
@@ -221,13 +221,13 @@ static void put_sync_string(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	if (!flag_cmd_ctx_get(shell)) {
-		shell_cmd_line_erase(shell);
+	if (!z_flag_cmd_ctx_get(shell)) {
+		z_shell_cmd_line_erase(shell);
 	}
 	log_output_string(shell->log_backend->log_output, src_level, timestamp,
 			  fmt, ap, flags);
-	if (!flag_cmd_ctx_get(shell)) {
-		shell_print_prompt_and_cmd(shell);
+	if (!z_flag_cmd_ctx_get(shell)) {
+		z_shell_print_prompt_and_cmd(shell);
 	}
 	irq_unlock(key);
 }
@@ -247,13 +247,13 @@ static void put_sync_hexdump(const struct log_backend *const backend,
 	}
 
 	key = irq_lock();
-	if (!flag_cmd_ctx_get(shell)) {
-		shell_cmd_line_erase(shell);
+	if (!z_flag_cmd_ctx_get(shell)) {
+		z_shell_cmd_line_erase(shell);
 	}
 	log_output_hexdump(shell->log_backend->log_output, src_level, timestamp,
 			   metadata, data, length, flags);
-	if (!flag_cmd_ctx_get(shell)) {
-		shell_print_prompt_and_cmd(shell);
+	if (!z_flag_cmd_ctx_get(shell)) {
+		z_shell_print_prompt_and_cmd(shell);
 	}
 	irq_unlock(key);
 }
@@ -277,8 +277,8 @@ static void panic(const struct log_backend *const backend)
 		shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
 						  shell->ctx->cmd_buff_pos,
 						  shell->ctx->cmd_buff_len);
-		shell_op_cursor_vert_move(shell, -1);
-		shell_op_cursor_horiz_move(shell,
+		z_shell_op_cursor_vert_move(shell, -1);
+		z_shell_op_cursor_horiz_move(shell,
 					   -shell->ctx->vt100_ctx.cons.cur_x);
 
 		while (z_shell_log_backend_process(shell->log_backend)) {

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -30,14 +30,14 @@ void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
  */
 static inline bool full_line_cmd(const struct shell *shell)
 {
-	return ((shell->ctx->cmd_buff_len + shell_strlen(shell->ctx->prompt))
+	return ((shell->ctx->cmd_buff_len + z_shell_strlen(shell->ctx->prompt))
 			% shell->ctx->vt100_ctx.cons.terminal_wid == 0U);
 }
 
 /* Function returns true if cursor is at beginning of an empty line. */
 bool z_shell_cursor_in_empty_line(const struct shell *shell)
 {
-	return ((shell->ctx->cmd_buff_pos + shell_strlen(shell->ctx->prompt))
+	return ((shell->ctx->cmd_buff_pos + z_shell_strlen(shell->ctx->prompt))
 			% shell->ctx->vt100_ctx.cons.terminal_wid == 0U);
 }
 
@@ -53,8 +53,8 @@ void z_shell_op_cursor_position_synchronize(const struct shell *shell)
 	struct shell_multiline_cons *cons = &shell->ctx->vt100_ctx.cons;
 	bool last_line;
 
-	shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				  shell->ctx->cmd_buff_len);
+	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
+				    shell->ctx->cmd_buff_len);
 	last_line = (cons->cur_y == cons->cur_y_end);
 
 	/* In case cursor reaches the bottom line of a terminal, it will
@@ -81,17 +81,18 @@ void z_shell_op_cursor_move(const struct shell *shell, int16_t val)
 	int32_t row_span;
 	int32_t col_span;
 
-	shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				  shell->ctx->cmd_buff_len);
+	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
+				    shell->ctx->cmd_buff_len);
 
 	/* Calculate the new cursor. */
-	row_span = row_span_with_buffer_offsets_get(&shell->ctx->vt100_ctx.cons,
-						    shell->ctx->cmd_buff_pos,
-						    new_pos);
-	col_span = column_span_with_buffer_offsets_get(
-						    &shell->ctx->vt100_ctx.cons,
-						    shell->ctx->cmd_buff_pos,
-						    new_pos);
+	row_span = z_row_span_with_buffer_offsets_get(
+						&shell->ctx->vt100_ctx.cons,
+						shell->ctx->cmd_buff_pos,
+						new_pos);
+	col_span = z_column_span_with_buffer_offsets_get(
+						&shell->ctx->vt100_ctx.cons,
+						shell->ctx->cmd_buff_pos,
+						new_pos);
 
 	z_shell_op_cursor_vert_move(shell, -row_span);
 	z_shell_op_cursor_horiz_move(shell, col_span);
@@ -323,9 +324,9 @@ void z_shell_op_completion_insert(const struct shell *shell,
 
 void z_shell_cmd_line_erase(const struct shell *shell)
 {
-	shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
-				  shell->ctx->cmd_buff_pos,
-				  shell->ctx->cmd_buff_len);
+	z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
+				    shell->ctx->cmd_buff_pos,
+				    shell->ctx->cmd_buff_len);
 	z_shell_op_cursor_horiz_move(shell,
 				   -(shell->ctx->vt100_ctx.cons.cur_x - 1));
 	z_shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -178,7 +178,7 @@ void shell_op_word_remove(const struct shell *shell)
 	/* Update display. */
 	shell_op_cursor_move(shell, -chars_to_delete);
 	cursor_save(shell);
-	shell_internal_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
+	z_shell_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
 	clear_eos(shell);
 	cursor_restore(shell);
 }
@@ -223,7 +223,7 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 		clear_eos(shell);
 	}
 
-	shell_internal_fprintf(shell, SHELL_NORMAL, "%s",
+	z_shell_fprintf(shell, SHELL_NORMAL, "%s",
 		      &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 
@@ -336,7 +336,7 @@ void shell_cmd_line_erase(const struct shell *shell)
 
 static void print_prompt(const struct shell *shell)
 {
-	shell_internal_fprintf(shell, SHELL_INFO, "%s", shell->ctx->prompt);
+	z_shell_fprintf(shell, SHELL_INFO, "%s", shell->ctx->prompt);
 }
 
 void shell_print_cmd(const struct shell *shell)
@@ -393,10 +393,9 @@ void shell_write(const struct shell *shell, const void *data,
 }
 
 /* Function shall be only used by the fprintf module. */
-void shell_print_stream(const void *user_ctx, const char *data,
-			size_t data_len)
+void z_shell_print_stream(const void *user_ctx, const char *data, size_t len)
 {
-	shell_write((const struct shell *) user_ctx, data, data_len);
+	shell_write((const struct shell *) user_ctx, data, len);
 }
 
 static void vt100_bgcolor_set(const struct shell *shell,
@@ -444,9 +443,8 @@ void shell_vt100_colors_restore(const struct shell *shell,
 	vt100_bgcolor_set(shell, color->bgcol);
 }
 
-void shell_internal_vfprintf(const struct shell *shell,
-			     enum shell_vt100_color color, const char *fmt,
-			     va_list args)
+void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
+		      const char *fmt, va_list args)
 {
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS) &&
 	    shell->ctx->internal.flags.use_colors &&
@@ -456,15 +454,15 @@ void shell_internal_vfprintf(const struct shell *shell,
 		shell_vt100_colors_store(shell, &col);
 		shell_vt100_color_set(shell, color);
 
-		shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
 
 		shell_vt100_colors_restore(shell, &col);
 	} else {
-		shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
 	}
 }
 
-void shell_internal_fprintf(const struct shell *shell,
+void z_shell_fprintf(const struct shell *shell,
 			    enum shell_vt100_color color,
 			    const char *fmt, ...)
 {
@@ -477,6 +475,6 @@ void shell_internal_fprintf(const struct shell *shell,
 	va_list args;
 
 	va_start(args, fmt);
-	shell_internal_vfprintf(shell, color, fmt, args);
+	z_shell_vfprintf(shell, color, fmt, args);
 	va_end(args);
 }

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -7,21 +7,21 @@
 #include <ctype.h>
 #include "shell_ops.h"
 
-void shell_op_cursor_vert_move(const struct shell *shell, int32_t delta)
+void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta)
 {
 	if (delta != 0) {
-		shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
-				  delta > 0 ? delta : -delta,
-				  delta > 0 ? 'A' : 'B');
+		z_shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
+				    delta > 0 ? delta : -delta,
+				    delta > 0 ? 'A' : 'B');
 	}
 }
 
-void shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
+void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
 {
 	if (delta != 0) {
-		shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
-				  delta > 0 ? delta : -delta,
-				  delta > 0 ? 'C' : 'D');
+		z_shell_raw_fprintf(shell->fprintf_ctx, "\033[%d%c",
+				    delta > 0 ? delta : -delta,
+				    delta > 0 ? 'C' : 'D');
 	}
 }
 
@@ -35,20 +35,20 @@ static inline bool full_line_cmd(const struct shell *shell)
 }
 
 /* Function returns true if cursor is at beginning of an empty line. */
-bool shell_cursor_in_empty_line(const struct shell *shell)
+bool z_shell_cursor_in_empty_line(const struct shell *shell)
 {
 	return ((shell->ctx->cmd_buff_pos + shell_strlen(shell->ctx->prompt))
 			% shell->ctx->vt100_ctx.cons.terminal_wid == 0U);
 }
 
-void shell_op_cond_next_line(const struct shell *shell)
+void z_shell_op_cond_next_line(const struct shell *shell)
 {
-	if (shell_cursor_in_empty_line(shell) || full_line_cmd(shell)) {
-		cursor_next_line_move(shell);
+	if (z_shell_cursor_in_empty_line(shell) || full_line_cmd(shell)) {
+		z_cursor_next_line_move(shell);
 	}
 }
 
-void shell_op_cursor_position_synchronize(const struct shell *shell)
+void z_shell_op_cursor_position_synchronize(const struct shell *shell)
 {
 	struct shell_multiline_cons *cons = &shell->ctx->vt100_ctx.cons;
 	bool last_line;
@@ -61,20 +61,20 @@ void shell_op_cursor_position_synchronize(const struct shell *shell)
 	 * be moved to the next line.
 	 */
 	if (full_line_cmd(shell)) {
-		cursor_next_line_move(shell);
+		z_cursor_next_line_move(shell);
 	}
 
 	if (last_line) {
-		shell_op_cursor_horiz_move(shell, cons->cur_x -
+		z_shell_op_cursor_horiz_move(shell, cons->cur_x -
 							       cons->cur_x_end);
 	} else {
-		shell_op_cursor_vert_move(shell, cons->cur_y_end - cons->cur_y);
-		shell_op_cursor_horiz_move(shell, cons->cur_x -
+		z_shell_op_cursor_vert_move(shell, cons->cur_y_end - cons->cur_y);
+		z_shell_op_cursor_horiz_move(shell, cons->cur_x -
 							       cons->cur_x_end);
 	}
 }
 
-void shell_op_cursor_move(const struct shell *shell, int16_t val)
+void z_shell_op_cursor_move(const struct shell *shell, int16_t val)
 {
 	struct shell_multiline_cons *cons = &shell->ctx->vt100_ctx.cons;
 	uint16_t new_pos = shell->ctx->cmd_buff_pos + val;
@@ -93,8 +93,8 @@ void shell_op_cursor_move(const struct shell *shell, int16_t val)
 						    shell->ctx->cmd_buff_pos,
 						    new_pos);
 
-	shell_op_cursor_vert_move(shell, -row_span);
-	shell_op_cursor_horiz_move(shell, col_span);
+	z_shell_op_cursor_vert_move(shell, -row_span);
+	z_shell_op_cursor_horiz_move(shell, col_span);
 	shell->ctx->cmd_buff_pos = new_pos;
 }
 
@@ -123,7 +123,7 @@ static uint16_t shift_calc(const char *str, uint16_t pos, uint16_t len, int16_t 
 	return ret;
 }
 
-void shell_op_cursor_word_move(const struct shell *shell, int16_t val)
+void z_shell_op_cursor_word_move(const struct shell *shell, int16_t val)
 {
 	int16_t shift;
 	int16_t sign;
@@ -139,11 +139,11 @@ void shell_op_cursor_word_move(const struct shell *shell, int16_t val)
 		shift = shift_calc(shell->ctx->cmd_buff,
 				   shell->ctx->cmd_buff_pos,
 				   shell->ctx->cmd_buff_len, sign);
-		shell_op_cursor_move(shell, sign * shift);
+		z_shell_op_cursor_move(shell, sign * shift);
 	}
 }
 
-void shell_op_word_remove(const struct shell *shell)
+void z_shell_op_word_remove(const struct shell *shell)
 {
 	char *str = &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos - 1];
 	char *str_start = &shell->ctx->cmd_buff[0];
@@ -176,36 +176,35 @@ void shell_op_word_remove(const struct shell *shell)
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
 
 	/* Update display. */
-	shell_op_cursor_move(shell, -chars_to_delete);
-	cursor_save(shell);
+	z_shell_op_cursor_move(shell, -chars_to_delete);
+	z_cursor_save(shell);
 	z_shell_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
-	clear_eos(shell);
-	cursor_restore(shell);
+	z_clear_eos(shell);
+	z_cursor_restore(shell);
 }
 
-void shell_op_cursor_home_move(const struct shell *shell)
+void z_shell_op_cursor_home_move(const struct shell *shell)
 {
-	shell_op_cursor_move(shell, -shell->ctx->cmd_buff_pos);
+	z_shell_op_cursor_move(shell, -shell->ctx->cmd_buff_pos);
 }
 
-void shell_op_cursor_end_move(const struct shell *shell)
+void z_shell_op_cursor_end_move(const struct shell *shell)
 {
-	shell_op_cursor_move(shell, shell->ctx->cmd_buff_len -
+	z_shell_op_cursor_move(shell, shell->ctx->cmd_buff_len -
 						shell->ctx->cmd_buff_pos);
 }
 
-
-void shell_op_left_arrow(const struct shell *shell)
+void z_shell_op_left_arrow(const struct shell *shell)
 {
 	if (shell->ctx->cmd_buff_pos > 0) {
-		shell_op_cursor_move(shell, -1);
+		z_shell_op_cursor_move(shell, -1);
 	}
 }
 
-void shell_op_right_arrow(const struct shell *shell)
+void z_shell_op_right_arrow(const struct shell *shell)
 {
 	if (shell->ctx->cmd_buff_pos < shell->ctx->cmd_buff_len) {
-		shell_op_cursor_move(shell, 1);
+		z_shell_op_cursor_move(shell, 1);
 	}
 }
 
@@ -220,7 +219,7 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 	 * bytes transmitted between terminal and device.
 	 */
 	if (data_removed) {
-		clear_eos(shell);
+		z_clear_eos(shell);
 	}
 
 	z_shell_fprintf(shell, SHELL_NORMAL, "%s",
@@ -229,11 +228,11 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 
 	if (full_line_cmd(shell)) {
 		if (((data_removed) && (diff > 0)) || (!data_removed)) {
-			cursor_next_line_move(shell);
+			z_cursor_next_line_move(shell);
 		}
 	}
 
-	shell_op_cursor_move(shell, -diff);
+	z_shell_op_cursor_move(shell, -diff);
 }
 
 static void data_insert(const struct shell *shell, const char *data, uint16_t len)
@@ -250,7 +249,7 @@ static void data_insert(const struct shell *shell, const char *data, uint16_t le
 	shell->ctx->cmd_buff_len += len;
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
 
-	if (!flag_echo_get(shell)) {
+	if (!z_flag_echo_get(shell)) {
 		shell->ctx->cmd_buff_pos += len;
 		return;
 	}
@@ -262,17 +261,17 @@ static void char_replace(const struct shell *shell, char data)
 {
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos++] = data;
 
-	if (!flag_echo_get(shell)) {
+	if (!z_flag_echo_get(shell)) {
 		return;
 	}
 
-	shell_raw_fprintf(shell->fprintf_ctx, "%c", data);
-	if (shell_cursor_in_empty_line(shell)) {
-		cursor_next_line_move(shell);
+	z_shell_raw_fprintf(shell->fprintf_ctx, "%c", data);
+	if (z_shell_cursor_in_empty_line(shell)) {
+		z_cursor_next_line_move(shell);
 	}
 }
 
-void shell_op_char_insert(const struct shell *shell, char data)
+void z_shell_op_char_insert(const struct shell *shell, char data)
 {
 	if (shell->ctx->internal.flags.insert_mode &&
 		(shell->ctx->cmd_buff_len != shell->ctx->cmd_buff_pos)) {
@@ -282,18 +281,18 @@ void shell_op_char_insert(const struct shell *shell, char data)
 	}
 }
 
-void shell_op_char_backspace(const struct shell *shell)
+void z_shell_op_char_backspace(const struct shell *shell)
 {
 	if ((shell->ctx->cmd_buff_len == 0) ||
 	    (shell->ctx->cmd_buff_pos == 0)) {
 		return;
 	}
 
-	shell_op_cursor_move(shell, -1);
-	shell_op_char_delete(shell);
+	z_shell_op_cursor_move(shell, -1);
+	z_shell_op_char_delete(shell);
 }
 
-void shell_op_char_delete(const struct shell *shell)
+void z_shell_op_char_delete(const struct shell *shell)
 {
 	uint16_t diff = shell->ctx->cmd_buff_len - shell->ctx->cmd_buff_pos;
 	char *str = &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos];
@@ -307,31 +306,31 @@ void shell_op_char_delete(const struct shell *shell)
 	reprint_from_cursor(shell, --diff, true);
 }
 
-void shell_op_delete_from_cursor(const struct shell *shell)
+void z_shell_op_delete_from_cursor(const struct shell *shell)
 {
 	shell->ctx->cmd_buff_len = shell->ctx->cmd_buff_pos;
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos] = '\0';
 
-	clear_eos(shell);
+	z_clear_eos(shell);
 }
 
-void shell_op_completion_insert(const struct shell *shell,
-				const char *compl,
-				uint16_t compl_len)
+void z_shell_op_completion_insert(const struct shell *shell,
+				  const char *compl,
+				  uint16_t compl_len)
 {
 	data_insert(shell, compl, compl_len);
 }
 
-void shell_cmd_line_erase(const struct shell *shell)
+void z_shell_cmd_line_erase(const struct shell *shell)
 {
 	shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
 				  shell->ctx->cmd_buff_pos,
 				  shell->ctx->cmd_buff_len);
-	shell_op_cursor_horiz_move(shell,
+	z_shell_op_cursor_horiz_move(shell,
 				   -(shell->ctx->vt100_ctx.cons.cur_x - 1));
-	shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);
+	z_shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);
 
-	clear_eos(shell);
+	z_clear_eos(shell);
 }
 
 static void print_prompt(const struct shell *shell)
@@ -339,18 +338,18 @@ static void print_prompt(const struct shell *shell)
 	z_shell_fprintf(shell, SHELL_INFO, "%s", shell->ctx->prompt);
 }
 
-void shell_print_cmd(const struct shell *shell)
+void z_shell_print_cmd(const struct shell *shell)
 {
-	shell_raw_fprintf(shell->fprintf_ctx, "%s", shell->ctx->cmd_buff);
+	z_shell_raw_fprintf(shell->fprintf_ctx, "%s", shell->ctx->cmd_buff);
 }
 
-void shell_print_prompt_and_cmd(const struct shell *shell)
+void z_shell_print_prompt_and_cmd(const struct shell *shell)
 {
 	print_prompt(shell);
 
-	if (flag_echo_get(shell)) {
-		shell_print_cmd(shell);
-		shell_op_cursor_position_synchronize(shell);
+	if (z_flag_echo_get(shell)) {
+		z_shell_print_cmd(shell);
+		z_shell_op_cursor_position_synchronize(shell);
 	}
 }
 
@@ -362,13 +361,13 @@ static void shell_pend_on_txdone(const struct shell *shell)
 		k_poll_signal_reset(&shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
 	} else {
 		/* Blocking wait in case of bare metal. */
-		while (!flag_tx_rdy_get(shell)) {
+		while (!z_flag_tx_rdy_get(shell)) {
 		}
-		flag_tx_rdy_set(shell, false);
+		z_flag_tx_rdy_set(shell, false);
 	}
 }
 
-void shell_write(const struct shell *shell, const void *data,
+void z_shell_write(const struct shell *shell, const void *data,
 		 size_t length)
 {
 	__ASSERT_NO_MSG(shell && data);
@@ -395,7 +394,7 @@ void shell_write(const struct shell *shell, const void *data,
 /* Function shall be only used by the fprintf module. */
 void z_shell_print_stream(const void *user_ctx, const char *data, size_t len)
 {
-	shell_write((const struct shell *) user_ctx, data, len);
+	z_shell_write((const struct shell *) user_ctx, data, len);
 }
 
 static void vt100_bgcolor_set(const struct shell *shell,
@@ -410,12 +409,12 @@ static void vt100_bgcolor_set(const struct shell *shell,
 	uint8_t cmd[] = SHELL_VT100_BGCOLOR(bgcolor - 1);
 
 	shell->ctx->vt100_ctx.col.bgcol = bgcolor;
-	shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+	z_shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
 
 }
 
-void shell_vt100_color_set(const struct shell *shell,
-			   enum shell_vt100_color color)
+void z_shell_vt100_color_set(const struct shell *shell,
+			     enum shell_vt100_color color)
 {
 
 	if (shell->ctx->vt100_ctx.col.col == color) {
@@ -428,18 +427,18 @@ void shell_vt100_color_set(const struct shell *shell,
 
 		uint8_t cmd[] = SHELL_VT100_COLOR(color - 1);
 
-		shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+		z_shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
 	} else {
 		static const uint8_t cmd[] = SHELL_VT100_MODESOFF;
 
-		shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+		z_shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
 	}
 }
 
-void shell_vt100_colors_restore(const struct shell *shell,
+void z_shell_vt100_colors_restore(const struct shell *shell,
 				       const struct shell_vt100_colors *color)
 {
-	shell_vt100_color_set(shell, color->col);
+	z_shell_vt100_color_set(shell, color->col);
 	vt100_bgcolor_set(shell, color->bgcol);
 }
 
@@ -451,12 +450,12 @@ void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 	    (color != shell->ctx->vt100_ctx.col.col)) {
 		struct shell_vt100_colors col;
 
-		shell_vt100_colors_store(shell, &col);
-		shell_vt100_color_set(shell, color);
+		z_shell_vt100_colors_store(shell, &col);
+		z_shell_vt100_color_set(shell, color);
 
 		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
 
-		shell_vt100_colors_restore(shell, &col);
+		z_shell_vt100_colors_restore(shell, &col);
 	} else {
 		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
 	}

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -15,8 +15,8 @@
 extern "C" {
 #endif
 
-static inline void shell_raw_fprintf(const struct shell_fprintf *const ctx,
-				     const char *fmt, ...)
+static inline void z_shell_raw_fprintf(const struct shell_fprintf *const ctx,
+				       const char *fmt, ...)
 {
 	va_list args;
 
@@ -26,161 +26,155 @@ static inline void shell_raw_fprintf(const struct shell_fprintf *const ctx,
 }
 
 /* Macro to send VT100 commands. */
-#define SHELL_VT100_CMD(_shell_, _cmd_) \
+#define Z_SHELL_VT100_CMD(_shell_, _cmd_)				\
 	do {								\
 		static const char cmd[] = _cmd_;			\
-		shell_raw_fprintf(_shell_->fprintf_ctx, "%s", cmd);	\
+		z_shell_raw_fprintf(_shell_->fprintf_ctx, "%s", cmd);	\
 	} while (0)
 
 /* Function sends VT100 command to clear the screen from cursor position to
  * end of the screen.
  */
-static inline void clear_eos(const struct shell *shell)
+static inline void z_clear_eos(const struct shell *shell)
 {
-	SHELL_VT100_CMD(shell, SHELL_VT100_CLEAREOS);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_CLEAREOS);
 }
 
 /* Function sends VT100 command to save cursor position. */
-static inline void cursor_save(const struct shell *shell)
+static inline void z_cursor_save(const struct shell *shell)
 {
-	SHELL_VT100_CMD(shell, SHELL_VT100_SAVECURSOR);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_SAVECURSOR);
 }
 
 /* Function sends VT100 command to restore saved cursor position. */
-static inline void cursor_restore(const struct shell *shell)
+static inline void z_cursor_restore(const struct shell *shell)
 {
-	SHELL_VT100_CMD(shell, SHELL_VT100_RESTORECURSOR);
+	Z_SHELL_VT100_CMD(shell, SHELL_VT100_RESTORECURSOR);
 }
 
 /* Function forcing new line - cannot be replaced with function
  * cursor_down_move.
  */
-static inline void cursor_next_line_move(const struct shell *shell)
+static inline void z_cursor_next_line_move(const struct shell *shell)
 {
-	shell_raw_fprintf(shell->fprintf_ctx, "\n");
+	z_shell_raw_fprintf(shell->fprintf_ctx, "\n");
 }
 
-/* Function sends 1 character to the shell instance. */
-static inline void shell_putc(const struct shell *shell, char ch)
-{
-	shell_raw_fprintf(shell->fprintf_ctx, "%c", ch);
-}
-
-static inline bool flag_insert_mode_get(const struct shell *shell)
+static inline bool z_flag_insert_mode_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.insert_mode == 1;
 }
 
-static inline void flag_insert_mode_set(const struct shell *shell, bool val)
+static inline void z_flag_insert_mode_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.insert_mode = val ? 1 : 0;
 }
 
-static inline bool flag_use_colors_get(const struct shell *shell)
+static inline bool z_flag_use_colors_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.use_colors == 1;
 }
 
-static inline void flag_use_colors_set(const struct shell *shell, bool val)
+static inline void z_flag_use_colors_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.use_colors = val ? 1 : 0;
 }
 
-static inline bool flag_echo_get(const struct shell *shell)
+static inline bool z_flag_echo_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.echo == 1;
 }
 
-static inline void flag_echo_set(const struct shell *shell, bool val)
+static inline void z_flag_echo_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.echo = val ? 1 : 0;
 }
 
-static inline bool flag_processing_get(const struct shell *shell)
+static inline bool z_flag_processing_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.processing == 1;
 }
 
-static inline bool flag_tx_rdy_get(const struct shell *shell)
+static inline bool z_flag_tx_rdy_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.tx_rdy == 1;
 }
 
-static inline void flag_tx_rdy_set(const struct shell *shell, bool val)
+static inline void z_flag_tx_rdy_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.tx_rdy = val ? 1 : 0;
 }
 
-static inline bool flag_mode_delete_get(const struct shell *shell)
+static inline bool z_flag_mode_delete_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.mode_delete == 1;
 }
 
-static inline void flag_mode_delete_set(const struct shell *shell, bool val)
+static inline void z_flag_mode_delete_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.mode_delete = val ? 1 : 0;
 }
 
-static inline bool flag_history_exit_get(const struct shell *shell)
+static inline bool z_flag_history_exit_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.history_exit == 1;
 }
 
-static inline void flag_history_exit_set(const struct shell *shell, bool val)
+static inline void z_flag_history_exit_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.history_exit = val ? 1 : 0;
 }
 
-static inline bool flag_cmd_ctx_get(const struct shell *shell)
+static inline bool z_flag_cmd_ctx_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.cmd_ctx == 1;
 }
 
-static inline void flag_cmd_ctx_set(const struct shell *shell, bool val)
+static inline void z_flag_cmd_ctx_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.cmd_ctx = val ? 1 : 0;
 }
 
-static inline uint8_t flag_last_nl_get(const struct shell *shell)
+static inline uint8_t z_flag_last_nl_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.last_nl;
 }
 
-static inline void flag_last_nl_set(const struct shell *shell, uint8_t val)
+static inline void z_flag_last_nl_set(const struct shell *shell, uint8_t val)
 {
 	shell->ctx->internal.flags.last_nl = val;
 }
 
-static inline bool flag_print_noinit_get(const struct shell *shell)
+static inline bool z_flag_print_noinit_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.print_noinit == 1;
 }
 
-static inline void flag_print_noinit_set(const struct shell *shell, bool val)
+static inline void z_flag_print_noinit_set(const struct shell *shell, bool val)
 {
 	shell->ctx->internal.flags.print_noinit = val ? 1 : 0;
 }
 
-void shell_op_cursor_vert_move(const struct shell *shell, int32_t delta);
-void shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta);
+void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta);
+void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta);
 
-void shell_op_cond_next_line(const struct shell *shell);
+void z_shell_op_cond_next_line(const struct shell *shell);
 
 /* Function will move cursor back to position == cmd_buff_pos. Example usage is
  * when cursor needs to be moved back after printing some text. This function
  * cannot be used to move cursor to new location by manual change of
  * cmd_buff_pos.
  */
-void shell_op_cursor_position_synchronize(const struct shell *shell);
+void z_shell_op_cursor_position_synchronize(const struct shell *shell);
 
-void shell_op_cursor_move(const struct shell *shell, int16_t val);
+void z_shell_op_cursor_move(const struct shell *shell, int16_t val);
 
-void shell_op_left_arrow(const struct shell *shell);
+void z_shell_op_left_arrow(const struct shell *shell);
 
-void shell_op_right_arrow(const struct shell *shell);
+void z_shell_op_right_arrow(const struct shell *shell);
 
 /* Moves cursor by defined number of words left (val negative) or right. */
-void shell_op_cursor_word_move(const struct shell *shell, int16_t val);
+void z_shell_op_cursor_word_move(const struct shell *shell, int16_t val);
 
 /*
  *  Removes the "word" to the left of the cursor:
@@ -188,45 +182,45 @@ void shell_op_cursor_word_move(const struct shell *shell, int16_t val);
  *  - remove the non-spaces (word) until a space is found or a beginning of
  *    buffer
  */
-void shell_op_word_remove(const struct shell *shell);
+void z_shell_op_word_remove(const struct shell *shell);
 
 /* Function moves cursor to begin of command position, just after console
  * name.
  */
-void shell_op_cursor_home_move(const struct shell *shell);
+void z_shell_op_cursor_home_move(const struct shell *shell);
 
 /* Function moves cursor to end of command. */
-void shell_op_cursor_end_move(const struct shell *shell);
+void z_shell_op_cursor_end_move(const struct shell *shell);
 
-void shell_op_char_insert(const struct shell *shell, char data);
+void z_shell_op_char_insert(const struct shell *shell, char data);
 
-void shell_op_char_backspace(const struct shell *shell);
+void z_shell_op_char_backspace(const struct shell *shell);
 
-void shell_op_char_delete(const struct shell *shell);
+void z_shell_op_char_delete(const struct shell *shell);
 
-void shell_op_delete_from_cursor(const struct shell *shell);
+void z_shell_op_delete_from_cursor(const struct shell *shell);
 
-void shell_op_completion_insert(const struct shell *shell,
-				const char *compl,
-				uint16_t compl_len);
+void z_shell_op_completion_insert(const struct shell *shell,
+				  const char *compl,
+				  uint16_t compl_len);
 
-bool shell_cursor_in_empty_line(const struct shell *shell);
+bool z_shell_cursor_in_empty_line(const struct shell *shell);
 
-void shell_cmd_line_erase(const struct shell *shell);
+void z_shell_cmd_line_erase(const struct shell *shell);
 
 /**
  * @brief Print command buffer.
  *
  * @param shell Shell instance.
  */
-void shell_print_cmd(const struct shell *shell);
+void z_shell_print_cmd(const struct shell *shell);
 
 /**
  * @brief Print prompt followed by command buffer.
  *
  * @param shell Shell instance.
  */
-void shell_print_prompt_and_cmd(const struct shell *shell);
+void z_shell_print_prompt_and_cmd(const struct shell *shell);
 
 /* Function sends data stream to the shell instance. Each time before the
  * shell_write function is called, it must be ensured that IO buffer of fprintf
@@ -236,8 +230,7 @@ void shell_print_prompt_and_cmd(const struct shell *shell);
  * This function can be only used by shell module, it shall not be called
  * directly.
  */
-void shell_write(const struct shell *shell, const void *data,
-		 size_t length);
+void z_shell_write(const struct shell *shell, const void *data, size_t length);
 
 /**
  * @internal @brief This function shall not be used directly, it is required by
@@ -250,17 +243,17 @@ void shell_write(const struct shell *shell, const void *data,
 void z_shell_print_stream(const void *user_ctx, const char *data, size_t len);
 
 /** @internal @brief Function for setting font color */
-void shell_vt100_color_set(const struct shell *shell,
-			   enum shell_vt100_color color);
+void z_shell_vt100_color_set(const struct shell *shell,
+			     enum shell_vt100_color color);
 
-static inline void shell_vt100_colors_store(const struct shell *shell,
-					    struct shell_vt100_colors *color)
+static inline void z_shell_vt100_colors_store(const struct shell *shell,
+					      struct shell_vt100_colors *color)
 {
 	memcpy(color, &shell->ctx->vt100_ctx.col, sizeof(*color));
 }
 
-void shell_vt100_colors_restore(const struct shell *shell,
-				const struct shell_vt100_colors *color);
+void z_shell_vt100_colors_restore(const struct shell *shell,
+				  const struct shell_vt100_colors *color);
 
 /* This function can be called only within shell thread but not from command
  * handlers.

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -21,7 +21,7 @@ static inline void shell_raw_fprintf(const struct shell_fprintf *const ctx,
 	va_list args;
 
 	va_start(args, fmt);
-	shell_fprintf_fmt(ctx, fmt, args);
+	z_shell_fprintf_fmt(ctx, fmt, args);
 	va_end(args);
 }
 
@@ -245,10 +245,9 @@ void shell_write(const struct shell *shell, const void *data,
  *
  * @param[in] p_user_ctx    Pointer to the context for the shell instance.
  * @param[in] p_data        Pointer to the data buffer.
- * @param[in] data_len      Data buffer size.
+ * @param[in] len           Data buffer size.
  */
-void shell_print_stream(const void *user_ctx, const char *data,
-			size_t data_len);
+void z_shell_print_stream(const void *user_ctx, const char *data, size_t len);
 
 /** @internal @brief Function for setting font color */
 void shell_vt100_color_set(const struct shell *shell,
@@ -266,13 +265,11 @@ void shell_vt100_colors_restore(const struct shell *shell,
 /* This function can be called only within shell thread but not from command
  * handlers.
  */
-void shell_internal_fprintf(const struct shell *shell,
-			    enum shell_vt100_color color,
-			    const char *fmt, ...);
+void z_shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
+		     const char *fmt, ...);
 
-void shell_internal_vfprintf(const struct shell *shell,
-			     enum shell_vt100_color color, const char *fmt,
-			     va_list args);
+void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
+		      const char *fmt, va_list args);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -310,7 +310,7 @@ const struct shell_static_entry *shell_get_last_command(
 {
 	const struct shell_static_entry *prev_entry = NULL;
 
-	*match_arg = SHELL_CMD_ROOT_LVL;
+	*match_arg = Z_SHELL_CMD_ROOT_LVL;
 
 	while (*match_arg < argc) {
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -357,35 +357,8 @@ int shell_set_root_cmd(const char *cmd)
 	return 0;
 }
 
-int shell_command_add(char *buff, uint16_t *buff_len,
-		      const char *new_cmd, const char *pattern)
-{
-	uint16_t cmd_len = shell_strlen(new_cmd);
-	char *cmd_source_addr;
-	uint16_t shift;
 
-	/* +1 for space */
-	if ((*buff_len + cmd_len + 1) > CONFIG_SHELL_CMD_BUFF_SIZE) {
-		return -ENOMEM;
-	}
 
-	cmd_source_addr = strstr(buff, pattern);
-
-	if (!cmd_source_addr) {
-		return -EINVAL;
-	}
-
-	shift = shell_strlen(cmd_source_addr);
-
-	/* make place for new command: + 1 for space + 1 for EOS */
-	memmove(cmd_source_addr + cmd_len + 1, cmd_source_addr, shift + 1);
-	memcpy(cmd_source_addr, new_cmd, cmd_len);
-	cmd_source_addr[cmd_len] = ' ';
-
-	*buff_len += cmd_len + 1; /* + 1 for space */
-
-	return 0;
-}
 
 void shell_spaces_trim(char *str)
 {

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -31,24 +31,24 @@ static uint32_t col_num_with_buffer_offset_get(struct shell_multiline_cons *cons
 	return (1 + ((buffer_pos + cons->name_len) % cons->terminal_wid));
 }
 
-int32_t column_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
-					  uint16_t offset1,
-					  uint16_t offset2)
+int32_t z_column_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
+					      uint16_t offset1,
+					      uint16_t offset2)
 {
 	return col_num_with_buffer_offset_get(cons, offset2)
 			- col_num_with_buffer_offset_get(cons, offset1);
 }
 
-int32_t row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
-				       uint16_t offset1,
-				       uint16_t offset2)
+int32_t z_row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
+					   uint16_t offset1,
+					   uint16_t offset2)
 {
 	return line_num_with_buffer_offset_get(cons, offset2)
 		- line_num_with_buffer_offset_get(cons, offset1);
 }
 
-void shell_multiline_data_calc(struct shell_multiline_cons *cons,
-			       uint16_t buff_pos, uint16_t buff_len)
+void z_shell_multiline_data_calc(struct shell_multiline_cons *cons,
+				 uint16_t buff_pos, uint16_t buff_len)
 {
 	/* Current cursor position in command.
 	 * +1 -> because home position is (1, 1)
@@ -77,14 +77,14 @@ static char make_argv(char **ppcmd, uint8_t c)
 			switch (c) {
 			case '\\':
 				memmove(cmd, cmd + 1,
-						shell_strlen(cmd));
+						z_shell_strlen(cmd));
 				cmd += 1;
 				continue;
 
 			case '\'':
 			case '\"':
 				memmove(cmd, cmd + 1,
-						shell_strlen(cmd));
+						z_shell_strlen(cmd));
 				quote = c;
 				continue;
 			default:
@@ -93,7 +93,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 		}
 
 		if (quote == c) {
-			memmove(cmd, cmd + 1, shell_strlen(cmd));
+			memmove(cmd, cmd + 1, z_shell_strlen(cmd));
 			quote = 0;
 			continue;
 		}
@@ -103,7 +103,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 
 			if (t == quote) {
 				memmove(cmd, cmd + 1,
-						shell_strlen(cmd));
+						z_shell_strlen(cmd));
 				cmd += 1;
 				continue;
 			}
@@ -124,7 +124,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 
 				if (i > 2) {
 					memmove(cmd, cmd + (i - 1),
-						shell_strlen(cmd) - (i - 2));
+						z_shell_strlen(cmd) - (i - 2));
 					*cmd++ = v;
 					continue;
 				}
@@ -151,7 +151,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 
 				if (i > 2) {
 					memmove(cmd, cmd + (i - 1),
-						shell_strlen(cmd) - (i - 2));
+						z_shell_strlen(cmd) - (i - 2));
 					*cmd++ = v;
 					continue;
 				}
@@ -170,7 +170,8 @@ static char make_argv(char **ppcmd, uint8_t c)
 }
 
 
-char shell_make_argv(size_t *argc, const char **argv, char *cmd, uint8_t max_argc)
+char z_shell_make_argv(size_t *argc, const char **argv, char *cmd,
+		       uint8_t max_argc)
 {
 	char quote = 0;
 	char c;
@@ -197,11 +198,11 @@ char shell_make_argv(size_t *argc, const char **argv, char *cmd, uint8_t max_arg
 	return quote;
 }
 
-void shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern)
+void z_shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern)
 {
 	char *pattern_addr = strstr(buff, pattern);
 	uint16_t shift;
-	uint16_t pattern_len = shell_strlen(pattern);
+	uint16_t pattern_len = z_shell_strlen(pattern);
 
 	if (!pattern_addr) {
 		return;
@@ -214,7 +215,7 @@ void shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern)
 		}
 	}
 
-	shift = shell_strlen(pattern_addr) - pattern_len + 1; /* +1 for EOS */
+	shift = z_shell_strlen(pattern_addr) - pattern_len + 1; /* +1 for EOS */
 	*buff_len -= pattern_len;
 
 	memmove(pattern_addr, pattern_addr + pattern_len, shift);
@@ -243,7 +244,7 @@ static const struct shell_static_entry *root_cmd_find(const char *syntax)
 	return NULL;
 }
 
-const struct shell_static_entry *shell_cmd_get(
+const struct shell_static_entry *z_shell_cmd_get(
 					const struct shell_static_entry *parent,
 					size_t idx,
 					struct shell_static_entry *dloc)
@@ -283,7 +284,7 @@ const struct shell_static_entry *shell_cmd_get(
  *
  * @return		Pointer to found command.
  */
-const struct shell_static_entry *shell_find_cmd(
+const struct shell_static_entry *z_shell_find_cmd(
 					const struct shell_static_entry *parent,
 					const char *cmd_str,
 					struct shell_static_entry *dloc)
@@ -291,7 +292,7 @@ const struct shell_static_entry *shell_find_cmd(
 	const struct shell_static_entry *entry;
 	size_t idx = 0;
 
-	while ((entry = shell_cmd_get(parent, idx++, dloc)) != NULL) {
+	while ((entry = z_shell_cmd_get(parent, idx++, dloc)) != NULL) {
 		if (strcmp(cmd_str, entry->syntax) == 0) {
 			return entry;
 		}
@@ -300,7 +301,7 @@ const struct shell_static_entry *shell_find_cmd(
 	return NULL;
 }
 
-const struct shell_static_entry *shell_get_last_command(
+const struct shell_static_entry *z_shell_get_last_command(
 					const struct shell_static_entry *entry,
 					size_t argc,
 					const char *argv[],
@@ -323,7 +324,7 @@ const struct shell_static_entry *shell_get_last_command(
 		}
 
 		prev_entry = entry;
-		entry = shell_find_cmd(entry, argv[*match_arg], dloc);
+		entry = z_shell_find_cmd(entry, argv[*match_arg], dloc);
 		if (entry) {
 			(*match_arg)++;
 		} else {
@@ -360,9 +361,9 @@ int shell_set_root_cmd(const char *cmd)
 
 
 
-void shell_spaces_trim(char *str)
+void z_shell_spaces_trim(char *str)
 {
-	uint16_t len = shell_strlen(str);
+	uint16_t len = z_shell_strlen(str);
 	uint16_t shift = 0U;
 
 	if (!str) {
@@ -427,7 +428,7 @@ static void buffer_trim(char *buff, uint16_t *buff_len)
 	}
 }
 
-void shell_cmd_trim(const struct shell *shell)
+void z_shell_cmd_trim(const struct shell *shell)
 {
 	buffer_trim(shell->ctx->cmd_buff, &shell->ctx->cmd_buff_len);
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -316,7 +316,7 @@ const struct shell_static_entry *shell_get_last_command(
 
 		if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
 			/* ignore wildcard argument */
-			if (shell_wildcard_character_exist(argv[*match_arg])) {
+			if (z_shell_has_wildcard(argv[*match_arg])) {
 				(*match_arg)++;
 				continue;
 			}

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -228,7 +228,7 @@ static inline uint32_t shell_root_cmd_count(void)
 }
 
 /* Function returning pointer to parent command matching requested syntax. */
-const struct shell_static_entry *shell_root_cmd_find(const char *syntax)
+static const struct shell_static_entry *root_cmd_find(const char *syntax)
 {
 	const size_t cmd_count = shell_root_cmd_count();
 	const struct shell_cmd_entry *cmd;
@@ -344,7 +344,7 @@ int shell_set_root_cmd(const char *cmd)
 {
 	const struct shell_static_entry *entry;
 
-	entry = cmd ? shell_root_cmd_find(cmd) : NULL;
+	entry = cmd ? root_cmd_find(cmd) : NULL;
 
 	if (cmd && (entry == NULL)) {
 		return -EINVAL;

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -77,8 +77,6 @@ const struct shell_static_entry *shell_get_last_command(
 					struct shell_static_entry *dloc,
 					bool only_static);
 
-const struct shell_static_entry *shell_root_cmd_find(const char *syntax);
-
 void shell_spaces_trim(char *str);
 
 static inline void transport_buffer_flush(const struct shell *shell)

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -77,9 +77,6 @@ const struct shell_static_entry *shell_get_last_command(
 					struct shell_static_entry *dloc,
 					bool only_static);
 
-int shell_command_add(char *buff, uint16_t *buff_len,
-		      const char *new_cmd, const char *pattern);
-
 const struct shell_static_entry *shell_root_cmd_find(const char *syntax);
 
 void shell_spaces_trim(char *str);

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -86,7 +86,7 @@ void shell_spaces_trim(char *str);
 
 static inline void transport_buffer_flush(const struct shell *shell)
 {
-	shell_fprintf_buffer_flush(shell->fprintf_ctx);
+	z_shell_fprintf_buffer_flush(shell->fprintf_ctx);
 }
 
 void shell_cmd_trim(const struct shell *shell);

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -15,29 +15,30 @@ extern "C" {
 
 #define SHELL_MSG_SPECIFY_SUBCOMMAND	"Please specify a subcommand.\n"
 
-int32_t row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
-				       uint16_t offset1,
-				       uint16_t offset2);
+int32_t z_row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
+					   uint16_t offset1,
+					   uint16_t offset2);
 
-int32_t column_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
-					  uint16_t offset1,
-					  uint16_t offset2);
+int32_t z_column_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
+					      uint16_t offset1,
+					      uint16_t offset2);
 
-void shell_multiline_data_calc(struct shell_multiline_cons *cons,
-				   uint16_t buff_pos, uint16_t buff_len);
+void z_shell_multiline_data_calc(struct shell_multiline_cons *cons,
+				 uint16_t buff_pos, uint16_t buff_len);
 
-static inline uint16_t shell_strlen(const char *str)
+static inline uint16_t z_shell_strlen(const char *str)
 {
 	return str == NULL ? 0U : (uint16_t)strlen(str);
 }
 
-char shell_make_argv(size_t *argc, const char **argv,
-		     char *cmd, uint8_t max_argc);
+char z_shell_make_argv(size_t *argc, const char **argv,
+		       char *cmd, uint8_t max_argc);
 
 /** @brief Removes pattern and following space
  *
  */
-void shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern);
+void z_shell_pattern_remove(char *buff, uint16_t *buff_len,
+			    const char *pattern);
 
 /** @brief Get subcommand with given index from the root.
  *
@@ -47,12 +48,12 @@ void shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern);
  *
  * @return Fetched command or null if command with that index does not exist.
  */
-const struct shell_static_entry *shell_cmd_get(
+const struct shell_static_entry *z_shell_cmd_get(
 					const struct shell_static_entry *parent,
 					size_t idx,
 					struct shell_static_entry *dloc);
 
-const struct shell_static_entry *shell_find_cmd(
+const struct shell_static_entry *z_shell_find_cmd(
 					const struct shell_static_entry *parent,
 					const char *cmd_str,
 					struct shell_static_entry *dloc);
@@ -69,7 +70,7 @@ const struct shell_static_entry *shell_find_cmd(
  *
  * @return		Pointer to found command.
  */
-const struct shell_static_entry *shell_get_last_command(
+const struct shell_static_entry *z_shell_get_last_command(
 					const struct shell_static_entry *entry,
 					size_t argc,
 					const char *argv[],
@@ -77,16 +78,15 @@ const struct shell_static_entry *shell_get_last_command(
 					struct shell_static_entry *dloc,
 					bool only_static);
 
-void shell_spaces_trim(char *str);
+void z_shell_spaces_trim(char *str);
+void z_shell_cmd_trim(const struct shell *shell);
 
-static inline void transport_buffer_flush(const struct shell *shell)
+static inline void z_transport_buffer_flush(const struct shell *shell)
 {
 	z_shell_fprintf_buffer_flush(shell->fprintf_ctx);
 }
 
-void shell_cmd_trim(const struct shell *shell);
-
-static inline bool shell_in_select_mode(const struct shell *shell)
+static inline bool z_shell_in_select_mode(const struct shell *shell)
 {
 	return shell->ctx->selected_cmd == NULL ? false : true;
 }

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -83,12 +83,10 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 					      &shell->ctx->cmd_tmp_buff_len,
 					      entry->syntax, pattern);
 			if (ret_val == SHELL_WILDCARD_CMD_MISSING_SPACE) {
-				shell_internal_fprintf(shell,
-					      SHELL_WARNING,
-					      "Command buffer is too short to"
-					      " expand all commands matching"
-					      " wildcard pattern: %s\n",
-					      pattern);
+				z_shell_fprintf(shell, SHELL_WARNING,
+					"Command buffer is too short to"
+					" expand all commands matching"
+					" wildcard pattern: %s\n", pattern);
 				break;
 			} else if (ret_val != SHELL_WILDCARD_CMD_ADDED) {
 				break;

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -14,7 +14,7 @@ static enum shell_wildcard_status command_add(char *buff, uint16_t *buff_len,
 					      char const *cmd,
 					      char const *pattern)
 {
-	uint16_t cmd_len = shell_strlen(cmd);
+	uint16_t cmd_len = z_shell_strlen(cmd);
 	char *completion_addr;
 	uint16_t shift;
 
@@ -29,7 +29,7 @@ static enum shell_wildcard_status command_add(char *buff, uint16_t *buff_len,
 		return SHELL_WILDCARD_CMD_NO_MATCH_FOUND;
 	}
 
-	shift = shell_strlen(completion_addr);
+	shift = z_shell_strlen(completion_addr);
 
 	/* make place for new command: + 1 for space + 1 for EOS */
 	memmove(completion_addr + cmd_len + 1, completion_addr, shift + 1);
@@ -76,7 +76,7 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 	size_t cmd_idx = 0;
 	size_t cnt = 0;
 
-	while ((entry = shell_cmd_get(cmd, cmd_idx++, &dloc)) != NULL) {
+	while ((entry = z_shell_cmd_get(cmd, cmd_idx++, &dloc)) != NULL) {
 
 		if (fnmatch(pattern, entry->syntax, 0) == 0) {
 			ret_val = command_add(shell->ctx->temp_buff,
@@ -96,8 +96,8 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 	};
 
 	if (cnt > 0) {
-		shell_pattern_remove(shell->ctx->temp_buff,
-				     &shell->ctx->cmd_tmp_buff_len, pattern);
+		z_shell_pattern_remove(shell->ctx->temp_buff,
+				       &shell->ctx->cmd_tmp_buff_len, pattern);
 	}
 
 	return ret_val;
@@ -105,7 +105,7 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 
 bool z_shell_has_wildcard(const char *str)
 {
-	uint16_t str_len = shell_strlen(str);
+	uint16_t str_len = z_shell_strlen(str);
 
 	for (size_t i = 0; i < str_len; i++) {
 		if ((str[i] == '?') || (str[i] == '*')) {
@@ -149,10 +149,10 @@ void z_shell_wildcard_prepare(const struct shell *shell)
 	 * At this point it is important to keep temp_buff as one string.
 	 * It will allow to find wildcard commands easily with strstr function.
 	 */
-	shell_spaces_trim(shell->ctx->temp_buff);
+	z_shell_spaces_trim(shell->ctx->temp_buff);
 
 	/* +1 for EOS*/
-	shell->ctx->cmd_tmp_buff_len = shell_strlen(shell->ctx->temp_buff) + 1;
+	shell->ctx->cmd_tmp_buff_len = z_shell_strlen(shell->ctx->temp_buff) + 1;
 }
 
 

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -103,7 +103,7 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 	return ret_val;
 }
 
-bool shell_wildcard_character_exist(const char *str)
+bool z_shell_has_wildcard(const char *str)
 {
 	uint16_t str_len = shell_strlen(str);
 
@@ -116,7 +116,7 @@ bool shell_wildcard_character_exist(const char *str)
 	return false;
 }
 
-void shell_wildcard_prepare(const struct shell *shell)
+void z_shell_wildcard_prepare(const struct shell *shell)
 {
 	/* Wildcard can be correctly handled under following conditions:
 	 * - wildcard command does not have a handler
@@ -156,7 +156,7 @@ void shell_wildcard_prepare(const struct shell *shell)
 }
 
 
-enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
+enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
 					const struct shell_static_entry *cmd,
 					const char *pattern)
 {
@@ -166,7 +166,7 @@ enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
 		return ret_val;
 	}
 
-	if (!shell_wildcard_character_exist(pattern)) {
+	if (!z_shell_has_wildcard(pattern)) {
 		return ret_val;
 	}
 
@@ -182,7 +182,7 @@ enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
 	return ret_val;
 }
 
-void shell_wildcard_finalize(const struct shell *shell)
+void z_shell_wildcard_finalize(const struct shell *shell)
 {
 	memcpy(shell->ctx->cmd_buff,
 	       shell->ctx->temp_buff,

--- a/subsys/shell/shell_wildcard.h
+++ b/subsys/shell/shell_wildcard.h
@@ -20,7 +20,7 @@ enum shell_wildcard_status {
  *
  * @param[in] shell	Pointer to the shell instance.
  */
-void shell_wildcard_prepare(const struct shell *shell);
+void z_shell_wildcard_prepare(const struct shell *shell);
 
 /* Function returns true if string contains wildcard character: '?' or '*'
  *
@@ -29,7 +29,7 @@ void shell_wildcard_prepare(const struct shell *shell);
  * @retval true		wildcard character found
  * @retval false	wildcard character not found
  */
-bool shell_wildcard_character_exist(const char *str);
+bool z_shell_has_wildcard(const char *str);
 
 /* Function expands wildcards in the shell temporary buffer
  *
@@ -44,7 +44,7 @@ bool shell_wildcard_character_exist(const char *str);
  * @param[in] cmd	Pointer to command which will be processed.
  * @param[in] pattern	Pointer to wildcard pattern.
  */
-enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
+enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
 					const struct shell_static_entry *cmd,
 					const char *pattern);
 
@@ -52,7 +52,7 @@ enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
  *
  * @param[in] shell	Pointer to the shell instance.
  */
-void shell_wildcard_finalize(const struct shell *shell);
+void z_shell_wildcard_finalize(const struct shell *shell);
 
 
 #endif /* SHELL_SHELL_WILDCARDS_H__ */

--- a/tests/subsys/shell/shell_history/src/shell_history_test.c
+++ b/tests/subsys/shell/shell_history/src/shell_history_test.c
@@ -15,7 +15,7 @@
 #include <shell/shell_history.h>
 
 #define HIST_BUF_SIZE 160
-SHELL_HISTORY_DEFINE(history, HIST_BUF_SIZE);
+Z_SHELL_HISTORY_DEFINE(history, HIST_BUF_SIZE);
 
 static void init_test_buf(uint8_t *buf, size_t len, uint8_t offset)
 {
@@ -36,7 +36,7 @@ static void test_get(bool ok, bool up, uint8_t *exp_buf, uint16_t exp_len)
 
 	out_len = sizeof(out_buf);
 
-	res = shell_history_get(&history, up, out_buf, &out_len);
+	res = z_shell_history_get(&history, up, out_buf, &out_len);
 
 	if (ok) {
 		zassert_true(res, "history should contain one entry.\n");
@@ -64,15 +64,15 @@ static void test_history_add_get(void)
 
 	init_test_buf(exp_buf, sizeof(exp_buf), 0);
 
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
 	test_get(false, true, NULL, 0);
 
-	shell_history_put(&history, exp_buf, 20);
+	z_shell_history_put(&history, exp_buf, 20);
 
 	test_get(true, true, exp_buf, 20);
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 }
 
 /* Test verifies that after purging there is no line in the history. */
@@ -82,12 +82,12 @@ static void test_history_purge(void)
 
 	init_test_buf(exp_buf, sizeof(exp_buf), 0);
 
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
-	shell_history_put(&history, exp_buf, 20);
-	shell_history_put(&history, exp_buf, 20);
+	z_shell_history_put(&history, exp_buf, 20);
+	z_shell_history_put(&history, exp_buf, 20);
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 
 	test_get(false, true, NULL, 0);
 }
@@ -117,11 +117,11 @@ static void test_history_get_up_and_down(void)
 	init_test_buf(exp2_buf, sizeof(exp2_buf), 10);
 	init_test_buf(exp3_buf, sizeof(exp3_buf), 20);
 
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
-	shell_history_put(&history, exp1_buf, 20);
-	shell_history_put(&history, exp2_buf, 15);
-	shell_history_put(&history, exp3_buf, 20);
+	z_shell_history_put(&history, exp1_buf, 20);
+	z_shell_history_put(&history, exp2_buf, 15);
+	z_shell_history_put(&history, exp3_buf, 20);
 
 	test_get(true, true, exp3_buf, 20); /* up - 3*/
 	test_get(true, true, exp2_buf, 15); /* up - 2*/
@@ -132,7 +132,7 @@ static void test_history_get_up_and_down(void)
 	test_get(true, false, exp3_buf, 20); /* down - 3 */
 	test_get(false, false, NULL, 0); /* down - nothing */
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 }
 
 /* Function for getting maximal buffer size that can be stored in the history */
@@ -143,13 +143,13 @@ static int get_max_buffer_len(void)
 	int len = sizeof(buf);
 	uint16_t out_len;
 
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
 	do {
-		shell_history_put(&history, buf, len);
+		z_shell_history_put(&history, buf, len);
 		out_len = sizeof(out_buf);
-		if (shell_history_get(&history, true, out_buf, &out_len)) {
-			shell_history_purge(&history);
+		if (z_shell_history_get(&history, true, out_buf, &out_len)) {
+			z_shell_history_purge(&history);
 			break;
 		}
 	} while (len--);
@@ -172,21 +172,21 @@ static void test_too_long_line_not_stored(void)
 	int max_len = get_max_buffer_len();
 
 	init_test_buf(exp1_buf, sizeof(exp1_buf), 0);
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
-	shell_history_put(&history, exp1_buf, max_len + 1);
+	z_shell_history_put(&history, exp1_buf, max_len + 1);
 
 	/*validate that nothing is stored */
 	test_get(false, true, NULL, 0); /* empty */
 
-	shell_history_put(&history, exp1_buf, 20);
-	shell_history_put(&history, exp1_buf, max_len - 10);
+	z_shell_history_put(&history, exp1_buf, 20);
+	z_shell_history_put(&history, exp1_buf, max_len - 10);
 
 	/* Test that long entry evicts older entry. */
 	test_get(true, true, exp1_buf, max_len - 10);
 	test_get(false, true, NULL, 0); /* only one entry */
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 }
 
 /* Test verifies that same line as the previous one is not stored in the
@@ -202,16 +202,16 @@ static void test_no_duplicates_in_a_row(void)
 	uint8_t exp1_buf[HIST_BUF_SIZE];
 
 	init_test_buf(exp1_buf, sizeof(exp1_buf), 0);
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
-	shell_history_put(&history, exp1_buf, 20);
-	shell_history_put(&history, exp1_buf, 20);
+	z_shell_history_put(&history, exp1_buf, 20);
+	z_shell_history_put(&history, exp1_buf, 20);
 
 	test_get(true, true, exp1_buf, 20);
 	/* only one line stored. */
 	test_get(false, true, NULL, 0);
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 }
 
 /* Test storing long lines in the history.
@@ -236,21 +236,21 @@ static void test_storing_long_buffers(void)
 	init_test_buf(exp2_buf, sizeof(exp2_buf), 10);
 	init_test_buf(exp3_buf, sizeof(exp3_buf), 20);
 
-	shell_history_init(&history);
+	z_shell_history_init(&history);
 
-	shell_history_put(&history, exp1_buf, max_len);
+	z_shell_history_put(&history, exp1_buf, max_len);
 	test_get(true, true, exp1_buf, max_len);
 	test_get(false, true, NULL, 0); /* only one entry */
 
-	shell_history_put(&history, exp2_buf, max_len);
+	z_shell_history_put(&history, exp2_buf, max_len);
 	test_get(true, true, exp2_buf, max_len);
 	test_get(false, true, NULL, 0); /* only one entry */
 
-	shell_history_put(&history, exp3_buf, max_len);
+	z_shell_history_put(&history, exp3_buf, max_len);
 	test_get(true, true, exp3_buf, max_len);
 	test_get(false, true, NULL, 0); /* only one entry */
 
-	shell_history_purge(&history);
+	z_shell_history_purge(&history);
 }
 
 void test_main(void)


### PR DESCRIPTION
Added a prefix `z_` to functions and macros that should not be used outside the shell module. 