### PR TITLE
boards: arm: Added Arduino's nexus node on stm32l496g_disco's devicetree

### DIFF
--- a/boards/arm/stm32l496g_disco/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32l496g_disco/arduino_r3_connector.dtsi
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Thomas Le Roux
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =
+			<0 0 &gpioc 4 0>,    /* A0 */
+			<1 0 &gpioc 1 0>,    /* A1 */
+			<2 0 &gpioc 3 0>,    /* A2 */
+			<3 0 &gpiof 10 0>,   /* A3 */
+			<4 0 &gpioa 1 0>,    /* A4 */
+			<5 0 &gpioc 0 0>,    /* A5 */
+			<6 0 &gpiog 8 0>,    /* D0 */
+			<7 0 &gpiog 7 0>,    /* D1 */
+			<8 0 &gpiog 13 0>,   /* D2 */
+			<9 0 &gpioh 15 0>,   /* D3 */
+			<10 0 &gpioi 11 0>,  /* D4 */
+			<11 0 &gpiob 9 0>,   /* D5 */
+			<12 0 &gpioi 6 0>,   /* D6 */
+			<13 0 &gpiog 6 0>,   /* D7 */
+			<14 0 &gpiog 15 0>,  /* D8 */
+			<15 0 &gpioh 13 0>,  /* D9 */
+			<16 0 &gpioa 15 0>,  /* D10 */
+			<17 0 &gpiob 5 0>,   /* D11 */
+			<18 0 &gpiob 4 0>,   /* D12 */
+			<19 0 &gpioa 5 0>,   /* D13 */
+			<20 0 &gpiob 7 0>,   /* D14 */
+			<21 0 &gpiob 8 0>;   /* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/l4/stm32l496Xg.dtsi>
 #include <st/l4/stm32l496a(e-g)ix-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L496G-DISCO board";
@@ -54,12 +55,13 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &joy_sel;
+		sw1 = &joy_down;
+		sw2 = &joy_right;
+		sw3 = &joy_up;
+		sw4 = &joy_left;
 	};
-};
 
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &lpuart1 {};
+};
 
 &usart1 {
 	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pg10>;


### PR DESCRIPTION
- Added Arduino's nexus node on the board's devicetree based on the board's datasheet.
- Also added various joystick aliases that weren't declared before.