### PR TITLE
gpio: clean up flags related to logical initialization

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -572,9 +572,10 @@ static inline int gpio_pin_configure(const struct device *port,
 	if (((flags & GPIO_OUTPUT_INIT_LOGICAL) != 0)
 	    && ((flags & (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH)) != 0)
 	    && ((flags & GPIO_ACTIVE_LOW) != 0)) {
-		flags ^= GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH
-			| GPIO_OUTPUT_INIT_LOGICAL;
+		flags ^= GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH;
 	}
+
+	flags &= ~GPIO_OUTPUT_INIT_LOGICAL;
 
 	(void)cfg;
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,


### PR DESCRIPTION
The wrapper function detects when a logic-level initial value requires
inverting the physical level initial value, and updates the flags to
effect the necessary change.  However where logical and physical
levels are not inverted the flag requesting logic-level initialization
was left in place and passed to a driver that got confused by it.

Clear the flag after its purpose has been addressed.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>