### PR TITLE
[TOPIC-BLE-LLCP] Data Length Update procedure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -28,6 +28,15 @@ struct node_tx {
 	uint8_t pdu[];
 };
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+struct data_pdu_length {
+	uint16_t max_tx_octets;
+	uint16_t max_rx_octets;
+	uint16_t max_tx_time;
+	uint16_t max_rx_time;
+};
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+
 struct lll_conn {
 	struct lll_hdr hdr;
 
@@ -71,6 +80,8 @@ struct lll_conn {
 #endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 	uint16_t max_tx_octets;
 	uint16_t max_rx_octets;
 
@@ -78,7 +89,16 @@ struct lll_conn {
 	uint16_t max_tx_time;
 	uint16_t max_rx_time;
 #endif /* CONFIG_BT_CTLR_PHY */
+
+#else /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
+	struct {
+		struct data_pdu_length local;
+		struct data_pdu_length remote;
+		struct data_pdu_length eff;
+		uint8_t update;
+	} dle;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+#endif/* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	uint8_t phy_tx:3;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -473,7 +473,11 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	LL_ASSERT(node_rx);
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 	max_rx_octets = lll->max_rx_octets;
+#else
+	max_rx_octets = lll->dle.eff.max_rx_octets;
+#endif
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
 	max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
@@ -517,7 +521,11 @@ void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx)
 	uint8_t phy, flags;
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 	max_tx_octets = lll->max_tx_octets;
+#else
+	max_tx_octets = lll->dle.eff.max_tx_octets;
+#endif
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
 	max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -422,7 +422,11 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	LL_ASSERT(node_rx);
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 	max_rx_octets = lll->max_rx_octets;
+#else
+	max_rx_octets = lll->dle.eff.max_rx_octets;
+#endif
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
 	max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
@@ -456,7 +460,11 @@ void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx)
 	uint8_t phy, flags;
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 	max_tx_octets = lll->max_tx_octets;
+#else
+	max_tx_octets = lll->dle.eff.max_tx_octets;
+#endif
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
 	max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -55,6 +55,7 @@
 
 #if (!defined(CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY))
 #include "ll_sw/ull_llcp.h"
+#include "ll_sw/ull_conn_llcp_internal.h"
 #endif
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
@@ -833,6 +834,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->nesn = 0;
 		conn_lll->empty = 0;
 
+#ifdef CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		conn_lll->max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 		conn_lll->max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
@@ -849,7 +851,17 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->max_rx_time = PKT_US(PDU_DC_PAYLOAD_SIZE_MIN, PHY_1M);
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PHY */
+#endif
+#else /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#if defined(CONFIG_BT_CTLR_PHY) && defined(CONFIG_BT_CTLR_ADV_EXT)
+		const uint8_t phy = lll->phy_s;
+#else
+		const uint8_t phy = PHY_1M;
+#endif
+		ull_dle_init(conn, phy);
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+#endif /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_PHY)
 		conn_lll->phy_flags = 0;
@@ -957,11 +969,11 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_length.req = conn->llcp_length.ack = 0U;
 		conn->llcp_length.disabled = 0U;
 		conn->llcp_length.cache.tx_octets = 0U;
-#endif /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 		conn->default_tx_octets = ull_conn_default_tx_octets_get();
 #if defined(CONFIG_BT_CTLR_PHY)
 		conn->default_tx_time = ull_conn_default_tx_time_get();
 #endif /* CONFIG_BT_CTLR_PHY */
+#endif /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CTLR_PHY)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
@@ -22,6 +22,9 @@ uint16_t ull_conn_default_tx_time_get(void);
 void ull_conn_default_tx_octets_set(uint16_t tx_octets);
 void ull_conn_default_tx_time_set(uint16_t tx_time);
 uint8_t ull_conn_lll_phy_active(struct ll_conn *conn, uint8_t phy);
+void ull_dle_init(struct ll_conn *conn, uint8_t phy);
+uint8_t ull_dle_update_eff(struct ll_conn *conn);
+void ull_dle_local_tx_update(struct ll_conn *conn, uint16_t tx_octets, uint16_t tx_time);
 uint8_t ull_conn_default_phy_tx_get(void);
 uint8_t ull_conn_default_phy_rx_get(void);
 void ull_conn_default_phy_tx_set(uint8_t tx);
@@ -41,7 +44,6 @@ memq_link_t *ull_conn_ack_by_last_peek(uint8_t last, uint16_t *handle,
 void *ull_conn_ack_dequeue(void);
 void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx);
 uint8_t ull_conn_llcp_req(void *conn);
-
 void *ull_conn_tx_mem_acquire(void);
 void ull_conn_tx_mem_release(void *tx);
 uint8_t ull_conn_mfifo_get_tx(void **lll_tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -107,6 +107,11 @@ void ull_cp_conn_param_req_reply(struct ll_conn *conn);
 void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn);
 
 /**
+ * @brief Check if a remote data length update is in the works.
+ */
+uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn);
+
+/**
  * @brief Initiate a Termination Procedure.
  */
 uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code);
@@ -115,3 +120,9 @@ uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code);
  * @brief Initiate a Channel Map Update Procedure.
  */
 uint8_t ull_cp_chan_map_update(struct ll_conn *conn, uint8_t chm[5]);
+
+/**
+ * @brief Initiate a Data Length Update Procedure.
+ */
+uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, uint16_t max_tx_time);
+

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
@@ -5,11 +5,15 @@
  */
 
 
+static inline void feature_unmask_features(struct ll_conn *conn, uint64_t ll_feat_mask)
+{
+	conn->llcp.fex.features_used &= ~ll_feat_mask;
+}
 
 static inline bool feature_le_encryption(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_LE_ENC)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_ENC;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_ENC;
 #else
 	return 0;
 #endif
@@ -18,7 +22,7 @@ static inline bool feature_le_encryption(struct ll_conn *conn)
 static inline bool feature_conn_param_req(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_CONN_PARAM_REQ;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_CONN_PARAM_REQ;
 #else
 	return 0;
 #endif
@@ -27,7 +31,7 @@ static inline bool feature_conn_param_req(struct ll_conn *conn)
 static inline bool feature_ext_rej_ind(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_EXT_REJ_IND)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_EXT_REJ_IND;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_EXT_REJ_IND;
 #else
 	return 0;
 #endif
@@ -36,7 +40,7 @@ static inline bool feature_ext_rej_ind(struct ll_conn *conn)
 static inline bool feature_slave_feat_req(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_SLAVE_FEAT_REQ)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_SLAVE_FEAT_REQ;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_SLAVE_FEAT_REQ;
 #else
 	return 0;
 #endif
@@ -45,7 +49,7 @@ static inline bool feature_slave_feat_req(struct ll_conn *conn)
 static inline bool feature_le_ping(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_LE_PING)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_PING;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_PING;
 #else
 	return 0;
 #endif
@@ -54,7 +58,7 @@ static inline bool feature_le_ping(struct ll_conn *conn)
 static inline bool feature_dle(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_DLE;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_DLE;
 #else
 	return 0;
 #endif
@@ -63,7 +67,7 @@ static inline bool feature_dle(struct ll_conn *conn)
 static inline bool feature_privacy(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_PRIVACY;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_PRIVACY;
 #else
 	return 0;
 #endif
@@ -72,7 +76,7 @@ static inline bool feature_privacy(struct ll_conn *conn)
 static inline bool feature_ext_scan(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_EXT_SCAN;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_EXT_SCAN;
 #else
 	return 0;
 #endif
@@ -81,7 +85,7 @@ static inline bool feature_ext_scan(struct ll_conn *conn)
 static inline bool feature_chan_sel_2(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_CHAN_SEL_2;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_CHAN_SEL_2;
 #else
 	return 0;
 #endif
@@ -90,7 +94,7 @@ static inline bool feature_chan_sel_2(struct ll_conn *conn)
 static inline bool feature_min_used_chan(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_MIN_USED_CHAN;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_MIN_USED_CHAN;
 #else
 	return 0;
 #endif
@@ -99,7 +103,7 @@ static inline bool feature_min_used_chan(struct ll_conn *conn)
 static inline bool feature_phy_2m(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_PHY_2M)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_PHY_2M;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_PHY_2M;
 #else
 	return 0;
 #endif
@@ -108,7 +112,7 @@ static inline bool feature_phy_2m(struct ll_conn *conn)
 static inline bool feature_phy_coded(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	return conn->llcp.fex.features_peer & LL_FEAT_BIT_PHY_CODED;
+	return conn->llcp.fex.features_used & LL_FEAT_BIT_PHY_CODED;
 #else
 	return 0;
 #endif

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -17,6 +17,7 @@ enum llcp_proc {
 	PROC_CONN_PARAM_REQ,
 	PROC_TERMINATE,
 	PROC_CHAN_MAP_UPDATE,
+	PROC_DATA_LENGTH_UPDATE
 };
 
 struct llcp_enc {
@@ -296,6 +297,13 @@ static inline void tx_pause_data(struct ll_conn *conn)
 	return ull_cp_priv_tx_pause_data(conn);
 }
 
+void ull_cp_priv_tx_resume_data(struct ll_conn *conn);
+
+static inline void tx_resume_data(struct ll_conn *conn)
+{
+	return ull_cp_priv_tx_resume_data(conn);
+}
+
 void ull_cp_priv_tx_flush(struct ll_conn *conn);
 
 static inline void tx_flush(struct ll_conn *conn)
@@ -338,6 +346,13 @@ static inline void lp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void 
 /*
  * LLCP Remote Procedure Common
  */
+void ull_cp_priv_rp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
+
+static inline void rp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
+{
+	return ull_cp_priv_rp_comm_tx_ack(conn, ctx, tx);
+}
+
 void ull_cp_priv_rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 
 static inline void rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
@@ -1019,6 +1034,45 @@ void ull_cp_priv_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *p
 static inline void rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 {
 	return ull_cp_priv_rp_chmu_run(conn, ctx, param);
+}
+/*
+ * Data Length Update Procedure Helper
+ */
+void ull_cp_priv_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
+
+static inline void pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_encode_length_req(conn, pdu);
+}
+
+void ull_cp_priv_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+
+static inline void pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_encode_length_rsp(conn, pdu);
+}
+
+void ull_cp_priv_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
+
+static inline void pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_decode_length_req(conn, pdu);
+}
+
+void ull_cp_priv_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+
+static inline void pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	return ull_cp_priv_pdu_decode_length_rsp(conn, pdu);
+}
+
+void ull_cp_priv_ntf_encode_length_change(struct ll_conn *conn,
+					struct pdu_data *pdu);
+
+static inline void ntf_encode_length_change(struct ll_conn *conn,
+				    struct pdu_data *pdu)
+{
+	return ull_cp_priv_ntf_encode_length_change(conn, pdu);
 }
 
 #ifdef ZTEST_UNITTEST

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -131,6 +131,9 @@ void ull_cp_priv_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_r
 	case PROC_TERMINATE:
 		lp_comm_rx(conn, ctx, rx);
 		break;
+	case PROC_DATA_LENGTH_UPDATE:
+		lp_comm_rx(conn, ctx, rx);
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -146,6 +149,9 @@ void ull_cp_priv_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct no
 		lp_comm_tx_ack(conn, ctx, tx);
 		break;
 	case PROC_TERMINATE:
+		lp_comm_tx_ack(conn, ctx, tx);
+		break;
+	case PROC_DATA_LENGTH_UPDATE:
 		lp_comm_tx_ack(conn, ctx, tx);
 		break;
 	default:
@@ -188,6 +194,9 @@ static void lr_act_run(struct ll_conn *conn)
 		break;
 	case PROC_CHAN_MAP_UPDATE:
 		lp_chmu_run(conn, ctx, NULL);
+		break;
+	case PROC_DATA_LENGTH_UPDATE:
+		lp_comm_run(conn, ctx, NULL);
 		break;
 	default:
 		/* Unknown procedure */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -447,3 +447,69 @@ void ull_cp_priv_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu
 	ctx->data.chmu.instant = sys_le16_to_cpu(pdu->llctrl.chan_map_ind.instant);
 	memcpy(ctx->data.chmu.chm, pdu->llctrl.chan_map_ind.chm, sizeof(ctx->data.chmu.chm));
 }
+
+/*
+ * Data Length Update Procedure Helpers
+*/
+void ull_cp_priv_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, length_req) +
+		sizeof(struct pdu_data_llctrl_length_req);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_REQ;
+	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_rx_octets);
+	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_tx_octets);
+	p->max_rx_time = sys_cpu_to_le16(conn->lll.dle.local.max_rx_time);
+	p->max_tx_time = sys_cpu_to_le16(conn->lll.dle.local.max_tx_time);
+}
+
+void ull_cp_priv_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, length_rsp) +
+		sizeof(struct pdu_data_llctrl_length_rsp);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
+	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_rx_octets);
+	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_tx_octets);
+	p->max_rx_time = sys_cpu_to_le16(conn->lll.dle.local.max_rx_time);
+	p->max_tx_time = sys_cpu_to_le16(conn->lll.dle.local.max_tx_time);
+}
+
+void ull_cp_priv_ntf_encode_length_change(struct ll_conn *conn,
+					struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, length_rsp) +
+		sizeof(struct pdu_data_llctrl_length_rsp);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
+	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.eff.max_rx_octets);
+	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.eff.max_tx_octets);
+	p->max_rx_time   = sys_cpu_to_le16(conn->lll.dle.eff.max_rx_time);
+	p->max_tx_time   = sys_cpu_to_le16(conn->lll.dle.eff.max_tx_time);
+}
+
+void ull_cp_priv_pdu_decode_length_req(struct ll_conn *conn,
+					struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
+	conn->lll.dle.remote.max_rx_octets = sys_le16_to_cpu(p->max_rx_octets);
+	conn->lll.dle.remote.max_tx_octets = sys_le16_to_cpu(p->max_tx_octets);
+	conn->lll.dle.remote.max_rx_time = sys_le16_to_cpu(p->max_rx_time);
+	conn->lll.dle.remote.max_tx_time = sys_le16_to_cpu(p->max_tx_time);
+}
+
+void ull_cp_priv_pdu_decode_length_rsp(struct ll_conn *conn,
+					struct pdu_data *pdu)
+{
+	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
+	conn->lll.dle.remote.max_rx_octets = sys_le16_to_cpu(p->max_rx_octets);
+	conn->lll.dle.remote.max_tx_octets = sys_le16_to_cpu(p->max_tx_octets);
+	conn->lll.dle.remote.max_rx_time = sys_le16_to_cpu(p->max_rx_time);
+	conn->lll.dle.remote.max_tx_time = sys_le16_to_cpu(p->max_tx_time);
+}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -93,8 +93,13 @@ static bool proc_with_instant(struct proc_ctx *ctx)
 		break;
 	case PROC_TERMINATE:
 		return 0U;
+		break;
 	case PROC_CHAN_MAP_UPDATE:
 		return 1U;
+		break;
+	case PROC_DATA_LENGTH_UPDATE:
+		return 0U;
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -195,6 +200,9 @@ void ull_cp_priv_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_r
 	case PROC_CHAN_MAP_UPDATE:
 		rp_chmu_rx(conn, ctx,rx);
 		break;
+	case PROC_DATA_LENGTH_UPDATE:
+		rp_comm_rx(conn, ctx, rx);
+		break;
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -205,6 +213,9 @@ void ull_cp_priv_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_r
 void ull_cp_priv_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
 {
 	switch (ctx->proc) {
+	case PROC_DATA_LENGTH_UPDATE:
+		rp_comm_tx_ack(conn, ctx, tx);
+		break;
 	default:
 		/* Ignore tx_ack */
 		break;
@@ -246,6 +257,9 @@ static void rr_act_run(struct ll_conn *conn)
 		break;
 	case PROC_CHAN_MAP_UPDATE:
 		rp_chmu_run(conn, ctx, NULL);
+		break;
+	case PROC_DATA_LENGTH_UPDATE:
+		rp_comm_run(conn, ctx, NULL);
 		break;
 	default:
 		/* Unknown procedure */
@@ -558,6 +572,9 @@ void ull_cp_priv_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
 		break;
 	case PDU_DATA_LLCTRL_TYPE_CHAN_MAP_IND:
 		proc = PROC_CHAN_MAP_UPDATE;
+		break;
+	case PDU_DATA_LLCTRL_TYPE_LENGTH_REQ:
+		proc = PROC_DATA_LENGTH_UPDATE;
 		break;
 	default:
 		/* Unknown opcode */

--- a/tests/bluetooth/controller/common/include/helper_pdu.h
+++ b/tests/bluetooth/controller/common/include/helper_pdu.h
@@ -39,6 +39,9 @@ void helper_pdu_encode_terminate_ind(struct pdu_data *pdu, void *param);
 
 void helper_pdu_encode_channel_map_update_ind(struct pdu_data *pdu, void *param);
 
+void helper_pdu_encode_length_req(struct pdu_data *pdu, void *param);
+void helper_pdu_encode_length_rsp(struct pdu_data *pdu, void *param);
+
 void helper_pdu_verify_ping_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 void helper_pdu_verify_ping_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
@@ -84,6 +87,9 @@ void helper_pdu_verify_conn_update_ind(const char *file, uint32_t line, struct p
 void helper_node_verify_conn_update(const char *file, uint32_t line, struct node_rx_pdu *rx, void *param);
 
 
+void helper_pdu_verify_length_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+void helper_pdu_verify_length_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
+
 typedef enum {
 	LL_VERSION_IND,
 	LL_LE_PING_REQ,
@@ -107,6 +113,8 @@ typedef enum {
 	LL_CONNECTION_PARAM_RSP,
 	LL_TERMINATE_IND,
 	LL_CHAN_MAP_UPDATE_IND,
+	LL_LENGTH_REQ,
+	LL_LENGTH_RSP,
 } helper_pdu_opcode_t;
 
 typedef enum {

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -255,6 +255,33 @@ void helper_pdu_encode_channel_map_update_ind(struct pdu_data *pdu, void *param)
 	memcpy(pdu->llctrl.chan_map_ind.chm, p->chm, sizeof(pdu->llctrl.chan_map_ind.chm));
 }
 
+void helper_pdu_encode_length_req(struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_length_req *p = param;
+
+	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, length_req) + sizeof(struct pdu_data_llctrl_length_req);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_REQ;
+
+	pdu->llctrl.length_req.max_rx_octets = p->max_rx_octets;
+	pdu->llctrl.length_req.max_tx_octets = p->max_tx_octets;
+	pdu->llctrl.length_req.max_rx_time = p->max_rx_time;
+	pdu->llctrl.length_req.max_tx_time = p->max_tx_time;
+}
+
+void helper_pdu_encode_length_rsp(struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_length_rsp *p = param;
+
+ 	pdu->ll_id = PDU_DATA_LLID_CTRL;
+	pdu->len = offsetof(struct pdu_data_llctrl, length_rsp) + sizeof(struct pdu_data_llctrl_length_rsp);
+	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
+
+	pdu->llctrl.length_req.max_rx_octets = p->max_rx_octets;
+	pdu->llctrl.length_req.max_tx_octets = p->max_tx_octets;
+	pdu->llctrl.length_req.max_rx_time = p->max_rx_time;
+	pdu->llctrl.length_req.max_tx_time = p->max_tx_time;
+}
 
 void helper_pdu_verify_version_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
@@ -502,5 +529,29 @@ void helper_pdu_verify_channel_map_update_ind(const char *file, uint32_t line, s
 	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, chan_map_ind) + sizeof(struct pdu_data_llctrl_chan_map_ind), "Wrong length.\nCalled at %s:%d\n", file, line);
 	zassert_equal(pdu->llctrl.chan_map_ind.instant, p->instant, "Instant mismatch.\nCalled at %s:%d\n", file, line);
 	zassert_mem_equal(pdu->llctrl.chan_map_ind.chm, p->chm, sizeof(p->chm), "Channel Map mismatch.\nCalled at %s:%d\n", file, line);
+}
+
+void helper_pdu_verify_length_req(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_length_req *p = param;
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, length_req) + sizeof(struct pdu_data_llctrl_length_req), "Wrong length.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_LENGTH_REQ, "Not a LL_LENGTH_REQ.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_req.max_rx_octets, p->max_rx_octets, "max_rx_octets mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_req.max_tx_octets, p->max_tx_octets, "max_tx_octets mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_req.max_rx_time, p->max_rx_time, "max_rx_time mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_req.max_tx_time, p->max_tx_time, "max_tx_time mismatch.\nCalled at %s:%d\n", file, line);
+}
+
+void helper_pdu_verify_length_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
+{
+	struct pdu_data_llctrl_length_rsp *p = param;
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, "Not a Control PDU.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->len, offsetof(struct pdu_data_llctrl, length_rsp) + sizeof(struct pdu_data_llctrl_length_rsp), "Wrong length.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_LENGTH_RSP, "Not a LL_LENGTH_RSP.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_rsp.max_rx_octets, p->max_rx_octets, "max_rx_octets mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_rsp.max_tx_octets, p->max_tx_octets, "max_tx_octets mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_rsp.max_rx_time, p->max_rx_time, "max_rx_time mismatch.\nCalled at %s:%d\n", file, line);
+	zassert_equal(pdu->llctrl.length_rsp.max_tx_time, p->max_tx_time, "max_tx_time mismatch.\nCalled at %s:%d\n", file, line);
 }
 

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -70,6 +70,8 @@ helper_pdu_encode_func_t * const helper_pdu_encode[] = {
 	[LL_CONNECTION_PARAM_RSP]  = helper_pdu_encode_conn_param_rsp,
 	[LL_TERMINATE_IND]         = helper_pdu_encode_terminate_ind,
 	[LL_CHAN_MAP_UPDATE_IND]   = helper_pdu_encode_channel_map_update_ind,
+	[LL_LENGTH_REQ]            = helper_pdu_encode_length_req,
+	[LL_LENGTH_RSP]            = helper_pdu_encode_length_rsp,
 };
 
 helper_pdu_verify_func_t *const helper_pdu_verify[] = {
@@ -95,6 +97,8 @@ helper_pdu_verify_func_t *const helper_pdu_verify[] = {
 	[LL_CONNECTION_PARAM_RSP]  = helper_pdu_verify_conn_param_rsp,
 	[LL_TERMINATE_IND]         = helper_pdu_verify_terminate_ind,
 	[LL_CHAN_MAP_UPDATE_IND]   = helper_pdu_verify_channel_map_update_ind,
+	[LL_LENGTH_REQ]            = helper_pdu_verify_length_req,
+	[LL_LENGTH_RSP]            = helper_pdu_verify_length_rsp,
 };
 
 helper_pdu_ntf_verify_func_t *const helper_pdu_ntf_verify[] = {
@@ -120,6 +124,8 @@ helper_pdu_ntf_verify_func_t *const helper_pdu_ntf_verify[] = {
 	[LL_CONNECTION_PARAM_RSP]  = NULL,
 	[LL_TERMINATE_IND]         = NULL,
 	[LL_CHAN_MAP_UPDATE_IND]   = NULL,
+	[LL_LENGTH_REQ]            = NULL,
+	[LL_LENGTH_RSP]            = NULL,
 };
 
 

--- a/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
@@ -9,6 +9,13 @@ endif()
 FILE(GLOB SOURCES
   src/*.c
 )
+if(CONFIG_BT_CTLR_PHY_CODED)
+  add_compile_definitions(CONFIG_BT_CTLR_PHY_CODED)
+endif(CONFIG_BT_CTLR_PHY_CODED)
+
+if(CONFIG_BT_CTLR_PHY)
+  add_compile_definitions(CONFIG_BT_CTLR_PHY)
+endif(CONFIG_BT_CTLR_PHY)
 
 project(bluetooth_ull_llcp_data_length_update)
 find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})

--- a/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES
+  src/*.c
+)
+
+project(bluetooth_ull_llcp_data_length_update)
+find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
+include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
+target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/kconfig_override.h
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/kconfig_override.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020 Demant
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Common Kconfig settings
+ */
+
+
+#ifdef CONFIG_BT_CTLR_PHY
+#undef CONFIG_BT_CTLR_PHY
+#endif

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <sys/byteorder.h>
+#include <ztest.h>
+#include "kconfig.h"
+
+
+#define ULL_LLCP_UNITTEST
+
+
+#include <bluetooth/hci.h>
+#include <sys/byteorder.h>
+#include <sys/slist.h>
+#include <sys/util.h>
+#include "hal/ccm.h"
+
+#include "util/mem.h"
+#include "util/memq.h"
+
+#include "pdu.h"
+#include "ll.h"
+#include "ll_settings.h"
+
+#include "lll.h"
+#include "lll_conn.h"
+
+#include "ull_tx_queue.h"
+#include "ull_internal.h"
+#include "ull_conn_types.h"
+#include "ull_llcp.h"
+#include "ull_conn_llcp_internal.h"
+#include "ull_llcp_internal.h"
+
+
+#include "helper_pdu.h"
+#include "helper_util.h"
+#include "helper_features.h"
+
+struct ll_conn conn;
+
+static void setup(void)
+{
+	test_setup(&conn);
+}
+
+/*
+ * Locally triggered Data Length Update procedure
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,211,1800)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |     (201,1720,251,2120)      |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |<-----------------------------|
+ *    | (251,2120,201,1720)        |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |                   Complete |                              |
+ *    |<---------------------------|                              |
+ *    |                            |                              |
+ */
+
+void test_data_length_update_mas_loc(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+
+	struct pdu_data_llctrl_length_req local_length_req = {251,2120,211,1800};
+	struct pdu_data_llctrl_length_rsp remote_length_rsp = {201,1720,251,2120};
+	struct pdu_data_llctrl_length_rsp length_ntf = {251,2120,201,1720};
+
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Steal all ntf buffers, so as to check that the wait_ntf mechanism works */
+	while (ll_pdu_rx_alloc_peek(1)) {
+		ntf = ll_pdu_rx_alloc();
+		/* Make sure we use a correct type or the release won't work */
+		ntf->hdr.type = NODE_RX_TYPE_DC_PDU;
+	}
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 1800 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_LENGTH_RSP, &conn, &remote_length_rsp);
+
+	event_done(&conn);
+
+	ut_rx_q_is_empty();
+
+	/* Release Ntf, so next cycle will generate NTF and complete procedure */
+	ull_cp_release_ntf(ntf);
+
+	event_prepare(&conn);
+	event_done(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+	zassert_equal(conn.lll.event_counter, 2,
+		      "Wrong event-count %d\n", conn.lll.event_counter);
+}
+
+/*
+ * Locally triggered Data Length Update procedure - with no update to eff and thus no ntf
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,211,1800)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |     (27,328,27,328)          |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |<-----------------------------|
+ *    |                            |                              |
+ */
+void test_data_length_update_mas_loc_no_eff_change(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_length_req local_length_req = {251, 2120, 211, 1800};
+	struct pdu_data_llctrl_length_rsp remote_length_rsp = {27, 328, 27, 328};
+
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 1800 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_LENGTH_RSP, &conn, &remote_length_rsp);
+
+	event_done(&conn);
+
+	/* There should be no host notification */
+	ut_rx_q_is_empty();
+	zassert_equal(conn.lll.event_counter, 1,
+		      "Wrong event-count %d\n", conn.lll.event_counter);
+
+}
+/*
+ * Locally triggered Data Length Update procedure -
+ * - first updating effective DLE and then without update to eff and thus no ntf
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,221,2020)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |     (101,1020,251,2120)      |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |<-----------------------------|
+ *    | (251,2120,101,1020)        |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |                   Complete |                              |
+ *    |<---------------------------|                              |
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,211,2020)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |     (101,1020,251,2120)      |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |<-----------------------------|
+ *    |                            |                              |
+ */
+
+void test_data_length_update_mas_loc_no_eff_change2(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+
+	struct pdu_data_llctrl_length_req local_length_req = {251,2120,221,2020};
+	struct pdu_data_llctrl_length_rsp remote_length_rsp = {101,1020,251,2120};
+	struct pdu_data_llctrl_length_rsp length_ntf = {251,2120,101,1020};
+	struct pdu_data_llctrl_length_req local_length_req2 = {251,2120,211,2100};
+	struct pdu_data_llctrl_length_rsp remote_length_rsp2 = {101,1020,251,2120};
+
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 221, 2020 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_LENGTH_RSP, &conn, &remote_length_rsp);
+
+	event_done(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+	zassert_equal(conn.lll.event_counter, 1,
+		      "Wrong event-count %d\n", conn.lll.event_counter);
+
+	/* Now lets generate another DLU, but one that should not result in
+	   change to effective numbers, thus not generate NTF */
+	err = ull_cp_data_length_update(&conn, 211, 2100 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req2);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_LENGTH_RSP, &conn, &remote_length_rsp2);
+
+	event_done(&conn);
+
+	/* There should be no host notification */
+	ut_rx_q_is_empty();
+	zassert_equal(conn.lll.event_counter, 2,
+		      "Wrong event-count %d\n", conn.lll.event_counter);
+}
+
+void test_data_length_update_sla_loc(void)
+{
+	uint64_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+
+	struct pdu_data_llctrl_length_req local_length_req = { 251, 2120, 211, 2020};
+	struct pdu_data_llctrl_length_rsp remote_length_rsp = { 211, 2020, 251, 2120};
+	struct pdu_data_llctrl_length_rsp length_ntf = {251,2120,211,2020};
+
+	test_set_role(&conn, BT_HCI_ROLE_SLAVE);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 2020 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_LENGTH_RSP, &conn, &remote_length_rsp);
+
+	event_done(&conn);
+
+	/* There should be one host notification */
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+	zassert_equal(conn.lll.event_counter, 1,
+		      "Wrong event-count %d\n", conn.lll.event_counter);
+}
+
+/*
+ * Remotely triggered Data Length Update procedure
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    |                            |  (27, 328, 251, 2120)        |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |<-----------------------------|
+ *    |                            |   (251, 2120, 251, 2120)     |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |----------------------------->|
+ *    |  (251,2120,27,328)         |                              |
+ *    | Data Length Changed        |                              |
+ *    |<---------------------------|                              |
+ *    |                            |                              |
+ */
+
+void test_data_length_update_mas_rem(void)
+{
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_length_req remote_length_req =  { 27, 328, 251, 2120};
+	struct pdu_data_llctrl_length_rsp local_length_rsp = { 251, 2120, 221, 2020};
+	struct pdu_data_llctrl_length_rsp length_ntf = {251,2120,27,328};
+
+	struct node_rx_pdu *ntf;
+
+	test_set_role(&conn, BT_HCI_ROLE_MASTER);
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(221);
+	ull_conn_default_tx_time_set(2020);
+	ull_dle_init(&conn, PHY_1M);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_tx(LL_LENGTH_REQ, &conn, &remote_length_req);
+
+	event_done(&conn);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_RSP, &conn, &tx, &local_length_rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	event_done(&conn);
+
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+}
+
+/*
+ * Remotely triggered Data Length Update procedure
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    |                            | (27, 328, 211, 1820)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |<-----------------------------|
+ *    |                            |                              |
+ *    |                            |     (251, 2120, 231, 1920)   |
+ *    |                            |    LL_DATA_LENGTH_UPDATE_RSP |
+ *    |                            |----------------------------->|
+ *    |  (211,1820,27,328)         |                              |
+ *    | Data Length Changed        |                              |
+ *    |<---------------------------|                              |
+ *    |                            |                              |
+ */
+
+void test_data_length_update_sla_rem(void)
+{
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_length_req remote_length_req =  { 27, 328, 211, 1820};
+	struct pdu_data_llctrl_length_rsp local_length_rsp = { 251, 2120, 231, 1920};
+	struct pdu_data_llctrl_length_rsp length_ntf = {211,1820,27,328};
+	struct node_rx_pdu *ntf;
+
+	test_set_role(&conn, BT_HCI_ROLE_SLAVE);
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(231);
+	ull_conn_default_tx_time_set(1920);
+	ull_dle_init(&conn, PHY_1M);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_tx(LL_LENGTH_REQ, &conn, &remote_length_req);
+
+	event_done(&conn);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_RSP, &conn, &tx, &local_length_rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	event_done(&conn);
+
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+}
+
+/*
+ * Remotely triggered Data Length Update procedure with local request piggy back
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    |                            | (27, 328, 211, 1820)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |<-----------------------------|
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |                              |
+ *    |                            |   (251, 2120, 231, 1920)     |
+ *    |                            |  LL_DATA_LENGTH_UPDATE_RSP   |
+ *    |                            |----------------------------->|
+ *    |  (211,1820,27,328)         |                              |
+ *    | Data Length Changed        |                              |
+ *    |<---------------------------|                              |
+ *    |                            |                              |
+ */
+
+void test_data_length_update_sla_rem_and_loc(void)
+{
+	uint64_t err;
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_length_req remote_length_req =  { 27, 328, 211, 1820};
+	struct pdu_data_llctrl_length_rsp local_length_rsp = { 251, 2120, 211, 2020};
+	struct pdu_data_llctrl_length_rsp length_ntf = {211,1820,27,328};
+	struct node_rx_pdu *ntf;
+
+	test_set_role(&conn, BT_HCI_ROLE_SLAVE);
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(231);
+	ull_conn_default_tx_time_set(1920);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Steal all tx buffers, so as to hold back length_rsp */
+	while (ull_cp_priv_tx_alloc_is_available()) {
+		tx = ull_cp_priv_tx_alloc();
+	}
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_tx(LL_LENGTH_REQ, &conn, &remote_length_req);
+
+	event_done(&conn);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have no LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 2020 );
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_done(&conn);
+
+	ull_cp_release_tx(tx);
+
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_RSP, &conn, &tx, &local_length_rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	event_done(&conn);
+
+	ut_rx_pdu(LL_LENGTH_RSP, &ntf,  &length_ntf);
+	ut_rx_q_is_empty();
+}
+
+void test_main(void)
+{
+	ztest_test_suite(data_length_update_master,
+			 ztest_unit_test_setup_teardown(test_data_length_update_mas_loc, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_data_length_update_mas_loc_no_eff_change, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_data_length_update_mas_loc_no_eff_change2, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_data_length_update_mas_rem, setup, unit_test_noop)
+		);
+
+	ztest_test_suite(data_length_update_slave,
+			 ztest_unit_test_setup_teardown(test_data_length_update_sla_loc, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_data_length_update_sla_rem, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_data_length_update_sla_rem_and_loc, setup, unit_test_noop)
+		);
+
+	ztest_run_test_suite(data_length_update_master);
+	ztest_run_test_suite(data_length_update_slave);
+
+}

--- a/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
@@ -3,3 +3,12 @@ common:
 tests:
   bluetooth.controller.ctrl_data_length_update.test:
      type: unit
+     extra_args: CONFIG_BT_CTLR_PHY=y
+  bluetooth.controller.ctrl_data_length_update.test_codedphy:
+     type: unit
+     extra_args: CONFIG_BT_CTLR_PHY=y CONFIG_BT_CTLR_PHY_CODED=y
+  bluetooth.controller.ctrl_data_length_update.test_nophy:
+     type: unit
+     extra_args: KCONFIG_OVERRIDE_FILE="kconfig_override.h"
+
+

--- a/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
@@ -1,0 +1,5 @@
+common:
+    tags: test_framework bluetooth bt_data_length_update bt_ull_llcp
+tests:
+  bluetooth.controller.ctrl_data_length_update.test:
+     type: unit

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -265,12 +265,12 @@ void test_hci_phy(void)
 
 	err = ll_phy_req_send(conn_handle+1,  0x00, 0x00, 0x00);
 	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, NULL);
-	conn_from_pool->llcp.fex.features_peer = 0x00;
+	conn_from_pool->llcp.fex.features_used = 0x00;
 	err = ll_phy_req_send(conn_handle,  0x03, 0xFF, 0x03);
 	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE,
 		      "Errorcode %d", err);
 
-	conn_from_pool->llcp.fex.features_peer = 0xFFFF;
+	conn_from_pool->llcp.fex.features_used = 0xFFFF;
 	err = ll_phy_req_send(conn_handle,  0x03, 0xFF, 0x03);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, "Errorcode %d", err);
 	err = ll_phy_get(conn_handle + 1, &phy_tx, &phy_rx);
@@ -313,24 +313,21 @@ void test_hci_dle(void)
 	tx_octets = 251;
 	tx_time = 2400;
 
-	conn_from_pool->llcp.fex.features_peer = 0x00;
+	conn_from_pool->llcp.fex.features_used = 0x00;
 	err = ll_length_req_send(conn_handle, tx_octets, tx_time);
 	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE,
 		      "Errorcode %d", err);
-	conn_from_pool->llcp.fex.features_peer = 0xFFFFFFFF;
+	conn_from_pool->llcp.fex.features_used = 0xFFFFFFFF;
 	err = ll_length_req_send(conn_handle+1, tx_octets, tx_time);
 	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID,
-		      "Errorcode %d", err);
-	err = ll_length_req_send(conn_handle, tx_octets, tx_time);
-	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CMD,
 		      "Errorcode %d", err);
 
 	ll_length_max_get(&max_tx_octets, &max_tx_time,
 			  &max_rx_octets, &max_rx_time);
 	zassert_equal(max_tx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
 	zassert_equal(max_rx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
-	zassert_equal(max_tx_time, 2112, "Actual time is %d", max_tx_time);
-	zassert_equal(max_rx_time, 2112, "Actual time is %d", max_rx_time);
+	zassert_equal(max_tx_time, 2120, "Actual time is %d", max_tx_time);
+	zassert_equal(max_rx_time, 2120, "Actual time is %d", max_rx_time);
 
 	err = ll_length_default_set(0x00, 0x00);
         ll_length_default_get(&max_tx_octets, &max_tx_time);


### PR DESCRIPTION
First cut of procedure implementation.

Unittest pass, of cause, as well as EDTT/LL tests related to DLU procedure 1M_PHY case (con/sla/bv-77 & 78 and con/mas/bv-73 & 74). The LL tests require a slight rework and aligning this will be in separate PR