### PR TITLE
Bluetooth: controller: fix mesh build error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <soc.h>
+
 static inline void cpu_sleep(void)
 {
 #if defined(CONFIG_CPU_CORTEX_M0) || \


### PR DESCRIPTION
Cleanup of a module removed soc.h which was depended on by an internal
SOC-specific include file.

Fixes nightly build error with `bbc_microbit` `tests/bluetooth/mesh/bluetooth.mesh.main.microbit`;  apparently nRF51 doesn't have the necessaries elsewhere in the include paths.
 
```
zephyr/subsys/bluetooth/controller/CMakeFiles/subsys__bluetooth__controller.dir/ll_sw/nordic/lll/lll_adv.c.obj 
ccache /opt/sdk/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DBUILD_VERSION=zephyr-v2.4.0-2631-g3b89f4a474c5 -DKERNEL -DNRF51 -D_FORTIFY_SOURCE=2 -D__PROGRAM_START -D__ZEPHYR__=1 -I../../../../../../subsys/bluetooth/controller/ll_sw/nordic/lll -I../../../../../../subsys/bluetooth/controller/ll_sw/nordic -I../../../../../../subsys/bluetooth/controller/hci/nordic -I../../../../../../subsys/bluetooth/controller/. -I../../../../../../subsys/bluetooth/controller/include -I../../../../../../subsys/bluetooth/controller/ll_sw -I../../../../../../include -Izephyr/include/generated -I../../../../../../soc/arm/nordic_nrf/nrf51 -I../../../../../../subsys/testsuite/include -I../../../../../../subsys/bluetooth -I/var/lib/buildkite-agent/zephyr-module-cache/modules/hal/cmsis/CMSIS/Core/Include -I/var/lib/buildkite-agent/zephyr-module-cache/modules/hal/nordic/nrfx -I/var/lib/buildkite-agent/zephyr-module-cache/modules/hal/nordic/nrfx/drivers/include -I/var/lib/buildkite-agent/zephyr-module-cache/modules/hal/nordic/nrfx/mdk -I/var/lib/buildkite-agent/zephyr-module-cache/modules/hal/nordic/. -I/var/lib/buildkite-agent/zephyr-module-cache/modules/crypto/tinycrypt/lib/include -isystem ../../../../../../lib/libc/minimal/include -isystem /opt/sdk/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/include -isystem /opt/sdk/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/include-fixed -Os -imacros /workdir/zephyr/twister-out/bbc_microbit/tests/bluetooth/mesh/bluetooth.mesh.main.microbit/zephyr/include/generated/autoconf.h -ffreestanding -fno-common -g -mcpu=cortex-m0 -mthumb -mabi=aapcs -imacros /workdir/zephyr/include/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wno-main -Wno-pointer-sign -Wpointer-arith -Wno-address-of-packed-member -Wno-unused-but-set-variable -Werror=implicit-int -Werror -fno-asynchronous-unwind-tables -fno-pie -fno-pic -fno-strict-overflow -fno-reorder-functions -fno-defer-pop -fmacro-prefix-map=/workdir/zephyr/tests/bluetooth/mesh=CMAKE_SOURCE_DIR -fmacro-prefix-map=/workdir/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/workdir=WEST_TOPDIR -ffunction-sections -fdata-sections -std=c99 -nostdinc -MD -MT zephyr/subsys/bluetooth/controller/CMakeFiles/subsys__bluetooth__controller.dir/ll_sw/nordic/lll/lll_adv.c.obj -MF zephyr/subsys/bluetooth/controller/CMakeFiles/subsys__bluetooth__controller.dir/ll_sw/nordic/lll/lll_adv.c.obj.d -o zephyr/subsys/bluetooth/controller/CMakeFiles/subsys__bluetooth__controller.dir/ll_sw/nordic/lll/lll_adv.c.obj   -c /workdir/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
In file included from ../../../../../../subsys/bluetooth/controller/ll_sw/nordic/hal/cpu_vendor_hal.h:7,
                 from ../../../../../../subsys/bluetooth/controller/./hal/cpu.h:7,
                 from /workdir/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c:14:
../../../../../../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h: In function 'cpu_sleep':
../../../../../../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h:13:2: error: implicit declaration of function '__WFE' [-Werror=implicit-function-declaration]
   13 |  __WFE();
      |  ^~~~~
../../../../../../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h:14:2: error: implicit declaration of function '__SEV' [-Werror=implicit-function-declaration]
   14 |  __SEV();
      |  ^~~~~
cc1: all warnings being treated as errors
```