### PR TITLE
scripts: move pip pykwalify from requirements-build-test to -base

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -7,8 +7,11 @@
 pyelftools>=0.26
 
 # used by dts generation to parse binding YAMLs, also used by
-# twister to parse YAMLs
+# twister to parse YAMLs, by west, zephyr_module,...
 PyYAML>=5.1
+
+# YAML validation. Used by zephyr_module.
+pykwalify
 
 # used by west_commands
 canopen

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -9,9 +9,6 @@ colorama
 # python lex/yex used by twister
 ply>=3.10
 
-# optional, but used for validation of YAML
-pykwalify
-
 # used for code coverage
 gcovr>=4.2
 coverage


### PR DESCRIPTION
... because zephyr_module needs it.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>