### PR TITLE
logging: add log_msg_timestamp_to_us() helper function

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -188,6 +188,14 @@ static inline void log_output_hostname_set(const struct log_output *log_output,
  */
 void log_output_timestamp_freq_set(uint32_t freq);
 
+/** @brief Convert timestamp of the message to us.
+ *
+ * @param timestamp Message timestamp
+ *
+ * @return Timestamp value in us.
+ */
+uint64_t log_output_timestamp_to_us(uint32_t timestamp);
+
 /**
  * @}
  */

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -668,3 +668,10 @@ void log_output_timestamp_freq_set(uint32_t frequency)
 
 	freq = frequency;
 }
+
+uint64_t log_output_timestamp_to_us(uint32_t timestamp)
+{
+	timestamp /= timestamp_div;
+
+	return ((uint64_t) timestamp * 1000000U) / freq;
+}


### PR DESCRIPTION
So far we only have log_msg_timestamp_get() function, which returns
internal timestamp representation. This is either clock cycles or uptime
in ms, depending on main clock precision.

Introduce log_msg_timestamp_to_us() helper function, which allows to
convert internal logging timestamp to us.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>