### PR TITLE
usb: hid: allow boot interface Protocol Code to be set per device 

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -54,6 +54,10 @@ Deprecated in this release
 * USB HID specific macros in ``<include/usb/class/usb_hid.h>`` are deprecated
   in favor of new common HID macros defined in ``<include/usb/class/hid.h>``.
 
+* USB HID Kconfig option USB_HID_PROTOCOL_CODE is deprecated.
+  USB_HID_PROTOCOL_CODE does not allow to set boot protocol code for specific
+  HID device. USB HID API function usb_hid_set_proto_code() can be used instead.
+
 * The ``CONFIG_OPENOCD_SUPPORT`` Kconfig option has been deprecated in favor
   of ``CONFIG_DEBUG_THREAD_INFO``.
 

--- a/include/usb/class/hid.h
+++ b/include/usb/class/hid.h
@@ -53,6 +53,13 @@ extern "C" {
 /** USB HID Class SetProtocol bRequest value */
 #define USB_HID_SET_PROTOCOL		0x0B
 
+/** USB HID Boot Interface Protocol (bInterfaceProtocol) Code None */
+#define HID_BOOT_IFACE_CODE_NONE	0
+/** USB HID Boot Interface Protocol (bInterfaceProtocol) Code Keyboard */
+#define HID_BOOT_IFACE_CODE_KEYBOARD	1
+/** USB HID Boot Interface Protocol (bInterfaceProtocol) Code Mouse */
+#define HID_BOOT_IFACE_CODE_MOUSE	2
+
 /** USB HID Class Boot protocol code */
 #define HID_PROTOCOL_BOOT		0
 /** USB HID Class Report protocol code */

--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -109,6 +109,18 @@ int hid_int_ep_read(const struct device *dev,
 		    uint32_t *ret_bytes);
 
 /**
+ * @brief Set USB HID class Protocol Code
+ *
+ * @details Should be called before usb_hid_init().
+ *
+ * @param[in]  dev          Pointer to USB HID device
+ * @param[in]  proto_code   Protocol Code to be used for bInterfaceProtocol
+ *
+ * @return 0 on success, negative errno code on fail.
+ */
+int usb_hid_set_proto_code(const struct device *dev, uint8_t proto_code);
+
+/**
  * @brief Initialize USB HID class support
  *
  * @param[in]  dev          Pointer to USB HID device

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -182,7 +182,7 @@ struct usb_cfg_data {
 	 */
 	const uint8_t *usb_device_description;
 	/** Pointer to interface descriptor */
-	const void *interface_descriptor;
+	void *interface_descriptor;
 	/** Function for interface runtime configuration */
 	usb_interface_config interface_config;
 	/** Callback to be notified on USB connection status change */

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -165,6 +165,10 @@ static int composite_pre_init(const struct device *dev)
 	atomic_set_bit(hid_ep_in_busy, HID_EP_BUSY_FLAG);
 	k_timer_start(&event_timer, REPORT_PERIOD, REPORT_PERIOD);
 
+	if (usb_hid_set_proto_code(hdev, HID_BOOT_IFACE_CODE_NONE)) {
+		LOG_WRN("Failed to set Protocol Code");
+	}
+
 	return usb_hid_init(hdev);
 }
 

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -66,16 +66,12 @@ config USB_HID_BOOT_PROTOCOL
 	  for more information.
 
 config USB_HID_PROTOCOL_CODE
-	int "HID protocol code"
+	int "HID Boot Interface protocol code (DEPRECATED)"
 	default 0
 	range 0 2
 	depends on USB_HID_BOOT_PROTOCOL
 	help
-	  Sets bIntefaceProtocol in HID instance.
-	  0 = None
-	  1 = Keyboard
-	  2 = Mouse
-	  See Chapter 4.3 of Device Class Definition for Human Interface Devices 1.11
-	  for more information.
+	  This option is deprecated.
+	  Please use usb_hid_set_proto_code() instead.
 
 endif # USB_DEVICE_HID

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -675,6 +675,19 @@ static void hid_interface_config(struct usb_desc_header *head,
 		.endpoint = hid_ep_data_##x,				\
 	};
 
+int usb_hid_set_proto_code(const struct device *dev, uint8_t proto_code)
+{
+	const struct usb_cfg_data *cfg = dev->config;
+	struct usb_if_descriptor *if_desc = cfg->interface_descriptor;
+
+	if (IS_ENABLED(CONFIG_USB_HID_BOOT_PROTOCOL)) {
+		if_desc->bInterfaceProtocol = proto_code;
+		return 0;
+	}
+
+	return -ENOTSUP;
+}
+
 int usb_hid_init(const struct device *dev)
 {
 	struct usb_cfg_data *cfg = (void *)dev->config;


### PR DESCRIPTION
Kconfig option USB_HID_PROTOCOL_CODE does not allow to set
boot interface protocol code for specific HID device but
only to set the same value for all device.
Add new API function to allow the application to set
Protocol Code per device. Deprecate USB_HID_PROTOCOL_CODE option.

Fixes: #32778