### PR TITLE
net: buf: Allow passing NULL as allocator to net_buf_append_bytes

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -2346,7 +2346,8 @@ typedef struct net_buf *(*net_buf_allocator_cb)(k_timeout_t timeout,
  *
  * @details Append data to a net_buf. If there is not enough space in the
  * net_buf then more net_buf will be added, unless there are no free net_buf
- * and timeout occurs.
+ * and timeout occurs. If not allocator is provided it attempts to allocate from
+ * the same pool as the original buffer.
  *
  * @param buf Network buffer.
  * @param len Total length of input data

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -750,7 +750,18 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 			return added_len;
 		}
 
-		frag = allocate_cb(timeout, user_data);
+		if (allocate_cb) {
+			frag = allocate_cb(timeout, user_data);
+		} else {
+			struct net_buf_pool *pool;
+
+			/* Allocate from the original pool if no callback has
+			 * been provided.
+			 */
+			pool = net_buf_pool_get(buf->pool_id);
+			frag = net_buf_alloc_len(pool, len, timeout);
+		}
+
 		if (!frag) {
 			return added_len;
 		}


### PR DESCRIPTION
This enables to use net_buf_append_bytes without passing an allocator in
which case the code would attempt to use the net_buf_pool of the
original buffer.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>