### PR TITLE
tests: uart_basic_api: set integration_platforms to mps2_an385

### DIFF
--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  integration_platforms:
+    - mps2_an385
+
 tests:
   drivers.uart:
     tags: drivers


### PR DESCRIPTION
Set integration_platforms on these tests to just mps2_an385.  This
should be sufficient to make sure these tests build and run.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>