### PR TITLE
kernel: Kconfig: increase test default MAIN_STACK_SIZE

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -150,6 +150,7 @@ config SCHED_CPU_MASK
 config MAIN_STACK_SIZE
 	int "Size of stack for initialization and main thread"
 	default 2048 if COVERAGE_GCOV
+	default 1024 if TEST_ARM_CORTEX_M
 	default 512 if ZTEST && !(RISCV || X86)
 	default 1024
 	help


### PR DESCRIPTION
There are several reasons to increase MAIN_STACK_SIZE for test purpose:
* activation of CONFIG_FPU_SHARING by default when CONFIG_FPU is enabled for ARM arch (see #31772)
  This increase stack usage and requires MAIN_STACK_SIZE enlargement.
* more and more tests failed due to stackoverflow.
    - tests/kernel/threads/tls/kernel.threads.tls.userspace
    - tests/kernel/fatal/exception/kernel.common.stack_protection_arm_fpu_sharing
    - tests/kernel/common/kernel.common.tls
    - tests/kernel/poll/

    And it concerns several boards: stm32f3_disco and nucleo_f746zg

Arbitrary increase from 512 to 768.
This fixes above issues.
No regression found on STM32 test bench.
