### PR TITLE
sched: timeout: Do not miss slice timeouts

### DIFF
--- a/doc/reference/kernel/scheduling/index.rst
+++ b/doc/reference/kernel/scheduling/index.rst
@@ -177,9 +177,7 @@ only when dealing with lower priority threads that are less time-sensitive.
    The kernel's time slicing algorithm does *not* ensure that a set
    of equal-priority threads receive an equitable amount of CPU time,
    since it does not measure the amount of time a thread actually gets to
-   execute. For example, a thread may become the current thread just before
-   the end of a time slice and then immediately have to yield the CPU.
-   However, the algorithm *does* ensure that a thread never executes
+   execute. However, the algorithm *does* ensure that a thread never executes
    for longer than a single time slice without being required to yield.
 
 Scheduler Locking

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -62,8 +62,6 @@ int z_clock_driver_init(const struct device *device)
 
 void z_clock_set_timeout(int32_t ticks, bool idle)
 {
-	ARG_UNUSED(idle);
-
 #if defined(CONFIG_TICKLESS_KERNEL)
 
 	if (ticks == K_TICKS_FOREVER && idle) {
@@ -90,6 +88,8 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	arm_arch_timer_set_irq_mask(false);
 	k_spin_unlock(&lock, key);
 
+#else  /* CONFIG_TICKLESS_KERNEL */
+	ARG_UNUSED(idle);
 #endif
 }
 

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -89,6 +89,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 	k_spin_unlock(&lock, key);
 
 #else  /* CONFIG_TICKLESS_KERNEL */
+	ARG_UNUSED(ticks);
 	ARG_UNUSED(idle);
 #endif
 }

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -66,7 +66,7 @@ void z_clock_set_timeout(int32_t ticks, bool idle)
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 
-	if (idle) {
+	if (ticks == K_TICKS_FOREVER && idle) {
 		return;
 	}
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -123,7 +123,23 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 		}
 
 		if (to == first()) {
+#if CONFIG_TIMESLICING
+			/*
+			 * This is not ideal, since it does not
+			 * account the time elapsed since the the
+			 * last announcement, and slice_ticks is based
+			 * on that. It means the that time remaining for
+			 * the next announcement can be lesser than
+			 * slice_ticks.
+			 */
+			int32_t next_time = next_timeout();
+
+			if (_current_cpu->slice_ticks != next_time) {
+				z_clock_set_timeout(next_time, false);
+			}
+#else
 			z_clock_set_timeout(next_timeout(), false);
+#endif	/* CONFIG_TIMESLICING */
 		}
 	}
 }

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -85,6 +85,12 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 thread_idx, t, expected_slice_min, expected_slice_max);
 #endif
 
+	/* Before the assert, otherwise in case of fail the output
+	 * will give the impression that the same thread ran more than
+	 * once
+	 */
+	thread_idx = (thread_idx + 1) % NUM_THREAD;
+
 	/** TESTPOINT: timeslice should be reset for each preemptive thread */
 #ifndef CONFIG_COVERAGE
 	zassert_true(t >= expected_slice_min,
@@ -96,7 +102,6 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 #else
 	(void)t;
 #endif /* CONFIG_COVERAGE */
-	thread_idx = (thread_idx + 1) % NUM_THREAD;
 
 	/* Keep the current thread busy for more than one slice, even though,
 	 * when timeslice used up the next thread should be scheduled in.

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -51,6 +51,8 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 {
 	uint32_t t = cycles_delta(&elapsed_slice);
 	uint32_t expected_slice_min, expected_slice_max;
+	uint32_t switch_tolerance_ticks =
+		k_ms_to_ticks_ceil32(TASK_SWITCH_TOLERANCE);
 
 	if (thread_idx == 0) {
 		/*
@@ -70,11 +72,11 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 		 */
 		expected_slice_min =
 			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 - TASK_SWITCH_TOLERANCE)
+			 - switch_tolerance_ticks)
 			* k_ticks_to_cyc_floor32(1);
 		expected_slice_max =
 			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 + TASK_SWITCH_TOLERANCE)
+			 + switch_tolerance_ticks)
 			* k_ticks_to_cyc_floor32(1);
 	}
 


### PR DESCRIPTION
Time slices don't have a timeout struct associated and stored in
timeout_list. Time slice timeout is direct programmed in the system
clock and tracked in _current_cpu->slice_ticks.

There is one issue where the time slice timeout can be missed because
the system clock is re-programmed to a longer timeout. To this happens,
it is only necessary that the timeout_list is empty (any timeout set)
and a new timeout longer than remaining time slice is set. This is cause
because z_add_timeout does not check for the slice ticks.

Fixes #29705