### PR TITLE
boards: arm: arty: Enable gpio is a feature on board yaml

### DIFF
--- a/boards/arm/arty/arty_a7_arm_designstart_m1.yaml
+++ b/boards/arm/arty/arty_a7_arm_designstart_m1.yaml
@@ -11,3 +11,4 @@ flash: 64
 supported:
   - flash
   - spi
+  - gpio

--- a/boards/arm/arty/arty_a7_arm_designstart_m3.yaml
+++ b/boards/arm/arty/arty_a7_arm_designstart_m3.yaml
@@ -11,3 +11,4 @@ flash: 32
 supported:
   - flash
   - spi
+  - gpio


### PR DESCRIPTION
There is a GPIO driver for use with arty so enable the GPIO feature in
the board yaml to get some testing of it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>