### PR TITLE
power: Idle depends on system clock when power management enabled

### DIFF
--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -13,6 +13,7 @@ config SYS_POWER_MANAGEMENT
 menuconfig PM
 	bool "System Power management"
 	select TICKLESS_IDLE
+	depends on SYS_CLOCK_EXISTS
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the


### PR DESCRIPTION
The idle, when power management is enabled, requires system clock to
be present.
This commit adds selection to, to PM option, that selects
SYS_CLOCK_EXISTS.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>