### PR TITLE
net: ipv6: resolve literal IPv6 addresses

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2017 Linaro Limited
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /* libc headers */
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 
 /* Zephyr headers */
@@ -13,22 +15,31 @@
 LOG_MODULE_REGISTER(net_sock_addr, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <kernel.h>
+#include <net/net_ip.h>
 #include <net/socket.h>
 #include <net/socket_offload.h>
 #include <syscall_handler.h>
 
 #define AI_ARR_MAX	2
 
-#if defined(CONFIG_DNS_RESOLVER)
+#if defined(CONFIG_DNS_RESOLVER) || \
+	defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
+#define ANY_RESOLVER
 
-/* Helper macros which take into account the fact that ai_family as passed
- * into getaddrinfo() may take values AF_INET, AF_INET6, or AF_UNSPEC, where
- * AF_UNSPEC means resolve both AF_INET and AF_INET6.
+/* Initialize static fields of addrinfo structure. A macro to let it work
+ * with any sockaddr_* type.
  */
-#define RESOLVE_IPV4(ai_family) \
-	(IS_ENABLED(CONFIG_NET_IPV4) && (ai_family) != AF_INET6)
-#define RESOLVE_IPV6(ai_family) \
-	(IS_ENABLED(CONFIG_NET_IPV6) && (ai_family) != AF_INET)
+#define INIT_ADDRINFO(addrinfo, sockaddr) { \
+		(addrinfo)->ai_addr = &(addrinfo)->_ai_addr; \
+		(addrinfo)->ai_addrlen = sizeof(*(sockaddr)); \
+		(addrinfo)->ai_canonname = (addrinfo)->_ai_canonname; \
+		(addrinfo)->_ai_canonname[0] = '\0'; \
+		(addrinfo)->ai_next = NULL; \
+	}
+
+#endif
+
+#if defined(CONFIG_DNS_RESOLVER)
 
 struct getaddrinfo_state {
 	const struct zsock_addrinfo *hints;
@@ -38,17 +49,6 @@ struct getaddrinfo_state {
 	uint16_t port;
 	struct zsock_addrinfo *ai_arr;
 };
-
-/* Initialize static fields of addrinfo structure. A macro to let it work
- * with any sockaddr_* type.
- */
-#define INIT_ADDRINFO(addrinfo, sockaddr) { \
-		(addrinfo)->ai_addr = &(addrinfo)->_ai_addr; \
-		(addrinfo)->ai_addrlen = sizeof(*sockaddr); \
-		(addrinfo)->ai_canonname = (addrinfo)->_ai_canonname; \
-		(addrinfo)->_ai_canonname[0] = '\0'; \
-		(addrinfo)->ai_next = NULL; \
-	}
 
 static void dns_resolve_cb(enum dns_resolve_status status,
 			   struct dns_addrinfo *info, void *user_data)
@@ -162,16 +162,17 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	struct sockaddr *ai_addr;
 	int ret;
 	struct getaddrinfo_state ai_state;
-	int socktype = SOCK_STREAM;
-	int protocol = IPPROTO_TCP;
 
 	if (hints) {
 		family = hints->ai_family;
 		ai_flags = hints->ai_flags;
-		if (hints->ai_socktype == SOCK_DGRAM) {
-			socktype = SOCK_DGRAM;
-			protocol = IPPROTO_UDP;
-		}
+	}
+
+	if (ai_flags & AI_NUMERICHOST) {
+		/* Asked to resolve host as numeric, but it wasn't possible
+		 * to do that.
+		 */
+		return DNS_EAI_FAIL;
 	}
 
 	if (service) {
@@ -189,35 +190,6 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 		}
 
 		return getaddrinfo_null_host(port, hints, res);
-	}
-
-#define SIN_ADDR(ptr) (net_sin(ptr)->sin_addr)
-
-	/* Check for IPv4 numeric address. Start with a quick heuristic check,
-	 * of first char of the address, then do long validating inet_pton()
-	 * call if needed.
-	 */
-	if (RESOLVE_IPV4(family) &&
-	    isdigit((int)*host) &&
-	    zsock_inet_pton(AF_INET, host,
-			    &SIN_ADDR(&res->_ai_addr)) == 1) {
-		struct sockaddr_in *addr =
-			(struct sockaddr_in *)&res->_ai_addr;
-
-		addr->sin_port = htons(port);
-		addr->sin_family = AF_INET;
-		INIT_ADDRINFO(res, addr);
-		res->ai_family = AF_INET;
-		res->ai_socktype = socktype;
-		res->ai_protocol = protocol;
-		return 0;
-	}
-
-	if (ai_flags & AI_NUMERICHOST) {
-		/* Asked to resolve host as numeric, but it wasn't possible
-		 * to do that.
-		 */
-		return DNS_EAI_FAIL;
 	}
 
 	ai_state.hints = hints;
@@ -346,6 +318,84 @@ out:
 
 #endif /* defined(CONFIG_DNS_RESOLVER) */
 
+#if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
+static int try_resolve_literal_addr(const char *host, const char *service,
+				    const struct zsock_addrinfo *hints,
+				    struct zsock_addrinfo *res)
+{
+	int family = AF_UNSPEC;
+	int resolved_family = AF_UNSPEC;
+	long port = 0;
+	bool result;
+	int socktype = SOCK_STREAM;
+	int protocol = IPPROTO_TCP;
+
+	if (!host) {
+		return DNS_EAI_NONAME;
+	}
+
+	if (hints) {
+		family = hints->ai_family;
+		if (hints->ai_socktype == SOCK_DGRAM) {
+			socktype = SOCK_DGRAM;
+			protocol = IPPROTO_UDP;
+		}
+	}
+
+	result = net_ipaddr_parse(host, strlen(host), &res->_ai_addr);
+
+	if (!result) {
+		return DNS_EAI_NONAME;
+	}
+
+	resolved_family = res->_ai_addr.sa_family;
+
+	if ((family != AF_UNSPEC) && (resolved_family != family)) {
+		return DNS_EAI_NONAME;
+	}
+
+	if (service) {
+		port = strtol(service, NULL, 10);
+		if (port < 1 || port > 65535) {
+			return DNS_EAI_NONAME;
+		}
+	}
+
+	res->ai_family = resolved_family;
+	res->ai_socktype = socktype;
+	res->ai_protocol = protocol;
+
+	switch (resolved_family) {
+	case AF_INET:
+	{
+		struct sockaddr_in *addr =
+			(struct sockaddr_in *)&res->_ai_addr;
+
+		INIT_ADDRINFO(res, addr);
+		addr->sin_port = htons(port);
+		addr->sin_family = AF_INET;
+		break;
+	}
+
+	case AF_INET6:
+	{
+		struct sockaddr_in6 *addr =
+			(struct sockaddr_in6 *)&res->_ai_addr;
+
+		INIT_ADDRINFO(res, addr);
+		addr->sin6_port = htons(port);
+		addr->sin6_family = AF_INET6;
+		break;
+	}
+
+	default:
+		return DNS_EAI_NONAME;
+	}
+
+	return 0;
+}
+#endif /* defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4) */
+
 int zsock_getaddrinfo(const char *host, const char *service,
 		      const struct zsock_addrinfo *hints,
 		      struct zsock_addrinfo **res)
@@ -354,22 +404,36 @@ int zsock_getaddrinfo(const char *host, const char *service,
 		return socket_offload_getaddrinfo(host, service, hints, res);
 	}
 
-#if defined(CONFIG_DNS_RESOLVER)
-	int ret;
+	int ret = DNS_EAI_FAIL;
 
+#if defined(ANY_RESOLVER)
 	*res = calloc(AI_ARR_MAX, sizeof(struct zsock_addrinfo));
 	if (!(*res)) {
 		return DNS_EAI_MEMORY;
 	}
-	ret = z_zsock_getaddrinfo_internal(host, service, hints, *res);
+#endif
+
+#if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
+	/* Resolve literal address even if DNS is not available */
+	if (ret) {
+		ret = try_resolve_literal_addr(host, service, hints, *res);
+	}
+#endif
+
+#if defined(CONFIG_DNS_RESOLVER)
+	if (ret) {
+		ret = z_zsock_getaddrinfo_internal(host, service, hints, *res);
+	}
+#endif
+
+#if defined(ANY_RESOLVER)
 	if (ret) {
 		free(*res);
 		*res = NULL;
 	}
-	return ret;
 #endif
 
-	return DNS_EAI_FAIL;
+	return ret;
 }
 
 void zsock_freeaddrinfo(struct zsock_addrinfo *ai)

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -312,6 +312,215 @@ void test_getaddrinfo_num_ipv4(void)
 	zsock_freeaddrinfo(res);
 }
 
+void test_getaddrinfo_num_ipv6(void)
+{
+	struct zsock_addrinfo *res = NULL;
+	struct sockaddr_in6 *saddr;
+	int ret;
+
+	struct zsock_addrinfo hints = {
+		.ai_family = AF_INET6,
+		.ai_socktype = SOCK_STREAM
+	};
+
+	ret = zsock_getaddrinfo("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]",
+			"65534", NULL, &res);
+
+	zassert_equal(ret, 0, "Invalid result");
+	zassert_not_null(res, "");
+	zassert_is_null(res->ai_next, "");
+	zassert_equal(res->ai_family, AF_INET6, "");
+	zassert_equal(res->ai_socktype, SOCK_STREAM, "");
+	zassert_equal(res->ai_protocol, IPPROTO_TCP, "");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0xFE, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0xDC, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0xBA, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x98, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x76, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x54, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x32, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x10, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0xFE, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0xDC, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0xBA, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x98, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 0x76, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 0x54, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 0x32, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 0x10, "");
+	zsock_freeaddrinfo(res);
+
+
+	ret = zsock_getaddrinfo("[1080:0:0:0:8:800:200C:417A]",
+			"65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+	zassert_not_null(res, "");
+	zassert_is_null(res->ai_next, "");
+	zassert_equal(res->ai_family, AF_INET6, "");
+	zassert_equal(res->ai_socktype, SOCK_STREAM, "");
+	zassert_equal(res->ai_protocol, IPPROTO_TCP, "");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x10, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0x80, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x08, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0x08, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x00, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 0x20, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 0x0C, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 0x41, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 0x7A, "");
+	zsock_freeaddrinfo(res);
+
+
+	hints.ai_socktype = SOCK_DGRAM;
+	ret = zsock_getaddrinfo("[3ffe:2a00:100:7031::1]",
+			"65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+	zassert_not_null(res, "");
+	zassert_is_null(res->ai_next, "");
+	zassert_equal(res->ai_family, AF_INET6, "");
+	zassert_equal(res->ai_socktype, SOCK_DGRAM, "");
+	zassert_equal(res->ai_protocol, IPPROTO_UDP, "");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x3f, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0xfe, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x2a, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x00, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x01, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x00, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x70, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x31, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 0x1, "");
+	zsock_freeaddrinfo(res);
+
+
+	ret = zsock_getaddrinfo("[1080::8:800:200C:417A]",
+			"65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x10, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0x80, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x8, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0x08, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x00, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 0x20, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 0x0C, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 0x41, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 0x7A, "");
+	zsock_freeaddrinfo(res);
+
+
+	ret = zsock_getaddrinfo("[::192.9.5.5]", "65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 192, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 9, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 5, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 5, "");
+	zsock_freeaddrinfo(res);
+
+
+	ret = zsock_getaddrinfo("[::FFFF:129.144.52.38]",
+			"65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0xFF, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0xFF, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 129, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 144, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 52, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 38, "");
+	zsock_freeaddrinfo(res);
+
+
+	ret = zsock_getaddrinfo("[2010:836B:4179::836B:4179]",
+			"65534", &hints, &res);
+	zassert_equal(ret, 0, "Invalid result");
+
+	saddr = (struct sockaddr_in6 *)res->ai_addr;
+	zassert_equal(saddr->sin6_family, AF_INET6, "");
+	zassert_equal(saddr->sin6_port, htons(65534), "");
+	zassert_equal(saddr->sin6_addr.s6_addr[0], 0x20, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[1], 0x10, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[2], 0x83, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[3], 0x6B, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[4], 0x41, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[5], 0x79, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[6], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[7], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[8], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[9], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[10], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[11], 0x0, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[12], 0x83, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[13], 0x6B, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[14], 0x41, "");
+	zassert_equal(saddr->sin6_addr.s6_addr[15], 0x79, "");
+	zsock_freeaddrinfo(res);
+}
+
 void test_getaddrinfo_flags_numerichost(void)
 {
 	int ret;
@@ -447,6 +656,7 @@ void test_main(void)
 			 ztest_unit_test(test_getaddrinfo_cancelled),
 			 ztest_unit_test(test_getaddrinfo_no_host),
 			 ztest_unit_test(test_getaddrinfo_num_ipv4),
+			 ztest_unit_test(test_getaddrinfo_num_ipv6),
 			 ztest_unit_test(test_getaddrinfo_flags_numerichost),
 			 ztest_unit_test(test_getaddrinfo_ipv4_hints_ipv6),
 			 ztest_unit_test(test_getaddrinfo_ipv6_hints_ipv4),


### PR DESCRIPTION
With this patch the resolver module can resolve literal IPv6
addresses even when DNS client is not presnet in the system.