### PR TITLE
drivers: pinmux: Convert drivers to new DT device macros

### DIFF
--- a/drivers/pinmux/pinmux_lpc11u6x.c
+++ b/drivers/pinmux/pinmux_lpc11u6x.c
@@ -108,8 +108,8 @@ static const struct pinmux_lpc11u6x_config			\
 	.npins = DT_INST_REG_SIZE(id) / 4,			\
 };								\
 								\
-DEVICE_AND_API_INIT(pinmux_lpc11u6x_##id, DT_INST_LABEL(id),	\
-		    &pinmux_lpc11u6x_init, NULL,		\
+DEVICE_DT_INST_DEFINE(id, &pinmux_lpc11u6x_init,		\
+		    device_pm_control_nop, NULL,		\
 		    &pinmux_lpc11u6x_config_##id, PRE_KERNEL_1,	\
 		    CONFIG_PINMUX_INIT_PRIORITY,		\
 		    &pinmux_lpc11u6x_driver_api);

--- a/drivers/pinmux/pinmux_mchp_xec.c
+++ b/drivers/pinmux/pinmux_mchp_xec.c
@@ -129,9 +129,9 @@ static const struct pinmux_xec_config pinmux_xec_port000_036_config = {
 	.port_num = MCHP_GPIO_000_036,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port000_036,
-		    DT_LABEL(DT_NODELABEL(pinmux_000_036)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_000_036),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port000_036_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -143,9 +143,9 @@ static const struct pinmux_xec_config pinmux_xec_port040_076_config = {
 	.port_num = MCHP_GPIO_040_076,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port040_076,
-		    DT_LABEL(DT_NODELABEL(pinmux_040_076)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_040_076),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port040_076_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -157,9 +157,9 @@ static const struct pinmux_xec_config pinmux_xec_port100_136_config = {
 	.port_num = MCHP_GPIO_100_136,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port100_136,
-		    DT_LABEL(DT_NODELABEL(pinmux_100_136)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_100_136),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port100_136_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -171,9 +171,9 @@ static const struct pinmux_xec_config pinmux_xec_port140_176_config = {
 	.port_num = MCHP_GPIO_140_176,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port140_176,
-		    DT_LABEL(DT_NODELABEL(pinmux_140_176)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_140_176),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port140_176_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -185,9 +185,9 @@ static const struct pinmux_xec_config pinmux_xec_port200_236_config = {
 	.port_num = MCHP_GPIO_200_236,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port200_236,
-		    DT_LABEL(DT_NODELABEL(pinmux_200_236)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_200_236),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port200_236_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -199,9 +199,9 @@ static const struct pinmux_xec_config pinmux_xec_port240_276_config = {
 	.port_num = MCHP_GPIO_240_276,
 };
 
-DEVICE_AND_API_INIT(pinmux_xec_port240_276,
-		    DT_LABEL(DT_NODELABEL(pinmux_240_276)),
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_240_276),
 		    &pinmux_xec_init,
+		    device_pm_control_nop,
 		    NULL, &pinmux_xec_port240_276_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);

--- a/drivers/pinmux/pinmux_npcx.c
+++ b/drivers/pinmux/pinmux_npcx.c
@@ -81,9 +81,9 @@ static int npcx_pinctrl_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(npcx_pinctrl,
-		    DT_LABEL(DT_NODELABEL(scfg)),
+DEVICE_DT_DEFINE(DT_NODELABEL(scfg),
 		    &npcx_pinctrl_init,
+		    device_pm_control_nop,
 		    NULL, &npcx_pinctrl_cfg,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    NULL);

--- a/drivers/pinmux/pinmux_rv32m1.c
+++ b/drivers/pinmux/pinmux_rv32m1.c
@@ -75,8 +75,9 @@ static const struct pinmux_driver_api pinmux_rv32m1_driver_api = {
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(n),		\
 	};								\
 									\
-	DEVICE_AND_API_INIT(pinmux_rv32m1_##n, DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &pinmux_rv32m1_init,			\
+			    device_pm_control_nop,			\
 			    NULL, &pinmux_rv32m1_##n##_config,		\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/pinmux/pinmux_sam0.c
+++ b/drivers/pinmux/pinmux_sam0.c
@@ -78,8 +78,8 @@ static const struct pinmux_sam0_config pinmux_sam0_config_0 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_a)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_0, DT_LABEL(DT_NODELABEL(pinmux_a)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_0,
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_a), pinmux_sam0_init,
+		    device_pm_control_nop, NULL, &pinmux_sam0_config_0,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -89,8 +89,8 @@ static const struct pinmux_sam0_config pinmux_sam0_config_1 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_b)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_1, DT_LABEL(DT_NODELABEL(pinmux_b)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_1,
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_b), pinmux_sam0_init,
+		    device_pm_control_nop, NULL, &pinmux_sam0_config_1,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -100,8 +100,8 @@ static const struct pinmux_sam0_config pinmux_sam0_config_2 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_c)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_2, DT_LABEL(DT_NODELABEL(pinmux_c)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_2,
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_c), pinmux_sam0_init,
+		    device_pm_control_nop, NULL, &pinmux_sam0_config_2,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -111,8 +111,8 @@ static const struct pinmux_sam0_config pinmux_sam0_config_3 = {
 	.regs = (PortGroup *)DT_REG_ADDR(DT_NODELABEL(pinmux_d)),
 };
 
-DEVICE_AND_API_INIT(pinmux_sam0_3, DT_LABEL(DT_NODELABEL(pinmux_d)),
-		    pinmux_sam0_init, NULL, &pinmux_sam0_config_3,
+DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_d), pinmux_sam0_init,
+		    device_pm_control_nop, NULL, &pinmux_sam0_config_3,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif


### PR DESCRIPTION
Convert pinmux drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT{_INST}_DEFINE

etc..

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>