### PR TITLE
aarch64: linker: Align end symbols

### DIFF
--- a/include/arch/arm/aarch64/scripts/linker.ld
+++ b/include/arch/arm/aarch64/scripts/linker.ld
@@ -294,6 +294,7 @@ SECTIONS
 
     /* Define linker symbols */
 
+    MMU_ALIGN;
     _image_ram_end = .;
     _end = .; /* end of image */
     z_mapped_end = .;


### PR DESCRIPTION
The end symbols and especially z_mapped_end must be aligned to the MMU
page size.

Otherwise we can hit an assert under certain circumstances.