### PR TITLE
doc: release-notes-2.5: boards and SoCs: x86 ehl_crb acrn_ehl_crb

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -215,6 +215,7 @@ Boards & SoC Support
 * Added support for these SoC series:
 
   * Cypress PSoC-63
+  * Intel Elkhart Lake
 
 * Made these changes in other SoC series:
 
@@ -228,6 +229,11 @@ Boards & SoC Support
 * Added support for these ARM boards:
 
   * Cypress CY8CKIT_062_BLE board
+
+*  Added support for these x86 boards:
+
+  * Elkhart Lake CRB board
+  * ACRN configuration on Elkhart Lake CRB board
 
 * Added support for these SPARC boards:
 


### PR DESCRIPTION
This adds a few lines for newly added board and SoC defintions
for Elkhart Lake (ehl_crb) and ACRN configurations (acrn_ehl_crb).

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>