### PR TITLE
Various testcase fixes

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -654,13 +654,6 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 {
 	__ASSERT(!arch_is_in_isr(), "Threads may not be created in ISRs");
 
-	/* Special case, only for unit tests */
-#if defined(CONFIG_TEST) && defined(CONFIG_ARCH_HAS_USERSPACE) && !defined(CONFIG_USERSPACE)
-	__ASSERT((options & K_USER) == 0,
-		 "Platform is capable of user mode, and test thread created with K_USER option,"
-		 " but neither CONFIG_TEST_USERSPACE nor CONFIG_USERSPACE is set\n");
-#endif
-
 	z_setup_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options, NULL);
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -296,6 +296,17 @@ void test_syscall_cpu_scrubs_regs(void)
 				"not scrubbed after system call.");
 	}
 }
+#else
+void test_syscall_cpu_scrubs_regs(void)
+{
+	ztest_test_skip();
+}
+
+void test_arm_syscalls(void)
+{
+	ztest_test_skip();
+}
+
 #endif /* CONFIG_USERSPACE */
 /**
  * @}

--- a/tests/arch/arm/arm_thread_swap/src/main.c
+++ b/tests/arch/arm/arm_thread_swap/src/main.c
@@ -13,12 +13,8 @@ extern void test_syscall_cpu_scrubs_regs(void);
 void test_main(void)
 {
 	ztest_test_suite(arm_thread_swap,
-		ztest_unit_test(test_arm_thread_swap));
-	ztest_run_test_suite(arm_thread_swap);
-#if defined(CONFIG_USERSPACE)
-	ztest_test_suite(arm_syscalls,
+		ztest_unit_test(test_arm_thread_swap),
 		ztest_unit_test(test_arm_syscalls),
 		ztest_user_unit_test(test_syscall_cpu_scrubs_regs));
-	ztest_run_test_suite(arm_syscalls);
-#endif
+	ztest_run_test_suite(arm_thread_swap);
 }

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -21,7 +21,7 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=n
     tags: kernel threads sched userspace
-  kernel.scheduler.dumb_no_timeslicing:
+  kernel.scheduler.dumb_timeslicing:
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=y

--- a/tests/kernel/threads/tls/src/main.c
+++ b/tests/kernel/threads/tls/src/main.c
@@ -183,17 +183,26 @@ static void start_tls_test(uint32_t thread_options)
 	zassert_true(passed, "Test failed");
 }
 
+#ifdef CONFIG_USERSPACE
+void test_tls(void)
+{
+	ztest_test_skip();
+}
+void test_tls_userspace(void)
+{
+	/* TLS test in supervisor mode */
+	start_tls_test(K_USER | K_INHERIT_PERMS);
+}
+#else
 void test_tls(void)
 {
 	/* TLS test in supervisor mode */
 	start_tls_test(0);
 }
 
-#ifdef CONFIG_USERSPACE
 void test_tls_userspace(void)
 {
-	/* TLS test in supervisor mode */
-	start_tls_test(K_USER | K_INHERIT_PERMS);
+	ztest_test_skip();
 }
 #endif
 
@@ -221,12 +230,8 @@ void test_main(void)
 #endif /* CONFIG_USERSPACE */
 
 	ztest_test_suite(thread_tls,
-			 ztest_unit_test(test_tls));
+			 ztest_unit_test(test_tls),
+			 ztest_user_unit_test(test_tls_userspace));
 	ztest_run_test_suite(thread_tls);
 
-#ifdef CONFIG_USERSPACE
-	ztest_test_suite(thread_tls_userspace,
-			 ztest_user_unit_test(test_tls_userspace));
-	ztest_run_test_suite(thread_tls_userspace);
-#endif /* CONFIG_USERSPACE */
 }


### PR DESCRIPTION
- remove duplicate IDs
- do not declare 2 testsuites, use skip instead.