### PR TITLE
tracing: Add ISR numbers to SystemView for Cortex-M

### DIFF
--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -27,6 +27,10 @@ uint32_t sysview_get_timestamp(void)
 
 uint32_t sysview_get_interrupt(void)
 {
+#ifdef CONFIG_CPU_CORTEX_M
+	interrupt = ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) >>
+		     SCB_ICSR_VECTACTIVE_Pos);
+#endif
 	return interrupt;
 }
 


### PR DESCRIPTION
The sysview module does not set an interrupt number when recording ISRs
for SEGGER SystemView. Added ISR numbers for Cortex-M based chips.

Signed-off-by: Jan Müller <jan.mueller@nordicsemi.no>