### PR TITLE
scripts: add retwist to help with bisecting twister failures

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -514,6 +514,7 @@
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif
+/scripts/retwist                         @pabigot
 /scripts/ci/                              @nashif
 /arch/x86/gen_gdt.py                      @dcpleung @nashif
 /arch/x86/gen_idt.py                      @dcpleung @nashif

--- a/scripts/retwist
+++ b/scripts/retwist
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script can be used as a bisect test script, or manually, to run
+# twister a repeated number of times to identify whether an
+# intermittent failure is visible at a particular Zephyr commit.
+#
+# Invoke with the same arguments passed to twister.
+#
+# The number of times to retry a test can be controlled by setting the
+# RETWIST_REPS environment variable.  The default is 5 repetitions.
+#
+# To use when testing commits before the script was introduced copy it
+# to a location out of tree.
+#
+# Example of automating a bisect:
+#
+# % cp -p scripts/retwist /tmp
+# % git bisect start bad good
+# % git bisect run /tmp/retwist -p platform -s testid
+#
+
+head=$(git describe HEAD)
+
+log () {
+  now=$(date +%Y-%m-%dT%H:%M:%S)
+  echo "${now}: ${head}: ${@}" \
+   | tee -a retwist.log
+}
+
+TWISTER_ARGS="${@}"
+MAX_REPS=${RETWIST_REPS:-5}
+rm -rf twister-out*
+west update
+log "twister ${TWISTER_ARGS}"
+twister ${TWISTER_ARGS}
+result=$?
+rep=1
+while [ ${result} -eq 0 -a ${rep} -lt ${MAX_REPS} ]; do
+  log "rep ${rep} succeeded, retrying"
+  rep=$((${rep} + 1))
+  twister --test-only ${TWISTER_ARGS}
+  result=$?
+done
+if [ ${result} -eq 0 ] ; then
+  log "PASS: Not reproduced in ${MAX_REPS} attempts"
+else
+  log "FAIL: Reproduced at attempt ${rep}, result ${result}"
+  mv twister-out retwist-out-${head}
+fi
+
+exit ${result}


### PR DESCRIPTION
A test that fails with twister can be isolated to a particular commit using twister.  In some cases the test can be intermittent, requiring it be run multiple times to gain confidence that the problem is not present at a particular commit.

retwist provides a script that takes the same arguments as twister but does all the steps necessary to check for failures after switching to a specific commit in bisect:

* make sure west is up to date
* build the test and run it the first time
* if it passes, repeat until the desired confidence has been reached
* if it fails, capture the twister artifacts in a directory named according to the failed commit
* log all tested branches in retwist.log

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>