### PR TITLE
Bluetooth: Mesh: Pull all function calls out of the K_MSEC macro

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -568,9 +568,11 @@ static void enqueue_sub_cfm(struct bt_mesh_friend *frnd, uint8_t xact)
 
 static void friend_recv_delay(struct bt_mesh_friend *frnd)
 {
+	int32_t delay = recv_delay(frnd);
+
 	frnd->pending_req = 1U;
-	k_delayed_work_submit(&frnd->timer, K_MSEC(recv_delay(frnd)));
-	BT_DBG("Waiting RecvDelay of %d ms", recv_delay(frnd));
+	k_delayed_work_submit(&frnd->timer, K_MSEC(delay));
+	BT_DBG("Waiting RecvDelay of %d ms", delay);
 }
 
 int bt_mesh_friend_sub_add(struct bt_mesh_net_rx *rx,
@@ -916,6 +918,7 @@ int bt_mesh_friend_req(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 	struct bt_mesh_ctl_friend_req *msg = (void *)buf->data;
 	struct bt_mesh_friend *frnd = NULL;
 	uint32_t poll_to;
+	int32_t delay;
 	int i, err;
 
 	if (rx->net_if == BT_MESH_NET_IF_LOCAL) {
@@ -1005,9 +1008,8 @@ init_friend:
 		clear_procedure_start(frnd);
 	}
 
-	k_delayed_work_submit(&frnd->timer,
-			      K_MSEC(offer_delay(frnd, rx->ctx.recv_rssi,
-						 msg->criteria)));
+	delay = offer_delay(frnd, rx->ctx.recv_rssi, msg->criteria);
+	k_delayed_work_submit(&frnd->timer, K_MSEC(delay));
 
 	enqueue_offer(frnd, rx->ctx.recv_rssi);
 

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -936,7 +936,9 @@ int bt_mesh_lpn_friend_sub_cfm(struct bt_mesh_net_rx *rx,
 	}
 
 	if (!lpn->sent_req) {
-		k_delayed_work_submit(&lpn->timer, K_MSEC(poll_timeout(lpn)));
+		int32_t timeout = poll_timeout(lpn);
+
+		k_delayed_work_submit(&lpn->timer, K_MSEC(timeout));
 	}
 
 	return 0;
@@ -1025,7 +1027,9 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 	}
 
 	if (!lpn->sent_req) {
-		k_delayed_work_submit(&lpn->timer, K_MSEC(poll_timeout(lpn)));
+		int32_t timeout = poll_timeout(lpn);
+
+		k_delayed_work_submit(&lpn->timer, K_MSEC(timeout));
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1110,6 +1110,7 @@ static void seg_rx_reset(struct seg_rx *rx, bool full_reset)
 static void seg_ack(struct k_work *work)
 {
 	struct seg_rx *rx = CONTAINER_OF(work, struct seg_rx, ack);
+	int32_t timeout;
 
 	BT_DBG("rx %p", rx);
 
@@ -1127,7 +1128,8 @@ static void seg_ack(struct k_work *work)
 	send_ack(rx->sub, rx->dst, rx->src, rx->ttl, &rx->seq_auth,
 		 rx->block, rx->obo);
 
-	k_delayed_work_submit(&rx->ack, K_MSEC(ack_timeout(rx)));
+	timeout = ack_timeout(rx);
+	k_delayed_work_submit(&rx->ack, K_MSEC(timeout));
 }
 
 static inline bool sdu_len_is_ok(bool ctl, uint8_t seg_n)
@@ -1409,7 +1411,9 @@ found_rx:
 
 	if (!k_delayed_work_remaining_get(&rx->ack) &&
 	    !bt_mesh_lpn_established()) {
-		k_delayed_work_submit(&rx->ack, K_MSEC(ack_timeout(rx)));
+		int32_t timeout = ack_timeout(rx);
+
+		k_delayed_work_submit(&rx->ack, K_MSEC(timeout));
 	}
 
 	/* Allocated segment here */


### PR DESCRIPTION
The K_MSEC macro evaluates its argument twice, which causes double
evaluation of some function calls in the mesh stack.

This removes all instances of function calls inside K_MSEC macros in the
mesh stack.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>