### PR TITLE
ztest: fix z_assert_within() bounds

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -190,7 +190,7 @@ static inline void z_zassert(bool cond,
  * @param msg Optional message to print if the assertion fails
  */
 #define zassert_within(a, b, d, msg, ...)			     \
-	zassert(((a) > ((b) - (d))) && ((a) < ((b) + (d))),	     \
+	zassert(((a) >= ((b) - (d))) && ((a) <= ((b) + (d))),	     \
 		#a " not within " #b " +/- " #d,		     \
 		msg, ##__VA_ARGS__)
 


### PR DESCRIPTION
zassert_within should also compare on equality instead
of only greater/lower.
example:
zassert_within(1,1,0); // should return true
zassert_within(1,2,1); // should return true