### PR TITLE
drivers: serial: native_posix: Convert 2nd UART to be devicetree based

### DIFF
--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -131,6 +131,16 @@
 		current-speed = <0>;
 	};
 
+	uart1: uart_1 {
+		status = "okay";
+		compatible = "zephyr,native-posix-uart";
+		label = "UART_1";
+		/* Dummy current-speed entry to comply with serial
+		 * DTS binding
+		 */
+		current-speed = <0>;
+	};
+
 	rng: rng {
 		status = "okay";
 		compatible = "zephyr,native-posix-rng";

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -56,14 +56,6 @@ config UART_NATIVE_POSIX_PORT_1_ENABLE
 	  This is used for example in PPP (Point-to-Point Protocol)
 	  implementation.
 
-config UART_NATIVE_POSIX_PORT_1_NAME
-	string "Port 1 Device Name"
-	default "UART_1"
-	depends on UART_NATIVE_POSIX_PORT_1_ENABLE
-	help
-	  This is the device name for UART, and is included in the device
-	  struct.
-
 config NATIVE_UART_AUTOATTACH_DEFAULT_CMD
 	string "Default command to attach the UART to a new terminal"
 	default "xterm -e screen %s &"

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -253,7 +253,7 @@ static int np_uart_1_init(const struct device *dev)
 
 	d = (struct native_uart_status *)dev->data;
 
-	tty_fn = open_tty(d, CONFIG_UART_NATIVE_POSIX_PORT_1_NAME, false);
+	tty_fn = open_tty(d, DT_INST_LABEL(1), false);
 
 	d->in_fd = tty_fn;
 	d->out_fd = tty_fn;
@@ -371,9 +371,8 @@ DEVICE_DT_INST_DEFINE(0,
 	    &np_uart_driver_api_0);
 
 #if defined(CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE)
-DEVICE_DEFINE(uart_native_posix1,
-	    CONFIG_UART_NATIVE_POSIX_PORT_1_NAME, &np_uart_1_init,
-	    device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(1,
+	    &np_uart_1_init, device_pm_control_nop,
 	    (void *)&native_uart_status_1, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_1);


### PR DESCRIPTION
The first uart instance was already devicetree based.  To be consistent
convert the second instance to also be devicetree based.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>