### PR TITLE
checkpatch: Disable "blank line after declarations" warning

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -27,4 +27,5 @@
 --ignore TRAILING_SEMICOLON
 --ignore COMPLEX_MACRO
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore LINE_SPACING_DECL
 --exclude ext


### PR DESCRIPTION
[Yes, this is implicitly changing our standard coding style.  This subject came up a few days ago and the same warning bit me again on a recent submission, so I figure I'll throw this out and see what people say.]

This warning comes out of Linux, which enforces a conventional style
with a bunch of declarations at the top of a function followed by code
that uses them.

Zephyr code, however (especially recent Zephyr code) tends to use a
lot of inline declarations in a more declarative and less imperative
style.  The newline checkpatch requires is IMHO hurting and not
helping.  It prevents natural idioms like:

    k_spinlock_key_t k = k_spin_lock(&my_lock);
    do_something_while_locked();
    k_spin_unlock(&my_lock, k);

Or:

    int end = <complicated expression>;
    for (int i = 0; i < end; i ++) {
        ....
    }

Zephyr's own coding guidelines are silent on this subject, this is
purely a checkpatch behavior.  Move the warning to its own category
("LINE_SPACING" is shared with other warnings we want to keep) and
ignore it with .checkpatch.conf

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>