### PR TITLE
riscv: rv32m1: Rework device_get_binding for pinmux

### DIFF
--- a/boards/riscv/rv32m1_vega/pinmux.c
+++ b/boards/riscv/rv32m1_vega/pinmux.c
@@ -21,23 +21,28 @@ static int rv32m1_vega_pinmux_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porta), okay)
 	__unused const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porta)));
+		DEVICE_DT_GET(DT_NODELABEL(porta));
+	__ASSERT_NO_MSG(device_is_ready(porta));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portb), okay)
 	__unused const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portb)));
+		DEVICE_DT_GET(DT_NODELABEL(portb));
+	__ASSERT_NO_MSG(device_is_ready(portb));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portc), okay)
 	__unused const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portc)));
+		DEVICE_DT_GET(DT_NODELABEL(portc));
+	__ASSERT_NO_MSG(device_is_ready(portc));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(portd), okay)
 	__unused const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(portd)));
+		DEVICE_DT_GET(DT_NODELABEL(portd));
+	__ASSERT_NO_MSG(device_is_ready(portd));
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(porte), okay)
 	__unused const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(porte)));
+		DEVICE_DT_GET(DT_NODELABEL(porte));
+	__ASSERT_NO_MSG(device_is_ready(porte));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart0), okay) && CONFIG_SERIAL

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -5,9 +5,6 @@ compatible: "openisa,rv32m1-pinmux"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -282,35 +282,30 @@
 			compatible = "openisa,rv32m1-pinmux";
 			reg = <0x40046000 0xd0>;
 			clocks = <&pcc0 0x118>;
-			label = "porta";
 		};
 
 		portb: pinmux@40047000 {
 			compatible = "openisa,rv32m1-pinmux";
 			reg = <0x40047000 0xd0>;
 			clocks = <&pcc0 0x11c>;
-			label = "portb";
 		};
 
 		portc: pinmux@40048000 {
 			compatible = "openisa,rv32m1-pinmux";
 			reg = <0x40048000 0xd0>;
 			clocks = <&pcc0 0x120>;
-			label = "portc";
 		};
 
 		portd: pinmux@40049000 {
 			compatible = "openisa,rv32m1-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&pcc0 0x124>;
-			label = "portd";
 		};
 
 		porte: pinmux@41037000 {
 			compatible = "openisa,rv32m1-pinmux";
 			reg = <0x41037000 0xd0>;
 			clocks = <&pcc1 0xdc>;
-			label = "porte";
 		};
 
 		gpioa: gpio@48020000 {


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>