### PR TITLE
Bluetooth: HCI: Add option CONFIG_BUF_ACL_DATA_LEN

### DIFF
--- a/include/bluetooth/hci_raw.h
+++ b/include/bluetooth/hci_raw.h
@@ -21,22 +21,18 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_BT_CTLR_TX_BUFFER_SIZE)
-#define BT_L2CAP_MTU (CONFIG_BT_CTLR_TX_BUFFER_SIZE - BT_L2CAP_HDR_SIZE)
-#else
-#define BT_L2CAP_MTU 65 /* 64-byte public key + opcode */
-#endif /* CONFIG_BT_CTLR */
+#define _BT_ACL_BUF_SIZE(len) (BT_BUF_RESERVE + \
+				BT_HCI_ACL_HDR_SIZE + \
+				(len))
 
 /** Data size needed for ACL buffers */
-#define BT_BUF_ACL_SIZE BT_L2CAP_BUF_SIZE(BT_L2CAP_MTU)
+#define BT_BUF_ACL_SIZE _BT_ACL_BUF_SIZE(CONFIG_BT_HCI_ACL_DATA_SIZE)
 
 #if defined(CONFIG_BT_CTLR_TX_BUFFERS)
 #define BT_HCI_ACL_COUNT CONFIG_BT_CTLR_TX_BUFFERS
 #else
 #define BT_HCI_ACL_COUNT 6
 #endif
-
-#define BT_BUF_TX_SIZE MAX(BT_BUF_RX_SIZE, BT_BUF_ACL_SIZE)
 
 /** @brief Send packet to the Bluetooth controller
  *

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -126,6 +126,16 @@ config BT_HCI_RESERVE
 	  Headroom that the driver needs for sending and receiving buffers. Add a
 	  new 'default' entry for each new driver.
 
+config BT_HCI_ACL_DATA_SIZE
+	int
+	prompt "ACL data buffer size" if !BT_CTLR
+	depends on BT_HCI_RAW
+	range 27 251
+	default BT_CTLR_DATA_LENGTH_MAX if BT_CTLR
+	default 27
+	help
+	  Maximum ACL data payload in HCI packets, excluding HCI header.
+
 config BT_RECV_IS_RX_THREAD
 	# Hidden option set by the HCI driver to indicate that there's
 	# no need for the host to have its own RX thread.


### PR DESCRIPTION
Add the option CONFIG_BT_BUF_ACL_DATA_LEN which allows the user
to configure the max HCI ACL payload. This is needed for platorms
where the BLE LL, HCI uart and host run on three different cores.

Fixes: #30441

Signed-off-by: Johan Stridkvist <johan.stridkvist@nordicsemi.no>