### PR TITLE
doc: scripts: fix parsing directive inside literal

### DIFF
--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -83,7 +83,7 @@ def src_deps(zephyr_base, src_file, dest, src_root):
     # argument, which is a (relative) path to the additional
     # dependency file.
     directives = "|".join(DIRECTIVES)
-    pattern = re.compile(r"\.\.\s+(?P<directive>%s)::\s+(?P<dep_rel>[^\s]+)" %
+    pattern = re.compile(r"\.\.\s+(?P<directive>%s)::\s+(?P<dep_rel>[^\s`]+)" %
                          directives)
     deps = []
     for m in pattern.finditer(content):


### PR DESCRIPTION
This expands the current directive matching regex in the extract_content script to also allow "`" as an ending character along with spaces; it fixes issues when directives are added inside a literal ("``"), when they are used as examples that are not to be interpreted by the docutils state-machine, but are "accepted" by extract_content.

Technically this is not correct, a directive must always end in space-like characters,  but a proper parser knows that it is inside a literal and accept the contents without interpretation; short of implementing a proper rST parser this "band-aid" fix should work with no side-effects.