### PR TITLE
driver: uart stm32: Check irq enabled in API calls

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -533,7 +533,8 @@ static int uart_stm32_irq_tx_ready(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return LL_USART_IsActiveFlag_TXE(UartInstance);
+	return LL_USART_IsActiveFlag_TXE(UartInstance) &&
+		LL_USART_IsEnabledIT_TC(UartInstance);
 }
 
 static int uart_stm32_irq_tx_complete(const struct device *dev)
@@ -561,7 +562,8 @@ static int uart_stm32_irq_rx_ready(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return LL_USART_IsActiveFlag_RXNE(UartInstance);
+	return LL_USART_IsActiveFlag_RXNE(UartInstance) &&
+		LL_USART_IsEnabledIT_RXNE(UartInstance);
 }
 
 static void uart_stm32_irq_err_enable(const struct device *dev)


### PR DESCRIPTION
When calling `irq_rx_ready` or `irq_tx_ready` API, return the logical AND between the irq status and the enable of that irq.

The reason behind this PR is to be consistent with nRF and MCUX chips and return true on the `irq_[tr]x_ready` if the corresponding irq is set and enabled.

This allows #26516 improvements to work on stm32.

This has been tested on nucleo_h743 and nucleo_f429 on the `sample/subsys/modbus/` samples.
