### PR TITLE
Add missing offset_adjust member in sync_info field of extended advertising header 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -89,6 +89,8 @@
 /* Offset Units field encoding */
 #define OFFS_UNIT_30_US         30
 #define OFFS_UNIT_300_US        300
+/* Value specified in BT Spec. Vol 6, Part B, section 2.3.4.6 */
+#define OFFS_ADJUST_US          245760
 
 /* transmitWindowDelay times (us) */
 #define WIN_DELAY_LEGACY     1250
@@ -331,9 +333,11 @@ struct pdu_adv_sync_info {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint16_t offs:13;
 	uint16_t offs_units:1;
-	uint16_t rfu:2;
+	uint16_t offs_adjust:1;
+	uint16_t rfu:1;
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint16_t rfu:2;
+	uint16_t rfu:1;
+	uint16_t offs_adjust:1;
 	uint16_t offs_units:1;
 	uint16_t offs:13;
 #else

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1018,6 +1018,10 @@ static inline void sync_info_fill(struct lll_adv_sync *lll_sync,
 
 	/* NOTE: sync offset and offset unit filled by secondary prepare */
 	si->offs_units = 0U;
+	/* If sync_info is part of ADV PDU the offs_adjust field
+	 * is always set to 0.
+	 */
+	si->offs_adjust = 0U;
 	si->offs = 0U;
 
 	sync = (void *)HDR_LLL2EVT(lll_sync);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -418,6 +418,8 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 
 	sync_offset_us = ftr->radio_end_us;
 	sync_offset_us += (uint32_t)si->offs * lll->window_size_event_us;
+	/* offs_adjust may be 1 only if sync setup by LL_PERIODIC_SYNC_IND */
+	sync_offset_us += (si->offs_adjust ? OFFS_ADJUST_US : 0U);
 	sync_offset_us -= PKT_AC_US(pdu->len, 0, lll->phy);
 	sync_offset_us -= EVENT_OVERHEAD_START_US;
 	sync_offset_us -= EVENT_JITTER_US;


### PR DESCRIPTION
Add missing offset_adjust member to `pdu_adv_sync_info`. Size of the `pdu_adv_sync_info` was correct, missing field was set as bit in RFU member.

Fix periodic_adv and periodic_scan samples, by selecting missing CONFIG_BT_CTLR_ADV_EXT config entry.