### PR TITLE
twister: Improve handling of errors while flashing device

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -814,6 +814,8 @@ class DeviceHandler(Handler):
                         self.instance.reason = "Device issue (Flash?)"
                         with open(d_log, "w") as dlog_fp:
                             dlog_fp.write(stderr.decode())
+                        os.write(write_pipe, b'x')  # halt the thread
+                        out_state = "flash_error"
                 except subprocess.TimeoutExpired:
                     proc.kill()
                     (stdout, stderr) = proc.communicate()
@@ -846,12 +848,15 @@ class DeviceHandler(Handler):
 
         handler_time = time.time() - start_time
 
-        if out_state == "timeout":
+        if out_state in ["timeout", "flash_error"]:
             for c in self.instance.testcase.cases:
                 if c not in harness.tests:
                     harness.tests[c] = "BLOCK"
 
-            self.instance.reason = "Timeout"
+            if out_state == "timeout":
+                self.instance.reason = "Timeout"
+            elif out_state == "flash_error":
+                self.instance.reason = "Flash error"
 
         self.instance.results = harness.tests
 
@@ -864,7 +869,7 @@ class DeviceHandler(Handler):
 
         if harness.state:
             self.set_state(harness.state, handler_time)
-            if  harness.state == "failed":
+            if harness.state == "failed":
                 self.instance.reason = "Failed"
         else:
             self.set_state(out_state, handler_time)
@@ -2411,7 +2416,7 @@ class ProjectBuilder(FilterBuilder):
         results.done += 1
         instance = self.instance
 
-        if instance.status in ["error", "failed", "timeout"]:
+        if instance.status in ["error", "failed", "timeout", "flash_error"]:
             if instance.status == "error":
                 results.error += 1
             results.failed += 1
@@ -3371,7 +3376,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                         else:
                             fails += 1
                 else:
-                    if instance.status in ["error", "failed", "timeout"]:
+                    if instance.status in ["error", "failed", "timeout", "flash_error"]:
                         if instance.reason in ['build_error', 'handler_crash']:
                             errors += 1
                         else:
@@ -3457,7 +3462,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                                     eleTestcase,
                                     'error',
                                     type="failure",
-                                    message="failed")
+                                    message=instance.reason)
                             log_root = os.path.join(self.outdir, instance.platform.name, instance.testcase.name)
                             log_file = os.path.join(log_root, "handler.log")
                             el.text = self.process_log(log_file)
@@ -3488,7 +3493,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                         name="%s" % (instance.testcase.name),
                         time="%f" % handler_time)
 
-                    if instance.status in ["error", "failed", "timeout"]:
+                    if instance.status in ["error", "failed", "timeout", "flash_error"]:
                         failure = ET.SubElement(
                             eleTestcase,
                             'failure',


### PR DESCRIPTION
The patch improves handling runners errors from flashing. It
add thread termination in case of process returning non 0 exit
code. Before, even though the error was returned,
a thread was not terminated and test ended
only after timeout termination. The patch also adds information about
the failure reason to the reports

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>