### PR TITLE
dts: Rename compatible arm,arm-timer to arm,armv8-timer

### DIFF
--- a/boards/arm/xenvm/xenvm.dts
+++ b/boards/arm/xenvm/xenvm.dts
@@ -63,7 +63,7 @@
 	};
 
 	timer {
-		compatible = "arm,arm-timer";
+		compatible = "arm,armv8-timer";
 		interrupts = <GIC_PPI 0x0d IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY
 			      GIC_PPI 0x0e IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY
 			      GIC_PPI 0x0b IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;

--- a/dts/arm/broadcom/viper-a72.dtsi
+++ b/dts/arm/broadcom/viper-a72.dtsi
@@ -21,8 +21,8 @@
 		};
 	};
 
-	arch_timer: timer {
-		compatible = "arm,arm-timer";
+	timer {
+		compatible = "arm,armv8-timer";
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm/qemu-virt/qemu-virt-a53.dtsi
@@ -29,8 +29,8 @@
 		};
 	};
 
-	arch_timer: timer {
-		compatible = "arm,arm-timer";
+	timer {
+		compatible = "arm,armv8-timer";
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>,

--- a/dts/bindings/timer/arm,armv8-timer.yaml
+++ b/dts/bindings/timer/arm,armv8-timer.yaml
@@ -1,7 +1,7 @@
 description: >
     per-core ARM architected timer
 
-compatible: "arm,arm-timer"
+compatible: "arm,armv8-timer"
 
 include: base.yaml
 

--- a/include/drivers/timer/arm_arch_timer.h
+++ b/include/drivers/timer/arm_arch_timer.h
@@ -11,7 +11,7 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/types.h>
 
-#define ARM_TIMER_NODE DT_INST(0, arm_arm_timer)
+#define ARM_TIMER_NODE DT_INST(0, arm_armv8_timer)
 
 #define ARM_TIMER_SECURE_IRQ		DT_IRQ_BY_IDX(ARM_TIMER_NODE, 0, irq)
 #define ARM_TIMER_NON_SECURE_IRQ	DT_IRQ_BY_IDX(ARM_TIMER_NODE, 1, irq)


### PR DESCRIPTION
The compatible for the ARMv8 timer should have been arm,armv8-timer and
not arm,arm-timer.  The dts binding file name was correct, just the
compatible was wrong.  Rename dts, binding, and associated code to use
arm,armv8-timer.

Fixes #31946

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>