### PR TITLE
boards: arm: mps2_an521: Enable TFM testing in CI

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
@@ -2,9 +2,12 @@ identifier: mps2_an521_nonsecure
 name: ARM V2M MPS2-AN521_nonsecure
 type: mcu
 arch: arm
+simulation: qemu
 toolchain:
   - gnuarmemb
   - zephyr
   - xtools
-supported:
-  - gpio
+testing:
+  default: true
+  only_tags:
+     - tfm


### PR DESCRIPTION
The mps2_an521_nonsecure exists for TFM and is also utilized as a config
for multicore samples.  We can enable just the TFM tests with only_tags
and get a bit of additional coverage in QEMU for the TFM integration.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>