### PR TITLE
devicetree: pwms: add helper macros to obtain device

### DIFF
--- a/include/devicetree/pwms.h
+++ b/include/devicetree/pwms.h
@@ -102,6 +102,74 @@ extern "C" {
 #define DT_PWMS_LABEL(node_id) DT_PWMS_LABEL_BY_IDX(node_id, 0)
 
 /**
+ * @brief Get the node identifier for the PWM controller from a
+ *        pwms property at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     pwm1: pwm-controller@... { ... };
+ *
+ *     pwm2: pwm-controller@... { ... };
+ *
+ *     n: node {
+ *             pwms = <&pwm1 1 PWM_POLARITY_NORMAL>,
+ *                    <&pwm2 3 PWM_POLARITY_INVERTED>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_PWMS_CTLR_BY_IDX(DT_NODELABEL(n), 0) // DT_NODELABEL(pwm1)
+ *     DT_PWMS_CTLR_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(pwm2)
+ *
+ * @param node_id node identifier for a node with a pwms property
+ * @param idx logical index into pwms property
+ * @return the node identifier for the PWM controller referenced at
+ *         index "idx"
+ * @see DT_PROP_BY_PHANDLE_IDX()
+ */
+#define DT_PWMS_CTLR_BY_IDX(node_id, idx) \
+	DT_PHANDLE_BY_IDX(node_id, pwms, idx)
+
+/**
+ * @brief Get the node identifier for the PWM controller from a
+ *        pwms property by name
+ *
+ * Example devicetree fragment:
+ *
+ *     pwm1: pwm-controller@... { ... };
+ *
+ *    pwm2: pwm-controller@... { ... };
+ *
+ *     n: node {
+ *             pwms = <&pwm1 1 PWM_POLARITY_NORMAL>,
+ *                    <&pwm2 3 PWM_POLARITY_INVERTED>;
+ *             pwm-names = "alpha", "beta";
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_PWMS_CTLR_BY_NAME(DT_NODELABEL(n), alpha) // DT_NODELABEL(pwm1)
+ *     DT_PWMS_CTLR_BY_NAME(DT_NODELABEL(n), beta)  // DT_NODELABEL(pwm2)
+ *
+ * @param node_id node identifier for a node with a pwms property
+ * @param name lowercase-and-underscores name of a pwms element
+ *             as defined by the node's pwm-names property
+ * @return the node identifier for the PWM controller in the named element
+ * @see DT_PHANDLE_BY_NAME()
+ */
+#define DT_PWMS_CTLR_BY_NAME(node_id, name) \
+	DT_PHANDLE_BY_NAME(node_id, pwms, name)
+
+/**
+ * @brief Equivalent to DT_PWMS_CTLR_BY_IDX(node_id, 0)
+ * @param node_id node identifier for a node with a pwms property
+ * @return the node identifier for the PWM controller at index 0
+ *         in the node's "pwms" property
+ * @see DT_PWMS_CTLR_BY_IDX()
+ */
+#define DT_PWMS_CTLR(node_id) DT_PWMS_CTLR_BY_IDX(node_id, 0)
+
+/**
  * @brief Get PWM specifier's cell value at an index
  *
  * Example devicetree fragment:
@@ -363,6 +431,40 @@ extern "C" {
  * @see DT_PWMS_LABEL_BY_IDX()
  */
 #define DT_INST_PWMS_LABEL(inst) DT_INST_PWMS_LABEL_BY_IDX(inst, 0)
+
+/**
+ * @brief Get the node identifier for the PWM controller from a
+ *        DT_DRV_COMPAT instance's pwms property at an index
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into pwms property
+ * @return the node identifier for the PWM controller referenced at
+ *         index "idx"
+ * @see DT_PWMS_CTLR_BY_IDX()
+ */
+#define DT_INST_PWMS_CTLR_BY_IDX(inst, idx) \
+	DT_PWMS_CTLR_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get the node identifier for the PWM controller from a
+ *        DT_DRV_COMPAT instance's pwms property by name
+ * @param inst DT_DRV_COMPAT instance number
+ * @param name lowercase-and-underscores name of a pwms element
+ *             as defined by the node's pwm-names property
+ * @return the node identifier for the PWM controller in the named element
+ * @see DT_PWMS_CTLR_BY_NAME()
+ */
+#define DT_INST_PWMS_CTLR_BY_NAME(inst, name) \
+	DT_PWMS_CTLR_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Equivalent to DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the node identifier for the PWM controller at index 0
+ *         in the instance's "pwms" property
+ * @see DT_PWMS_CTLR_BY_IDX()
+ */
+#define DT_INST_PWMS_CTLR(inst) DT_INST_PWMS_CTLR_BY_IDX(inst, 0)
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's PWM specifier's cell value

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -47,6 +47,9 @@
 #define TEST_SPI_NO_CS DT_NODELABEL(test_spi_no_cs)
 #define TEST_SPI_DEV_NO_CS DT_NODELABEL(test_spi_no_cs)
 
+#define TEST_PWM_CTLR_1 DT_NODELABEL(test_pwm1)
+#define TEST_PWM_CTLR_2 DT_NODELABEL(test_pwm2)
+
 #define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
 
 #define TO_STRING(x) TO_STRING_(x)
@@ -922,6 +925,22 @@ static void test_pwms(void)
 	/* DT_PWMS_LABEL */
 	zassert_true(!strcmp(DT_PWMS_LABEL(TEST_PH), "TEST_PWM_CTRL_1"), "");
 
+	/* DT_PWMS_CTLR_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_PWMS_CTLR_BY_IDX(TEST_PH, 0),
+				  TEST_PWM_CTLR_1), "");
+	zassert_true(DT_SAME_NODE(DT_PWMS_CTLR_BY_IDX(TEST_PH, 1),
+				  TEST_PWM_CTLR_2), "");
+
+	/* DT_PWMS_CTLR_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_PWMS_CTLR_BY_NAME(TEST_PH, red),
+				  TEST_PWM_CTLR_1), "");
+	zassert_true(DT_SAME_NODE(DT_PWMS_CTLR_BY_NAME(TEST_PH, green),
+				  TEST_PWM_CTLR_2), "");
+
+	/* DT_PWMS_CTLR */
+	zassert_true(DT_SAME_NODE(DT_PWMS_CTLR(TEST_PH),
+				  TEST_PWM_CTLR_1), "");
+
 	/* DT_PWMS_CELL_BY_IDX */
 	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, channel), 5, "");
 	zassert_equal(DT_PWMS_CELL_BY_IDX(TEST_PH, 1, period), 100, "");
@@ -977,6 +996,21 @@ static void test_pwms(void)
 
 	/* DT_INST_PWMS_LABEL */
 	zassert_true(!strcmp(DT_INST_PWMS_LABEL(0), "TEST_PWM_CTRL_1"), "");
+
+	/* DT_INST_PWMS_CTLR_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_INST_PWMS_CTLR_BY_IDX(0, 0),
+				  TEST_PWM_CTLR_1), "");
+	zassert_true(DT_SAME_NODE(DT_INST_PWMS_CTLR_BY_IDX(0, 1),
+				  TEST_PWM_CTLR_2), "");
+
+	/* DT_INST_PWMS_CTLR_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_INST_PWMS_CTLR_BY_NAME(0, red),
+				  TEST_PWM_CTLR_1), "");
+	zassert_true(DT_SAME_NODE(DT_INST_PWMS_CTLR_BY_NAME(0, green),
+				  TEST_PWM_CTLR_2), "");
+
+	/* DT_INST_PWMS_CTLR */
+	zassert_true(DT_SAME_NODE(DT_INST_PWMS_CTLR(0), TEST_PWM_CTLR_1), "");
 
 	/* DT_INST_PWMS_CELL_BY_IDX */
 	zassert_equal(DT_INST_PWMS_CELL_BY_IDX(0, 1, channel), 5, "");


### PR DESCRIPTION
Added helper macros to obtain the pwm-controller device object
pointer from a pwms phandle.