### PR TITLE
Allow DT properties to be true by default

### DIFF
--- a/dts/bindings/test/vnd,bool-with-default.yaml
+++ b/dts/bindings/test/vnd,bool-with-default.yaml
@@ -1,0 +1,19 @@
+description: Test binding for booleans with defaults in the bindings
+
+compatible: "vnd,bool-with-default"
+
+properties:
+  compatible:
+    type: string
+    required: true
+
+  default-true:
+    type: boolean
+    default: true
+
+  default-false:
+    type: boolean
+
+  default-false-explicit:
+    type: boolean
+    default: false

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -2041,7 +2041,7 @@ def _check_prop_type_and_default(prop_name, prop_type, default, binding_path):
     if default is None:
         return
 
-    if prop_type in {"boolean", "compound", "phandle", "phandles",
+    if prop_type in {"compound", "phandle", "phandles",
                      "phandle-array", "path"}:
         _err("'default:' can't be combined with 'type: {}' for '{}' in "
              "'properties:' in {}".format(prop_type, prop_name, binding_path))
@@ -2049,8 +2049,9 @@ def _check_prop_type_and_default(prop_name, prop_type, default, binding_path):
     def ok_default():
         # Returns True if 'default' is an okay default for the property's type
 
-        if prop_type == "int" and isinstance(default, int) or \
-           prop_type == "string" and isinstance(default, str):
+        if (prop_type == "int" and isinstance(default, int)) or \
+           (prop_type == "string" and isinstance(default, str)) or \
+           (prop_type == "boolean" and isinstance(default, bool)):
             return True
 
         # array, uint8-array, or string-array

--- a/scripts/dts/test-bindings/defaults.yaml
+++ b/scripts/dts/test-bindings/defaults.yaml
@@ -30,6 +30,14 @@ properties:
         required: false
         default: ["hello", "there"]
 
+    boolean-true:
+        type: boolean
+        default: true
+
+    boolean-false:
+        type: boolean
+        default: false
+
     default-not-used:
         type: int
         required: false

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -258,6 +258,8 @@ def test_prop_defaults():
          r"('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), "
          "('string', <Property, name: string, type: string, value: 'hello'>), "
          "('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), "
+         "('boolean-true', <Property, name: boolean-true, type: boolean, value: True>), "
+         "('boolean-false', <Property, name: boolean-false, type: boolean, value: False>), "
          "('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])")
 
 def test_prop_enums():

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -253,7 +253,12 @@ def test_prop_defaults():
     edt = edtlib.EDT("test.dts", ["test-bindings"])
 
     assert str(edt.get_node("/defaults").props) == \
-        r"OrderedDict([('int', <Property, name: int, type: int, value: 123>), ('array', <Property, name: array, type: array, value: [1, 2, 3]>), ('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), ('string', <Property, name: string, type: string, value: 'hello'>), ('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), ('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])"
+        ("OrderedDict([('int', <Property, name: int, type: int, value: 123>), "
+         "('array', <Property, name: array, type: array, value: [1, 2, 3]>), "
+         r"('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), "
+         "('string', <Property, name: string, type: string, value: 'hello'>), "
+         "('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), "
+         "('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])")
 
 def test_prop_enums():
     '''test properties with enum: in the binding'''

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -368,5 +368,9 @@
 				};
 			};
 		};
+
+		bool-with-default { /* there should only be one of these */
+			compatible = "vnd,bool-with-default";
+		};
 	};
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -129,8 +129,13 @@ static void test_inst_props(void)
 			      strlen(label_startswith)), "");
 }
 
-static void test_default_prop_access(void)
+static void test_prop_or(void)
 {
+	/*
+	 * Tests for APIs that expand to a default value if a property
+	 * is undefined, like DT_PROP_OR, DT_PHA_BY_IDX_OR, etc.
+	 */
+
 	/*
 	 * The APIs guarantee that the default_value is not expanded
 	 * if the relevant property or cell is defined. This "X" macro
@@ -1545,7 +1550,7 @@ void test_main(void)
 			 ztest_unit_test(test_alias_props),
 			 ztest_unit_test(test_nodelabel_props),
 			 ztest_unit_test(test_inst_props),
-			 ztest_unit_test(test_default_prop_access),
+			 ztest_unit_test(test_prop_or),
 			 ztest_unit_test(test_has_path),
 			 ztest_unit_test(test_has_alias),
 			 ztest_unit_test(test_inst_checks),

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -129,6 +129,22 @@ static void test_inst_props(void)
 			      strlen(label_startswith)), "");
 }
 
+#define BOOL_WITH_DEFAULT DT_PATH(test, bool_with_default)
+static void test_bool_with_default(void)
+{
+	/* Boolean properties with default values */
+
+	zassert_true(DT_PROP(BOOL_WITH_DEFAULT, default_true), "");
+	zassert_false(DT_PROP(BOOL_WITH_DEFAULT, default_false), "");
+	zassert_false(DT_PROP(BOOL_WITH_DEFAULT, default_false_explicit), "");
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_bool_with_default
+	zassert_true(DT_INST_PROP(0, default_true), "");
+	zassert_false(DT_INST_PROP(0, default_false), "");
+	zassert_false(DT_INST_PROP(0, default_false_explicit), "");
+}
+
 static void test_prop_or(void)
 {
 	/*
@@ -1550,6 +1566,7 @@ void test_main(void)
 			 ztest_unit_test(test_alias_props),
 			 ztest_unit_test(test_nodelabel_props),
 			 ztest_unit_test(test_inst_props),
+			 ztest_unit_test(test_bool_with_default),
 			 ztest_unit_test(test_prop_or),
 			 ztest_unit_test(test_has_path),
 			 ztest_unit_test(test_has_alias),


### PR DESCRIPTION
@MaureenHelm [reports](https://github.com/zephyrproject-rtos/zephyr/pull/31034#issuecomment-761102627) in https://github.com/zephyrproject-rtos/zephyr/pull/31034:

> scripts/dts/gen_defines.py wouldn't let me set boolean properties as default true

That's a bug; this is a legitimate use case.

Fix it in edtlib, adding test coverage in the C API to make sure we aren't missing anything subtle.