### PR TITLE
include: drivers: sensor: Add constants for power and thermocouple

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -79,6 +79,10 @@ enum sensor_channel {
 	SENSOR_CHAN_DIE_TEMP,
 	/** Ambient temperature in degrees Celsius. */
 	SENSOR_CHAN_AMBIENT_TEMP,
+	/** Thermocouple cold temperature in degrees Celsius. */
+	SENSOR_CHAN_COLD_TEMP,
+	/** Thermocouple difference temperature in degrees Celsius. */
+	SENSOR_CHAN_DIFF_TEMP,
 	/** Pressure in kilopascal. */
 	SENSOR_CHAN_PRESS,
 	/**
@@ -121,6 +125,14 @@ enum sensor_channel {
 	SENSOR_CHAN_VOLTAGE,
 	/** Current, in amps **/
 	SENSOR_CHAN_CURRENT,
+	/** Power, in watts **/
+	SENSOR_CHAN_POWER,
+	/** Average voltage, in volts **/
+	SENSOR_CHAN_AVG_VOLTAGE,
+	/** Average current, in amps **/
+	SENSOR_CHAN_AVG_CURRENT,
+	/** Average power, in watts **/
+	SENSOR_CHAN_AVG_POWER,
 	/** Resistance , in Ohm **/
 	SENSOR_CHAN_RESISTANCE,
 


### PR DESCRIPTION
Added constants for future commits of an acs71020 power meter and
an mcp9600 thermocouple i2c interface. Working with just this file
to get zephyr commits and pulls correct before adding the drivers.

Why: This is where sensor constants go

Assumptions: None

Tests: Ran builds with existing and new to be committed drivers

Signed-off-by: Steven Riedl <steve@serconsultingllc.com>