### PR TITLE
Fix virtual clock in RISC-V

### DIFF
--- a/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl
+++ b/boards/riscv/m2gl025_miv/support/m2gl025_miv.repl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using "platforms/cpus/miv.repl"
+
+uart:
+    clockFrequency: 4000000
+
+clint:
+    frequency: 4000000
+
+timer0:
+    clockFrequency: 4000000
+
+timer1:
+    clockFrequency: 4000000

--- a/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc
+++ b/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc
@@ -5,10 +5,10 @@ $name?="Mi-V"
 
 using sysbus
 mach create $name
-machine LoadPlatformDescription @platforms/boards/miv-board.repl
+machine LoadPlatformDescription $ORIGIN/m2gl025_miv.repl
 
 showAnalyzer uart
-cpu PerformanceInMips 80
+cpu PerformanceInMips 4
 
 macro reset
 """

--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -6,7 +6,7 @@ config SOC_SERIES
 	default "miv"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 660000
+	default 4000000
 
 config RISCV_SOC_INTERRUPT_INIT
 	default y

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     arch_exclude: nios2 xtensa
     min_ram: 32
     tags: benchmark
+    timeout: 120

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -2,7 +2,7 @@ common:
   min_flash: 65
   min_ram: 36
   tags: crypto mbedtls userspace
-  timeout: 200
+  timeout: 400
 tests:
   crypto.mbedtls:
     arch_exclude: riscv64

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags: posix
   min_ram: 64
   arch_exclude: posix
+  timeout: 120
 
 tests:
   portability.posix.common:


### PR DESCRIPTION
The first commit fixes #31726 and the second one's goal is to compensate timeouts caused by extended busy waiting.