### PR TITLE
bsim_bt: run_parallel.sh: Fix execution without explicit SEARCH_PATH

### DIFF
--- a/tests/bluetooth/bsim_bt/run_parallel.sh
+++ b/tests/bluetooth/bsim_bt/run_parallel.sh
@@ -28,7 +28,7 @@ fi
 err=0
 i=0
 
-SEARCH_PATH="${SEARCH_PATH:-`pwd`}"
+SEARCH_PATH="${SEARCH_PATH:-.}"
 
 #All the testcases we want to run:
 all_cases=`find ${SEARCH_PATH} -name "*.sh" | \


### PR DESCRIPTION
Set SEARCH_PATH to "." instead of `pwd` if not set explicitly. This
avoids the construction of paths that contain `pwd` twice in test
scripts such as ll.1.sh.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>