### PR TITLE
dts: arm: st: h7: Add the UART9 nodes to STM32H7xx SoC

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -248,6 +248,15 @@
 			status = "disabled";
 			label = "UART_8";
 		};
+		uart9: serial@40011800 {
+            compatible = "st,stm32-uart";
+            reg = <0x40011800 0x400>;
+            clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000040>;
+            interrupts = <155 0>;
+            current-speed = <115200>;
+            status = "disabled";
+			label = "UART_9";
+        };
 
 		lpuart1: serial@58000c00 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";


### PR DESCRIPTION
Add the available UART9 nodes to STM32H7xx Series Soc dtsi

Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>
