### PR TITLE
aarch64: mmu: Remove SRAM memory region

### DIFF
--- a/arch/arm/core/aarch64/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch64/mmu/arm_mmu.c
@@ -271,32 +271,26 @@ move_on:
 /* zephyr execution regions with appropriate attributes */
 static const struct arm_mmu_region mmu_zephyr_regions[] = {
 
-	/* Mark the whole SRAM as read-write */
-	MMU_REGION_FLAT_ENTRY("SRAM",
-			      (uintptr_t)CONFIG_SRAM_BASE_ADDRESS,
-			      (uintptr_t)KB(CONFIG_SRAM_SIZE),
-			      MT_NORMAL | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
-
-	/* Mark rest of the zephyr execution regions (data, bss, noinit, etc.)
+	/* Mark the zephyr execution regions (data, bss, noinit, etc.)
 	 * cacheable, read-write
 	 * Note: read-write region is marked execute-never internally
 	 */
 	MMU_REGION_FLAT_ENTRY("zephyr_data",
 			      (uintptr_t)__kernel_ram_start,
 			      (uintptr_t)__kernel_ram_size,
-			      MT_NORMAL | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE | MT_OVERWRITE),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	/* Mark text segment cacheable,read only and executable */
 	MMU_REGION_FLAT_ENTRY("zephyr_code",
 			      (uintptr_t)_image_text_start,
 			      (uintptr_t)_image_text_size,
-			      MT_NORMAL | MT_P_RX_U_NA | MT_DEFAULT_SECURE_STATE | MT_OVERWRITE),
+			      MT_NORMAL | MT_P_RX_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	/* Mark rodata segment cacheable, read only and execute-never */
 	MMU_REGION_FLAT_ENTRY("zephyr_rodata",
 			      (uintptr_t)_image_rodata_start,
 			      (uintptr_t)_image_rodata_size,
-			      MT_NORMAL | MT_P_RO_U_NA | MT_DEFAULT_SECURE_STATE | MT_OVERWRITE),
+			      MT_NORMAL | MT_P_RO_U_NA | MT_DEFAULT_SECURE_STATE),
 };
 
 static inline void add_arm_mmu_region(struct arm_mmu_ptables *ptables,


### PR DESCRIPTION
Now that the arch_mem_map() hook is actually working correctly we can remove the big SRAM region.