### PR TITLE
dts: silabs: Fix minor soc dts issues

### DIFF
--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -128,7 +128,7 @@
 		gpio: gpio@4000a400 {
 			compatible = "silabs,gecko-gpio";
 			reg = <0x4000a400 0xf00>;
-			interrupts = <1 2 11 2>;
+			interrupts = <10 2 18 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
 			label = "GPIO";
 

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -225,32 +225,32 @@
 				#gpio-cells = <2>;
 				status = "disabled";
 			};
+		};
 
-			wdog0: wdog@40052000 {
-				compatible = "silabs,gecko-wdog";
-				reg = <0x40052000 0x2C>;
-				peripheral-id = <0>;
-				label = "WDOG0";
-				interrupts = <2 0>;
-				status = "disabled";
-			};
+		wdog0: wdog@40052000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x40052000 0x2C>;
+			peripheral-id = <0>;
+			label = "WDOG0";
+			interrupts = <2 0>;
+			status = "disabled";
+		};
 
-			wdog1: wdog@40052400 {
-				compatible = "silabs,gecko-wdog";
-				reg = <0x40052400 0x2C>;
-				peripheral-id = <1>;
-				label = "WDOG1";
-				interrupts = <3 0>;
-				status = "disabled";
-			};
+		wdog1: wdog@40052400 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x40052400 0x2C>;
+			peripheral-id = <1>;
+			label = "WDOG1";
+			interrupts = <3 0>;
+			status = "disabled";
+		};
 
-			trng0: trng@4001d000 {
-				compatible = "silabs,gecko-trng";
-				reg = <0x4001d000 0x400>;
-				interrupts = <49 0>;
-				label = "TRNG0";
-				status = "disabled";
-			};
+		trng0: trng@4001d000 {
+			compatible = "silabs,gecko-trng";
+			reg = <0x4001d000 0x400>;
+			interrupts = <49 0>;
+			label = "TRNG0";
+			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -289,15 +289,14 @@
 				#gpio-cells = <2>;
 				status = "disabled";
 			};
+		};
 
-
-			trng0: trng@4001d000 {
-				compatible = "silabs,gecko-trng";
-				reg = <0x4001d000 0x400>;
-				interrupts = <66 0>;
-				label = "TRNG0";
-				status = "disabled";
-			};
+		trng0: trng@4001d000 {
+			compatible = "silabs,gecko-trng";
+			reg = <0x4001d000 0x400>;
+			interrupts = <66 0>;
+			label = "TRNG0";
+			status = "disabled";
 		};
 
 		wdog0: wdog@40052000 {

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -127,7 +127,7 @@
 		gpio: gpio@4000a400 {
 			compatible = "silabs,gecko-gpio";
 			reg = <0x4000a400 0xc00>;
-			interrupts = <9 2 17 2>;
+			interrupts = <10 2 18 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
 			label = "GPIO";
 


### PR DESCRIPTION
1. The gpio interrupt numbers were wrong for the efm32jg12b, efm32pg12b and efr32mg. This had no effect, since these device tree properties are not used by the gpio driver. Instead the hard-coded defines from the hal are used there, see https://github.com/zephyrproject-rtos/zephyr/blob/master/drivers/gpio/gpio_gecko.c#L292

2. Some unrelated node were nested inside the gpio node. This seems to have no effect and no script/tool noticed it.