### PR TITLE
drivers: dac: dacx3608: fix I2C read error

### DIFF
--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -191,7 +191,7 @@ static int dacx3608_device_id_check(const struct device *dev)
 	uint16_t dev_id;
 	int ret;
 
-	ret = dacx3608_reg_read(dev, DACX3608_REG_STATUS_TRIGGER, dev_id);
+	ret = dacx3608_reg_read(dev, DACX3608_REG_STATUS_TRIGGER, &dev_id);
 	if (ret) {
 		LOG_ERR("Unable to read device ID");
 		return -EIO;


### PR DESCRIPTION
This commit fixes I2C error while reading chip ID in the
init function.

Signed-off-by: Matija Tudan <mtudan@mobilisis.hr>