### PR TITLE
drivers: ieee802154: Reserve TIMER used by 802.15.4 driver

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -12,6 +12,7 @@ menuconfig NRF_802154_RADIO_DRIVER
 	depends on HAS_HW_NRF_RADIO_IEEE802154
 	select DYNAMIC_INTERRUPTS
 	select ENTROPY_GENERATOR
+	select NRF_HW_TIMER1_RESERVED
 	help
 	  This option enables nRF IEEE 802.15.4 radio driver in Zephyr. Note,
 	  that beside the radio peripheral itself, this drivers occupies several


### PR DESCRIPTION
Use new Kconfig structure to marks which TIMER peripheral is reserved by
802.15.4 radio driver. It prevents peripheral usage collisions.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>