### PR TITLE
Bluetooth: host: Use uintptr in bt_le_ext_adv_get_index before return

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2685,30 +2685,31 @@ int bt_conn_auth_pairing_confirm(struct bt_conn *conn)
 
 uint8_t bt_conn_index(struct bt_conn *conn)
 {
-	uint8_t index;
+	ptrdiff_t index;
 
 	switch (conn->type) {
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
 		index = conn - iso_conns;
-		__ASSERT(index < CONFIG_BT_MAX_ISO_CONN,
+		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
 			"Invalid bt_conn pointer");
 		break;
 #endif
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_SCO:
 		index = conn - sco_conns;
-		__ASSERT(index < CONFIG_BT_MAX_SCO_CONN,
+		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
 			"Invalid bt_conn pointer");
 		break;
 #endif
 	default:
 		index = conn - acl_conns;
-		__ASSERT(index < CONFIG_BT_MAX_CONN, "Invalid bt_conn pointer");
+		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
+			 "Invalid bt_conn pointer");
 		break;
 	}
 
-	return index;
+	return (uint8_t)index;
 }
 
 struct bt_conn *bt_conn_lookup_index(uint8_t index)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -382,10 +382,11 @@ const bt_addr_le_t *bt_lookup_id_addr(uint8_t id, const bt_addr_le_t *addr)
 #if defined(CONFIG_BT_EXT_ADV)
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv)
 {
-	uint8_t index = adv - adv_pool;
+	ptrdiff_t index = adv - adv_pool;
 
-	__ASSERT(index < ARRAY_SIZE(adv_pool), "Invalid bt_adv pointer");
-	return index;
+	__ASSERT(0 <= index && index < ARRAY_SIZE(adv_pool),
+		 "Invalid bt_adv pointer");
+	return (uint8_t)index;
 }
 
 static struct bt_le_ext_adv *adv_new(void)
@@ -7285,12 +7286,11 @@ int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync)
 {
-	uintptr_t index = per_adv_sync - per_adv_sync_pool;
+	ptrdiff_t index = per_adv_sync - per_adv_sync_pool;
 
-	__ASSERT(per_adv_sync >= per_adv_sync_pool &&
-			index < ARRAY_SIZE(per_adv_sync_pool),
+	__ASSERT(0 <= index && index < ARRAY_SIZE(per_adv_sync_pool),
 		 "Invalid per_adv_sync pointer");
-	return index;
+	return (uint8_t)index;
 }
 
 int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,


### PR DESCRIPTION
Align bt_le_per_adv_sync_get_index, bt_conn_index and
bt_le_ext_adv_get_index in use of uintptr_t.

This fixes an issue where the cast to uint8_t happened before the
assert for a valid index, which could lead to invalid pointers passing
this assert.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>