### PR TITLE
drivers: neural_net: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -523,7 +523,7 @@ static struct intel_gna_data intel_gna_driver_data = {
 	.regs = (volatile struct intel_gna_regs *)INTEL_GNA_BASE_ADDR,
 };
 
-DEVICE_AND_API_INIT(gna, CONFIG_INTEL_GNA_NAME, intel_gna_initialize,
-		    (void *)&intel_gna_driver_data, &intel_gna_config,
-		    POST_KERNEL, CONFIG_INTEL_GNA_INIT_PRIORITY,
-		    &gna_driver_api);
+DEVICE_DEFINE(gna, CONFIG_INTEL_GNA_NAME, intel_gna_initialize,
+		device_pm_control_nop, (void *)&intel_gna_driver_data,
+		&intel_gna_config, POST_KERNEL,
+		CONFIG_INTEL_GNA_INIT_PRIORITY, &gna_driver_api);


### PR DESCRIPTION
Convert intel gna driver to DEVICE_DEFINE instead of
DEVICE_AND_API_INIT so we can deprecate DEVICE_AND_API_INIT in the
future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>