### PR TITLE
sanitycheck: fix json file generation

### DIFF
--- a/scripts/sanity_chk/sanitylib.py
+++ b/scripts/sanity_chk/sanitylib.py
@@ -3502,7 +3502,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                 for i in data["test_suite"]:
                     test_details = i["test_details"]
                     for test_data in test_details:
-                        if not (test_data["status"]) == "failed":
+                        if test_data.get("status") != "failed":
                             new_dict = test_data
                             results_dict["test_details"].append(new_dict)
 


### PR DESCRIPTION
script was failing during a run with -f, the status key was not in the
dictionary and the check would cause an exception. Fix that using
.get().