### PR TITLE
tests: common: fix kernel.common test case build fail in intel_adsp_cavs15, 18, 20, 25

### DIFF
--- a/soc/xtensa/intel_adsp/common/bootloader/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/bootloader/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(base_module PUBLIC
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/include
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/../common/include
   ${ZEPHYR_BASE}/../modules/hal/xtensa/include
-  ${ZEPHYR_BASE}/build/zephyr/include/generated
+  ${PROJECT_BINARY_DIR}/include/generated
   ${ZEPHYR_BASE}/../modules/audio/sof/zephyr/include
   )
 
@@ -18,7 +18,7 @@ target_include_directories(boot_module PUBLIC
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/include
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/../common/include
   ${ZEPHYR_BASE}/../modules/hal/xtensa/include
-  ${ZEPHYR_BASE}/build/zephyr/include/generated
+  ${PROJECT_BINARY_DIR}/include/generated
   ${ZEPHYR_BASE}/../modules/audio/sof/zephyr/include
   )
 
@@ -40,11 +40,11 @@ set(zephyr_sdk $ENV{ZEPHYR_SDK_INSTALL_DIR})
 
 target_include_directories(bootloader PUBLIC
   ./
-  ${ZEPHYR_BASE}/include
+  ${PROJECT_BINARY_DIR}/include
   ${TOOLCHAIN_INCLUDES}
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/include
-  ${ZEPHYR_BASE}/build/zephyr/include/generated
+  ${PROJECT_BINARY_DIR}/include/generated
   ${ZEPHYR_BASE}/../modules/audio/sof/zephyr/include
   )
 


### PR DESCRIPTION
Fix kernel.common and kernel.common test cases fail due to build error
in platform intel_adsp_cavs15, 18, 20, 25.

Some of our test cases block due to intel_adsp_cavs build error when using twister, but success by west build.  
Current error message shows some of the CONFIG redefine due to reference to wrong PATH.
The needed file put in include/generated/ reference to build/zephyr/ directory, should be in twister.out/...../zephyr/  directory. 

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>