### PR TITLE
Network connection manager fixes

### DIFF
--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -69,6 +69,10 @@ static void conn_mgr_notify_status(int index)
 {
 	struct net_if *iface = net_if_get_by_index(index + 1);
 
+	if (iface == NULL) {
+		return;
+	}
+
 	if (iface_states[index] & NET_STATE_CONNECTED) {
 		NET_DBG("Iface %d (%p) connected",
 			net_if_get_by_iface(iface), iface);
@@ -86,6 +90,11 @@ static void conn_mgr_act_on_changes(void)
 
 	for (idx = 0; idx < ARRAY_SIZE(iface_states); idx++) {
 		enum net_conn_mgr_state state;
+
+		if (iface_states[idx] == 0) {
+			/* This interface is not used */
+			continue;
+		}
 
 		if (!(iface_states[idx] & NET_STATE_CHANGED)) {
 			continue;
@@ -193,7 +202,13 @@ void net_conn_mgr_resend_status(void)
 
 static int conn_mgr_init(const struct device *dev)
 {
+	int i;
+
 	ARG_UNUSED(dev);
+
+	for (i = 0; i < ARRAY_SIZE(iface_states); i++) {
+		iface_states[i] = 0;
+	}
 
 	k_thread_start(conn_mgr);
 

--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -70,10 +70,12 @@ static void conn_mgr_notify_status(int index)
 	struct net_if *iface = net_if_get_by_index(index + 1);
 
 	if (iface_states[index] & NET_STATE_CONNECTED) {
-		NET_DBG("Iface %p connected", iface);
+		NET_DBG("Iface %d (%p) connected",
+			net_if_get_by_iface(iface), iface);
 		net_mgmt_event_notify(NET_EVENT_L4_CONNECTED, iface);
 	} else {
-		NET_DBG("Iface %p disconnected", iface);
+		NET_DBG("Iface %d (%p) disconnected",
+			net_if_get_by_iface(iface), iface);
 		net_mgmt_event_notify(NET_EVENT_L4_DISCONNECTED, iface);
 	}
 }

--- a/subsys/net/lib/conn_mgr/events_handler.c
+++ b/subsys/net/lib/conn_mgr/events_handler.c
@@ -25,7 +25,8 @@ static void conn_mgr_iface_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("Iface event %u received on iface %p", mgmt_event, iface);
+	NET_DBG("Iface event %u received on iface %d (%p)", mgmt_event,
+		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IFACE_EVENTS_MASK) != mgmt_event) {
 		return;
@@ -57,7 +58,8 @@ static void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("IPv6 event %u received on iface %p", mgmt_event, iface);
+	NET_DBG("IPv6 event %u received on iface %d (%p)", mgmt_event,
+		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IPV6_EVENTS_MASK) != mgmt_event) {
 		return;
@@ -114,7 +116,8 @@ static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("IPv4 event %u received on iface %p", mgmt_event, iface);
+	NET_DBG("IPv4 event %u received on iface %d (%p)", mgmt_event,
+		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IPV4_EVENTS_MASK) != mgmt_event) {
 		return;


### PR DESCRIPTION
Fixes some issues I noticed which debugging the virtual interface #32840. Without these, echo-server thought that there was no connectivity in the system, if the last interface in the system was not found but the first was properly up.