### PR TITLE
log: Fix defining CONFIG_LOG_STRDUP_MAX_STRING

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -111,6 +111,7 @@ config LOG_DETECT_MISSED_STRDUP
 
 config LOG_STRDUP_MAX_STRING
 	int "Longest string that can be duplicated using log_strdup()"
+	range 1 8192
 	default 66 if BT
 	default 46 if NETWORKING
 	default 32

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -36,7 +36,10 @@ LOG_MODULE_REGISTER(log);
 #endif
 
 #ifndef CONFIG_LOG_STRDUP_MAX_STRING
-#define CONFIG_LOG_STRDUP_MAX_STRING 0
+/* Required to suppress compiler warnings related to array subscript above array bounds.
+ * log_strdup explicitly accesses element with index of (sizeof(log_strdup_buf.buf) - 2).
+ */
+#define CONFIG_LOG_STRDUP_MAX_STRING 1
 #endif
 
 #ifndef CONFIG_LOG_STRDUP_BUF_COUNT


### PR DESCRIPTION
Change fixes an issue related to data access out of array bounds and suppresses compiler warning.

Signed-off-by: Marek Pieta <Marek.Pieta@nordicsemi.no>