### PR TITLE
drivers: modem: gsm_ppp: Kconfig for autostarting ppp

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -53,6 +53,15 @@ config MODEM_GSM_APN
 	  Specify Access Point Name, i.e. the name to identify Internet IP
 	  GPRS cellular data context.
 
+config GSM_PPP_AUTOSTART
+	bool "Auto-start PPP at boot"
+	default y
+	help
+	  This setting lets driver connect to network and initialize PPP at
+	  boot. Unselect this if you want to run application code before
+	  modem connects to network. See contents of "drivers/gsm_ppp.h"
+	  to get an idea of the API.
+
 config MODEM_GSM_MANUAL_MCCMNO
 	string "MCC/MNO for establishing network connection"
 	help

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -794,7 +794,9 @@ static int gsm_init(const struct device *device)
 		return -ENODEV;
 	}
 
-	gsm_ppp_start(device);
+	if (IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART)) {
+		gsm_ppp_start(device);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Autostarting PPP is far from controversial. There are many, many reasons
someone could have for wanting to control exactly when PPP starts. Power
management, NET_EVENT race condition avoidance and any application not
requiring constant and instant use of networking just to name a few.

This commit introduces a Kconfig setting, GSM_PPP_AUTOSTART, which
controls whether gsm_ppp should connect and initialize PPP at boot. It
is set to "y" as default to minimize surprises for legacy code.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>