### PR TITLE
kernel: Move LOCKED() macro to spinlock.h

### DIFF
--- a/arch/arc/core/arc_connect.c
+++ b/arch/arc/core/arc_connect.c
@@ -13,15 +13,9 @@
 #include <kernel.h>
 #include <arch/cpu.h>
 #include <spinlock.h>
-
+#include <kernel_internal.h>
 
 static struct k_spinlock arc_connect_spinlock;
-
-#define LOCKED(lck) for (k_spinlock_key_t __i = {},			\
-					  __key = k_spin_lock(lck);	\
-			!__i.key;					\
-			k_spin_unlock(lck, __key), __i.key = 1)
-
 
 /* Generate an inter-core interrupt to the target core */
 void z_arc_connect_ici_generate(uint32_t core)

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -202,6 +202,11 @@ void z_mem_manage_init(void);
 /* Workaround for build-time page table mapping of the kernel */
 void z_kernel_map_fixup(void);
 
+#define LOCKED(lck) for (k_spinlock_key_t __i = {},			\
+					  __key = k_spin_lock(lck);	\
+			!__i.key;					\
+			k_spin_unlock(lck, __key), __i.key = 1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -60,11 +60,6 @@ static struct k_spinlock sched_spinlock;
 
 static void update_cache(int);
 
-#define LOCKED(lck) for (k_spinlock_key_t __i = {},			\
-					  __key = k_spin_lock(lck);	\
-			!__i.key;					\
-			k_spin_unlock(lck, __key), __i.key = 1)
-
 static inline int is_preempt(struct k_thread *thread)
 {
 #ifdef CONFIG_PREEMPT_ENABLED

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -12,11 +12,6 @@
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 
-#define LOCKED(lck) for (k_spinlock_key_t __i = {},			\
-					  __key = k_spin_lock(lck);	\
-			__i.key == 0;					\
-			k_spin_unlock(lck, __key), __i.key = 1)
-
 static uint64_t curr_tick;
 
 static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);


### PR DESCRIPTION
Remove duplication in the code by moving macro LOCKED() to the correct
spinlock.h header.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>