### PR TITLE
soc: arm: stm32wb serie low power modes substates

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -26,19 +26,19 @@
 		stop0: state0 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <0>;
+			substate-id = <1>;
 			min-residency-us = <100>;
 		};
 		stop1: state1 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <1>;
+			substate-id = <2>;
 			min-residency-us = <500>;
 		};
 		stop2: state2 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <2>;
+			substate-id = <3>;
 			min-residency-us = <900>;
 		};
 	};

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -12,11 +12,9 @@ config SOC_SERIES
 
 if PM
 config PM_DEVICE
-	bool
 	default y
 
 config STM32_LPTIM_TIMER
-	bool
 	default y
 endif # PM
 

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -27,12 +27,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 
 	switch (info.substate_id) {
-	case 0:
-		/* this corresponds to the STOP0 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 0: /* this corresponds to the STOP0 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP0 mode */
@@ -41,12 +36,7 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 1:
-		/* this corresponds to the STOP1 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 1: /* this corresponds to the STOP1 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP1 mode */
@@ -54,12 +44,7 @@ void pm_power_state_set(struct pm_state_info info)
 		LL_LPM_EnableDeepSleep();
 		k_cpu_idle();
 		break;
-	case 2:
-		/* this corresponds to the STOP2 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 2: /* this corresponds to the STOP2 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 #ifdef PWR_CR1_RRSTP
@@ -107,3 +92,18 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 	 */
 	irq_unlock(0);
 }
+
+/* Initialize STM32 Power */
+static int stm32_power_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#ifdef CONFIG_DEBUG
+	/* Enable the Debug Module during STOP mode */
+	LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -27,7 +27,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 
 	switch (info.substate_id) {
-	case 0: /* this corresponds to the STOP0 mode: */
+	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP0 mode */
@@ -36,15 +36,16 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 1: /* this corresponds to the STOP1 mode: */
+	case 2: /* this corresponds to the STOP1 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 		/* enter STOP1 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
 		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 2: /* this corresponds to the STOP2 mode: */
+	case 3: /* this corresponds to the STOP2 mode: */
 		/* ensure HSI is the wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 #ifdef PWR_CR1_RRSTP
@@ -53,6 +54,7 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter STOP2 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
 		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
 	default:
@@ -68,11 +70,11 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 		LOG_DBG("Unsupported power state %u", info.state);
 	} else {
 		switch (info.substate_id) {
-		case 0:	/* STOP0 */
+		case 1:	/* STOP0 */
 			__fallthrough;
-		case 1:	/* STOP1 */
+		case 2:	/* STOP1 */
 			__fallthrough;
-		case 2:	/* STOP2 */
+		case 3:	/* STOP2 */
 			LL_LPM_DisableSleepOnExit();
 			LL_LPM_EnableSleep();
 			break;


### PR DESCRIPTION
Change the substate-id range from 1-3 as described in the include/power/power_state.h
this is changing the range in pm_power_state_set() of the soc/arm/st_stm32/stm32wb/power.c
The debug config will let the clocks active in STOP mode at init.
Following the https://github.com/zephyrproject-rtos/zephyr/pull/33131, the power.c part of the stm32wb is modified in the same way.

Signed-off-by: Francois Ramu <francois.ramu@st.com>