### PR TITLE
drivers: modem: fix coverity issue

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3347,7 +3347,7 @@ static void hl7800_rx(void)
 
 	while (true) {
 		/* wait for incoming data */
-		k_sem_take(&ictx.mdm_ctx.rx_sem, K_FOREVER);
+		(void) k_sem_take(&ictx.mdm_ctx.rx_sem, K_FOREVER);
 
 		hl7800_read_rx(&rx_buf);
 		/* If an external module hasn't locked the command processor,


### PR DESCRIPTION
Added `(void)` cast to supress coverity report. The usage of `K_FOREVER`
tells me we're not interested in the returned value.

Coverity-CID: 219653
Fixes #33034

Signed-off-by: Guðni Már Gilbert <gudni.m.g@gmail.com>