### PR TITLE
net: utils: fix strlen issue in net_addr_pton

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -452,12 +452,11 @@ int z_impl_net_addr_pton(sa_family_t family, const char *src,
 int z_vrfy_net_addr_pton(sa_family_t family, const char *src,
 			 void *dst)
 {
-	char str[INET6_ADDRSTRLEN];
+	char str[MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN)] = {};
 	struct in6_addr addr6;
 	struct in_addr addr4;
 	void *addr;
 	size_t size;
-	size_t nlen;
 	int err;
 
 	if (family == AF_INET) {
@@ -470,16 +469,11 @@ int z_vrfy_net_addr_pton(sa_family_t family, const char *src,
 		return -EINVAL;
 	}
 
-	memset(str, 0, sizeof(str));
-
-	nlen = z_user_string_nlen((const char *)src, sizeof(str), &err);
-	if (err) {
+	if (z_user_string_copy(str, (char *)src, sizeof(str)) != 0) {
 		return -EINVAL;
 	}
 
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, size));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(src, nlen));
-	Z_OOPS(z_user_from_copy(str, (const void *)src, nlen));
 
 	err = z_impl_net_addr_pton(family, str, addr);
 	if (err) {


### PR DESCRIPTION
Previously, a non null-terminated "string" could
be passed to z_impl_net_addr_pton if the string was
exactly `INET6_ADDRSTRLEN` long.

Signed-off-by: James Harris <james.harris@intel.com>