### PR TITLE
samples: rpmsg_service: do not run test for nrf5340 in CI

### DIFF
--- a/samples/subsys/ipc/rpmsg_service/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: RPMsg Service example integration
 tests:
     sample.ipc.rpmsg_service:
-        platform_allow: nrf5340dk_nrf5340_cpuapp mps2_an521 v2m_musca_b1
+        platform_allow: mps2_an521 v2m_musca_b1
         tags: ipm
         harness: console
         harness_config:
@@ -13,3 +13,9 @@ tests:
             - "Master core received a message: 1"
             - "Master core received a message: 99"
             - "RPMsg Service demo ended."
+    sample.ipc.rpmsg_service.nrf:
+        platform_allow: nrf5340dk_nrf5340_cpuapp
+        integration_platforms:
+          - nrf5340dk_nrf5340_cpuapp
+        tags: ipm
+        build_only: true


### PR DESCRIPTION
We cannot automatically flash both master and remote images
to nRF5340 application and network core, this needs to be
done separately. We therefore, cannot execute the test on
nRF5340, so we switch to make the test build-only on this
platform.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #31616 