### PR TITLE
west_commands: runners: openocd: clear DHCSR after flashing completes

### DIFF
--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -16,7 +16,18 @@ endif()
 set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH}")
 set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image")
 
+# Cortex-M-specific halt debug enable bit clearing:
+# OpenOCD sets DHCSR.DEBUGEN to 1 to halt and flash the target.
+# As openOCD shutdown does not clear DEBUGEN, we introduce a runner
+# option to explicitly clear DEBUGEN (Halt Debug Enable bit) after
+# openOCD has finished flashing and resetting the target (but before
+# it shuts down).
+if(CONFIG_CPU_CORTEX_M)
+set(OPENOCD_CMD_HALT_DEBUG_EN_CLEAR "mww 0xE000EDF0 0xA05F0000")
+endif()
+
 board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"
   --cmd-verify "${OPENOCD_CMD_VERIFY_DEFAULT}"
+  --cmd-post-reset "${OPENOCD_CMD_HALT_DEBUG_EN_CLEAR}"
   )

--- a/boards/common/pyocd.board.cmake
+++ b/boards/common/pyocd.board.cmake
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Cortex-M-specific halt debug enable bit clearing:
+# OpenOCD sets DHCSR.DEBUGEN to 1 to halt and flash the target.
+# As openOCD shutdown does not clear DEBUGEN, we introduce a runner
+# option to explicitly clear DEBUGEN (Halt Debug Enable bit) after
+# openOCD has finished flashing and resetting the target (but before
+# it shuts down).
+if(CONFIG_CPU_CORTEX_M)
+set(PYOCD_CMD_HALT_DEBUG_EN_CLEAR "write32 0xE000EDF0 0xA05F0000")
+endif()
+
+
 board_set_flasher_ifnset(pyocd)
 board_set_debugger_ifnset(pyocd)
-board_finalize_runner_args(pyocd "--dt-flash=y")
+board_finalize_runner_args(pyocd "--dt-flash=y"
+    --post-flash "${PYOCD_CMD_HALT_DEBUG_EN_CLEAR}")


### PR DESCRIPTION
Fixes #32984 

openOCD does not clear DHCSR.DEBUGEN bit after flashing
completes, effectively leaving the Cortex-M processor in
debug mode. Manually clean DHCSR becore exiting the flash
operation, to work around the problem.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>