### PR TITLE
doc: gsg: Update Homebrew installation for macOS

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -100,7 +100,7 @@ Next, you'll install some host dependencies using your package manager.
 
          .. code-block:: bash
 
-            /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       #. Use ``brew`` to install dependencies:
 


### PR DESCRIPTION
Homebrew now uses bash instead of Ruby to install itself. Use the
recommended command instead of the old one.

Fixes #30037.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>