### PR TITLE
Bluetooth: Mesh: Reduce proxy rx buffer to an exact fit

### DIFF
--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -51,7 +51,7 @@
 
 #define PDU_HDR(sar, type) (sar << 6 | (type & BIT_MASK(6)))
 
-#define CLIENT_BUF_SIZE 68
+#define CLIENT_BUF_SIZE 65
 
 #if defined(CONFIG_BT_MESH_DEBUG_USE_ID_ADDR)
 #define ADV_OPT                                                                \


### PR DESCRIPTION
Removes the 3 byte padding at the end of each proxy connection's rx
buffer.

Fixes #18509.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>