### PR TITLE
arm: nxp: kinetis: Rework device_get_binding for pinmux

### DIFF
--- a/boards/arm/frdm_k22f/pinmux.c
+++ b/boards/arm/frdm_k22f/pinmux.c
@@ -14,23 +14,28 @@ static int frdm_k22f_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL

--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -15,22 +15,27 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
 		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL

--- a/boards/arm/frdm_k82f/pinmux.c
+++ b/boards/arm/frdm_k82f/pinmux.c
@@ -14,23 +14,28 @@ static int frdm_k82f_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM

--- a/boards/arm/frdm_kl25z/pinmux.c
+++ b/boards/arm/frdm_kl25z/pinmux.c
@@ -14,23 +14,28 @@ static int frdm_kl25z_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL

--- a/boards/arm/frdm_kw41z/pinmux.c
+++ b/boards/arm/frdm_kw41z/pinmux.c
@@ -14,15 +14,18 @@ static int frdm_kw41z_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 
 	/* Red, green, blue LEDs. Note the red LED and accel INT1 are both

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -15,19 +15,23 @@ static int hexiwear_k64_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm3), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM
@@ -85,7 +89,8 @@ static int hexiwear_k64_pinmux_init(const struct device *dev)
 
 #if defined(CONFIG_MAX30101) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpioa), okay)
 	const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 
 	/* LDO - MAX30101 power supply */
 	pinmux_pin_set(porta, 29, PORT_PCR_MUX(kPORT_MuxAsGpio));

--- a/boards/arm/hexiwear_kw40z/pinmux.c
+++ b/boards/arm/hexiwear_kw40z/pinmux.c
@@ -14,11 +14,13 @@ static int hexiwear_kw40z_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart0), okay) && CONFIG_SERIAL

--- a/boards/arm/ip_k66f/pinmux.c
+++ b/boards/arm/ip_k66f/pinmux.c
@@ -14,23 +14,28 @@ static int ip_k66f_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 	/* Red0, Red2 LEDs */

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -14,23 +14,28 @@ static int twr_ke18f_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(ftm0), nxp_kinetis_ftm_pwm, okay) && CONFIG_PWM

--- a/boards/arm/twr_kv58f220m/pinmux.c
+++ b/boards/arm/twr_kv58f220m/pinmux.c
@@ -14,23 +14,28 @@ static int twr_kv58f220m_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 	/* LEDs */

--- a/boards/arm/usb_kw24d512/pinmux.c
+++ b/boards/arm/usb_kw24d512/pinmux.c
@@ -14,23 +14,28 @@ static int usb_kw24d512_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) && CONFIG_SERIAL

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -178,35 +178,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -236,35 +236,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -230,35 +230,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		ftm0: ftm@40038000 {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -302,35 +302,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0x1000>;
 			clocks = <&pcc 0x124 KINETIS_PCC_SRC_NONE_OR_EXT>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0x1000>;
 			clocks = <&pcc 0x128 KINETIS_PCC_SRC_NONE_OR_EXT>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0x1000>;
 			clocks = <&pcc 0x12c KINETIS_PCC_SRC_NONE_OR_EXT>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0x1000>;
 			clocks = <&pcc 0x130 KINETIS_PCC_SRC_NONE_OR_EXT>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0x1000>;
 			clocks = <&pcc 0x134 KINETIS_PCC_SRC_NONE_OR_EXT>;
-			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -101,35 +101,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -154,35 +154,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0x1000>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		ftm0: ftm@40038000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -143,35 +143,30 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-			label = "portd";
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -109,21 +109,18 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -120,21 +120,18 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-			label = "porta";
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			label = "portb";
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-			label = "portc";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -5,9 +5,6 @@ compatible: "nxp,kinetis-pinmux"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/samples/net/cloud/tagoio_http_post/src/pinmux.c
+++ b/samples/net/cloud/tagoio_http_post/src/pinmux.c
@@ -16,8 +16,9 @@ static int tagoio_pinmux_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 #if defined(CONFIG_BOARD_FRDM_K64F)
-	const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+	const struct device *portc = DEVICE_DT_GET(DT_NODELABEL(portc));
+
+	__ASSERT_NO_MSG(device_is_ready(portc));
 
 	pinmux_pin_set(portc, 2, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portc, 3, PORT_PCR_MUX(kPORT_MuxAsGpio));


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>