### PR TITLE
lib/p4wq: Fix race with completed work items

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -233,6 +233,17 @@ extern void k_thread_foreach_unlocked(
  */
 #define K_INHERIT_PERMS (BIT(3))
 
+/**
+ * @brief Callback item state
+ *
+ * @details
+ * This is a single bit of state reserved for "callback manager"
+ * utilities (p4wq initially) who need to track operations invoked
+ * from within a user-provided callback they have been invoked.
+ * Effectively it serves as a tiny bit of zero-overhead TLS data.
+ */
+#define K_CALLBACK_STATE (BIT(4))
+
 #ifdef CONFIG_X86
 /* x86 Bitmask definitions for threads user options */
 


### PR DESCRIPTION
Work items can be legally resubmitted from within their own handler.
Currently the p4wq detects this case by checking their thread field to
see if it's been set to NULL.  But that's a race, because if the item
was NOT resubmitted then it no longer belongs to the queue and may
have been freed or reused or otherwise clobbered legally by user code.

Instead, steal a single bit in the thread struct for this purpose.
This patch adds a K_CALLBACK_STATE bit in user_options and documents
it in such a way (as being intended for "callback manager" utilities)
that it can't be used recursively or otherwise collide.

Fixes #32052

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>