### PR TITLE
usb: cdc_acm: select features required for use

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -8,6 +8,7 @@ config USB_CDC_ACM
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select RING_BUFFER
+	select UART_INTERRUPT_DRIVEN
 	help
 	  USB CDC ACM device class driver. Default device name is
 	  "CDC_ACM_0".


### PR DESCRIPTION
If UART_INTERRUPT_DRIVEN isn't selected the CDC ACM class driver won't
build.  Don't require the user's intervention to avoid this.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>