### PR TITLE
tests: application_development: set integration_platforms

### DIFF
--- a/tests/application_development/cpp/testcase.yaml
+++ b/tests/application_development/cpp/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   application_development.cpp.main:
+    integration_platforms:
+      - mps2_an385
     platform_exclude: qemu_x86_coverage
     tags: cpp

--- a/tests/application_development/gen_inc_file/testcase.yaml
+++ b/tests/application_development/gen_inc_file/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   buildsystem.include_file:
+    integration_platforms:
+      - native_posix
     tags: gen_inc_file

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  integration_platforms:
+    - mps2_an385
 tests:
   application_development.cpp.libcxx:
     platform_exclude: qemu_x86_coverage


### PR DESCRIPTION
Set integration_platforms on these samples to a single platform, we
prefer native_posix, than a qemu platform mps2_an385 and finally a
hardware platform.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>