### PR TITLE
Bluetooth: samples: hci_uart: Add overlays for nRF5340

### DIFF
--- a/samples/bluetooth/hci_uart/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/bluetooth/hci_uart/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};


### PR DESCRIPTION
Add overlays for the current nRF5340 DK boards:

- nrf5340dk_nrf5340_cpuapp
- nrf5340dk_nrf5340_cpunet

Fixes #29440.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>