### PR TITLE
Bluetooth: controller: Fix race between ULL and LLL when initiating connection

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -154,7 +154,6 @@ struct ull_hdr {
 
 struct lll_hdr {
 	void *parent;
-	uint8_t is_stop:1;
 };
 
 struct lll_prepare_param {
@@ -370,17 +369,6 @@ static inline void lll_hdr_init(void *lll, void *parent)
 	struct lll_hdr *hdr = lll;
 
 	hdr->parent = parent;
-	hdr->is_stop = 0U;
-}
-
-static inline int lll_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-	int ret = !!hdr->is_stop;
-
-	hdr->is_stop = 1U;
-
-	return ret;
 }
 
 int lll_init(void);

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -46,6 +46,7 @@ struct lll_conn {
 	uint8_t data_chan_count:6;
 	uint8_t data_chan_sel:1;
 	uint8_t role:1;
+	uint8_t initiated:1;
 
 	union {
 		struct {
@@ -59,6 +60,7 @@ struct lll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 	struct {
 		uint8_t  latency_enabled:1;
+
 		uint32_t window_widening_periodic_us;
 		uint32_t window_widening_max_us;
 		uint32_t window_widening_prepare_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1331,7 +1331,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
 					     devmatch_ok, &rl_idx) &&
-		   lll->conn) {
+		   lll->conn &&
+		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		int ret;
@@ -1365,6 +1366,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -659,7 +659,6 @@ static void isr_tx_connect_rsp(void *param)
 	struct node_rx_pdu *rx;
 	struct lll_adv *lll;
 	bool is_done;
-	int ret;
 
 	rx = param;
 	ftr = &(rx->hdr.rx_ftr);
@@ -687,9 +686,6 @@ static void isr_tx_connect_rsp(void *param)
 
 	if (is_done) {
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -14,12 +14,6 @@ int lll_is_abort_cb(void *next, int prio, void *curr,
 			 lll_prepare_cb_t *resume_cb, int *resume_prio);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
-static inline int lll_is_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-
-	return !!hdr->is_stop;
-}
 uint32_t lll_evt_offset_get(struct evt_hdr *evt);
 uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 		uint32_t ticks_at_event);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -768,7 +768,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if ((lll->conn) &&
+	} else if (lll->conn && !lll->conn->initiated &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;
@@ -924,6 +924,8 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -326,10 +326,11 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	DEBUG_RADIO_START_A(1);
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll_is_stop(lll)) {
+	if (lll->conn && lll->conn->initiated) {
 		int err;
 
 		err = lll_clk_off();
@@ -340,6 +341,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		DEBUG_RADIO_START_A(0);
 		return 0;
 	}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
@@ -900,7 +902,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
-		int ret;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -928,9 +929,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		}
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -896,7 +896,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
 		   isr_rx_ci_check(lll, pdu_adv, pdu_rx, devmatch_ok,
 				   &rl_idx) &&
-		   lll->conn) {
+		   lll->conn &&
+		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		int ret;
@@ -929,6 +930,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
@@ -14,13 +14,6 @@ int lll_is_abort_cb(void *next, int prio, void *curr,
 			 lll_prepare_cb_t *resume_cb, int *resume_prio);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
-static inline int lll_is_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-
-	return !!hdr->is_stop;
-}
-
 int lll_clk_on(void);
 int lll_clk_on_wait(void);
 int lll_clk_off(void);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -128,10 +128,11 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	DEBUG_RADIO_START_O(1);
 
+#if defined(CONFIG_BT_CENTRAL)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll_is_stop(lll)) {
+	if (lll->conn && lll->conn->initiated) {
 		int err;
 
 		err = lll_clk_off();
@@ -142,6 +143,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		DEBUG_RADIO_START_O(0);
 		return 0;
 	}
+#endif /* CONFIG_BT_CENTRAL */
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
@@ -686,7 +688,6 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		bt_addr_t *lrpa;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-		int ret;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -826,9 +827,6 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		 */
 
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -672,7 +672,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if ((lll->conn) &&
+	} else if (lll->conn && !lll->conn->initiated &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;
@@ -828,6 +828,8 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -872,6 +872,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 		/* FIXME: BEGIN: Move to ULL? */
 		conn_lll->role = 1;
+		conn_lll->initiated = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
 		conn_lll->event_counter = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -213,6 +213,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->data_chan_sel = 0;
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
+	conn_lll->initiated = 0;
 	/* FIXME: END: Move to ULL? */
 #if defined(CONFIG_BT_CTLR_CONN_META)
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));


### PR DESCRIPTION
When scanning, the LLL checks lll->conn to determine whether to send a
connection indication. That field is cleared in ull_master_setup. If
scanning is restarted before ull_master_setup has a chance to execute,
there is a risk that a second connection indication is sent. That in
turn would lead to ull_conn_setup being called a second time, with a
cleared lll->conn, resulting in a null-pointer access.

To avoid this race, a new flag is introduced to keep track of whether a
connection indication has already been sent for the respective
connection.

This change also removes the use of lll_stop, which was used to solve
the same race condition, but did not handle the case that more than one
scanner or advertiser could share the same connection object.