### PR TITLE
boards: reel_board: remove non-minimal peripherals from defconfig

### DIFF
--- a/boards/arm/reel_board/Kconfig.defconfig
+++ b/boards/arm/reel_board/Kconfig.defconfig
@@ -26,9 +26,15 @@ config BT_CTLR
 	default y
 	depends on BT
 
+if DISPLAY
+
 config SSD16XX
 	default y
-	depends on DISPLAY
+
+config SPI
+	default y
+
+endif # DISPLAY
 
 if LVGL
 

--- a/boards/arm/reel_board/reel_board_defconfig
+++ b/boards/arm/reel_board/reel_board_defconfig
@@ -10,9 +10,6 @@ CONFIG_ARM_MPU=y
 # enable GPIO
 CONFIG_GPIO=y
 
-# enable SPI
-CONFIG_SPI=y
-
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/arm/reel_board/reel_board_v2_defconfig
+++ b/boards/arm/reel_board/reel_board_v2_defconfig
@@ -10,9 +10,6 @@ CONFIG_ARM_MPU=y
 # enable GPIO
 CONFIG_GPIO=y
 
-# enable SPI
-CONFIG_SPI=y
-
 # enable uart driver
 CONFIG_SERIAL=y
 


### PR DESCRIPTION
This PR removes SPI as peripheral for `reel_board` and `reel_board_v2` as discussed in #30694.

Signed-off-by: Jonas Remmert <j.remmert@phytec.de>