### PR TITLE
openthread: platform UART fix

### DIFF
--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -111,7 +111,8 @@ static void uart_callback(const struct device *dev, void *user_data)
 			uart_rx_handle(dev);
 		}
 
-		if (uart_irq_tx_ready(dev)) {
+		if (uart_irq_tx_ready(dev) &&
+		    atomic_get(&ot_uart.tx_busy) == 1) {
 			uart_tx_handle(dev);
 		}
 	}
@@ -143,7 +144,7 @@ void platformUartProcess(otInstance *aInstance)
 		otPlatUartSendDone();
 		ot_uart.tx_finished = 0;
 	}
-};
+}
 
 otError otPlatUartEnable(void)
 {
@@ -161,7 +162,7 @@ otError otPlatUartEnable(void)
 	uart_irq_rx_enable(ot_uart.dev);
 
 	return OT_ERROR_NONE;
-};
+}
 
 otError otPlatUartDisable(void)
 {
@@ -176,8 +177,7 @@ otError otPlatUartDisable(void)
 	uart_irq_tx_disable(ot_uart.dev);
 	uart_irq_rx_disable(ot_uart.dev);
 	return OT_ERROR_NONE;
-};
-
+}
 
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
@@ -200,7 +200,7 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 	}
 
 	return OT_ERROR_NONE;
-};
+}
 
 otError otPlatUartFlush(void)
 {

--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -185,10 +185,10 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 		return OT_ERROR_FAILED;
 	}
 
-	write_buffer = aBuf;
-	write_length = aBufLength;
+	if (atomic_cas(&(ot_uart.tx_busy), 0, 1)) {
+		write_buffer = aBuf;
+		write_length = aBufLength;
 
-	if (atomic_set(&(ot_uart.tx_busy), 1) == 0) {
 		if (is_panic_mode) {
 			/* In panic mode all data have to be send immediately
 			 * without using interrupts
@@ -197,9 +197,10 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 		} else {
 			uart_irq_tx_enable(ot_uart.dev);
 		}
+		return OT_ERROR_NONE;
 	}
 
-	return OT_ERROR_NONE;
+	return OT_ERROR_BUSY;
 }
 
 otError otPlatUartFlush(void)


### PR DESCRIPTION
This PR addresses two problems:
1. The transmission buffer may have been overwritten by calling otPlatUartSend when the transmission had not been finished - now when the transmission is in progress the function: otPlatUartSend returns OT_ERROR_BUSY.
2. The UART tx callback has been processed even if it was not triggered by otPlatUartSend - now there is an additional condition checking if the flag for transmission has been marked by otPlatUartSend