### PR TITLE
drivers/flash: stm32: Extend qspi-nor support to F7 series - no DMA

### DIFF
--- a/boards/arm/stm32f746g_disco/doc/index.rst
+++ b/boards/arm/stm32f746g_disco/doc/index.rst
@@ -112,6 +112,8 @@ The Zephyr stm32f746g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| QSPI NOR  | on-chip    | flash                               |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash-controller = &n25q128a1;
 	};
 
 	leds {
@@ -118,4 +119,36 @@
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
+};
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pb6
+		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pd12
+		     &quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	status = "okay";
+
+	n25q128a1: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		label = "N25Q128A1";
+		reg = <0>;
+		qspi-max-frequency = <72000000>;
+		size = <DT_SIZE_M(16*8)>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x00000000 0x000a0000>;
+				};
+
+			storage_partition: partition@a0000 {
+				label = "storage";
+				reg = <0x000a0000 DT_SIZE_M(15)>;
+			};
+		};
+	};
 };

--- a/boards/arm/stm32f769i_disco/doc/index.rst
+++ b/boards/arm/stm32f769i_disco/doc/index.rst
@@ -116,6 +116,8 @@ The Zephyr stm32f769i_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | ETHERNET  | on-chip    | Ethernet                            |
 +-----------+------------+-------------------------------------+
+| QSPI NOR  | on-chip    | flash                               |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
+		zephyr,flash-controller = &mx25l51245g;
 	};
 
 	leds {
@@ -103,4 +104,36 @@ arduino_serial: &usart6 {};
 		     &sdmmc2_d2_pb3 &sdmmc2_d3_pb4
 		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
+};
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pb6
+		     &quadspi_bk1_io0_pc9 &quadspi_bk1_io1_pc10
+		     &quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	status = "okay";
+
+	mx25l51245g: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		label = "MX25L51245G";
+		reg = <0>;
+		qspi-max-frequency = <72000000>;
+		size = <DT_SIZE_M(64*8)>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x00000000 0x001a0000>;
+				};
+
+			storage_partition: partition@1a0000 {
+				label = "storage";
+				reg = <0x001a0000 DT_SIZE_M(62)>;
+			};
+		};
+	};
 };

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -694,6 +694,17 @@
 			label = "BACKUP_SRAM";
 			status = "disabled";
 		};
+
+		quadspi: quadspi@a0001000 {
+			compatible = "st,stm32-qspi";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			reg = <0xa0001000 0x34>;
+			interrupts = <92 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x2>;
+			status = "disabled";
+			label = "QUADSPI";
+		};
 	};
 
 	otghs_fs_phy: otghs_fs_phy {


### PR DESCRIPTION
This PR adds qspi flash support to stm32 f7. DMA is not supported (will be added in #31405).

I have verified that `samples/drivers/spi_flash` works on boards _stm32f746g_disco_ and _stm32f769i_disco_.