### PR TITLE
drivers: gpio: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/include/drivers/gpio/gpio_mmio32.h
+++ b/include/drivers/gpio/gpio_mmio32.h
@@ -55,8 +55,9 @@ static const struct gpio_mmio32_config _dev_name##_dev_cfg = {		\
 	.mask	= _mask,						\
 };									\
 									\
-DEVICE_AND_API_INIT(_dev_name, _drv_name,				\
+DEVICE_DEFINE(_dev_name, _drv_name,					\
 		    &gpio_mmio32_init,					\
+		    device_pm_control_nop,				\
 		    &_dev_name##_dev_data,				\
 		    &_dev_name##_dev_cfg,				\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>