### PR TITLE
net: lwm2m: fix buffer length check in lwm2m_engine_set

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1487,7 +1487,7 @@ static int lwm2m_engine_set(char *pathstr, void *value, uint16_t len)
 	}
 
 	/* check length (note: we add 1 to string length for NULL pad) */
-	if (len > res_inst->max_data_len -
+	if (len > max_data_len -
 		(obj_field->data_type == LWM2M_RES_TYPE_STRING ? 1 : 0)) {
 		LOG_ERR("length %u is too long for res instance %d data",
 			len, path.res_id);


### PR DESCRIPTION
Previously, lwm2m_engine set would check against the max_data_len parameter of
the ressource, but didn't take into consideration the (possibly changed)
max_data_len returned by the pre_write callback.

Fixes #30541

Signed-off-by: Henning Fleddermann <henning.fleddermann@grandcentrix.net>