### PR TITLE
drivers/timer: Kconfig: Use Cortex-M systick if not using stm32 lptim

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -99,6 +99,7 @@ config CORTEX_M_SYSTICK
 	default $(dt_compat_enabled,$(DT_COMPAT_ARM_V6M_SYSTICK)) || \
 		$(dt_compat_enabled,$(DT_COMPAT_ARM_V7M_SYSTICK)) || \
 		$(dt_compat_enabled,$(DT_COMPAT_ARM_V8M_SYSTICK))
+	depends on !STM32_LPTIM_TIMER
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the Cortex-M processor

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -7,10 +7,6 @@
 
 if SOC_FAMILY_STM32
 
-config CORTEX_M_SYSTICK
-	bool
-	depends on !STM32_LPTIM_TIMER
-
 # set the tick per sec as a divider of the LPTIM clock source
 config SYS_CLOCK_TICKS_PER_SEC
 	default 4096 if STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSE


### PR DESCRIPTION
STM32_LPTIM_TIMER is the low power alternive to Cortex-M Systick
for kernel tick source.
Prevent CORTEX_M_SYSTICK to be enabled when STM32_LPTIM_TIMER is
selected.
Since CORTEX_M_SYSTICK is now set based on dts input, any tweaking
to this configuration attempt to do it under soc/ (which would look
cleaner) occurs too late and have no effect.

Fixes: #33342

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>