### PR TITLE
tests: kernel: sched: schedule_api: increase SLICE_SIZE

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -14,7 +14,17 @@
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
 /* slice size in millisecond */
+#if defined(CONFIG_SOC_FAMILY_STM32)
+/*
+ * Tests may fail with low system frequency.
+ * SLICE_SIZE = 600 allows to pass tests with frequency greater than 32MHZ.
+ * But this value is not valid for all chips: buildkite detected issue on
+ * several platforms like mps2_an521, native_posix_64, nrf52_bsim ...
+ */
+#define SLICE_SIZE 600
+#else
 #define SLICE_SIZE 200
+#endif
 /* busy for more than one slice */
 #define BUSY_MS (SLICE_SIZE + 20)
 /* a half timeslice */


### PR DESCRIPTION
tests: kernel: sched: schedule_api: increase SLICE_SIZE

Increase SLICE_SIZE in order to pass test with slow frequency:
Since merge of #29296, test was failed on some STM32 boards.
I found that boards with 'high' CPU frequency test was passed, and boards with 'low' CPU frequency test was failed.
And finally on the same board (nucleo_f746zg) when CPU freq is below 83MHz test is failed
and when CPU freq is above 84MHZ test is passed.
After some more investigation I figure out that increasing SLICE_SIZE allow to pass the test,
and I found a direct correlation between CPU frequency and SLICE_SIZE required to pass the test.
Thus SLICE_SIZE = 600 allow to pass tests with 32MHZ frequency (The lowest frequency used within STM32 boards in Zephyr).

I don't have the root cause, but maybe as said @andrewboie in #29296 

> in case the thread creation itself causes overhead which could affect the test
