### PR TITLE
usb: mass storage: add missing prompt to Kconfig

### DIFF
--- a/subsys/usb/class/Kconfig.msc
+++ b/subsys/usb/class/Kconfig.msc
@@ -44,7 +44,7 @@ config MASS_STORAGE_BULK_EP_MPS
 	  Mass storage device class bulk endpoints size
 
 config MASS_STORAGE_STACK_SIZE
-	int
+	int "Set stack size for mass storage thread"
 	default 512
 	help
 	  Stack size for mass storage disk operations thread


### PR DESCRIPTION
thread stack size was missing input prompt.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>