### PR TITLE
cmake: scripts: supporting gen_relocate_app feature in windows

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -199,7 +199,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i '$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>'
+    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -17,7 +17,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i '$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>'
+    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -395,7 +395,7 @@ def create_dict_wrt_mem():
     if args.input_rel_dict == '':
         sys.exit("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
     for line in args.input_rel_dict.split(';'):
-        mem_region, file_name = line.split(':')
+        mem_region, file_name = line.split(':', 1)
 
         file_name_list = glob.glob(file_name)
         if not file_name_list:


### PR DESCRIPTION
Fixes: #28847

This commit fixes two places that was causing gen_relocate_app to fail
in windows.

gen_relocate_app.py now splits only on first `:` in
`<MEM_REGION>:<file>`.

Windows contains `:` in path, thus only first `:` is valid for splitting
mem region and file path.

Second part of the issue is fixed in CMake where `'` was used for
quoting of command arguments.
This causes a file not found on Windows because the final `'` would be
treated as part of the filename. Similar the first `'` would be treated
as path of the mem region name.

This is fixed by using `"` for quoting, which works correctly on all
platforms.

```
gen_relocate_app.py:403: UserWarning: File: .../kernel/sem.c' Not found
Note the stray `'`                                         ^^^
```

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>