### PR TITLE
driver: uart_npcx: do not check for irq enable in irq ready functions

### DIFF
--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -178,11 +178,7 @@ static void uart_npcx_irq_tx_disable(const struct device *dev)
 
 static int uart_npcx_irq_tx_ready(const struct device *dev)
 {
-	struct uart_reg *const inst = HAL_INSTANCE(dev);
-
-	/* Tx interrupt is enable and its FIFO is ready to send (not full) */
-	return (IS_BIT_SET(inst->UFTCTL, NPCX_UFTCTL_TEMPTY_EN) &&
-			uart_npcx_tx_fifo_ready(dev));
+	return uart_npcx_tx_fifo_ready(dev);
 }
 
 static int uart_npcx_irq_tx_complete(const struct device *dev)
@@ -209,11 +205,7 @@ static void uart_npcx_irq_rx_disable(const struct device *dev)
 
 static int uart_npcx_irq_rx_ready(const struct device *dev)
 {
-	struct uart_reg *const inst = HAL_INSTANCE(dev);
-
-	/* Rx interrupt is enable and at least one byte is in its FIFO */
-	return (IS_BIT_SET(inst->UFRCTL, NPCX_UFRCTL_RNEMPTY_EN) &&
-			uart_npcx_rx_fifo_available(dev));
+	return uart_npcx_rx_fifo_available(dev);
 }
 
 static void uart_npcx_irq_err_enable(const struct device *dev)


### PR DESCRIPTION
Current implementation of uart_npcx_irq_{tx,rx}_ready always returns
false if the respective interrupt enable bit is not set, which means
that the api cannot be used if the interrupts are temporarily disabled
for whatever reasons, breaking patterns such as [1].

Other uart drivers also seems to not have this check, this patch removes
it from the NPCX driver too.

[1] https://github.com/zephyrproject-rtos/zephyr/blob/master/drivers/console/uart_console.c#L549