### PR TITLE
tests: mem_map: fix execution test for x86_64 with coverage

### DIFF
--- a/tests/kernel/mem_protect/mem_map/CMakeLists.txt
+++ b/tests/kernel/mem_protect/mem_map/CMakeLists.txt
@@ -11,3 +11,5 @@ target_include_directories(app PRIVATE
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+zephyr_linker_sources(SECTIONS custom-sections.ld)

--- a/tests/kernel/mem_protect/mem_map/custom-sections.ld
+++ b/tests/kernel/mem_protect/mem_map/custom-sections.ld
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+SECTION_DATA_PROLOGUE(TEST_MEM_MAP,,SUBALIGN(CONFIG_MMU_PAGE_SIZE))
+{
+	/* transplanted_function() must be first */
+	KEEP(*(".test_mem_map.transplanted_function*"));
+	KEEP(*(".test_mem_map.*"));
+
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+PROVIDE(__test_mem_map_start = LOADADDR(TEST_MEM_MAP));
+PROVIDE(__test_mem_map_size = SIZEOF(TEST_MEM_MAP));
+PROVIDE(__test_mem_map_end = __test_mem_map_start + __test_mem_map_size);

--- a/tests/kernel/mem_protect/mem_map/prj_x86_64_coverage_exec.conf
+++ b/tests/kernel/mem_protect/mem_map/prj_x86_64_coverage_exec.conf
@@ -1,0 +1,6 @@
+CONFIG_ZTEST=y
+
+# Enable large memory model to avoid relative addressing
+# so the execution test can run with the function at
+# new location.
+CONFIG_COMPILER_OPT="-mcmodel=large"

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -13,15 +13,6 @@
 #define SKIP_EXECUTE_TESTS
 #endif
 
-/* Skip the memory map executing case when coverage enabled in x86_64,
- * because it will crash due to incorrect address accessing for gcov variables.
- * See issue#30434 for more details.
- */
-#if defined(CONFIG_X86_64) && defined(CONFIG_COVERAGE)
-#define SKIP_EXECUTE_TESTS
-#endif
-
-
 #define BASE_FLAGS	(K_MEM_CACHE_WB)
 volatile bool expect_fault;
 

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -6,6 +6,7 @@
 
 #include <ztest.h>
 #include <sys/mem_manage.h>
+#include <toolchain.h>
 
 /* 32-bit IA32 page tables have no mechanism to restrict execution */
 #if defined(CONFIG_X86) && !defined(CONFIG_X86_64) && !defined(CONFIG_X86_PAE)
@@ -87,6 +88,11 @@ void test_z_phys_map_rw(void)
 }
 
 #ifndef SKIP_EXECUTE_TESTS
+extern char __test_mem_map_start[];
+extern char __test_mem_map_end[];
+extern char __test_mem_map_size[];
+
+__in_section_unique(test_mem_map) __used
 static void transplanted_function(bool *executed)
 {
 	*executed = true;
@@ -99,29 +105,30 @@ static void transplanted_function(bool *executed)
  */
 void test_z_phys_map_exec(void)
 {
-	uint8_t *mapped_rw, *mapped_exec, *mapped_ro;
+	uint8_t *mapped_exec, *mapped_ro;
 	bool executed = false;
 	void (*func)(bool *executed);
 
 	expect_fault = false;
 
-	/* Map with write permissions and copy the function into the page */
-	z_phys_map(&mapped_rw, (uintptr_t)test_page,
-		   sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
-
-	memcpy(mapped_rw, (void *)&transplanted_function, CONFIG_MMU_PAGE_SIZE);
+	/*
+	 * Need to reference the function or else linker would
+	 * garbage collected it.
+	 */
+	func = transplanted_function;
 
 	/* Now map with execution enabled and try to run the copied fn */
-	z_phys_map(&mapped_exec, (uintptr_t)test_page,
-		   sizeof(test_page), BASE_FLAGS | K_MEM_PERM_EXEC);
+	z_phys_map(&mapped_exec, (uintptr_t)__test_mem_map_start,
+		   (uintptr_t)__test_mem_map_size,
+		   BASE_FLAGS | K_MEM_PERM_EXEC);
 
 	func = (void (*)(bool *executed))mapped_exec;
 	func(&executed);
 	zassert_true(executed, "function did not execute");
 
 	/* Now map without execution and execution should now fail */
-	z_phys_map(&mapped_ro, (uintptr_t)test_page,
-		   sizeof(test_page), BASE_FLAGS);
+	z_phys_map(&mapped_ro, (uintptr_t)__test_mem_map_start,
+		   (uintptr_t)__test_mem_map_size, BASE_FLAGS);
 
 	func = (void (*)(bool *executed))mapped_ro;
 	expect_fault = true;

--- a/tests/kernel/mem_protect/mem_map/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_map/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.memory_protection.mem_map:
     tags: kernel mmu ignore_faults
     filter: CONFIG_MMU
+    extra_sections: _TRANSPLANTED_FUNC

--- a/tests/kernel/mem_protect/mem_map/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_map/testcase.yaml
@@ -1,5 +1,20 @@
 tests:
   kernel.memory_protection.mem_map:
     tags: kernel mmu ignore_faults
-    filter: CONFIG_MMU
+    filter: CONFIG_MMU and not CONFIG_X86_64
     extra_sections: _TRANSPLANTED_FUNC
+    platform_exclude: qemu_x86_64
+  kernel.memory_protection.mem_map.x86_64:
+    tags: kernel mmu ignore_faults
+    filter: CONFIG_MMU and CONFIG_X86_64 and not CONFIG_COVERAGE
+    extra_sections: _TRANSPLANTED_FUNC
+  kernel.memory_protection.mem_map.x86_64.coverage:
+    tags: kernel mmu ignore_faults
+    filter: CONFIG_MMU and CONFIG_X86_64 and CONFIG_COVERAGE
+    extra_sections: _TRANSPLANTED_FUNC
+    extra_args: EXTRA_CFLAGS=-DSKIP_EXECUTE_TESTS
+  kernel.memory_protection.mem_map.x86_64.coverage.exec:
+    tags: kernel mmu ignore_faults
+    filter: CONFIG_MMU and CONFIG_X86_64 and CONFIG_COVERAGE
+    extra_sections: _TRANSPLANTED_FUNC
+    extra_args: CONF_FILE=prj_x86_64_coverage_exec.conf


### PR DESCRIPTION
When coverage is enabled on x86_64, GCC uses relative addressing
to increment the gcov counters. The generated code of the test
function assumes execution is in the same location where
the linker places the test function. This does not work with
the execution test as it copies the function into another part
of memory and tries to execute from there. When the copied
function starts to run, the instruction pointer is at the newly
copied function. So any relative addressing with regard to
the instruction pointer now is invalid. Instead of
<generated code RIP + offset> for gcov counter as it should be,
now the copied code is trying to access the counter at
<copied code RIP + offset>, which points to incorrect
memory location (and possibly invalid/non-mapped memory).
To fix this, we need to tell GCC not to use relative addressing.
This can be accomplished by telling GCC to use the large memory
model. This is only used for this test as this option increases
code size quite a bit, and should not be used in general.

Fixes #30434

Signed-off-by: Daniel Leung <daniel.leung@intel.com>