### PR TITLE
MAINTAINERS: fix syntax

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1042,7 +1042,7 @@ Twister:
         - nashif
     files:
         - scripts/twister
-        - scripts/pylib/twister
+        - scripts/pylib/twister/
     labels:
         - "area: Twister"
 


### PR DESCRIPTION
Add missing trailing / in directory

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

-------------

```
./scripts/get_maintainer.py: error: zephyr/MAINTAINERS.yml: glob pattern 'scripts/pylib/twister' in 'files' in area 'Twister' matches a directory, but has no trailing '/'
```
