### PR TITLE
boards: particle: use soft reset with nrfjprog

### DIFF
--- a/boards/arm/particle_argon/board.cmake
+++ b/boards/arm/particle_argon/board.cmake
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/particle_boron/board.cmake
+++ b/boards/arm/particle_boron/board.cmake
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/particle_xenon/board.cmake
+++ b/boards/arm/particle_xenon/board.cmake
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
By default nrfjprog presumes the pin reset will be used, and helpfully
enables it regardless of whether CONFIG_GPIO_PINRESET is selected or
not.  Stop it from doing this so the second button can be used for the
application as requested.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>