### PR TITLE
drivers: pcie: endpoint: Convert dma to use DEVICE_DT_GET

### DIFF
--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -181,13 +181,12 @@ static int iproc_pcie_pl330_dma_xfer(const struct device *dev,
 	const struct iproc_pcie_ep_config *cfg = dev->config;
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *pl330_dev;
 	uint32_t chan_id;
 	int ret = -EINVAL;
 
-	pl330_dev = device_get_binding(cfg->pl330_dev_name);
-	if (!pl330_dev) {
-		LOG_ERR("Cannot get dma controller\n");
+	if (!device_is_ready(cfg->pl330_dev)) {
+		LOG_ERR("DMA controller is not ready\n");
+		ret = -ENODEV;
 		goto out;
 	}
 
@@ -207,14 +206,14 @@ static int iproc_pcie_pl330_dma_xfer(const struct device *dev,
 		chan_id = cfg->pl330_rx_chan_id;
 	}
 
-	ret = dma_config(pl330_dev, chan_id,  &dma_cfg);
+	ret = dma_config(cfg->pl330_dev, chan_id,  &dma_cfg);
 	if (ret) {
 		LOG_ERR("DMA config failed\n");
 		goto out;
 	}
 
 	/* start DMA */
-	ret = dma_start(pl330_dev, chan_id);
+	ret = dma_start(cfg->pl330_dev, chan_id);
 	if (ret) {
 		LOG_ERR("DMA transfer failed\n");
 	}
@@ -476,7 +475,7 @@ static struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
 	.map_low_size = DT_INST_REG_SIZE_BY_NAME(0, map_lowmem),
 	.map_high_base = DT_INST_REG_ADDR_BY_NAME(0, map_highmem),
 	.map_high_size = DT_INST_REG_SIZE_BY_NAME(0, map_highmem),
-	.pl330_dev_name = DT_INST_DMAS_LABEL_BY_IDX(0, 0),
+	.pl330_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(0, 0)),
 	.pl330_tx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, txdma, channel),
 	.pl330_rx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, rxdma, channel),
 };

--- a/drivers/pcie/endpoint/pcie_ep_iproc.h
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.h
@@ -104,7 +104,7 @@ struct iproc_pcie_ep_config {
 	uint64_t map_high_base;	/* Base addr of outbound mapping at highmem */
 	uint32_t map_high_size;
 	unsigned int id;
-	const char *pl330_dev_name; /* pl330 device's "label" property */
+	const struct device *pl330_dev;
 	uint32_t pl330_tx_chan_id;  /* channel used for Device to Host write */
 	uint32_t pl330_rx_chan_id;  /* channel used for Host to Device read  */
 };


### PR DESCRIPTION
Replace device_get_binding with DEVICE_DT_GET for getting access
to the dma controller device.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>