### PR TITLE
drivers: sensor: icm42605: fix uninitialized variable usage

### DIFF
--- a/drivers/sensor/icm42605/icm42605_setup.c
+++ b/drivers/sensor/icm42605/icm42605_setup.c
@@ -232,7 +232,8 @@ int icm42605_turn_on_fifo(const struct device *dev)
 {
 	const struct icm42605_data *drv_data = dev->data;
 
-	uint8_t int0_en, fifo_en;
+	uint8_t int0_en = BIT_INT_UI_DRDY_INT1_EN;
+	uint8_t fifo_en = BIT_FIFO_ACCEL_EN | BIT_FIFO_GYRO_EN | BIT_FIFO_WM_TH;
 	uint8_t burst_read[3];
 	int result;
 	uint8_t v = 0;
@@ -265,14 +266,11 @@ int icm42605_turn_on_fifo(const struct device *dev)
 		return result;
 	}
 
-	fifo_en |= (BIT_FIFO_ACCEL_EN  | BIT_FIFO_GYRO_EN | BIT_FIFO_WM_TH);
-
 	result = inv_spi_single_write(REG_FIFO_CONFIG1, &fifo_en);
 	if (result) {
 		return result;
 	}
 
-	int0_en = BIT_INT_UI_DRDY_INT1_EN;
 	result = inv_spi_single_write(REG_INT_SOURCE0, &int0_en);
 	if (result) {
 		return result;


### PR DESCRIPTION
do not or with uninitialized variable.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>