### PR TITLE
fs: shell: Remove unneeded flags from fs_open calls

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -191,7 +191,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	fs_file_t_init(&file);
-	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
+	err = fs_open(&file, path, FS_O_WRITE);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;;
@@ -381,7 +381,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	fs_file_t_init(&file);
-	err = fs_open(&file, path, FS_O_CREATE | FS_O_RDWR);
+	err = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
 	if (err) {
 		shell_error(shell, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;


### PR DESCRIPTION
The cmd_write and cmd_ctunc have been opening/creating file for
read/write operation.
The commit changes cmd_write to open/create file for write only,
and cmd_trunc to only open file for write.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>