### PR TITLE
samples: hello_world: implement repeated printout

### DIFF
--- a/samples/hello_world/README.rst
+++ b/samples/hello_world/README.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 A simple sample that can be used with any :ref:`supported board <boards>` and
-prints "Hello World" to the console.
+prints "Hello World" to the console repeatedly, with approx. one second delay.
 
 Building and Running
 ********************
@@ -28,6 +28,9 @@ Sample Output
 
 .. code-block:: console
 
-    Hello World! x86
+    Hello World! x86 pass         1
+    Hello World! x86 pass         2
+    Hello World! x86 pass         3
+    ...
 
 Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -7,7 +7,20 @@
 #include <zephyr.h>
 #include <sys/printk.h>
 
+
+/* 1000 msec = 1 sec */
+#define SLEEP_LONG_TIME_MS   1000
+
+
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	int		Count;
+
+
+	Count = 0;
+	while (1) {
+		Count++;
+		printk("Hello World! %s pass %8d\n", CONFIG_BOARD, Count);
+		k_msleep(SLEEP_LONG_TIME_MS);
+	}
 }


### PR DESCRIPTION
Sometimes the processor comes up before the serial terminal
listening to the output port, so a single "hello world"
message might get lost.  This change implements repeated
"hello world" messages with a counter, so even if the
serial terminal is connected much later, output is observed.
The only extra system call made is for a simple timer, and
a counter is added to the forever loop.  The counter is
intentionally wrapped at a 16 bit maximum count.

Signed-off-by: Dean Weiten <dmw@weiten.com>