### PR TITLE
drivers: spi: spi_nrfx_spis: Fix compile error

### DIFF
--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -287,7 +287,7 @@ static int init_spis(const struct device *dev,
 		.spis = NRFX_SPIS_INSTANCE(idx),			       \
 		.max_buf_len = (1 << SPIS##idx##_EASYDMA_MAXCNT_SIZE) - 1,     \
 	};								       \
-	DEVICE_DT_INST_DEFINE(idx,					       \
+	DEVICE_DT_DEFINE(SPIS(idx),					       \
 			    spi_##idx##_init,				       \
 			    device_pm_control_nop,			       \
 			    &spi_##idx##_data,				       \


### PR DESCRIPTION
The spi_nrfx_spis driver uses nodelabel so we need to use
DEVICE_DT_DEFINE instead of DEVICE_DT_INST_DEFINE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>