### PR TITLE
boards: nrf5340dk_nrf5340: add pre_dt_board.cmake

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This SoC has duplicate unit addresses for some peripherals, such as
+# KMU and NVMC.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
We need to turn off the unique_unit_address_if_enabled warning flag
for this SoC before we run dtc. The only place to do this is in the
board directory, unfortunately. This means all nRF5340 boards will
need this file to avoid invalid warnings at DT generation time.

Fixes: #29713
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>