### PR TITLE
samples: syscall_perf: fix sample.yaml condition

### DIFF
--- a/samples/userspace/syscall_perf/sample.yaml
+++ b/samples/userspace/syscall_perf/sample.yaml
@@ -11,4 +11,4 @@ common:
 tests:
   sample.syscall_performances:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    platform_allow: riscv32
+    arch_allow: riscv32


### PR DESCRIPTION
riscv32 is arch_allow instead of platform_allow.

Signed-off-by: Jim Shu <cwshu@andestech.com>