### PR TITLE
Fix compiler warning in STM32G4 flash driver and update logging output of storage subsys

### DIFF
--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -69,7 +69,7 @@ static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 	/* Check if this double word is erased */
 	if (flash[0] != 0xFFFFFFFFUL ||
 	    flash[1] != 0xFFFFFFFFUL) {
-		LOG_ERR("Word at offs %d not erased", offset);
+		LOG_ERR("Word at offs %ld not erased", (long)offset);
 		return -EIO;
 	}
 

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -34,7 +34,7 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 	}
 
 	ctx->last_erased_page_start_offset = page.start_offset;
-	LOG_INF("Erasing page at offset 0x%08lx", (long)page.start_offset);
+	LOG_DBG("Erasing page at offset 0x%08lx", (long)page.start_offset);
 
 	flash_write_protection_set(ctx->fdev, false);
 	rc = flash_erase(ctx->fdev, page.start_offset, page.size);


### PR DESCRIPTION
See commit messages for details.