### PR TITLE
bluetooth: host: expand l2cap CID abbreviation

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -113,7 +113,7 @@ struct bt_l2cap_chan {
 
 /** @brief LE L2CAP Endpoint structure. */
 struct bt_l2cap_le_endpoint {
-	/** Endpoint CID */
+	/** Endpoint Channel Identifier (CID) */
 	uint16_t				cid;
 	/** Endpoint Maximum Transmission Unit */
 	uint16_t				mtu;
@@ -160,7 +160,7 @@ struct bt_l2cap_le_chan {
 
 /** @brief BREDR L2CAP Endpoint structure. */
 struct bt_l2cap_br_endpoint {
-	/** Endpoint CID */
+	/** Endpoint Channel Identifier (CID) */
 	uint16_t				cid;
 	/** Endpoint Maximum Transmission Unit */
 	uint16_t				mtu;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -326,7 +326,7 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 #endif
 
 	if (!ch) {
-		BT_ERR("Unable to allocate L2CAP CID");
+		BT_ERR("Unable to allocate L2CAP channel ID");
 		return false;
 	}
 
@@ -2292,7 +2292,7 @@ void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 
 	chan = bt_l2cap_le_lookup_rx_cid(conn, cid);
 	if (!chan) {
-		BT_WARN("Ignoring data for unknown CID 0x%04x", cid);
+		BT_WARN("Ignoring data for unknown channel ID 0x%04x", cid);
 		net_buf_unref(buf);
 		return;
 	}

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1489,7 +1489,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 
 	chan = bt_l2cap_br_lookup_rx_cid(conn, cid);
 	if (!chan) {
-		BT_WARN("Ignoring data for unknown CID 0x%04x", cid);
+		BT_WARN("Ignoring data for unknown channel ID 0x%04x", cid);
 		net_buf_unref(buf);
 		return;
 	}


### PR DESCRIPTION
Reduces some user confusion regarding whether it is related
to "Connection ID", "Channel ID", or "Company ID" for the
uninitiated.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>