### PR TITLE
drivers: modem: sara-r4: Add sanity timeout for @ prompt

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -378,7 +378,12 @@ static ssize_t send_socket_data(void *obj,
 	}
 
 	/* Wait for prompt '@' */
-	k_sem_take(&mdata.sem_prompt, K_FOREVER);
+	ret = k_sem_take(&mdata.sem_prompt, K_SECONDS(1));
+	if (ret != 0) {
+		ret = -ETIMEDOUT;
+		LOG_ERR("No @ prompt received");
+		goto exit;
+	}
 
 	/*
 	 * The AT commands manual requires a 50 ms wait


### PR DESCRIPTION
This wait on @ prompt was added in
fa3d58648342d1a708a431ceb7a45354aba2fe9b.
The situation were the @ prompt is never received should not occurs, however
it's definitively safer to catch it instead of having a deadlock.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>