### PR TITLE
Bluetooth: host: Assert conn ref counter on unref

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1890,6 +1890,8 @@ void bt_conn_unref(struct bt_conn *conn)
 	BT_DBG("handle %u ref %u -> %u", conn->handle, old,
 	       atomic_get(&conn->ref));
 
+	__ASSERT(old > 0, "Conn reference counter is 0");
+
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 	    atomic_get(&conn->ref) == 0) {
 		bt_le_adv_resume();


### PR DESCRIPTION
Adds an assert on the "old" ref counter when doing unref, that
checks if there indeed is a reference to unref. This prevents
any underflows of the ref counter.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>