### PR TITLE
Pave the way for converting nRF devicetrees to use phandles for pinmuxing

### DIFF
--- a/doc/guides/dts/bindings.rst
+++ b/doc/guides/dts/bindings.rst
@@ -15,6 +15,11 @@ dt-schema tools used by the Linux kernel). With one exception in
 :ref:`dt-inferred-bindings` the build system uses bindings when generating
 code for :ref:`dt-from-c`.
 
+.. note::
+
+   See the :ref:`devicetree_binding_index` for information on existing
+   bindings.
+
 .. _dt-binding-compat:
 
 Mapping nodes to bindings

--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -57,6 +57,8 @@ node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name
 ; The node's dependency ordinal. This is a non-negative integer
 ; value that is used to represent dependency information.
 node-macro =/ %s"DT_N" path-id %s"_ORD"
+; The node's path, as a string literal
+node-macro =/ %s"DT_N" path-id %s"_PATH"
 ; The dependency ordinals of a node's requirements (direct dependencies).
 node-macro =/ %s"DT_N" path-id %s"_REQUIRES_ORDS"
 ; The dependency ordinals of a node supports (reverse direct dependencies).

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -94,6 +94,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -79,6 +79,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		gpiote: gpiote@40006000 {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -92,6 +92,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -99,6 +99,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -89,6 +89,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -92,6 +92,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -105,6 +105,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		gpio1: gpio@50000300 {
@@ -116,6 +117,7 @@
 			ngpios = <10>;
 			label = "GPIO_1";
 			status = "disabled";
+			port = <1>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -101,6 +101,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		gpio1: gpio@50000300 {
@@ -112,6 +113,7 @@
 			ngpios = <16>;
 			label = "GPIO_1";
 			status = "disabled";
+			port = <1>;
 		};
 
 		i2c0: i2c@40003000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -332,6 +332,7 @@ gpio0: gpio@842500 {
 	#gpio-cells = <2>;
 	label = "GPIO_0";
 	status = "disabled";
+	port = <0>;
 };
 
 gpio1: gpio@842800 {
@@ -342,6 +343,7 @@ gpio1: gpio@842800 {
 	ngpios = <16>;
 	label = "GPIO_1";
 	status = "disabled";
+	port = <1>;
 };
 
 qspi: qspi@2b000 {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -101,6 +101,7 @@
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";
+			port = <0>;
 		};
 
 		gpio1: gpio@418c0800 {
@@ -111,6 +112,7 @@
 			ngpios = <16>;
 			label = "GPIO_1";
 			status = "disabled";
+			port = <1>;
 		};
 
 		gpiote: gpiote@4100a000 {

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -307,6 +307,7 @@ gpio0: gpio@842500 {
 	#gpio-cells = <2>;
 	label = "GPIO_0";
 	status = "disabled";
+	port = <0>;
 };
 
 rtc0: rtc@14000 {

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -26,14 +26,36 @@ properties:
     type: int
     required: true
     description: |
-      Pin number associated with serial clock pin
+      The SCK pin to use.
+
+      For pins P0.0 through P0.31, use the pin number. For example,
+      to use P0.16 for SCK, set:
+
+          sck-pin = <16>;
+
+      For pins P1.0 through P1.31, add 32 to the pin number. For
+      example, to use P1.2 for SCK, set:
+
+          sck-pin = <34>;  /* 32 + 2 */
   io-pins:
     type: array
     required: true
     description: |
-      Pin numbers associated with IO0 through IO3 signals
+      Pin numbers associated with IO0 through IO3 signals.
+
+      Examples:
+
+          io-pins = <io0-pin io1-pin>; // two pins
+
+          io-pins = <io0-pin io1-pin io2-pin io3-pin>; // four pins
+
+      Either two or four pins must be configured using this property
+      as shown above. The pin numbering scheme is the same as the
+      sck-pin property's.
   csn-pins:
     type: array
     required: true
     description: |
-      Pin numbers associated with chip-select signals
+      Chip select signal pin number. Exactly one pin should be
+      given. The pin numbering scheme is the same as the
+      sck-pin property's.

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -17,6 +17,18 @@ properties:
     "#gpio-cells":
       const: 2
 
+    port:
+      type: int
+      required: true
+      description: |
+        The GPIO port number. GPIO port P0 has:
+
+          port = <0>;
+
+        And P1 has:
+
+          port = <1>;
+
 gpio-cells:
   - pin
   - flags

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -16,9 +16,22 @@ properties:
     sda-pin:
       type: int
       required: true
-      description: SDA pin
+      description: |
+        The SDA pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for SDA, set:
+
+            sda-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for SDA, set:
+
+            sda-pin = <34>;  /* 32 + 2 */
 
     scl-pin:
       type: int
       required: true
-      description: SCL pin
+      description: |
+        The SCL pin to use. The pin numbering scheme is the same as
+        the sda-pin property's.

--- a/dts/bindings/i2c/nordic,nrf-twi.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi.yaml
@@ -1,7 +1,44 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWI (TWI master)
+description: |
+  Nordic nRF family TWI (TWI master).
+
+  This binding can be used for nodes which can represent TWI
+  peripherals. When a single SoC peripheral ID corresponds to multiple
+  I2C peripherals (like TWI or TWIM), the corresponding devicetree
+  nodes must be set up to select TWI before use.
+
+  To select TWI, set the node's "compatible" to "nordic,nrf-twi" and
+  its "status" to "okay", e.g. using an overlay file like this:
+
+      /* This is for TWI0 -- change to "i2c1" for TWI1. */
+      &i2c0 {
+              compatible = "nordic,nrf-twi";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  You can use either of these options to check TWI availability on
+  your SoC:
+
+      1. Check the peripheral Instantiation table in the Memory
+         section of your SoC's Product Specification document.
+         A "TWI0" instance in the table means "i2c0" in the devicetree
+         can be used with this binding, and similarly for "TWI1".
+
+      2. Open your SoC's .dtsi file and look for a node definition that
+         documents TWI support, like this:
+
+             i2c0: i2c@40003000 {
+                     /*
+                      * This i2c node can be TWI, [...].
+                      */
+                     ...
+             };
+
+   If your SoC only has TWIM and TWIS I2C peripherals, you cannot use
+   this binding. See the "nordic,nrf-twim" binding instead.
 
 compatible: "nordic,nrf-twi"
 

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -1,7 +1,25 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWIM (TWI master with EasyDMA)
+description: |
+  Nordic nRF family TWIM (TWI master with EasyDMA).
+
+  This binding can be used for nodes which can represent TWIM
+  peripherals. A single SoC peripheral ID is often associated with
+  multiple I2C peripherals, like a TWIM and a TWIS. You can choose
+  TWIM by setting the node's "compatible" to "nordic,nrf-twim"
+  and "status" to "okay", e.g. using an overlay file like this one:
+
+      /* This is for TWIM0 -- change to "i2c1" for TWIM1, etc. */
+      &i2c0 {
+              compatible = "nordic,nrf-twim";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  This works on any supported SoC, for all TWIM instances.
+
+  Note: on nRF51 SoCs, use the "nordic,nrf-twi" binding instead.
 
 compatible: "nordic,nrf-twim"
 

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -1,7 +1,29 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nordic nRF family TWIS (TWI slave with EasyDMA)
+description: |
+  Nordic nRF family TWIS (TWI slave with EasyDMA).
+
+  Note: for Zephyr users, the I2C slave API is not available for
+  these devices. See this issue for more details and a HAL-based
+  workaround:
+
+      https://github.com/zephyrproject-rtos/zephyr/issues/21445
+
+  This binding can be used for nodes which can represent TWIS
+  peripherals. A single SoC peripheral ID is often associated with
+  multiple I2C peripherals, like a TWIM and a TWIS. You can choose
+  TWIS by setting the node's "compatible" to "nordic,nrf-twis"
+  and its "status" to "okay", e.g. using an overlay file like this:
+
+      /* This is for TWIS0 -- change to "i2c1" for TWIS1, etc. */
+      &i2c0 {
+              compatible = "nordic,nrf-twis";
+              status = "okay";
+              /* other property settings can go here */
+      };
+
+  This works on any supported SoC, for all TWIS instances.
 
 compatible: "nordic,nrf-twis"
 

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -10,48 +10,65 @@ properties:
 
     center-aligned:
       type: boolean
-      description: Use center-aligned (up and down) counter mode
       required: false
+      description: Set this to use center-aligned (up and down) counter mode.
 
     ch0-pin:
       type: int
-      description: Channel 0 pin
       required: false
+      description: |
+        The channel 0 pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for channel 0, set:
+
+            ch0-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for channel 0, set:
+
+            ch0-pin = <34>;  /* 32 + 2 */
 
     ch0-inverted:
       type: boolean
-      description: Channel 0 inverted
       required: false
+      description: Set this to invert channel 0.
 
     ch1-pin:
       type: int
-      description: Channel 1 pin
       required: false
+      description: |
+        The channel 1 pin to use. The pin numbering scheme is the same
+        as the ch0-pin property's.
 
     ch1-inverted:
       type: boolean
-      description: Channel 1 inverted
       required: false
+      description: Set this to invert channel 1.
 
     ch2-pin:
       type: int
-      description: Channel 2 pin
       required: false
+      description: |
+        The channel 2 pin to use. The pin numbering scheme is the same
+        as the ch0-pin property's.
 
     ch2-inverted:
       type: boolean
-      description: Channel 2 inverted
       required: false
+      description: Set this to invert channel 2.
 
     ch3-pin:
       type: int
-      description: Channel 3 pin
       required: false
+      description: |
+        The channel 3 pin to use. The pin numbering scheme is the same
+        as the ch0-pin property's.
 
     ch3-inverted:
       type: boolean
-      description: Channel 3 inverted
       required: false
+      description: Set this to invert channel 3.
 
     "#pwm-cells":
       const: 1

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -16,23 +16,40 @@ properties:
 
     a-pin:
       type: int
-      description: A pin
       required: true
+      description: |
+        The A pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for the A pin, set:
+
+            a-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for the A pin, set:
+
+            a-pin = <34>;  /* 32 + 2 */
 
     b-pin:
       type: int
-      description: B pin
       required: true
+      description: |
+        The B pin to use. The pin numbering scheme is the same as
+        the a-pin property's.
 
     led-pin:
       type: int
-      description: LED pin for light based QDEC device
       required: false
+      description: |
+        The LED pin to use for a light based QDEC device. The pin
+        numbering scheme is the same as the a-pin property's.
 
     enable-pin:
       type: int
-      description: Enables connected QDEC device
       required: false
+      description: |
+        The enable pin to use, to enable a connected QDEC device. The
+        pin numbering scheme is the same as the a-pin property's.
 
     led-pre:
       type: int

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -1,0 +1,45 @@
+include: uart-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    tx-pin:
+      type: int
+      required: true
+      description: |
+        The TX pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for TX, set:
+
+            tx-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for TX, set:
+
+            tx-pin = <34>;  /* 32 + 2 */
+
+    rx-pin:
+      type: int
+      required: false
+      description: |
+        The RX pin to use. The pin numbering scheme is the same as the
+        tx-pin property's.
+
+    rts-pin:
+      type: int
+      required: false
+      description: |
+        The RTS pin to use. The pin numbering scheme is the same as the
+        tx-pin property's.
+
+    cts-pin:
+      type: int
+      required: false
+      description: |
+        The CTS pin to use. The pin numbering scheme is the same as the
+        tx-pin property's.

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,32 +1,10 @@
-description: Nordic UART
+description: |
+  Nordic nRF family UART.
+
+  This is the binding for the peripheral without EasyDMA support.
+  See the "nordic,nrf-uarte" binding for UARTE, i.e. UART with
+  EasyDMA.
 
 compatible: "nordic,nrf-uart"
 
-include: uart-controller.yaml
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    tx-pin:
-      type: int
-      description: TX pin
-      required: true
-
-    rx-pin:
-      type: int
-      description: RX pin
-      required: false
-
-    rts-pin:
-      type: int
-      description: RTS pin
-      required: false
-
-    cts-pin:
-      type: int
-      description: CTS pin
-      required: false
+include: nordic,nrf-uart-common.yaml

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,32 +1,5 @@
-description: Nordic UARTE
+description: Nordic nRF family UARTE (UART with EasyDMA)
 
 compatible: "nordic,nrf-uarte"
 
-include: uart-controller.yaml
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    tx-pin:
-      type: int
-      description: TX pin
-      required: true
-
-    rx-pin:
-      type: int
-      description: RX pin
-      required: false
-
-    rts-pin:
-      type: int
-      description: RTS pin
-      required: false
-
-    cts-pin:
-      type: int
-      description: CTS pin
-      required: false
+include: nordic,nrf-uart-common.yaml

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -15,14 +15,29 @@ properties:
     sck-pin:
       type: int
       required: true
-      description: SCK pin
+      description: |
+        The SCK pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for SCK, set:
+
+            sck-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for SCK, set:
+
+            sck-pin = <34>;  /* 32 + 2 */
 
     mosi-pin:
       type: int
       required: true
-      description: MOSI pin
+      description: |
+        The MOSI pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     miso-pin:
       type: int
       required: true
-      description: MISO pin
+      description: |
+        The MISO pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -11,7 +11,9 @@ properties:
     csn-pin:
       type: int
       required: true
-      description: CSN pin
+      description:  |
+          The CSN pin to use. The pin numbering scheme is the same as
+          the sck-pin property's.
 
     def-char:
       type: int

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -11,7 +11,8 @@ properties:
     clock-frequency:
       type: int
       required: false
-      description: Clock frequency the SPI peripheral is being driven at
+      description: |
+        Clock frequency the SPI peripheral is being driven at, in Hz.
     "#address-cells":
       required: true
       const: 1
@@ -23,3 +24,40 @@ properties:
     cs-gpios:
       type: phandle-array
       required: false
+      description: |
+        An array of chip select GPIOs to use. Each element
+        in the array specifies a GPIO. The index in the array
+        corresponds to the child node that the CS gpio controls.
+
+        Example:
+
+          spi@... {
+                  cs-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>,
+                                <&gpio1 10 GPIO_ACTIVE_LOW>,
+                                ...;
+
+                  spi-device@0 {
+                          reg = <0>;
+                          ...
+                  };
+                  spi-device@1 {
+                          reg = <1>;
+                          ...
+                  };
+                  ...
+          };
+
+        The child node "spi-device@0" specifies a SPI device with
+        chip select controller gpio0, pin 23, and devicetree
+        GPIO flags GPIO_ACTIVE_LOW. Similarly, "spi-device@1" has CS GPIO
+        controller gpio1, pin 10, and flags GPIO_ACTIVE_LOW. Additional
+        devices can be configured in the same way.
+
+        If unsure about the flags cell, GPIO_ACTIVE_LOW is generally a safe
+        choice for a typical "CSn" pin. GPIO_ACTIVE_HIGH may be used if
+        intervening hardware inverts the signal to the peripheral device or
+        the line itself is active high.
+
+        If this property is not defined, no chip select GPIOs are set.
+        SPI controllers with dedicated CS pins do not need to define
+        the cs-gpios property.

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -78,6 +78,9 @@
 /**
  * @brief Get a node identifier for a devicetree path
  *
+ * (This macro returns a node identifier from path components. To get
+ * a path string from a node identifier, use DT_NODE_PATH() instead.)
+ *
  * The arguments to this macro are the names of non-root nodes in the
  * tree required to reach the desired node, starting from the root.
  * Non-alphanumeric characters in each name must be converted to
@@ -370,6 +373,31 @@
  * @return node identifier for the node with the name referred to by 'child'
  */
 #define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
+
+/**
+ * @brief Get a devicetree node's full path as a string literal
+ *
+ * This returns the path to a node from a node identifier. To get a
+ * node identifier from path components instead, use DT_PATH().
+ *
+ * Example devicetree fragment:
+ *
+ *     / {
+ *             soc {
+ *                     node: my-node@12345678 { ... };
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *    DT_NODE_PATH(DT_NODELABEL(node)) // "/soc/my-node@12345678"
+ *    DT_NODE_PATH(DT_PATH(soc))       // "/soc"
+ *    DT_NODE_PATH(DT_ROOT)            // "/"
+ *
+ * @param node_id node identifier
+ * @return the node's full path in the devicetree
+ */
+#define DT_NODE_PATH(node_id) DT_CAT(node_id, _PATH)
 
 /**
  * @}

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -95,6 +95,9 @@ def main():
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
             write_node_comment(node)
 
+            out_comment(f"Node's full path:")
+            out_dt_define(f"{node.z_path_id}_PATH", f'"{escape(node.path)}"')
+
             if node.parent is not None:
                 out_comment(f"Node parent ({node.parent.path}) identifier:")
                 out_dt_define(f"{node.z_path_id}_PARENT",

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -248,11 +248,19 @@ Binding (compatible = {node.matching_compat}):
 """
 
     if node.description:
-        # Indent description by two spaces
-        s += "\nDescription:\n" + \
-            "\n".join("  " + line for line in
-                      node.description.splitlines()) + \
-            "\n"
+        # We used to put descriptions in the generated file, but
+        # devicetree bindings now have pages in the HTML
+        # documentation. Let users who are accustomed to digging
+        # around in the generated file where to find the descriptions
+        # now.
+        #
+        # Keeping them here would mean that the descriptions
+        # themselves couldn't contain C multi-line comments, which is
+        # inconvenient when we want to do things like quote snippets
+        # of .dtsi files within the descriptions, or otherwise
+        # include the string "*/".
+        s += ("\n(Descriptions have moved to the Devicetree Bindings Index\n"
+              "in the documentation.)\n")
 
     out_comment(s)
 

--- a/soc/arm/nordic_nrf/nrf51/soc.h
+++ b/soc/arm/nordic_nrf/nrf51/soc.h
@@ -11,14 +11,7 @@
 #ifndef _NORDICSEMI_NRF51_SOC_H_
 #define _NORDICSEMI_NRF51_SOC_H_
 
-#ifndef _ASMLANGUAGE
-
-#include <nrfx.h>
-
-/* Add include for DTS generated information */
-#include <devicetree.h>
-
-#endif /* !_ASMLANGUAGE */
+#include "../soc_nrf_common.h"
 
 #define NRF51_POWER_RAMON_ADDRESS              0x40000524
 #define NRF51_POWER_RAMONB_ADDRESS             0x40000554

--- a/soc/arm/nordic_nrf/nrf52/soc.h
+++ b/soc/arm/nordic_nrf/nrf52/soc.h
@@ -11,16 +11,9 @@
 #ifndef _NORDICSEMI_NRF52_SOC_H_
 #define _NORDICSEMI_NRF52_SOC_H_
 
-#ifndef _ASMLANGUAGE
+#include "../soc_nrf_common.h"
 
-#include <nrfx.h>
-
-/* Add include for DTS generated information */
-#include <devicetree.h>
-
-#endif /* !_ASMLANGUAGE */
-
-#define FLASH_PAGE_ERASE_MAX_TIME_US 	89700UL
+#define FLASH_PAGE_ERASE_MAX_TIME_US	89700UL
 #define FLASH_PAGE_MAX_CNT		256UL
 
 #endif /* _NORDICSEMI_NRF52_SOC_H_ */

--- a/soc/arm/nordic_nrf/nrf53/soc.h
+++ b/soc/arm/nordic_nrf/nrf53/soc.h
@@ -12,14 +12,7 @@
 #ifndef _NORDICSEMI_NRF53_SOC_H_
 #define _NORDICSEMI_NRF53_SOC_H_
 
-#ifndef _ASMLANGUAGE
-
-#include <nrfx.h>
-
-/* Add include for DTS generated information */
-#include <devicetree.h>
-
-#endif /* !_ASMLANGUAGE */
+#include "../soc_nrf_common.h"
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
 #define FLASH_PAGE_ERASE_MAX_TIME_US  89700UL

--- a/soc/arm/nordic_nrf/nrf91/soc.h
+++ b/soc/arm/nordic_nrf/nrf91/soc.h
@@ -11,16 +11,9 @@
 #ifndef _NORDICSEMI_NRF91_SOC_H_
 #define _NORDICSEMI_NRF91_SOC_H_
 
-#ifndef _ASMLANGUAGE
+#include "../soc_nrf_common.h"
 
-#include <nrfx.h>
-
-/* Add include for DTS generated information */
-#include <devicetree.h>
-
-#endif /* !_ASMLANGUAGE */
-
-#define FLASH_PAGE_ERASE_MAX_TIME_US 	89700UL
+#define FLASH_PAGE_ERASE_MAX_TIME_US	89700UL
 #define FLASH_PAGE_MAX_CNT		256UL
 
 #endif /* _NORDICSEMI_NRF91_SOC_H_ */

--- a/soc/arm/nordic_nrf/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/soc_nrf_common.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Common soc.h include for Nordic nRF5 SoCs.
+ */
+
+#ifndef _ZEPHYR_SOC_ARM_NORDIC_NRF_SOC_NRF_COMMON_H_
+#define _ZEPHYR_SOC_ARM_NORDIC_NRF_SOC_NRF_COMMON_H_
+
+#ifndef _ASMLANGUAGE
+#include <nrfx.h>
+#include <devicetree.h>
+#endif /* !_ASMLANGUAGE */
+
+#endif

--- a/soc/arm/nordic_nrf/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/soc_nrf_common.h
@@ -13,6 +13,68 @@
 #ifndef _ASMLANGUAGE
 #include <nrfx.h>
 #include <devicetree.h>
+#include <toolchain.h>
+
+/**
+ * @brief Convert a devicetree GPIO phandle+specifier to PSEL value
+ *
+ * Various peripherals in nRF SoCs have pin select registers, which
+ * usually have PSEL in their names. The low bits of these registers
+ * generally look like this in the register map description:
+ *
+ *     Bit number     5 4 3 2 1 0
+ *     ID             B A A A A A
+ *
+ *     ID  Field  Value    Description
+ *     A   PIN    [0..31]  Pin number
+ *     B   PORT   [0..1]   Port number
+ *
+ * Examples:
+ *
+ * - pin P0.4 has "PSEL value" 4 (B=0 and A=4)
+ * - pin P1.5 has "PSEL value" 37 (B=1 and A=5)
+ *
+ * This macro converts a devicetree GPIO phandle array value
+ * "<&gpioX pin ...>" to a "PSEL value".
+ *
+ * Note: in Nordic SoC devicetrees, "gpio0" means P0, and "gpio1"
+ * means P1. This is encoded in the "port" property of each GPIO node.
+ *
+ * Examples:
+ *
+ *     foo: my-node {
+ *             tx-gpios = <&gpio0 4 ...>;
+ *             rx-gpios = <&gpio1 5 ...>;
+ *     };
+ *
+ *     NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(foo), tx_gpios) // 0 + 4 = 4
+ *     NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(foo), rx_gpios) // 32 + 5 = 37
+ */
+#define NRF_DT_GPIOS_TO_PSEL(node_id, prop)				\
+	(DT_GPIO_PIN(node_id, prop) +					\
+	 (DT_PROP_BY_PHANDLE(node_id, prop, port) << 5))
+
+/**
+ * Error out the build if 'prop' is set on node 'node_id' and
+ * DT_GPIO_CTLR(node_id, prop) is not an SoC GPIO controller,
+ * i.e. a node with compatible "nordic,nrf-gpio".
+ *
+ * Otherwise, do nothing.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores PSEL style property
+ * @param prop_name human-readable string name for 'prop'
+ */
+#define NRF_DT_CHECK_GPIO_CTLR_IS_SOC(node_id, prop, prop_name)		\
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(node_id, prop) ||		\
+		     DT_NODE_HAS_COMPAT(DT_GPIO_CTLR(node_id, prop),	\
+					nordic_nrf_gpio),		\
+		     "Devicetree node " DT_NODE_PATH(node_id)		\
+		     " property " prop_name " must refer to a GPIO "	\
+		     " controller with compatible nordic,nrf-gpio; "	\
+		     "got " DT_NODE_PATH(DT_GPIO_CTLR(node_id, prop))	\
+		     ", which does not have this compatible")
+
 #endif /* !_ASMLANGUAGE */
 
 #endif

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1538,6 +1538,13 @@ static void test_dep_ord(void)
 	}
 }
 
+static void test_path(void)
+{
+	zassert_true(!strcmp(DT_NODE_PATH(DT_ROOT), "/"), "");
+	zassert_true(!strcmp(DT_NODE_PATH(TEST_DEADBEEF),
+			     "/test/gpio@deadbeef"), "");
+}
+
 void test_main(void)
 {
 	ztest_test_suite(devicetree_api,
@@ -1571,7 +1578,8 @@ void test_main(void)
 			 ztest_unit_test(test_parent),
 			 ztest_unit_test(test_child_nodes_list),
 			 ztest_unit_test(test_great_grandchild),
-			 ztest_unit_test(test_dep_ord)
+			 ztest_unit_test(test_dep_ord),
+			 ztest_unit_test(test_path)
 		);
 	ztest_run_test_suite(devicetree_api);
 }


### PR DESCRIPTION
RFC for now because of these questions:

1. what "flags" value should we use for I2C `sda-gpios` and `scl-gpios`? The driver ignores them, so I guess maybe documenting that and saying "just put 0" is right, even if it's a bit inconsistent with Linux's use of those properties for bit-banged I2C.
2. once we settle that, I need to convert all in-tree devicetrees to stop using the deprecated properties

Nordic SoC devices do their pinmuxing in devicetree using properties that look like `foo-pin = <PSEL value>;`, where a "PSEL value" is an integer that represents a GPIO (like P0.1, P1.2) to a bitmask with the lower 5 bits representing the pin (0-31), and the 6th bit representing the port (0 or 1).

This requires users to manually encode and decode pins to ints and vice versa.

This has two problems:

- it confuses people who aren't familiar with the underlying register maps (which usually have registers that take the PSEL values directly)
- it "hides" device dependencies on GPIO controllers, which may break automated tooling related to the devicetree, such as dependency tracking done for things like power management (#29644) or generating pin maps without special cases (https://github.com/zephyrproject-rtos/zephyr/pull/24132)

The same solution applies to both problems: use standard devicetree GPIO phandle and specifier, so you could say:

```
foo-gpios = <&gpio0 1 FLAGS>;   // P0.1
```

or

```
foo-gpios = <&gpio1 2 FLAGS>; // P1.2
```

This pull request makes that possible with backwards compatibility and sensible error messages from drivers that convert to the new style:

- both `foo-pin` and `foo-gpios` are supported, but `foo-pin` can be deprecated
- if both `foo-pin` and `foo-gpios` are given in a devicetree, the user gets a readable error message identifying the node and properties that need to be fixed
- the same is true if neither `foo-pin` nor `foo-gpios` is given

This is shown using the I2C drivers. I tested this using a sensor driver with the new `sda-gpios` and `scl-gpios` properties on nRF52840-DK.
