### PR TITLE
soc: arm: nrf5340: Add option to allow the app core to run at 128MHz

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -56,6 +56,10 @@ config BOARD_ENABLE_DCDC_HV
 	select SOC_DCDC_NRF53X_HV
 	default y
 
+config BOARD_ENABLE_128MHZ_APP
+	bool "Enable 128MHz speed in application core"
+	select SOC_CLOCK_128MHZ_NRF53X_APP
+
 choice BT_HCI_BUS_TYPE
 	default BT_RPMSG if BT
 endchoice

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -645,6 +645,12 @@ static int clk_init(const struct device *dev)
 		z_nrf_clock_calibration_init(data->mgr);
 	}
 
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	if (IS_ENABLED(CONFIG_SOC_CLOCK_128MHZ_NRF53X_APP)) {
+		nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
+	}
+#endif
+
 	nrfx_clock_enable();
 
 	for (enum clock_control_nrf_type i = 0;

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -132,6 +132,11 @@ config SOC_DCDC_NRF53X_HV
 	help
 	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
 
+config SOC_CLOCK_128MHZ_NRF53X_APP
+	bool
+	help
+	  Run nRF53 series app core at 128MHz.
+
 config SOC_ENABLE_LFXO
 	bool "Enable LFXO"
 	default y


### PR DESCRIPTION
This commit adds support for running the nRF53 app-core at 128MHz.

Signed-off-by: Johan Stridkvist <johan.stridkvist@nordicsemi.no>