### PR TITLE
driver: clock: npcx: remove useless operands.

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -39,7 +39,7 @@ static inline int npcx_clock_control_on(const struct device *dev,
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
 	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
 
-	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT || clk_cfg->bit >= 8)
+	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT)
 		return -EINVAL;
 
 	/* Clear related PD (Power-Down) bit of module to turn on clock */
@@ -54,7 +54,7 @@ static inline int npcx_clock_control_off(const struct device *dev,
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
 	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
 
-	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT || clk_cfg->bit >= 8)
+	if (clk_cfg->ctrl >= NPCX_PWDWN_CTL_COUNT)
 		return -EINVAL;
 
 	/* Set related PD (Power-Down) bit of module to turn off clock */


### PR DESCRIPTION
Remove useless operands since 'bit' field of npcx_clk_cfg structure is
only 3-bit depth and always under 8. Please refer [issue 33076](https://github.com/zephyrproject-rtos/zephyr/issues/33076) and [issue 33049](https://github.com/zephyrproject-rtos/zephyr/issues/33049) for more detail.


Fixes #33076
Fixes #33049

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>