### PR TITLE
Add example how to start net logging backend manually

### DIFF
--- a/samples/net/syslog_net/sample.yaml
+++ b/samples/net/syslog_net/sample.yaml
@@ -28,3 +28,7 @@ tests:
       - CONFIG_NET_CONFIG_NEED_IPV4=n
       - CONFIG_NET_CONFIG_MY_IPV4_ADDR=""
       - CONFIG_NET_CONFIG_PEER_IPV4_ADDR=""
+  sample.net.syslog.no_autostart:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_LOG_BACKEND_NET_AUTOSTART=n

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -9,8 +9,7 @@ LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 
 #include <zephyr.h>
 
-#include <net/net_core.h>
-#include <net/net_pkt.h>
+#include <logging/log_backend.h>
 
 #include <stdlib.h>
 
@@ -18,11 +17,31 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_LOG_BACKEND_NET), "syslog backend not enabled");
 
 #define SLEEP_BETWEEN_PRINTS 3
 
+#if IS_ENABLED(CONFIG_LOG_BACKEND_NET)
+extern const struct log_backend *log_backend_net_get(void);
+#endif
+
 void main(void)
 {
 	int i, count, sleep;
 
 	LOG_DBG("Starting");
+
+	if (!IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART)) {
+		/* Example how to start the backend if autostart is disabled.
+		 * This is useful if the application needs to wait the network
+		 * to be fully up before the syslog-net is able to work.
+		 */
+		const struct log_backend *backend = log_backend_net_get();
+
+		if (!log_backend_is_active(backend)) {
+			if (backend->api->init != NULL) {
+				backend->api->init();
+			}
+
+			log_backend_activate(backend, NULL);
+		}
+	}
 
 	if (CONFIG_NET_SAMPLE_SEND_ITERATIONS) {
 		count = CONFIG_NET_SAMPLE_SEND_ITERATIONS;

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -467,10 +467,15 @@ int net_config_init_app(const struct device *dev, const char *app_info)
 	/* This is activated late as it requires the network stack to be up
 	 * and running before syslog messages can be sent to network.
 	 */
-	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET)) {
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
+	    IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART)) {
 		const struct log_backend *backend = log_backend_net_get();
 
 		if (!log_backend_is_active(backend)) {
+			if (backend->api->init != NULL) {
+				backend->api->init();
+			}
+
 			log_backend_activate(backend, NULL);
 		}
 	}


### PR DESCRIPTION
This seems to be a useful pattern so add information to `syslog-net` sample how to start the network logging backend manually.
Also tweak the initialization in config lib so that we do auto init only if corresponding config option is set.
