### PR TITLE
soc/riscv: support reboot for QEMU RISC-V VirtIO

### DIFF
--- a/soc/riscv/riscv-privilege/virt/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/virt/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources()
+zephyr_sources(soc.c)

--- a/soc/riscv/riscv-privilege/virt/soc.c
+++ b/soc/riscv/riscv-privilege/virt/soc.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Katsuhiro Suzuki
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief QEMU RISC-V virt machine hardware depended interface
+ */
+
+#include <kernel.h>
+#include <arch/cpu.h>
+#include <sys/util.h>
+
+/*
+ * Exit QEMU and tell error number.
+ *   Higher 16bits: indicates error number.
+ *   Lower 16bits : set FINISHER_FAIL
+ */
+#define FINISHER_FAIL		0x3333
+
+/* Exit QEMU successfully */
+#define FINISHER_EXIT		0x5555
+
+/* Reboot machine */
+#define FINISHER_REBOOT		0x7777
+
+void sys_arch_reboot(int type)
+{
+	volatile uint32_t *reg = (uint32_t *)SIFIVE_SYSCON_TEST;
+
+	*reg = FINISHER_REBOOT;
+
+	ARG_UNUSED(type);
+}

--- a/soc/riscv/riscv-privilege/virt/soc.h
+++ b/soc/riscv/riscv-privilege/virt/soc.h
@@ -10,6 +10,7 @@
 #include <soc_common.h>
 #include <devicetree.h>
 
+#define SIFIVE_SYSCON_TEST           0x00100000
 #define RISCV_MTIME_BASE             0x0200BFF8
 #define RISCV_MTIMECMP_BASE          0x02004000
 


### PR DESCRIPTION
This patch adds reboot function for QEMU RISC-V VirtIO board.

Fixes #31854