### PR TITLE
toolchain: add GEN_ABSOLUTE_SYM_KCONFIG()

### DIFF
--- a/arch/x86/gen_mmu.py
+++ b/arch/x86/gen_mmu.py
@@ -457,8 +457,7 @@ def main():
     debug("building %s" % pclass.__name__)
 
     vm_base = syms["CONFIG_KERNEL_VM_BASE"]
-    # Work around #31562
-    vm_size = syms["CONFIG_KERNEL_VM_SIZE"] & 0xFFFFFFFF
+    vm_size = syms["CONFIG_KERNEL_VM_SIZE"]
 
     if isdef("CONFIG_ARCH_MAPS_ALL_RAM"):
         image_base = syms["CONFIG_SRAM_BASE_ADDRESS"]

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -396,6 +396,23 @@ do {                                                                    \
 
 #define GEN_ABS_SYM_END }
 
+/*
+ * Note that GEN_ABSOLUTE_SYM(), depending on the architecture
+ * and toolchain, may restrict the range of values permitted
+ * for assignment to the named symbol.
+ *
+ * For example, on x86, "value" is interpreated as signed
+ * 32-bit integer. Passing in an unsigned 32-bit integer
+ * with MSB set would result in a negative integer.
+ * Moreover, GCC would error out if an integer larger
+ * than 2^32-1 is passed as "value".
+ */
+
+/*
+ * GEN_ABSOLUTE_SYM_KCONFIG() is outputted by the build system
+ * to generate named symbol/value pairs for kconfigs.
+ */
+
 #if defined(CONFIG_ARM) && !defined(CONFIG_ARM64)
 
 /*
@@ -411,6 +428,11 @@ do {                                                                    \
 		",%B0"                              \
 		"\n\t.type\t" #name ",%%object" :  : "n"(~(value)))
 
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",%object")
+
 #elif defined(CONFIG_X86)
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
@@ -418,12 +440,22 @@ do {                                                                    \
 		",%c0"                              \
 		"\n\t.type\t" #name ",@object" :  : "n"(value))
 
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",@object")
+
 #elif defined(CONFIG_ARC) || defined(CONFIG_ARM64)
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
 	__asm__(".globl\t" #name "\n\t.equ\t" #name \
 		",%c0"                              \
 		"\n\t.type\t" #name ",@object" :  : "n"(value))
+
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",@object")
 
 #elif defined(CONFIG_NIOS2) || defined(CONFIG_RISCV) || defined(CONFIG_XTENSA)
 
@@ -433,18 +465,33 @@ do {                                                                    \
 		",%0"                              \
 		"\n\t.type\t" #name ",%%object" :  : "n"(value))
 
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",%object")
+
 #elif defined(CONFIG_ARCH_POSIX)
 #define GEN_ABSOLUTE_SYM(name, value)               \
 	__asm__(".globl\t" #name "\n\t.equ\t" #name \
 		",%c0"                              \
 		"\n\t.type\t" #name ",@object" :  : "n"(value))
 
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",@object")
 
 #elif defined(CONFIG_SPARC)
 #define GEN_ABSOLUTE_SYM(name, value)			\
 	__asm__(".global\t" #name "\n\t.equ\t" #name	\
 		",%0"					\
 		"\n\t.type\t" #name ",#object" : : "n"(value))
+
+#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
+	__asm__(".globl\t" #name                    \
+		"\n\t.equ\t" #name "," #value       \
+		"\n\t.type\t" #name ",#object")
+
 #else
 #error processor architecture not supported
 #endif

--- a/misc/generated/CMakeLists.txt
+++ b/misc/generated/CMakeLists.txt
@@ -9,7 +9,7 @@ file(STRINGS
   ENCODING "UTF-8"
   )
 foreach (CONFIG ${LIST_OF_CONFIGS})
-  string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM(\\1, \\2)" CONFIG ${CONFIG})
+  string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM_KCONFIG(\\1, \\2)" CONFIG ${CONFIG})
   string(REGEX REPLACE "\"(.*)\"" "1" CONFIG ${CONFIG})
   set(GEN_ABS_SYM_LIST "${GEN_ABS_SYM_LIST}${CONFIG};\n")
 endforeach()


### PR DESCRIPTION
This adds a new GEN_ABSOLUTE_SYM_KCONFIG() specifically for
generating absolute symbols in assembly for kconfig values.
This is needed as the existing GEN_ABSOLUTE_SYM() with
constraints in extended assembly parses the "value" as
signed 32-bit integers. An unsigned 32-bit integer with
MSB set results in a negative number in the final binary.
This also prevents integers larger than 32-bit. So this
new macro simply puts the value inline within the assembly
instrcution instead of having it as parameter.

Fixes #31562

Signed-off-by: Daniel Leung <daniel.leung@intel.com>