### PR TITLE
doc: fs: Add information on samples that utilize VFS

### DIFF
--- a/doc/reference/file_system/index.rst
+++ b/doc/reference/file_system/index.rst
@@ -44,10 +44,18 @@ where
 
 
 
-Sample
-******
+Samples
+*******
 
-A sample of how the file system can be used is supplied in ``samples/subsys/fs``.
+Samples for the VFS are mainly supplied in ``samples/subsys/fs``, although various examples of the
+VFS usage are provided as important functionalities in samples for different subsystems.
+Here is the list of samples worth looking at:
+
+- ``samples/subsys/fs/fat_fs`` is an example of FAT file system usage with SDHC media;
+- ``samples/subsys/shell/fs`` is an example of Shell fs subsystem, using internal flash partition
+	formatted to LittleFS;
+- ``samples/subsys/usb/mass/`` example of USB Mass Storage device that uses FAT FS driver with RAM
+	or SPI connected FLASH, or LittleFS in flash, depending on the sample configuration.
 
 API Reference
 *************


### PR DESCRIPTION
There are several interesting use caseis of VFS scattered around
in samples, for example usage of FAT in RAM in USB mass storage
that are worth mentioning in VFS reference documentation.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>