### PR TITLE
devicetree: default absent label to empty string

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -170,7 +170,7 @@ extern "C" {
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn,		\
 			 data_ptr, cfg_ptr, level, prio, api_ptr)	\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
-			DT_PROP_OR(node_id, label, NULL), init_fn,	\
+			DT_PROP_OR(node_id, label, ""), init_fn,	\
 			pm_control_fn,					\
 			data_ptr, cfg_ptr, level, prio, api_ptr)
 

--- a/include/device.h
+++ b/include/device.h
@@ -313,7 +313,8 @@ struct device {
  * it can use this function to retrieve the device structure of the lower level
  * driver by the name the driver exposes to the system.
  *
- * @param name device name to search for.
+ * @param name device name to search for.  A null pointer, or a pointer to an
+ * empty string, will cause NULL to be returned.
  *
  * @return pointer to device structure; NULL if not found or cannot be used.
  */

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -712,7 +712,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data,	\
 			       cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			      DT_PROP_OR(node_id, label, NULL),		\
+			      DT_PROP_OR(node_id, label, ""),		\
 			      init_fn, pm_control_fn, data, cfg, prio,	\
 			      api, mtu)
 

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2269,7 +2269,7 @@ struct net_if_api {
 #define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_control_fn, data, cfg,	\
 			   prio, api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			  DT_PROP_OR(node_id, label, NULL), init_fn,	\
+			  DT_PROP_OR(node_id, label, ""), init_fn,	\
 			  pm_control_fn, data, cfg, prio, api, l2,	\
 			  l2_ctx_type, mtu)
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -79,6 +79,13 @@ const struct device *z_impl_device_get_binding(const char *name)
 {
 	const struct device *dev;
 
+	/* A null string identifies no device.  So does an empty
+	 * string.
+	 */
+	if ((name == NULL) || (*name == 0)) {
+		return NULL;
+	}
+
 	/* Split the search into two loops: in the common scenario, where
 	 * device names are stored in ROM (and are referenced by the user
 	 * with CONFIG_* macros), only cheap pointer comparisons will be


### PR DESCRIPTION
When devices are defined using devicetree nodes, the `label` property is used as the driver name.  As we move to making the `label` property optional, we need to account for widespread use of `dev->name` in contexts where the pointer is not validated before it is dereferenced.

Explicitly recognize both a null name and an empty name as referring to no device, and use an empty name as the device name for devices defined from a devicertee node that has no label.
