### PR TITLE
add error checks of device_get_binding()

### DIFF
--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -412,6 +412,11 @@ static int ssd1306_init(const struct device *dev)
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	driver->cs_ctrl.gpio_dev = device_get_binding(
 				   DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
+	if (driver->cs_ctrl.gpio_dev == NULL) {
+		LOG_ERR("Failed to get pointer to %s device!",
+			    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
+		return ENODEV;
+	}
 	driver->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	driver->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
 	driver->cs_ctrl.delay = 0U;


### PR DESCRIPTION
### Contribution description
drivers/console/uart_console.c,  drivers/display/display_st7789v.c,  drivers/display/ssd1306.c  :  
add some error checks of device_get_binding()

I'm not sure the log info and return values of these error handlings are proper.

### Signed-off
Signed-off-by: Xinrong Han hanxr19@mails.tsinghua.edu.cn

### Issue
Fixes parts of #30195