### PR TITLE
samples/subsys/mcumgr/smp_svr: disable log over shell

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-shell.conf
@@ -1,2 +1,5 @@
 # Enable the shell mcumgr transport.
 CONFIG_MCUMGR_SMP_SHELL=y
+
+# mcumgr-cli application doesn't accepts log in the channel it uses
+CONFIG_SHELL_LOG_BACKEND=n


### PR DESCRIPTION
Mcumgr-cli application doesn't accept log on the communication
channel. Since #30370 was merged log messages are generated from
MCUBOOT_UTIL by default. That made `mcumgr image upload` failing.

Patch disables logging via shell which cure the issue.
It is not necessary if another application on the host intercepts
log messages (like picocom can).

fixes #31629

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>