### PR TITLE
subsys: testsuite: enable TEST_ARM_CORTEX_M only when building tests

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -132,6 +132,7 @@ config TEST_FLASH_DRIVERS
 config TEST_ARM_CORTEX_M
 	bool
 	depends on CPU_CORTEX_M
+	depends on TEST
 	default y
 	select ARM_SECURE_BUSFAULT_HARDFAULT_NMI if ARM_SECURE_FIRMWARE
 	help


### PR DESCRIPTION
Add a dependency on TEST_ARM_CORTEX_M switch, so it
only gets switched on when building tests, not samples,
as originally intended.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>