### PR TITLE
logging: fix warnings when building with -Wunused-variable

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -775,6 +775,10 @@ static inline log_arg_t z_log_do_strdup(uint32_t msk, uint32_t idx,
 			param = (log_arg_t)log_strdup(str);
 		}
 	}
+#else
+	ARG_UNUSED(msk);
+	ARG_UNUSED(idx);
+	ARG_UNUSED(action);
 #endif
 	return param;
 }


### PR DESCRIPTION
Said warning comes when building with LOG_MODE_MINIMAL and
including logging/log.h. This commit adds ARG_UNUSED on
relevant variables.
