### PR TITLE
scripts: dts: gen_defines: Add error check for duplicate labels

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -92,6 +92,16 @@ def main():
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
             node.z_path_id = node_z_path_id(node)
 
+        # Check to see if we have duplicate "label" property values.
+        labels = dict()
+        for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
+            if 'label' in node.props:
+                label = node.props['label'].val
+                if label in labels:
+                    sys.exit(f"ERROR: Duplicate label ({label}) properties "
+                             f"between {labels[label].path} and {node.path}")
+                labels[label] = node
+
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
             write_node_comment(node)
 


### PR DESCRIPTION
As the value of label properties get used as device names we shouldn't
have the same label value used more than once.  Treat this as an
error condition.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>