### PR TITLE
cmake: improved handling of output and byproducts in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,24 @@ add_custom_command(
   )
 
 add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS ${syscall_list_h})
+
+# This only works for CMake version >=3.15, but as the property is ignored on
+# older CMake versions there is no reason to check for version.
+set_property(TARGET ${SYSCALL_LIST_H_TARGET}
+             APPEND PROPERTY
+             ADDITIONAL_CLEAN_FILES
+             ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscalls
+)
+
+# Only works with make.
+if(${CMAKE_VERSION} VERSION_LESS 3.15)
+  set_property(DIRECTORY
+               APPEND PROPERTY
+               ADDITIONAL_MAKE_CLEAN_FILES
+               ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscalls
+  )
+endif()
+
 add_custom_target(${PARSE_SYSCALLS_TARGET}
   DEPENDS
   ${syscalls_json}
@@ -725,7 +743,7 @@ if(CONFIG_GEN_ISR_TABLES)
   # isr_tables.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
   # gen_isr_tables.py
   add_custom_command(
-    OUTPUT isr_tables.c
+    OUTPUT isr_tables.c isrList.bin
     COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
             $<TARGET_PROPERTY:bintools,elfconvert_flag>
             $<TARGET_PROPERTY:bintools,elfconvert_flag_intarget>${OUTPUT_FORMAT}
@@ -981,6 +999,9 @@ if(CONFIG_USERSPACE)
     LIBRARIES_POST_SCRIPT ""
     DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
+  target_byproducts(TARGET app_smem_unaligned_prebuilt
+                    BYPRODUCTS ${PROJECT_BINARY_DIR}/app_smem_unaligned_prebuilt.map
+  )
   set_property(TARGET   app_smem_unaligned_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_app_smem_unaligned.cmd)
   add_dependencies(     app_smem_unaligned_prebuilt linker_app_smem_unaligned_script ${OFFSETS_LIB})
 
@@ -1011,6 +1032,9 @@ toolchain_ld_link_elf(
   LIBRARIES_PRE_SCRIPT  ""
   LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/linker.cmd
   DEPENDENCIES          ${CODE_RELOCATION_DEP}
+)
+target_byproducts(TARGET ${ZEPHYR_PREBUILT_EXECUTABLE}
+                  BYPRODUCTS ${PROJECT_BINARY_DIR}/${ZEPHYR_PREBUILT_EXECUTABLE}.map
 )
 set_property(TARGET   ${ZEPHYR_PREBUILT_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
 add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
@@ -1054,6 +1078,9 @@ else()
     LIBRARIES_POST_SCRIPT ""
     DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
+  target_byproducts(TARGET ${ZEPHYR_FINAL_EXECUTABLE}
+                    BYPRODUCTS ${PROJECT_BINARY_DIR}/${ZEPHYR_FINAL_EXECUTABLE}.map
+  )
   set_property(TARGET   ${ZEPHYR_FINAL_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_pass_final.cmd)
   add_dependencies(     ${ZEPHYR_FINAL_EXECUTABLE} ${LINKER_PASS_FINAL_SCRIPT_TARGET})
 
@@ -1079,6 +1106,7 @@ list(APPEND
   COMMAND
   ${CMAKE_COMMAND} -E rename ${logical_target_for_zephyr_elf}.map ${KERNEL_MAP_NAME}
 )
+list(APPEND post_build_byproducts ${KERNEL_MAP_NAME})
 
 if(NOT CONFIG_BUILD_NO_GAP_FILL)
   # Use ';' as separator to get proper space in resulting command.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2136,3 +2136,27 @@ function(zephyr_get_targets directory types targets)
     endforeach()
     set(${targets} ${${targets}} PARENT_SCOPE)
 endfunction()
+
+# Usage:
+#   target_byproducts(TARGET <target> BYPRODUCTS <file> [<file>...])
+#
+# Specify additional BYPRODUCTS that this target produces.
+#
+# This function allows the build system to specify additional byproducts to
+# target created with `add_executable()`. When linking an executable the linker
+# may produce additional files, like map files. Those files are not known to the
+# build system. This function makes it possible to describe such additional
+# byproducts in an easy manner.
+function(target_byproducts)
+  cmake_parse_arguments(TB "" "TARGET" "BYPRODUCTS" ${ARGN})
+
+  if(NOT DEFINED TB_TARGET)
+    message(FATAL_ERROR "target_byproducts() missing parameter: TARGET <target>")
+  endif()
+
+  add_custom_command(TARGET ${TB_TARGET}
+                     POST_BUILD COMMAND ${CMAKE_COMMAND} -E echo ""
+                     BYPRODUCTS ${TB_BYPRODUCTS}
+                     COMMENT "Logical command for additional byproducts on target: ${TB_TARGET}"
+  )
+endfunction()

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -14,7 +14,7 @@ function(gen_kobj gen_dir_out)
   file(MAKE_DIRECTORY ${gen_dir})
 
   add_custom_command(
-    OUTPUT ${KOBJ_TYPES} ${KOBJ_OTYPE}
+    OUTPUT ${KOBJ_TYPES} ${KOBJ_OTYPE} ${KOBJ_SIZE}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_kobject_list.py


### PR DESCRIPTION
Fixes: #23449

This commit adds additional OUTPUT and BYPRODUCTS to custom command
and targets in the Zephyr build system.

This ensures that files produced during the build will be removed again
when invoking ninja clean / make clean.

The generated syscalls headers include folder is added to the syscall
target using ADDITIONAL_CLEAN_FILES property.
However, this property is new in CMake 3.15, so will not work when using
older CMake with ninja.

For CMake versions <=3.15 the ADDITIONAL_MAKE_CLEAN_FILES property is
used. However, this only supports Makefile generator.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>