### PR TITLE
boards: nrf: fix deprecated I2C properties

### DIFF
--- a/boards/arm/bmd_345_eval/bmd_345_eval.dts
+++ b/boards/arm/bmd_345_eval/bmd_345_eval.dts
@@ -154,16 +154,16 @@
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-pin = <26>;
-	scl-pin = <27>;
+	sda-gpios = <&gpio0 26 0>;
+	scl-gpios = <&gpio0 27 0>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-pin = <30>;
-	scl-pin = <31>;
+	sda-gpios = <&gpio0 30 0>;
+	scl-gpios = <&gpio0 31 0>;
 };
 
 &spi0 {

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -119,8 +119,8 @@
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-pin = <30>;
-	scl-pin = <31>;
+	sda-gpios = <&gpio0 30 0>;
+	scl-gpios = <&gpio0 31 0>;
 };
 
 &pwm0 {


### PR DESCRIPTION
Commit 821c03a14a66942fb69c9cc056e2751bd0a8f258 ("i2c: nordic: switch
to phandle arrays for pinmux") deprecated some Nordic devicetree
properties.

When boards get merged with stale CI results (i.e. if CI results are
from a mainline commit earlier than 821c03a1), we will get deprecation
warnings, which twister treats as errors.

Play whack-a-mole with the ones that are in tree.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>