### PR TITLE
boards/dts: riscv: add SiFive FE310 watchdog driver bindings

### DIFF
--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -9,10 +9,12 @@
 / {
 	model = "SiFive HiFive 1 Rev B";
 	compatible = "sifive,hifive1-revb";
+
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		watchdog0 = &wdog0;
 	};
 
 	chosen {

--- a/dts/bindings/watchdog/sifive,wdt.yaml
+++ b/dts/bindings/watchdog/sifive,wdt.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Katsuhiro Suzuki
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFive FE310 Watchdog driver
+
+compatible: "sifive,wdt"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    interrupts:
+      required: true

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -37,11 +37,19 @@
 		compatible = "SiFive,FE310G-0002-Z0-soc", "fe310-soc",
 			"sifive-soc", "simple-bus";
 		ranges;
-		aon: aon@10000000 {
+		wdog0: wdog@10000000 {
+			compatible = "sifive,wdt";
+			interrupt-parent = <&plic>;
+			interrupts = <1 1>;
+			reg = <0x10000000 0x40>;
+			reg-names = "control";
+			label = "WDOG0";
+		};
+		aon: aon@10000040 {
 			compatible = "sifive,aon0";
 			interrupt-parent = <&plic>;
-			interrupts = <1 1>, <2 1>;
-			reg = <0x10000000 0x1000>;
+			interrupts = <2 1>;
+			reg = <0x10000040 0x9c0>;
 			reg-names = "control";
 		};
 		clint: clint@2000000 {


### PR DESCRIPTION
This patch adds watchdog driver bindings and enable it for SiFive
HiFive1 rev.B board.