### PR TITLE
nRF: change UART DT pinmux properties to tx-gpios, rx-gpios, rts-gpios, cts-gpios

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/sdk/zephyr-sdk-0.12.3"
-    parallelism: 20
+    parallelism: 50
     timeout_in_minutes: 180
     retry:
       manual: true

--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -37,8 +37,8 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <29>;
-	rx-pin = <11>;
+	tx-gpios = <&gpio0 29 0>;
+	rx-gpios = <&gpio0 11 0>;
 };
 
 &spi1 {

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -66,10 +66,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <13>;
-	rx-pin = <15>;
-	rts-pin = <12>;
-	cts-pin = <14>;
+	tx-gpios = <&gpio0 13 0>;
+	rx-gpios = <&gpio0 15 0>;
+	rts-gpios = <&gpio0 12 0>;
+	cts-gpios = <&gpio0 14 0>;
 };
 
 &i2c0 {

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -98,24 +98,24 @@
 	status = "okay";
 
 	current-speed = <115200>;
-	tx-pin = <9>;
-	rx-pin = <6>;
-	rts-pin = <7>;
-	cts-pin = <25>;
+	tx-gpios = <&gpio0 9 0>;
+	rx-gpios = <&gpio0 6 0>;
+	rts-gpios = <&gpio0 7 0>;
+	cts-gpios = <&gpio0 25 0>;
 };
 
 &uart1 {
 	status = "okay";
 
 	current-speed = <115200>;
-	tx-pin = <24>;
-	rx-pin = <23>;
+	tx-gpios = <&gpio0 24 0>;
+	rx-gpios = <&gpio0 23 0>;
 };
 
 &uart2 {
 	current-speed = <115200>;
-	tx-pin = <4>;
-	rx-pin = <5>;
+	tx-gpios = <&gpio0 4 0>;
+	rx-gpios = <&gpio0 5 0>;
 };
 
 &i2c2 {

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -71,8 +71,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <25>;
-	rx-pin = <24>;
+	tx-gpios = <&gpio0 25 0>;
+	rx-gpios = <&gpio0 24 0>;
 };
 
 &i2c0 {

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -63,8 +63,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <35>; //P1.03
-	rx-pin = <42>; //P1.10
+	tx-gpios = <&gpio1 3 0>;
+	rx-gpios = <&gpio1 10 0>;
 };
 &i2c0 {
 	compatible = "nordic,nrf-twim";

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -53,8 +53,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <24>;
-	rx-pin = <25>;
+	tx-gpios = <&gpio0 24 0>;
+	rx-gpios = <&gpio0 25 0>;
 };
 
 &i2c0 {

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -83,8 +83,8 @@
 	compatible = "nordic,nrf-uart";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <40>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio1 8 0>;
 };
 
 &i2c0 {

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -71,10 +71,10 @@
 	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -95,10 +95,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -95,10 +95,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/bmd_345_eval/bmd_345_eval.dts
+++ b/boards/arm/bmd_345_eval/bmd_345_eval.dts
@@ -145,10 +145,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -103,8 +103,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 };
 
 &i2c0 {

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -90,19 +90,19 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <5>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 5 0>;
 };
 
 &uart1 {
 	current-speed = <115200>;
-	tx-pin = <0>;
-	rx-pin = <1>;
+	tx-gpios = <&gpio0 0 0>;
+	rx-gpios = <&gpio0 1 0>;
 };
 
 &uart2 {
-	tx-pin = <24>;
-	rx-pin = <23>;
+	tx-gpios = <&gpio0 24 0>;
+	rx-gpios = <&gpio0 23 0>;
 };
 
 &i2c1 {

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -37,8 +37,8 @@
 	status = "okay";
 	current-speed = <115200>;
 
-	tx-pin = <7>;
-	rx-pin = <6>;
+	tx-gpios = <&gpio0 7 0>;
+	rx-gpios = <&gpio0 6 0>;
 };
 
 arduino_serial: &uart1 {
@@ -46,10 +46,10 @@ arduino_serial: &uart1 {
 	current-speed = <115200>;
 
 	/* UART Pin info. */
-	rx-pin  = <20>;
-	tx-pin  = <24>;
-	rts-pin = <17>;
-	cts-pin = <16>;
+	rx-gpios = <&gpio0 20 0>;
+	tx-gpios = <&gpio0 24 0>;
+	rts-gpios = <&gpio0 17 0>;
+	cts-gpios = <&gpio0 16 0>;
 
 	/* Use hardware flow control. */
 	hw-flow-control;

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -90,8 +90,8 @@
 	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	tx-pin  = <5>;
-	rx-pin  = <11>;
+	tx-gpios = <&gpio0 5 0>;
+	rx-gpios = <&gpio0 11 0>;
 };
 
 &i2c0 {

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -85,10 +85,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <25>;
-	rx-pin = <24>;
-	rts-pin = <23>;
-	cts-pin = <21>;
+	tx-gpios = <&gpio0 25 0>;
+	rx-gpios = <&gpio0 24 0>;
+	rts-gpios = <&gpio0 23 0>;
+	cts-gpios = <&gpio0 21 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -154,17 +154,17 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 arduino_serial: &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	rx-pin = <33>;
-	tx-pin = <34>;
+	rx-gpios = <&gpio1 1 0>;
+	tx-gpios = <&gpio1 2 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -98,8 +98,8 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <9>;
-	rx-pin = <11>;
-	rts-pin = <8>;
-	cts-pin = <10>;
+	tx-gpios = <&gpio0 9 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 8 0>;
+	cts-gpios = <&gpio0 10 0>;
 };

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -44,8 +44,8 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <9>;
-	rx-pin = <11>;
-	rts-pin = <8>;
-	cts-pin = <10>;
+	tx-gpios = <&gpio0 9 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 8 0>;
+	cts-gpios = <&gpio0 10 0>;
 };

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -57,10 +57,10 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <10>;
-	rx-pin = <11>;
-	rts-pin = <12>;
-	cts-pin = <13>;
+	tx-gpios = <&gpio0 10 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 12 0>;
+	cts-gpios = <&gpio0 13 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -98,10 +98,10 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <9>;
-	rx-pin = <11>;
-	rts-pin = <8>;
-	cts-pin = <10>;
+	tx-gpios = <&gpio0 9 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 8 0>;
+	cts-gpios = <&gpio0 10 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -69,10 +69,10 @@
 &uart0 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <9>;
-	rx-pin = <11>;
-	rts-pin = <8>;
-	cts-pin = <10>;
+	tx-gpios = <&gpio0 9 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 8 0>;
+	cts-gpios = <&gpio0 10 0>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -94,10 +94,10 @@
 	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	tx-pin = <20>;
-	rx-pin = <19>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 20 0>;
+	rx-gpios = <&gpio0 19 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -94,10 +94,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -132,17 +132,17 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 arduino_serial: &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	rx-pin = <33>;
-	tx-pin = <34>;
+	rx-gpios = <&gpio1 1 0>;
+	tx-gpios = <&gpio1 2 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -77,10 +77,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -100,10 +100,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <20>;
-	rx-pin = <19>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 20 0>;
+	rx-gpios = <&gpio0 19 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -96,8 +96,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <8>;
-	rx-pin = <7>;
+	tx-gpios = <&gpio0 8 0>;
+	rx-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -99,10 +99,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -143,17 +143,17 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 arduino_serial: &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	rx-pin = <33>;
-	tx-pin = <34>;
+	rx-gpios = <&gpio1 1 0>;
+	tx-gpios = <&gpio1 2 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -104,10 +104,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <20>;
-	rx-pin = <24>;
-	rts-pin = <17>;
-	cts-pin = <22>;
+	tx-gpios = <&gpio0 20 0>;
+	rx-gpios = <&gpio0 24 0>;
+	rts-gpios = <&gpio0 17 0>;
+	cts-gpios = <&gpio0 22 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -78,8 +78,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -47,10 +47,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <29>;
-	rx-pin = <30>;
-	rts-pin = <2>;
-	cts-pin = <28>;
+	tx-gpios = <&gpio0 29 0>;
+	rx-gpios = <&gpio0 30 0>;
+	rts-gpios = <&gpio0 2 0>;
+	cts-gpios = <&gpio0 28 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -58,8 +58,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <27>;
-	rx-pin = <26>;
+	tx-gpios = <&gpio0 27 0>;
+	rx-gpios = <&gpio0 26 0>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -57,10 +57,10 @@
 	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -106,10 +106,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -93,10 +93,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &i2c0 {

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -140,10 +140,10 @@ arduino_serial: &uart0 {
 	status = "okay";
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -133,10 +133,10 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <20>;
-	rx-pin = <22>;
-	rts-pin = <19>;
-	cts-pin = <21>;
+	tx-gpios = <&gpio0 20 0>;
+	rx-gpios = <&gpio0 22 0>;
+	rts-gpios = <&gpio0 19 0>;
+	cts-gpios = <&gpio0 21 0>;
 };
 
 &pwm0 {
@@ -187,8 +187,8 @@
 arduino_serial: &uart1 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	tx-pin = <33>;
-	rx-pin = <32>;
+	tx-gpios = <&gpio1 1 0>;
+	rx-gpios = <&gpio1 0 0>;
 };
 
 arduino_i2c: &i2c1 {};

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -119,10 +119,10 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <33>;
-	rx-pin = <32>;
-	rts-pin = <11>;
-	cts-pin = <10>;
+	tx-gpios = <&gpio1 1 0>;
+	rx-gpios = <&gpio1 0 0>;
+	rts-gpios = <&gpio0 11 0>;
+	cts-gpios = <&gpio0 10 0>;
 };
 
 arduino_serial: &uart0{};

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -67,21 +67,21 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <29>;
-	rx-pin = <30>;
+	tx-gpios = <&gpio0 29 0>;
+	rx-gpios = <&gpio0 30 0>;
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <14>;
-	rx-pin = <15>;
+	tx-gpios = <&gpio0 14 0>;
+	rx-gpios = <&gpio0 15 0>;
 };
 
 &uart2 {
 	current-speed = <115200>;
-	tx-pin = <18>;
-	rx-pin = <19>;
+	tx-gpios = <&gpio0 18 0>;
+	rx-gpios = <&gpio0 19 0>;
 };
 
 &i2c2 {

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -67,22 +67,22 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <29>;
-	rx-pin = <30>;
+	tx-gpios = <&gpio0 29 0>;
+	rx-gpios = <&gpio0 30 0>;
 
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <14>;
-	rx-pin = <15>;
+	tx-gpios = <&gpio0 14 0>;
+	rx-gpios = <&gpio0 15 0>;
 };
 
 &uart2 {
 	current-speed = <115200>;
-	tx-pin = <18>;
-	rx-pin = <19>;
+	tx-gpios = <&gpio0 18 0>;
+	rx-gpios = <&gpio0 19 0>;
 };
 
 

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -42,10 +42,10 @@
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <5>;
-	rx-pin = <3>;
-	rts-pin = <40>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 5 0>;
+	rx-gpios = <&gpio0 3 0>;
+	rts-gpios = <&gpio1 8 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &flash0 {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -90,24 +90,24 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <29>;
-	rx-pin = <28>;
-	rts-pin = <27>;
-	cts-pin = <26>;
+	tx-gpios = <&gpio0 29 0>;
+	rx-gpios = <&gpio0 28 0>;
+	rts-gpios = <&gpio0 27 0>;
+	cts-gpios = <&gpio0 26 0>;
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <1>;
-	rx-pin = <0>;
-	rts-pin = <14>;
-	cts-pin = <15>;
+	tx-gpios = <&gpio0 1 0>;
+	rx-gpios = <&gpio0 0 0>;
+	rts-gpios = <&gpio0 14 0>;
+	cts-gpios = <&gpio0 15 0>;
 };
 
 &uart2 {
-	tx-pin = <24>;
-	rx-pin = <23>;
+	tx-gpios = <&gpio0 24 0>;
+	rx-gpios = <&gpio0 23 0>;
 };
 
 &i2c2 {

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -220,8 +220,8 @@ feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
 };
 

--- a/boards/arm/particle_argon/dts/mesh_feather_uart1_rtscts.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather_uart1_rtscts.dtsi
@@ -9,6 +9,6 @@
  * NOTE: This file is replicated in particle_{argon,boron,xenon}.
  * Changes should be made in all instances. */
 &uart0 {
-	rts-pin = <33>;
-	cts-pin = <34>;
+	rts-gpios = <&gpio1 1 0>;
+	cts-gpios = <&gpio1 2 0>;
 };

--- a/boards/arm/particle_argon/particle_argon.dts
+++ b/boards/arm/particle_argon/particle_argon.dts
@@ -31,8 +31,8 @@
 	compatible = "nordic,nrf-uarte";
 	current-speed = <921600>;
 	status = "okay";
-	tx-pin = <37>;
-	rx-pin = <36>;
-	rts-pin = <39>;
-	cts-pin = <38>;
+	tx-gpios = <&gpio1 5 0>;
+	rx-gpios = <&gpio1 4 0>;
+	rts-gpios = <&gpio1 7 0>;
+	cts-gpios = <&gpio1 6 0>;
 };

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -220,8 +220,8 @@ feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
 };
 

--- a/boards/arm/particle_boron/dts/mesh_feather_uart1_rtscts.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather_uart1_rtscts.dtsi
@@ -9,6 +9,6 @@
  * NOTE: This file is replicated in particle_{argon,boron,xenon}.
  * Changes should be made in all instances. */
 &uart0 {
-	rts-pin = <33>;
-	cts-pin = <34>;
+	rts-gpios = <&gpio1 1 0>;
+	cts-gpios = <&gpio1 2 0>;
 };

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -36,10 +36,10 @@
 	current-speed = <115200>;
 	status = "okay";
 
-	tx-pin = <37>;
-	rx-pin = <36>;
-	rts-pin = <39>;
-	cts-pin = <38>;
+	tx-gpios = <&gpio1 5 0>;
+	rx-gpios = <&gpio1 4 0>;
+	rts-gpios = <&gpio1 7 0>;
+	cts-gpios = <&gpio1 6 0>;
 	hw-flow-control;
 
 	sara_r4 {

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -220,8 +220,8 @@ feather_serial: &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
 };
 

--- a/boards/arm/particle_xenon/dts/mesh_xenon_uart2.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_xenon_uart2.dtsi
@@ -9,8 +9,8 @@
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <40>;
-	rx-pin = <42>;
+	tx-gpios = <&gpio1 8 0>;
+	rx-gpios = <&gpio1 10 0>;
 	rts-pin = <35>;
 	cts-pin = <43>;
 };

--- a/boards/arm/particle_xenon/particle_xenon.dts
+++ b/boards/arm/particle_xenon/particle_xenon.dts
@@ -31,7 +31,7 @@
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "disabled";
-	tx-pin = <40>;
-	rx-pin = <42>;
+	tx-gpios = <&gpio1 8 0>;
+	rx-gpios = <&gpio1 10 0>;
 	/* optional mesh_feather_uart2_rtscts.dtsi */
 };

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -79,8 +79,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <11>;
-	rx-pin = <30>;
+	tx-gpios = <&gpio0 11 0>;
+	rx-gpios = <&gpio0 30 0>;
 };
 
 &i2c0 {

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -94,20 +94,20 @@
 	compatible = "nordic,nrf-uart";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &uart1 {
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <14>;
-	rx-pin = <16>;
-	rts-pin = <13>;
-	cts-pin = <15>;
+	tx-gpios = <&gpio0 14 0>;
+	rx-gpios = <&gpio0 16 0>;
+	rts-gpios = <&gpio0 13 0>;
+	cts-gpios = <&gpio0 15 0>;
 	hl7800 {
 		compatible = "swir,hl7800";
 		status = "okay";

--- a/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
+++ b/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
@@ -34,8 +34,8 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <24>;
-	rx-pin = <25>;
+	tx-gpios = <&gpio0 24 0>;
+	rx-gpios = <&gpio0 25 0>;
 };
 
 &flash0 {

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -56,10 +56,10 @@
 	compatible = "nordic,nrf-uart";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <7>;
-	cts-pin = <11>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 7 0>;
+	cts-gpios = <&gpio0 11 0>;
 
 	/* QUECTEL BG9X */
 	quectel_bg9x: quectel_bg9x {
@@ -77,8 +77,8 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <33>;
-	rx-pin = <34>;
+	tx-gpios = <&gpio1 1 0>;
+	rx-gpios = <&gpio1 2 0>;
 };
 
 &i2c1 {

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -102,15 +102,15 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 };
 
 arduino_serial: &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	rx-pin = <33>;
-	tx-pin = <34>;
+	rx-gpios = <&gpio1 1 0>;
+	tx-gpios = <&gpio1 2 0>;
 };
 
 arduino_i2c: &i2c0 {

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -66,10 +66,10 @@
 	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	tx-pin = <5>;
-	rx-pin = <4>;
-	cts-pin = <31>;
-	rts-pin = <30>;
+	tx-gpios = <&gpio0 5 0>;
+	rx-gpios = <&gpio0 4 0>;
+	cts-gpios = <&gpio0 31 0>;
+	rts-gpios = <&gpio0 30 0>;
 };
 
 &spi0 {

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -119,8 +119,8 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <3>;
-	rx-pin = <2>;
+	tx-gpios = <&gpio0 3 0>;
+	rx-gpios = <&gpio0 2 0>;
 };
 
 &i2c0 {

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -46,8 +46,10 @@ properties:
 
     tx-pin:
       type: int
-      required: false
+      deprecated: true
       description: |
+        Deprecated; use tx-gpios instead.
+
         The TX pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -62,21 +64,27 @@ properties:
 
     rx-pin:
       type: int
-      required: false
+      deprecated: true
       description: |
+        Deprecated; use rx-gpios instead.
+
         The RX pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
 
     rts-pin:
       type: int
-      required: false
+      deprecated: true
       description: |
+        Deprecated; use rts-gpios instead.
+
         The RTS pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
 
     cts-pin:
       type: int
-      required: false
+      deprecated: true
       description: |
+        Deprecated; use cts-gpios instead.
+
         The CTS pin to use. The pin numbering scheme is the same as the
         tx-pin property's.

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -7,9 +7,46 @@ properties:
     interrupts:
       required: true
 
+    tx-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        The TX pin to use. The value is "<&gpioX Y flags>".
+        Pin PX.Y will be used for TX. The "flags" portion currently
+        has no effect, but must be set to zero.
+
+        For example, to use P0.16 for TX, set:
+
+          tx-gpios = <&gpio0 16 0>;
+
+        To use P1.2 for TX, set:
+
+          tx-gpios = <&gpio1 2 0>;
+
+    rx-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        The RX pin to use. The value should be set in the same
+        way as the tx-gpios property.
+
+    rts-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        The RTS pin to use. The value should be set in the same
+        way as the tx-gpios property.
+
+    cts-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        The CTS pin to use. The value should be set in the same
+        way as the tx-gpios property.
+
     tx-pin:
       type: int
-      required: true
+      required: false
       description: |
         The TX pin to use.
 

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -36,10 +36,10 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };
 
 &flash0 {

--- a/samples/bluetooth/hci_uart/boards/nrf9160dk_nrf52840.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf9160dk_nrf52840.overlay
@@ -11,8 +11,8 @@
 	current-speed = <1000000>;
 	status = "okay";
 	hw-flow-control;
-	tx-pin = <17>;
-	rx-pin = <20>;
-	rts-pin = <15>;
-	cts-pin = <22>;
+	tx-gpios = <&gpio0 17 0>;
+	rx-gpios = <&gpio0 20 0>;
+	rts-gpios = <&gpio0 15 0>;
+	cts-gpios = <&gpio0 22 0>;
 };

--- a/samples/drivers/spi_flash_at45/boards/nrf9160dk_nrf9160.overlay
+++ b/samples/drivers/spi_flash_at45/boards/nrf9160dk_nrf9160.overlay
@@ -48,5 +48,5 @@
 	 * Only TX is used in this sample, so delete the RX pin assignment
 	 * to prevent UART receiver from being enabled and consuming power.
 	 */
-	/delete-property/ rx-pin;
+	/delete-property/ rx-gpios;
 };

--- a/tests/drivers/uart/uart_async_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf52840dk_nrf52840.overlay
@@ -9,18 +9,18 @@
 &uart1 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <0>;
-	cts-pin = <0>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
+	rts-gpios = <&gpio0 0 0>;
+	cts-gpios = <&gpio0 0 0>;
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <33>;
-	rx-pin = <34>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	tx-gpios = <&gpio1 1 0>;
+	rx-gpios = <&gpio1 2 0>;
+	rts-gpios = <&gpio0 5 0>;
+	cts-gpios = <&gpio0 7 0>;
 };

--- a/tests/drivers/uart/uart_async_api/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf9160dk_nrf9160.overlay
@@ -4,6 +4,6 @@
 	current-speed = <115200>;
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
-	tx-pin = <10>;
-	rx-pin = <11>;
+	tx-gpios = <&gpio0 10 0>;
+	rx-gpios = <&gpio0 11 0>;
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
@@ -9,18 +9,18 @@
 &uart1 {
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <6>;
-	rx-pin = <8>;
+	tx-gpios = <&gpio0 6 0>;
+	rx-gpios = <&gpio0 8 0>;
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-	tx-pin = <44>;
-	rx-pin = <45>;
-	rts-pin = <46>;
-	cts-pin = <47>;
+	tx-gpios = <&gpio1 12 0>;
+	rx-gpios = <&gpio1 13 0>;
+	rts-gpios = <&gpio1 14 0>;
+	cts-gpios = <&gpio1 15 0>;
 	hw-flow-control;
 };
 

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf9160dk_nrf9160.overlay
@@ -4,10 +4,10 @@
 	current-speed = <115200>;
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
-	tx-pin = <10>;
-	rx-pin = <11>;
-	rts-pin = <12>;
-	cts-pin = <13>;
+	tx-gpios = <&gpio0 10 0>;
+	rx-gpios = <&gpio0 11 0>;
+	rts-gpios = <&gpio0 12 0>;
+	cts-gpios = <&gpio0 13 0>;
 	hw-flow-control;
 };
 


### PR DESCRIPTION
This continues work begun in #31965 by making a similar change to UART bindings.

A prototypical example is to specify TX and RX like this in an overlay:

```
   &uart0 {
         tx-gpios = <&gpio0 1 0>;
         rx-gpios = <&gpio1 4 0>;
   };
```

Instead of:

```
   &uart0 {
         tx-pin = <1>;
         rx-pin = <36>;
   };
```

The old style is still supported, but at most one property in each pair can be given. Provide error checking and understandable error messages for invalid configurations.