### PR TITLE
samples: logging: set integration_platforms

### DIFF
--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -4,6 +4,8 @@ sample:
   name: logger sample
 tests:
   sample.logger.basic:
+    integration_platforms:
+      - native_posix
     tags: logging
     harness: console
     harness_config:
@@ -17,6 +19,8 @@ tests:
         - Logs from external logging system showcase
 
   sample.logger.rtt:
+    integration_platforms:
+      - frdm_k64f
     tags: logging
     filter: CONFIG_HAS_SEGGER_RTT
     harness: keyboard
@@ -25,6 +29,8 @@ tests:
       - CONFIG_USE_SEGGER_RTT=y
 
   sample.logger.usermode:
+    integration_platforms:
+      - mps2_an385
     tags: logging usermode
     filter: CONFIG_ARCH_HAS_USERSPACE
     harness: keyboard


### PR DESCRIPTION
Set integration_platforms on these samples to a single platform, we
prefer native_posix, than a qemu platform mps2_an385 and finally a
hardware platform.

For the 'basic' sample we use native_posix, for the 'rtt' we use
frdm_k64f ad we need a hardware platform that supports 'rtt', and for
the 'usermode' we utilize 'mps2_an385' as we can run in QEMU.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>