### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: 9a069a55bd6a28598b9f9bafdd15056225ddf3b4
+      revision: 50283e0438d882a80fb681907664491c7042c817
       path: modules/hal/stm32
     - name: hal_ti
       revision: 277d70a65ab14d46bf1ec0935cf9bb28bbaa8ab9


### PR DESCRIPTION
F0: from version v1.11.1 to version v1.11.2
F1: from version v1.8.2 to version v1.8.3
F2: from version v1.9.1 to version v1.9.2
F3: from version v1.11.1 to version v1.11.2
F4: from version v1.25.1 to version v1.25.2
L0: from version v1.11.3 to version v1.12.0
MP1: from version 1.2.0 to version 1.3.0 -> Removed, cf https://github.com/zephyrproject-rtos/hal_stm32/pull/91#issuecomment-781982955

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>