### PR TITLE
cmake: using zephyr_get_compile_options_for_lang_as_string for export

### DIFF
--- a/cmake/makefile_exports/CMakeLists.txt
+++ b/cmake/makefile_exports/CMakeLists.txt
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-zephyr_get_compile_options_for_lang(ASM ASM_compile_options)
-zephyr_get_compile_options_for_lang(C C_compile_options)
-zephyr_get_compile_options_for_lang(CXX CXX_compile_options)
+zephyr_get_compile_options_for_lang_as_string(ASM ASM_compile_options)
+zephyr_get_compile_options_for_lang_as_string(C C_compile_options)
+zephyr_get_compile_options_for_lang_as_string(CXX CXX_compile_options)
 
 set(exports
   "


### PR DESCRIPTION
Fixes: #30712

Now using zephyr_get_compile_options_for_lang_as_string for makefile
export of Zephyr build flags.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>