### PR TITLE
Bluetooth: controller: Move connection event length calculation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -677,7 +677,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 
 	conn_interval_us = lll->interval * CONN_INT_UNIT_US;
 	conn_offset_us = ftr->radio_end_us;
-	conn_offset_us += HAL_TICKER_TICKS_TO_US(1);
+	conn_offset_us += EVENT_TICKER_RES_MARGIN_US;
 	conn_offset_us -= EVENT_OVERHEAD_START_US;
 
 #if defined(CONFIG_BT_CTLR_PHY)

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -116,9 +116,7 @@ void ull_sched_after_mstr_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 			}
 #endif
 
-			ticks_slot_abs_curr +=
-				conn->evt.ticks_slot +
-				HAL_TICKER_US_TO_TICKS(EVENT_JITTER_US << 3);
+			ticks_slot_abs_curr += conn->evt.ticks_slot;
 
 			if ((ticker_id_prev != 0xff) &&
 			    (ticker_ticks_diff_get(ticks_to_expire_normal,


### PR DESCRIPTION
Move the initial connection event length calculation to
when initiating connection so that initiator with advanced
scheduling to place central connections in a non-overlapping
timeline has the correct ticks slot value available.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>