### PR TITLE
Bluetooth: host: Add missing include in id.c

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -10,6 +10,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci_vs.h>
 #include <bluetooth/buf.h>
+#include <drivers/bluetooth/hci_driver.h>
 
 #include "hci_core.h"
 #include "id.h"


### PR DESCRIPTION
Add hci_driver.h to include files in id.c to ensure that prototype for
bt_read_static_addr is visible. This fixes builds that define
CONFIG_BT_CTLR but not CONFIG_BT_HCI_VS_EXT.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>