### PR TITLE
logging: Fix missing static to k_spinlock definition

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -899,7 +899,7 @@ char *log_strdup(const char *str)
 
 	if (IS_ENABLED(CONFIG_LOG_STRDUP_POOL_PROFILING)) {
 		size_t slen = strlen(str);
-		struct k_spinlock lock;
+		static struct k_spinlock lock;
 		k_spinlock_key_t key;
 
 		key = k_spin_lock(&lock);


### PR DESCRIPTION
The definition of lock, k_spinlock type, that has been used to guard
variables holding statistical data for log_strdup has been missing
static modifier, which caused the lock structure to be reallocated
on stack each time an execution entered the block.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>