### PR TITLE
net: openthread: remove misleading NCP configuration option

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -222,12 +222,6 @@ config OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE
 	help
 	  Provides path to compile vendor hook file.
 
-config OPENTHREAD_NCP_BUFFER_SIZE
-	int "The size of the NCP buffers"
-	default 2048
-	help
-	  The size of the NCP buffers.
-
 endif # OPENTHREAD_COPROCESSOR
 
 config OPENTHREAD_PLATFORM_INFO

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -172,16 +172,6 @@
 #define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
 
 /**
- * @def OPENTHREAD_CONFIG_NCP_BUFFER_SIZE
- *
- * The size of the NCP buffers.
- *
- */
-#ifdef CONFIG_OPENTHREAD_NCP_BUFFER_SIZE
-#define OPENTHREAD_CONFIG_NCP_BUFFER_SIZE CONFIG_OPENTHREAD_NCP_BUFFER_SIZE
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_PLAT_LOG_MACRO_NAME
  *
  * The platform logging function for openthread.


### PR DESCRIPTION
Remove `OPENTHREAD_CONFIG_NCP_BUFFER_SIZE` define since it does not exist in OpenThread.

Full NCP configuration is here: https://github.com/zephyrproject-rtos/openthread/blob/zephyr/src/ncp/ncp_config.h