### PR TITLE
doc: build: Add missing script info

### DIFF
--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -265,3 +265,10 @@ The following is a detailed description of the scripts used during the build pro
 .. include:: ../../../scripts/process_gperf.py
    :start-after: """
    :end-before: """
+
+:zephyr_file:`scripts/gen_app_partitions.py`
+============================================
+
+.. include:: ../../../scripts/gen_app_partitions.py
+   :start-after: """
+   :end-before: """


### PR DESCRIPTION
gen_app_partitions.py was missing.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>