### PR TITLE
dts: stm32g4: Add SPI4 node

### DIFF
--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -41,5 +41,16 @@
 			dma-channels = <16>;
 		};
 
+		spi4: spi@40013c00 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00008000>;
+			interrupts = <84 5>;
+			status = "disabled";
+			label = "SPI_4";
+		};
+
 	};
 };


### PR DESCRIPTION
This commit adds the SPI4 node on the stm32g4 SoC.
