### PR TITLE
Bluetooth: controller: Fix missing GPIOTE channel disable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1034,6 +1034,7 @@ void radio_gpio_pa_lna_disable(void)
 {
 	hal_radio_nrf_ppi_channels_disable(BIT(HAL_ENABLE_PALNA_PPI) |
 				 BIT(HAL_DISABLE_PALNA_PPI));
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN] = 0;
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 


### PR DESCRIPTION
Fix the missing GPIOTE channel disable when GPIOTE channel
is alternately used between PA and LNA use.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>