### PR TITLE
runners: jlink: Use specific target device for nrf9160DK

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -4,6 +4,6 @@ if(CONFIG_BOARD_NRF9160DK_NRF9160NS)
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
When proper target device is specified, instead of generic
Cortex-M33, JLinkGDBServer is able to flash the device on "load"
command.

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>