### PR TITLE
scripts: west_commands: dediprog

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/support/spi_cfg.txt
+++ b/boards/arm/mec15xxevb_assy6853/support/spi_cfg.txt
@@ -1,5 +1,5 @@
 [SPI]
-SPISizeMegabits = 128
+SPISizeMegabits = 4
 Flashmap = true
 FlshmapAddr = 0
 

--- a/scripts/west_commands/runners/dediprog.py
+++ b/scripts/west_commands/runners/dediprog.py
@@ -54,6 +54,10 @@ class DediProgBinaryRunner(ZephyrBinaryRunner):
             cmd_flash.append('--vcc')
             cmd_flash.append(self.vcc)
 
+        # Allow to flash images smaller than flash device capacity
+        cmd_flash.append('-x')
+        cmd_flash.append('ff')
+
         cmd_flash.append('--silent')
         cmd_flash.append('--verify')
 

--- a/scripts/west_commands/tests/test_dediprog.py
+++ b/scripts/west_commands/tests/test_dediprog.py
@@ -18,16 +18,20 @@ EXPECTED_COMMAND = {
     (RC_KERNEL_BIN, None):
     [DPCMD_EXE,
      '--auto', RC_KERNEL_BIN,
+     '-x', 'ff',
      '--silent', '--verify'],
+
 
     (RC_KERNEL_BIN, '0'):
     [DPCMD_EXE,
      '--auto', RC_KERNEL_BIN, '--vcc', '0',
+     '-x', 'ff',
      '--silent', '--verify'],
 
     (RC_KERNEL_BIN, '1'):
     [DPCMD_EXE,
      '--auto', RC_KERNEL_BIN, '--vcc', '1',
+     '-x', 'ff',
      '--silent', '--verify'],
 }
 


### PR DESCRIPTION
Use fill option to be able to flash file images small than flash device capacity with dediprog

Reduce SPI size image for mec15xxevb to speed up flashing process