### PR TITLE
Add USB 2.0 peripheral for STM32L053 in device tree

### DIFF
--- a/dts/arm/st/f4/stm32f469.dtsi
+++ b/dts/arm/st/f4/stm32f469.dtsi
@@ -14,7 +14,6 @@
 
 		usbotg_hs: usb@40040000 {
 			num-bidir-endpoints = <9>;
-			ram-size = <4096>;
 		};
 	};
 };

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -68,8 +68,28 @@
 			};
 		};
 
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <31 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <1024>;
+			maximum-speed = "full-speed";
+			phys = <&otgfs_phy>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			status = "disabled";
+			label= "USB";
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(2)>;
+		};
+
+		otgfs_phy: otgfs_phy {
+			compatible = "usb-nop-xceiv";
+			#phy-cells = <0>;
+			label = "OTGFS_PHY";
 		};
 	};
 };

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -19,6 +19,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -15,6 +15,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -26,6 +26,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -35,6 +35,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";


### PR DESCRIPTION
I noticed STM32L053 didn't have any USB FS peripheral set similar to STM32L073. It seems to be a copy-paste from STM32L073 since they are both STM32L0x3.

This pull request also:

* Removes redundant `ram-size` parameter set for STM32F469, it is already set for STM32F405 which is included into STM32F469 `.dtsi` file.
* Add `maximum-speed` parameter for USB peripheral for STM32L072 & STM32L073 and all STM32L4x2, STM32L4x3. I set it to `"full-speed"`. Saw this parameter when looking through STM32F4 `.dtsi` files.

This is my first pull request here, hope this helps. 😄 

![image](https://user-images.githubusercontent.com/8218499/109440793-4bdeb100-7a2b-11eb-9697-c81fc9f11b9a.png)