### PR TITLE
[backport v2.3] mempool: Fix possible overflow

### DIFF
--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -9,6 +9,7 @@
 #include <sys/__assert.h>
 #include <sys/mempool_base.h>
 #include <sys/mempool.h>
+#include <sys/math_extras.h>
 
 #ifdef CONFIG_MISRA_SANE
 #define LVL_ARRAY_SZ(n) (8 * sizeof(void *) / 2)
@@ -328,7 +329,12 @@ void *sys_mem_pool_alloc(struct sys_mem_pool *p, size_t size)
 
 	sys_mutex_lock(&p->mutex, K_FOREVER);
 
-	size += WB_UP(sizeof(struct sys_mem_pool_block));
+	if (size_add_overflow(size, WB_UP(sizeof(struct sys_mem_pool_block)),
+			      &size)) {
+		ret = NULL;
+		goto out;
+	}
+
 	if (z_sys_mem_pool_block_alloc(&p->base, size, &level, &block,
 				      (void **)&ret)) {
 		ret = NULL;


### PR DESCRIPTION
Backport of #31796
Fix possible overflow when allocating memory resulting in less memory
allocated what can cause further invalid memory access.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>
Signed-off-by: David Brown <david.brown@linaro.org>