### PR TITLE
usb: fix BOS descriptor registration

### DIFF
--- a/subsys/usb/bos.c
+++ b/subsys/usb/bos.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(usb_bos);
 extern const uint8_t __usb_bos_desc_start[];
 extern const uint8_t __usb_bos_desc_end[];
 
-USB_DEVICE_BOS_DESC_DEFINE_HDR struct usb_bos_descriptor hdr = {
+USB_DEVICE_BOS_DESC_DEFINE_HDR struct usb_bos_descriptor bos_hdr = {
 	.bLength = sizeof(struct usb_bos_descriptor),
 	.bDescriptorType = USB_BINARY_OBJECT_STORE_DESC,
 	.wTotalLength = 0, /* should be corrected with register */
@@ -37,19 +37,15 @@ const void *usb_bos_get_header(void)
 
 void usb_bos_fix_total_length(void)
 {
-	struct usb_bos_descriptor *hdr = (void *)__usb_bos_desc_start;
-
-	hdr->wTotalLength = usb_bos_get_length();
+	bos_hdr.wTotalLength = usb_bos_get_length();
 }
 
 void usb_bos_register_cap(struct usb_bos_platform_descriptor *desc)
 {
-	struct usb_bos_descriptor *hdr = (void *)__usb_bos_desc_start;
-
 	/* Has effect only on first register */
-	hdr->wTotalLength = usb_bos_get_length();
+	bos_hdr.wTotalLength = usb_bos_get_length();
 
-	hdr->bNumDeviceCaps += 1U;
+	bos_hdr.bNumDeviceCaps += 1U;
 }
 
 int usb_handle_bos(struct usb_setup_packet *setup,


### PR DESCRIPTION
Use BOS header structure directly we have access to
instead of casting extern const pointers.

Fixes: #30330