### PR TITLE
samples: tests: Fix sample.boards.nrf.nrfx test

### DIFF
--- a/samples/boards/nrf/nrfx/sample.yaml
+++ b/samples/boards/nrf/nrfx/sample.yaml
@@ -4,3 +4,10 @@ tests:
   sample.boards.nrf.nrfx:
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: board
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "nrfx_gpiote initialized"
+        - "\\(D\\)PPI configured, leaving main()"


### PR DESCRIPTION
The sample was failing twister test with a timeout because there was
no pass/fail criteria for it (nothing was tested). The fix adds
harness on consolse and some output that can be verified.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>