### PR TITLE
docs: some cleanup and improvements

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: build-docs
       run: |
         source zephyr-env.sh
-        make htmldocs
+        make -C doc htmldocs
         tar cvf htmldocs.tar --directory=./doc/_build html
 
     - name: upload-build

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -79,7 +79,7 @@ jobs:
         DOC_TAG: ${{ steps.tag.outputs.TYPE }}
       run: |
         source zephyr-env.sh
-        make DOC_TAG=${DOC_TAG} htmldocs
+        make DOC_TAG=${DOC_TAG} -C doc htmldocs
 
     - name: check-warns
       run: |

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -59,7 +59,7 @@ if(${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
 endif()
 
 if(NOT DEFINED SPHINXOPTS)
-  set(SPHINXOPTS -q)
+  set(SPHINXOPTS -q -j auto)
 else()
   separate_arguments(SPHINXOPTS)
 endif()

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 # Top level makefile for documentation build
 #
 
-BUILDDIR ?= doc/_build
+BUILDDIR ?= _build
 DOC_TAG ?= development
 SPHINXOPTS ?= -q
 KCONFIG_TURBO_MODE ?= 0
@@ -22,7 +22,7 @@ htmldocs pdfdocs doxygen: configure
 # needed
 .PHONY: configure
 configure:
-	cmake -GNinja  -B${BUILDDIR} -Sdoc/ -DDOC_TAG=${DOC_TAG} \
+	cmake -GNinja -B${BUILDDIR} -S. -DDOC_TAG=${DOC_TAG} \
 		-DSPHINXOPTS=${SPHINXOPTS} \
 		-DKCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -180,13 +180,13 @@ of the build folder and run ``cmake`` and then ``ninja`` again.
 
    If you add or remove a file from the documentation, you need to re-run CMake.
 
-On Unix platforms a convenience :zephyr_file:`Makefile` at the root folder
+On Unix platforms a convenience :zephyr_file:`Makefile` at the ``doc`` folder
 of the Zephyr repository can be used to build the documentation directly from
 there:
 
 .. code-block:: console
 
-   cd ~/zephyr
+   cd ~/zephyr/doc
 
    # To generate HTML output
    make htmldocs

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1118,9 +1118,9 @@ sub top_of_kernel_tree {
 	my ($root) = @_;
 
 	my @tree_check = (
-		"LICENSE", "CODEOWNERS", "Kconfig", "Makefile",
-		"README.rst", "doc", "arch", "include", "drivers",
-		"boards", "kernel", "lib", "scripts",
+		"LICENSE", "CODEOWNERS", "Kconfig", "README.rst",
+		"doc", "arch", "include", "drivers", "boards",
+		"kernel", "lib", "scripts",
 	);
 
 	foreach my $check (@tree_check) {


### PR DESCRIPTION
Summary:
- Current Makefile is just a thin wrapper around the CMake based documentation build. Removing this Makefile makes things more consistent as CMake is used everywhere in Zephyr as of today.
- Sphinx supports parallelized build (-j) option. Setting it to `auto` makes use of all available cores. This option seems to speed up the build on multi-core machines, even though not much when Kconfig is enabled.

Quick comparison on `-j auto` usage (cpu count=12):

`KCONFIG_TURBO_MODE=0`
- `SPHINXOPTS=`:        `ninja -C doc/_build htmldocs  650.51s user 8.50s system 100% cpu 10:55.39 total`
- `SPHINXOPTS=-j auto`: `ninja -C doc/_build htmldocs  2094.90s user 62.44s system 368% cpu 9:46.23 total`

`KCONFIG_TURBO_MODE=1`:
- `SPHINXOPTS=`:        `ninja -C doc/_build htmldocs  303.29s user 4.48s system 101% cpu 5:04.46 total`
- `SPHINXOPTS=-j auto`: `ninja -C doc/_build htmldocs  1060.54s user 21.20s system 555% cpu 3:14.64 total`