### PR TITLE
runners: fix nrfjprog UICR check

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -197,12 +197,19 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
         uicr = uicr_ranges[self.family]
 
-        if not self.force and has_region(uicr, self.hex_):
-            # Hex file has UICR contents.
+        if not self.uicr_data_ok and has_region(uicr, self.hex_):
+            # Hex file has UICR contents, and that's not OK.
             raise RuntimeError(
                 'The hex file contains data placed in the UICR, which '
                 'needs a full erase before reprogramming. Run west '
-                'flash again with --force or --erase.')
+                'flash again with --force, --erase, or --recover.')
+
+    @property
+    def uicr_data_ok(self):
+        # True if it's OK to try to flash even with UICR data
+        # in the image; False otherwise.
+
+        return self.force or self.erase or self.recover
 
     def recover_target(self):
         if self.family == 'NRF53':


### PR DESCRIPTION
It's fine to flash an image with UICR data as long as the user has
given any of the --erase, --recover, or --force options. Silence the
error correctly.
