### PR TITLE
tests: drivers: uart: Add gpio_loopback harness to test config

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -2,7 +2,9 @@ tests:
   drivers.uart.uart_async_api:
     tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
-    harness: keyboard
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback
   drivers.uart.uart_async_api.rtt:
     tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_HAS_SEGGER_RTT

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  harness: ztest
+  harness_config:
+    fixture: gpio_loopback
 tests:
   drivers.uart.uart_mix_poll:
     tags: drivers


### PR DESCRIPTION
Added gpio_loopback to indicate that test requires pins to be
shorten. This allows to filter out tests on setup which does
not have pin setup.

Until #30578 is resolved this help to prevent these tests from running on hardware without pin setup.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>