### PR TITLE
tests: update case settings for twr_ke18f boards

### DIFF
--- a/tests/arch/arm/arm_interrupt/boards/twr_ke18f.conf
+++ b/tests/arch/arm/arm_interrupt/boards/twr_ke18f.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/tests/arch/arm/arm_ramfunc/boards/twr_ke18f.conf
+++ b/tests/arch/arm/arm_ramfunc/boards/twr_ke18f.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/tests/arch/arm/arm_thread_swap/boards/twr_ke18f.conf
+++ b/tests/arch/arm/arm_thread_swap/boards/twr_ke18f.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/tests/benchmarks/sys_kernel/boards/twr_ke18f.conf
+++ b/tests/benchmarks/sys_kernel/boards/twr_ke18f.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   benchmark.kernel.core:
     arch_exclude: nios2 riscv32 xtensa
-    min_ram: 32
+    min_ram: 36
     tags: benchmark

--- a/tests/drivers/adc/adc_api/boards/twr_ke18f.conf
+++ b/tests/drivers/adc/adc_api/boards/twr_ke18f.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n


### PR DESCRIPTION
disable MPU for cases exhaust MPU region on twr_ke18f
update ram size for benchmarks

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>