### PR TITLE
twisterlib: checking for classname and testname

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3473,7 +3473,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                         classname = p + ":" + ".".join(instance.testcase.name.split(".")[:2])
 
                     # remove testcases that are being re-run from exiting reports
-                    for tc in eleTestsuite.findall(f'testcase/[@classname="{classname}"]'):
+                    for tc in eleTestsuite.findall(f'testcase/[@classname="{classname}"][@name="{instance.testcase.name}"]'):
                         eleTestsuite.remove(tc)
 
                     eleTestcase = ET.SubElement(eleTestsuite, 'testcase',


### PR DESCRIPTION
Many tests have multiple tests defined within the same test classname.
So checking for the combination of classname and testname before
removing from the testlist for twister.xml

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>