### PR TITLE
kernel: remove deprecated mem domain APIs

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -60,6 +60,8 @@ Removed APIs in this release
 
 * Removed support for the old zephyr integer typedefs (u8_t, u16_t, etc...).
 
+* Removed support for k_mem_domain_destroy and k_mem_domain_remove_thread
+
 ============================
 
 Stable API changes in this release

--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -124,20 +124,6 @@ struct k_mem_partition;
  */
 extern void k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 			      struct k_mem_partition *parts[]);
-/**
- * @brief Destroy a memory domain.
- *
- * Destroy a memory domain. All member threads will be re-assigned to the
- * default memory domain.
- *
- * The default memory domain may not be destroyed.
- *
- * This API is deprecated and will be removed in Zephyr 2.5.
- *
- * @param domain The memory domain to be destroyed.
- */
-__deprecated
-extern void k_mem_domain_destroy(struct k_mem_domain *domain);
 
 /**
  * @brief Add a memory partition into a memory domain.
@@ -188,17 +174,6 @@ extern void k_mem_domain_remove_partition(struct k_mem_domain *domain,
  */
 extern void k_mem_domain_add_thread(struct k_mem_domain *domain,
 				    k_tid_t thread);
-
-/**
- * @brief Remove a thread from its memory domain.
- *
- * Remove a thread from its memory domain. It will be reassigned to the
- * default memory domain.
- *
- * @param thread ID of thread going to be removed from its memory domain.
- */
-__deprecated
-extern void k_mem_domain_remove_thread(k_tid_t thread);
 
 #ifdef __cplusplus
 }

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -267,39 +267,6 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 	k_spin_unlock(&z_mem_domain_lock, key);
 }
 
-/* LCOV_EXCL_START */
-void k_mem_domain_remove_thread(k_tid_t thread)
-{
-	k_mem_domain_add_thread(&k_mem_domain_default, thread);
-}
-
-void k_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	k_spinlock_key_t key;
-	sys_dnode_t *node, *next_node;
-
-	__ASSERT_NO_MSG(domain != NULL);
-	__ASSERT(domain != &k_mem_domain_default,
-		 "cannot destroy default domain");
-
-	key = k_spin_lock(&z_mem_domain_lock);
-
-#ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
-	arch_mem_domain_destroy(domain);
-#endif
-
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
-		struct k_thread *thread =
-			CONTAINER_OF(node, struct k_thread, mem_domain_info);
-
-		remove_thread_locked(thread);
-		add_thread_locked(&k_mem_domain_default, thread);
-	}
-
-	k_spin_unlock(&z_mem_domain_lock, key);
-}
-/* LCOV_EXCL_STOP */
-
 static int init_mem_domain_module(const struct device *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
Remove k_mem_domain_destroy and k_mem_domain_remove_thread as they've
been deprecated for at least 2 releases now.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>