### PR TITLE
modules: introducing MODULE_ROOT to allow glue code in Zephyr repo

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -20,7 +20,6 @@ source "$(KCONFIG_BINARY_DIR)/Kconfig.soc.defconfig"
 
 menu "Modules"
 
-source "$(KCONFIG_BINARY_DIR)/Kconfig.modules"
 source "modules/Kconfig"
 
 endmenu

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -166,6 +166,13 @@ elseif(DEFINED ENV{ZEPHYR_EXTRA_MODULES})
   set(ZEPHYR_EXTRA_MODULES $ENV{ZEPHYR_EXTRA_MODULES})
 endif()
 
+# 'MODULE_EXT_ROOT' is a prioritized list of directories where module glue code
+# may be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+# For module roots, later entries may overrule module settings already defined
+# by processed module roots, hence first in list means lowest priority.
+zephyr_file(APPLICATION_ROOT MODULE_EXT_ROOT)
+list(INSERT MODULE_EXT_ROOT 0 ${ZEPHYR_BASE})
+
 #
 # Find Zephyr modules.
 # Those may contain additional DTS, BOARD, SOC, ARCH ROOTs.
@@ -189,6 +196,9 @@ add_custom_target(
 
 # Dummy add to generate files.
 zephyr_linker_sources(SECTIONS)
+
+zephyr_file(APPLICATION_ROOT BOARD_ROOT)
+list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
 
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority.

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -74,6 +74,13 @@ foreach(module_name ${ZEPHYR_MODULE_NAMES})
        ZEPHYR_KCONFIG_MODULES_DIR
        "ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR=${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR}"
   )
+
+  if(ZEPHYR_${MODULE_NAME_UPPER}_KCONFIG)
+    list(APPEND
+         ZEPHYR_KCONFIG_MODULES_DIR
+         "ZEPHYR_${MODULE_NAME_UPPER}_KCONFIG=${ZEPHYR_${MODULE_NAME_UPPER}_KCONFIG}"
+  )
+  endif()
 endforeach()
 
 # A list of common environment settings used when invoking Kconfig during CMake

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -1,14 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This cmake file provides functionality to import additional out-of-tree, OoT
-# CMakeLists.txt and Kconfig files into Zephyr build system.
-# It uses -DZEPHYR_MODULES=<oot-path-to-module>[;<additional-oot-module(s)>]
-# given to CMake for a list of folders to search.
-# It looks for: <oot-module>/zephyr/module.yml or
-#               <oot-module>/zephyr/CMakeLists.txt
-# to load the oot-module into Zephyr build system.
+# This cmake file provides functionality to import CMakeLists.txt and Kconfig
+# files for Zephyr modules into Zephyr build system.
+#
+# CMakeLists.txt and Kconfig files can reside directly in the module or in a
+# MODULE_EXT_ROOT.
+# The `<module>/zephyr/module.yml` file specifies whether the build files are
+# located in the module or in a MODULE_EXT_ROOT.
+#
+# A list of Zephyr modules can be provided to the build system using:
+#   -DZEPHYR_MODULES=<module-path>[;<additional-module(s)-path>]
+#
+# It looks for: <module>/zephyr/module.yml or
+#               <module>/zephyr/CMakeLists.txt
+# to load the module into Zephyr build system.
 # If west is available, it uses `west list` to obtain a list of projects to
 # search for zephyr/module.yml
+#
+# If the module.yml file specifies that build files are located in a
+# MODULE_EXT_ROOT then the variables:
+# - `ZEPHYR_<MODULE_NAME>_CMAKE_DIR` is used for inclusion of the CMakeLists.txt
+# - `ZEPHYR_<MODULE_NAME>_KCONFIG` is used for inclusion of the Kconfig
+# files into the build system.
 
 if(ZEPHYR_MODULES)
   set(ZEPHYR_MODULES_ARG "--modules" ${ZEPHYR_MODULES})
@@ -56,9 +69,24 @@ if(WEST OR ZEPHYR_MODULES)
       # lazy regexes (it supports greedy only).
       string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" key ${setting})
       string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" value ${setting})
-      list(APPEND ${key} ${value})
+      # MODULE_EXT_ROOT is process order which means module roots processed
+      # later wins. To ensure ZEPHYR_BASE stays first, and command line settings
+      # are processed last, we insert at position 1.
+      if ("${key}" STREQUAL "MODULE_EXT_ROOT")
+        list(INSERT ${key} 1 ${value})
+      else()
+        list(APPEND ${key} ${value})
+      endif()
     endforeach()
   endif()
+
+  foreach(root ${MODULE_EXT_ROOT})
+    if(NOT EXISTS ${root})
+      message(FATAL_ERROR "No `modules.cmake` found in module root `${root}`.")
+    endif()
+
+    include(${root}/modules/modules.cmake)
+  endforeach()
 
   if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
@@ -69,6 +97,7 @@ if(WEST OR ZEPHYR_MODULES)
       # Match "<name>":"<path>" for each line of file, each corresponding to
       # one module. The use of quotes is required due to CMake not supporting
       # lazy regexes (it supports greedy only).
+      string(CONFIGURE ${module} module)
       string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
       string(REGEX REPLACE "\".*\":\"(.*)\":\".*\"" "\\1" module_path ${module})
       string(REGEX REPLACE "\".*\":\".*\":\"(.*)\"" "\\1" cmake_path ${module})

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -1,6 +1,10 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+comment "Available modules."
+
+source "$(KCONFIG_BINARY_DIR)/Kconfig.modules"
+
 comment "Optional modules. Make sure they're installed, via the project manifest."
 
 source "modules/Kconfig.altera"
@@ -32,3 +36,23 @@ source "modules/Kconfig.tinycrypt"
 source "modules/Kconfig.vega"
 source "modules/Kconfig.xtensa"
 source "modules/Kconfig.mcuboot_bootutil"
+
+comment "Unavailable modules, please install those via the project manifest."
+
+# List of comments to display when Zephyr modules are not available, please
+# use the following syntax:
+# ---------------------------------------------------
+# comment "<module_name> module not available."
+#	depends on !ZEPHYR_<MODULE_NAME_UPPER>_MODULE
+#
+# Remember to add the following code inside the `<module>/Kconfig file:
+# ---------------------------------------------------
+# config ZEPHYR_<MODULE_NAME_UPPER>_MODULE
+# 	bool
+
+# This ensures that symbols are available in Kconfig for dependency checking
+# and referencing, while keeping the settings themselves unavailable when the
+# modules are not present in the workspace
+if 0
+osource "modules/*/Kconfig"
+endif

--- a/modules/modules.cmake
+++ b/modules/modules.cmake
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+file(GLOB cmake_modules "${CMAKE_CURRENT_LIST_DIR}/*/CMakeLists.txt")
+
+foreach(module ${cmake_modules})
+  get_filename_component(module_dir  ${module} DIRECTORY)
+  get_filename_component(module_name ${module_dir} NAME)
+  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${module_dir})
+endforeach()
+
+file(GLOB kconfig_modules "${CMAKE_CURRENT_LIST_DIR}/*/Kconfig")
+
+foreach(module ${kconfig_modules})
+  get_filename_component(module_dir  ${module} DIRECTORY)
+  get_filename_component(module_name ${module_dir} NAME)
+  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  set(ZEPHYR_${MODULE_NAME_UPPER}_KCONFIG ${module_dir}/Kconfig)
+endforeach()


### PR DESCRIPTION
This commit introduces MODULE_ROOT which allows CMake and Kconfig glue
code to be placed outside of the Zephyr module repository.

This allows for placing glue code in Zephyr, but also allows users to
specify custom MODULE_ROOTs for glue code using either `-DMODULE_ROOT`
or `zephyr/module.yml` with `build:settings:module_root` settings.

MODULE_ROOT' is a list of directories, similar to other roots such as
BOARD_ROOT, DTS_ROOT, etc.
The Zephyr repo folder ${ZEPHYR_BASE} is always to the MODULE_ROOT list
as lowest priority.
For each MODULE_ROOT, the file `<module_root>/modules/modules.cmake`
will be processed.

In Zephyr repo, the folder `modules/<module>/` contains CMakeLists.txt
and Kconfig glue code for the Zephyr module.

A Zephyr module can specify that CMakeLists.txt and Kconfig glue code is
placed in an external module root by specifying:
```
build:
  cmake-extern: True
  kconfig-extern: True
```

It is still possible to place the CMakeLists.txt and Kconfig files
directly in the Zephyr module using the existing:
```
build:
  cmake: <path>
  kconfig: <file>
```

----------
When using module gluecode extern, the menuconfig now looks as:
![image](https://user-images.githubusercontent.com/9802583/102659251-64a03000-4179-11eb-93bd-58fa0f3668ad.png)
when a module is available.

And like this, when it is not present in the manifest file.
![image](https://user-images.githubusercontent.com/9802583/102659419-a5984480-4179-11eb-97a1-cd96fc20159d.png)
