### PR TITLE
dma: Kconfig remove unused kconfig symbols

### DIFF
--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -10,30 +10,6 @@ menuconfig DMA
 	bool "DMA driver Configuration"
 
 if DMA
-config DMA_0_NAME
-	string "Device name for DMA Controller 0"
-	default "DMA_0"
-	help
-	  Device name for DMA Controller 0.
-
-config DMA_0_IRQ_PRI
-	int "IRQ Priority for DMA Controller 0"
-	default 3
-	help
-	  IRQ Priority for the DMA Controller.
-
-config DMA_1_NAME
-	string "Device name for DMA Controller 1"
-	default "DMA_1"
-	help
-	  Device name for DMA Controller 1.
-
-config DMA_2_NAME
-	string "Device name for DMA Controller 2"
-	default "DMA_2"
-	help
-	  Device name for DMA Controller 2.
-
 config DMA_64BIT
 	bool "DMA 64 bit address support"
 	help

--- a/samples/boards/96b_argonkey/microphone/prj.conf
+++ b/samples/boards/96b_argonkey/microphone/prj.conf
@@ -13,5 +13,4 @@ CONFIG_AUDIO_MPXXDTYY=y
 # disabled and DMA interrupts must run at maximum priority.
 
 CONFIG_DMA=y
-CONFIG_DMA_0_IRQ_PRI=0
 CONFIG_HEAP_MEM_POOL_SIZE=1024


### PR DESCRIPTION
All dma drivers are devicetree based now so we can remove the last
bits of Kconfig associated with the old driver style.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>