### PR TITLE
samples: bluetooth: Remove useless default_conn

### DIFF
--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -22,8 +22,6 @@
 #include <bluetooth/services/bas.h>
 #include <bluetooth/services/hrs.h>
 
-struct bt_conn *default_conn;
-
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
@@ -37,7 +35,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	if (err) {
 		printk("Connection failed (err 0x%02x)\n", err);
 	} else {
-		default_conn = bt_conn_ref(conn);
 		printk("Connected\n");
 	}
 }
@@ -45,11 +42,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02x)\n", reason);
-
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -23,8 +23,6 @@
 
 #include "hts.h"
 
-struct bt_conn *default_conn;
-
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
@@ -38,7 +36,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	if (err) {
 		printk("Connection failed (err 0x%02x)\n", err);
 	} else {
-		default_conn = bt_conn_ref(conn);
 		printk("Connected\n");
 	}
 }
@@ -46,11 +43,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02x)\n", reason);
-
-	if (default_conn) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-	}
 }
 
 static struct bt_conn_cb conn_callbacks = {


### PR DESCRIPTION
The connection object is not used.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>