### PR TITLE
drivers: clock_control: add support for PLL3 on STM32 H7

### DIFF
--- a/drivers/clock_control/Kconfig.stm32h7
+++ b/drivers/clock_control/Kconfig.stm32h7
@@ -104,4 +104,68 @@ config CLOCK_STM32_PLL_R_DIVISOR
 	help
 	  PLL R Output divisor, allowed values: 1-128.
 
+# PLL3 settings
+
+config CLOCK_STM32_PLL3_ENABLE
+	bool "Enable PLL3"
+	help
+	  Enable PLL3. It is used to generate the kernel clock for some peripherals.
+
+if CLOCK_STM32_PLL3_ENABLE
+
+config CLOCK_STM32_PLL3_M_DIVISOR
+	int "PLL3 divisor"
+	default 32
+	range 1 63
+	help
+	  PLL divisor, allowed values: 1-63.
+
+config CLOCK_STM32_PLL3_N_MULTIPLIER
+	int "PLL3 VCO multiplier"
+	default 129
+	range 4 512
+	help
+	  PLL3 multiplier, allowed values: 4-512.
+
+config CLOCK_STM32_PLL3_P_ENABLE
+	bool "Enable PLL3 P output"
+	help
+	  Enable PLL3 P output.
+
+config CLOCK_STM32_PLL3_P_DIVISOR
+	int "PLL3 P Divisor"
+	depends on CLOCK_STM32_PLL3_P_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL3 P Output divisor, allowed values: 1-128.
+
+config CLOCK_STM32_PLL3_Q_ENABLE
+	bool "Enable PLL3 Q output"
+	help
+	  Enable PLL3 Q output.
+
+config CLOCK_STM32_PLL3_Q_DIVISOR
+	int "PLL3 Q Divisor"
+	depends on CLOCK_STM32_PLL3_Q_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL3 Q Output divisor, allowed values: 1-128.
+
+config CLOCK_STM32_PLL3_R_ENABLE
+	bool "Enable PLL3 R output"
+	help
+	  Enable PLL3 R output.
+
+config CLOCK_STM32_PLL3_R_DIVISOR
+	int "PLL3 R Divisor"
+	depends on CLOCK_STM32_PLL3_R_ENABLE
+	default 2
+	range 1 128
+	help
+	  PLL3 R Output divisor, allowed values: 1-128.
+
+endif # CLOCK_STM32_PLL3_ENABLE
+
 endif # SOC_SERIES_STM32H7X

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -282,7 +282,8 @@ static int32_t optimize_regulator_voltage_scale(uint32_t sysclk_freq)
 
 #if defined(CONFIG_CLOCK_STM32_PLL_SRC_HSE) || \
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
-	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI)
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_ENABLE)
 
 static int get_vco_input_range(uint32_t m_div, uint32_t *range)
 {
@@ -290,13 +291,13 @@ static int get_vco_input_range(uint32_t m_div, uint32_t *range)
 
 	vco_freq = PLLSRC_FREQ / m_div;
 
-	if (1000000UL <= vco_freq && vco_freq <= 2000000UL) {
+	if (MHZ(1) <= vco_freq && vco_freq <= MHZ(2)) {
 		*range = LL_RCC_PLLINPUTRANGE_1_2;
-	} else if (2000000UL < vco_freq && vco_freq <= 4000000UL) {
+	} else if (MHZ(2) < vco_freq && vco_freq <= MHZ(4)) {
 		*range = LL_RCC_PLLINPUTRANGE_2_4;
-	} else if (4000000UL < vco_freq && vco_freq <= 8000000UL) {
+	} else if (MHZ(4) < vco_freq && vco_freq <= MHZ(8)) {
 		*range = LL_RCC_PLLINPUTRANGE_4_8;
-	} else if (8000000UL < vco_freq && vco_freq <= 16000000UL) {
+	} else if (MHZ(8) < vco_freq && vco_freq <= MHZ(16)) {
 		*range = LL_RCC_PLLINPUTRANGE_8_16;
 	} else {
 		return -ERANGE;
@@ -484,7 +485,8 @@ static int stm32_clock_control_init(const struct device *dev)
 
 #if defined(CONFIG_CLOCK_STM32_PLL_SRC_HSE) || \
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
-	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI)
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_ENABLE)
 
 	int r;
 	uint32_t vco_input_range;
@@ -683,6 +685,41 @@ static int stm32_clock_control_init(const struct device *dev)
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 
 #endif /* CONFIG_CPU_CORTEX_M4 */
+
+#if defined(CONFIG_CLOCK_STM32_PLL3_ENABLE)
+	/* Initialize PLL 3 */
+	r = get_vco_input_range(CONFIG_CLOCK_STM32_PLL3_M_DIVISOR, &vco_input_range);
+	if (r < 0) {
+		return r;
+	}
+
+	vco_output_range = get_vco_output_range(vco_input_range);
+
+	LL_RCC_PLL3FRACN_Disable();
+
+	LL_RCC_PLL3_SetM(CONFIG_CLOCK_STM32_PLL3_M_DIVISOR);
+	LL_RCC_PLL3_SetN(CONFIG_CLOCK_STM32_PLL3_N_MULTIPLIER);
+
+	LL_RCC_PLL3_SetVCOInputRange(vco_input_range);
+	LL_RCC_PLL3_SetVCOOutputRange(vco_output_range);
+
+#if defined(CONFIG_CLOCK_STM32_PLL3_P_ENABLE)
+	LL_RCC_PLL3P_Enable();
+	LL_RCC_PLL3_SetP(CONFIG_CLOCK_STM32_PLL3_P_DIVISOR);
+#endif /* CONFIG_CLOCK_STM32_PLL3_P_ENABLE */
+#if defined(CONFIG_CLOCK_STM32_PLL3_Q_ENABLE)
+	LL_RCC_PLL3Q_Enable();
+	LL_RCC_PLL3_SetQ(CONFIG_CLOCK_STM32_PLL3_Q_DIVISOR);
+#endif /* CONFIG_CLOCK_STM32_PLL3_Q_ENABLE */
+#if defined(CONFIG_CLOCK_STM32_PLL3_R_ENABLE)
+	LL_RCC_PLL3R_Enable();
+	LL_RCC_PLL3_SetR(CONFIG_CLOCK_STM32_PLL3_R_DIVISOR);
+#endif /* CONFIG_CLOCK_STM32_PLL3_R_ENABLE */
+
+	LL_RCC_PLL3_Enable();
+	while (LL_RCC_PLL3_IsReady() != 1U) {
+	}
+#endif /* CONFIG_CLOCK_STM32_PLL3_ENABLE */
 
 	/* Set systick to 1ms */
 	SysTick_Config(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000);

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -66,20 +66,6 @@
 #define PLLSRC_FREQ 0
 #endif
 
-#define VCO_FREQ	(PLLSRC_FREQ / CONFIG_CLOCK_STM32_PLL_M_DIVISOR)
-
-#if (1000000UL <= VCO_FREQ && VCO_FREQ <= 2000000UL)
-#define VCO_INPUT_RANGE LL_RCC_PLLINPUTRANGE_1_2
-#elif (2000000UL < VCO_FREQ && VCO_FREQ <= 4000000UL)
-#define VCO_INPUT_RANGE LL_RCC_PLLINPUTRANGE_2_4
-#elif (4000000UL < VCO_FREQ && VCO_FREQ <= 8000000UL)
-#define VCO_INPUT_RANGE LL_RCC_PLLINPUTRANGE_4_8
-#elif (8000000UL < VCO_FREQ && VCO_FREQ <= 16000000UL)
-#define VCO_INPUT_RANGE LL_RCC_PLLINPUTRANGE_8_16
-#else
-#error "PLL1 VCO frequency input range out of range"
-#endif
-
 /* Given source clock and dividers, computed the output frequency of PLLP */
 #define PLLP_FREQ(pllsrc_freq, divm, divn, divp)	(((pllsrc_freq)*\
 							(divn))/((divm)*(divp)))
@@ -298,7 +284,28 @@ static int32_t optimize_regulator_voltage_scale(uint32_t sysclk_freq)
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI)
 
-static int32_t get_vco_output_range(uint32_t vco_input_range)
+static int get_vco_input_range(uint32_t m_div, uint32_t *range)
+{
+	uint32_t vco_freq;
+
+	vco_freq = PLLSRC_FREQ / m_div;
+
+	if (1000000UL <= vco_freq && vco_freq <= 2000000UL) {
+		*range = LL_RCC_PLLINPUTRANGE_1_2;
+	} else if (2000000UL < vco_freq && vco_freq <= 4000000UL) {
+		*range = LL_RCC_PLLINPUTRANGE_2_4;
+	} else if (4000000UL < vco_freq && vco_freq <= 8000000UL) {
+		*range = LL_RCC_PLLINPUTRANGE_4_8;
+	} else if (8000000UL < vco_freq && vco_freq <= 16000000UL) {
+		*range = LL_RCC_PLLINPUTRANGE_8_16;
+	} else {
+		return -ERANGE;
+	}
+
+	return 0;
+}
+
+static uint32_t get_vco_output_range(uint32_t vco_input_range)
 {
 	if (vco_input_range == LL_RCC_PLLINPUTRANGE_1_2) {
 		return LL_RCC_PLLVCORANGE_MEDIUM;
@@ -479,7 +486,9 @@ static int stm32_clock_control_init(const struct device *dev)
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI)
 
-	int32_t vco_output_range = 0;
+	int r;
+	uint32_t vco_input_range;
+	uint32_t vco_output_range;
 #endif /* CONFIG_CLOCK_STM32_PLL_SRC_* */
 
 #endif /* ! CONFIG_CPU_CORTEX_M4 */
@@ -562,7 +571,12 @@ static int stm32_clock_control_init(const struct device *dev)
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
 	defined(CONFIG_CLOCK_STM32_PLL_SRC_CSI)
 
-	vco_output_range = get_vco_output_range(VCO_INPUT_RANGE);
+	r = get_vco_input_range(CONFIG_CLOCK_STM32_PLL_M_DIVISOR, &vco_input_range);
+	if (r < 0) {
+		return r;
+	}
+
+	vco_output_range = get_vco_output_range(vco_input_range);
 
 	/* Configure PLL1 */
 	/* According to the RM0433 datasheet */
@@ -572,7 +586,7 @@ static int stm32_clock_control_init(const struct device *dev)
 	/* Config PLL */
 
 	/* VCO sel, VCO range */
-	LL_RCC_PLL1_SetVCOInputRange(VCO_INPUT_RANGE);
+	LL_RCC_PLL1_SetVCOInputRange(vco_input_range);
 	LL_RCC_PLL1_SetVCOOutputRange(vco_output_range);
 
 	/* FRACN disable DIVP,DIVQ,DIVR enable*/


### PR DESCRIPTION
Add support for enabling and configuring PLL3 on STM32 H7 series. PLL3
is used as a clock source by certain peripherals, e.g. LTDC.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>