### PR TITLE
drivers: wifi: esp: don't queue send after socket connect

### DIFF
--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -150,10 +150,6 @@ static int esp_connect(struct net_context *context,
 
 	ret = _sock_connect(dev, sock);
 
-	if (esp_socket_connected(sock) && sock->tx_pkt) {
-		k_work_submit_to_queue(&dev->workq, &sock->send_work);
-	}
-
 	if (ret != -ETIMEDOUT && cb) {
 		cb(context, ret, user_data);
 	}


### PR DESCRIPTION
After a synchronous (timeout > 0) connection attempt was made, it was
being checked if there is some packet to be sent. If positive, then a
send work was queued.

This behavior makes little sense, as TCP connection is not even
considered established at this point (from net_context perspective) if
function has not returned yet. Additionally it differs from
asynchronous (timeout == 0) connection attempt. In case of UDP (and
calling esp_connect() from esp_sendto()) sock->tx_pkt is assured to be
NULL. Drop this piece of code as it doesn't seem to be justified.