### PR TITLE
cmake: use the toolchain path, id and version as extended signature.

### DIFF
--- a/cmake/target_toolchain.cmake
+++ b/cmake/target_toolchain.cmake
@@ -52,14 +52,3 @@ include(${TOOLCHAIN_ROOT}/cmake/compiler/${COMPILER}/target.cmake OPTIONAL)
 include(${TOOLCHAIN_ROOT}/cmake/linker/${LINKER}/target.cmake OPTIONAL)
 include(${CMAKE_CURRENT_LIST_DIR}/bintools/bintools_template.cmake)
 include(${TOOLCHAIN_ROOT}/cmake/bintools/${BINTOOLS}/target.cmake OPTIONAL)
-
-# Uniquely identify the toolchain wrt. it's capabilities.
-#
-# What we are looking for, is a signature definition that is defined
-# like this:
-#  * Toolchains with the same signature will always support the same set
-#    of flags.
-# It is not clear how this signature should be constructed. The
-# strategy chosen is to md5sum the CC binary.
-file(MD5 ${CMAKE_C_COMPILER} CMAKE_C_COMPILER_MD5_SUM)
-set(TOOLCHAIN_SIGNATURE ${CMAKE_C_COMPILER_MD5_SUM})

--- a/cmake/target_toolchain_flags.cmake
+++ b/cmake/target_toolchain_flags.cmake
@@ -1,3 +1,29 @@
+# Uniquely identify the toolchain wrt. it's capabilities.
+#
+# What we are looking for, is a signature definition that is defined
+# like this:
+#  * The MD5 sum of the compiler itself. A MD5 checksum is taken of the content
+#    after symlinks are resolved. This ensure that if the content changes, then
+#    the MD5 will also change (as example toolchain upgrade in same folder)
+#  * The CMAKE_C_COMPILER itself. This may be a symlink, but it ensures that
+#    multiple symlinks pointing to same executable will generate different
+#    signatures, as example: clang, gcc, arm-zephyr-eabi-gcc, links pointing to
+#    ccache will generate unique signatures
+#  * CMAKE_C_COMPILER_ID is taking the CMake compiler id for extra signature.
+#  * CMAKE_C_COMPILER_VERSION will ensure that even when using the previous
+#    methods, where an upgraded compiler could have same signature due to ccache
+#    usage and symbolic links, then the upgraded compiler will have new version
+#    and thus generate a new signature.
+#
+#  Toolchains with the same signature will always support the same set of flags.
+#
+file(MD5 ${CMAKE_C_COMPILER} CMAKE_C_COMPILER_MD5_SUM)
+set(TOOLCHAIN_SIGNATURE ${CMAKE_C_COMPILER_MD5_SUM})
+
+# Extend the CMAKE_C_COMPILER_MD5_SUM with the compiler signature.
+string(MD5 COMPILER_SIGNATURE ${CMAKE_C_COMPILER}_${CMAKE_C_COMPILER_ID}_${CMAKE_C_COMPILER_VERSION})
+set(TOOLCHAIN_SIGNATURE ${TOOLCHAIN_SIGNATURE}_${COMPILER_SIGNATURE})
+
 # Custom targets for compiler and linker flags.
 add_custom_target(asm)
 add_custom_target(compiler)


### PR DESCRIPTION
Fixes: #30531

Now using MD5 sum of CMAKE_C_COMPILER (path), CMAKE_C_COMPILER_ID and
CMAKE_C_COMPILER_VERSION variables as part of the TOOLCHAIN_SIGNATURE.

Moved MD5 calculation of executable into
cmake/target_toolchain_flags.cmake to have common location, as
CMAKE_C_COMPILER_ID and CMAKE_C_COMPILER_VERSION are not available until
project() has executed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>