### PR TITLE
drivers: flash: stm32h7: fix int/long int warnings

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -102,8 +102,8 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	if (write) {
 		if ((offset % FLASH_NB_32BITWORD_IN_FLASHWORD * 4) != 0) {
 			LOG_ERR("Write offset not aligned on flashword length. "
-				"Offset: 0x%x, flashword length: %d",
-				offset, FLASH_NB_32BITWORD_IN_FLASHWORD * 4);
+				"Offset: 0x%lx, flashword length: %d",
+				(unsigned long) offset, FLASH_NB_32BITWORD_IN_FLASHWORD * 4);
 			return false;
 		}
 	}
@@ -221,7 +221,7 @@ static int erase_sector(const struct device *dev, int offset)
 
 	if (sector.bank == 0) {
 
-		LOG_ERR("Offset %d does not exist", offset);
+		LOG_ERR("Offset %ld does not exist", (long) offset);
 		return -EINVAL;
 	}
 
@@ -270,7 +270,7 @@ static int wait_write_queue(const struct device *dev, off_t offset)
 	struct flash_stm32_sector_t sector = get_sector(dev, offset);
 
 	if (sector.bank == 0) {
-		LOG_ERR("Offset %d does not exist", offset);
+		LOG_ERR("Offset %ld does not exist", (long) offset);
 		return -EINVAL;
 	}
 
@@ -296,7 +296,7 @@ static int write_ndwords(const struct device *dev,
 	struct flash_stm32_sector_t sector = get_sector(dev, offset);
 
 	if (sector.bank == 0) {
-		LOG_ERR("Offset %d does not exist", offset);
+		LOG_ERR("Offset %ld does not exist", (long) offset);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Changed lines were producing warnings. As elsewhere in this file, offset is type-casted (or not, depending on compiler) to long int, and then `%ld` is used in format string.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/31994