### PR TITLE
dts: Add _OR variant macro for DT_PROP_LEN

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -443,6 +443,24 @@
 #define DT_PROP_LEN(node_id, prop) DT_PROP(node_id, prop##_LEN)
 
 /**
+ * @brief Like DT_PROP_LEN(), but with a fallback to default_value
+ *
+ * If the property is defined (as determined by DT_NODE_HAS_PROP()),
+ * this expands to DT_PROP_LEN(node_id, prop). The default_value
+ * parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param prop a lowercase-and-underscores property with a logical length
+ * @param default_value a fallback value to expand to
+ * @return the property's length or the given default value
+ */
+#define DT_PROP_LEN_OR(node_id, prop, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		    (DT_PROP_LEN(node_id, prop)), (default_value))
+
+/**
  * @brief Is index "idx" valid for an array type property?
  *
  * If this returns 1, then DT_PROP_BY_IDX(node_id, prop, idx) or

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -62,6 +62,8 @@ static void test_path_props(void)
 	zassert_equal(DT_PROP(TEST_ABCD1234, ngpios), 32, "");
 	zassert_true(!strcmp(DT_PROP(TEST_ABCD1234, status), "okay"), "");
 	zassert_equal(DT_PROP_LEN(TEST_ABCD1234, compatible), 1, "");
+	zassert_equal(DT_PROP_LEN_OR(TEST_ABCD1234, compatible, 4), 1, "");
+	zassert_equal(DT_PROP_LEN_OR(TEST_ABCD1234, invalid_property, 0), 0, "");
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_ABCD1234, compatible, 0),
 			     "vnd,gpio"), "");
 }


### PR DESCRIPTION
Add an or variant macro for `DT_PROP_LEN` macro, this is useful when you have to use with `UTIL_LISTIFY` to get a list from a property that is optional.