### PR TITLE
driver: espi: npcx: fix out-of-bounds read in espi_vw_generic_isr.

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -433,9 +433,11 @@ static void espi_vw_generic_isr(const struct device *dev, struct npcx_wui *wui)
 		}
 	}
 
-	if (idx == ARRAY_SIZE(vw_in_tbl))
+	if (idx == ARRAY_SIZE(vw_in_tbl)) {
 		LOG_ERR("Unknown VW event! %d %d %d", wui->table,
 				wui->group, wui->bit);
+		return;
+	}
 
 	signal = vw_in_tbl[idx].sig;
 	if (signal == ESPI_VWIRE_SIGNAL_SLP_S3


### PR DESCRIPTION
Fix out-of-bounds read [issue 33048](https://github.com/zephyrproject-rtos/zephyr/issues/33048) in espi_vw_generic_isr func.


Fixes #33048 

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>