### PR TITLE
usb: fix possible deadlock in usb_transfer_sync()

### DIFF
--- a/subsys/usb/usb_transfer.c
+++ b/subsys/usb/usb_transfer.c
@@ -14,6 +14,8 @@
 
 LOG_MODULE_REGISTER(usb_transfer, CONFIG_USB_DEVICE_LOG_LEVEL);
 
+#define USB_TRANSFER_SYNC_TIMEOUT 100
+
 struct usb_transfer_sync_priv {
 	int tsize;
 	struct k_sem sem;
@@ -313,8 +315,23 @@ int usb_transfer_sync(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags
 		return ret;
 	}
 
-	/* Semaphore will be released by the transfer completion callback */
-	k_sem_take(&pdata.sem, K_FOREVER);
+	/* Semaphore will be released by the transfer completion callback
+	 * which might not be called when transfer was cancelled
+	 */
+	while (1) {
+		struct usb_transfer_data *trans;
+
+		ret = k_sem_take(&pdata.sem, K_MSEC(USB_TRANSFER_SYNC_TIMEOUT));
+		if (ret == 0) {
+			break;
+		}
+
+		trans = usb_ep_get_transfer(ep);
+		if (!trans || trans->status != -EBUSY) {
+			LOG_WRN("Sync transfer cancelled, ep 0x%02x", ep);
+			return -ECANCELED;
+		}
+	}
 
 	return pdata.tsize;
 }


### PR DESCRIPTION
Syncing here is done with a semaphore declared on a function stack
and released in a callback. In case of a cancelled transfer (eg.
cable disconnect) the callback is never called.

The fix introduces a periodic check if a transfer is still valid.

Fixes #31091