### PR TITLE
net: tcp2: Flush pending data when interface comes up

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include "net_private.h"
 #include "ipv6.h"
 #include "ipv4_autoconf_internal.h"
+#include "tcp_internal.h"
 
 #include "net_stats.h"
 
@@ -3476,6 +3477,11 @@ done:
 		iface_ipv6_start(iface);
 
 		net_ipv4_autoconf_start(iface);
+	}
+
+	/* Flush sending queue for any pending data */
+	if (IS_ENABLED(CONFIG_NET_TCP)) {
+		net_tcp_send_pending(iface);
 	}
 
 exit:

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -850,6 +850,20 @@ static inline int net_tcp_put(struct net_context *context)
 }
 #endif
 
+/**
+ * @brief Send any pending data to a specific interface.
+ *
+ * @param iface Network interface.
+ */
+#if defined(CONFIG_NET_NATIVE_TCP) && defined(CONFIG_NET_TCP2)
+void net_tcp_send_pending(struct net_if *iface);
+#else
+static inline void net_tcp_send_pending(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+}
+#endif
+
 #define NET_TCP_MAX_OPT_SIZE  8
 
 #if defined(CONFIG_NET_NATIVE_TCP)


### PR DESCRIPTION
Make sure we send any pending data when network interface
comes up.

Fixes #32270

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>