### PR TITLE
test: kheap: add testcase to improve coverage

### DIFF
--- a/tests/kernel/mem_heap/k_heap_api/src/main.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/main.c
@@ -9,6 +9,7 @@ extern void test_k_heap_alloc(void);
 extern void test_k_heap_alloc_fail(void);
 extern void test_k_heap_free(void);
 extern void test_kheap_alloc_in_isr_nowait(void);
+extern void test_k_heap_alloc_pending(void);
 
 /**
  * @brief k heap api tests
@@ -26,6 +27,7 @@ void test_main(void)
 			 ztest_unit_test(test_k_heap_alloc),
 			 ztest_unit_test(test_k_heap_alloc_fail),
 			 ztest_unit_test(test_k_heap_free),
-			 ztest_unit_test(test_kheap_alloc_in_isr_nowait));
+			 ztest_unit_test(test_kheap_alloc_in_isr_nowait),
+			 ztest_unit_test(test_k_heap_alloc_pending));
 	ztest_run_test_suite(k_heap_api);
 }

--- a/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
@@ -8,6 +8,10 @@
 #include <irq_offload.h>
 #include "test_kheap.h"
 
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
+struct k_thread tdata;
+
 K_HEAP_DEFINE(k_heap_test, HEAP_SIZE);
 
 #define ALLOC_SIZE_1 1024
@@ -19,6 +23,16 @@ static void tIsr_kheap_alloc_nowait(void *data)
 	ARG_UNUSED(data);
 
 	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_1, K_NO_WAIT);
+
+	zassert_not_null(p, "k_heap_alloc operation failed");
+	k_heap_free(&k_heap_test, p);
+}
+
+static void thread_alloc_heap(void *p1, void *p2, void *p3)
+{
+	k_timeout_t timeout = Z_TIMEOUT_MS(200);
+
+	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, timeout);
 
 	zassert_not_null(p, "k_heap_alloc operation failed");
 	k_heap_free(&k_heap_test, p);
@@ -105,9 +119,38 @@ void test_k_heap_free(void)
 /**
  * @brief Validate allocation and free heap memory in isr context.
  *
+ * @details The test validates k_heap_alloc() in isr context, the timeout
+ * param should be K_NO_WAIT, because this situation isn't allow to wait.
+ *
  * @ingroup kernel_heap_tests
  */
 void test_kheap_alloc_in_isr_nowait(void)
 {
 	irq_offload((irq_offload_routine_t)tIsr_kheap_alloc_nowait, NULL);
+}
+
+/**
+ * @brief Validate the k_heap support wait between different threads.
+ *
+ * @details In main thread alloc a buffer from the heap, then run the
+ * child thread. If there isn't enough space in the heap, the child thread
+ * will wait timeout long until main thread free the buffer to heap.
+ *
+ * @ingroup kernel_heap_tests
+ */
+void test_k_heap_alloc_pending(void)
+{
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+					thread_alloc_heap, NULL, NULL, NULL,
+					K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
+
+	char *p = (char *)k_heap_alloc(&k_heap_test, ALLOC_SIZE_2, K_NO_WAIT);
+
+	zassert_not_null(p, "k_heap_alloc operation failed");
+
+	/* make the child thread run */
+	k_msleep(1);
+	k_heap_free(&k_heap_test, p);
+
+	k_thread_join(tid, K_FOREVER);
 }


### PR DESCRIPTION
Add a testcase to prove the thread can be waited on waitq when
there isn't enough space on heap.

Signed-off-by: Ying ming <mingx.ying@intel.com>