### PR TITLE
doc: west: Fix config overrides

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -392,14 +392,14 @@ Configuration Overrides
 
 The CMake cache contains default values West uses while flashing, such
 as where the board directory is on the file system, the path to the
-kernel binaries to flash in several formats, and more. You can
+zephyr binaries to flash in several formats, and more. You can
 override any of this configuration at runtime with additional options.
 
 For example, to override the HEX file containing the Zephyr image to
 flash (assuming your runner expects a HEX file), but keep other
 flash configuration at default values::
 
-  west flash --kernel-hex path/to/some/other.hex
+  west flash --hex-file path/to/some/other.hex
 
 The ``west flash -h`` output includes a complete list of overrides
 supported by all runners.
@@ -489,15 +489,15 @@ Configuration Overrides
 
 The CMake cache contains default values West uses for debugging, such
 as where the board directory is on the file system, the path to the
-kernel binaries containing symbol tables, and more. You can override
+zephyr binaries containing symbol tables, and more. You can override
 any of this configuration at runtime with additional options.
 
 For example, to override the ELF file containing the Zephyr binary and
 symbol tables (assuming your runner expects an ELF file), but keep
 other debug configuration at default values::
 
-  west debug --kernel-elf path/to/some/other.elf
-  west debugserver --kernel-elf path/to/some/other.elf
+  west debug --elf-file path/to/some/other.elf
+  west debugserver --elf-file path/to/some/other.elf
 
 The ``west debug -h`` output includes a complete list of overrides
 supported by all runners.


### PR DESCRIPTION
Fix the documentation of the usage of `--*-file`, which were renamed from
`--kernel-*`.

Fixes #31630.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>