### PR TITLE
Bluetooth: controller: Fix control procedure transaction violation checks

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -901,6 +901,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
 		conn->common.fex_valid = 0;
+		conn->common.txn_lock = 0;
 		conn->slave.latency_cancel = 0;
 
 		conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4545,11 +4545,12 @@ static int reject_ext_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 {
 	struct pdu_data *pdu_ctrl_tx;
 	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu_ctrl_tx = (void *)tx->pdu;
@@ -5453,6 +5454,12 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
 		if (pdu_tx->llctrl.reject_ext_ind.reject_opcode !=
 		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
+			/* Reset the transaction lock set by connection
+			 * parameter request and PHY update procedure when
+			 * sending the Reject Ext Ind PDU.
+			 */
+			conn->common.txn_lock = 0U;
+
 			break;
 		}
 		__fallthrough;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5148,13 +5148,14 @@ send_length_resp:
 #if defined(CONFIG_BT_CTLR_LE_PING)
 static int ping_resp_send(struct ll_conn *conn, struct node_rx_pdu *rx)
 {
-	struct node_tx *tx;
 	struct pdu_data *pdu_tx;
+	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu_tx = (void *)tx->pdu;
@@ -5385,6 +5386,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	break;
 
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+	case PDU_DATA_LLCTRL_TYPE_PING_RSP:
 	case PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP:
 		/* Reset the transaction lock */
 		conn->common.txn_lock = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5180,11 +5180,12 @@ static int phy_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	struct pdu_data_llctrl_phy_req *p;
 	struct pdu_data *pdu_ctrl_tx;
 	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	/* Wait for peer master to complete the procedure */
@@ -5560,9 +5561,18 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 			uint8_t phy_tx_time[8] = {PHY_1M, PHY_1M, PHY_2M,
 						  PHY_1M, PHY_CODED, PHY_CODED,
 						  PHY_CODED, PHY_CODED};
-			struct lll_conn *lll = &conn->lll;
+			struct lll_conn *lll;
 			uint8_t phys;
 
+			/* Reset the transaction lock when PHY update response
+			 * sent by peripheral is acknowledged.
+			 */
+			if (pdu_tx->llctrl.opcode ==
+			    PDU_DATA_LLCTRL_TYPE_PHY_RSP) {
+				conn->common.txn_lock = 0U;
+			}
+
+			lll = &conn->lll;
 			phys = conn->llcp_phy.tx | lll->phy_tx;
 			lll->phy_tx_time = phy_tx_time[phys];
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4908,9 +4908,12 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 
 	/* Check for free ctrl tx PDU */
 	if (pdu_rx->llctrl.opcode == PDU_DATA_LLCTRL_TYPE_LENGTH_REQ) {
-		tx = mem_acquire(&mem_conn_tx_ctrl.free);
+		int err;
+
+		/* Check transaction violation and get free ctrl tx PDU */
+		tx = ctrl_tx_rsp_mem_acquire(conn, *rx, &err);
 		if (!tx) {
-			return -ENOBUFS;
+			return err;
 		}
 	}
 
@@ -5107,6 +5110,11 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 		 */
 		if (pdu_rx->llctrl.opcode != PDU_DATA_LLCTRL_TYPE_LENGTH_RSP) {
 			mem_release(tx, &mem_conn_tx_ctrl.free);
+
+			/* Release the transacation lock, as ctrl tx PDU is not
+			 * being enqueued.
+			 */
+			conn->common.txn_lock = 0U;
 
 			/* Defer new request if previous in resize state */
 			if (conn->llcp_length.state ==
@@ -5481,6 +5489,9 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		break;
 
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_RSP:
+		/* Reset the transaction lock */
+		conn->common.txn_lock = 0U;
+
 		if (conn->llcp_length.req != conn->llcp_length.ack) {
 			switch (conn->llcp_length.state) {
 			case LLCP_LENGTH_STATE_RSP_ACK_WAIT:

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4299,13 +4299,14 @@ static inline bool ctrl_is_unexpected(struct ll_conn *conn, uint8_t opcode)
 static int unknown_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 			    uint8_t type)
 {
-	struct node_tx *tx;
 	struct pdu_data *pdu;
+	struct node_tx *tx;
+	int err;
 
-	/* acquire ctrl tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu = (void *)tx->pdu;
@@ -5375,6 +5376,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	break;
 
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+	case PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP:
 		/* Reset the transaction lock */
 		conn->common.txn_lock = 0U;
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1984,6 +1984,42 @@ static int empty_data_start_release(struct ll_conn *conn, struct node_tx *tx)
 }
 #endif /* CONFIG_BT_CTLR_LLID_DATA_START_EMPTY */
 
+/* Check transaction violation and get free ctrl tx PDU */
+static struct node_tx *ctrl_tx_rsp_mem_acquire(struct ll_conn *conn,
+					       struct node_rx_pdu *rx,
+					       int *err)
+{
+	struct node_tx *tx;
+
+	/* Ignore duplicate requests without previous being acknowledged. */
+	if (conn->common.txn_lock) {
+		/* Mark for buffer for release */
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
+
+		/* Drop request */
+		*err = 0U;
+
+		return NULL;
+	}
+
+	/* Acquire ctrl tx mem */
+	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	if (!tx) {
+		*err = -ENOBUFS;
+
+		return NULL;
+	}
+
+	/* Lock further responses to duplicate requests before previous
+	 * response is acknowledged.
+	 */
+	conn->common.txn_lock = 1U;
+
+	/* NOTE: err value not required when returning valid ctrl tx PDU */
+
+	return tx;
+}
+
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static inline void  ctrl_tx_check_and_resume(struct ll_conn *conn)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4354,14 +4354,15 @@ static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 			    struct pdu_data *pdu_rx)
 {
 	struct pdu_data_llctrl_feature_req *req;
-	struct node_tx *tx;
 	struct pdu_data *pdu_tx;
+	struct node_tx *tx;
 	uint64_t feat;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	/* AND the feature set to get Feature USED */
@@ -5372,6 +5373,11 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		conn_cleanup(conn, reason);
 	}
 	break;
+
+	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+		/* Reset the transaction lock */
+		conn->common.txn_lock = 0U;
+		break;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -66,6 +66,7 @@ struct ll_conn {
 	union {
 		struct {
 			uint8_t fex_valid:1;
+			uint8_t txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */
@@ -74,6 +75,7 @@ struct ll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
 			uint8_t  fex_valid:1;
+			uint8_t  txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t  is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */
@@ -94,6 +96,7 @@ struct ll_conn {
 #if defined(CONFIG_BT_CENTRAL)
 		struct {
 			uint8_t fex_valid:1;
+			uint8_t txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -252,6 +252,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 	conn->common.fex_valid = 0U;
+	conn->common.txn_lock = 0U;
 	conn->master.terminate_ack = 0U;
 
 	conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0U;


### PR DESCRIPTION
Fix the following control procedure handling to check transaction violations:
- Feature Exchange response
- Unknown Control Procedure response
- Reject Extended Indication dispatch
- Data Length Update response
- Ping response
- PHY Update response

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>