### PR TITLE
drivers: ieee802154_nrf5: Allocate net_pkt from correct pool

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -133,8 +133,8 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 
 		LOG_DBG("Frame received");
 
-		pkt = net_pkt_alloc_with_buffer(nrf5_radio->iface, pkt_len,
-						AF_UNSPEC, 0, K_NO_WAIT);
+		pkt = net_pkt_rx_alloc_with_buffer(nrf5_radio->iface, pkt_len,
+						   AF_UNSPEC, 0, K_NO_WAIT);
 		if (!pkt) {
 			LOG_ERR("No pkt available");
 			goto drop;


### PR DESCRIPTION
The driver allocated packet from the TX pool on its RX path. Fix this
by using a correct allocator function.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>