### PR TITLE
x86_64: Exclude a few tests that fail due to run on x86_64

### DIFF
--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -21,4 +21,5 @@ tests:
     tags: kernel ignore_faults userspace
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
+    platform_exclude: qemu_x86_64_nokpti qemu_x86_64
     tags: kernel ignore_faults

--- a/tests/ztest/mock/testcase.yaml
+++ b/tests/ztest/mock/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   testing.ztest.mock:
     arch_exclude: arm
+    platform_exclude: qemu_x86_64
     tags: test_framework
     integration_platforms:
       - native_posix


### PR DESCRIPTION
These tests hang and for now to make forward progress lets exclude
running them.  The introduction of the demand paging code is related
to these failures.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>