### PR TITLE
cmake: use build type from prj_<build>.conf when sourcing DTS overlay

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -479,7 +479,7 @@ The CACHED_CONF_FILE is internal Zephyr variable used between CMake runs. \
 To change CONF_FILE, use the CONF_FILE variable.")
 unset(CONF_FILE CACHE)
 
-zephyr_file(CONF_FILES ${APPLICATION_SOURCE_DIR}/boards DTS APP_BOARD_DTS)
+zephyr_file(CONF_FILES ${APPLICATION_SOURCE_DIR}/boards DTS APP_BOARD_DTS BUILD ${CONF_FILE_BUILD_TYPE})
 
 if(DTC_OVERLAY_FILE)
   # DTC_OVERLAY_FILE has either been specified on the cmake CLI or is already

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1934,6 +1934,10 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
 
     if(FILE_DTS)
       foreach(filename ${FILENAMES})
+        if(FILE_BUILD)
+          set(filename "${filename}_${FILE_BUILD}")
+        endif()
+
         if(EXISTS ${FILE_CONF_FILES}/${filename}.overlay)
           list(APPEND ${FILE_DTS} ${FILE_CONF_FILES}/${filename}.overlay)
         endif()


### PR DESCRIPTION
Draft PR inspired by: #32341
Still lacks documentation update, but feel free to comment on principle.

-------

Follow-up: #28039

The enhancement described in #27934 was fixed by #28039 by supporting
prj_<build>.conf file when sourcing additional Kconfig fragments with
following pattern `boards/<board>_<build>.conf in the application
folder.

This commit is following up on that work by aligning DTS overlays with
Kconfig fragments, by supporting `boards/<board>_<build>.overlay`.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>