### PR TITLE
device: binding lookup should return null if the name is null

### DIFF
--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -119,18 +119,11 @@ static void test_bogus_dynamic_name(void)
  */
 static void test_null_dynamic_name(void)
 {
-	/* Supplying a NULL dynamic name may trigger a SecureFault and
-	 * lead to system crash in TrustZone enabled Non-Secure builds.
-	 */
-#if defined(CONFIG_USERSPACE) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	const struct device *mux;
 	char *drv_name = NULL;
 
 	mux = device_get_binding(drv_name);
 	zassert_equal(mux, 0,  NULL);
-#else
-	ztest_test_skip();
-#endif
 }
 
 static struct init_record {


### PR DESCRIPTION
A null device name should map to a null device.

NB: #30951 was merged to test this, but it could never have passed.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>