### PR TITLE
Coding guideline: Fixing code violations 21.2 Rule

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -403,19 +403,19 @@ static inline char *log_strdup(const char *str)
 			LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__));     \
 									      \
 	static const struct log_source_const_data *			      \
-		__log_current_const_data __unused =			      \
+		log_current_const_data __unused =			      \
 			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
 			&LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)) :     \
 			NULL;						      \
 									      \
 	static struct log_source_dynamic_data *				      \
-		__log_current_dynamic_data __unused =			      \
+		log_current_dynamic_data __unused =			      \
 			(_LOG_LEVEL_RESOLVE(__VA_ARGS__) &&		      \
 			IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ?	      \
 			&LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__)) :   \
 			NULL;						      \
 									      \
-	static const uint32_t __log_level __unused =			      \
+	static const uint32_t log_level __unused =			      \
 					_LOG_LEVEL_RESOLVE(__VA_ARGS__)
 
 /**
@@ -425,7 +425,7 @@ static inline char *log_strdup(const char *str)
  * @param level Level used in file or in function.
  *
  */
-#define LOG_LEVEL_SET(level) static const uint32_t __log_level __unused = \
+#define LOG_LEVEL_SET(level) static const uint32_t log_level __unused = \
 				Z_LOG_RESOLVED_LEVEL(level, 0)
 
 /**

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -109,7 +109,7 @@ extern "C" {
 #define LOG_CONST_ID_GET(_addr) \
 	Z_LOG_EVAL(\
 	  CONFIG_LOG,\
-	  (__log_level ? \
+	  (log_level ? \
 	  log_const_source_id((const struct log_source_const_data *)_addr) : \
 	  0),\
 	  (0)\
@@ -119,15 +119,15 @@ extern "C" {
  * @def LOG_CURRENT_MODULE_ID
  * @brief Macro for getting ID of current module.
  */
-#define LOG_CURRENT_MODULE_ID() (__log_level != 0 ? \
-	log_const_source_id(__log_current_const_data) : 0U)
+#define LOG_CURRENT_MODULE_ID() (log_level != 0 ? \
+	log_const_source_id(log_current_const_data) : 0U)
 
 /**
  * @def LOG_CURRENT_DYNAMIC_DATA_ADDR
  * @brief Macro for getting address of dynamic structure of current module.
  */
-#define LOG_CURRENT_DYNAMIC_DATA_ADDR()	(__log_level ? \
-	__log_current_dynamic_data : (struct log_source_dynamic_data *)0U)
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR()	(log_level ? \
+	log_current_dynamic_data : (struct log_source_dynamic_data *)0U)
 
 /** @brief Macro for getting ID of the element of the section.
  *
@@ -136,7 +136,7 @@ extern "C" {
 #define LOG_DYNAMIC_ID_GET(_addr) \
 	Z_LOG_EVAL(\
 	  CONFIG_LOG,\
-	  (__log_level ? \
+	  (log_level ? \
 	  log_dynamic_source_id((struct log_source_dynamic_data *)_addr) : 0),\
 	  (0)\
 	)
@@ -224,7 +224,7 @@ extern "C" {
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
 	((IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) == false) &&		    \
-	(_level <= __log_level) &&					    \
+	(_level <= log_level) &&					    \
 	(_level <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))


### PR DESCRIPTION
A reserved identifier or reserved macro name shall
not be declared.

Changes are related to removing all the identifiers
or macro names begining with underscores.

Signed-off-by: Spoorthy Priya Yerabolu <spoorthy.priya.yerabolu@intel.com>