### PR TITLE
libc: minimal: stdout: fix 'fputs' return value

### DIFF
--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -48,7 +48,7 @@ int fputs(const char *_MLIBC_RESTRICT string, FILE *_MLIBC_RESTRICT stream)
 	int len = strlen(string);
 	int ret;
 
-	ret = fwrite(string, len, 1, stream);
+	ret = fwrite(string, 1, len, stream);
 
 	return len == ret ? 0 : EOF;
 }


### PR DESCRIPTION
The 'fputs' has flaw in the implementation. It almost always returns 'EOF' even if completed successfully.
This happens because we compare 'fwrite' return value which is "number of members successfully written" (which is 1 in current
implementation) to the total string size:
```
int fputs(const char *_MLIBC_RESTRICT string, FILE *_MLIBC_RESTRICT stream)
{
	int len = strlen(string);
	int ret;

	ret = fwrite(string, len, 1, stream);

	return len == ret ? 0 : EOF;
}
```
In result 'fputs' return 'EOF' in case of string length bigger than 1.

There are several fixes possible, and one of the fixes is to swap number of items (1) with size (string length) when we
are calling 'fwrite'. The only difference will be that 'fwrite' will return actual numbers of bytes written which can be compared with the string length.