### PR TITLE
doc: gsg: Document setting ZEPHYR_TOOLCHAIN_VARIANT for the SDK

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -318,6 +318,13 @@ to build Zephyr applications.
 
             You cannot move the SDK directory after you have installed it.
 
+      #. Set the required :ref:`environment variable <env_vars>`:
+
+         .. code-block:: bash
+
+            echo 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr' >> ~/.bashrc
+            source ~/.bashrc
+
       #. Install `udev <https://en.wikipedia.org/wiki/Udev>`_ rules, which
          allow you to flash most Zephyr boards as a regular user:
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -290,6 +290,9 @@ installed it.
    this allow Zephyr to pick the right toolchain, while allowing multiple Zephyr
    SDKs to be grouped together at a custom location.
 
+#. Set the required :ref:`environment variable <env_vars>`,
+   :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``.
+
 .. _sdkless_builds:
 
 Building on Linux without the Zephyr SDK


### PR DESCRIPTION
The getting started guide doesn't currently document that the
ZEPHYR_TOOLCHAIN_VARIANT env var needs to be set even in the case of
using the Zephyr SDK. Add mentions to it in both the short and long
guides.

Fixes #30713.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>