### PR TITLE
net: sockets: Provide close method for packet sockets

### DIFF
--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -12,6 +12,8 @@
 #define SOCK_EOF 1
 #define SOCK_NONBLOCK 2
 
+int zsock_close_ctx(struct net_context *ctx);
+
 static inline void sock_set_flag(struct net_context *ctx, uintptr_t mask,
 				 uintptr_t flag)
 {

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -360,10 +360,16 @@ static int packet_sock_setsockopt_vmeth(void *obj, int level, int optname,
 	return zpacket_setsockopt_ctx(obj, level, optname, optval, optlen);
 }
 
+static int packet_sock_close_vmeth(void *obj)
+{
+	return zsock_close_ctx(obj);
+}
+
 static const struct socket_op_vtable packet_sock_fd_op_vtable = {
 	.fd_vtable = {
 		.read = packet_sock_read_vmeth,
 		.write = packet_sock_write_vmeth,
+		.close = packet_sock_close_vmeth,
 		.ioctl = packet_sock_ioctl_vmeth,
 	},
 	.bind = packet_sock_bind_vmeth,


### PR DESCRIPTION
There was no close callback for AF_PACKET type sockets. This
meant that calling close() on packet socket caused a NULL
pointer access.

This will allow #32949 issue to work properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>