### PR TITLE
drivers: adc: Introduce the adc_sequence_options::user_data field

### DIFF
--- a/include/drivers/adc.h
+++ b/include/drivers/adc.h
@@ -218,8 +218,15 @@ enum adc_action {
  *
  * @param dev             Pointer to the device structure for the driver
  *                        instance.
- * @param sequence        Pointer to the sequence structure that triggered the
- *                        sampling.
+ * @param sequence        Pointer to the sequence structure that triggered
+ *                        the sampling. This parameter points to a copy of
+ *                        the structure that was supplied to the call that
+ *                        started the sampling sequence, thus it cannot be
+ *                        used with the CONTAINER_OF() macro to retrieve
+ *                        some other data associated with the sequence.
+ *                        Instead, the adc_sequence_options::user_data field
+ *                        should be used for such purpose.
+ *
  * @param sampling_index  Index (0-65535) of the sampling done.
  *
  * @returns Action to be performed by the driver. See @ref adc_action.
@@ -248,6 +255,12 @@ struct adc_sequence_options {
 	 * Optional - set to NULL if it is not needed.
 	 */
 	adc_sequence_callback callback;
+
+	/**
+	 * Pointer to user data. It can be used to associate the sequence
+	 * with any other data that is needed in the callback function.
+	 */
+	void *user_data;
 
 	/**
 	 * Number of extra samplings to perform (the total number of samplings


### PR DESCRIPTION
Introduce the field that can be used to associate a given sampling
sequence with any other data needed in the sampling-done callback
function.
Adjust one ADC API test case that uses a sequence callback so that
it checks if this introduced field is propagated as expected.

Also clarify in the description of the `sequence` parameter of the
callback function that this parameter is not supposed to be supplied
to the `CONTAINER_OF()` macro, to avoid any further confusion in that
regard.

Resolves #30362.