### PR TITLE
Bluetooth: Mesh: Add Proxy callback structure

### DIFF
--- a/include/bluetooth/mesh/proxy.h
+++ b/include/bluetooth/mesh/proxy.h
@@ -21,6 +21,38 @@
 extern "C" {
 #endif
 
+/** Callbacks for the Proxy feature.
+ *
+ *  Should be instantiated with @ref BT_MESH_PROXY_CB_DEFINE.
+ */
+struct bt_mesh_proxy_cb {
+	/** @brief Started sending Node Identity beacons on the given subnet.
+	 *
+	 *  @param net_idx Network index the Node Identity beacons are running
+	 *                 on.
+	 */
+	void (*identity_enabled)(uint16_t net_idx);
+	/** @brief Stopped sending Node Identity beacons on the given subnet.
+	 *
+	 *  @param net_idx Network index the Node Identity beacons were running
+	 *                 on.
+	 */
+	void (*identity_disabled)(uint16_t net_idx);
+};
+
+/** @def BT_MESH_PROXY_CB_DEFINE
+ *
+ *  @brief Register a callback structure for Proxy events.
+ *
+ *  Registers a structure with callback functions that gets called on various
+ *  Proxy events.
+ *
+ *  @param _name Name of callback structure.
+ */
+#define BT_MESH_PROXY_CB_DEFINE(_name)                                         \
+	static const Z_STRUCT_SECTION_ITERABLE(                                \
+		bt_mesh_proxy_cb, _CONCAT(bt_mesh_proxy_cb, _name))
+
 /** @brief Enable advertising with Node Identity.
  *
  *  This API requires that GATT Proxy support has been enabled. Once called

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -117,6 +117,10 @@
 	Z_ITERABLE_SECTION_ROM(bt_mesh_lpn_cb, 4)
 #endif
 
+#if defined(CONFIG_BT_MESH_PROXY)
+	Z_ITERABLE_SECTION_ROM(bt_mesh_proxy_cb, 4)
+#endif
+
 #if defined(CONFIG_EC_HOST_CMD)
 	Z_ITERABLE_SECTION_ROM(ec_host_cmd_handler, 4)
 #endif

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -379,6 +379,12 @@ static void node_id_start(struct bt_mesh_subnet *sub)
 {
 	sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
 	sub->node_id_start = k_uptime_get_32();
+
+	Z_STRUCT_SECTION_FOREACH(bt_mesh_proxy_cb, cb) {
+		if (cb->identity_enabled) {
+			cb->identity_enabled(sub->net_idx);
+		}
+	}
 }
 
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub)
@@ -393,6 +399,12 @@ void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub)
 {
 	sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
 	sub->node_id_start = 0U;
+
+	Z_STRUCT_SECTION_FOREACH(bt_mesh_proxy_cb, cb) {
+		if (cb->identity_disabled) {
+			cb->identity_disabled(sub->net_idx);
+		}
+	}
 }
 
 int bt_mesh_proxy_identity_enable(void)


### PR DESCRIPTION
Adds a Proxy callback structure with a callback for Node ID end. This
API follows the Friend and LPN API in mesh/main.h, and can be expanded
with more callbacks later.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>