### PR TITLE
Revert "scripts: west build: default build.pristine to auto"

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -150,7 +150,7 @@ class Build(Forceable):
             pristine = args.pristine
         else:
             # Load the pristine={auto, always, never} configuration value
-            pristine = config_get('pristine', 'auto')
+            pristine = config_get('pristine', 'never')
             if pristine not in ['auto', 'always', 'never']:
                 log.wrn(
                     'treating unknown build.pristine value "{}" as "never"'.


### PR DESCRIPTION
This reverts commit c505ca38cff9c492f09c4cce196a572599c4cc81.

Fixes: #31358

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>