### PR TITLE
drivers: eeprom: eeprom simulator fix range error

### DIFF
--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -98,7 +98,7 @@ static int eeprom_range_is_valid(const struct device *dev, off_t offset,
 {
 	const struct eeprom_sim_config *config = DEV_CONFIG(dev);
 
-	if ((offset + len) < config->size) {
+	if ((offset + len) <= config->size) {
 		return 1;
 	}
 


### PR DESCRIPTION
This PR fixes a bug in the eeprom simulator making the last byte
part of the readable/writeable range

Signed-off-by: Laczen JMS <laczenjms@gmail.com>