### PR TITLE
drivers: dac: Convert drivers to new DT device macros

### DIFF
--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -424,9 +424,9 @@ static const struct dac_driver_api dacx0508_driver_api = {
 		.gain[6] = DT_PROP(INST_DT_DACX0508(n, t), channel6_gain), \
 		.gain[7] = DT_PROP(INST_DT_DACX0508(n, t), channel7_gain), \
 	}; \
-	DEVICE_AND_API_INIT(dac##t##_##n, \
-			    DT_LABEL(INST_DT_DACX0508(n, t)), \
-			    &dacx0508_init, &dac##t##_data_##n, \
+	DEVICE_DT_DEFINE(INST_DT_DACX0508(n, t), \
+			    &dacx0508_init, device_pm_control_nop, \
+			    &dac##t##_data_##n, \
 			    &dac##t##_config_##n, POST_KERNEL, \
 			    CONFIG_DAC_DACX0508_INIT_PRIORITY, \
 			    &dacx0508_driver_api)

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -105,8 +105,8 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_dac_##n, DT_INST_LABEL(n),		\
-			mcux_dac_init, &mcux_dac_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, mcux_dac_init, device_pm_control_nop,	\
+			&mcux_dac_data_##n,				\
 			&mcux_dac_config_##n,				\
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
 			&mcux_dac_driver_api);

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -111,8 +111,8 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(mcux_dac32_##n, DT_INST_LABEL(n),		\
-			mcux_dac32_init, &mcux_dac32_data_##n,		\
+	DEVICE_DT_INST_DEFINE(n, mcux_dac32_init, device_pm_control_nop,\
+			&mcux_dac32_data_##n,				\
 			&mcux_dac32_config_##n,				\
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
 			&mcux_dac32_driver_api);

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -106,7 +106,7 @@ static const struct dac_driver_api api_sam0_driver_api = {
 		.refsel = UTIL_CAT(SAM0_DAC_REFSEL_, SAM0_DAC_REFSEL(n)),      \
 	};								       \
 									       \
-	DEVICE_AND_API_INIT(dac_##n, DT_INST_LABEL(n), &dac_sam0_init, NULL,   \
+	DEVICE_DT_INST_DEFINE(n, &dac_sam0_init, device_pm_control_nop, NULL,  \
 			    &dac_sam0_cfg_##n, POST_KERNEL,		       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 			    &api_sam0_driver_api)

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -166,8 +166,8 @@ static struct dac_stm32_data dac_stm32_data_##index = {			\
 	.channel_count = STM32_CHANNEL_COUNT				\
 };									\
 									\
-DEVICE_AND_API_INIT(dac_##index, DT_INST_LABEL(index),			\
-		    &dac_stm32_init, &dac_stm32_data_##index,		\
+DEVICE_DT_INST_DEFINE(index, &dac_stm32_init, device_pm_control_nop,	\
+		    &dac_stm32_data_##index,				\
 		    &dac_stm32_cfg_##index, POST_KERNEL,		\
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
 		    &api_stm32_driver_api);


### PR DESCRIPTION
Convert dac drivers from:

        DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>