### PR TITLE
twister: check if output is connected to tty before 'stty sane' call

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -564,8 +564,9 @@ class BinaryHandler(Handler):
 
         # FIXME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.
+        if sys.stdout.isatty():
+            subprocess.call(["stty", "sane"])
 
-        subprocess.call(["stty", "sane"])
         self.instance.results = harness.tests
 
         if not self.terminated and self.returncode != 0:
@@ -1063,7 +1064,8 @@ class QEMUHandler(Handler):
         self.thread.daemon = True
         logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
         self.thread.start()
-        subprocess.call(["stty", "sane"])
+        if sys.stdout.isatty():
+            subprocess.call(["stty", "sane"])
 
         logger.debug("Running %s (%s)" % (self.name, self.type_str))
         command = [self.generator_cmd]


### PR DESCRIPTION
As of today we unconditionally call `stty sane` that leads to lots of error messages `stty: standard input: Inappropriate ioctl for device` when output isn't connected to tty (for example when we launch twister in Jenkins)

Fix that by check if output is really connected to tty before `stty sane` call.

Fixes #19739