### PR TITLE
requirements-doc: add PyYAML which removes dependency on -base

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,8 +44,12 @@ jobs:
     - name: install-pip
       run: |
         pip3 install setuptools
-        pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
+        # west is not required to build documentation... except for
+        # including West APIs in documentation! Search ".. automodule"
+        # in doc/guides/west/. Let's not request it from every doc
+        # writer using requirements-doc.txt
+        pip3 install west
 
     - name: west setup
       run: |

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -574,6 +574,11 @@ from :file:`runners/__init__.py`.
    changes break existing test cases, CI testing on upstream pull
    requests will fail.
 
+..
+   Including this automodule fails with a clear warning if west is
+   missing because west_commands/runners/ have an unsurprising
+   dependency on west through (at least) zephyr_ext_common
+
 .. automodule:: runners.core
    :members:
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -7,5 +7,6 @@ sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 
-# Used by zephyr_module
+# YAML validation. Used by zephyr_module.
+PyYAML
 pykwalify


### PR DESCRIPTION
This makes requirements-doc stand alone. See previous discussion in
PR #31199.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>