### PR TITLE
samples: app_dev: set integration_platforms to native_posix

### DIFF
--- a/samples/application_development/external_lib/sample.yaml
+++ b/samples/application_development/external_lib/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: External Library
 tests:
   sample.app_dev.external_lib:
+    integration_platforms:
+      - native_posix
     tags: external
     harness: console
     harness_config:

--- a/samples/application_development/out_of_tree_driver/sample.yaml
+++ b/samples/application_development/out_of_tree_driver/sample.yaml
@@ -3,6 +3,8 @@ sample:
   name: Out-of-tree driver
 tests:
   sample.drivers.out_of_tree:
+    integration_platforms:
+      - native_posix
     tags: out_of_tree
     harness: console
     harness_config:


### PR DESCRIPTION
Set integration_platforms on these samples to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>