### PR TITLE
aarch64: Fix nested counter macros

### DIFF
--- a/arch/arm/core/aarch64/irq_manage.c
+++ b/arch/arm/core/aarch64/irq_manage.c
@@ -70,8 +70,3 @@ void z_irq_spurious(const void *unused)
 
 	z_arm64_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
 }
-
-_cpu_t *z_arm64_curr_cpu(void)
-{
-	return arch_curr_cpu();
-}

--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -33,7 +33,7 @@ GTEXT(_isr_wrapper)
 SECTION_FUNC(TEXT, _isr_wrapper)
 
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	inc_nest_counter
+	inc_nest_counter x0, x1
 
 #ifdef CONFIG_TRACING
 	bl	sys_trace_isr_enter
@@ -80,7 +80,7 @@ spurious_continue:
 #endif
 
 	/* if (--(_kernel->nested) != 0) exit */
-	dec_nest_counter
+	dec_nest_counter x0, x1
 
 	bne	exit
 

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -16,7 +16,7 @@ GDATA(_kernel)
  * Get CPU id
  */
 
-.macro z_arm64_get_cpu_id xreg0
+.macro get_cpu_id xreg0
 	mrs	\xreg0, mpidr_el1
 	/* FIMXME: aff3 not taken into consideration */
 	ubfx	\xreg0, \xreg0, #0, #24
@@ -28,7 +28,7 @@ GDATA(_kernel)
 
 .macro get_cpu xreg0, xreg1
 	ldr	\xreg0, =_curr_cpu
-	z_arm64_get_cpu_id \xreg1
+	get_cpu_id \xreg1
 	add	\xreg0, \xreg0, \xreg1, lsl #3
 	ldr	\xreg0, [\xreg0]
 .endm

--- a/arch/arm/core/aarch64/macro_priv.inc
+++ b/arch/arm/core/aarch64/macro_priv.inc
@@ -9,31 +9,64 @@
 
 #ifdef _ASMLANGUAGE
 
+GDATA(_curr_cpu)
+GDATA(_kernel)
+
+/*
+ * Get CPU id
+ */
+
 .macro z_arm64_get_cpu_id xreg0
 	mrs	\xreg0, mpidr_el1
 	/* FIMXME: aff3 not taken into consideration */
 	ubfx	\xreg0, \xreg0, #0, #24
 .endm
+
+/*
+ * Get CPU pointer
+ */
+
+.macro get_cpu xreg0, xreg1
+	ldr	\xreg0, =_curr_cpu
+	z_arm64_get_cpu_id \xreg1
+	add	\xreg0, \xreg0, \xreg1, lsl #3
+	ldr	\xreg0, [\xreg0]
+.endm
+
 /*
  * Increment nested counter
  */
 
-.macro inc_nest_counter
-	bl	z_arm64_curr_cpu
-	ldr	x1, [x0, #___cpu_t_nested_OFFSET]
-	add	x1, x1, #1
-	str	x1, [x0, #___cpu_t_nested_OFFSET]
+.macro inc_nest_counter xreg0, xreg1
+#ifdef CONFIG_SMP
+	get_cpu	\xreg0, \xreg1
+	ldr	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
+	add	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
+#else
+	ldr	\xreg0, =_kernel
+	ldr	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+	add	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+#endif
 .endm
 
 /*
  * Decrement nested counter and update condition flags
  */
 
-.macro dec_nest_counter
-	bl	z_arm64_curr_cpu
-	ldr	x1, [x0, #___cpu_t_nested_OFFSET]
-	subs	x1, x1, #1
-	str	x1, [x0, #___cpu_t_nested_OFFSET]
+.macro dec_nest_counter xreg0, xreg1
+#ifdef CONFIG_SMP
+	get_cpu	\xreg0, \xreg1
+	ldr	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
+	subs	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #___cpu_t_nested_OFFSET]
+#else
+	ldr	\xreg0, =_kernel
+	ldr	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+	subs	\xreg1, \xreg1, #1
+	str	\xreg1, [\xreg0, #_kernel_offset_to_nested]
+#endif
 .endm
 
 #endif /* _ASMLANGUAGE */

--- a/arch/arm/core/aarch64/reset.S
+++ b/arch/arm/core/aarch64/reset.S
@@ -76,7 +76,7 @@ out:
 	msr	SPSel, #0
 
 #if CONFIG_MP_NUM_CPUS > 1
-	z_arm64_get_cpu_id	x0
+	get_cpu_id x0
 	cbnz    x0, L_secondary_stack
 #endif
 
@@ -89,7 +89,7 @@ out:
 
 #if CONFIG_MP_NUM_CPUS > 1
 L_secondary_stack:
-	z_arm64_get_cpu_id	x1
+	get_cpu_id x1
 	adr	x0, arm64_cpu_init
 	mov	x2, #ARM64_CPU_INIT_SIZE
 	madd	x0, x1, x2, x0
@@ -156,7 +156,7 @@ switch_el:
 	isb
 
 #if CONFIG_MP_NUM_CPUS > 1
-	z_arm64_get_cpu_id	x0
+	get_cpu_id x0
 	cbnz    x0, L_enable_secondary
 #endif
 

--- a/arch/arm/core/aarch64/switch.S
+++ b/arch/arm/core/aarch64/switch.S
@@ -20,8 +20,6 @@
 
 _ASM_FILE_PROLOGUE
 
-GDATA(_kernel)
-
 /*
  * Routine to handle context switches
  *
@@ -119,12 +117,12 @@ SECTION_FUNC(TEXT, z_arm64_sync_exc)
 	b	inv
 offload:
 	/* ++(_kernel->nested) to be checked by arch_is_in_isr() */
-	inc_nest_counter
+	inc_nest_counter x0, x1
 
 	bl	z_irq_do_offload
 
 	/* --(_kernel->nested) */
-	dec_nest_counter
+	dec_nest_counter x0, x1
 	b	z_arm64_exit_exc
 #endif
 	b	inv


### PR DESCRIPTION
As explained in the commit message the `{inc,dec}_nested_counter` macros have several problems, mainly the macros can unexpectedly clobber several registers without any notice. It's just better to make the clobbered registers explicit again and avoid using a call to function to retrieve the current cpu pointer.