### PR TITLE
lorawan: notify MAC layer of new datarates

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -261,6 +261,22 @@ int lorawan_join(const struct lorawan_join_config *join_cfg)
 	}
 
 out:
+	/*
+	 * Several regions (AS923, AU915, US915) overwrite the datarate as part
+	 * of the join process. Reset the datarate to the value requested
+	 * (and validated) in lorawan_set_datarate so that the MAC layer is
+	 * aware of the set datarate for LoRaMacQueryTxPossible. This is only
+	 * performed when ADR is disabled as it the network servers
+	 * responsibility to increase datarates when ADR is enabled.
+	 */
+	if ((ret == 0) && (!lorawan_adr_enable)) {
+		MibRequestConfirm_t mib_req;
+
+		mib_req.Type = MIB_CHANNELS_DATARATE;
+		mib_req.Param.ChannelsDatarate = lorawan_datarate;
+		LoRaMacMibSetRequestConfirm(&mib_req);
+	}
+
 	k_mutex_unlock(&lorawan_join_mutex);
 	return ret;
 }

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -296,8 +296,18 @@ int lorawan_set_class(enum lorawan_class dev_class)
 
 int lorawan_set_datarate(enum lorawan_datarate dr)
 {
+	MibRequestConfirm_t mib_req;
+
 	/* Bail out if using ADR */
 	if (lorawan_adr_enable) {
+		return -EINVAL;
+	}
+
+	/* Notify MAC layer of the requested datarate */
+	mib_req.Type = MIB_CHANNELS_DATARATE;
+	mib_req.Param.ChannelsDatarate = dr;
+	if (LoRaMacMibSetRequestConfirm(&mib_req) != LORAMAC_STATUS_OK) {
+		/* Datarate is invalid for this region */
 		return -EINVAL;
 	}
 

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -53,7 +53,7 @@ K_SEM_DEFINE(mcps_confirm_sem, 0, 1);
 K_MUTEX_DEFINE(lorawan_join_mutex);
 K_MUTEX_DEFINE(lorawan_send_mutex);
 
-static enum lorawan_datarate lorawan_datarate = LORAWAN_DR_0;
+static enum lorawan_datarate lorawan_datarate;
 static uint8_t lorawan_conf_msg_tries = 1;
 static bool lorawan_adr_enable;
 
@@ -414,6 +414,8 @@ int lorawan_start(void)
 {
 	LoRaMacStatus_t status;
 	MibRequestConfirm_t mib_req;
+	GetPhyParams_t phy_params;
+	PhyParam_t phy_param;
 
 	status = LoRaMacStart();
 	if (status != LORAMAC_STATUS_OK) {
@@ -421,6 +423,11 @@ int lorawan_start(void)
 			lorawan_status2str(status));
 		return -EINVAL;
 	}
+
+	/* Retrieve the default TX datarate for selected region */
+	phy_params.Attribute = PHY_DEF_TX_DR;
+	phy_param = RegionGetPhyParam(LORAWAN_REGION, &phy_params);
+	lorawan_datarate = phy_param.Value;
 
 	/* TODO: Move these to a proper location */
 	mib_req.Type = MIB_SYSTEM_MAX_RX_ERROR;


### PR DESCRIPTION
Notify the MAC layer when application code calls `lorawan_set_datarate`.
This must occur because it is the MAC layer cached datarate that is used by `LoRaMacQueryTxPossible` in `lorawan_send`.
Failing to notify the MAC layer results in large packets being discarded, even if the requested datarate could support the length.
This also necessitates an additional call to the MAC layer after joining, as the set datarate is overwritten when joining for some regions.

Fixes #31551