### PR TITLE
lorawan: handling of datarate changes

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -122,6 +122,19 @@ struct lorawan_join_config {
 int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
 
 /**
+ * @brief Register a callback to be called when the datarate changes
+ *
+ * The callback is called once upon successfully joining a network and again
+ * each time the datarate changes due to ADR.
+ *
+ * The callback function takes one parameter:
+ *	- dr - updated datarate
+ *
+ * @param dr_cb Pointer to datarate update callback
+ */
+void lorawan_register_dr_changed_callback(void (*dr_cb)(enum lorawan_datarate));
+
+/**
  * @brief Join the LoRaWAN network
  *
  * Join the LoRaWAN network using OTAA or AWB.

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -206,6 +206,16 @@ void lorawan_enable_adr(bool enable);
 int lorawan_set_datarate(enum lorawan_datarate dr);
 
 /**
+ * @brief Get the minimum possible datarate
+ *
+ * The minimum possible datarate may change in response to a TxParamSetupReq
+ * command from the network server.
+ *
+ * @return Minimum possible data rate
+ */
+enum lorawan_datarate lorawan_get_min_datarate(void);
+
+/**
  * @brief Get the current payload sizes
  *
  * Query the current payload sizes. The maximum payload size varies with

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -205,6 +205,19 @@ void lorawan_enable_adr(bool enable);
  */
 int lorawan_set_datarate(enum lorawan_datarate dr);
 
+/**
+ * @brief Get the current payload sizes
+ *
+ * Query the current payload sizes. The maximum payload size varies with
+ * datarate, while the current payload size can be less due to MAC layer
+ * commands which are inserted into uplink packets.
+ *
+ * @param max_next_payload_size Maximum payload size for the next transmission
+ * @param max_payload_size Maximum payload size for this datarate
+ */
+void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
+			       uint8_t *max_payload_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/lorawan/class_a/src/main.c
+++ b/samples/lorawan/class_a/src/main.c
@@ -32,6 +32,14 @@ LOG_MODULE_REGISTER(lorawan_class_a);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
+static void lorwan_datarate_changed(enum lorawan_datarate dr)
+{
+	uint8_t unused, max_size;
+
+	lorawan_get_payload_sizes(&unused, &max_size);
+	LOG_INF("New Datarate: DR_%d, Max Payload %d", dr, max_size);
+}
+
 void main(void)
 {
 	const struct device *lora_dev;
@@ -52,6 +60,8 @@ void main(void)
 		LOG_ERR("lorawan_start failed: %d", ret);
 		return;
 	}
+
+	lorawan_register_dr_changed_callback(lorwan_datarate_changed);
 
 	join_cfg.mode = LORAWAN_ACT_OTAA;
 	join_cfg.dev_eui = dev_eui;

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -349,6 +349,18 @@ int lorawan_set_datarate(enum lorawan_datarate dr)
 	return 0;
 }
 
+void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
+			       uint8_t *max_payload_size)
+{
+	LoRaMacTxInfo_t txInfo;
+
+	/* QueryTxPossible cannot fail */
+	(void)LoRaMacQueryTxPossible(0, &txInfo);
+
+	*max_next_payload_size = txInfo.MaxPossibleApplicationDataSize;
+	*max_payload_size = txInfo.CurrentPossiblePayloadSize;
+}
+
 void lorawan_enable_adr(bool enable)
 {
 	MibRequestConfirm_t mib_req;

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -361,6 +361,16 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 	*max_payload_size = txInfo.CurrentPossiblePayloadSize;
 }
 
+enum lorawan_datarate lorawan_get_min_datarate(void)
+{
+	MibRequestConfirm_t mibGet;
+
+	mibGet.Type = MIB_CHANNELS_MIN_TX_DATARATE;
+	LoRaMacMibGetRequestConfirm(&mibGet);
+
+	return mibGet.Param.ChannelsMinTxDatarate;
+}
+
 void lorawan_enable_adr(bool enable)
 {
 	MibRequestConfirm_t mib_req;

--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
       revision: de1b85a13032a2de1d8b6695ae5f800b613e739d
       path: modules/lib/open-amp
     - name: loramac-node
-      revision: 3f545d76a2e6d1db83a470ccdb5bebd1f484e137
+      revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e
       path: modules/lib/loramac-node
     - name: openthread
       revision: d44ee763b7e8fea29b54dd064342c771161afcab


### PR DESCRIPTION
When enabling Adaptive-Data-Rate (ADR), the datarate of the network connection changes is response to packets transmitted and received. As datarates change, so too does the payload capacity of a single packet. What once was a valid payload may no longer fit in a single packet, or several packets may be able to be consolidated due to an increase in payload size, improving network efficiency. It is therefore useful to know both how much data we can possibly transmit, and to be notified when that value changes. 

This functionality also allows devices to handle the rare but catastrophic case of a network server reboot. As time passes without receiving acknowledgements, the ADR algorithm will automatically reduce the datarate used. However it will only reduce the datarate to the minimum possible datarate for a given region. Once there, no further action is taken, resulting in a node permanently stuck with the wrong network parameters. The correct action is to assume the network is lost if packets are still not being acknowledged at the lowest datarate, and initiate a rejoin.

This PR addresses the above problems. Firstly functionality to query possible payload sizes is added. Secondly a callback is provided to be notified when the datarate is changed. Finally, the minimum datarate can be queried.