### PR TITLE
samples: metairq_dispatch: set integration_platforms to mps2_an385

### DIFF
--- a/samples/scheduler/metairq_dispatch/sample.yaml
+++ b/samples/scheduler/metairq_dispatch/sample.yaml
@@ -3,6 +3,8 @@ sample:
     MetaIRQ thread
   name: MetaIRQ Dispatch
 common:
+    integration_platforms:
+      - mps2_an385
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
Set integration_platforms on these samples to just mps2_an385.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>