### PR TITLE
Bluetooth: controller: Move access to volatile out of assertion

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -64,6 +64,7 @@ void ull_sched_after_mstr_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 		uint32_t volatile ret_cb;
 		struct ll_conn *conn;
 		uint32_t ret;
+		bool success;
 
 		ret_cb = TICKER_STATUS_BUSY;
 		ret = ticker_next_slot_get(TICKER_INSTANCE_ID_CTLR, user_id,
@@ -77,7 +78,8 @@ void ull_sched_after_mstr_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 			}
 		}
 
-		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
+		success = (ret_cb == TICKER_STATUS_SUCCESS);
+		LL_ASSERT(success);
 
 		if (ticker_id == 0xff) {
 			break;
@@ -349,6 +351,7 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 		uint32_t volatile ret_cb;
 		struct ll_conn *conn;
 		uint32_t ret;
+		bool success;
 
 		ret_cb = TICKER_STATUS_BUSY;
 		ret = ticker_next_slot_get(TICKER_INSTANCE_ID_CTLR,
@@ -363,7 +366,8 @@ static void win_offset_calc(struct ll_conn *conn_curr, uint8_t is_select,
 			}
 		}
 
-		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
+		success = (ret_cb == TICKER_STATUS_SUCCESS);
+		LL_ASSERT(success);
 
 		if (ticker_id == 0xff) {
 			break;


### PR DESCRIPTION
Move access to volatile variable out of assertion to avoid warnings
about side effect in assertion.

Fixes #32930 
Fixes #32909 

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>