### PR TITLE
tests: scheduling: change code annotation

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -142,7 +142,7 @@ void test_sleep_cooperative(void)
 
 void test_busy_wait_cooperative(void)
 {
-	/* set current thread to a preemptible priority */
+	/* set current thread to a cooperative priority */
 	init_prio = -1;
 	setup_threads();
 


### PR DESCRIPTION
Change the code annotation of testcase test_busy_wait_cooperative.

Signed-off-by: Ying ming <mingx.ying@intel.com>