### PR TITLE
scripts: updated gen_handles.py to take Zephyr base as argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,6 +773,7 @@ add_custom_command(
   ${ZEPHYR_BASE}/scripts/gen_handles.py
   --output-source dev_handles.c
   --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+  --zephyr-base ${ZEPHYR_BASE}
   DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
   )
 set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -41,9 +41,6 @@ import elftools.elf.enums
 if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
-
 scr = os.path.basename(sys.argv[0])
 
 def debug(text):
@@ -65,9 +62,23 @@ def parse_args():
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
+
+    parser.add_argument("-z", "--zephyr-base",
+                        help="Path to current Zephyr base. If this argument \
+                        is not provided the environment will be checked for \
+                        the ZEPHYR_BASE environment variable.")
+
     args = parser.parse_args()
     if "VERBOSE" in os.environ:
         args.verbose = 1
+
+    ZEPHYR_BASE = args.zephyr_base or os.getenv("ZEPHYR_BASE")
+
+    if ZEPHYR_BASE is None:
+        sys.exit("-z / --zephyr-base not provided. Please provide "
+                 "--zephyr-base or set ZEPHYR_BASE in environment")
+
+    sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
 
 
 def symbol_data(elf, sym):


### PR DESCRIPTION
This fixes the issue where not having `ZEPHYR_BASE` in the environment fails with following error:
```
[136/141] Generating dev_handles.c
FAILED: zephyr/dev_handles.c 
cd /projects/github/ncs/zephyr/build/zephyr && /usr/bin/python3.8 /projects/github/ncs/zephyr/scripts/gen_handles.py --output-source dev_handles.c --kernel /projects/github/ncs/zephyr/build/zephyr/zephyr_prebuilt.elf
Traceback (most recent call last):
  File "/projects/github/ncs/zephyr/scripts/gen_handles.py", line 45, in <module>
    sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
  File "/usr/lib/python3.8/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
[137/141] Generating isr_tables.c, isrList.bin
ninja: build stopped: subcommand failed.
```

----------

The script gen_handles.py was introduce in #32127 but relies on
ZEPHYR_BASE being set in environment.

However, it is not a requirement to set Zephyr base in the users
environment, therefore this is changed to an argument `-z` or
`--zephyr-base` which will be passed from the build system to the
script.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>