### PR TITLE
shell: kernel: also print the thread entry pointer

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -78,7 +78,8 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		      thread->base.user_options,
 		      thread->base.prio,
 		      thread->base.timeout.dticks);
-	shell_print(shell, "\tstate: %s", k_thread_state_str(thread));
+	shell_print(shell, "\tstate: %s, entry: %p", k_thread_state_str(thread),
+		    thread->entry);
 
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	ret = 0;


### PR DESCRIPTION
Sometimes it is hard to tell which instance of a thread is which
in the printed list, based solely on the name (if present) and
the k_thread pointer, so also print the thread entry fn pointer.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>