### PR TITLE
tests: net: socket: af_packet: fix resource leak

### DIFF
--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -269,6 +269,8 @@ static void test_raw_packet_sockets(void)
 			  sizeof(data_to_send),
 			  "Sent and received buffers do not match");
 
+	close(sock1);
+	close(sock2);
 	close(sock3);
 	close(sock4);
 }
@@ -278,6 +280,9 @@ static void test_packet_sockets(void)
 	int sock1, sock2;
 
 	__test_packet_sockets(&sock1, &sock2);
+
+	close(sock1);
+	close(sock2);
 }
 
 static void test_packet_sockets_dgram(void)
@@ -360,6 +365,9 @@ static void test_packet_sockets_dgram(void)
 
 	zassert_equal(ret, sizeof(data_to_send), "Cannot receive all data (%d)",
 		      -errno);
+
+	close(sock1);
+	close(sock2);
 }
 
 void test_main(void)


### PR DESCRIPTION
Previously this fix failed and had to be reverted: https://github.com/zephyrproject-rtos/zephyr/pull/33304 -- the recently merged PR https://github.com/zephyrproject-rtos/zephyr/pull/33338 should fix the issue and allow this PR to work.