### PR TITLE
CODEOWNERS: Update path to usb_dfu.c

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -569,7 +569,7 @@
 /subsys/testsuite/                        @nashif
 /subsys/timing/                           @nashif @dcpleung
 /subsys/usb/                              @jfischer-no @finikorg
-/subsys/usb/class/usb_dfu.c               @nvlsianpu
+/subsys/usb/class/dfu/usb_dfu.c           @nvlsianpu
 /tests/                                   @nashif
 /tests/application_development/libcxx/    @pabigot
 /tests/arch/arm/                          @ioannisg @stephanosio


### PR DESCRIPTION
This is a follow-up to commit 1c89837e7957e1f94a9bc2af74cef727d9cf0775.

Update the path to dfu_usb.c after the file was moved, to prevent
compliance checks from failing because of non-existing file listed
in CODEOWNERS.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>