### PR TITLE
net: lwm2m: Initialize the variable to silence compiler warning

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -144,7 +144,7 @@ static void json_add_char(struct lwm2m_input_context *in,
 static int json_next_token(struct lwm2m_input_context *in,
 			   struct json_in_formatter_data *fd)
 {
-	uint8_t cont, c;
+	uint8_t cont, c = 0;
 	bool escape = false;
 
 	(void)memset(fd, 0, sizeof(*fd));


### PR DESCRIPTION
The compiler generates a warning regarding a variable being used
w/o being initialized in certian configuration. According to the logic
that's not the case, so just add some initial value to the variable to
silence the compiler.

Fixes #32853

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>