### PR TITLE
ci: add .buildkite/daily.yml to twister ignore list

### DIFF
--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -5,6 +5,7 @@
 # are matched, then twister will not do a full run and optionally will only
 # run on changed tests or boards.
 #
+.buildkite/daily.yml
 .gitlint
 .checkpatch.conf
 .clang-format


### PR DESCRIPTION
Changes to .buildkite/daily.yml don't make any sense to run twister
for since issues will only be seen when the daily builds run so add
it to the twister_ignore.txt list.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>