### PR TITLE
dma: stm32: remove dump stream info in irq

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -97,8 +97,6 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 	callback_arg = id + STREAM_OFFSET;
 #endif /* CONFIG_DMAMUX_STM32 */
 
-	dma_stm32_dump_stream_irq(dev, id);
-
 	if (!IS_ENABLED(CONFIG_DMAMUX_STM32)) {
 		stream->busy = false;
 	}


### PR DESCRIPTION
Remove printing dma stream info in irq context.
This is printed in case of error.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>


Fixes: #32030