### PR TITLE
requirements: Update to pyocd 0.29 for LPC55S69 support

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -6,7 +6,7 @@
 pyserial
 
 # used to flash & debug various boards
-pyocd>=0.28.0
+pyocd>=0.29.0
 
 # used by twister for board/hardware map
 tabulate


### PR DESCRIPTION
Pyocd 0.29 supports being able to flash newer LPC55S69 as it handles
the debug unlock handshake.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>