### PR TITLE
doc: releases: fix format issue in Boards & SoCs

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -302,7 +302,7 @@ Boards & SoC Support
 
   * Cypress CY8CKIT_062_BLE board
 
-*  Added support for these x86 boards:
+* Added support for these x86 boards:
 
   * Elkhart Lake CRB board
   * ACRN configuration on Elkhart Lake CRB board


### PR DESCRIPTION
Remove extra space character which is causing wrong format for
the bulleted list.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>