### PR TITLE
Bluetooth: Mesh: Fix restoring fast period divisor from settings

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -957,6 +957,7 @@ static int mod_set_pub(struct bt_mesh_model *mod, size_t len_rd,
 	mod->pub->ttl = pub.ttl;
 	mod->pub->period = pub.period;
 	mod->pub->retransmit = pub.retransmit;
+	mod->pub->period_div = pub.period_div;
 	mod->pub->count = 0U;
 
 	BT_DBG("Restored model publication, dst 0x%04x app_idx 0x%03x",


### PR DESCRIPTION
The Health Fast Period Divisor is stored within
the model publish parameters on the access layer.
The opposite part for divisor restoring has been missed.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>