### PR TITLE
Bluetooth: controller: Remove unused lll scan struct member

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -10,7 +10,6 @@ struct lll_scan {
 #if defined(CONFIG_BT_CENTRAL)
 	/* NOTE: conn context has to be after lll_hdr */
 	struct lll_conn *conn;
-	uint32_t conn_ticks_slot;
 	uint32_t conn_win_offset_us;
 	uint16_t conn_timeout;
 #endif /* CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -143,7 +143,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	lll->adv_addr_type = peer_addr_type;
 	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
 	lll->conn_timeout = timeout;
-	lll->conn_ticks_slot = 0; /* TODO: */
 
 	conn_lll = &conn->lll;
 


### PR DESCRIPTION
Remove the unused LLL scan context struct member,
conn_ticks_slot.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>