### PR TITLE
board: serpente fix dts (samd2x.dtsi)

### DIFF
--- a/boards/arm/serpente/pre_dt_board.cmake
+++ b/boards/arm/serpente/pre_dt_board.cmake
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/pinmux@41004400 & /soc/gpio@41004400
-# - /soc/pinmux@41004480 & /soc/gpio@41004480
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -102,12 +102,32 @@
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004400 0x80>;
 			label = "PINMUX_A";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			porta: gpio@41004400 {
+				compatible = "atmel,sam0-gpio";
+				reg = <0x41004400 0x80>;
+				label = "PORTA";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 
 		pinmux_b: pinmux@41004480 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004480 0x80>;
 			label = "PINMUX_B";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			portb: gpio@41004480 {
+				compatible = "atmel,sam0-gpio";
+				reg = <0x41004480 0x80>;
+				label = "PORTB";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
 		};
 
 		wdog: watchdog@40001000 {
@@ -163,22 +183,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42003000 0x20>;
 			label = "TIMER_4";
-		};
-
-		porta: gpio@41004400 {
-			compatible = "atmel,sam0-gpio";
-			reg = <0x41004400 0x80>;
-			label = "PORTA";
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
-
-		portb: gpio@41004480 {
-			compatible = "atmel,sam0-gpio";
-			reg = <0x41004480 0x80>;
-			label = "PORTB";
-			gpio-controller;
-			#gpio-cells = <2>;
 		};
 
 		rtc: rtc@40001400 {


### PR DESCRIPTION
move port a under pinmux a and port b under pinmux b to remove dts
errors.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>