### PR TITLE
drivers: sensor: dps310 fix out of bounds write

### DIFF
--- a/drivers/sensor/dps310/dps310.c
+++ b/drivers/sensor/dps310/dps310.c
@@ -625,7 +625,7 @@ static int dps310_init(const struct device *dev)
 	uint8_t tmp_coef_srce = 0;
 
 	res = i2c_write_read(data->i2c_master, config->i2c_addr,
-			     &REG_ADDR_COEF_SRCE, 1, &tmp_coef_srce, 18);
+			     &REG_ADDR_COEF_SRCE, 1, &tmp_coef_srce, sizeof(tmp_coef_srce));
 	if (res < 0) {
 		LOG_WRN("I2C error: %d", res);
 		return -EIO;


### PR DESCRIPTION
Fixes a copy-paste error which results in an out of bounds write on the stack.

This should probably be marked for backporting to all supported releases with this driver.