### PR TITLE
document memory barrier requirements for irq/lock unlock and fix them on SPARC

### DIFF
--- a/include/arch/sparc/arch.h
+++ b/include/arch/sparc/arch.h
@@ -66,7 +66,8 @@ static ALWAYS_INLINE unsigned int z_sparc_set_pil_inline(unsigned int newpil)
 	__asm__ volatile (
 		"ta %1\nnop\n" :
 		"=r" (oldpil) :
-		"i" (SPARC_SW_TRAP_SET_PIL), "r" (oldpil)
+		"i" (SPARC_SW_TRAP_SET_PIL), "r" (oldpil) :
+		"memory"
 		);
 	return oldpil;
 }

--- a/include/irq.h
+++ b/include/irq.h
@@ -187,6 +187,10 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
  * whether interrupts were locked prior to the call. The lock-out key must be
  * passed to irq_unlock() to re-enable interrupts.
  *
+ * @note
+ * This routine must also serve as a memory barrier to ensure the uniprocessor
+ * implementation of `k_spinlock_t` is correct.
+ *
  * This routine can be called recursively, as long as the caller keeps track
  * of each lock-out key that is generated. Interrupts are re-enabled by
  * passing each of the keys to irq_unlock() in the reverse order they were
@@ -230,6 +234,10 @@ unsigned int z_smp_global_lock(void);
  * the associated lock-out key. The caller must call the routine once for
  * each time it called irq_lock(), supplying the keys in the reverse order
  * they were acquired, before interrupts are enabled.
+ *
+ * @note
+ * This routine must also serve as a memory barrier to ensure the uniprocessor
+ * implementation of `k_spinlock_t` is correct.
  *
  * This routine can only be invoked from supervisor mode. Some architectures
  * (for example, ARM) will fail silently if invoked from user mode instead


### PR DESCRIPTION
Correct functioning of spinlocks requires that they be memory barriers.  With CONFIG_SMP=y this falls out as a consequence of using sequentially consistent atomic operations to ensure all processors are locked out.  With CONFIG_SMP=n a spinlock uses arch_irq_lock/unlock(), so the barrier behavior must come from that function.
    
As arch_irq_lock/unlock() delegates to irq_lock/unlock() for documentation, document the barrier requirement there.

Most architectures achieve the barrier by using the GCC extended asm syntax to force a compiler soft barrier at the point the interrupt status is changing.  This clobber was missing from the SPARC definition, so add it.
