### PR TITLE
drivers: ieee802154: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -767,9 +767,10 @@ NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx,
 		&ieee802154_cc13xx_cc26xx_radio_api, IEEE802154_L2,
 		NET_L2_GET_CTX_TYPE(IEEE802154_L2), IEEE802154_MTU);
 #else
-DEVICE_AND_API_INIT(ieee802154_cc13xx_cc26xx,
+DEVICE_DEFINE(ieee802154_cc13xx_cc26xx,
 		CONFIG_IEEE802154_CC13XX_CC26XX_DRV_NAME,
-		ieee802154_cc13xx_cc26xx_init, &ieee802154_cc13xx_cc26xx_data,
+		ieee802154_cc13xx_cc26xx_init, device_pm_control_nop,
+		&ieee802154_cc13xx_cc26xx_data,
 		NULL, POST_KERNEL, CONFIG_IEEE802154_CC13XX_CC26XX_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_radio_api);
 #endif

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -765,9 +765,10 @@ NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx_subg,
 		&ieee802154_cc13xx_cc26xx_subg_radio_api, IEEE802154_L2,
 		NET_L2_GET_CTX_TYPE(IEEE802154_L2), IEEE802154_MTU);
 #else
-DEVICE_AND_API_INIT(ieee802154_cc13xx_cc26xx_subg,
+DEVICE_DEFINE(ieee802154_cc13xx_cc26xx_subg,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DRV_NAME,
 		ieee802154_cc13xx_cc26xx_subg_init,
+		device_pm_control_nop,
 		&ieee802154_cc13xx_cc26xx_subg_data, NULL, POST_KERNEL,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_subg_radio_api);

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1150,10 +1150,10 @@ static struct ieee802154_radio_api cc2520_radio_api = {
 };
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
-		    cc2520_init, &cc2520_context_data, NULL,
-		    POST_KERNEL, CONFIG_IEEE802154_CC2520_INIT_PRIO,
-		    &cc2520_radio_api);
+DEVICE_DEFINE(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
+		cc2520_init, device_pm_control_nop, &cc2520_context_data, NULL,
+		POST_KERNEL, CONFIG_IEEE802154_CC2520_INIT_PRIO,
+		&cc2520_radio_api);
 #else
 NET_DEVICE_INIT(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
 		cc2520_init, device_pm_control_nop,
@@ -1485,9 +1485,9 @@ struct crypto_driver_api cc2520_crypto_api = {
 	.crypto_async_callback_set	= NULL
 };
 
-DEVICE_AND_API_INIT(cc2520_crypto, CONFIG_IEEE802154_CC2520_CRYPTO_DRV_NAME,
-		    cc2520_crypto_init, &cc2520_context_data, NULL,
-		    POST_KERNEL, CONFIG_IEEE802154_CC2520_CRYPTO_INIT_PRIO,
-		    &cc2520_crypto_api);
+DEVICE_DEFINE(cc2520_crypto, CONFIG_IEEE802154_CC2520_CRYPTO_DRV_NAME,
+		cc2520_crypto_init, device_pm_control_nop,
+		&cc2520_context_data, NULL, POST_KERNEL,
+		CONFIG_IEEE802154_CC2520_CRYPTO_INIT_PRIO, &cc2520_crypto_api);
 
 #endif /* CONFIG_IEEE802154_CC2520_CRYPTO */

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1477,10 +1477,10 @@ static struct ieee802154_radio_api mcr20a_radio_api = {
 };
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_AND_API_INIT(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
-		    mcr20a_init, &mcr20a_context_data, NULL,
-		    POST_KERNEL, CONFIG_IEEE802154_MCR20A_INIT_PRIO,
-		    &mcr20a_radio_api);
+DEVICE_DEFINE(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
+		mcr20a_init, device_pm_control_nop, &mcr20a_context_data, NULL,
+		POST_KERNEL, CONFIG_IEEE802154_MCR20A_INIT_PRIO,
+		&mcr20a_radio_api);
 #else
 NET_DEVICE_INIT(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
 		mcr20a_init, device_pm_control_nop, &mcr20a_context_data, NULL,

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -823,8 +823,8 @@ NET_DEVICE_INIT(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
 		&nrf5_radio_api, L2,
 		L2_CTX_TYPE, MTU);
 #else
-DEVICE_AND_API_INIT(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
-		    nrf5_init, &nrf5_data, &nrf5_radio_cfg,
-		    POST_KERNEL, CONFIG_IEEE802154_NRF5_INIT_PRIO,
-		    &nrf5_radio_api);
+DEVICE_DEFINE(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
+		nrf5_init, device_pm_control_nop, &nrf5_data, &nrf5_radio_cfg,
+		POST_KERNEL, CONFIG_IEEE802154_NRF5_INIT_PRIO,
+		&nrf5_radio_api);
 #endif


### PR DESCRIPTION
Convert drivers to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>