### PR TITLE
bluetooth: mesh: functionality for immediate saving the mesh settings

### DIFF
--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -770,3 +770,21 @@ The Configuration database is an optional Mesh subsystem that can be enabled thr
 	Delete an application key from the Configuration database.
 
 	* ``AppKeyIdx``: Key index of the application key to delete.
+
+Settings
+========
+
+The Settings is an optional Mesh subsystem. The commands help to change the work mode of the subsystem to speed up data storing in case of emergency situations.
+
+``mesh setting-flush``
+----------------------
+
+	If there are not stored yet mesh settings they will be sent into the settings backend.
+
+
+``mesh setting-timeout-bypass <val: off, on>``
+----------------------------------------------
+
+	Switch on/off the bypassing of the :option:`CONFIG_BT_MESH_STORE_TIMEOUT` and :option:`CONFIG_BT_MESH_RPL_STORE_TIMEOUT` timeouts for storing data into the persistent memory.
+
+	* ``val``: Enable or disable the timeouts bypassing

--- a/subsys/bluetooth/mesh/settings.h
+++ b/subsys/bluetooth/mesh/settings.h
@@ -17,6 +17,7 @@ enum bt_mesh_settings_flag {
 	BT_MESH_SETTINGS_MOD_PENDING,
 	BT_MESH_SETTINGS_VA_PENDING,
 	BT_MESH_SETTINGS_CDB_PENDING,
+	BT_MESH_SETTINGS_BYPASS_TIMEOUT,
 
 	BT_MESH_SETTINGS_FLAG_COUNT,
 };
@@ -40,3 +41,5 @@ void bt_mesh_settings_init(void);
 void bt_mesh_settings_store_schedule(enum bt_mesh_settings_flag flag);
 int bt_mesh_settings_set(settings_read_cb read_cb, void *cb_arg,
 			 void *out, size_t read_len);
+void bt_mesh_settings_store_flush(void);
+void bt_mesh_settings_timeout_bypass(bool enable);

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -2645,6 +2645,28 @@ static int cmd_cdb_app_key_del(const struct shell *shell, size_t argc,
 }
 #endif
 
+#if defined(CONFIG_BT_SETTINGS)
+static int cmd_setting_flush(const struct shell *shell, size_t argc,
+		char *argv[])
+{
+	bt_mesh_settings_store_flush();
+
+	shell_print(shell, "Settings flushed");
+
+	return 0;
+}
+
+static int cmd_setting_timeout_bypass(const struct shell *shell, size_t argc,
+		char *argv[])
+{
+	bt_mesh_settings_timeout_bypass(str2bool(argv[1]));
+
+	shell_print(shell, "Settings timeout bypassing: %s", argv[1]);
+
+	return 0;
+}
+#endif
+
 /* List of Mesh subcommands.
  *
  * Each command is documented in doc/reference/bluetooth/mesh/shell.rst.
@@ -2790,6 +2812,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 		      "[<AppKey>]", cmd_cdb_app_key_add, 3, 1),
 	SHELL_CMD_ARG(cdb-app-key-del, NULL, "<AppKeyIdx>", cmd_cdb_app_key_del,
 		      2, 0),
+#endif
+
+#if defined(CONFIG_BT_SETTINGS)
+	/* Mesh Settings Operations */
+	SHELL_CMD_ARG(setting-flush, NULL, NULL, cmd_setting_flush, 1, 0),
+	SHELL_CMD_ARG(setting-timeout-bypass, NULL, "<val: off, on>",
+			cmd_setting_timeout_bypass, 2, 0),
 #endif
 
 	SHELL_SUBCMD_SET_END


### PR DESCRIPTION
The mesh settings are stored immediately or by timeout depends on
the data source. The timeout for regular data update
in the persistent memory is configurable compile-time
and might take significant time.

However, there are cases when the final application requires
emergency storing all mesh data. PR changes provide functionality
that allows to flush all not stored mesh core data yet
and switch on\off timeout logic in mesh settings.
Additionally, the mesh shell has been extended by commands to get access
to this functionality.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>