### PR TITLE
 Update can_common: Check bitrate is greater than 0

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -753,9 +753,11 @@ static inline int can_set_bitrate(const struct device *dev,
 static inline int can_configure(const struct device *dev, enum can_mode mode,
 				uint32_t bitrate)
 {
-	int err = can_set_bitrate(dev, bitrate, 0);
-	if (err != 0) {
-		return err;
+	if (bitrate > 0) {
+		int err = can_set_bitrate(dev, bitrate, 0);
+		if (err != 0) {
+			return err;
+		}
 	}
 
 	return can_set_mode(dev, mode);


### PR DESCRIPTION
Ensure bitrate is greater than 0 so the program does not fault when RESET nmt command is sent