### PR TITLE
lib: cbprintf: fix mishandling of precision string output

### DIFF
--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -341,8 +341,8 @@ static void test_s(void)
 		return;
 	}
 
-	rc = TEST_PRF("/%.6s/%.2s/", s, s);
-	PRF_CHECK("/123/12/", rc);
+	rc = TEST_PRF("/%.6s/%.2s/%.s/", s, s, s);
+	PRF_CHECK("/123/12//", rc);
 
 	rc = TEST_PRF("%ls", ws);
 	if (IS_ENABLED(USE_LIBC)) {


### PR DESCRIPTION
If a precision flag is included for s formatting that bounds the maximum output length, so we need to use strnlen rather than strlen to get the amount of data to emit.  With that flag we can't expect there to be a terminating NUL following the text to print.

Also fix handling of an empty precision, which should behave as if a precision of zero was provided.