### PR TITLE
docs: Application <BOARD>_<revision>.overlay description

### DIFF
--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -181,6 +181,9 @@ Here are some ways to set it:
 #. with the CMake ``set()`` command in the application ``CMakeLists.txt``,
    before including zephyr's :file:`boilerplate.cmake` file
 #. using a ``DTC_OVERLAY_FILE`` environment variable (deprecated)
+#. create a ``boards/<BOARD>_<revision>.overlay`` file in the application
+   folder for the current board revision. This requires that the board supports
+   multiple revisions, see :ref:`porting_board_revisions`.
 #. create a ``boards/<BOARD>.overlay`` file in the application
    folder, for the current board
 #. create a ``<BOARD>.overlay`` file in the application folder

--- a/doc/guides/porting/shields.rst
+++ b/doc/guides/porting/shields.rst
@@ -71,16 +71,19 @@ introduced overriding node element:
 Board specific shield configuration
 -----------------------------------
 
-If modifications are needed to fit a shield to a particular board, you can
-override a shield description for a specific board by adding board-overriding
-files to a shield, as follows:
+If modifications are needed to fit a shield to a particular board or board
+revision, you can override a shield description for a specific board by adding
+board or board revision overriding files to a shield, as follows:
 
 .. code-block:: none
 
    boards/shields/<shield>
    └── boards
+       ├── <board>_<revision>.overlay
        ├── <board>.overlay
-       └── <board>.defconfig
+       ├── <board>.defconfig
+       ├── <board>_<revision>.conf
+       └── <board>.conf
 
 
 Shield activation


### PR DESCRIPTION
This commit is a follow-up to #29990 with added board adjustment files
for shields and DTS overlay description.

It adds `boards/<BOARD>_<revision>.overlay` and
`boards/<BOARD>_<revision>.conf` to the list of files containing board
specific adjustments.
It also adds `<BOARD>.conf` to the documentation, as this has always
been supported but not described in shield docs.

It documents the possibility of using
`boards/<BOARD>_<revision>.overlay` files for DTS adjustments to
specific board revisions.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>