### PR TITLE
tests: net: select: Increase the timeout to 20ms

### DIFF
--- a/tests/net/socket/select/src/main.c
+++ b/tests/net/socket/select/src/main.c
@@ -23,8 +23,8 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #define SERVER_PORT 4242
 #define CLIENT_PORT 9898
 
-/* On QEMU, poll() which waits takes +10ms from the requested time. */
-#define FUZZ 10
+/* On QEMU, poll() which waits takes +20ms from the requested time. */
+#define FUZZ 20
 
 void test_fd_set(void)
 {


### PR DESCRIPTION
The timeout might take more than 10ms in a heavily loaded system,
so increase the timeout to 20ms.

For example this is often seen for mps2_an385 platform.

  Assertion failed at \
  WEST_TOPDIR/zephyr/tests/net/socket/select/src/main.c:101: \
  test_select: (tstamp <= FUZZ is false)

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>