### PR TITLE
drivers: clock_control: Avoid using kernel api in timing critical code

### DIFF
--- a/include/drivers/timer/nrf_rtc_timer.h
+++ b/include/drivers/timer/nrf_rtc_timer.h
@@ -11,6 +11,15 @@
 extern "C" {
 #endif
 
+/** @brief RTC counter bit width. */
+#define Z_NRF_RTC_TIMER_BITS 24
+
+/** @brief RTC counter span. */
+#define Z_NRF_RTC_TIMER_SPAN BIT(Z_NRF_RTC_TIMER_BITS)
+
+/** @brief RTC counter mask. */
+#define Z_NRF_RTC_TIMER_MAX BIT_MASK(Z_NRF_RTC_TIMER_BITS)
+
 typedef void (*z_nrf_rtc_timer_compare_handler_t)(uint32_t id,
 						uint32_t cc_value,
 						void *user_data);


### PR DESCRIPTION
### drivers: clock_control: Avoid using kernel api in timing critical code

When shell was enabled then high frequency stopping and starting
was logged using k_uptime_get(). This function is locking interrupts
and clock starting happens in time critical code in bluetooth stack.
    
Converted to use direct reading from RTC used for system timer. HW
register is read directly so it can be used in time critical code.
The drawback is potential invalid values reported if high frequency
clock does not change state for RTC counter span (512 seconds).

### drivers: timer: nrf_rtc_timer: Expose RTC counter bit width

Exposed RTC counter bit width in the header to allow using
is by external components.

Fixes #29994.