### PR TITLE
actions: rename jobs

### DIFF
--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -1,9 +1,11 @@
+name: Conflict Finder
+
 on:
   push:
     branches-ignore:
       - '**'
 jobs:
-  triage:
+  conflict:
     runs-on: ubuntu-latest
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@ on:
   - pull_request_target
 
 jobs:
-  triage:
+  labeler:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v2.1.1


### PR DESCRIPTION
Do not use default 'triage' job names.