### PR TITLE
Bluetooth: controller: openisa: Fix build failures

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -40,6 +40,7 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_CTLR_XTAL_ADVANCED_SUPPORT
 	select BT_CTLR_SCHED_ADVANCED_SUPPORT
 	select BT_CTLR_TIFS_HW_SUPPORT
+	select BT_CTLR_ULL_LLL_PRIO_SUPPORT
 
 	default y
 	help
@@ -64,6 +65,9 @@ config BT_CTLR_SCHED_ADVANCED_SUPPORT
 	bool
 
 config BT_CTLR_TIFS_HW_SUPPORT
+	bool
+
+config BT_CTLR_ULL_LLL_PRIO_SUPPORT
 	bool
 
 config BT_CTLR_RX_PRIO_STACK_SIZE
@@ -274,7 +278,7 @@ config BT_CTLR_SCHED_ADVANCED
 	  leading to skipped events amongst active roles.
 
 config BT_CTLR_LLL_PRIO
-	int "Lower Link Layer (Radio) IRQ priority" if !BT_CTLR_ZLI
+	int "Lower Link Layer (Radio) IRQ priority" if (BT_CTLR_ULL_LLL_PRIO_SUPPORT && !BT_CTLR_ZLI)
 	range 0 3 if SOC_SERIES_NRF51X
 	range 0 6 if (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
 	default 0
@@ -282,17 +286,17 @@ config BT_CTLR_LLL_PRIO
 	  The interrupt priority for event preparation and radio IRQ.
 
 config BT_CTLR_ULL_HIGH_PRIO
-	int "Upper Link Layer High IRQ priority"
+	int "Upper Link Layer High IRQ priority" if BT_CTLR_ULL_LLL_PRIO_SUPPORT
 	range BT_CTLR_LLL_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_LLL_PRIO 6 if (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
-	default BT_CTLR_LLL_PRIO if (BT_CTLR_ZLI || BT_CTLR_LOW_LAT)
+	default BT_CTLR_LLL_PRIO if (!BT_CTLR_ULL_LLL_PRIO_SUPPORT || BT_CTLR_ZLI || BT_CTLR_LOW_LAT)
 	default 1
 	help
 	  The interrupt priority for Ticker's Worker IRQ and Upper Link Layer
 	  higher priority functions.
 
 config BT_CTLR_ULL_LOW_PRIO
-	int "Upper Link Layer Low IRQ priority"
+	int "Upper Link Layer Low IRQ priority" if BT_CTLR_ULL_LLL_PRIO_SUPPORT
 	range BT_CTLR_ULL_HIGH_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_ULL_HIGH_PRIO 6 if (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
 	default BT_CTLR_ULL_HIGH_PRIO

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -285,7 +285,7 @@ config BT_CTLR_ULL_HIGH_PRIO
 	int "Upper Link Layer High IRQ priority"
 	range BT_CTLR_LLL_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_LLL_PRIO 6 if (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
-	default BT_CTLR_LLL_PRIO if (BT_CTLR_ZLI || BT_CTLR_LOW_LAT_ULL)
+	default BT_CTLR_LLL_PRIO if (BT_CTLR_ZLI || BT_CTLR_LOW_LAT)
 	default 1
 	help
 	  The interrupt priority for Ticker's Worker IRQ and Upper Link Layer

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu.h
@@ -11,3 +11,12 @@ static inline void cpu_sleep(void)
 	/* __SEV(); */
 	__WFE();
 }
+
+static inline void cpu_dmb(void)
+{
+	/* FIXME: Add necessary host machine required Data Memory Barrier
+	 *        instruction alongwith the below defined compiler memory
+	 *        clobber.
+	 */
+	__asm__ volatile ("" : : : "memory");
+}

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -7,12 +7,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <zephyr/types.h>
+#include <toolchain.h>
+#include <soc.h>
+#include <bluetooth/hci.h>
 #include <sys/byteorder.h>
 
-#include <toolchain.h>
-#include <bluetooth/hci.h>
-
+#include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/ticker.h"
@@ -40,7 +40,6 @@
 
 #define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_adv
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);
@@ -212,14 +211,11 @@ struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx)
 		uint8_t first_latest;
 
 		pdu->last = first;
-		/* FIXME: Ensure that data is synchronized so that an ISR
+		/* NOTE: Ensure that data is synchronized so that an ISR
 		 *        vectored, after pdu->last has been updated, does
-		 *        access the latest value. __DMB() is used in ARM
-		 *        Cortex M4 architectures. Use appropriate
-		 *        instructions on other platforms.
-		 *
-		 *        cpu_dmb();
+		 *        access the latest value.
 		 */
+		cpu_dmb();
 		first_latest = pdu->first;
 		if (first_latest != first) {
 			last++;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -8,15 +8,16 @@
 #include <stddef.h>
 
 #include <toolchain.h>
-#include <zephyr/types.h>
+#include <soc.h>
 #include <sys/util.h>
+
+#include "hal/cpu.h"
+#include "hal/ccm.h"
+#include "hal/radio.h"
 
 #include "util/mem.h"
 #include "util/memq.h"
 #include "util/mfifo.h"
-
-#include "hal/ccm.h"
-#include "hal/radio.h"
 
 #include "pdu.h"
 
@@ -29,7 +30,6 @@
 
 #define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_conn
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);


### PR DESCRIPTION
Fix OpenISA port to include compiler memory barrier as in
commit 1a14f8b ("Bluetooth: controller: Use DMB instead
of DSB").

Relates to commit 1af2b91 ("Bluetooth: controller: Fix
Tx Buffer Overflow") and to commit ef2ece8 ("Bluetooth:
controller: openisa: Fix sanitycheck failures") and to
commit c2fc629 ("Bluetooth: controller: 255 byte AD
payload support").

Fix BT_CTLR_ULL_HIGH_PRIO default value to equal
BT_CTLR_LLL_PRIO value if BT_CTLR_LOW_LAT is enabled, else
default ULL_HIGH to lower IRQ priority level in comparison
to LLL IRQ priority level. If BT_CTLR_ZLI is enabled,
BT_CTLR_ULL_HIGH_PRIO can default to a priority level value
of 0 and still be lower priority level than the LLL which
is placed at Zero Latency IRQ priority level (highest
priority in the CPU).

Fix for OpenISA rv32m1_vega_ri5cy board not supporting
different IRQ Priority levels for LLL, ULL_HIGH and ULL_LOW
execution contexts.

Fixes #31937.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>