### PR TITLE
twister: BinaryHandler: call try_kill_process_by_pid in a 'with' scope

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -554,14 +554,13 @@ class BinaryHandler(Handler):
                 t.join()
             proc.wait()
             self.returncode = proc.returncode
+            self.try_kill_process_by_pid()
 
         handler_time = time.time() - start_time
 
         if self.coverage:
             subprocess.call(["GCOV_PREFIX=" + self.build_dir,
                              "gcov", self.sourcedir, "-b", "-s", self.build_dir], shell=True)
-
-        self.try_kill_process_by_pid()
 
         # FIXME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.


### PR DESCRIPTION
The commit 531fe89e80f859d9bc820418059cec93463e0539 (sanitycheck: use multiprcoessing instead of threads) introduce regression for ARC nsim_hs_smp platform.

The regression is that verification on nsim_hs_smp hangs. That happens because now we don't call `try_kill_process_by_pid()` in the `with` scope of the `subprocess.Popen` when we spawning `BinaryHandler` thread. Previously it was called via `terminate` method of `BinaryHandler` but it was changed in 531fe89e80f859d9bc820418059cec93463e0539. So if we can't terminate the simulator in a normal way (which is expected for `mdb` which is used for nsim_hs_smp simulation) we will hang forever - we will never return from `with` scope of the `subprocess.Popen` as we are waiting for process termination but the `try_kill_process_by_pid()` is located latter and we never reach it.

Fix that.