### PR TITLE
boards: nrf9160dk: Switch to sda-gpios, scl-gpios DT properties

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
@@ -24,8 +24,8 @@
 &i2c2 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-pin = <30>;
-	scl-pin = <31>;
+	sda-gpios = <&gpio0 30 0>;
+	scl-gpios = <&gpio0 31 0>;
 
 	pcal6408a: pcal6408a@20 {
 		compatible = "nxp,pcal6408a";


### PR DESCRIPTION
This is a follow-up to commit 763e73d7daf24d33444c6becfd7a09d21712fbfb.

Switch to the new properties for specifying SDA and SCL pins,
as the old ones (sda-pin and scl-pin) are now deprecated.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>