### PR TITLE
Bluetooth: SMP: fix for bt fixed passkey BT_PASSKEY_INVALID

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5472,7 +5472,7 @@ int bt_smp_auth_pairing_confirm(struct bt_conn *conn)
 int bt_passkey_set(unsigned int passkey)
 {
 	if (passkey == BT_PASSKEY_INVALID) {
-		passkey = BT_PASSKEY_INVALID;
+		fixed_passkey = BT_PASSKEY_INVALID;
 		return 0;
 	}
 


### PR DESCRIPTION
when BT_PASSKEY_INVALID was set, it never updated the fixed
passkey which made its use ineffective

Signed-off-by: faisal Saleem <faisal.saleem@setec.com.au>