### PR TITLE
Adjust riscv miv clock rate, fix timeslice glitch

### DIFF
--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -5,8 +5,13 @@ if SOC_SERIES_RISCV32_MIV
 config SOC_SERIES
 	default "miv"
 
+# NOTE: 4 MHz was chosen here as a reasonable workaround value because
+# it allows the test suite to complete in reasonable time (the renode
+# simulator is ~40x slower than the emulated CPU).  The default
+# emulated device, however, reports itself as a having a 66 Mhz clock
+# rate.
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 660000
+	default 4000000
 
 config RISCV_SOC_INTERRUPT_INIT
 	default y


### PR DESCRIPTION
This is a workaround (but not a complete fix) for #31726 

It changes the simulated clock rate for the miv SoC to 4 Mhz, which picks a happy medium between "enough CPU time for the test to pass" and "not so slow in real time for twister to time the test out".

A full fix would adjust the renode configuration such that it reports the 4 MHz rate in its output and software config (e.g. the timestamps on the console output are currently wrong).

This also includes a small fix to timeslicing logic that the oddball clock rate muckery exposed.