### PR TITLE
xtensa: include core-macros.h on esp32 only

### DIFF
--- a/include/arch/xtensa/xtensa_api.h
+++ b/include/arch/xtensa/xtensa_api.h
@@ -7,7 +7,9 @@
 #define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_API_H_
 
 #include <xtensa/hal.h>
+#if defined(CONFIG_SOC_ESP32)
 #include <xtensa/core-macros.h>
+#endif
 #include "xtensa_rtos.h"
 #include "xtensa_context.h"
 


### PR DESCRIPTION
core-macros.h includes other files not part of the xtensa HAL, make this
esp32 specific now until the headers are recovered.

Fixes #31301