### PR TITLE
samples: sht3xd: fix unchecked failure mode

### DIFF
--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -51,6 +51,10 @@ void main(void)
 	if (rc == 0) {
 		rc = sensor_trigger_set(dev, &trig, trigger_handler);
 	}
+	if (rc != 0) {
+		printf("SHT3XD: trigger config failed: %d\n", rc);
+		return;
+	}
 	printf("Alert outside %d..%d %%RH got %d\n", lo_thr.val1,
 	       hi_thr.val1, rc);
 #endif


### PR DESCRIPTION
Failure to configure the trigger should cause the application to fail.

Fixes #30189

Supersedes #30718