### PR TITLE
kernel: userspace: aligned memory allocation for dynamic objects

### DIFF
--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -445,6 +445,25 @@ extern struct task_state_segment _main_tss;
 	CODE_UNREACHABLE; \
 } while (false)
 
+/*
+ * Dynamic thread object memory alignment.
+ *
+ * If support for SSEx extensions is enabled a 16 byte boundary is required,
+ * since the 'fxsave' and 'fxrstor' instructions require this. In all other
+ * cases a 4 byte boundary is sufficient.
+ */
+#if defined(CONFIG_EAGER_FPU_SHARING) || defined(CONFIG_LAZY_FPU_SHARING)
+#ifdef CONFIG_SSE
+#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	16
+#else
+#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
+#endif
+#else
+/* No special alignment requirements, simply align on pointer size. */
+#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	(sizeof(void *))
+#endif /* CONFIG_*_FP_SHARING */
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/arch/x86/intel64/arch.h
+++ b/include/arch/x86/intel64/arch.h
@@ -133,4 +133,9 @@ struct x86_ssf {
 				 (void (*)(const void *))isr_p,		\
 				 isr_param_p, flags_p)
 
+/*
+ * Thread object needs to be 16-byte aligned.
+ */
+#define ARCH_DYMANIC_OBJ_K_THREAD_ALIGNMENT	16
+
 #endif /* ZEPHYR_INCLUDE_ARCH_X86_INTEL64_ARCH_H_ */

--- a/include/sys/kobject.h
+++ b/include/sys/kobject.h
@@ -267,12 +267,37 @@ __syscall void *k_object_alloc(enum k_objects otype);
  * and may be freed later by passing the actual object pointer (found
  * in the returned z_object's 'name' member) to k_object_free().
  *
+ * @param align Required memory alignment for the allocated object
  * @param size Size of the allocated object
  * @return NULL on insufficient memory
  * @return A pointer to the associated z_object that is installed in the
  *	kernel object tables
  */
-struct z_object *z_dynamic_object_create(size_t size);
+struct z_object *z_dynamic_object_aligned_create(size_t align, size_t size);
+
+/**
+ * Allocate memory and install as a generic kernel object
+ *
+ * This is a low-level function to allocate some memory, and register that
+ * allocated memory in the kernel object lookup tables with type K_OBJ_ANY.
+ * Initialization state and thread permissions will be cleared. The
+ * returned z_object's data value will be uninitialized.
+ *
+ * Most users will want to use k_object_alloc() instead.
+ *
+ * Memory allocated will be drawn from the calling thread's reasource pool
+ * and may be freed later by passing the actual object pointer (found
+ * in the returned z_object's 'name' member) to k_object_free().
+ *
+ * @param size Size of the allocated object
+ * @return NULL on insufficient memory
+ * @return A pointer to the associated z_object that is installed in the
+ *	kernel object tables
+ */
+static inline struct z_object *z_dynamic_object_create(size_t size)
+{
+	return z_dynamic_object_aligned_create(0, size);
+}
 
 /**
  * Free a kernel object previously allocated with k_object_alloc()
@@ -289,6 +314,15 @@ void k_object_free(void *obj);
 static inline void *z_impl_k_object_alloc(enum k_objects otype)
 {
 	ARG_UNUSED(otype);
+
+	return NULL;
+}
+
+static inline struct z_object *z_dynamic_object_aligned_create(size_t align,
+							       size_t size)
+{
+	ARG_UNUSED(align);
+	ARG_UNUSED(size);
 
 	return NULL;
 }

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -47,6 +47,22 @@ extern char *z_setup_new_thread(struct k_thread *new_thread,
 				int prio, uint32_t options, const char *name);
 
 /**
+ * @brief Allocate aligned memory from the current thread's resource pool
+ *
+ * Threads may be assigned a resource pool, which will be used to allocate
+ * memory on behalf of certain kernel and driver APIs. Memory reserved
+ * in this way should be freed with k_free().
+ *
+ * If called from an ISR, the k_malloc() system heap will be used if it exists.
+ *
+ * @param align Required memory alignment
+ * @param size Memory allocation size
+ * @return A pointer to the allocated memory, or NULL if there is insufficient
+ * RAM in the pool or there is no pool to draw memory from
+ */
+void *z_thread_aligned_alloc(size_t align, size_t size);
+
+/**
  * @brief Allocate some memory from the current thread's resource pool
  *
  * Threads may be assigned a resource pool, which will be used to allocate
@@ -59,7 +75,10 @@ extern char *z_setup_new_thread(struct k_thread *new_thread,
  * @return A pointer to the allocated memory, or NULL if there is insufficient
  * RAM in the pool or there is no pool to draw memory from
  */
-void *z_thread_malloc(size_t size);
+static inline void *z_thread_malloc(size_t size)
+{
+	return z_thread_aligned_alloc(0, size);
+}
 
 /* set and clear essential thread flag */
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -37,11 +37,6 @@ static void *z_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t size
 	return mem + excess;
 }
 
-static void *z_heap_malloc(struct k_heap *heap, size_t size)
-{
-	return z_heap_aligned_alloc(heap, sizeof(void *), size);
-}
-
 void k_free(void *ptr)
 {
 	struct k_heap **heap_ref;
@@ -98,7 +93,7 @@ void k_thread_system_pool_assign(struct k_thread *thread)
 #define _SYSTEM_HEAP	NULL
 #endif
 
-void *z_thread_malloc(size_t size)
+void *z_thread_aligned_alloc(size_t align, size_t size)
 {
 	void *ret;
 	struct k_heap *heap;
@@ -110,7 +105,7 @@ void *z_thread_malloc(size_t size)
 	}
 
 	if (heap) {
-		ret = z_heap_malloc(heap, size);
+		ret = z_heap_aligned_alloc(heap, align, size);
 	} else {
 		ret = NULL;
 	}


### PR DESCRIPTION
This allows allocating dynamic kernel objects with memory alignment
requirements. The first candidate is for thread objects for x86
and x86_64 where saving/restoring SSE/FPU registers require strict
alignment.
    
Fixes #29589
Fixes #29629