### PR TITLE
Add a special internal API to unlock spinlock without key and provide an example of it's usage

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -8,14 +8,19 @@
 
 ZTEST_BMEM volatile bool valid_fault;
 
+extern void post_fatal_error_hook(unsigned int reason, const z_arch_esf_t *pEsf);
+
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	printk("Caught system error -- reason %d %d\n", reason, valid_fault);
 	if (valid_fault) {
 		printk("fatal error expected as part of test case\n");
 		valid_fault = false; /* reset back to normal */
+
+		post_fatal_error_hook(reason, pEsf);
 	} else {
 		printk("fatal error was unexpected, aborting\n");
 		k_fatal_halt(reason);
 	}
+
 }

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -34,6 +34,7 @@ void test_main(void)
 		ztest_unit_test(test_mem_domain_boot_threads),
 		ztest_unit_test(test_mem_domain_migration),
 		ztest_unit_test(test_mem_part_overlap),
+		ztest_unit_test(test_mem_domain_error_case_spin_unlock),
 
 		/* mem_partition.c */
 		ztest_user_unit_test(test_mem_part_assign_bss_vars_zero),

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -21,6 +21,7 @@ extern void test_mem_domain_remove_add_partition(void);
 extern void test_mem_domain_api_supervisor_only(void);
 extern void test_mem_domain_boot_threads(void);
 extern void test_mem_domain_migration(void);
+extern void test_mem_domain_error_case_spin_unlock(void);
 
 extern void test_macros_obtain_names_data_bss(void);
 extern void test_mem_part_assign_bss_vars_zero(void);


### PR DESCRIPTION
This is in order to deal with a special test case scenario, we need to unlock spinlock without it's key. For example, when an assertion failed after spinlock has been held. This make sure the error case testing won't affect our environment.
So this PR make some change on spinlock structure (stored it's key value) and provide a dedicate internal API k_spin_unlock_without_key().

The second commit is an error test case example  that assert fail happened after the spinlock was held. Then we call k_spin_unlock_without_key() API to unlock it.
