### PR TITLE
net: tcp2: Cleanup properly if running out of mem

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -337,7 +337,7 @@ static void tcp_send_queue_flush(struct tcp *conn)
 
 	k_delayed_work_cancel(&conn->send_timer);
 
-	while ((pkt = tcp_slist(&conn->send_queue, get,
+	while ((pkt = tcp_slist(conn, &conn->send_queue, get,
 				struct net_pkt, next))) {
 		tcp_pkt_unref(pkt);
 	}
@@ -430,7 +430,7 @@ static bool tcp_send_process_no_lock(struct tcp *conn)
 	bool unref = false;
 	struct net_pkt *pkt;
 
-	pkt = tcp_slist(&conn->send_queue, peek_head,
+	pkt = tcp_slist(conn, &conn->send_queue, peek_head,
 			struct net_pkt, next);
 	if (!pkt) {
 		goto out;
@@ -456,8 +456,9 @@ static bool tcp_send_process_no_lock(struct tcp *conn)
 		bool forget = ACK == fl || PSH == fl || (ACK | PSH) == fl ||
 			RST & fl;
 
-		pkt = forget ? tcp_slist(&conn->send_queue, get, struct net_pkt,
-						next) : tcp_pkt_clone(pkt);
+		pkt = forget ? tcp_slist(conn, &conn->send_queue, get,
+					 struct net_pkt, next) :
+			tcp_pkt_clone(pkt);
 		if (!pkt) {
 			NET_ERR("net_pkt alloc failure");
 			goto out;
@@ -505,7 +506,7 @@ static void tcp_send_timer_cancel(struct tcp *conn)
 	k_delayed_work_cancel(&conn->send_timer);
 
 	{
-		struct net_pkt *pkt = tcp_slist(&conn->send_queue, get,
+		struct net_pkt *pkt = tcp_slist(conn, &conn->send_queue, get,
 						struct net_pkt, next);
 		if (pkt) {
 			NET_DBG("%s", log_strdup(tcp_th(pkt)));

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -302,13 +302,19 @@ static void tcp_send(struct net_pkt *pkt)
 	if (is_6lo_technology(pkt)) {
 		struct net_pkt *new_pkt;
 
-		new_pkt = net_pkt_clone(pkt, TCP_PKT_ALLOC_TIMEOUT);
+		new_pkt = tcp_pkt_clone(pkt);
 		if (!new_pkt) {
+			/* The caller of this func assumes that the net_pkt
+			 * is consumed by this function. We call unref here
+			 * so that the unref at the end of the func will
+			 * free the net_pkt.
+			 */
+			tcp_pkt_unref(pkt);
 			goto out;
 		}
 
 		if (net_send_data(new_pkt) < 0) {
-			net_pkt_unref(new_pkt);
+			tcp_pkt_unref(new_pkt);
 		}
 
 		/* We simulate sending of the original pkt and unref it like
@@ -352,15 +358,14 @@ static int tcp_conn_unref(struct tcp *conn)
 	}
 #endif /* CONFIG_NET_TEST_PROTOCOL */
 
-	ref_count = atomic_dec(&conn->ref_count) - 1;
+	k_mutex_lock(&tcp_lock, K_FOREVER);
 
+	ref_count = atomic_dec(&conn->ref_count) - 1;
 	if (ref_count) {
 		tp_out(net_context_get_family(conn->context), conn->iface,
 		       "TP_TRACE", "event", "CONN_DELETE");
-		goto out;
+		goto unlock;
 	}
-
-	k_mutex_lock(&tcp_lock, K_FOREVER);
 
 	/* If there is any pending data, pass that to application */
 	while ((pkt = k_fifo_get(&conn->recv_data, K_NO_WAIT)) != NULL) {
@@ -401,6 +406,7 @@ static int tcp_conn_unref(struct tcp *conn)
 
 	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
 
+unlock:
 	k_mutex_unlock(&tcp_lock);
 out:
 	return ref_count;
@@ -679,7 +685,7 @@ static int tcp_data_get(struct tcp *conn, struct net_pkt *pkt, size_t *len)
 	}
 
 	if (conn->context->recv_cb) {
-		struct net_pkt *up = net_pkt_clone(pkt, TCP_PKT_ALLOC_TIMEOUT);
+		struct net_pkt *up = tcp_pkt_clone(pkt);
 
 		if (!up) {
 			ret = -ENOBUFS;
@@ -913,11 +919,11 @@ static int tcp_send_data(struct tcp *conn)
 		conn->unacked_len += len;
 
 		if (conn->data_mode == TCP_DATA_MODE_RESEND) {
-			net_stats_update_tcp_resent(net_pkt_iface(pkt), len);
+			net_stats_update_tcp_resent(conn->iface, len);
 			net_stats_update_tcp_seg_rexmit(conn->iface);
 		} else {
-			net_stats_update_tcp_sent(net_pkt_iface(pkt), len);
-			net_stats_update_tcp_seg_sent(net_pkt_iface(pkt));
+			net_stats_update_tcp_sent(conn->iface, len);
+			net_stats_update_tcp_seg_sent(conn->iface);
 		}
 	}
 
@@ -1083,38 +1089,44 @@ static struct tcp *tcp_conn_alloc(void)
 
 	ret = k_mem_slab_alloc(&tcp_conns_slab, (void **)&conn, K_NO_WAIT);
 	if (ret) {
+		NET_ERR("Cannot allocate slab");
 		goto out;
 	}
 
 	memset(conn, 0, sizeof(*conn));
 
+	if (CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT) {
+		conn->queue_recv_data = tcp_rx_pkt_alloc(conn, 0);
+		if (conn->queue_recv_data == NULL) {
+			NET_ERR("Cannot allocate %s queue for conn %p", "recv",
+				conn);
+			goto fail;
+		}
+	}
+
+	conn->send_data = tcp_pkt_alloc(conn, 0);
+	if (conn->send_data == NULL) {
+		NET_ERR("Cannot allocate %s queue for conn %p", "send", conn);
+		goto fail;
+	}
+
 	k_mutex_init(&conn->lock);
 	k_fifo_init(&conn->recv_data);
+	k_sem_init(&conn->connect_sem, 0, UINT_MAX);
 
+	conn->in_connect = false;
 	conn->state = TCP_LISTEN;
-
 	conn->recv_win = tcp_window;
-
 	conn->seq = (IS_ENABLED(CONFIG_NET_TEST_PROTOCOL) ||
 		     IS_ENABLED(CONFIG_NET_TEST)) ? 0 : sys_rand32_get();
 
 	sys_slist_init(&conn->send_queue);
 
 	k_delayed_work_init(&conn->send_timer, tcp_send_process);
-
 	k_delayed_work_init(&conn->timewait_timer, tcp_timewait_timeout);
 	k_delayed_work_init(&conn->fin_timer, tcp_fin_timeout);
-
-	if (CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT) {
-		conn->queue_recv_data = tcp_rx_pkt_alloc(conn, 0);
-	}
-
-	conn->send_data = tcp_pkt_alloc(conn, 0);
 	k_delayed_work_init(&conn->send_data_timer, tcp_resend_data);
 	k_delayed_work_init(&conn->recv_queue_timer, tcp_cleanup_recv_queue);
-
-	k_sem_init(&conn->connect_sem, 0, UINT_MAX);
-	conn->in_connect = false;
 
 	tcp_conn_ref(conn);
 
@@ -1123,6 +1135,15 @@ out:
 	NET_DBG("conn: %p", conn);
 
 	return conn;
+
+fail:
+	if (CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT && conn->queue_recv_data) {
+		tcp_pkt_unref(conn->queue_recv_data);
+		conn->queue_recv_data = NULL;
+	}
+
+	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
+	return NULL;
 }
 
 int net_tcp_get(struct net_context *context)

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -369,9 +369,13 @@ static int tcp_conn_unref(struct tcp *conn)
 
 	/* If there is any pending data, pass that to application */
 	while ((pkt = k_fifo_get(&conn->recv_data, K_NO_WAIT)) != NULL) {
-		net_context_packet_received(
-			(struct net_conn *)conn->context->conn_handler,
-			pkt, NULL, NULL, conn->recv_user_data);
+		if (net_context_packet_received(
+			    (struct net_conn *)conn->context->conn_handler,
+			    pkt, NULL, NULL, conn->recv_user_data) ==
+		    NET_DROP) {
+			/* Application is no longer there, unref the pkt */
+			tcp_pkt_unref(pkt);
+		}
 	}
 
 	if (conn->context->conn_handler) {
@@ -1795,8 +1799,12 @@ next_state:
 	 */
 	while (conn_handler && atomic_get(&conn->ref_count) > 0 &&
 	       (recv_pkt = k_fifo_get(recv_data_fifo, K_NO_WAIT)) != NULL) {
-		net_context_packet_received(conn_handler, recv_pkt, NULL, NULL,
-					    recv_user_data);
+		if (net_context_packet_received(conn_handler, recv_pkt, NULL,
+						NULL, recv_user_data) ==
+		    NET_DROP) {
+			/* Application is no longer there, unref the pkt */
+			tcp_pkt_unref(recv_pkt);
+		}
 	}
 
 	/* We must not try to unref the connection while having a connection

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -20,11 +20,15 @@
 #define th_flags(_x) UNALIGNED_GET(&(_x)->th_flags)
 #define th_win(_x) UNALIGNED_GET(&(_x)->th_win)
 
-#define tcp_slist(_slist, _op, _type, _link)				\
+#define tcp_slist(_conn, _slist, _op, _type, _link)			\
 ({									\
+	k_mutex_lock(&conn->lock, K_FOREVER);				\
+									\
 	sys_snode_t *_node = sys_slist_##_op(_slist);			\
 									\
 	_type * _x = _node ? CONTAINER_OF(_node, _type, _link) : NULL;	\
+									\
+	k_mutex_unlock(&conn->lock);					\
 									\
 	_x;								\
 })


### PR DESCRIPTION
If we cannot allocate net_pkt or net_buf, then check the condition
properly and release other resources that needs to be allocated.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>