### PR TITLE
doc: coding_guidelines: replace a whitelist replacement

### DIFF
--- a/doc/guides/coding_guidelines/index.rst
+++ b/doc/guides/coding_guidelines/index.rst
@@ -865,7 +865,7 @@ governing body, or immediately if no specifications apply.
 
    * - ``blacklist / whitelist``
      - * ``denylist / allowlist``
-       * ``blocklist / passlist``
+       * ``blocklist / allowlist``
        * ``rejectlist / acceptlist``
 
    * - ``grandfather policy``


### PR DESCRIPTION
Nothing in the tree is using the "passlist" term in the "blocklist /
passlist" pair. However, west is using "blocklist / allowlist" already in a
released version.

Recommend blocklist/allowlist instead of blocklist/passlist to avoid
having to add yet another possible replacement, since nothing is using
passlist right now.

Note that blocklist/allowlist is in widespread use throughout many
projects, including Chrome.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>