### PR TITLE
stm32: dmamux: change initialization order to `PRE_KERNEL_1`

### DIFF
--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -252,7 +252,7 @@ DEVICE_DT_INST_DEFINE(index,						\
 		    &dmamux_stm32_init,					\
 		    device_pm_control_nop,				\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &dma_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DMAMUX_INIT)


### PR DESCRIPTION
When running the tests of the async api of uart
on nucleo-l4r5zi we get MPU fault.
The reason is ordering initialization. The uart and dma
drivers are initialized PRE_KERNEL_1 while dmamux is
initialized POST_KERNEL.
Thus, the function device_get_binding fails since the
dmamux device is not ready to be used.

Fixes: #32715.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>