### PR TITLE
tests/subsys/dfu/mcuboot: Fix coverity issue on not checked return val

### DIFF
--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -77,7 +77,7 @@ void test_request_upgrade(void)
 	zassert(memcmp(expectation, readout, sizeof(expectation)) == 0,
 		"pass", "fail");
 
-	boot_erase_img_bank(FLASH_AREA_ID(image_1));
+	zassert(boot_erase_img_bank(FLASH_AREA_ID(image_1)) == 0, "pass", "fail");
 
 	zassert(boot_request_upgrade(true) == 0, "pass", "fail");
 


### PR DESCRIPTION
The commit fixes coverity issue where return status bank erase operation
has not been checked prior to proceeding with tests.

Fixes: #32924, Coverity-CID: 219522

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>