### PR TITLE
Bluetooth: controller: Rename periodic adv rx enable flag

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -25,7 +25,7 @@ struct lll_sync {
 	uint32_t window_size_event_us;
 
 	uint8_t phy:3;
-	uint8_t is_enabled:1;
+	uint8_t is_rx_enabled:1;
 };
 
 int lll_sync_init(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -150,7 +150,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	lll_sync->window_widening_event_us = 0U;
 
 	/* Reporting initially enabled/disabled */
-	lll_sync->is_enabled = options & BIT(1);
+	lll_sync->is_rx_enabled = options & BIT(1);
 
 	/* sync_lost node_rx */
 	sync->node_rx_lost.hdr.link = link_sync_lost;


### PR DESCRIPTION
Rename the Periodic Advertising Rx Enable flag from
is_enabled to is_rx_enabled.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>