### PR TITLE
coverage: C++ fix loop in gcov_coverage_dump

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -223,6 +223,7 @@ void gcov_coverage_dump(void)
 	uint8_t *buffer;
 	size_t size;
 	size_t written_size;
+	struct gcov_info *gcov_list_first = gcov_info_head;
 	struct gcov_info *gcov_list = gcov_info_head;
 
 	k_sched_lock();
@@ -247,6 +248,9 @@ void gcov_coverage_dump(void)
 
 		k_heap_free(&gcov_heap, buffer);
 		gcov_list = gcov_list->next;
+		if (gcov_list_first == gcov_list) {
+			goto coverage_dump_end;
+		}
 	}
 coverage_dump_end:
 	printk("\nGCOV_COVERAGE_DUMP_END\n");


### PR DESCRIPTION
During coverage reports generation in C++ code gcov_coverage_dump()
function would get stuck in endless loop. Fix by checking list head
pointer with current list pointer.

Signed-off-by: Marko Poljanic <mpoljanic@gmail.com>

**Environment:**
Host: macOS 11.1
Cross toolchain: gcc-arm-none-eabi-9-2020-q2-update

**Steps to test the fix:**
Test will run in qemu and dump gcov data to log.log file after that it is possible to generate .html coverage report.
1. `cd $ZEPHYR_BASE/tests/application_development/gen_inc_file`

2. `west build -b mps2_an385 -- -DCONFIG_COVERAGE=y -DCONFIG_COVERAGE_GCOV=y -DCONFIG_COVERAGE_DUMP=y`

3. `ninja -Cbuild run | tee log.log`

4. `python3 $ZEPHYR_BASE/scripts/gen_gcov_files.py -i log.log`

5. `cp src/main.cpp build/CMakeFiles/app.dir/src` 

6. `cd build/CMakeFiles/app.dir`

7. `gcovr -r . --html -o coverage.html --html-details --gcov-executable <gcov_path_in_SDK>`

Related to:
https://github.com/zephyrproject-rtos/zephyr/issues/20729
- 