### PR TITLE
drivers/timer: stm32_lptim: Fix stm32 ll header list

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -10,6 +10,7 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/timer/system_timer.h>


### PR DESCRIPTION
LPTIM stm32 ll header list was not adequate for debug builds.
Add _system.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>