### PR TITLE
modules/Kconfig.nordic: Enable temperature sensor for SL opensource

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -61,6 +61,8 @@ choice NRF_802154_SL_TYPE
 
 config NRF_802154_SL_OPENSOURCE
 	bool "nRF IEEE 802.15.4 Open source Service Layer"
+	select SENSOR
+	select TEMP_NRF5
 
 endchoice
 

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: f0d54d8449acbee49b3cebcef0e3e56640c50277
+      revision: pull/88/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This manifest update corresponds to PR#88 into hal_nordic sub-repo, that provide the following commit:

-  drivers: Add temperature platform implementation for Zephyr
This commit adds temperature platform implementation utilizing
temperature sensor provided by Zephyr.