### PR TITLE
ztest: fix ztest thread priority in cooperative mode

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -33,6 +33,7 @@ config ZTEST_ASSERT_VERBOSE
 
 config ZTEST_THREAD_PRIORITY
 	int "Testing thread priority"
+	default -2 if !PREEMPT_ENABLED
 	default -1
 	help
 	  Set priority of the testing thread. Default is -1 (cooperative).


### PR DESCRIPTION
By default ztest thread is running at the priority `-1`. This value is
invalid when the testcase is running in cooperative mode only. Set
default ztest thread priority to `-2` if this is the case. The fix is
modeled on the approach used to define the default
`MAIN_THREAD_PRIORITY`.

Fixes #34434.