### PR TITLE
boards: bbc_microbit_v2: add missing i2c0 compatible

### DIFF
--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -88,6 +88,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <16>;


### PR DESCRIPTION
The board's main I2C bus controller doesn't have a compatible set, so
it's not detected as an I2C bus at all.

This breaks the build when trying to build the samples/sensor/lis2dh
application with the lis2dh sensor on that bus.

Fixes: #32420
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>