### PR TITLE
Bluetooth: controller: Remove vendor specific internal LLL include

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -26,21 +26,28 @@
 
 #include "util/util.h"
 #include "util/memq.h"
+
 #include "hal/ecb.h"
 #include "hal/ccm.h"
+
 #include "ll_sw/pdu.h"
+
 #include "ll_sw/lll.h"
+#include "lll/lll_adv_types.h"
 #include "ll_sw/lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "ll_sw/lll_sync_iso.h"
 #include "ll_sw/lll_scan.h"
 #include "ll_sw/lll_sync.h"
 #include "ll_sw/lll_conn.h"
 #include "ll_sw/lll_conn_iso.h"
+
 #include "ll_sw/ull_adv_types.h"
 #include "ll_sw/ull_scan_types.h"
 #include "ll_sw/ull_sync_types.h"
 #include "ll_sw/ull_conn_types.h"
 #include "ll_sw/ull_conn_iso_types.h"
+
 #include "ll.h"
 #include "ll_feat.h"
 #include "ll_settings.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -15,19 +15,20 @@
 #include "util/util.h"
 #include "util/memq.h"
 
-#include "hal/cpu.h"
-
 #include "pdu.h"
-#include "ll.h"
-#include "lll.h"
 
+#include "lll.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
+
+#include "ll.h"
 
 static uint8_t pub_addr[BDADDR_SIZE];
 static uint8_t rnd_addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -19,20 +19,22 @@
 
 #include "pdu.h"
 
-#include "ll.h"
 #include "lll.h"
-
-#include "lll_scan.h"
-#include "ull_scan_types.h"
-#include "ull_scan_internal.h"
-
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
-#include "ull_adv_types.h"
-#include "ull_adv_internal.h"
-
+#include "lll/lll_adv_pdu.h"
+#include "lll_scan.h"
 #include "lll_conn.h"
+
+#include "ull_adv_types.h"
+#include "ull_scan_types.h"
 #include "ull_conn_types.h"
+
+#include "ull_adv_internal.h"
+#include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
+
+#include "ll.h"
 
 uint8_t ll_tx_pwr_lvl_get(uint8_t handle_type,
 		       uint16_t handle, uint8_t type, int8_t *tx_pwr_lvl)

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "lll_adv_pdu.h"
-
 struct lll_adv_iso {
 	struct lll_hdr hdr;
 	struct lll_adv *adv;

--- a/subsys/bluetooth/controller/ll_sw/lll_df.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_df.h
@@ -6,3 +6,6 @@
 
 int lll_df_init(void);
 int lll_df_reset(void);
+
+/* Provides number of available antennae for Direction Finding */
+uint8_t lll_df_ant_num_get(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -29,19 +29,20 @@
 #include "lll.h"
 #include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll_adv_pdu.h"
 #include "lll_adv_aux.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"
+#include "lll_df_types.h"
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
-#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 #include "lll_df_internal.h"
-#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -25,7 +25,9 @@
 #include "lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_chan.h"
+#include "lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll_adv_pdu.h"
 #include "lll_adv_aux.h"
 #include "lll_filter.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_internal.h
@@ -4,114 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int lll_adv_data_init(struct lll_adv_pdu *pdu);
-int lll_adv_data_reset(struct lll_adv_pdu *pdu);
-int lll_adv_data_release(struct lll_adv_pdu *pdu);
-
-struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx);
-
-int lll_adv_and_extra_data_release(struct lll_adv_pdu *pdu);
-struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
-						 void **extra_data,
-						 uint8_t *idx);
-
-static inline void lll_adv_pdu_enqueue(struct lll_adv_pdu *pdu, uint8_t idx)
-{
-	pdu->last = idx;
-}
-
-static inline struct pdu_adv *lll_adv_data_alloc(struct lll_adv *lll, uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->adv_data, idx);
-}
-
-static inline void lll_adv_data_enqueue(struct lll_adv *lll, uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->adv_data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_data_peek(struct lll_adv *lll)
-{
-	return (void *)lll->adv_data.pdu[lll->adv_data.last];
-}
-
-static inline struct pdu_adv *lll_adv_scan_rsp_alloc(struct lll_adv *lll,
-						     uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->scan_rsp, idx);
-}
-
-static inline void lll_adv_scan_rsp_enqueue(struct lll_adv *lll, uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->scan_rsp, idx);
-}
-
-static inline struct pdu_adv *lll_adv_scan_rsp_peek(struct lll_adv *lll)
-{
-	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.last];
-}
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
-static inline struct pdu_adv *lll_adv_aux_data_alloc(struct lll_adv_aux *lll,
-						     uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->data, idx);
-}
-
-static inline void lll_adv_aux_data_enqueue(struct lll_adv_aux *lll,
-					    uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_aux_data_peek(struct lll_adv_aux *lll)
-{
-	return (void *)lll->data.pdu[lll->data.last];
-}
-
-#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
-static inline struct pdu_adv *lll_adv_sync_data_alloc(struct lll_adv_sync *lll,
-						      void **extra_data,
-						      uint8_t *idx)
-{
-#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
-	return lll_adv_pdu_and_extra_data_alloc(&lll->data, extra_data, idx);
-#else
-	return lll_adv_pdu_alloc(&lll->data, idx);
-#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
-}
-
-static inline void lll_adv_sync_data_release(struct lll_adv_sync *lll)
-{
-#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
-	lll_adv_and_extra_data_release(&lll->data);
-#else
-	lll_adv_data_release(&lll->data);
-#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
-}
-
-static inline void lll_adv_sync_data_enqueue(struct lll_adv_sync *lll,
-					     uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_sync_data_peek(struct lll_adv_sync *lll,
-						     void **extra_data)
-{
-	uint8_t last = lll->data.last;
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
-	if (extra_data) {
-		*extra_data = lll->data.extra_data[last];
-	}
-#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
-
-	return (void *)lll->data.pdu[last];
-}
-#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
-
 struct pdu_adv *lll_adv_pdu_latest_get(struct lll_adv_pdu *pdu,
 				       uint8_t *is_modified);
 
@@ -134,11 +26,6 @@ static inline struct pdu_adv *lll_adv_scan_rsp_latest_get(struct lll_adv *lll,
 	return lll_adv_pdu_latest_get(&lll->scan_rsp, is_modified);
 }
 
-static inline struct pdu_adv *lll_adv_data_curr_get(struct lll_adv *lll)
-{
-	return (void *)lll->adv_data.pdu[lll->adv_data.first];
-}
-
 static inline struct pdu_adv *lll_adv_scan_rsp_curr_get(struct lll_adv *lll)
 {
 	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.first];
@@ -149,11 +36,6 @@ static inline struct pdu_adv *
 lll_adv_aux_data_latest_get(struct lll_adv_aux *lll, uint8_t *is_modified)
 {
 	return lll_adv_pdu_latest_get(&lll->data, is_modified);
-}
-
-static inline struct pdu_adv *lll_adv_aux_data_curr_get(struct lll_adv_aux *lll)
-{
-	return (void *)lll->data.pdu[lll->data.first];
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -1,28 +1,125 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Structure used to double buffer pointers of AD Data PDU buffer.
- * The first and last members are used to make modification to AD data to be
- * context safe. Thread always appends or updates the buffer pointed to
- * the array element indexed by the member last.
- * LLL in the ISR context, checks, traverses to the valid pointer indexed
- * by the member first, such that the buffer is the latest committed by
- * the thread context.
- */
-struct lll_adv_pdu {
-	uint8_t volatile first;
-	uint8_t          last;
-	uint8_t          *pdu[DOUBLE_BUFFER_SIZE];
+int lll_adv_data_init(struct lll_adv_pdu *pdu);
+int lll_adv_data_reset(struct lll_adv_pdu *pdu);
+int lll_adv_data_release(struct lll_adv_pdu *pdu);
+
+static inline void lll_adv_pdu_enqueue(struct lll_adv_pdu *pdu, uint8_t idx)
+{
+	pdu->last = idx;
+}
+
+struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx);
+
+static inline struct pdu_adv *lll_adv_data_alloc(struct lll_adv *lll,
+						 uint8_t *idx)
+{
+	return lll_adv_pdu_alloc(&lll->adv_data, idx);
+}
+
+static inline void lll_adv_data_enqueue(struct lll_adv *lll, uint8_t idx)
+{
+	lll_adv_pdu_enqueue(&lll->adv_data, idx);
+}
+
+static inline struct pdu_adv *lll_adv_data_peek(struct lll_adv *lll)
+{
+	return (void *)lll->adv_data.pdu[lll->adv_data.last];
+}
+
+static inline struct pdu_adv *lll_adv_data_curr_get(struct lll_adv *lll)
+{
+	return (void *)lll->adv_data.pdu[lll->adv_data.first];
+}
+
+static inline struct pdu_adv *lll_adv_scan_rsp_alloc(struct lll_adv *lll,
+						     uint8_t *idx)
+{
+	return lll_adv_pdu_alloc(&lll->scan_rsp, idx);
+}
+
+static inline void lll_adv_scan_rsp_enqueue(struct lll_adv *lll, uint8_t idx)
+{
+	lll_adv_pdu_enqueue(&lll->scan_rsp, idx);
+}
+
+static inline struct pdu_adv *lll_adv_scan_rsp_peek(struct lll_adv *lll)
+{
+	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.last];
+}
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+static inline struct pdu_adv *lll_adv_aux_data_alloc(struct lll_adv_aux *lll,
+						     uint8_t *idx)
+{
+	return lll_adv_pdu_alloc(&lll->data, idx);
+}
+
+static inline void lll_adv_aux_data_enqueue(struct lll_adv_aux *lll,
+					    uint8_t idx)
+{
+	lll_adv_pdu_enqueue(&lll->data, idx);
+}
+
+static inline struct pdu_adv *lll_adv_aux_data_peek(struct lll_adv_aux *lll)
+{
+	return (void *)lll->data.pdu[lll->data.last];
+}
+
+static inline struct pdu_adv *lll_adv_aux_data_curr_get(struct lll_adv_aux *lll)
+{
+	return (void *)lll->data.pdu[lll->data.first];
+}
+
+#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
+int lll_adv_and_extra_data_release(struct lll_adv_pdu *pdu);
+
+struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
+						 void **extra_data,
+						 uint8_t *idx);
+
+static inline struct pdu_adv *lll_adv_sync_data_alloc(struct lll_adv_sync *lll,
+						      void **extra_data,
+						      uint8_t *idx)
+{
 #if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
-	/* This is a storage for LLL configuration that may be
-	 * changed while LLL advertising role is started.
-	 * Also it makes the configuration data to be in sync
-	 * with extended advertising PDU e.g. CTE TX configuration
-	 * and CTEInfo field.
-	 */
-	void             *extra_data[DOUBLE_BUFFER_SIZE];
+	return lll_adv_pdu_and_extra_data_alloc(&lll->data, extra_data, idx);
+#else
+	return lll_adv_pdu_alloc(&lll->data, idx);
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
-};
+}
+
+static inline void lll_adv_sync_data_release(struct lll_adv_sync *lll)
+{
+#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
+	lll_adv_and_extra_data_release(&lll->data);
+#else
+	lll_adv_data_release(&lll->data);
+#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
+}
+
+static inline void lll_adv_sync_data_enqueue(struct lll_adv_sync *lll,
+					     uint8_t idx)
+{
+	lll_adv_pdu_enqueue(&lll->data, idx);
+}
+
+static inline struct pdu_adv *lll_adv_sync_data_peek(struct lll_adv_sync *lll,
+						     void **extra_data)
+{
+	uint8_t last = lll->data.last;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
+	if (extra_data) {
+		*extra_data = lll->data.extra_data[last];
+	}
+#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
+
+	return (void *)lll->data.pdu[last];
+}
+#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
+#endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -23,15 +23,16 @@
 #include "lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_chan.h"
+#include "lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll_adv_pdu.h"
 #include "lll_adv_sync.h"
+#include "lll_df_types.h"
 
 #include "lll_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_tim_internal.h"
-#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 #include "lll_df_internal.h"
-#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_adv_sync

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_types.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Structure used to double buffer pointers of AD Data PDU buffer.
+ * The first and last members are used to make modification to AD data to be
+ * context safe. Thread always appends or updates the buffer pointed to
+ * the array element indexed by the member last.
+ * LLL in the ISR context, checks, traverses to the valid pointer indexed
+ * by the member first, such that the buffer is the latest committed by
+ * the thread context.
+ */
+struct lll_adv_pdu {
+	uint8_t volatile first;
+	uint8_t          last;
+	uint8_t          *pdu[DOUBLE_BUFFER_SIZE];
+#if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
+	/* This is a storage for LLL configuration that may be
+	 * changed while LLL advertising role is started.
+	 * Also it makes the configuration data to be in sync
+	 * with extended advertising PDU e.g. CTE TX configuration
+	 * and CTEInfo field.
+	 */
+	void             *extra_data[DOUBLE_BUFFER_SIZE];
+#endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
+};

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
@@ -4,33 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* @brief Configuration of Constant Tone Extension for connectionless
- * transmission.
- */
-struct lll_df_adv_cfg {
-	uint8_t is_enabled:1;
-	uint8_t is_started:1;
-	uint8_t cte_length:6;   /* Length of CTE in 8us units */
-	uint8_t cte_type:2;
-	uint8_t cte_count:6;
-	uint8_t ant_sw_len:6;
-	uint8_t ant_ids[CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN];
-};
-
-/* @brief Max supported CTE length in 8us units */
-#define LLL_DF_MAX_CTE_LEN 20
-/* @brief Min supported CTE length in 8us units */
-#define LLL_DF_MIN_CTE_LEN 2
-
-/* @brief Min supported length of antenna switching pattern */
-#define LLL_DF_MIN_ANT_PATTERN_LEN 3
-
-/* @brief Macro to convert length of CTE to [us] */
-#define CTE_LEN_US(n) ((n) * 8U)
-
-/* Provides number of available antennae for Direction Finding */
-uint8_t lll_df_ant_num_get(void);
-
 /* Enables CTE transmission according to provided configuration */
 void lll_df_conf_cte_tx_enable(uint8_t type, uint8_t length,
 			       uint8_t ant_num, uint8_t *ant_ids);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* @brief Max supported CTE length in 8us units */
+#define LLL_DF_MAX_CTE_LEN 20
+/* @brief Min supported CTE length in 8us units */
+#define LLL_DF_MIN_CTE_LEN 2
+
+/* @brief Min supported length of antenna switching pattern */
+#define LLL_DF_MIN_ANT_PATTERN_LEN 3
+
+/* @brief Macro to convert length of CTE to [us] */
+#define CTE_LEN_US(n) ((n) * 8U)
+
+#if defined(CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN)
+#define BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN \
+	CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN
+#else
+#define BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN 0
+#endif
+
+/* @brief Configuration of Constant Tone Extension for connectionless
+ * transmission.
+ */
+struct lll_df_adv_cfg {
+	uint8_t is_enabled:1;
+	uint8_t is_started:1;
+	uint8_t cte_length:6;   /* Length of CTE in 8us units */
+	uint8_t cte_type:2;
+	uint8_t cte_count:6;
+	uint8_t ant_sw_len:6;
+	uint8_t ant_ids[BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN];
+};

--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -59,9 +59,6 @@ if(CONFIG_BT_LL_SW_SPLIT)
   if(CONFIG_BT_CTLR_DF AND NOT CONFIG_SOC_SERIES_BSIM_NRFXX)
     zephyr_library_sources(ll_sw/nordic/hal/nrf5/radio/radio_df.c)
   endif()
-  zephyr_library_include_directories(
-    ll_sw/nordic/lll
-    )
 endif()
 
 zephyr_library_sources(

--- a/subsys/bluetooth/controller/ll_sw/openisa.cmake
+++ b/subsys/bluetooth/controller/ll_sw/openisa.cmake
@@ -30,9 +30,6 @@ if(CONFIG_BT_LL_SW_SPLIT)
       )
     endif()
   endif()
-    zephyr_library_include_directories(
-      ll_sw/openisa/lll
-    )
   zephyr_library_sources_ifdef(
     CONFIG_BT_CTLR_DTM
     ll_sw/openisa/lll/lll_test.c

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,7 +28,9 @@
 
 #include "lll.h"
 #include "lll_vendor.h"
+#include "lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll_adv_pdu.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_internal.h
@@ -1,91 +1,12 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int lll_adv_data_init(struct lll_adv_pdu *pdu);
-int lll_adv_data_reset(struct lll_adv_pdu *pdu);
-int lll_adv_data_release(struct lll_adv_pdu *pdu);
-
-struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx);
-
-static inline void lll_adv_pdu_enqueue(struct lll_adv_pdu *pdu, uint8_t idx)
-{
-	pdu->last = idx;
-}
-
-static inline struct pdu_adv *lll_adv_data_alloc(struct lll_adv *lll, uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->adv_data, idx);
-}
-
-static inline void lll_adv_data_enqueue(struct lll_adv *lll, uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->adv_data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_data_peek(struct lll_adv *lll)
-{
-	return (void *)lll->adv_data.pdu[lll->adv_data.last];
-}
-
-static inline struct pdu_adv *lll_adv_scan_rsp_alloc(struct lll_adv *lll,
-						     uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->scan_rsp, idx);
-}
-
-static inline void lll_adv_scan_rsp_enqueue(struct lll_adv *lll, uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->scan_rsp, idx);
-}
-
-static inline struct pdu_adv *lll_adv_scan_rsp_peek(struct lll_adv *lll)
-{
-	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.last];
-}
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
-static inline struct pdu_adv *lll_adv_aux_data_alloc(struct lll_adv_aux *lll,
-						     uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->data, idx);
-}
-
-static inline void lll_adv_aux_data_enqueue(struct lll_adv_aux *lll,
-					    uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_aux_data_peek(struct lll_adv_aux *lll)
-{
-	return (void *)lll->data.pdu[lll->data.last];
-}
-
-#if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
-static inline struct pdu_adv *lll_adv_sync_data_alloc(struct lll_adv_sync *lll,
-						     uint8_t *idx)
-{
-	return lll_adv_pdu_alloc(&lll->data, idx);
-}
-
-static inline void lll_adv_sync_data_enqueue(struct lll_adv_sync *lll,
-					     uint8_t idx)
-{
-	lll_adv_pdu_enqueue(&lll->data, idx);
-}
-
-static inline struct pdu_adv *lll_adv_sync_data_peek(struct lll_adv_sync *lll)
-{
-	return (void *)lll->data.pdu[lll->data.last];
-}
-#endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
-
 struct pdu_adv *lll_adv_pdu_latest_get(struct lll_adv_pdu *pdu,
 				       uint8_t *is_modified);
+
 static inline struct pdu_adv *lll_adv_data_latest_get(struct lll_adv *lll,
 						      uint8_t *is_modified)
 {

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_types.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Structure used to double buffer pointers of AD Data PDU buffer.
+ * The first and last members are used to make modification to AD data to be
+ * context safe. Thread always appends or updates the buffer pointed to
+ * the array element indexed by the member last.
+ * LLL in the ISR context, checks, traverses to the valid pointer indexed
+ * by the member first, such that the buffer is the latest committed by
+ * the thread context.
+ */
+struct lll_adv_pdu {
+	uint8_t volatile first;
+	uint8_t          last;
+	uint8_t          *pdu[DOUBLE_BUFFER_SIZE];
+};

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -28,22 +28,24 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
 #include "lll_df.h"
+
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
 #include "ull_sync_types.h"
 #include "ull_conn_types.h"
 #include "ull_filter.h"
+#include "ull_df.h"
 
 #include "ull_internal.h"
 #include "ull_iso_internal.h"
@@ -55,11 +57,14 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_central_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
-#include "ull_df.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 #include "ull_vendor.h"
 #endif /* CONFIG_BT_CTLR_USER_EXT */
+
+#include "ll.h"
+#include "ll_feat.h"
+#include "ll_settings.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -24,18 +24,16 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+
 #include "lll.h"
-#include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
-#include "lll_internal.h"
 #include "lll_filter.h"
-#include "lll_adv_internal.h"
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -46,6 +44,10 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 #include "ull_internal.h"
+
+#include "ll.h"
+#include "ll_feat.h"
+#include "ll_settings.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_adv

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -20,21 +20,22 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
+
 #include "lll.h"
-#include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_adv_aux.h"
-#include "lll_adv_internal.h"
-#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
-#include "lll_df_internal.h"
-#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
+#include "lll/lll_df_types.h"
 
 #include "ull_adv_types.h"
 
 #include "ull_internal.h"
 #include "ull_adv_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_adv_aux

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -5,33 +5,40 @@
  */
 
 #include <zephyr.h>
+#include <sys/byteorder.h>
+#include <bluetooth/bluetooth.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_adv_iso
-#include "common/log.h"
-#include "hal/debug.h"
 #include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/ticker.h"
 
 #include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
 #include "util/mem.h"
+#include "util/memq.h"
 #include "util/mfifo.h"
+#include "util/mayfly.h"
+
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
-#include "lll.h"
 
-#include "lll_vendor.h"
+#include "lll.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_conn.h"
 
 #include "ull_internal.h"
 #include "ull_adv_types.h"
 #include "ull_adv_internal.h"
+
+#include "ll.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_adv_iso
+#include "common/log.h"
+#include "hal/debug.h"
 
 static struct ll_adv_iso ll_adv_iso[BT_CTLR_ADV_SET];
 static void *adv_iso_free;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -20,21 +20,22 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
+
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_adv_sync.h"
-#include "lll_adv_internal.h"
-#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
-#include "lll_df_internal.h"
-#endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
+#include "lll/lll_df_types.h"
 
 #include "ull_adv_types.h"
 
 #include "ull_internal.h"
 #include "ull_chan_internal.h"
 #include "ull_adv_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_adv_sync

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -29,7 +29,6 @@
 #include "lll.h"
 #include "lll_clock.h"
 #include "lll_conn.h"
-#include "lll_tim_internal.h"
 
 #include "ull_conn_types.h"
 #include "ull_internal.h"
@@ -39,6 +38,10 @@
 #include "ull_slave_internal.h"
 #include "ull_master_internal.h"
 
+#if defined(CONFIG_BT_CTLR_USER_EXT)
+#include "ull_vendor.h"
+#endif /* CONFIG_BT_CTLR_USER_EXT */
+
 #include "ll.h"
 #include "ll_feat.h"
 #include "ll_settings.h"
@@ -47,10 +50,6 @@
 #define LOG_MODULE_NAME bt_ctlr_ull_conn
 #include "common/log.h"
 #include "hal/debug.h"
-
-#if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
-#endif /* CONFIG_BT_CTLR_USER_EXT */
 
 /**
  *  User CPR Interval

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -11,6 +11,7 @@
 
 #include "lll.h"
 #include "lll_conn_iso.h"
+
 #include "ull_conn_iso_types.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -5,32 +5,37 @@
  */
 
 #include <stdint.h>
+
 #include <zephyr.h>
 #include <sys/util.h>
 #include <bluetooth/hci.h>
 
-#include "hal/debug.h"
 #include "hal/cpu.h"
 
 #include "util/util.h"
-#include "util/memq.h"
 #include "util/mem.h"
+#include "util/memq.h"
 
 #include "pdu.h"
-#include "ll.h"
+
 #include "lll.h"
-
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
-#include "ull_adv_types.h"
-#include "ull_adv_internal.h"
-#include "lll_adv_internal.h"
+#include "lll/lll_adv_pdu.h"
+#include "lll/lll_df_types.h"
+#include "lll_df.h"
 
+#include "ull_adv_types.h"
 #include "ull_df.h"
-#include "lll_df_internal.h"
+
+#include "ull_adv_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_df
 #include "common/log.h"
+#include "hal/debug.h"
 
 /* ToDo:
  * - Add release of df_adv_cfg when adv_sync is released.
@@ -154,7 +159,7 @@ uint8_t ll_df_set_cl_cte_tx_params(uint8_t adv_handle, uint8_t cte_len,
 	if ((cte_type == BT_HCI_LE_AOD_CTE_1US ||
 	     cte_type == BT_HCI_LE_AOD_CTE_2US) &&
 	    (num_ant_ids < LLL_DF_MIN_ANT_PATTERN_LEN ||
-	     num_ant_ids > CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN ||
+	     num_ant_ids > BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN ||
 	     !ant_ids)) {
 		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
 	}
@@ -359,7 +364,7 @@ void ll_df_read_ant_inf(uint8_t *switch_sample_rates,
 		*switch_sample_rates |= DF_AOA_1US;
 	}
 
-	*max_switch_pattern_len = CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN;
+	*max_switch_pattern_len = BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN;
 	*num_ant = lll_df_ant_num_get();
 	*max_cte_len = LLL_DF_MAX_CTE_LEN;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -20,14 +20,14 @@
 #include "util/mayfly.h"
 
 #include "pdu.h"
-#include "ll.h"
 
 #include "lll.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
 #include "lll_filter.h"
-#include "lll_adv_internal.h"
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -37,12 +37,14 @@
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
 
-#define ADDR_TYPE_ANON 0xFF
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_filter
 #include "common/log.h"
 #include "hal/debug.h"
+
+#define ADDR_TYPE_ANON 0xFF
 
 /* Hardware whitelist */
 static struct lll_filter wl_filter;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -21,19 +21,17 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
 #include "lll_master.h"
 #include "lll_filter.h"
-#include "lll_tim_internal.h"
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -45,6 +43,10 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 #include "ull_master_internal.h"
+
+#include "ll.h"
+#include "ll_feat.h"
+#include "ll_settings.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_master

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -22,11 +22,12 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
 #include "lll_filter.h"
@@ -39,6 +40,8 @@
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
 #include "ull_sched_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_scan

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -18,7 +18,7 @@
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
 #include "lll_scan.h"
 #include "lll_scan_aux.h"
 #include "lll_sync.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -20,7 +20,7 @@
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -21,16 +21,16 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll/lll_vendor.h"
+#include "lll/lll_adv_types.h"
 #include "lll_adv.h"
+#include "lll/lll_adv_pdu.h"
 #include "lll_conn.h"
 #include "lll_slave.h"
 #include "lll_filter.h"
-#include "lll_tim_internal.h"
 
 #include "ull_adv_types.h"
 #include "ull_conn_types.h"
@@ -40,6 +40,8 @@
 #include "ull_adv_internal.h"
 #include "ull_conn_internal.h"
 #include "ull_slave_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_slave

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -20,11 +20,10 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
 #include "lll_clock.h"
+#include "lll/lll_vendor.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
@@ -35,6 +34,8 @@
 #include "ull_internal.h"
 #include "ull_scan_internal.h"
 #include "ull_sync_internal.h"
+
+#include "ll.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_sync

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -5,12 +5,7 @@
  */
 
 #include <zephyr.h>
-
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_ull_sync_iso
-#include "common/log.h"
-#include "hal/debug.h"
-
+#include <bluetooth/bluetooth.h>
 #include <sys/byteorder.h>
 
 #include "util/util.h"
@@ -25,10 +20,9 @@
 #include "ticker/ticker.h"
 
 #include "pdu.h"
-#include "ll.h"
 
 #include "lll.h"
-#include "lll_vendor.h"
+#include "lll/lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
@@ -41,6 +35,13 @@
 #include "ull_scan_internal.h"
 #include "ull_sync_internal.h"
 #include "ull_sync_iso_internal.h"
+
+#include "ll.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_sync_iso
+#include "common/log.h"
+#include "hal/debug.h"
 
 static int init_reset(void);
 static inline struct ll_sync_iso *sync_iso_acquire(void);


### PR DESCRIPTION
Remove inclusion of vendor specific internal LLL include
files in ULL source code.

Prefix `lll/` include file path to correctly include vendor
defined types and function implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>