### PR TITLE
bluetooth: host: improve documentation on stack override

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -91,7 +91,8 @@ config BT_HCI_TX_STACK_SIZE
 	help
 	  Stack size needed for executing bt_send with specified driver.
 	  NOTE: This is an advanced setting and should not be changed unless
-	  absolutely necessary
+	  absolutely necessary.  To change this you must first select
+	  BT_HCI_TX_STACK_SIZE_WITH_PROMPT.
 
 config BT_HCI_TX_STACK_SIZE_WITH_PROMPT
 	bool "Override HCI Tx thread stack size"


### PR DESCRIPTION
There's a prompt to set the TX stack size, that's documented as an
advanced setting, but attempts to override it it are rejected unless
you add another setting that allows it to be change.  Tell the user
how to make changes work.

Based on a research responding to a direct request for support from a Nordic application engineer.