### PR TITLE
sensor: bq27421: lazy configure fuel gauge

### DIFF
--- a/drivers/sensor/bq274xx/Kconfig
+++ b/drivers/sensor/bq274xx/Kconfig
@@ -2,8 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config BQ274XX
+menuconfig BQ274XX
 	bool "BQ274xx Fuel Gauge"
 	depends on I2C
 	help
 	  Enable I2C-based driver for BQ274xx Fuel Gauge.
+
+if BQ274XX
+
+config BQ274XX_LAZY_CONFIGURE
+	bool "Configure on first usage instead of init"
+	help
+	  Configuring the sensor can take a long time, which
+	  we can delay till the first sample request and keep
+	  the boot time as short as possible.
+
+endif # BQ274XX

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -80,6 +80,9 @@ LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 
 struct bq274xx_data {
 	const struct device *i2c;
+#ifdef CONFIG_BQ274XX_LAZY_CONFIGURE
+	bool lazy_loaded;
+#endif
 	uint16_t voltage;
 	int16_t avg_current;
 	int16_t stdby_current;


### PR DESCRIPTION
The BQ274XX driver `init` function performs a lot i2c transfers
that slow down booting the system. We can do this lazely on the
first sample request to speed up the boot.