### PR TITLE
Add syscall include search directories build setting for modules

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -510,6 +510,8 @@ Build settings supported in the :file:`module.yml` file are:
 - ``arch_root``: Contains additional architectures that are available to the
   build system. Additional architectures must be located in a
   :file:`<arch_root>/arch` folder.
+- ``syscall_includes``: Sequence of additional directories to look for system
+  calls. All directories are relative to the root of the module.
 
 Example of a :file:`module.yaml` file containing additional roots, and the
 corresponding file system layout.
@@ -522,6 +524,8 @@ corresponding file system layout.
        dts_root: .
        soc_root: .
        arch_root: .
+       syscall_includes:
+         - include
 
 
 requires the following folder structure:
@@ -532,6 +536,7 @@ requires the following folder structure:
    ├── arch
    ├── boards
    ├── dts
+   ├── include
    └── soc
 
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -64,6 +64,11 @@ mapping:
           arch_root:
             required: false
             type: str
+          syscall_includes:
+            required: false
+            type: seq
+            sequence:
+              - type: str
   tests:
     required: false
     type: seq
@@ -155,6 +160,11 @@ def process_settings(module, meta):
             if setting is not None:
                 root_path = PurePath(module) / setting
                 out_text += f'"{root.upper()}_ROOT":"{root_path.as_posix()}"\n'
+
+        syscall_includes = build_settings.get('syscall_includes', [])
+        for include in  syscall_includes:
+            include_path = PurePath(module) / include
+            out_text += f'"SYSCALL_INCLUDE_DIRS":"{include_path.as_posix()}"\n'
 
     return out_text
 


### PR DESCRIPTION
Add build setting `syscall_includes` to specify additional system call search paths that resides inside a module.

This makes it possible to have out-of-tree drivers with system calls without the need to modify the system call search path (via `SYSCALL_INCLUDE_DIRS`) for each application.

Without this change the CMake file in an application repo needs to append the syscall include directories of all module repos it requires   to `SYSCALL_INCLUDE_DIRS` 

Eg.

```
cmake_minimum_required(VERSION 3.13.1)

list(APPEND SYSCALL_INCLUDE_DIRS ../module_1/include ../module_2/include ../module_3/include)

find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
project(app)

target_sources(app PRIVATE src/main.c)

```