### PR TITLE
Bluetooth: controller: Fix regression in PA/LNA support

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -462,8 +462,8 @@ void lll_isr_tx_status_reset(void)
 	radio_status_reset();
 	radio_tmr_status_reset();
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
-	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA)) {
 		radio_gpio_pa_lna_disable();
 	}
 }
@@ -474,8 +474,8 @@ void lll_isr_rx_status_reset(void)
 	radio_tmr_status_reset();
 	radio_rssi_status_reset();
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
-	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA)) {
 		radio_gpio_pa_lna_disable();
 	}
 }
@@ -488,8 +488,8 @@ void lll_isr_status_reset(void)
 	radio_ar_status_reset();
 	radio_rssi_status_reset();
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
-	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA)) {
 		radio_gpio_pa_lna_disable();
 	}
 }


### PR DESCRIPTION
Fix regression in PA/LNA support wherein the GPIO pins where
left in undefined state after each radio event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>