### PR TITLE
kernel: simple part of _current / _current_cpu optimizations

### DIFF
--- a/include/arch/arc/v2/aux_regs.h
+++ b/include/arch/arc/v2/aux_regs.h
@@ -188,10 +188,10 @@
 #define z_arc_v2_core_id() \
 	({                                               \
 		unsigned int __ret;                      \
-		__asm__ __volatile__("lr %0, [%1]\n" \
-				     "xbfu %0, %0, 0xe8\n" \
-				     : "=r"(__ret)       \
-				     : "i"(_ARC_V2_IDENTITY));        \
+		__asm__("lr %0, [%1]\n" \
+				"xbfu %0, %0, 0xe8\n" \
+				: "=r"(__ret)       \
+				: "i"(_ARC_V2_IDENTITY));        \
 		__ret;                                   \
 	})
 

--- a/include/arch/x86/arch_inlines.h
+++ b/include/arch/x86/arch_inlines.h
@@ -15,7 +15,7 @@
 #include <arch/x86/intel64/thread.h>
 #include <kernel_structs.h>
 
-static inline struct _cpu *arch_curr_cpu(void)
+static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	struct _cpu *cpu;
 

--- a/include/arch/x86/arch_inlines.h
+++ b/include/arch/x86/arch_inlines.h
@@ -19,7 +19,7 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	struct _cpu *cpu;
 
-	__asm__ volatile("movq %%gs:(%c1), %0"
+	__asm__("movq %%gs:(%c1), %0"
 			 : "=r" (cpu)
 			 : "i" (offsetof(x86_tss64_t, cpu)));
 

--- a/include/arch/xtensa/arch_inlines.h
+++ b/include/arch/xtensa/arch_inlines.h
@@ -17,6 +17,11 @@
 	 __asm__ volatile ("rsr." sr " %0" : "=a"(v)); \
 	 v; })
 
+#define RSR_NV(sr) \
+	({uint32_t v; \
+	 __asm__ ("rsr." sr " %0" : "=a"(v)); \
+	 v; })
+
 #define WSR(sr, v) \
 	do { \
 		__asm__ volatile ("wsr." sr " %0" : : "r"(v)); \
@@ -26,7 +31,7 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	_cpu_t *cpu;
 
-	cpu = (_cpu_t *)RSR(CONFIG_XTENSA_KERNEL_CPU_PTR_SR);
+	cpu = (_cpu_t *)RSR_NV(CONFIG_XTENSA_KERNEL_CPU_PTR_SR);
 
 	return cpu;
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -528,9 +528,9 @@ __syscall void k_wakeup(k_tid_t thread);
  * @return ID of current thread.
  *
  */
-__syscall k_tid_t k_current_get(void);
+__attribute__((const)) __syscall k_tid_t k_current_get(void);
 
-static ALWAYS_INLINE k_tid_t z_impl_k_current_get(void)
+static ALWAYS_INLINE __attribute__((const)) k_tid_t z_impl_k_current_get(void)
 {
 #ifdef CONFIG_SMP
 	/* In SMP, _current is a field read from _current_cpu, which

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -27,6 +27,7 @@
 #define ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_
 
 #ifndef _ASMLANGUAGE
+#include <kernel_structs.h>
 #include <toolchain.h>
 #include <stddef.h>
 #include <zephyr/types.h>
@@ -373,7 +374,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter);
  */
 #ifdef CONFIG_SMP
 /** Return the CPU struct for the currently executing CPU */
-static inline struct _cpu *arch_curr_cpu(void);
+static ALWAYS_INLINE __attribute__((pure, returns_nonnull)) _cpu_t *arch_curr_cpu(void);
 
 /**
  * Broadcast an interrupt to all CPUs

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1352,23 +1352,6 @@ static inline void z_vrfy_k_wakeup(k_tid_t thread)
 #include <syscalls/k_wakeup_mrsh.c>
 #endif
 
-k_tid_t z_impl_k_current_get(void)
-{
-#ifdef CONFIG_SMP
-	/* In SMP, _current is a field read from _current_cpu, which
-	 * can race with preemption before it is read.  We must lock
-	 * local interrupts when reading it.
-	 */
-	unsigned int k = arch_irq_lock();
-#endif
-
-	k_tid_t ret = _current_cpu->current;
-
-#ifdef CONFIG_SMP
-	arch_irq_unlock(k);
-#endif
-	return ret;
-}
 
 #ifdef CONFIG_USERSPACE
 static inline k_tid_t z_vrfy_k_current_get(void)


### PR DESCRIPTION
I figured I should split out the simple/straightforward parts of the _current / _current_cpu optimizations into their own PR.

See also: #32709, #32806.

This PR:

1. inlines k_current_get where appropriate.
2. const-ifies `k_current_get`.
3. pure-ifies `arch_curr_cpu`.
4. Marks `arch_curr_cpu` as always returning a valid pointer (instead of e.g. NULL). 
5. Removes a couple of unnecessary `asm volatile`s.