### PR TITLE
west.yml: Update hal_nordic revision

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -217,17 +217,25 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 //------------------------------------------------------------------------------
 
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_CHANNELS_USED   NRFX_PPI_CHANNELS_USED_BY_BT_CTLR
+#define NRFX_DPPI_CHANNELS_USED   (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
+				   NRFX_PPI_CHANNELS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines DPPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_GROUPS_USED     NRFX_PPI_GROUPS_USED_BY_BT_CTLR
+#define NRFX_DPPI_GROUPS_USED     (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
+				   NRFX_PPI_GROUPS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines PPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_CHANNELS_USED    (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR | \
-                                   NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
+#define NRFX_PPI_CHANNELS_USED    (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
+				   NRFX_PPI_CHANNELS_USED_BY_MPSL |       \
+				   NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
 
 /** @brief Bitmask that defines PPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_GROUPS_USED      NRFX_PPI_GROUPS_USED_BY_BT_CTLR
+#define NRFX_PPI_GROUPS_USED      (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
+				   NRFX_PPI_GROUPS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines GPIOTE channels that are reserved for use outside of the nrfx library. */
 #define NRFX_GPIOTE_CHANNELS_USED NRFX_GPIOTE_CHANNELS_USED_BY_PWM_SW
@@ -240,6 +248,27 @@ extern const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
 #else
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR   0
 #define NRFX_PPI_GROUPS_USED_BY_BT_CTLR     0
+#endif
+
+#if defined(CONFIG_NRF_802154_RADIO_DRIVER)
+extern const uint32_t g_nrf_802154_used_nrf_ppi_channels;
+extern const uint32_t g_nrf_802154_used_nrf_ppi_groups;
+#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   g_nrf_802154_used_nrf_ppi_channels
+#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     g_nrf_802154_used_nrf_ppi_groups
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   0
+#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     0
+#endif
+
+#if defined(CONFIG_NRF_802154_RADIO_DRIVER) && \
+	!defined(CONFIG_NRF_802154_SL_OPENSOURCE)
+extern const uint32_t z_mpsl_used_nrf_ppi_channels;
+extern const uint32_t z_mpsl_used_nrf_ppi_groups;
+#define NRFX_PPI_CHANNELS_USED_BY_MPSL   z_mpsl_used_nrf_ppi_channels
+#define NRFX_PPI_GROUPS_USED_BY_MPSL     z_mpsl_used_nrf_ppi_groups
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_MPSL   0
+#define NRFX_PPI_GROUPS_USED_BY_MPSL     0
 #endif
 
 #if defined(CONFIG_PWM_NRF5_SW)

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: f0d54d8449acbee49b3cebcef0e3e56640c50277
+      revision: pull/80/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This manifest update corresponds to [PR#80](https://github.com/zephyrproject-rtos/hal_nordic/pull/80) into hal_nordic sub-repo, that provide the following commit:

* nrfx_glue: Reserve PPI/DPPI channels and groups used by 802.15.4 drv
Mark the (D)PPI channels used by the 802.15.4 driver as occupied
and thus unavailable for allocation through nrfx_ppi.
Verification if these resources do not overlap with those used
by the MPSL (if enabled).