### PR TITLE
devicetree: clocks: provide accessors for controller phandle

### DIFF
--- a/include/devicetree/clocks.h
+++ b/include/devicetree/clocks.h
@@ -23,6 +23,72 @@ extern "C" {
  */
 
 /**
+ * @brief Get the node identifier for the controller phandle from a
+ *        "clocks" phandle-array property at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     clk1: clock-controller@... { ... };
+ *
+ *     clk2: clock-controller@... { ... };
+ *
+ *     n: node {
+ *             clocks = <&clk1 10 20>, <&clk2 30 40>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_CLOCKS_CTLR_BY_IDX(DT_NODELABEL(n), 0)) // DT_NODELABEL(clk1)
+ *     DT_CLOCKS_CTLR_BY_IDX(DT_NODELABEL(n), 1)) // DT_NODELABEL(clk2)
+ *
+ * @param node_id node identifier
+ * @param idx logical index into "clocks"
+ * @return the node identifier for the clock controller referenced at
+ *         index "idx"
+ * @see DT_PHANDLE_BY_IDX()
+ */
+#define DT_CLOCKS_CTLR_BY_IDX(node_id, idx) \
+	DT_PHANDLE_BY_IDX(node_id, clocks, idx)
+
+/**
+ * @brief Equivalent to DT_CLOCKS_CTLR_BY_IDX(node_id, 0)
+ * @param node_id node identifier
+ * @return a node identifier for the clocks controller at index 0
+ *         in "clocks"
+ * @see DT_CLOCKS_CTLR_BY_IDX()
+ */
+#define DT_CLOCKS_CTLR(node_id) DT_CLOCKS_CTLR_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get the node identifier for the controller phandle from a
+ *        clocks phandle-array property at an index
+ *
+
+ * Example devicetree fragment:
+ *
+ *     clk1: clock-controller@... { ... };
+ *
+ *     clk2: clock-controller@... { ... };
+ *
+ *     n: node {
+ *             clocks = <&clk1 10 20>, <&clk2 30 40>;
+ *             clock-names = "alpha", "beta";
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_CLOCKS_CTLR_BY_NAME(DT_NODELABEL(n), beta) // DT_NODELABEL(clk2)
+ *
+ * @param node_id node identifier
+ * @param name lowercase-and-underscores name of a clocks element
+ *             as defined by the node's clock-names property
+ * @return the node identifier for the clock controller referenced by name
+ * @see DT_PHANDLE_BY_NAME()
+ */
+#define DT_CLOCKS_CTLR_BY_NAME(node_id, name) \
+	DT_PHANDLE_BY_NAME(node_id, clocks, name)
+
+/**
  * @brief Get a label property from the node referenced by a pwms
  *        property at an index
  *
@@ -177,6 +243,42 @@ extern "C" {
  * @see DT_CLOCKS_CELL_BY_IDX()
  */
 #define DT_CLOCKS_CELL(node_id, cell) DT_CLOCKS_CELL_BY_IDX(node_id, 0, cell)
+
+/**
+ * @brief Get the node identifier for the controller phandle from a
+ *        "clocks" phandle-array property at an index
+ *
+ * @param inst instance number
+ * @param idx logical index into "clocks"
+ * @return the node identifier for the clock controller referenced at
+ *         index "idx"
+ * @see DT_CLOCKS_CTLR_BY_IDX()
+ */
+#define DT_INST_CLOCKS_CTLR_BY_IDX(inst, idx) \
+	DT_CLOCKS_CTLR_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Equivalent to DT_INST_CLOCKS_CTLR_BY_IDX(inst, 0)
+ * @param inst instance number
+ * @return a node identifier for the clocks controller at index 0
+ *         in "clocks"
+ * @see DT_CLOCKS_CTLR()
+ */
+#define DT_INST_CLOCKS_CTLR(inst) DT_INST_CLOCKS_CTLR_BY_IDX(inst, 0)
+
+/**
+ * @brief Get the node identifier for the controller phandle from a
+ *        clocks phandle-array property by name
+ *
+ * @param inst instance number
+ * @param name lowercase-and-underscores name of a clocks element
+ *             as defined by the node's clock-names property
+ * @return the node identifier for the clock controller referenced by
+ *         the named element
+ * @see DT_CLOCKS_CTLR_BY_NAME()
+ */
+#define DT_INST_CLOCKS_CTLR_BY_NAME(inst, name) \
+	DT_CLOCKS_CTLR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
  * @brief Get a label property from a DT_DRV_COMPAT instance's clocks

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1270,6 +1270,18 @@ static void test_enums_required_false(void)
 #define DT_DRV_COMPAT vnd_adc_temp_sensor
 static void test_clocks(void)
 {
+	/* DT_CLOCKS_CTLR_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_CLOCKS_CTLR_BY_IDX(TEST_TEMP, 1),
+				  DT_NODELABEL(test_fixed_clk)), "");
+
+	/* DT_CLOCKS_CTLR */
+	zassert_true(DT_SAME_NODE(DT_CLOCKS_CTLR(TEST_TEMP),
+				  DT_NODELABEL(test_clk)), "");
+
+	/* DT_CLOCKS_CTLR_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_CLOCKS_CTLR_BY_NAME(TEST_TEMP, clk_b),
+				  DT_NODELABEL(test_clk)), "");
+
 	/* DT_CLOCKS_LABEL_BY_IDX */
 	zassert_true(!strcmp(DT_CLOCKS_LABEL_BY_IDX(TEST_TEMP, 0),
 			     "TEST_CLOCK"), "");
@@ -1300,6 +1312,18 @@ static void test_clocks(void)
 
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
+
+	/* DT_INST_CLOCKS_CTLR_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_INST_CLOCKS_CTLR_BY_IDX(0, 1),
+				  DT_NODELABEL(test_fixed_clk)), "");
+
+	/* DT_INST_CLOCKS_CTLR */
+	zassert_true(DT_SAME_NODE(DT_INST_CLOCKS_CTLR(0),
+				  DT_NODELABEL(test_clk)), "");
+
+	/* DT_INST_CLOCKS_CTLR_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_INST_CLOCKS_CTLR_BY_NAME(0, clk_b),
+				  DT_NODELABEL(test_clk)), "");
 
 	/* DT_INST_CLOCKS_LABEL_BY_IDX */
 	zassert_true(!strcmp(DT_INST_CLOCKS_LABEL_BY_IDX(0, 0),


### PR DESCRIPTION
Provide a helper to extract the devicetree node_id for a CLOCKS
controller from a clocks phandle array.  This can be used with
DEVICE_DT_GET() to directly reference the corresponding controller
device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>