### PR TITLE
compiler: do not allow expansion-to-defined

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -39,6 +39,9 @@ check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
 # Prohibit void pointer arithmetic. Illegal in C99
 check_set_compiler_property(APPEND PROPERTY warning_base -Wpointer-arith)
 
+# not portable
+check_set_compiler_property(APPEND PROPERTY warning_base -Wexpansion-to-defined)
+
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
   set_compiler_property(APPEND PROPERTY warning_base
                         # FIXME: Remove once #16587 is fixed


### PR DESCRIPTION
```
'-Wexpansion-to-defined'
     Warn whenever 'defined' is encountered in the expansion of a macro
     (including the case where the macro is expanded by an '#if'
     directive).  Such usage is not portable.  This warning is also
     enabled by '-Wpedantic' and '-Wextra'.

```

This is enabled by default in llvm but not in gcc. Given that it is 'not
portable', lets disallow this in gcc and keep both compilers in sync.


Also see
https://github.com/zephyrproject-rtos/zephyr/pull/32280#discussion_r576219993