### PR TITLE
samples: mass: add SD card support

### DIFF
--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -4,7 +4,9 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mass)
 
-if((NOT CONFIG_DISK_ACCESS_FLASH) AND (NOT CONFIG_DISK_ACCESS_RAM))
+if((NOT CONFIG_DISK_ACCESS_FLASH) AND
+   (NOT CONFIG_DISK_ACCESS_RAM) AND
+   (NOT CONFIG_DISK_ACCESS_SDHC))
 	message( FATAL_ERROR "No disk access settings detected." )
 endif()
 

--- a/samples/subsys/usb/mass/Kconfig
+++ b/samples/subsys/usb/mass/Kconfig
@@ -37,6 +37,12 @@ config APP_MSC_STORAGE_FLASH_LITTLEFS
 	imply FILE_SYSTEM
 	imply FILE_SYSTEM_LITTLEFS
 
+config APP_MSC_STORAGE_SDCARD
+	bool "Use SDHC and FAT file system"
+	imply DISK_ACCESS_SDHC
+	imply FILE_SYSTEM
+	imply FAT_FILESYSTEM_ELM
+
 endchoice
 
 config DISK_RAM_VOLUME_SIZE
@@ -45,6 +51,21 @@ config DISK_RAM_VOLUME_SIZE
 config MASS_STORAGE_DISK_NAME
 	default "NAND" if DISK_ACCESS_FLASH
 	default "RAM" if DISK_ACCESS_RAM
+	default "SD" if DISK_ACCESS_SDHC
+
+if DISK_ACCESS_SDHC
+
+if !DISK_ACCESS_USDHC
+
+config SPI
+	default y
+
+config DISK_ACCESS_SPI_SDHC
+	default y
+
+endif #!DISK_ACCESS_USDHC
+
+endif #DISK_ACCESS_SDHC
 
 if DISK_ACCESS_FLASH
 

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -106,6 +106,52 @@ The output to the console will look something like this
 
 On most operating systems the drive will be automatically mounted.
 
+SD Card Example
+===============
+
+For this example a board or shield with :ref:`sdhc_api` support and
+a SD card formatted with FAT filesystem is needed.
+
+If a board with SD card controller is available, the example can be built as
+follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/mass
+   :board: mimxrt1050_evk
+   :gen-args: -DCONFIG_APP_MSC_STORAGE_SDCARD=y
+   :goals: build
+   :compact:
+
+In case the board has no support for SD card controller, but the card can
+be connected to SPI using e.g. a shield, example can be built as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/mass
+   :board: nrf52840dk_nrf52840
+   :shield: waveshare_epaper_gdeh0154a07
+   :gen-args: -DCONFIG_APP_MSC_STORAGE_SDCARD=y
+   :goals: build
+   :compact:
+
+Depending on the size of the media it can take time until the file system has
+initialized the card and it is available via USB. It should also be noted that
+the transfer speed over SPI is very slow.
+
+.. code-block:: none
+
+   *** Booting Zephyr OS build v2.5.0-rc3-73-gd85067f0a759  ***
+   Mount /SD:: 0
+   [00:00:00.281,585] <inf> sdhc_spi: Found a ~3751 MiB SDHC card.
+   [00:00:00.282,867] <inf> sdhc_spi: Manufacturer ID=27 OEM='SM' Name='00000' Revision=0x10 Serial=0x16fdd47b
+   [00:00:00.308,654] <inf> sdhc_spi: Found a ~3751 MiB SDHC card.
+   [00:00:00.309,906] <inf> sdhc_spi: Manufacturer ID=27 OEM='SM' Name='00000' Revision=0x10 Serial=0x16fdd47b
+   /SD:: bsize = 512 ; frsize = 32768 ; blocks = 119776 ; bfree = 119773
+   /SD: opendir: 0
+     D 0 42
+     F 1111 TEST.TXT
+   End of files
+   [00:00:18.588,043] <inf> main: The device is put in USB mass storage mode.
+
 LittleFS Example
 ================
 

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -39,6 +39,19 @@ tests:
       type: one_line
       regex:
         - "The device is put in USB mass storage mode."
+  sample.usb.mass_sdhc_fatfs:
+    min_ram: 32
+    depends_on: usb_device sdhc
+    extra_configs:
+        - CONFIG_LOG_DEFAULT_LEVEL=3
+        - CONFIG_APP_MSC_STORAGE_SDCARD=y
+    tags: msd usb
+    harness: console
+    harness_config:
+      type: one_line
+      fixture: fixture_sdcard
+      regex:
+        - "The device is put in USB mass storage mode."
   sample.usb.mass_flash_littlefs:
     min_ram: 32
     depends_on: usb_device

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -67,6 +67,8 @@ static int mount_app_fs(struct fs_mount_t *mnt)
 	mnt->fs_data = &fat_fs;
 	if (IS_ENABLED(CONFIG_DISK_ACCESS_RAM)) {
 		mnt->mnt_point = "/RAM:";
+	} else if (IS_ENABLED(CONFIG_DISK_ACCESS_SDHC)) {
+		mnt->mnt_point = "/SD:";
 	} else {
 		mnt->mnt_point = "/NAND:";
 	}


### PR DESCRIPTION
Add SD card support to USB MSC sample.

I am not sure how usable it is since the transfer speed is quite slow.