### PR TITLE
kernel: arch: introduce k_float_enable()

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -232,7 +232,7 @@ int arch_float_disable(struct k_thread *thread)
 }
 
 
-int arch_float_enable(struct k_thread *thread)
+int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
 	unsigned int key;
 

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -458,6 +458,12 @@ int arch_float_disable(struct k_thread *thread)
 
 	return 0;
 }
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+	/* This is not supported in Cortex-M and Cortex-R does not have FPU */
+	return -ENOTSUP;
+}
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 /* Internal function for Cortex-M initialization,

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -152,7 +152,7 @@ int arch_float_disable(struct k_thread *thread)
 }
 
 
-int arch_float_enable(struct k_thread *thread)
+int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
 	unsigned int key;
 

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -78,4 +78,9 @@ int arch_float_disable(struct k_thread *thread)
 {
 	return -ENOSYS;
 }
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+	return -ENOTSUP;
+}
 #endif /* CONFIG_FPU_SHARING */

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -76,7 +76,7 @@ void *z_arch_get_next_switch_handle(struct k_thread **old_thread)
 #if defined(CONFIG_FPU_SHARING)
 int arch_float_disable(struct k_thread *thread)
 {
-	return -ENOSYS;
+	return -ENOTSUP;
 }
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)

--- a/arch/x86/core/ia32/float.c
+++ b/arch/x86/core/ia32/float.c
@@ -179,7 +179,7 @@ static inline void FpCtxInit(struct k_thread *thread)
  * The locking isn't really needed when the routine is called by a cooperative
  * thread (since context switching can't occur), but it is harmless.
  */
-void k_float_enable(struct k_thread *thread, unsigned int options)
+void z_float_enable(struct k_thread *thread, unsigned int options)
 {
 	unsigned int imask;
 	struct k_thread *fp_owner;

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -59,6 +59,17 @@ int arch_float_disable(struct k_thread *thread)
 	return -ENOSYS;
 #endif /* CONFIG_LAZY_FPU_SHARING */
 }
+
+extern int z_float_enable(struct k_thread *thread, unsigned int options);
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+#if defined(CONFIG_LAZY_FPU_SHARING)
+	return z_float_enable(thread, options);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_LAZY_FPU_SHARING */
+}
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -56,7 +56,7 @@ int arch_float_disable(struct k_thread *thread)
 #if defined(CONFIG_LAZY_FPU_SHARING)
 	return z_float_disable(thread);
 #else
-	return -ENOSYS;
+	return -ENOTSUP;
 #endif /* CONFIG_LAZY_FPU_SHARING */
 }
 

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -397,37 +397,6 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 struct k_thread;
 
 /**
- * @brief Enable preservation of floating point context information.
- *
- * This routine informs the kernel that the specified thread (which may be
- * the current thread) will be using the floating point registers.
- * The @a options parameter indicates which floating point register sets
- * will be used by the specified thread:
- *
- * - K_FP_REGS  indicates x87 FPU and MMX registers only
- * - K_SSE_REGS indicates SSE registers (and also x87 FPU and MMX registers)
- *
- * Invoking this routine initializes the thread's floating point context info
- * to that of an FPU that has been reset. The next time the thread is scheduled
- * by z_swap() it will either inherit an FPU that is guaranteed to be in a "sane"
- * state (if the most recent user of the FPU was cooperatively swapped out)
- * or the thread's own floating point context will be loaded (if the most
- * recent user of the FPU was preempted, or if this thread is the first user
- * of the FPU). Thereafter, the kernel will protect the thread's FP context
- * so that it is not altered during a preemptive context switch.
- *
- * @warning
- * This routine should only be used to enable floating point support for a
- * thread that does not currently have such support enabled already.
- *
- * @param thread ID of thread.
- * @param options Registers to be preserved (K_FP_REGS or K_SSE_REGS).
- *
- * @return N/A
- */
-extern void k_float_enable(struct k_thread *thread, unsigned int options);
-
-/**
  * @}
  */
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5544,6 +5544,46 @@ __syscall void k_str_out(char *c, size_t n);
  */
 __syscall int k_float_disable(struct k_thread *thread);
 
+/**
+ * @brief Enable preservation of floating point context information.
+ *
+ * This routine informs the kernel that the specified thread
+ * will use the floating point registers.
+
+ * Invoking this routine initializes the thread's floating point context info
+ * to that of an FPU that has been reset. The next time the thread is scheduled
+ * by z_swap() it will either inherit an FPU that is guaranteed to be in a
+ * "sane" state (if the most recent user of the FPU was cooperatively swapped
+ * out) or the thread's own floating point context will be loaded (if the most
+ * recent user of the FPU was preempted, or if this thread is the first user
+ * of the FPU). Thereafter, the kernel will protect the thread's FP context
+ * so that it is not altered during a preemptive context switch.
+ *
+ * The @a options parameter indicates which floating point register sets will
+ * be used by the specified thread.
+ *
+ * For x86 options:
+ *
+ * - K_FP_REGS  indicates x87 FPU and MMX registers only
+ * - K_SSE_REGS indicates SSE registers (and also x87 FPU and MMX registers)
+ *
+ * @warning
+ * Some architectures apply restrictions on how the enabling of floating
+ * point preservation may be requested, see arch_float_enable.
+ *
+ * @warning
+ * This routine should only be used to enable floating point support for
+ * a thread that currently has such support enabled.
+ *
+ * @param thread  ID of thread.
+ * @param options architecture dependent options
+ *
+ * @retval 0        On success.
+ * @retval -ENOTSUP If the floating point enabling is not implemented.
+ *         -EINVAL  If the floating point enabling could not be performed.
+ */
+__syscall int k_float_enable(struct k_thread *thread, unsigned int options);
+
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 
 /**

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5538,9 +5538,9 @@ __syscall void k_str_out(char *c, size_t n);
  *
  * @param thread ID of thread.
  *
- * @retval 0       On success.
- * @retval -ENOSYS If the floating point disabling is not implemented.
- *         -EINVAL If the floating point disabling could not be performed.
+ * @retval 0        On success.
+ * @retval -ENOTSUP If the floating point disabling is not implemented.
+ *         -EINVAL  If the floating point disabling could not be performed.
  */
 __syscall int k_float_disable(struct k_thread *thread);
 

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -185,6 +185,25 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
  * @retval -EINVAL If the floating point disabling could not be performed.
  */
 int arch_float_disable(struct k_thread *thread);
+
+/**
+ * @brief Enable floating point context preservation
+ *
+ * The function is used to enable the preservation of floating
+ * point context information for a particular thread.
+ * This API depends on each architecture implimentation. If the architecture
+ * does not support enableing, this API will always be failed.
+ *
+ * The @a options parameter indicates which floating point register sets will
+ * be used by the specified thread. Currently it is used by x86 only.
+ *
+ * @param thread  ID of thread.
+ * @param options architecture dependent options
+ *
+ * @retval 0       On success.
+ * @retval -EINVAL If the floating point enabling could not be performed.
+ */
+int arch_float_enable(struct k_thread *thread, unsigned int options);
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 /** @} */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -880,7 +880,7 @@ int z_impl_k_float_disable(struct k_thread *thread)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_disable(thread);
 #else
-	return -ENOSYS;
+	return -ENOTSUP;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -884,6 +884,15 @@ int z_impl_k_float_disable(struct k_thread *thread)
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }
 
+int z_impl_k_float_enable(struct k_thread *thread, unsigned int options)
+{
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	return arch_float_enable(thread, options);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+}
+
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_k_float_disable(struct k_thread *thread)
 {

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -36,7 +36,7 @@ static void usr_fp_thread_entry_1(void)
 	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 #define K_FLOAT_DISABLE_SYSCALL_RETVAL 0
 #else
-#define K_FLOAT_DISABLE_SYSCALL_RETVAL -ENOSYS
+#define K_FLOAT_DISABLE_SYSCALL_RETVAL -ENOTSUP
 #endif
 
 static void usr_fp_thread_entry_2(void)
@@ -98,7 +98,7 @@ void test_k_float_disable_common(void)
 		usr_fp_thread.base.user_options);
 #else
 	/* Verify k_float_disable() is not supported */
-	zassert_true((k_float_disable(&usr_fp_thread) == -ENOSYS),
+	zassert_true((k_float_disable(&usr_fp_thread) == -ENOTSUP),
 		"k_float_disable() successful when not supported");
 #endif
 }


### PR DESCRIPTION
This patch introduce new API to enable FPU of thread. This is pair of
existed k_float_disable() API. And also add empty arch_float_enable()
into each architectures that have arch_float_disable(). The arc and
riscv already implemented arch_float_enable() so I do not touch
these implementations.

Motivation: Current Zephyr implementation does not allow to use FPU
on main and other system threads like as work queue. Users need to
create an other thread with K_FP_REGS for floating point programs.
Users can use FPU more easily if they can enable FPU on running
threads.