### PR TITLE
refactor devicetree binding support for JESD216 devices

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -59,7 +59,6 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x200000>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <20000>;
 		t-exit-dpd = <100000>;

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -112,7 +112,6 @@
 		t-enter-dpd = <4000>;
 		t-exit-dpd = <25000>;
 		jedec-id = [ef 40 15];
-		has-be32k;
 	};
 };
 

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -143,7 +143,6 @@
 		t-enter-dpd = <4000>;
 		t-exit-dpd = <25000>;
 		jedec-id = [ef 40 15];
-		has-be32k;
 	};
 };
 

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -77,7 +77,6 @@
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 		size = <0x800000>;
-		has-be32k;
 		jedec-id = [c2 28 14];
 	};
 };

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -198,7 +198,6 @@
 		wp-gpios = <&gpioe 3 0>;
 		reset-gpios = <&gpioe 0 0>;
 		size = <0x2000000>;
-		has-be32k;
 		jedec-id = [c2 25 36];
 	};
 };

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -169,7 +169,6 @@
 		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -145,7 +145,6 @@ arduino_spi: &lpspi0 {
 		label = "MX25R32";
 		jedec-id = [c2 28 16];
 		size = <33554432>;
-		has-be32k;
 	};
 };
 

--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2018 Peter Bigot Consulting, LLC
+# Copyright (c) 2019-2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common properties used by nodes describing serial flash devices that
+# are compatible with the JESD216 Serial Flash Discoverable Parameters
+# specification.
+#
+# This allows encoding the entire BFP block in devicetree to avoid
+# reading at runtime, while still allowing the driver to pull out extra
+# data of interest, such as erase sizes.
+#
+# Alternatively the BFP block can be absent, but critical fields like
+# size can be provided directly along with the JEDEC ID of the expected
+# device to verify its presence at runtime.
+#
+# Only properties supported by parameter tables documented in the
+# JESD216 standards should be listed in this binding include file.
+
+properties:
+  jedec-id:
+    type: uint8-array
+    required: false
+    description: JEDEC ID as manufacturer ID, memory type, memory density
+
+  size:
+    type: int
+    required: false
+    description: flash capacity in bits
+
+  sfdp-bfp:
+    type: uint8-array
+    required: false
+    description: |
+      Contains the 32-bit words in little-endian byte order from the
+      JESD216 Serial Flash Discoverable Parameters Basic Flash
+      Parameters table.  This provides flash-specific configuration
+      information in cases were runtime retrieval of SFDP data
+      is not desired.
+
+  has-be32k:
+    type: boolean
+    required: false
+    deprecated: true
+    description: Not used after Zephyr 2.3.0

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -3,28 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Common properties used by nodes describing M25P80-compatible SPI NOR
-# serial flash devices.
+# serial flash devices, regardless of which Zephyr driver is being used.
+#
+# This extends JESD216-defined features with additional functionality
+# that may be specific to the vendor of a M25P80-compatible device and
+# only supported in certain drivers.  Any information that can be
+# obtained from standardized SFDP parameter blocks should be in
+# jedec,jesd216.yaml instead.
+
+include: "jedec,jesd216.yaml"
 
 properties:
-  jedec-id:
-    type: uint8-array
-    required: false
-    description: JEDEC ID as manufacturer ID, memory type, memory density
-
-  sfdp-bfp:
-    type: uint8-array
-    required: false
-    description: |
-      Contains the 32-bit words in little-endian byte order from the
-      JESD216 Serial Flash Discoverable Parameters Basic Flash
-      Parameters table.  This provides flash-specific configuration
-      information in cases were runtime configuration is not desired.
-
-  has-be32k:
-    type: boolean
-    required: false
-    description: Not used after Zephyr 2.3.0
-
   requires-ulbpr:
     type: boolean
     required: false
@@ -89,8 +78,3 @@ properties:
       deep power down and be ready to receive additional commands.
 
       If not provided the driver does not enforce a delay.
-
-  size:
-    type: int
-    required: false
-    description: flash capacity in bits

--- a/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/jesd216/boards/nrf52840dk_nrf52840.overlay
@@ -29,7 +29,6 @@
 		];
 
 		size = <67108864>;
-		has-be32k;
 		has-dpd;
 		t-enter-dpd = <10000>;
 		dpd-wakeup-sequence = <30000 20 45000>;

--- a/tests/drivers/build_all/spi.dtsi
+++ b/tests/drivers/build_all/spi.dtsi
@@ -138,7 +138,6 @@ test_spi_spi_nor: spi-nor@d {
 	hold-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
 	jedec-id = [];
-	/* has-be32k; */
 	/* requires-ulbpr; */
 	/* has-dpd; */
 	size = <0>;


### PR DESCRIPTION
JESD216 specifies serial flash discoverable parameters used by various flash memory devices.  Historically the only Zephyr driver for these devices was the one that became `SPI_NOR`.  Subsequently Nordic introduced a QSPI driver that required some of the parameters, but not others.  This introduced a split so the shared properties could be described once and used in multiple driver-specific bindings.

Now there are additional QSPI drivers being proposed for different SOCs, including #30864 and #31034.  #30864 includes a commit to further split the shared properties by eliminating ones that aren't supported by a driver.

I'd like to see that split discussed and merged separately so that all QSPI rework in progress (including Nordic) can use it.  Hence this PR, which is much the same as the one from @erwango in #30864 but adds documentation explaining what goes in which layer, and takes steps towards removing a legacy property.