### PR TITLE
intc: gic: Use SYS_INIT instead of custom init function

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/irq_init.c
+++ b/arch/arm/core/aarch32/cortex_a_r/irq_init.c
@@ -23,10 +23,7 @@ void z_arm_interrupt_init(void)
 	/*
 	 * Initialise interrupt controller.
 	 */
-#if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
-	/* Initialise the Generic Interrupt Controller (GIC) driver */
-	arm_gic_init();
-#else
+#ifdef CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER
 	/* Invoke SoC-specific interrupt controller initialisation */
 	z_soc_irq_init();
 #endif

--- a/arch/arm/core/aarch64/irq_init.c
+++ b/arch/arm/core/aarch64/irq_init.c
@@ -24,10 +24,7 @@
  */
 void z_arm64_interrupt_init(void)
 {
-#if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
-	/* Initialise the Generic Interrupt Controller (GIC) driver */
-	arm_gic_init();
-#else
+#ifdef CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER
 	/* Invoke SoC-specific interrupt controller initialisation */
 	z_soc_irq_init();
 #endif

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -196,8 +196,10 @@ static void gic_cpu_init(void)
 #define GIC_PARENT_IRQ 0
 #define GIC_PARENT_IRQ_PRI 0
 #define GIC_PARENT_IRQ_FLAGS 0
-int arm_gic_init(void)
+int arm_gic_init(const struct device *unused)
 {
+	ARG_UNUSED(unused);
+
 	/* Init of Distributor interface registers */
 	gic_dist_init();
 
@@ -206,3 +208,5 @@ int arm_gic_init(void)
 
 	return 0;
 }
+
+SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -275,8 +275,10 @@ static void gicv3_dist_init(void)
 }
 
 /* TODO: add arm_gic_secondary_init() for multicore support */
-int arm_gic_init(void)
+int arm_gic_init(const struct device *unused)
 {
+	ARG_UNUSED(unused);
+
 	gicv3_dist_init();
 
 	/* Fixme: populate each redistributor */
@@ -288,3 +290,5 @@ int arm_gic_init(void)
 
 	return 0;
 }
+
+SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/include/drivers/interrupt_controller/gic.h
+++ b/include/drivers/interrupt_controller/gic.h
@@ -278,13 +278,6 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
  */
 
 /**
- * @brief Initialise ARM GIC driver
- *
- * @return 0 if successful
- */
-int arm_gic_init(void);
-
-/**
  * @brief Enable interrupt
  *
  * @param irq interrupt ID


### PR DESCRIPTION
The GIC interrupt controller driver is using a custom init function called directly from the prep_c function. For consistency move that to use SYS_INIT.