### PR TITLE
samples: basic: blinky: implement pattern of blinks

### DIFF
--- a/samples/basic/blinky/README.rst
+++ b/samples/basic/blinky/README.rst
@@ -6,9 +6,9 @@ Blinky
 Overview
 ********
 
-Blinky is a simple application which blinks an LED forever using the :ref:`GPIO
-API <gpio_api>`. The source code shows how to configure GPIO pins as outputs,
-then turn them on and off.
+Blinky is a simple application which blinks an LED forever, in a simple pattern,
+using the :ref:`GPIO API <gpio_api>`. The source code shows how to configure GPIO
+pins as outputs, then turn them on and off.
 
 See :ref:`pwm-blinky-sample` for a sample which uses the PWM API to blink an
 LED.

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -10,27 +10,28 @@
 #include <drivers/gpio.h>
 
 /* 1000 msec = 1 sec */
-#define SLEEP_TIME_MS   1000
+#define SLEEP_SHORT_TIME_MS   500
+#define SLEEP_LONG_TIME_MS   1000
 
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)
 
 #if DT_NODE_HAS_STATUS(LED0_NODE, okay)
 #define LED0	DT_GPIO_LABEL(LED0_NODE, gpios)
-#define PIN	DT_GPIO_PIN(LED0_NODE, gpios)
+#define PIN     DT_GPIO_PIN(LED0_NODE, gpios)
 #define FLAGS	DT_GPIO_FLAGS(LED0_NODE, gpios)
 #else
 /* A build error here means your board isn't set up to blink an LED. */
 #error "Unsupported board: led0 devicetree alias is not defined"
 #define LED0	""
-#define PIN	0
+#define PIN     0
 #define FLAGS	0
 #endif
 
 void main(void)
 {
 	const struct device *dev;
-	bool led_is_on = true;
+	bool led_is_on = false;
 	int ret;
 
 	dev = device_get_binding(LED0);
@@ -43,9 +44,50 @@ void main(void)
 		return;
 	}
 
+	/*
+	 * Many boards ship with a basic "blinky" pattern running already.
+	 * In order to be able to distinguish the Zephyr blinky, it has a
+	 * rather unique pattern.
+	 *
+	 * LED pattern is:
+	 *     on:      short short     short      long
+	 *     off:        short   long      long        short
+	 *
+	 * As a waveform:
+	 *     on:      +--+  +--+      +--+      +------+  + ...
+	 *     off: ... +  +--+  +------+  +------+      +--+
+	 */
 	while (1) {
+		led_is_on = true;
 		gpio_pin_set(dev, PIN, (int)led_is_on);
-		led_is_on = !led_is_on;
-		k_msleep(SLEEP_TIME_MS);
+		k_msleep(SLEEP_SHORT_TIME_MS);
+
+		led_is_on = false;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_SHORT_TIME_MS);
+
+		led_is_on = true;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_SHORT_TIME_MS);
+
+		led_is_on = false;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_LONG_TIME_MS);
+
+		led_is_on = true;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_SHORT_TIME_MS);
+
+		led_is_on = false;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_LONG_TIME_MS);
+
+		led_is_on = true;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_LONG_TIME_MS);
+
+		led_is_on = false;
+		gpio_pin_set(dev, PIN, (int)led_is_on);
+		k_msleep(SLEEP_SHORT_TIME_MS);
 	}
 }


### PR DESCRIPTION
Many boards ship with a basic "blinky" pattern running already.
In order to be able to distinguish the Zephyr blinky, this
implements a more unique pattern.  It uses no extra system
calls or functions, just enlarges the forever loop to
include longer and shorter delays during multiple LED
on and off times.

Signed-off-by: Dean Weiten <dmw@weiten.com>