### PR TITLE
samples: cpp_synchronization: fix 'main' signature

### DIFF
--- a/samples/cpp_synchronization/src/main.cpp
+++ b/samples/cpp_synchronization/src/main.cpp
@@ -133,7 +133,7 @@ void coop_thread_entry(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	struct k_timer timer;
 
@@ -154,4 +154,6 @@ void main(void)
 		/* Wait for coop thread to let us have a turn */
 		sem_main.wait();
 	}
+
+	return 0;
 }


### PR DESCRIPTION
'main' function should retun 'int' and not 'void'. Otherwise some picky compilers (like ARC MWDT) would warn about that.