### PR TITLE
drivers: eeprom: Convert drivers to new DT device macros

### DIFF
--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -658,9 +658,8 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 		.write_fn = eeprom_at##t##_write, \
 	}; \
 	static struct eeprom_at2x_data eeprom_at##t##_data_##n; \
-	DEVICE_AND_API_INIT(eeprom_at##t##_##n, \
-			    DT_LABEL(INST_DT_AT2X(n, t)), \
-			    &eeprom_at2x_init, &eeprom_at##t##_data_##n, \
+	DEVICE_DT_DEFINE(INST_DT_AT2X(n, t), &eeprom_at2x_init, \
+			    device_pm_control_nop, &eeprom_at##t##_data_##n, \
 			    &eeprom_at##t##_config_##n, POST_KERNEL, \
 			    CONFIG_EEPROM_AT2X_INIT_PRIORITY, \
 			    &eeprom_at2x_api)

--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -115,7 +115,6 @@ static const struct eeprom_lpc11u6x_config eeprom_config = {
 	.size = DT_INST_PROP(0, size),
 };
 
-DEVICE_AND_API_INIT(eeprom_lpc11u6x, DT_INST_LABEL(0),
-		    &eeprom_lpc11u6x_init, NULL,
+DEVICE_DT_INST_DEFINE(0, &eeprom_lpc11u6x_init, device_pm_control_nop, NULL,
 		    &eeprom_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_lpc11u6x_api);

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -267,8 +267,8 @@ static int eeprom_sim_init(const struct device *dev)
 	return eeprom_mock_init(dev);
 }
 
-DEVICE_AND_API_INIT(eeprom_sim_0, DT_INST_LABEL(0),
-		    &eeprom_sim_init, NULL, &eeprom_sim_config_0, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, &eeprom_sim_init, device_pm_control_nop,
+		    NULL, &eeprom_sim_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_sim_api);
 
 #ifdef CONFIG_ARCH_POSIX

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -122,7 +122,6 @@ static const struct eeprom_stm32_config eeprom_config = {
 	.size = DT_INST_REG_SIZE(0),
 };
 
-DEVICE_AND_API_INIT(eeprom_stm32, DT_INST_LABEL(0),
-		    &eeprom_stm32_init, NULL,
+DEVICE_DT_INST_DEFINE(0, &eeprom_stm32_init, device_pm_control_nop, NULL,
 		    &eeprom_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_stm32_api);


### PR DESCRIPTION
Convert sensor drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>