### PR TITLE
tests: kernel: Add missing kernel tag to tests

### DIFF
--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -4,9 +4,9 @@ common:
     - native_posix
 tests:
   kernel.device:
-    tags: device
+    tags: kernel device
   kernel.device.pm:
-    tags: device
+    tags: kernel device
     platform_exclude: mec15xxevb_assy6853
     extra_configs:
       - CONFIG_PM_DEVICE=y

--- a/tests/kernel/fatal/message_capture/testcase.yaml
+++ b/tests/kernel/fatal/message_capture/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.logging.message_capture:
+    tags: kernel
     harness: console
     harness_config:
       type: multi_line

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     arch_allow: arm
     platform_allow: bbc_microbit atsamr21_xpro nrf51dk_nrf51422 nucleo_g071rb qemu_cortex_m0
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV6_M_ARMV8_M_BASELINE
-    tags: interrupt isr_table
+    tags: kernel interrupt isr_table
     extra_configs:
       - CONFIG_CORTEX_M_DEBUG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
   arch.interrupt.gen_isr_table.arm_mainline:
@@ -12,7 +12,7 @@ tests:
         stm32_min_dev_blue usb_kw24d512 v2m_beetle cc1352r1_launchxl
         cc26x2r1_launchxl olimex_stm32_h103 cc1352r_sensortag
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-    tags: interrupt isr_table
+    tags: kernel interrupt isr_table
     extra_configs:
       - CONFIG_CORTEX_M_DEBUG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
   arch.interrupt.gen_isr_table.disabled:
@@ -20,7 +20,7 @@ tests:
     extra_configs:
       - CONFIG_GEN_ISR_TABLES=n
       - CONFIG_CORTEX_M_DEBUG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-    tags: interrupt isr_table
+    tags: kernel interrupt isr_table
     build_only: true
   arch.interrupt.gen_isr_table.arc:
     arch_allow: arc
@@ -28,4 +28,4 @@ tests:
     extra_configs:
       - CONFIG_ARC_FIRQ_STACK=y
       - CONFIG_TEST_HW_STACK_PROTECTION=n
-    tags: interrupt isr_table
+    tags: kernel interrupt isr_table

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -2,5 +2,5 @@ tests:
   arch.interrupt:
     # nios2 excluded, see #22956
     arch_exclude: nios2
-    tags: interrupt
+    tags: kernel interrupt
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.stack_random:
     arch_exclude: posix
-    tags: memory_protection
+    tags: kernel memory_protection

--- a/tests/kernel/mp/testcase.yaml
+++ b/tests/kernel/mp/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.multiprocessing:
-    tags: smp
+    tags: kernel smp
     filter: CONFIG_MP_NUM_CPUS > 1

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.multiprocessing.smp:
-    tags: smp
+    tags: kernel smp
     filter: (CONFIG_MP_NUM_CPUS > 1)

--- a/tests/kernel/spinlock/testcase.yaml
+++ b/tests/kernel/spinlock/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.multiprocessing.spinlock:
-    tags: smp spinlock
+    tags: kernel smp spinlock
     filter: CONFIG_SMP and CONFIG_MP_NUM_CPUS > 1 and CONFIG_MP_NUM_CPUS <= 4

--- a/tests/kernel/timer/starve/testcase.yaml
+++ b/tests/kernel/timer/starve/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.timer.starve:
     build_only: true
-    tags: timer
+    tags: kernel timer

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.timer.monotonic:
-    tags: timer
+    tags: kernel timer

--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   arch.common.xip:
     filter: CONFIG_XIP
-    tags: xip
+    tags: kernel xip


### PR DESCRIPTION
Add kernel to any testcase.yaml files that happen to be missing for
tests under tests/kernel/

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>