### PR TITLE
drivers: native_posix: fix for native posix counter

### DIFF
--- a/drivers/counter/counter_native_posix.c
+++ b/drivers/counter/counter_native_posix.c
@@ -154,6 +154,6 @@ static const struct counter_config_info ctr_config = {
 	.flags = DRIVER_CONFIG_INFO_FLAGS
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(DT_COUNTER_LABEL), device_pm_control_nop,
-		    &ctr_init, NULL, &ctr_config, PRE_KERNEL_1,
+DEVICE_DT_DEFINE(DT_NODELABEL(DT_COUNTER_LABEL), ctr_init,
+		    device_pm_control_nop, NULL, &ctr_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ctr_api);


### PR DESCRIPTION
There was an error in the ordering of the parameters in the DEVICE_DT_DEFINE for the native POSIX counter. This made a project using a counter built for native POSIX not being able to compile. This commit switches places for ctr_init and device_pm_control_nop. This fix was confirmed by successfully building and running the `samples/drivers/counter/alarm` sample for native_posix.