### PR TITLE
Bluetooth: HCI: Fix option CONFIG_BT_HCI_ACL_DATA_SIZE default to 0

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -131,7 +131,7 @@ config BT_HCI_ACL_DATA_SIZE
 	prompt "ACL data buffer size" if !BT_CTLR
 	depends on BT_HCI_RAW
 	range 27 251
-	default BT_CTLR_DATA_LENGTH_MAX if BT_CTLR
+	default BT_CTLR_DATA_LENGTH_MAX if BT_CTLR_DATA_LENGTH
 	default 27
 	help
 	  Maximum ACL data payload in HCI packets, excluding HCI header.


### PR DESCRIPTION
Fix CONFIG_BT_HCI_ACL_DATA_SIZE default value set to 0 when data length
feature in the controller is not enabled. In this case the default value
will be set to 0 which is outside of the range specified for the option.

Fixes: #33426

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>