### PR TITLE
Bluetooth: Mesh: Friend re-encrypt regressions

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -350,7 +350,12 @@ static int unseg_app_sdu_unpack(struct bt_mesh_friend *frnd,
 				struct unseg_app_sdu_meta *meta)
 {
 	uint16_t app_idx = FRIEND_ADV(buf)->app_idx;
-	struct bt_mesh_net_rx net;
+	struct bt_mesh_net_rx net = {
+		.ctx = {
+			.app_idx = app_idx,
+			.net_idx = frnd->subnet->net_idx,
+		},
+	};
 	int err;
 
 	meta->subnet = frnd->subnet;
@@ -426,6 +431,8 @@ static int unseg_app_sdu_prepare(struct bt_mesh_friend *frnd,
 	if (meta.crypto.seq_num == bt_mesh.seq) {
 		return 0;
 	}
+
+	BT_DBG("Re-encrypting friend pdu");
 
 	err = unseg_app_sdu_decrypt(frnd, buf, &meta);
 	if (err) {

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -432,13 +432,16 @@ static int unseg_app_sdu_prepare(struct bt_mesh_friend *frnd,
 		return 0;
 	}
 
-	BT_DBG("Re-encrypting friend pdu");
+	BT_DBG("Re-encrypting friend pdu (SeqNum %06x -> %06x)",
+	       meta.crypto.seq_num, bt_mesh.seq);
 
 	err = unseg_app_sdu_decrypt(frnd, buf, &meta);
 	if (err) {
 		BT_WARN("Decryption failed! %d", err);
 		return err;
 	}
+
+	meta.crypto.seq_num = bt_mesh.seq;
 
 	err = unseg_app_sdu_encrypt(frnd, buf, &meta);
 	if (err) {


### PR DESCRIPTION
#28511 introduced a regression in the mechanism for re-encrypting unsegmented app messages from a Friend to one of its LPNs.
This PR fixes two issues related to this:
-  Bluetooth: Mesh: Initialize msg_ctx when re-encrypting friend msg
   Set app_idx and net_idx in the msg_ctx before calling bt_mesh_keys_resolve when re-encrypting friend messages, as they'll be referenced inside the function.
-  Bluetooth: Mesh: Update seqnum when re-encrypting for friend
   Sets the sequence number when re-encrypting messages from the friend to the lpn.

Fixes #32033.