### PR TITLE
cmake: disable warning on C++ 20

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -124,7 +124,8 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp11 "-std=c++11" "-Wno-register")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp14 "-std=c++14" "-Wno-register")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17" "-Wno-register")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "-std=c++2a" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "-std=c++2a"
+  "-Wno-register" "-Wno-volatile")
 
 # Disable exeptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")


### PR DESCRIPTION
Compound assigments like x |= y to volatile qualified values are
deprecated in C++20.  This idiom is common in CMSIS headers for
manipulating peripheral registers.  Since these headers are core they
are likely to be included indirectly in C++ modules; since they are in
vendor-provided headers we can't "fix" them.

Disable the warning when building for C++.

Fixes #30871

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>