### PR TITLE
arm: microchip: mec1501hsz: Rework device_get_binding for pinmux

### DIFF
--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -128,33 +128,45 @@ static int board_pinmux_init(const struct device *dev)
 	struct pinmux_ports_t pinmux_ports;
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_000_036), okay)
-	const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_000_036)));
+	const struct device *porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
+
+	__ASSERT_NO_MSG(device_is_ready(porta));
+
 	pinmux_ports.porta = porta;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_040_076), okay)
-	const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_040_076)));
+	const struct device *portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
+
+	__ASSERT_NO_MSG(device_is_ready(portb));
+
 	pinmux_ports.portb = portb;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_100_136), okay)
-	const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_100_136)));
+	const struct device *portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
+
+	__ASSERT_NO_MSG(device_is_ready(portc));
+
 	pinmux_ports.portc = portc;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_140_176), okay)
-	const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_140_176)));
+	const struct device *portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
+
+	__ASSERT_NO_MSG(device_is_ready(portd));
+
 	pinmux_ports.portd = portd;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_200_236), okay)
-	const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_200_236)));
+	const struct device *porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
+
+	__ASSERT_NO_MSG(device_is_ready(porte));
+
 	pinmux_ports.porte = porte;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_240_276), okay)
-	const struct device *portf =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_240_276)));
+	const struct device *portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
+
+	__ASSERT_NO_MSG(device_is_ready(portf));
+
 	pinmux_ports.portf = portf;
 #endif
 

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -130,33 +130,45 @@ static int board_pinmux_init(const struct device *dev)
 	struct pinmux_ports_t pinmux_ports;
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_000_036), okay)
-	const struct device *porta =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_000_036)));
+	const struct device *porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
+
+	__ASSERT_NO_MSG(device_is_ready(porta));
+
 	pinmux_ports.porta = porta;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_040_076), okay)
-	const struct device *portb =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_040_076)));
+	const struct device *portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
+
+	__ASSERT_NO_MSG(device_is_ready(portb));
+
 	pinmux_ports.portb = portb;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_100_136), okay)
-	const struct device *portc =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_100_136)));
+	const struct device *portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
+
+	__ASSERT_NO_MSG(device_is_ready(portc));
+
 	pinmux_ports.portc = portc;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_140_176), okay)
-	const struct device *portd =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_140_176)));
+	const struct device *portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
+
+	__ASSERT_NO_MSG(device_is_ready(portd));
+
 	pinmux_ports.portd = portd;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_200_236), okay)
-	const struct device *porte =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_200_236)));
+	const struct device *porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
+
+	__ASSERT_NO_MSG(device_is_ready(porte));
+
 	pinmux_ports.porte = porte;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_240_276), okay)
-	const struct device *portf =
-		device_get_binding(DT_LABEL(DT_NODELABEL(pinmux_240_276)));
+	const struct device *portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
+
+	__ASSERT_NO_MSG(device_is_ready(portf));
+
 	pinmux_ports.portf = portf;
 #endif
 

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -42,27 +42,21 @@
 
 		pinmux_000_036: pinmux-0 {
 			ph-reg = <&gpio_000_036>;
-			label = "PINMUX000_036";
 		};
 		pinmux_040_076: pinmux-1 {
 			ph-reg = <&gpio_040_076>;
-			label = "PINMUX040_076";
 		};
 		pinmux_100_136: pinmux-2 {
 			ph-reg = <&gpio_100_136>;
-			label = "PINMUX100_136";
 		};
 		pinmux_140_176: pinmux-3 {
 			ph-reg = <&gpio_140_176>;
-			label = "PINMUX140_176";
 		};
 		pinmux_200_236: pinmux-4 {
 			ph-reg = <&gpio_200_236>;
-			label = "PINMUX200_236";
 		};
 		pinmux_240_276: pinmux-5 {
 			ph-reg = <&gpio_240_276>;
-			label = "PINMUX240_276";
 		};
 	};
 

--- a/dts/bindings/pinctrl/microchip,xec-pinmux.yaml
+++ b/dts/bindings/pinctrl/microchip,xec-pinmux.yaml
@@ -10,7 +10,3 @@ child-binding:
        ph-reg:
           type: phandle
           required: true
-       label:
-          required: true
-          type: string
-          description: Human readable string describing the device (used as device_get_binding() argument)


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>