### PR TITLE
drivers/i2c: stm32_v1: TX IRQ enable called twice in a row

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -619,12 +619,10 @@ int32_t stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 {
 	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
 	struct i2c_stm32_data *data = DEV_DATA(dev);
-	I2C_TypeDef *i2c = cfg->i2c;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_WRITE);
 
 	stm32_i2c_enable_transfer_interrupts(dev);
-	LL_I2C_EnableIT_TX(i2c);
 
 	if (k_sem_take(&data->device_sync_sem,
 			K_MSEC(STM32_I2C_TRANSFER_TIMEOUT_MSEC)) != 0) {


### PR DESCRIPTION
On I2C V1 parts, LL_I2C_EnableIT_TX() translates to EVT and BUF
IRQ enabling.
In stm32_i2c_msg_write function, LL_I2C_EnableIT_TX is called right
after stm32_i2c_enable_transfer_interrupts which already enables BUF
IRQ, which starts the transfer.
As a consequence it could happen that transfer is already complete
at the time LL_I2C_EnableIT_TX is called. This case is not expected
but remaining ppart of the code and loops waiting for BUF IRQ to be
raised.
Remove the superfluous LL_I2C_EnableIT_TX call.

Fixes: #32265

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>