### PR TITLE
net: hostname: Update unique hostname on link address change

### DIFF
--- a/subsys/net/Kconfig.hostname
+++ b/subsys/net/Kconfig.hostname
@@ -24,6 +24,14 @@ config NET_HOSTNAME_UNIQUE
 	  hostname. For example, zephyr00005e005357 could be the hostname
 	  if this setting is enabled.
 
+config NET_HOSTNAME_UNIQUE_UPDATE
+	bool "Update unique hostname"
+	depends on NET_HOSTNAME_UNIQUE
+	help
+	  This will update the unique hostname on link address changes. By
+	  default, this option is disabled, which means the unique hostname
+	  is set once at start-up and is not updated afterwards.
+
 module = NET_HOSTNAME
 module-dep = NET_LOG
 module-str = Log level for hostname configuration

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -27,13 +27,17 @@ const char *net_hostname_get(void)
 int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 			     int postfix_len)
 {
+#if !defined(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)
 	static bool postfix_set;
+#endif
 	int pos = 0;
 	int i;
 
+#if !defined(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)
 	if (postfix_set) {
 		return -EALREADY;
 	}
+#endif
 
 	NET_ASSERT(postfix_len > 0);
 
@@ -50,7 +54,9 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 
 	NET_DBG("New hostname %s", log_strdup(hostname));
 
+#if !defined(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)
 	postfix_set = true;
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Make sure the unique hostname - which is derived from the network
interface's link address - is updated on both initial assignment and
updates of the link address.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>