### PR TITLE
ppp: add net events for PPP dead and running

### DIFF
--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -547,6 +547,8 @@ void net_ppp_init(struct net_if *iface);
 enum net_event_ppp_cmd {
 	NET_EVENT_PPP_CMD_CARRIER_ON = 1,
 	NET_EVENT_PPP_CMD_CARRIER_OFF,
+	NET_EVENT_PPP_CMD_PHASE_RUNNING,
+	NET_EVENT_PPP_CMD_PHASE_DEAD,
 };
 
 #define NET_EVENT_PPP_CARRIER_ON					\
@@ -554,6 +556,12 @@ enum net_event_ppp_cmd {
 
 #define NET_EVENT_PPP_CARRIER_OFF					\
 	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_OFF)
+
+#define NET_EVENT_PPP_PHASE_RUNNING					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_RUNNING)
+
+#define NET_EVENT_PPP_PHASE_DEAD					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_DEAD)
 
 struct net_if;
 
@@ -582,6 +590,34 @@ static inline void ppp_mgmt_raise_carrier_on_event(struct net_if *iface)
 void ppp_mgmt_raise_carrier_off_event(struct net_if *iface);
 #else
 static inline void ppp_mgmt_raise_carrier_off_event(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+}
+#endif
+
+/**
+ * @brief Raise PHASE_RUNNING event when PPP reaching RUNNING phase
+ *
+ * @param iface PPP network interface.
+ */
+#if defined(CONFIG_NET_L2_PPP_MGMT)
+void ppp_mgmt_raise_phase_running_event(struct net_if *iface);
+#else
+static inline void ppp_mgmt_raise_phase_running_event(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+}
+#endif
+
+/**
+ * @brief Raise PHASE_DEAD event when PPP reaching DEAD phase
+ *
+ * @param iface PPP network interface.
+ */
+#if defined(CONFIG_NET_L2_PPP_MGMT)
+void ppp_mgmt_raise_phase_dead_event(struct net_if *iface);
+#else
+static inline void ppp_mgmt_raise_phase_dead_event(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 }

--- a/subsys/net/l2/ppp/misc.c
+++ b/subsys/net/l2/ppp/misc.c
@@ -98,6 +98,12 @@ void ppp_change_phase(struct ppp_context *ctx, enum ppp_phase new_phase)
 	validate_phase_transition(ctx->phase, new_phase);
 
 	ctx->phase = new_phase;
+
+	if (ctx->phase == PPP_DEAD) {
+		ppp_mgmt_raise_phase_dead_event(ctx->iface);
+	} else if (ctx->phase == PPP_RUNNING) {
+		ppp_mgmt_raise_phase_running_event(ctx->iface);
+	}
 }
 
 const char *ppp_state_str(enum ppp_state state)

--- a/subsys/net/l2/ppp/ppp_mgmt.c
+++ b/subsys/net/l2/ppp/ppp_mgmt.c
@@ -15,3 +15,13 @@ void ppp_mgmt_raise_carrier_off_event(struct net_if *iface)
 {
 	net_mgmt_event_notify(NET_EVENT_PPP_CARRIER_OFF, iface);
 }
+
+void ppp_mgmt_raise_phase_running_event(struct net_if *iface)
+{
+	net_mgmt_event_notify(NET_EVENT_PPP_PHASE_RUNNING, iface);
+}
+
+void ppp_mgmt_raise_phase_dead_event(struct net_if *iface)
+{
+	net_mgmt_event_notify(NET_EVENT_PPP_PHASE_DEAD, iface);
+}


### PR DESCRIPTION
There's currently no way for an app to get notifications about the state of a PPP connection.  For example, if the initial connection fails to establish (here configured with a timeout of 1 second and 2 configure retransmits), the PPP state machine will just enter the "DEAD" phase and stop working:
```
[00:00:02.391,113] <dbg> net_l2_ppp.carrier_on: (sysworkq): Carrier ON for interface 0x20002d88
[00:00:02.393,218] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x20002df8] phase DEAD (0) => ESTABLISH (1) (start_ppp():194)
[00:00:02.396,057] <dbg> net_l2_ppp.ppp_fsm_lower_up: (sysworkq): [LCP/0x20002e38] Current state INITIAL (0)
[00:00:02.398,376] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x20002e38] state INITIAL (0) => CLOSED (2) (ppp_fsm_lower_up():322)
[00:00:02.401,458] <dbg> net_l2_ppp.start_ppp: (sysworkq): Starting LCP
[00:00:02.403,076] <dbg> net_l2_ppp.ppp_fsm_open: (sysworkq): [LCP/0x20002e38] Current state CLOSED (2)
[00:00:02.405,303] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x20002e38] state CLOSED (2) => REQUEST_SENT (6) (ppp_fsm_open():345)
[00:00:02.408,416] <dbg> net_l2_ppp.fsm_send_configure_req: (sysworkq): [LCP/0x20002e38] Sending Configure-Req (1) id 1 to peer while in REQUEST_SENT (6)
[00:00:02.411,712] <dbg> net_l2_ppp.ppp_send_pkt: (sysworkq): [LCP/0x20002e38] Sending 6 bytes pkt 0x2000c328 (options len 0)
[00:00:02.414,367] <wrn> main: Event (ppp): d2090001 = PPP carrier on
[00:00:02.416,076] <dbg> net_l2_ppp.net_pkt_hexdump: send L2
[00:00:02.417,388] <dbg> net_l2_ppp.0x2000c328
                                    c0 21 01 01 00 04                                |.!....           
[00:00:02.420,562] <dbg> net_ppp.net_pkt_hexdump: send ppp
[00:00:02.421,936] <dbg> net_ppp.0x2000c328
                                 c0 21 01 01 00 04                                |.!....           
done..
[00:00:03.414,398] <dbg> net_l2_ppp.ppp_fsm_timeout: (sysworkq): [LCP/0x20002e38] Current state REQUEST_SENT (6)
[00:00:03.416,595] <dbg> net_l2_ppp.fsm_send_configure_req: (sysworkq): [LCP/0x20002e38] Sending Configure-Req (1) id 1 to peer while in REQUEST_SENT (6)
[00:00:03.419,891] <dbg> net_l2_ppp.ppp_send_pkt: (sysworkq): [LCP/0x20002e38] Sending 6 bytes pkt 0x2000c328 (options len 0)
[00:00:03.422,576] <dbg> net_l2_ppp.net_pkt_hexdump: send L2
[00:00:03.423,950] <dbg> net_l2_ppp.0x2000c328
                                    c0 21 01 01 00 04                                |.!....           
[00:00:03.427,124] <dbg> net_ppp.net_pkt_hexdump: send ppp
[00:00:03.428,497] <dbg> net_ppp.0x2000c328
                                 c0 21 01 01 00 04                                |.!....           
[00:00:04.422,576] <dbg> net_l2_ppp.ppp_fsm_timeout: (sysworkq): [LCP/0x20002e38] Current state REQUEST_SENT (6)
[00:00:04.424,804] <dbg> net_l2_ppp.ppp_fsm_timeout: (sysworkq): [LCP/0x20002e38] Configure-Req retransmit limit 0 reached
[00:00:04.427,398] <dbg> net_l2_ppp.ppp_change_state_debug: (sysworkq): [LCP/0x20002e38] state REQUEST_SENT (6) => STOPPED (3) (ppp_fsm_timeout():112)
[00:00:04.430,603] <dbg> net_l2_ppp.ppp_change_phase_debug: (sysworkq): [0x20002df8] phase ESTABLISH (1) => DEAD (0) (ppp_link_terminated():123)
[00:00:04.433,654] <dbg> net_l2_ppp.ppp_link_terminated: (sysworkq): [0x20002df8] Link terminated
```
This patch lets the user get a network management event when this happens, so that the app can try to recover.  Or is there a better way to plumb things so it can be detected in a non-PPP-specific way?