### PR TITLE
samples: canbus: canopen: mark program download test as build-only

### DIFF
--- a/samples/subsys/canbus/canopen/sample.yaml
+++ b/samples/subsys/canbus/canopen/sample.yaml
@@ -13,6 +13,7 @@ tests:
   sample.subsys.canbus.canopen:
     tags: introduction
   sample.subsys.canbus.canopen.program_download:
+    build_only: true
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
   sample.subsys.canbus.canopen.no_storage:


### PR DESCRIPTION
Mark the CANopen sample with program download support as build-only since it depends on MCUboot being flashed to the board prior to the generated application firmware image.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>