### PR TITLE
drivers: i2c_mchp_xec: fix incorrect timeout value

### DIFF
--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -124,7 +124,7 @@ static int xec_spin_yield(int *counter)
 {
 	*counter = *counter + 1;
 
-	if (*counter > TIMEOUT) {
+	if (*counter > WAIT_COUNT) {
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
Use WAIT_COUNT instead of TIME_OUT.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>