### PR TITLE
doc: samples: bluetooth: Add note about nRF5340.

### DIFF
--- a/samples/bluetooth/bluetooth.rst
+++ b/samples/bluetooth/bluetooth.rst
@@ -16,6 +16,14 @@ QEMU or Native POSIX), those are named accordingly with an "HCI" prefix in the
 documentation and are prefixed with :literal:`hci_` in their folder names.
 
 .. note::
+   If you want to run any bluetooth sample on the nRF5340 device (build using
+   ``-DBOARD=nrf5340dk_nrf5340_cpuapp`` or
+   ``-DBOARD=nrf5340dk_nrf5340_cpuappns``) you must also build
+   and program the corresponding sample for the nRF5340 network core
+   :ref:` bluetooth-hci-rpmsg-sample` which implements the Bluetooth
+   Low Energy controller.
+
+.. note::
    The mutually-shared encryption key created during host-device paring may get
    old after many test iterations.  If this happens, subsequent host-device
    connections will fail. You can force a re-paring and new key to be created


### PR DESCRIPTION
Document that for BLE samples to work on the nRF5340 device,
the additional application for the nRF5340 network core is required:
hci_rpmsg.
This PR is a response to: https://github.com/zephyrproject-rtos/zephyr/discussions/32264#discussioncomment-363261