### PR TITLE
tests: drivers: dma: remove dead code in test_dma_loop.c

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -146,11 +146,10 @@ static int test_loop(void)
 	if (transfer_count < TRANSFER_LOOPS) {
 		transfer_count = TRANSFER_LOOPS;
 		TC_PRINT("ERROR: unfinished transfer\n");
-		return TC_FAIL;
 		if (dma_stop(dma, chan_id)) {
 			TC_PRINT("ERROR: transfer stop\n");
-			return TC_FAIL;
 		}
+		return TC_FAIL;
 	}
 
 	TC_PRINT("Each RX buffer should contain the full TX buffer string.\n");


### PR DESCRIPTION
Fix the error of the [Coverity CID :219489] "Structurally
dead code in tests/drivers/dma/loop_transfer/src/test_dma_loop.c"

Fix https://github.com/zephyrproject-rtos/zephyr/issues/32951

Signed-off-by: Francois Ramu <francois.ramu@st.com>