### PR TITLE
drivers: net_offload: Convert offload network drivers to DT device macros

### DIFF
--- a/drivers/modem/Kconfig.ublox-sara-r4
+++ b/drivers/modem/Kconfig.ublox-sara-r4
@@ -39,10 +39,6 @@ config MODEM_UBLOX_SARA_AUTODETECT_VARIANT
 
 endchoice
 
-config MODEM_UBLOX_SARA_R4_NAME
-	string "Driver name"
-	default "MODEM_SARA"
-
 config MODEM_UBLOX_SARA_R4_RX_STACK_SIZE
 	int "Stack size for the u-blox SARA-R4 modem driver RX thread"
 	default 1028

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -4886,6 +4886,7 @@ static struct net_if_api api_funcs = {
 	.init = offload_iface_init,
 };
 
-NET_DEVICE_OFFLOAD_INIT(modem_hl7800, "MODEM_HL7800", hl7800_init,
-			device_pm_control_nop, &ictx, NULL,
-			CONFIG_MODEM_HL7800_INIT_PRIORITY, &api_funcs, MDM_MTU);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, hl7800_init, device_pm_control_nop,
+				  &ictx, NULL,
+				  CONFIG_MODEM_HL7800_INIT_PRIORITY, &api_funcs,
+				  MDM_MTU);

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1173,10 +1173,10 @@ error:
 }
 
 /* Register the device with the Networking stack. */
-NET_DEVICE_OFFLOAD_INIT(modem_gb9x, DT_INST_LABEL(0),
-			modem_init, device_pm_control_nop, &mdata, NULL,
-			CONFIG_MODEM_QUECTEL_BG9X_INIT_PRIORITY, &api_funcs,
-			MDM_MAX_DATA_LENGTH);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, device_pm_control_nop,
+				  &mdata, NULL,
+				  CONFIG_MODEM_QUECTEL_BG9X_INIT_PRIORITY,
+				  &api_funcs, MDM_MAX_DATA_LENGTH);
 
 /* Register NET sockets. */
 NET_SOCKET_REGISTER(quectel_bg9x, AF_UNSPEC, offload_is_supported, offload_socket);

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1917,7 +1917,8 @@ error:
 	return ret;
 }
 
-NET_DEVICE_OFFLOAD_INIT(modem_sara, CONFIG_MODEM_UBLOX_SARA_R4_NAME,
-			modem_init, device_pm_control_nop, &mdata, NULL,
-			CONFIG_MODEM_UBLOX_SARA_R4_INIT_PRIORITY, &api_funcs,
-			MDM_MAX_DATA_LENGTH);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, device_pm_control_nop,
+				  &mdata, NULL,
+				  CONFIG_MODEM_UBLOX_SARA_R4_INIT_PRIORITY,
+				  &api_funcs,
+				  MDM_MAX_DATA_LENGTH);

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1848,7 +1848,8 @@ static struct net_if_api api_funcs = {
 	.init	= offload_iface_init,
 };
 
-NET_DEVICE_OFFLOAD_INIT(modem_wncm14a2a, "MODEM_WNCM14A2A",
-			wncm14a2a_init, device_pm_control_nop, &ictx,
-			NULL, CONFIG_MODEM_WNCM14A2A_INIT_PRIORITY, &api_funcs,
-			MDM_MAX_DATA_LENGTH);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, wncm14a2a_init, device_pm_control_nop,
+				  &ictx, NULL,
+				  CONFIG_MODEM_WNCM14A2A_INIT_PRIORITY,
+				  &api_funcs,
+				  MDM_MAX_DATA_LENGTH);

--- a/drivers/wifi/esp/Kconfig.esp
+++ b/drivers/wifi/esp/Kconfig.esp
@@ -12,10 +12,6 @@ menuconfig WIFI_ESP
 
 if WIFI_ESP
 
-config WIFI_ESP_NAME
-	string "Driver name"
-	default "esp-wifi-modem"
-
 config WIFI_ESP_RX_STACK_SIZE
 	int "Stack size for the Espressif esp wifi driver RX thread"
 	default 1024

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -1130,7 +1130,7 @@ error:
 	return ret;
 }
 
-NET_DEVICE_OFFLOAD_INIT(wifi_esp, CONFIG_WIFI_ESP_NAME,
-			esp_init, device_pm_control_nop, &esp_driver_data, NULL,
-			CONFIG_WIFI_INIT_PRIORITY, &esp_api,
-			ESP_MTU);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, esp_init, device_pm_control_nop,
+				  &esp_driver_data, NULL,
+				  CONFIG_WIFI_INIT_PRIORITY, &esp_api,
+				  ESP_MTU);

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -689,6 +689,8 @@ static const struct net_wifi_mgmt_offload eswifi_offload_api = {
 	.ap_disable	= eswifi_mgmt_ap_disable,
 };
 
-NET_DEVICE_OFFLOAD_INIT(eswifi_mgmt, DT_INST_LABEL(0),
-			eswifi_init, device_pm_control_nop, &eswifi0, NULL,
-			CONFIG_WIFI_INIT_PRIORITY, &eswifi_offload_api, 1500);
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, eswifi_init, device_pm_control_nop,
+				  &eswifi0, NULL,
+				  CONFIG_WIFI_INIT_PRIORITY,
+				  &eswifi_offload_api,
+				  1500);


### PR DESCRIPTION
Convert net_offload drivers that already support DT to use DT device macros for device definition:

`NET_DEVICE_OFFLOAD_INIT` -> `NET_DEVICE_DT_INST_OFFLOAD_DEFINE`
