### PR TITLE
tests: mem_protect: exclude nRF5340 DK from the gap filling test

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -3,7 +3,15 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
     tags: kernel security userspace ignore_faults
-  kernel.memory_protection.gap_filling:
+  kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
+    arch_allow: arc
+    extra_args: CONFIG_MPU_GAP_FILLING=y
+    tags: kernel security userspace ignore_faults
+  kernel.memory_protection.gap_filling.arm:
+    filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
+    arch_allow: arm
+    platform_allow: efr32_radio_brd4180a mps2_an521 nrf5340pdk_nrf5340_cpuapp
+     nrf5340pdk_nrf5340_cpunet nrf9160dk_nrf9160
     extra_args: CONFIG_MPU_GAP_FILLING=y
     tags: kernel security userspace ignore_faults


### PR DESCRIPTION
Modify test .yaml file, to allow the .gap_filling test
variant to execute only on cortex-m33 platforms with
sufficient number of MPU regions. Copy pasting the
configuration from mem_protect/userspace test.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #30253