### PR TITLE
drivers: i2c: i2c_sifive: Fix build issue

### DIFF
--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -329,7 +329,7 @@ static struct i2c_driver_api i2c_sifive_api = {
 		.f_sys = DT_INST_PROP(n, input_frequency), \
 		.f_bus = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	DEVICE_DT_INST_DEFINE(n \
+	DEVICE_DT_INST_DEFINE(n, \
 			    i2c_sifive_init, \
 			    device_pm_control_nop, \
 			    NULL, \


### PR DESCRIPTION
Add a missing ',' in DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>