### PR TITLE
Bluetooth: Host: Updated ISO SCA description

### DIFF
--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -162,6 +162,20 @@ enum {
 	BT_GAP_CTE_NONE = 0xFF,
 };
 
+
+/** @brief Peripheral sleep clock accuracy (SCA) in ppm (parts per million) */
+enum {
+	BT_GAP_SCA_UNKNOWN = 0,
+	BT_GAP_SCA_251_500 = 0,
+	BT_GAP_SCA_151_250 = 1,
+	BT_GAP_SCA_101_150 = 2,
+	BT_GAP_SCA_76_100 = 3,
+	BT_GAP_SCA_51_75 = 4,
+	BT_GAP_SCA_31_50 = 5,
+	BT_GAP_SCA_21_30 = 6,
+	BT_GAP_SCA_0_20 = 7,
+};
+
 /**
  * @}
  */

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -85,7 +85,11 @@ struct bt_iso_chan_qos {
 	uint8_t				dir;
 	/** Channel interval in us. Value range 0x0000FF - 0x0FFFFFF. */
 	uint32_t			interval;
-	/** Channel SCA - Only for CIS */
+	/** @brief Channel peripherals sleep clock accuracy Only for CIS
+	 *
+	 * Shall be worst case sleep clock accuracy of all the peripherals.
+	 * If unknown for the peripherals, this should be set to BT_GAP_SCA_UNKNOWN.
+	 */
 	uint8_t				sca;
 	/** Channel packing mode. 0 for unpacked, 1 for packed. */
 	uint8_t				packing;

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -46,7 +46,7 @@ static struct bt_iso_chan_ops iso_ops = {
 };
 
 static struct bt_iso_chan_qos iso_qos = {
-	.sca = 0x07,
+	.sca = BT_GAP_SCA_UNKNOWN,
 };
 
 struct bt_iso_chan iso_chan = {


### PR DESCRIPTION
The SCA (sca) field of bt_iso_chan_qos did not give much
information about the expected values or what they meant,
nor any information about what the value perhaps should be.

Updated the description and the ISO shell.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>