### PR TITLE
tests: thread: thread_api: fix to allow test to run for non-secure

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -167,8 +167,13 @@ void test_thread_name_user_get_set(void)
 	char too_small[2];
 
 	/* Some memory-related error cases for k_thread_name_set() */
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Non-Secure images cannot normally access memory outside the image
+	 * flash and ram.
+	 */
 	ret = k_thread_name_set(NULL, (const char *)0xFFFFFFF0);
 	zassert_equal(ret, -EFAULT, "accepted nonsense string (%d)", ret);
+#endif
 	ret = k_thread_name_set(NULL, unreadable_string);
 	zassert_equal(ret, -EFAULT, "accepted unreadable string");
 	ret = k_thread_name_set((struct k_thread *)&sem, "some name");


### PR DESCRIPTION
Allow the test to run for non-secure firmware builds, by
removing the test-case for nonsense string, as this test-case
will likely produce a secure fault which will crash the kernel.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>