### PR TITLE
boards: stm32f7 disco: Update openocd target

### DIFF
--- a/boards/arm/stm32f723e_disco/support/openocd.cfg
+++ b/boards/arm/stm32f723e_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/stm32f7discovery.cfg]
+source [find board/stm32f723e-disco.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"

--- a/boards/arm/stm32f746g_disco/support/openocd.cfg
+++ b/boards/arm/stm32f746g_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/stm32f7discovery.cfg]
+source [find board/stm32f746g-disco.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"
@@ -15,5 +15,5 @@ $_TARGETNAME configure -event gdb-detach {
 # inherited from stm32f7x.cfg for reset-start defaults to 2000 kHz, so
 # override that speed setting it also to the maximum speed.
 $_TARGETNAME configure -event reset-start {
-        adapter_khz 4000
+        adapter speed 4000
 }

--- a/boards/arm/stm32f769i_disco/support/openocd.cfg
+++ b/boards/arm/stm32f769i_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/stm32f7discovery.cfg]
+source [find board/stm32f769i-disco.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Stm32f7 disco boards benefit from dedicated openocd board target.
Use these target as the generic stm32f7discovery one will be
eventually removed.
Additionally, replace now deprecated 'adapter_khz' by 'adapter speed'.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>