### PR TITLE
modules: tfm: add kconfig to enable/disable tfm secure partitions

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -64,7 +64,7 @@ function(trusted_firmware_build)
   endif()
   set(TFM_BL2_ARG "-DBL2=${TFM_BL2}")
 
-  if(DEFINED TFM_IPC)
+  if(TFM_IPC)
     set(TFM_IPC_ARG -DTFM_PSA_API=ON)
     # PSA API awareness for the Non-Secure application
     target_compile_definitions(app PRIVATE "TFM_PSA_API")
@@ -74,7 +74,7 @@ function(trusted_firmware_build)
     set(TFM_ISOLATION_LEVEL_ARG -DTFM_ISOLATION_LEVEL=${TFM_ISOLATION_LEVEL})
   endif()
 
-  if(DEFINED TFM_REGRESSION)
+  if(TFM_REGRESSION)
     set(TFM_REGRESSION_ARG -DTEST_S=ON)
   endif()
 

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -3,6 +3,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# List of all partitions supported by TF-M
+# Name must match name in 'trusted-firmware-m/config/config_default.cmake'
+set(TFM_VALID_PARTITIONS
+  TFM_PARTITION_PROTECTED_STORAGE
+  TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
+  TFM_PARTITION_CRYPTO
+  TFM_PARTITION_INITIAL_ATTESTATION
+  TFM_PARTITION_PLATFORM
+  TFM_PARTITION_AUDIT_LOG
+  )
+
 # Adds trusted-firmware-m as an external project.
 # Also creates a target called 'tfm_api'
 # which can be linked into the app.
@@ -18,6 +29,7 @@
 # ISOLATION_LEVEL: The TF-M isolation level to use
 # REGRESSION: Boolean if TF-M build includes building the TF-M regression tests
 # BL2: Boolean if the TF-M build uses MCUboot. Default: True
+# ENABLED_PARTITIONS: List of TFM partitions to enable.
 #
 # Example usage:
 #
@@ -28,12 +40,24 @@
 #                        ISOLATION_LEVEL 2
 #                        REGRESSION
 #                        BL2 True
-#                        BUILD_PROFILE profile_small)
+#                        BUILD_PROFILE profile_small
+#                        ENABLED_PARTITIONS TFM_PARTITION_PLATFORM TFM_PARTITION_CRYPTO)
 function(trusted_firmware_build)
   set(options IPC REGRESSION)
   set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE
     MCUBOOT_IMAGE_NUMBER)
-  cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "" ${ARGN})
+  set(multiValueArgs ENABLED_PARTITIONS)
+  cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  foreach(partition ${TFM_VALID_PARTITIONS})
+    list(FIND TFM_ENABLED_PARTITIONS ${partition} idx)
+    if (idx EQUAL -1)
+      set(val "OFF")
+    else()
+      set(val "ON")
+    endif()
+    list(APPEND TFM_PARTITIONS_ARGS -D${partition}=${val})
+  endforeach()
 
   if(NOT DEFINED TFM_BL2)
     set(TFM_BL2 True)
@@ -132,6 +156,7 @@ function(trusted_firmware_build)
                ${MCUBOOT_IMAGE_NUM_ARG}
                -DTFM_TEST_REPO_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/tf-m-tests
                -DMCUBOOT_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/../tfm-mcuboot
+               ${TFM_PARTITIONS_ARGS}
     BUILD_ALWAYS True
     USES_TERMINAL_BUILD True
     BUILD_BYPRODUCTS ${BUILD_BYPRODUCTS}
@@ -217,6 +242,13 @@ if (CONFIG_BUILD_WITH_TFM)
         MCUBOOT_IMAGE_NUMBER ${CONFIG_TFM_MCUBOOT_IMAGE_NUMBER})
   endif()
 
+  # Enable TFM partitions as specified in Kconfig
+  foreach(partition ${TFM_VALID_PARTITIONS})
+    if (CONFIG_${partition})
+      list(APPEND TFM_ENABLED_PARTITIONS_ARG ${partition})
+    endif()
+  endforeach()
+
   trusted_firmware_build(
     BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
     BOARD ${CONFIG_TFM_BOARD}
@@ -226,6 +258,7 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_BL2_ARG}
     ${TFM_IPC_ARG}
     ${TFM_REGRESSION_ARG}
+    ENABLED_PARTITIONS ${TFM_ENABLED_PARTITIONS_ARG}
     CMAKE_BUILD_TYPE ${TFM_CMAKE_BUILD_TYPE}
   )
 

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -126,6 +126,72 @@ config TFM_MCUBOOT_IMAGE_NUMBER
 	  updated in one atomic operation. When this is 2, they are split and
 	  can be updated independently if dependency requirements are met.
 
+config TFM_PARTITION_PROTECTED_STORAGE
+	bool "Enable secure partition 'Protected Storage'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_PROTECTED_STORAGE'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
+config TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
+	bool "Enable secure partition 'Internal Trusted Storage'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_INTERNAL_TRUSTED_STORAGE'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
+config TFM_PARTITION_CRYPTO
+	bool "Enable secure partition 'Crypto'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_CRYPTO'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
+config TFM_PARTITION_INITIAL_ATTESTATION
+	bool "Enable secure partition 'Initial Attestation'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_INITIAL_ATTESTATION'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
+config TFM_PARTITION_PLATFORM
+	bool "Enable secure partition 'Platform'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_PLATFORM'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
+config TFM_PARTITION_AUDIT_LOG
+	bool "Enable secure partition 'Audit Log'"
+	default y
+	help
+	  Setting this option will cause '-DTFM_PARTITION_AUDIT_LOG'
+	  to be passed to the TF-M build system. Look at 'config_default.cmake'
+	  in the trusted-firmware-m repository for details regarding this
+	  parameter. Any dependencies between the various TFM_PARTITION_*
+	  options are handled by the build system in the trusted-firmware-m
+	  repository.
+
 config TFM_IPC
 	bool "IPC"
 	help


### PR DESCRIPTION
Also update tfm module to pass them to the trusted-firmware-m
build system.

Depends on https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/40

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>