### PR TITLE
boards: arm: stm32: Update support for STM32F746G Discovery board

### DIFF
--- a/boards/arm/stm32f746g_disco/support/openocd.cfg
+++ b/boards/arm/stm32f746g_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/stm32f7discovery.cfg]
+source [find board/stm32f746g-disco.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Hi,

Could the following change be reviewed please?

Support for STM32F746G Discovery board was updated on 'openocd' by commit [0]:

```
  commit f79c902686f3ae500f3426dc2e552fdec80796d1
  Author: Andreas Bolsch <hyphen0break@gmail.com>
  Date:   Wed Dec 21 10:35:58 2016 +0100

      Flash, FRAM and EEPROM driver for STM32 QUAD-/OCTOSPI interface
```

which among other comments reads:
```
    - tcl/board/stm32f7discovery.cfg removed as name is ambiguous
      (superseded by stm32f746g-disco.cfg vs. stm32f769i-disco.cfg)
```

Thus that commit replaces the use of stm32f7discovery.cfg (superseded) by
stm32f746g-disco.cfg on Zephyr so the updated config file is used instead
of the current superseded one that sets incorrectly (lower) the adapter
speed when flashing the board (2000 kHz vs 4000 kHz).

One of the goals of that change is get rid of messages like the following when flashing:

```
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
```

That change is also related to openocd PR 41 [1].

Thanks,
Gustavo

[0] https://github.com/zephyrproject-rtos/openocd/commit/f79c902686f3ae500f3426dc2e552fdec80796d1
[1] https://github.com/zephyrproject-rtos/openocd/pull/41