### PR TITLE
samples: canbus: canopen: mass-erase flash prior to running sample

### DIFF
--- a/samples/subsys/canbus/canopen/CMakeLists.txt
+++ b/samples/subsys/canbus/canopen/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.13.1)
 
 macro(app_set_runner_args)
   board_runner_args(canopen "--node-id=${CONFIG_CANOPEN_NODE_ID}")
+  board_runner_args(dfu-util "--dfuse-modifiers=force:mass-erase")
+  board_runner_args(pyocd "--erase")
+  board_runner_args(nrfjprog "--erase")
 endmacro()
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
Mass-erase the flash prior to running the sample to ensure the storage partition can be initialized correctly.

Fixes: #30477

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>