### PR TITLE
drivers: eeprom: mark the EEPROM API as stable

### DIFF
--- a/doc/reference/overview.rst
+++ b/doc/reference/overview.rst
@@ -98,7 +98,7 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.4
 
    * - :ref:`eeprom_api`
-     - Unstable
+     - Stable
      - 2.1
      - 2.1
 


### PR DESCRIPTION
Mark the EEPROM API as stable for the upcoming Zephyr v2.5.0. The EEPROM API was introduced in Zephyr v2.1.0 and has not seen any changes since.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>