### PR TITLE
drivers/i2c: stm32_v1: remove unused variable

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -617,7 +617,6 @@ end:
 int32_t stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 			    uint8_t *next_msg_flags, uint16_t saddr)
 {
-	const struct i2c_stm32_config *cfg = DEV_CFG(dev);
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_WRITE);


### PR DESCRIPTION
A recent patch removed use of the cfg structure, but left a pointer to it defined which causes build failures:  
https://buildkite.com/zephyr/zephyr-daily/builds/241

Broken by #32267.  No idea why this wasn't caught in testing.