### PR TITLE
test: mem_map: Fix compilation by removing __test_mem_map_size

### DIFF
--- a/tests/kernel/mem_protect/mem_map/custom-sections.ld
+++ b/tests/kernel/mem_protect/mem_map/custom-sections.ld
@@ -9,5 +9,4 @@ SECTION_DATA_PROLOGUE(TEST_MEM_MAP,,SUBALIGN(CONFIG_MMU_PAGE_SIZE))
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 PROVIDE(__test_mem_map_start = LOADADDR(TEST_MEM_MAP));
-PROVIDE(__test_mem_map_size = SIZEOF(TEST_MEM_MAP));
-PROVIDE(__test_mem_map_end = __test_mem_map_start + __test_mem_map_size);
+PROVIDE(__test_mem_map_end = __test_mem_map_start + SIZEOF(TEST_MEM_MAP));

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -92,7 +92,6 @@ void test_z_phys_map_exec(void)
 #else
 extern char __test_mem_map_start[];
 extern char __test_mem_map_end[];
-extern char __test_mem_map_size[];
 
 __in_section_unique(test_mem_map) __used
 static void transplanted_function(bool *executed)
@@ -121,7 +120,7 @@ void test_z_phys_map_exec(void)
 
 	/* Now map with execution enabled and try to run the copied fn */
 	z_phys_map(&mapped_exec, (uintptr_t)__test_mem_map_start,
-		   (uintptr_t)__test_mem_map_size,
+		   (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
 		   BASE_FLAGS | K_MEM_PERM_EXEC);
 
 	func = (void (*)(bool *executed))mapped_exec;
@@ -130,7 +129,7 @@ void test_z_phys_map_exec(void)
 
 	/* Now map without execution and execution should now fail */
 	z_phys_map(&mapped_ro, (uintptr_t)__test_mem_map_start,
-		   (uintptr_t)__test_mem_map_size, BASE_FLAGS);
+		   (uintptr_t)(__test_mem_map_end - __test_mem_map_start), BASE_FLAGS);
 
 	func = (void (*)(bool *executed))mapped_ro;
 	expect_fault = true;


### PR DESCRIPTION
This is the same problem as seen for #32053. Refer to that for the
details and propose a similar fix.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>