### PR TITLE
Bluetooth: GAP: LE connection complete event handling priority

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -6319,8 +6319,22 @@ int bt_recv(struct net_buf *buf)
 		hci_event(buf);
 #else
 		struct bt_hci_evt_hdr *hdr = (void *)buf->data;
-		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
 
+		if (hdr->evt == BT_HCI_EVT_LE_META_EVENT) {
+			struct bt_hci_evt_le_meta_event *sub_event =
+				(struct bt_hci_evt_le_meta_event *)(buf->data
+					+ sizeof(struct bt_hci_evt_hdr));
+			switch (sub_event->subevent) {
+			case BT_HCI_EVT_LE_CONN_COMPLETE:
+			case BT_HCI_EVT_LE_ENH_CONN_COMPLETE:
+				hci_event(buf);
+				return 0;
+			default:
+				break;
+			}
+		}
+
+		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
 		if (evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO) {
 			hci_event_prio(buf);
 		}


### PR DESCRIPTION
the LE connection complete event shall keep the same priority with
disconnect event. otherwise LE conn complete event go back first, but
is dealt after LE conn disconnect event because of the rx_queue delay,
causes an error in the connection state machine.

Signed-off-by: YanBiao Hao <haoyanbiao@xiaomi.com>