### PR TITLE
boards: arduino due: add reset after load for Jlink flashing

### DIFF
--- a/boards/arm/arduino_due/board.cmake
+++ b/boards/arm/arduino_due/board.cmake
@@ -2,5 +2,5 @@
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)
 
-board_runner_args(jlink "--device=atsam3x8e" "--speed=4000")
+board_runner_args(jlink "--device=atsam3x8e" "--speed=4000" "--reset-after-load")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Force the Arduino Due device to preform a reset after loading
the program using JLink, effectively allowing the program to
run after west flash.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>