### PR TITLE
lora: power consumption fixes

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -222,10 +222,16 @@ static LoRaMacStatus_t lorawan_join_abp(
 
 int lorawan_join(const struct lorawan_join_config *join_cfg)
 {
+	MibRequestConfirm_t mib_req;
 	LoRaMacStatus_t status;
 	int ret = 0;
 
 	k_mutex_lock(&lorawan_join_mutex, K_FOREVER);
+
+	/* MIB_PUBLIC_NETWORK powers on the radio and does not turn it off */
+	mib_req.Type = MIB_PUBLIC_NETWORK;
+	mib_req.Param.EnablePublicNetwork = true;
+	LoRaMacMibSetRequestConfirm(&mib_req);
 
 	if (join_cfg->mode == LORAWAN_ACT_OTAA) {
 		status = lorawan_join_otaa(join_cfg);
@@ -425,10 +431,6 @@ int lorawan_start(void)
 	/* TODO: Move these to a proper location */
 	mib_req.Type = MIB_SYSTEM_MAX_RX_ERROR;
 	mib_req.Param.SystemMaxRxError = CONFIG_LORAWAN_SYSTEM_MAX_RX_ERROR;
-	LoRaMacMibSetRequestConfirm(&mib_req);
-
-	mib_req.Type = MIB_PUBLIC_NETWORK;
-	mib_req.Param.EnablePublicNetwork = true;
 	LoRaMacMibSetRequestConfirm(&mib_req);
 
 	return 0;


### PR DESCRIPTION
Fixes two causes of excess power consumption.

The initial commit keeps the drivers power state variable in sync with the actual state, to ensure the wakeup function is only called once per exit from sleep.

The second commit disables the DIO1 interrupt when the modem is in sleep mode, fixes #31569

The third commit moves when the LoRaWAN MAC layer is notified of the public network state.
The new location in `lorawan_join` is the more correct location for the command, and reduces power consumption when `lorawan_start` and `lorawan_join` are separated in time.