### PR TITLE
soc: arm: stm32l4 serie low power modes substates

### DIFF
--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -24,19 +24,19 @@
 		stop0: state0 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <0>;
+			substate-id = <1>;
 			min-residency-us = <500>;
 		};
 		stop1: state1 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <1>;
+			substate-id = <2>;
 			min-residency-us = <700>;
 		};
 		stop2: state2 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			substate-id = <2>;
+			substate-id = <3>;
 			min-residency-us = <1000>;
 		};
 	};

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -15,11 +15,9 @@ config SOC_SERIES
 
 if PM
 config PM_DEVICE
-	bool
 	default y
 
 config STM32_LPTIM_TIMER
-	bool
 	default y
 endif # PM
 

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -35,13 +35,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 
 	switch (info.substate_id) {
-	case 0:
-
-		/* this corresponds to the STOP0 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 0: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP0 mode */
@@ -50,12 +44,7 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 1:
-		/* this corresponds to the STOP1 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 1: /* this corresponds to the STOP1 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP1 mode */
@@ -63,12 +52,7 @@ void pm_power_state_set(struct pm_state_info info)
 		LL_LPM_EnableDeepSleep();
 		k_cpu_idle();
 		break;
-	case 2:
-		/* this corresponds to the STOP2 mode: */
-#ifdef CONFIG_DEBUG
-		/* Enable the Debug Module during STOP mode */
-		LL_DBGMCU_EnableDBGStopMode();
-#endif /* CONFIG_DEBUG */
+	case 2: /* this corresponds to the STOP2 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 #ifdef PWR_CR1_RRSTP
@@ -121,16 +105,15 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 /* Initialize STM32 Power */
 static int stm32_power_init(const struct device *dev)
 {
-	unsigned int ret;
-
 	ARG_UNUSED(dev);
-
-	ret = irq_lock();
 
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
-	irq_unlock(ret);
+#ifdef CONFIG_DEBUG
+	/* Enable the Debug Module during STOP mode */
+	LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
 
 	return 0;
 }

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -35,7 +35,7 @@ void pm_power_state_set(struct pm_state_info info)
 	}
 
 	switch (info.substate_id) {
-	case 0: /* this corresponds to the STOP0 mode: */
+	case 1: /* this corresponds to the STOP0 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP0 mode */
@@ -44,15 +44,16 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 1: /* this corresponds to the STOP1 mode: */
+	case 2: /* this corresponds to the STOP1 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 		/* enter STOP1 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
 		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
-	case 2: /* this corresponds to the STOP2 mode: */
+	case 3: /* this corresponds to the STOP2 mode: */
 		/* ensure the proper wake-up system clock */
 		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
 #ifdef PWR_CR1_RRSTP
@@ -61,6 +62,7 @@ void pm_power_state_set(struct pm_state_info info)
 		/* enter STOP2 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
 		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
 		k_cpu_idle();
 		break;
 	default:
@@ -77,11 +79,11 @@ void pm_power_state_exit_post_ops(struct pm_state_info info)
 		LOG_DBG("Unsupported power substate-id %u", info.state);
 	} else {
 		switch (info.substate_id) {
-		case 0:	/* STOP0 */
+		case 1:	/* STOP0 */
 			__fallthrough;
-		case 1:	/* STOP1 */
+		case 2:	/* STOP1 */
 			__fallthrough;
-		case 2:	/* STOP2 */
+		case 3:	/* STOP2 */
 			LL_LPM_DisableSleepOnExit();
 			LL_LPM_EnableSleep();
 			break;


### PR DESCRIPTION
Change the substate-id range from 1-3 as described in the include/power/power_state.h
this is changing the range in pm_power_state_set() of the soc/arm/st_stm32/stm32l4/power.c
The debug config will let the clocks active in STOP mode at init.The debug config will let the clocks active in STOP mode at init.
Following the #33131, the power.c part of the stm32wb is modified in the same way.

Signed-off-by: Francois Ramu <francois.ramu@st.com>