### PR TITLE
bluetooth: mesh: update heartbeat use of k_work API

### DIFF
--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -31,7 +31,7 @@ struct hb_pub_val {
 static struct bt_mesh_hb_pub pub;
 static struct bt_mesh_hb_sub sub;
 static struct k_delayed_work sub_timer;
-static struct k_delayed_work pub_timer;
+static struct k_work_delayable pub_timer;
 
 static int64_t sub_remaining(void)
 {
@@ -45,7 +45,7 @@ static int64_t sub_remaining(void)
 static void hb_publish_end_cb(int err, void *cb_data)
 {
 	if (pub.period && pub.count > 1) {
-		k_delayed_work_submit(&pub_timer, K_SECONDS(pub.period));
+		k_work_reschedule(&pub_timer, K_SECONDS(pub.period));
 	}
 
 	if (pub.count != 0xffff) {
@@ -149,14 +149,15 @@ static void hb_publish(struct k_work *work)
 
 	BT_DBG("hb_pub.count: %u", pub.count);
 
+	/* Fast exit if disabled or expired */
+	if (pub.period == 0U || pub.count == 0U) {
+		return;
+	}
+
 	sub = bt_mesh_subnet_get(pub.net_idx);
 	if (!sub) {
 		BT_ERR("No matching subnet for idx 0x%02x", pub.net_idx);
 		pub.dst = BT_MESH_ADDR_UNASSIGNED;
-		return;
-	}
-
-	if (pub.count == 0U) {
 		return;
 	}
 
@@ -216,7 +217,11 @@ static void pub_disable(void)
 	pub.ttl = 0U;
 	pub.period = 0U;
 
-	k_delayed_work_cancel(&pub_timer);
+	/* Try to cancel, but it's OK if this still runs (or is
+	 * running) as the handler will be a no-op if it hasn't
+	 * already checked period for being non-zero.
+	 */
+	(void)k_work_cancel_delayable(&pub_timer);
 }
 
 uint8_t bt_mesh_hb_pub_set(struct bt_mesh_hb_pub *new_pub)
@@ -248,12 +253,11 @@ uint8_t bt_mesh_hb_pub_set(struct bt_mesh_hb_pub *new_pub)
 	/* The first Heartbeat message shall be published as soon as possible
 	 * after the Heartbeat Publication Period state has been configured for
 	 * periodic publishing.
+	 *
+	 * If the new configuration disables publishing this flushes
+	 * the work item.
 	 */
-	if (pub.period && pub.count) {
-		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
-	} else {
-		k_delayed_work_cancel(&pub_timer);
-	}
+	k_work_reschedule(&pub_timer, K_NO_WAIT);
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_settings_store_schedule(
@@ -347,7 +351,7 @@ void bt_mesh_hb_feature_changed(uint16_t features)
 void bt_mesh_hb_init(void)
 {
 	pub.net_idx = BT_MESH_KEY_UNUSED;
-	k_delayed_work_init(&pub_timer, hb_publish);
+	k_work_init_delayable(&pub_timer, hb_publish);
 	k_delayed_work_init(&sub_timer, sub_end);
 }
 
@@ -355,20 +359,23 @@ void bt_mesh_hb_start(void)
 {
 	if (pub.count && pub.period) {
 		BT_DBG("Starting heartbeat publication");
-		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
+		k_work_reschedule(&pub_timer, K_NO_WAIT);
 	}
 }
 
 void bt_mesh_hb_suspend(void)
 {
-	k_delayed_work_cancel(&pub_timer);
+	/* Best-effort suspend.  This cannot guarantee that an
+	 * in-progress publish will not complete.
+	 */
+	(void)k_work_cancel_delayable(&pub_timer);
 }
 
 void bt_mesh_hb_resume(void)
 {
 	if (pub.period && pub.count) {
 		BT_DBG("Starting heartbeat publication");
-		k_delayed_work_submit(&pub_timer, K_NO_WAIT);
+		k_work_reschedule(&pub_timer, K_NO_WAIT);
 	}
 }
 

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -30,7 +30,7 @@ struct hb_pub_val {
 
 static struct bt_mesh_hb_pub pub;
 static struct bt_mesh_hb_sub sub;
-static struct k_delayed_work sub_timer;
+static struct k_work_delayable sub_timer;
 static struct k_work_delayable pub_timer;
 
 static int64_t sub_remaining(void)
@@ -39,7 +39,10 @@ static int64_t sub_remaining(void)
 		return 0U;
 	}
 
-	return k_delayed_work_remaining_get(&sub_timer) / MSEC_PER_SEC;
+	uint32_t rem_ms = k_ticks_to_ms_floor32(
+		k_work_delayable_remaining_get(&sub_timer));
+
+	return rem_ms / MSEC_PER_SEC;
 }
 
 static void hb_publish_end_cb(int err, void *cb_data)
@@ -187,8 +190,8 @@ int bt_mesh_hb_recv(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 		return 0;
 	}
 
-	if (!k_delayed_work_pending(&sub_timer)) {
-		BT_DBG("Heartbeat subscription period expired");
+	if (!k_work_delayable_is_pending(&sub_timer)) {
+		BT_DBG("Heartbeat subscription inactive");
 		return 0;
 	}
 
@@ -299,10 +302,7 @@ uint8_t bt_mesh_hb_sub_set(uint16_t src, uint16_t dst, uint32_t period)
 		sub.min_hops = 0U;
 		sub.max_hops = 0U;
 		sub.count = 0U;
-		sub.period = sub.period - sub_remaining();
-		if (!k_delayed_work_cancel(&sub_timer)) {
-			notify_sub_end();
-		}
+		sub.period = 0U;
 	} else if (period) {
 		sub.src = src;
 		sub.dst = dst;
@@ -310,16 +310,17 @@ uint8_t bt_mesh_hb_sub_set(uint16_t src, uint16_t dst, uint32_t period)
 		sub.max_hops = 0U;
 		sub.count = 0U;
 		sub.period = period;
-		k_delayed_work_submit(&sub_timer, K_SECONDS(period));
 	} else {
 		/* Clearing the period should stop heartbeat subscription
 		 * without clearing the parameters, so we can still read them.
 		 */
-		sub.period = sub.period - sub_remaining();
-		if (!k_delayed_work_cancel(&sub_timer)) {
-			notify_sub_end();
-		}
+		sub.period = 0U;
 	}
+
+	/* Start the timer, which notifies immediately if the new
+	 * configuration disables the subscription.
+	 */
+	k_work_reschedule(&sub_timer, K_SECONDS(sub.period));
 
 	return STATUS_SUCCESS;
 }
@@ -352,7 +353,7 @@ void bt_mesh_hb_init(void)
 {
 	pub.net_idx = BT_MESH_KEY_UNUSED;
 	k_work_init_delayable(&pub_timer, hb_publish);
-	k_delayed_work_init(&sub_timer, sub_end);
+	k_work_init_delayable(&sub_timer, sub_end);
 }
 
 void bt_mesh_hb_start(void)


### PR DESCRIPTION
Replace the legacy delayed work API with the new delayable work API.  Avoid race conditions in canceling work items by using a zero period as a flag value to ensure that the work publish handler is a no-op of the publish operation is disabled, and allow subscription expiration to be done by the handler.
