### PR TITLE
drivers: can: mcp2515: Enable CAN_NORMAL_MODE

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -923,12 +923,12 @@ static int mcp2515_init(const struct device *dev)
 		}
 	}
 
-	ret = can_set_mode(dev, CAN_NORMAL_MODE);
+	ret = can_set_timing(dev, &timing, NULL);
 	if (ret) {
 		return ret;
 	}
 
-	ret = can_set_timing(dev, &timing, NULL);
+	ret = can_set_mode(dev, CAN_NORMAL_MODE);
 
 	return ret;
 }


### PR DESCRIPTION
Enable CAN_NORMAL_MODE after configuring the CNF1, CNF2, CNF3 register.

Signed-off-by: NavinSankar Velliangiri <navin@linumiz.com>