### PR TITLE
Bluetooth: controller: Refactor PA/LNA PPI configuration

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -118,6 +118,10 @@ void radio_reset(void)
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 	hal_radio_sw_switch_ppi_group_setup();
 #endif
+
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN) || defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+	hal_palna_ppi_setup();
+#endif
 }
 
 void radio_phy_set(uint8_t phy, uint8_t flags)
@@ -1023,9 +1027,6 @@ void radio_gpio_lna_off(void)
 void radio_gpio_pa_lna_enable(uint32_t trx_us)
 {
 	nrf_timer_cc_set(EVENT_TIMER, 2, trx_us);
-
-	hal_enable_palna_ppi_config();
-	hal_disable_palna_ppi_config();
 	hal_radio_nrf_ppi_channels_enable(BIT(HAL_ENABLE_PALNA_PPI) |
 				BIT(HAL_DISABLE_PALNA_PPI));
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -264,9 +264,10 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 /******************************************************************************/
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN) || defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 
-#define HAL_ENABLE_PALNA_PPI 15
+#define HAL_ENABLE_PALNA_PPI  15
+#define HAL_DISABLE_PALNA_PPI 16
 
-static inline void hal_enable_palna_ppi_config(void)
+static inline void hal_palna_ppi_setup(void)
 {
 	nrf_ppi_channel_endpoint_setup(
 		NRF_PPI,
@@ -274,12 +275,6 @@ static inline void hal_enable_palna_ppi_config(void)
 		(uint32_t)&(EVENT_TIMER->EVENTS_COMPARE[2]),
 		(uint32_t)&(NRF_GPIOTE->TASKS_OUT[
 				CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN]));
-}
-
-#define HAL_DISABLE_PALNA_PPI 16
-
-static inline void hal_disable_palna_ppi_config(void)
-{
 	nrf_ppi_channel_endpoint_setup(
 		NRF_PPI,
 		HAL_DISABLE_PALNA_PPI,


### PR DESCRIPTION
Refactor the implementation of PA/LNA PPI configuration
which was done on every Tx or Rx as common code to be
executed once per radio reset. And only setup the timeout
and enabling of PPI at every Tx or Rx.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>