### PR TITLE
Bluetooth: Mesh: Fix mod app key get vnd

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1482,7 +1482,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 	}
 
 	return mod_member_list_get(OP_VND_MOD_APP_GET, OP_VND_MOD_APP_LIST,
-				   net_idx, addr, elem_addr, mod_id, CID_NVAL,
+				   net_idx, addr, elem_addr, mod_id, cid,
 				   status, apps, app_cnt);
 }
 


### PR DESCRIPTION
pass cid instead of CID_NVAL in parameters of mod_member_list_get

Signed-off-by: Nicolas LANTZ <nicolas.lantz@ubicore.net>