### PR TITLE
pinmux: Convert drivers to be devicetree based

### DIFF
--- a/boards/xtensa/intel_s1000_crb/pinmux.c
+++ b/boards/xtensa/intel_s1000_crb/pinmux.c
@@ -25,7 +25,7 @@ static int intel_s1000_pinmux_init(const struct device *dev)
 {
 	const struct device *pinmux;
 
-	pinmux = device_get_binding(CONFIG_PINMUX_NAME);
+	pinmux = device_get_binding(DT_LABEL(DT_INST(0, intel_s1000_pinmux)));
 
 	if (pinmux == NULL) {
 		return -ENXIO;

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -270,7 +270,7 @@ static int gpio_esp32_init(const struct device *device)
 	struct gpio_esp32_data *data = device->data;
 	static bool isr_connected;
 
-	data->pinmux = device_get_binding(CONFIG_PINMUX_NAME);
+	data->pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));
 	if (!data->pinmux) {
 		return -ENOTSUP;
 	}

--- a/drivers/pinmux/pinmux_cc13xx_cc26xx.c
+++ b/drivers/pinmux/pinmux_cc13xx_cc26xx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT ti_cc13xx_cc26xx_pinmux
+
 #include <device.h>
 #include <errno.h>
 #include <sys/__assert.h>
@@ -87,7 +89,7 @@ static const struct pinmux_driver_api pinmux_cc13xx_cc26xx_driver_api = {
 	.input = pinmux_cc13xx_cc26xx_input,
 };
 
-DEVICE_AND_API_INIT(pinmux_cc13xx_cc26xx, CONFIG_PINMUX_NAME,
-		    &pinmux_cc13xx_cc26xx_init, NULL, NULL, PRE_KERNEL_1,
+DEVICE_DT_INST_DEFINE(0, &pinmux_cc13xx_cc26xx_init, device_pm_control_nop,
+		    NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_cc13xx_cc26xx_driver_api);

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -180,7 +180,7 @@ static int pinmux_initialize(const struct device *device)
 /* Initialize using PRE_KERNEL_1 priority so that GPIO can use the pin
  * mux driver.
  */
-DEVICE_AND_API_INIT(pmux_dev, CONFIG_PINMUX_NAME,
-		    &pinmux_initialize, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, &pinmux_initialize,
+		    device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &api_funcs);

--- a/drivers/pinmux/pinmux_intel_s1000.c
+++ b/drivers/pinmux/pinmux_intel_s1000.c
@@ -94,5 +94,5 @@ static int pinmux_init(const struct device *device)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(pinmux, CONFIG_PINMUX_NAME, &pinmux_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, &pinmux_init, device_pm_control_nop, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY, &apis);

--- a/drivers/pinmux/pinmux_ite_it8xxx2.c
+++ b/drivers/pinmux/pinmux_ite_it8xxx2.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * @brief PINMUX driver for the IT8xxx2
  */
@@ -98,8 +97,7 @@ static const struct pinmux_it8xxx2_config pinmux_it8xxx2_0_config = {
 	.base = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_AND_API_INIT(pinmux_it8xxx2, CONFIG_PINMUX_ITE_IT8XXX2_NAME,
-		    &pinmux_it8xxx2_init, NULL,
-		    &pinmux_it8xxx2_0_config,
+DEVICE_DT_INST_DEFINE(0, &pinmux_it8xxx2_init, device_pm_control_nop,
+		    NULL, &pinmux_it8xxx2_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_it8xxx2_driver_api);

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -9,6 +9,9 @@ properties:
     reg:
       required: true
 
+    label:
+      required: true
+
 pinmux-cells:
   - pin
   - function

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -123,6 +123,7 @@
 		pinmux: pinmux@81c30 {
 			compatible = "intel,s1000-pinmux";
 			reg = <0x00081c30 0xC>;
+			label = "PINMUX";
 		};
 
 		uart0: uart@80800 {


### PR DESCRIPTION
Convert drivers to use pinmux devicetree node to create pinmux device
object.

On intel S1000 we add 'label' as a required property and set it to
'PINMUX' to match CONFIG_PINMUX_NAME.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>