### PR TITLE
ci: Bump up number of builds

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.12.2"
-    parallelism: 300
+    parallelism: 400
     timeout_in_minutes: 210
     retry:
       manual: true


### PR DESCRIPTION
Still seeing a few timeouts after recently bumping up the number of
builds.  Bump this again to hopefully address the issue for now.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>