### PR TITLE
net: buf: remove data from end of buffers

### DIFF
--- a/doc/reference/networking/net_buf.rst
+++ b/doc/reference/networking/net_buf.rst
@@ -81,6 +81,18 @@ Add
      void net_buf_add_le16(struct net_buf *buf, uint16_t value);
      void net_buf_add_le32(struct net_buf *buf, uint32_t value);
 
+Remove
+  Remove data from the end of the buffer. Modifies the data length value
+  while leaving the actual data pointer intact. Some examples of APIs for
+  removing data:
+
+  .. code-block:: c
+
+     void *net_buf_remove_mem(struct net_buf *buf, size_t len);
+     uint8_t net_buf_remove_u8(struct net_buf *buf);
+     uint16_t net_buf_remove_le16(struct net_buf *buf);
+     uint32_t net_buf_remove_le32(struct net_buf *buf);
+
 Push
   Prepend data to the beginning of the buffer. Modifies both the data
   length value as well as the data pointer. Requires that there is
@@ -107,7 +119,8 @@ Pull
      uint32_t net_buf_pull_le32(struct net_buf *buf);
 
 The Add and Push operations are used when encoding data into the buffer,
-whereas Pull is used when decoding data from a buffer.
+whereas the Remove and Pull operations are used when decoding data from a
+buffer.
 
 Reference Counting
 ******************

--- a/doc/reference/networking/net_buf.rst
+++ b/doc/reference/networking/net_buf.rst
@@ -89,6 +89,7 @@ Push
   .. code-block:: c
 
      void *net_buf_push(struct net_buf *buf, size_t len);
+     void *net_buf_push_mem(struct net_buf *buf, const void *mem, size_t len);
      void net_buf_push_u8(struct net_buf *buf, uint8_t value);
      void net_buf_push_le16(struct net_buf *buf, uint16_t value);
 

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -357,6 +357,21 @@ void net_buf_simple_add_be64(struct net_buf_simple *buf, uint64_t val);
 void *net_buf_simple_push(struct net_buf_simple *buf, size_t len);
 
 /**
+ * @brief Copy given number of bytes from memory to the start of the buffer.
+ *
+ * Modifies the data pointer and buffer length to account for more data
+ * in the beginning of the buffer.
+ *
+ * @param buf Buffer to update.
+ * @param mem Location of data to be added.
+ * @param len Length of data to be added.
+ *
+ * @return The new beginning of the buffer data.
+ */
+void *net_buf_simple_push_mem(struct net_buf_simple *buf, const void *mem,
+			      size_t len);
+
+/**
  * @brief Push 16-bit value to the beginning of the buffer
  *
  * Adds 16-bit value in little endian format to the beginning of the
@@ -1466,6 +1481,22 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
  * @return The new beginning of the buffer data.
  */
 #define net_buf_push(buf, len) net_buf_simple_push(&(buf)->b, len)
+
+/**
+ * @def net_buf_push_mem
+ * @brief Copies the given number of bytes to the start of the buffer
+ *
+ * Modifies the data pointer and buffer length to account for more data
+ * in the beginning of the buffer.
+ *
+ * @param buf Buffer to update.
+ * @param mem Location of data to be added.
+ * @param len Length of data to be added.
+ *
+ * @return The new beginning of the buffer data.
+ */
+#define net_buf_push_mem(buf, mem, len) net_buf_simple_push_mem(&(buf)->b, \
+								mem, len)
 
 /**
  * @def net_buf_push_le16

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -344,7 +344,151 @@ void net_buf_simple_add_le64(struct net_buf_simple *buf, uint64_t val);
 void net_buf_simple_add_be64(struct net_buf_simple *buf, uint64_t val);
 
 /**
- * @brief Push data to the beginning of the buffer.
+ * @brief Remove data from the end of the buffer.
+ *
+ * Removes data from the end of the buffer by modifying the buffer length.
+ *
+ * @param buf Buffer to update.
+ * @param len Number of bytes to remove.
+ *
+ * @return New end of the buffer data.
+ */
+void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len);
+
+/**
+ * @brief Remove a 8-bit value from the end of the buffer
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 8-bit values.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return The 8-bit removed value
+ */
+uint8_t net_buf_simple_remove_u8(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 16 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 16-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 16-bit value converted from little endian to host endian.
+ */
+uint16_t net_buf_simple_remove_le16(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 16 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 16-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 16-bit value converted from big endian to host endian.
+ */
+uint16_t net_buf_simple_remove_be16(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 24 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 24-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from little endian to host endian.
+ */
+uint32_t net_buf_simple_remove_le24(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 24 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 24-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from big endian to host endian.
+ */
+uint32_t net_buf_simple_remove_be24(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 32 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 32-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 32-bit value converted from little endian to host endian.
+ */
+uint32_t net_buf_simple_remove_le32(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 32 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 32-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 32-bit value converted from big endian to host endian.
+ */
+uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 48 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 48-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from little endian to host endian.
+ */
+uint64_t net_buf_simple_remove_le48(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 48 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 48-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from big endian to host endian.
+ */
+uint64_t net_buf_simple_remove_be48(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 64 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 64-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from little endian to host endian.
+ */
+uint64_t net_buf_simple_remove_le64(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 64 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 64-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from big endian to host endian.
+ */
+uint64_t net_buf_simple_remove_be64(struct net_buf_simple *buf);
+
+/**
+ * @brief Prepare data to be added to the start of the buffer
  *
  * Modifies the data pointer and buffer length to account for more data
  * in the beginning of the buffer.
@@ -1469,8 +1613,164 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
 #define net_buf_add_be64(buf, val) net_buf_simple_add_be64(&(buf)->b, val)
 
 /**
+ * @def net_buf_remove_mem
+ * @brief Remove data from the end of the buffer.
+ *
+ * Removes data from the end of the buffer by modifying the buffer length.
+ *
+ * @param buf Buffer to update.
+ * @param len Number of bytes to remove.
+ *
+ * @return New end of the buffer data.
+ */
+#define net_buf_remove_mem(buf, len) net_buf_simple_remove_mem(&(buf)->b, len)
+
+/**
+ * @def net_buf_remove_u8
+ * @brief Remove a 8-bit value from the end of the buffer
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 8-bit values.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return The 8-bit removed value
+ */
+#define net_buf_remove_u8(buf) net_buf_simple_remove_u8(&(buf)->b)
+
+/**
+ * @def net_buf_remove_le16
+ * @brief Remove and convert 16 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 16-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 16-bit value converted from little endian to host endian.
+ */
+#define net_buf_remove_le16(buf) net_buf_simple_remove_le16(&(buf)->b)
+
+/**
+ * @def net_buf_remove_be16
+ * @brief Remove and convert 16 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 16-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 16-bit value converted from big endian to host endian.
+ */
+#define net_buf_remove_be16(buf) net_buf_simple_remove_be16(&(buf)->b)
+
+/**
+ * @def net_buf_remove_be24
+ * @brief Remove and convert 24 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 24-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from big endian to host endian.
+ */
+#define net_buf_remove_be24(buf) net_buf_simple_remove_be24(&(buf)->b)
+
+/**
+ * @def net_buf_remove_le24
+ * @brief Remove and convert 24 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 24-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from little endian to host endian.
+ */
+#define net_buf_remove_le24(buf) net_buf_simple_remove_le24(&(buf)->b)
+
+/**
+ * @def net_buf_remove_le32
+ * @brief Remove and convert 32 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 32-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 32-bit value converted from little endian to host endian.
+ */
+#define net_buf_remove_le32(buf) net_buf_simple_remove_le32(&(buf)->b)
+
+/**
+ * @def net_buf_remove_be32
+ * @brief Remove and convert 32 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 32-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 32-bit value converted from big endian to host endian.
+ */
+#define net_buf_remove_be32(buf) net_buf_simple_remove_be32(&(buf)->b)
+
+/**
+ * @def net_buf_remove_le48
+ * @brief Remove and convert 48 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 48-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from little endian to host endian.
+ */
+#define net_buf_remove_le48(buf) net_buf_simple_remove_le48(&(buf)->b)
+
+/**
+ * @def net_buf_remove_be48
+ * @brief Remove and convert 48 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 48-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 48-bit value converted from big endian to host endian.
+ */
+#define net_buf_remove_be48(buf) net_buf_simple_remove_be48(&(buf)->b)
+
+/**
+ * @def net_buf_remove_le64
+ * @brief Remove and convert 64 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 64-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from little endian to host endian.
+ */
+#define net_buf_remove_le64(buf) net_buf_simple_remove_le64(&(buf)->b)
+
+/**
+ * @def net_buf_remove_be64
+ * @brief Remove and convert 64 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 64-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 64-bit value converted from big endian to host endian.
+ */
+#define net_buf_remove_be64(buf) net_buf_simple_remove_be64(&(buf)->b)
+
+/**
  * @def net_buf_push
- * @brief Push data to the beginning of the buffer.
+ * @brief Prepare data to be added at the start of the buffer
  *
  * Modifies the data pointer and buffer length to account for more data
  * in the beginning of the buffer.

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -893,6 +893,14 @@ void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 	return buf->data;
 }
 
+void *net_buf_simple_push_mem(struct net_buf_simple *buf, const void *mem,
+			      size_t len)
+{
+	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
+
+	return memcpy(net_buf_simple_push(buf, len), mem, len);
+}
+
 void net_buf_simple_push_le16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -882,6 +882,145 @@ void net_buf_simple_add_be64(struct net_buf_simple *buf, uint64_t val)
 	sys_put_be64(val, net_buf_simple_add(buf, sizeof(val)));
 }
 
+void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len)
+{
+	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
+
+	__ASSERT_NO_MSG(buf->len >= len);
+
+	buf->len -= len;
+	return buf->data + buf->len;
+}
+
+uint8_t net_buf_simple_remove_u8(struct net_buf_simple *buf)
+{
+	uint8_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = *(uint8_t *)ptr;
+
+	return val;
+}
+
+uint16_t net_buf_simple_remove_le16(struct net_buf_simple *buf)
+{
+	uint16_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint16_t *)ptr);
+
+	return sys_le16_to_cpu(val);
+}
+
+uint16_t net_buf_simple_remove_be16(struct net_buf_simple *buf)
+{
+	uint16_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint16_t *)ptr);
+
+	return sys_be16_to_cpu(val);
+}
+
+uint32_t net_buf_simple_remove_le24(struct net_buf_simple *buf)
+{
+	struct uint24 {
+		uint32_t u24 : 24;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint24 *)ptr);
+
+	return sys_le24_to_cpu(val.u24);
+}
+
+uint32_t net_buf_simple_remove_be24(struct net_buf_simple *buf)
+{
+	struct uint24 {
+		uint32_t u24 : 24;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint24 *)ptr);
+
+	return sys_be24_to_cpu(val.u24);
+}
+
+uint32_t net_buf_simple_remove_le32(struct net_buf_simple *buf)
+{
+	uint32_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint32_t *)ptr);
+
+	return sys_le32_to_cpu(val);
+}
+
+uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf)
+{
+	uint32_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint32_t *)ptr);
+
+	return sys_be32_to_cpu(val);
+}
+
+uint64_t net_buf_simple_remove_le48(struct net_buf_simple *buf)
+{
+	struct uint48 {
+		uint64_t u48 : 48;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint48 *)ptr);
+
+	return sys_le48_to_cpu(val.u48);
+}
+
+uint64_t net_buf_simple_remove_be48(struct net_buf_simple *buf)
+{
+	struct uint48 {
+		uint64_t u48 : 48;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint48 *)ptr);
+
+	return sys_be48_to_cpu(val.u48);
+}
+
+uint64_t net_buf_simple_remove_le64(struct net_buf_simple *buf)
+{
+	uint64_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint64_t *)ptr);
+
+	return sys_le64_to_cpu(val);
+}
+
+uint64_t net_buf_simple_remove_be64(struct net_buf_simple *buf)
+{
+	uint64_t val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((uint64_t *)ptr);
+
+	return sys_be64_to_cpu(val);
+}
+
 void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -30,13 +30,13 @@ struct bt_data {
 
 struct in6_addr {
 	union {
-		uint8_t		u6_addr8[16];
-		uint16_t	u6_addr16[8]; /* In big endian */
-		uint32_t	u6_addr32[4]; /* In big endian */
+		uint8_t u6_addr8[16];
+		uint16_t u6_addr16[8];          /* In big endian */
+		uint32_t u6_addr32[4];          /* In big endian */
 	} in6_u;
-#define s6_addr			in6_u.u6_addr8
-#define s6_addr16		in6_u.u6_addr16
-#define s6_addr32		in6_u.u6_addr32
+#define s6_addr         in6_u.u6_addr8
+#define s6_addr16       in6_u.u6_addr16
+#define s6_addr32       in6_u.u6_addr32
 };
 
 struct ipv6_hdr {
@@ -115,7 +115,7 @@ static void test_net_buf_1(void)
 	}
 
 	zassert_equal(destroy_called, ARRAY_SIZE(bufs),
-		     "Incorrect destroy callback count");
+		      "Incorrect destroy callback count");
 }
 
 static void test_net_buf_2(void)
@@ -141,7 +141,7 @@ static void test_net_buf_2(void)
 	destroy_called = 0;
 	net_buf_unref(head);
 	zassert_equal(destroy_called, bufs_pool.buf_count,
-		     "Incorrect fragment destroy callback count");
+		      "Incorrect fragment destroy callback count");
 }
 
 static void test_3_thread(void *arg1, void *arg2, void *arg3)
@@ -158,7 +158,7 @@ static void test_3_thread(void *arg1, void *arg2, void *arg3)
 	destroy_called = 0;
 	net_buf_unref(buf);
 	zassert_equal(destroy_called, bufs_pool.buf_count,
-		     "Incorrect destroy callback count");
+		      "Incorrect destroy callback count");
 
 	k_sem_give(sema);
 }
@@ -192,12 +192,12 @@ static void test_net_buf_3(void)
 			K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	zassert_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
-		    "Timeout while waiting for semaphore");
+		     "Timeout while waiting for semaphore");
 
 	net_buf_put(&fifo, head);
 
 	zassert_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
-		    "Timeout while waiting for semaphore");
+		     "Timeout while waiting for semaphore");
 }
 
 static void test_net_buf_4(void)
@@ -261,7 +261,7 @@ static void test_net_buf_4(void)
 	}
 
 	zassert_equal(1 + i + removed, bufs_pool.buf_count,
-		     "Incorrect removed fragment count");
+		      "Incorrect removed fragment count");
 
 	removed = 0;
 
@@ -275,7 +275,7 @@ static void test_net_buf_4(void)
 
 	zassert_equal(removed, i, "Incorrect removed fragment count");
 	zassert_equal(destroy_called, bufs_pool.buf_count - 1,
-		     "Incorrect frag destroy callback count");
+		      "Incorrect frag destroy callback count");
 
 	/* Add the fragments back and verify that they are properly unref
 	 * by freeing the top buf.
@@ -307,7 +307,7 @@ static void test_net_buf_4(void)
 	net_buf_unref(buf);
 
 	zassert_equal(destroy_called, bufs_pool.buf_count,
-		     "Incorrect frag destroy callback count");
+		      "Incorrect frag destroy callback count");
 }
 
 static void test_net_buf_big_buf(void)
@@ -335,7 +335,7 @@ static void test_net_buf_big_buf(void)
 	len = strlen(example_data);
 	for (i = 0; i < 2; i++) {
 		zassert_true(net_buf_tailroom(frag) >= len,
-			    "Allocated buffer is too small");
+			     "Allocated buffer is too small");
 		memcpy(net_buf_add(frag, len), example_data, len);
 	}
 
@@ -387,7 +387,7 @@ static void test_net_buf_multi_frags(void)
 	len = strlen(example_data);
 	for (i = 0; i < bufs_pool.buf_count - 2; i++) {
 		zassert_true(net_buf_tailroom(frags[i]) >= len,
-			    "Allocated buffer is too small");
+			     "Allocated buffer is too small");
 		memcpy(net_buf_add(frags[i], len), example_data, len);
 		occupied += frags[i]->len;
 	}
@@ -398,7 +398,7 @@ static void test_net_buf_multi_frags(void)
 	net_buf_unref(buf);
 
 	zassert_equal(destroy_called, bufs_pool.buf_count,
-		     "Incorrect frag destroy callback count");
+		      "Incorrect frag destroy callback count");
 }
 
 static void test_net_buf_clone(void)
@@ -477,6 +477,7 @@ static void test_net_buf_byte_order(void)
 	buf = net_buf_alloc_len(&fixed_pool, 16, K_FOREVER);
 	zassert_not_null(buf, "Failed to get buffer");
 
+	/* add/pull byte order */
 	net_buf_add_mem(buf, &le16, sizeof(le16));
 	net_buf_add_mem(buf, &be16, sizeof(be16));
 
@@ -569,6 +570,112 @@ static void test_net_buf_byte_order(void)
 			  sizeof(le64), "Invalid 64 bits byte order");
 	zassert_mem_equal(be64, net_buf_pull_mem(buf, sizeof(be64)),
 			  sizeof(be48), "Invalid 64 bits byte order");
+
+	/* push/remove byte order */
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le16, sizeof(le16));
+	net_buf_push_mem(buf, &be16, sizeof(be16));
+
+	u16 = net_buf_remove_le16(buf);
+	zassert_equal(u16, net_buf_remove_be16(buf),
+		      "Invalid 16 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le16(buf, u16);
+	net_buf_push_be16(buf, u16);
+
+	zassert_mem_equal(le16, net_buf_remove_mem(buf, sizeof(le16)),
+			  sizeof(le16),  "Invalid 16 bits byte order");
+	zassert_mem_equal(be16, net_buf_remove_mem(buf, sizeof(be16)),
+			  sizeof(be16),  "Invalid 16 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le24, sizeof(le24));
+	net_buf_push_mem(buf, &be24, sizeof(be24));
+
+	u32 = net_buf_remove_le24(buf);
+	zassert_equal(u32, net_buf_remove_be24(buf),
+		      "Invalid 24 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le24(buf, u32);
+	net_buf_push_be24(buf, u32);
+
+	zassert_mem_equal(le24, net_buf_remove_mem(buf, sizeof(le24)),
+			  sizeof(le24),  "Invalid 24 bits byte order");
+	zassert_mem_equal(be24, net_buf_remove_mem(buf, sizeof(be24)),
+			  sizeof(be24),  "Invalid 24 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le32, sizeof(le32));
+	net_buf_push_mem(buf, &be32, sizeof(be32));
+
+	u32 = net_buf_remove_le32(buf);
+	zassert_equal(u32, net_buf_remove_be32(buf),
+		      "Invalid 32 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le32(buf, u32);
+	net_buf_push_be32(buf, u32);
+
+	zassert_mem_equal(le32, net_buf_remove_mem(buf, sizeof(le32)),
+			  sizeof(le32), "Invalid 32 bits byte order");
+	zassert_mem_equal(be32, net_buf_remove_mem(buf, sizeof(be32)),
+			  sizeof(be32), "Invalid 32 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le48, sizeof(le48));
+	net_buf_push_mem(buf, &be48, sizeof(be48));
+
+	u64 = net_buf_remove_le48(buf);
+	zassert_equal(u64, net_buf_remove_be48(buf),
+		      "Invalid 48 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le48(buf, u64);
+	net_buf_push_be48(buf, u64);
+
+	zassert_mem_equal(le48, net_buf_remove_mem(buf, sizeof(le48)),
+			  sizeof(le48),  "Invalid 48 bits byte order");
+	zassert_mem_equal(be48, net_buf_remove_mem(buf, sizeof(be48)),
+			  sizeof(be48),  "Invalid 48 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le64, sizeof(le64));
+	net_buf_push_mem(buf, &be64, sizeof(be64));
+
+	u64 = net_buf_remove_le64(buf);
+	zassert_equal(u64, net_buf_remove_be64(buf),
+		      "Invalid 64 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le64(buf, u64);
+	net_buf_push_be64(buf, u64);
+
+	zassert_mem_equal(le64, net_buf_remove_mem(buf, sizeof(le64)),
+			  sizeof(le64), "Invalid 64 bits byte order");
+	zassert_mem_equal(be64, net_buf_remove_mem(buf, sizeof(be64)),
+			  sizeof(be64), "Invalid 64 bits byte order");
 
 	net_buf_unref(buf);
 }


### PR DESCRIPTION
Adds a family of functions that remove data from the end of a `struct net_buf`.
This rounds out the capabilities of `struct net_buf`, data can now be added and removed from both the start and end.

Implements #31069