### PR TITLE
drivers: wifi: esp: optimize +CIPRECVDATA handling

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -497,7 +497,6 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ipd)
 	 * command but must be polled with AT+CIPRECVDATA.
 	 */
 	if (ESP_PROTO_PASSIVE(sock->ip_proto)) {
-		sock->bytes_avail = data_len;
 		k_work_submit_to_queue(&dev->workq, &sock->recvdata_work);
 		return data_offset;
 	}

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -144,9 +144,6 @@ struct esp_socket {
 	enum net_ip_protocol ip_proto;
 	struct sockaddr dst;
 
-	/* for +CIPRECVDATA */
-	size_t bytes_avail;
-
 	/* packets */
 	struct k_fifo fifo_rx_pkt;
 	struct net_pkt *tx_pkt;

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -465,8 +465,6 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 		return err;
 	}
 
-	sock->bytes_avail -= data_len;
-
 	esp_socket_rx(sock, data->rx_buf, data_offset, data_len);
 
 	return data_offset + data_len;
@@ -508,8 +506,6 @@ static void esp_recvdata_work(struct k_work *work)
 	if (ret < 0) {
 		LOG_ERR("Error during rx: link %d, ret %d", sock->link_id,
 			ret);
-	} else if (sock->bytes_avail > 0) {
-		k_work_submit_to_queue(&dev->workq, &sock->recvdata_work);
 	}
 }
 
@@ -551,8 +547,7 @@ static void esp_recv_work(struct k_work *work)
 	}
 
 	/* Should we notify that the socket has been closed? */
-	if (!esp_socket_connected(sock) && sock->bytes_avail == 0 &&
-	    sock->recv_cb) {
+	if (!esp_socket_connected(sock) && sock->recv_cb) {
 		sock->recv_cb(sock->context, NULL, NULL, NULL, 0,
 			      sock->recv_user_data);
 		k_sem_give(&sock->sem_data_ready);


### PR DESCRIPTION
It seems that we don't need to keep track of how many bytes were notified as "ready/waiting" using `+IPD` message in passive mode. It is enough to always request MRU number of bytes whenever `+IPD` has been received.

Additionally we can rely on receiving `+IPD` after each `+CIPRECVDATA` (assuming there will be more bytes to read), so we can safely schedule `AT+CIPRECVDATA` only after receving `+IPD`, removing any other logic (e.g. scheduling automatically after `AT+CIPRECVDATA` hasn't retrieved all data in single shot).