### PR TITLE
__assert: add __ASSERT_EXPR()

### DIFF
--- a/doc/reference/kernel/other/fatal.rst
+++ b/doc/reference/kernel/other/fatal.rst
@@ -117,6 +117,26 @@ reports the failed test and its location, but lacks additional debugging
 information provided to assist the user in diagnosing the problem; its use is
 discouraged.
 
+__ASSERT_EXPR()
+---------------
+
+The ``__ASSERT_EXPR()`` macro is functionally equivalent to ``__ASSERT()`` if
+assertions are enabled.
+
+The provided test expression is still evaluated even if assertions
+are disabled, but in that case it is simply cast to ``void`` with no actions
+taken based on the result of the evaluation.
+
+This is useful for tests that have side effects which should be consistent
+regardless of assertion level, or to silence compiler warnings about checks
+against local variables containing return values which would otherwise be seen
+as assigned but not used.
+
+.. code-block:: c
+
+  int ret = do_something();
+  __ASSERT_EXPR(ret == 0, "something didn't happen");
+
 Build Assertions
 ================
 

--- a/include/sys/__assert.h
+++ b/include/sys/__assert.h
@@ -104,6 +104,8 @@ void assert_post_action(const char *file, unsigned int line);
 		__ASSERT(test, fmt, ##__VA_ARGS__);                \
 	} while (false)
 
+#define __ASSERT_EXPR(test, fmt, ...)	__ASSERT(test, fmt, ##__VA_ARGS__)
+
 #if (__ASSERT_ON == 1)
 #warning "__ASSERT() statements are ENABLED"
 #endif
@@ -111,11 +113,19 @@ void assert_post_action(const char *file, unsigned int line);
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_EXPR(test, fmt, ...)					\
+	do {								\
+		(void)(test);						\
+	} while (false)
 #endif
 #else
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_EXPR(test, fmt, ...)					\
+	do {								\
+		(void)(test);						\
+	} while (false)
 #endif
 
 #endif /* ZEPHYR_INCLUDE_SYS___ASSERT_H_ */


### PR DESCRIPTION
Variant of __ASSERT whose test expression is still evaluated
even if assertions are disabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>