### PR TITLE
pinmux: sifive: Convert SiFive pinmux to be devicetree based

### DIFF
--- a/boards/riscv/hifive1/pinmux.c
+++ b/boards/riscv/hifive1/pinmux.c
@@ -12,7 +12,9 @@ static int hifive1_pinmux_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	const struct device *p = device_get_binding(CONFIG_PINMUX_SIFIVE_0_NAME);
+	const struct device *p = DEVICE_DT_GET(DT_NODELABEL(pinctrl));
+
+	__ASSERT_NO_MSG(device_is_ready(p));
 
 	/* UART0 RX */
 	pinmux_pin_set(p, 16, SIFIVE_PINMUX_IOF0);

--- a/boards/riscv/hifive1_revb/pinmux.c
+++ b/boards/riscv/hifive1_revb/pinmux.c
@@ -12,7 +12,9 @@ static int hifive1_revb_pinmux_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	const struct device *p = device_get_binding(CONFIG_PINMUX_SIFIVE_0_NAME);
+	const struct device *p = DEVICE_DT_GET(DT_NODELABEL(pinctrl));
+
+	__ASSERT_NO_MSG(device_is_ready(p));
 
 #ifdef CONFIG_UART_SIFIVE
 #ifdef CONFIG_UART_SIFIVE_PORT_0

--- a/drivers/pinmux/Kconfig.sifive
+++ b/drivers/pinmux/Kconfig.sifive
@@ -3,13 +3,8 @@
 # Copyright (c) 2017 Jean-Paul Etienne <fractalclone@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PINMUX_SIFIVE
+config PINMUX_SIFIVE
 	bool "SiFive Freedom SOC pinmux driver"
 	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
 	help
 	  Enable driver for the SiFive Freedom SOC pinmux driver
-
-config PINMUX_SIFIVE_0_NAME
-	string "SIFIVE pinmux 0 driver name"
-	default "pinmux0"
-	depends on PINMUX_SIFIVE

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT sifive_iof
+
 /**
  * @brief PINMUX driver for the SiFive Freedom Processor
  */
@@ -94,10 +96,10 @@ static const struct pinmux_driver_api pinmux_sifive_driver_api = {
 };
 
 static const struct pinmux_sifive_config pinmux_sifive_0_config = {
-	.base = SIFIVE_PINMUX_0_BASE_ADDR,
+	.base = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DEFINE(pinmux_sifive_0, CONFIG_PINMUX_SIFIVE_0_NAME,
+DEVICE_DT_INST_DEFINE(0,
 		    &pinmux_sifive_init, device_pm_control_nop, NULL,
 		    &pinmux_sifive_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/dts/bindings/pinctrl/sifive,iof.yaml
+++ b/dts/bindings/pinctrl/sifive,iof.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2021, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  SiFive FE310 IO Function (iof)
+  Binding covers the IOF_EN/IOF_SEL registers that are a subset of the GPIO
+  controller.
+
+compatible: "sifive,iof"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+pinmux-cells:
+  - pin
+  - function

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -93,6 +93,15 @@
 			label = "gpio_0";
 			status = "disabled";
 			#gpio-cells = <2>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			pinctrl: pinctrl@10012038 {
+				compatible = "sifive,iof";
+				reg = <0x10012038 0x8>;
+			};
 		};
 		i2c0: i2c@10016000 {
 			compatible = "sifive,i2c0";

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -14,9 +14,6 @@
 #include <soc_common.h>
 #include <devicetree.h>
 
-/* PINMUX Configuration */
-#define SIFIVE_PINMUX_0_BASE_ADDR     (DT_REG_ADDR(DT_INST(0, sifive_gpio0)) + 0x38)
-
 /* PINMUX IO Hardware Functions */
 #define SIFIVE_PINMUX_IOF0            0x00
 #define SIFIVE_PINMUX_IOF1            0x01


### PR DESCRIPTION
Add a simple pinctrl node for the IOF registers under the GPIO
controller node to be used by the pinmux driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>