### PR TITLE
net: coap: Define default CoAP version

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -77,6 +77,8 @@ enum coap_method {
 
 #define COAP_REQUEST_MASK 0x07
 
+#define COAP_VERSION_1 1U
+
 /**
  * @brief CoAP packets may be of one of these types.
  */

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -141,7 +141,7 @@ static int send_simple_coap_request(uint8_t method)
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
 			     COAP_VERSION_1, COAP_TYPE_CON,
-			     8, coap_next_token(),
+			     COAP_TOKEN_MAX_LEN, coap_next_token(),
 			     method, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -328,7 +328,7 @@ static int send_large_coap_request(void)
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
 			     COAP_VERSION_1, COAP_TYPE_CON,
-			     8, coap_next_token(),
+			     COAP_TOKEN_MAX_LEN, coap_next_token(),
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -486,7 +486,7 @@ static int send_obs_coap_request(void)
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
 			     COAP_VERSION_1, COAP_TYPE_CON,
-			     8, coap_next_token(),
+			     COAP_TOKEN_MAX_LEN, coap_next_token(),
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -532,7 +532,7 @@ static int send_obs_reset_coap_request(void)
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
 			     COAP_VERSION_1, COAP_TYPE_RESET,
-			     8, coap_next_token(),
+			     COAP_TOKEN_MAX_LEN, coap_next_token(),
 			     0, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -140,7 +140,8 @@ static int send_simple_coap_request(uint8_t method)
 	}
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_CON, 8, coap_next_token(),
+			     COAP_VERSION_1, COAP_TYPE_CON,
+			     8, coap_next_token(),
 			     method, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -326,7 +327,8 @@ static int send_large_coap_request(void)
 	}
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_CON, 8, coap_next_token(),
+			     COAP_VERSION_1, COAP_TYPE_CON,
+			     8, coap_next_token(),
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -398,7 +400,7 @@ static int send_obs_reply_ack(uint16_t id, uint8_t *token, uint8_t tkl)
 	}
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, token, 0, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token, 0, id);
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
 		goto end;
@@ -483,7 +485,8 @@ static int send_obs_coap_request(void)
 	}
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_CON, 8, coap_next_token(),
+			     COAP_VERSION_1, COAP_TYPE_CON,
+			     8, coap_next_token(),
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");
@@ -528,7 +531,8 @@ static int send_obs_reset_coap_request(void)
 	}
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_RESET, 8, coap_next_token(),
+			     COAP_VERSION_1, COAP_TYPE_RESET,
+			     8, coap_next_token(),
 			     0, coap_next_id());
 	if (r < 0) {
 		LOG_ERR("Failed to init CoAP message");

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -234,8 +234,7 @@ static int piggyback_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -307,8 +306,7 @@ static int test_del(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_DELETED, id);
 	if (r < 0) {
 		goto end;
@@ -363,8 +361,7 @@ static int test_put(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CHANGED, id);
 	if (r < 0) {
 		goto end;
@@ -424,8 +421,7 @@ static int test_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CREATED, id);
 	if (r < 0) {
 		goto end;
@@ -501,8 +497,7 @@ static int query_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *) token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -578,8 +573,7 @@ static int location_query_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CREATED, id);
 	if (r < 0) {
 		goto end;
@@ -635,8 +629,7 @@ static int separate_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *)token, 0, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token, 0, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -654,8 +647,7 @@ static int separate_get(struct coap_resource *resource,
 
 	/* Do not free and allocate "data" again, re-use the buffer */
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -735,8 +727,7 @@ static int large_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *) token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		return -EINVAL;
@@ -852,8 +843,8 @@ static int large_update_put(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *) token, code, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
+			     code, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -934,8 +925,8 @@ static int large_create_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *)token, code, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
+			     code, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -1046,8 +1037,7 @@ static int send_notification_packet(const struct sockaddr *addr,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, type, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -1179,8 +1169,7 @@ static int core_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
-			     (uint8_t *)token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		r = -EINVAL;

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -234,7 +234,8 @@ static int piggyback_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -306,7 +307,8 @@ static int test_del(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_DELETED, id);
 	if (r < 0) {
 		goto end;
@@ -361,7 +363,8 @@ static int test_put(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CHANGED, id);
 	if (r < 0) {
 		goto end;
@@ -421,7 +424,8 @@ static int test_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CREATED, id);
 	if (r < 0) {
 		goto end;
@@ -497,7 +501,8 @@ static int query_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *) token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *) token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -573,7 +578,8 @@ static int location_query_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CREATED, id);
 	if (r < 0) {
 		goto end;
@@ -629,7 +635,8 @@ static int separate_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *)token, 0, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *)token, 0, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -647,7 +654,8 @@ static int separate_get(struct coap_resource *resource,
 
 	/* Do not free and allocate "data" again, re-use the buffer */
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -727,7 +735,8 @@ static int large_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *) token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *) token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		return -EINVAL;
@@ -843,7 +852,8 @@ static int large_update_put(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *) token, code, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *) token, code, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -924,7 +934,8 @@ static int large_create_post(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *)token, code, id);
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *)token, code, id);
 	if (r < 0) {
 		goto end;
 	}
@@ -1035,7 +1046,8 @@ static int send_notification_packet(const struct sockaddr *addr,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, type, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, type, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -1167,7 +1179,8 @@ static int core_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, MAX_COAP_MSG_LEN,
-			     1, COAP_TYPE_ACK, tkl, (uint8_t *)token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl,
+			     (uint8_t *)token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		r = -EINVAL;

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -265,7 +265,7 @@ static int send_request(enum coap_msgtype msgtype, enum coap_method method,
 
 	ret = coap_packet_init(&request_packet, data, MAX_PAYLOAD_SIZE,
 			       COAP_VERSION_1, COAP_TYPE_CON,
-			       8, coap_next_token(), method,
+			       COAP_TOKEN_MAX_LEN, coap_next_token(), method,
 			       coap_next_id());
 	if (ret < 0) {
 		LOG_ERR("Could not init packet");

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -263,8 +263,9 @@ static int send_request(enum coap_msgtype msgtype, enum coap_method method,
 		goto error;
 	}
 
-	ret = coap_packet_init(&request_packet, data, MAX_PAYLOAD_SIZE, 1,
-			       COAP_TYPE_CON, 8, coap_next_token(), method,
+	ret = coap_packet_init(&request_packet, data, MAX_PAYLOAD_SIZE,
+			       COAP_VERSION_1, COAP_TYPE_CON,
+			       8, coap_next_token(), method,
 			       coap_next_id());
 	if (ret < 0) {
 		LOG_ERR("Could not init packet");

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -41,9 +41,6 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #define COAP_OPTION_EXT_15 15
 #define COAP_OPTION_EXT_269 269
 
-/* CoAP Version */
-#define COAP_VERSION		1
-
 /* CoAP Payload Marker */
 #define COAP_MARKER		0xFF
 

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -456,7 +456,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 	struct coap_option query;
 	unsigned int num_queries;
 	size_t offset;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint16_t remaining;
 	uint16_t id;
 	uint8_t tkl;
@@ -653,7 +653,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 			     uint8_t *data, uint16_t len)
 {
 	struct coap_option query;
-	uint8_t token[8];
+	uint8_t token[COAP_TOKEN_MAX_LEN];
 	uint16_t id;
 	uint8_t tkl;
 	uint8_t num_queries;

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -495,7 +495,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 
 	num_queries = r;
 
-	r = coap_packet_init(response, data, len, 1, COAP_TYPE_ACK,
+	r = coap_packet_init(response, data, len, COAP_VERSION_1, COAP_TYPE_ACK,
 			     tkl, token, COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		goto end;
@@ -676,7 +676,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 
 	num_queries = r;
 
-	r = coap_packet_init(response, data, len, 1, COAP_TYPE_ACK,
+	r = coap_packet_init(response, data, len, COAP_VERSION_1, COAP_TYPE_ACK,
 			     tkl, token, COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
 		return r;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -940,7 +940,8 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 	}
 
 	r = coap_packet_init(&msg->cpkt, msg->msg_data, sizeof(msg->msg_data),
-			     1, msg->type, tokenlen, token, msg->code, msg->mid);
+			     COAP_VERSION_1, msg->type, tokenlen, token,
+			     msg->code, msg->mid);
 	if (r < 0) {
 		LOG_ERR("coap packet init error (err:%d)", r);
 		goto cleanup;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -73,7 +73,7 @@ static int test_build_empty_pdu(void)
 	}
 
 	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_CON, 0, NULL,
+			     COAP_VERSION_1, COAP_TYPE_CON, 0, NULL,
 			     COAP_METHOD_GET, 0);
 	if (r < 0) {
 		TC_PRINT("Could not initialize packet\n");
@@ -117,7 +117,7 @@ static int test_build_simple_pdu(void)
 	}
 
 	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_NON_CON,
+			     COAP_VERSION_1, COAP_TYPE_NON_CON,
 			     strlen(token), (uint8_t *)token,
 			     COAP_RESPONSE_CODE_PROXYING_NOT_SUPPORTED,
 			     0x1234);
@@ -615,7 +615,7 @@ static int prepare_block1_request(struct coap_packet *req,
 		goto done;
 	}
 
-	r = coap_packet_init(req, data, COAP_BUF_SIZE, 1,
+	r = coap_packet_init(req, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_CON, strlen(token),
 			     (uint8_t *) token, COAP_METHOD_POST,
 			     coap_next_id());
@@ -687,7 +687,7 @@ static int prepare_block1_response(struct coap_packet *rsp,
 	id = coap_header_get_id(req);
 	tkl = coap_header_get_token(req, token);
 
-	r = coap_packet_init(rsp, data, COAP_BUF_SIZE, 1,
+	r = coap_packet_init(rsp, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_CREATED, id);
 	if (r < 0) {
@@ -850,7 +850,7 @@ static int prepare_block2_request(struct coap_packet *req,
 		goto done;
 	}
 
-	r = coap_packet_init(req, data, COAP_BUF_SIZE, 1,
+	r = coap_packet_init(req, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_CON, strlen(token),
 			     (uint8_t *) token, COAP_METHOD_GET,
 			     coap_next_id());
@@ -900,7 +900,7 @@ static int prepare_block2_response(struct coap_packet *rsp,
 	id = coap_header_get_id(req);
 	tkl = coap_header_get_token(req, token);
 
-	r = coap_packet_init(rsp, data, COAP_BUF_SIZE, 1,
+	r = coap_packet_init(rsp, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_CONTENT, id);
 	if (r < 0) {
@@ -1085,8 +1085,8 @@ static int test_retransmit_second_round(void)
 
 	id = coap_next_id();
 
-	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_CON, 0, coap_next_token(),
+	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1,
+			     COAP_TYPE_CON, 0, coap_next_token(),
 			     COAP_METHOD_GET, id);
 	if (r < 0) {
 		TC_PRINT("Could not initialize packet\n");
@@ -1125,7 +1125,7 @@ static int test_retransmit_second_round(void)
 	}
 
 	r = coap_packet_init(&rsp, rsp_data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_ACK, 0, NULL,
+			     COAP_VERSION_1, COAP_TYPE_ACK, 0, NULL,
 			     COAP_METHOD_GET, id);
 	if (r < 0) {
 		TC_PRINT("Could not initialize packet\n");
@@ -1228,7 +1228,7 @@ static int server_resource_1_get(struct coap_resource *resource,
 	}
 
 	r = coap_packet_init(&response, data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_ACK, tkl, token,
+			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
 			     COAP_RESPONSE_CODE_OK, id);
 	if (r < 0) {
 		TC_PRINT("Unable to initialize packet.\n");
@@ -1377,7 +1377,7 @@ static int test_observer_client(void)
 	}
 
 	r = coap_packet_init(&req, data, COAP_BUF_SIZE,
-			     1, COAP_TYPE_CON,
+			     COAP_VERSION_1, COAP_TYPE_CON,
 			     strlen(token), (uint8_t *)token,
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -118,7 +118,7 @@ static int test_build_simple_pdu(void)
 
 	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE,
 			     COAP_VERSION_1, COAP_TYPE_NON_CON,
-			     strlen(token), (uint8_t *)token,
+			     strlen(token), token,
 			     COAP_RESPONSE_CODE_PROXYING_NOT_SUPPORTED,
 			     0x1234);
 	if (r < 0) {
@@ -617,7 +617,7 @@ static int prepare_block1_request(struct coap_packet *req,
 
 	r = coap_packet_init(req, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_CON, strlen(token),
-			     (uint8_t *) token, COAP_METHOD_POST,
+			     token, COAP_METHOD_POST,
 			     coap_next_id());
 	if (r < 0) {
 		TC_PRINT("Unable to initialize request\n");
@@ -852,7 +852,7 @@ static int prepare_block2_request(struct coap_packet *req,
 
 	r = coap_packet_init(req, data, COAP_BUF_SIZE, COAP_VERSION_1,
 			     COAP_TYPE_CON, strlen(token),
-			     (uint8_t *) token, COAP_METHOD_GET,
+			     token, COAP_METHOD_GET,
 			     coap_next_id());
 	if (r < 0) {
 		TC_PRINT("Unable to initialize request\n");
@@ -1378,7 +1378,7 @@ static int test_observer_client(void)
 
 	r = coap_packet_init(&req, data, COAP_BUF_SIZE,
 			     COAP_VERSION_1, COAP_TYPE_CON,
-			     strlen(token), (uint8_t *)token,
+			     strlen(token), token,
 			     COAP_METHOD_GET, coap_next_id());
 	if (r < 0) {
 		TC_PRINT("Unable to initialize request\n");


### PR DESCRIPTION
RFC 7252 (CoAP) specifies value of the Version (Ver) field in the
protocol header to value 1. This patch defines default value of the
Version field to make packet initialization easier. All samples
and tests are updated to use the new COAP_VERSION field when
initializing a CoAP packet.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>