### PR TITLE
west 0.10.0 and 0.9.1 docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -47,7 +47,7 @@ jobs:
         pip3 install setuptools wheel
         pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
-        pip3 install west==0.9.0
+        pip3 install west==0.10.0a1
 
     - name: west setup
       run: |

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -1713,16 +1713,19 @@ which defines a project ``P``, must be up to date in order for west to update
 ``P`` itself. For example, this means ``west update P`` would update
 ``manifest-rev`` in the ``baz`` project if :file:`baz/west.yml` defines ``P``,
 as well as updating the ``manifest-rev`` branch in the local git clone of
-``P``. Confusingly, the update of ``baz`` may result in the removal of ``P``
-from :file:`baz/west.yml`, which would cause ``west update P`` to fail with an
+``P``. Confusingly, updating ``baz`` may result in the removal of ``P``
+from :file:`baz/west.yml`, which "should" cause ``west update P`` to fail with an
 unrecognized project!
 
-For this reason, it's usually best to run plain ``west update`` to avoid errors
-if you use manifest imports. By default, west won't fetch any project data over
-the network if a project's revision is a SHA or tag which is already available
-locally, so updating the extra projects shouldn't take too much time unless
-it's really needed. See the documentation for the :ref:`update.fetch
-<west-config-index>` configuration option for more information.
+For this reason, it's not possible to run ``west update P`` if ``P`` is defined
+in an imported manifest; you must update this project along with all the others
+with a plain ``west update``.
+
+By default, west won't fetch any project data over the network if a project's
+revision is a SHA or tag which is already available locally, so updating the
+extra projects shouldn't take too much time unless it's really needed. See the
+documentation for the :ref:`update.fetch <west-config-index>` configuration
+option for more information.
 
 If an imported manifest file has a ``west-commands:`` definition in its
 ``self:`` section, the extension commands defined there are added to the set of

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -1015,10 +1015,16 @@ Here, ``west update`` will initialize and update all submodules in ``foo``. If
 Option 2: List of mappings
 ==========================
 
-The ``submodules`` key may be a list of mappings. Each element in the list
-defines the name of the submodule to update, and the path -- relative to the
-project's absolute path in the workspace -- to use for the submodule.
-The submodule will be updated recursively.
+The ``submodules`` key may be a list of mappings, one list element for
+each desired submodule. Each submodule listed is updated recursively.
+You can still track and update unlisted submodules with ``git`` commands
+manually; present or not they will be completely ignored by ``west``.
+
+The ``path`` key must match exactly the path of one submodule relative
+to its parent west project, as shown in the output of ``git submodule
+status``. The ``name`` key is optional and not used by west for now;
+it's not passed to ``git submodule`` commands either. The ``name`` key
+was briefly mandatory in west version 0.9.0, but was made optional in 0.9.1.
 
 For example, let's say you have a source code repository ``foo``, which has
 many submodules, and you want ``west update`` to keep some but not all of them
@@ -1032,8 +1038,7 @@ You can do that with this manifest file:
      projects:
        - name: foo
          submodules:
-           - name: foo-first-sub
-             path: path/to/foo-first-sub
+           - path: path/to/foo-first-sub
            - name: foo-second-sub
              path: path/to/foo-second-sub
        - name: bar

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -89,7 +89,7 @@ with some subsections, like this:
      self:
        # configuration related to the manifest repository itself,
        # i.e. the repository containing west.yml
-     version: <schema-version>
+     version: "<schema-version>"
      group-filter:
        # a list of project groups to enable or disable
 
@@ -398,20 +398,25 @@ manifest file schema that can parse this file's data:
 .. code-block:: yaml
 
    manifest:
-     version: 0.7
-     # marks that this manifest uses features available in west 0.7 and
-     # up, like manifest imports
+     version: "0.10"
+     # marks that this file uses version 0.10 of the west manifest
+     # file format.
 
 The pykwalify schema :file:`manifest-schema.yml` in the west source code
 repository is used to validate the manifest section. The current manifest
-``version`` is 0.9, which corresponds to west version 0.9.
+``version`` is 0.10, which is supported by west version v0.10.x.
 
-The ``version`` value may be 0.7, 0.8, or 0.9.
+The ``version`` value may be ``"0.7"``, ``"0.8"``, ``"0.9"``, or ``"0.10"``.
+West v0.10.x can load manifests with any of these ``version`` values, while
+west v0.9.x can only load versions up to ``"0.9"``, and so on.
 
-If a later version of west, say version ``21.0``, includes changes to the
-manifest schema that cannot be parsed by west 0.7, then setting ``version:
-21.0`` will cause west to print an error when attempting to parse the manifest
-data.
+West halts with an error if you ask it to load a manifest file written in a
+version it cannot handle.
+
+Quoting the ``version`` value as shown above forces the YAML parser to treat
+it as a string. Without quotes, ``0.10`` in YAML is just the floating point
+value ``0.1``. You can omit the quotes if the value is the same when cast to
+string, but it's best to include them. Always use quotes if you're not sure.
 
 Group-filter
 ============

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -81,17 +81,17 @@ with some subsections, like this:
 
    manifest:
      remotes:
-       # short names for project URLs (optional)
+       # short names for project URLs
      projects:
-       # a list of projects managed by west (mandatory)
+       # a list of projects managed by west
      defaults:
-       # default project attributes (optional)
+       # default project attributes
      self:
        # configuration related to the manifest repository itself,
-       # i.e. the repository containing west.yml (optional)
-     version: <schema-version> # optional
+       # i.e. the repository containing west.yml
+     version: <schema-version>
      group-filter:
-       # a list of project groups to enable or disable (optional)
+       # a list of project groups to enable or disable
 
 In YAML terms, the manifest file contains a mapping, with a ``manifest``
 key. Any other keys and their contents are ignored (west v0.5 also required a
@@ -99,8 +99,12 @@ key. Any other keys and their contents are ignored (west v0.5 also required a
 
 The manifest contains subsections, like ``defaults``, ``remotes``,
 ``projects``, and ``self``. In YAML terms, the value of the ``manifest`` key is
-also a mapping, with these "subsections" as keys. Only ``projects`` is
-mandatory: this is the list of repositories managed by west and their metadata.
+also a mapping, with these "subsections" as keys. As of west v0.10, all of
+these "subsection" keys are optional.
+
+The ``projects`` value is a list of repositories managed by west and associated
+metadata. We'll discuss it soon, but first we will describe the ``remotes``
+section, which can be used to save typing in the ``projects`` list.
 
 Remotes
 =======

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -409,6 +409,462 @@ Group-filter
 
 See :ref:`west-manifest-groups`.
 
+.. _west-manifest-groups:
+
+Project Groups and Active Projects
+**********************************
+
+You can use the ``groups`` and ``group-filter`` keys briefly described
+:ref:`above <west-manifest-files>` to place projects into groups, and filter
+which groups are enabled. These keys appear in the manifest like this:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: some-project
+         groups: ...
+     group-filter: ...
+
+You can enable or disable project groups using ``group-filter``. Projects whose
+groups are all disabled are *inactive*; west essentially ignores inactive
+projects unless explicitly requested not to.
+
+The next section introduces project groups; the following sections describe
+:ref:`west-enabled-disabled-groups` and :ref:`west-active-inactive-projects`.
+Finally, there are :ref:`west-project-group-examples`.
+
+Project Groups
+==============
+
+Inside ``manifest: projects:``, you can add a project to one or more groups.
+The ``groups`` key is a list of group names. Group names are strings.
+
+For example, in this manifest fragment:
+
+.. code-block:: yaml
+
+  manifest:
+    projects:
+      - name: project-1
+        groups:
+          - groupA
+      - name: project-2
+        groups:
+          - groupB
+          - groupC
+      - name: project-3
+
+The projects are in these groups:
+
+- ``project-1``: one group, named ``groupA``
+- ``project-2``: two groups, named ``groupB`` and ``groupC``
+- ``project-3``: no groups
+
+Project group names must not contain commas (,), colons (:), or whitespace.
+
+Group names must not begin with a dash (-) or the plus sign (+), but they may
+contain these characters elsewhere in their names. For example, ``foo-bar`` and
+``foo+bar`` are valid groups, but ``-foobar`` and ``+foobar`` are not.
+
+Group names are otherwise arbitrary strings. Group names are case sensitive.
+
+As a restriction, no project may use both ``import:`` and ``groups:``. (This
+avoids some edge cases whose semantics are difficult to specify.)
+
+.. _west-enabled-disabled-groups:
+
+Enabled and Disabled Project Groups
+===================================
+
+You can enable or disable project groups in both your manifest file and
+:ref:`west-config`.
+
+All groups are enabled by default.
+
+Within the manifest file, the top level ``manifest: group-filter:`` value can
+be used to disable project groups. To disable a group, prefix its name with a
+dash (-). For example, in this manifest fragment:
+
+.. code-block:: yaml
+
+   manifest:
+     group-filter: [-groupA,-groupB]
+
+The groups named ``groupA`` and ``groupB`` are disabled by this
+``group-filter`` value.
+
+The ``group-filter`` list is an ordinary YAML list, so you could have also
+written this fragment like this:
+
+.. code-block:: yaml
+
+   manifest:
+     group-filter:
+       - -groupA
+       - -groupB
+
+However, this syntax is harder to read and therefore discouraged.
+
+Although it's not an error to enable groups within ``manifest: group-filter:``,
+like this:
+
+.. code-block:: yaml
+
+   manifest:
+     ...
+     group-filter: [+groupA]
+
+doing so is redundant since groups are enabled by default.
+
+Only the **top level manifest file's** ``manifest: group-filter:`` value has
+any effect. The ``manifest: group-filter:`` values in any
+:ref:`imported manifests <west-manifest-import>` are ignored.
+
+In addition to the manifest file, you can control which groups are enabled and
+disabled using the ``manifest.group-filter`` configuration option. This option
+is a comma-separated list of groups to enable and/or disable.
+
+To enable a group, add its name to the list prefixed with ``+``. To disable a
+group, add its name prefixed with ``-``. For example, setting
+``manifest.group-filter`` to ``+groupA,-groupB`` enables ``groupA``, and
+disables ``groupB``.
+
+The value of the configuration option overrides any data in the manifest file.
+You can think of this as if the ``manifest.group-filter`` configuration option
+is appended to the ``manifest: group-filter:`` list from YAML, with "last entry
+wins" semantics.
+
+.. _west-active-inactive-projects:
+
+Active and Inactive Projects
+============================
+
+All projects are *active* by default. Projects with no groups are always
+active. A project is *inactive* if all of its groups are disabled. This is the
+only way to make a project inactive.
+
+Most west commands that operate on projects will ignore inactive projects by
+default. For example, :ref:`west-update` when run without arguments will not
+update inactive projects. As another example, running ``west list`` without
+arguments will not print information for inactive projects.
+
+.. _west-project-group-examples:
+
+Project Group Examples
+======================
+
+This section contains example situations involving project groups and active
+projects. The examples use both ``manifest: group-filter:`` YAML lists and
+``manifest.group-filter`` configuration lists, to show how they work together.
+
+Note that the ``defaults`` and ``remotes`` data in the following manifests
+isn't relevant except to make the examples complete and self-contained.
+
+Example 1: no disabled groups
+-----------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         groups:
+           - groupA
+       - name: bar
+         groups:
+           - groupA
+           - groupB
+       - name: baz
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is not set (you can ensure
+this by running ``west config -D manifest.group-filter``).
+
+No groups are disabled, because all groups are enabled by default. Therefore,
+all three projects (``foo``, ``bar``, and ``baz``) are active. Note that there
+is no way to make project ``baz`` inactive, since it has no groups.
+
+Example 2: Disabling one group via manifest
+-------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         groups:
+           - groupA
+       - name: bar
+         groups:
+           - groupA
+           - groupB
+
+     group-filter: [-groupA]
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is not set (you can ensure
+this by running ``west config -D manifest.group-filter``).
+
+Since ``groupA`` is disabled, project ``foo`` is inactive. Project ``bar`` is
+active, because ``groupB`` is enabled.
+
+Example 3: Disabling multiple groups via manifest
+-------------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         groups:
+           - groupA
+       - name: bar
+         groups:
+           - groupA
+           - groupB
+
+     group-filter: [-groupA,-groupB]
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is not set (you can ensure
+this by running ``west config -D manifest.group-filter``).
+
+Both ``foo`` and ``bar`` are inactive, because all of their groups are
+disabled.
+
+Example 4: Disabling a group via configuration
+----------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         groups:
+           - groupA
+       - name: bar
+         groups:
+           - groupA
+           - groupB
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is set to ``-groupA`` (you
+can ensure this by running ``west config manifest.group-filter -- -groupA``;
+the extra ``--`` is required so the argument parser does not treat ``-groupA``
+as a command line option ``-g`` with value ``roupA``).
+
+Project ``foo`` is inactive because ``groupA`` has been disabled by the
+``manifest.group-filter`` configuration option. Project ``bar`` is active
+because ``groupB`` is enabled.
+
+Example 5: Overriding a disabled group via configuration
+--------------------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+       - name: bar
+         groups:
+           - groupA
+       - name: baz
+         groups:
+           - groupA
+           - groupB
+
+     group-filter: [-groupA]
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is set to ``+groupA`` (you
+can ensure this by running ``west config manifest.group-filter +groupA``).
+
+In this case, ``groupA`` is enabled: the ``manifest.group-filter``
+configuration option has higher precedence than the ``manifest: group-filter:
+[-groupA]`` content in the manifest file.
+
+Therefore, projects ``foo`` and ``bar`` are both active.
+
+Example 6: Overriding multiple disabled groups via configuration
+----------------------------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+       - name: bar
+         groups:
+           - groupA
+       - name: baz
+         groups:
+           - groupA
+           - groupB
+
+     group-filter: [-groupA,-groupB]
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is set to
+``+groupA,+groupB`` (you can ensure this by running ``west config
+manifest.group-filter "+groupA,+groupB"``).
+
+In this case, both ``groupA`` and ``groupB`` are enabled, because the
+configuration value overrides the manifest file for both groups.
+
+Therefore, projects ``foo`` and ``bar`` are both active.
+
+Example 7: Disabling multiple groups via configuration
+------------------------------------------------------
+
+The entire manifest file is:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+       - name: bar
+         groups:
+           - groupA
+       - name: baz
+         groups:
+           - groupA
+           - groupB
+
+     defaults:
+       remote: example-remote
+     remotes:
+       - name: example-remote
+         url-base: https://git.example.com
+
+The ``manifest.group-filter`` configuration option is set to
+``-groupA,-groupB`` (you can ensure this by running ``west config
+manifest.group-filter -- "-groupA,-groupB"``).
+
+In this case, both ``groupA`` and ``groupB`` are disabled.
+
+Therefore, projects ``foo`` and ``bar`` are both inactive.
+
+.. _west-manifest-submodules:
+
+Git Submodules in Projects
+**************************
+
+You can use the ``submodules`` keys briefly described :ref:`above
+<west-manifest-files>` to force ``west update`` to also handle any `Git
+submodules`_ configured in project's git repository. The ``submodules`` key can
+appear inside ``projects``, like this:
+
+.. code-block:: YAML
+
+   manifest:
+     projects:
+       - name: some-project
+         submodules: ...
+
+The ``submodules`` key can be a boolean or a list of mappings. We'll describe
+these in order.
+
+Option 1: Boolean
+=================
+
+This is the easiest way to use ``submodules``.
+
+If ``submodules`` is ``true`` as a ``projects`` attribute, ``west update`` will
+recursively update the project's Git submodules whenever it updates the project
+itself. If it's ``false`` or missing, it has no effect.
+
+For example, let's say you have a source code repository ``foo``, which has
+some submodules, and you want ``west update`` to keep all of them them in sync,
+along with another project named ``bar`` in the same workspace.
+
+You can do that with this manifest file:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         submodules: true
+       - name: bar
+
+Here, ``west update`` will initialize and update all submodules in ``foo``. If
+``bar`` has any submodules, they are ignored, because ``bar`` does not have a
+``submodules`` value.
+
+Option 2: List of mappings
+==========================
+
+The ``submodules`` key may be a list of mappings. Each element in the list
+defines the name of the submodule to update, and the path -- relative to the
+project's absolute path in the workspace -- to use for the submodule.
+The submodule will be updated recursively.
+
+For example, let's say you have a source code repository ``foo``, which has
+many submodules, and you want ``west update`` to keep some but not all of them
+in sync, along with another project named ``bar`` in the same workspace.
+
+You can do that with this manifest file:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: foo
+         submodules:
+           - name: foo-first-sub
+             path: path/to/foo-first-sub
+           - name: foo-second-sub
+             path: path/to/foo-second-sub
+       - name: bar
+
+Here, ``west update`` will recursively initialize and update just the
+submodules in ``foo`` with paths ``path/to/foo-first-sub`` and
+``path/to/foo-second-sub``. Any submodules in ``bar`` are still ignored.
+
 .. _west-manifest-import:
 
 Manifest Imports
@@ -1281,462 +1737,6 @@ processed in this order:
   lexicographic order -- i.e., sorted by file name.
 - If the value is a sequence, its elements are recursively imported in the
   order they appear.
-
-.. _west-manifest-groups:
-
-Project Groups and Active Projects
-**********************************
-
-You can use the ``groups`` and ``group-filter`` keys briefly described
-:ref:`above <west-manifest-files>` to place projects into groups, and filter
-which groups are enabled. These keys appear in the manifest like this:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: some-project
-         groups: ...
-     group-filter: ...
-
-You can enable or disable project groups using ``group-filter``. Projects whose
-groups are all disabled are *inactive*; west essentially ignores inactive
-projects unless explicitly requested not to.
-
-The next section introduces project groups; the following sections describe
-:ref:`west-enabled-disabled-groups` and :ref:`west-active-inactive-projects`.
-Finally, there are :ref:`west-project-group-examples`.
-
-Project Groups
-==============
-
-Inside ``manifest: projects:``, you can add a project to one or more groups.
-The ``groups`` key is a list of group names. Group names are strings.
-
-For example, in this manifest fragment:
-
-.. code-block:: yaml
-
-  manifest:
-    projects:
-      - name: project-1
-        groups:
-          - groupA
-      - name: project-2
-        groups:
-          - groupB
-          - groupC
-      - name: project-3
-
-The projects are in these groups:
-
-- ``project-1``: one group, named ``groupA``
-- ``project-2``: two groups, named ``groupB`` and ``groupC``
-- ``project-3``: no groups
-
-Project group names must not contain commas (,), colons (:), or whitespace.
-
-Group names must not begin with a dash (-) or the plus sign (+), but they may
-contain these characters elsewhere in their names. For example, ``foo-bar`` and
-``foo+bar`` are valid groups, but ``-foobar`` and ``+foobar`` are not.
-
-Group names are otherwise arbitrary strings. Group names are case sensitive.
-
-As a restriction, no project may use both ``import:`` and ``groups:``. (This
-avoids some edge cases whose semantics are difficult to specify.)
-
-.. _west-enabled-disabled-groups:
-
-Enabled and Disabled Project Groups
-===================================
-
-You can enable or disable project groups in both your manifest file and
-:ref:`west-config`.
-
-All groups are enabled by default.
-
-Within the manifest file, the top level ``manifest: group-filter:`` value can
-be used to disable project groups. To disable a group, prefix its name with a
-dash (-). For example, in this manifest fragment:
-
-.. code-block:: yaml
-
-   manifest:
-     group-filter: [-groupA,-groupB]
-
-The groups named ``groupA`` and ``groupB`` are disabled by this
-``group-filter`` value.
-
-The ``group-filter`` list is an ordinary YAML list, so you could have also
-written this fragment like this:
-
-.. code-block:: yaml
-
-   manifest:
-     group-filter:
-       - -groupA
-       - -groupB
-
-However, this syntax is harder to read and therefore discouraged.
-
-Although it's not an error to enable groups within ``manifest: group-filter:``,
-like this:
-
-.. code-block:: yaml
-
-   manifest:
-     ...
-     group-filter: [+groupA]
-
-doing so is redundant since groups are enabled by default.
-
-Only the **top level manifest file's** ``manifest: group-filter:`` value has
-any effect. The ``manifest: group-filter:`` values in any
-:ref:`imported manifests <west-manifest-import>` are ignored.
-
-In addition to the manifest file, you can control which groups are enabled and
-disabled using the ``manifest.group-filter`` configuration option. This option
-is a comma-separated list of groups to enable and/or disable.
-
-To enable a group, add its name to the list prefixed with ``+``. To disable a
-group, add its name prefixed with ``-``. For example, setting
-``manifest.group-filter`` to ``+groupA,-groupB`` enables ``groupA``, and
-disables ``groupB``.
-
-The value of the configuration option overrides any data in the manifest file.
-You can think of this as if the ``manifest.group-filter`` configuration option
-is appended to the ``manifest: group-filter:`` list from YAML, with "last entry
-wins" semantics.
-
-.. _west-active-inactive-projects:
-
-Active and Inactive Projects
-============================
-
-All projects are *active* by default. Projects with no groups are always
-active. A project is *inactive* if all of its groups are disabled. This is the
-only way to make a project inactive.
-
-Most west commands that operate on projects will ignore inactive projects by
-default. For example, :ref:`west-update` when run without arguments will not
-update inactive projects. As another example, running ``west list`` without
-arguments will not print information for inactive projects.
-
-.. _west-project-group-examples:
-
-Project Group Examples
-======================
-
-This section contains example situations involving project groups and active
-projects. The examples use both ``manifest: group-filter:`` YAML lists and
-``manifest.group-filter`` configuration lists, to show how they work together.
-
-Note that the ``defaults`` and ``remotes`` data in the following manifests
-isn't relevant except to make the examples complete and self-contained.
-
-Example 1: no disabled groups
------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         groups:
-           - groupA
-       - name: bar
-         groups:
-           - groupA
-           - groupB
-       - name: baz
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is not set (you can ensure
-this by running ``west config -D manifest.group-filter``).
-
-No groups are disabled, because all groups are enabled by default. Therefore,
-all three projects (``foo``, ``bar``, and ``baz``) are active. Note that there
-is no way to make project ``baz`` inactive, since it has no groups.
-
-Example 2: Disabling one group via manifest
--------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         groups:
-           - groupA
-       - name: bar
-         groups:
-           - groupA
-           - groupB
-
-     group-filter: [-groupA]
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is not set (you can ensure
-this by running ``west config -D manifest.group-filter``).
-
-Since ``groupA`` is disabled, project ``foo`` is inactive. Project ``bar`` is
-active, because ``groupB`` is enabled.
-
-Example 3: Disabling multiple groups via manifest
--------------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         groups:
-           - groupA
-       - name: bar
-         groups:
-           - groupA
-           - groupB
-
-     group-filter: [-groupA,-groupB]
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is not set (you can ensure
-this by running ``west config -D manifest.group-filter``).
-
-Both ``foo`` and ``bar`` are inactive, because all of their groups are
-disabled.
-
-Example 4: Disabling a group via configuration
-----------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         groups:
-           - groupA
-       - name: bar
-         groups:
-           - groupA
-           - groupB
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is set to ``-groupA`` (you
-can ensure this by running ``west config manifest.group-filter -- -groupA``;
-the extra ``--`` is required so the argument parser does not treat ``-groupA``
-as a command line option ``-g`` with value ``roupA``).
-
-Project ``foo`` is inactive because ``groupA`` has been disabled by the
-``manifest.group-filter`` configuration option. Project ``bar`` is active
-because ``groupB`` is enabled.
-
-Example 5: Overriding a disabled group via configuration
---------------------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-       - name: bar
-         groups:
-           - groupA
-       - name: baz
-         groups:
-           - groupA
-           - groupB
-
-     group-filter: [-groupA]
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is set to ``+groupA`` (you
-can ensure this by running ``west config manifest.group-filter +groupA``).
-
-In this case, ``groupA`` is enabled: the ``manifest.group-filter``
-configuration option has higher precedence than the ``manifest: group-filter:
-[-groupA]`` content in the manifest file.
-
-Therefore, projects ``foo`` and ``bar`` are both active.
-
-Example 6: Overriding multiple disabled groups via configuration
-----------------------------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-       - name: bar
-         groups:
-           - groupA
-       - name: baz
-         groups:
-           - groupA
-           - groupB
-
-     group-filter: [-groupA,-groupB]
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is set to
-``+groupA,+groupB`` (you can ensure this by running ``west config
-manifest.group-filter "+groupA,+groupB"``).
-
-In this case, both ``groupA`` and ``groupB`` are enabled, because the
-configuration value overrides the manifest file for both groups.
-
-Therefore, projects ``foo`` and ``bar`` are both active.
-
-Example 7: Disabling multiple groups via configuration
-------------------------------------------------------
-
-The entire manifest file is:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-       - name: bar
-         groups:
-           - groupA
-       - name: baz
-         groups:
-           - groupA
-           - groupB
-
-     defaults:
-       remote: example-remote
-     remotes:
-       - name: example-remote
-         url-base: https://git.example.com
-
-The ``manifest.group-filter`` configuration option is set to
-``-groupA,-groupB`` (you can ensure this by running ``west config
-manifest.group-filter -- "-groupA,-groupB"``).
-
-In this case, both ``groupA`` and ``groupB`` are disabled.
-
-Therefore, projects ``foo`` and ``bar`` are both inactive.
-
-.. _west-manifest-submodules:
-
-Git Submodules in Projects
-**************************
-
-You can use the ``submodules`` keys briefly described :ref:`above
-<west-manifest-files>` to force ``west update`` to also handle any `Git
-submodules`_ configured in project's git repository. The ``submodules`` key can
-appear inside ``projects``, like this:
-
-.. code-block:: YAML
-
-   manifest:
-     projects:
-       - name: some-project
-         submodules: ...
-
-The ``submodules`` key can be a boolean or a list of mappings. We'll describe
-these in order.
-
-Option 1: Boolean
-=================
-
-This is the easiest way to use ``submodules``.
-
-If ``submodules`` is ``true`` as a ``projects`` attribute, ``west update`` will
-recursively update the project's Git submodules whenever it updates the project
-itself. If it's ``false`` or missing, it has no effect.
-
-For example, let's say you have a source code repository ``foo``, which has
-some submodules, and you want ``west update`` to keep all of them them in sync,
-along with another project named ``bar`` in the same workspace.
-
-You can do that with this manifest file:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         submodules: true
-       - name: bar
-
-Here, ``west update`` will initialize and update all submodules in ``foo``. If
-``bar`` has any submodules, they are ignored, because ``bar`` does not have a
-``submodules`` value.
-
-Option 2: List of mappings
-==========================
-
-The ``submodules`` key may be a list of mappings. Each element in the list
-defines the name of the submodule to update, and the path -- relative to the
-project's absolute path in the workspace -- to use for the submodule.
-The submodule will be updated recursively.
-
-For example, let's say you have a source code repository ``foo``, which has
-many submodules, and you want ``west update`` to keep some but not all of them
-in sync, along with another project named ``bar`` in the same workspace.
-
-You can do that with this manifest file:
-
-.. code-block:: yaml
-
-   manifest:
-     projects:
-       - name: foo
-         submodules:
-           - name: foo-first-sub
-             path: path/to/foo-first-sub
-           - name: foo-second-sub
-             path: path/to/foo-second-sub
-       - name: bar
-
-Here, ``west update`` will recursively initialize and update just the
-submodules in ``foo`` with paths ``path/to/foo-first-sub`` and
-``path/to/foo-second-sub``. Any submodules in ``bar`` are still ignored.
 
 .. _west-manifest-cmd:
 

--- a/doc/guides/west/manifest.rst
+++ b/doc/guides/west/manifest.rst
@@ -110,9 +110,14 @@ Remotes
 =======
 
 The ``remotes`` subsection contains a sequence which specifies the base URLs
-where projects can be fetched from. Each sequence element has a name and a "URL
-base". These are used to form the complete fetch URL for each project. For
-example:
+where projects can be fetched from.
+
+Each ``remotes`` element has a name and a "URL base". These are used to form
+the complete Git fetch URL for each project. A project's fetch URL can be set
+by appending a project-specific path onto a remote URL base. (As we'll see
+below, projects can also specify their complete fetch URLs.)
+
+For example:
 
 .. code-block:: yaml
 

--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -1,6 +1,20 @@
 West Release Notes
 ##################
 
+v0.10.0
+*******
+
+New features:
+
+- A manifest file's ``group-filter`` is now propagated through an ``import``.
+  This is a change from how west v0.9.x handled this. In west v0.9.x, only the
+  top level manifest file's ``group-filter`` had any effect; the group filter
+  lists from any imported manifests were ignored. Starting with west v0.10.0,
+  the group filter lists from imported manifests are also imported. For
+  details, see :ref:`west-group-filter-imports`.
+
+- The ``name`` key in a project's submodules list is now optional.
+
 v0.9.0
 ******
 
@@ -9,6 +23,12 @@ v0.9.0
    The ``west config`` fix described below comes at a cost: any comments or
    other manual edits in configuration files will be removed when setting a
    configuration option via that command or the ``west.configuration`` API.
+
+.. warning::
+
+   Combining the ``group-filter`` feature introduced in this release with
+   manifest imports is discouraged. The resulting behavior has changed in west
+   v0.10.
 
 New features:
 

--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -6,14 +6,49 @@ v0.10.0
 
 New features:
 
+- The ``name`` key in a project's :ref:`submodules list
+  <west-manifest-submodules>` is now optional.
+
+Bug fixes:
+
+- West now checks that the manifest schema version is one of the explicitly
+  allowed vlaues documented in :ref:`west-manifest-schema-version`. The old
+  behavior was just to check that the schema version was newer than the west
+  version where the ``manifest: version:`` key was introduced. This incorrectly
+  allowed invalid schema versions, like ``0.8.2``.
+
+Other changes:
+
 - A manifest file's ``group-filter`` is now propagated through an ``import``.
   This is a change from how west v0.9.x handled this. In west v0.9.x, only the
   top level manifest file's ``group-filter`` had any effect; the group filter
-  lists from any imported manifests were ignored. Starting with west v0.10.0,
-  the group filter lists from imported manifests are also imported. For
-  details, see :ref:`west-group-filter-imports`.
+  lists from any imported manifests were ignored.
 
-- The ``name`` key in a project's submodules list is now optional.
+  Starting with west v0.10.0, the group filter lists from imported manifests
+  are also imported. For details, see :ref:`west-group-filter-imports`.
+
+  The new behavior will take effect if ``manifest: version:`` is not given or
+  is at least ``0.10``. The old behavior is still available in the top level
+  manifest file only with an explicit ``manifest: version: 0.9``. See
+  :ref:`west-manifest-schema-version` for more information on schema versions.
+
+  See `west pull request #482
+  <https://github.com/zephyrproject-rtos/west/pull/482>`_ for the motivation
+  for this change and additional context.
+
+v0.9.1
+******
+
+Bug fixes:
+
+- Commands like ``west manifest --resolve`` now correctly include group and
+  group filter information.
+
+Other changes:
+
+- West now warns if you combine ``import`` with ``group-filter``. Semantics for
+  this combination have changed starting with v0.10.x. See the v0.10.0 release
+  notes above for more information.
 
 v0.9.0
 ******


### PR DESCRIPTION
This PR documents new `group-filter` semantics proposed for west 0.10 in https://github.com/zephyrproject-rtos/west/pull/482 along with changes for v0.9.1.

DNM because it can't be merged until we've cut these two releases.