### PR TITLE
drivers: entropy: stm32: fix discarding of false negative rng values

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -127,6 +127,7 @@ static int random_byte_get(void)
 		} else {
 			retval = LL_RNG_ReadRandData32(
 						    entropy_stm32_rng_data.rng);
+			retval &= 0xFF;
 		}
 	}
 


### PR DESCRIPTION
Function random_byte_get() returns only the least significant byte of
the 32-bit random datum, as this is the used value, so avoiding that
higher numbers are interpreted as negative error codes and their value
is not discarded.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>