### PR TITLE
drivers: clock_control: npcx: Convert to use DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -160,7 +160,7 @@ const struct npcx_pcc_config pcc_config = {
 	.base_pmc  = DT_INST_REG_ADDR_BY_NAME(0, pmc),
 };
 
-DEVICE_DEFINE(npcx_cdcg, NPCX_CLK_CTRL_NAME,
+DEVICE_DT_INST_DEFINE(0,
 		    &npcx_clock_control_init,
 		    device_pm_control_nop,
 		    NULL, &pcc_config,

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /* Common clock control device name for all NPCX series */
-#define NPCX_CLK_CTRL_NAME "npcx-cc"
+#define NPCX_CLK_CTRL_NAME DT_LABEL(DT_NODELABEL(pcc))
 
 /**
  * @brief NPCX clock configuration structure


### PR DESCRIPTION
The NPCX clock driver was already using devicetree, just need to make a
small tweak to use DEVICE_DT_INST_DEFINE and update NPCX_CLK_CTRL_NAME
to match the label for the "nuvoton,npcx-pcc" clock controller.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>