### PR TITLE
drivers: video: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -273,7 +273,8 @@ static int video_sw_generator_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(video_sw_generator, "VIDEO_SW_GENERATOR",
-		    &video_sw_generator_init, &video_sw_generator_data_0, NULL,
+DEVICE_DEFINE(video_sw_generator, "VIDEO_SW_GENERATOR",
+		    &video_sw_generator_init, device_pm_control_nop,
+		    &video_sw_generator_data_0, NULL,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_sw_generator_driver_api);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>