### PR TITLE
isr_tables: adopt _irq_vector_table for using on 64bit architectures

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -134,7 +134,7 @@ source_header = """
 #include <arch/cpu.h>
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
-#define ISR_WRAPPER ((uint32_t)&_isr_wrapper)
+#define ISR_WRAPPER ((uintptr_t)&_isr_wrapper)
 #else
 #define ISR_WRAPPER NULL
 #endif
@@ -148,7 +148,7 @@ def write_source_file(fp, vt, swt, intlist, syms):
     nv = intlist["num_vectors"]
 
     if vt:
-        fp.write("uint32_t __irq_vector_table _irq_vector_table[%d] = {\n" % nv)
+        fp.write("uintptr_t __irq_vector_table _irq_vector_table[%d] = {\n" % nv)
         for i in range(nv):
             fp.write("\t{},\n".format(vt[i]))
         fp.write("};\n")

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -50,8 +50,8 @@ Z_GENERIC_SECTION(.irq_info) struct int_list_header _iheader = {
 #define IRQ_VECTOR_TABLE_DEFAULT_ISR	z_irq_spurious
 #endif /* CONFIG_GEN_SW_ISR_TABLE */
 
-uint32_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
-	[0 ...(IRQ_TABLE_SIZE - 1)] = (uint32_t)&IRQ_VECTOR_TABLE_DEFAULT_ISR,
+uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
+	[0 ...(IRQ_TABLE_SIZE - 1)] = (uintptr_t)&IRQ_VECTOR_TABLE_DEFAULT_ISR,
 };
 #endif /* CONFIG_GEN_IRQ_VECTOR_TABLE */
 


### PR DESCRIPTION
As of today generic _irq_vector_table is used only on 32bit architectures and 64bit architectures have their own implementation. 
Make vectors size adjustable by using uintptr_t instead of uint32_t for vectors.

The ARCv3 64 bit HS6x processors are going to be first users for that.