### PR TITLE
drivers: wifi: esp: support 32-bit length in +IPD

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -441,8 +441,8 @@ struct net_pkt *esp_prepare_pkt(struct esp_data *dev, struct net_buf *src,
  * Passive mode: "+IPD,<id>,<len>\r\n"
  * Other:        "+IPD,<id>,<len>:<data>"
  */
-#define MIN_IPD_LEN (sizeof("+IPD,I,LE") - 1)
-#define MAX_IPD_LEN (sizeof("+IPD,I,LLLLE") - 1)
+#define MIN_IPD_LEN (sizeof("+IPD,I,0E") - 1)
+#define MAX_IPD_LEN (sizeof("+IPD,I,4294967295E") - 1)
 MODEM_CMD_DIRECT_DEFINE(on_cmd_ipd)
 {
 	char *endptr, end, ipd_buf[MAX_IPD_LEN + 1];


### PR DESCRIPTION
+IPD,<sock>,<bytes_avail> command in passive mode notifies about ESP
internal buffer usage level. Hence value of <bytes_avail> can exceed
4 digit value, which currently results in failure.

+IPD message is used in driver only for scheduling AT+CIPRECVDATA
command and actual value of <bytes_avail> doesn't really
matter. Increase maximum supported value that can be received from
9999 (maximum 4 digits) to 4294967295, which is maximum value of 32-bit
unsigned integer.