### PR TITLE
scripts: using pathlib for in get_toolchain() method

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2840,7 +2840,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
     @staticmethod
     def get_toolchain():
-        toolchain_script = ZEPHYR_BASE + "/cmake/verify-toolchain.cmake"
+        toolchain_script = Path(ZEPHYR_BASE) / Path('cmake/verify-toolchain.cmake')
         result = CMake.run_cmake_script([toolchain_script, "FORMAT=json"])
 
         try:


### PR DESCRIPTION
Followup commit on comment in #32003.

Using pathlib to avoid mixing of `/` and `\` if twister someday will be
able to run on Windows.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>