### PR TITLE
renode: fix dependencies for renode platforms

### DIFF
--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -17,5 +17,6 @@ add_custom_target(run
   ${RENODE_FLAGS}
   -e '$$bin=@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; s'
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  DEPENDS ${logical_target_for_zephyr_elf}
   USES_TERMINAL
   )


### PR DESCRIPTION
Make renode platforms run target depend on zephyr ELF.