### PR TITLE
ci: revert change in checkpatch - handle warnings as errors

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -213,7 +213,12 @@ class CheckPatch(ComplianceTest):
 
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
-            self.add_failure(output)
+            if re.search("[1-9][0-9]* errors,", output):
+                self.add_failure(output)
+                self.add_failure(output)
+            else:
+                # No errors found, but warnings. Show them.
+                self.add_info(output)
 
 
 class KconfigCheck(ComplianceTest):


### PR DESCRIPTION
Reverts commit: 5d50797.

It fails when there are no errors but warnings are available.

There is no issue/bug created about it.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>