### PR TITLE
Add support for STM32L0 series timers and PWM driver

### DIFF
--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -185,6 +185,54 @@
 			label = "SPI_1";
 		};
 
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000001>;
+			interrupts = <15 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_2";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_2";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers21: timers@40010800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40010800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000004>;
+			interrupts = <20 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_21";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_21";
+				#pwm-cells = <3>;
+			};
+		};
+
+		lptim1: timers@40007c00 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40007c00 0x400>;
+			interrupts = <13 0>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+			label = "LPTIM_1";
+		};
+
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;

--- a/dts/arm/st/l0/stm32l031.dtsi
+++ b/dts/arm/st/l0/stm32l031.dtsi
@@ -8,6 +8,24 @@
 
 / {
 	soc {
+		timers22: timers@40011400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
+			interrupts = <22 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_22";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_22";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(1)>;
 		};

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -32,6 +32,42 @@
 			label = "SPI_2";
 		};
 
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
+			interrupts = <17 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_6";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_6";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers22: timers@40011400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
+			interrupts = <22 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_22";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_22";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(2)>;
 		};

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -56,6 +56,78 @@
 			label = "SPI_2";
 		};
 
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000002>;
+			interrupts = <16 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_3";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_3";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
+			interrupts = <17 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_6";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_6";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers7: timers@40001400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000020>;
+			interrupts = <18 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_7";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_7";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers22: timers@40011400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
+			interrupts = <22 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_22";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_22";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(6)>;
 		};


### PR DESCRIPTION
This PR adds all timers and PWM channels for the STM32L0 series MCUs to devicetree and updates the PWM driver to support also the L0 series.

I was not sure what the rule for setting the the PWM prescaler in the devicetree is. For other MCUs it's either set to `0` or to `10000`, but I could not see a pattern. As the L0 MCUs have rather low system clock frequency, I chose `0` to allow high PWM signal frequencies by default.

Tested on `nucleo_l073rz`.