### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: c52ecb771a9b2bdabfc70bee094555f11edbb539
+      revision: 9f09bae7c0ad7df5e0a72731061125913fba61c7
       path: modules/lib/mcumgr
     - name: net-tools
       revision: 41132e9220f8bc1223084975350c5e5f3b492afe


### PR DESCRIPTION
Commits affecting Zephyr that are included with the new revision:

* 99f9fd6 img_mgmt: Use IMG_MGMT_BOOT_CURR_SLOT as current running slot ID
 	    (enhancement)
* 6f52fd9 zephyr: fix initialization of file struct (bug fix)

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>