### PR TITLE
linker: common-rom: tweak section naming to fit all linkers

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -41,9 +41,9 @@
 	{
 		__device_handles_start = .;
 #ifdef LINKER_PASS2
-		KEEP(*(SORT(.__device_handles_pass2)));
+		KEEP(*(SORT(.__device_handles_pass2*)));
 #else /* LINKER_PASS2 */
-		KEEP(*(SORT(.__device_handles_pass1)));
+		KEEP(*(SORT(.__device_handles_pass1*)));
 #endif /* LINKER_PASS2 */
 		__device_handles_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
MWDT toolchain adds additional suffix to sections name in case of ffunction-sections / fdata-sections are enabled.

The 40d3653758cd commit (device: add post-process of elf file to manage device handles) breaks linkage with MWDT toolchain as it adds new sections which are not meet MWDT requirements.

Let's pick a single set of rules and syntax that work for all toolchain.