### PR TITLE
Clean up runners dependency handling

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -326,7 +326,10 @@ def use_runner_cls(command, board, args, runners_yaml, cache):
                 fatal=True)
         log.inf(f'To fix, configure this runner in {board_cmake} and rebuild.')
         sys.exit(1)
-    runner_cls = get_runner_cls(runner)
+    try:
+        runner_cls = get_runner_cls(runner)
+    except ValueError as e:
+        log.die(e)
     if command.name not in runner_cls.capabilities().commands:
         log.die(f'runner {runner} does not support command {command.name}')
 

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -22,6 +22,12 @@ from west.commands import CommandError
 from west.configuration import config
 import yaml
 
+from zephyr_ext_common import ZEPHYR_SCRIPTS
+
+# Runners depend on edtlib. Make sure the copy in the tree is
+# available to them before trying to import any.
+sys.path.append(str(ZEPHYR_SCRIPTS / 'dts'))
+
 from runners import get_runner_cls, ZephyrBinaryRunner, MissingProgram
 from runners.core import RunnerConfig
 import zcmake

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -2,34 +2,54 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
+import logging
+
 from runners.core import ZephyrBinaryRunner, MissingProgram
+
+_logger = logging.getLogger('runners')
+
+def _import_runner_module(runner_name):
+    try:
+        importlib.import_module(f'runners.{runner_name}')
+    except ImportError:
+        # Runners are supposed to gracefully handle failures when they
+        # import anything outside of stdlib, but they sometimes do
+        # not. Catch ImportError to handle this.
+        _logger.warning(f'The module for runner "{runner_name}" '
+                        'could not be imported. This most likely means '
+                        'it is not handling its dependencies properly. '
+                        'Please report this to the zephyr developers.')
 
 # We import these here to ensure the ZephyrBinaryRunner subclasses are
 # defined; otherwise, ZephyrBinaryRunner.get_runners() won't work.
 
-# Explicitly silence the unused import warning.
-# flake8: noqa: F401
-# Keep this list sorted by runner name.
-from runners import blackmagicprobe
-from runners import bossac
-from runners import canopen_program
-from runners import dediprog
-from runners import dfu
-from runners import esp32
-from runners import hifive1
-from runners import intel_s1000
-from runners import jlink
-from runners import misc
-from runners import nios2
-from runners import nrfjprog
-from runners import nsim
-from runners import openocd
-from runners import pyocd
-from runners import qemu
-from runners import stm32flash
-from runners import xtensa
-from runners import mdb
-from runners import stm32cubeprogrammer
+_names = [
+    'blackmagicprobe',
+    'bossac',
+    'canopen_program',
+    'dediprog',
+    'dfu',
+    'esp32',
+    'hifive1',
+    'intel_s1000',
+    'jlink',
+    'mdb',
+    'misc',
+    'nios2',
+    'nrfjprog',
+    'nsim',
+    'openocd',
+    'pyocd',
+    'qemu',
+    'stm32cubeprogrammer',
+    'stm32flash',
+    'xtensa',
+    # Keep this list sorted by runner name; don't add to the end.
+]
+
+for _name in _names:
+    _import_runner_module(_name)
 
 def get_runner_cls(runner):
     '''Get a runner's class object, given its name.'''

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -9,14 +9,18 @@ import pathlib
 import pickle
 import platform
 import subprocess
-import sys
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
-from zephyr_ext_common import ZEPHYR_SCRIPTS
 
 # This is needed to load edt.pickle files.
-sys.path.append(str(ZEPHYR_SCRIPTS / 'dts'))
-import edtlib  # pylint: disable=unused-import
+try:
+    import edtlib  # pylint: disable=unused-import
+    MISSING_EDTLIB = False
+except ImportError:
+    # This can happen when building the documentation for the
+    # runners package if edtlib is not on sys.path. This is fine
+    # to ignore in that case.
+    MISSING_EDTLIB = True
 
 DEFAULT_BOSSAC_PORT = '/dev/ttyACM0'
 DEFAULT_BOSSAC_SPEED = '115200'
@@ -185,6 +189,11 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         return cmd_flash
 
     def do_run(self, command, **kwargs):
+        if MISSING_EDTLIB:
+            self.logger.warning(
+                'could not import edtlib; something may be wrong with the '
+                'python environment')
+
         if platform.system() == 'Windows':
             msg = 'CAUTION: BOSSAC runner not support on Windows!'
             raise RuntimeError(msg)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -9,13 +9,18 @@ import os
 import platform
 import re
 import shlex
+from subprocess import TimeoutExpired
 import sys
 import tempfile
 
-from packaging import version
 from runners.core import ZephyrBinaryRunner, RunnerCaps, \
     BuildConfiguration
-from subprocess import TimeoutExpired
+
+try:
+    from packaging import version
+    MISSING_REQUIREMENTS = False
+except ImportError:
+    MISSING_REQUIREMENTS = True
 
 DEFAULT_JLINK_EXE = 'JLink.exe' if sys.platform == 'win32' else 'JLinkExe'
 DEFAULT_JLINK_GDB_PORT = 2331
@@ -141,6 +146,11 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         return version.parse(ver) >= version.parse("6.80")
 
     def do_run(self, command, **kwargs):
+        if MISSING_REQUIREMENTS:
+            raise RuntimeError('one or more Python dependencies were missing; '
+                               "see the getting started guide for details on "
+                               "how to fix")
+
         server_cmd = ([self.gdbserver] +
                       ['-select', 'usb', # only USB connections supported
                        '-port', str(self.gdb_port),


### PR DESCRIPTION
The bossac runner is breaking the rule that only stdlib imports can be used without handling ImportError.

In this case, it's importing edtlib. That's legitimate for all runners, so make it possible to import edtlib in individual runners without having to touch sys.path to let bossac just `import edtlib` without looking for `ZEPHYR_SCRIPTS`. 

I've been bitten by this sort of thing one too many times. Add an extra layer of error handling in `runners/__init__.py` to turn an import error for an individual runner into a warning.

A runner that follows the rules will never cause an ImportError here, and a runner that doesn't might not even be relevant to the user's environment, so the ImportError should not be fatal. If the user tries to use the runner and it couldn't be imported, they'll still get an error from `get_runner_cls()`.