### PR TITLE
twister: add 10 hexadecimal digits to version

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2580,7 +2580,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
     def check_zephyr_version(self):
         try:
-            subproc = subprocess.run(["git", "describe"],
+            subproc = subprocess.run(["git", "describe", "--abbrev=12"],
                                      stdout=subprocess.PIPE,
                                      universal_newlines=True,
                                      cwd=ZEPHYR_BASE)


### PR DESCRIPTION
In https://testing.zephyrproject.org/daily_tests/versions.json, all tags have 10 hexadecimal digits.  But sometimes when I run twister on different hosts, the following command will use the default 7 hexadecimal digits as the abbreviated object name. 
https://github.com/zephyrproject-rtos/zephyr/blob/fe8311843285b93951adfdb55c411dffe4bf78ca/scripts/pylib/twister/twisterlib.py#L2583

The generated xml file will contain a tag that  `version.json` doesn't have. So I think it's necessary to add `--abbrev=10` to prevent twister using the default 7 hexadecimal digits as the abbreviated object name.

Signed-off-by: Jingru Wang <jingru@synopsys.com>