### PR TITLE
 samples: tests: Fix usb.audio.headset test

### DIFF
--- a/samples/subsys/usb/audio/headphones_microphone/sample.yaml
+++ b/samples/subsys/usb/audio/headphones_microphone/sample.yaml
@@ -5,3 +5,12 @@ tests:
     depends_on: usb_device
     tags: usb
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Entered main"
+        - "Found USB Headphones Device"
+        - "Found USB Microphone Device"
+        - "USB enabled"

--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -76,10 +76,14 @@ void main(void)
 		return;
 	}
 
+	LOG_INF("Found USB Headphones Device");
+
 	if (!mic_dev) {
 		LOG_ERR("Can not get USB Microphone Device");
 		return;
 	}
+
+	LOG_INF("Found USB Microphone Device");
 
 	usb_audio_register(hp_dev, &hp_ops);
 
@@ -90,4 +94,6 @@ void main(void)
 		LOG_ERR("Failed to enable USB");
 		return;
 	}
+
+	LOG_INF("USB enabled");
 }

--- a/samples/subsys/usb/audio/headset/sample.yaml
+++ b/samples/subsys/usb/audio/headset/sample.yaml
@@ -5,3 +5,11 @@ tests:
     depends_on: usb_device
     tags: usb
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Entered main"
+        - "Found USB Headset Device"
+        - "USB enabled"

--- a/samples/subsys/usb/audio/headset/src/main.c
+++ b/samples/subsys/usb/audio/headset/src/main.c
@@ -70,6 +70,8 @@ void main(void)
 		return;
 	}
 
+	LOG_INF("Found USB Headset Device");
+
 	usb_audio_register(hs_dev, &ops);
 
 	ret = usb_enable(NULL);
@@ -77,4 +79,6 @@ void main(void)
 		LOG_ERR("Failed to enable USB");
 		return;
 	}
+
+	LOG_INF("USB enabled");
 }


### PR DESCRIPTION
 samples: tests: Fix usb.audio.headset test
 
 The samples were failing twister test with a timeout because there were
no pass/fail criteria for them (nothing was tested). The fix adds
harness on console and some output that can be verified.
