### PR TITLE
drivers: net_offload: set NET_CONTEXT_CONNECTED state

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1660,7 +1660,9 @@ static int offload_connect(struct net_context *context,
 		 sock->socket_id, wncm14a2a_sprint_ip_addr(addr),
 		 dst_port, timeout_sec);
 	ret = send_at_cmd(sock, buf, MDM_CMD_CONN_TIMEOUT);
-	if (ret < 0) {
+	if (!ret) {
+		net_context_set_state(sock->context, NET_CONTEXT_CONNECTED);
+	} else {
 		LOG_ERR("AT@SOCKCONN ret:%d", ret);
 	}
 

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -81,6 +81,10 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 	ret = esp_cmd_send(dev, NULL, 0, connect_msg, ESP_CMD_TIMEOUT);
 	if (ret == 0) {
 		sock->flags |= ESP_SOCK_CONNECTED;
+		if (sock->type == SOCK_STREAM) {
+			net_context_set_state(sock->context,
+					      NET_CONTEXT_CONNECTED);
+		}
 	} else if (ret == -ETIMEDOUT) {
 		/* FIXME:
 		 * What if the connection finishes after we return from

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -85,6 +85,7 @@ static void eswifi_off_connect_work(struct k_work *work)
 	err = __eswifi_off_start_client(eswifi, socket);
 	if (!err) {
 		socket->state = ESWIFI_SOCKET_STATE_CONNECTED;
+		net_context_set_state(socket->context, NET_CONTEXT_CONNECTED);
 	} else {
 		socket->state = ESWIFI_SOCKET_STATE_NONE;
 	}

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -763,6 +763,10 @@ static void handle_socket_msg_connect(struct socket_data *sd, void *pvMsg)
 	LOG_ERR("CONNECT: socket %d error %d",
 		strConnMsg->sock, strConnMsg->s8Error);
 
+	if (!strConnMsg->s8Error) {
+		net_context_set_state(sd->context, NET_CONTEXT_CONNECTED);
+	}
+
 	if (sd->connect_cb) {
 		sd->connect_cb(sd->context,
 			       strConnMsg->s8Error,


### PR DESCRIPTION
Set NET_CONTEXT_CONNECTED when stream socket got connected. This fixes
TCP connection when using ESP WiFi driver, which got broken after
sockets layer started to validate net_context connection state before
allowing to receive any data.

This fixes stream socket issues after merging #30139.

Tested only with ESP WiFi.