### PR TITLE
Bluetooth: gatt: notify application of MTU updates

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -18,6 +18,7 @@
  */
 
 #include <stddef.h>
+#include <sys/slist.h>
 #include <sys/types.h>
 #include <sys/util.h>
 #include <bluetooth/conn.h>
@@ -181,6 +182,22 @@ struct bt_gatt_include {
 	uint16_t end_handle;
 };
 
+/** @brief GATT callback structure. */
+struct bt_gatt_cb {
+	/** @brief The maximum ATT MTU on a connection has changed.
+	 *
+	 *  This callback notifies the application that the maximum TX or RX
+	 *  ATT MTU has increased.
+	 *
+	 *  @param conn Connection object.
+	 *  @param tx Updated TX ATT MTU.
+	 *  @param rx Updated RX ATT MTU.
+	 */
+	void (*att_mtu_updated)(struct bt_conn *conn, uint16_t tx, uint16_t rx);
+
+	sys_snode_t node;
+};
+
 /** Characteristic Properties Bit field values */
 
 /** @def BT_GATT_CHRC_BROADCAST
@@ -313,6 +330,14 @@ struct bt_gatt_cpf {
  * @ingroup bt_gatt
  * @{
  */
+
+/** @brief Register GATT callbacks.
+ *
+ *  Register callbacks to monitor the state of GATT.
+ *
+ *  @param cb Callback struct.
+ */
+void bt_gatt_cb_register(struct bt_gatt_cb *cb);
 
 /** @brief Register GATT service.
  *

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -233,6 +233,15 @@ static const struct bt_data ad[] = {
 		      0x78, 0x56, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12),
 };
 
+void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+{
+	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
+}
+
+static struct bt_gatt_cb gatt_callbacks = {
+	.att_mtu_updated = mtu_updated
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -335,6 +344,7 @@ void main(void)
 
 	bt_ready();
 
+	bt_gatt_cb_register(&gatt_callbacks);
 	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&auth_cb_display);
 

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -117,6 +117,7 @@ typedef void (*bt_att_chan_sent_t)(struct bt_att_chan *chan);
 static bt_att_chan_sent_t chan_cb(struct net_buf *buf);
 static bt_conn_tx_cb_t att_cb(bt_att_chan_sent_t cb);
 
+static void att_chan_mtu_updated(struct bt_att_chan *updated_chan);
 static void bt_att_disconnected(struct bt_l2cap_chan *chan);
 
 void att_sent(struct bt_conn *conn, void *user_data)
@@ -553,6 +554,9 @@ static uint8_t att_mtu_req(struct bt_att_chan *chan, struct net_buf *buf)
 	chan->chan.tx.mtu = chan->chan.rx.mtu;
 
 	BT_DBG("Negotiated MTU %u", chan->chan.rx.mtu);
+
+	att_chan_mtu_updated(chan);
+
 	return 0;
 }
 
@@ -664,6 +668,8 @@ static uint8_t att_mtu_rsp(struct bt_att_chan *chan, struct net_buf *buf)
 	chan->chan.tx.mtu = chan->chan.rx.mtu;
 
 	BT_DBG("Negotiated MTU %u", chan->chan.rx.mtu);
+
+	att_chan_mtu_updated(chan);
 
 	return att_handle_rsp(chan, rsp, buf->len, 0);
 }
@@ -2617,6 +2623,8 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 		ch->rx.mtu = BT_ATT_DEFAULT_LE_MTU;
 	}
 
+	att_chan_mtu_updated(att_chan);
+
 	k_work_init_delayable(&att_chan->timeout_work, att_timeout);
 }
 
@@ -2951,6 +2959,30 @@ uint16_t bt_att_get_mtu(struct bt_conn *conn)
 	}
 
 	return mtu;
+}
+
+static void att_chan_mtu_updated(struct bt_att_chan *updated_chan)
+{
+	struct bt_att *att = updated_chan->att;
+	struct bt_att_chan *chan, *tmp;
+	uint16_t max_tx = 0, max_rx = 0;
+
+	/* Get maximum MTU's of other channels */
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
+		if (chan == updated_chan) {
+			continue;
+		}
+		max_tx = MAX(max_tx, chan->chan.tx.mtu);
+		max_rx = MAX(max_rx, chan->chan.rx.mtu);
+	}
+
+	/* If either maximum MTU has changed */
+	if ((updated_chan->chan.tx.mtu > max_tx) ||
+	    (updated_chan->chan.rx.mtu > max_rx)) {
+		max_tx = MAX(max_tx, updated_chan->chan.tx.mtu);
+		max_rx = MAX(max_rx, updated_chan->chan.rx.mtu);
+		bt_gatt_att_max_mtu_changed(att->conn, max_tx, max_rx);
+	}
 }
 
 struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -71,6 +71,7 @@ struct gatt_sub {
 #endif /* CONFIG_BT_GATT_CLIENT */
 
 static struct gatt_sub subscriptions[SUB_MAX];
+static sys_slist_t callback_list;
 
 static const uint16_t gap_appearance = CONFIG_BT_DEVICE_APPEARANCE;
 
@@ -1066,6 +1067,8 @@ void bt_gatt_init(void)
 
 	bt_gatt_service_init();
 
+	sys_slist_init(&callback_list);
+
 #if defined(CONFIG_BT_GATT_CACHING)
 	k_work_init_delayable(&db_hash.work, db_hash_process);
 
@@ -1116,6 +1119,11 @@ submit:
 	sc_work_submit(SC_TIMEOUT);
 }
 #endif /* BT_GATT_DYNAMIC_DB || (BT_GATT_CACHING && BT_SETTINGS) */
+
+void bt_gatt_cb_register(struct bt_gatt_cb *cb)
+{
+	sys_slist_append(&callback_list, &cb->node);
+}
 
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
 static void db_changed(void)
@@ -4770,6 +4778,17 @@ void bt_gatt_connected(struct bt_conn *conn)
 #if defined(CONFIG_BT_GATT_CLIENT)
 	add_subscriptions(conn);
 #endif /* CONFIG_BT_GATT_CLIENT */
+}
+
+void bt_gatt_att_max_mtu_changed(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+{
+	struct bt_gatt_cb *cb;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, cb, node) {
+		if (cb->att_mtu_updated) {
+			cb->att_mtu_updated(conn, tx, rx);
+		}
+	}
 }
 
 void bt_gatt_encrypt_change(struct bt_conn *conn)

--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -24,6 +24,7 @@
 
 void bt_gatt_init(void);
 void bt_gatt_connected(struct bt_conn *conn);
+void bt_gatt_att_max_mtu_changed(struct bt_conn *conn, uint16_t tx, uint16_t rx);
 void bt_gatt_encrypt_change(struct bt_conn *conn);
 void bt_gatt_disconnected(struct bt_conn *conn);
 


### PR DESCRIPTION
Add a new callback to `struct bt_conn_cb` to allow applications to track
changes to the ATT MTU. This callback is only called when the remote
side changes the MTU. The application is already notified of a changed
MTU if it initiated the update via the `struct bt_gatt_exchange_params`
callback.

Fixes #32035.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>