### PR TITLE
ci: Add twister tag support to get_twister_opt

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -92,21 +92,29 @@ function build_test_file() {
 	rm -f test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_full.txt
 	touch test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_full.txt
 
+	twister_exclude_tag_opt=""
+	if [ -s modified_tags.args ]; then
+		twister_exclude_tag_opt="+modified_tags.args"
+	fi
+
 	# In a pull-request see if we have changed any tests or board definitions
 	if [ -n "${pull_request_nr}" -o -n "${local_run}"  ]; then
 		./scripts/zephyr_module.py --twister-out module_tests.args
 		./scripts/ci/get_twister_opt.py --commits ${commit_range}
 
 		if [ -s modified_boards.args ]; then
-			${twister} ${twister_options} +modified_boards.args \
+			${twister} ${twister_options} ${twister_exclude_tag_opt} \
+				+modified_boards.args \
 				--save-tests test_file_boards.txt || exit 1
 		fi
 		if [ -s modified_tests.args ]; then
-			${twister} ${twister_options} +modified_tests.args \
+			${twister} ${twister_options} ${twister_exclude_tag_opt} \
+				+modified_tests.args \
 				--save-tests test_file_tests.txt || exit 1
 		fi
 		if [ -s modified_archs.args ]; then
-			${twister} ${twister_options} +modified_archs.args \
+			${twister} ${twister_options} ${twister_exclude_tag_opt} \
+				+modified_archs.args \
 				--save-tests test_file_archs.txt || exit 1
 		fi
 		rm -f modified_tests.args modified_boards.args modified_archs.args
@@ -114,7 +122,8 @@ function build_test_file() {
 
 	if [ "$SC" == "full" ]; then
 		# Save list of tests to be run
-		${twister} ${twister_options} --save-tests test_file_full.txt || exit 1
+		${twister} ${twister_options} ${twister_exclude_tag_opt} \
+			--save-tests test_file_full.txt || exit 1
 	fi
 
 	# Remove headers from all files.  We insert it into test_file.txt explicitly

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1,0 +1,58 @@
+# This file contains information on what files are associated with which
+# twister tag.
+#
+# File format
+# ###########
+#
+# "tag" (the quotes are only needed for titles with special characters,
+#  like colons):
+#     files:
+#         List of paths and/or glob patterns giving the files in the tag,
+#         relative to the root directory.
+#
+#         If a path or glob pattern ends in a '/', it matches all files within
+#         the given directory or directories. Otherwise, an exact match is
+#         required.
+#
+#         Paths to directories should always have a trailing '/'.
+#
+#     files-regex:
+#         List of regular expressions applied to paths to determine if they
+#         belong to the tag. The regular expression may match anywhere within
+#         the path, but can be anchored with ^ and $ as usual.
+#
+#         Can be combined with a 'files' key.
+#
+#         Note: Prefer plain 'files' patterns where possible. get_maintainer.py
+#         will check that they match some file, but won't check regexes
+#         (because it might be slow).
+#
+#     files-exclude:
+#         Like 'files', but any matching files will be excluded from the tag.
+#
+#     files-regex-exclude:
+#         Like 'files-regex', but any matching files will be excluded from the
+#         tag.
+#
+# All tags must have a 'files' and/or 'files-regex' key.
+
+kernel:
+    files:
+        - kernel/
+        - include/*.h
+        - include/app_memory/
+        - include/arch/
+        - include/power/
+        - include/sys/
+        - include/timing/
+        - include/zephyr/
+    files-exclude:
+        - include/ptp_clock.h
+
+ptp:
+    files:
+        - include/ptp_clock.h
+
+gptp:
+    files:
+        - include/ptp_clock.h


### PR DESCRIPTION
Add the ability to map file/dir paths of a PR to twister TAG.  We
introduce scripts/ci/tags.yaml to conveys which files are associated
with which tag.

Since not all file/tags will be specified in tags.yaml we use the
combination of the files modified list and the tags.yaml information to
determine which tags can be excluded (ie if the file list doesn't match
any file in tags.yaml for a given tag listed there, we can that exclude
it).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>