### PR TITLE
Bluetooth: controller: Fix SyncInfo with correct event counter

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -526,6 +526,14 @@ config BT_TICKER_COMPATIBILITY_MODE
 	  radio RX/TX. Enabling this option disables the ticker priority- and
 	  'must expire' features.
 
+config BT_TICKER_LAZY_GET
+	bool "Ticker Next Slot Get with Lazy"
+	default y if BT_CTLR_ADV_PERIODIC
+	help
+	  This option enables ticker interface to iterate through active
+	  ticker nodes, returning tick to expire and lazy count from a reference
+	  tick.
+
 config BT_TICKER_EXT
 	bool "Ticker extensions"
 	depends on !BT_TICKER_COMPATIBILITY_MODE

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -890,6 +890,7 @@ static void mfy_sync_offset_get(void *param)
 	uint32_t ticks_current;
 	struct pdu_adv *pdu;
 	uint8_t ticker_id;
+	uint16_t lazy;
 	uint8_t retry;
 	uint8_t id;
 
@@ -909,11 +910,11 @@ static void mfy_sync_offset_get(void *param)
 		ticks_previous = ticks_current;
 
 		ret_cb = TICKER_STATUS_BUSY;
-		ret = ticker_next_slot_get(TICKER_INSTANCE_ID_CTLR,
-					   TICKER_USER_ID_ULL_LOW,
-					   &id,
-					   &ticks_current, &ticks_to_expire,
-					   ticker_op_cb, (void *)&ret_cb);
+		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR,
+					       TICKER_USER_ID_ULL_LOW,
+					       &id, &ticks_current,
+					       &ticks_to_expire, &lazy,
+					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {
 			while (ret_cb == TICKER_STATUS_BUSY) {
 				ticker_job_sched(TICKER_INSTANCE_ID_CTLR,
@@ -936,7 +937,8 @@ static void mfy_sync_offset_get(void *param)
 	pdu = lll_adv_aux_data_curr_get(adv->lll.aux);
 	si = sync_info_get(pdu);
 	sync_info_offset_fill(si, ticks_to_expire, 0);
-	si->evt_cntr = lll_sync->event_counter + lll_sync->latency_prepare;
+	si->evt_cntr = lll_sync->event_counter + lll_sync->latency_prepare +
+		       lazy;
 }
 
 static inline struct pdu_adv_sync_info *sync_info_get(struct pdu_adv *pdu)

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -170,6 +170,9 @@ struct ticker_user_op_slot_get {
 	uint8_t  *ticker_id;
 	uint32_t *ticks_current;
 	uint32_t *ticks_to_expire;
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+	uint16_t *lazy;
+#endif /* CONFIG_BT_TICKER_LAZY_GET */
 };
 
 /* User operation data structure for priority_set opcode. Used for passing
@@ -351,7 +354,11 @@ static uint8_t ticker_by_slot_get(struct ticker_node *node, uint8_t ticker_id_he
  */
 static void ticker_by_next_slot_get(struct ticker_instance *instance,
 				    uint8_t *ticker_id_head, uint32_t *ticks_current,
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+				    uint32_t *ticks_to_expire, uint16_t *lazy)
+#else /* !CONFIG_BT_TICKER_LAZY_GET */
 				    uint32_t *ticks_to_expire)
+#endif /* !CONFIG_BT_TICKER_LAZY_GET */
 {
 	struct ticker_node *ticker;
 	struct ticker_node *node;
@@ -385,6 +392,11 @@ static void ticker_by_next_slot_get(struct ticker_instance *instance,
 	if (_ticker_id_head != TICKER_NULL) {
 		/* Add ticks for found ticker */
 		_ticks_to_expire += ticker->ticks_to_expire;
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+		if (lazy) {
+			*lazy = ticker->lazy_current;
+		}
+#endif /* CONFIG_BT_TICKER_LAZY_GET */
 	}
 
 	*ticker_id_head = _ticker_id_head;
@@ -2105,7 +2117,12 @@ static inline void ticker_job_op_inquire(struct ticker_instance *instance,
 		ticker_by_next_slot_get(instance,
 					uop->params.slot_get.ticker_id,
 					uop->params.slot_get.ticks_current,
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+					uop->params.slot_get.ticks_to_expire,
+					uop->params.slot_get.lazy);
+#else /* !CONFIG_BT_TICKER_LAZY_GET */
 					uop->params.slot_get.ticks_to_expire);
+#endif /* !CONFIG_BT_TICKER_LAZY_GET */
 		__fallthrough;
 	case TICKER_USER_OP_TYPE_IDLE_GET:
 		uop->status = TICKER_STATUS_SUCCESS;
@@ -2825,10 +2842,23 @@ uint32_t ticker_stop_abs(uint8_t instance_index, uint8_t user_id, uint8_t ticker
  * available, and TICKER_STATUS_SUCCESS is returned if ticker_job gets to run
  * before exiting ticker_next_slot_get
  */
-uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id, uint8_t *ticker_id,
-			   uint32_t *ticks_current, uint32_t *ticks_to_expire,
-			   ticker_op_func fp_op_func, void *op_context)
+uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
+			      uint8_t *ticker_id, uint32_t *ticks_current,
+			      uint32_t *ticks_to_expire,
+			      ticker_op_func fp_op_func, void *op_context)
 {
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+	return ticker_next_slot_get_ext(instance_index, user_id, ticker_id,
+					ticks_current, ticks_to_expire, NULL,
+					fp_op_func, op_context);
+}
+
+uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
+				  uint8_t *ticker_id, uint32_t *ticks_current,
+				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  ticker_op_func fp_op_func, void *op_context)
+{
+#endif /* CONFIG_BT_TICKER_LAZY_GET */
 	struct ticker_instance *instance = &_instance[instance_index];
 	struct ticker_user_op *user_op;
 	struct ticker_user *user;
@@ -2851,6 +2881,9 @@ uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id, uint8_t *
 	user_op->params.slot_get.ticker_id = ticker_id;
 	user_op->params.slot_get.ticks_current = ticks_current;
 	user_op->params.slot_get.ticks_to_expire = ticks_to_expire;
+#if defined(CONFIG_BT_TICKER_LAZY_GET)
+	user_op->params.slot_get.lazy = lazy;
+#endif /* CONFIG_BT_TICKER_LAZY_GET */
 	user_op->status = TICKER_STATUS_BUSY;
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -144,9 +144,13 @@ uint32_t ticker_stop_abs(uint8_t instance_index, uint8_t user_id, uint8_t ticker
 		      uint32_t ticks_at_stop, ticker_op_func fp_op_func,
 		      void *op_context);
 uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
-			   uint8_t *ticker_id_head, uint32_t *ticks_current,
-			   uint32_t *ticks_to_expire,
-			   ticker_op_func fp_op_func, void *op_context);
+			      uint8_t *ticker_id, uint32_t *ticks_current,
+			      uint32_t *ticks_to_expire,
+			      ticker_op_func fp_op_func, void *op_context);
+uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
+				  uint8_t *ticker_id, uint32_t *ticks_current,
+				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  ticker_op_func fp_op_func, void *op_context);
 uint32_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 			  ticker_op_func fp_op_func, void *op_context);
 void ticker_job_sched(uint8_t instance_index, uint8_t user_id);


### PR DESCRIPTION
Updated ticker implementation to return lazy value for a
ticker when enumerating active tickers with time
reservations.

This is required to find offsets and to use the lazy value
to correctly calculate event and payload counter values that
needs to be filled into SyncInfo and BigInfo structures.

Fix Periodic Advertising SyncInfo structure to be filled
with correct event counter value considering accumulated
latency and ticker lazy value.

Fixes #32860.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

