### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: align with changes from master

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_connections.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_connections.c
@@ -394,7 +394,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 	conn = ll_connected_get((*rx)->hdr.handle);
 	if (!conn) {
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		return 0;
 	}
@@ -421,7 +421,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 				BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL;
 
 			/* Mark for buffer for release */
-			(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+			(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 		}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 		break;
@@ -442,7 +442,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 		/* Invalid LL id, drop it. */
 
 		/* Mark for buffer for release */
-		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
@@ -528,7 +528,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	lll->adv_addr_type = peer_addr_type;
 	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
 	lll->conn_timeout = timeout;
-	lll->conn_ticks_slot = 0; /* TODO: */
 
 	conn_lll = &conn->lll;
 


### PR DESCRIPTION
Due to some re-factoring in master changes are needed in topic-ble-llcp:
- rename of constant
- removal of variable from lll structure

Signed-off-by: kruithofa <Andries.Kruithof@nordicsemi.no>