### PR TITLE
drivers: display: add inversion support for ili9xxx displays

### DIFF
--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -343,6 +343,13 @@ static int ili9xxx_configure(const struct device *dev)
 		return r;
 	}
 
+	if (config->inversion) {
+		r = ili9xxx_transmit(dev, ILI9XXX_DINVON, NULL, 0U);
+		if (r < 0) {
+			return r;
+		}
+	}
+
 	r = config->regs_init_fn(dev);
 	if (r < 0) {
 		return r;
@@ -471,6 +478,7 @@ static const struct display_driver_api ili9xxx_api = {
 		.rotation = DT_PROP(INST_DT_ILI9XXX(n, t), rotation),          \
 		.x_resolution = ILI##t##_X_RES,                                \
 		.y_resolution = ILI##t##_Y_RES,                                \
+		.inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),\
 		.regs = &ili9xxx_regs_##n,                                     \
 		.regs_init_fn = ili##t##_regs_init,                            \
 	};                                                                     \

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -13,6 +13,7 @@
 
 /* Commands/registers. */
 #define ILI9XXX_SLPOUT 0x11
+#define ILI9XXX_DINVON 0x21
 #define ILI9XXX_GAMSET 0x26
 #define ILI9XXX_DISPOFF 0x28
 #define ILI9XXX_DISPON 0x29
@@ -67,6 +68,7 @@ struct ili9xxx_config {
 	uint16_t rotation;
 	uint16_t x_resolution;
 	uint16_t y_resolution;
+	bool inversion;
 	const void *regs;
 	int (*regs_init_fn)(const struct device *dev);
 };

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -46,3 +46,9 @@ properties:
         - 270
       description:
         Display rotation (CW) in degrees.
+
+    display-inversion:
+      type: boolean
+      description:
+        Display inversion mode. Every bit is inverted from the frame memory to
+        the display.


### PR DESCRIPTION
Add a new display-inversion property to ili9xxx based display drivers to
send a "Display Inversion ON (0x21)" command during initialization.

This seems to be required for some ILI9xxx based displays to work
correctly, such as BuyDisplay ER-TFT028A2-4 (ILI9341 basd IPS display).

Signed-off-by: Fabio Baltieri <fabio.baltieri@gmail.com>