### PR TITLE
devicetree: fix child binding registry

### DIFF
--- a/dts/bindings/test/vnd,i2c-mux.yaml
+++ b/dts/bindings/test/vnd,i2c-mux.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  I2C mux
+
+  This is an I2C device that is also (multiple) I2C controllers. We
+  model this as a node which is an I2C device, whose children are I2C
+  controllers, and whose grandchildren are therefore I2C devices.
+
+compatible: "vnd,i2c-mux"
+
+include: "i2c-device.yaml"
+
+child-binding:
+  description: I2C mux controller
+  compatible: "vnd,i2c-mux-controller"
+  include: "i2c-controller.yaml"

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -161,6 +161,34 @@
 				reg = <0x11>;
 				label = "TEST_EXPANDER_I2C";
 			};
+
+			test_i2c_mux: i2c-mux@12 {
+				compatible = "vnd,i2c-mux";
+				label = "I2C_MUX";
+				reg = <0x12>;
+				i2c-mux-ctlr-1 {
+					compatible = "vnd,i2c-mux-controller";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					label = "I2C_MUX_CTLR_1";
+					test_muxed_i2c_dev_1: muxed-i2c-dev@10 {
+						compatible = "vnd,i2c-device";
+						status = "disabled";
+						reg = <0x10>;
+					};
+				};
+				i2c-mux-ctlr-2 {
+					compatible = "vnd,i2c-mux-controller";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					label = "I2C_MUX_CTLR_1";
+					test_muxed_i2c_dev_2: muxed-i2c-dev@10 {
+						compatible = "vnd,i2c-device";
+						status = "disabled";
+						reg = <0x10>;
+					};
+				};
+			};
 		};
 
 		test_i2c_no_reg: i2c {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -48,6 +48,12 @@
 #define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
 #define TEST_I2C_BUS DT_BUS(TEST_I2C_DEV)
 
+#define TEST_I2C_MUX DT_NODELABEL(test_i2c_mux)
+#define TEST_I2C_MUX_CTLR_1 DT_CHILD(TEST_I2C_MUX, i2c_mux_ctlr_1)
+#define TEST_I2C_MUX_CTLR_2 DT_CHILD(TEST_I2C_MUX, i2c_mux_ctlr_2)
+#define TEST_MUXED_I2C_DEV_1 DT_NODELABEL(test_muxed_i2c_dev_1)
+#define TEST_MUXED_I2C_DEV_2 DT_NODELABEL(test_muxed_i2c_dev_2)
+
 #define TEST_SPI DT_NODELABEL(test_spi)
 
 #define TEST_SPI_DEV_0 DT_PATH(test, spi_33334444, test_spi_dev_0)
@@ -299,6 +305,12 @@ static void test_bus(void)
 
 	zassert_equal(DT_SPI_DEV_HAS_CS_GPIOS(TEST_SPI_DEV_0), 1, "");
 	zassert_equal(DT_SPI_DEV_HAS_CS_GPIOS(TEST_SPI_DEV_NO_CS), 0, "");
+
+	/* Test a nested I2C bus using vnd,i2c-mux. */
+	zassert_true(DT_SAME_NODE(TEST_I2C_MUX_CTLR_1,
+				  DT_BUS(TEST_MUXED_I2C_DEV_1)), "");
+	zassert_true(DT_SAME_NODE(TEST_I2C_MUX_CTLR_2,
+				  DT_BUS(TEST_MUXED_I2C_DEV_2)), "");
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_spi_device_2


### PR DESCRIPTION
Whenever a child-binding: dict has a compatible, we ought to make that available in EDT._compat2binding. If we don't, we can't look it up later.

This has adverse effects like missing child bindings which describe buses.

Fix it.

Fixes: #32071