### PR TITLE
tests: shell: set integration_platforms to native_posix

### DIFF
--- a/tests/subsys/shell/shell/testcase.yaml
+++ b/tests/subsys/shell/shell/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   tags: shell
   min_ram: 32
+  integration_platforms:
+    - native_posix
 
 tests:
   shell.core:

--- a/tests/subsys/shell/shell_history/testcase.yaml
+++ b/tests/subsys/shell/shell_history/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   shell.history:
+    integration_platforms:
+      - native_posix
     min_flash: 64
     min_ram: 32
     filter: ( CONFIG_SHELL )


### PR DESCRIPTION
Set integration_platforms on these tests to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>