### PR TITLE
Bluetooth: controller: Fix encryption and procedure with instant

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -897,6 +897,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_enc.req = conn->llcp_enc.ack = 0U;
 		conn->llcp_enc.pause_tx = conn->llcp_enc.pause_rx = 0U;
 		conn->llcp_enc.refresh = 0U;
+		conn->slave.llcp_type = 0U;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -93,7 +93,9 @@ static inline void event_ch_map_prep(struct ll_conn *conn,
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static bool is_enc_req_pause_tx(struct ll_conn *conn);
 static inline void event_enc_prep(struct ll_conn *conn);
+#if defined(CONFIG_BT_PERIPHERAL)
 static int enc_rsp_send(struct ll_conn *conn);
+#endif /* CONFIG_BT_PERIPHERAL */
 static int start_enc_rsp_send(struct ll_conn *conn,
 			      struct pdu_data *pdu_ctrl_tx);
 static inline bool ctrl_is_unexpected(struct ll_conn *conn, uint8_t opcode);
@@ -2620,7 +2622,7 @@ static inline void event_enc_prep(struct ll_conn *conn)
 	struct node_tx *tx;
 
 	if (conn->llcp.encryption.state) {
-#if !defined(CONFIG_BT_CTLR_FAST_ENC)
+#if defined(CONFIG_BT_PERIPHERAL) && !defined(CONFIG_BT_CTLR_FAST_ENC)
 		if (lll->role &&
 		    (conn->llcp.encryption.state == LLCP_ENC_STATE_INIT)) {
 			struct node_rx_pdu *rx;
@@ -2663,7 +2665,7 @@ static inline void event_enc_prep(struct ll_conn *conn)
 			/* Wait for LTK reply */
 			conn->llcp.encryption.state = LLCP_ENC_STATE_LTK_WAIT;
 		}
-#endif /* !CONFIG_BT_CTLR_FAST_ENC */
+#endif /* CONFIG_BT_PERIPHERAL && !CONFIG_BT_CTLR_FAST_ENC */
 
 		return;
 	}
@@ -3810,6 +3812,7 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 }
 #endif /* CONFIG_BT_CTLR_PHY */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 			  struct node_rx_pdu **rx, struct pdu_data *pdu)
 {
@@ -3905,6 +3908,7 @@ chan_map_upd_recv_exit:
 
 	return err;
 }
+#endif /* CONFIG_BT_PERIPHERAL */
 
 static void terminate_ind_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 			      struct pdu_data *pdu)
@@ -3917,6 +3921,7 @@ static void terminate_ind_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 }
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CENTRAL)
 static void enc_req_reused_send(struct ll_conn *conn, struct node_tx **tx)
 {
 	struct pdu_data *pdu_ctrl_tx;
@@ -3950,7 +3955,9 @@ static void enc_req_reused_send(struct ll_conn *conn, struct node_tx **tx)
 	/* dont release ctrl PDU memory */
 	*tx = NULL;
 }
+#endif /* CONFIG_BT_CENTRAL */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 static int enc_rsp_send(struct ll_conn *conn)
 {
 	struct pdu_data *pdu_ctrl_tx;
@@ -3992,6 +3999,7 @@ static int enc_rsp_send(struct ll_conn *conn)
 
 	return 0;
 }
+#endif /* CONFIG_BT_PERIPHERAL */
 
 static int start_enc_rsp_send(struct ll_conn *conn,
 			      struct pdu_data *pdu_ctrl_tx)
@@ -5087,10 +5095,13 @@ static inline void ctrl_tx_pre_ack(struct ll_conn *conn,
 			break;
 		}
 		__fallthrough;
-
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
-	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:
 	case PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ:
+#endif /* CONFIG_BT_CENTRAL */
+#if defined(CONFIG_BT_PERIPHERAL)
+	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:
+#endif /* CONFIG_BT_PERIPHERAL */
 		/* pause data packet tx */
 		conn->llcp_enc.pause_tx = 1U;
 		break;
@@ -5098,7 +5109,9 @@ static inline void ctrl_tx_pre_ack(struct ll_conn *conn,
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	case PDU_DATA_LLCTRL_TYPE_PHY_REQ:
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_RSP:
+#endif /* CONFIG_BT_PERIPHERAL */
 		/* pause data packet tx */
 		conn->llcp_phy.pause_tx = 1U;
 		break;
@@ -5126,6 +5139,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	break;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 		/* things from master stored for session key calculation */
 		memcpy(&conn->llcp.encryption.skd[0],
@@ -5145,7 +5159,9 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		/* Reset enc req queued state */
 		conn->llcp_enc.ack = conn->llcp_enc.req;
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:
 		/* pause data packet tx */
 		conn->llcp_enc.pause_tx = 1U;
@@ -5157,7 +5173,9 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		 * alongwith this tx ack at this point in time.
 		 */
 		break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ:
 		/* pause data packet tx */
 		conn->llcp_enc.pause_tx = 1U;
@@ -5174,12 +5192,16 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		/* Reset enc req queued state */
 		conn->llcp_enc.ack = conn->llcp_enc.req;
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 
 	case PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_RSP:
+#if defined(CONFIG_BT_CENTRAL)
 		if (!conn->lll.role) {
 			/* reused tx-ed PDU and send enc req */
 			enc_req_reused_send(conn, tx);
-		} else {
+		} else
+#endif /* CONFIG_BT_CENTRAL */
+		{
 			/* pause data packet tx */
 			conn->llcp_enc.pause_tx = 1U;
 		}
@@ -5265,6 +5287,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		conn->llcp_phy.state = LLCP_PHY_STATE_RSP_WAIT;
 		__fallthrough;
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_RSP:
 		if (conn->lll.role) {
 			/* select the probable PHY with longest Tx time, which
@@ -5284,12 +5307,15 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		/* resume data packet tx */
 		conn->llcp_phy.pause_tx = 0U;
 		break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND:
 		conn->lll.phy_tx_time = conn->llcp.phy_upd_ind.tx;
 		/* resume data packet tx */
 		conn->llcp_phy.pause_tx = 0U;
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	default:
@@ -5380,6 +5406,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	switch (opcode) {
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_CONN_UPDATE_IND:
 	{
 		uint8_t err;
@@ -5418,6 +5445,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 	}
 	break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	case PDU_DATA_LLCTRL_TYPE_TERMINATE_IND:
 		if (!pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_TERMINATE_IND,
@@ -5429,6 +5457,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		break;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 		if (!conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_ENC_REQ, pdu_rx->len)) {
@@ -5480,7 +5509,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		conn->procedure_expire = conn->procedure_reload;
 
 		break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:
 		if (conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_ENC_RSP, pdu_rx->len)) {
@@ -5516,6 +5547,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 
 	case PDU_DATA_LLCTRL_TYPE_START_ENC_RSP:
 		if (!pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_START_ENC_RSP,
@@ -5568,6 +5600,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_REQ:
 		if (!conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_FEATURE_REQ,
@@ -5577,8 +5610,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 		nack = feature_rsp_send(conn, *rx, pdu_rx);
 		break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
-#if defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
 	case PDU_DATA_LLCTRL_TYPE_SLAVE_FEATURE_REQ:
 		if (conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_SLAVE_FEATURE_REQ,
@@ -5588,8 +5622,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 		nack = feature_rsp_send(conn, *rx, pdu_rx);
 		break;
-#endif /* CONFIG_BT_CTLR_SLAVE_FEAT_REQ */
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_CTLR_SLAVE_FEAT_REQ */
 
+#if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
 		if ((!IS_ENABLED(CONFIG_BT_CTLR_SLAVE_FEAT_REQ) &&
 		     conn->lll.role) ||
@@ -5600,8 +5635,10 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 		feature_rsp_recv(conn, pdu_rx);
 		break;
+#endif /* CONFIG_BT_CENTRAL || CONFIG_BT_CTLR_SLAVE_FEAT_REQ */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ:
 		if (!conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ,
@@ -5611,6 +5648,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 		nack = pause_enc_rsp_send(conn, *rx, 1);
 		break;
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	case PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_RSP:
 		if (!pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_RSP,
@@ -5894,6 +5932,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 		break;
 
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_CONN_PARAM_RSP:
 		if (conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_CONN_PARAM_RSP,
@@ -5966,6 +6005,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
@@ -6247,6 +6287,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 		break;
 
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_RSP:
 		if (conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_PHY_RSP, pdu_rx->len)) {
@@ -6280,7 +6321,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
+#endif /* CONFIG_BT_CENTRAL */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND:
 	{
 		uint8_t err;
@@ -6297,9 +6340,11 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 	}
 	break;
+#endif /* CONFIG_BT_PERIPHERAL */
 #endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
+#if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND:
 		if (conn->lll.role ||
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND,
@@ -6337,6 +6382,7 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		break;
+#endif  /* CONFIG_BT_CENTRAL */
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 
 	default:

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -996,6 +996,32 @@ int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy)
 		}
 	}
 
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+	/* Run any pending procedure stored while encryption was started */
+	if (conn->llcp.encryption.pend_llcp_type != LLCP_NONE) {
+		switch (conn->llcp.encryption.pend_llcp_type) {
+#if defined(CONFIG_BT_CTLR_PHY)
+		case LLCP_PHY_UPD:
+		{
+			struct lll_conn *lll = &conn->lll;
+			uint16_t event_counter;
+
+			/* Calculate current event counter */
+			event_counter = lll->event_counter +
+					lll->latency_prepare + lazy;
+
+			event_phy_upd_ind_prep(conn, event_counter);
+		}
+		break;
+#endif /* CONFIG_BT_CTLR_PHY */
+
+		default:
+			LL_ASSERT(0);
+			break;
+		}
+	}
+#endif /* CONFIG_BT_CTLR_LE_ENC */
+
 	/* Terminate Procedure Request */
 	if (conn->llcp_terminate.ack != conn->llcp_terminate.req) {
 		struct node_tx *tx;
@@ -2777,6 +2803,19 @@ static inline void event_enc_prep(struct ll_conn *conn)
 		/* resume data packet rx and tx */
 		conn->llcp_enc.pause_rx = 0U;
 		conn->llcp_enc.pause_tx = 0U;
+
+		/* If the encryption procedure interrupted another procedcure,
+		 * continue that procedure
+		 */
+		if (conn->llcp.encryption.pend_llcp_type != LLCP_NONE) {
+			conn->llcp_type = conn->llcp.encryption.pend_llcp_type;
+			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
+			/* return now to prevent the 'procedure request acked',
+			 * below, otherwise the ack/req flow prevents the
+			 * interrupted procedure to run.
+			 */
+			return;
+		}
 #endif /* !CONFIG_BT_CTLR_FAST_ENC */
 	}
 
@@ -3683,8 +3722,15 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 		struct node_rx_pdu *rx;
 		uint8_t old_tx, old_rx;
 
-		/* procedure request acked */
-		conn->llcp_ack = conn->llcp_req;
+		if (conn->llcp.encryption.pend_llcp_type == LLCP_NONE) {
+			/* procedure request acked */
+			conn->llcp_ack = conn->llcp_req;
+		} else {
+			/* PHY Update completed, so clear the
+			 * pending procedure
+			 */
+			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
+		}
 
 		/* apply new phy */
 		old_tx = lll->phy_tx;
@@ -5463,6 +5509,21 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		    !pdu_len_cmp(PDU_DATA_LLCTRL_TYPE_ENC_REQ, pdu_rx->len)) {
 			goto ull_conn_rx_unknown_rsp_send;
 		}
+
+#if defined(CONFIG_BT_CTLR_PHY)
+		/* LL_ENC_REQ was received while LLCP_PHY_UPD was running */
+		if (conn->llcp_type == LLCP_PHY_UPD &&
+		    conn->llcp_ack != conn->llcp_req) {
+			 /* Adjust ack due to decrement below, to prevent
+			  * failures
+			  */
+			conn->llcp_ack += 2U;
+			/* Remember that LLCP_PHY_UPD was interrupted */
+			conn->llcp.encryption.pend_llcp_type = LLCP_PHY_UPD;
+		} else {
+			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
+		}
+#endif /* CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_FAST_ENC)
 		/* TODO: BT Spec. text: may finalize the sending of additional

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -864,6 +864,9 @@ int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy)
 	 */
 	if ((conn->llcp_ack == conn->llcp_req) &&
 #if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_PERIPHERAL)
+	    (!conn->lll.role || (conn->slave.llcp_type == LLCP_NONE)) &&
+#endif /* CONFIG_BT_PERIPHERAL */
 	    !conn->llcp_enc.pause_rx) {
 #else /* !CONFIG_BT_CTLR_LE_ENC */
 	    1) {
@@ -996,10 +999,34 @@ int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy)
 		}
 	}
 
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-	/* Run any pending procedure stored while encryption was started */
-	if (conn->llcp.encryption.pend_llcp_type != LLCP_NONE) {
-		switch (conn->llcp.encryption.pend_llcp_type) {
+#if defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CTLR_LE_ENC)
+	/* Run any pending local peripheral role initiated procedure stored when
+	 * peer central initiated a encryption procedure
+	 */
+	if (conn->lll.role && (conn->slave.llcp_type != LLCP_NONE)) {
+		switch (conn->slave.llcp_type) {
+		case LLCP_CONN_UPD:
+		{
+			if (event_conn_upd_prep(conn, lazy,
+						ticks_at_expire) == 0) {
+				return -ECANCELED;
+			}
+		}
+		break;
+
+		case LLCP_CHAN_MAP:
+		{
+			struct lll_conn *lll = &conn->lll;
+			uint16_t event_counter;
+
+			/* Calculate current event counter */
+			event_counter = lll->event_counter +
+					lll->latency_prepare + lazy;
+
+			event_ch_map_prep(conn, event_counter);
+		}
+		break;
+
 #if defined(CONFIG_BT_CTLR_PHY)
 		case LLCP_PHY_UPD:
 		{
@@ -1020,7 +1047,7 @@ int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy)
 			break;
 		}
 	}
-#endif /* CONFIG_BT_CTLR_LE_ENC */
+#endif /* CONFIG_BT_PERIPHERAL && CONFIG_BT_CTLR_LE_ENC */
 
 	/* Terminate Procedure Request */
 	if (conn->llcp_terminate.ack != conn->llcp_terminate.req) {
@@ -2320,9 +2347,21 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 		uint32_t periodic_us;
 		uint16_t latency;
 
+#if defined(CONFIG_BT_PERIPHERAL)
+		if (conn->lll.role && (conn->slave.llcp_type != LLCP_NONE)) {
+			/* Local peripheral initiated PHY update completed while
+			 * a remote central had initiated encryption procedure
+			 */
+			conn->slave.llcp_type = LLCP_NONE;
+		} else
+#endif /* CONFIG_BT_PERIPHERAL */
+		{
+			/* procedure request acked */
+			conn->llcp_ack = conn->llcp_req;
+		}
+
 		/* procedure request acked */
 		conn->llcp_cu.ack = conn->llcp_cu.req;
-		conn->llcp_ack = conn->llcp_req;
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 		if ((conn->llcp_conn_param.req != conn->llcp_conn_param.ack) &&
@@ -2592,8 +2631,18 @@ static inline void event_ch_map_prep(struct ll_conn *conn,
 			    <= 0x7FFF) {
 		struct lll_conn *lll = &conn->lll;
 
-		/* procedure request acked */
-		conn->llcp_ack = conn->llcp_req;
+#if defined(CONFIG_BT_PERIPHERAL)
+		if (conn->lll.role && (conn->slave.llcp_type != LLCP_NONE)) {
+			/* Local peripheral initiated PHY update completed while
+			 * a remote central had initiated encryption procedure
+			 */
+			conn->slave.llcp_type = LLCP_NONE;
+		} else
+#endif /* CONFIG_BT_PERIPHERAL */
+		{
+			/* procedure request acked */
+			conn->llcp_ack = conn->llcp_req;
+		}
 
 		/* copy to active channel map */
 		memcpy(&lll->data_chan_map[0],
@@ -2803,19 +2852,6 @@ static inline void event_enc_prep(struct ll_conn *conn)
 		/* resume data packet rx and tx */
 		conn->llcp_enc.pause_rx = 0U;
 		conn->llcp_enc.pause_tx = 0U;
-
-		/* If the encryption procedure interrupted another procedcure,
-		 * continue that procedure
-		 */
-		if (conn->llcp.encryption.pend_llcp_type != LLCP_NONE) {
-			conn->llcp_type = conn->llcp.encryption.pend_llcp_type;
-			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
-			/* return now to prevent the 'procedure request acked',
-			 * below, otherwise the ack/req flow prevents the
-			 * interrupted procedure to run.
-			 */
-			return;
-		}
 #endif /* !CONFIG_BT_CTLR_FAST_ENC */
 	}
 
@@ -3722,14 +3758,17 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 		struct node_rx_pdu *rx;
 		uint8_t old_tx, old_rx;
 
-		if (conn->llcp.encryption.pend_llcp_type == LLCP_NONE) {
+#if defined(CONFIG_BT_PERIPHERAL)
+		if (conn->lll.role && (conn->slave.llcp_type != LLCP_NONE)) {
+			/* Local peripheral initiated PHY update completed while
+			 * a remote central had initiated encryption procedure
+			 */
+			conn->slave.llcp_type = LLCP_NONE;
+		} else
+#endif /* CONFIG_BT_PERIPHERAL */
+		{
 			/* procedure request acked */
 			conn->llcp_ack = conn->llcp_req;
-		} else {
-			/* PHY Update completed, so clear the
-			 * pending procedure
-			 */
-			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
 		}
 
 		/* apply new phy */
@@ -5511,17 +5550,19 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 
 #if defined(CONFIG_BT_CTLR_PHY)
-		/* LL_ENC_REQ was received while LLCP_PHY_UPD was running */
-		if (conn->llcp_type == LLCP_PHY_UPD &&
-		    conn->llcp_ack != conn->llcp_req) {
-			 /* Adjust ack due to decrement below, to prevent
-			  * failures
-			  */
+		/* LL_ENC_REQ was received while local peripheral initiated
+		 * procedure is in progress.
+		 */
+		if (unlikely(((conn->llcp_req - conn->llcp_ack) & 0x03) ==
+			     0x02)) {
+			/* Adjust ack due to decrement below, to prevent
+			 * failures
+			 */
 			conn->llcp_ack += 2U;
-			/* Remember that LLCP_PHY_UPD was interrupted */
-			conn->llcp.encryption.pend_llcp_type = LLCP_PHY_UPD;
-		} else {
-			conn->llcp.encryption.pend_llcp_type = LLCP_NONE;
+
+			/* Store the local peripheral initiated procedure */
+			LL_ASSERT(conn->slave.llcp_type == LLCP_NONE);
+			conn->slave.llcp_type = conn->llcp_type;
 		}
 #endif /* CONFIG_BT_CTLR_PHY */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -72,6 +72,9 @@ struct ll_conn {
 #endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t  latency_cancel:1;
 			uint8_t  sca:3;
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+			uint8_t  llcp_type;
+#endif /* CONFIG_BT_CTLR_LE_ENC */
 #if defined(CONFIG_BT_CTLR_CONN_RANDOM_FORCE)
 			uint32_t force;
 #endif /* CONFIG_BT_CTLR_CONN_RANDOM_FORCE */
@@ -94,6 +97,7 @@ struct ll_conn {
 
 	uint8_t llcp_req;
 	uint8_t llcp_ack;
+
 	uint8_t llcp_type;
 
 	struct {
@@ -128,7 +132,6 @@ struct ll_conn {
 				LLCP_ENC_STATE_INIT,
 				LLCP_ENC_STATE_LTK_WAIT,
 			} state:2 __packed;
-			uint8_t  pend_llcp_type;
 			uint8_t  error_code;
 			uint8_t  skd[16];
 		} encryption;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -72,8 +72,12 @@ struct ll_conn {
 #endif /* CONFIG_BT_CTLR_CONN_META */
 			uint8_t  latency_cancel:1;
 			uint8_t  sca:3;
+#if defined(CONFIG_BT_CTLR_CONN_RANDOM_FORCE)
 			uint32_t force;
+#endif /* CONFIG_BT_CTLR_CONN_RANDOM_FORCE */
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 			uint32_t ticks_to_offset;
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 		} slave;
 #endif /* CONFIG_BT_PERIPHERAL */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -96,28 +96,30 @@ struct ll_conn {
 	uint8_t llcp_ack;
 	uint8_t llcp_type;
 
-	union {
-		struct {
-			uint16_t instant;
-			uint16_t *pdu_win_offset;
-			uint32_t ticks_anchor;
-		} conn_upd;
+	struct {
+		union {
+			struct {
+				uint16_t instant;
+				uint16_t *pdu_win_offset;
+				uint32_t ticks_anchor;
+			} conn_upd;
 
-		struct {
-			uint8_t  initiate:1;
-			uint8_t  chm[5];
-			uint16_t instant;
-		} chan_map;
+			struct {
+				uint8_t  initiate:1;
+				uint8_t  chm[5];
+				uint16_t instant;
+			} chan_map;
 
 #if defined(CONFIG_BT_CTLR_PHY)
-		struct {
-			uint8_t initiate:1;
-			uint8_t cmd:1;
-			uint8_t tx:3;
-			uint8_t rx:3;
-			uint16_t instant;
-		} phy_upd_ind;
+			struct {
+				uint8_t initiate:1;
+				uint8_t cmd:1;
+				uint8_t tx:3;
+				uint8_t rx:3;
+				uint16_t instant;
+			} phy_upd_ind;
 #endif /* CONFIG_BT_CTLR_PHY */
+		};
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 		struct {
@@ -126,6 +128,7 @@ struct ll_conn {
 				LLCP_ENC_STATE_INIT,
 				LLCP_ENC_STATE_LTK_WAIT,
 			} state:2 __packed;
+			uint8_t  pend_llcp_type;
 			uint8_t  error_code;
 			uint8_t  skd[16];
 		} encryption;


### PR DESCRIPTION
Fix implementation to run local peripheral initiated control
procedure with instant in parallel with remote initiated
encryption procedure.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

If a PHY update is waiting for the instant to be reached and the master
starts the encryption procedure, store the pending PHY update procedure
and handle it simultaneously with the encryption setup.

This fix prevents the encryption setup from stalling and thereby timing
out after 40s, after which the master drops the link.

The ll_conn::llcp::encryption can not longer be unioned with the
ll_conn::llcp:phy_upd_ind as one would overwrite the other.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>

2021.01.26: 
babblesim trace verifying overlapping peer initiated PHY update and Encryption Setup.Three cases, Encryption Request reception from central before PHY Request is dispatch, the second wherein Encryption Request reception from central after PHY request is dispatched, and the third as Zephyr Controller as central tester does not start encryption, a hacked central that sends Encryption Request while PHY update waits for instant (hacked central is not completely implemented to finish the PHY update, but the test is sufficient to verify that the peripheral completed encryption setup and also tried to switch PHY at the instant, evident from the connection loss due to incorrect hacked central that does not change PHY).
[gh28887_phy_upd_before_enc.zip](https://github.com/zephyrproject-rtos/zephyr/files/5872795/gh28887_phy_upd_before_enc.zip)

Fixes #28887 