### PR TITLE
samples: display: make the display sample support ssd16xx based displays in general

### DIFF
--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -22,8 +22,8 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #define DISPLAY_DEV_NAME DT_LABEL(DT_INST(0, solomon_ssd1306fb))
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_INST(0, gooddisplay_gdeh0213b1), okay)
-#define DISPLAY_DEV_NAME DT_LABEL(DT_INST(0, gooddisplay_gdeh0213b1))
+#if DT_NODE_HAS_STATUS(DT_INST(0, solomon_ssd16xxfb), okay)
+#define DISPLAY_DEV_NAME DT_LABEL(DT_INST(0, solomon_ssd16xxfb))
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_INST(0, sitronix_st7789v), okay)


### PR DESCRIPTION
Minor additions to make the display sample support ssd16xx based e-ink displays in general and
the make the NXP frdm_k64f board support the Waveshare i-ink GDEH0213B72 in particular