### PR TITLE
arc: sys_io: fix sys_read32 return value from uint16_t to uint32_t

### DIFF
--- a/include/arch/arc/v2/sys_io.h
+++ b/include/arch/arc/v2/sys_io.h
@@ -164,7 +164,7 @@ static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
 
 static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 {
-	uint16_t value;
+	uint32_t value;
 
 	compiler_barrier();
 	value = *(volatile uint32_t *)addr;


### PR DESCRIPTION
Fix sys_read32 return value from uint16_t to uint32_t.
Current implementation causes read/modify/write of 32bit
registers to fail on the high bits.

Fix: #31385 