### PR TITLE
drivers: dma: mcux_edma: Convert drivers to new DT device macros

### DIFF
--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -436,7 +436,7 @@ struct dma_mcux_edma_data dma_data;
 /*
  * define the dma
  */
-DEVICE_AND_API_INIT(dma_mcux_edma_0, CONFIG_DMA_0_NAME, &dma_mcux_edma_init,
+DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, device_pm_control_nop,
 		    &dma_data, &dma_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_mcux_edma_api);
 
@@ -448,88 +448,88 @@ void dma_imx_config_func_0(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 0, irq),
 		    DT_INST_IRQ_BY_IDX(0, 0, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 1, irq),
 		    DT_INST_IRQ_BY_IDX(0, 1, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 1, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 2, irq),
 		    DT_INST_IRQ_BY_IDX(0, 2, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 2, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 3, irq),
 		    DT_INST_IRQ_BY_IDX(0, 3, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 3, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 4, irq),
 		    DT_INST_IRQ_BY_IDX(0, 4, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 4, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 5, irq),
 		    DT_INST_IRQ_BY_IDX(0, 5, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 5, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 6, irq),
 		    DT_INST_IRQ_BY_IDX(0, 6, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 6, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 7, irq),
 		    DT_INST_IRQ_BY_IDX(0, 7, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 7, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 8, irq),
 		    DT_INST_IRQ_BY_IDX(0, 8, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 8, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 9, irq),
 		    DT_INST_IRQ_BY_IDX(0, 9, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 9, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 10, irq),
 		    DT_INST_IRQ_BY_IDX(0, 10, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 10, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 11, irq),
 		    DT_INST_IRQ_BY_IDX(0, 11, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 11, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 12, irq),
 		    DT_INST_IRQ_BY_IDX(0, 12, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 12, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 13, irq),
 		    DT_INST_IRQ_BY_IDX(0, 13, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 13, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 14, irq),
 		    DT_INST_IRQ_BY_IDX(0, 14, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 14, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 15, irq),
 		    DT_INST_IRQ_BY_IDX(0, 15, priority),
-		    dma_mcux_edma_irq_handler, DEVICE_GET(dma_mcux_edma_0), 0);
+		    dma_mcux_edma_irq_handler, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 15, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(0, 16, irq),
 		    DT_INST_IRQ_BY_IDX(0, 16, priority),
 		    dma_mcux_edma_error_irq_handler,
-		    DEVICE_GET(dma_mcux_edma_0), 0);
+		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQ_BY_IDX(0, 16, irq));
 
 	LOG_DBG("install irq done");


### PR DESCRIPTION
Convert dma mcux_edma driver from:

    DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
    DEVICE_GET -> DEVICE_DT_INST_GET

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>