### PR TITLE
manifest: MCUBoot update + release-note record on bootutil_public library introduction

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -293,6 +293,12 @@ Libraries / Subsystems
 
 * Debug
 
+* DFU
+
+ * boot: Reworked using MCUBoot's bootutil_public library which allow to use
+   API implementation already provided by MCUboot codebase and remove
+   zephyr's own implementations.
+
 HALs
 ****
 
@@ -331,6 +337,8 @@ MCUBoot
   * Configure logging to LOG_MINIMAL by default.
   * boot: cleanup NXP MPU configuration before boot.
   * Fix nokogiri<=1.11.0.rc4 vulnerability.
+  * bootutil_public library was extracted as code which is common API for
+    MCUboot and the DFU application, see ``CONFIG_MCUBOOT_BOOTUTIL_LIB``
 
 * imgtool
 

--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 13cf2e52024a144ecee9f37680681760a85febab
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 6f48e0abfd7c4284719dd7c25ef293d68ab528cf
+      revision: 3f49b5abf38659c22b6b73f5fe289de2e395263e
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 697e145d5ee5e4b400e9d7bceaec79f6ac29df7c


### PR DESCRIPTION
MCUboot Synchronized up to:
mcu-tools/mcuboot@ce50334
  - MCUboot ci: relax signed-off-by checks on forks

Added notes on lastest MCUBoot related changes
