### PR TITLE
net: dhcpv4: The client needs info about network interfaces

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -48,6 +48,8 @@ config NET_IPV4_ACCEPT_ZERO_BROADCAST
 
 config NET_DHCPV4
 	bool "Enable DHCPv4 client"
+	select NET_MGMT
+	select NET_MGMT_EVENT
 	depends on NET_UDP
 
 config NET_DHCPV4_INITIAL_DELAY_MAX


### PR DESCRIPTION
DHCPv4 client code needs to know information when network
interfaces are going down and up. So make sure that network
management config options are enabled in that case.

Fixes #33137

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>