### PR TITLE
arch: aarch64: Set ARCH_MAPS_ALL_RAM

### DIFF
--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -100,6 +100,7 @@ config ARM_MMU
 	default y
 	select MMU
 	select SRAM_REGION_PERMISSIONS
+	select ARCH_MAPS_ALL_RAM
 	help
 	  Memory Management Unit support.
 


### PR DESCRIPTION
We are indeed mapping all RAM at boot, set the proper symbol.

See https://github.com/zephyrproject-rtos/zephyr/pull/31494#pullrequestreview-576715758

Signed-off-by: Carlo Caione <ccaione@baylibre.com>