### PR TITLE
Bluetooth: controller: Move version define to ll_feat.h file

### DIFF
--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -1,11 +1,9 @@
 /*
- * Copyright (c) 2016-2018 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2021 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
 
 #define LL_ADV_CMDS_ANY    0 /* Any advertising cmd/evt allowed */
 #define LL_ADV_CMDS_LEGACY 1 /* Only legacy advertising cmd/evt allowed */

--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2016-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2021 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 #define LL_FEAT_BIT_ENC BIT64(BT_LE_FEAT_BIT_ENC)


### PR DESCRIPTION
Move the controller version define into ll_feat.h file to
keep the version number and featureset bitmaps together.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>