### PR TITLE
soc: arm: microchip: Add save and restore for additional blocks (option power optimization)

### DIFF
--- a/soc/arm/microchip_mec/mec1501/device_power.c
+++ b/soc/arm/microchip_mec/mec1501/device_power.c
@@ -10,28 +10,7 @@
 #include <sys/__assert.h>
 #include <power/power.h>
 #include <soc.h>
-
-/*
- * CPU will spin up to DEEP_SLEEP_WAIT_SPIN_CLK_REQ times
- * waiting for PCR CLK_REQ bits to clear except for the
- * CPU bit itself. This is not necessary as the sleep hardware
- * will wait for all CLK_REQ to clear once WFI has executed.
- * Once all CLK_REQ signals are clear the hardware will transition
- * to the low power state.
- */
-/* #define DEEP_SLEEP_WAIT_ON_CLK_REQ_ENABLE */
-#define DEEP_SLEEP_WAIT_SPIN_CLK_REQ		1000
-
-
-/*
- * Some peripherals if enabled always assert their CLK_REQ bits.
- * For example, any peripheral with a clock generator such as
- * timers, counters, UART, etc. We save the enables for these
- * peripherals, disable them, and restore the enabled state upon
- * wake.
- */
-#define DEEP_SLEEP_PERIPH_SAVE_RESTORE
-
+#include "device_power.h"
 
 /*
  * Light sleep: PLL remains on. Fastest wake latency.
@@ -64,15 +43,23 @@ void soc_deep_sleep_wait_clk_idle(void)
 #ifdef DEEP_SLEEP_WAIT_ON_CLK_REQ_ENABLE
 	uint32_t clkreq, cnt;
 
-	cnt = DEEP_SLEEP_WAIT_CLK_REQ;
+	cnt = DEEP_SLEEP_WAIT_SPIN_CLK_REQ;
 	do {
 		clkreq = PCR_REGS->CLK_REQ0 | PCR_REGS->CLK_REQ1
 			 | PCR_REGS->CLK_REQ2 | PCR_REGS->CLK_REQ3
 			 | PCR_REGS->CLK_REQ4;
 	} while ((clkreq != (1ul << MCHP_PCR1_CPU_POS)) && (cnt-- != 0));
 #endif
-}
 
+#ifdef DEEP_SLEEP_CLK_REQ_DUMP
+	/* Save status to debug LPM been blocked */
+	VBATM_REGS->MEM.u32[0] = PCR_REGS->CLK_REQ0;
+	VBATM_REGS->MEM.u32[1] = PCR_REGS->CLK_REQ1;
+	VBATM_REGS->MEM.u32[2] = PCR_REGS->CLK_REQ2;
+	VBATM_REGS->MEM.u32[3] = PCR_REGS->CLK_REQ3;
+	VBATM_REGS->MEM.u32[4] = PCR_REGS->CLK_REQ4;
+#endif
+}
 
 /*
  * Allow peripherals connected to external masters to wake the PLL but not
@@ -102,19 +89,6 @@ void soc_deep_sleep_non_wake_dis(void)
 /* Variables used to save various HW state */
 #ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE
 
-static uint32_t ecs[1];
-
-static void deep_sleep_save_ecs(void)
-{
-	ecs[0] = ECS_REGS->ETM_CTRL;
-	ECS_REGS->ETM_CTRL = 0;
-}
-
-struct ds_timer_info {
-	uintptr_t addr;
-	uint32_t restore_mask;
-};
-
 const struct ds_timer_info ds_timer_tbl[] = {
 	{
 		(uintptr_t)&B16TMR0_REGS->CTRL, 0
@@ -133,33 +107,42 @@ const struct ds_timer_info ds_timer_tbl[] = {
 		(MCHP_CCT_CTRL_COMP1_SET | MCHP_CCT_CTRL_COMP0_SET),
 	},
 };
-#define NUM_DS_TIMER_ENTRIES \
-	(sizeof(ds_timer_tbl) / sizeof(struct ds_timer_info))
 
+static struct ds_dev_info ds_ctx;
 
-static uint32_t timers[NUM_DS_TIMER_ENTRIES];
-static uint8_t uart_activate[3];
+static void deep_sleep_save_ecs(void)
+{
+	ds_ctx.ecs[0] = ECS_REGS->ETM_CTRL;
+	ds_ctx.ecs[1] = ECS_REGS->DEBUG_CTRL;
+#ifdef DEEP_SLEEP_JTAG
+	ECS_REGS->ETM_CTRL = 0;
+	ECS_REGS->DEBUG_CTRL = 0x00;
+#endif
+}
 
 static void deep_sleep_save_uarts(void)
 {
-	uart_activate[0] = UART0_REGS->ACTV;
-	if (uart_activate[0]) {
+	ds_ctx.uart_info[0] = UART0_REGS->ACTV;
+	if (ds_ctx.uart_info[0]) {
 		while ((UART0_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
 		}
 	}
 	UART0_REGS->ACTV = 0;
-	uart_activate[1] = UART1_REGS->ACTV;
-	if (uart_activate[1]) {
+	ds_ctx.uart_info[1] = UART1_REGS->ACTV;
+	if (ds_ctx.uart_info[1]) {
 		while ((UART1_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
 		}
 	}
 	UART1_REGS->ACTV = 0;
-	uart_activate[2] = UART2_REGS->ACTV;
-	if (uart_activate[2]) {
+	ds_ctx.uart_info[2] = UART2_REGS->ACTV;
+	if (ds_ctx.uart_info[2]) {
 		while ((UART2_REGS->LSR & MCHP_UART_LSR_TEMT) == 0) {
 		}
 	}
+
 	UART2_REGS->ACTV = 0;
+	UART1_REGS->ACTV = 0;
+	UART0_REGS->ACTV = 0;
 }
 
 static void deep_sleep_save_timers(void)
@@ -169,7 +152,7 @@ static void deep_sleep_save_timers(void)
 
 	p = &ds_timer_tbl[0];
 	for (i = 0; i < NUM_DS_TIMER_ENTRIES; i++) {
-		timers[i] = REG32(p->addr);
+		ds_ctx.timers[i] = REG32(p->addr);
 		REG32(p->addr) = 0;
 		p++;
 	}
@@ -177,14 +160,28 @@ static void deep_sleep_save_timers(void)
 
 static void deep_sleep_restore_ecs(void)
 {
-	ECS_REGS->ETM_CTRL = ecs[0];
+#ifdef DEEP_SLEEP_JTAG
+	ECS_REGS->ETM_CTRL = ds_ctx.ecs[0];
+	ECS_REGS->DEBUG_CTRL = ds_ctx.ecs[1];
+#endif
 }
 
 static void deep_sleep_restore_uarts(void)
 {
-	UART0_REGS->ACTV = uart_activate[0];
-	UART1_REGS->ACTV = uart_activate[1];
-	UART2_REGS->ACTV = uart_activate[2];
+	UART0_REGS->ACTV = ds_ctx.uart_info[0];
+	if (ds_ctx.uart_info[0]) {
+		mchp_pcr_periph_slp_ctrl(PCR_UART0, MCHP_PCR_SLEEP_DIS);
+	}
+
+	UART1_REGS->ACTV = ds_ctx.uart_info[1];
+	if (ds_ctx.uart_info[1]) {
+		mchp_pcr_periph_slp_ctrl(PCR_UART1, MCHP_PCR_SLEEP_DIS);
+	}
+
+	UART2_REGS->ACTV = ds_ctx.uart_info[2];
+	if (ds_ctx.uart_info[2]) {
+		mchp_pcr_periph_slp_ctrl(PCR_UART2, MCHP_PCR_SLEEP_DIS);
+	}
 }
 
 static void deep_sleep_restore_timers(void)
@@ -194,16 +191,118 @@ static void deep_sleep_restore_timers(void)
 
 	p = &ds_timer_tbl[0];
 	for (i = 0; i < NUM_DS_TIMER_ENTRIES; i++) {
-		REG32(p->addr) = timers[i] & ~p->restore_mask;
+		REG32(p->addr) = ds_ctx.timers[i] & ~p->restore_mask;
 		p++;
 	}
 }
 
+#ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
+
+static void deep_sleep_save_blocks(void)
+{
+	/* ADC Power saving feature is enabled */
+	ds_ctx.adc_info.adc_ctrl = ADC_REGS->CONTROL;
+	ds_ctx.adc_info.adc_cfg = ADC_REGS->CONFIG;
+	ADC_REGS->CONTROL = 0;
+	ADC_REGS->CONFIG = 0;
+
+	ds_ctx.peci_info.peci_ctrl = PECI_REGS->CONTROL;
+	ds_ctx.peci_info.peci_dis = ECS_REGS->PECI_DIS;
+	PECI_REGS->CONTROL = 0x08;
+	PECI_REGS->CONTROL = 0x09;
+	ECS_REGS->PECI_DIS = 0x01;
+
+	/* SMBUS */
+	ds_ctx.smb_info[0] = SMB0_REGS->CTRLSTS;
+	ds_ctx.smb_info[1] = SMB1_REGS->CTRLSTS;
+	ds_ctx.smb_info[2] = SMB2_REGS->CTRLSTS;
+	ds_ctx.smb_info[3] = SMB3_REGS->CTRLSTS;
+	ds_ctx.smb_info[4] = SMB4_REGS->CTRLSTS;
+
+	mchp_pcr_periph_slp_ctrl(PCR_SMB1, MCHP_PCR_SLEEP_EN);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB2, MCHP_PCR_SLEEP_EN);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB2, MCHP_PCR_SLEEP_EN);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB3, MCHP_PCR_SLEEP_EN);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB4, MCHP_PCR_SLEEP_EN);
+
+	mchp_pcr_periph_slp_ctrl(PCR_ESPI, MCHP_PCR_SLEEP_EN);
+
+	/* Comparators */
+	ds_ctx.comp_info = ECS_REGS->CMP_SLP_CTRL;
+	ECS_REGS->CMP_SLP_CTRL = 0;
+
+	/* Disable VCI_INPUT_ENABLE */
+	ds_ctx.vci_info = VCI_REGS->INPUT_EN;
+	VCI_REGS->INPUT_EN = 0;
+
+	/* Disable WEEK TIMER */
+	ds_ctx.wktmr_info = WKTMR_REGS->BGPO_PWR;
+	WKTMR_REGS->BGPO_PWR = 0;
+
+	/* Set SLOW_CLOCK_DIVIDE = CLKOFF */
+	ds_ctx.slwclk_info = PCR_REGS->SLOW_CLK_CTRL;
+	PCR_REGS->SLOW_CLK_CTRL &= (~MCHP_PCR_SLOW_CLK_CTRL_100KHZ & MCHP_PCR_SLOW_CLK_CTRL_MASK);
+
+	ds_ctx.tfdp_info = TFDP_REGS->CTRL;
+	TFDP_REGS->CTRL = 0;
+
+	/* Port 80 */
+	ds_ctx.port80_info[0] = PORT80_CAP0_REGS->ACTV;
+	ds_ctx.port80_info[1] = PORT80_CAP1_REGS->ACTV;
+	PORT80_CAP0_REGS->ACTV = 0;
+	PORT80_CAP1_REGS->ACTV = 0;
+}
+
+static void deep_sleep_restore_blocks(void)
+{
+	ADC_REGS->CONTROL = ds_ctx.adc_info.adc_ctrl;
+	ADC_REGS->CONFIG = ds_ctx.adc_info.adc_cfg;
+
+	ECS_REGS->PECI_DIS = ds_ctx.peci_info.peci_dis;
+	PECI_REGS->CONTROL = MCHP_PECI_CTRL_PD;
+	PECI_REGS->CONTROL = ds_ctx.peci_info.peci_ctrl;
+	PECI_REGS->CONTROL &= ~MCHP_PECI_CTRL_PD;
+
+	SMB0_REGS->CTRLSTS = ds_ctx.smb_info[0];
+	SMB1_REGS->CTRLSTS = ds_ctx.smb_info[1];
+	SMB2_REGS->CTRLSTS = ds_ctx.smb_info[2];
+	SMB3_REGS->CTRLSTS = ds_ctx.smb_info[3];
+	SMB4_REGS->CTRLSTS = ds_ctx.smb_info[4];
+
+	mchp_pcr_periph_slp_ctrl(PCR_SMB1, MCHP_PCR_SLEEP_DIS);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB2, MCHP_PCR_SLEEP_DIS);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB2, MCHP_PCR_SLEEP_DIS);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB3, MCHP_PCR_SLEEP_DIS);
+	mchp_pcr_periph_slp_ctrl(PCR_SMB4, MCHP_PCR_SLEEP_DIS);
+
+	mchp_pcr_periph_slp_ctrl(PCR_ESPI, MCHP_PCR_SLEEP_DIS);
+
+	/* Comparators */
+	ECS_REGS->CMP_SLP_CTRL = ds_ctx.comp_info;
+
+	/* Disable VCI_INPUT_ENABLE */
+	VCI_REGS->INPUT_EN = ds_ctx.vci_info;
+
+	/* Disable WEEK TIMER */
+	WKTMR_REGS->BGPO_PWR = ds_ctx.wktmr_info;
+
+	PCR_REGS->SLOW_CLK_CTRL = ds_ctx.slwclk_info;
+	TFDP_REGS->CTRL = ds_ctx.tfdp_info;
+
+	/* Port 80 */
+	PORT80_CAP0_REGS->ACTV = ds_ctx.port80_info[0];
+	PORT80_CAP1_REGS->ACTV = ds_ctx.port80_info[1];
+}
+#endif /* DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED */
+
 void soc_deep_sleep_periph_save(void)
 {
-	deep_sleep_save_uarts();
+#ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
+	deep_sleep_save_blocks();
+#endif
 	deep_sleep_save_ecs();
 	deep_sleep_save_timers();
+	deep_sleep_save_uarts();
 }
 
 void soc_deep_sleep_periph_restore(void)
@@ -211,6 +310,9 @@ void soc_deep_sleep_periph_restore(void)
 	deep_sleep_restore_ecs();
 	deep_sleep_restore_uarts();
 	deep_sleep_restore_timers();
+#ifdef DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
+	deep_sleep_restore_blocks();
+#endif
 }
 
 #else

--- a/soc/arm/microchip_mec/mec1501/device_power.h
+++ b/soc/arm/microchip_mec/mec1501/device_power.h
@@ -9,6 +9,84 @@
 
 #ifndef _ASMLANGUAGE
 
+/* Enable SoC control over peripherals only when drivers do not support
+ * power management
+ */
+#ifndef CONFIG_DEVICE_POWER_MANAGEMENT
+
+/* Comment out to use JTAG without interruptions.
+ * Beware this blocks PLL going off, hence should be enabled
+ * for power consumption measurements
+ * Note: To attach JTAG for any debug need to be performed with breakpoint
+ * prior to deep sleep entry.
+ */
+#define DEEP_SLEEP_JTAG
+
+/*
+ * CPU will spin up to DEEP_SLEEP_WAIT_SPIN_CLK_REQ times
+ * waiting for PCR CLK_REQ bits to clear except for the
+ * CPU bit itself. This is not necessary as the sleep hardware
+ * will wait for all CLK_REQ to clear once WFI has executed.
+ * Once all CLK_REQ signals are clear the hardware will transition
+ * to the low power state.
+ */
+
+/* #define DEEP_SLEEP_WAIT_ON_CLK_REQ_ENABLE */
+
+/* #define DEEP_SLEEP_CLK_REQ_DUMP */
+
+#define DEEP_SLEEP_WAIT_SPIN_CLK_REQ		1000
+
+/*
+ * Some peripherals if enabled always assert their CLK_REQ bits.
+ * For example, any peripheral with a clock generator such as
+ * timers, counters, UART, etc. We save the enables for these
+ * peripherals, disable them, and restore the enabled state upon
+ * wake.
+ */
+#define DEEP_SLEEP_PERIPH_SAVE_RESTORE
+
+/* Power optimization if certain HW blocks are not used.
+ * These are not part of any Zephyr subsystem.
+ *  #define DEEP_SLEEP_PERIPH_SAVE_RESTORE_EXTENDED
+ */
+
+#define NUM_DS_TIMER_ENTRIES 4
+
+struct ds_timer_info {
+	uintptr_t addr;
+	uint32_t restore_mask;
+};
+
+struct ds_adc_info {
+	uint32_t adc_ctrl;
+	uint32_t adc_cfg;
+};
+
+struct ds_peci_info {
+	uint32_t peci_ctrl;
+	uint32_t peci_dis;
+};
+
+struct ds_dev_info {
+	uint32_t ecs[2];
+	uint32_t timers[NUM_DS_TIMER_ENTRIES];
+	uint8_t uart_info[3];
+	/* Analog power */
+	struct ds_adc_info adc_info;
+	struct ds_peci_info peci_info;
+	uint32_t smb_info[5];
+	/* HW blocks not always used */
+	uint32_t vci_info;
+	uint32_t tfdp_info;
+	uint32_t comp_info;
+	uint32_t wktmr_info;
+	uint32_t slwclk_info;
+	uint32_t port80_info[2];
+};
+
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+
 void soc_lite_sleep_enable(void);
 
 void soc_deep_sleep_enable(void);


### PR DESCRIPTION
Extend save and restore for additional peripherals if device driver power management is not supported.

Change introduces a macro disabled by default that allows to evaluate power consumption to prioritize optimizations are required for each SoC HW block
