### PR TITLE
libc: implement _gettimeofday() newlib hook

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -17,6 +17,7 @@
 #include <init.h>
 #include <sys/sem.h>
 #include <sys/mem_manage.h>
+#include <sys/time.h>
 
 #define LIBC_BSS	K_APP_BMEM(z_libc_partition)
 #define LIBC_DATA	K_APP_DMEM(z_libc_partition)
@@ -396,12 +397,7 @@ void *_sbrk_r(struct _reent *r, int count)
 }
 #endif /* CONFIG_XTENSA */
 
-struct timeval;
-
 int _gettimeofday(struct timeval *__tp, void *__tzp)
 {
-	ARG_UNUSED(__tp);
-	ARG_UNUSED(__tzp);
-
-	return -1;
+	return gettimeofday(__tp, __tzp);
 }


### PR DESCRIPTION
`time()` always returns -1 because the `_gettimeofday` newlib hook is empty.

I never understand the state of POSIX layer vs libc vs newlib in zephyr, so maybe this needs to be protected by some Kconfig ifdefs or something, but it works for my config.  Here is the program that demonstrates the problem (custom nrf52-based board)

prj.conf:
```
CONFIG_SOC_SERIES_NRF52X=y
CONFIG_SOC_NRF52840_QIAA=y
CONFIG_NEWLIB_LIBC=y
CONFIG_POSIX_API=y
CONFIG_OPENOCD_SUPPORT=y
CONFIG_LOG=y
CONFIG_LOG_PRINTK=y
CONFIG_LOG_MODE_IMMEDIATE=y
CONFIG_LOG_BACKEND_SWO=y
CONFIG_LOG_BACKEND_SWO_FREQ_HZ=460800
```

main.c
```
#include <stdio.h>
#include <unistd.h>

#include <zephyr.h>
#include <sys/printk.h>
#include <time.h>

void main(void)
{
	printk("zephyr version 0x%08x\n", sys_kernel_version_get());

	struct timespec a = { 1222333444, 0 };
	clock_settime(CLOCK_REALTIME, &a);
	printk("set time to %lld.%09ld\n", a.tv_sec, a.tv_nsec);

	struct timespec b;
	clock_gettime(CLOCK_REALTIME, &b);
	printk("time is %lld.%09ld\n", b.tv_sec, b.tv_nsec);

	time_t c;
	c = time(NULL);
	printk("time is %lld\n", c);
}
```

output (before fix)
```
zephyr version 0x02050000
set time to 1222333444.000000000
time is 1222333444.002960205
time is -1
```