### PR TITLE
drivers: pwm: fix nrfx pwm device definition

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -414,7 +414,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
 	};								      \
 	PWM_NRFX_PM_CONTROL(idx)					      \
-	DEVICE_DT_INST_DEFINE(idx,					      \
+	DEVICE_DT_DEFINE(PWM(idx),					      \
 		      pwm_nrfx_init, pwm_##idx##_nrfx_pm_control,	      \
 		      &pwm_nrfx_##idx##_data,				      \
 		      &pwm_nrfx_##idx##config,				      \


### PR DESCRIPTION
Driver does not use the numeric index directly to identify devicetree instance nodes.

Fixes #30638