### PR TITLE
device.h: Add macro API to get a devicename from a devicetree node

### DIFF
--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -55,6 +55,13 @@
 			label = "STM32_CLK_RCC";
 		};
 
+		exti: interrupt-controller@58000800 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x58000800 0x400>;
+		};
+
 		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/include/device.h
+++ b/include/device.h
@@ -157,6 +157,21 @@ typedef int16_t device_handle_t;
 			data_ptr, cfg_ptr, level, prio, api_ptr)
 
 /**
+ * @def DEVICE_DT_NAME
+ *
+ * @brief Return a string name for a devicetree node.
+ *
+ * @details This macro returns a string literal usable as a device name
+ * from a devicetree node. If the node has a "label" property, its value is
+ * returned. Otherwise, the node's full "node-name@@unit-address" name is
+ * returned.
+ *
+ * @param node_id The devicetree node identifier.
+ */
+#define DEVICE_DT_NAME(node_id) \
+	DT_PROP_OR(node_id, label, DT_NODE_FULL_NAME(node_id))
+
+/**
  * @def DEVICE_DT_DEFINE
  *
  * @brief Like DEVICE_DEFINE but taking metadata from a devicetree node.
@@ -197,7 +212,7 @@ typedef int16_t device_handle_t;
 			 data_ptr, cfg_ptr, level, prio,		\
 			 api_ptr, ...)					\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
-			DT_PROP_OR(node_id, label, ""), init_fn,	\
+			DEVICE_DT_NAME(node_id), init_fn,		\
 			pm_control_fn,					\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr, __VA_ARGS__)


### PR DESCRIPTION
Add a macro to control / provide a device name string back from a devicetree nodeid.  We default to the `label` property if it exists and if not utilize `DT_NODE_NAME`.

- [x] todo: fixup API comment doc.