### PR TITLE
script: add ram and rom total size to json file

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -12,6 +12,7 @@ import os
 import sys
 import re
 from pathlib import Path
+import json
 
 from distutils.version import LooseVersion
 
@@ -30,7 +31,7 @@ if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
 from colorama import init, Fore
 
 from anytree import RenderTree, NodeMixin, findall_by_attr
-from anytree.exporter import JsonExporter
+from anytree.exporter import DictExporter
 
 
 # ELF section flags
@@ -633,10 +634,12 @@ def main():
         print_any_tree(root, symsize)
 
         if args.json:
-            exporter = JsonExporter(indent=2, sort_keys=True)
-            data = exporter.export(root)
+            exporter = DictExporter()
+            data = dict()
+            data["symbols"] = exporter.export(root)
+            data["total_size"] = symsize
             with open(args.json, "w") as fp:
-                fp.write(data)
+                json.dump(data, fp, indent=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We want to get the rom and ram size by reading the JSON file. Because it's safer and easier to parse JSON file rather than extract total size from `stdout`. But the printed total size differs from calculated from JSON file https://github.com/zephyrproject-rtos/zephyr/issues/33967.

Take rom size as example. The generated `rom.json' contains only symbols data,  I think we can convert the target data as a python dict which including 2 key-value pairs, and then save this target data into JSON file.
```
            target = dict()
            target["symbols"] = json.loads(data) # The symbols data stored in the JSON file before
            target["total_size"] = symsize
```



Signed-off-by: Jingru Wang <jingru@synopsys.com>