### PR TITLE
tests/drivers: pwm_api: Document how to tune test for stm32 targets

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -76,6 +76,15 @@
 #elif defined CONFIG_BOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS
 #define DEFAULT_PWM_PORT 2 /* TCC1/WO[2] on PA18 (D7) */
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_pwm)
+/* Default port should be adapted per board to fit the channel
+ * associated to the PWM pin. For intsance, for following device,
+ *      pwm1: pwm {
+ *              status = "okay";
+ *              pinctrl-0 = <&tim1_ch3_pe13>;
+ *      };
+ * the following should be used:
+ * #define DEFAULT_PWM_PORT 3
+ */
 #define DEFAULT_PWM_PORT 1
 #else
 #define DEFAULT_PWM_PORT 0


### PR DESCRIPTION
The way the test is implemented requires some adaptation to
be effective on all STM32 boards.
I'm not adding per board code on purpose, as this would be a
never ending story.

Fixes #31582

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>