### PR TITLE
Bluetooth: controller: Add/Remove ACAD on create/terminate BIG

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5021,7 +5021,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			       sys_le16_to_cpu(si->interval),
 			       (si->sca_chm[4] >> 5),
 			       si->sca_chm[0], si->sca_chm[1], si->sca_chm[2],
-			       si->sca_chm[3], (si->sca_chm[4] & 0x3F),
+			       si->sca_chm[3], (si->sca_chm[4] & 0x1F),
 			       sys_le32_to_cpu(si->aa),
 			       si->crc_init[0], si->crc_init[1],
 			       si->crc_init[2], sys_le16_to_cpu(si->evt_cntr));

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5019,9 +5019,13 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			       sys_le16_to_cpu(si->offs),
 			       si->offs_units,
 			       sys_le16_to_cpu(si->interval),
-			       (si->sca_chm[4] >> 5),
+			       ((si->sca_chm[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] &
+				 PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK) >>
+				PDU_SYNC_INFO_SCA_CHM_SCA_BIT_POS),
 			       si->sca_chm[0], si->sca_chm[1], si->sca_chm[2],
-			       si->sca_chm[3], (si->sca_chm[4] & 0x1F),
+			       si->sca_chm[3],
+			       (si->sca_chm[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] &
+				~PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK),
 			       sys_le32_to_cpu(si->aa),
 			       si->crc_init[0], si->crc_init[1],
 			       si->crc_init[2], sys_le16_to_cpu(si->evt_cntr));

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -366,6 +366,11 @@ struct pdu_adv_sync_info {
 	uint16_t evt_cntr;
 } __packed;
 
+#define PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET 4
+#define PDU_SYNC_INFO_SCA_CHM_SCA_BIT_POS     5
+#define PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK    \
+		(0x07 << (PDU_SYNC_INFO_SCA_CHM_SCA_BIT_POS))
+
 enum pdu_adv_type {
 	PDU_ADV_TYPE_ADV_IND = 0x00,
 	PDU_ADV_TYPE_DIRECT_IND = 0x01,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -93,7 +93,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 			    uint8_t const *const data)
 {
 	struct ll_adv_set *adv;
-	uint8_t value[5];
+	uint8_t value[1 + sizeof(data)];
 	uint8_t *val_ptr;
 	uint8_t pri_idx;
 	uint8_t err;
@@ -122,7 +122,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 
 	val_ptr = value;
 	*val_ptr++ = len;
-	sys_put_le32((uint32_t)data, val_ptr);
+	memcpy(val_ptr, &data, sizeof(data));
 	err = ull_adv_aux_hdr_set_clear(adv, ULL_ADV_PDU_HDR_FIELD_AD_DATA,
 					0, value, NULL, &pri_idx);
 	if (err) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -46,20 +46,24 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 
+/* Below are BT Spec v5.2, Vol 6, Part B Section 2.3.4 Table 2.12 defined */
 #define ULL_ADV_PDU_HDR_FIELD_ADVA      BIT(0)
 #define ULL_ADV_PDU_HDR_FIELD_TARGETA   BIT(1)
 #define ULL_ADV_PDU_HDR_FIELD_CTE_INFO  BIT(2)
 #define ULL_ADV_PDU_HDR_FIELD_ADI       BIT(3)
 #define ULL_ADV_PDU_HDR_FIELD_AUX_PTR   BIT(4)
 #define ULL_ADV_PDU_HDR_FIELD_SYNC_INFO BIT(5)
-#define ULL_ADV_PDU_HDR_FIELD_TX_POWER  BIT(7)
-#define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(8)
+#define ULL_ADV_PDU_HDR_FIELD_TX_POWER  BIT(6)
+#define ULL_ADV_PDU_HDR_FIELD_RFU       BIT(7)
+/* Below are implementation defined bit fields */
+#define ULL_ADV_PDU_HDR_FIELD_ACAD      BIT(8)
+#define ULL_ADV_PDU_HDR_FIELD_AD_DATA   BIT(9)
 
 /* Helper type to store data for extended advertising
  * header fields and extra data.
  */
-struct adv_pdu_field_data {
-	uint8_t *field_data;
+struct ull_adv_ext_hdr_data {
+	void *field_data;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY)
 	void *extra_data;
@@ -116,7 +120,7 @@ void ull_adv_sync_release(struct ll_adv_sync_set *sync);
 uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
 			       uint16_t hdr_add_fields,
 			       uint16_t hdr_rem_fields,
-			       struct adv_pdu_field_data *data,
+			       struct ull_adv_ext_hdr_data *hdr_data,
 			       struct pdu_adv **ter_pdu_prev,
 			       struct pdu_adv **ter_pdu_new,
 			       void **extra_data_prev,
@@ -131,7 +135,7 @@ uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
 				   struct pdu_adv *ter_pdu,
 				   uint16_t hdr_add_fields,
 				   uint16_t hdr_rem_fields,
-				   struct adv_pdu_field_data *data);
+				   struct ull_adv_ext_hdr_data *hdr_data);
 
 /* helper function to update extra_data field */
 void ull_adv_sync_extra_data_set_clear(void *extra_data_prev,
@@ -186,10 +190,6 @@ void ull_adv_sync_update(struct ll_adv_sync_set *sync, uint32_t slot_plus_us,
 
 /* helper function to schedule a mayfly to get sync offset */
 void ull_adv_sync_offset_get(struct ll_adv_set *adv);
-
-/* helper function to reserve ACAD field in PDU buffer */
-uint8_t ull_adv_sync_acad_enable(struct lll_adv_sync *lll_sync,
-				 uint8_t acad_len, void **acad);
 
 int ull_adv_iso_init(void);
 int ull_adv_iso_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -111,39 +111,6 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 				  struct pdu_adv_adi *adi,
 				  uint8_t *pri_idx);
 
-/* helper function to release periodic advertising instance */
-void ull_adv_sync_release(struct ll_adv_sync_set *sync);
-
-/* helper function to allocate new PDU data for AUX_SYNC_IND and return
- * previous and new PDU for further processing.
- */
-uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
-			       uint16_t hdr_add_fields,
-			       uint16_t hdr_rem_fields,
-			       struct ull_adv_ext_hdr_data *hdr_data,
-			       struct pdu_adv **ter_pdu_prev,
-			       struct pdu_adv **ter_pdu_new,
-			       void **extra_data_prev,
-			       void **extra_data_new,
-			       uint8_t *ter_idx);
-
-/* helper function to set/clear common extended header format fields
- * for AUX_SYNC_IND PDU.
- */
-uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
-				   struct pdu_adv *ter_pdu_prev,
-				   struct pdu_adv *ter_pdu,
-				   uint16_t hdr_add_fields,
-				   uint16_t hdr_rem_fields,
-				   struct ull_adv_ext_hdr_data *hdr_data);
-
-/* helper function to update extra_data field */
-void ull_adv_sync_extra_data_set_clear(void *extra_data_prev,
-				       void *extra_data_new,
-				       uint16_t hdr_add_fields,
-				       uint16_t hdr_rem_fields,
-				       void *data);
-
 /* helper function to calculate common ext adv payload header length and
  * adjust the data pointer.
  * NOTE: This function reverts the header data pointer if there is no
@@ -184,9 +151,46 @@ uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 			    struct ll_adv_sync_set *sync,
 			    uint32_t ticks_anchor);
 
+/* helper function to release periodic advertising instance */
+void ull_adv_sync_release(struct ll_adv_sync_set *sync);
+
+/* helper function to fill initial value of sync_info structure */
+void ull_adv_sync_info_fill(struct ll_adv_sync_set *sync,
+			    struct pdu_adv_sync_info *si);
+
 /* helper function to update periodic advertising event length */
 void ull_adv_sync_update(struct ll_adv_sync_set *sync, uint32_t slot_plus_us,
 			 uint32_t slot_minus_us);
+
+/* helper function to allocate new PDU data for AUX_SYNC_IND and return
+ * previous and new PDU for further processing.
+ */
+uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
+			       uint16_t hdr_add_fields,
+			       uint16_t hdr_rem_fields,
+			       struct ull_adv_ext_hdr_data *hdr_data,
+			       struct pdu_adv **ter_pdu_prev,
+			       struct pdu_adv **ter_pdu_new,
+			       void **extra_data_prev,
+			       void **extra_data_new,
+			       uint8_t *ter_idx);
+
+/* helper function to set/clear common extended header format fields
+ * for AUX_SYNC_IND PDU.
+ */
+uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
+				   struct pdu_adv *ter_pdu_prev,
+				   struct pdu_adv *ter_pdu,
+				   uint16_t hdr_add_fields,
+				   uint16_t hdr_rem_fields,
+				   struct ull_adv_ext_hdr_data *hdr_data);
+
+/* helper function to update extra_data field */
+void ull_adv_sync_extra_data_set_clear(void *extra_data_prev,
+				       void *extra_data_new,
+				       uint16_t hdr_add_fields,
+				       uint16_t hdr_rem_fields,
+				       void *data);
 
 /* helper function to schedule a mayfly to get sync offset */
 void ull_adv_sync_offset_get(struct ll_adv_set *adv);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -187,6 +187,10 @@ void ull_adv_sync_update(struct ll_adv_sync_set *sync, uint32_t slot_plus_us,
 /* helper function to schedule a mayfly to get sync offset */
 void ull_adv_sync_offset_get(struct ll_adv_set *adv);
 
+/* helper function to reserve ACAD field in PDU buffer */
+uint8_t ull_adv_sync_acad_enable(struct lll_adv_sync *lll_sync,
+				 uint8_t acad_len, void **acad);
+
 int ull_adv_iso_init(void);
 int ull_adv_iso_reset(void);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -58,11 +58,16 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 		      uint8_t packing, uint8_t framing, uint8_t encryption,
 		      uint8_t *bcode)
 {
+	uint8_t field_data[1 + sizeof(uint8_t *)];
+	struct ull_adv_ext_hdr_data hdr_data;
+	void *extra_data_prev, *extra_data;
 	struct lll_adv_sync *lll_adv_sync;
 	struct lll_adv_iso *lll_adv_iso;
+	struct pdu_adv *pdu_prev, *pdu;
 	struct node_rx_pdu *node_rx;
 	struct ll_adv_iso *adv_iso;
 	struct ll_adv_set *adv;
+	uint8_t ter_idx;
 	uint8_t *acad;
 	uint8_t err;
 
@@ -133,15 +138,28 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 	}
 
-	/* Add ACAD to AUX_SYNC_IND */
-	err = ull_adv_sync_acad_enable(lll_adv_sync,
-				       (sizeof(struct pdu_big_info) + 2),
-				       (void **)&acad);
+	/* Allocate next PDU */
+	err = ull_adv_sync_pdu_alloc(adv, 0, 0, NULL, &pdu_prev, &pdu,
+				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;
 	}
+
+	/* Add ACAD to AUX_SYNC_IND */
+	hdr_data.field_data = field_data;
+	field_data[0] = sizeof(struct pdu_big_info) + 2;
+	err = ull_adv_sync_pdu_set_clear(lll_adv_sync, pdu_prev, pdu,
+					 ULL_ADV_PDU_HDR_FIELD_ACAD, 0U,
+					 &hdr_data);
+	if (err) {
+		return err;
+	}
+
+	memcpy(&acad, &field_data[1], sizeof(acad));
 	acad[0] = sizeof(struct pdu_big_info) + 1;
 	acad[1] = BT_DATA_BIG_INFO;
+
+	lll_adv_sync_data_enqueue(lll_adv_sync, ter_idx);
 
 	/* TODO: For now we can just use the unique BIG handle as the BIS
 	 * handle until we support multiple BIS
@@ -209,11 +227,15 @@ uint8_t ll_big_test_create(uint8_t big_handle, uint8_t adv_handle,
 
 uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 {
+	void *extra_data_prev, *extra_data;
 	struct lll_adv_sync *lll_adv_sync;
 	struct lll_adv_iso *lll_adv_iso;
+	struct pdu_adv *pdu_prev, *pdu;
 	struct node_rx_pdu *node_rx;
 	struct ll_adv_iso *adv_iso;
 	struct lll_adv *lll_adv;
+	struct ll_adv_set *adv;
+	uint8_t ter_idx;
 	uint32_t ret;
 	uint8_t err;
 
@@ -229,12 +251,23 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 	}
 
 	lll_adv_sync = lll_adv->sync;
+	adv = HDR_LLL2ULL(lll_adv);
 
-	/* Remove ACAD to AUX_SYNC_IND */
-	err = ull_adv_sync_acad_enable(lll_adv_sync, 0, NULL);
+	/* Allocate next PDU */
+	err = ull_adv_sync_pdu_alloc(adv, 0, 0, NULL, &pdu_prev, &pdu,
+				     &extra_data_prev, &extra_data, &ter_idx);
 	if (err) {
 		return err;
 	}
+
+	/* Remove ACAD to AUX_SYNC_IND */
+	err = ull_adv_sync_pdu_set_clear(lll_adv_sync, pdu_prev, pdu,
+					 0U, ULL_ADV_PDU_HDR_FIELD_ACAD, NULL);
+	if (err) {
+		return err;
+	}
+
+	lll_adv_sync_data_enqueue(lll_adv_sync, ter_idx);
 
 	/* TODO: Terminate all BIS data paths */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -790,6 +790,151 @@ uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
 	return 0;
 }
 
+uint8_t ull_adv_sync_acad_enable(struct lll_adv_sync *lll_sync,
+				 uint8_t acad_len, void **acad)
+{
+	struct pdu_adv_com_ext_adv *ter_com_hdr, *ter_com_hdr_prev;
+	struct pdu_adv_ext_hdr *ter_hdr, ter_hdr_prev;
+	struct pdu_adv *ter_pdu, *ter_pdu_prev;
+	uint8_t *ter_dptr, *ter_dptr_prev;
+	uint16_t ter_len, ter_len_prev;
+	uint8_t acad_len_prev;
+	uint8_t *ad_data;
+	uint8_t ter_idx;
+	uint8_t ad_len;
+
+	/* Get reference to previous tertiary PDU data */
+	ter_pdu_prev = lll_adv_sync_data_peek(lll_sync, NULL);
+	ter_com_hdr_prev = (void *)&ter_pdu_prev->adv_ext_ind;
+	ter_hdr = (void *)ter_com_hdr_prev->ext_hdr_adv_data;
+	ter_hdr_prev = *ter_hdr;
+	ter_dptr_prev = ter_hdr->data;
+
+	/* Get reference to new tertiary PDU data buffer */
+	ter_pdu = lll_adv_sync_data_alloc(lll_sync, NULL, &ter_idx);
+	ter_pdu->type = ter_pdu_prev->type;
+	ter_pdu->rfu = 0U;
+	ter_pdu->chan_sel = 0U;
+	ter_com_hdr = (void *)&ter_pdu->adv_ext_ind;
+	ter_com_hdr->adv_mode = ter_com_hdr_prev->adv_mode;
+	ter_hdr = (void *)ter_com_hdr->ext_hdr_adv_data;
+	ter_dptr = ter_hdr->data;
+	*(uint8_t *)ter_hdr = 0U;
+
+	/* No AdvA */
+	/* No TargetA */
+
+	/* TODO: CTEInfo */
+
+	/* No ADI */
+
+	/* AuxPtr */
+	if (ter_hdr_prev.aux_ptr) {
+		ter_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
+
+		ter_hdr->aux_ptr = 1;
+		ter_dptr += sizeof(struct pdu_adv_aux_ptr);
+	}
+
+	/* No SyncInfo */
+
+	/* Tx Power flag */
+	if (ter_hdr_prev.tx_pwr) {
+		ter_dptr_prev++;
+
+		ter_hdr->tx_pwr = 1;
+		ter_dptr++;
+	}
+
+	/* Calc previous ACAD len and update PDU len */
+	ter_len_prev = ter_dptr_prev - (uint8_t *)ter_com_hdr_prev;
+	if (ter_len_prev < (ter_com_hdr_prev->ext_hdr_len +
+			    offsetof(struct pdu_adv_com_ext_adv,
+				     ext_hdr_adv_data))) {
+		acad_len_prev = ter_com_hdr_prev->ext_hdr_len +
+				offsetof(struct pdu_adv_com_ext_adv,
+					 ext_hdr_adv_data) - ter_len_prev;
+		ter_len_prev += acad_len_prev;
+		ter_dptr_prev += acad_len_prev;
+	} else {
+		acad_len_prev = 0;
+		ter_len_prev = offsetof(struct pdu_adv_com_ext_adv,
+					ext_hdr_adv_data);
+		ter_dptr_prev = (uint8_t *)ter_com_hdr_prev + ter_len_prev;
+	}
+
+	/* Did we parse beyond PDU length? */
+	if (ter_len_prev > ter_pdu_prev->len) {
+		/* we should not encounter invalid length */
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+
+	/* Fill new ACAD */
+	if (acad) {
+		*acad = ter_dptr;
+		ter_dptr += acad_len;
+	}
+
+	/* Calc current tertiary PDU len */
+	ter_len = ull_adv_aux_hdr_len_calc(ter_com_hdr, &ter_dptr);
+	ull_adv_aux_hdr_len_fill(ter_com_hdr, ter_len);
+
+	/* Calc the previous AD data length in auxiliary PDU */
+	ad_len = ter_pdu_prev->len - ter_len_prev;
+	ad_data = ter_dptr_prev;
+
+	/* Add AD len to tertiary PDU length */
+	ter_len += ad_len;
+
+	/* Check AdvData overflow */
+	if (ter_len > PDU_AC_PAYLOAD_SIZE_MAX) {
+		return BT_HCI_ERR_PACKET_TOO_LONG;
+	}
+
+	/* set the tertiary PDU len */
+	ter_pdu->len = ter_len;
+
+	/* Start filling tertiary PDU payload based on flags from here
+	 * ==============================================================
+	 */
+
+	/* Fill AdvData in tertiary PDU */
+	memmove(ter_dptr, ad_data, ad_len);
+
+	/* NOTE: ACAD in tertiary PDU is filled by the caller of this
+	 *       function. Only decrement the new ACAD length.
+	 */
+	ter_dptr_prev -= acad_len_prev;
+	if (acad) {
+		ter_dptr -= acad_len;
+	}
+
+	/* Tx Power */
+	if (ter_hdr->tx_pwr) {
+		*--ter_dptr = *--ter_dptr_prev;
+	}
+
+	/* No SyncInfo in tertiary PDU */
+
+	/* AuxPtr */
+	if (ter_hdr_prev.aux_ptr) {
+		ter_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
+
+		ull_adv_aux_ptr_fill(&ter_dptr, lll_sync->adv->phy_s);
+	}
+
+	/* No ADI */
+
+	/* TODO: CTEInfo */
+
+	/* No TargetA*/
+	/* No AdvA */
+
+	lll_adv_sync_data_enqueue(lll_sync, ter_idx);
+
+	return 0;
+}
+
 /* @brief Set or clear fields in extended advertising header and store
  *        extra_data if requested.
  *

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -724,8 +724,12 @@ void ull_adv_sync_info_fill(struct ll_adv_sync_set *sync,
 	lll_sync = &sync->lll;
 	memcpy(si->sca_chm, lll_sync->data_chan_map,
 	       sizeof(si->sca_chm));
-	si->sca_chm[4] &= 0x1f;
-	si->sca_chm[4] |= lll_clock_sca_local_get() << 5;
+	si->sca_chm[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] &=
+		~PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK;
+	si->sca_chm[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] |=
+		((lll_clock_sca_local_get() <<
+		  PDU_SYNC_INFO_SCA_CHM_SCA_BIT_POS) &
+		 PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK);
 	memcpy(&si->aa, lll_sync->access_addr, sizeof(si->aa));
 	memcpy(si->crc_init, lll_sync->crc_init, sizeof(si->crc_init));
 

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -334,7 +334,7 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		df_cfg->is_enabled = 0U;
 	} else {
 		struct pdu_cte_info cte_info;
-		struct adv_pdu_field_data pdu_data;
+		struct ull_adv_ext_hdr_data hdr_data;
 
 		if (df_cfg->is_enabled) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
@@ -342,8 +342,8 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 
 		cte_info.type = df_cfg->cte_type;
 		cte_info.time = df_cfg->cte_length;
-		pdu_data.field_data = (uint8_t *)&cte_info;
-		pdu_data.extra_data = df_cfg;
+		hdr_data.field_data = (uint8_t *)&cte_info;
+		hdr_data.extra_data = df_cfg;
 
 		err = ull_adv_sync_pdu_alloc(adv, 0,
 					     ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
@@ -358,12 +358,12 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 			ull_adv_sync_extra_data_set_clear(extra_data_prev,
 							  extra_data,
 							  ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-							  0, &pdu_data);
+							  0, &hdr_data);
 		}
 
 		err = ull_adv_sync_pdu_set_clear(lll_sync, pdu_prev, pdu,
 						 ULL_ADV_PDU_HDR_FIELD_CTE_INFO,
-						 0, &pdu_data);
+						 0, &hdr_data);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -383,8 +383,13 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	}
 
 	lll = &sync->lll;
+
+	/* Copy channel map from sca_chm field in sync_info structure, and
+	 * clear the SCA bits.
+	 */
 	memcpy(lll->data_chan_map, si->sca_chm, sizeof(lll->data_chan_map));
-	lll->data_chan_map[4] &= ~0xE0;
+	lll->data_chan_map[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] &=
+		~PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK;
 	lll->data_chan_count = util_ones_count_get(&lll->data_chan_map[0],
 						   sizeof(lll->data_chan_map));
 	if (lll->data_chan_count < 2) {
@@ -397,7 +402,13 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	lll->event_counter = si->evt_cntr;
 	lll->phy = aux->lll.phy;
 
-	sca = si->sca_chm[4] >> 5;
+	/* Extract the SCA value from the sca_chm field of the sync_info
+	 * structure.
+	 */
+	sca = (si->sca_chm[PDU_SYNC_INFO_SCA_CHM_SCA_BYTE_OFFSET] &
+	       PDU_SYNC_INFO_SCA_CHM_SCA_BIT_MASK) >>
+	      PDU_SYNC_INFO_SCA_CHM_SCA_BIT_POS;
+
 	interval = sys_le16_to_cpu(si->interval);
 	interval_us = interval * CONN_INT_UNIT_US;
 

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -59,7 +59,6 @@ static void test_iso_main(void)
 {
 	struct bt_le_ext_adv *adv;
 	int err;
-	int index;
 	uint8_t bis_count = 1; /* TODO: Add support for multiple BIS per BIG */
 
 	printk("\n*ISO broadcast test*\n");
@@ -108,6 +107,7 @@ static void test_iso_main(void)
 
 #if !IS_ENABLED(USE_HOST_API)
 	uint8_t big_handle = 0;
+	uint8_t adv_handle;
 	uint32_t sdu_interval = 0x10000; /*us */
 	uint16_t max_sdu = 0x10;
 	uint16_t max_latency = 0x0A;
@@ -119,10 +119,10 @@ static void test_iso_main(void)
 	uint8_t bcode[16] = { 0 };
 
 	/* Assume that index == handle */
-	index = bt_le_ext_adv_get_index(adv);
+	adv_handle = bt_le_ext_adv_get_index(adv);
 
 	printk("Creating BIG...");
-	err = ll_big_create(big_handle, index, bis_count, sdu_interval, max_sdu,
+	err = ll_big_create(big_handle, adv_handle, bis_count, sdu_interval, max_sdu,
 			    max_latency, rtn, phy, packing, framing, encryption,
 			    bcode);
 	if (err) {

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/tests_scripts/broadcast_iso.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/tests_scripts/broadcast_iso.sh
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 20 $@ & process_ids="$process_ids $!"
+  timeout 30 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"


### PR DESCRIPTION
Added implementation to add/remove ACAD field in the common
extended header format of the periodic advertising PDU on
create/terminate BIG.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>