### PR TITLE
drivers/gpio: stm32: Set SWJ higher prio vs device pin configuration

### DIFF
--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -16,11 +16,9 @@ choice GPIO_STM32_SWJ
 	depends on SOC_SERIES_STM32F1X
 
 config GPIO_STM32_SWJ_ENABLE
-	depends on !(SOC_STM32F103XE && SPI_3)
 	bool "Full SWJ (JTAG-DP + SW-DP): Reset State"
 
 config GPIO_STM32_SWJ_NONJTRST
-	depends on !(SOC_STM32F103XE && SPI_3)
 	bool "Full SWJ (JTAG-DP + SW-DP) but without NJTRST"
 
 config GPIO_STM32_SWJ_NOJTAG


### PR DESCRIPTION
Serial Wire JTAG configuration option is made available
under condition that SPI_3 was not enabled on SOC_STM32F103XE.
Besides being obsolete there are various other potential conflicts
with other periphals, and it is not possible to explicit them all.

To make it more coherent remove such condition, assume that user
needs to take care of such pin conflict and express SWJ as having
precedence over peripheral devices pin configuration.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>