### PR TITLE
drivers: flash: spi_nor: correct log message

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -647,7 +647,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 	struct jesd216_erase_type *etp = data->erase_types;
 	const size_t flash_size = jesd216_bfp_density(bfp) / 8U;
 
-	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 23));
+	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 20));
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)


### PR DESCRIPTION
Flash size is specified in bits by SFDP and devicetree, but the stored
flash size is in bytes.  Correct the divisor.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>