### PR TITLE
kernel: smp: remove unused internal API z_smp_reacquire_global_lock()

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -25,7 +25,6 @@ extern struct k_spinlock sched_spinlock;
  * to restore the lock state to whatever the thread's counter
  * expects.
  */
-void z_smp_reacquire_global_lock(struct k_thread *thread);
 void z_smp_release_global_lock(struct k_thread *thread);
 
 /* context switching and scheduling-related routines */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -41,17 +41,6 @@ void z_smp_global_unlock(unsigned int key)
 	arch_irq_unlock(key);
 }
 
-void z_smp_reacquire_global_lock(struct k_thread *thread)
-{
-	if (thread->base.global_lock_count) {
-		arch_irq_lock();
-
-		while (!atomic_cas(&global_lock, 0, 1)) {
-		}
-	}
-}
-
-
 /* Called from within z_swap(), so assumes lock already held */
 void z_smp_release_global_lock(struct k_thread *thread)
 {


### PR DESCRIPTION
The internal function z_smp_reacquire_global_lock() has not used by
anywhere inside zephyr code, the context switch code logic did use it anymore also,  so remove it.

Fixes #33273.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>