### PR TITLE
boards: arm: Add qspi flash dts node to mimxrt1064_evk

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -96,6 +96,19 @@
 	};
 };
 
+&flexspi {
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
+	is25wp064: is25wp064@0 {
+		compatible = "issi,is25wp064", "jedec,spi-nor";
+		size = <67108864>;
+		label = "IS25WP064";
+		reg = <0>;
+		spi-max-frequency = <133000000>;
+		status = "okay";
+		jedec-id = [9d 70 17];
+	};
+};
+
 arduino_i2c: &lpi2c1 {};
 
 &lcdif {


### PR DESCRIPTION
Copies the QSPI flash device tree node from the mimxrt1060_evk to the
mimxrt1064_evk board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>