### PR TITLE
Bluetooth: controller: Fix deferred Conn Update offset population

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -904,6 +904,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_conn_param.req = 0;
 		conn->llcp_conn_param.ack = 0;
 		conn->llcp_conn_param.disabled = 0;
+		conn->slave.ticks_to_offset = 0;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2510,7 +2510,10 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 				(conn_interval_us >> 1) - EVENT_IFS_US;
 			lll->slave.window_size_prepare_us =
 				conn->llcp_cu.win_size * CONN_INT_UNIT_US;
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 			conn->slave.ticks_to_offset = 0U;
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 			lll->slave.window_widening_prepare_us +=
 				lll->slave.window_widening_periodic_us *
@@ -4325,6 +4328,7 @@ static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	return 0;
 }
 
+#if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
 static void feature_rsp_recv(struct ll_conn *conn, struct pdu_data *pdu_rx)
 {
 	struct pdu_data_llctrl_feature_rsp *rsp;
@@ -4348,6 +4352,7 @@ static void feature_rsp_recv(struct ll_conn *conn, struct pdu_data *pdu_rx)
 	conn->llcp_feature.ack = conn->llcp_feature.req;
 	conn->procedure_expire = 0U;
 }
+#endif /* CONFIG_BT_CENTRAL || CONFIG_BT_CTLR_SLAVE_FEAT_REQ */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static int pause_enc_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2320,8 +2320,14 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 			return -EINPROGRESS;
 
 		case LLCP_CUI_STATE_REJECT:
-			/* move to in progress */
-			conn->llcp_cu.state = LLCP_CUI_STATE_INPROG;
+			/* procedure request acked */
+			conn->llcp_ack = conn->llcp_req;
+			conn->llcp_cu.ack = conn->llcp_cu.req;
+			conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+
+			/* reset mutex */
+			ull_conn_upd_curr_reset();
+
 			/* enqueue control PDU */
 			pdu_ctrl_tx =
 				CONTAINER_OF(conn->llcp.conn_upd.pdu_win_offset,
@@ -2329,7 +2335,8 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 					     llctrl.conn_update_ind.win_offset);
 			tx = CONTAINER_OF(pdu_ctrl_tx, struct node_tx, pdu);
 			ctrl_tx_enqueue(conn, tx);
-			return -EINPROGRESS;
+			return -ECANCELED;
+
 		default:
 			LL_ASSERT(0);
 			break;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -146,8 +146,11 @@ struct ll_conn {
 		enum {
 			LLCP_CUI_STATE_INPROG,
 			LLCP_CUI_STATE_USE,
-			LLCP_CUI_STATE_SELECT
-		} state:2 __packed;
+			LLCP_CUI_STATE_SELECT,
+			LLCP_CUI_STATE_OFFS_REQ,
+			LLCP_CUI_STATE_OFFS_RDY,
+			LLCP_CUI_STATE_REJECT,
+		} state:3 __packed;
 		uint8_t  cmd:1;
 		uint16_t interval;
 		uint16_t latency;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -218,7 +218,9 @@ struct ll_conn {
 			LLCP_CPR_STATE_APP_REQ,
 			LLCP_CPR_STATE_APP_WAIT,
 			LLCP_CPR_STATE_RSP_WAIT,
-			LLCP_CPR_STATE_UPD
+			LLCP_CPR_STATE_UPD,
+			LLCP_CPR_STATE_OFFS_REQ,
+			LLCP_CPR_STATE_OFFS_RDY,
 		} state:3 __packed;
 		uint8_t  cmd:1;
 		uint8_t  disabled:1;

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -277,15 +277,6 @@ void ull_sched_mfy_win_offset_select(void *param)
 	} else {
 		struct pdu_data *pdu_ctrl_tx;
 
-		/* procedure request acked */
-		conn->llcp_ack = conn->llcp_req;
-
-		/* CPR request acked */
-		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
-
-		/* reset mutex */
-		ull_conn_upd_curr_reset();
-
 		/* send reject_ind_ext */
 		pdu_ctrl_tx = CONTAINER_OF(conn->llcp.conn_upd.pdu_win_offset,
 					   struct pdu_data,

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -470,10 +470,10 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 							ticks_to_expire_prev) >=
 					(ticks_slot_abs_prev + ticks_slot_abs +
 					 ticks_slot_margin))) {
-					offset = HAL_TICKER_TICKS_TO_US(
-						ticks_to_expire_prev +
-						ticks_slot_abs_prev) /
-						CONN_INT_UNIT_US;
+					offset = (ticks_to_expire_prev +
+						  ticks_slot_abs_prev) /
+						 HAL_TICKER_US_TO_TICKS(
+							CONN_INT_UNIT_US);
 					if (offset >= conn_interval) {
 						ticks_to_expire_prev = 0U;
 
@@ -511,9 +511,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 		}
 
 		while (offset_index < *offset_max) {
-			offset = HAL_TICKER_TICKS_TO_US(ticks_to_expire_prev +
-							ticks_slot_abs_prev) /
-				 CONN_INT_UNIT_US;
+			offset = (ticks_to_expire_prev + ticks_slot_abs_prev) /
+				 HAL_TICKER_US_TO_TICKS(CONN_INT_UNIT_US);
 			if (offset >= conn_interval) {
 				ticks_to_expire_prev = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -210,6 +210,9 @@ void ull_sched_mfy_free_win_offset_calc(void *param)
 	win_offset_calc(conn, 0, ticks_to_offset_next,
 			conn->llcp_conn_param.interval_max, &offset_max,
 			(void *)conn->llcp_conn_param.pdu_win_offset0);
+
+	/* move to offset calculated state */
+	conn->llcp_conn_param.state = LLCP_CPR_STATE_OFFS_RDY;
 }
 
 void ull_sched_mfy_win_offset_select(void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -262,15 +262,14 @@ void ull_sched_mfy_win_offset_select(void *param)
 	}
 
 	if (offset_index_s < OFFSET_S_MAX) {
-		conn->llcp_cu.win_offset_us = win_offset_s *
-			CONN_INT_UNIT_US;
+		conn->llcp_cu.win_offset_us = win_offset_s * CONN_INT_UNIT_US;
 		sys_put_le16(win_offset_s,
 			     (void *)conn->llcp.conn_upd.pdu_win_offset);
 		/* move to offset calculated state */
 		conn->llcp_cu.state = LLCP_CUI_STATE_OFFS_RDY;
 	} else if (!has_offset_s) {
 		conn->llcp_cu.win_offset_us = win_offset_m[0] *
-			CONN_INT_UNIT_US;
+					      CONN_INT_UNIT_US;
 		sys_put_le16(win_offset_m[0],
 			     (void *)conn->llcp.conn_upd.pdu_win_offset);
 		/* move to offset calculated state */
@@ -448,8 +447,7 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 #endif
 
 			ticks_slot_abs_curr += conn->evt.ticks_slot +
-					HAL_TICKER_US_TO_TICKS(
-						CONN_INT_UNIT_US);
+				HAL_TICKER_US_TO_TICKS(CONN_INT_UNIT_US);
 
 			if (conn->lll.role) {
 				ticks_slot_margin =
@@ -524,7 +522,7 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 			offset_index++;
 
 			ticks_to_expire_prev += HAL_TICKER_US_TO_TICKS(
-				CONN_INT_UNIT_US);
+							CONN_INT_UNIT_US);
 		}
 
 		*ticks_to_offset_next = ticks_to_expire_prev;
@@ -558,8 +556,7 @@ static void after_mstr_offset_get(uint16_t conn_interval, uint32_t ticks_slot,
 	}
 
 	if ((*win_offset_us & BIT(31)) == 0) {
-		uint32_t conn_interval_us = conn_interval *
-			CONN_INT_UNIT_US;
+		uint32_t conn_interval_us = conn_interval * CONN_INT_UNIT_US;
 
 		while (*win_offset_us > conn_interval_us) {
 			*win_offset_us -= conn_interval_us;

--- a/west.yml
+++ b/west.yml
@@ -140,7 +140,7 @@ manifest:
       path: modules/hal/xtensa
     - name: edtt
       path: tools/edtt
-      revision: b209a60ba3ad8887a7f35f67c0372c84a28b9b9b
+      revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
       revision: 96340fb6c0b7e31c2070e1f428ca24076d2700a6


### PR DESCRIPTION
Fix deferred Connection Update offset population by
introduction of explicit states waiting for the offset
calculation to complete in the ULL_LOW context.

Fixes #29636.

The problem was, in an encrypted connection the enqueued PDU
to be transmitted is encrypt in the prepare callback by the
hardware and swapped to a different buffer for transmission;
the deferred offset population did not reflect in the
transmitted PDU as it was filled in the cleartext buffer
while encryption completed into the encrypted buffer.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

~Draft PR, pending work:~
- ~Convert the Connection Parameter Request procedure too to wait on states for the 6 offsets to be populated.~
- ~Use CONTAINER_OF in ull_sched.c file instead of offsetof calculation being used.~

Also, Fixes #31704