### PR TITLE
driver: sensor: icm42605: Fixed Dereference afterr null check issue

### DIFF
--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -135,18 +135,22 @@ int icm42605_tap_fetch(const struct device *dev)
 			if (drv_data->fifo_data[0] & APEX_TAP) {
 				if (drv_data->tap_trigger.type ==
 				    SENSOR_TRIG_TAP) {
-					LOG_DBG("Single Tap detected");
-					drv_data->tap_handler(dev
-					      , &drv_data->tap_trigger);
+					if (drv_data->tap_handler) {
+						LOG_DBG("Single Tap detected");
+						drv_data->tap_handler(dev
+						      , &drv_data->tap_trigger);
+					}
 				} else {
 					LOG_ERR("Trigger type is mismatched");
 				}
 			} else if (drv_data->fifo_data[0] & APEX_DOUBLE_TAP) {
 				if (drv_data->double_tap_trigger.type ==
 				    SENSOR_TRIG_DOUBLE_TAP) {
-					LOG_DBG("Double Tap detected");
-					drv_data->double_tap_handler(dev
+					if (drv_data->double_tap_handler) {
+						LOG_DBG("Double Tap detected");
+						drv_data->double_tap_handler(dev
 						     , &drv_data->tap_trigger);
+					}
 				} else {
 					LOG_ERR("Trigger type is mismatched");
 				}


### PR DESCRIPTION
Fixed Coverity CID: 219524 : Dereference after null check
For fix this issue added null check before call function pointer

Fixes #32913

Signed-off-by: JuHyun Kim <jkim@invensense.com>