### PR TITLE
Bluetooth: Define assigned number values of BIGInfo and Broadcast Code

### DIFF
--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -53,6 +53,8 @@ extern "C" {
 #define BT_DATA_MESH_PROV               0x29 /* Mesh Provisioning PDU */
 #define BT_DATA_MESH_MESSAGE            0x2a /* Mesh Networking PDU */
 #define BT_DATA_MESH_BEACON             0x2b /* Mesh Beacon */
+#define BT_DATA_BIG_INFO                0x2c /* BIGInfo */
+#define BT_DATA_BROADCAST_CODE          0x2d /* Broadcast Code */
 
 #define BT_DATA_MANUFACTURER_DATA       0xff /* Manufacturer Specific Data */
 


### PR DESCRIPTION
Add defines for assigned number values of BIGInfo and
Broadcast Code.

Refer to https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>