### PR TITLE
MAINTAINERS.yml updates

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -156,7 +156,11 @@ Bluetooth:
         - include/bluetooth/
         - include/drivers/bluetooth/
         - samples/bluetooth/
-        - subsys/bluetooth/
+        - subsys/bluetooth/*
+        - subsys/bluetooth/common/
+        - subsys/bluetooth/host/
+        - subsys/bluetooth/services/
+        - subsys/bluetooth/shell/
         - tests/bluetooth/
     labels:
         - "area: Bluetooth"
@@ -182,6 +186,7 @@ Bluetooth Mesh:
     files:
         - subsys/bluetooth/mesh/
         - include/bluetooth/mesh/
+        - tests/bluetooth/mesh*/
     labels:
         - "area: Bluetooth Mesh"
 
@@ -193,9 +198,10 @@ Build system:
         - nashif
     files:
         - cmake/
-    files-regex:
-        - CMakeLists.txt$
-        - \.cmake$
+        - CMakeLists.txt
+        - scripts/zephyr_module.py
+        - doc/guides/build/
+        - doc/guides/modules.rst
     labels:
         - "area: Build System"
 
@@ -243,11 +249,30 @@ Debug:
     status: maintained
     maintainers:
         - nashif
+    collaborators:
+        - dcpleung
     files:
         - include/debug/
         - subsys/debug/
+        - tests/subsys/debug/
     labels:
         - "area: Debugging"
+
+Device Driver Model:
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - dcpleung
+        - nashif
+    files:
+        - include/device.h
+        - kernel/device.c
+        - include/init.h
+        - tests/kernel/device/
+        - doc/reference/drivers/
+    labels:
+        - "area: Device Model"
 
 DFU:
     status: maintained
@@ -270,8 +295,11 @@ Devicetree:
         - scripts/dts/
         - dts/bindings/
         - dts/common/
+        - tests/lib/devicetree/
+        - dts/bindings/test/
+        - doc/guides/dts/
     labels:
-        - "area: Device Tree"
+        - "area: Devicetree"
 
 Disk:
     status: orphaned
@@ -295,6 +323,7 @@ Display drivers:
         - include/drivers/display.h
         - lib/gui/
         - subsys/fb/
+        - samples/display/
     labels:
         - "area: Display"
 
@@ -304,11 +333,15 @@ Documentation:
         - carlescufi
     collaborators:
         - nashif
+        - utzig
     files:
-        - doc/
-    files-regex:
-        - \.rst$
-        - /doc/
+        - doc/*
+        - doc/static/
+        - doc/templates/
+        - doc/custom-doxygen/
+        - doc/scripts/
+        - README.rst
+        - Makefile
     labels:
         - "area: Documentation"
 
@@ -320,16 +353,22 @@ Documentation:
         - drivers/adc/
         - include/drivers/adc.h
         - tests/drivers/adc/
+        - samples/drivers/adc/
     labels:
         - "area: ADC"
 
 "Drivers: Audio":
     status: maintained
     maintainers:
-        - Vudentz
+        - andyross
+    collaborators:
+        - nashif
+        - lyakh
+        - lgirdwood
     files:
         - drivers/audio/
         - include/audio/
+        - samples/audio/
     labels:
         - "area: Audio"
 
@@ -342,10 +381,15 @@ Documentation:
         - karstenkoenig
     files:
         - drivers/can/
+        - include/canbus/
+        - subsys/canbus/
+        - subsys/net/l2/canbus/
+        - tests/subsys/canbus/
         - dts/bindings/can/
         - include/drivers/can.h
         - samples/drivers/can/
         - tests/drivers/can/
+        - samples/subsys/canbus/
     labels:
         - "area: CAN"
 
@@ -402,6 +446,7 @@ Documentation:
         - drivers/dac/
         - include/drivers/dac.h
         - tests/drivers/dac/
+        - samples/drivers/dac/
     labels:
         - "area: DAC"
 
@@ -439,7 +484,12 @@ Documentation:
         - "area: Crypto / RNG"
 
 "Drivers: ESPI":
-    status: orphaned
+    status: maintained
+    maintainers:
+      - albertofloyd
+    collaborators:
+      - VenkatKotakonda
+      - scottwcpg
     files:
         - drivers/espi/
         - include/drivers/espi.h
@@ -468,6 +518,7 @@ Documentation:
         - dts/bindings/flash_controller/
         - include/drivers/flash.h
         - samples/drivers/flash_shell/
+        - tests/drivers/flash/
     labels:
         - "area: Flash"
 
@@ -595,6 +646,9 @@ Documentation:
         - drivers/lora/
         - include/drivers/lora.h
         - samples/drivers/lora/
+        - include/lorawan/
+        - subsys/lorawan/
+        - samples/lorawan/
     labels:
         - "area: LoRa"
 
@@ -674,7 +728,10 @@ Documentation:
         - dcpleung
     files:
         - drivers/serial/
+        - include/drivers/uart.h
+        - include/drivers/uart/
         - dts/bindings/serial/
+        - tests/drivers/uart/
     labels:
         - "area: UART"
 
@@ -688,6 +745,8 @@ Documentation:
         - drivers/sensor/
         - include/drivers/sensor.h
         - samples/sensor/
+        - tests/drivers/sensor/
+        - dts/bindings/sensor/
     labels:
         - "area: Sensors"
 
@@ -771,7 +830,6 @@ Filesystems:
         - nashif
         - pabigot
         - vanwinkeljan
-        - wentongwu
     files:
         - include/fs/
         - samples/subsys/fs/
@@ -812,8 +870,22 @@ Kernel:
         - include/kernel*.h
         - kernel/
         - tests/kernel/
+        - include/sys_clock.h
     labels:
         - "area: Kernel"
+
+Base OS:
+    status: maintained
+    maintainers:
+        - andyross
+    collaborators:
+        - andrewboie
+        - nashif
+    files:
+        - include/sys/
+        - lib/os/
+    labels:
+        - "area: Base OS"
 
 Little FS:
     status: maintained
@@ -1015,11 +1087,15 @@ POSIX API layer:
 Power management:
     status: maintained
     maintainers:
-        - wentongwu
+        - ceolin
+    collaborators:
+        - nashif
+        - pabigot
     files:
         - include/power/power.h
         - samples/subsys/power/
         - subsys/power/
+        - tests/subsys/power/
     labels:
         - "area: Power Management"
 
@@ -1044,7 +1120,8 @@ Twister:
         - nashif
     files:
         - scripts/twister
-        - scripts/pylib/twister
+        - scripts/pylib/twister/
+        - scripts/tests/twister/
     labels:
         - "area: Twister"
 
@@ -1082,6 +1159,7 @@ Shields:
         - jfischer-no
     files:
         - boards/shields/
+        - doc/guides/porting/shields.rst
     labels:
         - "area: Shields"
 
@@ -1095,7 +1173,93 @@ SPARC arch:
     labels:
         - "area: SPARC"
 
-STM32:
+Synopsys Platforms:
+    status: maintained
+    maintainers:
+        - ruudw
+    collaborators:
+        - abrodkin
+        - evgeniy-paltsev
+        - IRISZZW
+    files:
+        - soc/arc/
+        - boards/arc/
+    labels:
+        - "platform: Synopsys"
+
+Intel Platforms (X86):
+    status: maintained
+    maintainers:
+        - jenmwms
+    collaborators:
+        - jhedberg
+        - aasthagr
+    files:
+        - boards/x86/
+        - soc/x86/
+    labels:
+        - "platform: X86"
+
+Intel Platforms (Xtensa):
+    status: maintained
+    maintainers:
+        - nashif
+    collaborators:
+        - andyross
+        - dcpleung
+    files:
+        - boards/xtensa/intel_*/
+        - soc/xtensa/intel_*/
+        - samples/boards/intel_s1000_crb/
+    labels:
+        - "platform: Intel CAVS"
+
+NXP Platforms:
+  status: maintained
+  maintainers:
+    - MaureenHelm
+  files:
+    - boards/arm/mimx*/
+    - boards/arm/frdm_k*/
+    - boards/arm/lpcxpress*/
+    - boards/arm/twr_*
+    - soc/arm/nxp_*/
+    - drivers/*/*imx*
+    - drivers/*/*lpc*
+    - drivers/*/*mcux*
+    - dts/arm/nxp/
+  labels:
+    - "platform: NXP"
+
+Microchip Platforms:
+  status: maintained
+  maintainers:
+    - scottwcpg
+  collaborators:
+    - VenkatKotakonda
+    - albertofloyd
+  files:
+    - boards/arm/mec*/
+    - dts/arm/microchip/
+    - soc/arm/microchip_mec/
+    - drivers/*/*mchp*
+  labels:
+    - "platform: Microchip"
+
+nRF Platforms:
+    status: maintained
+    maintainers:
+        - ioannisg
+    files:
+        - boards/arm/nrf*/
+        - drivers/*/*nrfx*
+        - soc/arm/nordic_nrf/
+        - samples/boards/nrf/
+        - dts/arm/nordic/
+    labels:
+        - "platform: nRF"
+
+STM32 Platforms:
     status: maintained
     maintainers:
         - erwango
@@ -1104,6 +1268,7 @@ STM32:
         - boards/arm/stm32*_disco/
         - boards/arm/stm32*_eval/
         - drivers/*/*stm32*/
+        - drivers/*/*stm32*
         - drivers/*/*/*stm32*
         - dts/arm/st/
         - dts/bindings/*/*stm32*
@@ -1140,11 +1305,12 @@ Tracing:
     status: maintained
     maintainers:
         - nashif
-    collaborators:
-        - wentongwu
     files:
         - subsys/tracing/
         - include/tracing/
+        - subsys/timing/
+        - samples/subsys/tracing/
+        - doc/guides/tracing/
     labels:
         - "area: tracing"
 
@@ -1173,6 +1339,10 @@ Userspace:
         - doc/reference/usermode/kernelobjects.rst
         - include/app_memory/
         - include/linker/app_smem*.ld
+        - tests/kernel/mem_protect/
+        - samples/userspace/
+        - include/syscall.h
+        - kernel/userspace*
     labels:
         - "area: Userspace"
 
@@ -1220,15 +1390,32 @@ Xtensa arch:
 x86 arch:
     status: maintained
     maintainers:
-        - ceolin
+        - jhedberg
     collaborators:
         - andyross
+        - nashif
+        - andrewboie
+        - ceolin
+        - jenmwms
+        - aasthagr
     files:
         - arch/x86/
         - include/arch/x86/
         - tests/arch/x86/
     labels:
         - "area: X86"
+
+CI:
+    status: maintained
+    maintainers:
+        - nashif
+        - galak
+    files:
+        - .github/
+        - .buildkite/
+        - scripts/ci/
+    labels:
+        - "area: Continuous Integration"
 
 ZTest:
     status: maintained

--- a/doc/contribute/project_roles.rst
+++ b/doc/contribute/project_roles.rst
@@ -175,10 +175,8 @@ MAINTAINERS File
 
 Generic guidelines for deciding and filling in the Maintainers' list
 
-* The MAINTAINERS file shall coexist with the CODEOWNERS file.
-  MAINTAINERS file is used to set assignees, CODEOWNERS file is used for
-  more granularity and to add reviewers down to the file level.
-  CODEOWNERS file entries do not signify maintainership.
+* The MAINTAINERS file shall replace the CODEOWNERS file and will be used
+  for both setting assignees and reviewers.
 * We should keep the granularity of code maintainership at a manageable level
 * We should be looking for maintainers for areas of code that
   are orphaned (i.e. without an explicit maintainer)

--- a/doc/contribute/project_roles.rst
+++ b/doc/contribute/project_roles.rst
@@ -194,7 +194,17 @@ Generic guidelines for deciding and filling in the Maintainers' list
 
   * Re-assigned by original assignee (see “Assignee” slide)
 
-* Updates to the MAINTAINERS file should be in a standalone PRs
+* In general, updates to the MAINTAINERS file should be
+  in a standalone commit alongside other changes introducing new files and
+  directories to the tree.
+* Major changes to the file, including the addition of new areas with new maintainers
+  should come in as standalone pull-requests and require TSC review.
+* If additional review by the TSC is required, the maintainers of the file
+  should send the requested changes to the TSC and give members of the TSC two
+  (2) days to object to any of the changes to maintainership of areas or the
+  addition of new maintainers or areas.
+* Path, collaborator and name changes do not require a review by the TSC.
+* Addition of new areas without a maintainer do not require review by the TSC.
 * The MAINTAINERS file itself shall have a maintainer
 * Architectures, core components, sub-systems, samples, tests
 


### PR DESCRIPTION
The changes here are the result of running all open pull-requests through a script to identify the assignee and finding many gaps or old data. Some of the changes here are coming from pending PRs that were waiting for some TSC confirmation, others are done based on pending maintainer and collaborator changes that were not submitting yet.

Two noteable changes:

- CMake/Build system: This is now limited to just the infrastructure and not every single Cmake file in the tree.
- Documentation: ditto, this is just for the doc infrastructure and not for every RST file in the tree.

The reason for the above two changes is the fact that most PRs would have some cmake or doc changes and assignees in this case should not be the owners of the build system or the doc infra, instead we should assign to the subsystem being changed. (Otherwise majority of PRs would be assigned to the doc and build system maintainers).