### PR TITLE
Fix system_off example for cc13x2/cc26x2 to enter shutdown mode

### DIFF
--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -64,11 +64,10 @@ void main(void)
 	status = GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
 	GPIO_clearEventMultiDio(status);
 
-	/* Above we disabled entry to deep sleep based on duration of
-	 * controlled delay.  Here we need to override that, then
-	 * force a sleep so that the deep sleep takes effect.
+	/*
+	 * Force the SOFT_OFF state.
 	 */
-	pm_power_state_force((struct pm_state_info){PM_STATE_STANDBY, 0, 0});
+	pm_power_state_force((struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 	k_sleep(K_MSEC(1));
 
 	printk("ERROR: System off failed\n");

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -111,6 +111,8 @@ void pm_power_state_set(struct pm_state_info info)
 	case PM_STATE_SUSPEND_TO_RAM:
 		__fallthrough;
 	case PM_STATE_SUSPEND_TO_DISK:
+		__fallthrough;
+	case PM_STATE_SOFT_OFF:
 		Power_shutdown(0, 0);
 		break;
 	default:


### PR DESCRIPTION
Due to some recent changes, the example no longer enters shutdown mode as the last step. Instead, it is erroneously entering the standby mode.

This commit changes the example to enter the new "soft off" power state, which should be mapped to the hardware's shutdown mode.