### PR TITLE
net: tcp2: Mark tcphdr struct as packed

### DIFF
--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -12,8 +12,13 @@
 #define MIN3(_a, _b, _c) MIN((_a), MIN((_b), (_c)))
 #endif
 
+#define th_sport(_x) UNALIGNED_GET(&(_x)->th_sport)
+#define th_dport(_x) UNALIGNED_GET(&(_x)->th_dport)
 #define th_seq(_x) ntohl(UNALIGNED_GET(&(_x)->th_seq))
 #define th_ack(_x) ntohl(UNALIGNED_GET(&(_x)->th_ack))
+#define th_off(_x) ((_x)->th_off)
+#define th_flags(_x) UNALIGNED_GET(&(_x)->th_flags)
+#define th_win(_x) UNALIGNED_GET(&(_x)->th_win)
 
 #define tcp_slist(_slist, _op, _type, _link)				\
 ({									\
@@ -133,7 +138,7 @@ struct tcphdr {
 	uint16_t th_win;
 	uint16_t th_sum;
 	uint16_t th_urp;
-};
+} __packed;
 
 enum th_flags {
 	FIN = 1,


### PR DESCRIPTION
As the tcp header struct can be cast to unaligned memory, mark
it as packed and access fields using UNALIGNED_GET/PUT when
needed.

Fixes #31145

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>