### PR TITLE
fix build errors related to PM selection

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -189,7 +189,6 @@ void idle(void *p1, void *unused2, void *unused3)
 		 * API we need to honor...
 		 */
 		z_set_timeout_expiry((ticks < IDLE_THRESH) ? 1 : ticks, true);
-#endif /* CONFIG_SYS_CLOCK_EXISTS */
 #ifdef CONFIG_PM
 		_kernel.idle = ticks;
 		/* Check power policy and decide if we are going to sleep or
@@ -198,9 +197,12 @@ void idle(void *p1, void *unused2, void *unused3)
 		if (pm_save_idle(ticks) == POWER_STATE_ACTIVE) {
 			k_cpu_idle();
 		}
-#else
+#else /* CONFIG_PM */
 		k_cpu_idle();
 #endif /* CONFIG_PM */
+#else /* CONFIG_SYS_CLOCK_EXISTS */
+		k_cpu_idle();
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 		IDLE_YIELD_IF_COOP();
 #endif /* SMP_FALLBACK */

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
@@ -62,7 +62,7 @@ config SPI_XEC_QMSPI
 if SOC_POWER_MANAGEMENT
 
 config PM
-	default y
+	default y if SYS_CLOCK_EXISTS
 
 config PM_SLEEP_STATES
 	default y

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -28,7 +28,7 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
 config PM
-	default y
+	default y if SYS_CLOCK_EXISTS
 
 config BUILD_OUTPUT_HEX
 	default y


### PR DESCRIPTION
The kernel idle code was inconsistent in the case where PM was selected but the system clock was not defined, resulting in build errors of:
```
/workdir/zephyr/kernel/idle.c: In function 'idle':
/workdir/zephyr/kernel/idle.c:194:18: error: 'ticks' undeclared (first use in this function)
  194 |   _kernel.idle = ticks;
      |                  ^~~~~
```

That this configuration was observed is due to certain SoCs selecting PM without the dependency that was added in #30877.  Update those SoC-specific overrides.

Fixes multiple build errors in: https://buildkite.com/zephyr/zephyr-daily/builds/185