### PR TITLE
net: coap: acknowledgement initialization helper function

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -375,6 +375,24 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
 		     const uint8_t *token, uint8_t code, uint16_t id);
 
 /**
+ * @brief Create a new CoAP Acknowledgment message for given request.
+ *
+ * This function works like @ref coap_packet_init, filling CoAP header type,
+ * CoAP header token, and CoAP header message id fields according to
+ * acknowledgment rules.
+ *
+ * @param cpkt New packet to be initialized using the storage from @a data.
+ * @param req CoAP request packet that is being acknowledged
+ * @param data Data that will contain a CoAP packet information
+ * @param max_len Maximum allowable length of data
+ * @param code CoAP header code
+ *
+ * @return 0 in case of success or negative in case of error.
+ */
+int coap_ack_init(struct coap_packet *cpkt, const struct coap_packet *req,
+		  uint8_t *data, uint16_t max_len, uint8_t code);
+
+/**
  * @brief Returns a randomly generated array of 8 bytes, that can be
  * used as a message's token.
  *

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -149,6 +149,22 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
 	return 0;
 }
 
+int coap_ack_init(struct coap_packet *cpkt, const struct coap_packet *req,
+		  uint8_t *data, uint16_t max_len, uint8_t code)
+{
+	uint16_t id;
+	uint8_t ver;
+	uint8_t tkl;
+	uint8_t token[COAP_TOKEN_MAX_LEN];
+
+	ver = coap_header_get_version(req);
+	id = coap_header_get_id(req);
+	tkl = code ? coap_header_get_token(req, token) : 0;
+
+	return coap_packet_init(cpkt, data, max_len, ver, COAP_TYPE_ACK, tkl,
+				token, code, id);
+}
+
 static void option_header_set_delta(uint8_t *opt, uint8_t delta)
 {
 	*opt = (delta & 0xF) << 4;


### PR DESCRIPTION
When handling CoAP Confirmable requests, there is a common
Acknowledgement initialization procedure that repeats for each
response packet initialization. This patch adds a function that
simplifies Acknowledgement initialization procedure encapsulating
repeating code.