### PR TITLE
edac: Various EDAC / IBECC fixes

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT intel_ibecc
+
 #include <zephyr.h>
 #include <device.h>
 #include <drivers/pcie/pcie.h>
@@ -17,6 +19,12 @@
  */
 #include <logging/log.h>
 LOG_MODULE_REGISTER(edac_ibecc, CONFIG_EDAC_LOG_LEVEL);
+
+#define DEVICE_NODE DT_NODELABEL(ibecc)
+/* Workaround for getting bus/device/function from DTS */
+#define PCI_ENDPOINT DT_REG_ADDR(DEVICE_NODE)
+/* Workaround for getting PCI Vendor ID from DTS */
+#define PCI_VENDOR_ID DT_REG_SIZE(DEVICE_NODE)
 
 struct ibecc_data {
 	mem_addr_t mchbar;
@@ -339,18 +347,16 @@ static const struct edac_driver_api api = {
 
 int edac_ibecc_init(const struct device *dev)
 {
-	const pcie_bdf_t bdf = PCIE_BDF(0, 0, 0);
+	const pcie_bdf_t bdf = PCI_ENDPOINT;
 	struct ibecc_data *data = dev->data;
 	uint32_t tolud;
 	uint64_t touud, tom, mchbar;
 
 	LOG_INF("EDAC IBECC initialization");
 
-	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU7)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU12))) {
-		LOG_ERR("Probe failed");
+	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID, PCI_DEVICE_ID_SKU7)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID, PCI_DEVICE_ID_SKU12))) {
+		LOG_ERR("PCI Probe failed");
 		return -ENODEV;
 	}
 
@@ -399,9 +405,9 @@ int edac_ibecc_init(const struct device *dev)
 
 static struct ibecc_data ibecc_data;
 
-DEVICE_DEFINE(edac_ibecc, EDAC_IBECC_NAME, &edac_ibecc_init,
-	      NULL, &ibecc_data, NULL, POST_KERNEL,
-	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api);
+DEVICE_DT_DEFINE(DEVICE_NODE, &edac_ibecc_init,
+		 NULL, &ibecc_data, NULL, POST_KERNEL,
+		 CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api);
 
 /**
  * An IBECC error causes SERR_NMI_STS set and is indicated by
@@ -447,7 +453,7 @@ static bool handle_nmi(void)
 
 bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 {
-	const struct device *dev = DEVICE_GET(edac_ibecc);
+	const struct device *dev = DEVICE_DT_GET(DEVICE_NODE);
 	struct ibecc_data *data = dev->data;
 	struct ibecc_error error_data;
 	k_spinlock_key_t key;

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(edac_ibecc, CONFIG_EDAC_LOG_LEVEL);
 
 #define DEVICE_NODE DT_NODELABEL(ibecc)
-#define PCI_ENDPOINT PCIE_BDF(0, 0, 0)
+#define PCI_HOST_BRIDGE PCIE_BDF(0, 0, 0)
 
 struct ibecc_data {
 	mem_addr_t mchbar;
@@ -344,7 +344,7 @@ static const struct edac_driver_api api = {
 
 int edac_ibecc_init(const struct device *dev)
 {
-	const pcie_bdf_t bdf = PCI_ENDPOINT;
+	const pcie_bdf_t bdf = PCI_HOST_BRIDGE;
 	struct ibecc_data *data = dev->data;
 	uint32_t tolud;
 	uint64_t touud, tom, mchbar;
@@ -482,7 +482,7 @@ bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 
 	edac_ecc_error_log_clear(dev);
 
-	ibecc_errsts_clear(PCI_ENDPOINT);
+	ibecc_errsts_clear(PCI_HOST_BRIDGE);
 
 out:
 	k_spin_unlock(&nmi_lock, key);

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -21,10 +21,7 @@
 LOG_MODULE_REGISTER(edac_ibecc, CONFIG_EDAC_LOG_LEVEL);
 
 #define DEVICE_NODE DT_NODELABEL(ibecc)
-/* Workaround for getting bus/device/function from DTS */
-#define PCI_ENDPOINT DT_REG_ADDR(DEVICE_NODE)
-/* Workaround for getting PCI Vendor ID from DTS */
-#define PCI_VENDOR_ID DT_REG_SIZE(DEVICE_NODE)
+#define PCI_ENDPOINT PCIE_BDF(0, 0, 0)
 
 struct ibecc_data {
 	mem_addr_t mchbar;
@@ -354,8 +351,10 @@ int edac_ibecc_init(const struct device *dev)
 
 	LOG_INF("EDAC IBECC initialization");
 
-	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID, PCI_DEVICE_ID_SKU7)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID, PCI_DEVICE_ID_SKU12))) {
+	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU7)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU12))) {
 		LOG_ERR("PCI Probe failed");
 		return -ENODEV;
 	}
@@ -483,7 +482,7 @@ bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 
 	edac_ecc_error_log_clear(dev);
 
-	ibecc_errsts_clear(PCIE_BDF(0, 0, 0));
+	ibecc_errsts_clear(PCI_ENDPOINT);
 
 out:
 	k_spin_unlock(&nmi_lock, key);

--- a/drivers/edac/ibecc.h
+++ b/drivers/edac/ibecc.h
@@ -7,6 +7,8 @@
 /* TODO: Add to include/sys/util.h */
 #define BITFIELD(val, h, l)	(((val) & GENMASK(h, l)) >> l)
 
+#define PCI_VENDOR_ID_INTEL	0x8086
+
 #define PCI_DEVICE_ID_SKU7	0x452a
 #define PCI_DEVICE_ID_SKU12	0x4518
 

--- a/drivers/edac/ibecc.h
+++ b/drivers/edac/ibecc.h
@@ -7,9 +7,6 @@
 /* TODO: Add to include/sys/util.h */
 #define BITFIELD(val, h, l)	(((val) & GENMASK(h, l)) >> l)
 
-#define EDAC_IBECC_NAME		"IBECC"
-
-#define PCI_VENDOR_ID_INTEL	0x8086
 #define PCI_DEVICE_ID_SKU7	0x452a
 #define PCI_DEVICE_ID_SKU12	0x4518
 

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -11,6 +11,8 @@
 #include <drivers/edac.h>
 #include "ibecc.h"
 
+#define DEVICE_NAME DT_LABEL(DT_NODELABEL(ibecc))
+
 /**
  * EDAC Error Injection interface
  *
@@ -58,7 +60,7 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 	uint64_t error;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -88,7 +90,7 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 {
 	const struct device *dev;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -121,7 +123,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 {
 	const struct device *dev;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -156,7 +158,7 @@ static int cmd_inject_ctrl(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 	uint32_t value;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -213,7 +215,7 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 	const struct device *dev;
 	uint64_t error;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -234,7 +236,7 @@ static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
 {
 	const struct device *dev;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -259,7 +261,7 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 	const struct device *dev;
 	uint64_t error;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
@@ -276,7 +278,7 @@ static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
 {
 	const struct device *dev;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;

--- a/dts/bindings/edac/intel,ibecc.yaml
+++ b/dts/bindings/edac/intel,ibecc.yaml
@@ -9,4 +9,4 @@ include: base.yaml
 
 properties:
     reg:
-      required: true
+      required: false

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -410,10 +410,9 @@
 
 		ibecc: ibecc@0 {
 			compatible = "intel,ibecc";
-			reg = <PCIE_BDF(0,0,0) 0x8086>;
 			label = "ibecc";
 			status = "okay";
+			reg = <1 1>;
 		};
 	};
-
 };

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -411,7 +411,7 @@
 		ibecc: ibecc@0 {
 			compatible = "intel,ibecc";
 			reg = <PCIE_BDF(0,0,0) 0x8086>;
-
+			label = "ibecc";
 			status = "okay";
 		};
 	};

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -27,6 +27,12 @@
 		reg = <0x0 DT_DRAM_SIZE>;
 	};
 
+	ibecc: ibecc {
+	       compatible = "intel,ibecc";
+	       label = "ibecc";
+	       status = "okay";
+	};
+
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
@@ -406,13 +412,6 @@
 			interrupt-parent = <&intc>;
 
 			status = "okay";
-		};
-
-		ibecc: ibecc@0 {
-			compatible = "intel,ibecc";
-			label = "ibecc";
-			status = "okay";
-			reg = <1 1>;
 		};
 	};
 };

--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <devicetree.h>
 
 #include <drivers/edac.h>
 
@@ -29,13 +30,15 @@ static void notification_callback(const struct device *dev, void *data)
 	atomic_set(&handled, true);
 }
 
+#define DEVICE_NAME DT_LABEL(DT_NODELABEL(ibecc))
+
 void main(void)
 {
 	const struct device *dev;
 
-	dev = device_get_binding("IBECC");
+	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
-		LOG_ERR("Cannot open EDAC device");
+		LOG_ERR("Cannot open EDAC device: %s", DEVICE_NAME);
 		return;
 	}
 

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -12,7 +12,7 @@
 #include <drivers/edac.h>
 #include <ibecc.h>
 
-#define DEVICE_NAME		"IBECC"
+#define DEVICE_NAME		DT_LABEL(DT_NODELABEL(ibecc))
 
 #if defined(CONFIG_EDAC_ERROR_INJECT)
 #define TEST_ADDRESS1		0x1000


### PR DESCRIPTION
Start using DTS values for PCI Vendor ID and PCI BDF. For the PCI
Device ID we do not use DTS since this would require changing overlay
for different SKU board.