### PR TITLE
api: remove unnecessary parentheses in DEVICE_NAME_GET.

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -43,7 +43,7 @@ extern "C" {
  *
  * @return The expanded name of the device object created by DEVICE_DEFINE()
  */
-#define DEVICE_NAME_GET(name) (_CONCAT(__device_, name))
+#define DEVICE_NAME_GET(name) _CONCAT(__device_, name)
 
 /**
  * @def SYS_DEVICE_DEFINE


### PR DESCRIPTION
Get rid of compilation warnings (SDK 0.12.1) caused by additional parentheses:
```
zephyr/include/device.h:46:31: warning: unnecessary parentheses in declaration of '__device_DT_N' [-Wparentheses]
   46 | #define DEVICE_NAME_GET(name) (_CONCAT(__device_, name))
      |                               ^
```