### PR TITLE
board: correct dts for 96b_stm32_sensor_mez

### DIFF
--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -109,7 +109,8 @@
 &spi2 {
 	pinctrl-0 = <&spi2_nss_pb9 &spi2_sck_pd3
 		     &spi2_miso_pb14 &spi2_mosi_pb15>;
-	status = "okay";
+	/* Cannot be used together with i2s2. */
+	/* status = "okay"; */
 };
 
 &spi4_nss_pe11 { slew-rate = "very-high-speed"; };

--- a/boards/arm/96b_stm32_sensor_mez/pre_dt_board.cmake
+++ b/boards/arm/96b_stm32_sensor_mez/pre_dt_board.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/i2s@40003800 & /soc/spi@40003800
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
i2s2 and spi2 cannot be okay at the same time. This removes dts error.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>