### PR TITLE
boards: hifive1: remove incorrect alias for GPIO use of LEDs

### DIFF
--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -9,13 +9,9 @@
 	model = "SiFive HiFive 1";
 	compatible = "sifive,hifive1";
 	aliases {
-		led0 = &led0;
-		led1 = &led1;
-		led2 = &led2;
 		pwm-led0 = &led0;
 		pwm-led1 = &led1;
 		pwm-led2 = &led2;
-
 	};
 
 	chosen {


### PR DESCRIPTION
The devicetree for this board only provides PWM-compatible LEDs.  Remove the aliases that suggest it supports GPIO-compatible LEDs.

Fixes #30315 by producing:

```
/mnt/nordic/zp/zephyr/samples/basic/blinky/src/main.c:24:2: error: #error "Unsupported board: led0 devicetree alias is not defined"
   24 | #error "Unsupported board: led0 devicetree alias is not defined"
      |  ^~~~~
````