### PR TITLE
Bluetooth: GATT: Make bt_gatt_unsubscribe work while disconnected

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -203,6 +203,20 @@ int bt_iso_server_register(struct bt_iso_server *server);
 int bt_iso_chan_bind(struct bt_conn **conns, uint8_t num_conns,
 		     struct bt_iso_chan **chans);
 
+/** @brief Unbind ISO channel
+ *
+ *  Unbind ISO channel from ACL connection, channel must be in BT_ISO_BOUND
+ *  state.
+ *
+ *  Note: Channels which the ACL connection has been disconnected are unbind
+ *  automatically.
+ *
+ *  @param chan Channel object.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_iso_chan_unbind(struct bt_iso_chan *chan);
+
 /** @brief Connect ISO channels
  *
  *  Connect ISO channels, once the connection is completed each channel

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1502,7 +1502,7 @@ struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 			return iso_conn;
 		}
 
-		if (conn->iso.acl == conn) {
+		if (iso_conn->iso.acl == conn) {
 			return iso_conn;
 		}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2039,7 +2039,9 @@ static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 		return err;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_DISCONNECT);
+	if (conn->state == BT_CONN_CONNECTED) {
+		bt_conn_set_state(conn, BT_CONN_DISCONNECT);
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1616,7 +1616,10 @@ static void hci_disconn_complete(struct net_buf *buf)
 	conn->err = evt->reason;
 
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
-	conn->handle = 0U;
+
+	if (conn->type != BT_CONN_TYPE_ISO) {
+		conn->handle = 0U;
+	}
 
 	if (conn->type != BT_CONN_TYPE_LE) {
 #if defined(CONFIG_BT_BREDR)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -8,6 +8,7 @@
 
 #include <zephyr.h>
 #include <sys/byteorder.h>
+#include <sys/check.h>
 
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
@@ -114,7 +115,10 @@ void hci_le_cis_estabilished(struct net_buf *buf)
 		return;
 	}
 
-	__ASSERT(conn->type == BT_CONN_TYPE_ISO, "Invalid connection type");
+	CHECKIF(conn->type != BT_CONN_TYPE_ISO) {
+		BT_DBG("Invalid connection type %u", conn->type);
+		return;
+	}
 
 	if (!evt->status) {
 		/* TODO: Add CIG sync delay */
@@ -253,7 +257,11 @@ void bt_iso_cleanup(struct bt_conn *conn)
 {
 	int i;
 
-	__ASSERT_NO_MSG(conn->type == BT_CONN_TYPE_ISO);
+	CHECKIF(!conn || conn->type != BT_CONN_TYPE_ISO) {
+		BT_DBG("Invalid parameters: conn %p conn->type %u", conn,
+		       conn ? conn->type : 0);
+		return;
+	}
 
 	BT_DBG("%p", conn);
 
@@ -641,7 +649,11 @@ int bt_iso_accept(struct bt_conn *conn)
 	struct bt_iso_chan *chan;
 	int err;
 
-	__ASSERT_NO_MSG(conn->type == BT_CONN_TYPE_ISO);
+	CHECKIF(!conn || conn->type != BT_CONN_TYPE_ISO) {
+		BT_DBG("Invalid parameters: conn %p conn->type %u", conn,
+		       conn ? conn->type : 0);
+		return -EINVAL;
+	}
 
 	BT_DBG("%p", conn);
 
@@ -708,7 +720,11 @@ void bt_iso_connected(struct bt_conn *conn)
 {
 	struct bt_iso_chan *chan;
 
-	__ASSERT_NO_MSG(conn->type == BT_CONN_TYPE_ISO);
+	CHECKIF(!conn || conn->type != BT_CONN_TYPE_ISO) {
+		BT_DBG("Invalid parameters: conn %p conn->type %u", conn,
+		       conn ? conn->type : 0);
+		return;
+	}
 
 	BT_DBG("%p", conn);
 
@@ -761,7 +777,11 @@ void bt_iso_disconnected(struct bt_conn *conn)
 {
 	struct bt_iso_chan *chan, *next;
 
-	__ASSERT_NO_MSG(conn->type == BT_CONN_TYPE_ISO);
+	CHECKIF(!conn || conn->type != BT_CONN_TYPE_ISO) {
+		BT_DBG("Invalid parameters: conn %p conn->type %u", conn,
+		       conn ? conn->type : 0);
+		return;
+	}
 
 	BT_DBG("%p", conn);
 
@@ -778,7 +798,10 @@ void bt_iso_disconnected(struct bt_conn *conn)
 
 int bt_iso_server_register(struct bt_iso_server *server)
 {
-	__ASSERT_NO_MSG(server);
+	CHECKIF(!server) {
+		BT_DBG("Invalid parameter: server %p", server);
+		return -EINVAL;
+	}
 
 	/* Check if controller is ISO capable */
 	if (!BT_FEAT_LE_CIS_SLAVE(bt_dev.le.features)) {
@@ -891,9 +914,11 @@ int bt_iso_chan_bind(struct bt_conn **conns, uint8_t num_conns,
 	int i, err;
 	static uint8_t id;
 
-	__ASSERT_NO_MSG(conns);
-	__ASSERT_NO_MSG(num_conns);
-	__ASSERT_NO_MSG(chans);
+	CHECKIF(!conns || !num_conns || !chans) {
+		BT_DBG("Invalid parameters: conns %p num_conns %u chans %p",
+		       conns, num_conns, chans);
+		return -EINVAL;
+	}
 
 	memset(&param, 0, sizeof(param));
 
@@ -918,7 +943,10 @@ int bt_iso_chan_bind(struct bt_conn **conns, uint8_t num_conns,
 
 int bt_iso_chan_unbind(struct bt_iso_chan *chan)
 {
-	__ASSERT_NO_MSG(chan);
+	CHECKIF(!chan) {
+		BT_DBG("Invalid parameter: chan %p", chan);
+		return -EINVAL;
+	}
 
 	if (!chan->conn || chan->state != BT_ISO_BOUND) {
 		return -EINVAL;
@@ -939,8 +967,11 @@ int bt_iso_chan_connect(struct bt_iso_chan **chans, uint8_t num_chans)
 	struct bt_conn *conns[CONFIG_BT_ISO_MAX_CHAN];
 	int i, err;
 
-	__ASSERT_NO_MSG(chans);
-	__ASSERT_NO_MSG(num_chans);
+	CHECKIF(!chans || !num_chans) {
+		BT_DBG("Invalid parameters: chans %p num_chans %u", chans,
+		       num_chans);
+		return -EINVAL;
+	}
 
 	for (i = 0; i < num_chans; i++) {
 		if (!chans[i]->conn) {
@@ -964,7 +995,10 @@ int bt_iso_chan_connect(struct bt_iso_chan **chans, uint8_t num_chans)
 
 int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 {
-	__ASSERT_NO_MSG(chan);
+	CHECKIF(!chan) {
+		BT_DBG("Invalid parameter: chan %p", chan);
+		return -EINVAL;
+	}
 
 	if (!chan->conn) {
 		return -ENOTCONN;
@@ -1114,8 +1148,10 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
 	struct bt_hci_iso_data_hdr *hdr;
 	static uint16_t sn;
 
-	__ASSERT_NO_MSG(chan);
-	__ASSERT_NO_MSG(buf);
+	CHECKIF(!chan || !buf) {
+		BT_DBG("Invalid parameters: chan %p buf %p", chan, buf);
+		return -EINVAL;
+	}
 
 	BT_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -724,6 +724,25 @@ static void bt_iso_remove_data_path(struct bt_conn *conn)
 	hci_le_remove_iso_data_path(conn, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
 }
 
+static void bt_iso_chan_del(struct bt_iso_chan *chan)
+{
+	BT_DBG("%p", chan);
+
+	if (!chan->conn) {
+		goto done;
+	}
+
+	if (chan->ops->disconnected) {
+		chan->ops->disconnected(chan);
+	}
+
+	bt_conn_unref(chan->conn);
+	chan->conn = NULL;
+
+done:
+	bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
+}
+
 void bt_iso_disconnected(struct bt_conn *conn)
 {
 	struct bt_iso_chan *chan, *next;
@@ -739,16 +758,7 @@ void bt_iso_disconnected(struct bt_conn *conn)
 	bt_iso_remove_data_path(conn);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->channels, chan, next, node) {
-		if (chan->ops->disconnected) {
-			chan->ops->disconnected(chan);
-		}
-
-		if (chan->conn) {
-			bt_conn_unref(chan->conn);
-			chan->conn = NULL;
-		}
-
-		bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
+		bt_iso_chan_del(chan);
 	}
 }
 
@@ -933,10 +943,8 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 	}
 
 	if (chan->state == BT_ISO_BOUND) {
-		bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
 		bt_iso_chan_remove(chan->conn, chan);
-		bt_conn_unref(chan->conn);
-		chan->conn = NULL;
+		bt_iso_chan_del(chan);
 		return 0;
 	}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -763,8 +763,9 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan)
 
 	bt_iso_chan_set_state(chan, BT_ISO_BOUND);
 
-	/* Unbind if acting as slave */
-	if (chan->conn->role == BT_HCI_ROLE_SLAVE) {
+	/* Unbind if acting as slave or ACL has been disconnected */
+	if (chan->conn->role == BT_HCI_ROLE_SLAVE ||
+	    chan->conn->iso.acl->state == BT_CONN_DISCONNECTED) {
 		bt_iso_chan_unbind(chan);
 	}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -380,10 +380,10 @@ static struct net_buf *hci_le_set_cig_params(struct bt_iso_create_param *param)
 
 		switch (param->chans[i]->qos->dir) {
 		case BT_ISO_CHAN_QOS_IN:
-			cis->m_sdu = param->chans[i]->qos->sdu;
+			cis->s_sdu = param->chans[i]->qos->sdu;
 			break;
 		case BT_ISO_CHAN_QOS_OUT:
-			cis->s_sdu = param->chans[i]->qos->sdu;
+			cis->m_sdu = param->chans[i]->qos->sdu;
 			break;
 		case BT_ISO_CHAN_QOS_INOUT:
 			cis->m_sdu = param->chans[i]->qos->sdu;


### PR DESCRIPTION
This allows application to call bt_gatt_unsubscribe while disconnected
as otherwise the parameters cannot be cleared/resused until a device is
finally connected again.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>