### PR TITLE
devicetree: error out on deprecated properties

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -219,6 +219,7 @@ if(SUPPORTS_DTS)
   --device-header-out ${DEVICE_EXTERN_H}
   --dts-out ${ZEPHYR_DTS} # As a debugging aid
   --edt-pickle-out ${EDT_PICKLE}
+  ${EXTRA_GEN_DEFINES_ARGS}
   )
 
   execute_process(

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -54,7 +54,9 @@ def main():
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
                          default_prop_types=True,
-                         infer_binding_for_paths=["/zephyr,user"])
+                         infer_binding_for_paths=["/zephyr,user"],
+                         err_on_deprecated_properties=
+                         args.err_on_deprecated_properties)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
 
@@ -193,6 +195,8 @@ def parse_args():
                         help="path to write device struct extern header to")
     parser.add_argument("--edt-pickle-out",
                         help="path to write pickled edtlib.EDT object to")
+    parser.add_argument("--err-on-deprecated-properties", action="store_true",
+                        help="if set, deprecated property usage is an error")
 
     return parser.parse_args()
 

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1977,8 +1977,10 @@ class CMake():
             ldflags = "-Wl,--fatal-warnings"
             cflags = "-Werror"
             aflags = "-Wa,--fatal-warnings"
+            gen_defines_args = "--err-on-deprecated-properties"
         else:
             ldflags = cflags = aflags = ""
+            gen_defines_args = ""
 
         logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
         cmake_args = [
@@ -1987,6 +1989,7 @@ class CMake():
             f'-DEXTRA_CFLAGS="{cflags}"',
             f'-DEXTRA_AFLAGS="{aflags}',
             f'-DEXTRA_LDFLAGS="{ldflags}"',
+            f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.generator}'
         ]
 


### PR DESCRIPTION
This pull request adds an edtlib feature which optionally makes deprecated property usage a hard error, and plumbs it into twister.