### PR TITLE
[DNM] west.yml: Test update of mcumgr revision for PR mynewt-mcumgr#114 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: apache
+      url-base: https://github.com/apache
 
   #
   # Please add items below based on alphabetical order
@@ -93,8 +95,9 @@ manifest:
     - name: mcuboot
       revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
       path: bootloader/mcuboot
-    - name: mcumgr
-      revision: 43845e883ff3a6cdaae22e23f3e60b5fcf78c6ba
+    - name: mynewt-mcumgr
+      remote: apache
+      revision: pull/114/head
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 41132e9220f8bc1223084975350c5e5f3b492afe


### PR DESCRIPTION
The commit updates mcumgr revision to:
 https://github.com/apache/mynewt-mcumgr/pull/114
from upstream apache/mynewt-mcumgr for the purpose of testing the PR

The tested PR includes changes that affect how the currently running
application slot is identified in the code.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>