### PR TITLE
spi: Add LPSPI support for i.MX RT1062

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -134,6 +134,7 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
+	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
 	select HAS_MCUX_SEMC
@@ -160,6 +161,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_PWM
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
+	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
 	select HAS_MCUX_SEMC
@@ -188,6 +190,7 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_PWM
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
+	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_GPT
 	select HAS_MCUX_SEMC


### PR DESCRIPTION
Refers to #26428 and #30204.

Test ```tests/drivers/spi/spi_loopback``` succeeds on Teensy4.1 board.