### PR TITLE
lib: os: cbprintf: Fix Z_C_GENERIC not being used

### DIFF
--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -11,7 +11,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <toolchain.h>
-#include <sys/cbprintf_internal.h>
 
 #ifdef CONFIG_CBPRINTF_LIBC_SUBSTS
 #include <stdio.h>
@@ -35,6 +34,9 @@ extern "C" {
 #define Z_C_GENERIC 0
 #endif
 #endif
+
+/* Z_C_GENERIC is used there */
+#include <sys/cbprintf_internal.h>
 
 /**
  * @defgroup cbprintf_apis Formatted Output APIs

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -242,7 +242,7 @@ do { \
 			"Buffer must be aligned."); \
 	} \
 	uint8_t *_pbuf = buf; \
-	size_t _pmax = (buf != NULL) ? *_inlen : SIZE_MAX; \
+	size_t _pmax = (buf != NULL) ? _inlen : SIZE_MAX; \
 	size_t _pkg_len = 0; \
 	union z_cbprintf_hdr *_len_loc; \
 	/* package starts with string address and field with length */ \

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -124,6 +124,7 @@ void test_main(void)
 	printk("alignof: int=%zu long=%zu ptr=%zu long long=%zu double=%zu long double=%zu\n",
 	       __alignof__(int), __alignof__(long), __alignof__(void *),
 	       __alignof__(long long), __alignof__(double), __alignof__(long double));
+	printk("%s C11 _Generic\n", Z_C_GENERIC ? "With" : "Without");
 
 	ztest_test_suite(cbprintf_package,
 			 ztest_unit_test(test_cbprintf_package)

--- a/tests/lib/cbprintf_package/testcase.yaml
+++ b/tests/lib/cbprintf_package/testcase.yaml
@@ -10,6 +10,18 @@ tests:
     extra_configs:
       - CONFIG_CBPRINTF_COMPLETE=y
 
+  libraries.cbprintf_package_no_generic:
+    tags: cbprintf
+    integration_platforms:
+      - native_posix
+    platform_allow: >
+      qemu_arc_em qemu_arc_hs qemu_cortex_a53 qemu_cortex_m0 qemu_cortex_m3
+      qemu_cortex_r5 qemu_leon3 qemu_nios2 qemu_riscv32 qemu_riscv64 qemu_x86
+      qemu_x86_64 qemu_xtensa
+    extra_configs:
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_COMPILER_OPT="-DZ_C_GENERIC=0"
+
   libraries.cbprintf_package_fp:
     tags: cbprintf
     integration_platforms:

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -14,7 +14,6 @@
 #include <wctype.h>
 #include <stddef.h>
 #include <string.h>
-#include <sys/cbprintf.h>
 #include <sys/util.h>
 
 #define CBPRINTF_VIA_UNIT_TEST
@@ -96,6 +95,9 @@
 #if (VIA_TWISTER & 0x400) != 0
 #define CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE 1
 #endif
+#if (VIA_TWISTER & 0x800) != 0
+#define AVOID_C_GENERIC 1
+#endif
 
 #endif /* VIA_TWISTER */
 
@@ -114,6 +116,11 @@
 #define ENABLED_USE_PACKAGED false
 #endif
 
+#if AVOID_C_GENERIC
+#define Z_C_GENERIC 0
+#endif
+
+#include <sys/cbprintf.h>
 #include "../../../lib/os/cbprintf.c"
 
 #if defined(CONFIG_CBPRINTF_COMPLETE)
@@ -1219,13 +1226,14 @@ void test_main(void)
 	}
 	if (IS_ENABLED(CONFIG_CBPRINTF_COMPLETE)) {
 		TC_PRINT(" COMPLETE");
-		if (ENABLED_USE_PACKAGED) {
-			TC_PRINT(" PACKAGED\n");
-		} else {
-			TC_PRINT(" VA_LIST\n");
-		}
 	} else {
 		TC_PRINT(" NANO\n");
+	}
+	if (ENABLED_USE_PACKAGED) {
+		TC_PRINT(" PACKAGED %s C11 _Generic\n",
+				Z_C_GENERIC ? "with" : "without");
+	} else {
+		TC_PRINT(" VA_LIST\n");
 	}
 	if (IS_ENABLED(CONFIG_CBPRINTF_FULL_INTEGRAL)) {
 		TC_PRINT(" FULL_INTEGRAL\n");

--- a/tests/unit/cbprintf/testcase.yaml
+++ b/tests/unit/cbprintf/testcase.yaml
@@ -45,6 +45,21 @@ tests:
   utilities.prf.m32v281: # PACKAGED NANO + FULL
     extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0x281
 
+  utilities.prf.m32va00: # PACKAGED REDUCED + AVOID_C_GENERIC
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa00
+
+  utilities.prf.m32va01: # PACKAGED FULL + AVOID_C_GENERIC
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa01
+
+  utilities.prf.m32va07: # PACKAGED FULL + FP + FP_A + AVOID_C_GENERIC
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa07
+
+  utilities.prf.m32va08: # PACKAGED %n + AVOID_C_GENERIC
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa08
+
+  utilities.prf.m32va81: # PACKAGED NANO + FULL + AVOID_C_GENERIC
+    extra_args: M64_MODE=0 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa81
+
   utilities.prf.m64v00: # m64
     extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0x00
 
@@ -95,3 +110,18 @@ tests:
 
   utilities.prf.m64v681: # PACKAGED NANO + FULL + LONG_DOUBLE PACKAGING
     extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0x681
+
+  utilities.prf.m64va00: # PACKAGED REDUCED + AVOID_C_GENERIC
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa00
+
+  utilities.prf.m64va01: # PACKAGED FULL + AVOID_C_GENERIC
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa01
+
+  utilities.prf.m64va07: # PACKAGED FULL + FP + FP_A + AVOID_C_GENERIC
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa07
+
+  utilities.prf.m64va08: # PACKAGED %n + AVOID_C_GENERIC
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa08
+
+  utilities.prf.m64va81: # PACKAGED NANO + FULL + AVOID_C_GENERIC
+    extra_args: M64_MODE=1 EXTRA_CPPFLAGS=-DVIA_TWISTER=0xa81


### PR DESCRIPTION
Due to the fact that `Z_C_GENERIC` define was created after including cbprintf_internal.h, it was not used there. Change the order and fix the issue that was revealed.

Updated tests to test configurations with and without use of `_Generic`.