### PR TITLE
Bluetooth: controller: Use PHY_xxx symbols consistently

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -207,20 +207,20 @@ void radio_pkt_configure(uint8_t bits_len, uint8_t max_len, uint8_t flags)
 
 	phy = (flags >> 1) & 0x07; /* phy */
 	switch (phy) {
-	case BIT(0):
+	case PHY_1M:
 	default:
 		extra |= (RADIO_PCNF0_PLEN_8bit << RADIO_PCNF0_PLEN_Pos) &
 			 RADIO_PCNF0_PLEN_Msk;
 		break;
 
-	case BIT(1):
+	case PHY_2M:
 		extra |= (RADIO_PCNF0_PLEN_16bit << RADIO_PCNF0_PLEN_Pos) &
 			 RADIO_PCNF0_PLEN_Msk;
 		break;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
 #if defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
-	case BIT(2):
+	case PHY_CODED:
 		extra |= (RADIO_PCNF0_PLEN_LongRange << RADIO_PCNF0_PLEN_Pos) &
 			 RADIO_PCNF0_PLEN_Msk;
 		extra |= (2UL << RADIO_PCNF0_CILEN_Pos) & RADIO_PCNF0_CILEN_Msk;
@@ -471,7 +471,7 @@ static void sw_switch(uint8_t dir, uint8_t phy_curr, uint8_t flags_curr, uint8_t
 			HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI(
 			    sw_tifs_toggle);
 
-		if (phy_curr & BIT(2)) {
+		if (phy_curr & PHY_CODED) {
 			/* Switching to TX after RX on LE Coded PHY. */
 
 			uint8_t cc_s2 =
@@ -1056,13 +1056,13 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt)
 	/* Select CCM data rate based on current PHY in use. */
 	switch (phy) {
 	default:
-	case BIT(0):
+	case PHY_1M:
 		mode |= (CCM_MODE_DATARATE_1Mbit <<
 			 CCM_MODE_DATARATE_Pos) &
 			CCM_MODE_DATARATE_Msk;
 		break;
 
-	case BIT(1):
+	case PHY_2M:
 		mode |= (CCM_MODE_DATARATE_2Mbit <<
 			 CCM_MODE_DATARATE_Pos) &
 			CCM_MODE_DATARATE_Msk;
@@ -1070,7 +1070,7 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt)
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
 #if defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
-	case BIT(2):
+	case PHY_CODED:
 		mode |= (CCM_MODE_DATARATE_125Kbps <<
 			 CCM_MODE_DATARATE_Pos) &
 			CCM_MODE_DATARATE_Msk;
@@ -1189,7 +1189,7 @@ void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags)
 
 	/* Check if extended PDU or non-1M and not legacy PDU */
 	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
-	    ((flags & BIT(1)) || (!(flags & BIT(0)) && (phy > BIT(0))))) {
+	    ((flags & BIT(1)) || (!(flags & BIT(0)) && (phy > PHY_1M)))) {
 		addrptr = NRF_RADIO->PACKETPTR + 1;
 		bcc = 80;
 	} else {
@@ -1198,7 +1198,7 @@ void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags)
 	}
 
 	/* For Coded PHY adjust for CI and TERM1 */
-	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) && (phy == BIT(2))) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) && (phy == PHY_CODED)) {
 		bcc += 5;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1199,11 +1199,11 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
 		struct pdu_adv *pdu_adv_rx;
 
 		switch (lll->phy) {
-		case BIT(0):
+		case PHY_1M:
 			node_rx->hdr.type = NODE_RX_TYPE_EXT_1M_REPORT;
 			break;
 
-		case BIT(2):
+		case PHY_CODED:
 			node_rx->hdr.type = NODE_RX_TYPE_EXT_CODED_REPORT;
 			break;
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -1096,11 +1096,11 @@ static uint32_t isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (lll->phy) {
 		switch (lll->phy) {
-		case BIT(0):
+		case PHY_1M:
 			node_rx->hdr.type = NODE_RX_TYPE_EXT_1M_REPORT;
 			break;
 
-		case BIT(2):
+		case PHY_CODED:
 			node_rx->hdr.type = NODE_RX_TYPE_EXT_CODED_REPORT;
 			break;
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_tim_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_tim_internal.h
@@ -16,11 +16,11 @@ static inline uint32_t addr_us_get(uint8_t phy)
 {
 	switch (phy) {
 	default:
-	case BIT(0):
+	case PHY_1M:
 		return 40;
-	case BIT(1):
+	case PHY_2M:
 		return 24;
-	case BIT(2):
+	case PHY_CODED:
 		return 376;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -819,9 +819,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN,
 					       lll->phy_s);
 #else
-		/* Use the default 1M packet max time. Value of 0 is
-		 * equivalent to using BIT(0).
-		 */
+		/* Use the default 1M packet max time */
 		conn_lll->max_tx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
@@ -838,9 +836,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 			conn_lll->phy_rx = lll->phy_s;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 		} else {
-			conn_lll->phy_tx = BIT(0);
-			conn_lll->phy_tx_time = BIT(0);
-			conn_lll->phy_rx = BIT(0);
+			conn_lll->phy_tx = PHY_1M;
+			conn_lll->phy_tx_time = PHY_1M;
+			conn_lll->phy_rx = PHY_1M;
 		}
 #endif /* CONFIG_BT_CTLR_PHY */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1542,7 +1542,7 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 #if defined(CONFIG_BT_CTLR_PHY)
 	switch (lll->phy_tx_time) {
 	default:
-	case BIT(0):
+	case PHY_1M:
 		/* 1M PHY, 1us = 1 bit, hence divide by 8.
 		 * Deduct 10 bytes for preamble (1), access address (4),
 		 * header (2), and CRC (3).
@@ -1550,7 +1550,7 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 		max_tx_octets = (lll->max_tx_time >> 3) - 10;
 		break;
 
-	case BIT(1):
+	case PHY_2M:
 		/* 2M PHY, 1us = 2 bits, hence divide by 4.
 		 * Deduct 11 bytes for preamble (2), access address (4),
 		 * header (2), and CRC (3).
@@ -1559,7 +1559,7 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 		break;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	case BIT(2):
+	case PHY_CODED:
 		if (lll->phy_flags & 0x01) {
 			/* S8 Coded PHY, 8us = 1 bit, hence divide by
 			 * 64.
@@ -1636,17 +1636,17 @@ static int init_reset(void)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	/* Initialize the PHY defaults */
-	default_phy_tx = BIT(0);
-	default_phy_rx = BIT(0);
+	default_phy_tx = PHY_1M;
+	default_phy_rx = PHY_1M;
 
 #if defined(CONFIG_BT_CTLR_PHY_2M)
-	default_phy_tx |= BIT(1);
-	default_phy_rx |= BIT(1);
+	default_phy_tx |= PHY_2M;
+	default_phy_rx |= PHY_2M;
 #endif /* CONFIG_BT_CTLR_PHY_2M */
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	default_phy_tx |= BIT(2);
-	default_phy_rx |= BIT(2);
+	default_phy_tx |= PHY_CODED;
+	default_phy_rx |= PHY_CODED;
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 #endif /* CONFIG_BT_CTLR_PHY */
 
@@ -3514,23 +3514,23 @@ static inline void event_phy_req_prep(struct ll_conn *conn)
 		conn->llcp_phy.ack = conn->llcp_phy.req;
 
 		/* select only one tx phy, prefer 2M */
-		if (conn->llcp_phy.tx & BIT(1)) {
-			conn->llcp_phy.tx = BIT(1);
-		} else if (conn->llcp_phy.tx & BIT(0)) {
-			conn->llcp_phy.tx = BIT(0);
-		} else if (conn->llcp_phy.tx & BIT(2)) {
-			conn->llcp_phy.tx = BIT(2);
+		if (conn->llcp_phy.tx & PHY_2M) {
+			conn->llcp_phy.tx = PHY_2M;
+		} else if (conn->llcp_phy.tx & PHY_1M) {
+			conn->llcp_phy.tx = PHY_1M;
+		} else if (conn->llcp_phy.tx & PHY_CODED) {
+			conn->llcp_phy.tx = PHY_CODED;
 		} else {
 			conn->llcp_phy.tx = 0U;
 		}
 
 		/* select only one rx phy, prefer 2M */
-		if (conn->llcp_phy.rx & BIT(1)) {
-			conn->llcp_phy.rx = BIT(1);
-		} else if (conn->llcp_phy.rx & BIT(0)) {
-			conn->llcp_phy.rx = BIT(0);
-		} else if (conn->llcp_phy.rx & BIT(2)) {
-			conn->llcp_phy.rx = BIT(2);
+		if (conn->llcp_phy.rx & PHY_2M) {
+			conn->llcp_phy.rx = PHY_2M;
+		} else if (conn->llcp_phy.rx & PHY_1M) {
+			conn->llcp_phy.rx = PHY_1M;
+		} else if (conn->llcp_phy.rx & PHY_CODED) {
+			conn->llcp_phy.rx = PHY_CODED;
 		} else {
 			conn->llcp_phy.rx = 0U;
 		}
@@ -5252,8 +5252,9 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 			 * will be restricted to fit current
 			 * connEffectiveMaxTxTime.
 			 */
-			uint8_t phy_tx_time[8] = {BIT(0), BIT(0), BIT(1), BIT(0),
-					       BIT(2), BIT(2), BIT(2), BIT(2)};
+			uint8_t phy_tx_time[8] = {PHY_1M, PHY_1M, PHY_2M,
+						  PHY_1M, PHY_CODED, PHY_CODED,
+						  PHY_CODED, PHY_CODED};
 			struct lll_conn *lll = &conn->lll;
 			uint8_t phys;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -181,10 +181,10 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	conn_lll->phy_tx = BIT(0);
+	conn_lll->phy_tx = PHY_1M;
 	conn_lll->phy_flags = 0;
-	conn_lll->phy_tx_time = BIT(0);
-	conn_lll->phy_rx = BIT(0);
+	conn_lll->phy_tx_time = PHY_1M;
+	conn_lll->phy_rx = PHY_1M;
 #endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
@@ -352,7 +352,7 @@ uint8_t ll_connect_enable(uint8_t is_coded_included)
 	}
 
 	if (!is_coded_included ||
-	    (scan->lll.phy & BIT(0))) {
+	    (scan->lll.phy & PHY_1M)) {
 		err = ull_scan_enable(scan);
 		if (err) {
 			return err;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -185,7 +185,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & BT_HCI_LE_EXT_SCAN_PHY_1M))
+	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	{
 		err = duration_period_setup(scan, duration, period,
@@ -233,7 +233,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & BT_HCI_LE_EXT_SCAN_PHY_1M))
+	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	{
 		err = duration_period_update(scan, is_update_1m);
@@ -255,7 +255,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 	}
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & BT_HCI_LE_EXT_SCAN_PHY_1M))
+	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 	{
@@ -525,7 +525,7 @@ void ull_scan_term_dequeue(uint8_t handle)
 		struct ll_scan_set *scan_coded;
 
 		scan_coded = ull_scan_set_get(SCAN_HANDLE_PHY_CODED);
-		if (scan_coded->lll.phy & BT_HCI_LE_EXT_SCAN_PHY_CODED) {
+		if (scan_coded->lll.phy & PHY_CODED) {
 			uint8_t err;
 
 			err = disable(SCAN_HANDLE_PHY_CODED);
@@ -535,7 +535,7 @@ void ull_scan_term_dequeue(uint8_t handle)
 		struct ll_scan_set *scan_1m;
 
 		scan_1m = ull_scan_set_get(SCAN_HANDLE_1M);
-		if (scan_1m->lll.phy & BT_HCI_LE_EXT_SCAN_PHY_1M) {
+		if (scan_1m->lll.phy & PHY_1M) {
 			uint8_t err;
 
 			err = disable(SCAN_HANDLE_1M);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -124,13 +124,13 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			/* Here we are scanner context */
 			sync = sync_create_get(scan);
 			switch (phy) {
-			case BT_HCI_LE_EXT_SCAN_PHY_1M:
+			case PHY_1M:
 				rx->type = NODE_RX_TYPE_EXT_1M_REPORT;
 				break;
-			case BT_HCI_LE_EXT_SCAN_PHY_2M:
+			case PHY_2M:
 				rx->type = NODE_RX_TYPE_EXT_2M_REPORT;
 				break;
-			case BT_HCI_LE_EXT_SCAN_PHY_CODED:
+			case PHY_CODED:
 				rx->type = NODE_RX_TYPE_EXT_CODED_REPORT;
 				break;
 			default:


### PR DESCRIPTION
We have convenient PHY_1M, PHY_2M and PHY_CODED symbols defined but
they are not used too much in the code. This replaces all usages of
magic numbers and other symbols as PHY constants with those symbols.

Signed-off-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>