### PR TITLE
OpenOCD configuration fixes for ARC

### DIFF
--- a/boards/arc/em_starterkit/support/openocd.cfg
+++ b/boards/arc/em_starterkit/support/openocd.cfg
@@ -1,6 +1,12 @@
 # Configure JTAG cable
 # EM Starter Kit has built-in FT2232 chip, which is similar to Digilent HS-1.
-source [find interface/ftdi/digilent-hs1.cfg]
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+# channel 1 does not have any functionality
+ftdi_channel 0
+# just TCK TDI TDO TMS, no reset
+ftdi_layout_init 0x0088 0x008b
+reset_config none
 
 # Only specify FTDI serial number if it is specified via
 # "set _ZEPHYR_BOARD_SERIAL 12345" before reading this script

--- a/boards/arc/em_starterkit/support/openocd.cfg
+++ b/boards/arc/em_starterkit/support/openocd.cfg
@@ -1,6 +1,6 @@
 # Configure JTAG cable
 # EM Starter Kit has built-in FT2232 chip, which is similar to Digilent HS-1.
-interface ftdi
+adapter driver ftdi
 ftdi_vid_pid 0x0403 0x6010
 # channel 1 does not have any functionality
 ftdi_channel 0
@@ -15,7 +15,7 @@ if { [info exists _ZEPHYR_BOARD_SERIAL] } {
 }
 
 # EM11D reportedly requires 5 MHz. Other cores and board can work faster.
-adapter_khz 5000
+adapter speed 5000
 
 # ARCs support only JTAG.
 transport select jtag

--- a/boards/arc/emsdp/support/openocd.cfg
+++ b/boards/arc/emsdp/support/openocd.cfg
@@ -8,7 +8,7 @@
 
 # Configure JTAG cable
 # EM SDP has built-in FT2232 chip, which is similiar to Digilent HS-1.
-interface ftdi
+adapter driver ftdi
 
 # Only specify FTDI serial number if it is specified via
 # "set _ZEPHYR_BOARD_SERIAL 12345" before reading this script
@@ -22,7 +22,7 @@ ftdi_channel 0
 
 
 # EM11D requires 10 MHz.
-adapter_khz 10000
+adapter speed 10000
 
 # ARCs support only JTAG.
 transport select jtag

--- a/boards/arc/iotdk/support/openocd.cfg
+++ b/boards/arc/iotdk/support/openocd.cfg
@@ -8,7 +8,7 @@
 
 # Configure JTAG cable
 # IoT DK has built-in FT2232 chip, which is similar to Digilent HS-1.
-interface ftdi
+adapter driver ftdi
 
 # Only specify FTDI serial number if it is specified via
 # "set _ZEPHYR_BOARD_SERIAL 12345" before reading this script
@@ -22,7 +22,7 @@ ftdi_channel 1
 
 
 # EM9D requires 8 MHz.
-adapter_khz 8000
+adapter speed 8000
 
 # ARCs support only JTAG.
 transport select jtag


### PR DESCRIPTION
In newer OpenOCD version from Zephyr's SDK v0.12, there are some
changes in OpenOCD scripts.

- OpenOCD cofig command: ftdi_device_desc description provides the
USB device description (the iProduct string) of the adapter. And If not
specified, the device description is ignored during device selection.
In file interface/ftdi/digilent-hs1.cfg, ftdi_device_desc will be set to
"Digilent Adept USB Device", while we get the iProduct string
"Digilent USB Device" from em_starterkit adapter.  it's better not
specify it and only use the vid and pid of the adapter for selection.

- there are some changes in OpenOCD scripts: JTAG probe interface 
(AKA "adapter") setup, see http://openocd.zylin.com/#/c/5784/

So we need to change OpenOCD scripts accordingly to match
newer OpenOCD version from Zephyr's SDK v0.12. 

Note: the fix for HSDK board is done in PR: #30266 
