### PR TITLE
scripts: edtlib: do not inherit parent compatibles

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -244,6 +244,22 @@ Documentation
 Tests and Samples
 *****************
 
+* Twister's ``dt_compat_enabled_with_alias()`` test case filter was deprecated
+  in favor of a new ``dt_enabled_alias_with_parent_compat()`` filter. The old
+  filter is still supported, but it may be removed in a future release.
+
+  To update, replace uses like this:
+
+  .. code-block:: yaml
+
+     filter: dt_compat_enabled_with_alias("gpio-leds", "led0")
+
+  with:
+
+  .. code-block:: yaml
+
+     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
+
 Issue Related Items
 *******************
 

--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.basic.blinky:
     tags: LED gpio
-    filter: dt_compat_enabled_with_alias("gpio-leds", "led0")
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
     depends_on: gpio
     harness: led
     integration_platforms:

--- a/samples/basic/button/sample.yaml
+++ b/samples/basic/button/sample.yaml
@@ -3,6 +3,6 @@ sample:
 tests:
   sample.basic.button:
     tags: button gpio
-    filter: dt_compat_enabled_with_alias("gpio-keys", "sw0")
+    filter: dt_enabled_alias_with_parent_compat("sw0", "gpio-keys")
     depends_on: gpio
     harness: button

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -5,8 +5,8 @@ sample:
 tests:
   sample.basic.threads:
     tags: kernel threads gpio
-    filter: dt_compat_enabled_with_alias("gpio-leds", "led0") and
-            dt_compat_enabled_with_alias("gpio-leds", "led1")
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+            dt_enabled_alias_with_parent_compat("led1", "gpio-leds")
     depends_on: gpio
     harness: console
     harness_config:

--- a/samples/subsys/mgmt/osdp/control_panel/sample.yaml
+++ b/samples/subsys/mgmt/osdp/control_panel/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.mgmt.osdp.control_panel:
     tags: osdp
-    filter: dt_compat_enabled_with_alias("gpio-leds", "led0") and CONFIG_SERIAL
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and CONFIG_SERIAL
     harness: osdp
     integration_platforms:
       - frdm_k64f

--- a/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
+++ b/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.mgmt.osdp.peripheral_device:
     tags: osdp
-    filter: dt_compat_enabled_with_alias("gpio-leds", "led0") and CONFIG_SERIAL
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and CONFIG_SERIAL
     harness: osdp
     integration_platforms:
       - frdm_k64f

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1437,10 +1437,11 @@ class Binding:
       The free-form description of the binding.
 
     compatible:
-      The compatible string the binding matches. This is None if the Binding is
-      inferred from node properties. If the Binding is a child binding, then
-      this will be inherited from the parent binding unless the child binding
-      explicitly sets its own compatible.
+      The compatible string the binding matches.
+
+      This may be None. For example, it's None when the Binding is inferred
+      from node properties. It can also be None for Binding objects created
+      using 'child-binding:' with no compatible.
 
     prop2specs:
       A collections.OrderedDict mapping property names to PropertySpec objects
@@ -1547,14 +1548,6 @@ class Binding:
             if key.endswith("-cells"):
                 self.specifier2cells[key[:-len("-cells")]] = val
 
-        # Make child binding compatibles match ours if they are missing.
-        if self.compatible is not None:
-            child = self.child_binding
-            while child is not None:
-                if child.compatible is None:
-                    child.compatible = self.compatible
-                child = child.child_binding
-
     def __repr__(self):
         if self.compatible:
             compat = f" for compatible '{self.compatible}'"
@@ -1570,14 +1563,7 @@ class Binding:
     @property
     def compatible(self):
         "See the class docstring"
-        if hasattr(self, '_compatible'):
-            return self._compatible
         return self.raw.get('compatible')
-
-    @compatible.setter
-    def compatible(self, compatible):
-        "See the class docstring"
-        self._compatible = compatible
 
     @property
     def bus(self):

--- a/scripts/dts/test-bindings/child-binding-with-compat.yaml
+++ b/scripts/dts/test-bindings/child-binding-with-compat.yaml
@@ -2,7 +2,7 @@
 
 description: child-binding with separate compatible than the parent
 
-compatible: "child-binding-with-compat"
+compatible: "top-binding-with-compat"
 
 child-binding:
     compatible: child-compat

--- a/scripts/dts/test-bindings/child-binding.yaml
+++ b/scripts/dts/test-bindings/child-binding.yaml
@@ -2,7 +2,7 @@
 
 description: child-binding test
 
-compatible: "child-binding"
+compatible: "top-binding"
 
 child-binding:
     description: child node

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -359,7 +359,7 @@
 	//
 
 	child-binding {
-		compatible = "child-binding";
+		compatible = "top-binding";
 		child-1 {
 			child-prop = <1>;
 			grandchild {

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -181,15 +181,15 @@ def test_child_binding():
     child = top.child_binding
     assert Path(top.path) == binding_file
     assert Path(child.path) == binding_file
-    assert top.compatible == 'child-binding'
-    assert child.compatible == 'child-binding'
+    assert top.compatible == 'top-binding'
+    assert child.compatible is None
 
     binding_file = Path("test-bindings/child-binding-with-compat.yaml").resolve()
     top = edtlib.Binding(binding_file, {})
     child = top.child_binding
     assert Path(top.path) == binding_file
     assert Path(child.path) == binding_file
-    assert top.compatible == 'child-binding-with-compat'
+    assert top.compatible == 'top-binding-with-compat'
     assert child.compatible == 'child-compat'
 
 def test_props():

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import logging
 import os
 import re
 import sys
@@ -17,6 +18,8 @@ except ImportError:
     sys.exit("PLY library for Python 3 not installed.\n"
              "Please install the ply package using your workstation's\n"
              "package manager or the 'pip' tool.")
+
+_logger = logging.getLogger('twister')
 
 reserved = {
     'and' : 'AND',
@@ -233,19 +236,54 @@ def ast_expr(ast, env, edt):
             if alias in node.aliases and node.status == "okay":
                 return True
         return False
+    elif ast[0] == "dt_enabled_alias_with_parent_compat":
+        # Checks if the DT has an enabled alias node whose parent has
+        # a given compatible. For matching things like gpio-leds child
+        # nodes, which do not have compatibles themselves.
+        #
+        # The legacy "dt_compat_enabled_with_alias" form is still
+        # accepted but is now deprecated and causes a warning. This is
+        # meant to give downstream users some time to notice and
+        # adjust. Its argument order only made sense under the (bad)
+        # assumption that the gpio-leds child node has the same compatible
+
+        alias = ast[1][0]
+        compat = ast[1][1]
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
     elif ast[0] == "dt_compat_enabled_with_alias":
         compat = ast[1][0]
         alias = ast[1][1]
-        for node in edt.nodes:
-            if node.status == "okay" and alias in node.aliases and node.matching_compat == compat:
-                return True
-        return False
+
+        _logger.warning('dt_compat_enabled_with_alias("%s", "%s"): '
+                        'this is deprecated, use '
+                        'dt_enabled_alias_with_parent_compat("%s", "%s") '
+                        'instead',
+                        compat, alias, alias, compat)
+
+        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
+                                                              compat)
     elif ast[0] == "dt_chosen_enabled":
         chosen = ast[1][0]
         node = edt.chosen_node(chosen)
         if node and node.status == "okay":
             return True
         return False
+
+def ast_handle_dt_enabled_alias_with_parent_compat(edt, alias, compat):
+    # Helper shared with the now deprecated
+    # dt_compat_enabled_with_alias version.
+
+    for node in edt.nodes:
+        parent = node.parent
+        if parent is None:
+            continue
+        if (node.status == "okay" and alias in node.aliases and
+                    parent.matching_compat == compat):
+            return True
+
+    return False
 
 mutex = threading.Lock()
 

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import os
 import copy
-import threading
+import os
 import re
+import sys
+import threading
 
 try:
     import ply.lex as lex

--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     min_flash: 48
     # Fix exclude when we can exclude just sim run
     platform_exclude: mps2_an385 mps2_an521
-    filter: dt_compat_enabled_with_alias("gpio-leds", "led0")
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")


### PR DESCRIPTION
Commit 0d4dca10b2ac156b598f96b4dadb44ac7001380b ("scripts: edtlib: child binding compatibles match parents") was a hack meant to keep the edtlib.Binding class in place without modifying some twister behavior that needed further changes to work properly with first-class binding objects.

This is a hack which was necessary due to the way the dt_compat_enabled_with_alias twister filter works. Avoid the need for it by updating the filter so it works by matching the alias node's parent compatible instead. This works for in-tree users, which are all buttons and LEDs. Deprecate the filter and add a replacement, dt_enabled_alias_with_parent_compat, that's clearer.

Now that the edtlib hack is no longer necessary, remove it. Child Binding objects now have None compatible properties unless the binding YAML explicitly sets a compatible.
