### PR TITLE
drivers: wifi: esp: calculate size of each command buffer

### DIFF
--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -48,8 +48,9 @@ static int esp_listen(struct net_context *context, int backlog)
 
 static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 {
+	char connect_msg[sizeof("AT+CIPSTART=0,\"TCP\",\"\",65535,7200") +
+			 NET_IPV4_ADDR_LEN];
 	char addr_str[NET_IPV4_ADDR_LEN];
-	char connect_msg[100];
 	int ret;
 
 	if (!esp_flags_are_set(dev, EDF_STA_CONNECTED)) {
@@ -201,7 +202,10 @@ MODEM_CMD_DEFINE(on_cmd_send_fail)
 
 static int _sock_send(struct esp_data *dev, struct esp_socket *sock)
 {
-	char cmd_buf[64], addr_str[NET_IPV4_ADDR_LEN];
+	char cmd_buf[sizeof("AT+CIPSEND=0,,\"\",") +
+		     sizeof(STRINGIFY(ESP_MTU)) - 1 +
+		     NET_IPV4_ADDR_LEN + sizeof("65535") - 1];
+	char addr_str[NET_IPV4_ADDR_LEN];
 	int ret, write_len, pkt_len;
 	struct net_buf *frag;
 	static const struct modem_cmd cmds[] = {
@@ -492,7 +496,7 @@ static void esp_recvdata_work(struct k_work *work)
 	struct esp_socket *sock;
 	struct esp_data *dev;
 	int len = CIPRECVDATA_MAX_LEN, ret;
-	char cmd[32];
+	char cmd[sizeof("AT+CIPRECVDATA=0,"STRINGIFY(CIPRECVDATA_MAX_LEN))];
 	static const struct modem_cmd cmds[] = {
 		MODEM_CMD_DIRECT(_CIPRECVDATA, on_cmd_ciprecvdata),
 	};

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -75,7 +75,7 @@ void esp_socket_init(struct esp_data *data)
 void esp_socket_close(struct esp_socket *sock)
 {
 	struct esp_data *dev = esp_socket_to_dev(sock);
-	char cmd_buf[16];
+	char cmd_buf[sizeof("AT+CIPCLOSE=0")];
 	int ret;
 
 	snprintk(cmd_buf, sizeof(cmd_buf), "AT+CIPCLOSE=%d",


### PR DESCRIPTION
Calculate size based on the real message, instead of assuming some
arbitrary size. This consumes slightly less stack space, but more
importantly gives an idea what has been taken into account when
calculating the size.