### PR TITLE
Bluetooth: host: Fix pairing failed when peer cannot establish required security

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1915,8 +1915,12 @@ static int smp_error(struct bt_smp *smp, uint8_t reason)
 	struct bt_smp_pairing_fail *rsp;
 	struct net_buf *buf;
 
-	/* reset context and report */
-	smp_pairing_complete(smp, reason);
+	if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING) ||
+	    atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING) ||
+	    atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ)) {
+		/* reset context and report */
+		smp_pairing_complete(smp, reason);
+	}
 
 	buf = smp_create_pdu(smp, BT_SMP_CMD_PAIRING_FAIL, sizeof(*rsp));
 	if (!buf) {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2808,6 +2808,7 @@ bool bt_smp_request_ltk(struct bt_conn *conn, uint64_t rand, uint16_t ediv, uint
 				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
 		}
 
+		atomic_set_bit(smp->flags, SMP_FLAG_ENC_PENDING);
 		return true;
 	}
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1807,6 +1807,26 @@ static void smp_reset(struct bt_smp *smp)
 	}
 }
 
+static uint8_t hci_err_get(enum bt_security_err err)
+{
+	switch (err) {
+	case BT_SECURITY_ERR_SUCCESS:
+		return BT_HCI_ERR_SUCCESS;
+	case BT_SECURITY_ERR_AUTH_FAIL:
+		return BT_HCI_ERR_AUTH_FAIL;
+	case BT_SECURITY_ERR_PIN_OR_KEY_MISSING:
+		return BT_HCI_ERR_PIN_OR_KEY_MISSING;
+	case BT_SECURITY_ERR_PAIR_NOT_SUPPORTED:
+		return BT_HCI_ERR_PAIRING_NOT_SUPPORTED;
+	case BT_SECURITY_ERR_PAIR_NOT_ALLOWED:
+		return BT_HCI_ERR_PAIRING_NOT_ALLOWED;
+	case BT_SECURITY_ERR_INVALID_PARAM:
+		return BT_HCI_ERR_INVALID_PARAM;
+	default:
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+}
+
 /* Note: This function not only does set the status but also calls smp_reset
  * at the end which clears any flags previously set.
  */
@@ -1852,7 +1872,9 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		}
 
 		if (!atomic_test_bit(smp->flags, SMP_FLAG_KEYS_DISTR)) {
-			bt_conn_security_changed(conn, status, security_err);
+			bt_conn_security_changed(conn,
+						 hci_err_get(security_err),
+						 security_err);
 		}
 
 		if (bt_auth && bt_auth->pairing_failed) {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4506,6 +4506,13 @@ static void bt_smp_disconnected(struct bt_l2cap_chan *chan)
 
 	k_delayed_work_cancel(&smp->work);
 
+	if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING) ||
+	    atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING) ||
+	    atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ)) {
+		/* reset context and report */
+		smp_pairing_complete(smp, BT_SMP_ERR_UNSPECIFIED);
+	}
+
 	if (keys) {
 		/*
 		 * If debug keys were used for pairing remove them.

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -411,7 +411,7 @@ static uint8_t get_pair_method(struct bt_smp *smp, uint8_t remote_io)
 #endif
 }
 
-static enum bt_security_err auth_err_get(uint8_t smp_err)
+static enum bt_security_err security_err_get(uint8_t smp_err)
 {
 	switch (smp_err) {
 	case BT_SMP_ERR_PASSKEY_ENTRY_FAILED:
@@ -1003,7 +1003,7 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 
 		if (bt_auth && bt_auth->pairing_failed) {
 			bt_auth->pairing_failed(smp->chan.chan.conn,
-						auth_err_get(status));
+						security_err_get(status));
 		}
 	} else {
 		bool bond_flag = atomic_test_bit(smp->flags, SMP_FLAG_BOND);
@@ -1838,7 +1838,7 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 			bt_auth->pairing_complete(conn, bond_flag);
 		}
 	} else {
-		uint8_t auth_err = auth_err_get(status);
+		enum bt_security_err security_err = security_err_get(status);
 
 		/* Clear the key pool entry in case of pairing failure if the
 		 * keys already existed before the pairing procedure or the
@@ -1852,11 +1852,11 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 		}
 
 		if (!atomic_test_bit(smp->flags, SMP_FLAG_KEYS_DISTR)) {
-			bt_conn_security_changed(conn, status, auth_err);
+			bt_conn_security_changed(conn, status, security_err);
 		}
 
 		if (bt_auth && bt_auth->pairing_failed) {
-			bt_auth->pairing_failed(conn, auth_err);
+			bt_auth->pairing_failed(conn, security_err);
 		}
 	}
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2653,6 +2653,13 @@ static struct bt_conn_auth_cb auth_cb_oob = {
 	.bond_deleted = bond_deleted,
 };
 
+static struct bt_conn_auth_cb auth_cb_status = {
+	.pairing_failed = auth_pairing_failed,
+	.pairing_complete = auth_pairing_complete,
+#if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
+	.pairing_accept = pairing_accept,
+#endif
+};
 
 static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -2670,6 +2677,8 @@ static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 		err = bt_conn_auth_cb_register(&auth_cb_confirm);
 	} else if (!strcmp(argv[1], "oob")) {
 		err = bt_conn_auth_cb_register(&auth_cb_oob);
+	} else if (!strcmp(argv[1], "status")) {
+		err = bt_conn_auth_cb_register(&auth_cb_status);
 	} else if (!strcmp(argv[1], "none")) {
 		err = bt_conn_auth_cb_register(NULL);
 	} else {
@@ -3031,7 +3040,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(connections, NULL, HELP_NONE, cmd_connections, 1, 0),
 	SHELL_CMD_ARG(auth, NULL,
 		      "<method: all, input, display, yesno, confirm, "
-		      "oob, none>",
+		      "oob, status, none>",
 		      cmd_auth, 2, 0),
 	SHELL_CMD_ARG(auth-cancel, NULL, HELP_NONE, cmd_auth_cancel, 1, 0),
 	SHELL_CMD_ARG(auth-passkey, NULL, "<passkey>", cmd_auth_passkey, 2, 0),

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -309,6 +309,32 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 #endif
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
+static const char *security_err_str(enum bt_security_err err)
+{
+	switch (err) {
+	case BT_SECURITY_ERR_SUCCESS:
+		return "Success";
+	case BT_SECURITY_ERR_AUTH_FAIL:
+		return "Authentication failure";
+	case BT_SECURITY_ERR_PIN_OR_KEY_MISSING:
+		return "PIN or key missing";
+	case BT_SECURITY_ERR_OOB_NOT_AVAILABLE:
+		return "OOB not available";
+	case BT_SECURITY_ERR_AUTH_REQUIREMENT:
+		return "Authentication requirements";
+	case BT_SECURITY_ERR_PAIR_NOT_SUPPORTED:
+		return "Pairing not supported";
+	case BT_SECURITY_ERR_PAIR_NOT_ALLOWED:
+		return "Pairing not allowed";
+	case BT_SECURITY_ERR_INVALID_PARAM:
+		return "Invalid parameters";
+	case BT_SECURITY_ERR_UNSPECIFIED:
+		return "Unspecified";
+	default:
+		return "Unknown";
+	}
+}
+
 static void security_changed(struct bt_conn *conn, bt_security_t level,
 			     enum bt_security_err err)
 {
@@ -320,8 +346,9 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 		shell_print(ctx_shell, "Security changed: %s level %u", addr,
 			    level);
 	} else {
-		shell_print(ctx_shell, "Security failed: %s level %u reason %d",
-			    addr, level, err);
+		shell_print(ctx_shell, "Security failed: %s level %u "
+			    "reason: %s (%d)",
+			    addr, level, security_err_str(err), err);
 	}
 }
 #endif
@@ -2481,15 +2508,14 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 		    addr);
 }
 
-static void auth_pairing_failed(struct bt_conn *conn,
-				enum bt_security_err reason)
+static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing failed with %s reason %d", addr,
-		    reason);
+	shell_print(ctx_shell, "Pairing failed with %s reason: %s (%d)", addr,
+		    security_err_str(err), err);
 }
 
 #if defined(CONFIG_BT_BREDR)


### PR DESCRIPTION
This PR fixes the issue where the pairing failed callback was not called when the pairing procedure could not establish the required security level because the peer did not support it, either through pairing method not supporting MITM or LE Secure Connections.
In addition the failure of this pairing procedure could be terminated earlier, instead of doing this after the connection has been encrypted with weaker security keys that what was required.

Fixes: #31607

In addition the following issues was discovered and fixed in this PR:
- Fix pairing procedure not completed when disconnected during pairing, leaves a key entry.
- Fix missing encryption pending flag with LE SC Bond.
- Fix pairing failed and security changed callbacks called when receiving unexpected SMP PDUs.
- Fix wrong error code type passed to security changed, passed SMP error
code instead of HCI error code.
