### PR TITLE
ppp, ethernet: prevent overlapping carrier operations

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -733,18 +733,26 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.
  * This happens when cable is connected.
+ * A NET_EVENT_ETHERNET_CARRIER_ON event will be generated when done.
  *
  * @param iface Network interface
+ *
+ * @return 0 if the operation has been submitted to system workqueue,
+ * < 0 if a carrier change is already pending.
  */
-void net_eth_carrier_on(struct net_if *iface);
+int net_eth_carrier_on(struct net_if *iface);
 
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier was lost.
  * This happens when cable is disconnected.
+ * A NET_EVENT_ETHERNET_CARRIER_OFF event will be generated when done.
  *
  * @param iface Network interface
+ *
+ * @return 0 if the operation has been submitted to system workqueue,
+ * < 0 if a carrier change is already pending.
  */
-void net_eth_carrier_off(struct net_if *iface);
+int net_eth_carrier_off(struct net_if *iface);
 
 /**
  * @brief Set promiscuous mode either ON or OFF.

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -511,18 +511,27 @@ struct ppp_context {
 /**
  * @brief Inform PPP L2 driver that carrier is detected.
  * This happens when cable is connected etc.
+ * A NET_EVENT_PPP_CARRIER_ON event will be generated when done,
+ * if the carrier was previously off.
  *
  * @param iface Network interface
+ *
+ * @return 0 if the operation has been submitted to system workqueue,
+ * < 0 if a carrier change is already pending.
  */
-void net_ppp_carrier_on(struct net_if *iface);
+int net_ppp_carrier_on(struct net_if *iface);
 
 /**
  * @brief Inform PPP L2 driver that carrier was lost.
  * This happens when cable is disconnected etc.
+ * A NET_EVENT_PPP_CARRIER_OFF event will be generated when done.
  *
  * @param iface Network interface
+ *
+ * @return 0 if the operation has been submitted to system workqueue,
+ * < 0 if a carrier change is already pending.
  */
-void net_ppp_carrier_off(struct net_if *iface);
+int net_ppp_carrier_off(struct net_if *iface);
 
 /**
  * @brief Initialize PPP L2 stack for a given interface


### PR DESCRIPTION
`net_ppp_carrier_off` and `net_ppp_carrier_on` re-initialize a single `carrier_mgmt.work`.  If called in immediate succession, they will modify and resubmit a pending item on the system workqueue, leading to loops in the queue's linked list and other corruption.

Instead, return `-EBUSY` if the work is still pending.  Callers can use network management events to know when a call should succeed.

This PR also covers the identical situation in `net_eth_carrier_off` and `net_eth_carrier_on`, but I can't test those changes here at the moment.
