### PR TITLE
tests: kernel: some more minor fixes for cortex-M non-secure builds

### DIFF
--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -119,7 +119,10 @@ static void test_bogus_dynamic_name(void)
  */
 static void test_null_dynamic_name(void)
 {
-#if CONFIG_USERSPACE
+	/* Supplying a NULL dynamic name may trigger a SecureFault and
+	 * lead to system crash in TrustZone enabled Non-Secure builds.
+	 */
+#if defined(CONFIG_USERSPACE) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	const struct device *mux;
 	char *drv_name = NULL;
 

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     # nios2 excluded, see #22956
     arch_exclude: nios2
     tags: interrupt
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
Some more fixes to the kernel test-suite, to allow running the tests for Cortex-M Non-Secure