### PR TITLE
Bluetooth: controller: Initial CIS peripheral establishment

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -46,6 +46,7 @@
 #include "ll_sw/ull_scan_types.h"
 #include "ll_sw/ull_sync_types.h"
 #include "ll_sw/ull_conn_types.h"
+#include "ll_sw/ull_conn_internal.h"
 #include "ll_sw/ull_conn_iso_types.h"
 
 #include "ll.h"
@@ -3207,7 +3208,7 @@ static void le_cis_established(struct pdu_data *pdu_data,
 	cis = node_rx->hdr.rx_ftr.param;
 	cig = cis->group;
 	lll_cis = &cis->lll;
-	is_central = lll_cis->conn->role == BT_CONN_ROLE_MASTER;
+	is_central = cig->lll.role == BT_CONN_ROLE_MASTER;
 	lll_cis_c = is_central ? &lll_cis->tx : &lll_cis->rx;
 	lll_cis_p = is_central ? &lll_cis->rx : &lll_cis->tx;
 	est = (void *)pdu_data;

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -114,6 +114,12 @@ enum {
 			       1),
 #endif /* CONFIG_BT_CONN */
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO_GROUPS)
+	TICKER_ID_CONN_ISO_BASE,
+	TICKER_ID_CONN_ISO_LAST = ((TICKER_ID_CONN_ISO_BASE) +
+				   (CONFIG_BT_CTLR_CONN_ISO_GROUPS) - 1),
+#endif /* CONFIG_BT_CTLR_CONN_ISO_GROUPS */
+
 #if defined(CONFIG_BT_CTLR_USER_EXT) && \
 	(CONFIG_BT_CTLR_USER_TICKER_ID_RANGE > 0)
 	TICKER_ID_USER_BASE,
@@ -280,8 +286,8 @@ struct node_rx_hdr {
 	union {
 		struct node_rx_ftr rx_ftr;
 #if defined(CONFIG_BT_CTLR_SYNC_ISO) || \
-	defined(BT_CTLR_PERIPHERAL_ISO) || \
-	defined(BT_CTLR_CENTRAL_ISO)
+	defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) || \
+	defined(CONFIG_BT_CTLR_CENTRAL_ISO)
 		struct node_rx_iso_meta rx_iso_meta;
 #endif
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
@@ -324,6 +330,10 @@ enum {
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_OBSERVER */
+
+#if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS)
+	EVENT_DONE_EXTRA_TYPE_CIS,
+#endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 
 /* Following proprietary defines must be at end of enum range */
 #if defined(CONFIG_BT_CTLR_USER_EXT)

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -22,8 +22,10 @@ struct lll_conn_iso_stream_rxtx {
 };
 
 struct lll_conn_iso_stream {
-	/* Link to ACL connection (for encryption, channel map, crc init) */
-	struct lll_conn *conn;
+	uint16_t acl_handle;        /* ACL connection handle (for encryption,
+				     * channel map, crc init)
+				     */
+	uint16_t handle;            /* CIS handle */
 
 	/* Connection parameters */
 	uint8_t  access_addr[4];    /* Access address */
@@ -55,10 +57,11 @@ struct lll_conn_iso_stream {
 struct lll_conn_iso_group {
 	struct lll_hdr hdr;
 
+	uint16_t handle;   /* CIG handle (internal) */
 	uint8_t  num_cis;  /* Number of CISes in this CIG */
+	uint8_t  role;     /* 0: CENTRAL, 1: PERIPHERAL*/
 #if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP)
-	struct lll_conn_iso_stream *streams
-				[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
+	uint16_t cis_handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
 #endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 
 	/* Resumption information */
@@ -68,4 +71,6 @@ struct lll_conn_iso_group {
 
 int lll_conn_iso_init(void);
 int lll_conn_iso_reset(void);
+void lll_conn_iso_done(struct lll_conn_iso_group *cig, uint8_t trx_cnt,
+		       uint16_t prog_to_anchor_us, uint8_t mic_state);
 void lll_conn_iso_flush(uint16_t handle, struct lll_conn_iso_stream *lll);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -643,7 +643,7 @@ struct pdu_data_llctrl_cis_rsp {
 } __packed;
 
 struct pdu_data_llctrl_cis_ind {
-	uint32_t aa;
+	uint8_t  aa[4];
 	uint8_t  cis_offset[3];
 	uint8_t  cig_sync_delay[3];
 	uint8_t  cis_sync_delay[3];

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -175,6 +175,13 @@
 #define FLASH_TICKER_USER_APP_OPS 0
 #endif
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO_GROUPS)
+#define BT_CIG_TICKER_NODES ((TICKER_ID_CONN_ISO_LAST) -
+			     (TICKER_ID_CONN_ISO_BASE) + 1)
+#else
+#define BT_CIG_TICKER_NODES 0
+#endif
+
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 #define USER_TICKER_NODES         CONFIG_BT_CTLR_USER_TICKER_ID_RANGE
 #else
@@ -190,6 +197,7 @@
 				   BT_SCAN_SYNC_TICKER_NODES + \
 				   BT_CONN_TICKER_NODES + \
 				   FLASH_TICKER_NODES + \
+				   BT_CIG_TICKER_NODES + \
 				   USER_TICKER_NODES)
 #define TICKER_USER_APP_OPS       (TICKER_USER_THREAD_OPS + \
 				   FLASH_TICKER_USER_APP_OPS)
@@ -1015,6 +1023,15 @@ void ll_rx_dequeue(void)
 		__fallthrough;
 #endif /* CONFIG_BT_CTLR_USER_EVT_RANGE > 0 */
 
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	case NODE_RX_TYPE_CIS_REQUEST:
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) || \
+	defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+	case NODE_RX_TYPE_CIS_ESTABLISHED:
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO || CONFIG_BT_CTLR_CENTRAL_ISO */
+
 	/* Ensure that at least one 'case' statement is present for this
 	 * code block.
 	 */
@@ -1174,6 +1191,15 @@ void ll_rx_mem_release(void **node_rx)
 #if CONFIG_BT_CTLR_USER_EVT_RANGE > 0
 		case NODE_RX_TYPE_USER_START ... NODE_RX_TYPE_USER_END - 1:
 #endif /* CONFIG_BT_CTLR_USER_EVT_RANGE > 0 */
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+		case NODE_RX_TYPE_CIS_REQUEST:
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) || \
+	defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+		case NODE_RX_TYPE_CIS_ESTABLISHED:
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO || CONFIG_BT_CTLR_CENTRAL_ISO */
 
 		/* Ensure that at least one 'case' statement is present for this
 		 * code block.
@@ -2268,6 +2294,12 @@ static inline void rx_demux_event_done(memq_link_t *link,
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 #endif /* CONFIG_BT_OBSERVER */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+#if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS)
+	case EVENT_DONE_EXTRA_TYPE_CIS:
+		ull_conn_iso_done(done);
+		break;
+#endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 	case EVENT_DONE_EXTRA_TYPE_USER_START

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -5,14 +5,18 @@
  */
 
 #include <zephyr.h>
+#include <sys/byteorder.h>
 
 #include "util/mem.h"
 #include "util/memq.h"
+#include "util/mayfly.h"
+#include "ticker/ticker.h"
 
 #include "lll.h"
 #include "lll_conn_iso.h"
 
 #include "ull_conn_iso_types.h"
+#include "ull_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_conn_iso
@@ -27,6 +31,80 @@ static void *cig_free;
 
 static int init_reset(void);
 
+struct ll_conn_iso_group *ll_conn_iso_group_acquire(void)
+{
+	return mem_acquire(&cig_free);
+}
+
+void ll_conn_iso_group_release(struct ll_conn_iso_group *cig)
+{
+	mem_release(cig, &cig_free);
+}
+
+uint16_t ll_conn_iso_group_handle_get(struct ll_conn_iso_group *cig)
+{
+	return mem_index_get(cig, cig_pool, sizeof(struct ll_conn_iso_group));
+}
+
+struct ll_conn_iso_group *ll_conn_iso_group_get(uint16_t handle)
+{
+	return mem_get(cig_pool, sizeof(struct ll_conn_iso_group), handle);
+}
+
+struct ll_conn_iso_group *ll_conn_iso_group_get_by_id(uint8_t id)
+{
+	struct ll_conn_iso_group *cig;
+
+	for (int h = 0; h < CONFIG_BT_CTLR_CONN_ISO_GROUPS; h++) {
+		cig = ll_conn_iso_group_get(h);
+		if (id == cig->cig_id) {
+			return cig;
+		}
+	}
+
+	return NULL;
+}
+
+struct ll_conn_iso_stream *ll_conn_iso_stream_acquire(void)
+{
+	return mem_acquire(&cis_free);
+}
+
+void ll_conn_iso_stream_release(struct ll_conn_iso_stream *cis)
+{
+	mem_release(cis, &cig_free);
+}
+
+uint16_t ll_conn_iso_stream_handle_get(struct ll_conn_iso_stream *cis)
+{
+	return mem_index_get(cis, cis_pool,
+			     sizeof(struct ll_conn_iso_stream)) +
+			     LL_CIS_HANDLE_BASE;
+}
+
+struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle)
+{
+	return mem_get(cis_pool, sizeof(struct ll_conn_iso_stream), handle -
+		       LL_CIS_HANDLE_BASE);
+}
+
+struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle)
+{
+	struct ll_conn_iso_stream *cis;
+
+	if (handle >= CONFIG_BT_CTLR_CONN_ISO_STREAMS +
+		      LL_CIS_HANDLE_BASE) {
+		return NULL;
+	}
+
+	cis = ll_conn_iso_stream_get(handle);
+	if (cis->lll.handle != handle) {
+		return NULL;
+	}
+
+	return cis;
+}
+
 int ull_conn_iso_init(void)
 {
 	return init_reset();
@@ -39,6 +117,8 @@ int ull_conn_iso_reset(void)
 
 static int init_reset(void)
 {
+	int err;
+
 	/* Initialize CIS pool */
 	mem_init(cis_pool, sizeof(struct ll_conn_iso_stream),
 		 sizeof(cis_pool) / sizeof(struct ll_conn_iso_stream),
@@ -49,5 +129,96 @@ static int init_reset(void)
 		 sizeof(cig_pool) / sizeof(struct ll_conn_iso_group),
 		 &cig_free);
 
+	for (int h = 0; h < CONFIG_BT_CTLR_CONN_ISO_GROUPS; h++) {
+		ll_conn_iso_group_get(h)->cig_id = 0xFF;
+	}
+
+	/* Initialize LLL */
+	err = lll_conn_iso_init();
+	if (err) {
+		return err;
+	}
+
 	return 0;
+}
+
+static void ticker_update_cig_op_cb(uint32_t status, void *param)
+{
+	/* CIG drift compensation succeeds, or it fails in a race condition
+	 * when disconnecting (race between ticker_update and ticker_stop
+	 * calls). TODO: Are the race-checks needed?
+	 */
+	LL_ASSERT(status == TICKER_STATUS_SUCCESS ||
+		  param == ull_update_mark_get() ||
+		  param == ull_disable_mark_get());
+}
+
+void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis)
+{
+	struct node_rx_conn_iso_estab *est;
+	struct node_rx_pdu *node_rx;
+
+	node_rx = ull_pdu_rx_alloc();
+	if (!node_rx) {
+		/* No node available - try again later */
+		return;
+	}
+
+	/* TODO: Send CIS_ESTABLISHED with status != 0 in error scenarios */
+	node_rx->hdr.type = NODE_RX_TYPE_CIS_ESTABLISHED;
+	node_rx->hdr.handle = 0xFFFF;
+	node_rx->hdr.rx_ftr.param = cis;
+
+	est = (void *)node_rx->pdu;
+	est->status = 0;
+	est->cis_handle = sys_le16_to_cpu(cis->lll.handle);
+
+	ll_rx_put(node_rx->hdr.link, node_rx);
+	ll_rx_sched();
+
+	cis->established = 1;
+}
+
+void ull_conn_iso_done(struct node_rx_event_done *done)
+{
+	struct lll_conn_iso_group *lll = (void *)HDR_ULL2LLL(done->param);
+	struct ll_conn_iso_group *cig = (void *)HDR_LLL2EVT(lll);
+	uint32_t ticks_drift_minus;
+	uint32_t ticks_drift_plus;
+
+	/* Skip if CIG terminated by local host */
+	if (unlikely(lll->handle == 0xFFFF)) {
+		return;
+	}
+
+	ticks_drift_plus  = 0;
+	ticks_drift_minus = 0;
+
+	if (done->extra.trx_cnt) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_PERIPHERAL_ISO) && lll->role) {
+			ull_drift_ticks_get(done, &ticks_drift_plus,
+					    &ticks_drift_minus);
+		}
+	}
+
+	/* Update CIG ticker to compensate for drift */
+	if (ticks_drift_plus || ticks_drift_minus) {
+		uint8_t ticker_id = TICKER_ID_CONN_ISO_BASE +
+				    ll_conn_iso_group_handle_get(cig);
+		struct ll_conn *conn = lll->hdr.parent;
+		uint32_t ticker_status;
+
+		ticker_status = ticker_update(TICKER_INSTANCE_ID_CTLR,
+					      TICKER_USER_ID_ULL_HIGH,
+					      ticker_id,
+					      ticks_drift_plus,
+					      ticks_drift_minus, 0, 0,
+					      TICKER_NULL_LAZY, 0,
+					      ticker_update_cig_op_cb,
+					      cig);
+
+		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+			  (ticker_status == TICKER_STATUS_BUSY) ||
+			  ((void *)conn == ull_disable_mark_get()));
+	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -7,3 +7,18 @@
 /* Helper functions to initialize and reset ull_conn_iso module */
 int ull_conn_iso_init(void);
 int ull_conn_iso_reset(void);
+
+struct ll_conn_iso_group *ll_conn_iso_group_acquire(void);
+void ll_conn_iso_group_release(struct ll_conn_iso_group *cig);
+uint16_t ll_conn_iso_group_handle_get(struct ll_conn_iso_group *cig);
+struct ll_conn_iso_group *ll_conn_iso_group_get(uint16_t handle);
+struct ll_conn_iso_group *ll_conn_iso_group_get_by_id(uint8_t id);
+
+struct ll_conn_iso_stream *ll_conn_iso_stream_acquire(void);
+void ll_conn_iso_stream_release(struct ll_conn_iso_stream *cis);
+uint16_t ll_conn_iso_stream_handle_get(struct ll_conn_iso_stream *cis);
+struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle);
+struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle);
+
+void ull_conn_iso_done(struct node_rx_event_done *done);
+void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -4,10 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #define LL_CIS_HANDLE_BASE CONFIG_BT_MAX_CONN
+
+ #define LL_CIS_IDX_FROM_HANDLE(_handle) \
+	((_handle) - LL_CIS_HANDLE_BASE)
+
 struct ll_conn_iso_stream {
 	struct ll_conn_iso_group *group;
 	struct lll_conn_iso_stream lll;
 	uint32_t sync_delay;
+	uint8_t  cis_id;
+	uint8_t  established;	/* 0 if CIS has not yet been established.
+				 * 1 if CIS has been established and host
+				 * notified.
+				 */
 };
 
 struct ll_conn_iso_group {
@@ -16,13 +26,19 @@ struct ll_conn_iso_group {
 	struct lll_conn_iso_group lll;
 
 	uint32_t sync_delay;
-	uint32_t c_latency;
-	uint32_t p_latency;
+	uint32_t c_latency;	/* Transport_Latency_M_To_S = CIG_Sync_Delay +
+				 * (FT_M_To_S) × ISO_Interval +
+				 * SDU_Interval_M_To_S
+				 */
+	uint32_t p_latency;	/* Transport_Latency_S_To_M = CIG_Sync_Delay +
+				 * (FT_S_To_M) × ISO_Interval +
+				 * SDU_Interval_S_To_M
+				 */
 	uint16_t iso_interval;
+	uint8_t  cig_id;
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP)
-	struct ll_conn_iso_stream *streams
-				[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
+	uint16_t cis_handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
 #endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 };
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -311,6 +311,32 @@ struct ll_conn {
 	struct node_tx *tx_data_last;
 
 	uint8_t chm_updated;
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	struct {
+		uint8_t  req;
+		uint8_t  ack;
+		enum {
+			LLCP_CIS_STATE_REQ,
+			LLCP_CIS_STATE_RSP_WAIT,
+			LLCP_CIS_STATE_IND_WAIT,
+			LLCP_CIS_STATE_INST_WAIT
+		} state:8 __packed;
+		uint8_t  cig_id;
+		uint16_t cis_handle;
+		uint8_t  cis_id;
+		uint32_t c_max_sdu:12;
+		uint32_t p_max_sdu:12;
+		uint32_t framed:1;
+		uint32_t c_sdu_interval;
+		uint32_t p_sdu_interval;
+		uint32_t cis_offset_min;
+		uint32_t cis_offset_max;
+		uint16_t conn_event_count;
+		uint32_t cig_sync_delay;
+		uint32_t cis_sync_delay;
+	} llcp_cis;
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 };
 
 struct node_rx_cc {

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
@@ -7,3 +7,11 @@
 /* Helper functions to initialize and reset ull_peripheral_iso module */
 int ull_peripheral_iso_init(void);
 int ull_peripheral_iso_reset(void);
+
+uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
+				   struct pdu_data_llctrl_cis_req *req,
+				   uint16_t *cis_handle);
+uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
+				 uint8_t cig_id,
+				 uint16_t cis_handle);
+void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -234,7 +234,13 @@ void hci_le_cis_req(struct net_buf *buf)
 	iso->role = BT_HCI_ROLE_SLAVE;
 	bt_conn_set_state(iso, BT_CONN_CONNECT);
 
-	hci_le_accept_cis(cis_handle);
+	err = hci_le_accept_cis(cis_handle);
+	if (err) {
+		bt_iso_cleanup(iso);
+		hci_le_reject_cis(cis_handle,
+				  BT_HCI_ERR_INSUFFICIENT_RESOURCES);
+		return;
+	}
 }
 
 int hci_le_remove_cig(uint8_t cig_id)


### PR DESCRIPTION
LL_CIS_IND starts a ticker for the created CIG, using the event_counter
and offset provided. Ticker generates callbacks to
lll_peripheral_iso_prepare. Event done with ISO (extra) type is demuxed
and done handled for CIG including ticker update with drift compensation.
    
TODO: Handle multiple CISes as well as pause/resume and scheduling
latency.
    
Implemented LL_CIS_REQ/RSP and LL_CIS_IND handling to allow a central
to establish a CIS connection. Implementation is temporary, for
test/development purpose and should be re-implemented in the new LLCP
framework when ready.

   