### PR TITLE
usb: mass storage: set thread stack size from Kconfig

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -88,6 +88,13 @@ config MASS_STORAGE_BULK_EP_MPS
 	help
 	  Mass storage device class bulk endpoints size
 
+config MASS_STORAGE_STACK_SIZE
+	int
+	depends on USB_MASS_STORAGE
+	default 512
+	help
+	  Stack size for mass storage disk operations thread
+
 if USB_MASS_STORAGE
 module = USB_MASS_STORAGE
 module-str = usb mass storage

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -52,7 +52,6 @@ LOG_MODULE_REGISTER(usb_msc);
 #define MAX_PACKET	CONFIG_MASS_STORAGE_BULK_EP_MPS
 
 #define BLOCK_SIZE	512
-#define DISK_KERNEL_STACK_SZ	512
 #define DISK_THREAD_PRIO	-5
 
 #define THREAD_OP_READ_QUEUED		1
@@ -104,7 +103,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_mass_config mass_cfg = {
 };
 
 static volatile int thread_op;
-static K_KERNEL_STACK_DEFINE(mass_thread_stack, DISK_KERNEL_STACK_SZ);
+static K_KERNEL_STACK_DEFINE(mass_thread_stack, CONFIG_MASS_STORAGE_STACK_SIZE);
 static struct k_thread mass_thread_data;
 static struct k_sem disk_wait_sem;
 static volatile uint32_t defered_wr_sz;
@@ -988,7 +987,7 @@ static int mass_storage_init(const struct device *dev)
 
 	/* Start a thread to offload disk ops */
 	k_thread_create(&mass_thread_data, mass_thread_stack,
-			DISK_KERNEL_STACK_SZ,
+			CONFIG_MASS_STORAGE_STACK_SIZE,
 			(k_thread_entry_t)mass_thread_main, NULL, NULL, NULL,
 			DISK_THREAD_PRIO, 0, K_NO_WAIT);
 


### PR DESCRIPTION
allow user to select stack size depending on the situation.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>