### PR TITLE
linker: tool-gcc: remove gratuitous define

### DIFF
--- a/include/linker/linker-tool-gcc.h
+++ b/include/linker/linker-tool-gcc.h
@@ -131,8 +131,6 @@
 #define SECTION_DATA_PROLOGUE(name, options, align) name options : align
 #endif
 
-#define SORT_BY_NAME(x) SORT(x)
-
 #define COMMON_SYMBOLS *(COMMON)
 
 #endif /* ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_GCC_H_ */


### PR DESCRIPTION
In binutils `SORT` is an alias for `SORT_BY_NAME`.  Don't confuse people by replacing explicit use of the actual directive with an alias for that same directive.

(The define makes the generated linker scripts inconsistent with the text provided in, for example, `common-rom.ld`, forcing the maintainer to [search the binutils documentation](https://sourceware.org/binutils/docs-2.29/ld/Input-Section-Wildcards.html#index-SORT) to figure out what `SORT` means, and then the toolchain header to figure out why it appeared at all.)