### PR TITLE
Bluetooth: controller: Handle ACAD in Periodic Advertising

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4683,6 +4683,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		struct pdu_adv_ext_hdr *h;
 		uint8_t sec_phy_curr = 0U;
 		uint8_t evt_type_curr;
+		uint8_t hdr_buf_len;
 		uint8_t hdr_len;
 		uint8_t *ptr;
 
@@ -4707,8 +4708,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		evt_type_curr = p->adv_mode;
 
 		if (!p->ext_hdr_len) {
-			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adv_data);
+			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
 
 			goto no_ext_hdr;
 		}
@@ -4798,24 +4798,18 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		}
 
 		hdr_len = ptr - (uint8_t *)p;
-		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
-					 ext_hdr_adv_data) +
+		if (hdr_len <= (PDU_AC_EXT_HEADER_SIZE_MIN +
 				sizeof(struct pdu_adv_ext_hdr))) {
-			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adv_data);
+			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
 			ptr = (uint8_t *)h;
 		}
 
-		if (hdr_len > (p->ext_hdr_len +
-			       offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adv_data))) {
+		hdr_buf_len = PDU_AC_EXT_HEADER_SIZE_MIN + p->ext_hdr_len;
+		if (hdr_len > hdr_buf_len) {
 			BT_WARN("    Header length %u/%u, INVALID.", hdr_len,
 				p->ext_hdr_len);
 		} else {
-			uint8_t acad_len = p->ext_hdr_len +
-					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adv_data) -
-					   hdr_len;
+			uint8_t acad_len = hdr_buf_len - hdr_len;
 
 			if (acad_len) {
 				ptr += acad_len;
@@ -5104,6 +5098,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		uint8_t *data_curr = NULL;
 		uint8_t sec_phy_curr = 0U;
 		struct pdu_adv_ext_hdr *h;
+		uint8_t hdr_buf_len;
 		uint8_t hdr_len;
 		uint8_t *ptr;
 
@@ -5167,24 +5162,18 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		}
 
 		hdr_len = ptr - (uint8_t *)p;
-		if (hdr_len <= (offsetof(struct pdu_adv_com_ext_adv,
-					 ext_hdr_adv_data) +
+		if (hdr_len <= (PDU_AC_EXT_HEADER_SIZE_MIN +
 				sizeof(struct pdu_adv_ext_hdr))) {
-			hdr_len = offsetof(struct pdu_adv_com_ext_adv,
-					   ext_hdr_adv_data);
+			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
 			ptr = (uint8_t *)h;
 		}
 
-		if (hdr_len > (p->ext_hdr_len +
-			       offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adv_data))) {
+		hdr_buf_len = PDU_AC_EXT_HEADER_SIZE_MIN + p->ext_hdr_len;
+		if (hdr_len > hdr_buf_len) {
 			BT_WARN("    Header length %u/%u, INVALID.", hdr_len,
 				p->ext_hdr_len);
 		} else {
-			uint8_t acad_len = p->ext_hdr_len +
-					   offsetof(struct pdu_adv_com_ext_adv,
-						    ext_hdr_adv_data) -
-					   hdr_len;
+			uint8_t acad_len = hdr_buf_len - hdr_len;
 
 			if (acad_len) {
 				ptr += acad_len;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -39,13 +39,14 @@
 
 /* Advertisement channel maximum payload size */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+#define PDU_AC_EXT_HEADER_SIZE_MIN  offsetof(struct pdu_adv_com_ext_adv, \
+					     ext_hdr_adv_data)
 #define PDU_AC_EXT_HEADER_SIZE_MAX  63
 /* TODO: PDU_AC_EXT_PAYLOAD_OVERHEAD can be reduced based on supported
  *       features, like omitting support for periodic advertising will reduce
  *       18 octets in the Common Extended Advertising Payload Format.
  */
-#define PDU_AC_EXT_PAYLOAD_OVERHEAD (offsetof(struct pdu_adv_com_ext_adv, \
-					      ext_hdr_adv_data) + \
+#define PDU_AC_EXT_PAYLOAD_OVERHEAD (PDU_AC_EXT_HEADER_SIZE_MIN + \
 				     PDU_AC_EXT_HEADER_SIZE_MAX)
 #define PDU_AC_PAYLOAD_SIZE_MAX     MAX(MIN((PDU_AC_EXT_PAYLOAD_OVERHEAD + \
 					     CONFIG_BT_CTLR_ADV_DATA_LEN_MAX), \

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -438,15 +438,16 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
 	struct pdu_adv_ext_hdr *pri_hdr, pri_hdr_prev;
 	struct pdu_adv_ext_hdr *sec_hdr, sec_hdr_prev;
-	uint16_t pri_len, sec_len, sec_len_prev;
 	struct pdu_adv *pri_pdu, *pri_pdu_prev;
 	struct pdu_adv *sec_pdu_prev, *sec_pdu;
 	uint8_t *pri_dptr, *pri_dptr_prev;
 	uint8_t *sec_dptr, *sec_dptr_prev;
+	uint8_t pri_len, sec_len_prev;
 	struct lll_adv_aux *lll_aux;
 	struct lll_adv *lll;
 	uint8_t is_aux_new;
 	uint8_t *ad_data;
+	uint16_t sec_len;
 	uint8_t sec_idx;
 	uint8_t ad_len;
 
@@ -524,8 +525,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		 */
 		sec_pdu_prev->tx_addr = 0U;
 		sec_pdu_prev->rx_addr = 0U;
-		sec_pdu_prev->len = offsetof(struct pdu_adv_com_ext_adv,
-					     ext_hdr_adv_data);
+		sec_pdu_prev->len = PDU_AC_EXT_HEADER_SIZE_MIN;
 		*(uint8_t *)&sec_hdr_prev = 0U;
 	}
 	sec_dptr_prev = sec_hdr->data;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -125,10 +125,9 @@ ull_adv_aux_hdr_len_calc(struct pdu_adv_com_ext_adv *com_hdr, uint8_t **dptr)
 	uint8_t len;
 
 	len = *dptr - (uint8_t *)com_hdr;
-	if (len <= (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adv_data) +
+	if (len <= (PDU_AC_EXT_HEADER_SIZE_MIN +
 		    sizeof(struct pdu_adv_ext_hdr))) {
-		len = offsetof(struct pdu_adv_com_ext_adv,
-			       ext_hdr_adv_data);
+		len = PDU_AC_EXT_HEADER_SIZE_MIN;
 		*dptr = (uint8_t *)com_hdr + len;
 	}
 
@@ -139,8 +138,7 @@ ull_adv_aux_hdr_len_calc(struct pdu_adv_com_ext_adv *com_hdr, uint8_t **dptr)
 static inline void
 ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
 {
-	com_hdr->ext_hdr_len = len - offsetof(struct pdu_adv_com_ext_adv,
-					      ext_hdr_adv_data);
+	com_hdr->ext_hdr_len = len - PDU_AC_EXT_HEADER_SIZE_MIN;
 
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -658,6 +658,8 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 	struct pdu_adv_ext_hdr *ter_hdr, ter_hdr_prev;
 	uint8_t *ter_dptr, *ter_dptr_prev;
 	uint16_t ter_len, ter_len_prev;
+	uint16_t ext_hdr_buf_len;
+	uint8_t acad_len_prev;
 	uint8_t *ad_data;
 #if IS_ENABLED(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	uint8_t cte_info;
@@ -732,12 +734,28 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 		ter_dptr++;
 	}
 
-	/* TODO: ACAD */
-
-	/* AdvData */
-	/* Calc previous tertiary PDU len */
-	ter_len_prev = ull_adv_aux_hdr_len_calc(ter_com_hdr_prev,
-						&ter_dptr_prev);
+	/* Calc previous ACAD len and update PDU len */
+	ter_len_prev = ter_dptr_prev - (uint8_t *)ter_com_hdr_prev;
+	ext_hdr_buf_len = ter_com_hdr_prev->ext_hdr_len +
+			  offsetof(struct pdu_adv_com_ext_adv,
+				   ext_hdr_adv_data);
+	if (ter_len_prev <= ext_hdr_buf_len) {
+		acad_len_prev = ext_hdr_buf_len - ter_len_prev;
+		ter_len_prev += acad_len_prev;
+		ter_dptr_prev += acad_len_prev;
+		ter_dptr += acad_len_prev;
+	} else {
+		acad_len_prev = 0;
+		/* NOTE: If no flags are set then extended header length will be
+		 *       zero. Under this condition the current ter_len_prev
+		 *       value will be greater than extended header length,
+		 *       hence set ter_len_prev to size of the length/mode
+		 *       field.
+		 */
+		ter_len_prev = offsetof(struct pdu_adv_com_ext_adv,
+					ext_hdr_adv_data);
+		ter_dptr_prev = (uint8_t *)ter_com_hdr_prev + ter_len_prev;
+	}
 
 	/* Did we parse beyond PDU length? */
 	if (ter_len_prev > ter_pdu_prev->len) {
@@ -782,7 +800,10 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 	/* Fill AdvData in tertiary PDU */
 	memmove(ter_dptr, ad_data, ad_len);
 
-	/* TODO: Fill ACAD in tertiary PDU */
+	/* Fill ACAD in tertiary PDU */
+	ter_dptr_prev -= acad_len_prev;
+	ter_dptr -= acad_len_prev;
+	memmove(ter_dptr, ter_dptr_prev, acad_len_prev);
 
 	/* Tx Power */
 	if (ter_hdr->tx_pwr) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -657,9 +657,10 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 	struct pdu_adv_com_ext_adv *ter_com_hdr, *ter_com_hdr_prev;
 	struct pdu_adv_ext_hdr *ter_hdr, ter_hdr_prev;
 	uint8_t *ter_dptr, *ter_dptr_prev;
-	uint16_t ter_len, ter_len_prev;
-	uint16_t ext_hdr_buf_len;
 	uint8_t acad_len_prev;
+	uint8_t ter_len_prev;
+	uint8_t hdr_buf_len;
+	uint16_t ter_len;
 	uint8_t *ad_data;
 #if IS_ENABLED(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	uint8_t cte_info;
@@ -736,11 +737,10 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 
 	/* Calc previous ACAD len and update PDU len */
 	ter_len_prev = ter_dptr_prev - (uint8_t *)ter_com_hdr_prev;
-	ext_hdr_buf_len = ter_com_hdr_prev->ext_hdr_len +
-			  offsetof(struct pdu_adv_com_ext_adv,
-				   ext_hdr_adv_data);
-	if (ter_len_prev <= ext_hdr_buf_len) {
-		acad_len_prev = ext_hdr_buf_len - ter_len_prev;
+	hdr_buf_len = ter_com_hdr_prev->ext_hdr_len +
+		      PDU_AC_EXT_HEADER_SIZE_MIN;
+	if (ter_len_prev <= hdr_buf_len) {
+		acad_len_prev = hdr_buf_len - ter_len_prev;
 		ter_len_prev += acad_len_prev;
 		ter_dptr_prev += acad_len_prev;
 		ter_dptr += acad_len_prev;
@@ -752,8 +752,7 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 		 *       hence set ter_len_prev to size of the length/mode
 		 *       field.
 		 */
-		ter_len_prev = offsetof(struct pdu_adv_com_ext_adv,
-					ext_hdr_adv_data);
+		ter_len_prev = PDU_AC_EXT_HEADER_SIZE_MIN;
 		ter_dptr_prev = (uint8_t *)ter_com_hdr_prev + ter_len_prev;
 	}
 


### PR DESCRIPTION
Handle ACAD field in when updating the Advertising Data in
Periodic Advertising PDU.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>