### PR TITLE
:doc Add gitlint to contribution workflow

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -498,6 +498,10 @@ workflow here:
    agreement with the `DCO`_.  See the `Commit Guidelines`_ section for
    specific guidelines for writing your commit messages.
 
+#. Check your commit::
+
+     gitlint
+
 #. Push your topic branch with your changes to your fork in your personal
    GitHub account::
 


### PR DESCRIPTION
Gitlint is mentioned in the Contribution Guidelines, but is not part of
the Contribution Workflow, making it easy to forget. A simple gitlint
can prevent a failed pull request check because of a long commit line.

Signed-off-by: Daniel Noom <ggatw@outlook.com>