### PR TITLE
boards: qemu_arc: enable back as default test platform

### DIFF
--- a/boards/arc/qemu_arc/qemu_arc_em.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_em.yaml
@@ -6,6 +6,7 @@ arch: arc
 toolchain:
   - zephyr
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/qemu_arc/qemu_arc_hs.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs.yaml
@@ -6,6 +6,7 @@ arch: arc
 toolchain:
   - zephyr
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   crypto.tinycrypt:
     tags: tinycrypt crypto aes ccm
+    platform_exclude: qemu_arc_em qemu_arc_hs
     timeout: 300
     integration_platforms:
       - native_posix


### PR DESCRIPTION
With addition of icount support (#31550) ARC QEMU is now stable, so we can finally enable it as default test platform.

Even though ARC QEMU has received advanced multiplication instructions support recently the ARC QEMU in the latest
Zephyr SDK still misses them, so tinycrypt may execute too long and reach timeout in case of execution on slow host.

We disable tinycrypt for ARC QEMU platforms till we update ARC QEMU in Zephyr SDK.