### PR TITLE
samples/drivers: led_pwm: Fixes for device testing

### DIFF
--- a/samples/drivers/led_pwm/README.rst
+++ b/samples/drivers/led_pwm/README.rst
@@ -16,12 +16,12 @@ Test pattern
 
 For each PWM LEDs (one after the other):
 
-- turn on
-- turn off
-- increase the brightness gradually up to the maximum level
-- blink (0.1 sec on, 0.1 sec off)
-- blink (1 sec on, 1 sec off)
-- turn off
+- Turning on
+- Turning off
+- Increasing brightness gradually
+- Blinking on: 0.1 sec, off: 0.1 sec
+- Blinking on: 1 sec, off: 1 sec
+- Turning off
 
 Building and Running
 ********************

--- a/samples/drivers/led_pwm/sample.yaml
+++ b/samples/drivers/led_pwm/sample.yaml
@@ -7,3 +7,17 @@ tests:
     tags: LED
     depends_on: pwm
     platform_exclude: reel_board
+    timeout: 15
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Found device LED_PWM_\\d+"
+        - "Testing LED \\d+"
+        - "Turning on"
+        - "Turning off"
+        - "Increasing brightness gradually"
+        - "Blinking on: 0.1 sec, off: 0.1 sec"
+        - "Blinking on: 1 sec, off: 1 sec"
+        - "Turning off"

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -44,7 +44,7 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	int err;
 	uint16_t level;
 
-	LOG_INF("Testing LED %d (%s)", led, led_label[led] ? : "no label");
+	LOG_INF("Testing LED %d - %s", led, led_label[led] ? : "no label");
 
 	/* Turn LED on. */
 	err = led_on(led_pwm, led);
@@ -77,7 +77,7 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	k_sleep(K_MSEC(1000));
 
 	/* Set LED blinking (on: 0.1 sec, off: 0.1 sec) */
-	LOG_INF("  Blinking (on: 0.1 sec, off: 0.1 sec)");
+	LOG_INF("  Blinking on: 0.1 sec, off: 0.1 sec");
 	err = led_blink(led_pwm, led, 100, 100);
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
@@ -86,7 +86,7 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	k_sleep(K_MSEC(5000));
 
 	/* Enable LED blinking (on: 1 sec, off: 1 sec) */
-	LOG_INF("  Blinking (on: 1 sec, off: 1 sec)");
+	LOG_INF("  Blinking on: 1 sec, off: 1 sec");
 	err = led_blink(led_pwm, led, 1000, 1000);
 	if (err < 0) {
 		LOG_ERR("err=%d", err);


### PR DESCRIPTION
Modify led_pwm sample in order to make it usable in device testing:
- Remove parenthesis from the logs as they prevent use of regex
- Add a harness_config multiline regex in order to enable verdict
generation
- Update README

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>