### PR TITLE
soc: arm: nrf5340: remove handling for Erratum 19

### DIFF
--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -45,7 +45,6 @@ if CPU_HAS_NRF_IDAU
 config NRF_SPU_FLASH_REGION_SIZE
 	hex
 	default 0x8000 if SOC_NRF9160
-	default 0x8000 if SOC_NRF5340_CPUAPP && NRF5340_CPUAPP_ERRATUM19
 	default 0x4000 if SOC_NRF5340_CPUAPP
 	help
 	  FLASH region size for the NRF_SPU peripheral

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
@@ -11,19 +11,6 @@ config SOC
 config NUM_IRQS
 	default 69
 
-config NRF5340_CPUAPP_ERRATUM19
-	bool "Include workarounds for Erratum 19"
-	depends on !TRUSTED_EXECUTION_NONSECURE
-	help
-	  This anomaly applies to IC Rev. Engineering A, build codes QKAA-AB0.
-	  This config MUST be enabled if there is a chance the code will be run
-	  on nRF5340 Engineering A. Enabling this config is safe on other
-	  nRF5340 variants, but might increase flash size.
-	  The workaround involves adding run-time checks when using the SPU,
-	  and aligning regions on 32 KiB instead of 16 KiB if they are to be
-	  locked with the SPU.
-	  More info: https://infocenter.nordicsemi.com/topic/errata_nRF5340_EngA/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html?cp=3_0_1_0_1_15
-
 config IEEE802154_NRF5
 	default IEEE802154
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -102,24 +102,4 @@ void z_platform_init(void)
 	SystemInit();
 }
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && \
-	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && \
-	!defined(CONFIG_NRF5340_CPUAPP_ERRATUM19)
-
-static int check_erratum19(const struct device *arg)
-{
-	ARG_UNUSED(arg);
-	if (nrf53_errata_19()) {
-		LOG_ERR("This device is affected by nRF53 Erratum 19,");
-		LOG_ERR("but workarounds have not been enabled.");
-		LOG_ERR("See CONFIG_NRF5340_CPUAPP_ERRATUM19.");
-		k_panic();
-	}
-
-	return 0;
-}
-
-SYS_INIT(check_erratum19, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
-#endif
-
 SYS_INIT(nordicsemi_nrf53_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
Erratum 19 applies to earlier revisions of nRF5340 DK,
which are no longer supported in the tree, so we can
remove the code that handles it.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>