### PR TITLE
dts: stm: f1: Fix duplicate label

### DIFF
--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -174,7 +174,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
 			interrupts = < 56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
-			label = "DMA_1";
+			label = "DMA_2";
 		};
 	};
 };


### PR DESCRIPTION
The dma1 & dma2 controllers had the same label value.  The dma2
controller should really be "DMA_2".

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>