### PR TITLE
FatFs: add support for file systems on devicetree partition 

### DIFF
--- a/dts/bindings/fs/zephyr,fstab,fatfs.yaml
+++ b/dts/bindings/fs/zephyr,fstab,fatfs.yaml
@@ -1,0 +1,11 @@
+# Copyright (C) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Description of pre-defined FatFs file systems.
+
+compatible: "zephyr,fstab,fatfs"
+
+include: "zephyr,fstab-common.yaml"
+
+# FatFs does not support filesystem-specific configuration

--- a/dts/bindings/fs/zephyr,fstab,littlefs.yaml
+++ b/dts/bindings/fs/zephyr,fstab,littlefs.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Description of pre-defined file systems.
+    Description of pre-defined littlefs file systems.
 
 compatible: "zephyr,fstab,littlefs"
 


### PR DESCRIPTION
This was intended to make it possible to describe FatFs file systems in devicetree.  It fails, because FatFs uses the disk_access API, which supports only one underlying storage device, and identifies it and all of its attributes through Kconfig.

Zephyr's FatFs support needs to be brought into the current century before this can actually go anywhere.  I'm not planning to work that unless it becomes a priority.