### PR TITLE
drivers: display: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -123,7 +123,8 @@ static const struct display_driver_api dummy_display_api = {
 	.set_pixel_format = dummy_display_set_pixel_format,
 };
 
-DEVICE_AND_API_INIT(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
-		    &dummy_display_init, &dummy_display_data, NULL,
+DEVICE_DEFINE(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
+		    &dummy_display_init, device_pm_control_nop,
+		    &dummy_display_data, NULL,
 		    APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &dummy_display_api);

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -415,9 +415,9 @@ static const struct display_driver_api sdl_display_api = {
 	.set_pixel_format = sdl_display_set_pixel_format,
 };
 
-DEVICE_AND_API_INIT(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
-		    &sdl_display_data, NULL, APPLICATION,
-		    CONFIG_APPLICATION_INIT_PRIORITY, &sdl_display_api);
+DEVICE_DEFINE(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
+		device_pm_control_nop, &sdl_display_data, NULL, APPLICATION,
+		CONFIG_APPLICATION_INIT_PRIORITY, &sdl_display_api);
 
 
 NATIVE_TASK(sdl_display_cleanup, ON_EXIT, 1);

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -342,7 +342,7 @@ static struct glcd_data grove_lcd_driver = {
 	 * so grove_lcd can be referenced.
 	 * since grove_lcd_driver struct is available, populating with it
 	 */
-DEVICE_AND_API_INIT(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
-			&grove_lcd_driver, &grove_lcd_config,
-			POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
-			(void *)&grove_lcd_driver);
+DEVICE_DEFINE(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
+		device_pm_control_nop, &grove_lcd_driver, &grove_lcd_config,
+		POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		(void *)&grove_lcd_driver);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>