### PR TITLE
Civetweb compilation fixes

### DIFF
--- a/samples/net/civetweb/http_server/prj.conf
+++ b/samples/net/civetweb/http_server/prj.conf
@@ -30,3 +30,7 @@ CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"
 
 # logging
 CONFIG_NET_LOG=y
+
+# Do not include mbedtls via this option as civetweb does not
+# work properly with mbedtls.
+CONFIG_NET_TCP_ISN_RFC6528=n

--- a/samples/net/civetweb/websocket_server/prj.conf
+++ b/samples/net/civetweb/websocket_server/prj.conf
@@ -34,3 +34,7 @@ CONFIG_IDLE_STACK_SIZE=1024
 CONFIG_LOG=y
 # CONFIG_NET_LOG=y
 # CONFIG_LOG_STRDUP_MAX_STRING=256
+
+# Do not include mbedtls via this option as civetweb does not
+# work properly with mbedtls.
+CONFIG_NET_TCP_ISN_RFC6528=n

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -12,7 +12,10 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #include <stdlib.h>
 #include <zephyr.h>
 #include <random/rand32.h>
+
+#if defined(CONFIG_NET_TCP_ISN_RFC6528)
 #include <mbedtls/md5.h>
+#endif
 #include <net/net_pkt.h>
 #include <net/net_context.h>
 #include <net/udp.h>
@@ -1313,7 +1316,10 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 	}
 
 	memcpy(buf.key, unique_key, sizeof(buf.key));
+
+#if IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528)
 	mbedtls_md5_ret((const unsigned char *)&buf, sizeof(buf), hash);
+#endif
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));
 }
@@ -1345,7 +1351,10 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 	}
 
 	memcpy(buf.key, unique_key, sizeof(unique_key));
+
+#if IS_ENABLED(CONFIG_NET_TCP_ISN_RFC6528)
 	mbedtls_md5_ret((const unsigned char *)&buf, sizeof(buf), hash);
+#endif
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));
 }


### PR DESCRIPTION
Some issues with civetweb when `CONFIG_NET_TCP_ISN_RFC6528` is enabled.