### PR TITLE
cmake: show memory usage on zephyr.elf always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,7 +1086,7 @@ if(NOT CONFIG_BUILD_NO_GAP_FILL)
 endif()
 
 if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
-  target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} $<TARGET_PROPERTY:linker,memusage>)
+  target_link_libraries(${logical_target_for_zephyr_elf} $<TARGET_PROPERTY:linker,memusage>)
 
   get_property(memusage_build_command TARGET bintools PROPERTY memusage_command)
   if(memusage_build_command)


### PR DESCRIPTION
Fixes: #30591

Now using the `logical_target_for_zephyr_elf` variable for memusage
report.

The `logical_target_for_zephyr_elf` variable will point to the final
elf when two stage linking is done.

On single stage linking the prebuilt target == final elf, in which case
the `logical_target_for_zephyr_elf` points directly to the prebuilt
target.

Thus using `logical_target_for_zephyr_elf` for memusage report ensures
the correct elf file is always used for the memory usage report.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>