### PR TITLE
net: openthread: Add option to enable software CSMA backoff

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -279,6 +279,13 @@ config OPENTHREAD_MAC_SOFTWARE_RETRANSMIT_ENABLE
 	help
 	  Set y if the radio supports tx retry logic with collision avoidance (CSMA)
 
+config OPENTHREAD_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
+	bool "Enable software CSMA backoff logic"
+	default y
+	help
+	  Set y to enable software CSMA backoff. The option can be disabled if
+	  the radio has hardware support for this feature (IEEE802154_HW_CSMA).
+
 config OPENTHREAD_PLATFORM_USEC_TIMER_ENABLE
 	bool "Enable microsecond backoff timer implemented in platform"
 	help

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -82,6 +82,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
+ *
+ * Define to 1 if you want to enable software CSMA-CA backoff logic.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
  *
  * Define to 1 if you want to enable microsecond backoff timer implemented


### PR DESCRIPTION
Add option to enable software CSMA backoff in the OpenThread MAC layer.

This allows to run CSMA procedure correctly in radios that do not
support hardware CSMA backoff, and use them as RCP, where this feature
is required.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>