### PR TITLE
Bluetooth: controller: Fix undeclared BT_CTLR_SCAN_SET

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -55,7 +55,9 @@
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 #define BT_CTLR_SCAN_SET 1
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
-#endif /* CONFIG_BT_OBSERVER */
+#else /* !CONFIG_BT_OBSERVER */
+#define BT_CTLR_SCAN_SET 0
+#endif /* !CONFIG_BT_OBSERVER */
 
 enum {
 	TICKER_ID_LLL_PREEMPT = 0,


### PR DESCRIPTION
Fix undeclared BT_CTLR_SCAN_SET when BT_OBSERVER is
disabled.

Regression in commit bee6aa325b4e ("Bluetooth: controller:
Increased thread context operation queue count").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>