### PR TITLE
usb: fix for parallel transfer deadlock with usb_transfer_sync() 

### DIFF
--- a/subsys/usb/usb_transfer.c
+++ b/subsys/usb/usb_transfer.c
@@ -49,7 +49,7 @@ static struct usb_transfer_data ut_data[CONFIG_USB_MAX_NUM_TRANSFERS];
 static struct usb_transfer_data *usb_ep_get_transfer(uint8_t ep)
 {
 	for (int i = 0; i < ARRAY_SIZE(ut_data); i++) {
-		if (ut_data[i].ep == ep) {
+		if (ut_data[i].ep == ep && ut_data[i].status != 0) {
 			return &ut_data[i];
 		}
 	}
@@ -197,6 +197,11 @@ int usb_transfer(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags,
 {
 	struct usb_transfer_data *trans = NULL;
 	int i, key, ret = 0;
+
+	/* Parallel transfer to same endpoint is not supported. */
+	if (usb_transfer_is_busy(ep)) {
+		return -EBUSY;
+	}
 
 	LOG_DBG("Transfer start, ep 0x%02x, data %p, dlen %zd",
 		ep, data, dlen);


### PR DESCRIPTION
Transfer status was not checked when accessing to transfer from endpoint callback. Adding status check, to prevent double complete. Double complete will cause deadlock when ongoing transfer complete callback is not called.

Fixes #30736