### PR TITLE
[DNM] Test PR for apache-mcumgr PR 115 and Zephyr changes that support it

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -144,6 +144,15 @@ menuconfig MCUMGR_CMD_IMG_MGMT
 	  Enables mcumgr handlers for image management
 
 if MCUMGR_CMD_IMG_MGMT
+config IMG_MGMT_DIRECT_XIP
+	bool "Enables mcuboot Direct-XIP restrictions within image management"
+	help
+	  The option should be enabled if mcuboot, on the device the the
+	  application will be built for, has been built with Direct-XIP;
+	  The option will will force mcmgr to ignore pending bits for slots,
+	  as they have no meaning for Direct-XIP, and allow to overwrite slots
+	  that have been set peding for test or permanently.
+
 config IMG_MGMT_UL_CHUNK_SIZE
 	int "Maximum chunk size for image uploads"
 	default 512

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: apache
+      url-base: https://github.com/apache
 
   #
   # Please add items below based on alphabetical order
@@ -93,8 +95,9 @@ manifest:
     - name: mcuboot
       revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
       path: bootloader/mcuboot
-    - name: mcumgr
-      revision: c52ecb771a9b2bdabfc70bee094555f11edbb539
+    - name: mynewt-mcumgr
+      remote: apache
+      revision: pull/115/head
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 41132e9220f8bc1223084975350c5e5f3b492afe


### PR DESCRIPTION
~~**This PR depends on https://github.com/zephyrproject-rtos/zephyr/pull/32446**~~

This is test update of west.yml that tests:
 https://github.com/apache/mynewt-mcumgr/pull/115

 that introduce:
   1) compile time selection of slot from which application is running
       to mcumgr;
   2) removal of restrictions on uploading images to slots marked as
       pending, for Direct-XIP enabled applications.

It also changes to Zephyr that introduce IMG_MGMT_DIRECT_XIP Kconfig
option that controls 2) from the level of Zephyr compilation.