### PR TITLE
power: add missing header dependency

### DIFF
--- a/include/power/power.h
+++ b/include/power/power.h
@@ -10,6 +10,7 @@
 #include <zephyr/types.h>
 #include <sys/slist.h>
 #include <power/power_state.h>
+#include <toolchain.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Inline functions reference a __fallthrough macro that is toolchain
specific.  Include the header that provides that macro.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>