### PR TITLE
drivers: i2c: Add some Kconfig depends

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -3,6 +3,7 @@
 
 config I2C_ITE_IT8XXX2
 	bool "ITE IT8XXX2 I2C driver"
+	depends on SOC_IT8XXX2
 	help
 	  Enable I2C support on it8xxx2_evb.
 	  Supported Speeds: 100kHz, 400kHz and 1MHz.

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -7,6 +7,7 @@ DT_COMPAT_ST_STM32_I2C_V2 := st,stm32-i2c-v2
 menuconfig I2C_STM32
 	bool "STM32 I2C driver"
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V1)) || $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V2))
+	depends on SOC_FAMILY_STM32
 	help
 	  Enable I2C support on the STM32 SoCs
 


### PR DESCRIPTION
Add some simple depends so we limit various I2C drivers to the SoC
families that the drivers are relevant to.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>