### PR TITLE
Bluetooth: controller: nRF5: Move HAL_RADIO_PDU_LEN_MAX into radio_nrf5

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -8,18 +8,18 @@
 #include <sys/dlist.h>
 #include <toolchain.h>
 
-#include <hal/nrf_radio.h>
 #include <hal/nrf_rtc.h>
 #include <hal/nrf_timer.h>
 #include <hal/nrf_ccm.h>
 #include <hal/nrf_aar.h>
 
 #include "util/mem.h"
+
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/ticker.h"
+
 #include "ll_sw/pdu.h"
-#include "radio_nrf5.h"
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
 #if ((CONFIG_BT_CTLR_GPIO_PA_PIN) > 31)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -432,6 +432,7 @@ void *radio_pkt_scratch_get(void)
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
 	defined(CONFIG_BT_CTLR_LE_ENC) && \
+	defined(HAL_RADIO_PDU_LEN_MAX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
 static uint8_t MALIGN(4) _pkt_decrypt[MAX((HAL_RADIO_PDU_LEN_MAX + 3),
@@ -441,6 +442,8 @@ void *radio_pkt_decrypt_get(void)
 {
 	return _pkt_decrypt;
 }
+#elif !defined(HAL_RADIO_PDU_LEN_MAX)
+#error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #endif
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -38,6 +38,14 @@
 #include "radio_nrf52840.h"
 #elif defined(CONFIG_SOC_NRF5340_CPUNET)
 #include "radio_nrf5340.h"
+#elif
+#error "Unsupported SoC."
+#endif
+
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define HAL_RADIO_PDU_LEN_MAX (BIT(5) - 1)
+#else
+#define HAL_RADIO_PDU_LEN_MAX (BIT(8) - 1)
 #endif
 
 #include "radio_nrf5_ppi.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_SOC_SERIES_NRF51X)
-#define HAL_RADIO_PDU_LEN_MAX (BIT(5) - 1)
-#else
-#define HAL_RADIO_PDU_LEN_MAX (BIT(8) - 1)
-#endif
+#include <hal/nrf_radio.h>
 
 #include "hal/nrf5/radio/radio.h"
+#include "hal/nrf5/radio/radio_nrf5.h"
 #include "hal/nrf5/radio/radio_nrf5_txp.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -339,6 +339,7 @@ lll_conn_isr_rx_exit:
 	if (is_rx_enqueue) {
 #if defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
 	defined(CONFIG_BT_CTLR_LE_ENC) && \
+	defined(HAL_RADIO_PDU_LEN_MAX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
 		if (lll->enc_rx) {
@@ -349,6 +350,8 @@ lll_conn_isr_rx_exit:
 			memcpy((void *)pdu_data_rx->lldata,
 			       (void *)pkt_decrypt_data, pdu_data_rx->len);
 		}
+#elif !defined(HAL_RADIO_PDU_LEN_MAX)
+#error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #endif
 
 		ull_pdu_rx_alloc();
@@ -489,10 +492,13 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 		radio_pkt_configure(8, (max_rx_octets + 4), (phy << 1) | 0x01);
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
+	defined(HAL_RADIO_PDU_LEN_MAX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
 		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, phy,
 						      radio_pkt_decrypt_get()));
+#elif !defined(HAL_RADIO_PDU_LEN_MAX)
+#error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #else
 		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, phy,
 						      node_rx->pdu));
@@ -673,6 +679,7 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 {
 #if defined(CONFIG_SOC_COMPATIBLE_NRF52832) && \
 	defined(CONFIG_BT_CTLR_LE_ENC) && \
+	defined(HAL_RADIO_PDU_LEN_MAX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
 	if (lll->enc_rx) {
@@ -682,6 +689,8 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 		memcpy((void *)pdu_data_rx, (void *)pkt_decrypt,
 		       offsetof(struct pdu_data, lldata));
 	}
+#elif !defined(HAL_RADIO_PDU_LEN_MAX)
+#error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #endif
 
 	/* Ack for tx-ed data */


### PR DESCRIPTION
Move the define HAL_RADIO_PDU_LEN_MAX into radio_nrf5.h in
the HAL folders.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>