### PR TITLE
Bluetooth: Mesh: Fix friendship counter increasing order

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -178,6 +178,7 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 		}
 	}
 
+	frnd->counter++;
 	frnd->subnet = NULL;
 	frnd->established = 0U;
 	frnd->pending_buf = 0U;
@@ -861,6 +862,10 @@ static void enqueue_offer(struct bt_mesh_friend *frnd, int8_t rssi)
 	off->queue_size = CONFIG_BT_MESH_FRIEND_QUEUE_SIZE,
 	off->sub_list_size = ARRAY_SIZE(frnd->sub_list),
 	off->rssi = rssi,
+
+	/* The Counter may be used in the later key update procedure. Therefore
+	 * we should postpone the update of counter until we terminated friendship.
+	 */
 	off->frnd_counter = sys_cpu_to_be16(frnd->counter);
 
 	buf = encode_friend_ctl(frnd, TRANS_CTL_OP_FRIEND_OFFER, &sdu);
@@ -872,8 +877,6 @@ static void enqueue_offer(struct bt_mesh_friend *frnd, int8_t rssi)
 	if (encrypt_friend_pdu(frnd, buf, true)) {
 		return;
 	}
-
-	frnd->counter++;
 
 	if (frnd->last) {
 		net_buf_unref(frnd->last);

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -297,6 +297,9 @@ static int send_friend_req(struct bt_mesh_lpn *lpn)
 		.src = bt_mesh_primary_addr(),
 		.xmit = POLL_XMIT,
 	};
+
+	lpn->lpn_counter++;
+
 	struct bt_mesh_ctl_friend_req req = {
 		.criteria    = LPN_CRITERIA,
 		.recv_delay  = LPN_RECV_DELAY,
@@ -558,8 +561,6 @@ int bt_mesh_lpn_friend_offer(struct bt_mesh_net_rx *rx,
 		return err;
 	}
 
-	lpn->lpn_counter++;
-
 	return 0;
 }
 
@@ -785,7 +786,7 @@ static void lpn_timeout(struct k_work *work)
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
 		}
-		lpn->lpn_counter++;
+
 		lpn_set_state(BT_MESH_LPN_ENABLED);
 		lpn->sent_req = 0U;
 		k_delayed_work_submit(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);


### PR DESCRIPTION
For Bluetooth Mesh, counter shall be increasing by one when
every try to establishing friendship.

Counter to be used when create friendship security material.
So this value shall be consist between friend and lpn.

Due to zephyr bluetooth mesh send previous counter, after that
it will automatically increase one, which will result in the
incorrect generation of friend key when key rephase.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>