### PR TITLE
Misc Cortex-R changes

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -29,6 +29,7 @@ config CPU_CORTEX_R
 	select CPU_CORTEX
 	select HAS_CMSIS_CORE
 	select HAS_FLASH_LOAD_OFFSET
+	select ARCH_HAS_EXTRA_EXCEPTION_INFO
 	help
 	  This option signifies the use of a CPU of the Cortex-R family.
 

--- a/arch/arm/core/aarch32/cortex_a_r/exc.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc.S
@@ -65,17 +65,52 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 
+	/*
+	 * Create new esf struct for exception handler debug.  The first
+	 * time the basic stack frame is saved is for getting in and out
+	 * of the exception.
+	 */
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	sub sp, #___callee_saved_t_SIZEOF
+	sub sp, #___extra_esf_info_t_SIZEOF
+#endif
+
+	srsdb sp!, #MODE_UND
+	stmfd sp, {r0-r3, r12, lr}^
+	sub sp, #24
+
 	/* Increment exception nesting count */
 	ldr r2, =_kernel
 	ldr r0, [r2, #_kernel_offset_to_nested]
 	add r0, r0, #1
 	str r0, [r2, #_kernel_offset_to_nested]
 
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	/* Pointer to extra esf info */
+	add r0, sp, #___basic_sf_t_SIZEOF
+	mov r1, #0
+	str r1, [r0, #4]
+	str r1, [r0, #8]
+
+	/* Pointer to callee saved registers */
+	add r1, r0, #___extra_esf_info_t_SIZEOF
+	str r1, [r0]
+
+	cps #MODE_SYS
+	stm r1, {r4-r11, sp}
+	cps #MODE_UND
+#endif
+
 	/* Invoke fault handler */
 	mov r0, sp
 	bl z_arm_fault_undef_instruction
 
 	/* Exit exception */
+	add sp, sp, #___basic_sf_t_SIZEOF
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	add sp, #___extra_esf_info_t_SIZEOF
+	add sp, #___callee_saved_t_SIZEOF
+#endif
 	b z_arm_exc_exit
 
 /**
@@ -99,17 +134,52 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_prefetch_abort)
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 
+	/*
+	 * Create new esf struct for exception handler debug.  The first
+	 * time the basic stack frame is saved is for getting in and out
+	 * of the exception.
+	 */
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	sub sp, #___callee_saved_t_SIZEOF
+	sub sp, #___extra_esf_info_t_SIZEOF
+#endif
+
+	srsdb sp!, #MODE_ABT
+	stmfd sp, {r0-r3, r12, lr}^
+	sub sp, #24
+
 	/* Increment exception nesting count */
 	ldr r2, =_kernel
 	ldr r0, [r2, #_kernel_offset_to_nested]
 	add r0, r0, #1
 	str r0, [r2, #_kernel_offset_to_nested]
 
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	/* Pointer to extra esf info */
+	add r0, sp, #___basic_sf_t_SIZEOF
+	mov r1, #0
+	str r1, [r0, #4]
+	str r1, [r0, #8]
+
+	/* Pointer to callee saved registers */
+	add r1, r0, #___extra_esf_info_t_SIZEOF
+	str r1, [r0]
+
+	cps #MODE_SYS
+	stm r1, {r4-r11, sp}
+	cps #MODE_ABT
+#endif
+
 	/* Invoke fault handler */
 	mov r0, sp
 	bl z_arm_fault_prefetch
 
 	/* Exit exception */
+	add sp, sp, #___basic_sf_t_SIZEOF
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	add sp, #___extra_esf_info_t_SIZEOF
+	add sp, #___callee_saved_t_SIZEOF
+#endif
 	b z_arm_exc_exit
 
 /**
@@ -134,15 +204,50 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_data_abort)
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 
+	/*
+	 * Create new esf struct for exception handler debug.  The first
+	 * time the basic stack frame is saved is for getting in and out
+	 * of the exception.
+	 */
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	sub sp, #___callee_saved_t_SIZEOF
+	sub sp, #___extra_esf_info_t_SIZEOF
+#endif
+
+	srsdb sp!, #MODE_ABT
+	stmfd sp, {r0-r3, r12, lr}^
+	sub sp, #24
+
 	/* Increment exception nesting count */
 	ldr r2, =_kernel
 	ldr r0, [r2, #_kernel_offset_to_nested]
 	add r0, r0, #1
 	str r0, [r2, #_kernel_offset_to_nested]
 
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	/* Pointer to extra esf info */
+	add r0, sp, #___basic_sf_t_SIZEOF
+	mov r1, #0
+	str r1, [r0, #4]
+	str r1, [r0, #8]
+
+	/* Pointer to callee saved registers */
+	add r1, r0, #___extra_esf_info_t_SIZEOF
+	str r1, [r0]
+
+	cps #MODE_SYS
+	stm r1, {r4-r11, sp}
+	cps #MODE_ABT
+#endif
+
 	/* Invoke fault handler */
 	mov r0, sp
 	bl z_arm_fault_data
 
 	/* Exit exception */
+	add sp, sp, #___basic_sf_t_SIZEOF
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	add sp, #___extra_esf_info_t_SIZEOF
+	add sp, #___callee_saved_t_SIZEOF
+#endif
 	b z_arm_exc_exit

--- a/arch/arm/core/aarch32/cortex_a_r/exc.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc.S
@@ -61,7 +61,7 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	 * Store r0-r3, r12, lr, lr_und and spsr_und into the stack to
 	 * construct an exception stack frame.
 	 */
-	srsdb sp, #MODE_UND!
+	srsdb sp!, #MODE_UND
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 
@@ -95,7 +95,7 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_prefetch_abort)
 	 * Store r0-r3, r12, lr, lr_abt and spsr_abt into the stack to
 	 * construct an exception stack frame.
 	 */
-	srsdb sp, #MODE_ABT!
+	srsdb sp!, #MODE_ABT
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 
@@ -130,7 +130,7 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_data_abort)
 	 * Store r0-r3, r12, lr, lr_abt and spsr_abt into the stack to
 	 * construct an exception stack frame.
 	 */
-	srsdb sp, #MODE_ABT!
+	srsdb sp!, #MODE_ABT
 	stmfd sp, {r0-r3, r12, lr}^
 	sub sp, #24
 

--- a/arch/arm/core/aarch32/fatal.c
+++ b/arch/arm/core/aarch32/fatal.c
@@ -24,7 +24,7 @@ static void esf_dump(const z_arch_esf_t *esf)
 		esf->basic.a4, esf->basic.ip, esf->basic.lr);
 	LOG_ERR(" xpsr:  0x%08x", esf->basic.xpsr);
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	for (int i = 0; i < 16; i += 4) {
+	for (int i = 0; i < ARRAY_SIZE(esf->s); i += 4) {
 		LOG_ERR("s[%2d]:  0x%08x  s[%2d]:  0x%08x"
 			"  s[%2d]:  0x%08x  s[%2d]:  0x%08x",
 			i, (uint32_t)esf->s[i],

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -51,6 +51,7 @@ GEN_OFFSET_SYM(_basic_sf_t, ip);
 GEN_OFFSET_SYM(_basic_sf_t, lr);
 GEN_OFFSET_SYM(_basic_sf_t, pc);
 GEN_OFFSET_SYM(_basic_sf_t, xpsr);
+GEN_ABSOLUTE_SYM(___basic_sf_t_SIZEOF, sizeof(_basic_sf_t));
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 GEN_OFFSET_SYM(_esf_t, s);
@@ -72,6 +73,10 @@ GEN_OFFSET_SYM(_callee_saved_t, psp);
 /* size of the entire preempt registers structure */
 
 GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
+
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+GEN_ABSOLUTE_SYM(___extra_esf_info_t_SIZEOF, sizeof(struct __extra_esf_info));
+#endif
 
 #if defined(CONFIG_THREAD_STACK_INFO)
 GEN_OFFSET_SYM(_thread_stack_info_t, start);


### PR DESCRIPTION
This cleans up a couple of minor nits.

There is also a patch that dumps out the callee saved registers on a fatal exception.  These registers can be very helpful when debugging crashes.

example of output
```
*** Booting Zephyr OS build zephyr-v2.4.0-4934-gc2a5cf2acb85  ***
Coredump: qemu_cortex_r5
E: ***** UNDEFINED INSTRUCTION ABORT *****
E:  r4: 0x00001519  r5:  0x00000000  r6:  00000000
E:  r7: 0x00000000  r8:  0x00000000  r9:  00000000
E: r10: 0x00000000 r11:  0x00000000 psp:  00003c48
E: r0/a1:  0x00000019  r1/a2:  0x0000000a  r2/a3:  0xff00002c
E: r3/a4:  0x00000000 r12/ip:  0x0000000a r14/lr:  0x0000019b
E:  xpsr:  0x4000013f
E: Faulting instruction address (r15/pc): 0x0000019e
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x2e78 (unknown)
E: Halting system
```