### PR TITLE
Revert "kernel: init: activate FPU for main thread"

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -241,7 +241,6 @@ static void init_idle_thread(int i)
 static char *prepare_multithreading(void)
 {
 	char *stack_ptr;
-	uint32_t opt;
 
 	/* _kernel.ready_q is all zeroes */
 	z_sched_init();
@@ -258,18 +257,11 @@ static char *prepare_multithreading(void)
 	 */
 	_kernel.ready_q.cache = &z_main_thread;
 #endif
-
-	opt = K_ESSENTIAL;
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/* Enable FPU in main thread */
-	opt |= K_FP_REGS;
-#endif
-
 	stack_ptr = z_setup_new_thread(&z_main_thread, z_main_stack,
 				       CONFIG_MAIN_STACK_SIZE, bg_thread_main,
 				       NULL, NULL, NULL,
 				       CONFIG_MAIN_THREAD_PRIORITY,
-				       opt, "main");
+				       K_ESSENTIAL, "main");
 	z_mark_thread_as_started(&z_main_thread);
 	z_ready_thread(&z_main_thread);
 


### PR DESCRIPTION
Activating K_FP_REGS flags introduces additional stack memory overhead for the main thread in Cortex-M architecture.
Several ARM platforms experience main thread stack overflows when building with FPU_SHARING=y. Enabling FPU sharing in main thread should not be the default configuration. Users are welcome to enable FP usage on the main thread in the
application code, in main(). [Actually, for Cortex-M this is done seamlessly.] There are use cases where ARM developers want to use the FPU in their own application-threads, so there is not need to waste extra memory on the main thread.

This reverts commit 8453a73ede9c9dca4123783e2014b82f600a7783.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>