### PR TITLE
ci: Bump up number of builds

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.12.1"
-    parallelism: 240
+    parallelism: 300
     timeout_in_minutes: 210
     retry:
       manual: true


### PR DESCRIPTION
To get the daily build to hopefully run completely w/o timeouts lets
increase the number of builders.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>