### PR TITLE
net: openthread: add missing settings deinit function

### DIFF
--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -310,3 +310,8 @@ void otPlatSettingsWipe(otInstance *aInstance)
 
 	(void)ot_setting_delete_subtree(-1, -1);
 }
+
+void otPlatSettingsDeinit(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+}


### PR DESCRIPTION
This commit adds a missing otPlatSettingsDeinit function
to the Zephyr OpenThread platform implementation.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>