### PR TITLE
dts/arm: stm32f2: Fix usart1 clock

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -172,7 +172,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";


### PR DESCRIPTION
usart1 clock setting was wrongly defined. Fix it.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/32007

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>