### PR TITLE
device: Remove unnecessary z_impl_device_is_ready()

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -638,11 +638,6 @@ static inline bool device_is_ready(const struct device *dev)
 	return device_usable_check(dev) == 0;
 }
 
-static inline bool z_impl_device_is_ready(const struct device *dev)
-{
-	return z_device_ready(dev);
-}
-
 /**
  * @}
  */


### PR DESCRIPTION
This is a follow up to commit 2aab687270a9c094591568cc1a6d5d4d436ccd7c.

Since device_is_ready() is no longer a system call, there is no need
to keep z_impl_device_is_ready().

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>