### PR TITLE
Coding guideline: Fixing code violations for 21.13 Rule

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -257,7 +257,7 @@ struct conversion {
 	bool pad_fp: 1;
 
 	/** Conversion specifier character */
-	char specifier;
+	unsigned char specifier;
 
 	union {
 		/** Width value from specification.

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -39,7 +39,7 @@ static void minimal_hexdump_line_print(const char *data, size_t length)
 
 	for (size_t i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
 		if (i < length) {
-			char c = data[i];
+			unsigned char c = data[i];
 
 			printk("%c", isprint((int)c) ? c : '.');
 		} else {


### PR DESCRIPTION
Any value passed to a function in <ctype.h> shall be representable as an unsigned char or be the value EOF.
    
 So changed type of variable to unsigned char.