### PR TITLE
xtensa: remove core-macros.h from xtensa HAL

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -21,6 +21,7 @@
 #include <sys/util.h>
 #include "clock_control_esp32.h"
 #include "driver/periph_ctrl.h"
+#include <xtensa/core-macros.h>
 
 struct esp32_clock_config {
 	uint32_t clk_src_sel;

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -15,6 +15,7 @@
 #include <soc/apb_ctrl_reg.h>
 #include <esp_system.h>
 #include <soc.h>
+#include <xtensa/core-macros.h>
 
 extern int esp_clk_cpu_freq(void);
 extern int esp_clk_apb_freq(void);

--- a/include/arch/xtensa/xtensa_api.h
+++ b/include/arch/xtensa/xtensa_api.h
@@ -7,7 +7,6 @@
 #define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_API_H_
 
 #include <xtensa/hal.h>
-#include <xtensa/core-macros.h>
 #include "xtensa_rtos.h"
 #include "xtensa_context.h"
 


### PR DESCRIPTION
core-macros.h includes other files not part of the xtensa HAL, make this
esp32 specific

Fixes #31301

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>