### PR TITLE
Bluetooth: controller: radio: Fix compilation error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <devicetree.h>
 #include <sys/util_macro.h>
-#include <nrfx/hal/nrf_radio.h>
+#include <hal/nrf_radio.h>
 
 #include "radio_df.h"
 


### PR DESCRIPTION
Fix compilation error caused by use of wrong header file:
nrfx/hal/nrf_radio.h instead of hal/nrf_radio.h.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>