### PR TITLE
samples: shields: lmp90100_evb: rtd: various fixes and improvements

### DIFF
--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -43,8 +43,8 @@ static double sqrt(double value)
 
 static double rtd_temperature(int nom, double resistance)
 {
-	double a0 =  3.90802E-3;
-	double b0 = -0.58020E-6;
+	const double a0 =  3.90802E-3;
+	const double b0 = -0.58020E-6;
 	double temp;
 
 	temp = -nom * a0;

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -8,6 +8,7 @@
 #include <device.h>
 #include <drivers/adc.h>
 #include <stdio.h>
+#include <math.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
@@ -25,6 +26,7 @@ LOG_MODULE_REGISTER(main);
 /* Bottom resistor value in ohms */
 #define BOTTOM_RESISTANCE 2000
 
+#ifndef CONFIG_NEWLIB_LIBC
 static double sqrt(double value)
 {
 	double sqrt = value / 3;
@@ -40,6 +42,7 @@ static double sqrt(double value)
 
 	return sqrt;
 }
+#endif /* CONFIG_NEWLIB_LIBC */
 
 static double rtd_temperature(int nom, double resistance)
 {

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -13,7 +13,17 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
+/* Nominal RTD (PT100) resistance in ohms */
 #define RTD_NOMINAL_RESISTANCE 100
+
+/* ADC resolution in bits */
+#define ADC_RESOLUTION 24U
+
+/* ADC maximum value (taking sign bit into consideration) */
+#define ADC_MAX BIT_MASK(ADC_RESOLUTION - 1)
+
+/* Bottom resistor value in ohms */
+#define BOTTOM_RESISTANCE 2000
 
 static double sqrt(double value)
 {
@@ -65,7 +75,7 @@ void main(void)
 		.channels = BIT(0),
 		.buffer = &buffer,
 		.buffer_size = sizeof(buffer),
-		.resolution = 24,
+		.resolution = ADC_RESOLUTION,
 		.oversampling = 0,
 		.calibrate = 0
 	};
@@ -87,7 +97,7 @@ void main(void)
 		if (err) {
 			LOG_ERR("failed to read ADC (err %d)", err);
 		} else {
-			resistance = (buffer / 8388608.0) * 2000;
+			resistance = (buffer / (double)ADC_MAX) * BOTTOM_RESISTANCE;
 			printf("R: %.02f ohm\n", resistance);
 			printf("T: %.02f degC\n",
 				rtd_temperature(RTD_NOMINAL_RESISTANCE,


### PR DESCRIPTION
This PR contains various small fixes and improvements to the TI LMP90100-EVB RTS sample:
- Improve the readability of the LMP90100-EVB RTD sample by adding comments and further definitions instead of magic values within the code.
- Fix an off-by-one error for the maximum ADC value used in the formula for calculating the resistance of the RTD (8388607 vs. 8388608).
- Mark the constant coeffiecients used in the RTD resistance to temperature conversion as const.
- Avoid using local sqrt() approximation when newlib is enabled.
