### PR TITLE
cmake: Fix unexpected token after &

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -226,11 +226,17 @@ elseif(QEMU_NET_STACK)
     set_ifndef(NET_TOOLS ${ZEPHYR_BASE}/../net-tools) # Default if not set
 
     list(APPEND PRE_QEMU_COMMANDS_FOR_server
-      COMMAND ${NET_TOOLS}/monitor_15_4
-  ${PCAP}
-  /tmp/ip-stack-server
+      COMMAND
+      #This command is run in the background using '&'. This prevents
+      #chaining other commands with '&&'. The command is enclosed in '{}'
+      #to fix this.
+      {
+      ${NET_TOOLS}/monitor_15_4
+      ${PCAP}
+      /tmp/ip-stack-server
       /tmp/ip-stack-client
       > /dev/null &
+      }
       # TODO: Support cleanup of the monitor_15_4 process
       )
   endif()


### PR DESCRIPTION
In bash a '&&' cannot follow directly after a '&'. So a task that is run in the background should be enclosed in (curly) braces.

This:
```
west build -b qemu_x86 -d build/server samples/net/sockets/echo_server -- -DOVERLAY_CONFIG=overlay-qemu_802154.conf -DPCAP=capture.pcap
west build -t server -d build/server
```
works correctly after this fix.

Fixes #29793

Signed-off-by: GroteGnoom <8137208+GroteGnoom@users.noreply.github.com>