### PR TITLE
net: openthread: added heap related otPlat methods implementation

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -81,6 +81,9 @@ config OPENTHREAD_DIAG
 config OPENTHREAD_DNS_CLIENT
 	bool "Enable DNS client support"
 
+config OPENTHREAD_DNSSD_SERVER
+	bool "Enable DNS-SD server support"
+
 config OPENTHREAD_DUA
 	bool "Enable Domain Unicast Address support"
 	help

--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_DIAG diag.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_COPROCESSOR uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_EXTERNAL_HEAP memory.c)
 zephyr_library_sources_ifndef(CONFIG_LOG_BACKEND_SPINEL logging.c)
 
 zephyr_include_directories(.)

--- a/subsys/net/lib/openthread/platform/memory.c
+++ b/subsys/net/lib/openthread/platform/memory.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+
+#include <openthread/platform/memory.h>
+
+#include <stdlib.h>
+
+void *otPlatCAlloc(size_t aNum, size_t aSize)
+{
+	return calloc(aNum, aSize);
+}
+
+void otPlatFree(void *aPtr)
+{
+	free(aPtr);
+}

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
       revision: 3f545d76a2e6d1db83a470ccdb5bebd1f484e137
       path: modules/lib/loramac-node
     - name: openthread
-      revision: 1d668284a0b897bd6d539e7c3ed8009f0028099d
+      revision: d44ee763b7e8fea29b54dd064342c771161afcab
       path: modules/lib/openthread
     - name: segger
       revision: 38c79a447e4a47d413b4e8d34448316a5cece77c


### PR DESCRIPTION
Added implementations of otPlatCAlloc and otPlatFree methods
necessary for the OpenThread in case of using EXTERNAL_HEAP.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>