### PR TITLE
cmake: zephyr_file() now accepts BOARD and BOARD_REVISION as argument

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -224,6 +224,8 @@ if(NOT (REVISION_SEPARATOR_INDEX EQUAL -1))
   string(SUBSTRING ${BOARD} 0 ${REVISION_SEPARATOR_INDEX} BOARD)
 endif()
 
+zephyr_boilerplate_watch(BOARD)
+
 set(BOARD_MESSAGE "Board: ${BOARD}")
 
 if(DEFINED ENV{ZEPHYR_BOARD_ALIASES})
@@ -292,7 +294,7 @@ if(DEFINED BOARD_REVISION)
 endif()
 
 # Check that SHIELD has not changed.
-zephyr_check_cache(SHIELD)
+zephyr_check_cache(SHIELD WATCH)
 
 if(SHIELD)
   set(BOARD_MESSAGE "${BOARD_MESSAGE}, Shield(s): ${SHIELD}")

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -2026,6 +2026,8 @@ endfunction()
 # variable: Name of <variable> to check and set, for example BOARD.
 # REQUIRED: Optional flag. If specified, then an unset <variable> will be
 #           treated as an error.
+# WATCH: Optional flag. If specified, watch the variable and print a warning if
+#        the variable is later being changed.
 #
 # Details:
 #   <variable> can be set by 3 sources.
@@ -2056,7 +2058,7 @@ endfunction()
 #   <variable> the build directory must be cleaned.
 #
 function(zephyr_check_cache variable)
-  cmake_parse_arguments(CACHE_VAR "REQUIRED" "" "" ${ARGN})
+  cmake_parse_arguments(CACHE_VAR "REQUIRED;WATCH" "" "" ${ARGN})
   string(TOLOWER ${variable} variable_text)
   string(REPLACE "_" " " variable_text ${variable_text})
 
@@ -2120,8 +2122,10 @@ function(zephyr_check_cache variable)
   set(${variable} ${${variable}} PARENT_SCOPE)
   set(CACHED_${variable} ${${variable}} CACHE STRING "Selected ${variable_text}")
 
-  # The variable is now set to its final value.
-  zephyr_boilerplate_watch(${variable})
+  if(CACHE_VAR_WATCH)
+    # The variable is now set to its final value.
+    zephyr_boilerplate_watch(${variable})
+  endif()
 endfunction(zephyr_check_cache variable)
 
 


### PR DESCRIPTION
With the introduction of #32556 changing the BOARD now prints a warning.

Zephyr provides `zephyr_file()` to look up overlays and Kconfig
fragments for a specified board, and it used to be possible and safe to
do:
```
function(my_func)
  set(BOARD <local_scope_board>)
  zephyr_file(CONF_FILES ...)
endfunction(my_func)
```

As the BOARD inside `my_func` is locally scoped, this is safe to do.
But with introduction of #32556 a warning is now printed when running
CMake.

Therefore `zephyr_file` has been extended to allow for optional BOARD
and BOARD_REVISION arguments.
If BOARD is not given as argument the current BOARD in the build system
will be used.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>