### PR TITLE
scripts: check_compliance.py: include known Zephyr Kconfig glue code

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -252,6 +252,21 @@ class KconfigCheck(ComplianceTest):
         except subprocess.CalledProcessError as ex:
             self.error(ex.output)
 
+        modules_dir = ZEPHYR_BASE + '/modules'
+        modules = [name for name in os.listdir(modules_dir) if
+                   os.path.exists(os.path.join(modules_dir, name, 'Kconfig'))]
+
+        with open(modules_file, 'r') as fp_module_file:
+            content = fp_module_file.read()
+
+        with open(modules_file, 'w') as fp_module_file:
+            for module in modules:
+                fp_module_file.write("ZEPHYR_{}_KCONFIG = {}\n".format(
+                    module.upper(),
+                    modules_dir + '/' + module + '/Kconfig'
+                ))
+            fp_module_file.write(content)
+
     def write_kconfig_soc(self):
         """
         Write KConfig soc files to be sourced during Kconfig parsing


### PR DESCRIPTION
Fixes: #31436

This fix adds ZEPHYR_<MODULE_NAME>_KCONFIG variable to compliance check.
This ensures that Zephyr Kconfig glue code is included in the
compliance check, and thus remove the issue reported in #31436.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>