### PR TITLE
Run PSA tests with Zephyr+TFM

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -24,6 +24,9 @@ set(TFM_VALID_PARTITIONS
 # BINARY_DIR: The location where the build outputs will be written
 # BOARD: The string identifying the board target for TF-M (AN521, etc.)
 # CMAKE_BUILD_TYPE: The TF-M build type to use, (Debug, Release, etc.)
+# PSA_TEST_SUITE: A PSA test suite to add, choose one of
+#                 PROTECTED_STORAGE/INTERNAL_TRUSTED_STORAGE/STORAGE/CRYPTO/
+#                 INITIAL_ATTESTATION
 # IPC: Build TFM IPC library. This library allows a non-secure application to
 #      interface to secure domain using IPC.
 # ISOLATION_LEVEL: The TF-M isolation level to use
@@ -45,7 +48,7 @@ set(TFM_VALID_PARTITIONS
 function(trusted_firmware_build)
   set(options IPC REGRESSION BL2)
   set(oneValueArgs BINARY_DIR BOARD ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE
-    MCUBOOT_IMAGE_NUMBER)
+    MCUBOOT_IMAGE_NUMBER PSA_TEST_SUITE)
   set(multiValueArgs ENABLED_PARTITIONS)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -87,9 +90,25 @@ function(trusted_firmware_build)
     set(MCUBOOT_IMAGE_NUM_ARG -DMCUBOOT_IMAGE_NUMBER=${TFM_MCUBOOT_IMAGE_NUMBER})
   endif()
 
+  if(DEFINED TFM_PSA_TEST_SUITE)
+    set(PSA_TEST_ARG -DTEST_PSA_API=${TFM_PSA_TEST_SUITE})
+  endif()
+
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
   set(TFM_API_NS_PATH ${TFM_BINARY_DIR}/app/libtfm_api_ns.a)
   set(TFM_GENERATED_INCLUDES ${TFM_BINARY_DIR}/generated/interface/include)
+  set(PLATFORM_NS_FILE ${TFM_BINARY_DIR}/platform/libplatform_ns.a)
+
+  if (TFM_PSA_TEST_SUITE)
+    set(PSA_TEST_VAL_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/val/val_nspe.a)
+    set(PSA_TEST_PAL_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/platform/pal_nspe.a)
+    set(COMBINE_DIR_STORAGE storage)
+    set(COMBINE_DIR_PROTECTED_STORAGE storage)
+    set(COMBINE_DIR_INTERNAL_TRUSTED_STORAGE storage)
+    set(COMBINE_DIR_CRYPTO crypto)
+    set(COMBINE_DIR_INITIAL_ATTESTATION initial_attestation)
+    set(PSA_TEST_COMBINE_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/dev_apis/${COMBINE_DIR_${TFM_PSA_TEST_SUITE}}/test_combine.a)
+  endif()
 
   if(TFM_BL2)
     set(BL2_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2.bin)
@@ -107,6 +126,10 @@ function(trusted_firmware_build)
     ${VENEERS_FILE}
     ${TFM_API_NS_PATH}
     ${TFM_GENERATED_INCLUDES}/psa_manifest/sid.h
+    ${PSA_TEST_VAL_FILE}
+    ${PSA_TEST_PAL_FILE}
+    ${PSA_TEST_COMBINE_FILE}
+    ${PLATFORM_NS_FILE}
     ${BL2_BIN_FILE}
     ${BL2_HEX_FILE}
     ${TFM_S_BIN_FILE}
@@ -149,8 +172,10 @@ function(trusted_firmware_build)
                ${TFM_REGRESSION_ARG}
                ${TFM_PROFILE_ARG}
                ${MCUBOOT_IMAGE_NUM_ARG}
+               ${PSA_TEST_ARG}
                -DTFM_TEST_REPO_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/tf-m-tests
                -DMCUBOOT_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/../tfm-mcuboot
+               -DPSA_ARCH_TESTS_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/psa-arch-tests
                ${TFM_PARTITIONS_ARGS}
     BUILD_ALWAYS True
     USES_TERMINAL_BUILD True
@@ -183,6 +208,7 @@ function(trusted_firmware_build)
   add_library(tfm_api
     ${ZEPHYR_BASE}/modules/trusted-firmware-m/src/zephyr_tfm_log.c
   )
+  zephyr_sources_ifndef(CONFIG_TFM_PSA_TEST_NONE src/zephyr_tfm_psa_test.c)
 
   target_include_directories(tfm_api
     PRIVATE
@@ -197,6 +223,10 @@ function(trusted_firmware_build)
     PUBLIC
     zephyr_interface
     INTERFACE
+    ${PSA_TEST_VAL_FILE}
+    ${PSA_TEST_PAL_FILE}
+    ${PSA_TEST_COMBINE_FILE}
+    ${PLATFORM_NS_FILE}
     ${TFM_API_NS_PATH}
     ${VENEERS_FILE}
     $<TARGET_FILE:tfm_api>
@@ -224,6 +254,17 @@ if (CONFIG_BUILD_WITH_TFM)
   endif()
   if (CONFIG_TFM_PROFILE)
     set(TFM_PROFILE_ARG BUILD_PROFILE ${CONFIG_TFM_PROFILE})
+  endif()
+  if (CONFIG_TFM_PSA_TEST_CRYPTO)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE CRYPTO)
+  elseif (CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE PROTECTED_STORAGE)
+  elseif (CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE INTERNAL_TRUSTED_STORAGE)
+  elseif (CONFIG_TFM_PSA_TEST_STORAGE)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE STORAGE)
+  elseif (CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE INITIAL_ATTESTATION)
   endif()
   if (CONFIG_TFM_CMAKE_BUILD_TYPE_RELEASE)
     set(TFM_CMAKE_BUILD_TYPE "Release")
@@ -256,6 +297,7 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_IPC_ARG}
     ${TFM_REGRESSION_ARG}
     ENABLED_PARTITIONS ${TFM_ENABLED_PARTITIONS_ARG}
+    ${TFM_PSA_TEST_ARG}
     CMAKE_BUILD_TYPE ${TFM_CMAKE_BUILD_TYPE}
   )
 

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -235,6 +235,42 @@ config TFM_REGRESSION
 	  When enabled, this option signifies that the TF-M build includes
 	  the Secure and the Non-Secure regression tests.
 
+choice TFM_PSA_TEST
+	prompt "Enable a PSA test suite"
+	default TFM_PSA_TEST_NONE
+
+config TFM_PSA_TEST_CRYPTO
+	bool "Crypto tests"
+	depends on MAIN_STACK_SIZE >= 4096
+	help
+	  Enable the PSA Crypto test suite.
+
+config TFM_PSA_TEST_PROTECTED_STORAGE
+	bool "Storage tests"
+	help
+	  Enable the PSA Protected Storage test suite.
+
+config TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE
+	bool "Internal Trusted Storage tests"
+	help
+	  Enable the PSA Internal Trusted Storage test suite.
+
+config TFM_PSA_TEST_STORAGE
+	bool "Storage tests"
+	help
+	  Enable the PSA Storage test suite. This is a combination of the
+	  protected storage and internal trusted storage tests.
+
+config TFM_PSA_TEST_INITIAL_ATTESTATION
+	bool "Initial attestation tests"
+	depends on MAIN_STACK_SIZE >= 4096
+	help
+	  Enable the PSA Initial Attestation test suite.
+
+config TFM_PSA_TEST_NONE
+	bool "No PSA test suite"
+
+endchoice
 
 if TFM_BL2
 

--- a/modules/trusted-firmware-m/src/zephyr_tfm_psa_test.c
+++ b/modules/trusted-firmware-m/src/zephyr_tfm_psa_test.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+/**
+ * \brief This symbol is the entry point provided by the PSA API compliance
+ *        test libraries
+ */
+extern void val_entry(void);
+
+
+void psa_test(void)
+{
+	val_entry();
+}

--- a/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(tfm_psa_storage_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/tfm_integration/tfm_psa_test/README.rst
+++ b/samples/tfm_integration/tfm_psa_test/README.rst
@@ -1,0 +1,99 @@
+.. _tfm_psa_test:
+
+TF-M Platform Security Architecture Test Sample
+###############################################
+
+Overview
+********
+
+Run PSA test suites tests with Zephyr and TFM.
+
+The PSA tests are implemented in the psa-arch-tests repo: https://github.com/ARM-software/psa-arch-tests
+
+This sample is supported for platforms that have a port in psa-arch-tests.
+See sample.yaml for a list of supported platforms.
+
+Building and Running
+********************
+
+You must choose a suite via the CONFIG_TFM_PSA_TEST_* configs.
+
+On Target
+=========
+
+Refer to :ref:`tfm_ipc` for detailed instructions.
+
+On QEMU:
+========
+
+Refer to :ref:`tfm_ipc` for detailed instructions.
+Following is an example based on ``west build``
+
+   .. code-block:: bash
+
+      $ west build samples/tfm_integration/tfm_psa_test/ -p -b mps2_an521_nonsecure -t run -- -DCONFIG_TFM_PSA_TEST_STORAGE=y
+
+Sample Output
+=============
+
+   .. code-block:: console
+
+      *** Booting Zephyr OS build zephyr-v2.5.0-456-g06f4da459a99  ***
+
+      ***** PSA Architecture Test Suite - Version 1.0 *****
+
+      Running.. Storage Suite
+      ******************************************
+
+      TEST: 401 | DESCRIPTION: UID not found check
+      [Info] Executing tests from non-secure
+
+      [Info] Executing ITS tests
+      [Check 1] Call get API for UID 6 which is not set
+      [Check 2] Call get_info API for UID 6 which is not set
+      [Check 3] Call remove API for UID 6 which is not set
+      [Check 4] Call get API for UID 6 which is removed
+      [Check 5] Call get_info API for UID 6 which is removed
+      [Check 6] Call remove API for UID 6 which is removed
+      Set storage for UID 6
+      [Check 7] Call get API for different UID 5
+      [Check 8] Call get_info API for different UID 5
+      [Check 9] Call remove API for different UID 5
+
+      [Info] Executing PS tests
+      [Check 1] Call get API for UID 6 which is not set
+      [Check 2] Call get_info API for UID 6 which is not set
+      [Check 3] Call remove API for UID 6 which is not set
+      [Check 4] Call get API for UID 6 which is removed
+      [Check 5] Call get_info API for UID 6 which is removed
+      [Check 6] Call remove API for UID 6 which is removed
+      Set storage for UID 6
+      [Check 7] Call get API for different UID 5
+      [Check 8] Call get_info API for different UID 5
+      [Check 9] Call remove API for different UID 5
+
+      TEST RESULT: PASSED
+
+      ******************************************
+
+      [...]
+
+      TEST: 417 | DESCRIPTION: Storage assest capacity modification check
+      [Info] Executing tests from non-secure
+
+      [Info] Executing PS tests
+      Test Case skipped as Optional PS APIs not are supported.
+
+      TEST RESULT: SKIPPED (Skip Code=0x0000002B)
+
+      ******************************************
+
+      ************ Storage Suite Report **********
+      TOTAL TESTS     : 17
+      TOTAL PASSED    : 11
+      TOTAL SIM ERROR : 0
+      TOTAL FAILED    : 0
+      TOTAL SKIPPED   : 6
+      ******************************************
+
+      Entering standby..

--- a/samples/tfm_integration/tfm_psa_test/prj.conf
+++ b/samples/tfm_integration/tfm_psa_test/prj.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BUILD_WITH_TFM=y
+
+# Needed for CRYPTO and INITIAL_ATTESTATION
+CONFIG_MAIN_STACK_SIZE=4096

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -1,0 +1,19 @@
+common:
+    tags: tfm
+    platform_allow: mps2_an521_nonsecure v2m_musca_s1_nonsecure
+                    nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "\\*\\*\\*\\*\\* PSA Architecture Test Suite - Version .* \\*\\*\\*\\*\\*"
+        - "TOTAL FAILED *: 0"
+sample:
+  name: "TFM PSA Test"
+
+tests:
+  sample.tfm.psa_protected_storage_test:
+    extra_args: "CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y"
+    timeout: 100
+  sample.tfm.psa_internal_trusted_storage_test:
+    extra_args: "CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y"

--- a/samples/tfm_integration/tfm_psa_test/src/main.c
+++ b/samples/tfm_integration/tfm_psa_test/src/main.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+/* Run the PSA test suite */
+void psa_test(void);
+
+__attribute__((noreturn))
+void main(void)
+{
+#ifdef CONFIG_TFM_PSA_TEST_NONE
+	#error "No PSA test suite set. Use Kconfig to enable a test suite.\n"
+#else
+	psa_test();
+#endif
+
+	for (;;) {
+	}
+}

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
       revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 33216b0d61a6bc585a87e548c4a345d3fd0d2177
+      revision: 2c2aa3724a040233095a5c41ab79c8ad36134c8e
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
This PR concerns adding the support for running the PSA tests in Zephyr with TF-M as the the secure firmware.