### PR TITLE
watchdog: sifive: Remove use of DEVICE_DT_INST_DECLARE

### DIFF
--- a/drivers/watchdog/wdt_sifive.c
+++ b/drivers/watchdog/wdt_sifive.c
@@ -258,8 +258,6 @@ static const struct wdt_driver_api wdt_sifive_api = {
 	.feed = wdt_sifive_feed,
 };
 
-DEVICE_DT_INST_DECLARE(0);
-
 static void wdt_sifive_irq_config(void)
 {
 	IRQ_CONNECT(DT_INST_IRQN(0),


### PR DESCRIPTION
DEVICE_DT_INST_DECLARE is no longer needed and this one case was missed
in the cleanup to remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>