### PR TITLE
drivers: flash: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -498,8 +498,8 @@ struct flash_nios2_qspi_config flash_cfg = {
 	}
 };
 
-DEVICE_AND_API_INIT(flash_nios2_qspi,
-			CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME,
-			flash_nios2_qspi_init, &flash_cfg, NULL,
-			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-			&flash_nios2_qspi_api);
+DEVICE_DEFINE(flash_nios2_qspi,
+		CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME,
+		flash_nios2_qspi_init, device_pm_control_nop, &flash_cfg, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		&flash_nios2_qspi_api);


### PR DESCRIPTION
Convert soc nios2 qspi to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>