### PR TITLE
drivers: wifi: esp: process received packets in esp_rx thread

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -369,7 +369,6 @@ static inline int esp_cmd_send(struct esp_data *data,
 }
 
 void esp_connect_work(struct k_work *work);
-void esp_recv_work(struct k_work *work);
 void esp_recvdata_work(struct k_work *work);
 void esp_close_work(struct k_work *work);
 

--- a/drivers/wifi/esp/esp_offload.c
+++ b/drivers/wifi/esp/esp_offload.c
@@ -469,24 +469,6 @@ void esp_recvdata_work(struct k_work *work)
 	}
 }
 
-void esp_recv_work(struct k_work *work)
-{
-	struct net_pkt *pkt = CONTAINER_OF(work, struct net_pkt, work);
-	struct net_context *context = pkt->context;
-	struct esp_socket *sock = context->offload_context;
-
-	k_mutex_lock(&sock->lock, K_FOREVER);
-	if (sock->recv_cb) {
-		sock->recv_cb(context, pkt, NULL, NULL,
-			      0, sock->recv_user_data);
-		k_sem_give(&sock->sem_data_ready);
-	} else {
-		/* Discard */
-		net_pkt_unref(pkt);
-	}
-	k_mutex_unlock(&sock->lock);
-}
-
 void esp_close_work(struct k_work *work)
 {
 	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,


### PR DESCRIPTION
So far received packets were parsed (at AT command level) and allocated
in [esp_rx] thread. Then they were submitted to [esp_workq] thread for
processing (calling application callback).

This flow results in following deadlock when esp_workq thread waits on
response to some AT command:

  - [esp_rx] waits on allocation of new RX packet
  - [esp_workq] waits for [esp_rx] to process response to AT command
    that was just sent
  - blocked [esp_workq] prevents processing and deallocating RX packets
  - [esp_rx] times out on allocation and closes socket

Process RX packets directly from [esp_rx] thread to prevent above
deadlock.