### PR TITLE
tests/sched/deadline: Fix precision rollover

### DIFF
--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -64,8 +64,17 @@ void test_deadline(void)
 		 * deadlines end up in the opposite order due to the
 		 * changing "now" between calls to
 		 * k_thread_deadline_set().
+		 *
+		 * Use only 30 bits of significant value.  The API
+		 * permits 31 (strictly: the deadline time of the
+		 * "first" runnable thread in any given priority and
+		 * the "last" must be less than 2^31), but because the
+		 * time between our generation here and the set of the
+		 * deadline below takes non-zero time, it's possible
+		 * to see rollovers.  Easier than using a modulus test
+		 * or whatnot to restrict the values.
 		 */
-		thread_deadlines[i] = sys_rand32_get() & 0x7fffff00;
+		thread_deadlines[i] = sys_rand32_get() & 0x3fffff00;
 	}
 
 	zassert_true(n_exec == 0, "threads ran too soon");


### PR DESCRIPTION
The deadline scheduler as of commit ef626571b2b8 got an optimization
that requires that the the cycle difference of the deadline time of
the "first" and "last" runnable thread never be higher than 2^31.

The test code here was masking off the bottom 31 bits of the generated
deadlines, so it looked OK.  But because the actual setting of the
deadline values takes time too, it was still possible to select values
that would roll over.  The window was VERY small, but the RNG on one
platform (up_squared) hit it.

Shrink the selected deadlines to live in a 30 bit space for safety.

Fixes #31508

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>