### PR TITLE
drivers: gpio: esp32: fix device binding error

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -270,7 +270,8 @@ static int gpio_esp32_init(const struct device *device)
 	struct gpio_esp32_data *data = device->data;
 	static bool isr_connected;
 
-	data->pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));
+	data->pinmux = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux)));
+
 	if (!data->pinmux) {
 		return -ENOTSUP;
 	}

--- a/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
@@ -10,3 +10,10 @@ include: base.yaml
 properties:
     reg:
       required: true
+
+    label:
+      required: true
+
+pinmux-cells:
+  - pin
+  - function

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -79,6 +79,7 @@
 		pinmux: pinmux@3ff49000 {
 			compatible = "espressif,esp32-pinmux";
 			reg = <0x3ff49000 0x94>;
+			label = "PINMUX";
 		};
 
 		gpio0: gpio@3ff44000 {


### PR DESCRIPTION
fix issue introduced by DT update: #30845 

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>

Fixes  #30961