### PR TITLE
dts: add support for a bus to have multiple types

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -63,7 +63,7 @@ compatible: "manufacturer,device"
 include: other.yaml # or [other1.yaml, other2.yaml]
 
 # If the node describes a bus, then the bus type should be given, like below
-bus: <string describing bus type, e.g. "i2c">
+bus: <string or list of strings describing bus type, e.g. "i2c" or ["i3c", "i2c"]>
 
 # If the node appears on a bus, then the bus type should be given, like below.
 #

--- a/scripts/dts/test-bindings/bazbar-bus.yaml
+++ b/scripts/dts/test-bindings/bazbar-bus.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Bazbar bus controller
+
+compatible: "bazbar-bus"
+
+bus: ["baz", "bar"]

--- a/scripts/dts/test-bindings/device-on-baz-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-baz-bus.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Device on baz bus
+
+compatible: "on-bus"
+
+on-bus: "baz"

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -348,6 +348,12 @@
 				compatible = "on-bus";
 			};
 		};
+		bazbar-bus {
+			compatible = "bazbar-bus";
+			node {
+				compatible = "on-bus";
+			};
+		};
 		no-bus-node {
 			compatible = "on-any-bus";
 		};

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -157,6 +157,11 @@ def test_bus():
     assert str(edt.get_node("/buses/foo-bus/node1/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
 
+    # Some buses can support other bus types, ensure that the priority is
+    # maintained in the ordering
+    assert str(edt.get_node("/buses/bazbar-bus/node").binding_path) == \
+        hpath("test-bindings/device-on-baz-bus.yaml")
+
 def test_child_binding():
     '''Test 'child-binding:' in bindings'''
     edt = edtlib.EDT("test.dts", ["test-bindings"])


### PR DESCRIPTION
Some upcoming buses, such as i3c, have backward compatibility with i2c.
Currently, the `bus` parameter only supports a single string. This will
be problematic for binding on an i3c bus which can utilize all the
existing i2c drivers and have their `on-bus: i2c` which won't bind to
something defined as `bus: i3c`.

`bus:` would have to be defined as a list (ex. `bus: [i3c, i2c]`) for
it to bind both i3c and i2c devices. This also leaves support for it to
just be defined as a string. The preference is also encoded in the list
order so if there are bindings for both i3c and i2c, it will choose i3c
as that is first in the list.

fixes #29986