### PR TITLE
riscv: ite: it8xxx2: Rework device_get_binding for pinmux

### DIFF
--- a/boards/riscv/it8xxx2_evb/pinmux.c
+++ b/boards/riscv/it8xxx2_evb/pinmux.c
@@ -13,8 +13,9 @@ static int it8xxx2_evb_pinmux_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	const struct device *p =
-		device_get_binding(CONFIG_PINMUX_ITE_IT8XXX2_NAME);
+	const struct device *p = DEVICE_DT_GET(DT_NODELABEL(pinmux));
+
+	__ASSERT_NO_MSG(device_is_ready(p));
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 	pinmux_pin_set(p, 0, IT8XXX2_PINMUX_IOF1);

--- a/drivers/pinmux/Kconfig.it8xxx2
+++ b/drivers/pinmux/Kconfig.it8xxx2
@@ -1,12 +1,7 @@
 # Copyright (c) 2020 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PINMUX_ITE_IT8XXX2
+config PINMUX_ITE_IT8XXX2
 	bool "IT8XXX2 pinmux driver"
 	help
 	  Enable driver for the IT8XXX2 pinmux driver
-
-config PINMUX_ITE_IT8XXX2_NAME
-	string "IT8XXX2 pinmux driver name"
-	default "PINMUX"
-	depends on PINMUX_ITE_IT8XXX2

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinmux.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinmux.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -45,7 +45,6 @@
 		pinmux: pinmux@f016f0 {
 			compatible = "ite,it8xxx2-pinmux";
 			reg = <0x00f016f0 0x0010>;
-			label = "PINMUX";
 		};
 		sram0: memory@80080000 {
 			compatible = "mmio-sram";


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>