### PR TITLE
CODEOWNERS: add codeowner for usb dfu class

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -562,6 +562,7 @@
 /subsys/testsuite/                        @nashif
 /subsys/timing/                           @nashif @dcpleung
 /subsys/usb/                              @jfischer-no @finikorg
+/subsys/usb/class/usb_dfu.c               @nvlsianpu
 /tests/                                   @nashif
 /tests/application_development/libcxx/    @pabigot
 /tests/arch/arm/                          @ioannisg @stephanosio


### PR DESCRIPTION
Added myself as USB DFU class code-owner.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>