### PR TITLE
xtensa: intel_s1000: Rework device_get_binding for pinmux

### DIFF
--- a/boards/xtensa/intel_s1000_crb/pinmux.c
+++ b/boards/xtensa/intel_s1000_crb/pinmux.c
@@ -25,7 +25,9 @@ static int intel_s1000_pinmux_init(const struct device *dev)
 {
 	const struct device *pinmux;
 
-	pinmux = device_get_binding(DT_LABEL(DT_INST(0, intel_s1000_pinmux)));
+	pinmux = DEVICE_DT_GET(DT_INST(0, intel_s1000_pinmux));
+
+	__ASSERT_NO_MSG(device_is_ready(pinmux));
 
 	if (pinmux == NULL) {
 		return -ENXIO;

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -9,9 +9,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
 pinmux-cells:
   - pin
   - function

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -123,7 +123,6 @@
 		pinmux: pinmux@81c30 {
 			compatible = "intel,s1000-pinmux";
 			reg = <0x00081c30 0xC>;
-			label = "PINMUX";
 		};
 
 		uart0: uart@80800 {


### PR DESCRIPTION
Switch to use DEVICE_DT_GET instead of device_get_binding for pinmux
device.  As part of this change drop the "label" property from
the pinmux devicetree node and update the binding and dts files to
reflect that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>