### PR TITLE
arch: riscv: linker: fix _image_rom_start symbol

### DIFF
--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -31,6 +31,27 @@
 #define _EXCEPTION_SECTION_NAME     exceptions
 #define _RESET_SECTION_NAME         reset
 
+#ifdef CONFIG_XIP
+#if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
+#define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
+#define ROM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), jedec_spi_nor, okay)
+/* For jedec,spi-nor we expect the spi controller to memory map the flash
+ * and for that mapping to be the second register property of the spi
+ * controller.
+ */
+#define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
+#define ROM_BASE DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)
+#define ROM_SIZE DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)
+#endif
+#else /* CONFIG_XIP */
+#define ROM_BASE CONFIG_SRAM_BASE_ADDRESS
+#define ROM_SIZE KB(CONFIG_SRAM_SIZE)
+#endif /* CONFIG_XIP */
+
+#define RAM_BASE CONFIG_SRAM_BASE_ADDRESS
+#define RAM_SIZE KB(CONFIG_SRAM_SIZE)
+
 #ifdef CONFIG_RISCV_PMP
 	#define MPU_MIN_SIZE 4
 	#define MPU_MIN_SIZE_ALIGN . = ALIGN(MPU_MIN_SIZE );
@@ -50,21 +71,9 @@
 MEMORY
 {
 #ifdef CONFIG_XIP
-#if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
-#define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
-#define ROM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
-#elif DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), jedec_spi_nor, okay)
-/* For jedec,spi-nor we expect the spi controller to memory map the flash
- * and for that mapping to be the second register property of the spi
- * controller.
- */
-#define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
-#define ROM_BASE DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)
-#define ROM_SIZE DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)
-#endif
     ROM (rx)  : ORIGIN = ROM_BASE, LENGTH = ROM_SIZE
 #endif
-    RAM (rwx) : ORIGIN = CONFIG_SRAM_BASE_ADDRESS, LENGTH = KB(CONFIG_SRAM_SIZE)
+    RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
@@ -91,7 +100,7 @@ SECTIONS
 	}
 
     GROUP_START(ROMABLE_REGION)
-    _image_rom_start = .;
+    _image_rom_start = ROM_BASE;
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
     {


### PR DESCRIPTION
In riscv linker script, fix _image_rom_start symbol from 0 to the start address of ROM.

image_rom_[start|end] is a one PMP region of ROM and do it's alignment if RISC-V PMP is enabled.
If rom start symbol is 0, the padding of rom end symbol will be too large.

Related to #31811

**Update:** add example
build `tests/kernel/mem_protect/protection` on `hifive1_revb` board with `CONFIG_PMP_POWER_OF_TWO_ALIGNMENT=y`

Before fix:
```
nm zephyr/zephyr.elf | grep _image_rom
00000000 T _image_rom_start
40000000 B _image_rom_end
40000000 A _image_rom_size
```
After fix:
```
nm zephyr/zephyr.elf | grep _image_rom
20010000 T _image_rom_start
20018000 B _image_rom_end
00008000 A _image_rom_size
```