### PR TITLE
pwm: convert Synopsys DesignWare PWM to use devicetree

### DIFF
--- a/drivers/pwm/Kconfig.dw
+++ b/drivers/pwm/Kconfig.dw
@@ -3,16 +3,9 @@
 # Copyright (c) 2016 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PWM_DW
+config PWM_DW
 	bool "DesignWare PWM"
 	help
 	  Enable driver to utilize PWM on the DesignWare Timer IP block.
 	  Care must be taken if one is also to use the timer feature, as
 	  they both use the same set of registers.
-
-config PWM_DW_0_DRV_NAME
-	string "DesignWare PWM Device Name"
-	default "PWM_0"
-	depends on PWM_DW
-	help
-	  Specify the device name for the DesignWare PWM driver.

--- a/dts/bindings/pwm/snps,designware-pwm.yaml
+++ b/dts/bindings/pwm/snps,designware-pwm.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Synopsys DesignWare PWM node
+
+compatible: "snps,designware-pwm"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    channels:
+      type: int
+      required: true
+      description: Number of PWM channels


### PR DESCRIPTION
This converts the Designware PWM driver to use devicetree
for device information.

Fixes #30869

Signed-off-by: Daniel Leung <daniel.leung@intel.com>