### PR TITLE
doc: release: 2.5: Add notes about Atmel, Cypress, UpdateHub, Inventek, TagoIO, Bossac

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -124,11 +124,15 @@ Boards & SoC Support
 
 * Added support for these SoC series:
 
+  * Cypress PSoC-63
+
 * Made these changes in other SoC series:
 
 * Changes for ARC boards:
 
 * Added support for these ARM boards:
+
+  * Cypress CY8CKIT_062_BLE board
 
 * Added support for these SPARC boards:
 
@@ -138,6 +142,9 @@ Boards & SoC Support
 
 * Made these changes in other boards:
 
+  * CY8CKIT_062_WIFI_BT_M0: was renamed to CY8CKIT_062_WIFI_BT.
+  * CY8CKIT_062_WIFI_BT_M4: was moved into CY8CKIT_062_WIFI_BT.
+  * CY8CKIT_062_WIFI_BT: Now M0+/M4 are at same common board.
   * nRF5340 DK: Selected TF-M as the default Secure Processing Element
     (SPE) when building Zephyr for the non-secure domain.
 
@@ -186,7 +193,11 @@ Drivers and Sensors
 
 * GPIO
 
+  * Added Cypress PSoC-6 driver.
+
 * Hardware Info
+
+  * Added Cypress PSoC-6 driver.
 
 * I2C
 
@@ -195,6 +206,8 @@ Drivers and Sensors
 * IEEE 802.15.4
 
 * Interrupt Controller
+
+  * Added Cypress PSoC-6 Cortex-M0+ interrupt multiplexer driver.
 
 * IPM
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -151,6 +151,8 @@ Boards & SoC Support
 
 * Added support for these following shields:
 
+  * Inventek es-WIFI shield
+
 Drivers and Sensors
 *******************
 
@@ -248,6 +250,8 @@ Drivers and Sensors
 * Watchdog
 
 * WiFi
+
+  * Added uart bus interface for eswifi driver.
 
 Networking
 **********

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -289,6 +289,15 @@ Libraries / Subsystems
 
   * updatehub
 
+    * Added support to Network Manager and interface overlays at UpdateHub
+      sample. Ethernet is the default interface configuration and overlays
+      can be used to change default configuration
+    * Added WIFI overlay
+    * Added MODEM overlay
+    * Added IEEE 802.15.4 overlay [experimental]
+    * Added BLE IPSP overlay as [experimental]
+    * Added OpenThread overlay as [experimental].
+
 * Settings
 
 * Random

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -147,7 +147,8 @@ Boards & SoC Support
   * CY8CKIT_062_WIFI_BT: Now M0+/M4 are at same common board.
   * nRF5340 DK: Selected TF-M as the default Secure Processing Element
     (SPE) when building Zephyr for the non-secure domain.
-
+  * SAM4E_XPRO: Added support to SAM-BA ROM bootloader.
+  * SAM4S_XPLAINED: Added support to SAM-BA ROM bootloader.
 
 * Added support for these following shields:
 
@@ -196,12 +197,15 @@ Drivers and Sensors
 * GPIO
 
   * Added Cypress PSoC-6 driver.
+  * Added Atmel SAM4L driver.
 
 * Hardware Info
 
   * Added Cypress PSoC-6 driver.
 
 * I2C
+
+  * Added Atmel SAM4L TWIM driver.
 
 * I2S
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -260,6 +260,8 @@ Drivers and Sensors
 Networking
 **********
 
+  * Added TagoIO IoT Cloud HTTP post sample.
+
 Bluetooth
 *********
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -295,6 +295,13 @@ Build and Infrastructure
     documented in :ref:`dt-from-c`. Information on flash partitions has moved
     to :ref:`flash_map_api`.
 
+* West
+
+  * Improve bossac runner. It supports now native ROM bootloader for Atmel
+    MCUs and extended SAM-BA bootloader like Arduino and Adafruit UF2. The
+    devices supported depend on bossac version inside Zephyr SDK or in users
+    path. The recommended Zephyr SDK version is 0.12.0 or newer.
+
 Libraries / Subsystems
 **********************
 


### PR DESCRIPTION
 - Atmel boards and drivers
 - Cypress SoC, boards and drivers
 - UpdateHub improvements
 - Inventek es-WIFI shield
 - TagoIO Network Cloud sample
 - West bossac runner improvements