### PR TITLE
[RFC] scheduler: add support for CPU-affine work

### DIFF
--- a/include/sys/p4wq.h
+++ b/include/sys/p4wq.h
@@ -30,6 +30,7 @@ struct k_p4wq_work {
 	int32_t priority;
 	int32_t deadline;
 	k_p4wq_handler_t handler;
+	uint32_t cpu_mask;
 
 	/* reserved for implementation */
 	union {

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -313,4 +313,19 @@ static inline struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 	return thread;
 }
 
+#ifdef CONFIG_SCHED_CPU_MASK
+static inline struct k_thread *z_unpend1_no_timeout_mask(_wait_q_t *wait_q,
+							 uint32_t cpu_mask)
+{
+	struct k_thread *thread = z_find_first_thread_to_unpend_mask(wait_q,
+								NULL, cpu_mask);
+
+	if (thread != NULL) {
+		z_unpend_thread_no_timeout(thread);
+	}
+
+	return thread;
+}
+#endif
+
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSCHED_H_ */

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -179,7 +179,9 @@ void k_p4wq_submit(struct k_p4wq *queue, struct k_p4wq_work *item)
 	 * error: we are breaking our promise about run order.
 	 * Complain.
 	 */
-	struct k_thread *th = z_unpend_first_thread(&queue->waitq);
+	struct k_thread *th = w->cpu_mask ?
+		z_unpend_first_thread_mask(&queue->waitq, w->cpu_mask) :
+		z_unpend_first_thread(&queue->waitq);
 
 	if (th == NULL) {
 		LOG_WRN("Out of worker threads, priority guarantee violated");


### PR DESCRIPTION
Add a CPU mask to the P4WQ work dispatcher and add support for it in the scheduler.

This should be split into 2 patches at least of course. And not tested yet.