### PR TITLE
iis2dlpc: Add multi-instance support

### DIFF
--- a/drivers/sensor/iis2dlpc/iis2dlpc.h
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.h
@@ -11,11 +11,18 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_IIS2DLPC_IIS2DLPC_H_
 #define ZEPHYR_DRIVERS_SENSOR_IIS2DLPC_IIS2DLPC_H_
 
-#include <drivers/spi.h>
 #include <drivers/gpio.h>
 #include <sys/util.h>
 #include <drivers/sensor.h>
 #include "iis2dlpc_reg.h"
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#include <drivers/spi.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#include <drivers/i2c.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
 union axis3bit16_t {
 	int16_t i16bit[3];
@@ -46,22 +53,41 @@ union axis3bit16_t {
 #define IIS2DLPC_SHIFT_PM1		4
 #define IIS2DLPC_SHIFT_PMOTHER		2
 
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+struct iis2dlpc_spi_cfg {
+	struct spi_config spi_conf;
+	const char *cs_gpios_label;
+};
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+
+union iis2dlpc_bus_cfg {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+	uint16_t i2c_slv_addr;
+#endif
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	const struct iis2dlpc_spi_cfg *spi_cfg;
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+};
+
 /**
- * struct iis2dlpc_device_config - iis2dlpc hw configuration
+ * struct iis2dlpc_dev_config - iis2dlpc hw configuration
  * @bus_name: Pointer to bus master identifier.
  * @pm: Power mode (lis2dh_powermode).
- * @int_gpio_port: Pointer to GPIO PORT identifier.
- * @int_gpio_pin: GPIO pin number connecter to sensor int pin.
+ * @irq_dev_name: Pointer to GPIO PORT identifier.
+ * @irq_pin: GPIO pin number connecter to sensor int pin.
  * @drdy_int: Sensor drdy int (int1/int2).
  */
-struct iis2dlpc_device_config {
+struct iis2dlpc_dev_config {
 	const char *bus_name;
+	int (*bus_init)(const struct device *dev);
+	const union iis2dlpc_bus_cfg bus_cfg;
 	iis2dlpc_mode_t pm;
 	uint8_t range;
 #ifdef CONFIG_IIS2DLPC_TRIGGER
-	const char *int_gpio_port;
-	uint8_t int_gpio_pin;
-	uint8_t int_gpio_flags;
+	const char *irq_dev_name;
+	gpio_pin_t irq_pin;
+	gpio_flags_t irq_flags;
 	uint8_t drdy_int;
 #ifdef CONFIG_IIS2DLPC_TAP
 	uint8_t tap_mode;
@@ -75,6 +101,7 @@ struct iis2dlpc_device_config {
 
 /* sensor data */
 struct iis2dlpc_data {
+	const struct device *dev;
 	const struct device *bus;
 	int16_t acc[3];
 
@@ -82,8 +109,15 @@ struct iis2dlpc_data {
 	uint16_t gain;
 
 	stmdev_ctx_t *ctx;
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+	stmdev_ctx_t ctx_i2c;
+#endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	stmdev_ctx_t ctx_spi;
+#endif
+
 #ifdef CONFIG_IIS2DLPC_TRIGGER
-	const struct device *dev;
 	const struct device *gpio;
 	uint8_t gpio_pin;
 	struct gpio_callback gpio_cb;
@@ -100,9 +134,9 @@ struct iis2dlpc_data {
 	struct k_work work;
 #endif /* CONFIG_IIS2DLPC_TRIGGER_GLOBAL_THREAD */
 #endif /* CONFIG_IIS2DLPC_TRIGGER */
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	struct spi_cs_control cs_ctrl;
-#endif
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };
 
 int iis2dlpc_i2c_init(const struct device *dev);

--- a/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
@@ -10,7 +10,6 @@
 
 #define DT_DRV_COMPAT st_iis2dlpc
 
-
 #include <string.h>
 #include "iis2dlpc.h"
 #include <logging/log.h>
@@ -21,18 +20,12 @@
 
 LOG_MODULE_DECLARE(IIS2DLPC, CONFIG_SENSOR_LOG_LEVEL);
 
-static struct spi_config iis2dlpc_spi_conf = {
-	.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
-	.slave     = DT_INST_REG_ADDR(0),
-	.cs        = NULL,
-};
-
-static int iis2dlpc_spi_read(struct iis2dlpc_data *ctx, uint8_t reg,
-			    uint8_t *data, uint16_t len)
+static int iis2dlpc_spi_read(struct iis2dlpc_data *data, uint8_t reg,
+			    uint8_t *val, uint16_t len)
 {
-	struct spi_config *spi_cfg = &iis2dlpc_spi_conf;
+	const struct device *dev = data->dev;
+	const struct iis2dlpc_dev_config *cfg = dev->config;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[2] = { reg | IIS2DLPC_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -48,7 +41,7 @@ static int iis2dlpc_spi_read(struct iis2dlpc_data *ctx, uint8_t reg,
 			.len = 1,
 		},
 		{
-			.buf = data,
+			.buf = val,
 			.len = len,
 		}
 	};
@@ -57,17 +50,19 @@ static int iis2dlpc_spi_read(struct iis2dlpc_data *ctx, uint8_t reg,
 		.count = 2
 	};
 
-	if (spi_transceive(ctx->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive(data->bus, spi_cfg, &tx, &rx)) {
 		return -EIO;
 	}
 
 	return 0;
 }
 
-static int iis2dlpc_spi_write(struct iis2dlpc_data *ctx, uint8_t reg,
-			     uint8_t *data, uint16_t len)
+static int iis2dlpc_spi_write(struct iis2dlpc_data *data, uint8_t reg,
+			     uint8_t *val, uint16_t len)
 {
-	struct spi_config *spi_cfg = &iis2dlpc_spi_conf;
+	const struct device *dev = data->dev;
+	const struct iis2dlpc_dev_config *cfg = dev->config;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
 	uint8_t buffer_tx[1] = { reg & ~IIS2DLPC_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -75,7 +70,7 @@ static int iis2dlpc_spi_write(struct iis2dlpc_data *ctx, uint8_t reg,
 			.len = 1,
 		},
 		{
-			.buf = data,
+			.buf = val,
 			.len = len,
 		}
 	};
@@ -85,7 +80,7 @@ static int iis2dlpc_spi_write(struct iis2dlpc_data *ctx, uint8_t reg,
 	};
 
 
-	if (spi_write(ctx->bus, spi_cfg, &tx)) {
+	if (spi_write(data->bus, spi_cfg, &tx)) {
 		return -EIO;
 	}
 
@@ -100,29 +95,27 @@ stmdev_ctx_t iis2dlpc_spi_ctx = {
 int iis2dlpc_spi_init(const struct device *dev)
 {
 	struct iis2dlpc_data *data = dev->data;
+	const struct iis2dlpc_dev_config *cfg = dev->config;
+	const struct iis2dlpc_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
-	data->ctx = &iis2dlpc_spi_ctx;
+	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2dlpc_spi_read,
+	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2dlpc_spi_write,
+
+	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;
 
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	/* handle SPI CS thru GPIO if it is the case */
-	data->cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-	if (!data->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
+	if (spi_cfg->cs_gpios_label != NULL) {
+		/* handle SPI CS thru GPIO if it is the case */
+		data->cs_ctrl.gpio_dev =
+			    device_get_binding(spi_cfg->cs_gpios_label);
+		if (!data->cs_ctrl.gpio_dev) {
+			LOG_ERR("Unable to get GPIO SPI CS device");
+			return -ENODEV;
+		}
+
+		LOG_DBG("SPI GPIO CS configured on %s:%u",
+			spi_cfg->cs_gpios_label, data->cs_ctrl.gpio_pin);
 	}
-
-	data->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
-	data->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
-	data->cs_ctrl.delay = 0U;
-
-	iis2dlpc_spi_conf.cs = &data->cs_ctrl;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-		    DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
Make this driver multi-instance and use the new API.

TESTED on x_nucleo_iks02a1 shield using
 1. iis2dlpc attached to I2C
 2. iis2dlpc adapter on DIL24 attached to SPI.
