### PR TITLE
drivers/serial: stm32: Force oversampling value

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -75,7 +75,10 @@ static inline void uart_stm32_set_baudrate(const struct device *dev,
 				      baud_rate);
 	} else {
 #endif /* HAS_LPUART_1 */
-
+#ifdef USART_CR1_OVER8
+		LL_USART_SetOverSampling(UartInstance,
+					 LL_USART_OVERSAMPLING_16);
+#endif
 		LL_USART_SetBaudRate(UartInstance,
 				     clock_rate,
 #ifdef USART_PRESC_PRESCALER


### PR DESCRIPTION
When setting baudrate register, baudrate value is computed according
to the oversampling given value, which is default boot time
value (16).
In case oversampling value has been changed by bootloader (as in case
of TFM bootloader), a desynchronsation happens between OVR and BRR
values and the ouptut baudarate is incorrect.
For oversampling register before setting the baudrate to avoid this
situation.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>