### PR TITLE
spinlock: validate: fix the dependency with MP_NUM_CPUS

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -61,7 +61,7 @@ struct k_spinlock {
 bool z_spin_lock_valid(struct k_spinlock *l);
 bool z_spin_unlock_valid(struct k_spinlock *l);
 void z_spin_lock_set_owner(struct k_spinlock *l);
-BUILD_ASSERT(CONFIG_MP_NUM_CPUS < 4, "Too many CPUs for mask");
+BUILD_ASSERT(CONFIG_MP_NUM_CPUS <= 4, "Too many CPUs for mask");
 #endif /* CONFIG_SPIN_VALIDATE */
 
 /**

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -222,7 +222,7 @@ config ASSERT_LEVEL
 config SPIN_VALIDATE
 	bool "Enable spinlock validation"
 	depends on ASSERT
-	depends on MP_NUM_CPUS < 4
+	depends on MP_NUM_CPUS <= 4
 	default y if !FLASH || FLASH_SIZE > 32
 	help
 	  There's a spinlock validation framework available when asserts are

--- a/tests/kernel/spinlock/testcase.yaml
+++ b/tests/kernel/spinlock/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.multiprocessing.spinlock:
     tags: smp spinlock
-    filter: CONFIG_SMP and CONFIG_MP_NUM_CPUS > 1
+    filter: CONFIG_SMP and CONFIG_MP_NUM_CPUS > 1 and CONFIG_MP_NUM_CPUS <= 4


### PR DESCRIPTION
the implementation of spinlock validation uses two LSB bits in the
bottom of a pointer union to store a CPU index, which only has space
for 4 CPUS. the MP_NUM_CPUS should be <= 4.

https://github.com/zephyrproject-rtos/zephyr/blob/43187e2723cfa6d095968f74726b24d7297329d5/kernel/thread.c#L861-L890

