### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 43845e883ff3a6cdaae22e23f3e60b5fcf78c6ba
+      revision: c52ecb771a9b2bdabfc70bee094555f11edbb539
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 41132e9220f8bc1223084975350c5e5f3b492afe


### PR DESCRIPTION
Commits affecting Zephyr that are included with the new revision:
-   fb489e1f mgmt: Add support for un-registering a group along with  the same support in img_mgmt
-   c8151d80 zephyr: Rely on img_mgmt_find_best_area_id to select update  partition
-   b92aa0b8 Fix encoding usage for halffloat

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

