### PR TITLE
net: pkt: context: Respect reserved bytes

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -88,10 +88,14 @@ struct net_buf_simple {
 	/** Pointer to the start of data in the buffer. */
 	uint8_t *data;
 
-	/** Length of the data behind the data pointer. */
+	/**
+	 * Length of the data behind the data pointer.
+	 *
+	 * To determine the max length, use net_buf_simple_max_len(), not #size!
+	 */
 	uint16_t len;
 
-	/** Amount of data that this buffer can store. */
+	/** Amount of data that net_buf_simple#__buf can store. */
 	uint16_t size;
 
 	/** Start of the data storage. Not to be accessed directly
@@ -828,6 +832,17 @@ size_t net_buf_simple_headroom(struct net_buf_simple *buf);
  * @return Number of bytes available at the end of the buffer.
  */
 size_t net_buf_simple_tailroom(struct net_buf_simple *buf);
+
+/**
+ * @brief Check maximum net_buf_simple::len value.
+ *
+ * This value is depending on the number of bytes being reserved as headroom.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return Number of bytes usable behind the net_buf_simple::data pointer.
+ */
+uint16_t net_buf_simple_max_len(struct net_buf_simple *buf);
 
 /**
  * @brief Parsing state of a buffer.
@@ -2235,6 +2250,20 @@ static inline size_t net_buf_tailroom(struct net_buf *buf)
 static inline size_t net_buf_headroom(struct net_buf *buf)
 {
 	return net_buf_simple_headroom(&buf->b);
+}
+
+/**
+ * @brief Check maximum net_buf::len value.
+ *
+ * This value is depending on the number of bytes being reserved as headroom.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return Number of bytes usable behind the net_buf::data pointer.
+ */
+static inline uint16_t net_buf_max_len(struct net_buf *buf)
+{
+	return net_buf_simple_max_len(&buf->b);
 }
 
 /**

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1568,6 +1568,9 @@ void net_pkt_append_buffer(struct net_pkt *pkt, struct net_buf *buffer);
 /**
  * @brief Get available buffer space from a pkt
  *
+ * @note Reserved bytes (headroom) in any of the fragments are not considered to
+ *       be available.
+ *
  * @param pkt The net_pkt which buffer availability should be evaluated
  *
  * @return the amount of buffer available
@@ -1576,6 +1579,9 @@ size_t net_pkt_available_buffer(struct net_pkt *pkt);
 
 /**
  * @brief Get available buffer space for payload from a pkt
+ *
+ * @note Reserved bytes (headroom) in any of the fragments are not considered to
+ *       be available.
  *
  * @details Unlike net_pkt_available_buffer(), this will take into account
  *          the headers space.

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -1279,3 +1279,8 @@ size_t net_buf_simple_tailroom(struct net_buf_simple *buf)
 {
 	return buf->size - net_buf_simple_headroom(buf) - buf->len;
 }
+
+uint16_t net_buf_simple_max_len(struct net_buf_simple *buf)
+{
+	return buf->size - net_buf_simple_headroom(buf);
+}

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -343,9 +343,9 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 
 		frag_size = frag->size;
 
-		NET_INFO("[%d] frag %p len %d size %d pool %p",
-			 count, frag, frag->len, frag_size,
-			 net_buf_pool_get(frag->pool_id));
+		NET_INFO("[%d] frag %p len %d max len %u size %d pool %p",
+			 count, frag, frag->len, net_buf_max_len(buf),
+			 frag_size, net_buf_pool_get(frag->pool_id));
 
 		count++;
 

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -261,8 +261,8 @@ static inline void net_pkt_print_buffer_info(struct net_pkt *pkt, const char *st
 	}
 
 	while (buf) {
-		printk("%p[%d/%u (%u)]",
-		       buf, atomic_get(&pkt->atomic_ref), buf->len, buf->size);
+		printk("%p[%d/%u (%u/%u)]", buf, atomic_get(&pkt->atomic_ref),
+		       buf->len, net_buf_max_len(buf), buf->size);
 
 		buf = buf->frags;
 		if (buf) {

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3951,8 +3951,8 @@ static void net_pkt_buffer_info(const struct shell *shell, struct net_pkt *pkt)
 	}
 
 	while (buf) {
-		PR("%p[%d/%u (%u)]",
-		   buf, atomic_get(&pkt->atomic_ref), buf->len, buf->size);
+		PR("%p[%d/%u (%u/%u)]", buf, atomic_get(&pkt->atomic_ref),
+		   buf->len, net_buf_max_len(buf), buf->size);
 
 		buf = buf->frags;
 		if (buf) {

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -785,6 +785,127 @@ void test_net_pkt_clone(void)
 	net_pkt_unref(cloned_pkt);
 }
 
+NET_BUF_POOL_FIXED_DEFINE(test_net_pkt_headroom_pool, 4, 2, NULL);
+void test_net_pkt_headroom(void)
+{
+	struct net_pkt *pkt;
+	struct net_buf *frag1;
+	struct net_buf *frag2;
+	struct net_buf *frag3;
+	struct net_buf *frag4;
+
+	/*
+	 * Create a net_pkt; append net_bufs with reserved bytes (headroom).
+	 *
+	 * Layout to be crafted before writing to the net_buf: "HA|HH|HA|AA"
+	 *  H: Headroom
+	 *  |: net_buf/fragment delimiter
+	 *  A: available byte
+	 */
+	pkt = net_pkt_alloc_on_iface(eth_if, K_NO_WAIT);
+	zassert_true(pkt != NULL, "Pkt not allocated");
+
+	/* 1st fragment has 1 byte headroom and one byte available: "HA" */
+	frag1 = net_buf_alloc_len(&test_net_pkt_headroom_pool, 2, K_NO_WAIT);
+	net_buf_reserve(frag1, 1);
+	net_pkt_append_buffer(pkt, frag1);
+	zassert_equal(net_pkt_available_buffer(pkt), 1, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt), 0, "Length mismatch");
+
+	/* 2nd fragment affecting neither size nor length: "HH" */
+	frag2 = net_buf_alloc_len(&test_net_pkt_headroom_pool, 2, K_NO_WAIT);
+	net_buf_reserve(frag2, 2);
+	net_pkt_append_buffer(pkt, frag2);
+	zassert_equal(net_pkt_available_buffer(pkt), 1, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt), 0, "Length mismatch");
+
+	/* 3rd fragment has 1 byte headroom and one byte available: "HA" */
+	frag3 = net_buf_alloc_len(&test_net_pkt_headroom_pool, 2, K_NO_WAIT);
+	net_buf_reserve(frag3, 1);
+	net_pkt_append_buffer(pkt, frag3);
+	zassert_equal(net_pkt_available_buffer(pkt), 2, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt), 0, "Length mismatch");
+
+	/* 4th fragment has no headroom and two available bytes: "AA" */
+	frag4 = net_buf_alloc_len(&test_net_pkt_headroom_pool, 2, K_NO_WAIT);
+	net_pkt_append_buffer(pkt, frag4);
+	zassert_equal(net_pkt_available_buffer(pkt), 4, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt), 0, "Length mismatch");
+
+	/* Writing net_pkt via cursor, spanning all 4 fragments */
+	net_pkt_cursor_init(pkt);
+	zassert_true(net_pkt_write(pkt, "1234", 4) == 0, "Pkt write failed");
+
+	/* Expected layout across all four fragments: "H1|HH|H2|34" */
+	zassert_equal(frag1->size, 2, "Size mismatch");
+	zassert_equal(frag1->len, 1, "Length mismatch");
+	zassert_equal(frag2->size, 2, "Size mismatch");
+	zassert_equal(frag2->len, 0, "Length mismatch");
+	zassert_equal(frag3->size, 2, "Size mismatch");
+	zassert_equal(frag3->len, 1, "Length mismatch");
+	zassert_equal(frag4->size, 2, "Size mismatch");
+	zassert_equal(frag4->len, 2, "Length mismatch");
+	net_pkt_cursor_init(pkt);
+	zassert_true(net_pkt_read(pkt, small_buffer, 4) == 0, "Read failed");
+	zassert_mem_equal(small_buffer, "1234", 4, "Data mismatch");
+
+	/* Making use of the headrooms */
+	net_buf_push_u8(frag3, 'D');
+	net_buf_push_u8(frag2, 'C');
+	net_buf_push_u8(frag2, 'B');
+	net_buf_push_u8(frag1, 'A');
+	net_pkt_cursor_init(pkt);
+	zassert_true(net_pkt_read(pkt, small_buffer, 8) == 0, "Read failed");
+	zassert_mem_equal(small_buffer, "A1BCD234", 8, "Data mismatch");
+
+	net_pkt_unref(pkt);
+}
+
+NET_BUF_POOL_FIXED_DEFINE(test_net_pkt_headroom_copy_pool, 2, 4, NULL);
+void test_net_pkt_headroom_copy(void)
+{
+	struct net_pkt *pkt_src;
+	struct net_pkt *pkt_dst;
+	struct net_buf *frag1_dst;
+	struct net_buf *frag2_dst;
+
+	/* Create et_pkt containing the bytes "0123" */
+	pkt_src = net_pkt_alloc_with_buffer(eth_if, 4,
+					AF_UNSPEC, 0, K_NO_WAIT);
+	zassert_true(pkt_src != NULL, "Pkt not allocated");
+	net_pkt_write(pkt_src, "0123", 4);
+
+	/* Create net_pkt consisting of net_buf fragments with reserved bytes */
+	pkt_dst = net_pkt_alloc_on_iface(eth_if, K_NO_WAIT);
+	zassert_true(pkt_src != NULL, "Pkt not allocated");
+
+	frag1_dst = net_buf_alloc_len(&test_net_pkt_headroom_copy_pool, 2,
+				      K_NO_WAIT);
+	net_buf_reserve(frag1_dst, 1);
+	net_pkt_append_buffer(pkt_dst, frag1_dst);
+	frag2_dst = net_buf_alloc_len(&test_net_pkt_headroom_copy_pool, 4,
+				      K_NO_WAIT);
+	net_buf_reserve(frag2_dst, 1);
+	net_pkt_append_buffer(pkt_dst, frag2_dst);
+	zassert_equal(net_pkt_available_buffer(pkt_dst), 4, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt_dst), 0, "Length missmatch");
+
+	/* Copy to net_pkt which contains fragments with reserved bytes */
+	net_pkt_cursor_init(pkt_src);
+	net_pkt_cursor_init(pkt_dst);
+	net_pkt_copy(pkt_dst, pkt_src, 4);
+	zassert_equal(net_pkt_available_buffer(pkt_dst), 0, "Wrong space left");
+	zassert_equal(net_pkt_get_len(pkt_dst), 4, "Length missmatch");
+
+	net_pkt_cursor_init(pkt_dst);
+	zassert_true(net_pkt_read(pkt_dst, small_buffer, 4) == 0,
+		     "Pkt read failed");
+	zassert_mem_equal(small_buffer, "0123", 4, "Data mismatch");
+
+	net_pkt_unref(pkt_dst);
+	net_pkt_unref(pkt_src);
+}
+
 void test_main(void)
 {
 	eth_if = net_if_get_default();
@@ -797,7 +918,9 @@ void test_main(void)
 			 ztest_unit_test(test_net_pkt_easier_rw_usage),
 			 ztest_unit_test(test_net_pkt_copy),
 			 ztest_unit_test(test_net_pkt_pull),
-			 ztest_unit_test(test_net_pkt_clone)
+			 ztest_unit_test(test_net_pkt_clone),
+			 ztest_unit_test(test_net_pkt_headroom),
+			 ztest_unit_test(test_net_pkt_headroom_copy)
 		);
 
 	ztest_run_test_suite(net_pkt_tests);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -541,6 +541,7 @@ struct net_buf b5 = {
 	.data  = b5_data,
 	.len   = 0,
 	.size  = 0,
+	.__buf  = b5_data,
 };
 
 uint8_t b4_data[4] = "mnop";
@@ -550,11 +551,14 @@ struct net_buf b4 = {
 	.data  = b4_data,
 	.len   = sizeof(b4_data) - 2,
 	.size  = sizeof(b4_data),
+	.__buf  = b4_data,
 };
 
 struct net_buf b3 = {
 	.frags = &b4,
 	.ref   = 1,
+	.data  = NULL,
+	.__buf  = NULL,
 };
 
 uint8_t b2_data[8] = "efghijkl";
@@ -564,6 +568,7 @@ struct net_buf b2 = {
 	.data  = b2_data,
 	.len   = 0,
 	.size  = sizeof(b2_data),
+	.__buf  = b2_data,
 };
 
 uint8_t b1_data[4] = "abcd";
@@ -573,6 +578,7 @@ struct net_buf b1 = {
 	.data  = b1_data,
 	.len   = sizeof(b1_data) - 2,
 	.size  = sizeof(b1_data),
+	.__buf  = b1_data,
 };
 
 void test_net_pkt_copy(void)


### PR DESCRIPTION
When operating on a net_pkt using the curser functionality, reserved
bytes (headroom) must be respected.

This commit achieves this by updating the size member of the
net_buf_simple structure when reserving (and pushing) bytes.

While this solution changes the semantic of the size member, it requires
a low amount of code changes in addition to allowing the pattern of
writing (up to) size bytes starting at the data pointer to work properly
even in the presence of reserved bytes.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>