### PR TITLE
samples: drivers: lora: receive: add formatted received packet display

### DIFF
--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -139,7 +139,7 @@ void main(void)
 					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
 						CharCtr++) {
 				switch (CharCtr & 0x0F) {
-				case  0:	/* A line is 16 bytes.  Put "address" at beginning of line */
+				case  0:	/* A line is 16 bytes.  Put address at beginning */
 					printk("\n  0x%4.4X - ", CharCtr);
 					break;
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -62,8 +62,8 @@ void main(void)
 	 * to each other, meaning that one system will see the
 	 * other system's signal as uncorrelated noise.
 	 */
-	LoraConfig.frequency = 915000000;  /* In Hz */
-	LoraConfig.bandwidth = BW_250_KHZ; /* Driver can interpret valid Hz or enum */
+	LoraConfig.frequency = 915000000;	/* In Hz */
+	LoraConfig.bandwidth = BW_250_KHZ;	/* Driver can interpret valid Hz or enum */
 	LoraConfig.datarate = SF_10;
 	LoraConfig.preamble_len = 8;
 	LoraConfig.coding_rate = CR_4_5;

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -138,15 +138,19 @@ void main(void)
 			for (CharCtr = 0;
 					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
 						CharCtr++) {
-				if  ((CharCtr & 0x0F) == 0) {
-					printk("\n  0x%4.4X - ", CharCtr);
-				} else {
-					if  (((CharCtr & 0x0F) == 4) || ((CharCtr & 0x0F) == 12)) {
+				switch (CharCtr & 0x0F) {
+					case  0:	/* A line is 16 bytes.  Put "address" within packet at beginning of line */
+						printk("\n  0x%4.4X - ", CharCtr);
+						break;
+
+					case  4:	/* Small visual cue at the quarter line marks - 4th and 12th byte */
+					case 12:
 						printk(" ");
-					} else {
-						if  ((CharCtr & 0x0F) == 8)
-							printk("- ");
-					}
+						break;
+
+					case  8:	/* Larger visual cue at the half line mark - 8th byte */
+						printk("- ");
+						break;
 				}
 				printk("%2.2X ", RawData[CharCtr]);
 			}

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -68,13 +68,13 @@ void main(void)
 
 	/* Print LoRa settings in use */
 	printk("Settings:\n");
-	printk("  Frequency                      = %d (Hz)\n", LoraConfig.frequency);
-	printk("  Bandwidth                      = %d (Hz or enum)\n", LoraConfig.bandwidth);
-	printk("  DataRate (spreading factor/SF) = %d\n", LoraConfig.datarate);
-	printk("  PreambleLen                    = %d\n", LoraConfig.preamble_len);
-	printk("  CodingRate                     = %d\n", LoraConfig.coding_rate);
-	printk("  TxPower                        = %d\n", LoraConfig.tx_power);
-	printk("  Tx                             = %d\n", LoraConfig.tx);
+	printk("  Frequency                      = %9d (Hz)\n", LoraConfig.frequency);
+	printk("  Bandwidth                      = %9d (Hz or enum)\n", LoraConfig.bandwidth);
+	printk("  DataRate (spreading factor/SF) = %9d\n", LoraConfig.datarate);
+	printk("  PreambleLen                    = %9d\n", LoraConfig.preamble_len);
+	printk("  CodingRate                     = %9d\n", LoraConfig.coding_rate);
+	printk("  TxPower                        = %9d\n", LoraConfig.tx_power);
+	printk("  Tx                             = %9d\n", LoraConfig.tx);
 	printk("\n");
 
 	/* Set the configuration of the LoRa receiver */

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -64,7 +64,7 @@ void main(void)
 	 */
 	LoraConfig.frequency = 915000000;	/* In Hz */
 	LoraConfig.bandwidth = BW_250_KHZ;	/* Driver can interpret valid Hz or enum */
-	LoraConfig.datarate = SF_10;
+	LoraConfig.datarate = SF_7;			/* Many systems default to SF_10 */
 	LoraConfig.preamble_len = 8;
 	LoraConfig.coding_rate = CR_4_5;
 	LoraConfig.tx_power = 14;
@@ -139,18 +139,18 @@ void main(void)
 					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
 						CharCtr++) {
 				switch (CharCtr & 0x0F) {
-					case  0:	/* A line is 16 bytes.  Put "address" within packet at beginning of line */
-						printk("\n  0x%4.4X - ", CharCtr);
-						break;
+				case  0:	/* A line is 16 bytes.  Put "address" within packet at beginning of line */
+					printk("\n  0x%4.4X - ", CharCtr);
+					break;
 
-					case  4:	/* Small visual cue at the quarter line marks - 4th and 12th byte */
-					case 12:
-						printk(" ");
-						break;
+				case  4:	/* Small visual cue at the quarter line marks - 4th and 12th byte */
+				case 12:
+					printk(" ");
+					break;
 
-					case  8:	/* Larger visual cue at the half line mark - 8th byte */
-						printk("- ");
-						break;
+				case  8:	/* Larger visual cue at the half line mark - 8th byte */
+					printk("- ");
+					break;
 				}
 				printk("%2.2X ", RawData[CharCtr]);
 			}

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -30,8 +30,8 @@ void main(void)
 	struct lora_modem_config LoraConfig;
 	int     IntRetVal;
 	int     DataLength;
-	uint8_t RawData[MAX_DATA_LEN*2] = {0};
-	uint8_t SafeData[MAX_DATA_LEN*2];
+	uint8_t RawData[MAX_DATA_LEN+10] = {0};
+	uint8_t SafeData[MAX_DATA_LEN+10];
 	int16_t rssi;
 	int8_t  snr;
 	int		MessageCounter;

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -139,16 +139,16 @@ void main(void)
 					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
 						CharCtr++) {
 				switch (CharCtr & 0x0F) {
-				case  0:	/* A line is 16 bytes.  Put "address" within packet at beginning of line */
+				case  0:	/* A line is 16 bytes.  Put "address" at beginning of line */
 					printk("\n  0x%4.4X - ", CharCtr);
 					break;
 
-				case  4:	/* Small visual cue at the quarter line marks - 4th and 12th byte */
+				case  4:	/* Small visual cue at the quarter line marks */
 				case 12:
 					printk(" ");
 					break;
 
-				case  8:	/* Larger visual cue at the half line mark - 8th byte */
+				case  8:	/* Larger visual cue at the half line mark */
 					printk("- ");
 					break;
 				}

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -114,7 +114,9 @@ void main(void)
 			 */
 
 			/* Some data received is not string-safe, so sanitize string for printing */
-			for (CharCtr = 0; ((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN)); CharCtr++) {
+			for (CharCtr = 0;
+					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
+						CharCtr++) {
 				if  (isprint(RawData[CharCtr])) {
 					SafeData[CharCtr] = RawData[CharCtr];
 				} else {
@@ -133,7 +135,9 @@ void main(void)
 
 			/* Print hex dump of byte data */
 			printk("As hex bytes:");
-			for (CharCtr = 0; ((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN)); CharCtr++) {
+			for (CharCtr = 0;
+					((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN));
+						CharCtr++) {
 				if  ((CharCtr & 0x0F) == 0) {
 					printk("\n  0x%4.4X - ", CharCtr);
 				} else {

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -18,7 +18,7 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
 	     "No default LoRa radio specified in DT");
 #define DEFAULT_RADIO DT_LABEL(DEFAULT_RADIO_NODE)
 
-#define MAX_DATA_LEN 25
+#define MAX_DATA_LEN	(255)
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -119,8 +119,6 @@ void main(void)
 
 		/* Print statistics */
 		printk("\n");
-		printk("Msg 0x%4.4X received (RSSI:%ddBm, SNR:%ddBm):\n",
-				MessageCounter, rssi, snr);
 
 		/* Print sanitized string */
 		printk("As string: %s\n", SafeData);
@@ -133,6 +131,8 @@ void main(void)
 			} else {
 				if  (((CharCtr & 0x0F) == 4) || ((CharCtr & 0x0F) == 12)) {
 					printk(" ");
+			printk("Msg 0x%4.4X of length %3d received (RSSI:%ddBm, SNR:%ddBm):\n",
+					MessageCounter, DataLength, rssi, snr);
 				} else {
 					if  ((CharCtr & 0x0F) == 8)
 						printk("- ");

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -107,11 +107,11 @@ void main(void)
 				MessageCounter = 0;
 
 			/*
-			* Changed from LOG_INF to give more flexibility in printout.
-			*
-			* LOG_INF("Received data 0x%4.4X: %s (RSSI:%ddBm, SNR:%ddBm)",
-			*	MessageCounter, log_strdup(SafeData), rssi, snr);
-			*/
+			 * Changed from LOG_INF to give more flexibility in printout.
+			 *
+			 * LOG_INF("Received data 0x%4.4X: %s (RSSI:%ddBm, SNR:%ddBm)",
+			 *	MessageCounter, log_strdup(SafeData), rssi, snr);
+			 */
 
 			/* Some data received is not string-safe, so sanitize string for printing */
 			for (CharCtr = 0; ((CharCtr < DataLength) && (CharCtr < MAX_DATA_LEN)); CharCtr++) {


### PR DESCRIPTION
Added more descriptive introductory prints to show settings being used,
then "sanitized" string and byte hex dump prints for each packet
received.  Packet counter also shown.

Signed-off-by: Dean Weiten <dmw@weiten.com>