### PR TITLE
Bluetooth: Controller: re-factor magic constants

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -17,6 +17,10 @@
 #define EVENT_PIPELINE_MAX 7
 #define EVENT_DONE_MAX 3
 
+#define ADV_INT_UNIT_US  625U
+#define SCAN_INT_UNIT_US 625U
+#define CONN_INT_UNIT_US 1250U
+
 #define HDR_ULL(p)     ((void *)((uint8_t *)(p) + sizeof(struct evt_hdr)))
 #define HDR_ULL2LLL(p) ((struct lll_hdr *)((uint8_t *)(p) + \
 					   sizeof(struct ull_hdr)))

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -799,7 +799,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			uint32_t scan_interval_us;
 
 			/* FIXME: is this correct for continuous scanning? */
-			scan_interval_us = lll->interval * 625U;
+			scan_interval_us = lll->interval * SCAN_INT_UNIT_US;
 			pdu_end_us %= scan_interval_us;
 		}
 		evt = HDR_LLL2EVT(lll);
@@ -848,8 +848,10 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		       &lll_conn->crc_init[0], 3);
 		pdu_tx->connect_ind.win_size = 1;
 
-		conn_interval_us = (uint32_t)lll_conn->interval * 1250U;
-		conn_offset_us = radio_tmr_end_get() + 502 + 1250;
+		conn_interval_us = (uint32_t)lll_conn->interval *
+			CONN_INT_UNIT_US;
+		conn_offset_us = radio_tmr_end_get() + 502 +
+			CONN_INT_UNIT_US;
 
 		if (!IS_ENABLED(CONFIG_BT_CTLR_SCHED_ADVANCED) ||
 		    lll->conn_win_offset_us == 0U) {
@@ -863,7 +865,8 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			}
 			pdu_tx->connect_ind.win_offset =
 				sys_cpu_to_le16((conn_space_us -
-						 conn_offset_us) / 1250U);
+						 conn_offset_us) /
+				CONN_INT_UNIT_US);
 			pdu_tx->connect_ind.win_size++;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -104,7 +104,8 @@ static void isr_tx(void *param)
 
 	/* LE Test Packet Interval */
 	l = radio_tmr_end_get() - radio_tmr_ready_get();
-	i = ((l + 249 + 624) / 625) * 625U;
+	i = ((l + 249 + (SCAN_INT_UNIT_US - 1)) / SCAN_INT_UNIT_US) *
+		SCAN_INT_UNIT_US;
 	t = radio_tmr_end_get() - l + i;
 	t -= radio_tx_ready_delay_get(test_phy, test_phy_flags);
 
@@ -112,7 +113,7 @@ static void isr_tx(void *param)
 	radio_tmr_sample();
 	s = radio_tmr_sample_get();
 	while (t < s) {
-		t += 625U;
+		t += SCAN_INT_UNIT_US;
 	}
 
 	/* Setup next Tx */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -702,7 +702,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 			uint32_t scan_interval_us;
 
 			/* FIXME: is this correct for continuous scanning? */
-			scan_interval_us = lll->interval * 625U;
+			scan_interval_us = lll->interval * SCAN_INT_UNIT_US;
 			pdu_end_us %= scan_interval_us;
 		}
 		evt = HDR_LLL2EVT(lll);
@@ -751,8 +751,10 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		       &lll_conn->crc_init[0], 3);
 		pdu_tx->connect_ind.win_size = 1;
 
-		conn_interval_us = (uint32_t)lll_conn->interval * 1250U;
-		conn_offset_us = radio_tmr_end_get() + 502 + 1250;
+		conn_interval_us = (uint32_t)lll_conn->interval *
+			CONN_INT_UNIT_US;
+		conn_offset_us = radio_tmr_end_get() + 502 +
+			CONN_INT_UNIT_US;
 
 		if (!IS_ENABLED(CONFIG_BT_CTLR_SCHED_ADVANCED) ||
 		    lll->conn_win_offset_us == 0U) {
@@ -766,7 +768,8 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 			}
 			pdu_tx->connect_ind.win_offset =
 				sys_cpu_to_le16((conn_space_us -
-						 conn_offset_us) / 1250U);
+						 conn_offset_us) /
+					CONN_INT_UNIT_US);
 			pdu_tx->connect_ind.win_size++;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
@@ -102,7 +102,8 @@ static void isr_tx(void *param)
 
 	/* LE Test Packet Interval */
 	l = radio_tmr_end_get() - radio_tmr_ready_get();
-	i = ((l + 249 + 624) / 625) * 625U;
+	i = ((l + 249 + (SCAN_INT_UNIT_US - 1)) / SCAN_INT_UNIT_US) *
+		SCAN_INT_UNIT_US;
 	t = radio_tmr_end_get() - l + i;
 	t -= radio_tx_ready_delay_get(test_phy, test_phy_flags);
 
@@ -110,7 +111,7 @@ static void isr_tx(void *param)
 	radio_tmr_sample();
 	s = radio_tmr_sample_get();
 	while (t < s) {
-		t += 625U;
+		t += SCAN_INT_UNIT_US;
 	}
 
 	/* Setup next Tx */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1066,8 +1066,10 @@ uint8_t ll_adv_enable(uint8_t enable)
 		_radio.advertiser.scan_window_ms = scan_window;
 
 		interval_min_us = slot_us + (scan_delay + scan_window) * 1000;
-		if ((interval * 625) < interval_min_us) {
-			interval = (interval_min_us + (625 - 1)) / 625;
+		if ((interval * SCAN_INT_UNIT_US) < interval_min_us) {
+			interval = (interval_min_us +
+				(SCAN_INT_UNIT_US - 1)) /
+				SCAN_INT_UNIT_US;
 		}
 
 		/* passive scanning */
@@ -1217,7 +1219,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 			 */
 			aux->interval = adv->interval +
 					(HAL_TICKER_TICKS_TO_US(
-						ULL_ADV_RANDOM_DELAY) / 625U);
+						ULL_ADV_RANDOM_DELAY) /
+						ADV_INT_UNIT_US);
 
 			ret = ull_adv_aux_start(aux, ticks_anchor_aux,
 						ticks_slot_overhead_aux);
@@ -1244,7 +1247,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 				   (TICKER_ID_ADV_BASE + handle),
 				   ticks_anchor, 0,
 				   HAL_TICKER_US_TO_TICKS((uint64_t)interval *
-							  625),
+							  ADV_INT_UNIT_US),
 				   TICKER_NULL_REMAINDER,
 #if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE) && \
 	!defined(CONFIG_BT_CTLR_LOW_LAT)
@@ -1565,7 +1568,8 @@ void ull_adv_done(struct node_rx_event_done *done)
 		rx_hdr->rx_ftr.param_adv_term.status = BT_HCI_ERR_LIMIT_REACHED;
 	} else if (adv->ticks_remain_duration &&
 		   (adv->ticks_remain_duration <
-		    HAL_TICKER_US_TO_TICKS((uint64_t)adv->interval * 625U))) {
+		    HAL_TICKER_US_TO_TICKS((uint64_t)adv->interval *
+			ADV_INT_UNIT_US))) {
 		adv->ticks_remain_duration = 0;
 
 		rx_hdr = (void *)lll->node_rx_adv_term;
@@ -1707,7 +1711,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t laz
 		if (adv->ticks_remain_duration) {
 			uint32_t ticks_interval =
 				HAL_TICKER_US_TO_TICKS((uint64_t)adv->interval *
-						       625U);
+						       ADV_INT_UNIT_US);
 			if (adv->ticks_remain_duration > ticks_interval) {
 				adv->ticks_remain_duration -= ticks_interval;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -140,7 +140,8 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 
 			aux->interval =	adv->interval +
 					(HAL_TICKER_TICKS_TO_US(
-						ULL_ADV_RANDOM_DELAY) / 625U);
+						ULL_ADV_RANDOM_DELAY) /
+						ADV_INT_UNIT_US);
 
 			/* FIXME: Find absolute ticks until after primary PDU
 			 *        on air to place the auxiliary advertising PDU.
@@ -850,7 +851,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 			   (TICKER_ID_ADV_AUX_BASE + aux_handle),
 			   ticks_anchor, 0,
 			   HAL_TICKER_US_TO_TICKS((uint64_t)aux->interval *
-						  625),
+						  ADV_INT_UNIT_US),
 			   TICKER_NULL_REMAINDER, TICKER_NULL_LAZY,
 			   (aux->evt.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, aux,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -396,7 +396,8 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			 */
 			aux->interval = adv->interval +
 					(HAL_TICKER_TICKS_TO_US(
-						ULL_ADV_RANDOM_DELAY) /	625U);
+						ULL_ADV_RANDOM_DELAY) /
+						ADV_INT_UNIT_US);
 
 			ret = ull_adv_aux_start(aux, ticks_anchor_aux,
 						ticks_slot_overhead_aux);
@@ -477,7 +478,7 @@ uint32_t ull_adv_sync_start(struct ll_adv_sync_set *sync,
 		ticks_slot_overhead = 0;
 	}
 
-	interval_us = (uint32_t)sync->interval * 1250U;
+	interval_us = (uint32_t)sync->interval * CONN_INT_UNIT_US;
 
 	sync_handle = sync_handle_get(sync);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -686,7 +686,8 @@ uint8_t ll_apto_set(uint16_t handle, uint16_t apto)
 	}
 
 	conn->apto_reload = RADIO_CONN_EVENTS(apto * 10U * 1000U,
-					      conn->lll.interval * 1250);
+					      conn->lll.interval *
+					      CONN_INT_UNIT_US);
 
 	return 0;
 }
@@ -2143,7 +2144,8 @@ static inline void event_conn_upd_init(struct ll_conn *conn,
 	pdu_ctrl_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CONN_UPDATE_IND;
 	pdu_ctrl_tx->llctrl.conn_update_ind.win_size = conn->llcp_cu.win_size;
 	pdu_ctrl_tx->llctrl.conn_update_ind.win_offset =
-		sys_cpu_to_le16(conn->llcp_cu.win_offset_us / 1250U);
+		sys_cpu_to_le16(conn->llcp_cu.win_offset_us /
+			CONN_INT_UNIT_US);
 	pdu_ctrl_tx->llctrl.conn_update_ind.interval =
 		sys_cpu_to_le16(conn->llcp_cu.interval);
 	pdu_ctrl_tx->llctrl.conn_update_ind.latency =
@@ -2308,7 +2310,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 		if ((conn->llcp_cu.interval != lll->interval) ||
 		    (conn->llcp_cu.latency != lll->latency) ||
 		    (RADIO_CONN_EVENTS(conn->llcp_cu.timeout * 10000U,
-				       lll->interval * 1250) !=
+				       lll->interval * CONN_INT_UNIT_US) !=
 		     conn->supervision_reload)) {
 			struct node_rx_cu *cu;
 
@@ -2349,10 +2351,12 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 		conn_interval_new = latency * conn->llcp_cu.interval;
 		if (conn_interval_new > conn_interval_old) {
 			ticks_at_expire += HAL_TICKER_US_TO_TICKS(
-				(conn_interval_new - conn_interval_old) * 1250U);
+				(conn_interval_new - conn_interval_old) *
+				CONN_INT_UNIT_US);
 		} else {
 			ticks_at_expire -= HAL_TICKER_US_TO_TICKS(
-				(conn_interval_old - conn_interval_new) * 1250U);
+				(conn_interval_old - conn_interval_new) *
+				CONN_INT_UNIT_US);
 		}
 		lll->latency_prepare += lazy;
 		lll->latency_prepare -= (instant_latency - latency);
@@ -2368,7 +2372,8 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 		}
 
 		/* calculate the window widening and interval */
-		conn_interval_us = conn->llcp_cu.interval * 1250U;
+		conn_interval_us = conn->llcp_cu.interval *
+			CONN_INT_UNIT_US;
 		periodic_us = conn_interval_us;
 
 		if (0) {
@@ -2385,7 +2390,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 			lll->slave.window_widening_max_us =
 				(conn_interval_us >> 1) - EVENT_IFS_US;
 			lll->slave.window_size_prepare_us =
-				conn->llcp_cu.win_size * 1250U;
+				conn->llcp_cu.win_size * CONN_INT_UNIT_US;
 			conn->slave.ticks_to_offset = 0U;
 
 			lll->slave.window_widening_prepare_us +=
@@ -2401,7 +2406,8 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 				lll->slave.window_widening_periodic_us *
 				latency);
 			ticks_win_offset = HAL_TICKER_US_TO_TICKS(
-				(conn->llcp_cu.win_offset_us / 1250U) * 1250U);
+				(conn->llcp_cu.win_offset_us /
+				CONN_INT_UNIT_US) * CONN_INT_UNIT_US);
 			periodic_us -= lll->slave.window_widening_periodic_us;
 #endif /* CONFIG_BT_PERIPHERAL */
 
@@ -3824,7 +3830,8 @@ static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 
 	conn->llcp_cu.win_size = pdu->llctrl.conn_update_ind.win_size;
 	conn->llcp_cu.win_offset_us =
-		sys_le16_to_cpu(pdu->llctrl.conn_update_ind.win_offset) * 1250;
+		sys_le16_to_cpu(pdu->llctrl.conn_update_ind.win_offset) *
+			CONN_INT_UNIT_US;
 	conn->llcp_cu.interval =
 		sys_le16_to_cpu(pdu->llctrl.conn_update_ind.interval);
 	conn->llcp_cu.latency =
@@ -5747,7 +5754,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				    (RADIO_CONN_EVENTS(conn->llcp_conn_param.timeout *
 						       10000U,
 						       lll->interval *
-						       1250) !=
+						       CONN_INT_UNIT_US) !=
 				     conn->supervision_reload)) {
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 					/* postpone CP request event if under
@@ -5850,7 +5857,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			    (RADIO_CONN_EVENTS(conn->llcp_conn_param.timeout *
 					       10000U,
 					       lll->interval *
-					       1250) !=
+					       CONN_INT_UNIT_US) !=
 			     conn->supervision_reload)) {
 				conn->llcp_conn_param.state =
 					LLCP_CPR_STATE_APP_WAIT;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -217,7 +217,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 
 	conn->connect_expire = 6U;
 	conn->supervision_expire = 0U;
-	conn_interval_us = (uint32_t)interval * 1250U;
+	conn_interval_us = (uint32_t)interval * CONN_INT_UNIT_US;
 	conn->supervision_reload = RADIO_CONN_EVENTS(timeout * 10000U,
 							 conn_interval_us);
 
@@ -675,7 +675,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		ticks_slot_overhead = 0U;
 	}
 
-	conn_interval_us = lll->interval * 1250;
+	conn_interval_us = lll->interval * CONN_INT_UNIT_US;
 	conn_offset_us = ftr->radio_end_us;
 	conn_offset_us += HAL_TICKER_TICKS_TO_US(1);
 	conn_offset_us -= EVENT_OVERHEAD_START_US;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -339,7 +339,7 @@ void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval,
 	lll->filter_policy = filter_policy;
 	lll->interval = interval;
 	lll->ticks_window = HAL_TICKER_US_TO_TICKS((uint64_t)window *
-						   SCAN_INTERVAL_UNIT_US);
+						   SCAN_INT_UNIT_US);
 }
 
 uint8_t ull_scan_enable(struct ll_scan_set *scan)
@@ -359,7 +359,7 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	lll_hdr_init(lll, scan);
 
 	ticks_interval = HAL_TICKER_US_TO_TICKS((uint64_t)lll->interval *
-						SCAN_INTERVAL_UNIT_US);
+						SCAN_INT_UNIT_US);
 
 	/* TODO: active_to_start feature port */
 	scan->evt.ticks_active_to_start = 0U;
@@ -422,7 +422,7 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 			   TICKER_USER_ID_THREAD, TICKER_ID_SCAN_BASE + handle,
 			   ticks_anchor, 0, ticks_interval,
 			   HAL_TICKER_REMAINDER((uint64_t)lll->interval *
-						SCAN_INTERVAL_UNIT_US),
+						SCAN_INT_UNIT_US),
 			   TICKER_NULL_LAZY,
 			   (scan->evt.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, scan,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -9,7 +9,6 @@
 #define SCAN_HANDLE_1M        0
 #define SCAN_HANDLE_PHY_CODED 1
 
-#define SCAN_INTERVAL_UNIT_US     625U
 #define EXT_SCAN_DURATION_UNIT_US 10000U
 #define EXT_SCAN_PERIOD_UNIT_US   1280000U
 
@@ -21,12 +20,12 @@
 /* Convert duration in 10 ms unit to radio events count */
 #define ULL_SCAN_DURATION_TO_EVENTS(duration, interval) \
 	(((uint32_t)(duration) * EXT_SCAN_DURATION_UNIT_US / \
-	  SCAN_INTERVAL_UNIT_US) / (interval))
+	  SCAN_INT_UNIT_US) / (interval))
 
 /* Convert period in 1.28 s unit to radio events count */
 #define ULL_SCAN_PERIOD_TO_EVENTS(period, interval) \
 	(((uint32_t)(period) * EXT_SCAN_PERIOD_UNIT_US / \
-	  SCAN_INTERVAL_UNIT_US) / (interval))
+	  SCAN_INT_UNIT_US) / (interval))
 
 int ull_scan_init(void);
 int ull_scan_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -181,7 +181,7 @@ void ull_sched_mfy_win_offset_use(void *param)
 			      conn->llcp.conn_upd.ticks_anchor,
 			      &conn->llcp_cu.win_offset_us);
 
-	win_offset = conn->llcp_cu.win_offset_us / 1250;
+	win_offset = conn->llcp_cu.win_offset_us / CONN_INT_UNIT_US;
 
 	sys_put_le16(win_offset, (void *)conn->llcp.conn_upd.pdu_win_offset);
 }
@@ -224,7 +224,7 @@ void ull_sched_mfy_win_offset_select(void *param)
 	uint16_t win_offset_s;
 
 	ticks_to_offset = HAL_TICKER_US_TO_TICKS(conn->llcp_conn_param.offset0 *
-						 1250);
+						 CONN_INT_UNIT_US);
 
 	win_offset_calc(conn, 1, &ticks_to_offset,
 			conn->llcp_conn_param.interval_max, &offset_m_max,
@@ -258,11 +258,13 @@ void ull_sched_mfy_win_offset_select(void *param)
 	}
 
 	if (offset_index_s < OFFSET_S_MAX) {
-		conn->llcp_cu.win_offset_us = win_offset_s * 1250;
+		conn->llcp_cu.win_offset_us = win_offset_s *
+			CONN_INT_UNIT_US;
 		sys_put_le16(win_offset_s,
 			     (void *)conn->llcp.conn_upd.pdu_win_offset);
 	} else if (!has_offset_s) {
-		conn->llcp_cu.win_offset_us = win_offset_m[0] * 1250;
+		conn->llcp_cu.win_offset_us = win_offset_m[0] *
+			CONN_INT_UNIT_US;
 		sys_put_le16(win_offset_m[0],
 			     (void *)conn->llcp.conn_upd.pdu_win_offset);
 	} else {
@@ -437,7 +439,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 #endif
 
 			ticks_slot_abs_curr += conn->evt.ticks_slot +
-					       HAL_TICKER_US_TO_TICKS(1250);
+					HAL_TICKER_US_TO_TICKS(
+						CONN_INT_UNIT_US);
 
 			if (conn->lll.role) {
 				ticks_slot_margin =
@@ -460,7 +463,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 					 ticks_slot_margin))) {
 					offset = HAL_TICKER_TICKS_TO_US(
 						ticks_to_expire_prev +
-						ticks_slot_abs_prev) / 1250;
+						ticks_slot_abs_prev) /
+						CONN_INT_UNIT_US;
 					if (offset >= conn_interval) {
 						ticks_to_expire_prev = 0U;
 
@@ -474,7 +478,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 					offset_index++;
 
 					ticks_to_expire_prev +=
-						HAL_TICKER_US_TO_TICKS(1250);
+						HAL_TICKER_US_TO_TICKS(
+							CONN_INT_UNIT_US);
 				}
 
 				*ticks_to_offset_next = ticks_to_expire_prev;
@@ -499,7 +504,7 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 		while (offset_index < *offset_max) {
 			offset = HAL_TICKER_TICKS_TO_US(ticks_to_expire_prev +
 							ticks_slot_abs_prev) /
-				 1250;
+				 CONN_INT_UNIT_US;
 			if (offset >= conn_interval) {
 				ticks_to_expire_prev = 0U;
 
@@ -510,7 +515,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 							    offset_index)));
 			offset_index++;
 
-			ticks_to_expire_prev += HAL_TICKER_US_TO_TICKS(1250);
+			ticks_to_expire_prev += HAL_TICKER_US_TO_TICKS(
+				CONN_INT_UNIT_US);
 		}
 
 		*ticks_to_offset_next = ticks_to_expire_prev;
@@ -544,7 +550,8 @@ static void after_mstr_offset_get(uint16_t conn_interval, uint32_t ticks_slot,
 	}
 
 	if ((*win_offset_us & BIT(31)) == 0) {
-		uint32_t conn_interval_us = conn_interval * 1250;
+		uint32_t conn_interval_us = conn_interval *
+			CONN_INT_UNIT_US;
 
 		while (*win_offset_us > conn_interval_us) {
 			*win_offset_us -= conn_interval_us;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -98,7 +98,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	lll->latency = sys_le16_to_cpu(pdu_adv->connect_ind.latency);
 
 	win_offset = sys_le16_to_cpu(pdu_adv->connect_ind.win_offset);
-	conn_interval_us = interval * 1250U;
+	conn_interval_us = interval * CONN_INT_UNIT_US;
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -121,7 +121,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		  conn_interval_us) + (1000000 - 1)) / 1000000U;
 	lll->slave.window_widening_max_us = (conn_interval_us >> 1) -
 					    EVENT_IFS_US;
-	lll->slave.window_size_event_us = pdu_adv->connect_ind.win_size * 1250U;
+	lll->slave.window_size_event_us = pdu_adv->connect_ind.win_size *
+		CONN_INT_UNIT_US;
 
 	/* procedure timeouts */
 	timeout = sys_le16_to_cpu(pdu_adv->connect_ind.timeout);
@@ -296,7 +297,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_interval_us -= lll->slave.window_widening_periodic_us;
 
 	conn_offset_us = ftr->radio_end_us;
-	conn_offset_us += win_offset * 1250U;
+	conn_offset_us += win_offset * CONN_INT_UNIT_US;
 	conn_offset_us += win_delay_us;
 	conn_offset_us -= EVENT_OVERHEAD_START_US;
 	conn_offset_us -= EVENT_TICKER_RES_MARGIN_US;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -381,7 +381,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 
 	sca = si->sca_chm[4] >> 5;
 	interval = sys_le16_to_cpu(si->interval);
-	interval_us = interval * 1250U;
+	interval_us = interval * CONN_INT_UNIT_US;
 
 	sync->timeout_reload = RADIO_SYNC_EVENTS((sync->timeout * 10U * 1000U),
 						 interval_us);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -196,7 +196,7 @@ void ull_sync_iso_setup(struct ll_sync_iso *sync_iso,
 	handle = ull_sync_iso_handle_get(sync_iso);
 
 	interval = sys_le16_to_cpu(biginfo->iso_interval);
-	interval_us = interval * 1250U;
+	interval_us = interval * CONN_INT_UNIT_US;
 
 	/* TODO: Populate LLL with information from the BIGINFO */
 


### PR DESCRIPTION
Defined 625 and 1250 as context specific interval common to ULL and LLL.
Checked with bluetooth sanity checks.

Fixes #23314.

Signed-off-by: Nirosharn Amarasinghe <niag@demant.com>