### PR TITLE
doc: add support for Sphinx dummy builder

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: build-docs
       run: |
         source zephyr-env.sh
-        make htmldocs
+        DUMMY_BUILD=ON make htmldocs
         tar cvf htmldocs.tar --directory=./doc/_build html
 
     - name: upload-build

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILDDIR ?= doc/_build
 DOC_TAG ?= development
 SPHINXOPTS ?= -q
 KCONFIG_TURBO_MODE ?= 0
+DUMMY_BUILD ?= OFF
 
 # Documentation targets
 # ---------------------------------------------------------------------------
@@ -24,7 +25,8 @@ htmldocs pdfdocs doxygen: configure
 configure:
 	cmake -GNinja  -B${BUILDDIR} -Sdoc/ -DDOC_TAG=${DOC_TAG} \
 		-DSPHINXOPTS=${SPHINXOPTS} \
-		-DKCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
+		-DKCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE} \
+		-DDUMMY_BUILD=${DUMMY_BUILD}
 
 clean:
 	rm -rf ${BUILDDIR}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -64,6 +64,11 @@ else()
   separate_arguments(SPHINXOPTS)
 endif()
 
+option(DUMMY_BUILD "Use Sphinx dummy builder" OFF)
+if(DUMMY_BUILD)
+  list(APPEND SPHINXOPTS -b dummy)
+endif()
+
 if(NOT DEFINED SPHINX_OUTPUT_DIR)
   set(SPHINX_OUTPUT_DIR_HTML ${CMAKE_CURRENT_BINARY_DIR}/html)
   set(SPHINX_OUTPUT_DIR_LATEX ${CMAKE_CURRENT_BINARY_DIR}/latex)


### PR DESCRIPTION
Dummy builder writes no files. It is useful e.g. in a CI environment where the actual documentation output is not relevant. The documentation is still built, so errors or warnings are detected.

Enable it for PR builds where the output is not relevant. It should speed up documentation action (edit: saves ~30%).

Ref. https://www.sphinx-doc.org/es/master/_modules/sphinx/builders/dummy.html