### PR TITLE
board: ip_k66f: Update list of used (supported) features

### DIFF
--- a/boards/arm/ip_k66f/ip_k66f.yaml
+++ b/boards/arm/ip_k66f/ip_k66f.yaml
@@ -11,5 +11,7 @@ supported:
   - gpio
   - nvs
   - watchdog
+  - i2c
+  - netif:eth
 ram: 256
 flash: 2048


### PR DESCRIPTION
The following features: 'i2c' and 'netif:eth' are now used in the
ip_k66f board. Let's mark them in the "supported:" section of the
ip_k66f.yaml.

The latter one is necessary as a prerequisite to run some tests (like
e.g. netif:eth is necessary to run network related ones).

Signed-off-by: Lukasz Majewski <lukma@denx.de>