### PR TITLE
Config: Patch messaging to avoid printing to stderr

### DIFF
--- a/share/zephyr-package/cmake/ZephyrConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfig.cmake
@@ -20,7 +20,7 @@ macro(include_boilerplate location)
   endif()
 
   if(NOT NO_BOILERPLATE)
-    message("Including boilerplate (${location}): ${BOILERPLATE_FILE}")
+    message(STATUS "Including boilerplate (${location}): ${BOILERPLATE_FILE}")
     include(${BOILERPLATE_FILE} NO_POLICY_SCOPE)
   endif()
 endmacro()


### PR DESCRIPTION
The default logging level for the messaging here is NOTICE which logs
to stderr. This, possibly, can be confusing when looking at logs from
build servers/CI. Updaing the log level to explicitly log to STATUS
which prints to stdout.