### PR TITLE
drivers: wifi: esp: unify log level

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -6,9 +6,8 @@
 
 #define DT_DRV_COMPAT espressif_esp
 
-#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_esp);
+LOG_MODULE_REGISTER(wifi_esp, CONFIG_WIFI_LOG_LEVEL);
 
 #include <kernel.h>
 #include <ctype.h>

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_esp_offload);
+LOG_MODULE_REGISTER(wifi_esp_offload, CONFIG_WIFI_LOG_LEVEL);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -9,7 +9,7 @@
 #include "esp.h"
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(wifi_esp);
+LOG_MODULE_DECLARE(wifi_esp, CONFIG_WIFI_LOG_LEVEL);
 
 /* esp_data->mtx_sock should be held */
 struct esp_socket *esp_socket_get(struct esp_data *data)


### PR DESCRIPTION
2 (out of 3) components used CONFIG_WIFI_LOG_LEVEL, while the last one
didn't specify explicit log level. Always use CONFIG_WIFI_LOG_LEVEL in
all components.

While at it switch to LOG_MODULE_REGISTER(<module>, <log_level>), which
is a more compact way to define log level.