### PR TITLE
arm: cortex_m: fix vector table relocation in non-XIP builds

### DIFF
--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -44,11 +44,8 @@ void *_vector_table_pointer;
 
 #ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
 
-#ifdef CONFIG_XIP
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)
-#else
-#define VECTOR_ADDRESS CONFIG_SRAM_BASE_ADDRESS
-#endif
+
 static inline void relocate_vector_table(void)
 {
 	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;


### PR DESCRIPTION
When VTOR is implemented on the Cortex-M SoC, we can
basically use any address (properly aligned) for the
vector table starting address. We fix the setting of
VTOR in prep_c.c for non-XIP images, in this commit,
so we do not need to always have the vector table be
present at the start of RAM (CONFIG_SRAM_BASE_ADDRESS)
and allow for extra linker sections being placed before
the vector table section.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #31235 (@GrixaYrev pls, confirm)