### PR TITLE
driver: i2c: npcx: Fix i2c event-completed semaphore issue caused by bus error

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -427,7 +427,7 @@ static int i2c_ctrl_recovery(const struct device *dev)
 	 * - Wait for STOP condition completed
 	 * - Then clear BB (BUS BUSY) bit
 	 */
-	inst_fifo->SMBST |= BIT(NPCX_SMBST_BER) | BIT(NPCX_SMBST_NEGACK);
+	inst_fifo->SMBST = BIT(NPCX_SMBST_BER) | BIT(NPCX_SMBST_NEGACK);
 	ret = i2c_ctrl_wait_stop_completed(dev, I2C_MAX_TIMEOUT);
 	inst_fifo->SMBCST |= BIT(NPCX_SMBCST_BB);
 	if (ret != 0) {
@@ -686,7 +686,7 @@ static void i2c_ctrl_isr(const struct device *dev)
 		i2c_ctrl_stop(dev);
 
 		/* Clear BER Bit */
-		inst_fifo->SMBST |= BIT(NPCX_SMBST_BER);
+		inst_fifo->SMBST = BIT(NPCX_SMBST_BER);
 
 		/* Make sure slave doesn't hold bus by reading FIFO again */
 		tmp = i2c_ctrl_fifo_read(dev);
@@ -705,7 +705,7 @@ static void i2c_ctrl_isr(const struct device *dev)
 		i2c_ctrl_stop(dev);
 
 		/* Clear NEGACK Bit */
-		inst_fifo->SMBST |= BIT(NPCX_SMBST_NEGACK);
+		inst_fifo->SMBST = BIT(NPCX_SMBST_NEGACK);
 
 		/* End transaction */
 		data->oper_state = NPCX_I2C_WAIT_STOP;

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -790,6 +790,13 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 	data->trans_err = 0;
 	data->addr = addr;
 
+	/*
+	 * Reset i2c event-completed semaphore before starting transactions.
+	 * Some interrupt events such as BUS_ERROR might change its counter
+	 * when bus is idle.
+	 */
+	k_sem_reset(&data->sync_sem);
+
 	for (i = 0U; i < num_msgs; i++) {
 		struct i2c_msg *msg = msgs + i;
 


### PR DESCRIPTION
Since some interrupt events such as BUS_ERROR (caused by a glitch
on bus) might change i2c event-completed semaphore's counter. It 
causes that the driver cannot wait for the i2c event completed and 
return immediately. The first CL resets i2c  before starting transactions 
to solve the issue.

The other two CLs are trying to fix the potential leaks only. So far we 
don't see any symptom cause by them.