### PR TITLE
lorawan: fix premature return in `lorawan_send`

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -85,7 +85,10 @@ static void McpsConfirm(McpsConfirm_t *mcpsConfirm)
 	}
 
 	last_mcps_confirm_status = mcpsConfirm->Status;
-	k_sem_give(&mcps_confirm_sem);
+	/* mcps_confirm_sem is only blocked on in the MCPS_CONFIRMED case */
+	if (mcpsConfirm->McpsRequest == MCPS_CONFIRMED) {
+		k_sem_give(&mcps_confirm_sem);
+	}
 }
 
 static void McpsIndication(McpsIndication_t *mcpsIndication)


### PR DESCRIPTION
Fixes an issue where `lorawan_send` would return prematurely when
`LORAWAN_MSG_CONFIRMED` is mixed with unconfirmed messages.

All calls to `LoRaMacMcpsRequest` result in `McpsConfirm` being run,
where the semaphore `mcps_confirm_sem` is given. However this semaphore
is only taken when `LORAWAN_MSG_CONFIRMED` is set.

Therefore if an unconfirmed message is sent, any following confirmed
messages will return from `lorawan_send` immediately as the semaphore
will be available from the previous send. The return value would also
be wrong for the same reasons.

Fixed by only giving the semaphore in situations when it is being
blocked on.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>