### PR TITLE
scripts: module: support for name field in zephyr/module.yml

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -404,6 +404,35 @@ Module yaml file description
 A module can be described using a file named :file:`zephyr/module.yml`.
 The format of :file:`zephyr/module.yml` is described in the following:
 
+Module name
+===========
+
+Each Zephyr module is given a name by which it can be referred to in the build
+system.
+
+The name may be specified in the :file:`zephyr/module.yml` file:
+
+.. code-block:: yaml
+
+   name: <name>
+
+In CMake the location of the Zephyr module can then be referred to using the
+CMake variable ``ZEPHYR_<MODULE_NAME>_MODULE_DIR`` and the variable
+``ZEPHYR_<MODULE_NAME>_CMAKE_DIR`` holds the location of the directory
+containing the module's :file:`CMakeLists.txt` file.
+
+Here is an example for the Zephyr module ``foo``:
+
+.. code-block:: yaml
+
+   name: foo
+
+.. note::
+   If the ``name`` field is not specified then the Zephyr module name will be
+   set to the name of the module folder.
+   As example, the Zephyr module located in :file:`<workspace>/modules/bar` will
+   use ``bar`` as its module name if nothing is specified in
+   :file:`zephyr/module.yml`.
 
 Module integration files (in-module)
 ====================================
@@ -440,10 +469,10 @@ When a module has a :file:`module.yml` file, it will automatically be included i
 the Zephyr build system. The path to the module is then accessible through Kconfig
 and CMake variables.
 
-In both Kconfig and CMake, the variable ``ZEPHYR_<module-name>_MODULE_DIR``
+In both Kconfig and CMake, the variable ``ZEPHYR_<MODULE_NAME>_MODULE_DIR``
 contains the absolute path to the module.
 
-In CMake, ``ZEPHYR_<module-name>_CMAKE_DIR`` contains the
+In CMake, ``ZEPHYR_<MODULE_NAME>_CMAKE_DIR`` contains the
 absolute path to the directory containing the :file:`CMakeLists.txt` file that
 is included into CMake build system. This variable's value is empty if the
 module.yml file does not specify a CMakeLists.txt.

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -515,6 +515,36 @@ variables. For example:
 
   include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/code.cmake)
 
+Zephyr module dependencies
+==========================
+
+A Zephyr module may be dependent on other Zephyr modules to be present in order
+to function correctly. Or it might be that a given Zephyr module must be
+processed after another Zephyr module, due to dependencies of certain CMake
+targets.
+
+Such a dependency can be described using the ``depends`` field.
+
+.. code-block:: yaml
+
+   build:
+     depends:
+       - <module>
+
+Here is an example for the Zephyr module ``foo`` that is dependent on the Zephyr
+module ``bar`` to be present in the build system:
+
+.. code-block:: yaml
+
+   name: foo
+   build:
+     depends:
+     - bar
+
+This example will ensure that ``bar`` is present when ``foo`` is included into
+the build system, and it will also ensure that ``bar`` is processed before
+``foo``.
+
 .. _modules_module_ext_root:
 
 Module integration files (external)


### PR DESCRIPTION
The folder name of a Zephyr module is also used as its module name
when integrating it into the build system.

This means that a Zephyr module, BAR, located in:
```
<workspace>/modules/foo
                    |--- zephyr
                          |--- CMakeLists.txt
                          |--- Kconfig
```

will be referred to as FOO in the build system, that is:
ZEPHYR_FOO_MODULE_DIR==<workspace>/modules/foo
ZEPHYR_FOO_CMAKE_DIR==<workspace>/modules/foo/zephyr

The `name` field allows the module to specify its module name,
independent of its location like:

`<workspace>/modules/foo/zephyr/module.yml`
```
name: bar
build:
  cmake: zephyr
```

will instead be referred to as BAR in the build system, that is:
ZEPHYR_BAR_MODULE_DIR==<workspace>/modules/foo
ZEPHYR_BAR_CMAKE_DIR==<workspace>/modules/foo/zephyr

This allows for greater flexibility of relocating Zephyr modules in
other folders and at the same time be guaranteed that other modules
depending on `ZEPHYR_BAR_MODULE_DIR` is still working.

If `name` field is not specified in `module.yml`, then the existing
behavior of using the folder name will be used.

-------

Introducing `name: <module-name>` as requirement in Zephyr maintained
modules.

This will ensure that Zephyr module names are kept in sync between the
project names in the default `west.yml` manifest file, and the names
used when referring to the Zephyr module in the build system.

This means the project `foo` in `west.yml` will look as:

west.yml
```
manifest:
  projects:
    - name: foo
```

must have:
`<foo-repo>/zephyr/module.yml` with content
```
name: foo
```

and can be referred to in the build system as:
- `ZEPHYR_FOO_MODULE_DIR`, for the module directory
- `ZEPHYR_FOO_CMAKE_DIR`, for the directory containing the Zephyr module
  CMakeLists.txt.

-------
 doc: documenting the depends feature in Zephyr modules

Fixes: #29549

This commit documents the Zephyr module `depends` feature.