### PR TITLE
dts: sensor: remove lis3dh binding

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -56,7 +56,7 @@
 	status = "okay";
 
 	lis3dh@32 {
-		compatible = "st,lis3dh";
+		compatible = "st,lis3dh", "st,lis2dh";
 		reg = <0x32>;
 		label = "LIS3DH";
 	};

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -85,7 +85,7 @@
 	};
 
 	lsm303agr-accel@19 {
-		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		compatible = "st,lsm303agr-accel", "st,lis2dh";
 		status = "disabled";
 		reg = <0x19>;
 		label = "LSM303AGR-ACCEL";

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -104,7 +104,7 @@
 	};
 
 	lsm303agr-accel@19 {
-		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		compatible = "st,lsm303agr-accel", "st,lis2dh";
 		status = "okay";
 		reg = <0x19>;
 		label = "LSM303AGR-ACCEL";

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -85,7 +85,7 @@
 
 	/* ST Microelectronics LIS3DH motion sensor */
 	lis3dh@19 {
-		compatible = "st,lis3dh";
+		compatible = "st,lis3dh", "st,lis2dh";
 		label = "LIS3DH";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 15 0>;

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -88,7 +88,7 @@
 	};
 
 	lis2dh12: lis2dh12@1 {
-		compatible = "st,lis2dh", "st,lis2dh12";
+		compatible = "st,lis2dh12", "st,lis2dh";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
 		irq-gpios =  <&gpio0 2 GPIO_ACTIVE_HIGH>, <&gpio0 6 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -95,7 +95,7 @@
 	};
 
 	lsm303dlhc-accel@19 {
-		compatible = "st,lis2dh", "st,lsm303dlhc-accel";
+		compatible = "st,lsm303dlhc-accel", "st,lis2dh";
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -34,7 +34,7 @@
 	};
 
 	lsm303agr-accel@19 {
-		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		compatible = "st,lsm303agr-accel", "st,lis2dh";
 		reg = <0x19>;
 		label = "LSM303AGR-ACCEL";
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -2,7 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LIS2DH 3-axis accelerometer accessed through I2C bus
+    STMicroelectronics LIS2DH 3-axis accelerometer accessed through I2C bus.
+
+    This binding is supported by CONFIG_LIS2DH.
+
+    The LIS3DH sensor is supported by the same driver, and should be
+    specified in devicetree with:
+
+        compatible = "st,lis3dh", "st,lis2dh";
+
+    The LIS2DH12 sensor is supported by the same driver, and should be
+    specified in devicetree with:
+
+        compatible = "st,lis2dh12", "st,lis2dh";
+
+    The accelerometer side of the LSM303DHLC sensor is supported by the
+    same driver, and should be specified in devicetree with:
+
+        compatible = "st,lsm303dlhc-accel", "st,lis2dh";
+
+    The accelerometer side of the LSM303AGC sensor is supported by the
+    same driver, and should be specified in devicetree with:
+
+        compatible = "st,lsm303agr-accel", "st,lis2dh";
+
 
 compatible: "st,lis2dh"
 

--- a/dts/bindings/sensor/st,lis2dh12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh12-i2c.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2019 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-description: STMicroelectronics LIS2DH12 3-axis accelerometer
-
-compatible: "st,lis2dh12"
-
-include: ["i2c-device.yaml", "st,lis2dh-common.yaml"]

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2018 STMicroelectronics
-# SPDX-License-Identifier: Apache-2.0
-
-description: STMicroelectronics LIS3DH 3-axis accelerometer
-
-compatible: "st,lis3dh"
-
-include: ["i2c-device.yaml", "st,lis2dh-common.yaml"]

--- a/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
@@ -1,9 +1,0 @@
-# Copyright (c) 2019 Grinn
-# SPDX-License-Identifier: Apache-2.0
-
-description: |
-    STMicroelectronics LSM303AGR 3-axis accelerometer accessed through I2C bus
-
-compatible: "st,lsm303agr-accel"
-
-include: ["i2c-device.yaml", "st,lis2dh-common.yaml"]

--- a/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
@@ -1,9 +1,0 @@
-# Copyright (c) 2019 Grinn
-# SPDX-License-Identifier: Apache-2.0
-
-description: |
-    STMicroelectronics LSM303AGR 3-axis accelerometer accessed through SPI bus
-
-compatible: "st,lsm303agr-accel"
-
-include: ["spi-device.yaml", "st,lis2dh-common.yaml"]

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2018 Philémon Jaermann
-# SPDX-License-Identifier: Apache-2.0
-
-description: LSM303DLHC acceleration sensor
-
-compatible: "st,lsm303dlhc-accel"
-
-include: ["i2c-device.yaml", "st,lis2dh-common.yaml"]

--- a/tests/drivers/build_all/i2c.dtsi
+++ b/tests/drivers/build_all/i2c.dtsi
@@ -333,7 +333,7 @@ test_i2c_lis2dh: lis2dh@2b {
 };
 
 test_i2c_lis2dh12: lis2dh12@2c {
-	compatible = "st,lis2dh12";
+	compatible = "st,lis2dh12", "st,lis2dh";
 	label = "LIS2DH12";
 	reg = <0x2c>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -361,7 +361,7 @@ test_i2c_lis2mdl: lis2mdl@2f {
 };
 
 test_i2c_lis3dh: lis3dh@30 {
-	compatible = "st,lis3dh";
+	compatible = "st,lis3dh", "st,lis2dh";
 	label = "LIS3DH";
 	reg = <0x30>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -394,7 +394,7 @@ test_i2c_lps25hb_press: lps25hb-press@34 {
 };
 
 test_i2c_lsm303agr_accel: lsm303agr-accel@35 {
-	compatible = "st,lsm303agr-accel";
+	compatible = "st,lsm303agr-accel", "st,lis2dh";
 	label = "LSM303AGR-ACCEL";
 	reg = <0x35>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -402,7 +402,7 @@ test_i2c_lsm303agr_accel: lsm303agr-accel@35 {
 };
 
 test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@36 {
-	compatible = "st,lsm303dlhc-accel";
+	compatible = "st,lsm303dlhc-accel", "st,lis2dh";
 	label = "LSM303DLHC-ACCEL";
 	reg = <0x36>;
 	irq-gpios = <&test_gpio 0 0>;


### PR DESCRIPTION
While there once was a separate driver for st,lis3dh support for that variant was merged into lis2dh.  That driver only recognizes devices that are identified as st,lis2dh.  Remove the lis3dh binding, and update in-tree devicetree nodes to add the compatible required by the driver.

Also st,lis2dh12 same thing.  Also propose standard documentation block to relate compatibles with bindings and drivers.

(NB: Prior to this I verified that neither of the affected in-tree boards could build the lis2dh sample because the required devicetree binding macros were not generated.)

Fixes #31253.