### PR TITLE
dts: nuvoton_npcx: Change io status of host-uart device to "disabled".

### DIFF
--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -491,7 +491,6 @@
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 6>,
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 7>;
 			label = "HOST_SUBS";
-			status = "disabled";
 		};
 
 		host_uart: io_host_uart {
@@ -502,6 +501,7 @@
 						&altb_ri_sl &altb_dtr_bout_sl
 						&altb_dcd_sl &altb_dsr_sl>;
 			label = "HOST_UART_IO";
+			status = "disabled";
 		};
 
 		/* I2c Controllers - Do not use them as i2c node directly */


### PR DESCRIPTION
Change io status of host-uart device to "disabled". It was caused by a mistake during solving conflicts.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>