### PR TITLE
dts/arm: npcx: move def_lvol_io_list node from board dts to dtsi file.

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -34,17 +34,6 @@
 		};
 	};
 
-	def_lvol_io_list {
-		compatible = "nuvoton,npcx-lvolctrl-def";
-		/*
-		 * Put low-voltage io pads into "lvol_io_pads" property if the
-		 * detection level of them is 1.8V, For example, if the bus
-		 * voltage of i2c1_0 port is 1.8V, this property should be:
-		 * lvol_io_pads = <&lvol_io90 &lvol_io87>;
-		 */
-		lvol_io_pads = <>;
-	};
-
 };
 
 /* Overwirte default device properties with overlays in board dt file here. */

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -93,6 +93,16 @@
 			   &alta_no_kso17_sl>;
 	};
 
+	def_lvol_io_list {
+		compatible = "nuvoton,npcx-lvolctrl-def";
+		/* Put low-voltage io pads into "lvol_io_pads" property if the
+		 * detection level of them is 1.8V, For example, if the bus
+		 * voltage of i2c1_0 port is 1.8V, this property should be:
+		 * lvol_io_pads = <&lvol_io90 &lvol_io87>;
+		 */
+		lvol_io_pads = <>;
+	};
+
 	soc {
 		compatible = "syscon";
 


### PR DESCRIPTION
This CL moves def_lvol_io_list device-tree node from npcx7m6fb_evb.dts
to npcx7m6fb.dtsi. The benefit of it is that we needn't add
def_lvol_io_list node for each board dts file if there are no 1.8V
io-pads on the platform. If so, add them in the specific board dts file
directly.

Signed-off-by: Fabio Baltieri <fabiobaltieri@google.com>
Signed-off-by: Mulin Chao <mlchao@nuvoton.com>