### PR TITLE
tests: drivers: can: timing: Fix potential div by zero

### DIFF
--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -61,6 +61,8 @@ static void verify_bitrate(struct can_timing  *timing, uint32_t bitrate)
 	uint32_t bitrate_calc;
 	int ret;
 
+	zassert_not_equal(timing->prescaler, 0, "Prescaler is zero");
+
 	ret = can_get_core_clock(can_dev, &core_clock);
 	zassert_equal(ret, 0, "Unable to get core clock");
 


### PR DESCRIPTION
If the prescaler is zero in the test, a div by zero would happen.
Add an assert to check for zero prescaler.
Fix CID 216790 (#31675)