### PR TITLE
net: context: Set target network interface in send if needed

### DIFF
--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -53,8 +53,8 @@ static struct in6_addr my_addr2 = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 
 /* Destination address for test packets */
-static struct in6_addr dst_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 9, 0, 0, 0,
-					0, 0, 0, 0, 0, 0, 0, 0x1 } } };
+static struct in6_addr dst_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0x2 } } };
 
 /* Extra address is assigned to ll_addr */
 static struct in6_addr ll_addr = { { { 0xfe, 0x80, 0x43, 0xb8, 0, 0, 0, 0,
@@ -845,7 +845,7 @@ static void test_rx_chksum_offload_enabled_test_v6(void)
 			       sizeof(struct sockaddr_in6));
 	zassert_equal(ret, 0, "Context bind failure test failed");
 
-	iface = eth_interfaces[1];
+	iface = net_if_ipv6_select_src_iface(&dst_addr6.sin6_addr);
 	ctx = net_if_get_device(iface)->data;
 	zassert_equal_ptr(&eth_context_offloading_enabled, ctx,
 			  "eth context mismatch");


### PR DESCRIPTION
If we are sending a network packet and if the remote address
is not set in the context (which means that bind() has not
been called), then we must set the target network interface
to a proper value. This is required if we have multiple network
interfaces in which case the packet would be always assigned to
first network interface if remote address is unspecified.

Noticed this while debugging #32750. This issue has been undetected earlier but after commit 157c11d6e7072b5cf1ae8816a5673147c0e587f5 we started to return `-ENETDOWN` if network interface is down. In my tests, I had several network interfaces, but sometimes when using the `net udp` command, the sending failed because the first interface was down. In that case, the packet was meant to be sent to the second interface so it was quite mysterious why that happened.
The fact that the network packet was sent to wrong interface might explain some weird routing issues with VLANs.
