### PR TITLE
CODEOWNERS: cleanup and replacing few entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@
 /arch/arm/include/aarch32/cortex_m/cmse.h @ioannisg
 /arch/arm/include/aarch64/                @carlocaione
 /arch/arm/core/aarch32/cortex_a_r/        @MaureenHelm @galak @ioannisg @bbolen @stephanosio
-/arch/common/                             @andrewboie @ioannisg @andyross
+/arch/common/                             @ioannisg @andyross
 /soc/arc/snps_*/                          @abrodkin @ruuddw
 /soc/nios2/                               @nashif
 /soc/arm/                                 @MaureenHelm @galak @ioannisg
@@ -56,16 +56,16 @@
 /soc/arm/ti_simplelink/msp432p4xx/        @Mani-Sadhasivam
 /soc/arm/xilinx_zynqmp/                   @stephanosio
 /soc/xtensa/intel_s1000/                  @sathishkuttan @dcpleung
-/arch/x86/                                @jhedberg @andrewboie @jenmwms @aasthagr
+/arch/x86/                                @jhedberg @nashif @jenmwms @aasthagr
 /arch/nios2/                              @nashif
 /arch/posix/                              @aescolar @daor-oti
 /arch/riscv/                              @kgugala @pgielda
 /soc/posix/                               @aescolar @daor-oti
 /soc/riscv/                               @kgugala @pgielda
 /soc/riscv/openisa*/                      @MaureenHelm
-/soc/x86/                                 @andrewboie @jenmwms @aasthagr
-/arch/xtensa/                             @andrewboie @dcpleung @andyross
-/soc/xtensa/                              @andrewboie @dcpleung @andyross
+/soc/x86/                                 @dcpleung @nashif @jenmwms @aasthagr
+/arch/xtensa/                             @dcpleung @andyross @nashif
+/soc/xtensa/                              @dcpleung @andyross @nashif
 /arch/sparc/                              @martin-aberg
 /soc/sparc/                               @martin-aberg
 /boards/arc/                              @abrodkin @ruuddw
@@ -136,7 +136,7 @@
 /boards/shields/atmel_rf2xx/              @nandojve
 /boards/shields/esp_8266/                 @nandojve
 /boards/shields/inventek_eswifi/          @nandojve
-/boards/x86/                              @andrewboie @nashif @jenmwms @aasthagr
+/boards/x86/                              @dcpleung @nashif @jenmwms @aasthagr
 /boards/xtensa/                           @nashif @dcpleung
 /boards/xtensa/intel_s1000_crb/           @sathishkuttan @dcpleung
 /boards/xtensa/odroid_go/                 @ydamigos
@@ -175,12 +175,12 @@
 /drivers/counter/                         @nordic-krch
 /drivers/console/ipm_console.c            @finikorg
 /drivers/console/semihost_console.c       @luozhongyao
-/drivers/counter/counter_cmos.c           @andrewboie
+/drivers/counter/counter_cmos.c           @dcpleung
 /drivers/counter/maxim_ds3231.c           @pabigot
 /drivers/crypto/*nrf_ecb*                 @maciekfabia @anangl
 /drivers/console/*mux*                    @jukkar
 /drivers/display/                         @vanwinkeljan
-/drivers/display/display_framebuf.c       @andrewboie
+/drivers/display/display_framebuf.c       @dcpleung
 /drivers/dac/                             @martinjaeger
 /drivers/dma/*dw*                         @tbursztyka
 /drivers/dma/*sam0*                       @Sizurka
@@ -219,7 +219,7 @@
 /drivers/ieee802154/                      @jukkar @tbursztyka
 /drivers/ieee802154/ieee802154_rf2xx*     @jukkar @tbursztyka @nandojve
 /drivers/ieee802154/ieee802154_cc13xx*    @bwitherspoon @cfriedt
-/drivers/interrupt_controller/            @andrewboie
+/drivers/interrupt_controller/            @dcpleung @nashif
 /drivers/interrupt_controller/intc_gic.c  @stephanosio
 /drivers/ipm/ipm_mhu*                     @karl-zh
 /drivers/ipm/Kconfig.nrfx                 @masz-nordic @ioannisg
@@ -237,7 +237,7 @@
 /drivers/modem/*gsm*                      @jukkar
 /drivers/modem/hl7800.c                   @rerickson1
 /drivers/modem/Kconfig.hl7800             @rerickson1
-/drivers/pcie/                            @andrewboie
+/drivers/pcie/                            @dcpleung @nashif @jhedberg
 /drivers/peci/                            @albertofloyd @franciscomunoz @scottwcpg
 /drivers/pinmux/*hsdk*                    @iriszzw
 /drivers/pinmux/*it8xxx2*                 @ite
@@ -260,7 +260,7 @@
 /drivers/sensor/mpr/                      @sven-hm
 /drivers/sensor/st*/                      @avisconti
 /drivers/serial/uart_altera_jtag_hal.c    @nashif
-/drivers/serial/*ns16550*                 @andrewboie @jenmwms @aasthagr
+/drivers/serial/*ns16550*                 @dcpleung @nashif @jenmwms @aasthagr
 /drivers/serial/*nrfx*                    @Mierunski @anangl
 /drivers/serial/uart_liteuart.c           @mateusz-holenko @kgugala @pgielda
 /drivers/serial/Kconfig.mcux_iuart        @Mani-Sadhasivam
@@ -277,7 +277,7 @@
 /drivers/ptp_clock/                       @jukkar
 /drivers/spi/                             @tbursztyka
 /drivers/spi/spi_rv32m1_lpspi*            @karstenkoenig
-/drivers/timer/apic_timer.c               @andrewboie
+/drivers/timer/apic_timer.c               @dcpleung @nashif
 /drivers/timer/arm_arch_timer.c           @carlocaione
 /drivers/timer/cortex_m_systick.c         @ioannisg
 /drivers/timer/altera_avalon_timer_hal.c  @nashif
@@ -298,7 +298,7 @@
 /drivers/*/*xec*                          @franciscomunoz @albertofloyd @scottwcpg
 /drivers/watchdog/*gecko*                 @oanerer
 /drivers/watchdog/*sifive*                @katsuster
-/drivers/watchdog/wdt_handlers.c          @andrewboie
+/drivers/watchdog/wdt_handlers.c          @dcpleung @nashif
 /drivers/wifi/                            @jukkar @tbursztyka @pfalcon
 /drivers/wifi/esp/                        @mniestroj
 /drivers/wifi/eswifi/                     @loicpoulain @nandojve
@@ -350,7 +350,7 @@
 /dts/bindings/i2c/zephyr*i2c-emul.yaml    @sjg20
 /dts/bindings/adc/st*stm32-adc.yaml       @cybertale
 /dts/bindings/modem/*hl7800.yaml          @rerickson1
-/dts/bindings/serial/ns16550.yaml         @andrewboie
+/dts/bindings/serial/ns16550.yaml         @dcpleung @nashif
 /dts/bindings/wifi/*esp.yaml              @mniestroj
 /dts/bindings/*/*npcx*                    @MulinChao
 /dts/bindings/*/nordic*                   @anangl
@@ -377,10 +377,10 @@
 /include/drivers/flash.h                  @nashif @carlescufi @galak @MaureenHelm @nvlsianpu
 /include/drivers/i2c_emul.h               @sjg20
 /include/drivers/led/ht16k33.h            @henrikbrixandersen
-/include/drivers/interrupt_controller/    @andrewboie
+/include/drivers/interrupt_controller/    @dcpleung @nashif
 /include/drivers/interrupt_controller/gic.h @stephanosio
 /include/drivers/modem/hl7800.h           @rerickson1
-/include/drivers/pcie/                    @andrewboie
+/include/drivers/pcie/                    @dcpleung
 /include/drivers/hwinfo.h                 @alexanderwachter
 /include/drivers/led.h                    @Mani-Sadhasivam
 /include/drivers/led_strip.h              @mbolivar-nordic
@@ -389,26 +389,26 @@
 /include/drivers/lora.h                   @Mani-Sadhasivam
 /include/drivers/peci.h                   @albertofloyd @franciscomunoz @scottwcpg
 /include/drivers/psci.h                   @carlocaione
-/include/app_memory/                      @andrewboie
+/include/app_memory/                      @dcpleung
 /include/arch/arc/                        @abrodkin @ruuddw
-/include/arch/arc/arch.h                  @andrewboie
-/include/arch/arc/v2/irq.h                @andrewboie
+/include/arch/arc/arch.h                  @abrodkin @ruuddw
+/include/arch/arc/v2/irq.h                @abrodkin @ruuddw
 /include/arch/arm/aarch32/                @MaureenHelm @galak @ioannisg
 /include/arch/arm/aarch32/cortex_a_r/     @stephanosio
 /include/arch/arm/aarch64/                @carlocaione
 /include/arch/arm/arm-smccc.h             @carlocaione
-/include/arch/arm/aarch32/irq.h           @andrewboie
+/include/arch/arm/aarch32/irq.h           @carlocaione
 /include/arch/nios2/                      @nashif
 /include/arch/nios2/arch.h                @nashif
 /include/arch/posix/                      @aescolar @daor-oti
 /include/arch/riscv/                      @kgugala @pgielda
-/include/arch/x86/                        @andrewboie @jhedberg @dcpleung
-/include/arch/common/                     @andrewboie @andyross @nashif
-/include/arch/xtensa/                     @andrewboie
+/include/arch/x86/                        @jhedberg @dcpleung
+/include/arch/common/                     @andyross @nashif
+/include/arch/xtensa/                     @andyross @dcpleung
 /include/arch/sparc/                      @martin-aberg
-/include/sys/atomic.h                     @andrewboie @andyross
+/include/sys/atomic.h                     @andyross
 /include/bluetooth/                       @joerchan @jhedberg @Vudentz
-/include/cache.h                          @andrewboie @andyross
+/include/cache.h                          @carlocaione @andyross
 /include/canbus/                          @alexanderwachter
 /include/tracing/                         @nashif
 /include/debug/                           @nashif
@@ -420,17 +420,17 @@
 /include/dt-bindings/clock/kinetis_mcg.h  @henrikbrixandersen
 /include/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/dt-bindings/dma/stm32_dma.h      @cybertale
-/include/dt-bindings/pcie/                @andrewboie
+/include/dt-bindings/pcie/                @dcpleung
 /include/dt-bindings/usb/usb.h            @galak @finikorg
 /include/emul.h                           @sjg20
 /include/fs/                              @nashif @nvlsianpu @de-nordic @pabigot
-/include/init.h                           @andrewboie @andyross
-/include/irq.h                            @andrewboie @andyross
-/include/irq_offload.h                    @andrewboie @andyross
-/include/kernel.h                         @andrewboie @andyross
-/include/kernel_version.h                 @andrewboie @andyross
-/include/linker/app_smem*.ld              @andrewboie
-/include/linker/                          @andrewboie @andyross
+/include/init.h                           @nashif @andyross
+/include/irq.h                            @dcpleung @nashif @andyross
+/include/irq_offload.h                    @dcpleung @nashif @andyross
+/include/kernel.h                         @dcpleung @nashif @andyross
+/include/kernel_version.h                 @dcpleung @nashif @andyross
+/include/linker/app_smem*.ld              @dcpleung @nashif
+/include/linker/                          @dcpleung @nashif @andyross
 /include/logging/                         @nordic-krch
 /include/lorawan/lorawan.h                @Mani-Sadhasivam
 /include/mgmt/osdp.h                      @cbsiddharth
@@ -442,28 +442,28 @@
 /include/posix/                           @pfalcon
 /include/power/power.h                    @pabigot @nashif @ceolin
 /include/ptp_clock.h                      @jukkar
-/include/shared_irq.h                     @andrewboie @andyross
+/include/shared_irq.h                     @dcpleung @nashif @andyross
 /include/shell/                           @jakub-uC @nordic-krch
-/include/sw_isr_table.h                   @andrewboie @andyross
-/include/sys_clock.h                      @andrewboie @andyross
-/include/sys/sys_io.h                     @andrewboie @andyross
-/include/sys/kobject.h                    @andrewboie
-/include/toolchain.h                      @andrewboie @andyross @nashif
-/include/toolchain/                       @andrewboie @andyross
-/include/zephyr.h                         @andrewboie @andyross
-/kernel/                                  @andrewboie @andyross
+/include/sw_isr_table.h                   @dcpleung @nashif @andyross
+/include/sys_clock.h                      @dcpleung @nashif @andyross
+/include/sys/sys_io.h                     @dcpleung @nashif @andyross
+/include/sys/kobject.h                    @dcpleung @nashif
+/include/toolchain.h                      @dcpleung @andyross @nashif
+/include/toolchain/                       @dcpleung @nashif @andyross
+/include/zephyr.h                         @dcpleung @nashif @andyross
+/kernel/                                  @dcpleung @nashif @andyross
 /lib/fnmatch/                             @carlescufi
 /lib/gui/                                 @vanwinkeljan
 /lib/open-amp/                            @arnopo
-/lib/os/                                  @andrewboie @andyross
+/lib/os/                                  @dcpleung @nashif @andyross
 /lib/posix/                               @pfalcon
 /lib/cmsis_rtos_v2/                       @nashif
 /lib/cmsis_rtos_v1/                       @nashif
-/lib/libc/                                @nashif @andrewboie
+/lib/libc/                                @nashif
 /modules/                                 @nashif
 /modules/Kconfig.tfm                      @ioannisg @microbuilder
-/kernel/device.c                          @andrewboie @andyross @nashif
-/kernel/idle.c                            @andrewboie @andyross @nashif
+/kernel/device.c                          @andyross @nashif
+/kernel/idle.c                            @andyross @nashif
 /samples/                                 @nashif
 /samples/basic/minimal/                   @carlescufi
 /samples/basic/servo_motor/boards/*microbit* @jhe
@@ -495,25 +495,25 @@
 /samples/subsys/usb/                      @jfischer-no @finikorg
 /samples/subsys/power/                    @nashif @pabigot @ceolin
 /samples/tfm_integration/                 @ioannisg @microbuilder
-/samples/userspace/                       @andrewboie
+/samples/userspace/                       @dcpleung @nashif
 /scripts/coccicheck                       @himanshujha199640 @JuliaLawall
 /scripts/coccinelle/                      @himanshujha199640 @JuliaLawall
 /scripts/coredump/                        @dcpleung
 /scripts/kconfig/                         @ulfalizer
 /scripts/pylib/twister/expr_parser.py     @nashif
 /scripts/schemas/twister/                 @nashif
-/scripts/gen_app_partitions.py            @andrewboie
+/scripts/gen_app_partitions.py            @dcpleung @nashif
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif
 /scripts/ci/                              @nashif
-/arch/x86/gen_gdt.py                      @andrewboie
-/arch/x86/gen_idt.py                      @andrewboie
-/scripts/gen_kobject_list.py              @andrewboie
-/scripts/gen_syscalls.py                  @andrewboie
+/arch/x86/gen_gdt.py                      @dcpleung @nashif
+/arch/x86/gen_idt.py                      @dcpleung @nashif
+/scripts/gen_kobject_list.py              @dcpleung @nashif
+/scripts/gen_syscalls.py                  @dcpleung @nashif
 /scripts/list_boards.py                   @mbolivar-nordic
 /scripts/net/                             @jukkar
-/scripts/process_gperf.py                 @andrewboie
+/scripts/process_gperf.py                 @dcpleung @nashif
 /scripts/gen_relocate_app.py              @dcpleung
 /scripts/requirements*.txt                @mbolivar-nordic @galak @nashif
 /scripts/tests/twister/                   @aasthagr
@@ -541,7 +541,7 @@
 /subsys/dfu/                              @nvlsianpu
 /subsys/tracing/                          @nashif
 /subsys/debug/asan_hacks.c                @vanwinkeljan @aescolar @daor-oti
-/subsys/demand_paging/                    @andrewboie
+/subsys/demand_paging/                    @dcpleung @nashif
 /subsys/disk/disk_access_spi_sdhc.c       @JunYangNXP
 /subsys/disk/disk_access_sdhc.h           @JunYangNXP
 /subsys/disk/disk_access_usdhc.c          @JunYangNXP
@@ -607,7 +607,7 @@
 /tests/drivers/hwinfo/                    @alexanderwachter
 /tests/drivers/spi/                       @tbursztyka
 /tests/drivers/uart/uart_async_api/       @Mierunski
-/tests/kernel/                            @andrewboie @andyross @nashif
+/tests/kernel/                            @dcpleung @andyross @nashif
 /tests/lib/                               @nashif
 /tests/lib/cmsis_dsp/                     @stephanosio
 /tests/net/                               @jukkar @tbursztyka @pfalcon
@@ -624,5 +624,5 @@
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
 # Get all docs reviewed
 *.rst                                     @nashif
-/doc/reference/kernel/                    @andrewboie @andyross @nashif
+/doc/reference/kernel/                    @andyross @nashif
 *posix*.rst                               @aescolar @daor-oti


### PR DESCRIPTION
Replace andreboie in the file.
Temporary until we completely move to MAINTAINER file.