### PR TITLE
[Backport v2.5-branch] Bluetooth: controller: backport bug fixes post v.2.5 release

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -138,7 +138,6 @@ struct ull_hdr {
 
 struct lll_hdr {
 	void *parent;
-	uint8_t is_stop:1;
 };
 
 struct lll_prepare_param {
@@ -341,17 +340,6 @@ static inline void lll_hdr_init(void *lll, void *parent)
 	struct lll_hdr *hdr = lll;
 
 	hdr->parent = parent;
-	hdr->is_stop = 0U;
-}
-
-static inline int lll_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-	int ret = !!hdr->is_stop;
-
-	hdr->is_stop = 1U;
-
-	return ret;
 }
 
 int lll_init(void);

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -59,6 +59,7 @@ struct lll_conn {
 	union {
 		struct {
 			uint8_t initiated:1;
+			uint8_t cancelled:1;
 		} master;
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -46,6 +46,7 @@ struct lll_conn {
 	uint8_t data_chan_count:6;
 	uint8_t data_chan_sel:1;
 	uint8_t role:1;
+	uint8_t initiated:1;
 
 	union {
 		struct {
@@ -59,6 +60,7 @@ struct lll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 	struct {
 		uint8_t  latency_enabled:1;
+
 		uint32_t window_widening_periodic_us;
 		uint32_t window_widening_max_us;
 		uint32_t window_widening_prepare_us;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -46,7 +46,6 @@ struct lll_conn {
 	uint8_t data_chan_count:6;
 	uint8_t data_chan_sel:1;
 	uint8_t role:1;
-	uint8_t initiated:1;
 
 	union {
 		struct {
@@ -57,18 +56,24 @@ struct lll_conn {
 		uint16_t data_chan_id;
 	};
 
+	union {
+		struct {
+			uint8_t initiated:1;
+		} master;
 #if defined(CONFIG_BT_PERIPHERAL)
-	struct {
-		uint8_t  latency_enabled:1;
+		struct {
+			uint8_t  initiated:1;
+			uint8_t  latency_enabled:1;
 
-		uint32_t window_widening_periodic_us;
-		uint32_t window_widening_max_us;
-		uint32_t window_widening_prepare_us;
-		uint32_t window_widening_event_us;
-		uint32_t window_size_prepare_us;
-		uint32_t window_size_event_us;
-	} slave;
+			uint32_t window_widening_periodic_us;
+			uint32_t window_widening_max_us;
+			uint32_t window_widening_prepare_us;
+			uint32_t window_widening_event_us;
+			uint32_t window_size_prepare_us;
+			uint32_t window_size_event_us;
+		} slave;
 #endif /* CONFIG_BT_PERIPHERAL */
+	};
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	uint16_t max_tx_octets;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -12,7 +12,7 @@ struct lll_scan {
 	 *       check ull_conn_setup how it access the connection LLL
 	 *       context.
 	 */
-	struct lll_conn *conn;
+	struct lll_conn *volatile conn;
 
 	uint8_t  adv_addr[BDADDR_SIZE];
 	uint32_t conn_win_offset_us;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -8,8 +8,13 @@ struct lll_scan {
 	struct lll_hdr hdr;
 
 #if defined(CONFIG_BT_CENTRAL)
-	/* NOTE: conn context has to be after lll_hdr */
+	/* NOTE: conn context SHALL be after lll_hdr,
+	 *       check ull_conn_setup how it access the connection LLL
+	 *       context.
+	 */
 	struct lll_conn *conn;
+
+	uint8_t  adv_addr[BDADDR_SIZE];
 	uint32_t conn_win_offset_us;
 	uint16_t conn_timeout;
 #endif /* CONFIG_BT_CENTRAL */
@@ -17,9 +22,11 @@ struct lll_scan {
 	uint8_t  state:1;
 	uint8_t  chan:2;
 	uint8_t  filter_policy:2;
-	uint8_t  adv_addr_type:1;
-	uint8_t  init_addr_type:1;
 	uint8_t  type:1;
+	uint8_t  init_addr_type:1;
+#if defined(CONFIG_BT_CENTRAL)
+	uint8_t  adv_addr_type:1;
+#endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	uint16_t duration_reload;
@@ -35,7 +42,6 @@ struct lll_scan {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	uint8_t  init_addr[BDADDR_SIZE];
-	uint8_t  adv_addr[BDADDR_SIZE];
 
 	uint16_t interval;
 	uint32_t ticks_window;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1031,8 +1031,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
 					     devmatch_ok, &rl_idx) &&
-		   lll->conn &&
-		   !lll->conn->initiated) {
+		   lll->conn) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -440,10 +440,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	lll = p->param;
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll_is_stop(lll))) {
+	if (unlikely(lll->conn && lll->conn->initiated)) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -454,6 +455,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		DEBUG_RADIO_CLOSE_A(0);
 		return 0;
 	}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	radio_reset();
 
@@ -1033,7 +1035,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
-		int ret;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -1062,9 +1063,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -444,7 +444,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->initiated)) {
+	if (unlikely(lll->conn && lll->conn->slave.initiated)) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -1062,7 +1062,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->slave.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1029,7 +1029,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
 					     devmatch_ok, &rl_idx) &&
-		   lll->conn) {
+		   lll->conn &&
+		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		int ret;
@@ -1063,6 +1064,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
@@ -80,7 +80,10 @@ struct lll_adv {
 	struct lll_hdr hdr;
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	/* NOTE: conn context has to be after lll_hdr */
+	/* NOTE: conn context SHALL be after lll_hdr,
+	 *       check ull_conn_setup how it access the connection LLL
+	 *       context.
+	 */
 	struct lll_conn *conn;
 	uint8_t is_hdcd:1;
 #endif /* CONFIG_BT_PERIPHERAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -572,8 +572,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
 					     devmatch_ok, &rl_idx) &&
-		   lll->conn &&
-		   !lll->conn->initiated) {
+		   lll->conn) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		struct pdu_adv *pdu_tx;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -27,6 +27,7 @@
 #include "lll_chan.h"
 #include "lll_adv.h"
 #include "lll_adv_aux.h"
+#include "lll_conn.h"
 #include "lll_filter.h"
 
 #include "lll_internal.h"
@@ -54,7 +55,9 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rssi_ready);
+#if defined(CONFIG_BT_PERIPHERAL)
 static void isr_tx_connect_rsp(void *param);
+#endif /* CONFIG_BT_PERIPHERAL */
 
 static struct pdu_adv *init_connect_rsp_pdu(void)
 {
@@ -101,6 +104,7 @@ static struct pdu_adv *init_connect_rsp_pdu(void)
 	return pdu;
 }
 
+#if defined(CONFIG_BT_PERIPHERAL)
 static struct pdu_adv *update_connect_rsp_pdu(struct pdu_adv *pdu_ci)
 {
 	struct pdu_adv_com_ext_adv *cr_com_hdr;
@@ -125,6 +129,7 @@ static struct pdu_adv *update_connect_rsp_pdu(struct pdu_adv *pdu_ci)
 
 	return pdu_cr;
 }
+#endif /* CONFIG_BT_PERIPHERAL */
 
 int lll_adv_aux_init(void)
 {
@@ -483,7 +488,6 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 	struct pdu_adv *pdu_adv;
 	struct pdu_adv *pdu_aux;
 	struct pdu_adv *pdu_rx;
-	struct pdu_adv *pdu_tx;
 	struct lll_adv *lll;
 	uint8_t *tgt_addr;
 	uint8_t tx_addr;
@@ -561,13 +565,18 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 		return 0;
+
+#if defined(CONFIG_BT_PERIPHERAL)
 	} else if ((pdu_rx->type == PDU_ADV_TYPE_AUX_CONNECT_REQ) &&
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
-					     devmatch_ok, &rl_idx)) {
+					     devmatch_ok, &rl_idx) &&
+		   lll->conn &&
+		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
+		struct pdu_adv *pdu_tx;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -632,11 +641,13 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		}
 
 		return 0;
+#endif /* CONFIG_BT_PERIPHERAL */
 	}
 
 	return -EINVAL;
 }
 
+#if defined(CONFIG_BT_PERIPHERAL)
 static void isr_tx_connect_rsp(void *param)
 {
 	struct node_rx_ftr *ftr;
@@ -673,9 +684,12 @@ static void isr_tx_connect_rsp(void *param)
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 	}
 
 	/* Clear radio status and events */
 	lll_isr_status_reset();
 	lll_isr_cleanup(lll);
 }
+#endif /* CONFIG_BT_PERIPHERAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -680,7 +680,7 @@ static void isr_tx_connect_rsp(void *param)
 
 	if (is_done) {
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->slave.initiated = 1;
 	}
 
 	/* Clear radio status and events */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -654,7 +654,6 @@ static void isr_tx_connect_rsp(void *param)
 	struct node_rx_pdu *rx;
 	struct lll_adv *lll;
 	bool is_done;
-	int ret;
 
 	rx = param;
 	ftr = &(rx->hdr.rx_ftr);
@@ -682,9 +681,6 @@ static void isr_tx_connect_rsp(void *param)
 
 	if (is_done) {
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -14,12 +14,6 @@ int lll_is_abort_cb(void *next, int prio, void *curr,
 			 lll_prepare_cb_t *resume_cb, int *resume_prio);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
-static inline int lll_is_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-
-	return !!hdr->is_stop;
-}
 uint32_t lll_evt_offset_get(struct evt_hdr *evt);
 uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 		uint32_t ticks_at_event);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -768,7 +768,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if ((lll->conn) &&
+	} else if (lll->conn && !lll->conn->initiated &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;
@@ -924,6 +924,8 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -138,7 +138,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->initiated)) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -371,7 +371,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 		} else if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
-			   lll->conn && lll->conn->initiated) {
+			   lll->conn && lll->conn->master.initiated) {
 			while (!radio_has_disabled()) {
 				cpu_sleep();
 			}
@@ -930,7 +930,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		 */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -777,7 +777,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if (lll->conn && !lll->conn->initiated &&
+	} else if (lll->conn &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -140,7 +140,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->master.initiated)) {
+	if (unlikely(lll->conn &&
+		     (lll->conn->master.initiated ||
+		      lll->conn->master.cancelled))) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -779,7 +781,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if (lll->conn &&
+	} else if (lll->conn && !lll->conn->master.cancelled &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -66,10 +66,12 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rl_idx, uint8_t rssi_ready);
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx);
 static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 					    struct pdu_adv *pdu, uint8_t rl_idx);
+#endif /* CONFIG_BT_CENTRAL */
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,
 				       bool *dir_report);
@@ -1104,6 +1106,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	return -ECANCELED;
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx)
 {
@@ -1133,6 +1136,7 @@ static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 	return ((lll->adv_addr_type == pdu->tx_addr) &&
 		!memcmp(lll->adv_addr, &pdu->adv_ind.addr[0], BDADDR_SIZE));
 }
+#endif /* CONFIG_BT_CENTRAL */
 
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -894,7 +894,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
 		   isr_rx_ci_check(lll, pdu_adv, pdu_rx, devmatch_ok,
 				   &rl_idx) &&
-		   lll->conn) {
+		   lll->conn &&
+		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		int ret;
@@ -927,6 +928,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -326,10 +326,11 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	DEBUG_RADIO_START_A(1);
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll_is_stop(lll)) {
+	if (lll->conn && lll->conn->initiated) {
 		int err;
 
 		err = lll_clk_off();
@@ -340,6 +341,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		DEBUG_RADIO_START_A(0);
 		return 0;
 	}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
@@ -898,7 +900,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   !lll->conn->initiated) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
-		int ret;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -926,9 +927,6 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		}
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -330,7 +330,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll->conn && lll->conn->initiated) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_clk_off();
@@ -926,7 +926,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		}
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -896,8 +896,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
 		   isr_rx_ci_check(lll, pdu_adv, pdu_rx, devmatch_ok,
 				   &rl_idx) &&
-		   lll->conn &&
-		   !lll->conn->initiated) {
+		   lll->conn) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_internal.h
@@ -14,13 +14,6 @@ int lll_is_abort_cb(void *next, int prio, void *curr,
 			 lll_prepare_cb_t *resume_cb, int *resume_prio);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
 
-static inline int lll_is_stop(void *lll)
-{
-	struct lll_hdr *hdr = lll;
-
-	return !!hdr->is_stop;
-}
-
 int lll_clk_on(void);
 int lll_clk_on_wait(void);
 int lll_clk_off(void);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -673,7 +673,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if (lll->conn && !lll->conn->initiated &&
+	} else if (lll->conn &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -127,10 +127,11 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	DEBUG_RADIO_START_O(1);
 
+#if defined(CONFIG_BT_CENTRAL)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll_is_stop(lll)) {
+	if (lll->conn && lll->conn->initiated) {
 		int err;
 
 		err = lll_clk_off();
@@ -141,6 +142,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		DEBUG_RADIO_START_O(0);
 		return 0;
 	}
+#endif /* CONFIG_BT_CENTRAL */
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
@@ -685,7 +687,6 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		bt_addr_t *lrpa;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-		int ret;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
 			rx = ull_pdu_rx_alloc_peek(4);
@@ -825,9 +826,6 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		 */
 
 		/* Stop further LLL radio events */
-		ret = lll_stop(lll);
-		LL_ASSERT(!ret);
-
 		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -671,7 +671,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if ((lll->conn) &&
+	} else if (lll->conn && !lll->conn->initiated &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;
@@ -827,6 +827,8 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);
 		LL_ASSERT(!ret);
+
+		lll->conn->initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -131,7 +131,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll->conn && lll->conn->initiated) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_clk_off();
@@ -826,7 +826,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		 */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -856,6 +856,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 		/* FIXME: BEGIN: Move to ULL? */
 		conn_lll->role = 1;
+		conn_lll->initiated = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
 		conn_lll->event_counter = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -856,7 +856,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 		/* FIXME: BEGIN: Move to ULL? */
 		conn_lll->role = 1;
-		conn_lll->initiated = 0;
+		conn_lll->slave.initiated = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
 		conn_lll->event_counter = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -877,6 +877,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->procedure_expire = 0;
 
 		conn->common.fex_valid = 0;
+		conn->common.txn_lock = 0;
 		conn->slave.latency_cancel = 0;
 
 		conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -779,6 +779,9 @@ void ull_conn_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	ftr = &(rx->rx_ftr);
 
+	/* NOTE: LLL conn context SHALL be after lll_hdr in
+	 *       struct lll_adv and struct lll_scan.
+	 */
 	lll = *((struct lll_conn **)((uint8_t *)ftr->param +
 				     sizeof(struct lll_hdr)));
 	switch (lll->role) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5157,11 +5157,12 @@ static int phy_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	struct pdu_data_llctrl_phy_req *p;
 	struct pdu_data *pdu_ctrl_tx;
 	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	/* Wait for peer master to complete the procedure */
@@ -5537,9 +5538,18 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 			uint8_t phy_tx_time[8] = {PHY_1M, PHY_1M, PHY_2M,
 						  PHY_1M, PHY_CODED, PHY_CODED,
 						  PHY_CODED, PHY_CODED};
-			struct lll_conn *lll = &conn->lll;
+			struct lll_conn *lll;
 			uint8_t phys;
 
+			/* Reset the transaction lock when PHY update response
+			 * sent by peripheral is acknowledged.
+			 */
+			if (pdu_tx->llctrl.opcode ==
+			    PDU_DATA_LLCTRL_TYPE_PHY_RSP) {
+				conn->common.txn_lock = 0U;
+			}
+
+			lll = &conn->lll;
 			phys = conn->llcp_phy.tx | lll->phy_tx;
 			lll->phy_tx_time = phy_tx_time[phys];
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -6121,7 +6121,12 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn_upd_curr = conn;
 			}
 		} else {
-			LL_ASSERT(0);
+			/* Ignore duplicate request as peripheral is busy
+			 * processing the previously initiated connection
+			 * update request procedure.
+			 */
+			/* Mark for buffer for release */
+			(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 		}
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5125,13 +5125,14 @@ send_length_resp:
 #if defined(CONFIG_BT_CTLR_LE_PING)
 static int ping_resp_send(struct ll_conn *conn, struct node_rx_pdu *rx)
 {
-	struct node_tx *tx;
 	struct pdu_data *pdu_tx;
+	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu_tx = (void *)tx->pdu;
@@ -5362,6 +5363,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	break;
 
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+	case PDU_DATA_LLCTRL_TYPE_PING_RSP:
 	case PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP:
 		/* Reset the transaction lock */
 		conn->common.txn_lock = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4332,14 +4332,15 @@ static int feature_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 			    struct pdu_data *pdu_rx)
 {
 	struct pdu_data_llctrl_feature_req *req;
-	struct node_tx *tx;
 	struct pdu_data *pdu_tx;
+	struct node_tx *tx;
 	uint32_t feat;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	/* AND the feature set to get Feature USED */
@@ -5349,6 +5350,11 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		conn_cleanup(conn, reason);
 	}
 	break;
+
+	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+		/* Reset the transaction lock */
+		conn->common.txn_lock = 0U;
+		break;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4278,13 +4278,14 @@ static inline bool ctrl_is_unexpected(struct ll_conn *conn, uint8_t opcode)
 static int unknown_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 			    uint8_t type)
 {
-	struct node_tx *tx;
 	struct pdu_data *pdu;
+	struct node_tx *tx;
+	int err;
 
-	/* acquire ctrl tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu = (void *)tx->pdu;
@@ -5352,6 +5353,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	break;
 
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
+	case PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP:
 		/* Reset the transaction lock */
 		conn->common.txn_lock = 0U;
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4522,11 +4522,12 @@ static int reject_ext_ind_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 {
 	struct pdu_data *pdu_ctrl_tx;
 	struct node_tx *tx;
+	int err;
 
-	/* acquire tx mem */
-	tx = mem_acquire(&mem_conn_tx_ctrl.free);
+	/* Check transaction violation and get free ctrl tx PDU */
+	tx = ctrl_tx_rsp_mem_acquire(conn, rx, &err);
 	if (!tx) {
-		return -ENOBUFS;
+		return err;
 	}
 
 	pdu_ctrl_tx = (void *)tx->pdu;
@@ -5430,6 +5431,12 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
 		if (pdu_tx->llctrl.reject_ext_ind.reject_opcode !=
 		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
+			/* Reset the transaction lock set by connection
+			 * parameter request and PHY update procedure when
+			 * sending the Reject Ext Ind PDU.
+			 */
+			conn->common.txn_lock = 0U;
+
 			break;
 		}
 		__fallthrough;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -59,6 +59,7 @@ struct ll_conn {
 	union {
 		struct {
 			uint8_t fex_valid:1;
+			uint8_t txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */
@@ -67,6 +68,7 @@ struct ll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
 			uint8_t  fex_valid:1;
+			uint8_t  txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t  is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */
@@ -87,6 +89,7 @@ struct ll_conn {
 #if defined(CONFIG_BT_CENTRAL)
 		struct {
 			uint8_t fex_valid:1;
+			uint8_t txn_lock:1;
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -211,6 +211,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
 	conn_lll->master.initiated = 0;
+	conn_lll->master.cancelled = 0;
 	/* FIXME: END: Move to ULL? */
 #if defined(CONFIG_BT_CTLR_CONN_META)
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));
@@ -384,8 +385,28 @@ uint8_t ll_connect_disable(void **rx)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+	/* Check if initiator active */
 	conn_lll = scan->lll.conn;
 	if (!conn_lll) {
+		/* Scanning not associated with initiation of a connection or
+		 * connection setup already complete (was set to NULL in
+		 * ull_master_setup), but HCI event not processed by host.
+		 */
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	/* Indicate to LLL that a cancellation is requested */
+	conn_lll->master.cancelled = 1U;
+	cpu_dmb();
+
+	/* Check if connection was established under race condition, i.e.
+	 * before the cancelled flag was set.
+	 */
+	conn_lll = scan->lll.conn;
+	if (!conn_lll) {
+		/* Connection setup completed on race condition with cancelled
+		 * flag, before it was set.
+		 */
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -210,7 +210,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->data_chan_sel = 0;
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
-	conn_lll->initiated = 0;
+	conn_lll->master.initiated = 0;
 	/* FIXME: END: Move to ULL? */
 #if defined(CONFIG_BT_CTLR_CONN_META)
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -241,6 +241,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 	conn->common.fex_valid = 0U;
+	conn->common.txn_lock = 0U;
 	conn->master.terminate_ack = 0U;
 
 	conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -210,6 +210,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->data_chan_sel = 0;
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
+	conn_lll->initiated = 0;
 	/* FIXME: END: Move to ULL? */
 #if defined(CONFIG_BT_CTLR_CONN_META)
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -86,7 +86,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	lll->interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	if ((lll->data_chan_count < 2) || (lll->data_chan_hop < 5) ||
 	    (lll->data_chan_hop > 16) || !lll->interval) {
-		lll->initiated = 0U;
+		lll->slave.initiated = 0U;
 
 		/* Mark for buffer for release */
 		rx->type = NODE_RX_TYPE_RELEASE;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -59,17 +59,16 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	uint8_t peer_addr[BDADDR_SIZE];
 	uint32_t ticks_slot_overhead;
 	uint32_t ticks_slot_offset;
+	uint32_t ready_delay_us;
 	struct pdu_adv *pdu_adv;
 	struct ll_adv_set *adv;
-	struct node_rx_cc *cc;
-	struct ll_conn *conn;
-	uint32_t ready_delay_us;
 	uint32_t ticker_status;
 	uint8_t peer_addr_type;
-	uint16_t win_offset;
 	uint16_t win_delay_us;
+	struct node_rx_cc *cc;
+	struct ll_conn *conn;
+	uint16_t win_offset;
 	uint16_t timeout;
-	uint16_t interval;
 	uint8_t chan_sel;
 
 	adv = ((struct lll_adv *)ftr->param)->hdr.parent;
@@ -84,8 +83,9 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	lll->data_chan_count = util_ones_count_get(&lll->data_chan_map[0],
 			       sizeof(lll->data_chan_map));
 	lll->data_chan_hop = pdu_adv->connect_ind.hop;
+	lll->interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	if ((lll->data_chan_count < 2) || (lll->data_chan_hop < 5) ||
-	    (lll->data_chan_hop > 16)) {
+	    (lll->data_chan_hop > 16) || !lll->interval) {
 		lll->initiated = 0U;
 
 		/* Mark for buffer for release */
@@ -120,12 +120,10 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 
 	((struct lll_adv *)ftr->param)->conn = NULL;
 
-	interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
-	lll->interval = interval;
 	lll->latency = sys_le16_to_cpu(pdu_adv->connect_ind.latency);
 
 	win_offset = sys_le16_to_cpu(pdu_adv->connect_ind.win_offset);
-	conn_interval_us = interval * CONN_INT_UNIT_US;
+	conn_interval_us = lll->interval * CONN_INT_UNIT_US;
 
 	if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -83,11 +83,38 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	       sizeof(lll->data_chan_map));
 	lll->data_chan_count = util_ones_count_get(&lll->data_chan_map[0],
 			       sizeof(lll->data_chan_map));
-	if (lll->data_chan_count < 2) {
-		return;
-	}
 	lll->data_chan_hop = pdu_adv->connect_ind.hop;
-	if ((lll->data_chan_hop < 5) || (lll->data_chan_hop > 16)) {
+	if ((lll->data_chan_count < 2) || (lll->data_chan_hop < 5) ||
+	    (lll->data_chan_hop > 16)) {
+		lll->initiated = 0U;
+
+		/* Mark for buffer for release */
+		rx->type = NODE_RX_TYPE_RELEASE;
+
+		/* Release CSA#2 related node rx too */
+		if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
+			struct node_rx_pdu *rx_csa;
+
+			/* pick the rx node instance stored within the
+			 * connection rx node.
+			 */
+			rx_csa = (void *)ftr->extra;
+
+			/* Enqueue the connection event to be release */
+			ll_rx_put(link, rx);
+
+			/* Use the rx node for CSA event */
+			rx = (void *)rx_csa;
+			link = rx->link;
+
+			/* Mark for buffer for release */
+			rx->type = NODE_RX_TYPE_RELEASE;
+		}
+
+		/* Enqueue connection or CSA event to be release */
+		ll_rx_put(link, rx);
+		ll_rx_sched();
+
 		return;
 	}
 


### PR DESCRIPTION
- Avoid race between ULL and LLL when initiating
- Replace development assert in connection parameter request procedure
- Fix channel map and interval value checks when accepting connection indication
- Fix regression in control tx PDU queue handling
- Fix Feature Exchange procedure to check transaction violations.
- Fix race in create connection cancel

Fixes #33883.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>