### PR TITLE
drivers: adc: Convert drivers to new DT device macros

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1129,12 +1129,12 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
 		.resolution = res, \
 		.channels = ch, \
 	}; \
-	DEVICE_AND_API_INIT(lmp##t##_##n, \
-			    DT_LABEL(DT_INST_LMP90XXX(n, t)), \
-			    &lmp90xxx_init, &lmp##t##_data_##n, \
-			    &lmp##t##_config_##n, POST_KERNEL, \
-			    CONFIG_ADC_LMP90XXX_INIT_PRIORITY, \
-			    &lmp90xxx_adc_api)
+	DEVICE_DT_DEFINE(DT_INST_LMP90XXX(n, t), \
+			 &lmp90xxx_init, device_pm_control_nop, \
+			 &lmp##t##_data_##n, \
+			 &lmp##t##_config_##n, POST_KERNEL, \
+			 CONFIG_ADC_LMP90XXX_INIT_PRIORITY, \
+			 &lmp90xxx_adc_api)
 
 /*
  * LMP90077: 16 bit, 2 diff/4 se (4 channels), 0 currents

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -52,7 +52,7 @@ struct adc_xec_regs {
 	((struct adc_xec_regs *)(DT_INST_REG_ADDR(0)))
 
 
-DEVICE_DECLARE(adc_xec);
+DEVICE_DT_INST_DECLARE(0);
 
 static void adc_context_start_sampling(struct adc_context *ctx)
 {
@@ -296,7 +296,7 @@ static int adc_xec_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    adc_xec_isr, DEVICE_GET(adc_xec), 0);
+		    adc_xec_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	adc_context_unlock_unconditionally(&data->ctx);
@@ -310,7 +310,7 @@ static struct adc_xec_data adc_xec_dev_data_0 = {
 	ADC_CONTEXT_INIT_SYNC(adc_xec_dev_data_0, ctx),
 };
 
-DEVICE_AND_API_INIT(adc_xec, DT_INST_LABEL(0),
-		    adc_xec_init, &adc_xec_dev_data_0, NULL,
+DEVICE_DT_INST_DEFINE(0, adc_xec_init, device_pm_control_nop,
+		    &adc_xec_dev_data_0, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_xec_api);

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -356,12 +356,12 @@ static const struct adc_driver_api mcp320x_adc_api = {
 		}, \
 		.channels = ch, \
 	}; \
-	DEVICE_AND_API_INIT(mcp##t##_##n, \
-			    DT_LABEL(INST_DT_MCP320X(n, t)), \
-			    &mcp320x_init, &mcp##t##_data_##n, \
-			    &mcp##t##_config_##n, POST_KERNEL, \
-			    CONFIG_ADC_MCP320X_INIT_PRIORITY, \
-			    &mcp320x_adc_api)
+	DEVICE_DT_DEFINE(INST_DT_MCP320X(n, t), \
+			 &mcp320x_init, device_pm_control_nop, \
+			 &mcp##t##_data_##n, \
+			 &mcp##t##_config_##n, POST_KERNEL, \
+			 CONFIG_ADC_MCP320X_INIT_PRIORITY, \
+			 &mcp320x_adc_api)
 
 /*
  * MCP3204: 4 channels

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -283,8 +283,8 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 		ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_adc12_##n, DT_INST_LABEL(n),		\
-			    &mcux_adc12_init, &mcux_adc12_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &mcux_adc12_init,			\
+			    device_pm_control_nop, &mcux_adc12_data_##n,\
 			    &mcux_adc12_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &mcux_adc12_driver_api);			\
@@ -293,7 +293,7 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority), mcux_adc12_isr,	\
-			    DEVICE_GET(mcux_adc12_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -293,8 +293,8 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 		ADC_CONTEXT_INIT_SYNC(mcux_adc16_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_adc16_##n, DT_INST_LABEL(n),		\
-			    &mcux_adc16_init, &mcux_adc16_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &mcux_adc16_init,			\
+			    device_pm_control_nop, &mcux_adc16_data_##n,\
 			    &mcux_adc16_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &mcux_adc16_driver_api);			\
@@ -303,7 +303,7 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    mcux_adc16_isr,				\
-			    DEVICE_GET(mcux_adc16_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -393,8 +393,8 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 		ADC_CONTEXT_INIT_SYNC(mcux_lpadc_data_##n, ctx),	\
 	};														\
 										\
-	DEVICE_AND_API_INIT(mcux_lpadc_##n, DT_INST_LABEL(n),	\
-		&mcux_lpadc_init, &mcux_lpadc_data_##n,				\
+	DEVICE_DT_INST_DEFINE(n,						\
+		&mcux_lpadc_init, device_pm_control_nop, &mcux_lpadc_data_##n,	\
 		&mcux_lpadc_config_##n, POST_KERNEL,				\
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					\
 		&mcux_lpadc_driver_api);							\
@@ -403,7 +403,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 	{									\
 		IRQ_CONNECT(DT_INST_IRQN(n),					\
 			DT_INST_IRQ(n, priority), mcux_lpadc_isr,	\
-			DEVICE_GET(mcux_lpadc_##n), 0);				\
+			DEVICE_DT_INST_GET(n), 0);				\
 										\
 		irq_enable(DT_INST_IRQN(n));					\
 	}

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -321,8 +321,8 @@ static struct adc_npcx_data adc_npcx_data_0 = {
 	ADC_CONTEXT_INIT_SYNC(adc_npcx_data_0, ctx),
 };
 
-DEVICE_AND_API_INIT(adc_npcx, DT_INST_LABEL(0),
-		    adc_npcx_init,
+DEVICE_DT_INST_DEFINE(0,
+		    adc_npcx_init, device_pm_control_nop,
 		    &adc_npcx_data_0, &adc_npcx_cfg_0,
 		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -373,7 +373,7 @@ static int adc_npcx_init(const struct device *dev)
 
 	/* Configure ADC interrupt and enable it */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), adc_npcx_isr,
-			    DEVICE_GET(adc_npcx), 0);
+			    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	/* Initialize mutex of ADC channels */

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -239,11 +239,11 @@ static int adc_nrfx_read_async(const struct device *dev,
 }
 #endif /* CONFIG_ADC_ASYNC */
 
-DEVICE_DECLARE(adc_0);
+DEVICE_DT_INST_DECLARE(0);
 
 static void event_handler(const nrfx_adc_evt_t *p_event)
 {
-	const struct device *dev = DEVICE_GET(adc_0);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 
 	if (p_event->type == NRFX_ADC_EVT_DONE) {
 		adc_context_on_sampling_done(&m_data.ctx, dev);
@@ -291,8 +291,8 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 #define ADC_INIT(inst)							\
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
-	DEVICE_AND_API_INIT(adc_0, DT_INST_LABEL(0),			\
-			    init_adc, NULL, NULL,			\
+	DEVICE_DT_INST_DEFINE(0,					\
+			    init_adc, device_pm_control_nop, NULL, NULL,\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &adc_nrfx_driver_api);

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -390,7 +390,7 @@ static void saadc_irq_handler(const struct device *dev)
 	}
 }
 
-DEVICE_DECLARE(adc_0);
+DEVICE_DT_INST_DECLARE(0);
 
 static int init_saadc(const struct device *dev)
 {
@@ -401,7 +401,7 @@ static int init_saadc(const struct device *dev)
 	NRFX_IRQ_ENABLE(DT_INST_IRQN(0));
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
-		    saadc_irq_handler, DEVICE_GET(adc_0), 0);
+		    saadc_irq_handler, DEVICE_DT_INST_GET(0), 0);
 
 	adc_context_unlock_unconditionally(&m_data.ctx);
 
@@ -429,9 +429,9 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 #define SAADC_INIT(inst)						\
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
-	DEVICE_AND_API_INIT(adc_0,					\
-			    DT_INST_LABEL(0),				\
+	DEVICE_DT_INST_DEFINE(0,					\
 			    init_saadc,					\
+			    device_pm_control_nop,			\
 			    NULL,					\
 			    NULL,					\
 			    POST_KERNEL,				\

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -602,8 +602,8 @@ do {									\
 		ADC_CONTEXT_INIT_LOCK(adc_sam_data_##n, ctx),		\
 		ADC_CONTEXT_INIT_SYNC(adc_sam_data_##n, ctx),		\
 	};								\
-	DEVICE_AND_API_INIT(adc0_sam_##n, DT_INST_LABEL(n),		\
-			    adc_sam0_init, &adc_sam_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, adc_sam0_init, device_pm_control_nop,	\
+			    &adc_sam_data_##n,				\
 			    &adc_sam_cfg_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &adc_sam0_api);				\
@@ -612,7 +612,7 @@ do {									\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
 			    adc_sam0_isr,				\
-			    DEVICE_GET(adc0_sam_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 		ADC_SAM0_CONFIGURE(n);					\
 	}

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -365,8 +365,8 @@ static void adc_sam_isr(const struct device *dev)
 		ADC_CONTEXT_INIT_SYNC(adc##n##_sam_data, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(adc##n##_sam, DT_INST_LABEL(n),		\
-			    adc_sam_init, &adc##n##_sam_data,		\
+	DEVICE_DT_INST_DEFINE(n, adc_sam_init, device_pm_control_nop,	\
+			    &adc##n##_sam_data,				\
 			    &adc##n##_sam_cfg, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &adc_sam_api);				\
@@ -375,7 +375,7 @@ static void adc_sam_isr(const struct device *dev)
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    adc_sam_isr,				\
-			    DEVICE_GET(adc##n##_sam), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -740,8 +740,8 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 	ADC_CONTEXT_INIT_SYNC(adc_stm32_data_##index, ctx),		\
 };									\
 									\
-DEVICE_AND_API_INIT(adc_##index, DT_INST_LABEL(index),			\
-		    &adc_stm32_init,					\
+DEVICE_DT_INST_DEFINE(index,						\
+		    &adc_stm32_init, device_pm_control_nop,		\
 		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &api_stm32_driver_api);				\
@@ -750,7 +750,7 @@ static void adc_stm32_cfg_func_##index(void)				\
 {									\
 	IRQ_CONNECT(DT_INST_IRQN(index),				\
 		    DT_INST_IRQ(index, priority),			\
-		    adc_stm32_isr, DEVICE_GET(adc_##index), 0);		\
+		    adc_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
 	irq_enable(DT_INST_IRQN(index));				\
 }
 


### PR DESCRIPTION
Convert adc drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>