### PR TITLE
fix device definition from devicetree with no labels

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -265,12 +265,19 @@ static void gpio_esp32_fire_callbacks(const struct device *device)
 
 static void gpio_esp32_isr(const void *param);
 
+DEVICE_DT_DECLARE(DT_NODELABEL(pinmux));
+
 static int gpio_esp32_init(const struct device *device)
 {
 	struct gpio_esp32_data *data = device->data;
 	static bool isr_connected;
 
 	data->pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));
+	if ((data->pinmux != NULL)
+	    && !device_is_ready(data->pinmux)) {
+		data->pinmux = NULL;
+	}
+
 	if (!data->pinmux) {
 		return -ENOTSUP;
 	}

--- a/include/device.h
+++ b/include/device.h
@@ -168,7 +168,8 @@ extern "C" {
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
 			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
-	Z_DEVICE_DEFINE(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+	Z_DEVICE_DEFINE(node_id, node_id,				\
+			DT_PROP_OR(node_id, label, NULL), init_fn,	\
 			pm_control_fn,					\
 			data_ptr, cfg_ptr, level, prio, api_ptr)
 


### PR DESCRIPTION
The DEVICE_DT_DEFINE() macro assumed that the devicetree node had a `label` property, which was true for every device except ESP32 pinmux.  Such a property should not be required, so if it's missing use NULL.

Then fix the reference to the pinmux device in the `gpio_esp32` module so that the declaration is visible and the retrieved device is validated before it's used.

Alternative to  #30937

Fixes #30961