### PR TITLE
drivers: i2c_dw: Device Tree related cleanups

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -43,7 +43,9 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 
 if(CONFIG_I2C_DW)
   zephyr_library_sources(i2c_dw.c)
-  foreach(NUM RANGE 0 11)
+  math(EXPR max_index "${CONFIG_I2C_DW_MAX_INSTANCES} - 1")
+  foreach(NUM RANGE 0 ${max_index})
+    math(EXPR NEXT_NUM "${NUM} + 1")
     configure_file(
       i2c_dw_port_x.h
       ${PROJECT_BINARY_DIR}/include/generated/i2c_dw_port_${NUM}.h

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -12,7 +12,17 @@ menuconfig I2C_DW
 	help
 	  Enable the Design Ware I2C driver
 
+if I2C_DW
+
 config I2C_DW_CLOCK_SPEED
 	int "Set the clock speed for I2C"
 	default 32
-	depends on I2C_DW
+
+config I2C_DW_MAX_INSTANCES
+	int "Maximum number of supported driver instances"
+	range 1 32
+	default 12
+	help
+	  The maximum number of supported driver instances in device tree.
+
+endif # I2C_DW

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -609,7 +609,7 @@ static int i2c_dw_initialize(const struct device *dev)
 	struct i2c_dw_dev_config * const dw = dev->data;
 	volatile struct i2c_dw_registers *regs;
 
-#ifdef I2C_DW_PCIE_ENABLED
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
 		struct pcie_mbar mbar;
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -665,50 +665,8 @@ static int i2c_dw_initialize(const struct device *dev)
 	return 0;
 }
 
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(0), okay)
+/* The instance-specific header files are chained together (each instance
+ * includes the next one, unless it's the last instance) so we only need to
+ * include the first instance.
+ */
 #include <i2c_dw_port_0.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(1), okay)
-#include <i2c_dw_port_1.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(2), okay)
-#include <i2c_dw_port_2.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(3), okay)
-#include <i2c_dw_port_3.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(4), okay)
-#include <i2c_dw_port_4.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(5), okay)
-#include <i2c_dw_port_5.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(6), okay)
-#include <i2c_dw_port_6.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(7), okay)
-#include <i2c_dw_port_7.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(8), okay)
-#include <i2c_dw_port_8.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(9), okay)
-#include <i2c_dw_port_9.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(10), okay)
-#include <i2c_dw_port_10.h>
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_DRV_INST(11), okay)
-#include <i2c_dw_port_11.h>
-#endif

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -13,16 +13,8 @@
 
 #define DT_DRV_COMPAT snps_designware_i2c
 
-#if DT_INST_PROP(0, pcie) || \
-	DT_INST_PROP(1, pcie) || \
-	DT_INST_PROP(2, pcie) || \
-	DT_INST_PROP(3, pcie) || \
-	DT_INST_PROP(4, pcie) || \
-	DT_INST_PROP(5, pcie) || \
-	DT_INST_PROP(6, pcie) || \
-	DT_INST_PROP(7, pcie)
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
-#define I2C_DW_PCIE_ENABLED
 #include <drivers/pcie/pcie.h>
 #endif
 
@@ -98,7 +90,7 @@ struct i2c_dw_rom_config {
 	DEVICE_MMIO_ROM;
 	i2c_isr_cb_t	config_func;
 	uint32_t		bitrate;
-#ifdef I2C_DW_PCIE_ENABLED
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	bool		pcie;
 	pcie_bdf_t	pcie_bdf;
 	pcie_id_t	pcie_id;

--- a/drivers/i2c/i2c_dw_port_x.h
+++ b/drivers/i2c/i2c_dw_port_x.h
@@ -6,6 +6,8 @@
  * This file is a template for cmake and is not meant to be used directly!
  */
 
+#if DT_NODE_HAS_STATUS(DT_DRV_INST(@NUM@), okay)
+
 static void i2c_config_@NUM@(const struct device *port);
 
 static const struct i2c_dw_rom_config i2c_config_dw_@NUM@ = {
@@ -82,3 +84,10 @@ static void i2c_config_@NUM@(const struct device *port)
 
 #endif
 }
+
+#endif /* DT_NODE_HAS_STATUS(DT_DRV_INST(@NUM@), okay) */
+
+/* Include subsequent instances */
+#if @NEXT_NUM@ < CONFIG_I2C_DW_MAX_INSTANCES
+#include <i2c_dw_port_@NEXT_NUM@.h>
+#endif

--- a/drivers/i2c/i2c_dw_port_x.h
+++ b/drivers/i2c/i2c_dw_port_x.h
@@ -13,7 +13,7 @@ static const struct i2c_dw_rom_config i2c_config_dw_@NUM@ = {
 	.config_func = i2c_config_@NUM@,
 	.bitrate = DT_INST_PROP(@NUM@, clock_frequency),
 
-#if DT_INST_PROP(@NUM@, pcie)
+#if DT_INST_ON_BUS(@NUM@, pcie)
 	.pcie = true,
 	.pcie_bdf = DT_INST_REG_ADDR(@NUM@),
 	.pcie_id = DT_INST_REG_SIZE(@NUM@),
@@ -36,7 +36,7 @@ static void i2c_config_@NUM@(const struct device *port)
 {
 	ARG_UNUSED(port);
 
-#if DT_INST_PROP(@NUM@, pcie)
+#if DT_INST_ON_BUS(@NUM@, pcie)
 #if DT_INST_IRQN(@NUM@) == PCIE_IRQ_DETECT
 
 	/* PCI(e) with auto IRQ detection */

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -13,8 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    pcie:
-      type: boolean
-      required: false
-      description: attached via PCI(e) bus

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -95,6 +95,110 @@
 			status = "okay";
 			current-speed = <115200>;
 		};
+
+		i2c0: i2c@b000 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x16,0) PCIE_ID(0x8086,0x5aac)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_0";
+
+			status = "okay";
+		};
+
+		i2c1: i2c@b100 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x16,1) PCIE_ID(0x8086,0x5aae)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_1";
+
+			status = "okay";
+		};
+
+		i2c2: i2c@b200 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x16,2) PCIE_ID(0x8086,0x5ab0)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_2";
+
+			status = "okay";
+		};
+
+		i2c3: i2c@b300 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x16,3) PCIE_ID(0x8086,0x5ab2)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_3";
+
+			status = "okay";
+		};
+
+		i2c4: i2c@b800 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x17,0) PCIE_ID(0x8086,0x5ab4)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_4";
+
+			status = "okay";
+		};
+
+		i2c5: i2c@b900 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x17,1) PCIE_ID(0x8086,0x5ab6)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_5";
+
+			status = "okay";
+		};
+
+		i2c6: i2c@ba00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x17,2) PCIE_ID(0x8086,0x5ab8)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_6";
+
+			status = "okay";
+		};
+
+		i2c7: i2c@bb00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x17,3) PCIE_ID(0x8086,0x5aba)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_7";
+
+			status = "okay";
+		};
 	};
 
 	soc {
@@ -110,118 +214,6 @@
 			reg = <0xfed65000 0x1000>;
 
 			status = "disabled";
-		};
-
-		i2c0: i2c@b000 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x16,0) PCIE_ID(0x8086,0x5aac)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_0";
-
-			status = "okay";
-		};
-
-		i2c1: i2c@b100 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x16,1) PCIE_ID(0x8086,0x5aae)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_1";
-
-			status = "okay";
-		};
-
-		i2c2: i2c@b200 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x16,2) PCIE_ID(0x8086,0x5ab0)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_2";
-
-			status = "okay";
-		};
-
-		i2c3: i2c@b300 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x16,3) PCIE_ID(0x8086,0x5ab2)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_3";
-
-			status = "okay";
-		};
-
-		i2c4: i2c@b800 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x17,0) PCIE_ID(0x8086,0x5ab4)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_4";
-
-			status = "okay";
-		};
-
-		i2c5: i2c@b900 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x17,1) PCIE_ID(0x8086,0x5ab6)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_5";
-
-			status = "okay";
-		};
-
-		i2c6: i2c@ba00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x17,2) PCIE_ID(0x8086,0x5ab8)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_6";
-
-			status = "okay";
-		};
-
-		i2c7: i2c@bb00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x17,3) PCIE_ID(0x8086,0x5aba)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_7";
-
-			status = "okay";
 		};
 
 		gpio_n_000_031: gpio@d0c50000 {

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -165,6 +165,201 @@
 			status = "disabled";
 			current-speed = <115200>;
 		};
+
+		i2c0: i2c@a800 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x15,0) PCIE_ID(0x8086,0x4b78)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_0";
+
+			status = "okay";
+		};
+
+		i2c1: i2c@a900 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x15,1) PCIE_ID(0x8086,0x4b79)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_1";
+
+			status = "okay";
+		};
+
+		i2c2: i2c@aa00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x15,2) PCIE_ID(0x8086,0x4b7a)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_2";
+
+			status = "okay";
+		};
+
+		i2c3: i2c@ab00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x15,3) PCIE_ID(0x8086,0x4b7b)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_3";
+
+			status = "okay";
+		};
+
+		i2c4: i2c@c800 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x19,0) PCIE_ID(0x8086,0x4b4b)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_4";
+
+			status = "okay";
+		};
+
+		i2c5: i2c@c900 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x19,1) PCIE_ID(0x8086,0x4b4c)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_5";
+
+			status = "okay";
+		};
+
+		i2c6: i2c@8000 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x10,0) PCIE_ID(0x8086,0x4b44)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_6";
+
+			status = "okay";
+		};
+
+		i2c7: i2c@8100 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x10,1) PCIE_ID(0x8086,0x4b45)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_7";
+
+			status = "okay";
+		};
+
+		i2c_pse_0: i2c@d800 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,0) PCIE_ID(0x8086,0x4bb9)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_0";
+
+			status = "okay";
+		};
+
+		i2c_pse_1: i2c@d900 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,1) PCIE_ID(0x8086,0x4bba)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_1";
+
+			status = "okay";
+		};
+
+		i2c_pse_2: i2c@da00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,2) PCIE_ID(0x8086,0x4bbb)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_2";
+
+			status = "okay";
+		};
+
+		i2c_pse_3: i2c@db00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,3) PCIE_ID(0x8086,0x4bbc)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_3";
+
+			status = "okay";
+		};
+
+		i2c_pse_4: i2c@dc00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,4) PCIE_ID(0x8086,0x4bbd)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_4";
+
+			status = "okay";
+		};
+
+		i2c_pse_5: i2c@dd00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,5) PCIE_ID(0x8086,0x4bbe)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_5";
+
+			status = "okay";
+		};
+
+		i2c_pse_6: i2c@de00 {
+			compatible = "snps,designware-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <PCIE_BDF(0,0x1b,6) PCIE_ID(0x8086,0x4bbf)>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			label = "I2C_PSE_6";
+
+			status = "okay";
+		};
 	};
 
 	soc {
@@ -201,216 +396,6 @@
 
 			status = "disabled";
 			current-speed = <115200>;
-		};
-
-		i2c0: i2c@a800 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x15,0) PCIE_ID(0x8086,0x4b78)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_0";
-
-			status = "okay";
-		};
-
-		i2c1: i2c@a900 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x15,1) PCIE_ID(0x8086,0x4b79)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_1";
-
-			status = "okay";
-		};
-
-		i2c2: i2c@aa00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x15,2) PCIE_ID(0x8086,0x4b7a)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_2";
-
-			status = "okay";
-		};
-
-		i2c3: i2c@ab00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x15,3) PCIE_ID(0x8086,0x4b7b)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_3";
-
-			status = "okay";
-		};
-
-		i2c4: i2c@c800 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x19,0) PCIE_ID(0x8086,0x4b4b)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_4";
-
-			status = "okay";
-		};
-
-		i2c5: i2c@c900 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x19,1) PCIE_ID(0x8086,0x4b4c)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_5";
-
-			status = "okay";
-		};
-
-		i2c6: i2c@8000 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x10,0) PCIE_ID(0x8086,0x4b44)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_6";
-
-			status = "okay";
-		};
-
-		i2c7: i2c@8100 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x10,1) PCIE_ID(0x8086,0x4b45)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_7";
-
-			status = "okay";
-		};
-
-		i2c_pse_0: i2c@d800 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,0) PCIE_ID(0x8086,0x4bb9)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_0";
-
-			status = "okay";
-		};
-
-		i2c_pse_1: i2c@d900 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,1) PCIE_ID(0x8086,0x4bba)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_1";
-
-			status = "okay";
-		};
-
-		i2c_pse_2: i2c@da00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,2) PCIE_ID(0x8086,0x4bbb)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_2";
-
-			status = "okay";
-		};
-
-		i2c_pse_3: i2c@db00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,3) PCIE_ID(0x8086,0x4bbc)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_3";
-
-			status = "okay";
-		};
-
-		i2c_pse_4: i2c@dc00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,4) PCIE_ID(0x8086,0x4bbd)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_4";
-
-			status = "okay";
-		};
-
-		i2c_pse_5: i2c@dd00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,5) PCIE_ID(0x8086,0x4bbe)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_5";
-
-			status = "okay";
-		};
-
-		i2c_pse_6: i2c@de00 {
-			compatible = "snps,designware-i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			pcie;
-			reg = <PCIE_BDF(0,0x1b,6) PCIE_ID(0x8086,0x4bbf)>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			label = "I2C_PSE_6";
-
-			status = "okay";
 		};
 
 		hpet: hpet@fed00000 {

--- a/soc/x86/apollo_lake/Kconfig.defconfig
+++ b/soc/x86/apollo_lake/Kconfig.defconfig
@@ -52,6 +52,10 @@ config I2C_DW
 	default y
 	depends on I2C
 
+config I2C_DW_MAX_INSTANCES
+	default 8
+	depends on I2C_DW
+
 config GPIO_INTEL_APL
 	default y
 	depends on GPIO

--- a/soc/x86/elkhart_lake/Kconfig.defconfig
+++ b/soc/x86/elkhart_lake/Kconfig.defconfig
@@ -52,6 +52,10 @@ config I2C_DW
 	default y
 	depends on I2C
 
+config I2C_DW_MAX_INSTANCES
+	default 15
+	depends on I2C_DW
+
 config UART_NS16550_MAX_INSTANCES
 	default 11
 	depends on UART_NS16550


### PR DESCRIPTION
These two patches take a similar approach as #31274 to organise all PCIe-based I2C nodes under a PCIe bus, as well as to eliminate the hardcoded instance count assumption in the driver in favour of a Kconfig option (normally set by the SoC). Similar to #31274 we can't unfortunately take advantage of `DT_INST_FOREACH_STATUS_OKAY()` due to the complexities of the per-instance IRQ configuration function.