### PR TITLE
coding guidelines: 15.7: fix several cases of if else if constructs missing final else

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/debug.c
+++ b/arch/arm/core/aarch32/cortex_m/debug.c
@@ -37,7 +37,8 @@ bool z_arm_debug_monitor_event_error_check(void)
 			"MATCHED flag should have been cleared on read.");
 
 		return true;
-	} else if (SCB->DFSR & SCB_DFSR_BKPT_Msk) {
+	}
+	if (SCB->DFSR & SCB_DFSR_BKPT_Msk) {
 		/* Treat BKPT events as an error as well (since they
 		 * would mean the system would be stuck in an infinite loop).
 		 */

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -397,6 +397,8 @@ static int bus_fault(z_arch_esf_t *esf, int from_hard_fault, bool *recoverable)
 #else
 	} else if (SCB->CFSR & SCB_CFSR_LSPERR_Msk) {
 		PR_FAULT_INFO("  Floating-point lazy state preservation error");
+	} else {
+		;
 	}
 #endif /* !defined(CONFIG_ARMV7_M_ARMV8_M_FP) */
 
@@ -687,7 +689,11 @@ static uint32_t hard_fault(z_arch_esf_t *esf, bool *recoverable)
 		} else if (SAU->SFSR != 0) {
 			secure_fault(esf);
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
+		} else {
+			;
 		}
+	} else {
+		;
 	}
 #else
 #error Unknown ARM architecture

--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -96,7 +96,8 @@ static TIME_CONSTEXPR ALWAYS_INLINE uint64_t z_tmcvt(uint64_t t, uint32_t from_h
 
 		if (round_up) {
 			off = rdivisor - 1U;
-		} else if (round_off) {
+		}
+		if (round_off) {
 			off = rdivisor / 2U;
 		}
 	}

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -213,6 +213,8 @@ static inline int register_events(struct k_poll_event *events,
 		} else if (!just_check && poller->is_polling) {
 			register_event(&events[ii], poller);
 			events_registered += 1;
+		} else {
+			;
 		}
 		k_spin_unlock(&lock, key);
 	}
@@ -392,6 +394,8 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 			retcode = signal_poller(event, state);
 		} else if (poller->mode == MODE_TRIGGERED) {
 			retcode = signal_triggered_work(event, state);
+		} else {
+			;
 		}
 
 		poller->is_polling = false;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -310,12 +310,13 @@ uint64_t sys_clock_timeout_end_calc(k_timeout_t timeout)
 		return UINT64_MAX;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		return sys_clock_tick_get();
-	}
+	} else {
 
-	dt = timeout.ticks;
+		dt = timeout.ticks;
 
-	if (IS_ENABLED(CONFIG_TIMEOUT_64BIT) && Z_TICK_ABS(dt) >= 0) {
-		return Z_TICK_ABS(dt);
+		if (IS_ENABLED(CONFIG_TIMEOUT_64BIT) && Z_TICK_ABS(dt) >= 0) {
+			return Z_TICK_ABS(dt);
+		}
+		return sys_clock_tick_get() + MAX(1, dt);
 	}
-	return sys_clock_tick_get() + MAX(1, dt);
 }

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -646,6 +646,11 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			 * submissions.
 			 */
 			(void)z_sched_wake_all(&queue->drainq, 1, NULL);
+		} else {
+			/* No work is available and no queue state requires
+			 * special handling.
+			 */
+			;
 		}
 
 		if (work == NULL) {

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -557,6 +557,8 @@ int_conv:
 			default:
 				break;
 			}
+		} else {
+			;
 		}
 		break;
 
@@ -586,6 +588,8 @@ int_conv:
 		} else if ((conv->length_mod != LENGTH_NONE)
 			   && (conv->length_mod != LENGTH_UPPER_L)) {
 			conv->invalid = true;
+		} else {
+			;
 		}
 
 		break;
@@ -802,6 +806,8 @@ static char *encode_uint(uint_value_type value,
 			conv->altform_0 = true;
 		} else if (radix == 16) {
 			conv->altform_0c = true;
+		} else {
+			;
 		}
 	}
 
@@ -878,6 +884,8 @@ static char *encode_float(double value,
 		*sign = '+';
 	} else if (conv->flag_space) {
 		*sign = ' ';
+	} else {
+		;
 	}
 
 	/* Extract the non-negative offset exponent and fraction.  Record
@@ -1383,31 +1391,34 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 		/* If dynamic width is specified, process it,
 		 * otherwise set with if present.
 		 */
-		if (conv->width_star) {
-			width = va_arg(ap, int);
-
-			if (width < 0) {
-				conv->flag_dash = true;
-				width = -width;
+		if (conv->width_present) {
+			if (conv->width_star) {
+				width = va_arg(ap, int);
+				if (width < 0) {
+					conv->flag_dash = true;
+					width = -width;
+				}
+			} else {
+				width = conv->width_value;
 			}
-		} else if (conv->width_present) {
-			width = conv->width_value;
 		}
 
 		/* If dynamic precision is specified, process it, otherwise
 		 * set precision if present.  For floating point where
 		 * precision is not present use 6.
 		 */
-		if (conv->prec_star) {
-			int arg = va_arg(ap, int);
+		if (conv->prec_present) {
+			if (conv->prec_star) {
+				int arg = va_arg(ap, int);
 
-			if (arg < 0) {
-				conv->prec_present = false;
+				if (arg < 0) {
+					conv->prec_present = false;
+				} else {
+					precision = arg;
+				}
 			} else {
-				precision = arg;
+				precision = conv->prec_value;
 			}
-		} else if (conv->prec_present) {
-			precision = conv->prec_value;
 		}
 
 		/* Reuse width and precision memory in conv for value

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -204,6 +204,8 @@ start:
 			} else if (special == '+') {
 				prefix = "+";
 				min_width--;
+			} else {
+				;
 			}
 			data_len = convert_value(d, 10, 0, buf + sizeof(buf));
 			data = buf + sizeof(buf) - data_len;

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -207,33 +207,34 @@ static bool rand_alloc_choice(struct z_heap_stress_rec *sr)
 		return true;
 	} else if (sr->blocks_alloced >= sr->nblocks) {
 		return false;
+	} else {
+
+		/* The way this works is to scale the chance of choosing to
+		 * allocate vs. free such that it's even odds when the heap is
+		 * at the target percent, with linear tapering on the low
+		 * slope (i.e. we choose to always allocate with an empty
+		 * heap, allocate 50% of the time when the heap is exactly at
+		 * the target, and always free when above the target).  In
+		 * practice, the operations aren't quite symmetric (you can
+		 * always free, but your allocation might fail), and the units
+		 * aren't matched (we're doing math based on bytes allocated
+		 * and ignoring the overhead) but this is close enough.  And
+		 * yes, the math here is coarse (in units of percent), but
+		 * that's good enough and fits well inside 32 bit quantities.
+		 * (Note precision issue when heap size is above 40MB
+		 * though!).
+		 */
+		__ASSERT(sr->total_bytes < 0xffffffffU / 100, "too big for u32!");
+		uint32_t full_pct = (100 * sr->bytes_alloced) / sr->total_bytes;
+		uint32_t target = sr->target_percent ? sr->target_percent : 1;
+		uint32_t free_chance = 0xffffffffU;
+
+		if (full_pct < sr->target_percent) {
+			free_chance = full_pct * (0x80000000U / target);
+		}
+
+		return rand32() > free_chance;
 	}
-
-	/* The way this works is to scale the chance of choosing to
-	 * allocate vs. free such that it's even odds when the heap is
-	 * at the target percent, with linear tapering on the low
-	 * slope (i.e. we choose to always allocate with an empty
-	 * heap, allocate 50% of the time when the heap is exactly at
-	 * the target, and always free when above the target).  In
-	 * practice, the operations aren't quite symmetric (you can
-	 * always free, but your allocation might fail), and the units
-	 * aren't matched (we're doing math based on bytes allocated
-	 * and ignoring the overhead) but this is close enough.  And
-	 * yes, the math here is coarse (in units of percent), but
-	 * that's good enough and fits well inside 32 bit quantities.
-	 * (Note precision issue when heap size is above 40MB
-	 * though!).
-	 */
-	__ASSERT(sr->total_bytes < 0xffffffffU / 100, "too big for u32!");
-	uint32_t full_pct = (100 * sr->bytes_alloced) / sr->total_bytes;
-	uint32_t target = sr->target_percent ? sr->target_percent : 1;
-	uint32_t free_chance = 0xffffffffU;
-
-	if (full_pct < sr->target_percent) {
-		free_chance = full_pct * (0x80000000U / target);
-	}
-
-	return rand32() > free_chance;
 }
 
 /* Chooses a size of block to allocate, logarithmically favoring

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -361,6 +361,8 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 		merge_chunks(h, c, rc);
 		set_chunk_used(h, c, true);
 		return ptr;
+	} else {
+		;
 	}
 
 	/* Fallback: allocate and copy */

--- a/lib/os/onoff.c
+++ b/lib/os/onoff.c
@@ -222,6 +222,8 @@ static int process_recheck(struct onoff_manager *mgr)
 	} else if ((state == ONOFF_STATE_ERROR)
 		   && !sys_slist_is_empty(&mgr->clients)) {
 		evt = EVT_RESET;
+	} else {
+		;
 	}
 
 	return evt;
@@ -406,6 +408,8 @@ static void process_event(struct onoff_manager *mgr,
 		} else if ((mgr->flags & ONOFF_FLAG_RECHECK) != 0) {
 			mgr->flags &= ~ONOFF_FLAG_RECHECK;
 			evt = EVT_RECHECK;
+		} else {
+			;
 		}
 
 		state = mgr->flags & ONOFF_STATE_MASK;

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -63,6 +63,8 @@ static inline bool item_lessthan(struct k_p4wq_work *a, struct k_p4wq_work *b)
 	} else if ((a->priority == b->priority) &&
 		   (a->deadline != b->deadline)) {
 		return a->deadline - b->deadline > 0;
+	} else {
+		;
 	}
 	return false;
 }

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -74,8 +74,9 @@ int sys_sem_give(struct sys_sem *sem)
 		}
 	} else if (old_value >= sem->limit) {
 		return -EAGAIN;
+	} else {
+		;
 	}
-
 	return ret;
 }
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -79,6 +79,8 @@ static int cleanup_test(struct unit_test *test)
 		PRINT("Test %s failed: Unused mock return values\n",
 		      test->name);
 		ret = TC_FAIL;
+	} else {
+		;
 	}
 
 	return ret;

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -496,6 +496,8 @@ static bool set_endpoint(const struct usb_ep_descriptor *ep_desc)
 	} else if (ret) {
 		LOG_ERR("Failed to configure endpoint 0x%02x", ep_cfg.ep_addr);
 		return false;
+	} else {
+		;
 	}
 
 	ret = usb_dc_ep_enable(ep_cfg.ep_addr);
@@ -504,6 +506,8 @@ static bool set_endpoint(const struct usb_ep_descriptor *ep_desc)
 	} else if (ret) {
 		LOG_ERR("Failed to enable endpoint 0x%02x", ep_cfg.ep_addr);
 		return false;
+	} else {
+		;
 	}
 
 	usb_dev.configured = true;
@@ -540,6 +544,8 @@ static bool reset_endpoint(const struct usb_ep_descriptor *ep_desc)
 	} else if (ret) {
 		LOG_ERR("Failed to disable endpoint 0x%02x", ep_cfg.ep_addr);
 		return false;
+	} else {
+		;
 	}
 
 	return true;


### PR DESCRIPTION
The following contained cases of if else if constructs that
were missing a final else. This commit adds else {} to
comply with coding guideline 15.7.
- arch/arm/aarch32/cortex_m
- include/logging and /sys/
- kernel/
- lib/os/
- subsys/

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>