### PR TITLE
tests: ztest: add a configuration to exclude LOG macro

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -257,6 +257,14 @@ static inline char z_log_minimal_level_to_char(int level)
 /******************************************************************************/
 /****************** Macros for standard logging *******************************/
 /******************************************************************************/
+#if defined(CONFIG_ZTEST_COVERAGE_EXCLUDE_LOG)
+/* Exclude the LOG macro while generating code coverage report. */
+#define __LOG(_level, _id, _filter, ...)				       \
+	do {								       \
+		Z_LOG_TO_PRINTK(_level, __VA_ARGS__);				\
+	} while (false)
+#else
+/* Normal functionality of LOG macro */
 #define __LOG(_level, _id, _filter, ...)				       \
 	do {								       \
 		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
@@ -292,6 +300,7 @@ static inline char z_log_minimal_level_to_char(int level)
 			log_printf_arg_checker(__VA_ARGS__);		       \
 		}							       \
 	} while (false)
+#endif
 
 #define Z_LOG(_level, ...)			       \
 	__LOG(_level,				       \
@@ -311,6 +320,17 @@ static inline char z_log_minimal_level_to_char(int level)
 /******************************************************************************/
 /****************** Macros for hexdump logging ********************************/
 /******************************************************************************/
+#if defined(CONFIG_ZTEST_COVERAGE_EXCLUDE_LOG)
+/* Exclude the LOG macro while generating code coverage report. */
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)		\
+	do {									\
+		Z_LOG_TO_PRINTK(_level, "%s", _str);				\
+		log_minimal_hexdump_print(_level,				\
+					  (const char *)_data,			\
+					  _length);				\
+	} while (false)
+#else
+/* Normal functionality of LOG_HEXDUMP macro */
 #define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	       \
 	do {								       \
 		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
@@ -346,6 +366,7 @@ static inline char z_log_minimal_level_to_char(int level)
 			}						       \
 		}							       \
 	} while (false)
+#endif
 
 #define Z_LOG_HEXDUMP(_level, _data, _length, _str)	       \
 	__LOG_HEXDUMP(_level,				       \

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -72,6 +72,14 @@ config ZTEST_ASSERT_HOOK
 	  error test case. Remember to add ignore_fault tag in yaml file when
 	  using twister to run testing.
 
+config ZTEST_COVERAGE_EXCLUDE_LOG
+	bool "Exclude LOG marco when generation code covergage report"
+	default n
+	depends on HAS_COVERAGE_SUPPORT
+	depends on COVERAGE_GCOV
+	help
+	  If True the code coverage report will not include the LOG relvant macro.
+
 endif # ZTEST
 
 config ZTEST_MOCKING


### PR DESCRIPTION
Add a configuration CONFIG_ZTEST_COVERAGE_EXCLUDE_LOG, which is use to
exclude LOG relevant macro line when generating code coverage report.

There are many LOG relevant macro used every where in zephyr code. But when generating code coverage report, one of the branch of this line will never been hit, unless we build LOG test cases for every module.  
We thought all LOG macro should be only testing in LOG module itself (tests/subsys/logging).
So maybe a better practice is the add a dedicate configuration to exclude LOG module when showing the code coverage report, and also only be used for code coverage.

By this way, generating code coverage report can use following command, such as:
twister -T tests/kernel/ -p qemu_x86 --coverage -x=CONFIG_ZTEST_COVERAGE_EXCLUDE_LOG=y

And for LOG module itself, CONFIG_ZTEST_COVERAGE_EXCLUDE_LOG=n can be set in its prj.conf, to make sure all LOG feature are tested.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>