### PR TITLE
Bluetooth: controller: Fix AUX_CONNECT_RSP PDU buffer size

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -42,6 +42,8 @@
 static uint8_t lll_adv_connect_rsp_pdu[PDU_AC_LL_HEADER_SIZE +
 				       offsetof(struct pdu_adv_com_ext_adv,
 						ext_hdr_adv_data) +
+				       offsetof(struct pdu_adv_ext_hdr,
+						data) +
 				       ADVA_SIZE + TARGETA_SIZE];
 
 static int init_reset(void);


### PR DESCRIPTION
AUX_CONNECT_RSP PDU static buffer definition was missing one
byte required for the Extended Header Flags.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>