### PR TITLE
drivers/sensor: iis2iclx: fix multi-instance using new helpers

### DIFF
--- a/drivers/sensor/iis2iclx/iis2iclx.h
+++ b/drivers/sensor/iis2iclx/iis2iclx.h
@@ -35,25 +35,18 @@
 #define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
 #define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-struct iis2iclx_spi_cfg {
-	struct spi_config spi_conf;
-	const char *cs_gpios_label;
-};
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
-
 union iis2iclx_bus_cfg {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	uint16_t i2c_slv_addr;
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	const struct iis2iclx_spi_cfg *spi_cfg;
+	struct spi_config spi_cfg;
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };
 
 struct iis2iclx_config {
-	char *bus_name;
+	const struct device *bus;
 	int (*bus_init)(const struct device *dev);
 	const union iis2iclx_bus_cfg bus_cfg;
 	uint8_t odr;
@@ -119,10 +112,6 @@ struct iis2iclx_data {
 	struct k_work work;
 #endif
 #endif /* CONFIG_IIS2ICLX_TRIGGER */
-
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_cs_control cs_ctrl;
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 };
 
 int iis2iclx_spi_init(const struct device *dev);

--- a/drivers/sensor/iis2iclx/iis2iclx_i2c.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_i2c.c
@@ -19,23 +19,21 @@
 
 LOG_MODULE_DECLARE(IIS2ICLX, CONFIG_SENSOR_LOG_LEVEL);
 
-static int iis2iclx_i2c_read(struct iis2iclx_data *data, uint8_t reg_addr,
+static int iis2iclx_i2c_read(const struct device *dev, uint8_t reg_addr,
 			       uint8_t *value, uint8_t len)
 {
-	const struct device *dev = data->dev;
 	const struct iis2iclx_config *cfg = dev->config;
 
-	return i2c_burst_read(data->bus, cfg->bus_cfg.i2c_slv_addr,
+	return i2c_burst_read(cfg->bus, cfg->bus_cfg.i2c_slv_addr,
 			      reg_addr, value, len);
 }
 
-static int iis2iclx_i2c_write(struct iis2iclx_data *data, uint8_t reg_addr,
+static int iis2iclx_i2c_write(const struct device *dev, uint8_t reg_addr,
 				uint8_t *value, uint8_t len)
 {
-	const struct device *dev = data->dev;
 	const struct iis2iclx_config *cfg = dev->config;
 
-	return i2c_burst_write(data->bus, cfg->bus_cfg.i2c_slv_addr,
+	return i2c_burst_write(cfg->bus, cfg->bus_cfg.i2c_slv_addr,
 			       reg_addr, value, len);
 }
 
@@ -43,11 +41,11 @@ int iis2iclx_i2c_init(const struct device *dev)
 {
 	struct iis2iclx_data *data = dev->data;
 
-	data->ctx_i2c.read_reg = (stmdev_read_ptr) iis2iclx_i2c_read,
-	data->ctx_i2c.write_reg = (stmdev_write_ptr) iis2iclx_i2c_write,
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) iis2iclx_i2c_read;
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) iis2iclx_i2c_write;
 
 	data->ctx = &data->ctx_i2c;
-	data->ctx->handle = data;
+	data->ctx->handle = (void *)dev;
 
 	return 0;
 }

--- a/drivers/sensor/iis2iclx/iis2iclx_spi.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_spi.c
@@ -20,12 +20,11 @@
 
 LOG_MODULE_DECLARE(IIS2ICLX, CONFIG_SENSOR_LOG_LEVEL);
 
-static int iis2iclx_spi_read(struct iis2iclx_data *data, uint8_t reg_addr,
+static int iis2iclx_spi_read(const struct device *dev, uint8_t reg_addr,
 			       uint8_t *value, uint8_t len)
 {
-	const struct device *dev = data->dev;
 	const struct iis2iclx_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg;
 	uint8_t buffer_tx[2] = { reg_addr | IIS2ICLX_SPI_READ, 0 };
 	const struct spi_buf tx_buf = {
 			.buf = buffer_tx,
@@ -55,19 +54,18 @@ static int iis2iclx_spi_read(struct iis2iclx_data *data, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_transceive(data->bus, spi_cfg, &tx, &rx)) {
+	if (spi_transceive(cfg->bus, spi_cfg, &tx, &rx)) {
 		return -EIO;
 	}
 
 	return 0;
 }
 
-static int iis2iclx_spi_write(struct iis2iclx_data *data, uint8_t reg_addr,
+static int iis2iclx_spi_write(const struct device *dev, uint8_t reg_addr,
 				uint8_t *value, uint8_t len)
 {
-	const struct device *dev = data->dev;
 	const struct iis2iclx_config *cfg = dev->config;
-	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg->spi_conf;
+	const struct spi_config *spi_cfg = &cfg->bus_cfg.spi_cfg;
 	uint8_t buffer_tx[1] = { reg_addr & ~IIS2ICLX_SPI_READ };
 	const struct spi_buf tx_buf[2] = {
 		{
@@ -89,7 +87,7 @@ static int iis2iclx_spi_write(struct iis2iclx_data *data, uint8_t reg_addr,
 		return -EIO;
 	}
 
-	if (spi_write(data->bus, spi_cfg, &tx)) {
+	if (spi_write(cfg->bus, spi_cfg, &tx)) {
 		return -EIO;
 	}
 
@@ -99,27 +97,12 @@ static int iis2iclx_spi_write(struct iis2iclx_data *data, uint8_t reg_addr,
 int iis2iclx_spi_init(const struct device *dev)
 {
 	struct iis2iclx_data *data = dev->data;
-	const struct iis2iclx_config *cfg = dev->config;
-	const struct iis2iclx_spi_cfg *spi_cfg = cfg->bus_cfg.spi_cfg;
 
 	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2iclx_spi_read;
 	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2iclx_spi_write;
 
 	data->ctx = &data->ctx_spi;
-	data->ctx->handle = data;
-
-	if (spi_cfg->cs_gpios_label != NULL) {
-		/* handle SPI CS thru GPIO if it is the case */
-		data->cs_ctrl.gpio_dev =
-			    device_get_binding(spi_cfg->cs_gpios_label);
-		if (!data->cs_ctrl.gpio_dev) {
-			LOG_ERR("Unable to get GPIO SPI CS device");
-			return -ENODEV;
-		}
-
-		LOG_DBG("SPI GPIO CS configured on %s:%u",
-			spi_cfg->cs_gpios_label, data->cs_ctrl.gpio_pin);
-	}
+	data->ctx->handle = (void *)dev;
 
 	return 0;
 }


### PR DESCRIPTION
This commit aims to simplify the Device Tree configuration
retrieving using few new helpers introduced in #30536.

In particular:
    - get bus devices with DEVICE_DT_GET
    - get SPI information with SPI_CONFIG_DT_INST

Tested on x_nucleo_iks01a2 DIL24 in SPI mode.

Note:
This PR is used to help changing #31775 as it is easier to test.