### PR TITLE
subsys: Bluetooth: LLL: Add functions that allow configure Radio for reception and sampling of CTE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
@@ -21,14 +21,20 @@ void radio_df_mode_set_aoa(void);
 void radio_df_mode_set_aod(void);
 /* Sets inline configuration enabled or disabled for receive of CTE. */
 void radio_df_cte_inline_set(uint8_t eanble);
-/* Sets length of the CTE for transmission. */
-void radio_df_cte_length_set(uint8_t value);
+
+/* Configure CTE transmission with 2us antenna switching for AoD. */
+void radio_df_cte_tx_aod_2us_set(uint8_t cte_len);
+/* Configure CTE transmission with 4us antenna switching for AoD. */
+void radio_df_cte_tx_aod_4us_set(uint8_t cte_len);
+/* Configure CTE transmission with for AoA. */
+void radio_df_cte_tx_aoa_set(uint8_t cte_len);
+/* Configure CTE reception with optionall AoA mode and 2us antenna switching. */
+void radio_df_cte_rx_2us_switching(void);
+/* Configure CTE reception with optionall AoA mode and 4us antenna switching. */
+void radio_df_cte_rx_4us_switching(void);
+
 /* Clears antenna switch pattern. */
 void radio_df_ant_switch_pattern_clear(void);
-/* Set antenna switch spacing to 2[us] */
-void radio_df_ant_switch_spacing_set_2us(void);
-/* Set antenna switch spacing to 4[us] */
-void radio_df_ant_switch_spacing_set_4us(void);
 /* Set antenna switch pattern. Pay attention, paterns are added to
  * Radio internal list. Before start of new patterns clear the list
  * by call to @ref radio_df_ant_switch_pattern_clear.
@@ -39,3 +45,12 @@ void radio_df_reset(void);
 
 /* Completes switching and enables shortcut between PHYEND and DISABLE events */
 void radio_switch_complete_and_phy_end_disable(void);
+
+/* Enables CTE inline configuration to automatically setup sampling and
+ * switching according to CTEInfo in received PDU.
+ */
+void radio_df_cte_inline_set_enabled(bool cte_info_in_s1);
+/* Set buffer to store IQ samples collected during CTE sampling */
+void radio_df_iq_data_packet_set(uint8_t *buffer, size_t len);
+/* Get number of stored IQ samples during CTE receive */
+uint32_t radio_df_iq_samples_amount_get(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -67,6 +67,7 @@ void lll_df_conf_cte_tx_enable(uint8_t type, uint8_t length,
 {
 	if (type == BT_HCI_LE_AOA_CTE) {
 		radio_df_mode_set_aoa();
+		radio_df_cte_tx_aoa_set(length);
 	}
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX) || \
 	defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
@@ -74,9 +75,9 @@ void lll_df_conf_cte_tx_enable(uint8_t type, uint8_t length,
 		radio_df_mode_set_aod();
 
 		if (type == BT_HCI_LE_AOD_CTE_1US) {
-			radio_df_ant_switch_spacing_set_2us();
+			radio_df_cte_tx_aod_2us_set(length);
 		} else {
-			radio_df_ant_switch_spacing_set_4us();
+			radio_df_cte_tx_aod_4us_set(length);
 		}
 
 		radio_df_ant_switching_pin_sel_cfg();
@@ -84,8 +85,6 @@ void lll_df_conf_cte_tx_enable(uint8_t type, uint8_t length,
 		radio_df_ant_switch_pattern_set(ant_ids, ant_num);
 	}
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX || CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
-
-	radio_df_cte_length_set(length);
 }
 
 void lll_df_conf_cte_tx_disable(void)

--- a/tests/bluetooth/df/src/radio_df_stub.c
+++ b/tests/bluetooth/df/src/radio_df_stub.c
@@ -8,7 +8,6 @@
 /* Stub functitons that does nothing. Just to avoid liker complains. */
 void radio_df_ant_configure(void)
 {
-
 }
 
 uint8_t radio_df_ant_num_get(void)
@@ -18,60 +17,52 @@ uint8_t radio_df_ant_num_get(void)
 
 void radio_df_cte_inline_set(uint8_t enable)
 {
-
 }
 
 void radio_df_cte_length_set(uint8_t value)
 {
-
 }
 
 void radio_df_ant_switch_pattern_clear(void)
 {
-
 }
 
 void radio_df_ant_switch_pattern_set(uint8_t pattern)
 {
-
 }
 
 void radio_df_reset(void)
 {
-
 }
 
 void radio_switch_complete_and_phy_end_disable(void)
 {
-
 }
 
-void radio_df_ant_switch_spacing_set_2us(void)
+void radio_df_cte_tx_aod_2us_set(uint8_t cte_len)
 {
-
 }
 
-void radio_df_ant_switch_spacing_set_4us(void)
+void radio_df_cte_tx_aod_4us_set(uint8_t cte_len)
 {
+}
 
+void radio_df_cte_tx_aoa_set(uint8_t cte_len)
+{
 }
 
 void radio_df_mode_set_aoa(void)
 {
-
 }
 
 void radio_df_mode_set_aod(void)
 {
-
-}
-
-void radio_df_ant_switching_gpios_cfg(void)
-{
-
 }
 
 void radio_df_ant_switching_pin_sel_cfg(void)
 {
+}
 
+void radio_df_ant_switching_gpios_cfg(void)
+{
 }


### PR DESCRIPTION
The PR includes:
- fix for build error from direction finding compilation when `IS_ENABLE(CONFIG_BT_CTLR_DF_ADV_CTE_TX)`  is `false`
- API to configure Radio to receive and sample CTE

Part of former code responsible for configuration of CTE Tx was refactored to comply with code responsible for CTE Rx configuration.