### PR TITLE
arm: cortex_m: fix arguments to dwt_init() function

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/timing.c
+++ b/arch/arm/core/aarch32/cortex_m/timing.c
@@ -45,7 +45,7 @@ static inline uint64_t z_arm_dwt_freq_get(void)
 
 	if (!dwt_frequency) {
 
-		z_arm_dwt_init(NULL);
+		z_arm_dwt_init();
 
 		uint32_t cyc_start = k_cycle_get_32();
 		uint64_t dwt_start = z_arm_dwt_get_cycles();


### PR DESCRIPTION
Fix the call to z_arm_dwt_init(), remove the NULL argument.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>