### PR TITLE
kernel: fix usage of KERNEL_COHERENCE macro

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -127,7 +127,7 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 
 #ifdef CONFIG_SPIN_VALIDATE
 	__ASSERT(z_spin_lock_valid(l), "Recursive spinlock %p", l);
-# ifdef KERNEL_COHERENCE
+# ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(z_spin_lock_mem_coherent(l));
 # endif
 #endif

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -66,6 +66,11 @@ bool z_spin_lock_valid(struct k_spinlock *l);
 bool z_spin_unlock_valid(struct k_spinlock *l);
 void z_spin_lock_set_owner(struct k_spinlock *l);
 BUILD_ASSERT(CONFIG_MP_NUM_CPUS <= 4, "Too many CPUs for mask");
+
+# ifdef CONFIG_KERNEL_COHERENCE
+bool z_spin_lock_mem_coherent(struct k_spinlock *l);
+# endif /* CONFIG_KERNEL_COHERENCE */
+
 #endif /* CONFIG_SPIN_VALIDATE */
 
 /**
@@ -123,7 +128,7 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 #ifdef CONFIG_SPIN_VALIDATE
 	__ASSERT(z_spin_lock_valid(l), "Recursive spinlock %p", l);
 # ifdef KERNEL_COHERENCE
-	__ASSERT_NO_MSG(arch_mem_coherent(l));
+	__ASSERT_NO_MSG(z_spin_lock_mem_coherent(l));
 # endif
 #endif
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -166,7 +166,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_init_static_threads();
 
 #ifdef KERNEL_COHERENCE
-	__ASSERT_NO_MSG(arch_mem_coherent(_kernel));
+	__ASSERT_NO_MSG(arch_mem_coherent(&_kernel));
 #endif
 
 #ifdef CONFIG_SMP

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -165,7 +165,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 	z_init_static_threads();
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(&_kernel));
 #endif
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -413,7 +413,7 @@ static void update_cache(int preempt_ok)
 
 static void ready_thread(struct k_thread *thread)
 {
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(thread));
 #endif
 
@@ -673,7 +673,7 @@ static void add_thread_timeout(struct k_thread *thread, k_timeout_t timeout)
 static void pend(struct k_thread *thread, _wait_q_t *wait_q,
 		 k_timeout_t timeout)
 {
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(wait_q));
 #endif
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -567,7 +567,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	z_init_thread_base(&new_thread->base, prio, _THREAD_PRESTART, options);
 	stack_ptr = setup_thread_stack(new_thread, stack, stack_size);
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	/* Check that the thread object is safe, but that the stack is
 	 * still cached!
 	 */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -883,6 +883,14 @@ void z_spin_lock_set_owner(struct k_spinlock *l)
 {
 	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
 }
+
+#ifdef CONFIG_KERNEL_COHERENCE
+bool z_spin_lock_mem_coherent(struct k_spinlock *l)
+{
+	return arch_mem_coherent((void *)l);
+}
+#endif /* CONFIG_KERNEL_COHERENCE */
+
 #endif /* CONFIG_SPIN_VALIDATE */
 
 int z_impl_k_float_disable(struct k_thread *thread)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -91,7 +91,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 		return;
 	}
 
-#ifdef KERNEL_COHERENCE
+#ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(to));
 #endif
 


### PR DESCRIPTION
This is another attempt to fix the `KERNEL_COHERENCE` macro.

Fixes #30380 and the issue discovered in #30502.