### PR TITLE
tests: coverage: fix test cases failed with code coverage in mps2_an385

### DIFF
--- a/boards/arm/mps2_an385/Kconfig.defconfig
+++ b/boards/arm/mps2_an385/Kconfig.defconfig
@@ -44,4 +44,23 @@ config I2C_SBCON
 config ZTEST_STACKSIZE
 	default 4096 if ZTEST
 
+if COVERAGE
+
+config MAIN_STACK_SIZE
+	default 4096
+
+config IDLE_STACK_SIZE
+	default 4096
+
+config PRIVILEGED_STACK_SIZE
+	default 4096
+
+config ISR_STACK_SIZE
+	default 4096
+
+config TEST_EXTRA_STACKSIZE
+	default 4096
+
+endif # COVERAGE
+
 endif


### PR DESCRIPTION
This only fix several test cases failed while running code coverage
report inmps2_an385 platform. Enlarge the stack size for which failed
due to MPU fault of stack overflow.


While running test case by:  twister -T tests/kernel/ -p mps2_an385 --coverage
........
INFO    - Total complete:   99/  99  100%  skipped:   34, failed:   46
INFO    - 35 of 82 test configurations passed (43.21%), 46 failed, 34 skipped with 0 warnings in 838.47 seconds
INFO    - In total 818 test cases were executed, 279 skipped on 1 out of total 328 platforms (0.30%)
INFO    - 35 test configurations executed on platforms, 46 test configurations were only built.
INFO    - Generating coverage files...

Most of them failed due to stack overflow.

After enlarge the stack size:
INFO    - Total complete:   99/  99  100%  skipped:   34, failed:    9
INFO    - 73 of 82 test configurations passed (89.02%), 9 failed, 34 skipped with 0 warnings in 599.17 seconds
INFO    - In total 838 test cases were executed, 299 skipped on 1 out of total 329 platforms (0.30%)
INFO    - 72 test configurations executed on platforms, 7 test configurations were only built.
INFO    - Generating coverage files...

And there are several test cases still failed by other reason, need to keep taking a look at them.  