### PR TITLE
drivers: pinmux: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/pinmux/pinmux_hsdk.c
+++ b/drivers/pinmux/pinmux_hsdk.c
@@ -68,7 +68,7 @@ static const struct pinmux_driver_api pinmux_hsdk_driver_api = {
 	.input = pinmux_hsdk_input,
 };
 
-DEVICE_AND_API_INIT(pinmux_hsdk, CONFIG_PINMUX_NAME,
-			&pinmux_hsdk_init, NULL, NULL,
-			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-			&pinmux_hsdk_driver_api);
+DEVICE_DEFINE(pinmux_hsdk, CONFIG_PINMUX_NAME,
+		&pinmux_hsdk_init, device_pm_control_nop, NULL, NULL,
+		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&pinmux_hsdk_driver_api);

--- a/drivers/pinmux/pinmux_mcux_lpc.c
+++ b/drivers/pinmux/pinmux_mcux_lpc.c
@@ -98,8 +98,8 @@ static const struct pinmux_mcux_lpc_config pinmux_mcux_lpc_port0_config = {
 	.port_no = PORT0_IDX,
 };
 
-DEVICE_AND_API_INIT(pinmux_port0, CONFIG_PINMUX_MCUX_LPC_PORT0_NAME,
-		    &pinmux_mcux_lpc_init,
+DEVICE_DEFINE(pinmux_port0, CONFIG_PINMUX_MCUX_LPC_PORT0_NAME,
+		    &pinmux_mcux_lpc_init, device_pm_control_nop,
 		    NULL, &pinmux_mcux_lpc_port0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);
@@ -116,8 +116,8 @@ static const struct pinmux_mcux_lpc_config pinmux_mcux_lpc_port1_config = {
 	.port_no = PORT1_IDX,
 };
 
-DEVICE_AND_API_INIT(pinmux_port1, CONFIG_PINMUX_MCUX_LPC_PORT1_NAME,
-		    &pinmux_mcux_lpc_init,
+DEVICE_DEFINE(pinmux_port1, CONFIG_PINMUX_MCUX_LPC_PORT1_NAME,
+		    &pinmux_mcux_lpc_init, device_pm_control_nop,
 		    NULL, &pinmux_mcux_lpc_port1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_mcux_driver_api);

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -97,8 +97,8 @@ static const struct pinmux_sifive_config pinmux_sifive_0_config = {
 	.base = SIFIVE_PINMUX_0_BASE_ADDR,
 };
 
-DEVICE_AND_API_INIT(pinmux_sifive_0, CONFIG_PINMUX_SIFIVE_0_NAME,
-		    &pinmux_sifive_init, NULL,
+DEVICE_DEFINE(pinmux_sifive_0, CONFIG_PINMUX_SIFIVE_0_NAME,
+		    &pinmux_sifive_init, device_pm_control_nop, NULL,
 		    &pinmux_sifive_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_sifive_driver_api);


### PR DESCRIPTION
Convert driver(s) to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>