### PR TITLE
remove usage of deprecated gccarmemb

### DIFF
--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -36,12 +36,6 @@ if(NOT ZEPHYR_TOOLCHAIN_VARIANT)
   endif()
 endif()
 
-# Until we completely deprecate it
-if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "gccarmemb")
-  message(WARNING "gccarmemb is deprecated, please use gnuarmemb instead")
-  set(ZEPHYR_TOOLCHAIN_VARIANT "gnuarmemb")
-endif()
-
 # Host-tools don't unconditionally set TOOLCHAIN_HOME anymore,
 # but in case Zephyr's SDK toolchain is used, set TOOLCHAIN_HOME
 if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "zephyr")

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2809,13 +2809,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
     @staticmethod
     def get_toolchain():
-        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None) or \
-                    os.environ.get("ZEPHYR_GCC_VARIANT", None)
-
-        if toolchain == "gccarmemb":
-            # Remove this translation when gccarmemb is no longer supported.
-            toolchain = "gnuarmemb"
-
+        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None)
         try:
             if not toolchain:
                 raise TwisterRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")


### PR DESCRIPTION
gccarmemb was deprecated 2 years ago, so remove it.