### PR TITLE
Raise exception if cmake is not found in path

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2061,6 +2061,10 @@ class CMake():
 
         logger.debug("Calling cmake with arguments: {}".format(cmake_args))
         cmake = shutil.which('cmake')
+        if not cmake:
+            msg = "Unable to find `cmake` in path"
+            logger.error(msg)
+            raise Exception(msg)
         cmd = [cmake] + cmake_args
 
         kwargs = dict()


### PR DESCRIPTION
Otherwise the real failure is swallowed and a TypeError exception is raised instead.

### Before patch

This is what a user without cmake installed sees when they are trying to run tests:
```
proxima@DESKTOP-SL4KPAL:~/zephyrproject/zephyr$ ~/zephyr/venv/bin/python ~/zephyrproject/zephyr/scripts/twister -T samples/subsys/testsuite/
ZEPHYR_BASE unset, using "/home/proxima/zephyrproject/zephyr"
Renaming output directory to /home/proxima/zephyrproject/zephyr/twister-out.13
INFO    - Zephyr version: zephyr-v2.5.0-1120-g7874052df220
INFO    - JOBS: 6
Traceback (most recent call last):
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1283, in <module>
    main()
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1047, in main
    discards = suite.apply_filters(
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2995, in apply_filters
    toolchain = self.get_toolchain()
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2864, in get_toolchain
    result = CMake.run_cmake_script([toolchain_script, "FORMAT=json"])
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2075, in run_cmake_script
    p = subprocess.Popen(cmd, **kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1583, in _execute_child
    and os.path.dirname(executable)
  File "/usr/lib/python3.8/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

### Before patch with logs

Same situation but now with verbose logging and a `print(cmd)` before `subprocess.Popen`. 
Note the `None` returned from `shutil.which("cmake")`:

```
proxima@DESKTOP-SL4KPAL:~/zephyrproject/zephyr$ ~/zephyr/venv/bin/python ~/zephyrproject/zephyr/scripts/twister -T samples/subsys/testsuite/ -vv
ZEPHYR_BASE unset, using "/home/proxima/zephyrproject/zephyr"
Renaming output directory to /home/proxima/zephyrproject/zephyr/twister-out.11
INFO    - Zephyr version: zephyr-v2.5.0-1120-g7874052df220
INFO    - JOBS: 6
DEBUG   - Reading test case configuration files under /home/proxima/zephyrproject/zephyr/samples/subsys/testsuite...
DEBUG   - Found possible test case in /home/proxima/zephyrproject/zephyr/samples/subsys/testsuite/integration
DEBUG   - Reading platform configuration files under /home/proxima/zephyrproject/zephyr/boards...
DEBUG   - Reading platform configuration files under /home/proxima/zephyrproject/zephyr/scripts/pylib/twister/boards...
DEBUG   - Running cmake script /home/proxima/zephyrproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Calling cmake with arguments: ['-DFORMAT=json', '-P', PosixPath('/home/proxima/zephyrproject/zephyr/cmake/verify-toolchain.cmake')]
cmd: [None, '-DFORMAT=json', '-P', PosixPath('/home/proxima/zephyrproject/zephyr/cmake/verify-toolchain.cmake')]
Traceback (most recent call last):
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1283, in <module>
    main()
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1047, in main
    discards = suite.apply_filters(
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2996, in apply_filters
    toolchain = self.get_toolchain()
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2865, in get_toolchain
    result = CMake.run_cmake_script([toolchain_script, "FORMAT=json"])
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2076, in run_cmake_script
    p = subprocess.Popen(cmd, **kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1583, in _execute_child
    and os.path.dirname(executable)
  File "/usr/lib/python3.8/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

### After patch 

Now it's much more clear why it failed.

```
proxima@DESKTOP-SL4KPAL:~/zephyrproject/zephyr$ ~/zephyr/venv/bin/python ~/zephyrproject/zephyr/scripts/twister -T samples/subsys/testsuite/
ZEPHYR_BASE unset, using "/home/proxima/zephyrproject/zephyr"
Renaming output directory to /home/proxima/zephyrproject/zephyr/twister-out.12
INFO    - Zephyr version: zephyr-v2.5.0-1120-g7874052df220
INFO    - JOBS: 6
ERROR   - Unable to find `cmake` in path
Traceback (most recent call last):
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1283, in <module>
    main()
  File "/home/proxima/zephyrproject/zephyr/scripts/twister", line 1047, in main
    discards = suite.apply_filters(
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2996, in apply_filters
    toolchain = self.get_toolchain()
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2865, in get_toolchain
    result = CMake.run_cmake_script([toolchain_script, "FORMAT=json"])
  File "/home/proxima/zephyrproject/zephyr/scripts/pylib/twister/twisterlib.py", line 2067, in run_cmake_script
    raise Exception(msg)
Exception: Unable to find `cmake` in path
```