### PR TITLE
Bluetooth: host: Remove deprecated definitions and functions

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -79,6 +79,15 @@ Deprecated in this release
 Removed APIs in this release
 ============================
 
+* Bluetooth
+
+  * The deprecated BT_LE_SCAN_FILTER_DUPLICATE define has been removed,
+    use BT_LE_SCAN_OPT_FILTER_DUPLICATE instead.
+  * The deprecated BT_LE_SCAN_FILTER_WHITELIST define has been removed,
+    use BT_LE_SCAN_OPT_FILTER_WHITELIST instead.
+  * The deprecated bt_le_scan_param::filter_dup argument has been removed,
+    use bt_le_scan_param::options instead.
+
 Stable API changes in this release
 ==================================
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -87,6 +87,8 @@ Removed APIs in this release
     use BT_LE_SCAN_OPT_FILTER_WHITELIST instead.
   * The deprecated bt_le_scan_param::filter_dup argument has been removed,
     use bt_le_scan_param::options instead.
+  * The deprecated BT_LE_ADV_* macros have been removed,
+    use the BT_GAP_ADV_* enums instead.
   * The deprecated BT_SECURITY_* defines NONE, LOW, MEDIUM, HIGH, FIPS have been
     removed, use the L0, L1, L2, L3, L4 defines instead.
   * The deprecated BT_HCI_ERR_AUTHENTICATION_FAIL define has been removed,

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -87,6 +87,10 @@ Removed APIs in this release
     use BT_LE_SCAN_OPT_FILTER_WHITELIST instead.
   * The deprecated bt_le_scan_param::filter_dup argument has been removed,
     use bt_le_scan_param::options instead.
+  * The deprecated BT_SECURITY_* defines NONE, LOW, MEDIUM, HIGH, FIPS have been
+    removed, use the L0, L1, L2, L3, L4 defines instead.
+  * The deprecated BT_HCI_ERR_AUTHENTICATION_FAIL define has been removed,
+    use BT_HCI_ERR_AUTH_FAIL instead.
 
 Stable API changes in this release
 ==================================

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -87,6 +87,10 @@ Removed APIs in this release
     use BT_LE_SCAN_OPT_FILTER_WHITELIST instead.
   * The deprecated bt_le_scan_param::filter_dup argument has been removed,
     use bt_le_scan_param::options instead.
+  * The deprecated bt_conn_create_le() function has been removed,
+    use bt_conn_le_create() instead.
+  * The deprecated bt_conn_create_auto_le() function has been removed,
+    use bt_conn_le_create_auto() instead.
   * The deprecated BT_LE_ADV_* macros have been removed,
     use the BT_GAP_ADV_* enums instead.
   * The deprecated BT_SECURITY_* defines NONE, LOW, MEDIUM, HIGH, FIPS have been

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -93,6 +93,8 @@ Removed APIs in this release
     use bt_conn_le_create_auto() instead.
   * The deprecated BT_LE_ADV_* macros have been removed,
     use the BT_GAP_ADV_* enums instead.
+  * The deprecated bt_conn_security function has been removed,
+    use bt_conn_set_security instead.
   * The deprecated BT_SECURITY_* defines NONE, LOW, MEDIUM, HIGH, FIPS have been
     removed, use the L0, L1, L2, L3, L4 defines instead.
   * The deprecated BT_HCI_ERR_AUTHENTICATION_FAIL define has been removed,

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -91,6 +91,9 @@ Removed APIs in this release
     use bt_conn_le_create() instead.
   * The deprecated bt_conn_create_auto_le() function has been removed,
     use bt_conn_le_create_auto() instead.
+  * The deprecated bt_conn_create_slave_le() function has been removed,
+    use bt_le_adv_start() instead with bt_le_adv_param::peer set to the remote
+    peers address.
   * The deprecated BT_LE_ADV_* macros have been removed,
     use the BT_GAP_ADV_* enums instead.
   * The deprecated bt_conn_security function has been removed,

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -1489,11 +1489,6 @@ enum {
 	 * @note Requires @ref BT_LE_SCAN_OPT_CODED.
 	 */
 	BT_LE_SCAN_OPT_NO_1M = BIT(3),
-
-	BT_LE_SCAN_FILTER_DUPLICATE __deprecated =
-		BT_LE_SCAN_OPT_FILTER_DUPLICATE,
-	BT_LE_SCAN_FILTER_WHITELIST __deprecated =
-		BT_LE_SCAN_OPT_FILTER_WHITELIST,
 };
 
 enum {
@@ -1509,13 +1504,8 @@ struct bt_le_scan_param {
 	/** Scan type (BT_LE_SCAN_TYPE_ACTIVE or BT_LE_SCAN_TYPE_PASSIVE) */
 	uint8_t  type;
 
-	union {
-		/** Bit-field of scanning filter options. */
-		uint32_t filter_dup __deprecated;
-
-		/** Bit-field of scanning options. */
-		uint32_t options;
-	};
+	/** Bit-field of scanning options. */
+	uint32_t options;
 
 	/** Scan interval (N * 0.625 ms) */
 	uint16_t interval;

--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -45,9 +45,6 @@ struct bt_buf_data {
 	uint8_t type;
 };
 
-/** Minimum amount of user data size for buffers passed to the stack. */
-#define BT_BUF_USER_DATA_MIN __DEPRECATED_MACRO 4
-
 #if defined(CONFIG_BT_HCI_RAW)
 #define BT_BUF_RESERVE MAX(CONFIG_BT_HCI_RESERVE, CONFIG_BT_HCI_RAW_RESERVE)
 #else

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -748,12 +748,6 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec);
  */
 bt_security_t bt_conn_get_security(struct bt_conn *conn);
 
-static inline int __deprecated bt_conn_security(struct bt_conn *conn,
-						bt_security_t sec)
-{
-	return bt_conn_set_security(conn, sec);
-}
-
 /** @brief Get encryption key size.
  *
  *  This function gets encryption key size.

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -542,7 +542,7 @@ struct bt_conn_le_create_param {
 	 *  Set zero to use the default @option{CONFIG_BT_CREATE_CONN_TIMEOUT}
 	 *  timeout.
 	 *
-	 *  @note Unused in @ref bt_conn_create_auto_le
+	 *  @note Unused in @ref bt_conn_le_create_auto
 	 */
 	uint16_t timeout;
 };
@@ -612,24 +612,6 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 		      const struct bt_le_conn_param *conn_param,
 		      struct bt_conn **conn);
 
-__deprecated static inline
-struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
-				  const struct bt_le_conn_param *conn_param)
-{
-	struct bt_conn *conn;
-	struct bt_conn_le_create_param param = BT_CONN_LE_CREATE_PARAM_INIT(
-						BT_CONN_LE_OPT_NONE,
-						BT_GAP_SCAN_FAST_INTERVAL,
-						BT_GAP_SCAN_FAST_INTERVAL);
-
-	if (bt_conn_le_create(peer, &param, conn_param,
-			      &conn)) {
-		return NULL;
-	}
-
-	return conn;
-}
-
 /** @brief Automatically connect to remote devices in whitelist.
  *
  *  This uses the Auto Connection Establishment procedure.
@@ -647,17 +629,6 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
  */
 int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 			   const struct bt_le_conn_param *conn_param);
-
-__deprecated static inline
-int bt_conn_create_auto_le(const struct bt_le_conn_param *conn_param)
-{
-	struct bt_conn_le_create_param param = BT_CONN_LE_CREATE_PARAM_INIT(
-						BT_CONN_LE_OPT_NONE,
-						BT_GAP_SCAN_FAST_INTERVAL,
-						BT_GAP_SCAN_FAST_WINDOW);
-
-	return bt_conn_le_create_auto(&param, conn_param);
-}
 
 /** @brief Stop automatic connect creation.
  *
@@ -845,7 +816,7 @@ struct bt_conn_cb {
 	 *
 	 *  @p err can mean either of the following:
 	 *  - @ref BT_HCI_ERR_UNKNOWN_CONN_ID Creating the connection started by
-	 *    @ref bt_conn_create_le was canceled either by the user through
+	 *    @ref bt_conn_le_create was canceled either by the user through
 	 *    @ref bt_conn_disconnect or by the timeout in the host through
 	 *    @ref bt_conn_le_create_param timeout parameter, which defaults to
 	 *    @option{CONFIG_BT_CREATE_CONN_TIMEOUT} seconds.

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -653,45 +653,6 @@ int bt_conn_create_auto_stop(void);
 int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 			const struct bt_le_conn_param *param);
 
-/** @brief Initiate directed advertising to a remote device
- *
- *  Allows initiating a new LE connection to remote peer with the remote
- *  acting in central role and the local device in peripheral role.
- *
- *  The advertising type will either be BT_LE_ADV_DIRECT_IND, or
- *  BT_LE_ADV_DIRECT_IND_LOW_DUTY if the BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY
- *  option was used as part of the advertising parameters.
- *
- *  In case of high duty cycle this will result in a callback with
- *  connected() with a new connection or with an error.
- *
- *  The advertising may be canceled with bt_conn_disconnect().
- *
- *  The caller gets a new reference to the connection object which must be
- *  released with bt_conn_unref() once done using the object.
- *
- *  @param peer  Remote address.
- *  @param param Directed advertising parameters.
- *
- *  @return Valid connection object on success or NULL otherwise.
- */
-__deprecated static inline
-struct bt_conn *bt_conn_create_slave_le(const bt_addr_le_t *peer,
-					const struct bt_le_adv_param *param)
-{
-	struct bt_le_adv_param adv_param = *param;
-
-	adv_param.options |= (BT_LE_ADV_OPT_CONNECTABLE |
-			      BT_LE_ADV_OPT_ONE_TIME);
-	adv_param.peer = peer;
-
-	if (!bt_le_adv_start(&adv_param, NULL, 0, NULL, 0)) {
-		return NULL;
-	}
-
-	return bt_conn_lookup_addr_le(param->id, peer);
-}
-
 /** Security level. */
 typedef enum __packed {
 	/** Level 0: Only for BR/EDR special cases, like SDP */

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -733,13 +733,6 @@ typedef enum __packed {
 	BT_SECURITY_L3,
 	/** Level 4: Authenticated Secure Connections and 128-bit key. */
 	BT_SECURITY_L4,
-
-	BT_SECURITY_NONE   __deprecated = BT_SECURITY_L0,
-	BT_SECURITY_LOW    __deprecated = BT_SECURITY_L1,
-	BT_SECURITY_MEDIUM __deprecated = BT_SECURITY_L2,
-	BT_SECURITY_HIGH   __deprecated = BT_SECURITY_L3,
-	BT_SECURITY_FIPS   __deprecated = BT_SECURITY_L4,
-
 	/** Bit to force new pairing procedure, bit-wise OR with requested
 	 *  security level.
 	 */

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -803,15 +803,6 @@ struct bt_hci_cp_le_set_random_address {
 	bt_addr_t bdaddr;
 } __packed;
 
-/* LE Advertising Types (LE Advertising Parameters Set)*/
-#define BT_LE_ADV_IND                  (__DEPRECATED_MACRO 0x00)
-#define BT_LE_ADV_DIRECT_IND           (__DEPRECATED_MACRO 0x01)
-#define BT_LE_ADV_SCAN_IND             (__DEPRECATED_MACRO 0x02)
-#define BT_LE_ADV_NONCONN_IND          (__DEPRECATED_MACRO 0x03)
-#define BT_LE_ADV_DIRECT_IND_LOW_DUTY  (__DEPRECATED_MACRO 0x04)
-/* LE Advertising PDU Types. */
-#define BT_LE_ADV_SCAN_RSP             (__DEPRECATED_MACRO 0x04)
-
 #define BT_HCI_ADV_IND                          0x00
 #define BT_HCI_ADV_DIRECT_IND                   0x01
 #define BT_HCI_ADV_SCAN_IND                     0x02

--- a/include/bluetooth/hci_err.h
+++ b/include/bluetooth/hci_err.h
@@ -83,8 +83,6 @@ extern "C" {
 #define BT_HCI_ERR_OP_CANCELLED_BY_HOST         0x44
 #define BT_HCI_ERR_PACKET_TOO_LONG              0x45
 
-#define BT_HCI_ERR_AUTHENTICATION_FAIL __DEPRECATED_MACRO BT_HCI_ERR_AUTH_FAIL
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -228,7 +228,7 @@ static int scan_start(void)
 	 */
 	struct bt_le_scan_param scan_param = {
 		.type       = BT_LE_SCAN_TYPE_ACTIVE,
-		.filter_dup = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval   = BT_GAP_SCAN_FAST_INTERVAL,
 		.window     = BT_GAP_SCAN_FAST_WINDOW,
 	};

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2158,17 +2158,6 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 			bt_le_scan_update(false);
 		}
 		return 0;
-	case BT_CONN_CONNECT_DIR_ADV:
-		BT_WARN("Deprecated: Use bt_le_adv_stop instead");
-		conn->err = reason;
-		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-			/* User should unref connection object when receiving
-			 * error in connection callback.
-			 */
-			return bt_le_adv_stop();
-		}
-		return 0;
 	case BT_CONN_CONNECT:
 #if defined(CONFIG_BT_BREDR)
 		if (conn->type == BT_CONN_TYPE_BR) {


### PR DESCRIPTION
Remove Bluetooth definitions and functions that have  been deprecated since the 2.3.0 release or older.