### PR TITLE
include: arch: riscv: drop __soc_get_irq() declaration

### DIFF
--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -278,12 +278,6 @@ typedef struct {
 	uint8_t pmp_attr;
 } k_mem_partition_attr_t;
 
-/*
- * SOC-specific function to get the IRQ number generating the interrupt.
- * __soc_get_irq returns a bitfield of pending IRQs.
- */
-extern uint32_t __soc_get_irq(void);
-
 void arch_irq_enable(unsigned int irq);
 void arch_irq_disable(unsigned int irq);
 int arch_irq_is_enabled(unsigned int irq);


### PR DESCRIPTION
There is no ``__soc_get_irq()`` definition in the Zephyr source code tree.