### PR TITLE
Bluetooth: controller: Add missing initialization of ISO sync

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -142,6 +142,13 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	/* Initialize sync context */
 	sync->timeout_reload = 0U;
 	sync->timeout_expire = 0U;
+
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+	/* Reset Broadcast Isochronous Group Sync Establishment */
+	sync->sync_iso = NULL;
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
+
+	/* Initialize sync LLL context */
 	lll_sync = &sync->lll;
 	lll_sync->skip_prepare = 0U;
 	lll_sync->skip_event = 0U;


### PR DESCRIPTION
Add missing initialization of ISO sync context to be
established.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>