### PR TITLE
doc-build.yml: pip3 install wheel, fix 'invalid command bdist_wheel'

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: install-pip
       run: |
-        pip3 install setuptools
+        pip3 install setuptools wheel
         pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
 


### PR DESCRIPTION
As recommended by @mbolivar-nordic and... stackoverflow.

While I could not reproduce this locally, this should get rid of many
non-fatal pip errors in CI all looking like this one:
```
Building wheels for collected packages: PyYAML, progress, psutil, ...

 Running setup.py bdist_wheel for PyYAML: started
 Running setup.py bdist_wheel for PyYAML: finished with status 'error'

 Complete output from command /usr/bin/python3 -u -c "import setuptools,
  tokenize;__file__='/tmp/pip-build-b3sj5a6m/PyYAML/setup.py';
  f=getattr(tokenize, 'open',open)(__file__);code=f.read().replace(
  '\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))"
  bdist_wheel -d /tmp/tmpvn0bt6xfpip-wheel- --python-tag cp36:

  Failed building wheel for PyYAML
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Running setup.py clean for PyYAML
```
Etc.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>