### PR TITLE
device: abstract API to walk dependencies

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -162,6 +162,28 @@ bool z_device_ready(const struct device *dev)
 	return dev->state->initialized && (dev->state->init_res == 0);
 }
 
+int device_required_foreach(const struct device *dev,
+			  device_visitor_callback_t visitor_cb,
+			  void *context)
+{
+	size_t handle_count = 0;
+	const device_handle_t *handles =
+		device_required_handles_get(dev, &handle_count);
+
+	/* Iterate over fixed devices */
+	for (size_t i = 0; i < handle_count; ++i) {
+		device_handle_t dh = handles[i];
+		const struct device *rdev = device_from_handle(dh);
+		int rc = visitor_cb(rdev, context);
+
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	return handle_count;
+}
+
 #ifdef CONFIG_PM_DEVICE
 int device_pm_control_nop(const struct device *unused_device,
 			  uint32_t unused_ctrl_command,

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -74,23 +74,51 @@ static bool check_handle(device_handle_t hdl,
 	return false;
 }
 
+struct requires_context {
+	uint8_t ndevs;
+	const struct device *rdevs[2];
+};
+
+static int requires_visitor(const struct device *dev,
+			    void *context)
+{
+	struct requires_context *ctx = context;
+	const struct device **rdp = ctx->rdevs;
+
+	while (rdp < (ctx->rdevs + ctx->ndevs)) {
+		if (*rdp == NULL) {
+			*rdp = dev;
+			return 0;
+		}
+
+		++rdp;
+	}
+
+	return -ENOSPC;
+}
+
 static void test_requires(void)
 {
 	size_t nhdls = 0;
 	const device_handle_t *hdls;
 	const struct device *dev;
+	struct requires_context ctx = { 0 };
 
 	/* TEST_GPIO: no req */
 	dev = device_get_binding(DT_LABEL(TEST_GPIO));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
+		      NULL);
 
 	/* TEST_I2C: no req */
 	dev = device_get_binding(DT_LABEL(TEST_I2C));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(0, device_required_foreach(dev, requires_visitor, &ctx),
+		      NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
 	dev = device_get_binding(DT_LABEL(TEST_DEVA));
@@ -100,12 +128,39 @@ static void test_requires(void)
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls), NULL);
 
+	/* Visit fails if not enough space */
+	ctx = (struct requires_context){
+		.ndevs = 1,
+	};
+	zassert_equal(-ENOSPC, device_required_foreach(dev, requires_visitor, &ctx),
+		      NULL);
+
+	/* Visit succeeds if enough space. */
+	ctx = (struct requires_context){
+		.ndevs = 2,
+	};
+	zassert_equal(2, device_required_foreach(dev, requires_visitor, &ctx),
+		      NULL);
+	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)))
+		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
+		     NULL);
+	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_GPIO)))
+		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
+		     NULL);
+
 	/* TEST_GPIOX: TEST_I2C */
 	dev = device_get_binding(DT_LABEL(TEST_GPIOX));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIOX), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
+	ctx = (struct requires_context){
+		.ndevs = 3,
+	};
+	zassert_equal(1, device_required_foreach(dev, requires_visitor, &ctx),
+		      NULL);
+	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)),
+		     NULL);
 
 	/* TEST_DEVB: TEST_I2C TEST_GPIOX */
 	dev = device_get_binding(DT_LABEL(TEST_DEVB));


### PR DESCRIPTION
It's currently anticipated that we will need to support runtime registration of device dependencies.  In these cases there will not be a contiguous sequence that identifies all dependencies, as is the case with devicetree-defined dependencies.  So we'll need an API that is more flexible.

Add a visitor-pattern API to iterate over the devices, and switch to using this in existing code that wants to operate on dependency information.
