### PR TITLE
gpio: add struct gpio_dt_spec

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -305,6 +305,59 @@ typedef uint8_t gpio_dt_flags_t;
 typedef uint32_t gpio_flags_t;
 
 /**
+ * @brief Provides a type to hold GPIO information specified in devicetree
+ *
+ * This type is sufficient to hold a GPIO device pointer, pin number,
+ * and the subset of the flags used to control GPIO configuration
+ * which may be given in devicetree.
+ */
+struct gpio_dt_spec {
+	const struct device *port;
+	gpio_pin_t pin;
+	gpio_dt_flags_t dt_flags;
+};
+
+/**
+ * @brief Static initializer for a @p gpio_dt_spec
+ *
+ * This returns a static initializer for a @p gpio_dt_spec structure
+ * given a devicetree node identifier and a property specifying a
+ * GPIO.
+ *
+ * Example devicetree fragment:
+ *
+ *	n: node {
+ *		foo-gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+ *	}
+ *
+ * Example usage:
+ *
+ *	const struct gpio_dt_spec spec = GPIO_DT_SPEC_GET(DT_NODELABEL(n),
+ *							  foo_gpios);
+ *	// Initializes 'spec' to:
+ *	// {
+ *	//         .port = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
+ *	//         .pin = 2,
+ *	//         .dt_flags = GPIO_ACTIVE_LOW
+ *	// }
+ *
+ * The 'gpio' field must still be checked for readiness, e.g. using
+ * device_is_ready(). It is an error to use this macro unless the node
+ * exists, has the given property, and that property specifies a GPIO
+ * controller, pin number, and flags as shown above.
+ *
+ * @param node_id devicetree node identifier
+ * @param prop lowercase-and-underscores property name
+ * @return static initializer for a struct gpio_dt_spec for the property
+ */
+#define GPIO_DT_SPEC_GET(node_id, prop)					\
+	{								\
+		.port = DEVICE_DT_GET(DT_GPIO_CTLR(node_id, prop)),	\
+		.pin = DT_GPIO_PIN(node_id, prop),			\
+		.dt_flags = DT_GPIO_FLAGS(node_id, prop),		\
+	}
+
+/**
  * @brief Maximum number of pins that are supported by `gpio_port_pins_t`.
  */
 #define GPIO_MAX_PINS_PER_PORT (sizeof(gpio_port_pins_t) * __CHAR_BIT__)
@@ -523,6 +576,25 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 }
 
 /**
+ * @brief Configure pin interrupts from a @p gpio_dt_spec.
+ *
+ * This is equivalent to:
+ *
+ *     gpio_pin_interrupt_configure(spec->port, spec->pin, flags);
+ *
+ * The <tt>spec->dt_flags</tt> value is not used.
+ *
+ * @param spec GPIO specification from devicetree
+ * @param flags interrupt configuration flags
+ * @retval a value from gpio_pin_interrupt_configure()
+ */
+static inline int gpio_pin_interrupt_configure_dt(const struct gpio_dt_spec *spec,
+						  gpio_flags_t flags)
+{
+	return gpio_pin_interrupt_configure(spec->port, spec->pin, flags);
+}
+
+/**
  * @brief Configure a single pin.
  *
  * @param port Pointer to device structure for the driver instance.
@@ -598,6 +670,25 @@ static inline int gpio_pin_configure(const struct device *port,
 	}
 
 	return ret;
+}
+
+/**
+ * @brief Configure a single pin from a @p gpio_dt_spec and some extra flags.
+ *
+ * This is equivalent to:
+ *
+ *     gpio_pin_configure(spec->port, spec->pin, spec->dt_flags | extra_flags);
+ *
+ * @param spec GPIO specification from devicetree
+ * @param extra_flags additional flags
+ * @retval a value from gpio_pin_configure()
+ */
+static inline int gpio_pin_configure_dt(const struct gpio_dt_spec *spec,
+					gpio_flags_t extra_flags)
+{
+	return gpio_pin_configure(spec->port,
+				  spec->pin,
+				  spec->dt_flags | extra_flags);
 }
 
 /**

--- a/samples/bluetooth/mesh_demo/src/board.h
+++ b/samples/bluetooth/mesh_demo/src/board.h
@@ -15,15 +15,16 @@ uint16_t board_set_target(void);
 void board_play(const char *str);
 
 #if defined(CONFIG_BOARD_BBC_MICROBIT)
-void board_init(uint16_t *addr);
+int board_init(uint16_t *addr);
 void board_play_tune(const char *str);
 void board_heartbeat(uint8_t hops, uint16_t feat);
 void board_other_dev_pressed(uint16_t addr);
 void board_attention(bool attention);
 #else
-static inline void board_init(uint16_t *addr)
+static inline int board_init(uint16_t *addr)
 {
 	*addr = NODE_ADDR;
+	return 0;
 }
 
 static inline void board_play_tune(const char *str)

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -268,7 +268,11 @@ void main(void)
 
 	printk("Initializing...\n");
 
-	board_init(&addr);
+	err = board_init(&addr);
+	if (err) {
+		printk("Board initialization failed\n");
+		return;
+	}
 
 	printk("Unicast address: 0x%04x\n", addr);
 
@@ -276,6 +280,7 @@ void main(void)
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
+		return;
 	}
 
 	while (1) {

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -29,9 +29,13 @@
 #define SEQ_PAGE     (NRF_FICR->CODEPAGESIZE * (NRF_FICR->CODESIZE - 1))
 #define SEQ_MAX      (NRF_FICR->CODEPAGESIZE * 8 * SEQ_PER_BIT)
 
-static const struct device *gpio;
-static const struct device *nvm;
-static const struct device *pwm;
+static const struct gpio_dt_spec button_a =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(buttona), gpios);
+static const struct gpio_dt_spec button_b =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(buttonb), gpios);
+static const struct device *nvm =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+static const struct device *pwm = DEVICE_DT_GET_ANY(nordic_nrf_sw_pwm);
 
 static struct k_work button_work;
 
@@ -46,7 +50,7 @@ static void button_pressed(const struct device *dev, struct gpio_callback *cb,
 {
 	struct mb_display *disp = mb_display_get();
 
-	if (pins & BIT(DT_GPIO_PIN(DT_ALIAS(sw0), gpios))) {
+	if (pins & BIT(button_a.pin)) {
 		k_work_submit(&button_work);
 	} else {
 		uint16_t target = board_set_target();
@@ -222,36 +226,54 @@ void board_attention(bool attention)
 	}
 }
 
-static void configure_button(void)
+static int configure_button(const struct gpio_dt_spec *button)
+{
+	int err;
+
+	err = gpio_pin_configure_dt(button, GPIO_INPUT);
+	if (err) {
+		return err;
+	}
+	return gpio_pin_interrupt_configure_dt(button, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static int configure_buttons(void)
 {
 	static struct gpio_callback button_cb;
+	int err;
 
 	k_work_init(&button_work, button_send_pressed);
 
-	gpio = device_get_binding(DT_GPIO_LABEL(DT_ALIAS(sw0), gpios));
+	err = configure_button(&button_a);
+	if (err) {
+		return err;
+	}
 
-	gpio_pin_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
-			   GPIO_INPUT | DT_GPIO_FLAGS(DT_ALIAS(sw0), gpios));
-	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
-				     GPIO_INT_EDGE_TO_ACTIVE);
+	err = configure_button(&button_b);
+	if (err) {
+		return err;
+	}
 
-	gpio_pin_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw1), gpios),
-			   GPIO_INPUT | DT_GPIO_FLAGS(DT_ALIAS(sw1), gpios));
-	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw1), gpios),
-				     GPIO_INT_EDGE_TO_ACTIVE);
+	if (button_a.port != button_b.port) {
+		/* These should be the same device on this board. */
+		return -EINVAL;
+	}
 
 	gpio_init_callback(&button_cb, button_pressed,
-			   BIT(DT_GPIO_PIN(DT_ALIAS(sw0), gpios)) |
-			   BIT(DT_GPIO_PIN(DT_ALIAS(sw1), gpios)));
-	gpio_add_callback(gpio, &button_cb);
+			   BIT(button_a.pin) | BIT(button_b.pin));
+	return gpio_add_callback(button_a.port, &button_cb);
 }
 
-void board_init(uint16_t *addr)
+int board_init(uint16_t *addr)
 {
 	struct mb_display *disp = mb_display_get();
 
-	nvm = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	pwm = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_sw_pwm)));
+	if (!(device_is_ready(nvm) && device_is_ready(pwm) &&
+	      device_is_ready(button_a.port) &&
+	      device_is_ready(button_b.port))) {
+		printk("One or more devices are not ready\n");
+		return -ENODEV;
+	}
 
 	*addr = NRF_UICR->CUSTOMER[0];
 	if (!*addr || *addr == 0xffff) {
@@ -265,5 +287,5 @@ void board_init(uint16_t *addr)
 	mb_display_print(disp, MB_DISPLAY_MODE_DEFAULT, SCROLL_SPEED,
 			 "0x%04x", *addr);
 
-	configure_button();
+	return configure_buttons();
 }


### PR DESCRIPTION
See #31280 for discussion and motivation.

This adds a structure and helper macro for converting a `foo-gpios` style devicetree property to a GPIO device and specifier data at build time.

Use the mesh_demo sample as a first user.

Fixes: #31280