### PR TITLE
Bluetooth: Mesh: Store network at the end of provisioning

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -134,6 +134,10 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 		bt_mesh_lpn_group_add(BT_MESH_ADDR_ALL_NODES);
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_net_pending_net_store();
+	}
+
 	bt_mesh_start();
 
 	return 0;

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -138,11 +138,6 @@ static void msg_cache_add(struct bt_mesh_net_rx *rx)
 	msg_cache_next %= ARRAY_SIZE(msg_cache);
 }
 
-static void store_net(void)
-{
-	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_NET_PENDING);
-}
-
 static void store_iv(bool only_duration)
 {
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_IV_PENDING);
@@ -198,7 +193,6 @@ int bt_mesh_net_create(uint16_t idx, uint8_t flags, const uint8_t key[16],
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing network information persistently");
-		store_net();
 		bt_mesh_subnet_store(idx);
 		store_iv(false);
 	}


### PR DESCRIPTION
After #31176, the network would get stored immediately in
bt_mesh_net_create, causing the address and devicekey to get stored as
their zero-initialized version, as they're only being set in the
bt_mesh_comp_provision call, which fires after.

Fixes #32067.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>