### PR TITLE
Test: queue: Add a testcase to test queue

### DIFF
--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -54,6 +54,7 @@ void test_main(void)
 			 ztest_unit_test(test_queue_alloc),
 			 ztest_1cpu_unit_test(test_queue_poll_race),
 			 ztest_unit_test(test_multiple_queues),
+			 ztest_unit_test(test_queue_multithread_competition),
 			 ztest_unit_test(test_access_kernel_obj_with_priv_data),
 			 ztest_unit_test(test_queue_append_list_error),
 			 ztest_unit_test(test_queue_merge_list_error),

--- a/tests/kernel/queue/src/test_queue.h
+++ b/tests/kernel/queue/src/test_queue.h
@@ -34,6 +34,7 @@ extern void test_queue_cancel_wait_error(void);
 extern void test_queue_alloc(void);
 extern void test_queue_poll_race(void);
 extern void test_multiple_queues(void);
+extern void test_queue_multithread_competition(void);
 extern void test_access_kernel_obj_with_priv_data(void);
 extern void test_queue_append_list_error(void);
 extern void test_queue_merge_list_error(void);


### PR DESCRIPTION
Test point:
1. Any number of threads may wait on an empty queue simultaneously.
2. When a data item is added, it is given to the highest priority
thread that has waited longest.

Signed-off-by: Ningx Zhao <ningx.zhao@intel.com>