### PR TITLE
pinctrl: cc13x2_cc26x2: drop label property from pinmux node

### DIFF
--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -48,7 +48,6 @@
 		pinmux: pinmux@40081000 {
 			compatible = "ti,cc13xx-cc26xx-pinmux";
 			reg = <0x40081000 0x1000>;
-			label = "PINMUX";
 		};
 
 		gpio0: gpio@40022000 {

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true


### PR DESCRIPTION
We've removed the need for label properties from the pinmux devicetree
nodes on all other controllers and its not required for the TI one, so
remove it from the .dts and drop label being required in the binding.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>