### PR TITLE
drivers: wifi: esp: suppress warning logs when socket was closed

### DIFF
--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -398,7 +398,7 @@ MODEM_CMD_DEFINE(on_cmd_closed)
 				ESP_SOCK_CONNECTED, ESP_SOCK_CLOSE_PENDING);
 
 	if (!(old_flags & ESP_SOCK_CONNECTED)) {
-		LOG_WRN("Link %d already closed", link_id);
+		LOG_DBG("Link %d already closed", link_id);
 		goto socket_unref;
 	}
 


### PR DESCRIPTION
Socket can be closed either by Zephyr or by peer. In the former case ESP
WiFi chip still notfies about closed socket, which currently results in
printing warning log:

```
<wrn> wifi_esp: Link X already closed
```

Change level of this log from warning to debug, so that driver users are
not concerned about situation that is a normal behaviour.