### PR TITLE
boards: nrf: fix incorrect debug docs

### DIFF
--- a/boards/arm/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/arm/bl653_dvk/doc/bl653_dvk.rst
@@ -108,10 +108,9 @@ Push buttons
 Programming and Debugging
 *************************
 
-Applications for the ``bl653_dvk`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``bl653_dvk`` board configuration can be built, flashed,
+and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========

--- a/boards/arm/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/arm/bl654_dvk/doc/bl654_dvk.rst
@@ -115,10 +115,9 @@ Push buttons
 Programming and Debugging
 *************************
 
-Applications for the ``bl654_dvk`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``bl654_dvk`` board configuration can be built, flashed,
+and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========

--- a/boards/arm/bt510/doc/bt510.rst
+++ b/boards/arm/bt510/doc/bt510.rst
@@ -127,10 +127,9 @@ The BT510 incorporates an I2C Silabs SI7055 temperature sensor. Refer to the `Si
 Programming and Debugging
 *************************
 
-Applications for the ``bt510`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``bt510`` board configuration can be built, flashed, and
+debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 The BT510 features a TagConnect 10 way socket for connection of a
 programmer/debugger, refer to `TagConnect TC2050 product page`_

--- a/boards/arm/decawave_dwm1001_dev/doc/index.rst
+++ b/boards/arm/decawave_dwm1001_dev/doc/index.rst
@@ -17,10 +17,9 @@ board, `Decawave DWM1001 website`_ about the board itself, and `nRF52832 website
 Programming and Debugging
 *************************
 
-Applications for the ``decawave_dwm1001_dev`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``decawave_dwm1001_dev`` board configuration can be built,
+flashed, and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========

--- a/boards/arm/nrf21540dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf21540dk_nrf52840/doc/index.rst
@@ -123,10 +123,9 @@ Front End Module
 Programming and Debugging
 *************************
 
-Applications for the ``nrf21540dk_nrf52840`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``nrf21540dk_nrf52840`` board configuration can be built,
+flashed, and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -106,10 +106,9 @@ Push buttons
 Programming and Debugging
 *************************
 
-Applications for the ``nrf52833dk_nrf52833`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+Applications for the ``nrf52833dk_nrf52833`` board configuration can be built,
+flashed, and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========

--- a/boards/arm/nrf52840dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52840/doc/index.rst
@@ -112,9 +112,9 @@ Programming and Debugging
 *************************
 
 Applications for the ``nrf52840dk_nrf52840`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+built, flashed, and debugged in the usual way. See
+:ref:`build_an_application` and :ref:`application_run` for more details on
+building and running.
 
 Flashing
 ========

--- a/boards/arm/nrf52_adafruit_feather/doc/index.rst
+++ b/boards/arm/nrf52_adafruit_feather/doc/index.rst
@@ -104,9 +104,8 @@ The ``nrf52_adafruit_feather`` board is available in two different versions:
    needs to be soldered.
 
 Applications for the ``nrf52_adafruit_feather`` board configuration can be
-built and flashed in the usual way (see :ref:`build_an_application`
-and :ref:`application_run` for more details); however, the standard
-debugging targets are not currently available.
+built, flashed, and debugged in the usual way. See :ref:`build_an_application`
+and :ref:`application_run` for more details on building and running.
 
 Flashing
 ========


### PR DESCRIPTION
All of these boards can be debugged with west debug via settings in
board.cmake, but the docs say they can't be. This is being copy/pasted
around; fix it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>