### PR TITLE
samples: crypto: set integration_platforms to native_posix

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -6,6 +6,8 @@ common:
   tags: crypto
   min_ram: 20
   arch_exclude: xtensa
+  integration_platforms:
+    - native_posix
 tests:
   sample.drivers.crypto.mbedtls:
     min_flash: 34


### PR DESCRIPTION
Set integration_platforms on these samples to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>