### PR TITLE
net: dhcp: identify and resolve multiple issues

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -445,29 +445,29 @@ static void dhcpv4_enter_selecting(struct net_if *iface)
 		net_dhcpv4_state_name(iface->config.dhcpv4.state));
 }
 
-static bool dhcpv4_check_timeout(int64_t start, uint32_t time, int64_t timeout)
+static bool dhcpv4_check_timeout(int64_t start, uint32_t time, int64_t now)
 {
-	start += MSEC_PER_SEC * time;
+	int64_t deadline = start + MSEC_PER_SEC * time;
 
-	if (start > timeout) {
+	if (deadline > now) {
 		return false;
 	}
 
 	return true;
 }
 
-static bool dhcpv4_request_timedout(struct net_if *iface, int64_t timeout)
+static bool dhcpv4_request_timedout(struct net_if *iface, int64_t now)
 {
 	return dhcpv4_check_timeout(iface->config.dhcpv4.timer_start,
 				    iface->config.dhcpv4.request_time,
-				    timeout);
+				    now);
 }
 
-static bool dhcpv4_renewal_timedout(struct net_if *iface, int64_t timeout)
+static bool dhcpv4_renewal_timedout(struct net_if *iface, int64_t now)
 {
 	if (!dhcpv4_check_timeout(iface->config.dhcpv4.timer_start,
 				  iface->config.dhcpv4.renewal_time,
-				  timeout)) {
+				  now)) {
 		return false;
 	}
 
@@ -479,11 +479,11 @@ static bool dhcpv4_renewal_timedout(struct net_if *iface, int64_t timeout)
 	return true;
 }
 
-static bool dhcpv4_rebinding_timedout(struct net_if *iface, int64_t timeout)
+static bool dhcpv4_rebinding_timedout(struct net_if *iface, int64_t now)
 {
 	if (!dhcpv4_check_timeout(iface->config.dhcpv4.timer_start,
 				  iface->config.dhcpv4.rebinding_time,
-				  timeout)) {
+				  now)) {
 		return false;
 	}
 
@@ -539,12 +539,12 @@ static void dhcpv4_enter_bound(struct net_if *iface)
 					sizeof(iface->config.dhcpv4));
 }
 
-static uint32_t dhcph4_manage_timers(struct net_if *iface, int64_t timeout)
+static uint32_t dhcpv4_manage_timers(struct net_if *iface, int64_t now)
 {
 	NET_DBG("iface %p state=%s", iface,
 		net_dhcpv4_state_name(iface->config.dhcpv4.state));
 
-	if (!dhcpv4_request_timedout(iface, timeout)) {
+	if (!dhcpv4_request_timedout(iface, now)) {
 		return iface->config.dhcpv4.request_time;
 	}
 
@@ -570,8 +570,8 @@ static uint32_t dhcph4_manage_timers(struct net_if *iface, int64_t timeout)
 
 		return dhcpv4_send_request(iface);
 	case NET_DHCPV4_BOUND:
-		if (dhcpv4_renewal_timedout(iface, timeout) ||
-		    dhcpv4_rebinding_timedout(iface, timeout)) {
+		if (dhcpv4_renewal_timedout(iface, now) ||
+		    dhcpv4_rebinding_timedout(iface, now)) {
 			return dhcpv4_send_request(iface);
 		}
 
@@ -604,7 +604,7 @@ static uint32_t dhcph4_manage_timers(struct net_if *iface, int64_t timeout)
 static void dhcpv4_timeout(struct k_work *work)
 {
 	uint32_t timeout_update = UINT32_MAX;
-	int64_t timeout = k_uptime_get();
+	int64_t now = k_uptime_get();
 	struct net_if_dhcpv4 *current, *next;
 
 	ARG_UNUSED(work);
@@ -615,7 +615,7 @@ static void dhcpv4_timeout(struct k_work *work)
 			struct net_if, config);
 		uint32_t next_timeout;
 
-		next_timeout = dhcph4_manage_timers(iface, timeout);
+		next_timeout = dhcpv4_manage_timers(iface, now);
 		if (next_timeout < timeout_update) {
 			timeout_update = next_timeout;
 		}

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -602,7 +602,7 @@ static uint32_t dhcph4_manage_timers(struct net_if *iface, int64_t timeout)
 
 static void dhcpv4_timeout(struct k_work *work)
 {
-	uint32_t timeout_update = UINT32_MAX - 1;
+	uint32_t timeout_update = UINT32_MAX;
 	int64_t timeout = k_uptime_get();
 	struct net_if_dhcpv4 *current, *next;
 

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -440,9 +440,6 @@ static void dhcpv4_enter_selecting(struct net_if *iface)
 static bool dhcpv4_check_timeout(int64_t start, uint32_t time, int64_t timeout)
 {
 	start += MSEC_PER_SEC * time;
-	if (start < 0) {
-		start = -start;
-	}
 
 	if (start > timeout) {
 		return false;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -421,12 +421,7 @@ fail:
 
 static void dhcpv4_update_timeout_work(uint32_t timeout)
 {
-	if (!k_delayed_work_remaining_get(&timeout_work) ||
-	    (MSEC_PER_SEC * timeout) <
-	    k_delayed_work_remaining_get(&timeout_work)) {
-		k_delayed_work_cancel(&timeout_work);
-		k_delayed_work_submit(&timeout_work, K_SECONDS(timeout));
-	}
+	k_delayed_work_submit(&timeout_work, K_SECONDS(timeout));
 }
 
 static void dhcpv4_enter_selecting(struct net_if *iface)

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -305,7 +305,7 @@ static uint32_t dhcpv4_send_request(struct net_if *iface)
 	const struct in_addr *src_addr = NULL;
 	bool with_server_id = false;
 	bool with_requested_ip = false;
-	struct net_pkt *pkt;
+	struct net_pkt *pkt = NULL;
 	uint32_t timeout;
 
 	iface->config.dhcpv4.xid++;
@@ -318,6 +318,7 @@ static uint32_t dhcpv4_send_request(struct net_if *iface)
 		/* Not possible */
 		NET_ASSERT(0, "Invalid state %s",
 			   net_dhcpv4_state_name(iface->config.dhcpv4.state));
+		goto fail;
 		break;
 	case NET_DHCPV4_REQUESTING:
 		with_server_id = true;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -426,11 +426,18 @@ static void dhcpv4_update_timeout_work(uint32_t timeout)
 
 static void dhcpv4_enter_selecting(struct net_if *iface)
 {
+	struct in_addr any = INADDR_ANY_INIT;
+
 	iface->config.dhcpv4.attempts = 0U;
 
 	iface->config.dhcpv4.lease_time = 0U;
 	iface->config.dhcpv4.renewal_time = 0U;
 	iface->config.dhcpv4.rebinding_time = 0U;
+
+	iface->config.dhcpv4.server_id.s_addr = INADDR_ANY;
+	iface->config.dhcpv4.requested_ip.s_addr = INADDR_ANY;
+
+	net_if_ipv4_set_gw(iface, &any);
 
 	iface->config.dhcpv4.state = NET_DHCPV4_SELECTING;
 	NET_DBG("enter state=%s",
@@ -1103,13 +1110,6 @@ void net_dhcpv4_start(struct net_if *iface)
 		iface->config.dhcpv4.state = NET_DHCPV4_INIT;
 		NET_DBG("iface %p state=%s", iface,
 			net_dhcpv4_state_name(iface->config.dhcpv4.state));
-
-		iface->config.dhcpv4.attempts = 0U;
-		iface->config.dhcpv4.lease_time = 0U;
-		iface->config.dhcpv4.renewal_time = 0U;
-
-		iface->config.dhcpv4.server_id.s_addr = 0U;
-		iface->config.dhcpv4.requested_ip.s_addr = 0U;
 
 		/* We need entropy for both an XID and a random delay
 		 * before sending the initial discover message.


### PR DESCRIPTION
*Part of an ongoing review of existing `k_work` usage in support of #29618*

### net: dhcp: remove incorrect sign check

The start time is negative only if the interface came up in the the first milliscond since startup; even then changing the sign of the start is not appropriate.  Presumably a left-over from signed 32-bit timestamps.

### net: dhcp: clear option state when selecting

When a connection is lost the client will first attempt to renew, and then to rebind, and finally to select.  Options like gateway may have been provided by the original connection, but not the new connection, resulting in an inconsistent configuration for the new network.

Remove the partial state clearing when entering INIT, and expand the state cleared when entering SELECTING to be more comprehensive.

### net: dhcp: fix bounds check in timeout

The flag value UINT32_MAX is returned from manage_timers() when a send operation did not succeed.  This indicates that the timeout should not be rescheduled, but because it will never replace the starting update value UINT32_MAX-1 the check will never pass, and in cases where it should work will be submitted to run at UINT32_MAX-1 seconds.

Fix the upper bound.

### net: dhcp: avoid undefined behavior when assertions disabled

If assertions are disabled the send operation would continue on to transmit a message.  Stop it from doing so.

### net: dhcp: rename variable for clarity

A variable named "timeout" is used to represent the current time in comparisons against timeouts calculated from a start time and an interval.  Since this current time is not the timeout change its name to "now" to reduce maintainer confusion.

### net: dhcp: fix invalid timeout on send failure

If send_request() fails it would return UINT32_MAX as the next timeout.  Callers pass the returned value to update_timeout_work without validating it.  This has worked only because update_timeout_work will not set a timeout if an existing timeout would fire earlier, and the way the state is currently structured it is likely there will be an existing timeout.  However, if work thread retransmission from REQUESTING failed the timer would not be rescheduled, causing the state machine to stop.

A more clean solution, which matches the behavior of send_discover(), is to return the timeout for the next transmission even in the case when the send fails.  The observed behavior is the same as if the network, rather than the sender, failed to transport the request.

### net: dhcp: correct timeout calculation with multiple interfaces

When there is only a single interface the timeout infrastructure can correctly calculate time to next event, because timeouts only occur when an event for that interface is due.  This is not the case when multiple interfaces are present: the timeout is scheduled for the next event calculated over all interfaces.

When calculating the next event for an interface where the timeout is not due the current code returns the original absolute delay associated with its current state, without accounting for the time that has passed since the start time.

For example if interface A's T1 is 3600 s and is due at 3610, but at 3605 a timeout for interface B occurs, the contribution of A to the delay to the next scheduled event would be 3600 rather than 5, preventing the renewal from occurring at the scheduled time.

Fix this by replacing the boolean timed-out state with the number of seconds remaining until the interface event will occur, and propagating that through the system so the correct delay over all interfaces can be maintained.

### net: dhcp: fix timeout on entry to bound state

When a renewal occurs the client enters RENEWING, sends a request, then sets a short timeout (about 4 s) for the response.  In the common case the response will arrive immediately, which will trigger an attempt to reset the timer with T1 which is generally large.

However the check for updating the timer performs the update only if the new deadline is closer than the currently set one.  Thus the timer fires at the time the RENEWING request would have been retransmitted, and only then updates to the correct deadline (T1) for the current machine state.

Remove the extra timeout by unconditionally setting the timeout to the new value.

This works when there is one interface; it could be wrong if there were multiple interfaces one of which had a closer deadline, but multiple interfaces are mishandled anyway and will be fixed next.

### net: dhcp: correct timeout scheduling with multiple interfaces

If there are multiple interfaces a change to the timeout for one cannot determine the correct delay until the next timeout event.  That can be determined only by checking for the next event over all interfaces, which is exactly what's done by the timeout worker.

Refactor interface timeout configuration to just set the start time and request time, and trigger the worker to calculate the next scheduled event.
