### PR TITLE
drivers: watchdog: npcx: mask the WDRST_STS when accessing T0CSR

### DIFF
--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -88,7 +88,8 @@ static inline void wdt_t0out_reload(const struct device *dev)
 
 	key = irq_lock();
 	/* Reload and restart T0 timer */
-	inst->T0CSR |= BIT(NPCX_T0CSR_RST);
+	inst->T0CSR = (inst->T0CSR & ~BIT(NPCX_T0CSR_WDRST_STS)) |
+		      BIT(NPCX_T0CSR_RST);
 	/* Wait for timer is loaded and restart */
 	while (IS_BIT_SET(inst->T0CSR, NPCX_T0CSR_RST))
 		;
@@ -312,8 +313,8 @@ static int wdt_npcx_init(const struct device *dev)
 	inst->TWCFG = BIT(NPCX_TWCFG_WDSDME) | BIT(NPCX_TWCFG_WDCT0I);
 
 	/* Disable early touch functionality */
-	inst->T0CSR |= BIT(NPCX_T0CSR_TESDIS);
-
+	inst->T0CSR = (inst->T0CSR & ~BIT(NPCX_T0CSR_WDRST_STS)) |
+		      BIT(NPCX_T0CSR_TESDIS);
 	/*
 	 * Plan clock frequency of T0 timer and watchdog timer as below:
 	 * - T0 Timer freq is LFCLK/32 Hz


### PR DESCRIPTION
Register T0CSR bit 4 is WDRST_STS which is used to check whether the
chip has watchdog reset from the last power-up or vcc1_rst. WDRST_STS
hardware is design to write one clear. For the original
read-modify-write, it will reset the WDRST_STS unexpected. Add a mask
to avoid it.