### PR TITLE
twister: fix the inconsistent total tests number of twister

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -850,6 +850,13 @@ class DeviceHandler(Handler):
 
         self.instance.results = harness.tests
 
+        # sometimes a test instance hasn't been executed successfully with an
+        # empty dictionary results, in order to include it into final report,
+        # so fill the results as BLOCK
+        if self.instance.results == {}:
+            for k in self.instance.testcase.cases:
+                self.instance.results[k] = 'BLOCK'
+
         if harness.state:
             self.set_state(harness.state, handler_time)
             if  harness.state == "failed":


### PR DESCRIPTION
sometimes a test instance hasn't been boot up to execute successfully,
so the results is an empty dictionary, it will not be added into final
twister_report.xml file.
so in order to include it, fill the results as BLOCK.

fix: #32158 

Signed-off-by: peng1 chen <peng1.chen@intel.com>