### PR TITLE
intel_adsp test fixups

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.yaml
@@ -4,7 +4,3 @@ type: mcu
 arch: xtensa
 toolchain:
   - zephyr
-testing:
-  only_tags:
-     - kernel
-     - sof

--- a/samples/application_development/external_lib/sample.yaml
+++ b/samples/application_development/external_lib/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.app_dev.external_lib:
     integration_platforms:
       - native_posix
+    platform_exclude: intel_adsp_cavs15
     tags: external
     harness: console
     harness_config:

--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -4,7 +4,7 @@ sample:
 common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   tags: posix
-  platform_exclude: m2gl025_miv
+  platform_exclude: m2gl025_miv intel_adsp_cavs15
   integration_platforms:
     - mps2_an385
 tests:

--- a/samples/posix/gettimeofday/sample.yaml
+++ b/samples/posix/gettimeofday/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: POSIX API gettimeofday() example (with SNTP)
   name: gettimeofday
 common:
-  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  filter: ( TOOLCHAIN_HAS_NEWLIB == 1 and not CONFIG_SOC_FAMILY_INTEL_ADSP )
   harness: net
   min_ram: 32
   min_flash: 96

--- a/samples/userspace/hello_world_user/sample.yaml
+++ b/samples/userspace/hello_world_user/sample.yaml
@@ -5,6 +5,7 @@ sample:
 common:
     integration_platforms:
       - mps2_an385
+    platform_exclude: intel_adsp_cavs15
     tags: introduction
     harness: console
     harness_config:

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -58,9 +58,6 @@ config TEST_LOGGING_DEFAULTS
 
 if LOG
 
-config LOG_PRINTK
-	default y
-
 config LOG_BACKEND_ADSP
 	default y
 

--- a/soc/xtensa/intel_adsp/cavs_v15/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v15/linker.ld
@@ -502,6 +502,8 @@ SECTIONS
   /* Initial/boot stack lives in the CPU0 interrupt stack */
   __stack = z_interrupt_stacks + CONFIG_ISR_STACK_SIZE;
 
+  _end = .;
+
   /* dma buffers */
   .lpbuf (NOLOAD): ALIGN(4)
   {

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -61,10 +61,6 @@ config TEST_LOGGING_DEFAULTS
 
 if LOG
 
-# When console is enabled printk should go through it
-config LOG_PRINTK
-	default y if !CONSOLE
-
 config LOG_BACKEND_ADSP
 	default y
 

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -61,9 +61,6 @@ config TEST_LOGGING_DEFAULTS
 
 if LOG
 
-config LOG_PRINTK
-	default y
-
 config LOG_BACKEND_ADSP
 	default y
 

--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -61,9 +61,6 @@ config TEST_LOGGING_DEFAULTS
 
 if LOG
 
-config LOG_PRINTK
-	default y
-
 config LOG_BACKEND_ADSP
 	default y
 

--- a/soc/xtensa/intel_adsp/common/bootloader.cmake
+++ b/soc/xtensa/intel_adsp/common/bootloader.cmake
@@ -24,7 +24,7 @@ add_custom_target(
   COMMAND ${CMAKE_OBJCOPY} --add-section .module=mod-apl.bin --set-section-flags .module=load,readonly ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME} ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}.mod
 
   # Adjust final section addresses so they all appear in the cached region.
-  COMMAND ${ELF_FIX} ${CMAKE_OBJCOPY} ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf.mod
+  COMMAND ${ELF_FIX} ${CMAKE_OBJCOPY} ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}.mod
   )
 
 add_custom_target(

--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   crypto.tinycrypt:
     tags: tinycrypt crypto aes ccm
-    platform_exclude: qemu_arc_em qemu_arc_hs
+    platform_exclude: qemu_arc_em qemu_arc_hs intel_adsp_cavs15
     timeout: 300
     integration_platforms:
       - native_posix

--- a/tests/kernel/fatal/message_capture/testcase.yaml
+++ b/tests/kernel/fatal/message_capture/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.logging.message_capture:
     tags: kernel
+    platform_exclude: intel_adsp_cavs15
     harness: console
     harness_config:
       type: multi_line

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -144,7 +144,7 @@ void test_spinlock_bounce(void)
 void test_spinlock_mutual_exclusion(void)
 {
 	k_spinlock_key_t key;
-	struct k_spinlock lock_runtime;
+	static struct k_spinlock lock_runtime;
 	unsigned int irq_key;
 
 	(void)memset(&lock_runtime, 0, sizeof(lock_runtime));

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -1320,7 +1320,7 @@ static void test_1cpu_legacy_delayed_submit(void)
 	uint32_t max_ms = k_ticks_to_ms_ceil32(1U
 				+ k_ms_to_ticks_ceil32(DELAY_MS));
 	uint32_t elapsed_ms;
-	struct k_delayed_work lwork;
+	static struct k_delayed_work lwork;
 
 	/* Reset state and use non-blocking handler */
 	reset_counters();
@@ -1362,7 +1362,7 @@ static void test_1cpu_legacy_delayed_resubmit(void)
 	uint32_t max_ms = k_ticks_to_ms_ceil32(1U
 				+ k_ms_to_ticks_ceil32(DELAY_MS));
 	uint32_t elapsed_ms;
-	struct k_delayed_work lwork;
+	static struct k_delayed_work lwork;
 
 	/* Reset state and use non-blocking handler */
 	reset_counters();
@@ -1408,7 +1408,7 @@ static void test_1cpu_legacy_delayed_resubmit(void)
 static void test_1cpu_legacy_delayed_cancel(void)
 {
 	int rc;
-	struct k_delayed_work lwork;
+	static struct k_delayed_work lwork;
 
 	/* Reset state and use non-blocking handler */
 	reset_counters();

--- a/tests/lib/cbprintf_fp/testcase.yaml
+++ b/tests/lib/cbprintf_fp/testcase.yaml
@@ -4,6 +4,7 @@ common:
   integration_platforms:
     - qemu_x86
     - qemu_x86_64
+  filter: CONSOLE_HAS_DRIVER
 tests:
   lib.cbprintf_fp.printk:
     extra_configs:

--- a/tests/lib/onoff/src/main.c
+++ b/tests/lib/onoff/src/main.c
@@ -1054,7 +1054,7 @@ static void test_cancel_or_release(void)
 
 static void test_sync_basic(void)
 {
-	struct onoff_sync_service srv = {};
+	static struct onoff_sync_service srv = {};
 	k_spinlock_key_t key;
 	int res = 5;
 	int rc;
@@ -1131,7 +1131,7 @@ static void test_sync_basic(void)
 
 static void test_sync_error(void)
 {
-	struct onoff_sync_service srv = {};
+	static struct onoff_sync_service srv = {};
 	k_spinlock_key_t key;
 	int res = -EPERM;
 	int rc;

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -845,7 +845,7 @@ void test_ringbuffer_equal_bufs(void)
 void test_ringbuffer_performance(void)
 {
 	uint8_t buf[16];
-	struct ring_buf rbuf;
+	static struct ring_buf rbuf;
 	uint8_t indata[16];
 	uint8_t outdata[16];
 	uint8_t *ptr;

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -121,7 +121,7 @@ static void test_net_buf_1(void)
 static void test_net_buf_2(void)
 {
 	struct net_buf *frag, *head;
-	struct k_fifo fifo;
+	static struct k_fifo fifo;
 	int i;
 
 	head = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
@@ -169,8 +169,8 @@ static void test_net_buf_3(void)
 {
 	static struct k_thread test_3_thread_data;
 	struct net_buf *frag, *head;
-	struct k_fifo fifo;
-	struct k_sem sema;
+	static struct k_fifo fifo;
+	static struct k_sem sema;
 	int i;
 
 	head = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: net socket userspace
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  platform_exclude: intel_adsp_cavs15
 tests:
   net.socket.socketpair:
     min_ram: 21

--- a/tests/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/portability/cmsis_rtos_v2/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   portability.cmsis_rtos_v2:
-    platform_exclude: m2gl025_miv
+    platform_exclude: m2gl025_miv intel_adsp_cavs15
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/subsys/logging/log_immediate/testcase.yaml
+++ b/tests/subsys/logging/log_immediate/testcase.yaml
@@ -5,10 +5,10 @@ common:
 tests:
   logging.log_immediate:
     tags: log_core logging
-    platform_exclude: nucleo_l053r8 nucleo_f030r8
+    platform_exclude: nucleo_l053r8 nucleo_f030r8 intel_adsp_cavs15
       stm32f0_disco nrf52_bsim
   logging.log_immediate.clean_output:
     extra_args: CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT=y
     tags: log_core logging
-    platform_exclude: nucleo_l053r8 nucleo_f030r8
+    platform_exclude: nucleo_l053r8 nucleo_f030r8 intel_adsp_cavs15
       stm32f0_disco nrf52_bsim

--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -4,4 +4,5 @@ common:
 
 tests:
   logging.log_output:
+    platform_exclude: intel_adsp_cavs15
     tags: log_output logging


### PR DESCRIPTION
Post-merge of the big series, these are the remaining patches I'm tracking which are needed to get to reliable test runs on CAVS 1.5 hardware.

Note that this includes some test exclusions that are tracked in #32836 and that I see a handful of new failures due to changes in test code over the past week.  So there will be another fixup coming behind this one.