### PR TITLE
Bluetooth: host: Fix crash when receiving response after ATT timeout

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -283,6 +283,11 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 
 	atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
 
+	if (!att) {
+		BT_DBG("Ignore sent on detached ATT chan");
+		return;
+	}
+
 	/* Process pending requests first since they require a response they
 	 * can only be processed one at time while if other queues were
 	 * processed before they may always contain a buffer starving the
@@ -2432,6 +2437,11 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	BT_DBG("Received ATT chan %p code 0x%02x len %zu", att_chan, hdr->code,
 	       net_buf_frags_len(buf));
 
+	if (!att_chan->att) {
+		BT_DBG("Ignore recv on detached ATT chan");
+		return 0;
+	}
+
 	for (i = 0, handler = NULL; i < ARRAY_SIZE(handlers); i++) {
 		if (hdr->code == handlers[i].op) {
 			handler = &handlers[i];
@@ -2689,6 +2699,11 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 	BT_DBG("chan %p conn %p handle %u sec_level 0x%02x status 0x%02x", ch,
 	       conn, conn->handle, conn->sec_level, hci_status);
 
+	if (!att_chan->att) {
+		BT_DBG("Ignore encrypt change on detached ATT chan");
+		return;
+	}
+
 	/*
 	 * If status (HCI status of security procedure) is non-zero, notify
 	 * outstanding request about security failure.
@@ -2730,6 +2745,11 @@ static void bt_att_status(struct bt_l2cap_chan *ch, atomic_t *status)
 	BT_DBG("chan %p status %p", ch, status);
 
 	if (!atomic_test_bit(status, BT_L2CAP_STATUS_OUT)) {
+		return;
+	}
+
+	if (!chan->att) {
+		BT_DBG("Ignore status on detached ATT chan");
 		return;
 	}
 


### PR DESCRIPTION
Fix crash in ATT when the response for a request is received after
the ATT timeout has fired and the ATT channel has been detached.
Add similar handling for all ATT channel operations.

Discovered why reproducing the GATT indication timeout issue described here:
https://github.com/zephyrproject-rtos/zephyr/issues/28685#issuecomment-741664883

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>