### PR TITLE
Triv fix arm kconfig

### DIFF
--- a/soc/arm/arm/beetle/Kconfig.series
+++ b/soc/arm/arm/beetle/Kconfig.series
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_BEETLE
-	bool "ARM Beetle MCU Series"
+	bool "Arm Beetle MCU Series"
 	select ARM
 	select CPU_CORTEX_M3
 	select SOC_FAMILY_ARM

--- a/soc/arm/arm/designstart/Kconfig.series
+++ b/soc/arm/arm/designstart/Kconfig.series
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_ARM_DESIGNSTART
-	bool "ARM DesignStart SoC Series"
+	bool "Arm DesignStart SoC Series"
 	select ARM
 	select SOC_FAMILY_ARM
 	help

--- a/soc/arm/arm/designstart/Kconfig.series
+++ b/soc/arm/arm/designstart/Kconfig.series
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_ARM_DESIGNSTART
-       bool "ARM DesignStart SoC Series"
-       select ARM
-       select SOC_FAMILY_ARM
-       help
-         Enable support for the ARM DesignStart SoC Series
+	bool "ARM DesignStart SoC Series"
+	select ARM
+	select SOC_FAMILY_ARM
+	help
+	  Enable support for the ARM DesignStart SoC Series

--- a/soc/arm/arm/mps2/Kconfig.series
+++ b/soc/arm/arm/mps2/Kconfig.series
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MPS2
-	bool "ARM MPS2 MCU Series"
+	bool "Arm MPS2 MCU Series"
 	select ARM
 	select SOC_FAMILY_ARM
 	select GPIO_MMIO32 if GPIO

--- a/soc/arm/arm/musca_a/Kconfig.series
+++ b/soc/arm/arm/musca_a/Kconfig.series
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MUSCA
-	bool "ARM v2m MUSCA MCU Series"
+	bool "Arm v2m MUSCA MCU Series"
 	select ARM
 	select SOC_FAMILY_ARM
 	select BUILD_OUTPUT_HEX

--- a/soc/arm/arm/musca_b1/Kconfig.series
+++ b/soc/arm/arm/musca_b1/Kconfig.series
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MUSCA_B1
-	bool "arm v2m MUSCA B1 MCU Series"
+	bool "Arm v2m MUSCA B1 MCU Series"
 	select ARM
 	select SOC_FAMILY_ARM
 	select BUILD_OUTPUT_HEX

--- a/soc/arm/arm/musca_s1/Kconfig.series
+++ b/soc/arm/arm/musca_s1/Kconfig.series
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MUSCA_S1
-	bool "arm v2m MUSCA-S1 MCU Series"
+	bool "Arm v2m MUSCA-S1 MCU Series"
 	select ARM
 	select SOC_FAMILY_ARM
 	select BUILD_OUTPUT_HEX

--- a/soc/arm/st_stm32/stm32f2/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.series
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_STM32F2X
-	bool "stm32f2x Series MCU"
+	bool "STM32F2x Series MCU"
 	select ARM
 	select CPU_CORTEX_M3
 	select CPU_CORTEX_M_HAS_DWT


### PR DESCRIPTION
These trivial Kconfig patches align upper and lower case in the SoC selection in menuconfig.

Before:

> ( ) ARM Beetle MCU Series
> ( ) ARM DesignStart SoC Series
> ( ) ARM MPS2 MCU Series
> ( ) ARM v2m MUSCA MCU Series
> ( ) arm v2m MUSCA B1 MCU Series
> ( ) arm v2m MUSCA-S1 MCU Series

and 

> ( ) STM32F0x Series MCU
> ( ) STM32F1x Series MCU
> ( ) stm32f2x Series MCU
> ( ) STM32F3x Series MCU
> ( ) STM32F4x Series MCU
> ( ) STM32F7x Series MCU
> ( ) STM32G0x Series MCU
> ( ) STM32G4x Series MCU
> ( ) STM32H7x Series MCU
> ( ) STM32L0x Series MCU
> ( ) STM32L1x Series MCU
> ( ) STM32L4x Series MCU
> ( ) STM32L5x Series MCU
> ( ) STM32MP15 Series MPU
> ( ) STM32WBx Series MCU

After the changes:

> ( ) Arm Beetle MCU Series
> ( ) Arm DesignStart SoC Series
> ( ) Arm MPS2 MCU Series
> ( ) Arm v2m MUSCA MCU Series
> ( ) Arm v2m MUSCA B1 MCU Series
> ( ) Arm v2m MUSCA-S1 MCU Series

> ( ) STM32F0x Series MCU
> ( ) STM32F1x Series MCU
> ( ) STM32F2x Series MCU
> ( ) STM32F3x Series MCU
> ( ) STM32F4x Series MCU
> ( ) STM32F7x Series MCU
> ( ) STM32G0x Series MCU
> ( ) STM32G4x Series MCU
> ( ) STM32H7x Series MCU
> ( ) STM32L0x Series MCU
> ( ) STM32L1x Series MCU
> ( ) STM32L4x Series MCU
> ( ) STM32L5x Series MCU
> ( ) STM32MP15 Series MPU
> ( ) STM32WBx Series MCU
