### PR TITLE
samples: userspace: set integration_platforms to mps2_an385

### DIFF
--- a/samples/userspace/hello_world_user/sample.yaml
+++ b/samples/userspace/hello_world_user/sample.yaml
@@ -3,6 +3,8 @@ sample:
     Zephyr application
   name: hello world user
 common:
+    integration_platforms:
+      - mps2_an385
     tags: introduction
     harness: console
     harness_config:

--- a/samples/userspace/prod_consumer/sample.yaml
+++ b/samples/userspace/prod_consumer/sample.yaml
@@ -2,6 +2,8 @@ sample:
   description: userspace producer-consumer example
   name: producer-consumer
 common:
+    integration_platforms:
+      - mps2_an385
     tags: userspace
     harness: console
     harness_config:

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -3,6 +3,8 @@ sample:
     example application
   name: protected memory
 common:
+    integration_platforms:
+      - mps2_an385
     tags: userspace
     harness: console
     harness_config:


### PR DESCRIPTION
Set integration_platforms on these samples to just mps2_an385.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>