### PR TITLE
Add iis2mdc multi instance support

### DIFF
--- a/drivers/sensor/iis2mdc/Kconfig
+++ b/drivers/sensor/iis2mdc/Kconfig
@@ -53,8 +53,4 @@ config IIS2MDC_MAG_ODR_RUNTIME
 	bool "Set magnetometer sampling frequency (ODR) at runtime (default: 10 Hz)"
 	default y
 
-config IIS2MDC_SPI_FULL_DUPLEX
-	bool "Enable SPI 4wire mode (separated MISO and MOSI lines)"
-	depends on SPI
-
 endif # IIS2MDC

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -279,13 +279,6 @@ static int iis2mdc_init(const struct device *dev)
 
 	k_busy_wait(100);
 
-#if CONFIG_IIS2MDC_SPI_FULL_DUPLEX
-	/* After s/w reset set SPI 4wires again if the case */
-	if (iis2mdc_spi_mode_set(iis2mdc->ctx, IIS2MDC_SPI_4_WIRE) < 0) {
-		return -EIO;
-	}
-#endif
-
 	/* enable BDU */
 	if (iis2mdc_block_data_update_set(iis2mdc->ctx, PROPERTY_ENABLE) < 0) {
 		LOG_DBG("setting bdu failed\n");

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -244,60 +244,20 @@ static const struct sensor_driver_api iis2mdc_driver_api = {
 	.channel_get = iis2mdc_channel_get,
 };
 
-static int iis2mdc_init_interface(const struct device *dev)
-{
-	const struct iis2mdc_config *const config = dev->config;
-	struct iis2mdc_data *iis2mdc = dev->data;
-
-	iis2mdc->bus = device_get_binding(config->master_dev_name);
-	if (!iis2mdc->bus) {
-		LOG_DBG("Could not get pointer to %s device",
-			    config->master_dev_name);
-		return -EINVAL;
-	}
-
-	return config->bus_init(dev);
-}
-
-static const struct iis2mdc_config iis2mdc_dev_config = {
-	.master_dev_name = DT_INST_BUS_LABEL(0),
-#ifdef CONFIG_IIS2MDC_TRIGGER
-	.drdy_port = DT_INST_GPIO_LABEL(0, drdy_gpios),
-	.drdy_pin = DT_INST_GPIO_PIN(0, drdy_gpios),
-	.drdy_flags = DT_INST_GPIO_FLAGS(0, drdy_gpios),
-#endif  /* CONFIG_IIS2MDC_TRIGGER */
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	.bus_init = iis2mdc_spi_init,
-	.spi_conf.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.spi_conf.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
-			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
-			       SPI_LINES_SINGLE),
-	.spi_conf.slave     = DT_INST_REG_ADDR(0),
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	.gpio_cs_port	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-	.cs_gpio	    = DT_INST_SPI_DEV_CS_GPIOS_PIN(0),
-	.cs_gpio_flags	    = DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-
-	.spi_conf.cs        =  &iis2mdc_data.cs_ctrl,
-#else
-	.spi_conf.cs        = NULL,
-#endif
-#elif DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-	.bus_init = iis2mdc_i2c_init,
-	.i2c_slv_addr = DT_INST_REG_ADDR(0),
-#else
-#error "BUS MACRO NOT DEFINED IN DTS"
-#endif
-};
-
 static int iis2mdc_init(const struct device *dev)
 {
+	const struct iis2mdc_dev_config *const cfg = dev->config;
 	struct iis2mdc_data *iis2mdc = dev->data;
 	uint8_t wai;
 
 	iis2mdc->dev = dev;
 
-	if (iis2mdc_init_interface(dev)) {
+	if (!device_is_ready(cfg->bus)) {
+		LOG_ERR("Cannot get pointer to bus device");
+		return -ENODEV;
+	}
+
+	if (cfg->bus_init(dev) < 0) {
 		return -EINVAL;
 	}
 
@@ -367,6 +327,78 @@ static int iis2mdc_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, iis2mdc_init, device_pm_control_nop,
-		     &iis2mdc_data, &iis2mdc_dev_config, POST_KERNEL,
-		     CONFIG_SENSOR_INIT_PRIORITY, &iis2mdc_driver_api);
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#warning "IIS2MDC driver enabled without any devices"
+#endif
+
+/*
+ * Device creation macro, shared by IIS2MDC_DEFINE_SPI() and
+ * IIS2MDC_DEFINE_I2C().
+ */
+
+#define IIS2MDC_DEVICE_INIT(inst)					\
+	DEVICE_DT_INST_DEFINE(inst,					\
+			    iis2mdc_init,				\
+			    device_pm_control_nop,			\
+			    &iis2mdc_data_##inst,			\
+			    &iis2mdc_config_##inst,			\
+			    POST_KERNEL,				\
+			    CONFIG_SENSOR_INIT_PRIORITY,		\
+			    &iis2mdc_driver_api);
+
+/*
+ * Instantiation macros used when a device is on a SPI bus.
+ */
+
+#ifdef CONFIG_IIS2MDC_TRIGGER
+#define IIS2MDC_CFG_IRQ(inst) \
+	.gpio_drdy = GPIO_DT_SPEC_GET(DT_DRV_INST(inst), drdy_gpios),
+#else
+#define IIS2MDC_CFG_IRQ(inst)
+#endif /* CONFIG_IIS2MDC_TRIGGER */
+
+#define IIS2MDC_SPI_OP  (SPI_WORD_SET(8) |				\
+			 SPI_OP_MODE_MASTER |				\
+			 SPI_LINES_SINGLE |				\
+			 SPI_MODE_CPOL |				\
+			 SPI_MODE_CPHA)					\
+
+#define IIS2MDC_CONFIG_SPI(inst)					\
+	{								\
+		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
+		.bus_init = iis2mdc_spi_init,				\
+		.bus_cfg.spi_cfg =					\
+			SPI_CONFIG_DT_INST(inst,			\
+					   IIS2MDC_SPI_OP,		\
+					   0),				\
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),	\
+			(IIS2MDC_CFG_IRQ(inst)), ())			\
+	}
+
+/*
+ * Instantiation macros used when a device is on an I2C bus.
+ */
+
+#define IIS2MDC_CONFIG_I2C(inst)					\
+	{								\
+		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
+		.bus_init = iis2mdc_i2c_init,				\
+		.bus_cfg.i2c_slv_addr = DT_INST_REG_ADDR(inst),		\
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),	\
+			(IIS2MDC_CFG_IRQ(inst)), ())			\
+	}
+
+/*
+ * Main instantiation macro. Use of COND_CODE_1() selects the right
+ * bus-specific macro at preprocessor time.
+ */
+
+#define IIS2MDC_DEFINE(inst)						\
+	static struct iis2mdc_data iis2mdc_data_##inst;			\
+	static const struct iis2mdc_dev_config iis2mdc_config_##inst =	\
+		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
+			(IIS2MDC_CONFIG_SPI(inst)),			\
+			(IIS2MDC_CONFIG_I2C(inst)));			\
+	IIS2MDC_DEVICE_INIT(inst)
+
+DT_INST_FOREACH_STATUS_OKAY(IIS2MDC_DEFINE)

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -11,46 +11,42 @@
 #ifndef __MAG_IIS2MDC_H
 #define __MAG_IIS2MDC_H
 
-#include <drivers/spi.h>
 #include <drivers/gpio.h>
 #include <drivers/sensor.h>
 #include <sys/util.h>
 #include "iis2mdc_reg.h"
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#include <drivers/spi.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-union axis1bit16_t {
-	int16_t i16bit;
-	uint8_t u8bit[2];
-};
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#include <drivers/i2c.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
-struct iis2mdc_config {
-	char *master_dev_name;
-	int (*bus_init)(const struct device *dev);
-#ifdef CONFIG_IIS2MDC_TRIGGER
-	const char *drdy_port;
-	gpio_pin_t drdy_pin;
-	gpio_dt_flags_t drdy_flags;
-#endif  /* CONFIG_IIS2MDC_TRIGGER */
+
+union iis2mdc_bus_cfg {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	uint16_t i2c_slv_addr;
-#elif DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_config spi_conf;
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const char *gpio_cs_port;
-	uint8_t cs_gpio;
-	uint8_t cs_gpio_flags;
-#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
+#endif
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	struct spi_config spi_cfg;
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+};
+
+struct iis2mdc_dev_config {
+	const struct device *bus;
+	int (*bus_init)(const struct device *dev);
+	const union iis2mdc_bus_cfg bus_cfg;
+#ifdef CONFIG_IIS2MDC_TRIGGER
+	const struct gpio_dt_spec gpio_drdy;
+#endif  /* CONFIG_IIS2MDC_TRIGGER */
 };
 
 /* Sensor data */
 struct iis2mdc_data {
 	const struct device *dev;
-	const struct device *bus;
 	uint16_t i2c_addr;
 	int16_t mag[3];
 	int32_t temp_sample;
@@ -59,12 +55,12 @@ struct iis2mdc_data {
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	stmdev_ctx_t ctx_i2c;
-#elif DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	stmdev_ctx_t ctx_spi;
 #endif
 
 #ifdef CONFIG_IIS2MDC_TRIGGER
-	const struct device *gpio;
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
@@ -77,9 +73,6 @@ struct iis2mdc_data {
 	struct k_work work;
 #endif  /* CONFIG_IIS2MDC_TRIGGER_GLOBAL_THREAD */
 #endif  /* CONFIG_IIS2MDC_TRIGGER */
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	struct spi_cs_control cs_ctrl;
-#endif /* DT_INST_SPI_DEV_HAS_CS_GPIOS(0) */
 };
 
 int iis2mdc_spi_init(const struct device *dev);

--- a/drivers/sensor/iis2mdc/iis2mdc_i2c.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_i2c.c
@@ -11,30 +11,29 @@
 #define DT_DRV_COMPAT st_iis2mdc
 
 #include <string.h>
-#include <drivers/i2c.h>
 #include <logging/log.h>
 
 #include "iis2mdc.h"
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 
-#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
-LOG_MODULE_DECLARE(IIS2MDC);
+LOG_MODULE_DECLARE(IIS2MDC, CONFIG_SENSOR_LOG_LEVEL);
 
-static int iis2mdc_i2c_read(struct iis2mdc_data *data, uint8_t reg_addr,
-			    uint8_t *value, uint16_t len)
-{	const struct iis2mdc_config *cfg = data->dev->config;
+static int iis2mdc_i2c_read(const struct device *dev, uint8_t reg_addr,
+				 uint8_t *value, uint16_t len)
+{
+	const struct iis2mdc_dev_config *cfg = dev->config;
 
-	return i2c_burst_read(data->bus, cfg->i2c_slv_addr,
+	return i2c_burst_read(cfg->bus, cfg->bus_cfg.i2c_slv_addr,
 			      reg_addr, value, len);
 }
 
-static int iis2mdc_i2c_write(struct iis2mdc_data *data, uint8_t reg_addr,
-			     uint8_t *value, uint16_t len)
+static int iis2mdc_i2c_write(const struct device *dev, uint8_t reg_addr,
+				  uint8_t *value, uint16_t len)
 {
-	const struct iis2mdc_config *cfg = data->dev->config     ;
+	const struct iis2mdc_dev_config *cfg = dev->config;
 
-	return i2c_burst_write(data->bus, cfg->i2c_slv_addr,
+	return i2c_burst_write(cfg->bus, cfg->bus_cfg.i2c_slv_addr,
 			       reg_addr, value, len);
 }
 
@@ -46,7 +45,7 @@ int iis2mdc_i2c_init(const struct device *dev)
 	data->ctx_i2c.write_reg = (stmdev_write_ptr) iis2mdc_i2c_write;
 
 	data->ctx = &data->ctx_i2c;
-	data->ctx->handle = data;
+	data->ctx->handle = (void *)dev;
 
 	return 0;
 }

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -109,13 +109,6 @@ int iis2mdc_spi_init(const struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = (void *)dev;
 
-#if CONFIG_IIS2MDC_SPI_FULL_DUPLEX
-	/* Set SPI 4wires */
-	if (iis2mdc_spi_mode_set(data->ctx, IIS2MDC_SPI_4_WIRE) < 0) {
-		return -EIO;
-	}
-#endif
-
 	return 0;
 }
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -18,15 +18,14 @@
 
 #define IIS2MDC_SPI_READ		(1 << 7)
 
-#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
-LOG_MODULE_DECLARE(IIS2MDC);
+LOG_MODULE_DECLARE(IIS2MDC, CONFIG_SENSOR_LOG_LEVEL);
 
-static int iis2mdc_spi_read(struct iis2mdc_data *data, uint8_t reg_addr,
-			    uint8_t *value, uint8_t len)
+static int iis2mdc_spi_read(const struct device *dev, uint8_t reg,
+			    uint8_t *val, uint16_t len)
 {
-	const struct iis2mdc_config *cfg = data->dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
-	uint8_t buffer_tx[2] = { reg_addr | IIS2MDC_SPI_READ, 0 };
+	const struct iis2mdc_dev_config *cfg = dev->config;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg;
+	uint8_t buffer_tx[2] = { reg | IIS2MDC_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
 			.len = 2,
@@ -41,7 +40,7 @@ static int iis2mdc_spi_read(struct iis2mdc_data *data, uint8_t reg_addr,
 			.len = 1,
 		},
 		{
-			.buf = value,
+			.buf = val,
 			.len = len,
 		}
 	};
@@ -50,31 +49,30 @@ static int iis2mdc_spi_read(struct iis2mdc_data *data, uint8_t reg_addr,
 		.count = 2
 	};
 
-
 	if (len > 64) {
 		return -EIO;
 	}
 
-	if (spi_transceive(data->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive(cfg->bus, spi_cfg, &tx, &rx)) {
 		return -EIO;
 	}
 
 	return 0;
 }
 
-static int iis2mdc_spi_write(struct iis2mdc_data *data, uint8_t reg_addr,
-			     uint8_t *value, uint8_t len)
+static int iis2mdc_spi_write(const struct device *dev, uint8_t reg,
+			     uint8_t *val, uint16_t len)
 {
-	const struct iis2mdc_config *cfg = data->dev->config;
-	const struct spi_config *spi_cfg = &cfg->spi_conf;
-	uint8_t buffer_tx[1] = { reg_addr & ~IIS2MDC_SPI_READ };
+	const struct iis2mdc_dev_config *cfg = dev->config;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg;
+	uint8_t buffer_tx[1] = { reg & ~IIS2MDC_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
 			.buf = buffer_tx,
 			.len = 1,
 		},
 		{
-			.buf = value,
+			.buf = val,
 			.len = len,
 		}
 	};
@@ -83,12 +81,11 @@ static int iis2mdc_spi_write(struct iis2mdc_data *data, uint8_t reg_addr,
 		.count = 2
 	};
 
-
 	if (len > 64) {
 		return -EIO;
 	}
 
-	if (spi_write(data->bus, spi_cfg, &tx)) {
+	if (spi_write(cfg->bus, spi_cfg, &tx)) {
 		return -EIO;
 	}
 
@@ -98,30 +95,19 @@ static int iis2mdc_spi_write(struct iis2mdc_data *data, uint8_t reg_addr,
 int iis2mdc_spi_init(const struct device *dev)
 {
 	struct iis2mdc_data *data = dev->data;
+	const struct iis2mdc_dev_config *const cfg = dev->config;
+	const struct spi_cs_control *cs_ctrl = cfg->bus_cfg.spi_cfg.cs;
+
+	if (!device_is_ready(cs_ctrl->gpio_dev)) {
+		LOG_ERR("Cannot get pointer to CS gpio device");
+		return -ENODEV;
+	}
 
 	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2mdc_spi_read;
 	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2mdc_spi_write;
 
 	data->ctx = &data->ctx_spi;
-	data->ctx->handle = data;
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	const struct iis2mdc_config *cfg = dev->config;
-
-	/* handle SPI CS thru GPIO if it is the case */
-	data->cs_ctrl.gpio_dev = device_get_binding(cfg->gpio_cs_port);
-	if (!data->cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
-	}
-
-	data->cs_ctrl.gpio_pin = cfg->cs_gpio;
-	data->cs_ctrl.gpio_dt_flags = cfg->cs_gpio_flags;
-	data->cs_ctrl.delay = 0;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		cfg->gpio_cs_port, cfg->cs_gpio);
-#endif
+	data->ctx->handle = (void *)dev;
 
 #if CONFIG_IIS2MDC_SPI_FULL_DUPLEX
 	/* Set SPI 4wires */


### PR DESCRIPTION
IIS2MDC sensor

1. Add multi-instance support
2. Remove SPI 4-wires (FIX)

Tested on IKS02A1 shield

EDIT:
I made use of new helpers introduced in #30536 (DEVICE_DT_GET, SPI_CONFIG_DT_INST).
The SPI part was tested in #32874, with a different sensor (iis2iclx) but with same approach
