### PR TITLE
dts: arm: st: add support for STM32F205xx SOC

### DIFF
--- a/dts/arm/st/f2/stm32f205Xe.dtsi
+++ b/dts/arm/st/f2/stm32f205Xe.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Manuel Forcen <manuforcen@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f2/stm32f2.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(128)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f205xx
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f205xx
@@ -1,0 +1,14 @@
+# ST Microelectronics stm32f205 MCU
+
+# Copyright (c) 2021 Manuel Forcen <manuforcen@gmail.com
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F205XX
+
+config SOC
+	default "STM32F205xx"
+
+config NUM_IRQS
+	default 81
+
+endif

--- a/soc/arm/st_stm32/stm32f2/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.soc
@@ -10,4 +10,7 @@ choice
 config SOC_STM32F207XX
 	bool "STM32F207XX"
 
+config SOC_STM32F205XX
+	bool "STM32F205XX"
+
 endchoice


### PR DESCRIPTION
Signed-off-by: Manuel Forcén Muñoz <manuforcen@gmail.com>

STM32F205xx device tree include files added.
Tested properly in a custom board.