### PR TITLE
[backport 2.4] mempool: Fix possible overflow

### DIFF
--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -10,6 +10,7 @@
 #include <sys/mempool_base.h>
 #include <sys/mempool.h>
 #include <sys/check.h>
+#include <sys/math_extras.h>
 
 #ifdef CONFIG_MISRA_SANE
 #define LVL_ARRAY_SZ(n) (8 * sizeof(void *) / 2)
@@ -336,7 +337,12 @@ void *sys_mem_pool_alloc(struct sys_mem_pool *p, size_t size)
 		return NULL;
 	}
 
-	size += WB_UP(sizeof(struct sys_mem_pool_block));
+	if (size_add_overflow(size, WB_UP(sizeof(struct sys_mem_pool_block)),
+			      &size)) {
+		ret = NULL;
+		goto out;
+	}
+
 	if (z_sys_mem_pool_block_alloc(&p->base, size, &level, &block,
 				      (void **)&ret)) {
 		ret = NULL;


### PR DESCRIPTION
Fix possible overflow when allocating memory resulting in less memory
allocated what can cause further invalid memory access.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>