### PR TITLE
Bluetooth: controller: Extended create connection cancel

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -53,6 +53,7 @@
 #include "ull_scan_internal.h"
 #include "ull_sync_internal.h"
 #include "ull_sync_iso_internal.h"
+#include "ull_master_internal.h"
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 #include "ull_central_iso_internal.h"
@@ -1085,27 +1086,7 @@ void ll_rx_mem_release(void **node_rx)
 
 #if defined(CONFIG_BT_CENTRAL)
 			} else if (cc->status == BT_HCI_ERR_UNKNOWN_CONN_ID) {
-				struct node_rx_ftr *ftr = &rx_free->rx_ftr;
-				struct ll_scan_set *scan =
-					(void *)HDR_LLL2EVT(ftr->param);
-				struct lll_conn *conn_lll;
-				struct ll_conn *conn;
-				memq_link_t *link;
-
-				conn_lll = scan->lll.conn;
-				LL_ASSERT(conn_lll);
-				scan->lll.conn = NULL;
-
-				LL_ASSERT(!conn_lll->link_tx_free);
-				link = memq_deinit(&conn_lll->memq_tx.head,
-						   &conn_lll->memq_tx.tail);
-				LL_ASSERT(link);
-				conn_lll->link_tx_free = link;
-
-				conn = (void *)HDR_LLL2EVT(conn_lll);
-				ll_conn_release(conn);
-
-				scan->is_enabled = 0U;
+				ull_master_cleanup(rx_free);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 #if defined(CONFIG_BT_BROADCASTER)

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -394,22 +394,47 @@ uint8_t ll_connect_enable(uint8_t is_coded_included)
 
 uint8_t ll_connect_disable(void **rx)
 {
+	struct ll_scan_set *scan_coded;
+	struct lll_scan *scan_lll;
 	struct lll_conn *conn_lll;
 	struct ll_scan_set *scan;
-	uint8_t status;
+	uint8_t err;
 
-	scan = ull_scan_is_enabled_get(0);
-	if (!scan) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+	scan = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) &&
+	    IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+		scan_coded = ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+	} else {
+		scan_coded = NULL;
 	}
 
-	conn_lll = scan->lll.conn;
+	if (!scan) {
+		if (!scan_coded) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
+
+		scan_lll = &scan_coded->lll;
+	} else {
+		scan_lll = &scan->lll;
+	}
+
+	conn_lll = scan_lll->conn;
 	if (!conn_lll) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	status = ull_scan_disable(0, scan);
-	if (!status) {
+	if (scan) {
+		err = ull_scan_disable(SCAN_HANDLE_1M, scan);
+	} else {
+		err = 0U;
+	}
+
+	if (!err && scan_coded) {
+		err = ull_scan_disable(SCAN_HANDLE_PHY_CODED, scan_coded);
+	}
+
+	if (!err) {
 		struct ll_conn *conn = (void *)HDR_LLL2EVT(conn_lll);
 		struct node_rx_pdu *node_rx;
 		struct node_rx_cc *cc;
@@ -435,12 +460,12 @@ uint8_t ll_connect_disable(void **rx)
 		 *       LLL context for other cases, pass LLL context as
 		 *       parameter.
 		 */
-		node_rx->hdr.rx_ftr.param = &scan->lll;
+		node_rx->hdr.rx_ftr.param = scan_lll;
 
 		*rx = node_rx;
 	}
 
-	return status;
+	return err;
 }
 
 /* FIXME: Refactor out this interface so that its usable by extended
@@ -554,6 +579,46 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand,
 	return BT_HCI_ERR_CMD_DISALLOWED;
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+void ull_master_cleanup(struct node_rx_hdr *rx_free)
+{
+	struct node_rx_ftr *ftr = &rx_free->rx_ftr;
+	struct ll_scan_set *scan =
+		(void *)HDR_LLL2EVT(ftr->param);
+	struct lll_conn *conn_lll;
+	struct ll_conn *conn;
+	memq_link_t *link;
+
+	conn_lll = scan->lll.conn;
+	LL_ASSERT(conn_lll);
+	scan->lll.conn = NULL;
+
+	LL_ASSERT(!conn_lll->link_tx_free);
+	link = memq_deinit(&conn_lll->memq_tx.head,
+			   &conn_lll->memq_tx.tail);
+	LL_ASSERT(link);
+	conn_lll->link_tx_free = link;
+
+	conn = (void *)HDR_LLL2EVT(conn_lll);
+	ll_conn_release(conn);
+
+	scan->is_enabled = 0U;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
+	scan->lll.phy = 0U;
+
+	struct ll_scan_set *scan_coded =
+				ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+	if (scan_coded && scan_coded != scan) {
+		conn_lll = scan_coded->lll.conn;
+		LL_ASSERT(conn_lll);
+		scan_coded->lll.conn = NULL;
+
+		scan_coded->is_enabled = 0U;
+		scan_coded->lll.phy = 0U;
+	}
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
+}
 
 void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		      struct node_rx_ftr *ftr, struct lll_conn *lll)

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -98,6 +98,12 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	lll = &scan->lll;
 	lll_coded = &scan_coded->lll;
 
+	/* NOTE: When coded PHY is supported, and connection establishment
+	 *       over coded PHY is selected by application then look for
+	 *       a connection context already assigned to 1M PHY scanning
+	 *       context. Use the same connection context in the coded PHY
+	 *       scanning context.
+	 */
 	if (phy & BT_HCI_LE_EXT_SCAN_PHY_CODED) {
 		if (!lll_coded->conn) {
 			lll_coded->conn = lll->conn;
@@ -119,6 +125,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 
+	/* NOTE: non-zero PHY value enables initiating connection on that PHY */
 	lll->phy = phy;
 
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
@@ -589,6 +596,11 @@ void ull_master_cleanup(struct node_rx_hdr *rx_free)
 	struct ll_conn *conn;
 	memq_link_t *link;
 
+	/* NOTE: `scan` variable can be 1M PHY or coded PHY scanning context.
+	 *       Single connection context is allocated in both the 1M PHY and
+	 *       coded PHY scanning context, hence releasing only this one
+	 *       connection context.
+	 */
 	conn_lll = scan->lll.conn;
 	LL_ASSERT(conn_lll);
 	scan->lll.conn = NULL;
@@ -602,11 +614,17 @@ void ull_master_cleanup(struct node_rx_hdr *rx_free)
 	conn = (void *)HDR_LLL2EVT(conn_lll);
 	ll_conn_release(conn);
 
+	/* 1M PHY is disabled here if both 1M and coded PHY was enabled for
+	 * connection establishment.
+	 */
 	scan->is_enabled = 0U;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
 	scan->lll.phy = 0U;
 
+	/* Determine if coded PHY was also enabled, if so, reset the assigned
+	 * connection context, enabled flag and phy value.
+	 */
 	struct ll_scan_set *scan_coded =
 				ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
 	if (scan_coded && scan_coded != scan) {

--- a/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+void ull_master_cleanup(struct node_rx_hdr *rx_free);
 void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		      struct node_rx_ftr *ftr, struct lll_conn *lll);
 void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,


### PR DESCRIPTION
Initial work in progress implementation of Create Connection
Cancel for Extended connection initiation.

Adds implementation to teardown connection initiated at ULL
layer and gracefully release allocated resources.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>