### PR TITLE
drivers: flash: stm32g4x: Fix include for dual bank

### DIFF
--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <drivers/flash.h>
 #include <init.h>
 #include <soc.h>
+#include <stm32_ll_system.h>
 
 #include "flash_stm32.h"
 


### PR DESCRIPTION
The LL header include was missing for the functions used for STM32G474
MCUs with dual bank feature.

This was missing in #30231 and was apparently not detected by buildkite.