### PR TITLE
kernel/sched: only send IPI to abort thread if hardware supports it

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1497,7 +1497,10 @@ void z_thread_abort(struct k_thread *thread)
 	if (active) {
 		/* It's running somewhere else, flag and poke */
 		thread->base.thread_state |= _THREAD_ABORTING;
+
+#ifdef CONFIG_SCHED_IPI_SUPPORTED
 		arch_sched_ipi();
+#endif
 	}
 
 	if (is_aborting(thread) && thread != _current) {


### PR DESCRIPTION
Wrap arch_sched_ipi() call in z_thread_abort() with ifdef checking for
hardware support of IPI.

Fixes #32723

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>