### PR TITLE
doc: contribute: modifying_contributions: clarify DCO requirements

### DIFF
--- a/doc/contribute/modifying_contributions.rst
+++ b/doc/contribute/modifying_contributions.rst
@@ -65,6 +65,13 @@ If the original patches are substantially modified, the developer can either:
   number).
 
 .. note::
+
+  In any case commits that include content from both the original and
+  modifying author **must** include the ``Signed-off-by`` statements
+  from the original commit that provided the content as well as one from
+  the modifying author.  See :ref:`DCO`.
+
+.. note::
   Contributors should uncheck the box *“Allow Edits By Maintainers"*
   to indicate that they do not wish their patches to be amended,
   inside their original branch or pull request, by other Zephyr developers.


### PR DESCRIPTION
Make clear that modified commits or new commits that incorporate material from other commits must retain the Signed-off-by: lines from the original author(s), to preserve the chain-of-responsibility that affirms the content meets Zephyr's licensing criteria.

Context: https://github.com/zephyrproject-rtos/zephyr/pull/32734#issuecomment-790682427