### PR TITLE
sensor: mcp9808: adding ability to change the resolution of the sensor through kconfig

### DIFF
--- a/drivers/sensor/mcp9808/mcp9808.h
+++ b/drivers/sensor/mcp9808/mcp9808.h
@@ -55,6 +55,8 @@
 #define MCP9808_TEMP_UPR_BIT		BIT(14)
 #define MCP9808_TEMP_CRT_BIT		BIT(15)
 
+#define MCP9808_REG_RESOLUTION          0x08
+
 struct mcp9808_data {
 	const struct device *i2c_master;
 
@@ -82,6 +84,7 @@ struct mcp9808_data {
 struct mcp9808_config {
 	const char *i2c_bus;
 	uint16_t i2c_addr;
+	uint8_t resolution;
 #ifdef CONFIG_MCP9808_TRIGGER
 	uint8_t alert_pin;
 	uint8_t alert_flags;
@@ -90,6 +93,10 @@ struct mcp9808_config {
 };
 
 int mcp9808_reg_read(const struct device *dev, uint8_t reg, uint16_t *val);
+int mcp9808_reg_write_16bit(const struct device *dev, uint8_t reg,
+			    uint16_t val);
+int mcp9808_reg_write_8bit(const struct device *dev, uint8_t reg,
+			   uint8_t val);
 
 #ifdef CONFIG_MCP9808_TRIGGER
 int mcp9808_attr_set(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -14,20 +14,6 @@
 
 LOG_MODULE_DECLARE(MCP9808, CONFIG_SENSOR_LOG_LEVEL);
 
-static int mcp9808_reg_write(const struct device *dev, uint8_t reg,
-			     uint16_t val)
-{
-	const struct mcp9808_data *data = dev->data;
-	const struct mcp9808_config *cfg = dev->config;
-	uint8_t buf[3] = {
-		reg,
-		val >> 8,	/* big-endian register storage */
-		val & 0xFF,
-	};
-
-	return i2c_write(data->i2c_master, buf, sizeof(buf), cfg->i2c_addr);
-}
-
 int mcp9808_attr_set(const struct device *dev, enum sensor_channel chan,
 		     enum sensor_attribute attr,
 		     const struct sensor_value *val)
@@ -54,7 +40,7 @@ int mcp9808_attr_set(const struct device *dev, enum sensor_channel chan,
 	temp = val->val1 * MCP9808_TEMP_SCALE_CEL;
 	temp += (MCP9808_TEMP_SCALE_CEL * val->val2) / 1000000;
 
-	return mcp9808_reg_write(dev, reg_addr,
+	return mcp9808_reg_write_16bit(dev, reg_addr,
 				 mcp9808_temp_reg_from_signed(temp));
 }
 
@@ -162,10 +148,10 @@ int mcp9808_setup_interrupt(const struct device *dev)
 	struct mcp9808_data *data = dev->data;
 	const struct mcp9808_config *cfg = dev->config;
 	const struct device *gpio;
-	int rc = mcp9808_reg_write(dev, MCP9808_REG_CRITICAL,
+	int rc = mcp9808_reg_write_16bit(dev, MCP9808_REG_CRITICAL,
 				   MCP9808_TEMP_ABS_MASK);
 	if (rc == 0) {
-		rc = mcp9808_reg_write(dev, MCP9808_REG_CONFIG,
+		rc = mcp9808_reg_write_16bit(dev, MCP9808_REG_CONFIG,
 				       MCP9808_CFG_ALERT_ENA);
 	}
 

--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -18,3 +18,15 @@ properties:
         sensor, and is open-drain.  A pull-up may be appropriate.  The
         property value should ensure the flags properly describe the
         signal that is presented to the driver.
+
+    resolution:
+      type: int
+      required: false
+      default: 3
+      description: Sensor resolution. Default is 0.0625C (0b11),
+        which is the power-up default.
+      enum:
+        - 0 # 0.5C
+        - 1 # 0.25C
+        - 2 # 0.125C
+        - 3 # 0.0625C

--- a/samples/sensor/mcp9808/boards/nucleo_l031k6.overlay
+++ b/samples/sensor/mcp9808/boards/nucleo_l031k6.overlay
@@ -9,6 +9,7 @@
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
 		int-gpios = <&gpiob 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		resolution = <3>;
 		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
+++ b/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Steven Daglish <s.c.daglish@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c1 {
+	mcp9808@18 {
+		compatible = "microchip,mcp9808";
+		reg = <0x18>;
+		int-gpios = <&gpioa 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		label = "MCP9808";
+		resolution = <3>;
+	};
+};

--- a/samples/sensor/mcp9808/sample.yaml
+++ b/samples/sensor/mcp9808/sample.yaml
@@ -6,3 +6,4 @@ tests:
     tags: sensors
     depends_on: i2c
     filter: dt_compat_enabled("microchip,mcp9808")
+    platform_allow: nucleo_l053r8


### PR DESCRIPTION
The current MCP9808 driver does not set the resolution for the sensor, instead using the default resolution of 0.0625C.

In some cases, it is better to use a lower resolution (for example to reduce the time required to acquire a new sample).

This PR adds the ability to change the resolution of the temperature measurements at compile time.

As the resolution is set during the MCP9808 init function, the i2c write functions have been moved from mcp9808_trigger.c to mcp9808.c.

Since the resolution register is only 8 bits, an 8bit write function has been created, and the original 16bit write function renamed to show the difference.