### PR TITLE
serial: `CONFIG_USB_CDC_ACM` adds file to library

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -36,6 +36,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_XLNX_UARTLITE uart_xlnx_uartlite.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XMC4XXX uart_xmc4xxx.c)
 zephyr_library_sources_ifdef(CONFIG_UART_NPCX uart_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_UART_APBUART uart_apbuart.c)
+zephyr_library_sources_ifdef(CONFIG_USB_CDC_ACM ${ZEPHYR_BASE}/misc/empty_file.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 


### PR DESCRIPTION
It is possible to use the UART abstraction for USB communications
without any of the dedicated UART drivers being enabled. This currently
causes a compilation error because CMake throws an error if a library
has no sources. The empty file forces there to be at least one file in
the library when `CONFIG_USB_CDC_ACM` is enabled.

Removing `select CONFIG_SERIAL_HAS_DRIVER` from `CONFIG_USB_CDC_ACM` is
not a valid solution as this symbol is required by `CONFIG_UART_CONSOLE`
and therefore `USB_UART_CONSOLE`.

Fixes #31067.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>