### PR TITLE
Bluetooth: samples: Fix stack overflow in TX power control samples

### DIFF
--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -34,7 +34,7 @@ static const struct bt_data ad[] = {
 #define DEVICE_BEACON_TXPOWER_NUM  8
 
 static struct k_thread pwr_thread_data;
-static K_THREAD_STACK_DEFINE(pwr_thread_stack, 320);
+static K_THREAD_STACK_DEFINE(pwr_thread_stack, 512);
 
 static const int8_t txp[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
 						    -15, -18, -23, -30};


### PR DESCRIPTION
Fix stack overflow in the TX power control sample.
Current stack usage with 0.11.1 zephyr toolchain was at 100% stack
usage of the DYN TX stack.

Fixes: #31433

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>