### PR TITLE
net/6lo: First buffer fragment should hold the full compressed header

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1348,6 +1348,11 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 			nhc_inline_size;
 	}
 
+	if (pkt->buffer->len < compressed_hdr_size) {
+		NET_ERR("Scattered compressed header?");
+		return false;
+	}
+
 	if (net_buf_tailroom(pkt->buffer) >= diff) {
 		NET_DBG("Enough tailroom. Uncompress inplace");
 		frag = pkt->buffer;


### PR DESCRIPTION
Current 6lo implementation is unable to deal with scattered headers
(which should not happen usually, though it's a valid use case), so
let's just fail uncompressing such packet then.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>