### PR TITLE
dts: arm: stm32: stm32l1 EEPROM updates

### DIFF
--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -257,7 +257,6 @@
 
 		eeprom: eeprom@8080000{
 			compatible = "st,stm32-eeprom";
-			reg = <0x08080000 DT_SIZE_K(4)>;
 			status = "disabled";
 			label = "EEPROM_0";
 		};

--- a/dts/arm/st/l1/stm32l151X8-a.dtsi
+++ b/dts/arm/st/l1/stm32l151X8-a.dtsi
@@ -18,5 +18,8 @@
 				reg = <0x08000000 DT_SIZE_K(64)>;
 			};
 		};
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(4)>;
+		};
 	};
 };

--- a/dts/arm/st/l1/stm32l151Xb-a.dtsi
+++ b/dts/arm/st/l1/stm32l151Xb-a.dtsi
@@ -18,5 +18,8 @@
 				reg = <0x08000000 DT_SIZE_K(128)>;
 			};
 		};
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(4)>;
+		};
 	};
 };

--- a/dts/arm/st/l1/stm32l151Xb.dtsi
+++ b/dts/arm/st/l1/stm32l151Xb.dtsi
@@ -18,5 +18,8 @@
 				reg = <0x08000000 DT_SIZE_K(128)>;
 			};
 		};
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(4)>;
+		};
 	};
 };


### PR DESCRIPTION
As discussed in #30927, changes to stm32l1x dtsi files. 

Includes:
- removal of eeprom's `reg` attribute in stm32l1.dtsi, to ensure that EEPROM size is specified per SoC in the series (same method as done for stm32l0x) 
- EEPROM sizes specified for stm32l151X8-a, stm32l151Xb-a, stm32l151Xb 
(already covered in stm32l1Xc.dtsi & stm32l152Xe - included in #30926 for stm32l152Xc)

