### PR TITLE
cmake: west: do not print error if west topdir fails

### DIFF
--- a/cmake/west.cmake
+++ b/cmake/west.cmake
@@ -90,7 +90,15 @@ else()
   execute_process(
     COMMAND ${WEST} topdir
     OUTPUT_VARIABLE WEST_TOPDIR
+    ERROR_QUIET
+    RESULT_VARIABLE west_topdir_result
     OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${ZEPHYR_BASE}
     )
+
+  if(west_topdir_result)
+    # west topdir is undefined.
+    # That's fine; west is optional, so could be custom Zephyr project.
+    set(WEST WEST-NOTFOUND CACHE INTERNAL "West")
+  endif()
 endif()


### PR DESCRIPTION
`west` is an optional tool.
Although `west` is optional, a developer might be working with both west and
non-west based projects, like
- vanilla Zephyr (using west)
- downstream project (not using west)

and thus have west installed, but not always in use.

In the downstream project scenario not using west, then running CMake
will print the following error:
```
FATAL ERROR: no west workspace found from "<path>/zephyr";
"west topdir" requires one.
Things to try:
  - Change directory to somewhere inside a west workspace and retry.
  - Set ZEPHYR_BASE to a zephyr repository path in a west workspace.
  - Run "west init" to set up a workspace here.
  - Run "west init -h" for additional information.
```

This commit sets `WEST` CMake variable to `WEST-NOTFOUND` when west is
found but Zephyr is not in a west workspace (`west topdir` fails)

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>