### PR TITLE
Bluetooth: host: Overwrite existing bond when IRK has been updated

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3827,6 +3827,18 @@ static uint8_t smp_ident_addr_info(struct bt_smp *smp, struct net_buf *buf)
 		return BT_SMP_ERR_INVALID_PARAMS;
 	}
 
+	if (bt_addr_le_cmp(&conn->le.dst, &req->addr) != 0) {
+		struct bt_keys *keys = bt_keys_find_addr(conn->id, &req->addr);
+
+		if (keys) {
+			if (!update_keys_check(smp, keys)) {
+				return BT_SMP_ERR_UNSPECIFIED;
+			}
+
+			bt_keys_clear(keys);
+		}
+	}
+
 	if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 		const bt_addr_le_t *dst;
 		struct bt_keys *keys;


### PR DESCRIPTION
Overwrite the existing bond when the IRK of the existing bond could not
resolve the RPA of the peer. This would happen if the peer has deleted
the bond and replaced the IRK that was used.