### PR TITLE
cmake: warn if it's too late to set a boilerplate variable

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -478,6 +478,9 @@ unset(CONF_FILE CACHE)
 
 zephyr_file(CONF_FILES ${APPLICATION_SOURCE_DIR}/boards DTS APP_BOARD_DTS)
 
+# The CONF_FILE variable is now set to its final value.
+zephyr_boilerplate_watch(CONF_FILE)
+
 if(DTC_OVERLAY_FILE)
   # DTC_OVERLAY_FILE has either been specified on the cmake CLI or is already
   # in the CMakeCache.txt. This has precedence over the environment
@@ -514,6 +517,9 @@ include(${ZEPHYR_BASE}/cmake/host-tools.cmake)
 
 # Include board specific device-tree flags before parsing.
 include(${BOARD_DIR}/pre_dt_board.cmake OPTIONAL)
+
+# The DTC_OVERLAY_FILE variable is now set to its final value.
+zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
 
 # DTS should be close to kconfig because CONFIG_ variables from
 # kconfig and dts should be available at the same time.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2108,7 +2108,44 @@ function(zephyr_check_cache variable)
   # Store the specified variable in parent scope and the cache
   set(${variable} ${${variable}} PARENT_SCOPE)
   set(CACHED_${variable} ${${variable}} CACHE STRING "Selected ${variable_text}")
+
+  # The variable is now set to its final value.
+  zephyr_boilerplate_watch(${variable})
 endfunction(zephyr_check_cache variable)
+
+
+# Usage:
+#   zephyr_boilerplate_watch(SOME_BOILERPLATE_VAR)
+#
+# Inform the build system that SOME_BOILERPLATE_VAR, a variable
+# handled in cmake/app/boilerplate.cmake, is now fixed and should no
+# longer be changed.
+#
+# This function uses variable_watch() to print a noisy warning
+# if the variable is set after it returns.
+function(zephyr_boilerplate_watch variable)
+  variable_watch(${variable} zephyr_variable_set_too_late)
+endfunction()
+
+function(zephyr_variable_set_too_late variable access value current_list_file)
+  if (access STREQUAL "MODIFIED_ACCESS")
+    message(WARNING
+"
+   **********************************************************************
+   *
+   *                    WARNING
+   *
+   * CMake variable ${variable} set to \"${value}\" in:
+   *     ${current_list_file}
+   *
+   * This is too late to make changes! The change was ignored.
+   *
+   * Hint: ${variable} must be set before calling find_package(Zephyr ...).
+   *
+   **********************************************************************
+")
+  endif()
+endfunction()
 
 # Usage:
 #   zephyr_get_targets(<directory> <types> <targets>)


### PR DESCRIPTION
Several variables must be set by the time boilerplate.cmake is run.
This includes BOARD, SHIELD, CONF_FILE, and DTC_OVERLAY_FILE.

It's not always clear to users that this is the case, and we sometimes
see attempts to modify these variables in app CMakeLists.txt files
after find_package(Zephyr ...) lines, where they will have no effect.
This causes confusion.

Add a new extension function, zephyr_boilerplate_watch(), which traps
attempts to set these variables and prints a noisy warning. Use it
from boilerplate.cmake on the variables mentioned above.

This will hopefully make it clearer at build time why the changes are
being ignored.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>