### PR TITLE
samples: subsys: mgmt: smp_svr: increase fs support stack size

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -12,5 +12,8 @@ CONFIG_MCUMGR_SMP_SHELL=y
 CONFIG_FILE_SYSTEM=y
 CONFIG_FILE_SYSTEM_LITTLEFS=y
 
+# Add 256 bytes to accommodate upload command (lfs_stat overflows)
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+
 # Enable file system commands
 CONFIG_MCUMGR_CMD_FS_MGMT=y


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/zephyr/commit/0a018db0f
increases worqueue stack size for overlay-fs.conf
exclusively.
overlay-bt.conf also need to be updated as enables mcumgr FS
command set as well.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>