### PR TITLE
drivers: led: Convert drivers to new DT device macros

### DIFF
--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -473,8 +473,8 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_AND_API_INIT(ht16k33_##id, DT_INST_LABEL(id),		\
-			    &ht16k33_init, &ht16k33_##id##_data,	\
+	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, device_pm_control_nop,	\
+			    &ht16k33_##id##_data,			\
 			    &ht16k33_##id##_cfg, POST_KERNEL,		\
 			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
 
@@ -493,8 +493,8 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_AND_API_INIT(ht16k33_##id, DT_INST_LABEL(id),		\
-			    &ht16k33_init, &ht16k33_##id##_data,	\
+	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, device_pm_control_nop,	\
+			    &ht16k33_##id##_data,			\
 			    &ht16k33_##id##_cfg, POST_KERNEL,		\
 			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
 #else /* ! CONFIG_HT16K33_KEYSCAN */

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -279,7 +279,7 @@ static const struct led_driver_api lp3943_led_api = {
 	.off = lp3943_led_off,
 };
 
-DEVICE_AND_API_INIT(lp3943_led, DT_INST_LABEL(0),
-		    &lp3943_led_init, &lp3943_led_data,
+DEVICE_DT_INST_DEFINE(0, &lp3943_led_init, device_pm_control_nop,
+		    &lp3943_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &lp3943_led_api);

--- a/drivers/led/lp503x.c
+++ b/drivers/led/lp503x.c
@@ -276,8 +276,9 @@ static struct lp503x_data lp503x_data_##id = {			\
 	.chan_buf	= lp503x_chan_buf_##id,			\
 };								\
 								\
-DEVICE_AND_API_INIT(lp503x_led_##id, DT_INST_LABEL(id),		\
+DEVICE_DT_INST_DEFINE(id,					\
 		    &lp503x_init,				\
+		    device_pm_control_nop,			\
 		    &lp503x_data_##id,				\
 		    &lp503x_config_##id,			\
 		    POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -953,7 +953,7 @@ static const struct led_driver_api lp5562_led_api = {
 	.off = lp5562_led_off,
 };
 
-DEVICE_AND_API_INIT(lp5562_led, DT_INST_LABEL(0),
-		&lp5562_led_init, &lp5562_led_data,
+DEVICE_DT_INST_DEFINE(0, &lp5562_led_init, device_pm_control_nop,
+		&lp5562_led_data,
 		NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		&lp5562_led_api);

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -203,7 +203,7 @@ static const struct led_driver_api pca9633_led_api = {
 	.off = pca9633_led_off,
 };
 
-DEVICE_AND_API_INIT(pca9633_led, DT_INST_LABEL(0),
-		    &pca9633_led_init, &pca9633_led_data,
+DEVICE_DT_INST_DEFINE(0, &pca9633_led_init, device_pm_control_nop,
+		    &pca9633_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &pca9633_led_api);


### PR DESCRIPTION
Convert led drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>