### PR TITLE
devicetree-based device definitions and dependency representations reboot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,19 @@ if(CONFIG_GEN_ISR_TABLES)
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)
 endif()
 
+# dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+# gen_handles.py
+add_custom_command(
+  OUTPUT dev_handles.c
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/gen_handles.py
+  --output-source dev_handles.c
+  --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+  )
+set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+
 if(CONFIG_CODE_DATA_RELOCATION)
   # @Intent: Linker script to relocate .text, data and .bss sections
   toolchain_ld_relocation()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -503,6 +503,7 @@
 /scripts/pylib/twister/expr_parser.py     @nashif
 /scripts/schemas/twister/                 @nashif
 /scripts/gen_app_partitions.py            @dcpleung @nashif
+/scripts/gen_handles.py                   @pabigot
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif

--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -151,9 +151,16 @@ is skipped.
 Final binary
 ============
 
-In some configurations, the binary from the previous stage is
-incomplete, with empty and/or placeholder sections that must be filled
-in by, essentially, reflection. When :ref:`usermode_api` is enabled:
+The binary from the previous stage is incomplete, with empty and/or
+placeholder sections that must be filled in by, essentially, reflection.
+
+Device dependencies
+   The *gen_handles.py* script scans the first-pass binary to determine
+   relationships between devices that were recorded from devicetree data,
+   and replaces the encoded relationships with values that are optimized to
+   locate the devices actually present in the application.
+
+When :ref:`usermode_api` is enabled:
 
 Kernel object hashing
    The *gen_kobject_list.py* scans the *ELF DWARF*
@@ -199,6 +206,15 @@ The following is a detailed description of the scripts used during the build pro
 ========================================
 
 .. include:: ../../../scripts/gen_syscalls.py
+   :start-after: """
+   :end-before: """
+
+.. _gen_handles.py:
+
+:zephyr_file:`scripts/gen_handles.py`
+==========================================
+
+.. include:: ../../../scripts/gen_handles.py
    :start-after: """
    :end-before: """
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -180,3 +180,14 @@
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	Z_ITERABLE_SECTION_ROM(tracing_backend, 4)
+
+	SECTION_DATA_PROLOGUE(device_handles,,)
+	{
+		__device_handles_start = .;
+#ifdef LINKER_PASS2
+		KEEP(*(SORT(.__device_handles_pass2*)));
+#else /* LINKER_PASS2 */
+		KEEP(*(SORT(.__device_handles_pass1*)));
+#endif /* LINKER_PASS2 */
+		__device_handles_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -86,5 +86,9 @@ GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 /* size of the device structure. Used by linker scripts */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(const struct device));
 
+/* member offsets in the device structure. Used in image post-processing */
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,
+		 offsetof(struct device, handles));
+
 /* LCOV_EXCL_STOP */
 #endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_ */

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2020 Nordic Semiconductor NA
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Translate generic handles into ones optimized for the application.
+
+Immutable device data includes information about dependencies,
+e.g. that a particular sensor is controlled through a specific I2C bus
+and that it signals event on a pin on a specific GPIO controller.
+This information is encoded in the first-pass binary using identifiers
+derived from the devicetree.  This script extracts those identifiers
+and replaces them with ones optimized for use with the devices
+actually present.
+
+For example the sensor might have a first-pass handle defined by its
+devicetree ordinal 52, with the I2C driver having ordinal 24 and the
+GPIO controller ordinal 14.  The runtime ordinal is the index of the
+corresponding device in the static devicetree array, which might be 6,
+5, and 3, respectively.
+
+The output is a C source file that provides alternative definitions
+for the array contents referenced from the immutable device objects.
+In the final link these definitions supersede the ones in the
+driver-specific object file.
+"""
+
+import sys
+import argparse
+import os
+import struct
+import pickle
+from distutils.version import LooseVersion
+
+import elftools
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+import elftools.elf.enums
+
+if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
+
+scr = os.path.basename(sys.argv[0])
+
+def debug(text):
+    if not args.verbose:
+        return
+    sys.stdout.write(scr + ": " + text + "\n")
+
+def parse_args():
+    global args
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-k", "--kernel", required=True,
+                        help="Input zephyr ELF binary")
+    parser.add_argument("-o", "--output-source", required=True,
+            help="Output source file")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print extra debugging information")
+    args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
+
+
+def symbol_data(elf, sym):
+    addr = sym.entry.st_value
+    len = sym.entry.st_size
+    for section in elf.iter_sections():
+        start = section['sh_addr']
+        end = start + section['sh_size']
+
+        if (start <= addr) and (addr + len) <= end:
+            offset = addr - section['sh_addr']
+            return bytes(section.data()[offset:offset + len])
+
+def symbol_handle_data(elf, sym):
+    data = symbol_data(elf, sym)
+    if data:
+        format = "<" if elf.little_endian else ">"
+        format += "%uh" % (len(data) / 2)
+        return struct.unpack(format, data)
+
+# These match the corresponding constants in <device.h>
+DEVICE_HANDLE_SEP = -32768
+DEVICE_HANDLE_ENDS = 32767
+def handle_name(hdl):
+    if hdl == DEVICE_HANDLE_SEP:
+        return "DEVICE_HANDLE_SEP"
+    if hdl == DEVICE_HANDLE_ENDS:
+        return "DEVICE_HANDLE_ENDS"
+    if hdl == 0:
+        return "DEVICE_HANDLE_NULL"
+    return str(int(hdl))
+
+class Device:
+    """
+    Represents information about a device object and its references to other objects.
+    """
+    def __init__(self, elf, ld_constants, sym, addr):
+        self.elf = elf
+        self.ld_constants = ld_constants
+        self.sym = sym
+        self.addr = addr
+        # Point to the handles instance associated with the device;
+        # assigned by correlating the device struct handles pointer
+        # value with the addr of a Handles instance.
+        self.__handles = None
+
+    @property
+    def obj_handles(self):
+        """
+        Returns the value from the device struct handles field, pointing to the
+        array of handles for devices this device depends on.
+        """
+        if self.__handles is None:
+            data = symbol_data(self.elf, self.sym)
+            format = "<" if self.elf.little_endian else ">"
+            if self.elf.elfclass == 32:
+                format += "I"
+                size = 4
+            else:
+                format += "Q"
+                size = 8
+            offset = self.ld_constants["DEVICE_STRUCT_HANDLES_OFFSET"]
+            self.__handles = struct.unpack(format, data[offset:offset + size])[0]
+        return self.__handles
+
+class Handles:
+    def __init__(self, sym, addr, handles, node):
+        self.sym = sym
+        self.addr = addr
+        self.handles = handles
+        self.node = node
+        self.dep_ord = None
+        self.dev_deps = None
+        self.ext_deps = None
+
+def main():
+    parse_args()
+
+    assert args.kernel, "--kernel ELF required to extract data"
+    elf = ELFFile(open(args.kernel, "rb"))
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
+
+    devices = []
+    handles = []
+    # Leading _ are stripped from the stored constant key
+    want_constants = set(["__device_start",
+                          "_DEVICE_STRUCT_SIZEOF",
+                          "_DEVICE_STRUCT_HANDLES_OFFSET"])
+    ld_constants = dict()
+
+    for section in elf.iter_sections():
+        if isinstance(section, SymbolTableSection):
+            for sym in section.iter_symbols():
+                if sym.name in want_constants:
+                    ld_constants[sym.name.lstrip("_")] = sym.entry.st_value
+                    continue
+                if sym.entry.st_info.type != 'STT_OBJECT':
+                    continue
+                if sym.name.startswith("__device"):
+                    addr = sym.entry.st_value
+                    if sym.name.startswith("__device_"):
+                        devices.append(Device(elf, ld_constants, sym, addr))
+                        debug("device %s" % (sym.name,))
+                    elif sym.name.startswith("__devicehdl_"):
+                        hdls = symbol_handle_data(elf, sym)
+
+                        # The first element of the hdls array is the dependency
+                        # ordinal of the device, which identifies the devicetree
+                        # node.
+                        node = edt.dep_ord2node[hdls[0]] if (hdls and hdls[0] != 0) else None
+                        handles.append(Handles(sym, addr, hdls, node))
+                        debug("handles %s %d %s" % (sym.name, hdls[0] if hdls else -1, node))
+
+    assert len(want_constants) == len(ld_constants), "linker map data incomplete"
+
+    devices = sorted(devices, key = lambda k: k.sym.entry.st_value)
+
+    device_start_addr = ld_constants["device_start"]
+    device_size = 0
+
+    assert len(devices) == len(handles), 'mismatch devices and handles'
+
+    used_nodes = set()
+    for handle in handles:
+        for device in devices:
+            if handle.addr == device.obj_handles:
+                handle.device = device
+                break
+        device = handle.device
+        assert device, 'no device for %s' % (handle.sym.name,)
+
+        device.handle = handle
+
+        if device_size == 0:
+            device_size = device.sym.entry.st_size
+
+        # The device handle is one plus the ordinal of this device in
+        # the device table.
+        device.dev_handle = 1 + int((device.sym.entry.st_value - device_start_addr) / device_size)
+        debug("%s dev ordinal %d" % (device.sym.name, device.dev_handle))
+
+        n = handle.node
+        if n is not None:
+            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_handle, ' ; '.join(str(_) for _ in handle.handles)))
+            used_nodes.add(n)
+            n.__device = device
+        else:
+            debug("orphan %d" % (device.dev_handle,))
+        hv = handle.handles
+        hvi = 1
+        handle.dev_deps = []
+        handle.ext_deps = []
+        deps = handle.dev_deps
+        while True:
+            h = hv[hvi]
+            if h == DEVICE_HANDLE_ENDS:
+                break
+            if h == DEVICE_HANDLE_SEP:
+                deps = handle.ext_deps
+            else:
+                deps.append(h)
+                n = edt
+            hvi += 1
+
+    # Compute the dependency graph induced from the full graph restricted to the
+    # the nodes that exist in the application.  Note that the edges in the
+    # induced graph correspond to paths in the full graph.
+    root = edt.dep_ord2node[0]
+    assert root not in used_nodes
+
+    for sn in used_nodes:
+        # Where we're storing the final set of nodes: these are all used
+        sn.__depends = set()
+
+        deps = set(sn.depends_on)
+        debug("\nNode: %s\nOrig deps:\n\t%s" % (sn.path, "\n\t".join([dn.path for dn in deps])))
+        while len(deps) > 0:
+            dn = deps.pop()
+            if dn in used_nodes:
+                # this is used
+                sn.__depends.add(dn)
+            elif dn != root:
+                # forward the dependency up one level
+                for ddn in dn.depends_on:
+                    deps.add(ddn)
+        debug("final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in sn.__depends])))
+
+    with open(args.output_source, "w") as fp:
+        fp.write('#include <device.h>\n')
+        fp.write('#include <toolchain.h>\n')
+
+        for dev in devices:
+            hs = dev.handle
+            assert hs, "no hs for %s" % (dev.sym.name,)
+            dep_paths = []
+            ext_paths = []
+            hdls = []
+
+            sn = hs.node
+            if sn:
+                hdls.extend(dn.__device.dev_handle for dn in sn.__depends)
+                for dn in sn.depends_on:
+                    if dn in sn.__depends:
+                        dep_paths.append(dn.path)
+                    else:
+                        dep_paths.append('(%s)' % dn.path)
+            if len(hs.ext_deps) > 0:
+                # TODO: map these to something smaller?
+                ext_paths.extend(map(str, hs.ext_deps))
+                hdls.append(DEVICE_HANDLE_SEP)
+                hdls.extend(hs.ext_deps)
+
+            # When CONFIG_USERSPACE is enabled the pre-built elf is
+            # also used to get hashes that identify kernel objects by
+            # address.  We can't allow the size of any object in the
+            # final elf to change.
+            while len(hdls) < len(hs.handles):
+                hdls.append(DEVICE_HANDLE_ENDS)
+            assert len(hdls) == len(hs.handles), "%s handle overflow" % (dev.sym.name,)
+
+            lines = [
+                '',
+                '/* %d : %s:' % (dev.dev_handle, (sn and sn.path) or "sysinit"),
+            ]
+
+            if len(dep_paths) > 0:
+                lines.append(' * - %s' % ('\n * - '.join(dep_paths)))
+            if len(ext_paths) > 0:
+                lines.append(' * + %s' % ('\n * + '.join(ext_paths)))
+
+            lines.extend([
+                ' */',
+                'const device_handle_t __aligned(2) __attribute__((__section__(".__device_handles_pass2")))',
+                '%s[] = { %s };' % (hs.sym.name, ', '.join([handle_name(_h) for _h in hdls])),
+                '',
+            ])
+
+            fp.write('\n'.join(lines))
+
+if __name__ == "__main__":
+    main()

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -33,16 +33,32 @@ static const struct device *levels[] = {
 	__device_end,
 };
 
+static const char *get_device_name(const struct device *dev,
+				   char *buf,
+				   size_t len)
+{
+	const char *name = dev->name;
+
+	if ((name == NULL) || (name[0] == 0)) {
+		snprintf(buf, len, "[%p]", dev);
+		name = buf;
+	}
+
+	return name;
+}
+
 static bool device_get_config_level(const struct shell *shell, int level)
 {
 	const struct device *dev;
 	bool devices = false;
+	char buf[20];
 
 	for (dev = levels[level]; dev < levels[level+1]; dev++) {
 		if (device_is_ready(dev)) {
 			devices = true;
 
-			shell_fprintf(shell, SHELL_NORMAL, "- %s\n", dev->name);
+			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
+				      get_device_name(dev, buf, sizeof(buf)));
 		}
 	}
 	return devices;
@@ -54,18 +70,6 @@ static int cmd_device_levels(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	bool ret;
-
-	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_POST_KERNEL);
-	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
-	}
-
-	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_APPLICATION);
-	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
-	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 1:\n");
 	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_PRE_KERNEL_1);
@@ -79,21 +83,27 @@ static int cmd_device_levels(const struct shell *shell,
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
-	return 0;
-}
-
-static const char *get_device_name(const struct device *dev,
-				   char *buf,
-				   size_t len)
-{
-	const char *name = dev->name;
-
-	if ((name == NULL) || (name[0] == 0)) {
-		snprintf(buf, len, "[%p]", dev);
-		name = buf;
+	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\n");
+	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_POST_KERNEL);
+	if (ret == false) {
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
-	return name;
+	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\n");
+	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_APPLICATION);
+	if (ret == false) {
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+	}
+
+#ifdef CONFIG_SMP
+	shell_fprintf(shell, SHELL_NORMAL, "SMP:\n");
+	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_SMP);
+	if (ret == false) {
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+	}
+#endif /* CONFIG_SMP */
+
+	return 0;
 }
 
 static int cmd_device_list(const struct shell *shell,

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -8,9 +8,9 @@
 #include <shell/shell.h>
 #include <init.h>
 #include <string.h>
+#include <stdio.h>
 #include <device.h>
 
-extern const struct device __device_start[];
 extern const struct device __device_PRE_KERNEL_1_start[];
 extern const struct device __device_PRE_KERNEL_2_start[];
 extern const struct device __device_POST_KERNEL_start[];
@@ -82,33 +82,62 @@ static int cmd_device_levels(const struct shell *shell,
 	return 0;
 }
 
+static const char *get_device_name(const struct device *dev,
+				   char *buf,
+				   size_t len)
+{
+	const char *name = dev->name;
+
+	if ((name == NULL) || (name[0] == 0)) {
+		snprintf(buf, len, "[%p]", dev);
+		name = buf;
+	}
+
+	return name;
+}
+
 static int cmd_device_list(const struct shell *shell,
 			      size_t argc, char **argv)
 {
+	const struct device *devlist;
+	size_t devcnt = z_device_get_all_static(&devlist);
+	const struct device *devlist_end = devlist + devcnt;
 	const struct device *dev;
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
 
-	for (dev = __device_start; dev != __device_end; dev++) {
+	for (dev = devlist; dev < devlist_end; dev++) {
+		char buf[20];
+		const char *name = get_device_name(dev, buf, sizeof(buf));
+		const char *state = "READY";
+		size_t nhdls = 0;
+		const device_handle_t *hdls =
+			device_required_handles_get(dev, &nhdls);
+
+		shell_fprintf(shell, SHELL_NORMAL, "- %s", name);
 		if (!device_is_ready(dev)) {
-			continue;
-		}
-
-		shell_fprintf(shell, SHELL_NORMAL, "- %s", dev->name);
-
+			state = "DISABLED";
+		} else {
 #ifdef CONFIG_PM_DEVICE
-		uint32_t state = DEVICE_PM_ACTIVE_STATE;
-		int err;
+			uint32_t st = DEVICE_PM_ACTIVE_STATE;
+			int err = device_get_power_state(dev, &st);
 
-		err = device_get_power_state(dev, &state);
-		if (!err) {
-			shell_fprintf(shell, SHELL_NORMAL, " (%s)",
-				      device_pm_state_str(state));
-		}
+			if (!err) {
+				state = device_pm_state_str(st);
+			}
 #endif /* CONFIG_PM_DEVICE */
-		shell_fprintf(shell, SHELL_NORMAL, "\n");
+		}
+
+		shell_fprintf(shell, SHELL_NORMAL, " (%s)\n", state);
+		for (size_t di = 0; di < nhdls; ++di) {
+			device_handle_t dh = hdls[di];
+			const struct device *rdp = device_from_handle(dh);
+
+			shell_fprintf(shell, SHELL_NORMAL, "  requires: %s\n",
+				      get_device_name(rdp, buf, sizeof(buf)));
+		}
 	}
 
 	return 0;

--- a/tests/lib/devicetree/devices/CMakeLists.txt
+++ b/tests/lib/devicetree/devices/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(devicetree_devices)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/devicetree/devices/README
+++ b/tests/lib/devicetree/devices/README
@@ -1,0 +1,1 @@
+Test cases for the device API devicetree data.

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for testing the devicetree.h API.
+ *
+ * Names in this file should be chosen in a way that won't conflict
+ * with real-world devicetree nodes, to allow these tests to run on
+ * (and be extended to test) real hardware.
+ */
+
+/ {
+	test {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		test_gpio_0: gpio@0 {
+			gpio-controller;
+			#gpio-cells = <0x2>;
+			compatible = "vnd,gpio";
+			status = "okay";
+			reg = <0x0 0x1000>;
+			label = "TEST_GPIO_0";
+		};
+
+		test_i2c: i2c@11112222 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			status = "okay";
+			reg = <0x11112222 0x1000>;
+			clock-frequency = <100000>;
+			label = "TEST_I2C_CTLR";
+
+			test_dev_a: test-i2c-dev@10 {
+				compatible = "vnd,i2c-device";
+				status = "okay";
+				reg = <0x10>;
+				supply-gpios = <&test_gpio_0 1 0>;
+				label = "TEST_I2C_DEV_10";
+			};
+
+			test_gpiox: test-i2c-dev@11 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				compatible = "vnd,gpio-expander";
+				status = "okay";
+				reg = <0x11>;
+				label = "TEST_I2C_GPIO";
+			};
+
+			test_dev_b: test-i2c-dev@12 {
+				compatible = "vnd,i2c-device";
+				status = "okay";
+				reg = <0x12>;
+				supply-gpios = <&test_gpiox 2 0>;
+				label = "TEST_I2C_DEV_12";
+			};
+		};
+	};
+};

--- a/tests/lib/devicetree/devices/prj.conf
+++ b/tests/lib/devicetree/devices/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -83,19 +83,19 @@ static void test_requires(void)
 	/* TEST_GPIO: no req */
 	dev = device_get_binding(DT_LABEL(TEST_GPIO));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
-	hdls = device_get_requires_handles(dev, &nhdls);
+	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
 
 	/* TEST_I2C: no req */
 	dev = device_get_binding(DT_LABEL(TEST_I2C));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
-	hdls = device_get_requires_handles(dev, &nhdls);
+	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
 	dev = device_get_binding(DT_LABEL(TEST_DEVA));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVA), NULL);
-	hdls = device_get_requires_handles(dev, &nhdls);
+	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 2, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls), NULL);
@@ -103,14 +103,14 @@ static void test_requires(void)
 	/* TEST_GPIOX: TEST_I2C */
 	dev = device_get_binding(DT_LABEL(TEST_GPIOX));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIOX), NULL);
-	hdls = device_get_requires_handles(dev, &nhdls);
+	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
 
 	/* TEST_DEVB: TEST_I2C TEST_GPIOX */
 	dev = device_get_binding(DT_LABEL(TEST_DEVB));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVB), NULL);
-	hdls = device_get_requires_handles(dev, &nhdls);
+	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 2, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);

--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  libraries.devicetree:
+    tags: devicetree
+    # We only need this to run on one platform so use native_posix as it
+    # will mostly likely be the fastest.
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
This PR resurrects the features of #29644 that were reverted in #31548 with a few changes:

* The issue identified in #31546 was isolated to binutils introducing padding between arrays of 16-bit values that appeared in the same x86_64 input section.  Resolved by explicitly marking each handle array object as requiring 2-byte alignment.
* The device handle structures were moved after all kernel objects.  This is not necessary now, where we work to ensure the handle arrays don't change size, but could be in the future; see #32129.
* The handle value zero is now reserved to identify an invalid or unknown device; see #31541.
