### PR TITLE
drivers: counter: stm32: fix alarm time calculation

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -165,11 +165,13 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 		 * that tick+1 event occurs before alarm setting is finished.
 		 */
 		ticks += now + 1;
+		alarm_val = (time_t)(counter_ticks_to_us(dev, ticks) / USEC_PER_SEC)
+			+ T_TIME_OFFSET;
+	} else {
+		alarm_val = (time_t)(counter_ticks_to_us(dev, ticks) / USEC_PER_SEC);
 	}
 
 	LOG_DBG("Set Alarm: %d\n", ticks);
-
-	alarm_val = (time_t)(counter_ticks_to_us(dev, ticks) / USEC_PER_SEC);
 
 	gmtime_r(&alarm_val, &alarm_tm);
 


### PR DESCRIPTION
The calculated alarm time starts from 2000 but the gmtime_r needs as
input the time from epoch (1970). This causes the alarm time to be
miscalculated due to leap years, as 2000 is a leap year and 1970 is not.
To fix the issue, the 2000 timestamp can be added to the input time of
gmtime_r.

Fixes #32260

Signed-off-by: Antonis Sioutas <antonis.si510@gmail.com>