### PR TITLE
fs/fatfs: Basic FAT FS in basic flash sample

### DIFF
--- a/samples/subsys/fs/fat_fs_basic/CMakeLists.txt
+++ b/samples/subsys/fs/fat_fs_basic/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(fs_fat_basic)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/fs/fat_fs_basic/README.rst
+++ b/samples/subsys/fs/fat_fs_basic/README.rst
@@ -1,0 +1,33 @@
+.. _fat_fs_basic:
+
+FAT File system Sample Application on internal/external Flash
+#############################################################
+
+Overview
+********
+
+The sample application demonstrates how to configure and mount FAT file system on internal or
+external flash memory.
+Sample presents how to configure project, prepare overalays and explains types of objects used in
+source code for the purpose of mounting the file system.
+
+Requirements
+************
+
+FAT requires at least 128 sectors, in this sample configured to be 512b in size, which means
+that there is need to provided 64kiB of flash for the FAT to work.
+When the sector size gets changed, the size of flash needs adjustment.
+
+Building and Running
+********************
+
+Currently the sample will build for following boards:
+	``nrf52840dk_nrf52840`` internal, external NOR on QSPI
+	``nrf9160dk_nrf52840``	internal flash only
+	``nrf9160dk_nrf9160@0.14.0`` internal, external NOR on SPI
+
+Upon first run the sample will format provided flash partition to FAT file system and will create
+single file there. On next runs, a one byte from file will be read incremented and written back
+per run.
+
+While building the application, remember to use proper overlay for the board.

--- a/samples/subsys/fs/fat_fs_basic/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/fs/fat_fs_basic/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The overlay provides following changes to the DTS
+ *  1) it changes organizations of SoC internal flash to fit minimal FAT system; this is needed for
+ *  for FAT in internal flash sample;
+ *  2) it add definition of partition within external, mx25r64, flash; this change is needed for FAT
+ *  in external flash sample.
+ *
+ * Of course demo of FAT in internal flash requires 1) only and demo of FAT in external flash
+ * requires 2) only, but they have been merged here for convenience.
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &scratch_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x0000C000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x00063000>;
+		};
+		slot1_partition: partition@67000 {
+			label = "image-1";
+			reg = <0x0006F000 0x00063000>;
+		};
+		scratch_partition: partition@d2000 {
+			label = "image-scratch";
+			reg = <0x000d2000 0x0001e000>;
+		};
+
+		/*
+		 * FAT FS requires at least 128 sectors set by CONFIG_DISK_FLASH_SECTOR_SIZE
+		 * configuration option to 512, which means that at least 64kiB are needed.
+		 */
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 0x00010000>;
+		};
+	};
+};
+
+&mx25r64 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Use 128kiB of flash for storage, starting at 0x0000 address */
+		partition@0 {
+			label = "external_storage";
+			reg = <0x00000000 0x00020000>;
+		};
+	};
+};

--- a/samples/subsys/fs/fat_fs_basic/boards/nrf9160dk_nrf52840.overlay
+++ b/samples/subsys/fs/fat_fs_basic/boards/nrf9160dk_nrf52840.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The overlay changes organizations of SoC internal flash to fit minimal FAT system.
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &scratch_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x0000C000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x00063000>;
+		};
+		slot1_partition: partition@67000 {
+			label = "image-1";
+			reg = <0x0006F000 0x00063000>;
+		};
+		scratch_partition: partition@d2000 {
+			label = "image-scratch";
+			reg = <0x000d2000 0x0001e000>;
+		};
+
+		/*
+		 * FAT FS requires at least 128 sectors set by CONFIG_DISK_FLASH_SECTOR_SIZE
+		 * configuration option to 512, which means that at least 64kiB are needed.
+		 */
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 0x00010000>;
+		};
+	};
+};

--- a/samples/subsys/fs/fat_fs_basic/boards/nrf9160dk_nrf9160.overlay
+++ b/samples/subsys/fs/fat_fs_basic/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The overlay provides following changes to the DTS
+ *  1) it changes organizations of SoC internal flash to fit minimal FAT system; this is needed for
+ *  for FAT in internal flash sample;
+ *  2) it add definition of partition within external, mx25r64, flash; this change is needed for FAT
+ *  in external flash sample.
+ *
+ * Of course demo of FAT in internal flash requires 1) only and demo of FAT in external flash
+ * requires 2) only, but they have been merged here for convenience.
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &scratch_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x0000C000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x00063000>;
+		};
+		slot1_partition: partition@67000 {
+			label = "image-1";
+			reg = <0x0006F000 0x00063000>;
+		};
+		scratch_partition: partition@d2000 {
+			label = "image-scratch";
+			reg = <0x000d2000 0x0001e000>;
+		};
+
+		/*
+		 * FAT FS requires at least 128 sectors set by CONFIG_DISK_FLASH_SECTOR_SIZE
+		 * configuration option to 512, which means that at least 64kiB are needed.
+		 */
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 0x00010000>;
+		};
+	};
+};
+
+&mx25r64 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Use 128kiB of flash for storage, starting at 0x0000 address */
+		partition@0 {
+			label = "external_storage";
+			reg = <0x00000000 0x00020000>;
+		};
+	};
+};

--- a/samples/subsys/fs/fat_fs_basic/prj.conf
+++ b/samples/subsys/fs/fat_fs_basic/prj.conf
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+CONFIG_MAIN_STACK_SIZE=2048
+
+# General file system support
+CONFIG_FILE_SYSTEM=y
+# FAT Driver
+CONFIG_FAT_FILESYSTEM_ELM=y
+# FAT Driver requires storage subsystem
+CONFIG_DISK_DRIVERS=y
+# Flash driver for storage
+CONFIG_DISK_DRIVER_FLASH=y
+# Mount point of FAT FS, the <dir> part in "/<dir>:"
+CONFIG_DISK_FLASH_VOLUME_NAME="NAND"
+# Flash driver name, to identify device in DTS
+CONFIG_DISK_FLASH_DEV_NAME="NRF_FLASH_DRV_NAME"
+# Max number of bytes per operation
+CONFIG_DISK_FLASH_MAX_RW_SIZE=256
+# 1 flash page per erase is 4096 byte => 0x1000
+CONFIG_DISK_FLASH_ERASE_ALIGNMENT=0x1000
+CONFIG_DISK_ERASE_BLOCK_SIZE=0x1000
+# Start of "storage" partition in overlay file
+CONFIG_DISK_FLASH_START=0xf0000
+# Size of "storage" partition in overlay file
+CONFIG_DISK_VOLUME_SIZE=0x10000
+# Sector size, the block device write unit.
+CONFIG_DISK_FLASH_SECTOR_SIZE=512
+
+# Need to allow to create file system if not-existent and system needs to allow writes
+CONFIG_FS_FATFS_MOUNT_MKFS=y
+CONFIG_FS_FATFS_READ_ONLY=n

--- a/samples/subsys/fs/fat_fs_basic/prj_external_qspi.conf
+++ b/samples/subsys/fs/fat_fs_basic/prj_external_qspi.conf
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SPI=y
+CONFIG_NORDIC_QSPI_NOR=y
+CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# General file system support
+CONFIG_FILE_SYSTEM=y
+# FAT Driver
+CONFIG_FAT_FILESYSTEM_ELM=y
+# FAT Driver requires storage subsystem
+CONFIG_DISK_DRIVERS=y
+# Flash driver for storage
+CONFIG_DISK_DRIVER_FLASH=y
+# Mount point of FAT FS, the <dir> part in "/<dir>:"
+CONFIG_DISK_FLASH_VOLUME_NAME="NAND"
+# Flash driver name, to identify device in DTS
+CONFIG_DISK_FLASH_DEV_NAME="MX25R64"
+# Max number of bytes per operation
+CONFIG_DISK_FLASH_MAX_RW_SIZE=256
+# 1 flash page per erase is 4096 byte => 0x1000, same as
+# CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
+CONFIG_DISK_FLASH_ERASE_ALIGNMENT=0x1000
+CONFIG_DISK_ERASE_BLOCK_SIZE=0x1000
+# Start of "external_storage" partition in overlay file
+CONFIG_DISK_FLASH_START=0x00000
+# Size of "external_storage" partition in overlay file
+CONFIG_DISK_VOLUME_SIZE=0x20000
+# Sector size, the block device write unit.
+CONFIG_DISK_FLASH_SECTOR_SIZE=512
+
+# Need to allow to create file system if not-existent and system needs to allow writes
+CONFIG_FS_FATFS_MOUNT_MKFS=y
+CONFIG_FS_FATFS_READ_ONLY=n

--- a/samples/subsys/fs/fat_fs_basic/prj_external_spi.conf
+++ b/samples/subsys/fs/fat_fs_basic/prj_external_spi.conf
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+
+# General file system support
+CONFIG_FILE_SYSTEM=y
+# FAT Driver
+CONFIG_FAT_FILESYSTEM_ELM=y
+# FAT Driver requires storage subsystem
+CONFIG_DISK_DRIVERS=y
+# Flash driver for storage
+CONFIG_DISK_DRIVER_FLASH=y
+# Mount point of FAT FS, the <dir> part in "/<dir>:"
+CONFIG_DISK_FLASH_VOLUME_NAME="NAND"
+# Flash driver name, to identify device in DTS
+CONFIG_DISK_FLASH_DEV_NAME="MX25R64"
+# Max number of bytes per operation
+CONFIG_DISK_FLASH_MAX_RW_SIZE=256
+# 1 flash page per erase is 4096 byte => 0x1000, same as
+# CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
+CONFIG_DISK_FLASH_ERASE_ALIGNMENT=0x1000
+CONFIG_DISK_ERASE_BLOCK_SIZE=0x1000
+# Start of "external_storage" partition in overlay file
+CONFIG_DISK_FLASH_START=0x00000
+# Size of "external_storage" partition in overlay file
+CONFIG_DISK_VOLUME_SIZE=0x20000
+# Sector size, the block device write unit.
+CONFIG_DISK_FLASH_SECTOR_SIZE=512
+
+# Need to allow to create file system if not-existent and system needs to allow writes
+CONFIG_FS_FATFS_MOUNT_MKFS=y
+CONFIG_FS_FATFS_READ_ONLY=n

--- a/samples/subsys/fs/fat_fs_basic/sample.yaml
+++ b/samples/subsys/fs/fat_fs_basic/sample.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+sample:
+  name: Simple FAT file system in internal/external flash sample
+common:
+  tags: filesystem, fat
+tests:
+  sample.filesystem.fat_fs_basic.nrf52840dk_nrf52840.internal:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay"
+  sample.filesystem.fat_fs_basic.nrf9160dk_nrf52840.internal:
+    platform_allow: nrf9160dk_nrf52840
+    extra_args: DTC_OVERLAY_FILE="boards/nrf9160dk_nrf52840.overlay"
+  sample.filesystem.fat_fs_basic.nrf52840dk_nrf52840.external:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay" CONF_FILE="prj_external_qspi.conf"
+  sample.filesystem.fat_fs_basic.nrf9160dk_nrf9160.external:
+    platform_allow: nrf9160dk_nrf9160@0.14.0
+    extra_args: DTC_OVERLAY_FILE="boards/nrf9160dk_nrf9160.overlay" CONF_FILE="prj_external_spi.conf"
+  sample.filesystem.fat_fs_basic.nrf9160dk_nrf9160.internal:
+    platform_allow: nrf9160dk_nrf9160@0.14.0
+    extra_args: DTC_OVERLAY_FILE="boards/nrf9160dk_nrf9160.overlay"

--- a/samples/subsys/fs/fat_fs_basic/src/main.c
+++ b/samples/subsys/fs/fat_fs_basic/src/main.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This is very basic sample that demonstrates how the to use SoC internal flash for FAT FS
+ * file system.
+ * The sample will make FAT FS at first run and create file to which it will write single byte
+ * increamenting it at each reboot.
+ *
+ * Note that, in case when using SoC flash for FAT, the system somehow needs to be created so
+ * if an appication of only means to do so then the CONFIG_FS_FATFS_MOUNT_MKFS=y Kconfig
+ * option is required, this will enable application to create FAT in designated area on first run.
+ * The CONFIG_FS_FATFS_READ_ONLY=n is required as read-only systems prevent usage of
+ * CONFIG_FS_FATFS_MOUNT_MKFS.
+ */
+#include <zephyr.h>
+#include <device.h>
+#include <disk/disk_access.h>
+#include <logging/log.h>
+#include <fs/fs.h>
+#include <ff.h>
+
+LOG_MODULE_REGISTER(main);
+
+/*
+ * This object, or buffer of its size, is needed by the FAT driver to store internal objects;
+ * it will be given the driver via mount point definition, structure of type fs_mount_t.
+ * User should avoiding accessing it and care must be taken for the structure to be defined
+ * for the entire time when FAT FS is mounted.
+ * Each mounted FAT file system requires separate FATFS object.
+ */
+static FATFS fat_fs;
+
+/*
+ * The correct format for mount point, for FAT FS, is "/<dir>:" where dir is 0-9 digit or one of
+ * strings listed by preprocesor macro _VOLUME_STRS in FAT ELM configuration,
+ * modules/fs/fatfs/include/ffconf.h.
+ * In this sample the <dir> is taken from Kconfig option CONFIG_DISK_FLASH_VOLUME_NAME.
+ */
+static struct fs_mount_t mp = {
+	.type = FS_FATFS,
+	.fs_data = &fat_fs,
+	.mnt_point = "/"CONFIG_DISK_FLASH_VOLUME_NAME":",
+};
+
+
+void main(void)
+{
+	struct fs_file_t f;
+	uint8_t b = 0;
+	/*
+	 * Notice the additional '/' in path of file name, after the ':'; the FAT fs is special that
+	 * it requires mount points to end with ':', and as the mount point serves as virtual
+	 * directory in structure the '/' before next path element is required, for example:
+	 *  /RAM:/Hello.txt
+	 * is correct, but attempting to open
+	 *  /RAM:Hello.txt
+	 * will result in error -2 and information that mount point does not exist.
+	 */
+	const char *fname = "/"CONFIG_DISK_FLASH_VOLUME_NAME":/Hello.txt";
+
+	/*
+	 * Use the fs_mount_t object mp to mount file system
+	 */
+	int res = fs_mount(&mp);
+	/* Initialize fs_file_t type object before first use */
+	fs_file_t_init(&f);
+
+	if (res == 0) {
+		printk("Successfully mounted FAT at %s\n", mp.mnt_point);
+	} else {
+		printk("Error mounting disk.\n");
+		printk("Failed to mount disk at %s with error %d\n", mp.mnt_point, res);
+		goto spin_me;
+	}
+
+	/* Open or create the file */
+	res = fs_open(&f, fname, FS_O_CREATE | FS_O_RDWR);
+	if (res != 0) {
+		printk("Failed to open file with error %d\n", res);
+		goto spin_me;
+	}
+
+	res = fs_read(&f, &b, 1);
+	if (res == 0) {
+		printk("Nothing to read yet\n");
+	} else if (res == 1) {
+		printk("One byte read %x\n", (int)b);
+		++b;
+	} else if (res < 0) {
+		printk("Failed to read file with error %d\n", res);
+		goto spin_me;
+	}
+
+	/* Rewind file */
+	res = fs_seek(&f, 0, FS_SEEK_SET);
+	if (res < 0) {
+		printk("Failed to rewind file with error %d\n", res);
+		goto spin_me;
+	}
+
+	printk("Write to file %x\n", (int)b);
+
+	res = fs_write(&f, &b, 1);
+	if (res < 0) {
+		printk("Failed to write to file with error %d\b", res);
+		goto spin_me;
+	}
+	fs_sync(&f);
+
+spin_me:
+	/* Can close unopened file with no error */
+	fs_close(&f);
+
+	if (res != 0) {
+		printk("Halting");
+	} else {
+		printk("Idle looping, awaiting reboot");
+
+	}
+	while (1) {
+		k_sleep(K_MSEC(1000));
+	}
+}


### PR DESCRIPTION
This is very basic sample that presents how the FAT FS can be used with internal flash.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

There have been queries regarding the possibility of using internal flash for FAT and the only example for such solution is USB mass storage which seems; that is why this simpler sample has been created.