### PR TITLE
heap: clean up some size related issues

### DIFF
--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -102,7 +102,7 @@ The :dfn:`system heap` is a predefined memory allocator that allows
 threads to dynamically allocate memory from a common memory region in
 a :c:func:`malloc`-like manner.
 
-Only a single system heap is be defined. Unlike other heaps or memory
+Only a single system heap is defined. Unlike other heaps or memory
 pools, the system heap cannot be directly referenced using its
 memory address.
 
@@ -136,9 +136,6 @@ A chunk of heap memory is allocated by calling :c:func:`k_malloc`.
 The following code allocates a 200 byte chunk of heap memory, then fills it
 with zeros. A warning is issued if a suitable chunk is not obtained.
 
-Note that the application will actually allocate a 256 byte memory block,
-since that is the closest matching size supported by the heap memory pool.
-
 .. code-block:: c
 
     char *mem_ptr;
@@ -157,8 +154,7 @@ Releasing Memory
 A chunk of heap memory is released by calling :c:func:`k_free`.
 
 The following code allocates a 75 byte chunk of memory, then releases it
-once it is no longer needed. (A 256 byte memory block from the heap memory
-pool is actually used to satisfy the request.)
+once it is no longer needed.
 
 .. code-block:: c
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -512,15 +512,6 @@ config HEAP_MEM_POOL_SIZE
 	  the memory pool is only limited to available memory. A size of zero
 	  means that no heap memory pool is defined.
 
-config HEAP_MEM_POOL_MIN_SIZE
-	int "The smallest blocks in the heap memory pool (in bytes)"
-	depends on HEAP_MEM_POOL_SIZE != 0
-	default 64
-	help
-	  This option specifies the size of the smallest block in the pool.
-	  Option must be a power of 2 and lower than or equal to the size
-	  of the entire pool.
-
 endif # KERNEL_MEM_POOL
 
 endmenu

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -351,8 +351,8 @@ void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 
 void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 {
-	/* Must fit in a 32 bit count of HUNK_UNIT */
-	__ASSERT(bytes / CHUNK_UNIT <= 0xffffffffU, "heap size is too big");
+	/* Must fit in a 31 bit count of HUNK_UNIT */
+	__ASSERT(bytes / CHUNK_UNIT <= 0x7fffffffU, "heap size is too big");
 
 	/* Reserve the final marker chunk's header */
 	__ASSERT(bytes > heap_footer_bytes(bytes), "heap size is too small");


### PR DESCRIPTION
First, the maximum heap size must fit in 31 bits worth of chunks
because the internal 32-bit field holding the size is shared with
the `used` bit.

Then the mention of a 256-byte block in the doc is no longer
relevant. That pertained to the previous allocator implementation.

And ditto for the HEAP_MEM_POOL_MIN_SIZE kconfig option.