### PR TITLE
arm: cortex-m: add extra stack size for test build with FPU_SHARING

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -296,6 +296,13 @@ config CORTEX_M_DWT
 	help
 	  Enable and use the Data Watchpoint and Trace (DWT) unit for
 	  timing functions.
+
+# Additional stack for tests when building with FPU_SHARING
+# enabled, which may increase ESF stacking requirements for
+# threads.
+config TEST_EXTRA_STACKSIZE
+	default 512 if TEST_ARM_CORTEX_M && FPU_SHARING
+
 endmenu
 
 rsource "mpu/Kconfig"


### PR DESCRIPTION
Additional stack for tests when building with FPU_SHARING
enabled is required, because the option may increase ESF
stacking requirements for threads.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

partially fixing #31982 (the kernel queue test)