### PR TITLE
sensor: shell: add missing va_ends

### DIFF
--- a/drivers/sensor/shell_battery.c
+++ b/drivers/sensor/shell_battery.c
@@ -38,10 +38,12 @@ static int get_channels(const struct device *dev, ...)
 		val = va_arg(ptr, struct sensor_value *);
 		err = sensor_channel_get(dev, chan, val);
 		if (err < 0) {
+			va_end(ptr);
 			return err;
 		}
 	}
 
+	va_end(ptr);
 	return 0;
 }
 


### PR DESCRIPTION
each call to va_start must have a corresponding call to va_end.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>