### PR TITLE
Bluetooth: Mesh: Add a send callback mechanism for proxy

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1964,11 +1964,27 @@ send_list:
 	}
 }
 
+static void reset_send_start(uint16_t duration, int err, void *cb_data)
+{
+	if (err) {
+		BT_ERR("Sending Node Reset Status failed (err %d)", err);
+		bt_mesh_reset();
+	}
+}
+
+static void reset_send_end(int err, void *cb_data)
+{
+	bt_mesh_reset();
+}
+
 static void node_reset(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	static struct bt_mesh_proxy_idle_cb proxy_idle = {.cb = bt_mesh_reset};
+	static const struct bt_mesh_send_cb reset_cb = {
+		.start = reset_send_start,
+		.end = reset_send_end,
+	};
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET_STATUS, 0);
 
@@ -1976,25 +1992,12 @@ static void node_reset(struct bt_mesh_model *model,
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-
 	bt_mesh_model_msg_init(&msg, OP_NODE_RESET_STATUS);
 
-	/* Send the response first since we wont have any keys left to
-	 * send it later.
-	 */
-	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, &reset_cb, NULL)) {
 		BT_ERR("Unable to send Node Reset Status");
-	}
-
-	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 		bt_mesh_reset();
-		return;
 	}
-
-	/* If the response goes to a proxy node, we'll wait for the sending to
-	 * complete before moving on.
-	 */
-	bt_mesh_proxy_on_idle(&proxy_idle);
 }
 
 static void send_friend_status(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -12,13 +12,8 @@
 #define BT_MESH_PROXY_PROV      0x03
 
 
-struct bt_mesh_proxy_idle_cb {
-	sys_snode_t n;
-	void (*cb)(void);
-};
-
-int bt_mesh_proxy_send(struct bt_conn *conn, uint8_t type,
-		       struct net_buf_simple *msg);
+int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *msg,
+			 const struct bt_mesh_send_cb *cb, void *user_data);
 
 int bt_mesh_proxy_prov_enable(void);
 int bt_mesh_proxy_prov_disable(bool disconnect);
@@ -36,8 +31,8 @@ int bt_mesh_proxy_adv_start(void);
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
 
-bool bt_mesh_proxy_relay(struct net_buf_simple *buf, uint16_t dst);
+bool bt_mesh_proxy_relay(struct net_buf_simple *buf, uint16_t dst,
+			 const struct bt_mesh_send_cb *cb, void *user_data);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, uint16_t addr);
 
 int bt_mesh_proxy_init(void);
-void bt_mesh_proxy_on_idle(struct bt_mesh_proxy_idle_cb *cb);


### PR DESCRIPTION
Zephyr Bluetooth Mesh did not check whether the proxy message
was actually sent out, so that the response message could
not be received during reset. Although @trond-snekvik  tried to fix
this problem in PR(#26668), it did not solve the status
callback of the proxy sending message, so a new problem was
introduced after PR(#28457) merged.

`bt_mesh_prov_send(&buf, public_key_sent))`

This PR will try to solve the above problem, and will fix
the problem due to thread competition, and PR(26668) will
not be necessary.

Fixes: #31019

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>