### PR TITLE
dts: add lpuart1 node for stm32h7 devices

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -236,6 +236,15 @@
 			label = "UART_8";
 		};
 
+		lpuart1: serial@58000c00 {
+			compatible = "st,stm32-lpuart", "st,stm32-uart";
+			reg = <0x58000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000008>;
+			interrupts = <142 0>;
+			status = "disabled";
+			label = "LPUART_1";
+		};
+
 		rtc: rtc@58004000 {
 			compatible = "st,stm32-rtc";
 			reg = <0x58004000 0x400>;


### PR DESCRIPTION
lpuart1 device node was not present in stm32h7 dtsi.

This has been tested on nucleo-h743 by setting the console and shell-uart onto lpuart1 pb6/pb7.