### PR TITLE
boards: Fix usage of srec_cat -> ${SREC_CAT} in nrf

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -97,7 +97,7 @@ if (CONFIG_BUILD_WITH_TFM)
 			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 			# Generate an intel hex file from the signed output binary
-			COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin
+			COMMAND ${SREC_CAT} ${CMAKE_BINARY_DIR}/tfm_sign.bin
 				-binary
 				-offset 0x10000
 				-o ${CMAKE_BINARY_DIR}/tfm_sign.hex

--- a/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
+++ b/boards/arm/nrf9160dk_nrf9160/CMakeLists.txt
@@ -74,7 +74,7 @@ if (CONFIG_BUILD_WITH_TFM)
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:tfm,BL2_BIN_FILE> ${CMAKE_BINARY_DIR}/mcuboot.bin
 
 		# Generate an intel hex file from the signed output binary
-		COMMAND srec_cat ${CMAKE_BINARY_DIR}/tfm_sign.bin
+		COMMAND ${SREC_CAT} ${CMAKE_BINARY_DIR}/tfm_sign.bin
 		-binary
 		-offset 0x10000
 		-o ${CMAKE_BINARY_DIR}/tfm_sign.hex


### PR DESCRIPTION
in TFM signing code in nrf9160 and nrf5340.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>