### PR TITLE
NVS: increase type holding sector size

### DIFF
--- a/include/fs/nvs.h
+++ b/include/fs/nvs.h
@@ -48,7 +48,7 @@ struct nvs_fs {
 	off_t offset;		/* filesystem offset in flash */
 	uint32_t ate_wra;		/* next alloc table entry write address */
 	uint32_t data_wra;		/* next data write address */
-	uint16_t sector_size;	/* filesystem is divided into sectors,
+	uint32_t sector_size;	/* filesystem is divided into sectors,
 				 * sector size should be multiple of pagesize
 				 */
 	uint16_t sector_count;	/* amount of sectors in the filesystem */


### PR DESCRIPTION
uint16_t for sector_size is not enough for some devices where pages can be greater than 64k -1.

This change has been tested on `nucleo_f429zi` with `zephyr/samples/subsys/nvs/`