### PR TITLE
ARM: Make FPU Sharing the default mode and activate Lazy FP stacking dynamically

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -764,11 +764,21 @@ config FPU
 
 config FPU_SHARING
 	bool "FPU register sharing"
-	depends on FPU
+	depends on FPU && MULTITHREADING
+	default y if ARM && ARMV7_M_ARMV8_M_FP
 	help
 	  This option enables preservation of the hardware floating point registers
 	  across context switches to allow multiple threads to perform concurrent
 	  floating point operations.
+
+	  Note that on Cortex-M processors with the floating point extension we
+	  enable by default the FPU register sharing mode, as some GCC compilers
+	  may activate a floating point context by generating FP instructions for
+	  any thread, and that context must be preserved when switching such
+	  threads in and out. The developers can still disable the FP sharing
+	  mode in their application projects, and switch to Unshared FP registers
+	  mode, if it is guaranteed that the image code does not generate FP
+	  instructions outside the single thread context that is allowed to do so.
 
 endmenu
 

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
@@ -50,6 +50,11 @@ LOG_MODULE_REGISTER(mpu);
 extern K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 #endif
 
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING) \
+	&& defined(CONFIG_MPU_STACK_GUARD)
+uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread);
+#endif
+
 static const struct z_arm_mpu_partition static_regions[] = {
 #if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
 		{
@@ -247,9 +252,7 @@ void z_arm_configure_dynamic_mpu_regions(struct k_thread *thread)
 	size_t guard_size = MPU_GUARD_ALIGN_AND_SIZE;
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	if ((thread->base.user_options & K_FP_REGS) != 0) {
-		guard_size = MPU_GUARD_ALIGN_AND_SIZE_FLOAT;
-	}
+	guard_size = z_arm_mpu_stack_guard_and_fpu_adjust(thread);
 #endif
 
 #if defined(CONFIG_USERSPACE)

--- a/arch/arm/core/aarch32/fatal.c
+++ b/arch/arm/core/aarch32/fatal.c
@@ -45,6 +45,9 @@ static void esf_dump(const z_arch_esf_t *esf)
 		LOG_ERR("r10/v7: 0x%08x  r11/v8: 0x%08x    psp:  0x%08x",
 			callee->v7, callee->v8, callee->psp);
 	}
+
+	LOG_ERR("EXC_RETURN: 0x%0x", esf->extra_info.exc_return);
+
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 	LOG_ERR("Faulting instruction address (r15/pc): 0x%08x",
 		esf->basic.pc);

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -103,8 +103,8 @@ static inline void z_arm_floating_point_init(void)
 	 * Upon reset, the FPU Context Control Register is 0xC0000000
 	 * (both Automatic and Lazy state preservation is enabled).
 	 */
-#if !defined(CONFIG_FPU_SHARING)
-	/* Default mode is Unshared FP registers mode. We disable the
+#if defined(CONFIG_MULTITHREADING) && !defined(CONFIG_FPU_SHARING)
+	/* Unshared FP registers (multithreading) mode. We disable the
 	 * automatic stacking of FP registers (automatic setting of
 	 * FPCA bit in the CONTROL register), upon exception entries,
 	 * as the FP registers are to be used by a single context (and
@@ -116,6 +116,8 @@ static inline void z_arm_floating_point_init(void)
 	FPU->FPCCR &= (~(FPU_FPCCR_ASPEN_Msk | FPU_FPCCR_LSPEN_Msk));
 #else
 	/*
+	 * FP register sharing (multithreading) mode or single-threading mode.
+	 *
 	 * Enable both automatic and lazy state preservation of the FP context.
 	 * The FPCA bit of the CONTROL register will be automatically set, if
 	 * the thread uses the floating point registers. Because of lazy state
@@ -123,7 +125,8 @@ static inline void z_arm_floating_point_init(void)
 	 * exception entry, however, the required area in the stack frame will
 	 * be reserved for them. This configuration improves interrupt latency.
 	 * The registers will eventually be stacked when the thread is swapped
-	 * out during context-switch.
+	 * out during context-switch or if an ISR attempts to execute floating
+	 * point instructions.
 	 */
 	FPU->FPCCR = FPU_FPCCR_ASPEN_Msk | FPU_FPCCR_LSPEN_Msk;
 #endif /* CONFIG_FPU_SHARING */

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -154,8 +154,12 @@ static inline void z_arm_floating_point_init(void)
 	 * Note:
 	 * In Sharing FP Registers mode CONTROL.FPCA is cleared before switching
 	 * to main, so it may be skipped here (saving few boot cycles).
+	 *
+	 * If CONFIG_INIT_ARCH_HW_AT_BOOT is set, CONTROL is cleared at reset.
 	 */
-#if !defined(CONFIG_FPU) || !defined(CONFIG_FPU_SHARING)
+#if (!defined(CONFIG_FPU) || !defined(CONFIG_FPU_SHARING)) && \
+	(!defined(CONFIG_INIT_ARCH_HW_AT_BOOT))
+
 	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
 #endif
 }

--- a/doc/reference/kernel/other/float.rst
+++ b/doc/reference/kernel/other/float.rst
@@ -75,6 +75,10 @@ or SSE user are not impacted by the computations performed by the other users.
 ARM Cortex-M architecture (with the Floating Point Extension)
 -------------------------------------------------------------
 
+.. note::
+    The Shared FP registers mode is the default Floating Point
+    Services mode in ARM Cortex-M.
+
 On the ARM Cortex-M architecture with the Floating Point Extension, the kernel
 treats *all* threads as FPU users when shared FP registers mode is enabled.
 This means that any thread is allowed to access the floating point registers.
@@ -92,7 +96,8 @@ using one of the techniques listed below.
 
 Pretagging a thread with the :c:macro:`K_FP_REGS` option instructs the
 MPU-based stack protection mechanism to properly configure the size of
-the thread's guard region to always guarantee stack overflow detection.
+the thread's guard region to always guarantee stack overflow detection,
+and enable lazy stacking for the given thread upon thread creation.
 
 During thread context switching the ARM kernel saves the *callee-saved*
 floating point registers, if the switched-out thread has been using them.
@@ -112,6 +117,17 @@ be saved.
 is currently enabled in Zephyr applications on ARM Cortex-M
 architecture, minimizing interrupt latency, when the floating
 point context is active.
+
+When the MPU-based stack protection mechanism is not enabled, lazy stacking
+is always active in the Zephyr application. When the MPU-based stack protection
+is enabled, the following rules apply with respect to lazy stacking:
+
+* Lazy stacking is activated by default on threads that are pretagged with
+  :c:macro:`K_FP_REGS`
+* Lazy stacking is activated dynamically on threads that are not pretagged with
+  :c:macro:`K_FP_REGS`, as soon as the kernel detects that they are using the
+  floating point registers.
+
 
 If an ARM thread does not require use of the floating point registers any
 more, it can call :c:func:`k_float_disable`. This instructs the kernel

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -135,6 +135,8 @@ Architectures
     * Introduced the functionality for chain-loadable Zephyr
       fimrmware images to force the initialization of internal
       architecture state during early system boot (Cortex-M).
+    * Changed the default Floating Point Services mode to
+      Shared FP registers mode.
 
   * AARCH64
 

--- a/include/arch/arm/aarch32/thread.h
+++ b/include/arch/arm/aarch32/thread.h
@@ -75,6 +75,23 @@ struct _thread_arch {
 #endif
 
 #if defined(CONFIG_USERSPACE) || defined(CONFIG_FPU_SHARING)
+	/*
+	 * Status variable holding several thread status flags
+	 * as follows:
+	 *
+	 * +--------------bit-3----------bit-2--------bit-1---+----bit-0------+
+	 * :          |             |              |          |               |
+	 * : reserved |<Guard FLOAT>| <FP context> | reserved |  <priv mode>  |
+	 * :   bits   |             | CONTROL.FPCA |          | CONTROL.nPRIV |
+	 * +------------------------------------------------------------------+
+	 *
+	 * Bit 0: thread's current privileged mode (Supervisor or User mode)
+	 *        Mirrors CONTROL.nPRIV flag.
+	 * Bit 2: indicating whether the thread has an active FP context.
+	 *        Mirrors CONTROL.FPCA flag.
+	 * Bit 3: indicating whether the thread is applying the long (FLOAT)
+	 *        or the default MPU stack guard size.
+	 */
 	uint32_t mode;
 #if defined(CONFIG_USERSPACE)
 	uint32_t priv_stack_start;
@@ -82,6 +99,9 @@ struct _thread_arch {
 #endif
 };
 
+#if defined(CONFIG_FPU_SHARING) && defined(CONFIG_MPU_STACK_GUARD)
+#define Z_ARM_MODE_MPU_GUARD_FLOAT_Msk (1 << 3)
+#endif
 typedef struct _thread_arch _thread_arch_t;
 
 #endif /* _ASMLANGUAGE */


### PR DESCRIPTION
Fixes #29590 ( Also fixes #31472, which was reporting an in-tree failure, related to the same thing)
Fixes #28014

The PR does the following

1. Force FP sharing mode when we build with FPU support, effectively making the FP Sharing the default Floating Point services mode in Cortex-M
2. When MPU Stack Guard feature is enabled, activate the Lazy FP stacking functionality dynamically, for the threads actively using the FP registers
    - some extra logic is implemented on the context-switch (only under #ifdef MPU_STACK_GUARD, which is a debug feature)
    - saves threads from the need for large MPU guards if they are not using the FP registers, while still guaranteeing stack overflow detection