### PR TITLE
Bluetooth: Mesh: Add poll callback for friend role

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -610,6 +610,19 @@ struct bt_mesh_friend_cb {
 	 *  @param lpn_addr Low Power Node address.
 	 */
 	void (*terminated)(uint16_t net_idx, uint16_t lpn_addr);
+
+	/** @brief Friend Poll Request.
+	 *
+	 *  This callback notifies the application that the low power node has
+	 *  polled the friend node.
+	 *
+	 *  This callback will be called before @ref bt_mesh_friend_cb::established
+	 *  when attempting to establish a friendship.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param lpn_addr LPN address.
+	 */
+	void (*polled)(uint16_t net_idx, uint16_t lpn_addr);
 };
 
 /** @def BT_MESH_FRIEND_CB_DEFINE

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -705,6 +705,12 @@ int bt_mesh_friend_poll(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 
 	friend_recv_delay(frnd);
 
+	Z_STRUCT_SECTION_FOREACH(bt_mesh_friend_cb, cb) {
+		if (cb->polled) {
+			cb->polled(frnd->subnet->net_idx, frnd->lpn);
+		}
+	}
+
 	if (!frnd->established) {
 		BT_DBG("Friendship established with 0x%04x", frnd->lpn);
 		frnd->established = 1U;


### PR DESCRIPTION
Adds a "polled" function to the friend callback structure, that gets
called every time the friend receives a poll message. The polled
callback is called before the establish callback, to match the LPN
behavior.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>