### PR TITLE
drivers: spi: Use timeout for transfer completion

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -31,6 +31,12 @@ config SPI_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 
+config SPI_COMPLETION_TIMEOUT_TOLERANCE
+	int "Completion timeout tolerance (ms)"
+	default 200
+	help
+	  The tolerance value in ms for the SPI completion timeout logic.
+
 module = SPI
 module-str = spi
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Instead of waiting forever for the SPI transfer to complete, let's use
a timeout value and bail out if elapsed. The timeout value logic is,

xfer_len/frequency + 200 ms (tolerance)

Fixes: #33192

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>