### PR TITLE
dts: psl: npcx: add PSL input pads support for ultra-low power mode.

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -49,10 +49,19 @@
 			min-residency-us = <201000>;
 		};
 	};
+
+	vsby-psl-in-list {
+		psl-in-pads = <&psl_in1>; /* Use PSL_IN1 as detection pins */
+	};
 };
 
 &cpu0 {
 	cpu-power-states = <&suspend_to_idle0 &suspend_to_idle1>;
+};
+
+&psl_in1 {
+	/* A falling edge detection type for PSL_IN1 */
+	flag = <NPCX_PSL_FALLING_EDGE>;
 };
 
 /* Overwirte default device properties with overlays in board dt file here. */

--- a/dts/arm/nuvoton/npcx/npcx7-psl-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-psl-ctrl-map.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	def-psl-conf-list {
+		compatible = "nuvoton,npcx-pslctrl-conf";
+
+		/* PSL input IO configurations */
+		psl_in1: psl-iod2 {
+			offset = <0>; /* PSL_IN1/PIND2 */
+			pinctrl-0 = <&altd_npsl_in1_sl>;
+			polarity-0 = <&altd_psl_in1_ahi>;
+		};
+		psl_in2: psl-io00 {
+			offset = <1>; /* PSL_IN2/PIN00 */
+			pinctrl-0 = <&altd_npsl_in2_sl>;
+			polarity-0 = <&altd_psl_in2_ahi>;
+		};
+		psl_in3: psl-io01 {
+			offset = <2>; /* PSL_IN3/PIN01 */
+			pinctrl-0 = <&altd_psl_in3_sl>;
+			polarity-0 = <&altd_psl_in3_ahi>;
+		};
+		psl_in4: psl-io02 {
+			offset = <3>; /* PSL_IN4/PIN02 */
+			pinctrl-0 = <&altd_psl_in4_sl>;
+			polarity-0 = <&altd_psl_in4_ahi>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -10,6 +10,7 @@
 #include <dt-bindings/espi/npcx_espi.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/npcx-pinctrl.h>
 #include <dt-bindings/pwm/pwm.h>
 #include <dt-bindings/sensor/npcx_tach.h>
 
@@ -23,6 +24,8 @@
 #include "npcx/npcx7-espi-vws-map.dtsi"
 /* NPCX7 series low-voltage io controls mapping table */
 #include "npcx/npcx7-lvol-ctrl-map.dtsi"
+/* NPCX7 series power-switch-logic (PSL) io controls mapping table */
+#include "npcx/npcx7-psl-ctrl-map.dtsi"
 
 / {
 	cpus {
@@ -93,6 +96,20 @@
 		 * lvol_io_pads = <&lvol_io90 &lvol_io87>;
 		 */
 		lvol_io_pads = <>;
+	};
+
+	vsby-psl-in-list {
+		compatible = "nuvoton,npcx-pslctrl-def";
+		/* Put Power Switch Logic (PSL) input pads which detect the
+		 * wake-up events and turn on core power supply (VCC1) from
+		 * standby power state (ultra-low-power mode) into "psl-in-pads"
+		 * property. For example, if PSL input 1 that is plan to detect
+		 * a 'falling edge' event, this property should be:
+		 *   psl-in-pads = <&psl_in1>;
+		 * And the flag property in psl_in1 should change to
+		 *   flag = <NPCX_PSL_FALLING_EDGE>;
+		 */
+		psl-in-pads = <>;
 	};
 
 	soc {
@@ -716,6 +733,13 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 6>;
 			label = "TACH_2";
 			status = "disabled";
+		};
+
+		psl_out: psl-out {
+			compatible = "nuvoton,npcx-psl-out";
+			controller = <&gpio8>;
+			pin = <5>;
+			label = "PSL_OUT";
 		};
 	};
 };

--- a/dts/bindings/gpio/nuvoton,npcx-psl-out.yaml
+++ b/dts/bindings/gpio/nuvoton,npcx-psl-out.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX-PSL (Power Switch Logic) Output node
+
+compatible: "nuvoton,npcx-psl-out"
+
+include: [base.yaml]
+
+properties:
+    controller:
+        type: phandle
+        required: true
+        description: gpio controller to handle PSL output pad.
+
+    pin:
+        type: int
+        required: true
+        description: pin in gpio controller for PSL output.

--- a/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-conf.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-conf.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton NPCX pads configuration map between Pin Mux controller and
+             Power Switch Logic (PSL) controller driver instances.
+
+compatible: "nuvoton,npcx-pslctrl-conf"
+
+child-binding:
+   description: Child node to present the mapping between pin-mux controller
+                and its power switch logic (PSL) support
+   properties:
+      offset:
+         type: int
+         required: true
+         description: Offset in PSL_CTS for status and detection mode.
+
+      pinctrl-0:
+         type: phandles
+         required: true
+         description: Pinmux controller configuration for PSL io pads.
+
+      polarity-0:
+         type: phandles
+         required: true
+         description: Active polarity configuration for PSL io pads.
+
+      flag:
+         type: int
+         required: false
+         description: |
+            Detection mode and type for wake-up event detection.
+            5 = Configures PSL input in detecting rising edge.
+            6 = Configures PSL input in in detecting level high state.
+            9 = Configures PSL input in detecting falling edge.
+            10 = Configures PSL input in detecting level low state.
+         enum:
+            - 5
+            - 6
+            - 9
+            - 10

--- a/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-def.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-def.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX Default Power Switch Logic (PSL) input pads configurations
+
+compatible: "nuvoton,npcx-pslctrl-def"
+
+include: [base.yaml]
+
+properties:
+    psl-in-pads:
+        type: phandles
+        required: true
+        description: |
+            list of PSL input pads that are in charge of detecting the wake-up
+            signals and the related circuit will turn on core power supply
+            (VCC1) from standby power state (ultra-low-power mode) later.

--- a/include/dt-bindings/pinctrl/npcx-pinctrl.h
+++ b/include/dt-bindings/pinctrl/npcx-pinctrl.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NPCX_PINCTRL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NPCX_PINCTRL_H_
+
+/**
+ * @brief NPCX specific PIN configuration flag
+ *
+ * Pin configuration is coded with the following fields
+ *    Power Switch Logic (PSL) [ 0 : 3 ]
+ *    Reserved                 [ 4 : 31]
+ *
+ * Applicable to NPCX7 series.
+ */
+
+/*
+ * Power Switch Logic (PSL) input wake-up mode is sensitive to edge signals.
+ *
+ * This is a component flag that should be combined with other
+ * `NPCX_PSL_ACTIVE_*` flags to produce a meaningful configuration.
+ */
+#define NPCX_PSL_MODE_EDGE                   (1 << 0)
+
+/*
+ * Power Switch Logic (PSL) input wake-up mode is sensitive to logical levels.
+ *
+ * This is a component flag that should be combined with other
+ * `NPCX_PSL_ACTIVE_*` flags to produce a meaningful configuration.
+ */
+#define NPCX_PSL_MODE_LEVEL                  (1 << 1)
+
+/*
+ * The active polarity of Power Switch Logic (PSL) input is high level or
+ * low-to-high transition.
+ *
+ * This is a component flag that should be combined with other
+ * `NPCX_PSL_MODE_*` flags to produce a meaningful configuration.
+ */
+#define NPCX_PSL_ACTIVE_HIGH                 (1 << 2)
+
+/*
+ * The active polarity of Power Switch Logic (PSL) input is low level or
+ * high-to-low transition.
+ *
+ * This is a component flag that should be combined with other
+ * `NPCX_PSL_MODE_*` flags to produce a meaningful configuration.
+ */
+#define NPCX_PSL_ACTIVE_LOW                  (1 << 3)
+
+/*
+ * Configures Power Switch Logic (PSL) input in detecting rising edge.
+ *
+ * This is used for describing the 'flag' property from PSL input device with
+ * 'nuvoton,npcx-pslctrl-conf' compatible.
+ */
+#define NPCX_PSL_RISING_EDGE (NPCX_PSL_MODE_EDGE | NPCX_PSL_ACTIVE_HIGH)
+
+/*
+ * Configures Power Switch Logic (PSL) input in detecting falling edge.
+ *
+ * This is used for describing the 'flag' property from PSL input device with
+ * 'nuvoton,npcx-pslctrl-conf' compatible.
+ */
+#define NPCX_PSL_FALLING_EDGE (NPCX_PSL_MODE_EDGE | NPCX_PSL_ACTIVE_LOW)
+
+/*
+ * Configures Power Switch Logic (PSL) input in detecting level high state (has
+ * logical value '1').
+ *
+ * This is used for describing the 'flag' property from PSL input device with
+ * 'nuvoton,npcx-pslctrl-conf' compatible.
+ */
+#define NPCX_PSL_LEVEL_HIGH (NPCX_PSL_MODE_LEVEL | NPCX_PSL_ACTIVE_HIGH)
+
+/*
+ * Configures Power Switch Logic (PSL) input in detecting level low state (has
+ * logical value '0').
+ *
+ * This is used for describing the 'flag' property from PSL input device with
+ * 'nuvoton,npcx-pslctrl-conf' compatible.
+ */
+#define NPCX_PSL_LEVEL_LOW (NPCX_PSL_MODE_LEVEL | NPCX_PSL_ACTIVE_LOW)
+
+#endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NPCX_PINCTRL_H_ */

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -542,4 +542,137 @@
 			NPCX_DT_LVOL_ITEMS_BY_IDX, _)   \
 	}
 
+/**
+ * @brief Get a node from path '/vsby-psl-in-list' which has a property
+ *        'psl-in-pads' contains Power Switch Logic (PSL) input pads which are
+ *        in charge of detecting wake-up events on VSBY power domain.
+ *
+ * @return node identifier with that path.
+ */
+#define NPCX_DT_NODE_PSL_IN_LIST  DT_PATH(vsby_psl_in_list)
+
+/**
+ * @brief Length of npcx_psl_in structures in 'psl-in-pads' property
+ *
+ * @return length of 'psl-in-pads' prop which type is 'phandles'
+ */
+#define NPCX_DT_PSL_IN_ITEMS_LEN DT_PROP_LEN(NPCX_DT_NODE_PSL_IN_LIST, \
+								psl_in_pads)
+
+/**
+ * @brief Get phandle from 'psl-in-pads' prop which type is 'phandles' at index
+ *        'i'
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return phandle from 'psl-in-pads' prop at index 'i'
+ */
+#define NPCX_DT_PHANDLE_FROM_PSL_IN_NODE(i) \
+	DT_PHANDLE_BY_IDX(NPCX_DT_NODE_PSL_IN_LIST, psl_in_pads, i)
+
+/**
+ * @brief Get phandle from 'pinctrl-0' prop which type is 'phandles' at index
+ *        'i'
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return phandle from 'pinctrl-0' prop at index 'i'
+ */
+#define NPCX_DT_PHANDLE_FROM_PSL_PINMUX_NODE(i) \
+	DT_PHANDLE(NPCX_DT_PHANDLE_FROM_PSL_IN_NODE(i), pinctrl_0)
+
+/**
+ * @brief Get phandle from 'polarity-0' prop which type is 'phandles' at index
+ *        'i'
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return phandle from 'polarity-0' prop at index 'i'
+ */
+#define NPCX_DT_PHANDLE_FROM_PSL_POLARITY_NODE(i) \
+	DT_PHANDLE(NPCX_DT_PHANDLE_FROM_PSL_IN_NODE(i), polarity_0)
+
+/**
+ * @brief Construct a npcx_alt structure from 'pinctrl-0' property at index 'i'
+ *        of 'psl-in-pads' prop.
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return npcx_alt item from 'pinctrl-0' property at index 'i'
+ */
+#define NPCX_DT_PSL_IN_ALT_CONF_BY_IDX(i)                                         \
+	{                                                                         \
+	  .group = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_PINMUX_NODE(i), alts, group),  \
+	  .bit = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_PINMUX_NODE(i), alts, bit),      \
+	  .inverted = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_PINMUX_NODE(i), alts, inv), \
+	},
+
+/**
+ * @brief Construct a npcx_alt structure from 'polarity-0' property at index 'i'
+ *        of 'psl-in-pads' prop.
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return npcx_alt item from 'pinctrl-0' property at index 'i'
+ */
+#define NPCX_DT_PSL_IN_POL_CONF_BY_IDX(i)                                                 \
+	{                                                                                 \
+		.group = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_POLARITY_NODE(i), alts, group),  \
+		.bit = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_POLARITY_NODE(i), alts, bit),      \
+		.inverted = DT_PHA(NPCX_DT_PHANDLE_FROM_PSL_POLARITY_NODE(i), alts, inv), \
+	},
+
+/**
+ * @brief Construct a npcx_psl_in structure from 'psl-in-pads' property at index
+ *        'i'
+ *
+ * @param i index of 'psl-in-pads' prop which type is 'phandles'
+ * @return npcx_psl_in item from 'psl-in-pads' property at index 'i'
+ */
+#define NPCX_DT_PSL_IN_ITEMS_BY_IDX(i, _)                                      \
+	{                                                                      \
+		.flag = DT_PROP(NPCX_DT_PHANDLE_FROM_PSL_IN_NODE(i), flag),    \
+		.offset = DT_PROP(NPCX_DT_PHANDLE_FROM_PSL_IN_NODE(i), offset),\
+		.pinctrl = NPCX_DT_PSL_IN_ALT_CONF_BY_IDX(i)                   \
+		.polarity = NPCX_DT_PSL_IN_POL_CONF_BY_IDX(i)                  \
+	},
+
+/**
+ * @brief Macro function to construct a list of npcx_psl_in items by
+ *        UTIL_LISTIFY func.
+ *
+ * Example devicetree fragment:
+ *    / {
+ *          vsby-psl-in-list {
+ *              psl-in-pads = <&psl_in1>;
+ *          };
+ *	};
+ *   &psl_in1 {
+ *	flag = <NPCX_PSL_FALLING_EDGE>;
+ *   };
+ *
+ * Example usage:
+ * static const struct npcx_psl_in psl_in_confs[] = NPCX_DT_PSL_IN_ITEMS_LIST;
+ *
+ * @return an array of npcx_psl_in items which configures PSL input pads
+ */
+#define NPCX_DT_PSL_IN_ITEMS_LIST {                       \
+		UTIL_LISTIFY(NPCX_DT_PSL_IN_ITEMS_LEN,    \
+			NPCX_DT_PSL_IN_ITEMS_BY_IDX, _)   \
+	}
+
+/**
+ * @brief Get base address of corresponding GPIO controller for enabling PSL
+ *        output.
+ *
+ * @param @param inst number for devices with compatible 'nuvoton_npcx_psl_out'.
+ * @return base address of corresponding GPIO controller
+ */
+#define NPCX_DT_PSL_OUT_CONTROLLER(inst) DT_REG_ADDR_BY_IDX(DT_PHANDLE_BY_IDX( \
+		DT_INST(inst, nuvoton_npcx_psl_out), controller, 0), 0)
+
+/**
+ * @brief Get pin of corresponding GPIO controller for enabling PSL output.
+ *
+ * @param @param inst number for devices with compatible 'nuvoton_npcx_psl_out'.
+ * @return pin of corresponding GPIO controller.
+ */
+#define NPCX_DT_PSL_OUT_PIN(inst) DT_PROP(DT_INST(inst, nuvoton_npcx_psl_out), \
+							pin)
+
 #endif /* _NUVOTON_NPCX_SOC_DT_H_ */

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -37,6 +37,27 @@ struct npcx_lvol {
 };
 
 /**
+ * @brief NPCX Power Switch Logic (PSL) input configuration structure
+ *
+ * Used to configure PSL input pad which detect the wake-up events and switch
+ * core power supply (VCC1) on from standby power state (ultra-low-power mode).
+ */
+struct npcx_psl_in {
+	/** flag to indicate the detection mode and type. */
+	uint32_t flag;
+	/** offset in PSL_CTS for status and detection mode. */
+	uint32_t offset;
+	/** Device Alternate Function. (DEVALT) register/bit for PSL pin-muxing.
+	 * It determines whether PSL input or GPIO selected to the pad.
+	 */
+	struct npcx_alt pinctrl;
+	/** Device Alternate Function. (DEVALT) register/bit for PSL polarity.
+	 * It determines active polarity of wake-up signal via PSL input.
+	 */
+	struct npcx_alt polarity;
+};
+
+/**
  * @brief Select device pin-mux to I/O or its alternative functionality
  *
  * Example devicetree fragment:
@@ -79,6 +100,34 @@ void npcx_pinctrl_mux_configure(const struct npcx_alt *alts_list,
  * @param port index for i2c port pads
  */
 void npcx_pinctrl_i2c_port_sel(int controller, int port);
+
+/**
+ * @brief Set PSL output pad to inactive level.
+ *
+ * The PSL_OUT output pad should be connected to the control pin of either the
+ * switch or the power supply used generate the VCC1 power from the VSBY power.
+ * When PSL_OUT is high (active), the Core Domain power supply (VCC1) is turned
+ * on. When PSL_OUT is low (inactive) by setting bit of related PDOUT, VCC1 is
+ * turned off for entering standby power state (ultra-low-power mode).
+ */
+void npcx_pinctrl_psl_output_set_inactive(void);
+
+/**
+ * @brief Configure PSL input pads in psl_in_pads list
+ *
+ * Used to configure PSL input pads list from "psl-in-pads" property which
+ * detect the wake-up events and the related circuit will turn on core power
+ * supply (VCC1) from standby power state (ultra-low-power mode) later.
+ */
+void npcx_pinctrl_psl_input_configure(void);
+
+/**
+ * @brief Get the asserted status of PSL input pads
+ *
+ * @param i index of 'psl-in-pads' prop
+ * @return 1 is asserted, otherwise de-asserted.
+ */
+bool npcx_pinctrl_psl_input_asserted(int i);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This CL introduces the Power Switch Logic (PSL) pads which detect the
wake-up events and turn on core power supply (VCC1) from standby power
state (ultra-low power mode) in npcx device-tree file.

By adding PSL input-pad objects, psl_in1, psl_in2, and so on, into
'psl_in_pads' property and configuring their 'flag' properties, the
related driver will configure them via soc specific functions later.

For example, if PSL input 1 pad that is plan to detect a 'falling edge'
event, this property should be:
	vsby_psl_in_list {
		psl_in_pads = <&psl_in1>;
	};

And the flag property in psl_in1 should change to
	&psl_in1 {
		flag = <(NPCX_PSL_MODE_EDGE | NPCX_PSL_ACTIVE_LOW)>;
	};

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>