### PR TITLE
boards: arm: mps2-an521: Change SRAM location to PSRAM

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <mem.h>
 #include <arm/armv8-m.dtsi>
 #include <dt-bindings/i2c/i2c.h>
 
@@ -25,8 +26,8 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
+		zephyr,sram = &sram2_3;
+		zephyr,flash = &sram1;
 	};
 
 	leds {
@@ -72,13 +73,25 @@
 		};
 	};
 
-	sram0: memory@30000000 {
+	/*
+	 * The memory regions defined below are according to AN521:
+	 * https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f
+	 * Please see tables from 3-1 to 3-4.
+	 */
+
+	sram1: memory@10000000 {
 		compatible = "mmio-sram";
-		reg = <0x30000000 0x1000000>;
+		reg = <0x10000000 DT_SIZE_M(4)>;
 	};
 
-	flash0: flash@10000000 {
-		reg = <0x10000000 0xE000000>;
+	sram2_3: memory@38000000 {
+		compatible = "mmio-sram";
+		reg = <0x38000000 DT_SIZE_M(4)>;
+	};
+
+	psram: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 DT_SIZE_M(16)>;
 	};
 
 	soc {

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <mem.h>
 #include <arm/armv8-m.dtsi>
 #include <dt-bindings/i2c/i2c.h>
 
@@ -25,8 +26,8 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
+		zephyr,sram = &ram;
+		zephyr,flash = &code;
 	};
 
 	leds {
@@ -72,13 +73,45 @@
 		};
 	};
 
-	sram0: memory@28100000 {
+	/*
+	 * The memory regions defined below are according to AN521:
+	 * https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f
+	 * Please see tables from 3-1 to 3-4.
+	 */
+
+	sram1: memory@0 {
 		compatible = "mmio-sram";
-		reg = <0x28100000 0x100000>;
+		reg = <0x0 DT_SIZE_M(4)>;
 	};
 
-	flash0: flash@100000 {
-		reg = <0x100000 0xDF00000>;
+	sram2_3: memory@28000000 {
+		compatible = "mmio-sram";
+		reg = <0x28000000 DT_SIZE_M(4)>;
+	};
+
+	psram: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 DT_SIZE_M(16)>;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/* The memory regions defined below must match what the TF-M
+		 * project has defined for that board - a single image boot is
+		 * assumed. Please see the memory layout in:
+		 * https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/target/mps2/an521/partition/flash_layout.h
+		 */
+
+		code: memory@100000 {
+			reg = <0x00100000 DT_SIZE_K(512)>;
+		};
+
+		ram: memory@28100000 {
+			reg = <0x28100000 DT_SIZE_M(1)>;
+		};
 	};
 
 	soc {


### PR DESCRIPTION
Hi,

Could the following change be reviewed, please?

Currently SRAM region specified in dt for board mps-an512 is set to start
at 0x3000_0000 and a 16M contigous space is assumed. However, at that
address there is no such contigous space of 16M, rather only a 128K area
is available. As a consequence large applications linked with Zephyr might
end up using memory regions that are not valid, causing a BusFault.

Application Note AN512 [0] only specifies a 16M contigous space available
starting at 0x8000_0000 (please see 'Table 3-4: SSRAM2 and SSRAM3 address
mapping' and 'Table 3-6: External PSRAM mapping to Code Memory', on pages
3-7 and 3-8, respectively), which resides on the PSRAM (external RAM).

This commit sets the mps-an521 board to use SRAM starting at 0x8000_0000,
so 16M of contigous memory is in fact available as specified in the dt and
as further used by the linker scripts responsible to generate the final
'zephyr.elf' image.

Without that change the following crash is observed when Zephyr is used
with microTVM runtime, due to spills to invalid  memory regions (`push`)
in function prologues:

```
<snip>
[100%] [QEMU] CPU: cortex-m33
qemu-system-arm -cpu cortex-m33 -machine mps2-an521 -nographic -m 16 -vga none -net none -chardev pipe,id=con,mux=on,path=/tmp/tmp7_2xn65a/fifo -serial chardev:con -mon chardev=con,mode=readline -icount shift=7,align=off,sleep=off -rtc clock=vm -kernel /tmp/tvm-debug-mode-tempdirs/2021-02-24T21-59-17___m9g6dasg/00000/build/runtime/zephyr/zephyr.elf
qemu-system-arm: warning: nic lan9118.0 has no peer
qemu: fatal: Lockup: can't escalate 3 to HardFault (current priority -1)

R00=300231a0 R01=30023a80 R02=00000000 R03=00000000
R04=00000000 R05=00000000 R06=00000000 R07=00000000
R08=00000000 R09=00000000 R10=00000000 R11=00000000
R12=00000000 R13=300231a0 R14=fffffffd R15=10001dbc
XPSR=01000003 ---- T S handler
FPSCR: 00000000
<snip>
```

Thanks and best regards,
Gustavo

[0] https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f?token=