### PR TITLE
RFC: twister: Include coverage support for device testing

### DIFF
--- a/boards/x86/ehl_crb/Kconfig.board
+++ b/boards/x86/ehl_crb/Kconfig.board
@@ -5,6 +5,7 @@ config BOARD_EHL_CRB
 	bool "Elkhart Lake CRB"
 	depends on SOC_ELKHART_LAKE
 	select X86_64
+	select HAS_COVERAGE_SUPPORT
 
 config BOARD_EHL_CRB_SBL
 	bool "Elkhart Lake CRB (with Slim Bootloader)"

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -604,6 +604,14 @@ class DeviceHandler(Handler):
         ser_fileno = ser.fileno()
         readlist = [halt_fileno, ser_fileno]
 
+        if self.coverage:
+            # Set capture_coverage to True to indicate that right after
+            # test results we should get coverage data, otherwise we exit
+            # from the test.
+            harness.capture_coverage = True
+
+        ser.flush()
+
         while ser.isOpen():
             readable, _, _ = select.select(readlist, [], [], self.timeout)
 
@@ -634,8 +642,9 @@ class DeviceHandler(Handler):
                 harness.handle(sl.rstrip())
 
             if harness.state:
-                ser.close()
-                break
+                if not harness.capture_coverage:
+                    ser.close()
+                    break
 
         log_out_fp.close()
 
@@ -2202,6 +2211,7 @@ class ProjectBuilder(FilterBuilder):
             instance.handler.call_make_run = True
         elif self.device_testing:
             instance.handler = DeviceHandler(instance, "device")
+            instance.handler.coverage = self.coverage
         elif instance.platform.simulation == "nsim":
             if find_executable("nsimdrv"):
                 instance.handler = BinaryHandler(instance, "nsim")


### PR DESCRIPTION
Include coverage support for device testing. It works by switching
capture_coverage to True (as it would meet coverage data start
pattern). Then we continue tot read coverage data until we get
coverage data end pattern. Otherwise, after receiving test result
pattern, we close serial console and do not get time to find start
coverage data pattern.

