### PR TITLE
test: skip sys_kernel benchmarks for twr_ke18f

### DIFF
--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -15,7 +15,12 @@
 #include <toolchain.h>
 
 #define STACK_SIZE 2048
+#if CONFIG_SRAM_SIZE <= 32
+#define NUMBER_OF_LOOPS 100
+#else
 #define NUMBER_OF_LOOPS 1000
+#endif
+
 
 extern K_THREAD_STACK_DEFINE(thread_stack1, STACK_SIZE);
 extern K_THREAD_STACK_DEFINE(thread_stack2, STACK_SIZE);


### PR DESCRIPTION
need ram up to 36M for twr_ke18f

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>