### PR TITLE
kernel: mailbox: Change a mbox testcase that condition unsuitable

### DIFF
--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -442,11 +442,8 @@ static void thread_mbox_data_get_null(void *p1, void *p2, void *p3)
 	get_msg.size = 16;
 	get_msg.rx_source_thread = K_ANY;
 	get_msg.tx_block.data = str_data;
-	get_msg._syncing_thread = receiver_tid;
-
-	k_mbox_data_get(&get_msg, NULL);
-
 	get_msg._syncing_thread = NULL;
+
 	k_mbox_data_get(&get_msg, NULL);
 	k_sem_give(&end_sema);
 }


### PR DESCRIPTION
fixed: #33114 and #33120
Modify the testcase that run failed on iotdk
and nsim. This testing do not need receive thread ID when invoke
k_mbox_data_get() with NULL param. The testcase purpose is invoke
this API with NULL buffer and NULL receive_id. It will cause fatal
error if use a uninitialize receive id. 

Signed-off-by: Jian Kang <jianx.kang@intel.com>