### PR TITLE
net: coap: define Content-Format option values

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2021 Nordic Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -146,6 +147,21 @@ enum coap_response_code {
 };
 
 #define COAP_CODE_EMPTY (0)
+
+/**
+ * @brief Set of Content-Format option values for CoAP.
+ *
+ * To be used when encoding or decoding a Content-Format option.
+ */
+enum coap_content_format {
+	COAP_CONTENT_FORMAT_TEXT_PLAIN = 0, /* charset=urf-8 */
+	COAP_CONTENT_FORMAT_APP_LINK_FORMAT = 40,
+	COAP_CONTENT_FORMAT_APP_XML = 41,
+	COAP_CONTENT_FORMAT_APP_OCTET_STREAM = 42,
+	COAP_CONTENT_FORMAT_APP_EXI = 47,
+	COAP_CONTENT_FORMAT_APP_JSON = 50,
+	COAP_CONTENT_FORMAT_APP_CBOR = 60,
+};
 
 /* block option helper */
 #define GET_BLOCK_NUM(v)        ((v) >> 4)

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -45,8 +45,6 @@ LOG_MODULE_REGISTER(net_coap_server_sample, LOG_LEVEL_DBG);
 /* CoAP socket fd */
 static int sock;
 
-static const uint8_t plain_text_format;
-
 static struct coap_observer observers[NUM_OBSERVERS];
 
 static struct coap_pending pendings[NUM_PENDINGS];
@@ -242,9 +240,8 @@ static int piggyback_get(struct coap_resource *resource,
 		goto end;
 	}
 
-	r = coap_packet_append_option(&response, COAP_OPTION_CONTENT_FORMAT,
-				      &plain_text_format,
-				      sizeof(plain_text_format));
+	r = coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		goto end;
 	}
@@ -506,9 +503,8 @@ static int query_get(struct coap_resource *resource,
 		goto end;
 	}
 
-	r = coap_packet_append_option(&response, COAP_OPTION_CONTENT_FORMAT,
-				      &plain_text_format,
-				      sizeof(plain_text_format));
+	r = coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		goto end;
 	}
@@ -657,9 +653,8 @@ static int separate_get(struct coap_resource *resource,
 		goto end;
 	}
 
-	r = coap_packet_append_option(&response, COAP_OPTION_CONTENT_FORMAT,
-				      &plain_text_format,
-				      sizeof(plain_text_format));
+	r = coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		goto end;
 	}
@@ -738,9 +733,8 @@ static int large_get(struct coap_resource *resource,
 		return -EINVAL;
 	}
 
-	r = coap_packet_append_option(&response, COAP_OPTION_CONTENT_FORMAT,
-				      &plain_text_format,
-				      sizeof(plain_text_format));
+	r = coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		goto end;
 	}
@@ -1053,9 +1047,8 @@ static int send_notification_packet(const struct sockaddr *addr,
 		}
 	}
 
-	r = coap_packet_append_option(&response, COAP_OPTION_CONTENT_FORMAT,
-				      &plain_text_format,
-				      sizeof(plain_text_format));
+	r = coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		goto end;
 	}

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -256,7 +256,6 @@ static int send_request(enum coap_msgtype msgtype, enum coap_method method,
 {
 	struct coap_packet request_packet;
 	int ret = -1;
-	uint8_t content_application_json = 50;
 	uint8_t *data = k_malloc(MAX_PAYLOAD_SIZE);
 
 	if (data == NULL) {
@@ -314,10 +313,9 @@ static int send_request(enum coap_msgtype msgtype, enum coap_method method,
 			goto error;
 		}
 
-		ret = coap_packet_append_option(&request_packet,
-						COAP_OPTION_CONTENT_FORMAT,
-						&content_application_json,
-						sizeof(content_application_json));
+		ret = coap_append_option_int(&request_packet,
+					     COAP_OPTION_CONTENT_FORMAT,
+					     COAP_CONTENT_FORMAT_APP_JSON);
 		if (ret < 0) {
 			LOG_ERR("Unable add option to request format");
 			goto error;

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -460,7 +460,6 @@ int coap_well_known_core_get(struct coap_resource *resource,
 	uint16_t remaining;
 	uint16_t id;
 	uint8_t tkl;
-	uint8_t format;
 	int r;
 	bool more = false;
 
@@ -502,10 +501,8 @@ int coap_well_known_core_get(struct coap_resource *resource,
 		goto end;
 	}
 
-	format = 40U; /* application/link-format */
-
-	r = coap_packet_append_option(response, COAP_OPTION_CONTENT_FORMAT,
-				      &format, sizeof(format));
+	r = coap_append_option_int(response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_APP_LINK_FORMAT);
 	if (r < 0) {
 		goto end;
 	}
@@ -659,7 +656,6 @@ int coap_well_known_core_get(struct coap_resource *resource,
 	uint8_t token[8];
 	uint16_t id;
 	uint8_t tkl;
-	uint8_t format;
 	uint8_t num_queries;
 	int r;
 
@@ -686,9 +682,8 @@ int coap_well_known_core_get(struct coap_resource *resource,
 		return r;
 	}
 
-	format = 40U; /* application/link-format */
-	r = coap_packet_append_option(response, COAP_OPTION_CONTENT_FORMAT,
-				      &format, sizeof(format));
+	r = coap_append_option_int(response, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_APP_LINK_FORMAT);
 	if (r < 0) {
 		return -EINVAL;
 	}

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -103,12 +103,11 @@ done:
 static int test_build_simple_pdu(void)
 {
 	uint8_t result_pdu[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e',
-				 'n', 0xC1, 0x00, 0xFF, 'p', 'a', 'y', 'l',
+				 'n', 0xC0, 0xFF, 'p', 'a', 'y', 'l',
 				 'o', 'a', 'd', 0x00 };
 	struct coap_packet cpkt;
 	const char token[] = "token";
 	uint8_t *data;
-	uint8_t format = 0U;
 	int result = TC_FAIL;
 	int r;
 
@@ -127,8 +126,8 @@ static int test_build_simple_pdu(void)
 		goto done;
 	}
 
-	r = coap_packet_append_option(&cpkt, COAP_OPTION_CONTENT_FORMAT,
-				      &format, sizeof(format));
+	r = coap_append_option_int(&cpkt, COAP_OPTION_CONTENT_FORMAT,
+				   COAP_CONTENT_FORMAT_TEXT_PLAIN);
 	if (r < 0) {
 		TC_PRINT("Could not append option\n");
 		goto done;
@@ -356,7 +355,8 @@ static int test_parse_simple_pdu(void)
 		goto done;
 	}
 
-	if (((uint8_t *)options[0].value)[0] != 0U) {
+	if (((uint8_t *)options[0].value)[0] !=
+			COAP_CONTENT_FORMAT_TEXT_PLAIN) {
 		TC_PRINT("Option value doesn't match the reference\n");
 		goto done;
 	}


### PR DESCRIPTION
CoAP protocol defines registry of Content-Format option values.
This patch adds this enumeration to coap header file to make it
available to all applications using CoAP protocol. It modifies
code using CoAP service to use new enumeration.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>