### PR TITLE
soc: arm: stm32l4: Fix stm32 ll header list

### DIFF
--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -12,6 +12,7 @@
 #include <stm32l4xx_ll_cortex.h>
 #include <stm32l4xx_ll_pwr.h>
 #include <stm32l4xx_ll_rcc.h>
+#include <stm32l4xx_ll_system.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);


### PR DESCRIPTION
PM stm32 ll header list was not adequate for L4 debug builds.
Add _system.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>