### PR TITLE
stm32: coverity fixes (gpio and watchdog)

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -363,8 +363,13 @@ static int gpio_stm32_enable_int(int port, int pin)
 		.enr = LL_APB2_GRP1_PERIPH_SYSCFG
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 	};
+	int ret;
+
 	/* Enable SYSCFG clock */
-	clock_control_on(clk, (clock_control_subsys_t *) &pclken);
+	ret = clock_control_on(clk, (clock_control_subsys_t *) &pclken);
+	if (ret != 0) {
+		return ret;
+	}
 #endif
 
 	gpio_stm32_set_exti_source(port, pin);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -251,11 +251,9 @@ static int wwdg_stm32_init(const struct device *dev)
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
-
 	wwdg_stm32_irq_config(dev);
 
-	return 0;
+	return clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 }
 
 static struct wwdg_stm32_data wwdg_stm32_dev_data = {


### PR DESCRIPTION
Fixes: [Coverity CID :219652] Unchecked return value in drivers/gpio/gpio_stm32.c #33035
Fixes:  [Coverity CID :219600] Unchecked return value in drivers/watchdog/wdt_wwdg_stm32.c #33067