### PR TITLE
kernel (mostly): locally cache values of _current and _current_cpu

### DIFF
--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -93,10 +93,12 @@ static inline int eswifi_request(struct eswifi_dev *eswifi, char *cmd,
 
 static inline void eswifi_lock(struct eswifi_dev *eswifi)
 {
+	struct k_thread *const current = _current;
+
 	/* Nested locking */
-	if (atomic_get(&eswifi->mutex_owner) != (atomic_t)(uintptr_t)_current) {
+	if (atomic_get(&eswifi->mutex_owner) != (atomic_t)(uintptr_t)current) {
 		k_mutex_lock(&eswifi->mutex, K_FOREVER);
-		atomic_set(&eswifi->mutex_owner, (atomic_t)(uintptr_t)_current);
+		atomic_set(&eswifi->mutex_owner, (atomic_t)(uintptr_t)current);
 		eswifi->mutex_depth = 1;
 	} else {
 		eswifi->mutex_depth++;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -252,10 +252,12 @@ static inline void _ready_one_thread(_wait_q_t *wq)
 static inline void z_sched_lock(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
-	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(_current->base.sched_locked != 1, "");
+	struct k_thread *const current = _current;
 
-	--_current->base.sched_locked;
+	__ASSERT(!arch_is_in_isr(), "");
+	__ASSERT(current->base.sched_locked != 1, "");
+
+	--current->base.sched_locked;
 
 	compiler_barrier();
 
@@ -265,12 +267,14 @@ static inline void z_sched_lock(void)
 static ALWAYS_INLINE void z_sched_unlock_no_reschedule(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
+	struct k_thread *const current = _current;
+
 	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(_current->base.sched_locked != 0, "");
+	__ASSERT(current->base.sched_locked != 0, "");
 
 	compiler_barrier();
 
-	++_current->base.sched_locked;
+	++current->base.sched_locked;
 #endif
 }
 

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -84,6 +84,8 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 	new_thread = z_swap_next_thread();
 
 	if (new_thread != old_thread) {
+		_cpu_t *const current_cpu = _current_cpu;
+
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice();
 #endif
@@ -91,7 +93,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		old_thread->swap_retval = -EAGAIN;
 
 #ifdef CONFIG_SMP
-		_current_cpu->swap_ok = 0;
+		current_cpu->swap_ok = 0;
 		new_thread->base.cpu = arch_curr_cpu()->id;
 
 		if (!is_spinlock) {
@@ -100,7 +102,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 #endif
 		z_thread_mark_switched_out();
 		wait_for_switch(new_thread);
-		_current_cpu->current = new_thread;
+		current_cpu->current = new_thread;
 
 #ifdef CONFIG_SPIN_VALIDATE
 		z_spin_lock_set_owner(&sched_spinlock);

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -387,9 +387,10 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	struct k_mbox_msg *tx_msg;
 	k_spinlock_key_t key;
 	int result;
+	struct k_thread *const current = _current;
 
 	/* save receiver id so it can be used during message matching */
-	rx_msg->tx_target_thread = _current;
+	rx_msg->tx_target_thread = current;
 
 	/* search mailbox's tx queue for a compatible sender */
 	key = k_spin_lock(&mbox->lock);
@@ -417,7 +418,7 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	}
 
 	/* wait until a matching sender appears or a timeout occurs */
-	_current->base.swap_data = rx_msg;
+	current->base.swap_data = rx_msg;
 	result = z_pend_curr(&mbox->lock, key, &mbox->rx_msg_queue, timeout);
 
 	/* consume message data immediately, if needed */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -17,23 +17,26 @@ static atomic_t start_flag;
 unsigned int z_smp_global_lock(void)
 {
 	unsigned int key = arch_irq_lock();
+	struct k_thread *const current = _current;
 
-	if (!_current->base.global_lock_count) {
+	if (!current->base.global_lock_count) {
 		while (!atomic_cas(&global_lock, 0, 1)) {
 		}
 	}
 
-	_current->base.global_lock_count++;
+	current->base.global_lock_count++;
 
 	return key;
 }
 
 void z_smp_global_unlock(unsigned int key)
 {
-	if (_current->base.global_lock_count) {
-		_current->base.global_lock_count--;
+	struct k_thread *const current = _current;
 
-		if (!_current->base.global_lock_count) {
+	if (current->base.global_lock_count) {
+		current->base.global_lock_count--;
+
+		if (!current->base.global_lock_count) {
 			atomic_clear(&global_lock);
 		}
 	}

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -70,10 +70,11 @@ static int32_t next_timeout(void)
 	int32_t ticks_elapsed = elapsed();
 	int32_t ret = to == NULL ? MAX_WAIT
 		: CLAMP(to->dticks - ticks_elapsed, 0, MAX_WAIT);
-
 #ifdef CONFIG_TIMESLICING
-	if (_current_cpu->slice_ticks && _current_cpu->slice_ticks < ret) {
-		ret = _current_cpu->slice_ticks;
+	_cpu_t *const current_cpu = _current_cpu;
+
+	if (current_cpu->slice_ticks && current_cpu->slice_ticks < ret) {
+		ret = current_cpu->slice_ticks;
 	}
 #endif
 	return ret;

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -581,9 +581,11 @@ static int thread_perms_test(struct z_object *ko)
 
 static void dump_permission_error(struct z_object *ko)
 {
-	int index = thread_index_get(_current);
+	struct k_thread *const current = _current;
+	int index = thread_index_get(current);
+
 	LOG_ERR("thread %p (%d) does not have permission on %s %p",
-		_current, index,
+		current, index,
 		otype_to_str(ko->type), ko->name);
 	LOG_HEXDUMP_ERR(ko->perms, sizeof(ko->perms), "permission bitmap");
 }

--- a/lib/cmsis_rtos_v2/mutex.c
+++ b/lib/cmsis_rtos_v2/mutex.c
@@ -65,6 +65,7 @@ osStatus_t osMutexAcquire(osMutexId_t mutex_id, uint32_t timeout)
 {
 	struct cv2_mutex *mutex = (struct cv2_mutex *) mutex_id;
 	int status;
+	struct k_thread *const current = _current;
 
 	if (mutex_id == NULL) {
 		return osErrorParameter;
@@ -74,15 +75,11 @@ osStatus_t osMutexAcquire(osMutexId_t mutex_id, uint32_t timeout)
 		return osErrorISR;
 	}
 
-	if (mutex->z_mutex.lock_count == 0U ||
-	    mutex->z_mutex.owner == _current) {
-	}
-
 	/* Throw an error if the mutex is not configured to be recursive and
 	 * the current thread is trying to acquire the mutex again.
 	 */
 	if ((mutex->state & osMutexRecursive) == 0U) {
-		if ((mutex->z_mutex.owner == _current) &&
+		if ((mutex->z_mutex.owner == current) &&
 		    (mutex->z_mutex.lock_count != 0U)) {
 			return osErrorResource;
 		}

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -255,7 +255,8 @@ def marshall_defs(func_name, func_type, args):
     else:
         mrsh += "\t\t" + "uintptr_t arg3, uintptr_t arg4, void *more, void *ssf)\n"
     mrsh += "{\n"
-    mrsh += "\t" + "_current->syscall_frame = ssf;\n"
+    mrsh += "\t" + "struct k_thread *const current = _current;\n\n"
+    mrsh += "\t" + "current->syscall_frame = ssf;\n"
 
     for unused_arg in range(nmrsh, 6):
         mrsh += "\t(void) arg%d;\t/* unused */\n" % unused_arg
@@ -284,7 +285,7 @@ def marshall_defs(func_name, func_type, args):
 
     if func_type == "void":
         mrsh += "\t" + "%s;\n" % vrfy_call
-        mrsh += "\t" + "_current->syscall_frame = NULL;\n"
+        mrsh += "\t" + "current->syscall_frame = NULL;\n"
         mrsh += "\t" + "return 0;\n"
     else:
         mrsh += "\t" + "%s ret = %s;\n" % (func_type, vrfy_call)
@@ -293,10 +294,10 @@ def marshall_defs(func_name, func_type, args):
             ptr = "((uint64_t *)%s)" % mrsh_rval(nmrsh - 1, nmrsh)
             mrsh += "\t" + "Z_OOPS(Z_SYSCALL_MEMORY_WRITE(%s, 8));\n" % ptr
             mrsh += "\t" + "*%s = ret;\n" % ptr
-            mrsh += "\t" + "_current->syscall_frame = NULL;\n"
+            mrsh += "\t" + "current->syscall_frame = NULL;\n"
             mrsh += "\t" + "return 0;\n"
         else:
-            mrsh += "\t" + "_current->syscall_frame = NULL;\n"
+            mrsh += "\t" + "current->syscall_frame = NULL;\n"
             mrsh += "\t" + "return (uintptr_t) ret;\n"
 
     mrsh += "}\n"


### PR DESCRIPTION
See e.g. discussion around #32709. Long story short, the compiler isn't particularly good at the best of times at realizing when it is doing redundant calls.

See e.g. https://godbolt.org/z/6jdzhq for a simple example.

Unfortunately, this often has serious knock-on effects (because the compiler doesn't recognize that the two are the same, it'll also e.g. do multiple comparisons, emit code for the case of `_current` being value A then value B later, etc, etc.).

This mainly affects SMP and is a fairly "soft" failure (in the sense that it reduces performance, generally speaking, but doesn't generally affect correctness); don't worry too much about reintroducing duplication later.

This PR gets the low-hanging fruit - that is, cases where `_current` or `_current_cpu` were unconditionally dereferenced more than once within a code path. It does not attempt to tackle e.g. cases where function A dereferences `_current` then calls inline function B that dereferences `_current` again.

As an added bonus, in some cases this results in moving getting `_current` out of a spinlock.

(There _are_ potential cases where this results in worse code, but only slightly so, and I haven't run across any in practice as of yet. Mainly if the compiler does the function call too early and has to spill other values to stack as a result.)

(There is also the possibility here of introducing errors if the resulting caching is overzealous, e.g. if you cache a `_current_cpu` value across a spin unlock/lock.)