### PR TITLE
drivers: can: Fix building with socket_can_generic.h

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -303,6 +303,8 @@ DEVICE_DEFINE(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
 
 #include "socket_can_generic.h"
 
+static struct socket_can_context socket_can_context_1;
+
 static int socket_can_init_1(const struct device *dev)
 {
 	const struct device *can_dev = DEVICE_GET(can_loopback_1);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -977,6 +977,8 @@ DEVICE_DT_INST_DEFINE(0, &mcp2515_init, device_pm_control_nop,
 
 #include "socket_can_generic.h"
 
+static struct socket_can_context socket_can_context_1;
+
 static int socket_can_init(const struct device *dev)
 {
 	const struct device *can_dev = DEVICE_DT_INST_GET(1);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -820,11 +820,12 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 DT_INST_FOREACH_STATUS_OKAY(FLEXCAN_DEVICE_INIT_MCUX)
 
 #if defined(CONFIG_NET_SOCKETS_CAN)
-#include "socket_can_generic.h"						\
+#include "socket_can_generic.h"
 #define FLEXCAN_DEVICE_SOCKET_CAN(id)					\
+	static struct socket_can_context socket_can_context_##id;	\
 	static int socket_can_init_##id(const struct device *dev)	\
 	{								\
-		struct device *can_dev = DEVICE_DT_INST_GET(id);	\
+		const struct device *can_dev = DEVICE_DT_INST_GET(id);	\
 		struct socket_can_context *socket_context = dev->data;	\
 		LOG_DBG("Init socket CAN device %p (%s) for dev %p (%s)", \
 			dev, dev->name, can_dev, can_dev->name);	\

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1190,6 +1190,8 @@ static void config_can_1_irq(CAN_TypeDef *can)
 
 #include "socket_can_generic.h"
 
+static struct socket_can_context socket_can_context_1;
+
 static int socket_can_init_1(const struct device *dev)
 {
 	const struct device *can_dev = DEVICE_DT_GET(DT_NODELABEL(can1));
@@ -1279,6 +1281,8 @@ static void config_can_2_irq(CAN_TypeDef *can)
 #if defined(CONFIG_NET_SOCKETS_CAN)
 
 #include "socket_can_generic.h"
+
+static struct socket_can_context socket_can_context_2;
 
 static int socket_can_init_2(const struct device *dev)
 {

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -13,7 +13,9 @@
 #ifndef ZEPHYR_DRIVERS_CAN_SOCKET_CAN_GENERIC_H_
 #define ZEPHYR_DRIVERS_CAN_SOCKET_CAN_GENERIC_H_
 
+#define SOCKET_CAN_NAME_0 "SOCKET_CAN_0"
 #define SOCKET_CAN_NAME_1 "SOCKET_CAN_1"
+#define SOCKET_CAN_NAME_2 "SOCKET_CAN_2"
 #define SEND_TIMEOUT K_MSEC(100)
 #define RX_THREAD_STACK_SIZE 512
 #define RX_THREAD_PRIORITY 2
@@ -116,8 +118,6 @@ static struct canbus_api socket_can_api = {
 	.close = socket_can_close,
 	.setsockopt = socket_can_setsockopt,
 };
-
-static struct socket_can_context socket_can_context_1;
 
 static inline void rx_thread(void *ctx, void *unused1, void *unused2)
 {

--- a/samples/net/sockets/can/sample.yaml
+++ b/samples/net/sockets/can/sample.yaml
@@ -2,7 +2,6 @@ common:
   tags: net socket can CAN
   depends_on: can
   harness: can
-  platform_allow: stm32f072b_disco nucleo_l432kc
 sample:
   description: Test BSD sockets CAN support
   name: Socket CAN example


### PR DESCRIPTION
socket_can_generic.h makes some assumptions that are not always valid
for various drivers with regards to numbering.  To clean this up we
add defines for SOCKET_CAN_NAME_0 and SOCKET_CAN_NAME_2 in addition to
SOCKET_CAN_NAME_1.

We also move struct socket_can_context into the drivers themselves
since they know best how many CAN interfaces are getting supported and
what naming/number convention they'd have.

Additionally, this also exposes a few other build issues with the
can_mcux_flexcan driver that get fixed.

Finally, we remove the platform_allow from samples/net/sockets/can
since it is no longer needed.

Fixes #31733

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>