### PR TITLE
Bluetooth: controller: update k_work_pending to new API

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -811,7 +811,7 @@ bool ull_filter_lll_rl_enabled(void)
 uint8_t ull_filter_deferred_resolve(bt_addr_t *rpa, resolve_callback_t cb)
 {
 	if (rl_enable) {
-		if (!k_work_pending(&(resolve_work.prpa_work))) {
+		if (!k_work_is_pending(&(resolve_work.prpa_work))) {
 			/* copy input param to work variable */
 			memcpy(resolve_work.rpa.val, rpa->val, sizeof(bt_addr_t));
 			resolve_work.cb = cb;
@@ -829,7 +829,7 @@ uint8_t ull_filter_deferred_targeta_resolve(bt_addr_t *rpa, uint8_t rl_idx,
 					 resolve_callback_t cb)
 {
 	if (rl_enable) {
-		if (!k_work_pending(&(t_work.target_work))) {
+		if (!k_work_is_pending(&(t_work.target_work))) {
 			/* copy input param to work variable */
 			memcpy(t_work.rpa.val, rpa->val, sizeof(bt_addr_t));
 			t_work.cb = cb;


### PR DESCRIPTION
k_work_pending is now called k_work_is_pending.

These two uses are correct assuming the functions that invoke them are
not involved in race conditions: that the work is not pending is an
allowed condition for modifying state that will be used by the work
handler.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>