### PR TITLE
stream_flash minor fixes

### DIFF
--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -161,7 +161,11 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 		}
 
 		rc = flash_sync(ctx);
-		ctx->bytes_written -= fill_length;
+		if (rc == 0) {
+			ctx->bytes_written -= fill_length;
+		} else {
+			ctx->buf_bytes -= fill_length;
+		}
 	}
 
 	return rc;

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -98,6 +98,7 @@ static int flash_sync(struct stream_flash_ctx *ctx)
 		rc = ctx->callback(ctx->buf, ctx->buf_bytes, write_addr);
 		if (rc != 0) {
 			LOG_ERR("callback failed: %d", rc);
+			return rc;
 		}
 	}
 

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -33,7 +33,6 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 		return 0;
 	}
 
-	ctx->last_erased_page_start_offset = page.start_offset;
 	LOG_DBG("Erasing page at offset 0x%08lx", (long)page.start_offset);
 
 	flash_write_protection_set(ctx->fdev, false);
@@ -42,6 +41,8 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 
 	if (rc != 0) {
 		LOG_ERR("Error %d while erasing page", rc);
+	} else {
+		ctx->last_erased_page_start_offset = page.start_offset;
 	}
 
 	return rc;

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -152,19 +152,7 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 		fill_length = flash_get_write_block_size(ctx->fdev);
 		if (ctx->buf_bytes % fill_length) {
 			fill_length -= ctx->buf_bytes % fill_length;
-			/*
-			 * Leverage the fact that unwritten memory
-			 * should be erased in order to get the erased
-			 * byte-value.
-			 */
-			rc = flash_read(ctx->fdev,
-					ctx->offset + ctx->bytes_written,
-					(void *)&filler,
-					1);
-
-			if (rc != 0) {
-				return rc;
-			}
+			filler = flash_get_parameters(ctx->fdev)->erase_value;
 
 			memset(ctx->buf + ctx->buf_bytes, filler, fill_length);
 			ctx->buf_bytes += fill_length;

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -56,10 +56,11 @@ static int flash_sync(struct stream_flash_ctx *ctx)
 	size_t write_addr = ctx->offset + ctx->bytes_written;
 
 
+	if (ctx->buf_bytes == 0) {
+		return 0;
+	}
+
 	if (IS_ENABLED(CONFIG_STREAM_FLASH_ERASE)) {
-		if (ctx->buf_bytes == 0) {
-			return 0;
-		}
 
 		rc = stream_flash_erase_page(ctx,
 					     write_addr + ctx->buf_bytes - 1);


### PR DESCRIPTION
The batch of changes that include:
 1) Use flash_get_parameters to get erase value for stream_flash_buffered_write, where read of erased flash has been used previously;
 2) The ctx->buf_bytes check, within flash_sync, has been moved outside CONFIG_STREAM_FLASH_ERASE conditional code, as it is universal check whether there is any work to do;
 3) The update, within flash_sync,  of flash_stream_ctx bytes_written and buf_bytes is not done when verification callback fails;
 4) The stream_flash_erase_page will only update last_erased_page_start_offset if successful.