### PR TITLE
x86: early_serial: Suppress output attempts prior to init

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -60,6 +60,9 @@ static mm_reg_t mmio;
 #define FCR_XMITCLR BIT(2)  /* clear XMIT FIFO           */
 #define FCR_FIFO_1  0       /* 1 byte in RCVR FIFO       */
 
+static bool early_serial_init_done;
+static uint32_t suppressed_chars;
+
 static void serout(int c)
 {
 	while ((IN(REG_LSR) & LSR_THRE) == 0) {
@@ -69,6 +72,11 @@ static void serout(int c)
 
 int arch_printk_char_out(int c)
 {
+	if (!early_serial_init_done) {
+		suppressed_chars++;
+		return c;
+	}
+
 	if (c == '\n') {
 		serout('\r');
 	}
@@ -99,4 +107,11 @@ void z_x86_early_serial_init(void)
 
 	/* Turn on FIFO. Some hardware needs this before transmitting */
 	OUT(REG_FCR, FCR_FIFO | FCR_FIFO_1 | FCR_RCVRCLR | FCR_XMITCLR);
+
+	early_serial_init_done = true;
+
+	if (suppressed_chars) {
+		printk("WARNING: %u chars lost before early serial init\n",
+		       suppressed_chars);
+	}
 }


### PR DESCRIPTION
Until now, any attempts to call printk prior to early serial init has
caused page faults due to the device not being mapped yet. Add static
variable to track the pre-init status, and instead of page faulting
just suppress the characters and log a warning right after init to
give an indication that output characters have been lost.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>