### PR TITLE
tests: Bluetooth: df: Add missing intergration_platforms

### DIFF
--- a/tests/bluetooth/df/testcase.yaml
+++ b/tests/bluetooth/df/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df:
     platform_allow: nrf52_bsim
+    integration_platforms:
+      - nrf52_bsim
     tags: bluetooth


### PR DESCRIPTION
Add intergration_plaforms entry in testcase.yaml.
Thanks to that nrf52_bsim platform will be used instead
of default platforms that do not include nrf52_bsim.
The test will be not dead as it is now (executed only
when tests code has been changed).

Fixes issue: https://github.com/zephyrproject-rtos/zephyr/issues/33337 for Bluetooth DF test.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>