### PR TITLE
stm32: dma: Simplify handling of Kconfig symbols

### DIFF
--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -4,6 +4,10 @@
 # Copyright (c) 2019 Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_ST_STM32_DMA_V1 := st,stm32-dma-v1
+DT_COMPAT_ST_STM32_DMA_V2 := st,stm32-dma-v2
+DT_COMPAT_ST_STM32_DMAMUX := st,stm32-dmamux
+
 config DMA_STM32
 	bool "Enable STM32 DMA driver"
 	select USE_STM32_LL_DMA
@@ -15,22 +19,22 @@ if DMA_STM32
 
 config DMA_STM32_V1
 	bool
-	depends on SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	default y if $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_DMA_V1))
 	help
-	  Enable DMA support on F2/F4/F7 series SoCs.
+	  Enable DMA V1 support.
 
 config DMA_STM32_V2
 	bool
-	depends on SOC_SERIES_STM32F0X || SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X || SOC_SERIES_STM32WBX
+	default y if $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_DMA_V2))
 	help
-	  Enable DMA support on F0/F1/F3/L0/L4/WB series SoCs.
+	  Enable DMA V2 support.
 
 config DMAMUX_STM32
 	bool
 	depends on DMA_STM32_V2
-	depends on SOC_STM32L4R5XX || SOC_SERIES_STM32WBX
+	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_DMAMUX))
 	help
-	  Enable DMAMUX support on L4R/WB series SoCs.
+	  Enable DMAMUX support.
 
 config DMA_STM32_SHARED_IRQS
 	bool

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT st_stm32_dma
-
 /**
  * @brief Common part of DMA drivers for stm32.
  * @note  Functions named with stm32_dma_* are SoCs related functions
@@ -20,6 +18,12 @@
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)
+#define DT_DRV_COMPAT st_stm32_dma_v1
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2)
+#define DT_DRV_COMPAT st_stm32_dma_v2
+#endif
 
 #if DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay)
 #if DT_INST_IRQ_HAS_IDX(0, 7)
@@ -610,6 +614,13 @@ static const struct dma_driver_api dma_funcs = {
 #define DMA_STM32_OFFSET_INIT(index)
 #endif /* CONFIG_DMAMUX_STM32 */
 
+#ifdef CONFIG_DMA_STM32_V1
+#define DMA_STM32_MEM2MEM_INIT(index)					\
+	.support_m2m = DT_INST_PROP(index, st_mem2mem),
+#else
+#define DMA_STM32_MEM2MEM_INIT(index)
+#endif /* CONFIG_DMA_STM32_V1 */					\
+
 #define DMA_STM32_INIT_DEV(index)					\
 static struct dma_stm32_stream						\
 	dma_stm32_streams_##index[DMA_STM32_##index##_STREAM_COUNT];	\
@@ -619,7 +630,7 @@ const struct dma_stm32_config dma_stm32_config_##index = {		\
 		    .enr = DT_INST_CLOCKS_CELL(index, bits) },		\
 	.config_irq = dma_stm32_config_irq_##index,			\
 	.base = DT_INST_REG_ADDR(index),				\
-	.support_m2m = DT_INST_PROP(index, st_mem2mem),			\
+	DMA_STM32_MEM2MEM_INIT(index)					\
 	.max_streams = DMA_STM32_##index##_STREAM_COUNT,		\
 	.streams = dma_stm32_streams_##index,				\
 	DMA_STM32_OFFSET_INIT(index)					\

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -343,7 +343,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -69,7 +69,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -75,7 +75,6 @@
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0
 				      11 0 10 0 10 0 11 0 11 0 11 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -273,7 +273,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -173,7 +173,6 @@
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = < 56 0 57 0 58 0 59 0 60 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -168,7 +168,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -13,7 +13,6 @@
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -9,7 +9,7 @@
 / {
 	soc {
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -248,7 +248,7 @@
 		};
 
 		dma1: dma@40026000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
@@ -258,7 +258,7 @@
 		};
 
 		dma2: dma@40026400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -353,7 +353,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;

--- a/dts/arm/st/f3/stm32f303Xc.dtsi
+++ b/dts/arm/st/f3/stm32f303Xc.dtsi
@@ -25,7 +25,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;

--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -25,7 +25,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;

--- a/dts/arm/st/f3/stm32f373Xc.dtsi
+++ b/dts/arm/st/f3/stm32f373Xc.dtsi
@@ -24,7 +24,6 @@
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
-			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/arm/st/f3/stm32f373Xc.dtsi
+++ b/dts/arm/st/f3/stm32f373Xc.dtsi
@@ -20,7 +20,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			reg = <0x40020400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -403,7 +403,7 @@
 		};
 
 		dma1: dma@40026000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
@@ -413,7 +413,7 @@
 		};
 
 		dma2: dma@40026400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -643,7 +643,7 @@
 		};
 
 		dma1: dma@40026000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
@@ -653,7 +653,7 @@
 		};
 
 		dma2: dma@40026400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -681,8 +681,8 @@
 			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
-			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,
-						 <17 0>, <47 0>;
+			interrupts = <56 0>, <57 0>, <58 0>, <59 0>, <60 0>, <68 0>,
+						<69 0>, <70 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
 			status = "disabled";
 			label = "DMA_2";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -667,7 +667,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,
@@ -678,7 +678,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -673,6 +673,7 @@
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,
 						 <17 0>, <47 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
+			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
 		};
@@ -684,6 +685,7 @@
 			interrupts = <56 0>, <57 0>, <58 0>, <59 0>, <60 0>, <68 0>,
 						<69 0>, <70 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
+			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -253,7 +253,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0 11 0>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -329,7 +329,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
@@ -341,7 +341,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -334,7 +334,6 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
-			st,mem2mem;
 			dma-requests = <7>;
 			status = "disabled";
 			label = "DMA_1";
@@ -346,7 +345,6 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
-			st,mem2mem;
 			dma-requests = <7>;
 			status = "disabled";
 			label = "DMA_2";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -304,7 +304,7 @@
 		};
 
 		dma1: dma@40020000 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
@@ -317,7 +317,7 @@
 		};
 
 		dma2: dma@40020400 {
-			compatible = "st,stm32-dma";
+			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;
 			reg = <0x40020400 0x400>;
 			interrupts = <55 0 56 0 57 0 58 0 59 0 60 0 61 0>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -309,7 +309,6 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x1>;
-			st,mem2mem;
 			dma-requests = <7>;
 			dma-offset = <0>;
 			status = "disabled";
@@ -322,7 +321,6 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <55 0 56 0 57 0 58 0 59 0 60 0 61 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
-			st,mem2mem;
 			dma-requests = <7>;
 			dma-offset = <7>;
 			status = "disabled";

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -82,6 +82,7 @@ properties:
 
     st,mem2mem:
       type: boolean
+      required: false
       description: If the DMA controller V1 supports memory to memory transfer
 
     dma-offset:

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 DMA controller
+  STM32 DMA controller (V1)
 
   The STM32 DMA is a general-purpose direct memory access controller
   capable of supporting 5 or 6 or 7 or 8 independent DMA channels.
@@ -10,48 +10,49 @@ description: |
   DMA clients connected to the STM32 DMA controller must use the format
   described in the dma.txt file, using a four-cell specifier for each
   channel: a phandle to the DMA controller plus the following four integer cells:
-    1. channel: the dma stream from 0 in V1 or 1 in V2 to <dma-requests>
-    2. slot: DMA periph request ID in DMA_V2 or DMAMUX, dma request in V1
+    1. channel: the dma stream from 0 to <dma-requests>
+    2. slot: dma request
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
         -bit 6-7 : Direction  (see dma.h)
-       	       0x0: MEM to MEM
-       	       0x1: MEM to PERIPH
-       	       0x2: PERIPH to MEM
-       	       0x3: reserved for PERIPH to PERIPH
+               0x0: MEM to MEM
+               0x1: MEM to PERIPH
+               0x2: PERIPH to MEM
+               0x3: reserved for PERIPH to PERIPH
         -bit 9 : Peripheral Increment Address
-       	       0x0: no address increment between transfers
-       	       0x1: increment address between transfers
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
         -bit 10 : Memory Increment Address
-       	       0x0: no address increment between transfers
-       	       0x1: increment address between transfers
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
         -bit 11-12 : Peripheral data size
-       	       0x0: Byte (8 bits)
-       	       0x1: Half-word (16 bits)
-       	       0x2: Word (32 bits)
-       	       0x3: reserved
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
         -bit 13-14 : Memory data size
-       	       0x0: Byte (8 bits)
-       	       0x1: Half-word (16 bits)
-       	       0x2: Word (32 bits)
-       	       0x3: reserved
-        -bit 15: Peripheral Increment Offset Size (not USED for DMA V2)
-       	       0x0: offset size is linked to the peripheral bus width
-       	       0x1: offset size is fixed to 4 (32-bit alignment)
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
+        -bit 15: Peripheral Increment Offset Size
+               0x0: offset size is linked to the peripheral bus width
+               0x1: offset size is fixed to 4 (32-bit alignment)
         -bit 16-17 : Priority level
-       	       0x0: low
-       	       0x1: medium
-       	       0x2: high
-       	       0x3: very high
+               0x0: low
+               0x1: medium
+               0x2: high
+               0x3: very high
     4. features: A 32bit bitfield value specifying DMA features
-        -bit 0-1: DMA FIFO threshold selection (not USED for DMA V2)
-       	       0x0: 1/4 full FIFO
-       	       0x1: 1/2 full FIFO
-       	       0x2: 3/4 full FIFO
-       	       0x3: full FIFO
-    examples for stm32wb55x
+        -bit 0-1: DMA FIFO threshold selection
+               0x0: 1/4 full FIFO
+               0x1: 1/2 full FIFO
+               0x2: 3/4 full FIFO
+               0x3: full FIFO
+
+    examples for stm32f411
      dma2: dma-controller@40020400 {
-         compatible = "st,stm32-dma";
+         compatible = "st,stm32-dma-v1";
          ...
          st,mem2mem;
          dma-requests = <7>;
@@ -59,7 +60,7 @@ description: |
          label = "DMA_2";
         };
 
-  For the client part, example for stm32f411 DMA V1 on DMA2 instance
+  For the client part, example for stm32f411 on DMA2 instance
     Tx using stream 5 on channel 3 (stream 2 on channel 2 is also possible)
     Rx using stream 2 on channel 3 (stream 0 on channel 3 is also possible)
     spi1 {
@@ -68,17 +69,7 @@ description: |
      dma-names = "tx", "rx";
      };
 
-  For the client part, example for stm32l476 DMA V2 on DMA1 instance
-    Tx using channel 3 with request 1
-    Rx using channel 2 with request 1
-    spi1 {
-     compatible = "st,stm32-spi";
-     dmas = <&dma1 3 1 0x20440 0x04>,
-           <&dma1 2 1 0x20480 0x04>;
-     dma-names = "tx", "rx";
-   };
-
-compatible: "st,stm32-dma"
+compatible: "st,stm32-dma-v1"
 
 include: dma-controller.yaml
 

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -1,0 +1,97 @@
+# Copyright (c) 2019, Song Qiang <songqiang1304521@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 DMA controller (V2)
+
+  The STM32 DMA is a general-purpose direct memory access controller
+  capable of supporting 5 or 6 or 7 or 8 independent DMA channels.
+  Each channel can have up to 8 requests.
+  DMA clients connected to the STM32 DMA controller must use the format
+  described in the dma.txt file, using a four-cell specifier for each
+  channel: a phandle to the DMA controller plus the following four integer cells:
+    1. channel: the dma stream from 1 to <dma-requests>
+    2. slot: DMA periph request ID
+    3. channel-config: A 32bit mask specifying the DMA channel configuration
+    which is device dependent:
+        -bit 6-7 : Direction  (see dma.h)
+               0x0: MEM to MEM
+               0x1: MEM to PERIPH
+               0x2: PERIPH to MEM
+               0x3: reserved for PERIPH to PERIPH
+        -bit 9 : Peripheral Increment Address
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
+        -bit 10 : Memory Increment Address
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
+        -bit 11-12 : Peripheral data size
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
+        -bit 13-14 : Memory data size
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
+        -bit 15: Reserved
+        -bit 16-17 : Priority level
+               0x0: low
+               0x1: medium
+               0x2: high
+               0x3: very high
+    4. Features. Not used. Kept for binding compatibility with "st,stm32-dma-v1"
+
+  Example of dma node for stm32wb55x
+     dma2: dma-controller@40020400 {
+         compatible = "st,stm32-dma-v2";
+         ...
+         dma-requests = <7>;
+         status = "disabled";
+         label = "DMA_2";
+        };
+
+  For the client part, example for stm32l476 on DMA1 instance
+    Tx using channel 3 with request 1
+    Rx using channel 2 with request 1
+    spi1 {
+     compatible = "st,stm32-spi";
+     dmas = <&dma1 3 1 0x20440 0x00>,
+            <&dma1 2 1 0x20480 0x00>;
+     dma-names = "tx", "rx";
+    };
+
+compatible: "st,stm32-dma-v2"
+
+include: dma-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    dma-offset:
+      type: int
+      required: false
+      description: >
+        offset in the table of channels when mapping to a DMAMUX
+        for 1st dma instance, offset is 0,
+        for 2nd dma instance, offset is the nb of dma channels of the 1st dma,
+        for 3rd dma instance, offset is the nb of dma channels of the 2nd dma
+        plus the nb of dma channels of the 1st dma instance, etc.
+
+    "#dma-cells":
+      const: 4
+
+# Parameter syntax of stm32 follows the dma client dts syntax
+# in the Linux kernel declared in
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+
+dma-cells:
+  - channel
+  - slot
+  - channel-config
+  - features

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -13,34 +13,34 @@ description: |
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
         -bit 6-7 : Direction  (see dma.h)
-       	       0x0: MEM to MEM
-       	       0x1: MEM to PERIPH
-       	       0x2: PERIPH to MEM
-       	       0x3: reserved for PERIPH to PERIPH
+               0x0: MEM to MEM
+               0x1: MEM to PERIPH
+               0x2: PERIPH to MEM
+               0x3: reserved for PERIPH to PERIPH
         -bit 9 : Peripheral Increment Address
-       	       0x0: no address increment between transfers
-       	       0x1: increment address between transfers
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
         -bit 10 : Memory Increment Address
-       	       0x0: no address increment between transfers
-       	       0x1: increment address between transfers
+               0x0: no address increment between transfers
+               0x1: increment address between transfers
         -bit 11-12 : Peripheral data size
-       	       0x0: Byte (8 bits)
-       	       0x1: Half-word (16 bits)
-       	       0x2: Word (32 bits)
-       	       0x3: reserved
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
         -bit 13-14 : Memory data size
-       	       0x0: Byte (8 bits)
-       	       0x1: Half-word (16 bits)
-       	       0x2: Word (32 bits)
-       	       0x3: reserved
+               0x0: Byte (8 bits)
+               0x1: Half-word (16 bits)
+               0x2: Word (32 bits)
+               0x3: reserved
         -bit 15: Peripheral Increment Offset Size not USED for DMA V2
-       	       0x0: offset size is linked to the peripheral bus width
-       	       0x1: offset size is fixed to 4 (32-bit alignment)
+               0x0: offset size is linked to the peripheral bus width
+               0x1: offset size is fixed to 4 (32-bit alignment)
         -bit 16-17 : Priority level
-       	       0x0: low
-       	       0x1: medium
-       	       0x2: high
-       	       0x3: very high
+               0x0: low
+               0x1: medium
+               0x2: high
+               0x3: very high
      4. features: NOT USED by dmamux
    exemple for stm32wb55x
      dmamux1: dmamux@40020800 {

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
 config SOC_SERIES
 	default "stm32f0"
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F0X

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 config SOC_SERIES
 	default "stm32f1"
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F1X

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f2*"
 config SOC_SERIES
 	default "stm32f2"
 
-config DMA_STM32_V1
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F2X

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
 config SOC_SERIES
 	default "stm32f3"
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F3X

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 config SOC_SERIES
 	default "stm32f4"
 
-config DMA_STM32_V1
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F4X

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f7*"
 config SOC_SERIES
 	default "stm32f7"
 
-config DMA_STM32_V1
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32F7X

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ source "soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h7*"
 config SOC_SERIES
 	default "stm32h7"
 
-config DMA_STM32_V1
-	default y
-	depends on DMA_STM32
-
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x0   if !BOOTLOADER_MCUBOOT

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -12,8 +12,4 @@ source "soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 config SOC_SERIES
 	default "stm32l0"
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32L0X

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -18,8 +18,4 @@ config STM32_LPTIM_TIMER
 	default y
 	depends on PM
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32L4X

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -15,8 +15,4 @@ config STM32_LPTIM_TIMER
 	default y
 	depends on PM
 
-config DMA_STM32_V2
-	default y
-	depends on DMA_STM32
-
 endif # SOC_SERIES_STM32WBX

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
@@ -11,8 +11,4 @@ config SOC
 config NUM_IRQS
 	default 63
 
-config DMAMUX_STM32
-	default y
-	depends on DMA_STM32
-
 endif # SOC_STM32WB55XX


### PR DESCRIPTION
In order to simplify the handling of DMA_STM32_V1/V2 and DMAMUX_STM32
symbols, set them directly based on related compatible status.

As a preliminary step, instantiate matching compatibles.