### PR TITLE
device: deprecate DEVICE_AND_API_INIT

### DIFF
--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -431,9 +431,9 @@ using instance numbers. Do this after defining ``my_api_funcs``.
    	static const struct my_dev_cfg my_cfg_##inst = {		\
    		/* initialize ROM values as needed. */			\
    	};								\
-   	DEVICE_AND_API_INIT(my_dev_##inst,				\
-   			    DT_INST_LABEL(inst),			\
+   	DEVICE_DT_INST_DEFINE(inst,					\
    			    my_dev_init_function,			\
+   			    device_pm_control_nop,                      \
    			    &my_data_##inst,				\
    			    &my_cfg_##inst,				\
    			    MY_DEV_INIT_LEVEL, MY_DEV_INIT_PRIORITY,	\
@@ -508,9 +508,9 @@ devicetree to operate on specific device nodes:
 		.freq = DT_PROP(MYDEV(idx), clock_frequency),		\
 	};								\
 	static const struct my_dev_cfg my_cfg_##idx = { /* ... */ };	\
-	DEVICE_AND_API_INIT(my_dev_##idx,				\
-			    DT_LABEL(MYDEV(idx)),			\
+	DEVICE_DT_INST_DEFINE(idx,					\
 			    my_dev_init_function,			\
+			    device_pm_control_nop,                      \
 			    &my_data_##idx,				\
 			    &my_cfg_##idx,				\
 			    MY_DEV_INIT_LEVEL, MY_DEV_INIT_PRIORITY,	\

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -72,10 +72,6 @@ applications.
    Create device object and related data structures including setting it
    up for boot-time initialization.
 
-:c:func:`DEVICE_AND_API_INIT()`
-   Like :c:func:`DEVICE_DEFINE()` but without support for device power
-   management.
-
 :c:func:`DEVICE_NAME_GET()`
    Converts a device identifier to the global identifier for a device
    object.
@@ -175,7 +171,7 @@ of these APIs, and populate an instance of subsystem_api structure:
   };
 
 The driver would then pass ``my_driver_api_funcs`` as the ``api`` argument to
-``DEVICE_AND_API_INIT()``.
+``DEVICE_DEFINE()``.
 
 .. note::
 
@@ -329,9 +325,9 @@ Then when the particular instance is declared:
 
   static struct my_data_0;
 
-  DEVICE_AND_API_INIT(my_driver_0, MY_DRIVER_0_NAME, my_driver_init,
-                      &my_data_0, &my_driver_config_0, POST_KERNEL,
-                      MY_DRIVER_0_PRIORITY, &my_api_funcs);
+  DEVICE_DEFINE(my_driver_0, MY_DRIVER_0_NAME, my_driver_init,
+                device_pm_control_nop, &my_data_0, &my_driver_config_0,
+                POST_KERNEL, MY_DRIVER_0_PRIORITY, &my_api_funcs);
 
   #endif /* CONFIG_MY_DRIVER_0 */
 

--- a/doc/reference/networking/net_l2.rst
+++ b/doc/reference/networking/net_l2.rst
@@ -74,7 +74,7 @@ There are, however, two differences:
 
 - The network device driver must use :c:macro:`NET_DEVICE_INIT_INSTANCE()`
   or :c:macro:`ETH_NET_DEVICE_INIT()` for Ethernet devices. These
-  macros will call the :c:macro:`DEVICE_AND_API_INIT()` macro, and also
+  macros will call the :c:macro:`DEVICE_DEFINE()` macro, and also
   instantiate a unique :c:struct:`net_if` related to the created
   device driver instance.
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -62,6 +62,9 @@ Deprecated in this release
 
 * DEVICE_INIT was deprecated in favor of utilizing DEVICE_DEFINE directly.
 
+* DEVICE_AND_API_INIT was deprecated in favor of DEVICE_DT_INST_DEFINE and
+  DEVICE_DEFINE.
+
 Removed APIs in this release
 ============================
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1997,7 +1997,6 @@ PREDEFINED             = "CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT" \
                          "CONFIG_USE_SWITCH" \
                          "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \
                          "DEVICE_DEFINE()=" \
-                         "DEVICE_AND_API_INIT()=" \
                          "BUILD_ASSERT_MSG()=" \
                          "BUILD_ASSERT()=" \
                          "__deprecated=" \

--- a/include/device.h
+++ b/include/device.h
@@ -80,6 +80,7 @@ extern "C" {
  */
 #define DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,		\
 			    data_ptr, cfg_ptr, level, prio, api_ptr)	\
+	__DEPRECATED_MACRO						\
 	DEVICE_DEFINE(dev_name, drv_name, init_fn,			\
 		      NULL,						\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)
@@ -95,8 +96,7 @@ extern "C" {
  * @details This macro defines a device object that is automatically
  * configured by the kernel during system initialization. Note that
  * devices set up with this macro will not be accessible from user mode
- * since the API is not specified; whenever possible, use DEVICE_AND_API_INIT
- * instead.
+ * since the API is not specified;
  *
  * @param dev_name Device name. This must be less than Z_DEVICE_MAX_NAME_LEN
  * characters in order to be looked up from user mode with device_get_binding().

--- a/include/init.h
+++ b/include/init.h
@@ -67,7 +67,7 @@ void z_sys_init_run_level(int32_t _level);
  * configured by the kernel during system initialization. Note that
  * init entries will not be accessible from user mode. Also this macro should
  * not be used directly, use relevant macro such as SYS_INIT() or
- * DEVICE_AND_API_INIT() instead.
+ * DEVICE_DEFINE() instead.
  *
  * @param _entry_name Init entry name. It is the name this instance exposes to
  * the system.


### PR DESCRIPTION
Make DEVICE_AND_API_INIT deprecated in favor of DEVICE_DT_INST_DEFINE
or DEVICE_DEFINE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>