### PR TITLE
Bluetooth: tester: Fix net send command

### DIFF
--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tester)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)
+zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/mesh)
 target_sources(app PRIVATE
     src/main.c
     src/bttester.c

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -8,10 +8,13 @@
 
 #include <bluetooth/bluetooth.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <bluetooth/mesh.h>
 #include <bluetooth/testing.h>
+#include <bluetooth/mesh/cfg.h>
 #include <sys/byteorder.h>
+#include <app_keys.h>
 
 #include <logging/log.h>
 #define LOG_MODULE_NAME bttester_mesh
@@ -44,6 +47,8 @@ static uint8_t static_auth[16];
 
 /* Vendor Model data */
 #define VND_MODEL_ID_1 0x1234
+static uint8_t vnd_app_key[16];
+static uint16_t vnd_app_key_idx = 0x000f;
 
 /* Model send data */
 #define MODEL_BOUNDS_MAX 2
@@ -427,9 +432,6 @@ static void init(uint8_t *data, uint16_t len)
 		}
 	}
 
-	/* Set device key for vendor model */
-	vnd_models[0].keys[0] = BT_MESH_KEY_DEV;
-
 rsp:
 	tester_rsp(BTP_SERVICE_ID_MESH, MESH_INIT, CONTROLLER_INDEX,
 		   status);
@@ -562,7 +564,7 @@ static void net_send(uint8_t *data, uint16_t len)
 	NET_BUF_SIMPLE_DEFINE(msg, UINT8_MAX);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net.net_idx,
-		.app_idx = BT_MESH_KEY_DEV,
+		.app_idx = vnd_app_key_idx,
 		.addr = sys_le16_to_cpu(cmd->dst),
 		.send_ttl = cmd->ttl,
 	};
@@ -570,6 +572,12 @@ static void net_send(uint8_t *data, uint16_t len)
 
 	LOG_DBG("ttl 0x%02x dst 0x%04x payload_len %d", ctx.send_ttl,
 		ctx.addr, cmd->payload_len);
+
+	if (!bt_mesh_app_key_get(vnd_app_key_idx)) {
+		(void)bt_mesh_app_key_add(vnd_app_key_idx, net.net_idx,
+					  vnd_app_key);
+		vnd_models[0].keys[0] = vnd_app_key_idx;
+	}
 
 	net_buf_simple_add_mem(&msg, cmd->payload, cmd->payload_len);
 


### PR DESCRIPTION
After change 7e302979f30e112f5a458bee063e4c8e4f75b8a1 some
MESH/NODE/NET/ tests would fail because we tried to send a message to a
non-unicast address using the device key. This patch fixes that by
defining and adding an app key for vendor model which is then used to
send network packets for these test cases.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>