### PR TITLE
kernel: remove arch_mem_domain_destroy

### DIFF
--- a/arch/arm/core/aarch64/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch64/mmu/arm_mmu.c
@@ -917,20 +917,6 @@ int arch_mem_domain_init(struct k_mem_domain *domain)
 	return 0;
 }
 
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	struct arm_mmu_ptables *domain_ptables = &domain->arch.ptables;
-	k_spinlock_key_t key;
-
-	MMU_DEBUG("%s\n", __func__);
-
-	sys_slist_remove(&domain_list, NULL, &domain->arch.node);
-	key = k_spin_lock(&xlat_lock);
-	discard_table(domain_ptables->base_xlat_table, BASE_XLAT_LEVEL);
-	domain_ptables->base_xlat_table = NULL;
-	k_spin_unlock(&xlat_lock, key);
-}
-
 static void private_map(struct arm_mmu_ptables *ptables, const char *name,
 			uintptr_t phys, uintptr_t virt, size_t size, uint32_t attrs)
 {

--- a/arch/riscv/core/pmp/core_pmp.c
+++ b/arch/riscv/core/pmp/core_pmp.c
@@ -503,18 +503,6 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	}
 }
 
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	sys_dnode_t *node, *next_node;
-	struct k_thread *thread;
-
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
-		thread = CONTAINER_OF(node, struct k_thread, mem_domain_info);
-
-		arch_mem_domain_thread_remove(thread);
-	}
-}
-
 void arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    uint32_t partition_id)
 {

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1390,11 +1390,6 @@ void arch_mem_domain_thread_remove(struct k_thread *thread)
 {
 
 }
-
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-
-}
 #else
 /* Memory domains each have a set of page tables assigned to them */
 
@@ -1619,11 +1614,6 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	/* Reset the partition's region back to defaults */
 	reset_region(domain->arch.ptables, (void *)partition->start,
 		     partition->size);
-}
-
-void arch_mem_domain_destroy(struct k_mem_domain *domain)
-{
-	/* No-op, this is eventually getting removed in 2.5 */
 }
 
 /* Called on thread exit or when moving it to a different memory domain */

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -824,8 +824,6 @@ on MMU systems and uncommon on MPU systems:
 
 * :c:func:`arch_mem_domain_partition_remove`
 
-* :c:func:`arch_mem_domain_destroy`
-
 Please see the doxygen documentation of these APIs for details.
 
 In addition to implementing these APIs, there are some other tasks as well:

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -609,19 +609,6 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
  */
 void arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				   uint32_t partition_id);
-
-/**
- * @brief Remove the memory domain
- *
- * Architecture-specific hook to manage internal data structures or hardware
- * state when a memory domain has been destroyed.
- *
- * Thread assignments to the memory domain are only cleared after this function
- * runs.
- *
- * @param domain The memory domain structure which needs to be deleted.
- */
-void arch_mem_domain_destroy(struct k_mem_domain *domain);
 #endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 /**

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -753,7 +753,6 @@ config ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	  arch_mem_domain_thread_remove
 	  arch_mem_domain_partition_remove
 	  arch_mem_domain_partition_add
-	  arch_mem_domain_destroy
 
 	  It's important to note that although supervisor threads can be
 	  members of memory domains, they have no implications on supervisor


### PR DESCRIPTION
The only user of arch_mem_domain_destroy was the deprecated
k_mem_domain_destroy function which has now been removed.  So remove
arch_mem_domain_destroy as well.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>