### PR TITLE
manifest: fix MCUboot build after #31404

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -407,6 +407,7 @@ MCUBoot
   * Usage of --confirm implies --pad.
   * Fixed 'custom_tlvs' argument handling.
   * Add support for setting fixed ROM address into image header.
+  * Fixed verification with protected TLVs.
 
 
 Trusted-Firmware-M

--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 13cf2e52024a144ecee9f37680681760a85febab
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 3f49b5abf38659c22b6b73f5fe289de2e395263e
+      revision: 30e0c5a0af21433efc8ea35cabc44bee3f096a62
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 43845e883ff3a6cdaae22e23f3e60b5fcf78c6ba


### PR DESCRIPTION
MCUboot version with bugfix for following issue:
CONFIG_LOG_MINIMAL was replaced by
CONFIG_LOG_MODE_MINIMAL by
zephyrproject-rtos/zephyr#31404 which
broke MCUboot default build.

fixes #31640

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>