### PR TITLE
soc: stm32: convert to use DEVICE_DT_GET for clocks

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -584,8 +584,7 @@ static int adc_stm32_init(const struct device *dev)
 {
 	struct adc_stm32_data *data = dev->data;
 	const struct adc_stm32_cfg *config = dev->config;
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 	int err;
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -398,8 +398,7 @@ int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct device *clock;
 	int ret;
 
-	clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clock);
+	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ret = clock_control_get_rate(clock,
 				     (clock_control_subsys_t *) &cfg->pclken,
@@ -438,8 +437,7 @@ static int can_stm32_init(const struct device *dev)
 	(void)memset(data->rx_cb, 0, sizeof(data->rx_cb));
 	(void)memset(data->cb_arg, 0, sizeof(data->cb_arg));
 
-	clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clock);
+	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ret = clock_control_on(clock, (clock_control_subsys_t *) &cfg->pclken);
 	if (ret != 0) {

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -286,14 +286,15 @@ void rtc_stm32_isr(const struct device *dev)
 
 static int rtc_stm32_init(const struct device *dev)
 {
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct rtc_stm32_config *cfg = DEV_CFG(dev);
-
-	__ASSERT_NO_MSG(clk);
 
 	DEV_DATA(dev)->callback = NULL;
 
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	if (clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken) != 0) {
+		LOG_ERR("clock op failed\n");
+		return -EIO;
+	}
 
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -423,13 +423,14 @@ static int crypto_stm32_query_caps(const struct device *dev)
 
 static int crypto_stm32_init(const struct device *dev)
 {
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(dev);
 	const struct crypto_stm32_config *cfg = CRYPTO_STM32_CFG(dev);
 
-	__ASSERT_NO_MSG(clk);
-
-	clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken);
+	if (clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken) != 0) {
+		LOG_ERR("clock op failed\n");
+		return -EIO;
+	}
 
 	k_sem_init(&data->device_sem, 1, 1);
 	k_sem_init(&data->session_sem, 1, 1);

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -121,8 +121,7 @@ static int dac_stm32_init(const struct device *dev)
 	int err;
 
 	/* enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t *) &cfg->pclken) != 0) {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -577,8 +577,7 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 static int dma_stm32_init(const struct device *dev)
 {
 	const struct dma_stm32_config *config = dev->config;
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (clock_control_on(clk,
 		(clock_control_subsys_t *) &config->pclken) != 0) {

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -163,8 +163,7 @@ static int dmamux_stm32_init(const struct device *dev)
 {
 	struct dmamux_stm32_data *data = dev->data;
 	const struct dmamux_stm32_config *config = dev->config;
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (clock_control_on(clk,
 		(clock_control_subsys_t *) &config->pclken) != 0) {

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -411,8 +411,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 #endif /* CONFIG_SOC_SERIES_STM32L4X */
 
-	dev_data->clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(dev_data->clock != NULL);
+	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	res = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&dev_cfg->pclken);

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -635,8 +635,7 @@ static int eth_initialize(const struct device *dev)
 	__ASSERT_NO_MSG(dev_data != NULL);
 	__ASSERT_NO_MSG(cfg != NULL);
 
-	dev_data->clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(dev_data->clock != NULL);
+	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* enable clock */
 	ret = clock_control_on(dev_data->clock,

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -364,7 +364,7 @@ static int stm32_flash_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32F3X) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/*
 	 * On STM32F0, Flash interface clock source is always HSI,

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -753,15 +753,13 @@ static int flash_stm32_qspi_init(const struct device *dev)
 #endif /* STM32_QSPI_USE_DMA */
 
 	/* Clock configuration */
-	__ASSERT_NO_MSG(device_get_binding(STM32_CLOCK_CONTROL_NAME));
-
-	if (clock_control_on(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			     (clock_control_subsys_t) &dev_cfg->pclken) != 0) {
 		LOG_DBG("Could not enable QSPI clock");
 		return -EIO;
 	}
 
-	if (clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			(clock_control_subsys_t) &dev_cfg->pclken,
 			&ahb_clock_freq) < 0) {
 		LOG_DBG("Failed to get AHB clock frequency");

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -606,7 +606,7 @@ static const struct flash_driver_api flash_stm32h7_api = {
 static int stm32h7_flash_init(const struct device *dev)
 {
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* enable clock */
 	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -309,7 +309,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 	defined(CONFIG_SOC_SERIES_STM32L1X) || \
 	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X)
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct stm32_pclken pclken = {
 #ifdef CONFIG_SOC_SERIES_STM32H7X
 		.bus = STM32_CLOCK_BUS_APB4,
@@ -531,8 +531,7 @@ static int gpio_stm32_init(const struct device *device)
 	data->dev = device;
 
 	/* enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t *)&cfg->pclken) != 0) {

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -43,7 +43,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	LL_RCC_GetSystemClocksFreq(&rcc_clocks);
 	clock = rcc_clocks.SYSCLK_Frequency;
 #else
-	if (clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			(clock_control_subsys_t *) &cfg->pclken, &clock) < 0) {
 		LOG_ERR("Failed call clock_control_get_rate");
 		return -EIO;
@@ -180,7 +180,7 @@ static const struct i2c_driver_api api_funcs = {
 
 static int i2c_stm32_init(const struct device *dev)
 {
-	const struct device *clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
 	uint32_t bitrate_cfg;
 	int ret;
@@ -206,7 +206,6 @@ static int i2c_stm32_init(const struct device *dev)
 	 */
 	k_sem_init(&data->bus_mutex, 1, 1);
 
-	__ASSERT_NO_MSG(clock);
 	if (clock_control_on(clock,
 		(clock_control_subsys_t *) &cfg->pclken) != 0) {
 		LOG_ERR("i2c: failure enabling clock");

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -100,8 +100,7 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 	const struct device *clk;
 	int ret;
 
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ret = clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 	if (ret != 0) {

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -247,8 +247,7 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 	const struct device *clk;
 	uint32_t i;
 
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* enable clock */
 	if (clock_control_on(clk,

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -37,8 +37,7 @@ static int memc_stm32_init(const struct device *dev)
 	}
 
 	/* enable FMC peripheral clock */
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	r = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
 	if (r < 0) {

--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -90,7 +90,7 @@ static int enable_port(uint32_t port, const struct device *clk)
 {
 	/* enable port clock */
 	if (!clk) {
-		clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+		clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	}
 
 	struct stm32_pclken pclken;
@@ -150,7 +150,7 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl) */
 
 	/* make sure to enable port clock first */
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	for (int i = 0; i < list_size; i++) {
 		mux = pinctrl[i].pinmux;
@@ -470,7 +470,7 @@ void stm32_setup_pins(const struct pin_config *pinconf,
 	const struct device *clk;
 	int i;
 
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	for (i = 0; i < pins; i++) {
 		z_pinmux_stm32_set(pinconf[i].pin_num,

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -117,8 +117,7 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 	const struct device *clk;
 	uint32_t bus_clk, apb_psc;
 
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
 				   &bus_clk);
@@ -284,8 +283,7 @@ static int pwm_stm32_init(const struct device *dev)
 	LL_TIM_InitTypeDef init;
 
 	/* enable clock and store its speed */
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	r = clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken);
 	if (r < 0) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -473,10 +473,7 @@ static int uart_stm32_err_check(const struct device *dev)
 static inline void __uart_stm32_get_clock(const struct device *dev)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
-	const struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
-
-	__ASSERT_NO_MSG(clk);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	data->clock = clk;
 }

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -455,7 +455,7 @@ static int spi_stm32_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			(clock_control_subsys_t) &cfg->pclken, &clock) < 0) {
 		LOG_ERR("Failed call clock_control_get_rate");
 		return -EIO;
@@ -802,9 +802,7 @@ static int spi_stm32_init(const struct device *dev)
 	const struct spi_stm32_config *cfg = dev->config;
 	int err;
 
-	__ASSERT_NO_MSG(device_get_binding(STM32_CLOCK_CONTROL_NAME));
-
-	if (clock_control_on(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			       (clock_control_subsys_t) &cfg->pclken) != 0) {
 		LOG_ERR("Could not enable SPI clock");
 		return -EIO;

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -215,7 +215,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 
 static int usb_dc_stm32_clock_enable(void)
 {
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct stm32_pclken pclken = {
 		.bus = USB_CLOCK_BUS,
 		.enr = USB_CLOCK_BITS,

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -68,11 +68,9 @@ static void wwdg_stm32_irq_config(const struct device *dev);
 
 static uint32_t wwdg_stm32_get_pclk(const struct device *dev)
 {
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 	uint32_t pclk_rate;
-
-	__ASSERT_NO_MSG(clk);
 
 	if (clock_control_get_rate(clk, (clock_control_subsys_t *) &cfg->pclken,
 			       &pclk_rate) < 0) {
@@ -250,10 +248,8 @@ static const struct wdt_driver_api wwdg_stm32_api = {
 
 static int wwdg_stm32_init(const struct device *dev)
 {
-	const struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
-
-	__ASSERT_NO_MSG(clk);
 
 	clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -53,7 +53,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@48000000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -55,7 +55,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@40010800 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -52,7 +52,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -54,7 +54,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@48000000 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -53,7 +53,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -57,7 +57,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -56,7 +56,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@50000000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -96,7 +96,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@48000000 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -53,7 +53,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x58024400 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@58020000 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -63,7 +63,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@50000000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -235,7 +235,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		flash: flash-controller@40023c00 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -56,7 +56,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@48000000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -56,7 +56,6 @@
 			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@42020000 {

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -38,7 +38,6 @@
 			compatible = "st,stm32-rcc";
 			reg = <0x50000000 0x1000>;
 			#clock-cells = <2>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@50002000 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -54,7 +54,6 @@
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x58000000 0x400>;
-			label = "STM32_CLK_RCC";
 		};
 
 		pinctrl: pin-controller@48000000 {

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -12,8 +12,8 @@
 #include <drivers/clock_control.h>
 #include <dt-bindings/clock/stm32_clock.h>
 
-/* common clock control device name for all STM32 chips */
-#define STM32_CLOCK_CONTROL_NAME DT_LABEL(DT_NODELABEL(rcc))
+/* common clock control device node for all STM32 chips */
+#define STM32_CLOCK_CONTROL_NODE DT_NODELABEL(rcc)
 
 struct stm32_pclken {
 	uint32_t bus;

--- a/subsys/disk/disk_access_stm32_sdmmc.c
+++ b/subsys/disk/disk_access_stm32_sdmmc.c
@@ -66,10 +66,7 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 	LL_RCC_SetSDMMCClockSource(LL_RCC_SDMMC1_CLKSOURCE_PLLSAI1);
 #endif
 
-	clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	if (!clock) {
-		return -ENODEV;
-	}
+	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* Enable the APB clock for stm32_sdmmc */
 	return clock_control_on(clock, (clock_control_subsys_t *)&priv->pclken);
@@ -79,10 +76,7 @@ static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
 {
 	const struct device *clock;
 
-	clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	if (!clock) {
-		return -ENODEV;
-	}
+	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	return clock_control_off(clock,
 				 (clock_control_subsys_t *)&priv->pclken);


### PR DESCRIPTION
    Convert from device_get_binding to DEVICE_DT_GET.  In doing this we
    no longer need the label in the devicetree node so we remove that.
    
    Removed all __ASSERT_NO_MSG(clk) since we'll get a build error if
    DEVICE_DT_GET cant be satisfied, and the clock control api's will
    handle reporting if the device_is_ready.
