### PR TITLE
dts/arm: stm32: Don't disable systick

### DIFF
--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -393,7 +393,3 @@
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };
-
-&systick {
-	status = "disabled";
-};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -382,7 +382,3 @@
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };
-
-&systick {
-	status = "disabled";
-};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -180,8 +180,3 @@
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };
-
-&systick {
-	status = "disabled";
-};
-

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -9,7 +9,6 @@ if SOC_FAMILY_STM32
 
 config CORTEX_M_SYSTICK
 	bool
-	default y
 	depends on !STM32_LPTIM_TIMER
 
 # set the tick per sec as a divider of the LPTIM clock source


### PR DESCRIPTION
In some stm32 series systick was disabled in order to
allow alternate use of lptim timer as kernel low power ticker.
Doing this, dts based definition of CORTEX_M_SYSTICK Kconfig symbol
is disabled and CORTEX_M_SYSTICK was redefined with 'default y'
in stm32 soc files which makes things more complex to handle to
alternate with LPTIM activation.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>