### PR TITLE
drivers: counter: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -208,5 +208,5 @@ static const struct counter_driver_api api = {
 	.get_value = get_value
 };
 
-DEVICE_AND_API_INIT(counter_cmos, "CMOS", init, NULL, &info,
+DEVICE_DEFINE(counter_cmos, "CMOS", init, device_pm_control_nop, NULL, &info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>