### PR TITLE
cmake: move the BOARD variable watch below deprecated board handling

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -224,8 +224,6 @@ if(NOT (REVISION_SEPARATOR_INDEX EQUAL -1))
   string(SUBSTRING ${BOARD} 0 ${REVISION_SEPARATOR_INDEX} BOARD)
 endif()
 
-zephyr_boilerplate_watch(BOARD)
-
 set(BOARD_MESSAGE "Board: ${BOARD}")
 
 if(DEFINED ENV{ZEPHYR_BOARD_ALIASES})
@@ -242,6 +240,8 @@ if(${BOARD}_DEPRECATED)
   set(BOARD ${${BOARD}_DEPRECATED})
   message(WARNING "Deprecated BOARD=${BOARD_DEPRECATED} name specified, board automatically changed to: ${BOARD}.")
 endif()
+
+zephyr_boilerplate_watch(BOARD)
 
 foreach(root ${BOARD_ROOT})
   # Check that the board root looks reasonable.


### PR DESCRIPTION
Fixes: #33138

Board alias and deprecated board handling is setting the BOARD variable
after `zephyr_boilerplate_watch(BOARD)` has been executed.

This results in the board changed warning.

This commit moves the `zephyr_boilerplate_watch(BOARD)` code below the
board alias and deprecation handling.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>