### PR TITLE
doc: Replace *_thread_resource_pool_assign with k_thread_heap_assign

### DIFF
--- a/doc/reference/usermode/memory_domain.rst
+++ b/doc/reference/usermode/memory_domain.rst
@@ -122,8 +122,8 @@ noted for users who do not want heap allocations within their application:
    dynamically allocated at runtime and a usable pointer to them returned to
    the caller.
 
-The relevant API is :c:func:`k_thread_resource_pool_assign` which assigns
-a k_mem_pool to draw these allocations from for the target thread.
+The relevant API is :c:func:`k_thread_heap_assign` which assigns
+a k_heap to draw these allocations from for the target thread.
 
 If the system heap is enabled, then the system heap may be used with
 :c:func:`k_thread_system_pool_assign`, but it is preferable for different

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -402,7 +402,7 @@ __syscall int k_thread_stack_space_get(const struct k_thread *thread,
 /**
  * @brief Assign the system heap as a thread's resource pool
  *
- * Similar to z_thread_resource_pool_assign(), but the thread will use
+ * Similar to z_thread_heap_assign(), but the thread will use
  * the kernel heap to draw memory.
  *
  * Use with caution, as a malicious thread could perform DoS attacks on the

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -21,7 +21,7 @@ static inline void dummy_end(struct k_timer *timer)
 K_THREAD_STACK_DEFINE(test_1_stack, INHERIT_STACK_SIZE);
 K_THREAD_STACK_DEFINE(parent_thr_stack, STACK_SIZE);
 K_THREAD_STACK_DEFINE(child_thr_stack, STACK_SIZE);
-K_HEAP_DEFINE(res_pool, BLK_SIZE_MAX * BLK_NUM_MAX);
+K_HEAP_DEFINE(heap_mem, BLK_SIZE_MAX * BLK_NUM_MAX);
 K_SEM_DEFINE(inherit_sem, SEMAPHORE_INIT_COUNT, SEMAPHORE_MAX_COUNT);
 K_SEM_DEFINE(sync_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 K_MUTEX_DEFINE(inherit_mutex);
@@ -133,18 +133,18 @@ static inline struct k_heap *z_vrfy_ret_resource_pool_ptr(void)
 	return z_impl_ret_resource_pool_ptr();
 }
 #include <syscalls/ret_resource_pool_ptr_mrsh.c>
-struct k_heap *child_res_pool_ptr;
-struct k_heap *parent_res_pool_ptr;
+struct k_heap *child_heap_mem_ptr;
+struct k_heap *parent_heap_mem_ptr;
 
 void child_handler(void *p1, void *p2, void *p3)
 {
-	child_res_pool_ptr = ret_resource_pool_ptr();
+	child_heap_mem_ptr = ret_resource_pool_ptr();
 	k_sem_give(&sync_sem);
 }
 
 void parent_handler(void *p1, void *p2, void *p3)
 {
-	parent_res_pool_ptr = ret_resource_pool_ptr();
+	parent_heap_mem_ptr = ret_resource_pool_ptr();
 	k_thread_create(&child_thr, child_thr_stack,
 			K_THREAD_STACK_SIZEOF(child_thr_stack),
 			child_handler,
@@ -156,7 +156,7 @@ void parent_handler(void *p1, void *p2, void *p3)
  * @brief Test child thread inherits parent's thread resource pool
  *
  * @details
- * - Create a resource pool res_pool for the parent thread.
+ * - Create a memory heap heap_mem for the parent thread.
  * - Then special system call ret_resource_pool_ptr() returns pointer
  *   to the resource pool of the current thread.
  * - Call it in the parent_handler() and in the child_handler()
@@ -167,7 +167,7 @@ void parent_handler(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_thread_resource_pool_assign()
+ * @see z_thread_heap_assign()
  */
 void test_inherit_resource_pool(void)
 {
@@ -177,10 +177,10 @@ void test_inherit_resource_pool(void)
 			parent_handler,
 			NULL, NULL, NULL,
 			PRIORITY, 0, K_FOREVER);
-	k_thread_heap_assign(&parent_thr, &res_pool);
+	k_thread_heap_assign(&parent_thr, &heap_mem);
 	k_thread_start(&parent_thr);
 	k_sem_take(&sync_sem, K_FOREVER);
-	zassert_true(parent_res_pool_ptr == child_res_pool_ptr,
+	zassert_true(parent_heap_mem_ptr == child_heap_mem_ptr,
 		     "Resource pool of the parent thread not inherited,"
 		     " by child thread");
 }

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -292,7 +292,7 @@ static void tqueue_alloc(struct k_queue *pqueue)
  * @brief Test queue alloc append and prepend
  * @ingroup kernel_queue_tests
  * @see k_queue_alloc_append(), k_queue_alloc_prepend(),
- * z_thread_resource_pool_assign(), k_queue_is_empty(),
+ * z_thread_heap_assign(), k_queue_is_empty(),
  * k_queue_get(), k_queue_remove()
  */
 void test_queue_alloc(void)


### PR DESCRIPTION
Replace *_thread_resource_pool_assign() in the reference with the new
k_thread_heap_assign() since both k_thread_resource_pool_assign() and
z_thread_resource_pool_assign() has been removed prio to v2.5 (by the
commit c770cab1a3 and 3c2c1d85b0 respectively) along with the
k_mem_pool API removal.

For the resource pool inheritance test, the variables with "res_pool"
string has been replaced by "heap_mem" to align with the documentation
fix.  No functionality has been changed.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>