### PR TITLE
Bluetooth: controller: openisa: Fix unsupported ISR profiling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa.cmake
+++ b/subsys/bluetooth/controller/ll_sw/openisa.cmake
@@ -37,10 +37,6 @@ if(CONFIG_BT_LL_SW_SPLIT)
     CONFIG_BT_CTLR_DTM
     ll_sw/openisa/lll/lll_test.c
   )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_CTLR_PROFILE_ISR
-    ll_sw/openisa/lll/lll_test.c
-  )
 endif()
 
 zephyr_library_sources_ifdef(


### PR DESCRIPTION
Fix duplicate include of lll_test.c file under the
unsupported ISR profiling feature in OpenISA port.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>