### PR TITLE
drivers: serial: stm32: Fix compile issues

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1393,14 +1393,18 @@ static int uart_stm32_set_power_state(const struct device *dev,
 
 	/* setting a low power mode */
 	if (new_state != DEVICE_PM_ACTIVE_STATE) {
+#ifdef USART_ISR_BUSY
 		/* Make sure that no USART transfer is on-going */
 		while (LL_USART_IsActiveFlag_BUSY(UartInstance) == 1) {
 		}
+#endif
 		while (LL_USART_IsActiveFlag_TC(UartInstance) == 0) {
 		}
+#ifdef USART_ISR_REACK
 		/* Make sure that USART is ready for reception */
 		while (LL_USART_IsActiveFlag_REACK(UartInstance) == 0) {
 		}
+#endif
 		/* Clear OVERRUN flag */
 		LL_USART_ClearFlag_ORE(UartInstance);
 		/* Leave UartInstance unchanged */


### PR DESCRIPTION
The stm32 uart driver fails to build on certian platforms due to
changes introduced by:

commit 3c18bcbf77da62f9f8fef0352520d7f1aa268dc1
Author: Francois Ramu <francois.ramu@st.com>
Date:   Wed Jan 27 10:27:33 2021 +0100

    drivers: serial: stm32 restore uart after lowpower

Fix this by adding some ifdef's around the code that is specific to the
given platforms that the code works on.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>