### PR TITLE
drivers: dmamux: stm32: build time dmamux channels initialization

### DIFF
--- a/drivers/dma/dmamux_stm32.h
+++ b/drivers/dma/dmamux_stm32.h
@@ -15,7 +15,6 @@ struct dmamux_stm32_channel {
 
 /* the table of all the dmamux channel */
 struct dmamux_stm32_data {
-	struct dmamux_stm32_channel *mux_channels;
 	void *callback_arg;
 	void (*dmamux_callback)(void *arg, uint32_t id,
 				int error_code);
@@ -28,6 +27,7 @@ struct dmamux_stm32_config {
 	uint8_t channel_nb;	/* total nb of channels */
 	uint8_t gen_nb;	/* total nb of Request generator */
 	uint8_t req_nb;	/* total nb of Peripheral Request inputs */
+	const struct dmamux_stm32_channel *mux_channels;
 };
 
 uint32_t table_ll_channel[] = {


### PR DESCRIPTION
This PR proposes to move the stm32 dmamux channel from driver data to the driver configuration.
Additionally it gets rid of the constraint that the soc must have two DMAs with an equal number of channels.

The assignment can be moved to the configuration, because this association is hardwired in all known series.
The information is taken fromt the dma_offset and dma_requests device tree properties.
The current implementation is valid for series with either
a single or two dma peripherals and a single dmamux peripheral.
Both dmas can independently enabled.
As the driver uses multi-instance DT_INST_DEFINE, also macros for a
second dmamux are are added that should allow easier extension to a
second dmamux instance.

This proposed solution adds quite a lot of macros. As I am not completely familiar with all the macro magic in Zephyr, I am pretty sure there are still simplifications possible.

Alternatives I have considered:
- Get rid of the dmamux_channel assignment and use macros to resolve the mapping during runtime from the device tree definitions. But if more dmas are added this might get impractical.