### PR TITLE
drivers: spi-nor: support 4-byte addresses for flags with >128 MiBi address space

### DIFF
--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -182,6 +182,16 @@ struct jesd216_bfp {
  * * DW17-20 (quad/oct support) no API except jesd216_bfp_read_support().
  */
 
+/* Extract the supported address bytes from BFP DW1. */
+static inline uint8_t jesd216_bfp_addrbytes(const struct jesd216_bfp *hp)
+{
+	uint32_t dw1 = sys_le32_to_cpu(hp->dw1);
+	uint8_t addr_support = (dw1 & JESD216_SFDP_BFP_DW1_ADDRBYTES_MASK)
+		>> JESD216_SFDP_BFP_DW1_ADDRBYTES_SHFT;
+
+	return addr_support;
+}
+
 /* Extract the density of the chip in bits from BFP DW2. */
 static inline uint64_t jesd216_bfp_density(const struct jesd216_bfp *hp)
 {

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -28,6 +28,7 @@
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
 #define SPI_NOR_CMD_ULBPR       0x98    /* Global Block Protection Unlock */
+#define SPI_NOR_CMD_4BA         0xB7    /* Enter 4-Byte Address Mode */
 #define SPI_NOR_CMD_DPD         0xB9    /* Deep Power Down */
 #define SPI_NOR_CMD_RDPD        0xAB    /* Release from Deep Power Down */
 

--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -62,3 +62,20 @@ properties:
       instruction.  Use S1B6 if QE is bit 6 of the first status register
       byte, and can be configured by reading then writing one byte with
       RDSR and WRSR.  For other fields see the specification.
+
+  enter-4byte-addr:
+    type: int
+    required: false
+    description: |
+      Enter 4-Byte Addressing value from JESD216 BFP DW16
+
+      This property is ignored if the device is configured to use SFDP data
+      from the sfdp-bfp property (CONFIG_SPI_NOR_SFDP_DEVICETREE) or to read
+      SFDP properties at runtime (CONFIG_SPI_NOR_SFDP_RUNTIME).
+
+      For CONFIG_SPI_NOR_SFDP_MINIMAL this is the 8-bit value from bits 31:24
+      of DW16 identifying ways a device can be placed into 4-byte addressing
+      mode.  If provided as a non-zero value the driver assumes that 4-byte
+      addressing is require to access the full address range, and
+      automatically puts the device into 4-byte address mode when the device
+      is initialized.

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -206,9 +206,7 @@ static void summarize_dw16(const struct jesd216_param_header *php,
 		return;
 	}
 
-	uint32_t dw1 = sys_le32_to_cpu(bfp->dw1);
-	uint8_t addr_support = (dw1 & JESD216_SFDP_BFP_DW1_ADDRBYTES_MASK)
-		>> JESD216_SFDP_BFP_DW1_ADDRBYTES_SHFT;
+	uint8_t addr_support = jesd216_bfp_addrbytes(bfp);
 
 	/* Don't display bits when 4-byte addressing is not supported. */
 	if (addr_support != JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B) {


### PR DESCRIPTION
Add support for entering and using 4-byte addressing mode based on information derived from SFDP headers or devicetree.

Only the top four commits of this PR are relevant to this PR; the remainder are from #32680.

Fixes #22965