### PR TITLE
power: dts: Add residency info in boards dts

### DIFF
--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -59,10 +59,25 @@
 			label = "Push button 2";
 		};
 	};
+
+	idle-states {
+		idle: idle {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "runtime-idle";
+			min-residency-us = <1000>;
+		};
+
+		standby: standby {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "standby";
+			min-residency-us = <5000>;
+		};
+	};
 };
 
 &cpu0 {
 	clock-frequency = <48000000>;
+	cpu-idle-states = <&idle &standby>;
 };
 
 &trng {

--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
@@ -68,10 +68,25 @@
 			label = "Push button 2";
 		};
 	};
+
+	idle-states {
+		idle: idle {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "runtime-idle";
+			min-residency-us = <1000>;
+		};
+
+		standby: standby {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "standby";
+			min-residency-us = <5000>;
+		};
+	};
 };
 
 &cpu0 {
 	clock-frequency = <48000000>;
+	cpu-idle-states = <&idle &standby>;
 };
 
 &trng {

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -59,10 +59,25 @@
 			label = "Push button 2";
 		};
 	};
+
+	idle-states {
+		idle: idle {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "runtime-idle";
+			min-residency-us = <1000>;
+		};
+
+		standby: standby {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "standby";
+			min-residency-us = <5000>;
+		};
+	};
 };
 
 &cpu0 {
 	clock-frequency = <48000000>;
+	cpu-idle-states = <&idle &standby>;
 };
 
 &trng {

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -27,6 +27,24 @@
 		i2c1 = &i2c_smb_1;
 		kscan0 = &kscan0;
 	};
+
+	idle-states {
+		idle: idle {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "runtime-idle";
+			min-residency-us = <1000000>;
+		};
+
+		suspend_to_ram: suspend_to_ram {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "suspend-to-ram";
+			min-residency-us = <2000000>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-idle-states = <&idle &suspend_to_ram>;
 };
 
 &uart1 {

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -54,6 +54,24 @@
 			label = "LED 4";
 		};
 	};
+
+	idle-states {
+		idle: idle {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "runtime-idle";
+			min-residency-us = <1000000>;
+		};
+
+		suspend_to_ram: suspend_to_ram {
+			compatible = "zephyr,idle-state";
+			idle-state-name = "suspend-to-ram";
+			min-residency-us = <2000000>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-idle-states = <&idle &suspend_to_ram>;
 };
 
 &uart2 {

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -13,7 +13,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -10,7 +10,7 @@ properties:
       type: int
       required: false
       description: Clock frequency in Hz
-    pm-states:
+    cpu-idle-states:
        type: phandles
        required: false
        description: List of power management states supported by this cpu

--- a/dts/bindings/power/state.yaml
+++ b/dts/bindings/power/state.yaml
@@ -3,10 +3,10 @@
 
 description: Properties for power management state
 
-compatible: "pm-state"
+compatible: "zephyr,idle-state"
 
 properties:
-    pm-state:
+    idle-state-name:
         type: string
         required: true
         description: indicates a power state

--- a/include/power/power_state.h
+++ b/include/power/power_state.h
@@ -119,34 +119,34 @@ struct pm_state_info {
 };
 
 /**
- * @brief Construct a pm_state_info from 'pm_states' property at index 'i'
+ * @brief Construct a pm_state_info from 'cpu-idle-states' property at index 'i'
  *
- * @param node_id A node identifier compatible with pm-states
- * @param i index of pm_states prop which type is 'phandles'
- * @return pm_state_info item from 'pm_states' property at index 'i'
+ * @param node_id A node identifier compatible with zephyr.idle-state
+ * @param i index of cpu-idle-states prop which type is 'phandles'
+ * @return pm_state_info item from 'cpu-idle-states' property at index 'i'
  */
 #define PM_STATE_INFO_DT_ITEM_BY_IDX(node_id, i)                    \
 	{                                                           \
 		.state = DT_ENUM_IDX(DT_PHANDLE_BY_IDX(node_id,     \
-					pm_states, i), pm_state),    \
+				cpu_idle_states, i), idle_state_name),\
 		.min_residency_us = DT_PROP_BY_PHANDLE_IDX_OR(node_id, \
-				pm_states, i, min_residency_us, 0),   \
+				cpu_idle_states, i, min_residency_us, 0),\
 	},
 
 /**
- * @brief Length of 'pm-states' property which type is 'phandles'
+ * @brief Length of 'cpu-idle-states' property which type is 'phandles'
  *
- * @param node_id A node identifier compatible with pm-states
- * @return length of 'pm-states' property which type is 'phandles'
+ * @param node_id A node identifier compatible with zephyr,idle-state
+ * @return length of 'cpu-idle-states' property which type is 'phandles'
  */
-#define PM_STATE_DT_ITEMS_LEN(node_id) DT_PROP_LEN(node_id, pm_states)
+#define PM_STATE_DT_ITEMS_LEN(node_id) DT_PROP_LEN(node_id, cpu_idle_states)
 
 /**
  * @brief Macro function to construct enum pm_state item in UTIL_LISTIFY
  * extension.
  *
  * @param child child index in UTIL_LISTIFY extension.
- * @param node_id A node identifier compatible with pm-states
+ * @param node_id A node identifier compatible with zephyr,idle-state
  * @return macro function to construct a pm_state_info
  */
 #define PM_STATE_INFO_DT_ITEMS_LISTIFY_FUNC(child, node_id) \
@@ -162,28 +162,30 @@ struct pm_state_info {
  *		cpu0: cpu@0 {
  *			device_type = "cpu";
  *			...
- *			pm-states = <&state0 &state1>;
+ *			cpu-idle-states = <&state0 &state1>;
  *		};
  *	};
  *
  *	...
- *	state0: state0 {
- *		compatible = "pm-state";
- *		pm-state = "suspend-to-idle";
- *		min-residency-us = <1>;
- *	};
+ *      idle-states {
+ *		state0: state0 {
+ *			compatible = "zephyr,idle-state";
+ *			idle-pm-state-name = "suspend-to-idle";
+ *			min-residency-us = <1>;
+ *		};
  *
- *	state1: state1 {
- *		compatible = "pm-state";
- *		pm-state = "suspend-to-ram";
- *		min-residency-us = <5>;
+ *		state1: state1 {
+ *			compatible = "zephyr,idle-state";
+ *			idle-state-name = "suspend-to-ram";
+ *			min-residency-us = <5>;
+ *		};
  *	};
  *
  * Example usage: *
  *    const enum pm_state states[] =
  *		PM_STATE_DT_INFO_ITEMS_LIST(DT_NODELABEL(cpu0));
  *
- * @param node_id A node identifier compatible with pm-states
+ * @param node_id A node identifier compatible with zephyr,idle-state
  * @return an array of struct pm_state_info.
  */
 #define PM_STATE_INFO_DT_ITEMS_LIST(node_id) {         \
@@ -193,15 +195,15 @@ struct pm_state_info {
 	}
 
 /**
- * @brief Construct a pm_state enum from 'pm_states' property at index 'i'
+ * @brief Construct a pm_state enum from 'cpu-idle-states' property at index 'i'
  *
- * @param node_id A node identifier compatible with pm-states
- * @param i index of pm_states prop which type is 'phandles'
- * @return pm_state item from 'pm_states' property at index 'i'
+ * @param node_id A node identifier compatible with zephyr,idle-state
+ * @param i index of cpu-idle-states prop which type is 'phandles'
+ * @return pm_state item from 'cpu-idle-states' property at index 'i'
  */
 #define PM_STATE_DT_ITEM_BY_IDX(node_id, i)                \
 		DT_ENUM_IDX(DT_PHANDLE_BY_IDX(node_id,     \
-				pm_states, i), pm_state),
+				cpu_idle_states, i), idle_state_name),
 
 
 /**
@@ -209,7 +211,7 @@ struct pm_state_info {
  * extension.
  *
  * @param child child index in UTIL_LISTIFY extension.
- * @param node_id A node identifier compatible with pm-states
+ * @param node_id A node identifier compatible with zephyr,idle-state
  * @return macro function to construct a pm_state enum
  */
 #define PM_STATE_DT_ITEMS_LISTIFY_FUNC(child, node_id) \
@@ -225,19 +227,19 @@ struct pm_state_info {
  *		cpu0: cpu@0 {
  *			device_type = "cpu";
  *			...
- *			pm-states = <&state0 &state1>;
+ *			cpu-idle-states = <&state0 &state1>;
  *		};
  *	};
  *
  *	...
  *	state0: state0 {
- *		compatible = "pm-state";
+ *		compatible = "zephyr,idle-state";
  *		pm-state = "suspend-to-idle";
  *		min-residency-us = <1>;
  *	};
  *
  *	state1: state1 {
- *		compatible = "pm-state";
+ *		compatible = "zephyr,idle-state";
  *		pm-state = "suspend-to-ram";
  *		min-residency-us = <5>;
  *	};
@@ -245,7 +247,7 @@ struct pm_state_info {
  * Example usage: *
  *    const enum pm_state states[] = PM_STATE_DT_ITEMS_LIST(DT_NODELABEL(cpu0));
  *
- * @param node_id A node identifier compatible with pm-states
+ * @param node_id A node identifier compatible with zephyr,idle-state
  * @return an array of enum pm_state items.
  */
 #define PM_STATE_DT_ITEMS_LIST(node_id) {           \

--- a/tests/subsys/power/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/power/power_states_api/boards/native_posix.overlay
@@ -7,23 +7,23 @@
 / {
 	power_states: power_states {
 		compatible = "test,power_states_api";
-		pm-states = <&state0 &state1 &state2>;
+		cpu-idle-states = <&state0 &state1 &state2>;
 	};
 
 	state0: state0 {
-		compatible = "pm-state";
-		pm-state = "suspend-to-idle";
+		compatible = "zephyr,idle-state";
+		idle-state-name = "suspend-to-idle";
 		min-residency-us = <1>;
 	};
 
 	state1: state1 {
-		compatible = "pm-state";
-		pm-state = "suspend-to-ram";
+		compatible = "zephyr,idle-state";
+		idle-state-name = "suspend-to-ram";
 		min-residency-us = <5>;
 	};
 
 	state2: state2 {
-		compatible = "pm-state";
-		pm-state = "standby";
+		compatible = "zephyr,idle-state";
+		idle-state-name = "standby";
 	};
 };

--- a/tests/subsys/power/power_states_api/dts/bindings/test,power_states_api.yaml
+++ b/tests/subsys/power/power_states_api/dts/bindings/test,power_states_api.yaml
@@ -8,7 +8,7 @@ description: |
 compatible: "test,power_states_api"
 
 properties:
-    pm-states:
+    cpu-idle-states:
        type: phandles
        required: false
        description: List of power management states supported by this cpu.


### PR DESCRIPTION
 - Fix power bindings
 - Add residency info in boards dts

notes:

- This is using the current values but has re-mapped old states to new power states
- Next step is replace code getting this info from Kconfig. To to this is necessary to replace
  the current power states with new ones.

- Regarding dts bindings, this had been agreed and I had implemented it but forgot to push before the pr be merged. My fault.