### PR TITLE
[TOPIC-BLE-LLCP]: Bluetooth: controller: add Erik and Szymon as codeo…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -530,7 +530,7 @@
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
-/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
+/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/canbus/                           @alexanderwachter
 /subsys/cpp/                              @pabigot @vanwinkeljan
@@ -592,7 +592,7 @@
 /tests/benchmarks/cmsis_dsp/              @stephanosio
 /tests/boards/native_posix/               @aescolar @daor-oti
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
-/tests/bluetooth/                         @carlescufi @cvinayak @thoh-ot @kruithofa @dagbja
+/tests/bluetooth/                         @carlescufi @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc
 /tests/bluetooth/bsim_bt/                 @joerchan @jhedberg @Vudentz @aescolar @wopu-ot
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin


### PR DESCRIPTION
…wners

Added both Erik and Szymon as codeowners, so that they get automatically
added for PR review; removed Dag Bjarvin as he is working on other
projects

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>