### PR TITLE
net: mqtt: log struct mqtt_utf8 with hexdump

### DIFF
--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -55,6 +55,11 @@ extern "C" {
 #define NET_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define NET_INFO(fmt, ...) LOG_INF(fmt,  ##__VA_ARGS__)
 
+#define NET_HEXDUMP_DBG(_data, _length, _str) LOG_HEXDUMP_DBG(_data, _length, _str)
+#define NET_HEXDUMP_ERR(_data, _length, _str) LOG_HEXDUMP_ERR(_data, _length, _str)
+#define NET_HEXDUMP_WARN(_data, _length, _str) LOG_HEXDUMP_WRN(_data, _length, _str)
+#define NET_HEXDUMP_INFO(_data, _length, _str) LOG_HEXDUMP_INF(_data, _length, _str)
+
 #define NET_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 
 /* This needs to be here in order to avoid circular include dependency between

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -287,8 +287,8 @@ int connect_request_encode(const struct mqtt_client *client,
 	buf->cur += MQTT_FIXED_HEADER_MAX_SIZE;
 	start = buf->cur;
 
-	MQTT_TRC("Encoding Protocol Description. Str:%s Size:%08x.",
-		 mqtt_proto_desc->utf8, mqtt_proto_desc->size);
+	MQTT_HEXDUMP_TRC(mqtt_proto_desc->utf8, mqtt_proto_desc->size,
+			 "Encoding Protocol Description.");
 
 	err_code = pack_utf8_str(mqtt_proto_desc, buf);
 	if (err_code != 0) {
@@ -317,8 +317,8 @@ int connect_request_encode(const struct mqtt_client *client,
 		return err_code;
 	}
 
-	MQTT_TRC("Encoding Client Id. Str:%s Size:%08x.",
-		 client->client_id.utf8, client->client_id.size);
+	MQTT_HEXDUMP_TRC(client->client_id.utf8, client->client_id.size,
+			 "Encoding Client Id.");
 	err_code = pack_utf8_str(&client->client_id, buf);
 	if (err_code != 0) {
 		return err_code;
@@ -331,18 +331,18 @@ int connect_request_encode(const struct mqtt_client *client,
 		connect_flags |= ((client->will_topic->qos & 0x03) << 3);
 		connect_flags |= client->will_retain << 5;
 
-		MQTT_TRC("Encoding Will Topic. Str:%s Size:%08x.",
-			 client->will_topic->topic.utf8,
-			 client->will_topic->topic.size);
+		MQTT_HEXDUMP_TRC(client->will_topic->topic.utf8,
+				 client->will_topic->topic.size,
+				 "Encoding Will Topic.");
 		err_code = pack_utf8_str(&client->will_topic->topic, buf);
 		if (err_code != 0) {
 			return err_code;
 		}
 
 		if (client->will_message != NULL) {
-			MQTT_TRC("Encoding Will Message. Str:%s Size:%08x.",
-				 client->will_message->utf8,
-				 client->will_message->size);
+			MQTT_HEXDUMP_TRC(client->will_message->utf8,
+					 client->will_message->size,
+					 "Encoding Will Message.");
 			err_code = pack_utf8_str(client->will_message, buf);
 			if (err_code != 0) {
 				return err_code;
@@ -360,8 +360,9 @@ int connect_request_encode(const struct mqtt_client *client,
 	if (client->user_name != NULL) {
 		connect_flags |= MQTT_CONNECT_FLAG_USERNAME;
 
-		MQTT_TRC("Encoding Username. Str:%s, Size:%08x.",
-			 client->user_name->utf8, client->user_name->size);
+		MQTT_HEXDUMP_TRC(client->user_name->utf8,
+				 client->user_name->size,
+				 "Encoding Username.");
 		err_code = pack_utf8_str(client->user_name, buf);
 		if (err_code != 0) {
 			return err_code;
@@ -372,8 +373,9 @@ int connect_request_encode(const struct mqtt_client *client,
 	if (client->password != NULL) {
 		connect_flags |= MQTT_CONNECT_FLAG_PASSWORD;
 
-		MQTT_TRC("Encoding Password. Str:%s Size:%08x.",
-			 client->password->utf8, client->password->size);
+		MQTT_HEXDUMP_TRC(client->password->utf8,
+				 client->password->size,
+				 "Encoding Password.");
 		err_code = pack_utf8_str(client->password, buf);
 		if (err_code != 0) {
 			return err_code;

--- a/subsys/net/lib/mqtt/mqtt_os.h
+++ b/subsys/net/lib/mqtt/mqtt_os.h
@@ -36,6 +36,18 @@ extern "C" {
 /**@brief Method to error logs from the module. */
 #define MQTT_ERR(...) NET_ERR(__VA_ARGS__)
 
+/**@brief Method to hexdump trace logs from the module. */
+#define MQTT_HEXDUMP_TRC(_data, _length, _str) NET_HEXDUMP_DBG(_data, _length, _str)
+
+/**@brief Method to hexdump error logs from the module. */
+#define MQTT_HEXDUMP_ERR(_data, _length, _str) NET_HEXDUMP_ERR(_data, _length, _str)
+
+/**@brief Method to hexdump warning logs from the module. */
+#define MQTT_HEXDUMP_WARN(_data, _length, _str) NET_HEXDUMP_WARN(_data, _length, _str)
+
+/**@brief Method to hexdump info logs from the module. */
+#define MQTT_HEXDUMP_INFO(_data, _length, _str) NETHEXDUMP_INFO(_data, _length, _str)
+
 /**@brief Initialize the mutex for the module, if any.
  *
  * @details This method is called during module initialization @ref mqtt_init.


### PR DESCRIPTION
Add NET_HEXDUMP_DBG/ERR/WARN/INFO macros, then use them for new
MQTT_HEXDUMP_TRC/ERR/WARN/INFO macros.

Log struct mqtt_utf8 using MQTT_HEXDUMP_TRC. One cannot safely log
mqtt_utf8 strings due to no guarantee of a NULL terminator being
present.  Also, logging without log_strdup() as if it were a NULL
terminated string asserts when CONFIG_LOG_IMMEDIATE=n. This solves
both issues.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>