### PR TITLE
CAN ISO-TP updates to allow padding and fixed addressing

### DIFF
--- a/include/canbus/isotp.h
+++ b/include/canbus/isotp.h
@@ -35,7 +35,9 @@
  * FC      Flow Control
  * FF      First Frame
  * FS      Flow Status
- * AE      Adders Extension
+ * AE      Address Extension
+ * SA      Source Address
+ * TA      Target Address
  */
 
 /*
@@ -90,6 +92,38 @@
 /** Timeout for recv */
 #define ISOTP_RECV_TIMEOUT      -14
 
+/*
+ * CAN ID filtering for ISO-TP fixed addressing according to SAE J1939
+ *
+ * Format of 29-bit CAN identifier:
+ * ------------------------------------------------------
+ * | 28 .. 26 | 25  | 24 | 23 .. 16 | 15 .. 8  | 7 .. 0 |
+ * ------------------------------------------------------
+ * | Priority | EDP | DP | N_TAtype |   N_TA   |  N_SA  |
+ * ------------------------------------------------------
+ */
+
+/** Position of fixed source address (SA) */
+#define ISOTP_FIXED_ADDR_SA_POS         (0U)
+
+/** Mask to obtain fixed source address (SA) */
+#define ISOTP_FIXED_ADDR_SA_MASK        (0xFF << ISOTP_FIXED_ADDR_SA_POS)
+
+/** Position of fixed target address (TA) */
+#define ISOTP_FIXED_ADDR_TA_POS         (8U)
+
+/** Mask to obtain fixed target address (TA) */
+#define ISOTP_FIXED_ADDR_TA_MASK        (0xFF << ISOTP_FIXED_ADDR_TA_POS)
+
+/** Position of priority in fixed addressing mode */
+#define ISOTP_FIXED_ADDR_PRIO_POS       (26U)
+
+/** Mask for priority in fixed addressing mode */
+#define ISOTP_FIXED_ADDR_PRIO_MASK      (0x7 << ISOTP_FIXED_ADDR_PRIO_POS)
+
+/* CAN filter RX mask to match any priority and source address (SA) */
+#define ISOTP_FIXED_ADDR_RX_MASK        (0x03FFFF00)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,17 +134,24 @@ extern "C" {
  * Used to pass addresses to the bind and send functions.
  */
 struct isotp_msg_id {
-	/** Message identifier*/
+	/**
+	 * CAN identifier
+	 *
+	 * If ISO-TP fixed addressing is used, isotp_bind ignores SA and
+	 * priority sections and modifies TA section in flow control frames.
+	 */
 	union {
 		uint32_t std_id  : 11;
 		uint32_t ext_id  : 29;
 	};
-	/** extended address */
+	/** ISO-TP extended address (if used) */
 	uint8_t ext_addr;
-	/** Indicates the identifier type (standard or extended) */
+	/** Indicates the CAN identifier type (standard or extended) */
 	uint8_t id_type : 1;
-	/** Indicates if extended addressing is used */
+	/** Indicates if ISO-TP extended addressing is used */
 	uint8_t use_ext_addr : 1;
+	/** Indicates if ISO-TP fixed addressing (acc. to SAE J1939) is used */
+	uint8_t use_fixed_addr : 1;
 };
 
 /*

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -47,6 +47,22 @@ config ISOTP_CR_TIMEOUT
 	  Cr (receiver consecutive frame) timeout.
 	  ISO 15765-2: 1000ms
 
+config ISOTP_REQUIRE_RX_PADDING
+	bool "Require padding for received messages"
+	help
+	  If enabled, SFs and the last CF must always have a DLC of 8 bytes
+	  (for classic CAN) and unused bytes must be padded by the sending
+	  device. This setting allows to be compliant to AUTOSAR Specification
+	  of CAN Transport Layer.
+
+	  By default, received CAN frames with or without padding are accepted.
+
+config ISOTP_ENABLE_TX_PADDING
+	bool "Enable padding for transmitted messages"
+	help
+	  Add padding bytes 0xCC (as recommended by Bosch) if the PDU payload
+	  does not fit exactly into the CAN frame.
+
 config ISOTP_WORKQUEUE_PRIO
 	int "Priority level of the RX and TX work queue"
 	default 2

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -557,7 +557,7 @@ int isotp_bind(struct isotp_recv_ctx *ctx, const struct device *can_dev,
 
 	__ASSERT(ctx, "ctx is NULL");
 	__ASSERT(can_dev, "CAN device is NULL");
-	__ASSERT(rx_addr && rx_addr, "RX or TX addr is NULL");
+	__ASSERT(rx_addr && tx_addr, "RX or TX addr is NULL");
 	__ASSERT(opts, "OPTS is NULL");
 
 	ctx->can_dev = can_dev;
@@ -1106,7 +1106,7 @@ static int send(struct isotp_send_ctx *ctx, const struct device *can_dev,
 
 	__ASSERT_NO_MSG(ctx);
 	__ASSERT_NO_MSG(can_dev);
-	__ASSERT_NO_MSG(rx_addr && rx_addr);
+	__ASSERT_NO_MSG(rx_addr && tx_addr);
 
 	if (complete_cb) {
 		ctx->fin_cb.cb = complete_cb;

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -1068,11 +1068,11 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 	switch (ctx->state) {
 
 	case ISOTP_TX_SEND_FF:
-		LOG_DBG("SM send FF");
 		send_ff(ctx);
 		z_add_timeout(&ctx->timeout, send_timeout_handler,
 			      K_MSEC(ISOTP_BS));
 		ctx->state = ISOTP_TX_WAIT_FC;
+		LOG_DBG("SM send FF");
 		break;
 
 	case ISOTP_TX_SEND_CF:
@@ -1094,11 +1094,11 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 			}
 
 			if (ctx->opts.bs && !ctx->bs) {
-				LOG_DBG("BS reached. Wait for FC again");
-				ctx->state = ISOTP_TX_WAIT_FC;
 				z_add_timeout(&ctx->timeout,
 					      send_timeout_handler,
 					      K_MSEC(ISOTP_BS));
+				ctx->state = ISOTP_TX_WAIT_FC;
+				LOG_DBG("BS reached. Wait for FC again");
 				break;
 			} else if (ctx->opts.stmin) {
 				ctx->state = ISOTP_TX_WAIT_ST;
@@ -1109,10 +1109,10 @@ static void send_state_machine(struct isotp_send_ctx *ctx)
 		break;
 
 	case ISOTP_TX_WAIT_ST:
-		LOG_DBG("SM wait ST");
 		z_add_timeout(&ctx->timeout, send_timeout_handler,
 			      stmin_to_ticks(ctx->opts.stmin));
 		ctx->state = ISOTP_TX_SEND_CF;
+		LOG_DBG("SM wait ST");
 		break;
 
 	case ISOTP_TX_ERR:

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -136,6 +136,7 @@ static void receive_send_fc(struct isotp_recv_ctx *ctx, uint8_t fs)
 		.id = ctx->tx_addr.ext_id
 	};
 	uint8_t *data = frame.data;
+	uint8_t payload_len;
 	int ret;
 
 	__ASSERT_NO_MSG(!(fs & ISOTP_PCI_TYPE_MASK));
@@ -147,7 +148,16 @@ static void receive_send_fc(struct isotp_recv_ctx *ctx, uint8_t fs)
 	*data++ = ISOTP_PCI_TYPE_FC | fs;
 	*data++ = ctx->opts.bs;
 	*data++ = ctx->opts.stmin;
-	frame.dlc = data - frame.data;
+	payload_len = data - frame.data;
+
+#if defined(CONFIG_ISOTP_REQUIRE_RX_PADDING) || \
+				defined(CONFIG_ISOTP_ENABLE_TX_PADDING)
+	/* AUTOSAR requirement SWS_CanTp_00347 */
+	memset(&frame.data[payload_len], 0xCC, ISOTP_CAN_DL - payload_len);
+	frame.dlc = ISOTP_CAN_DL;
+#else
+	frame.dlc = payload_len;
+#endif
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
 		       receive_can_tx_isr, ctx);
@@ -264,10 +274,10 @@ static void receive_state_machine(struct isotp_recv_ctx *ctx)
 
 	switch (ctx->state) {
 	case ISOTP_RX_STATE_PROCESS_SF:
-		ctx->buf->len = receive_get_sf_length(ctx->buf);
+		ctx->length = receive_get_sf_length(ctx->buf);
 		ud_rem_len = net_buf_user_data(ctx->buf);
 		*ud_rem_len = 0;
-		LOG_DBG("SM process SF of length %d", ctx->buf->len);
+		LOG_DBG("SM process SF of length %d", ctx->length);
 		net_buf_put(&ctx->fifo, ctx->buf);
 		ctx->state = ISOTP_RX_STATE_RECYCLE;
 		receive_state_machine(ctx);
@@ -380,6 +390,7 @@ static void receive_work_handler(struct k_work *item)
 static void process_ff_sf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 {
 	int index = 0;
+	uint8_t payload_len;
 
 	if (ctx->rx_addr.use_ext_addr) {
 		if (frame->data[index++] != ctx->rx_addr.ext_addr) {
@@ -391,19 +402,30 @@ static void process_ff_sf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 	case ISOTP_PCI_TYPE_FF:
 		LOG_DBG("Got FF IRQ");
 		if (frame->dlc != ISOTP_CAN_DL) {
-			LOG_INF("FF DL does not match. Ignore");
+			LOG_INF("FF DLC invalid. Ignore");
 			return;
 		}
 
+		payload_len = ISOTP_CAN_DL;
 		ctx->state = ISOTP_RX_STATE_PROCESS_FF;
 		ctx->sn_expected = 1;
 		break;
 
 	case ISOTP_PCI_TYPE_SF:
 		LOG_DBG("Got SF IRQ");
-		if ((frame->data[index] & ISOTP_PCI_FF_DL_UPPER_MASK) +
-		    index + 1 != frame->dlc) {
-			LOG_INF("SF DL does not match. Ignore");
+#ifdef CONFIG_ISOTP_REQUIRE_RX_PADDING
+		/* AUTOSAR requirement SWS_CanTp_00345 */
+		if (frame->dlc != ISOTP_CAN_DL) {
+			LOG_INF("SF DLC invalid. Ignore");
+			return;
+		}
+#endif
+
+		payload_len = index + 1 + (frame->data[index] &
+						ISOTP_PCI_SF_DL_MASK);
+
+		if (payload_len > frame->dlc) {
+			LOG_INF("SF DL does not fit. Ignore");
 			return;
 		}
 
@@ -415,7 +437,7 @@ static void process_ff_sf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 		return;
 	}
 
-	net_buf_add_mem(ctx->buf, &frame->data[index], frame->dlc - index);
+	net_buf_add_mem(ctx->buf, &frame->data[index], payload_len - index);
 }
 
 static inline void receive_add_mem(struct isotp_recv_ctx *ctx, uint8_t *data,
@@ -432,7 +454,7 @@ static inline void receive_add_mem(struct isotp_recv_ctx *ctx, uint8_t *data,
 	net_buf_add_mem(ctx->act_frag, data, tailroom);
 	ctx->act_frag = ctx->act_frag->frags;
 	if (!ctx->act_frag) {
-		LOG_ERR("No fragmet left to append data");
+		LOG_ERR("No fragment left to append data");
 		receive_report_error(ctx, ISOTP_N_BUFFER_OVERFLW);
 		return;
 	}
@@ -444,6 +466,7 @@ static void process_cf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 {
 	uint32_t *ud_rem_len = (uint32_t *)net_buf_user_data(ctx->buf);
 	int index = 0;
+	uint32_t data_len;
 
 	if (ctx->rx_addr.use_ext_addr) {
 		if (frame->data[index++] != ctx->rx_addr.ext_addr) {
@@ -470,14 +493,20 @@ static void process_cf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 		return;
 	}
 
-	if (frame->dlc - index > ctx->length) {
-		LOG_ERR("The frame contains more bytes than expected");
+#ifdef CONFIG_ISOTP_REQUIRE_RX_PADDING
+	/* AUTOSAR requirement SWS_CanTp_00346 */
+	if (frame->dlc != ISOTP_CAN_DL) {
+		LOG_ERR("CF DL invalid");
 		receive_report_error(ctx, ISOTP_N_ERROR);
+		return;
 	}
+#endif
 
 	LOG_DBG("Got CF irq. Appending data");
-	receive_add_mem(ctx, &frame->data[index], frame->dlc - index);
-	ctx->length -= frame->dlc - index;
+	data_len = (ctx->length > frame->dlc - index) ? frame->dlc - index :
+		ctx->length;
+	receive_add_mem(ctx, &frame->data[index], data_len);
+	ctx->length -= data_len;
 	LOG_DBG("%d bytes remaining", ctx->length);
 
 	if (ctx->length == 0) {
@@ -755,6 +784,15 @@ static void send_process_fc(struct isotp_send_ctx *ctx,
 		return;
 	}
 
+#ifdef CONFIG_ISOTP_ENABLE_TX_PADDING
+	/* AUTOSAR requirement SWS_CanTp_00349 */
+	if (frame->dlc != ISOTP_CAN_DL) {
+		LOG_ERR("FC DL invalid. Ignore");
+		send_report_error(ctx, ISOTP_N_ERROR);
+		return;
+	}
+#endif
+
 	switch (*data++ & ISOTP_PCI_FS_MASK) {
 	case ISOTP_PCI_FS_CTS:
 		ctx->state = ISOTP_TX_SEND_CF;
@@ -853,7 +891,13 @@ static inline int send_sf(struct isotp_send_ctx *ctx)
 	__ASSERT_NO_MSG(len <= ISOTP_CAN_DL - index);
 	memcpy(&frame.data[index], data, len);
 
+#ifdef CONFIG_ISOTP_ENABLE_TX_PADDING
+	/* AUTOSAR requirement SWS_CanTp_00348 */
+	memset(&frame.data[index + len], 0xCC, ISOTP_CAN_DL - len - index);
+	frame.dlc = ISOTP_CAN_DL;
+#else
 	frame.dlc = len + index;
+#endif
 
 	ctx->state = ISOTP_TX_SEND_SF;
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
@@ -926,9 +970,16 @@ static inline int send_cf(struct isotp_send_ctx *ctx)
 	rem_len = get_ctx_data_length(ctx);
 	len = MIN(rem_len, ISOTP_CAN_DL - index);
 	rem_len -= len;
-	frame.dlc = len + index;
 	data = get_data_ctx(ctx);
 	memcpy(&frame.data[index], data, len);
+
+#ifdef CONFIG_ISOTP_ENABLE_TX_PADDING
+	/* AUTOSAR requirement SWS_CanTp_00348 */
+	memset(&frame.data[index + len], 0xCC, ISOTP_CAN_DL - len - index);
+	frame.dlc = ISOTP_CAN_DL;
+#else
+	frame.dlc = len + index;
+#endif
 
 	ret = can_send(ctx->can_dev, &frame, K_MSEC(ISOTP_A),
 		       send_can_tx_isr, ctx);


### PR DESCRIPTION
This PR fixes some small issues and adds two new features to the ISO-TP implementation:

### Allow Padding in SF, FF and last CF

Some protocols including OBD require that CAN messages always have a length of 8 bytes, which requires padding in the ISO-TP implementation.

Similar to [AUTOSAR requirements](https://www.autosar.org/fileadmin/user_upload/standards/classic/19-11/AUTOSAR_SWS_CANTransportLayer.pdf), I added two build-time configuration flags that allow to activate padding in received and sent frames. If padding is activated for RX, a frame with length < 8 leads to an error, as specified in AUTOSAR. Otherwise, both types of frames are now accepted (default setting).

Padding is mandatory for CAN-FD, as the frame length cannot be adjusted to perfectly match the actual data. However, proper CAN-FD support will require some further modifications which are not part of this PR.

### Add support for fixed addressing

ISO 15765-2 specifies how to use ISO-TP for CAN ID layouts according to SAE J1939 and NMEA-2000, where a source (N_SA) and target address (N_TA) is encoded inside the ID (called "fixed addressing"):
```
 Format of 29-bit CAN identifier:
 ------------------------------------------------------
 | 28 .. 26 | 25  | 24 | 23 .. 16 | 15 .. 8  | 7 .. 0 |
 ------------------------------------------------------
 | Priority | EDP | DP | N_TAtype |   N_TA   |  N_SA  |
 ------------------------------------------------------
 ```
In order to support this message type, a CAN filter mask that ignores the source address and the priority during reception was added. In addition to that, FC frames are sent back to the correct source address with the same priority, which requires an automatic modification of the TX CAN ID.