### PR TITLE
Add UART5 to STM32F446Xe SoC

### DIFF
--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -26,6 +26,15 @@
 			label = "UART_4";
 		};
 
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			interrupts = <53 0>;
+			status = "disabled";
+			label = "UART_5";
+		};
+
 		usbotg_fs: usb@50000000 {
 			num-bidir-endpoints = <6>;
 		};


### PR DESCRIPTION
Add uart5 to stm32f446Xe SoC. @erwango Please take a look. It is almost copy & paste from stm32f405 and works / compiles fine for me. Thererfore it should be very simple one.