### PR TITLE
ARC: MWDT: drop incorrect -Hnocopyr linker option

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -109,7 +109,6 @@ endfunction(toolchain_ld_link_elf)
 macro(toolchain_ld_baremetal)
   zephyr_ld_options(
     -Hlld
-    -Hnocopyr
     -Hnosdata
     -Hnocrt
     -Xtimer0 # to suppress the warning message


### PR DESCRIPTION
`-Hnocopyr` option suppress copyright message in case of LDAC linker but in case of LLDAC linker somehow it leads to partial linking and generation output file with relocations. Looks like we are converting MWDT option to LLVM option incorrectly in this
case. Besides the partial linking itself it may cause build errors when `elf.get_dwarf_info` from `gen_kobject_list.py` meets the
arch-specific relocation which isn't supported by 'elftools'

It requires future investigation, let's disable `-Hnocopyr` for now to have elf image linked correctly.

Internal jira ID against the MWDT toolchain: P10019563-44747 (for SNPS reference)