### PR TITLE
Paxdma driver fixes

### DIFF
--- a/drivers/dma/dma_iproc_pax.h
+++ b/drivers/dma/dma_iproc_pax.h
@@ -479,7 +479,7 @@ struct dma_iproc_pax_ring_data {
 	/* alert for the ring */
 	struct k_sem alert;
 	/* posted write sync src location */
-	struct dma_iproc_pax_write_sync_data sync_loc;
+	struct dma_iproc_pax_write_sync_data *sync_loc;
 	/* posted write sync pci dst address */
 	struct dma_iproc_pax_addr64 sync_pci;
 	/* ring status */

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -985,7 +985,13 @@ static int dma_iproc_pax_process_dma_blocks(const struct device *dev,
 		block_config = block_config->next_block;
 	}
 
-	/* Append write sync payload descriptors */
+	/*
+	 * Write sync payload descriptors should go with separate RM header
+	 * as RM implementation allows all the BD's in a header packet should
+	 * have same data transfer direction. Setting non_hdr_bd_count to 0,
+	 * helps generate separate packet.
+	 */
+	ring->non_hdr_bd_count = 0;
 	dma_iproc_pax_gen_packets(dev, ring, MEMORY_TO_PERIPHERAL, &sync_pl,
 				  &non_hdr_bd_count);
 

--- a/drivers/dma/dma_iproc_pax_v2.h
+++ b/drivers/dma/dma_iproc_pax_v2.h
@@ -31,7 +31,7 @@
 #define PAX_DMA_TYPE_MEGA_SRC_DESC	0x6
 #define PAX_DMA_TYPE_MEGA_DST_DESC	0x7
 #define PAX_DMA_TYPE_PCIE_DESC		0xB
-#define PAX_DMA_NUM_BD_BUFFS		7
+#define PAX_DMA_NUM_BD_BUFFS		9
 /* PCIE DESC, either DST or SRC DESC */
 #define PAX_DMA_RM_DESC_BDCOUNT		2
 
@@ -45,7 +45,7 @@
 #define PAX_DMA_MEGA_LENGTH_MULTIPLE	16
 
 /* Maximum DMA block count supported per request */
-#define RM_V2_MAX_BLOCK_COUNT		4096
+#define RM_V2_MAX_BLOCK_COUNT		1024
 #define MAX_BD_COUNT_PER_HEADER		30
 
 /*

--- a/drivers/dma/dma_iproc_pax_v2.h
+++ b/drivers/dma/dma_iproc_pax_v2.h
@@ -49,6 +49,12 @@
 #define MAX_BD_COUNT_PER_HEADER		30
 
 /*
+ * Sync payload buffer size is of 4 bytes,4096 Bytes allocated here
+ * to make sure BD memories fall in 4K alignment.
+ */
+#define PAX_DMA_RM_SYNC_BUFFER_MISC_SIZE       4096
+
+/*
  * Per-ring memory, with 8K & 4K alignment
  * Alignment may not be ensured by allocator
  * s/w need to allocate extra upto 8K to
@@ -56,7 +62,8 @@
  */
 #define PAX_DMA_PER_RING_ALLOC_SIZE	(PAX_DMA_RM_CMPL_RING_SIZE * 2 + \
 					 PAX_DMA_NUM_BD_BUFFS * \
-					 PAX_DMA_RM_DESC_RING_SIZE)
+					 PAX_DMA_RM_DESC_RING_SIZE + \
+					 PAX_DMA_RM_SYNC_BUFFER_MISC_SIZE)
 
 /* RM header desc field */
 struct rm_header {


### PR DESCRIPTION
This PR contains below pax dma driver changes/fixes:

- drivers: dma: paxdma: increase bd buffers.
- drivers: dma: paxdma: Sync payload as separate packet
- drivers: dma: paxdma: Use uncached sync bufer