### PR TITLE
Bluetooth: L2CAP: Fix missing buffer length check for sdu_len

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2189,6 +2189,12 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 		return;
 	}
 
+	if (buf->len < 2) {
+		BT_WARN("Too short data packet");
+		bt_l2cap_chan_disconnect(&chan->chan);
+		return;
+	}
+
 	sdu_len = net_buf_pull_le16(buf);
 
 	BT_DBG("chan %p len %u sdu_len %u", chan, buf->len, sdu_len);


### PR DESCRIPTION
We should verify that the buffer has sufficient data before attempting
to parse the SDU length field.

Fixes #32497

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>