### PR TITLE
test: thread : test run k_thread_resume on unsuspend thread

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -40,6 +40,7 @@ extern void test_k_thread_foreach_unlocked_null_cb(void);
 extern void test_k_thread_state_str(void);
 extern void test_threads_cpu_mask(void);
 extern void test_threads_suspend_timeout(void);
+extern void test_resume_unsuspend_thread(void);
 extern void test_threads_suspend(void);
 extern void test_abort_from_isr(void);
 extern void test_abort_from_isr_not_self(void);
@@ -686,6 +687,7 @@ void test_main(void)
 			 ztest_unit_test(test_user_mode),
 			 ztest_1cpu_unit_test(test_threads_cpu_mask),
 			 ztest_unit_test(test_threads_suspend_timeout),
+			 ztest_unit_test(test_resume_unsuspend_thread),
 			 ztest_unit_test(test_threads_suspend),
 			 ztest_user_unit_test(test_thread_join),
 			 ztest_unit_test(test_thread_join_isr),

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -146,3 +146,30 @@ void test_threads_suspend_timeout(void)
 
 	k_thread_abort(tid);
 }
+
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Check resume an unsuspend thread
+ *
+ * @details Use k_thread_state_str() to get thread state.
+ * Resume an unsuspend thread will not change the thread state.
+ */
+void test_resume_unsuspend_thread(void)
+{
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      0, K_USER, K_NO_WAIT);
+
+	/* Resume an unsuspend thread will not change the thread state. */
+	zassert_true(strcmp(k_thread_state_str(tid), "queued") == 0, NULL);
+	k_thread_resume(tid);
+	zassert_true(strcmp(k_thread_state_str(tid), "queued") == 0, NULL);
+
+	/* suspend created thread */
+	k_thread_suspend(tid);
+	zassert_true(strcmp(k_thread_state_str(tid), "suspended") == 0, NULL);
+	/* Resume an suspend thread will make it to be next eligible.*/
+	k_thread_resume(tid);
+	zassert_true(strcmp(k_thread_state_str(tid), "queued") == 0, NULL);
+	k_thread_abort(tid);
+}


### PR DESCRIPTION
If calling function k_thread_resume() when the thread is not suspend,
it takes no effect. This change improve coverage of function
k_thread_resume() in sched.c

Signed-off-by: Ying ming <mingx.ying@intel.com>