### PR TITLE
STM32: Run time GPIO clocks gating

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -22,6 +22,8 @@
 #include <drivers/pinmux.h>
 #include <sys/util.h>
 #include <drivers/interrupt_controller/exti_stm32.h>
+#include <pm/device.h>
+#include <pm/device_runtime.h>
 
 #include "stm32_hsem.h"
 #include "gpio_stm32.h"
@@ -238,7 +240,6 @@ int gpio_stm32_clock_request(const struct device *dev, bool on)
 	if (on) {
 		ret = clock_control_on(clk,
 					(clock_control_subsys_t *)&cfg->pclken);
-
 	} else {
 		ret = clock_control_off(clk,
 					(clock_control_subsys_t *)&cfg->pclken);
@@ -463,6 +464,9 @@ static int gpio_stm32_port_toggle_bits(const struct device *dev,
 static int gpio_stm32_config(const struct device *dev,
 			     gpio_pin_t pin, gpio_flags_t flags)
 {
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	struct gpio_stm32_data *data = dev->data;
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 	int err = 0;
 	int pincfg;
 
@@ -474,6 +478,16 @@ static int gpio_stm32_config(const struct device *dev,
 		goto exit;
 	}
 
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Enable device clock before configuration (requires bank writes) */
+	if (data->power_state != PM_DEVICE_ACTIVE_STATE) {
+		err = pm_device_get_sync(dev);
+		if (err < 0) {
+			return err;
+		}
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
 	if ((flags & GPIO_OUTPUT) != 0) {
 		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
 			gpio_stm32_port_set_bits_raw(dev, BIT(pin));
@@ -483,6 +497,17 @@ static int gpio_stm32_config(const struct device *dev,
 	}
 
 	gpio_stm32_configure(dev, pin, pincfg, 0);
+
+	/* Device released */
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Release clock only if configuration doesn't require bank writes */
+	if ((flags & GPIO_OUTPUT) == 0) {
+		err = pm_device_put(dev);
+		if (err < 0) {
+			return err;
+		}
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 
 exit:
 	return err;
@@ -561,6 +586,69 @@ static const struct gpio_driver_api gpio_stm32_driver = {
 	.manage_callback = gpio_stm32_manage_callback,
 };
 
+#ifdef CONFIG_PM_DEVICE
+static uint32_t gpio_stm32_get_power_state(const struct device *dev)
+{
+	struct gpio_stm32_data *data = dev->data;
+
+	return data->power_state;
+}
+
+static int gpio_stm32_set_power_state(const struct device *dev,
+					      uint32_t new_state)
+{
+	struct gpio_stm32_data *data = dev->data;
+	int ret = 0;
+
+	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+		ret = gpio_stm32_clock_request(dev, true);
+	} else if (new_state == PM_DEVICE_SUSPEND_STATE) {
+		ret = gpio_stm32_clock_request(dev, false);
+	} else if (new_state == PM_DEVICE_LOW_POWER_STATE) {
+		ret = gpio_stm32_clock_request(dev, false);
+	}
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->power_state = new_state;
+
+	return 0;
+}
+
+static int gpio_stm32_pm_device_ctrl(const struct device *dev,
+				     uint32_t ctrl_command,
+				     void *context, pm_device_cb cb, void *arg)
+{
+	struct gpio_stm32_data *data = dev->data;
+	uint32_t new_state;
+	int ret = 0;
+
+	switch (ctrl_command) {
+	case PM_DEVICE_STATE_SET:
+		new_state = *((const uint32_t *)context);
+		if (new_state != data->power_state) {
+			ret = gpio_stm32_set_power_state(dev, new_state);
+		}
+		break;
+	case PM_DEVICE_STATE_GET:
+		*((uint32_t *)context) = gpio_stm32_get_power_state(dev);
+		break;
+	default:
+		ret = -EINVAL;
+
+	}
+
+	if (cb) {
+		cb(dev, ret, context, arg);
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+
 /**
  * @brief Initialize GPIO port
  *
@@ -577,7 +665,25 @@ static int gpio_stm32_init(const struct device *dev)
 
 	data->dev = dev;
 
+#if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
+	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+	/* Port G[15:2] requires external power supply */
+	/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */
+	LL_PWR_EnableVddIO2();
+	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
+#endif
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	data->power_state = PM_DEVICE_OFF_STATE;
+	pm_device_enable(dev);
+
+	return 0;
+#else
+#ifdef CONFIG_PM_DEVICE
+	data->power_state = PM_DEVICE_ACTIVE_STATE;
+#endif
 	return gpio_stm32_clock_request(dev, true);
+#endif
 }
 
 #define GPIO_DEVICE_INIT(__node, __suffix, __base_addr, __port, __cenr, __bus) \
@@ -592,7 +698,7 @@ static int gpio_stm32_init(const struct device *dev)
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
 	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
-			    NULL,					       \
+			    gpio_stm32_pm_device_ctrl,			       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    POST_KERNEL,				       \

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -249,20 +249,6 @@ int gpio_stm32_clock_request(const struct device *dev, bool on)
 		return ret;
 	}
 
-#if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
-	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-	if (cfg->port == STM32_PORTG) {
-		/* Port G[15:2] requires external power supply */
-		/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */
-		if (on) {
-			LL_PWR_EnableVddIO2();
-		} else {
-			LL_PWR_DisableVddIO2();
-		}
-	}
-	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
-#endif
-
 	return ret;
 }
 

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -229,6 +229,10 @@ struct gpio_stm32_data {
 	const struct device *dev;
 	/* user ISR cb */
 	sys_slist_t cb;
+#ifdef CONFIG_PM_DEVICE
+	/* device power state */
+	uint32_t power_state;
+#endif
 };
 
 /**

--- a/samples/boards/stm32/power_mgmt/blinky/CMakeLists.txt
+++ b/samples/boards/stm32/power_mgmt/blinky/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stm32_pm_blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/stm32/power_mgmt/blinky/README.rst
+++ b/samples/boards/stm32/power_mgmt/blinky/README.rst
@@ -1,0 +1,42 @@
+.. _stm32-pm-blinky-sample:
+
+Blinky
+######
+
+Overview
+********
+
+Blinky is a simple application which blinks an LED forever using the :ref:`GPIO
+API <gpio_api>` in low power context.
+
+.. _stm32-pm-blinky-sample-requirements:
+
+Requirements
+************
+
+You will see this error if you try to build Blinky for an unsupported board:
+
+.. code-block:: none
+
+   Unsupported board: led0 devicetree alias is not defined
+
+The board must have an LED connected via a GPIO pin. These are called "User
+LEDs" on many of Zephyr's :ref:`boards`. The LED must be configured using the
+``led0`` :ref:`devicetree <dt-guide>` alias. This is usually done in the
+:ref:`BOARD.dts file <devicetree-in-out-files>` or a :ref:`devicetree overlay
+<set-devicetree-overlays>`.
+
+The board should support enabling PM.
+
+Building and Running
+********************
+
+Build and flash Blinky as follows, changing ``nucleo_l476rg`` for your board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_l476rg
+   :goals: build flash
+   :compact:
+
+After flashing, the LED starts to blink. Blinky does not print to the console.

--- a/samples/boards/stm32/power_mgmt/blinky/prj.conf
+++ b/samples/boards/stm32/power_mgmt/blinky/prj.conf
@@ -1,0 +1,15 @@
+CONFIG_GPIO=y
+
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y
+
+# Disable debug to enter core low power states
+# Warning: requires to erase the device for next flashing actions
+CONFIG_DEBUG=y
+
+
+# FIXME: Early console not supported due to uart init postponed
+CONFIG_BOOT_BANNER=n
+# Disable serial to ease debug
+CONFIG_SERIAL=n

--- a/samples/boards/stm32/power_mgmt/blinky/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/blinky/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: STM32 GPIO Power Management
+tests:
+  sample.boards.stm32.power_mgmt.blinky:
+    tags: LED power
+    filter: dt_compat_enabled("zephyr,power-state") and
+            dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
+    depends_on: gpio

--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <devicetree.h>
+#include <drivers/gpio.h>
+
+
+#define SLEEP_TIME_MS   2000
+
+static const struct gpio_dt_spec led =
+	GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
+
+void main(void)
+{
+	bool led_is_on = true;
+
+	__ASSERT_NO_MSG(device_is_ready(led.port));
+
+	while (true) {
+		gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+		gpio_pin_set(led.port, led.pin, (int)led_is_on);
+		if (led_is_on == false) {
+			/* Release resource to release device clock */
+			gpio_pin_configure(led.port, led.pin, GPIO_DISCONNECTED);
+		}
+		k_msleep(SLEEP_TIME_MS);
+		if (led_is_on == true) {
+			/* Release resource to release device clock */
+			gpio_pin_configure(led.port, led.pin, GPIO_DISCONNECTED);
+		}
+		led_is_on = !led_is_on;
+	}
+}

--- a/tests/drivers/gpio/gpio_basic_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/stm32l562e_dk.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};


### PR DESCRIPTION
Evolution of #32495 using dedicated device_pm framework

Tested on a blinky sample, with the following settings:
```
CONFIG_PM=y
CONFIG_PM_DEVICE=y
CONFIG_PM_DEVICE_RUNTIME=y
```

Now based on #34781.

Using these settings:
- GPIO port clock is enabled only when needed:
  - When GPIO status is !GPIO_DISCONNECTED and !GPIO_INT_MODE_DISABLED (gpio used by application)
  - and GPIO clock not needed for pinmux configuration
  - In other cases GPIO clock is on and device set as busy
- SoC low power state is entered asynchronously if no device set as busy (in which case we reach 2/3 uA)

EDIT: New PR description after the whole stuff is now actually working.
EDIT: 04-05: Pushed curated version based on latest #34781
EDIT: 04-60: Rebased on master after #34698 was merged. Removed #34781 as not rebased