### PR TITLE
doc: fix typo trough -> through

### DIFF
--- a/boards/arm/thingy52_nrf52832/doc/index.rst
+++ b/boards/arm/thingy52_nrf52832/doc/index.rst
@@ -140,7 +140,7 @@ Internal I2C Bus
 ----------------
 
 The internal I2C bus (I2C_0) is not routed to any of the external connectors,
-but most of the on-board devices are accessed trough it. The following pins
+but most of the on-board devices are accessed through it. The following pins
 have been assigned to the bus:
 
 +---------+---------+

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -1467,11 +1467,11 @@ static enum net_verdict canbus_recv(struct net_if *iface,
 
 	if (pkt->canbus_rx_ctx) {
 		if (lladdr->len == sizeof(struct net_canbus_lladdr)) {
-			NET_DBG("Push reassembled packet from 0x%04x trough "
+			NET_DBG("Push reassembled packet from 0x%04x through "
 				"stack again", canbus_get_src_lladdr(pkt));
 		} else {
 			NET_DBG("Push reassembled packet from "
-				"%02x:%02x:%02x:%02x:%02x:%02x trough stack again",
+				"%02x:%02x:%02x:%02x:%02x:%02x through stack again",
 				lladdr->addr[0], lladdr->addr[1], lladdr->addr[2],
 				lladdr->addr[3], lladdr->addr[4], lladdr->addr[5]);
 		}

--- a/subsys/net/l2/canbus/Kconfig
+++ b/subsys/net/l2/canbus/Kconfig
@@ -58,7 +58,7 @@ config NET_L2_CANBUS_ETH_TRANSLATOR
 	help
 	  Enable a 6LoCAN Ethernet translator. With this translator it is
 	  possible to connect a 6LoCAN network to a Ethernet network directly,
-	  via a Switch or trough a router. Messages that goes through the
+	  via a Switch or through a router. Messages that goes through the
 	  translator have a special address and the MAC address is carried inline.
 	  The packet is forwarded with uncompressed IPv6 header.
 


### PR DESCRIPTION
Fix common typo.

Fixes #31543