### PR TITLE
samples: display: lvgl: Fix README.rst

### DIFF
--- a/samples/display/lvgl/README.rst
+++ b/samples/display/lvgl/README.rst
@@ -49,7 +49,7 @@ Building and Running
 Example building for :ref:`nrf52840dk_nrf52840`:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: adafruit_2_8_tft_touch_v2
    :goals: build flash
@@ -57,7 +57,7 @@ Example building for :ref:`nrf52840dk_nrf52840`:
 Example building for :ref:`native_posix`:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/display/lvgl
    :board: native_posix
    :goals: build flash
 


### PR DESCRIPTION
The commands still refer to the old directory name 'gui' instead of
'display'.

Signed-off-by: Detlev Zundel <dzu@member.fsf.org>