### PR TITLE
Sched: Time slice fix

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -92,10 +92,6 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 #endif
 
 	if (new_thread != old_thread) {
-#ifdef CONFIG_TIMESLICING
-		z_reset_time_slice();
-#endif
-
 		old_thread->swap_retval = -EAGAIN;
 
 #ifdef CONFIG_SMP

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -389,11 +389,6 @@ static void update_cache(int preempt_ok)
 	struct k_thread *thread = next_up();
 
 	if (should_preempt(thread, preempt_ok)) {
-#ifdef CONFIG_TIMESLICING
-		if (thread != _current) {
-			z_reset_time_slice();
-		}
-#endif
 		update_metairq_preempt(thread);
 		_kernel.ready_q.cache = thread;
 	} else {
@@ -935,9 +930,6 @@ void *z_get_next_switch_handle(void *interrupted)
 			wait_for_switch(new_thread);
 			arch_cohere_stacks(old_thread, interrupted, new_thread);
 
-#ifdef CONFIG_TIMESLICING
-			z_reset_time_slice();
-#endif
 			_current_cpu->swap_ok = 0;
 			set_current(new_thread);
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -51,6 +51,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 {
 	uint32_t t = cycles_delta(&elapsed_slice);
 	uint32_t expected_slice_min, expected_slice_max;
+	uint32_t switch_tolerance = k_ms_to_ticks_ceil32(TASK_SWITCH_TOLERANCE);
 
 	if (thread_idx == 0) {
 		/*
@@ -70,11 +71,11 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 */
 		expected_slice_min =
 			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 - TASK_SWITCH_TOLERANCE)
+			 - switch_tolerance)
 			* k_ticks_to_cyc_floor32(1);
 		expected_slice_max =
 			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 + TASK_SWITCH_TOLERANCE)
+			 + switch_tolerance)
 			* k_ticks_to_cyc_floor32(1);
 	}
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -84,6 +84,12 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 thread_idx, t, expected_slice_min, expected_slice_max);
 #endif
 
+	/* Before the assert, otherwise in case of fail the output
+	 * will give the impression that the same thread ran more than
+	 * once
+	 */
+	thread_idx = (thread_idx + 1) % NUM_THREAD;
+
 	/** TESTPOINT: timeslice should be reset for each preemptive thread */
 #ifndef CONFIG_COVERAGE
 	zassert_true(t >= expected_slice_min,
@@ -95,7 +101,6 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 #else
 	(void)t;
 #endif /* CONFIG_COVERAGE */
-	thread_idx = (thread_idx + 1) % NUM_THREAD;
 
 	/* Keep the current thread busy for more than one slice, even though,
 	 * when timeslice used up the next thread should be scheduled in.


### PR DESCRIPTION
z_reset_time_slice() should be called only when the slice time is
reached or when time slice is explicitly changed by
k_sched_time_slice_set().

Currently, z_reset_time_slice() is unconditionally called from several
places when a different thread is scheduled making the scheduler
misbehave. For instance:

Thread A

k_sched_time_slice_set(200, K_PRIO_PREEMPT(0));
/* ... spins for half slice time */
k_msleep(300);

Instead of thread B runs for the other half of the slice, it will run
for a much longer period because k_msleep() will end up calling
z_reset_time_slice() that does:

...
_current_cpu->slice_ticks = slice_time + z_clock_elapsed();
...

and the next time that the slice time expires the following condition
will be false and the thread won't be preempted

if (ticks >= _current_cpu->slice_ticks)