### PR TITLE
fs: Fix fs_diropen resource leak when invoked on fs_dir_t object in use

### DIFF
--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -223,7 +223,7 @@ struct fs_statvfs {
 /**
  * @brief Initialize fs_file_t object
  *
- * Initialized the fs_file_t object; the function needs to be invoked
+ * Initializes the fs_file_t object; the function needs to be invoked
  * on object before first use with fs_open.
  *
  * @param zfp Pointer to file object

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -235,6 +235,20 @@ static inline void fs_file_t_init(struct fs_file_t *zfp)
 }
 
 /**
+ * @brief Initialize fs_dir_t object
+ *
+ * Initializes the fs_dir_t object; the function needs to be invoked
+ * on object before first use with fs_opendir.
+ *
+ * @param zdp Pointer to file object
+ *
+ */
+static inline void fs_dir_t_init(struct fs_dir_t *zdp)
+{
+	*zdp = (struct fs_dir_t){ 0 };
+}
+
+/**
  * @brief Open or create file
  *
  * Opens or possibly creates a file and associates a stream with it.

--- a/include/fs/fs_interface.h
+++ b/include/fs/fs_interface.h
@@ -59,6 +59,8 @@ struct fs_file_t {
 /**
  * @brief Directory object representing an open directory
  *
+ * The object needs to be initialized with function fs_dir_t_init().
+ *
  * @param dirp Pointer to directory object structure
  * @param mp Pointer to mount point structure
  */

--- a/lib/gui/lvgl/lvgl_fs.c
+++ b/lib/gui/lvgl/lvgl_fs.c
@@ -214,6 +214,7 @@ static lv_fs_res_t lvgl_fs_dir_open(struct _lv_fs_drv_t *drv, void *dir,
 	 */
 	path--;
 
+	fs_dir_t_init((struct fs_dir_t *)dir);
 	err = fs_opendir((struct fs_dir_t *)dir, path);
 	return errno_to_lv_fs_res(err);
 }

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -230,7 +230,7 @@ DIR *opendir(const char *dirname)
 		return NULL;
 	}
 
-	(void)memset(&ptr->dir, 0, sizeof(ptr->dir));
+	fs_dir_t_init(&ptr->dir);
 
 	rc = fs_opendir(&ptr->dir, dirname);
 	if (rc < 0) {

--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -84,6 +84,8 @@ static int lsdir(const char *path)
 	struct fs_dir_t dirp;
 	static struct fs_dirent entry;
 
+	fs_dir_t_init(&dirp);
+
 	/* Verify fs_opendir() */
 	res = fs_opendir(&dirp, path);
 	if (res) {

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -125,7 +125,9 @@ void main(void)
 	rc = fs_close(&file);
 	printk("%s close: %d\n", fname, rc);
 
-	struct fs_dir_t dir = { 0 };
+	struct fs_dir_t dir;
+
+	fs_dir_t_init(&dir);
 
 	rc = fs_opendir(&dir, mp->mnt_point);
 	printk("%s opendir: %d\n", mp->mnt_point, rc);

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -84,9 +84,11 @@ static int mount_app_fs(struct fs_mount_t *mnt)
 static void setup_disk(void)
 {
 	struct fs_mount_t *mp = &fs_mnt;
-	struct fs_dir_t dir = { 0 };
+	struct fs_dir_t dir;
 	struct fs_statvfs sbuf;
 	int rc;
+
+	fs_dir_t_init(&dir);
 
 	if (IS_ENABLED(CONFIG_DISK_ACCESS_FLASH)) {
 		rc = setup_flash(mp);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -328,6 +328,11 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 		return -EINVAL;
 	}
 
+	if (zdp->mp != NULL || zdp->dirp != NULL) {
+		return -EBUSY;
+	}
+
+
 	if (strcmp(abs_path, "/") == 0) {
 		/* Open VFS root dir, marked by zdp->mp == NULL */
 		k_mutex_lock(&mutex, K_FOREVER);
@@ -353,6 +358,8 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 	zdp->mp = mp;
 	rc = zdp->mp->fs->opendir(zdp, abs_path);
 	if (rc < 0) {
+		zdp->mp = NULL;
+		zdp->dirp = NULL;
 		LOG_ERR("directory open error (%d)", rc);
 	}
 
@@ -461,6 +468,7 @@ int fs_closedir(struct fs_dir_t *zdp)
 	}
 
 	zdp->mp = NULL;
+	zdp->dirp = NULL;
 	return rc;
 }
 

--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -169,6 +169,8 @@ static int fuse_fs_access_readdir(const char *path, void *buf,
 		return fuse_fs_access_readmount(buf, filler);
 	}
 
+	fs_dir_t_init(&dir);
+
 	if (is_mount_point(path)) {
 		/* File system API expects trailing slash for a mount point
 		 * directory but FUSE strips the trailing slashes from

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -137,6 +137,8 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 		create_abs_path(argv[1], path, sizeof(path));
 	}
 
+	fs_dir_t_init(&dir);
+
 	err = fs_opendir(&dir, path);
 	if (err) {
 		shell_error(shell, "Unable to open %s (err %d)", path, err);

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
@@ -65,6 +65,8 @@ static int test_lsdir(const char *path)
 
 	TC_PRINT("\nlsdir tests:\n");
 
+	fs_dir_t_init(&dirp);
+
 	/* Verify fs_opendir() */
 	res = fs_opendir(&dirp, path);
 	if (res) {
@@ -104,6 +106,8 @@ static int test_rmdir(void)
 	char file_path[80 + MAX_FILE_NAME];
 
 	TC_PRINT("\nrmdir tests:\n");
+
+	fs_dir_t_init(&dirp);
 
 	if (!check_file_dir_exists(TEST_DIR)) {
 		TC_PRINT("%s doesn't exist\n", TEST_DIR);

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
@@ -70,6 +70,8 @@ static int test_lsdir(const char *path)
 
 	TC_PRINT("lsdir tests:\n");
 
+	fs_dir_t_init(&dirp);
+
 	/* Verify fs_opendir() */
 	res = fs_opendir(&dirp, path);
 	if (res) {
@@ -109,6 +111,8 @@ static int test_rmdir(const char *dir)
 	char file_path[80];
 
 	TC_PRINT("rmdir tests:\n");
+
+	fs_dir_t_init(&dirp);
 
 	if (!check_file_dir_exists(dir)) {
 		TC_PRINT("%s doesn't exist\n", dir);

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -78,6 +78,7 @@ void test_main(void)
 			 ztest_unit_test(test_mkdir),
 			 ztest_unit_test(test_opendir),
 			 ztest_unit_test(test_closedir),
+			 ztest_unit_test(test_opendir_closedir),
 			 ztest_unit_test(test_lsdir),
 			 ztest_unit_test(test_file_open),
 			 ztest_unit_test(test_file_write),

--- a/tests/subsys/fs/fs_api/src/main.c
+++ b/tests/subsys/fs/fs_api/src/main.c
@@ -73,6 +73,7 @@ void test_main(void)
 							fs_setup,
 							dummy_teardown),
 			 ztest_unit_test(test_fs_file_t_init),
+			 ztest_unit_test(test_fs_dir_t_init),
 			 ztest_unit_test(test_file_statvfs),
 			 ztest_unit_test(test_mkdir),
 			 ztest_unit_test(test_opendir),

--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -22,6 +22,7 @@ static char *cur = buffer;
 static int file_length;
 static struct fs_mount_t *mp[FS_TYPE_EXTERNAL_BASE];
 static bool nospace;
+static int opendir_result;
 
 static
 int temp_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
@@ -208,17 +209,21 @@ static int temp_mkdir(struct fs_mount_t *mountp, const char *path)
 	return 0;
 }
 
+void mock_opendir_result(int ret)
+{
+	opendir_result = ret;
+}
+
 static int temp_opendir(struct fs_dir_t *zdp, const char *path)
 {
 	if (zdp == NULL || path == NULL) {
 		return -EINVAL;
 	}
 
-	if (zdp->dirp) {
-		if (strcmp(zdp->dirp, path) == 0) {
-			return -EIO;
-		}
+	if (opendir_result) {
+		return opendir_result;
 	}
+
 	zdp->dirp = (char *)path;
 	return 0;
 }

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -32,6 +32,7 @@ struct test_fs_data {
 	int reserve;
 };
 
+void test_fs_dir_t_init(void);
 void test_fs_file_t_init(void);
 void test_fs_register(void);
 void test_mount(void);

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -32,6 +32,8 @@ struct test_fs_data {
 	int reserve;
 };
 
+void mock_opendir_result(int ret);
+
 void test_fs_dir_t_init(void);
 void test_fs_file_t_init(void);
 void test_fs_register(void);

--- a/tests/subsys/fs/fs_api/src/test_fs.h
+++ b/tests/subsys/fs/fs_api/src/test_fs.h
@@ -34,6 +34,7 @@ struct test_fs_data {
 
 void mock_opendir_result(int ret);
 
+void test_opendir_closedir(void);
 void test_fs_dir_t_init(void);
 void test_fs_file_t_init(void);
 void test_fs_register(void);

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -273,11 +273,13 @@ void test_mkdir(void)
 void test_opendir(void)
 {
 	int ret;
-	struct fs_dir_t dirp;
+	struct fs_dir_t dirp, dirp2, dirp3;
 
 	TC_PRINT("\nopendir tests:\n");
 
 	fs_dir_t_init(&dirp);
+	fs_dir_t_init(&dirp2);
+	fs_dir_t_init(&dirp3);
 
 	TC_PRINT("Test null path\n");
 	ret = fs_opendir(NULL, NULL);
@@ -303,11 +305,11 @@ void test_opendir(void)
 	ret = fs_opendir(&dirp, "/");
 	zassert_equal(ret, 0, "Fail to open root dir");
 
-	ret = fs_opendir(&dirp, TEST_DIR);
+	ret = fs_opendir(&dirp2, TEST_DIR);
 	zassert_equal(ret, 0, "Fail to open dir");
 
 	TC_PRINT("Open same directory multi times\n");
-	ret = fs_opendir(&dirp, TEST_DIR);
+	ret = fs_opendir(&dirp3, TEST_DIR);
 	zassert_not_equal(ret, 0, "Can't reopen an opened dir");
 }
 
@@ -369,6 +371,7 @@ static int _test_lsdir(const char *path)
 	}
 
 	TC_PRINT("read an opened dir\n");
+	fs_dir_t_init(&dirp);
 	ret = fs_opendir(&dirp, path);
 	if (ret) {
 		if (path) {

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -94,6 +94,20 @@ void test_fs_file_t_init(void)
 }
 
 /**
+ * @brief Test fs_dir_t_init initializer
+ */
+void test_fs_dir_t_init(void)
+{
+	struct fs_dir_t dirp;
+
+	memset(&dirp, 0xff, sizeof(dirp));
+
+	fs_dir_t_init(&dirp);
+	zassert_equal(dirp.mp, NULL, "Expected to be initialized to NULL");
+	zassert_equal(dirp.dirp, NULL, "Expected to be initialized to NULL");
+}
+
+/**
  * @brief Test mount interface of filesystem
  *
  * @details
@@ -263,7 +277,8 @@ void test_opendir(void)
 
 	TC_PRINT("\nopendir tests:\n");
 
-	memset(&dirp, 0, sizeof(dirp));
+	fs_dir_t_init(&dirp);
+
 	TC_PRINT("Test null path\n");
 	ret = fs_opendir(NULL, NULL);
 	zassert_not_equal(ret, 0, "Open dir with NULL pointer parameter");
@@ -307,7 +322,7 @@ void test_closedir(void)
 	struct fs_dir_t dirp;
 
 	TC_PRINT("\nclosedir tests: %s\n", TEST_DIR);
-	memset(&dirp, 0, sizeof(dirp));
+	fs_dir_t_init(&dirp);
 	ret = fs_opendir(&dirp, TEST_DIR);
 	zassert_equal(ret, 0, "Fail to open dir");
 
@@ -331,7 +346,7 @@ static int _test_lsdir(const char *path)
 
 	TC_PRINT("\nlsdir tests:\n");
 
-	memset(&dirp, 0, sizeof(dirp));
+	fs_dir_t_init(&dirp);
 	memset(&entry, 0, sizeof(entry));
 
 	TC_PRINT("read an unopened dir\n");

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -308,9 +308,11 @@ void test_opendir(void)
 	ret = fs_opendir(&dirp2, TEST_DIR);
 	zassert_equal(ret, 0, "Fail to open dir");
 
-	TC_PRINT("Open same directory multi times\n");
+	mock_opendir_result(-EIO);
+	TC_PRINT("Transfer underlying FS error\n");
 	ret = fs_opendir(&dirp3, TEST_DIR);
-	zassert_not_equal(ret, 0, "Can't reopen an opened dir");
+	mock_opendir_result(0);
+	zassert_equal(ret, -EIO, "FS error not transferred\n");
 }
 
 /**

--- a/tests/subsys/fs/littlefs/src/testfs_util.c
+++ b/tests/subsys/fs/littlefs/src/testfs_util.c
@@ -354,6 +354,8 @@ int testfs_bcmd_verify_layout(struct testfs_path *pp,
 		++cp;
 	}
 
+	fs_dir_t_init(&dir);
+
 	int rc = fs_opendir(&dir, pp->path);
 
 	if (rc != 0) {

--- a/tests/subsys/fs/multi-fs/src/test_common_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_dir.c
@@ -72,6 +72,8 @@ int test_lsdir(const char *path)
 
 	TC_PRINT("\nlsdir tests:\n");
 
+	fs_dir_t_init(&dirp);
+
 	/* Verify fs_opendir() */
 	res = fs_opendir(&dirp, path);
 	if (res) {
@@ -108,6 +110,8 @@ int test_rmdir(const char *dir_path)
 	int res;
 	struct fs_dir_t dirp;
 	static struct fs_dirent entry;
+
+	fs_dir_t_init(&dirp);
 
 	if (!check_file_dir_exists(dir_path)) {
 		TC_PRINT("%s doesn't exist\n", dir_path);


### PR DESCRIPTION
The fs_dir_t_init() function has been added that should be used
for initialization of fs_dir_t structures before passing them
to fs_open and other functions.

fixes #31749