### PR TITLE
arch/x86: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -143,9 +143,10 @@ static int multiboot_framebuf_init(const struct device *dev)
 	}
 }
 
-DEVICE_AND_API_INIT(multiboot_framebuf,
+DEVICE_DEFINE(multiboot_framebuf,
 		    "FRAMEBUF",
 		    multiboot_framebuf_init,
+		    device_pm_control_nop,
 		    &multiboot_framebuf_data,
 		    NULL,
 		    PRE_KERNEL_1,


### PR DESCRIPTION
Convert device to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>