### PR TITLE
boards: mec15xxevb_assy6853/mec15xxevb_assy6853: Fix compile warning

### DIFF
--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -32,6 +32,7 @@ struct pinmux_ports_t {
 #endif
 };
 
+#ifdef CONFIG_I2C_XEC
 static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 {
 	switch (port_sel) {
@@ -97,6 +98,7 @@ static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 		break;
 	}
 }
+#endif
 
 static void configure_debug_interface(void)
 {

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -32,6 +32,7 @@ struct pinmux_ports_t {
 #endif
 };
 
+#ifdef CONFIG_I2C_XEC
 static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 {
 	switch (port_sel) {
@@ -97,6 +98,7 @@ static void i2c_pinmux(struct pinmux_ports_t *p, uint8_t port_sel)
 		break;
 	}
 }
+#endif
 
 static void configure_debug_interface(void)
 {


### PR DESCRIPTION
If CONFIG_I2C=n is set we get a build warning:

pinmux.c:35:13: error: 'i2c_pinmux' defined but not used

Fix this by adding ifdef protection around i2c_pinmux.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>