### PR TITLE
Cleanups in dts bindings

### DIFF
--- a/dts/bindings/clock/litex,clkout.yaml
+++ b/dts/bindings/clock/litex,clkout.yaml
@@ -27,37 +27,37 @@ properties:
 
   litex,clock-frequency:
     required: true
-    type : int
+    type: int
     description: |
       default frequency in Hz for clock output
 
   litex,clock-phase:
     required: true
-    type : int
+    type: int
     description: |
       default phase offset given in degrees
 
   litex,clock-duty-num:
     required: true
-    type : int
+    type: int
     description: |
       default duty cycle numerator value
 
   litex,clock-duty-den:
     required: true
-    type : int
+    type: int
     description: |
       default duty cycle denominator value
 
   litex,clock-margin:
     required: true
-    type : int
+    type: int
     description: |
       clock output margin coefficient
 
   litex,clock-margin-exp:
     required: true
-    type : int
+    type: int
     description: |
       exponent for clkout margin
       effective clkout margin shall be

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -14,7 +14,7 @@ properties:
     "#size-cells":
       required: true
       const: 0
-    clock-frequency :
+    clock-frequency:
       type: int
       required: false
       description: Initial clock frequency in Hz

--- a/dts/bindings/i2c/nuvoton,npcx-i2c-port.yaml
+++ b/dts/bindings/i2c/nuvoton,npcx-i2c-port.yaml
@@ -8,9 +8,6 @@ compatible: "nuvoton,npcx-i2c-port"
 include: i2c-controller.yaml
 
 properties:
-    label:
-        required: true
-
     port:
         type: int
         required: true
@@ -27,6 +24,4 @@ properties:
         description: configurations of pinmux controllers
 
     clock-frequency:
-        type: int
-        required: false
-        description: Initial clock frequency in Hz
+        required: true


### PR DESCRIPTION
Hi, this is changing the clock-frequency for npcx-i2c-port as required (the driver fails to build without it) and drops the redundant definitions. Spotted a couple of syntax nits in other files so I sent one for those while I'm on it.