### PR TITLE
Bluetooth: host: iso: Fix typo in hci_le_big_terminate

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5071,7 +5071,7 @@ static const struct event_handler meta_events[] = {
 		      hci_le_big_complete,
 		      sizeof(struct bt_hci_evt_le_big_complete)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_BIG_TERMINATE,
-		      hci_le_big_termimate,
+		      hci_le_big_terminate,
 		      sizeof(struct bt_hci_evt_le_big_terminate)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_BIG_SYNC_ESTABLISHED,
 		      hci_le_big_sync_established,

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1357,7 +1357,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 		err = hci_le_terminate_big(big);
 
 		/* Wait for BT_HCI_EVT_LE_BIG_TERMINATE before cleaning up
-		 * the BIG in hci_le_big_termimate
+		 * the BIG in hci_le_big_terminate
 		 */
 		if (!err) {
 			for (int i = 0; i < big->num_bis; i++) {
@@ -1402,7 +1402,7 @@ void hci_le_big_complete(struct net_buf *buf)
 	}
 }
 
-void hci_le_big_termimate(struct net_buf *buf)
+void hci_le_big_terminate(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_terminate *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->big_handle);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -64,7 +64,7 @@ void hci_le_cis_req(struct net_buf *buf);
 void hci_le_big_complete(struct net_buf *buf);
 
 /** Process BIG terminate event */
-void hci_le_big_termimate(struct net_buf *buf);
+void hci_le_big_terminate(struct net_buf *buf);
 
 /** Process BIG sync established event */
 void hci_le_big_sync_established(struct net_buf *buf);


### PR DESCRIPTION
Fix typo in hci_le_big_terminate function name.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>