### PR TITLE
net: dns: review use of k_work APIs

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -642,9 +642,7 @@ static int dns_read(struct dns_resolve_context *ctx,
 		goto quit;
 	}
 
-	if (k_delayed_work_remaining_get(&ctx->queries[query_idx].timer) > 0) {
-		k_delayed_work_cancel(&ctx->queries[query_idx].timer);
-	}
+	k_delayed_work_cancel(&ctx->queries[query_idx].timer);
 
 	/* Marks the end of the results */
 	ctx->queries[query_idx].cb(ret, NULL,
@@ -745,9 +743,7 @@ quit:
 		goto free_buf;
 	}
 
-	if (k_delayed_work_remaining_get(&ctx->queries[i].timer) > 0) {
-		k_delayed_work_cancel(&ctx->queries[i].timer);
-	}
+	k_delayed_work_cancel(&ctx->queries[i].timer);
 
 	/* Marks the end of the results */
 	ctx->queries[i].cb(ret, NULL, ctx->queries[i].user_data);
@@ -855,9 +851,7 @@ static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 		log_strdup(query_name), ctx->queries[i].query_type,
 		query_hash);
 
-	if (k_delayed_work_remaining_get(&ctx->queries[i].timer) > 0) {
-		k_delayed_work_cancel(&ctx->queries[i].timer);
-	}
+	k_delayed_work_cancel(&ctx->queries[i].timer);
 
 	ctx->queries[i].cb(DNS_EAI_CANCELED, NULL, ctx->queries[i].user_data);
 	ctx->queries[i].cb = NULL;
@@ -1124,11 +1118,7 @@ try_resolve:
 quit:
 	if (ret < 0) {
 		if (i >= 0) {
-			if (k_delayed_work_remaining_get(
-				    &ctx->queries[i].timer) > 0) {
-				k_delayed_work_cancel(&ctx->queries[i].timer);
-			}
-
+			k_delayed_work_cancel(&ctx->queries[i].timer);
 			ctx->queries[i].cb = NULL;
 		}
 


### PR DESCRIPTION
*Part of an ongoing review of existing `k_work` usage in support of #29618*

It is documented that using transient information like whether a work item is pending or a delayed work item has time left to determine the state of the work item before subsequent reconfiguration is prone to race conditions, and known to produce unexpected behavior in the presence of preemptive threads, SMP, or use of the work item from interrupts.  As a best practice such pre-validation steps should be avoided unless algorithmically necessary.

All comparisons of remaining delayed time before canceling a delayed work item in this module appear to be optimizations subject to the above race conditions.  Remove the checks so that only the inherent race conditions in the implementation of canceling a work item remain.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>