### PR TITLE
 device: Use CHECKIF macro to check if device name is NULL 

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -313,8 +313,7 @@ struct device {
  * it can use this function to retrieve the device structure of the lower level
  * driver by the name the driver exposes to the system.
  *
- * @param name device name to search for.  A null pointer, or a pointer to an
- * empty string, will cause NULL to be returned.
+ * @param name device name to search for.
  *
  * @return pointer to device structure; NULL if not found or cannot be used.
  */

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -8,6 +8,7 @@
 #include <device.h>
 #include <sys/atomic.h>
 #include <syscall_handler.h>
+#include <sys/check.h>
 
 extern const struct init_entry __init_start[];
 extern const struct init_entry __init_PRE_KERNEL_1_start[];
@@ -78,6 +79,10 @@ void z_sys_init_run_level(int32_t level)
 const struct device *z_impl_device_get_binding(const char *name)
 {
 	const struct device *dev;
+
+	CHECKIF((name == NULL) || (*name == 0)) {
+		return NULL;
+	}
 
 	/* Split the search into two loops: in the common scenario, where
 	 * device names are stored in ROM (and are referenced by the user

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -79,13 +79,6 @@ const struct device *z_impl_device_get_binding(const char *name)
 {
 	const struct device *dev;
 
-	/* A null string identifies no device.  So does an empty
-	 * string.
-	 */
-	if ((name == NULL) || (*name == 0)) {
-		return NULL;
-	}
-
 	/* Split the search into two loops: in the common scenario, where
 	 * device names are stored in ROM (and are referenced by the user
 	 * with CONFIG_* macros), only cheap pointer comparisons will be


### PR DESCRIPTION
Zephyr assumes the application to be trusted for this reason all
parameters check are done using assert (or derivatives) that can be
turned off in production to reduce the footprint. This commit follows
up commit reverting a hard check.

Nevertheless, parameters are already checked in verification functions
in syscalls when user mode is enabled. That is aligned with Zephyr's threat
model that assume that code running in user mode is untrusted.
