### PR TITLE
testcase:qspi: modify the value used to check whether qspi is enabled

### DIFF
--- a/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
+++ b/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
@@ -446,7 +446,7 @@ void test_spi_quad_write(void)
 				"error %d", ret);
 
 		spi_status2 = safbuf2[0];
-		zassert_true((spi_status2 & SPI_STATUS2_QE) == 1,
+		zassert_true((spi_status2 & SPI_STATUS2_QE) == SPI_STATUS2_QE,
 				"Enable QSPI mode failure");
 	}
 


### PR DESCRIPTION
if qspi mode is enabled, the status register will be like xxxxxx1x, so we should compare with value 2 to check whether qspi mode
is enabled successfully.
however, for now it compared with value 1, so it reported a coverity issue "operands don't affect result", because this line zassert_true((spi_status2 & SPI_STATUS2_QE) == 1 always failed.

fixed: #32920 

Signed-off-by: peng1 chen <peng1.chen@intel.com>