### PR TITLE
samples: console: set integration_platforms to mps2_an385

### DIFF
--- a/samples/subsys/console/echo/sample.yaml
+++ b/samples/subsys/console/echo/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: echo Sample
 tests:
   sample.console.echo:
+    integration_platforms:
+      - mps2_an385
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard

--- a/samples/subsys/console/getchar/sample.yaml
+++ b/samples/subsys/console/getchar/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: getchar sample
 tests:
   sample.console.getchar:
+    integration_platforms:
+      - mps2_an385
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard

--- a/samples/subsys/console/getline/sample.yaml
+++ b/samples/subsys/console/getline/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: getline Sample
 tests:
   sample.console.getline:
+    integration_platforms:
+      - mps2_an385
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard


### PR DESCRIPTION
Set integration_platforms on these samples to just mps2_an385.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>