### PR TITLE
Fix race and deadlock in SMP context switch paths

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -189,16 +189,6 @@ static inline void z_reset_thread_states(struct k_thread *thread,
 	thread->base.thread_state &= ~states;
 }
 
-static inline void z_mark_thread_as_queued(struct k_thread *thread)
-{
-	z_set_thread_states(thread, _THREAD_QUEUED);
-}
-
-static inline void z_mark_thread_as_not_queued(struct k_thread *thread)
-{
-	z_reset_thread_states(thread, _THREAD_QUEUED);
-}
-
 static inline bool z_is_under_prio_ceiling(int prio)
 {
 	return prio >= CONFIG_PRIORITY_CEILING;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -66,6 +66,7 @@ void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);
 void z_thread_single_abort(struct k_thread *thread);
 FUNC_NORETURN void z_self_abort(void);
+void z_requeue_current(struct k_thread *curr);
 
 static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, k_timeout_t timeout)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -941,6 +941,8 @@ void *z_get_next_switch_handle(void *interrupted)
 	z_check_stack_sentinel();
 
 #ifdef CONFIG_SMP
+	void *ret = NULL;
+
 	LOCKED(&sched_spinlock) {
 		struct k_thread *old_thread = _current, *new_thread;
 
@@ -968,12 +970,15 @@ void *z_get_next_switch_handle(void *interrupted)
 #endif
 		}
 		old_thread->switch_handle = interrupted;
+		ret = new_thread->switch_handle;
+		new_thread->switch_handle = NULL;
 	}
+	return ret;
 #else
 	_current->switch_handle = interrupted;
 	set_current(z_get_next_ready_thread());
-#endif
 	return _current->switch_handle;
+#endif
 }
 #endif
 


### PR DESCRIPTION
Two bugs found by one exerciser in #28105 that repeatedly hammered the thread preemption paths.

The first was simple enough, some needless defensive coding (not wanting to change a preexisting switch handle) could be seen by code spinning in wait_for_switch() as a completed context switch and cause the other to start running the current thread before it had spilled its context.

The second was an even rarer (and more interesting) deadlock exposed when that was fixed, in a similar area of code.  Crazy timing (possible seemingly only under qemu) could lead to two CPUs trying to run **each other's** active threads, and spinning forever waiting for the other CPU to context switch.

Fixes #28105