### PR TITLE
drivers: display: mcux_elcdif: fix k_heap call

### DIFF
--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -193,9 +193,8 @@ static int mcux_elcdif_init(const struct device *dev)
 
 	for (i = 0; i < ARRAY_SIZE(data->fb); i++) {
 		data->fb[i].data = k_heap_alloc(&mcux_elcdif_pool,
-						&data->fb[i],
 						data->fb_bytes, K_NO_WAIT);
-		if (data->fb[i] == NULL) {
+		if (data->fb[i].data == NULL) {
 			LOG_ERR("Could not allocate frame buffer %d", i);
 			return -ENOMEM;
 		}


### PR DESCRIPTION
Rework in #28611 left an old argument in place and missed a type check.

Failure displayed in https://buildkite.com/zephyr/zephyr/builds/15534#139b3fe0-700c-4cdc-8b26-6982c12680c5