### PR TITLE
boards: Clean up TF-M signing code for nrf53 and nrf91

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -46,13 +46,10 @@ if (CONFIG_BUILD_WITH_TFM)
 		# Merge tfm_s and zephyr (NS) image to a single binary.
 		set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
 			COMMAND ${SREC_CAT}
-			ARGS ${CMAKE_BINARY_DIR}/tfm/bin/tfm_s.bin -Binary
+			ARGS $<TARGET_PROPERTY:tfm,TFM_S_BIN_FILE> -Binary
 				${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME} -Binary
 				-offset ${CONFIG_FLASH_LOAD_OFFSET}
 				-o ${CMAKE_BINARY_DIR}/tfm_merged.hex -intel
-
-			# Copy tfm_sign.hex to zephyr
-			COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm_merged.hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
 		)
 	else()
 		#Create and sign for concatenated binary image, should align with the TF-M BL2
@@ -102,9 +99,13 @@ if (CONFIG_BUILD_WITH_TFM)
 				-offset 0x10000
 				-o ${CMAKE_BINARY_DIR}/tfm_sign.hex
 				-intel
+		)
 
-			# Copy tfm_sign.hex to zephyr
-			COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm_sign.hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+		set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+			${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+			${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+			${CMAKE_BINARY_DIR}/tfm_sign.bin
+			${CMAKE_BINARY_DIR}/tfm_sign.hex
 		)
 	endif()
 endif()

--- a/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
+++ b/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
@@ -65,7 +65,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
 		#Create concatenated binary image from the two independently signed binary files
 		COMMAND ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/assemble.py
-		     --layout ${PREPROCESSED_FILE_S}
+			 --layout ${PREPROCESSED_FILE_S}
 			 -s ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
 			 -n ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
 			 -o ${CMAKE_BINARY_DIR}/tfm_sign.bin
@@ -79,8 +79,12 @@ if (CONFIG_BUILD_WITH_TFM)
 		-offset 0x10000
 		-o ${CMAKE_BINARY_DIR}/tfm_sign.hex
 		-intel
+	)
 
-		# Copy tfm_sign.hex to zephyr
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tfm_sign.hex ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+	set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+		${CMAKE_BINARY_DIR}/tfm_s_signed.bin
+		${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
+		${CMAKE_BINARY_DIR}/tfm_sign.bin
+		${CMAKE_BINARY_DIR}/tfm_sign.hex
 	)
 endif()


### PR DESCRIPTION
-Add byproducts
-Don't overwrite zephyr.hex
-Whitespace
-Use target property

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>