### PR TITLE
Use correct OpenOCD config for stm32f4discovery

### DIFF
--- a/boards/arm/stm32f4_disco/support/openocd.cfg
+++ b/boards/arm/stm32f4_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/st_nucleo_f4.cfg]
+source [find board/stm32f4discovery.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Fixed incorrect config script - flashing and debugging the board now works.

Signed-off-by: Petr Hodina <phodina@protonmail.com>