### PR TITLE
Improve I2S CI coverage

### DIFF
--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - netif:eth
   - adc
+  - i2s
   - gpio
   - spi
   - watchdog

--- a/boards/riscv/litex_vexriscv/litex_vexriscv.yaml
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.yaml
@@ -13,6 +13,7 @@ toolchain:
 ram: 262144
 supported:
   - spi
+  - i2s
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
@@ -6,6 +6,8 @@ toolchain:
   - xcc
   - xtools
   - zephyr
+supported:
+  - i2s
 testing:
   ignore_tags:
     - net

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -654,8 +654,6 @@ static int i2s_cavs_trigger(const struct device *dev, enum i2s_dir dir,
 			break;
 		}
 
-		__ASSERT_NO_MSG(strm->mem_block == NULL);
-
 		if (dir == I2S_DIR_TX) {
 			ret = i2s_tx_stream_start(dev_data, ssp,
 					dev_data->dev_dma);


### PR DESCRIPTION
Several I2S drivers never get even build tested.  Add `i2s` as a supported feature to some boards to ensure each i2s driver is at least building on one platform.