### PR TITLE
arch: x86: zefi: add license identifier to zefi.ld

### DIFF
--- a/arch/x86/zefi/efi.ld
+++ b/arch/x86/zefi/efi.ld
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020-2021 Intel Corporation
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 ENTRY(efi_entry)
 
 SECTIONS {


### PR DESCRIPTION
Add missing license identifier to linker file, needed
for release.

Partial fix for #32194.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>