### PR TITLE
driver: espi: add more KBC 8042 protocol support in npcx series.

### DIFF
--- a/soc/arm/nuvoton_npcx/common/soc_espi.h
+++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
@@ -12,8 +12,22 @@ extern "C" {
 #endif
 
 /* 8042 event data format */
+#define NPCX_8042_EVT_POS 16U
 #define NPCX_8042_DATA_POS 8U
 #define NPCX_8042_TYPE_POS 0U
+
+/* 8042 event type format */
+#define NPCX_8042_EVT_IBF BIT(0)
+#define NPCX_8042_EVT_OBE BIT(1)
+
+/*
+ * The format of event data for KBC 8042 protocol:
+ * [23:16] - 8042 event type: 1: Input buffer full, 2: Output buffer empty.
+ * [15:8]  - 8042 data: 8-bit 8042 data.
+ * [0:7]   - 8042 protocol type: 0: data type, 1: command type.
+ */
+#define NPCX_8042_EVT_DATA(event, data, type) (((event) << NPCX_8042_EVT_POS) \
+	| ((data) << NPCX_8042_DATA_POS) | ((type) << NPCX_8042_TYPE_POS));
 
 /* ACPI event data format */
 #define NPCX_ACPI_DATA_POS 8U


### PR DESCRIPTION
This CL added more additional details for KBC (Keyboard and Mouse
Controller) bus in espi_event structure. It helps the application to
handle different 8042 events in the callback function.

The format of event data for KBC 8042 protocol is:
[23:16] - 8042 event type: 1: Input buffer full, 2: Output buffer empty.
[15:8]  - 8042 data: 8-bit 8042 data.
[0:7]   - 8042 protocol type: 0: data type, 1: command type.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>