### PR TITLE
net: lwm2m: Utility functions added to LWM2M Engine

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -392,6 +392,36 @@ struct lwm2m_objlnk {
 };
 
 /**
+ * @brief Change an observer's pmin value.
+ *
+ * LwM2M clients use this function to modify the pmin attribute
+ * for an observation being made.
+ * Example to update the pmin of a temperature sensor value being observed:
+ * lwm2m_engine_update_observer_min_period("3303/0/5700",5);
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
+ * @param[in] period_s Value of pmin to be given (in seconds).
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_update_observer_min_period(char *pathstr, uint32_t period_s);
+
+/**
+ * @brief Change an observer's pmax value.
+ *
+ * LwM2M clients use this function to modify the pmax attribute
+ * for an observation being made.
+ * Example to update the pmax of a temperature sensor value being observed:
+ * lwm2m_engine_update_observer_max_period("3303/0/5700",5);
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
+ * @param[in] period_s Value of pmax to be given (in seconds).
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_update_observer_max_period(char *pathstr, uint32_t period_s);
+
+/**
  * @brief Create an LwM2M object instance.
  *
  * LwM2M clients use this function to create non-default LwM2M objects:
@@ -842,6 +872,21 @@ int lwm2m_engine_create_res_inst(char *pathstr);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_engine_delete_res_inst(char *pathstr);
+
+/**
+ * @brief Update the period of a given service.
+ *
+ * Allow the period modification on an existing service created with
+ * lwm2m_engine_add_service().
+ * Example to frequency at which a periodic_service changes it's values :
+ * lwm2m_engine_update_service(device_periodic_service,5*MSEC_PER_SEC);
+ *
+ * @param[in] service Handler of the periodic_service
+ * @param[in] period_ms New period for the periodic_service (in milliseconds)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_update_service_period(k_work_handler_t service, uint32_t period_ms);
 
 /**
  * @brief Start the LwM2M engine

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1924,6 +1924,58 @@ int lwm2m_engine_get_resource(char *pathstr, struct lwm2m_engine_res **res)
 	return path_to_objs(&path, NULL, NULL, res, NULL);
 }
 
+int lwm2m_engine_update_observer_min_period(char *pathstr, uint32_t period_s)
+{
+	int i, ret;
+	struct lwm2m_obj_path path;
+
+	ret = string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
+		if (observe_node_data[i].path.level == path.level &&
+		    observe_node_data[i].path.obj_id == path.obj_id &&
+		    (path.level >= 2 ?
+		     observe_node_data[i].path.obj_inst_id == path.obj_inst_id : true) &&
+		    (path.level >= 3 ?
+		     observe_node_data[i].path.res_id == path.res_id : true)) {
+
+			observe_node_data[i].min_period_sec = period_s;
+			return 0;
+		}
+	}
+
+	return -ENOENT;
+}
+
+int lwm2m_engine_update_observer_max_period(char *pathstr, uint32_t period_s)
+{
+	int i, ret;
+	struct lwm2m_obj_path path;
+
+	ret = string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
+		if (observe_node_data[i].path.level == path.level &&
+		    observe_node_data[i].path.obj_id == path.obj_id &&
+		    (path.level >= 2 ?
+		     observe_node_data[i].path.obj_inst_id == path.obj_inst_id : true) &&
+		    (path.level >= 3 ?
+		     observe_node_data[i].path.res_id == path.res_id : true)) {
+
+			observe_node_data[i].max_period_sec = period_s;
+			return 0;
+		}
+	}
+
+	return -ENOENT;
+}
+
 void lwm2m_engine_get_binding(char *binding)
 {
 	if (IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_ENABLED)) {
@@ -4393,6 +4445,20 @@ int lwm2m_engine_add_service(k_work_handler_t service, uint32_t period_ms)
 			 &service_node_data[i].node);
 
 	return 0;
+}
+
+int lwm2m_engine_update_service_period(k_work_handler_t service, uint32_t period_ms)
+{
+	int i = 0;
+
+	for (i = 0; i < MAX_PERIODIC_SERVICE; i++) {
+		if (service_node_data[i].service_work == service) {
+			service_node_data[i].min_call_period = period_ms;
+			return 0;
+		}
+	}
+
+	return -ENOENT;
 }
 
 static int lwm2m_engine_service(void)


### PR DESCRIPTION
Added 3 utility functions :
- _lwm2m_engine_update_period_service_() which updates the period of a given service. 
This allow the service to occur more or less frequently depending on programmer's choice without having to remove the service and add another one. It is also possible to control the system with this function being called on a callback execute trigger.
- _lwm2m_engine_update_period_min_observer_() which updates the min_period_sec for a given observe node.
This allow the dynamic change of the observer pmin value during the execution of the program, without the user having to request it through REST commands. 
- _lwm2m_engine_update_period_max_observer_() which updates the max_period_sec for a given observe node.
This allow the dynamic change of the observer pmax value during the execution of the program, without the user having to request it through REST commands. 