### PR TITLE
soc: silabs: Activate SPI peripheral in soc Kconfig

### DIFF
--- a/soc/arm/silabs_exx32/efm32gg11b/Kconfig.defconfig.efm32gg11b
+++ b/soc/arm/silabs_exx32/efm32gg11b/Kconfig.defconfig.efm32gg11b
@@ -24,3 +24,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
@@ -18,3 +18,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
+++ b/soc/arm/silabs_exx32/efm32jg12b/Kconfig.defconfig.efm32jg12b
@@ -24,3 +24,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -24,3 +24,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efm32pg1b/Kconfig.defconfig.efm32pg1b
+++ b/soc/arm/silabs_exx32/efm32pg1b/Kconfig.defconfig.efm32pg1b
@@ -24,3 +24,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -18,3 +18,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI

--- a/soc/arm/silabs_exx32/efr32bg13p/Kconfig.defconfig.efr32bg13p
+++ b/soc/arm/silabs_exx32/efr32bg13p/Kconfig.defconfig.efr32bg13p
@@ -3,30 +3,18 @@
 # Copyright (c) 2020 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO
-
 config GPIO_GECKO
 	default y
-
-endif # GPIO
-
-if I2C
+	depends on GPIO
 
 config I2C_GECKO
 	default y
-
-endif # I2C
-
-if FLASH
+	depends on I2C
 
 config SOC_FLASH_GECKO
 	default y
-
-endif # FLASH
-
-if SPI
+	depends on FLASH
 
 config SPI_GECKO
 	default y
-
-endif # SPI
+	depends on SPI

--- a/soc/arm/silabs_exx32/efr32mg21/Kconfig.defconfig.efr32mg21
+++ b/soc/arm/silabs_exx32/efr32mg21/Kconfig.defconfig.efr32mg21
@@ -18,3 +18,7 @@ config I2C_GECKO
 config SOC_FLASH_GECKO
 	default y
 	depends on FLASH
+
+config SPI_GECKO
+	default y
+	depends on SPI


### PR DESCRIPTION
With this change the soc Kconfig files are a little bit improved:

* activate SPI peripheral depending on CONFIG_SPI in all socs
* for efr32bg13p use "depends on", like in all other socs