### PR TITLE
dts/arm/st: stm32g0 change tim3 pwm prescaler default prop from 10000 to 0

### DIFF
--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -183,7 +183,7 @@
 			pwm {
 				compatible = "st,stm32-pwm";
 				status = "disabled";
-				st,prescaler = <10000>;
+				st,prescaler = <0>;
 				label = "PWM_3";
 				#pwm-cells = <3>;
 			};


### PR DESCRIPTION
G0 until now only had a single tim defined.
The upcoming pr #32614 introduces much more timers.
So it's best to change the default property of the pwm prescaler according to issue #31290 now.