### PR TITLE
boards: arm: stm32: Adjust maximum speed for STM32F746G disco board

### DIFF
--- a/boards/arm/stm32f746g_disco/support/openocd.cfg
+++ b/boards/arm/stm32f746g_disco/support/openocd.cfg
@@ -10,3 +10,10 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+# Event reset-init already uses the maximum speed however adapter speed
+# inherited from stm32f7x.cfg for reset-start defaults to 2000 kHz, so
+# override that speed setting it also to the maximum speed.
+$_TARGETNAME configure -event reset-start {
+        adapter_khz 4000
+}


### PR DESCRIPTION
Currently configuration for STM32F746G Discovery board on reset-start
event is inherited from included files (OpenOCD stm32f7x.cfg), but
contrary to the inherited adapter speed on reset-init event, the speed
inherited for the reset-start event is only 2000 kHz, which is not
available, so a lower speed is picked up automatically generating the
following message several times when flashing the board:

Info : Unable to match requested speed 2000 kHz, using 1800 kHz

That commit overrides that suboptimal speed for reset-start event and
sets it to the same speed as used by reset-init event, i.e. the maximum
speed (4000 kHz), so the noisy messages like the above one disappear.

The change also improves a bit the throughput when writing to the board.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>