### PR TITLE
power: fix bound on state array

### DIFF
--- a/subsys/power/pm_ctrl.c
+++ b/subsys/power/pm_ctrl.c
@@ -15,7 +15,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-#define PM_STATES_LEN (PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
+#define PM_STATES_LEN (1 + PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
 
 static atomic_t power_state_disable_count[PM_STATES_LEN];
 


### PR DESCRIPTION
Attempts to disable PM_STATE_SOFT_OFF would index past the end of the count array.  Increase the array length to allow operations on PM_STATE_SOFT_OFF.

(This broke the Nordic system-off application.)