### PR TITLE
Bluetooth: controller: Fix missing call to radio_setup interface

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -177,6 +177,8 @@ int lll_init(void)
 	irq_enable(HAL_SWI_JOB_IRQ);
 #endif
 
+	radio_setup();
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix regression, add back missing call to radio_setup HAL
interface. This is needed to setup the initial PA/LNA GPIO
states.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>