### PR TITLE
drivers: uart: Convert drivers to new DT device macros

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -351,8 +351,8 @@ static const struct leuart_gecko_config leuart_gecko_0_config = {
 
 static struct leuart_gecko_data leuart_gecko_0_data;
 
-DEVICE_AND_API_INIT(leuart_0, DT_INST_LABEL(0),
-		    &leuart_gecko_init, &leuart_gecko_0_data,
+DEVICE_DT_INST_DEFINE(0, &leuart_gecko_init,
+		    device_pm_control_nop, &leuart_gecko_0_data,
 		    &leuart_gecko_0_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);
@@ -362,7 +362,7 @@ static void leuart_gecko_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    leuart_gecko_isr, DEVICE_GET(leuart_0), 0);
+		    leuart_gecko_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }
@@ -404,8 +404,8 @@ static const struct leuart_gecko_config leuart_gecko_1_config = {
 
 static struct leuart_gecko_data leuart_gecko_1_data;
 
-DEVICE_AND_API_INIT(leuart_1, DT_INST_LABEL(1),
-		    &leuart_gecko_init, &leuart_gecko_1_data,
+DEVICE_DT_INST_DEFINE(1, &leuart_gecko_init,
+		    device_pm_control_nop, &leuart_gecko_1_data,
 		    &leuart_gecko_1_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);
@@ -415,7 +415,7 @@ static void leuart_gecko_config_func_1(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
-		    leuart_gecko_isr, DEVICE_GET(leuart_1), 0);
+		    leuart_gecko_isr, DEVICE_DT_INST_GET(1), 0);
 
 	irq_enable(DT_INST_IRQN(1));
 }

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -482,9 +482,9 @@ static const struct uart_driver_api apbuart_driver_api = {
 		.usefifo        = 0,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(uart_apbuart_##index,			\
-			    DT_INST_LABEL(index),			\
+	DEVICE_DT_INST_DEFINE(index,					\
 			    &apbuart_init,				\
+			    device_pm_control_nop,			\
 			    &apbuart##index##_data,			\
 			    &apbuart##index##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -556,7 +556,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 				DT_INST_IRQ(n, priority),		\
 				uart_cc13xx_cc26xx_isr,			\
-				DEVICE_GET(uart_cc13xx_cc26xx_##n),	\
+				DEVICE_DT_INST_GET(n),			\
 				0);					\
 		irq_enable(DT_INST_IRQN(n));				\
 		/* Causes an initial TX ready INT when TX INT enabled */\
@@ -572,18 +572,11 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 #define UART_CC13XX_CC26XX_DEVICE_DEFINE(n)				     \
-	DEVICE_DEFINE(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),		     \
+	DEVICE_DT_INST_DEFINE(n,					     \
 		uart_cc13xx_cc26xx_init_##n,				     \
 		uart_cc13xx_cc26xx_pm_control,				     \
 		&uart_cc13xx_cc26xx_data_##n, &uart_cc13xx_cc26xx_config_##n,\
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	     \
-		&uart_cc13xx_cc26xx_driver_api)
-
-#define UART_CC13XX_CC26XX_DEVICE_API_INIT(n)				     \
-	DEVICE_AND_API_INIT(uart_cc13xx_cc26xx_##n, DT_INST_LABEL(n),	     \
-		uart_cc13xx_cc26xx_init_##n, &uart_cc13xx_cc26xx_data_##n,   \
-		&uart_cc13xx_cc26xx_config_##n, PRE_KERNEL_1,		     \
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			     \
 		&uart_cc13xx_cc26xx_driver_api)
 
 #ifdef CONFIG_PM_DEVICE
@@ -625,7 +618,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 
 
 #define UART_CC13XX_CC26XX_INIT(n)				     \
-	DEVICE_DECLARE(uart_cc13xx_cc26xx_##n);			     \
+	DEVICE_DT_INST_DECLARE(n);				     \
 								     \
 	UART_CC13XX_CC26XX_INIT_FUNC(n);			     \
 								     \

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -32,7 +32,7 @@ struct uart_cc32xx_dev_data_t {
 #define PRIME_CHAR '\r'
 
 /* Forward decls: */
-DEVICE_DECLARE(uart_cc32xx_0);
+DEVICE_DT_INST_DECLARE(0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cc32xx_isr(const struct device *dev);
@@ -79,7 +79,7 @@ static int uart_cc32xx_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    uart_cc32xx_isr, DEVICE_GET(uart_cc32xx_0),
+		    uart_cc32xx_isr, DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 
@@ -316,8 +316,8 @@ static const struct uart_driver_api uart_cc32xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-DEVICE_AND_API_INIT(uart_cc32xx_0, DT_INST_LABEL(0),
-		    uart_cc32xx_init, &uart_cc32xx_dev_data_0,
+DEVICE_DT_INST_DEFINE(0, uart_cc32xx_init,
+		    device_pm_control_nop, &uart_cc32xx_dev_data_0,
 		    &uart_cc32xx_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_cc32xx_driver_api);

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -481,9 +481,9 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
 			.device = DT_INST_REG_ADDR(0),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_0,
-		    DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &uart_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -496,7 +496,7 @@ static void uart_cmsdk_apb_irq_config_func_0(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 }
@@ -506,14 +506,14 @@ static void uart_cmsdk_apb_irq_config_func_0(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx, irq),
 		    DT_INST_IRQ_BY_NAME(0, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx, irq),
 		    DT_INST_IRQ_BY_NAME(0, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rx, irq));
 }
@@ -546,9 +546,9 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
 			.device = DT_INST_REG_ADDR(1),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_1,
-		    DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 		    &uart_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -561,7 +561,7 @@ static void uart_cmsdk_apb_irq_config_func_1(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQN(1));
 }
@@ -571,14 +571,14 @@ static void uart_cmsdk_apb_irq_config_func_1(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx, irq),
 		    DT_INST_IRQ_BY_NAME(1, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx, irq),
 		    DT_INST_IRQ_BY_NAME(1, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, rx, irq));
 }
@@ -611,9 +611,9 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
 			.device = DT_INST_REG_ADDR(2),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_2,
-		    DT_INST_LABEL(2),
+DEVICE_DT_INST_DEFINE(2,
 		    &uart_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -626,7 +626,7 @@ static void uart_cmsdk_apb_irq_config_func_2(const struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_2_IRQ,
 		    DT_INST_IRQ_BY_NAME(2, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_DT_INST_GET(2),
 		    0);
 	irq_enable(CMSDK_APB_UART_2_IRQ);
 }
@@ -636,14 +636,14 @@ static void uart_cmsdk_apb_irq_config_func_2(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, tx, irq),
 		    DT_INST_IRQ_BY_NAME(2, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_DT_INST_GET(2),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(2, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(2, rx, irq),
 		    DT_INST_IRQ_BY_NAME(2, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_2),
+		    DEVICE_DT_INST_GET(2),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(2, rx, irq));
 }
@@ -676,9 +676,9 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
 			.device = DT_INST_REG_ADDR(3),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_3,
-		    DT_INST_LABEL(3),
+DEVICE_DT_INST_DEFINE(3,
 		    &uart_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -691,7 +691,7 @@ static void uart_cmsdk_apb_irq_config_func_3(const struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_3_IRQ,
 		    DT_INST_IRQ_BY_NAME(3, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_DT_INST_GET(3),
 		    0);
 	irq_enable(CMSDK_APB_UART_3_IRQ);
 }
@@ -701,14 +701,14 @@ static void uart_cmsdk_apb_irq_config_func_3(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, tx, irq),
 		    DT_INST_IRQ_BY_NAME(3, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_DT_INST_GET(3),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(3, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(3, rx, irq),
 		    DT_INST_IRQ_BY_NAME(3, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_3),
+		    DEVICE_DT_INST_GET(3),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(3, rx, irq));
 }
@@ -741,9 +741,9 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
 			.device = DT_INST_REG_ADDR(4),},
 };
 
-DEVICE_AND_API_INIT(uart_cmsdk_apb_4,
-		    DT_INST_LABEL(4),
+DEVICE_DT_INST_DEFINE(4,
 		    &uart_cmsdk_apb_init,
+		    device_pm_control_nop,
 		    &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -756,7 +756,7 @@ static void uart_cmsdk_apb_irq_config_func_4(const struct device *dev)
 	IRQ_CONNECT(CMSDK_APB_UART_4_IRQ,
 		    DT_INST_IRQ_BY_NAME(4, priority, irq),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_DT_INST_GET(4),
 		    0);
 	irq_enable(CMSDK_APB_UART_4_IRQ);
 }
@@ -766,14 +766,14 @@ static void uart_cmsdk_apb_irq_config_func_4(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, tx, irq),
 		    DT_INST_IRQ_BY_NAME(4, tx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_DT_INST_GET(4),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(4, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(4, rx, irq),
 		    DT_INST_IRQ_BY_NAME(4, rx, priority),
 		    uart_cmsdk_apb_isr,
-		    DEVICE_GET(uart_cmsdk_apb_4),
+		    DEVICE_DT_INST_GET(4),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(4, rx, irq));
 }

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -483,7 +483,7 @@ static const struct uart_driver_api uart_esp32_api = {
 		IRQ_CONNECT(INST_##idx##_ESPRESSIF_ESP32_UART_IRQ_0,	     \
 			    1,						     \
 			    uart_esp32_isr,				     \
-			    DEVICE_GET(uart_esp32_##idx),		     \
+			    DEVICE_DT_INST_GET(idx),			     \
 			    0);						     \
 		irq_enable(INST_##idx##_ESPRESSIF_ESP32_UART_IRQ_0);	     \
 	}
@@ -540,9 +540,9 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 	}								       \
 };									       \
 									       \
-DEVICE_AND_API_INIT(uart_esp32_##idx,					       \
-		    DT_INST_LABEL(idx),		       \
+DEVICE_DT_INST_DEFINE(idx,						       \
 		    uart_esp32_init,					       \
+		    device_pm_control_nop,				       \
 		    &uart_esp32_data_##idx,				       \
 		    &uart_esp32_cfg_port_##idx,				       \
 		    PRE_KERNEL_1,					       \

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -425,10 +425,10 @@ static const struct uart_driver_api uart_gecko_driver_api = {
 	{								       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(idx, rx, irq),		       \
 			    DT_INST_IRQ_BY_NAME(idx, rx, priority),	       \
-			    uart_gecko_isr, DEVICE_GET(uart_##idx), 0);	       \
+			    uart_gecko_isr, DEVICE_DT_INST_GET(idx), 0);       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(idx, tx, irq),		       \
 			    DT_INST_IRQ_BY_NAME(idx, tx, priority),	       \
-			    uart_gecko_isr, DEVICE_GET(uart_##idx), 0);	       \
+			    uart_gecko_isr, DEVICE_DT_INST_GET(idx), 0);       \
 									       \
 		irq_enable(DT_INST_IRQ_BY_NAME(idx, rx, irq));		       \
 		irq_enable(DT_INST_IRQ_BY_NAME(idx, tx, irq));		       \
@@ -546,8 +546,8 @@ static const struct uart_driver_api uart_gecko_driver_api = {
 									       \
 	static struct uart_gecko_data uart_gecko_data_##idx;		       \
 									       \
-	DEVICE_AND_API_INIT(uart_##idx, DT_INST_LABEL(idx),		       \
-			    &uart_gecko_init, &uart_gecko_data_##idx,	       \
+	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, 			       \
+			    device_pm_control_nop, &uart_gecko_data_##idx,     \
 			    &uart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \
 			    &uart_gecko_driver_api);			       \
@@ -570,10 +570,10 @@ DT_INST_FOREACH_STATUS_OKAY(GECKO_UART_INIT)
 	{								       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(idx, rx, irq),		       \
 			    DT_INST_IRQ_BY_NAME(idx, rx, priority),	       \
-			    uart_gecko_isr, DEVICE_GET(usart_##idx), 0);       \
+			    uart_gecko_isr, DEVICE_DT_INST_GET(idx), 0);       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(idx, tx, irq),		       \
 			    DT_INST_IRQ_BY_NAME(idx, tx, priority),	       \
-			    uart_gecko_isr, DEVICE_GET(usart_##idx), 0);       \
+			    uart_gecko_isr, DEVICE_DT_INST_GET(idx), 0);       \
 									       \
 		irq_enable(DT_INST_IRQ_BY_NAME(idx, rx, irq));		       \
 		irq_enable(DT_INST_IRQ_BY_NAME(idx, tx, irq));		       \
@@ -604,8 +604,8 @@ DT_INST_FOREACH_STATUS_OKAY(GECKO_UART_INIT)
 									       \
 	static struct uart_gecko_data usart_gecko_data_##idx;		       \
 									       \
-	DEVICE_AND_API_INIT(usart_##idx, DT_INST_LABEL(idx),		       \
-			    &uart_gecko_init, &usart_gecko_data_##idx,	       \
+	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, device_pm_control_nop,    \
+			    &usart_gecko_data_##idx,			       \
 			    &usart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \
 			    &uart_gecko_driver_api);			       \

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -297,7 +297,7 @@ static const struct uart_driver_api uart_imx_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 				DT_INST_IRQ(n, priority),		\
 				uart_imx_isr,				\
-				DEVICE_GET(uart_##n), 0);		\
+				DEVICE_DT_INST_GET(n), 0);		\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 #define UART_IMX_IRQ_CFG_FUNC_INIT(n)					\
@@ -316,7 +316,7 @@ static const struct uart_driver_api uart_imx_driver_api = {
 									\
 	static const struct imx_uart_config imx_uart_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n), &uart_imx_init,	\
+	DEVICE_DT_INST_DEFINE(n, &uart_imx_init, device_pm_control_nop,	\
 			&imx_uart_##n##_data, &imx_uart_##n##_config,	\
 			PRE_KERNEL_1,					\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -317,8 +317,9 @@ static const struct uart_liteuart_device_config uart_liteuart_dev_cfg_0 = {
 	.baud_rate	= DT_INST_PROP(0, current_speed)
 };
 
-DEVICE_AND_API_INIT(uart_liteuart_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		uart_liteuart_init,
+		device_pm_control_nop,
 		&uart_liteuart_data_0, &uart_liteuart_dev_cfg_0,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		(void *)&uart_liteuart_driver_api);
@@ -329,7 +330,7 @@ static int uart_liteuart_init(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	IRQ_CONNECT(UART_IRQ, DT_INST_IRQ(0, priority),
-			liteuart_uart_irq_handler, DEVICE_GET(uart_liteuart_0),
+			liteuart_uart_irq_handler, DEVICE_DT_INST_GET(0),
 			0);
 	irq_enable(UART_IRQ);
 #endif

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -374,13 +374,13 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, status, irq),	\
 			    DT_INST_IRQ_BY_NAME(n, status, priority),	\
-			    uart_mcux_isr, DEVICE_GET(uart_##n), 0);	\
+			    uart_mcux_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_NAME(n, status, irq));	\
 									\
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, error, irq),		\
 			    DT_INST_IRQ_BY_NAME(n, error, priority),	\
-			    uart_mcux_isr, DEVICE_GET(uart_##n), 0);	\
+			    uart_mcux_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_NAME(n, error, irq));		\
 	}
@@ -410,8 +410,9 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 									\
 	static const struct uart_mcux_config uart_mcux_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &uart_mcux_init,				\
+			    device_pm_control_nop,			\
 			    &uart_mcux_##n##_data,			\
 			    &uart_mcux_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -304,7 +304,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
-			    mcux_flexcomm_isr, DEVICE_GET(uart_##n), 0);\
+			    mcux_flexcomm_isr, DEVICE_DT_INST_GET(n), 0);\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
@@ -336,8 +336,9 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {	\
 									\
 	static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_flexcomm_init,			\
+			    device_pm_control_nop,			\
 			    &mcux_flexcomm_##n##_data,			\
 			    &mcux_flexcomm_##n##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -279,7 +279,7 @@ static const struct uart_driver_api mcux_iuart_driver_api = {
 	do {								\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
-			    mcux_iuart_isr, DEVICE_GET(uart_##n), 0);	\
+			    mcux_iuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
 	} while (0)
@@ -317,8 +317,9 @@ static const struct mcux_iuart_config mcux_iuart_##n##_config = {	\
 									\
 	static const struct mcux_iuart_config mcux_iuart_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_iuart_init,				\
+			    device_pm_control_nop,			\
 			    &mcux_iuart_##n##_data,			\
 			    &mcux_iuart_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -291,7 +291,7 @@ static const struct uart_driver_api mcux_lpsci_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
-			    mcux_lpsci_isr, DEVICE_GET(uart_##n), 0);	\
+			    mcux_lpsci_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
@@ -321,8 +321,9 @@ static const struct mcux_lpsci_config mcux_lpsci_##n##_config = {	\
 									\
 	static const struct mcux_lpsci_config mcux_lpsci_##n##_config;	\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_lpsci_init,				\
+			    device_pm_control_nop,			\
 			    &mcux_lpsci_##n##_data,			\
 			    &mcux_lpsci_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -403,7 +403,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 	do {								\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
-			    mcux_lpuart_isr, DEVICE_GET(uart_##n), 0);	\
+			    mcux_lpuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
 	} while (0)
@@ -441,8 +441,9 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {	\
 									\
 	static const struct mcux_lpuart_config mcux_lpuart_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_lpuart_init,				\
+			    device_pm_control_nop,			\
 			    &mcux_lpuart_##n##_data,			\
 			    &mcux_lpuart_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -408,8 +408,8 @@ static const struct uart_miv_device_config uart_miv_dev_cfg_0 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_miv_0, DT_INST_LABEL(0),
-		    uart_miv_init, &uart_miv_data_0, &uart_miv_dev_cfg_0,
+DEVICE_DT_INST_DEFINE(0, uart_miv_init, device_pm_control_nop,
+		    &uart_miv_data_0, &uart_miv_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_miv_driver_api);
 

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -33,7 +33,7 @@ struct uart_msp432p4xx_dev_data_t {
 #define DEV_DATA(dev) \
 	((struct uart_msp432p4xx_dev_data_t * const)(dev)->data)
 
-DEVICE_DECLARE(uart_msp432p4xx_0);
+DEVICE_DT_INST_DECLARE(0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_msp432p4xx_isr(const struct device *dev);
@@ -148,7 +148,7 @@ static int uart_msp432p4xx_init(const struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	IRQ_CONNECT(DT_INST_IRQN(0),
 			DT_INST_IRQ(0, priority),
-			uart_msp432p4xx_isr, DEVICE_GET(uart_msp432p4xx_0),
+			uart_msp432p4xx_isr, DEVICE_DT_INST_GET(0),
 			0);
 	irq_enable(DT_INST_IRQN(0));
 
@@ -360,8 +360,9 @@ static const struct uart_driver_api uart_msp432p4xx_driver_api = {
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
-DEVICE_AND_API_INIT(uart_msp432p4xx_0, DT_INST_LABEL(0),
-			uart_msp432p4xx_init, &uart_msp432p4xx_dev_data_0,
+DEVICE_DT_INST_DEFINE(0,
+			uart_msp432p4xx_init, device_pm_control_nop,
+			&uart_msp432p4xx_dev_data_0,
 			&uart_msp432p4xx_dev_cfg_0,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_msp432p4xx_driver_api);

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -364,8 +364,8 @@ static int np_uart_tty_poll_in(const struct device *dev,
 	return 0;
 }
 
-DEVICE_AND_API_INIT(uart_native_posix0,
-	    DT_INST_LABEL(0), &np_uart_0_init,
+DEVICE_DT_INST_DEFINE(0,
+	    &np_uart_0_init, device_pm_control_nop,
 	    (void *)&native_uart_status_0, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_0);

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -374,7 +374,7 @@ static int uart_npcx_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),		                       \
 			DT_INST_IRQ(inst, priority),                           \
 			uart_npcx_isr,                                         \
-			DEVICE_GET(uart_npcx_##inst),                          \
+			DEVICE_DT_INST_GET(inst),                              \
 			0);                                                    \
 		irq_enable(DT_INST_IRQN(inst));		                       \
 	}
@@ -405,8 +405,9 @@ static int uart_npcx_init(const struct device *dev)
 		.baud_rate = DT_INST_PROP(inst, current_speed)                 \
 	};                                                                     \
 									       \
-	DEVICE_AND_API_INIT(uart_npcx_##inst, DT_INST_LABEL(inst),             \
+	DEVICE_DT_INST_DEFINE(inst,					       \
 			&uart_npcx_init,                                       \
+			device_pm_control_nop,				       \
 			&uart_npcx_data_##inst, &uart_npcx_cfg_##inst,         \
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,      \
 			&uart_npcx_driver_api);                                \

--- a/drivers/serial/uart_ns16550_port_x.h
+++ b/drivers/serial/uart_ns16550_port_x.h
@@ -53,8 +53,9 @@ static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_@NUM@ = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_ns16550_@NUM@, DT_INST_LABEL(@NUM@),
+DEVICE_DT_INST_DEFINE(@NUM@,
 		    &uart_ns16550_init,
+		    device_pm_control_nop,
 		    &uart_ns16550_dev_data_@NUM@, &uart_ns16550_dev_cfg_@NUM@,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_ns16550_driver_api);
@@ -89,7 +90,7 @@ static void irq_config_func_@NUM@(const struct device *dev)
 	irq_connect_dynamic(irq,
 			    DT_INST_IRQ(@NUM@, priority),
 			    (void (*)(const void *))uart_ns16550_isr,
-			    DEVICE_GET(uart_ns16550_@NUM@),
+			    DEVICE_DT_INST_GET(@NUM@),
 			    INST_@NUM@_IRQ_FLAGS);
 
 	pcie_irq_enable(DT_INST_REG_ADDR(@NUM@), irq);
@@ -101,7 +102,7 @@ static void irq_config_func_@NUM@(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(@NUM@),
 		    DT_INST_IRQ(@NUM@, priority),
 		    uart_ns16550_isr,
-		    DEVICE_GET(uart_ns16550_@NUM@),
+		    DEVICE_DT_INST_GET(@NUM@),
 		    INST_@NUM@_IRQ_FLAGS);
 
 	pcie_irq_enable(DT_INST_REG_ADDR(@NUM@),
@@ -115,7 +116,7 @@ static void irq_config_func_@NUM@(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(@NUM@),
 		    DT_INST_IRQ(@NUM@, priority),
 		    uart_ns16550_isr,
-		    DEVICE_GET(uart_ns16550_@NUM@),
+		    DEVICE_DT_INST_GET(@NUM@),
 		    INST_@NUM@_IRQ_FLAGS);
 
 	irq_enable(DT_INST_IRQN(@NUM@));

--- a/drivers/serial/uart_nuvoton.c
+++ b/drivers/serial/uart_nuvoton.c
@@ -198,8 +198,9 @@ static struct uart_numicro_data uart_numicro_data_##index = {		\
 	},								\
 };									\
 									\
-DEVICE_AND_API_INIT(uart_numicro_##index, DT_INST_LABEL(index),		\
+DEVICE_DT_INST_DEFINE(index,						\
 		    &uart_numicro_init,					\
+		    device_pm_control_nop,				\
 		    &uart_numicro_data_##index,				\
 		    &uart_numicro_cfg_##index,				\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -425,9 +425,9 @@ static struct pl011_data pl011_data_port_0 = {
 	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
-DEVICE_AND_API_INIT(pl011_port_0,
-		    DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &pl011_init,
+		    device_pm_control_nop,
 		    &pl011_data_port_0,
 		    &pl011_cfg_port_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -440,28 +440,28 @@ static void pl011_irq_config_func_0(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, tx, irq),
 		    DT_INST_IRQ_BY_NAME(0, tx, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rx, irq),
 		    DT_INST_IRQ_BY_NAME(0, rx, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rxtim, irq),
 		    DT_INST_IRQ_BY_NAME(0, rxtim, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_0),
+		    DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rxtim, irq));
 #endif
@@ -488,9 +488,9 @@ static struct pl011_data pl011_data_port_1 = {
 	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
-DEVICE_AND_API_INIT(pl011_port_1,
-		    DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 		    &pl011_init,
+		    device_pm_control_nop,
 		    &pl011_data_port_1,
 		    &pl011_cfg_port_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -503,28 +503,28 @@ static void pl011_irq_config_func_1(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQN(1));
 #else
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, tx, irq),
 		    DT_INST_IRQ_BY_NAME(1, tx, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, tx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rx, irq),
 		    DT_INST_IRQ_BY_NAME(1, rx, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, rx, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(1, rxtim, irq),
 		    DT_INST_IRQ_BY_NAME(1, rxtim, priority),
 		    pl011_isr,
-		    DEVICE_GET(pl011_port_1),
+		    DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQ_BY_NAME(1, rxtim, irq));
 #endif

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -158,8 +158,8 @@ static const struct cypress_psoc6_config cypress_psoc6_uart5_config = {
 	.scb_clock = PCLK_SCB5_CLOCK,
 };
 
-DEVICE_AND_API_INIT(uart_5, DT_LABEL(DT_NODELABEL(uart5)),
-			uart_psoc6_init, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(uart5),
+			uart_psoc6_init, device_pm_control_nop, NULL,
 			&cypress_psoc6_uart5_config,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_psoc6_driver_api);
@@ -176,8 +176,8 @@ static const struct cypress_psoc6_config cypress_psoc6_uart6_config = {
 	.scb_clock = PCLK_SCB6_CLOCK,
 };
 
-DEVICE_AND_API_INIT(uart_6, DT_LABEL(DT_NODELABEL(uart6)),
-			uart_psoc6_init, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(uart6),
+			uart_psoc6_init, device_pm_control_nop, NULL,
 			&cypress_psoc6_uart6_config,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			(void *)&uart_psoc6_driver_api);

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -215,8 +215,8 @@ static const struct uart_driver_api uart_rtt_driver_api = {
 #define UART_RTT_INIT(idx, config)					      \
 	struct uart_rtt_data uart_rtt##idx##_data;			      \
 									      \
-	DEVICE_AND_API_INIT(uart_rtt##idx, DT_LABEL(UART_RTT(idx)),	      \
-			    uart_rtt_init, &uart_rtt##idx##_data, config,     \
+	DEVICE_DT_DEFINE(UART_RTT(idx), uart_rtt_init, device_pm_control_nop, \
+			    &uart_rtt##idx##_data, config,		      \
 			    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &uart_rtt_driver_api)
 

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -314,7 +314,7 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 	static void rv32m1_lpuart_config_func_##n(const struct device *dev)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), 0, rv32m1_lpuart_isr,	\
-			    DEVICE_GET(uart_0), 0);			\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
@@ -334,8 +334,9 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 									\
 	static const struct rv32m1_lpuart_config rv32m1_lpuart_##n##_cfg;\
 									\
-	DEVICE_AND_API_INIT(uart_##n, DT_INST_LABEL(n),			\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &rv32m1_lpuart_init,			\
+			    device_pm_control_nop,			\
 			    &rv32m1_lpuart_##n##_data,			\
 			    &rv32m1_lpuart_##n##_cfg,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -340,7 +340,7 @@ static const struct uart_driver_api uart_sam_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
 			    uart_sam_isr,				\
-			    DEVICE_GET(uart##n##_sam), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 #define UART_SAM_IRQ_CFG_FUNC_INIT(n)					\
@@ -361,8 +361,8 @@ static const struct uart_driver_api uart_sam_driver_api = {
 									\
 	static const struct uart_sam_dev_cfg uart##n##_sam_config;	\
 									\
-	DEVICE_AND_API_INIT(uart##n##_sam, DT_INST_LABEL(n),		\
-			    &uart_sam_init, &uart##n##_sam_data,	\
+	DEVICE_DT_INST_DEFINE(n, &uart_sam_init, 			\
+			    device_pm_control_nop, &uart##n##_sam_data,	\
 			    &uart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &uart_sam_driver_api);			\

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1069,7 +1069,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, m, priority),		\
 			    uart_sam0_isr,				\
-			    DEVICE_GET(uart_sam0_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
 	} while (0)
 
@@ -1144,8 +1144,8 @@ static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		\
 static struct uart_sam0_dev_data uart_sam0_data_##n;			\
 UART_SAM0_IRQ_HANDLER_DECL(n);						\
 UART_SAM0_CONFIG_DEFN(n);						\
-DEVICE_AND_API_INIT(uart_sam0_##n, DT_INST_LABEL(n),			\
-		    uart_sam0_init, &uart_sam0_data_##n,		\
+DEVICE_DT_INST_DEFINE(n, uart_sam0_init, device_pm_control_nop,		\
+		    &uart_sam0_data_##n,				\
 		    &uart_sam0_config_##n, PRE_KERNEL_1,		\
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
 		    &uart_sam0_driver_api);				\

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -392,8 +392,9 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_0 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_sifive_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    uart_sifive_init,
+		    device_pm_control_nop,
 		    &uart_sifive_data_0, &uart_sifive_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);
@@ -403,7 +404,7 @@ static void uart_sifive_irq_cfg_func_0(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    CONFIG_UART_SIFIVE_PORT_0_IRQ_PRIORITY,
-		    uart_sifive_irq_handler, DEVICE_GET(uart_sifive_0),
+		    uart_sifive_irq_handler, DEVICE_DT_INST_GET(0),
 		    0);
 
 	irq_enable(DT_INST_IRQN(0));
@@ -431,8 +432,9 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_1 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_sifive_1, DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 		    uart_sifive_init,
+		    device_pm_control_nop,
 		    &uart_sifive_data_1, &uart_sifive_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);
@@ -442,7 +444,7 @@ static void uart_sifive_irq_cfg_func_1(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    CONFIG_UART_SIFIVE_PORT_1_IRQ_PRIORITY,
-		    uart_sifive_irq_handler, DEVICE_GET(uart_sifive_1),
+		    uart_sifive_irq_handler, DEVICE_DT_INST_GET(1),
 		    0);
 
 	irq_enable(DT_INST_IRQN(1));

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -648,8 +648,9 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_0 = {
 	.baud_rate = DT_INST_PROP(0, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &uart_stellaris_init,
+		    device_pm_control_nop,
 		    &uart_stellaris_dev_data_0, &uart_stellaris_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
@@ -659,7 +660,7 @@ static void irq_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    uart_stellaris_isr, DEVICE_GET(uart_stellaris0),
+		    uart_stellaris_isr, DEVICE_DT_INST_GET(0),
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 }
@@ -686,8 +687,9 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_1 = {
 	.baud_rate = DT_INST_PROP(1, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris1, DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 		    &uart_stellaris_init,
+		    device_pm_control_nop,
 		    &uart_stellaris_dev_data_1, &uart_stellaris_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
@@ -697,7 +699,7 @@ static void irq_config_func_1(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
-		    uart_stellaris_isr, DEVICE_GET(uart_stellaris1),
+		    uart_stellaris_isr, DEVICE_DT_INST_GET(1),
 		    0);
 	irq_enable(DT_INST_IRQN(1));
 }
@@ -724,8 +726,9 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_2 = {
 	.baud_rate = DT_INST_PROP(2, current_speed),
 };
 
-DEVICE_AND_API_INIT(uart_stellaris2, DT_INST_LABEL(2),
+DEVICE_DT_INST_DEFINE(2,
 		    &uart_stellaris_init,
+		    device_pm_control_nop,
 		    &uart_stellaris_dev_data_2, &uart_stellaris_dev_cfg_2,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
@@ -735,7 +738,7 @@ static void irq_config_func_2(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(2),
 		    DT_INST_IRQ(2, priority),
-		    uart_stellaris_isr, DEVICE_GET(uart_stellaris2),
+		    uart_stellaris_isr, DEVICE_DT_INST_GET(2),
 		    0);
 	irq_enable(DT_INST_IRQN(2));
 }

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -761,7 +761,7 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 {									\
 	IRQ_CONNECT(DT_INST_IRQN(index),				\
 		DT_INST_IRQ(index, priority),				\
-		uart_stm32_isr, DEVICE_GET(uart_stm32_##index),		\
+		uart_stm32_isr, DEVICE_DT_INST_GET(index),		\
 		0);							\
 	irq_enable(DT_INST_IRQN(index));				\
 }
@@ -795,8 +795,9 @@ static struct uart_stm32_data uart_stm32_data_##index = {		\
 	.baud_rate = DT_INST_PROP(index, current_speed),		\
 };									\
 									\
-DEVICE_AND_API_INIT(uart_stm32_##index, DT_INST_LABEL(index),		\
+DEVICE_DT_INST_DEFINE(index,						\
 		    &uart_stm32_init,					\
+		    device_pm_control_nop,				\
 		    &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 		    &uart_stm32_driver_api);				\

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -1173,13 +1173,13 @@ static const struct uart_driver_api uart_xlnx_ps_driver_api = {
 	.irq_config_func = uart_xlnx_ps_irq_config_##port,
 
 #define UART_XLNX_PS_IRQ_CONF_FUNC(port) \
-DEVICE_DECLARE(uart_xlnx_ps_##port); \
+DEVICE_DT_INST_DECLARE(port); \
 \
 static void uart_xlnx_ps_irq_config_##port(const struct device *dev) \
 { \
 	IRQ_CONNECT(DT_INST_IRQN(port), \
 	DT_INST_IRQ(port, priority), \
-	uart_xlnx_ps_isr, DEVICE_GET(uart_xlnx_ps_##port), \
+	uart_xlnx_ps_isr, DEVICE_DT_INST_GET(port), \
 	0); \
 	irq_enable(DT_INST_IRQN(port)); \
 }
@@ -1205,8 +1205,9 @@ static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
 }
 
 #define UART_XLNX_PS_INIT(port) \
-DEVICE_AND_API_INIT(uart_xlnx_ps_##port, DT_INST_LABEL(port), \
+DEVICE_DT_INST_DEFINE(port, \
 	uart_xlnx_ps_init, \
+	device_pm_control_nop, \
 	&uart_xlnx_ps_dev_data_##port, \
 	&uart_xlnx_ps_dev_cfg_##port, \
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -340,7 +340,7 @@ static const struct uart_driver_api xlnx_uartlite_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
 			    xlnx_uartlite_isr,				\
-			    DEVICE_GET(xlnx_uartlite_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
 	} while (0)
@@ -373,8 +373,9 @@ static const struct xlnx_uartlite_config xlnx_uartlite_##n##_config = {	\
 									\
 	static const struct xlnx_uartlite_config xlnx_uartlite_##n##_config;\
 									\
-	DEVICE_AND_API_INIT(xlnx_uartlite_##n, DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &xlnx_uartlite_init,			\
+			    device_pm_control_nop,			\
 			    &xlnx_uartlite_##n##_data,			\
 			    &xlnx_uartlite_##n##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -73,8 +73,9 @@ static const struct uart_device_config xmc4xxx_config_##index = {	\
 	.base = (void *)DT_INST_REG_ADDR(index),			\
 };									\
 									\
-	DEVICE_AND_API_INIT(uart_xmc4xxx_##index, DT_INST_LABEL(index),	\
-			    &uart_xmc4xxx_init, &xmc4xxx_data_##index,	\
+	DEVICE_DT_INST_DEFINE(index, &uart_xmc4xxx_init,		\
+			    device_pm_control_nop,			\
+			    &xmc4xxx_data_##index,			\
 			    &xmc4xxx_config_##index, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &uart_xmc4xxx_driver_api);

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -341,7 +341,7 @@ static const struct uart_driver_api usart_sam_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
 			    usart_sam_isr,				\
-			    DEVICE_GET(usart##n##_sam), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 #define USART_SAM_IRQ_CFG_FUNC_INIT(n)					\
@@ -362,8 +362,9 @@ static const struct uart_driver_api usart_sam_driver_api = {
 									\
 	static const struct usart_sam_dev_cfg usart##n##_sam_config;	\
 									\
-	DEVICE_AND_API_INIT(usart##n##_sam, DT_INST_LABEL(n),		\
-			    &usart_sam_init, &usart##n##_sam_data,	\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    &usart_sam_init, device_pm_control_nop,	\
+			    &usart##n##_sam_data,			\
 			    &usart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &usart_sam_driver_api);			\


### PR DESCRIPTION
Convert uart drivers from:

	DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
	DEVICE_GET -> DEVICE_DT_INST_GET
	DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>