### PR TITLE
Fix AArch32 interrupt nesting and exception exiting bugs

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -131,10 +131,18 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
 	/* Clean up exception stack frame */
 	add sp, #32
 
-	/* Switch in the next scheduled thread */
+	/*
+	 * Switch in the next scheduled thread.
+	 *
+	 * Note that z_arm_pendsv must be called in the SVC mode because it
+	 * switches to the SVC mode during context switch and returns to the
+	 * caller using lr_svc.
+	 */
+	cps #MODE_SVC
 	bl z_arm_pendsv
 
 	/* Decrement exception nesting count */
+	ldr r3, =_kernel
 	ldr r0, [r3, #_kernel_offset_to_nested]
 	sub r0, r0, #1
 	str r0, [r3, #_kernel_offset_to_nested]

--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -82,6 +82,13 @@ __EXIT_INT:
 	add sp, sp, r3
 
 	/*
+	 * Restore lr_svc stored into the SVC mode stack by the mode entry
+	 * function. This ensures that the return address of the interrupted
+	 * context is preserved in case of interrupt nesting.
+	 */
+	pop {lr}
+
+	/*
 	 * Restore r0-r3, r12 and lr_irq stored into the process stack by the
 	 * mode entry function. These registers are saved by _isr_wrapper for
 	 * IRQ mode and z_arm_svc for SVC mode.

--- a/arch/arm/core/aarch32/isr_wrapper.S
+++ b/arch/arm/core/aarch32/isr_wrapper.S
@@ -68,6 +68,13 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	 */
 	cps #MODE_SVC
 
+	/*
+	 * Preserve lr_svc which may contain the branch return address of the
+	 * interrupted context in case of a nested interrupt. This value will
+	 * be restored prior to exiting the interrupt in z_arm_int_exit.
+	 */
+	push {lr}
+
 	/* Align stack at double-word boundary */
 	and r3, sp, #4
 	sub sp, sp, r3

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -49,8 +49,8 @@ GDATA(z_arm_tls_ptr)
  * For Cortex-M, z_arm_pendsv() is invoked with no arguments.
  *
  * For Cortex-R, PendSV exception is not supported by the architecture and this
- * function is directly called either by _IntExit in case of preemption, or
- * z_arm_svc in case of cooperative switching.
+ * function is directly called either by z_arm_{exc,int}_exit in case of
+ * preemption, or z_arm_svc in case of cooperative switching.
  */
 
 SECTION_FUNC(TEXT, z_arm_pendsv)
@@ -380,7 +380,7 @@ _thread_irq_disabled:
 
     /*
      * Cortex-M: return from PendSV exception
-     * Cortex-R: return to the caller (_IntExit or z_arm_svc)
+     * Cortex-R: return to the caller (z_arm_{exc,int}_exit, or z_arm_svc)
      */
     bx lr
 

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -610,6 +610,12 @@ SECTION_FUNC(TEXT, z_arm_svc)
     push {r0-r3, r12, lr}
     cps #MODE_SVC
 
+    /*
+     * Store lr_svc to the SVC mode stack. This value will be restored prior to
+     * exiting the SVC call in z_arm_int_exit.
+     */
+    push {lr}
+
     /* Align stack at double-word boundary */
     and r3, sp, #4
     sub sp, sp, r3


### PR DESCRIPTION
This series fixes some critical bugs in the nested interrupt handling and fatal exception handling code.

Fixes #31511 
Fixes #30517 