### PR TITLE
Simplify code where k_mutex_unlock() is used and small documentation fixes

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -118,6 +118,7 @@ static inline int sys_mutex_lock(struct sys_mutex *mutex, k_timeout_t timeout)
  * thread.
  *
  * @param mutex Address of the mutex, which may reside in user memory
+ * @retval 0 Mutex unlocked
  * @retval -EACCES Caller has no access to provided mutex address
  * @retval -EINVAL Provided mutex not recognized by the kernel or mutex wasn't
  *                 locked

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -156,16 +156,7 @@ static inline int sys_mutex_lock(struct sys_mutex *mutex, k_timeout_t timeout)
 
 static inline int sys_mutex_unlock(struct sys_mutex *mutex)
 {
-	if (mutex->kernel_mutex.lock_count == 0) {
-		return -EINVAL;
-	}
-
-	if (mutex->kernel_mutex.owner != _current) {
-		return -EPERM;
-	}
-
-	k_mutex_unlock(&mutex->kernel_mutex);
-	return 0;
+	return k_mutex_unlock(&mutex->kernel_mutex);
 }
 
 #endif /* CONFIG_USERSPACE */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -98,7 +98,7 @@ __syscall int z_sys_mutex_kernel_unlock(struct sys_mutex *mutex);
  * @retval 0 Mutex locked.
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
- * @retval -EACCESS Caller has no access to provided mutex address
+ * @retval -EACCES Caller has no access to provided mutex address
  * @retval -EINVAL Provided mutex not recognized by the kernel
  */
 static inline int sys_mutex_lock(struct sys_mutex *mutex, k_timeout_t timeout)
@@ -118,7 +118,7 @@ static inline int sys_mutex_lock(struct sys_mutex *mutex, k_timeout_t timeout)
  * thread.
  *
  * @param mutex Address of the mutex, which may reside in user memory
- * @retval -EACCESS Caller has no access to provided mutex address
+ * @retval -EACCES Caller has no access to provided mutex address
  * @retval -EINVAL Provided mutex not recognized by the kernel or mutex wasn't
  *                 locked
  * @retval -EPERM Caller does not own the mutex

--- a/lib/os/mutex.c
+++ b/lib/os/mutex.c
@@ -60,12 +60,7 @@ int z_impl_z_sys_mutex_kernel_unlock(struct sys_mutex *mutex)
 		return -EINVAL;
 	}
 
-	if (kernel_mutex->owner != _current) {
-		return -EPERM;
-	}
-
-	k_mutex_unlock(kernel_mutex);
-	return 0;
+	return k_mutex_unlock(kernel_mutex);
 }
 
 static inline int z_vrfy_z_sys_mutex_kernel_unlock(struct sys_mutex *mutex)


### PR DESCRIPTION
Fix #32994

* docs: Fix typo in mutex docs 
  * `-EACCESS` should be `-EACCES`
* docs: Add missing retval for `sys_mutex_unlock() `
  *  Should return 0 if mutex is unlocked, like `k_mutex_unlock()`
* include: sys: Simplify `sys_mutex_unlock()`
  * Remove redundant `if()` statements that are already included with `k_mutex_unlock()`
* lib: os: Simplify `z_impl_z_sys_mutex_kernel_unlock()`
  * Remove one redundant `if()` statement already included when `k_mutex_unlock()` is used