### PR TITLE
drivers: timer: nrf_rtc_timer: Add lockless, non-wraping counter reading

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -395,9 +395,13 @@ uint32_t sys_clock_elapsed(void)
 
 uint32_t sys_clock_cycle_get_32(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = counter_sub(counter(), last_count) + last_count;
+	volatile uint32_t *base = &last_count;
+	uint32_t ret, anchor;
 
-	k_spin_unlock(&lock, key);
+	do {
+		anchor = *base;
+		ret = counter_sub(counter(), anchor) + anchor;
+	} while (anchor != *base);
+
 	return ret;
 }


### PR DESCRIPTION
Updates z_timer_cycle_get_32 to use lockless algorithm.

Proposed algorithm is also faster than the previous one.

Additionally, updated clock control to not use locking `k_uptime_get()`:

### drivers: clock_control: Use k_cycle_get_32() for start/sop timestamping
    
When shell command is enabled, start/stop is timestamped to provide
status. Previously, k_uptime_get() was used which locks interrupts and
takes more cycles. It was leading to bluetooth failures because
clock is controlled in critical path and any delays are unaccepted.
    
Converted to use k_cycle_get_32() which has lockless implementation
but is limited to 32 bits which means that status will be invalid
if clock state change occurs too far in the past (~36 hours). Note was
added to status command help message.

Fixes #29994.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>