### PR TITLE
lib: os: Introduce support for CRC32C algorithm

### DIFF
--- a/include/sys/crc.h
+++ b/include/sys/crc.h
@@ -162,6 +162,21 @@ uint32_t crc32_ieee(const uint8_t *data, size_t len);
 uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len);
 
 /**
+ * @brief Calculate CRC32C (Castagnoli) checksum.
+ *
+ * @param crc       CRC32C checksum that needs to be updated.
+ * @param *data     Pointer to data on which the CRC should be calculated.
+ * @param len       Data length.
+ * @param first_pkt Whether this is the first packet in the stream.
+ * @param last_pkt  Whether this is the last packet in the stream.
+ *
+ * @return CRC32 value.
+ *
+ */
+uint32_t crc32_c(uint32_t crc, const uint8_t *data,
+		 size_t len, bool first_pkt, bool last_pkt);
+
+/**
  * @brief Compute CCITT variant of CRC 8
  *
  * Normal CCITT variant of CRC 8 is using 0x07.

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_sources_ifdef(CONFIG_BASE64 base64.c)
 
 zephyr_sources(
   cbprintf.c
+  crc32c_sw.c
   crc32_sw.c
   crc16_sw.c
   crc8_sw.c

--- a/lib/os/crc32c_sw.c
+++ b/lib/os/crc32c_sw.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Workaround GmbH.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/crc.h>
+
+/* crc table generated from polynomial 0x1EDC6F41UL (Castagnoli) */
+static const uint32_t crc32c_table[16] = {
+	0x00000000UL, 0x105EC76FUL, 0x20BD8EDEUL, 0x30E349B1UL,
+	0x417B1DBCUL, 0x5125DAD3UL, 0x61C69362UL, 0x7198540DUL,
+	0x82F63B78UL, 0x92A8FC17UL, 0xA24BB5A6UL, 0xB21572C9UL,
+	0xC38D26C4UL, 0xD3D3E1ABUL, 0xE330A81AUL, 0xF36E6F75UL
+};
+
+/* This value needs to be XORed with the final crc value once crc for
+ * the entire stream is calculated. This is a requirement of crc32c algo.
+ */
+#define CRC32C_XOR_OUT	0xFFFFFFFFUL
+
+/* The crc32c algorithm requires the below value as Init value at the
+ * beginning of the stream.
+ */
+#define CRC32C_INIT	0xFFFFFFFFUL
+
+uint32_t crc32_c(uint32_t crc, const uint8_t *data,
+		 size_t len, bool first_pkt, bool last_pkt)
+{
+	if (first_pkt) {
+		crc = CRC32C_INIT;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		crc = crc32c_table[(crc ^ data[i]) & 0x0F] ^ (crc >> 4);
+		crc = crc32c_table[(crc ^ (data[i] >> 4)) & 0x0F] ^ (crc >> 4);
+	}
+
+	return last_pkt ? (crc ^ CRC32C_XOR_OUT) : crc;
+}

--- a/tests/unit/crc/main.c
+++ b/tests/unit/crc/main.c
@@ -9,8 +9,35 @@
 #include "../../../lib/os/crc8_sw.c"
 #include "../../../lib/os/crc16_sw.c"
 #include "../../../lib/os/crc32_sw.c"
+#include "../../../lib/os/crc32c_sw.c"
 #include "../../../lib/os/crc7_sw.c"
 
+void test_crc32c(void)
+{
+	uint8_t test1[] = { 'A' };
+	uint8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+	uint8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r' };
+
+	/* Single streams */
+	zassert_equal(crc32_c(0, test1, sizeof(test1), true, true),
+			0xE16DCDEE, NULL);
+	zassert_equal(crc32_c(0, test2, sizeof(test2), true, true),
+			0xE3069283, NULL);
+	zassert_equal(crc32_c(0, test3, sizeof(test3), true, true),
+			0xFCDEB58D, NULL);
+
+	/* Continuous streams - test1, test2 and test3 are considered part
+	 * of one big stream whose CRC needs to be calculated. Note that the
+	 * CRC of the first string is passed over to the second crc calculation,
+	 * second to third and so on.
+	 */
+	zassert_equal(crc32_c(0, test1, sizeof(test1), true, false),
+			0x1E923211, NULL);
+	zassert_equal(crc32_c(0x1E923211, test2, sizeof(test2), false, false),
+			0xB2983B83, NULL);
+	zassert_equal(crc32_c(0xB2983B83, test3, sizeof(test3), false, true),
+			0x7D4F9D21, NULL);
+}
 
 void test_crc32_ieee(void)
 {
@@ -205,6 +232,7 @@ void test_crc8(void)
 void test_main(void)
 {
 	ztest_test_suite(test_crc,
+			 ztest_unit_test(test_crc32c),
 			 ztest_unit_test(test_crc32_ieee),
 			 ztest_unit_test(test_crc16),
 			 ztest_unit_test(test_crc16_ansi),


### PR DESCRIPTION
This introduces the support for CRC32C (Castagnoli) algorithm.
The generator polynomial used is 0x1EDC6F41UL.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>