### PR TITLE
gpio: stm32: Provide a central function for port clocks handling

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -538,18 +538,12 @@ static int gpio_stm32_init(const struct device *device)
 		return -EIO;
 	}
 
-#ifdef PWR_CR2_IOSV
+#if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
 	if (cfg->port == STM32_PORTG) {
 		/* Port G[15:2] requires external power supply */
-		/* Cf: L4XX RM, §5.1 Power supplies */
+		/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */
 		z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-		if (LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_PWR)) {
-			LL_PWR_EnableVddIO2();
-		} else {
-			LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-			LL_PWR_EnableVddIO2();
-			LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_PWR);
-		}
+		LL_PWR_EnableVddIO2();
 		z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 	}
 #endif  /* PWR_CR2_IOSV */

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -112,9 +112,10 @@ static inline uint32_t stm32_pinval_get(int pin)
 /**
  * @brief Configure the hardware.
  */
-int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf)
+int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf)
 {
-	GPIO_TypeDef *gpio = (GPIO_TypeDef *)base_addr;
+	const struct gpio_stm32_config *cfg = dev->config;
+	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
 	int pin_ll = stm32_pinval_get(pin);
 
@@ -457,7 +458,6 @@ static int gpio_stm32_port_toggle_bits(const struct device *dev,
 static int gpio_stm32_config(const struct device *dev,
 			     gpio_pin_t pin, gpio_flags_t flags)
 {
-	const struct gpio_stm32_config *cfg = dev->config;
 	int err = 0;
 	int pincfg;
 
@@ -477,7 +477,7 @@ static int gpio_stm32_config(const struct device *dev,
 		}
 	}
 
-	gpio_stm32_configure(cfg->base, pin, pincfg, 0);
+	gpio_stm32_configure(dev, pin, pincfg, 0);
 
 exit:
 	return err;

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -233,12 +233,12 @@ struct gpio_stm32_data {
 /**
  * @brief helper for configuration of GPIO pin
  *
- * @param base_addr GPIO port base address
+ * @param dev GPIO port device pointer
  * @param pin IO pin
- * @param func GPIO mode
+ * @param conf GPIO mode
  * @param altf Alternate function
  */
-int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf);
+int gpio_stm32_configure(const struct device *dev, int pin, int conf, int altf);
 
 /**
  * @brief Enable / disable GPIO port clock.

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -240,4 +240,12 @@ struct gpio_stm32_data {
  */
 int gpio_stm32_configure(uint32_t *base_addr, int pin, int conf, int altf);
 
+/**
+ * @brief Enable / disable GPIO port clock.
+ *
+ * @param dev GPIO port device pointer
+ * @param on boolean for on/off clock request
+ */
+int gpio_stm32_clock_request(const struct device *dev, bool on);
+
 #endif /* ZEPHYR_DRIVERS_GPIO_GPIO_STM32_H_ */

--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -31,79 +31,24 @@
 #endif /* CONFIG_SOC_SERIES_STM32MP1X */
 /* base address for where GPIO registers start */
 #define GPIO_PORTS_BASE       (GPIOA_BASE)
+#define GPIO_DEVICE(gpio_port)						\
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_NODELABEL(gpio_port), okay),	\
+		    (DEVICE_DT_GET(DT_NODELABEL(gpio_port))),		\
+		    ((const struct device *)NULL))
 
-static const uint32_t ports_enable[STM32_PORTS_MAX] = {
-	STM32_PERIPH_GPIOA,
-	STM32_PERIPH_GPIOB,
-	STM32_PERIPH_GPIOC,
-#ifdef GPIOD_BASE
-	STM32_PERIPH_GPIOD,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOE_BASE
-	STM32_PERIPH_GPIOE,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOF_BASE
-	STM32_PERIPH_GPIOF,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOG_BASE
-	STM32_PERIPH_GPIOG,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOH_BASE
-	STM32_PERIPH_GPIOH,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOI_BASE
-	STM32_PERIPH_GPIOI,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOJ_BASE
-	STM32_PERIPH_GPIOJ,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
-#ifdef GPIOK_BASE
-	STM32_PERIPH_GPIOK,
-#else
-	STM32_PORT_NOT_AVAILABLE,
-#endif
+const struct device * const gpio_ports[STM32_PORTS_MAX] = {
+	GPIO_DEVICE(gpioa),
+	GPIO_DEVICE(gpiob),
+	GPIO_DEVICE(gpioc),
+	GPIO_DEVICE(gpiod),
+	GPIO_DEVICE(gpioe),
+	GPIO_DEVICE(gpiof),
+	GPIO_DEVICE(gpiog),
+	GPIO_DEVICE(gpioh),
+	GPIO_DEVICE(gpioi),
+	GPIO_DEVICE(gpioj),
+	GPIO_DEVICE(gpiok),
 };
-
-/**
- * @brief enable IO port clock
- *
- * @param port I/O port ID
- * @param clk  optional clock device
- *
- * @return 0 on success, error otherwise
- */
-static int enable_port(uint32_t port, const struct device *clk)
-{
-	/* enable port clock */
-	if (!clk) {
-		clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	}
-
-	struct stm32_pclken pclken;
-
-	pclken.bus = STM32_CLOCK_BUS_GPIO;
-	pclken.enr = ports_enable[port];
-
-	if (pclken.enr == STM32_PORT_NOT_AVAILABLE) {
-		return -EIO;
-	}
-
-	return clock_control_on(clk, (clock_control_subsys_t *) &pclken);
-}
 
 static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 {
@@ -131,9 +76,10 @@ static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 			       size_t list_size, uint32_t base)
 {
-	const struct device *clk;
+	const struct device *port_device;
 	uint32_t pin, mux;
 	uint32_t func = 0;
+	int ret = 0;
 
 	if (!list_size) {
 		/* Empty pinctrl. Exit */
@@ -148,9 +94,6 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 #else
 	ARG_UNUSED(base);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl) */
-
-	/* make sure to enable port clock first */
-	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	for (int i = 0; i < list_size; i++) {
 		mux = pinctrl[i].pinmux;
@@ -189,8 +132,12 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 
 		pin = STM32PIN(STM32_DT_PINMUX_PORT(mux),
 			       STM32_DT_PINMUX_LINE(mux));
+		port_device = gpio_ports[STM32_PORT(pin)];
 
-		enable_port(STM32_PORT(pin), clk);
+		ret = gpio_stm32_clock_request(port_device, true);
+		if (ret != 0) {
+			return ret;
+		}
 
 		stm32_pin_configure(pin, func, STM32_DT_PINMUX_FUNC(mux));
 	}
@@ -447,11 +394,12 @@ int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
  *
  * @return 0 on success, error otherwise
  */
-int z_pinmux_stm32_set(uint32_t pin, uint32_t func,
-				const struct device *clk)
+int z_pinmux_stm32_set(uint32_t pin, uint32_t func)
 {
+	const struct device *port_device = gpio_ports[STM32_PORT(pin)];
+
 	/* make sure to enable port clock first */
-	if (enable_port(STM32_PORT(pin), clk)) {
+	if (gpio_stm32_clock_request(port_device, true)) {
 		return -EIO;
 	}
 
@@ -467,14 +415,10 @@ int z_pinmux_stm32_set(uint32_t pin, uint32_t func,
 void stm32_setup_pins(const struct pin_config *pinconf,
 		      size_t pins)
 {
-	const struct device *clk;
 	int i;
-
-	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	for (i = 0; i < pins; i++) {
 		z_pinmux_stm32_set(pinconf[i].pin_num,
-				  pinconf[i].mode,
-				  clk);
+				  pinconf[i].mode);
 	}
 }

--- a/drivers/pinmux/stm32/pinmux_stm32.h
+++ b/drivers/pinmux/stm32/pinmux_stm32.h
@@ -125,8 +125,7 @@ clock_control_subsys_t stm32_get_port_clock(int port);
  * @param clk clock control device, for enabling/disabling clock gate
  * for the port
  */
-int z_pinmux_stm32_set(uint32_t pin, uint32_t func,
-		      const struct device *clk);
+int z_pinmux_stm32_set(uint32_t pin, uint32_t func);
 
 /**
  * @brief helper for obtaining pin configuration for the board


### PR DESCRIPTION
Rework gpio and pinmux stm32 driver to make use of a central function for gpio ports clocks handling.

This is a preparation work in the way of PM GPIO clocks control.
This has the extra advantage of simplifying code by the creation of gpio device array
that simplifies api between gpio and pinmux drivers.

This also saves a few bytes of flash (76) at expense of 36 bytes of RAM.