### PR TITLE
tests: lib: cbprintf_fp: add missed README

### DIFF
--- a/tests/lib/cbprintf_fp/README.txt
+++ b/tests/lib/cbprintf_fp/README.txt
@@ -1,0 +1,12 @@
+Footprint and Behavior Test for cbprintf variants
+#################################################
+
+This ensures that formatted output to the console works as expected with
+minimal libc and newlib versions with printk, printf, and cbprintf.
+
+Footprint data can be obtained with:
+
+    for f in sanity-out/*/tests/lib/cbprintf_fp/benchmark.cbprintf_fp.*/build.log ; do
+      basename $(dirname $f)
+      sed -n '/Memory/,/^\[/p' < $f
+    done


### PR DESCRIPTION
Basic explanation of what this test is doing, was missed in the commit
where the test was added.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>