### PR TITLE
arch: arm: initialize variable

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -794,7 +794,7 @@ static inline z_arch_esf_t *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_ret
 	bool *nested_exc)
 {
 	bool alternative_state_exc = false;
-	z_arch_esf_t *ptr_esf;
+	z_arch_esf_t *ptr_esf = NULL;
 
 	*nested_exc = false;
 


### PR DESCRIPTION
there are several code paths where this variable could end up being
returned uninitialized.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>