### PR TITLE
soc: stm32: Fix backup_sram clock enable

### DIFF
--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -23,11 +23,9 @@ static int stm32_backup_sram_init(const struct device *dev)
 	const struct stm32_backup_sram_config *config = dev->config;
 
 	int ret;
-	const struct device *clk;
 
-	/* enable backup SRAM clock */
-	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
-	__ASSERT_NO_MSG(clk);
+	/* enable clock for subsystem */
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ret = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
 	if (ret < 0) {


### PR DESCRIPTION
This driver missed #32228 PR that converted STM32 drivers
to use DEVICE_DT_GET for clock activation.
Due to the renaming of STM32_CLOCK_CONTROL_NAME to
STM32_CLOCK_CONTROL_NODE, driver could not compile anymore

Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>