### PR TITLE
floating point: introduce a Kconfig option to completely forbid FP usage

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -743,9 +743,20 @@ config SRAM_REGION_PERMISSIONS
 
 menu "Floating Point Options"
 
+config FORBID_FP
+	bool "Forbid any floating point usage"
+	default y if ARMV8_A # FP is not yet supported
+	help
+	  This ensures that the Zephyr build contains no floating point
+	  usage at all. This is especially useful to forcefully prevent
+	  compilers from implicitly using hardware FP registers to implement
+	  some optimizations, and also to exclude code that would explicitly
+	  trigger such FP register usage or pull software FP library code
+	  into the build.
+
 config FPU
 	bool "Enable floating point unit (FPU)"
-	depends on CPU_HAS_FPU
+	depends on CPU_HAS_FPU && !FORBID_FP
 	depends on ARC || ARM || RISCV || SPARC || X86
 	help
 	  This option enables the hardware Floating Point Unit (FPU), in order to

--- a/arch/arm/core/aarch64/Kconfig
+++ b/arch/arm/core/aarch64/Kconfig
@@ -78,6 +78,7 @@ config ARMV8_A_NS
 config ARMV8_A
 	bool
 	select ATOMIC_OPERATIONS_BUILTIN
+	select CPU_HAS_FPU
 	select CPU_HAS_MMU
 	help
 	  This option signifies the use of an ARMv8-A processor

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -5,6 +5,10 @@ if(CONFIG_ARM64)
 
   list(APPEND TOOLCHAIN_C_FLAGS   -mabi=lp64)
   list(APPEND TOOLCHAIN_LD_FLAGS  -mabi=lp64)
+
+  if(CONFIG_FORBID_FP)
+    list(APPEND TOOLCHAIN_C_FLAGS   -mgeneral-regs-only)
+  endif()
 else()
   list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
   list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -19,7 +19,6 @@ zephyr_sources(
   rb.c
   sem.c
   thread_entry.c
-  timeutil.c
   heap.c
   heap-validate.c
   )
@@ -30,6 +29,8 @@ zephyr_sources_ifdef(CONFIG_CBPRINTF_NANO cbprintf_nano.c)
 zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
 
 zephyr_sources_ifdef(CONFIG_RING_BUFFER ring_buffer.c)
+
+zephyr_sources_ifndef(CONFIG_FORBID_FP timeutil.c)
 
 zephyr_sources_ifdef(CONFIG_ASSERT assert.c)
 

--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -7,6 +7,7 @@ choice CBPRINTF_IMPLEMENTATION
 
 config CBPRINTF_COMPLETE
 	bool "All selected features"
+	depends on !FORBID_FP
 	help
 	  Select this for an implementation that supports all potential
 	  conversions, with Kconfig options to control availability at build
@@ -72,7 +73,7 @@ config CBPRINTF_FP_SUPPORT
 # 04: 13% / 456 B (07 / 03)
 config CBPRINTF_FP_A_SUPPORT
 	bool "Enable floating point %a conversions"
-	depends on CBPRINTF_FULL_INTEGRAL
+	depends on CBPRINTF_COMPLETE && CBPRINTF_FULL_INTEGRAL
 	select CBPRINTF_FP_SUPPORT
 	help
 	  The %a hexadecimal format for floating point value conversion was
@@ -85,6 +86,7 @@ config CBPRINTF_FP_A_SUPPORT
 # 40: -15% / -508 B (46 / 06)
 config CBPRINTF_FP_ALWAYS_A
 	bool "Select %a format for all floating point specifications"
+	depends on CBPRINTF_COMPLETE
 	select CBPRINTF_FP_A_SUPPORT
 	help
 	  The %a format for floats requires significantly less code than the

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -355,6 +355,7 @@ int cbvprintf_package(void *packaged, size_t len,
 			parsing = false;
 			break;
 
+#ifndef CONFIG_FORBID_FP
 		case 'a':
 		case 'A':
 		case 'e':
@@ -397,6 +398,7 @@ int cbvprintf_package(void *packaged, size_t len,
 			parsing = false;
 			continue;
 		}
+#endif
 
 		default:
 			parsing = false;


### PR DESCRIPTION
It is sometimes desirable to avoid FP usage altogether to avoid the
cost of managing the FP register context. This is especially true on
ARM64 where the compiler is otherwise free to use FP registers to
implement generic code optimizations. The absence of CONFIG_FPU isn't
enough in that case as the compiler, if told not to use FP registers,
will immediately complain as soon as a float or a double variable is
used. Hence this additional Kconfig symbol.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
