### PR TITLE
aarch64: mem_domain: Introduce k_mem_partition_attr_t

### DIFF
--- a/include/arch/arm/aarch64/arch.h
+++ b/include/arch/arm/aarch64/arch.h
@@ -29,6 +29,7 @@
 #include <arch/arm/aarch64/sys_io.h>
 #include <arch/arm/aarch64/timer.h>
 #include <arch/arm/aarch64/error.h>
+#include <arch/arm/aarch64/arm_mmu.h>
 #include <arch/common/addr_types.h>
 #include <arch/common/sys_bitops.h>
 #include <arch/common/ffs.h>
@@ -36,6 +37,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef _ASMLANGUAGE
 
 /**
  * @brief Declare the ARCH_STACK_PTR_ALIGN
@@ -45,6 +48,36 @@ extern "C" {
  *
  */
 #define ARCH_STACK_PTR_ALIGN	16
+
+/* Kernel macros for memory attribution
+ * (access permissions and cache-ability).
+ *
+ * The macros are to be stored in k_mem_partition_attr_t
+ * objects. The format of a k_mem_partition_attr_t object
+ * is an uint32_t composed by permission and attribute flags
+ * located in include/arch/arm/aarch64/arm_mmu.h
+ */
+
+/* Read-Write access permission attributes */
+#define K_MEM_PARTITION_P_RW_U_RW ((k_mem_partition_attr_t) \
+	{MT_P_RW_U_RW})
+#define K_MEM_PARTITION_P_RW_U_NA ((k_mem_partition_attr_t) \
+	{MT_P_RW_U_NA})
+#define K_MEM_PARTITION_P_RO_U_RO ((k_mem_partition_attr_t) \
+	{MT_P_RO_U_RO})
+#define K_MEM_PARTITION_P_RO_U_NA ((k_mem_partition_attr_t) \
+	{MT_P_RO_U_NA})
+
+/* Execution-allowed attributes */
+#define K_MEM_PARTITION_P_RX_U_RX ((k_mem_partition_attr_t) \
+	{MT_P_RX_U_RX})
+
+/* Typedef for the k_mem_partition attribute */
+typedef struct {
+	uint32_t attrs;
+} k_mem_partition_attr_t;
+
+#endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus
 }

--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -1,2 +1,3 @@
+k_mem_partition_attr_t
 mbedtls_pk_context
 z_arch_esf_t


### PR DESCRIPTION
Introduce the kernel macros for memory attribution also for AArch64.

Pushing this PR as a standalone change (instead of being part of the huge PR that will come later to which this belongs) because it can possibly fails on CI due to checkpatch complaining about `WARNING:NEW_TYPEDEFS` and pushing this as a singleton can speed up the process of guaranteeing an all green CI on the subsequent PRs instead of slowing everything down because of a failing CI on a bogus checkpatch warning.