### PR TITLE
cmake: modules: remove Zephyr module duplicates from ZEPHYR_MODULE_NAMES

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -122,3 +122,5 @@ else()
     )
 
 endif()
+
+list(REMOVE_DUPLICATES ZEPHYR_MODULE_NAMES)

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -392,6 +392,14 @@ variable or by adding a :makevar:`ZEPHYR_EXTRA_MODULES` line to ``.zephyrrc``
 useful if you want to keep the list of modules found with west and also add
 your own.
 
+.. note::
+   If the module ``FOO`` is provided by :ref:`west <west>` but also given with
+   ``-DZEPHYR_EXTRA_MODULES=/<path>/foo`` then the module given by the command
+   line variable :makevar:`ZEPHYR_EXTRA_MODULES` will take precedence.
+   This allows you to use a custom version of ``FOO`` when building and still
+   use other Zephyr modules provided by :ref:`west <west>`.
+   This can for example be useful for special test purposes.
+
 See the section about :ref:`west-multi-repo` for more details.
 
 Finally, you can also specify the list of modules yourself in various ways, or


### PR DESCRIPTION
This allows users to overrule a module from command line.
As example, the Zephyr build system loads the module FOO from
`modules/FOO`, but user has a custom FOO locally at `custom/FOO` and
would like to use this module instead of manifest specified.

If user does `-DZEPHYR_EXTRA_MODULES=custom/FOO` the following error
will be seen:
```
The binary directory

  build/modules/FOO

is already used to build a source directory.  It cannot be used to build
source directory

  custom/FOO

Specify a unique binary directory name.
```

Removing duplicates from the list allows a user to use
`-DZEPHYR_EXTRA_MODULES=custom/FOO` and thus replace `modules/FOO` for
the current build.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>