### PR TITLE
linker: remove asterisk from IRQ/ISR section name macro

### DIFF
--- a/arch/arc/core/vector_table.ld
+++ b/arch/arc/core/vector_table.ld
@@ -8,4 +8,4 @@
 
 KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
-KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))
+KEEP(*(_IRQ_VECTOR_TABLE_SECTION_SYMS))

--- a/arch/arm/core/aarch32/vector_table.ld
+++ b/arch/arm/core/aarch32/vector_table.ld
@@ -32,7 +32,7 @@ _vector_start = .;
 KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
 
-KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))
+KEEP(*(_IRQ_VECTOR_TABLE_SECTION_SYMS))
 
 KEEP(*(.vectors))
 

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -171,7 +171,7 @@ SECTIONS
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
     {
-        KEEP(*(_IRQ_VECTOR_TABLE_SECTION_NAME))
+        KEEP(*(_IRQ_VECTOR_TABLE_SECTION_SYMS))
 
         KEEP(*(.openocd_dbg))
         KEEP(*(".openocd_dbg.*"))

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -9,7 +9,7 @@
 		 * instruction.  See include/sw_isr_table.h.
 		 */
 		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
-		*(_SW_ISR_TABLE_SECTION_NAME)
+		*(_SW_ISR_TABLE_SECTION_SYMS)
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -26,7 +26,7 @@
 		 * instruction.  See include/sw_isr_table.h.
 		 */
 		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
-		*(_SW_ISR_TABLE_SECTION_NAME)
+		*(_SW_ISR_TABLE_SECTION_SYMS)
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -31,8 +31,11 @@
 #define _UNDEFINED_SECTION_NAME undefined
 
 /* Interrupts */
-#define _IRQ_VECTOR_TABLE_SECTION_NAME	.gnu.linkonce.irq_vector_table*
-#define _SW_ISR_TABLE_SECTION_NAME	.gnu.linkonce.sw_isr_table*
+#define _IRQ_VECTOR_TABLE_SECTION_NAME	.gnu.linkonce.irq_vector_table
+#define _IRQ_VECTOR_TABLE_SECTION_SYMS	.gnu.linkonce.irq_vector_table*
+
+#define _SW_ISR_TABLE_SECTION_NAME	.gnu.linkonce.sw_isr_table
+#define _SW_ISR_TABLE_SECTION_SYMS	.gnu.linkonce.sw_isr_table*
 
 /* Architecture-specific sections */
 #if defined(CONFIG_ARM)


### PR DESCRIPTION
Both _IRQ_VECTOR_TABLE_SECTION_NAME and _SW_ISR_TABLE_SECTION_NAME
are defined with asterisk at the end in an attempt to include
all related symbols in the linker script. However, these two
macros are also being used in the source code to specify
the destination sections for variables. Asterisks in the name
results in older GCC (4.x) complaining about those asterisks.
So create new macros for use in linker script, and keep
the names asterisk free.

Fixes #29936

Signed-off-by: Daniel Leung <daniel.leung@intel.com>