### PR TITLE
drivers: gpio: mchp: Add support for GPIO disconnected flag

### DIFF
--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -133,6 +133,13 @@ static int gpio_xec_configure(const struct device *dev,
 		mask = MCHP_GPIO_CTRL_DIR_MASK;
 		pcr1 = MCHP_GPIO_CTRL_DIR_OUTPUT;
 		*current_pcr1 = (*current_pcr1 & ~mask) | pcr1;
+	} else if ((flags & GPIO_INPUT) != 0U) {
+		/* Already configured */
+	} else {
+		/*  GPIO disconnected */
+		mask |= MCHP_GPIO_CTRL_PWRG_MASK;
+		pcr1 |= MCHP_GPIO_CTRL_PWRG_OFF;
+		*current_pcr1 = (*current_pcr1 & ~mask) | pcr1;
 	}
 
 	return 0;


### PR DESCRIPTION
Currently, if GPIO_DISCONNECTED flag is used pin remains as input,
this causes some additional power to be drain which is
undesired.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>