### PR TITLE
tests: drivers: flash: Extend the flash test for more coverage

### DIFF
--- a/tests/drivers/flash/boards/nrf5340_flash_soc.conf
+++ b/tests/drivers/flash/boards/nrf5340_flash_soc.conf
@@ -1,0 +1,4 @@
+# Minimal configuration for testing flash driver
+# on nrf5340dk_nrf5340 board
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -7,3 +7,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     tags: nrf52 soc_flash_nrf
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
+  drivers.flash.soc_flash_nrf:
+    platform_allow: nrf5340dk_nrf5340
+    tags: nrf53 soc_flash_nrf
+    extra_args: OVERLAY_CONFIG=boards/nrf5340_flash_soc.conf


### PR DESCRIPTION
Extend the flash driver test for better coverage when running on
device directly. Test is expected to run on both nRF52 family and
nRF5340 network core.

Signed-off-by: Xie Lang <Lang.Xie@nordicsemi.no>