### PR TITLE
drivers: led_strip: Convert drivers to new DT device macros

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -121,6 +121,6 @@ static const struct led_strip_driver_api apa102_api = {
 	.update_channels = apa102_update_channels,
 };
 
-DEVICE_AND_API_INIT(apa102_0, DT_INST_LABEL(0), apa102_init,
+DEVICE_DT_INST_DEFINE(0, apa102_init, device_pm_control_nop,
 		    &apa102_data_0, NULL, POST_KERNEL,
 		    CONFIG_LED_STRIP_INIT_PRIORITY, &apa102_api);

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -154,7 +154,7 @@ static const struct led_strip_driver_api lpd880x_strip_api = {
 	.update_channels = lpd880x_strip_update_channels,
 };
 
-DEVICE_AND_API_INIT(lpd880x_strip, DT_INST_LABEL(0),
-		    lpd880x_strip_init, &lpd880x_strip_data,
+DEVICE_DT_INST_DEFINE(0, lpd880x_strip_init, device_pm_control_nop,
+		    &lpd880x_strip_data,
 		    NULL, POST_KERNEL, CONFIG_LED_STRIP_INIT_PRIORITY,
 		    &lpd880x_strip_api);

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -192,8 +192,6 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 	.update_channels = ws2812_gpio_update_channels,
 };
 
-#define WS2812_GPIO_LABEL(idx) \
-	(DT_INST_LABEL(idx))
 #define WS2812_GPIO_HAS_WHITE(idx) \
 	(DT_INST_PROP(idx, has_white_channel) == 1)
 #define WS2812_GPIO_DEV(idx) \
@@ -236,8 +234,9 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 		.has_white = WS2812_GPIO_HAS_WHITE(idx),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(ws2812_gpio_##idx, WS2812_GPIO_LABEL(idx),	\
+	DEVICE_DT_INST_DEFINE(idx,					\
 			    ws2812_gpio_##idx##_init,			\
+			    device_pm_control_nop,			\
 			    &ws2812_gpio_##idx##_data,			\
 			    &ws2812_gpio_##idx##_cfg, POST_KERNEL,	\
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -170,8 +170,6 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 	.update_channels = ws2812_strip_update_channels,
 };
 
-#define WS2812_SPI_LABEL(idx) \
-	(DT_INST_LABEL(idx))
 #define WS2812_SPI_NUM_PIXELS(idx) \
 	(DT_INST_PROP(idx, chain_length))
 #define WS2812_SPI_HAS_WHITE(idx) \
@@ -223,9 +221,9 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 		return 0;						\
 	}								\
 									\
-	DEVICE_AND_API_INIT(ws2812_spi_##idx,				\
-			    WS2812_SPI_LABEL(idx),			\
+	DEVICE_DT_INST_DEFINE(idx,					\
 			    ws2812_spi_##idx##_init,			\
+			    device_pm_control_nop,			\
 			    &ws2812_spi_##idx##_data,			\
 			    &ws2812_spi_##idx##_cfg,			\
 			    POST_KERNEL,				\


### PR DESCRIPTION
Convert led_strip drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>