### PR TITLE
power: device: provide device_pm_state_str() with CONFIG_PM=n

### DIFF
--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -60,24 +60,6 @@ static device_idx_t num_pm;
 /* Number of devices successfully suspended. */
 static device_idx_t num_susp;
 
-const char *device_pm_state_str(uint32_t state)
-{
-	switch (state) {
-	case DEVICE_PM_ACTIVE_STATE:
-		return "active";
-	case DEVICE_PM_LOW_POWER_STATE:
-		return "low power";
-	case DEVICE_PM_SUSPEND_STATE:
-		return "suspend";
-	case DEVICE_PM_FORCE_SUSPEND_STATE:
-		return "force suspend";
-	case DEVICE_PM_OFF_STATE:
-		return "off";
-	default:
-		return "";
-	}
-}
-
 static int _pm_devices(uint32_t state)
 {
 	num_susp = 0;
@@ -183,3 +165,21 @@ void pm_create_device_list(void)
 	}
 }
 #endif /* defined(CONFIG_PM) */
+
+const char *device_pm_state_str(uint32_t state)
+{
+	switch (state) {
+	case DEVICE_PM_ACTIVE_STATE:
+		return "active";
+	case DEVICE_PM_LOW_POWER_STATE:
+		return "low power";
+	case DEVICE_PM_SUSPEND_STATE:
+		return "suspend";
+	case DEVICE_PM_FORCE_SUSPEND_STATE:
+		return "force suspend";
+	case DEVICE_PM_OFF_STATE:
+		return "off";
+	default:
+		return "";
+	}
+}


### PR DESCRIPTION
So far `device_pm_state_str()` was built only when `CONFIG_PM=y` (former
`CONFIG_SYSTEM_POWER_MANAGEMENT=y`). `device list` shell
command (`CONFIG_DEVICE_SHELL=y`) is using that function when
`CONFIG_PM_DEVICE=y`. This resulted in build failures when `CONFIG_PM=n`, as
linker could not find its implementation.

Build `device_pm_state_str()` function regardless of `CONFIG_PM` value, so
device shell module builds successfully in every case.

Simple reason why this hasn't been detected (by me) before is that CONFIG_PM 
was previously automatically selected for NRF platforms. This has changed with: 
https://github.com/zephyrproject-rtos/zephyr/commit/f38ba314ea29a34931453e8eed59e27bd4ae4da4