### PR TITLE
AArch64: Make SMC helpers more useful

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -38,6 +38,12 @@ config ARM_CUSTOM_INTERRUPT_CONTROLLER
 	       family cores. The Cortex-M family cores are always equipped with
 	       the ARM Nested Vectored Interrupt Controller (NVIC).
 
+config HAS_ARM_SMCCC
+	bool
+	help
+	  Include support for the Secure Monitor Call (SMC) and Hypervisor
+	  Call (HVC) instructions on Armv7 and above architectures.
+
 if !ARM64
 rsource "core/aarch32/Kconfig"
 endif

--- a/arch/arm/core/aarch64/CMakeLists.txt
+++ b/arch/arm/core/aarch64/CMakeLists.txt
@@ -22,7 +22,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE ../common/tls.c)
-zephyr_library_sources_ifdef(CONFIG_ARM_PSCI smccc-call.S)
+zephyr_library_sources_ifdef(CONFIG_HAS_ARM_SMCCC smccc-call.S)
 zephyr_library_sources_ifdef(CONFIG_AARCH64_IMAGE_HEADER header.S)
 
 add_subdirectory_ifdef(CONFIG_ARM_MMU mmu)

--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -9,6 +9,7 @@ config CPU_CORTEX_A
 	select HAS_FLASH_LOAD_OFFSET
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
+	select HAS_ARM_SMCCC
 	help
 	  This option signifies the use of a CPU of the Cortex-A family.
 

--- a/arch/arm/core/aarch64/smccc-call.S
+++ b/arch/arm/core/aarch64/smccc-call.S
@@ -8,7 +8,7 @@
  * This file implements the common calling mechanism to be used with the Secure
  * Monitor Call (SMC) and Hypervisor Call (HVC).
  *
- * See http://infocenter.arm.com/help/topic/com.arm.doc.den0028a/index.html
+ * See https://developer.arm.com/docs/den0028/latest
  */
 
 #include <toolchain.h>

--- a/arch/arm/core/aarch64/smccc-call.S
+++ b/arch/arm/core/aarch64/smccc-call.S
@@ -14,12 +14,13 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>
+#include <offsets_short.h>
 
 .macro SMCCC instr
 	\instr  #0
 	ldr     x4, [sp]
-	stp     x0, x1, [x4]
-	stp     x2, x3, [x4, #16]
+	stp     x0, x1, [x4, __arm_smccc_res_t_a0_a1_OFFSET]
+	stp     x2, x3, [x4, __arm_smccc_res_t_a2_a3_OFFSET]
 	ret
 .endm
 

--- a/arch/arm/core/aarch64/smccc-call.S
+++ b/arch/arm/core/aarch64/smccc-call.S
@@ -21,6 +21,8 @@
 	ldr     x4, [sp]
 	stp     x0, x1, [x4, __arm_smccc_res_t_a0_a1_OFFSET]
 	stp     x2, x3, [x4, __arm_smccc_res_t_a2_a3_OFFSET]
+	stp     x4, x5, [x4, __arm_smccc_res_t_a4_a5_OFFSET]
+	stp     x6, x7, [x4, __arm_smccc_res_t_a6_a7_OFFSET]
 	ret
 .endm
 

--- a/arch/arm/core/offsets/offsets_aarch64.c
+++ b/arch/arm/core/offsets/offsets_aarch64.c
@@ -52,4 +52,13 @@ GEN_NAMED_OFFSET_SYM(_esf_t, x0, x0_x1);
 
 GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
 
+#ifdef CONFIG_HAS_ARM_SMCCC
+
+#include <arch/arm/arm-smccc.h>
+
+GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a0, a0_a1);
+GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a2, a2_a3);
+
+#endif /* CONFIG_HAS_ARM_SMCCC */
+
 #endif /* _ARM_OFFSETS_INC_ */

--- a/arch/arm/core/offsets/offsets_aarch64.c
+++ b/arch/arm/core/offsets/offsets_aarch64.c
@@ -58,6 +58,8 @@ GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
 
 GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a0, a0_a1);
 GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a2, a2_a3);
+GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a4, a4_a5);
+GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a6, a6_a7);
 
 #endif /* CONFIG_HAS_ARM_SMCCC */
 

--- a/drivers/psci/Kconfig
+++ b/drivers/psci/Kconfig
@@ -6,6 +6,7 @@
 config ARM_PSCI
 	bool "Support for the ARM Power State Coordination Interface (PSCI)"
 	depends on ARMV8_A
+	depends on HAS_ARM_SMCCC
 	help
 	  Say Y here if you want Zephyr to communicate with system firmware
 	  implementing the PSCI specification for CPU-centric power

--- a/include/arch/arm/arm-smccc.h
+++ b/include/arch/arm/arm-smccc.h
@@ -9,13 +9,17 @@
 
 /*
  * Result from SMC/HVC call
- * @a0-a3 result values from registers 0 to 3
+ * @a0-a7 result values from registers 0 to 7
  */
 struct arm_smccc_res {
 	unsigned long a0;
 	unsigned long a1;
 	unsigned long a2;
 	unsigned long a3;
+	unsigned long a4;
+	unsigned long a5;
+	unsigned long a6;
+	unsigned long a7;
 };
 
 typedef struct arm_smccc_res arm_smccc_res_t;

--- a/include/arch/arm/arm-smccc.h
+++ b/include/arch/arm/arm-smccc.h
@@ -18,6 +18,8 @@ struct arm_smccc_res {
 	unsigned long a3;
 };
 
+typedef struct arm_smccc_res arm_smccc_res_t;
+
 enum arm_smccc_conduit {
 	SMCCC_CONDUIT_NONE,
 	SMCCC_CONDUIT_SMC,


### PR DESCRIPTION
Patchset to make the SMCCC decoupled from PSCI  so that it can be used by other drivers / applications when they need to call into the secure monitor.