### PR TITLE
linker: arcmwdt: use preprocess opiton -E.

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -49,7 +49,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     ${current_defines}
     ${linker_pass_define}
     ${LINKER_SCRIPT}
-    -P
+    -E
     -o ${linker_script_gen}
     VERBATIM
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
-P is an option that was inherited from the old MetaWare compiler.
[ccac foo.c -P] is actually a shortcut for: [ccac -E foo.c -o foo.i].
In new version of mwdt, -P option can't redirect the output. we need
to use -E option, which works in all versions.

-P:  Preprocess the file and write it to <src>.i (C) or
      <src>.ii(C++). No compilation is performed.

-E:  Run preprocessor only.
