### PR TITLE
ARC: soc: hsdk: add MWDT compiler options

### DIFF
--- a/soc/arc/snps_arc_hsdk/CMakeLists.txt
+++ b/soc/arc/snps_arc_hsdk/CMakeLists.txt
@@ -2,11 +2,20 @@
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
-# -mcpu=hs38_linux includes -matomic -mcode-density -mdiv-rem
-# -mswap -mnorm -mll64 -mmpy-option=9 -mfpu=fpud_all
-zephyr_cc_option(-mcpu=${GCC_M_CPU})
-zephyr_cc_option(-mno-sdata)
-zephyr_cc_option_ifdef(CONFIG_FPU -mfpu=fpud_all)
+if(COMPILER STREQUAL gcc)
+  # GNU compiler options
+  # -mcpu=hs38_linux includes -matomic -mcode-density -mdiv-rem
+  # -mswap -mnorm -mll64 -mmpy-option=9 -mfpu=fpud_all
+  zephyr_cc_option(-mcpu=${GCC_M_CPU})
+  zephyr_cc_option(-mno-sdata)
+  zephyr_cc_option_ifdef(CONFIG_FPU -mfpu=fpud_all)
+else()
+  # MWDT compiler options
+  zephyr_cc_option(-arcv2hs -core2 -Xatomic -Xll64 -Xunaligned -Xcode_density
+		   -Xdiv_rem=radix4 -Xswap -Xbitscan -Xmpy_option=qmpyh
+		   -Xshift_assist -Xbarrel_shifter -Xtimer0 -Xtimer1 -Xrtc)
+  zephyr_cc_option_ifdef(CONFIG_FPU -Xfpu_mac -Xfpud_div)
+endif()
 
 zephyr_sources(
   soc.c


### PR DESCRIPTION
HSDK board misses MWDT compiler options, so CCAC uses default ones (which doesn't match HSDK HW).

Add MWDT compiler options.