### PR TITLE
drivers: i2c: mchp: Use I2C logging control

### DIFF
--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <drivers/i2c.h>
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_mchp);
+LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
 
 #define SPEED_100KHZ_BUS    0
 #define SPEED_400KHZ_BUS    1


### PR DESCRIPTION
Fix CONFIG_I2C_LOG_LEVEL_XXX not having effect on this driver.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>