### PR TITLE
net: tls: Allow access to TLS socket in userspace

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -73,7 +73,7 @@ struct dtls_timing_context {
 };
 
 /** TLS context information. */
-struct tls_context {
+__net_socket struct tls_context {
 	/** Information whether TLS context is used. */
 	bool is_used;
 


### PR DESCRIPTION
If userspace is enabled, then the TLS context needs to be
made a NET_SOCKET kernel object. Without this the userspace
cannot access TLS sockets.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>