### PR TITLE
cleanup: rename sanitycheck references to twister

### DIFF
--- a/samples/drivers/espi/README.rst
+++ b/samples/drivers/espi/README.rst
@@ -22,7 +22,7 @@ The sample can be built and executed on boards supporting eSPI.
 Any pins required for minimum eSPI handshake should be configured.
 Sample requires a correct harness and fixture setup.
 Please connect an eSPI device to the testing board.
-After that for the correct execution of that sample in sanitycheck, add into
+After that for the correct execution of that sample in twister, add into
 boards's map-file next fixture settings::
 
       - fixture: espi_device_connect

--- a/samples/drivers/kscan/README.rst
+++ b/samples/drivers/kscan/README.rst
@@ -17,7 +17,7 @@ The sample can be built and executed on boards supporting a Keyboard Matrix.
 It requires a correct fixture setup. Please connect a Keyboard Matrix to
 exercise the functionality (you need to obtain the right keymap from the vendor
 because they vary across different manufactures).
-For the correct execution of that sample in sanitycheck, add into boards's
+For the correct execution of that sample in twister, add into boards's
 map-file next fixture settings::
 
       - fixture: fixture_connect_keyboard

--- a/samples/drivers/ps2/README.rst
+++ b/samples/drivers/ps2/README.rst
@@ -16,7 +16,7 @@ Building and Running
 The sample can be built and executed on boards supporting PS/2.
 It requires a correct fixture setup. Please connect a PS/2 mouse in order to
 exercise the functionality.
-For the correct execution of that sample in sanitycheck, add into boards's
+For the correct execution of that sample in twister, add into boards's
 map-file next fixture settings::
 
       - fixture: fixture_connect_mouse

--- a/samples/sensor/ti_hdc/README.rst
+++ b/samples/sensor/ti_hdc/README.rst
@@ -64,14 +64,14 @@ Build Testing
 
 .. code-block:: bash
 
-    $ZEPHYR_BASE/scripts/sanitycheck -T $ZEPHYR_BASE/samples/sensor/ti_hdc/ -p nucleo_l496zg --device-testing --device-serial /dev/ttyACM0 -t build
+    $ZEPHYR_BASE/scripts/twister -T $ZEPHYR_BASE/samples/sensor/ti_hdc/ -p nucleo_l496zg --device-testing --device-serial /dev/ttyACM0 -t build
 
 Target Testing
 **************
 
 .. code-block:: bash
 
-    $ZEPHYR_BASE/scripts/sanitycheck -T $ZEPHYR_BASE/samples/sensor/ti_hdc/ -p nucleo_l496zg --device-testing --device-serial /dev/ttyACM0 -t target
+    $ZEPHYR_BASE/scripts/twister -T $ZEPHYR_BASE/samples/sensor/ti_hdc/ -p nucleo_l496zg --device-testing --device-serial /dev/ttyACM0 -t target
 
 
 References

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,7 +1,7 @@
 parser.out
 parsetab.py
 tests/.mypy_cache
-tests/sanitycheck/.pytest_cache
-tests/sanitycheck/htmlcov
-tests/sanitycheck/__pycache__
-tests/sanitycheck/.coverage
+tests/twister/.pytest_cache
+tests/twister/htmlcov
+tests/twister/__pycache__
+tests/twister/.coverage

--- a/scripts/footprint/compare_footprint
+++ b/scripts/footprint/compare_footprint
@@ -5,7 +5,7 @@
 This script help you to compare footprint results with previous commits in git.
 If you don't have a git repository, it will compare your current tree
 against the last release results.
-To run it you need to set up the same environment as sanity check.
+To run it you need to set up the same environment as twister.
 The scripts take 2 optional args COMMIT and BASE_COMMIT, which tell the scripts
 which commit to use as current commit and as base for comparing, respectively.
 The script can take any SHA commit recognized for git.
@@ -70,7 +70,7 @@ def init_logs():
 def parse_args():
     parser = argparse.ArgumentParser(
                 description="Compare footprint apps RAM and ROM sizes. Note: "
-                "To run it you need to set up the same environment as sanitycheck.")
+                "To run it you need to set up the same environment as twister.")
     parser.add_argument('-b', '--base-commit', default=None,
                         help="Commit ID to use as base for footprint "
                                     "compare. Default is parent current commit."
@@ -119,7 +119,7 @@ def run_sanity_footprint(commit=None, cwd=os.environ.get('ZEPHYR_BASE'),
                          output_file=None):
     if not output_file:
         output_file = sanity_results_filename(commit)
-    cmd = '/bin/bash -c "source ./zephyr-env.sh && sanitycheck'
+    cmd = '/bin/bash -c "source ./zephyr-env.sh && twister'
     cmd += ' +scripts/sanity_chk/sanity_compare.args -o %s"' % output_file
     logger.debug('Sanity (%s)   %s' %(commit, cmd))
 

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -7,7 +7,7 @@
 pyelftools>=0.26
 
 # used by dts generation to parse binding YAMLs, also used by
-# sanitycheck to parse YAMLs
+# twister to parse YAMLs
 PyYAML>=5.1
 
 # used by west_commands

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -1,12 +1,12 @@
 # BUILD-TEST: required to do build tests of zephyr
 #
-# things used by sanitycheck or other things like code coverage or python
+# things used by twister or other things like code coverage or python
 # testing
 
-# used by sanitycheck for ansi color
+# used by twister for ansi color
 colorama
 
-# python lex/yex used by sanitycheck
+# python lex/yex used by twister
 ply>=3.10
 
 # optional, but used for validation of YAML

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -1,6 +1,6 @@
 # EXTRAS: optional or useful for development/developers workflow
 
-# used by sanitycheck for --test-tree option
+# used by twister for --test-tree option
 anytree
 
 # helper for developers - check git commit messages

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -1,6 +1,6 @@
 # RUN-TEST: required to do run time tests of zephyr
 #
-# things used by sanitycheck or related in run time testing
+# things used by twister or related in run time testing
 
 # used to connect to boards for console IO
 pyserial
@@ -8,11 +8,11 @@ pyserial
 # used to flash & debug various boards
 pyocd>=0.28.0
 
-# used by sanitycheck for board/hardware map
+# used by twister for board/hardware map
 tabulate
 
 # used by mcuboot
 cbor>=1.0.0
 
-# use for sanitycheck
+# use for twister
 psutil

--- a/scripts/schemas/twister/testcase-schema.yaml
+++ b/scripts/schemas/twister/testcase-schema.yaml
@@ -6,7 +6,7 @@
 # a YAML structure validator, to validate the YAML files that describe
 # Zephyr test platforms
 #
-# The original spec comes from Zephyr's sanitycheck script
+# The original spec comes from Zephyr's twister script
 #
 type: map
 mapping:

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -41,7 +41,7 @@ def get_cld_pid(mdb_process):
 # MDB creates child process (cld) which won't be terminated if we simply
 # terminate parents process (mdb). 'record_cld_pid' is provided to record 'cld'
 # process pid to file (mdb.pid) so this process can be terminated correctly by
-# sanitycheck infrastructure
+# twister infrastructure
 def record_cld_pid(mdb_runner, mdb_process):
     for _i in range(100):
         found, pid = get_cld_pid(mdb_process)

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -61,7 +61,7 @@ config ZTEST_FATAL_HOOK
 	  Use the pre-defined common fatal error handler and a post hook to
 	  do actions in your test case, this option often enabled when doing
 	  error test case. Remember to add ignore_fault tag in yaml file when
-	  using sanitycheck to run testing.
+	  using twister to run testing.
 
 config ZTEST_ASSERT_HOOK
 	bool "Using a pre-defined assert handler and hook function"
@@ -70,7 +70,7 @@ config ZTEST_ASSERT_HOOK
 	  Use the pre-defined common assert fail handler and a post hook to
 	  do actions in your test case, this option often enabled when doing
 	  error test case. Remember to add ignore_fault tag in yaml file when
-	  using sanitycheck to run testing.
+	  using twister to run testing.
 
 endif # ZTEST
 

--- a/tests/bluetooth/bsim_bt/README.txt
+++ b/tests/bluetooth/bsim_bt/README.txt
@@ -1,5 +1,5 @@
 This folder contains tests meant to be run with BabbleSim's physical layer
-simulation, and therefore cannot be run directly from sanitycheck
+simulation, and therefore cannot be run directly from twister
 
 The compile.sh and run_parallel.sh scripts are used by the CI system to build
 the needed images and execute these tests in batch.


### PR DESCRIPTION
Cleanup references to sanitycheck that should now be twister.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>