### PR TITLE
doc: release: 2.5: note build-time resolution of device pointers

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -294,6 +294,9 @@ Build and Infrastructure
     should be using the new devicetree API introduced in Zephyr 2.3 and
     documented in :ref:`dt-from-c`. Information on flash partitions has moved
     to :ref:`flash_map_api`.
+  * It is now possible to resolve at build time the device pointer associated
+    with a device that is defined in devicetree, via ``DEVICE_DT_GET``.  See
+    :ref:`dt-get-device`.
 
 * West
 


### PR DESCRIPTION
Document the existence of new API to retrieve device pointers at build
time.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>