### PR TITLE
drivers: timer: reduce max cycles of riscv machine timer

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -10,7 +10,7 @@
 
 #define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec()	\
 			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_CYC 0xffffffffu
+#define MAX_CYC INT_MAX
 #define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000
 


### PR DESCRIPTION
If next_timeout() returns INT_MAX and pass it to
z_clock_set_timeout(), and machine goes to freeze or slow down.
Bad scenario as follows:

- If an argument int32_t ticks is set large value 0xffffffff,
    ticks = MAX(MIN(ticks - 1, (int32_t)MAX_TICKS), 0);
  replaces it into MAX_TICKS.
- uint32_t cyc will be set near by 0xffffffff
  (this is 0xfffd7280 in 100 ticks per second).
- Add adjustment to cyc, adjustment max value is MAX_CYC.
  (cyc = 0xffff14fd)
- Over 0x80000000 value of uint32_t is considered as negative
  value of int32_t.
    if ((int32_t)(cyc + last_count - now) < MIN_DELAY)
  This condition is always true.
- Because cyc += CYC_PER_TICK will get overflow, driver sets mtimecmp
  near value of current mtime.
  (cyc = 0x00007fc0)
- Next timer interrupt will happen soon after return from interrupt
  handler.
- By repeating these events, machine cannot go to next instruction,
  and it's going to freeze or slow down.


Fixed #32711