### PR TITLE
net: pkt: Add function net_pkt_get_contiguous_len()

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1904,6 +1904,16 @@ uint16_t net_pkt_get_current_offset(struct net_pkt *pkt);
  */
 bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size);
 
+/**
+ * Get the contiguous buffer space
+ *
+ * @param pkt Network packet
+ *
+ * @return The available contiguous buffer space in bytes starting from the
+ *         current cursor position. 0 in case of an error.
+ */
+size_t net_pkt_get_contiguous_len(struct net_pkt *pkt);
+
 struct net_pkt_data_access {
 #if !defined(CONFIG_NET_HEADERS_ALWAYS_CONTIGUOUS)
 	void *data;

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1959,6 +1959,13 @@ uint16_t net_pkt_get_current_offset(struct net_pkt *pkt)
 
 bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size)
 {
+	size_t len = net_pkt_get_contiguous_len(pkt);
+
+	return len >= size;
+}
+
+size_t net_pkt_get_contiguous_len(struct net_pkt *pkt)
+{
 	pkt_cursor_advance(pkt, !net_pkt_is_being_overwritten(pkt));
 
 	if (pkt->cursor.buf && pkt->cursor.pos) {
@@ -1967,12 +1974,10 @@ bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size)
 		len = net_pkt_is_being_overwritten(pkt) ?
 			pkt->cursor.buf->len : pkt->cursor.buf->size;
 		len -= pkt->cursor.pos - pkt->cursor.buf->data;
-		if (len >= size) {
-			return true;
-		}
+		return len;
 	}
 
-	return false;
+	return 0;
 }
 
 void *net_pkt_get_data(struct net_pkt *pkt,


### PR DESCRIPTION
This returns the available contingous space in the packet starting from
the current cursor position.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>