### PR TITLE
west: build: [RFC] Generate SPDX tag-value documents

### DIFF
--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -607,6 +607,7 @@ __comp_west_build()
 		--cmake-only
 		-n --just-print --dry-run --recon
 		--force -f
+		--spdx
 	"
 
 	local build_args_opts="
@@ -615,6 +616,7 @@ __comp_west_build()
 		--target -t
 		--pristine -p
 		--build-opt -o
+		--spdx-prefix
 	"
 
 	case "$prev" in

--- a/scripts/west_commands/spdx/__init__.py
+++ b/scripts/west_commands/spdx/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/west_commands/spdx/builder.py
+++ b/scripts/west_commands/spdx/builder.py
@@ -230,7 +230,7 @@ def getHashes(filePath):
             hSHA1.update(buf)
             hSHA256.update(buf)
             hMD5.update(buf)
-    except FileNotFoundError:
+    except:
         return None
 
     return (hSHA1.hexdigest(), hSHA256.hexdigest(), hMD5.hexdigest())

--- a/scripts/west_commands/spdx/builder.py
+++ b/scripts/west_commands/spdx/builder.py
@@ -1,0 +1,521 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+import hashlib
+import os
+import re
+
+from west import log
+
+class BuilderDocumentConfig:
+    def __init__(self):
+        super(BuilderDocumentConfig, self).__init__()
+
+        #####
+        ##### Document info
+        #####
+
+        # name of document
+        self.documentName = ""
+
+        # namespace for this document
+        self.documentNamespace = ""
+
+        # external document refs that this document uses
+        # list of tuples of external doc refs, in format:
+        #    [("DocumentRef-<docID>", "<namespaceURI>", "<hashAlg>", "<hashValue>"), ...]
+        self.extRefs = []
+
+        # configs for packages: package root dir => BuilderPackageConfig
+        self.packageConfigs = {}
+
+class BuilderPackageConfig:
+    def __init__(self):
+        super(BuilderPackageConfig, self).__init__()
+
+        #####
+        ##### Package-specific config info
+        #####
+
+        # name of package
+        self.packageName = ""
+
+        # SPDX ID for package, must begin with "SPDXRef-"
+        self.spdxID = ""
+
+        # download location for package, defaults to "NOASSERTION"
+        self.packageDownloadLocation = "NOASSERTION"
+
+        # should conclude package license based on detected licenses,
+        # AND'd together?
+        self.shouldConcludeLicense = True
+
+        # declared license, defaults to "NOASSERTION"
+        self.declaredLicense = "NOASSERTION"
+
+        # copyright text, defaults to "NOASSERTION"
+        self.copyrightText = "NOASSERTION"
+
+        # should include SHA256 hashes? (will also include SHA1 regardless)
+        self.doSHA256 = False
+
+        # should include MD5 hashes? (will also include MD5 regardless)
+        self.doMD5 = False
+
+        # root directory to be scanned
+        self.scandir = ""
+
+        # directories whose files should not be included
+        self.excludeDirs = [".git/"]
+
+        # directories whose files should be included, but not scanned
+        # FIXME not yet enabled
+        self.skipScanDirs = []
+
+        # number of lines to scan for SPDX-License-Identifier (0 = all)
+        # defaults to 20
+        self.numLinesScanned = 20
+
+class BuilderDocument:
+    def __init__(self, docCfg):
+        super(BuilderDocument, self).__init__()
+
+        # corresponding document configuration
+        self.config = docCfg
+
+        # packages in this document: package root dir => BuilderPackage
+        self.packages = {}
+        for rootPath, pkgCfg in docCfg.packageConfigs.items():
+            self.packages[rootPath] = BuilderPackage(pkgCfg)
+
+class BuilderPackage:
+    def __init__(self, pkgCfg):
+        super(BuilderPackage, self).__init__()
+
+        self.config = pkgCfg
+
+        self.name = pkgCfg.packageName
+        self.spdxID = pkgCfg.spdxID
+        self.downloadLocation = pkgCfg.packageDownloadLocation
+        self.verificationCode = ""
+        self.licenseConcluded = "NOASSERTION"
+        self.licenseInfoFromFiles = []
+        self.licenseDeclared = pkgCfg.declaredLicense
+        self.copyrightText = pkgCfg.copyrightText
+        self.files = []
+
+class BuilderFile:
+    def __init__(self):
+        super(BuilderFile, self).__init__()
+
+        self.name = ""
+        self.spdxID = ""
+        # FIXME not yet implementing FileType
+        self.type = ""
+        self.sha1 = ""
+        self.sha256 = ""
+        self.md5 = ""
+        self.licenseConcluded = "NOASSERTION"
+        self.licenseInfoInFile = []
+        self.copyrightText = "NOASSERTION"
+
+def shouldExcludeFile(filename, excludes):
+    """
+    Determines whether a file is in an excluded directory.
+
+    Arguments:
+        - filename: filename being tested
+        - excludes: array of excluded directory names
+    Returns: True if should exclude, False if not.
+    """
+    for exc in excludes:
+        if exc in filename:
+            return True
+    return False
+
+def getAllPaths(topDir, excludes):
+    """
+    Gathers a list of all paths for all files within topDir or its children.
+
+    Arguments:
+        - topDir: root directory of files being collected
+        - excludes: array of excluded directory names
+    Returns: array of paths
+    """
+    paths = []
+    # ignoring second item in tuple, which lists immediate subdirectories
+    for (currentDir, _, filenames) in os.walk(topDir):
+        for filename in filenames:
+            p = os.path.join(currentDir, filename)
+            if not shouldExcludeFile(p, excludes):
+                paths.append(p)
+    return sorted(paths)
+
+def parseLineForExpression(line):
+    """Return parsed SPDX expression if tag found in line, or None otherwise."""
+    p = line.partition("SPDX-License-Identifier:")
+    if p[2] == "":
+        return None
+    # strip away trailing comment marks and whitespace, if any
+    expression = p[2].strip()
+    expression = expression.rstrip("/*")
+    expression = expression.strip()
+    return expression
+
+def getExpressionData(filePath, numLines):
+    """
+    Scans the specified file for the first SPDX-License-Identifier:
+    tag in the file.
+
+    Arguments:
+        - filePath: path to file to scan.
+        - numLines: number of lines to scan for an expression before
+                    giving up. If 0, will scan the entire file.
+    Returns: parsed expression if found; None if not found.
+    """
+    with open(filePath, "r") as f:
+        try:
+            lineno = 0
+            for line in f:
+                lineno += 1
+                if lineno > numLines > 0:
+                    break
+                expression = parseLineForExpression(line)
+                if expression is not None:
+                    return expression
+        except UnicodeDecodeError:
+            # invalid UTF-8 content
+            return None
+
+    # if we get here, we didn't find an expression
+    return None
+
+def splitExpression(expression):
+    """
+    Parse a license expression into its constituent identifiers.
+
+    Arguments:
+        - expression: SPDX license expression
+    Returns: array of split identifiers
+    """
+    # remove parens and plus sign
+    e2 = re.sub(r'\(|\)|\+', "", expression, flags=re.IGNORECASE)
+
+    # remove word operators, ignoring case, leaving a blank space
+    e3 = re.sub(r' AND | OR | WITH ', " ", e2, flags=re.IGNORECASE)
+
+    # and split on space
+    e4 = e3.split(" ")
+
+    return sorted(e4)
+
+def getHashes(filePath):
+    """
+    Scan for and return hashes.
+
+    Arguments:
+        - filePath: path to file to scan.
+    Returns: tuple of (SHA1, SHA256, MD5) hashes for filePath.
+    """
+    hSHA1 = hashlib.sha1()
+    hSHA256 = hashlib.sha256()
+    hMD5 = hashlib.md5()
+
+    with open(filePath, 'rb') as f:
+        buf = f.read()
+        hSHA1.update(buf)
+        hSHA256.update(buf)
+        hMD5.update(buf)
+
+    return (hSHA1.hexdigest(), hSHA256.hexdigest(), hMD5.hexdigest())
+
+def calculateVerificationCode(bfs):
+    """
+    Calculate the SPDX Package Verification Code for all files in the package.
+
+    Arguments:
+        - bfs: array of BuilderFiles
+    Returns: verification code as string
+    """
+    hashes = []
+    for bf in bfs:
+        hashes.append(bf.sha1)
+    hashes.sort()
+    filelist = "".join(hashes)
+
+    hSHA1 = hashlib.sha1()
+    hSHA1.update(filelist.encode('utf-8'))
+    return hSHA1.hexdigest()
+
+def getSPDXIDSafeCharacter(c):
+    """
+    Converts a character to an SPDX-ID-safe character.
+
+    Arguments:
+        - c: character to test
+    Returns: c if it is SPDX-ID-safe (letter, number, '-' or '.');
+             '-' otherwise
+    """
+    if c.isalpha() or c.isdigit() or c == "-" or c == ".":
+        return c
+    return "-"
+
+def convertToSPDXIDSafe(filenameOnly):
+    """
+    Converts a filename to only SPDX-ID-safe characters.
+    Note that a separate check (such as in getUniqueID, below) will need
+    to be used to confirm that this is still a unique identifier, after
+    conversion.
+
+    Arguments:
+        - filenameOnly: filename only (directories omitted) seeking ID.
+    Returns: filename with all non-safe characters replaced with dashes.
+    """
+    return "".join([getSPDXIDSafeCharacter(c) for c in filenameOnly])
+
+def getUniqueID(filenameOnly, timesSeen):
+    """
+    Find an SPDX ID that is unique among others seen so far.
+
+    Arguments:
+        - filenameOnly: filename only (directories omitted) seeking ID.
+        - timesSeen: dict of all filename-only to number of times seen.
+    Returns: unique SPDX ID; updates timesSeen to include it.
+    """
+
+    converted = convertToSPDXIDSafe(filenameOnly)
+    spdxID = f"SPDXRef-File-{converted}"
+
+    # determine whether spdxID is unique so far, or not
+    filenameTimesSeen = timesSeen.get(converted, 0) + 1
+    if filenameTimesSeen > 1:
+        # we'll append the # of times seen to the end
+        spdxID += f"-{filenameTimesSeen}"
+    else:
+        # first time seeing this filename
+        # edge case: if the filename itself ends in "-{number}", then we
+        # need to add a "-1" to it, so that we don't end up overlapping
+        # with an appended number from a similarly-named file.
+        p = re.compile(r"-\d+$")
+        if p.search(converted):
+            spdxID += "-1"
+
+    timesSeen[converted] = filenameTimesSeen
+    return spdxID
+
+def makeFileData(filePath, pkgCfg, timesSeen):
+    """
+    Scan for expression, get hashes, and fill in data.
+
+    Arguments:
+        - filePath: path to file to scan.
+        - pkgCfg: BuilderPackageConfig for this scan.
+        - timesSeen: dict of all filename-only (converted to SPDX-ID-safe)
+                     to number of times seen.
+    Returns: BuilderFile
+    """
+    bf = BuilderFile()
+    bf.name = os.path.join(".", os.path.relpath(filePath, pkgCfg.scandir))
+
+    filenameOnly = os.path.basename(filePath)
+    bf.spdxID = getUniqueID(filenameOnly, timesSeen)
+
+    (sha1, sha256, md5) = getHashes(filePath)
+    bf.sha1 = sha1
+    if pkgCfg.doSHA256:
+        bf.sha256 = sha256
+    if pkgCfg.doMD5:
+        bf.md5 = md5
+
+    expression = getExpressionData(filePath, pkgCfg.numLinesScanned)
+    if expression is not None:
+        bf.licenseConcluded = expression
+        bf.licenseInfoInFile = splitExpression(expression)
+
+    return bf
+
+def makeAllFileData(filePaths, pkgCfg, timesSeen):
+    """
+    Scan all files for expressions and hashes, and fill in data.
+
+    Arguments:
+        - filePaths: sorted array of paths to files to scan.
+        - pkgCfg: BuilderPackageConfig for this scan.
+        - timesSeen: dict of all filename-only (converted to SPDX-ID-safe)
+                     to number of times seen.
+    Returns: array of BuilderFiles
+    """
+    bfs = []
+    for filePath in filePaths:
+        bf = makeFileData(filePath, pkgCfg, timesSeen)
+        bfs.append(bf)
+
+    return bfs
+
+def getPackageLicenses(bfs):
+    """
+    Extract lists of all concluded and infoInFile licenses seen.
+
+    Arguments:
+        - bfs: array of BuilderFiles
+    Returns: tuple(sorted list of concluded license exprs,
+                   sorted list of infoInFile ID's)
+    """
+    licsConcluded = set()
+    licsFromFiles = set()
+    for bf in bfs:
+        licsConcluded.add(bf.licenseConcluded)
+        for licInfo in bf.licenseInfoInFile:
+            licsFromFiles.add(licInfo)
+    return (sorted(list(licsConcluded)), sorted(list(licsFromFiles)))
+
+def normalizeExpression(licsConcluded):
+    """
+    Combine array of license expressions into one AND'd expression,
+    adding parens where needed.
+
+    Arguments:
+        - licsConcluded: array of license expressions
+    Returns: string with single AND'd expression.
+    """
+    # return appropriate for simple cases
+    if len(licsConcluded) == 0:
+        return "NOASSERTION"
+    if len(licsConcluded) == 1:
+        return licsConcluded[0]
+
+    # more than one, so we'll need to combine them
+    # iff an expression has spaces, it needs parens
+    revised = []
+    for lic in licsConcluded:
+        if lic in ["NONE", "NOASSERTION"]:
+            continue
+        if " " in lic:
+            revised.append(f"({lic})")
+        else:
+            revised.append(lic)
+    return " AND ".join(revised)
+
+def makePackageData(pkg, timesSeen):
+    """
+    Create package and call sub-functions to scan and create file data.
+
+    Arguments:
+        - pkg: BuilderPackage (already stored in BuilderDocument.packages)
+        - timesSeen: dict of all filename-only (converted to SPDX-ID-safe)
+                     to number of times seen.
+    Returns: None; fills in Package data in-place
+    """
+    filePaths = getAllPaths(pkg.config.scandir, pkg.config.excludeDirs)
+    bfs = makeAllFileData(filePaths, pkg.config, timesSeen)
+    (licsConcluded, licsFromFiles) = getPackageLicenses(bfs)
+
+    if pkg.config.shouldConcludeLicense:
+        pkg.licenseConcluded = normalizeExpression(licsConcluded)
+    pkg.licenseInfoFromFiles = licsFromFiles
+    pkg.files = bfs
+    pkg.verificationCode = calculateVerificationCode(bfs)
+
+def makeDocument(docCfg):
+    """
+    Create BuilderDocument (and its sub-Packages) from BuilderDocumentConfig.
+
+    Arguments:
+        - cfg: BuilderDocumentConfig
+    Returns: BuilderDocument
+    """
+    doc = BuilderDocument(docCfg)
+    # dict of filename-only (converted to SPDX-ID-safe) to number of times seen
+    # for use in making unique identifiers
+    timesSeen = {}
+    for pkg in doc.packages.values():
+        makePackageData(pkg, timesSeen)
+
+    return doc
+
+def outputSPDX(doc, spdxPath):
+    """
+    Write SPDX doc, package and files content to disk.
+
+    Arguments:
+        - doc: BuilderDocument
+        - spdxPath: path to write SPDX content
+    Returns: True on success, False on error.
+    """
+    try:
+        with open(spdxPath, 'w') as f:
+            # write document creation info section
+            f.write(f"""SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: {doc.config.documentName}
+DocumentNamespace: {doc.config.documentNamespace}
+Creator: Tool: cmake-spdx
+Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
+""")
+            # write any external document references
+            for extRef in doc.config.extRefs:
+                f.write(f"ExternalDocumentRef: {extRef[0]} {extRef[1]} {extRef[2]}:{extRef[3]}\n")
+            f.write(f"\n")
+
+            # write package sections
+            for pkg in doc.packages.values():
+                f.write(f"""##### Package: {pkg.name}
+
+PackageName: {pkg.name}
+SPDXID: {pkg.spdxID}
+PackageDownloadLocation: {pkg.downloadLocation}
+FilesAnalyzed: true
+PackageVerificationCode: {pkg.verificationCode}
+PackageLicenseConcluded: {pkg.licenseConcluded}
+""")
+                for licFromFiles in pkg.licenseInfoFromFiles:
+                    f.write(f"PackageLicenseInfoFromFiles: {licFromFiles}\n")
+                f.write(f"""PackageLicenseDeclared: {pkg.licenseDeclared}
+PackageCopyrightText: NOASSERTION
+
+Relationship: SPDXRef-DOCUMENT DESCRIBES {pkg.spdxID}
+
+""")
+
+                # write file sections
+                for bf in pkg.files:
+                    f.write(f"""FileName: {bf.name}
+SPDXID: {bf.spdxID}
+FileChecksum: SHA1: {bf.sha1}
+""")
+                    if bf.sha256 != "":
+                        f.write(f"FileChecksum: SHA256: {bf.sha256}\n")
+                    if bf.md5 != "":
+                        f.write(f"FileChecksum: MD5: {bf.md5}\n")
+                    f.write(f"LicenseConcluded: {bf.licenseConcluded}\n")
+                    if len(bf.licenseInfoInFile) == 0:
+                        f.write(f"LicenseInfoInFile: NONE\n")
+                    else:
+                        for licInfoInFile in bf.licenseInfoInFile:
+                            f.write(f"LicenseInfoInFile: {licInfoInFile}\n")
+                    f.write(f"FileCopyrightText: {bf.copyrightText}\n\n")
+
+            # we're done for now; will do other relationships later
+            return True
+
+    except OSError as e:
+        log.err(f"Error: Unable to write to {spdxPath}: {str(e)}")
+        return False
+
+def makeSPDX(docCfg, spdxPath):
+    """
+    Scan, create and write SPDX details to disk.
+
+    Arguments:
+        - docCfg: BuilderDocumentConfig
+        - spdxPath: path to write SPDX content
+    Returns: BuilderDocument on success, None on failure.
+    """
+    doc = makeDocument(docCfg)
+    if outputSPDX(doc, spdxPath):
+        return doc
+    else:
+        return None

--- a/scripts/west_commands/spdx/cmakefileapi.py
+++ b/scripts/west_commands/spdx/cmakefileapi.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+
+class Codemodel:
+
+    def __init__(self):
+        super(Codemodel, self).__init__()
+
+        self.paths_source = ""
+        self.paths_build = ""
+        self.configurations = []
+
+    def __repr__(self):
+        return f"Codemodel: source {self.paths_source}, build {self.paths_build}"
+
+# A member of the codemodel configurations array
+class Config:
+
+    def __init__(self):
+        super(Config, self).__init__()
+
+        self.name = ""
+        self.directories = []
+        self.projects = []
+        self.configTargets = []
+
+    def __repr__(self):
+        if self.name == "":
+            return f"Config: [no name]"
+        else:
+            return f"Config: {self.name}"
+
+# A member of the configuration.directories array
+class ConfigDir:
+
+    def __init__(self):
+        super(ConfigDir, self).__init__()
+
+        self.source = ""
+        self.build = ""
+        self.parentIndex = -1
+        self.childIndexes = []
+        self.projectIndex = -1
+        self.targetIndexes = []
+        self.minimumCMakeVersion = ""
+        self.hasInstallRule = False
+
+        # actual items, calculated from indices after loading
+        self.parent = None
+        self.children = []
+        self.project = None
+        self.targets = []
+
+    def __repr__(self):
+        return f"ConfigDir: source {self.source}, build {self.build}"
+
+# A member of the configuration.projects array
+class ConfigProject:
+
+    def __init__(self):
+        super(ConfigProject, self).__init__()
+
+        self.name = ""
+        self.parentIndex = -1
+        self.childIndexes = []
+        self.directoryIndexes = []
+        self.targetIndexes = []
+
+        # actual items, calculated from indices after loading
+        self.parent = None
+        self.children = []
+        self.directories = []
+        self.targets = []
+
+    def __repr__(self):
+        return f"ConfigProject: {self.name}"
+
+# A member of the configuration.configTargets array
+class ConfigTarget:
+
+    def __init__(self):
+        super(ConfigTarget, self).__init__()
+
+        self.name = ""
+        self.id = ""
+        self.directoryIndex = -1
+        self.projectIndex = -1
+        self.jsonFile = ""
+
+        # actual target data, loaded from self.jsonFile
+        self.target = None
+
+        # actual items, calculated from indices after loading
+        self.directory = None
+        self.project = None
+
+    def __repr__(self):
+        return f"ConfigTarget: {self.name}"
+
+# The available values for Target.type
+class TargetType(Enum):
+    UNKNOWN = 0
+    EXECUTABLE = 1
+    STATIC_LIBRARY = 2
+    SHARED_LIBRARY = 3
+    MODULE_LIBRARY = 4
+    OBJECT_LIBRARY = 5
+    UTILITY = 6
+
+# A member of the target.install_destinations array
+class TargetInstallDestination:
+
+    def __init__(self):
+        super(TargetInstallDestination, self).__init__()
+
+        self.path = ""
+        self.backtrace = -1
+
+    def __repr__(self):
+        return f"TargetInstallDestination: {self.path}"
+
+# A member of the target.link_commandFragments and
+# archive_commandFragments array
+class TargetCommandFragment:
+
+    def __init__(self):
+        super(TargetCommandFragment, self).__init__()
+
+        self.fragment = ""
+        self.role = ""
+
+    def __repr__(self):
+        return f"TargetCommandFragment: {self.fragment}"
+
+# A member of the target.dependencies array
+class TargetDependency:
+
+    def __init__(self):
+        super(TargetDependency, self).__init__()
+
+        self.id = ""
+        self.backtrace = -1
+
+    def __repr__(self):
+        return f"TargetDependency: {self.id}"
+
+# A member of the target.sources array
+class TargetSource:
+
+    def __init__(self):
+        super(TargetSource, self).__init__()
+
+        self.path = ""
+        self.compileGroupIndex = -1
+        self.sourceGroupIndex = -1
+        self.isGenerated = False
+        self.backtrace = -1
+
+        # actual items, calculated from indices after loading
+        self.compileGroup = None
+        self.sourceGroup = None
+
+    def __repr__(self):
+        return f"TargetSource: {self.path}"
+
+# A member of the target.sourceGroups array
+class TargetSourceGroup:
+
+    def __init__(self):
+        super(TargetSourceGroup, self).__init__()
+
+        self.name = ""
+        self.sourceIndexes = []
+
+        # actual items, calculated from indices after loading
+        self.sources = []
+
+    def __repr__(self):
+        return f"TargetSourceGroup: {self.name}"
+
+# A member of the target.compileGroups.includes array
+class TargetCompileGroupInclude:
+
+    def __init__(self):
+        super(TargetCompileGroupInclude, self).__init__()
+
+        self.path = ""
+        self.isSystem = False
+        self.backtrace = -1
+
+    def __repr__(self):
+        return f"TargetCompileGroupInclude: {self.path}"
+
+# A member of the target.compileGroups.precompileHeaders array
+class TargetCompileGroupPrecompileHeader:
+
+    def __init__(self):
+        super(TargetCompileGroupPrecompileHeader, self).__init__()
+
+        self.header = ""
+        self.backtrace = -1
+
+    def __repr__(self):
+        return f"TargetCompileGroupPrecompileHeader: {self.header}"
+
+# A member of the target.compileGroups.defines array
+class TargetCompileGroupDefine:
+
+    def __init__(self):
+        super(TargetCompileGroupDefine, self).__init__()
+
+        self.define = ""
+        self.backtrace = -1
+
+    def __repr__(self):
+        return f"TargetCompileGroupDefine: {self.define}"
+
+# A member of the target.compileGroups array
+class TargetCompileGroup:
+
+    def __init__(self):
+        super(TargetCompileGroup, self).__init__()
+
+        self.sourceIndexes = []
+        self.language = ""
+        self.compileCommandFragments = []
+        self.includes = []
+        self.precompileHeaders = []
+        self.defines = []
+        self.sysroot = ""
+
+        # actual items, calculated from indices after loading
+        self.sources = []
+
+    def __repr__(self):
+        return f"TargetCompileGroup: {self.sources}"
+
+# A member of the target.backtraceGraph_nodes array
+class TargetBacktraceGraphNode:
+
+    def __init__(self):
+        super(TargetBacktraceGraphNode, self).__init__()
+
+        self.file = -1
+        self.line = -1
+        self.command = -1
+        self.parent = -1
+
+    def __repr__(self):
+        return f"TargetBacktraceGraphNode: {self.command}"
+
+# Actual data in config.target.target, loaded from
+# config.target.jsonFile
+class Target:
+
+    def __init__(self):
+        super(Target, self).__init__()
+
+        self.name = ""
+        self.id = ""
+        self.type = TargetType.UNKNOWN
+        self.backtrace = -1
+        self.folder = ""
+        self.paths_source = ""
+        self.paths_build = ""
+        self.nameOnDisk = ""
+        self.artifacts = []
+        self.isGeneratorProvided = False
+
+        # only if install rule is present
+        self.install_prefix = ""
+        self.install_destinations = []
+
+        # only for executables and shared library targets that link into
+        # a runtime binary
+        self.link_language = ""
+        self.link_commandFragments = []
+        self.link_lto = False
+        self.link_sysroot = ""
+
+        # only for static library targets
+        self.archive_commandFragments = []
+        self.archive_lto = False
+
+        # only if the target depends on other targets
+        self.dependencies = []
+
+        # corresponds to target's source files
+        self.sources = []
+
+        # only if sources are grouped together by source_group() or by default
+        self.sourceGroups = []
+
+        # only if target has sources that compile
+        self.compileGroups = []
+
+        # graph of backtraces referenced from elsewhere
+        self.backtraceGraph_nodes = []
+        self.backtraceGraph_commands = []
+        self.backtraceGraph_files = []
+
+    def __repr__(self):
+        return f"Target: {self.name}"

--- a/scripts/west_commands/spdx/cmakefileapijson.py
+++ b/scripts/west_commands/spdx/cmakefileapijson.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+from west import log
+
+import spdx.cmakefileapi
+
+def parseReply(replyIndexPath):
+    replyDir, _ = os.path.split(replyIndexPath)
+
+    # first we need to find the codemodel reply file
+    try:
+        with open(replyIndexPath, 'r') as indexFile:
+            js = json.load(indexFile)
+
+            # get reply object
+            reply_dict = js.get("reply", {})
+            if reply_dict == {}:
+                log.err(f"no \"reply\" field found in index file")
+                return None
+            # get codemodel object
+            cm_dict = reply_dict.get("codemodel-v2", {})
+            if cm_dict == {}:
+                log.err(f"no \"codemodel-v2\" field found in \"reply\" object in index file")
+                return None
+            # and get codemodel filename
+            jsonFile = cm_dict.get("jsonFile", "")
+            if jsonFile == "":
+                log.err(f"no \"jsonFile\" field found in \"codemodel-v2\" object in index file")
+                return None
+
+            return parseCodemodel(replyDir, jsonFile)
+
+    except OSError as e:
+        log.err(f"Error loading {replyIndexPath}: {str(e)}")
+        return None
+    except json.decoder.JSONDecodeError as e:
+        log.err(f"Error parsing JSON in {replyIndexPath}: {str(e)}")
+        return None
+
+def parseCodemodel(replyDir, codemodelFile):
+    codemodelPath = os.path.join(replyDir, codemodelFile)
+
+    try:
+        with open(codemodelPath, 'r') as cmFile:
+            js = json.load(cmFile)
+
+            cm = spdx.cmakefileapi.Codemodel()
+
+            # FIXME for correctness, should probably check kind and version
+
+            # get paths
+            paths_dict = js.get("paths", {})
+            cm.paths_source = paths_dict.get("source", "")
+            cm.paths_build = paths_dict.get("build", "")
+
+            # get configurations
+            configs_arr = js.get("configurations", [])
+            for cfg_dict in configs_arr:
+                cfg = parseConfig(cfg_dict, replyDir)
+                if cfg:
+                    cm.configurations.append(cfg)
+
+            # and after parsing is done, link all the indices
+            linkCodemodel(cm)
+
+            return cm
+
+    except OSError as e:
+        log.err(f"Error loading {codemodelPath}: {str(e)}")
+        return None
+    except json.decoder.JSONDecodeError as e:
+        log.err(f"Error parsing JSON in {codemodelPath}: {str(e)}")
+        return None
+
+def parseConfig(cfg_dict, replyDir):
+    cfg = spdx.cmakefileapi.Config()
+    cfg.name = cfg_dict.get("name", "")
+
+    # parse and add each directory
+    dirs_arr = cfg_dict.get("directories", [])
+    for dir_dict in dirs_arr:
+        if dir_dict != {}:
+            cfgdir = spdx.cmakefileapi.ConfigDir()
+            cfgdir.source = dir_dict.get("source", "")
+            cfgdir.build = dir_dict.get("build", "")
+            cfgdir.parentIndex = dir_dict.get("parentIndex", -1)
+            cfgdir.childIndexes = dir_dict.get("childIndexes", [])
+            cfgdir.projectIndex = dir_dict.get("projecttIndex", -1)
+            cfgdir.targetIndexes = dir_dict.get("targetIndexes", [])
+            minCMakeVer_dict = dir_dict.get("minimumCMakeVersion", {})
+            cfgdir.minimumCMakeVersion = minCMakeVer_dict.get("string", "")
+            cfgdir.hasInstallRule = dir_dict.get("hasInstallRule", False)
+            cfg.directories.append(cfgdir)
+
+    # parse and add each project
+    projects_arr = cfg_dict.get("projects", [])
+    for prj_dict in projects_arr:
+        if prj_dict != {}:
+            prj = spdx.cmakefileapi.ConfigProject()
+            prj.name = prj_dict.get("name", "")
+            prj.parentIndex = prj_dict.get("parentIndex", -1)
+            prj.childIndexes = prj_dict.get("childIndexes", [])
+            prj.directoryIndexes = prj_dict.get("directoryIndexes", [])
+            prj.targetIndexes = prj_dict.get("targetIndexes", [])
+            cfg.projects.append(prj)
+
+    # parse and add each target
+    cfgTargets_arr = cfg_dict.get("targets", [])
+    for cfgTarget_dict in cfgTargets_arr:
+        if cfgTarget_dict != {}:
+            cfgTarget = spdx.cmakefileapi.ConfigTarget()
+            cfgTarget.name = cfgTarget_dict.get("name", "")
+            cfgTarget.id = cfgTarget_dict.get("id", "")
+            cfgTarget.directoryIndex = cfgTarget_dict.get("directoryIndex", -1)
+            cfgTarget.projectIndex = cfgTarget_dict.get("projectIndex", -1)
+            cfgTarget.jsonFile = cfgTarget_dict.get("jsonFile", "")
+
+            if cfgTarget.jsonFile != "":
+                cfgTarget.target = parseTarget(os.path.join(replyDir, cfgTarget.jsonFile))
+            else:
+                cfgTarget.target = None
+
+            cfg.configTargets.append(cfgTarget)
+
+    return cfg
+
+def parseTarget(targetPath):
+    try:
+        with open(targetPath, 'r') as targetFile:
+            js = json.load(targetFile)
+
+            target = spdx.cmakefileapi.Target()
+
+            target.name = js.get("name", "")
+            target.id = js.get("id", "")
+            target.type = parseTargetType(js.get("type", "UNKNOWN"))
+            target.backtrace = js.get("backtrace", -1)
+            target.folder = js.get("folder", "")
+
+            # get paths
+            paths_dict = js.get("paths", {})
+            target.paths_source = paths_dict.get("source", "")
+            target.paths_build = paths_dict.get("build", "")
+
+            target.nameOnDisk = js.get("nameOnDisk", "")
+
+            # parse artifacts if present
+            artifacts_arr = js.get("artifacts", [])
+            target.artifacts = []
+            for artifact_dict in artifacts_arr:
+                artifact_path = artifact_dict.get("path", "")
+                if artifact_path != "":
+                    target.artifacts.append(artifact_path)
+
+            target.isGeneratorProvided = js.get("isGeneratorProvided", False)
+
+            # call separate functions to parse subsections
+            parseTargetInstall(target, js)
+            parseTargetLink(target, js)
+            parseTargetArchive(target, js)
+            parseTargetDependencies(target, js)
+            parseTargetSources(target, js)
+            parseTargetSourceGroups(target, js)
+            parseTargetCompileGroups(target, js)
+            parseTargetBacktraceGraph(target, js)
+
+            return target
+
+    except OSError as e:
+        log.err(f"Error loading {targetPath}: {str(e)}")
+        return None
+    except json.decoder.JSONDecodeError as e:
+        log.err(f"Error parsing JSON in {targetPath}: {str(e)}")
+        return None
+
+def parseTargetType(targetType):
+    if targetType == "EXECUTABLE":
+        return spdx.cmakefileapi.TargetType.EXECUTABLE
+    elif targetType == "STATIC_LIBRARY":
+        return spdx.cmakefileapi.TargetType.STATIC_LIBRARY
+    elif targetType == "SHARED_LIBRARY":
+        return spdx.cmakefileapi.TargetType.SHARED_LIBRARY
+    elif targetType == "MODULE_LIBRARY":
+        return spdx.cmakefileapi.TargetType.MODULE_LIBRARY
+    elif targetType == "OBJECT_LIBRARY":
+        return spdx.cmakefileapi.TargetType.OBJECT_LIBRARY
+    elif targetType == "UTILITY":
+        return spdx.cmakefileapi.TargetType.UTILITY
+    else:
+        return spdx.cmakefileapi.TargetType.UNKNOWN
+
+def parseTargetInstall(target, js):
+    install_dict = js.get("install", {})
+    if install_dict == {}:
+        return
+    prefix_dict = install_dict.get("prefix", {})
+    target.install_prefix = prefix_dict.get("path", "")
+
+    destinations_arr = install_dict.get("destinations", [])
+    for destination_dict in destinations_arr:
+        dest = spdx.cmakefileapi.TargetInstallDestination()
+        dest.path = destination_dict.get("path", "")
+        dest.backtrace = destination_dict.get("backtrace", -1)
+        target.install_destinations.append(dest)
+
+def parseTargetLink(target, js):
+    link_dict = js.get("link", {})
+    if link_dict == {}:
+        return
+    target.link_language = link_dict.get("language", {})
+    target.link_lto = link_dict.get("lto", False)
+    sysroot_dict = link_dict.get("sysroot", {})
+    target.link_sysroot = sysroot_dict.get("path", "")
+
+    fragments_arr = link_dict.get("commandFragments", [])
+    for fragment_dict in fragments_arr:
+        fragment = spdx.cmakefileapi.TargetCommandFragment()
+        fragment.fragment = fragment_dict.get("fragment", "")
+        fragment.role = fragment_dict.get("role", "")
+        target.link_commandFragments.append(fragment)
+
+def parseTargetArchive(target, js):
+    archive_dict = js.get("archive", {})
+    if archive_dict == {}:
+        return
+    target.archive_lto = archive_dict.get("lto", False)
+
+    fragments_arr = archive_dict.get("commandFragments", [])
+    for fragment_dict in fragments_arr:
+        fragment = spdx.cmakefileapi.TargetCommandFragment()
+        fragment.fragment = fragment_dict.get("fragment", "")
+        fragment.role = fragment_dict.get("role", "")
+        target.archive_commandFragments.append(fragment)
+
+def parseTargetDependencies(target, js):
+    dependencies_arr = js.get("dependencies", [])
+    for dependency_dict in dependencies_arr:
+        dep = spdx.cmakefileapi.TargetDependency()
+        dep.id = dependency_dict.get("id", "")
+        dep.backtrace = dependency_dict.get("backtrace", -1)
+        target.dependencies.append(dep)
+
+def parseTargetSources(target, js):
+    sources_arr = js.get("sources", [])
+    for source_dict in sources_arr:
+        src = spdx.cmakefileapi.TargetSource()
+        src.path = source_dict.get("path", "")
+        src.compileGroupIndex = source_dict.get("compileGroupIndex", -1)
+        src.sourceGroupIndex = source_dict.get("sourceGroupIndex", -1)
+        src.isGenerated = source_dict.get("isGenerated", False)
+        src.backtrace = source_dict.get("backtrace", -1)
+        target.sources.append(src)
+
+def parseTargetSourceGroups(target, js):
+    sourceGroups_arr = js.get("sourceGroups", [])
+    for sourceGroup_dict in sourceGroups_arr:
+        srcgrp = spdx.cmakefileapi.TargetSourceGroup()
+        srcgrp.name = sourceGroup_dict.get("name", "")
+        srcgrp.sourceIndexes = sourceGroup_dict.get("sourceIndexes", [])
+        target.sourceGroups.append(srcgrp)
+
+def parseTargetCompileGroups(target, js):
+    compileGroups_arr = js.get("compileGroups", [])
+    for compileGroup_dict in compileGroups_arr:
+        cmpgrp = spdx.cmakefileapi.TargetCompileGroup()
+        cmpgrp.sourceIndexes = compileGroup_dict.get("sourceIndexes", [])
+        cmpgrp.language = compileGroup_dict.get("language", "")
+        cmpgrp.sysroot = compileGroup_dict.get("sysroot", "")
+
+        commandFragments_arr = compileGroup_dict.get("compileCommandFragments", [])
+        for commandFragment_dict in commandFragments_arr:
+            fragment = commandFragment_dict.get("fragment", "")
+            if fragment != "":
+                cmpgrp.compileCommandFragments.append(fragment)
+
+        includes_arr = compileGroup_dict.get("includes", [])
+        for include_dict in includes_arr:
+            grpInclude = spdx.cmakefileapi.TargetCompileGroupInclude()
+            grpInclude.path = include_dict.get("path", "")
+            grpInclude.isSystem = include_dict.get("isSystem", False)
+            grpInclude.backtrace = include_dict.get("backtrace", -1)
+            cmpgrp.includes.append(grpInclude)
+
+        precompileHeaders_arr = compileGroup_dict.get("precompileHeaders", [])
+        for precompileHeader_dict in precompileHeaders_arr:
+            grpHeader = spdx.cmakefileapi.TargetCompileGroupPrecompileHeader()
+            grpHeader.header = precompileHeader_dict.get("header", "")
+            grpHeader.backtrace = precompileHeader_dict.get("backtrace", -1)
+            cmpgrp.precompileHeaders.append(grpHeader)
+
+        defines_arr = compileGroup_dict.get("defines", [])
+        for define_dict in defines_arr:
+            grpDefine = spdx.cmakefileapi.TargetCompileGroupDefine()
+            grpDefine.define = define_dict.get("define", "")
+            grpDefine.backtrace = define_dict.get("backtrace", -1)
+            cmpgrp.defines.append(grpDefine)
+
+        target.compileGroups.append(cmpgrp)
+
+def parseTargetBacktraceGraph(target, js):
+    backtraceGraph_dict = js.get("backtraceGraph", {})
+    if backtraceGraph_dict == {}:
+        return
+    target.backtraceGraph_commands = backtraceGraph_dict.get("commands", [])
+    target.backtraceGraph_files = backtraceGraph_dict.get("files", [])
+
+    nodes_arr = backtraceGraph_dict.get("nodes", [])
+    for node_dict in nodes_arr:
+        node = spdx.cmakefileapi.TargetBacktraceGraphNode()
+        node.file = node_dict.get("file", -1)
+        node.line = node_dict.get("line", -1)
+        node.command = node_dict.get("command", -1)
+        node.parent = node_dict.get("parent", -1)
+        target.backtraceGraph_nodes.append(node)
+
+# Create direct pointers for all Configs in Codemodel
+# takes: Codemodel
+def linkCodemodel(cm):
+    for cfg in cm.configurations:
+        linkConfig(cfg)
+
+# Create direct pointers for all contents of Config
+# takes: Config
+def linkConfig(cfg):
+    for cfgDir in cfg.directories:
+        linkConfigDir(cfg, cfgDir)
+    for cfgPrj in cfg.projects:
+        linkConfigProject(cfg, cfgPrj)
+    for cfgTarget in cfg.configTargets:
+        linkConfigTarget(cfg, cfgTarget)
+
+# Create direct pointers for ConfigDir indices
+# takes: Config and ConfigDir
+def linkConfigDir(cfg, cfgDir):
+    if cfgDir.parentIndex == -1:
+        cfgDir.parent = None
+    else:
+        cfgDir.parent = cfg.directories[cfgDir.parentIndex]
+
+    if cfgDir.projectIndex == -1:
+        cfgDir.project = None
+    else:
+        cfgDir.project = cfg.projects[cfgDir.projectIndex]
+
+    cfgDir.children = []
+    for childIndex in cfgDir.childIndexes:
+        cfgDir.children.append(cfg.directories[childIndex])
+
+    cfgDir.targets = []
+    for targetIndex in cfgDir.targetIndexes:
+        cfgDir.targets.append(cfg.configTargets[targetIndex])
+
+# Create direct pointers for ConfigProject indices
+# takes: Config and ConfigProject
+def linkConfigProject(cfg, cfgPrj):
+    if cfgPrj.parentIndex == -1:
+        cfgPrj.parent = None
+    else:
+        cfgPrj.parent = cfg.projects[cfgPrj.parentIndex]
+
+    cfgPrj.children = []
+    for childIndex in cfgPrj.childIndexes:
+        cfgPrj.children.append(cfg.projects[childIndex])
+
+    cfgPrj.directories = []
+    for dirIndex in cfgPrj.directoryIndexes:
+        cfgPrj.directories.append(cfg.directories[dirIndex])
+
+    cfgPrj.targets = []
+    for targetIndex in cfgPrj.targetIndexes:
+        cfgPrj.targets.append(cfg.configTargets[targetIndex])
+
+# Create direct pointers for ConfigTarget indices
+# takes: Config and ConfigTarget
+def linkConfigTarget(cfg, cfgTarget):
+    if cfgTarget.directoryIndex == -1:
+        cfgTarget.directory = None
+    else:
+        cfgTarget.directory = cfg.directories[cfgTarget.directoryIndex]
+
+    if cfgTarget.projectIndex == -1:
+        cfgTarget.project = None
+    else:
+        cfgTarget.project = cfg.projects[cfgTarget.projectIndex]
+
+    # and link target's sources and source groups
+    for ts in cfgTarget.target.sources:
+        linkTargetSource(cfgTarget.target, ts)
+    for tsg in cfgTarget.target.sourceGroups:
+        linkTargetSourceGroup(cfgTarget.target, tsg)
+    for tcg in cfgTarget.target.compileGroups:
+        linkTargetCompileGroup(cfgTarget.target, tcg)
+
+# Create direct pointers for TargetSource indices
+# takes: Target and TargetSource
+def linkTargetSource(target, targetSrc):
+    if targetSrc.compileGroupIndex == -1:
+        targetSrc.compileGroup = None
+    else:
+        targetSrc.compileGroup = target.compileGroups[targetSrc.compileGroupIndex]
+
+    if targetSrc.sourceGroupIndex == -1:
+        targetSrc.sourceGroup = None
+    else:
+        targetSrc.sourceGroup = target.sourceGroups[targetSrc.sourceGroupIndex]
+
+# Create direct pointers for TargetSourceGroup indices
+# takes: Target and TargetSourceGroup
+def linkTargetSourceGroup(target, targetSrcGrp):
+    targetSrcGrp.sources = []
+    for srcIndex in targetSrcGrp.sourceIndexes:
+        targetSrcGrp.sources.append(target.sources[srcIndex])
+
+# Create direct pointers for TargetCompileGroup indices
+# takes: Target and TargetCompileGroup
+def linkTargetCompileGroup(target, targetCmpGrp):
+    targetCmpGrp.sources = []
+    for srcIndex in targetCmpGrp.sourceIndexes:
+        targetCmpGrp.sources.append(target.sources[srcIndex])

--- a/scripts/west_commands/spdx/relationships.py
+++ b/scripts/west_commands/spdx/relationships.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from west import log
+
+def resolveRelationshipID(relpathSrcDir, relpathBuildDir, srcDoc, buildDoc, filepath, is_build):
+    """
+    Determines the corresponding SPDX ID for filepath, depending on whether
+    it is a source file or build file.
+
+    Arguments:
+        - relpathSrcDir: root directory of sources location for relative paths
+        - relpathBuildDir: root directory of build location for relative paths
+        - srcPkg: source SPDX Package section data
+        - buildPkg: build SPDX Package section data
+        - filepath: path to file being resolved; might be absolute or relative
+        - is_build: should this file ID be in the build paths or the sources paths?
+    Returns: resolved ID or None if not resolvable
+    """
+    # figure out relative path we're searching for
+    # FIXME this is probably not the best way to do this
+    is_relative = not(filepath.startswith("/") or filepath.startswith("\\"))
+
+    # figure out if maybe it's a build file based on its absolute path,
+    # even though we earlier concluded it was probably a sources file based on
+    # its relation to the target type
+    # FIXME this is really hackish -- we should be able to tell earlier in
+    # FIXME the process whether it's a sources or build file, but isGenerated
+    # FIXME doesn't always seem to be reliable
+    if not is_relative and (os.path.commonpath([relpathBuildDir, filepath]) == relpathBuildDir):
+        is_build = True
+
+    # exclude files that have a relative path above its root dir
+    # FIXME this is also probably not the best way to do this
+    if filepath.startswith("../") or filepath.startswith("..\\"):
+        # points to somewhere outside our sources root dir;
+        # we won't be able to create this relationship
+        log.wrn(f"{filepath} contains \"..\", can't create relationship")
+        return None
+
+    # is this a file from the build results?
+    if is_build:
+        if is_relative:
+            searchPath = filepath
+        else:
+            searchPath = os.path.join(".", os.path.relpath(filepath, relpathBuildDir))
+        # only one package in the build doc; get the "first" one
+        for p in buildDoc.packages.values():
+            pkg = p
+            break
+
+        # search through files for the one with this filename
+        for f in pkg.files:
+            if os.path.normpath(f.name) == os.path.normpath(searchPath):
+                return f.spdxID
+
+        log.wrn(f"{filepath} not found in build document, can't create relationship")
+        return None
+
+    # if we get here, it's a sources file
+    # search the sources doc's packages for which one has this file
+    # FIXME note that this may pick the wrong sources package / file path
+    # FIXME   if two sources packages have the exact same file path
+    # FIXME currently it will just go through in order and pick the first one
+    # FIXME   that matches
+    for srcRootDir, srcPkg in srcDoc.packages.items():
+        if is_relative:
+            searchPath = filepath
+        else:
+            searchPath = os.path.join(".", os.path.relpath(filepath, srcRootDir))
+
+        # search through files for the one with this filename
+        for f in srcPkg.files:
+            if os.path.normpath(f.name) == os.path.normpath(searchPath):
+                return f.spdxID
+
+    # if we get here, we checked all the source packages and couldn't find it
+    log.wrn(f"{filepath} not found in sources document, can't create relationship")
+    return None
+
+def outputSPDXRelationships(relpathSrcDir, relpathBuildDir, srcDoc, buildDoc, rlns, spdxPath):
+    """
+    Create and append SPDX relationships to the end of the previously-created
+    SPDX build document.
+
+    Arguments:
+        - relpathSrcDir: root directory of sources location for relative paths
+        - relpathBuildDir: root directory of build location for relative paths
+        - srcDoc: source SPDX Document data
+        - buildDoc: build SPDX Document data
+        - rlns: Cmake relationship data from call to getCmakeRelationships()
+        - spdxPath: path to previously-started SPDX build document
+    Returns: True on success, False on error.
+    """
+    try:
+        with open(spdxPath, "a") as f:
+            for rln in rlns:
+                pathA = rln[0]
+                is_buildA = rln[1]
+                rln_type = rln[2]
+                pathB = rln[3]
+                is_buildB = rln[4]
+
+                rlnIDA = resolveRelationshipID(relpathSrcDir, relpathBuildDir, srcDoc, buildDoc, pathA, is_buildA)
+                rlnIDB = resolveRelationshipID(relpathSrcDir, relpathBuildDir, srcDoc, buildDoc, pathB, is_buildB)
+                if not rlnIDA or not rlnIDB:
+                    continue
+
+                # add DocumentRef- prefix for sources files
+                if not is_buildA:
+                    rlnIDA = "DocumentRef-sources:" + rlnIDA
+                if not is_buildB:
+                    rlnIDB = "DocumentRef-sources:" + rlnIDB
+
+                f.write(f"Relationship: {rlnIDA} {rln_type} {rlnIDB}\n")
+            return True
+
+    except OSError as e:
+        log.err(f"Error: Unable to append to {spdxPath}: {str(e)}")
+        return False

--- a/scripts/west_commands/spdx/sbom.py
+++ b/scripts/west_commands/spdx/sbom.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2020 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import os
+
+from west import log
+
+from spdx.cmakefileapi import TargetType
+from spdx.cmakefileapijson import parseReply
+from spdx.builder import BuilderDocumentConfig, BuilderPackageConfig, convertToSPDXIDSafe, makeSPDX
+from spdx.relationships import outputSPDXRelationships
+
+def getCmakeRelationships(cm):
+    """
+    Extracts details from Cmake API about which built files derive from
+    which sources. Looks at all targets within the first configuration
+    in the CodeModel.
+
+    Arguments:
+        - cm: CodeModel
+    Returns: list of tuples with relationships: [(filepathA, is_buildA, rln, filepathB, is_buildB), ...]
+    """
+    # get relative path: os.path.relpath(filename, cfg.scandir)
+    rlns = []
+    # walk through targets
+    for cfgTarget in cm.configurations[0].configTargets:
+        target = cfgTarget.target
+        # FIXME currently only handles static / object libraries
+        # for static / object libraries or executables, gather source files
+        if target.type in [TargetType.EXECUTABLE, TargetType.STATIC_LIBRARY, TargetType.OBJECT_LIBRARY]:
+            # FIXME currently only handles one artifact in list
+            if len(target.artifacts) != 1:
+                log.wrn(f"For target {target.name}, expected 1 artifact, got {len(target.artifacts)}; not generating relationships")
+                continue
+            artifactPath = target.artifacts[0]
+            for src in target.sources:
+                # FIXME this assumes that isGenerated tells us whether the file
+                # FIXME is in build or sources; may not always be correct
+                newRln = (os.path.join(".", artifactPath), True, "GENERATED_FROM", src.path, src.isGenerated)
+                rlns.append(newRln)
+            # also, if any dependencies of static libraries or executables created
+            # artifacts, include STATIC_LINK relationships for those
+            if target.type in [TargetType.EXECUTABLE, TargetType.STATIC_LIBRARY]:
+                for dep in target.dependencies:
+                    # now we need to find the target with this dep's ID
+                    for depCfgTarget in cm.configurations[0].configTargets:
+                        depTarget = depCfgTarget.target
+                        if depTarget.id != dep.id:
+                            continue
+                        # now we've got the right one; check the dep types
+                        # only link in library dependencies, not utility or executable
+                        if depTarget.type in [TargetType.STATIC_LIBRARY, TargetType.OBJECT_LIBRARY]:
+                            if len(depTarget.artifacts) != 1:
+                                log.wrn(f"For dependency {depTarget.name}, expected 1 artifact, got {len(depTarget.artifacts)}; not generating linking relationship")
+                                continue
+                            depArtifactPath = depTarget.artifacts[0]
+                            # FIXME this assumes that artifacts are always statically linking to something
+                            # FIXME that was in the build directory; may not always be correct
+                            newDepRln = (os.path.join(".", artifactPath), True, "STATIC_LINK",
+                                         os.path.join(".", depArtifactPath), True)
+                            rlns.append(newDepRln)
+                            break
+    return rlns
+
+def makeCmakeSpdx(cm, srcRootDirs, spdxOutputDir, spdxNamespacePrefix):
+    """
+    Parse Cmake data and scan source / build directories, and create a
+    corresponding SPDX tag-value document.
+
+    Arguments:
+        - cm: Cmake codemodel parsed by parseReply()
+        - srcRootDirs: mapping of package SPDX ID (without "SPDXRef-") =>
+                       sources root dir
+        - spdxOutputDir: output directory where SPDX documents will be written
+        - spdxNamespacePrefix: prefix for SPDX Document Namespace (will have
+            "sources" and "build" appended); see Document Creation Info
+            section in SPDX spec for more information
+    Returns: True on success, False on failure; note that failure may still
+             produce one or more partial SPDX documents
+    """
+    # create SPDX file for sources
+    srcSpdxPath = os.path.join(spdxOutputDir, "sources.spdx")
+    srcDocCfg = BuilderDocumentConfig()
+    srcDocCfg.documentName = "sources"
+    srcDocCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "sources")
+    for pkgID, pkgRootDir in srcRootDirs.items():
+        srcPkgCfg = BuilderPackageConfig()
+        srcPkgCfg.packageName = pkgID + " sources"
+        srcPkgCfg.spdxID = "SPDXRef-" + pkgID
+        srcPkgCfg.doSHA256 = True
+        srcPkgCfg.scandir = pkgRootDir
+        # FIXME is this correct as-is, or needs adjustment / resolve relative?
+        srcPkgCfg.excludeDirs.append(cm.paths_build)
+        srcDocCfg.packageConfigs[pkgRootDir] = srcPkgCfg
+
+    srcDoc = makeSPDX(srcDocCfg, srcSpdxPath)
+    if srcDoc:
+        log.inf(f"Saved sources SPDX to {srcSpdxPath}")
+    else:
+        log.err(f"Couldn't generate sources SPDX file")
+        return False
+
+    # get hash of sources SPDX file, to use for build doc's extRef
+    hSHA256 = hashlib.sha256()
+    with open(srcSpdxPath, 'rb') as f:
+        buf = f.read()
+        hSHA256.update(buf)
+    srcSHA256 = hSHA256.hexdigest()
+
+    # get auto-generated relationships between filenames
+    fileRlns = getCmakeRelationships(cm)
+
+    # create SPDX file for build
+    buildSpdxPath = os.path.join(spdxOutputDir, "build.spdx")
+    buildDocCfg = BuilderDocumentConfig()
+    buildDocCfg.documentName = "build"
+    buildDocCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "build")
+
+    buildPkgCfg = BuilderPackageConfig()
+    buildPkgCfg.packageName = "build"
+    buildPkgCfg.spdxID = "SPDXRef-build"
+    buildPkgCfg.doSHA256 = True
+    buildPkgCfg.scandir = cm.paths_build
+    buildDocCfg.packageConfigs[cm.paths_build] = buildPkgCfg
+
+    # add external document ref to sources SPDX file
+    buildDocCfg.extRefs = [("DocumentRef-sources", srcDocCfg.documentNamespace, "SHA256", srcSHA256)]
+
+    # exclude CMake file-based API responses -- presume only used for this
+    # SPDX generation scan, not for actual build artifact
+    buildExcludeDir = os.path.join(cm.paths_build, ".cmake", "api")
+    buildPkgCfg.excludeDirs.append(buildExcludeDir)
+    # also exclude the generated SPDX documents themselves
+    buildPkgCfg.excludeDirs.append("spdx")
+
+    buildDoc = makeSPDX(buildDocCfg, buildSpdxPath)
+    if buildDoc:
+        log.inf(f"Saved build SPDX to {buildSpdxPath}")
+    else:
+        log.err(f"Couldn't generate build SPDX file")
+        return False
+
+    # and output relationships to build file also
+    retval = outputSPDXRelationships(cm.paths_source, cm.paths_build, srcDoc, buildDoc, fileRlns, buildSpdxPath)
+    if retval:
+        log.inf(f"Added relationships to {buildSpdxPath}")
+    else:
+        log.err(f"Couldn't add relationships to build SPDX file")
+        return False
+
+    return True
+
+def makeSpdxFromCmakeReply(replyIndexPath, spdxOutputDir, spdxNamespacePrefix):
+    """
+    Parse Cmake data to determine source / build directories, and call
+    makeCmakeSpdx to create the corresponding SPDX tag-value document.
+
+    Arguments:
+        - replyIndexPath: path to index file from Cmake API reply JSON file
+        - spdxOutputDir: output directory where SPDX documents will be written
+        - spdxNamespacePrefix: prefix for SPDX Document Namespace (will have
+            "sources" and "build" appended); see Document Creation Info
+            section in SPDX spec for more information
+    Returns: True on success, False on failure; note that failure may still
+             produce one or more partial SPDX documents
+    """
+    # get CMake info from build
+    cm = parseReply(replyIndexPath)
+
+    # determine source packages and directory mappings
+    srcRootDirs = {}
+    for prj in cm.configurations[0].projects:
+        # go through the directories and determine top directory for this package
+        seen_first_dir = False
+        is_prj_relative = False
+        should_skip = False
+        dirs_seen = []
+        for dt in prj.directories:
+            # make sure each project has either just relative or just absolute paths
+            # FIXME this is probably not the best way to do this
+            is_dir_relative = not(dt.source.startswith("/") or dt.source.startswith("\\"))
+            if not seen_first_dir:
+                is_prj_relative = is_dir_relative
+                seen_first_dir = True
+            else:
+                if is_prj_relative != is_dir_relative:
+                    log.wrn(f"directories for project {prj.name} contain both absolute and relative paths; skipping")
+                    should_skip = True
+                    break
+            dirs_seen.append(dt.source)
+        if should_skip:
+            break
+        srcRootDir = os.path.commonpath(dirs_seen)
+        if is_prj_relative:
+            srcRootDir = os.path.join(cm.paths_source, srcRootDir)
+
+        # make SPDX ID for package
+        # FIXME this needs to also ensure there isn't overlap in IDs
+        pkgID = convertToSPDXIDSafe(prj.name)
+
+        # add it to map
+        srcRootDirs[pkgID] = srcRootDir
+
+    # scan and create SPDX document
+    return makeCmakeSpdx(cm, srcRootDirs, spdxOutputDir, spdxNamespacePrefix)
+
+def setupCmakeQuery(buildDir):
+    """
+    Ensures that the query file (buildDir/.cmake/api/v1/query/codemodel-v2)
+    exists, and creates it if it doesn't.
+
+    Arguments:
+        - buildDir: build directory
+    Returns: True on success, False on failure
+    """
+    # check that query dir exists as a directory, or else create it
+    cmakeApiDirPath = os.path.join(buildDir, ".cmake", "api", "v1", "query")
+    if os.path.exists(cmakeApiDirPath):
+        if not os.path.isdir(cmakeApiDirPath):
+            log.err(f'cmake api query directory {cmakeApiDirPath} exists and is not a directory')
+            return False
+        # directory exists, we're good
+    else:
+        # create the directory
+        os.makedirs(cmakeApiDirPath, exist_ok=False)
+
+    # check that codemodel-v2 exists as a file, or else create it
+    queryFilePath = os.path.join(cmakeApiDirPath, "codemodel-v2")
+    if os.path.exists(queryFilePath):
+        if not os.path.isfile(queryFilePath):
+            log.err(f'cmake api query file {queryFilePath} exists and is not a directory')
+            return False
+        # file exists, we're good
+        return True
+    else:
+        # file doesn't exist, let's create it
+        os.mknod(queryFilePath)
+        return True
+
+def findIndexFile(buildDir):
+    """
+    Find the path to the index file from the cmake API response.
+
+    Arguments:
+        - buildDir: build directory
+    Returns: path to index file in API reply directory or None if not found
+    """
+    # make sure the reply directory exists
+    cmakeReplyDirPath = os.path.join(buildDir, ".cmake", "api", "v1", "reply")
+    if not os.path.exists(cmakeReplyDirPath):
+        log.err(f'cmake api reply directory {cmakeReplyDirPath} does not exist')
+        log.err('was query directory created before cmake build ran?')
+        return None
+    if not os.path.isdir(cmakeReplyDirPath):
+        log.err(f'cmake api reply directory {cmakeReplyDirPath} exists but is not a directory')
+        return None
+
+    # find file with "index" prefix; there should only be one
+    for f in os.listdir(cmakeReplyDirPath):
+        if f.startswith("index"):
+            return os.path.join(cmakeReplyDirPath, f)
+
+    # didn't find it
+    log.err(f'cmake api reply index file not found in {cmakeReplyDirPath}')
+    return None


### PR DESCRIPTION
This is a draft PR to address #7317 by enabling creation of SPDX documents automatically during the west build process. This is based on a non-Zephyr-specific approach for creating SPDX documents for CMake-based projects that I've been working on at https://github.com/swinslow/cmake-spdx.

Comments and questions are very welcome! This is my first substantive contribution to Zephyr so I'm especially grateful for any feedback.

Fixes #7317

Signed-off-by: Steve Winslow <steve@swinslow.net>

## Overview

This adds support to generate SPDX 2.2 tag-value documents as part of the west build command. The CMake file-based APIs are leveraged to create relationships from source files to the corresponding generated build files. SPDX-License-Identifier comments in source files are scanned and filled into the SPDX documents.

SPDX generation is activated by calling `west build` with the `--spdx` option. This will generate two SPDX documents in `build/spdx/`:

1) **sources.spdx**: This contains the bill-of-materials for the source files used for the build. It creates a separate SPDX Package for each Cmake "project," scanning files at the parent root of the directories used by that project.

2) **build.spdx**: This contains the bill-of-materials for the built output files. It includes SPDX Relationships back to the corresponding C source files used as inputs for each built target. It also includes relationships for libraries that are statically linked during the build.

The `--spdx-prefix=...` flag can also optionally be provided to specify a prefix for the Document Namespaces that will be included in the generated SPDX documents. See SPDX spec 2.2 section 2.5 at https://spdx.github.io/spdx-spec/2-document-creation-information/. If `--spdx-prefix` is omitted, a default namespace will be generated according to the default format described in section 2.5, using a UUID generated at build time.

## Next steps for improvements

This PR is a first step for creating SPDX documents. Here are some ways that it could be improved, which I'm noting here to use for future issues in case this PR does get merged:

### Should filter for valid SPDX license IDs

Currently, this PR will fill in the `LicenseConcluded` field for each file with whatever it finds in a `SPDX-License-Identifier` comment. It will fill it in even if it is not a valid SPDX license ID, which results in an SPDX document that is not technically valid. More details about this can be seen [here](https://github.com/swinslow/cmake-spdx/blob/master/docs/next-steps.md#invalid-spdx-document-due-to-invalid-identifiers).

The only identifiers that should be permitted are (1) IDs on the [SPDX license list](https://spdx.org/licenses), and (2) [LicenseRef- custom IDs](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/). For the latter, an [Other License Info section](https://spdx.github.io/spdx-spec/6-other-licensing-information-detected/) should be created for each LicenseRef-. 

For invalid `SPDX-License-Identifier` comments, they should be corrected in the actual source files, but the SPDX generator should also handle them by translating them to LicenseRef- custom license IDs.

### Should auto-conclude licenses for built files

Since we know (1) the license for each source file, and (2) which source files are built into a binary file, it should be possible for the generator to conclude the license for each built binary file based on its particular source file inputs.

Some legal-minded folks might take issue with whether it is appropriate to do this sort of auto-concluding, so this should be an optional flag to enable.

### Should handle more than C => binary files

The GENERATED_FROM relationships are based solely on the data that is gathered from the CMake file-based APIs. Someone with a deeper knowledge of the Zephyr build process might be able to extract more info about other types of files that are generated during the build, and could enrich these relationships with more details.

### Consider creating separate SPDX Packages for each build target

Currently, this creates a single SPDX Package corresponding to the entire build directory as a whole (excluding a couple of directories). This could be more useful by also creating separate SPDX Packages -- or perhaps even separate SPDX Documents -- for each target in the build process.