### PR TITLE
samples: basic: blinky_pwm: fix bad path in README

### DIFF
--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -65,7 +65,7 @@ Building and Running
 To build and flash this sample for the :ref:`nrf52840dk_nrf52840`:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/basic/blink_led
+   :zephyr-app: samples/basic/blinky_pwm
    :board: nrf52840dk_nrf52840
    :goals: build flash
    :compact:


### PR DESCRIPTION
The README gives as example the command to build
the sample with west. The path of the sample as
stated does not exist. This fixes it to blinky_pwm.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>