### PR TITLE
x86: remove CONFIG_CPU_MINUTEIA

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -25,13 +25,6 @@ config CPU_ATOM
 	help
 	  This option signifies the use of a CPU from the Atom family.
 
-config CPU_MINUTEIA
-	bool
-	select ARCH_HAS_STACK_PROTECTION if X86_MMU
-	select ARCH_HAS_USERSPACE if X86_MMU
-	help
-	  This option signifies the use of a CPU from the Minute IA family.
-
 config CPU_APOLLO_LAKE
 	bool
 	select CPU_HAS_FPU

--- a/soc/x86/ia32/Kconfig.soc
+++ b/soc/x86/ia32/Kconfig.soc
@@ -3,7 +3,7 @@
 config SOC_IA32
 	bool "Generic IA32 SoC"
 	select X86
-	select CPU_MINUTEIA
+	select CPU_ATOM
 	select X86_CPU_HAS_MMX
 	select X86_CPU_HAS_SSE
 	select ARCH_HAS_RESERVED_PAGE_FRAMES if SRAM_BASE_ADDRESS = 0


### PR DESCRIPTION
Since the removal of Quark-based boards, there are no user of
Minute-IA. Also, the generic x86 SoC is not exactly Minute-IA
so change it to use a fairly safe CPU_ATOM.

Fixes #14442

Signed-off-by: Daniel Leung <daniel.leung@intel.com>