### PR TITLE
api: fix integer comparison compilation warning.

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -375,7 +375,7 @@ device_from_handle(device_handle_t dev_handle)
 	extern const struct device __device_start[];
 	extern const struct device __device_end[];
 	const struct device *dev = NULL;
-	size_t numdev = __device_end - __device_start;
+	ptrdiff_t numdev = __device_end - __device_start;
 
 	if (dev_handle < numdev) {
 		dev = &__device_start[dev_handle];


### PR DESCRIPTION
Fix warning generated when size_t and int16_t types are compared.
This warning is visible after switching to GCC 10 (SDK 0.12.1) and only when device.h is included from the C++ code.
Apperance conditions similar to [#31471](https://github.com/zephyrproject-rtos/zephyr/pull/31471)

```
[14/101] Building CXX object CMakeFiles/app.dir/src/shell/shell_upload.cpp.obj
In file included from /home/hid/aurora/zephyr/include/drivers/flash.h:26,
                 from /home/hid/aurora/app/src/shell/shell_upload.cpp:18:
/home/hid/aurora/zephyr/include/device.h: In function 'const device* device_from_handle(device_handle_t)':
/home/hid/aurora/zephyr/include/device.h:380:17: warning: comparison of integer expressions of different signedness: 'device_handle_t' {aka 'short int'} and 'size_t' {aka 'unsigned int'} [-Wsign-compare]
  380 |  if (dev_handle < numdev) {
      |      ~~~~~~~~~~~^~~~~~~~
```