### PR TITLE
drivers: counters: Fix TIMER0 and RTC0 with Bluetooth controller

### DIFF
--- a/drivers/counter/Kconfig.nrfx
+++ b/drivers/counter/Kconfig.nrfx
@@ -10,44 +10,49 @@ config COUNTER_NRF_RTC
 config COUNTER_TIMER0
 	bool "Enable Counter on TIMER0"
 	depends on HAS_HW_NRF_TIMER0
-	depends on !BT_LL_SW_SPLIT
+	depends on !NRF_HW_TIMER0_RESERVED
 	select COUNTER_NRF_TIMER
 
 config COUNTER_TIMER1
 	bool "Enable Counter on TIMER1"
 	depends on HAS_HW_NRF_TIMER1
+	depends on !NRF_HW_TIMER1_RESERVED
 	select COUNTER_NRF_TIMER
 
 config COUNTER_TIMER2
 	bool "Enable Counter on TIMER2"
 	depends on HAS_HW_NRF_TIMER2
+	depends on !NRF_HW_TIMER2_RESERVED
 	select COUNTER_NRF_TIMER
 
 config COUNTER_TIMER3
 	bool "Enable Counter on TIMER3"
 	depends on HAS_HW_NRF_TIMER3
+	depends on !NRF_HW_TIMER3_RESERVED
 	select COUNTER_NRF_TIMER
 
 config COUNTER_TIMER4
 	bool "Enable Counter on TIMER4"
 	depends on HAS_HW_NRF_TIMER4
+	depends on !NRF_HW_TIMER4_RESERVED
 	select COUNTER_NRF_TIMER
 
 config COUNTER_RTC0
 	bool "Enable Counter on RTC0"
 	depends on HAS_HW_NRF_RTC0
-	depends on !BT_LL_SW_SPLIT
+	depends on !NRF_HW_RTC0_RESERVED
 	select COUNTER_NRF_RTC
 
 config COUNTER_RTC1
 	bool "Enable Counter on RTC1"
 	depends on HAS_HW_NRF_RTC1
-	depends on !NRF_RTC_TIMER
+	depends on !NRF_HW_RTC1_RESERVED
 	select COUNTER_NRF_RTC
 
 config COUNTER_RTC2
 	bool "Enable Counter on RTC2"
 	depends on HAS_HW_NRF_RTC2
+	depends on !NRF_HW_RTC2_RESERVED
 	select COUNTER_NRF_RTC
 
 # Internal flag which detects if PPI wrap feature is enabled for any instance

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -150,6 +150,7 @@ config NRF_RTC_TIMER
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
 	select TICKLESS_CAPABLE
+	select NRF_HW_RTC1_RESERVED
 	help
 	  This module implements a kernel device driver for the nRF Real Time
 	  Counter NRF_RTC1 and provides the standard "system clock driver"

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -276,3 +276,28 @@ config HAS_HW_NRF_WDT0
 
 config HAS_HW_NRF_WDT1
 	bool
+
+# Reserved HW peripherals
+config NRF_HW_TIMER0_RESERVED
+	bool
+
+config NRF_HW_TIMER1_RESERVED
+	bool
+
+config NRF_HW_TIMER2_RESERVED
+	bool
+
+config NRF_HW_TIMER3_RESERVED
+	bool
+
+config NRF_HW_TIMER4_RESERVED
+	bool
+
+config NRF_HW_RTC0_RESERVED
+	bool
+
+config NRF_HW_RTC1_RESERVED
+	bool
+
+config NRF_HW_RTC2_RESERVED
+	bool

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -97,6 +97,8 @@ config BT_LL_SW_SPLIT
 	bool "Software-based BLE Link Layer"
 	select BT_RECV_IS_RX_THREAD
 	select ENTROPY_GENERATOR
+	select NRF_HW_TIMER0_RESERVED
+	select NRF_HW_RTC0_RESERVED
 	help
 	  Use Zephyr software BLE Link Layer ULL LLL split implementation.
 


### PR DESCRIPTION
Fix TIMER0 and RTC0 being selectable when using out-of-tree Bluetooth
controller.
Generalize the Kconfig to have the features that use the HW peripheral
select them as reserved to make the dependencies more manageable.
