### PR TITLE
boards: nrf: remove misleading DT overlay docs

### DIFF
--- a/boards/arm/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/arm/bl653_dvk/doc/bl653_dvk.rst
@@ -194,12 +194,6 @@ more than one UART for connecting peripheral devices:
 
 2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
 
-Overlay file naming
-===================
-
-The file has to be named ``<board>.overlay`` and placed in the app main directory to be
-picked up automatically by the build system.
-
 See :ref:`set-devicetree-overlays` for further details.
 
 Selecting the pins

--- a/boards/arm/nrf21540dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf21540dk_nrf52840/doc/index.rst
@@ -200,11 +200,7 @@ more than one UART for connecting peripheral devices:
 
 2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
 
-Overlay file naming
-===================
-
-The file has to be named ``<board>.overlay`` and placed in the app main directory to be
-picked up automatically by the build system.
+See :ref:`set-devicetree-overlays` for further details.
 
 Selecting the pins
 ==================

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -181,11 +181,7 @@ more than one UART for connecting peripheral devices:
 
 2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
 
-Overlay file naming
-===================
-
-The file has to be named ``<board>.overlay`` and placed in the app main directory to be
-picked up automatically by the build system.
+See :ref:`set-devicetree-overlays` for further details.
 
 Selecting the pins
 ==================

--- a/boards/arm/nrf52840dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52840/doc/index.rst
@@ -188,11 +188,7 @@ more than one UART for connecting peripheral devices:
 
 2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
 
-Overlay file naming
-===================
-
-The file has to be named ``<board>.overlay`` and placed in the app main directory to be
-picked up automatically by the build system.
+See :ref:`set-devicetree-overlays` for further details.
 
 Selecting the pins
 ==================

--- a/boards/arm/pinnacle_100_dvk/doc/index.rst
+++ b/boards/arm/pinnacle_100_dvk/doc/index.rst
@@ -208,15 +208,6 @@ You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
 :zephyr_file:`boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts`.
 
-
-Overlay file naming
-===================
-
-The file has to be named ``<board>.overlay`` and placed in the app main directory to be
-picked up automatically by the build system.
-
-See :ref:`set-devicetree-overlays` for further details.
-
 Selecting the pins
 ==================
 To select the pin numbers for tx-pin and rx-pin:


### PR DESCRIPTION
Replace these with links to the actual documentation as needed, or
just remove them entirely. These are getting copy/pasted around and
I'm trying to avoid that happening in the future.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>