### PR TITLE
Fix error in include/net/socket_select.h

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -16,6 +16,10 @@
 
 #include <net/socket_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct zsock_fd_set {
 	uint32_t bitset[(CONFIG_POSIX_MAX_FDS + 31) / 32];
 } zsock_fd_set;


### PR DESCRIPTION
You have deleted 
```c
#ifdef __cplusplus	
extern "C" {	
#endif
```

in commit 2dd611c9d0b9a863f710c5ab8878df427bcb6828, from file include/net/socket_select.h but you have kept [the closing bracket](https://github.com/zephyrproject-rtos/zephyr/blob/74c4d5ae2a457258629fd6cb2f02d24755d8f5ca/include/net/socket_select.h#L137)

```c
#ifdef __cplusplus
}
#endif
```

Solves: https://github.com/zephyrproject-rtos/zephyr/issues/31444