### PR TITLE
Bluetooth: Document and validate disconnect reason according to spec allowed reasons.

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -476,6 +476,18 @@ int bt_conn_le_phy_update(struct bt_conn *conn,
  *  Disconnect an active connection with the specified reason code or cancel
  *  pending outgoing connection.
  *
+ *  The disconnect reason for a normal disconnect should be:
+ *  @ref BT_HCI_ERR_REMOTE_USER_TERM_CONN.
+ *
+ *  The following disconnect reasons are accepted:
+ *   - @ref BT_HCI_ERR_AUTH_FAIL
+ *   - @ref BT_HCI_ERR_REMOTE_USER_TERM_CONN
+ *   - @ref BT_HCI_ERR_REMOTE_LOW_RESOURCES
+ *   - @ref BT_HCI_ERR_REMOTE_POWER_OFF
+ *   - @ref BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
+ *   - @ref BT_HCI_ERR_PAIRING_NOT_SUPPORTED
+ *   - @ref BT_HCI_ERR_UNACCEPT_CONN_PARAM
+ *
  *  @param conn Connection to disconnect.
  *  @param reason Reason code for the disconnection.
  *

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -410,9 +410,29 @@ uint8_t ll_chm_get(uint16_t handle, uint8_t *chm)
 	return 0;
 }
 
+static bool is_valid_disconnect_reason(uint8_t reason)
+{
+	switch (reason) {
+	case BT_HCI_ERR_AUTH_FAIL:
+	case BT_HCI_ERR_REMOTE_USER_TERM_CONN:
+	case BT_HCI_ERR_REMOTE_LOW_RESOURCES:
+	case BT_HCI_ERR_REMOTE_POWER_OFF:
+	case BT_HCI_ERR_UNSUPP_REMOTE_FEATURE:
+	case BT_HCI_ERR_PAIRING_NOT_SUPPORTED:
+	case BT_HCI_ERR_UNACCEPT_CONN_PARAM:
+		return true;
+	default:
+		return false;
+	}
+}
+
 uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 {
 	struct ll_conn *conn;
+
+	if (!is_valid_disconnect_reason(reason)) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
 
 	conn = ll_connected_get(handle);
 	if (!conn) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1539,7 +1539,7 @@ int bt_hci_disconnect(uint16_t handle, uint8_t reason)
 	disconn->handle = sys_cpu_to_le16(handle);
 	disconn->reason = reason;
 
-	return bt_hci_cmd_send(BT_HCI_OP_DISCONNECT, buf);
+	return bt_hci_cmd_send_sync(BT_HCI_OP_DISCONNECT, buf, NULL);
 }
 
 static void hci_disconn_complete_prio(struct net_buf *buf)

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -113,7 +113,8 @@ static uint8_t notify_func(struct bt_conn *conn,
 		int err;
 
 		/* Disconnect before actually passing */
-		err = bt_conn_disconnect(default_conn, BT_HCI_ERR_SUCCESS);
+		err = bt_conn_disconnect(default_conn,
+					 BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		if (err) {
 			FAIL("Disconnection failed (err %d)\n", err);
 			return BT_GATT_ITER_STOP;

--- a/west.yml
+++ b/west.yml
@@ -136,7 +136,7 @@ manifest:
       path: modules/hal/xtensa
     - name: edtt
       path: tools/edtt
-      revision: c39888ff74acf421eeff9a7514fa9b172c3373f7
+      revision: b209a60ba3ad8887a7f35f67c0372c84a28b9b9b
     - name: trusted-firmware-m
       path: modules/tee/tfm
       revision: 4544ab9fc4d5305ae5de97c73a9356ef0f342f7a


### PR DESCRIPTION
Document the disconnect reasons that is allowed in the disconnect
command.

Return the error code from the disconnect command to the application
when an invalid disconnect reason has been provided.

Validate the disconnect reason in the disconnect command, according
to the the core specification.

7.1.6 Disconnect command:
Authentication Failure error code (0x05), Other End Terminated Connec-
tion error codes (0x13 to 0x15), Unsupported Remote Feature error code
(0x1A), Pairing with Unit Key Not Supported error code (0x29) and Unac-
ceptable Connection Parameters error code (0x3B).
