### PR TITLE
driver: pinctrl: add functions to set/get WP pin status

### DIFF
--- a/drivers/pinmux/pinmux_npcx.c
+++ b/drivers/pinmux/pinmux_npcx.c
@@ -100,6 +100,25 @@ void npcx_pinctrl_i2c_port_sel(int controller, int port)
 	}
 }
 
+int npcx_pinctrl_flash_write_protect_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	inst_scfg->DEV_CTL4 |= BIT(NPCX_DEV_CTL4_WP_IF);
+	if (!IS_BIT_SET(inst_scfg->DEV_CTL4, NPCX_DEV_CTL4_WP_IF)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+bool npcx_pinctrl_flash_write_protect_is_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	return IS_BIT_SET(inst_scfg->DEV_CTL4, NPCX_DEV_CTL4_WP_IF);
+}
+
 /* Pin-control driver registration */
 static int npcx_pinctrl_init(const struct device *dev)
 {

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -80,6 +80,19 @@ void npcx_pinctrl_mux_configure(const struct npcx_alt *alts_list,
  */
 void npcx_pinctrl_i2c_port_sel(int controller, int port);
 
+/**
+ * @brief Force the internal SPI flash write-protect pin (WP) to low level to
+ * protect the flash Status registers.
+ */
+int npcx_pinctrl_flash_write_protect_set(void);
+
+/**
+ * @brief Get write protection status
+ *
+ * @return 1 if write protection is set, 0 otherwise.
+ */
+bool npcx_pinctrl_flash_write_protect_is_set(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The Write Protect pin of the internal SPI flash can be controlled by
WP_IF bit in DEV_CTL4 register. Add functions to set/get the status of WP pin.