### PR TITLE
driver: gpio: add low-voltage (1.8v) level detection in npcx series.

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -36,7 +36,13 @@
 
 	def_lvol_io_list {
 		compatible = "nuvoton,npcx-lvolctrl-def";
-		lvol_io_pads = <>; /* Put low-voltage io pads here */
+		/*
+		 * Put low-voltage io pads into "lvol_io_pads" property if the
+		 * detection level of them is 1.8V, For example, if the bus
+		 * voltage of i2c1_0 port is 1.8V, this property should be:
+		 * lvol_io_pads = <&lvol_io90 &lvol_io87>;
+		 */
+		lvol_io_pads = <>;
 	};
 
 };

--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -33,6 +33,12 @@
 			label = "User D7 green";
 		};
 	};
+
+	def_lvol_io_list {
+		compatible = "nuvoton,npcx-lvolctrl-def";
+		lvol_io_pads = <>; /* Put low-voltage io pads here */
+	};
+
 };
 
 /* Overwirte default device properties with overlays in board dt file here. */

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -102,7 +102,7 @@ static int gpio_npcx_config(const struct device *dev,
 		inst->PPULL &= ~mask;
 	}
 
-	/* Set level 0:low 1:high*/
+	/* Set level 0:low 1:high */
 	if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0)
 		inst->PDOUT |= mask;
 	else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0)

--- a/dts/arm/nuvoton/npcx/npcx7-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-lvol-ctrl-map.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	def_lvol_conf_list {
+		compatible = "nuvoton,npcx-lvolctrl-conf";
+
+		/* Low-Voltage IO Control 0 */
+		lvol_iob5: lvol00 { lvols = <&scfg 0x0b 5 0 0>; };
+		lvol_iob4: lvol01 { lvols = <&scfg 0x0b 4 0 1>; };
+		lvol_iob3: lvol02 { lvols = <&scfg 0x0b 3 0 2>; };
+		lvol_iob2: lvol03 { lvols = <&scfg 0x0b 2 0 3>; };
+		lvol_io90: lvol04 { lvols = <&scfg 0x09 0 0 4>; };
+		lvol_io87: lvol05 { lvols = <&scfg 0x08 7 0 5>; };
+		lvol_io00: lvol06 { lvols = <&scfg 0x00 0 0 6>; };
+		lvol_io33: lvol07 { lvols = <&scfg 0x03 3 0 7>; };
+		/* Low-Voltage IO Control 1 */
+		lvol_io92: lvol10 { lvols = <&scfg 0x09 2 1 0>; };
+		lvol_io91: lvol11 { lvols = <&scfg 0x09 1 1 1>; };
+		lvol_iod1: lvol12 { lvols = <&scfg 0x0d 1 1 2>; };
+		lvol_iod0: lvol13 { lvols = <&scfg 0x0d 0 1 3>; };
+		lvol_io36: lvol14 { lvols = <&scfg 0x03 6 1 4>; };
+		lvol_io64: lvol15 { lvols = <&scfg 0x06 4 1 5>; };
+		/* Low-Voltage IO Control 2 */
+		lvol_io74: lvol20 { lvols = <&scfg 0x07 4 2 0>; };
+		lvol_io73: lvol23 { lvols = <&scfg 0x07 3 2 3>; };
+		lvol_ioc1: lvol24 { lvols = <&scfg 0x0c 1 2 4>; };
+		lvol_ioc7: lvol25 { lvols = <&scfg 0x0c 7 2 5>; };
+		lvol_io34: lvol27 { lvols = <&scfg 0x03 4 2 7>; };
+		/* Low-Voltage IO Control 3 */
+		lvol_ioc6: lvol30 { lvols = <&scfg 0x0c 6 3 0>; };
+		lvol_io37: lvol31 { lvols = <&scfg 0x03 7 3 1>; };
+		lvol_io40: lvol32 { lvols = <&scfg 0x04 0 3 2>; };
+		lvol_io82: lvol34 { lvols = <&scfg 0x08 2 3 4>; };
+		lvol_io75: lvol35 { lvols = <&scfg 0x07 5 3 5>; };
+		lvol_io80: lvol36 { lvols = <&scfg 0x08 0 3 6>; };
+		lvol_ioc5: lvol37 { lvols = <&scfg 0x0c 5 3 7>; };
+		/* Low-Voltage IO Control 4 */
+		lvol_io86: lvol40 { lvols = <&scfg 0x08 6 4 0>; };
+		lvol_ioc2: lvol41 { lvols = <&scfg 0x0c 2 4 1>; };
+		lvol_iof3: lvol42 { lvols = <&scfg 0x0f 3 4 2>; };
+		lvol_iof2: lvol43 { lvols = <&scfg 0x0f 2 4 3>; };
+		lvol_iof5: lvol44 { lvols = <&scfg 0x0f 5 4 4>; };
+		lvol_iof4: lvol45 { lvols = <&scfg 0x0f 4 4 5>; };
+		lvol_ioe4: lvol46 { lvols = <&scfg 0x0e 4 4 6>; };
+		lvol_ioe6: lvol47 { lvols = <&scfg 0x0e 6 4 7>; };
+		/* Low-Voltage IO Control 5 */
+		lvol_io72: lvol50 { lvols = <&scfg 0x07 2 5 0>; };
+		lvol_io50: lvol53 { lvols = <&scfg 0x05 0 5 3>; };
+	};
+};

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -20,6 +20,8 @@
 #include "npcx/npcx7-miwus-int-map.dtsi"
 /* NPCX7 series eSPI VW mapping table */
 #include "npcx/npcx7-espi-vws-map.dtsi"
+/* NPCX7 series low-voltage io controls mapping table */
+#include "npcx/npcx7-lvol-ctrl-map.dtsi"
 
 / {
 	cpus {
@@ -114,7 +116,7 @@
 			       0x400a5000 0x2000>;
 			reg-names = "scfg", "glue";
 			#alt-cells = <3>;
-			#lvol-cells = <2>;
+			#lvol-cells = <4>;
 			label = "SCFG";
 		};
 

--- a/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-conf.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-conf.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton NPCX7 Low-Voltage level detection configuration map
+    between Nuvoton NPCX GPIO and low-voltage controller (LV_GPIO_CTL) driver instances.
+
+compatible: "nuvoton,npcx-lvolctrl-conf"
+
+child-binding:
+    description: Child node to present the mapping between GPIO pad and its low-voltage support
+    properties:
+       lvols:
+          type: phandle-array
+          required: true
+          description: list of configurations map between io and low-voltage controllers

--- a/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-def.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-def.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX Default Low-Voltage Configurations
+
+compatible: "nuvoton,npcx-lvolctrl-def"
+
+include: [base.yaml]
+
+properties:
+    lvol_io_pads:
+        type: phandles
+        required: false
+        description: list of low-voltage configurations that need to set by default

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
@@ -18,11 +18,16 @@ properties:
 
     "#lvol-cells":
         type: int
-        required: false
-        const: 2
+        required: true
         description: Number of items to expect in a SCFG LV_GPIO_CTL (Low level IO controllers) specifier
 
 alt-cells:
     - group
     - bit
     - inv
+
+lvol-cells:
+    - io_port
+    - io_bit
+    - ctrl
+    - bit

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -19,7 +19,7 @@
  *		};
  *	};
  *
- * Example usage: *
+ * Example usage:
  *      const struct npcx_clk_cfg clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
@@ -79,7 +79,7 @@
  *				 <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 7>;
  *			...
  *		};
- * Example usage: *
+ * Example usage:
  *	const struct npcx_clk_cfg clk_cfg[] = NPCX_DT_CLK_CFG_ITEMS_LIST(0);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
@@ -145,7 +145,7 @@
  *		};
  *	};
  *
- * Example usage: *
+ * Example usage:
  *      const struct npcx_alt uart_alts[] = NPCX_DT_ALT_ITEMS_LIST(inst);
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
@@ -252,7 +252,7 @@
  *		};
  *	};
  *
- * Example usage: *
+ * Example usage:
  *      const struct npcx_alt host_uart_alts[] =
  *                   NPCX_DT_IO_ALT_ITEMS_LIST(nuvoton_npcx_host_uart, 0);
  * @param io_comp compatible string in devicetree file for io-pads device
@@ -353,7 +353,7 @@
  *		};
  *	};
  *
- * Example usage: *
+ * Example usage:
  * const struct npcx_wui wui_map = NPCX_DT_PHANDLE_FROM_WUI_NAME(inst, uart_rx);
  * const struct npcx_wui wui_maps[] = NPCX_DT_WUI_ITEMS_LIST(inst);
  *
@@ -471,6 +471,75 @@
 									0),    \
 	  .bitmask = DT_PROP_BY_IDX(NPCX_DT_NODE_FROM_VWTABLE(name), vw_reg,   \
 									1),    \
+	}
+
+/**
+ * @brief Get a node from path '/def_lvol_io_list' which has a property
+ *        'lvol_io_pads' contains low-voltage configurations and need to set
+ *        by default.
+ *
+ * @return node identifier with that path.
+ */
+#define NPCX_DT_NODE_DEF_LVOL_LIST  DT_PATH(def_lvol_io_list)
+
+/**
+ * @brief Length of npcx_lvol structures in 'lvol_io_pads' property
+ *
+ * @return length of 'lvol_io_pads' prop which type is 'phandles'
+ */
+#define NPCX_DT_LVOL_ITEMS_LEN DT_PROP_LEN(NPCX_DT_NODE_DEF_LVOL_LIST, \
+								lvol_io_pads)
+
+/**
+ * @brief Get phandle from 'lvol_io_pads' prop which type is 'phandles' at index
+ *        'i'
+ *
+ * @param i index of 'lvol_io_pads' prop which type is 'phandles'
+ * @return phandle from 'lvol_io_pads' prop at index 'i'
+ */
+#define NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i) \
+	DT_PHANDLE_BY_IDX(NPCX_DT_NODE_DEF_LVOL_LIST, lvol_io_pads, i)
+
+/**
+ * @brief Construct a npcx_lvol structure from 'lvol_io_pads' property at index
+ *        'i'.
+ *
+ * @param i index of 'lvol_io_pads' prop which type is 'phandles'
+ * @return npcx_lvol item from 'lvol_io_pads' property at index 'i'
+ */
+#define NPCX_DT_LVOL_ITEMS_BY_IDX(i, _)                                        \
+	{                                                                      \
+	  .io_port = DT_PHA(NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i),              \
+							lvols, io_port),       \
+	  .io_bit = DT_PHA(NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i),               \
+							lvols, io_bit),        \
+	  .ctrl = DT_PHA(NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i),                 \
+							lvols, ctrl),          \
+	  .bit = DT_PHA(NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i),                  \
+							lvols, bit),           \
+	},
+
+/**
+ * @brief Macro function to construct a list of npcx_lvol items by UTIL_LISTIFY
+ *        func.
+ *
+ * Example devicetree fragment:
+ *    / {
+ *          def_lvol_io_list {
+ *              compatible = "nuvoton,npcx-lvolctrl-def";
+ *              lvol_io_pads = <&lvol_io90   // I2C1_SCL0 1.8V support
+ *                              &lvol_io87>; // I2C1_SDA0 1,8V support
+ *          };
+ *	};
+ *
+ * Example usage:
+ * static const struct npcx_lvol def_lvols[] = NPCX_DT_IO_LVOL_ITEMS_DEF_LIST;
+ *
+ * @return an array of npcx_lvol items which configure low-voltage support
+ */
+#define NPCX_DT_IO_LVOL_ITEMS_DEF_LIST {                \
+		UTIL_LISTIFY(NPCX_DT_LVOL_ITEMS_LEN,    \
+			NPCX_DT_LVOL_ITEMS_BY_IDX, _)   \
 	}
 
 #endif /* _NUVOTON_NPCX_SOC_DT_H_ */

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -24,6 +24,19 @@ struct npcx_alt {
 };
 
 /**
+ * @brief NPCX low-voltage configuration structure
+ *
+ * Used to indicate the device's corresponding LV_GPIO_CTL register/bit for
+ * low-voltage detection.
+ */
+struct npcx_lvol {
+	uint16_t io_port:5; /** A io pad's port which support low-voltage. */
+	uint16_t io_bit:3; /** A io pad's bit which support low-voltage. */
+	uint16_t ctrl:5; /** Related register index for low-voltage conf. */
+	uint16_t bit:3; /** Related register bit for low-voltage conf. */
+};
+
+/**
  * @brief Select device pin-mux to I/O or its alternative functionality
  *
  * Example devicetree fragment:


### PR DESCRIPTION
Part of GPIO pads in npcx series support low-voltage (1.8V) level
detection. In order to introduce this feature, this CL adds a new
NPCX-specific controller property, lvol_io_pads, in devicetree file.
For example, here is devicetree fragment which turn on low-voltage
support of i2c1_0 port.
 

    /{  
       def_lvol_io_list {
          compatible = "nuvoton,npcx-lvolctrl-def";
          lvol_io_pads = <&lvol_io90 /* I2C1_SCL0 1.8V support */
                          &lvol_io87>; /* I2C1_SDA0 1,8V support */
     };
  };

Then these pads will turn on 1.8V level detection during initialization.
