### PR TITLE
tests/fs/fa_api: Fix order of checks and broken zassert messages

### DIFF
--- a/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_mount_flags.c
@@ -22,39 +22,44 @@ void test_mount_flags(void)
 
 	/* Format volume and add some files/dirs to check read-only flag */
 	mp.flags = 0;
-	ret = fs_mount(&mp);
 	TC_PRINT("Mount to prepare tests\n");
-	zassert_equal(ret, 0, "Expected success", ret);
+	ret = fs_mount(&mp);
+	zassert_equal(ret, 0, "Expected success (%d)", ret);
 	TC_PRINT("Create some file\n");
 	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_CREATE);
-	zassert_equal(ret, 0, "Expected success", ret);
-	fs_close(&fs);
+	zassert_equal(ret, 0, "Expected success fs_open(FS_O_CREATE) (%d)",
+		      ret);
+	ret = fs_close(&fs);
+	zassert_equal(ret, 0, "Expected fs_close success (%d)", ret);
 	TC_PRINT("Create other directory\n");
-	zassert_equal(ret, 0, "Expected success", ret);
 	ret = fs_mkdir(TEST_FS_MNTP"/other");
-	fs_unmount(&mp);
+	zassert_equal(ret, 0, "Expected fs_mkdir success (%d)", ret);
+	ret = fs_unmount(&mp);
+	zassert_equal(ret, 0, "Expected fs_umount success (%d)", ret);
 
 	/* Check fs operation on volume mounted with FS_MOUNT_FLAG_READ_ONLY */
 	mp.flags = FS_MOUNT_FLAG_READ_ONLY;
 	TC_PRINT("Mount as read-only\n");
 	ret = fs_mount(&mp);
-	zassert_equal(ret, 0, "Expected success", ret);
+	zassert_equal(ret, 0, "Expected fs_mount success (%d)", ret);
 
 	/* Attempt creating new file */
 	ret = fs_open(&fs, TEST_FS_MNTP"/nosome", FS_O_CREATE);
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_mkdir(TEST_FS_MNTP"/another");
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_rename(TEST_FS_MNTP"/some", TEST_FS_MNTP"/nosome");
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_unlink(TEST_FS_MNTP"/some");
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_open(&fs, TEST_FS_MNTP"/other", FS_O_CREATE);
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_RDWR);
-	zassert_equal(ret, -EROFS, "Expected EROFS", ret);
+	zassert_equal(ret, -EROFS, "Expected EROFS got %d", ret);
 	ret = fs_open(&fs, TEST_FS_MNTP"/some", FS_O_READ);
-	zassert_equal(ret, 0, "Expected success", ret);
-	fs_close(&fs);
-	fs_unmount(&mp);
+	zassert_equal(ret, 0, "Expected fs_open(FS_O_READ) success (%d)", ret);
+	ret = fs_close(&fs);
+	zassert_equal(ret, 0, "Expected fs_close success (%d)", ret);
+	ret = fs_unmount(&mp);
+	zassert_equal(ret, 0, "Expected fs_unmount success (%d)", ret);
 }


### PR DESCRIPTION
The commit fixes three things:
 - the order of zassert_* checks has been often incorrect, and some
   checks of values have been done after some other operations has
   been performed;
 - some operations have been missing checks at all;
 - most of zassert_* messages have been given ret parameter to be
   printed but it has been missing from format string.

This addresses:
Coverity CID :215714
GH Issue: #31668

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>