### PR TITLE
tests: exclude sam0 boards from tests that will not build on them

### DIFF
--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: spi
   tags: drivers spi
+  platform_exclude: seeeduino_xiao serpente arduino_nano_33_iot atsamr21_xpro
+    atsamd21_xpro arduino_zero adafruit_trinket_m0
 tests:
   drivers.spi.loopback:
     harness: ztest

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -1,3 +1,8 @@
+common:
+  platform_exclude: seeeduino_xiao serpente arduino_nano_33_iot atsamr21_xpro
+    adafruit_itsybitsy_m4_express atsame54_xpro atsamd21_xpro adafruit_trinket_m0
+    arduino_nano_33_iot arduino_zero atsamd21_xpro adafruit_feather_m0_basic_proto
+
 tests:
   drivers.uart.uart_async_api:
     tags: drivers


### PR DESCRIPTION
the async uart and spi loopback tests will not build on SAM0 based boards as they require dma to be configured and none of the boards do that.  So we exclude these boards from being built for these tests.