### PR TITLE
Bluetooth: controller: Fix ticker to avoid recursive ticker_job

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2364,13 +2364,13 @@ void ticker_job(void *param)
 		ticker_job_list_inquire(instance);
 	}
 
-	/* Permit worker job to run */
-	instance->job_guard = 0U;
-
 	/* update compare if head changed */
 	if (flag_compare_update) {
 		ticker_job_compare_update(instance, ticker_id_old_head);
 	}
+
+	/* Permit worker to run */
+	instance->job_guard = 0U;
 
 	/* trigger worker if deferred */
 	if (instance->worker_trigger) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2276,9 +2276,16 @@ void ticker_job(void *param)
 
 	DEBUG_TICKER_JOB(1);
 
-	/* Defer worker, as job is now running */
+	/* Defer job, as worker is running */
 	if (instance->worker_trigger) {
 		DEBUG_TICKER_JOB(0);
+		return;
+	}
+
+	/* Defer job, as job is already running */
+	if (instance->job_guard) {
+		instance->sched_cb(TICKER_CALL_ID_JOB, TICKER_CALL_ID_JOB, 1,
+				   instance);
 		return;
 	}
 	instance->job_guard = 1U;


### PR DESCRIPTION
Fix ticker job to defer itself to avoid recursive
invocation to itself due to ticker interface calls from
inside the ticker operation callbacks.

The recursive use was exposed when using ticker stop
operation callback of stopping an auxiliary PDU to stop
the primary PDU scheduling as part of generation of
Advertising Terminate event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>