### PR TITLE
 dts: pinctrl: Introduce pincfg-node and convert Atmel SAM as example

### DIFF
--- a/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
@@ -1,11 +1,22 @@
 # Copyright (c) 2020, Linaro Limited
+# Copyright (c) 2021, Gerson Fernando Budke
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM Pinctrl container node
+description: |
+  Atmel SAM Pinctrl container node
+
+  The Atmel SAM pins implements following pin configuration option:
+
+    * bias-pull-up
+    * bias-pull-down
+    * drive-open-drain
+
+  These options define devicetree flags that are converted to SoC flags at
+  ATMEL_SAM_PIN_FLAGS().
 
 compatible: "atmel,sam-pinctrl"
 
-include: [base.yaml]
+include: [base.yaml, pincfg-node.yaml]
 
 properties:
     "#address-cells":
@@ -16,22 +27,7 @@ properties:
       const: 1
 
 child-binding:
-    description: atmel pins
+    description: Atmel pins
     properties:
       "atmel,pins":
         type: phandle-array
-
-      bias-pull-up:
-        required: false
-        type: boolean
-        description: pull up the pin
-
-      bias-pull-down:
-        required: false
-        type: boolean
-        description: pull down the pin
-
-      drive-open-drain:
-        required: false
-        type: boolean
-        description: drive with open drain

--- a/dts/bindings/pinctrl/pincfg-node.yaml
+++ b/dts/bindings/pinctrl/pincfg-node.yaml
@@ -1,0 +1,160 @@
+# Copyright (c) 2020, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Generic pin configuration schema
+
+child-binding:
+    description: |
+      Many data items that are represented in a pin configuration node are
+      common and generic. Pin control bindings should use the properties
+      defined below where they are applicable; not all of these properties are
+      relevant or useful for all hardware or binding structures. Each
+      individual binding document should state which of these generic
+      properties, if any, are used, and the structure of the DT nodes that
+      contain these properties.
+
+      This is based on Linux, documentation:
+        https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/pincfg-node.yaml
+
+    properties:
+      bias-disable:
+        required: false
+        type: boolean
+        description: disable any pin bias
+
+      bias-high-impedance:
+        required: false
+        type: boolean
+        description: high impedance mode ("third-state", "floating")
+
+      bias-bus-hold:
+        required: false
+        type: boolean
+        description: latch weakly
+
+      bias-pull-up:
+        required: false
+        type: boolean
+        description: enable pull-up resistor
+
+      bias-pull-down:
+        required: false
+        type: boolean
+        description: enable pull-down resistor
+
+      bias-pull-pin-default:
+        required: false
+        type: boolean
+        description: use pin's default pull state
+
+      drive-push-pull:
+        required: false
+        type: boolean
+        description: drive actively high and low
+
+      drive-open-drain:
+        required: false
+        type: boolean
+        description: drive with open drain (hardware AND)
+
+      drive-open-source:
+        required: false
+        type: boolean
+        description: drive with open source (hardware OR)
+
+      drive-strength:
+        required: false
+        type: int
+        description: maximum sink or source current in mA
+
+      drive-strength-microamp:
+        required: false
+        type: int
+        description: maximum sink or source current in μA
+
+      input-enable:
+        required: false
+        type: boolean
+        description: |
+          enable input on pin (no effect on output, such as enabling an input
+          buffer)
+
+      input-disable:
+        required: false
+        type: boolean
+        description: |
+          disable input on pin (no effect on output, such as disabling an input
+          buffer)
+
+      input-schmitt-enable:
+        required: false
+        type: boolean
+        description: enable schmitt-trigger mode
+
+      input-schmitt-disable:
+        required: false
+        type: boolean
+        description: disable schmitt-trigger mode
+
+      input-debounce:
+        required: false
+        type: int
+        description: |
+          Takes the debounce time in μsec, as argument or 0 to disable debouncing
+
+      power-source:
+        required: false
+        type: int
+        description: select between different power supplies
+
+      low-power-enable:
+        required: false
+        type: boolean
+        description: enable low power mode
+
+      low-power-disable:
+        required: false
+        type: boolean
+        description: disable low power mode
+
+      output-disable:
+        required: false
+        type: boolean
+        description: disable output on a pin (such as disable an output buffer)
+
+      output-enable:
+        required: false
+        type: boolean
+        description: |
+          enable output on a pin without actively driving it (such as enabling
+          an output buffer)
+
+      output-low:
+        required: false
+        type: boolean
+        description: set the pin to output mode with low level
+
+      output-high:
+        required: false
+        type: boolean
+        description: set the pin to output mode with high level
+
+      sleep-hardware-state:
+        required: false
+        type: boolean
+        description: |
+          indicate this is sleep related state which will be programmed into
+          the registers for the sleep state
+
+      slew-rate:
+        required: false
+        type: int
+        description: set the slew rate
+
+      skew-delay:
+        required: false
+        type: int
+        description: |
+          This affects the expected clock skew on input pins and the delay
+          before latching a value to an output pin. Typically indicates how
+          many double-inverters are used to delay the signal.


### PR DESCRIPTION
Many data items that are represented in a pin configuration node are common and generic.  Pin control bindings should use the properties defined on a standard way when are applicable; not all of these properties are relevant or useful for all hardware or binding structures.  Each individual binding document should state which of these generic properties, if any, are used, and the structure of the DT nodes that contain these properties. This intents to have a standard name in devicetree and be closer to Linux to easy understanding.

This is based on Linux, documentation:
https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/pincfg-node.yaml

The Atmel SAM was converted to use pincfg-node schema as an example for other follows.
Since this is platform dependent the best path is introduce the common schema and than migrate platforms when appropriated.
