### PR TITLE
Add stm32h7 dmamux1 bindings

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -694,7 +694,7 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,
 						 <17 0>, <47 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000001>;
 			st,mem2mem;
 			status = "disabled";
 			label = "DMA_1";
@@ -706,7 +706,7 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0>, <57 0>, <58 0>, <59 0>, <60 0>, <68 0>,
 						<69 0>, <70 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000002>;
 			st,mem2mem;
 			status = "disabled";
 			label = "DMA_2";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -712,6 +712,23 @@
 			label = "DMA_2";
 		};
 
+		dmamux1: dmamux@40020800 {
+			compatible = "st,stm32-dmamux";
+			#dma-cells = <4>;
+			reg = <0x40020800 0x400>;
+			interrupts = <102 0>;
+			/* dmamux1 has no dedicated clock, so we enable dma1 clock */
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000001>;
+			dma-channels = <16>;
+			dma-generators = <8>;
+			status = "disabled";
+			label = "DMAMUX_1";
+			/*
+			 * dma-requests is different among h7 socs,
+			 * so we set in specific dtsi files
+			 */
+		};
+
 		rng: rng@48021800 {
 			compatible = "st,stm32-rng";
 			reg = <0x48021800 0x400>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -22,7 +22,12 @@
 			status = "disabled";
 			label = "UART_9";
 		};
+
+		dmamux1: dmamux@40020800 {
+			dma-requests= <129>;
+		};
 	};
+
 	/* DTCM memory directly coppled to CPU */
 	dtcm: memory@20000000 {
 		compatible = "arm,dtcm";

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -14,7 +14,12 @@
 				erase-block-size = <DT_SIZE_K(128)>;
 			};
 		};
+
+		dmamux1: dmamux@40020800 {
+			dma-requests= <107>;
+		};
 	};
+
 	/* system data RAM accessible over over AXI bus */
 	sram0: memory@24000000 {
 		compatible = "mmio-sram";

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -20,6 +20,10 @@
 				erase-block-size = <DT_SIZE_K(128)>;
 			};
 		};
+
+		dmamux1: dmamux@40020800 {
+			dma-requests= <107>;
+		};
 	};
 	/*
 	* The RAM memories placed here can be used by both cores M4/M7

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -7,6 +7,12 @@
 #include <st/h7/stm32h7.dtsi>
 
 / {
+	soc {
+		dmamux1: dmamux@40020800 {
+			dma-requests= <107>;
+		};
+	};
+
 	/* system data RAM accessible over over AXI bus */
 	sram0: memory@24000000 {
 		compatible = "mmio-sram";


### PR DESCRIPTION
This pr is a preparation for enabling the dma controller for stm32h7 soc.
It adds the dmamux1 bindings and fix the bindings for dma1 and dma2