### PR TITLE
manifest: openthread update fixing coprocessor vendor hooks

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
       revision: 3f545d76a2e6d1db83a470ccdb5bebd1f484e137
       path: modules/lib/loramac-node
     - name: openthread
-      revision: b7433ff4ef9e0d8348bdc605ff82efb9c356b233
+      revision: bd3a99488fb629444690a286e3cad20f9897c614
       path: modules/lib/openthread
     - name: segger
       revision: 38c79a447e4a47d413b4e8d34448316a5cece77c


### PR DESCRIPTION
Update manifest with new openthread commit fixing Coprocessor
Vendor Hooks Kconfig usage in CMake.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>