### PR TITLE
drivers/flash: stm32: Extend qspi-nor support to F7 series

### DIFF
--- a/boards/arm/stm32f746g_disco/doc/index.rst
+++ b/boards/arm/stm32f746g_disco/doc/index.rst
@@ -112,6 +112,8 @@ The Zephyr stm32f746g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| QSPI NOR  | on-chip    | flash                               |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash-controller = &n25q128a1;
 	};
 
 	leds {
@@ -118,4 +119,43 @@
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
+};
+&dma2 {
+	status = "okay";
+};
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pb6
+		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pd12
+		     &quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	dmas = <&dma2 7 3 0x0000 0x03>;
+	dma-names = "tx_rx";
+
+	status = "okay";
+
+	n25q128a1: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		label = "N25Q128A1";
+		reg = <0>;
+		qspi-max-frequency = <108000000>;
+		/* 128 Megabits = 16 Megabytes */
+		size = <0x8000000>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x00000000 0x000D8000>;
+				};
+
+			storage_partition: partition@D8000 {
+				label = "storage";
+				reg = <0x000D8000 DT_SIZE_M(7)>;
+			};
+		};
+	};
 };

--- a/boards/arm/stm32f769i_disco/doc/index.rst
+++ b/boards/arm/stm32f769i_disco/doc/index.rst
@@ -116,6 +116,8 @@ The Zephyr stm32f769i_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | ETHERNET  | on-chip    | Ethernet                            |
 +-----------+------------+-------------------------------------+
+| QSPI NOR  | on-chip    | flash                               |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash-controller = &mx25l51245g;
 	};
 
 	leds {
@@ -103,4 +104,44 @@ arduino_serial: &usart6 {};
 		     &sdmmc2_d2_pb3 &sdmmc2_d3_pb4
 		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pb6
+		     &quadspi_bk1_io0_pc9 &quadspi_bk1_io1_pc10
+		     &quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	dmas = <&dma2 7 3 0x0000 0x03>;
+	dma-names = "tx_rx";
+
+	status = "okay";
+
+	mx25l51245g: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		label = "MX25L51245G";
+		reg = <0>;
+		qspi-max-frequency = <70000000>;
+		/* 512 Megabits = 64 Megabytes */
+		size = <0x20000000>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x00000000 0x000D8000>;
+				};
+
+			storage_partition: partition@D8000 {
+				label = "storage";
+				reg = <0x000D8000 DT_SIZE_M(7)>;
+			};
+		};
+	};
 };

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -729,8 +729,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	hdma.Init.Mode = DMA_NORMAL;
 	hdma.Init.Priority = dma_cfg.channel_priority;
 #ifdef CONFIG_DMA_STM32_V1
-	/* TODO: Not tested in this configuration */
-	hdma.Init.Channel = dma_cfg.dma_slot;
+	hdma.Init.Channel = dma_cfg.dma_slot << DMA_SxCR_CHSEL_Pos;
 	hdma.Instance = __LL_DMA_GET_STREAM_INSTANCE(dev_data->dma.reg,
 						     dev_data->dma.channel);
 #else

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -679,6 +679,16 @@
 			status = "disabled";
 			label = "SDMMC_1";
 		};
+		quadspi: quadspi@a0001000 {
+			compatible = "st,stm32-qspi";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xa0001000 0x34>;
+			interrupts = <92 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x2>;
+			status = "disabled";
+			label = "QUADSPI";
+		};
 	};
 
 	otghs_fs_phy: otghs_fs_phy {


### PR DESCRIPTION
I was hoping to get these changes in as part of #30864 but got in too late.

The QSPI implementation that is now in master _compiles_ for stm32f7, but it fails to boot `samples/drivers/spi_flash`. This PR already has a patch that fixes that.

I have also added `.dtsi` for stm32f7 and `.dts` files for _stm32f746g_disco_ and _stm32f769i_disco_.

`samples/drivers/spi_flash` works for both boards **when DMA is disabled**.

However, if I try to use it with DMA I get some errors, see output below.

I will continue to look into this, but would appreciate some help. @erwango ?

```
JEDEC QSPI-NOR SPI flash testing
==========================
SPI flash driver MX25L51245G was not found!
[00:00:00.000,000] <err> flash_stm32_qspi: SFDP magic 00000000 invalid
```


