### PR TITLE
requirements-compliance: restrict junitparser version < 2

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1086,7 +1086,8 @@ def main():
     except BaseException:
         # Catch BaseException instead of Exception to include stuff like
         # SystemExit (raised by sys.exit())
-        print(format(__file__, traceback.format_exc()))
+        print("Python exception in `{}`:\n\n"
+              "```\n{}\n```".format(__file__, traceback.format_exc()))
 
         raise
 

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -2,5 +2,5 @@
 
 # used by ci/check_compliance
 python-magic
-junitparser
+junitparser<2
 pylint


### PR DESCRIPTION
junitparser version 2 is incompatible with check_compliance.py, it fails
like this:
```
File "./scripts/ci/check_compliance.py", line 295, in parse_kconfig
   self.skip("Not a Zephyr tree (ZEPHYR_BASE unset)")
File "./scripts/ci/check_compliance.py", line 141, in skip
   self.case.result = Skipped(msg, "skipped")
File "/usr/local/lib/python3.9/site-packages/junitparser/junitparser.py"
   line 682, in result
   for entry in value:

TypeError: 'Skipped' object is not iterable
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>