### PR TITLE
tests: littlefs: check unmount return value

### DIFF
--- a/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
@@ -50,9 +50,11 @@ void test_fs_mount_flags(void)
 	zassert_equal(ret, 0, "Expected success", ret);
 	fs_close(&fs);
 	TC_PRINT("Create other directory\n");
-	zassert_equal(ret, 0, "Expected success", ret);
 	ret = fs_mkdir("/sml/other");
-	fs_unmount(mp);
+	zassert_equal(ret, 0, "Expected success", ret);
+
+	ret = fs_unmount(mp);
+	zassert_equal(ret, 0, "Expected success", ret);
 
 	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
 	mp->flags = FS_MOUNT_FLAG_READ_ONLY;
@@ -76,5 +78,6 @@ void test_fs_mount_flags(void)
 	ret = fs_open(&fs, "/sml/some", FS_O_READ);
 	zassert_equal(ret, 0, "Expected success", ret);
 	fs_close(&fs);
-	fs_unmount(mp);
+	ret = fs_unmount(mp);
+	zassert_equal(ret, 0, "Expected success", ret);
 }


### PR DESCRIPTION
Most tests are checking this; make littlefs conform.

Fixes #31669

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>