### PR TITLE
Timeslice fixups

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -134,7 +134,8 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 			 */
 			int32_t next_time = next_timeout();
 
-			if (_current_cpu->slice_ticks != next_time) {
+			if (next_time == 0 ||
+			    _current_cpu->slice_ticks != next_time) {
 				z_clock_set_timeout(next_time, false);
 			}
 #else

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -215,7 +215,7 @@ void z_set_timeout_expiry(int32_t ticks, bool is_idle)
 	LOCKED(&timeout_lock) {
 		int next_to = next_timeout();
 		bool sooner = (next_to == K_TICKS_FOREVER)
-			      || (ticks < next_to);
+			      || (ticks <= next_to);
 		bool imminent = next_to <= 1;
 
 		/* Only set new timeouts when they are sooner than


### PR DESCRIPTION
Fix an edge case that snuck in with the recent fix: if timeslicing is
enabled, the CPU's slice_ticks will be zero, and thus match a timeout
object's dticks value of zero, and thus get suppressed (because "we
already have a timeout scheduled for that") incorrectly.

Fixes #31789

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>