### PR TITLE
MAINTAINERS: update collaborators in Nuvoton platforms.

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1211,6 +1211,8 @@ Nuvoton Platforms:
         - MulinChao
         - sjg20
         - jackrosenthal
+        - ChiHuaL
+        - WealianLiao
     files:
         - soc/arm/nuvoton/
         - boards/arm/npcx*/


### PR DESCRIPTION
Add Nuvoton developers, ChiHuaL and WealianLiao, as collaborators for
Nuvoton platforms in MAINTAINERS.yaml.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>