### PR TITLE
driver: timer: npcx: fix dead code flow for K_TICKS_FOREVER.

### DIFF
--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -134,13 +134,12 @@ static int npcx_itim_start_evt_tmr_by_tick(int32_t ticks)
 	 * Get desired cycles of event timer from the requested ticks which
 	 * round up to next tick boundary.
 	 */
-	if (ticks <= 0) {
-		ticks = 1;
-	}
-
 	if (ticks == K_TICKS_FOREVER) {
 		cyc_evt_timeout = NPCX_ITIM32_MAX_CNT;
 	} else {
+		if (ticks <= 0) {
+			ticks = 1;
+		}
 		cyc_evt_timeout = MIN(EVT_CYCLES_FROM_TICKS(ticks),
 				      NPCX_ITIM32_MAX_CNT);
 	}


### PR DESCRIPTION
Fix dead code flow if ticks is K_TICKS_FOREVER. Please refer [issue 33018](https://github.com/zephyrproject-rtos/zephyr/issues/33018) for more detail.

Fixes #33018 

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>