### PR TITLE
doc: release-notes-2.5: Power management contents

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -759,6 +759,14 @@ Libraries / Subsystems
 
 * Power management
 
+  * Use a consistent naming convention using **pm_** namespace.
+  * Overhaul power states. New states :c:enum:`pm_state` are more
+    meaningful and ACPI alike.
+  * Move residency information and supported power states to devicetree
+    and remove related Kconfig options.
+  * New power state changes notification API :c:struct:`pm_notifier`
+  * Cleanup build options.
+
 * Logging
 
 * LVGL


### PR DESCRIPTION
Add some high-level bullets about power management changes in 2.5.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>