### PR TITLE
copyright: add missing license

### DIFF
--- a/include/arch/riscv/csr.h
+++ b/include/arch/riscv/csr.h
@@ -1,6 +1,8 @@
 /*
+ * Copyright (c) 2020 Michael Schaffner
  * Copyright (c) 2020 BayLibre, SAS
  *
+ * SPDX-License-Identifier: SHL-0.51
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/riscv/riscv-ite/common/encoding.h
+++ b/soc/riscv/riscv-ite/common/encoding.h
@@ -1,8 +1,9 @@
 /*
+ * Copyright (c) 2020 Michael Schaffner
  * Copyright (c) 2020 ITE Corporation. All Rights Reserved.
  *
+ * SPDX-License-Identifier: SHL-0.51
  * SPDX-License-Identifier: Apache-2.0
- *
  */
 
 #ifndef RISCV_CSR_ENCODING_H


### PR DESCRIPTION
Solderpad Hardware License

Signed-off-by: Alexandre Mergnat <amergnat@baylibre.com>