### PR TITLE
boards: fix dts for nrf5340 and nrf9160

### DIFF
--- a/boards/arm/circuitdojo_feather_nrf9160/pre_dt_board.cmake
+++ b/boards/arm/circuitdojo_feather_nrf9160/pre_dt_board.cmake
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - flash-controller@39000 & kmu@39000
-# - power@5000 & clock@5000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -244,14 +244,16 @@ arduino_spi: &spi4 {
 
 		sram0_image: image@20000000 {
 			/* Zephyr image(s) memory */
-		};
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			sram0_s: image_s@20000000 {
+				/* Secure image memory */
+			};
 
-		sram0_s: image_s@20000000 {
-			/* Secure image memory */
-		};
-
-		sram0_ns: image_ns@20040000 {
-			/* Non-Secure image memory */
+			sram0_ns: image_ns@20040000 {
+				/* Non-Secure image memory */
+			};
 		};
 	};
 };

--- a/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/pre_dt_board.cmake
@@ -1,8 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - flash-controller@39000 & kmu@39000
-# - power@5000 & clock@5000
-# - /reserved-memory/image@20000000 & /reserved-memory/image_s@20000000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160_innblue21/pre_dt_board.cmake
+++ b/boards/arm/nrf9160_innblue21/pre_dt_board.cmake
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - flash-controller@39000 & kmu@39000
-# - power@5000 & clock@5000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160_innblue22/pre_dt_board.cmake
+++ b/boards/arm/nrf9160_innblue22/pre_dt_board.cmake
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - flash-controller@39000 & kmu@39000
-# - power@5000 & clock@5000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160dk_nrf9160/pre_dt_board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/pre_dt_board.cmake
@@ -1,7 +1,0 @@
-# Copyright (c) 2021 Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - flash-controller@39000 & kmu@39000
-# - power@5000 & clock@5000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -19,6 +19,13 @@ flash_controller: flash-controller@39000 {
 		erase-block-size = <4096>;
 		write-block-size = <4>;
 	};
+
+	kmu: kmu@39000 {
+		compatible = "nordic,nrf-kmu";
+		reg = <0x39000 0x1000>;
+		interrupts = <57 NRF_DEFAULT_IRQ_PRIORITY>;
+		status = "okay";
+	};
 };
 
 adc: adc@e000 {
@@ -95,13 +102,6 @@ ipc: ipc@2a000 {
 	interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "okay";
 	label = "IPC";
-};
-
-kmu: kmu@39000 {
-	compatible = "nordic,nrf-kmu";
-	reg = <0x39000 0x1000>;
-	interrupts = <57 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "okay";
 };
 
 pdm0: pdm@26000 {
@@ -384,13 +384,15 @@ clock: clock@5000 {
 	interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "okay";
 	label = "CLOCK";
-};
+	#address-cells = <1>;
+	#size-cells = <1>;
 
-power: power@5000 {
-	compatible = "nordic,nrf-power";
-	reg = <0x5000 0x1000>;
-	interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "okay";
+	power: power@5000 {
+		compatible = "nordic,nrf-power";
+		reg = <0x5000 0x1000>;
+		interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
+		status = "okay";
+	};
 };
 
 wdt: wdt0: watchdog@18000 {

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -19,6 +19,13 @@ flash_controller: flash-controller@39000 {
 		erase-block-size = <4096>;
 		write-block-size = <4>;
 	};
+
+	kmu: kmu@39000 {
+		compatible = "nordic,nrf-kmu";
+		reg = <0x39000 0x1000>;
+		interrupts = <57 NRF_DEFAULT_IRQ_PRIORITY>;
+		status = "okay";
+	};
 };
 
 adc: adc@e000 {
@@ -87,13 +94,6 @@ i2s0: i2s@28000 {
 	interrupts = <40 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "I2S_0";
-};
-
-kmu: kmu@39000 {
-	compatible = "nordic,nrf-kmu";
-	reg = <0x39000 0x1000>;
-	interrupts = <57 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "okay";
 };
 
 pdm0: pdm@26000 {
@@ -338,13 +338,15 @@ clock: clock@5000 {
 	interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "okay";
 	label = "CLOCK";
-};
+	#address-cells = <1>;
+	#size-cells = <1>;
 
-power: power@5000 {
-	compatible = "nordic,nrf-power";
-	reg = <0x5000 0x1000>;
-	interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "okay";
+	power: power@5000 {
+		compatible = "nordic,nrf-power";
+		reg = <0x5000 0x1000>;
+		interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
+		status = "okay";
+	};
 };
 
 wdt: wdt0: watchdog@18000 {


### PR DESCRIPTION
move kmu under flash_controller and power under clock
move sram0_s and sram0_ns under sram_image

this removes dts errors

Signed-off-by: Laczen JMS <laczenjms@gmail.com>