### PR TITLE
Bluetooth: Mesh: Send Link Close message when closing link

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -125,6 +125,7 @@ static void gen_prov_ack_send(uint8_t xact_id);
 static void link_open(struct prov_rx *rx, struct net_buf_simple *buf);
 static void link_ack(struct prov_rx *rx, struct net_buf_simple *buf);
 static void link_close(struct prov_rx *rx, struct net_buf_simple *buf);
+static void prov_link_close(enum prov_bearer_link_status status);
 
 static void buf_sent(int err, void *user_data)
 {
@@ -276,7 +277,7 @@ static void protocol_timeout(struct k_work *work)
 	BT_DBG("");
 
 	link.rx.seg = 0U;
-	close_link(PROV_BEARER_LINK_STATUS_TIMEOUT);
+	prov_link_close(PROV_BEARER_LINK_STATUS_TIMEOUT);
 }
 /*******************************************************************************
  * Generic provisioning
@@ -592,7 +593,7 @@ static void prov_retransmit(struct k_work *work)
 			close_link(PROV_BEARER_LINK_STATUS_SUCCESS);
 		} else {
 			BT_WARN("Giving up transaction");
-			close_link(PROV_BEARER_LINK_STATUS_TIMEOUT);
+			prov_link_close(PROV_BEARER_LINK_STATUS_FAIL);
 		}
 
 		return;


### PR DESCRIPTION
Instead of silently closing the link we should send a Link Close message
three times before resetting provisioning state.

From Mesh Profile Specification v1.0.1.:
```
5.3.1.4.3 Link Close message

The Link Close message is used to close a link.
```

```
5.3.2 Link Establishment procedure

The device shall start the link timer, set to 60 seconds, when the link
is open. When the link timer expires, then the device shall close the
link.
```

```
5.3.3 Generic Provisioning behavior

If the sender does not receive a Transaction Acknowledgment message
within 30 seconds after sending the first message in a transaction,
the sender shall cancel the transaction, cancel the provisioning
process and close the link.
```

From Mesh Profile Test Specification p6:
```
MESH/PVNR/PBADV/BV-01-C

Test Procedure:
[...]
6. The IUT is induced to send a Link Close message with the Reason field
set to 0x02 to terminate the link. The message is sent at least three
times to ensure the message is received by the Lower Tester.
```

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>