### PR TITLE
Bluetooth: controller: Add association between adv, sync and iso

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -8,6 +8,7 @@
 
 struct lll_adv_iso {
 	struct lll_hdr hdr;
+	struct lll_adv *adv;
 };
 
 struct lll_adv_sync {
@@ -30,7 +31,7 @@ struct lll_adv_sync {
 	struct lll_adv_pdu data;
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO)
-	struct lll_adv_iso *adv_iso;
+	struct lll_adv_iso *iso;
 #endif /* CONFIG_BT_CTLR_ADV_ISO */
 
 #if IS_ENABLED(CONFIG_BT_CTLR_DF_ADV_CTE_TX)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -73,22 +73,24 @@ struct ll_adv_iso {
 	struct ull_hdr        ull;
 	struct lll_adv_iso    lll;
 
+#if defined(CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING)
 	uint8_t  hci_handle;
+#endif /* CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING */
+
 	uint16_t bis_handle; /* TODO: Support multiple BIS per BIG */
 
-	uint8_t  is_created:1;
-	uint8_t  encryption:1;
-	uint8_t  framing:1;
 	uint8_t  num_bis:5;
+	uint8_t  packing:1;
+	uint8_t  framing:1;
+	uint8_t  encryption:1;
 
 	uint32_t sdu_interval:20;
-	uint16_t max_sdu:12;
+	uint32_t max_sdu:12;
 
 	uint16_t max_latency:12;
+	uint16_t rtn:4;
 
-	uint8_t  rtn:4;
 	uint8_t  phy:3;
-	uint8_t  packing:1;
 
 	uint8_t  bcode[16];
 


### PR DESCRIPTION
Add association between extended advertising, periodic
advertising and broadcast ISO instance, so that attempts to
create and terminate BIG can detect error conditions.

Error conditions being, trying to create BIG without a valid
periodic advertising train, or terminating BIG without prior
creation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>