### PR TITLE
drivers: led: Convert DEVICE_AND_API_INIT to DEVICE_DEFINE

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -153,8 +153,9 @@ const struct led_pwm_config led_pwm_config_##id = {		\
 static struct led_pwm_data					\
 	led_pwm_data_##id[ARRAY_SIZE(led_pwm_##id)];		\
 								\
-DEVICE_AND_API_INIT(led_pwm_##id,				\
+DEVICE_DEFINE(led_pwm_##id,					\
 		    DT_INST_PROP_OR(id, label, "LED_PWM_"#id),	\
+		    device_pm_control_nop,			\
 		    &led_pwm_init,				\
 		    &led_pwm_data_##id,				\
 		    &led_pwm_config_##id,			\


### PR DESCRIPTION
Convert LED PWM driver to DEVICE_DEFINE instead of DEVICE_AND_API_INIT
so we can deprecate DEVICE_AND_API_INIT in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>