### PR TITLE
arch: x86: Fix early_serial build error when using fixed MMIO address

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -27,7 +27,7 @@ static mm_reg_t mmio;
 /* Still other devices use a MMIO region containing packed byte
  * registers
  */
-#if DEVICE_MMIO_IS_IN_RAM
+#ifdef DEVICE_MMIO_IS_IN_RAM
 static mm_reg_t mmio;
 #define BASE mmio
 #else


### PR DESCRIPTION
Fix the following complilation error that happens when specifying a
fixed MMIO address for the UART through X86_SOC_EARLY_SERIAL_MMIO8_ADDR:

arch/x86/core/early_serial.c:30:26: error: #if with no expression
   30 | #if DEVICE_MMIO_IS_IN_RAM

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>