### PR TITLE
boards: sam_e70_xplained: default enable EEPROM source for MAC address

### DIFF
--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -25,6 +25,7 @@ config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
 	default "I2C_0"
 
 config ETH_SAM_GMAC_MAC_I2C_EEPROM
+	default y
 	select I2C
 
 endif # ETH_SAM_GMAC


### PR DESCRIPTION
The SAME70-XPLD board comes with an EEPROM that holds the MAC address
to be used with its Ethernet interface.  Enable that feature by
default, so the application doesn't have to.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>