### PR TITLE
device: fix edge condition mapping device handles to devices

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -377,7 +377,10 @@ device_from_handle(device_handle_t dev_handle)
 	const struct device *dev = NULL;
 	size_t numdev = __device_end - __device_start;
 
-	if (dev_handle < numdev) {
+	/* Negative values are reserved for things that are not
+	 * devices, or at least not in the standard table.
+	 */
+	if ((dev_handle >= 0) && ((size_t)dev_handle < numdev)) {
 		dev = &__device_start[dev_handle];
 	}
 


### PR DESCRIPTION
The device handle type is signed to support representing "devices"
that don't have a device structure, such as initialization functions.
Avoid signed/unsigned comparisons if one is encountered.

Supersedes #31514.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>