### PR TITLE
drivers: kscan: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -106,7 +106,7 @@ static const struct kscan_driver_api sdl_driver_api = {
 
 static struct sdl_data sdl_data;
 
-DEVICE_AND_API_INIT(sdl, CONFIG_SDL_POINTER_KSCAN_DEV_NAME, sdl_init,
-		    &sdl_data, NULL,
+DEVICE_DEFINE(sdl, CONFIG_SDL_POINTER_KSCAN_DEV_NAME, sdl_init,
+		    device_pm_control_nop, &sdl_data, NULL,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &sdl_driver_api);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>