### PR TITLE
logging: Add default log level option to log_config template

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -536,6 +536,7 @@ UNDEF_KCONFIG_WHITELIST = {
     "FLAG",  # Used as an example
     "FOO",
     "FOO_LOG_LEVEL",
+    "FOO_LOG_LEVEL_DBG",
     "FOO_SETTING_1",
     "FOO_SETTING_2",
     "LIS2DW12_INT_PIN",

--- a/subsys/logging/Kconfig.template.log_config
+++ b/subsys/logging/Kconfig.template.log_config
@@ -1,8 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Template for setting module log level. Default log level is set to INF with
+# optional overwrite. Following variables need to be configured prior to
+# including the template file:
+#
+# module - module name used for prefixing log level defines. Capital letters
+# should be used.
+#
+# module-str - module name as it that will be added to the help message.
+#
+# default-log-level - optionally specifies default level setting. It accepts
+# following values: OFF, ERR, WRN, INF, DBG. INF level is the default when
+# variable is not set.
+#
+# Example:
+#
+#   module = FOO
+#   module-str = foo
+#   default-log-level = WRN
+#   source "subsys/logging/Kconfig.template.log_config"
+#
+# Following example will create define CONFIG_FOO_LOG_LEVEL 2 which shall be
+# used when module is registered,
+# e.g. LOG_MODULE_REGISTER(foo, CONFIG_FOO_LOG_LEVEL);
+#
+# It will also create choice menu for menuconfig configuration. In order to
+# overwrite the level in a configuration file specific level option must be
+# enabled, e.g. setting debug level for foo module is done by:
+# CONFIG_FOO_LOG_LEVEL_DBG=y
+
+config $(module)_LOG_LEVEL_OFF_DUMMY
+	bool
+
+config $(module)_LOG_LEVEL_ERR_DUMMY
+	bool
+
+config $(module)_LOG_LEVEL_WRN_DUMMY
+	bool
+
+config $(module)_LOG_LEVEL_INF_DUMMY
+	bool
+
+config $(module)_LOG_LEVEL_DBG_DUMMY
+	bool
+
+config $(module)_LOG_LEVEL_$(default-log-level)_DUMMY
+	bool
+	default y
+
 choice
 	prompt "Max compiled-in log level for $(module-str)"
-	default $(module)_LOG_LEVEL_INF
+	default $(module)_LOG_LEVEL_OFF if $(module)_LOG_LEVEL_OFF_DUMMY
+	default $(module)_LOG_LEVEL_ERR if $(module)_LOG_LEVEL_ERR_DUMMY
+	default $(module)_LOG_LEVEL_WRN if $(module)_LOG_LEVEL_WRN_DUMMY
+	default $(module)_LOG_LEVEL_INF if $(module)_LOG_LEVEL_INF_DUMMY
+	default $(module)_LOG_LEVEL_DBG if $(module)_LOG_LEVEL_DBG_DUMMY
+	default $(module)_LOG_LEVEL_INF if $(module)_LOG_LEVEL__DUMMY
 	depends on LOG
 
 config $(module)_LOG_LEVEL_OFF


### PR DESCRIPTION
Template was setting INF level as a default one and it was not possible
to change that. Extended it by adding optional default-log-level variable
which can pass default log level to the template.

Additionally, added documentation in the template file.

Here is an example where logging are fixed to ERR probably because template could not be used and INF was not an option since UART is typically used for logging/console:
https://github.com/zephyrproject-rtos/zephyr/blob/0426a5a682e5c1b9620042f0410d6c7f1b10cc27/drivers/serial/uart_nrfx_uarte.c#L19
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>