### PR TITLE
tests: unit: cbprintf: force libc substitutes in test case

### DIFF
--- a/tests/unit/cbprintf/CMakeLists.txt
+++ b/tests/unit/cbprintf/CMakeLists.txt
@@ -2,5 +2,4 @@
 
 project(lib_os_cbprintf)
 set(SOURCES main.c)
-set(EXTRA_CPPFLAGS "-DCONFIG_CBPRINTF_LIBC_SUBSTS=1")
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define CONFIG_CBPRINTF_LIBC_SUBSTS 1
 
 #include <ztest.h>
 #include <float.h>


### PR DESCRIPTION
The test infrastructure uses EXTRA_CPPFLAGS to control which
configuration is used, but this was also added to CMakeLists to ensure
a common optional infrastructure was always available.  Since unit
tests don't use Kconfig, this actually prevented the test variants
from being selected.

Add the flag in the test itself, which works correctly since the test
includes the implementation directly.

Broken by: 427508cf159e6955671790f591c59dbb7c5ade70
Fixes: #32459