### PR TITLE
tests: mem_protect: disable some test cases for Cortex-M NonSecure builds, because they cannot run.

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -209,8 +209,16 @@ void test_string_nlen(void)
 	 * this address doesn't fault
 	 * Also skip this scenario for em_starterkit_7d, which won't generate
 	 * exceptions when unmapped address is accessed.
+	 *
+	 * In addition to the above, skip the scenario for Non-Secure Cortex-M
+	 * builds; Zephyr running in Non-Secure mode will generate SecureFault
+	 * if it attempts to access any address outside the image Flash or RAM
+	 * boundaries, and the program will hang.
 	 */
-#if !((defined(CONFIG_BOARD_NSIM) && defined(CONFIG_SOC_NSIM_SEM)) || defined(CONFIG_SOC_EMSK_EM7D))
+#if !((defined(CONFIG_BOARD_NSIM) && defined(CONFIG_SOC_NSIM_SEM)) || \
+	defined(CONFIG_SOC_EMSK_EM7D) || \
+	(defined(CONFIG_CPU_CORTEX_M) && \
+		defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)))
 	/* Try to blow up the kernel */
 	ret = string_nlen((char *)FAULTY_ADDRESS, BUF_SIZE, &err);
 	zassert_equal(err, -1, "nonsense string address did not fault");

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -184,9 +184,18 @@ static void test_disable_mmu_mpu(void)
 		);
 #endif
 #elif defined(CONFIG_ARM)
+#ifndef CONFIG_TRUSTED_EXECUTION_NONSECURE
 	set_fault(K_ERR_CPU_EXCEPTION);
 
 	arm_core_mpu_disable();
+#else
+	/* Disabling MPU from unprivileged code
+	 * generates BusFault which is not banked
+	 * between Security states. Do not execute
+	 * this scenario for Non-Secure Cortex-M.
+	 */
+	return;
+#endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE */
 #elif defined(CONFIG_ARC)
 	set_fault(K_ERR_CPU_EXCEPTION);
 


### PR DESCRIPTION
The PR disables a small set of test cases in syscall and userspace test suites because, by design, the test-cases can not be executed for Zephyr Non-Secure Cortex-M firmware images. The vast majority of the test cases in the aforementioned tests suites still run properly for Non-Secure COrtex-m builds.