### PR TITLE
fix build errors with nr53 net core and power management

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -28,7 +28,7 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
 config PM
-	default y if SYS_CLOCK_EXISTS
+	default y if SYS_CLOCK_EXISTS && !HAS_NO_SYS_PM
 
 config BUILD_OUTPUT_HEX
 	default y

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -27,6 +27,9 @@ config SYS_CLOCK_TICKS_PER_SEC
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
+config PM
+	default y if SYS_CLOCK_EXISTS
+
 config BUILD_OUTPUT_HEX
 	default y
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -96,6 +96,7 @@ config SOC_NRF5340_CPUNET
 	select HAS_HW_NRF_TWIS0
 	select HAS_HW_NRF_UARTE0
 	select HAS_HW_NRF_WDT
+	select HAS_NO_SYS_PM
 
 choice
 	prompt "nRF53x MCU Selection"

--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -13,7 +13,7 @@ config SYS_POWER_MANAGEMENT
 menuconfig PM
 	bool "System Power management"
 	select TICKLESS_IDLE
-	depends on SYS_CLOCK_EXISTS && !SOC_NRF5340_CPUNET_QKAA
+	depends on SYS_CLOCK_EXISTS
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the

--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -13,7 +13,7 @@ config SYS_POWER_MANAGEMENT
 menuconfig PM
 	bool "System Power management"
 	select TICKLESS_IDLE
-	depends on SYS_CLOCK_EXISTS
+	depends on SYS_CLOCK_EXISTS && !HAS_NO_SYS_PM
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the
@@ -51,6 +51,14 @@ source "subsys/logging/Kconfig.template.log_config"
 
 
 endif # PM
+
+config HAS_NO_SYS_PM
+	bool
+	help
+	  This option blocks selection of PM.  It can be selected in SOC
+	  targets where system power management is not supported, for example
+	  on support core of a multi-core device where SoC power management is
+	  the responsibility of a different core.
 
 config PM_DEVICE
 	bool "Device power management"

--- a/tests/kernel/profiling/profiling_api/testcase.yaml
+++ b/tests/kernel/profiling/profiling_api/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   kernel.common.profiling:
     arch_exclude: nios2
-    platform_exclude: em_starterkit litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+    platform_exclude: em_starterkit
+      litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+      nrf5340dk_nrf5340_cpunet nrf5340pdk_nrf5340_cpunet
     tags: kernel

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -3,5 +3,7 @@ tests:
     arch_exclude: nios2
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.
-    platform_exclude: qemu_x86_coverage litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+    platform_exclude: qemu_x86_coverage
+      litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+      nrf5340dk_nrf5340_cpunet nrf5340pdk_nrf5340_cpunet
     tags: kernel

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -5,5 +5,7 @@ tests:
   kernel.timer.tickless:
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: nios2 posix
-    platform_exclude: qemu_x86_coverage litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+    platform_exclude: qemu_x86_coverage
+      litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
+      nrf5340dk_nrf5340_cpunet nrf5340pdk_nrf5340_cpunet
     tags: kernel timer userspace

--- a/tests/subsys/power/power_mgmt/testcase.yaml
+++ b/tests/subsys/power/power_mgmt/testcase.yaml
@@ -2,8 +2,11 @@ tests:
   subsys.power.device_pm:
     # arch_irq_unlock(0) can't work correctly on these arch
     arch_exclude: arc xtensa
-    # When CONFIG_TICKLESS_IDLE enable, these platforms don't provide timer driver
+    # When CONFIG_TICKLESS_IDLE enable, some of these platforms don't
+    # provide a timer driver.  Other platforms are excluded because
+    # they lack some other required feature.
     platform_exclude: rv32m1_vega_ri5cy rv32m1_vega_zero_riscy litex_vexriscv
+       nrf5340dk_nrf5340_cpunet nrf5340pdk_nrf5340_cpunet
     integration_platforms:
       - qemu_x86
       - mps2_an385


### PR DESCRIPTION
The net core of nRF53 doesn't provide access to the power regulator features: they can be accessed only from the application core.

Revert the previous way of attempting to avoid the test problem, and exclude the net cores from the test.

Fixes #31627