### PR TITLE
cmake: remove duplicated ZEPHYR_BASE append to BOARD_ROOT

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -199,9 +199,6 @@ add_custom_target(
 # Dummy add to generate files.
 zephyr_linker_sources(SECTIONS)
 
-zephyr_file(APPLICATION_ROOT BOARD_ROOT)
-list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
-
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
 zephyr_file(APPLICATION_ROOT BOARD_ROOT)


### PR DESCRIPTION
The following two lines are duplicated in boilerplate.cmake
```
zephyr_file(APPLICATION_ROOT BOARD_ROOT)
list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
```

This commit removes one set of the duplicated lines.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>