### PR TITLE
x86: fix running 32-bit QEMU with ACPI

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -15,6 +15,15 @@ config FLASH_SIMULATOR
 config KERNEL_VM_SIZE
 	default 0x10000000 if ACPI
 
+config MULTIBOOT
+	default y
+
+config MULTIBOOT_INFO
+	default y if MULTIBOOT
+
+config MULTIBOOT_MEMMAP
+	default y if MULTIBOOT
+
 endif # BOARD_QEMU_X86
 
 if BOARD_QEMU_X86_64

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -12,8 +12,17 @@ config FLASH_SIMULATOR
 	default y
 	depends on FLASH
 
+config KERNEL_VM_SIZE
+	default 0x10000000 if ACPI
+
 endif # BOARD_QEMU_X86
+
+if BOARD_QEMU_X86_64
 
 config BOARD
 	default "qemu_x86_64"
-	depends on BOARD_QEMU_X86_64
+
+config KERNEL_VM_SIZE
+	default 0x10000000 if ACPI
+
+endif # BOARD_QEMU_X86_64

--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -19,8 +19,15 @@ else()
   set(QEMU_CPU_TYPE_${ARCH} qemu32,+nx,+pae)
 endif()
 
+if(CONFIG_XIP)
+  # Extra 4MB to emulate flash area
+  math(EXPR QEMU_MEMORY_SIZE_MB "${CONFIG_SRAM_SIZE} / 1024 + 4")
+else()
+  math(EXPR QEMU_MEMORY_SIZE_MB "${CONFIG_SRAM_SIZE} / 1024")
+endif()
+
 set(QEMU_FLAGS_${ARCH}
-  -m 9
+  -m ${QEMU_MEMORY_SIZE_MB}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}

--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -27,6 +27,10 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   )
 
+if(NOT CONFIG_ACPI)
+  list(APPEND QEMU_FLAGS_${ARCH} -no-acpi)
+endif()
+
 # TODO: Support debug
 # board_set_debugger_ifnset(qemu)
 # debugserver: QEMU_EXTRA_FLAGS += -s -S

--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   arch.x86.info:
     arch_allow: x86
-    platform_allow: ehl_crb up_squared up_squared_32
+    platform_allow: qemu_x86 ehl_crb up_squared up_squared_32
     harness: console
     harness_config:
         type: one_line

--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -7,3 +7,13 @@ tests:
         type: one_line
         regex:
           - "info: complete"
+  arch.x86.info.userspace:
+    arch_allow: x86
+    platform_allow: qemu_x86 ehl_crb up_squared up_squared_32
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y
+    harness: console
+    harness_config:
+        type: one_line
+        regex:
+          - "info: complete"


### PR DESCRIPTION
* This contains a few commits to fix running 32-bit QEMU when ACPI is enabled. 
* The `tests/arch/x86/info` is now enabled for QEMU so we can actually test running ACPI code in CI to avoid breakage.