### PR TITLE
driver: peci: Add supported peci response codes

### DIFF
--- a/include/drivers/peci.h
+++ b/include/drivers/peci.h
@@ -65,9 +65,11 @@ enum peci_command_code {
 };
 
 /** PECI read/write supported responses */
-#define PECI_RW_PKG_CFG_RSP_PASS       (0x40U)
-#define PECI_RW_PKG_CFG_RSP_TIMEOUT    (0x80U)
-#define PECI_RW_PKG_CFG_RSP_ILLEGAL    (0x90U)
+#define PECI_CC_RSP_SUCCESS              (0x40U)
+#define PECI_CC_RSP_TIMEOUT              (0x80U)
+#define PECI_CC_OUT_OF_RESOURCES_TIMEOUT (0x81U)
+#define PECI_CC_RESOURCES_LOWPWR_TIMEOUT (0x82U)
+#define PECI_CC_ILLEGAL_REQUEST          (0x90U)
 
 /** Ping command format. */
 #define PECI_PING_WR_LEN               (0U)

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -90,7 +90,7 @@ int peci_get_tjmax(uint8_t *tjmax)
 		k_sleep(K_MSEC(1));
 		printk("\npeci_resp %x\n", peci_resp);
 		retries--;
-	} while ((peci_resp != PECI_RW_PKG_CFG_RSP_PASS) && (retries > 0));
+	} while ((peci_resp != PECI_CC_RSP_SUCCESS) && (retries > 0));
 
 	*tjmax = packet.rx_buffer.buf[3];
 


### PR DESCRIPTION
Add supported peci response codes 0x80 (Out of resources timeout)
and 0x81 (Resources required to service the command are in low
power state).

Signed-off-by: Diwakar C <diwakar.c@intel.com>