### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: add missing include directory for unit-tests

### DIFF
--- a/tests/bluetooth/controller/common/defaults_cmake.txt
+++ b/tests/bluetooth/controller/common/defaults_cmake.txt
@@ -11,6 +11,7 @@ include_directories(
         ${ZEPHYR_BASE}/subsys/bluetooth/controller/util
         ${ZEPHYR_BASE}/subsys/bluetooth/controller/include
         ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+        ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
         ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic/lll
 )
 


### PR DESCRIPTION
An include directory needs to be added for unit-tests to pass

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>