### PR TITLE
tests: mem_protect: use MP_NUM_CPUS instead of SMP

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -298,7 +298,7 @@ static void spin_entry(void *p1, void *p2, void *p3)
  * @see k_mem_domain_add_thread()
  */
 
-#ifdef CONFIG_SMP
+#if CONFIG_MP_NUM_CPUS > 1
 #define PRIO	K_PRIO_COOP(0)
 #else
 #define PRIO	K_PRIO_PREEMPT(1)


### PR DESCRIPTION
The test_mem_domain_migration test creates a new thread with
different priority based on whether SMP is enabled. This causes
an issue where SMP=y and MP_NUM_CPUS=1 where the spin_entry()
would spin forever (with k_busy_wait()) and not yielding since
it has cooperative priority. Fix this by using MP_NUM_CPUS to
figure out which priority to use, as it is valid configuration
to have SMP=y and MP_NUM_CPUS=1.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>