### PR TITLE
net: coap: Fix long options encoding

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -218,7 +218,7 @@ static int encode_option(struct coap_packet *cpkt, uint16_t code,
 		if (!res) {
 			return -EINVAL;
 		}
-	} else if (delta_size == 2U) {
+	} else if (len_size == 2U) {
 		res = append_be16(cpkt, len_ext);
 		if (!res) {
 			return -EINVAL;


### PR DESCRIPTION
`delta_size` was incorrectly used to assess whether extended option
length field shall be used. In result, options larger than 268 bytes
were not encoded properly.

Fixes #31206

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>