### PR TITLE
Some improvements to the documentation README

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -67,52 +67,58 @@ described in :ref:`getting_started`. Then install additional tools
 that are only required to generate the documentation,
 as described below:
 
-On Ubuntu Linux:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Linux
 
-   sudo apt-get install --no-install-recommends doxygen librsvg2-bin \
-     texlive-latex-base texlive-latex-extra latexmk texlive-fonts-recommended
+      On Ubuntu Linux:
 
-On Fedora Linux:
+      .. code-block:: console
 
-.. code-block:: console
+         sudo apt-get install --no-install-recommends doxygen librsvg2-bin \
+         texlive-latex-base texlive-latex-extra latexmk texlive-fonts-recommended
 
-   sudo dnf install doxygen texlive-latex latexmk \
-     texlive-collection-fontsrecommended librsvg2-tools
+      On Fedora Linux:
 
-On Clear Linux:
+      .. code-block:: console
 
-.. code-block:: console
+         sudo dnf install doxygen texlive-latex latexmk \
+         texlive-collection-fontsrecommended librsvg2-tools
 
-  sudo swupd bundle-add texlive
+      On Clear Linux:
 
-On Arch Linux:
+      .. code-block:: console
 
-.. code-block:: console
+         sudo swupd bundle-add texlive
 
-   sudo pacman -S doxygen librsvg texlive-core texlive-bin
+      On Arch Linux:
 
-On macOS:
+      .. code-block:: console
 
-.. code-block:: console
+         sudo pacman -S doxygen librsvg texlive-core texlive-bin
 
-   brew install doxygen mactex librsvg
-   tlmgr install latexmk
-   tlmgr install collection-fontsrecommended
+   .. group-tab:: macOS
 
-On Windows in an Administrator ``cmd.exe`` prompt:
+      .. code-block:: console
 
-.. code-block:: console
+         brew install doxygen mactex librsvg
+         tlmgr install latexmk
+         tlmgr install collection-fontsrecommended
 
-   choco install doxygen.install strawberryperl miktex rsvg-convert
+   .. group-tab:: Windows
 
-.. note::
-   On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in
-   the ``Scripts`` folder of your Python installation path.
-   Dependending on how you have installed Python, you may need to
-   add this folder to your ``PATH`` environment variable. Follow
-   the instructions in `Windows Python Path`_ to add those if needed.
+      Run in an Administrator ``cmd.exe`` prompt:
+
+      .. code-block:: console
+
+         choco install doxygen.install strawberryperl miktex rsvg-convert
+
+      .. note::
+         On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in
+         the ``Scripts`` folder of your Python installation path.
+         Dependending on how you have installed Python, you may need to
+         add this folder to your ``PATH`` environment variable. Follow
+         the instructions in `Windows Python Path`_ to add those if needed.
 
 Documentation presentation theme
 ********************************

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -55,12 +55,9 @@ Installing the documentation processors
 Our documentation processing has been tested to run with:
 
 * Doxygen version 1.8.13
-* Sphinx version 3.2.0
-* Breathe version 4.20.0
-* docutils version 0.16
-* sphinx_rtd_theme version 0.4.0
-* sphinxcontrib-svg2pdfconverter version 0.1.0
 * Latexmk version 4.56
+* All Python dependencies listed in the repository file
+  ``scripts/requirements-doc.txt``
 
 In order to install the documentation tools, first install Zephyr as
 described in :ref:`getting_started`. Then install additional tools


### PR DESCRIPTION
- doc: readme: group requirements using one tab per platform
It is easier to follow the user guide if each platform has its own tab
for requirements.

- doc: readme: remove list of Python dependencies
Instead of listing Python dependencies in the docs, refer to the
requirements file. This way docs are never out of sync.