### PR TITLE
doc: fix broken text search

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,7 +2,7 @@
 
 breathe>=4.23.0
 docutils>=0.16
-sphinx>=3.3.0,<4.0
+sphinx>=3.3.0,<3.4.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Require Sphinx<3.4.0 to avoid the issue described in: https://github.com/sphinx-doc/sphinx/issues/8603

This requirement can be relaxed once a new sphinx-rtd-theme is released.