### PR TITLE
kernel: sem: add K_SEM_MAX_LIMIT

### DIFF
--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -134,7 +134,7 @@ int ipm_console_receiver_init(const struct device *d)
 
 	driver_data->ipm_device = ipm;
 	driver_data->channel_disabled = 0;
-	k_sem_init(&driver_data->sem, 0, UINT_MAX);
+	k_sem_init(&driver_data->sem, 0, K_SEM_MAX_LIMIT);
 	ring_buf_init(&driver_data->rb, config_info->rb_size32,
 		      config_info->ring_buf_data);
 

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -182,7 +182,7 @@ int ataes132a_init(const struct device *dev)
 
 	i2c_configure(ataes132a->i2c, i2c_cfg);
 
-	k_sem_init(&ataes132a->device_sem, 1, UINT_MAX);
+	k_sem_init(&ataes132a->device_sem, 1, K_SEM_MAX_LIMIT);
 
 	ataes132a_init_states();
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -612,7 +612,7 @@ static void eth_iface_init(struct net_if *iface)
 
 	/* Initialise TX/RX semaphores */
 	k_sem_init(&dev_data->tx_sem, 1, ETH_TX_BUF_COUNT);
-	k_sem_init(&dev_data->rx_sem, 0, UINT_MAX);
+	k_sem_init(&dev_data->rx_sem, 0, K_SEM_MAX_LIMIT);
 
 	/* Start interruption-poll thread */
 	k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -703,9 +703,9 @@ static int eth_initialize(const struct device *dev)
 
 	/* Initialize semaphores */
 	k_mutex_init(&dev_data->tx_mutex);
-	k_sem_init(&dev_data->rx_int_sem, 0, UINT_MAX);
+	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
 #ifdef CONFIG_SOC_SERIES_STM32H7X
-	k_sem_init(&dev_data->tx_int_sem, 0, UINT_MAX);
+	k_sem_init(&dev_data->tx_int_sem, 0, K_SEM_MAX_LIMIT);
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 	/* Start interruption-poll thread */

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -923,7 +923,7 @@ static int spi_nor_init(const struct device *dev)
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct spi_nor_data *const driver_data = dev->data;
 
-		k_sem_init(&driver_data->sem, 1, UINT_MAX);
+		k_sem_init(&driver_data->sem, 1, K_SEM_MAX_LIMIT);
 	}
 
 	return spi_nor_configure(dev);

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -332,8 +332,8 @@ static int i2c_cc32xx_init(const struct device *dev)
 	int error;
 	uint32_t regval;
 
-	k_sem_init(&data->mutex, 1, UINT_MAX);
-	k_sem_init(&data->transfer_complete, 0, UINT_MAX);
+	k_sem_init(&data->mutex, 1, K_SEM_MAX_LIMIT);
+	k_sem_init(&data->transfer_complete, 0, K_SEM_MAX_LIMIT);
 
 	/* In case of app restart: disable I2C module, clear NVIC interrupt */
 	/* Note: this was done *during* pinmux setup in SimpleLink SDK. */

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -628,7 +628,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	}
 
-	k_sem_init(&dw->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	regs = get_regs(dev);
 	/* verify that we have a valid DesignWare register first */

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -341,7 +341,7 @@ static int i2c_imx_init(const struct device *dev)
 	uint32_t bitrate_cfg;
 	int error;
 
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -778,7 +778,7 @@ static int i2c_it8xxx2_init(const struct device *dev)
 	uint32_t bitrate_cfg, offset = 0;
 	int error;
 
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	switch ((uint32_t)base) {
 	case DT_REG_ADDR(DT_NODELABEL(i2c0)):

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -186,7 +186,7 @@ static int i2c_stm32_init(const struct device *dev)
 	int ret;
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 #ifdef CONFIG_I2C_STM32_INTERRUPT
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	cfg->irq_config_func(dev);
 #endif
 

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -193,7 +193,7 @@ static int i2c_mcux_init(const struct device *dev)
 	int error;
 
 	k_sem_init(&data->lock, 1, 1);
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	clock_freq = CLOCK_GetFreq(config->clock_source);
 	I2C_MasterGetDefaultConfig(&master_config);

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -183,7 +183,7 @@ static int mcux_flexcomm_init(const struct device *dev)
 	i2c_master_config_t master_config;
 	int error;
 
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	/* Get the clock frequency */
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -191,7 +191,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 	lpi2c_master_config_t master_config;
 	int error;
 
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -878,7 +878,7 @@ static int i2c_ctrl_init(const struct device *dev)
 
 	/* initialize mutux and semaphore for i2c/smb controller */
 	k_sem_init(&data->lock_sem, 1, 1);
-	k_sem_init(&data->sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	/* Initialize driver status machine */
 	data->oper_state = NPCX_I2C_IDLE;

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -830,7 +830,7 @@ static int cc2520_tx(const struct device *dev,
 	/* 1 retry is allowed here */
 	do {
 		atomic_set(&cc2520->tx, 1);
-		k_sem_init(&cc2520->tx_sync, 0, UINT_MAX);
+		k_sem_init(&cc2520->tx_sync, 0, K_SEM_MAX_LIMIT);
 
 		if (!instruct_stxoncca(cc2520)) {
 			LOG_ERR("Cannot start transmission");
@@ -1087,7 +1087,7 @@ static int cc2520_init(const struct device *dev)
 	struct cc2520_context *cc2520 = dev->data;
 
 	atomic_set(&cc2520->tx, 0);
-	k_sem_init(&cc2520->rx_lock, 0, UINT_MAX);
+	k_sem_init(&cc2520->rx_lock, 0, K_SEM_MAX_LIMIT);
 
 #ifdef CONFIG_IEEE802154_CC2520_CRYPTO
 	k_sem_init(&cc2520->access_lock, 1, 1);

--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -142,7 +142,7 @@ int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 
 int sx12xx_init(const struct device *dev)
 {
-	k_sem_init(&dev_data.data_sem, 0, UINT_MAX);
+	k_sem_init(&dev_data.data_sem, 0, K_SEM_MAX_LIMIT);
 
 	dev_data.events.TxDone = sx12xx_ev_tx_done;
 	dev_data.events.RxDone = sx12xx_ev_rx_done;

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -156,7 +156,7 @@ int adt7420_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_ADT7420_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_ADT7420_THREAD_STACK_SIZE,

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -150,7 +150,7 @@ int adxl362_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_ADXL362_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_ADXL362_THREAD_STACK_SIZE,

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -158,7 +158,7 @@ int adxl372_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_ADXL372_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_ADXL372_THREAD_STACK_SIZE,

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -191,7 +191,7 @@ int amg88xx_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_AMG88XX_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_AMG88XX_THREAD_STACK_SIZE,

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -396,7 +396,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 	}
 
 #else
-	k_sem_init(&drv_data->data_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->data_sem, 0, K_SEM_MAX_LIMIT);
 #endif
 	apds9960_setup_int(drv_data, true);
 

--- a/drivers/sensor/bma280/bma280_trigger.c
+++ b/drivers/sensor/bma280/bma280_trigger.c
@@ -275,7 +275,7 @@ int bma280_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_BMA280_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_BMA280_THREAD_STACK_SIZE,

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -144,7 +144,7 @@ int bmc150_magn_init_interrupt(const struct device *dev)
 
 	data->handler_drdy = NULL;
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_BMC150_MAGN_TRIGGER_THREAD_STACK,

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -290,7 +290,7 @@ int bmg160_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	k_sem_init(&bmg160->sem, 1, UINT_MAX);
+	k_sem_init(&bmg160->sem, 1, K_SEM_MAX_LIMIT);
 
 	if (bmg160_read_byte(dev, BMG160_REG_CHIPID, &chip_id) < 0) {
 		LOG_DBG("Failed to read chip id.");

--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -245,7 +245,7 @@ int bmg160_trigger_init(const struct device *dev)
 	bmg160->dev = dev;
 
 #if defined(CONFIG_BMG160_TRIGGER_OWN_THREAD)
-	k_sem_init(&bmg160->trig_sem, 0, UINT_MAX);
+	k_sem_init(&bmg160->trig_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&bmg160_thread, bmg160_thread_stack,
 			CONFIG_BMG160_THREAD_STACK_SIZE,
 			(k_thread_entry_t)bmg160_thread_main,

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -277,7 +277,7 @@ int bmi160_trigger_mode_init(const struct device *dev)
 	data->dev = dev;
 
 #if defined(CONFIG_BMI160_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&bmi160_thread, bmi160_thread_stack,
 			CONFIG_BMI160_THREAD_STACK_SIZE,

--- a/drivers/sensor/ccs811/ccs811_trigger.c
+++ b/drivers/sensor/ccs811/ccs811_trigger.c
@@ -180,7 +180,7 @@ int ccs811_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_CCS811_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_CCS811_THREAD_STACK_SIZE,

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -254,7 +254,7 @@ static int fxas21002_init(const struct device *dev)
 		return -EIO;
 	}
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 #if CONFIG_FXAS21002_TRIGGER
 	if (fxas21002_trigger_init(dev)) {

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -171,7 +171,7 @@ int fxas21002_trigger_init(const struct device *dev)
 	data->dev = dev;
 
 #if defined(CONFIG_FXAS21002_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->trig_sem, 0, UINT_MAX);
+	k_sem_init(&data->trig_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_FXAS21002_THREAD_STACK_SIZE,
 			(k_thread_entry_t)fxas21002_thread_main, data, 0, NULL,

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -497,7 +497,7 @@ static int fxos8700_init(const struct device *dev)
 		return -EIO;
 	}
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 #if CONFIG_FXOS8700_TRIGGER
 	if (fxos8700_trigger_init(dev)) {

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -412,7 +412,7 @@ int fxos8700_trigger_init(const struct device *dev)
 	data->dev = dev;
 
 #if defined(CONFIG_FXOS8700_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->trig_sem, 0, UINT_MAX);
+	k_sem_init(&data->trig_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_FXOS8700_THREAD_STACK_SIZE,
 			(k_thread_entry_t)fxos8700_thread_main,

--- a/drivers/sensor/hmc5883l/hmc5883l_trigger.c
+++ b/drivers/sensor/hmc5883l/hmc5883l_trigger.c
@@ -126,7 +126,7 @@ int hmc5883l_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_HMC5883L_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_HMC5883L_THREAD_STACK_SIZE,

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -151,7 +151,7 @@ int hts221_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_HTS221_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->drdy_sem, 0, UINT_MAX);
+	k_sem_init(&data->drdy_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_HTS221_THREAD_STACK_SIZE,

--- a/drivers/sensor/icm42605/icm42605_trigger.c
+++ b/drivers/sensor/icm42605/icm42605_trigger.c
@@ -135,7 +135,7 @@ int icm42605_init_interrupt(const struct device *dev)
 		return result;
 	}
 
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_ICM42605_THREAD_STACK_SIZE,

--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -147,7 +147,7 @@ int iis2dh_init_interrupt(const struct device *dev)
 	iis2dh->dev = dev;
 
 #if defined(CONFIG_IIS2DH_TRIGGER_OWN_THREAD)
-	k_sem_init(&iis2dh->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&iis2dh->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&iis2dh->thread, iis2dh->thread_stack,
 		       CONFIG_IIS2DH_THREAD_STACK_SIZE,

--- a/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc_trigger.c
@@ -243,7 +243,7 @@ int iis2dlpc_init_interrupt(const struct device *dev)
 	iis2dlpc->dev = dev;
 
 #if defined(CONFIG_IIS2DLPC_TRIGGER_OWN_THREAD)
-	k_sem_init(&iis2dlpc->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&iis2dlpc->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&iis2dlpc->thread, iis2dlpc->thread_stack,
 		       CONFIG_IIS2DLPC_THREAD_STACK_SIZE,

--- a/drivers/sensor/iis2iclx/iis2iclx_trigger.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_trigger.c
@@ -216,7 +216,7 @@ int iis2iclx_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_IIS2ICLX_TRIGGER_OWN_THREAD)
-	k_sem_init(&iis2iclx->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&iis2iclx->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&iis2iclx->thread, iis2iclx->thread_stack,
 			CONFIG_IIS2ICLX_THREAD_STACK_SIZE,

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -118,7 +118,7 @@ int iis2mdc_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_IIS2MDC_TRIGGER_OWN_THREAD)
-	k_sem_init(&iis2mdc->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&iis2mdc->gpio_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&iis2mdc->thread, iis2mdc->thread_stack,
 			CONFIG_IIS2MDC_THREAD_STACK_SIZE,
 			(k_thread_entry_t)iis2mdc_thread, iis2mdc,

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -132,7 +132,7 @@ int iis3dhhc_init_interrupt(const struct device *dev)
 	iis3dhhc->dev = dev;
 
 #if defined(CONFIG_IIS3DHHC_TRIGGER_OWN_THREAD)
-	k_sem_init(&iis3dhhc->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&iis3dhhc->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&iis3dhhc->thread, iis3dhhc->thread_stack,
 		       CONFIG_IIS3DHHC_THREAD_STACK_SIZE,

--- a/drivers/sensor/isl29035/isl29035_trigger.c
+++ b/drivers/sensor/isl29035/isl29035_trigger.c
@@ -192,7 +192,7 @@ int isl29035_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_ISL29035_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_ISL29035_THREAD_STACK_SIZE,

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -256,7 +256,7 @@ int ism330dhcx_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD)
-	k_sem_init(&ism330dhcx->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&ism330dhcx->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&ism330dhcx->thread, ism330dhcx->thread_stack,
 			CONFIG_ISM330DHCX_THREAD_STACK_SIZE,

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -395,7 +395,7 @@ int lis2dh_init_interrupt(const struct device *dev)
 	lis2dh->dev = dev;
 
 #if defined(CONFIG_LIS2DH_TRIGGER_OWN_THREAD)
-	k_sem_init(&lis2dh->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&lis2dh->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&lis2dh->thread, lis2dh->thread_stack,
 			CONFIG_LIS2DH_THREAD_STACK_SIZE,

--- a/drivers/sensor/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_trigger.c
@@ -137,7 +137,7 @@ int lis2ds12_trigger_init(const struct device *dev)
 	data->dev = dev;
 
 #if defined(CONFIG_LIS2DS12_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->trig_sem, 0, UINT_MAX);
+	k_sem_init(&data->trig_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_LIS2DS12_THREAD_STACK_SIZE,

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -245,7 +245,7 @@ int lis2dw12_init_interrupt(const struct device *dev)
 	lis2dw12->dev = dev;
 
 #if defined(CONFIG_LIS2DW12_TRIGGER_OWN_THREAD)
-	k_sem_init(&lis2dw12->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&lis2dw12->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&lis2dw12->thread, lis2dw12->thread_stack,
 		       CONFIG_LIS2DW12_THREAD_STACK_SIZE,

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -118,7 +118,7 @@ int lis2mdl_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_LIS2MDL_TRIGGER_OWN_THREAD)
-	k_sem_init(&lis2mdl->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&lis2mdl->gpio_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&lis2mdl->thread, lis2mdl->thread_stack,
 			CONFIG_LIS2MDL_THREAD_STACK_SIZE,
 			(k_thread_entry_t)lis2mdl_thread, lis2mdl,

--- a/drivers/sensor/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_trigger.c
@@ -141,7 +141,7 @@ int lis3mdl_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_LIS3MDL_THREAD_STACK_SIZE,

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -136,7 +136,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_LPS22HH_TRIGGER_OWN_THREAD)
-	k_sem_init(&lps22hh->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&lps22hh->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&lps22hh->thread, lps22hh->thread_stack,
 		       CONFIG_LPS22HH_THREAD_STACK_SIZE,

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -154,7 +154,7 @@ int lsm6dsl_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 #if defined(CONFIG_LSM6DSL_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_LSM6DSL_THREAD_STACK_SIZE,

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -257,7 +257,7 @@ int lsm6dso_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
-	k_sem_init(&lsm6dso->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&lsm6dso->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&lsm6dso->thread, lsm6dso->thread_stack,
 			CONFIG_LSM6DSO_THREAD_STACK_SIZE,

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -101,7 +101,7 @@ int lsm9ds0_gyro_init_interrupt(const struct device *dev)
 	struct lsm9ds0_gyro_data *data = dev->data;
 
 	data->dev = dev;
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_LSM9DS0_GYRO_THREAD_STACK_SIZE,

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -158,7 +158,7 @@ int mcp9808_setup_interrupt(const struct device *dev)
 	data->dev = dev;
 
 #ifdef CONFIG_MCP9808_TRIGGER_OWN_THREAD
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&mcp9808_thread, mcp9808_thread_stack,
 			CONFIG_MCP9808_THREAD_STACK_SIZE,

--- a/drivers/sensor/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/mpu6050/mpu6050_trigger.c
@@ -130,7 +130,7 @@ int mpu6050_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_MPU6050_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_MPU6050_THREAD_STACK_SIZE,

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -119,7 +119,7 @@ static int temp_nrf5_init(const struct device *dev)
 		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	__ASSERT_NO_MSG(data->clk_mgr);
 
-	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
+	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	k_mutex_init(&data->mutex);
 
 	IRQ_CONNECT(

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -240,7 +240,7 @@ int sht3xd_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_SHT3XD_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_SHT3XD_THREAD_STACK_SIZE,

--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -212,7 +212,7 @@ static int sm351lt_init(const struct device *dev)
 #if defined(CONFIG_SM351LT_TRIGGER_OWN_THREAD)
 	data->dev = dev;
 
-	k_sem_init(&data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_SM351LT_THREAD_STACK_SIZE,

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -127,7 +127,7 @@ int stts751_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_STTS751_TRIGGER_OWN_THREAD)
-	k_sem_init(&stts751->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&stts751->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&stts751->thread, stts751->thread_stack,
 			CONFIG_STTS751_THREAD_STACK_SIZE,

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -133,7 +133,7 @@ int sx9500_setup_interrupt(const struct device *dev)
 	const struct device *gpio;
 
 #ifdef CONFIG_SX9500_TRIGGER_OWN_THREAD
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 #else
 	data->work.handler = sx9500_work_cb;
 #endif

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -145,7 +145,7 @@ static int ti_hdc_init(const struct device *dev)
 	}
 
 #if DT_INST_NODE_HAS_PROP(0, drdy_gpios)
-	k_sem_init(&drv_data->data_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->data_sem, 0, K_SEM_MAX_LIMIT);
 
 	/* setup data ready gpio interrupt */
 	drv_data->gpio = device_get_binding(

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -175,7 +175,7 @@ int tmp007_init_interrupt(const struct device *dev)
 	}
 
 #if defined(CONFIG_TMP007_TRIGGER_OWN_THREAD)
-	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&drv_data->thread, drv_data->thread_stack,
 			CONFIG_TMP007_THREAD_STACK_SIZE,

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -322,7 +322,7 @@ static int vcnl4040_init(const struct device *dev)
 	}
 #endif
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
+	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 #if CONFIG_VCNL4040_TRIGGER
 	if (vcnl4040_trigger_init(dev)) {

--- a/drivers/sensor/vcnl4040/vcnl4040_trigger.c
+++ b/drivers/sensor/vcnl4040/vcnl4040_trigger.c
@@ -251,7 +251,7 @@ int vcnl4040_trigger_init(const struct device *dev)
 	data->dev = dev;
 
 #if defined(CONFIG_VCNL4040_TRIGGER_OWN_THREAD)
-	k_sem_init(&data->trig_sem, 0, UINT_MAX);
+	k_sem_init(&data->trig_sem, 0, K_SEM_MAX_LIMIT);
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_VCNL4040_THREAD_STACK_SIZE,
 			(k_thread_entry_t)vcnl4040_thread_main,

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -16,6 +16,7 @@
 #if !defined(_ASMLANGUAGE)
 #include <kernel_includes.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <toolchain.h>
 
@@ -2699,8 +2700,8 @@ __syscall int k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 
 struct k_sem {
 	_wait_q_t wait_q;
-	uint32_t count;
-	uint32_t limit;
+	unsigned int count;
+	unsigned int limit;
 
 	_POLL_EVENT;
 
@@ -2728,6 +2729,16 @@ struct k_sem {
  */
 
 /**
+ * @brief Maximum limit value allowed for a semaphore.
+ *
+ * This is intended for use when a semaphore does not have
+ * an explicit maximum limit, and instead is just used for
+ * counting purposes.
+ *
+ */
+#define K_SEM_MAX_LIMIT UINT_MAX
+
+/**
  * @brief Initialize a semaphore.
  *
  * This routine initializes a semaphore object, prior to its first use.
@@ -2735,6 +2746,8 @@ struct k_sem {
  * @param sem Address of the semaphore.
  * @param initial_count Initial semaphore count.
  * @param limit Maximum permitted semaphore count.
+ *
+ * @see K_SEM_MAX_LIMIT
  *
  * @retval 0 Semaphore created successfully
  * @retval -EINVAL Invalid values
@@ -2827,7 +2840,8 @@ static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
 	Z_STRUCT_SECTION_ITERABLE(k_sem, name) = \
 		Z_SEM_INITIALIZER(name, initial_count, count_limit); \
 	BUILD_ASSERT(((count_limit) != 0) && \
-		     ((initial_count) <= (count_limit)));
+		     ((initial_count) <= (count_limit)) && \
+			 ((count_limit) <= K_SEM_MAX_LIMIT));
 
 /** @} */
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -65,7 +65,7 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 	/*
 	 * Limit cannot be zero and count cannot be greater than limit
 	 */
-	CHECKIF(limit == 0U || initial_count > limit) {
+	CHECKIF(limit == 0U || limit > K_SEM_MAX_LIMIT || initial_count > limit) {
 		return -EINVAL;
 	}
 

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -66,7 +66,7 @@ static inline void init_app(void)
 {
 	LOG_INF("Run IPSP sample");
 
-	k_sem_init(&quit_lock, 0, UINT_MAX);
+	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
 	if (net_addr_pton(AF_INET6,
 			  CONFIG_NET_CONFIG_MY_IPV6_ADDR,

--- a/samples/cpp_synchronization/src/main.cpp
+++ b/samples/cpp_synchronization/src/main.cpp
@@ -64,7 +64,7 @@ public:
 cpp_semaphore::cpp_semaphore()
 {
 	printk("Create semaphore %p\n", this);
-	k_sem_init(&_sema_internal, 0, UINT_MAX);
+	k_sem_init(&_sema_internal, 0, K_SEM_MAX_LIMIT);
 }
 
 /*

--- a/samples/net/gptp/src/gptp.c
+++ b/samples/net/gptp/src/gptp.c
@@ -80,7 +80,7 @@ void init_testing(void)
 		return;
 	}
 
-	k_sem_init(&quit_lock, 0, UINT_MAX);
+	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
 	k_delayed_work_init(&stop_sample, stop_handler);
 	k_delayed_work_submit(&stop_sample, K_SECONDS(run_duration));

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -437,7 +437,7 @@ void main(void)
 
 	LOG_INF(APP_BANNER);
 
-	k_sem_init(&quit_lock, 0, UINT_MAX);
+	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
 	ret = lwm2m_setup();
 	if (ret < 0) {

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -134,7 +134,7 @@ static void init_app(void)
 	int err;
 #endif
 
-	k_sem_init(&quit_lock, 0, UINT_MAX);
+	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
 	LOG_INF(APP_BANNER);
 

--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -215,7 +215,7 @@ static void send_packet(void)
 
 void main(void)
 {
-	k_sem_init(&quit_lock, 0, UINT_MAX);
+	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
 	LOG_INF("Packet socket sample is running");
 

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -49,7 +49,7 @@
 
 #include "hal/debug.h"
 
-static K_SEM_DEFINE(sem_prio_recv, 0, UINT_MAX);
+static K_SEM_DEFINE(sem_prio_recv, 0, K_SEM_MAX_LIMIT);
 static K_FIFO_DEFINE(recv_fifo);
 
 struct k_thread prio_recv_thread_data;

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1186,7 +1186,7 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 			if (session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
 				session->cfc = BT_RFCOMM_CFC_SUPPORTED;
 			}
-			k_sem_init(&dlc->tx_credits, 0, UINT32_MAX);
+			k_sem_init(&dlc->tx_credits, 0, K_SEM_MAX_LIMIT);
 			rfcomm_dlc_tx_give_credits(dlc, pn->credits);
 		} else {
 			session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
@@ -1216,7 +1216,7 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 				if (session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
 					session->cfc = BT_RFCOMM_CFC_SUPPORTED;
 				}
-				k_sem_init(&dlc->tx_credits, 0, UINT32_MAX);
+				k_sem_init(&dlc->tx_credits, 0, K_SEM_MAX_LIMIT);
 				rfcomm_dlc_tx_give_credits(dlc, pn->credits);
 			} else {
 				session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -270,7 +270,7 @@ int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size)
 	tty->rx_ringbuf_sz = size;
 
 	if (size > 0) {
-		k_sem_init(&tty->rx_sem, 0, UINT_MAX);
+		k_sem_init(&tty->rx_sem, 0, K_SEM_MAX_LIMIT);
 		uart_irq_rx_enable(tty->uart_dev);
 	}
 
@@ -284,7 +284,7 @@ int tty_set_tx_buf(struct tty_serial *tty, void *buf, size_t size)
 	tty->tx_ringbuf = buf;
 	tty->tx_ringbuf_sz = size;
 
-	k_sem_init(&tty->tx_sem, size - 1, UINT_MAX);
+	k_sem_init(&tty->tx_sem, size - 1, K_SEM_MAX_LIMIT);
 
 	/* New buffer is initially empty, no need to re-enable interrupts,
 	 * it will be done when needed (on first output char).

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2488,6 +2488,6 @@ void net_ipv6_nbr_init(void)
 	net_icmpv6_register_handler(&ra_input_handler);
 	k_delayed_work_init(&ipv6_nd_reachable_timer,
 			    ipv6_nd_reachable_timeout);
-	k_sem_init(&nbr_lock, 1, UINT_MAX);
+	k_sem_init(&nbr_lock, 1, K_SEM_MAX_LIMIT);
 #endif
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -306,7 +306,7 @@ int net_context_get(sa_family_t family,
 		}
 
 #if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
-		k_sem_init(&contexts[i].recv_data_wait, 1, UINT_MAX);
+		k_sem_init(&contexts[i].recv_data_wait, 1, K_SEM_MAX_LIMIT);
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
 		k_mutex_init(&contexts[i].lock);
@@ -2371,5 +2371,5 @@ const char *net_context_state(struct net_context *context)
 
 void net_context_init(void)
 {
-	k_sem_init(&contexts_lock, 1, UINT_MAX);
+	k_sem_init(&contexts_lock, 1, K_SEM_MAX_LIMIT);
 }

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -33,7 +33,7 @@ struct mgmt_event_wait {
 	struct net_if *iface;
 };
 
-static K_SEM_DEFINE(network_event, 0, UINT_MAX);
+static K_SEM_DEFINE(network_event, 0, K_SEM_MAX_LIMIT);
 static K_SEM_DEFINE(net_mgmt_lock, 1, 1);
 
 K_KERNEL_STACK_DEFINE(mgmt_stack, CONFIG_NET_MGMT_EVENT_STACK_SIZE);
@@ -239,7 +239,7 @@ static void mgmt_thread(void)
 			NET_DBG("Some event got probably lost (%u)",
 				k_sem_count_get(&network_event));
 
-			k_sem_init(&network_event, 0, UINT_MAX);
+			k_sem_init(&network_event, 0, K_SEM_MAX_LIMIT);
 			k_sem_give(&net_mgmt_lock);
 
 			continue;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -323,7 +323,7 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 	tcp_context[i].accept_cb = NULL;
 
 	k_delayed_work_init(&tcp_context[i].retry_timer, tcp_retry_expired);
-	k_sem_init(&tcp_context[i].connect_wait, 0, UINT_MAX);
+	k_sem_init(&tcp_context[i].connect_wait, 0, K_SEM_MAX_LIMIT);
 
 	return &tcp_context[i];
 }

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1142,7 +1142,7 @@ static struct tcp *tcp_conn_alloc(void)
 
 	k_mutex_init(&conn->lock);
 	k_fifo_init(&conn->recv_data);
-	k_sem_init(&conn->connect_sem, 0, UINT_MAX);
+	k_sem_init(&conn->connect_sem, 0, K_SEM_MAX_LIMIT);
 
 	conn->in_connect = false;
 	conn->state = TCP_LISTEN;

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -1727,7 +1727,7 @@ void net_6locan_init(struct net_if *iface)
 
 	k_mutex_init(&l2_ctx.tx_ctx_mtx);
 	k_mutex_init(&l2_ctx.rx_ctx_mtx);
-	k_sem_init(&l2_ctx.tx_sem, 1, INT_MAX);
+	k_sem_init(&l2_ctx.tx_sem, 1, K_SEM_MAX_LIMIT);
 
 	/* This work queue should have precedence over the tx stream
 	 * TODO thread_priority = tx_tc2thread(NET_TC_TX_COUNT -1) - 1;

--- a/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
@@ -32,7 +32,7 @@ static inline bool prepare_for_ack(struct ieee802154_context *ctx,
 
 		ctx->ack_seq = fs->sequence;
 		ctx->ack_received = false;
-		k_sem_init(&ctx->ack_lock, 0, UINT_MAX);
+		k_sem_init(&ctx->ack_lock, 0, K_SEM_MAX_LIMIT);
 
 		return true;
 	}
@@ -56,7 +56,7 @@ static inline int wait_for_ack(struct net_if *iface,
 		 * We reinit the semaphore in case handle_ack
 		 * got called multiple times.
 		 */
-		k_sem_init(&ctx->ack_lock, 0, UINT_MAX);
+		k_sem_init(&ctx->ack_lock, 0, K_SEM_MAX_LIMIT);
 	}
 
 	ctx->ack_seq = 0U;

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -452,7 +452,7 @@ void net_ppp_init(struct net_if *iface)
 	ctx->iface = iface;
 
 #if defined(CONFIG_NET_SHELL)
-	k_sem_init(&ctx->shell.wait_echo_reply, 0, UINT_MAX);
+	k_sem_init(&ctx->shell.wait_echo_reply, 0, K_SEM_MAX_LIMIT);
 #endif
 
 	/* TODO: Unify the startup worker code so that we can save

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -361,7 +361,7 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 
 	/* First make sure that network interface is up */
 	if (check_interface(iface) == false) {
-		k_sem_init(&counter, 1, UINT_MAX);
+		k_sem_init(&counter, 1, K_SEM_MAX_LIMIT);
 
 		while (count-- > 0) {
 			if (!k_sem_count_get(&counter)) {

--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(conn_mgr, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 
 uint16_t iface_states[CONN_MGR_IFACE_MAX];
 
-K_SEM_DEFINE(conn_mgr_lock, 1, UINT_MAX);
+K_SEM_DEFINE(conn_mgr_lock, 1, K_SEM_MAX_LIMIT);
 
 static enum net_conn_mgr_state conn_mgr_iface_status(int index)
 {

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -196,7 +196,7 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	ai_state.idx = 0U;
 	ai_state.port = htons(port);
 	ai_state.ai_arr = res;
-	k_sem_init(&ai_state.sem, 0, UINT_MAX);
+	k_sem_init(&ai_state.sem, 0, K_SEM_MAX_LIMIT);
 
 	/* Link entries in advance */
 	ai_state.ai_arr[0].ai_next = &ai_state.ai_arr[1];

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -988,5 +988,5 @@ void websocket_context_foreach(websocket_context_cb_t cb, void *user_data)
 
 void websocket_init(void)
 {
-	k_sem_init(&contexts_lock, 1, UINT_MAX);
+	k_sem_init(&contexts_lock, 1, K_SEM_MAX_LIMIT);
 }

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -546,7 +546,7 @@ static int cdc_acm_init(const struct device *dev)
 	LOG_DBG("Device dev %p dev_data %p cfg %p added to devlist %p",
 		dev, dev_data, dev->config, &cdc_acm_data_devlist);
 
-	k_sem_init(&dev_data->poll_wait_sem, 0, UINT_MAX);
+	k_sem_init(&dev_data->poll_wait_sem, 0, K_SEM_MAX_LIMIT);
 	k_work_init(&dev_data->cb_work, cdc_acm_irq_callback_work_handler);
 	k_work_init(&dev_data->tx_work, tx_work_handler);
 

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -147,7 +147,7 @@ void test_arm_irq_vector_table(void)
 	for (int ii = 0; ii < 3; ii++) {
 		irq_enable(_ISR_OFFSET + ii);
 		z_arm_irq_priority_set(_ISR_OFFSET + ii, 0, 0);
-		k_sem_init(&sem[ii], 0, UINT_MAX);
+		k_sem_init(&sem[ii], 0, K_SEM_MAX_LIMIT);
 	}
 
 	zassert_true((k_sem_take(&sem[0], K_NO_WAIT) ||


### PR DESCRIPTION
Currently there is no way to distinguish between a caller
explicitly asking for a semaphore with a limit that
happens to be `UINT_MAX` and a semaphore that just
has a limit "as large as possible".

Add `K_SEM_MAX_LIMIT`, currently defined to `UINT_MAX`, and akin
to `K_FOREVER` versus just passing some very large wait time.

In addition, the `k_sem_*` APIs were type-confused, where
the internal data structure was `uint32_t`, but the APIs took
and returned `unsigned int`. This changes the underlying data
structure to also use `unsigned int`, as changing the APIs
would be a (potentially) breaking change.

These changes are backwards-compatible, but it is strongly suggested
to take a quick scan for `k_sem_init` and `K_SEM_DEFINE` calls with
`UINT_MAX` (or `UINT32_MAX`) and replace them with `K_SEM_MAX_LIMIT`
where appropriate.

Signed-off-by: James Harris <james.harris@intel.com>