### PR TITLE
drivers: stm32: rtc: Add option to keep rtc value

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -81,4 +81,11 @@ config COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
 	help
 	  Force a backup domain reset on startup
 
+config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
+	bool "Save rtc time value between resets"
+	default y
+	depends on !COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
+	help
+	  Do not reset the rtc time and date after each reset.
+
 endif # COUNTER_RTC_STM32

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -359,9 +359,11 @@ static int rtc_stm32_init(const struct device *dev)
 
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 
+#if !defined(CONFIG_COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS)
 	if (LL_RTC_DeInit(RTC) != SUCCESS) {
 		return -EIO;
 	}
+#endif
 
 	if (LL_RTC_Init(RTC, ((LL_RTC_InitTypeDef *)
 			      &cfg->ll_rtc_config)) != SUCCESS) {


### PR DESCRIPTION
Add option to keep rtc value between resets.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>

In my opinion this should be the default configuration and `COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET`
should be set to `n` by default.