### PR TITLE
x86: use TSC for timing information

### DIFF
--- a/arch/x86/timing.c
+++ b/arch/x86/timing.c
@@ -55,7 +55,7 @@ void arch_timing_stop(void)
 
 timing_t arch_timing_counter_get(void)
 {
-	return k_cycle_get_32();
+	return z_tsc_read();
 }
 
 uint64_t arch_timing_cycles_get(volatile timing_t *const start,
@@ -72,7 +72,7 @@ uint64_t arch_timing_freq_get(void)
 
 uint64_t arch_timing_cycles_to_ns(uint64_t cycles)
 {
-	return k_cyc_to_ns_floor64(cycles);
+	return ((cycles) * NSEC_PER_SEC / tsc_freq);
 }
 
 uint64_t arch_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)


### PR DESCRIPTION
This changes the timing functions to use TSC to gather
timing information instead of using the timer for
scheduling as it provides higher resolution for timing
information.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>