### PR TITLE
drivers: gpio_ite_it8xxx2: fix use of uninitialized variable

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -268,7 +268,7 @@ static void gpio_ite_isr(const void *arg)
 	int gpio_index = 0;
 	const struct device *dev = arg;
 	struct gpio_ite_wui *wui_local;
-	struct gpio_ite_reg_table *gpio_tab_local;
+	struct gpio_ite_reg_table *gpio_tab_local = NULL;
 	const struct gpio_ite_cfg *gpio_config = DEV_GPIO_CFG(dev);
 	struct gpio_ite_data *data = DEV_GPIO_DATA(dev);
 


### PR DESCRIPTION
Retain the assumption that the loop will assign a pointer, but
initialize it pointer first to eliminate build warnings.

Fixes nightly build failure: https://buildkite.com/zephyr/zephyr-daily/builds/204