### PR TITLE
STM32: Convert interrupt controller to DT_DEVICE API

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -17,6 +17,9 @@
  * STM32F7: Lines 0 to 15, 16, 17 18, 21, 22 and 23. Others not supported
  *
  */
+
+#define EXTI_NODE DT_INST(0, st_stm32_exti)
+
 #include <device.h>
 #include <soc.h>
 #include <stm32_ll_exti.h>
@@ -412,17 +415,18 @@ static int stm32_exti_init(const struct device *dev)
 }
 
 static struct stm32_exti_data exti_data;
-DEVICE_DEFINE(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
-	      NULL, &exti_data, NULL,
-	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-	      NULL);
+DEVICE_DT_DEFINE(EXTI_NODE, &stm32_exti_init,
+		 device_pm_control_nop,
+		 &exti_data, NULL,
+		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 NULL);
 
 /**
  * @brief set & unset for the interrupt callbacks
  */
 int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 {
-	const struct device *dev = DEVICE_GET(exti_stm32);
+	const struct device *dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
 	if (data->cb[line].cb) {
@@ -437,7 +441,7 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 
 void stm32_exti_unset_callback(int line)
 {
-	const struct device *dev = DEVICE_GET(exti_stm32);
+	const struct device *dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
 	data->cb[line].cb = NULL;
@@ -456,15 +460,15 @@ static void __stm32_exti_connect_irqs(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32G0X)
 	IRQ_CONNECT(EXTI0_1_IRQn,
 		CONFIG_EXTI_STM32_EXTI1_0_IRQ_PRI,
-		__stm32_exti_isr_0_1, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_0_1, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI2_3_IRQn,
 		CONFIG_EXTI_STM32_EXTI3_2_IRQ_PRI,
-		__stm32_exti_isr_2_3, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_2_3, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI4_15_IRQn,
 		CONFIG_EXTI_STM32_EXTI15_4_IRQ_PRI,
-		__stm32_exti_isr_4_15, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_4_15, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #elif defined(CONFIG_SOC_SERIES_STM32F1X) || \
 	defined(CONFIG_SOC_SERIES_STM32F2X) || \
@@ -480,85 +484,85 @@ static void __stm32_exti_connect_irqs(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32G4X)
 	IRQ_CONNECT(EXTI0_IRQn,
 		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_0, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI1_IRQn,
 		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_1, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #ifdef CONFIG_SOC_SERIES_STM32F3X
 	IRQ_CONNECT(EXTI2_TSC_IRQn,
 		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_2, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #else
 	IRQ_CONNECT(EXTI2_IRQn,
 		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_2, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #endif /* CONFIG_SOC_SERIES_STM32F3X */
 	IRQ_CONNECT(EXTI3_IRQn,
 		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_3, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI4_IRQn,
 		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_4, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #if !defined(CONFIG_SOC_SERIES_STM32MP1X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L5X)
 	IRQ_CONNECT(EXTI9_5_IRQn,
 		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_9_5, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI15_10_IRQn,
 		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_15_10, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #else
 	IRQ_CONNECT(EXTI5_IRQn,
 		CONFIG_EXTI_STM32_EXTI5_IRQ_PRI,
-		__stm32_exti_isr_5, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_5, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI6_IRQn,
 		CONFIG_EXTI_STM32_EXTI6_IRQ_PRI,
-		__stm32_exti_isr_6, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_6, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI7_IRQn,
 		CONFIG_EXTI_STM32_EXTI7_IRQ_PRI,
-		__stm32_exti_isr_7, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_7, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI8_IRQn,
 		CONFIG_EXTI_STM32_EXTI8_IRQ_PRI,
-		__stm32_exti_isr_8, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_8, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI9_IRQn,
 		CONFIG_EXTI_STM32_EXTI9_IRQ_PRI,
-		__stm32_exti_isr_9, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_9, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI10_IRQn,
 		CONFIG_EXTI_STM32_EXTI10_IRQ_PRI,
-		__stm32_exti_isr_10, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_10, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI11_IRQn,
 		CONFIG_EXTI_STM32_EXTI11_IRQ_PRI,
-		__stm32_exti_isr_11, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_11, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI12_IRQn,
 		CONFIG_EXTI_STM32_EXTI12_IRQ_PRI,
-		__stm32_exti_isr_12, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_12, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI13_IRQn,
 		CONFIG_EXTI_STM32_EXTI13_IRQ_PRI,
-		__stm32_exti_isr_13, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_13, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI14_IRQn,
 		CONFIG_EXTI_STM32_EXTI14_IRQ_PRI,
-		__stm32_exti_isr_14, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_14, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(EXTI15_IRQn,
 		CONFIG_EXTI_STM32_EXTI15_IRQ_PRI,
-		__stm32_exti_isr_15, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_15, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #endif /* CONFIG_SOC_SERIES_STM32MP1X || CONFIG_SOC_SERIES_STM32L5X */
 
@@ -567,27 +571,27 @@ static void __stm32_exti_connect_irqs(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32F7X)
 	IRQ_CONNECT(PVD_IRQn,
 		CONFIG_EXTI_STM32_PVD_IRQ_PRI,
-		__stm32_exti_isr_16, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_16, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #if !defined(CONFIG_SOC_STM32F410RX)
 	IRQ_CONNECT(OTG_FS_WKUP_IRQn,
 		CONFIG_EXTI_STM32_OTG_FS_WKUP_IRQ_PRI,
-		__stm32_exti_isr_18, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_18, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #endif
 	IRQ_CONNECT(TAMP_STAMP_IRQn,
 		CONFIG_EXTI_STM32_TAMP_STAMP_IRQ_PRI,
-		__stm32_exti_isr_21, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_21, DEVICE_DT_GET(EXTI_NODE),
 		0);
 	IRQ_CONNECT(RTC_WKUP_IRQn,
 		CONFIG_EXTI_STM32_RTC_WKUP_IRQ_PRI,
-		__stm32_exti_isr_22, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_22, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #endif
 #if CONFIG_SOC_SERIES_STM32F7X
 	IRQ_CONNECT(LPTIM1_IRQn,
 		CONFIG_EXTI_STM32_LPTIM1_IRQ_PRI,
-		__stm32_exti_isr_23, DEVICE_GET(exti_stm32),
+		__stm32_exti_isr_23, DEVICE_DT_GET(EXTI_NODE),
 		0);
 #endif /* CONFIG_SOC_SERIES_STM32F7X */
 #endif

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -56,6 +56,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -58,6 +58,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@40010800 {
 			compatible = "st,stm32f1-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -55,6 +55,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40013C00 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40013C00 0x400>;
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -57,6 +57,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -56,6 +56,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40013c00 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40013C00 0x400>;
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -53,11 +53,19 @@
 				write-block-size = <1>;
 			};
 		};
+
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";
+		};
+
+		exti: interrupt-controller@40013C00 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40013C00 0x400>;
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -59,6 +59,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40021800 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40021800 0x400>;
+		};
+
 		pinctrl: pin-controller@50000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -99,6 +99,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -56,6 +56,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@58000000 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x58000000 0x400>;
+		};
+
 		pinctrl: pin-controller@58020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -66,6 +66,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@50000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -154,6 +154,13 @@
 			#io-channel-cells = <1>;
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -59,6 +59,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@40010400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -59,6 +59,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@4000F400 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x4000F400 0x400>;
+		};
+
 		pinctrl: pin-controller@42020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -41,6 +41,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@5000D000 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x5000D000 0x400>;
+		};
+
 		pinctrl: pin-controller@50002000 {
 			compatible = "st,stm32-pinctrl";
 			reg = <0x50002000 0x9000>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -57,6 +57,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@58000800 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x58000800 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/bindings/interrupt-controller/st,stm32-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32-exti.yaml
@@ -1,0 +1,9 @@
+description: STMicroelectronics STM32 family External Interrupt Controller
+
+compatible: "st,stm32-exti"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/include/drivers/interrupt_controller/exti_stm32.h
+++ b/include/drivers/interrupt_controller/exti_stm32.h
@@ -23,9 +23,6 @@
 
 #include <zephyr/types.h>
 
-/* device name */
-#define STM32_EXTI_NAME "stm32-exti"
-
 /**
  * @brief enable EXTI interrupt for specific line
  *


### PR DESCRIPTION
- Add exti nodes in stm32 dtsi files
- Make use of DT_DEVICE macros inside the driver