### PR TITLE
Flash area functions for listing active and specified type flash memory areas/partitions

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -247,18 +247,22 @@ arduino_spi: &spi3 {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mcuboot,image";
 			label = "mcuboot";
 			reg = <0x000000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,application-image";
 			label = "image-0";
 			reg = <0x0000C000 0x00067000>;
 		};
 		slot1_partition: partition@73000 {
+			compatible = "zephyr,application-image";
 			label = "image-1";
 			reg = <0x00073000 0x00067000>;
 		};
 		scratch_partition: partition@da000 {
+			compatible = "zephyr,mcuboot-scratch";
 			label = "image-scratch";
 			reg = <0x000da000 0x0001e000>;
 		};

--- a/dts/bindings/mtd/zephyr,application-image.yaml
+++ b/dts/bindings/mtd/zephyr,application-image.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Partition or other storage area for application binary image.
+
+compatible: "zephyr,application-image"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true
+  reg:
+    required: true

--- a/dts/bindings/mtd/zephyr,mcuboot-image.yaml
+++ b/dts/bindings/mtd/zephyr,mcuboot-image.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Partition or other storage area for mcuboot bootloader image.
+
+compatible: "zephyr,mcuboot-image"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true
+  reg:
+    required: true

--- a/dts/bindings/mtd/zephyr,mcuboot-scratch.yaml
+++ b/dts/bindings/mtd/zephyr,mcuboot-scratch.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Partition or other storage area for mcuboot bootloader scratch.
+
+compatible: "zephyr,mcuboot-scratch"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true
+  reg:
+    required: true

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -55,7 +55,8 @@ struct flash_area {
 	uint8_t fa_id;
 	/** Provided for compatibility with MCUboot */
 	uint8_t fa_device_id;
-	uint16_t pad16;
+	uint8_t fa_type;
+	uint8_t pad8;
 	/** Start offset from the beginning of the flash device */
 	off_t fa_off;
 	/** Total size */
@@ -66,6 +67,12 @@ struct flash_area {
 	 */
 	const char *fa_dev_name;
 };
+
+#define FLASH_AREA_TYPE_UNSPECIFIED			0x00 /* No type */
+#define FLASH_AREA_TYPE_MCUBOOT				0x01 /* zephyr,mcuboot,image */
+#define FLASH_AREA_TYPE_MCUBOOT_SCRATCH			0x02 /* zephyr,mcuboot,scratch */
+#define FLASH_AREA_TYPE_ZEPHYR_APPLICATION		0x10 /* zephyr,application,image */
+#define FLASH_AREA_TYPE_UNKNOWN				0xff /* Reserved for unknown compatible */
 
 /**
  * @brief Structure for transfer flash sector boundaries

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -116,6 +116,25 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 #endif
 
 /**
+ * @brief Return pointer to flash_area occupied by running application.
+ *
+ * @return non-NULL pointer to @p flash_area structure holding information on area an application is
+ * running; NULL pointer if application is not running from any of the partitions in flash_map.
+ */
+const struct flash_area *flash_area_active(void);
+
+/**
+ * Enumerate flash areas of specified type.
+ *
+ * @param[in] current	Pointer to flash_map entry to start after; if NULL the first entry is used.
+ * @param[in] type	Type to match: one of FLASH_AREA_TYPE_* constants.
+ *
+ * @returns non-NULL pointer to flash area that matches a given type; NULL if there are no more
+ * areas to match.
+ */
+const struct flash_area *flash_area_enum_type(const struct flash_area *current, uint8_t type);
+
+/**
  * @brief Retrieve partitions flash area from the flash_map.
  *
  * Function Retrieves flash_area from flash_map for given partition.

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -275,6 +275,20 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 #define FLASH_AREA_SIZE(label) \
 	DT_REG_SIZE(DT_NODE_BY_FIXED_PARTITION_LABEL(label))
 
+#define FLASH_AREA_NODE_COMPAT_TYPE(n, c, t)  COND_CODE_1(DT_NODE_HAS_COMPAT(n, c), (t), ())
+
+#define FLASH_AREA_NODE_TYPE(n)									   \
+	FLASH_AREA_NODE_COMPAT_TYPE(n, zephyr_mcuboot_image, FLASH_AREA_TYPE_MCUBOOT)		   \
+	FLASH_AREA_NODE_COMPAT_TYPE(n, zephyr_mcuboot_scratch, FLASH_AREA_TYPE_MCUBOOT_SCRATCH)	   \
+	FLASH_AREA_NODE_COMPAT_TYPE(n, zephyr_application_image, FLASH_AREA_TYPE_ZEPHYR_APPLICATION)
+
+#define FLASH_AREA_NODE_TYPE_OR_UNSPECIFIED(n)		\
+	COND_CODE_0(					\
+		IS_EMPTY(FLASH_AREA_NODE_TYPE(n)),	\
+		(FLASH_AREA_NODE_TYPE(n)),		\
+		(FLASH_AREA_TYPE_UNSPECIFIED)		\
+	)
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/subsys/storage/flash_map/flash_area_type/CMakeLists.txt
+++ b/samples/subsys/storage/flash_map/flash_area_type/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(flash_area_type)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/storage/flash_map/flash_area_type/prj.conf
+++ b/samples/subsys/storage/flash_map/flash_area_type/prj.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_LOG=y
+CONFIG_PRINTK=y

--- a/samples/subsys/storage/flash_map/flash_area_type/sample.yaml
+++ b/samples/subsys/storage/flash_map/flash_area_type/sample.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+sample:
+  name: flash_area_type
+  description: Flash area type API usage for partition enumeration
+common:
+  tags: flash_area
+tests:
+  sample.storage.flash_area:
+    platform_allow: nrf52840dk_nrf52840 native_posix
+    tags: flash_area
+    harness: console
+    harness_config:
+        type: multi_line
+        regex:
+          - "Known types:(.*)"
+          - "(.*)"

--- a/samples/subsys/storage/flash_map/flash_area_type/src/main.c
+++ b/samples/subsys/storage/flash_map/flash_area_type/src/main.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Sample explains usage functions:
+ *  flash_area_active
+ *  flash_area_enum_type
+ * and macros:
+ *  FLASH_AREA_FOR_EACH_COMPATIBLE
+ *
+ * for obtaining information on active partitions and generating code for user selected type of
+ * partitions.
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <storage/flash_map.h>
+
+#define MAKE_LIST_ITEM(type, compatible) { type, #type, compatible }
+
+const static struct type_meta {
+	int type;
+	const char *stype;
+	const char *compatible;
+} types[] = {
+	MAKE_LIST_ITEM(FLASH_AREA_TYPE_UNSPECIFIED, "None"),
+	MAKE_LIST_ITEM(FLASH_AREA_TYPE_MCUBOOT, "zephyr,mcuboot,image"),
+	MAKE_LIST_ITEM(FLASH_AREA_TYPE_MCUBOOT_SCRATCH, "zephyr,mcyboot, scratch"),
+	MAKE_LIST_ITEM(FLASH_AREA_TYPE_ZEPHYR_APPLICATION, "zephyr,application,image"),
+	MAKE_LIST_ITEM(FLASH_AREA_TYPE_UNKNOWN, "Unknown")
+};
+
+/*
+ * This function will only present list of known types with C definitions for them and "compatible"
+ * string that they correspond to; function has been provided for convenience.
+ */
+static void list_known_types(void)
+{
+	size_t i = 0;
+
+	printk("Known types:\n");
+	while (i < ARRAY_SIZE(types)) {
+		printk("\t%s = 0x%x, compatible = %s\n", types[i].stype, types[i].type,
+		       types[i].compatible);
+		++i;
+	}
+}
+
+
+/*
+ * The function will enumerate, at run-time, partitions of all known types. Some list may be
+ * generated empty, when the DTS or overlay does not specify the partition or it has been
+ * disabled within DTS.
+ */
+static void enum_all_of_type(const struct type_meta *t)
+{
+	const struct flash_area *other = NULL;
+
+	printk("\nList of all %s areas\n", t->stype);
+	printk(" Offset | ID\n");
+	printk("========+====\n");
+	while (1) {
+		other = flash_area_enum_type(other, t->type);
+		if (other == NULL) {
+			break;
+		}
+
+		printk("%8lx|%4d\n", (unsigned long)other->fa_off, other->fa_id);
+	}
+	printk("--------+----\n");
+}
+
+
+/*
+ * Macros given as function parameter to FLASH_AREA_FOR_EACH_COMPATIBLE take two parameters; first
+ * parameter is the instance index of compatible the second is the compatible string, same one
+ * that is passed as a first parameter to FLASH_AREA_FOR_EACH_COMPATIBLE.
+ *
+ * The exemplary macro below will expand each par of idx (index) and compat (compatible) to
+ * printk printing the partition ID and string representing the DT node that represents the
+ * partition.
+ */
+#define PRINT_ID_AND_NODE(idx, compat)				\
+	printk(" ID %d -> %s\n",				\
+	       DT_FIXED_PARTITION_ID(DT_INST(idx, compat)),	\
+	       STRINGIFY(DT_INST(idx, compat))			\
+	);							\
+
+/*
+ * Function, together with PRINT_ID_AND_NODE macro, provides example on how compile time expansion
+ * works; the FLASH_AREA_FOR_EACH_COMPATIBLE can be also used to generate structure at compile time.
+ */
+static void compile_time_expanded(void)
+{
+	printk("\nExamples of compile time expansions by 'compatible'\n");
+	printk("===================================================\n");
+	printk("List of zephyr,mcuboot,image:\n");
+	FLASH_AREA_FOR_EACH_COMPATIBLE(zephyr_mcuboot_image, PRINT_ID_AND_NODE);
+	printk("List of zephyr,mcuboot,scratch:\n");
+	FLASH_AREA_FOR_EACH_COMPATIBLE(zephyr_mcuboot_scratch, PRINT_ID_AND_NODE);
+	printk("List of zephyr,application,image:\n");
+	FLASH_AREA_FOR_EACH_COMPATIBLE(zephyr_application_image, PRINT_ID_AND_NODE);
+	printk("List of fake, not exisitng partition (empty):\n");
+	FLASH_AREA_FOR_EACH_COMPATIBLE(not_existing_junk, PRINT_ID_AND_NODE);
+}
+
+void main(void)
+{
+	/* raw disk i/o */
+	const struct flash_area *active = flash_area_active();
+
+	/* Just list know types for reference  */
+	list_known_types();
+
+	if (active == NULL) {
+		printk("\nActive flash area not found in flash map\n");
+	} else {
+		printk("\nActive flash area is %p, ID is %d, type is 0x%x\n", active, active->fa_id,
+		       active->fa_type);
+	}
+
+	/* Go through the list of types and print lists of flash areas that have certain type */
+	for (int i = 0; i < ARRAY_SIZE(types); ++i) {
+		enum_all_of_type(&types[i]);
+	}
+
+	compile_time_expanded();
+}

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -13,6 +13,7 @@
 #define FLASH_AREA_FOO(part)						\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
 	 .fa_off = DT_REG_ADDR(part),					\
+	 .fa_type = FLASH_AREA_NODE_TYPE_OR_UNSPECIFIED(part),		\
 	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
 	 .fa_size = DT_REG_SIZE(part),},
 


### PR DESCRIPTION
The PR adds:
  - dts bindings for describing type of flash partitions (compatibles)
  - adds FLASH_AREA_TYPE definitions that correspond to new compatibles
  - adds functions to get information on active partition end enumerate partitions by type
  - modifies default flash map to add type of partition
  

TODO
- [ ] Tests for macros
- [ ] Tests for functions
- [ ] Documentation
- [ ] Sample overlays
- [ ]  Modify code that needs to figure out DFU or active partition to use the new API

Resolves #32257
