### PR TITLE
scripts: menuconfig: proper handling of NULL character as input

### DIFF
--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1757,6 +1757,9 @@ def _input_dialog(title, initial_text, info_text=None):
             _safe_curs_set(0)
             return None
 
+        elif c == "\0":  # \0 = NUL, ignore
+            pass
+
         else:
             s, i, hscroll = _edit_text(c, s, i, hscroll, edit_width())
 
@@ -2195,6 +2198,9 @@ def _jump_to_dialog():
 
         elif c == curses.KEY_HOME:
             sel_node_i = scroll = 0
+
+        elif c == "\0":  # \0 = NUL, ignore
+            pass
 
         else:
             s, s_i, hscroll = _edit_text(c, s, s_i, hscroll,


### PR DESCRIPTION
Fixes: #33212

Upstream PR: ulfalizer/Kconfiglib#103

Ignoring when user inputs NULL in a text field.
menuconfig exits with a python stack trace if NULL is provided as input
character, therefore ignore NULL as an input character to prevent this
behaviour.

A NULL character may be given accidentally by the user through the
following ways:
- Pressing `Win` key on keyboard (Windows only)
- Pressing `<CTRL>-@` / `<CTRL>-2`.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>