### PR TITLE
Bluetooth: controller: nRF21540 FEM support for nRF52x and nRF53x Series

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -649,9 +649,9 @@ config BT_CTLR_GPIO_PA_POL_INV
 config BT_CTLR_GPIO_PA_OFFSET
 	int "Time from PA ON to Tx ready"
 	default 5
-	range 0 10
+	range 0 15
 	help
-	  Time before Tx ready to turn on PA.
+	  Time before Tx ready to turn on PA in micro seconds.
 
 endif # BT_CTLR_GPIO_PA
 
@@ -680,11 +680,56 @@ config BT_CTLR_GPIO_LNA_POL_INV
 config BT_CTLR_GPIO_LNA_OFFSET
 	int "Time from LNA ON to Rx ready"
 	default 5
-	range 0 10
+	range 0 15
 	help
-	  Time before Rx ready to turn on LNA.
+	  Time before Rx ready to turn on LNA in micro seconds.
 
 endif # BT_CTLR_GPIO_LNA
+
+menuconfig BT_CTLR_FEM_NRF21540
+	bool "nRF21540 GPIO interface"
+	depends on !SOC_SERIES_NRF51X
+	select BT_CTLR_GPIO_PA
+	select BT_CTLR_GPIO_LNA
+	help
+	  Enable PDN and CSN GPIO interface for the nRF21540. This allows
+	  hardware designs using the nRF21540 to let the controller toggle
+	  their state based on radio activity.
+
+if BT_CTLR_FEM_NRF21540
+
+config BT_CTLR_GPIO_PDN_PIN
+	int "FEM PDN pin number"
+	range 0 47 if SOC_NRF52840 || SOC_NRF5340_CPUNET
+	range 0 31
+	help
+	  GPIO Pin number connected to the PDN pin of the nRF21540 FEM.
+
+config BT_CTLR_GPIO_PDN_POL_INV
+	bool "Inverted polarity for the PDN pin"
+	help
+	  Enable inverted polarity (active low) for the PDN pin.
+
+config BT_CTLR_GPIO_CSN_PIN
+	int "FEM CSN pin number"
+	range 0 47 if SOC_NRF52840 || SOC_NRF5340_CPUNET
+	range 0 31
+	help
+	  GPIO Pin number connected to the CSN pin of the nRF21540 FEM.
+
+config BT_CTLR_GPIO_CSN_POL_INV
+	bool "Inverted polarity for the CSN pin"
+	default y
+	help
+	  Enable inverted polarity (active low) for the CSN pin.
+
+config BT_CTLR_GPIO_PDN_CSN_OFFSET
+	int "Time from PDN and CSN toggle to PA/LNA pin toggle"
+	range 0 20
+	help
+	  Time from PDN and CSN toggle to PA/LNA pin toggle in micro seconds.
+
+endif # BT_CTLR_FEM_NRF21540
 
 config BT_CTLR_PA_LNA_GPIOTE_CHAN
 	# Hidden "nRF5 GPIO PA/LNA GPIOTE Channel"
@@ -694,6 +739,24 @@ config BT_CTLR_PA_LNA_GPIOTE_CHAN
 	default 0
 	help
 	  Select the nRF5 GPIOTE channel to use for PA/LNA GPIO feature.
+
+config BT_CTLR_PDN_GPIOTE_CHAN
+	# Hidden "nRF5 GPIO FEM PDN GPIOTE Channel"
+	int
+	depends on SOC_FAMILY_NRF && BT_CTLR_FEM_NRF21540
+	default 4 if PWM_NRF5_SW
+	default 1
+	help
+	  Select the nRF5 GPIOTE channel to use for FEM PDN GPIO pin toggle.
+
+config BT_CTLR_CSN_GPIOTE_CHAN
+	# Hidden "nRF5 GPIO FEM CSN GPIOTE Channel"
+	int
+	depends on SOC_FAMILY_NRF && BT_CTLR_FEM_NRF21540
+	default 5 if PWM_NRF5_SW
+	default 2
+	help
+	  Select the nRF5 GPIOTE channel to use for FEM CSN GPIO pin toggle.
 
 comment "BLE Controller debug configuration"
 

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -636,7 +636,7 @@ if BT_CTLR_GPIO_PA
 
 config BT_CTLR_GPIO_PA_PIN
 	int "Power Amplifier GPIO pin number"
-	range 0 47 if SOC_NRF52840
+	range 0 47 if SOC_NRF52840 || SOC_NRF5340_CPUNET
 	range 0 31
 	help
 	  GPIO Pin number connected to a Power Amplifier.
@@ -667,7 +667,7 @@ if BT_CTLR_GPIO_LNA
 
 config BT_CTLR_GPIO_LNA_PIN
 	int "Low Noise Amplifier GPIO pin number"
-	range 0 47 if SOC_NRF52840
+	range 0 47 if SOC_NRF52840 || SOC_NRF5340_CPUNET
 	range 0 31
 	help
 	  GPIO Pin number connected to a Low Noise Amplifier.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -41,6 +41,27 @@
 #endif
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_PIN)
+#if ((CONFIG_BT_CTLR_GPIO_PDN_PIN) > 31)
+#define NRF_GPIO_PDN     NRF_P1
+#define NRF_GPIO_PDN_PIN ((CONFIG_BT_CTLR_GPIO_PDN_PIN) - 32)
+#else
+#define NRF_GPIO_PDN     NRF_P0
+#define NRF_GPIO_PDN_PIN CONFIG_BT_CTLR_GPIO_PDN_PIN
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_PDN_PIN */
+
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_PIN)
+#if ((CONFIG_BT_CTLR_GPIO_CSN_PIN) > 31)
+#define NRF_GPIO_CSN     NRF_P1
+#define NRF_GPIO_CSN_PIN ((CONFIG_BT_CTLR_GPIO_CSN_PIN) - 32)
+#else
+#define NRF_GPIO_CSN     NRF_P0
+#define NRF_GPIO_CSN_PIN CONFIG_BT_CTLR_GPIO_CSN_PIN
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_CSN_PIN */
+
+
 /* The following two constants are used in nrfx_glue.h for marking these PPI
  * channels and groups as occupied and thus unavailable to other modules.
  */
@@ -97,6 +118,24 @@ void radio_setup(void)
 	radio_gpio_lna_off();
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_PIN)
+	NRF_GPIO_PDN->DIRSET = BIT(NRF_GPIO_PDN_PIN);
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_POL_INV)
+	NRF_GPIO_PDN->OUTSET = BIT(NRF_GPIO_PDN_PIN);
+#else
+	NRF_GPIO_PDN->OUTCLR = BIT(NRF_GPIO_PDN_PIN);
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_PDN_PIN */
+
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_PIN)
+	NRF_GPIO_CSN->DIRSET = BIT(NRF_GPIO_CSN_PIN);
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_POL_INV)
+	NRF_GPIO_CSN->OUTSET = BIT(NRF_GPIO_CSN_PIN);
+#else
+	NRF_GPIO_CSN->OUTCLR = BIT(NRF_GPIO_CSN_PIN);
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_CSN_PIN */
+
 	hal_radio_ram_prio_setup();
 }
 
@@ -121,6 +160,9 @@ void radio_reset(void)
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN) || defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 	hal_palna_ppi_setup();
+#endif
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+	hal_fem_ppi_setup();
 #endif
 }
 
@@ -982,6 +1024,12 @@ void radio_gpio_pa_setup(void)
 		(GPIOTE_CONFIG_OUTINIT_Low <<
 		 GPIOTE_CONFIG_OUTINIT_Pos);
 #endif
+
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+	hal_pa_ppi_setup();
+	radio_gpio_pdn_setup();
+	radio_gpio_csn_setup();
+#endif
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 
@@ -1006,7 +1054,61 @@ void radio_gpio_lna_setup(void)
 		(GPIOTE_CONFIG_OUTINIT_Low <<
 		 GPIOTE_CONFIG_OUTINIT_Pos);
 #endif
+
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+	hal_lna_ppi_setup();
+	radio_gpio_pdn_setup();
+	radio_gpio_csn_setup();
+#endif
 }
+
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_PIN)
+void radio_gpio_pdn_setup(void)
+{
+	/* NOTE: With GPIO Pins above 31, left shift of
+	 *       CONFIG_BT_CTLR_GPIO_PA_PIN by GPIOTE_CONFIG_PSEL_Pos will
+	 *       set the NRF_GPIOTE->CONFIG[n].PORT to 1 (P1 port).
+	 */
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PDN_GPIOTE_CHAN] =
+		(GPIOTE_CONFIG_MODE_Task <<
+		 GPIOTE_CONFIG_MODE_Pos) |
+		(CONFIG_BT_CTLR_GPIO_PDN_PIN <<
+		 GPIOTE_CONFIG_PSEL_Pos) |
+		(GPIOTE_CONFIG_POLARITY_Toggle <<
+		 GPIOTE_CONFIG_POLARITY_Pos) |
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_POL_INV)
+		(GPIOTE_CONFIG_OUTINIT_High <<
+		 GPIOTE_CONFIG_OUTINIT_Pos);
+#else
+		(GPIOTE_CONFIG_OUTINIT_Low <<
+		 GPIOTE_CONFIG_OUTINIT_Pos);
+#endif
+}
+#endif /* CONFIG_BT_CTLR_GPIO_PDN_PIN */
+
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_PIN)
+void radio_gpio_csn_setup(void)
+{
+	/* NOTE: With GPIO Pins above 31, left shift of
+	 *       CONFIG_BT_CTLR_GPIO_PA_PIN by GPIOTE_CONFIG_PSEL_Pos will
+	 *       set the NRF_GPIOTE->CONFIG[n].PORT to 1 (P1 port).
+	 */
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_CSN_GPIOTE_CHAN] =
+		(GPIOTE_CONFIG_MODE_Task <<
+		 GPIOTE_CONFIG_MODE_Pos) |
+		(CONFIG_BT_CTLR_GPIO_CSN_PIN <<
+		 GPIOTE_CONFIG_PSEL_Pos) |
+		(GPIOTE_CONFIG_POLARITY_Toggle <<
+		 GPIOTE_CONFIG_POLARITY_Pos) |
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_POL_INV)
+		(GPIOTE_CONFIG_OUTINIT_High <<
+		 GPIOTE_CONFIG_OUTINIT_Pos);
+#else
+		(GPIOTE_CONFIG_OUTINIT_Low <<
+		 GPIOTE_CONFIG_OUTINIT_Pos);
+#endif
+}
+#endif /* CONFIG_BT_CTLR_GPIO_CSN_PIN */
 
 void radio_gpio_lna_on(void)
 {
@@ -1030,15 +1132,34 @@ void radio_gpio_lna_off(void)
 void radio_gpio_pa_lna_enable(uint32_t trx_us)
 {
 	nrf_timer_cc_set(EVENT_TIMER, 2, trx_us);
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+	nrf_timer_cc_set(EVENT_TIMER, 3, (trx_us -
+					  CONFIG_BT_CTLR_GPIO_PDN_CSN_OFFSET));
 	hal_radio_nrf_ppi_channels_enable(BIT(HAL_ENABLE_PALNA_PPI) |
-				BIT(HAL_DISABLE_PALNA_PPI));
+					  BIT(HAL_DISABLE_PALNA_PPI) |
+					  BIT(HAL_ENABLE_FEM_PPI) |
+					  BIT(HAL_DISABLE_FEM_PPI));
+#else
+	hal_radio_nrf_ppi_channels_enable(BIT(HAL_ENABLE_PALNA_PPI) |
+					  BIT(HAL_DISABLE_PALNA_PPI));
+#endif
 }
 
 void radio_gpio_pa_lna_disable(void)
 {
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
 	hal_radio_nrf_ppi_channels_disable(BIT(HAL_ENABLE_PALNA_PPI) |
-				 BIT(HAL_DISABLE_PALNA_PPI));
+					   BIT(HAL_DISABLE_PALNA_PPI) |
+					   BIT(HAL_ENABLE_FEM_PPI) |
+					   BIT(HAL_DISABLE_FEM_PPI));
 	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN] = 0;
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PDN_GPIOTE_CHAN] = 0;
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_CSN_GPIOTE_CHAN] = 0;
+#else
+	hal_radio_nrf_ppi_channels_disable(BIT(HAL_ENABLE_PALNA_PPI) |
+					   BIT(HAL_DISABLE_PALNA_PPI));
+	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN] = 0;
+#endif
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -88,6 +88,8 @@ uint32_t radio_tmr_sample_get(void);
 
 void radio_gpio_pa_setup(void);
 void radio_gpio_lna_setup(void);
+void radio_gpio_pdn_setup(void);
+void radio_gpio_csn_setup(void);
 void radio_gpio_lna_on(void);
 void radio_gpio_lna_off(void);
 void radio_gpio_pa_lna_enable(uint32_t trx_us);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -28,7 +28,7 @@ static inline void hal_radio_nrf_ppi_channels_disable(uint32_t mask)
  * Enable Radio on Event Timer tick:
  * wire the EVENT_TIMER EVENTS_COMPARE[0] event to RADIO TASKS_TXEN/RXEN task.
  */
-#define HAL_RADIO_ENABLE_ON_TICK_PPI 0
+#define HAL_RADIO_ENABLE_ON_TICK_PPI 6
 #define HAL_RADIO_ENABLE_TX_ON_TICK_PPI HAL_RADIO_ENABLE_ON_TICK_PPI
 #define HAL_RADIO_ENABLE_RX_ON_TICK_PPI HAL_RADIO_ENABLE_ON_TICK_PPI
 
@@ -63,7 +63,7 @@ static inline void hal_radio_enable_on_tick_ppi_config_and_enable(uint8_t trx)
  * wire the RADIO EVENTS_ADDRESS event to the
  * EVENT_TIMER TASKS_CAPTURE[<address timer>] task.
  */
-#define HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI 3
+#define HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI 9
 
 static inline void hal_radio_recv_timeout_cancel_ppi_config(void)
 {
@@ -78,7 +78,7 @@ static inline void hal_radio_recv_timeout_cancel_ppi_config(void)
  * wire the EVENT_TIMER EVENTS_COMPARE[<HCTO timer>] event
  * to the RADIO TASKS_DISABLE task.
  */
-#define HAL_RADIO_DISABLE_ON_HCTO_PPI 4
+#define HAL_RADIO_DISABLE_ON_HCTO_PPI 10
 
 static inline void hal_radio_disable_on_hcto_ppi_config(void)
 {
@@ -93,7 +93,7 @@ static inline void hal_radio_disable_on_hcto_ppi_config(void)
  * wire the RADIO EVENTS_END event to the
  * EVENT_TIMER TASKS_CAPTURE[<radio end timer>] task.
  */
-#define HAL_RADIO_END_TIME_CAPTURE_PPI 5
+#define HAL_RADIO_END_TIME_CAPTURE_PPI 11
 
 static inline void hal_radio_end_time_capture_ppi_config(void)
 {
@@ -106,7 +106,7 @@ static inline void hal_radio_end_time_capture_ppi_config(void)
  * Start event timer on RTC tick:
  * wire the RTC0 EVENTS_COMPARE[2] event to EVENT_TIMER  TASKS_START task.
  */
-#define HAL_EVENT_TIMER_START_PPI 1
+#define HAL_EVENT_TIMER_START_PPI 7
 
 static inline void hal_event_timer_start_ppi_config(void)
 {
@@ -119,7 +119,7 @@ static inline void hal_event_timer_start_ppi_config(void)
  * wire the RADIO EVENTS_READY event to the
  * EVENT_TIMER TASKS_CAPTURE[<radio ready timer>] task.
  */
-#define HAL_RADIO_READY_TIME_CAPTURE_PPI 2
+#define HAL_RADIO_READY_TIME_CAPTURE_PPI 8
 
 static inline void hal_radio_ready_time_capture_ppi_config(void)
 {
@@ -149,7 +149,7 @@ static inline void hal_trigger_crypt_ppi_config(void)
  * Trigger automatic address resolution on Bit counter match:
  * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
  */
-#define HAL_TRIGGER_AAR_PPI 6
+#define HAL_TRIGGER_AAR_PPI 12
 
 static inline void hal_trigger_aar_ppi_config(void)
 {
@@ -211,7 +211,7 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
  * 2 adjacent PPIs (8 & 9) and 2 adjacent PPI groups are used for this wiring;
  * <index> must be 0 or 1. <offset> must be a valid TIMER CC register offset.
  */
-#define HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE 8
+#define HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE 14
 #define HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI(index) \
 	(HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE + index)
 
@@ -266,7 +266,7 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
  * We use the same PPI for the alternative SW Switch Timer compare
  * event.
  */
-#define HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE 8
+#define HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE 14
 #define HAL_SW_SWITCH_RADIO_ENABLE_PPI(index) \
 	(HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE + index)
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -13,6 +13,7 @@
 #include <hal/nrf_rtc.h>
 #include <hal/nrf_ccm.h>
 #include <hal/nrf_aar.h>
+#include <hal/nrf_gpiote.h>
 
 static inline void hal_radio_nrf_ppi_channels_enable(uint32_t mask)
 {
@@ -167,6 +168,27 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_RATEBOOST, HAL_TRIGGER_RATEOVERRIDE_PPI);
 	nrf_ccm_subscribe_set(NRF_CCM, NRF_CCM_TASK_RATEOVERRIDE, HAL_TRIGGER_RATEOVERRIDE_PPI);
 }
+
+/******************************************************************************/
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN) || defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+
+#define HAL_ENABLE_PALNA_PPI 5
+#define HAL_DISABLE_PALNA_PPI HAL_ENABLE_PALNA_PPI
+
+static inline void hal_palna_ppi_setup(void)
+{
+	nrf_gpiote_task_t task;
+
+	nrf_timer_publish_set(EVENT_TIMER, NRF_TIMER_EVENT_COMPARE2,
+			      HAL_ENABLE_PALNA_PPI);
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED,
+			      HAL_DISABLE_PALNA_PPI);
+
+	task = nrf_gpiote_out_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+}
+
+#endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -173,22 +173,105 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN) || defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 
 #define HAL_ENABLE_PALNA_PPI 5
+
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+#define HAL_DISABLE_PALNA_PPI 4
+#else
 #define HAL_DISABLE_PALNA_PPI HAL_ENABLE_PALNA_PPI
+#endif
 
 static inline void hal_palna_ppi_setup(void)
 {
-	nrf_gpiote_task_t task;
-
 	nrf_timer_publish_set(EVENT_TIMER, NRF_TIMER_EVENT_COMPARE2,
 			      HAL_ENABLE_PALNA_PPI);
 	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED,
 			      HAL_DISABLE_PALNA_PPI);
 
+#if !defined(CONFIG_BT_CTLR_FEM_NRF21540)
+	nrf_gpiote_task_t task;
+
 	task = nrf_gpiote_out_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
 	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+#endif
 }
 
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+/******************************************************************************/
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+
+static inline void hal_pa_ppi_setup(void)
+{
+	nrf_gpiote_task_t task;
+
+#if defined(CONFIG_BT_CTLR_GPIO_PA_POL_INV)
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_PALNA_PPI);
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+#else /* !CONFIG_BT_CTLR_GPIO_PA_POL_INV */
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_PALNA_PPI);
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+#endif /* !CONFIG_BT_CTLR_GPIO_PA_POL_INV */
+}
+
+static inline void hal_lna_ppi_setup(void)
+{
+	nrf_gpiote_task_t task;
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_POL_INV)
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_PALNA_PPI);
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+#else /* !CONFIG_BT_CTLR_GPIO_LNA_POL_INV */
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_PALNA_PPI);
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_PALNA_PPI);
+#endif /* !CONFIG_BT_CTLR_GPIO_LNA_POL_INV */
+}
+
+#define HAL_ENABLE_FEM_PPI 3
+#define HAL_DISABLE_FEM_PPI HAL_DISABLE_PALNA_PPI
+
+static inline void hal_fem_ppi_setup(void)
+{
+	nrf_gpiote_task_t task;
+
+	nrf_timer_publish_set(EVENT_TIMER, NRF_TIMER_EVENT_COMPARE3,
+			      HAL_ENABLE_FEM_PPI);
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED,
+			      HAL_DISABLE_FEM_PPI);
+
+#if defined(CONFIG_BT_CTLR_GPIO_PDN_POL_INV)
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PDN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_FEM_PPI);
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PDN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_FEM_PPI);
+#else /* !CONFIG_BT_CTLR_GPIO_PDN_POL_INV */
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_PDN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_FEM_PPI);
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_PDN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_FEM_PPI);
+#endif /* !CONFIG_BT_CTLR_GPIO_PDN_POL_INV */
+
+#if defined(CONFIG_BT_CTLR_GPIO_CSN_POL_INV)
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_CSN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_FEM_PPI);
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_CSN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_FEM_PPI);
+#else /* !CONFIG_BT_CTLR_GPIO_CSN_POL_INV */
+	task = nrf_gpiote_set_task_get(CONFIG_BT_CTLR_CSN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_ENABLE_FEM_PPI);
+	task = nrf_gpiote_clr_task_get(CONFIG_BT_CTLR_CSN_GPIOTE_CHAN);
+	nrf_gpiote_subscribe_set(NRF_GPIOTE, task, HAL_DISABLE_FEM_PPI);
+#endif /* !CONFIG_BT_CTLR_GPIO_CSN_POL_INV */
+}
+
+#endif /* CONFIG_BT_CTLR_FEM_NRF21540 */
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
@@ -547,7 +630,8 @@ static inline void hal_radio_group_task_disable_ppi_setup(void)
 	 BIT(HAL_TRIGGER_CRYPT_PPI) | \
 	 BIT(HAL_TRIGGER_AAR_PPI) | \
 	 HAL_USED_PPI_CHANNELS_2 | HAL_USED_PPI_CHANNELS_3 | \
-	 HAL_USED_PPI_CHANNELS_4 | HAL_USED_PPI_CHANNELS_5)
+	 HAL_USED_PPI_CHANNELS_4 | HAL_USED_PPI_CHANNELS_5 | \
+	 HAL_USED_PPI_CHANNELS_6)
 
 #if defined(HAL_TRIGGER_RATEOVERRIDE_PPI)
 #define HAL_USED_PPI_CHANNELS_2 \
@@ -583,6 +667,14 @@ static inline void hal_radio_group_task_disable_ppi_setup(void)
 	 BIT(HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI))
 #else
 #define HAL_USED_PPI_CHANNELS_5 0
+#endif
+
+#if defined(HAL_ENABLE_FEM_PPI)
+#define HAL_USED_PPI_CHANNELS_6 \
+	(BIT(HAL_ENABLE_FEM_PPI) | \
+	 BIT(HAL_DISABLE_FEM_PPI))
+#else
+#define HAL_USED_PPI_CHANNELS_6 0
 #endif
 
 BUILD_ASSERT(

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -297,14 +297,29 @@ static inline void hal_lna_ppi_setup(void)
 	/* Nothing specific to LNA with FEM to handle inside TRX chains */
 }
 
-/* TODO: Dummy assignments, implementation will be added in subsequently */
 #define HAL_ENABLE_FEM_PPI  4
 #define HAL_DISABLE_FEM_PPI 5
 
 static inline void hal_fem_ppi_setup(void)
 {
-	/* TODO: Implementation will be added in subsequently */
+	nrf_ppi_channel_and_fork_endpoint_setup(
+		NRF_PPI,
+		HAL_ENABLE_FEM_PPI,
+		(uint32_t)&(EVENT_TIMER->EVENTS_COMPARE[3]),
+		(uint32_t)&(NRF_GPIOTE->TASKS_OUT[
+				CONFIG_BT_CTLR_PDN_GPIOTE_CHAN]),
+		(uint32_t)&(NRF_GPIOTE->TASKS_OUT[
+				CONFIG_BT_CTLR_CSN_GPIOTE_CHAN]));
+	nrf_ppi_channel_and_fork_endpoint_setup(
+		NRF_PPI,
+		HAL_DISABLE_FEM_PPI,
+		(uint32_t)&(NRF_RADIO->EVENTS_DISABLED),
+		(uint32_t)&(NRF_GPIOTE->TASKS_OUT[
+				CONFIG_BT_CTLR_PDN_GPIOTE_CHAN]),
+		(uint32_t)&(NRF_GPIOTE->TASKS_OUT[
+				CONFIG_BT_CTLR_CSN_GPIOTE_CHAN]));
 }
+
 #endif /* CONFIG_BT_CTLR_FEM_NRF21540 */
 
 /******************************************************************************/
@@ -639,7 +654,8 @@ static inline void hal_radio_sw_switch_ppi_group_setup(void)
 	 BIT(HAL_TRIGGER_CRYPT_PPI) | \
 	 BIT(HAL_TRIGGER_AAR_PPI) | \
 	 HAL_USED_PPI_CHANNELS_2 | HAL_USED_PPI_CHANNELS_3 | \
-	 HAL_USED_PPI_CHANNELS_4 | HAL_USED_PPI_CHANNELS_5)
+	 HAL_USED_PPI_CHANNELS_4 | HAL_USED_PPI_CHANNELS_5 | \
+	 HAL_USED_PPI_CHANNELS_6)
 
 #if defined(HAL_TRIGGER_RATEOVERRIDE_PPI)
 #define HAL_USED_PPI_CHANNELS_2 \
@@ -675,6 +691,14 @@ static inline void hal_radio_sw_switch_ppi_group_setup(void)
 	 BIT(HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI))
 #else
 #define HAL_USED_PPI_CHANNELS_5 0
+#endif
+
+#if defined(HAL_ENABLE_FEM_PPI)
+#define HAL_USED_PPI_CHANNELS_6 \
+	(BIT(HAL_ENABLE_FEM_PPI) | \
+	 BIT(HAL_DISABLE_FEM_PPI))
+#else
+#define HAL_USED_PPI_CHANNELS_6 0
 #endif
 
 BUILD_ASSERT(

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -286,6 +286,28 @@ static inline void hal_palna_ppi_setup(void)
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
 /******************************************************************************/
+#if defined(CONFIG_BT_CTLR_FEM_NRF21540)
+static inline void hal_pa_ppi_setup(void)
+{
+	/* Nothing specific to PA with FEM to handle inside TRX chains */
+}
+
+static inline void hal_lna_ppi_setup(void)
+{
+	/* Nothing specific to LNA with FEM to handle inside TRX chains */
+}
+
+/* TODO: Dummy assignments, implementation will be added in subsequently */
+#define HAL_ENABLE_FEM_PPI  4
+#define HAL_DISABLE_FEM_PPI 5
+
+static inline void hal_fem_ppi_setup(void)
+{
+	/* TODO: Implementation will be added in subsequently */
+}
+#endif /* CONFIG_BT_CTLR_FEM_NRF21540 */
+
+/******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 /* PPI setup used for SW-based auto-switching during TIFS. */
 


### PR DESCRIPTION
Added nRF21540 FEM support for nRF52x and nRF53x Series.

Thanks to @bjornspock for the FEM contributions and @auroraslb for the DPPI refactoring.

![image](https://user-images.githubusercontent.com/6350656/104682603-649e3c00-56f5-11eb-8a4c-3116bfe24a3c.png)

Fixes #24142.

~Contains cherry-picked commit from @auroraslb PR: #30732~
