### PR TITLE
arch: aarch64: Compile with -fPIC

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 if(CONFIG_ARM64)
   set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf64-littleaarch64)
+  zephyr_compile_options(-fPIC)
 
   add_subdirectory(core/aarch64)
 else()

--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -196,19 +196,19 @@ SECTIONS
     _image_rodata_size = _image_rodata_end - _image_rodata_start;
     _image_rom_end = .;
 
+    GROUP_END(ROMABLE_REGION)
+
     /*
      * These are here according to 'arm-zephyr-elf-ld --verbose',
      * before data section.
      */
-    /DISCARD/ :
+    SECTION_PROLOGUE(.got,,)
     {
         *(.got.plt)
         *(.igot.plt)
         *(.got)
         *(.igot)
     }
-
-    GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
 


### PR DESCRIPTION
As usual a bit of rationale.

This is a general fix to a very specific problem. The problem is described in #31952 and it is caused by the symbol:

https://github.com/zephyrproject-rtos/zephyr/blob/4d4a636555cdec8785652e016d974667be7c201b/kernel/include/mmu.h#L41

when compiling on very high SRAM addresses, for example `CONFIG_SRAM_BASE_ADDRESS=0x2000000000`

The obvious local fix in this case is just to use:

```
#define Z_KERNEL_VIRT_SIZE	((size_t)Z_KERNEL_VIRT_END - Z_KERNEL_VIRT_START) 
```
but doing so we are just hiding the real issue so here I propose a more general fix.