### PR TITLE
kernel/sched: Adjust locking in z_swap()

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -67,6 +67,7 @@ void z_ready_thread(struct k_thread *thread);
 void z_thread_single_abort(struct k_thread *thread);
 FUNC_NORETURN void z_self_abort(void);
 void z_requeue_current(struct k_thread *curr);
+struct k_thread *z_swap_next_thread(void);
 
 static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, k_timeout_t timeout)
 {
@@ -77,17 +78,6 @@ static inline void z_reschedule_unlocked(void)
 {
 	(void) z_reschedule_irqlock(arch_irq_lock());
 }
-
-/* find which one is the next thread to run */
-/* must be called with interrupts locked */
-#ifdef CONFIG_SMP
-extern struct k_thread *z_get_next_ready_thread(void);
-#else
-static ALWAYS_INLINE struct k_thread *z_get_next_ready_thread(void)
-{
-	return _kernel.ready_q.cache;
-}
-#endif
 
 static inline bool z_is_idle_thread_entry(void *entry_point)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -56,7 +56,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 /* the only struct z_kernel instance */
 struct z_kernel _kernel;
 
-static struct k_spinlock sched_spinlock;
+struct k_spinlock sched_spinlock;
 
 static void update_cache(int);
 
@@ -222,10 +222,8 @@ static ALWAYS_INLINE void dequeue_thread(void *pq,
  */
 void z_requeue_current(struct k_thread *curr)
 {
-	LOCKED(&sched_spinlock) {
-		if (z_is_thread_queued(curr)) {
-			_priq_run_add(&_kernel.ready_q.runq, curr);
-		}
+	if (z_is_thread_queued(curr)) {
+		_priq_run_add(&_kernel.ready_q.runq, curr);
 	}
 }
 #endif
@@ -919,7 +917,7 @@ static inline bool need_swap(void)
 	struct k_thread *new_thread;
 
 	/* Check if the next ready thread is the same as the current thread */
-	new_thread = z_get_next_ready_thread();
+	new_thread = _kernel.ready_q.cache;
 	return new_thread != _current;
 #endif
 }
@@ -967,18 +965,14 @@ void k_sched_unlock(void)
 #endif
 }
 
-#ifdef CONFIG_SMP
-struct k_thread *z_get_next_ready_thread(void)
+struct k_thread *z_swap_next_thread(void)
 {
-	struct k_thread *ret = 0;
-
-	LOCKED(&sched_spinlock) {
-		ret = next_up();
-	}
-
-	return ret;
-}
+#ifdef CONFIG_SMP
+	return next_up();
+#else
+	return _kernel.ready_q.cache;
 #endif
+}
 
 /* Just a wrapper around _current = xxx with tracing */
 static inline void set_current(struct k_thread *new_thread)
@@ -1044,7 +1038,7 @@ void *z_get_next_switch_handle(void *interrupted)
 	return ret;
 #else
 	_current->switch_handle = interrupted;
-	set_current(z_get_next_ready_thread());
+	set_current(_kernel.ready_q.cache);
 	return _current->switch_handle;
 #endif
 }

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -770,16 +770,21 @@ ALWAYS_INLINE void z_unpend_thread_no_timeout(struct k_thread *thread)
 /* Timeout handler for *_thread_timeout() APIs */
 void z_thread_timeout(struct _timeout *timeout)
 {
-	LOCKED(&sched_spinlock) {
-		struct k_thread *thread = CONTAINER_OF(timeout,
-						struct k_thread, base.timeout);
+	struct k_thread *thread = CONTAINER_OF(timeout,
+					       struct k_thread, base.timeout);
 
-		if (thread->base.pended_on != NULL) {
-			unpend_thread_no_timeout(thread);
+	LOCKED(&sched_spinlock) {
+		bool killed = ((thread->base.thread_state & _THREAD_DEAD) ||
+			       (thread->base.thread_state & _THREAD_ABORTING));
+
+		if (!killed) {
+			if (thread->base.pended_on != NULL) {
+				unpend_thread_no_timeout(thread);
+			}
+			z_mark_thread_as_started(thread);
+			z_mark_thread_as_not_suspended(thread);
+			ready_thread(thread);
 		}
-		z_mark_thread_as_started(thread);
-		z_mark_thread_as_not_suspended(thread);
-		ready_thread(thread);
 	}
 }
 #endif

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -807,7 +807,7 @@ void z_init_thread_base(struct _thread_base *thread_base, int priority,
 		       uint32_t initial_state, unsigned int options)
 {
 	/* k_q_node is initialized upon first insertion in a list */
-
+	thread_base->pended_on = NULL;
 	thread_base->user_options = (uint8_t)options;
 	thread_base->thread_state = (uint8_t)initial_state;
 


### PR DESCRIPTION
[I wrote this as part of work to address a known abort race in #32344 .  But it turns out that this change all by itself hides that problem for me.  It is NOT a fix for the race, but the window (which got opened in the deadlock fix a few commits back) is now so tiny that I can't make it happen.   So it's probably worth reviewing and committing early to unwreck CI.] 

Swap was originally written to use the scheduler lock just to select a
new thread, but it would be nice to be able to rely on scheduler
atomicity later in the process.  Rework the code a bit so that swap
takes the lock itself and holds it until just before the call to
arch_switch().

Note that the local interrupt mask has always been required to be held
across the swap, so extending the lock here has no effect on latency
at all on uniprocessor setups, and even on SMP only affects average
latency and not worst case.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>