### PR TITLE
drivers: modem: optional factory reset at modem boot

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -61,4 +61,12 @@ config MODEM_GSM_MANUAL_MCCMNO
 	  the network provider and may need to be changed if auto is not
 	  selected.
 
+config MODEM_GSM_FACTORY_RESET_AT_BOOT
+	bool "Factory reset modem at boot"
+	help
+	  If this is enabled, the modem will be reset to factory default
+	  settings first thing in the initialization sequence. This is
+	  helpful if your modem has a tendency to get stuck due to cached
+	  state.
+
 endif

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -366,6 +366,16 @@ static void gsm_finalize_connection(struct gsm_modem *gsm)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_MODEM_GSM_FACTORY_RESET_AT_BOOT)) {
+		(void)modem_cmd_send_nolock(&gsm->context.iface,
+					    &gsm->context.cmd_handler,
+					    &response_cmds[0],
+					    ARRAY_SIZE(response_cmds),
+					    "AT&F", &gsm->sem_response,
+					    GSM_CMD_AT_TIMEOUT);
+		k_sleep(K_SECONDS(1));
+	}
+
 	(void)gsm_setup_mccmno(gsm);
 
 	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,


### PR DESCRIPTION
Some modems, under some conditions, have a tendency to get stuck without
a connection due to cached state. We have observed this on some Simcom
LTE modems after large cellular outages. The modems are unable to escape
their cached state for some reason unless they're factory reset (or a
cache clearence is forced in some other way).

This commit allows for the modem to be factory reset at each boot. This
minimizes dependencies on external state by ensuring each power-up is as
similar as possible.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>