### PR TITLE
Bluetooth: Fix a comment typo for bt_l2cap_server.sec_level in l2cap.h

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -292,7 +292,7 @@ struct bt_l2cap_server {
 	 */
 	uint16_t			psm;
 
-	/** Required minimim security level */
+	/** Required minimum security level */
 	bt_security_t		sec_level;
 
 	/** @brief Server accept callback


### PR DESCRIPTION
Change "minimim" to "minimum" for for bt_l2cap_server.sec_level comments

Signed-off-by: Jingsai Lu <jingsai.lu@oss.nxp.com>