### PR TITLE
requirements-doc: add missing pkwalify

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -6,3 +6,6 @@ sphinx>=3.3.0,<3.4.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
+
+# Used by zephyr_module
+pykwalify


### PR DESCRIPTION
doc/CMakeLists.txt uses zephyr_module

Signed-off-by: Marc Herbert <marc.herbert@intel.com>