### PR TITLE
Bluetooth: Mesh: Fix heartbeat subscription tests

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2323,11 +2323,19 @@ static void heartbeat_sub_set(struct bt_mesh_model *model,
 	/* MESH/NODE/CFG/HBS/BV-01-C expects the MinHops to be 0x7f after
 	 * disabling subscription, but 0x00 for subsequent Get requests.
 	 */
-	if (!period_log) {
+	if (sub.src == BT_MESH_ADDR_UNASSIGNED || !period_log) {
 		sub.min_hops = BT_MESH_TTL_MAX;
 	}
 
 	hb_sub_send_status(model, ctx, &sub);
+
+	/* MESH/NODE/CFG/HBS/BV-02-C expects us to return previous
+	 * count value and then reset it to 0.
+	 */
+	if (sub.src != BT_MESH_ADDR_UNASSIGNED &&
+	    sub.dst != BT_MESH_ADDR_UNASSIGNED && !period) {
+		bt_mesh_hb_sub_reset_count();
+	}
 }
 
 const struct bt_mesh_model_op bt_mesh_cfg_srv_op[] = {

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -308,6 +308,11 @@ uint8_t bt_mesh_hb_sub_set(uint16_t src, uint16_t dst, uint32_t period)
 	return STATUS_SUCCESS;
 }
 
+void bt_mesh_hb_sub_reset_count(void)
+{
+	sub.count = 0;
+}
+
 void bt_mesh_hb_sub_get(struct bt_mesh_hb_sub *get)
 {
 	*get = sub;

--- a/subsys/bluetooth/mesh/heartbeat.h
+++ b/subsys/bluetooth/mesh/heartbeat.h
@@ -36,3 +36,4 @@ void bt_mesh_hb_feature_changed(uint16_t features);
 
 uint8_t bt_mesh_hb_pub_set(struct bt_mesh_hb_pub *hb_pub);
 uint8_t bt_mesh_hb_sub_set(uint16_t src, uint16_t dst, uint32_t period);
+void bt_mesh_hb_sub_reset_count(void);


### PR DESCRIPTION
MESH/NODE/CFG/HBS/BV-01-C expects the MinHops to be 0x7f after
disabling subscription, but 0x00 for subsequent Get requests.

MESH/NODE/CFG/HBS/BV-02-C expects us to return previous
count value and then reset it to 0.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>