### PR TITLE
xtensa: fix an assembly warning in start_address.S

### DIFF
--- a/soc/xtensa/intel_adsp/common/bootloader/start_address.S
+++ b/soc/xtensa/intel_adsp/common/bootloader/start_address.S
@@ -21,4 +21,10 @@
 __start:
 	movi	a0, 0
 	call0	_start		 /* jump to _start (in crt1-*.S) */
+
+	/* never returns */
+
+	.size	__start, . - __start
+
+	.end	literal_prefix
 #endif


### PR DESCRIPTION
Add missing .end and .size in start_address.S