### PR TITLE
drivers: flash: at45: Add Reset pin

### DIFF
--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -62,3 +62,11 @@ properties:
       Time, in nanoseconds, needed by the chip to exit from the Deep Power-Down
       mode (or Ultra-Deep Power-Down mode when the "use-udpd" property is set)
       after the corresponding command is issued.
+
+  reset-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      The RESET pin of AT45 is active low.
+      If connected directly the MCU pin should be configured
+      as active low.


### PR DESCRIPTION
Adding Reset pin initialization during AT45 driver start-up. Usually this pin is driven high, this implementation only initializes GPIO as output with the passive state. The AT45 device incorporates an internal power-on reset circuit, so there is no initial on-off sequence.

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>