### PR TITLE
Bluetooth: controller: Next Generation Scheduler [framework]

### DIFF
--- a/drivers/flash/soc_flash_nrf_ticker.c
+++ b/drivers/flash/soc_flash_nrf_ticker.c
@@ -53,7 +53,8 @@ static inline int _ticker_stop(uint8_t inst_idx, uint8_t u_id, uint8_t tic_id)
 
 static void time_slot_callback_work(uint32_t ticks_at_expire,
 				    uint32_t remainder,
-				    uint16_t lazy, void *context)
+				    uint16_t lazy, uint8_t force,
+				    void *context)
 {
 	struct flash_op_desc *op_desc;
 	uint8_t instance_index;
@@ -120,7 +121,8 @@ static void time_slot_delay(uint32_t ticks_at_expire, uint32_t ticks_delay,
 
 static void time_slot_callback_abort(uint32_t ticks_at_expire,
 				     uint32_t remainder,
-				     uint16_t lazy, void *context)
+				     uint16_t lazy, uint8_t force,
+				     void *context)
 {
 	ll_radio_state_abort();
 	time_slot_delay(ticks_at_expire,
@@ -131,10 +133,12 @@ static void time_slot_callback_abort(uint32_t ticks_at_expire,
 
 static void time_slot_callback_prepare(uint32_t ticks_at_expire,
 				       uint32_t remainder,
-				       uint16_t lazy, void *context)
+				       uint16_t lazy, uint8_t force,
+				       void *context)
 {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
-	time_slot_callback_abort(ticks_at_expire, remainder, lazy, context);
+	time_slot_callback_abort(ticks_at_expire, remainder, lazy, force,
+				 context);
 #else /* !CONFIG_BT_CTLR_LOW_LAT */
 	time_slot_delay(ticks_at_expire,
 			HAL_TICKER_US_TO_TICKS(FLASH_RADIO_ABORT_DELAY_US),

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -21,6 +21,7 @@ zephyr_library_sources_ifdef(
 if(CONFIG_BT_LL_SW_SPLIT)
   zephyr_library_sources(
     ll_sw/ull.c
+    ll_sw/lll_common.c
     )
   if(CONFIG_BT_BROADCASTER)
     zephyr_library_sources(

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -536,8 +536,8 @@ config BT_MAYFLY_YIELD_AFTER_CALL
 	  If set to 'n', all pending mayflies for callee are executed before
 	  yielding
 
-config BT_TICKER_COMPATIBILITY_MODE
-	bool "Ticker compatibility mode"
+config BT_TICKER_LOW_LAT
+	bool "Ticker low latency mode"
 	default y if SOC_SERIES_NRF51X
 	help
 	  This option enables legacy ticker scheduling which defers overlapping
@@ -555,7 +555,7 @@ config BT_TICKER_LAZY_GET
 
 config BT_TICKER_EXT
 	bool "Ticker extensions"
-	depends on !BT_TICKER_COMPATIBILITY_MODE
+	depends on !BT_TICKER_LOW_LAT
 	default y
 	help
 	  This option enables ticker extensions such as re-scheduling of

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -570,6 +570,15 @@ config BT_TICKER_SLOT_AGNOSTIC
 	  reservations and collision handling, and operates as a simple
 	  multi-instance programmable timer.
 
+config BT_CTLR_JIT_SCHEDULING
+	bool "Just-in-Time Scheduling"
+	select BT_TICKER_SLOT_AGNOSTIC
+	help
+	  This option enables the experimental 'Next Generation' scheduling
+	  feature, which eliminates priorities and collision resolving in the
+	  ticker, and instead relies on just-in-time ("lazy") resolution in
+	  the link layer.
+
 config BT_CTLR_USER_EXT
 	prompt "Enable proprietary extensions in Controller"
 	bool

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -555,13 +555,20 @@ config BT_TICKER_LAZY_GET
 
 config BT_TICKER_EXT
 	bool "Ticker extensions"
-	depends on !BT_TICKER_LOW_LAT
+	depends on !BT_TICKER_LOW_LAT && !BT_TICKER_SLOT_AGNOSTIC
 	default y
 	help
 	  This option enables ticker extensions such as re-scheduling of
 	  ticker nodes with slot_window set to non-zero. Ticker extensions
 	  are invoked by using available '_ext' versions of ticker interface
 	  functions.
+
+config BT_TICKER_SLOT_AGNOSTIC
+	bool "Slot agnostic ticker mode"
+	help
+	  This option enables slot agnostic ticker mode, which ignores slot
+	  reservations and collision handling, and operates as a simple
+	  multi-instance programmable timer.
 
 config BT_CTLR_USER_EXT
 	prompt "Enable proprietary extensions in Controller"

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -171,8 +171,8 @@ struct lll_prepare_param {
 };
 
 typedef int (*lll_prepare_cb_t)(struct lll_prepare_param *prepare_param);
-typedef int (*lll_is_abort_cb_t)(void *next, int prio, void *curr,
-				 lll_prepare_cb_t *resume_cb, int *resume_prio);
+typedef int (*lll_is_abort_cb_t)(void *next, void *curr,
+				 lll_prepare_cb_t *resume_cb);
 typedef void (*lll_abort_cb_t)(struct lll_prepare_param *prepare_param,
 			       void *param);
 
@@ -181,9 +181,8 @@ struct lll_event {
 	lll_prepare_cb_t         prepare_cb;
 	lll_is_abort_cb_t        is_abort_cb;
 	lll_abort_cb_t           abort_cb;
-	int                      prio;
-	uint8_t                     is_resume:1;
-	uint8_t                     is_aborted:1;
+	uint8_t                  is_resume:1;
+	uint8_t                  is_aborted:1;
 };
 
 #define DEFINE_NODE_RX_USER_TYPE(i, _) NODE_RX_TYPE_##i,
@@ -402,7 +401,7 @@ int lll_rand_isr_get(void *buf, size_t len);
 int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 			       lll_abort_cb_t abort_cb,
 			       struct lll_prepare_param *prepare_param,
-			       lll_prepare_cb_t prepare_cb, int prio,
+			       lll_prepare_cb_t prepare_cb,
 			       uint8_t is_resume);
 void *ull_prepare_dequeue_get(void);
 void *ull_prepare_dequeue_iter(uint8_t *idx);
@@ -426,6 +425,6 @@ int lll_prepare(lll_is_abort_cb_t is_abort_cb,
 		struct lll_prepare_param *prepare_param);
 int lll_resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio);
 int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-			lll_prepare_cb_t prepare_cb,  int prio,
+			lll_prepare_cb_t prepare_cb,
 			struct lll_prepare_param *prepare_param,
 			uint8_t is_resume, uint8_t is_dequeue);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -166,7 +166,8 @@ struct lll_prepare_param {
 	uint32_t ticks_at_expire;
 	uint32_t remainder;
 	uint16_t lazy;
-	void  *param;
+	uint8_t force;
+	void *param;
 };
 
 typedef int (*lll_prepare_cb_t)(struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -419,3 +419,13 @@ void ull_rx_sched(void);
 void ull_rx_sched_done(void);
 void *ull_event_done_extra_get(void);
 void *ull_event_done(void *param);
+
+int lll_prepare(lll_is_abort_cb_t is_abort_cb,
+		lll_abort_cb_t abort_cb,
+		lll_prepare_cb_t prepare_cb, int8_t event_prio,
+		struct lll_prepare_param *prepare_param);
+int lll_resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio);
+int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
+			lll_prepare_cb_t prepare_cb,  int prio,
+			struct lll_prepare_param *prepare_param,
+			uint8_t is_resume, uint8_t is_dequeue);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -160,12 +160,19 @@ struct ull_hdr {
 
 struct lll_hdr {
 	void *parent;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	uint8_t score;
+	uint8_t latency;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 };
 
 struct lll_prepare_param {
 	uint32_t ticks_at_expire;
 	uint32_t remainder;
 	uint16_t lazy;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	int8_t  prio;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	uint8_t force;
 	void *param;
 };
@@ -379,7 +386,14 @@ static inline void lll_hdr_init(void *lll, void *parent)
 	struct lll_hdr *hdr = lll;
 
 	hdr->parent = parent;
+
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	hdr->score = 0U;
+	hdr->latency = 0U;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 }
+
+void lll_done_score(void *param, uint8_t too_late, uint8_t aborted);
 
 int lll_init(void);
 int lll_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <device.h>
+
+#include "util/mem.h"
+#include "util/memq.h"
+
+#include "lll.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_common
+#include "common/log.h"
+#include "hal/debug.h"
+
+/**
+ * @brief Common entry point for LLL event prepare invocations from ULL.
+ *
+ * This function will resolve the event priority and invoke the LLL
+ * lll_prepare_resolve, which decides if event should be programmed in
+ * the radio via the prepare callback function, or queued in the prepare
+ * pipeline.
+ *
+ * @param is_abort_cb   Callback for checking if event is aborted
+ * @param abort_cb      Callback for aborting event
+ * @param prepare_cb    Callback for event prepare
+ * @param event_prio    Priority of event [-128..127]
+ * @param prepare_param Prepare data
+ *
+ * @return 0: Prepare was successfully completed
+ *	   1: TICKER_STATUS_FAILURE: Preemption ticker stop error
+ *	   2: TICKER_STATUS_BUSY: Preemption ticker stop error
+ *	   -EINPROGRESS: Event already in progress and prepare was queued
+ */
+int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
+		lll_prepare_cb_t prepare_cb, int8_t event_prio,
+		struct lll_prepare_param *prepare_param)
+{
+	/* TODO: Calculate priority */
+
+	return lll_prepare_resolve(is_abort_cb, abort_cb, prepare_cb,
+				   prepare_param, 0, 0);
+}
+
+void lll_resume(void *param)
+{
+	struct lll_event *next;
+	int ret;
+
+	next = param;
+	ret = lll_prepare_resolve(next->is_abort_cb, next->abort_cb,
+				  next->prepare_cb, &next->prepare_param,
+				  next->is_resume, 1);
+	LL_ASSERT(!ret || ret == -EINPROGRESS);
+}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -77,7 +77,7 @@ static void ticker_stop_op_cb(uint32_t status, void *param);
 static void ticker_start_op_cb(uint32_t status, void *param);
 static void preempt_ticker_start(struct lll_prepare_param *prepare_param);
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			      uint16_t lazy, void *param);
+			      uint16_t lazy, uint8_t force, void *param);
 static void preempt(void *param);
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 #if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
@@ -790,7 +790,7 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 }
 
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			       uint16_t lazy, void *param)
+			       uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, preempt};

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -65,10 +65,6 @@ static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
 static inline void done_inc(void);
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
-static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		   lll_prepare_cb_t prepare_cb, int prio,
-		   struct lll_prepare_param *prepare_param,
-		   uint8_t is_resume, uint8_t is_dequeue);
 static int resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio);
 static void isr_race(void *param);
 
@@ -244,25 +240,6 @@ int lll_reset(void)
 	}
 
 	return 0;
-}
-
-int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		lll_prepare_cb_t prepare_cb, int prio,
-		struct lll_prepare_param *prepare_param)
-{
-	return prepare(is_abort_cb, abort_cb, prepare_cb, prio, prepare_param,
-		       0, 0);
-}
-
-void lll_resume(void *param)
-{
-	struct lll_event *next;
-	int ret;
-
-	next = param;
-	ret = prepare(next->is_abort_cb, next->abort_cb, next->prepare_cb,
-		      next->prio, &next->prepare_param, next->is_resume, 1);
-	LL_ASSERT(!ret || ret == -EINPROGRESS);
 }
 
 void lll_disable(void *param)
@@ -618,10 +595,10 @@ static inline bool is_done_sync(void)
 #endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 }
 
-static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		   lll_prepare_cb_t prepare_cb, int prio,
-		   struct lll_prepare_param *prepare_param,
-		   uint8_t is_resume, uint8_t is_dequeue)
+int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
+			lll_prepare_cb_t prepare_cb, int prio,
+			struct lll_prepare_param *prepare_param,
+			uint8_t is_resume, uint8_t is_dequeue)
 {
 	struct lll_event *p;
 	uint8_t idx;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -344,6 +344,10 @@ int lll_done(void *param)
 	ull_prepare_dequeue(TICKER_USER_ID_LLL);
 #endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	lll_done_score(param, 0, 0); /* TODO */
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
+
 	/* Let ULL know about LLL event done */
 	evdone = ull_event_done(ull);
 	LL_ASSERT(evdone);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -59,8 +59,8 @@ static int adv_extra_data_free(struct lll_adv_pdu *pdu, uint8_t last);
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
 
 static int prepare_cb(struct lll_prepare_param *p);
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio);
+static int is_abort_cb(void *next, void *curr,
+		       lll_prepare_cb_t *resume_cb);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void isr_tx(void *param);
 static void isr_rx(void *param);
@@ -861,8 +861,7 @@ static int resume_prepare_cb(struct lll_prepare_param *p)
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio)
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
 #if defined(CONFIG_BT_PERIPHERAL)
 	struct lll_adv *lll = curr;
@@ -878,7 +877,6 @@ static int is_abort_cb(void *next, int prio, void *curr,
 
 			/* wrap back after the pre-empter */
 			*resume_cb = resume_prepare_cb;
-			*resume_prio = 0; /* TODO: */
 
 			/* Retain HF clk */
 			err = lll_hfclock_on();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -7,8 +7,7 @@
 int lll_prepare_done(void *param);
 int lll_done(void *param);
 bool lll_is_done(void *param);
-int lll_is_abort_cb(void *next, int prio, void *curr,
-			 lll_prepare_cb_t *resume_cb, int *resume_prio);
+int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
 uint32_t lll_evt_offset_get(struct evt_hdr *evt);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		lll_prepare_cb_t prepare_cb, int prio,
-		struct lll_prepare_param *prepare_param);
 int lll_prepare_done(void *param);
 int lll_done(void *param);
 bool lll_is_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -50,7 +50,7 @@ static int is_abort_cb(void *next, int prio, void *curr,
 		       lll_prepare_cb_t *resume_cb, int *resume_prio);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			   void *param);
+			   uint8_t force, void *param);
 static void ticker_op_start_cb(uint32_t status, void *param);
 static void isr_rx(void *param);
 static void isr_tx(void *param);
@@ -392,7 +392,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 }
 
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			   void *param)
+			   uint8_t force, void *param)
 {
 	radio_isr_set(isr_done_cleanup, param);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -46,8 +46,8 @@
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio);
+static int is_abort_cb(void *next, void *curr,
+		       lll_prepare_cb_t *resume_cb);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
 			   uint8_t force, void *param);
@@ -315,8 +315,7 @@ static int resume_prepare_cb(struct lll_prepare_param *p)
 	return prepare_cb(p);
 }
 
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio)
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
 	struct lll_scan *lll = curr;
 
@@ -330,7 +329,6 @@ static int is_abort_cb(void *next, int prio, void *curr,
 
 			/* wrap back after the pre-empter */
 			*resume_cb = resume_prepare_cb;
-			*resume_prio = 0; /* TODO: */
 
 			/* Retain HF clock */
 			err = lll_hfclock_on();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -49,10 +49,7 @@ static struct {
 static const struct device *dev_entropy;
 
 static int init_reset(void);
-static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		   lll_prepare_cb_t prepare_cb, int prio,
-		   struct lll_prepare_param *prepare_param, uint8_t is_resume);
-static int resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio);
+static int resume_enqueue(lll_prepare_cb_t resume_cb);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 static void ticker_start_op_cb(uint32_t status, void *param);
@@ -193,24 +190,6 @@ int lll_reset(void)
 	return 0;
 }
 
-int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		lll_prepare_cb_t prepare_cb, int prio,
-		struct lll_prepare_param *prepare_param)
-{
-	return prepare(is_abort_cb, abort_cb, prepare_cb, prio, prepare_param,
-		       0);
-}
-
-void lll_resume(void *param)
-{
-	struct lll_event *next = param;
-	int ret;
-
-	ret = prepare(next->is_abort_cb, next->abort_cb, next->prepare_cb,
-		      next->prio, &next->prepare_param, next->is_resume);
-	LL_ASSERT(!ret || ret == -EINPROGRESS);
-}
-
 void lll_disable(void *param)
 {
 	/* LLL disable of current event, done is generated */
@@ -305,8 +284,7 @@ bool lll_is_done(void *param)
 	return !event.curr.abort_cb;
 }
 
-int lll_is_abort_cb(void *next, int prio, void *curr,
-			 lll_prepare_cb_t *resume_cb, int *resume_prio)
+int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
 	return -ECANCELED;
 }
@@ -440,9 +418,10 @@ static int init_reset(void)
 	return 0;
 }
 
-static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		   lll_prepare_cb_t prepare_cb, int prio,
-		   struct lll_prepare_param *prepare_param, uint8_t is_resume)
+int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
+			lll_prepare_cb_t prepare_cb,
+			struct lll_prepare_param *prepare_param,
+			uint8_t is_resume, uint8_t is_dequeue)
 {
 	uint8_t idx = UINT8_MAX;
 	struct lll_event *p;
@@ -469,7 +448,7 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 		/* Store the next prepare for deferred call */
 		ret = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
-					  prepare_cb, prio, is_resume);
+					  prepare_cb, is_resume);
 		LL_ASSERT(!ret);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
@@ -499,11 +478,11 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		if (next) {
 			/* check if resume requested by curr */
 			ret = event.curr.is_abort_cb(NULL, 0, event.curr.param,
-						     &resume_cb, &resume_prio);
+						     &resume_cb);
 			LL_ASSERT(ret);
 
 			if (ret == -EAGAIN) {
-				ret = resume_enqueue(resume_cb, resume_prio);
+				ret = resume_enqueue(resume_cb);
 				LL_ASSERT(!ret);
 			} else {
 				LL_ASSERT(ret == -ECANCELED);
@@ -527,7 +506,7 @@ static int prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	return err;
 }
 
-static int resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio)
+static int resume_enqueue(lll_prepare_cb_t resume_cb)
 {
 	struct lll_prepare_param prepare_param;
 
@@ -535,7 +514,7 @@ static int resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio)
 	event.curr.param = NULL;
 
 	return ull_prepare_enqueue(event.curr.is_abort_cb, event.curr.abort_cb,
-				   &prepare_param, resume_cb, resume_prio, 1);
+				   &prepare_param, resume_cb, 1);
 }
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
@@ -598,7 +577,6 @@ static void preempt(void *param)
 	struct lll_event *next = ull_prepare_dequeue_get();
 	lll_prepare_cb_t resume_cb;
 	uint8_t idx = UINT8_MAX;
-	int resume_prio;
 	int ret;
 
 	if (!event.curr.abort_cb || !event.curr.param) {
@@ -618,9 +596,9 @@ static void preempt(void *param)
 		return;
 	}
 
-	ret = event.curr.is_abort_cb(next->prepare_param.param, next->prio,
+	ret = event.curr.is_abort_cb(next->prepare_param.param,
 				     event.curr.param,
-				     &resume_cb, &resume_prio);
+				     &resume_cb);
 	if (!ret) {
 		/* Let LLL know about the cancelled prepare */
 		next->is_aborted = 1;
@@ -647,7 +625,7 @@ static void preempt(void *param)
 			iter = ull_prepare_dequeue_iter(&iter_idx);
 		}
 
-		ret = resume_enqueue(resume_cb, resume_prio);
+		ret = resume_enqueue(resume_cb);
 		LL_ASSERT(!ret);
 	} else {
 		LL_ASSERT(ret == -ECANCELED);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -58,7 +58,7 @@ static int resume_enqueue(lll_prepare_cb_t resume_cb, int resume_prio);
 static void ticker_start_op_cb(uint32_t status, void *param);
 static void preempt_ticker_start(struct lll_prepare_param *prepare_param);
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			      uint16_t lazy, void *param);
+			      uint16_t lazy, uint8_t force, void *param);
 static void preempt(void *param);
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 #if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
@@ -582,7 +582,7 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 }
 
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			       uint16_t lazy, void *param)
+			      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, preempt};

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -46,8 +46,7 @@
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio);
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void isr_tx(void *param);
 static void isr_rx(void *param);
@@ -447,8 +446,7 @@ static int resume_prepare_cb(struct lll_prepare_param *p)
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio)
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
 #if defined(CONFIG_BT_PERIPHERAL)
 	struct lll_adv *lll = curr;
@@ -464,7 +462,6 @@ static int is_abort_cb(void *next, int prio, void *curr,
 
 			/* wrap back after the pre-empter */
 			*resume_cb = resume_prepare_cb;
-			*resume_prio = 0; /* TODO: */
 
 			/* Retain HF clk */
 			err = lll_clk_on();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
@@ -4,14 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
-		lll_prepare_cb_t prepare_cb, int prio,
-		struct lll_prepare_param *prepare_param);
 int lll_prepare_done(void *param);
 int lll_done(void *param);
 bool lll_is_done(void *param);
-int lll_is_abort_cb(void *next, int prio, void *curr,
-			 lll_prepare_cb_t *resume_cb, int *resume_prio);
+int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
 int lll_clk_on(void);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -45,7 +45,7 @@ static int is_abort_cb(void *next, int prio, void *curr,
 		       lll_prepare_cb_t *resume_cb, int *resume_prio);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			   void *param);
+			   uint8_t force, void *param);
 static void ticker_op_start_cb(uint32_t status, void *param);
 static void isr_rx(void *param);
 static void isr_tx(void *param);
@@ -333,7 +333,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 }
 
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			   void *param)
+			   uint8_t force, void *param)
 {
 	radio_isr_set(isr_cleanup, param);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -41,8 +41,7 @@
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio);
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
 			   uint8_t force, void *param);
@@ -276,8 +275,7 @@ static int resume_prepare_cb(struct lll_prepare_param *p)
 	return prepare_cb(p);
 }
 
-static int is_abort_cb(void *next, int prio, void *curr,
-		       lll_prepare_cb_t *resume_cb, int *resume_prio)
+static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
 	struct lll_scan *lll = curr;
 
@@ -287,7 +285,6 @@ static int is_abort_cb(void *next, int prio, void *curr,
 
 		/* wrap back after the pre-empter */
 		*resume_cb = resume_prepare_cb;
-		*resume_prio = 0; /* TODO: */
 
 		/* Retain HF clk */
 		err = lll_clk_on();

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1597,7 +1597,7 @@ void ull_rx_sched_done(void)
 int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 			lll_abort_cb_t abort_cb,
 			struct lll_prepare_param *prepare_param,
-			lll_prepare_cb_t prepare_cb, int prio,
+			lll_prepare_cb_t prepare_cb,
 			uint8_t is_resume)
 {
 	struct lll_event *e;
@@ -1612,7 +1612,6 @@ int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 	e->prepare_cb = prepare_cb;
 	e->is_abort_cb = is_abort_cb;
 	e->abort_cb = abort_cb;
-	e->prio = prio;
 	e->is_resume = is_resume;
 	e->is_aborted = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -60,12 +60,12 @@ inline uint16_t ull_adv_handle_get(struct ll_adv_set *adv);
 static int init_reset(void);
 static inline struct ll_adv_set *is_disabled_get(uint8_t handle);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_update_cb(uint32_t status, void *params);
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			   uint16_t lazy, void *param);
+			   uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_stop_cb(uint32_t status, void *params);
 static void disabled_cb(void *param);
 static void conn_release(struct ll_adv_set *adv);
@@ -1707,7 +1707,7 @@ static inline struct ll_adv_set *is_disabled_get(uint8_t handle)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-		      void *param)
+		      uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_adv_prepare};
@@ -1731,6 +1731,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t laz
 		p.ticks_at_expire = ticks_at_expire;
 		p.remainder = remainder;
 		p.lazy = lazy;
+		p.force = force;
 		p.param = lll;
 		mfy.param = &p;
 
@@ -1798,7 +1799,7 @@ static void ticker_op_update_cb(uint32_t status, void *param)
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			   uint16_t lazy, void *param)
+			   uint16_t lazy, uint8_t force, void *param)
 {
 	struct ll_adv_set *adv = param;
 	uint8_t handle;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1277,13 +1277,13 @@ uint8_t ll_adv_enable(uint8_t enable)
 				   HAL_TICKER_US_TO_TICKS((uint64_t)interval *
 							  ADV_INT_UNIT_US),
 				   TICKER_NULL_REMAINDER,
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE) && \
+#if !defined(CONFIG_BT_TICKER_LOW_LAT) && \
 	!defined(CONFIG_BT_CTLR_LOW_LAT)
 				   /* Force expiry to ensure timing update */
 				   TICKER_LAZY_MUST_EXPIRE,
 #else
 				   TICKER_NULL_LAZY,
-#endif
+#endif /* !CONFIG_BT_TICKER_LOW_LAT && !CONFIG_BT_CTLR_LOW_LAT */
 				   ticks_slot,
 				   ticker_cb, adv,
 				   ull_ticker_status_give,
@@ -1721,7 +1721,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t laz
 
 	lll = &adv->lll;
 
-	if (IS_ENABLED(CONFIG_BT_TICKER_COMPATIBILITY_MODE) ||
+	if (IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) ||
 	    (lazy != TICKER_LAZY_MUST_EXPIRE)) {
 		/* Increment prepare reference count */
 		ref = ull_ref_inc(&adv->ull);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -53,7 +53,7 @@ static inline void sync_info_fill(struct lll_adv_sync *lll_sync,
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 static void mfy_aux_offset_get(void *param);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 
 static struct ll_adv_aux_set ll_adv_aux_pool[CONFIG_BT_CTLR_ADV_AUX_SET];
@@ -1102,7 +1102,7 @@ static void mfy_aux_offset_get(void *param)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_adv_aux_prepare};
@@ -1124,6 +1124,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -48,7 +48,7 @@ static uint32_t ull_adv_iso_start(struct ll_adv_iso *adv_iso,
 static inline struct ll_adv_iso *ull_adv_iso_get(uint8_t handle);
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void tx_lll_flush(void *param);
 static void ticker_op_stop_cb(uint32_t status, void *param);
 
@@ -379,7 +379,7 @@ static int init_reset(void)
 
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	/* TODO: LLL support for ADV ISO */
 #if 0
@@ -403,6 +403,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -71,7 +71,7 @@ static inline void sync_info_offset_fill(struct pdu_adv_sync_info *si,
 					 uint32_t ticks_offset,
 					 uint32_t start_us);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 
 static struct ll_adv_sync_set ll_adv_sync_pool[CONFIG_BT_CTLR_ADV_SYNC_SET];
@@ -985,7 +985,7 @@ static inline void sync_info_offset_fill(struct pdu_adv_sync_info *si,
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_adv_sync_prepare};
@@ -1007,6 +1007,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2709,11 +2709,11 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 				     ticks_at_expire, ticks_win_offset,
 				     HAL_TICKER_US_TO_TICKS(periodic_us),
 				     HAL_TICKER_REMAINDER(periodic_us),
-#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if defined(CONFIG_BT_TICKER_LOW_LAT)
 				     TICKER_NULL_LAZY,
 #else
 				     TICKER_LAZY_MUST_EXPIRE_KEEP,
-#endif
+#endif /* CONFIG_BT_TICKER_LOW_LAT */
 				     (ticks_slot_overhead +
 				      conn->evt.ticks_slot),
 #if defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -840,7 +840,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 }
 
 void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			  void *param)
+			  uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_master_prepare};
@@ -892,6 +892,7 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = &conn->lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
@@ -8,4 +8,4 @@ void ull_master_cleanup(struct node_rx_hdr *rx_free);
 void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		      struct node_rx_ftr *ftr, struct lll_conn *lll);
 void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			  void *param);
+			  uint8_t force, void *param);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -200,7 +200,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = { 0, 0, &link, NULL,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -50,7 +50,7 @@
 
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-		      void *param);
+		      uint8_t force, void *param);
 static uint8_t disable(uint8_t handle);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -647,7 +647,7 @@ static int init_reset(void)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_scan_prepare};
@@ -716,6 +716,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.remainder = remainder;
 	p.lazy = lazy;
 	p.param = lll;
+	p.force = force;
 	mfy.param = &p;
 
 	/* Kick LLL prepare */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -44,7 +44,7 @@ static inline uint8_t aux_handle_get(struct ll_scan_aux_set *aux);
 static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan);
 static void flush(struct ll_scan_aux_set *aux, struct node_rx_hdr *rx);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 static void ticker_op_aux_failure(void *param);
 
@@ -418,7 +418,7 @@ static void flush(struct ll_scan_aux_set *aux, struct node_rx_hdr *rx)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_scan_aux_prepare};
@@ -437,6 +437,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = 0; /* FIXME: remainder; */
 	p.lazy = lazy;
+	p.force = force;
 	p.param = &aux->lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -447,7 +447,7 @@ void ull_slave_latency_cancel(struct ll_conn *conn, uint16_t handle)
 }
 
 void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			 uint16_t lazy, void *param)
+			 uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_slave_prepare};
@@ -493,6 +493,7 @@ void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = &conn->lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
@@ -8,4 +8,4 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		     struct node_rx_ftr *ftr, struct lll_conn *lll);
 void ull_slave_latency_cancel(struct ll_conn *conn, uint16_t handle);
 void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			 uint16_t lazy, void *param);
+			 uint16_t lazy, uint8_t force, void *param);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -48,7 +48,7 @@ static int init_reset(void);
 static inline struct ll_sync_set *sync_acquire(void);
 static void timeout_cleanup(struct ll_sync_set *sync);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 static void ticker_update_sync_op_cb(uint32_t status, void *param);
 static void ticker_stop_op_cb(uint32_t status, void *param);
@@ -585,7 +585,7 @@ static void timeout_cleanup(struct ll_sync_set *sync)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_sync_prepare};
@@ -607,6 +607,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -46,7 +46,7 @@
 static int init_reset(void);
 static inline struct ll_sync_iso *sync_iso_acquire(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param);
+		      uint16_t lazy, uint8_t force, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 
 static struct ll_sync_iso ll_sync_iso_pool[CONFIG_BT_CTLR_SCAN_SYNC_ISO_SET];
@@ -307,7 +307,7 @@ static inline struct ll_sync_iso *sync_iso_acquire(void)
 }
 
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-		      uint16_t lazy, void *param)
+		      uint16_t lazy, uint8_t force, void *param)
 {
 	/* TODO: Implement LLL handling */
 #if 0
@@ -331,6 +331,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;
 	p.lazy = lazy;
+	p.force = force;
 	p.param = lll;
 	mfy.param = &p;
 

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -943,6 +943,7 @@ void ticker_worker(void *param)
 					     must_expire_skip ?
 					     TICKER_LAZY_MUST_EXPIRE :
 					     ticker->lazy_current,
+					     ticker->force,
 					     ticker->context);
 			DEBUG_TICKER_TASK(0);
 

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -29,59 +29,62 @@
  ****************************************************************************/
 
 struct ticker_node {
-	uint8_t  next;			 /* Next ticker node */
+	uint8_t  next;			    /* Next ticker node */
 
-	uint8_t  req;			 /* Request counter */
-	uint8_t  ack;			 /* Acknowledge counter. Imbalance
-					  * between req and ack indicates
-					  * ongoing operation
-					  */
-	uint8_t  force;			 /* If non-zero, node timeout should
-					  * be forced at next expiration
-					  */
-	uint32_t ticks_periodic;		 /* If non-zero, interval
-					  * between expirations
-					  */
-	uint32_t ticks_to_expire;		 /* Ticks until expiration */
-	ticker_timeout_func timeout_func;/* User timeout function */
-	void  *context;			 /* Context delivered to timeout
-					  * function
-					  */
-	uint32_t ticks_to_expire_minus;	 /* Negative drift correction */
-	uint32_t ticks_slot;		 /* Air-time reservation for node */
-	uint16_t lazy_periodic;		 /* Number of timeouts to allow
-					  * skipping
-					  */
-	uint16_t lazy_current;		 /* Current number of timeouts
-					  * skipped = slave latency
-					  */
+	uint8_t  req;			    /* Request counter */
+	uint8_t  ack;			    /* Acknowledge counter. Imbalance
+					     * between req and ack indicates
+					     * ongoing operation
+					     */
+	uint8_t  force;			    /* If non-zero, node timeout should
+					     * be forced at next expiration
+					     */
+	uint32_t ticks_periodic;	    /* If non-zero, interval
+					     * between expirations
+					     */
+	uint32_t ticks_to_expire;	    /* Ticks until expiration */
+	ticker_timeout_func timeout_func;   /* User timeout function */
+	void  *context;			    /* Context delivered to timeout
+					     * function
+					     */
+	uint32_t ticks_to_expire_minus;	    /* Negative drift correction */
+	uint32_t ticks_slot;		    /* Air-time reservation for node */
+	uint16_t lazy_periodic;		    /* Number of timeouts to allow
+					     * skipping
+					     */
+	uint16_t lazy_current;		    /* Current number of timeouts
+					     * skipped = slave latency
+					     */
 	union {
-		uint32_t remainder_periodic;  /* Sub-microsecond tick remainder
-					       * for each period
-					       */
-		ticker_op_func fp_op_func; /* Operation completion callback */
+		uint32_t remainder_periodic;/* Sub-microsecond tick remainder
+					     * for each period
+					     */
+		ticker_op_func fp_op_func;  /* Operation completion callback */
 	};
 
 	union {
 		uint32_t remainder_current; /* Current sub-microsecond tick
-					  * remainder
-					  */
-		void  *op_context;       /* Context passed in completion
-					  * callback
-					  */
+					     * remainder
+					     */
+		void  *op_context;	    /* Context passed in completion
+					     * callback
+					     */
 	};
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 #if  defined(CONFIG_BT_TICKER_EXT)
-	struct ticker_ext *ext_data;	 /* Ticker extension data */
+	struct ticker_ext *ext_data;	    /* Ticker extension data */
 #endif /* CONFIG_BT_TICKER_EXT */
-	uint8_t  must_expire;		 /* Node must expire, even if it
-					  * collides with other nodes
-					  */
-	int8_t  priority;			 /* Ticker node priority. 0 is default.
-					  * Lower value is higher priority
-					  */
-#endif /* CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+	uint8_t  must_expire;		    /* Node must expire, even if it
+					     * collides with other nodes
+					     */
+	int8_t  priority;		    /* Ticker node priority. 0 is
+					     * default. Lower value is higher
+					     * priority
+					     */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT &&
+	* !CONFIG_BT_TICKER_SLOT_AGNOSTIC
+	*/
 };
 
 /* Operations to be performed in ticker_job.
@@ -113,9 +116,9 @@ struct ticker_node {
  * requests to ticker_job
  */
 struct ticker_user_op_start {
-	uint32_t ticks_at_start;		/* Anchor ticks (absolute) */
+	uint32_t ticks_at_start;	/* Anchor ticks (absolute) */
 	uint32_t ticks_first;		/* Initial timeout ticks */
-	uint32_t ticks_periodic;		/* Ticker period ticks */
+	uint32_t ticks_periodic;	/* Ticker period ticks */
 	uint32_t remainder_periodic;	/* Sub-microsecond tick remainder */
 	uint16_t lazy;			/* Periodic latency in number of
 					 * periods
@@ -132,12 +135,12 @@ struct ticker_user_op_start {
  * requests to ticker_job
  */
 struct ticker_user_op_update {
-	uint32_t ticks_drift_plus;		/* Requested positive drift in ticks */
+	uint32_t ticks_drift_plus;	/* Requested positive drift in ticks */
 	uint32_t ticks_drift_minus;	/* Requested negatice drift in ticks */
-	uint32_t ticks_slot_plus;		/* Number of ticks to add to slot
+	uint32_t ticks_slot_plus;	/* Number of ticks to add to slot
 					 * reservation (air-time)
 					 */
-	uint32_t ticks_slot_minus;		/* Number of ticks to subtract from
+	uint32_t ticks_slot_minus;	/* Number of ticks to subtract from
 					 * slot reservation (air-time)
 					 */
 	uint16_t lazy;			/* Slave latency:
@@ -160,7 +163,7 @@ struct ticker_user_op_update {
  * requests with absolute tick to ticker_job
  */
 struct ticker_user_op_stop {
-	uint32_t ticks_at_stop;            /* Anchor ticks (absolute) */
+	uint32_t ticks_at_stop;		/* Anchor ticks (absolute) */
 };
 
 /* User operation data structure for slot_get opcode. Used for passing request
@@ -179,74 +182,77 @@ struct ticker_user_op_slot_get {
  * request to set ticker node priority via ticker_job
  */
 struct ticker_user_op_priority_set {
-	int8_t priority;		   /* Node priority. Defaults to 0 */
+	int8_t priority;		/* Node priority. Defaults to 0 */
 };
 
 /* User operation top level data structure. Used for passing requests to
  * ticker_job
  */
 struct ticker_user_op {
-	uint8_t op;		   /* User operation */
-	uint8_t id;		   /* Ticker node id */
+	uint8_t op;			/* User operation */
+	uint8_t id;			/* Ticker node id */
 	union {
 		struct ticker_user_op_start        start;
 		struct ticker_user_op_update       update;
 		struct ticker_user_op_stop         stop;
 		struct ticker_user_op_slot_get     slot_get;
 		struct ticker_user_op_priority_set priority_set;
-	} params;		   /* User operation parameters */
-	uint32_t status;		   /* Operation result */
-	ticker_op_func fp_op_func; /* Operation completion callback */
-	void  *op_context;	   /* Context passed in completion callback */
+	} params;			/* User operation parameters */
+	uint32_t status;		/* Operation result */
+	ticker_op_func fp_op_func;	/* Operation completion callback */
+	void  *op_context;		/* Context passed in completion callback */
 };
 
 /* User data structure for operations
  */
 struct ticker_user {
-	uint8_t count_user_op;	   /* Number of user operation slots */
-	uint8_t first;		   /* Slot index of first user operation */
-	uint8_t middle;		   /* Slot index of last managed user op.
-				    * Updated by ticker_job_list_manage
-				    * for use in ticker_job_list_insert
-				    */
-	uint8_t last;		   /* Slot index of last user operation */
+	uint8_t count_user_op;		/* Number of user operation slots */
+	uint8_t first;			/* Slot index of first user operation */
+	uint8_t middle;			/* Slot index of last managed user op.
+					 * Updated by ticker_job_list_manage
+					 * for use in ticker_job_list_insert
+					 */
+	uint8_t last;			/* Slot index of last user operation */
 	struct ticker_user_op *user_op; /* Pointer to user operation array */
 };
 
 /* Ticker instance
  */
 struct ticker_instance {
-	struct ticker_node *nodes; /* Pointer to ticker nodes */
-	struct ticker_user *users; /* Pointer to user nodes */
-	uint8_t  count_node;	   /* Number of ticker nodes */
-	uint8_t  count_user;	   /* Number of user nodes */
-	uint8_t  ticks_elapsed_first; /* Index from which elapsed ticks count is
-				    * pulled
-				    */
-	uint8_t  ticks_elapsed_last;  /* Index to which elapsed ticks count is
-				    * pushed
-				    */
-	uint32_t ticks_elapsed[DOUBLE_BUFFER_SIZE]; /* Buffer for elapsed ticks */
-	uint32_t ticks_current;	   /* Absolute ticks elapsed at last
-				    * ticker_job
-				    */
-	uint32_t ticks_slot_previous; /* Number of ticks previously reserved by a
-				    * ticker node (active air-time)
-				    */
-	uint8_t  ticker_id_slot_previous; /* Id of previous slot reserving ticker
-					* node
-					*/
-	uint8_t  ticker_id_head;      /* Index of first ticker node (next to
-				    * expire)
-				    */
-	uint8_t  job_guard;	   /* Flag preventing ticker_worker from
-				    * running if ticker_job is active
-				    */
-	uint8_t  worker_trigger;	   /* Flag preventing ticker_job from starting
-				    * if ticker_worker was requested, and to
-				    * trigger ticker_worker at end of job, if
-				    * requested
-				    */
+	struct ticker_node *nodes;	/* Pointer to ticker nodes */
+	struct ticker_user *users;	/* Pointer to user nodes */
+	uint8_t  count_node;		/* Number of ticker nodes */
+	uint8_t  count_user;		/* Number of user nodes */
+	uint8_t  ticks_elapsed_first;	/* Index from which elapsed ticks count
+					 * is pulled
+					 */
+	uint8_t  ticks_elapsed_last;	/* Index to which elapsed ticks count
+					 * is pushed
+					 */
+	uint32_t ticks_elapsed[DOUBLE_BUFFER_SIZE]; /* Buffer for elapsed
+						     * ticks
+						     */
+	uint32_t ticks_current;		/* Absolute ticks elapsed at last
+					 * ticker_job
+					 */
+	uint32_t ticks_slot_previous;	/* Number of ticks previously reserved
+					 * by a ticker node (active air-time)
+					 */
+	uint8_t  ticker_id_slot_previous; /* Id of previous slot reserving
+					   * ticker node
+					   */
+	uint8_t  ticker_id_head;	/* Index of first ticker node (next to
+					 * expire)
+					 */
+	uint8_t  job_guard;		/* Flag preventing ticker_worker from
+					 * running if ticker_job is active
+					 */
+	uint8_t  worker_trigger;	/* Flag preventing ticker_job from
+					 * starting if ticker_worker was
+					 * requested, and to trigger
+					 * ticker_worker at end of job, if
+					 * requested
+					 */
 
 	ticker_caller_id_get_cb_t caller_id_get_cb; /* Function for retrieving
 						     * the caller id from user
@@ -293,7 +299,7 @@ static inline void ticker_next_elapsed(uint8_t *ticks_elapsed_index)
 	*ticks_elapsed_index = idx;
 }
 
-#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if defined(CONFIG_BT_TICKER_LOW_LAT)
 /**
  * @brief Get ticker expiring in a specific slot
  *
@@ -335,7 +341,7 @@ static uint8_t ticker_by_slot_get(struct ticker_node *node, uint8_t ticker_id_he
 
 	return ticker_id_head;
 }
-#endif /* CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Get next ticker with slot ticks
@@ -403,7 +409,7 @@ static void ticker_by_next_slot_get(struct ticker_instance *instance,
 	*ticks_to_expire = _ticks_to_expire;
 }
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 /**
  * @brief Enqueue ticker node
  *
@@ -472,7 +478,7 @@ static uint8_t ticker_enqueue(struct ticker_instance *instance, uint8_t id)
 
 	return id;
 }
-#else /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#else /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Enqueue ticker node
@@ -569,7 +575,7 @@ static uint8_t ticker_enqueue(struct ticker_instance *instance, uint8_t id)
 
 	return id;
 }
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Dequeue ticker node
@@ -642,7 +648,7 @@ static uint32_t ticker_dequeue(struct ticker_instance *instance, uint8_t id)
 	return (total + timeout);
 }
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 /**
  * @brief Resolve ticker node collision
  *
@@ -762,7 +768,7 @@ static uint8_t ticker_resolve_collision(struct ticker_node *nodes,
 
 	return 0U;
 }
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Ticker worker
@@ -807,19 +813,18 @@ void ticker_worker(void *param)
 	/* Auto variable containing the head of tickers expiring */
 	ticker_id_head = instance->ticker_id_head;
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
 	/* Check if the previous ticker node which had air-time, is still
 	 * active and has this time slot reserved
 	 */
 	uint8_t slot_reserved = 0;
 
-	if (instance->ticker_id_slot_previous != TICKER_NULL) {
+	if (!IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) &&
+	    instance->ticker_id_slot_previous != TICKER_NULL) {
 		if (instance->ticks_slot_previous > ticks_elapsed) {
 			/* This node intersects reserved slot */
 			slot_reserved = 1;
 		}
 	}
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
 
 	/* Expire all tickers within ticks_elapsed and collect ticks_expired */
 	node = &instance->nodes[0];
@@ -850,7 +855,7 @@ void ticker_worker(void *param)
 			continue;
 		}
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 		/* Check if node has slot reservation and resolve any collision
 		 * with other ticker nodes
 		 */
@@ -901,7 +906,7 @@ void ticker_worker(void *param)
 				TICKER_RESCHEDULE_STATE_NONE;
 		}
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 		/* Scheduled timeout is acknowledged to be complete */
 		ticker->ack--;
@@ -924,8 +929,8 @@ void ticker_worker(void *param)
 					     ticker->context);
 			DEBUG_TICKER_TASK(0);
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
-			if (must_expire_skip == 0U) {
+			if (!IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) &&
+			   (must_expire_skip == 0U)) {
 				/* Reset latency to periodic offset */
 				ticker->lazy_current = 0U;
 				ticker->force = 0U;
@@ -934,7 +939,6 @@ void ticker_worker(void *param)
 					slot_reserved = 1U;
 				}
 			}
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
 		}
 	}
 
@@ -1404,13 +1408,13 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 	struct ticker_node *node;
 	uint32_t ticks_expired;
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 	uint32_t ticks_latency;
 	uint32_t ticks_now;
 
 	ticks_now = cntr_cnt_get();
 	ticks_latency = ticker_ticks_diff_get(ticks_now, ticks_previous);
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 	node = &instance->nodes[0];
 	ticks_expired = 0U;
@@ -1436,7 +1440,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 		ticks_elapsed -= ticks_to_expire;
 		ticks_expired += ticks_to_expire;
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 		ticks_latency -= ticks_to_expire;
 
 		/* Node with lazy count did not expire with callback, but
@@ -1444,7 +1448,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 		 * not define the active slot reservation (slot_previous).
 		 */
 		skip_collision = (ticker->lazy_current != 0U);
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 		/* decrement ticks_slot_previous */
 		if (instance->ticks_slot_previous > ticks_to_expire) {
@@ -1473,7 +1477,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 		/* Ticker will be restarted if periodic or to be re-scheduled */
 		if ((ticker->ticks_periodic != 0U) ||
 		    TICKER_RESCHEDULE_PENDING(ticker)) {
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 			if (TICKER_RESCHEDULE_PENDING(ticker)) {
 				/* Set the re-scheduled node to now. Will be
 				 * collision resolved after all nodes are
@@ -1540,7 +1544,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 
 			ticks_to_expire_prep(ticker, instance->ticks_current,
 					     (ticks_previous + ticks_expired));
-#else /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#else /* !CONFIG_BT_TICKER_LOW_LAT */
 			uint32_t count;
 
 			/* Prepare for next interval */
@@ -1558,7 +1562,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 			/* Reset latency to periodic offset */
 			ticker->lazy_current = ticker->lazy_periodic;
 			ticker->force = 0U;
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 			/* Add to insert list */
 			ticker->next = *insert_head;
 			*insert_head = id_expired;
@@ -1566,7 +1570,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 			/* set schedule status of node as restarting. */
 			ticker->req++;
 		} else {
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 			/* A single-shot ticker in requested or skipped due to
 			 * collision shall generate a operation function
 			 * callback with failure status.
@@ -1576,7 +1580,7 @@ static inline void ticker_job_worker_bh(struct ticker_instance *instance,
 				ticker->fp_op_func(TICKER_STATUS_FAILURE,
 						   ticker->op_context);
 			}
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 			/* reset schedule status of node */
 			ticker->req = ticker->ack;
@@ -1601,7 +1605,7 @@ static inline void ticker_job_op_start(struct ticker_node *ticker,
 {
 	struct ticker_user_op_start *start = (void *)&user_op->params.start;
 
-#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if defined(CONFIG_BT_TICKER_LOW_LAT)
 	/* Must expire is not supported in compatibility mode */
 	LL_ASSERT(start->lazy < TICKER_LAZY_MUST_EXPIRE_KEEP);
 #else
@@ -1613,7 +1617,7 @@ static inline void ticker_job_op_start(struct ticker_node *ticker,
 #if defined(CONFIG_BT_TICKER_EXT)
 	ticker->ext_data = start->ext_data;
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* CONFIG_BT_TICKER_LOW_LAT */
 
 	ticker->ticks_periodic = start->ticks_periodic;
 	ticker->remainder_periodic = start->remainder_periodic;
@@ -1631,7 +1635,7 @@ static inline void ticker_job_op_start(struct ticker_node *ticker,
 	ticker->force = 1U;
 }
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 /**
  * @brief Insert new ticker node
  *
@@ -1877,7 +1881,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 	return rescheduled;
 }
 #endif /* CONFIG_BT_TICKER_EXT */
-#else  /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#else  /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Insert new ticker node
@@ -1990,7 +1994,7 @@ static inline uint32_t ticker_job_insert(struct ticker_instance *instance,
 
 	return TICKER_STATUS_SUCCESS;
 }
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Insert and start ticker nodes for all users
@@ -2082,15 +2086,14 @@ static inline void ticker_job_list_insert(struct ticker_instance *instance,
 			if (user_op) {
 				ticker_job_op_cb(user_op, status);
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
-				if ((ticker->ticks_periodic == 0U) &&
+				if (!IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) &&
+				    (ticker->ticks_periodic == 0U) &&
 				    user_op) {
 					ticker->fp_op_func =
 						user_op->fp_op_func;
 					ticker->op_context =
 						user_op->op_context;
 				}
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
 			}
 		}
 	}
@@ -2126,7 +2129,7 @@ static inline void ticker_job_op_inquire(struct ticker_instance *instance,
 		uop->status = TICKER_STATUS_SUCCESS;
 		fp_op_func = uop->fp_op_func;
 		break;
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 	case TICKER_USER_OP_TYPE_PRIORITY_SET:
 		if (uop->id < instance->count_node) {
 			struct ticker_node *node = instance->nodes;
@@ -2139,7 +2142,7 @@ static inline void ticker_job_op_inquire(struct ticker_instance *instance,
 		}
 		fp_op_func = uop->fp_op_func;
 		break;
-#endif
+#endif /* CONFIG_BT_TICKER_LOW_LAT */
 	default:
 		/* do nothing for other ops */
 		break;
@@ -2439,11 +2442,13 @@ uint32_t ticker_init(uint8_t instance_index, uint8_t count_node, void *node,
 	instance->count_node = count_node;
 	instance->nodes = node;
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 	while (count_node--) {
 		instance->nodes[count_node].priority = 0;
 	}
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT &&
+	* !CONFIG_BT_TICKER_SLOT_AGNOSTIC
+	*/
 
 	instance->count_user = count_user;
 	instance->users = user;
@@ -2946,7 +2951,7 @@ uint32_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 	return user_op->status;
 }
 
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 /**
  * @brief Set ticker node priority
  *
@@ -3003,7 +3008,7 @@ uint32_t ticker_priority_set(uint8_t instance_index, uint8_t user_id, uint8_t ti
 
 	return user_op->status;
 }
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 /**
  * @brief Schedule ticker job

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -43,9 +43,13 @@
 #if defined(CONFIG_BT_TICKER_EXT)
 #define TICKER_NODE_T_SIZE      48
 #else
+#if defined(CONFIG_BT_TICKER_SLOT_AGNOSTIC)
+#define TICKER_NODE_T_SIZE      36
+#else
 #define TICKER_NODE_T_SIZE      44
+#endif /* CONFIG_BT_TICKER_SLOT_AGNOSTIC */
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* CONFIG_BT_TICKER_LOW_LAT*/
+#endif /* CONFIG_BT_TICKER_LOW_LAT */
 
 /** \brief Timer user type size.
  */
@@ -56,7 +60,11 @@
 #if defined(CONFIG_BT_TICKER_EXT)
 #define TICKER_USER_OP_T_SIZE   52
 #else
+#if defined(CONFIG_BT_TICKER_SLOT_AGNOSTIC)
+#define TICKER_USER_OP_T_SIZE   44
+#else
 #define TICKER_USER_OP_T_SIZE   48
+#endif /* CONFIG_BT_TICKER_SLOT_AGNOSTIC */
 #endif /* CONFIG_BT_TICKER_EXT */
 
 #define TICKER_CALL_ID_NONE     0
@@ -97,15 +105,15 @@ typedef void (*ticker_op_func) (uint32_t status, void *op_context);
 
 #if defined(CONFIG_BT_TICKER_EXT)
 struct ticker_ext {
-	uint32_t ticks_slot_window; /* Window in which the slot
-				  * reservation may be re-scheduled
-				  * to avoid collision
-				  */
-	int32_t ticks_drift;	 /* Applied drift since last expiry */
-	uint8_t  reschedule_state;	 /* State of re-scheduling of the
-				  * node. See defines
-				  * TICKER_RESCHEDULE_STATE_XXX
-				  */
+	uint32_t ticks_slot_window;/* Window in which the slot
+				    * reservation may be re-scheduled
+				    * to avoid collision
+				    */
+	int32_t ticks_drift;	   /* Applied drift since last expiry */
+	uint8_t reschedule_state;  /* State of re-scheduling of the
+				    * node. See defines
+				    * TICKER_RESCHEDULE_STATE_XXX
+				    */
 };
 #endif /* CONFIG_BT_TICKER_EXT */
 
@@ -156,7 +164,8 @@ uint32_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 void ticker_job_sched(uint8_t instance_index, uint8_t user_id);
 uint32_t ticker_ticks_now_get(void);
 uint32_t ticker_ticks_diff_get(uint32_t ticks_now, uint32_t ticks_old);
-#if !defined(CONFIG_BT_TICKER_LOW_LAT)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT) && \
+	!defined(CONFIG_BT_TICKER_SLOT_AGNOSTIC)
 uint32_t ticker_priority_set(uint8_t instance_index, uint8_t user_id, uint8_t ticker_id,
 			  int8_t priority, ticker_op_func fp_op_func,
 			  void *op_context);
@@ -176,4 +185,6 @@ uint32_t ticker_update_ext(uint8_t instance_index, uint8_t user_id,
 			   ticker_op_func fp_op_func, void *op_context,
 			   uint8_t must_expire);
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* !CONFIG_BT_TICKER_LOW_LAT */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT &&
+	* !CONFIG_BT_TICKER_SLOT_AGNOSTIC
+	*/

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -37,7 +37,7 @@
 
 /** \brief Timer node type size.
  */
-#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if defined(CONFIG_BT_TICKER_LOW_LAT)
 #define TICKER_NODE_T_SIZE      40
 #else
 #if defined(CONFIG_BT_TICKER_EXT)
@@ -45,7 +45,7 @@
 #else
 #define TICKER_NODE_T_SIZE      44
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* CONFIG_BT_TICKER_COMPATIBILITY_MODE*/
+#endif /* CONFIG_BT_TICKER_LOW_LAT*/
 
 /** \brief Timer user type size.
  */
@@ -156,7 +156,7 @@ uint32_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 void ticker_job_sched(uint8_t instance_index, uint8_t user_id);
 uint32_t ticker_ticks_now_get(void);
 uint32_t ticker_ticks_diff_get(uint32_t ticks_now, uint32_t ticks_old);
-#if !defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE)
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
 uint32_t ticker_priority_set(uint8_t instance_index, uint8_t user_id, uint8_t ticker_id,
 			  int8_t priority, ticker_op_func fp_op_func,
 			  void *op_context);
@@ -176,4 +176,4 @@ uint32_t ticker_update_ext(uint8_t instance_index, uint8_t user_id,
 			   ticker_op_func fp_op_func, void *op_context,
 			   uint8_t must_expire);
 #endif /* CONFIG_BT_TICKER_EXT */
-#endif /* !CONFIG_BT_TICKER_COMPATIBILITY_MODE */
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -97,7 +97,7 @@ typedef void (*ticker_trigger_set_cb_t)(uint32_t value);
 /** \brief Timer timeout function type.
  */
 typedef void (*ticker_timeout_func) (uint32_t ticks_at_expire, uint32_t remainder,
-				     uint16_t lazy, void *context);
+				     uint16_t lazy, uint8_t force, void *context);
 
 /** \brief Timer operation complete function type.
  */


### PR DESCRIPTION
This commit splits code from Nordic LLL into lll_common.c, which can
then be reused across LLL implementations.

The ticker can now be configured in a "slot agnostic" mode, in which no
collision resolving or slot reservation is used. In this mode, the
ticker acts as a simple timer.

Event scheduling states are stored in the lll_hdr, and event priority
is passed from LLL implementation, and runtime priority calculated.

LLL implementation decides whether to program radio, start preemption
timer, and/or queue prepare in the prepare pipeline.

Event arbitration is made possible via the common LLL, but not yet
implemented in Nordic LLL.

Split only covers Nordic implementation. Other vendors should adjust
and implement their LLL accordingly to use the feature.

Signed-off-by: Morten Priess <mtpr@oticon.com>