### PR TITLE
tests: posix: Add new testcases for posix APIs

### DIFF
--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -16,6 +16,7 @@ extern void test_posix_rw_lock(void);
 extern void test_posix_realtime(void);
 extern void test_posix_timer(void);
 extern void test_posix_pthread_execution(void);
+extern void test_posix_pthread_error_condition(void);
 extern void test_posix_pthread_termination(void);
 extern void test_posix_multiple_threads_single_key(void);
 extern void test_posix_single_thread_multiple_keys(void);
@@ -39,6 +40,7 @@ void test_main(void)
 {
 	ztest_test_suite(posix_apis,
 			ztest_unit_test(test_posix_pthread_execution),
+			ztest_unit_test(test_posix_pthread_error_condition),
 			ztest_unit_test(test_posix_pthread_termination),
 			ztest_unit_test(test_posix_multiple_threads_single_key),
 			ztest_unit_test(test_posix_single_thread_multiple_keys),


### PR DESCRIPTION
Add error condition to test posix APIs of pthread. Like give NULL when
invoke pthread APIs.

Signed-off-by: Jian Kang <jianx.kang@intel.com>