### PR TITLE
Bluetooth: controller: Avoid sizeof to access ULL/LLL struct member

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -325,7 +325,7 @@ int lll_done(void *param)
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
 		if (param) {
-			ull = HDR_ULL(((struct lll_hdr *)param)->parent);
+			ull = HDR_LLL2ULL(param);
 		}
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
@@ -337,7 +337,7 @@ int lll_done(void *param)
 
 		DEBUG_RADIO_CLOSE(0);
 	} else {
-		ull = HDR_ULL(((struct lll_hdr *)param)->parent);
+		ull = HDR_LLL2ULL(param);
 	}
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -397,21 +397,21 @@ void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	lll_done(param);
 }
 
-uint32_t lll_evt_offset_get(struct evt_hdr *evt)
+uint32_t lll_event_offset_get(struct ull_hdr *ull)
 {
 	if (0) {
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-	} else if (evt->ticks_xtal_to_start & XON_BITMASK) {
-		return MAX(evt->ticks_active_to_start,
-			   evt->ticks_preempt_to_start);
+	} else if (ull->ticks_prepare_to_start & XON_BITMASK) {
+		return MAX(ull->ticks_active_to_start,
+			   ull->ticks_preempt_to_start);
 #endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
 	} else {
-		return MAX(evt->ticks_active_to_start,
-			   evt->ticks_xtal_to_start);
+		return MAX(ull->ticks_active_to_start,
+			   ull->ticks_prepare_to_start);
 	}
 }
 
-uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
+uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 		       uint32_t ticks_at_event)
 {
 	uint32_t ticks_now;
@@ -740,16 +740,16 @@ static void ticker_start_op_cb(uint32_t status, void *param)
 static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 {
 	uint32_t preempt_anchor;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t preempt_to;
 	uint32_t ret;
 
 	/* Calc the preempt timeout */
-	evt = HDR_LLL2EVT(prepare_param->param);
+	ull = HDR_LLL2ULL(prepare_param->param);
 	preempt_anchor = prepare_param->ticks_at_expire;
-	preempt_to = MAX(evt->ticks_active_to_start,
-			 evt->ticks_xtal_to_start) -
-			 evt->ticks_preempt_to_start;
+	preempt_to = MAX(ull->ticks_active_to_start,
+			 ull->ticks_prepare_to_start) -
+		     ull->ticks_preempt_to_start;
 
 	/* Setup pre empt timeout */
 	ret = ticker_start(TICKER_INSTANCE_ID_CTLR,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -730,7 +730,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	struct pdu_adv *pdu;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	struct lll_adv *lll;
 	uint32_t remainder;
 	uint32_t start_us;
@@ -809,8 +809,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	}
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -832,7 +832,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_ADV_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_ADV_BASE +
 				   ull_adv_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(isr_abort, lll);
@@ -854,10 +854,10 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_PERIPHERAL)
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 
-	evt = HDR_LLL2EVT(p->param);
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(p->param);
+	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
 	p->remainder = 0;
 	p->lazy = 0;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -188,7 +188,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	struct pdu_adv_ext_hdr *pri_hdr;
 	struct lll_adv_aux *lll;
 	struct lll_adv *lll_adv;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t start_us;
 	uint8_t *pri_dptr;
@@ -293,8 +293,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	}
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -316,7 +316,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_ADV_AUX_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_ADV_AUX_BASE +
 				   ull_adv_aux_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(lll_isr_abort, lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -108,7 +108,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint16_t event_counter;
 	uint8_t data_chan_use;
 	struct pdu_adv *pdu;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t start_us;
 	void *extra_data;
@@ -186,8 +186,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	}
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -207,7 +207,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_ADV_SYNC_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_ADV_SYNC_BASE +
 				   ull_adv_sync_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(lll_isr_abort, lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -10,10 +10,12 @@ bool lll_is_done(void *param);
 int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
-uint32_t lll_evt_offset_get(struct evt_hdr *evt);
-uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
-		uint32_t ticks_at_event);
+uint32_t lll_event_offset_get(struct ull_hdr *ull);
+uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
+			  uint32_t ticks_at_event);
+
 void lll_chan_set(uint32_t chan);
+
 void lll_isr_tx_status_reset(void);
 void lll_isr_rx_status_reset(void);
 void lll_isr_status_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -101,7 +101,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
 	struct lll_conn *lll;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 
 	DEBUG_RADIO_START_M(1);
@@ -183,8 +183,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -215,7 +215,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
 			     ticks_at_event)) {
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -128,7 +128,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	struct node_rx_pdu *node_rx;
 	uint32_t remainder_us;
 	struct lll_scan *lll;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t aa;
 
@@ -218,8 +218,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	}
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -248,7 +248,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_SCAN_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_SCAN_BASE +
 				   ull_scan_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(isr_abort, lll);
@@ -305,10 +305,10 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 
-	evt = HDR_LLL2EVT(p->param);
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(p->param);
+	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
 	p->remainder = 0;
 	p->lazy = 0;
 
@@ -783,7 +783,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		uint32_t conn_interval_us;
 		uint32_t conn_offset_us;
 		uint32_t conn_space_us;
-		struct evt_hdr *evt;
+		struct ull_hdr *ull;
 		uint32_t pdu_end_us;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		bt_addr_t *lrpa;
@@ -807,8 +807,8 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			scan_interval_us = lll->interval * SCAN_INT_UNIT_US;
 			pdu_end_us %= scan_interval_us;
 		}
-		evt = HDR_LLL2EVT(lll);
-		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(evt->ticks_slot) -
+		ull = HDR_LLL2ULL(lll);
+		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(ull->ticks_slot) -
 				  EVENT_IFS_US - 352 - EVENT_OVERHEAD_START_US -
 				  EVENT_TICKER_RES_MARGIN_US)) {
 			return -ETIME;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -92,7 +92,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	struct lll_scan_aux *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder_us;
 	uint32_t remainder;
 	uint32_t hcto;
@@ -139,8 +139,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	/* Calculate event timings, coarse and fine */
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -173,7 +173,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_SCAN_AUX_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_SCAN_AUX_BASE +
 				   ull_scan_aux_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(isr_done, lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -108,7 +108,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
 	struct lll_conn *lll;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
 
@@ -202,8 +202,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -257,7 +257,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
 			     ticks_at_event)) {
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -108,7 +108,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
 	struct lll_sync *lll;
-	struct evt_hdr *evt;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
 
@@ -172,8 +172,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_switch_complete_and_disable();
 
 	ticks_at_event = p->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -206,7 +206,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_SCAN_SYNC_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_SCAN_SYNC_BASE +
 				   ull_sync_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(lll_isr_abort, lll);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -319,8 +319,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	struct lll_adv *lll = prepare_param->param;
 	uint32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	uint32_t ticks_at_event, ticks_at_start;
-	struct evt_hdr *evt;
 	uint32_t remainder_us;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 
 	DEBUG_RADIO_START_A(1);
@@ -390,8 +390,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		}
 
 	ticks_at_event = prepare_param->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -414,7 +414,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_ADV_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_ADV_BASE +
 				   ull_adv_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(isr_abort, lll);
@@ -436,9 +436,9 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_PERIPHERAL)
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt = HDR_LLL2EVT(p->param);
+	struct ull_hdr *ull = HDR_LLL2ULL(p->param);
 
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
+	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
 	p->remainder = 0;
 	p->lazy = 0;
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
@@ -13,7 +13,7 @@ void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 int lll_clk_on(void);
 int lll_clk_on_wait(void);
 int lll_clk_off(void);
-uint32_t lll_evt_offset_get(struct evt_hdr *evt);
-uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
-		uint32_t ticks_at_event);
+uint32_t lll_event_offset_get(struct ull_hdr *ull);
+uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
+			  uint32_t ticks_at_event);
 void lll_chan_set(uint32_t chan);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_master.c
@@ -90,10 +90,10 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	struct lll_conn *lll = prepare_param->param;
 	uint32_t ticks_at_event, ticks_at_start;
 	struct pdu_data *pdu_data_tx;
-	struct evt_hdr *evt;
 	uint16_t event_counter;
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 
 	DEBUG_RADIO_START_M(1);
@@ -160,8 +160,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	ticks_at_event = prepare_param->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -192,7 +192,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
 			     ticks_at_event)) {
 		radio_isr_set(lll_conn_isr_abort, lll);
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -123,8 +123,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	uint32_t aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	uint32_t ticks_at_event, ticks_at_start;
 	struct node_rx_pdu *node_rx;
-	struct evt_hdr *evt;
 	uint32_t remainder_us;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 
 	DEBUG_RADIO_START_O(1);
@@ -200,8 +200,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		}
 
 	ticks_at_event = prepare_param->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -229,7 +229,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_SCAN_BASE +
+	if (lll_preempt_calc(ull, (TICKER_ID_SCAN_BASE +
 				   ull_scan_lll_handle_get(lll)),
 			     ticks_at_event)) {
 		radio_isr_set(isr_abort, lll);
@@ -266,9 +266,9 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
-	struct evt_hdr *evt = HDR_LLL2EVT(p->param);
+	struct ull_hdr *ull = HDR_LLL2ULL(p->param);
 
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_evt_offset_get(evt);
+	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
 	p->remainder = 0;
 	p->lazy = 0;
 
@@ -682,7 +682,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		uint32_t conn_interval_us;
 		uint32_t conn_offset_us;
 		uint32_t conn_space_us;
-		struct evt_hdr *evt;
+		struct ull_hdr *ull;
 		uint32_t pdu_end_us;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		bt_addr_t *lrpa;
@@ -706,8 +706,8 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 			scan_interval_us = lll->interval * SCAN_INT_UNIT_US;
 			pdu_end_us %= scan_interval_us;
 		}
-		evt = HDR_LLL2EVT(lll);
-		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(evt->ticks_slot) -
+		ull = HDR_LLL2ULL(lll);
+		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(ull->ticks_slot) -
 				  EVENT_IFS_US - 352 - EVENT_OVERHEAD_START_US -
 				  EVENT_TICKER_RES_MARGIN_US)) {
 			return -ETIME;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_slave.c
@@ -98,10 +98,10 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_conn *lll = prepare_param->param;
 	uint32_t ticks_at_event, ticks_at_start;
-	struct evt_hdr *evt;
 	uint16_t event_counter;
 	uint32_t remainder_us;
 	uint8_t data_chan_use;
+	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
 
@@ -181,8 +181,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	ticks_at_event = prepare_param->ticks_at_expire;
-	evt = HDR_LLL2EVT(lll);
-	ticks_at_event += lll_evt_offset_get(evt);
+	ull = HDR_LLL2ULL(lll);
+	ticks_at_event += lll_event_offset_get(ull);
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -235,7 +235,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
 			     ticks_at_event)) {
 		radio_isr_set(lll_conn_isr_abort, lll);
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -867,7 +867,7 @@ void ll_rx_dequeue(void)
 		if (lll_aux) {
 			struct ll_adv_aux_set *aux;
 
-			aux = (void *)HDR_LLL2EVT(lll_aux);
+			aux = HDR_LLL2ULL(lll_aux);
 
 			aux->is_started = 0U;
 		}
@@ -889,7 +889,7 @@ void ll_rx_dequeue(void)
 
 		lll_conn->link_tx_free = link;
 
-		struct ll_conn *conn = (void *)HDR_LLL2EVT(lll_conn);
+		struct ll_conn *conn = HDR_LLL2ULL(lll_conn);
 
 		ll_conn_release(conn);
 		adv->lll.conn = NULL;
@@ -917,8 +917,12 @@ void ll_rx_dequeue(void)
 
 #if defined(CONFIG_BT_PERIPHERAL)
 		} else if ((cc->status == BT_HCI_ERR_ADV_TIMEOUT) || cc->role) {
-			struct lll_adv *lll = ftr->param;
-			struct ll_adv_set *adv = (void *)HDR_LLL2EVT(lll);
+			struct ll_adv_set *adv;
+			struct lll_adv *lll;
+
+			/* Get reference to ULL context */
+			lll = ftr->param;
+			adv = HDR_LLL2ULL(lll);
 
 			if (cc->status == BT_HCI_ERR_ADV_TIMEOUT) {
 				struct lll_conn *conn_lll;
@@ -935,7 +939,7 @@ void ll_rx_dequeue(void)
 				LL_ASSERT(link);
 				conn_lll->link_tx_free = link;
 
-				conn = (void *)HDR_LLL2EVT(conn_lll);
+				conn = HDR_LLL2ULL(conn_lll);
 				ll_conn_release(conn);
 			} else {
 				/* Release un-utilized node rx */
@@ -953,7 +957,7 @@ void ll_rx_dequeue(void)
 			if (lll->aux) {
 				struct ll_adv_aux_set *aux;
 
-				aux = (void *)HDR_LLL2EVT(lll->aux);
+				aux = HDR_LLL2ULL(lll->aux);
 				aux->is_started = 0U;
 			}
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
@@ -964,8 +968,7 @@ void ll_rx_dequeue(void)
 #endif /* !CONFIG_BT_PERIPHERAL */
 
 		} else if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-			struct lll_scan *lll = ftr->param;
-			struct ll_scan_set *scan = (void *)HDR_LLL2EVT(lll);
+			struct ll_scan_set *scan = HDR_LLL2ULL(ftr->param);
 
 			scan->is_enabled = 0U;
 		} else {
@@ -1526,19 +1529,15 @@ int ull_disable(void *lll)
 	struct k_sem sem;
 	uint32_t ret;
 
-	hdr = HDR_ULL(((struct lll_hdr *)lll)->parent);
-	if (!hdr) {
-		return ULL_STATUS_SUCCESS;
+	hdr = HDR_LLL2ULL(lll);
+	if (!hdr || !ull_ref_get(hdr)) {
+		return 0;
 	}
 
 	k_sem_init(&sem, 0, 1);
 
 	hdr->disabled_param = &sem;
 	hdr->disabled_cb = disabled_cb;
-
-	if (!ull_ref_get(hdr)) {
-		return ULL_STATUS_SUCCESS;
-	}
 
 	mfy.param = lll;
 	ret = mayfly_enqueue(TICKER_USER_ID_THREAD, TICKER_USER_ID_LLL, 0,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -136,7 +136,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref, ui
 	if (adv->is_enabled) {
 		struct ll_adv_aux_set *aux;
 
-		aux = (void *)HDR_LLL2EVT(adv->lll.aux);
+		aux = HDR_LLL2ULL(adv->lll.aux);
 		if (!aux->is_started) {
 			uint32_t ticks_slot_overhead;
 			uint32_t ticks_anchor;
@@ -351,7 +351,7 @@ uint8_t ll_adv_aux_set_remove(uint8_t handle)
 	if (lll->sync) {
 		struct ll_adv_sync_set *sync;
 
-		sync = (void *)HDR_LLL2EVT(lll->sync);
+		sync = HDR_LLL2ULL(lll->sync);
 
 		if (sync->is_enabled) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
@@ -377,7 +377,7 @@ uint8_t ll_adv_aux_set_remove(uint8_t handle)
 	if (lll->aux) {
 		struct ll_adv_aux_set *aux;
 
-		aux = (void *)HDR_LLL2EVT(lll->aux);
+		aux = HDR_LLL2ULL(lll->aux);
 		lll->aux = NULL;
 
 		ull_adv_aux_release(aux);
@@ -837,16 +837,16 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux)
 	slot_us += 1000;
 
 	/* TODO: active_to_start feature port */
-	aux->evt.ticks_active_to_start = 0;
-	aux->evt.ticks_xtal_to_start =
+	aux->ull.ticks_active_to_start = 0;
+	aux->ull.ticks_prepare_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	aux->evt.ticks_preempt_to_start =
+	aux->ull.ticks_preempt_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-	aux->evt.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
+	aux->ull.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(aux->evt.ticks_active_to_start,
-					  aux->evt.ticks_xtal_to_start);
+		ticks_slot_overhead = MAX(aux->ull.ticks_active_to_start,
+					  aux->ull.ticks_prepare_to_start);
 	} else {
 		ticks_slot_overhead = 0;
 	}
@@ -871,7 +871,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 			   HAL_TICKER_US_TO_TICKS((uint64_t)aux->interval *
 						  ADV_INT_UNIT_US),
 			   TICKER_NULL_REMAINDER, TICKER_NULL_LAZY,
-			   (aux->evt.ticks_slot + ticks_slot_overhead),
+			   (aux->ull.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, aux,
 			   ull_ticker_status_give, (void *)&ret_cb);
 	ret = ull_ticker_status_take(ret, &ret_cb);
@@ -1025,7 +1025,7 @@ static inline void sync_info_fill(struct lll_adv_sync *lll_sync,
 	si->offs_adjust = 0U;
 	si->offs = 0U;
 
-	sync = (void *)HDR_LLL2EVT(lll_sync);
+	sync = HDR_LLL2ULL(lll_sync);
 	si->interval = sys_cpu_to_le16(sync->interval);
 	memcpy(si->sca_chm, lll_sync->data_chan_map,
 	       sizeof(si->sca_chm));
@@ -1049,7 +1049,7 @@ static void mfy_aux_offset_get(void *param)
 	uint8_t retry;
 	uint8_t id;
 
-	aux = (void *)HDR_LLL2EVT(adv->lll.aux);
+	aux = HDR_LLL2ULL(adv->lll.aux);
 	ticker_id = TICKER_ID_ADV_AUX_BASE + ull_adv_aux_handle_get(aux);
 
 	id = TICKER_NULL;
@@ -1136,11 +1136,11 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 	struct ll_adv_set *adv;
 
-	adv = (void *)HDR_LLL2EVT(lll->adv);
+	adv = HDR_LLL2ULL(lll->adv);
 	if (adv->lll.sync) {
 		struct ll_adv_sync_set *sync;
 
-		sync  = (void *)HDR_LLL2EVT(adv->lll.sync);
+		sync  = HDR_LLL2ULL(adv->lll.sync);
 		if (sync->is_started) {
 			ull_adv_sync_offset_get(adv);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -324,16 +324,16 @@ static uint32_t ull_adv_iso_start(struct ll_adv_iso *adv_iso,
 	slot_us = EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 	slot_us += 1000;
 
-	adv_iso->evt.ticks_active_to_start = 0;
-	adv_iso->evt.ticks_xtal_to_start =
+	adv_iso->ull.ticks_active_to_start = 0;
+	adv_iso->ull.ticks_prepare_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	adv_iso->evt.ticks_preempt_to_start =
+	adv_iso->ull.ticks_preempt_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-	adv_iso->evt.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
+	adv_iso->ull.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(adv_iso->evt.ticks_active_to_start,
-					  adv_iso->evt.ticks_xtal_to_start);
+		ticks_slot_overhead = MAX(adv_iso->ull.ticks_active_to_start,
+					  adv_iso->ull.ticks_prepare_to_start);
 	} else {
 		ticks_slot_overhead = 0;
 	}
@@ -351,7 +351,7 @@ static uint32_t ull_adv_iso_start(struct ll_adv_iso *adv_iso,
 			   HAL_TICKER_US_TO_TICKS(iso_interval_us),
 			   HAL_TICKER_REMAINDER(iso_interval_us),
 			   TICKER_NULL_LAZY,
-			   (ll_adv_iso->evt.ticks_slot + ticks_slot_overhead),
+			   (ll_adv_iso->ull.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, ll_adv_iso,
 			   ull_ticker_status_give, (void *)&ret_cb);
 	ret = ull_ticker_status_take(ret, &ret_cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -156,7 +156,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 		ter_pdu->len = ter_len;
 	} else {
-		sync = (void *)HDR_LLL2EVT(lll_sync);
+		sync = HDR_LLL2ULL(lll_sync);
 	}
 
 	sync->interval = interval;
@@ -232,7 +232,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
-	sync = (void *)HDR_LLL2EVT(lll_sync);
+	sync = HDR_LLL2ULL(lll_sync);
 
 	if (!enable) {
 		if (!sync->is_enabled) {
@@ -290,12 +290,12 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			aux = NULL;
 		} else {
 			lll_aux = adv->lll.aux;
-			aux = (void *)HDR_LLL2EVT(lll_aux);
+			aux = HDR_LLL2ULL(lll_aux);
 			ticks_anchor_aux = ticker_ticks_now_get();
 			ticks_slot_overhead_aux = ull_adv_aux_evt_init(aux);
 			ticks_anchor_sync =
 				ticks_anchor_aux + ticks_slot_overhead_aux +
-				aux->evt.ticks_slot +
+				aux->ull.ticks_slot +
 				HAL_TICKER_US_TO_TICKS(EVENT_MAFS_US);
 		}
 
@@ -395,16 +395,16 @@ uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 
 	/* TODO: active_to_start feature port */
-	sync->evt.ticks_active_to_start = 0;
-	sync->evt.ticks_xtal_to_start =
+	sync->ull.ticks_active_to_start = 0;
+	sync->ull.ticks_prepare_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	sync->evt.ticks_preempt_to_start =
+	sync->ull.ticks_preempt_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-	sync->evt.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
+	sync->ull.ticks_slot = HAL_TICKER_US_TO_TICKS(slot_us);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(sync->evt.ticks_active_to_start,
-					  sync->evt.ticks_xtal_to_start);
+		ticks_slot_overhead = MAX(sync->ull.ticks_active_to_start,
+					  sync->ull.ticks_prepare_to_start);
 	} else {
 		ticks_slot_overhead = 0;
 	}
@@ -419,7 +419,7 @@ uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 			   ticks_anchor, 0,
 			   HAL_TICKER_US_TO_TICKS(interval_us),
 			   HAL_TICKER_REMAINDER(interval_us), TICKER_NULL_LAZY,
-			   (sync->evt.ticks_slot + ticks_slot_overhead),
+			   (sync->ull.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, sync,
 			   ull_ticker_status_give, (void *)&ret_cb);
 	ret = ull_ticker_status_take(ret, &ret_cb);
@@ -896,7 +896,7 @@ static void mfy_sync_offset_get(void *param)
 	uint8_t id;
 
 	lll_sync = adv->lll.sync;
-	sync = (void *)HDR_LLL2EVT(lll_sync);
+	sync = HDR_LLL2ULL(lll_sync);
 	ticker_id = TICKER_ID_ADV_SYNC_BASE + sync_handle_get(sync);
 
 	id = TICKER_NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -9,7 +9,6 @@ struct lll_df_adv_cfg;
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 
 struct ll_adv_set {
-	struct evt_hdr evt;
 	struct ull_hdr ull;
 	struct lll_adv lll;
 
@@ -52,7 +51,6 @@ struct ll_adv_set {
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 struct ll_adv_aux_set {
-	struct evt_hdr     evt;
 	struct ull_hdr     ull;
 	struct lll_adv_aux lll;
 
@@ -62,7 +60,6 @@ struct ll_adv_aux_set {
 };
 
 struct ll_adv_sync_set {
-	struct evt_hdr      evt;
 	struct ull_hdr      ull;
 	struct lll_adv_sync lll;
 
@@ -73,7 +70,6 @@ struct ll_adv_sync_set {
 };
 
 struct ll_adv_iso {
-	struct evt_hdr        evt;
 	struct ull_hdr        ull;
 	struct lll_adv_iso    lll;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -181,10 +181,14 @@ void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis)
 
 void ull_conn_iso_done(struct node_rx_event_done *done)
 {
-	struct lll_conn_iso_group *lll = (void *)HDR_ULL2LLL(done->param);
-	struct ll_conn_iso_group *cig = (void *)HDR_LLL2EVT(lll);
+	struct lll_conn_iso_group *lll;
+	struct ll_conn_iso_group *cig;
 	uint32_t ticks_drift_minus;
 	uint32_t ticks_drift_plus;
+
+	/* Get reference to ULL context */
+	cig = CONTAINER_OF(done->param, struct ll_conn_iso_group, ull);
+	lll = &cig->lll;
 
 	/* Skip if CIG terminated by local host */
 	if (unlikely(lll->handle == 0xFFFF)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -24,7 +24,6 @@ struct ll_conn_iso_stream {
 };
 
 struct ll_conn_iso_group {
-	struct evt_hdr            evt;
 	struct ull_hdr            ull;
 	struct lll_conn_iso_group lll;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -190,7 +190,7 @@ struct ll_conn {
 		uint8_t req;
 		uint8_t ack;
 		uint8_t reason_own;
-		uint8_t reason_peer;
+		uint8_t reason_final;
 		/* node rx type with memory aligned storage for terminate
 		 * reason.
 		 * HCI will reference the value using the pdu member of

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -31,7 +31,6 @@ enum llcp {
 };
 
 struct ll_conn {
-	struct evt_hdr  evt;
 	struct ull_hdr  ull;
 	struct lll_conn lll;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -228,7 +228,7 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	sync = (void *)HDR_LLL2EVT(lll_sync);
+	sync = HDR_LLL2ULL(lll_sync);
 
 	/* If df_cfg is NULL, then the HCI_LE_Set_Connectionless_CTE_Transmit_-
 	 * Parameters command was not issued before.

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -27,6 +27,7 @@ static inline uint8_t ull_ref_dec(struct ull_hdr *hdr)
 
 static inline void ull_hdr_init(struct ull_hdr *hdr)
 {
+	hdr->ref = 0U;
 	hdr->disabled_cb = hdr->disabled_param = NULL;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -264,7 +264,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_feature.features_peer = 0;
 	conn->llcp_version.req = conn->llcp_version.ack = 0;
 	conn->llcp_version.tx = conn->llcp_version.rx = 0U;
-	conn->llcp_terminate.reason_peer = 0U;
+	conn->llcp_terminate.reason_final = 0U;
 	/* NOTE: use allocated link for generating dedicated
 	 * terminate ind rx node
 	 */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -855,6 +855,7 @@ static void ticker_op_ext_stop_cb(uint32_t status, void *param)
 		uint32_t ret;
 
 		LL_ASSERT(!hdr->disabled_cb);
+
 		hdr->disabled_param = mfy.param;
 		hdr->disabled_cb = ext_disabled_cb;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -5,7 +5,6 @@
  */
 
 struct ll_scan_set {
-	struct evt_hdr  evt;
 	struct ull_hdr  ull;
 	struct lll_scan lll;
 
@@ -39,7 +38,6 @@ struct ll_scan_set {
 };
 
 struct ll_scan_aux_set {
-	struct evt_hdr      evt;
 	struct ull_hdr      ull;
 	struct lll_scan_aux lll;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -328,18 +328,18 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #endif
 
 	/* TODO: active_to_start feature port */
-	conn->evt.ticks_active_to_start = 0U;
-	conn->evt.ticks_xtal_to_start =
+	conn->ull.ticks_active_to_start = 0U;
+	conn->ull.ticks_prepare_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	conn->evt.ticks_preempt_to_start =
+	conn->ull.ticks_preempt_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-	conn->evt.ticks_slot =
+	conn->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
 				       328 + EVENT_IFS_US + 328);
 
-	ticks_slot_offset = MAX(conn->evt.ticks_active_to_start,
-				conn->evt.ticks_xtal_to_start);
+	ticks_slot_offset = MAX(conn->ull.ticks_active_to_start,
+				conn->ull.ticks_prepare_to_start);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
@@ -370,7 +370,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	if (lll_aux) {
 		struct ll_adv_aux_set *aux;
 
-		aux = (void *)HDR_LLL2EVT(lll_aux);
+		aux = HDR_LLL2ULL(lll_aux);
 
 		ticker_id_adv = TICKER_ID_ADV_AUX_BASE +
 				ull_adv_aux_handle_get(aux);
@@ -411,7 +411,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 				     HAL_TICKER_US_TO_TICKS(conn_interval_us),
 				     HAL_TICKER_REMAINDER(conn_interval_us),
 				     TICKER_NULL_LAZY,
-				     (conn->evt.ticks_slot +
+				     (conn->ull.ticks_slot +
 				      ticks_slot_overhead),
 				     ull_slave_ticker_cb, conn, ticker_op_cb,
 				     (void *)__LINE__);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -223,7 +223,7 @@ uint8_t ull_sync_iso_handle_get(struct ll_sync_iso *sync)
 
 uint8_t ull_sync_iso_lll_handle_get(struct lll_sync_iso *lll)
 {
-	return ull_sync_handle_get((void *)HDR_LLL2EVT(lll));
+	return ull_sync_handle_get(HDR_LLL2ULL(lll));
 }
 
 void ull_sync_iso_release(struct ll_sync_iso *sync_iso)

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -13,7 +13,6 @@ struct ll_sync_iso;
 #endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 struct ll_sync_set {
-	struct evt_hdr evt;
 	struct ull_hdr ull;
 	struct lll_sync lll;
 
@@ -56,7 +55,6 @@ struct node_rx_sync {
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)
 struct ll_sync_iso {
-	struct evt_hdr evt;
 	struct ull_hdr ull;
 	struct lll_sync_iso lll;
 


### PR DESCRIPTION
Avoid using sizeof to access ULL and LLL struct members.
Based on the alignment requirements of structures, due to
padding between structure members, use of sizeof of previous
struct member to access next struct member is incorrect.

Continue to use explicitly stored parent pointer to access
ULL context. Combine event header and ULL header so that
the parent pointer point directly to the combined ULL
struct.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>