### PR TITLE
tests: Bluetooth: df: Fix build error, missing antenna config in DTS

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -55,7 +55,10 @@ if(CONFIG_BT_LL_SW_SPLIT)
   zephyr_library_sources_ifdef(
     CONFIG_BT_CTLR_DF
     ll_sw/nordic/lll/lll_df.c
-    ll_sw/nordic/hal/nrf5/radio/radio_df.c
+    )
+  zephyr_library_sources_ifdef(
+    (CONFIG_BT_CTLR_DF AND NOT CONFIG_SOC_SERIES_BSIM_NRFXX)
+    zephyr_library_sources(ll_sw/nordic/hal/nrf5/radio/radio_df.c)
     )
   zephyr_library_include_directories(
     ll_sw/nordic/lll

--- a/tests/bluetooth/df/CMakeLists.txt
+++ b/tests/bluetooth/df/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(df)
+project(bluetooth_df)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/bluetooth/df/src/radio_df_stub.c
+++ b/tests/bluetooth/df/src/radio_df_stub.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+
+/* Stub functitons that does nothing. Just to avoid liker complains. */
+void radio_df_ant_configure(void)
+{
+
+}
+
+uint8_t radio_df_ant_num_get(void)
+{
+	return 0;
+}


### PR DESCRIPTION
The DF tests are implemented to be executed with nrf52_bsim platform.
The nrf52_bsim platform does not include Direction Finding Extenstion.
Due to that, radio_df.c compilation failed with error about missing
antenna configuration in DTS.

To solve the problem, I've changed nrf.cmake to include radio_df.c
file when CONFIG_BT_CTLR_DF is defined and CONFIG_SOC_SERIES_BSIM_NRFXX
is not definded.

Thanks to that any other platform is not affected. The file will not
build if there is no appropriate configuration or there are missing
features in a hardwared.

Unit tests have provided stub imlpementation or radio functionality.
If nrf52_bsim has implemented Direction Finding Extension, the
DF unit tests code will stil work and will not require additional
changes. Also content of the file is not affected by contional
compilation entries.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>