### PR TITLE
Bluetooth: host: Prevent calls to bt_rand before bt_enable

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -76,6 +76,12 @@ Deprecated in this release
 * DEVICE_AND_API_INIT was deprecated in favor of DEVICE_DT_INST_DEFINE and
   DEVICE_DEFINE.
 
+* Bluetooth
+
+  * Deprecated the :c:func:`bt_set_id_addr` function, use :c:func:`bt_id_create`
+    before calling :c:func:`bt_enable` instead. When ``CONFIG_PRIVACY`` is
+    enabled a valid IRK has to be supplied by the application for this case.
+
 Removed APIs in this release
 ============================
 

--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -41,14 +41,14 @@ typedef struct {
 	bt_addr_t a;
 } bt_addr_le_t;
 
-/* Bluetooth device "any" address, not a valid address */
+/** Bluetooth device "any" address, not a valid address */
 #define BT_ADDR_ANY     ((bt_addr_t[]) { { { 0, 0, 0, 0, 0, 0 } } })
-/* Bluetooth device "none" address, not a valid address */
+/** Bluetooth device "none" address, not a valid address */
 #define BT_ADDR_NONE    ((bt_addr_t[]) { { \
 			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
-/* Bluetooth LE device "any" address, not a valid address */
+/** Bluetooth LE device "any" address, not a valid address */
 #define BT_ADDR_LE_ANY  ((bt_addr_le_t[]) { { 0, { { 0, 0, 0, 0, 0, 0 } } } })
-/* Bluetooth LE device "none" address, not a valid address */
+/** Bluetooth LE device "none" address, not a valid address */
 #define BT_ADDR_LE_NONE ((bt_addr_le_t[]) { { 0, \
 			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } } })
 
@@ -151,38 +151,35 @@ static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
 	return BT_ADDR_IS_STATIC(&addr->a);
 }
 
-/**
- * @def BT_ADDR_STR_LEN
+/** @def BT_ADDR_STR_LEN
  *
- * @brief Recommended length of user string buffer for Bluetooth address
+ *  @brief Recommended length of user string buffer for Bluetooth address
  *
- * @details The recommended length guarantee the output of address
- * conversion will not lose valuable information about address being
- * processed.
+ *  @details The recommended length guarantee the output of address
+ *  conversion will not lose valuable information about address being
+ *  processed.
  */
 #define BT_ADDR_STR_LEN 18
 
-/**
- * @def BT_ADDR_LE_STR_LEN
+/** @def BT_ADDR_LE_STR_LEN
  *
- * @brief Recommended length of user string buffer for Bluetooth LE address
+ *  @brief Recommended length of user string buffer for Bluetooth LE address
  *
- * @details The recommended length guarantee the output of address
- * conversion will not lose valuable information about address being
- * processed.
+ *  @details The recommended length guarantee the output of address
+ *  conversion will not lose valuable information about address being
+ *  processed.
  */
 #define BT_ADDR_LE_STR_LEN 30
 
-/**
- * @brief Converts binary Bluetooth address to string.
+/** @brief Converts binary Bluetooth address to string.
  *
- * @param addr Address of buffer containing binary Bluetooth address.
- * @param str Address of user buffer with enough room to store formatted
- * string containing binary address.
- * @param len Length of data to be copied to user string buffer. Refer to
- * BT_ADDR_STR_LEN about recommended value.
+ *  @param addr Address of buffer containing binary Bluetooth address.
+ *  @param str Address of user buffer with enough room to store formatted
+ *  string containing binary address.
+ *  @param len Length of data to be copied to user string buffer. Refer to
+ *  BT_ADDR_STR_LEN about recommended value.
  *
- * @return Number of successfully formatted bytes from binary address.
+ *  @return Number of successfully formatted bytes from binary address.
  */
 static inline int bt_addr_to_str(const bt_addr_t *addr, char *str, size_t len)
 {
@@ -191,16 +188,15 @@ static inline int bt_addr_to_str(const bt_addr_t *addr, char *str, size_t len)
 			addr->val[2], addr->val[1], addr->val[0]);
 }
 
-/**
- * @brief Converts binary LE Bluetooth address to string.
+/** @brief Converts binary LE Bluetooth address to string.
  *
- * @param addr Address of buffer containing binary LE Bluetooth address.
- * @param str Address of user buffer with enough room to store
- * formatted string containing binary LE address.
- * @param len Length of data to be copied to user string buffer. Refer to
- * BT_ADDR_LE_STR_LEN about recommended value.
+ *  @param addr Address of buffer containing binary LE Bluetooth address.
+ *  @param str Address of user buffer with enough room to store
+ *  formatted string containing binary LE address.
+ *  @param len Length of data to be copied to user string buffer. Refer to
+ *  BT_ADDR_LE_STR_LEN about recommended value.
  *
- * @return Number of successfully formatted bytes from binary address.
+ *  @return Number of successfully formatted bytes from binary address.
  */
 static inline int bt_addr_le_to_str(const bt_addr_le_t *addr, char *str,
 				    size_t len)
@@ -230,25 +226,23 @@ static inline int bt_addr_le_to_str(const bt_addr_le_t *addr, char *str,
 			addr->a.val[2], addr->a.val[1], addr->a.val[0], type);
 }
 
-/**
- * @brief Convert Bluetooth address from string to binary.
+/** @brief Convert Bluetooth address from string to binary.
  *
- * @param[in]  str   The string representation of a Bluetooth address.
- * @param[out] addr  Address of buffer to store the Bluetooth address
+ *  @param[in]  str   The string representation of a Bluetooth address.
+ *  @param[out] addr  Address of buffer to store the Bluetooth address
  *
- * @return Zero on success or (negative) error code otherwise.
+ *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_addr_from_str(const char *str, bt_addr_t *addr);
 
-/**
- * @brief Convert LE Bluetooth address from string to binary.
+/** @brief Convert LE Bluetooth address from string to binary.
  *
- * @param[in]  str   The string representation of an LE Bluetooth address.
- * @param[in]  type  The string representation of the LE Bluetooth address
+ *  @param[in]  str   The string representation of an LE Bluetooth address.
+ *  @param[in]  type  The string representation of the LE Bluetooth address
  *                   type.
- * @param[out] addr  Address of buffer to store the LE Bluetooth address
+ *  @param[out] addr  Address of buffer to store the LE Bluetooth address
  *
- * @return Zero on success or (negative) error code otherwise.
+ *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_addr_le_from_str(const char *str, const char *type, bt_addr_le_t *addr);
 

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -163,9 +163,11 @@ const char *bt_get_name(void);
  * At the moment, the given address must be a static random address. In the
  * future support for public addresses may be added.
  *
+ * @deprecated in 2.5 release, replace with bt_id_create before bt_enable.
+ *
  * @return Zero on success or (negative) error code otherwise.
  */
-int bt_set_id_addr(const bt_addr_le_t *addr);
+__deprecated int bt_set_id_addr(const bt_addr_le_t *addr);
 
 /**
  * @brief Get the currently configured identities.

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -202,6 +202,9 @@ void bt_id_get(bt_addr_le_t *addrs, size_t *count);
  * the address from and will be able to repeat the procedure on every power
  * cycle, i.e. it would be redundant to also store the information in flash.
  *
+ * Generating random static address or random IRK is not supported when calling
+ * this function before bt_enable().
+ *
  * If the application wants to have the stack randomly generate identities
  * and store them in flash for later recovery, the way to do it would be
  * to first initialize the stack (using bt_enable), then call settings_load(),
@@ -210,8 +213,8 @@ void bt_id_get(bt_addr_le_t *addrs, size_t *count);
  * call bt_id_create() to create new ones.
  *
  * @param addr Address to use for the new identity. If NULL or initialized
- *             to BT_ADDR_LE_ANY the stack will generate a new static
- *             random address for the identity and copy it to the given
+ *             to BT_ADDR_LE_ANY the stack will generate a new random
+ *             static address for the identity and copy it to the given
  *             parameter upon return from this function (in case the
  *             parameter was non-NULL).
  * @param irk  Identity Resolving Key (16 bytes) to be used with this

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6845,6 +6845,20 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 		return -ENOMEM;
 	}
 
+	/* bt_rand is not available before Bluetooth enable has been called */
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		uint8_t zero_irk[16] = { 0 };
+
+		if (!(addr && bt_addr_le_cmp(addr, BT_ADDR_LE_ANY))) {
+			return -EINVAL;
+		}
+
+		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		    !(irk && memcmp(irk, zero_irk, 16))) {
+			return -EINVAL;
+		}
+	}
+
 	new_id = bt_dev.id_count++;
 	id_create(new_id, addr, irk);
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -672,6 +672,7 @@ static int cmd_id_create(const struct shell *shell, size_t argc, char *argv[])
 	err = bt_id_create(&addr, NULL);
 	if (err < 0) {
 		shell_error(shell, "Creating new ID failed (err %d)", err);
+		return err;
 	}
 
 	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -39,6 +39,8 @@
 #define DEVICE_NAME		CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN		(sizeof(DEVICE_NAME) - 1)
 
+static bool no_settings_load;
+
 uint8_t selected_id = BT_ID_DEFAULT;
 const struct shell *ctx_shell;
 
@@ -511,8 +513,9 @@ static void bt_ready(int err)
 
 	shell_print(ctx_shell, "Bluetooth initialized");
 
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_SETTINGS) && !no_settings_load) {
 		settings_load();
+		shell_print(ctx_shell, "Settings Loaded");
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -537,16 +540,54 @@ static void bt_ready(int err)
 static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
+	bool no_ready_cb = false;
 
 	ctx_shell = shell;
 
-	err = bt_enable(bt_ready);
-	if (err) {
-		shell_error(shell, "Bluetooth init failed (err %d)", err);
+	for (size_t argn = 1; argn < argc; argn++) {
+		const char *arg = argv[argn];
+
+		if (!strcmp(arg, "no-settings-load")) {
+			no_settings_load = true;
+		} else if (!strcmp(arg, "sync")) {
+			no_ready_cb = true;
+		} else {
+			shell_help(shell);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	if (no_ready_cb) {
+		err = bt_enable(bt_ready);
+		if (err) {
+			shell_error(shell, "Bluetooth init failed (err %d)",
+				    err);
+		}
+
+	} else {
+		err = bt_enable(NULL);
+		bt_ready(err);
 	}
 
 	return err;
 }
+
+#ifdef CONFIG_SETTINGS
+static int cmd_settings_load(const struct shell *shell, size_t argc,
+			     char *argv[])
+{
+	int err;
+
+	err = settings_load();
+	if (err) {
+		shell_error(shell, "Settings load failed (err %d)", err);
+		return err;
+	}
+
+	shell_print(shell, "Settings loaded");
+	return 0;
+}
+#endif
 
 #if defined(CONFIG_BT_HCI)
 static int cmd_hci_cmd(const struct shell *shell, size_t argc, char *argv[])
@@ -2880,7 +2921,11 @@ static int cmd_auth_oob_tk(const struct shell *shell, size_t argc, char *argv[])
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
-	SHELL_CMD_ARG(init, NULL, HELP_NONE, cmd_init, 1, 0),
+	SHELL_CMD_ARG(init, NULL, "[no-settings-load], [sync]",
+		      cmd_init, 1, 2),
+#if defined(CONFIG_SETTINGS)
+	SHELL_CMD_ARG(settings-load, NULL, HELP_NONE, cmd_settings_load, 1, 0),
+#endif
 #if defined(CONFIG_BT_HCI)
 	SHELL_CMD_ARG(hci-cmd, NULL, "<ogf> <ocf> [data]", cmd_hci_cmd, 3, 1),
 #endif


### PR DESCRIPTION
Prevent the bt_rand function from being called before bt_enable.
Depending on the implementation of bt_rand this function cannot
be called before bluetooth has been initialized. With host supplied
crypto functions the HCI LE rand command is used for example.

The use case for calling bt_id_create before bt_enable is meant for
when the application has storage for the identity instead of the stack.
So we add the requirement that the application has to have storage
for the identity resolving key (IRK) in addition when the local
device is privacy-enabled.

Deprecate the bt_set_id_addr API function. This is merely a wrapper
for the bt_id_create function now, except an IRK cannot be given.
When CONFIG_BT_PRIVACY is enabled an IRK has to be given by the
application because the bt_rand function cannot be called before
bt_enable.