### PR TITLE
drivers: serial: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -57,8 +57,8 @@ static const struct uart_device_config uart_altera_jtag_dev_cfg_0 = {
 	.sys_clk_freq = 0, /* Unused */
 };
 
-DEVICE_AND_API_INIT(uart_altera_jtag_0, "jtag_uart0",
-		    uart_altera_jtag_init, NULL,
+DEVICE_DEFINE(uart_altera_jtag_0, "jtag_uart0",
+		    uart_altera_jtag_init, device_pm_control_nop, NULL,
 		    &uart_altera_jtag_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_altera_jtag_driver_api);

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -371,8 +371,9 @@ DEVICE_DT_INST_DEFINE(0,
 	    &np_uart_driver_api_0);
 
 #if defined(CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE)
-DEVICE_AND_API_INIT(uart_native_posix1,
+DEVICE_DEFINE(uart_native_posix1,
 	    CONFIG_UART_NATIVE_POSIX_PORT_1_NAME, &np_uart_1_init,
+	    device_pm_control_nop,
 	    (void *)&native_uart_status_1, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_1);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>