### PR TITLE
device.h: remove incorrect docstring

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -213,9 +213,6 @@ extern "C" {
  * @details Return the address of a device object created by
  * DEVICE_DT_INIT(), using the dev_name derived from @p node_id
  *
- * @note A declaration for the corresponding device must be in scope;
- * e.g:
- *
  * @param node_id The same as node_id provided to DEVICE_DT_DEFINE()
  *
  * @return A pointer to the device object created by DEVICE_DT_DEFINE()


### PR DESCRIPTION
This appears to be leftovers from when DEVICE_DT_DECLARE() was briefly
around.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>