### PR TITLE
tests: lib: set integration_platforms

### DIFF
--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   libraries.libc:
     tags: clib
+    integration_platforms:
+      - native_posix

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -9,5 +9,7 @@ tests:
   lib.heap:
     tags: heap
     platform_exclude: m2gl025_miv qemu_xtensa
+    integration_platforms:
+      - native_posix
     filter: not CONFIG_SOC_NSIM
     timeout: 480

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   lib.heap_align:
+    integration_platforms:
+      - native_posix
     tags: heap

--- a/tests/lib/p4workq/testcase.yaml
+++ b/tests/lib/p4workq/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   lib.p4wq:
+      integration_platforms:
+        - native_posix
       tags: p4wq


### PR DESCRIPTION
Set integration_platforms on these tests to just native_posix or are
relevant qemu platform.  This should be sufficient to make sure these
tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>