### PR TITLE
runners: nsim: allow to use runner if gdb is missing

### DIFF
--- a/scripts/west_commands/runners/nsim.py
+++ b/scripts/west_commands/runners/nsim.py
@@ -28,7 +28,10 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
                  gdb_port=DEFAULT_ARC_GDB_PORT,
                  props=DEFAULT_PROPS_FILE):
         super().__init__(cfg)
-        self.gdb_cmd = [cfg.gdb] + (['-tui'] if tui else [])
+        if cfg.gdb is None:
+            self.gdb_cmd = None
+        else:
+            self.gdb_cmd = [cfg.gdb] + (['-tui'] if tui else [])
         self.nsim_cmd = ['nsimdrv']
         self.gdb_port = gdb_port
         self.props = props
@@ -46,9 +49,6 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def do_create(cls, cfg, args):
-        if cfg.gdb is None:
-            raise ValueError('--gdb not provided at command line')
-
         return NsimBinaryRunner(
             cfg,
             gdb_port=args.gdb_port,
@@ -73,6 +73,9 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
         self.check_call(cmd)
 
     def do_debug(self, **kwargs):
+        if self.gdb_cmd is None:
+            raise ValueError('Cannot debug; gdb is missing')
+
         config = kwargs['nsim-cfg']
 
         server_cmd = (self.nsim_cmd + ['-gdb',


### PR DESCRIPTION
As of today we check for `gdb` presence in `do_create` method and raise an exception in case of `gdb` is missing. That makes nsim runner unusable without `gdb` even for the commands which don't use it (like `flash` command).

Fix that.