### PR TITLE
boards: Fix ram/flash values in nrf5340dk_nrf5340_cpuapp

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
@@ -6,8 +6,8 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
-ram: 64
-flash: 256
+ram: 448
+flash: 1024
 supported:
   - gpio
   - i2c


### PR DESCRIPTION
Increase the size of ram/flash given in nrf5340dk_nrf5340_cpuapp.yaml
so they match the actual numbers which are available for default
tests and samples.

Fixes #32045

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>