### PR TITLE
scripts: gen_syscalls: declare syscalls with void instead of zero args

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -168,7 +168,7 @@ def wrapper_defs(func_name, func_type, args):
     if ret64:
         mrsh_args.append("(uintptr_t)&ret64")
 
-    decl_arglist = ", ".join([" ".join(argrec) for argrec in args])
+    decl_arglist = ", ".join([" ".join(argrec) for argrec in args]) or "void"
 
     wrap = "extern %s z_impl_%s(%s);\n" % (func_type, func_name, decl_arglist)
     wrap += "static inline %s %s(%s)\n" % (func_type, func_name, decl_arglist)


### PR DESCRIPTION
In C, `void foo(void);` and `void foo();` mean subtly different things.
The former means "foo takes zero arguments"; the latter means
"foo takes an unspecified number of arguments". This can result in
calling convention mismatches in exceptional cases.

Change to emitting `(void)` instead of `()` for a syscall with
zero arguments.

Signed-off-by: James Harris <james.harris@intel.com>