### PR TITLE
max17055: Fix current conversion

### DIFF
--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -42,6 +42,18 @@ static int max17055_reg_read(struct max17055_data *priv, int reg_addr,
 }
 
 /**
+ * @brief Convert current in MAX17055 units to milliamps
+ *
+ * @param rsense_mohms Value of Rsense in milliohms
+ * @param val Value to convert (taken from a MAX17055 register)
+ * @return corresponding value in milliamps
+ */
+static int current_to_ma(unsigned int rsense_mohms, int16_t val)
+{
+	return (val * 1.5625) / rsense_mohms;
+}
+
+/**
  * @brief Convert capacity in MAX17055 units to milliamps
  *
  * @param rsense_mohms Value of Rsense in milliohms
@@ -91,11 +103,11 @@ static int max17055_channel_get(const struct device *dev,
 		valp->val2 = tmp % 1000000;
 		break;
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT: {
-		int cap_ma;
+		int current_ma;
 
-		cap_ma = capacity_to_ma(config->rsense_mohms,
-					priv->avg_current);
-		set_millis(valp, cap_ma);
+		current_ma = current_to_ma(config->rsense_mohms,
+					   priv->avg_current);
+		set_millis(valp, current_ma);
 		break;
 	}
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:


### PR DESCRIPTION
`SENSOR_CHAN_GAUGE_AVG_CURRENT` is currently treated as a capacity
by the MAX17055 driver, however the unit conversion is different
for current and must be calculated separately.

Add a separate method to convert a current reading to milliamps.

Tested by comparing value read and converted from MAX17055 with
value from an external power profiling kit.

Signed-off-by: Hayden Ball <hayden@playerdata.co.uk>