### PR TITLE
doc: release: Add DAC release notes for v2.5.0

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -292,6 +292,9 @@ Drivers and Sensors
 
 * DAC
 
+  * STM32: Enabled support for G0 and H7 series.
+  * Added TI DACx3608 driver.
+
 * Debug
 
 * Display


### PR DESCRIPTION
Adding notes regarding new TI driver and enabled support for some
more STM32 series.
