### PR TITLE
scripts: size_report: Add handling of depth argument

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(flag_for_ram_report ram)
 set(flag_for_rom_report rom)
+set(report_depth 99)
 
 foreach(report ram_report rom_report)
   add_custom_target(
@@ -12,6 +13,7 @@ foreach(report ram_report rom_report)
     -z ${ZEPHYR_BASE}
     -o ${CMAKE_BINARY_DIR}
     --json ${CMAKE_BINARY_DIR}/${flag_for_${report}}.json
+    -d ${report_depth}
     ${flag_for_${report}}
     DEPENDS ${logical_target_for_zephyr_elf}
             $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -538,12 +538,12 @@ def generate_any_tree(symbol_dict):
 def node_sort(items):
     return sorted(items, key=lambda item: item.name)
 
-def print_any_tree(root, total_size):
+def print_any_tree(root, total_size, depth):
 
     print('{:101s} {:7s} {:8s}'.format(
         Fore.YELLOW + "Path", "Size", "%" + Fore.RESET))
     print('=' * 110)
-    for row in RenderTree(root, childiter=node_sort):
+    for row in RenderTree(root, childiter=node_sort, maxlevel=depth):
         f = len(row.pre) + len(row.node.name)
         s = str(row.node.size).rjust(100-f)
         percent = 100 * float(row.node.size) / float(total_size)
@@ -574,7 +574,8 @@ def parse_args():
     parser.add_argument("-o", "--output", required=True,
                         help="Output path")
     parser.add_argument("target", choices=['rom', 'ram'])
-    parser.add_argument("-d", "--depth", dest="depth", type=int,
+    parser.add_argument("-d", "--depth", dest="depth",
+                        type=int, default=None,
                         help="How deep should we go into the tree",
                         metavar="DEPTH")
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -630,7 +631,7 @@ def main():
                 print("INFO: Unmapped symbol: {0}".format(sym))
 
         root = generate_any_tree(symbol_dict)
-        print_any_tree(root, symsize)
+        print_any_tree(root, symsize, args.depth)
 
         if args.json:
             exporter = JsonExporter(indent=2, sort_keys=True)


### PR DESCRIPTION
The script already accepts a depth parameter to configure the output,
but that parameter was not used at all.  This commit adds the correct
handling by passing it to anytrees RenderTree iterator.

Signed-off-by: Detlev Zundel <dzu@member.fsf.org>