### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: add unit test for memory leaks

### DIFF
--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -29,6 +29,7 @@
 #include "ull_tx_queue.h"
 #include "ull_conn_types.h"
 
+#include "ull_llcp_internal.h"
 #include "ull_llcp.h"
 
 #include "helper_pdu.h"

--- a/tests/bluetooth/controller/ctrl_chmu/src/main.c
+++ b/tests/bluetooth/controller/ctrl_chmu/src/main.c
@@ -113,6 +113,8 @@ void test_channel_map_update_mas_loc(void)
 	ut_rx_q_is_empty();
 
 	/*TODO verify if new chm is in use... ? */
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_channel_map_update_sla_loc(void)
@@ -128,6 +130,8 @@ void test_channel_map_update_sla_loc(void)
 
 	err = ull_cp_chan_map_update(&conn, chm);
 	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_main(void)

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -157,6 +157,7 @@ void test_conn_update_mas_loc_accept(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -227,6 +228,7 @@ void test_conn_update_mas_loc_reject(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -345,6 +347,7 @@ void test_conn_update_mas_loc_unsupp_feat(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -509,6 +512,7 @@ void test_conn_update_mas_loc_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 
@@ -630,6 +634,7 @@ void test_conn_update_mas_rem_accept(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -704,6 +709,8 @@ void test_conn_update_mas_rem_reject(void)
 
 	/* Done */
 	event_done(&conn);
+	/* Note that context is not released for this test */
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* Slave-initiated Connection Parameters Request procedure.
@@ -962,6 +969,7 @@ void test_conn_update_mas_rem_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1066,6 +1074,7 @@ void test_conn_update_sla_loc_accept(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1145,6 +1154,7 @@ void test_conn_update_sla_loc_reject(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1224,6 +1234,7 @@ void test_conn_update_sla_loc_unsupp_feat(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1405,6 +1416,7 @@ void test_conn_update_sla_loc_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1537,6 +1549,7 @@ void test_conn_update_sla_rem_accept(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1614,6 +1627,8 @@ void test_conn_update_sla_rem_reject(void)
 
 	/* Done */
 	event_done(&conn);
+	/* Note that for this test the context is not released */
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -1866,6 +1881,7 @@ void test_conn_update_sla_rem_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -42,7 +42,6 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-
 /* +-----+                     +-------+              +-----+
  * | UT  |                     | LL_A  |              | LT  |
  * +-----+                     +-------+              +-----+
@@ -141,6 +140,8 @@ void test_encryption_start_mas_loc(void)
 
 	/* Rx Decryption should be enabled */
 	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                     +-------+              +-----+
@@ -284,6 +285,8 @@ void test_encryption_start_mas_loc_limited_memory(void)
 
 	/* Rx Decryption should be enabled */
 	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                     +-------+              +-----+
@@ -367,6 +370,8 @@ void test_encryption_start_mas_loc_no_ltk(void)
 
 	/* Rx Decryption should be disabled */
 	zassert_equal(conn.lll.enc_rx, 0U, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                +-------+              +-----+
@@ -494,6 +499,8 @@ void test_encryption_start_mas_rem(void)
 
 	/* Tx Encryption should be enabled */
 	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                +-------+              +-----+
@@ -673,6 +680,8 @@ void test_encryption_start_mas_rem_limited_memory(void)
 
 	/* Tx Encryption should be enabled */
 	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                +-------+              +-----+
@@ -766,6 +775,9 @@ void test_encryption_start_mas_rem_no_ltk(void)
 
 	/* Rx Decryption should be disabled */
 	zassert_equal(conn.lll.enc_rx, 0U, NULL);
+
+	/* Note that for this test the context is not released */
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -50,15 +50,6 @@ static void setup(void)
 }
 
 /*
- * EGON TODO: Currently a placeholder only
- * to verify that the fix for unittesting works
- */
-static void teardown(void)
-{
-	ztest_test_pass();
-}
-
-/*
  * +-----+                     +-------+            +-----+
  * | UT  |                     | LL_A  |            | LT  |
  * +-----+                     +-------+            +-----+
@@ -130,6 +121,7 @@ void test_feature_exchange_mas_loc(void)
 	}
 	zassert_equal(conn.lll.event_counter, feat_to_test,
 		      "Wrong event-count %d\n", conn.lll.event_counter);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_feature_exchange_mas_loc_2(void)
@@ -146,8 +138,7 @@ void test_feature_exchange_mas_loc_2(void)
 	}
 
 	zassert_not_equal(err, BT_HCI_ERR_SUCCESS, NULL);
-	zassert_equal(conn.lll.event_counter, 0,
-		      "Wrong event-count %d\n", conn.lll.event_counter);
+	zassert_equal(ctx_buffers_free(), 0, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -213,6 +204,7 @@ void test_feature_exchange_mas_rem(void)
 	zassert_equal(conn.lll.event_counter,
 		      MAS_REM_NR_OF_EVENTS*(feat_to_test),
 		      "Wrong event-count %d\n", conn.lll.event_counter);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 #define MAS_REM_2_NR_OF_EVENTS 3
@@ -305,6 +297,7 @@ void test_feature_exchange_mas_rem_2(void)
 	zassert_equal(conn.lll.event_counter,
 		      MAS_REM_2_NR_OF_EVENTS*(feat_to_test),
 		      "Wrong event-count %d\n", conn.lll.event_counter);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 
@@ -345,6 +338,7 @@ void test_slave_feature_exchange_sla_loc(void)
 	ut_rx_q_is_empty();
 	zassert_equal(conn.lll.event_counter, 1,
 		      "Wrong event-count %d\n", conn.lll.event_counter);
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 
@@ -391,7 +385,7 @@ void test_feature_exchange_sla_loc_unknown_rsp(void)
 	ut_rx_q_is_empty();
 	zassert_equal(conn.lll.event_counter, 2,
 	  	      "Wrong event-count %d\n", conn.lll.event_counter);
-
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 
@@ -400,18 +394,18 @@ void test_hci_main(void);
 void test_main(void)
 {
 	ztest_test_suite(feature_exchange_master,
-			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_loc, setup, teardown),
-			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_loc_2, setup, teardown),
-			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_rem, setup, teardown),
-			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_rem_2, setup, teardown)
+			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_loc, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_loc_2, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_rem, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_feature_exchange_mas_rem_2, setup, unit_test_noop)
 		);
 
 	ztest_test_suite(feature_exchange_slave,
-			 ztest_unit_test_setup_teardown(test_slave_feature_exchange_sla_loc, setup, teardown)
+			 ztest_unit_test_setup_teardown(test_slave_feature_exchange_sla_loc, setup, unit_test_noop)
 		);
 
 	ztest_test_suite(feature_exchange_unknown,
-			 ztest_unit_test_setup_teardown(test_feature_exchange_sla_loc_unknown_rsp, setup, teardown)
+			 ztest_unit_test_setup_teardown(test_feature_exchange_sla_loc_unknown_rsp, setup, unit_test_noop)
 		);
 
 	ztest_run_test_suite(feature_exchange_master);

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
@@ -53,9 +53,7 @@ static void setup(void)
 			 "Could not allocate connection memory", NULL);
 
 	test_setup(conn_from_pool);
-
 }
-
 
 /*
  * +-----+                     +-------+            +-----+
@@ -140,6 +138,7 @@ void test_hci_feature_exchange_mas_loc(void)
 
 
 	}
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_hci_feature_exchange_wrong_handle(void)
@@ -168,7 +167,7 @@ void test_hci_feature_exchange_wrong_handle(void)
 	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED,
 		      "Wrong reply for wrong handle\n");
 
-
+	zassert_equal(ctx_buffers_free(), 0, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 

--- a/tests/bluetooth/controller/ctrl_le_ping/src/main.c
+++ b/tests/bluetooth/controller/ctrl_le_ping/src/main.c
@@ -39,8 +39,6 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-
-
 /* +-----+                     +-------+            +-----+
  * | UT  |                     | LL_A  |            | LT  |
  * +-----+                     +-------+            +-----+
@@ -96,6 +94,8 @@ void test_ping_mas_loc(void)
 
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                     +-------+            +-----+
@@ -153,6 +153,8 @@ void test_ping_sla_loc(void)
 
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+ +-------+            +-----+
@@ -207,6 +209,7 @@ void test_ping_mas_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+ +-------+            +-----+
@@ -261,6 +264,7 @@ void test_ping_sla_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_main(void)

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -41,8 +41,6 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-
-
 /* +-----+                     +-------+                  +-----+
  * | UT  |                     | LL_A  |                  | LT  |
  * +-----+                     +-------+                  +-----+
@@ -103,6 +101,8 @@ void test_min_used_chans_sla_loc(void)
 
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_min_used_chans_mas_loc(void)
@@ -118,6 +118,8 @@ void test_min_used_chans_mas_loc(void)
 	/* Initiate an LE Ping Procedure */
 	err = ull_cp_min_used_chans(&conn, 1, 2);
 	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED, NULL);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_min_used_chans_mas_rem(void)
@@ -154,14 +156,15 @@ void test_min_used_chans_mas_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_main(void)
 {
 	ztest_test_suite(muc,
-			ztest_unit_test_setup_teardown(test_min_used_chans_sla_loc, setup, unit_test_noop),
-			ztest_unit_test_setup_teardown(test_min_used_chans_mas_loc, setup, unit_test_noop),
-			ztest_unit_test_setup_teardown(test_min_used_chans_mas_rem, setup, unit_test_noop)
+			 ztest_unit_test_setup_teardown(test_min_used_chans_sla_loc, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_min_used_chans_mas_loc, setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_min_used_chans_mas_rem, setup, unit_test_noop)
 			);
 
 	ztest_run_test_suite(muc);

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -137,6 +137,8 @@ void test_phy_update_mas_loc(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_mas_loc_unsupp_feat(void)
@@ -185,6 +187,8 @@ void test_phy_update_mas_loc_unsupp_feat(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_mas_rem(void)
@@ -260,6 +264,8 @@ void test_phy_update_mas_rem(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_sla_loc(void)
@@ -341,6 +347,8 @@ void test_phy_update_sla_loc(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_sla_rem(void)
@@ -420,6 +428,8 @@ void test_phy_update_sla_rem(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_mas_loc_collision(void)
@@ -552,6 +562,8 @@ void test_phy_update_mas_loc_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_mas_rem_collision(void)
@@ -695,6 +707,8 @@ void test_phy_update_mas_rem_collision(void)
 
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_phy_update_sla_loc_collision(void)
@@ -806,6 +820,7 @@ void test_phy_update_sla_loc_collision(void)
 	/* Release Ntf */
 	ull_cp_release_ntf(ntf);
 
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 
@@ -822,7 +837,6 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(test_phy_update_mas_rem_collision, setup, unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_phy_update_sla_loc_collision, setup, unit_test_noop)
 			);
-
 
 	ztest_run_test_suite(phy);
 }

--- a/tests/bluetooth/controller/ctrl_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_terminate/src/main.c
@@ -66,6 +66,8 @@ static void test_terminate_rem(uint8_t role)
 
 	/* There should be no host notification */
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_terminate_mas_rem(void)
@@ -115,6 +117,8 @@ void test_terminate_loc(uint8_t role)
 
 	/* There should be no host notification */
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_terminate_mas_loc(void)

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -41,8 +41,6 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-
-
 /* +-----+                     +-------+            +-----+
  * | UT  |                     | LL_A  |            | LT  |
  * +-----+                     +-------+            +-----+
@@ -106,6 +104,8 @@ void test_version_exchange_mas_loc(void)
 	/* There should be one host notification */
 	ut_rx_pdu(LL_VERSION_IND, &ntf, &remote_version_ind);
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_version_exchange_mas_loc_2(void)
@@ -124,6 +124,8 @@ void test_version_exchange_mas_loc_2(void)
 	}
 
 	zassert_not_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	zassert_equal(ctx_buffers_free(), 0, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+ +-------+            +-----+
@@ -181,6 +183,7 @@ void test_version_exchange_mas_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                     +-------+            +-----+
@@ -246,6 +249,8 @@ void test_version_exchange_mas_rem_2(void)
 	/* There should be one host notification */
 	ut_rx_pdu(LL_VERSION_IND, &ntf, &remote_version_ind);
 	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /* +-----+                     +-------+            +-----+
@@ -335,6 +340,9 @@ void test_version_exchange_mas_loc_twice(void)
 	/* There should be one host notification */
 	ut_rx_pdu(LL_VERSION_IND, &ntf, &remote_version_ind);
 	ut_rx_q_is_empty();
+
+	/* Note that one context buffer is not freed for this test */
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_main(void)


### PR DESCRIPTION
Added a check to ensure that the procedure context is released when an llcp
is finished
Some tests queue up calls until no more contexts are available; a special test
has been added for those as well

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>