### PR TITLE
tests: logging: set integration_platforms to native_posix

### DIFF
--- a/tests/subsys/logging/log_core/testcase.yaml
+++ b/tests/subsys/logging/log_core/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   logging.log_core:
+    integration_platforms:
+      - native_posix
     tags: log_core logging
     filter: not CONFIG_LOG_IMMEDIATE

--- a/tests/subsys/logging/log_core_additional/testcase.yaml
+++ b/tests/subsys/logging/log_core_additional/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - native_posix
+
 tests:
   logging.add.async:
     tags: logging

--- a/tests/subsys/logging/log_immediate/testcase.yaml
+++ b/tests/subsys/logging/log_immediate/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - native_posix
+
 tests:
   logging.log_immediate:
     tags: log_core logging

--- a/tests/subsys/logging/log_list/testcase.yaml
+++ b/tests/subsys/logging/log_list/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - native_posix
+
 tests:
   logging.log_list:
     tags: log_list logging

--- a/tests/subsys/logging/log_msg/testcase.yaml
+++ b/tests/subsys/logging/log_msg/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - native_posix
+
 tests:
   logging.log_msg:
     tags: log_msg logging

--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - native_posix
+
 tests:
   logging.log_output:
     tags: log_output logging


### PR DESCRIPTION
Set integration_platforms on these tests to just native_posix.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>