### PR TITLE
bsim_bt: tests: Fix relative paths search in scripts

### DIFF
--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gap.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gap.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # GAP regression tests based on the EDTTool
-CWD=`pwd`"/"`dirname $0`
+CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 export SIMULATION_ID="edtt_gap"
 export TEST_FILE=${CWD}"/gap.test_list"

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.sh
@@ -6,7 +6,7 @@
 SIMULATION_ID="edtt_gatt"
 VERBOSITY_LEVEL=2
 PROCESS_IDS=""; EXIT_CODE=0
-CWD=`pwd`"/"`dirname $0`
+CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 function Execute(){
   if [ ! -f $1 ]; then

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/hci.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HCI regression tests based on the EDTTool
-CWD=`pwd`"/"`dirname $0`
+CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 export SIMULATION_ID="edtt_hci"
 export TEST_FILE=${CWD}"/hci.test_list"

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.1.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.1.sh
@@ -4,7 +4,7 @@
 
 # LL regression tests based on the EDTTool (part 1)
 
-CWD=`pwd`"/"`dirname $0`
+CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 export SIMULATION_ID="edtt_ll_set1"
 export TEST_FILE=${CWD}"/ll.set1.test_list"

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.2.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.2.sh
@@ -4,7 +4,7 @@
 
 # LL regression tests based on the EDTTool (part 2)
 
-CWD=`pwd`"/"`dirname $0`
+CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 export SIMULATION_ID="edtt_ll_set2"
 export TEST_FILE=${CWD}"/ll.set2.test_list"


### PR DESCRIPTION
The way these scripts looked for the current working directory
was not correct or reliable. With this change it should
work properly.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>