### PR TITLE
drivers: entropy: Convert drivers to new DT device macros

### DIFF
--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -40,7 +40,7 @@ struct entropy_cc13xx_cc26xx_data {
 #endif
 };
 
-DEVICE_DECLARE(entropy_cc13xx_cc26xx);
+DEVICE_DT_INST_DECLARE(0);
 
 static inline struct entropy_cc13xx_cc26xx_data *
 get_dev_data(const struct device *dev)
@@ -376,7 +376,7 @@ static int entropy_cc13xx_cc26xx_init(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
 		    entropy_cc13xx_cc26xx_isr,
-		    DEVICE_GET(entropy_cc13xx_cc26xx), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
 	return 0;
@@ -392,7 +392,7 @@ static struct entropy_cc13xx_cc26xx_data entropy_cc13xx_cc26xx_data = {
 	.sync = Z_SEM_INITIALIZER(entropy_cc13xx_cc26xx_data.sync, 0, 1),
 };
 
-DEVICE_DEFINE(entropy_cc13xx_cc26xx, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		entropy_cc13xx_cc26xx_init,
 		entropy_cc13xx_cc26xx_pm_control,
 		&entropy_cc13xx_cc26xx_data, NULL,

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -57,7 +57,7 @@ static struct entropy_driver_api entropy_esp32_api_funcs = {
 	.get_entropy = entropy_esp32_get_entropy
 };
 
-DEVICE_AND_API_INIT(entropy_esp32, DT_INST_LABEL(0),
-		    entropy_esp32_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_esp32_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_esp32_api_funcs);

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -99,7 +99,8 @@ static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
 	.get_entropy_isr = entropy_gecko_trng_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_gecko_trng, DT_INST_LABEL(0),
-			entropy_gecko_trng_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0,
+			entropy_gecko_trng_init, device_pm_control_nop,
+			NULL, NULL,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&entropy_gecko_trng_api_funcs);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -59,7 +59,7 @@ static const struct entropy_driver_api entropy_prbs_api = {
 	.get_entropy = entropy_prbs_get_entropy
 };
 
-DEVICE_AND_API_INIT(entropy_prbs, DT_INST_LABEL(0),
-		    entropy_prbs_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_prbs_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_prbs_api);

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -42,8 +42,9 @@ static const struct mcux_entropy_config entropy_mcux_config = {
 
 static int entropy_mcux_rng_init(const struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_rng, DT_INST_LABEL(0),
-		    entropy_mcux_rng_init, NULL, &entropy_mcux_config,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_rng_init, device_pm_control_nop, NULL,
+		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rng_api_funcs);
 

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -59,8 +59,8 @@ static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
 
 static int entropy_mcux_rnga_init(const struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_rnga, DT_INST_LABEL(0),
-		    entropy_mcux_rnga_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_rnga_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rnga_api_funcs);
 

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -42,8 +42,9 @@ static struct mcux_entropy_config entropy_mcux_config = {
 
 static int entropy_mcux_trng_init(const struct device *);
 
-DEVICE_AND_API_INIT(entropy_mcux_trng, DT_INST_LABEL(0),
-		    entropy_mcux_trng_init, NULL, &entropy_mcux_config,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_trng_init, device_pm_control_nop, NULL,
+		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_trng_api_funcs);
 

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -331,8 +331,9 @@ static const struct entropy_driver_api entropy_nrf5_api_funcs = {
 	.get_entropy_isr = entropy_nrf5_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_nrf5, DT_INST_LABEL(0),
-		    entropy_nrf5_init, &entropy_nrf5_data, NULL,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_nrf5_init, device_pm_control_nop,
+		    &entropy_nrf5_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_nrf5_api_funcs);
 

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -42,8 +42,9 @@ static struct rv32m1_entropy_config entropy_rv32m1_config = {
 
 static int entropy_rv32m1_trng_init(const struct device *);
 
-DEVICE_AND_API_INIT(entropy_rv32m1_trng, DT_INST_LABEL(0),
-		    entropy_rv32m1_trng_init, NULL, &entropy_rv32m1_config,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_rv32m1_trng_init, device_pm_control_nop,
+		    NULL, &entropy_rv32m1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_rv32m1_trng_api_funcs);
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -183,7 +183,8 @@ static const struct trng_sam_dev_cfg trng_sam_cfg = {
 	.regs = (Trng *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(entropy_sam, DT_INST_LABEL(0),
-		    entropy_sam_init, NULL, &trng_sam_cfg,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_sam_init, device_pm_control_nop,
+		    NULL, &trng_sam_cfg,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_sam_api);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -448,8 +448,8 @@ static const struct entropy_driver_api entropy_stm32_rng_api = {
 	.get_entropy_isr = entropy_stm32_rng_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_stm32_rng, DT_INST_LABEL(0),
-		    entropy_stm32_rng_init,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_stm32_rng_init, device_pm_control_nop,
 		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_stm32_rng_api);

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -75,8 +75,9 @@ static const struct entropy_driver_api entropy_native_posix_api_funcs = {
 	.get_entropy_isr = entropy_native_posix_get_entropy_isr
 };
 
-DEVICE_AND_API_INIT(entropy_native_posix, DT_INST_LABEL(0),
-		    entropy_native_posix_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_native_posix_init, device_pm_control_nop,
+		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_native_posix_api_funcs);
 


### PR DESCRIPTION
Convert entropy drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_GET

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>