### PR TITLE
tests: kernel: pipe: testcases to improve code coverage for pipes

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -13,18 +13,25 @@
 
 #include <ztest.h>
 extern void test_pipe_thread2thread(void);
-
 extern void test_pipe_put_fail(void);
 extern void test_pipe_get_fail(void);
 extern void test_pipe_block_put(void);
 extern void test_pipe_block_put_sema(void);
 extern void test_pipe_get_put(void);
-extern void test_half_pipe_get_put(void);
+
+extern void test_half_pipe_put_get(void);
 extern void test_half_pipe_saturating_block_put(void);
 extern void test_half_pipe_block_put_sema(void);
 extern void test_pipe_alloc(void);
 extern void test_pipe_reader_wait(void);
 extern void test_pipe_block_writer_wait(void);
+extern void test_pipe_cleanup(void);
+#ifdef CONFIG_USERSPACE
+extern void test_pipe_user_thread2thread(void);
+extern void test_pipe_user_put_fail(void);
+extern void test_pipe_user_get_fail(void);
+extern void test_resource_pool_auto_free(void);
+#endif
 
 extern void test_pipe_avail_r_lt_w(void);
 extern void test_pipe_avail_w_lt_r(void);
@@ -37,6 +44,20 @@ extern struct k_pipe pipe, kpipe, khalfpipe, put_get_pipe;
 extern struct k_sem end_sema;
 extern struct k_stack tstack;
 extern struct k_thread tdata;
+extern struct k_heap test_pool;
+
+#ifndef CONFIG_USERSPACE
+#define dummy_test(_name) \
+	static void _name(void) \
+	{ \
+		ztest_test_skip(); \
+	}
+
+dummy_test(test_pipe_user_thread2thread);
+dummy_test(test_pipe_user_put_fail);
+dummy_test(test_pipe_user_get_fail);
+dummy_test(test_resource_pool_auto_free);
+#endif /* !CONFIG_USERSPACE */
 
 /*test case main entry*/
 void test_main(void)
@@ -45,11 +66,20 @@ void test_main(void)
 			      &kpipe, &end_sema, &tdata, &tstack,
 			      &khalfpipe, &put_get_pipe);
 
+	k_thread_heap_assign(k_current_get(), &test_pool);
+
 	ztest_test_suite(pipe_api,
 			 ztest_1cpu_unit_test(test_pipe_thread2thread),
+			 ztest_1cpu_user_unit_test(test_pipe_user_thread2thread),
+			 ztest_1cpu_user_unit_test(test_pipe_user_put_fail),
+			 ztest_user_unit_test(test_pipe_user_get_fail),
+			 ztest_unit_test(test_resource_pool_auto_free),
 			 ztest_1cpu_unit_test(test_pipe_put_fail),
 			 ztest_unit_test(test_pipe_get_fail),
-			 ztest_unit_test(test_half_pipe_get_put),
+			 ztest_unit_test(test_half_pipe_put_get),
+			 ztest_unit_test(test_pipe_get_put),
+			 ztest_1cpu_unit_test(test_pipe_alloc),
+			 ztest_unit_test(test_pipe_cleanup),
 			 ztest_unit_test(test_pipe_reader_wait),
 			 ztest_unit_test(test_pipe_avail_r_lt_w),
 			 ztest_unit_test(test_pipe_avail_w_lt_r),


### PR DESCRIPTION
Added back test_pipe_alloc because the z_thread_malloc called in the API has been updated to use k_heap instead of k_mem_pool.
Adjusted test_resource_pool_auto_free by replacing z_mem_pool_malloc with k_heap_alloc. 
Added new test_k_pipe_cleanup to cover one more branch in k_pipe_cleanup. 
Modified test_half_pipe_put_get to cover branches for (reader != NULL) in k_pipe_put. 
Added test test_pipe_get_put to cover branches for (writer != NULL) in k_pipe_get. 
Added other trivial tests to cover branches of input validity check.
The rest of the original testcases (deleted by Andy) are discarded due to their dependence on k_pipe_block_put, which is also going to be deprecated per [31212](https://github.com/zephyrproject-rtos/zephyr/pull/31212). 

Line coverage has been improved from 37.4% to 89.6%. Function coverage has been improved from 43.8% to 100%. Branch coverage has been improved from 19.8% to 65.6%. Will continue to work on branch coverage. 