### PR TITLE
device: fix potential truncation of DT-derived device names

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -711,7 +711,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  */
 #define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data,	\
 			       cfg, prio, api, mtu)			\
-	Z_ETH_NET_DEVICE_INIT(node_id, node_id, DT_LABEL(node_id),	\
+	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+			      DT_PROP_OR(node_id, label, NULL),		\
 			      init_fn, pm_control_fn, data, cfg, prio,	\
 			      api, mtu)
 

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2268,7 +2268,8 @@ struct net_if_api {
  */
 #define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data, cfg,	\
 			   prio, api, l2, l2_ctx_type, mtu)		\
-	Z_NET_DEVICE_INIT(node_id, node_id, DT_LABEL(node_id), init_fn,	\
+	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+			  DT_PROP_OR(node_id, label, NULL), init_fn,	\
 			  pm_control_fn, data, cfg, prio, api, l2,	\
 			  l2_ctx_type, mtu)
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -132,7 +132,8 @@ def write_device_extern_header(device_header_out, edt):
         print("", file=dev_header_file)
 
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
-            print(f"extern const struct device DEVICE_DT_NAME_GET(DT_{node.z_path_id});", file=dev_header_file)
+            print(f"extern const struct device DEVICE_DT_NAME_GET(DT_{node.z_path_id}); /* dts_ord_{node.dep_ordinal} */",
+                  file=dev_header_file)
 
         print("", file=dev_header_file)
         print("#ifdef __cplusplus", file=dev_header_file)


### PR DESCRIPTION
While using the encoded path to a device tree node guarantees a unique identifier for the corresponding device there is a limit on the number of characters of that name that can be captured when looking up a device by name from user mode, and the path can exceed that limit.

Synthesize a unique name from the node dependency ordinal instead, and update the gen_defines script to record the name associated with the full path in the extern declaration.

Add a build-time check that no device is created with a name that violates the user mode requirement.

Also update the ethernet device DTS helper function to use the same inference for dev_name and label that the real one does, since it bypasses the real one.