### PR TITLE
test: arch: arm: arm_interrupt: clear FPSCR register in ISR

### DIFF
--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -191,6 +191,15 @@ void arm_isr_handler(const void *args)
 {
 	ARG_UNUSED(args);
 
+#if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_FPU) && \
+	defined(CONFIG_FPU_SHARING)
+	/* Clear Floating Point Status and Control Register (FPSCR),
+	 * to prevent from having the interrupt line set to pending again,
+	 * in case FPU IRQ is selected by the test as "Available IRQ line"
+	 */
+	__set_FPSCR(0);
+#endif
+
 	test_flag++;
 
 	if (test_flag == 1) {


### PR DESCRIPTION
test: arch: arm: arm_interrupt: clear FPSCR register in ISR

Clear Floating Point Status and Control Register (FPSCR),
in case FPU IRQ is selected by the test as "Available IRQ line"

Fixes #31982