### PR TITLE
net: ipv6: add function checking if given address is ULA

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -764,6 +764,18 @@ static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
 }
 
 /**
+ * @brief Check if the given IPv6 address is a unique local address.
+ *
+ * @param addr A valid pointer on an IPv6 address
+ *
+ * @return True if it is, false otherwise.
+ */
+static inline bool net_ipv6_is_ula_addr(const struct in6_addr *addr)
+{
+	return addr->s6_addr[0] == 0xFD;
+}
+
+/**
  * @brief Return pointer to any (all bits zeros) IPv6 address.
  *
  * @return Any IPv6 address.


### PR DESCRIPTION
This patch adds a helper function to verify if given IPv6 address is a unique local address.

This function is useful to determine if given address is local (within given mesh/ecosystem) or global.