### PR TITLE
STM32: Convert dma users to new dma helpers macros

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -52,7 +52,6 @@ typedef void (*irq_config_func_t)(const struct device *dev);
 
 
 struct stream {
-	const char *name;
 	DMA_TypeDef *reg;
 	const struct device *dev;
 	uint32_t channel;
@@ -695,14 +694,9 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	struct dma_config dma_cfg = dev_data->dma.cfg;
 	static DMA_HandleTypeDef hdma;
 
-	if (dev_data->dma.name != NULL) {
-		dev_data->dma.dev = device_get_binding(dev_data->dma.name);
-		if (!dev_data->dma.dev) {
-			LOG_ERR("%s device not found", dev_data->dma.name);
-			return -ENODEV;
-		}
-	} else {
-		return -EINVAL;
+	if (!device_is_ready(dev_data->dma.dev)) {
+		LOG_ERR("%s device not ready", dev_data->dma.dev->name);
+		return -ENODEV;
 	}
 
 	/* Proceed to the minimum Zephyr DMA driver init */
@@ -861,7 +855,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 		DT_DMAS_CELL_BY_NAME(node, dir, channel_config)
 
 #define QSPI_DMA_CHANNEL_INIT(node, dir)				\
-	.name = DT_DMAS_LABEL_BY_NAME(node, dir),			\
+	.dev = DEVICE_DT_GET(DT_DMAS_CTLR(node)),			\
 	.channel = DT_DMAS_CELL_BY_NAME(node, dir, channel),		\
 	.reg = (DMA_TypeDef *)DT_REG_ADDR(				\
 				   DT_PHANDLE_BY_NAME(node, dmas, dir)),\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -29,7 +29,7 @@ struct uart_stm32_config {
 
 #ifdef CONFIG_UART_ASYNC_API
 struct uart_dma_stream {
-	const char *dma_name;
+	const struct device *dma_dev;
 	uint32_t dma_channel;
 	struct dma_config dma_cfg;
 	uint8_t priority;
@@ -60,8 +60,6 @@ struct uart_stm32_data {
 
 #ifdef CONFIG_UART_ASYNC_API
 	const struct device *uart_dev;
-	const struct device *dev_dma_tx;
-	const struct device *dev_dma_rx;
 	uart_callback_t async_cb;
 	void *async_user_data;
 	struct uart_dma_stream dma_rx;

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -866,12 +866,10 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 		DT_INST_DMAS_CTLR_BY_NAME(id, dir)
 
 #define SPI_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)	\
-	.channel =							\
-		DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),		\
 	.dma_dev = DEVICE_DT_GET(DMA_CTLR(index, dir)),			\
+	.channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),	\
 	.dma_cfg = {							\
-		.dma_slot =						\
-		   DT_INST_DMAS_CELL_BY_NAME(index, dir, slot),		\
+		.dma_slot = DT_INST_DMAS_CELL_BY_NAME(index, dir, slot),\
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
 					DMA_CHANNEL_CONFIG(index, dir)),       \
 		.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(    \
@@ -890,7 +888,7 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 	.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(	\
 				DMA_CHANNEL_CONFIG(index, dir)),	\
 	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(		\
-					DMA_FEATURES(index, dir)),	\
+				DMA_FEATURES(index, dir)),		\
 
 
 #if CONFIG_SPI_STM32_DMA

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -768,8 +768,8 @@ static int spi_stm32_transceive(const struct device *dev,
 #ifdef CONFIG_SPI_STM32_DMA
 	struct spi_stm32_data *data = DEV_DATA(dev);
 
-	if ((data->dma_tx.dma_name != NULL)
-	 && (data->dma_rx.dma_name != NULL)) {
+	if ((data->dma_tx.dma_dev != NULL)
+	 && (data->dma_rx.dma_dev != NULL)) {
 		return transceive_dma(dev, config, tx_bufs, rx_bufs,
 				      false, NULL);
 	}
@@ -822,21 +822,16 @@ static int spi_stm32_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_SPI_STM32_DMA
-	if (data->dma_tx.dma_name != NULL) {
-		/* Get the binding to the DMA device */
-		data->dma_tx.dma_dev = device_get_binding(data->dma_tx.dma_name);
-		if (!data->dma_tx.dma_dev) {
-			LOG_ERR("%s device not found", data->dma_tx.dma_name);
-			return -ENODEV;
-		}
+	if ((data->dma_rx.dma_dev != NULL) &&
+				!device_is_ready(data->dma_rx.dma_dev)) {
+		LOG_ERR("%s device not ready", data->dma_rx.dma_dev->name);
+		return -ENODEV;
 	}
 
-	if (data->dma_rx.dma_name != NULL) {
-		data->dma_rx.dma_dev = device_get_binding(data->dma_rx.dma_name);
-		if (!data->dma_rx.dma_dev) {
-			LOG_ERR("%s device not found", data->dma_rx.dma_name);
-			return -ENODEV;
-		}
+	if ((data->dma_tx.dma_dev != NULL) &&
+				!device_is_ready(data->dma_tx.dma_dev)) {
+		LOG_ERR("%s device not ready", data->dma_tx.dma_dev->name);
+		return -ENODEV;
 	}
 #endif /* CONFIG_SPI_STM32_DMA */
 	spi_context_unlock_unconditionally(&data->ctx);
@@ -867,11 +862,13 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 		DT_INST_DMAS_CELL_BY_NAME(id, dir, channel_config)
 #define DMA_FEATURES(id, dir)						\
 		DT_INST_DMAS_CELL_BY_NAME(id, dir, features)
+#define DMA_CTLR(id, dir)						\
+		DT_INST_DMAS_CTLR_BY_NAME(id, dir)
 
 #define SPI_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)	\
-	.dma_name = DT_INST_DMAS_LABEL_BY_NAME(index, dir),		\
 	.channel =							\
 		DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),		\
+	.dma_dev = DEVICE_DT_GET(DMA_CTLR(index, dir)),			\
 	.dma_cfg = {							\
 		.dma_slot =						\
 		   DT_INST_DMAS_CELL_BY_NAME(index, dir, slot),		\
@@ -903,11 +900,9 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 			(SPI_DMA_CHANNEL_INIT(id, dir, DIR, src, dest)),\
 			(NULL))						\
 		},
-
 #define SPI_DMA_STATUS_SEM(id)						\
 	.status_sem = Z_SEM_INITIALIZER(				\
 		spi_stm32_dev_data_##id.status_sem, 0, 1),
-
 #else
 #define SPI_DMA_CHANNEL(id, dir, DIR, src, dest)
 #define SPI_DMA_STATUS_SEM(id)

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -30,7 +30,6 @@ struct spi_stm32_config {
 	(SPI_STM32_DMA_RX_DONE_FLAG | SPI_STM32_DMA_TX_DONE_FLAG)
 
 struct stream {
-	const char *dma_name;
 	const struct device *dma_dev;
 	uint32_t channel; /* stores the channel for dma or mux */
 	struct dma_config dma_cfg;


### PR DESCRIPTION
New DT_DMA helpers macros are available to directly access dma controller devices.

Make use of these macros in existing users.