### PR TITLE
arch: x86_64: Correct sys_read64 return type

### DIFF
--- a/include/arch/x86/intel64/arch.h
+++ b/include/arch/x86/intel64/arch.h
@@ -28,7 +28,7 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mm_reg_t addr)
 			 : "memory");
 }
 
-static ALWAYS_INLINE uint32_t sys_read64(mm_reg_t addr)
+static ALWAYS_INLINE uint64_t sys_read64(mm_reg_t addr)
 {
 	uint64_t ret;
 


### PR DESCRIPTION
It does make sense to use uint64_t as a return type.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>