### PR TITLE
libc/minimal: small fixes to malloc() and friends

### DIFF
--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -11,7 +11,6 @@
 #include <sys/math_extras.h>
 #include <string.h>
 #include <app_memory/app_memdomain.h>
-#include <sys/check.h>
 #include <sys/mutex.h>
 #include <sys/sys_heap.h>
 #include <zephyr/types.h>
@@ -38,16 +37,15 @@ Z_GENERIC_SECTION(POOL_SECTION) static char z_malloc_heap_mem[HEAP_BYTES];
 
 void *malloc(size_t size)
 {
-	int lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	int lock_ret;
 
-	CHECKIF(lock_ret != 0) {
-		return NULL;
-	}
+	lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	__ASSERT_NO_MSG(lock_ret == 0);
 
 	void *ret = sys_heap_aligned_alloc(&z_malloc_heap,
 					   __alignof__(z_max_align_t),
 					   size);
-	if (ret == NULL) {
+	if (ret == NULL && size != 0) {
 		errno = ENOMEM;
 	}
 
@@ -67,11 +65,10 @@ static int malloc_prepare(const struct device *unused)
 
 void *realloc(void *ptr, size_t requested_size)
 {
-	int lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	int lock_ret;
 
-	CHECKIF(lock_ret != 0) {
-		return NULL;
-	}
+	lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	__ASSERT_NO_MSG(lock_ret == 0);
 
 	void *ret = sys_heap_aligned_realloc(&z_malloc_heap, ptr,
 					     __alignof__(z_max_align_t),
@@ -87,7 +84,10 @@ void *realloc(void *ptr, size_t requested_size)
 
 void free(void *ptr)
 {
-	sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	int lock_ret;
+
+	lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	__ASSERT_NO_MSG(lock_ret == 0);
 	sys_heap_free(&z_malloc_heap, ptr);
 	sys_mutex_unlock(&z_malloc_heap_mutex);
 }


### PR DESCRIPTION
When malloc() is called with a size of 0 we should not set errno to
ENOMEM as there is no actual allocation failure in that case. This
duplicates the realloc() behavior.

Check the return value of sys_mutex_lock() in the free() case to make
Coverity happy (issue #32938). 

Replace all CHECKIF() by explicit assertion statements to uniformize
those checks with the free() case which can't return errors. In theory
sys_mutex_lock() will never return an error here anyway.
