### PR TITLE
driver: gpio: intc: npcx: disable WK_EN before configuring gpio interrupt.

### DIFF
--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -170,14 +170,11 @@ void npcx_miwu_irq_disable(const struct npcx_wui *wui)
 	NPCX_WKEN(base, wui->group) &= ~BIT(wui->bit);
 }
 
-unsigned int npcx_miwu_irq_get_state(const struct npcx_wui *wui)
+bool npcx_miwu_irq_get_state(const struct npcx_wui *wui)
 {
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
 
-	if (IS_BIT_SET(NPCX_WKEN(base, wui->group), wui->bit))
-		return 1;
-	else
-		return 0;
+	return IS_BIT_SET(NPCX_WKEN(base, wui->group), wui->bit);
 }
 
 int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
@@ -186,60 +183,58 @@ int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
 	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
 	uint8_t pmask = BIT(wui->bit);
 
-	if (mode == NPCX_MIWU_MODE_DISABLED) {
-		/* Clear MIWU enable bit */
-		NPCX_WKEN(base, wui->group) &= ~pmask;
-	} else {
-		/* Handle interrupt for level trigger */
-		if (mode == NPCX_MIWU_MODE_LEVEL) {
-			/* Set detection mode to level */
-			NPCX_WKMOD(base, wui->group) |= pmask;
-			switch (trig) {
-			/* Enable interrupting on level high */
-			case NPCX_MIWU_TRIG_HIGH:
-				NPCX_WKEDG(base, wui->group) &= ~pmask;
-				break;
-			/* Enable interrupting on level low */
-			case NPCX_MIWU_TRIG_LOW:
-				NPCX_WKEDG(base, wui->group) |= pmask;
-				break;
-			default:
-				return -EINVAL;
-			}
-		/* Handle interrupt for edge trigger */
-		} else {
-			/* Set detection mode to edge */
-			NPCX_WKMOD(base, wui->group) &= ~pmask;
-			switch (trig) {
-			/* Handle interrupting on falling edge */
-			case NPCX_MIWU_TRIG_LOW:
-				NPCX_WKAEDG(base, wui->group) &= ~pmask;
-				NPCX_WKEDG(base, wui->group) |= pmask;
-				break;
-			/* Handle interrupting on rising edge */
-			case NPCX_MIWU_TRIG_HIGH:
-				NPCX_WKAEDG(base, wui->group) &= ~pmask;
-				NPCX_WKEDG(base, wui->group) &= ~pmask;
-				break;
-			/* Handle interrupting on both edges */
-			case NPCX_MIWU_TRIG_BOTH:
-				/* Enable any edge */
-				NPCX_WKAEDG(base, wui->group) |= pmask;
-				break;
-			default:
-				return -EINVAL;
-			}
+	/* Disable interrupt of wake-up input source before configuring it */
+	npcx_miwu_irq_disable(wui);
+
+	/* Handle interrupt for level trigger */
+	if (mode == NPCX_MIWU_MODE_LEVEL) {
+		/* Set detection mode to level */
+		NPCX_WKMOD(base, wui->group) |= pmask;
+		switch (trig) {
+		/* Enable interrupting on level high */
+		case NPCX_MIWU_TRIG_HIGH:
+			NPCX_WKEDG(base, wui->group) &= ~pmask;
+			break;
+		/* Enable interrupting on level low */
+		case NPCX_MIWU_TRIG_LOW:
+			NPCX_WKEDG(base, wui->group) |= pmask;
+			break;
+		default:
+			return -EINVAL;
 		}
-
-		/* Enable wake-up input sources */
-		NPCX_WKINEN(base, wui->group) |= pmask;
-
-		/*
-		 * Clear pending bit since it might be set if WKINEN bit is
-		 * changed.
-		 */
-		NPCX_WKPCL(base, wui->group) |= pmask;
+	/* Handle interrupt for edge trigger */
+	} else {
+		/* Set detection mode to edge */
+		NPCX_WKMOD(base, wui->group) &= ~pmask;
+		switch (trig) {
+		/* Handle interrupting on falling edge */
+		case NPCX_MIWU_TRIG_LOW:
+			NPCX_WKAEDG(base, wui->group) &= ~pmask;
+			NPCX_WKEDG(base, wui->group) |= pmask;
+			break;
+		/* Handle interrupting on rising edge */
+		case NPCX_MIWU_TRIG_HIGH:
+			NPCX_WKAEDG(base, wui->group) &= ~pmask;
+			NPCX_WKEDG(base, wui->group) &= ~pmask;
+			break;
+		/* Handle interrupting on both edges */
+		case NPCX_MIWU_TRIG_BOTH:
+			/* Enable any edge */
+			NPCX_WKAEDG(base, wui->group) |= pmask;
+			break;
+		default:
+			return -EINVAL;
+		}
 	}
+
+	/* Enable wake-up input sources */
+	NPCX_WKINEN(base, wui->group) |= pmask;
+
+	/*
+	 * Clear pending bit since it might be set if WKINEN bit is
+	 * changed.
+	 */
+	NPCX_WKPCL(base, wui->group) |= pmask;
 
 	return 0;
 }
@@ -333,8 +328,8 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 									       \
 		/* Clear all MIWUs' pending and enable bits of MIWU device */  \
 		for (i = 0; i < NPCX_MIWU_GROUP_COUNT; i++) {                  \
-			NPCX_WKPCL(base, i) = 0xFF;                            \
 			NPCX_WKEN(base, i) = 0;                                \
+			NPCX_WKPCL(base, i) = 0xFF;                            \
 		}                                                              \
 									       \
 		/* Config IRQ and MWIU group directly */                       \

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -34,15 +34,12 @@ enum miwu_group {
 
 /* Interrupt modes supported by npcx miwu modules */
 enum miwu_int_mode {
-	NPCX_MIWU_MODE_DISABLED,
 	NPCX_MIWU_MODE_LEVEL,
 	NPCX_MIWU_MODE_EDGE,
 };
 
 /* Interrupt trigger modes supported by npcx miwu modules */
 enum miwu_int_trig {
-
-	NPCX_MIWU_TRIG_NONE, /** No trigger detection */
 	NPCX_MIWU_TRIG_LOW,  /** Edge failing or active low detection */
 	NPCX_MIWU_TRIG_HIGH, /** Edge rising or active high detection */
 	NPCX_MIWU_TRIG_BOTH, /** Both edge rising and failing detection */
@@ -140,7 +137,7 @@ void npcx_miwu_irq_disable(const struct npcx_wui *wui);
  *
  * @retval 0 if interrupt is disabled, otherwise interrupt is enabled
  */
-unsigned int npcx_miwu_irq_get_state(const struct npcx_wui *wui);
+bool npcx_miwu_irq_get_state(const struct npcx_wui *wui);
 
 /**
  * @brief Configure interrupt type of the wake-up input source


### PR DESCRIPTION
Although the default state of WK_EN is disabled, the users still have
the chance to configure them when WK_EN is enabled if the target gpio
has been configured and enabled before. This CL makes sure WK_EN is
disabled before the driver configures gpio interrupt in case of
unexpected side effects.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>