### PR TITLE
shell: improve help for conditional commands

### DIFF
--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -112,7 +112,7 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	static const uint8_t tabulator[] = "  ";
 	const uint16_t offset = 2 * strlen(tabulator) + item_name_width + 1;
 
-	if (item_name == NULL) {
+	if ((item_name == NULL) || (item_name[0] == '\0')) {
 		return;
 	}
 


### PR DESCRIPTION
If a shell command is compiled out using SHELL_COND_CMD(), a line for this command will still be printed but will be blank. Change it so compiled out commands are not listed as blank lines.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>