### PR TITLE
drivers: pwm: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/pwm/pwm_dw.c
+++ b/drivers/pwm/pwm_dw.c
@@ -200,9 +200,9 @@ static struct pwm_dw_config pwm_dw_cfg = {
 	.num_ports = PWM_DW_NUM_PORTS,
 };
 
-DEVICE_AND_API_INIT(pwm_dw_0, CONFIG_PWM_DW_0_DRV_NAME, pwm_dw_init,
-		    NULL, &pwm_dw_cfg,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &pwm_dw_drv_api_funcs);
+DEVICE_DEFINE(pwm_dw_0, CONFIG_PWM_DW_0_DRV_NAME, pwm_dw_init,
+		device_pm_control_nop, NULL, &pwm_dw_cfg,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		&pwm_dw_drv_api_funcs);
 
 #endif /* CONFIG_PWM_DW */

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -519,7 +519,7 @@ const static struct pwm_led_esp32_config pwm_led_esp32_config = {
 	},
 };
 
-DEVICE_AND_API_INIT(pwm_led_esp32_0, CONFIG_PWM_LED_ESP32_DEV_NAME_0,
-		    pwm_led_esp32_init, NULL, &pwm_led_esp32_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &pwm_led_esp32_api);
+DEVICE_DEFINE(pwm_led_esp32_0, CONFIG_PWM_LED_ESP32_DEV_NAME_0,
+		pwm_led_esp32_init, device_pm_control_nop, NULL,
+		&pwm_led_esp32_config, POST_KERNEL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_led_esp32_api);

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -168,10 +168,10 @@ static const struct pwm_pca9685_config pwm_pca9685_0_cfg = {
 static struct pwm_pca9685_drv_data pwm_pca9685_0_drvdata;
 
 /* This has to init after I2C master */
-DEVICE_AND_API_INIT(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
-			pwm_pca9685_init,
-			&pwm_pca9685_0_drvdata, &pwm_pca9685_0_cfg,
-			POST_KERNEL, CONFIG_PWM_PCA9685_INIT_PRIORITY,
-			&pwm_pca9685_drv_api_funcs);
+DEVICE_DEFINE(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
+		pwm_pca9685_init, device_pm_control_nop,
+		&pwm_pca9685_0_drvdata, &pwm_pca9685_0_cfg,
+		POST_KERNEL, CONFIG_PWM_PCA9685_INIT_PRIORITY,
+		&pwm_pca9685_drv_api_funcs);
 
 #endif /* CONFIG_PWM_PCA9685_0 */


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>