### PR TITLE
dts: bindings: mtd: rename SPI/I2C EEPROM base binding

### DIFF
--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -6,4 +6,4 @@ description: Atmel AT24 (or compatible) I2C EEPROM
 
 compatible: "atmel,at24"
 
-include: [eeprom-spi-i2c.yaml, i2c-device.yaml]
+include: ["atmel,at2x-base.yaml", i2c-device.yaml]

--- a/dts/bindings/mtd/atmel,at25.yaml
+++ b/dts/bindings/mtd/atmel,at25.yaml
@@ -5,4 +5,4 @@ description: Atmel AT25 (or compatible) SPI EEPROM
 
 compatible: "atmel,at25"
 
-include: [eeprom-spi-i2c.yaml, spi-device.yaml]
+include: ["atmel,at2x-base.yaml", spi-device.yaml]

--- a/dts/bindings/mtd/atmel,at2x-base.yaml
+++ b/dts/bindings/mtd/atmel,at2x-base.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-# Common fields for I2C and SPI EEPROM devices
+# Common fields for AT24 (I2C) and AT25 (SPI) EEPROM devices
 
 include: eeprom-base.yaml
 


### PR DESCRIPTION
Rename the SPI/I2C EEPROM devicetree binding to reflect that it only covers AT24 and AT25 EEPROMs).

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>