### PR TITLE
twister: generate json report on demand

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2734,7 +2734,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         logger.info(f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms, \
 {Fore.RED}{results.total - run - results.skipped_configs}{Fore.RESET} test configurations were only built.")
 
-    def save_reports(self, name, suffix, report_dir, no_update, release, only_failed, platform_reports):
+    def save_reports(self, name, suffix, report_dir, no_update, release, only_failed, platform_reports, json_report):
         if not self.instances:
             return
 
@@ -2761,7 +2761,9 @@ class TestSuite(DisablePyTestCollectionMixin):
             self.xunit_report(filename + "_report.xml", full_report=True,
                               append=only_failed, version=self.version)
             self.csv_report(filename + ".csv")
-            self.json_report(filename + ".json", append=only_failed, version=self.version)
+
+            if json_report:
+                self.json_report(filename + ".json", append=only_failed, version=self.version)
 
             if platform_reports:
                 self.target_report(outdir, suffix, append=only_failed)

--- a/scripts/twister
+++ b/scripts/twister
@@ -337,7 +337,10 @@ Artificially long but functional example:
         The output will be both in CSV and JUNIT format
         (twister.csv and twister.xml).
         """)
-
+    parser.add_argument(
+        "--json-report", action="store_true",
+        help="""Generate a JSON file with all test results. [Experimental]
+        """)
     parser.add_argument(
         "--platform-reports", action="store_true",
         help="""Create individual reports for each platform.
@@ -1254,6 +1257,7 @@ def main():
                        options.release,
                        options.only_failed,
                        options.platform_reports,
+                       options.json_report
                        )
 
     # FIXME: remove later


### PR DESCRIPTION
Do not generate json report by default. Use --json-report to generate
the file.

Fixes #31584