### PR TITLE
drivers: dma: Convert drivers to new DT device macros

### DIFF
--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -362,7 +362,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 
 #define DW_DMAC_INIT(inst)						\
 									\
-	DEVICE_DECLARE(dw_dma##inst);		\
+	DEVICE_DT_INST_DECLARE(inst);					\
 									\
 	static struct dw_drv_plat_data dmac##inst = {			\
 		.chan[0] = {						\
@@ -410,8 +410,9 @@ static const struct dma_driver_api dw_dma_driver_api = {
 		.channel_data = &dmac##inst,				\
 	};								\
 									\
-	DEVICE_AND_API_INIT(dw_dma##inst, DT_INST_LABEL(inst),		\
+	DEVICE_DT_INST_DEFINE(inst,					\
 			    &dw_dma_init,				\
+			    device_pm_control_nop,			\
 			    &dw_dma##inst##_data,			\
 			    &dw_dma##inst##_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
@@ -421,7 +422,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority), dw_dma_isr,	\
-			    DEVICE_GET(dw_dma##inst),			\
+			    DEVICE_DT_INST_GET(inst),			\
 			    DT_INST_IRQ(inst, sense));			\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -442,7 +442,7 @@ static const struct dma_driver_api dma_mcux_lpc_api = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority),			\
-			    dma_mcux_lpc_irq_handler, DEVICE_GET(dma_mcux_lpc_##n), 0);\
+			    dma_mcux_lpc_irq_handler, DEVICE_DT_INST_GET(n), 0);\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
 	}
@@ -467,8 +467,9 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {	\
 		.data_cb = NULL,					\
 	};								\
 									\
-	DEVICE_AND_API_INIT(dma_mcux_lpc_##n, DT_INST_LABEL(n),	\
+	DEVICE_DT_INST_DEFINE(n,					\
 			    &dma_mcux_lpc_init,				\
+			    device_pm_control_nop,			\
 			    &dma_data_##n, &dma_##n##_config,\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,\
 			    &dma_mcux_lpc_api);			\

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -396,13 +396,13 @@ static int dma_sam0_get_status(const struct device *dev, uint32_t channel,
 	return 0;
 }
 
-DEVICE_DECLARE(dma_sam0_0);
+DEVICE_DT_INST_DECLARE(0);
 
 #define DMA_SAM0_IRQ_CONNECT(n)						 \
 	do {								 \
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, n, irq),		 \
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		 \
-			    dma_sam0_isr, DEVICE_GET(dma_sam0_0), 0);	 \
+			    dma_sam0_isr, DEVICE_DT_INST_GET(0), 0);	 \
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		 \
 	} while (0)
 
@@ -459,6 +459,6 @@ static const struct dma_driver_api dma_sam0_api = {
 	.get_status = dma_sam0_get_status,
 };
 
-DEVICE_AND_API_INIT(dma_sam0_0, DT_INST_LABEL(0), &dma_sam0_init,
+DEVICE_DT_INST_DEFINE(0, &dma_sam0_init, device_pm_control_nop,
 		    &dmac_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_sam0_api);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -347,12 +347,12 @@ static const struct dma_driver_api sam_xdmac_driver_api = {
 
 /* DMA0 */
 
-DEVICE_DECLARE(dma0_sam);
+DEVICE_DT_INST_DECLARE(0);
 
 static void dma0_sam_irq_config(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), sam_xdmac_isr,
-		    DEVICE_GET(dma0_sam), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 }
 
 static const struct sam_xdmac_dev_cfg dma0_sam_config = {
@@ -364,6 +364,6 @@ static const struct sam_xdmac_dev_cfg dma0_sam_config = {
 
 static struct sam_xdmac_dev_data dma0_sam_data;
 
-DEVICE_AND_API_INIT(dma0_sam, DT_INST_LABEL(0), &sam_xdmac_initialize,
+DEVICE_DT_INST_DEFINE(0, &sam_xdmac_initialize, device_pm_control_nop,
 		    &dma0_sam_data, &dma0_sam_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &sam_xdmac_driver_api);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -628,8 +628,9 @@ const struct dma_stm32_config dma_stm32_config_##index = {		\
 static struct dma_stm32_data dma_stm32_data_##index = {			\
 };									\
 									\
-DEVICE_AND_API_INIT(dma_stm32_##index##_dev, DT_INST_LABEL(index),	\
+DEVICE_DT_INST_DEFINE(index,						\
 		    &dma_stm32_init,					\
+		    device_pm_control_nop,				\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &dma_funcs)
@@ -643,7 +644,7 @@ DEVICE_AND_API_INIT(dma_stm32_##index##_dev, DT_INST_LABEL(index),	\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(dma, chan, irq),		\
 			    DT_INST_IRQ_BY_IDX(dma, chan, priority),	\
 			    dma_stm32_shared_irq_handler,		\
-			    DEVICE_GET(dma_stm32_##dma##_dev), 0);	\
+			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
 	} while (0)
 
@@ -662,7 +663,7 @@ static void dma_stm32_irq_##dma##_##chan(const struct device *dev)	\
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(dma, chan, irq),		\
 			    DT_INST_IRQ_BY_IDX(dma, chan, priority),	\
 			    dma_stm32_irq_##dma##_##chan,		\
-			    DEVICE_GET(dma_stm32_##dma##_dev), 0);	\
+			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
 	} while (0)
 
@@ -671,7 +672,7 @@ static void dma_stm32_irq_##dma##_##chan(const struct device *dev)	\
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay)
 
-DEVICE_DECLARE(dma_stm32_0_dev);
+DEVICE_DT_INST_DECLARE(0);
 
 DMA_STM32_DEFINE_IRQ_HANDLER(0, 0);
 DMA_STM32_DEFINE_IRQ_HANDLER(0, 1);
@@ -720,7 +721,7 @@ DMA_STM32_INIT_DEV(0);
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay)
 
-DEVICE_DECLARE(dma_stm32_1_dev);
+DEVICE_DT_INST_DECLARE(1);
 
 DMA_STM32_DEFINE_IRQ_HANDLER(1, 0);
 DMA_STM32_DEFINE_IRQ_HANDLER(1, 1);

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -202,8 +202,9 @@ static struct dmamux_stm32_data dmamux_stm32_data_##index = {	\
 	.mux_channels = NULL,					\
 };								\
 								\
-DEVICE_AND_API_INIT(dmamux_##index, DT_INST_LABEL(index),	\
+DEVICE_DT_INST_DEFINE(index,					\
 		    &dmamux_stm32_init,				\
+		    device_pm_control_nop,			\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,\
 		    &dma_funcs);


### PR DESCRIPTION
Convert dma drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    DEVICE_GET -> DEVICE_DT_INST_GET
    DEVICE_DECLARE -> DEVICE_DT_INST_DECLARE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>