### PR TITLE
modules: hal_nordic: move nrf_802154 glue to Zephyr

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -33,7 +33,7 @@ config IEEE802154_NRF5_INIT_PRIO
 	  you know what you are doing.
 
 config IEEE802154_NRF5_EXT_IRQ_MGMT
-	bool "Radio IRQ is managed by an external module"
+	bool
 	help
 	  The driver may manage radio IRQs by itself, or use an external
 	  radio IRQ provider. When radio IRQs are managed by an external

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -542,7 +542,7 @@ static int nrf5_stop(const struct device *dev)
 	return 0;
 }
 
-#ifndef CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT
+#if !IS_ENABLED(CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT)
 static void nrf5_radio_irq(void *arg)
 {
 	ARG_UNUSED(arg);
@@ -555,7 +555,7 @@ static void nrf5_irq_config(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-#ifndef CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT
+#if !IS_ENABLED(CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT)
 	IRQ_CONNECT(RADIO_IRQn, NRF_802154_IRQ_PRIORITY,
 		    nrf5_radio_irq, NULL, 0);
 	irq_enable(RADIO_IRQn);

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -1,11 +1,8 @@
-if(CONFIG_HAS_NORDIC_DRIVERS OR CONFIG_HAS_NRFX)
-  zephyr_library()
-endif()
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_HAS_NORDIC_DRIVERS)
-  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/drivers drivers)
-endif()
+if(CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
+  add_subdirectory(nrf_802154)
+endif ()
 
-if(CONFIG_HAS_NRFX)
-  add_subdirectory(nrfx)
-endif()
+add_subdirectory_ifdef(CONFIG_HAS_NRFX   nrfx)

--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -103,12 +103,18 @@ config NRF_802154_RX_BUFFERS
 
 endif # NRF_802154_RADIO_DRIVER
 
+config NRF_802154_SERIALIZATION
+	bool
+	select RPMSG_SERVICE
+	help
+	  This helper symbol indicates that the nRF 802.15.4 serialization is available.
+
 config NRF_802154_SER_HOST
 	bool "nRF IEEE 802.15.4 Driver serialization host"
 	depends on !NRF_802154_RADIO_DRIVER
 	depends on !HAS_HW_NRF_RADIO_IEEE802154
-	select RPMSG_SERVICE
 	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
+	select NRF_802154_SERIALIZATION
 	help
 	  Enable serialization of nRF IEEE 802.15.4 Driver. This option is to be
 	  used if radio is not available in the core, but radio services are
@@ -118,8 +124,8 @@ menuconfig NRF_802154_SER_RADIO
 	bool "nRF IEEE 802.15.4 Driver serialization radio"
 	depends on HAS_HW_NRF_RADIO_IEEE802154
 	depends on !IEEE802154_NRF5
-	select RPMSG_SERVICE
 	select NRF_802154_RADIO_DRIVER
+	select NRF_802154_SERIALIZATION
 	help
 	  Enable serialization of nRF IEEE 802.15.4 Driver. This option is to be
 	  used if radio is available in the core to provide radio services over

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory_ifdef(CONFIG_NRF_802154_RADIO_DRIVER  sl_opensource)
+add_subdirectory_ifdef(CONFIG_NRF_802154_RADIO_DRIVER  radio)
+add_subdirectory_ifdef(CONFIG_NRF_802154_SERIALIZATION serialization)

--- a/modules/hal_nordic/nrf_802154/radio/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/radio/CMakeLists.txt
@@ -1,0 +1,118 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set(NRF_802154_DRIVER_ROOT ${ZEPHYR_CURRENT_MODULE_DIR}/drivers/nrf_radio_802154)
+
+include(${NRF_802154_DRIVER_ROOT}/nrf_802154_driver_sources.cmake)
+
+zephyr_library()
+
+zephyr_include_directories(${NRF_802154_DRIVER_INCLUDE_DIRS})
+
+if (CONFIG_SOC_SERIES_NRF52X)
+zephyr_library_sources(
+  ${NRF_802154_DRIVER_SOURCES_NRF52}
+  )
+elseif (CONFIG_SOC_SERIES_NRF53X)
+zephyr_library_sources(
+  ${NRF_802154_DRIVER_SOURCES_NRF53}
+  )
+else()
+    message(FATAL_ERROR "SoC unsupported by this module")
+endif()
+
+if (CONFIG_NRF_802154_SL_OPENSOURCE)
+zephyr_library_sources(
+  ${NRF_802154_DRIVER_SOURCES_DIRECT}
+  )
+
+else()
+zephyr_library_sources(
+  ${NRF_802154_DRIVER_SOURCES_SWI}
+  )
+
+endif()
+
+zephyr_library_sources(${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_random_zephyr.c)
+
+if(     CONFIG_NRF_802154_CCA_MODE_ED)
+  set(radio_cca_mode NRF_RADIO_CCA_MODE_ED)
+
+elseif( CONFIG_NRF_802154_CCA_MODE_CARRIER)
+  set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER)
+
+elseif( CONFIG_NRF_802154_CCA_MODE_CARRIER_AND_ED)
+  set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER_AND_ED)
+
+elseif( CONFIG_NRF_802154_CCA_MODE_CARRIER_OR_ED)
+  set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER_OR_ED)
+
+endif()
+
+zephyr_compile_definitions(
+  # Radio driver shim layer uses raw api
+  NRF_802154_USE_RAW_API=1
+
+  # Number of slots containing short addresses of nodes for which
+  # pending data is stored.
+  NRF_802154_PENDING_SHORT_ADDRESSES=${CONFIG_NRF_802154_PENDING_SHORT_ADDRESSES}
+
+  # Number of slots containing extended addresses of nodes for which
+  # pending data is stored.
+  NRF_802154_PENDING_EXTENDED_ADDRESSES=${CONFIG_NRF_802154_PENDING_EXTENDED_ADDRESSES}
+
+  # Number of buffers in receive queue.
+  NRF_802154_RX_BUFFERS=${CONFIG_NRF_802154_RX_BUFFERS}
+
+  # CCA mode
+  NRF_802154_CCA_MODE_DEFAULT=${radio_cca_mode}
+
+  # CCA mode options
+  NRF_802154_CCA_CORR_LIMIT_DEFAULT=${CONFIG_NRF_802154_CCA_CORR_LIMIT}
+  NRF_802154_CCA_CORR_THRESHOLD_DEFAULT=${CONFIG_NRF_802154_CCA_CORR_THRESHOLD}
+  NRF_802154_CCA_ED_THRESHOLD_DEFAULT=${CONFIG_NRF_802154_CCA_ED_THRESHOLD}
+
+  # Enable CSMA/CA
+  NRF_802154_CSMA_CA_ENABLED=1
+  NRF_802154_TX_STARTED_NOTIFY_ENABLED=1
+
+  # ACK timeout
+  NRF_802154_ACK_TIMEOUT_ENABLED=1
+)
+
+if (CONFIG_IEEE802154_NRF5 OR NOT CONFIG_NRF_802154_SL_OPENSOURCE)
+  zephyr_compile_definitions(
+    NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=0
+  )
+else()
+  zephyr_compile_definitions(
+    NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=1
+  )
+endif()
+
+if (CONFIG_NRF_802154_SL_OPENSOURCE OR CONFIG_SOC_SERIES_NRF53X)
+  zephyr_compile_definitions(
+    # Disable Frame Timestamps
+    NRF_802154_FRAME_TIMESTAMP_ENABLED=0
+    # Disable DTRX
+    NRF_802154_DELAYED_TRX_ENABLED=0
+    # Disable IFS
+    NRF_802154_IFS_ENABLED=0
+  )
+
+else()
+  zephyr_compile_definitions(
+    # Enable Frame Timestamps
+    NRF_802154_FRAME_TIMESTAMP_ENABLED=1
+    # Enable DTRX
+    NRF_802154_DELAYED_TRX_ENABLED=1
+    # Enable IFS
+    NRF_802154_IFS_ENABLED=1
+  )
+endif()
+
+if (NOT CONFIG_NRF_802154_SL_OPENSOURCE)
+  zephyr_compile_definitions(
+    NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL=1
+  )
+endif()

--- a/modules/hal_nordic/nrf_802154/radio/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/radio/CMakeLists.txt
@@ -80,15 +80,11 @@ zephyr_compile_definitions(
   NRF_802154_ACK_TIMEOUT_ENABLED=1
 )
 
-if (CONFIG_IEEE802154_NRF5 OR NOT CONFIG_NRF_802154_SL_OPENSOURCE)
-  zephyr_compile_definitions(
-    NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=0
-  )
-else()
-  zephyr_compile_definitions(
-    NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=1
-  )
-endif()
+if (NOT CONFIG_IEEE802154_NRF5 AND NOT CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT)
+  zephyr_compile_definitions(NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=1)
+else ()
+  zephyr_compile_definitions(NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=0)
+endif ()
 
 if (CONFIG_NRF_802154_SL_OPENSOURCE OR CONFIG_SOC_SERIES_NRF53X)
   zephyr_compile_definitions(

--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <platform/temperature/nrf_802154_temperature.h>
+#include <drivers/entropy.h>
+
+static uint32_t state;
+
+static uint32_t next(void)
+{
+	uint32_t num = state;
+
+	state = 1664525 * num + 1013904223;
+	return num;
+}
+
+void nrf_802154_random_init(void)
+{
+	const struct device *dev;
+	int err;
+
+	dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+	__ASSERT_NO_MSG(dev != NULL);
+
+	do {
+		err = entropy_get_entropy(dev, (uint8_t *)&state, sizeof(state));
+		__ASSERT_NO_MSG(err == 0);
+	} while (state == 0);
+}
+
+void nrf_802154_random_deinit(void)
+{
+	/* Intentionally empty */
+}
+
+uint32_t nrf_802154_random_get(void)
+{
+	return next();
+}

--- a/modules/hal_nordic/nrf_802154/serialization/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/serialization/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set(NRF_802154_SER_SOURCE_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/drivers/nrf_802154_serialization)
+
+zephyr_library_named(nrf_802154_ser)
+
+zephyr_library_sources(
+  ${NRF_802154_SER_SOURCE_DIR}/spinel_base/spinel.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_buffer_allocator.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_buffer_mgr_dst.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_buffer_mgr_src.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_kvmap.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel_dec.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_serialization_crit_sect.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_spinel_log.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_spinel_backend_ipc.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_spinel_response_notifier.c
+)
+
+zephyr_library_sources_ifdef(
+  CONFIG_NRF_802154_SER_HOST
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel_app.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel_dec_app.c
+)
+
+zephyr_library_sources_ifdef(
+  CONFIG_NRF_802154_SER_RADIO
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel_net.c
+  ${NRF_802154_SER_SOURCE_DIR}/src/nrf_802154_spinel_dec_net.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_init_net.c
+)
+
+zephyr_include_directories(${NRF_802154_SER_SOURCE_DIR}/include)
+zephyr_library_include_directories(${NRF_802154_SER_SOURCE_DIR}/src/include)

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+
+#include "nrf_802154.h"
+#include "nrf_802154_serialization.h"
+
+static int serialization_init(const struct device *dev)
+{
+	/* On NET core we don't use Zephyr's shim layer so we have to call inits manually */
+	nrf_802154_init();
+
+	nrf_802154_serialization_init();
+
+	return 0;
+}
+
+SYS_INIT(serialization_init, POST_KERNEL, CONFIG_NRF_802154_SER_RADIO_INIT_PRIO);
+BUILD_ASSERT(CONFIG_NRF_802154_SER_RADIO_INIT_PRIO < CONFIG_RPMSG_SERVICE_INIT_PRIORITY,
+	     "CONFIG_NRF_802154_SER_RADIO_INIT_PRIO must be lower than CONFIG_RPMSG_SERVICE_INIT_PRIORITY");

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf_802154_serialization_crit_sect.h"
+
+#ifndef TEST
+#include <irq.h>
+#endif
+
+void nrf_802154_serialization_crit_sect_enter(uint32_t *p_critical_section)
+{
+#ifndef TEST
+	*p_critical_section = irq_lock();
+#else
+	(void)p_critical_section;
+#endif
+}
+
+void nrf_802154_serialization_crit_sect_exit(uint32_t critical_section)
+{
+#ifndef TEST
+	irq_unlock(critical_section);
+#else
+	(void)critical_section;
+#endif
+}

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <ipc/rpmsg_service.h>
+#include <device.h>
+#include <logging/log.h>
+
+#include "nrf_802154_spinel_backend_callouts.h"
+#include "nrf_802154_serialization_error.h"
+#include "../../spinel_base/spinel.h"
+
+#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_MODULE_NAME spinel_ipc_backend
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#define IPC_MASTER IS_ENABLED(CONFIG_RPMSG_SERVICE_MODE_MASTER)
+
+static K_SEM_DEFINE(ready_sem, 0, 1);
+static int endpoint_id;
+
+static int endpoint_cb(struct rpmsg_endpoint *ept,
+		       void                  *data,
+		       size_t                 len,
+		       uint32_t               src,
+		       void                  *priv)
+{
+	LOG_DBG("Received message of %u bytes.", len);
+
+	if (len) {
+		nrf_802154_spinel_encoded_packet_received(data, len);
+	}
+
+	return RPMSG_SUCCESS;
+}
+
+nrf_802154_ser_err_t nrf_802154_backend_init(void)
+{
+#if IPC_MASTER
+	while (!rpmsg_service_endpoint_is_bound(endpoint_id)) {
+		k_sleep(K_MSEC(1));
+	}
+#endif
+	return NRF_802154_SERIALIZATION_ERROR_OK;
+}
+
+/* Make sure we register endpoint before RPMsg Service is initialized. */
+static int register_endpoint(const struct device *arg)
+{
+	int status;
+
+	status = rpmsg_service_register_endpoint("nrf_spinel", endpoint_cb);
+
+	if (status < 0) {
+		LOG_ERR("Registering endpoint failed with %d", status);
+		return status;
+	}
+
+	endpoint_id = status;
+	return 0;
+}
+
+SYS_INIT(register_endpoint, POST_KERNEL, CONFIG_RPMSG_SERVICE_EP_REG_PRIORITY);
+
+/* Send packet thread details */
+#define RING_BUFFER_LEN 4
+#define SEND_THREAD_STACK_SIZE 1024
+
+static K_SEM_DEFINE(send_sem, 0, RING_BUFFER_LEN);
+K_THREAD_STACK_DEFINE(send_thread_stack, SEND_THREAD_STACK_SIZE);
+struct k_thread send_thread_data;
+
+struct ringbuffer {
+	uint32_t len;
+	uint8_t data[SPINEL_FRAME_BUFFER_SIZE];
+};
+
+static struct ringbuffer ring_buffer[RING_BUFFER_LEN];
+static uint8_t rd_idx;
+static uint8_t wr_idx;
+
+static uint8_t get_rb_idx_plus_1(uint8_t i)
+{
+	return (i + 1) % RING_BUFFER_LEN;
+}
+
+static nrf_802154_ser_err_t spinel_packet_from_thread_send(const uint8_t *data, uint32_t len)
+{
+	if (get_rb_idx_plus_1(wr_idx) == rd_idx) {
+		LOG_ERR("No spinel buffer available to send a new packet");
+		return NRF_802154_SERIALIZATION_ERROR_BACKEND_FAILURE;
+	}
+
+	LOG_DBG("Scheduling %u bytes for send thread", len);
+
+	struct ringbuffer *buf = &ring_buffer[wr_idx];
+
+	wr_idx = get_rb_idx_plus_1(wr_idx);
+	buf->len = len;
+	memcpy(buf->data, data, len);
+
+	k_sem_give(&send_sem);
+	return (nrf_802154_ser_err_t)len;
+}
+
+static void spinel_packet_send_thread_fn(void *arg1, void *arg2, void *arg3)
+{
+	LOG_DBG("Spinel backend send thread started");
+	while (true) {
+		k_sem_take(&send_sem, K_FOREVER);
+		struct ringbuffer *buf = &ring_buffer[rd_idx];
+		uint32_t expected_ret = buf->len;
+
+		LOG_DBG("Sending %u bytes from send thread", buf->len);
+		int ret = rpmsg_service_send(endpoint_id, buf->data, buf->len);
+
+		rd_idx = get_rb_idx_plus_1(rd_idx);
+
+		if (ret != expected_ret) {
+			nrf_802154_ser_err_data_t err = {
+				.reason = NRF_802154_SERIALIZATION_ERROR_BACKEND_FAILURE,
+			};
+
+			nrf_802154_serialization_error(&err);
+		}
+	}
+}
+
+K_THREAD_DEFINE(spinel_packet_send_thread, SEND_THREAD_STACK_SIZE,
+		spinel_packet_send_thread_fn, NULL, NULL, NULL, K_PRIO_COOP(0), 0, 0);
+
+nrf_802154_ser_err_t nrf_802154_spinel_encoded_packet_send(const void *p_data,
+							   size_t      data_len)
+{
+	if (k_is_in_isr()) {
+		return spinel_packet_from_thread_send(p_data, data_len);
+	}
+
+	LOG_DBG("Sending %u bytes directly", data_len);
+	int ret = rpmsg_service_send(endpoint_id, p_data, data_len);
+
+	return ((ret < 0) ? NRF_802154_SERIALIZATION_ERROR_BACKEND_FAILURE
+			  : (nrf_802154_ser_err_t) ret);
+}

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_log.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_log.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <kernel.h>
+
+void nrf_802154_spinel_log(const char *p_fmt, ...)
+{
+	va_list args;
+
+	va_start(args, p_fmt);
+	vprintk(p_fmt, args);
+	va_end(args);
+}
+
+void nrf_802154_spinel_buff_log(const uint8_t *p_buff, size_t buff_len)
+{
+	for (size_t i = 0; i < buff_len; i++) {
+		if (i != 0) {
+			printk(" ");
+		}
+
+		printk("0x%02x", p_buff[i]);
+	}
+}

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf_802154_spinel_response_notifier.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <logging/log.h>
+#include <zephyr.h>
+
+#include "../spinel_base/spinel.h"
+#include "nrf_802154_spinel_log.h"
+
+#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_MODULE_NAME spinel_ipc_backend_rsp_ntf
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+/* TODO: Current implementation doesn't support reentrancy or multiple awaits. */
+
+/**
+ * Valid property IDs are from 0 to SPINEL_MAX_UINT_PACKED (2097151).
+ * We use UINT32_MAX which is out of this range to indicate that we are
+ * not waiting for any property.
+ */
+#define AWAITED_PROPERTY_NONE UINT32_MAX
+
+struct spinel_notify_buff_internal {
+	nrf_802154_spinel_notify_buff_t buff;
+	bool                            free;
+};
+
+static K_SEM_DEFINE(notify_sem, 0, 1);
+static struct k_mutex await_mutex;
+
+static struct spinel_notify_buff_internal notify_buff;
+
+static spinel_prop_key_t awaited_property = AWAITED_PROPERTY_NONE;
+
+void nrf_802154_spinel_response_notifier_init(void)
+{
+	notify_buff.free = true;
+	k_mutex_init(&await_mutex);
+}
+
+void nrf_802154_spinel_response_notifier_lock_before_request(spinel_prop_key_t property)
+{
+	/*
+	 * Only one thread can await response.
+	 * TODO: Implement matching responses to requests and allow multiple threads
+	 *       to await simulatneously
+	 */
+
+	LOG_DBG("Locking response notifier");
+	int ret = k_mutex_lock(&await_mutex, K_FOREVER);
+
+	assert(ret == 0);
+	(void)ret;
+
+	assert(awaited_property == AWAITED_PROPERTY_NONE);
+	awaited_property = property;
+}
+
+nrf_802154_spinel_notify_buff_t *nrf_802154_spinel_response_notifier_property_await(
+	uint32_t timeout)
+{
+	nrf_802154_spinel_notify_buff_t *result = NULL;
+	int ret;
+
+	k_timeout_t k_timeout;
+
+	if (timeout == 0) {
+		k_timeout = K_NO_WAIT;
+	} else if (timeout == SPINEL_RESPONSE_NOTIFIER_INF_TIMEOUT) {
+		k_timeout = K_FOREVER;
+	} else {
+		k_timeout = K_MSEC(timeout);
+	}
+
+	if (k_sem_take(&notify_sem, k_timeout) == 0) {
+		result = &notify_buff.buff;
+	} else {
+		LOG_ERR("No response within timeout %u", timeout);
+	}
+
+	ret = k_mutex_unlock(&await_mutex);
+	assert(ret == 0);
+	(void)ret;
+	LOG_DBG("Unlockling response notifier");
+
+	return result;
+}
+
+void nrf_802154_spinel_response_notifier_free(nrf_802154_spinel_notify_buff_t *p_notify)
+{
+	struct spinel_notify_buff_internal *p_notify_buff_free;
+
+	p_notify_buff_free = CONTAINER_OF(p_notify,
+					  struct spinel_notify_buff_internal,
+					  buff);
+
+	assert(p_notify_buff_free == &notify_buff);
+
+	p_notify_buff_free->free = true;
+}
+
+void nrf_802154_spinel_response_notifier_property_notify(spinel_prop_key_t property,
+					      const void       *p_data,
+					      size_t            data_len)
+{
+	if (property == awaited_property) {
+		assert(notify_buff.free);
+
+		notify_buff.free = false;
+		awaited_property = AWAITED_PROPERTY_NONE;
+
+		assert(data_len <= sizeof(notify_buff.buff.data));
+
+		memcpy(notify_buff.buff.data, p_data, data_len);
+		notify_buff.buff.data_len = data_len;
+
+		k_sem_give(&notify_sem);
+	} else {
+		/* TODO: Determine if this is an error condition. */
+		NRF_802154_SPINEL_LOG_RAW("Received property that noone is waiting for\n");
+	}
+}

--- a/modules/hal_nordic/nrf_802154/sl_opensource/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set(NRF_802154_SL_ROOT ${ZEPHYR_CURRENT_MODULE_DIR}/drivers/nrf_802154_sl_opensource)
+
+include(${NRF_802154_SL_ROOT}/nrf_802154_sl_files.cmake)
+
+zephyr_library()
+
+zephyr_library_sources(
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_clock_zephyr.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_irq_zephyr.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_gpiote_zephyr.c
+)
+
+if (CONFIG_NRF_802154_SL_OPENSOURCE)
+  zephyr_include_directories(${NRF_802154_SL_OPENSOURCE_INCLUDE_DIRS})
+  zephyr_library_sources(${NRF_802154_SL_OPENSOURCE_SOURCES})
+else ()
+  zephyr_include_directories(${NRF_802154_SL_INCLUDE_DIRS})
+  zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_NRF52X ${NRF_802154_SL_SOURCES_NRF52})
+  zephyr_library_sources_ifdef(
+    CONFIG_SOC_SERIES_NRF53X
+    ${NRF_802154_SL_SOURCES_NRF53}
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/nrf_802154_lp_timer_zephyr.c
+  )
+endif ()

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <platform/clock/nrf_802154_clock.h>
+
+#include <stddef.h>
+
+#include <compiler_abstraction.h>
+#include <drivers/clock_control/nrf_clock_control.h>
+#include <drivers/clock_control.h>
+
+static bool hfclk_is_running;
+static bool lfclk_is_running;
+static struct onoff_client hfclk_cli;
+static struct onoff_client lfclk_cli;
+
+void nrf_802154_clock_init(void)
+{
+	/* Intentionally empty. */
+}
+
+void nrf_802154_clock_deinit(void)
+{
+	/* Intentionally empty. */
+}
+
+static void hfclk_on_callback(struct onoff_manager *mgr,
+			      struct onoff_client  *cli,
+			      uint32_t state,
+			      int res)
+{
+	hfclk_is_running = true;
+	nrf_802154_clock_hfclk_ready();
+}
+
+void nrf_802154_clock_hfclk_start(void)
+{
+	int ret;
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+
+	__ASSERT_NO_MSG(mgr != NULL);
+
+	sys_notify_init_callback(&hfclk_cli.notify, hfclk_on_callback);
+
+	ret = onoff_request(mgr, &hfclk_cli);
+	__ASSERT_NO_MSG(ret >= 0);
+}
+
+void nrf_802154_clock_hfclk_stop(void)
+{
+	int ret;
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+
+	__ASSERT_NO_MSG(mgr != NULL);
+
+	ret = onoff_cancel_or_release(mgr, &hfclk_cli);
+	__ASSERT_NO_MSG(ret >= 0);
+	hfclk_is_running = false;
+}
+
+bool nrf_802154_clock_hfclk_is_running(void)
+{
+	return hfclk_is_running;
+}
+
+static void lfclk_on_callback(struct onoff_manager *mgr,
+			      struct onoff_client  *cli,
+			      uint32_t state,
+			      int res)
+{
+	lfclk_is_running = true;
+	nrf_802154_clock_lfclk_ready();
+}
+
+void nrf_802154_clock_lfclk_start(void)
+{
+	int ret;
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
+
+	__ASSERT_NO_MSG(mgr != NULL);
+
+	sys_notify_init_callback(&lfclk_cli.notify, lfclk_on_callback);
+
+	ret = onoff_request(mgr, &lfclk_cli);
+	__ASSERT_NO_MSG(ret >= 0);
+}
+
+void nrf_802154_clock_lfclk_stop(void)
+{
+	int ret;
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
+
+	__ASSERT_NO_MSG(mgr != NULL);
+
+	ret = onoff_cancel_or_release(mgr, &lfclk_cli);
+	__ASSERT_NO_MSG(ret >= 0);
+	lfclk_is_running = false;
+}
+
+bool nrf_802154_clock_lfclk_is_running(void)
+{
+	return lfclk_is_running;
+}
+
+__WEAK void nrf_802154_clock_hfclk_ready(void)
+{
+	/* Intentionally empty. */
+}
+
+__WEAK void nrf_802154_clock_lfclk_ready(void)
+{
+	/* Intentionally empty. */
+}

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <platform/gpiote/nrf_802154_gpiote.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <sys/__assert.h>
+#include <device.h>
+#include <toolchain.h>
+#include <drivers/gpio.h>
+
+#include <hal/nrf_gpio.h>
+#include <nrf_802154_sl_coex.h>
+#include <nrf_802154_sl_utils.h>
+
+static const struct device *dev;
+static struct gpio_callback grant_cb;
+static uint32_t pin_number = COEX_GPIO_PIN_INVALID;
+
+static void gpiote_irq_handler(const struct device *gpiob, struct gpio_callback *cb,
+			       uint32_t pins)
+{
+	ARG_UNUSED(gpiob);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(pins);
+
+	nrf_802154_wifi_coex_gpiote_irqhandler();
+}
+
+void nrf_802154_gpiote_init(void)
+{
+	switch (nrf_802154_wifi_coex_interface_type_id_get()) {
+	case NRF_802154_WIFI_COEX_IF_NONE:
+		return;
+
+	case NRF_802154_WIFI_COEX_IF_3WIRE: {
+		nrf_802154_wifi_coex_3wire_if_config_t cfg;
+
+		nrf_802154_wifi_coex_cfg_3wire_get(&cfg);
+
+		pin_number = cfg.grant_cfg.gpio_pin;
+		__ASSERT_NO_MSG(pin_number != COEX_GPIO_PIN_INVALID);
+
+		bool use_port_1 = (pin_number > P0_PIN_NUM);
+
+		/* Convert to the Zephyr primitive */
+		pin_number = use_port_1 ? pin_number - P0_PIN_NUM : pin_number;
+
+		uint32_t pull_up_down = cfg.grant_cfg.active_high ?
+					GPIO_PULL_UP :
+					GPIO_PULL_DOWN;
+
+#if DT_NODE_EXISTS(DT_NODELABEL(gpio1))
+		dev = device_get_binding(use_port_1 ?
+					 DT_LABEL(DT_NODELABEL(gpio1)) :
+					 DT_LABEL(DT_NODELABEL(gpio0)));
+#else
+		dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+#endif
+		__ASSERT_NO_MSG(dev != NULL);
+
+		gpio_pin_configure(dev, pin_number, GPIO_INPUT | pull_up_down);
+
+		gpio_init_callback(&grant_cb, gpiote_irq_handler,
+				   BIT(pin_number));
+		gpio_add_callback(dev, &grant_cb);
+
+		gpio_pin_interrupt_configure(dev, pin_number,
+					     GPIO_INT_EDGE_BOTH);
+		break;
+	}
+
+	default:
+		__ASSERT_NO_MSG(false);
+	}
+}
+
+void nrf_802154_gpiote_deinit(void)
+{
+	switch (nrf_802154_wifi_coex_interface_type_id_get()) {
+	case NRF_802154_WIFI_COEX_IF_NONE:
+		break;
+
+	case NRF_802154_WIFI_COEX_IF_3WIRE:
+		gpio_pin_interrupt_configure(dev, pin_number, GPIO_INT_DISABLE);
+		gpio_remove_callback(dev, &grant_cb);
+		pin_number = COEX_GPIO_PIN_INVALID;
+		break;
+
+	default:
+		__ASSERT_NO_MSG(false);
+	}
+}

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <platform/irq/nrf_802154_irq.h>
+
+#include <irq.h>
+#include <nrfx.h>
+
+void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr)
+{
+	irq_connect_dynamic(irqn, prio, isr, NULL, 0);
+}
+
+void nrf_802154_irq_enable(uint32_t irqn)
+{
+	irq_enable(irqn);
+}
+
+void nrf_802154_irq_disable(uint32_t irqn)
+{
+	irq_disable(irqn);
+}
+
+void nrf_802154_irq_set_pending(uint32_t irqn)
+{
+	/* Zephyr does not provide abstraction layer for setting pending IRQ */
+	NVIC_SetPendingIRQ(irqn);
+}
+
+void nrf_802154_irq_clear_pending(uint32_t irqn)
+{
+	/* Zephyr does not provide abstraction layer for clearing pending IRQ */
+	NVIC_ClearPendingIRQ(irqn);
+}
+
+bool nrf_802154_irq_is_enabled(uint32_t irqn)
+{
+	return irq_is_enabled(irqn);
+}
+
+uint32_t nrf_802154_irq_priority_get(uint32_t irqn)
+{
+	return NVIC_GetPriority(irqn);
+}

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "platform/lp_timer/nrf_802154_lp_timer.h"
+
+#include <assert.h>
+#include <kernel.h>
+#include <stdbool.h>
+
+#include "drivers/timer/nrf_rtc_timer.h"
+
+#include "platform/clock/nrf_802154_clock.h"
+#include "nrf_802154_sl_utils.h"
+
+static volatile bool m_clock_ready;
+static bool m_is_running;
+static uint32_t m_rtc_channel;
+static bool m_in_critical_section;
+
+void rtc_irq_handler(uint32_t id, uint32_t cc_value, void *user_data)
+{
+	(void)cc_value;
+	(void)user_data;
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	assert(id == m_rtc_channel);
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_is_running = false;
+	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+
+	nrf_802154_sl_mcu_critical_exit(state);
+
+	nrf_802154_lp_timer_fired();
+}
+
+/**
+ * @brief Start one-shot timer that expires at specified time on desired channel.
+ *
+ * Start one-shot timer that will expire @p dt microseconds after @p t0 time on channel @p channel.
+ *
+ * @param[in]  channel  Compare channel on which timer will be started.
+ * @param[in]  t0       Number of microseconds representing timer start time.
+ * @param[in]  dt       Time of timer expiration as time elapsed from @p t0 [us].
+ */
+static void timer_start_at(uint32_t channel,
+			   uint32_t t0,
+			   uint32_t dt)
+{
+	uint32_t cc_value = NRF_802154_SL_US_TO_RTC_TICKS(t0 + dt);
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	z_nrf_rtc_timer_compare_set(m_rtc_channel, cc_value, rtc_irq_handler, NULL);
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_is_running = true;
+	z_nrf_rtc_timer_compare_int_unlock(m_rtc_channel, (m_in_critical_section == false));
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+void nrf_802154_clock_lfclk_ready(void)
+{
+	m_clock_ready = true;
+}
+
+void nrf_802154_lp_timer_init(void)
+{
+	m_in_critical_section = false;
+	m_is_running = false;
+
+	/* Setup low frequency clock. */
+	nrf_802154_clock_lfclk_start();
+
+	while (!m_clock_ready) {
+		/* Intentionally empty */
+	}
+
+	int32_t chan = z_nrf_rtc_timer_chan_alloc();
+
+	if (chan >= 0) {
+		m_rtc_channel = (uint32_t)chan;
+	} else   {
+		assert(false);
+		return;
+	}
+
+	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+}
+
+void nrf_802154_lp_timer_deinit(void)
+{
+	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+
+	z_nrf_rtc_timer_chan_free(m_rtc_channel);
+
+	nrf_802154_clock_lfclk_stop();
+}
+
+void nrf_802154_lp_timer_critical_section_enter(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	if (!m_in_critical_section) {
+		(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+		m_in_critical_section = true;
+	}
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+void nrf_802154_lp_timer_critical_section_exit(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_in_critical_section = false;
+
+	z_nrf_rtc_timer_compare_int_unlock(m_rtc_channel, m_is_running);
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+uint32_t nrf_802154_lp_timer_time_get(void)
+{
+	/* Please note that this function does not handle RTC overflow */
+	return NRF_802154_SL_RTC_TICKS_TO_US(z_nrf_rtc_timer_read());
+}
+
+uint32_t nrf_802154_lp_timer_granularity_get(void)
+{
+	return NRF_802154_SL_US_PER_TICK;
+}
+
+void nrf_802154_lp_timer_start(uint32_t t0, uint32_t dt)
+{
+	timer_start_at(m_rtc_channel, t0, dt);
+}
+
+bool nrf_802154_lp_timer_is_running(void)
+{
+	return m_is_running;
+}
+
+void nrf_802154_lp_timer_stop(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_is_running = false;
+	(void)z_nrf_rtc_timer_compare_int_lock(m_rtc_channel);
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+void nrf_802154_lp_timer_sync_start_now(void)
+{
+	/* Currently not supported */
+}
+
+void nrf_802154_lp_timer_sync_start_at(uint32_t t0, uint32_t dt)
+{
+	(void)t0;
+	(void)dt;
+	/* Currently not supported */
+}
+
+void nrf_802154_lp_timer_sync_stop(void)
+{
+	/* Currently not supported */
+}
+
+uint32_t nrf_802154_lp_timer_sync_event_get(void)
+{
+	/* Currently not supported */
+	return 0;
+}
+
+uint32_t nrf_802154_lp_timer_sync_time_get(void)
+{
+	/* Currently not supported */
+	return 0;
+}
+
+#ifndef UNITY_ON_TARGET
+__WEAK void nrf_802154_lp_timer_synchronized(void)
+{
+	/* Intentionally empty */
+}
+
+#endif

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
 set(NRFX_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/nrfx)
 set(INC_DIR ${NRFX_DIR}/drivers/include)
 set(SRC_DIR ${NRFX_DIR}/drivers/src)

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: c8f03de5639cb611e449232788249f599bf2beaa
+      revision: 46b65a5a6ebb6d089431bc80a4f78746c1c90a88
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This commit moves all hal_nordic radio driver code that is
strictly dependent on Zephyr into the Zephyr repository.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>