### PR TITLE
x86: Fix compiler warning in z_x86_dump_mmu_flags

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -686,8 +686,8 @@ void z_x86_pentry_get(int *paging_level, pentry_t *val, pentry_t *ptables,
  */
 void z_x86_dump_mmu_flags(pentry_t *ptables, void *virt)
 {
-	pentry_t entry;
-	int level;
+	pentry_t entry = 0;
+	int level = 0;
 
 	pentry_get(&level, &entry, ptables, virt);
 


### PR DESCRIPTION
Fix compiler warnings associated with 'level' and 'entry' variables
'may be used uninitialized in this function'

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>