### PR TITLE
manifest: fixed MCUboot with image encryption enabled.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 24d84ecff195fb15c889d9046e44e4804d626c67
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 30e0c5a0af21433efc8ea35cabc44bee3f096a62
+      revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 43845e883ff3a6cdaae22e23f3e60b5fcf78c6ba


### PR DESCRIPTION
MCUBoot was updated to version with bugfix for issue
which caused that it can not be built if image encryption
was enabled.

fixes #32002

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>