### PR TITLE
drivers: dac: Enable for STM32H7 (single core) series

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -657,6 +657,15 @@
 			#io-channel-cells = <1>;
 		};
 
+		dac1: dac@40007400 {
+			compatible = "st,stm32-dac";
+			reg = <0x40007400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x20000000>;
+			status = "disabled";
+			label = "DAC_1";
+			#io-channel-cells = <1>;
+		};
+
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma";
 			#dma-cells = <4>;


### PR DESCRIPTION
Add DAC nodes to devicetree

Signed-off-by: los <los@magnatek.dk>