### PR TITLE
net: dns: update k_work API and fix misuse

### DIFF
--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -185,12 +185,15 @@ struct dns_resolve_context {
 	 */
 	struct dns_pending_query {
 		/** Timeout timer */
-		struct k_delayed_work timer;
+		struct k_work_delayable timer;
 
 		/** Back pointer to ctx, needed in timeout handler */
 		struct dns_resolve_context *ctx;
 
-		/** Result callback */
+		/** Result callback.
+		 *
+		 * A null value indicates the slot is not in use.
+		 */
 		dns_resolve_cb_t cb;
 
 		/** User data */
@@ -200,6 +203,10 @@ struct dns_resolve_context {
 		k_timeout_t timeout;
 
 		/** String containing the thing to resolve like www.example.com
+		 *
+		 * The pointer is zeroed to indicate that an active query is
+		 * complete.  Release of the query slot is performed by the
+		 * timeout handler.
 		 */
 		const char *query;
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1870,8 +1870,8 @@ static void print_dns_info(const struct shell *shell,
 			continue;
 		}
 
-		remaining =
-			k_delayed_work_remaining_get(&ctx->queries[i].timer);
+		remaining = k_ticks_to_ms_ceil32(
+			k_work_delayable_remaining_get(&ctx->queries[i].timer));
 
 		if (ctx->queries[i].query_type == DNS_QUERY_TYPE_A) {
 			PR("\tIPv4[%u]: %s remaining %d\n",


### PR DESCRIPTION
Cancelling an in-progress work item is not guaranteed to complete synchronously.  Convert the DNS timeout to use the new delayable work structure, and use its handler to release the query slot for use in subsequent operations.

This delays the release of the query slot but avoids some race conditions.

Allocation of slots remains racy as the mixed identification of query slots through pointers and indexes, and the use of a null check for a function pointer (not compatible with the atomic_ptr API) as the in-use condition, makes it difficult to switch to a thread-safe request/release interface.

May help resolve #33101, though other race conditions are not addressed in this PR.