### PR TITLE
samples: portability: set integration_platforms to native_posix

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -1,6 +1,8 @@
 sample:
   name: CMSIS_RTOS_V1 Dining Philosophers
 common:
+  integration_platforms:
+    - native_posix
   extra_args: DEBUG_PRINTF=1
   tags: cmsis_rtos
   min_ram: 32

--- a/samples/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: CMSIS_RTOS_V1 Synchronization
 tests:
   sample.portability.cmsis_rtos_v1.timer_synchronization:
+    integration_platforms:
+      - native_posix
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -1,6 +1,8 @@
 sample:
   name: CMSIS_RTOS_V2 Dining Philosophers
 common:
+  integration_platforms:
+    - native_posix
   extra_args: DEBUG_PRINTF=1
   tags: cmsis_rtos
   min_ram: 32

--- a/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: CMSIS_RTOS_V2 Synchronization
 tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
+    integration_platforms:
+      - native_posix
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34


### PR DESCRIPTION
Set integration_platforms on these samples to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>