### PR TITLE
arch: riscv: add common stub reboot function

### DIFF
--- a/arch/riscv/core/CMakeLists.txt
+++ b/arch/riscv/core/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_library_sources(
   irq_manage.c
   isr.S
   prep_c.c
+  reboot.c
   reset.S
   swap.S
   thread.c

--- a/arch/riscv/core/reboot.c
+++ b/arch/riscv/core/reboot.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Katsuhiro Suzuki
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief RISC-V reboot interface
+ */
+
+#include <kernel.h>
+#include <arch/cpu.h>
+#include <sys/util.h>
+
+/**
+ * @brief Reset the system
+ *
+ * This is stub function to avoid build error with CONFIG_REBOOT=y
+ * RISC-V specification does not have a common interface for system reset.
+ * Each RISC-V SoC that has reset feature should implement own reset function.
+ *
+ * @return N/A
+ */
+
+void __weak sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+}

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -10,11 +10,6 @@
 #include <init.h>
 #include <soc.h>
 
-void sys_arch_reboot(int type)
-{
-	ARG_UNUSED(type);
-}
-
 static int ite_it8xxx2_init(const struct device *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
This patch adds weak sys_arch_reboot() function to avoid build error
with CONFIG_REBOOT=y. Some SoC has already had own reboot function
but others (Ex. qemu boards) faced buld error.

- openisa_rv32m1: Not change
- riscv-ite: Do nothing, remove and use arch/riscv function