### PR TITLE
edtlib: Match any parent bus when binding lacks an explicit on-bus

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -69,8 +69,12 @@ bus: <string describing bus type, e.g. "i2c">
 #
 # When looking for a binding for a node, the code checks if the binding for the
 # parent node contains 'bus: <bus type>'. If it does, then only bindings with a
-# matching 'on-bus: <bus type>' are considered. This allows the same type of
-# device to have different bindings depending on what bus it appears on.
+# matching 'on-bus: <bus type>' and bindings without an explicit 'on-bus'
+# are considered. Bindings with an explicit 'on-bus: <bus type>' are looked
+# for first, and if none is found bindings without an explicit `on-bus` are
+# attempted. These two tests are done for each item in the `compatible` array
+# in the order specified. This allows the same type of device to have different
+# bindings depending on what bus it appears on.
 on-bus: <string describing bus type, e.g. "i2c">
 
 # 'properties' describes properties on the node, e.g.

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -768,13 +768,22 @@ class Node:
             on_bus = self.on_bus
 
             for compat in self.compats:
+                # When matching, respect the order of the 'compatible' entries,
+                # and for each one first try to match against an explicitly
+                # specified bus (if any) and then against any bus. This is so
+                # that matching against bindings which do not specify a bus
+                # works the same way in Zephyr as it does elsewhere.
                 if (compat, on_bus) in self.edt._compat2binding:
-                    # Binding found
                     binding = self.edt._compat2binding[compat, on_bus]
-                    self.binding_path = binding.path
-                    self.matching_compat = compat
-                    self._binding = binding
-                    return
+                elif (compat, None) in self.edt._compat2binding:
+                    binding = self.edt._compat2binding[compat, None]
+                else:
+                    continue
+
+                self.binding_path = binding.path
+                self.matching_compat = compat
+                self._binding = binding
+                return
         else:
             # No 'compatible' property. See if the parent binding has
             # a compatible. This can come from one or more levels of

--- a/scripts/dts/test-bindings/device-on-any-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-any-bus.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Device on any bus
+
+compatible: "on-any-bus"

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -332,11 +332,14 @@
 		// they appear on different buses
 		foo-bus {
 			compatible = "foo-bus";
-			node {
-				compatible = "on-bus";
+			node1 {
+				compatible = "on-bus", "on-any-bus";
 				nested {
 					compatible = "on-bus";
 				};
+			};
+			node2 {
+				compatible = "on-any-bus", "on-bus";
 			};
 		};
 		bar-bus {
@@ -344,6 +347,9 @@
 			node {
 				compatible = "on-bus";
 			};
+		};
+		no-bus-node {
+			compatible = "on-any-bus";
 		};
 	};
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -124,23 +124,37 @@ def test_bus():
     assert edt.get_node("/buses/foo-bus").on_bus is None
     assert edt.get_node("/buses/foo-bus").bus_node is None
 
-    # foo-bus/node is not a bus node...
-    assert edt.get_node("/buses/foo-bus/node").bus is None
+    # foo-bus/node1 is not a bus node...
+    assert edt.get_node("/buses/foo-bus/node1").bus is None
     # ...but is on a bus
-    assert edt.get_node("/buses/foo-bus/node").on_bus == "foo"
-    assert edt.get_node("/buses/foo-bus/node").bus_node.path == \
+    assert edt.get_node("/buses/foo-bus/node1").on_bus == "foo"
+    assert edt.get_node("/buses/foo-bus/node1").bus_node.path == \
         "/buses/foo-bus"
+
+    # foo-bus/node2 is not a bus node...
+    assert edt.get_node("/buses/foo-bus/node2").bus is None
+    # ...but is on a bus
+    assert edt.get_node("/buses/foo-bus/node2").on_bus == "foo"
+
+    # no-bus-node is not a bus node...
+    assert edt.get_node("/buses/no-bus-node").bus is None
+    # ... and is not on a bus
+    assert edt.get_node("/buses/no-bus-node").on_bus is None
 
     # Same compatible string, but different bindings from being on different
     # buses
-    assert str(edt.get_node("/buses/foo-bus/node").binding_path) == \
+    assert str(edt.get_node("/buses/foo-bus/node1").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
+    assert str(edt.get_node("/buses/foo-bus/node2").binding_path) == \
+        hpath("test-bindings/device-on-any-bus.yaml")
     assert str(edt.get_node("/buses/bar-bus/node").binding_path) == \
         hpath("test-bindings/device-on-bar-bus.yaml")
+    assert str(edt.get_node("/buses/no-bus-node").binding_path) == \
+        hpath("test-bindings/device-on-any-bus.yaml")
 
     # foo-bus/node/nested also appears on the foo-bus bus
-    assert edt.get_node("/buses/foo-bus/node/nested").on_bus == "foo"
-    assert str(edt.get_node("/buses/foo-bus/node/nested").binding_path) == \
+    assert edt.get_node("/buses/foo-bus/node1/nested").on_bus == "foo"
+    assert str(edt.get_node("/buses/foo-bus/node1/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
 
 def test_child_binding():


### PR DESCRIPTION
There are some drivers in the tree that support devices on multiple
different buses, although so far this has not been represented in
device tree using the bus concept. In order to convert these drivers &
bindings to refer to a formal bus in device tree we need to be able to
match bindings which lack an explicit "on-bus: ..." value against any
parent bus.

The two drivers I'm particularly targeting is the ns16550 UART driver
(drivers/serial/uart_ns16550.c) and the DW I2C driver
(drivers/i2c/i2c_dw.c). They both support devices with a fixed MMIO
address as well as devices connected and discovered over PCIe. The
only issue is that instead of encoding the bus information the proper
DT way these bindings use a special "pcie" property in the DT node
entries to indicate whether the node is on the PCIe bus or not.

Being able to convert the above two drivers to use the DT bus concept
allow the removal of "hacks" like this:

```
 #if DT_INST_PROP(0, pcie) || \
       DT_INST_PROP(1, pcie) || \
       DT_INST_PROP(2, pcie) || \
       DT_INST_PROP(3, pcie)
```

to the more intuitive:

```
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
```

This also has the benefit that the driver doesn't need to make any
arbitrary assumptions of how many matching devices there may be but
works for any number of matches. This is already a problem now since
e.g. the ns16550 driver assumes a maximum of 4 nodes, whereas
dts/x86/elkhart_lake.dtsi defines up to 9 different ns16550 nodes.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>