### PR TITLE
linker: arm: Fix and enhance Cortex-M TCM support

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
+		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &dtcm;
+		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,sram = &sdram0;
+		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -351,6 +351,8 @@ the source code to specify a device name.
      - A node whose ``reg`` is used by the OpenAMP subsystem to determine the
        base address and size of the shared memory (SHM) usable for
        interprocess-communication (IPC)
+   * - zephyr,itcm
+     - Instruction Tightly Coupled Memory node on some Arm SoCs
    * - zephyr,shell-uart
      - Sets default :option:`CONFIG_UART_SHELL_ON_DEV_NAME`
    * - zephyr,sram

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -66,6 +66,16 @@
 #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
+#define CCM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_ccm))
+#define CCM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_ccm))
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
+#define DTCM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_dtcm))
+#define DTCM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_dtcm))
+#endif
+
 #if defined(CONFIG_CUSTOM_SECTION_ALIGN)
 _region_min_align = CONFIG_CUSTOM_SECTION_MIN_ALIGN_SIZE;
 #else
@@ -96,10 +106,10 @@ MEMORY
     FLASH_CCFG            (rwx): ORIGIN = CCFG_ADDR, LENGTH = CCFG_SIZE
 #endif
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
-    CCM                   (rw) : ORIGIN = DT_REG_ADDR(DT_CHOSEN(zephyr_ccm)), LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_ccm))
+    CCM                   (rw) : ORIGIN = CCM_ADDR, LENGTH = CCM_SIZE
 #endif
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
-    DTCM                  (rw) : ORIGIN = DT_REG_ADDR(DT_CHOSEN(zephyr_dtcm)), LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_dtcm))
+    DTCM                  (rw) : ORIGIN = DTCM_ADDR, LENGTH = DTCM_SIZE
 #endif
     SRAM                  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
 #ifdef CONFIG_BT_STM32_IPM
@@ -418,27 +428,25 @@ GROUP_START(DTCM)
 		__dtcm_bss_start = .;
 		*(.dtcm_bss)
 		*(".dtcm_bss.*")
+		__dtcm_bss_end = .;
 	} GROUP_LINK_IN(DTCM)
-
-	__dtcm_bss_end = .;
 
 	SECTION_PROLOGUE(_DTCM_NOINIT_SECTION_NAME, (NOLOAD),SUBALIGN(4))
 	{
 		__dtcm_noinit_start = .;
 		*(.dtcm_noinit)
 		*(".dtcm_noinit.*")
+		__dtcm_noinit_end = .;
 	} GROUP_LINK_IN(DTCM)
-
-	__dtcm_noinit_end = .;
 
 	SECTION_PROLOGUE(_DTCM_DATA_SECTION_NAME,,SUBALIGN(4))
 	{
 		__dtcm_data_start = .;
 		*(.dtcm_data)
 		*(".dtcm_data.*")
+		__dtcm_data_end = .;
 	} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)
 
-	__dtcm_data_end = .;
 	__dtcm_end = .;
 
 	__dtcm_data_rom_start = LOADADDR(_DTCM_DATA_SECTION_NAME);

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -71,6 +71,11 @@
 #define CCM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_ccm))
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+#define ITCM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_itcm))
+#define ITCM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_itcm))
+#endif
+
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 #define DTCM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_dtcm))
 #define DTCM_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_dtcm))
@@ -107,6 +112,9 @@ MEMORY
 #endif
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
     CCM                   (rw) : ORIGIN = CCM_ADDR, LENGTH = CCM_SIZE
+#endif
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+    ITCM                  (rw) : ORIGIN = ITCM_ADDR, LENGTH = ITCM_SIZE
 #endif
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
     DTCM                  (rw) : ORIGIN = DTCM_ADDR, LENGTH = DTCM_SIZE
@@ -418,6 +426,23 @@ SECTIONS
     __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
     GROUP_END(RAMABLE_REGION)
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+GROUP_START(ITCM)
+
+	SECTION_PROLOGUE(_ITCM_SECTION_NAME,,SUBALIGN(4))
+	{
+		__itcm_start = .;
+		*(.itcm)
+		*(".itcm.*")
+		__itcm_end = .;
+	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
+
+	__itcm_size = __itcm_end - __itcm_start;
+	__itcm_rom_start = LOADADDR(_ITCM_SECTION_NAME);
+
+GROUP_END(ITCM)
+#endif
 
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 GROUP_START(DTCM)

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -230,6 +230,13 @@ extern char __ccm_noinit_end[];
 extern char __ccm_end[];
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+extern char __itcm_start[];
+extern char __itcm_end[];
+extern char __itcm_size[];
+extern char __itcm_rom_start[];
+#endif
+
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 extern char __dtcm_data_start[];
 extern char __dtcm_data_end[];

--- a/include/linker/section_tags.h
+++ b/include/linker/section_tags.h
@@ -23,6 +23,7 @@
 #define __ccm_data_section Z_GENERIC_SECTION(_CCM_DATA_SECTION_NAME)
 #define __ccm_bss_section Z_GENERIC_SECTION(_CCM_BSS_SECTION_NAME)
 #define __ccm_noinit_section Z_GENERIC_SECTION(_CCM_NOINIT_SECTION_NAME)
+#define __itcm_section Z_GENERIC_SECTION(_ITCM_SECTION_NAME)
 #define __dtcm_data_section Z_GENERIC_SECTION(_DTCM_DATA_SECTION_NAME)
 #define __dtcm_bss_section Z_GENERIC_SECTION(_DTCM_BSS_SECTION_NAME)
 #define __dtcm_noinit_section Z_GENERIC_SECTION(_DTCM_NOINIT_SECTION_NAME)

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -43,6 +43,8 @@
 #define _CCM_BSS_SECTION_NAME		.ccm_bss
 #define _CCM_NOINIT_SECTION_NAME	.ccm_noinit
 
+#define _ITCM_SECTION_NAME		.itcm
+
 #define _DTCM_DATA_SECTION_NAME	.dtcm_data
 #define _DTCM_BSS_SECTION_NAME		.dtcm_bss
 #define _DTCM_NOINIT_SECTION_NAME	.dtcm_noinit

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -35,6 +35,10 @@ void z_data_copy(void)
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
 		 __ccm_data_end - __ccm_data_start);
 #endif
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+	(void)memcpy(&__itcm_start, &__itcm_rom_start,
+		 (uintptr_t) &__itcm_size);
+#endif
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 	(void)memcpy(&__dtcm_data_start, &__dtcm_data_rom_start,
 		 __dtcm_data_end - __dtcm_data_start);

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -17,9 +17,6 @@ MEMORY
 #if (DT_REG_SIZE(DT_NODELABEL(sdram0)) > 0) && !IS_CHOSEN_SRAM(sdram0)
         SDRAM  (wx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(sdram0)), LENGTH = DT_REG_SIZE(DT_NODELABEL(sdram0))
 #endif
-#if (DT_REG_SIZE(DT_INST(0, nxp_imx_itcm)) > 0) && !defined(CONFIG_CODE_ITCM)
-        ITCM    (wx) : ORIGIN = DT_REG_ADDR(DT_INST(0, nxp_imx_itcm)), LENGTH = DT_REG_SIZE(DT_INST(0, nxp_imx_itcm))
-#endif
      }
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/st_stm32/common/ccm.ld
+++ b/soc/arm/st_stm32/common/ccm.ld
@@ -8,27 +8,25 @@ GROUP_START(CCM)
 		__ccm_bss_start = .;
 		*(.ccm_bss)
 		*(".ccm_bss.*")
+		__ccm_bss_end = .;
 	} GROUP_LINK_IN(CCM)
-
-	__ccm_bss_end = .;
 
 	SECTION_PROLOGUE(_CCM_NOINIT_SECTION_NAME, (NOLOAD),SUBALIGN(4))
 	{
 		__ccm_noinit_start = .;
 		*(.ccm_noinit)
 		*(".ccm_noinit.*")
+		__ccm_noinit_end = .;
 	} GROUP_LINK_IN(CCM)
-
-	__ccm_noinit_end = .;
 
 	SECTION_PROLOGUE(_CCM_DATA_SECTION_NAME,,SUBALIGN(4))
 	{
 		__ccm_data_start = .;
 		*(.ccm_data)
 		*(".ccm_data.*")
+		__ccm_data_end = .;
 	} GROUP_LINK_IN(CCM AT> ROMABLE_REGION)
 
-	__ccm_data_end = .;
 	__ccm_end = .;
 
 	__ccm_data_rom_start = LOADADDR(_CCM_DATA_SECTION_NAME);


### PR DESCRIPTION
Fixes the Cortex-M DTCM linker section to work with relocation using scripts/gen_relocate_app.py

Adds support for the Cortex-M ITCM linker section.

This is in preparation for extending #31034 to support XIP.