### PR TITLE
doc: kernel: other: ring_buffers: Add Kconfig option description

### DIFF
--- a/doc/reference/kernel/other/ring_buffers.rst
+++ b/doc/reference/kernel/other/ring_buffers.rst
@@ -301,6 +301,13 @@ operations on the ring buffer's memory.  For example:
 	...
     }
 
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :option:`CONFIG_RING_BUFFER`: Enable ring buffer.
+
 API Reference
 *************
 


### PR DESCRIPTION
Added section with configuration options.

Fixes #30183.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>