### PR TITLE
logging: Cleanup log_minimal

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -241,7 +241,6 @@ extern "C" {
 #define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length, _str)	\
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
 
-#ifndef CONFIG_LOG_MINIMAL
 /**
  * @brief Writes an formatted string to the log.
  *
@@ -255,6 +254,7 @@ extern "C" {
  */
 void log_printk(const char *fmt, va_list ap);
 
+#ifndef CONFIG_LOG_MINIMAL
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *
  * Function should be used when transient string is intended to be logged.
@@ -274,10 +274,6 @@ void log_printk(const char *fmt, va_list ap);
  */
 char *log_strdup(const char *str);
 #else
-static inline void log_printk(const char *fmt, va_list ap)
-{
-	vprintk(fmt, ap);
-}
 
 static inline char *log_strdup(const char *str)
 {

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -182,24 +182,11 @@ static void detect_missed_strdup(struct log_msg *msg)
 #undef ERR_MSG
 }
 
-static inline void msg_finalize(struct log_msg *msg,
-				struct log_msg_ids src_level)
+static void z_log_msg_post_finalize(void)
 {
-	unsigned int key;
-
-	msg->hdr.ids = src_level;
-	msg->hdr.timestamp = timestamp_func();
-
 	atomic_inc(&buffered_cnt);
-
-	key = irq_lock();
-
-	log_list_add_tail(&list, msg);
-
-	irq_unlock(key);
-
 	if (panic_mode) {
-		key = irq_lock();
+		unsigned int key = irq_lock();
 		(void)log_process(false);
 		irq_unlock(key);
 	} else if (proc_tid != NULL && buffered_cnt == 1) {
@@ -213,6 +200,23 @@ static inline void msg_finalize(struct log_msg *msg,
 		}
 	} else {
 	}
+}
+
+static inline void msg_finalize(struct log_msg *msg,
+				struct log_msg_ids src_level)
+{
+	unsigned int key;
+
+	msg->hdr.ids = src_level;
+	msg->hdr.timestamp = timestamp_func();
+
+	key = irq_lock();
+
+	log_list_add_tail(&list, msg);
+
+	irq_unlock(key);
+
+	z_log_msg_post_finalize();
 }
 
 void log_0(const char *str, struct log_msg_ids src_level)

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -7,8 +7,23 @@
 #include <sys/printk.h>
 #include <ctype.h>
 #include <logging/log.h>
+#include <sys/printk.h>
 
 #define HEXDUMP_BYTES_IN_LINE 8
+
+void z_log_minimal_printk(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vprintk(fmt, ap);
+	va_end(ap);
+}
+
+void z_log_minimal_vprintk(const char *fmt, va_list ap)
+{
+	vprintk(fmt, ap);
+}
 
 static void minimal_hexdump_line_print(const char *data, size_t length)
 {
@@ -34,7 +49,7 @@ static void minimal_hexdump_line_print(const char *data, size_t length)
 	printk("\n");
 }
 
-void log_minimal_hexdump_print(int level, const void *_data, size_t size)
+void z_log_minimal_hexdump_print(int level, const void *_data, size_t size)
 {
 	const char *data = (const char *)_data;
 	while (size > 0) {


### PR DESCRIPTION
Cleanup log minimal in `log_core.h` to remove dependency on `printk.h`.

Additionally, extracted post message finalize actions to separate function. This is in preparation for v2 where it will be reused.