### PR TITLE
kernel: sched: fix legacy timeout calculation in z_tick_sleep

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1282,7 +1282,7 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 	timeout = Z_TIMEOUT_TICKS(ticks);
 #else
 	ticks += _TICK_ALIGN;
-	timeout = Z_TIMEOUT_TICKS(ticks);
+	timeout = ticks;
 #endif
 
 	expected_wakeup_ticks = ticks + z_tick_get_32();


### PR DESCRIPTION
Ticks should be assigned directly to timeout value in case of
CONFIG_LEGACY_TIMEOUT_API=y, just as they were before referenced patch.

Due to: 7a815d5d993d ("kernel: sched: Use k_ticks_t in z_tick_sleep")
Fixes: #30860

Tested with:
```
	LOG_INF("uptime: %d", (int) k_uptime_get());
	k_sleep(K_SECONDS(1));
	LOG_INF("uptime: %d", (int) k_uptime_get());
```
in `ztest` framework.

Before this PR:
```
I: uptime: 2070400
I: uptime: 2080500
```
after:
```
I: uptime: 207040
I: uptime: 208050
```