### PR TITLE
Bluetooth: controller: Add invalid ACL data length check

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4075,6 +4075,11 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 		return -EINVAL;
 	}
 
+	if (len > CONFIG_BT_CTLR_TX_BUFFER_SIZE) {
+		BT_ERR("Invalid HCI ACL Data length");
+		return -EINVAL;
+	}
+
 	/* assigning flags first because handle will be overwritten */
 	flags = bt_acl_flags(handle);
 	handle = bt_acl_handle(handle);


### PR DESCRIPTION
Add checks to detect ACL data lengths greater than the
configured maximum Tx buffer size in the controller.
The Host should conform to the LE_ACL_Data_Packet_Length
returned by the LE Read Buffer Size command.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>