### PR TITLE
aarch64: Fix corrupted IRQ state when tracing enabled

### DIFF
--- a/arch/arm/core/aarch64/cpu_idle.S
+++ b/arch/arm/core/aarch64/cpu_idle.S
@@ -29,9 +29,9 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 GTEXT(arch_cpu_atomic_idle)
 SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 #ifdef CONFIG_TRACING
-	stp	xzr, x30, [sp, #-16]!
+	stp	x0, x30, [sp, #-16]!
 	bl	sys_trace_idle
-	ldp	xzr, x30, [sp], #16
+	ldp	x0, x30, [sp], #16
 #endif
 	msr	daifset, #(DAIFSET_IRQ)
 	isb


### PR DESCRIPTION
The call to sys_trace_idle() is potentially clobbering x0 resulting in a
wrong value being used by the following code. Save and restore x0 before
and after the call to sys_trace_idle() to avoid any issue.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>
Suggested-by: James Harris <james.harris@intel.com>