### PR TITLE
boards: nsim: add mdb unaligned memory access option

### DIFF
--- a/boards/arc/nsim/support/mdb_em.args
+++ b/boards/arc/nsim/support/mdb_em.args
@@ -61,3 +61,4 @@
 	-dmac_int_config=single_internal
 	-prop=nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24
 	-noprofile
+	-Xunaligned

--- a/boards/arc/nsim/support/mdb_em7d_v22.args
+++ b/boards/arc/nsim/support/mdb_em7d_v22.args
@@ -46,3 +46,4 @@
 	-dmac_int_config=single_internal
 	-prop=nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24
 	-noprofile
+	-Xunaligned


### PR DESCRIPTION
During my debug, I found `tests/kernel/mem_protect/mem_protect/` will
run successfully in `nsim_em`, but when I debug it with `mdb` debuger, it
will run failed.  
nsim has two config files:
[nsim_em.props](https://github.com/zephyrproject-rtos/zephyr/blob/master/boards/arc/nsim/support/nsim_em.props)
[mdb_em.args](https://github.com/zephyrproject-rtos/zephyr/blob/master/boards/arc/nsim/support/mdb_em.args)
When we launch nsim through mdb, we use `mdb_em.args`, in other case, we use `nsim_em.props`

When CONFIG_ARC_USE_UNALIGNED_MEM_ACCESS=y, we also
need to add -Xunaligned option in `mdb_em.args`for mdb to enable unaligned
memory access feature for nsim, like the option we add similar in `nsim_em.props` : `nsim_isa_unaligned_option=1`
