### PR TITLE
lib/os/heap: always assert the align value argument

### DIFF
--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -248,7 +248,7 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 {
 	struct z_heap *h = heap->heap;
 
-	CHECK((align & (align - 1)) == 0);
+	__ASSERT((align & (align - 1)) == 0, "align must be a power of 2");
 
 	if (align <= chunk_header_bytes(h)) {
 		return sys_heap_alloc(heap, bytes);


### PR DESCRIPTION
Just like commit 0ae04f01b6f3 ("lib/os/heap: make some checks more
assertive") we shouldn't validate the externally provided align
argument only when CONFIG_SYS_HEAP_VALIDATE is set.