### PR TITLE
Revert "tests: context: disable if DEMAND_PAGING"

### DIFF
--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,5 +1,3 @@
 tests:
-  kernel.context:
+  kernel.common:
     tags: kernel
-    # Bug is #31333
-    filter: not CONFIG_DEMAND_PAGING


### PR DESCRIPTION
This reverts commit 79d73063af81c2f3e89d1a846a56c0360e0d285b.
The issue #31333 is fixed so this can be reverted to
enable tests/kernel/context to run with demand paging enabled.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>