### PR TITLE
lora: sx12xx_common: force sleep on boot

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -148,5 +148,14 @@ int sx12xx_init(const struct device *dev)
 	dev_data.events.RxDone = sx12xx_ev_rx_done;
 	Radio.Init(&dev_data.events);
 
+	/*
+	 * Automatically place the radio into sleep mode upon boot.
+	 * The required `lora_config` call before transmission or reception
+	 * will bring the radio out of sleep mode before it is used. The radio
+	 * is automatically placed back into sleep mode upon TX or RX
+	 * completion.
+	 */
+	Radio.Sleep();
+
 	return 0;
 }


### PR DESCRIPTION
Force sx12xx modems into sleep mode on boot. This is the default state
of the modem when not being used due to the TX/RX complete callbacks.
This reduces current consumption by 600uA before the modems are used
for the first time.

As sleep is the normal state after TX/RX when using the LoRa API, it is
garaunteed that this will not change the behaviour of application code.
LoRaWAN starts by calling Radio.Init(), which resets the modem, so any
sleep configuration we do here is discarded.

Fixes #31567.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>