### PR TITLE
Bluetooth: controller: Fix missing advertising PDU len initialization

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -161,6 +161,7 @@ int lll_adv_data_init(struct lll_adv_pdu *pdu)
 		return -ENOMEM;
 	}
 
+	p->len = 0U;
 	pdu->pdu[0] = (void *)p;
 
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -149,6 +149,7 @@ int lll_adv_data_init(struct lll_adv_pdu *pdu)
 		return -ENOMEM;
 	}
 
+	p->len = 0U;
 	pdu->pdu[0] = (void *)p;
 
 	return 0;


### PR DESCRIPTION
Fix missing advertising PDU length initialization which
prevented advertising PDU to be transmitted by Radio. This
issue was reproduced when connectable undirected advertising
was enabled without setting an advertising data.

Fixes #32167.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>