### PR TITLE
drivers: memc: Convert drivers to new DT device macros

### DIFF
--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -59,5 +59,5 @@ static const struct memc_stm32_config config = {
 	.pinctrl_len = ARRAY_SIZE(pinctrl),
 };
 
-DEVICE_DEFINE(memc_stm32, DT_INST_LABEL(0), memc_stm32_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, memc_stm32_init, device_pm_control_nop, NULL,
 	      &config, POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);

--- a/drivers/memc/memc_stm32_sdram.c
+++ b/drivers/memc/memc_stm32_sdram.c
@@ -129,5 +129,5 @@ static const struct memc_stm32_sdram_config config = {
 	.banks_len = ARRAY_SIZE(bank_config),
 };
 
-DEVICE_DEFINE(memc_stm32_sdram, DT_INST_LABEL(0), memc_stm32_sdram_init, NULL,
+DEVICE_DT_INST_DEFINE(0, memc_stm32_sdram_init, device_pm_control_nop,
 	      NULL, &config, POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);


### PR DESCRIPTION
Convert memc drivers from:

    DEVICE_DEFINE -> DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>