### PR TITLE
drivers: led: fix led_pwm initialization

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -155,8 +155,8 @@ static struct led_pwm_data					\
 								\
 DEVICE_DEFINE(led_pwm_##id,					\
 		    DT_INST_PROP_OR(id, label, "LED_PWM_"#id),	\
-		    device_pm_control_nop,			\
 		    &led_pwm_init,				\
+		    device_pm_control_nop,			\
 		    &led_pwm_data_##id,				\
 		    &led_pwm_config_##id,			\
 		    POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\


### PR DESCRIPTION
The PM control function and the init function were swapped.

Causes build failures in nightly: https://buildkite.com/zephyr/zephyr-daily/builds/184#f22a8789-54e1-4f43-b403-c52c273be46a

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>