### PR TITLE
tests: arm_interrupt: exend test case for FPU SHARING

### DIFF
--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -15,7 +15,7 @@ static volatile int expected_reason = -1;
 static volatile int run_esf_validation;
 static volatile int esf_validation_rv;
 static volatile uint32_t expected_msp;
-static K_THREAD_STACK_DEFINE(esf_collection_stack, 1024);
+static K_THREAD_STACK_DEFINE(esf_collection_stack, 2048);
 static struct k_thread esf_collection_thread;
 #define MAIN_PRIORITY 7
 #define PRIORITY 5
@@ -377,7 +377,21 @@ void test_arm_interrupt(void)
 	 * entry will make PSP descend below the limit and into the MPU guard
 	 * section (or beyond the address pointed by PSPLIM in ARMv8-M MCUs).
 	 */
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING) && \
+	defined(CONFIG_MPU_STACK_GUARD)
+#define FPU_STACK_EXTRA_SIZE 0x48
+	/* If an FP context is present, we should not set the PSP
+	 * too close to the end of the stack, because stacking of
+	 * the ESF might corrupt kernel memory, making it not
+	 * possible to continue the test execution.
+	 */
+	uint32_t fp_extra_size =
+		(__get_CONTROL() & CONTROL_FPCA_Msk) ?
+			FPU_STACK_EXTRA_SIZE : 0;
+	__set_PSP(_current->stack_info.start + 0x10 + fp_extra_size);
+#else
 	__set_PSP(_current->stack_info.start + 0x10);
+#endif
 
 	__enable_irq();
 	__DSB();


### PR DESCRIPTION
Extend the stress test of stacking error, to cover
the case of an active FP context.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>