### PR TITLE
net: net_if: identify and resolve multiple issues

### DIFF
--- a/doc/reference/networking/net_timeout.rst
+++ b/doc/reference/networking/net_timeout.rst
@@ -10,10 +10,50 @@ Network Timeout
 Overview
 ********
 
-The ``k_delayed_work`` API has a 1 ms accuracy for a timeout value,
-so the maximum timeout can be about 24 days. Some network timeouts
-are longer than this, so the net_timeout API provides a generic timeout
-mechanism that tracks such wraparounds and restarts the timeout as needed.
+Zephyr's network infrastructure mostly uses the millisecond-resolution uptime
+clock to track timeouts, with both deadlines and durations measured with
+32-bit unsigned values.  The 32-bit value rolls over at 49 days 17 hours 2 minutes
+47.296 seconds.
+
+Timeout processing is often affected by latency, so that the time at which the
+timeout is checked may be some time after it should have expired.  Handling
+this correctly without arbitrary expectations of maximum latency requires that
+the maximum delay that can be directly represented be a 31-bit non-negative
+number (``INT32_MAX``), which overflows at 24 days 20 hours 31 minutes 23.648
+seconds.
+
+Most network timeouts are shorter than the delay rollover, but a few protocols
+allow for delays that are represented as unsigned 32-bit values counting
+seconds, which corresponds to a 42-bit millisecond count.
+
+The net_timeout API provides a generic timeout mechanism to correctly track
+the remaining time for these extended-duration timeouts.
+
+Use
+***
+
+The simplest use of this API is:
+
+#. Configure a network timeout using :c:func:`net_timeout_set()`.
+#. Use :c:func:`net_timeout_evaluate()` to determine how long it is until the
+   timeout occurs.  Schedule a timeout to occur after this delay.
+#. When the timeout callback is invoked, use :c:func:`net_timeout_evaluate()`
+   again to determine whether the timeout has completed, or whether there is
+   additional time remaining.  If the latter, reschedule the callback.
+#. While the timeout is running, use :c:func:`net_timeout_remaining` to get
+   the number of seconds until the timeout expires.  This may be used to
+   explicitly update the timeout, which should be done by canceling any
+   pending callback and restarting from step 1 with the new timeout.
+
+The :c:struct:`net_timeout` contains a ``sys_snode_t`` that allows multiple
+timeout instances to be aggregated to share a single kernel timer element.
+The application must use :c:func:`net_timeout_evaluate()` on all instances to
+determine the next timeout event to occur.
+
+:c:func:`net_timeout_deadline()` may be used to reconstruct the full-precision
+deadline of the timeout.  This exists primarily for testing but may have use
+in some applications, as it does allow a millisecond-resolution calculation of
+remaining time.
 
 API Reference
 *************

--- a/include/net/net_timeout.h
+++ b/include/net/net_timeout.h
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,39 +22,136 @@
  */
 
 #include <string.h>
-#include <zephyr/types.h>
 #include <stdbool.h>
+#include <limits.h>
+#include <zephyr/types.h>
+#include <sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** Let the max timeout be 100 ms lower because of
- * possible rounding in delayed work implementation.
+/** @brief Divisor used to support ms resolution timeouts.
+ *
+ * Because delays are processed in work queues which are not invoked
+ * synchronously with clock changes we need to be able to detect timeouts
+ * after they occur, which requires comparing "deadline" to "now" with enough
+ * "slop" to handle any observable latency due to "now" advancing past
+ * "deadline".
+ *
+ * The simplest solution is to use the native conversion of the well-defined
+ * 32-bit unsigned difference to a 32-bit signed difference, which caps the
+ * maximum delay at INT32_MAX.  This is compatible with the standard mechanism
+ * for detecting completion of deadlines that do not overflow their
+ * representation.
  */
-#define NET_TIMEOUT_MAX_VALUE ((uint32_t)(INT32_MAX - 100))
+#define NET_TIMEOUT_MAX_VALUE ((uint32_t)INT32_MAX)
 
-/** Generic struct for handling network timeouts */
+/** Generic struct for handling network timeouts.
+ *
+ * Except for the linking node, all access to state from these objects must go
+ * through the defined API.
+ */
 struct net_timeout {
-	/** Used to track timers */
+	/** Used to link multiple timeouts that share a common timer infrastructure.
+	 *
+	 * For examples a set of related timers may use a single delayed work
+	 * structure, which is always scheduled at the shortest time to a
+	 * timeout event.
+	 */
 	sys_snode_t node;
 
-	/** Address lifetime timer start time */
+	/* Time at which the timer was last set.
+	 *
+	 * This usually corresponds to the low 32 bits of k_uptime_get(). */
 	uint32_t timer_start;
 
-	/** Address lifetime timer timeout in milliseconds. Note that this
-	 * value is signed as k_delayed_work_submit() only supports signed
-	 * delay value.
+	/* Portion of remaining timeout that does not exceed
+	 * NET_TIMEOUT_MAX_VALUE.
+	 *
+	 * This value is updated in parallel with timer_start and wrap_counter
+	 * by net_timeout_evaluate().
 	 */
-	int32_t timer_timeout;
+	uint32_t timer_timeout;
 
-	/** Timer wrap count. Used if the timer timeout is larger than
-	 * about 24 days. The reason we need to track wrap arounds, is
-	 * that the timer timeout used in k_delayed_work_submit() is
-	 * 32-bit signed value and the resolution is 1ms.
+	/* Timer wrap count.
+	 *
+	 * This tracks multiples of NET_TIMEOUT_MAX_VALUE milliseconds that
+	 * have yet to pass.  It is also updated along with timer_start and
+	 * wrap_counter by net_timeout_evaluate().
 	 */
-	int32_t wrap_counter;
+	uint32_t wrap_counter;
 };
+
+/** @brief Configure a network timeout structure.
+ *
+ * @param timeout a pointer to the timeout state.
+ *
+ * @param lifetime the duration of the timeout in seconds.
+ *
+ * @param now the time at which the timeout started counting down, in
+ * milliseconds.  This is generally a captured value of k_uptime_get_32().
+ */
+void net_timeout_set(struct net_timeout *timeout,
+		     uint32_t lifetime,
+		     uint32_t now);
+
+/** @brief Return the 64-bit system time at which the timeout will complete.
+ *
+ * @note Correct behavior requires invocation of net_timeout_evaluate() at its
+ * specified intervals.
+ *
+ * @param timeout state a pointer to the timeout state, initialized by
+ * net_timeout_set() and maintained by net_timeout_evaluate().
+ *
+ * @param now the full-precision value of k_uptime_get() relative to which the
+ * deadline will be calculated.
+ *
+ * @return the value of k_uptime_get() at which the timeout will expire.
+ */
+int64_t net_timeout_deadline(const struct net_timeout *timeout,
+			     int64_t now);
+
+/** @brief Calculate the remaining time to the timeout in whole seconds.
+ *
+ * @note This function rounds the remaining time down, i.e. if the timeout
+ * will occur in 3500 milliseconds the value 3 will be returned.
+ *
+ * @note Correct behavior requires invocation of net_timeout_evaluate() at its
+ * specified intervals.
+ *
+ * @param timeout a pointer to the timeout state
+ *
+ * @param now the time relative to which the estimate of remaining time should
+ * be calculated.  This should be recently captured value from
+ * k_uptime_get_32().
+ *
+ * @retval 0 if the timeout has completed.
+ * @retval positive the remaining duration of the timeout, in seconds.
+ */
+uint32_t net_timeout_remaining(const struct net_timeout *timeout,
+			       uint32_t now);
+
+/** @brief Update state to reflect elapsed time and get new delay.
+ *
+ * This function must be invoked periodically to (1) apply the effect of
+ * elapsed time on what remains of a total delay that exceeded the maximum
+ * representable delay, and (2) determine that either the timeout has
+ * completed or that the infrastructure must wait a certain period before
+ * checking again for completion.
+ *
+ * @param timeout a pointer to the timeout state
+ *
+ * @param now the time relative to which the estimate of remaining time should
+ * be calculated.  This should be recently captured value from
+ * k_uptime_get_32().
+ *
+ * @retval 0 if the timeout has completed
+ * @retval positive the maximum delay until the state of this timeout should
+ * be re-evaluated, in milliseconds.
+ */
+uint32_t net_timeout_evaluate(struct net_timeout *timeout,
+			      uint32_t now);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_compile_definitions_ifdef(
 zephyr_library_sources(
   net_core.c
   net_if.c
+  net_timeout.c
   utils.c
   )
 

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2122,26 +2122,9 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 
 #define TWO_HOURS (2 * 60 * 60)
 
-static uint32_t time_diff(uint32_t time1, uint32_t time2)
-{
-	return (uint32_t)abs((int32_t)time1 - (int32_t)time2);
-}
-
 static inline uint32_t remaining_lifetime(struct net_if_addr *ifaddr)
 {
-	uint64_t remaining;
-
-	if (ifaddr->lifetime.timer_timeout == 0) {
-		return 0;
-	}
-
-	remaining = (uint64_t)ifaddr->lifetime.timer_timeout +
-		(uint64_t)ifaddr->lifetime.wrap_counter *
-		(uint64_t)NET_TIMEOUT_MAX_VALUE -
-		(uint64_t)time_diff(k_uptime_get_32(),
-				 ifaddr->lifetime.timer_start);
-
-	return (uint32_t)(remaining / MSEC_PER_SEC);
+	return net_timeout_remaining(&ifaddr->lifetime, k_uptime_get_32());
 }
 
 static inline void handle_prefix_autonomous(struct net_pkt *pkt,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1320,79 +1320,40 @@ static inline int z_vrfy_net_if_ipv6_addr_lookup_by_index(
 #include <syscalls/net_if_ipv6_addr_lookup_by_index_mrsh.c>
 #endif
 
-static bool check_timeout(uint32_t start, int32_t timeout, uint32_t counter,
-			  uint32_t current_time)
-{
-	if (counter > 0) {
-		return false;
-	}
-
-	if ((int32_t)((start + (uint32_t)timeout) - current_time) > 0) {
-		return false;
-	}
-
-	return true;
-}
-
 static void address_expired(struct net_if_addr *ifaddr)
 {
 	NET_DBG("IPv6 address %s is deprecated",
 		log_strdup(net_sprint_ipv6_addr(&ifaddr->address.in6_addr)));
 
 	ifaddr->addr_state = NET_ADDR_DEPRECATED;
-	ifaddr->lifetime.timer_timeout = 0;
-	ifaddr->lifetime.wrap_counter = 0;
 
 	sys_slist_find_and_remove(&active_address_lifetime_timers,
 				  &ifaddr->lifetime.node);
-}
 
-static bool address_manage_timeout(struct net_if_addr *ifaddr,
-				   uint32_t current_time, uint32_t *next_wakeup)
-{
-	if (check_timeout(ifaddr->lifetime.timer_start,
-			  ifaddr->lifetime.timer_timeout,
-			  ifaddr->lifetime.wrap_counter,
-			  current_time)) {
-		address_expired(ifaddr);
-		return true;
-	}
-
-	if (current_time == NET_TIMEOUT_MAX_VALUE) {
-		ifaddr->lifetime.timer_start = k_uptime_get_32();
-		ifaddr->lifetime.wrap_counter--;
-	}
-
-	if (ifaddr->lifetime.wrap_counter > 0) {
-		*next_wakeup = NET_TIMEOUT_MAX_VALUE;
-	} else {
-		*next_wakeup = ifaddr->lifetime.timer_timeout;
-	}
-
-	return false;
+	net_timeout_set(&ifaddr->lifetime, 0, 0);
 }
 
 static void address_lifetime_timeout(struct k_work *work)
 {
-	uint64_t timeout_update = UINT64_MAX;
+	uint32_t next_update = UINT32_MAX;
 	uint32_t current_time = k_uptime_get_32();
-	bool found = false;
 	struct net_if_addr *current, *next;
 
 	ARG_UNUSED(work);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&active_address_lifetime_timers,
 					  current, next, lifetime.node) {
-		uint32_t next_timeout;
-		bool is_timeout;
+		struct net_timeout *timeout = &current->lifetime;
+		uint32_t this_update = net_timeout_evaluate(timeout,
+							     current_time);
 
-		is_timeout = address_manage_timeout(current, current_time,
-						    &next_timeout);
-		if (!is_timeout) {
-			if (next_timeout < timeout_update) {
-				timeout_update = next_timeout;
-				found = true;
-			}
+		if (this_update == 0U) {
+			address_expired(current);
+			continue;
+		}
+
+		if (this_update < next_update) {
+			next_update = this_update;
 		}
 
 		if (current == next) {
@@ -1400,18 +1361,11 @@ static void address_lifetime_timeout(struct k_work *work)
 		}
 	}
 
-	if (found) {
-		/* If we are near upper limit of int32_t timeout, then lower it
-		 * a bit so that kernel timeout variable will not overflow.
-		 */
-		if (timeout_update >= NET_TIMEOUT_MAX_VALUE) {
-			timeout_update = NET_TIMEOUT_MAX_VALUE;
-		}
-
-		NET_DBG("Waiting for %d ms", (int32_t)timeout_update);
+	if (next_update != UINT32_MAX) {
+		NET_DBG("Waiting for %d ms", (int32_t)next_update);
 
 		k_delayed_work_submit(&address_lifetime_timer,
-				      K_MSEC(timeout_update));
+				      K_MSEC(next_update));
 	}
 }
 
@@ -1422,43 +1376,13 @@ void net_address_lifetime_timeout(void)
 }
 #endif
 
-static void address_submit_work(struct net_if_addr *ifaddr)
-{
-	int32_t remaining;
-
-	remaining = k_delayed_work_remaining_get(&address_lifetime_timer);
-	if (!remaining || (ifaddr->lifetime.wrap_counter == 0 &&
-			   ifaddr->lifetime.timer_timeout < remaining)) {
-		k_delayed_work_cancel(&address_lifetime_timer);
-
-		if (ifaddr->lifetime.wrap_counter > 0 && remaining == 0) {
-			k_delayed_work_submit(&address_lifetime_timer,
-					      K_MSEC(NET_TIMEOUT_MAX_VALUE));
-		} else {
-			k_delayed_work_submit(&address_lifetime_timer,
-				       K_MSEC(ifaddr->lifetime.timer_timeout));
-		}
-
-		NET_DBG("Next wakeup in %d ms",
-			k_delayed_work_remaining_get(&address_lifetime_timer));
-	}
-}
-
 static void address_start_timer(struct net_if_addr *ifaddr, uint32_t vlifetime)
 {
-	uint64_t expire_timeout = (uint64_t)MSEC_PER_SEC * (uint64_t)vlifetime;
-
 	sys_slist_append(&active_address_lifetime_timers,
 			 &ifaddr->lifetime.node);
 
-	ifaddr->lifetime.timer_start = k_uptime_get_32();
-	ifaddr->lifetime.wrap_counter = expire_timeout /
-		(uint64_t)NET_TIMEOUT_MAX_VALUE;
-	ifaddr->lifetime.timer_timeout = expire_timeout -
-		(uint64_t)NET_TIMEOUT_MAX_VALUE *
-		(uint64_t)ifaddr->lifetime.wrap_counter;
-
-	address_submit_work(ifaddr);
+	net_timeout_set(&ifaddr->lifetime, vlifetime, k_uptime_get_32());
+	k_delayed_work_submit(&address_lifetime_timer, K_NO_WAIT);
 }
 
 void net_if_ipv6_addr_update_lifetime(struct net_if_addr *ifaddr,
@@ -1906,58 +1830,33 @@ static void prefix_timer_remove(struct net_if_ipv6_prefix *ifprefix)
 		log_strdup(net_sprint_ipv6_addr(&ifprefix->prefix)),
 		ifprefix->len);
 
-	ifprefix->lifetime.timer_timeout = 0;
-	ifprefix->lifetime.wrap_counter = 0;
-
 	sys_slist_find_and_remove(&active_prefix_lifetime_timers,
 				  &ifprefix->lifetime.node);
-}
 
-static bool prefix_manage_timeout(struct net_if_ipv6_prefix *ifprefix,
-				  uint32_t current_time, uint32_t *next_wakeup)
-{
-	if (check_timeout(ifprefix->lifetime.timer_start,
-			  ifprefix->lifetime.timer_timeout,
-			  ifprefix->lifetime.wrap_counter,
-			  current_time)) {
-		prefix_lifetime_expired(ifprefix);
-		return true;
-	}
-
-	if (current_time == NET_TIMEOUT_MAX_VALUE) {
-		ifprefix->lifetime.wrap_counter--;
-	}
-
-	if (ifprefix->lifetime.wrap_counter > 0) {
-		*next_wakeup = NET_TIMEOUT_MAX_VALUE;
-	} else {
-		*next_wakeup = ifprefix->lifetime.timer_timeout;
-	}
-
-	return false;
+	net_timeout_set(&ifprefix->lifetime, 0, 0);
 }
 
 static void prefix_lifetime_timeout(struct k_work *work)
 {
-	uint64_t timeout_update = UINT64_MAX;
+	uint32_t next_update = UINT32_MAX;
 	uint32_t current_time = k_uptime_get_32();
-	bool found = false;
 	struct net_if_ipv6_prefix *current, *next;
 
 	ARG_UNUSED(work);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&active_prefix_lifetime_timers,
 					  current, next, lifetime.node) {
-		uint32_t next_timeout;
-		bool is_timeout;
+		struct net_timeout *timeout = &current->lifetime;
+		uint32_t this_update = net_timeout_evaluate(timeout,
+							    current_time);
 
-		is_timeout = prefix_manage_timeout(current, current_time,
-						   &next_timeout);
-		if (!is_timeout) {
-			if (next_timeout < timeout_update) {
-				timeout_update = next_timeout;
-				found = true;
-			}
+		if (this_update == 0U) {
+			prefix_lifetime_expired(current);
+			continue;
+		}
+
+		if (this_update < next_update) {
+			next_update = this_update;
 		}
 
 		if (current == next) {
@@ -1965,61 +1864,22 @@ static void prefix_lifetime_timeout(struct k_work *work)
 		}
 	}
 
-	if (found) {
-		/* If we are near upper limit of int32_t timeout, then lower it
-		 * a bit so that kernel timeout will not overflow.
-		 */
-		if (timeout_update >= NET_TIMEOUT_MAX_VALUE) {
-			timeout_update = NET_TIMEOUT_MAX_VALUE;
-		}
-
-		NET_DBG("Waiting for %d ms", (uint32_t)timeout_update);
-
+	if (next_update != UINT32_MAX) {
 		k_delayed_work_submit(&prefix_lifetime_timer,
-				      K_MSEC(timeout_update));
-	}
-}
-
-static void prefix_submit_work(struct net_if_ipv6_prefix *ifprefix)
-{
-	int32_t remaining;
-
-	remaining = k_delayed_work_remaining_get(&prefix_lifetime_timer);
-	if (!remaining || (ifprefix->lifetime.wrap_counter == 0 &&
-			   ifprefix->lifetime.timer_timeout < remaining)) {
-		k_delayed_work_cancel(&prefix_lifetime_timer);
-
-		if (ifprefix->lifetime.wrap_counter > 0 && remaining == 0) {
-			k_delayed_work_submit(&prefix_lifetime_timer,
-					      K_MSEC(NET_TIMEOUT_MAX_VALUE));
-		} else {
-			k_delayed_work_submit(&prefix_lifetime_timer,
-				     K_MSEC(ifprefix->lifetime.timer_timeout));
-		}
-
-		NET_DBG("Next wakeup in %d ms",
-			k_delayed_work_remaining_get(&prefix_lifetime_timer));
+				      K_MSEC(next_update));
 	}
 }
 
 static void prefix_start_timer(struct net_if_ipv6_prefix *ifprefix,
 			       uint32_t lifetime)
 {
-	uint64_t expire_timeout = (uint64_t)MSEC_PER_SEC * (uint64_t)lifetime;
-
 	(void)sys_slist_find_and_remove(&active_prefix_lifetime_timers,
 					&ifprefix->lifetime.node);
 	sys_slist_append(&active_prefix_lifetime_timers,
 			 &ifprefix->lifetime.node);
 
-	ifprefix->lifetime.timer_start = k_uptime_get_32();
-	ifprefix->lifetime.wrap_counter = expire_timeout /
-		(uint64_t)NET_TIMEOUT_MAX_VALUE;
-	ifprefix->lifetime.timer_timeout = expire_timeout -
-		(uint64_t)NET_TIMEOUT_MAX_VALUE *
-		(uint64_t)ifprefix->lifetime.wrap_counter;
-
-	prefix_submit_work(ifprefix);
+	net_timeout_set(&ifprefix->lifetime, lifetime, k_uptime_get_32());
+	k_delayed_work_submit(&prefix_lifetime_timer, K_NO_WAIT);
 }
 
 static struct net_if_ipv6_prefix *ipv6_prefix_find(struct net_if *iface,

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3105,10 +3105,6 @@ static int cmd_net_iface_down(const struct shell *shell, size_t argc,
 }
 
 #if defined(CONFIG_NET_NATIVE_IPV6)
-static uint32_t time_diff(uint32_t time1, uint32_t time2)
-{
-	return (uint32_t)abs((int32_t)time1 - (int32_t)time2);
-}
 
 static void address_lifetime_cb(struct net_if *iface, void *user_data)
 {
@@ -3142,11 +3138,8 @@ static void address_lifetime_cb(struct net_if *iface, void *user_data)
 			continue;
 		}
 
-		remaining = (uint64_t)ipv6->unicast[i].lifetime.timer_timeout +
-			(uint64_t)ipv6->unicast[i].lifetime.wrap_counter *
-			(uint64_t)NET_TIMEOUT_MAX_VALUE -
-			(uint64_t)time_diff(k_uptime_get_32(),
-				ipv6->unicast[i].lifetime.timer_start);
+		remaining = net_timeout_remaining(&ipv6->unicast[i].lifetime,
+						  k_uptime_get_32());
 
 		prefix = net_if_ipv6_prefix_get(iface,
 					   &ipv6->unicast[i].address.in6_addr);

--- a/subsys/net/ip/net_timeout.c
+++ b/subsys/net/ip/net_timeout.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <net/net_timeout.h>
+#include <sys_clock.h>
+
+void net_timeout_set(struct net_timeout *timeout,
+		     uint32_t lifetime,
+		     uint32_t now)
+{
+	uint64_t expire_timeout;
+
+	timeout->timer_start = now;
+
+	/* Highly unlikely, but a zero timeout isn't correctly handled by the
+	 * standard calculation.
+	 */
+	if (lifetime == 0U) {
+		timeout->wrap_counter = 0;
+		timeout->timer_timeout = 0;
+		return;
+	}
+
+	expire_timeout = (uint64_t)MSEC_PER_SEC * (uint64_t)lifetime;
+	timeout->wrap_counter = expire_timeout /
+		(uint64_t)NET_TIMEOUT_MAX_VALUE;
+	timeout->timer_timeout = expire_timeout -
+		(uint64_t)NET_TIMEOUT_MAX_VALUE *
+		(uint64_t)timeout->wrap_counter;
+
+	/* The implementation requires that the fractional timeout be zero
+	 * only when the timeout has completed, so if the residual is zero
+	 * copy over one timeout from the wrap.
+	 */
+	if (timeout->timer_timeout == 0U) {
+		timeout->timer_timeout = NET_TIMEOUT_MAX_VALUE;
+		timeout->wrap_counter -= 1;
+	}
+}
+
+int64_t net_timeout_deadline(const struct net_timeout *timeout,
+			     int64_t now)
+{
+	uint64_t start;
+	uint64_t deadline;
+
+	/* Reconstruct the full-precision start time assuming that the full
+	 * precision start time is less than 2^32 ticks in the past.
+	 */
+	start = (uint64_t)now;
+	start -= (uint32_t)now - timeout->timer_start;
+
+	/* Offset the start time by the full precision remaining delay. */
+	deadline = start + timeout->timer_timeout;
+	deadline += (uint64_t)NET_TIMEOUT_MAX_VALUE
+		* (uint64_t)timeout->wrap_counter;
+
+	return (int64_t)deadline;
+}
+
+uint32_t net_timeout_remaining(const struct net_timeout *timeout,
+			       uint32_t now)
+{
+	int64_t ret = timeout->timer_timeout;
+
+	ret += timeout->wrap_counter * (uint64_t)NET_TIMEOUT_MAX_VALUE;
+	ret -= (int64_t)(int32_t)(now - timeout->timer_start);
+	if (ret <= 0) {
+		return 0;
+	}
+
+	return (uint32_t)((uint64_t)ret / MSEC_PER_SEC);
+}
+
+uint32_t net_timeout_evaluate(struct net_timeout *timeout,
+			      uint32_t now)
+{
+	uint32_t elapsed;
+	uint32_t last_delay;
+	int32_t remains;
+	bool wraps;
+
+	/* Time since last evaluation or set. */
+	elapsed = now - timeout->timer_start;
+
+	/* The delay used the last time this was evaluated. */
+	wraps = (timeout->wrap_counter > 0U);
+	last_delay = wraps
+		? NET_TIMEOUT_MAX_VALUE
+		: timeout->timer_timeout;
+
+	/* Time remaining until completion of the last delay. */
+	remains = (int32_t)(last_delay - elapsed);
+
+	/* If the deadline for the next event hasn't been reached yet just
+	 * return the remaining time.
+	 */
+	if (remains > 0) {
+		return (uint32_t)remains;
+	}
+
+	/* Deadline has been reached.  If we're not wrapping we've completed
+	 * the last portion of the full timeout, so return zero to indicate
+	 * the timeout has completed.
+	 */
+	if (!wraps) {
+		return 0U;
+	}
+
+	/* There's more to do.  We need to update timer_start to correspond to
+	 * now, then reduce the remaining time by the elapsed time.  We know
+	 * that's at least NET_TIMEOUT_MAX_VALUE, and can apply the
+	 * reduction by decrementing the wrap count.
+	 */
+	timeout->timer_start = now;
+	elapsed -= NET_TIMEOUT_MAX_VALUE;
+	timeout->wrap_counter -= 1;
+
+	/* The residual elapsed must reduce timer_timeout, which is capped at
+	 * NET_TIMEOUT_MAX_VALUE.  But if subtracting would reduce the
+	 * counter to zero or go negative we need to reduce the the wrap
+	 * counter once more and add the residual to the counter, so the
+	 * counter remains positive.
+	 */
+	if (timeout->timer_timeout > elapsed) {
+		timeout->timer_timeout -= elapsed;
+	} else {
+		timeout->timer_timeout += NET_TIMEOUT_MAX_VALUE - elapsed;
+		timeout->wrap_counter -= 1U;
+	}
+
+	return (timeout->wrap_counter == 0U)
+		? timeout->timer_timeout
+		: NET_TIMEOUT_MAX_VALUE;
+}

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -589,7 +589,7 @@ static void test_prefix_timeout_long(void)
 	net_if_ipv6_prefix_set_lf(ifprefix, false);
 	net_if_ipv6_prefix_set_timer(ifprefix, lifetime);
 
-	zassert_equal(ifprefix->lifetime.wrap_counter, 2000,
+	zassert_equal(ifprefix->lifetime.wrap_counter, 1999,
 		      "Wrap counter wrong (%d)",
 		      ifprefix->lifetime.wrap_counter);
 	remaining = MSEC_PER_SEC * (uint64_t)lifetime -

--- a/tests/unit/net_timeout/CMakeLists.txt
+++ b/tests/unit/net_timeout/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+project(lib_net_timeout)
+set(SOURCES main.c)
+find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/net_timeout/main.c
+++ b/tests/unit/net_timeout/main.c
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <string.h>
+#include <inttypes.h>
+#include <net/net_timeout.h>
+
+#include "../../../subsys/net/ip/net_timeout.c"
+
+#define HALFMAX_S (23U + 60U * (31U + 60U * (20U + 24U * 24U)))
+#define NTO_MAX_S HALFMAX_S
+#define FULLMAX_S (47U + 60U * (2U + 60U * (17U + 24U * 49U)))
+
+#if 0
+static void dump_nto(const struct net_timeout *nto)
+{
+	uint64_t remaining = nto->timer_timeout;
+	uint64_t deadline = nto->timer_start;
+
+	remaining += NET_TIMEOUT_MAX_VALUE * nto->wrap_counter;
+	deadline += remaining;
+
+	printk("start %u, rem %u * %u + %u = %" PRIu64 ", ends %" PRIu64 "\n",
+	       nto->timer_start, nto->wrap_counter,
+	       NET_TIMEOUT_MAX_VALUE, nto->timer_timeout,
+	       remaining, deadline);
+}
+#endif
+
+static void test_basics(void)
+{
+	zassert_equal(NET_TIMEOUT_MAX_VALUE, INT32_MAX,
+		      "Max value not as expected");
+	zassert_equal(((uint32_t)(INT32_MAX / MSEC_PER_SEC)),
+		      HALFMAX_S,
+		      "Half-max constant is wrong");
+	zassert_equal((UINT32_MAX / MSEC_PER_SEC),
+		      FULLMAX_S,
+		      "Full-max constant is wrong");
+}
+
+static void test_set(void)
+{
+	struct net_timeout nto;
+	uint32_t now = 4;
+	uint32_t lifetime = 0U;
+
+	/* Zero is a special case. */
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, 0, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_timeout, 0, NULL);
+
+	/* Less than the max is straightforward. */
+	lifetime = NTO_MAX_S / 2;
+	++now;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_timeout, lifetime * MSEC_PER_SEC,
+		      NULL);
+
+	/* Max must not incur wrap, so fraction is not zero. */
+	lifetime = NTO_MAX_S;
+	++now;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_timeout, lifetime * MSEC_PER_SEC,
+		      NULL);
+
+	/* Next after max does wrap. */
+	lifetime += 1U;
+	++now;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 1U, NULL);
+	zassert_equal(nto.timer_timeout,
+		      (lifetime * MSEC_PER_SEC) % NET_TIMEOUT_MAX_VALUE,
+		      NULL);
+
+	/* Fullmax should be one plus partial */
+	lifetime = FULLMAX_S;
+	++now;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 1U, NULL);
+	zassert_equal(nto.timer_timeout,
+		      (lifetime * (uint64_t)MSEC_PER_SEC) % NET_TIMEOUT_MAX_VALUE,
+		      NULL);
+
+	/* Multiples of max must also not have a zero fraction. */
+	lifetime = NET_TIMEOUT_MAX_VALUE;
+	++now;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, MSEC_PER_SEC - 1, NULL);
+	zassert_equal(nto.timer_timeout, NET_TIMEOUT_MAX_VALUE, NULL);
+}
+
+static void test_deadline(void)
+{
+	struct net_timeout nto;
+	uint64_t now = 1234;
+	uint64_t rollover31 = BIT64(31);
+	uint64_t rollover32 = BIT64(32);
+	uint32_t lifetime = 562;
+
+	net_timeout_set(&nto, lifetime, now);
+	uint64_t expected = now + lifetime * MSEC_PER_SEC;
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      expected,
+		      NULL);
+
+	/* Advancing now has no effect until it wraps. */
+	zassert_equal(net_timeout_deadline(&nto, now + 23U),
+		      expected,
+		      NULL);
+
+	/* Advancing by 2^31 is not a wrap. */
+	now += rollover31;
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      expected,
+		      NULL);
+
+	/* Advancing by 2^32 is a wrap, and should be reflected in the
+	 * returned deadline
+	 */
+	now += rollover31;
+	expected += rollover32;
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      expected,
+		      NULL);
+
+	zassert_equal(net_timeout_deadline(&nto, now + 52),
+		      expected,
+		      NULL);
+}
+
+static void test_remaining(void)
+{
+	struct net_timeout nto;
+	uint32_t now = 4;
+	uint32_t lifetime = 0U;
+
+	/* Zero is a special case. */
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, 0, now);
+	zassert_equal(net_timeout_remaining(&nto, now), 0U,
+		      NULL);
+
+	/* Without wrap is straightforward. */
+	lifetime = NTO_MAX_S / 2;
+	memset(&nto, 0xa5, sizeof(nto));
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(net_timeout_remaining(&nto, now), lifetime,
+		      NULL);
+
+	/* Estimate rounds down (legacy behavior). */
+	zassert_equal(net_timeout_remaining(&nto, now + 1U),
+		      lifetime - 1U,
+		      NULL);
+	zassert_equal(net_timeout_remaining(&nto, now + MSEC_PER_SEC - 1U),
+		      lifetime - 1U,
+		      NULL);
+	zassert_equal(net_timeout_remaining(&nto, now + MSEC_PER_SEC),
+		      lifetime - 1U,
+		      NULL);
+	zassert_equal(net_timeout_remaining(&nto, now + MSEC_PER_SEC + 1U),
+		      lifetime - 2U,
+		      NULL);
+
+	/* Works when wrap is involved */
+	lifetime = 4 * FULLMAX_S;
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.wrap_counter, 7, NULL);
+	zassert_equal(net_timeout_remaining(&nto, now), lifetime,
+		      NULL);
+}
+
+static void test_evaluate_basic(void)
+{
+	struct net_timeout nto;
+	uint64_t now = 0;
+	uint32_t half_max = NET_TIMEOUT_MAX_VALUE / 2U;
+	uint32_t lifetime = FULLMAX_S + HALFMAX_S;
+	uint32_t remainder;
+	uint32_t delay;
+	uint64_t deadline;
+
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 2,
+		      NULL);
+	remainder = 2147482706;
+	zassert_equal(nto.timer_timeout, remainder,
+		      NULL);
+	deadline = net_timeout_deadline(&nto, now);
+
+	/* Evaluation with wrap and no advance returns max value
+	 * without changing anything. */
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE,
+		       NULL);
+	zassert_equal(nto.timer_start, now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 2,
+		      NULL);
+	zassert_equal(nto.timer_timeout, remainder,
+		      NULL);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+
+	/* Advance now by half the delay should return the remainder,
+	 * again without advancing anything.
+	 */
+	delay = net_timeout_evaluate(&nto, now + half_max);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE - half_max,
+		       NULL);
+	zassert_equal(nto.timer_start, now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 2,
+		      NULL);
+	zassert_equal(nto.timer_timeout, remainder,
+		      NULL);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+
+	/* Advance now by just below delay still doesn't change
+	 * anything.
+	 */
+	delay = net_timeout_evaluate(&nto, now + NET_TIMEOUT_MAX_VALUE - 1U);
+	zassert_equal(delay, 1U,
+		       NULL);
+	zassert_equal(nto.timer_start, now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 2,
+		      NULL);
+	zassert_equal(nto.timer_timeout, remainder,
+		      NULL);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+
+	/* Advancing by the delay consumes the value of the delay. The
+	 * deadline is unchanged.
+	 */
+	now += NET_TIMEOUT_MAX_VALUE;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE,
+		      NULL);
+	zassert_equal(nto.timer_start, now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 1,
+		      NULL);
+	zassert_equal(nto.timer_timeout, remainder,
+		      "remainder %u", nto.timer_timeout);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+
+	/* Advancing by more than the delay consumes the value of the delay,
+	 * with the excess reducing the remainder.  The deadline is
+	 * unchanged.
+	 */
+	now += NET_TIMEOUT_MAX_VALUE + 1234;
+	remainder -= 1234;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, remainder,
+		      NULL);
+	zassert_equal(nto.timer_start, (uint32_t)now,
+		      NULL);
+	zassert_equal(nto.wrap_counter, 0,
+		      NULL);
+	zassert_equal(nto.timer_timeout, remainder,
+		      NULL);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+
+	/* Final advance completes the timeout precisely */
+	now += delay;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, 0,
+		      NULL);
+	zassert_equal(net_timeout_deadline(&nto, now), deadline,
+		     NULL);
+}
+
+static void test_evaluate_whitebox(void)
+{
+	/* This explicitly tests the path where subtracting the excess elapsed
+	 * from the fractional timeout requires reducing the wrap count a
+	 * second time.
+	 */
+	struct net_timeout nto;
+	uint64_t now = 0;
+	uint32_t lifetime = 3 * HALFMAX_S + 2;
+
+	net_timeout_set(&nto, lifetime, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 3, NULL);
+	zassert_equal(nto.timer_timeout, 59, NULL);
+
+	/* Preserve the deadline for validation */
+	uint64_t deadline = net_timeout_deadline(&nto, now);
+
+	uint32_t delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE, NULL);
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      deadline, NULL);
+
+	/* Simulate a late evaluation, far enough late that the counter gets
+	 * wiped out.
+	 */
+	now += delay + 100U;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(nto.timer_start, now, NULL);
+	zassert_equal(nto.wrap_counter, 1, NULL);
+	zassert_equal(nto.timer_timeout, 2147483606, NULL);
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      deadline, NULL);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE, NULL);
+
+	/* Another late evaluation finishes the wrap leaving some extra.
+	 */
+	now += delay + 123U;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(nto.timer_start, (uint32_t)now, NULL);
+	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_timeout, 2147483483, NULL);
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      deadline, NULL);
+	zassert_equal(delay, nto.timer_timeout, NULL);
+
+	/* Complete the timeout.  This does *not* adjust the internal
+	 * state.
+	 */
+	now += delay + 234U;
+	delay = net_timeout_evaluate(&nto, now);
+	zassert_equal(delay, 0, NULL);
+	zassert_equal(net_timeout_deadline(&nto, now),
+		      deadline, NULL);
+}
+
+static void test_nop(void)
+{
+}
+
+/*test case main entry*/
+void test_main(void)
+{
+
+	ztest_test_suite(test_prf,
+			 ztest_unit_test(test_basics),
+			 ztest_unit_test(test_set),
+			 ztest_unit_test(test_deadline),
+			 ztest_unit_test(test_remaining),
+			 ztest_unit_test(test_evaluate_basic),
+			 ztest_unit_test(test_evaluate_whitebox),
+			 ztest_unit_test(test_nop)
+			 );
+	ztest_run_test_suite(test_prf);
+}

--- a/tests/unit/net_timeout/testcase.yaml
+++ b/tests/unit/net_timeout/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  utilities.net_timeout:
+    tags: net
+    type: unit


### PR DESCRIPTION
*Part of an ongoing review of existing `k_work` usage in support of #29618*

### net: net_timeout: refactor to fix multiple problems

The net_timeout structure is documented to exist because of behavior that is no longer true, i.e. that `k_delayed_work_submit()` supports only delays up to INT32_MAX milliseconds.  Nonetheless, use of 32-bit timestamps within the work handlers mean the restriction is still present.

This infrastructure is currently used for two timers with long durations:
* address for IPv6 addresses
* prefix for IPv6 prefixes

The handling of rollover was subtly different between these: address wraps reset the start time while prefix wraps did not.

The calculation of remaining time in ipv6_nbr was incorrect when the original requested time in seconds was a multiple of NET_TIMEOUT_MAX_VALUE: the remainder value would be zero while the wrap counter was positive, causing the calculation to indicate no time remained.

The maximum value was set to allow a 100 ms latency between elapse of the deadline and assessment of a given timer, but detection of rollover assumed that the captured time in the work handler was precisely the expected deadline, which is unlikely to be true.  Use of the shared system work queue also risks observed latency exceeding 100 ms.  These calculations could produce delays to next event that exceeded the maximum delay, which introduced special cases.

Refactor so all operations that use this structure are encapsulated into API that is documented and has a full-coverage unit test.  Switch to the standard mechanism of detecting completed deadlines by calculating the signed difference between the deadline and the current time, which eliminates some special cases.

Uniformly rely on the scanning the set of timers to determine the next deadline, rather than assuming that the most recent update is always next.

### net: net_if: fix error in calculating router expiration

The existing implementation is inconsistent in that checking for expired routers when a timeout is processed detects end-of-life correctly (when the remaining duration exceeds the signed maximum), but the calculation of time remaining before expiration uses only unsigned calculation.  So when the set of routers is changed the newly calculated timeout will not recognize routers that have expired, and so those routers expired late.  In the worst case if the only remaining router had expired the timer may be set for almost two months in the future.

Refactor to calculate remaining time in one place and as a signed value.  Change a function name to more clearly reflect what it does. Avoid unnecessary race conditions in k_work API.

### net: net_if: tweak DAD and RS timeout handling

Both RS and DAD timeouts are simplified because the delay is a constant, and by construction the list of timeouts is in increasing time remaining.

Refactor to avoid repeating the expression that represents the time until DAD state expires.  Uniformly use unsigned operands in deadline calculation.

Note a case where the racy idiom for retaining an existing timeout is required in the current work API, but can be replaced with a robust solution in the proposed new API (the reschedule API replaces any existing pending update, but the schedule API will leave an existing scheduled submission in place).
