### PR TITLE
soc: stm32: Explicitly disable CORTEX_M_SYSTICK if LPTIM enabled

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -8,8 +8,7 @@
 if SOC_FAMILY_STM32
 
 config CORTEX_M_SYSTICK
-	bool
-	depends on !STM32_LPTIM_TIMER
+	default n if STM32_LPTIM_TIMER
 
 # set the tick per sec as a divider of the LPTIM clock source
 config SYS_CLOCK_TICKS_PER_SEC


### PR DESCRIPTION
CORTEX_M_SYSTICK should be disabled if LPTIM is selected.
Current implementation is not efficient to do so.
Rework the way the dependency is stated.

Fixes #33342

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>