### PR TITLE
manifest: Mcuboot update

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -131,6 +131,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -80,6 +80,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -79,6 +79,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -109,6 +109,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -80,6 +80,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -120,6 +120,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -72,6 +72,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -74,6 +74,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -121,6 +121,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -104,6 +104,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -101,6 +101,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -72,6 +72,7 @@
 		sw1 = &button3;
 		sw2 = &button0;
 		sw3 = &button1;
+		bootloader-led0 = &led0;
 	};
 };
 

--- a/west.yml
+++ b/west.yml
@@ -91,7 +91,7 @@ manifest:
       revision: 24d84ecff195fb15c889d9046e44e4804d626c67
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 3fc59410b633a6d83bbb534e43aac43160f9bd32
+      revision: 846b104e67c46f9428fd020ba8dccf94f786d94d
       path: bootloader/mcuboot
     - name: mcumgr
       revision: c52ecb771a9b2bdabfc70bee094555f11edbb539


### PR DESCRIPTION
Mcuboot was updated to the version synchronized with
the upstream 5b7ed6a which introduces:

- Added LED support for signaling enter to the serial recovery mode
- Added boot delay/debonuce of serial detect pin.
- Fixed compilation warnings with ZEPHYR_LOG_MODE_MINIMAL
- Added optional check which prevents attempting to boot image that
has been build for different ROM address than a slot it currently
resides in. Check is enabled if image was signed with
IMAGE_F_ROM_FIXED flag.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>