### PR TITLE
soc: arm: stm32: DTSI update for eeprom size stm32l151Xc

### DIFF
--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -18,5 +18,8 @@
 				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(8)>;
+		};
 	};
 };


### PR DESCRIPTION
Add EEPROM size to STM32L151xC.dtsi. 

Signed-off-by: Noelle Clement <noelleclement@hotmail.com>