### PR TITLE
DRGN-13107: Verification of NCS flash driver

### DIFF
--- a/tests/drivers/flash/boards/nrf5340_flash_soc.conf
+++ b/tests/drivers/flash/boards/nrf5340_flash_soc.conf
@@ -1,0 +1,4 @@
+# Minimal configuration for testing flash driver
+# on nrf52840dk_nrf52840 board
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -7,3 +7,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     tags: nrf52 soc_flash_nrf
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
+  drivers.flash.soc_flash_nrf:
+    platform_allow: nrf5340dk_nrf5340
+    tags: nrf53 soc_flash_nrf
+    extra_args: OVERLAY_CONFIG=boards/nrf5340_flash_soc.conf


### PR DESCRIPTION
Extend the flash test.
Test should run on both 52 family and 5340 network core.