### PR TITLE
bluetooth: mesh: health_srv: update k_work API

### DIFF
--- a/include/bluetooth/mesh/health_srv.h
+++ b/include/bluetooth/mesh/health_srv.h
@@ -153,7 +153,7 @@ struct bt_mesh_health_srv {
 	const struct bt_mesh_health_srv_cb *cb;
 
 	/** Attention Timer state */
-	struct k_delayed_work attn_timer;
+	struct k_work_delayable attn_timer;
 };
 
 /** @def BT_MESH_MODEL_HEALTH_SRV


### PR DESCRIPTION
Switch to new work API.  Avoid a racy cancel by allowing the work
handler to deal with an immediate off when the time remaining changes
to zero.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>