### PR TITLE
pm: power: npcx: add console expired mechanism.

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -81,6 +81,27 @@ config UART_CONSOLE_MCUMGR
 	  process mcumgr frames, but it hands them up to a higher level module
 	  (e.g., the shell).  If unset, incoming mcumgr frames are dropped.
 
+config UART_CONSOLE_INPUT_EXPIRED
+	bool "Enable support for UART console input expired mechanism"
+	default y
+	depends on UART_CONSOLE && PM
+	help
+	  This option allows a notification to the power management module that
+	  the module for UART console is in use now. If the interval of console
+	  module doesn't receive any input message exceeds expired timeout, such
+	  as UART_CONSOLE_INPUT_EXPIRED_TIMEOUT, the power management module is
+	  allowed to enter sleep/deep sleep state and turn off the clock of UART
+	  console module. This mechanism gives a window in which the users can
+	  organize input message if CONFIG_PM is enabled.
+
+config UART_CONSOLE_INPUT_EXPIRED_TIMEOUT
+	int "Fixed amount of time to keep the UART console in use flag true"
+	default 15000
+	depends on UART_CONSOLE_INPUT_EXPIRED
+	help
+	  Fixed amount of time which unit is milliseconds to keep the UART
+	  console in use flag true.
+
 config USB_UART_CONSOLE
 	bool "Use USB port for console outputs"
 	select UART_CONSOLE

--- a/soc/arm/nuvoton_npcx/common/soc_power.h
+++ b/soc/arm/nuvoton_npcx/common/soc_power.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NUVOTON_NPCX_SOC_POWER_H_
+#define _NUVOTON_NPCX_SOC_POWER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Receive whether the module for the console is in use.
+ *
+ * @return 1 if console is in use. Otherwise
+ * @return
+ *  - True if the console is in use.
+ *  - False otherwise,  the module for console is reday to enter low power mode.
+ */
+bool npcx_power_console_is_in_use(void);
+
+/**
+ * @brief Notify the power module that the module for the console is in use.
+ *
+ * Notify the power module that the module for the console is in use. It also
+ * extends expired time by CONFIG_UART_CONSOLE_INPUT_EXPIRED_TIMEOUT.
+ */
+void npcx_power_console_is_in_use_refresh(void);
+
+/**
+ * @brief Set expired time-out directly for the console is in use.
+ *
+ * @param timeout Expired time-out for the console is in use.
+ */
+void npcx_power_set_console_in_use_timeout(int64_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NUVOTON_NPCX_SOC_POWER_H_ */

--- a/soc/arm/nuvoton_npcx/npcx7/power.c
+++ b/soc/arm/nuvoton_npcx/npcx7/power.c
@@ -82,6 +82,27 @@ enum {
 	NPCX_STANDARD_WAKE_UP,
 };
 
+#ifdef CONFIG_UART_CONSOLE_INPUT_EXPIRED
+static int64_t expired_timeout = CONFIG_UART_CONSOLE_INPUT_EXPIRED_TIMEOUT;
+static int64_t console_expired_time = CONFIG_UART_CONSOLE_INPUT_EXPIRED_TIMEOUT;
+
+/* Platform specific power control functions */
+bool npcx_power_console_is_in_use(void)
+{
+	return (k_uptime_get() < console_expired_time);
+}
+
+void npcx_power_console_is_in_use_refresh(void)
+{
+	console_expired_time = k_uptime_get() + expired_timeout;
+}
+
+void npcx_power_set_console_in_use_timeout(int64_t timeout)
+{
+	expired_timeout = timeout;
+}
+#endif
+
 static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 {
 	/* Disable interrupts */

--- a/soc/arm/nuvoton_npcx/npcx7/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.h
@@ -19,5 +19,6 @@
 #include <soc_dt.h>
 #include <soc_clock.h>
 #include <soc_pins.h>
+#include <soc_power.h>
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */


### PR DESCRIPTION
This CL adds support for console expired mechanism. It implements the
notification to power management module that the module for console is
in use. If the interval that module doesn't receive any input message
exceeds CONFIG_SOC_POWER_CONSOLE_EXPIRED_TIMEOUT, the power management
module is allowed to enter deep sleep mode. This mechanism gives a
window in which the users can organize console input.

By npcx_power_console_is_in_use(), the application can forbid ec enter deep sleep in customized pm_policy_next_state().

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>