### PR TITLE
drivers: sensor: tmp116: Correct dev_name to tmp116

### DIFF
--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -145,6 +145,6 @@ static const struct tmp116_dev_config tmp116_config = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(hdc1080, DT_INST_LABEL(0), tmp116_init,
+DEVICE_AND_API_INIT(tmp116, DT_INST_LABEL(0), tmp116_init,
 		    &tmp116_data, &tmp116_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &tmp116_driver_api);


### PR DESCRIPTION
The dev_name field in DEVICE_AND_API_INIT() call should match the
driver's name. Tmp116 driver had a wrong dev_name field.

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>