### PR TITLE
drivers: ieee802154_nrf5: Fix initialization order

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -555,6 +555,8 @@ static int nrf5_init(const struct device *dev)
 
 	nrf_802154_init();
 
+	nrf5_get_capabilities_at_boot();
+
 	nrf5_radio_cfg->irq_config_func(dev);
 
 	k_thread_create(&nrf5_radio->rx_thread, nrf5_radio->rx_stack,
@@ -581,7 +583,6 @@ static void nrf5_iface_init(struct net_if *iface)
 	nrf5_radio->iface = iface;
 
 	ieee802154_init(iface);
-	nrf5_get_capabilities_at_boot();
 }
 
 static int nrf5_configure(const struct device *dev,


### PR DESCRIPTION
The driver was reworked recently so that driver capabilites are
obtained at runtime. The function to obtain the capabilities was
called after L2 initialization though, which is invalid as L2
initialization code already depends on certain driver capabilites.

Move the capability initializer to an earliest possible stage
(i. e. just after the core driver is initialized) to fix the issue.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>