### PR TITLE
drivers: spi-nor: Add option to unlock flash areas

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -73,4 +73,12 @@ config SPI_NOR_IDLE_IN_DPD
 	  long periods, and when used the impact of waiting for mode
 	  enter and exit delays is acceptable.
 
+config SPI_NOR_UNLOCK_ON_STARTUP
+	bool "Unlock flash partitions on startup"
+	help
+	  Flash devices areas can be locked against erases and writes.
+	  This can be done with writing to the block protect bits in the
+	  status register. This option allows to unlock those areas on
+	  configuring the spi-nor device.
+
 endif # SPI_NOR

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -304,6 +304,12 @@ static int spi_nor_access(const struct device *const dev,
 #define spi_nor_cmd_addr_write(dev, opcode, addr, src, length) \
 	spi_nor_access(dev, opcode, true, addr, (void *)src, length, true)
 
+static inline int spi_nor_cmd_write_sr(const struct device *const dev,
+						uint8_t value)
+{
+	return spi_nor_access(dev, SPI_NOR_CMD_WRSR, false, 0, &value, 1, true);
+}
+
 #if defined(CONFIG_SPI_NOR_SFDP_RUNTIME) || defined(CONFIG_FLASH_JESD216_API)
 /*
  * @brief Read content from the SFDP hierarchy
@@ -908,6 +914,12 @@ static int spi_nor_configure(const struct device *dev)
 	    && (enter_dpd(dev) != 0)) {
 		return -ENODEV;
 	}
+
+#if defined(CONFIG_SPI_NOR_UNLOCK_ON_STARTUP)
+	spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
+	spi_nor_cmd_write_sr(dev, 0);
+	spi_nor_wait_until_ready(dev);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Flash devices areas can be locked against erases and writes.
This can be done with writing to the block protect bits in the
status register. This option allows to unlock those areas on
configuring the spi-nor device. This is implemented using
write 0 to the status register.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>