### PR TITLE
Fix system configuration DTS

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
@@ -54,8 +54,8 @@
 
 		/* SCFG DEVALT 5 */
 		alt5_trace_en:     alt50     { alts = <&scfg 0x05 0x0 0>; };
-		alt5_njen1_en:     alt51     { alts = <&scfg 0x05 0x1 0>; };
-		alt5_njen0_en:     alt52     { alts = <&scfg 0x05 0x2 0>; };
+		alt5_njen1_en:     alt51     { alts = <&scfg 0x05 0x1 1>; };
+		alt5_njen0_en:     alt52     { alts = <&scfg 0x05 0x2 1>; };
 		alt5_strace_en:    alt54     { alts = <&scfg 0x05 0x4 0>; };
 
 		/* SCFG DEVALT 6 */

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -124,7 +124,7 @@
 			compatible = "nuvoton,npcx-pinctrl";
 			/* First reg region is System Configuration Device */
 			/* Second reg region is System Glue Device */
-			reg = <0x400c3000 0x2000
+			reg = <0x400c3000 0x70
 			       0x400a5000 0x2000>;
 			reg-names = "scfg", "glue";
 			#alt-cells = <3>;


### PR DESCRIPTION
This PR includes two fixes for system configuration device node:
1. fix the size of scfg register.
2. fix the invert field for alt5_njen0_en and alt5_njen1_en