### PR TITLE
device: fix mishandling of null device handle

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -348,17 +348,23 @@ struct device {
  *
  * @param dev the device for which a handle is desired.
  *
- * @return the handle for the device.
+ * @return the handle for the device, or DEVICE_HANDLE_NULL if the
+ * device does not have an associated handle.
  */
 static inline device_handle_t
 device_handle_get(const struct device *dev)
 {
+	device_handle_t ret = DEVICE_HANDLE_NULL;
 	extern const struct device __device_start[];
 
 	/* TODO: If/when devices can be constructed that are not part of the
 	 * fixed we'll need another solution.
 	 */
-	return 1 + (device_handle_t)(dev - __device_start);
+	if (dev != NULL) {
+		ret = 1 + (device_handle_t)(dev - __device_start);
+	}
+
+	return ret;
 }
 
 /**

--- a/include/device.h
+++ b/include/device.h
@@ -358,7 +358,7 @@ device_handle_get(const struct device *dev)
 	/* TODO: If/when devices can be constructed that are not part of the
 	 * fixed we'll need another solution.
 	 */
-	return (device_handle_t)(dev - __device_start);
+	return 1 + (device_handle_t)(dev - __device_start);
 }
 
 /**
@@ -377,8 +377,8 @@ device_from_handle(device_handle_t dev_handle)
 	const struct device *dev = NULL;
 	size_t numdev = __device_end - __device_start;
 
-	if (dev_handle < numdev) {
-		dev = &__device_start[dev_handle];
+	if ((dev_handle > 0) && ((size_t)dev_handle < numdev)) {
+		dev = &__device_start[dev_handle - 1];
 	}
 
 	return dev;

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -79,6 +79,10 @@ const struct device *z_impl_device_get_binding(const char *name)
 {
 	const struct device *dev;
 
+	if (name == NULL) {
+		return NULL;
+	}
+
 	/* Split the search into two loops: in the common scenario, where
 	 * device names are stored in ROM (and are referenced by the user
 	 * with CONFIG_* macros), only cheap pointer comparisons will be

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -207,17 +207,18 @@ def main():
         if device_size == 0:
             device_size = device.sym.entry.st_size
 
-        # Where in the sequence of devices this particular node occurs
-        device.dev_ordinal = (device.sym.entry.st_value - device_start_addr) / device_size
-        debug("%s dev ordinal %d" % (device.sym.name, device.dev_ordinal))
+        # The device handle is one plus the ordinal of this device in
+        # the device table.
+        device.dev_handle = 1 + int((device.sym.entry.st_value - device_start_addr) / device_size)
+        debug("%s dev ordinal %d" % (device.sym.name, device.dev_handle))
 
         n = handle.node
         if n is not None:
-            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_ordinal, ' ; '.join(str(_) for _ in handle.handles)))
+            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_handle, ' ; '.join(str(_) for _ in handle.handles)))
             used_nodes.add(n)
             n.__device = device
         else:
-            debug("orphan %d" % (device.dev_ordinal,))
+            debug("orphan %d" % (device.dev_handle,))
         hv = handle.handles
         hvi = 1
         handle.dev_deps = []
@@ -269,7 +270,7 @@ def main():
 
             sn = hs.node
             if sn:
-                hdls.extend(dn.__device.dev_ordinal for dn in sn.__depends)
+                hdls.extend(dn.__device.dev_handle for dn in sn.__depends)
                 for dn in sn.depends_on:
                     if dn in sn.__depends:
                         dep_paths.append(dn.path)
@@ -291,7 +292,7 @@ def main():
 
             lines = [
                 '',
-                '/* %d : %s:' % (dev.dev_ordinal, (sn and sn.path) or "sysinit"),
+                '/* %d : %s:' % (dev.dev_handle, (sn and sn.path) or "sysinit"),
             ]
 
             if len(dep_paths) > 0:


### PR DESCRIPTION
The intent was always to have a zero valued device handle represent an unknown device.  This was not reflected in the values used for handles, which were instead the zero-based ordinal of the device within the device table, making the first device indistinguishable from the null device.
    
Fix the generated dependency handles and the round-trip conversions between handle and device pointer.

Incidentally fixes the same issue as #31526, which this supersedes.