### PR TITLE
x86: clear GS at boot for x86_64

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -182,6 +182,15 @@ enter_code64:
 	movw %ax, %ss
 	movw %ax, %fs
 
+	/* On Intel processors, if GS is not zero and is being set to
+	 * zero, GS_BASE is also being set to zero. This would interfere
+	 * with the actual use of GS_BASE for usespace. To avoid accidentally
+	 * clearing GS_BASE, simply set GS to 0 at boot, so any subsequent
+	 * clearing of GS will not clear GS_BASE.
+	 */
+	mov $0, %eax
+	movw %ax, %gs
+
 	movw __x86_cpuboot_t_tr_OFFSET(%rbp), %ax
 	ltr %ax
 


### PR DESCRIPTION
On Intel processors, if GS is not zero and is being set to
zero, GS_BASE is also being set to zero. This would interfere
with the actual use of GS_BASE for usespace. To avoid accidentally
clearing GS_BASE, simply set GS to 0 at boot, so any subsequent
clearing of GS will not clear GS_BASE.

The clearing of GS_BASE was discovered while trying to figure out
why the mem_protect test would hang within 10-20 repeated runs.
GDB revealed that both GS and GS_BASE was set to zero when the tests
hanged. After setting GS to zero at boot, the mem_protect tests
were running repeated for 5,000+ times without hanging.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>