### PR TITLE
tests: net: socket: getaddrinfo: fix resource leak

### DIFF
--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -551,6 +551,7 @@ static void test_getaddrinfo_ipv4_hints_ipv6(void)
 	ret = zsock_getaddrinfo("192.0.2.1", NULL, &hints, &res);
 	zassert_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
 	zassert_is_null(res, "");
+	zsock_freeaddrinfo(res);
 }
 
 static void test_getaddrinfo_ipv6_hints_ipv4(void)
@@ -564,6 +565,7 @@ static void test_getaddrinfo_ipv6_hints_ipv4(void)
 	ret = zsock_getaddrinfo("2001:db8::1", NULL, &hints, &res);
 	zassert_equal(ret, DNS_EAI_ADDRFAMILY, "Invalid result (%d)", ret);
 	zassert_is_null(res, "");
+	zsock_freeaddrinfo(res);
 }
 
 static void test_getaddrinfo_port_invalid(void)
@@ -573,6 +575,7 @@ static void test_getaddrinfo_port_invalid(void)
 	ret = zsock_getaddrinfo("192.0.2.1", "70000", NULL, &res);
 	zassert_equal(ret, DNS_EAI_NONAME, "Invalid result (%d)", ret);
 	zassert_is_null(res, "");
+	zsock_freeaddrinfo(res);
 }
 
 static void test_getaddrinfo_null_host(void)


### PR DESCRIPTION
Fix resource leak detected by coverity by adding missing
`zsock_freeaddrinfo(res)` calls.

Coverity-CID: 219527
Fixes #32919

Signed-off-by: Guðni Már Gilbert <gudni.m.g@gmail.com>