### PR TITLE
tests: drivers: pwm: fix order of parameters

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/src/main.c
+++ b/tests/drivers/pwm/pwm_loopback/src/main.c
@@ -14,7 +14,7 @@ void test_main(void)
 	struct test_pwm in;
 	struct test_pwm out;
 
-	get_test_pwms(&in, &out);
+	get_test_pwms(&out, &in);
 
 	k_object_access_grant(out.dev, k_current_get());
 	k_object_access_grant(in.dev, k_current_get());


### PR DESCRIPTION
Fix #32918 [Coverity CID :219528] "Arguments in wrong order
in tests/drivers/pwm/pwm_loopback/src/main.c"

Signed-off-by: Guðni Már Gilbert <gudni.m.g@gmail.com>