### PR TITLE
Switch flash_map to resolve devices at compile-time instead of using device_get_binding

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -65,6 +65,12 @@ struct flash_area {
 	 * device_get_binding().
 	 */
 	const char *fa_dev_name;
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	/**
+	 * Pointer to device structure for the flash device.
+	 */
+	const struct device *fa_dev;
+#endif
 };
 
 /**

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -60,11 +60,13 @@ struct flash_area {
 	off_t fa_off;
 	/** Total size */
 	size_t fa_size;
+#if defined(CONFIG_FLASH_MAP_DEV_NAME_IN_FLASH_AREA)
 	/**
 	 * Name of the flash device, suitable for passing to
 	 * device_get_binding().
 	 */
 	const char *fa_dev_name;
+#endif
 #if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
 	/**
 	 * Pointer to device structure for the flash device.

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -55,8 +55,7 @@ void main(void)
 		return;
 	}
 
-	printk("Area %u at 0x%x on %s for %u bytes\n",
-	       id, (unsigned int)pfa->fa_off, pfa->fa_dev_name,
+	printk("Area %u at 0x%x for %u bytes\n", id, (unsigned int)pfa->fa_off,
 	       (unsigned int)pfa->fa_size);
 
 	/* Optional wipe flash contents */

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -113,7 +113,7 @@ fcb_init(int f_area_id, struct fcb *fcb)
 		return -EINVAL;
 	}
 
-	dev = device_get_binding(fcb->fap->fa_dev_name);
+	dev = flash_area_get_device(fcb->fap);
 	fparam = flash_get_parameters(dev);
 	fcb->f_erase_value = fparam->erase_value;
 

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -635,7 +635,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 
 	dev = flash_area_get_device(fs->area);
 	if (dev == NULL) {
-		LOG_ERR("can't get flash device: %s", log_strdup(fs->area->fa_dev_name));
+		LOG_ERR("can't get flash device for area with id: %u", area_id);
 		ret = -ENODEV;
 		goto out;
 	}

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -60,6 +60,7 @@ config SETTINGS_NVS
 	bool "NVS non-volatile storage support"
 	depends on NVS
 	depends on FLASH_MAP
+	depends on FLASH_MAP_DEV_NAME_IN_FLASH_AREA
 	help
 	  Enables NVS storage support
 

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -18,8 +18,12 @@ if FLASH_MAP
 config FLASH_MAP_SHELL
 	bool "Enable flash map shell interface"
 	depends on SHELL
+	select FLASH_MAP_DEV_NAME_IN_FLASH_AREA
 	help
 	  This enables shell commands to list and test flash maps.
+	  The option depends on FLASH_MAP_DEV_NAME_IN_FLASH_AREA being selected, even when
+	  FLASH_MAP_DEV_IN_FLASH_AREA is enabled, to be able to list names of devices tied to
+	  flash areas, as the names need to be accessible from flash_area structure.
 
 config FLASH_MAP_DEV_IN_FLASH_AREA
 	bool "Switch flash map to use compile time evaluated devices objects"
@@ -35,6 +39,26 @@ config FLASH_MAP_DEV_IN_FLASH_AREA
 	  The option is set to n, by default, for custom flash maps (FLASH_MAP_CUSTOM=n); if your
 	  custom map populates the flash_area.fa_dev areas you may want to set this option to
 	  improve flash map performance.
+
+if FLASH_MAP_DEV_IN_FLASH_AREA
+config FLASH_MAP_DEV_NAME_IN_FLASH_AREA
+	bool "Keep fa_dev_name filed to flash_area structure"
+	default y
+	help
+	  The options allows storage of string name of flash device that is tied to the flash area
+	  record.  This may be useful when device_get_binding is used for obtaining device object
+	  for the flash_area or when in need to have such information at run-time.
+	  The flash map does not use flash_area.fa_dev_name internally when
+	  FLASH_MAP_USE_DEV_IN_FLASH_AREA is enabled, and in such case, unless used by other code,
+	  this can be safely disabled and will reduce size of flash_area structure by size of
+	  a pointer.
+endif
+
+if !FLASH_MAP_DEV_IN_FLASH_AREA
+config FLASH_MAP_DEV_NAME_IN_FLASH_AREA
+	bool
+	default y
+endif
 
 config FLASH_MAP_CUSTOM
 	bool "Custom flash map description"

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -21,6 +21,21 @@ config FLASH_MAP_SHELL
 	help
 	  This enables shell commands to list and test flash maps.
 
+config FLASH_MAP_DEV_IN_FLASH_AREA
+	bool "Switch flash map to use compile time evaluated devices objects"
+	default y if !FLASH_MAP_CUSTOM
+	help
+	  The option adds the fa_dev field to the flash_area structure that allows to evaluate flash
+	  device object pointer at compile time, and store it within flash_area structure to avoid
+	  run-time calls to obtain it.
+	  Enabling the option switches flash map API to use the flash_area.fa_dev instead of using
+	  flash_area.fa_dev_name to get device by name.
+	  In case of the default flash map, enabling this option will cause the fa_dev, of
+	  each map entry, to be populated with a pointer to the device tied to that flash area.
+	  The option is set to n, by default, for custom flash maps (FLASH_MAP_CUSTOM=n); if your
+	  custom map populates the flash_area.fa_dev areas you may want to set this option to
+	  improve flash map performance.
+
 config FLASH_MAP_CUSTOM
 	bool "Custom flash map description"
 	help

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -145,7 +145,11 @@ flash_page_cb cb, struct layout_data *cb_data)
 	cb_data->ret_len = *cnt;
 	cb_data->status = 0;
 
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	flash_dev = fa->fa_dev;
+#else
 	flash_dev = device_get_binding(fa->fa_dev_name);
+#endif
 	if (flash_dev == NULL) {
 		return -ENODEV;
 	}
@@ -193,7 +197,11 @@ int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	dev = fa->fa_dev;
+#else
 	dev = device_get_binding(fa->fa_dev_name);
+#endif
 
 	return flash_read(dev, fa->fa_off + off, dst, len);
 }
@@ -208,7 +216,11 @@ int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	flash_dev = fa->fa_dev;
+#else
 	flash_dev = device_get_binding(fa->fa_dev_name);
+#endif
 
 	rc = flash_write_protection_set(flash_dev, false);
 	if (rc) {
@@ -232,7 +244,11 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	flash_dev = fa->fa_dev;
+#else
 	flash_dev = device_get_binding(fa->fa_dev_name);
+#endif
 
 	rc = flash_write_protection_set(flash_dev, false);
 	if (rc) {
@@ -249,34 +265,44 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 
 uint8_t flash_area_align(const struct flash_area *fa)
 {
-	const struct device *dev;
-
-	dev = device_get_binding(fa->fa_dev_name);
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	const struct device *dev = fa->fa_dev;
+#else
+	const struct device *dev = device_get_binding(fa->fa_dev_name);
+#endif
 
 	return flash_get_write_block_size(dev);
 }
 
 int flash_area_has_driver(const struct flash_area *fa)
 {
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	return (fa->fa_dev != NULL);
+#else
 	if (device_get_binding(fa->fa_dev_name) == NULL) {
 		return -ENODEV;
 	}
 
 	return 1;
+#endif
 }
 
 const struct device *flash_area_get_device(const struct flash_area *fa)
 {
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	return fa->fa_dev;
+#else
 	return device_get_binding(fa->fa_dev_name);
+#endif
 }
 
 uint8_t flash_area_erased_val(const struct flash_area *fa)
 {
-	const struct flash_parameters *param;
-
-	param = flash_get_parameters(device_get_binding(fa->fa_dev_name));
-
-	return param->erase_value;
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	return flash_get_parameters(fa->fa_dev)->erase_value;
+#else
+	return flash_get_parameters(device_get_binding(fa->fa_dev_name))->erase_value;
+#endif
 }
 
 #if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY)
@@ -303,7 +329,11 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 		return -ESRCH;
 	}
 
+#if defined(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA)
+	dev = fa->fa_dev;
+#else
 	dev = device_get_binding(fa->fa_dev_name);
+#endif
 	to_read = fac->rblen;
 
 	for (pos = 0; pos < fac->clen; pos += to_read) {

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -9,11 +9,16 @@
 
 #include <zephyr.h>
 #include <storage/flash_map.h>
+#include <device.h>
 
-#define FLASH_AREA_FOO(part)						\
-	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
-	 .fa_off = DT_REG_ADDR(part),					\
-	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+#define FLASH_AREA_FOO(part)							\
+	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
+	 .fa_off = DT_REG_ADDR(part),						\
+	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),		\
+	 COND_CODE_1(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA,			\
+		(.fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),),	\
+		()								\
+	 )									\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -14,7 +14,10 @@
 #define FLASH_AREA_FOO(part)							\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
 	 .fa_off = DT_REG_ADDR(part),						\
-	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),		\
+	 COND_CODE_1(CONFIG_FLASH_MAP_DEV_NAME_IN_FLASH_AREA,			\
+		(.fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),),	\
+		()								\
+	 )									\
 	 COND_CODE_1(CONFIG_FLASH_MAP_DEV_IN_FLASH_AREA,			\
 		(.fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),),	\
 		()								\

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -151,7 +151,7 @@ void test_get_flash_erase_value(void)
 	rc = flash_area_open(TEST_FCB_FLASH_AREA_ID, &fa);
 	zassert_equal(rc, 0, "Failed top open flash area");
 
-	dev = device_get_binding(fa->fa_dev_name);
+	dev = flash_area_get_device(fa);
 	flash_area_close(fa);
 
 	zassert_true(dev != NULL, "Failed to obtain device");


### PR DESCRIPTION
The PR contains series of commits that switch flash_map from using device_get_binding on flash_area.fa_dev_name
to using new filed flash_area.fa_dev, that is filled at compile time with a pointer to the flash device the flash_area is tied to.
This PR also contains commit that makes the filed flash_area.fa_dev_name optional, as it is no longer used within flash map API, but is left available for external code that relies on existence of this field.

Set to DNM due to ongoing tests.