### PR TITLE
doc: releases: 2.5: add EEPROM release notes for v2.5

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -234,6 +234,9 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Marked the EEPROM API as stable.
+  * Added support for AT24Cxx devices.
+
 * Entropy
 
 * ESPI


### PR DESCRIPTION
Add EEPROM release notes for v2.5.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>