### PR TITLE
boards: arm: 96b_nitrogen: Change MCUboot partition size

### DIFF
--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -96,15 +96,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xa000>;
+			reg = <0x00000000 0xc000>;
 		};
 		slot0_partition: partition@a000 {
 			label = "image-0";
-			reg = <0x0000a000 0x33000>;
+			reg = <0x0000a000 0x32000>;
 		};
 		slot1_partition: partition@3d000 {
 			label = "image-1";
-			reg = <0x0003d000 0x33000>;
+			reg = <0x0003d000 0x32000>;
 		};
 		scratch_partition: partition@70000 {
 			label = "image-scratch";


### PR DESCRIPTION
The boot partition requires minimum 42KB to flash the mcuboot
bootloader. Boot partition size, image partition size changed based on
the requirement.

Signed-off-by: NavinSankar Velliangiri <navin@linumiz.com>