### PR TITLE
mcumgr: Update revision, update Kconfig and update release notes

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -261,6 +261,10 @@ Libraries / Subsystems
   * MCUmgr
 
     * Added support for flash devices that have non-0xff erase value.
+    * Added optional verification, enabled via
+      :option:`CONFIG_IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT`, of an uploaded
+      Direct-XIP binary, which will reject any binary that is not able to boot
+      from base address of offered upload slot.
 
   * updatehub
 

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -16,4 +16,4 @@ lpc_checksum
 Pillow
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
-imgtool
+imgtool>=1.7.1

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -164,6 +164,17 @@ config IMG_MGMT_DUMMY_HDR
 	help
 	  Returns dummy image header data for imgr functions,
 	  useful when there are no images present, Eg: unit tests.
+
+config IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT
+	bool "Reject Direct-XIP applications with mismatched address"
+	help
+	  When enabled, the mcumgr will compare base address of application,
+	  encoded into .bin file header with use of imgtool, on upload and will
+	  reject binaries that would not be able to start from available
+	  Direct-XIP address.
+	  The base address can be set, to an image binary header, with imgtool,
+	  using the --rom-fixed command line option.
+
 endif
 
 

--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
       revision: c71d2186077f9fd5f6d1aa53ee3f09dc41ce78f6
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 697e145d5ee5e4b400e9d7bceaec79f6ac29df7c
+      revision: 43845e883ff3a6cdaae22e23f3e60b5fcf78c6ba
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 41132e9220f8bc1223084975350c5e5f3b492afe


### PR DESCRIPTION
The series of commits update mcumgr to latest revision and include support for following features:
 - Optional image verification, enabled with `CONFIG_IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT`, that will reject .bin images that would not be able to boot from offered Direct-XIP slot; such image needs to be signed and have the base address embedded into header with imgtool.

Tthe PR depends on: https://github.com/apache/mynewt-mcumgr/pull/104