### PR TITLE
dts: npcx: fix i2c label prefix

### DIFF
--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -519,7 +519,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <13 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
-			label = "I2C_CTRL0";
+			label = "I2CCTRL_0";
 		};
 
 		i2c_ctrl1: i2c@4000b000 {
@@ -527,7 +527,7 @@
 			reg = <0x4000b000 0x1000>;
 			interrupts = <14 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
-			label = "I2C_CTRL1";
+			label = "I2CCTRL_1";
 		};
 
 		i2c_ctrl2: i2c@400c0000 {
@@ -535,7 +535,7 @@
 			reg = <0x400c0000 0x1000>;
 			interrupts = <36 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
-			label = "I2C_CTRL2";
+			label = "I2CCTRL_2";
 		};
 
 		i2c_ctrl3: i2c@400c2000 {
@@ -543,7 +543,7 @@
 			reg = <0x400c2000 0x1000>;
 			interrupts = <37 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
-			label = "I2C_CTRL3";
+			label = "I2CCTRL_3";
 		};
 
 		i2c_ctrl4: i2c@40008000 {
@@ -551,7 +551,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <19 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
-			label = "I2C_CTRL4";
+			label = "I2CCTRL_4";
 		};
 
 		i2c_ctrl5: i2c@40017000 {
@@ -559,7 +559,7 @@
 			reg = <0x40017000 0x1000>;
 			interrupts = <20 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
-			label = "I2C_CTRL5";
+			label = "I2CCTRL_5";
 		};
 
 		i2c_ctrl6: i2c@40018000 {
@@ -567,7 +567,7 @@
 			reg = <0x40018000 0x1000>;
 			interrupts = <16 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
-			label = "I2C_CTRL6";
+			label = "I2CCTRL_6";
 		};
 
 		i2c_ctrl7: i2c@40019000 {
@@ -575,7 +575,7 @@
 			reg = <0x40019000 0x1000>;
 			interrupts = <8 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
-			label = "I2C_CTRL7";
+			label = "I2CCTRL_7";
 		};
 
 		/* I2c Ports - Please use them as i2c node */
@@ -586,7 +586,7 @@
 			port = <0x00>;
 			controller = <&i2c_ctrl0>;
 			pinctrl-0 = <&alt2_i2c0_0_sl>; /* PINB5.B4 */
-			label = "I2C0_PORT0";
+			label = "I2C_0_PORT_0";
 			status = "disabled";
 		};
 
@@ -597,7 +597,7 @@
 			port = <0x10>;
 			controller = <&i2c_ctrl1>;
 			pinctrl-0 = <&alt2_i2c1_0_sl>; /* PIN90.87 */
-			label = "I2C1_PORT0";
+			label = "I2C_1_PORT_0";
 			status = "disabled";
 		};
 
@@ -608,7 +608,7 @@
 			port = <0x20>;
 			controller = <&i2c_ctrl2>;
 			pinctrl-0 = <&alt2_i2c2_0_sl>; /* PIN92.91 */
-			label = "I2C2_PORT0";
+			label = "I2C_2_PORT_0";
 			status = "disabled";
 		};
 
@@ -619,7 +619,7 @@
 			port = <0x30>;
 			controller = <&i2c_ctrl3>;
 			pinctrl-0 = <&alt2_i2c3_0_sl>; /* PIND1.D0 */
-			label = "I2C3_PORT0";
+			label = "I2C_3_PORT_0";
 			status = "disabled";
 		};
 
@@ -630,7 +630,7 @@
 			port = <0x41>;
 			controller = <&i2c_ctrl4>;
 			pinctrl-0 = <&alt6_i2c4_1_sl>; /* PINF3.F2 */
-			label = "I2C4_PORT1";
+			label = "I2C_4_PORT_1";
 			status = "disabled";
 		};
 
@@ -641,7 +641,7 @@
 			port = <0x50>;
 			controller = <&i2c_ctrl5>;
 			pinctrl-0 = <&alt2_i2c5_0_sl>; /* PIN33.36 */
-			label = "I2C5_PORT0";
+			label = "I2C_5_PORT_0";
 			status = "disabled";
 		};
 
@@ -652,7 +652,7 @@
 			port = <0x51>;
 			controller = <&i2c_ctrl5>;
 			pinctrl-0 = <&alt6_i2c5_1_sl>; /* PINF5.F4 */
-			label = "I2C5_PORT1";
+			label = "I2C_5_PORT_1";
 			status = "disabled";
 		};
 
@@ -663,7 +663,7 @@
 			port = <0x60>;
 			controller = <&i2c_ctrl6>;
 			pinctrl-0 = <&alt2_i2c6_0_sl>; /* PINC2.C1 */
-			label = "I2C6_PORT0";
+			label = "I2C_6_PORT_0";
 			status = "disabled";
 		};
 
@@ -674,7 +674,7 @@
 			port = <0x61>;
 			controller = <&i2c_ctrl6>;
 			pinctrl-0 = <&alt6_i2c6_1_sl>; /* PINE4.E3 */
-			label = "I2C6_PORT1";
+			label = "I2C_6_PORT_1";
 			status = "disabled";
 		};
 
@@ -685,7 +685,7 @@
 			port = <0x70>;
 			controller = <&i2c_ctrl7>;
 			pinctrl-0 = <&alt2_i2c7_0_sl>; /* PINB3.B2 */
-			label = "I2C7_PORT0";
+			label = "I2C_7_PORT_0";
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
i2c_shell uses "I2C_" label prefix to get the device. However, NPCX uses controller-port architecture. Users should access the ports instead of the controllers. Change I2C_CTRLX & I2CX_PORTX to I2CCTRL_X & I2C_X_PORT_X to guarantee i2c_shell could get the correct device by autocomplete.

i2c_shell autocomplete result:
```
uart:~$ i2c scan
  I2C_7_PORT_0  I2C_6_PORT_1  I2C_5_PORT_1  I2C_4_PORT_1  I2C_3_PORT_0
  I2C_2_PORT_0  I2C_1_PORT_0  I2C_0_PORT_0
uart:~$ i2c scan I2C_
```