### PR TITLE
add error check of dac_write_value()

### DIFF
--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -218,7 +218,7 @@ uint32_t ht16k33_get_pending_int(const struct device *dev)
 	err = i2c_write_read(data->i2c, config->i2c_addr, &cmd, sizeof(cmd),
 			     &flag, sizeof(flag));
 	if (err) {
-		LOG_ERR("Failed to to read HT16K33 IRQ flag");
+		LOG_ERR("Failed to read HT16K33 IRQ flag");
 		return 0;
 	}
 

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -69,7 +69,11 @@ void main(void)
 			4096 / dac_values : 1;
 
 		for (int i = 0; i < dac_values; i++) {
-			dac_write_value(dac_dev, DAC_CHANNEL_ID, i);
+			ret = dac_write_value(dac_dev, DAC_CHANNEL_ID, i);
+			if (ret != 0) {
+				printk("dac_write_value() failed with code %d\n", ret);
+				return;
+			}
 			k_sleep(K_MSEC(sleep_time));
 		}
 	}


### PR DESCRIPTION
### Contribution description
samples/drivers/dac/src/main.c : add an error check of function dac_write_value()

### Signed-off
Signed-off-by: Xinrong Han hanxr19@mails.tsinghua.edu.cn

### Issue
Fixes parts of #30205