### PR TITLE
drivers: i2c: DW i2c: use 32 bit access instead of 16 and 32 bit mix

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -34,9 +34,9 @@ LOG_MODULE_REGISTER(i2c_dw);
 
 #include "i2c-priv.h"
 
-static inline volatile struct i2c_dw_registers *get_regs(const struct device *dev)
+static inline uint32_t get_regs(const struct device *dev)
 {
-	return (volatile struct i2c_dw_registers *)DEVICE_MMIO_GET(dev);
+	return (uint32_t)DEVICE_MMIO_GET(dev);
 }
 
 static inline void i2c_dw_data_ask(const struct device *dev)
@@ -46,17 +46,16 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 	uint8_t tx_empty;
 	int8_t rx_empty;
 	uint8_t cnt;
-
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
+	uint32_t reg_base = get_regs(dev);
 
 	/* No more bytes to request, so command queue is no longer needed */
 	if (dw->request_bytes == 0U) {
-		regs->ic_intr_mask.bits.tx_empty = 0U;
+		clear_bit_intr_mask_tx_empty(reg_base);
 		return;
 	}
 
 	/* How many bytes we can actually ask */
-	rx_empty = (I2C_DW_FIFO_DEPTH - regs->ic_rxflr) - dw->rx_pending;
+	rx_empty = (I2C_DW_FIFO_DEPTH - read_rxflr(reg_base)) - dw->rx_pending;
 
 	if (rx_empty < 0) {
 		/* RX FIFO expected to be full.
@@ -66,7 +65,7 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 	}
 
 	/* How many empty slots in TX FIFO (as command queue) */
-	tx_empty = I2C_DW_FIFO_DEPTH - regs->ic_txflr;
+	tx_empty = I2C_DW_FIFO_DEPTH - read_txflr(reg_base);
 
 	/* Figure out how many bytes we can request */
 	cnt = MIN(I2C_DW_FIFO_DEPTH, dw->request_bytes);
@@ -88,7 +87,7 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 			data |= IC_DATA_CMD_STOP;
 		}
 
-		regs->ic_data_cmd.raw = data;
+		write_cmd_data(data, reg_base);
 
 		dw->rx_pending++;
 		dw->request_bytes--;
@@ -99,11 +98,10 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 static void i2c_dw_data_read(const struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->data;
+	uint32_t reg_base = get_regs(dev);
 
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
-
-	while (regs->ic_status.bits.rfne && (dw->xfr_len > 0)) {
-		dw->xfr_buf[0] = regs->ic_data_cmd.raw;
+	while (test_bit_status_rfne(reg_base) && (dw->xfr_len > 0)) {
+		dw->xfr_buf[0] = (uint8_t)read_cmd_data(reg_base);
 
 		dw->xfr_buf++;
 		dw->xfr_len--;
@@ -126,19 +124,18 @@ static int i2c_dw_data_send(const struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->data;
 	uint32_t data = 0U;
-
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
+	uint32_t reg_base = get_regs(dev);
 
 	/* Nothing to send anymore, mask the interrupt */
 	if (dw->xfr_len == 0U) {
-		regs->ic_intr_mask.bits.tx_empty = 0U;
+		clear_bit_intr_mask_tx_empty(reg_base);
 
 		dw->state &= ~I2C_DW_CMD_SEND;
 
 		return 0;
 	}
 
-	while (regs->ic_status.bits.tfnf && (dw->xfr_len > 0)) {
+	while (test_bit_status_tfnt(reg_base) && (dw->xfr_len > 0)) {
 		/* We have something to transmit to a specific host */
 		data = dw->xfr_buf[0];
 
@@ -153,12 +150,12 @@ static int i2c_dw_data_send(const struct device *dev)
 			data |= IC_DATA_CMD_STOP;
 		}
 
-		regs->ic_data_cmd.raw = data;
+		write_cmd_data(data, reg_base);
 
 		dw->xfr_len--;
 		dw->xfr_buf++;
 
-		if (regs->ic_intr_stat.bits.tx_abrt) {
+		if (test_bit_intr_stat_tx_abrt(reg_base)) {
 			return -EIO;
 		}
 	}
@@ -170,11 +167,10 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->data;
 	uint32_t value;
+	uint32_t reg_base = get_regs(dev);
 
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
-
-	regs->ic_intr_mask.raw = DW_DISABLE_ALL_I2C_INT;
-	value = regs->ic_clr_intr;
+	write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+	value = read_clr_intr(reg_base);
 
 	k_sem_give(&dw->device_sync_sem);
 }
@@ -186,13 +182,12 @@ static void i2c_dw_isr(void *arg)
 	union ic_interrupt_register intr_stat;
 	uint32_t value;
 	int ret = 0;
-
-	volatile struct i2c_dw_registers * const regs = get_regs(port);
+	uint32_t reg_base = get_regs(port);
 
 	/* Cache ic_intr_stat for processing, so there is no need to read
 	 * the register multiple times.
 	 */
-	intr_stat.raw = regs->ic_intr_stat.raw;
+	intr_stat.raw = read_intr_stat(reg_base);
 
 	/*
 	 * Causes of an interrupt:
@@ -210,7 +205,7 @@ static void i2c_dw_isr(void *arg)
 	LOG_DBG("I2C: interrupt received");
 
 	/* Check if we are configured as a master device */
-	if (regs->ic_con.bits.master_mode) {
+	if (test_bit_con_master_mode(reg_base)) {
 		/* Bail early if there is any error. */
 		if ((DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_TX_OVER |
 		     DW_INTR_STAT_RX_OVER | DW_INTR_STAT_RX_UNDER) &
@@ -249,7 +244,7 @@ static void i2c_dw_isr(void *arg)
 
 	/* STOP detected: finish processing this message */
 	if (intr_stat.bits.stop_det) {
-		value = regs->ic_clr_stop_det;
+		value = read_clr_stop_det(reg_base);
 		goto done;
 	}
 
@@ -265,18 +260,19 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	struct i2c_dw_dev_config * const dw = dev->data;
 	uint32_t value;
 	union ic_con_register ic_con;
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
+	union ic_tar_register ic_tar;
+	uint32_t reg_base = get_regs(dev);
 
 	ic_con.raw = 0U;
 
 	/* Disable the device controller to be able set TAR */
-	regs->ic_enable.bits.enable = 0U;
+	clear_bit_enable_en(reg_base);
 
 	/* Disable interrupts */
-	regs->ic_intr_mask.raw = 0U;
+	write_intr_mask(0, reg_base);
 
 	/* Clear interrupts */
-	value = regs->ic_clr_intr;
+	value = read_clr_intr(reg_base);
 
 	/* Set master or slave mode - (initialization = slave) */
 	if (I2C_MODE_MASTER & dw->app_config) {
@@ -304,8 +300,8 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	switch (I2C_SPEED_GET(dw->app_config)) {
 	case I2C_SPEED_STANDARD:
 		LOG_DBG("I2C: speed set to STANDARD");
-		regs->ic_ss_scl_lcnt = dw->lcnt;
-		regs->ic_ss_scl_hcnt = dw->hcnt;
+		write_ss_scl_lcnt(dw->lcnt, reg_base);
+		write_ss_scl_hcnt(dw->hcnt, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_STANDARD;
 
 		break;
@@ -313,8 +309,8 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		__fallthrough;
 	case I2C_SPEED_FAST_PLUS:
 		LOG_DBG("I2C: speed set to FAST or FAST_PLUS");
-		regs->ic_fs_scl_lcnt = dw->lcnt;
-		regs->ic_fs_scl_hcnt = dw->hcnt;
+		write_fs_scl_lcnt(dw->lcnt, reg_base);
+		write_fs_scl_hcnt(dw->hcnt, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_FAST;
 
 		break;
@@ -324,8 +320,8 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		}
 
 		LOG_DBG("I2C: speed set to HIGH");
-		regs->ic_hs_scl_lcnt = dw->lcnt;
-		regs->ic_hs_scl_hcnt = dw->hcnt;
+		write_hs_scl_lcnt(dw->lcnt, reg_base);
+		write_hs_scl_hcnt(dw->hcnt, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_HIGH;
 
 		break;
@@ -338,7 +334,7 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	LOG_DBG("I2C: hcnt = %d", dw->hcnt);
 
 	/* Set the IC_CON register */
-	regs->ic_con = ic_con;
+	write_con(ic_con.raw, reg_base);
 
 	/* Set RX fifo threshold level.
 	 * Setting it to zero automatically triggers interrupt
@@ -346,7 +342,7 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	 *
 	 * TODO: extend the threshold for multi-byte RX.
 	 */
-	regs->ic_rx_tl = 0U;
+	write_rx_tl(0, reg_base);
 
 	/* Set TX fifo threshold level.
 	 * TX_EMPTY interrupt is triggered only when the
@@ -356,14 +352,16 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	 * cause some pauses during transfers, but this keeps
 	 * the device from interrupting often.
 	 */
-	regs->ic_tx_tl = 0U;
+	write_tx_tl(0, reg_base);
 
-	if (regs->ic_con.bits.master_mode) {
+	ic_tar.raw = read_tar(reg_base);
+
+	if (test_bit_con_master_mode(reg_base)) {
 		/* Set address of target slave */
-		regs->ic_tar.bits.ic_tar = slave_address;
+		ic_tar.bits.ic_tar = slave_address;
 	} else {
 		/* Set slave address for device */
-		regs->ic_sar.bits.ic_sar = slave_address;
+		write_sar(slave_address, reg_base);
 	}
 
 	/* If I2C is being operated in master mode and I2C_DYNAMIC_TAR_UPDATE
@@ -373,11 +371,13 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	 */
 	if (I2C_MODE_MASTER & dw->app_config) {
 		if (I2C_ADDR_10_BITS & dw->app_config) {
-			regs->ic_tar.bits.ic_10bitaddr_master = 1U;
+			ic_tar.bits.ic_10bitaddr_master = 1U;
 		} else {
-			regs->ic_tar.bits.ic_10bitaddr_master = 0U;
+			ic_tar.bits.ic_10bitaddr_master = 0U;
 		}
 	}
+
+	write_tar(ic_tar.raw, reg_base);
 
 	return 0;
 }
@@ -391,8 +391,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	uint8_t msg_left = num_msgs;
 	uint8_t pflags;
 	int ret;
-
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
+	uint32_t reg_base = get_regs(dev);
 
 	__ASSERT_NO_MSG(msgs);
 	if (!num_msgs) {
@@ -400,7 +399,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	}
 
 	/* First step, check if there is current activity */
-	if ((regs->ic_status.bits.activity) || (dw->state & I2C_DW_BUSY)) {
+	if (test_bit_status_activity(reg_base) || (dw->state & I2C_DW_BUSY)) {
 		return -EIO;
 	}
 
@@ -413,7 +412,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	}
 
 	/* Enable controller */
-	regs->ic_enable.bits.enable = 1U;
+	set_bit_enable_en(reg_base);
 
 	/*
 	 * While waiting at device_sync_sem, kernel can switch to idle
@@ -460,13 +459,13 @@ static int i2c_dw_transfer(const struct device *dev,
 		}
 
 		/* Enable interrupts to trigger ISR */
-		if (regs->ic_con.bits.master_mode) {
+		if (test_bit_con_master_mode(reg_base)) {
 			/* Enable necessary interrupts */
-			regs->ic_intr_mask.raw = (DW_ENABLE_TX_INT_I2C_MASTER |
-						  DW_ENABLE_RX_INT_I2C_MASTER);
+			write_intr_mask((DW_ENABLE_TX_INT_I2C_MASTER |
+						  DW_ENABLE_RX_INT_I2C_MASTER), reg_base);
 		} else {
 			/* Enable necessary interrupts */
-			regs->ic_intr_mask.raw = DW_ENABLE_TX_INT_I2C_SLAVE;
+			write_intr_mask(DW_ENABLE_TX_INT_I2C_SLAVE, reg_base);
 		}
 
 		/* Wait for transfer to be done */
@@ -499,8 +498,7 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 	struct i2c_dw_dev_config * const dw = dev->data;
 	uint32_t	value = 0U;
 	uint32_t	rc = 0U;
-
-	volatile struct i2c_dw_registers * const regs = get_regs(dev);
+	uint32_t reg_base = get_regs(dev);
 
 	dw->app_config = config;
 
@@ -511,8 +509,8 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		/* Following the directions on DW spec page 59, IC_SS_SCL_LCNT
 		 * must have register values larger than IC_FS_SPKLEN + 7
 		 */
-		if (I2C_STD_LCNT <= (regs->ic_fs_spklen + 7)) {
-			value = regs->ic_fs_spklen + 8;
+		if (I2C_STD_LCNT <= (read_fs_spklen(reg_base) + 7)) {
+			value = read_fs_spklen(reg_base) + 8;
 		} else {
 			value = I2C_STD_LCNT;
 		}
@@ -522,8 +520,8 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		/* Following the directions on DW spec page 59, IC_SS_SCL_HCNT
 		 * must have register values larger than IC_FS_SPKLEN + 5
 		 */
-		if (I2C_STD_HCNT <= (regs->ic_fs_spklen + 5)) {
-			value = regs->ic_fs_spklen + 6;
+		if (I2C_STD_HCNT <= (read_fs_spklen(reg_base) + 5)) {
+			value = read_fs_spklen(reg_base) + 6;
 		} else {
 			value = I2C_STD_HCNT;
 		}
@@ -537,8 +535,8 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT
 		 * must have register values larger than IC_FS_SPKLEN + 7
 		 */
-		if (I2C_FS_LCNT <= (regs->ic_fs_spklen + 7)) {
-			value = regs->ic_fs_spklen + 8;
+		if (I2C_FS_LCNT <= (read_fs_spklen(reg_base) + 7)) {
+			value = read_fs_spklen(reg_base) + 8;
 		} else {
 			value = I2C_FS_LCNT;
 		}
@@ -549,8 +547,8 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * Following the directions on DW spec page 59, IC_FS_SCL_HCNT
 		 * must have register values larger than IC_FS_SPKLEN + 5
 		 */
-		if (I2C_FS_HCNT <= (regs->ic_fs_spklen + 5)) {
-			value = regs->ic_fs_spklen + 6;
+		if (I2C_FS_HCNT <= (read_fs_spklen(reg_base) + 5)) {
+			value = read_fs_spklen(reg_base) + 6;
 		} else {
 			value = I2C_FS_HCNT;
 		}
@@ -559,16 +557,16 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		break;
 	case I2C_SPEED_HIGH:
 		if (dw->support_hs_mode) {
-			if (I2C_HS_LCNT <= (regs->ic_hs_spklen + 7)) {
-				value = regs->ic_hs_spklen + 8;
+			if (I2C_HS_LCNT <= (read_hs_spklen(reg_base) + 7)) {
+				value = read_hs_spklen(reg_base) + 8;
 			} else {
 				value = I2C_HS_LCNT;
 			}
 
 			dw->lcnt = value;
 
-			if (I2C_HS_HCNT <= (regs->ic_hs_spklen + 5)) {
-				value = regs->ic_hs_spklen + 6;
+			if (I2C_HS_HCNT <= (read_hs_spklen(reg_base) + 5)) {
+				value = read_hs_spklen(reg_base) + 6;
 			} else {
 				value = I2C_HS_HCNT;
 			}
@@ -586,7 +584,7 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 	/*
 	 * Clear any interrupts currently waiting in the controller
 	 */
-	value = regs->ic_clr_intr;
+	value = read_clr_intr(reg_base);
 
 	/*
 	 * TEMPORARY HACK - The I2C does not work in any mode other than Master
@@ -607,7 +605,8 @@ static int i2c_dw_initialize(const struct device *dev)
 {
 	const struct i2c_dw_rom_config * const rom = dev->config;
 	struct i2c_dw_dev_config * const dw = dev->data;
-	volatile struct i2c_dw_registers *regs;
+	union ic_con_register ic_con;
+	uint32_t reg_base = get_regs(dev);
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
@@ -630,9 +629,8 @@ static int i2c_dw_initialize(const struct device *dev)
 
 	k_sem_init(&dw->device_sync_sem, 0, UINT_MAX);
 
-	regs = get_regs(dev);
 	/* verify that we have a valid DesignWare register first */
-	if (regs->ic_comp_type != I2C_DW_MAGIC_KEY) {
+	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
 		LOG_DBG("I2C: DesignWare magic key not found, check base "
 			    "address. Stopping initialization");
 		return -EIO;
@@ -643,7 +641,8 @@ static int i2c_dw_initialize(const struct device *dev)
 	 * IC_MAX_SPEED_MODE in the hardware.  If it does support high speed we
 	 * can move provide support for it
 	 */
-	if (regs->ic_con.bits.speed == I2C_DW_SPEED_HIGH) {
+	ic_con.raw = read_con(reg_base);
+	if (ic_con.bits.speed == I2C_DW_SPEED_HIGH) {
 		LOG_DBG("I2C: high speed supported");
 		dw->support_hs_mode = true;
 	} else {

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -116,6 +116,41 @@ struct i2c_dw_dev_config {
 	bool			support_hs_mode;
 };
 
+#define Z_REG_READ(__sz) sys_read##__sz
+#define Z_REG_WRITE(__sz) sys_write##__sz
+#define Z_REG_SET_BIT sys_set_bit
+#define Z_REG_CLEAR_BIT sys_clear_bit
+#define Z_REG_TEST_BIT sys_test_bit
+
+#define DEFINE_MM_REG_READ(__reg, __off, __sz)				\
+	static inline uint32_t read_##__reg(uint32_t addr)			\
+	{								\
+		return Z_REG_READ(__sz)(addr + __off);			\
+	}
+#define DEFINE_MM_REG_WRITE(__reg, __off, __sz)				\
+	static inline void write_##__reg(uint32_t data, uint32_t addr)	\
+	{								\
+		Z_REG_WRITE(__sz)(data, addr + __off);			\
+	}
+
+#define DEFINE_SET_BIT_OP(__reg_bit, __reg_off, __bit)			\
+	static inline void set_bit_##__reg_bit(uint32_t addr)		\
+	{								\
+		Z_REG_SET_BIT(addr + __reg_off, __bit);			\
+	}
+
+#define DEFINE_CLEAR_BIT_OP(__reg_bit, __reg_off, __bit)		\
+	static inline void clear_bit_##__reg_bit(uint32_t addr)		\
+	{								\
+		Z_REG_CLEAR_BIT(addr + __reg_off, __bit);		\
+	}
+
+#define DEFINE_TEST_BIT_OP(__reg_bit, __reg_off, __bit)			\
+	static inline int test_bit_##__reg_bit(uint32_t addr)		\
+	{								\
+		return Z_REG_TEST_BIT(addr + __reg_off, __bit);		\
+	}
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -13,61 +13,26 @@ extern "C" {
 #endif
 
 /*  IC_CON bits */
-#define IC_CON_TX_INTR_MODE			(1 << 8)
-#define IC_CON_STOP_DET_IFADDR			(1 << 7)
-#define IC_CON_SLAVE_DISABLE			(1 << 6)
-#define IC_CON_RESTART_EN			(1 << 5)
-#define IC_CON_10BIT_ADDR_MASTER		(1 << 4)
-#define IC_CON_10BIT_ADDR_SLAVE			(1 << 3)
-#define IC_CON_SPEED_MASK			(0x3 << 1)
-#define IC_CON_MASTER_MODE			(1 << 0)
-
 union ic_con_register {
-	uint16_t                raw;
+	uint32_t                raw;
 	struct {
-		uint16_t         master_mode : 1 __packed;
-		uint16_t         speed : 2 __packed;
-		uint16_t         addr_slave_10bit : 1 __packed;
-		uint16_t         addr_master_10bit : 1 __packed;
-		uint16_t         restart_en : 1 __packed;
-		uint16_t         slave_disable : 1 __packed;
-		uint16_t         stop_det : 1 __packed;
-		uint16_t         tx_empty_ctl : 1 __packed;
-		uint16_t         rx_fifo_full : 1 __packed;
+		uint32_t         master_mode : 1 __packed;
+		uint32_t         speed : 2 __packed;
+		uint32_t         addr_slave_10bit : 1 __packed;
+		uint32_t         addr_master_10bit : 1 __packed;
+		uint32_t         restart_en : 1 __packed;
+		uint32_t         slave_disable : 1 __packed;
+		uint32_t         stop_det : 1 __packed;
+		uint32_t         tx_empty_ctl : 1 __packed;
+		uint32_t         rx_fifo_full : 1 __packed;
 	} bits;
 };
-
 
 /* IC_DATA_CMD bits */
 #define IC_DATA_CMD_DAT_MASK		0xFF
 #define IC_DATA_CMD_CMD			(1 << 8)
 #define IC_DATA_CMD_STOP		(1 << 9)
 #define IC_DATA_CMD_RESTART		(1 << 10)
-
-union ic_data_cmd_register {
-	uint16_t                raw;
-	struct {
-	       uint16_t         dat : 8 __packed;
-	       uint16_t         cmd : 1 __packed;
-	       uint16_t         stop : 1 __packed;
-	       uint16_t         restart : 1 __packed;
-	       uint16_t         reserved : 4 __packed;
-	} bits;
-};
-
-/* IC_ENABLE register bits */
-#define IC_ENABLE_ENABLE		(1 << 0)
-#define IC_ENABLE_ABORT			(1 << 1)
-
-union ic_enable_register {
-	uint16_t		raw;
-	struct {
-		uint16_t	enable : 1 __packed;
-		uint16_t	abort : 1 __packed;
-		uint16_t	reserved : 13 __packed;
-	} bits;
-};
-
 
 /* DesignWare Interrupt bits positions */
 #define DW_INTR_STAT_RX_UNDER		(1 << 0)
@@ -85,173 +50,120 @@ union ic_enable_register {
 #define DW_INTR_STAT_RESTART_DET	(1 << 12)
 #define DW_INTR_STAT_MST_ON_HOLD	(1 << 13)
 
-
 union ic_interrupt_register {
-	uint16_t			raw;
+	uint32_t			raw;
 	struct {
-		uint16_t	rx_under : 1 __packed;
-		uint16_t	rx_over : 1 __packed;
-		uint16_t	rx_full : 1 __packed;
-		uint16_t	tx_over : 1 __packed;
-		uint16_t	tx_empty : 1 __packed;
-		uint16_t	rd_req : 1 __packed;
-		uint16_t	tx_abrt : 1 __packed;
-		uint16_t	rx_done : 1 __packed;
-		uint16_t	activity : 1 __packed;
-		uint16_t	stop_det : 1 __packed;
-		uint16_t	start_det : 1 __packed;
-		uint16_t	gen_call : 1 __packed;
-		uint16_t	restart_det : 1 __packed;
-		uint16_t	mst_on_hold : 1 __packed;
-		uint16_t	reserved : 2 __packed;
+		uint32_t	rx_under : 1 __packed;
+		uint32_t	rx_over : 1 __packed;
+		uint32_t	rx_full : 1 __packed;
+		uint32_t	tx_over : 1 __packed;
+		uint32_t	tx_empty : 1 __packed;
+		uint32_t	rd_req : 1 __packed;
+		uint32_t	tx_abrt : 1 __packed;
+		uint32_t	rx_done : 1 __packed;
+		uint32_t	activity : 1 __packed;
+		uint32_t	stop_det : 1 __packed;
+		uint32_t	start_det : 1 __packed;
+		uint32_t	gen_call : 1 __packed;
+		uint32_t	restart_det : 1 __packed;
+		uint32_t	mst_on_hold : 1 __packed;
+		uint32_t	reserved : 2 __packed;
 	} bits;
 };
-
 
 /* IC_TAR */
 union ic_tar_register {
-	uint16_t		raw;
-	struct {
-		uint16_t	ic_tar : 10 __packed;
-		uint16_t	gc_or_start : 1 __packed;
-		uint16_t	special : 1 __packed;
-		uint16_t	ic_10bitaddr_master : 1 __packed;
-		uint16_t	reserved : 3 __packed;
-	} bits;
-};
-
-
-/* IC_SAR */
-union ic_sar_register {
-	uint16_t		raw;
-	struct {
-		uint16_t	ic_sar : 10 __packed;
-		uint16_t	reserved : 6 __packed;
-	} bits;
-};
-
-
-/* IC_STATUS */
-union ic_status_register {
 	uint32_t		raw;
 	struct {
-		uint32_t	activity : 1 __packed;
-		uint32_t	tfnf : 1 __packed;
-		uint32_t	tfe : 1 __packed;
-		uint32_t	rfne : 1 __packed;
-		uint32_t	rff : 1 __packed;
-		uint32_t	mst_activity : 1 __packed;
-		uint32_t	slv_activity : 1 __packed;
-		uint32_t	reserved : 24 __packed;
+		uint32_t	ic_tar : 10 __packed;
+		uint32_t	gc_or_start : 1 __packed;
+		uint32_t	special : 1 __packed;
+		uint32_t	ic_10bitaddr_master : 1 __packed;
+		uint32_t	reserved : 3 __packed;
 	} bits;
 };
 
+#define DW_IC_REG_CON				(0x00)
+#define DW_IC_REG_TAR				(0x04)
+#define DW_IC_REG_SAR				(0x08)
+#define DW_IC_REG_DATA_CMD			(0x10)
+#define DW_IC_REG_SS_SCL_HCNT		(0x14)
+#define DW_IC_REG_SS_SCL_LCNT		(0x18)
+#define DW_IC_REG_FS_SCL_HCNT		(0x1C)
+#define DW_IC_REG_FS_SCL_LCNT		(0x20)
+#define DW_IC_REG_HS_SCL_HCNT		(0x24)
+#define DW_IC_REG_HS_SCL_LCNT		(0x28)
+#define DW_IC_REG_INTR_STAT			(0x2C)
+#define DW_IC_REG_INTR_MASK			(0x30)
+#define DW_IC_REG_RX_TL				(0x38)
+#define DW_IC_REG_TX_TL				(0x3C)
+#define DW_IC_REG_CLR_INTR			(0x40)
+#define DW_IC_REG_CLR_STOP_DET		(0x60)
+#define DW_IC_REG_ENABLE			(0x6C)
+#define DW_IC_REG_STATUS			(0x70)
+#define DW_IC_REG_TXFLR				(0x74)
+#define DW_IC_REG_RXFLR				(0x78)
+#define DW_IC_REG_FS_SPKLEN			(0xA0)
+#define DW_IC_REG_HS_SPKLEN			(0xA4)
+#define DW_IC_REG_COMP_TYPE			(0xFC)
 
-union ic_comp_param_1_register {
-	uint32_t			raw;
-	struct {
-		uint32_t		apb_data_width : 2 __packed;
-		uint32_t		max_speed_mode : 2 __packed;
-		uint32_t		hc_count_values : 1 __packed;
-		uint32_t		intr_io : 1 __packed;
-		uint32_t		has_dma : 1 __packed;
-		uint32_t		add_encoded_params : 1 __packed;
-		uint32_t		rx_buffer_depth : 8 __packed;
-		uint32_t		tx_buffer_depth : 8 __packed;
-		uint32_t		reserved : 7 __packed;
-	} bits;
-};
+/* CON Bit */
+#define DW_IC_CON_MASTER_MODE_BIT		(0)
+
+DEFINE_TEST_BIT_OP(con_master_mode, DW_IC_REG_CON, DW_IC_CON_MASTER_MODE_BIT)
+DEFINE_MM_REG_WRITE(con, DW_IC_REG_CON, 32)
+DEFINE_MM_REG_READ(con, DW_IC_REG_CON, 32)
+
+DEFINE_MM_REG_WRITE(cmd_data, DW_IC_REG_DATA_CMD, 32)
+DEFINE_MM_REG_READ(cmd_data, DW_IC_REG_DATA_CMD, 32)
+
+DEFINE_MM_REG_WRITE(ss_scl_hcnt, DW_IC_REG_SS_SCL_HCNT, 32)
+DEFINE_MM_REG_WRITE(ss_scl_lcnt, DW_IC_REG_SS_SCL_LCNT, 32)
+
+DEFINE_MM_REG_WRITE(fs_scl_hcnt, DW_IC_REG_FS_SCL_HCNT, 32)
+DEFINE_MM_REG_WRITE(fs_scl_lcnt, DW_IC_REG_FS_SCL_LCNT, 32)
+
+DEFINE_MM_REG_WRITE(hs_scl_hcnt, DW_IC_REG_HS_SCL_HCNT, 32)
+DEFINE_MM_REG_WRITE(hs_scl_lcnt, DW_IC_REG_HS_SCL_LCNT, 32)
 
 
-/*
- * instantiate this like:
- *  volatile struct i2c_dw_registers *regs = (struct i2c_dw_regs *)0x80000000;
- *
- *  If this is being set as a global, use the following change to avoid the
- *  base pointer from being reloaded after function calls:
- *  volatile struct i2c_dw_regs* const *regs = (struct i2c_dw_regs*)0x80000000;
- *
- *  This will allow access to the registers like so:
- *  x = regs->ctrlreg;
- *  regs->ctrlreg = newval;
- */
-struct i2c_dw_registers {
-	union ic_con_register ic_con;	/* offset 0x00 */
-	uint16_t dummy1;
-	union ic_tar_register ic_tar;	/* offset 0x04 */
-	uint16_t dummy2;
-	union ic_sar_register ic_sar;	/* offset 0x08 */
-	uint16_t dummy3;
-	uint16_t ic_hs_maddr;		/* offset 0x0C */
-	uint16_t dummy4;
-	union ic_data_cmd_register ic_data_cmd;		/* offset 0x10 */
-	uint16_t dummy5;
-	uint16_t ic_ss_scl_hcnt;	/* offset 0x14 */
-	uint16_t dummy6;
-	uint16_t ic_ss_scl_lcnt;	/* offset 0x18 */
-	uint16_t dummy7;
-	uint16_t ic_fs_scl_hcnt;	/* offset 0x1C */
-	uint16_t dummy8;
-	uint16_t ic_fs_scl_lcnt;	/* offset 0x20 */
-	uint16_t dummy9;
-	uint16_t ic_hs_scl_hcnt;	/* offset 0x24 */
-	uint16_t dummy10;
-	uint16_t ic_hs_scl_lcnt;	/* offset 0x28 */
-	uint16_t dummy11;
-	union ic_interrupt_register ic_intr_stat;	/* offset 0x2C */
-	uint16_t dummy12;
-	union ic_interrupt_register ic_intr_mask;	/* offset 0x30 */
-	uint16_t dummy13;
-	union ic_interrupt_register ic_raw_intr_stat;	/* offset 0x34 */
-	uint16_t dummy14;
-	uint16_t ic_rx_tl;		/* offset 0x38 */
-	uint16_t dummy15;
-	uint16_t ic_tx_tl;		/* offset 0x3C */
-	uint16_t dummy16;
-	uint16_t ic_clr_intr;		/* offset 0x40 */
-	uint16_t dummy17;
-	uint16_t ic_clr_rx_under;	/* offset 0x44 */
-	uint16_t dummy18;
-	uint16_t ic_clr_rx_over;	/* offset 0x48 */
-	uint16_t dummy19;
-	uint16_t ic_clr_tx_over;	/* offset 0x4C */
-	uint16_t dummy20;
-	uint16_t ic_clr_rd_req;		/* offset 0x50 */
-	uint16_t dummy21;
-	uint16_t ic_clr_tx_abrt;	/* offset 0x54 */
-	uint16_t dummy22;
-	uint16_t ic_clr_rx_done;	/* offset 0x58 */
-	uint16_t dummy23;
-	uint16_t ic_clr_activity;	/* offset 0x5C */
-	uint16_t dummy24;
-	uint16_t ic_clr_stop_det;	/* offset 0x60 */
-	uint16_t dummy25;
-	uint16_t ic_clr_start_det;	/* offset 0x64 */
-	uint16_t dummy26;
-	uint16_t ic_clr_gen_call;	/* offset 0x68 */
-	uint16_t dummy27;
-	union ic_enable_register ic_enable;	/* offset 0x6c */
-	uint16_t dummy28;
-	union ic_status_register ic_status;	/* offset 0x70 */
-	uint32_t ic_txflr;		/* offset 0x74 */
-	uint32_t ic_rxflr;		/* offset 0x78 */
-	uint32_t ic_sda_hold;		/* offset 0x7C */
-	uint32_t ic_tx_abrt_source;	/* offset 0x80 */
-	uint32_t ic_slv_data_nack_only; /* offset 0x84 */
-	uint32_t ic_dma_cr;		/* offset 0x88 */
-	uint32_t ic_dma_tdlr;		/* offset 0x8C */
-	uint32_t ic_dma_rdlr;		/* offset 0x90 */
-	uint32_t ic_sda_setup;		/* offset 0x94 */
-	uint32_t ic_ack_general_call;	/* offset 0x98 */
-	uint32_t ic_enable_status;	/* offset 0x9C */
-	uint32_t ic_fs_spklen;		/* offset 0xA0 */
-	uint32_t ic_hs_spklen;		/* offset 0xA4 */
-	uint16_t ic_clr_restart_det;	/* offset 0xA8 */
-	uint8_t	 filler[74];
-	union ic_comp_param_1_register ic_comp_param_1;	/* offset 0xF4 */
-	uint32_t ic_comp_version;	/* offset 0xF8 */
-	uint32_t ic_comp_type;		/* offset 0xFC */
-};
+
+DEFINE_MM_REG_READ(intr_stat, DW_IC_REG_INTR_STAT, 32)
+#define DW_IC_INTR_STAT_TX_ABRT_BIT		(6)
+DEFINE_TEST_BIT_OP(intr_stat_tx_abrt, DW_IC_REG_INTR_STAT, DW_IC_INTR_STAT_TX_ABRT_BIT)
+
+DEFINE_MM_REG_WRITE(intr_mask, DW_IC_REG_INTR_MASK, 32)
+#define DW_IC_INTR_MASK_TX_EMPTY_BIT		(4)
+DEFINE_CLEAR_BIT_OP(intr_mask_tx_empty, DW_IC_REG_INTR_MASK, DW_IC_INTR_MASK_TX_EMPTY_BIT)
+
+DEFINE_MM_REG_WRITE(rx_tl, DW_IC_REG_RX_TL, 32)
+DEFINE_MM_REG_WRITE(tx_tl, DW_IC_REG_TX_TL, 32)
+
+DEFINE_MM_REG_READ(clr_intr, DW_IC_REG_CLR_INTR, 32)
+DEFINE_MM_REG_READ(clr_stop_det, DW_IC_REG_CLR_STOP_DET, 32)
+
+#define DW_IC_ENABLE_EN_BIT		(0)
+DEFINE_CLEAR_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
+DEFINE_SET_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
+
+
+#define DW_IC_STATUS_ACTIVITY_BIT	(0)
+#define DW_IC_STATUS_TFNT_BIT	(1)
+#define DW_IC_STATUS_RFNE_BIT	(3)
+DEFINE_TEST_BIT_OP(status_activity, DW_IC_REG_STATUS, DW_IC_STATUS_ACTIVITY_BIT)
+DEFINE_TEST_BIT_OP(status_tfnt, DW_IC_REG_STATUS, DW_IC_STATUS_TFNT_BIT)
+DEFINE_TEST_BIT_OP(status_rfne, DW_IC_REG_STATUS, DW_IC_STATUS_RFNE_BIT)
+
+DEFINE_MM_REG_READ(txflr, DW_IC_REG_TXFLR, 32)
+DEFINE_MM_REG_READ(rxflr, DW_IC_REG_RXFLR, 32)
+
+DEFINE_MM_REG_READ(fs_spklen, DW_IC_REG_FS_SPKLEN, 32)
+DEFINE_MM_REG_READ(hs_spklen, DW_IC_REG_HS_SPKLEN, 32)
+
+DEFINE_MM_REG_READ(comp_type, DW_IC_REG_COMP_TYPE, 32)
+DEFINE_MM_REG_READ(tar, DW_IC_REG_TAR, 32)
+DEFINE_MM_REG_WRITE(tar, DW_IC_REG_TAR, 32)
+DEFINE_MM_REG_WRITE(sar, DW_IC_REG_SAR, 32)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Current DW I2C driver uses 32 bit access for some registers and
16 bit access for others. So if DW I2C IP is connected via bus
which doesn't support 16 bit access we will get bus error.

Fix that by switching to 32 bit access only instead of 16 and 32 bit mix.
