### PR TITLE
drivers/flash/soc_flash_nrf: Include additional headers

### DIFF
--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -8,6 +8,7 @@
 #define __SOC_FLASH_NRF_H__
 
 #include <kernel.h>
+#include <soc.h>
 
 #define FLASH_OP_DONE    (0) /* 0 for compliance with the driver API. */
 #define FLASH_OP_ONGOING  1


### PR DESCRIPTION
Include <soc.h> and <autoconf.h> to make the header file self-sufficent.

Not including those headers causes compilation errors with files that don't include <soc.h>.

Signed-off-by: Ievgenii Meshcheriakov <ievgenii.meshcheriakov@nordicsemi.no>