### PR TITLE
samples: userspace: enable shared_mem on x86_64

### DIFF
--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -13,6 +13,5 @@ common:
         - "MSG"
 tests:
   sample.kernel.memory_protection.shared_mem:
-    # x86_64 excluded due to #29594 and #28105
-    filter: CONFIG_ARCH_HAS_USERSPACE and not CONFIG_X86_64
+    filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f


### PR DESCRIPTION
was excluded due to now resolved issues, so re-enable test.