### PR TITLE
net: review and update uses of k_work_pending

### DIFF
--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -37,10 +37,6 @@ static struct net_traffic_class rx_classes[NET_TC_RX_COUNT];
 
 bool net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
 {
-	if (k_work_pending(net_pkt_work(pkt))) {
-		return false;
-	}
-
 	net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
 	k_work_submit_to_queue(&tx_classes[tc].work_q, net_pkt_work(pkt));

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -234,7 +234,7 @@ static void tcp_retry_expired(struct k_work *work)
 		pkt = CONTAINER_OF(sys_slist_peek_head(&tcp->sent_list),
 				   struct net_pkt, sent_list);
 
-		if (k_work_pending(net_pkt_work(pkt))) {
+		if (k_work_is_pending(net_pkt_work(pkt))) {
 			/* If the packet is still pending in TX queue, then do
 			 * not try to resend it again. This can happen if the
 			 * device is so busy that the TX thread has not yet
@@ -391,7 +391,7 @@ int net_tcp_release(struct net_tcp *tcp)
 			 * it go as it will be released by L2 after it is
 			 * sent.
 			 */
-			if (k_work_pending(net_pkt_work(pkt)) ||
+			if (k_work_is_pending(net_pkt_work(pkt)) ||
 			    net_pkt_sent(pkt)) {
 				refcount--;
 			}

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -379,14 +379,13 @@ int notify_new_tx_frame(struct net_pkt *pkt)
 
 static int run_tx_task(otInstance *aInstance)
 {
-	static struct k_work tx_job;
+	static K_WORK_DEFINE(tx_job, transmit_message);
 
 	ARG_UNUSED(aInstance);
 
-	if (k_work_pending(&tx_job) == 0) {
+	if (!k_work_is_pending(&tx_job)) {
 		sState = OT_RADIO_STATE_TRANSMIT;
 
-		k_work_init(&tx_job, transmit_message);
 		k_work_submit_to_queue(&ot_work_q, &tx_job);
 		return 0;
 	} else {


### PR DESCRIPTION
k_work_pending is to be deprecated; see #32888.

This PR reviews existing uses in the net subsystem, removing one, and switching two others to the new API.  All uses are racy and alternative approaches (suggested in the commit messages) should be considered.