### PR TITLE
drivers: pwm: Convert drivers to new DT device macros

### DIFF
--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -166,8 +166,8 @@ static const struct pwm_driver_api imx_pwm_driver_api = {
 									\
 	static struct imx_pwm_data imx_pwm_data_##n;			\
 									\
-	DEVICE_AND_API_INIT(imx_pwm_##n, DT_INST_LABEL(n),		\
-			    &imx_pwm_init, &imx_pwm_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, &imx_pwm_init, device_pm_control_nop,	\
+			    &imx_pwm_data_##n,				\
 			    &imx_pwm_config_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &imx_pwm_driver_api);

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -105,9 +105,9 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 		.reg_period_size = DT_INST_REG_SIZE_BY_NAME(n, period) / 4,    \
 	};								       \
 									       \
-	DEVICE_AND_API_INIT(pwm_##n,					       \
-			    DT_INST_LABEL(n),		       \
+	DEVICE_DT_INST_DEFINE(n,					       \
 			    pwm_litex_init,				       \
+			    device_pm_control_nop,			       \
 			    NULL,					       \
 			    &pwm_litex_cfg_##n,				       \
 			    POST_KERNEL,				       \

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -387,9 +387,9 @@ static struct pwm_driver_api pwm_xec_api = {
 		.base_address = DT_INST_REG_ADDR(inst)			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(pwm_xec_##inst,				\
-			    DT_INST_LABEL(inst),			\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    pwm_xec_init,				\
+			    device_pm_control_nop,			\
 			    NULL,					\
 			    &pwm_xec_dev_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -163,9 +163,9 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 		.clock_source = kCLOCK_IpgClk,				  \
 	};								  \
 									  \
-	DEVICE_AND_API_INIT(pwm_mcux_ ## n,				  \
-			    DT_INST_LABEL(n),				  \
+	DEVICE_DT_INST_DEFINE(n,					  \
 			    pwm_mcux_init,				  \
+			    device_pm_control_nop,			  \
 			    &pwm_mcux_data_ ## n,			  \
 			    &pwm_mcux_config_ ## n,			  \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -168,8 +168,8 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 		.mode = kFTM_EdgeAlignedPwm, \
 	}; \
 	static struct mcux_ftm_data mcux_ftm_data_##n; \
-	DEVICE_AND_API_INIT(mcux_ftm_##n, DT_INST_LABEL(n), \
-			    &mcux_ftm_init, &mcux_ftm_data_##n, \
+	DEVICE_DT_INST_DEFINE(n, &mcux_ftm_init, \
+			    device_pm_control_nop, &mcux_ftm_data_##n, \
 			    &mcux_ftm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &mcux_ftm_driver_api);

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -194,9 +194,8 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct mcux_tpm_data mcux_tpm_data_##n; \
-	DEVICE_AND_API_INIT(mcux_tpm_##n, \
-			    DT_INST_LABEL(n), \
-			    &mcux_tpm_init, &mcux_tpm_data_##n, \
+	DEVICE_DT_INST_DEFINE(n, &mcux_tpm_init, device_pm_control_nop \
+			    &mcux_tpm_data_##n, \
 			    &mcux_tpm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &mcux_tpm_driver_api);

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -208,8 +208,8 @@ static int pwm_npcx_init(const struct device *dev)
 									       \
 	static struct pwm_npcx_data pwm_npcx_data_##inst;                      \
 									       \
-	DEVICE_AND_API_INIT(pwm_npcx_##inst, DT_INST_LABEL(inst),              \
-			    &pwm_npcx_init,                                    \
+	DEVICE_DT_INST_DEFINE(inst,					       \
+			    &pwm_npcx_init, device_pm_control_nop,             \
 			    &pwm_npcx_data_##inst, &pwm_npcx_cfg_##inst,       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    &pwm_npcx_driver_api);

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -263,9 +263,9 @@ static const struct pwm_config pwm_nrf5_sw_0_config = {
 
 static struct pwm_data pwm_nrf5_sw_0_data;
 
-DEVICE_AND_API_INIT(pwm_nrf5_sw_0,
-		    DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    pwm_nrf5_sw_init,
+		    device_pm_control_nop,
 		    &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,
 		    POST_KERNEL,

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -414,8 +414,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
 	};								      \
 	PWM_NRFX_PM_CONTROL(idx)					      \
-	DEVICE_DEFINE(pwm_nrfx_##idx,					      \
-		      DT_LABEL(PWM(idx)),				      \
+	DEVICE_DT_INST_DEFINE(idx,					      \
 		      pwm_nrfx_init, pwm_##idx##_nrfx_pm_control,	      \
 		      &pwm_nrfx_##idx##_data,				      \
 		      &pwm_nrfx_##idx##config,				      \

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -194,9 +194,8 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct rv32m1_tpm_data rv32m1_tpm_data_##n; \
-	DEVICE_AND_API_INIT(rv32m1_tpm_##n, \
-			    DT_INST_LABEL(n), \
-			    &rv32m1_tpm_init, &rv32m1_tpm_data_##n, \
+	DEVICE_DT_INST_DEFINE(n, &rv32m1_tpm_init, device_pm_control_nop, \
+			    &rv32m1_tpm_data_##n, \
 			    &rv32m1_tpm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &rv32m1_tpm_driver_api);

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -106,8 +106,8 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 		.divider = DT_INST_PROP(inst, divider),			\
 	};								\
 									\
-	DEVICE_AND_API_INIT(sam_pwm_##inst, DT_INST_LABEL(inst),	\
-			    &sam_pwm_init,				\
+	DEVICE_DT_INST_DEFINE(inst,					\
+			    &sam_pwm_init, device_pm_control_nop	\
 			    NULL, &sam_pwm_config_##inst,		\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -157,8 +157,8 @@ static const struct pwm_driver_api pwm_sam0_driver_api = {
 		PWM_SAM0_INIT_CLOCKS(inst),				       \
 	};								       \
 									       \
-	DEVICE_AND_API_INIT(pwm_sam0_##inst, DT_INST_LABEL(inst),	       \
-			    &pwm_sam0_init, NULL, &pwm_sam0_config_##inst,     \
+	DEVICE_DT_INST_DEFINE(inst, &pwm_sam0_init, device_pm_control_nop,     \
+			    NULL, &pwm_sam0_config_##inst,		       \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,   \
 			    &pwm_sam0_driver_api);
 

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -229,9 +229,9 @@ static const struct pwm_driver_api pwm_sifive_api = {
 			.f_sys = DT_INST_PROP(n, clock_frequency),  \
 			.cmpwidth = DT_INST_PROP(n, sifive_compare_width), \
 		};	\
-	DEVICE_AND_API_INIT(pwm_##n,	\
-			    DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,	\
 			    pwm_sifive_init,	\
+			    device_pm_control_nop,	\
 			    &pwm_sifive_data_##n,	\
 			    &pwm_sifive_cfg_##n,	\
 			    POST_KERNEL,	\

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -350,8 +350,8 @@ static int pwm_stm32_init(const struct device *dev)
 		.pinctrl_len = ARRAY_SIZE(pwm_pins_##index),                   \
 	};                                                                     \
 									       \
-	DEVICE_AND_API_INIT(pwm_stm32_##index, DT_INST_LABEL(index),           \
-			    &pwm_stm32_init, &pwm_stm32_data_##index,          \
+	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, device_pm_control_nop,   \
+			    &pwm_stm32_data_##index,                           \
 			    &pwm_stm32_config_##index, POST_KERNEL,            \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                \
 			    &pwm_stm32_driver_api);

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -203,8 +203,8 @@ static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
 			GENMASK(DT_INST_PROP(n, xlnx_count_width) - 1, 0), \
 	};								\
 									\
-	DEVICE_AND_API_INIT(xlnx_axi_timer_##n, DT_INST_LABEL(n),	\
-			    &xlnx_axi_timer_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, &xlnx_axi_timer_init,			\
+			    device_pm_control_nop, NULL,		\
 			    &xlnx_axi_timer_config_##n,			\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\


### PR DESCRIPTION
Convert pwm drivers to use new DT variants of the DEVICE APIs.
        DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>