### PR TITLE
tests: thread: refine the thread abort test case

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -38,6 +38,7 @@ extern void test_threads_cpu_mask(void);
 extern void test_threads_suspend_timeout(void);
 extern void test_threads_suspend(void);
 extern void test_abort_from_isr(void);
+extern void test_abort_from_isr_not_self(void);
 extern void test_essential_thread_abort(void);
 
 struct k_thread tdata;
@@ -516,7 +517,8 @@ void test_main(void)
 			 ztest_user_unit_test(test_thread_join),
 			 ztest_unit_test(test_thread_join_isr),
 			 ztest_user_unit_test(test_thread_join_deadlock),
-			 ztest_unit_test(test_abort_from_isr)
+			 ztest_unit_test(test_abort_from_isr),
+			 ztest_unit_test(test_abort_from_isr_not_self)
 			 );
 
 	ztest_run_test_suite(threads_lifecycle);


### PR DESCRIPTION
Refine the thread abort test case and add one extra condition.

There is a problem of original test case test_abort_from_isr():  The child thread abort itself in ISR might not release the offload_sem when the thread was aborted. So we add a k_sem_give for offload_sem at end of this test case.

And we also add another condition of test case, which is also going to abort child thread,  but call irq_offload from main thread.  

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>