### PR TITLE
drivers: watchdog: Convert drivers to new DT device macros

### DIFF
--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -199,8 +199,9 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdog_cmsdk_apb, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    wdog_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdog_cmsdk_apb_api);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -225,7 +225,7 @@ static const struct wdt_driver_api wdt_api = {
 };
 
 #define ESP32_WDT_INIT(idx)										   \
-	DEVICE_DECLARE(wdt_esp32_##idx);								   \
+	DEVICE_DT_INST_DECLARE(idx);									   \
 	static void wdt_esp32_connect_irq_func##idx(void)						   \
 	{												   \
 		esp32_rom_intr_matrix_set(0, ETS_TG##idx##_WDT_LEVEL_INTR_SOURCE,			   \
@@ -233,7 +233,7 @@ static const struct wdt_driver_api wdt_api = {
 		IRQ_CONNECT(CONFIG_WDT##idx##_ESP32_IRQ,						   \
 			    4,										   \
 			    wdt_esp32_isr,								   \
-			    DEVICE_GET(wdt_esp32_##idx),						   \
+			    DEVICE_DT_INST_GET(idx),							   \
 			    0);										   \
 	}												   \
 													   \
@@ -251,8 +251,9 @@ static const struct wdt_driver_api wdt_api = {
 		.connect_irq = wdt_esp32_connect_irq_func##idx						   \
 	};												   \
 													   \
-	DEVICE_AND_API_INIT(wdt_esp32_##idx, DT_INST_LABEL(idx),		   \
+	DEVICE_DT_INST_DEFINE(idx,									   \
 			    wdt_esp32_init,								   \
+			    device_pm_control_nop,							   \
 			    &wdt##idx##_data,								   \
 			    &wdt_esp32_config##idx,							   \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				   \

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -292,9 +292,9 @@ static const struct wdt_driver_api wdt_gecko_driver_api = {
 	};								\
 	static struct wdt_gecko_data wdt_gecko_data_##index;		\
 									\
-	DEVICE_AND_API_INIT(wdt_##index,				\
-				DT_INST_LABEL(index),\
-				&wdt_gecko_init, &wdt_gecko_data_##index,\
+	DEVICE_DT_INST_DEFINE(index,					\
+				&wdt_gecko_init, device_pm_control_nop,	\
+				&wdt_gecko_data_##index,		\
 				&wdt_gecko_cfg_##index, POST_KERNEL,	\
 				CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 				&wdt_gecko_driver_api);			\
@@ -303,7 +303,7 @@ static const struct wdt_driver_api wdt_gecko_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(index),	\
 			DT_INST_IRQ(index, priority),\
-			wdt_gecko_isr, DEVICE_GET(wdt_##index), 0);	\
+			wdt_gecko_isr, DEVICE_DT_INST_GET(index), 0);	\
 		irq_enable(DT_INST_IRQN(index));	\
 	}
 

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -192,7 +192,7 @@ static struct iwdg_stm32_data iwdg_stm32_dev_data = {
 	.Instance = (IWDG_TypeDef *)DT_INST_REG_ADDR(0)
 };
 
-DEVICE_AND_API_INIT(iwdg_stm32, DT_INST_LABEL(0),
-		    iwdg_stm32_init, &iwdg_stm32_dev_data, NULL,
+DEVICE_DT_INST_DEFINE(0, iwdg_stm32_init, device_pm_control_nop,
+		    &iwdg_stm32_dev_data, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &iwdg_stm32_api);

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -25,7 +25,7 @@ struct wdt_xec_data {
 };
 
 
-DEVICE_DECLARE(wdt_xec);
+DEVICE_DT_INST_DECLARE(0);
 
 static int wdt_xec_setup(const struct device *dev, uint8_t options)
 {
@@ -170,7 +170,7 @@ static int wdt_xec_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    wdt_xec_isr, DEVICE_GET(wdt_xec), 0);
+		    wdt_xec_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	return 0;
@@ -178,7 +178,7 @@ static int wdt_xec_init(const struct device *dev)
 
 static struct wdt_xec_data wdt_xec_dev_data;
 
-DEVICE_AND_API_INIT(wdt_xec, DT_INST_LABEL(0),
-		    wdt_xec_init, &wdt_xec_dev_data, NULL,
+DEVICE_DT_INST_DEFINE(0, wdt_xec_init, device_pm_control_nop,
+		    &wdt_xec_dev_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdt_xec_api);

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -151,8 +151,9 @@ static const struct mcux_wdog_config mcux_wdog_config = {
 
 static struct mcux_wdog_data mcux_wdog_data;
 
-DEVICE_AND_API_INIT(mcux_wdog, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &mcux_wdog_init,
+		    device_pm_control_nop,
 		    &mcux_wdog_data, &mcux_wdog_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog_api);
@@ -161,7 +162,7 @@ static void mcux_wdog_config_func(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_wdog_isr, DEVICE_GET(mcux_wdog), 0);
+		    mcux_wdog_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -175,8 +175,9 @@ static const struct mcux_wdog_config mcux_wdog_config_0 = {
 
 static struct mcux_wdog_data mcux_wdog_data_0;
 
-DEVICE_AND_API_INIT(mcux_wdog_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &mcux_wdog_init,
+		    device_pm_control_nop,
 		    &mcux_wdog_data_0, &mcux_wdog_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog_api);
@@ -185,7 +186,7 @@ static void mcux_wdog_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_wdog_isr, DEVICE_GET(mcux_wdog_0), 0);
+		    mcux_wdog_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -207,8 +207,8 @@ static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 
 static struct mcux_wdog32_data mcux_wdog32_data_0;
 
-DEVICE_AND_API_INIT(mcux_wdog32_0, DT_INST_LABEL(0),
-		    &mcux_wdog32_init, &mcux_wdog32_data_0,
+DEVICE_DT_INST_DEFINE(0, &mcux_wdog32_init,
+		    device_pm_control_nop, &mcux_wdog32_data_0,
 		    &mcux_wdog32_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog32_api);
@@ -217,7 +217,7 @@ static void mcux_wdog32_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_wdog32_isr, DEVICE_GET(mcux_wdog32_0), 0);
+		    mcux_wdog32_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -173,8 +173,8 @@ static const struct mcux_wwdt_config mcux_wwdt_config_0 = {
 
 static struct mcux_wwdt_data mcux_wwdt_data_0;
 
-DEVICE_AND_API_INIT(mcux_wwdt_0, DT_INST_LABEL(0),
-		    &mcux_wwdt_init, &mcux_wwdt_data_0,
+DEVICE_DT_INST_DEFINE(0, &mcux_wwdt_init,
+		    device_pm_control_nop, &mcux_wwdt_data_0,
 		    &mcux_wwdt_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wwdt_api);
@@ -183,7 +183,7 @@ static void mcux_wwdt_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_wwdt_isr, DEVICE_GET(mcux_wwdt_0), 0);
+		    mcux_wwdt_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -153,10 +153,10 @@ static void wdt_event_handler(const struct device *dev)
 #define WDT(idx) DT_NODELABEL(wdt##idx)
 
 #define WDT_NRFX_WDT_DEVICE(idx)					       \
-	DEVICE_DECLARE(wdt_##idx);					       \
+	DEVICE_DT_DECLARE(WDT(idx));					       \
 	static void wdt_##idx##_event_handler(void)			       \
 	{								       \
-		wdt_event_handler(DEVICE_GET(wdt_##idx));		       \
+		wdt_event_handler(DEVICE_DT_GET(WDT(idx)));		       \
 	}								       \
 	static int wdt_##idx##_init(const struct device *dev)		       \
 	{								       \
@@ -182,9 +182,9 @@ static void wdt_event_handler(const struct device *dev)
 			.reload_value  = 2000,				       \
 		}							       \
 	};								       \
-	DEVICE_AND_API_INIT(wdt_##idx,					       \
-			    DT_LABEL(WDT(idx)),				       \
+	DEVICE_DT_DEFINE(WDT(idx),					       \
 			    wdt_##idx##_init,				       \
+			    device_pm_control_nop,			       \
 			    &wdt_##idx##_data,				       \
 			    &wdt_##idx##z_config,			       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -34,7 +34,7 @@ struct wdt_sam_dev_cfg {
 	Wdt *regs;
 };
 
-DEVICE_DECLARE(wdt_sam);
+DEVICE_DT_INST_DECLARE(0);
 
 struct wdt_sam_dev_data {
 	wdt_callback_t cb;
@@ -237,7 +237,7 @@ static void wdt_sam_irq_config(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority), wdt_sam_isr,
-		    DEVICE_GET(wdt_sam), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 }
 
@@ -251,6 +251,6 @@ static int wdt_sam_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdt_sam, DT_INST_LABEL(0), wdt_sam_init,
+DEVICE_DT_INST_DEFINE(0, wdt_sam_init, device_pm_control_nop,
 		    &wdt_sam_data, &wdt_sam_cfg, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam_api);

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -38,7 +38,7 @@ struct wdt_sam0_dev_data {
 	bool timeout_valid;
 };
 
-DEVICE_DECLARE(wdt_sam0);
+DEVICE_DT_INST_DECLARE(0);
 
 static struct wdt_sam0_dev_data wdt_sam0_data = { 0 };
 
@@ -272,7 +272,7 @@ static int wdt_sam0_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority), wdt_sam0_isr,
-		    DEVICE_GET(wdt_sam0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	return 0;
@@ -280,6 +280,6 @@ static int wdt_sam0_init(const struct device *dev)
 
 static struct wdt_sam0_dev_data wdt_sam0_data;
 
-DEVICE_AND_API_INIT(wdt_sam0, DT_INST_LABEL(0), wdt_sam0_init,
+DEVICE_DT_INST_DEFINE(0, wdt_sam0_init, device_pm_control_nop,
 		    &wdt_sam0_data, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam0_api);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -271,8 +271,8 @@ static struct wwdg_stm32_config wwdg_stm32_dev_config = {
 	.Instance = (WWDG_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(wwdg_stm32, DT_INST_LABEL(0),
-		    wwdg_stm32_init, &wwdg_stm32_dev_data, &wwdg_stm32_dev_config,
+DEVICE_DT_INST_DEFINE(0, wwdg_stm32_init, device_pm_control_nop,
+		    &wwdg_stm32_dev_data, &wwdg_stm32_dev_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wwdg_stm32_api);
 
@@ -282,7 +282,7 @@ static void wwdg_stm32_irq_config(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    wwdg_stm32_isr, DEVICE_GET(wwdg_stm32), 0);
+		    wwdg_stm32_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 	LL_WWDG_EnableIT_EWKUP(wwdg);
 }


### PR DESCRIPTION
Convert watchdog drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>