### PR TITLE
doc: west: make it clearer how to override the default runner

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -381,6 +381,19 @@ the default with::
 
   west flash --runner jlink
 
+You can override the default flash runner at build time by using the
+``BOARD_FLASH_RUNNER`` CMake variable, and the debug runner with
+``BOARD_DEBUG_RUNNER``.
+
+For example::
+
+  # Set the default runner to "jlink", overriding the board's
+  # usual default.
+  west build [...] -- -DBOARD_FLASH_RUNNER=jlink
+
+See :ref:`west-building-cmake-args` and :ref:`west-building-cmake-config` for
+more information on setting CMake arguments.
+
 See :ref:`west-runner` below for more information on the ``runner``
 library used by West. The list of runners which support flashing can
 be obtained with ``west flash -H``; if run from a build directory or


### PR DESCRIPTION
Though BOARD_FLASH_RUNNER and BOARD_DEBUG_RUNNER are documented in the
debug host tools page, these variables are important enough to deserve
mention in the section dedicated to choosing a runner. Make it so.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>