### PR TITLE
include: Add missing extern "C" to spinlock.h

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -11,6 +11,10 @@
 #include <stdbool.h>
 #include <arch/cpu.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct z_spinlock_key {
 	int key;
 };
@@ -190,5 +194,8 @@ static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 #endif
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_SPINLOCK_H_ */


### PR DESCRIPTION
Change adds missing extern "C" to spinlock.h file. This is required to use spinlock from C++ code.