### PR TITLE
drivers: serial: Don't condition uart_irq_rx_ready on irq enabled

### DIFF
--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -257,7 +257,7 @@ static int uart_mcux_irq_rx_full(const struct device *dev)
 	return (flags & kUART_RxDataRegFullFlag) != 0U;
 }
 
-static int uart_mcux_irq_rx_ready(const struct device *dev)
+static int uart_mcux_irq_rx_pending(const struct device *dev)
 {
 	const struct uart_mcux_config *config = dev->config;
 	uint32_t mask = kUART_RxDataRegFullInterruptEnable;
@@ -288,7 +288,7 @@ static void uart_mcux_irq_err_disable(const struct device *dev)
 
 static int uart_mcux_irq_is_pending(const struct device *dev)
 {
-	return uart_mcux_irq_tx_ready(dev) || uart_mcux_irq_rx_ready(dev);
+	return uart_mcux_irq_tx_ready(dev) || uart_mcux_irq_rx_pending(dev);
 }
 
 static int uart_mcux_irq_update(const struct device *dev)
@@ -351,7 +351,7 @@ static const struct uart_driver_api uart_mcux_driver_api = {
 	.irq_tx_ready = uart_mcux_irq_tx_ready,
 	.irq_rx_enable = uart_mcux_irq_rx_enable,
 	.irq_rx_disable = uart_mcux_irq_rx_disable,
-	.irq_rx_ready = uart_mcux_irq_rx_ready,
+	.irq_rx_ready = uart_mcux_irq_rx_full,
 	.irq_err_enable = uart_mcux_irq_err_enable,
 	.irq_err_disable = uart_mcux_irq_err_disable,
 	.irq_is_pending = uart_mcux_irq_is_pending,

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -182,7 +182,7 @@ static int mcux_flexcomm_irq_rx_full(const struct device *dev)
 	return (flags & kUSART_RxFifoNotEmptyFlag) != 0U;
 }
 
-static int mcux_flexcomm_irq_rx_ready(const struct device *dev)
+static int mcux_flexcomm_irq_rx_pending(const struct device *dev)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
 	uint32_t mask = kUSART_RxLevelInterruptEnable;
@@ -214,7 +214,7 @@ static void mcux_flexcomm_irq_err_disable(const struct device *dev)
 static int mcux_flexcomm_irq_is_pending(const struct device *dev)
 {
 	return (mcux_flexcomm_irq_tx_ready(dev)
-		|| mcux_flexcomm_irq_rx_ready(dev));
+		|| mcux_flexcomm_irq_rx_pending(dev));
 }
 
 static int mcux_flexcomm_irq_update(const struct device *dev)
@@ -288,7 +288,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 	.irq_tx_ready = mcux_flexcomm_irq_tx_ready,
 	.irq_rx_enable = mcux_flexcomm_irq_rx_enable,
 	.irq_rx_disable = mcux_flexcomm_irq_rx_disable,
-	.irq_rx_ready = mcux_flexcomm_irq_rx_ready,
+	.irq_rx_ready = mcux_flexcomm_irq_rx_full,
 	.irq_err_enable = mcux_flexcomm_irq_err_enable,
 	.irq_err_disable = mcux_flexcomm_irq_err_disable,
 	.irq_is_pending = mcux_flexcomm_irq_is_pending,

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -164,7 +164,7 @@ static int mcux_iuart_irq_rx_full(const struct device *dev)
 	return (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag)) != 0U;
 }
 
-static int mcux_iuart_irq_rx_ready(const struct device *dev)
+static int mcux_iuart_irq_rx_pending(const struct device *dev)
 {
 	const struct mcux_iuart_config *config = DEV_CFG(dev);
 	uint32_t mask = kUART_RxDataReadyEnable;
@@ -193,7 +193,7 @@ static void mcux_iuart_irq_err_disable(const struct device *dev)
 
 static int mcux_iuart_irq_is_pending(const struct device *dev)
 {
-	return mcux_iuart_irq_tx_ready(dev) || mcux_iuart_irq_rx_ready(dev);
+	return mcux_iuart_irq_tx_ready(dev) || mcux_iuart_irq_rx_pending(dev);
 }
 
 static int mcux_iuart_irq_update(const struct device *dev)
@@ -265,7 +265,7 @@ static const struct uart_driver_api mcux_iuart_driver_api = {
 	.irq_tx_ready = mcux_iuart_irq_tx_ready,
 	.irq_rx_enable = mcux_iuart_irq_rx_enable,
 	.irq_rx_disable = mcux_iuart_irq_rx_disable,
-	.irq_rx_ready = mcux_iuart_irq_rx_ready,
+	.irq_rx_ready = mcux_iuart_irq_rx_full,
 	.irq_err_enable = mcux_iuart_irq_err_enable,
 	.irq_err_disable = mcux_iuart_irq_err_disable,
 	.irq_is_pending = mcux_iuart_irq_is_pending,

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -172,7 +172,7 @@ static int mcux_lpsci_irq_rx_full(const struct device *dev)
 	return (flags & kLPSCI_RxDataRegFullFlag) != 0U;
 }
 
-static int mcux_lpsci_irq_rx_ready(const struct device *dev)
+static int mcux_lpsci_irq_rx_pending(const struct device *dev)
 {
 	const struct mcux_lpsci_config *config = dev->config;
 	uint32_t mask = kLPSCI_RxDataRegFullInterruptEnable;
@@ -204,7 +204,7 @@ static void mcux_lpsci_irq_err_disable(const struct device *dev)
 static int mcux_lpsci_irq_is_pending(const struct device *dev)
 {
 	return (mcux_lpsci_irq_tx_ready(dev)
-		|| mcux_lpsci_irq_rx_ready(dev));
+		|| mcux_lpsci_irq_rx_pending(dev));
 }
 
 static int mcux_lpsci_irq_update(const struct device *dev)
@@ -276,7 +276,7 @@ static const struct uart_driver_api mcux_lpsci_driver_api = {
 	.irq_tx_ready = mcux_lpsci_irq_tx_ready,
 	.irq_rx_enable = mcux_lpsci_irq_rx_enable,
 	.irq_rx_disable = mcux_lpsci_irq_rx_disable,
-	.irq_rx_ready = mcux_lpsci_irq_rx_ready,
+	.irq_rx_ready = mcux_lpsci_irq_rx_full,
 	.irq_err_enable = mcux_lpsci_irq_err_enable,
 	.irq_err_disable = mcux_lpsci_irq_err_disable,
 	.irq_is_pending = mcux_lpsci_irq_is_pending,

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -174,7 +174,7 @@ static int mcux_lpuart_irq_rx_full(const struct device *dev)
 	return (flags & kLPUART_RxDataRegFullFlag) != 0U;
 }
 
-static int mcux_lpuart_irq_rx_ready(const struct device *dev)
+static int mcux_lpuart_irq_rx_pending(const struct device *dev)
 {
 	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
@@ -206,7 +206,7 @@ static void mcux_lpuart_irq_err_disable(const struct device *dev)
 static int mcux_lpuart_irq_is_pending(const struct device *dev)
 {
 	return (mcux_lpuart_irq_tx_ready(dev)
-		|| mcux_lpuart_irq_rx_ready(dev));
+		|| mcux_lpuart_irq_rx_pending(dev));
 }
 
 static int mcux_lpuart_irq_update(const struct device *dev)
@@ -388,7 +388,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 	.irq_tx_ready = mcux_lpuart_irq_tx_ready,
 	.irq_rx_enable = mcux_lpuart_irq_rx_enable,
 	.irq_rx_disable = mcux_lpuart_irq_rx_disable,
-	.irq_rx_ready = mcux_lpuart_irq_rx_ready,
+	.irq_rx_ready = mcux_lpuart_irq_rx_full,
 	.irq_err_enable = mcux_lpuart_irq_err_enable,
 	.irq_err_disable = mcux_lpuart_irq_err_disable,
 	.irq_is_pending = mcux_lpuart_irq_is_pending,

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -175,7 +175,7 @@ static int rv32m1_lpuart_irq_rx_full(const struct device *dev)
 	return (flags & kLPUART_RxDataRegFullFlag) != 0U;
 }
 
-static int rv32m1_lpuart_irq_rx_ready(const struct device *dev)
+static int rv32m1_lpuart_irq_rx_pending(const struct device *dev)
 {
 	const struct rv32m1_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
@@ -207,7 +207,7 @@ static void rv32m1_lpuart_irq_err_disable(const struct device *dev)
 static int rv32m1_lpuart_irq_is_pending(const struct device *dev)
 {
 	return (rv32m1_lpuart_irq_tx_ready(dev)
-		|| rv32m1_lpuart_irq_rx_ready(dev));
+		|| rv32m1_lpuart_irq_rx_pending(dev));
 }
 
 static int rv32m1_lpuart_irq_update(const struct device *dev)
@@ -287,7 +287,7 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 	.irq_tx_ready = rv32m1_lpuart_irq_tx_ready,
 	.irq_rx_enable = rv32m1_lpuart_irq_rx_enable,
 	.irq_rx_disable = rv32m1_lpuart_irq_rx_disable,
-	.irq_rx_ready = rv32m1_lpuart_irq_rx_ready,
+	.irq_rx_ready = rv32m1_lpuart_irq_rx_full,
 	.irq_err_enable = rv32m1_lpuart_irq_err_enable,
 	.irq_err_disable = rv32m1_lpuart_irq_err_disable,
 	.irq_is_pending = rv32m1_lpuart_irq_is_pending,


### PR DESCRIPTION
The function uart_irq_rx_ready() should return true if there is data in
the receive buffer, regardless of whether the irq is enabled. Fix the
mcux and rv32m1 shim drivers to implement this behavior correctly.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #31259