### PR TITLE
boards: stm32h747i_disco: fix SDRAM pinctrl

### DIFF
--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -94,15 +94,15 @@
 		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
 		     &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
 		     &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1 &fmc_a12_pg2
-		     &fmc_a13_pg3 &fmc_a14_pg4 &fmc_a15_pg5 &fmc_d0_pd14
-		     &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7
-		     &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10 &fmc_d8_pe11
-		     &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14 &fmc_d12_pe15
-		     &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10 &fmc_d16_ph8
-		     &fmc_d17_ph9 &fmc_d18_ph10 &fmc_d19_ph11 &fmc_d20_ph12
-		     &fmc_d21_ph13 &fmc_d22_ph14 &fmc_d23_ph15 &fmc_d24_pi0
-		     &fmc_d26_pi2 &fmc_d27_pi3 &fmc_d28_pi6 &fmc_d29_pi7
-		     &fmc_d30_pi9 &fmc_d31_pi10>;
+		     &fmc_a14_pg4 &fmc_a15_pg5 &fmc_d0_pd14 &fmc_d1_pd15
+		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		     &fmc_d15_pd10 &fmc_d16_ph8 &fmc_d17_ph9 &fmc_d18_ph10
+		     &fmc_d19_ph11 &fmc_d20_ph12 &fmc_d21_ph13 &fmc_d22_ph14
+		     &fmc_d23_ph15 &fmc_d24_pi0 &fmc_d25_pi1 &fmc_d26_pi2
+		     &fmc_d27_pi3 &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9
+		     &fmc_d31_pi10>;
 
 	sdram {
 		status = "okay";


### PR DESCRIPTION
SDRAM D25 pin was missing and A13 was added by mistake. Note that SDRAM worked previously, but it is likely that some failures occurred when accessing certain values/addresses.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>

Fixes #30857 