### PR TITLE
drivers: wifi: esp: drop unused esp_socket members

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -140,10 +140,8 @@ struct esp_socket {
 	uint8_t flags;
 
 	/* socket info */
-	sa_family_t family;
 	enum net_sock_type type;
 	enum net_ip_protocol ip_proto;
-	struct sockaddr src;
 	struct sockaddr dst;
 
 	/* for +CIPRECVDATA */

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -24,21 +24,11 @@ LOG_MODULE_REGISTER(wifi_esp_offload);
 static int esp_bind(struct net_context *context, const struct sockaddr *addr,
 		    socklen_t addrlen)
 {
-	struct esp_socket *sock;
-
-	sock = (struct esp_socket *)context->offload_context;
-
-	sock->src.sa_family = addr->sa_family;
-
 	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->sa_family == AF_INET) {
-		net_ipaddr_copy(&net_sin(&sock->src)->sin_addr,
-				&net_sin(addr)->sin_addr);
-		net_sin(&sock->src)->sin_port = net_sin(addr)->sin_port;
-	} else {
-		return -EAFNOSUPPORT;
+		return 0;
 	}
 
-	return 0;
+	return -EAFNOSUPPORT;
 }
 
 static int esp_listen(struct net_context *context, int backlog)
@@ -662,7 +652,6 @@ static int esp_get(sa_family_t family,
 	k_work_init(&sock->send_work, esp_send_work);
 	k_work_init(&sock->recv_work, esp_recv_work);
 	k_work_init(&sock->recvdata_work, esp_recvdata_work);
-	sock->family = family;
 	sock->type = type;
 	sock->ip_proto = ip_proto;
 	sock->context = *context;


### PR DESCRIPTION
No reason to occupy RAM if there is no use of stored information.