### PR TITLE
add an error check of flash_area_open()

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -188,6 +188,7 @@ void config_wipe_fcb(struct flash_sector *fs, int cnt)
 	int i;
 
 	rc = flash_area_open(FLASH_AREA_ID(storage), &fap);
+	zassert_true(rc == 0, "Can't open storage flash area");
 
 	for (i = 0; i < cnt; i++) {
 		rc = flash_area_erase(fap, fs[i].fs_off, fs[i].fs_size);


### PR DESCRIPTION
### Contribution description
tests/subsys/settings/fcb/src/settings_test_fcb.c : add an error check of flash_area_open() in config_wipe_fcb()

### Signed-off
Signed-off-by: Xinrong Han hanxr19@mails.tsinghua.edu.cn

### Issue
Fixes parts of #30195