### PR TITLE
ARC: MWDT: avoid xcheck object linkage as we don't use xcheck

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -112,7 +112,7 @@ macro(toolchain_ld_baremetal)
     -Hnosdata
     -Hnocrt
     -Xtimer0 # to suppress the warning message
-    -Hnoxcheck
+    -Hnoxcheck_obj
     -Hnocplus
     -Hcl
     -Hheap=0


### PR DESCRIPTION
We don't use xcheck (run-time checking for ARC extensions) [we disable it by passing `-Hnoxcheck` to linker] so let's avoid xcheck object linkage as well by passing `-Hnoxcheck_obj` option.

`-Hnoxcheck_obj` option implies the `-Hnoxcheck` option so we replace `-Hnoxcheck` with `-Hnoxcheck_obj`.