### PR TITLE
actions: Fix typo in twister action name

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Twsiter TestSuite
+name: Twister TestSuite
 
 on:
   push:


### PR DESCRIPTION
Replaces "Twsiter" with "Twister" in the associated GitHub Action name.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>