### PR TITLE
toolchain: gcc: fix extra space when using SECTION_VAR

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -355,7 +355,7 @@ do {                                                                    \
 	section_subsec_func sect, subsec, sym
 #else /* !CONFIG_ARC */
 
-#define SECTION_VAR(sect, sym)  .section .sect.##sym; sym :
+#define SECTION_VAR(sect, sym)  .section .sect.sym; sym :
 #define SECTION_FUNC(sect, sym)						\
 	.section .sect.sym, "ax";					\
 				FUNC_CODE()				\


### PR DESCRIPTION
The generic version of SECTION_VAR() is adding an extra space
when calling space before second argument (e.g.
SECTION_VAR(section, variable) => ".section. variable"
instead of ".section.variable") which would result in build
error. So remove the "##" in macro to fix this, and now it
will also behave the same as SECTION_FUNC().

Signed-off-by: Daniel Leung <daniel.leung@intel.com>