### PR TITLE
scripts: gen_relocate_app.py: fix relocate on windows

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -192,6 +192,7 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
   set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
+  # using VERBATIM would be better, but this breaks the "--verbose" argument
   add_custom_command(
     OUTPUT ${MEM_RELOCATION_CODE} ${MEM_RELOCATION_LD}
     COMMAND
@@ -199,7 +200,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i '$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>'
+    -i "\"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\""
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -10,6 +10,7 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
   set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
+  # using VERBATIM would be better, but this breaks the "--verbose" argument
   add_custom_command(
     OUTPUT ${MEM_RELOCATION_CODE} ${MEM_RELOCATION_LD}
     COMMAND
@@ -17,7 +18,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i '$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>'
+    -i "\"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\""
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -395,7 +395,7 @@ def create_dict_wrt_mem():
     if args.input_rel_dict == '':
         sys.exit("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
     for line in args.input_rel_dict.split(';'):
-        mem_region, file_name = line.split(':')
+        mem_region, file_name = line.split(':', 1)
 
         file_name_list = glob.glob(file_name)
         if not file_name_list:


### PR DESCRIPTION
Windows file paths can contain ':' characters which are used by the
relocate script as a delimiter to MEM_REGION:FILE_PATH

Windows cmd treats single quotes as a regular character