### PR TITLE
samples: eventfd: set integration_platforms to mps2_an385

### DIFF
--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -5,6 +5,8 @@ common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   tags: posix
   platform_exclude: m2gl025_miv
+  integration_platforms:
+    - mps2_an385
 tests:
   sample.posix.eventfd:
     tags: posix


### PR DESCRIPTION
Set integration_platforms on these samples to just mps2_an385.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>