### PR TITLE
Add Zephyr update instructions to the Beyond Getting Started Guide

### DIFF
--- a/doc/guides/beyond-GSG.rst
+++ b/doc/guides/beyond-GSG.rst
@@ -122,6 +122,20 @@ repo.
    repository, switch branches in it, or perform a ``git bisect`` inside of
    it.
 
+Keeping Zephyr updated
+======================
+
+To update the Zephyr project source code, you need to get the latest
+changes via ``git``. Afterwards, run ``west update`` as mentioned in
+the previous paragraph.
+
+.. code-block:: console
+
+   # replace zephyrproject with the path you gave west init
+   cd zephyrproject/zephyr
+   git pull
+   west update
+
 Export Zephyr CMake package
 ***************************
 


### PR DESCRIPTION
Add explicit instructions on how to update the Zephyr
source code. For a beginner, it might not be obvious
how to do that. "west update" sounds like it'd do that,
which is not the case, however.

Fixes #32234 