### PR TITLE
guiconfig: fix search function

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -60,6 +60,7 @@ $srctree is supported through Kconfiglib.
 
 import errno
 import os
+import re
 import sys
 
 _PY2 = sys.version_info[0] < 3


### PR DESCRIPTION
The _update_jump_to_matches() function used when searching from the
jump dialog is using the re module without importing it. Fix that.

Fixes: #32095
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>