### PR TITLE
modules: civetweb: Add proper dependency to Kconfig

### DIFF
--- a/modules/Kconfig.civetweb
+++ b/modules/Kconfig.civetweb
@@ -3,5 +3,11 @@
 
 config CIVETWEB
 	bool "Civetweb Support"
+	# The CONFIG_NET_TCP_ISN_RFC6528 option would pull in mbedtls,
+	# and there are include file issues if CONFIG_POSIX_API is set.
+	# Because Civetweb sets the POSIX API option in the samples,
+	# make sure that we do not try to use Civetweb if the TCP ISN
+	# option is set.
+	depends on !NET_TCP_ISN_RFC6528
 	help
 	  This option enables the civetweb HTTP API.


### PR DESCRIPTION
Make sure that CONFIG_NET_TCP_ISN_RFC6528 is not set when compiling
Civetweb. There are compile issues in Civetweb if both mbedtls and
POSIX API option are set, and this happens if the TCP ISN option is
enabled.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>