### PR TITLE
net: lwm2m: Allow cancel-observe to match path

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -87,6 +87,15 @@ config LWM2M_ENGINE_MAX_OBSERVER
 	  This value sets the maximum number of resources which can be
 	  added to the observe notification list.
 
+config LWM2M_CANCEL_OBSERVE_BY_PATH
+	bool "Use path matching as fallback for cancel-observe"
+	help
+	  Some ambiguous language in the LwM2M spec causes some LwM2M server
+	  implementations to implement cancel-observe by specifying the resource
+	  path rather than the token of the original observe request. Without
+	  this option, cancel-observe may not work properly when connecting to
+	  those servers.
+
 config LWM2M_ENGINE_DEFAULT_LIFETIME
 	int "LWM2M engine default server connection lifetime"
 	default 30


### PR DESCRIPTION
The specification states that the server can cancel observations "at any
moment, by sendinga GET request with Observe option=1, the LwM2M Server
cancancel an “Observe”operation on a specified Resource, or specified
Object Instance(s)."

It does not mention any token matching requirement. The EMQx LwM2M
implementation uses a new token for instance, which does not
work with Zephyrs token matching cancel-observe.

This commit introduces cancel-observe via path matching. This could
hypothetically introduce problems when we are connected to multiple
peers simultaneously, but since that is not likely to be supported for a
long time (if ever), this change should be fairly uncontroversial since
path matching is only used as a fallback.