### PR TITLE
ci: Re-enable bsim in CI

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -22,7 +22,7 @@ set -xe
 
 twister_options=" --inline-logs -N -v --integration"
 export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
-if [ ! -d "${BSIM_OUT_PATH}x" ]; then
+if [ ! -d "${BSIM_OUT_PATH}" ]; then
         unset BSIM_OUT_PATH
 fi
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"


### PR DESCRIPTION
BabbleSim execution was (AFAICT mistakenly) disabled in
dda6a5ee90d0f5b31e7d269761dc2ab1a2f8510c. Re-enable it so we run them in
CI again.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>