### PR TITLE
board: cavs15: Add a option to control signing ways

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
+++ b/boards/xtensa/intel_adsp_cavs15/tools/flash.sh
@@ -13,7 +13,7 @@ if [ -z "$2" ]
 elif [ -n "$3" ] && [ -n "$4" ]
   then
     echo "Signing with key " $key
-    west sign -d ${BUILD} -t rimage -p $4 -D $3 -- -k $2
+    west sign -d ${BUILD} -t rimage -p $4 -D $3 -- -k $2 --no-manifest
 fi
 echo ${FLASHER} -f ${FIRMWARE}
 ${FLASHER} -f ${FIRMWARE} || /bin/true  2>&1

--- a/boards/xtensa/intel_adsp_cavs15/tools/lib/stream_desc.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/lib/stream_desc.py
@@ -38,7 +38,7 @@ class DmaBuf:
             raise ValueError("Not enough buffer. allocated: %d requested: %d"
                              % (self.alloc_size, size))
         logging.debug("Copying Data to DMA buffer")
-        self.buf[:] = data[:]
+        self.buf[:size] = data[:size]
 
     def free(self):
         if self.mem:

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -453,6 +453,11 @@ class RimageSigner(Signer):
             conf_path_cmd = ['-c', conf_path]
         else:
             log.die('Configuration not found')
+        if '--no-manifest' in args.tool_args:
+            no_manifest = True
+            args.tool_args.remove('--no-manifest')
+        else:
+            no_manifest = False
 
         sign_base = ([tool_path] + args.tool_args +
                      ['-o', out_bin] +  conf_path_cmd + ['-i', '3', '-e'] +
@@ -462,7 +467,10 @@ class RimageSigner(Signer):
             log.inf(quote_sh_list(sign_base))
         subprocess.check_call(sign_base)
 
-        filenames = [out_xman, out_bin]
+        if no_manifest:
+            filenames = [out_bin]
+        else:
+            filenames = [out_xman, out_bin]
         with open(out_tmp, 'wb') as outfile:
             for fname in filenames:
                 with open(fname, 'rb') as infile:


### PR DESCRIPTION
Fixed [#31819](https://github.com/zephyrproject-rtos/zephyr/issues/31819)

Zephyr testcases(not SOF case) not use kernel DSP driver to load image
on ADSP board, thus do not need signing with xman. So add a 'no-manifest'
to specify signing without xman in image. If use DSP driver load image,
we should not specify.
And fixed a syntax error in script when download firmware. When copy the data to buffer, the old script can not assign sequence of same size, so specify size.

Signed-off-by: Jian Kang <jianx.kang@intel.com>