### PR TITLE
driver: i2c: npcx: Convert drivers to new DT device macros

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -874,7 +874,7 @@ static int i2c_ctrl_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),		                       \
 			DT_INST_IRQ(inst, priority),                           \
 			i2c_ctrl_isr,                                          \
-			DEVICE_GET(i2c_ctrl_##inst),                           \
+			DEVICE_DT_INST_GET(inst),                              \
 			0);                                                    \
 		irq_enable(DT_INST_IRQN(inst));                                \
 									       \
@@ -893,8 +893,9 @@ static int i2c_ctrl_init(const struct device *dev)
 									       \
 	static struct i2c_ctrl_data i2c_ctrl_data_##inst;                      \
 									       \
-	DEVICE_AND_API_INIT(i2c_ctrl_##inst, DT_INST_LABEL(inst),              \
+	DEVICE_DT_INST_DEFINE(inst,                                            \
 			    NPCX_I2C_CTRL_INIT_FUNC(inst),                     \
+			    device_pm_control_nop,                             \
 			    &i2c_ctrl_data_##inst, &i2c_ctrl_cfg_##inst,       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    NULL);                                             \

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -172,8 +172,9 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 									       \
 	static struct i2c_npcx_port_data i2c_npcx_port_data_##inst;            \
 									       \
-	DEVICE_AND_API_INIT(i2c_npcx_port_##inst, DT_INST_LABEL(inst),         \
+	DEVICE_DT_INST_DEFINE(inst,                                            \
 			    NPCX_I2C_PORT_INIT_FUNC(inst),                     \
+			    device_pm_control_nop,                             \
 			    &i2c_npcx_port_data_##inst,                        \
 			    &i2c_npcx_port_cfg_##inst,                         \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \


### PR DESCRIPTION
Convert i2c npcx drivers from:

DEVICE_AND_API_INIT -> DEVICE_DT_DEFINE
DEVICE_GET -> DEVICE_DT_GET

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>