### PR TITLE
add error checks in trigger_handler()

### DIFF
--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -84,10 +84,19 @@ static void trigger_handler(const struct device *dev,
 {
 	struct sensor_value temp;
 	static size_t cnt;
+	int rc;
 
 	++cnt;
-	sensor_sample_fetch(dev);
-	sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
+	rc = sensor_sample_fetch(dev);
+	if (rc != 0) {
+		printf("sensor_sample_fetch error: %d\n", rc);
+		return;
+	}
+	rc = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
+	if (rc != 0) {
+		printf("sensor_channel_get error: %d\n", rc);
+		return;
+	}
 
 	printf("trigger fired %u, temp %g deg C\n", cnt,
 	       sensor_value_to_double(&temp));


### PR DESCRIPTION
### Contribution description
samples/sensor/mcp9808/src/main.c : add error checks of sensor_sample_fetch() and sensor_channel_get() in trigger_handler()

### Signed-off
Signed-off-by: Xinrong Han hanxr19@mails.tsinghua.edu.cn

### Issue
Fixes #29945