### PR TITLE
kernel: describe detailed means of K_FP_REGS flag

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -510,7 +510,13 @@ extern void k_thread_foreach_unlocked(
 
 #if defined(CONFIG_FPU_SHARING)
 /**
- * @brief thread uses floating point registers
+ * @brief FPU registers are managed by context switch
+ *
+ * @details
+ * This option indicates that the thread uses the CPU's floating point
+ * registers. This instructs the kernel to take additional steps to save
+ * and restore the contents of these registers when scheduling the thread.
+ * No effect if @option{CONFIG_FPU_SHARING} is not enabled.
  */
 #define K_FP_REGS (BIT(1))
 #endif


### PR DESCRIPTION
Current brief of the flag is ambiguous. This patch adds more details
about K_FP_REGS flag.