### PR TITLE
kernel: Move memory domains init at PRE_KERNEL_2 level

### DIFF
--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -318,5 +318,5 @@ static int init_mem_domain_module(const struct device *arg)
 	return 0;
 }
 
-SYS_INIT(init_mem_domain_module, PRE_KERNEL_1,
+SYS_INIT(init_mem_domain_module, PRE_KERNEL_2,
 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
The vast majority of the drivers are initialized at PRE_KERNEL_1 level.

If the driver is using the device MMIO APIs to map its MMIO regions this means that the we have to wait until the end of the PRE_KERNEL_1 init level to have all the MMIO memory regions mapped in the page tables used at init.

At the same time also the memory module is initialized at PRE_KERNEL_1.

This could be a problem if the initialization of the default memory domain relies on having already a complete set of page tables with all the MMIO regions already mapped.

To avoid this problem move the memory module init at PRE_KERNEL_2.