### PR TITLE
test: drivers: pwm: api: allow test to run with NXP FlexTimer PWM

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -45,6 +45,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(xlnx_xps_timer_1_00_a_pwm)
 #define PWM_DEV_NAME DT_LABEL(DT_INST(0, xlnx_xps_timer_1_00_a_pwm))
 
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_ftm_pwm)
+#define PWM_DEV_NAME DT_LABEL(DT_INST(0, nxp_kinetis_ftm_pwm))
+
 #else
 #error "Define a PWM device"
 #endif


### PR DESCRIPTION
Allow the PWM API tests to run with the NXP MCUX FlexTimer PWM shim driver.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>