### PR TITLE
cmake: using MD5_INFILE variable instead of ZephyrPackagePath.txt

### DIFF
--- a/share/zephyr-package/cmake/zephyr_export.cmake
+++ b/share/zephyr-package/cmake/zephyr_export.cmake
@@ -34,4 +34,4 @@ else()
   message("~/.cmake/packages/Zephyr\n")
 endif()
 
-file(REMOVE ${CMAKE_CURRENT_LIST_DIR}/ZephyrPackagePath.txt)
+file(REMOVE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE})


### PR DESCRIPTION
Running `west zephyr-export` creates an entry in the CMake User package
registry.

During this process, a temporary file `current_path.txt` is created.

This commit ensure the file is removed when no longer needed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>