### PR TITLE
soc: npcx: add support for npcx7m6fc & npcx7m7fc

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m6fb
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m6fb
@@ -6,6 +6,6 @@
 if SOC_NPCX7M6FB
 
 config SOC
-	default "npcx76mfb"
+	default "npcx7m6fb"
 
 endif # SOC_NPCX7M6FB

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m6fc
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m6fc
@@ -1,0 +1,11 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NPCX7M6FC
+
+config SOC
+	default "npcx7m6fc"
+
+endif # SOC_NPCX7M6FC

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m7fc
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.npcx7m7fc
@@ -1,0 +1,11 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NPCX7M7FC
+
+config SOC
+	default "npcx7m7fc"
+
+endif # SOC_NPCX7M7FC

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.soc
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.soc
@@ -4,11 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-	prompt "NPCX7M6FB Selection"
+	prompt "NPCX7 Selection"
 	depends on SOC_SERIES_NPCX7
 
 config SOC_NPCX7M6FB
 	bool "NPCX7M6FB"
+
+config SOC_NPCX7M6FC
+	bool "NPCX7M6FC"
+
+config SOC_NPCX7M7FC
+	bool "NPCX7M7FC"
 
 endchoice
 

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -51,13 +51,13 @@ extern uint32_t _irq_vector_table[];
  * the board.
  */
 #define TEST_NUM_IRQS	30
-#elif defined(CONFIG_SOC_NPCX7M6FB)
-/* In NPCX7M6FB, it uses some the IRQs at the end of the vector table, for
+#elif defined(CONFIG_SOC_SERIES_NPCX7)
+/* In NPCX7 series, it uses some the IRQs at the end of the vector table, for
  * example, the irq 60 and 61 used for Multi-Input Wake-Up Unit (MIWU) device
  * by default, and conflicts with isr used for testing. Move IRQs for this
  * test suite to solve the issue.
  */
-#define TEST_NUM_IRQS	42
+#define TEST_NUM_IRQS	46
 #else
 #define TEST_NUM_IRQS	CONFIG_NUM_IRQS
 #endif


### PR DESCRIPTION
This PR adds support for npcx7m6fc & npcx7m7fc soc.
Also, change the "TEST_NUM_IRQS" for gen_isr_tables test & got the following pass message:
```
*** Booting Zephyr OS build zephyr-v2.5.0-390-gd8283b63ec6f  ***
START - Test gen_isr_tables
IRQ configuration (total lines 64):
Running test suite context
===================================================================
START - test_build_time_direct_interrupt
isr1 isr=0x100904c9 irq=45
isr2 isr=0x10090535 irq=44
Checking _irq_vector_table entry 45 for irq 45
triggering irq 45
isr1 ran
Checking _irq_vector_table entry 44 for irq 44
triggering irq 44
isr2 ran
 PASS - test_build_time_direct_interrupt
===================================================================
START - test_build_time_interrupt
_sw_isr_table at location 0x200c0160
isr3 isr=0x10090439 irq=43 param=0xb01dface
Checking _sw_isr_table entry 43 for irq 43
triggering irq 43
isr3 ran with parameter 0xb01dface
isr4 isr=0x1009045d irq=42 param=0xca55e77e
Checking _sw_isr_table entry 42 for irq 42
triggering irq 42
isr4 ran with parameter 0xca55e77e
 PASS - test_build_time_interrupt
===================================================================
START - test_run_time_interrupt
isr5 isr=0x10090481 irq=41 param=0xf0ccac1a
Checking _sw_isr_table entry 41 for irq 41
triggering irq 41
isr5 ran with parameter 0xf0ccac1a
isr6 isr=0x100904a5 irq=40 param=0xba5eba11
Checking _sw_isr_table entry 40 for irq 40
triggering irq 40
isr6 ran with parameter 0xba5eba11
 PASS - test_run_time_interrupt
===================================================================
Test suite context succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```