### PR TITLE
x86: power: Remove dead code

### DIFF
--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -38,10 +38,6 @@
 	GDATA(_sse_mxcsr_default_value)
 #endif
 
-#ifdef CONFIG_PM_DEEP_SLEEP_STATES
-	GTEXT(pm_system_resume_from_deep_sleep)
-#endif
-
 SECTION_FUNC(TEXT_START, __start)
 
 #include "../common.S"
@@ -134,15 +130,6 @@ __csSet:
 	 * kernel/init.c enforces that the z_interrupt_stacks pointer and
 	 * the ISR stack size are some multiple of ARCH_STACK_PTR_ALIGN, which
 	 * is at least 4.
-	 *
-	 * This is also used to call the pm_system_resume_from_deep_sleep()
-	 * routine to avoid memory corruption if the system is resuming from
-	 * deep sleep. It is important that pm_system_resume_from_deep_sleep()
-	 * restores the stack pointer to what it was at deep sleep before
-         * enabling interrupts.  This is necessary to avoid
-	 * interfering with interrupt handler use of this stack.
-	 * If it is a cold boot then pm_system_resume_from_deep_sleep() should
-	 * not do anything and must return immediately.
 	 */
 #ifdef CONFIG_INIT_STACKS
 	movl $0xAAAAAAAA, %eax
@@ -163,23 +150,6 @@ __csSet:
 	addl	$(CONFIG_ISR_STACK_SIZE + 4096), %esp
 #else
 	addl	$CONFIG_ISR_STACK_SIZE, %esp
-#endif
-#if defined(CONFIG_PM_DEEP_SLEEP_STATES) && \
-             !defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
-	/*
-	 * Invoke pm_system_resume_from_deep_sleep() hook to handle resume from
-	 * deep sleep. It should first check whether system is recovering from
-	 * deep sleep state. If it is, then this function should restore
-	 * states and resume at the point system went to deep sleep.
-	 * In this case this function will never return.
-	 *
-	 * If system is not recovering from deep sleep then it is a
-	 * cold boot.  In this case, this function would immediately
-	 * return and execution falls through to cold boot path.
-	 */
-
-	call pm_system_resume_from_deep_sleep
-
 #endif
 
 #ifdef CONFIG_XIP


### PR DESCRIPTION
X86 currently has no support for deep sleep states, just removing this
dead code.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>