### PR TITLE
drivers: nrf: avoid UARTE pm infinite loop

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -535,7 +535,8 @@ static int uarte_nrfx_init(const struct device *dev)
 	 */
 	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED)) {
 		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
-		while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
+		while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO) &&
+		       !nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
 			/* Busy wait for event to register */
 		}
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
@@ -1582,7 +1583,9 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 		if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXSTARTED)) {
 			nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
 			while (!nrf_uarte_event_check(uarte,
-						      NRF_UARTE_EVENT_RXTO)) {
+						      NRF_UARTE_EVENT_RXTO) &&
+			       !nrf_uarte_event_check(uarte,
+			                              NRF_UARTE_EVENT_ERROR)) {
 				/* Busy wait for event to register */
 			}
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);


### PR DESCRIPTION
If there is a UARTE receive error (e.g. framing or break), the RXTO event may never come.  Check error event too, to avoid an infinite loop.

The same hang was seen for another reason in #21444.  It may be better to never spin indefinitely here regardless of what the hardware flags do.
