### PR TITLE
samples: shell_module: set integration_platforms to native_posix

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,5 +1,8 @@
 sample:
   name: Shell Sample
+common:
+  integration_platforms:
+    - native_posix
 tests:
   sample.shell.shell_module:
     filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )


### PR DESCRIPTION
Set integration_platforms on these samples to just native_posix.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>