### PR TITLE
audio: dmic: fix compile error on arm gcc 8

### DIFF
--- a/include/audio/dmic.h
+++ b/include/audio/dmic.h
@@ -215,7 +215,7 @@ static inline void dmic_parse_channel_map(uint32_t channel_map_lo,
 	channel_map >>= ((channel & BIT_MASK(3)) * 4U);
 
 	*pdm = (channel >> 1) & BIT_MASK(3);
-	*lr = channel & BIT(0);
+	*lr = (enum pdm_lr) (channel & BIT(0));
 }
 
 /**


### PR DESCRIPTION
So I ran accidentally into a GCC error compiling an application with DMIC support.
I'm using ARM GCC8  (2018 Q4 Major) directly from ARM. So I didn't use the SDK.
I'm not sure if it matters, but I was compiling a C++ application.

GCC Error:
`zephyrproject/zephyr/include/audio/dmic.h: In function 'void dmic_parse_channel_map(uint32_t, uint32_t, uint8_t, uint8_t*, pdm_lr*)':
zephyrproject/zephyr/include/audio/dmic.h:218:29: error: invalid conversion from 'long unsigned int' to 'pdm_lr' [-fpermissive]
  *lr = channel & BIT(0);`
