### PR TITLE
Fix llvm-clang coverage without shell backend.

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1249,7 +1249,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 		return;
 	}
 
-	if (log_backend && IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND) && log_backend) {
 		z_shell_log_backend_enable(shell->log_backend, (void *)shell,
 					   log_level);
 	}


### PR DESCRIPTION
Building this file with CONFIG_COVERAGE=y and CONFIG_SHELL_LOG_BACKEND=n fails on the llvm-clang compiler. Swapping the IS_ENABLED and log_backend allows the compiler to optimize out the if block even with coverage enabled.
