### PR TITLE
scripts: west_commands: runners: Extend jlink timeout for delays on Rosetta

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -127,7 +127,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         ver_re = re.compile(r'\s+V([.0-9]+)[a-zA-Z]*\s+', re.IGNORECASE)
         cmd = ([self.commander] + ['-bogus-argument-that-does-not-exist'])
         try:
-            self.check_output(cmd, timeout=0.1)
+            self.check_output(cmd, timeout=1)
         except TimeoutExpired as e:
             ver_m = ver_re.search(e.output.decode('utf-8'))
             if ver_m:


### PR DESCRIPTION
With Rosetta, jlink command runs longer than 0.1 seconds. Flashing succeeds with this timeout extended