### PR TITLE
nRF5340: fix west flash for in-tree tests when building for nRF5340 Non-Secure (with TF-M)

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -14,6 +14,17 @@ config BOARD
 config BUILD_WITH_TFM
 	default y if BOARD_NRF5340DK_NRF5340_CPUAPPNS
 
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+# (when building in-tree tests).
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y if TEST_ARM_CORTEX_M
+
+endif # BUILD_WITH_TFM
+
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning

--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -8,6 +8,10 @@ if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAP
 board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
+if(CONFIG_TFM_FLASH_MERGED_BINARY)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+endif()
+
 if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
 board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -207,4 +207,15 @@ config ROM_START_OFFSET
 
 endif # !TFM_BL2
 
+# Option to instruct flashing a merged binary consisting of BL2 (optionally),
+# TF-M (Secure), and application (Non-Secure).
+config TFM_FLASH_MERGED_BINARY
+	bool
+	help
+		This option instructs west flash to program the
+		combined (merged) binary consisting of the TF-M
+		Secure firmware image, optionally, the BL2 image
+		(if building with TFM_BL2 is enabled), and the
+		Non-Secure application firmware.
+
 endif # BUILD_WITH_TFM


### PR DESCRIPTION
Introduce a Kconfig option for tfm, which instructs zephyr to flash the merged (combined) Secure and non secure binary whe. Doing west flash. Use this option in nrf 5340 NS target, so ci can automate running tests on nrf5350 Non secure board. 