### PR TITLE
[backport v1.14] Bluetooth: SMP: fix for bt fixed passkey BT_PASSKEY_INVALID 

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4424,7 +4424,7 @@ int bt_smp_auth_pairing_confirm(struct bt_conn *conn)
 int bt_passkey_set(unsigned int passkey)
 {
 	if (passkey == BT_PASSKEY_INVALID) {
-		passkey = BT_PASSKEY_INVALID;
+		fixed_passkey = BT_PASSKEY_INVALID;
 		return 0;
 	}
 


### PR DESCRIPTION
When BT_PASSKEY_INVALID was set, it never updated the fixed
passkey which made its use ineffective.

Signed-off-by: Faisal Saleem <faisal.saleem@setec.com.au>

Backport from pull request: https://github.com/zephyrproject-rtos/zephyr/pull/32198