### PR TITLE
stm32: Support for SDMMC on STM32H7

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -69,6 +69,8 @@ The current Zephyr stm32h747i_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | FMC       | on-chip    | memc (SDRAM)                        |
 +-----------+------------+-------------------------------------+
+| SDMMC     | on-chip    | SDMMC 4 wire mode                   |
++-----------+------------+-------------------------------------+
 
 (*) From UM2411 Rev 4:
    With the default setting, the Ethernet feature is not working because of

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -127,3 +127,11 @@
 		};
 	};
 };
+
+&sdmmc1 {
+	status = "okay";
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+};

--- a/drivers/clock_control/Kconfig.stm32h7
+++ b/drivers/clock_control/Kconfig.stm32h7
@@ -104,6 +104,70 @@ config CLOCK_STM32_PLL_R_DIVISOR
 	help
 	  PLL R Output divisor, allowed values: 1-128.
 
+# PLL2 settings
+
+config CLOCK_STM32_PLL2_ENABLE
+	bool "Enable PLL2"
+	help
+	  Enable PLL2. It is used to generate the kernel clock for some peripherals.
+
+if CLOCK_STM32_PLL2_ENABLE
+
+config CLOCK_STM32_PLL2_M_DIVISOR
+	int "PLL2 divisor"
+	default 32
+	range 1 63
+	help
+	  PLL divisor, allowed values: 1-63.
+
+config CLOCK_STM32_PLL2_N_MULTIPLIER
+	int "PLL2 VCO multiplier"
+	default 129
+	range 4 512
+	help
+	  PLL2 multiplier, allowed values: 4-512.
+
+config CLOCK_STM32_PLL2_P_ENABLE
+	bool "Enable PLL2 P output"
+	help
+	  Enable PLL2 P output.
+
+config CLOCK_STM32_PLL2_P_DIVISOR
+	int "PLL2 P Divisor"
+	depends on CLOCK_STM32_PLL2_P_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL2 P Output divisor, allowed values: 1-128.
+
+config CLOCK_STM32_PLL2_Q_ENABLE
+	bool "Enable PLL2 Q output"
+	help
+	  Enable PLL2 Q output.
+
+config CLOCK_STM32_PLL2_Q_DIVISOR
+	int "PLL2 Q Divisor"
+	depends on CLOCK_STM32_PLL2_Q_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL2 Q Output divisor, allowed values: 1-128.
+
+config CLOCK_STM32_PLL2_R_ENABLE
+	bool "Enable PLL2 R output"
+	help
+	  Enable PLL2 R output.
+
+config CLOCK_STM32_PLL2_R_DIVISOR
+	int "PLL2 R Divisor"
+	depends on CLOCK_STM32_PLL2_R_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL2 R Output divisor, allowed values: 1-128.
+
+endif # CLOCK_STM32_PLL2_ENABLE
+
 # PLL3 settings
 
 config CLOCK_STM32_PLL3_ENABLE

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -675,6 +675,7 @@
 		sdmmc1: sdmmc@40012c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
+			interrupts = <49 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
 			status = "disabled";
 			label = "SDMMC_1";

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -35,6 +35,7 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
+			interrupts = <103 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
 			status = "disabled";
 			label = "SDMMC_2";

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -85,6 +85,7 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
+			interrupts = <103 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
 			status = "disabled";
 			label = "SDMMC_2";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -726,6 +726,24 @@
 				status = "disabled";
 			};
 		};
+
+		sdmmc1: sdmmc@52007000 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x52007000 0x400>;
+			interrupts = <49 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x10000>;
+			label = "SDMMC_1";
+			status = "disabled";
+		};
+
+		sdmmc2: sdmmc@48022400 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x48022400 0x400>;
+			interrupts = <124 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x200>;
+			label = "SDMMC_2";
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -202,6 +202,7 @@
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
+			interrupts = <49 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
 			status = "disabled";
 			label = "SDMMC_1";

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -14,6 +14,9 @@ properties:
     reg:
         required: true
 
+    interrupts:
+      required: true
+
     cd-gpios:
         type: phandle-array
         required: false

--- a/samples/subsys/disk/fs.rst
+++ b/samples/subsys/disk/fs.rst
@@ -1,0 +1,10 @@
+.. _disk-samples:
+
+Disk Access Samples
+###################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/samples/subsys/disk/rwcheck/CMakeLists.txt
+++ b/samples/subsys/disk/rwcheck/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(rwcheck)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/disk/rwcheck/README.rst
+++ b/samples/subsys/disk/rwcheck/README.rst
@@ -1,0 +1,32 @@
+.. _rwcheck:
+
+Disk Access Sample Application
+##############################
+
+Overview
+********
+
+This sample app demonstrates use of the disk access API,
+it can be also used to test new disk access API drivers.
+
+WARNING! First 100 sectors of the card will be erased!
+
+Requirements
+************
+
+This project requires a SDHC or microSD card.
+See the :ref:`sdhc_api` documentation for Zephyr implementation details.
+
+Building and Running
+********************
+
+This sample can be built for a variety of boards.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/disk/speedcheck
+   :board: stm32h747-disco
+   :goals: build
+   :compact:
+
+To run this sample, a microSD card should be present in the
+microSD slot. WARNING! First 100 sectors of the card will be erased!

--- a/samples/subsys/disk/rwcheck/prj.conf
+++ b/samples/subsys/disk/rwcheck/prj.conf
@@ -1,0 +1,7 @@
+CONFIG_DISK_ACCESS=y
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+# We don't need it but this settings changes
+# device name to SD in multiple drivers
+CONFIG_FAT_FILESYSTEM_ELM=y
+CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/subsys/disk/rwcheck/sample.yaml
+++ b/samples/subsys/disk/rwcheck/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: Disk Access Speed Test
+common:
+  tags: diskaccess
+tests:
+  sample.subsys.disk.rwcheck:
+    depends_on: sdhc
+    harness: console
+    harness_config:
+      fixture: fixture_sdhc

--- a/samples/subsys/disk/rwcheck/src/main.c
+++ b/samples/subsys/disk/rwcheck/src/main.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 Tavish Naruka <tavishnaruka@gmail.com>
+ * Copyright (c) 2021 Filip Zawadiak <fzawadiak@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <zephyr.h>
+#include <device.h>
+#include <disk/disk_access.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(main);
+
+void main(void)
+{
+	static const char *disk_pdrv = "SDMMC";
+	uint64_t memory_size_mb;
+	uint32_t block_count;
+	uint32_t block_size;
+
+	if (disk_access_init(disk_pdrv) != 0) {
+		LOG_ERR("Storage init ERROR!");
+		return;
+	}
+
+	if (disk_access_ioctl(disk_pdrv,
+			      DISK_IOCTL_GET_SECTOR_COUNT,
+			      &block_count)) {
+		LOG_ERR("Unable to get sector count");
+		return;
+	}
+	printk("Block count %u\n", block_count);
+
+	if (disk_access_ioctl(disk_pdrv,
+			      DISK_IOCTL_GET_SECTOR_SIZE,
+			      &block_size)) {
+		LOG_ERR("Unable to get sector size");
+		return;
+	}
+	printk("Sector size %u\n", block_size);
+
+	memory_size_mb = (uint64_t)block_count * block_size;
+	printk("Memory Size(MB) %u\n", (uint32_t)(memory_size_mb >> 20));
+
+	uint8_t buf[512];
+
+	printk("Writing sectors");
+	for (int i = 0; i < 100; i++) {
+		memset(buf, i, sizeof(buf));
+		if (disk_access_write(disk_pdrv, buf, i, 1)) {
+			printk("E");
+			continue;
+		}
+		printk(".");
+	}
+	printk("\nChecking sectors");
+
+	for (int i = 0; i < 100; i++) {
+		int j;
+
+		if (disk_access_read(disk_pdrv, buf, i, 1)) {
+			printk("E");
+			continue;
+		}
+
+		for (j = 0; j < sizeof(buf); j++) {
+			if (buf[j] != i) {
+				printk("X");
+				break;
+			}
+		}
+
+		if (j == sizeof(buf))
+			printk(".");
+	}
+
+	printk("\nErasing sectors");
+
+	memset(buf, 0, sizeof(buf));
+	for (int i = 0; i < 100; i++) {
+		if (disk_access_write(disk_pdrv, buf, i, 1)) {
+			printk("E");
+			continue;
+		}
+		printk(".");
+	}
+	printk("\n");
+
+	while (1) {
+		k_sleep(K_MSEC(1000));
+	}
+}

--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -144,10 +144,36 @@ config DISK_ACCESS_STM32_SDMMC
 	bool "STM32 SDMMC driver"
 	depends on HAS_STM32CUBE
 	select USE_STM32_HAL_SD
+	select USE_STM32_HAL_DMA if SOC_SERIES_STM32F7X
 	select USE_STM32_LL_SDMMC
+	select USE_STM32_LL_DELAYBLOCK
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_SDMMC))
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.
+
+config DISK_ACCESS_STM32_SDMMC_USE_DMA
+	bool "STM32 SDMMC with DMA"
+	depends on DISK_ACCESS_STM32_SDMMC
+	default y if SOC_SERIES_STM32H7X
+	help
+	  Use build-it DMA engine of STM32H7
+
+choice DISK_ACCESS_STM32_CLOCK_SOURCE
+	prompt "STM32 SDMMC Clock Source"
+	depends on DISK_ACCESS_STM32_SDMMC
+	default DISK_ACCESS_STM32_CLOCK_SOURCE_PLL1_Q
+	help
+	  Both sdmmc peripherials can be clocked either by PLL1 Q or PLL2 R.
+
+config DISK_ACCESS_STM32_CLOCK_SOURCE_PLL1_Q
+	bool "PLL1 Q"
+
+config DISK_ACCESS_STM32_CLOCK_SOURCE_PLL2_R
+	select CLOCK_STM32_PLL2_ENABLE
+	select CLOCK_STM32_PLL2_R_ENABLE
+	bool "PLL2 R"
+
+endchoice
 
 config DISK_STM32_SDMMC_VOLUME_NAME
 	string "SDMMC Disk mount point or drive name"


### PR DESCRIPTION
Extend STM32 SDMMC driver to work with STM32H7 CPUs.
Change configuration of STM32H747I-DISCO to enable it.

Signed-off-by: Filip Zawadiak <fzawadiak@gmail.com>