### PR TITLE
drivers: ieee802154_nrf5: Remove unnecessary NULL pointer check

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -199,9 +199,7 @@ drop:
 		nrf_802154_buffer_free_raw(rx_frame->psdu);
 		rx_frame->psdu = NULL;
 
-		if (pkt) {
-			net_pkt_unref(pkt);
-		}
+		net_pkt_unref(pkt);
 	}
 }
 


### PR DESCRIPTION
After changes in commit a42d6c98d3ae717cfaf851630bf28dc28dd55d40, the
pkt can no longer be a NULL pointer. Remove the unnecessary NULL pointer
check to silence the Coverity.

Coverity ID: 219536
Fixes #32912

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>