### PR TITLE
several improvements to lib/os/cbprintf_nano.c

### DIFF
--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -1,41 +1,49 @@
 /*
  * Copyright (c) 2010, 2013-2014 Wind River Systems, Inc.
  * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2021 BayLibre, SAS
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
 #include <sys/cbprintf.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <syscall_handler.h>
-#include <logging/log.h>
 #include <sys/types.h>
-
-enum pad_type {
-	PAD_NONE,
-	PAD_ZERO_BEFORE,
-	PAD_SPACE_BEFORE,
-	PAD_SPACE_AFTER,
-};
+#include <sys/util.h>
 
 #ifdef CONFIG_CBPRINTF_FULL_INTEGRAL
 typedef intmax_t int_value_type;
 typedef uintmax_t uint_value_type;
+#define DIGITS_BUFLEN 21
+BUILD_ASSERT(sizeof(uint_value_type) <= 8U,
+	     "DIGITS_BUFLEN may be incorrect");
 #else
 typedef int32_t int_value_type;
 typedef uint32_t uint_value_type;
+#define DIGITS_BUFLEN 10
 #endif
 
-/* Maximum number of digits in a printed decimal value (hex is always
- * less, obviously).  Funny formula produces 10 max digits for 32 bit,
- * 21 for 64.  It may be incorrect for other value lengths.
- */
-#define DIGITS_BUFLEN (11U * (sizeof(uint_value_type) / 4U) - 1U)
+#define ALPHA(fmt) (((fmt) & 0x60) - '0' - 10 + 1)
 
-BUILD_ASSERT(sizeof(uint_value_type) <= 8U,
-	     "DIGITS_BUFLEN formula may be incorrect");
+/* Convert value to string, storing characters downwards */
+static inline int convert_value(uint_value_type num, unsigned int base,
+				unsigned int alpha, char *buftop)
+{
+	int i = 0;
+
+	do {
+		unsigned int c = num % base;
+		if (c >= 10) {
+			c += alpha;
+		}
+		buftop[--i] = c + '0';
+		num /= base;
+	} while (num);
+
+	return -i;
+}
 
 #define OUTC(_c) do { \
 	out((int)(_c), ctx); \
@@ -44,76 +52,8 @@ BUILD_ASSERT(sizeof(uint_value_type) <= 8U,
 	} \
 } while (false)
 
-static void print_digits(cbprintf_cb out, void *ctx, uint_value_type num,
-			 unsigned int base, bool pad_before, char pad_char,
-			 int min_width, size_t *countp)
-{
-	size_t count = 0;
-	char buf[DIGITS_BUFLEN];
-	int i = 0;
-
-	/* Print it backwards, low digits first */
-	do {
-		char c = num % base;
-		if (c >= 10) {
-			c += 'a' - '0' - 10;
-		}
-		buf[i++] = c + '0';
-		num /= base;
-	} while (num);
-
-	int pad = MAX(min_width - i, 0);
-
-	for (/**/; pad > 0 && pad_before; pad--) {
-		OUTC(pad_char);
-	}
-	do {
-		OUTC(buf[--i]);
-	} while (i > 0);
-	for (/**/; pad > 0; pad--) {
-		OUTC(pad_char);
-	}
-
-	*countp += count;
-}
-
-static void print_hex(cbprintf_cb out, void *ctx, uint_value_type num,
-		      enum pad_type padding, int min_width, size_t *countp)
-{
-	print_digits(out, ctx, num, 16U, padding != PAD_SPACE_AFTER,
-		     padding == PAD_ZERO_BEFORE ? '0' : ' ', min_width,
-		     countp);
-}
-
-static void print_dec(cbprintf_cb out, void *ctx, uint_value_type num,
-		      enum pad_type padding, int min_width, size_t *countp)
-{
-	print_digits(out, ctx, num, 10U, padding != PAD_SPACE_AFTER,
-		     padding == PAD_ZERO_BEFORE ? '0' : ' ', min_width,
-		     countp);
-}
-
-static bool ok64(cbprintf_cb out, void *ctx, long long val, size_t *countp)
-{
-	size_t count = 0;
-
-	if (sizeof(int_value_type) < 8U && val != (int_value_type) val) {
-		const char *cp = "ERR";
-		do {
-			OUTC(*cp++);
-		} while (*cp);
-		*countp += count;
-		return false;
-	}
-	return true;
-}
-
-static bool negative(uint_value_type val)
-{
-	const uint_value_type hibit = ~(((uint_value_type) ~1) >> 1U);
-
-	return (val & hibit) != 0U;
-}
+#define PAD_ZERO	BIT(0)
+#define PAD_TAIL	BIT(1)
 
 /**
  * @brief Printk internals
@@ -122,175 +62,238 @@ static bool negative(uint_value_type val)
  * @param fmt Format string
  * @param ap Variable parameters
  *
- * @return N/A
+ * @return printed byte count if CONFIG_CBPRINTF_LIBC_SUBSTS is set
  */
 int cbvprintf(cbprintf_cb out, void *ctx, const char *fmt, va_list ap)
 {
 	size_t count = 0;
-	int might_format = 0; /* 1 if encountered a '%' */
-	enum pad_type padding = PAD_NONE;
-	int padlen, min_width = -1;
-	char length_mod = 0;
+	char buf[DIGITS_BUFLEN];
+	char *prefix, *data;
+	int min_width, precision, data_len;
+	char padding_mode, length_mod, special;
 
-	/* fmt has already been adjusted if needed */
-	while (*fmt) {
-		if (!might_format) {
-			if (*fmt != '%') {
-				OUTC(*fmt);
-			} else {
-				might_format = 1;
-				min_width = -1;
-				padding = PAD_NONE;
-				length_mod = 0;
+	/* we pre-increment in the loop  afterwards */
+	fmt--;
+
+start:
+	while (*++fmt != '%') {
+		if (*fmt == 0) {
+			return count;
+		}
+		OUTC(*fmt);
+	}
+
+	min_width = -1;
+	precision = -1;
+	prefix = "";
+	padding_mode = 0;
+	length_mod = 0;
+	special = 0;
+
+	for (fmt++ ; ; fmt++) {
+		switch (*fmt) {
+		case 0:
+			return count;
+
+		case '%':
+			OUTC('%');
+			goto start;
+
+		case '-':
+			padding_mode = PAD_TAIL;
+			continue;
+
+		case '.':
+			precision = 0;
+			padding_mode &= ~PAD_ZERO;
+			continue;
+
+		case '0':
+			if (min_width < 0 && precision < 0 && !padding_mode) {
+				padding_mode = PAD_ZERO;
+				continue;
 			}
-		} else {
-			switch (*fmt) {
-			case '-':
-				padding = PAD_SPACE_AFTER;
-				goto still_might_format;
-			case '0':
-				if (min_width < 0 && padding == PAD_NONE) {
-					padding = PAD_ZERO_BEFORE;
-					goto still_might_format;
-				}
-				__fallthrough;
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
+			__fallthrough;
+
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			if (precision >= 0) {
+				precision = 10 * precision + *fmt - '0';
+			} else {
 				if (min_width < 0) {
 					min_width = 0;
 				}
 				min_width = 10 * min_width + *fmt - '0';
-
-				if (padding == PAD_NONE) {
-					padding = PAD_SPACE_BEFORE;
-				}
-				goto still_might_format;
-			case 'h':
-			case 'l':
-			case 'z':
-				if (*fmt == 'h' && length_mod == 'h') {
-					length_mod = 'H';
-				} else if (*fmt == 'l' && length_mod == 'l') {
-					length_mod = 'L';
-				} else if (length_mod == 0) {
-					length_mod = *fmt;
-				} else {
-					OUTC('%');
-					OUTC(*fmt);
-					break;
-				}
-				goto still_might_format;
-			case 'd':
-			case 'i':
-			case 'u': {
-				uint_value_type d;
-
-				if (length_mod == 'z') {
-					d = va_arg(ap, ssize_t);
-				} else if (length_mod == 'l') {
-					d = va_arg(ap, long);
-				} else if (length_mod == 'L') {
-
-					long long lld = va_arg(ap,
-							       long long);
-					if (!ok64(out, ctx, lld, &count)) {
-						break;
-					}
-					d = (uint_value_type) lld;
-				} else if (*fmt == 'u') {
-					d = va_arg(ap, unsigned int);
-				} else {
-					d = va_arg(ap, int);
-				}
-
-				if (*fmt != 'u' && negative(d)) {
-					OUTC('-');
-					d = -d;
-					min_width--;
-				}
-				print_dec(out, ctx, d, padding, min_width,
-					  &count);
-				break;
 			}
-			case 'p':
-			case 'x':
-			case 'X': {
-				uint_value_type x;
+			continue;
 
-				if (*fmt == 'p') {
-					const char *cp;
-
-					x = (uintptr_t)va_arg(ap, void *);
-					if (x == 0) {
-						cp = "(nil)";
-					} else {
-						cp = "0x";
-					}
-
-					do {
-						OUTC(*cp++);
-					} while (*cp);
-					if (x == 0) {
-						padlen = min_width - 5;
-						goto pad_string;
-					}
-					min_width -= 2;
-				} else if (length_mod == 'l') {
-					x = va_arg(ap, unsigned long);
-				} else if (length_mod == 'L') {
-					x = va_arg(ap, unsigned long long);
-				} else {
-					x = va_arg(ap, unsigned int);
+		case '*':
+			if (precision >= 0) {
+				precision = va_arg(ap, int);
+			} else {
+				min_width = va_arg(ap, int);
+				if (min_width < 0) {
+					min_width = -min_width;
+					padding_mode = PAD_TAIL;
 				}
-
-				print_hex(out, ctx, x, padding, min_width,
-					  &count);
-				break;
 			}
-			case 's': {
-				char *s = va_arg(ap, char *);
-				char *start = s;
+			continue;
 
-				while (*s) {
-					OUTC(*s++);
-				}
-				padlen = min_width - (s - start);
+		case '+':
+		case ' ':
+		case '#':
+			special = *fmt;
+			continue;
 
-pad_string:
-				if (padding == PAD_SPACE_AFTER) {
-					while (padlen-- > 0) {
-						OUTC(' ');
-					}
-				}
-				break;
-			}
-			case 'c': {
-				int c = va_arg(ap, int);
-
-				OUTC(c);
-				break;
-			}
-			case '%': {
-				OUTC('%');
-				break;
-			}
-			default:
+		case 'h':
+		case 'l':
+		case 'z':
+			if (*fmt == 'h' && length_mod == 'h') {
+				length_mod = 'H';
+			} else if (*fmt == 'l' && length_mod == 'l') {
+				length_mod = 'L';
+			} else if (length_mod == 0) {
+				length_mod = *fmt;
+			} else {
 				OUTC('%');
 				OUTC(*fmt);
-				break;
+				goto start;
 			}
-			might_format = 0;
-		}
-still_might_format:
-		++fmt;
-	}
+			continue;
 
-	return count;
+		case 'd':
+		case 'i':
+		case 'u': {
+			uint_value_type d;
+
+			if (length_mod == 'z') {
+				d = va_arg(ap, ssize_t);
+			} else if (length_mod == 'l') {
+				d = va_arg(ap, long);
+			} else if (length_mod == 'L') {
+				long long lld = va_arg(ap, long long);
+
+				if (sizeof(int_value_type) < 8U &&
+				    lld != (int_value_type) lld) {
+					data = "ERR";
+					data_len = 3;
+					precision = 0;
+					break;
+				}
+				d = (uint_value_type) lld;
+			} else if (*fmt == 'u') {
+				d = va_arg(ap, unsigned int);
+			} else {
+				d = va_arg(ap, int);
+			}
+
+			if (*fmt != 'u' && (int_value_type)d < 0) {
+				d = -d;
+				prefix = "-";
+				min_width--;
+			} else if (special == ' ') {
+				prefix = " ";
+				min_width--;
+			} else if (special == '+') {
+				prefix = "+";
+				min_width--;
+			}
+			data_len = convert_value(d, 10, 0, buf + sizeof(buf));
+			data = buf + sizeof(buf) - data_len;
+			break;
+		}
+
+		case 'p':
+		case 'x':
+		case 'X': {
+			uint_value_type x;
+
+			if (*fmt == 'p') {
+				x = (uintptr_t)va_arg(ap, void *);
+				if (x == 0) {
+					data = "(nil)";
+					data_len = 5;
+					precision = 0;
+					break;
+				}
+				special = '#';
+			} else if (length_mod == 'l') {
+				x = va_arg(ap, unsigned long);
+			} else if (length_mod == 'L') {
+				x = va_arg(ap, unsigned long long);
+			} else {
+				x = va_arg(ap, unsigned int);
+			}
+			if (special == '#') {
+				prefix = (*fmt & 0x20) ? "0x" : "0X";
+				min_width -= 2;
+			}
+			data_len = convert_value(x, 16, ALPHA(*fmt),
+						 buf + sizeof(buf));
+			data = buf + sizeof(buf) - data_len;
+			break;
+		}
+
+		case 's': {
+			data = va_arg(ap, char *);
+			data_len = strlen(data);
+			if (precision >= 0 && data_len > precision) {
+				data_len = precision;
+			}
+			precision = 0;
+			break;
+		}
+
+		case 'c': {
+			int c = va_arg(ap, int);
+
+			buf[0] = c;
+			data = buf;
+			data_len = 1;
+			precision = 0;
+			break;
+		}
+
+		default:
+			OUTC('%');
+			OUTC(*fmt);
+			goto start;
+		}
+
+		if (precision < 0 && (padding_mode & PAD_ZERO)) {
+			precision = min_width;
+		}
+		min_width -= data_len;
+		precision -= data_len;
+		if (precision > 0) {
+			min_width -= precision;
+		}
+
+		if (!(padding_mode & PAD_TAIL)) {
+			while (--min_width >= 0) {
+				OUTC(' ');
+			}
+		}
+		while (*prefix) {
+			OUTC(*prefix++);
+		}
+		while (--precision >= 0) {
+			OUTC('0');
+		}
+		while (--data_len >= 0) {
+			OUTC(*data++);
+		}
+		while (--min_width >= 0) {
+			OUTC(' ');
+		}
+
+		goto start;
+	}
 }

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -117,8 +117,7 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	}
 
 	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) &&
-	    !IS_ENABLED(CONFIG_ARCH_POSIX)  &&
-	    !IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
+	    !IS_ENABLED(CONFIG_ARCH_POSIX)) {
 		/* print option name */
 		z_shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:", tabulator,
 				item_name_width, item_name, tabulator);

--- a/tests/unit/cbprintf/CMakeLists.txt
+++ b/tests/unit/cbprintf/CMakeLists.txt
@@ -2,5 +2,4 @@
 
 project(lib_os_cbprintf)
 set(SOURCES main.c)
-set(EXTRA_CPPFLAGS "-DCONFIG_CBPRINTF_LIBC_SUBSTS=1")
 find_package(ZephyrUnittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define CONFIG_CBPRINTF_LIBC_SUBSTS 1
 
 #include <ztest.h>
 #include <float.h>


### PR DESCRIPTION
Make lib/os/cbprintf_nano.c closer to standard printf behavior while
keeping it small.

Cherry-picked PR #32460 from @pabigot otherwise unit tests won't mean anything.

