### PR TITLE
drivers/flash/soc_flash_nrf: FTPAN-242 workaround

### DIFF
--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -10,7 +10,7 @@
 #include <kernel.h>
 
 #define FLASH_OP_DONE    (0) /* 0 for compliance with the driver API. */
-#define FLASH_OP_ONGOING (-1)
+#define FLASH_OP_ONGOING  1
 
 struct flash_context {
 	uint32_t data_addr;  /* Address of data to write. */
@@ -53,7 +53,8 @@ struct flash_context {
  *
  * @param context pointer to flash_context structure.
  * @retval @ref FLASH_OP_DONE once operation was done, @ref FLASH_OP_ONGOING if
- *         operation needs more time for execution.
+ *         operation needs more time for execution and a negative error code if
+ *         operation was aborted.
  */
 typedef int (*flash_op_handler_t) (void *context);
 
@@ -92,12 +93,13 @@ bool nrf_flash_sync_is_required(void);
  * to timing settings requested by nrf_flash_sync_set_context().
  * This routine need to be called the handler as many time as it returns
  * FLASH_OP_ONGOING, howewer an operation timeot should be implemented.
- * When the handler() returns FLASH_OP_DONE, no further execution windows are
- * needed so function should return as the handler() finished its operation.
+ * When the handler() returns FLASH_OP_DONE or an error code, no further
+ * execution windows are needed so function should return as the handler()
+ * finished its operation.
  *
- * @retval 0 if op_desc->handler() was executed and
- * finished its operation. Otherwise (timeout, couldn't schedule execution...)
- * a negative error code.
+ * @retval 0 if op_desc->handler() was executed and finished its operation
+ * successfully. Otherwise (handler returned error, timeout, couldn't schedule
+ * execution...) a negative error code.
  *
  *                              execution window
  *            Driver task           task

--- a/drivers/flash/soc_flash_nrf_ticker.c
+++ b/drivers/flash/soc_flash_nrf_ticker.c
@@ -58,18 +58,20 @@ static void time_slot_callback_work(uint32_t ticks_at_expire,
 	struct flash_op_desc *op_desc;
 	uint8_t instance_index;
 	uint8_t ticker_id;
+	int rc;
 
 	__ASSERT(ll_radio_state_is_idle(),
 		 "Radio is on during flash operation.\n");
 
 	op_desc = context;
-	if (op_desc->handler(op_desc->context) == FLASH_OP_DONE) {
+	rc = op_desc->handler(op_desc->context);
+	if (rc != FLASH_OP_ONGOING) {
 		ll_timeslice_ticker_id_get(&instance_index, &ticker_id);
 
 		/* Stop the time slot ticker */
 		_ticker_stop(instance_index, 0, ticker_id);
 
-		_ticker_sync_context.result = 0;
+		_ticker_sync_context.result = (rc == FLASH_OP_DONE) ? 0 : rc;
 
 		/* notify thread that data is available */
 		k_sem_give(&sem_sync);


### PR DESCRIPTION
- Introduce support for situation when synchronization back-end aborts operation before it is done. synchronization API will transfer operation return code to the driver shim back.

- Disable POFWARN by writing POFCON before a write or erase operation. Do not attempt to write or erase if EVENTS_POFWARN is already asserted.

fixes #32118