### PR TITLE
net: dns: update to new k_work API

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1870,8 +1870,8 @@ static void print_dns_info(const struct shell *shell,
 			continue;
 		}
 
-		remaining =
-			k_delayed_work_remaining_get(&ctx->queries[i].timer);
+		remaining = k_ticks_to_ms_ceil32(
+			k_work_delayable_remaining_get(&ctx->queries[i].timer));
 
 		if (ctx->queries[i].query_type == DNS_QUERY_TYPE_A) {
 			PR("\tIPv4[%u]: %s remaining %d\n",

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -76,6 +76,7 @@ NET_BUF_POOL_DEFINE(dns_qname_pool, DNS_RESOLVER_BUF_CTR, DNS_MAX_NAME_LEN,
 
 static struct dns_resolve_context dns_default_ctx;
 
+/* Must be invoked with context lock held */
 static int dns_write(struct dns_resolve_context *ctx,
 		     int server_idx,
 		     int query_idx,
@@ -338,12 +339,42 @@ fail:
 	return ret;
 }
 
+/* Check whether a slot is available for use, or optionally whether it can be
+ * reclaimed.
+ *
+ * @param pending_query the query slot in question
+ *
+ * @param reclaim_if_available if the slot is marked in use, but the query has
+ * been completed and the work item is no longer pending, complete the release
+ * of the slot.
+ *
+ * @return true if and only if the slot can be used for a new query.
+ */
+static inline bool check_query_active(struct dns_pending_query *pending_query,
+				      bool reclaim_if_available)
+{
+	int ret = false;
+
+	if (pending_query->cb != NULL) {
+		ret = true;
+		if (reclaim_if_available
+		    && pending_query->query == NULL
+		    && k_work_delayable_busy_get(&pending_query->timer) == 0) {
+			pending_query->cb = NULL;
+			ret = false;
+		}
+	}
+
+	return ret;
+}
+
+/* Must be invoked with context lock held */
 static inline int get_cb_slot(struct dns_resolve_context *ctx)
 {
 	int i;
 
 	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
-		if (!ctx->queries[i].cb) {
+		if (!check_query_active(&ctx->queries[i], true)) {
 			return i;
 		}
 	}
@@ -351,6 +382,50 @@ static inline int get_cb_slot(struct dns_resolve_context *ctx)
 	return -ENOENT;
 }
 
+/* Invoke the callback associated with a query slot, if still relevant.
+ *
+ * Must be invoked with context lock held.
+ *
+ * @param status the query status value
+ * @param info the query result structure
+ * @param pending_query the query slot that will provide the callback
+ **/
+static inline void invoke_query_callback(int status,
+					 struct dns_addrinfo *info,
+					 struct dns_pending_query *pending_query)
+{
+	/* Only notify if the slot is neither released nor in the process of
+	 * being released.
+	 */
+	if (pending_query->query != NULL)  {
+		pending_query->cb(status, info, pending_query->user_data);
+	}
+}
+
+/* Release a query slot reserved by get_cb_slot().
+ *
+ * Must be invoked with context lock held.
+ *
+ * @param pending_query the query slot to be released
+ */
+static void release_query(struct dns_pending_query *pending_query)
+{
+	int busy = k_work_cancel_delayable(&pending_query->timer);
+
+	/* If the work item is no longer pending we're done. */
+	if (busy == 0) {
+		/* All done. */
+		pending_query->cb = NULL;
+	} else {
+		/* Work item is still pending.  Set a secondary condition that
+		 * can be checked by get_cb_slot() to complete release of the
+		 * slot once the work item has been confirmed to be completed.
+		 */
+		pending_query->query = NULL;
+	}
+}
+
+/* Must be invoked with context lock held */
 static inline int get_slot_by_id(struct dns_resolve_context *ctx,
 				 uint16_t dns_id,
 				 uint16_t query_hash)
@@ -358,7 +433,8 @@ static inline int get_slot_by_id(struct dns_resolve_context *ctx,
 	int i;
 
 	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
-		if (ctx->queries[i].cb && ctx->queries[i].id == dns_id &&
+		if (check_query_active(&ctx->queries[i], false) &&
+		    ctx->queries[i].id == dns_id &&
 		    (query_hash == 0 ||
 		     ctx->queries[i].query_hash == query_hash)) {
 			return i;
@@ -540,8 +616,8 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 			memcpy(addr, src, address_size);
 
 		query_known:
-			ctx->queries[*query_idx].cb(DNS_EAI_INPROGRESS, &info,
-					ctx->queries[*query_idx].user_data);
+			invoke_query_callback(DNS_EAI_INPROGRESS, &info,
+					      &ctx->queries[*query_idx]);
 			items++;
 			break;
 
@@ -617,6 +693,7 @@ quit:
 	return ret;
 }
 
+/* Must be invoked with context lock held */
 static int dns_read(struct dns_resolve_context *ctx,
 		    struct net_pkt *pkt,
 		    struct net_buf *dns_data,
@@ -653,12 +730,10 @@ static int dns_read(struct dns_resolve_context *ctx,
 		goto quit;
 	}
 
-	k_delayed_work_cancel(&ctx->queries[query_idx].timer);
+	invoke_query_callback(ret, NULL, &ctx->queries[query_idx]);
 
 	/* Marks the end of the results */
-	ctx->queries[query_idx].cb(ret, NULL,
-				   ctx->queries[query_idx].user_data);
-	ctx->queries[query_idx].cb = NULL;
+	release_query(&ctx->queries[query_idx]);
 
 	net_pkt_unref(pkt);
 
@@ -756,11 +831,10 @@ quit:
 		goto free_buf;
 	}
 
-	k_delayed_work_cancel(&ctx->queries[i].timer);
+	invoke_query_callback(ret, NULL, &ctx->queries[i]);
 
 	/* Marks the end of the results */
-	ctx->queries[i].cb(ret, NULL, ctx->queries[i].user_data);
-	ctx->queries[i].cb = NULL;
+	release_query(&ctx->queries[i]);
 
 free_buf:
 	if (dns_data) {
@@ -774,6 +848,7 @@ free_buf:
 	k_mutex_unlock(&ctx->lock);
 }
 
+/* Must be invoked with context lock held */
 static int dns_write(struct dns_resolve_context *ctx,
 		     int server_idx,
 		     int query_idx,
@@ -827,8 +902,8 @@ static int dns_write(struct dns_resolve_context *ctx,
 		server_addr_len = sizeof(struct sockaddr_in6);
 	}
 
-	ret = k_delayed_work_submit(&ctx->queries[query_idx].timer,
-				    ctx->queries[query_idx].timeout);
+	ret = k_work_reschedule(&ctx->queries[query_idx].timer,
+				ctx->queries[query_idx].timeout);
 	if (ret < 0) {
 		NET_DBG("[%u] cannot submit work to server idx %d for id %u "
 			"ret %d", query_idx, server_idx, dns_id, ret);
@@ -861,7 +936,7 @@ static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 
 	i = get_slot_by_id(ctx, dns_id, query_hash);
-	if (i < 0 || !ctx->queries[i].cb) {
+	if (i < 0) {
 		ret = -ENOENT;
 		goto fail;
 	}
@@ -870,10 +945,9 @@ static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 		log_strdup(query_name), ctx->queries[i].query_type,
 		query_hash);
 
-	k_delayed_work_cancel(&ctx->queries[i].timer);
+	invoke_query_callback(DNS_EAI_CANCELED, NULL, &ctx->queries[i]);
 
-	ctx->queries[i].cb(DNS_EAI_CANCELED, NULL, ctx->queries[i].user_data);
-	ctx->queries[i].cb = NULL;
+	release_query(&ctx->queries[i]);
 
 fail:
 	k_mutex_unlock(&ctx->lock);
@@ -938,14 +1012,39 @@ static void query_timeout(struct k_work *work)
 {
 	struct dns_pending_query *pending_query =
 		CONTAINER_OF(work, struct dns_pending_query, timer);
+	int ret;
+
+	/* We have to take the lock as we're inspecting protected content
+	 * associated with the query.  But don't block the system work queue:
+	 * if the lock can't be taken immediately, reschedule the work item to
+	 * be run again after everything else has had a chance.
+	 *
+	 * Note that it's OK to use the k_work API on the delayable work
+	 * without holding the lock: it's only the associated state in the
+	 * containing structure that must be protected.
+	 */
+	ret = k_mutex_lock(&pending_query->ctx->lock, K_NO_WAIT);
+	if (ret != 0) {
+		struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+
+		k_work_reschedule(dwork, K_NO_WAIT);
+		return;
+	}
 
 	NET_DBG("Query timeout DNS req %u type %d hash %u", pending_query->id,
 		pending_query->query_type, pending_query->query_hash);
 
+	/* The resolve cancel will invoke release_query(), but release will
+	 * not be completed because the work item is still pending.  Instead
+	 * the release will be completed when check_query_active() confirms
+	 * the work item is no longer active.
+	 */
 	(void)dns_resolve_cancel_with_hash(pending_query->ctx,
 					   pending_query->id,
 					   pending_query->query_hash,
 					   pending_query->query);
+
+	k_mutex_unlock(&pending_query->ctx->lock);
 }
 
 int dns_resolve_name(struct dns_resolve_context *ctx,
@@ -1041,7 +1140,7 @@ try_resolve:
 	ctx->queries[i].ctx = ctx;
 	ctx->queries[i].query_hash = 0;
 
-	k_delayed_work_init(&ctx->queries[i].timer, query_timeout);
+	k_work_init_delayable(&ctx->queries[i].timer, query_timeout);
 
 	dns_data = net_buf_alloc(&dns_msg_pool, ctx->buf_timeout);
 	if (!dns_data) {
@@ -1140,8 +1239,7 @@ try_resolve:
 quit:
 	if (ret < 0) {
 		if (i >= 0) {
-			k_delayed_work_cancel(&ctx->queries[i].timer);
-			ctx->queries[i].cb = NULL;
+			release_query(&ctx->queries[i]);
 		}
 
 		if (dns_id) {

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -154,7 +154,7 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 		/* We need to cancel the query manually so that we
 		 * will not get a timeout.
 		 */
-		k_delayed_work_cancel(&ctx->queries[slot].timer);
+		k_work_cancel_delayable(&ctx->queries[slot].timer);
 
 		DBG("Calling cb %p with user data %p\n",
 		    ctx->queries[slot].cb,
@@ -511,7 +511,7 @@ static void verify_cancelled(void)
 			count++;
 		}
 
-		if (k_delayed_work_remaining_get(&ctx->queries[i].timer) > 0) {
+		if (k_work_delayable_busy_get(&ctx->queries[i].timer) != 0) {
 			timer_not_stopped++;
 		}
 	}


### PR DESCRIPTION
*NB: This is based on #33217 which it incorporates.  Draft until that's merged or incorporates this PR.*

Switch to the new API for delayed work related to DNS queries.

In the previous solution it was assumed that the work item could be immediately cancelled at the point the query slot was released.  This is not true. We need a secondary condition to record the fact that the query was completed while the work item was still pending, and an additional check to detect when the work item completed and the slot reclaimed.

Also annotate functions to indicate when they require the lock on query content to be held, add some helpers that abstract core operations like invoking a callback or releasing a query slot, and fix some more cases where query slot content was accessed outside of the new lock infrastructure.