### PR TITLE
ci: add action to create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Create a Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1
+        with:
+          args: spdx -o zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
+
+      - name: upload-results
+        uses: actions/upload-artifact@master
+        continue-on-error: True
+        with:
+          name: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
+          path: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
+
+      - name: Get Diff since last tag
+        run: |
+          oldtag=$(git describe --abbrev=0 ${{ github.ref }}^)
+          echo "Changes since ${oldtag}:" > release-notes.txt
+          echo "" >> release-notes.txt
+          echo "" >> release-notes.txt
+          git shortlog ${oldtag}..${{ github.ref }} >> release-notes.txt
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Zephyr ${{ github.ref }}
+          body_path: release-notes.txt
+          draft: true
+          prerelease: true
+
+      - name: Upload Release Assets
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
+          asset_name: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
+          asset_content_type: text/plain

--- a/doc/development_process/release_process.rst
+++ b/doc/development_process/release_process.rst
@@ -290,18 +290,27 @@ steps:
             $ git tag -s -m "Zephyr 1.11.0-rc1" v1.11.0-rc1
             $ git push git@github.com:zephyrproject-rtos/zephyr.git v1.11.0-rc1
 
-        #. Create a shortlog of changes between the previous release (use
-           rc1..rc2 between release candidates)::
+        #. Once the tag is pushed, a github action will create a draft release
+           in Github with a shortlog since the last tag. The action will also
+           create a SPDX manifest of the Zephyr tree and will add the file as an
+           asset in the release.
 
-            $ git shortlog v1.10.0..v1.11.0-rc1
+           Go to the draft release that was created and edit as needed. If this
+           step fails for a reason, it can be done manually following the steps
+           below:
 
-        #. Find the new tag at the top of the releases page and edit the release
-           with the ``Edit tag`` button with the following:
+                #. Create a shortlog of changes between the previous release (use
+                   rc1..rc2 between release candidates)::
 
-            * Name it ``Zephyr 1.11.0-rc1``
-            * Copy the shortlog into the release notes textbox (*don't forget
-              to quote it properly so it shows as unformatted text in Markdown*)
-            * Check the "This is a pre-release" checkbox
+                    $ git shortlog v1.10.0..v1.11.0-rc1
+
+                #. Find the new tag at the top of the releases page and edit the release
+                   with the ``Edit tag`` button with the following:
+
+                    * Name it ``Zephyr 1.11.0-rc1``
+                    * Copy the shortlog into the release notes textbox (*don't forget
+                      to quote it properly so it shows as unformatted text in Markdown*)
+                    * Check the "This is a pre-release" checkbox
 
         #. Send an email to the mailing lists (``announce`` and ``devel``)
            with a link to the release


### PR DESCRIPTION
Action to create release when tag is pushed. This will additionally
create an SPDX file and the changelog since the last tag.

The release is created as a draft and will have to be modified by the
release engineer and published when ready.