### PR TITLE
samples: cmsis_rtos_v1: philosophers: skip qemu_leon3

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -8,7 +8,7 @@ common:
   # qemu_x86_64 and up_squared need bigger stack
   # but CMSIS limits the stack size, resulting
   # in stack overflow.
-  platform_exclude: qemu_xtensa qemu_x86_64 up_squared
+  platform_exclude: qemu_xtensa qemu_x86_64 qemu_leon3 up_squared
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
SPARC systems take a huge penalty in stack usage due to register window saves.  A recent patch reverted SPARC-specific increases to various stack sizes, causing this test to fail.

Other platforms are excluded because of stack limits, so do that here too.

Will be required by #29618

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>