### PR TITLE
boards: mec15xxevb_assy6853: remove unused Kconfig settings

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -54,16 +54,6 @@ if SPI
 config SPI_XEC_QMSPI
 	default y
 
-if SPI_XEC_QMSPI
-
-config SPI_0
-	default y
-
-config SPI_0_OP_MODES
-	default 1
-
-endif # SPI_XEC_QMSPI
-
 endif # SPI
 
 config TACH_XEC


### PR DESCRIPTION
CONFIG_SPI_0 and CONFIG_SPI_0_OP_MODES aren't relevant for the
XEC QMSPI driver so remove setting them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>