### PR TITLE
Bluetooth: host: Fix size of L2CAP disconnect request pool

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -60,6 +60,7 @@
  */
 NET_BUF_POOL_FIXED_DEFINE(disc_pool, 1,
 			  BT_L2CAP_BUF_SIZE(
+				sizeof(struct bt_l2cap_sig_hdr) +
 				sizeof(struct bt_l2cap_disconn_req)),
 			  NULL);
 


### PR DESCRIPTION
Fix size of L2CAP disconnect request buffer pool which did not include
the size of the L2CAP signal header.

Regression from: 3346aa4d39bd2b0ed11ecbad6556affb8cea1569

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>