### PR TITLE
bluetooth: host: EAGAIN when initiating a connection when scanning

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -600,6 +600,9 @@ struct bt_conn_le_create_param {
  *
  *  This uses the General Connection Establishment procedure.
  *
+ *  The application must disable explicit scanning before initiating
+ *  a new LE connection.
+ *
  *  @param[in]  peer         Remote address.
  *  @param[in]  create_param Create connection parameters.
  *  @param[in]  conn_param   Initial connection parameters.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2345,7 +2345,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 	}
 
 	if (atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
-		return -EINVAL;
+		return -EAGAIN;
 	}
 
 	if (atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {


### PR DESCRIPTION
Also improve the documentation.
