### PR TITLE
Bluetooth: Mesh: LPN regressions

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -354,6 +354,7 @@ static void req_sent(uint16_t duration, int err, void *user_data)
 		k_delayed_work_submit(&lpn->timer,
 				      K_MSEC(LPN_RECV_DELAY - SCAN_LATENCY));
 	} else {
+		lpn_set_state(BT_MESH_LPN_WAIT_UPDATE);
 		k_delayed_work_submit(&lpn->timer,
 				      K_MSEC(LPN_RECV_DELAY + duration +
 					     lpn->recv_win));

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -592,7 +592,7 @@ bool bt_mesh_net_cred_find(struct bt_mesh_net_rx *rx, struct net_buf_simple *in,
 	BT_DBG("");
 
 #if defined(CONFIG_BT_MESH_LOW_POWER)
-	if (bt_mesh_lpn_established()) {
+	if (bt_mesh_lpn_waiting_update()) {
 		rx->sub = bt_mesh.lpn.sub;
 
 		for (j = 0; j < ARRAY_SIZE(bt_mesh.lpn.cred); j++) {


### PR DESCRIPTION
Fixes three LPN regressions, where two were introduced in the credentials fix, and the last appears to have been lurking for a long time.