### PR TITLE
kernel: Enable better optimization of _current_cpu and _current on SMP

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -170,22 +170,6 @@ typedef struct z_kernel _kernel_t;
 
 extern struct z_kernel _kernel;
 
-#ifdef CONFIG_SMP
-
-/* True if the current context can be preempted and migrated to
- * another SMP CPU.
- */
-bool z_smp_cpu_mobile(void);
-
-#define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
-			arch_curr_cpu(); })
-#define _current k_current_get()
-
-#else
-#define _current_cpu (&_kernel.cpus[0])
-#define _current _kernel.cpus[0].current
-#endif
-
 #define _timeout_q _kernel.timeout_q
 
 /* kernel wait queue record */


### PR DESCRIPTION
We weren't doing a very good job helping out the compiler here.  The
_current thread on SMP is derived from _current_cpu, which is in
general extracted via a bit of arch-specific voodoo from non-GPR CPU
state.

But _current can literally never change from the perspective of
generated code, and the poor compiler was being forced to generate the
extraction code every time it was reference (and it's referenced a
lot!).

Hide these two behind some inline functions with appropriate (GCC)
attributes informing the compiler of the optimization possibilities.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>