### PR TITLE
west.yml: Update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 8e132fee9794fcc8b809f3d7479b17031c156317
+      revision: db3d1ae2b8e319fc2cf9f628daf0a9d1628af104
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This manifest update corresponds to [PR#77](https://github.com/zephyrproject-rtos/hal_nordic/pull/77) into hal_nordic sub-repo, that provide the following commit: 

- drivers: nrf_radio_802154: Add callout for custom initialization part
This commit introduces nrf_802154_custom_part_of_radio_init callout.
Application can override weak empty implementation to provide some additional
operations to be performed at the beginning of each new timeslot.