### PR TITLE
tcp2: Fixed IS_ENABLED check for NET_TCP_MAX_SEND_WINDOW_SIZE

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1314,7 +1314,7 @@ static void tcp_in(struct tcp *conn, struct net_pkt *pkt)
 
 		conn->send_win = ntohs(th_win(th));
 
-#if IS_ENABLED(CONFIG_NET_TCP_MAX_SEND_WINDOW_SIZE)
+#if defined(CONFIG_NET_TCP_MAX_SEND_WINDOW_SIZE)
 		if (CONFIG_NET_TCP_MAX_SEND_WINDOW_SIZE) {
 			max_win = CONFIG_NET_TCP_MAX_SEND_WINDOW_SIZE;
 		} else


### PR DESCRIPTION
The #if statement used IS_ENABLED to check if it was defined.
IS_ENABLED will only return true if the value is 1, and false otherwise.
If the NET_TCP_MAX_SEND_WINDOW_SIZE value would be e.g. 8, then the
check would fail.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>