### PR TITLE
Bluetooth: host: Don't auto-update device name and document behavior

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -136,6 +136,10 @@ int bt_enable(bt_ready_cb_t cb);
  *
  * Set Bluetooth GAP Device Name.
  *
+ * When advertising with device name in the advertising data the name should
+ * be updated by calling @ref bt_le_adv_update_data or
+ * @ref bt_le_ext_adv_set_data.
+ *
  * @param name New name
  *
  * @return Zero on success or (negative) error code otherwise.
@@ -368,7 +372,23 @@ enum {
 	 */
 	BT_LE_ADV_OPT_USE_IDENTITY = BIT(2),
 
-	/** Advertise using GAP device name */
+	/** Advertise using GAP device name.
+	 *
+	 *  Include the GAP device name automatically when advertising.
+	 *  By default the GAP device name is put at the end of the scan
+	 *  response data.
+	 *  When advertising using @ref BT_LE_ADV_OPT_EXT_ADV and not
+	 *  @ref BT_LE_ADV_OPT_SCANNABLE then it will be put at the end of the
+	 *  advertising data.
+	 *  If the GAP device name does not fit into advertising data it will be
+	 *  converted to a shortened name if possible.
+	 *
+	 *  The application can set the device name itself by including the
+	 *  following in the advertising data.
+	 *  @code
+	 *  BT_DATA(BT_DATA_NAME_COMPLETE, name, strlen(name))
+	 *  @endcode
+	 */
 	BT_LE_ADV_OPT_USE_NAME = BIT(3),
 
 	/**

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6664,7 +6664,6 @@ static int set_sd(struct bt_le_ext_adv *adv, const struct bt_ad *sd,
 int bt_set_name(const char *name)
 {
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
-	struct bt_le_ext_adv *adv = bt_adv_lookup_legacy();
 	size_t len = strlen(name);
 	int err;
 
@@ -6678,15 +6677,6 @@ int bt_set_name(const char *name)
 
 	strncpy(bt_dev.name, name, len);
 	bt_dev.name[len] = '\0';
-
-	/* Update advertising name if in use */
-	if (adv && atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME)) {
-		struct bt_data data[] = { BT_DATA(BT_DATA_NAME_COMPLETE, name,
-						len) };
-		struct bt_ad sd = { data, ARRAY_SIZE(data) };
-
-		set_sd(adv, &sd, 1);
-	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		err = settings_save_one("bt/name", bt_dev.name, len);


### PR DESCRIPTION
Don't auto-update the device name in the advertising data as that
would clear any other scan-response data set by the application.
Document the behavior of the advertise with device name option
and the need to update data by the application to make sure
advertising data does not get cleared.

Fixes: #27692

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>