### PR TITLE
scripts/Kconfig: Add dt_node_has_prop Kconfig function

### DIFF
--- a/doc/guides/kconfig/preprocessor-functions.rst
+++ b/doc/guides/kconfig/preprocessor-functions.rst
@@ -39,6 +39,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_compat_enabled,<compatible string>)
    $(dt_chosen_enabled,<property in /chosen>)
    $(dt_node_has_bool_prop,<node path>,<prop>)
+   $(dt_node_has_prop,<node path>,<prop>)
 
 
 Example Usage

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -324,6 +324,29 @@ def dt_node_has_bool_prop(kconf, _, path, prop):
 
     return "n"
 
+def dt_node_has_prop(kconf, _, label, prop):
+    """
+    This function takes a 'label' and looks for an EDT node for that label. If
+    it finds an EDT node, it will look to see if that node has a property
+    by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
+    we return "n".
+    """
+
+    if doc_mode or edt is None:
+        return "n"
+
+    try:
+        node = edt.label2node.get(label)
+    except edtlib.EDTError:
+        return "n"
+
+    if node is None:
+        return "n"
+
+    if prop in node.props:
+        return "y"
+
+    return "n"
 
 def dt_node_int_prop(kconf, name, path, prop):
     """
@@ -445,6 +468,7 @@ functions = {
         "dt_node_reg_size_int": (dt_node_reg, 1, 3),
         "dt_node_reg_size_hex": (dt_node_reg, 1, 3),
         "dt_node_has_bool_prop": (dt_node_has_bool_prop, 2, 2),
+        "dt_node_has_prop": (dt_node_has_prop, 2, 2),
         "dt_node_int_prop_int": (dt_node_int_prop, 2, 2),
         "dt_node_int_prop_hex": (dt_node_int_prop, 2, 2),
         "dt_nodelabel_has_compat": (dt_nodelabel_has_compat, 2, 2),


### PR DESCRIPTION
Add dt_node_has_prop function to query the presence of 'prop'
for given node label.

Cf use in https://github.com/zephyrproject-rtos/zephyr/pull/30864

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>