### PR TITLE
samples: tracing: set integration_platforms to frdm_k64f

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -16,6 +16,8 @@ tests:
       - CONFIG_TRACING=y
       - CONFIG_TRACING_CPU_STATS=y
   tracing.osawareness.openocd:
+    integration_platforms:
+      - frdm_k64f
     extra_configs:
       - CONFIG_MP_NUM_CPUS=1
       - CONFIG_OPENOCD_SUPPORT=y


### PR DESCRIPTION
Set integration_platforms on these samples to just frdm_k64f.
This should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>