### PR TITLE
shield: cmake: using Kconfig.shield instead of looking for overlay files

### DIFF
--- a/boards/shields/boostxl_ulpsense/Kconfig.shield
+++ b/boards/shields/boostxl_ulpsense/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_BOOSTXL_ULPSENSE
+	def_bool $(shields_list_contains,boostxl_ulpsense)


### PR DESCRIPTION
Fixes: #26522
    
Now searching for Kconfig.shield instead of recursively looking for
overlay files.
    
Globbing recursively for overlay files also picks up board overlays,
which leads to errors in the shield handling, as user could wrongly
specify certain boards as shields.
Also it led to wrongly list some board as shields, as reported
in #26522.
    
The folder containing a Kconfig.shield is then used when looking up
overlay files, as all overlay files in that folder represents a shield.
    
Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
