### PR TITLE
aarch64: restore natural order in struct __esf

### DIFF
--- a/include/arch/arm/aarch64/exc.h
+++ b/include/arch/arm/aarch64/exc.h
@@ -25,28 +25,28 @@ extern "C" {
 #endif
 
 struct __esf {
-	uint64_t spsr;
-	uint64_t elr;
-	uint64_t x18;
-	uint64_t x30;
-	uint64_t x16;
-	uint64_t x17;
-	uint64_t x14;
-	uint64_t x15;
-	uint64_t x12;
-	uint64_t x13;
-	uint64_t x10;
-	uint64_t x11;
-	uint64_t x8;
-	uint64_t x9;
-	uint64_t x6;
-	uint64_t x7;
-	uint64_t x4;
-	uint64_t x5;
-	uint64_t x2;
-	uint64_t x3;
 	uint64_t x0;
 	uint64_t x1;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t x8;
+	uint64_t x9;
+	uint64_t x10;
+	uint64_t x11;
+	uint64_t x12;
+	uint64_t x13;
+	uint64_t x14;
+	uint64_t x15;
+	uint64_t x16;
+	uint64_t x17;
+	uint64_t x18;
+	uint64_t x30;
+	uint64_t spsr;
+	uint64_t elr;
 };
 
 typedef struct __esf z_arch_esf_t;


### PR DESCRIPTION
The funky order was necessary when registers were stored using a
sequence of `stp x(n), x(n+1), [sp, #-16]!`. Now that absolute offsets
are being used, we can restore natural ordering.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
