### PR TITLE
drivers: can: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -292,8 +292,8 @@ static int can_loopback_init(const struct device *dev)
 
 static struct can_loopback_data can_loopback_dev_data_1;
 
-DEVICE_AND_API_INIT(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
-		    &can_loopback_init,
+DEVICE_DEFINE(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
+		    &can_loopback_init, device_pm_control_nop,
 		    &can_loopback_dev_data_1, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>