### PR TITLE
nRF5340: Add support for QDEC in device tree and Kconfig

### DIFF
--- a/drivers/sensor/qdec_nrfx/Kconfig
+++ b/drivers/sensor/qdec_nrfx/Kconfig
@@ -3,7 +3,7 @@
 
 config QDEC_NRFX
 	bool "Nordic QDEC nrfx driver"
-	depends on HAS_HW_NRF_QDEC
+	depends on HAS_HW_NRF_QDEC || HAS_HW_NRF_QDEC0
 	select NRFX_QDEC
 	help
 	  Enable support for nrfx QDEC driver for nRF MCU series.

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -112,6 +112,22 @@ pdm0: pdm@26000 {
 	label = "PDM_0";
 };
 
+qdec0: qdec@33000 {
+	compatible = "nordic,nrf-qdec";
+	reg = <0x33000 0x1000>;
+	interrupts = <51 NRF_DEFAULT_IRQ_PRIORITY>;
+	status = "disabled";
+	label = "QDEC_0";
+};
+
+qdec1: qdec@34000 {
+	compatible = "nordic,nrf-qdec";
+	reg = <0x34000 0x1000>;
+	interrupts = <52 NRF_DEFAULT_IRQ_PRIORITY>;
+	status = "disabled";
+	label = "QDEC_1";
+};
+
 regulators: regulator@4000 {
 	compatible = "nordic,nrf-regulators";
 	reg = <0x4000 0x1000>;

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -129,7 +129,7 @@ config NRFX_PWM3
 
 config NRFX_QDEC
 	bool "Enable QDEC driver"
-	depends on HAS_HW_NRF_QDEC
+	depends on HAS_HW_NRF_QDEC || HAS_HW_NRF_QDEC0
 
 config NRFX_QSPI
 	bool "Enable QSPI driver"

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -109,6 +109,12 @@ config HAS_HW_NRF_PWM3
 config HAS_HW_NRF_QDEC
 	bool
 
+config HAS_HW_NRF_QDEC0
+	bool
+
+config HAS_HW_NRF_QDEC1
+	bool
+
 config HAS_HW_NRF_QSPI
 	bool
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -31,6 +31,8 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_PWM1
 	select HAS_HW_NRF_PWM2
 	select HAS_HW_NRF_PWM3
+	select HAS_HW_NRF_QDEC0
+	select HAS_HW_NRF_QDEC1
 	select HAS_HW_NRF_QSPI
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1


### PR DESCRIPTION
Adding support for QDEC in nRF5340