### PR TITLE
tests: Bluetooth: Fix compilation issue in direction finding test

### DIFF
--- a/tests/bluetooth/df/src/radio_df_stub.c
+++ b/tests/bluetooth/df/src/radio_df_stub.c
@@ -65,3 +65,13 @@ void radio_df_mode_set_aod(void)
 {
 
 }
+
+void radio_df_ant_switching_gpios_cfg(void)
+{
+
+}
+
+void radio_df_ant_switching_pin_sel_cfg(void)
+{
+
+}


### PR DESCRIPTION
Fix compilation issue in direction finding tests, undefined references
to radio_df_ant_switching_gpios_cfg and
radio_df_ant_switching_pin_sel_cfg

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>