### PR TITLE
cmake: show memory usage on final ELF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,7 +1086,7 @@ if(NOT CONFIG_BUILD_NO_GAP_FILL)
 endif()
 
 if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
-  target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} $<TARGET_PROPERTY:linker,memusage>)
+  target_link_libraries(${ZEPHYR_FINAL_EXECUTABLE} $<TARGET_PROPERTY:linker,memusage>)
 
   get_property(memusage_build_command TARGET bintools PROPERTY memusage_command)
   if(memusage_build_command)


### PR DESCRIPTION
Right now we show memory usage when linking prebuild executable, instead
do that on the final binary.

Fixes #30591