### PR TITLE
twister: bugfix: Fix twister output

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2559,6 +2559,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.testcases = {}
         self.platforms = []
         self.selected_platforms = []
+        self.filtered_platforms = []
         self.default_platforms = []
         self.outdir = os.path.abspath(outdir)
         self.discards = {}
@@ -2728,9 +2729,9 @@ class TestSuite(DisablePyTestCollectionMixin):
             logger.info("In total {} test cases were executed, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
                 results.cases - results.skipped_cases,
                 results.skipped_cases,
-                len(self.selected_platforms),
+                len(self.filtered_platforms),
                 self.total_platforms,
-                (100 * len(self.selected_platforms) / len(self.platforms))
+                (100 * len(self.filtered_platforms) / len(self.platforms))
             ))
 
         logger.info(f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms, \
@@ -3142,6 +3143,9 @@ class TestSuite(DisablePyTestCollectionMixin):
             instance.reason = self.discards[instance]
             instance.status = "skipped"
             instance.fill_results_by_status()
+
+        self.filtered_platforms = set(p.platform.name for p in self.instances.values()
+                                      if p.status != "skipped" )
 
         return discards
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -1151,7 +1151,7 @@ def main():
         suite.csv_report(options.save_tests)
         return
 
-    logger.info("%d test suites (%d configurations) selected, %d configurations discarded due to filters." %
+    logger.info("%d test scenarios (%d configurations) selected, %d configurations discarded due to filters." %
                 (len(suite.testcases), len(suite.instances), len(discards)))
 
     if options.device_testing and not options.build_only:


### PR DESCRIPTION
Fix twister output. "Test suite" used previously did not correspond
to what was counted (test scenarios). A test scenario is an entry from
testcase/sample.yaml under "tests:", which specify configuration used to
build a test. Changes in docs will follow later on. Also replace the
amount of preselectd platforms with the amount of platforms that
were not filtered out and actually tested.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>