### PR TITLE
drivers: mmio32: Add GPIO_OUTPUT_INIT_LOGICAL to supported flags

### DIFF
--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -41,7 +41,7 @@ static int gpio_mmio32_config(const struct device *dev,
 
 	if (flags & ~(GPIO_INPUT | GPIO_OUTPUT |
 		      GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH |
-		      GPIO_ACTIVE_LOW)) {
+		      GPIO_ACTIVE_LOW | GPIO_OUTPUT_INIT_LOGICAL)) {
 		/* We ignore direction and fake polarity, rest is unsupported */
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Allow GPIO_OUTPUT_INIT_LOGICAL as a flag supported flag.  Since we
fake polarity, we should allow GPIO_OUTPUT_INIT_LOGICAL to be set and
ignored.

This allows samples like blinky to work as it sets GPIO_OUTPUT_ACTIVE
which we have GPIO_OUTPUT_INIT_LOGICAL set.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>