### PR TITLE
drivers: counter: Convert drivers to new DT device macros

### DIFF
--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -332,11 +332,11 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 
 /* RTCC0 */
 
-DEVICE_DECLARE(counter_gecko_0);
+DEVICE_DT_INST_DECLARE(0);
 
 ISR_DIRECT_DECLARE(counter_gecko_isr_0)
 {
-	const struct device *dev = DEVICE_GET(counter_gecko_0);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct counter_gecko_data *const dev_data = DEV_DATA(dev);
 	counter_alarm_callback_t alarm_callback;
 	uint32_t count = RTCC_CounterGet();
@@ -392,7 +392,7 @@ static const struct counter_gecko_config counter_gecko_0_config = {
 
 static struct counter_gecko_data counter_gecko_0_data;
 
-DEVICE_AND_API_INIT(counter_gecko_0, DT_INST_LABEL(0),
-	counter_gecko_init, &counter_gecko_0_data, &counter_gecko_0_config,
+DEVICE_DT_INST_DEFINE(0, counter_gecko_init, device_pm_control_nop,
+	&counter_gecko_0_data, &counter_gecko_0_config,
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	&counter_gecko_driver_api);

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -162,8 +162,9 @@ static const struct imx_epit_config imx_epit_##idx##z_config = {	       \
 	.prescaler = DT_INST_PROP(idx, prescaler),			       \
 };									       \
 static struct imx_epit_data imx_epit_##idx##_data;			       \
-DEVICE_AND_API_INIT(epit_##idx, DT_INST_LABEL(idx),			       \
+DEVICE_DT_INST_DEFINE(idx,						       \
 		    &imx_epit_config_func_##idx,			       \
+		    device_pm_control_nop,				       \
 		    &imx_epit_##idx##_data, &imx_epit_##idx##z_config.info,    \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 		    &imx_epit_driver_api);				       \
@@ -172,7 +173,7 @@ static int imx_epit_config_func_##idx(const struct device *dev)		       \
 	imx_epit_init(dev);						       \
 	IRQ_CONNECT(DT_INST_IRQN(idx),					       \
 		    DT_INST_IRQ(idx, priority),				       \
-		    imx_epit_isr, DEVICE_GET(epit_##idx), 0);		       \
+		    imx_epit_isr, DEVICE_DT_INST_GET(idx), 0);		       \
 	irq_enable(DT_INST_IRQN(idx));					       \
 	return 0;							       \
 }

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -419,7 +419,7 @@ static const struct counter_driver_api rtc_stm32_driver_api = {
 		.get_max_relative_alarm = rtc_stm32_get_max_relative_alarm,
 };
 
-DEVICE_AND_API_INIT(rtc_stm32, DT_INST_LABEL(0), &rtc_stm32_init,
+DEVICE_DT_INST_DEFINE(0, &rtc_stm32_init, device_pm_control_nop,
 		    &rtc_data, &rtc_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &rtc_stm32_driver_api);
 
@@ -427,6 +427,6 @@ static void rtc_stm32_irq_config(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    rtc_stm32_isr, DEVICE_GET(rtc_stm32), 0);
+		    rtc_stm32_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -330,8 +330,9 @@ static int counter_xec_init(const struct device *dev)
 		.girq_bit = DT_INST_PROP(inst, girq_bit),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(counter_xec_##inst, DT_INST_LABEL(inst),	\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    counter_xec_init,				\
+			    device_pm_control_nop,			\
 			    &counter_xec_dev_data_##inst,		\
 			    &counter_xec_dev_config_##inst,		\
 			    POST_KERNEL,				\
@@ -343,7 +344,7 @@ static int counter_xec_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority),		\
 			    counter_xec_isr,				\
-			    DEVICE_GET(counter_xec_##inst), 0);		\
+			    DEVICE_DT_INST_GET(inst), 0);		\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}
 

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -215,9 +215,9 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	};								\
 									\
 	static int mcux_gpt_## n ##_init(const struct device *dev);	\
-	DEVICE_AND_API_INIT(mcux_gpt ## n,				\
-			    DT_INST_LABEL(n),				\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    mcux_gpt_## n ##_init,			\
+			    device_pm_control_nop,			\
 			    &mcux_gpt_data_ ## n,			\
 			    &mcux_gpt_config_ ## n,			\
 			    POST_KERNEL,				\
@@ -228,7 +228,7 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
-			    mcux_gpt_isr, DEVICE_GET(mcux_gpt ## n), 0);\
+			    mcux_gpt_isr, DEVICE_DT_INST_GET(n), 0);	\
 		irq_enable(DT_INST_IRQN(n));				\
 		return mcux_gpt_init(dev);				\
 	}								\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -241,8 +241,8 @@ static struct mcux_lptmr_config mcux_lptmr_config_0 = {
 	.irq_config_func = mcux_lptmr_irq_config_0,
 };
 
-DEVICE_AND_API_INIT(mcux_lptmr_0, DT_INST_LABEL(0),
-		    &mcux_lptmr_init, &mcux_lptmr_data_0,
+DEVICE_DT_INST_DEFINE(0, &mcux_lptmr_init, device_pm_control_nop,
+		    &mcux_lptmr_data_0,
 		    &mcux_lptmr_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_lptmr_driver_api);
@@ -250,7 +250,7 @@ DEVICE_AND_API_INIT(mcux_lptmr_0, DT_INST_LABEL(0),
 static void mcux_lptmr_irq_config_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
-		    mcux_lptmr_isr, DEVICE_GET(mcux_lptmr_0), 0);
+		    mcux_lptmr_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 }
 #endif	/* DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay) */

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -233,7 +233,7 @@ static const struct mcux_pit_config mcux_pit_config_0 = {
 	.irq_config_func = mcux_pit_irq_config_0,
 };
 
-DEVICE_AND_API_INIT(mcux_pit_0, DT_INST_LABEL(0), &mcux_pit_init,
+DEVICE_DT_INST_DEFINE(0, &mcux_pit_init, device_pm_control_nop,
 		    &mcux_pit_data_0, &mcux_pit_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcux_pit_driver_api);
 
@@ -241,18 +241,18 @@ static void mcux_pit_irq_config_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
 		    DT_INST_IRQ_BY_IDX(0, 0, priority), mcux_pit_isr,
-		    DEVICE_GET(mcux_pit_0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
 		    DT_INST_IRQ_BY_IDX(0, 1, priority), mcux_pit_isr,
-		    DEVICE_GET(mcux_pit_0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
 		    DT_INST_IRQ_BY_IDX(0, 2, priority), mcux_pit_isr,
-		    DEVICE_GET(mcux_pit_0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
 		    DT_INST_IRQ_BY_IDX(0, 3, priority), mcux_pit_isr,
-		    DEVICE_GET(mcux_pit_0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
 }

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -277,7 +277,7 @@ static struct mcux_rtc_config mcux_rtc_config_0 = {
 	},
 };
 
-DEVICE_AND_API_INIT(rtc, DT_INST_LABEL(0), &mcux_rtc_init,
+DEVICE_DT_INST_DEFINE(0, &mcux_rtc_init, device_pm_control_nop,
 		    &mcux_rtc_data_0, &mcux_rtc_config_0.info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_rtc_driver_api);
@@ -286,6 +286,6 @@ static void mcux_rtc_irq_config_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_rtc_isr, DEVICE_GET(rtc), 0);
+		    mcux_rtc_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/counter/counter_native_posix.c
+++ b/drivers/counter/counter_native_posix.c
@@ -154,6 +154,6 @@ static const struct counter_config_info ctr_config = {
 	.flags = DRIVER_CONFIG_INFO_FLAGS
 };
 
-DEVICE_AND_API_INIT(posix_rtc0, DT_LABEL(DT_NODELABEL(DT_COUNTER_LABEL)),
+DEVICE_DT_DEFINE(DT_NODELABEL(DT_COUNTER_LABEL), device_pm_control_nop,
 		    &ctr_init, NULL, &ctr_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ctr_api);

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -665,11 +665,11 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	BUILD_ASSERT((RTC_PROP(idx, prescaler) - 1) <=			       \
 		     RTC_PRESCALER_PRESCALER_Msk,			       \
 		     "RTC prescaler out of range");			       \
-	DEVICE_DECLARE(rtc_##idx);					       \
+	DEVICE_DT_DECLARE(RTC(idx));					       \
 	static int counter_##idx##_init(const struct device *dev)	       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(RTC(idx)), DT_IRQ(RTC(idx), priority),     \
-			    irq_handler, DEVICE_GET(rtc_##idx), 0);	       \
+			    irq_handler, DEVICE_DT_GET(RTC(idx)), 0);	       \
 		return init_rtc(dev, RTC_PROP(idx, prescaler) - 1);	       \
 	}								       \
 	static struct counter_nrfx_data counter_##idx##_data;		       \
@@ -693,9 +693,9 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			   (.fixed_top = RTC_PROP(idx, fixed_top),))	       \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
-	DEVICE_AND_API_INIT(rtc_##idx,					       \
-			    DT_LABEL(RTC(idx)),				       \
+	DEVICE_DT_DEFINE(RTC(idx),					       \
 			    counter_##idx##_init,			       \
+			    device_pm_control_nop,			       \
 			    &counter_##idx##_data,			       \
 			    &nrfx_counter_##idx##_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -397,11 +397,11 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	BUILD_ASSERT(TIMER_PROP(idx, prescaler) <=			       \
 			TIMER_PRESCALER_PRESCALER_Msk,			       \
 		     "TIMER prescaler out of range");			       \
-	DEVICE_DECLARE(timer_##idx);					       \
+	DEVICE_DT_DECLARE(TIMER(idx));					       \
 	static int counter_##idx##_init(const struct device *dev)		       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(TIMER(idx)), DT_IRQ(TIMER(idx), priority), \
-			    irq_handler, DEVICE_GET(timer_##idx), 0);	       \
+			    irq_handler, DEVICE_DT_GET(TIMER(idx)), 0);	       \
 		static const struct counter_timer_config config = {	       \
 			.freq = TIMER_PROP(idx, prescaler),		       \
 			.mode = NRF_TIMER_MODE_TIMER,			       \
@@ -428,9 +428,9 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		.timer = (NRF_TIMER_Type *)DT_REG_ADDR(TIMER(idx)),	       \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
-	DEVICE_AND_API_INIT(timer_##idx,				       \
-			    DT_LABEL(TIMER(idx)),			       \
+	DEVICE_DT_DEFINE(TIMER(idx),					       \
 			    counter_##idx##_init,			       \
+			    device_pm_control_nop,			       \
 			    &counter_##idx##_data,			       \
 			    &nrfx_counter_##idx##_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -442,9 +442,9 @@ static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 									\
 	static struct counter_sam0_tc32_data counter_sam0_tc32_dev_data_##n;\
 									\
-	DEVICE_AND_API_INIT(counter_sam0_tc32_##n,			\
-			    DT_INST_LABEL(n),				\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &counter_sam0_tc32_initialize,		\
+			    device_pm_control_nop,			\
 			    &counter_sam0_tc32_dev_data_##n,		\
 			    &counter_sam0_tc32_dev_config_##n,		\
 			    PRE_KERNEL_1,				\
@@ -456,7 +456,7 @@ static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
 			    counter_sam0_tc32_isr,			\
-			    DEVICE_GET(counter_sam0_tc32_##n), 0);	\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -345,8 +345,9 @@ static const struct counter_driver_api xlnx_axi_timer_driver_api = {
 									\
 	static struct xlnx_axi_timer_data xlnx_axi_timer_data_##n;	\
 									\
-	DEVICE_AND_API_INIT(xlnx_axi_timer_##n, DT_INST_LABEL(n),	\
-			&xlnx_axi_timer_init, &xlnx_axi_timer_data_##n,	\
+	DEVICE_DT_INST_DEFINE(n, &xlnx_axi_timer_init,			\
+			device_pm_control_nop,				\
+			&xlnx_axi_timer_data_##n,			\
 			&xlnx_axi_timer_config_##n,			\
 			POST_KERNEL,					\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -356,7 +357,7 @@ static const struct counter_driver_api xlnx_axi_timer_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    xlnx_axi_timer_isr,				\
-			    DEVICE_GET(xlnx_axi_timer_##n), 0);		\
+			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
 

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1323,8 +1323,7 @@ static struct ds3231_data ds3231_0_data;
 #error COUNTER_MAXIM_DS3231_INIT_PRIORITY must be greater than I2C_INIT_PRIORITY
 #endif
 
-DEVICE_AND_API_INIT(ds3231_0, DT_INST_LABEL(0),
-		    ds3231_init, &ds3231_0_data,
+DEVICE_DT_INST_DEFINE(0, ds3231_init, device_pm_control_nop, &ds3231_0_data,
 		    &ds3231_0_config,
 		    POST_KERNEL, CONFIG_COUNTER_MAXIM_DS3231_INIT_PRIORITY,
 		    &ds3231_api);

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -191,9 +191,9 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 		.load = UINT_MAX,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(dtmr_cmsdk_apb_##inst,			\
-			    DT_INST_LABEL(inst),			\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    dtmr_cmsdk_apb_init,			\
+			    device_pm_control_nop,			\
 			    &dtmr_cmsdk_apb_dev_data_##inst,		\
 			    &dtmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -204,7 +204,7 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority),		\
 			    dtmr_cmsdk_apb_isr,				\
-			    DEVICE_GET(dtmr_cmsdk_apb_##inst),		\
+			    DEVICE_DT_INST_GET(inst),			\
 			    0);						\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -186,9 +186,9 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 		.load = UINT32_MAX,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(tmr_cmsdk_apb_##inst,			\
-			    DT_INST_LABEL(inst),			\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    tmr_cmsdk_apb_init,				\
+			    device_pm_control_nop,			\
 			    &tmr_cmsdk_apb_dev_data_##inst,		\
 			    &tmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -199,7 +199,7 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority),		\
 			    tmr_cmsdk_apb_isr,				\
-			    DEVICE_GET(tmr_cmsdk_apb_##inst),		\
+			    DEVICE_DT_INST_GET(inst),			\
 			    0);						\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}


### PR DESCRIPTION
Convert counter drivers to use new DT variants of the DEVICE APIs.
    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>