### PR TITLE
samples: condition_variables: set integration_platforms to native_posix

### DIFF
--- a/samples/kernel/condition_variables/condvar/sample.yaml
+++ b/samples/kernel/condition_variables/condvar/sample.yaml
@@ -1,5 +1,7 @@
 tests:
   sample.kernel.cond_var:
+    integration_platforms:
+      - native_posix
     tags: kernel condition_variables
     harness: console
     harness_config:

--- a/samples/kernel/condition_variables/simple/sample.yaml
+++ b/samples/kernel/condition_variables/simple/sample.yaml
@@ -1,5 +1,7 @@
 tests:
   sample.kernel.cond_var.simple:
+    integration_platforms:
+      - native_posix
     tags: kernel condition_variables
     harness: console
     harness_config:


### PR DESCRIPTION
Set integration_platforms on these samples to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>