### PR TITLE
Bluetooth: controller: Fixed conn_meta bitflag misalignment

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -67,6 +67,9 @@ struct ll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
 			uint8_t  fex_valid:1;
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t  is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t  latency_cancel:1;
 			uint8_t  sca:3;
 			uint32_t force;
@@ -77,6 +80,9 @@ struct ll_conn {
 #if defined(CONFIG_BT_CENTRAL)
 		struct {
 			uint8_t fex_valid:1;
+#if defined(CONFIG_BT_CTLR_CONN_META)
+			uint8_t is_must_expire:1;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t terminate_ack:1;
 		} master;
 #endif /* CONFIG_BT_CENTRAL */


### PR DESCRIPTION
Fixed misalignment of bitflag in ll_conn type causing unintentional
overwrite between unions. Common flag must be present in master/slave
uinons as well. Problem is only present when enabling feature
CONFIG_BT_CTLR_CONN_META, which is default disabled.

Signed-off-by: Morten Priess <mtpr@oticon.com>