### PR TITLE
samples: net: Fix vlan error message in samples

### DIFF
--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -77,7 +77,7 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 	}
 
 	if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
-		LOG_ERR("Invalid address: %s", ipv6_addr);
+		LOG_ERR("Invalid address: %s", ipv4_addr);
 		return -EINVAL;
 	}
 

--- a/samples/net/lldp/src/main.c
+++ b/samples/net/lldp/src/main.c
@@ -90,7 +90,7 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 	}
 
 	if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
-		LOG_ERR("Invalid address: %s", ipv6_addr);
+		LOG_ERR("Invalid address: %s", ipv4_addr);
 		return -EINVAL;
 	}
 

--- a/samples/net/sockets/echo_client/src/vlan.c
+++ b/samples/net/sockets/echo_client/src/vlan.c
@@ -67,7 +67,7 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 	}
 
 	if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
-		LOG_ERR("Invalid address: %s", ipv6_addr);
+		LOG_ERR("Invalid address: %s", ipv4_addr);
 		return -EINVAL;
 	}
 

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -72,7 +72,7 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (net_addr_pton(AF_INET, ipv4_addr, &addr4)) {
-			LOG_ERR("Invalid address: %s", ipv6_addr);
+			LOG_ERR("Invalid address: %s", ipv4_addr);
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
This fixes an incorrect error message log statement for IPv4 vs.
IPv6 in several net samples.

The error message is in a portion of the files dealing with IPv4
bring-up. If the address is invalid, it logs the invalid address;
however, the IPv4 statement incorrectly refers to ipv6_addr. This
PR corrects it to output ipv4_addr as expected.

Signed-off-by: Steve Winslow <steve@swinslow.net>