### PR TITLE
Update hal_silabs module to gecko sdk v3.1.0 

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -22,6 +22,7 @@ config SOC_PART_NUMBER
 
 config SOC_GECKO_CORE
 	bool
+	default y
 	help
 	  Set if the Core interrupt handling (CORE) HAL module is used.
 

--- a/soc/arm/silabs_exx32/efr32mg21/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg21/Kconfig.series
@@ -14,7 +14,6 @@ config SOC_SERIES_EFR32MG21
 	select SOC_FAMILY_EXX32
 	select HAS_SILABS_GECKO
 	select HAS_SWO
-	select SOC_GECKO_CORE
 	select SOC_GECKO_CMU
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO

--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
       revision: a1ec761014740a08699720298dd37ad4da360840
       path: modules/hal/microchip
     - name: hal_silabs
-      revision: 6bb4a17a2f94a39eba295dd55dbeae6f6c4c9b1b
+      revision: de93f34488f2ab4d6337af0819b377636034fcda
       path: modules/hal/silabs
     - name: hal_st
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14


### PR DESCRIPTION
With this pr the complete hal is now based on the same version of the sdk. The version is the current release from SiLabs.

I successfully ran twister device testing on the boards efr32mg_sltb004a and efm32pg_stk3402a_jg (with only 2 or 3 tests failing).