### PR TITLE
bluetooth: controller: Disable Coded PHY by default

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -62,6 +62,9 @@ API Changes
   parameter, allowing to specify the maximum retransmission count of the
   confirmable message.
 
+* The ``CONFIG_BT_CTLR_CODED_PHY`` is now disabled by default for builds
+  combining both Bluetooth host and controller.
+
 Deprecated in this release
 ==========================
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -430,7 +430,7 @@ config BT_CTLR_PHY_2M
 config BT_CTLR_PHY_CODED
 	bool "Coded PHY Support"
 	depends on (BT_CTLR_PHY || BT_CTLR_ADV_EXT) && BT_CTLR_PHY_CODED_SUPPORT
-	default y
+	default y if BT_HCI_RAW
 	help
 	  Enable support for Bluetooth 5.0 Coded PHY in the Controller.
 


### PR DESCRIPTION
Coded PHY is not needed in most applications.
By disabling Coded PHY, most applications will:
 - Get smaller in terms of flash and ram usage
 - Not get vurnerable to devices trying to switch to Coded and
   thereby increasing power consumption.

HCI samples have Coded PHY enabled by default, as they expect all
features to be enabled.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>