### PR TITLE
device: rv32m1: Convert clock control to use DEVICE_DT_GET

### DIFF
--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -40,7 +40,7 @@
 
 struct rv32m1_intmux_config {
 	INTMUX_Type *regs;
-	char *clock_name;
+	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	struct _isr_table_entry *isr_base;
 };
@@ -145,7 +145,7 @@ static const struct irq_next_level_api rv32m1_intmux_apis = {
 
 static const struct rv32m1_intmux_config rv32m1_intmux_cfg = {
 	.regs = (INTMUX_Type *)DT_INST_REG_ADDR(0),
-	.clock_name = DT_INST_CLOCKS_LABEL(0),
+	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.clock_subsys = UINT_TO_POINTER(DT_INST_CLOCKS_CELL(0, name)),
 	.isr_base = &_sw_isr_table[CONFIG_2ND_LVL_ISR_TBL_OFFSET],
 };
@@ -154,15 +154,10 @@ static int rv32m1_intmux_init(const struct device *dev)
 {
 	const struct rv32m1_intmux_config *config = DEV_CFG(dev);
 	INTMUX_Type *regs = DEV_REGS(dev);
-	const struct device *clock_dev = device_get_binding(config->clock_name);
 	size_t i;
 
-	if (!clock_dev) {
-		return -ENODEV;
-	}
-
 	/* Enable INTMUX clock. */
-	clock_control_on(clock_dev, config->clock_subsys);
+	clock_control_on(config->clock_dev, config->clock_subsys);
 
 	/*
 	 * Reset all channels, not just the ones we're configured to

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -16,7 +16,7 @@
 
 struct rv32m1_lpuart_config {
 	LPUART_Type *base;
-	char *clock_name;
+	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	clock_ip_name_t clock_ip_name;
 	uint32_t clock_ip_src;
@@ -239,19 +239,13 @@ static int rv32m1_lpuart_init(const struct device *dev)
 {
 	const struct rv32m1_lpuart_config *config = dev->config;
 	lpuart_config_t uart_config;
-	const struct device *clock_dev;
 	uint32_t clock_freq;
 
 	/* set clock source */
 	/* TODO: Don't change if another core has configured */
 	CLOCK_SetIpSrc(config->clock_ip_name, config->clock_ip_src);
 
-	clock_dev = device_get_binding(config->clock_name);
-	if (clock_dev == NULL) {
-		return -EINVAL;
-	}
-
-	if (clock_control_get_rate(clock_dev, config->clock_subsys,
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;
 	}
@@ -299,7 +293,7 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 #define RV32M1_LPUART_DECLARE_CFG(n, IRQ_FUNC_INIT)			\
 	static const struct rv32m1_lpuart_config rv32m1_lpuart_##n##_cfg = {\
 		.base = (LPUART_Type *)DT_INST_REG_ADDR(n),		\
-		.clock_name = DT_INST_CLOCKS_LABEL(n),			\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
 		.clock_subsys =						\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(n),		\

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(spi_rv32m1_lpspi);
 
 struct spi_mcux_config {
 	LPSPI_Type *base;
-	char *clock_name;
+	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	clock_ip_name_t clock_ip_name;
 	uint32_t clock_ip_src;
@@ -132,7 +132,6 @@ static int spi_mcux_configure(const struct device *dev,
 	struct spi_mcux_data *data = dev->data;
 	LPSPI_Type *base = config->base;
 	lpspi_master_config_t master_config;
-	const struct device *clock_dev;
 	uint32_t clock_freq;
 	uint32_t word_size;
 
@@ -176,12 +175,7 @@ static int spi_mcux_configure(const struct device *dev,
 
 	master_config.baudRate = spi_cfg->frequency;
 
-	clock_dev = device_get_binding(config->clock_name);
-	if (clock_dev == NULL) {
-		return -EINVAL;
-	}
-
-	if (clock_control_get_rate(clock_dev, config->clock_subsys,
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;
 	}
@@ -288,7 +282,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 									\
 	static const struct spi_mcux_config spi_mcux_config_##n = {	\
 		.base = (LPSPI_Type *) DT_INST_REG_ADDR(n),		\
-		.clock_name = DT_INST_CLOCKS_LABEL(n),			\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
 		.clock_subsys = (clock_control_subsys_t)		\
 			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = spi_mcux_config_func_##n,		\


### PR DESCRIPTION
Replace device_get_binding with DEVICE_DT_GET for getting access
    to the clock controller device.
