### PR TITLE
drivers: timer: nrf_rtc_timer: Change type of channel argument

### DIFF
--- a/include/drivers/timer/nrf_rtc_timer.h
+++ b/include/drivers/timer/nrf_rtc_timer.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-typedef void (*z_nrf_rtc_timer_compare_handler_t)(uint32_t id,
+typedef void (*z_nrf_rtc_timer_compare_handler_t)(int32_t id,
 						uint32_t cc_value,
 						void *user_data);
 
@@ -22,13 +22,13 @@ typedef void (*z_nrf_rtc_timer_compare_handler_t)(uint32_t id,
  * @retval Non-negative indicates allocated channel ID.
  * @retval -ENOMEM if channel cannot be allocated.
  */
-int z_nrf_rtc_timer_chan_alloc(void);
+int32_t z_nrf_rtc_timer_chan_alloc(void);
 
 /** @brief Free RTC compare channel.
  *
  * @param chan Previously allocated channel ID.
  */
-void z_nrf_rtc_timer_chan_free(uint32_t chan);
+void z_nrf_rtc_timer_chan_free(int32_t chan);
 
 /** @brief Read current RTC counter value.
  *
@@ -44,7 +44,7 @@ uint32_t z_nrf_rtc_timer_read(void);
  *
  * @return Register address.
  */
-uint32_t z_nrf_rtc_timer_compare_evt_address_get(uint32_t chan);
+uint32_t z_nrf_rtc_timer_compare_evt_address_get(int32_t chan);
 
 /** @brief Safely disable compare event interrupt.
  *
@@ -54,7 +54,7 @@ uint32_t z_nrf_rtc_timer_compare_evt_address_get(uint32_t chan);
  *
  * @return key passed to @ref z_nrf_rtc_timer_compare_int_unlock.
  */
-bool z_nrf_rtc_timer_compare_int_lock(uint32_t chan);
+bool z_nrf_rtc_timer_compare_int_lock(int32_t chan);
 
 /** @brief Safely enable compare event interrupt.
  *
@@ -64,7 +64,7 @@ bool z_nrf_rtc_timer_compare_int_lock(uint32_t chan);
  *
  * @param key Key returned by @ref z_nrf_rtc_timer_compare_int_lock.
  */
-void z_nrf_rtc_timer_compare_int_unlock(uint32_t chan, bool key);
+void z_nrf_rtc_timer_compare_int_unlock(int32_t chan, bool key);
 
 /** @brief Read compare register value.
  *
@@ -72,7 +72,7 @@ void z_nrf_rtc_timer_compare_int_unlock(uint32_t chan, bool key);
  *
  * @return Value set in the compare register.
  */
-uint32_t z_nrf_rtc_timer_compare_read(uint32_t chan);
+uint32_t z_nrf_rtc_timer_compare_read(int32_t chan);
 
 /** @brief  Try to set compare channel to given value.
  *
@@ -95,7 +95,7 @@ uint32_t z_nrf_rtc_timer_compare_read(uint32_t chan);
  *
  * @param user_data Data passed to the handler.
  */
-void z_nrf_rtc_timer_compare_set(uint32_t chan, uint32_t cc_value,
+void z_nrf_rtc_timer_compare_set(int32_t chan, uint32_t cc_value,
 			       z_nrf_rtc_timer_compare_handler_t handler,
 			       void *user_data);
 

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_lp_timer_zephyr.c
@@ -17,10 +17,10 @@
 
 static volatile bool m_clock_ready;
 static bool m_is_running;
-static uint32_t m_rtc_channel;
+static int32_t m_rtc_channel;
 static bool m_in_critical_section;
 
-void rtc_irq_handler(uint32_t id, uint32_t cc_value, void *user_data)
+void rtc_irq_handler(int32_t id, uint32_t cc_value, void *user_data)
 {
 	(void)cc_value;
 	(void)user_data;
@@ -81,11 +81,8 @@ void nrf_802154_lp_timer_init(void)
 		/* Intentionally empty */
 	}
 
-	int32_t chan = z_nrf_rtc_timer_chan_alloc();
-
-	if (chan >= 0) {
-		m_rtc_channel = (uint32_t)chan;
-	} else   {
+	m_rtc_channel = z_nrf_rtc_timer_chan_alloc();
+	if (m_rtc_channel < 0) {
 		assert(false);
 		return;
 	}

--- a/tests/drivers/timer/nrf_rtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_rtc_timer/src/main.c
@@ -53,7 +53,7 @@ static void stop_zli_timer0(void)
 	nrf_timer_task_trigger(NRF_TIMER0, NRF_TIMER_TASK_STOP);
 }
 
-static void timeout_handler(uint32_t id, uint32_t cc_value, void *user_data)
+static void timeout_handler(int32_t id, uint32_t cc_value, void *user_data)
 {
 	struct test_data *data = user_data;
 	uint32_t now = z_nrf_rtc_timer_read();
@@ -70,7 +70,7 @@ static void timeout_handler(uint32_t id, uint32_t cc_value, void *user_data)
 	timeout_handler_cnt++;
 }
 
-static void test_timeout(uint32_t chan, k_timeout_t t, bool ext_window)
+static void test_timeout(int32_t chan, k_timeout_t t, bool ext_window)
 {
 	int32_t cc_val = z_nrf_rtc_timer_get_ticks(t);
 	struct test_data test_data = {
@@ -92,7 +92,7 @@ static void test_timeout(uint32_t chan, k_timeout_t t, bool ext_window)
 
 static void test_basic(void)
 {
-	int chan = z_nrf_rtc_timer_chan_alloc();
+	int32_t chan = z_nrf_rtc_timer_chan_alloc();
 
 	zassert_true(chan >= 0, "Failed to allocate RTC channel (%d).", chan);
 
@@ -139,7 +139,7 @@ static void test_int_disable_enabled(void)
 		.err = -EINVAL
 	};
 	bool key;
-	int chan;
+	int32_t chan;
 
 	chan = z_nrf_rtc_timer_chan_alloc();
 	zassert_true(chan >= 0, "Failed to allocate RTC channel.");
@@ -192,7 +192,7 @@ static void test_get_ticks(void)
 }
 
 
-static void sched_handler(uint32_t id, uint32_t cc_val, void *user_data)
+static void sched_handler(int32_t id, uint32_t cc_val, void *user_data)
 {
 	int64_t now = sys_clock_tick_get();
 	int rtc_ticks_now =
@@ -209,7 +209,7 @@ static void test_absolute_scheduling(void)
 	uint64_t target_us = now_us + 5678;
 	uint64_t evt_uptime_us;
 	int rtc_ticks;
-	int chan;
+	int32_t chan;
 
 	chan = z_nrf_rtc_timer_chan_alloc();
 	zassert_true(chan >= 0, "Failed to allocate RTC channel.");
@@ -246,8 +246,8 @@ static void test_absolute_scheduling(void)
 
 static void test_alloc_free(void)
 {
-	int chan[CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT];
-	int inv_ch;
+	int32_t chan[CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT];
+	int32_t inv_ch;
 
 	for (int i = 0; i < CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT; i++) {
 		chan[i] = z_nrf_rtc_timer_chan_alloc();
@@ -267,7 +267,7 @@ static void test_stress(void)
 	int x = 0;
 	uint32_t start = k_uptime_get_32();
 	uint32_t test_time = 5000;
-	int chan = z_nrf_rtc_timer_chan_alloc();
+	int32_t chan = z_nrf_rtc_timer_chan_alloc();
 
 	zassert_true(chan >= 0, "Failed to allocate RTC channel.");
 	start_zli_timer0();
@@ -293,9 +293,11 @@ static void test_reseting_cc(void)
 {
 	uint32_t start = k_uptime_get_32();
 	uint32_t test_time = 1000;
-	int chan = z_nrf_rtc_timer_chan_alloc();
+	int32_t chan = z_nrf_rtc_timer_chan_alloc();
 	int i = 0;
 	int cnt = 0;
+
+	zassert_true(chan >= 0, "Failed to allocate RTC channel.");
 
 	timeout_handler_cnt = 0;
 


### PR DESCRIPTION
There was an inconsistency in the API as z_nrf_rtc_timer_chan_alloc returned int but other function were using uint32_t for channel argument. Updated api to use int everywhere.
    
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
