### PR TITLE
west.yml: trusted-firmware-m: update module to clean up mbed-crypto

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: f3476cc16053f567eb07886db11e32505c25d097
+      revision: 4544ab9fc4d5305ae5de97c73a9356ef0f342f7a
 
   self:
     path: zephyr


### PR DESCRIPTION
Update TF-M module SHA. This picks up the clean-up
of the unnecessary mbed-crypto directories in the
module repository.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>