### PR TITLE
Bluetooth: Use bt_id_get function to get count

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -182,6 +182,10 @@ __deprecated int bt_set_id_addr(const bt_addr_le_t *addr);
  * identifier that some APIs expect (such as advertising parameters) is
  * simply the index of the identity in the @a addrs array.
  *
+ * If @a addrs is passed as NULL, then returned @a count contains the
+ * count of all available identities that can be retrieved with a
+ * subsequent call to this function with non-NULL @a addrs parameter.
+ *
  * @note Deleted identities may show up as BT_LE_ADDR_ANY in the returned
  * array.
  *

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6716,10 +6716,14 @@ int bt_set_id_addr(const bt_addr_le_t *addr)
 
 void bt_id_get(bt_addr_le_t *addrs, size_t *count)
 {
-	size_t to_copy = MIN(*count, bt_dev.id_count);
+	if (addrs) {
+		size_t to_copy = MIN(*count, bt_dev.id_count);
 
-	memcpy(addrs, bt_dev.id_addr, to_copy * sizeof(bt_addr_le_t));
-	*count = to_copy;
+		memcpy(addrs, bt_dev.id_addr, to_copy * sizeof(bt_addr_le_t));
+		*count = to_copy;
+	} else {
+		*count = bt_dev.id_count;
+	}
 }
 
 static int id_find(const bt_addr_le_t *addr)


### PR DESCRIPTION
Allow NULL pointer to be passed to bt_id_get function so
that only count can be fetched.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>