### PR TITLE
Revert "boards: arm: nrf5340: default to build TFM without BL2 for NS builds"

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -22,18 +22,6 @@ config BOARD
 config BUILD_WITH_TFM
 	default y if BOARD_NRF5340DK_NRF5340_CPUAPPNS || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
 
-if BUILD_WITH_TFM
-
-# By default, force building TF-M without bootloader support.
-
-choice TFM_BL2
-	bool
-	prompt "BL2 configuration, should TFM build with MCUboot support"
-	default TFM_BL2_FALSE
-endchoice
-
-endif # BUILD_WITH_TFM
-
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning


### PR DESCRIPTION
To give consistency with nrf91. Also, BL2 builds are now faster since
tfm-mcuboot is fetched via west.

This reverts commit 88a865c28de37c04978958005b60339ff579ed24.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>