### PR TITLE
net: if: Add locking

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -627,6 +627,8 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 #if defined(CONFIG_NET_OFFLOAD)
 	return iface->if_dev->offload;
 #else
+	ARG_UNUSED(iface);
+
 	return NULL;
 #endif
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -400,6 +400,8 @@ void net_if_stats_reset(struct net_if *iface)
 			return;
 		}
 	}
+#else
+	ARG_UNUSED(iface);
 #endif
 }
 
@@ -3801,6 +3803,9 @@ static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps)
 
 	return !(net_eth_get_hw_capabilities(iface) & caps);
 #else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(caps);
+
 	return true;
 #endif
 }
@@ -3960,6 +3965,8 @@ static int promisc_mode_set(struct net_if *iface, bool enable)
 		}
 	}
 #else
+	ARG_UNUSED(enable);
+
 	return -ENOTSUP;
 #endif
 


### PR DESCRIPTION
Add locking when accessing network interface.

Fixes #33374

It is possible to implement locking / network interface for those things that affect `net_if` struct. Here we just have one global lock for the network interface manipulation. I did not implement fine grained locking here, but it is certainly possible to do. Any opinions?
