### PR TITLE
boards: nordic: remove unnecessary nrfjprog.py args

### DIFF
--- a/boards/arm/rak5010_nrf52840/board.cmake
+++ b/boards/arm/rak5010_nrf52840/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 Guillaume Paquet <guillaume.paquet@smile.fr>
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -463,7 +463,6 @@ example :file:`board.cmake`:
 
 .. code-block:: cmake
 
-   board_runner_args(nrfjprog "--nrf-family=NRF52")
    board_runner_args(jlink "--device=nrf52" "--speed=4000")
    board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/board.cmake
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
The --nrf-family argument has been unnnecessary since 6628a16
(" runners: nrfjprog: boilerplate and recover rework").

Remove a few stragglers that are still using it, to avoid it being
copy/pasted into other board definitions.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>