### PR TITLE
api: add C++ friendly version of Z_TIMEOUT_TICKS.

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -80,7 +80,11 @@ typedef struct {
 #define K_TIMEOUT_EQ(a, b) ((a).ticks == (b).ticks)
 
 #define Z_TIMEOUT_NO_WAIT ((k_timeout_t) {})
+#if defined(__cplusplus) && ((__cplusplus - 0) < 202002L)
+#define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { (t) })
+#else
 #define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { .ticks = (t) })
+#endif
 #define Z_FOREVER Z_TIMEOUT_TICKS(K_TICKS_FOREVER)
 
 #ifdef CONFIG_TIMEOUT_64BIT


### PR DESCRIPTION
The designated initializer used in Z_TIMEOUT_TICKS causes problems for
some C++ parsers (at least in Eclipse).
Let's use standard C++ list initialization (C++11 and up) instead.

Signed-off-by: Artur Lipowski <Artur.Lipowski@hidglobal.com>