### PR TITLE
runners: pyocd: handle None in hex/bin files

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -128,9 +128,9 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             self.debug_debugserver(command, **kwargs)
 
     def flash(self, **kwargs):
-        if os.path.isfile(self.hex_name):
+        if self.hex_name is not None and os.path.isfile(self.hex_name):
             fname = self.hex_name
-        elif os.path.isfile(self.bin_name):
+        elif self.bin_name is not None and os.path.isfile(self.bin_name):
             self.logger.warning(
                 'hex file ({}) does not exist; falling back on .bin ({}). '.
                 format(self.hex_name, self.bin_name) +


### PR DESCRIPTION
Commit 3204554841db8e51fd (" scripts: runners: error on missing
non-elf outputs") created the possibility of None bin_file and
hex_file attributes in the RunnerConfig without updating pyocd
appropriately. Fix that.

Fixes: #31921
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>