### PR TITLE
driver: espi: npcx: prevent changing data content in host write func.

### DIFF
--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -780,7 +780,7 @@ int npcx_host_periph_read_request(enum lpc_peripheral_opcode op,
 }
 
 int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
-								uint32_t *data)
+							const uint32_t *data)
 {
 	volatile uint32_t __attribute__((unused)) dummy;
 	struct kbc_reg *const inst_kbc = host_sub_cfg.inst_kbc;
@@ -827,13 +827,11 @@ int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
 			break;
 		case E8042_SET_FLAG:
 			/* FW shouldn't modify these flags directly */
-			*data &= ~NPCX_KBC_STS_MASK;
-			inst_kbc->HIKMST |= *data;
+			inst_kbc->HIKMST |= *data & ~NPCX_KBC_STS_MASK;
 			break;
 		case E8042_CLEAR_FLAG:
 			/* FW shouldn't modify these flags directly */
-			*data &= ~NPCX_KBC_STS_MASK;
-			inst_kbc->HIKMST &= ~(*data);
+			inst_kbc->HIKMST &= ~(*data | NPCX_KBC_STS_MASK);
 			break;
 		default:
 			return -EINVAL;

--- a/soc/arm/nuvoton_npcx/common/soc_host.h
+++ b/soc/arm/nuvoton_npcx/common/soc_host.h
@@ -66,7 +66,7 @@ int npcx_host_periph_read_request(enum lpc_peripheral_opcode op,
  * @retval -EINVAL for unimplemented lpc opcode, but in range.
  */
 int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
-								uint32_t *data);
+							const uint32_t *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This CL prevents changing data content in the write function of host
interface by declaring it as constant pointer. Please refer [issue 33024](https://github.com/zephyrproject-rtos/zephyr/issues/33024) for more detail.

Fixes #33024 

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>