### PR TITLE
shield: cmake: adjust `if(EXISTS <shield>.conf)` to check for right file

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -347,7 +347,7 @@ foreach(root ${BOARD_ROOT})
         )
 
       # search for shield/shield.conf file
-      if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)
+      if(EXISTS ${SHIELD_DIR_${s}}/${s}.conf)
         # add shield.conf to the shield config list
         list(APPEND
           shield_conf_files


### PR DESCRIPTION
Fixes: #32269

This commit is a followup to #31877 where the `${shield_dir}/${s_dir}`
was adjusted to `${SHIELD_DIR_${s}}` to ensure only including shields
and not boards in list of known shields.

An `if(EXISTS ${shield_dir}/${s_dir}...)` was missed in this process
which causes #32269. This is corrected in this commit.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>