### PR TITLE
kernel: timer: Fix one-shot timer behavior when period is K_FOREVER 

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -126,7 +126,8 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 	 * argument the same way k_sleep() does), but historical.  The
 	 * timer_api test relies on this behavior.
 	 */
-	if (period.ticks != 0 && Z_TICK_ABS(period.ticks) < 0) {
+	if (!K_TIMEOUT_EQ(period, K_FOREVER) && period.ticks != 0 &&
+	    Z_TICK_ABS(period.ticks) < 0) {
 		period.ticks = MAX(period.ticks - 1, 1);
 	}
 	if (Z_TICK_ABS(duration.ticks) < 0) {

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -235,7 +235,7 @@ void test_timer_restart(void)
  * @brief Test Timer with zero period value
  *
  * Validates initial timer duration, keeping timer period to zero.
- * Basically, acting as one-short timer.
+ * Basically, acting as one-shot timer.
  * It initializes the timer with k_timer_init(), then starts the timer
  * using k_timer_start() with specific initial duration and period as
  * zero. Stops the timer using k_timer_stop() and checks for proper
@@ -258,7 +258,7 @@ void test_timer_period_0(void)
 	/* Need to wait at least 2 durations to ensure one-shot behavior. */
 	busy_wait_ms(2 * DURATION + 1);
 
-	/** TESTPOINT: ensure it is one-short timer */
+	/** TESTPOINT: ensure it is one-shot timer */
 	TIMER_ASSERT((tdata.expire_cnt == 1)
 		     || (INEXACT_MS_CONVERT
 			 && (tdata.expire_cnt == 0)), &period0_timer);

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -255,7 +255,8 @@ void test_timer_period_0(void)
 			      - BUSY_SLEW_THRESHOLD_TICKS(DURATION
 							  * USEC_PER_MSEC)),
 		      K_NO_WAIT);
-	busy_wait_ms(DURATION + 1);
+	/* Need to wait at least 2 durations to ensure one-shot behavior. */
+	busy_wait_ms(2 * DURATION + 1);
 
 	/** TESTPOINT: ensure it is one-short timer */
 	TIMER_ASSERT((tdata.expire_cnt == 1)


### PR DESCRIPTION
The Timer API docs define the timer period as the following:

> A period specifying the time interval between all timer expirations after the first one, also a k_timeout_t. It must be non-negative. A period of K_NO_WAIT (i.e. zero) or K_FOREVER means that the timer is a one shot timer that stops after a single expiration. (For example then, if a timer is started with a duration of 200 and a period of 75, it will first expire after 200ms and then every 75ms after that.)

However due to bug in `z_impl_k_timer_start`, K_FOREVER periods end up expiring after every tick. To prevent this, an additional check for a period of K_FOREVER is added here. I create a new test based on test_timer_period_0 as well.

I modified the tests regarding one-shot timers (test_timer_period_0, test_timer_period_k_forever) because I believe that to catch whether the timer is obeying one-shot behavior, the tests would need to wait for 2 durations, rather than 1 as they currently are.

Finally I fixed a couple of typos related to "one-shot".