### PR TITLE
pthread: facilitate dynamically allocated thread stacks

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -233,6 +233,14 @@ extern void k_thread_foreach_unlocked(
  */
 #define K_INHERIT_PERMS (BIT(3))
 
+/**
+ * @brief dynamically allocated stack
+ *
+ * This flag indicates that a thread stack has been heap-allocated with
+ * @ref k_malloc.
+ */
+#define K_STACK_ON_HEAP (BIT(4))
+
 #ifdef CONFIG_X86
 /* x86 Bitmask definitions for threads user options */
 

--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -477,6 +477,7 @@ static inline int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
 	return 0;
 }
 
+int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
 int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
 int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy);

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -39,6 +39,30 @@ config SEM_VALUE_MAX
 	help
 	  Maximum semaphore count in POSIX compliant Application.
 
+config PTHREAD_DYNAMIC_STACKS
+	bool "Support for dynamic stacks"
+	select THREAD_STACK_INFO
+	default n
+	help
+	  POSIX 1003.1 allows a NULL pthread_attr_t* to be passed to
+	  pthread_create(3). However, Zephyr has traditionally required
+	  that the caller statically allocate a stack and pass it in via the
+	  pthread_attr_t*. With this option selected, NULL will be permitted
+	  and a suitable stack will be automatically allocated and assigned,
+	  inheriting permissions from the calling thread.
+
+if PTHREAD_DYNAMIC_STACK
+config PTHREAD_DYNAMIC_STACK_DEFAULT_SIZE
+	int "Default size for a dynamic pthread stack (in bytes)"
+	default 1024
+	help
+	  This value is used for the default size of dynamically-allocated
+	  stacks. However, users may still specify the size of
+	  dynamically-allocated stacks via pthread_attr_setstacksize(3)
+	  prior to calling pthread_create(3).
+
+endif # PTHREAD_DYNAMIC_STACK
+
 endif # PTHREAD_IPC
 
 config POSIX_CLOCK

--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -19,6 +19,7 @@ extern void test_posix_pthread_execution(void);
 extern void test_posix_pthread_termination(void);
 extern void test_posix_multiple_threads_single_key(void);
 extern void test_posix_single_thread_multiple_keys(void);
+extern void test_posix_thread_attr_stacksize(void);
 extern void test_nanosleep_NULL_NULL(void);
 extern void test_nanosleep_NULL_notNULL(void);
 extern void test_nanosleep_notNULL_NULL(void);
@@ -42,6 +43,7 @@ void test_main(void)
 			ztest_unit_test(test_posix_pthread_termination),
 			ztest_unit_test(test_posix_multiple_threads_single_key),
 			ztest_unit_test(test_posix_single_thread_multiple_keys),
+			ztest_unit_test(test_posix_thread_attr_stacksize),
 			ztest_unit_test(test_posix_clock),
 			ztest_unit_test(test_posix_semaphore),
 			ztest_unit_test(test_posix_normal_mutex),

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -36,3 +36,18 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_TEST_HW_STACK_PROTECTION=n
+  portability.posix.common.dynamic_stack:
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=n
+      - CONFIG_PTHREAD_DYNAMIC_STACKS=y
+      - CONFIG_IDLE_STACK_SIZE=768
+      - CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE=16384
+  portability.posix.common.dynamic_stack.newlib:
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_PTHREAD_DYNAMIC_STACKS=y
+      - CONFIG_IDLE_STACK_SIZE=768
+      - CONFIG_HEAP_MEM_POOL_SIZE=16384


### PR DESCRIPTION
This change allows users to call `pthread_create(3)` with the `pthread_attr_t` argument equal to `NULL`, or with the `pthread_attr_t` argument specifying a `NULL` stack.

If either of the above to requirements are met, then a stack will be heap-allocated internally and freed again after the thread has terminated.

This helps the Zephyr implementation of `pthread_create(3)` become more compliant with the normative spec.

Fixes #25973
