### PR TITLE
dts: nrf/stm32: supress duplicate unit-address warning

### DIFF
--- a/boards/arm/96b_stm32_sensor_mez/pre_dt_board.cmake
+++ b/boards/arm/96b_stm32_sensor_mez/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - /soc/i2s@40003800 & /soc/spi@40003800
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/actinius_icarus/pre_dt_board.cmake
+++ b/boards/arm/actinius_icarus/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/bl652_dvk/pre_dt_board.cmake
+++ b/boards/arm/bl652_dvk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - /soc/i2c@40003000 & /soc/spi@40003000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/bl654_dvk/pre_dt_board.cmake
+++ b/boards/arm/bl654_dvk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - /soc/i2c@40003000 & /soc/spi@40003000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/circuitdojo_feather_nrf9160/pre_dt_board.cmake
+++ b/boards/arm/circuitdojo_feather_nrf9160/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+# - /reserved-memory/image@20000000 & /reserved-memory/image_s@20000000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160_innblue21/pre_dt_board.cmake
+++ b/boards/arm/nrf9160_innblue21/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160_innblue22/pre_dt_board.cmake
+++ b/boards/arm/nrf9160_innblue22/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160dk_nrf9160/pre_dt_board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/serpente/pre_dt_board.cmake
+++ b/boards/arm/serpente/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - /soc/pinmux@41004400 & /soc/gpio@41004400
+# - /soc/pinmux@41004480 & /soc/gpio@41004480
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
A number of SoCs have overlapping devices at the same unit address.
Surpress the warning for those cases:

* NRF - kmu@39000 & flash-controller@39000
* NRF - clock@5000 & power@5000
* NRF - image@20000000 & image_s@20000000
* NRF - i2c@40003000 & spi@40003000
* STM - i2s@40003800 & spi@40003800

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>