### PR TITLE
dts: nxp edma update edma label to align with config setting

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -507,7 +507,7 @@
 			clocks = <&sim KINETIS_SIM_DMA_CLK 0x1040 0x00000002>,
 				<&sim KINETIS_SIM_DMAMUX_CLK 0x103C 0x00000002>;
 			status = "disabled";
-			label = "EDMA0";
+			label = "DMA_0";
 		};
 
 		pit0: pit@40037000 {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -592,7 +592,7 @@
 				<16 0>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
 			status = "disabled";
-			label = "EDMA0";
+			label = "DMA_0";
 		};
 
 		flexcan1: can@401d0000 {

--- a/tests/drivers/dma/loop_transfer/src/dma.c
+++ b/tests/drivers/dma/loop_transfer/src/dma.c
@@ -28,7 +28,7 @@ static __aligned(16) char rx_data[TRANSFER_LOOPS][RX_BUFF_SIZE] __used
 #else
 /* this src memory shall be in RAM to support usingas a DMA source pointer.*/
 static char tx_data[] =
-	"The quick brown fox jumps over the lazy dog ....";
+	"The quick brown fox jumps over the lazy dog";
 static __aligned(16) char rx_data[TRANSFER_LOOPS][RX_BUFF_SIZE] = { { 0 } };
 #endif
 
@@ -116,9 +116,7 @@ void main(void)
 #endif
 	chan_id = CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR;
 	transfer_count = 0;
-	printk("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
-	printk("TX data: %s\n", tx_data);
-	printk("block_size %d\n", strlen(tx_data));
+	printk("Starting the transfer and waiting for 1 second\n");
 	dma_block_cfg.block_size = strlen(tx_data);
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];


### PR DESCRIPTION
after 7c699348a846df7c8105406898521eda1615be88
Convert drivers to new DT device macros

now the device name is aligned with label so we need
align them to default config

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>