### PR TITLE
Bluetooth: Audio: Add maintainers/codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -413,6 +413,7 @@
 /include/arch/sparc/                      @martin-aberg
 /include/sys/atomic.h                     @andyross
 /include/bluetooth/                       @joerchan @jhedberg @Vudentz
+/include/bluetooth/audio/                 @joerchan @jhedberg @Vudentz @Thalley @asbjornsabo
 /include/cache.h                          @carlocaione @andyross
 /include/canbus/                          @alexanderwachter
 /include/tracing/                         @nashif
@@ -539,6 +540,7 @@
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
+/subsys/bluetooth/audio/                  @joerchan @jhedberg @Vudentz @Thalley @asbjornsabo
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/canbus/                           @alexanderwachter

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -163,6 +163,8 @@ Bluetooth:
     collaborators:
         - joerchan
         - Vudentz
+        - Thalley
+        - asbjornsabo
     files:
         - doc/reference/bluetooth/
         - doc/guides/bluetooth/
@@ -175,6 +177,7 @@ Bluetooth:
         - subsys/bluetooth/host/
         - subsys/bluetooth/services/
         - subsys/bluetooth/shell/
+        - subsys/bluetooth/audio/
         - tests/bluetooth/
     labels:
         - "area: Bluetooth"

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1,0 +1,9 @@
+/** @file
+ *  @brief Header for Bluetooth le-audio
+ *
+ * Copyright (c) 2020 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* For now, this file is a place holder */


### PR DESCRIPTION
Add Thalley (emil.gydesen@nordicsemi.no) and asbjornsabo
(asbjorn.sabo@nordicsemi.no) as additional maintainers/codeowners for
bluetooth audio.

(Also adds empty audio.h file, that will later be expanded, so that
the include/bluetooth/audio directory now listed in CODEOWNERS
actually exists.)

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>