### PR TITLE
test: dynamic_thread: Fix race condition

### DIFF
--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -50,10 +50,12 @@ static void create_dynamic_thread(void)
 
 	tid = k_thread_create(dyn_thread, dyn_thread_stack, STACKSIZE,
 			      dyn_thread_entry, NULL, NULL, NULL,
-			      K_PRIO_PREEMPT(0), K_USER, K_NO_WAIT);
+			      K_PRIO_PREEMPT(0), K_USER, K_FOREVER);
 
 	k_object_access_grant(&start_sem, tid);
 	k_object_access_grant(&end_sem, tid);
+
+	k_thread_start(tid);
 
 	k_sem_give(&start_sem);
 
@@ -76,9 +78,11 @@ static void permission_test(void)
 
 	tid = k_thread_create(dyn_thread, dyn_thread_stack, STACKSIZE,
 			      dyn_thread_entry, NULL, NULL, NULL,
-			      K_PRIO_PREEMPT(0), K_USER, K_NO_WAIT);
+			      K_PRIO_PREEMPT(0), K_USER, K_FOREVER);
 
 	k_object_access_grant(&start_sem, tid);
+
+	k_thread_start(tid);
 
 	/*
 	 * Notice dyn_thread will not have permission to access


### PR DESCRIPTION
There is a race between k_sem_take() and k_object_access_grant() so it
is possible (especially when testing SMP) that the thread tries to take
the semaphore before the originating thread has had the chance to
grant it permission.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>