### PR TITLE
tests/kernel/common: Skip the printk test when not applicable

### DIFF
--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -100,6 +100,10 @@ void test_printk(void)
 {
 	int count;
 
+	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
+		ztest_test_skip();
+	}
+
 	_old_char_out = __printk_get_hook();
 	__printk_hook_install(ram_console_out);
 


### PR DESCRIPTION
When CONFIG_LOG_PRINTK is set, the printk hook mechanism doesn't exist
and this test can't pass.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>