### PR TITLE
drivers/serial: stm32: Revert change in uart_irq_rx_ready

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -565,8 +565,7 @@ static int uart_stm32_irq_rx_ready(const struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return LL_USART_IsActiveFlag_RXNE(UartInstance) &&
-		LL_USART_IsEnabledIT_RXNE(UartInstance);
+	return LL_USART_IsActiveFlag_RXNE(UartInstance);
 }
 
 static void uart_stm32_irq_err_enable(const struct device *dev)


### PR DESCRIPTION
In #31192 stm32 uart driver uart_irq_rx/tx_ready functions were
modified to take into account status of irq.
While it seems wlecome for TX (based on uart client's implementation),
this is not correct for RX.
Revert change in uart_stm32_irq_rx_ready function.

Based on discussion in https://github.com/zephyrproject-rtos/zephyr/issues/31259#issuecomment-760293023

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>