### PR TITLE
drivers: gpio: Convert drivers to new DT device macros

### DIFF
--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -217,7 +217,7 @@ static uint32_t gpio_cc13xx_cc26xx_get_pending_int(const struct device *dev)
 	return GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
 }
 
-DEVICE_DECLARE(gpio_cc13xx_cc26xx);
+DEVICE_DT_INST_DECLARE(0);
 
 static void gpio_cc13xx_cc26xx_isr(const struct device *dev)
 {
@@ -258,7 +258,7 @@ static int gpio_cc13xx_cc26xx_init(const struct device *dev)
 	/* Enable IRQ */
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    gpio_cc13xx_cc26xx_isr, DEVICE_GET(gpio_cc13xx_cc26xx), 0);
+		    gpio_cc13xx_cc26xx_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	/* Peripheral should not be accessed until power domain is on. */
@@ -282,8 +282,8 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 	.get_pending_int = gpio_cc13xx_cc26xx_get_pending_int
 };
 
-DEVICE_AND_API_INIT(gpio_cc13xx_cc26xx, DT_INST_LABEL(0),
-		    gpio_cc13xx_cc26xx_init, &gpio_cc13xx_cc26xx_data_0,
+DEVICE_DT_INST_DEFINE(0, gpio_cc13xx_cc26xx_init,
+		    device_pm_control_nop, &gpio_cc13xx_cc26xx_data_0,
 		    &gpio_cc13xx_cc26xx_cfg_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_cc13xx_cc26xx_driver_api);

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -250,7 +250,7 @@ static const struct gpio_driver_api api_funcs = {
 		ARG_UNUSED(dev);					     \
 									     \
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	     \
-			gpio_cc32xx_port_isr, DEVICE_GET(gpio_cc32xx_a##n),  \
+			gpio_cc32xx_port_isr, DEVICE_DT_INST_GET(n),         \
 			0);						     \
 									     \
 		MAP_IntPendClear(DT_INST_IRQN(n) + 16);			     \
@@ -260,8 +260,8 @@ static const struct gpio_driver_api api_funcs = {
 	}
 
 #define GPIO_CC32XX_DEVICE_INIT(n)					     \
-	DEVICE_AND_API_INIT(gpio_cc32xx_a##n, DT_INST_LABEL(n),		     \
-			&gpio_cc32xx_a##n##_init, &gpio_cc32xx_a##n##_data,  \
+	DEVICE_DT_INST_DEFINE(n, &gpio_cc32xx_a##n##_init,		     \
+			device_pm_control_nop, &gpio_cc32xx_a##n##_data,     \
 			&gpio_cc32xx_a##n##_config,			     \
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
 			&api_funcs)
@@ -275,7 +275,7 @@ static const struct gpio_driver_api api_funcs = {
 		.port_num = n						     \
 	};								     \
 									     \
-	DEVICE_DECLARE(gpio_cc32xx_a##n);		     \
+	DEVICE_DT_INST_DECLARE(n);					     \
 	static struct gpio_cc32xx_data gpio_cc32xx_a##n##_data;		     \
 									     \
 	GPIO_CC32XX_INIT_FUNC(n)					     \

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -272,9 +272,9 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 										\
 	static struct gpio_cmsdk_ahb_dev_data gpio_cmsdk_port_##n##_data;	\
 										\
-	DEVICE_AND_API_INIT(gpio_cmsdk_port_## n,				\
-			    DT_INST_LABEL(n),					\
+	DEVICE_DT_INST_DEFINE(n,						\
 			    gpio_cmsdk_ahb_init,				\
+			    device_pm_control_nop,				\
 			    &gpio_cmsdk_port_##n##_data,			\
 			    &gpio_cmsdk_port_## n ##_config,			\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
@@ -285,7 +285,7 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(n),					\
 			    DT_INST_IRQ(n, priority),				\
 			    gpio_cmsdk_ahb_isr,					\
-			    DEVICE_GET(gpio_cmsdk_port_## n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);				\
 										\
 		irq_enable(DT_INST_IRQN(n));					\
 	}

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -574,7 +574,7 @@ static struct gpio_dw_runtime gpio_0_runtime = {
 	.base_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DEFINE(gpio_dw_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_0_runtime,
 	      &gpio_config_0, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
@@ -592,7 +592,7 @@ static void gpio_config_0_irq(const struct device *port)
 #ifdef CONFIG_GPIO_DW_0_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority), gpio_dw_isr,
-		    DEVICE_GET(gpio_dw_0),
+		    DEVICE_DT_INST_GET(0),
 		    INST_0_IRQ_FLAGS);
 	irq_enable(config->irq_num);
 #elif defined(CONFIG_GPIO_DW_0_IRQ_SHARED)
@@ -636,7 +636,7 @@ static struct gpio_dw_runtime gpio_1_runtime = {
 	.base_addr = DT_INST_REG_ADDR(1),
 };
 
-DEVICE_DEFINE(gpio_dw_1, DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_1_runtime,
 	      &gpio_dw_config_1, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
@@ -654,7 +654,7 @@ static void gpio_config_1_irq(const struct device *port)
 #ifdef CONFIG_GPIO_DW_1_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority), gpio_dw_isr,
-		    DEVICE_GET(gpio_dw_1),
+		    DEVICE_DT_INST_GET(1),
 		    INST_1_IRQ_FLAGS);
 	irq_enable(config->irq_num);
 #elif defined(CONFIG_GPIO_DW_1_IRQ_SHARED)
@@ -697,7 +697,7 @@ static struct gpio_dw_runtime gpio_2_runtime = {
 	.base_addr = DT_INST_REG_ADDR(2),
 };
 
-DEVICE_DEFINE(gpio_dw_2, DT_INST_LABEL(2),
+DEVICE_DT_INST_DEFINE(2,
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_2_runtime,
 	      &gpio_dw_config_2, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
@@ -715,7 +715,7 @@ static void gpio_config_2_irq(const struct device *port)
 #ifdef CONFIG_GPIO_DW_2_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(2),
 		    DT_INST_IRQ(2, priority), gpio_dw_isr,
-		    DEVICE_GET(gpio_dw_2),
+		    DEVICE_DT_INST_GET(2),
 		    INST_2_IRQ_FLAGS);
 	irq_enable(config->irq_num);
 #elif defined(CONFIG_GPIO_DW_2_IRQ_SHARED)
@@ -758,7 +758,7 @@ static struct gpio_dw_runtime gpio_3_runtime = {
 	.base_addr = DT_INST_REG_ADDR(3),
 };
 
-DEVICE_DEFINE(gpio_dw_3, DT_INST_LABEL(3),
+DEVICE_DT_INST_DEFINE(3,
 	      gpio_dw_initialize, gpio_dw_device_ctrl, &gpio_3_runtime,
 	      &gpio_dw_config_3, POST_KERNEL, CONFIG_GPIO_DW_INIT_PRIORITY,
 	      &api_funcs);
@@ -776,7 +776,7 @@ static void gpio_config_3_irq(const struct device *port)
 #ifdef CONFIG_GPIO_DW_3_IRQ_DIRECT
 	IRQ_CONNECT(DT_INST_IRQN(3),
 		    DT_INST_IRQ(3, priority), gpio_dw_isr,
-		    DEVICE_GET(gpio_dw_3),
+		    DEVICE_DT_INST_GET(3),
 		    INST_3_IRQ_FLAGS);
 	irq_enable(config->irq_num);
 #elif defined(CONFIG_GPIO_DW_3_IRQ_SHARED)

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -335,9 +335,9 @@ static struct gpio_esp32_data gpio_1_data = { /* 32..39 */
 	static struct gpio_driver_config gpio_##_id##_cfg = { \
 		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(_id),  \
 	}; \
-	DEVICE_AND_API_INIT(gpio_esp32_##_id,				\
-			    DT_INST_LABEL(_id),	\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    gpio_esp32_init,				\
+			    device_pm_control_nop,			\
 			    &gpio_##_id##_data, &gpio_##_id##_cfg,	\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -359,10 +359,10 @@ static void gpio_esp32_isr(const void *param)
 {
 
 #if defined(CONFIG_GPIO_ESP32_0)
-	gpio_esp32_fire_callbacks(DEVICE_GET(gpio_esp32_0));
+	gpio_esp32_fire_callbacks(DEVICE_DT_INST_GET(0));
 #endif
 #if defined(CONFIG_GPIO_ESP32_1)
-	gpio_esp32_fire_callbacks(DEVICE_GET(gpio_esp32_1));
+	gpio_esp32_fire_callbacks(DEVICE_DT_INST_GET(1));
 #endif
 
 	ARG_UNUSED(param);

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -282,8 +282,9 @@ static const struct gpio_gecko_common_config gpio_gecko_common_config = {
 
 static struct gpio_gecko_common_data gpio_gecko_common_data;
 
-DEVICE_AND_API_INIT(gpio_gecko_common, DT_LABEL(DT_INST(0, silabs_gecko_gpio)),
+DEVICE_DT_DEFINE(DT_INST(0, silabs_gecko_gpio),
 		    gpio_gecko_common_init,
+		    device_pm_control_nop,
 		    &gpio_gecko_common_data, &gpio_gecko_common_config,
 		    POST_KERNEL, CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY,
 		    &gpio_gecko_common_driver_api);
@@ -293,11 +294,13 @@ static int gpio_gecko_common_init(const struct device *dev)
 	gpio_gecko_common_data.count = 0;
 	IRQ_CONNECT(GPIO_EVEN_IRQn,
 		    DT_IRQ_BY_NAME(DT_INST(0, silabs_gecko_gpio), gpio_even, priority),
-		    gpio_gecko_common_isr, DEVICE_GET(gpio_gecko_common), 0);
+		    gpio_gecko_common_isr,
+		    DEVICE_DT_GET(DT_INST(0, silabs_gecko_gpio)), 0);
 
 	IRQ_CONNECT(GPIO_ODD_IRQn,
 		    DT_IRQ_BY_NAME(DT_INST(0, silabs_gecko_gpio), gpio_odd, priority),
-		    gpio_gecko_common_isr, DEVICE_GET(gpio_gecko_common), 0);
+		    gpio_gecko_common_isr,
+		    DEVICE_DT_GET(DT_INST(0, silabs_gecko_gpio)), 0);
 
 	irq_enable(GPIO_EVEN_IRQn);
 	irq_enable(GPIO_ODD_IRQn);
@@ -317,9 +320,9 @@ static const struct gpio_gecko_config gpio_gecko_port##idx##_config = { \
 \
 static struct gpio_gecko_data gpio_gecko_port##idx##_data; \
 \
-DEVICE_AND_API_INIT(gpio_gecko_port##idx, \
-		    DT_INST_LABEL(idx), \
+DEVICE_DT_INST_DEFINE(idx, \
 		    gpio_gecko_port##idx##_init, \
+		    device_pm_control_nop, \
 		    &gpio_gecko_port##idx##_data, \
 		    &gpio_gecko_port##idx##_config, \
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -193,9 +193,9 @@ static const struct gpio_driver_api gpio_ht16k33_api = {
 									\
 	static struct gpio_ht16k33_data gpio_ht16k33_##id##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_ht16k33_##id,				\
-			    DT_INST_LABEL(id),	\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    &gpio_ht16k33_init,				\
+			    device_pm_control_nop,			\
 			    &gpio_ht16k33_##id##_data,			\
 			    &gpio_ht16k33_##id##_cfg, POST_KERNEL,	\
 			    CONFIG_GPIO_HT16K33_INIT_PRIORITY,		\

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -220,8 +220,9 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 									\
 	static struct imx_gpio_data imx_gpio_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(imx_gpio_##n, DT_INST_LABEL(n),		\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    imx_gpio_##n##_init,			\
+			    device_pm_control_nop,			\
 			    &imx_gpio_##n##_data,			\
 			    &imx_gpio_##n##_config,			\
 			    POST_KERNEL,				\
@@ -233,14 +234,14 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 0, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, 0, priority),		\
 			    imx_gpio_port_isr,				\
-			    DEVICE_GET(imx_gpio_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, 0, irq));		\
 									\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 1, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, 1, priority),		\
 			    imx_gpio_port_isr,				\
-			    DEVICE_GET(imx_gpio_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, 1, irq));		\
 									\

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -571,9 +571,9 @@ static const struct gpio_intel_apl_config				\
 									\
 static struct gpio_intel_apl_data gpio_intel_apl_data_##n;		\
 									\
-DEVICE_AND_API_INIT(gpio_intel_apl_##n,					\
-		    DT_INST_LABEL(n),					\
+DEVICE_DT_INST_DEFINE(n,						\
 		    gpio_intel_apl_init,				\
+		    device_pm_control_nop,				\
 		    &gpio_intel_apl_data_##n,				\
 		    &gpio_intel_apl_cfg_##n,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -230,9 +230,9 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 	}; \
 	static struct gpio_litex_data gpio_litex_data_##n; \
 \
-	DEVICE_AND_API_INIT(litex_gpio_##n, \
-			    DT_INST_LABEL(n), \
+	DEVICE_DT_INST_DEFINE(n, \
 			    gpio_litex_init, \
+			    device_pm_control_nop, \
 			    &gpio_litex_data_##n, \
 			    &gpio_litex_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -177,9 +177,9 @@ BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 									\
 	static struct gpio_lmp90xxx_data gpio_lmp90xxx_##id##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_lmp90xxx_##id,				\
-			    DT_INST_LABEL(id),				\
+	DEVICE_DT_INST_DEFINE(id,					\
 			    &gpio_lmp90xxx_init,			\
+			    device_pm_control_nop,			\
 			    &gpio_lmp90xxx_##id##_data,			\
 			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\
 			    CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -419,13 +419,13 @@ static uint32_t gpio_lpc11u6x_get_pending_int(const struct device *dev)
 }
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
-DEVICE_DECLARE(gpio_lpc11u6x_0);
+DEVICE_DT_DECLARE(DT_NODELABEL(gpio0));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
-DEVICE_DECLARE(gpio_lpc11u6x_1);
+DEVICE_DT_DECLARE(DT_NODELABEL(gpio1));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio2), okay)
-DEVICE_DECLARE(gpio_lpc11u6x_2);
+DEVICE_DT_DECLARE(DT_NODELABEL(gpio2));
 #endif
 
 static void gpio_lpc11u6x_isr(const void *arg)
@@ -469,21 +469,21 @@ static void gpio_lpc11u6x_isr(const void *arg)
 	/* For each port with active pins, fire the GPIO interrupt callbacks. */
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
 	if (pins[0]) {
-		port = DEVICE_GET(gpio_lpc11u6x_0);
+		port = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 		data = port->data;
 		gpio_fire_callbacks(&data->cb_list, port, pins[0]);
 	}
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
 	if (pins[1]) {
-		port = DEVICE_GET(gpio_lpc11u6x_1);
+		port = DEVICE_DT_GET(DT_NODELABEL(gpio1));
 		data = port->data;
 		gpio_fire_callbacks(&data->cb_list, port, pins[1]);
 	}
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio2), okay)
 	if (pins[2]) {
-		port = DEVICE_GET(gpio_lpc11u6x_2);
+		port = DEVICE_DT_GET(DT_NODELABEL(gpio2));
 		data = port->data;
 		gpio_fire_callbacks(&data->cb_list, port, pins[2]);
 	}
@@ -598,9 +598,9 @@ static const struct gpio_lpc11u6x_config				\
 									\
 static struct gpio_lpc11u6x_data gpio_lpc11u6x_data_##id;		\
 									\
-DEVICE_AND_API_INIT(gpio_lpc11u6x_##id,					\
-		    DT_LABEL(DT_NODELABEL(gpio##id)),			\
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio##id),				\
 		    &gpio_lpc11u6x_init,				\
+		    device_pm_control_nop,				\
 		    &gpio_lpc11u6x_data_##id,				\
 		    &gpio_lpc11u6x_config_##id,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -337,9 +337,9 @@ static const struct gpio_xec_config gpio_xec_port000_036_config = {
 
 static struct gpio_xec_data gpio_xec_port000_036_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port000_036,
-		    DT_LABEL(DT_NODELABEL(gpio_000_036)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_000_036),
 		    gpio_xec_port000_036_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port000_036_data, &gpio_xec_port000_036_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -354,7 +354,8 @@ static int gpio_xec_port000_036_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_000_036), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_000_036), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port000_036), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_000_036)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_000_036), irq));
 #endif
@@ -382,9 +383,9 @@ static const struct gpio_xec_config gpio_xec_port040_076_config = {
 
 static struct gpio_xec_data gpio_xec_port040_076_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port040_076,
-		    DT_LABEL(DT_NODELABEL(gpio_040_076)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_040_076),
 		    gpio_xec_port040_076_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port040_076_data, &gpio_xec_port040_076_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -399,7 +400,8 @@ static int gpio_xec_port040_076_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_040_076), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_040_076), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port040_076), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_040_076)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_040_076), irq));
 #endif
@@ -427,9 +429,9 @@ static const struct gpio_xec_config gpio_xec_port100_136_config = {
 
 static struct gpio_xec_data gpio_xec_port100_136_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port100_136,
-		    DT_LABEL(DT_NODELABEL(gpio_100_136)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_100_136),
 		    gpio_xec_port100_136_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port100_136_data, &gpio_xec_port100_136_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -444,7 +446,8 @@ static int gpio_xec_port100_136_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_100_136), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_100_136), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port100_136), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_100_136)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_100_136), irq));
 #endif
@@ -472,9 +475,9 @@ static const struct gpio_xec_config gpio_xec_port140_176_config = {
 
 static struct gpio_xec_data gpio_xec_port140_176_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port140_176,
-		    DT_LABEL(DT_NODELABEL(gpio_140_176)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_140_176),
 		    gpio_xec_port140_176_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port140_176_data, &gpio_xec_port140_176_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -489,7 +492,8 @@ static int gpio_xec_port140_176_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_140_176), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_140_176), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port140_176), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_140_176)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_140_176), irq));
 #endif
@@ -517,9 +521,9 @@ static const struct gpio_xec_config gpio_xec_port200_236_config = {
 
 static struct gpio_xec_data gpio_xec_port200_236_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port200_236,
-		    DT_LABEL(DT_NODELABEL(gpio_200_236)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_200_236),
 		    gpio_xec_port200_236_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port200_236_data, &gpio_xec_port200_236_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -534,7 +538,8 @@ static int gpio_xec_port200_236_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_200_236), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_200_236), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port200_236), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_200_236)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_200_236), irq));
 #endif
@@ -562,9 +567,9 @@ static const struct gpio_xec_config gpio_xec_port240_276_config = {
 
 static struct gpio_xec_data gpio_xec_port240_276_data;
 
-DEVICE_AND_API_INIT(gpio_xec_port240_276,
-		    DT_LABEL(DT_NODELABEL(gpio_240_276)),
+DEVICE_DT_DEFINE(DT_NODELABEL(gpio_240_276),
 		    gpio_xec_port240_276_init,
+		    device_pm_control_nop,
 		    &gpio_xec_port240_276_data, &gpio_xec_port240_276_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -579,7 +584,8 @@ static int gpio_xec_port240_276_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQ(DT_NODELABEL(gpio_240_276), irq),
 		    DT_IRQ(DT_NODELABEL(gpio_240_276), priority),
-		    gpio_gpio_xec_port_isr, DEVICE_GET(gpio_xec_port240_276), 0U);
+		    gpio_gpio_xec_port_isr,
+		    DEVICE_DT_GET(DT_NODELABEL(gpio_240_276)), 0U);
 
 	irq_enable(DT_IRQ(DT_NODELABEL(gpio_240_276), irq));
 #endif

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -441,8 +441,9 @@ static int mcp23s17_init(const struct device *dev)
 	};								\
 									\
 	/* This has to init after SPI master */				\
-	DEVICE_AND_API_INIT(mcp23s17_##inst, DT_INST_LABEL(inst),	\
-			    mcp23s17_init, &mcp23s17_##inst##_drvdata,	\
+	DEVICE_DT_INST_DEFINE(inst, mcp23s17_init,			\
+			    device_pm_control_nop,			\
+			    &mcp23s17_##inst##_drvdata,			\
 			    &mcp23s17_##inst##_config,			\
 			    POST_KERNEL,				\
 			    CONFIG_GPIO_MCP23S17_INIT_PRIORITY,		\

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -257,7 +257,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
 			    gpio_mcux_port_isr,				\
-			    DEVICE_GET(gpio_mcux_port##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	} while (0)
@@ -278,8 +278,9 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 									\
 	static struct gpio_mcux_data gpio_mcux_port## n ##_data;	\
 									\
-	DEVICE_AND_API_INIT(gpio_mcux_port## n, DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    gpio_mcux_port## n ##_init,			\
+			    device_pm_control_nop,			\
 			    &gpio_mcux_port## n ##_data,		\
 			    &gpio_mcux_port## n##_config,		\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -206,7 +206,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
 			    mcux_igpio_port_isr,			\
-			    DEVICE_GET(mcux_igpio_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
 	} while (0)
@@ -223,8 +223,9 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 									\
 	static struct mcux_igpio_data mcux_igpio_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(mcux_igpio_##n, DT_INST_LABEL(n),		\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    mcux_igpio_##n##_init,			\
+			    device_pm_control_nop,			\
 			    &mcux_igpio_##n##_data,			\
 			    &mcux_igpio_##n##_config,			\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -379,8 +379,8 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port0_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port0_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port0, DT_INST_LABEL(0),
-		    lpc_gpio_0_init, &gpio_mcux_lpc_port0_data,
+DEVICE_DT_INST_DEFINE(0, lpc_gpio_0_init, device_pm_control_nop,
+		    &gpio_mcux_lpc_port0_data,
 		    &gpio_mcux_lpc_port0_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_lpc_driver_api);
@@ -399,7 +399,7 @@ static int lpc_gpio_0_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(0, 0)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
 		    DT_INST_IRQ_BY_IDX(0, 0, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(0, 0, irq);
 #endif
@@ -407,7 +407,7 @@ static int lpc_gpio_0_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(0, 1)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
 		    DT_INST_IRQ_BY_IDX(0, 1, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(0, 1, irq);
 #endif
@@ -415,7 +415,7 @@ static int lpc_gpio_0_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(0, 2)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
 		    DT_INST_IRQ_BY_IDX(0, 2, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(0, 2, irq);
 #endif
@@ -423,7 +423,7 @@ static int lpc_gpio_0_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(0, 3)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
 		    DT_INST_IRQ_BY_IDX(0, 3, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(0, 3, irq);
 #endif
@@ -453,8 +453,8 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port1_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port1_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port1, DT_INST_LABEL(1),
-		    lpc_gpio_1_init, &gpio_mcux_lpc_port1_data,
+DEVICE_DT_INST_DEFINE(1, lpc_gpio_1_init, device_pm_control_nop,
+		    &gpio_mcux_lpc_port1_data,
 		    &gpio_mcux_lpc_port1_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_mcux_lpc_driver_api);
@@ -473,7 +473,7 @@ static int lpc_gpio_1_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(1, 0)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(1, 0, irq),
 		    DT_INST_IRQ_BY_IDX(1, 0, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(1), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(1, 0, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(1, 0, irq);
 #endif
@@ -481,7 +481,7 @@ static int lpc_gpio_1_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(1, 1)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(1, 1, irq),
 		    DT_INST_IRQ_BY_IDX(1, 1, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(1), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(1, 1, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(1, 1, irq);
 #endif
@@ -489,7 +489,7 @@ static int lpc_gpio_1_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(1, 2)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(1, 2, irq),
 		    DT_INST_IRQ_BY_IDX(1, 2, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(1), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(1, 2, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(1, 2, irq);
 #endif
@@ -497,7 +497,7 @@ static int lpc_gpio_1_init(const struct device *dev)
 #if DT_INST_IRQ_HAS_IDX(1, 3)
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(1, 3, irq),
 		    DT_INST_IRQ_BY_IDX(1, 3, priority),
-		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+		    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(1), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(1, 3, irq));
 	data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(1, 3, irq);
 #endif

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -279,9 +279,9 @@ int gpio_npcx_init(const struct device *dev)
 									       \
 	static struct gpio_npcx_data gpio_npcx_data_##inst;	               \
 									       \
-	DEVICE_AND_API_INIT(gpio_npcx_##inst,                                  \
-			    DT_INST_LABEL(inst),                               \
+	DEVICE_DT_INST_DEFINE(inst,					       \
 			    gpio_npcx_init,                                    \
+			    device_pm_control_nop,			       \
 			    &gpio_npcx_data_##inst,                            \
 			    &gpio_npcx_cfg_##inst,                             \
 			    POST_KERNEL,                                       \
@@ -291,7 +291,7 @@ int gpio_npcx_init(const struct device *dev)
 DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEVICE_INIT)
 
 /* GPIO module instances */
-#define NPCX_GPIO_DEV(inst) DEVICE_GET(gpio_npcx_##inst),
+#define NPCX_GPIO_DEV(inst) DEVICE_DT_INST_GET(inst),
 static const struct device *gpio_devs[] = {
 	DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEV)
 };

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -772,9 +772,9 @@ static struct gpio_pca95xx_drv_data gpio_pca95xx_##inst##_drvdata = {	\
 	))								\
 };									\
 									\
-DEVICE_AND_API_INIT(gpio_pca95xx_##inst,				\
-	DT_INST_LABEL(inst),				\
+DEVICE_DT_INST_DEFINE(inst,						\
 	gpio_pca95xx_init,						\
+	device_pm_control_nop,						\
 	&gpio_pca95xx_##inst##_drvdata,					\
 	&gpio_pca95xx_##inst##_cfg,					\
 	POST_KERNEL, CONFIG_GPIO_PCA95XX_INIT_PRIORITY,			\

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -318,8 +318,9 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 									\
 	static struct gpio_rv32m1_data gpio_rv32m1_##n##_data;		\
 									\
-	DEVICE_AND_API_INIT(gpio_rv32m1_##n, DT_INST_LABEL(n),		\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    gpio_rv32m1_init,				\
+			    device_pm_control_nop,			\
 			    &gpio_rv32m1_##n##_data,			\
 			    &gpio_rv32m1_##n##_config,			\
 			    POST_KERNEL,				\
@@ -331,7 +332,7 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    0,						\
 			    gpio_rv32m1_port_isr,			\
-			    DEVICE_GET(gpio_rv32m1_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(0));				\
 									\

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -322,8 +322,8 @@ int gpio_sam_init(const struct device *dev)
 									\
 	static struct gpio_sam_runtime port_##n##_sam_runtime;		\
 									\
-	DEVICE_AND_API_INIT(port_##n##_sam, DT_INST_LABEL(n),		\
-			    gpio_sam_init, &port_##n##_sam_runtime,	\
+	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, device_pm_control_nop,	\
+			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &gpio_sam_api);				\
@@ -332,7 +332,7 @@ int gpio_sam_init(const struct device *dev)
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    gpio_sam_isr,				\
-			    DEVICE_GET(port_##n##_sam), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -303,8 +303,9 @@ static const struct gpio_sam0_config gpio_sam0_config_0 = {
 
 static struct gpio_sam0_data gpio_sam0_data_0;
 
-DEVICE_AND_API_INIT(gpio_sam0_0, DT_LABEL(DT_NODELABEL(porta)),
-		    gpio_sam0_init, &gpio_sam0_data_0, &gpio_sam0_config_0,
+DEVICE_DT_DEFINE(DT_NODELABEL(porta),
+		    gpio_sam0_init, device_pm_control_nop,
+		    &gpio_sam0_data_0, &gpio_sam0_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -324,8 +325,9 @@ static const struct gpio_sam0_config gpio_sam0_config_1 = {
 
 static struct gpio_sam0_data gpio_sam0_data_1;
 
-DEVICE_AND_API_INIT(gpio_sam0_1, DT_LABEL(DT_NODELABEL(portb)),
-		    gpio_sam0_init, &gpio_sam0_data_1, &gpio_sam0_config_1,
+DEVICE_DT_DEFINE(DT_NODELABEL(portb),
+		    gpio_sam0_init, device_pm_control_nop,
+		    &gpio_sam0_data_1, &gpio_sam0_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -345,8 +347,9 @@ static const struct gpio_sam0_config gpio_sam0_config_2 = {
 
 static struct gpio_sam0_data gpio_sam0_data_2;
 
-DEVICE_AND_API_INIT(gpio_sam0_2, DT_LABEL(DT_NODELABEL(portc)),
-		    gpio_sam0_init, &gpio_sam0_data_2, &gpio_sam0_config_2,
+DEVICE_DT_DEFINE(DT_NODELABEL(portc),
+		    gpio_sam0_init, device_pm_control_nop,
+		    &gpio_sam0_data_2, &gpio_sam0_config_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
@@ -366,8 +369,9 @@ static const struct gpio_sam0_config gpio_sam0_config_3 = {
 
 static struct gpio_sam0_data gpio_sam0_data_3;
 
-DEVICE_AND_API_INIT(gpio_sam0_3, DT_LABEL(DT_NODELABEL(portd)),
-		    gpio_sam0_init, &gpio_sam0_data_3, &gpio_sam0_config_3,
+DEVICE_DT_DEFINE(DT_NODELABEL(portd),
+		    gpio_sam0_init, device_pm_control_nop,
+		    &gpio_sam0_data_3, &gpio_sam0_config_3,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -246,7 +246,7 @@ int gpio_sam_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, m, priority),		\
 			    gpio_sam_isr,				\
-			    DEVICE_GET(port_##n##_sam), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
 	} while (0)
 
@@ -264,8 +264,8 @@ int gpio_sam_init(const struct device *dev)
 									\
 	static struct gpio_sam_runtime port_##n##_sam_runtime;		\
 									\
-	DEVICE_AND_API_INIT(port_##n##_sam, DT_INST_LABEL(n),		\
-			    gpio_sam_init, &port_##n##_sam_runtime,	\
+	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, device_pm_control_nop,	\
+			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &gpio_sam_api);				\

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -357,8 +357,9 @@ static const struct gpio_sifive_config gpio_sifive_config0 = {
 
 static struct gpio_sifive_data gpio_sifive_data0;
 
-DEVICE_AND_API_INIT(gpio_sifive_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    gpio_sifive_init,
+		    device_pm_control_nop,
 		    &gpio_sifive_data0, &gpio_sifive_config0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sifive_driver);
@@ -367,7 +368,7 @@ DEVICE_AND_API_INIT(gpio_sifive_0, DT_INST_LABEL(0),
 IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, n, irq),			\
 		CONFIG_GPIO_SIFIVE_##n##_PRIORITY,		\
 		gpio_sifive_irq_handler,			\
-		DEVICE_GET(gpio_sifive_0),			\
+		DEVICE_DT_INST_GET(0),				\
 		0);
 
 static void gpio_sifive_cfg_0(void)

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -250,9 +250,9 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 		.config_func = port_## n ##_stellaris_config_func,			\
 	};										\
 											\
-	DEVICE_AND_API_INIT(gpio_stellaris_port_## n,					\
-			    DT_INST_LABEL(n),						\
+	DEVICE_DT_INST_DEFINE(n,							\
 			    gpio_stellaris_init,					\
+			    device_pm_control_nop,					\
 			    &port_## n ##_stellaris_runtime,				\
 			    &gpio_stellaris_port_## n ##_config,			\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
@@ -263,7 +263,7 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),			\
 			    DT_INST_IRQ(n, priority),		\
 			    gpio_stellaris_isr,						\
-			    DEVICE_GET(gpio_stellaris_port_## n), 0);			\
+			    DEVICE_DT_INST_GET(n), 0);					\
 											\
 		irq_enable(DT_INST_IRQN(n));			\
 	}

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -558,7 +558,7 @@ static int gpio_stm32_init(const struct device *device)
 	return 0;
 }
 
-#define GPIO_DEVICE_INIT(__name, __suffix, __base_addr, __port, __cenr, __bus) \
+#define GPIO_DEVICE_INIT(__node, __suffix, __base_addr, __port, __cenr, __bus) \
 	static const struct gpio_stm32_config gpio_stm32_cfg_## __suffix = {   \
 		.common = {						       \
 			 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_NGPIOS(16U), \
@@ -568,9 +568,9 @@ static int gpio_stm32_init(const struct device *device)
 		.pclken = { .bus = __bus, .enr = __cenr }		       \
 	};								       \
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
-	DEVICE_AND_API_INIT(gpio_stm32_## __suffix,			       \
-			    __name,					       \
+	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
+			    device_pm_control_nop,			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    POST_KERNEL,				       \
@@ -578,7 +578,7 @@ static int gpio_stm32_init(const struct device *device)
 			    &gpio_stm32_driver)
 
 #define GPIO_DEVICE_INIT_STM32(__suffix, __SUFFIX)			\
-	GPIO_DEVICE_INIT(DT_LABEL(DT_NODELABEL(gpio##__suffix)),	\
+	GPIO_DEVICE_INIT(DT_NODELABEL(gpio##__suffix),	\
 			 __suffix,					\
 			 DT_REG_ADDR(DT_NODELABEL(gpio##__suffix)),	\
 			 STM32_PORT##__SUFFIX,				\

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -281,9 +281,9 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 		.all_outputs = DT_INST_PROP_OR(n, xlnx_all_outputs2, 0),\
 	};								\
 									\
-	DEVICE_AND_API_INIT(gpio_xlnx_axi_##n##_2,			\
-			DT_LABEL(DT_CHILD(DT_DRV_INST(n), gpio2)),	\
+	DEVICE_DT_DEFINE(DT_CHILD(DT_DRV_INST(n), gpio2),		\
 			&gpio_xlnx_axi_init,				\
+			device_pm_control_nop,				\
 			&gpio_xlnx_axi_##n##_2_data,			\
 			&gpio_xlnx_axi_##n##_2_config,			\
 			POST_KERNEL,					\
@@ -309,8 +309,9 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 		.all_outputs = DT_INST_PROP_OR(n, xlnx_all_outputs, 0),	\
 	};								\
 									\
-	DEVICE_AND_API_INIT(gpio_xlnx_axi_##n, DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,					\
 			&gpio_xlnx_axi_init,				\
+			device_pm_control_nop,				\
 			&gpio_xlnx_axi_##n##_data,			\
 			&gpio_xlnx_axi_##n##_config,			\
 			POST_KERNEL,					\


### PR DESCRIPTION
Convert gpio drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>