### PR TITLE
cavs: unify defconfigs for v15, v18, v20 and v25

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -18,9 +18,6 @@ config SOC
 config SMP
 	default y
 
-config MP_NUM_CPUS
-	default 2
-
 config XTENSA_TIMER
 	default n
 
@@ -59,12 +56,6 @@ config TEST_LOGGING_DEFAULTS
 	default n
 	depends on TEST
 
-config IPM_CAVS_IDC
-	default y
-
-config IPM
-	default y
-
 if LOG
 
 config LOG_PRINTK
@@ -76,6 +67,15 @@ config LOG_BACKEND_ADSP
 endif # LOG
 
 if SMP
+
+config MP_NUM_CPUS
+	default 2
+
+config IPM
+       default y
+
+config IPM_CAVS_IDC
+	default y
 
 config SCHED_IPI_SUPPORTED
 	default y if IPM_CAVS_IDC

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -15,6 +15,15 @@ config SOC
 	string
 	default "intel_cavs_18"
 
+config SMP
+       default y
+
+config XTENSA_TIMER
+	default n
+
+config CAVS_TIMER
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 24000000 if CAVS_TIMER
@@ -66,12 +75,6 @@ if SMP
 config MP_NUM_CPUS
 	default 2
 
-config XTENSA_TIMER
-	default n
-
-config CAVS_TIMER
-	default y
-
 config IPM
 	default y
 
@@ -81,8 +84,6 @@ config IPM_CAVS_IDC
 config SCHED_IPI_SUPPORTED
 	default y if IPM_CAVS_IDC
 
-endif # SMP
-
 config IPM_INTEL_ADSP
 	default y
 	depends on IPM
@@ -91,5 +92,7 @@ config IPM_CONSOLE
 	default y
 	depends on CONSOLE
 	depends on IPM
+
+endif # SMP
 
 endif

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -15,6 +15,15 @@ config SOC
 	string
 	default "intel_cavs_20"
 
+config SMP
+       default y
+
+config XTENSA_TIMER
+	default n
+
+config CAVS_TIMER
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 38400000 if CAVS_TIMER
@@ -64,12 +73,6 @@ if SMP
 
 config MP_NUM_CPUS
 	default 2
-
-config XTENSA_TIMER
-	default n
-
-config CAVS_TIMER
-	default y
 
 config IPM
 	default y

--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -15,6 +15,15 @@ config SOC
 	string
 	default "intel_cavs_25"
 
+config SMP
+       default y
+
+config XTENSA_TIMER
+	default n
+
+config CAVS_TIMER
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 38400000 if CAVS_TIMER
@@ -64,12 +73,6 @@ if SMP
 
 config MP_NUM_CPUS
 	default 2
-
-config XTENSA_TIMER
-	default n
-
-config CAVS_TIMER
-	default y
 
 config IPM
 	default y


### PR DESCRIPTION
Unify default configurations to support both SMP and UP:

1. make SMP default, although it's currently disabled in prj.conf
2. use CAVS timer by default in both UP and SMP configurations
3. make MP_NUM_CPUS, IPM and IPM_CAVS_IDC depend on SMP
