### PR TITLE
cmake: zephyr modules: sanitize all module name when used as variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,7 @@ foreach(module_name ${ZEPHYR_MODULE_NAMES})
   # this binary_dir is created but stays empty. Object files land in
   # the main binary dir instead.
   # https://cmake.org/pipermail/cmake/2019-June/069547.html
-  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
   if(NOT ${ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR} STREQUAL "")
     set(ZEPHYR_CURRENT_MODULE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR})
     set(ZEPHYR_CURRENT_CMAKE_DIR ${ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1961,6 +1961,47 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
 endfunction()
 
 # Usage:
+#   zephyr_string(<mode> <out-var> <input> ...)
+#
+# Zephyr string function extension.
+# This function extends the CMake string function by providing additional
+# manipulation arguments to CMake string.
+#
+# SANITIZE: Ensure that the output string does not contain any special
+#           characters. Special characters, such as -, +, =, $, etc. are
+#           converted to underscores '_'.
+#
+# SANITIZE TOUPPER: Ensure that the output string does not contain any special
+#                   characters. Special characters, such as -, +, =, $, etc. are
+#                   converted to underscores '_'.
+#                   The sanitized string will be returned in UPPER case.
+#
+# returns the updated string
+function(zephyr_string)
+  set(options SANITIZE TOUPPER)
+  cmake_parse_arguments(ZEPHYR_STRING "${options}" "" "" ${ARGN})
+
+  if (NOT ZEPHYR_STRING_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Function zephyr_string() called without a return variable")
+  endif()
+
+  list(GET ZEPHYR_STRING_UNPARSED_ARGUMENTS 0 return_arg)
+  list(REMOVE_AT ZEPHYR_STRING_UNPARSED_ARGUMENTS 0)
+
+  list(JOIN ZEPHYR_STRING_UNPARSED_ARGUMENTS "" work_string)
+
+  if(ZEPHYR_STRING_SANITIZE)
+    string(REGEX REPLACE "[^a-zA-Z0-9_]" "_" work_string ${work_string})
+  endif()
+
+  if(ZEPHYR_STRING_TOUPPER)
+    string(TOUPPER ${work_string} work_string)
+  endif()
+
+  set(${return_arg} ${work_string} PARENT_SCOPE)
+endfunction()
+
+# Usage:
 #   zephyr_check_cache(<variable> [REQUIRED])
 #
 # Check the current CMake cache for <variable> and warn the user if the value

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -69,7 +69,7 @@ string(REPLACE ";" "?" DTS_ROOT_BINDINGS "${DTS_ROOT_BINDINGS}")
 # This allows Kconfig files to refer relative from a modules root as:
 # source "$(ZEPHYR_FOO_MODULE_DIR)/Kconfig"
 foreach(module_name ${ZEPHYR_MODULE_NAMES})
-  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
   list(APPEND
        ZEPHYR_KCONFIG_MODULES_DIR
        "ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR=${ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR}"

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -104,7 +104,7 @@ if(WEST OR ZEPHYR_MODULES)
 
       list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
 
-      string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+      zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
       if(NOT ${MODULE_NAME_UPPER} STREQUAL CURRENT)
         set(ZEPHYR_${MODULE_NAME_UPPER}_MODULE_DIR ${module_path})
         set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${cmake_path})

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -421,6 +421,13 @@ CMake variable ``ZEPHYR_<MODULE_NAME>_MODULE_DIR`` and the variable
 ``ZEPHYR_<MODULE_NAME>_CMAKE_DIR`` holds the location of the directory
 containing the module's :file:`CMakeLists.txt` file.
 
+.. note::
+   When used for CMake and Kconfig variables, all letters in module names are
+   converted to uppercase and all non-alphanumeric characters are converted
+   to underscores (_).
+   As example, the module ``foo-bar`` must be referred to as
+   ``ZEPHYR_FOO_BAR_MODULE_DIR`` in CMake and Kconfig.
+
 Here is an example for the Zephyr module ``foo``:
 
 .. code-block:: yaml

--- a/modules/modules.cmake
+++ b/modules/modules.cmake
@@ -5,7 +5,8 @@ file(GLOB cmake_modules "${CMAKE_CURRENT_LIST_DIR}/*/CMakeLists.txt")
 foreach(module ${cmake_modules})
   get_filename_component(module_dir  ${module} DIRECTORY)
   get_filename_component(module_name ${module_dir} NAME)
-  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
+
   set(ZEPHYR_${MODULE_NAME_UPPER}_CMAKE_DIR ${module_dir})
 endforeach()
 
@@ -14,6 +15,7 @@ file(GLOB kconfig_modules "${CMAKE_CURRENT_LIST_DIR}/*/Kconfig")
 foreach(module ${kconfig_modules})
   get_filename_component(module_dir  ${module} DIRECTORY)
   get_filename_component(module_name ${module_dir} NAME)
-  string(TOUPPER ${module_name} MODULE_NAME_UPPER)
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
+
   set(ZEPHYR_${MODULE_NAME_UPPER}_KCONFIG ${module_dir}/Kconfig)
 endforeach()

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -262,7 +262,7 @@ class KconfigCheck(ComplianceTest):
         with open(modules_file, 'w') as fp_module_file:
             for module in modules:
                 fp_module_file.write("ZEPHYR_{}_KCONFIG = {}\n".format(
-                    module.upper(),
+                    re.sub('[^a-zA-Z0-9]', '_', module).upper(),
                     modules_dir + '/' + module + '/Kconfig'
                 ))
             fp_module_file.write(content)


### PR DESCRIPTION
The introduction of Zephyr module glue code in the Zephyr repository
introduces a Kconfig variable in the form of:
`config ZEPHYR_<MODULE_NAME>_MODULE`.

All Kconfig variables go into `autoconf.h`, therefore it is necessary
to sanitize the Kconfig variable, so that it does not contain special
characters. To ensure consistent variable name, then the module name
will be sanitized in all variable use in both Kconfig and CMake.
The sanitization is done be replacing all special characters with an
underscore, `_`.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>