### PR TITLE
net: lwm2m: Add application/link-format content writer

### DIFF
--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources(
     lwm2m_obj_security.c
     lwm2m_obj_server.c
     lwm2m_obj_device.c
+    lwm2m_rw_link_format.c
     lwm2m_rw_plain_text.c
     lwm2m_rw_oma_tlv.c
     lwm2m_util.c

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -40,6 +40,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+#include "lwm2m_rw_link_format.h"
 #include "lwm2m_rw_plain_text.h"
 #include "lwm2m_rw_oma_tlv.h"
 #ifdef CONFIG_LWM2M_RW_JSON_SUPPORT
@@ -1165,7 +1166,7 @@ static int select_writer(struct lwm2m_output_context *out, uint16_t accept)
 	switch (accept) {
 
 	case LWM2M_FORMAT_APP_LINK_FORMAT:
-		/* TODO: rewrite do_discover as content formatter */
+		out->writer = &link_format_writer;
 		break;
 
 	case LWM2M_FORMAT_PLAIN_TEXT:
@@ -3129,86 +3130,22 @@ move_forward:
 	return ret;
 }
 
-static int print_attr(struct lwm2m_output_context *out,
-		      uint8_t *buf, uint16_t buflen, void *ref)
+int lwm2m_discover_handler(struct lwm2m_message *msg, bool is_bootstrap)
 {
-	struct lwm2m_attr *attr;
-	int i, used, base, ret;
-	uint8_t digit;
-	int32_t fraction;
-
-	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
-		if (ref != write_attr_pool[i].ref) {
-			continue;
-		}
-
-		attr = write_attr_pool + i;
-
-		/* assuming integer will have float_val.val2 set as 0 */
-
-		used = snprintk(buf, buflen, ";%s=%s%d%s",
-				LWM2M_ATTR_STR[attr->type],
-				attr->float_val.val1 == 0 &&
-				attr->float_val.val2 < 0 ? "-" : "",
-				attr->float_val.val1,
-				attr->float_val.val2 != 0 ? "." : "");
-
-		base = 100000;
-		fraction = attr->float_val.val2 < 0 ?
-			   -attr->float_val.val2 : attr->float_val.val2;
-		while (fraction && used < buflen && base > 0) {
-			digit = fraction / base;
-			buf[used++] = '0' + digit;
-			fraction -= digit * base;
-			base /= 10;
-		}
-
-		ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, used);
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
-static int print_resource_dimension(struct lwm2m_output_context *out,
-				    uint8_t *buf, uint16_t buflen,
-				    struct lwm2m_engine_res *res)
-{
-	int ret, i, inst_count = 0;
-
-	if (res->multi_res_inst) {
-		for (i = 0; i < res->res_inst_count; i++) {
-			if (res->res_instances[i].res_inst_id !=
-			    RES_INSTANCE_NOT_CREATED) {
-				inst_count++;
-			}
-		}
-
-		snprintk(buf, buflen, ";dim=%d", inst_count);
-		ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf,
-				 strlen(buf));
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
-static int do_discover_op(struct lwm2m_message *msg)
-{
-	static char disc_buf[24];
 	struct lwm2m_engine_obj *obj;
 	struct lwm2m_engine_obj_inst *obj_inst;
 	int ret;
 	bool reported = false;
 
-	/* object ID is required in Device Management Discovery (5.4.2).
-	 */
-	if (msg->path.level == 0U ||
-	    msg->path.obj_id == LWM2M_OBJECT_SECURITY_ID) {
+	/* Object ID is required in Device Management Discovery (5.4.2). */
+	if (!is_bootstrap &&
+	    (msg->path.level == LWM2M_PATH_LEVEL_NONE ||
+	     msg->path.obj_id == LWM2M_OBJECT_SECURITY_ID)) {
+		return -EPERM;
+	}
+
+	/* Bootstrap discovery allows to specify at most Object ID. */
+	if (is_bootstrap && msg->path.level > LWM2M_PATH_LEVEL_OBJECT) {
 		return -EPERM;
 	}
 
@@ -3226,115 +3163,115 @@ static int do_discover_op(struct lwm2m_message *msg)
 		return ret;
 	}
 
-	/* Report object attributes only when Object ID (alone) was
-	 * provided (and do it only once in case of multiple instances).
+	/*
+	 * Add required prefix for bootstrap discovery (5.2.7.3).
+	 * For device management discovery, `engine_put_begin()` adds nothing.
 	 */
-	if (msg->path.level == 1) {
-		SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_list, obj, node) {
-			if (obj->obj_id != msg->path.obj_id) {
-				continue;
-			}
+	engine_put_begin(&msg->out, &msg->path);
 
-			snprintk(disc_buf, sizeof(disc_buf), "%s</%u>",
-				 reported ? "," : "", obj->obj_id);
+	SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_list, obj, node) {
+		/* Skip unrelated objects */
+		if (msg->path.level > 0 && msg->path.obj_id != obj->obj_id) {
+			continue;
+		}
 
-			ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-					 disc_buf, strlen(disc_buf));
-			if (ret < 0) {
-				return ret;
-			}
+		/* For bootstrap discover, only report object ID when no
+		 * instance is available.
+		 * For device management discovery, only report object ID with
+		 * attributes if object ID (alone) was provided.
+		 */
+		if ((is_bootstrap && obj->instance_count == 0U) ||
+		    (!is_bootstrap && msg->path.level == LWM2M_PATH_LEVEL_OBJECT)) {
+			struct lwm2m_obj_path path = {
+				.obj_id = obj->obj_id,
+				.level = LWM2M_PATH_LEVEL_OBJECT,
+			};
 
-			/* report object attrs (5.4.2) */
-			ret = print_attr(&msg->out, disc_buf, sizeof(disc_buf),
-					 obj);
+			ret = engine_put_corelink(&msg->out, &path);
 			if (ret < 0) {
 				return ret;
 			}
 
 			reported = true;
-			break;
-		}
-	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_inst_list, obj_inst, node) {
-		if (obj_inst->obj->obj_id != msg->path.obj_id) {
-			continue;
+			if (is_bootstrap) {
+				continue;
+			}
 		}
 
-		/* skip unrelated object instance */
-		if (msg->path.level > 1 &&
-		    msg->path.obj_inst_id != obj_inst->obj_inst_id) {
-			continue;
-		}
-
-		/* Report object instances only if Resource ID is missing. */
-		if (msg->path.level <= 2U) {
-			snprintk(disc_buf, sizeof(disc_buf), "%s</%u/%u>",
-				 reported ? "," : "",
-				 obj_inst->obj->obj_id, obj_inst->obj_inst_id);
-
-			ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-					 disc_buf, strlen(disc_buf));
-			if (ret < 0) {
-				return ret;
+		SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_inst_list,
+					     obj_inst, node) {
+			if (obj_inst->obj->obj_id != obj->obj_id) {
+				continue;
 			}
 
-			/* Report object instance attributes only when Instance
-			 * ID was specified (5.4.2).
+			/* Skip unrelated object instance. */
+			if (msg->path.level > LWM2M_PATH_LEVEL_OBJECT &&
+			    msg->path.obj_inst_id != obj_inst->obj_inst_id) {
+				continue;
+			}
+
+			/* Report object instances only if no Resource ID is
+			 * provided.
 			 */
-			if (msg->path.level == 2U) {
-				ret = print_attr(&msg->out, disc_buf,
-						 sizeof(disc_buf), obj_inst);
+			if (msg->path.level <= LWM2M_PATH_LEVEL_OBJECT_INST) {
+				struct lwm2m_obj_path path = {
+					.obj_id = obj_inst->obj->obj_id,
+					.obj_inst_id = obj_inst->obj_inst_id,
+					.level = LWM2M_PATH_LEVEL_OBJECT_INST,
+				};
+
+				ret = engine_put_corelink(&msg->out, &path);
 				if (ret < 0) {
 					return ret;
 				}
+
+				reported = true;
 			}
 
-			reported = true;
-		}
-
-		for (int i = 0; i < obj_inst->resource_count; i++) {
-			/* skip unrelated resources */
-			if (msg->path.level == 3U &&
-			    msg->path.res_id != obj_inst->resources[i].res_id) {
+			/* Do not report resources in bootstrap discovery. */
+			if (is_bootstrap) {
 				continue;
 			}
 
-			snprintk(disc_buf, sizeof(disc_buf),
-				 "%s</%u/%u/%u>",
-				 reported ? "," : "",
-				 obj_inst->obj->obj_id,
-				 obj_inst->obj_inst_id,
-				 obj_inst->resources[i].res_id);
+			for (int i = 0; i < obj_inst->resource_count; i++) {
+				/* Skip unrelated resources. */
+				if (msg->path.level == LWM2M_PATH_LEVEL_RESOURCE &&
+				    msg->path.res_id != obj_inst->resources[i].res_id) {
+					continue;
+				}
 
-			ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-					 disc_buf, strlen(disc_buf));
-			if (ret < 0) {
-				return ret;
-			}
+				struct lwm2m_obj_path path = {
+					.obj_id = obj_inst->obj->obj_id,
+					.obj_inst_id = obj_inst->obj_inst_id,
+					.res_id = obj_inst->resources[i].res_id,
+					.level = LWM2M_PATH_LEVEL_RESOURCE,
+				};
 
-			/* report resource attrs when path > 1 (5.4.2) */
-			if (msg->path.level > 1) {
-				ret = print_resource_dimension(
-					&msg->out, disc_buf, sizeof(disc_buf),
-					&obj_inst->resources[i]);
+				ret = engine_put_corelink(&msg->out, &path);
 				if (ret < 0) {
 					return ret;
 				}
 
-				ret = print_attr(&msg->out,
-						 disc_buf, sizeof(disc_buf),
-						 &obj_inst->resources[i]);
-				if (ret < 0) {
-					return ret;
-				}
+				reported = true;
 			}
-
-			reported = true;
 		}
 	}
 
 	return reported ? 0 : -ENOENT;
+}
+
+static int do_discover_op(struct lwm2m_message *msg, uint16_t content_format)
+{
+	switch (content_format) {
+	case LWM2M_FORMAT_APP_LINK_FORMAT:
+		return do_discover_op_link_format(
+				msg, msg->ctx->bootstrap_mode);
+
+	default:
+		LOG_ERR("Unsupported format: %u", content_format);
+		return -ENOMSG;
+	}
 }
 
 int lwm2m_get_or_create_engine_obj(struct lwm2m_message *msg,
@@ -3510,149 +3447,6 @@ static int bootstrap_delete(struct lwm2m_message *msg)
 	}
 
 	return ret;
-}
-
-static inline int bs_discover_fill_enabler(struct lwm2m_message *msg)
-{
-	char buf[sizeof("lwm2m='" LWM2M_PROTOCOL_VERSION "'")];
-
-	snprintk(buf, sizeof(buf), "lwm2m=\"%s\"", LWM2M_PROTOCOL_VERSION);
-	return buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt), buf, strlen(buf));
-}
-
-static inline int bs_discover_fill_object(struct lwm2m_engine_obj *obj,
-					  struct lwm2m_message *msg)
-{
-	char buf[sizeof(",</xxxxx>")];
-
-	snprintk(buf, sizeof(buf), ",</%u>", obj->obj_id);
-	return buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt), buf, strlen(buf));
-}
-
-static int bs_discover_fill_instance(struct lwm2m_engine_obj_inst *obj_inst,
-				     struct lwm2m_message *msg)
-{
-	char buf[sizeof(",</xxxxx/xxxxx>")];
-	bool bootstrap_inst;
-	uint16_t server_id;
-	int ret;
-
-	snprintk(buf, sizeof(buf), ",</%u/%u>", obj_inst->obj->obj_id,
-		 obj_inst->obj_inst_id);
-
-	ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt), buf, strlen(buf));
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Security and Server instnaces shall report Short Server ID associated
-	 * with them (but only if not bootstrap instance).
-	 */
-	if (obj_inst->obj->obj_id == LWM2M_OBJECT_SECURITY_ID) {
-		snprintk(buf, sizeof(buf), "0/%d/1", obj_inst->obj_inst_id);
-		ret = lwm2m_engine_get_bool(buf, &bootstrap_inst);
-		if (ret < 0) {
-			return ret;
-		}
-
-		if (!bootstrap_inst) {
-			snprintk(buf, sizeof(buf), "0/%d/10",
-				 obj_inst->obj_inst_id);
-			ret = lwm2m_engine_get_u16(buf, &server_id);
-			if (ret < 0) {
-				return ret;
-			}
-
-			snprintk(buf, sizeof(buf), ";ssid=%d", server_id);
-			ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-					buf, strlen(buf));
-			if (ret < 0) {
-				return ret;
-			}
-		}
-	}
-
-	if (obj_inst->obj->obj_id == LWM2M_OBJECT_SERVER_ID) {
-		snprintk(buf, sizeof(buf), "1/%d/0", obj_inst->obj_inst_id);
-		ret = lwm2m_engine_get_u16(buf, &server_id);
-		if (ret < 0) {
-			return ret;
-		}
-
-		snprintk(buf, sizeof(buf), ";ssid=%d", server_id);
-		ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-				 buf, strlen(buf));
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
-static int bootstrap_discover(struct lwm2m_message *msg)
-{
-	struct lwm2m_engine_obj *obj;
-	struct lwm2m_engine_obj_inst *obj_inst;
-	int ret;
-	bool reported = false;
-
-	/* set output content-format */
-	ret = coap_append_option_int(msg->out.out_cpkt,
-				     COAP_OPTION_CONTENT_FORMAT,
-				     LWM2M_FORMAT_APP_LINK_FORMAT);
-	if (ret < 0) {
-		LOG_ERR("Error setting response content-format: %d", ret);
-		return ret;
-	}
-
-	ret = coap_packet_append_payload_marker(msg->out.out_cpkt);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/*
-	 * lwm2m spec 20170208-A sec 5.2.7.3 bootstrap discover on "/"
-	 * - prefixed w/ lwm2m enabler version. e.g. lwm2m="1.0"
-	 * - returns object and object instances only
-	 */
-	ret = bs_discover_fill_enabler(msg);
-	if (ret < 0) {
-		return ret;
-	}
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_list, obj, node) {
-		if (msg->path.level > 0 && msg->path.obj_id != obj->obj_id) {
-			continue;
-		}
-
-		/* Only report </OBJ_ID> when no instance available */
-		if (obj->instance_count == 0U) {
-			ret = bs_discover_fill_object(obj, msg);
-			if (ret < 0) {
-				return ret;
-			}
-
-			reported = true;
-			continue;
-		}
-
-		SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_inst_list,
-					     obj_inst, node) {
-			if (obj_inst->obj->obj_id != obj->obj_id) {
-				continue;
-			}
-
-			ret = bs_discover_fill_instance(obj_inst, msg);
-			if (ret < 0) {
-				return ret;
-			}
-
-			reported = true;
-		}
-	}
-
-	return reported ? 0 : -ENOENT;
 }
 #endif
 
@@ -3957,13 +3751,7 @@ static int handle_request(struct coap_packet *request,
 			break;
 
 		case LWM2M_OP_DISCOVER:
-#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
-			if (msg->ctx->bootstrap_mode) {
-				r = bootstrap_discover(msg);
-				break;
-			}
-#endif
-			r = do_discover_op(msg);
+			r = do_discover_op(msg, accept);
 			break;
 
 		case LWM2M_OP_WRITE:

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1367,6 +1367,37 @@ static int path_to_objs(const struct lwm2m_obj_path *path,
 	return 0;
 }
 
+struct lwm2m_attr *lwm2m_engine_get_next_attr(const void *ref,
+					      struct lwm2m_attr *prev)
+{
+	struct lwm2m_attr *iter = (prev == NULL) ? write_attr_pool : prev + 1;
+	struct lwm2m_attr *result = NULL;
+
+	if (!PART_OF_ARRAY(write_attr_pool, iter)) {
+		return NULL;
+	}
+
+	while (iter < &write_attr_pool[ARRAY_SIZE(write_attr_pool)]) {
+		if (ref == iter->ref) {
+			result = iter;
+			break;
+		}
+
+		++iter;
+	}
+
+	return result;
+}
+
+const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr)
+{
+	if (attr->type >= NR_LWM2M_ATTR) {
+		return NULL;
+	}
+
+	return LWM2M_ATTR_STR[attr->type];
+}
+
 int lwm2m_engine_create_obj_inst(char *pathstr)
 {
 	struct lwm2m_obj_path path;
@@ -3367,6 +3398,44 @@ int lwm2m_get_or_create_engine_obj(struct lwm2m_message *msg,
 	}
 
 	return ret;
+}
+
+struct lwm2m_engine_obj *lwm2m_engine_get_obj(
+					const struct lwm2m_obj_path *path)
+{
+	if (path->level < LWM2M_PATH_LEVEL_OBJECT) {
+		return NULL;
+	}
+
+	return get_engine_obj(path->obj_id);
+}
+
+struct lwm2m_engine_obj_inst *lwm2m_engine_get_obj_inst(
+					const struct lwm2m_obj_path *path)
+{
+	if (path->level < LWM2M_PATH_LEVEL_OBJECT_INST) {
+		return NULL;
+	}
+
+	return get_engine_obj_inst(path->obj_id, path->obj_inst_id);
+}
+
+struct lwm2m_engine_res *lwm2m_engine_get_res(
+					const struct lwm2m_obj_path *path)
+{
+	struct lwm2m_engine_res *res = NULL;
+	int ret;
+
+	if (path->level < LWM2M_PATH_LEVEL_RESOURCE) {
+		return NULL;
+	}
+
+	ret = path_to_objs(path, NULL, NULL, &res, NULL);
+	if (ret < 0) {
+		return NULL;
+	}
+
+	return res;
 }
 
 static int do_write_op(struct lwm2m_message *msg,

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -59,8 +59,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ENGINE_UPDATE_INTERVAL_MS 500
 #define OBSERVE_COUNTER_START 0U
 
-#define WELL_KNOWN_CORE_PATH	"</.well-known/core>"
-
 /*
  * TODO: to implement a way for clients to specify alternate path
  * via Kconfig (LwM2M specification 8.2.2 Alternate Path)
@@ -3199,7 +3197,7 @@ static int print_resource_dimension(struct lwm2m_output_context *out,
 	return 0;
 }
 
-static int do_discover_op(struct lwm2m_message *msg, bool well_known)
+static int do_discover_op(struct lwm2m_message *msg)
 {
 	static char disc_buf[24];
 	struct lwm2m_engine_obj *obj;
@@ -3207,12 +3205,10 @@ static int do_discover_op(struct lwm2m_message *msg, bool well_known)
 	int ret;
 	bool reported = false;
 
-	/* object ID is required unless it's a ".well-known/core" discovery
-	 * ref: lwm2m spec 20170208-A table 11
+	/* object ID is required in Device Management Discovery (5.4.2).
 	 */
-	if (!well_known &&
-	    (msg->path.level == 0U ||
-	     msg->path.obj_id == LWM2M_OBJECT_SECURITY_ID)) {
+	if (msg->path.level == 0U ||
+	    msg->path.obj_id == LWM2M_OBJECT_SECURITY_ID) {
 		return -EPERM;
 	}
 
@@ -3228,30 +3224,6 @@ static int do_discover_op(struct lwm2m_message *msg, bool well_known)
 	ret = coap_packet_append_payload_marker(msg->out.out_cpkt);
 	if (ret < 0) {
 		return ret;
-	}
-
-	/* Handle CoAP .well-known/core discover */
-	if (well_known) {
-		/* </.well-known/core> */
-		ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-				 WELL_KNOWN_CORE_PATH,
-				 strlen(WELL_KNOWN_CORE_PATH));
-		if (ret < 0) {
-			return ret;
-		}
-
-		SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_list, obj, node) {
-			snprintk(disc_buf, sizeof(disc_buf), ",</%u>",
-				 obj->obj_id);
-
-			ret = buf_append(CPKT_BUF_WRITE(msg->out.out_cpkt),
-					 disc_buf, strlen(disc_buf));
-			if (ret < 0) {
-				return ret;
-			}
-		}
-
-		return 0;
 	}
 
 	/* Report object attributes only when Object ID (alone) was
@@ -3695,7 +3667,6 @@ static int handle_request(struct coap_packet *request,
 	uint8_t tkl = 0U;
 	uint16_t format = LWM2M_FORMAT_NONE, accept;
 	int observe = -1; /* default to -1, 0 = ENABLE, 1 = DISABLE */
-	bool well_known = false;
 	int block_opt, block_num;
 	struct lwm2m_block_context *block_ctx = NULL;
 	enum coap_block_size block_size;
@@ -3755,22 +3726,10 @@ static int handle_request(struct coap_packet *request,
 		}
 	}
 
-	/* check for .well-known/core URI query (DISCOVER) */
-	if (r == 2 &&
-	    (options[0].len == 11U &&
-	     strncmp(options[0].value, ".well-known", 11) == 0) &&
-	    (options[1].len == 4U &&
-	     strncmp(options[1].value, "core", 4) == 0)) {
-		if ((code & COAP_REQUEST_MASK) != COAP_METHOD_GET) {
-			r = -EPERM;
-			goto error;
-		}
-
-		well_known = true;
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	/* check for bootstrap-finish */
-	} else if ((code & COAP_REQUEST_MASK) == COAP_METHOD_POST && r == 1 && \
-		   strncmp(options[0].value, "bs", options[0].len) == 0) {
+	if ((code & COAP_REQUEST_MASK) == COAP_METHOD_POST && r == 1 &&
+	    strncmp(options[0].value, "bs", options[0].len) == 0) {
 		engine_bootstrap_finish();
 
 		msg->code = COAP_RESPONSE_CODE_CHANGED;
@@ -3781,8 +3740,9 @@ static int handle_request(struct coap_packet *request,
 		}
 
 		return 0;
+	} else
 #endif
-	} else {
+	{
 		r = coap_options_to_path(options, r, &msg->path);
 		if (r < 0) {
 			r = -ENOENT;
@@ -3815,8 +3775,7 @@ static int handle_request(struct coap_packet *request,
 		goto error;
 	}
 
-	if (!well_known && !(msg->ctx->bootstrap_mode &&
-			     msg->path.level == 0)) {
+	if (!(msg->ctx->bootstrap_mode && msg->path.level == 0)) {
 		/* find registered obj */
 		obj = get_engine_obj(msg->path.obj_id);
 		if (!obj) {
@@ -3834,7 +3793,7 @@ static int handle_request(struct coap_packet *request,
 		 * LwM2M V1_0_1-20170704-A, table 25,
 		 * Discover: CoAP GET + accept=LWM2M_FORMAT_APP_LINK_FORMAT
 		 */
-		if (well_known || accept == LWM2M_FORMAT_APP_LINK_FORMAT) {
+		if (accept == LWM2M_FORMAT_APP_LINK_FORMAT) {
 			msg->operation = LWM2M_OP_DISCOVER;
 			accept = LWM2M_FORMAT_APP_LINK_FORMAT;
 		} else {
@@ -4004,7 +3963,7 @@ static int handle_request(struct coap_packet *request,
 				break;
 			}
 #endif
-			r = do_discover_op(msg, well_known);
+			r = do_discover_op(msg);
 			break;
 
 		case LWM2M_OP_WRITE:

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -97,6 +97,8 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_message *msg);
 
+int lwm2m_discover_handler(struct lwm2m_message *msg, bool is_bootstrap);
+
 enum coap_block_size lwm2m_default_block_size(void);
 
 int lwm2m_engine_add_service(k_work_handler_t service, uint32_t period_ms);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -65,6 +65,13 @@ int  lwm2m_get_or_create_engine_obj(struct lwm2m_message *msg,
 				    struct lwm2m_engine_obj_inst **obj_inst,
 				    uint8_t *created);
 
+struct lwm2m_engine_obj *lwm2m_engine_get_obj(
+					const struct lwm2m_obj_path *path);
+struct lwm2m_engine_obj_inst *lwm2m_engine_get_obj_inst(
+					const struct lwm2m_obj_path *path);
+struct lwm2m_engine_res *lwm2m_engine_get_res(
+					const struct lwm2m_obj_path *path);
+
 /* LwM2M context functions */
 int lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx);
 void lwm2m_engine_context_init(struct lwm2m_ctx *client_ctx);
@@ -117,6 +124,12 @@ void lwm2m_firmware_set_update_state(uint8_t state);
 void lwm2m_firmware_set_update_result(uint8_t result);
 uint8_t lwm2m_firmware_get_update_result(void);
 #endif
+
+/* Attribute handling. */
+
+struct lwm2m_attr *lwm2m_engine_get_next_attr(const void *ref,
+					      struct lwm2m_attr *prev);
+const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 
 /* Network Layer */
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -87,7 +87,7 @@ int lwm2m_init_message(struct lwm2m_message *msg);
 int lwm2m_send_message(struct lwm2m_message *msg);
 int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid);
 
-uint16_t lwm2m_get_rd_data(uint8_t *client_data, uint16_t size);
+int lwm2m_register_payload_handler(struct lwm2m_message *msg);
 
 int lwm2m_perform_read_op(struct lwm2m_message *msg, uint16_t content_format);
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -140,6 +140,12 @@
 struct lwm2m_engine_obj;
 struct lwm2m_message;
 
+#define LWM2M_PATH_LEVEL_NONE 0
+#define LWM2M_PATH_LEVEL_OBJECT 1
+#define LWM2M_PATH_LEVEL_OBJECT_INST 2
+#define LWM2M_PATH_LEVEL_RESOURCE 3
+#define LWM2M_PATH_LEVEL_RESOURCE_INST 4
+
 /* path representing object instances */
 struct lwm2m_obj_path {
 	uint16_t obj_id;

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -52,6 +52,7 @@
 #include <net/net_ip.h>
 #include <sys/printk.h>
 #include <sys/util.h>
+#include <sys/types.h>
 
 #include <net/coap.h>
 #include <net/lwm2m.h>
@@ -504,6 +505,8 @@ struct lwm2m_writer {
 	size_t (*put_objlnk)(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
 			     struct lwm2m_objlnk *value);
+	ssize_t (*put_corelink)(struct lwm2m_output_context *out,
+				const struct lwm2m_obj_path *path);
 };
 
 struct lwm2m_reader {
@@ -717,6 +720,16 @@ static inline size_t engine_put_objlnk(struct lwm2m_output_context *out,
 				       struct lwm2m_objlnk *value)
 {
 	return out->writer->put_objlnk(out, path, value);
+}
+
+static inline ssize_t engine_put_corelink(struct lwm2m_output_context *out,
+					  const struct lwm2m_obj_path *path)
+{
+	if (out->writer->put_corelink) {
+		return out->writer->put_corelink(out, path);
+	}
+
+	return -ENOTSUP;
 }
 
 static inline size_t engine_get_s32(struct lwm2m_input_context *in,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <logging/log.h>
+
+#include "lwm2m_engine.h"
+#include "lwm2m_rw_link_format.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_link_format, CONFIG_LWM2M_LOG_LEVEL);
+
+#define CORELINK_BUF_SIZE 24
+
+struct link_format_out_formatter_data {
+	uint8_t request_level;
+	bool is_bootstrap : 1;
+	bool is_first : 1;
+};
+
+static size_t put_begin(struct lwm2m_output_context *out,
+			struct lwm2m_obj_path *path)
+{
+	char enabler_ver[] = "lwm2m=\"" LWM2M_PROTOCOL_VERSION "\"";
+	struct link_format_out_formatter_data *fd;
+	int ret;
+
+	fd = engine_get_out_user_data(out);
+	if (fd == NULL) {
+		return 0;
+	}
+
+	if (!fd->is_bootstrap) {
+		/* Nothing to add in device management mode. */
+		return 0;
+	}
+
+	fd->is_first = false;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), enabler_ver,
+			 strlen(enabler_ver));
+	if (ret < 0) {
+		return 0;
+	}
+
+	return strlen(enabler_ver);
+}
+
+static int put_corelink_separator(struct lwm2m_output_context *out)
+{
+	char comma = ',';
+	int ret;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), &comma, sizeof(comma));
+	if (ret < 0) {
+		return ret;
+	}
+
+	return (int)sizeof(comma);
+}
+
+static int put_corelink_dimension(struct lwm2m_output_context *out,
+				  const struct lwm2m_engine_res *res,
+				  uint8_t *buf, uint16_t buflen)
+{
+	int ret, inst_count = 0, len = 0;
+
+	if (res->multi_res_inst) {
+		for (int i = 0; i < res->res_inst_count; i++) {
+			if (res->res_instances[i].res_inst_id !=
+			    RES_INSTANCE_NOT_CREATED) {
+				inst_count++;
+			}
+		}
+
+		len = snprintk(buf, buflen, ";dim=%d", inst_count);
+		if (len < 0 || len >= buflen) {
+			return -ENOMEM;
+		}
+
+		ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, len);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return len;
+}
+
+static int put_corelink_attributes(struct lwm2m_output_context *out,
+				   const void *ref, uint8_t *buf,
+				   uint16_t buflen)
+{
+	struct lwm2m_attr *attr = NULL;
+	int used, base, ret;
+	uint8_t digit;
+	int32_t fraction;
+	int len = 0;
+
+	while ((attr = lwm2m_engine_get_next_attr(ref, attr)) != NULL) {
+		const char *name = lwm2m_engine_get_attr_name(attr);
+
+		if (name == NULL) {
+			/* Invalid attribute, ignore. */
+			continue;
+		}
+
+		/* Assuming integer will have float_val.val2 set as 0. */
+		used = snprintk(buf, buflen, ";%s=%s%d%s",
+				name,
+				attr->float_val.val1 == 0 &&
+				attr->float_val.val2 < 0 ? "-" : "",
+				attr->float_val.val1,
+				attr->float_val.val2 != 0 ? "." : "");
+		if (used < 0 || used >= buflen) {
+			return -ENOMEM;
+		}
+
+		base = 100000;
+		fraction = attr->float_val.val2 < 0 ?
+			   -attr->float_val.val2 : attr->float_val.val2;
+		while (fraction && used < buflen && base > 0) {
+			digit = fraction / base;
+			buf[used++] = '0' + digit;
+			fraction -= digit * base;
+			base /= 10;
+		}
+
+		len += used;
+
+		ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, used);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return len;
+}
+
+static int put_corelink_ssid(struct lwm2m_output_context *out,
+			     const struct lwm2m_obj_path *path,
+			     uint8_t *buf, uint16_t buflen)
+{
+	uint16_t server_id = 0;
+	int ret;
+	int len;
+
+	switch (path->obj_id) {
+	case LWM2M_OBJECT_SECURITY_ID: {
+		bool bootstrap_inst;
+
+		ret = snprintk(buf, buflen, "0/%d/1",
+			       path->obj_inst_id);
+		if (ret < 0 || ret >= buflen) {
+			return -ENOMEM;
+		}
+
+		ret = lwm2m_engine_get_bool(buf, &bootstrap_inst);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Bootstrap Security object instance does not have associated
+		 * Server object instance, so do not report ssid for it.
+		 */
+		if (bootstrap_inst) {
+			return 0;
+		}
+
+		ret = snprintk(buf, buflen, "0/%d/10",
+				path->obj_inst_id);
+		if (ret < 0 || ret >= buflen) {
+			return -ENOMEM;
+		}
+
+		ret = lwm2m_engine_get_u16(buf, &server_id);
+		if (ret < 0) {
+			return ret;
+		}
+
+		break;
+	}
+
+	case LWM2M_OBJECT_SERVER_ID:
+		ret = snprintk(buf, buflen, "1/%d/0", path->obj_inst_id);
+		if (ret < 0 || ret >= buflen) {
+			return -ENOMEM;
+		}
+
+		ret = lwm2m_engine_get_u16(buf, &server_id);
+		if (ret < 0) {
+			return ret;
+		}
+
+		break;
+
+	default:
+		LOG_ERR("Invalid object ID for ssid attribute: %d",
+			path->obj_id);
+		return -EINVAL;
+	}
+
+	len = snprintk(buf, buflen, ";ssid=%d", server_id);
+	if (len < 0 || len >= buflen) {
+		return -ENOMEM;
+	}
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return len;
+}
+
+static int put_obj_corelink(struct lwm2m_output_context *out,
+			    const struct lwm2m_obj_path *path,
+			    struct link_format_out_formatter_data *fd)
+{
+	char obj_buf[CORELINK_BUF_SIZE];
+	int len = 0;
+	int ret;
+
+	ret = snprintk(obj_buf, sizeof(obj_buf), "</%u>", path->obj_id);
+	if (ret < 0 || ret >= sizeof(obj_buf)) {
+		return -ENOMEM;
+	}
+
+	len += ret;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), obj_buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!fd->is_bootstrap) {
+		/* Report object attributes only in device management mode
+		 * (5.4.2).
+		 */
+		struct lwm2m_engine_obj *obj = lwm2m_engine_get_obj(path);
+
+		if (obj == NULL) {
+			return -EINVAL;
+		}
+
+		ret = put_corelink_attributes(out, obj, obj_buf,
+					      sizeof(obj_buf));
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+	}
+
+	return len;
+}
+
+static int put_obj_inst_corelink(struct lwm2m_output_context *out,
+				 const struct lwm2m_obj_path *path,
+				 struct link_format_out_formatter_data *fd)
+{
+	char obj_buf[CORELINK_BUF_SIZE];
+	int len = 0;
+	int ret;
+
+	ret = snprintk(obj_buf, sizeof(obj_buf), "</%u/%u>",
+		       path->obj_id, path->obj_inst_id);
+	if (ret < 0 || ret >= sizeof(obj_buf)) {
+		return -ENOMEM;
+	}
+
+	len += ret;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), obj_buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Bootstrap object instance corelink shall only contain ssid
+	 * parameter for Security and Server objects (5.2.7.3).
+	 */
+	if (fd->is_bootstrap) {
+		if (path->obj_id == LWM2M_OBJECT_SECURITY_ID ||
+		    path->obj_id == LWM2M_OBJECT_SERVER_ID) {
+			ret = put_corelink_ssid(out, path, obj_buf,
+						sizeof(obj_buf));
+			if (ret < 0) {
+				return ret;
+			}
+
+			len += ret;
+		}
+
+		return len;
+	}
+
+	/* Report object instance attributes only when Instance
+	 * ID was specified (5.4.2).
+	 */
+	if (fd->request_level == LWM2M_PATH_LEVEL_OBJECT_INST) {
+		struct lwm2m_engine_obj_inst *obj_inst =
+					lwm2m_engine_get_obj_inst(path);
+
+		if (obj_inst == NULL) {
+			return -EINVAL;
+		}
+
+		ret = put_corelink_attributes(out, obj_inst, obj_buf,
+					      sizeof(obj_buf));
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+	}
+
+	return len;
+}
+
+static int put_res_corelink(struct lwm2m_output_context *out,
+			    const struct lwm2m_obj_path *path,
+			    struct link_format_out_formatter_data *fd)
+{
+	char obj_buf[CORELINK_BUF_SIZE];
+	int len = 0;
+	int ret;
+
+	if (fd->is_bootstrap) {
+		/* No resource reporting in bootstrap mode. */
+		return 0;
+	}
+
+	ret = snprintk(obj_buf, sizeof(obj_buf), "</%u/%u/%u>", path->obj_id,
+		       path->obj_inst_id, path->res_id);
+	if (ret < 0 || ret >= sizeof(obj_buf)) {
+		return -ENOMEM;
+	}
+
+	len += ret;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), obj_buf, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Report resource attrs when at least object instance was specified
+	 * (5.4.2).
+	 */
+	if (fd->request_level >= LWM2M_PATH_LEVEL_OBJECT_INST) {
+		struct lwm2m_engine_res *res = lwm2m_engine_get_res(path);
+
+		if (res == NULL) {
+			return -EINVAL;
+		}
+
+		ret = put_corelink_dimension(out, res, obj_buf,
+					     sizeof(obj_buf));
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+
+		ret = put_corelink_attributes(out, res, obj_buf,
+					      sizeof(obj_buf));
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+	}
+
+	return len;
+}
+
+static ssize_t put_corelink(struct lwm2m_output_context *out,
+			    const struct lwm2m_obj_path *path)
+{
+	struct link_format_out_formatter_data *fd;
+	ssize_t len = 0;
+	int ret;
+
+	fd = engine_get_out_user_data(out);
+	if (fd == NULL) {
+		return -EINVAL;
+	}
+
+	if (fd->is_first) {
+		fd->is_first = false;
+	} else {
+		ret = put_corelink_separator(out);
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+	}
+
+	switch (path->level) {
+	case LWM2M_PATH_LEVEL_OBJECT:
+		ret =  put_obj_corelink(out, path, fd);
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+		break;
+
+	case LWM2M_PATH_LEVEL_OBJECT_INST:
+		ret = put_obj_inst_corelink(out, path, fd);
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+		break;
+
+	case LWM2M_PATH_LEVEL_RESOURCE:
+		ret = put_res_corelink(out, path, fd);
+		if (ret < 0) {
+			return ret;
+		}
+
+		len += ret;
+		break;
+
+	default:
+		LOG_ERR("Invalid corelink path level: %d", path->level);
+		return -EINVAL;
+	}
+
+	return len;
+}
+
+const struct lwm2m_writer link_format_writer = {
+	.put_begin = put_begin,
+	.put_corelink = put_corelink,
+};
+
+int do_discover_op_link_format(struct lwm2m_message *msg, bool is_bootstrap)
+{
+	struct link_format_out_formatter_data fd;
+	int ret;
+
+	fd.is_first = true;
+	fd.is_bootstrap = is_bootstrap;
+	fd.request_level = msg->path.level;
+
+	engine_set_out_user_data(&msg->out, &fd);
+	ret = lwm2m_discover_handler(msg, is_bootstrap);
+	engine_clear_out_user_data(&msg->out);
+
+	return ret;
+}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LWM2M_RW_LINK_FORMAT_H_
+#define LWM2M_RW_LINK_FORMAT_H_
+
+#include "lwm2m_object.h"
+
+extern const struct lwm2m_writer link_format_writer;
+
+int do_discover_op_link_format(struct lwm2m_message *msg, bool is_bootstrap);
+
+#endif /* LWM2M_RW_LINK_FORMAT_H_ */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.h
@@ -12,5 +12,6 @@
 extern const struct lwm2m_writer link_format_writer;
 
 int do_discover_op_link_format(struct lwm2m_message *msg, bool is_bootstrap);
+int do_register_op_link_format(struct lwm2m_message *msg);
 
 #endif /* LWM2M_RW_LINK_FORMAT_H_ */


### PR DESCRIPTION
This PR adds a new content writer for the `application/link-format` data format. The new writer encapsulates link-format details and is reused in Discovery, Bootstrap Discovery, Registration and Registration Update procedures.

Along with the content writer, introduce a few helper functions needed to handle attributes outside of lwm2m_engine. 

The final change in this PR is the removal of `.well-known/core` resource handling in the lwm2m_engine. The LwM2M specification makes no mention that this resource should be implemented (it's optional in CoAP RFC), instead it defines an LwM2M specific Discovery mechanism. I really couldn't find a reason to justify its existence, and as it made the Discovery handler more complex I've decided to remove it.
 
Resolves #3933
Fixes #32939