### PR TITLE
boards: correct dts for bl654_dvk and bl652_dvk

### DIFF
--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -91,7 +91,8 @@
 
 &spi0 {
 	compatible = "nordic,nrf-spi";
-	status = "okay";
+	/* Cannot be used together with i2c0. */
+	/* status = "okay"; */
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;

--- a/boards/arm/bl652_dvk/pre_dt_board.cmake
+++ b/boards/arm/bl652_dvk/pre_dt_board.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/i2c@40003000 & /soc/spi@40003000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -115,7 +115,8 @@
 
 &spi0 {
 	compatible = "nordic,nrf-spi";
-	status = "okay";
+	/* Cannot be used together with i2c0. */
+	/* status = "okay"; */
 	sck-pin = <41>;
 	mosi-pin = <40>;
 	miso-pin = <4>;

--- a/boards/arm/bl654_dvk/pre_dt_board.cmake
+++ b/boards/arm/bl654_dvk/pre_dt_board.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/i2c@40003000 & /soc/spi@40003000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
i2c0 and spi0 cannot be enabled at the same time, corrects dts error.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>