### PR TITLE
drivers: ieee802154: Convert drivers to new DT device macros

### DIFF
--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1668,13 +1668,12 @@ static struct ieee802154_radio_api dwt_radio_api = {
 #define DWT_PSDU_LENGTH		(127 - DWT_FCS_LENGTH)
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(dw1000, DT_INST_LABEL(0),
-		    dw1000_init, &dwt_0_context, &dw1000_0_config,
+DEVICE_DT_INST_DEFINE(0, dw1000_init, device_pm_control_nop,
+		    &dwt_0_context, &dw1000_0_config,
 		    POST_KERNEL, CONFIG_IEEE802154_DW1000_INIT_PRIO,
 		    &dwt_radio_api);
 #else
-NET_DEVICE_INIT(dw1000,
-		DT_INST_LABEL(0),
+NET_DEVICE_DT_INST_DEFINE(0,
 		dw1000_init,
 		device_pm_control_nop,
 		&dwt_0_context,

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -950,10 +950,10 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 	}
 
 #define IEEE802154_RF2XX_RAW_DEVICE_INIT(n)	   \
-	DEVICE_AND_API_INIT(			   \
-		rf2xx_##n,			   \
-		DT_INST_LABEL(n),		   \
+	DEVICE_DT_INST_DEFINE(			   \
+		n,				   \
 		&rf2xx_init,			   \
+		device_pm_control_nop,		   \
 		&rf2xx_ctx_data_##n,		   \
 		&rf2xx_ctx_config_##n,		   \
 		POST_KERNEL,			   \
@@ -961,9 +961,8 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 		&rf2xx_radio_api)
 
 #define IEEE802154_RF2XX_NET_DEVICE_INIT(n)	   \
-	NET_DEVICE_INIT(			   \
-		rf2xx_##n,			   \
-		DT_INST_LABEL(n),		   \
+	NET_DEVICE_DT_INST_DEFINE(		   \
+		n,				   \
 		&rf2xx_init,			   \
 		device_pm_control_nop,		   \
 		&rf2xx_ctx_data_##n,		   \


### PR DESCRIPTION
Convert ieee802154 drivers from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    NET_DEVICE_INIT -> NET_DEVICE_DT_INST_DEFINE

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>