### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: remove compiler warning

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -451,7 +451,7 @@ void ull_cp_priv_rr_new(struct ull_cp_conn *conn, struct node_rx_pdu *rx)
 {
 	struct proc_ctx *ctx;
 	struct pdu_data *pdu;
-	uint8_t proc;
+	uint8_t proc = PROC_UNKNOWN;
 
 	pdu = (struct pdu_data *) rx->pdu;
 


### PR DESCRIPTION
Some compilers issue a warning when a variable may be used uninitialised

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>