### PR TITLE
boards: cavs15: change the signing command in flash.sh

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
+++ b/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
@@ -10,10 +10,10 @@ if [ -z "$2" ]
   then
     echo "Signing using default key"
     west sign -d ${BUILD} -t rimage
-else
+elif [ -n "$3" ] && [ -n "$4" ]
+  then
     echo "Signing with key " $key
-    west sign -d ${BUILD} -t rimage -- -k $2
+    west sign -d ${BUILD} -t rimage -p $4 -D $3 -- -k $2
 fi
-
 echo ${FLASHER} -f ${FIRMWARE}
 ${FLASHER} -f ${FIRMWARE} || /bin/true  2>&1


### PR DESCRIPTION
Fixed [#31684](https://github.com/zephyrproject-rtos/zephyr/issues/31684)

Change the command that signing with rimage by flash script after
commitID:b553166a has been merged, that patch add a new option -D for
specify configuration, so update the command of this script.

Signed-off-by: Jian Kang <jianx.kang@intel.com>