### PR TITLE
Cypress: Introduce PSoC-6 pinctrl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -317,6 +317,7 @@
 /dts/arm/atmel/samv71*                    @nandojve
 /dts/arm/atmel/                           @galak
 /dts/arm/broadcom/                        @sbranden
+/dts/arm/cypress/                         @nandojve
 /dts/arm/infineon/                        @parthitce
 /dts/arm/qemu-virt/                       @carlocaione
 /dts/arm/quicklogic/                      @wtatarski @kowalewskijan @kgugala
@@ -357,6 +358,7 @@
 /dts/bindings/serial/ns16550.yaml         @dcpleung @nashif
 /dts/bindings/wifi/*esp.yaml              @mniestroj
 /dts/bindings/*/*npcx*                    @MulinChao @WealianLiao @ChiHuaL
+/dts/bindings/*/*psoc6*                   @nandojve
 /dts/bindings/*/nordic*                   @anangl
 /dts/bindings/*/nxp*                      @MaureenHelm
 /dts/bindings/*/openisa*                  @MaureenHelm

--- a/dts/arm/cypress/pinctrl_cypress_psoc6.h
+++ b/dts/arm/cypress/pinctrl_cypress_psoc6.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020 Linaro Limited
+ * Copyright (c) 2021 ATL Electronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PINCTRL_CYPRESS_PSOC6_H_
+#define PINCTRL_CYPRESS_PSOC6_H_
+
+#include <dt-bindings/dt-util.h>
+
+/**
+ * Functions are defined using HSIOM SEL
+ */
+
+#define HSIOM_SEL_gpio          0
+#define HSIOM_SEL_gpio_dsi      1
+#define HSIOM_SEL_dsi_dsi       2
+#define HSIOM_SEL_dsi_gpio      3
+#define HSIOM_SEL_amuxa         4
+#define HSIOM_SEL_amuxb         5
+#define HSIOM_SEL_amuxa_dsi     6
+#define HSIOM_SEL_amuxb_dsi     7
+#define HSIOM_SEL_act_0         8
+#define HSIOM_SEL_act_1         9
+#define HSIOM_SEL_act_2        10
+#define HSIOM_SEL_act_3        11
+#define HSIOM_SEL_ds_0         12
+#define HSIOM_SEL_ds_1         13
+#define HSIOM_SEL_ds_2         14
+#define HSIOM_SEL_ds_3         15
+#define HSIOM_SEL_act_4        16
+#define HSIOM_SEL_act_5        17
+#define HSIOM_SEL_act_6        18
+#define HSIOM_SEL_act_7        19
+#define HSIOM_SEL_act_8        20
+#define HSIOM_SEL_act_9        21
+#define HSIOM_SEL_act_10       22
+#define HSIOM_SEL_act_11       23
+#define HSIOM_SEL_act_12       24
+#define HSIOM_SEL_act_13       25
+#define HSIOM_SEL_act_14       26
+#define HSIOM_SEL_act_15       27
+#define HSIOM_SEL_ds_4         28
+#define HSIOM_SEL_ds_5         29
+#define HSIOM_SEL_ds_6         30
+#define HSIOM_SEL_ds_7         31
+
+
+/* Create a pincfg device tree node:
+ *
+ * The node name and nodelabel will be of the form:
+ *
+ * NODE = p<port>_<pin>_<inst>_<signal>
+ *
+ * NODE: NODE {
+ *	cypress,pins = < &gpio_prt<port> <pin> HSIOM_SEL_<hsiom> >;
+ *	flags_1;
+ *	  ...
+ *	flags_N;
+ * }
+ *
+ * So for example:
+ *
+ * DT_CYPRESS_PIN(uart5, rx, 5, 0, act_6);
+ *
+ * Will become:
+ *
+ * p5_0_uart5_rx: p5_0_uart5_rx {
+ *    cypress,pins = <&gpio_prt5 0x0 0x12 >;
+ * }
+ *
+ * Flags are optional and should be pass one by one as arguments:
+ *
+ * DT_CYPRESS_PIN(uart5, rx, 5, 0, act_6, bias-pull-up, input-enable);
+ *
+ * Will become:
+ *
+ * p5_0_uart5_rx: p5_0_uart5_rx {
+ *    cypress,pins = <&gpio_prt5 0x0 0x12 >;
+ *    bias-pull-up;
+ *    input-enable;
+ * }
+ *
+ * For the complete list of flags see cypress,psoc6-pinctrl.yaml
+ *
+ */
+
+#define DT_CYPRESS_HSIOM_FLAG(flag) flag;
+#define DT_CYPRESS_HSIOM_FLAGS(...) \
+	MACRO_MAP_CAT(DT_CYPRESS_HSIOM_FLAG __VA_OPT__(,) __VA_ARGS__)
+
+#define DT_CYPRESS_HSIOM(inst, signal, port, pin, hsiom, ...) \
+	p##port##_##pin##_##inst##_##signal: \
+	p##port##_##pin##_##inst##_##signal { \
+	cypress,pins = < &gpio_prt##port pin HSIOM_SEL_##hsiom > ; \
+		DT_CYPRESS_HSIOM_FLAGS(__VA_ARGS__) \
+	}
+
+#endif /* PINCTRL_CYPRESS_PSOC6_H_ */

--- a/dts/arm/cypress/psoc6-pinctrl.dtsi
+++ b/dts/arm/cypress/psoc6-pinctrl.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 ATL Electronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pinctrl_cypress_psoc6.h"
+
+/ {
+	soc {
+		pinctrl@40310000 {
+			/* instance, signal, port, pin, hsiom [, flag1, ... ] */
+			DT_CYPRESS_HSIOM(uart5,  rx,  5, 0, act_6, input-enable);
+			DT_CYPRESS_HSIOM(uart5,  tx,  5, 1, act_6, drive-push-pull);
+			DT_CYPRESS_HSIOM(uart6,  rx, 13, 0, act_6, input-enable);
+			DT_CYPRESS_HSIOM(uart6,  tx, 13, 1, act_6, drive-push-pull);
+		};
+	};
+};

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2018, Cypress
+ * Copyright (c) 2020-2021, ATL Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <mem.h>
 #include <dt-bindings/gpio/gpio.h>
+
+#include "psoc6-pinctrl.dtsi"
 
 / {
 	cpus {
@@ -64,163 +67,185 @@
 	};
 
 	soc {
-		hsiom: hsiom@40310000 {
-			compatible = "cypress,psoc6-hsiom";
-			reg = <0x40310000 0x2024>;
-			interrupts = <15 1>, <16 1>;
-			label = "HSIOM";
-			status = "disabled";
-		};
+		pinctrl@40310000 {
+			compatible = "cypress,psoc6-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x40310000 0x40310000 0x2024>;
 
-		gpio_prt0: gpio@40320000 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320000 0x80>;
-			interrupts = <0 1>;
-			label = "P0";
-			gpio-controller;
-			ngpios = <6>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt1: gpio@40320080 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320080 0x80>;
-			interrupts = <1 1>;
-			label = "P1";
-			gpio-controller;
-			ngpios = <6>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt2: gpio@40320100 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320100 0x80>;
-			interrupts = <2 1>;
-			label = "P2";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt3: gpio@40320180 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320180 0x80>;
-			interrupts = <3 1>;
-			label = "P3";
-			gpio-controller;
-			ngpios = <6>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt4: gpio@40320200 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320200 0x80>;
-			interrupts = <4 1>;
-			label = "P4";
-			gpio-controller;
-			ngpios = <4>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt5: gpio@40320280 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320280 0x80>;
-			interrupts = <5 1>;
-			label = "P5";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt6: gpio@40320300 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320300 0x80>;
-			interrupts = <6 1>;
-			label = "P6";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt7: gpio@40320380 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320380 0x80>;
-			interrupts = <7 1>;
-			label = "P7";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt8: gpio@40320400 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320400 0x80>;
-			interrupts = <8 1>;
-			label = "P8";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt9: gpio@40320480 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320480 0x80>;
-			interrupts = <9 1>;
-			label = "P9";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt10: gpio@40320500 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320500 0x80>;
-			interrupts = <10 1>;
-			label = "P10";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt11: gpio@40320580 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320580 0x80>;
-			interrupts = <11 1>;
-			label = "P11";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt12: gpio@40320600 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320600 0x80>;
-			interrupts = <12 1>;
-			label = "P12";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt13: gpio@40320680 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320680 0x80>;
-			interrupts = <13 1>;
-			label = "P13";
-			gpio-controller;
-			ngpios = <8>;
-			#gpio-cells = <2>;
-			status = "disabled";
-		};
-		gpio_prt14: gpio@40320700 {
-			compatible = "cypress,psoc6-gpio";
-			reg = <0x40320700 0x80>;
-			interrupts = <14 1>;
-			label = "P14";
-			gpio-controller;
-			ngpios = <2>;
-			#gpio-cells = <2>;
-			status = "disabled";
+			hsiom: hsiom@40310000 {
+				compatible = "cypress,psoc6-hsiom";
+				reg = <0x40310000 0x2024>;
+				interrupts = <15 1>, <16 1>;
+				label = "HSIOM";
+				status = "disabled";
+			};
+
+			gpio_prt0: gpio@40320000 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320000 0x80>;
+				interrupts = <0 1>;
+				label = "P0";
+				gpio-controller;
+				ngpios = <6>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt1: gpio@40320080 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320080 0x80>;
+				interrupts = <1 1>;
+				label = "P1";
+				gpio-controller;
+				ngpios = <6>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt2: gpio@40320100 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320100 0x80>;
+				interrupts = <2 1>;
+				label = "P2";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt3: gpio@40320180 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320180 0x80>;
+				interrupts = <3 1>;
+				label = "P3";
+				gpio-controller;
+				ngpios = <6>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt4: gpio@40320200 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320200 0x80>;
+				interrupts = <4 1>;
+				label = "P4";
+				gpio-controller;
+				ngpios = <4>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt5: gpio@40320280 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320280 0x80>;
+				interrupts = <5 1>;
+				label = "P5";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt6: gpio@40320300 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320300 0x80>;
+				interrupts = <6 1>;
+				label = "P6";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt7: gpio@40320380 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320380 0x80>;
+				interrupts = <7 1>;
+				label = "P7";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt8: gpio@40320400 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320400 0x80>;
+				interrupts = <8 1>;
+				label = "P8";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt9: gpio@40320480 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320480 0x80>;
+				interrupts = <9 1>;
+				label = "P9";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt10: gpio@40320500 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320500 0x80>;
+				interrupts = <10 1>;
+				label = "P10";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt11: gpio@40320580 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320580 0x80>;
+				interrupts = <11 1>;
+				label = "P11";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt12: gpio@40320600 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320600 0x80>;
+				interrupts = <12 1>;
+				label = "P12";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt13: gpio@40320680 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320680 0x80>;
+				interrupts = <13 1>;
+				label = "P13";
+				gpio-controller;
+				ngpios = <8>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
+			gpio_prt14: gpio@40320700 {
+				compatible = "cypress,psoc6-gpio";
+				reg = <0x40320700 0x80>;
+				interrupts = <14 1>;
+				label = "P14";
+				gpio-controller;
+				ngpios = <2>;
+				#gpio-cells = <2>;
+				#cypress,pin-cells = <2>;
+				status = "disabled";
+			};
 		};
 
 		uart5: uart@40660000 {

--- a/dts/bindings/gpio/cypress,psoc6-gpio.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-gpio.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ATL Electronics
+# Copyright (c) 2020-2021 ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
 description: Cypress GPIO PORT node
@@ -20,6 +20,16 @@ properties:
     "#gpio-cells":
       const: 2
 
+    "#cypress,pin-cells":
+      type: int
+      required: true
+      const: 2
+      description: Number of items to expect in a cypress,pins specifier
+
 gpio-cells:
   - pin
   - flags
+
+cypress,pin-cells:
+  - pin
+  - hsiom

--- a/dts/bindings/pinctrl/cypress,psoc6-pinctrl.yaml
+++ b/dts/bindings/pinctrl/cypress,psoc6-pinctrl.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2020, Linaro Limited
+# Copyright (c) 2021, ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Cypress PSoC-6 Pinctrl container node
+
+  The Cypress PSoC-6 pins implements following pin configuration option:
+
+    * bias-pull-up
+    * bias-pull-down
+    * drive-open-drain
+    * drive-open-source
+    * drive-push-pull   (strong)
+    * input-enable      (input-buffer)
+
+  These options define devicetree flags that are converted to SoC flags at
+  CY_PSOC6_PIN_FLAGS().
+
+compatible: "cypress,psoc6-pinctrl"
+
+include: [base.yaml, pincfg-node.yaml]
+
+properties:
+    "#address-cells":
+      required: true
+      const: 1
+    "#size-cells":
+      required: true
+      const: 1
+
+child-binding:
+    description: cypress pins
+    properties:
+      "cypress,pins":
+        type: phandle-array

--- a/soc/arm/cypress/CMakeLists.txt
+++ b/soc/arm/cypress/CMakeLists.txt
@@ -1,7 +1,9 @@
 #
 # Copyright (c) 2018, Cypress
+# Copyright (c) 2021, ATL Electronics
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 add_subdirectory(${SOC_SERIES})
+add_subdirectory(common)

--- a/soc/arm/cypress/common/CMakeLists.txt
+++ b/soc/arm/cypress/common/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 ATL Electronics
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)
+
+zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_PSOC6 soc_gpio.c)

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Linaro Ltd.
- * Copyright (c) 2020 ATL Electronics
+ * Copyright (c) 2020-2021 ATL Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -97,5 +97,65 @@
 		CY_PSOC6_NVIC_MUX_MAP(n);		\
 		irq_enable(CY_PSOC6_NVIC_MUX_IRQN(n));	\
 	} while (0)
+
+/*
+ * Devicetree related macros to construct pin control config data
+ */
+
+/* Get a node id from a pinctrl-0 prop at index 'i' */
+#define NODE_ID_FROM_PINCTRL_0(inst, i) \
+	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_0, i)
+
+/* Get GPIO register address associated with pinctrl-0 pin at index 'i' */
+#define CY_PSOC6_PIN_TO_GPIO_REG_ADDR(inst, i) \
+	DT_REG_ADDR(DT_PHANDLE(NODE_ID_FROM_PINCTRL_0(inst, i), cypress_pins))
+
+/* Get PIN associated with pinctrl-0 pin at index 'i' */
+#define CY_PSOC6_PIN(inst, i) \
+	DT_PHA(NODE_ID_FROM_PINCTRL_0(inst, i), cypress_pins, pin)
+
+/* Get HSIOM value associated with pinctrl-0 pin at index 'i' */
+#define CY_PSOC6_PIN_HSIOM(inst, i) \
+	DT_PHA(NODE_ID_FROM_PINCTRL_0(inst, i), cypress_pins, hsiom)
+
+/* Helper function for CY_PSOC6_PIN_FLAGS */
+#define CY_PSOC6_PIN_FLAG(inst, i, flag) \
+	DT_PROP(NODE_ID_FROM_PINCTRL_0(inst, i), flag)
+
+/* Convert DT flags to SoC flags */
+#define CY_PSOC6_PIN_FLAGS(inst, i) \
+	(CY_PSOC6_PIN_FLAG(inst, i, bias_pull_up) << \
+		SOC_GPIO_PULLUP_POS | \
+	 CY_PSOC6_PIN_FLAG(inst, i, bias_pull_down) << \
+		SOC_GPIO_PULLUP_POS | \
+	 CY_PSOC6_PIN_FLAG(inst, i, drive_open_drain) << \
+		SOC_GPIO_OPENDRAIN_POS | \
+	 CY_PSOC6_PIN_FLAG(inst, i, drive_open_source) << \
+		SOC_GPIO_OPENSOURCE_POS | \
+	 CY_PSOC6_PIN_FLAG(inst, i, drive_push_pull) << \
+		SOC_GPIO_PUSHPULL_POS | \
+	 CY_PSOC6_PIN_FLAG(inst, i, input_enable) << \
+		SOC_GPIO_INPUTENABLE_POS)
+
+/* Construct a soc_pio_pin element for pin cfg */
+#define CY_PSOC6_DT_INST_PIN(inst, idx)					\
+	{								\
+		(GPIO_PRT_Type *)CY_PSOC6_PIN_TO_GPIO_REG_ADDR(inst, idx), \
+		CY_PSOC6_PIN(inst, idx),				\
+		CY_PSOC6_PIN_HSIOM(inst, idx) << SOC_GPIO_FUNC_POS |	\
+		CY_PSOC6_PIN_FLAGS(inst, idx)				\
+	}
+
+/* Get the number of pins for pinctrl-0 */
+#define CY_PSOC6_DT_INST_NUM_PINS(inst) DT_INST_PROP_LEN(inst, pinctrl_0)
+
+/* internal macro to structure things for use with UTIL_LISTIFY */
+#define CY_PSOC6_PIN_ELEM(idx, inst) CY_PSOC6_DT_INST_PIN(inst, idx),
+
+/* Construct an array intializer for soc_gpio_pin for a device instance */
+#define CY_PSOC6_DT_INST_PINS(inst)			\
+	{ UTIL_LISTIFY(CY_PSOC6_DT_INST_NUM_PINS(inst),	\
+		       CY_PSOC6_PIN_ELEM, inst)	\
+	}
 
 #endif /* _CYPRESS_PSOC6_SOC_DT_H_ */

--- a/soc/arm/cypress/common/soc_gpio.c
+++ b/soc/arm/cypress/common/soc_gpio.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 Piotr Mienkowski
+ * Copyright (c) 2021 ATL Electronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Cypress PSoC-6 MCU family General Purpose Input Output (GPIO)
+ * module HAL driver.
+ */
+
+#include "soc_gpio.h"
+#include "cy_gpio.h"
+
+static uint32_t soc_gpio_get_drv_mode(uint32_t flags)
+{
+	uint32_t drv_mode = CY_GPIO_DM_ANALOG;
+
+	flags = ((flags & SOC_GPIO_FLAGS_MASK) >> SOC_GPIO_FLAGS_POS);
+
+	if (flags & SOC_GPIO_OPENDRAIN) {
+		drv_mode = CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
+	} else if (flags & SOC_GPIO_OPENSOURCE) {
+		drv_mode = CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+	} else if (flags & SOC_GPIO_PUSHPULL) {
+		drv_mode = CY_GPIO_DM_STRONG_IN_OFF;
+	} else if ((flags & SOC_GPIO_PULLUP) && (flags & SOC_GPIO_PULLDOWN)) {
+		drv_mode = CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
+	} else if (flags & SOC_GPIO_PULLUP) {
+		drv_mode = CY_GPIO_DM_PULLUP_IN_OFF;
+	} else if (flags & SOC_GPIO_PULLDOWN) {
+		drv_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
+	}
+
+	if (flags & SOC_GPIO_INPUTENABLE) {
+		drv_mode |= CY_GPIO_DM_HIGHZ;
+	}
+
+	return drv_mode;
+}
+
+void soc_gpio_configure(const struct soc_gpio_pin *pin)
+{
+	uint32_t drv_mode = soc_gpio_get_drv_mode(pin->flags);
+	uint32_t function = ((pin->flags & SOC_GPIO_FUNC_MASK) >>
+			     SOC_GPIO_FUNC_POS);
+
+	Cy_GPIO_SetHSIOM(pin->regs, pin->pinum, function);
+	Cy_GPIO_SetDrivemode(pin->regs, pin->pinum, drv_mode);
+}
+
+void soc_gpio_list_configure(const struct soc_gpio_pin pins[], size_t size)
+{
+	for (size_t i = 0; i < size; i++) {
+		soc_gpio_configure(&pins[i]);
+	}
+}

--- a/soc/arm/cypress/common/soc_gpio.h
+++ b/soc/arm/cypress/common/soc_gpio.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016-2017 Piotr Mienkowski
+ * Copyright (c) 2021 ATL Electronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Cypress PSoC-6 MCU family General Purpose Input Output (GPIO)
+ * module HAL driver.
+ */
+
+#ifndef _CYPRESS_PSOC6_SOC_GPIO_H_
+#define _CYPRESS_PSOC6_SOC_GPIO_H_
+
+#include <zephyr/types.h>
+#include <soc.h>
+
+/*
+ * Pin flags/attributes
+ */
+
+#define SOC_GPIO_DEFAULT                (0)
+
+#define SOC_GPIO_FLAGS_POS              (0)
+#define SOC_GPIO_FLAGS_MASK             (0x3F << SOC_GPIO_FLAGS_POS)
+#define SOC_GPIO_PULLUP_POS             (0)
+#define SOC_GPIO_PULLUP                 (1 << SOC_GPIO_PULLUP_POS)
+#define SOC_GPIO_PULLDOWN_POS           (1)
+#define SOC_GPIO_PULLDOWN               (1 << SOC_GPIO_PULLDOWN_POS)
+#define SOC_GPIO_OPENDRAIN_POS          (2)
+#define SOC_GPIO_OPENDRAIN              (1 << SOC_GPIO_OPENDRAIN_POS)
+#define SOC_GPIO_OPENSOURCE_POS         (3)
+#define SOC_GPIO_OPENSOURCE             (1 << SOC_GPIO_OPENSOURCE_POS)
+/* Push-Pull means Strong, see dts/pinctrl/pincfg-node.yaml */
+#define SOC_GPIO_PUSHPULL_POS           (4)
+#define SOC_GPIO_PUSHPULL               (1 << SOC_GPIO_PUSHPULL_POS)
+/* Input-Enable means Input-Buffer, see dts/pinctrl/pincfg-node.yaml */
+#define SOC_GPIO_INPUTENABLE_POS        (5)
+#define SOC_GPIO_INPUTENABLE            (1 << SOC_GPIO_INPUTENABLE_POS)
+
+/* Bit field: SOC_GPIO_IN_FILTER */
+#define SOC_GPIO_IN_FILTER_POS          (6)
+#define SOC_GPIO_IN_FILTER_MASK         (3 << SOC_GPIO_IN_FILTER_POS)
+#define SOC_GPIO_IN_FILTER_NONE         (0 << SOC_GPIO_IN_FILTER_POS)
+#define SOC_GPIO_IN_FILTER_DEBOUNCE     (1 << SOC_GPIO_IN_FILTER_POS)
+#define SOC_GPIO_IN_FILTER_DEGLITCH     (2 << SOC_GPIO_IN_FILTER_POS)
+
+#define SOC_GPIO_INT_ENABLE             (1 << 8)
+
+/* Bit field: SOC_GPIO_INT_TRIG */
+#define SOC_GPIO_INT_TRIG_POS           (9)
+#define SOC_GPIO_INT_TRIG_MASK          (3 << SOC_GPIO_INT_TRIG_POS)
+/** Interrupt is triggered by a level detection event. */
+#define SOC_GPIO_INT_TRIG_LEVEL         (0 << SOC_GPIO_INT_TRIG_POS)
+/** Interrupt is triggered by an edge detection event. */
+#define SOC_GPIO_INT_TRIG_EDGE          (1 << SOC_GPIO_INT_TRIG_POS)
+/** Interrupt is triggered by any edge detection event. */
+#define SOC_GPIO_INT_TRIG_DOUBLE_EDGE   (2 << SOC_GPIO_INT_TRIG_POS)
+
+/** Interrupt is triggered by a high level / rising edge detection event */
+#define SOC_GPIO_INT_ACTIVE_HIGH        (1 << 11)
+
+/* Bit field: SOC_GPIO_FUNC */
+#define SOC_GPIO_FUNC_POS               (16)
+#define SOC_GPIO_FUNC_MASK              (0x1F << SOC_GPIO_FUNC_POS)
+
+struct soc_gpio_pin {
+	GPIO_PRT_Type *regs; /** pointer to registers of the GPIO controller */
+	uint32_t pinum;      /** pin number */
+	uint32_t flags;      /** pin flags/attributes */
+};
+
+/**
+ * @brief Configure GPIO pin(s).
+ *
+ * Configure one or several pins belonging to the same GPIO port.
+ * Example scenarios:
+ * - configure pin(s) as input with debounce filter enabled.
+ * - connect pin(s) to a HSIOM function and enable pull-up.
+ * - configure pin(s) as open drain output.
+ * All pins are configured in the same way.
+ *
+ * @param pin  pin's configuration data such as pin mask, pin attributes, etc.
+ */
+void soc_gpio_configure(const struct soc_gpio_pin *pin);
+
+/**
+ * @brief Configure a list of GPIO pin(s).
+ *
+ * Configure an arbitrary amount of pins in an arbitrary way. Each
+ * configuration entry is a single item in an array passed as an
+ * argument to the function.
+ *
+ * @param pins an array where each item contains pin's configuration data.
+ * @param size size of the pin list.
+ */
+void soc_gpio_list_configure(const struct soc_gpio_pin pins[], size_t size);
+
+#endif /* _CYPRESS_PSOC6_SOC_GPIO_H_ */

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Cypress
- * Copyright (c) 2020, ATL Electronics
+ * Copyright (c) 2020-2021, ATL Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +24,7 @@
 
 #include <cy_device_headers.h>
 
+#include "../common/soc_gpio.h"
 #include "../common/cypress_psoc6_dt.h"
 
 #endif /* !_ASMLANGUAGE */


### PR DESCRIPTION
Introduce PSoC-6 pinctrl infraestructure and definitions.  This add files to handle devicetree entries and following modifications:

 - add pinctrl bindings
 - update gpio bindings with pin-cells
 - add pinctrl node and move gpio nodes inside
 - declare pinctrl for current uart entries

On the SoC part, add devicetree macros to handle pinctrl nodes and SoC GPIO methods to configure pins.

~Note: Fixup was created to wait #32595 land and should be removed before merge.~

Signed-off-by: Gerson Fernando Budke <gerson.budke@atl-electronics.com>