### PR TITLE
fs: Fix fs_open resource leak when invoked on fs_file_t object in use

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -221,6 +221,20 @@ struct fs_statvfs {
 	extern struct fs_mount_t FS_FSTAB_ENTRY(node_id)
 
 /**
+ * @brief Initialize fs_file_t object
+ *
+ * Initialized the fs_file_t object; the function needs to be invoked
+ * on object before first use with fs_open.
+ *
+ * @param zfp Pointer to file object
+ *
+ */
+static inline void fs_file_t_init(struct fs_file_t *zfp)
+{
+	*zfp = (struct fs_file_t){ 0 };
+}
+
+/**
  * @brief Open or create file
  *
  * Opens or possibly creates a file and associates a stream with it.

--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -45,6 +45,8 @@ struct fs_mount_t;
 /**
  * @brief File object representing an open file
  *
+ * The object needs to be initialized with function fs_file_t_init().
+ *
  * @param Pointer to FATFS file object structure
  * @param mp Pointer to mount point structure
  */

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -107,7 +107,7 @@ int open(const char *name, int flags, ...)
 		return -1;
 	}
 
-	(void)memset(&ptr->file, 0, sizeof(ptr->file));
+	fs_file_t_init(&ptr->file);
 
 	rc = fs_open(&ptr->file, name, zmode);
 

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -4,5 +4,5 @@ tests:
   sample.filesystem.littlefs:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 particle_xenon disco_l475_iot1
-      mimxrt1064_evk
+      mimxrt1064_evk qemu_x86 native_posix
     tags: filesystem

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -99,6 +99,8 @@ void main(void)
 
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
+
 	rc = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (rc < 0) {
 		printk("FAIL: open %s: %d\n", fname, rc);

--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -468,6 +468,12 @@ static void fuse_fs_access_init(void)
 {
 	int err;
 	struct stat st;
+	size_t i = 0;
+
+	while (i < ARRAY_SIZE(files)) {
+		fs_file_t_init(&files[i]);
+		++i;
+	}
 
 	if (fuse_mountpoint == NULL) {
 		fuse_mountpoint = default_fuse_mountpoint;

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -188,6 +188,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 		length = 0;
 	}
 
+	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
@@ -277,6 +278,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 
 	shell_print(shell, "File size: %zd", dirent.size);
 
+	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
@@ -376,6 +378,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		arg_offset = 2;
 	}
 
+	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -123,6 +123,8 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 
 	lines = 0;
 
+	fs_file_t_init(&file);
+
 	rc = fs_open(&file, cf->cf_name, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		return -EINVAL;
@@ -239,6 +241,9 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 	int lines;
 	size_t new_name_len;
 	size_t val1_off;
+
+	fs_file_t_init(&rf);
+	fs_file_t_init(&wf);
 
 	if (fs_open(&rf, cf->cf_name, FS_O_CREATE | FS_O_RDWR) != 0) {
 		return -ENOEXEC;
@@ -360,13 +365,15 @@ static int settings_file_save_priv(struct settings_store *cs, const char *name,
 {
 	struct settings_file *cf = (struct settings_file *)cs;
 	struct line_entry_ctx entry_ctx;
-	struct fs_file_t  file;
+	struct fs_file_t file;
 	int rc2;
 	int rc;
 
 	if (!name) {
 		return -EINVAL;
 	}
+
+	fs_file_t_init(&file);
 
 	if (cf->cf_maxlines && (cf->cf_lines + 1 >= cf->cf_maxlines)) {
 		/*

--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -91,6 +91,7 @@ void setup_fs(void)
 		return;
 	}
 
+	fs_file_t_init(&img);
 	ret = fs_open(&img, IMG_FILE_PATH, FS_O_CREATE | FS_O_WRITE);
 	if (ret < 0) {
 		TC_PRINT("Failed to open image file: %d\n", ret);

--- a/tests/subsys/fs/common/test_fs_open_flags.c
+++ b/tests/subsys/fs/common/test_fs_open_flags.c
@@ -141,6 +141,8 @@ void test_fs_open_flags(void)
 	};
 	int block = 1;
 
+	fs_file_t_init(&ts.file);
+
 	ZBEGIN("Attempt open non-existent");
 	ZOPEN(&ts, 0, -ENOENT);
 	ZOPEN(&ts, FS_O_WRITE, -ENOENT);

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -11,6 +11,8 @@ const char *test_fs_open_flags_file_path =  FATFS_MNTP"/the_file.txt";
 
 void test_main(void)
 {
+	fs_file_t_init(&filep);
+
 	ztest_test_suite(fat_fs_basic_test,
 			 ztest_unit_test(test_fat_mount),
 			 ztest_unit_test(test_fat_file),

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
@@ -22,6 +22,7 @@ static void test_prepare(void)
 {
 	struct fs_file_t fs;
 
+	fs_file_t_init(&fs);
 	zassert_equal(fs_mount(&fatfs_mnt), 0, NULL);
 	zassert_equal(fs_open(&fs, "/NAND:/testfile.txt", FS_O_CREATE),
 		      0, NULL);
@@ -38,6 +39,8 @@ static void test_ops_on_rd(void)
 {
 	struct fs_file_t fs;
 	int ret;
+
+	fs_file_t_init(&fs);
 	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
 	fatfs_mnt.flags = FS_MOUNT_FLAG_READ_ONLY;
 	TC_PRINT("Mount as read-only\n");

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
@@ -25,6 +25,8 @@ static int create_file(const char *path)
 {
 	struct fs_file_t fp;
 	int res = 0;
+
+	fs_file_t_init(&fp);
 	if (!check_file_dir_exists(path)) {
 		res = fs_open(&fp, path, FS_O_CREATE | FS_O_RDWR);
 		if (!res) {

--- a/tests/subsys/fs/fat_fs_dual_drive/src/main.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/main.c
@@ -15,6 +15,8 @@
 
 void test_main(void)
 {
+	fs_file_t_init(&filep);
+
 	ztest_test_suite(fat_fs_basic_test,
 			 ztest_unit_test(test_fat_mount),
 			 ztest_unit_test(test_fat_file),

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -72,6 +72,7 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(test_mount,
 							fs_setup,
 							dummy_teardown),
+			 ztest_unit_test(test_fs_file_t_init),
 			 ztest_unit_test(test_file_statvfs),
 			 ztest_unit_test(test_mkdir),
 			 ztest_unit_test(test_opendir),

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -32,6 +32,7 @@ struct test_fs_data {
 	int reserve;
 };
 
+void test_fs_file_t_init(void);
 void test_fs_register(void);
 void test_mount(void);
 void test_file_statvfs(void);

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -436,6 +436,10 @@ void test_file_open(void)
 	ret = fs_open(&filep, TEST_FILE, FS_O_READ);
 	zassert_equal(ret, 0, "Fail to open file");
 
+	TC_PRINT("\nDouble-open\n");
+	ret = fs_open(&filep, TEST_FILE, FS_O_READ);
+	zassert_equal(ret, -EBUSY, "Expected -EBUSY, got %d", ret);
+
 	TC_PRINT("\nReopen the same file");
 	ret = fs_open(&filep, TEST_FILE, FS_O_READ);
 	zassert_not_equal(ret, 0, "Reopen an opend file");
@@ -826,6 +830,12 @@ void test_file_close(void)
 
 	ret = fs_close(&filep);
 	zassert_equal(ret, 0, "Fail to close file");
+
+	TC_PRINT("Reuse fs_file_t from closed file");
+	ret = fs_open(&filep, TEST_FILE, FS_O_READ);
+	zassert_equal(ret, 0, "Expected open to succeed, got %d", ret);
+	ret = fs_close(&filep);
+	zassert_equal(ret, 0, "Expected close to succeed, got %d", ret);
 
 	TC_PRINT("\nClose a closed file:\n");
 	filep.mp = &test_fs_mnt_1;

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -79,6 +79,21 @@ static struct fs_file_t err_filep;
 static const char test_str[] = "hello world!";
 
 /**
+ * @brief Test fs_file_t_init initializer
+ */
+void test_fs_file_t_init(void)
+{
+	struct fs_file_t fst;
+
+	memset(&fst, 0xff, sizeof(fst));
+
+	fs_file_t_init(&fst);
+	zassert_equal(fst.mp, NULL, "Expected to be initialized to NULL");
+	zassert_equal(fst.filep, NULL, "Expected to be initialized to NULL");
+	zassert_equal(fst.flags, 0, "Expected to be initialized to 0");
+}
+
+/**
  * @brief Test mount interface of filesystem
  *
  * @details
@@ -396,6 +411,7 @@ void test_file_open(void)
 	int ret;
 
 	TC_PRINT("\nOpen tests:\n");
+	fs_file_t_init(&filep);
 
 	TC_PRINT("\nOpen a file without a path\n");
 	ret = fs_open(&filep, NULL, FS_O_READ);
@@ -435,7 +451,7 @@ static int _test_file_write(void)
 	TC_PRINT("\nWrite tests:\n");
 
 	TC_PRINT("Write to an unopened file\n");
-	err_filep.mp = NULL;
+	fs_file_t_init(&err_filep);
 	brw = fs_write(&err_filep, (char *)test_str, strlen(test_str));
 	if (brw >= 0) {
 		return TC_FAIL;
@@ -500,7 +516,7 @@ static int _test_file_sync(void)
 	TC_PRINT("\nSync tests:\n");
 
 	TC_PRINT("sync an unopened file\n");
-	err_filep.mp = NULL;
+	fs_file_t_init(&err_filep);
 	ret = fs_sync(&err_filep);
 	if (!ret) {
 		return TC_FAIL;
@@ -513,6 +529,7 @@ static int _test_file_sync(void)
 		return TC_FAIL;
 	}
 
+	fs_file_t_init(&filep);
 	ret = fs_open(&filep, TEST_FILE, FS_O_RDWR);
 
 	for (;;) {
@@ -578,7 +595,7 @@ void test_file_read(void)
 	TC_PRINT("\nRead tests:\n");
 
 	TC_PRINT("Read an unopened file\n");
-	err_filep.mp = NULL;
+	fs_file_t_init(&err_filep);
 	brw = fs_read(&err_filep, read_buff, sz);
 	zassert_false(brw >= 0, "Can't read an unopened file");
 
@@ -637,7 +654,7 @@ static int _test_file_truncate(void)
 	TC_PRINT("\nTruncate tests: max file size is 128byte\n");
 
 	TC_PRINT("\nTruncate, seek, tell an unopened file\n");
-	err_filep.mp = NULL;
+	fs_file_t_init(&err_filep);
 	ret = fs_truncate(&err_filep, 256);
 	if (!ret) {
 		return TC_FAIL;
@@ -798,7 +815,7 @@ void test_file_close(void)
 	TC_PRINT("\nClose tests:\n");
 
 	TC_PRINT("Close an unopened file\n");
-	err_filep.mp = NULL;
+	fs_file_t_init(&err_filep);
 	ret = fs_close(&err_filep);
 	zassert_equal(ret, 0, "Should close an unopened file");
 

--- a/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
@@ -18,7 +18,9 @@ static struct fs_mount_t mp = {
 void test_mount_flags(void)
 {
 	int ret = 0;
-	struct fs_file_t fs = { 0 };
+	struct fs_file_t fs;
+
+	fs_file_t_init(&fs);
 
 	/* Format volume and add some files/dirs to check read-only flag */
 	mp.flags = 0;

--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -77,6 +77,7 @@ static int create_write_hello(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("creating and writing file\n");
 
 	zassert_equal(fs_open(&file,
@@ -144,6 +145,7 @@ static int verify_hello(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("opening and verifying file\n");
 
 	zassert_equal(fs_open(&file,
@@ -175,6 +177,7 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("seek and tell in file\n");
 
 	zassert_equal(fs_open(&file,
@@ -242,6 +245,7 @@ static int truncate_hello(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("truncate in file\n");
 
 	zassert_equal(fs_open(&file,
@@ -332,6 +336,7 @@ static int sync_goodbye(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("sync goodbye\n");
 
 	zassert_equal(fs_open(&file,
@@ -395,6 +400,7 @@ static int verify_goodbye(const struct fs_mount_t *mp)
 	struct testfs_path path;
 	struct fs_file_t file;
 
+	fs_file_t_init(&file);
 	TC_PRINT("verify goodbye\n");
 
 	zassert_equal(fs_open(&file,

--- a/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
@@ -62,6 +62,7 @@ static int check_mkdir(struct fs_mount_t *mp)
 	struct fs_file_t file;
 	struct testfs_path fpath;
 
+	fs_file_t_init(&file);
 	zassert_equal(fs_open(&file,
 			      testfs_path_extend(testfs_path_copy(&fpath,
 								  &dpath),

--- a/tests/subsys/fs/littlefs/src/test_lfs_perf.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_perf.c
@@ -36,6 +36,7 @@ static int write_read(const char *tag,
 	int rc;
 	int rv = TC_FAIL;
 
+	fs_file_t_init(&file);
 	TC_PRINT("clearing %s for %s write/read test\n",
 		 mp->mnt_point, tag);
 	if (testfs_lfs_wipe_partition(mp) != TC_PASS) {

--- a/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
@@ -26,6 +26,7 @@ void test_fs_mount_flags(void)
 	int ret = 0;
 	struct fs_file_t fs;
 
+	fs_file_t_init(&fs);
 	cleanup(mp);
 
 	/* Test FS_MOUNT_FLAG_NO_FORMAT flag */

--- a/tests/subsys/fs/littlefs/src/testfs_util.c
+++ b/tests/subsys/fs/littlefs/src/testfs_util.c
@@ -232,6 +232,7 @@ int testfs_build(struct testfs_path *root,
 		if (TESTFS_BCMD_IS_FILE(cp)) {
 			struct fs_file_t file;
 
+			fs_file_t_init(&file);
 			rc = fs_open(&file,
 				     testfs_path_extend(root,
 							cp->name,
@@ -296,6 +297,7 @@ static int check_layout_entry(struct testfs_path *pp,
 	if (statp->type == FS_DIR_ENTRY_FILE) {
 		struct fs_file_t file;
 
+		fs_file_t_init(&file);
 		rc = fs_open(&file, pp->path, FS_O_CREATE | FS_O_RDWR);
 		if (rc < 0) {
 			TC_PRINT("%s: content check open failed: %d\n",

--- a/tests/subsys/fs/multi-fs/src/test_common_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_dir.c
@@ -19,6 +19,7 @@ int test_mkdir(const char *dir_path, const char *file)
 	struct fs_file_t filep;
 	char file_path[PATH_MAX] = { 0 };
 
+	fs_file_t_init(&filep);
 	res = sprintf(file_path, "%s/%s", dir_path, file);
 	__ASSERT_NO_MSG(res < sizeof(file_path));
 
@@ -48,6 +49,7 @@ int test_mkdir(const char *dir_path, const char *file)
 	TC_PRINT("Testing write to file %s\n", file_path);
 	res = test_file_write(&filep, "NOTHING");
 	if (res) {
+		fs_close(&filep);
 		return res;
 	}
 

--- a/tests/subsys/fs/multi-fs/src/test_fat_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_file.c
@@ -14,6 +14,7 @@ static const char *test_str = "Hello world FAT";
 
 void test_fat_open(void)
 {
+	fs_file_t_init(&test_file);
 	zassert_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
 		NULL);
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
@@ -14,6 +14,7 @@ static const char *test_str = "Hello world LITTLEFS";
 
 void test_littlefs_open(void)
 {
+	fs_file_t_init(&test_file);
 	zassert_true(test_file_open(&test_file, TEST_FILE_PATH) == TC_PASS,
 		NULL);
 }

--- a/tests/subsys/settings/fs/src/settings_test_fs.c
+++ b/tests/subsys/settings/fs/src/settings_test_fs.c
@@ -151,6 +151,8 @@ int fsutil_read_file(const char *path, off_t offset, size_t len, void *dst,
 	int rc;
 	ssize_t r_len = 0;
 
+	fs_file_t_init(&file);
+
 	rc = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {
 		return rc;
@@ -171,6 +173,8 @@ int fsutil_write_file(const char *path, const void *data, size_t len)
 {
 	struct fs_file_t file;
 	int rc;
+
+	fs_file_t_init(&file);
 
 	rc = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
 	if (rc != 0) {


### PR DESCRIPTION
fs: Fix fs_open resource leak when invoked on fs_file_t object in use

Fixes problem when fs_open invoked on fs_file_t object, which is already
holding information on opened file, overwrites references to other
memory objects within the fs_file_t object causing resource leak.
If fs_open is invoked on already used fs_file_t object, it will return
-EBUSY.

Note: The change requires that all fs_file_t objects should be
initialized to 0.

Fixes: #29478