### PR TITLE
RFC: dts: bindings: pwm-controller: add channel child binding

### DIFF
--- a/dts/bindings/pwm/pwm-controller.yaml
+++ b/dts/bindings/pwm/pwm-controller.yaml
@@ -11,3 +11,16 @@ properties:
       type: int
       required: true
       description: Number of items to expect in a pwm specifier
+
+child-binding:
+  description: PWM Channel
+  properties:
+    reg:
+      type: int
+      required: true
+      description: PWM channel number
+    flags:
+      type: int
+      required: false
+      description: |
+        Flags as define in pwm.h, for example PWM_POLARITY_NORMAL.


### PR DESCRIPTION
This commit adds channel child-bindings to the pwm controller binding.
With those bindings, a user can add channels to a pwm node that generate
the channel-number and flags. The pwm device can be obtained from
the parent node.
