### PR TITLE
ARC: fix mpu version number

### DIFF
--- a/arch/arc/core/mpu/Kconfig
+++ b/arch/arc/core/mpu/Kconfig
@@ -9,7 +9,7 @@ config ARC_MPU_VER
 	default 2
 	help
 	  ARC MPU has several versions. For MPU v2, the minimum region is 2048 bytes;
-	  For MPU v3, the minimum region is 32 bytes
+	  For MPU v3 and v4, the minimum region is 32 bytes
 
 config ARC_CORE_MPU
 	bool "ARC Core MPU functionalities"
@@ -33,6 +33,6 @@ config ARC_MPU
 	select THREAD_STACK_INFO
 	select GEN_PRIV_STACKS if ARC_MPU_VER = 2
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT if ARC_MPU_VER = 2
-	select MPU_REQUIRES_NON_OVERLAPPING_REGIONS if ARC_MPU_VER = 3
+	select MPU_REQUIRES_NON_OVERLAPPING_REGIONS if ARC_MPU_VER = 4
 	help
 	  Target has ARC MPU (currently only works for EMSK 2.2/2.3 ARCEM7D)

--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -54,6 +54,6 @@ static inline uint32_t get_region_attr_by_type(uint32_t type)
 
 #if CONFIG_ARC_MPU_VER == 2
 #include "arc_mpu_v2_internal.h"
-#elif CONFIG_ARC_MPU_VER == 3
-#include "arc_mpu_v3_internal.h"
+#elif CONFIG_ARC_MPU_VER == 4
+#include "arc_mpu_v4_internal.h"
 #endif

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V3_INTERNAL_H_
-#define ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V3_INTERNAL_H_
+#ifndef ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_
+#define ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_
 
 #define AUX_MPU_RPER_SID1       0x10000
 /* valid mask: SID1+secure+valid */
@@ -12,13 +12,13 @@
 
 #define AUX_MPU_RPER_ATTR_MASK (0x1FF)
 
-/* For MPU version 3, the minimum protection region size is 32 bytes */
+/* For MPU version 4, the minimum protection region size is 32 bytes */
 #define ARC_FEATURE_MPU_ALIGNMENT_BITS 5
 
 #define CALC_REGION_END_ADDR(start, size) \
 	(start + size - (1 << ARC_FEATURE_MPU_ALIGNMENT_BITS))
 
-/* ARC MPU version 3 does not support mpu region overlap in hardware
+/* ARC MPU version 4 does not support mpu region overlap in hardware
  * so if we want to allocate MPU region dynamically, e.g. thread stack,
  * memory domain from a background region, a dynamic region splitting
  * approach is designed. pls see comments in
@@ -521,7 +521,7 @@ void arc_core_mpu_disable(void)
 void arc_core_mpu_configure_thread(struct k_thread *thread)
 {
 #if defined(CONFIG_MPU_GAP_FILLING)
-/* the mpu entries of ARC MPUv3 are divided into 2 parts:
+/* the mpu entries of ARC MPUv4 are divided into 2 parts:
  * static entries: global mpu entries, not changed in context switch
  * dynamic entries: MPU entries changed in context switch and
  * memory domain configure, including:
@@ -785,7 +785,7 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
 	int key = arch_irq_lock();
 
 	/*
-	 * For ARC MPU v3, overlapping is not supported.
+	 * For ARC MPU v4, overlapping is not supported.
 	 * we can stop the iteration immediately once we find the
 	 * matched region that grants permission or denies access.
 	 */
@@ -893,4 +893,4 @@ static int arc_mpu_init(const struct device *arg)
 SYS_INIT(arc_mpu_init, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
-#endif /* ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V3_INTERNAL_H_ */
+#endif /* ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_ */

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -129,8 +129,8 @@ done_cache_invalidate:
  * substitution of normal hardware reset sequence.
  */
 #ifdef CONFIG_INIT_ARCH_HW_AT_BOOT
-	/* Set MPU (v3) registers to default */
-#if CONFIG_ARC_MPU_VER == 3
+	/* Set MPU (v4) registers to default */
+#if CONFIG_ARC_MPU_VER == 4
 	/* Set default reset value to _ARC_V2_MPU_EN register */
 #define ARC_MPU_EN_RESET_VALUE 0x400181C0
 	mov_s r1, ARC_MPU_EN_RESET_VALUE

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -52,13 +52,13 @@ extern "C" {
  *
  * For regions that are NOT the minimum size, this define has no semantics
  * on ARC MPUv2 as its regions must be power of two size and aligned to their
- * own size. On ARC MPUv3, region sizes are arbitrary and this just indicates
+ * own size. On ARC MPUv4, region sizes are arbitrary and this just indicates
  * the required size granularity.
  */
 #ifdef CONFIG_ARC_CORE_MPU
 #if CONFIG_ARC_MPU_VER == 2
 #define Z_ARC_MPU_ALIGN	2048
-#elif CONFIG_ARC_MPU_VER == 3
+#elif CONFIG_ARC_MPU_VER == 4
 #define Z_ARC_MPU_ALIGN	32
 #else
 #error "Unsupported MPU version"
@@ -244,7 +244,7 @@ BUILD_ASSERT(CONFIG_PRIVILEGED_STACK_SIZE % Z_ARC_MPU_ALIGN == 0,
 		"the size of the partition must be power of 2" \
 		" and greater than or equal to the mpu adddress alignment." \
 		"start address of the partition must align with size.")
-#elif CONFIG_ARC_MPU_VER == 3
+#elif CONFIG_ARC_MPU_VER == 4
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
 	BUILD_ASSERT((size) % Z_ARC_MPU_ALIGN == 0 && \
 		     (size) >= Z_ARC_MPU_ALIGN && \

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -30,7 +30,7 @@
 #ifdef CONFIG_ARC_MPU_ENABLE
 	#if CONFIG_ARC_MPU_VER == 2
 		#define MPU_MIN_SIZE 2048
-	#elif CONFIG_ARC_MPU_VER == 3
+	#elif CONFIG_ARC_MPU_VER == 4
 		#define MPU_MIN_SIZE 32
 	#endif
 	#define MPU_MIN_SIZE_ALIGN . = ALIGN(MPU_MIN_SIZE);

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
@@ -10,7 +10,7 @@ config CPU_EM4_FPUDA
 	default y
 
 config ARC_MPU_VER
-	default 3
+	default 4
 
 config RGF_NUM_BANKS
 	default 1

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em7d
@@ -18,7 +18,7 @@ config NUM_IRQS
 	default 36 if BOARD_EM_STARTERKIT_R22
 
 config ARC_MPU_VER
-	default 3 if BOARD_EM_STARTERKIT_R23
+	default 4 if BOARD_EM_STARTERKIT_R23
 	default 2 if BOARD_EM_STARTERKIT_R22
 
 config RGF_NUM_BANKS

--- a/soc/arc/snps_nsim/Kconfig.defconfig.sem
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.sem
@@ -16,7 +16,7 @@ config NUM_IRQS
 	default 30
 
 config ARC_MPU_VER
-	default 3
+	default 4
 
 config RGF_NUM_BANKS
 	default 1


### PR DESCRIPTION
ARC mpu version used a wrong number 3, could cause conflict in future.
This PR fixes this issue to version number 4.

Fixes #31416
