### PR TITLE
doc-build.yml: Add west.yml to path filter

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -15,6 +15,7 @@ on:
     - 'tests/**'
     - '.known-issues/doc/**'
     - '**/Kconfig*'
+    - 'west.yml'
 
 jobs:
   build:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,6 +16,7 @@ on:
     - '.known-issues/doc/**'
     - '**/Kconfig*'
     - 'west.yml'
+    - '.github/workflows/doc-build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
We should be rebuilding the docs as part of CI whenever the manifest changes, because the documentation build system relies on the contents of modules for Kconfig documentation.

Without this, a broken module update could take down all of CI.