### PR TITLE
Bluetooth: controller: Fix CUI/CPR lock during TO

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1700,6 +1700,11 @@ static void conn_cleanup(struct ll_conn *conn, uint8_t reason)
 	struct node_rx_pdu *rx;
 	uint32_t ticker_status;
 
+	/* reset mutex */
+	if (conn == conn_upd_curr) {
+		ull_conn_upd_curr_reset();
+	}
+
 	/* Only termination structure is populated here in ULL context
 	 * but the actual enqueue happens in the LLL context in
 	 * tx_lll_flush. The reason being to avoid passing the reason


### PR DESCRIPTION
Release the CUI/CPR lock if the connection owning the lock is terminated.

This can happen if a device performing a CUI/CPR procedure gets a LSTO before the procedeure completes or the procedure itself TO.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>