### PR TITLE
[stm32] PM restore console after sleep mode

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -318,7 +318,20 @@ static inline void stm32_clock_control_mco_init(void)
 #endif /* CONFIG_CLOCK_STM32_MCO2_SRC_NOCLOCK */
 }
 
-static int stm32_clock_control_init(const struct device *dev)
+
+/**
+ * @brief Initialize clocks for the stm32
+ *
+ * This routine is called to enable and configure the clocks and PLL
+ * of the soc on the board. It depends on the board definition.
+ * This function is called on the startup and also to restore the config
+ * when exiting for low power mode.
+ *
+ * @param dev clock device struct
+ *
+ * @return 0
+ */
+int stm32_clock_control_init(const struct device *dev)
 {
 	LL_UTILS_ClkInitTypeDef s_ClkInitStruct;
 	uint32_t hclk_prescaler;

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -30,10 +30,15 @@
 	#define MCO2_SOURCE		LL_RCC_MCO2SOURCE_PLLCLK
 #endif
 
+#ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit);
+#endif /* CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL */
 void config_enable_default_clocks(void);
 
 /* Section for functions not available in every Cube packages */
 void LL_RCC_MSI_Disable(void);
+
+/* function exported to the soc power.c */
+int stm32_clock_control_init(const struct device *dev);
 
 #endif /* ZEPHYR_DRIVERS_CLOCK_CONTROL_STM32_LL_CLOCK_H_ */

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1376,6 +1376,9 @@ static int uart_stm32_init(const struct device *dev)
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	config->uconf.irq_config_func(dev);
 #endif
+#ifdef CONFIG_PM_DEVICE
+	data->pm_state = DEVICE_PM_ACTIVE_STATE;
+#endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_UART_ASYNC_API
 	return uart_stm32_async_init(dev);
@@ -1383,6 +1386,67 @@ static int uart_stm32_init(const struct device *dev)
 	return 0;
 #endif
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int uart_stm32_set_power_state(const struct device *dev,
+					      uint32_t new_state)
+{
+	USART_TypeDef *UartInstance = UART_STRUCT(dev);
+	struct uart_stm32_data *data = DEV_DATA(dev);
+
+	/* setting a low power mode */
+	if (new_state != DEVICE_PM_ACTIVE_STATE) {
+		/* Make sure that no USART transfer is on-going */
+		while (LL_USART_IsActiveFlag_BUSY(UartInstance) == 1) {
+		}
+		while (LL_USART_IsActiveFlag_TC(UartInstance) == 0) {
+		}
+		/* Make sure that USART is ready for reception */
+		while (LL_USART_IsActiveFlag_REACK(UartInstance) == 0) {
+		}
+		/* Clear OVERRUN flag */
+		LL_USART_ClearFlag_ORE(UartInstance);
+		/* Leave UartInstance unchanged */
+	}
+	data->pm_state = new_state;
+	/* UartInstance returning to active mode has nothing special to do */
+	return 0;
+}
+
+/**
+ * @brief disable the UART channel
+ *
+ * This routine is called to put the device in low power mode.
+ *
+ * @param dev UART device struct
+ *
+ * @return 0
+ */
+static int uart_stm32_pm_control(const struct device *dev,
+					 uint32_t ctrl_command,
+					 void *context, device_pm_cb cb,
+					 void *arg)
+{
+	struct uart_stm32_data *data = DEV_DATA(dev);
+
+	if (ctrl_command == DEVICE_PM_SET_POWER_STATE) {
+		uint32_t new_state = *((const uint32_t *)context);
+
+		if (new_state != data->pm_state) {
+			uart_stm32_set_power_state(dev, new_state);
+		}
+	} else {
+		__ASSERT_NO_MSG(ctrl_command == DEVICE_PM_GET_POWER_STATE);
+		*((uint32_t *)context) = data->pm_state;
+	}
+
+	if (cb) {
+		cb(dev, 0, context, arg);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_UART_ASYNC_API
 #define DMA_CHANNEL_CONFIG(id, dir)					\
@@ -1478,7 +1542,7 @@ static struct uart_stm32_data uart_stm32_data_##index = {		\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
 		    &uart_stm32_init,					\
-		    device_pm_control_nop,				\
+		    &uart_stm32_pm_control,				\
 		    &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 		    &uart_stm32_driver_api);				\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -69,6 +69,9 @@ struct uart_stm32_data {
 	uint8_t *rx_next_buffer;
 	size_t rx_next_buffer_len;
 #endif
+#ifdef CONFIG_PM_DEVICE
+	uint32_t pm_state;
+#endif
 };
 
 #endif	/* ZEPHYR_DRIVERS_SERIAL_UART_STM32_H_ */

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -13,9 +13,14 @@ source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 config SOC_SERIES
 	default "stm32l4"
 
+if PM
+config PM_DEVICE
+	bool
+	default y
+
 config STM32_LPTIM_TIMER
 	bool
 	default y
-	depends on PM
+endif # PM
 
 endif # SOC_SERIES_STM32L4X

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -8,11 +8,13 @@
 #include <soc.h>
 #include <init.h>
 
+#include <stm32l4xx_ll_utils.h>
 #include <stm32l4xx_ll_bus.h>
 #include <stm32l4xx_ll_cortex.h>
 #include <stm32l4xx_ll_pwr.h>
 #include <stm32l4xx_ll_rcc.h>
 #include <stm32l4xx_ll_system.h>
+#include <clock_control/clock_stm32_ll_common.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
@@ -104,6 +106,8 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 				info.substate_id);
 			break;
 		}
+		/* need to restore the clock */
+		stm32_clock_control_init(NULL);
 	}
 
 	/*

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -118,6 +118,11 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	irq_unlock(0);
 }
 
+__weak bool pm_policy_low_power_devices(enum pm_state state)
+{
+	return pm_is_sleep_state(state);
+}
+
 /* Initialize STM32 Power */
 static int stm32_power_init(const struct device *dev)
 {

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -10,9 +10,14 @@ source "soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb*"
 config SOC_SERIES
 	default "stm32wb"
 
+if PM
+config PM_DEVICE
+	bool
+	default y
+
 config STM32_LPTIM_TIMER
 	bool
 	default y
-	depends on PM
+endif # PM
 
 endif # SOC_SERIES_STM32WBX

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -8,10 +8,12 @@
 #include <soc.h>
 #include <init.h>
 
+#include <stm32wbxx_ll_utils.h>
 #include <stm32wbxx_ll_bus.h>
 #include <stm32wbxx_ll_cortex.h>
 #include <stm32wbxx_ll_pwr.h>
 #include <stm32wbxx_ll_rcc.h>
+#include <clock_control/clock_stm32_ll_common.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
@@ -94,6 +96,8 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 				info.substate_id);
 			break;
 		}
+		/* need to restore the clock */
+		stm32_clock_control_init(NULL);
 	}
 
 	/*

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -107,3 +107,8 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	 */
 	irq_unlock(0);
 }
+
+__weak bool pm_policy_low_power_devices(enum pm_state state)
+{
+	return pm_is_sleep_state(state);
+}

--- a/tests/subsys/power/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/power/power_mgmt_soc/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   subsys.power.pm_soc:
     platform_allow: cc26x2r1_launchxl cc1352r1_launchxl mec15xxevb_assy6853 mec1501modular_assy6885
+       nucleo_wb55rg nucleo_l476rg
     tags: power


### PR DESCRIPTION
With this change, the clock configuration is restored when leaving the low power mode. 
Then the console of the nucleo_wb55 can operate after sleeping.

The UART executes the `uart_stm32_set_power_state` to have a clean configuration before entering the low power mode.
On wakeup, the clocks are re-configured thanks to the `stm32_clock_control_init` function called directly in the 
`pm_power_state_exit_post_ops` of each soc.
This method is more efficient than introducing a _clock_stm32_pm_control_ function in the clock driver. 

Fix #31284
Requires #32042

Signed-off-by: Francois Ramu francois.ramu@st.com