### PR TITLE
drivers: ipm: Convert drivers to new DT device macros

### DIFF
--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -214,8 +214,9 @@ static const struct imx_mu_config imx_mu_b_config = {
 
 static struct imx_mu_data imx_mu_b_data;
 
-DEVICE_AND_API_INIT(mu_b, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &imx_mu_init,
+		    device_pm_control_nop,
 		    &imx_mu_b_data, &imx_mu_b_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &imx_mu_driver_api);
@@ -224,7 +225,7 @@ static void imx_mu_config_func_b(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    imx_mu_isr, DEVICE_GET(mu_b), 0);
+		    imx_mu_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/ipm/ipm_intel_adsp.c
+++ b/drivers/ipm/ipm_intel_adsp.c
@@ -205,8 +205,9 @@ static const struct ipm_adsp_config ipm_adsp_config = {
 
 static struct ipm_adsp_data ipm_adsp_data;
 
-DEVICE_AND_API_INIT(ipm_adsp, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &ipm_adsp_init,
+		    device_pm_control_nop,
 		    &ipm_adsp_data, &ipm_adsp_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_adsp_driver_api);
@@ -215,7 +216,7 @@ static void ipm_adsp_config_func(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    ipm_adsp_isr, DEVICE_GET(ipm_adsp), 0);
+		    ipm_adsp_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -162,8 +162,9 @@ static const struct mcux_mailbox_config mcux_mailbox_0_config = {
 
 static struct mcux_mailbox_data mcux_mailbox_0_data;
 
-DEVICE_AND_API_INIT(mailbox_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &mcux_mailbox_init,
+		    device_pm_control_nop,
 		    &mcux_mailbox_0_data, &mcux_mailbox_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &mcux_mailbox_driver_api);
@@ -173,7 +174,7 @@ static void mcux_mailbox_config_func_0(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    mcux_mailbox_isr, DEVICE_GET(mailbox_0), 0);
+		    mcux_mailbox_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));
 }

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -185,9 +185,9 @@ static struct ipm_mhu_data ipm_mhu_data_0 = {
 	.user_data = NULL,
 };
 
-DEVICE_AND_API_INIT(mhu_0,
-			DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 			&ipm_mhu_init,
+			device_pm_control_nop,
 			&ipm_mhu_data_0,
 			&ipm_mhu_cfg_0, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -199,7 +199,7 @@ static void ipm_mhu_irq_config_func_0(const struct device *d)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 			DT_INST_IRQ(0, priority),
 			ipm_mhu_isr,
-			DEVICE_GET(mhu_0),
+			DEVICE_DT_INST_GET(0),
 			0);
 	irq_enable(DT_INST_IRQN(0));
 }
@@ -216,9 +216,9 @@ static struct ipm_mhu_data ipm_mhu_data_1 = {
 	.user_data = NULL,
 };
 
-DEVICE_AND_API_INIT(mhu_1,
-			DT_INST_LABEL(1),
+DEVICE_DT_INST_DEFINE(1,
 			&ipm_mhu_init,
+			device_pm_control_nop,
 			&ipm_mhu_data_1,
 			&ipm_mhu_cfg_1, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -230,7 +230,7 @@ static void ipm_mhu_irq_config_func_1(const struct device *d)
 	IRQ_CONNECT(DT_INST_IRQN(1),
 			DT_INST_IRQ(1, priority),
 			ipm_mhu_isr,
-			DEVICE_GET(mhu_1),
+			DEVICE_DT_INST_GET(1),
 			0);
 	irq_enable(DT_INST_IRQN(1));
 }

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -27,7 +27,7 @@ static void gipm_send(uint32_t id);
 
 #if IS_ENABLED(CONFIG_IPM_NRF_SINGLE_INSTANCE)
 
-DEVICE_DECLARE(ipm_nrf);
+DEVICE_DT_INST_DECLARE(0);
 
 static void nrfx_ipc_handler(uint32_t event_mask, void *p_context)
 {
@@ -38,7 +38,7 @@ static void nrfx_ipc_handler(uint32_t event_mask, void *p_context)
 			__ASSERT(event_idx < NRFX_IPC_ID_MAX_VALUE,
 				 "Illegal event_idx: %d", event_idx);
 			event_mask &= ~BIT(event_idx);
-			nrfx_ipm_data.callback(DEVICE_GET(ipm_nrf),
+			nrfx_ipm_data.callback(DEVICE_DT_INST_GET(0),
 					       nrfx_ipm_data.user_data,
 					       event_idx,
 					       NULL);
@@ -110,8 +110,7 @@ static const struct ipm_driver_api ipm_nrf_driver_api = {
 	.set_enabled = ipm_nrf_set_enabled
 };
 
-DEVICE_AND_API_INIT(ipm_nrf, DT_INST_LABEL(0),
-		    ipm_nrf_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, ipm_nrf_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_nrf_driver_api);
 

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -295,8 +295,9 @@ static const struct stm32_ipcc_mailbox_config stm32_ipcc_mailbox_0_config = {
 
 };
 
-DEVICE_AND_API_INIT(mailbox_0, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 		    &stm32_ipcc_mailbox_init,
+		    device_pm_control_nop,
 		    &stm32_IPCC_data, &stm32_ipcc_mailbox_0_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &stm32_ipcc_mailbox_driver_api);
@@ -305,11 +306,11 @@ static void stm32_ipcc_mailbox_config_func(const struct device *dev)
 {
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, rxo, irq),
 		    DT_INST_IRQ_BY_NAME(0, rxo, priority),
-		    stm32_ipcc_mailbox_rx_isr, DEVICE_GET(mailbox_0), 0);
+		    stm32_ipcc_mailbox_rx_isr, DEVICE_DT_INST_GET(0), 0);
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, txf, irq),
 		    DT_INST_IRQ_BY_NAME(0, txf, priority),
-		    stm32_ipcc_mailbox_tx_isr, DEVICE_GET(mailbox_0), 0);
+		    stm32_ipcc_mailbox_tx_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQ_BY_NAME(0, rxo, irq));
 	irq_enable(DT_INST_IRQ_BY_NAME(0, txf, irq));


### PR DESCRIPTION
Convert ipm drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    DEVICE_GET -> DEVICE_DT_INST_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>