### PR TITLE
dts: espressif: Move wifi node out of under SoC node.

### DIFF
--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -34,6 +34,11 @@
 
 	};
 
+	wifi: wifi {
+		compatible = "espressif,esp32-wifi";
+		status = "disabled";
+	};
+
 	soc {
 		sram0: memory@3ffb0000 {
 			compatible = "mmio-sram";
@@ -49,11 +54,6 @@
 			#clock-cells = <1>;
 			status = "ok";
 		};
-
-	wifi: wifi {
-		compatible = "espressif,esp32-wifi";
-		status = "disabled";
-	};
 
 		uart0: uart@3ff40000 {
 			compatible = "espressif,esp32-uart";


### PR DESCRIPTION
The wifi controller isn't accessed via MMIO and thus shouldn't
exist under the SoC node which is for MMIO based devices so move
it up a level.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>