### PR TITLE
Bluetooth: controller: Cleanup included header files

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6,21 +6,21 @@
  */
 
 #include <stddef.h>
-#include <zephyr/types.h>
 #include <string.h>
-#include <version.h>
 
-#include <soc.h>
-#include <toolchain.h>
+#include <version.h>
 #include <errno.h>
+
+#include <sys/util.h>
+#include <sys/byteorder.h>
 #include <sys/atomic.h>
+
+#include <drivers/bluetooth/hci_driver.h>
+
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_vs.h>
 #include <bluetooth/buf.h>
 #include <bluetooth/bluetooth.h>
-#include <drivers/bluetooth/hci_driver.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
 
 #include "util/util.h"
 #include "util/memq.h"

--- a/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
+++ b/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <sys/byteorder.h>
 
 #include <bluetooth/addr.h>
 #include <bluetooth/hci_vs.h>
 
-#include <nrf.h>
+#include <soc.h>
 
 uint8_t hci_vendor_read_static_addr(struct bt_hci_vs_static_addr addrs[],
 				 uint8_t size)

--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <string.h>
 
 #include <settings/settings.h>
 
 #include <bluetooth/bluetooth.h>
+
 #include "ll_settings.h"
 
 #define LOG_MODULE_NAME bt_ctlr_ll_settings

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stddef.h>
-#include <sys/util.h>
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
 #include "lll_meta.h"
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <soc.h>
 
 #include "hal/nrf5/swi.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
@@ -10,7 +10,7 @@
  * This header needs lots of types and macros, instead of relaying on
  * good inclusion order let's pull them through soc.h
  */
-#include "soc.h"
+#include <soc.h>
 
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+#include <stdbool.h>
 #include <errno.h>
-#include <zephyr/types.h>
-#include <device.h>
-#include <drivers/entropy.h>
-#include <drivers/clock_control.h>
-#include <drivers/clock_control/nrf_clock_control.h>
+
+#include <toolchain.h>
 
 #include <soc.h>
+#include <device.h>
+
+#include <drivers/entropy.h>
 
 #include "hal/swi.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <zephyr.h>
-#include <soc.h>
 #include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 
@@ -43,6 +42,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv
 #include "common/log.h"
+#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
 #include <stddef.h>
 
-#include <zephyr.h>
-#include <soc.h>
 #include <sys/byteorder.h>
 #include <bluetooth/hci.h>
 
@@ -37,6 +36,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv_aux
 #include "common/log.h"
+#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdbool.h>
+#include <stdint.h>
 
-#include <zephyr.h>
 #include <soc.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <soc.h>
 #include <device.h>
+
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/nrf_clock_control.h>
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
 
 #include <toolchain.h>
-#include <zephyr/types.h>
+
 #include <sys/util.h>
-#include <drivers/clock_control/nrf_clock_control.h>
 
 #include "util/mem.h"
 #include "util/memq.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
 
 #include <toolchain.h>
-#include <zephyr/types.h>
+
 #include <sys/util.h>
 
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+#include <stddef.h>
+
 #include <toolchain.h>
-#include <zephyr/types.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <toolchain.h>
-#include <bluetooth/hci.h>
-#include <sys/byteorder.h>
+
 #include <soc.h>
+
+#include <sys/byteorder.h>
+#include <bluetooth/hci.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
-#include <bluetooth/hci.h>
+#include <stdint.h>
+
 #include <sys/byteorder.h>
 #include <sys/util.h>
+
+#include <bluetooth/hci.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdbool.h>
+#include <stdint.h>
 
 #include <toolchain.h>
-#include <zephyr/types.h>
+
 #include <sys/util.h>
 
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -8,9 +8,8 @@
 #include <string.h>
 
 #include <toolchain.h>
-#include <zephyr/types.h>
+
 #include <soc.h>
-#include <drivers/clock_control.h>
 
 #include "hal/cpu.h"
 #include "hal/cntr.h"

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-
 /*
  * PDU fields sizes
  */

--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stddef.h>
-
 #ifndef DOUBLE_BUFFER_SIZE
 #define DOUBLE_BUFFER_SIZE 2
 #endif


### PR DESCRIPTION
Clean up included header files, remove including
zephyr/types.h and other deprecated or redundant
header files.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>