### PR TITLE
kernel: thread: make offload_sem visible for releasing it outside

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -908,7 +908,10 @@ static inline int z_vrfy_k_float_disable(struct k_thread *thread)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_IRQ_OFFLOAD
-static K_SEM_DEFINE(offload_sem, 1, 1);
+/* Make offload_sem visible outside under testing, in order to release
+ * it outside when error happened.
+ */
+K_SEM_DEFINE(offload_sem, 1, 1);
 
 void irq_offload(irq_offload_routine_t routine, const void *parameter)
 {


### PR DESCRIPTION
In order to release irq_offload semaphore outside kernel/thread.c, we make it visible by modifying it non-static under ztest. 
his would be needed such as when call irq_offload() to enter interrupt context and a fatal error happened, then you have to release it in your fatal handler, or the irq_offload will still be locked and no longer be using again.

And what special case will we need this:  for a scenario of some negative test cases.  For example:
1. Mutex cannot be used in interrupt context, so there should be a test case that call k_mutex_lock in interrupt context, 
2. Then it will trigger a assert handler to catch this, and we leverage self-defined post assert handler and call k_thread_abort() or ztest_test_pass() to judge the test case pass.
3. But there is one problem here, the irq_offload semaphore has been taken before irq_offload(), and fatal or assert happened. So before terminated the thread, the resource(offload_sem) shall be released before next test case executing, otherwise, one other test case(or APP) can use offload_load() again, it would be block here.
        
Perhaps another way to achieve this goal  is to add an API interface for release the offload_sem, such as "int release_offload_sem(void)".

I am really not sure what is the better practice for handling this, look forward to your feedback, thanks!   


Signed-off-by: Enjia Mai <enjiax.mai@intel.com>