### PR TITLE
Tests: unittest: add call to teardown

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -189,6 +189,9 @@ static void run_test_functions(struct unit_test *test)
 	test->setup();
 	phase = TEST_PHASE_TEST;
 	test->test();
+	phase = TEST_PHASE_TEARDOWN;
+	test->teardown();
+	phase = TEST_PHASE_FRAMEWORK;
 }
 
 #ifndef KERNEL


### PR DESCRIPTION
The call to the teardown function in unittests was missing
Note that it was present in the case of kernel-testing.

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>