### PR TITLE
samples: driver: watchdog: rework how callback support is handled

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -27,6 +27,11 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_watchdog)
+/* Nordic supports a callback, but it has 61.2 us to complete before
+ * the reset occurs, which is too short for this sample to do anything
+ * useful.  Explicitly disallow use of the callback.
+ */
+#define WDT_ALLOW_CALLBACK 0
 #define WDT_NODE DT_INST(0, nordic_nrf_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_watchdog)
 #define WDT_NODE DT_INST(0, espressif_esp32_watchdog)
@@ -36,6 +41,10 @@
 #define WDT_NODE DT_INST(0, nxp_kinetis_wdog32)
 #elif DT_HAS_COMPAT_STATUS_OKAY(microchip_xec_watchdog)
 #define WDT_NODE DT_INST(0, microchip_xec_watchdog)
+#endif
+
+#ifndef WDT_ALLOW_CALLBACK
+#define WDT_ALLOW_CALLBACK 1
 #endif
 
 #ifndef WDT_MAX_WINDOW
@@ -52,6 +61,7 @@
 #error "Unsupported SoC and no watchdog0 alias in zephyr.dts"
 #endif
 
+#if WDT_ALLOW_CALLBACK
 static void wdt_callback(const struct device *wdt_dev, int channel_id)
 {
 	static bool handled_event;
@@ -65,13 +75,13 @@ static void wdt_callback(const struct device *wdt_dev, int channel_id)
 	printk("Handled things..ready to reset\n");
 	handled_event = true;
 }
+#endif /* WDT_ALLOW_CALLBACK */
 
 void main(void)
 {
 	int err;
 	int wdt_channel_id;
 	const struct device *wdt;
-	struct wdt_timeout_cfg wdt_config;
 
 	printk("Watchdog sample application\n");
 
@@ -81,19 +91,28 @@ void main(void)
 		return;
 	}
 
-	/* Reset SoC when watchdog timer expires. */
-	wdt_config.flags = WDT_FLAG_RESET_SOC;
+	struct wdt_timeout_cfg wdt_config = {
+		/* Reset SoC when watchdog timer expires. */
+		.flags = WDT_FLAG_RESET_SOC,
 
-	/* Expire watchdog after max window */
-	wdt_config.window.min = 0U;
-	wdt_config.window.max = WDT_MAX_WINDOW;
+		/* Expire watchdog after max window */
+		.window.min = 0U,
+		.window.max = WDT_MAX_WINDOW,
+	};
 
-	/* Set up watchdog callback. Jump into it when watchdog expired. */
+#if WDT_ALLOW_CALLBACK
+	/* Set up watchdog callback. */
 	wdt_config.callback = wdt_callback;
+
+	printk("Attempting to test pre-reset callback\n");
+#else /* WDT_ALLOW_CALLBACK */
+	printk("Callback in RESET_SOC disabled for this platform\n");
+#endif /* WDT_ALLOW_CALLBACK */
 
 	wdt_channel_id = wdt_install_timeout(wdt, &wdt_config);
 	if (wdt_channel_id == -ENOTSUP) {
 		/* IWDG driver for STM32 doesn't support callback */
+		printk("Callback support rejected, continuing anyway\n");
 		wdt_config.callback = NULL;
 		wdt_channel_id = wdt_install_timeout(wdt, &wdt_config);
 	}


### PR DESCRIPTION
Nordic watchdog does support a callback, but it has a time limit that is too tight for the way this sample uses it.  Add infrastructure to bypass using the callback in this sample.

Also add more diagnostics explaining the status of callback use in the sample.

Fixes #29991