### PR TITLE
tests: device: add two more error case testing

### DIFF
--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -110,6 +110,26 @@ static void test_bogus_dynamic_name(void)
 	zassert_true(mux == NULL, NULL);
 }
 
+/**
+ * @brief Test device binding for passing null name
+ *
+ * Validates device binding for device object when given dynamic name is null.
+ *
+ * @see device_get_binding(), DEVICE_DEFINE()
+ */
+static void test_null_dynamic_name(void)
+{
+#if CONFIG_USERSPACE
+	const struct device *mux;
+	char *drv_name = NULL;
+
+	mux = device_get_binding(drv_name);
+	zassert_equal(mux, 0,  NULL);
+#else
+	ztest_test_skip();
+#endif
+}
+
 static struct init_record {
 	bool pre_kernel;
 	bool is_in_isr;
@@ -151,6 +171,15 @@ SYS_INIT(pre1_fn, PRE_KERNEL_1, 0);
 SYS_INIT(pre2_fn, PRE_KERNEL_2, 0);
 SYS_INIT(post_fn, POST_KERNEL, 0);
 SYS_INIT(app_fn, APPLICATION, 0);
+
+/* This is an error case which driver initializes failed in SYS_INIT .*/
+static int null_driver_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return -EINVAL;
+}
+
+SYS_INIT(null_driver_init, POST_KERNEL, 0);
 
 /**
  * @brief Test detection of initialization before kernel services available.
@@ -446,6 +475,7 @@ void test_main(void)
 			 ztest_unit_test(test_enable_and_disable_automatic_idle_pm),
 			 ztest_unit_test(test_pre_kernel_detection),
 			 ztest_user_unit_test(test_bogus_dynamic_name),
+			 ztest_user_unit_test(test_null_dynamic_name),
 			 ztest_user_unit_test(test_dynamic_name),
 			 ztest_unit_test(test_device_init_level),
 			 ztest_unit_test(test_device_init_priority),


### PR DESCRIPTION
We add more case testing for device module:

1. Add a null dynamic name testing for device_get_binding().
2. Add a driver which initialization failed in SYS_INIT.

PS: This improve code coverage of device module.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>