### PR TITLE
Bluetooth: controller: Remove duplicate radio_isr_set call

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -174,7 +174,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_pkt_tx_set(pdu);
 
 	/* TODO: chaining */
-	radio_isr_set(lll_isr_done, lll);
 	radio_isr_set(isr_done, lll);
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)


### PR DESCRIPTION
Remove the redundant radio_isr_set function call.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>