### PR TITLE
Bluetooth: controller: ll_sw: Fix wrong cmake code that adds radio_df.c

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -56,10 +56,9 @@ if(CONFIG_BT_LL_SW_SPLIT)
     CONFIG_BT_CTLR_DF
     ll_sw/nordic/lll/lll_df.c
     )
-  zephyr_library_sources_ifdef(
-    (CONFIG_BT_CTLR_DF AND NOT CONFIG_SOC_SERIES_BSIM_NRFXX)
+  if(CONFIG_BT_CTLR_DF AND NOT CONFIG_SOC_SERIES_BSIM_NRFXX)
     zephyr_library_sources(ll_sw/nordic/hal/nrf5/radio/radio_df.c)
-    )
+  endif()
   zephyr_library_include_directories(
     ll_sw/nordic/lll
     )


### PR DESCRIPTION
Fix error introduced by pull request:
https://github.com/zephyrproject-rtos/zephyr/pull/31591

Zephyrs CMake extension function zephyr_library_sources_ifdef()
does not allow to use complex conditions to toggle if
sources should be included in build or not.
It allows to use only single variable as an input for
feature_toggle argument because it is double-expanded
in contition statement in the function.

In case there is a requirement that source file is included
when more complicated condition is true we have to fall-back
to reqular if() statement and zephyr_library_sources().

The fix is required because without it radio_df.c source
is never compiled. If DF functionality is enabled build
will fail because of missing functions implementation.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>