### PR TITLE
MAINTAINERS/CODEOWNERS: remove my association from subsystems

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -154,7 +154,6 @@
 /doc/guides/dts/                          @galak @mbolivar-nordic
 /doc/reference/bluetooth/                 @joerchan @jhedberg @Vudentz
 /doc/reference/devicetree/                @galak @mbolivar-nordic
-/doc/reference/resource_management/       @pabigot
 /doc/reference/networking/can*            @alexanderwachter
 /doc/security/                            @ceolin @d3zd3z
 /drivers/debug/                           @nashif
@@ -177,7 +176,6 @@
 /drivers/console/ipm_console.c            @finikorg
 /drivers/console/semihost_console.c       @luozhongyao
 /drivers/counter/counter_cmos.c           @dcpleung
-/drivers/counter/maxim_ds3231.c           @pabigot
 /drivers/crypto/*nrf_ecb*                 @maciekfabia @anangl
 /drivers/console/*mux*                    @jukkar
 /drivers/display/                         @vanwinkeljan
@@ -201,12 +199,10 @@
 /drivers/ethernet/*w5500*                 @parthitce
 /drivers/flash/                           @nashif @nvlsianpu
 /drivers/flash/*nrf*                      @nvlsianpu
-/drivers/flash/*spi_nor*                  @pabigot
-/drivers/gpio/                            @mnkp @pabigot
+/drivers/gpio/                            @mnkp
 /drivers/gpio/*ht16k33*                   @henrikbrixandersen
 /drivers/gpio/*lmp90xxx*                  @henrikbrixandersen
 /drivers/gpio/*stm32*                     @erwango
-/drivers/gpio/*sx1509b*                   @pabigot
 /drivers/gpio/*eos_s3*                    @wtatarski @kowalewskijan @kgugala
 /drivers/hwinfo/                          @alexanderwachter
 /drivers/i2s/i2s_ll_stm32*                @avisconti
@@ -253,7 +249,6 @@
 /drivers/pwm/*xlnx*                       @henrikbrixandersen
 /drivers/pwm/pwm_capture.c                @henrikbrixandersen
 /drivers/pwm/pwm_shell.c                  @henrikbrixandersen
-/drivers/regulator/                       @pabigot
 /drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter
@@ -432,7 +427,7 @@
 /include/dt-bindings/pcie/                @dcpleung
 /include/dt-bindings/usb/usb.h            @galak
 /include/emul.h                           @sjg20
-/include/fs/                              @nashif @nvlsianpu @de-nordic @pabigot
+/include/fs/                              @nashif @nvlsianpu @de-nordic
 /include/init.h                           @nashif @andyross
 /include/irq.h                            @dcpleung @nashif @andyross
 /include/irq_offload.h                    @dcpleung @nashif @andyross
@@ -449,7 +444,7 @@
 /include/net/lwm2m*.h                     @jukkar @rlubos
 /include/net/mqtt.h                       @jukkar @rlubos
 /include/posix/                           @pfalcon
-/include/power/power.h                    @pabigot @nashif @ceolin
+/include/power/power.h                    @nashif @ceolin
 /include/ptp_clock.h                      @jukkar
 /include/shared_irq.h                     @dcpleung @nashif @andyross
 /include/shell/                           @jakub-uC @nordic-krch
@@ -487,7 +482,6 @@
 /samples/drivers/display/                 @vanwinkeljan
 /samples/drivers/ht16k33/                 @henrikbrixandersen
 /samples/drivers/lora/                    @Mani-Sadhasivam
-/samples/drivers/counter/maxim_ds3231/    @pabigot
 /samples/subsys/lorawan/                  @Mani-Sadhasivam
 /samples/net/                             @jukkar @tbursztyka @pfalcon
 /samples/net/cloud/tagoio_http_post/      @nandojve
@@ -505,7 +499,7 @@
 /samples/subsys/mgmt/updatehub/           @nandojve @otavio
 /samples/subsys/mgmt/osdp/                @cbsiddharth
 /samples/subsys/usb/                      @jfischer-no
-/samples/subsys/power/                    @nashif @pabigot @ceolin
+/samples/subsys/power/                    @nashif @ceolin
 /samples/tfm_integration/                 @ioannisg @microbuilder
 /samples/userspace/                       @dcpleung @nashif
 /scripts/coccicheck                       @himanshujha199640 @JuliaLawall
@@ -515,7 +509,6 @@
 /scripts/pylib/twister/expr_parser.py     @nashif
 /scripts/schemas/twister/                 @nashif
 /scripts/gen_app_partitions.py            @dcpleung @nashif
-/scripts/gen_handles.py                   @pabigot
 /scripts/get_maintainer.py                @nashif
 /scripts/dts/                             @mbolivar-nordic @galak
 /scripts/release/                         @nashif
@@ -548,7 +541,7 @@
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/canbus/                           @alexanderwachter
-/subsys/cpp/                              @pabigot @vanwinkeljan
+/subsys/cpp/                              @vanwinkeljan
 /subsys/debug/                            @nashif
 /subsys/debug/coredump/                   @dcpleung
 /subsys/debug/gdbstub/                    @ceolin
@@ -566,7 +559,6 @@
 /subsys/fs/                               @nashif
 /subsys/fs/fcb/                           @nvlsianpu
 /subsys/fs/fuse_fs_access.c               @vanwinkeljan
-/subsys/fs/littlefs_fs.c                  @pabigot
 /subsys/fs/nvs/                           @Laczen
 /subsys/ipc/                              @ioannisg
 /subsys/logging/                          @nordic-krch
@@ -592,7 +584,7 @@
 /subsys/net/l2/                           @jukkar @tbursztyka
 /subsys/net/l2/canbus/                    @alexanderwachter @jukkar
 /subsys/net/*/openthread/                 @rlubos
-/subsys/power/                            @nashif @pabigot @ceolin
+/subsys/power/                            @nashif @ceolin
 /subsys/random/                           @dleach02
 /subsys/settings/                         @nvlsianpu
 /subsys/shell/                            @jakub-uC @nordic-krch
@@ -604,7 +596,6 @@
 /subsys/usb/                              @jfischer-no
 /subsys/usb/class/dfu/usb_dfu.c           @nvlsianpu
 /tests/                                   @nashif
-/tests/application_development/libcxx/    @pabigot
 /tests/arch/arm/                          @ioannisg @stephanosio
 /tests/benchmarks/cmsis_dsp/              @stephanosio
 /tests/boards/native_posix/               @aescolar @daor-oti
@@ -616,10 +607,9 @@
 /tests/crypto/mbedtls/                    @nashif @ceolin
 /tests/drivers/can/                       @alexanderwachter
 /tests/drivers/counter/                   @nordic-krch
-/tests/drivers/counter/maxim_ds3231_api/  @pabigot
 /tests/drivers/eeprom/                    @henrikbrixandersen @sjg20
 /tests/drivers/flash_simulator/           @nvlsianpu
-/tests/drivers/gpio/                      @mnkp @pabigot
+/tests/drivers/gpio/                      @mnkp
 /tests/drivers/hwinfo/                    @alexanderwachter
 /tests/drivers/spi/                       @tbursztyka
 /tests/drivers/uart/uart_async_api/       @Mierunski
@@ -635,7 +625,7 @@
 /tests/net/socket/socketpair/             @cfriedt
 /tests/net/socket/                        @jukkar @tbursztyka @pfalcon
 /tests/subsys/debug/coredump/             @dcpleung
-/tests/subsys/fs/                         @nashif @nvlsianpu @de-nordic @pabigot
+/tests/subsys/fs/                         @nashif @nvlsianpu @de-nordic
 /tests/subsys/settings/                   @nvlsianpu
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
 # Get all docs reviewed

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -575,9 +575,7 @@ Documentation:
         - "area: HWINFO"
 
 "Drivers: I2C":
-    status: maintained
-    maintainers:
-        - pabigot
+    status: orphaned
     files:
         - drivers/i2c/
         - dts/bindings/i2c/
@@ -871,7 +869,6 @@ Filesystems:
         - de-nordic
         - Laczen
         - nashif
-        - pabigot
         - vanwinkeljan
     files:
         - include/fs/
@@ -910,7 +907,6 @@ Kernel:
         - nashif
         - ceolin
         - dcpleung
-        - pabigot
     files:
         - doc/reference/kernel/
         - include/kernel*.h
@@ -934,9 +930,7 @@ Base OS:
         - "area: Base OS"
 
 Little FS:
-    status: maintained
-    maintainers:
-        - pabigot
+    status: orphaned
     files:
         - subsys/fs/Kconfig.littlefs
         - subsys/fs/littlefs_fs.c
@@ -1141,7 +1135,6 @@ Power management:
         - ceolin
     collaborators:
         - nashif
-        - pabigot
         - mengxianglinx
     files:
         - include/power/power.h


### PR DESCRIPTION
I've got personal obligations that will limit my availability for the next three to six months.  I've also realized that after several years of working to address Zephyr problems I'm really no closer to being able to use it for the low-power wireless sensor applications that I'd hoped it would support.

So this is a good time to disengage from the project, and open up maintenance for I2C, littlefs, and some other components to people who want to take them on.