### PR TITLE
drivers: timer: nrf_rtc_timer: Increase half tick busy wait

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -171,7 +171,11 @@ static void set_absolute_alarm(uint32_t chan, uint32_t abs_val)
 		 */
 		set_comparator(chan, now);
 		if (counter_sub(prev_cc, now) == 1) {
-			k_busy_wait(15);
+			/* It should wait for half of RTC tick 15.26us. As
+			 * busy wait runs from different clock source thus
+			 * wait longer to cover for discrepancy.
+			 */
+			k_busy_wait(19);
 		}
 
 


### PR DESCRIPTION
Due to clock discrepancy, busy waiting for 15us was not covering for
half tick in certain cases. Busy wait runs from HF clock source.

Increased to 19us to cover it. Anyway, this case is hit very rarely,
only when there was aborted, not-cancelled compare value that was
about to expire. Because of that, increase shall not impact the
performance.

Fixes #30730.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>