### PR TITLE
actions: use descriptive job names

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -15,7 +15,8 @@ on:
     - '.github/workflows/devicetree_checks.yml'
 
 jobs:
-  build:
+  devicetree-checks:
+    name: Devicetree script tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -19,7 +19,8 @@ on:
     - '.github/workflows/doc-build.yml'
 
 jobs:
-  build:
+  doc-build:
+    name: "Documentation Build"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -12,7 +12,8 @@ on:
     - '*'
 
 jobs:
-  build:
+  doc-publish:
+    name: Publish Documentation
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v2.1.1

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    name: Find Stale issues and PRs
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -18,7 +18,8 @@ on:
     - '.github/workflows/twister_tests.yml'
 
 jobs:
-  build:
+  twister-tests:
+    name: Twister Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -16,7 +16,8 @@ on:
     - '.github/workflows/west_cmds.yml'
 
 jobs:
-  build:
+  west-commnads:
+    name: West Command Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Use descriptive and unique job names, otherwise we end up with those
showing up in different location with no way to know which is which.