### PR TITLE
drivers: gpio_nrfx: support edge interrupts using GPIO SENSE

### DIFF
--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -31,5 +31,32 @@ config GPIO_NRF_P1
 	help
 	  Enable nRF GPIO port P1 config options.
 
+choice
+	prompt "nRF GPIO edge interrupts mechanism"
+	default GPIO_NRF_INT_EDGE_USING_GPIOTE
+
+config GPIO_NRF_INT_EDGE_USING_GPIOTE
+	bool "Edge interrupts using GPIOTE"
+	help
+	  Enable GPIO edge interrupts implementation using GPIOTE events.
+
+config GPIO_NRF_INT_EDGE_USING_SENSE
+	bool "Edge interrupts using SENSE"
+	help
+	  Enable GPIO edge interrupts implementation using GPIO SENSE, which is
+	  a level interrupt mechanism. Conversion from level to edge interrupts
+	  notification happens in GPIO driver, so it is transparent to GPIO
+	  consumers after switching from GPIOTE mechanism.
+
+	  Use this option as an alternative to GPIOTE event mechanism. According
+	  to product specifications and erratas to some nRF MCUs, using GPIOTE
+	  results in increased current consumption in System ON Idle and in
+	  conjunction with SPI/TWI peripherals. Selecting this option allows to
+	  reduce current for those cases.
+
+	  Using this option additionally allows detecting state changes of pins
+	  configured as output, which might be handy for some applications.
+
+endchoice
 
 endif # GPIO_NRFX


### PR DESCRIPTION
Currently level interrupts are implemented using GPIO SENSE, but edge
interrupts using GPIOTE events. Using GPIOTE events results in increased
power consumption according to erratas of some nRF MCUs. In case of
nRF52832 it is <20uA in System ON Idle and ~400-450uA when used in
conjunction with SPI or TWI.

Add a user configurable option to select between GPIOTE events and GPIO
SENSE mechanism, for implementing edge interrupts. Selecting GPIO SENSE
option will allow to reduce power consumption in scenarios mentioned by
nRF MCUs erratas.