### PR TITLE
arm: atmel: sam0: Rework device_get_binding for pinmux

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/pinmux.c
+++ b/boards/arm/adafruit_feather_m0_basic_proto/pinmux.c
@@ -10,9 +10,14 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+
 #if (ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_spi) && CONFIG_SPI_SAM0)
-	const struct device *muxb = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 #endif
 	ARG_UNUSED(dev);
 

--- a/boards/arm/adafruit_itsybitsy_m4_express/pinmux.c
+++ b/boards/arm/adafruit_itsybitsy_m4_express/pinmux.c
@@ -10,14 +10,13 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	__unused const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	__unused const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
-	(void)muxa;
-	(void)muxb;
 
 #if ATMEL_SAM0_DT_SERCOM_CHECK(3, atmel_sam0_uart) && defined(CONFIG_UART_SAM0)
 	/* SERCOM3 on RX=PA16/pad 1, TX=PA17/pad 0 */

--- a/boards/arm/adafruit_trinket_m0/pinmux.c
+++ b/boards/arm/adafruit_trinket_m0/pinmux.c
@@ -10,7 +10,9 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/arduino_nano_33_iot/pinmux.c
+++ b/boards/arm/arduino_nano_33_iot/pinmux.c
@@ -10,10 +10,11 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/arduino_zero/pinmux.c
+++ b/boards/arm/arduino_zero/pinmux.c
@@ -10,8 +10,11 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/atsamd20_xpro/pinmux.c
+++ b/boards/arm/atsamd20_xpro/pinmux.c
@@ -10,8 +10,11 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/atsamd21_xpro/pinmux.c
+++ b/boards/arm/atsamd21_xpro/pinmux.c
@@ -10,8 +10,11 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/atsame54_xpro/pinmux.c
+++ b/boards/arm/atsame54_xpro/pinmux.c
@@ -10,10 +10,15 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding("PINMUX_A");
-	const struct device *muxb = device_get_binding("PINMUX_B");
-	const struct device *muxc = device_get_binding("PINMUX_C");
-	const struct device *muxd = device_get_binding("PINMUX_D");
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+	const struct device *muxc = DEVICE_DT_GET(DT_NODELABEL(pinmux_c));
+	const struct device *muxd = DEVICE_DT_GET(DT_NODELABEL(pinmux_d));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
+	__ASSERT_NO_MSG(device_is_ready(muxc));
+	__ASSERT_NO_MSG(device_is_ready(muxd));
 
 	ARG_UNUSED(dev);
 	ARG_UNUSED(muxa);

--- a/boards/arm/atsamr21_xpro/pinmux.c
+++ b/boards/arm/atsamr21_xpro/pinmux.c
@@ -11,9 +11,13 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
-	const struct device *muxc = device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_c)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+	const struct device *muxc = DEVICE_DT_GET(DT_NODELABEL(pinmux_c));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
+	__ASSERT_NO_MSG(device_is_ready(muxc));
 
 	ARG_UNUSED(dev);
 

--- a/boards/arm/seeeduino_xiao/pinmux.c
+++ b/boards/arm/seeeduino_xiao/pinmux.c
@@ -10,15 +10,13 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
-	const struct device *muxb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_b)));
+	__unused const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+	__unused const struct device *muxb = DEVICE_DT_GET(DT_NODELABEL(pinmux_b));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
+	__ASSERT_NO_MSG(device_is_ready(muxb));
 
 	ARG_UNUSED(dev);
-	/* Prevent an unused variable error if all peripherals are disabled */
-	(void)muxa;
-	(void)muxb;
 
 #if ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_uart) && defined(CONFIG_UART_SAM0)
 	/* SERCOM4 on RX=PB9/pad 1, TX=PB8/pad 0 */

--- a/boards/arm/serpente/pinmux.c
+++ b/boards/arm/serpente/pinmux.c
@@ -10,8 +10,9 @@
 
 static int board_pinmux_init(const struct device *dev)
 {
-	const struct device *muxa =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_a)));
+	const struct device *muxa = DEVICE_DT_GET(DT_NODELABEL(pinmux_a));
+
+	__ASSERT_NO_MSG(device_is_ready(muxa));
 
 	ARG_UNUSED(dev);
 

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -43,8 +43,6 @@
 	};
 
 	aliases {
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
 		port-a = &porta;
 		port-b = &portb;
 		adc-0 = &adc;
@@ -101,13 +99,11 @@
 		pinmux_a: pinmux@41004400 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004400 0x80>;
-			label = "PINMUX_A";
 		};
 
 		pinmux_b: pinmux@41004480 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004480 0x80>;
-			label = "PINMUX_B";
 		};
 
 		wdog: watchdog@40001000 {

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -36,11 +36,6 @@
 		adc-0 = &adc0;
 		adc-1 = &adc1;
 
-		pinmux-a = &pinmux_a;
-		pinmux-b = &pinmux_b;
-		pinmux-c = &pinmux_c;
-		pinmux-d = &pinmux_d;
-
 		port-a = &porta;
 		port-b = &portb;
 		port-c = &portc;
@@ -142,25 +137,21 @@
 		pinmux_a: pinmux@41008000 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41008000 0x80>;
-			label = "PINMUX_A";
 		};
 
 		pinmux_b: pinmux@41008080 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41008080 0x80>;
-			label = "PINMUX_B";
 		};
 
 		pinmux_c: pinmux@41008100 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41008100 0x80>;
-			label = "PINMUX_C";
 		};
 
 		pinmux_d: pinmux@41008180 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41008180 0x80>;
-			label = "PINMUX_D";
 		};
 
 		wdog: watchdog@40002000 {

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -8,7 +8,6 @@
 
 / {
 	aliases {
-		pinmux-c = &pinmux_c;
 		port-c = &portc;
 	};
 
@@ -41,7 +40,6 @@
 		pinmux_c: pinmux@41004500 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004500 0x80>;
-			label = "PINMUX_C";
 		};
 
 		tcc0: tcc@42002000 {

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
 pinmux-cells:
   - pin
   - function


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>