### PR TITLE
drivers: spi: Convert drivers to new DT device macros

### DIFF
--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -330,7 +330,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #endif
 
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
-	DEVICE_DEFINE(spi_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		    \
+	DEVICE_DT_DEFINE(n,						    \
 		spi_cc13xx_cc26xx_init_##n,				    \
 		spi_cc13xx_cc26xx_pm_control,				    \
 		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -565,8 +565,8 @@ const struct spi_dw_config spi_dw_config_0 = {
 	.op_modes = CONFIG_SPI_0_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_0, DT_INST_LABEL(0),
-		    spi_dw_init, &spi_dw_data_port_0, &spi_dw_config_0,
+DEVICE_DT_INST_DEFINE(0, spi_dw_init, device_pm_control_nop,
+		    &spi_dw_data_port_0, &spi_dw_config_0,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -580,21 +580,21 @@ void spi_config_0_irq(void)
 #endif
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
+		    spi_dw_isr, DEVICE_DT_INST_GET(0),
 		    INST_0_IRQ_FLAGS);
 	irq_enable(DT_INST_IRQN(0));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx_avail, irq),
 		    DT_INST_IRQ_BY_NAME(0, rx_avail_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
+		    spi_dw_isr, DEVICE_DT_INST_GET(0),
 		    DT_INST_IRQ_BY_NAME(0, rx_avail, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx_req, irq),
 		    DT_INST_IRQ_BY_NAME(0, tx_req_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
+		    spi_dw_isr, DEVICE_DT_INST_GET(0),
 		    DT_INST_IRQ_BY_NAME(0, tx_req, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, err_int, irq),
 		    DT_INST_IRQ_BY_NAME(0, err_int_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_0),
+		    spi_dw_isr, DEVICE_DT_INST_GET(0),
 		    DT_INST_IRQ_BY_NAME(0, err_int, flags));
 
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rx_avail, irq));
@@ -631,8 +631,8 @@ static const struct spi_dw_config spi_dw_config_1 = {
 	.op_modes = CONFIG_SPI_1_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_1, DT_INST_LABEL(1),
-		    spi_dw_init, &spi_dw_data_port_1, &spi_dw_config_1,
+DEVICE_DT_INST_DEFINE(1, spi_dw_init, device_pm_control_nop,
+		    &spi_dw_data_port_1, &spi_dw_config_1,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -646,21 +646,21 @@ void spi_config_1_irq(void)
 #endif
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
+		    spi_dw_isr, DEVICE_DT_INST_GET(1),
 		    INST_1_IRQ_FLAGS);
 	irq_enable(DT_INST_IRQN(1));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx_avail, irq),
 		    DT_INST_IRQ_BY_NAME(1, rx_avail_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
+		    spi_dw_isr, DEVICE_DT_INST_GET(1),
 		    DT_INST_IRQ_BY_NAME(1, rx_avail, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx_req, irq),
 		    DT_INST_IRQ_BY_NAME(1, tx_req_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
+		    spi_dw_isr, DEVICE_DT_INST_GET(1),
 		    DT_INST_IRQ_BY_NAME(1, tx_req, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, err_int, irq),
 		    DT_INST_IRQ_BY_NAME(1, err_int_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_1),
+		    spi_dw_isr, DEVICE_DT_INST_GET(1),
 		    DT_INST_IRQ_BY_NAME(1, err_int, flags));
 
 	irq_enable(DT_INST_IRQ_BY_NAME(1, rx_avail, irq));
@@ -697,8 +697,8 @@ static const struct spi_dw_config spi_dw_config_2 = {
 	.op_modes = CONFIG_SPI_2_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_2, DT_INST_LABEL(2),
-		    spi_dw_init, &spi_dw_data_port_2, &spi_dw_config_2,
+DEVICE_DT_INST_DEFINE(2, spi_dw_init, device_pm_control_nop,
+		    &spi_dw_data_port_2, &spi_dw_config_2,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -712,21 +712,21 @@ void spi_config_2_irq(void)
 #endif
 	IRQ_CONNECT(DT_INST_IRQN(2),
 		    DT_INST_IRQ(2, priority),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
+		    spi_dw_isr, DEVICE_DT_INST_GET(2),
 		    INST_2_IRQ_FLAGS);
 	irq_enable(DT_INST_IRQN(2));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, rx_avail, irq),
 		    DT_INST_IRQ_BY_NAME(2, rx_avail_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
+		    spi_dw_isr, DEVICE_DT_INST_GET(2),
 		    DT_INST_IRQ_BY_NAME(2, rx_avail, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, tx_req, irq),
 		    DT_INST_IRQ_BY_NAME(2, tx_req_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
+		    spi_dw_isr, DEVICE_DT_INST_GET(2),
 		    DT_INST_IRQ_BY_NAME(2, tx_req, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, err_int, irq),
 		    DT_INST_IRQ_BY_NAME(2, err_int_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_2),
+		    spi_dw_isr, DEVICE_DT_INST_GET(2),
 		    DT_INST_IRQ_BY_NAME(2, err_int, flags));
 
 	irq_enable(DT_INST_IRQ_BY_NAME(2, rx_avail, irq));
@@ -763,8 +763,8 @@ static const struct spi_dw_config spi_dw_config_3 = {
 	.op_modes = CONFIG_SPI_3_OP_MODES
 };
 
-DEVICE_AND_API_INIT(spi_dw_port_3, DT_INST_LABEL(3),
-		    spi_dw_init, &spi_dw_data_port_3, &spi_dw_config_3,
+DEVICE_DT_INST_DEFINE(3, spi_dw_init, device_pm_control_nop,
+		    &spi_dw_data_port_3, &spi_dw_config_3,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
 
@@ -778,21 +778,21 @@ void spi_config_3_irq(void)
 #endif
 	IRQ_CONNECT(DT_INST_IRQN(3),
 		    DT_INST_IRQ(3, priority),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
+		    spi_dw_isr, DEVICE_DT_INST_GET(3),
 		    INST_3_IRQ_FLAGS);
 	irq_enable(DT_INST_IRQN(3));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, rx_avail, irq),
 		    DT_INST_IRQ_BY_NAME(3, rx_avail_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
+		    spi_dw_isr, DEVICE_DT_INST_GET(3),
 		    DT_INST_IRQ_BY_NAME(3, rx_avail, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, tx_req, irq),
 		    DT_INST_IRQ_BY_NAME(3, tx_req_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
+		    spi_dw_isr, DEVICE_DT_INST_GET(3),
 		    DT_INST_IRQ_BY_NAME(3, tx_req, flags));
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, err_int, irq),
 		    DT_INST_IRQ_BY_NAME(3, err_int_pri, irq),
-		    spi_dw_isr, DEVICE_GET(spi_dw_port_3),
+		    spi_dw_isr, DEVICE_DT_INST_GET(3),
 		    DT_INST_IRQ_BY_NAME(3, err_int, flags));
 
 	irq_enable(DT_INST_IRQ_BY_NAME(3, rx_avail, irq));

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -130,9 +130,9 @@ static struct spi_driver_api spi_emul_api = {
 		.num_children = ARRAY_SIZE(emuls_##n), \
 	}; \
 	static struct spi_emul_data spi_emul_data_##n; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			    DT_INST_LABEL(n), \
+	DEVICE_DT_INST_DEFINE(n, \
 			    spi_emul_init, \
+			    device_pm_control_nop, \
 			    &spi_emul_data_##n, \
 			    &spi_emul_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -309,9 +309,9 @@ static struct spi_driver_api spi_gecko_api = {
 	    .loc_tx = DT_INST_PROP_BY_IDX(n, location_tx, 0), \
 	    .loc_clk = DT_INST_PROP_BY_IDX(n, location_clk, 0), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
+	DEVICE_DT_INST_DEFINE(n, \
 			spi_gecko_init, \
+			device_pm_control_nop, \
 			&spi_gecko_data_##n, \
 			&spi_gecko_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -175,9 +175,9 @@ static struct spi_driver_api spi_litespi_api = {
 	static struct spi_litespi_cfg spi_litespi_cfg_##n = { \
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
+	DEVICE_DT_INST_DEFINE(n, \
 			spi_litespi_init, \
+			device_pm_control_nop, \
 			&spi_litespi_data_##n, \
 			&spi_litespi_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -856,7 +856,7 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 {									\
 	IRQ_CONNECT(DT_INST_IRQN(id),					\
 		    DT_INST_IRQ(id, priority),				\
-		    spi_stm32_isr, DEVICE_GET(spi_stm32_##id), 0);	\
+		    spi_stm32_isr, DEVICE_DT_INST_GET(id), 0);		\
 	irq_enable(DT_INST_IRQN(id));					\
 }
 #else
@@ -940,8 +940,7 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 	SPI_DMA_STATUS_SEM(id)						\
 };									\
 									\
-DEVICE_AND_API_INIT(spi_stm32_##id, DT_INST_LABEL(id),			\
-		    &spi_stm32_init,					\
+DEVICE_DT_INST_DEFINE(id, &spi_stm32_init, device_pm_control_nop,	\
 		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
 		    &api_funcs);					\

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -310,9 +310,9 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
 	};								\
-	DEVICE_AND_API_INIT(spi_mcux_##id,				\
-			    DT_INST_LABEL(id),				\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    &spi_mcux_init,				\
+			    device_pm_control_nop,			\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\
@@ -322,7 +322,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(id),				\
 			    DT_INST_IRQ(id, priority),			\
-			    spi_mcux_isr, DEVICE_GET(spi_mcux_##id),	\
+			    spi_mcux_isr, DEVICE_DT_INST_GET(id),	\
 			    0);						\
 		irq_enable(DT_INST_IRQN(id));				\
 	}

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -734,7 +734,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 {								\
 	IRQ_CONNECT(DT_INST_IRQN(id),				\
 			DT_INST_IRQ(id, priority),			\
-			spi_mcux_isr, DEVICE_GET(spi_mcux_##id),	\
+			spi_mcux_isr, DEVICE_DT_INST_GET(id),	\
 			0);					\
 	irq_enable(DT_INST_IRQN(id));				\
 }
@@ -783,9 +783,9 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
 		SPI_DMA_CHANNELS(id)		\
 	};								\
-	DEVICE_AND_API_INIT(spi_mcux_##id,				\
-			    DT_INST_LABEL(id),				\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    &spi_mcux_init,				\
+			    device_pm_control_nop,			\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -309,8 +309,8 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_mcux_##n, DT_INST_LABEL(n),		\
-			    &spi_mcux_init, &spi_mcux_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, device_pm_control_nop,	\
+			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &spi_mcux_driver_api);			\
@@ -318,7 +318,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static void spi_mcux_config_func_##n(const struct device *dev)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
-			    spi_mcux_isr, DEVICE_GET(spi_mcux_##n), 0);	\
+			    spi_mcux_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -287,9 +287,9 @@ static int init_spis(const struct device *dev,
 		.spis = NRFX_SPIS_INSTANCE(idx),			       \
 		.max_buf_len = (1 << SPIS##idx##_EASYDMA_MAXCNT_SIZE) - 1,     \
 	};								       \
-	DEVICE_AND_API_INIT(spi_##idx,					       \
-			    DT_LABEL(SPIS(idx)),			       \
+	DEVICE_DT_INST_DEFINE(idx,					       \
 			    spi_##idx##_init,				       \
+			    device_pm_control_nop,			       \
 			    &spi_##idx##_data,				       \
 			    &spi_##idx##z_config,			       \
 			    POST_KERNEL,				       \

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -214,9 +214,9 @@ int spi_oc_simple_init(const struct device *dev)
 		SPI_CONTEXT_INIT_SYNC(spi_oc_simple_data_##inst, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_oc_simple_##inst,			\
-			    DT_INST_LABEL(inst),			\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    spi_oc_simple_init,				\
+			    device_pm_control_nop,			\
 			    &spi_oc_simple_data_##inst,			\
 			    &spi_oc_simple_cfg_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -301,8 +301,8 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(spi_mcux_##n, DT_INST_LABEL(n),		\
-			    &spi_mcux_init, &spi_mcux_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, device_pm_control_nop,	\
+			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n,			\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -312,7 +312,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    0,						\
-			    spi_mcux_isr, DEVICE_GET(spi_mcux_##n), 0);	\
+			    spi_mcux_isr, DEVICE_DT_INST_GET(n), 0);	\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -467,9 +467,8 @@ static const struct spi_driver_api spi_sam_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_AND_API_INIT(spi_sam_##n,				\
-			    DT_INST_LABEL(n),				\
-			    &spi_sam_init, &spi_sam_dev_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_sam_init, device_pm_control_nop,	\
+			    &spi_sam_dev_data_##n,			\
 			    &spi_sam_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -770,9 +770,8 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_AND_API_INIT(spi_sam0_##n,				\
-			    DT_INST_LABEL(n),				\
-			    &spi_sam0_init, &spi_sam0_dev_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, device_pm_control_nop,	\
+			    &spi_sam0_dev_data_##n,			\
 			    &spi_sam0_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &spi_sam0_driver_api);

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -248,9 +248,9 @@ static struct spi_driver_api spi_sifive_api = {
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 		.f_sys = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	DEVICE_AND_API_INIT(spi_##n, \
-			DT_INST_LABEL(n), \
+	DEVICE_DT_INST_DEFINE(n, \
 			spi_sifive_init, \
+			device_pm_control_nop, \
 			&spi_sifive_data_##n, \
 			&spi_sifive_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -674,9 +674,8 @@ static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 	SPI_CONTEXT_INIT_SYNC(spi_qmspi_0_dev_data, ctx)
 };
 
-DEVICE_AND_API_INIT(spi_xec_qmspi_0,
-		    DT_INST_LABEL(0),
-		    &qmspi_init, &spi_qmspi_0_dev_data,
+DEVICE_DT_INST_DEFINE(0,
+		    &qmspi_init, device_pm_control_nop, &spi_qmspi_0_dev_data,
 		    &spi_qmspi_0_config, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_qmspi_driver_api);
 

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -477,8 +477,9 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(xlnx_quadspi_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(xlnx_quadspi_##n, DT_INST_LABEL(n),		\
-			    &xlnx_quadspi_init, &xlnx_quadspi_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &xlnx_quadspi_init,			\
+			    device_pm_control_nop,			\
+			    &xlnx_quadspi_data_##n,			\
 			    &xlnx_quadspi_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &xlnx_quadspi_driver_api);			\
@@ -487,7 +488,7 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    xlnx_quadspi_isr,				\
-			    DEVICE_GET(xlnx_quadspi_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 


### PR DESCRIPTION
Convert spi drivers from:

DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
DEVICE_GET -> DEVICE_DT_INST_GET

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>