### PR TITLE
WIP: add synchronization event update requests between ULL and LLL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -52,3 +52,11 @@ int ull_disable(void *param);
 void ull_drift_ticks_get(struct node_rx_event_done *done,
 			 uint32_t *ticks_drift_plus,
 			 uint32_t *ticks_drift_minus);
+/* Function acquire request lock. The function may be used from ULL,
+ * thread context only.
+ */
+int ull_req_acquire_lock(struct lll_req_ack_lock *state, k_timeout_t timeout);
+/* Function releases request lock. The function may be used from ULL,
+ * thread context only.
+ */
+void ull_req_release_lock(struct lll_req_ack_lock *state);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <sys_clock.h>
 #include <sys/byteorder.h>
 #include <sys/util.h>
 


### PR DESCRIPTION
…to LLL

There is a new functionality, connectionless CTE receive, that may be
enabled or disabled while Radio event is pending. That event update is
requested from ULL (thread context) to LLL (ISR context).
To allow concurent access to request object, synchronization mechanism
was needed.

Provided implementation is based on following assumptions:
- lll_req_ack_lock::req may be updated by single thread in ULL
- lll_req_ack_lock::ack may be updated by ISRs in LLL
- ISRs in LLL have higher priority than thread in ULL

When idle, request object is held in a locked state (REQ_LOCKED).
From LLL perspective the object is unusable, so the functionality
related with the request is disabled. LLL will not wait for the
request object. It just continues to work.

If ULL sends request to LLL then request object is set to released
state (REQ_RELEASED). In such situation LLL will acquire lock
(ACK_LOCKED) for event duration. During the event ULL is not able
to lock the request object.

If ULL wants to lock request object during LLL event (LLL holds
acknowledge lock, ACK_LOCKED), ULL can set lll_req_ack_lock::req to
REQ_LOCK_REQUEST. Then ULL waits for lll_req_ack_lock::wait_sem
to be signaled. When LLL finishes event it verifies if there is
an unlock object requestd by ULL. In such situation LLL will signal
the semaphore.

The implementation is coupled with controller imlementation for single
core SOC:
- ULL expected to run in single thread context, lll_req_ack_lock:req
is not atomic.
- functions that are used by LLL to acquire, release locks does not
contain memory barriers and lll_req_ack_lock::ack is not atomic.
Those functions are expected to run without interruption.
LLL prepare callbacks or ISRs that acquire or release ackgnowledge
lock will not contend for access to single lock object.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>