### PR TITLE
drivers: wifi: esp: use net_pkt->work and flush all TX packets before close

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -386,7 +386,7 @@ MODEM_CMD_DEFINE(on_cmd_closed)
 	}
 
 	sock->flags &= ~(ESP_SOCK_CONNECTED);
-	k_work_submit_to_queue(&dev->workq, &sock->recv_work);
+	k_work_submit_to_queue(&dev->workq, &sock->close_work);
 
 	return 0;
 }

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -144,16 +144,13 @@ struct esp_socket {
 	enum net_ip_protocol ip_proto;
 	struct sockaddr dst;
 
-	/* packets */
-	struct k_fifo fifo_rx_pkt;
-
 	/* sem */
 	struct k_sem sem_data_ready;
 
 	/* work */
 	struct k_work connect_work;
-	struct k_work recv_work;
 	struct k_work recvdata_work;
+	struct k_work close_work;
 
 	/* net context */
 	struct net_context *context;
@@ -280,6 +277,7 @@ static inline int esp_cmd_send(struct esp_data *data,
 void esp_connect_work(struct k_work *work);
 void esp_recv_work(struct k_work *work);
 void esp_recvdata_work(struct k_work *work);
+void esp_close_work(struct k_work *work);
 
 #ifdef __cplusplus
 }

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -146,14 +146,12 @@ struct esp_socket {
 
 	/* packets */
 	struct k_fifo fifo_rx_pkt;
-	struct net_pkt *tx_pkt;
 
 	/* sem */
 	struct k_sem sem_data_ready;
 
 	/* work */
 	struct k_work connect_work;
-	struct k_work send_work;
 	struct k_work recv_work;
 	struct k_work recvdata_work;
 

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -275,6 +275,10 @@ static inline int esp_cmd_send(struct esp_data *data,
 			      timeout);
 }
 
+void esp_connect_work(struct k_work *work);
+void esp_recv_work(struct k_work *work);
+void esp_recvdata_work(struct k_work *work);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -230,6 +230,8 @@ void esp_socket_close(struct esp_socket *sock);
 void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 		   size_t offset, size_t len);
 
+void esp_socket_workq_flush(struct esp_socket *sock);
+
 static inline struct esp_data *esp_socket_to_dev(struct esp_socket *sock)
 {
 	return CONTAINER_OF(sock - sock->idx, struct esp_data, sockets);

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -160,12 +160,10 @@ struct esp_socket {
 	/* net context */
 	struct net_context *context;
 	net_context_connect_cb_t connect_cb;
-	net_context_send_cb_t send_cb;
 	net_context_recv_cb_t recv_cb;
 
 	/* callback data */
 	void *conn_user_data;
-	void *send_user_data;
 	void *recv_user_data;
 };
 

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -552,10 +552,10 @@ static int esp_recv(struct net_context *context,
 
 static int esp_put(struct net_context *context)
 {
-	struct esp_socket *sock;
+	struct esp_socket *sock = context->offload_context;
 	struct net_pkt *pkt;
 
-	sock = (struct esp_socket *)context->offload_context;
+	esp_socket_workq_flush(sock);
 
 	if (esp_socket_connected(sock)) {
 		esp_socket_close(sock);

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -87,7 +87,7 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 	return ret;
 }
 
-static void esp_connect_work(struct k_work *work)
+void esp_connect_work(struct k_work *work)
 {
 	struct esp_socket *sock;
 	struct esp_data *dev;
@@ -444,7 +444,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	return data_offset + data_len;
 }
 
-static void esp_recvdata_work(struct k_work *work)
+void esp_recvdata_work(struct k_work *work)
 {
 	struct esp_socket *sock;
 	struct esp_data *dev;
@@ -476,8 +476,7 @@ static void esp_recvdata_work(struct k_work *work)
 	}
 }
 
-
-static void esp_recv_work(struct k_work *work)
+void esp_recv_work(struct k_work *work)
 {
 	struct esp_socket *sock;
 	struct esp_data *dev;
@@ -603,9 +602,6 @@ static int esp_get(sa_family_t family,
 		return -ENOMEM;
 	}
 
-	k_work_init(&sock->connect_work, esp_connect_work);
-	k_work_init(&sock->recv_work, esp_recv_work);
-	k_work_init(&sock->recvdata_work, esp_recvdata_work);
 	sock->type = type;
 	sock->ip_proto = ip_proto;
 	sock->context = *context;

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -304,12 +304,13 @@ static void esp_send_work(struct k_work *work)
 			ret);
 	}
 
+	if (sock->context->send_cb) {
+		sock->context->send_cb(sock->context, ret,
+				      sock->context->user_data);
+	}
+
 	net_pkt_unref(sock->tx_pkt);
 	sock->tx_pkt = NULL;
-
-	if (sock->send_cb) {
-		sock->send_cb(sock->context, ret, sock->send_user_data);
-	}
 }
 
 static int esp_sendto(struct net_pkt *pkt,
@@ -366,8 +367,6 @@ static int esp_sendto(struct net_pkt *pkt,
 	}
 
 	sock->tx_pkt = pkt;
-	sock->send_cb = cb;
-	sock->send_user_data = user_data;
 
 	if (timeout == 0) {
 		k_work_submit_to_queue(&dev->workq, &sock->send_work);
@@ -590,7 +589,6 @@ static int esp_put(struct net_context *context)
 
 	sock->connect_cb = NULL;
 	sock->recv_cb = NULL;
-	sock->send_cb = NULL;
 	sock->tx_pkt = NULL;
 
 	/* Drain rxfifo */

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -72,6 +72,9 @@ void esp_socket_init(struct esp_data *data)
 		sock->flags = 0;
 		k_sem_init(&sock->sem_data_ready, 0, 1);
 		k_fifo_init(&sock->fifo_rx_pkt);
+		k_work_init(&sock->connect_work, esp_connect_work);
+		k_work_init(&sock->recv_work, esp_recv_work);
+		k_work_init(&sock->recvdata_work, esp_recvdata_work);
 	}
 }
 


### PR DESCRIPTION
PR includes following improvements and fixes:
- use `net_context->send_cb` and `net_context->user_data` instead of keeping a copy in the driver itself,
- use `net_pkt->work` for scheduling RX and TX packets to `esp_workq`; this allows scheduling multiple TX packets and fixes a race condition when handling socket close and RX packets,
- initialize per-socket work items only once during driver initialization,
- flush all TX packets in `net_offload->put()` callback; this makes sure that all TX packets will actually be sent before closing socket.

Related: #30343 