### PR TITLE
Bluetooth: controller: Rename pdu_biginfo to pdu_big_info

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -825,7 +825,7 @@ struct pdu_bis {
 	} __packed;
 } __packed;
 
-struct pdu_biginfo {
+struct pdu_big_info {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint32_t offset:14;
 	uint32_t offset_units:1;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -232,7 +232,7 @@ void ull_sync_iso_release(struct ll_sync_iso *sync_iso)
 
 void ull_sync_iso_setup(struct ll_sync_iso *sync_iso,
 			struct node_rx_hdr *node_rx,
-			struct pdu_biginfo *biginfo)
+			struct pdu_big_info *big_info)
 {
 	uint32_t ticks_slot_overhead;
 	struct node_rx_sync_iso *se;
@@ -249,7 +249,7 @@ void ull_sync_iso_setup(struct ll_sync_iso *sync_iso,
 	lll = &sync_iso->lll;
 	handle = ull_sync_iso_handle_get(sync_iso);
 
-	interval = sys_le16_to_cpu(biginfo->iso_interval);
+	interval = sys_le16_to_cpu(big_info->iso_interval);
 	interval_us = interval * CONN_INT_UNIT_US;
 
 	/* TODO: Populate LLL with information from the BIGINFO */

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso_internal.h
@@ -12,4 +12,4 @@ uint8_t ull_sync_iso_lll_handle_get(struct lll_sync_iso *lll);
 void ull_sync_iso_release(struct ll_sync_iso *sync_iso);
 void ull_sync_iso_setup(struct ll_sync_iso *sync_iso,
 			struct node_rx_hdr *node_rx,
-			struct pdu_biginfo *biginfo);
+			struct pdu_big_info *big_info);


### PR DESCRIPTION
Rename struct pdu_biginfo to struct pdu_big_info.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>