### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: Fix build

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -72,7 +72,8 @@ if(CONFIG_BT_LL_SW_SPLIT)
         ll_sw/ull_llcp_phy.c
         ll_sw/ull_llcp_remote.c
         ll_sw/ull_connections.c
-	ll_sw/ull_llcp_hci.c
+        ll_sw/ull_llcp_hci.c
+        ll_sw/ull_llcp_conn_upd.c
         )
     endif()
     if(CONFIG_BT_PERIPHERAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -29,7 +29,7 @@
 #include "ull_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_llcp
+#define LOG_MODULE_NAME bt_ctlr_ull_llcp_conn_upd
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"


### PR DESCRIPTION
zephyr/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h:391:
    undefined reference to `ull_cp_priv_lp_cu_init_proc'
arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/../../../../
   arm-zephyr-eabi/bin/ld: zephyr/subsys/bluetooth/controller/
   libsubsys__bluetooth__controller.a(ull_llcp_remote.c.obj): in function `rp_cu_run':
zephyr/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h:447:
    undefined reference to `ull_cp_priv_rp_cu_run'
collect2: error: ld returned 1 exit status

arm-zephyr-eabi/bin/ld: zephyr/subsys/bluetooth/controller/libsubsys__bluetooth__controller.a
   (ull_llcp_conn_upd.c.obj):zephyr/zephyr/subsys/bluetooth/common/log.h:38:
    multiple definition of `log_dynamic_bt_ctlr_ull_llcp'; zephyr/subsys/bluetooth/controller/
   libsubsys__bluetooth__controller.a(ull_llcp.c.obj):zephyr/zephyr/subsys/bluetooth/common/log.h:38:
    first defined here
arm-zephyr-eabi/bin/ld: zephyr/subsys/bluetooth/controller/libsubsys__bluetooth__controller.a
   (ull_llcp_conn_upd.c.obj):zephyr/zephyr/subsys/bluetooth/common/log.h:38: multiple definition of
 `log_const_bt_ctlr_ull_llcp'; zephyr/subsys/bluetooth/controller/libsubsys__bluetooth__controller.a
   (ull_llcp.c.obj):zephyr/zephyr/subsys/bluetooth/common/log.h:38: first defined here

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>