### PR TITLE
tests: Bluetooth: Add minimal compilation coverage for openisa

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -24,6 +24,7 @@
 
 #include "lll.h"
 #include "lll_vendor.h"
+#include "lll_clock.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
 #include "lll_chan.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4277,6 +4277,8 @@ static inline uint64_t feat_land_octet0(uint64_t feat_to_keep, uint64_t feat_oct
 	return feat_result;
 }
 
+#if defined(CONFIG_BT_PERIPHERAL) || \
+	(defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ))
 static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 			    struct pdu_data *pdu_rx)
 {
@@ -4327,6 +4329,7 @@ static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 
 	return 0;
 }
+#endif /* PERIPHERAL || (CENTRAL && SLAVE_FEAT_REQ) */
 
 #if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
 static void feature_rsp_recv(struct ll_conn *conn, struct pdu_data *pdu_rx)

--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -76,7 +76,7 @@ tests:
   bluetooth.init.test_ctlr:
     extra_args: CONF_FILE=prj_ctlr.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
-      nrf51dk_nrf51422
+      nrf51dk_nrf51422 rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_4_0:
     extra_args: CONF_FILE=prj_ctlr_4_0.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
@@ -92,19 +92,19 @@ tests:
   bluetooth.init.test_ctlr_broadcaster:
     extra_args: CONF_FILE=prj_ctlr_broadcaster.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
-      nrf51dk_nrf51422
+      nrf51dk_nrf51422 rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_peripheral:
     extra_args: CONF_FILE=prj_ctlr_peripheral.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
-      nrf51dk_nrf51422
+      nrf51dk_nrf51422 rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_observer:
     extra_args: CONF_FILE=prj_ctlr_observer.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
-      nrf51dk_nrf51422
+      nrf51dk_nrf51422 rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_central:
     extra_args: CONF_FILE=prj_ctlr_central.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
-      nrf51dk_nrf51422
+      nrf51dk_nrf51422 rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_broadcaster_ext:
     extra_args: CONF_FILE=prj_ctlr_broadcaster_ext.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832


### PR DESCRIPTION
Add minimial compilation coverage for openisa Bluetooth controller to
avoid further rot.

Includes some trivial changes to make tests pass.