### PR TITLE
drivers: usb_dc_stm32: remove confusing comments

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1,5 +1,3 @@
-/* USB device controller driver for STM32 devices */
-
 /*
  * Copyright (c) 2017 Christer Weinigel.
  * Copyright (c) 2017, I-SENSE group of ICCS
@@ -9,39 +7,11 @@
 
 /**
  * @file
- * @brief USB device controller driver for STM32 devices
+ * @brief USB device controller shim driver for STM32 devices
  *
  * This driver uses the STM32 Cube low level drivers to talk to the USB
  * device controller on the STM32 family of devices using the
  * STM32Cube HAL layer.
- *
- * There is a bit of an impedance mismatch between the Zephyr
- * usb_device and the STM32 Cube HAL layer where higher levels make
- * assumptions about the low level drivers that don't quite match how
- * the low level drivers actually work.
- *
- * The usb_dc_ep_read function expects to get the data it wants
- * immediately while the HAL_PCD_EP_Receive function only starts a
- * read transaction and the data won't be available until call to
- * HAL_PCD_DataOutStageCallback. To work around this I've
- * had to add an extra packet buffer in the driver which wastes memory
- * and also leads to an extra copy of all received data.  It would be
- * better if higher drivers could call start_read and get_read_count
- * in this driver directly.
- *
- * To enable the driver together with the CDC_ACM high level driver,
- * add the following to your board's defconfig:
- *
- * CONFIG_USB=y
- * CONFIG_USB_DC_STM32=y
- * CONFIG_USB_CDC_ACM=y
- * CONFIG_USB_DEVICE_STACK=y
- *
- * To use the USB device as a console, also add:
- *
- * CONFIG_UART_CONSOLE_ON_DEV_NAME="CDC_ACM"
- * CONFIG_USB_UART_CONSOLE=y
- * CONFIG_UART_LINE_CTRL=y
  */
 
 #include <soc.h>


### PR DESCRIPTION
The comments at the beginning of the file are not quite correct
and instructions regarding configuration are not necessary at all.
Also remove the redundant first line.