### PR TITLE
drivers: i2c_dw: add 4 additional ports

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -40,7 +40,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 
 if(CONFIG_I2C_DW)
   zephyr_library_sources(i2c_dw.c)
-  foreach(NUM RANGE 0 7)
+  foreach(NUM RANGE 0 11)
     configure_file(
       i2c_dw_port_x.h
       ${PROJECT_BINARY_DIR}/include/generated/i2c_dw_port_${NUM}.h

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -696,3 +696,19 @@ static int i2c_dw_initialize(const struct device *dev)
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(7), okay)
 #include <i2c_dw_port_7.h>
 #endif
+
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(8), okay)
+#include <i2c_dw_port_8.h>
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(9), okay)
+#include <i2c_dw_port_9.h>
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(10), okay)
+#include <i2c_dw_port_10.h>
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(11), okay)
+#include <i2c_dw_port_11.h>
+#endif


### PR DESCRIPTION
Add an additional 4 ports for upcoming Arm based server that will have a
total of 12 I2C ports.

Similar to the original 8 ports, these additional 4 ports will not be
enabled unless specified at configuration time.

Signed-off-by: Dan Kalowsky <dkalowsky@amperecomputing.com>