### PR TITLE
tests: lib: cbprintf_fp: add filter for tests using newlib

### DIFF
--- a/tests/lib/cbprintf_fp/testcase.yaml
+++ b/tests/lib/cbprintf_fp/testcase.yaml
@@ -24,6 +24,7 @@ tests:
         - "Hello with printf"
         - "Complete"
   lib.cbprintf_fp.printf_nl:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTF=y
       - CONFIG_NEWLIB_LIBC=y
@@ -43,6 +44,7 @@ tests:
         - "Hello with printfcb"
         - "Complete"
   lib.cbprintf_fp.printfcb_nl:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTFCB=y
       - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
As some tests are enabling CONFIG_NEWLIB_LIBC, we need to filter out that tests in case of missing NEWLIB support in toolchain.
It can be done with `filter: TOOLCHAIN_HAS_NEWLIB == 1` filter in `testcase.yaml`

Fixes #30300