### PR TITLE
clock_control: Replace device_is_ready with device_usable_check

### DIFF
--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -104,8 +104,10 @@ struct clock_control_driver_api {
 static inline int clock_control_on(const struct device *dev,
 				   clock_control_subsys_t sys)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
+	int ret = device_usable_check(dev);
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	const struct clock_control_driver_api *api =
@@ -127,8 +129,10 @@ static inline int clock_control_on(const struct device *dev,
 static inline int clock_control_off(const struct device *dev,
 				    clock_control_subsys_t sys)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
+	int ret = device_usable_check(dev);
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	const struct clock_control_driver_api *api =
@@ -165,8 +169,10 @@ static inline int clock_control_async_on(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
+	int ret = device_usable_check(dev);
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	return api->async_on(dev, sys, cb, user_data);
@@ -208,8 +214,10 @@ static inline int clock_control_get_rate(const struct device *dev,
 					 clock_control_subsys_t sys,
 					 uint32_t *rate)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
+	int ret = device_usable_check(dev);
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	const struct clock_control_driver_api *api =


### PR DESCRIPTION
Use device_usable_check instead of device_is_ready so we can propagate
    back whatever error that device_usable_check() determined to the caller
    of the clock API.