### PR TITLE
dts: arm: st: f0: fix timer 1 interrupt names

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -193,7 +193,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000800>;
 			interrupts = <13 0>, <14 0>;
-			interrupt-names = "brk", "cc";
+			interrupt-names = "brk_up_trg_com", "cc";
 			status = "disabled";
 			label = "TIMERS_1";
 


### PR DESCRIPTION
Timer 1 has two interrupts on STM32F0: TIM1_BRK_UP_TRG_COM_IRQn (13) and
TIM1_CC_IRQn (14). "brk" interrupt name does not reflect all the events
supported by the interrupt, so it has been renamed to "brk_up_trg_com". On all
other series except G0 timer 1 has a specific interrupt for each event, so in
such case "brk" is just fine.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>