### PR TITLE
audio: intel_dmic: convert to use devicetree

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -19,6 +19,13 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flash0;
 	};
+
+	dmic: dmic {
+		compatible = "intel,dmic";
+		label = "PDM";
+
+		status = "okay";
+	};
 };
 
 &cpu0 {

--- a/drivers/audio/intel_dmic.c
+++ b/drivers/audio/intel_dmic.c
@@ -10,6 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT intel_dmic
+
 #include <errno.h>
 #include <zephyr.h>
 #include <device.h>
@@ -1445,5 +1447,7 @@ static struct _dmic_ops dmic_ops = {
 	.read = dmic_read_device,
 };
 
-DEVICE_AND_API_INIT(dmic, "PDM", &dmic_initialize_device, NULL, NULL,
-		POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY, &dmic_ops);
+DEVICE_DT_INST_DEFINE(0, &dmic_initialize_device, device_pm_control_nop,
+		      NULL, NULL,
+		      POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY,
+		      &dmic_ops);

--- a/dts/bindings/audio/intel,dmic.yaml
+++ b/dts/bindings/audio/intel,dmic.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel Digital PDM Microphone (DMIC) node
+
+compatible: "intel,dmic"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true


### PR DESCRIPTION
This converts the intel_dmic driver to use devicetree.

Fixes #30870

Signed-off-by: Daniel Leung <daniel.leung@intel.com>