### PR TITLE
Bluetooth: controller: Fix accept scan en/disable if already en/disabled

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -201,6 +201,13 @@ config BT_CTLR_SCAN_SYNC_ISO_SET
 	help
 	  Maximum supported broadcast isochronous groups (BIGs) sync sets.
 
+config BT_CTLR_SCAN_ENABLE_STRICT
+	bool "Enforce Strict Scan Enable/Disable"
+	depends on BT_OBSERVER
+	help
+	  Enforce returning HCI Error Command Disallowed on enabling/disabling
+	  already enabled/disabled scanning.
+
 config BT_CTLR_ZLI
 	bool "Use Zero Latency IRQs"
 	depends on ZERO_LATENCY_IRQS

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1502,6 +1502,11 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 	status = ll_scan_enable(cmd->enable);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SCAN_ENABLE_STRICT) &&
+	    (status == BT_HCI_ERR_CMD_DISALLOWED)) {
+		status = BT_HCI_ERR_SUCCESS;
+	}
+
 	*evt = cmd_complete_status(status);
 }
 
@@ -2971,6 +2976,11 @@ static void le_set_ext_scan_enable(struct net_buf *buf, struct net_buf **evt)
 #endif
 
 	status = ll_scan_enable(cmd->enable, cmd->duration, cmd->period);
+
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SCAN_ENABLE_STRICT) &&
+	    (status == BT_HCI_ERR_CMD_DISALLOWED)) {
+		status = BT_HCI_ERR_SUCCESS;
+	}
 
 	*evt = cmd_complete_status(status);
 }


### PR DESCRIPTION
Conform to Bluetooth Specification, if the LE_Scan_Enable
parameter is set to 0x01 and scanning is already enabled,
any change to the Filter_Duplicates setting shall take
effect. Disabling scanning when it is disabled has no
effect.

Fixes #31019.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>