### PR TITLE
arch: arm64: initialize IRQ stack and canary

### DIFF
--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -15,6 +15,10 @@
 #include <arch/cpu.h>
 #include "vector_table.h"
 #include "macro_priv.inc"
+#include <sys/util.h>
+#ifdef CONFIG_STACK_SENTINEL
+#include <kernel_structs.h> /* For STACK_SENTINEL definition */
+#endif
 
 _ASM_FILE_PROLOGUE
 
@@ -63,6 +67,54 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	msr	spsel, #0
 
 	ldr	x0, =(z_interrupt_stacks)
+#if !IS_POWER_OF_TWO(ARCH_STACK_PTR_ALIGN)
+	#error "This code assumes ARCH_STACK_PTR_ALIGN is a power of 2"
+	/*
+	 * How to implement this if necessary:
+	 * 1. Introduce a macro that expands to
+	 *    a. `and ... val-1` if val is a power of two
+	 *    b. `mod ... val` if val is not a power of two
+	 * (Why a and b instead of just b? Because mod is _very_ slow
+	 *  compared to and.)
+	 * 2. Use the macro for operations on ARCH_STACK_PTR_ALIGN
+	 */
+#endif
+#if (CONFIG_ISR_STACK_SIZE % ARCH_STACK_PTR_ALIGN)
+	#error "This code assumes that the stack size is aligned"
+	/*
+	 * How to implement this if necessary:
+	 * 1. Round down the resulting stack size to the next aligned value.
+	 * 2. Do all size checks / etc on the resulting rounded-down value.
+	 * (However, if your stack size isn't a multiple of `ARCH_STACK_PTR_ALIGN`
+	 * you're just wasting memory needlessly.)
+	 */
+#endif
+
+	/*
+	 * This check should be compile-time, but better late than never.
+	 * This check also could be `b.ne .` instead of `b.eq` over a `b .`,
+	 * but this way the resulting program counter value when spinning
+	 * is unambiguously in the assert.
+	 * This check could call something other than just spin, but this
+	 * is so early in boot that we would be very unlikely to recover.
+	 */
+
+	/* assert(z_interrupt_stacks % ARCH_STACK_PTR_ALIGN == 0) */
+#ifdef CONFIG_ASSERT
+	ands x1, x0, #(ARCH_STACK_PTR_ALIGN - 1)
+	b.eq z_interrupt_stacks_align_ok
+	/* If you're spinning here check the alignment of z_interrupt_stacks.
+	 * You could work around this by rounding `z_interrupt_stacks` up
+	 * to the next multiple of ARCH_STACK_PTR_ALIGN, but that would
+	 * just be wasting space.
+	 */
+	b .
+z_interrupt_stacks_align_ok:
+#endif
+
+#ifdef CONFIG_SMP
+	#error "This code does not yet comprehend SMP"
+#endif
 	add	x0, x0, #(CONFIG_ISR_STACK_SIZE)
 	mov	sp, x0
 
@@ -126,9 +178,48 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 	/* Switch to SP_EL0 and setup the stack */
 	msr	spsel, #0
 
+#if IS_ENABLED(CONFIG_STACK_SENTINEL) || IS_ENABLED(CONFIG_INIT_STACKS)
+#if ARCH_STACK_PTR_ALIGN % 4
+	#error "This code assumes that the stack can be written 4B at a time"
+	/*
+	 * How to implement this if necessary:
+	 * 1. Change the stack sentinel store to a series of byte stores
+	 * 2. Change the stack init to a series of byte stores
+	 * (This is not done currently because this can be significantly slower
+	 * than doing dword stores, especially if caching isn't yet operational)
+	 */
+#endif
+#endif
+
+#ifdef CONFIG_SMP
+	#error "This code does not yet comprehend SMP"
+#endif
+
 	ldr	x0, =(z_interrupt_stacks)
-	add	x0, x0, #(CONFIG_ISR_STACK_SIZE)
-	mov	sp, x0
+	add x2, x0, #(CONFIG_ISR_STACK_SIZE)
+#ifdef CONFIG_STACK_SENTINEL
+    /*
+	 * If you hit this check your stack size is so small that
+	 * you'll almost certainly stack overflow, but the check
+	 * is cheap, so might as well.
+	 */
+	cmp x0, x2
+	b.hs 2f
+	mov w1, #(STACK_SENTINEL)
+	str w1, [x0], 4
+#endif
+#ifdef CONFIG_INIT_STACKS
+	cmp x0, x2
+	b.hs 2f
+	/* TODO: this really should be a constant somewhere */
+	mov	w1, #0xaaaaaaaa
+1:
+	str w1, [x0], 4
+	cmp x0, x2
+	b.lo 1b
+#endif
+2:
+	mov	sp, x2
 
 	/* Disable access trapping in EL1 for NEON/FP */
 	mov_imm	x0, CPACR_EL1_FPEN_NOTRAP

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -21,6 +21,25 @@
  */
 #include <stdbool.h>
 
+/* Needs to be outside _ASMLANGUAGE so it can be used in
+ * preprocessor expressions for asm or linker scripts.
+ * Needs to be defined before is_power_of_two, below.
+ */
+
+/**
+ * @brief Is @p X a power of two?
+ * @param X value to check
+ * @note Argument is evaluated multiple times.
+ */
+#ifndef IS_POWER_OF_TWO
+/* Use Z_IS_POWER_OF_TWO for a GCC-only, single evaluation version */
+#if defined(_ASMLANGUAGE)
+#define IS_POWER_OF_TWO(X) (((X) != 0) && (((X) & ((X) - 1)) == 0U))
+#else
+#define IS_POWER_OF_TWO(X) (((X) != 0U) && (((X) & ((X) - 1U)) == 0U))
+#endif
+#endif
+
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
@@ -195,7 +214,7 @@ extern "C" {
  */
 static inline bool is_power_of_two(unsigned int x)
 {
-	return (x != 0U) && ((x & (x - 1U)) == 0U);
+	return IS_POWER_OF_TWO(x);
 }
 
 /**

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -544,6 +544,20 @@ do {                                                                    \
 	})
 
 /**
+ * @brief Is @p X a power of two?
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * macro limitations.
+ * Arguably redundant with is_power_of_two.
+ */
+#define Z_IS_POWER_OF_TWO(X) ({ \
+		/* random suffix to avoid naming conflict */ \
+		__typeof__(X) _value_x_ = (X); \
+		(((_value_x_) != 0U) && \
+		(((_value_x_) & ((_value_x_) - 1U)) == 0U)); \
+	})
+
+/**
  * @brief Calculate power of two ceiling for some nonzero value
  *
  * @param x Nonzero unsigned long value

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -203,11 +203,13 @@ static int inc_func(void)
 	return a++;
 }
 
-/* Test checks if @ref Z_MAX, @ref Z_MIN and @ref Z_CLAMP return correct result
+/* Test checks if @ref Z_MAX, @ref Z_MIN, @ref Z_CLAMP, and
+ * @ref Z_IS_POWER_OF_TWO return correct result
  * and perform single evaluation of input arguments.
  */
-static void test_z_max_z_min_z_clamp(void)
+static void test_z_max_z_min_z_clamp_z_is_power_of_two(void)
 {
+	int i;
 	zassert_equal(Z_MAX(inc_func(), 0), 1, "Unexpected macro result");
 	/* Z_MAX should have call inc_func only once */
 	zassert_equal(inc_func(), 2, "Unexpected return value");
@@ -224,6 +226,21 @@ static void test_z_max_z_min_z_clamp(void)
 		      "Unexpected macro result");
 	/* Z_CLAMP should have call inc_func only once */
 	zassert_equal(inc_func(), 8, "Unexpected return value");
+
+	/* We want to check Z_IS_POWER_OF_TWO for a power of two too */
+	for (i = 9; i < 14; i++) {
+		zassert_equal(inc_func(), i, "Unexpected return value");
+	}
+
+	zassert_equal(Z_IS_POWER_OF_TWO(inc_func()), false,
+				  "Unexpected macro result");
+	/* Z_IS_POWER_OF_TWO should have call inc_func only once */
+	zassert_equal(inc_func(), 15, "Unexpected return value");
+
+	zassert_equal(Z_IS_POWER_OF_TWO(inc_func()), true,
+				  "Unexpected macro result");
+	/* Z_IS_POWER_OF_TWO should have call inc_func only once */
+	zassert_equal(inc_func(), 17, "Unexpected return value");
 }
 
 static void test_CLAMP(void)
@@ -458,7 +475,7 @@ void test_cc(void)
 			 ztest_unit_test(test_IF_ENABLED),
 			 ztest_unit_test(test_UTIL_LISTIFY),
 			 ztest_unit_test(test_MACRO_MAP_CAT),
-			 ztest_unit_test(test_z_max_z_min_z_clamp),
+			 ztest_unit_test(test_z_max_z_min_z_clamp_z_is_power_of_two),
 			 ztest_unit_test(test_CLAMP),
 			 ztest_unit_test(test_FOR_EACH),
 			 ztest_unit_test(test_FOR_EACH_NONEMPTY_TERM),

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -259,6 +259,18 @@ static void test_CLAMP(void)
 		      0xffffffffaULL, "Unexpected clamp result");
 }
 
+static void test_IS_POWER_OF_TWO(void)
+{
+	zassert_equal(IS_POWER_OF_TWO(0x00000000), false, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0x00000001), true, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0x00000002), true, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0x00000003), false, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0x80000000), true, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0x80000001), false, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0xC0000000), false, "Unexpected macro result");
+	zassert_equal(IS_POWER_OF_TWO(0xFFFFFFFF), false, "Unexpected macro result");
+}
+
 static void test_FOR_EACH(void)
 {
 	#define FOR_EACH_MACRO_TEST(arg) *buf++ = arg
@@ -477,6 +489,7 @@ void test_cc(void)
 			 ztest_unit_test(test_MACRO_MAP_CAT),
 			 ztest_unit_test(test_z_max_z_min_z_clamp_z_is_power_of_two),
 			 ztest_unit_test(test_CLAMP),
+			 ztest_unit_test(test_IS_POWER_OF_TWO),
 			 ztest_unit_test(test_FOR_EACH),
 			 ztest_unit_test(test_FOR_EACH_NONEMPTY_TERM),
 			 ztest_unit_test(test_FOR_EACH_FIXED_ARG),


### PR DESCRIPTION
As per https://github.com/zephyrproject-rtos/zephyr/pull/30676#discussion_r574319395.

Fair warning: this is my first PR on this project. It's _entirely_ likely that I've missed things.

(Also: the [documentation](https://docs.zephyrproject.org/latest/contribute/index.html) doesn't seem to mention that `uncrustify` shouldn't be run on .S files.)

Signed-off-by: James Harris <james.harris@intel.com>