### PR TITLE
drivers: interrupt_controller: Convert drivers to new DT device macros

### DIFF
--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -147,8 +147,9 @@ static const struct irq_next_level_api cavs_apis = {
 	static struct cavs_ictl_runtime cavs_##n##_runtime = {		\
 		.base_addr = DT_INST_REG_ADDR(n),			\
 	};								\
-	DEVICE_AND_API_INIT(cavs_ictl_##n, DT_INST_LABEL(n),		\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    cavs_ictl_##n##_initialize,			\
+			    device_pm_control_nop,			\
 			    &cavs_##n##_runtime, &cavs_config_##n,	\
 			    PRE_KERNEL_1,				\
 			    CONFIG_CAVS_ICTL_INIT_PRIORITY, &cavs_apis);\
@@ -156,7 +157,7 @@ static const struct irq_next_level_api cavs_apis = {
 	static void cavs_config_##n##_irq(const struct device *port)	\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
-			    cavs_ictl_isr, DEVICE_GET(cavs_ictl_##n),	\
+			    cavs_ictl_isr, DEVICE_DT_INST_GET(n),	\
 			    DT_INST_IRQ(n, sense));			\
 	}
 

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -143,15 +143,15 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	.intr_get_line_state = dw_ictl_intr_get_line_state,
 };
 
-DEVICE_AND_API_INIT(dw_ictl, DT_INST_LABEL(0),
-		    dw_ictl_initialize, NULL, &dw_config,
-		    PRE_KERNEL_1, CONFIG_DW_ICTL_INIT_PRIORITY, &dw_ictl_apis);
+DEVICE_DT_INST_DEFINE(0, dw_ictl_initialize, device_pm_control_nop,
+		NULL, &dw_config, PRE_KERNEL_1,
+		CONFIG_DW_ICTL_INIT_PRIORITY, &dw_ictl_apis);
 
 static void dw_ictl_config_irq(const struct device *port)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
 		    dw_ictl_isr,
-		    DEVICE_GET(dw_ictl),
+		    DEVICE_DT_INST_GET(0),
 		    DT_INST_IRQ(0, sense));
 }

--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -129,7 +129,7 @@ static const struct vtd_ictl_cfg vtd_ictl_cfg_0 = {
 	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
 };
 
-DEVICE_DEFINE(vtd_ictl, DT_INST_LABEL(0),
+DEVICE_DT_INST_DEFINE(0,
 	      vtd_ictl_init, device_pm_control_nop,
 	      &vtd_ictl_data_0, &vtd_ictl_cfg_0,
 	      PRE_KERNEL_1, CONFIG_INTEL_VTD_ICTL_INIT_PRIORITY, &vtd_api);

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -351,8 +351,9 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 		.index = DT_PROP(DT_NODELABEL(miwu##inst), index),             \
 	};                                                                     \
 									       \
-	DEVICE_AND_API_INIT(intc_miwu_##inst, DT_INST_LABEL(inst),             \
+	DEVICE_DT_INST_DEFINE(inst,					       \
 			    NPCX_MIWU_INIT_FUNC(inst),                         \
+			    device_pm_control_nop,			       \
 			    NULL, &miwu_config_##inst,                         \
 			    PRE_KERNEL_1,                                      \
 			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS, NULL);        \
@@ -364,7 +365,7 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_INIT)
 
 /* MIWU module instances */
-#define NPCX_MIWU_DEV(inst) DEVICE_GET(intc_miwu_##inst),
+#define NPCX_MIWU_DEV(inst) DEVICE_DT_INST_GET(inst),
 
 static const struct device *miwu_devs[] = {
 	DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_DEV)

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -50,7 +50,7 @@ struct rv32m1_intmux_config {
 
 #define DEV_REGS(dev) (DEV_CFG(dev)->regs)
 
-DEVICE_DECLARE(intmux);
+DEVICE_DT_INST_DECLARE(0);
 
 /*
  * <irq_nextlevel.h> API
@@ -111,7 +111,7 @@ static int rv32m1_intmux_get_line_state(const struct device *dev,
 
 static void rv32m1_intmux_isr(const void *arg)
 {
-	const struct device *dev = DEVICE_GET(intmux);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	INTMUX_Type *regs = DEV_REGS(dev);
 	uint32_t channel = POINTER_TO_UINT(arg);
 	uint32_t line = (regs->CHANNEL[channel].CHn_VEC >> 2);
@@ -220,7 +220,6 @@ static int rv32m1_intmux_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(intmux, DT_INST_LABEL(0),
-		    &rv32m1_intmux_init, NULL,
+DEVICE_DT_INST_DEFINE(0, &rv32m1_intmux_init, device_pm_control_nop, NULL,
 		    &rv32m1_intmux_cfg, PRE_KERNEL_1,
 		    CONFIG_RV32M1_INTMUX_INIT_PRIORITY, &rv32m1_intmux_apis);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -30,7 +30,7 @@ struct sam0_eic_data {
 #define DEV_DATA(dev) \
 	((struct sam0_eic_data *const)(dev)->data)
 
-DEVICE_DECLARE(sam0_eic);
+DEVICE_DT_INST_DECLARE(0);
 
 
 static void wait_synchronization(void)
@@ -101,7 +101,7 @@ static void sam0_eic_isr(const struct device *dev)
 int sam0_eic_acquire(int port, int pin, enum sam0_eic_trigger trigger,
 		     bool filter, sam0_eic_callback_t cb, void *data)
 {
-	const struct device *dev = DEVICE_GET(sam0_eic);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_port_data *port_data;
 	struct sam0_eic_line_assignment *line_assignment;
@@ -191,7 +191,7 @@ err_in_use:
 
 static bool sam0_eic_check_ownership(int port, int pin, int line_index)
 {
-	const struct device *dev = DEVICE_GET(sam0_eic);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_line_assignment *line_assignment =
 		&dev_data->lines[line_index];
@@ -210,7 +210,7 @@ static bool sam0_eic_check_ownership(int port, int pin, int line_index)
 
 int sam0_eic_release(int port, int pin)
 {
-	const struct device *dev = DEVICE_GET(sam0_eic);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	uint32_t mask;
 	int line_index;
@@ -301,7 +301,7 @@ int sam0_eic_disable_interrupt(int port, int pin)
 
 uint32_t sam0_eic_interrupt_pending(int port)
 {
-	const struct device *dev = DEVICE_GET(sam0_eic);
+	const struct device *dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_line_assignment *line_assignment;
 	uint32_t set = EIC->INTFLAG.reg;
@@ -333,7 +333,7 @@ uint32_t sam0_eic_interrupt_pending(int port)
 	do {								\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, n, irq),		\
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		\
-			    sam0_eic_isr, DEVICE_GET(sam0_eic), 0);	\
+			    sam0_eic_isr, DEVICE_DT_INST_GET(0), 0);	\
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		\
 	} while (0)
 
@@ -413,7 +413,7 @@ static int sam0_eic_init(const struct device *dev)
 }
 
 static struct sam0_eic_data eic_data;
-DEVICE_DEFINE(sam0_eic, DT_INST_LABEL(0), sam0_eic_init,
-	      NULL, &eic_data, NULL,
+DEVICE_DT_INST_DEFINE(0, sam0_eic_init,
+	      device_pm_control_nop, &eic_data, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 	      NULL);

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -136,8 +136,8 @@ const struct shared_irq_config shared_irq_config_0 = {
 
 struct shared_irq_runtime shared_irq_0_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_0, DT_INST_LABEL(0),
-		shared_irq_initialize, &shared_irq_0_runtime,
+DEVICE_DT_INST_DEFINE(0, shared_irq_initialize,
+		device_pm_control_nop, &shared_irq_0_runtime,
 		&shared_irq_config_0, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
@@ -145,7 +145,7 @@ void shared_irq_config_0_irq(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    shared_irq_isr, DEVICE_GET(shared_irq_0),
+		    shared_irq_isr, DEVICE_DT_INST_GET(0),
 		    DT_INST_IRQ(0, sense));
 }
 
@@ -162,8 +162,8 @@ const struct shared_irq_config shared_irq_config_1 = {
 
 struct shared_irq_runtime shared_irq_1_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_1, DT_INST_LABEL(1),
-		shared_irq_initialize, &shared_irq_1_runtime,
+DEVICE_DT_INST_DEFINE(1, shared_irq_initialize,
+		device_pm_control_nop, &shared_irq_1_runtime,
 		&shared_irq_config_1, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
@@ -171,7 +171,7 @@ void shared_irq_config_1_irq(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(1),
 		    DT_INST_IRQ(1, priority),
-		    shared_irq_isr, DEVICE_GET(shared_irq_1),
+		    shared_irq_isr, DEVICE_DT_INST_GET(1),
 		    DT_INST_IRQ(1, sense));
 }
 


### PR DESCRIPTION
Convert interrupt_controller drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    DEVICE_GET -> DEVICE_DT_INST_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

etc...

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>