### PR TITLE
drivers: wifi: esp: add thread-safety on esp_socket operations

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -458,7 +458,7 @@ static int cmd_ipd_check_hdr_end(struct esp_socket *sock, char actual)
 	char expected;
 
 	/* When using passive mode, the +IPD command ends with \r\n */
-	if (ESP_PROTO_PASSIVE(sock->ip_proto)) {
+	if (ESP_PROTO_PASSIVE(esp_socket_ip_proto(sock))) {
 		expected = '\r';
 	} else {
 		expected = ':';
@@ -510,7 +510,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ipd)
 	 * When using passive TCP, the data itself is not included in the +IPD
 	 * command but must be polled with AT+CIPRECVDATA.
 	 */
-	if (ESP_PROTO_PASSIVE(sock->ip_proto)) {
+	if (ESP_PROTO_PASSIVE(esp_socket_ip_proto(sock))) {
 		esp_socket_work_submit(sock, &sock->recvdata_work);
 		ret = data_offset;
 		goto socket_unref;

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Tobias Svehagen
+ * Copyright (c) 2020 Grinn
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -131,13 +132,17 @@ enum esp_socket_flags {
 	ESP_SOCK_CONNECTING = BIT(2),
 	ESP_SOCK_CONNECTED  = BIT(3),
 	ESP_SOCK_CLOSE_PENDING = BIT(4),
+	ESP_SOCK_WORKQ_STOPPED = BIT(5),
 };
 
 struct esp_socket {
 	/* internal */
+	struct k_mutex lock;
+	atomic_t refcount;
+
 	uint8_t idx;
 	uint8_t link_id;
-	uint8_t flags;
+	atomic_t flags;
 
 	/* socket info */
 	enum net_sock_type type;
@@ -145,7 +150,13 @@ struct esp_socket {
 	struct sockaddr dst;
 
 	/* sem */
-	struct k_sem sem_data_ready;
+	union {
+		/* handles blocking receive */
+		struct k_sem sem_data_ready;
+
+		/* notifies about reaching 0 refcount */
+		struct k_sem sem_free;
+	};
 
 	/* work */
 	struct k_work connect_work;
@@ -218,35 +229,112 @@ struct esp_data {
 
 int esp_offload_init(struct net_if *iface);
 
-struct esp_socket *esp_socket_get();
+struct esp_socket *esp_socket_get(struct esp_data *data,
+				  enum net_sock_type type,
+				  enum net_ip_protocol ip_proto,
+				  struct net_context *context);
 int esp_socket_put(struct esp_socket *sock);
-struct esp_socket *esp_socket_from_link_id(struct esp_data *data,
-					   uint8_t link_id);
 void esp_socket_init(struct esp_data *data);
 void esp_socket_close(struct esp_socket *sock);
 void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 		   size_t offset, size_t len);
+void esp_socket_workq_stop_and_flush(struct esp_socket *sock);
+struct esp_socket *esp_socket_ref(struct esp_socket *sock);
+void esp_socket_unref(struct esp_socket *sock);
 
-void esp_socket_workq_flush(struct esp_socket *sock);
+static inline
+struct esp_socket *esp_socket_ref_from_link_id(struct esp_data *data,
+					       uint8_t link_id)
+{
+	if (link_id >= ARRAY_SIZE(data->sockets)) {
+		return NULL;
+	}
+
+	return esp_socket_ref(&data->sockets[link_id]);
+}
+
+static inline atomic_val_t esp_socket_flags_update(struct esp_socket *sock,
+						   atomic_val_t value,
+						   atomic_val_t mask)
+{
+	atomic_val_t flags;
+
+	do {
+		flags = atomic_get(&sock->flags);
+	} while (!atomic_cas(&sock->flags, flags, (flags & ~mask) | value));
+
+	return flags;
+}
+
+static inline
+atomic_val_t esp_socket_flags_clear_and_set(struct esp_socket *sock,
+					    atomic_val_t clear_flags,
+					    atomic_val_t set_flags)
+{
+	return esp_socket_flags_update(sock, set_flags,
+				       clear_flags | set_flags);
+}
+
+static inline atomic_val_t esp_socket_flags_set(struct esp_socket *sock,
+						atomic_val_t flags)
+{
+	return atomic_or(&sock->flags, flags);
+}
+
+static inline bool esp_socket_flags_test_and_clear(struct esp_socket *sock,
+						   atomic_val_t flags)
+{
+	return (atomic_and(&sock->flags, ~flags) & flags);
+}
+
+static inline bool esp_socket_flags_test_and_set(struct esp_socket *sock,
+						 atomic_val_t flags)
+{
+	return (atomic_or(&sock->flags, flags) & flags);
+}
+
+static inline atomic_val_t esp_socket_flags_clear(struct esp_socket *sock,
+						  atomic_val_t flags)
+{
+	return atomic_and(&sock->flags, ~flags);
+}
+
+static inline atomic_val_t esp_socket_flags(struct esp_socket *sock)
+{
+	return atomic_get(&sock->flags);
+}
 
 static inline struct esp_data *esp_socket_to_dev(struct esp_socket *sock)
 {
 	return CONTAINER_OF(sock - sock->idx, struct esp_data, sockets);
 }
 
-static inline bool esp_socket_in_use(struct esp_socket *sock)
+static inline void __esp_socket_work_submit(struct esp_socket *sock,
+					    struct k_work *work)
 {
-	return (sock->flags & ESP_SOCK_IN_USE) != 0;
+	struct esp_data *data = esp_socket_to_dev(sock);
+
+	k_work_submit_to_queue(&data->workq, work);
+}
+
+static inline int esp_socket_work_submit(struct esp_socket *sock,
+					  struct k_work *work)
+{
+	int ret = -EBUSY;
+
+	k_mutex_lock(&sock->lock, K_FOREVER);
+	if (!(esp_socket_flags(sock) & ESP_SOCK_WORKQ_STOPPED)) {
+		__esp_socket_work_submit(sock, work);
+		ret = 0;
+	}
+	k_mutex_unlock(&sock->lock);
+
+	return ret;
 }
 
 static inline bool esp_socket_connected(struct esp_socket *sock)
 {
-	return (sock->flags & ESP_SOCK_CONNECTED) != 0;
-}
-
-static inline bool esp_socket_close_pending(struct esp_socket *sock)
-{
-	return (sock->flags & ESP_SOCK_CLOSE_PENDING) != 0;
+	return (esp_socket_flags(sock) & ESP_SOCK_CONNECTED) != 0;
 }
 
 static inline void esp_flags_set(struct esp_data *dev, uint8_t flags)

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -145,8 +145,6 @@ struct esp_socket {
 	atomic_t flags;
 
 	/* socket info */
-	enum net_sock_type type;
-	enum net_ip_protocol ip_proto;
 	struct sockaddr dst;
 
 	/* sem */
@@ -230,8 +228,6 @@ struct esp_data {
 int esp_offload_init(struct net_if *iface);
 
 struct esp_socket *esp_socket_get(struct esp_data *data,
-				  enum net_sock_type type,
-				  enum net_ip_protocol ip_proto,
 				  struct net_context *context);
 int esp_socket_put(struct esp_socket *sock);
 void esp_socket_init(struct esp_data *data);
@@ -350,6 +346,16 @@ static inline void esp_flags_clear(struct esp_data *dev, uint8_t flags)
 static inline bool esp_flags_are_set(struct esp_data *dev, uint8_t flags)
 {
 	return (dev->flags & flags) != 0;
+}
+
+static inline enum net_sock_type esp_socket_type(struct esp_socket *sock)
+{
+	return net_context_get_type(sock->context);
+}
+
+static inline enum net_ip_protocol esp_socket_ip_proto(struct esp_socket *sock)
+{
+	return net_context_get_ip_proto(sock->context);
 }
 
 static inline int esp_cmd_send(struct esp_data *data,

--- a/drivers/wifi/esp/esp_socket.c
+++ b/drivers/wifi/esp/esp_socket.c
@@ -19,8 +19,6 @@ struct esp_workq_flush_data {
 };
 
 struct esp_socket *esp_socket_get(struct esp_data *data,
-				  enum net_sock_type type,
-				  enum net_ip_protocol ip_proto,
 				  struct net_context *context)
 {
 	struct esp_socket *sock = data->sockets;
@@ -32,8 +30,6 @@ struct esp_socket *esp_socket_get(struct esp_data *data,
 			sock->context = context;
 			context->offload_context = sock;
 
-			sock->type = type;
-			sock->ip_proto = ip_proto;
 			sock->connect_cb = NULL;
 			sock->recv_cb = NULL;
 
@@ -163,7 +159,7 @@ void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 	pkt = esp_socket_prepare_pkt(sock, buf, offset, len);
 	if (!pkt) {
 		LOG_ERR("Failed to get net_pkt: len %zu", len);
-		if (sock->type == SOCK_STREAM) {
+		if (esp_socket_type(sock) == SOCK_STREAM) {
 			if (!esp_socket_flags_test_and_set(sock,
 						ESP_SOCK_CLOSE_PENDING)) {
 				esp_socket_work_submit(sock, &sock->close_work);


### PR DESCRIPTION
Change type of esp_socket->flags from uint8_t to atomic_t, so that read
and write access to those flags is done in atomic (thread-safe) manner.

Introduce esp_socket_ref() and esp_socket_unref() functions, which
operate on atomic refcount variable. esp_socket_ref() role is to
increase refcount if it was already non-zero. If it was zero then NULL
is returned, which means that socket is not used by net_context at the
moment.

Role of refcount:
 * socket instance is assured to be between net_offload->get() and
   net_offload->put() when refcount > 0,
 * makes sure that socket instance can be used (its members can be
   dereferenced) when refcount > 0,
 * 'context' member is always valid and its members can be dereferenced
   when refcount > 0.

esp_socket_get() gets unused socket, as previously. Additionally it sets
refcount to 1 at the end of call, which basically means that from that
point such socket can be referenced by other parts of the driver. Each
esp_socket_get() call should be followed by esp_socket_unref() and
esp_socket_put() to properly invalidate socket and prevent other parts
of driver from using it.

Add ESP_SOCK_WORKQ_STOPPED flag, which is now used to prevent scheduling
more work into driver workqueue. This flag is set in net_offload->put()
callback, so that no more socket work (such as processing RX/TX packets
or closing socket because of errors) is submitted after that.

Introduce mutex lock, which has following role:
 * protects dst, connect_cb + conn_user_data, recv_cb + recv_user_data,
 * assures that checking ESP_SOCK_WORKQ_STOPPED flag and actually
   submitting (or not if net_offload->put was already called) new socket
   work to workqueue is done in atomic way.

As there is a mechanism to prevent submitting new work items to
workqueue when net_offload->put() has been executed, then there is no
need to explicitly call esp_socket_ref() in esp_workq thread. This is
because one reference is being held by net_context (after calling
net_context->get()). This is why all the esp_socket_in_use() were simply
dropped. Code running from esp_rx thread on the other hand always uses
esp_socket_ref_from_link_id() helper function (which is backed by
esp_socket_ref()), so that it replaces previous esp_socket_in_use()
calls and additionally makes sure that socket stays valid ("in use")
until esp_socket_unref() is called.