### PR TITLE
subsys/shell: check for shell context before accessing it

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1408,9 +1408,9 @@ void shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
 {
 	__ASSERT_NO_MSG(shell);
 	__ASSERT(!k_is_in_isr(), "Thread context required.");
+	__ASSERT_NO_MSG(shell->ctx);
 	__ASSERT_NO_MSG((shell->ctx->internal.flags.cmd_ctx == 1) ||
 			(k_current_get() != shell->ctx->tid));
-	__ASSERT_NO_MSG(shell->ctx);
 	__ASSERT_NO_MSG(shell->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
 


### PR DESCRIPTION
The ASSERT order is backwards, where the shell->ctx is being accessed
before it is being checked as valid.  Moving the check for the
shell->ctx to before the using it.

Signed-off-by: Dan Kalowsky <dkalowsky@amperecomputing.com>