### PR TITLE
drivers: can: stm32: fix bus-speed

### DIFF
--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -374,9 +374,11 @@ int can_stm32_set_timing(const struct device *dev,
 	can->BTR &= ~(CAN_BTR_BRP_Msk | CAN_BTR_TS1_Msk |
 		      CAN_BTR_TS2_Msk | CAN_BTR_SJW_Msk);
 
-	can->BTR |= (((timing->phase_seg1 - 1) & 0x0F) << CAN_BTR_TS1_Pos) |
-		    (((timing->phase_seg2 - 1) & 0x07) << CAN_BTR_TS2_Pos) |
-		    (((timing->sjw        - 1) & 0x07) << CAN_BTR_SJW_Pos);
+	can->BTR |=
+	     (((timing->phase_seg1 - 1) << CAN_BTR_TS1_Pos) & CAN_BTR_TS1_Msk) |
+	     (((timing->phase_seg2 - 1) << CAN_BTR_TS2_Pos) & CAN_BTR_TS2_Msk) |
+	     (((timing->sjw        - 1) << CAN_BTR_SJW_Pos) & CAN_BTR_SJW_Msk) |
+	     (((timing->prescaler  - 1) << CAN_BTR_BRP_Pos) & CAN_BTR_BRP_Msk);
 
 	ret = can_leave_init_mode(can);
 	if (ret) {


### PR DESCRIPTION
Set the prescaler in register BTR according to the configured bitrate in DTS.
This bug appeared in commit 8b6c1bd4b7a0ae4e1d1b3819d5db728120218c6b

Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>