### PR TITLE
kernel: Allow k_poll on message queues

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4126,6 +4126,8 @@ struct k_msgq {
 	/** Number of used messages */
 	uint32_t used_msgs;
 
+	_POLL_EVENT;
+
 	_OBJECT_TRACING_NEXT_PTR(k_msgq)
 	_OBJECT_TRACING_LINKED_FLAG
 
@@ -4147,6 +4149,7 @@ struct k_msgq {
 	.read_ptr = q_buffer, \
 	.write_ptr = q_buffer, \
 	.used_msgs = 0, \
+	_POLL_EVENT_OBJ_INIT(obj) \
 	_OBJECT_TRACING_INIT \
 	}
 
@@ -5098,6 +5101,9 @@ enum _poll_types_bits {
 	/* queue/FIFO/LIFO data availability */
 	_POLL_TYPE_DATA_AVAILABLE,
 
+	/* msgq data availability */
+	_POLL_TYPE_MSGQ_DATA_AVAILABLE,
+
 	_POLL_NUM_TYPES
 };
 
@@ -5119,6 +5125,9 @@ enum _poll_states_bits {
 
 	/* queue/FIFO/LIFO wait was cancelled */
 	_POLL_STATE_CANCELLED,
+
+	/* data is available to read on a message queue */
+	_POLL_STATE_MSGQ_DATA_AVAILABLE,
 
 	_POLL_NUM_STATES
 };
@@ -5150,6 +5159,7 @@ enum _poll_states_bits {
 #define K_POLL_TYPE_SEM_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_SEM_AVAILABLE)
 #define K_POLL_TYPE_DATA_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_DATA_AVAILABLE)
 #define K_POLL_TYPE_FIFO_DATA_AVAILABLE K_POLL_TYPE_DATA_AVAILABLE
+#define K_POLL_TYPE_MSGQ_DATA_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_MSGQ_DATA_AVAILABLE)
 
 /* public - polling modes */
 enum k_poll_modes {
@@ -5165,6 +5175,7 @@ enum k_poll_modes {
 #define K_POLL_STATE_SEM_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_SEM_AVAILABLE)
 #define K_POLL_STATE_DATA_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_DATA_AVAILABLE)
 #define K_POLL_STATE_FIFO_DATA_AVAILABLE K_POLL_STATE_DATA_AVAILABLE
+#define K_POLL_STATE_MSGQ_DATA_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_MSGQ_DATA_AVAILABLE)
 #define K_POLL_STATE_CANCELLED Z_POLL_STATE_BIT(_POLL_STATE_CANCELLED)
 
 /* public - poll signal object */
@@ -5221,6 +5232,7 @@ struct k_poll_event {
 		struct k_sem *sem;
 		struct k_fifo *fifo;
 		struct k_queue *queue;
+		struct k_msgq *msgq;
 	};
 };
 

--- a/tests/kernel/poll/src/main.c
+++ b/tests/kernel/poll/src/main.c
@@ -22,6 +22,7 @@ extern void test_k_poll_user_mem_err(void);
 extern void test_k_poll_user_type_sem_err(void);
 extern void test_k_poll_user_type_signal_err(void);
 extern void test_k_poll_user_type_fifo_err(void);
+extern void test_k_poll_user_type_msgq_err(void);
 extern void test_poll_signal_init_null(void);
 extern void test_poll_signal_check_obj(void);
 extern void test_poll_signal_check_signal(void);
@@ -40,6 +41,7 @@ dummy_test(test_k_poll_user_mem_err);
 dummy_test(test_k_poll_user_type_sem_err);
 dummy_test(test_k_poll_user_type_signal_err);
 dummy_test(test_k_poll_user_type_fifo_err);
+dummy_test(test_k_poll_user_type_msgq_err);
 dummy_test(test_poll_signal_init_null);
 dummy_test(test_poll_signal_check_obj);
 dummy_test(test_poll_signal_check_signal);
@@ -79,6 +81,7 @@ void test_main(void)
 			 ztest_user_unit_test(test_k_poll_user_type_sem_err),
 			 ztest_user_unit_test(test_k_poll_user_type_signal_err),
 			 ztest_user_unit_test(test_k_poll_user_type_fifo_err),
+			 ztest_user_unit_test(test_k_poll_user_type_msgq_err),
 			 ztest_user_unit_test(test_poll_signal_init_null),
 			 ztest_user_unit_test(test_poll_signal_check_obj),
 			 ztest_user_unit_test(test_poll_signal_check_signal),

--- a/tests/kernel/poll/src/test_poll_fail.c
+++ b/tests/kernel/poll/src/test_poll_fail.c
@@ -213,6 +213,29 @@ void test_k_poll_user_type_fifo_err(void)
 }
 
 /**
+ * @brief Test API k_poll with NULL message queue event in user mode
+ *
+ * @details Define a poll, and using API k_poll with NULL message queue
+ * as parameter to check if a error will be met.
+ *
+ * @see k_poll()
+ *
+ * @ingroup kernel_poll_tests
+ */
+void test_k_poll_user_type_msgq_err(void)
+{
+	struct k_poll_event event[] = {
+		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_MSGQ_DATA_AVAILABLE,
+					 K_POLL_MODE_NOTIFY_ONLY,
+					 NULL),
+	};
+
+	ztest_set_fault_valid(true);
+	k_poll(event, 1, K_NO_WAIT);
+}
+
+
+/**
  * @brief Test API k_poll_signal_init with NULL in user mode
  *
  * @details Using API k_poll_signal_init with NULL as


### PR DESCRIPTION
This commit adds the ability to use a message queue as a
k_poll object. It follows the same pattern as polling on
FIFOs.

This change has been proven in practice at Samsara.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/26728

Signed-off-by: Nick Graves <nicholas.graves@samsara.com>