### PR TITLE
Tfm sample.yaml fixes

### DIFF
--- a/samples/tfm_integration/psa_level_1/sample.yaml
+++ b/samples/tfm_integration/psa_level_1/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: TF-M PSA Level 1 example
 tests:
     sample.psa_level_1:
-        tags: introduction
+        tags: introduction tfm
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
           nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns v2m_musca_s1_nonsecure
         harness: console

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: TF-M IPC example
 tests:
     sample.tfm_ipc:
-        tags: introduction
+        tags: introduction tfm
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340pdk_nrf5340_cpuappns
           nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns nucleo_l552ze_q_ns
           v2m_musca_s1_nonsecure

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -12,6 +12,7 @@ tests:
         harness_config:
           type: multi_line
           regex:
-            - "Booting TFM v1.0"
-            - "Booting Zephyr OS"
+            - "The version of the PSA Framework API is"
             - "Connect success!"
+            - "Call success!"
+            - "TF-M IPC on .*"


### PR DESCRIPTION
This cannot be run on HW with twister since it doesn't flash tfm, but it might work on qemu. We are also using it in nRF Connect SDK.