### PR TITLE
doc: releasenotes 2.5: Add notes on addition fs_file_t_init

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -79,6 +79,9 @@ API Changes
   standard way to identify the control signal in nodes that support power
   control.
 
+* :c:type:`fs_tile_t` objects must now be initialized by calling
+  :c:func:`fs_file_t_init` before their first use.
+
 Deprecated in this release
 ==========================
 
@@ -355,6 +358,13 @@ Build and Infrastructure
 
 Libraries / Subsystems
 **********************
+
+* File systems
+
+  * API
+
+    * Added c:func:`fs_file_t_init` function for initialization of
+      c:type:`fs_file_t` objects.
 
 * Disk
 


### PR DESCRIPTION
The commit adds notes on addition on fs_file_t_init function and its
impact on File system API.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>