### PR TITLE
net: lwm2m: Make query buffer large enough to encode all query strings 

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1040,6 +1040,7 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 
 	set_sm_state(ENGINE_INIT);
 	strncpy(client.ep_name, ep_name, CLIENT_EP_LEN - 1);
+	client.ep_name[CLIENT_EP_LEN - 1] = '\0';
 	LOG_INF("Start LWM2M Client: %s", log_strdup(client.ep_name));
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -116,8 +116,12 @@ struct lwm2m_rd_client_info {
 	bool update_objects : 1;
 } client;
 
-/* buffers */
-static char query_buffer[64]; /* allocate some data for queries and updates */
+/* Allocate some data for queries and updates. Make sure it's large enough to
+ * hold the largest query string, which in most cases will be the endpoint
+ * string. In other case, 32 bytes are enough to encode any other query string
+ * documented in the LwM2M specification.
+ */
+static char query_buffer[MAX(32, sizeof("ep=") + CLIENT_EP_LEN)];
 static uint8_t client_data[256]; /* allocate some data for the RD */
 
 void engine_update_tx_time(void)


### PR DESCRIPTION
Make sure query string used by the lwm2m_rd_client is large enough to
encode any query string that can be sent during bootstrap/registration.
As the maximum query string length is related to the endpoint name,
which is limited by `CONFIG_LWM2M_RD_CLIENT_ENDPOINT_NAME_MAX_LENGTH`,
make the query string corellated to the value of this config.

Fixes #32566