### PR TITLE
Bluetooth: controller: Fix build error with ISO support

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -5,18 +5,24 @@
  */
 
 #include <zephyr.h>
+#include <soc.h>
+
+#include "hal/cpu.h"
+#include "hal/ccm.h"
+
+#include "util/memq.h"
+#include "util/mem.h"
+#include "util/mfifo.h"
+
+#include "pdu.h"
+
+#include "lll.h"
+#include "lll_conn.h" /* for `struct lll_tx` */
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_iso
 #include "common/log.h"
 #include "hal/debug.h"
-#include "hal/ccm.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/mfifo.h"
-#include "pdu.h"
-#include "lll.h"
-#include "lll_conn.h" /* for `struct lll_tx` */
 
 static int init_reset(void);
 


### PR DESCRIPTION
Fix build error due to missing include file with ISO support
enabled.

Fixes #31996.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>