### PR TITLE
drivers: dma: nios2_msgdma: Fix typo in irq priority

### DIFF
--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -218,7 +218,7 @@ static int nios2_msgdma0_initialize(const struct device *dev)
 
 	alt_msgdma_init(dev_cfg->msgdma_dev, 0, DT_INST_IRQN(0));
 
-	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(inst, priority),
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nios2_msgdma_isr, DEVICE_DT_INST_GET(0), 0);
 
 	irq_enable(DT_INST_IRQN(0));


### PR DESCRIPTION
Extracting priority from the devicetree should specify instance 0, not
'inst'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>