### PR TITLE
Bluetooth: Mesh: Fixes Friend Queue store message

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1618,6 +1618,11 @@ void bt_mesh_friend_enqueue_rx(struct bt_mesh_net_rx *rx,
 			continue;
 		}
 
+		if (friend_lpn_matches(frnd, rx->sub->net_idx,
+					rx->ctx.addr)) {
+			continue;
+		}
+
 		if (!friend_queue_prepare_space(frnd, rx->ctx.addr, seq_auth,
 						seg_count)) {
 			continue;


### PR DESCRIPTION
If the SRC field of the received message is a unicast
address of an element of the Low Power node, then the
message shall not be stored in the Friend Queue.

Otherwise, lpn will discard this message, eventually
it breaks friendship.

Fixes: #30657

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>