### PR TITLE
Scripts: Runners: Jlink wsl support

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -514,13 +514,19 @@ class ZephyrBinaryRunner(abc.ABC):
 
         It's useful to e.g. open a GDB server and client.'''
         server_proc = self.popen_ignore_int(server)
+        try:
+            self.run_client(client)
+        finally:
+            server_proc.terminate()
+            server_proc.wait()
+
+    def run_client(self, client):
+        '''Run a client that handles SIGINT.'''
         previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
         try:
             self.check_call(client)
         finally:
             signal.signal(signal.SIGINT, previous)
-            server_proc.terminate()
-            server_proc.wait()
 
     def _log_cmd(self, cmd: List[str]):
         escaped = ' '.join(shlex.quote(s) for s in cmd)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -126,8 +126,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         A timeout is used since the J-Link Commander takes up to a few seconds
         to exit upon failure.'''
-        if platform.system() == 'Windows':
-            # The check below does not work on Microsoft Windows
+        if platform.system() == 'Windows' or "microsoft" in platform.release().lower():
+            # The check below does not work on Microsoft Windows or in WSL
             return ''
 
         self.require(self.commander)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -32,7 +32,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  commander=DEFAULT_JLINK_EXE,
                  flash_addr=0x0, erase=True, reset_after_load=False,
                  iface='swd', speed='auto',
-                 gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
+                 gdbserver='JLinkGDBServer',
+                 gdb_host='',
+                 gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False, tool_opt=[]):
         super().__init__(cfg)
         self.hex_name = cfg.hex_file
@@ -47,6 +49,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.gdbserver = gdbserver
         self.iface = iface
         self.speed = speed
+        self.gdb_host = gdb_host
         self.gdb_port = gdb_port
         self.tui_arg = ['-tui'] if tui else []
 
@@ -77,6 +80,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='if given, GDB uses -tui')
         parser.add_argument('--gdbserver', default='JLinkGDBServer',
                             help='GDB server, default is JLinkGDBServer')
+        parser.add_argument('--gdb-host', default='',
+                            help='custom gdb host, defaults to the empty string '
+                            'and runs a gdb server')
         parser.add_argument('--gdb-port', default=DEFAULT_JLINK_GDB_PORT,
                             help='pyocd gdb port, defaults to {}'.format(
                                 DEFAULT_JLINK_GDB_PORT))
@@ -102,6 +108,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  reset_after_load=args.reset_after_load,
                                  iface=args.iface, speed=args.speed,
                                  gdbserver=args.gdbserver,
+                                 gdb_host=args.gdb_host,
                                  gdb_port=args.gdb_port,
                                  tui=args.tui, tool_opt=args.tool_opt)
 
@@ -155,11 +162,12 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         if command == 'flash':
             self.flash(**kwargs)
         elif command == 'debugserver':
+            if self.gdb_host:
+                raise ValueError('Cannot run debugserver with --gdb-host')
             self.require(self.gdbserver)
             self.print_gdbserver_message()
             self.check_call(server_cmd)
         else:
-            self.require(self.gdbserver)
             if self.gdb_cmd is None:
                 raise ValueError('Cannot debug; gdb is missing')
             if self.elf_name is None:
@@ -167,16 +175,19 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             client_cmd = (self.gdb_cmd +
                           self.tui_arg +
                           [self.elf_name] +
-                          ['-ex', 'target remote :{}'.format(self.gdb_port)])
+                          ['-ex', 'target remote {}:{}'.format(self.gdb_host, self.gdb_port)])
             if command == 'debug':
                 client_cmd += ['-ex', 'monitor halt',
                                '-ex', 'monitor reset',
                                '-ex', 'load']
                 if self.reset_after_load:
                     client_cmd += ['-ex', 'monitor reset']
-
-            self.print_gdbserver_message()
-            self.run_server_and_client(server_cmd, client_cmd)
+            if not self.gdb_host:
+                self.require(self.gdbserver)
+                self.print_gdbserver_message()
+                self.run_server_and_client(server_cmd, client_cmd)
+            else:
+                self.run_client(client_cmd)
 
     def flash(self, **kwargs):
         self.require(self.commander)


### PR DESCRIPTION
This commit allows to run the GDB server remotely and use the `west debug` command to connect to it.

A usecase is to develop a zephyr application within a WSL2 environment and run the GDB server on the Windows host.