### PR TITLE
Bluetooth: Mesh: Fix overflow of ivu_duration value

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -803,7 +803,8 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 
 static void ivu_refresh(struct k_work *work)
 {
-	bt_mesh.ivu_duration += BT_MESH_IVU_HOURS;
+	bt_mesh.ivu_duration = MIN(UINT8_MAX,
+	       bt_mesh.ivu_duration + BT_MESH_IVU_HOURS);
 
 	BT_DBG("%s for %u hour%s",
 	       atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) ?


### PR DESCRIPTION
Bluetooth Mesh require minimum limit time to enter iv update
state or return to iv nornal state.

For Zephyr bluetooth mesh implementation, use`ivu_duration`
type `uint8_t` to represent current time, but if the time is
more than 255 hours, there will be problems due to the
overflow of 8-bit unassigned variables.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>