### PR TITLE
frdm_k22f: Enable the use of PWM via FlexTimers

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_k2x.dtsi>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "NXP Freedom MK22F board";
@@ -18,6 +19,10 @@
 		led2 = &red_led;
 		sw0 = &user_button_3;
 		sw1 = &user_button_2;
+		pwm-led0 = &green_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
 	};
 
 	chosen {
@@ -42,6 +47,23 @@
 		blue_led: led_2 {
 			gpios = <&gpiod 5 0>;
 			label = "User LD3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: red_pwm_led {
+			label = "red_led";
+			pwms = <&ftm0 6 15625000 PWM_POLARITY_INVERTED>;
+		};
+		green_pwm_led: green_pwm_led {
+			label = "green_led";
+			pwms = <&ftm0 7 15625000 PWM_POLARITY_INVERTED>;
+		};
+		blue_pwm_led: blue_pwm_led {
+			label = "blue_led";
+			pwms = <&ftm0 5 15625000 PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -112,7 +134,7 @@ arduino_spi: &spi0 {
 	status = "okay";
 };
 
-&ftm3 {
+&ftm0 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;

--- a/boards/arm/frdm_k22f/frdm_k22f.yaml
+++ b/boards/arm/frdm_k22f/frdm_k22f.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - i2c
   - nvs
+  - pwm
   - spi
   - usb_device
   - watchdog

--- a/boards/arm/frdm_k22f/pinmux.c
+++ b/boards/arm/frdm_k22f/pinmux.c
@@ -59,10 +59,17 @@ static int frdm_k22f_pinmux_init(const struct device *dev)
 	/* FXOS8700 INT2 */
 	pinmux_pin_set(portd, 1, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	/* Red, green, blue LEDs */
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm0), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
+	/* Red, green, blue LEDs as PWM channels*/
+	pinmux_pin_set(porta, 1, PORT_PCR_MUX(kPORT_MuxAlt3));
+	pinmux_pin_set(porta, 2, PORT_PCR_MUX(kPORT_MuxAlt3));
+	pinmux_pin_set(portd, 5, PORT_PCR_MUX(kPORT_MuxAlt4));
+#else
+	/* Red, green, blue LEDs as GPIO channels*/
 	pinmux_pin_set(porta, 1, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(porta, 2, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portd, 5, PORT_PCR_MUX(kPORT_MuxAsGpio));
+#endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(spi0), okay) && CONFIG_SPI
 	/* SPI0 CS0, SCK, SOUT, SIN */

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -60,11 +60,10 @@
 		};
 
 		mcg: clock-controller@40064000 {
-			compatible = "nxp,k22f-mcg";
+			compatible = "nxp,kinetis-mcg";
 			reg = <0x40064000 0xd>;
-			system-clock-frequency = <120000000>;
-
-			clock-controller;
+			label = "MCG";
+			#clock-cells = <1>;
 		};
 
 		osc: clock-controller@40065000 {
@@ -298,6 +297,8 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
+			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
+					 <&sim KINETIS_SIM_BUS_CLK 0x103C 24>;
 			prescaler = <16>;
 			label = "FTM_0";
 			status = "disabled";
@@ -307,6 +308,8 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
+			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
+					 <&sim KINETIS_SIM_BUS_CLK 0x103C 25>;
 			prescaler = <16>;
 			label = "FTM_1";
 			status = "disabled";
@@ -316,6 +319,8 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
+			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
+					 <&sim KINETIS_SIM_BUS_CLK 0x103C 26>;
 			prescaler = <16>;
 			label = "FTM_2";
 			status = "disabled";
@@ -325,6 +330,8 @@
 			compatible = "nxp,kinetis-ftm";
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
+			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
+					 <&sim KINETIS_SIM_BUS_CLK 0x103C 6>;
 			prescaler = <16>;
 			label = "FTM_3";
 			status = "disabled";

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -12,9 +12,15 @@ config ADC_MCUX_ADC16
 	default y
 	depends on ADC
 
+if CLOCK_CONTROL
+
+config CLOCK_CONTROL_MCUX_MCG
+	default y
+
 config CLOCK_CONTROL_MCUX_SIM
 	default y
-	depends on CLOCK_CONTROL
+
+endif # CLOCK_CONTROL
 
 config PINMUX_MCUX
 	default y


### PR DESCRIPTION
Assign clocks and clock gates to enable PWM functionality from FlexTimers.

This update also enables the frdm_k22f to run the basic and driver PWM
sample projects.