### PR TITLE
drivers/sensor: Fix typos in iis2dlpc/iis2iclx/lsm6dso

### DIFF
--- a/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_spi.c
@@ -98,8 +98,8 @@ int iis2dlpc_spi_init(const struct device *dev)
 	const struct iis2dlpc_dev_config *cfg = dev->config;
 	const struct iis2dlpc_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
-	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2dlpc_spi_read,
-	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2dlpc_spi_write,
+	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2dlpc_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2dlpc_spi_write;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;

--- a/drivers/sensor/iis2iclx/iis2iclx_spi.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_spi.c
@@ -102,8 +102,8 @@ int iis2iclx_spi_init(const struct device *dev)
 	const struct iis2iclx_config *cfg = dev->config;
 	const struct iis2iclx_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
-	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2iclx_spi_read,
-	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2iclx_spi_write,
+	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2iclx_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2iclx_spi_write;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -98,8 +98,8 @@ int lsm6dso_spi_init(const struct device *dev)
 {
 	struct lsm6dso_data *data = dev->data;
 
-	data->ctx_spi.read_reg = (stmdev_read_ptr) lsm6dso_spi_read,
-	data->ctx_spi.write_reg = (stmdev_write_ptr) lsm6dso_spi_write,
+	data->ctx_spi.read_reg = (stmdev_read_ptr) lsm6dso_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) lsm6dso_spi_write;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;


### PR DESCRIPTION
The ',' character was used as line terminator instead of ';'
in SPI routines. The three affected drivers were not showing
any issue, but the typo is fixed for clarity.
