### PR TITLE
Add support for sdmmc on stm32l4+ devices

### DIFF
--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -256,6 +256,14 @@
 			status = "disabled";
 			label = "DMAMUX_1";
 		};
+
+		sdmmc1: sdmmc@50062400 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x50062400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x400000>;
+			status = "disabled";
+			label = "SDMMC_1";
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -144,6 +144,7 @@ config DISK_ACCESS_STM32_SDMMC
 	bool "STM32 SDMMC driver"
 	depends on HAS_STM32CUBE
 	select USE_STM32_HAL_SD
+	select USE_STM32_HAL_SD_EX if SOC_SERIES_STM32L4X
 	select USE_STM32_LL_SDMMC
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_SDMMC))
 	help


### PR DESCRIPTION
This pr adds the dts bindings for stm32l4+ sdmmc controller, and adds dependency on `USE_STM32_HAL_SD_EX` in `Kconfig`.