### PR TITLE
samples: sensor: set integration_platforms to frdm_k64f

### DIFF
--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: Shell Sensor Module Sample
 tests:
   sample.sensor.shell:
+    integration_platforms:
+      - frdm_k64f
     filter: ( CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT )
     tags: shell
     harness: keyboard

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -4,3 +4,5 @@ tests:
   sample.sensor.thermometer:
     tags: sensors
     harness: sensor
+    integration_platforms:
+      - frdm_k64f


### PR DESCRIPTION
Set integration_platforms on these samples to just frdm_k64f.
This should be sufficient to make sure these tests build.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>