### PR TITLE
tests: error_hook: fixing documentation, style, and test_catch_z_oops test-case

### DIFF
--- a/tests/ztest/error_hook/README.txt
+++ b/tests/ztest/error_hook/README.txt
@@ -179,20 +179,15 @@ Assert error expected as part of test case.
  PASS - test_catch_assert_in_isr
 ===================================================================
 START - test_catch_z_oops
-E: Page fault at address (nil) (error code 0x4)
-E: Linear address not present in page tables
-E: Access violation: user thread not allowed to read
-E: PTE: not present
-E: EAX: 0x00000000, EBX: 0x0011303c, ECX: 0x00000000, EDX: 0x0011303c
-E: ESI: 0x00000000, EDI: 0x00130fe8, EBP: 0x00130fc0, ESP: 0x00130fc0
-E: EFLAGS: 0x00000246 CS: 0x002b CR3: 0x001142c0
+E: EAX: 0x00000000, EBX: 0x00000000, ECX: 0x00000000, EDX: 0x00000000
+E: ESI: 0x00000000, EDI: 0x00000000, EBP: 0x00000000, ESP: 0x00000000
+E: EFLAGS: 0x001003c4 CS: 0x0511 CR3: 0x00115740
 E: call trace:
-E: EIP: 0x00100544
-E:      0x00104808 (0x130033)
-E:      0x001010ea (0x11303c)
-E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
-E: Current thread: 0x1140a0 (unknown)
-Caught system error -- reason 0 1
+E: EIP: 0x0010ff9e
+E: NULL base ptr
+E: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
+E: Current thread: 0x114120 (unknown)
+Caught system error -- reason 3 1
 Fatal error expected as part of test case.
  PASS - test_catch_z_oops
 ===================================================================

--- a/tests/ztest/error_hook/README.txt
+++ b/tests/ztest/error_hook/README.txt
@@ -2,9 +2,9 @@ Title: A common fatal error and assert fail handler
 
 Description:
 
-These two common handler is in order to reduce the redundancy code writing
-for fatal and assert handler for error case testing. They can be used both
-in kernel and userspace, and are also SMP safe.
+These two common handlers are developed in order to reduce the redundancy
+code writing for fatal and assert handler for error case testing. They can
+be used both in kernel and userspace, and they are also SMP safe.
 
 
 Why doing this
@@ -12,13 +12,14 @@ Why doing this
 
 When writing error testing case (or we call it negative test case), we might
 have to write self-defined k_sys_fatal_handler or post_assert_handler to deal
-with the errors we caught, in order to make test going on. This mean much
-identical code would be written. So we try to make it as a common part and
-let other test case or app can reuse it.
+with the errors we caught, in order to make the test continue. This means much
+identical code would be written. So we try to move the error handler definition
+into a common part and let other test suites or applications reuse it, instead
+of defining their own.
 
-And when error happened, it sometimes need a special action to make our testing
-program back to normal, such as release some resource hold before error
-happened. This is why we add a hook on it, in order to achieve that goal.
+And when error happens, we sometimes need a special action to make our testing
+program return back to normal, such as releasing some resource hold before the
+error happened. This is why we add a hook on it, in order to achieve that goal.
 
 
 How to use it in you app
@@ -48,8 +49,8 @@ Step4: call ztest_set_assert_valid(true) before where your target function
        call.
 
 
-You can choose to use one or both of them, depneds on your need.
-If you use none of them, you can still defined your own fatal or assert handler
+You can choose to use one or both of them, depending on your needs.
+If you use none of them, you can still define your own fatal or assert handler
 as usual.
 
 
@@ -57,19 +58,21 @@ Test example in this test set
 =============================
 
 This test verifies if the common fatal error and assert fail handler works.
-If the expected error got caught, the test case pass.
+If the expected error was caught, the test case will pass.
 
 test_catch_assert_fail
   - To call a function then giving the condition to trigger the assert fail,
     then catch it by the assert handler.
 
 test_catch_fatal_error
-  - start a thread to test trigger a null address then catch fatal error.
-  - start a thread to test trigger a illegal instruction then catch fatal
-    error.
-  - start a thread to test trigger a divide zero error then catch fatal error.
-  - start a thread to call k_oops() then catch fatal error.
-  - start a thread to call k_panel() then catch fatal error.
+  - start a thread to test triggerring a null address dereferencing, then catch
+    the (expected) fatal error.
+  - start a thread to test triggerring an illegal instruction, then catch
+    the (expected) fatal error.
+  - start a thread to test triggerring a divide-by-zero error, then catch
+    the (expected) fatal error.
+  - start a thread to call k_oops() then catch the (expected) fatal error.
+  - start a thread to call k_panel() then catch the (expected) fatal error.
 
 test_catch_assert_in_isr
   - start a thread to enter ISR context by calling irq_offload(), then trigger
@@ -77,14 +80,14 @@ test_catch_assert_in_isr
 
 test_catch_z_oops
   - Pass illegal address by syscall, then inside the syscall handler, the
-    Z_OOPS macro will trigger a fatal error then got caught.
+    Z_OOPS macro will trigger a fatal error that will get caught (as expected).
 
 
 
 Limitation of this usage
 ========================
 
-Trigger an fatal error in ISR context, that will cause problem due to
+Trigger a fatal error in ISR context, that will cause problem due to
 the interrupt stack is already abnormal when we want to continue other
 test case, we do not recover it so far.
 

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -41,11 +41,11 @@ static void trigger_assert_fail(void *a)
 	__ASSERT(a != NULL, "parameter a should not be NULL!");
 }
 
-static void trigger_fault_illeagl_instuction(void)
+static void trigger_fault_illegal_instruction(void)
 {
 	void *a = NULL;
 
-	/* execute an illeagal instructions */
+	/* execute an illeagal instruction */
 	((void(*)(void))&a)();
 }
 
@@ -70,7 +70,7 @@ static void trigger_fault_access(void)
 	 */
 	void *a = (void *)NULL;
 #endif
-	/* access a illeagal address */
+	/* access an illegal address */
 	volatile int b = *((int *)a);
 
 	printk("b is %d\n", b);
@@ -81,7 +81,7 @@ static void trigger_fault_divide_zero(void)
 	int a = 1;
 	int b = 0;
 
-	/* divde zero */
+	/* divide by zero */
 	a = a / b;
 	printk("a is %d\n", a);
 }
@@ -98,15 +98,16 @@ static void trigger_fault_panic(void)
 
 static void release_offload_sem(void)
 {
-	/* Semaphore used inside irq_offload need to be
-	 * released after assert or fault happened.
+	/* Semaphore used inside irq_offload needs to be
+	 * released after an assert or a fault has happened.
 	 */
 	k_sem_give(&offload_sem);
 }
 
-/* This is the fatal error hook that allow you to do actions after
- * fatal error happened. This is optional, you can choose to define
- * this yourself. If not, it will use the default one.
+/* This is the fatal error hook that allows you to do actions after
+ * the fatal error has occurred. This is optional; you can choose
+ * to define the hook yourself. If not, the program will use the
+ * default one.
  */
 void ztest_post_fatal_error_hook(unsigned int reason,
 		const z_arch_esf_t *pEsf)
@@ -134,9 +135,9 @@ void ztest_post_fatal_error_hook(unsigned int reason,
 	}
 }
 
-/* This is the assert fail post hook that allow you to do actions after
- * assert fail happened. This is optional, you can choose to define
- * this yourself. If not, it will use the default one.
+/* This is the assert fail post hook that allows you to do actions after
+ * the assert fail happened. This is optional, you can choose to define
+ * the hook yourself. If not, the program will use the default one.
  */
 void ztest_post_assert_fail_hook(void)
 {
@@ -170,7 +171,7 @@ static void tThread_entry(void *p1, void *p2, void *p3)
 		break;
 	case ZTEST_CATCH_FATAL_ILLEAGAL_INSTRUCTION:
 		ztest_set_fault_valid(true);
-		trigger_fault_illeagl_instuction();
+		trigger_fault_illegal_instruction();
 		break;
 	case ZTEST_CATCH_FATAL_DIVIDE_ZERO:
 		ztest_set_fault_valid(true);

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -275,9 +275,12 @@ void test_catch_assert_in_isr(void)
 
 
 #if defined(CONFIG_USERSPACE)
-static void trigger_z_oops(void *a)
+static void trigger_z_oops(void)
 {
-	Z_OOPS(*((bool *)a));
+	/* Set up a dummy syscall frame, pointing to a valid area in memory. */
+	_current->syscall_frame = _image_ram_start;
+
+	Z_OOPS(true);
 }
 
 /**
@@ -293,7 +296,7 @@ void test_catch_z_oops(void)
 	case_type = ZTEST_CATCH_USER_FATAL_Z_OOPS;
 
 	ztest_set_fault_valid(true);
-	trigger_z_oops((void *)false);
+	trigger_z_oops();
 }
 #endif
 
@@ -308,7 +311,7 @@ void test_main(void)
 			 ztest_user_unit_test(test_catch_assert_fail),
 			 ztest_user_unit_test(test_catch_fatal_error),
 			 ztest_unit_test(test_catch_assert_in_isr),
-			 ztest_user_unit_test(test_catch_z_oops)
+			 ztest_unit_test(test_catch_z_oops)
 			 );
 	ztest_run_test_suite(error_hook_tests);
 #else


### PR DESCRIPTION
Fixes #33424 

Fixes for the error hook test suite.
- documentation, typos and style
- fixes for catching oops test case