### PR TITLE
drivers: flash: Convert drivers to new DT device macros

### DIFF
--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -227,6 +227,6 @@ static const struct flash_driver_api flash_gecko_driver_api = {
 
 static struct flash_gecko_data flash_gecko_0_data;
 
-DEVICE_AND_API_INIT(flash_gecko_0, DT_INST_LABEL(0),
-		    flash_gecko_init, &flash_gecko_0_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, flash_gecko_init, device_pm_control_nop,
+		    &flash_gecko_0_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_gecko_driver_api);

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -370,7 +370,7 @@ static const struct flash_sam_dev_cfg flash_sam_cfg = {
 
 static struct flash_sam_dev_data flash_sam_data;
 
-DEVICE_AND_API_INIT(flash_sam, DT_INST_LABEL(0),
-		    flash_sam_init, &flash_sam_data, &flash_sam_cfg,
+DEVICE_DT_INST_DEFINE(0, flash_sam_init, device_pm_control_nop,
+		    &flash_sam_data, &flash_sam_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sam_api);

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -440,6 +440,6 @@ static const struct flash_driver_api flash_sam0_api = {
 
 static struct flash_sam0_data flash_sam0_data_0;
 
-DEVICE_AND_API_INIT(flash_sam0, DT_INST_LABEL(0),
-		    flash_sam0_init, &flash_sam0_data_0, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, flash_sam0_init, device_pm_control_nop,
+		    &flash_sam0_data_0, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_sam0_api);

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -41,7 +41,6 @@
 #define FLASH_SIMULATOR_PROG_UNIT DT_PROP(SOC_NV_FLASH_NODE, write_block_size)
 #define FLASH_SIMULATOR_FLASH_SIZE DT_REG_SIZE(SOC_NV_FLASH_NODE)
 
-#define FLASH_SIMULATOR_DEV_NAME DT_INST_LABEL(0)
 #define FLASH_SIMULATOR_ERASE_VALUE \
 		DT_PROP(DT_PARENT(SOC_NV_FLASH_NODE), erase_value)
 
@@ -440,7 +439,7 @@ static int flash_init(const struct device *dev)
 	return flash_mock_init(dev);
 }
 
-DEVICE_AND_API_INIT(flash_simulator, FLASH_SIMULATOR_DEV_NAME, flash_init,
+DEVICE_DT_INST_DEFINE(0, flash_init, device_pm_control_nop,
 		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sim_api);
 

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -415,6 +415,6 @@ static int stm32_flash_init(const struct device *dev)
 	return flash_stm32_write_protection(dev, false);
 }
 
-DEVICE_AND_API_INIT(stm32_flash, DT_INST_LABEL(0),
-		    stm32_flash_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, device_pm_control_nop,
+		    &flash_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32_api);

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -534,6 +534,6 @@ static int stm32h7_flash_init(const struct device *dev)
 }
 
 
-DEVICE_AND_API_INIT(stm32h7_flash, DT_INST_LABEL(0),
-		    stm32h7_flash_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, device_pm_control_nop,
+		    &flash_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32h7_api);

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -297,6 +297,6 @@ static int flash_mcux_init(const struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
-			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, flash_mcux_init, device_pm_control_nop,
+			&flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -176,6 +176,6 @@ static int flash_mcux_init(const struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_AND_API_INIT(flash_mcux, DT_INST_LABEL(0),
-			flash_mcux_init, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, flash_mcux_init, device_pm_control_nop,
+			&flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -706,7 +706,7 @@ static const struct flash_driver_api spi_flash_at45_api = {
 			"Page size specified for instance " #idx " of "	     \
 			"atmel,at45 is not compatible with its "	     \
 			"total size");))				     \
-	DEVICE_DEFINE(inst_##idx, DT_INST_LABEL(idx),			     \
+	DEVICE_DT_INST_DEFINE(idx,					     \
 		      spi_flash_at45_init, spi_flash_at45_pm_control,	     \
 		      &inst_##idx##_data, &inst_##idx##_config,		     \
 		      POST_KERNEL, CONFIG_SPI_FLASH_AT45_INIT_PRIORITY,      \


### PR DESCRIPTION
Convert flash drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    DEVICE_DEFINE -> DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>