### PR TITLE
adc: Fix stm32 driver and sample

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -319,15 +319,15 @@ static int start_read(const struct device *dev,
 	}
 
 	uint32_t channels = sequence->channels;
-	if (channels > find_lsb_set(channels)) {
+	uint8_t index = find_lsb_set(channels) - 1;
+
+	if (channels > BIT(index)) {
 		LOG_ERR("Only single channel supported");
 		return -ENOTSUP;
 	}
 
 	data->buffer = sequence->buffer;
-	uint8_t index;
 
-	index = find_lsb_set(channels) - 1;
 	uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(index);
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	/*

--- a/samples/drivers/adc/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/adc/boards/disco_l475_iot1.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Linaro Limited
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 5>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -4,9 +4,10 @@ tests:
   sample.drivers.adc:
     tags: ADC
     depends_on: adc
-    platform_allow: nucleo_l073rz
+    platform_allow: nucleo_l073rz disco_l475_iot1
     harness: console
+    timeout: 10
     harness_config:
-      type: single_line
+      type: one_line
       regex:
-        - "ADC reading(s): (.*)"
+        - "ADC reading: (.*)"

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -98,7 +98,7 @@ void main(void)
 			return;
 		}
 
-		printk("ADC reading(s):");
+		printk("ADC reading:");
 		for (uint8_t i = 0; i < ADC_NUM_CHANNELS; i++) {
 			int32_t raw_value = sample_buffer[i];
 


### PR DESCRIPTION
Few fixes following merge of https://github.com/zephyrproject-rtos/zephyr/pull/25590

```
    drivers/adc: stm32: Use bitfield for multiple channels detection
    
    For multiple channels detection, channels variable was compared with
    the output of find_lsb_set which actually is a decimal number.
    Since channel is a bitfield the comparison was not behaving as
    expected (detecting several channels while only one channel was used).
```

```
    samples/drivers/adc: Few fixes for use with twister
    
    Add some changes to adc sample to enable valid verdict generation
    using twister:
    -Replace 'single_line' keyword with correct 'one_line'
    -Remove parenthesis from the sample output to enable regex verdict
    -Add timeout to save time in execution
    
    Additionally, add support for disco_l475_iot1.
```

Fixes #31782