### PR TITLE
PCIe: Introduce helper to look up devices based on VID/DID

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -229,3 +229,28 @@ void pcie_irq_enable(pcie_bdf_t bdf, unsigned int irq)
 #endif
 	irq_enable(irq);
 }
+
+pcie_bdf_t pcie_bdf_lookup(pcie_id_t id)
+{
+	int bus, dev, func;
+
+	for (bus = 0; bus <= PCIE_MAX_BUS; bus++) {
+		for (dev = 0; dev <= PCIE_MAX_DEV; dev++) {
+			for (func = 0; func <= PCIE_MAX_FUNC; func++) {
+				pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
+				uint32_t data;
+
+				data = pcie_conf_read(bdf, PCIE_CONF_ID);
+				if (data == PCIE_ID_NONE) {
+					continue;
+				}
+
+				if (data == id) {
+					return bdf;
+				}
+			}
+		}
+	}
+
+	return PCIE_BDF_NONE;
+}

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -11,10 +11,6 @@
 #include <drivers/pcie/msi.h>
 #endif
 
-#define MAX_BUS (0xFFFFFFFF & PCIE_BDF_BUS_MASK)
-#define MAX_DEV (0xFFFFFFFF & PCIE_BDF_DEV_MASK)
-#define MAX_FUNC (0xFFFFFFFF & PCIE_BDF_FUNC_MASK)
-
 static void show_msi(const struct shell *shell, pcie_bdf_t bdf)
 {
 #ifdef CONFIG_PCIE_MSI
@@ -109,9 +105,9 @@ static int cmd_pcie_ls(const struct shell *shell, size_t argc, char **argv)
 	int dev;
 	int func;
 
-	for (bus = 0; bus <= MAX_BUS; ++bus) {
-		for (dev = 0; dev <= MAX_DEV; ++dev) {
-			for (func = 0; func <= MAX_FUNC; ++func) {
+	for (bus = 0; bus <= PCIE_MAX_BUS; ++bus) {
+		for (dev = 0; dev <= PCIE_MAX_DEV; ++dev) {
+			for (func = 0; func <= PCIE_MAX_FUNC; ++func) {
 				show(shell, PCIE_BDF(bus, dev, func));
 			}
 		}

--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -99,43 +99,6 @@ static void register_signal(const struct device *dev,
 #define register_signal(...)
 #endif /* CONFIG_IVSHMEM_DOORBELL */
 
-static bool ivshmem_check_on_bdf(pcie_bdf_t bdf)
-{
-	uint32_t data;
-
-	data = pcie_conf_read(bdf, PCIE_CONF_ID);
-	if ((data != PCIE_ID_NONE) &&
-	    (PCIE_ID_TO_VEND(data) == IVSHMEM_VENDOR_ID) &&
-	    (PCIE_ID_TO_DEV(data) == IVSHMEM_DEVICE_ID)) {
-		return true;
-	}
-
-	return false;
-}
-
-/* Ivshmem's BDF is not a static value that we could get from DTS,
- * since the same image could run on qemu or ACRN which could set
- * a different one. So instead, let's find it at runtime.
- */
-static pcie_bdf_t ivshmem_bdf_lookup(void)
-{
-	int bus, dev, func;
-
-	for (bus = 0; bus <= MAX_BUS; bus++) {
-		for (dev = 0; dev <= MAX_DEV; ++dev) {
-			for (func = 0; func <= MAX_FUNC; ++func) {
-				pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
-
-				if (ivshmem_check_on_bdf(bdf)) {
-					return bdf;
-				}
-			}
-		}
-	}
-
-	return 0;
-}
-
 static bool ivshmem_configure(const struct device *dev)
 {
 	struct ivshmem *data = dev->data;
@@ -251,8 +214,9 @@ static int ivshmem_init(const struct device *dev)
 {
 	struct ivshmem *data = dev->data;
 
-	data->bdf = ivshmem_bdf_lookup();
-	if (data->bdf == 0) {
+	data->bdf = pcie_bdf_lookup(PCIE_ID(IVSHMEM_VENDOR_ID,
+					    IVSHMEM_DEVICE_ID));
+	if (data->bdf == PCIE_BDF_NONE) {
 		LOG_WRN("ivshmem device not found");
 		return -ENOTSUP;
 	}

--- a/drivers/virtualization/virt_ivshmem.h
+++ b/drivers/virtualization/virt_ivshmem.h
@@ -16,10 +16,6 @@
 #define IVSHMEM_PCIE_REG_BAR_IDX	0
 #define IVSHMEM_PCIE_SHMEM_BAR_IDX	2
 
-#define MAX_BUS				(0xFFFFFFFF & PCIE_BDF_BUS_MASK)
-#define MAX_DEV				(0xFFFFFFFF & PCIE_BDF_DEV_MASK)
-#define MAX_FUNC			(0xFFFFFFFF & PCIE_BDF_FUNC_MASK)
-
 struct ivshmem_param {
 	const struct device *dev;
 	struct k_poll_signal *signal;

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -46,6 +46,17 @@ struct pcie_mbar {
  */
 
 /**
+ * @brief Look up the BDF based on PCI(e) vendor & device ID
+ *
+ * This function is used to look up the BDF for a device given its
+ * vendor and device ID.
+ *
+ * @param id PCI(e) vendor & device ID encoded using PCIE_ID()
+ * @return The BDF for the device, or PCIE_BDF_NONE if it was not found
+ */
+extern pcie_bdf_t pcie_bdf_lookup(pcie_id_t id);
+
+/**
  * @brief Read a 32-bit word from an endpoint's configuration space.
  *
  * This function is exported by the arch/SoC/board code.

--- a/include/drivers/pcie/pcie.h
+++ b/include/drivers/pcie/pcie.h
@@ -238,6 +238,10 @@ extern uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id);
 #define PCIE_CONF_INTR_IRQ(w)	((w) & 0xFFU)
 #define PCIE_CONF_INTR_IRQ_NONE	0xFFU  /* no interrupt routed */
 
+#define PCIE_MAX_BUS  (0xFFFFFFFF & PCIE_BDF_BUS_MASK)
+#define PCIE_MAX_DEV  (0xFFFFFFFF & PCIE_BDF_DEV_MASK)
+#define PCIE_MAX_FUNC (0xFFFFFFFF & PCIE_BDF_FUNC_MASK)
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dt-bindings/pcie/pcie.h
+++ b/include/dt-bindings/pcie/pcie.h
@@ -35,6 +35,8 @@
 
 #define PCIE_ID_NONE PCIE_ID(0xFFFF, 0xFFFF)
 
+#define PCIE_BDF_NONE 0xFFFFFFFFU
+
 /*
  * Since our internal representation of bus/device/function is arbitrary,
  * we choose the same format employed in the x86 Configuration Address Port:


### PR DESCRIPTION
Currently the only in-tree place that benefits from this is the ivshmem driver, but this is likely to be needed for more and more use cases whenever the BDF value isn't known up-front (e.g. in the case of removable PCIe devices).