### PR TITLE
scripts: kconfig: Fix uses of edt.compat2okay in helper functions

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -390,9 +390,10 @@ def dt_compat_on_bus(kconf, _, compat, bus):
     if doc_mode or edt is None:
         return "n"
 
-    for node in edt.compat2okay[compat]:
-        if node.on_bus is not None and node.on_bus == bus:
-            return "y"
+    if compat in edt.compat2okay:
+        for node in edt.compat2okay[compat]:
+            if node.on_bus is not None and node.on_bus == bus:
+                return "y"
 
     return "n"
 
@@ -406,9 +407,10 @@ def dt_nodelabel_has_compat(kconf, _, label, compat):
     if doc_mode or edt is None:
         return "n"
 
-    for node in edt.compat2okay[compat]:
-        if label in node.labels:
-            return "y"
+    if compat in edt.compat2okay:
+        for node in edt.compat2okay[compat]:
+            if label in node.labels:
+                return "y"
 
     return "n"
 


### PR DESCRIPTION
Check if a given 'compat' is a key in edt.compat2okay before accessing
its entry in dt_compat_on_bus() and dt_nodelabel_has_compat(), as for
a non-existing key a new entry with an empty list would be created,
and dt_compat_enabled() would then incorrectly return "y" when called
for the same 'compat'.

This issue currently causes CI for #31624 to [fail](https://buildkite.com/zephyr/zephyr/builds/19826) (`CONFIG_GPIO_PCAL6408A` gets incorrectly enabled [here](https://github.com/zephyrproject-rtos/zephyr/pull/31624/files#diff-1fcac8123369588d063e33e7d6d4c2d6c88ea878b8386c88e5e7a4a81e663193R11) because of [this check](https://github.com/zephyrproject-rtos/zephyr/pull/31624/files#diff-0291e0b6eb06c3f0ce15a9f3e3459596e772d479bb6340897a85ed876f75dbc6R45), and that results in the driver being compiled without any enabled instances of the corresponding hardware).