### PR TITLE
doc: module naming rule in zephyr/module.yml

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -44,6 +44,9 @@ Module Repositories
 * The module repository codebase shall include a *module.yml* file in a
   :file:`zephyr/` folder at the root of the repository.
 
+* The *module.yml* file shall contain the ``name`` key and have the value
+  identical to the ``project`` name in the default manifest file.
+
 * Module repository names should follow the convention of using lowercase
   letters and dashes instead of underscores. This rule will apply to all
   new module repositories, except for repositories that are directly


### PR DESCRIPTION
Introducing `name: <module-name>` as requirement in Zephyr maintained
modules.

This will ensure that Zephyr module names are kept in sync between the
project names in the default `west.yml` manifest file, and the names
used when referring to the Zephyr module in the build system.

This means the project `foo` in `west.yml` will look as:

west.yml
```
manifest:
  projects:
    - name: foo
```

must have:
`<foo-repo>/zephyr/module.yml` with content
```
name: foo
```

and can be referred to in the build system as:
- `ZEPHYR_FOO_MODULE_DIR`, for the module directory
- `ZEPHYR_FOO_CMAKE_DIR`, for the directory containing the Zephyr module
  CMakeLists.txt.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>


--------

Opening a separate PR for discussion of Module guideline rules independent of the name feature itself.

See:
- https://github.com/zephyrproject-rtos/zephyr/pull/31156#discussion_r555131382
- https://github.com/zephyrproject-rtos/zephyr/pull/31156#issuecomment-759920624
- https://github.com/zephyrproject-rtos/zephyr/pull/31156#issuecomment-760020603