### PR TITLE
drivers: gpio: Add PSoC-6 GPIO driver

### DIFF
--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
@@ -14,6 +14,8 @@
 	compatible = "cypress,cy8c6xx7_cm0p", "cypress,psoc6";
 
 	aliases {
+		sw0 = &user_bt;
+		led0 = &user_led;
 		uart-5 = &uart5;
 	};
 
@@ -23,6 +25,32 @@
 		zephyr,console = &uart5;
 		zephyr,shell-uart = &uart5;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		user_led: led_0 {
+			label = "LED_0";
+			gpios = <&gpio_prt13 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_bt: button_0 {
+			label = "SW_0";
+			gpios = <&gpio_prt0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+&gpio_prt0 {
+	status = "okay";
+	interrupt-parent = <&intmux_ch20>;
+};
+
+&gpio_prt13 {
+	status = "okay";
 };
 
 &uart5 {

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
@@ -15,3 +15,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
@@ -15,3 +15,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio

--- a/boards/arm/cy8ckit_062_ble/doc/index.rst
+++ b/boards/arm/cy8ckit_062_ble/doc/index.rst
@@ -99,6 +99,8 @@ The board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | SYSTICK   | on-chip    | system clock         |
 +-----------+------------+----------------------+
+| GPIO      | on-chip    | gpio                 |
++-----------+------------+----------------------+
 | UART      | on-chip    | serial port-polling  |
 +-----------+------------+----------------------+
 

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Cypress
+ * Copyright (c) 2020, ATL Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,8 @@
 	compatible = "cy8ckit_062_wifi_bt_m0", "PSoC6";
 
 	aliases {
+		sw0 = &user_bt;
+		led0 = &user_led;
 		uart-6 = &uart6;
 	};
 
@@ -22,6 +25,32 @@
 		zephyr,console = &uart6;
 		zephyr,shell-uart = &uart6;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		user_led: led_0 {
+			label = "LED_0";
+			gpios = <&gpio_prt13 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_bt: button_0 {
+			label = "SW_0";
+			gpios = <&gpio_prt0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+&gpio_prt0 {
+	status = "okay";
+	interrupt-parent = <&intmux_ch20>;
+};
+
+&gpio_prt13 {
+	status = "okay";
 };
 
 &uart6 {

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.yaml
@@ -14,3 +14,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.yaml
@@ -14,3 +14,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_LPC11U6X   gpio_lpc11u6x.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_XLNX_AXI   gpio_xlnx_axi.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_NPCX       gpio_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_EMUL       gpio_emul.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_PSOC6      gpio_psoc6.c)
 
 zephyr_library_sources_ifdef(CONFIG_GPIO_SHELL      gpio_shell.c)
 

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -83,4 +83,6 @@ source "drivers/gpio/Kconfig.npcx"
 
 source "drivers/gpio/Kconfig.emul"
 
+source "drivers/gpio/Kconfig.psoc6"
+
 endif # GPIO

--- a/drivers/gpio/Kconfig.psoc6
+++ b/drivers/gpio/Kconfig.psoc6
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+config GPIO_PSOC6
+	bool "Cypress PSoC-6 GPIO driver"
+	default y
+	depends on SOC_FAMILY_PSOC6
+	help
+	  Enable support for the Cypress PSoC-6 GPIO controllers.

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2018 Justin Watson
+ * Copyright (c) 2020 ATL Electronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT cypress_psoc6_gpio
+
+#include <errno.h>
+#include <kernel.h>
+#include <device.h>
+#include <init.h>
+#include <soc.h>
+#include <drivers/gpio.h>
+
+#include "gpio_utils.h"
+#include "cy_gpio.h"
+#include "cy_sysint.h"
+
+#define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(gpio_psoc6);
+
+typedef void (*config_func_t)(const struct device *dev);
+
+struct gpio_psoc6_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	GPIO_PRT_Type *regs;
+	config_func_t config_func;
+};
+
+struct gpio_psoc6_runtime {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	sys_slist_t cb;
+};
+
+#define DEV_CFG(dev) \
+	((const struct gpio_psoc6_config * const)(dev)->config)
+#define DEV_DATA(dev) \
+	((struct gpio_psoc6_runtime * const)(dev)->data)
+
+static int gpio_psoc6_config(const struct device *dev,
+			     gpio_pin_t pin,
+			     gpio_flags_t flags)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+	uint32_t drv_mode;
+	uint32_t pin_val;
+
+	if (flags & GPIO_OUTPUT) {
+		if (flags & GPIO_SINGLE_ENDED) {
+			drv_mode = (flags & GPIO_LINE_OPEN_DRAIN) ?
+				CY_GPIO_DM_OD_DRIVESLOW_IN_OFF :
+				CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+
+			pin_val = (flags & GPIO_LINE_OPEN_DRAIN) ? 1 : 0;
+		} else {
+			drv_mode = CY_GPIO_DM_STRONG_IN_OFF;
+
+			pin_val = (flags & GPIO_OUTPUT_INIT_HIGH) ? 1 : 0;
+		}
+	} else {
+		if ((flags & GPIO_PULL_UP) && (flags & GPIO_PULL_DOWN)) {
+			drv_mode = CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
+		} else if (flags & GPIO_PULL_UP) {
+			drv_mode = CY_GPIO_DM_PULLUP_IN_OFF;
+		} else if (flags & GPIO_PULL_DOWN) {
+			drv_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
+		} else {
+			drv_mode = CY_GPIO_DM_ANALOG;
+		}
+
+		pin_val = (flags & GPIO_PULL_UP) ? 1 : 0;
+	}
+
+	if (flags & GPIO_INPUT) {
+		/* enable input buffer */
+		drv_mode |= CY_GPIO_DM_HIGHZ;
+	}
+
+	Cy_GPIO_Pin_FastInit(port, pin, drv_mode, pin_val, HSIOM_SEL_GPIO);
+	Cy_GPIO_SetVtrip(port, pin, CY_GPIO_VTRIP_CMOS);
+	Cy_GPIO_SetSlewRate(port, pin, CY_GPIO_SLEW_FAST);
+	Cy_GPIO_SetDriveSel(port, pin, CY_GPIO_DRIVE_FULL);
+
+	LOG_DBG("P: 0x%08x, Pin: %d, Mode: 0x%08x, Val: 0x%02x",
+			(unsigned int) port, pin, drv_mode, pin_val);
+
+	return 0;
+}
+
+static int gpio_psoc6_port_get_raw(const struct device *dev,
+				   uint32_t *value)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	*value = GPIO_PRT_IN(port);
+
+	LOG_DBG("P: 0x%08x, V: 0x%08x", (unsigned int) port, *value);
+
+	return 0;
+}
+
+static int gpio_psoc6_port_set_masked_raw(const struct device *dev,
+					  uint32_t mask,
+					  uint32_t value)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	GPIO_PRT_OUT(port) = (GPIO_PRT_IN(port) & ~mask) | (mask & value);
+
+	return 0;
+}
+
+static int gpio_psoc6_port_set_bits_raw(const struct device *dev,
+					uint32_t mask)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	GPIO_PRT_OUT_SET(port) = mask;
+
+	return 0;
+}
+
+static int gpio_psoc6_port_clear_bits_raw(const struct device *dev,
+					  uint32_t mask)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	GPIO_PRT_OUT_CLR(port) = mask;
+
+	return 0;
+}
+
+static int gpio_psoc6_port_toggle_bits(const struct device *dev,
+				       uint32_t mask)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	GPIO_PRT_OUT_INV(port) = mask;
+
+	return 0;
+}
+
+static int gpio_psoc6_pin_interrupt_configure(const struct device *dev,
+					    gpio_pin_t pin,
+					    enum gpio_int_mode mode,
+					    enum gpio_int_trig trig)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+	uint32_t is_enabled = ((mode == GPIO_INT_MODE_DISABLED) ? 0 : 1);
+	uint32_t lv_trg = CY_GPIO_INTR_DISABLE;
+
+	if (mode == GPIO_INT_MODE_LEVEL) {
+		return -ENOTSUP;
+	}
+
+	if (is_enabled) {
+		switch (trig) {
+		case GPIO_INT_TRIG_BOTH:
+			lv_trg = CY_GPIO_INTR_BOTH;
+			break;
+		case GPIO_INT_TRIG_HIGH:
+			lv_trg = CY_GPIO_INTR_RISING;
+			break;
+		case GPIO_INT_TRIG_LOW:
+			lv_trg = CY_GPIO_INTR_FALLING;
+			break;
+		}
+	}
+
+	Cy_GPIO_ClearInterrupt(port, pin);
+	Cy_GPIO_SetInterruptEdge(port, pin, lv_trg);
+	Cy_GPIO_SetInterruptMask(port, pin, is_enabled);
+	/**
+	 * The driver will set 50ns glich free filter for any interrupt.
+	 */
+	Cy_GPIO_SetFilter(port, pin);
+
+	LOG_DBG("config: Pin: %d, Trg: %d", pin, lv_trg);
+
+	return 0;
+}
+
+static void gpio_psoc6_isr(const struct device *dev)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+	struct gpio_psoc6_runtime *context = dev->data;
+	uint32_t int_stat;
+
+	int_stat = GPIO_PRT_INTR_MASKED(port);
+
+	/* Any INTR MMIO registers AHB clearing must be preceded with an AHB
+	 * read access. Taken from Cy_GPIO_ClearInterrupt()
+	 */
+	(void)GPIO_PRT_INTR(port);
+	GPIO_PRT_INTR(port) = int_stat;
+	/* This read ensures that the initial write has been flushed out to HW
+	 */
+	(void)GPIO_PRT_INTR(port);
+
+	gpio_fire_callbacks(&context->cb, dev, int_stat);
+}
+
+static int gpio_psoc6_manage_callback(const struct device *port,
+				    struct gpio_callback *callback,
+				    bool set)
+{
+	struct gpio_psoc6_runtime *context = port->data;
+
+	return gpio_manage_callback(&context->cb, callback, set);
+}
+
+static uint32_t gpio_psoc6_get_pending_int(const struct device *dev)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+	GPIO_PRT_Type * const port = cfg->regs;
+
+	LOG_DBG("Pending: 0x%08x", GPIO_PRT_INTR_MASKED(port));
+
+	return GPIO_PRT_INTR_MASKED(port);
+}
+
+static const struct gpio_driver_api gpio_psoc6_api = {
+	.pin_configure = gpio_psoc6_config,
+	.port_get_raw = gpio_psoc6_port_get_raw,
+	.port_set_masked_raw = gpio_psoc6_port_set_masked_raw,
+	.port_set_bits_raw = gpio_psoc6_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_psoc6_port_clear_bits_raw,
+	.port_toggle_bits = gpio_psoc6_port_toggle_bits,
+	.pin_interrupt_configure = gpio_psoc6_pin_interrupt_configure,
+	.manage_callback = gpio_psoc6_manage_callback,
+	.get_pending_int = gpio_psoc6_get_pending_int,
+};
+
+int gpio_psoc6_init(const struct device *dev)
+{
+	const struct gpio_psoc6_config * const cfg = DEV_CFG(dev);
+
+	cfg->config_func(dev);
+
+	return 0;
+}
+
+#define GPIO_PSOC6_INIT(n)						\
+	static void port_##n##_psoc6_config_func(const struct device *dev); \
+									\
+	static const struct gpio_psoc6_config port_##n##_psoc6_config = { \
+		.common = {						\
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),\
+		},							\
+		.regs = (GPIO_PRT_Type *)DT_INST_REG_ADDR(n),		\
+		.config_func = port_##n##_psoc6_config_func,		\
+	};								\
+									\
+	static struct gpio_psoc6_runtime port_##n##_psoc6_runtime = { 0 }; \
+									\
+	DEVICE_DT_INST_DEFINE(n, gpio_psoc6_init, device_pm_control_nop, \
+			    &port_##n##_psoc6_runtime,			\
+			    &port_##n##_psoc6_config, POST_KERNEL,	\
+			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    &gpio_psoc6_api);				\
+									\
+	static void port_##n##_psoc6_config_func(const struct device *dev) \
+	{								\
+		CY_PSOC6_DT_INST_NVIC_INSTALL(n, gpio_psoc6_isr);	\
+	};
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_PSOC6_INIT)

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {
@@ -63,6 +64,165 @@
 	};
 
 	soc {
+		hsiom: hsiom@40310000 {
+			compatible = "cypress,psoc6-hsiom";
+			reg = <0x40310000 0x2024>;
+			interrupts = <15 1>, <16 1>;
+			label = "HSIOM";
+			status = "disabled";
+		};
+
+		gpio_prt0: gpio@40320000 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320000 0x80>;
+			interrupts = <0 1>;
+			label = "P0";
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt1: gpio@40320080 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320080 0x80>;
+			interrupts = <1 1>;
+			label = "P1";
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt2: gpio@40320100 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320100 0x80>;
+			interrupts = <2 1>;
+			label = "P2";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt3: gpio@40320180 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320180 0x80>;
+			interrupts = <3 1>;
+			label = "P3";
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt4: gpio@40320200 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320200 0x80>;
+			interrupts = <4 1>;
+			label = "P4";
+			gpio-controller;
+			ngpios = <4>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt5: gpio@40320280 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320280 0x80>;
+			interrupts = <5 1>;
+			label = "P5";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt6: gpio@40320300 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320300 0x80>;
+			interrupts = <6 1>;
+			label = "P6";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt7: gpio@40320380 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320380 0x80>;
+			interrupts = <7 1>;
+			label = "P7";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt8: gpio@40320400 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320400 0x80>;
+			interrupts = <8 1>;
+			label = "P8";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt9: gpio@40320480 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320480 0x80>;
+			interrupts = <9 1>;
+			label = "P9";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt10: gpio@40320500 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320500 0x80>;
+			interrupts = <10 1>;
+			label = "P10";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt11: gpio@40320580 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320580 0x80>;
+			interrupts = <11 1>;
+			label = "P11";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt12: gpio@40320600 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320600 0x80>;
+			interrupts = <12 1>;
+			label = "P12";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt13: gpio@40320680 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320680 0x80>;
+			interrupts = <13 1>;
+			label = "P13";
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt14: gpio@40320700 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320700 0x80>;
+			interrupts = <14 1>;
+			label = "P14";
+			gpio-controller;
+			ngpios = <2>;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
 		uart5: uart@40660000 {
 			compatible = "cypress,psoc6-uart";
 			reg = <0x40660000 0x10000>;

--- a/dts/bindings/gpio/cypress,psoc6-gpio.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-gpio.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: Cypress GPIO PORT node
+
+compatible: "cypress,psoc6-gpio"
+
+include: ["gpio-controller.yaml", "base.yaml"]
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    label:
+      required: true
+
+    "#gpio-cells":
+      const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/gpio/cypress,psoc6-hsiom.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-hsiom.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: Cypress High Speed I/O Matrix
+
+compatible: "cypress,psoc6-hsiom"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    label:
+      required: true


### PR DESCRIPTION
Add GPIO driver with external interrupt capabilities. This allows m0 to enable ext-int on port-x, m4 to enable ext-int on port-x and/or both m0/4 enabling at same time ext-int on port-x. The use is application defined, for instance, allows sync external events.

The cy8ckit_062_ble board receives m0 binds for LED and switch. This allows evaluate GPIO and Ext-Int using <samples/basic/button>

This replaces #29489 as _Originally posted by @galak in https://github.com/zephyrproject-rtos/zephyr/issues/29489#issuecomment-764034789_