### PR TITLE
lib: cbprintf: don't use double va_arg if no fp support

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1525,10 +1525,14 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 				value->uint = (unsigned short)value->uint;
 			}
 		} else if (specifier_cat == SPECIFIER_FP) {
-			if (length_mod == LENGTH_UPPER_L) {
-				value->ldbl = va_arg(ap, long double);
+			if (IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT)) {
+				if (length_mod == LENGTH_UPPER_L) {
+					value->ldbl = va_arg(ap, long double);
+				} else {
+					value->dbl = va_arg(ap, double);
+				}
 			} else {
-				value->dbl = va_arg(ap, double);
+				CODE_UNREACHABLE;
 			}
 		} else if (specifier_cat == SPECIFIER_PTR) {
 			value->ptr = va_arg(ap, void *);


### PR DESCRIPTION
Even though this portion of the code is unreachable, the
compiler cannot figure that out, and so produces floating-point
operations even if CBPRINTF_FP_SUPPORT is off. Give the compiler
a hand by explicitly disabling this code if CBPRINTF_FP_SUPPORT
is off.

Signed-off-by: James Harris <james.harris@intel.com>