### PR TITLE
net: shell: UDP commands

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4632,6 +4632,266 @@ static int cmd_net_tcp(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_NET_UDP) && defined(CONFIG_NET_NATIVE_UDP) && \
+		defined(CONFIG_NET_IPV6)
+static struct net_context *udp_ctx;
+static const struct shell *udp_shell;
+K_SEM_DEFINE(udp_send_wait, 0, 1);
+
+static void udp_rcvd(struct net_context *context, struct net_pkt *pkt,
+		     union net_ip_header *ip_hdr,
+		     union net_proto_header *proto_hdr, int status,
+		     void *user_data)
+{
+	if (pkt) {
+		size_t len = net_pkt_remaining_data(pkt);
+		uint8_t byte;
+
+		PR_SHELL(udp_shell, "Received UDP packet: ");
+		for (size_t i = 0; i < len; ++i) {
+			net_pkt_read_u8(pkt, &byte);
+			PR_SHELL(udp_shell, "%02x ", byte);
+		}
+		PR_SHELL(udp_shell, "\n");
+	}
+}
+
+static void udp_sent(struct net_context *context, int status, void *user_data)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(status);
+	ARG_UNUSED(user_data);
+
+	PR_SHELL(udp_shell, "Message sent\n");
+	k_sem_give(&udp_send_wait);
+}
+#endif
+
+static int cmd_net_udp_bind(const struct shell *shell, size_t argc,
+			    char *argv[])
+{
+#if !defined(CONFIG_NET_IPV6) || !defined(CONFIG_NET_UDP) || \
+		!defined(CONFIG_NET_NATIVE_UDP)
+	ARG_UNUSED(shell);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return -EOPNOTSUPP;
+#else
+	char *addr_str = NULL;
+	char *endptr = NULL;
+	uint16_t port;
+	int ret;
+
+	struct net_if *iface = net_if_get_default();
+	struct sockaddr addr;
+	int addrlen;
+
+	if (argc < 3) {
+		PR_WARNING("Not enough arguments given for udp bind command\n");
+		return -EINVAL;
+	}
+
+	addr_str = argv[1];
+	port = strtol(argv[2], &endptr, 0);
+
+	if (endptr == argv[2]) {
+		PR_WARNING("Invalid port number\n");
+		return -EINVAL;
+	}
+
+	if (udp_ctx && net_context_is_used(udp_ctx)) {
+		PR_WARNING("Network context already in use\n");
+		return -EALREADY;
+	}
+
+	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, &udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot get UDP context (%d)\n", ret);
+		return ret;
+	}
+
+	udp_shell = shell;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		ret = net_addr_pton(AF_INET6, addr_str,
+					&net_sin6(&addr)->sin6_addr);
+		if (ret < 0) {
+			PR_WARNING("Invalid IPv6 address\n");
+			goto release_ctx;
+		}
+
+		net_sin6(&addr)->sin6_port = htons(port);
+		addrlen = sizeof(struct sockaddr_in6);
+		addr.sa_family = AF_INET6;
+	} else {
+		PR_WARNING("IPv6 is disabled, but it is "
+			   "the only supported protocol in UDP shell\n");
+		goto release_ctx;
+	}
+
+	net_context_set_iface(udp_ctx, iface);
+
+	ret = net_context_bind(udp_ctx, &addr, addrlen);
+	if (ret < 0) {
+		PR_WARNING("Binding to UDP port failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	ret = net_context_recv(udp_ctx, udp_rcvd, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		PR_WARNING("Receiving from UDP port failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	return 0;
+
+release_ctx:
+	ret = net_context_put(udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot put UDP context (%d)\n", ret);
+	}
+
+	return 0;
+#endif
+}
+
+static int cmd_net_udp_close(const struct shell *shell, size_t argc,
+			     char *argv[])
+{
+#if !defined(CONFIG_NET_IPV6) || !defined(CONFIG_NET_UDP) || \
+		!defined(CONFIG_NET_NATIVE_UDP)
+	ARG_UNUSED(shell);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return -EOPNOTSUPP;
+#else
+	int ret;
+
+	if (!udp_ctx || !net_context_is_used(udp_ctx)) {
+		PR_WARNING("Network context is not used. Cannot close.\n");
+		return -EINVAL;
+	}
+
+	ret = net_context_put(udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot close UDP port (%d)\n", ret);
+	}
+
+	return 0;
+#endif
+}
+
+static int cmd_net_udp_send(const struct shell *shell, size_t argc,
+			    char *argv[])
+{
+#if !defined(CONFIG_NET_IPV6) || !defined(CONFIG_NET_UDP) || \
+		!defined(CONFIG_NET_NATIVE_UDP)
+	ARG_UNUSED(shell);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return -EOPNOTSUPP;
+#else
+	char *host = NULL;
+	char *endptr = NULL;
+	uint16_t port;
+	uint8_t *payload = NULL;
+	int ret;
+
+	struct net_if *iface = net_if_get_default();
+	struct sockaddr addr;
+	int addrlen;
+
+	if (argc < 4) {
+		PR_WARNING("Not enough arguments given for udp send command\n");
+		return -EINVAL;
+	}
+
+	host = argv[1];
+	port = strtol(argv[2], &endptr, 0);
+	payload = argv[3];
+
+	if (endptr == argv[2]) {
+		PR_WARNING("Invalid port number\n");
+		return -EINVAL;
+	}
+
+	if (udp_ctx && net_context_is_used(udp_ctx)) {
+		PR_WARNING("Network context already in use\n");
+		return -EALREADY;
+	}
+
+
+	ret = net_context_get(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, &udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot get UDP context (%d)\n", ret);
+		return ret;
+	}
+
+	udp_shell = shell;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		ret = net_addr_pton(AF_INET6, host,
+				    &net_sin6(&addr)->sin6_addr);
+		if (ret < 0) {
+			PR_WARNING("Invalid IPv6 address\n");
+			goto release_ctx;
+		}
+
+		net_sin6(&addr)->sin6_port = htons(port);
+		addrlen = sizeof(struct sockaddr_in6);
+		addr.sa_family = AF_INET6;
+
+		iface = net_if_ipv6_select_src_iface(
+				&net_sin6(&addr)->sin6_addr);
+		if (!iface) {
+			PR_WARNING("No interface to send to given host\n");
+			goto release_ctx;
+		}
+	} else {
+		PR_WARNING("IPv6 is disabled, but it is "
+			   "the only supported protocol in UDP shell\n");
+		goto release_ctx;
+	}
+
+	net_context_set_iface(udp_ctx, iface);
+
+	ret = net_context_recv(udp_ctx, udp_rcvd, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		PR_WARNING("Setting rcv callback failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	ret = net_context_sendto(udp_ctx, payload, strlen(payload), &addr,
+				 addrlen, udp_sent, K_FOREVER, NULL);
+	if (ret < 0) {
+		PR_WARNING("Sending packet failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	k_sem_take(&udp_send_wait, K_FOREVER);
+
+release_ctx:
+	ret = net_context_put(udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot put UDP context (%d)\n", ret);
+	}
+
+	return 0;
+#endif
+}
+
+static int cmd_net_udp(const struct shell *shell, size_t argc, char *argv[])
+{
+	ARG_UNUSED(shell);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 0;
+}
+
 #if defined(CONFIG_NET_VLAN)
 static void iface_vlan_del_cb(struct net_if *iface, void *user_data)
 {
@@ -5282,6 +5542,20 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_pkt,
 	SHELL_SUBCMD_SET_END
 );
 
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_udp,
+	SHELL_CMD(bind, NULL,
+		  "'net udp bind <addr> <port>' binds to UDP local port.",
+		  cmd_net_udp_bind),
+	SHELL_CMD(close, NULL,
+		  "'net udp close' closes previously bound port.",
+		  cmd_net_udp_close),
+	SHELL_CMD(send, NULL,
+		  "'net udp send <host> <port> <payload>' "
+		  "sends UDP packet to a network host.",
+		  cmd_net_udp_send),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(net_commands,
 	SHELL_CMD(allocs, NULL, "Print network memory allocations.",
 		  cmd_net_allocs),
@@ -5319,6 +5593,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_commands,
 		  cmd_net_suspend),
 	SHELL_CMD(tcp, &net_cmd_tcp, "Connect/send/close TCP connection.",
 		  cmd_net_tcp),
+	SHELL_CMD(udp, &net_cmd_udp, "Send/recv UDP packet", cmd_net_udp),
 	SHELL_CMD(vlan, &net_cmd_vlan, "Show VLAN information.", cmd_net_vlan),
 	SHELL_CMD(websocket, NULL, "Print information about WebSocket "
 								"connections.",


### PR DESCRIPTION
This patch adds to network shell set of basic commands for UDP protocol
to receive and send datagrams. It is compatible only with IPv6. It
can be extended later with IPv4 support as well.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>