### PR TITLE
boards: intel_s1000_crb: device_is_ready instead of NULL check

### DIFF
--- a/boards/xtensa/intel_s1000_crb/pinmux.c
+++ b/boards/xtensa/intel_s1000_crb/pinmux.c
@@ -29,7 +29,7 @@ static int intel_s1000_pinmux_init(const struct device *dev)
 
 	__ASSERT_NO_MSG(device_is_ready(pinmux));
 
-	if (pinmux == NULL) {
+	if (!device_is_ready(pinmux)) {
 		return -ENXIO;
 	}
 


### PR DESCRIPTION
This changes the NULL check to be using device_is_ready().

Fixes #32946
CID #219494

Signed-off-by: Daniel Leung <daniel.leung@intel.com>