### PR TITLE
drivers/clock_control: stm32h7: Fix line break on #error

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -151,8 +151,7 @@
 #endif
 
 #if SYSCLK_FREQ != CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
-#error "Calculated CPU clock frequency (SYS clock) for M7 core doesn't match \
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC"
+#error "SYS clock frequency for M7 core doesn't match CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC"
 #endif
 
 /* end of clock feasability check */


### PR DESCRIPTION
Line break on #error directive is confusing github and ending up
breaking syntax highligthing in github UI which makes me nervous
during review.
Convert error message to a one liner.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>