### PR TITLE
subsys: tracing: add RAM backend

### DIFF
--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -155,6 +155,7 @@ The following backends are currently supported:
 * USB
 * File (Using native posix port)
 * RTT (With SystemView)
+* RAM (buffer to be retrieved by a debugger)
 
 Using Tracing
 *************
@@ -182,6 +183,20 @@ the tracing data::
 The resulting CTF output can be visualized using babeltrace or TraceCompass
 by pointing the tool to the ``data`` directory with the metadata and trace files.
 
+Using RAM backend
+=================
+
+For devices that do not have available I/O for tracing such as USB or UART but have
+enough RAM to collect trace datas, the ram backend can be enabled with configuration
+`CONFIG_TRACING_BACKEND_RAM`.
+Adjust `CONFIG_RAM_TRACING_BUFFER_SIZE` to be able to record enough traces for your needs.
+Then thanks to a runtime debugger such as gdb this buffer can be fetched from the target
+to an host computer::
+
+    (gdb) dump binary memory data/channel0_0 <ram_tracing_start> <ram_tracing_end>
+
+The resulting channel0_0 file have to be placed in a directory with the ``metadata``
+file like the other backend.
 
 Visualisation Tools
 *******************

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -36,6 +36,12 @@ zephyr_sources_ifdef(
   CONFIG_TRACING_BACKEND_POSIX
   tracing_backend_posix.c
   )
+
+zephyr_sources_ifdef(
+  CONFIG_TRACING_BACKEND_RAM
+  tracing_backend_ram.c
+  )
+
 endif()
 
 zephyr_include_directories_ifdef(

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -165,6 +165,21 @@ config TRACING_BACKEND_POSIX
 	help
 	  Use posix architecture to output tracing data to file system.
 
+config TRACING_BACKEND_RAM
+	bool "Enable RAM backend"
+	help
+	  Use a ram buffer to output tracing data which can
+	  be dumped to a file at runtime with a debugger.
+	  See gdb dump binary memory documentation for example.
+
+config RAM_TRACING_BUFFER_SIZE
+	int "Ram Tracing buffer size"
+	default 4096
+	depends on TRACING_BACKEND_RAM
+	help
+	  Size of the RAM trace buffer. Trace will be discarded if the
+	  length is exceeded.
+
 endchoice
 
 config TRACING_BACKEND_UART_NAME

--- a/subsys/tracing/tracing_backend_ram.c
+++ b/subsys/tracing/tracing_backend_ram.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ctype.h>
+#include <kernel.h>
+#include <string.h>
+#include <tracing_core.h>
+#include <tracing_buffer.h>
+#include <tracing_backend.h>
+
+uint8_t ram_tracing[CONFIG_RAM_TRACING_BUFFER_SIZE];
+static uint32_t pos;
+static bool buffer_full;
+
+static void tracing_backend_ram_output(
+		const struct tracing_backend *backend,
+		uint8_t *data, uint32_t length)
+{
+	if (buffer_full) {
+		return;
+	}
+
+	if ((pos + length) > CONFIG_RAM_TRACING_BUFFER_SIZE) {
+		buffer_full = true;
+		return;
+	}
+
+	memcpy(ram_tracing + pos, data, length);
+	pos += length;
+}
+
+static void tracing_backend_ram_init(void)
+{
+	memset(ram_tracing, 0, CONFIG_RAM_TRACING_BUFFER_SIZE);
+}
+
+const struct tracing_backend_api tracing_backend_ram_api = {
+	.init = tracing_backend_ram_init,
+	.output  = tracing_backend_ram_output
+};
+
+TRACING_BACKEND_DEFINE(tracing_backend_ram, tracing_backend_ram_api);

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -22,6 +22,8 @@
 #define TRACING_BACKEND_NAME "tracing_backend_usb"
 #elif defined CONFIG_TRACING_BACKEND_POSIX
 #define TRACING_BACKEND_NAME "tracing_backend_posix"
+#elif defined CONFIG_TRACING_BACKEND_RAM
+#define TRACING_BACKEND_NAME "tracing_backend_ram"
 #else
 #define TRACING_BACKEND_NAME ""
 #endif


### PR DESCRIPTION
While trying to investigate on threads scheduling I noticed that I'm lacking I/O to output
tracing data, then I decide to output the data to a RAM buffer that I retrieved later using gdb.

Please pickup this patch if you think it could makes sense for other platforms too !