### PR TITLE
net: coap: module API enhancements

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -65,6 +65,13 @@ API Changes
 * The ``CONFIG_BT_CTLR_CODED_PHY`` is now disabled by default for builds
   combining both Bluetooth host and controller.
 
+* The :c:func:`coap_packet_append_payload` function will now take a pointer to a
+  constant buffer as the ``payload`` argument instead of a pointer to a writable
+  buffer.
+
+* The :c:func:`coap_packet_init` function will now take a pointer to a constant
+  buffer as the ``token`` argument instead of a pointer to a writable buffer.
+
 Deprecated in this release
 ==========================
 

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -148,6 +148,8 @@ enum coap_response_code {
 
 #define COAP_CODE_EMPTY (0)
 
+#define COAP_TOKEN_MAX_LEN 8UL
+
 /**
  * @brief Set of Content-Format option values for CoAP.
  *
@@ -300,9 +302,10 @@ uint8_t coap_header_get_type(const struct coap_packet *cpkt);
  * @brief Returns the token (if any) in the CoAP packet.
  *
  * @param cpkt CoAP packet representation
- * @param token Where to store the token
+ * @param token Where to store the token, must point to a buffer containing
+ *              at least COAP_TOKEN_MAX_LEN bytes
  *
- * @return Token length in the CoAP packet.
+ * @return Token length in the CoAP packet (0 - COAP_TOKEN_MAX_LEN).
  */
 uint8_t coap_header_get_token(const struct coap_packet *cpkt, uint8_t *token);
 

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -372,7 +372,7 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
  */
 int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
 		     uint8_t ver, uint8_t type, uint8_t token_len,
-		     uint8_t *token, uint8_t code, uint16_t id);
+		     const uint8_t *token, uint8_t code, uint16_t id);
 
 /**
  * @brief Returns a randomly generated array of 8 bytes, that can be
@@ -469,7 +469,7 @@ int coap_packet_append_payload_marker(struct coap_packet *cpkt);
  *
  * @return 0 in case of success or negative in case of error.
  */
-int coap_packet_append_payload(struct coap_packet *cpkt, uint8_t *payload,
+int coap_packet_append_payload(struct coap_packet *cpkt, const uint8_t *payload,
 			       uint16_t payload_len);
 
 /**

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -417,7 +417,7 @@ static int process_obs_coap_reply(void)
 {
 	struct coap_packet reply;
 	uint16_t id;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint8_t type;
 	uint8_t tkl;
@@ -455,7 +455,7 @@ static int process_obs_coap_reply(void)
 		goto end;
 	}
 
-	tkl = coap_header_get_token(&reply, (uint8_t *)token);
+	tkl = coap_header_get_token(&reply, token);
 	id = coap_header_get_id(&reply);
 
 	type = coap_header_get_type(&reply);

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -205,7 +205,7 @@ static int piggyback_get(struct coap_resource *resource,
 {
 	struct coap_packet response;
 	uint8_t payload[40];
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t id;
 	uint8_t code;
@@ -277,7 +277,7 @@ static int test_del(struct coap_resource *resource,
 		    struct sockaddr *addr, socklen_t addr_len)
 {
 	struct coap_packet response;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint8_t tkl;
 	uint8_t code;
@@ -325,7 +325,7 @@ static int test_put(struct coap_resource *resource,
 		    struct sockaddr *addr, socklen_t addr_len)
 {
 	struct coap_packet response;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	const uint8_t *payload;
 	uint8_t *data;
 	uint16_t payload_len;
@@ -385,7 +385,7 @@ static int test_post(struct coap_resource *resource,
 						      NULL };
 	const char * const *p;
 	struct coap_packet response;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	const uint8_t *payload;
 	uint8_t *data;
 	uint16_t payload_len;
@@ -451,7 +451,7 @@ static int query_get(struct coap_resource *resource,
 	struct coap_option options[4];
 	struct coap_packet response;
 	uint8_t payload[40];
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t id;
 	uint8_t code;
@@ -545,7 +545,7 @@ static int location_query_post(struct coap_resource *resource,
 	const char * const *p;
 	struct coap_packet response;
 	uint8_t *data;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint16_t id;
 	uint8_t code;
 	uint8_t type;
@@ -602,7 +602,7 @@ static int separate_get(struct coap_resource *resource,
 {
 	struct coap_packet response;
 	uint8_t payload[40];
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t id;
 	uint8_t code;
@@ -693,7 +693,7 @@ static int large_get(struct coap_resource *resource,
 	static struct coap_block_context ctx;
 	struct coap_packet response;
 	uint8_t payload[64];
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t size;
 	uint16_t id;
@@ -780,7 +780,7 @@ static int large_update_put(struct coap_resource *resource,
 	static struct coap_block_context ctx;
 	struct coap_packet response;
 	const uint8_t *payload;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t id;
 	uint16_t len;
@@ -869,7 +869,7 @@ static int large_create_post(struct coap_resource *resource,
 	static struct coap_block_context ctx;
 	struct coap_packet response;
 	const uint8_t *payload;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t len;
 	uint16_t id;
@@ -1099,7 +1099,7 @@ static int obs_get(struct coap_resource *resource,
 		   struct sockaddr *addr, socklen_t addr_len)
 {
 	struct coap_observer *observer;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint16_t id;
 	uint8_t code;
 	uint8_t type;
@@ -1152,7 +1152,7 @@ static int core_get(struct coap_resource *resource,
 {
 	static const char dummy_str[] = "Just a test\n";
 	struct coap_packet response;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint8_t *data;
 	uint16_t id;
 	uint8_t tkl;

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -99,9 +99,9 @@ static inline bool append(struct coap_packet *cpkt, const uint8_t *data, uint16_
 	return true;
 }
 
-int coap_packet_init(struct coap_packet *cpkt, uint8_t *data,
-		     uint16_t max_len, uint8_t ver, uint8_t type,
-		     uint8_t tokenlen, uint8_t *token, uint8_t code, uint16_t id)
+int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
+		     uint8_t ver, uint8_t type, uint8_t token_len,
+		     const uint8_t *token, uint8_t code, uint16_t id)
 {
 	uint8_t hdr;
 	bool res;
@@ -119,7 +119,7 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data,
 
 	hdr = (ver & 0x3) << 6;
 	hdr |= (type & 0x3) << 4;
-	hdr |= tokenlen & 0xF;
+	hdr |= token_len & 0xF;
 
 	res = append_u8(cpkt, hdr);
 	if (!res) {
@@ -136,15 +136,15 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data,
 		return -EINVAL;
 	}
 
-	if (token && tokenlen) {
-		res = append(cpkt, token, tokenlen);
+	if (token && token_len) {
+		res = append(cpkt, token, token_len);
 		if (!res) {
 			return -EINVAL;
 		}
 	}
 
 	/* Header length : (version + type + tkl) + code + id + [token] */
-	cpkt->hdr_len = 1 + 1 + 2 + tokenlen;
+	cpkt->hdr_len = 1 + 1 + 2 + token_len;
 
 	return 0;
 }
@@ -326,7 +326,7 @@ int coap_packet_append_payload_marker(struct coap_packet *cpkt)
 	return append_u8(cpkt, COAP_MARKER) ? 0 : -EINVAL;
 }
 
-int coap_packet_append_payload(struct coap_packet *cpkt, uint8_t *payload,
+int coap_packet_append_payload(struct coap_packet *cpkt, const uint8_t *payload,
 			       uint16_t payload_len)
 {
 	return append(cpkt, payload, payload_len) ? 0 : -EINVAL;


### PR DESCRIPTION
This PR includes two enhancements to CoAP protocol API:

1. Definition of maximal token length replaces magic numbers across the code.
2. `const` keyword added to data pointer parameters in function encoding token and payload, what allows appending token or payload from constant buffers.