### PR TITLE
Move stm 32 power subsystem to new power states

### DIFF
--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -20,6 +20,27 @@
 		zephyr,flash = &flash0;
 	};
 
+	power-states {
+		stop0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <0>;
+			min-residency-us = <500>;
+		};
+		stop1: state1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <1>;
+			min-residency-us = <700>;
+		};
+		stop2: state2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <2>;
+			min-residency-us = <1000>;
+		};
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
@@ -40,6 +61,10 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 	};
+};
+
+&cpu0 {
+	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
 &usart1 {

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -22,6 +22,27 @@
 		zephyr,code-partition = &slot0_partition;
 	};
 
+	power-states {
+		stop0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <0>;
+			min-residency-us = <100>;
+		};
+		stop1: state1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <1>;
+			min-residency-us = <500>;
+		};
+		stop2: state2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <2>;
+			min-residency-us = <900>;
+		};
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		blue_led_1: led_0 {
@@ -60,6 +81,10 @@
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
 	};
+};
+
+&cpu0 {
+	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
 &usart1 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -22,7 +22,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -20,7 +20,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;


### PR DESCRIPTION
This is adding new power state to the power subsystem for both stm32wb55 and stm32l4xx soc
-   Move power states and residency info to DTS
-   Remove old power states
As requested by the https://github.com/zephyrproject-rtos/zephyr/pull/31273

At the moment, only two boards are targeted to enable PM.

Signed-off-by: Francois Ramu <francois.ramu@st.com>