### PR TITLE
drivers: dma: nios2_msgdma: Conver to devicetree

### DIFF
--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT altr_msgdma
+
 #include <device.h>
 #include <errno.h>
 #include <init.h>
@@ -40,7 +42,7 @@ static void nios2_msgdma_isr(void *arg)
 	struct nios2_msgdma_dev_cfg *cfg = DEV_CFG(dev);
 
 	/* Call Altera HAL driver ISR */
-	alt_handle_irq(cfg->msgdma_dev, MSGDMA_0_CSR_IRQ);
+	alt_handle_irq(cfg->msgdma_dev, DT_INST_IRQN(0));
 }
 
 static void nios2_msgdma_callback(void *context)
@@ -205,9 +207,6 @@ static const struct dma_driver_api nios2_msgdma_driver_api = {
 	.stop = nios2_msgdma_transfer_stop,
 };
 
-/* DMA0 */
-DEVICE_DECLARE(dma0_nios2);
-
 static int nios2_msgdma0_initialize(const struct device *dev)
 {
 	struct nios2_msgdma_dev_cfg *dev_cfg = DEV_CFG(dev);
@@ -217,12 +216,12 @@ static int nios2_msgdma0_initialize(const struct device *dev)
 	/* Initialize semaphore */
 	k_sem_init(&dev_cfg->sem_lock, 1, 1);
 
-	alt_msgdma_init(dev_cfg->msgdma_dev, 0, MSGDMA_0_CSR_IRQ);
+	alt_msgdma_init(dev_cfg->msgdma_dev, 0, DT_INST_IRQN(0));
 
-	IRQ_CONNECT(MSGDMA_0_CSR_IRQ, CONFIG_DMA_0_IRQ_PRI,
-		    nios2_msgdma_isr, DEVICE_GET(dma0_nios2), 0);
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(inst, priority),
+		    nios2_msgdma_isr, DEVICE_DT_INST_GET(0), 0);
 
-	irq_enable(MSGDMA_0_CSR_IRQ);
+	irq_enable(DT_INST_IRQN(0));
 
 	return 0;
 }
@@ -234,6 +233,6 @@ static struct nios2_msgdma_dev_cfg dma0_nios2_config = {
 	.msgdma_dev = &msgdma_dev0,
 };
 
-DEVICE_DEFINE(dma0_nios2, CONFIG_DMA_0_NAME, &nios2_msgdma0_initialize,
+DEVICE_DT_INST_DEFINE(0, &nios2_msgdma0_initialize,
 		device_pm_control_nop, NULL, &dma0_nios2_config, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &nios2_msgdma_driver_api);

--- a/dts/bindings/dma/altr,msgdma.yaml
+++ b/dts/bindings/dma/altr,msgdma.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Altera mSGDMA (Modular Scatter-Gather DMA)
+
+compatible: "altr,msgdma"
+
+include: dma-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    "#dma-cells":
+      const: 0

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -51,7 +51,14 @@
 			#size-cells = <0>;
 			reg = <0x100200 0x400>;
 			label = "I2C_0";
+		};
 
+		dma: dma@100200 {
+			compatible = "altr,msgdma";
+			reg = <0x1002c0 0x30>;
+			label = "DMA_0";
+			interrupts = <3 3>;
+			#dma-cells = <0>;
 		};
 	};
 };

--- a/tests/boards/altera_max10/msgdma/src/dma.c
+++ b/tests/boards/altera_max10/msgdma/src/dma.c
@@ -44,8 +44,8 @@ void test_msgdma(void)
 	static uint32_t chan_id;
 	int i;
 
-	dma = device_get_binding(CONFIG_DMA_0_NAME);
-	zassert_true(dma != NULL, "DMA_0 device not found!!");
+	dma = DEVICE_DT_GET(DT_NODELABEL(dma));
+	__ASSERT_NO_MSG(device_is_ready(dma));
 
 	/* Init tx buffer */
 	for (i = 0; i < DMA_BUFF_SIZE; i++) {


### PR DESCRIPTION
Conver the NIOS-II mSGDMA driver to be devicetree based.  Add node for
dma controller into nios2f.dtsi.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>