### PR TITLE
drivers: gpio_nrfx: Allocate GPIOTE channels with nrfx

### DIFF
--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -5,6 +5,7 @@ menuconfig GPIO_NRFX
 	bool "nRF GPIO driver"
 	default y
 	depends on SOC_FAMILY_NRF
+	select NRFX_GPIOTE
 	help
 	  Enable GPIO driver for nRF line of MCUs.
 


### PR DESCRIPTION
The existing implementation of GPIOTE channel allocation does not take into account any channels preallocated for other modules. It might easily lead to allocating channels that have already been taken by other modules, thus breaking them. This PR fixes such behavior by using GPIOTE channel allocation mechanism provided by the nrfx driver, which can be used by other modules as well.