### PR TITLE
MAINTAINERS: Add AArch64 maintainer and collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -142,6 +142,20 @@ ARM arch:
     labels:
         - "area: ARM"
 
+ARM64 arch:
+    status: maintained
+    maintainers:
+        - carlocaione
+    collaborators:
+        - npitre
+        - ioannisg
+    files:
+        - arch/arm/core/aarch64/
+        - include/arch/arm/aarch64/
+        - tests/arch/arm64/
+    labels:
+        - "area: ARM64"
+
 Bluetooth:
     status: maintained
     maintainers:


### PR DESCRIPTION
As discussed on slack I'm proposing to add a new entry specifically for AArch64 in the maintainers file. I'm also adding @npitre and @ioannisg as collaborators. This will also be probably discussed during the next TSC.

I want also to ask if @sandeepbrcm @jharris-intel wants to be added as collaborators given that they also seems quite active in this area.