### PR TITLE
Bluetooth: controller: Add initial support for chaining in periodic advertising

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -165,6 +165,13 @@ config BT_CTLR_ADV_SYNC_SET
 	help
 	  Maximum supported periodic advertising sets.
 
+config BT_CTLR_ADV_PDU_LINK
+	bool "Enable linking of advertising PDU trains"
+	help
+	  Enables extra space in each advertising PDU to allow linking PDUs. This
+	  is required to enable advertising data trains (i.e. transmission of
+	  AUX_CHAIN_IND).
+
 config BT_CTLR_ADV_DATA_BUF_MAX
 	int "Advertising Data Maximum Buffers"
 	depends on BT_BROADCASTER

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -172,6 +172,26 @@ config BT_CTLR_ADV_PDU_LINK
 	  is required to enable advertising data trains (i.e. transmission of
 	  AUX_CHAIN_IND).
 
+config BT_CTLR_ADV_SYNC_PDU_BACK2BACK
+	bool "Enable back-to-back transmission of periodic advertising trains"
+	depends on BT_CTLR_ADV_PERIODIC
+	select BT_CTLR_ADV_PDU_LINK
+	help
+	  Enables transmission of AUX_CHAIN_IND in periodic advertising train by
+	  sending each AUX_CHAIN_IND one after another back-to-back.
+	  Note, consecutive AUX_CHAIN_IND packets are not scheduled but sent at
+	  a constant offset on a best effort basis. This means advertising train can
+	  be preempted by other event at any time.
+
+config BT_CTLR_ADV_SYNC_PDU_BACK2BACK_AFS
+	int "AUX Frame Space for back-to-back transmission of periodic advertising trains"
+	depends on BT_CTLR_ADV_SYNC_PDU_BACK2BACK
+	default 300
+	range 300 1000
+	help
+	  Specific AUX Frame Space to be used for back-to-back transmission of
+	  periodic advertising trains. Time specified in microseconds.
+
 config BT_CTLR_ADV_DATA_BUF_MAX
 	int "Advertising Data Maximum Buffers"
 	depends on BT_BROADCASTER

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -26,6 +26,7 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+#include "util/mem.h"
 
 #include "hal/ecb.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -14,6 +14,7 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+#include "util/mem.h"
 
 #include "pdu.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -16,6 +16,7 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+#include "util/mem.h"
 
 #include "pdu.h"
 

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -27,6 +27,9 @@ struct lll_adv_sync {
 	uint32_t ticks_offset;
 
 	struct lll_adv_pdu data;
+#if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
+	struct pdu_adv *last_pdu;
+#endif /* CONFIG_BT_CTLR_ADV_PDU_LINK */
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO)
 	struct lll_adv_iso *iso;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -410,38 +410,13 @@ struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
 						 void **extra_data,
 						 uint8_t *idx)
 {
-	uint8_t first, last;
 	struct pdu_adv *p;
-
-	first = pdu->first;
-	last = pdu->last;
-	if (first == last) {
-		last++;
-		if (last == DOUBLE_BUFFER_SIZE) {
-			last = 0U;
-		}
-	} else {
-		uint8_t first_latest;
-
-		pdu->last = first;
-		cpu_dmb();
-		first_latest = pdu->first;
-		if (first_latest != first) {
-			last++;
-			if (last == DOUBLE_BUFFER_SIZE) {
-				last = 0U;
-			}
-		}
-	}
-
-	*idx = last;
-
-	p = adv_pdu_allocate(pdu, last);
+	p = lll_adv_pdu_alloc(pdu, idx);
 
 	if (extra_data) {
-		*extra_data = adv_extra_data_allocate(pdu, last);
+		*extra_data = adv_extra_data_allocate(pdu, *idx);
 	} else {
-		if (adv_extra_data_free(pdu, last)) {
+		if (adv_extra_data_free(pdu, *idx)) {
 			/* There is no release of memory allocated by
 			 * adv_pdu_allocate because there is no memory leak.
 			 * If caller can recover from this error and subsequent

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -17,6 +17,7 @@
 #include "hal/ticker.h"
 
 #include "util/util.h"
+#include "util/mem.h"
 #include "util/memq.h"
 
 #include "pdu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -14,6 +14,7 @@ static inline void lll_adv_pdu_enqueue(struct lll_adv_pdu *pdu, uint8_t idx)
 }
 
 struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx);
+struct pdu_adv *lll_adv_pdu_alloc_pdu_adv(void);
 
 static inline struct pdu_adv *lll_adv_data_alloc(struct lll_adv *lll,
 						 uint8_t *idx)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -91,6 +91,10 @@ static inline struct pdu_adv *lll_adv_aux_data_curr_get(struct lll_adv_aux *lll)
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int lll_adv_and_extra_data_release(struct lll_adv_pdu *pdu);
 
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+void lll_adv_sync_pdu_b2b_update(struct lll_adv_sync *lll, uint8_t idx);
+#endif
+
 struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
 						 void **extra_data,
 						 uint8_t *idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -15,6 +15,7 @@
 #include "hal/radio_df.h"
 
 #include "util/util.h"
+#include "util/mem.h"
 #include "util/memq.h"
 
 #include "pdu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -33,6 +33,7 @@
 #include "lll_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_tim_internal.h"
+#include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
@@ -40,10 +41,21 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+#define ADV_SYNC_PDU_B2B_AFS  (CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK_AFS)
+#endif
+
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void isr_done(void *param);
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+static void isr_tx(void *param);
+static void pdu_b2b_update(struct lll_adv_sync *lll, struct pdu_adv *pdu);
+static void pdu_b2b_aux_ptr_update(struct pdu_adv *pdu, uint8_t phy,
+				   uint8_t flags, uint8_t chan_idx,
+				   uint32_t tifs);
+#endif /* CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK */
 
 int lll_adv_sync_init(void)
 {
@@ -148,6 +160,15 @@ static int prepare_cb(struct lll_prepare_param *p)
 	pdu = lll_adv_sync_data_latest_get(lll, &extra_data, &upd);
 	LL_ASSERT(pdu);
 
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+	if (upd) {
+		/* AuxPtr offsets for b2b TX are fixed for given chain so we can
+		 * calculate them here in advance.
+		 */
+		pdu_b2b_update(lll, pdu);
+	}
+#endif
+
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	if (extra_data) {
 		df_cfg = (struct lll_df_adv_cfg *)extra_data;
@@ -162,16 +183,26 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	radio_pkt_tx_set(pdu);
 
-	/* TODO: chaining */
-	radio_isr_set(isr_done, lll);
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+	if (pdu->adv_ext_ind.ext_hdr_len && pdu->adv_ext_ind.ext_hdr.aux_ptr) {
+		lll->last_pdu = pdu;
 
+		radio_isr_set(isr_tx, lll);
+		radio_tmr_tifs_set(ADV_SYNC_PDU_B2B_AFS);
+		radio_switch_complete_and_b2b_tx(phy_s, 0, phy_s, 0);
+#else
+	if (0) {
+#endif /* CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK */
+	} else {
+		radio_isr_set(isr_done, lll);
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
-	if (df_cfg) {
-		radio_switch_complete_and_phy_end_disable();
-	} else
+		if (df_cfg) {
+			radio_switch_complete_and_phy_end_disable();
+		} else
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
-	{
-		radio_switch_complete_and_disable();
+		{
+			radio_switch_complete_and_disable();
+		}
 	}
 
 	ticks_at_event = p->ticks_at_expire;
@@ -256,3 +287,132 @@ static void isr_done(void *param)
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 	lll_isr_done(lll);
 }
+
+#if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
+static void isr_tx(void *param)
+{
+	struct lll_adv_sync *lll_sync;
+	struct pdu_adv *pdu;
+	struct lll_adv *lll;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_latency_capture();
+	}
+
+	/* Clear radio tx status and events */
+	lll_isr_tx_status_reset();
+
+	lll_sync = param;
+	lll = lll_sync->adv;
+
+	/* TODO: do not hardcode to single value */
+	lll_chan_set(0);
+
+	pdu = lll_adv_pdu_linked_next_get(lll_sync->last_pdu);
+	LL_ASSERT(pdu);
+	lll_sync->last_pdu = pdu;
+
+	/* setup tIFS switching */
+	if (pdu->adv_ext_ind.ext_hdr_len && pdu->adv_ext_ind.ext_hdr.aux_ptr) {
+		radio_tmr_tifs_set(ADV_SYNC_PDU_B2B_AFS);
+		radio_isr_set(isr_tx, lll_sync);
+		radio_switch_complete_and_b2b_tx(lll->phy_s, 0, lll->phy_s, 0);
+	} else {
+		radio_isr_set(lll_isr_done, lll);
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+		if (lll_sync->cte_started) {
+			radio_switch_complete_and_phy_end_disable();
+		} else
+#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
+		{
+			radio_switch_complete_and_disable();
+		}
+	}
+
+	radio_pkt_tx_set(pdu);
+
+	/* assert if radio packet ptr is not set and radio started rx */
+	LL_ASSERT(!radio_is_ready());
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_cputime_capture();
+	}
+
+	/* capture end of AUX_SYNC_IND/AUX_CHAIN_IND PDU, used for calculating
+	 * next PDU timestamp.
+	 */
+	radio_tmr_end_capture();
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		/* PA/LNA enable is overwriting packet end used in ISR
+		 * profiling, hence back it up for later use.
+		 */
+		lll_prof_radio_end_backup();
+	}
+
+	radio_gpio_lna_setup();
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+				 ADV_SYNC_PDU_B2B_AFS - 4 -
+				 radio_tx_chain_delay_get(lll->phy_s, 0) -
+				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_send();
+	}
+}
+
+static void pdu_b2b_update(struct lll_adv_sync *lll, struct pdu_adv *pdu)
+{
+	while (pdu) {
+		pdu_b2b_aux_ptr_update(pdu, lll->adv->phy_s, 0, 0,
+				       ADV_SYNC_PDU_B2B_AFS);
+		pdu = lll_adv_pdu_linked_next_get(pdu);
+	}
+}
+
+static void pdu_b2b_aux_ptr_update(struct pdu_adv *pdu, uint8_t phy,
+				   uint8_t flags, uint8_t chan_idx,
+				   uint32_t tifs)
+{
+	struct pdu_adv_com_ext_adv *com_hdr;
+	struct pdu_adv_ext_hdr *hdr;
+	struct pdu_adv_aux_ptr *aux;
+	uint32_t offs;
+	uint8_t *dptr;
+
+	com_hdr = &pdu->adv_ext_ind;
+	hdr = &com_hdr->ext_hdr;
+	/* Skip flags */
+	dptr = hdr->data;
+
+	if (!com_hdr->ext_hdr_len || !hdr->aux_ptr) {
+		return;
+	}
+
+	LL_ASSERT(!hdr->adv_addr);
+	LL_ASSERT(!hdr->tgt_addr);
+
+	if (hdr->cte_info) {
+		dptr++;
+	}
+
+	LL_ASSERT(!hdr->adi);
+
+	/* Update AuxPtr */
+	aux = (void *)dptr;
+	offs = PKT_AC_US(pdu->len, phy) + tifs;
+	offs = offs / OFFS_UNIT_30_US;
+	if ((offs >> 13) != 0) {
+		aux->offs = offs / (OFFS_UNIT_300_US / OFFS_UNIT_30_US);
+		aux->offs_units = 1U;
+	} else {
+		aux->offs = offs;
+		aux->offs_units = 0U;
+	}
+	aux->chan_idx = chan_idx;
+	aux->ca = 0;
+	aux->phy = find_lsb_set(phy) - 1;
+}
+#endif /* CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -146,7 +146,7 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 
 	conn_interval_us = (uint32_t)lll_conn->interval * CONN_INT_UNIT_US;
 	conn_offset_us = radio_tmr_end_get() + EVENT_IFS_US +
-			 PKT_AC_US(sizeof(struct pdu_adv_connect_ind), 0,
+			 PKT_AC_US(sizeof(struct pdu_adv_connect_ind),
 				   phy == PHY_LEGACY ? PHY_1M : phy);
 
 	/* Add transmitWindowDelay to default calculated connection offset:

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -434,11 +434,9 @@ static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
 		ull = HDR_LLL2ULL(lll_scan);
 		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(ull->ticks_slot) -
 				  EVENT_IFS_US -
-				  PKT_AC_US(aux_connect_req_len, 0,
-					    lll->phy) -
+				  PKT_AC_US(aux_connect_req_len, lll->phy) -
 				  EVENT_IFS_US -
-				  PKT_AC_US(aux_connect_rsp_len, 0,
-					    lll->phy) -
+				  PKT_AC_US(aux_connect_rsp_len, lll->phy) -
 				  EVENT_OVERHEAD_START_US -
 				  EVENT_TICKER_RES_MARGIN_US)) {
 			return -ETIME;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -160,7 +160,7 @@
 
 #define PKT_US(octets, phy) PKT_DC_US((octets), (PDU_MIC_SIZE), (phy))
 
-#define PKT_AC_US(octets, mic, phy) PKT_DC_US((octets), (mic), (phy))
+#define PKT_AC_US(octets, phy) PKT_DC_US((octets), 0, (phy))
 
 #define PKT_BIS_US(octets, mic, phy) PKT_DC_US((octets), (mic), (phy))
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -110,14 +110,35 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 /* helper function to release periodic advertising instance */
 void ull_adv_sync_release(struct ll_adv_sync_set *sync);
 
+/* helper function to allocate new PDU data for AUX_SYNC_IND and return
+ * previous and new PDU for further processing.
+ */
+uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
+			       uint16_t hdr_add_fields,
+			       uint16_t hdr_rem_fields,
+			       struct adv_pdu_field_data *data,
+			       struct pdu_adv **ter_pdu_prev,
+			       struct pdu_adv **ter_pdu_new,
+			       void **extra_data_prev,
+			       void **extra_data_new,
+			       uint8_t *ter_idx);
+
 /* helper function to set/clear common extended header format fields
  * for AUX_SYNC_IND PDU.
  */
-uint8_t ull_adv_sync_pdu_set_clear(struct ll_adv_set *adv,
+uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
+				   struct pdu_adv *ter_pdu_prev,
+				   struct pdu_adv *ter_pdu,
 				   uint16_t hdr_add_fields,
 				   uint16_t hdr_rem_fields,
-				   struct adv_pdu_field_data *data,
-				   uint8_t *ter_idx);
+				   struct adv_pdu_field_data *data);
+
+/* helper function to update extra_data field */
+void ull_adv_sync_extra_data_set_clear(void *extra_data_prev,
+				       void *extra_data_new,
+				       uint16_t hdr_add_fields,
+				       uint16_t hdr_rem_fields,
+				       void *data);
 
 /* helper function to calculate common ext adv payload header length and
  * adjust the data pointer.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -47,9 +47,12 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 
 #define ULL_ADV_PDU_HDR_FIELD_ADVA      BIT(0)
+#define ULL_ADV_PDU_HDR_FIELD_TARGETA   BIT(1)
 #define ULL_ADV_PDU_HDR_FIELD_CTE_INFO  BIT(2)
+#define ULL_ADV_PDU_HDR_FIELD_ADI       BIT(3)
 #define ULL_ADV_PDU_HDR_FIELD_AUX_PTR   BIT(4)
 #define ULL_ADV_PDU_HDR_FIELD_SYNC_INFO BIT(5)
+#define ULL_ADV_PDU_HDR_FIELD_TX_POWER  BIT(7)
 #define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(8)
 
 /* Helper type to store data for extended advertising

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -267,6 +267,28 @@ static uint8_t adv_sync_pdu_ad_data_set(struct pdu_adv *pdu,
 	return 0;
 }
 
+static uint8_t adv_sync_pdu_cte_info_set(struct pdu_adv *pdu,
+					 const struct pdu_cte_info *cte_info)
+{
+	struct pdu_adv_com_ext_adv *com_hdr;
+	struct pdu_adv_ext_hdr *ext_hdr;
+	uint8_t *dptr;
+
+	com_hdr = &pdu->adv_ext_ind;
+	ext_hdr = &com_hdr->ext_hdr;
+	dptr = ext_hdr->data;
+
+	/* Periodic adv PDUs do not have AdvA/TargetA */
+	LL_ASSERT(!ext_hdr->adv_addr);
+	LL_ASSERT(!ext_hdr->tgt_addr);
+
+	if (ext_hdr->cte_info) {
+		memcpy(dptr, cte_info, sizeof(*cte_info));
+	}
+
+	return 0;
+}
+
 static struct pdu_adv *adv_sync_pdu_duplicate_chain(struct pdu_adv *pdu)
 {
 	struct pdu_adv *pdu_dup = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -256,6 +256,8 @@ uint8_t ll_df_set_cl_cte_tx_params(uint8_t adv_handle, uint8_t cte_len,
  */
 uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 {
+	void *extra_data_prev, *extra_data;
+	struct pdu_adv *pdu_prev, *pdu;
 	struct lll_adv_sync *lll_sync;
 	struct lll_df_adv_cfg *df_cfg;
 	struct ll_adv_sync_set *sync;
@@ -295,9 +297,25 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		err = ull_adv_sync_pdu_set_clear(adv, 0,
+		err = ull_adv_sync_pdu_alloc(adv, 0,
+					     ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
+					     NULL, &pdu_prev, &pdu,
+					     &extra_data_prev, &extra_data,
+					     &ter_idx);
+		if (err) {
+			return err;
+		}
+
+		if (extra_data) {
+			ull_adv_sync_extra_data_set_clear(extra_data_prev,
+							  extra_data, 0,
+							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
+							  NULL);
+		}
+
+		err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu, 0,
 						 ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-						 NULL, &ter_idx);
+						 NULL);
 		if (err) {
 			return err;
 		}
@@ -326,9 +344,26 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		cte_info.time = df_cfg->cte_length;
 		pdu_data.field_data = (uint8_t *)&cte_info;
 		pdu_data.extra_data = df_cfg;
-		err = ull_adv_sync_pdu_set_clear(adv,
+
+		err = ull_adv_sync_pdu_alloc(adv, 0,
+					     ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
+					     NULL, &pdu_prev, &pdu,
+					     &extra_data_prev, &extra_data,
+					     &ter_idx);
+		if (err) {
+			return err;
+		}
+
+		if (extra_data) {
+			ull_adv_sync_extra_data_set_clear(extra_data_prev,
+							  extra_data,
+							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
+							  0, &pdu_data);
+		}
+
+		err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu,
 						 ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-						 0, &pdu_data, &ter_idx);
+						 0, &pdu_data);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -11,6 +11,7 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+#include "util/mem.h"
 #include "util/mayfly.h"
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -269,7 +269,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	lll->chan = aux_ptr->chan_idx;
 	lll->phy = BIT(aux_ptr->phy);
 
-	aux_offset_us = ftr->radio_end_us - PKT_AC_US(pdu->len, 0, phy);
+	aux_offset_us = ftr->radio_end_us - PKT_AC_US(pdu->len, phy);
 	if (aux_ptr->offs_units) {
 		lll->window_size_us = 300U;
 	} else {
@@ -302,7 +302,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
 				       PKT_AC_US(PDU_AC_EXT_PAYLOAD_SIZE_MAX,
-						 0, lll->phy) +
+						 lll->phy) +
 				       EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(aux->ull.ticks_active_to_start,

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -11,6 +11,7 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+#include "util/mem.h"
 #include "util/mayfly.h"
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -438,7 +438,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	sync_offset_us += (uint32_t)si->offs * lll->window_size_event_us;
 	/* offs_adjust may be 1 only if sync setup by LL_PERIODIC_SYNC_IND */
 	sync_offset_us += (si->offs_adjust ? OFFS_ADJUST_US : 0U);
-	sync_offset_us -= PKT_AC_US(pdu->len, 0, lll->phy);
+	sync_offset_us -= PKT_AC_US(pdu->len, lll->phy);
 	sync_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	sync_offset_us -= EVENT_JITTER_US;
 	sync_offset_us -= ready_delay_us;
@@ -455,7 +455,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
 				       PKT_AC_US(PDU_AC_EXT_PAYLOAD_SIZE_MAX,
-						 0, lll->phy) +
+						 lll->phy) +
 				       EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,


### PR DESCRIPTION
This adds initial support for chaining in periodic advertising, i.e. we can send AUX_SYNC_IND followed by sequence of AUX_CHAIN_IND.

New set of APIs to manage chains instead of single PDUs in advertising set is described in relevant commit. AUX_CHAIN_IND packets are not scheduled as they should be, instead they are just sent one after another at constant offset (T_MAFS) on best effort basis since there's no reservation done for complete train. There's no code that can do fragmentation of data coming from host so I added a temporary commit which will add single chain whenever periodic advertising data is changed on a set.