### PR TITLE
aarch64: Remove useless _curr_cpu struct

### DIFF
--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -9,7 +9,6 @@
 
 #ifdef _ASMLANGUAGE
 
-GDATA(_curr_cpu)
 GDATA(_kernel)
 
 /*
@@ -27,10 +26,11 @@ GDATA(_kernel)
  */
 
 .macro get_cpu xreg0, xreg1
-	ldr	\xreg0, =_curr_cpu
 	get_cpu_id \xreg1
-	add	\xreg0, \xreg0, \xreg1, lsl #3
-	ldr	\xreg0, [\xreg0]
+	mov	\xreg0, #___cpu_t_SIZEOF
+	mul	\xreg0, \xreg0, \xreg1
+	ldr	\xreg1, =(_kernel + ___kernel_t_cpus_OFFSET)
+	add	\xreg0, \xreg0, \xreg1
 .endm
 
 /*

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -32,13 +32,8 @@ volatile struct {
 	char pad[] __aligned(L1_CACHE_BYTES);
 } arm64_cpu_init[CONFIG_MP_NUM_CPUS];
 
-/*
- * _curr_cpu is used to record the struct of _cpu_t of each cpu.
- * for efficient usage in assembly
- */
-volatile _cpu_t *_curr_cpu[CONFIG_MP_NUM_CPUS];
-
 extern void __start(void);
+
 /* Called from Zephyr initialization */
 void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
@@ -46,7 +41,6 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	__ASSERT(sizeof(arm64_cpu_init[0]) == ARM64_CPU_INIT_SIZE,
 		 "ARM64_CPU_INIT_SIZE != sizeof(arm64_cpu_init[0]\n");
 
-	_curr_cpu[cpu_num] = &(_kernel.cpus[cpu_num]);
 	arm64_cpu_init[cpu_num].fn = fn;
 	arm64_cpu_init[cpu_num].arg = arg;
 	arm64_cpu_init[cpu_num].sp =
@@ -123,9 +117,6 @@ void arch_sched_ipi(void)
 static int arm64_smp_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-
-	/* necessary master core init */
-	_curr_cpu[0] = &(_kernel.cpus[0]);
 
 	/*
 	 * SGI0 is use for sched ipi, this might be changed to use Kconfig

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -27,6 +27,10 @@ GEN_OFFSET_SYM(_cpu_t, current);
 GEN_OFFSET_SYM(_cpu_t, nested);
 GEN_OFFSET_SYM(_cpu_t, irq_stack);
 
+GEN_ABSOLUTE_SYM(___cpu_t_SIZEOF, sizeof(struct _cpu));
+
+GEN_OFFSET_SYM(_kernel_t, cpus);
+
 #if defined(CONFIG_THREAD_MONITOR)
 GEN_OFFSET_SYM(_kernel_t, threads);
 #endif


### PR DESCRIPTION
small fix suggested by @jharris-intel.

~Please note that if this is merged before #32854 we will have to fix the userspace PR because `get_cpu` now needs 3 registers to be clobbered.~