### PR TITLE
actions: compliance: Rebase before running `west update`

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -31,7 +31,15 @@ jobs:
         pip3 install west
 
     - name: west setup
+      env:
+        BASE_REF: ${{ github.base_ref }}
       run: |
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+        git remote -v
+        git rebase origin/${BASE_REF}
+        # debug
+        git log  --pretty=oneline | head -n 10
         west init -l . || true
         west update
 
@@ -42,10 +50,6 @@ jobs:
         BASE_REF: ${{ github.base_ref }}
       run: |
         export ZEPHYR_BASE=$PWD
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
-        git remote -v
-        git rebase origin/${BASE_REF}
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
Instead of rebasing just before running the compliance script, do so
before running `west update`, so that the main manifest, west.yml, is up
to date with the latest master before west inspects it.

Fixes #31327.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>