### PR TITLE
bluetooth: controller: radio: Add guards on TXPOWER

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
@@ -232,19 +232,25 @@ static inline uint32_t hal_radio_tx_power_min_get(void)
 
 static inline uint32_t hal_radio_tx_power_max_get(void)
 {
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
 	return RADIO_TXPOWER_TXPOWER_Pos4dBm;
+#else
+	return RADIO_TXPOWER_TXPOWER_0dBm;
+#endif
 }
 
 static inline uint32_t hal_radio_tx_power_floor(int8_t tx_power_lvl)
 {
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos4dBm) {
 		return RADIO_TXPOWER_TXPOWER_Pos4dBm;
 	}
-
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos3dBm) {
 		return RADIO_TXPOWER_TXPOWER_Pos3dBm;
 	}
-
+#endif
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_0dBm) {
 		return RADIO_TXPOWER_TXPOWER_0dBm;
 	}


### PR DESCRIPTION
Add guards on TXPOWER to ensure positive values only are used if they are defined.