### PR TITLE
tests: filter default platforms

### DIFF
--- a/boards/arm/qemu_cortex_a53/qemu_cortex_a53_xip.yaml
+++ b/boards/arm/qemu_cortex_a53/qemu_cortex_a53_xip.yaml
@@ -9,6 +9,5 @@ toolchain:
 ram: 128
 testing:
   default: true
-  ignore_tags:
-    - net
-    - bluetooth
+  only_tags:
+     - xip

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -11,3 +11,6 @@ ram: 65536
 flash: 32768
 testing:
   default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/riscv/qemu_riscv32/qemu_riscv32.yaml
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32.yaml
@@ -10,3 +10,6 @@ supported:
   - netif
 testing:
   default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/riscv/qemu_riscv64/qemu_riscv64.yaml
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64.yaml
@@ -9,3 +9,6 @@ supported:
   - netif
 testing:
   default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/sparc/qemu_leon3/qemu_leon3.yaml
+++ b/boards/sparc/qemu_leon3/qemu_leon3.yaml
@@ -12,3 +12,6 @@ supported:
   - netif
 testing:
   default: true
+  ignore_tags:
+    - net
+    - bluetooth


### PR DESCRIPTION
Do not attempt to build/run all tests. Emulation platforms should
primarily build kernel and architecture related tests.