### PR TITLE
cmake: check BOARD and SOC roots before use

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -245,6 +245,15 @@ if(${BOARD}_DEPRECATED)
 endif()
 
 foreach(root ${BOARD_ROOT})
+  # Check that the board root looks reasonable.
+  if(NOT IS_DIRECTORY "${root}/boards")
+    message(WARNING "BOARD_ROOT element without a 'boards' subdirectory:
+${root}
+Hints:
+  - if your board directory is '/foo/bar/boards/<ARCH>/my_board' then add '/foo/bar' to BOARD_ROOT, not the entire board directory
+  - if in doubt, use absolute paths")
+  endif()
+
   # NB: find_path will return immediately if the output variable is
   # already set
   if (BOARD_ALIAS)
@@ -549,6 +558,15 @@ endif()
 # Use SOC to search for a 'CMakeLists.txt' file.
 # e.g. zephyr/soc/xtense/intel_apl_adsp/CMakeLists.txt.
 foreach(root ${SOC_ROOT})
+  # Check that the root looks reasonable.
+  if(NOT IS_DIRECTORY "${root}/soc")
+    message(WARNING "SOC_ROOT element without a 'soc' subdirectory:
+${root}
+Hints:
+  - if your SoC family directory is '/foo/bar/soc/<ARCH>/my_soc_family', then add '/foo/bar' to SOC_ROOT, not the entire SoC family path
+  - if in doubt, use absolute paths")
+  endif()
+
   if(EXISTS ${root}/soc/${ARCH}/${SOC_PATH})
     set(SOC_DIR ${root}/soc)
     break()


### PR DESCRIPTION
People frequently do things like setting BOARD_ROOT to
/my/module/boards/arm/my_board when it should be set to /my/module.

Similar misconfigurations happen for SOC_ROOT.

Emit warnings in these situations to try to point users in the right
direction.

A similar change could be made for DTS_ROOT, but that is trickier
since at least one directory (the application root) is legitimately
added to it that does not always contain dts/ or include/
subdirectories.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>