### PR TITLE
tests: mem_protect: fix failing inheritance test under SMP

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -176,8 +176,9 @@ void test_inherit_resource_pool(void)
 			K_THREAD_STACK_SIZEOF(parent_thr_stack),
 			parent_handler,
 			NULL, NULL, NULL,
-			PRIORITY, 0, K_NO_WAIT);
+			PRIORITY, 0, K_FOREVER);
 	k_thread_heap_assign(&parent_thr, &res_pool);
+	k_thread_start(&parent_thr);
 	k_sem_take(&sync_sem, K_FOREVER);
 	zassert_true(parent_res_pool_ptr == child_res_pool_ptr,
 		     "Resource pool of the parent thread not inherited,"


### PR DESCRIPTION
The inheritance test first creates a parent thread, and then
creates a child thread inside this parent thread. At the same
time inside the main thread, a resource pool is assigned to
the parent thread. However, when under SMP, it is possible
that the pool assignment is done between both parent/child
threads are getting pointers to the pool, due to multiple
threads are running. So when doing pool pointer comparison,
there is a mismatch between those pointers (like parent has
a null pool pointer while child is pointing to the actual
pool), and thus failing the test. So fix this by delaying
the parent from running under after pool assignment is done.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>