### PR TITLE
Exclude code unreachable line of code coverage

### DIFF
--- a/include/arch/arc/v2/error.h
+++ b/include/arch/arc/v2/error.h
@@ -33,7 +33,7 @@ extern "C" {
 		: [reason] "i" (reason_p), \
 		[id] "i" (_TRAP_S_CALL_RUNTIME_EXCEPT) \
 		: "memory"); \
-		CODE_UNREACHABLE; \
+		CODE_UNREACHABLE; /* LCOV_EXCL_LINE */ \
 	} while (false)
 
 #ifdef __cplusplus

--- a/include/arch/riscv/error.h
+++ b/include/arch/riscv/error.h
@@ -43,7 +43,7 @@ extern "C" {
 			compiler_barrier();		\
 			z_impl_user_fault(reason_p);	\
 		}					\
-		CODE_UNREACHABLE;			\
+		CODE_UNREACHABLE; /* LCOV_EXCL_LINE */	\
 	} while (false)
 #else
 #define ARCH_EXCEPT(reason_p)	do {			\

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -442,7 +442,7 @@ extern struct task_state_segment _main_tss;
 		: \
 		: [vector] "i" (Z_X86_OOPS_VECTOR), \
 		  [reason] "i" (reason_p)); \
-	CODE_UNREACHABLE; \
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */ \
 } while (false)
 
 /*

--- a/include/arch/x86/intel64/arch.h
+++ b/include/arch/x86/intel64/arch.h
@@ -110,7 +110,7 @@ struct x86_ssf {
 		"int $32\n\t" \
 		: \
 		: [reason] "i" (reason_p)); \
-	CODE_UNREACHABLE; \
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */ \
 } while (false)
 
 #endif /* _ASMLANGUAGE */

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -37,7 +37,7 @@ void _StackCheckHandler(void)
 	/* Stack canary error is a software fatal condition; treat it as such.
 	 */
 	z_except_reason(K_ERR_STACK_CHK_FAIL);
-	CODE_UNREACHABLE;
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
 /* Global variable */

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -42,7 +42,7 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 	LOG_PANIC();
 	LOG_ERR("Halting system");
 	arch_system_halt(reason);
-	CODE_UNREACHABLE;
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 /* LCOV_EXCL_STOP */
 

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -267,6 +267,7 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 	k_spin_unlock(&z_mem_domain_lock, key);
 }
 
+/* LCOV_EXCL_START */
 void k_mem_domain_remove_thread(k_tid_t thread)
 {
 	k_mem_domain_add_thread(&k_mem_domain_default, thread);
@@ -297,6 +298,7 @@ void k_mem_domain_destroy(struct k_mem_domain *domain)
 
 	k_spin_unlock(&z_mem_domain_lock, key);
 }
+/* LCOV_EXCL_STOP */
 
 static int init_mem_domain_module(const struct device *arg)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1578,7 +1578,7 @@ static bool thread_obj_validate(struct k_thread *thread)
 #endif
 		Z_OOPS(Z_SYSCALL_VERIFY_MSG(ret, "access denied"));
 	}
-	CODE_UNREACHABLE;
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
 static inline int z_vrfy_k_thread_join(struct k_thread *thread,

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -74,7 +74,7 @@ static FUNC_NORETURN void smp_init_top(void *arg)
 	smp_timer_init();
 	z_swap_unlocked();
 
-	CODE_UNREACHABLE;
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 #endif
 

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -46,7 +46,7 @@ FUNC_NORETURN void z_self_abort(void)
 	k_thread_suspend(_current);
 	z_swap_irqlock(key);
 	__ASSERT(false, "should never get here");
-	CODE_UNREACHABLE;
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
 #if !defined(CONFIG_ARCH_HAS_THREAD_ABORT)


### PR DESCRIPTION
There are 2 change in this PR:

1. Exclude the CODE UNREACHABLE line while generating coverage report.
2. Exclude the memory domain deprecated API when calculating code coverage.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>