### PR TITLE
net: lwm2m: Add a data validation callback

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -233,6 +233,25 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 }
 #endif
 
+/* An example data validation callback. */
+static int timer_on_off_validate_cb(uint16_t obj_inst_id, uint16_t res_id,
+				    uint16_t res_inst_id, uint8_t *data,
+				    uint16_t data_len, bool last_block,
+				    size_t total_size)
+{
+	LOG_INF("Validating On/Off data");
+
+	if (data_len != 1) {
+		return -EINVAL;
+	}
+
+	if (*data > 1) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int timer_digital_state_cb(uint16_t obj_inst_id,
 				  uint16_t res_id, uint16_t res_inst_id,
 				  uint8_t *data, uint16_t data_len,
@@ -365,6 +384,8 @@ static int lwm2m_setup(void)
 
 	/* IPSO: Timer object */
 	lwm2m_engine_create_obj_inst("3340/0");
+	lwm2m_engine_register_validate_callback("3340/0/5850",
+			timer_on_off_validate_cb);
 	lwm2m_engine_register_post_write_callback("3340/0/5543",
 			timer_digital_state_cb);
 	lwm2m_engine_set_res_data("3340/0/5750", TIMER_NAME, sizeof(TIMER_NAME),

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -65,6 +65,7 @@ config LWM2M_ENGINE_VALIDATION_BUFFER_SIZE
 	  for which validation callback has been registered). Set this value to
 	  the maximum expected size of the resources that need to be validated
 	  (and thus have validation callback registered).
+	  Setting the validation buffer size to 0 disables validation support.
 
 config LWM2M_ENGINE_MAX_PENDING
 	int "LWM2M engine max. pending objects"

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -56,6 +56,16 @@ config LWM2M_ENGINE_MESSAGE_HEADER_SIZE
 	help
 	  Extra room allocated to handle CoAP header data
 
+config LWM2M_ENGINE_VALIDATION_BUFFER_SIZE
+	int "Size of the validation buffer for the incoming data"
+	default 64
+	help
+	  LwM2M will use the validation buffer during the write operation, to
+	  decode the resource value before validating it (applies for resources
+	  for which validation callback has been registered). Set this value to
+	  the maximum expected size of the resources that need to be validated
+	  (and thus have validation callback registered).
+
 config LWM2M_ENGINE_MAX_PENDING
 	int "LWM2M engine max. pending objects"
 	default 5

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -216,7 +216,7 @@ static struct lwm2m_engine_obj_inst *buzzer_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &buzzer_data[avail].onoff,
 		     sizeof(buzzer_data[avail].onoff),
-		     NULL, NULL, onoff_post_write_cb, NULL);
+		     NULL, NULL, NULL, onoff_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(BUZZER_LEVEL_ID, res[avail], i, res_inst[avail], j,
 			  &buzzer_data[avail].level,
 			  sizeof(buzzer_data[avail].level));

--- a/subsys/net/lib/lwm2m/ipso_generic_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_generic_sensor.c
@@ -207,7 +207,7 @@ static struct lwm2m_engine_obj_inst *generic_sensor_create(uint16_t obj_inst_id)
 	/* initialize instance resource data */
 	INIT_OBJ_RES(SENSOR_VALUE_RID, res[index], i, res_inst[index], j, 1,
 		     false, true, &sensor_value[index], sizeof(*sensor_value),
-		     NULL, NULL, sensor_value_write_cb, NULL);
+		     NULL, NULL, NULL, sensor_value_write_cb, NULL);
 	INIT_OBJ_RES_DATA(SENSOR_UNITS_RID, res[index], i, res_inst[index], j,
 			  units[index], UNIT_STR_MAX_SIZE);
 	INIT_OBJ_RES_DATA(MIN_MEASURED_VALUE_RID, res[index], i,

--- a/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
@@ -190,7 +190,7 @@ humidity_sensor_create(uint16_t obj_inst_id)
 	/* initialize instance resource data */
 	INIT_OBJ_RES(SENSOR_VALUE_RID, res[index], i, res_inst[index], j, 1,
 		     false, true, &sensor_value[index], sizeof(*sensor_value),
-		     NULL, NULL, sensor_value_write_cb, NULL);
+		     NULL, NULL, NULL, sensor_value_write_cb, NULL);
 	INIT_OBJ_RES_DATA(SENSOR_UNITS_RID, res[index], i, res_inst[index], j,
 			  units[index], UNIT_STR_MAX_SIZE);
 	INIT_OBJ_RES_DATA(MIN_MEASURED_VALUE_RID, res[index], i,

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -173,7 +173,7 @@ static struct lwm2m_engine_obj_inst *light_control_create(uint16_t obj_inst_id)
 	INIT_OBJ_RES(LIGHT_ON_TIME_ID, res[avail], i,
 		     res_inst[avail], j, 1, false, true,
 		     &on_time_value[avail], sizeof(*on_time_value),
-		     on_time_read_cb, NULL, on_time_post_write_cb, NULL);
+		     on_time_read_cb, NULL, NULL, on_time_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(LIGHT_CUMULATIVE_ACTIVE_POWER_ID, res[avail], i,
 			  res_inst[avail], j,
 			  &cumulative_active_value[avail],

--- a/subsys/net/lib/lwm2m/ipso_onoff_switch.c
+++ b/subsys/net/lib/lwm2m/ipso_onoff_switch.c
@@ -214,17 +214,17 @@ static struct lwm2m_engine_obj_inst *switch_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &switch_data[avail].state,
 		     sizeof(switch_data[avail].state),
-		     NULL, NULL, state_post_write_cb, NULL);
+		     NULL, NULL, NULL, state_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(SWITCH_DIGITAL_INPUT_COUNTER_ID, res[avail], i,
 			  res_inst[avail], j,
 			  &switch_data[avail].counter,
 			  sizeof(switch_data[avail].counter));
 	INIT_OBJ_RES_OPT(SWITCH_ON_TIME_ID, res[avail], i,
 		     res_inst[avail], j, 1, false, true,
-		     on_time_read_cb, NULL, time_post_write_cb, NULL);
+		     on_time_read_cb, NULL, NULL, time_post_write_cb, NULL);
 	INIT_OBJ_RES_OPT(SWITCH_OFF_TIME_ID, res[avail], i,
 		     res_inst[avail], j, 1, false, true,
-		     off_time_read_cb, NULL, time_post_write_cb, NULL);
+		     off_time_read_cb, NULL, NULL, time_post_write_cb, NULL);
 	INIT_OBJ_RES_OPTDATA(SWITCH_APPLICATION_TYPE_ID, res[avail], i,
 			     res_inst[avail], j);
 #if ADD_TIMESTAMPS

--- a/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
@@ -190,7 +190,7 @@ pressure_sensor_create(uint16_t obj_inst_id)
 	/* initialize instance resource data */
 	INIT_OBJ_RES(SENSOR_VALUE_RID, res[index], i, res_inst[index], j, 1,
 		     false, true, &sensor_value[index], sizeof(*sensor_value),
-		     NULL, NULL, sensor_value_write_cb, NULL);
+		     NULL, NULL, NULL, sensor_value_write_cb, NULL);
 	INIT_OBJ_RES_DATA(SENSOR_UNITS_RID, res[index], i, res_inst[index], j,
 			  units[index], UNIT_STR_MAX_SIZE);
 	INIT_OBJ_RES_DATA(MIN_MEASURED_VALUE_RID, res[index], i,

--- a/subsys/net/lib/lwm2m/ipso_push_button.c
+++ b/subsys/net/lib/lwm2m/ipso_push_button.c
@@ -146,7 +146,7 @@ static struct lwm2m_engine_obj_inst *button_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &button_data[avail].state,
 		     sizeof(button_data[avail].state),
-		     NULL, NULL, state_post_write_cb, NULL);
+		     NULL, NULL, NULL, state_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(BUTTON_DIGITAL_INPUT_COUNTER_ID, res[avail], i,
 			  res_inst[avail], j,
 			  &button_data[avail].counter,

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -205,7 +205,7 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(uint16_t obj_inst_id)
 	INIT_OBJ_RES(TEMP_SENSOR_VALUE_ID, res[index], i,
 		     res_inst[index], j, 1, false, true,
 		     &sensor_value[index], sizeof(*sensor_value),
-		     NULL, NULL, sensor_value_write_cb, NULL);
+		     NULL, NULL, NULL, sensor_value_write_cb, NULL);
 	INIT_OBJ_RES_DATA(TEMP_UNITS_ID, res[index], i, res_inst[index], j,
 			  units[index], TEMP_STRING_SHORT);
 	INIT_OBJ_RES_DATA(TEMP_MIN_MEASURED_VALUE_ID, res[index], i,

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -344,7 +344,7 @@ static struct lwm2m_engine_obj_inst *timer_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &timer_data[avail].remaining_time,
 		     sizeof(timer_data[avail].remaining_time),
-		     remaining_time_read_cb, NULL, NULL, NULL);
+		     remaining_time_read_cb, NULL, NULL, NULL, NULL);
 	INIT_OBJ_RES_DATA(TIMER_MINIMUM_OFF_TIME_ID, res[avail], i,
 			  res_inst[avail], j, &timer_data[avail].min_off_time,
 			  sizeof(timer_data[avail].min_off_time));
@@ -354,12 +354,12 @@ static struct lwm2m_engine_obj_inst *timer_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &timer_data[avail].enabled,
 		     sizeof(timer_data[avail].enabled),
-		     NULL, NULL, enabled_post_write_cb, NULL);
+		     NULL, NULL, NULL, enabled_post_write_cb, NULL);
 	INIT_OBJ_RES(TIMER_CUMULATIVE_TIME_ID, res[avail], i,
 		     res_inst[avail], j, 1, false, true,
 		     &timer_data[avail].cumulative_time,
 		     sizeof(timer_data[avail].cumulative_time),
-		     cumulative_time_read_cb, NULL,
+		     cumulative_time_read_cb, NULL, NULL,
 		     cumulative_time_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(TIMER_DIGITAL_STATE_ID, res[avail], i,
 			  res_inst[avail], j, &timer_data[avail].active,
@@ -368,7 +368,7 @@ static struct lwm2m_engine_obj_inst *timer_create(uint16_t obj_inst_id)
 		     res_inst[avail], j, 1, false, true,
 		     &timer_data[avail].trigger_counter,
 		     sizeof(timer_data[avail].trigger_counter),
-		     NULL, NULL, trigger_counter_post_write_cb, NULL);
+		     NULL, NULL, NULL, trigger_counter_post_write_cb, NULL);
 	INIT_OBJ_RES_DATA(TIMER_MODE_ID, res[avail], i, res_inst[avail], j,
 			  &timer_data[avail].timer_mode,
 			  sizeof(timer_data[avail].timer_mode));

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -229,7 +229,7 @@ static struct lwm2m_engine_obj_inst *device_create(uint16_t obj_inst_id)
 			     reset_error_list_cb);
 	INIT_OBJ_RES_OPT(DEVICE_CURRENT_TIME_ID, res, i, res_inst, j, 1, false,
 			 true, current_time_read_cb, current_time_pre_write_cb,
-			 current_time_post_write_cb, NULL);
+			 NULL, current_time_post_write_cb, NULL);
 	INIT_OBJ_RES_OPTDATA(DEVICE_UTC_OFFSET_ID, res, i, res_inst, j);
 	INIT_OBJ_RES_OPTDATA(DEVICE_TIMEZONE_ID, res, i, res_inst, j);
 	INIT_OBJ_RES_DATA(DEVICE_SUPPORTED_BINDING_MODES_ID, res, i,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -320,10 +320,10 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 
 	/* initialize instance resource data */
 	INIT_OBJ_RES_OPT(FIRMWARE_PACKAGE_ID, res, i, res_inst, j, 1, false,
-			 true, NULL, NULL, package_write_cb, NULL);
+			 true, NULL, NULL, NULL, package_write_cb, NULL);
 	INIT_OBJ_RES(FIRMWARE_PACKAGE_URI_ID, res, i, res_inst, j, 1, false,
 		     true, package_uri, PACKAGE_URI_LEN,
-		     NULL, NULL, package_uri_write_cb, NULL);
+		     NULL, NULL, NULL, package_uri_write_cb, NULL);
 	INIT_OBJ_RES_EXECUTE(FIRMWARE_UPDATE_ID, res, i, firmware_update_cb);
 	INIT_OBJ_RES_DATA(FIRMWARE_STATE_ID, res, i, res_inst, j,
 			  &update_state, sizeof(update_state));

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -213,7 +213,7 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 			  &server_id[index], sizeof(*server_id));
 	INIT_OBJ_RES(SERVER_LIFETIME_ID, res[index], i, res_inst[index], j,
 		     1U, false, true, &lifetime[index], sizeof(*lifetime),
-		     NULL, NULL, lifetime_write_cb, NULL);
+		     NULL, NULL, NULL, lifetime_write_cb, NULL);
 	INIT_OBJ_RES_DATA(SERVER_DEFAULT_MIN_PERIOD_ID, res[index], i,
 			  res_inst[index], j,
 			  &default_min_period[index],

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -198,13 +198,14 @@ struct lwm2m_engine_obj {
 
 /* Resource macros */
 #define _INIT_OBJ_RES(_id, _r_ptr, _r_idx, _ri_ptr, _ri_count, _multi_ri, \
-		      _r_cb, _pre_w_cb, _post_w_cb, _ex_cb) \
+		      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
 	_r_ptr[_r_idx].res_id = _id; \
 	_r_ptr[_r_idx].res_instances = _ri_ptr; \
 	_r_ptr[_r_idx].res_inst_count = _ri_count; \
 	_r_ptr[_r_idx].multi_res_inst = _multi_ri; \
 	_r_ptr[_r_idx].read_cb = _r_cb; \
 	_r_ptr[_r_idx].pre_write_cb = _pre_w_cb; \
+	_r_ptr[_r_idx].validate_cb = _val_cb; \
 	_r_ptr[_r_idx].post_write_cb = _post_w_cb; \
 	_r_ptr[_r_idx].execute_cb = _ex_cb
 
@@ -253,11 +254,11 @@ struct lwm2m_engine_obj {
 #define INIT_OBJ_RES(_id, _r_ptr, _r_idx, \
 		     _ri_ptr, _ri_idx, _ri_count, _multi_ri, _ri_create, \
 		     _data_ptr, _data_len, \
-		     _r_cb, _pre_w_cb, _post_w_cb, _ex_cb) \
+		     _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
 	do { \
 		_INIT_OBJ_RES(_id, _r_ptr, _r_idx, \
 			      (_ri_ptr + _ri_idx), _ri_count, _multi_ri, \
-			      _r_cb, _pre_w_cb, _post_w_cb, _ex_cb); \
+			      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb); \
 		_INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
 				   _data_ptr, _data_len); \
 	++_r_idx; \
@@ -266,11 +267,11 @@ struct lwm2m_engine_obj {
 
 #define INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, \
 			 _ri_ptr, _ri_idx, _ri_count, _multi_ri, _ri_create, \
-			 _r_cb, _pre_w_cb, _post_w_cb, _ex_cb) \
+			 _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
 	do { \
 		_INIT_OBJ_RES(_id, _r_ptr, _r_idx, \
 			      (_ri_ptr + _ri_idx), _ri_count, _multi_ri, \
-			      _r_cb, _pre_w_cb, _post_w_cb, _ex_cb); \
+			      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb); \
 		_INIT_OBJ_RES_INST_OPT(_ri_ptr, _ri_idx, _ri_count, _ri_create); \
 		++_r_idx; \
 	} while (false)
@@ -280,27 +281,27 @@ struct lwm2m_engine_obj {
 				_data_ptr, _data_len) \
 	INIT_OBJ_RES(_id, _r_ptr, _r_idx, \
 		     _ri_ptr, _ri_idx, _ri_count, true, _ri_create, \
-		     _data_ptr, _data_len, NULL, NULL, NULL, NULL)
+		     _data_ptr, _data_len, NULL, NULL, NULL, NULL, NULL)
 
 #define INIT_OBJ_RES_MULTI_OPTDATA(_id, _r_ptr, _r_idx, \
 				   _ri_ptr, _ri_idx, _ri_count, _ri_create) \
 	INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, \
 			 _ri_ptr, _ri_idx, _ri_count, true, _ri_create, \
-			 NULL, NULL, NULL, NULL)
+			 NULL, NULL, NULL, NULL, NULL)
 
 #define INIT_OBJ_RES_DATA(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, \
 			  _data_ptr, _data_len) \
 	INIT_OBJ_RES(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, 1U, false, true, \
-		     _data_ptr, _data_len, NULL, NULL, NULL, NULL)
+		     _data_ptr, _data_len, NULL, NULL, NULL, NULL, NULL)
 
 #define INIT_OBJ_RES_OPTDATA(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx) \
 	INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, 1U, false, \
-			 true, NULL, NULL, NULL, NULL)
+			 true, NULL, NULL, NULL, NULL, NULL)
 
 #define INIT_OBJ_RES_EXECUTE(_id, _r_ptr, _r_idx, _ex_cb) \
 	do { \
 		_INIT_OBJ_RES(_id, _r_ptr, _r_idx, NULL, 0, false, \
-			      NULL, NULL, NULL, _ex_cb); \
+			      NULL, NULL, NULL, NULL, _ex_cb); \
 		++_r_idx; \
 	} while (false)
 
@@ -336,6 +337,7 @@ struct lwm2m_engine_res_inst {
 struct lwm2m_engine_res {
 	lwm2m_engine_get_data_cb_t		read_cb;
 	lwm2m_engine_get_data_cb_t		pre_write_cb;
+	lwm2m_engine_set_data_cb_t		validate_cb;
 	lwm2m_engine_set_data_cb_t		post_write_cb;
 	lwm2m_engine_execute_cb_t		execute_cb;
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -197,6 +197,8 @@ struct lwm2m_engine_obj {
 #define RES_INSTANCE_NOT_CREATED 65535
 
 /* Resource macros */
+
+#if CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0
 #define _INIT_OBJ_RES(_id, _r_ptr, _r_idx, _ri_ptr, _ri_count, _multi_ri, \
 		      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
 	_r_ptr[_r_idx].res_id = _id; \
@@ -208,6 +210,18 @@ struct lwm2m_engine_obj {
 	_r_ptr[_r_idx].validate_cb = _val_cb; \
 	_r_ptr[_r_idx].post_write_cb = _post_w_cb; \
 	_r_ptr[_r_idx].execute_cb = _ex_cb
+#else
+#define _INIT_OBJ_RES(_id, _r_ptr, _r_idx, _ri_ptr, _ri_count, _multi_ri, \
+		      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
+	_r_ptr[_r_idx].res_id = _id; \
+	_r_ptr[_r_idx].res_instances = _ri_ptr; \
+	_r_ptr[_r_idx].res_inst_count = _ri_count; \
+	_r_ptr[_r_idx].multi_res_inst = _multi_ri; \
+	_r_ptr[_r_idx].read_cb = _r_cb; \
+	_r_ptr[_r_idx].pre_write_cb = _pre_w_cb; \
+	_r_ptr[_r_idx].post_write_cb = _post_w_cb; \
+	_r_ptr[_r_idx].execute_cb = _ex_cb
+#endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
 
 #define _INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
 			   _data_ptr, _data_len) \
@@ -337,7 +351,9 @@ struct lwm2m_engine_res_inst {
 struct lwm2m_engine_res {
 	lwm2m_engine_get_data_cb_t		read_cb;
 	lwm2m_engine_get_data_cb_t		pre_write_cb;
+#if CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0
 	lwm2m_engine_set_data_cb_t		validate_cb;
+#endif
 	lwm2m_engine_set_data_cb_t		post_write_cb;
 	lwm2m_engine_execute_cb_t		execute_cb;
 


### PR DESCRIPTION
Add a data validation callback to the resource structure, which can be
registered by an application. It allows to verify the data before
actually modifying the resource data.

If the callback is registered for a resource, the data is decoded into a
temporary buffer first, and only copied into the actual resource buffer
if the validation is successful. If no validation is required (and thus
no callback registered) the resource value is decoded directly into the
resource buffer, as it used to be.

Resolves #3931