### PR TITLE
scripts: modules: support west group feature

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -277,9 +277,15 @@ def main():
         # if user is providing a specific modules list.
         from west.manifest import Manifest
         from west.util import WestNotFound
+        from west.version import __version__ as WestVersion
+        from packaging import version
         try:
             manifest = Manifest.from_file()
-            projects = [p.posixpath for p in manifest.get_projects([])]
+            if version.parse(WestVersion) >= version.parse('0.9.0'):
+                projects = [p.posixpath for p in manifest.get_projects([])
+                            if manifest.is_active(p)]
+            else:
+                projects = [p.posixpath for p in manifest.get_projects([])]
         except WestNotFound:
             # Only accept WestNotFound, meaning we are not in a west
             # workspace. Such setup is allowed, as west may be installed


### PR DESCRIPTION
West has introduced support for group tags in:
https://github.com/zephyrproject-rtos/west/pull/454

This means that manifest files might start containing groups.
Zephyr itself only requires west>=0.7.2 where groups are not supported
but other Zephyr based projects might start using the group feature.

When using a west version with group support, then only active projects
will be processed as Zephyr modules.

West versions without group support will consider all projects active.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>