### PR TITLE
drivers: dma: pl330: Convert drivers to new DT device macros

### DIFF
--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -582,7 +582,7 @@ static const struct dma_driver_api pl330_driver_api = {
 	.stop = dma_pl330_transfer_stop,
 };
 
-static const struct device DEVICE_NAME_GET(dma_pl330);
+DEVICE_DT_INST_DECLARE(0);
 
 static const struct dma_pl330_config pl330_config = {
 	.reg_base = DT_INST_REG_ADDR(0),
@@ -594,8 +594,7 @@ static const struct dma_pl330_config pl330_config = {
 
 static struct dma_pl330_dev_data pl330_data;
 
-DEVICE_AND_API_INIT(dma_pl330, CONFIG_DMA_0_NAME,
-		    &dma_pl330_initialize,
+DEVICE_DT_INST_DEFINE(0, &dma_pl330_initialize, device_pm_control_nop,
 		    &pl330_data, &pl330_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pl330_driver_api);


### PR DESCRIPTION
Convert dma pl330 driver from:

    DEVICE_AND_API_INIT -> DEVICE_DT_INST_DEFINE
    DEVICE_NAME_GET -> DEVICE_DT_NAME_GET

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>