### PR TITLE
Twister: Refactor Test(Harness).handle()

### DIFF
--- a/scripts/pylib/twister/harness.py
+++ b/scripts/pylib/twister/harness.py
@@ -132,18 +132,7 @@ class Test(Harness):
             self.tests[name] = match.group(1)
             self.ztest = True
 
-        if self.RUN_PASSED in line:
-            if self.fault:
-                self.state = "failed"
-            else:
-                self.state = "passed"
-
-        if self.RUN_FAILED in line:
-            self.state = "failed"
-
-        if self.fail_on_fault:
-            if self.FAULT in line:
-                self.fault = True
+        self.process_test(line)
 
         if not self.ztest and self.state:
             if self.state == "passed":
@@ -151,12 +140,6 @@ class Test(Harness):
             else:
                 self.tests[self.id] = "FAIL"
 
-        if self.GCOV_START in line:
-            self.capture_coverage = True
-        elif self.GCOV_END in line:
-            self.capture_coverage = False
-
-        self.process_test(line)
 
 class Ztest(Test):
     pass


### PR DESCRIPTION
The function `handle()` from class `Test(Harness)` had most of its
code being the direct copy of the code from
`Harness.process_test(line)`. This patch replaces the copied code
with the call for `process_test(line)` and removes repetition of
this function call.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>