### PR TITLE
Bluetooth: host: Document not waiting for TX context from sys workqueue

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1047,8 +1047,6 @@ struct bt_gatt_indicate_params {
  *  automatically created after the Characteristic Declaration when using
  *  BT_GATT_CHARACTERISTIC.
  *
- *  The callback is run from System Workqueue context.
- *
  *  Alternatively it is possible to indicate by UUID by setting it on the
  *  parameters, when using this method the attribute given is used as the
  *  start range when looking up for possible matches.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -906,6 +906,10 @@ struct bt_gatt_notify_params {
  *  callback function will be called.
  *
  *  The callback is run from System Workqueue context.
+ *  When called from the System Workqueue context this API will not wait for
+ *  resources for the callback but instead return an error.
+ *  The number of pending callbacks can be increased with the
+ *  @option{CONFIG_BT_CONN_TX_MAX} option.
  *
  *  Alternatively it is possible to notify by UUID by setting it on the
  *  parameters, when using this method the attribute given is used as the
@@ -920,6 +924,8 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 		      struct bt_gatt_notify_params *params);
 
 /** @brief Notify multiple attribute value change.
+ *
+ *  This function works in the same way as @ref bt_gatt_notify_cb.
  *
  *  @param conn Connection object.
  *  @param num_params Number of notification parameters.
@@ -1367,6 +1373,11 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  called.
  *
  *  The callback is run from System Workqueue context.
+ *  When called from the System Workqueue context this API will not wait for
+ *  resources for the callback but instead return an error.
+ *  The number of pending callbacks can be increased with the
+ *  @option{CONFIG_BT_CONN_TX_MAX} option.
+
  *
  *  @note By using a callback it also disable the internal flow control
  *        which would prevent sending multiple commands without waiting for


### PR DESCRIPTION
Document the GATT APIs not waiting for TX context when being called
from the system workqueue context. This is because the TX contexts
are freed by the system workqueue so blocking would cause a deadlock.

The number of TX contexts are by default equal to the number of
TX buffers in the system. Since TX contexts is allocated after a buffer,
but freed from a lower priority than the buffer then there can be more
allocated TX contexts than TX buffers.

Remove the incorrect documentation note about the indication callback
being called from the system workqueue.
The callback will be called by the RX thread once the confirm indication
response has been received.

Fixes: #31742