### PR TITLE
net: offload: fix device and driver names generated by DT device macros

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2431,7 +2431,8 @@ struct net_if_api {
  */
 #define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_control_fn,	\
 				   data, cfg, prio, api, mtu)		\
-	Z_NET_DEVICE_OFFLOAD_INIT(node_id, node_id, DT_LABEL(node_id),	\
+	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
+				  DT_PROP_OR(node_id, label, NULL),	\
 				  init_fn, pm_control_fn, data, cfg,	\
 				  prio, api, mtu)
 


### PR DESCRIPTION
Generated device and driver names have changed with commits [1] and [2],
but net offload drivers missed the conversion. Update net offload DT
device macros now.

[1] commit 8c1bef535bff ("device: support generating defines from
  devicetree nodes with no label")
[2] commit f91e9fba51e5 ("device: fix potential truncation of DT-derived
  device names")