### PR TITLE
logging: swo: Add option to set custom reference frequency

### DIFF
--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -17,6 +17,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -21,6 +21,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -22,6 +22,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -17,6 +17,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -21,6 +21,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -17,6 +17,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			swo-ref-frequency = <32000000>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -18,6 +18,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			swo-ref-frequency = <64000000>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -18,6 +18,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			swo-ref-frequency = <32000000>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -18,6 +18,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			swo-ref-frequency = <32000000>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/bindings/cpu/arm,cortex-m.yaml
+++ b/dts/bindings/cpu/arm,cortex-m.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for ARM Cortex-M CPU
+
+include: cpu.yaml
+
+properties:
+    swo-ref-frequency:
+      type: int
+      required: false
+      description: Reference clock frequency for SWO if different than CPU clock.

--- a/dts/bindings/cpu/arm,cortex-m1.yaml
+++ b/dts/bindings/cpu/arm,cortex-m1.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M1 CPU
 
 compatible: "arm,cortex-m1"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m23.yaml
+++ b/dts/bindings/cpu/arm,cortex-m23.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M23 CPU
 
 compatible: "arm,cortex-m23"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m3.yaml
+++ b/dts/bindings/cpu/arm,cortex-m3.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M3 CPU
 
 compatible: "arm,cortex-m3"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m33.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M33 CPU
 
 compatible: "arm,cortex-m33"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m33f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33f.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M33F CPU
 
 compatible: "arm,cortex-m33f"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m4.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M4 CPU
 
 compatible: "arm,cortex-m4"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4f.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M4F CPU
 
 compatible: "arm,cortex-m4f"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m7.yaml
+++ b/dts/bindings/cpu/arm,cortex-m7.yaml
@@ -5,4 +5,4 @@ description: ARM Cortex-M7 CPU
 
 compatible: "arm,cortex-m7"
 
-include: cpu.yaml
+include: arm,cortex-m.yaml

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.series
@@ -14,5 +14,6 @@ config SOC_SERIES_NRF52X
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select HAS_SEGGER_RTT
+	select HAS_SWO
 	help
 	  Enable support for NRF52 MCU series

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.series
@@ -14,5 +14,6 @@ config SOC_SERIES_NRF53X
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select HAS_SEGGER_RTT
+	select HAS_SWO
 	help
 	 Enable support for NRF53 MCU series

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -16,5 +16,6 @@ config SOC_SERIES_NRF91X
 	select XIP
 	select HAS_NRFX
 	select HAS_SEGGER_RTT
+	select HAS_SWO
 	help
 	  Enable support for NRF91 MCU series

--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -36,18 +36,26 @@
 #if CONFIG_LOG_BACKEND_SWO_FREQ_HZ == 0
 #define SWO_FREQ_DIV  1
 #else
-#if DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
-#define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+
+/* Set reference frequency which can be custom or cpu frequency. */
+#if DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), swo_ref_frequency)
+#define SWO_REF_FREQ DT_PROP(DT_PATH(cpus, cpu_0), swo_ref_frequency)
+#elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+#define SWO_REF_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 #else
 #error "Missing DT 'clock-frequency' property on cpu@0 node"
 #endif
-#define SWO_FREQ (CPU_FREQ + (CONFIG_LOG_BACKEND_SWO_FREQ_HZ / 2))
-#define SWO_FREQ_DIV  (SWO_FREQ / CONFIG_LOG_BACKEND_SWO_FREQ_HZ)
+
+#define SWO_FREQ_DIV \
+	((SWO_REF_FREQ + (CONFIG_LOG_BACKEND_SWO_FREQ_HZ / 2)) / \
+		CONFIG_LOG_BACKEND_SWO_FREQ_HZ)
+
 #if SWO_FREQ_DIV > 0xFFFF
 #error CONFIG_LOG_BACKEND_SWO_FREQ_HZ is too low. SWO clock divider is 16-bit. \
 	Minimum supported SWO clock frequency is \
-	[CPU Clock Frequency]/2^16.
+	[Reference Clock Frequency]/2^16.
 #endif
+
 #endif
 
 static uint8_t buf[1];


### PR DESCRIPTION
Some devices may use different reference than cpu clock. Add
Kconfig option to provide custom frequency reference details.

Fixes #31058.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>