### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: eliminate sanity-check warnings

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -362,7 +362,7 @@ conn_is_valid:
 	return ull_scan_enable(scan);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 }
-#endif /* CONFIG_BT_LL_SW_SPLIT_LEGACY */
+#endif /* CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 uint8_t ll_connect_enable(uint8_t is_coded_included)

--- a/tests/bluetooth/controller/mock_ctrl/include/hal/cpu_vendor_hal.h
+++ b/tests/bluetooth/controller/mock_ctrl/include/hal/cpu_vendor_hal.h
@@ -1,4 +1,8 @@
-
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #define cpu_dsb()
 #define cpu_dmb()

--- a/tests/bluetooth/controller/mock_ctrl/include/kconfig.h
+++ b/tests/bluetooth/controller/mock_ctrl/include/kconfig.h
@@ -9,8 +9,8 @@
  * Common Kconfig settings
  */
 
-#ifndef CONFIG_BT_LL_SW
-#define CONFIG_BT_LL_SW y
+#ifndef CONFIG_BT_LL_SW_SPLIT
+#define CONFIG_BT_LL_SW_SPLIT y
 #endif
 
 #define CONFIG_BT_CONN


### PR DESCRIPTION
Removed warnings about kconfig names and blank lines when running
the sanity-check script

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>