### PR TITLE
Bluetooth: host: Handle ATT timeout on disconnected ATT channel 

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2611,7 +2611,6 @@ static void att_timeout(struct k_work *work)
 	 * target device on this ATT Bearer.
 	 */
 	bt_att_disconnected(&chan->chan.chan);
-	ch->chan.conn = NULL;
 }
 
 static struct bt_att_chan *att_get_fixed_chan(struct bt_conn *conn)


### PR DESCRIPTION
Handle ATT timeout on disconnected ATT channel.
When the ATT channel is disconnected with a pending request the ATT
timeout is canceled and the response processed with an error code.
However canceling of delayed work is not guaranted to succeed, e.g:
"Work queue thread has removed the work item from the queue but has not
 called its handler"
This could lead to timeout handler being invoked after the disconnected
handler.

Fixes: #29098

Remove ATT modifying the L2CAP channel state by unassigning the
the connection pointer on timeout.
Unassigning this pointer does not prevent the ATT channel from receiving
since bt_l2cap_recv does not inspect this pointer before calling the
channel receive function.
This prevented the disconnected callback from being called on the
channel after the channel had timed out, but since the disconnected
callback now handles this case this workaroun is no longer needed.

NOTE:
Issue has not been reproduced and fix is made based on theoretical understanding of the issue
Fix is similar to https://github.com/zephyrproject-rtos/zephyr/pull/30655, which was reproduced.