### PR TITLE
Bluetooth: controller: Fix missing cond. compile of adv extra data

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -57,7 +57,10 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
  */
 struct adv_pdu_field_data {
 	uint8_t *field_data;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
 	void *extra_data;
+#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
 };
 
 /* helper function to handle adv done events */


### PR DESCRIPTION
Fix missing conditional compilation of Advertising PDU's
exta data member.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>