### PR TITLE
counters: Remove deprecated APIs

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -62,6 +62,8 @@ Removed APIs in this release
 
 * Removed support for k_mem_domain_destroy and k_mem_domain_remove_thread
 
+* Removed support for counter_read and counter_get_max_relative_alarm
+
 ============================
 
 Stable API changes in this release

--- a/drivers/counter/counter_esp32.c
+++ b/drivers/counter/counter_esp32.c
@@ -205,11 +205,6 @@ static uint32_t counter_esp32_get_top_value(const struct device *dev)
 	return DEV_CFG(dev)->counter_info.max_top_value;
 }
 
-static uint32_t counter_esp32_get_max_relative_alarm(const struct device *dev)
-{
-	return counter_esp32_get_top_value(dev);
-}
-
 static const struct counter_driver_api counter_api = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
@@ -219,7 +214,6 @@ static const struct counter_driver_api counter_api = {
 	.set_top_value = counter_esp32_set_top_value,
 	.get_pending_int = counter_esp32_get_pending_int,
 	.get_top_value = counter_esp32_get_top_value,
-	.get_max_relative_alarm = counter_esp32_get_max_relative_alarm
 };
 
 static void counter_esp32_isr(struct device *dev)

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -153,13 +153,6 @@ static uint32_t counter_gecko_get_top_value(const struct device *dev)
 	return RTCC_ChannelCCVGet(1);
 }
 
-static uint32_t counter_gecko_get_max_relative_alarm(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return RTCC_ChannelCCVGet(1);
-}
-
 static int counter_gecko_set_alarm(const struct device *dev, uint8_t chan_id,
 				   const struct counter_alarm_cfg *alarm_cfg)
 {
@@ -327,7 +320,6 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 	.set_top_value = counter_gecko_set_top_value,
 	.get_pending_int = counter_gecko_get_pending_int,
 	.get_top_value = counter_gecko_get_top_value,
-	.get_max_relative_alarm = counter_gecko_get_max_relative_alarm,
 };
 
 /* RTCC0 */

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -129,13 +129,6 @@ static inline uint32_t z_vrfy_counter_get_max_top_value(const struct device *dev
 }
 #include <syscalls/counter_get_max_top_value_mrsh.c>
 
-static inline uint32_t z_vrfy_counter_get_max_relative_alarm(const struct device *dev)
-{
-	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, get_max_relative_alarm));
-	return z_impl_counter_get_max_relative_alarm((const struct device *)dev);
-}
-#include <syscalls/counter_get_max_relative_alarm_mrsh.c>
-
 static inline uint32_t z_vrfy_counter_get_guard_period(const struct device *dev,
 							uint32_t flags)
 {

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -134,11 +134,6 @@ static uint32_t imx_epit_get_top_value(const struct device *dev)
 	return EPIT_GetCounterLoadValue(base);
 }
 
-static uint32_t imx_epit_get_max_relative_alarm(const struct device *dev)
-{
-	return COUNTER_MAX_RELOAD;
-}
-
 static const struct counter_driver_api imx_epit_driver_api = {
 	.start = imx_epit_start,
 	.stop = imx_epit_stop,
@@ -146,7 +141,6 @@ static const struct counter_driver_api imx_epit_driver_api = {
 	.set_top_value = imx_epit_set_top_value,
 	.get_pending_int = imx_epit_get_pending_int,
 	.get_top_value = imx_epit_get_top_value,
-	.get_max_relative_alarm = imx_epit_get_max_relative_alarm,
 };
 
 #define COUNTER_IMX_EPIT_DEVICE(idx)					       \

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -246,15 +246,6 @@ static int rtc_stm32_set_top_value(const struct device *dev,
 
 }
 
-
-static uint32_t rtc_stm32_get_max_relative_alarm(const struct device *dev)
-{
-	const struct counter_config_info *info = dev->config;
-
-	return info->max_top_value;
-}
-
-
 void rtc_stm32_isr(const struct device *dev)
 {
 	struct rtc_stm32_data *data = DEV_DATA(dev);
@@ -423,7 +414,6 @@ static const struct counter_driver_api rtc_stm32_driver_api = {
 		.set_top_value = rtc_stm32_set_top_value,
 		.get_pending_int = rtc_stm32_get_pending_int,
 		.get_top_value = rtc_stm32_get_top_value,
-		.get_max_relative_alarm = rtc_stm32_get_max_relative_alarm,
 };
 
 DEVICE_DT_INST_DEFINE(0, &rtc_stm32_init, device_pm_control_nop,

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -241,13 +241,6 @@ static int counter_xec_set_top_value(const struct device *dev,
 	return ret;
 }
 
-static uint32_t counter_xec_get_max_relative_alarm(const struct device *dev)
-{
-	const struct counter_xec_config *counter_cfg = COUNTER_XEC_CONFIG(dev);
-
-	return counter_cfg->info.max_top_value;
-}
-
 static void counter_xec_isr(const struct device *dev)
 {
 	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
@@ -284,7 +277,6 @@ static const struct counter_driver_api counter_xec_api = {
 		.set_top_value = counter_xec_set_top_value,
 		.get_pending_int = counter_xec_get_pending_int,
 		.get_top_value = counter_xec_get_top_value,
-		.get_max_relative_alarm = counter_xec_get_max_relative_alarm,
 };
 
 static int counter_xec_init(const struct device *dev)

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -162,13 +162,6 @@ static uint32_t mcux_gpt_get_top_value(const struct device *dev)
 	return config->info.max_top_value;
 }
 
-static uint32_t mcux_gpt_get_max_relative_alarm(const struct device *dev)
-{
-	const struct mcux_gpt_config *config = dev->config;
-
-	return config->info.max_top_value;
-}
-
 static int mcux_gpt_init(const struct device *dev)
 {
 	const struct mcux_gpt_config *config = dev->config;
@@ -205,7 +198,6 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	.set_top_value = mcux_gpt_set_top_value,
 	.get_pending_int = mcux_gpt_get_pending_int,
 	.get_top_value = mcux_gpt_get_top_value,
-	.get_max_relative_alarm = mcux_gpt_get_max_relative_alarm,
 };
 
 #define GPT_DEVICE_INIT_MCUX(n)						\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -103,14 +103,6 @@ static uint32_t mcux_lptmr_get_top_value(const struct device *dev)
 	return (config->base->CMR & LPTMR_CMR_COMPARE_MASK) + 1U;
 }
 
-static uint32_t mcux_lptmr_get_max_relative_alarm(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/* Alarms not supported */
-	return 0;
-}
-
 static void mcux_lptmr_isr(const struct device *dev)
 {
 	const struct mcux_lptmr_config *config = dev->config;
@@ -156,7 +148,6 @@ static const struct counter_driver_api mcux_lptmr_driver_api = {
 	.set_top_value = mcux_lptmr_set_top_value,
 	.get_pending_int = mcux_lptmr_get_pending_int,
 	.get_top_value = mcux_lptmr_get_top_value,
-	.get_max_relative_alarm = mcux_lptmr_get_max_relative_alarm,
 };
 
 #define TO_LPTMR_CLK_SEL(val) _DO_CONCAT(kLPTMR_PrescalerClock_, val)

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -107,13 +107,6 @@ static uint32_t mcux_pit_get_pending_int(const struct device *dev)
 	return ((flags & mask) == mask);
 }
 
-static uint32_t mcux_pit_get_max_relative_alarm(const struct device *dev)
-{
-	const struct mcux_pit_config *config = dev->config;
-
-	return config->info.max_top_value;
-}
-
 static void mcux_pit_isr(const struct device *dev)
 {
 	const struct mcux_pit_config *config = dev->config;
@@ -208,7 +201,6 @@ static const struct counter_driver_api mcux_pit_driver_api = {
 	.cancel_alarm = mcux_pit_cancel_alarm,
 	.get_pending_int = mcux_pit_get_pending_int,
 	.get_top_value = mcux_pit_get_top_value,
-	.get_max_relative_alarm = mcux_pit_get_max_relative_alarm,
 };
 
 /*

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -182,13 +182,6 @@ static uint32_t mcux_rtc_get_top_value(const struct device *dev)
 	return info->max_top_value;
 }
 
-static uint32_t mcux_rtc_get_max_relative_alarm(const struct device *dev)
-{
-	const struct counter_config_info *info = dev->config;
-
-	return info->max_top_value;
-}
-
 static void mcux_rtc_isr(const struct device *dev)
 {
 	const struct counter_config_info *info = dev->config;
@@ -258,7 +251,6 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	.set_top_value = mcux_rtc_set_top_value,
 	.get_pending_int = mcux_rtc_get_pending_int,
 	.get_top_value = mcux_rtc_get_top_value,
-	.get_max_relative_alarm = mcux_rtc_get_max_relative_alarm,
 };
 
 static struct mcux_rtc_data mcux_rtc_data_0;

--- a/drivers/counter/counter_native_posix.c
+++ b/drivers/counter/counter_native_posix.c
@@ -92,11 +92,6 @@ static uint32_t ctr_get_top_value(const struct device *dev)
 	return TOP_VALUE;
 }
 
-static uint32_t ctr_get_max_relative_alarm(const struct device *dev)
-{
-	return TOP_VALUE;
-}
-
 static int ctr_set_alarm(const struct device *dev, uint8_t chan_id,
 			 const struct counter_alarm_cfg *alarm_cfg)
 {
@@ -144,7 +139,6 @@ static const struct counter_driver_api ctr_api = {
 	.set_top_value = ctr_set_top_value,
 	.get_pending_int = ctr_get_pending_int,
 	.get_top_value = ctr_get_top_value,
-	.get_max_relative_alarm = ctr_get_max_relative_alarm,
 };
 
 static const struct counter_config_info ctr_config = {

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -552,11 +552,6 @@ static uint32_t get_top_value(const struct device *dev)
 	return get_dev_data(dev)->top;
 }
 
-static uint32_t get_max_relative_alarm(const struct device *dev)
-{
-	return get_dev_data(dev)->top;
-}
-
 static uint32_t get_guard_period(const struct device *dev, uint32_t flags)
 {
 	return get_dev_data(dev)->guard_period;
@@ -647,7 +642,6 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	.set_top_value = set_top_value,
 	.get_pending_int = get_pending_int,
 	.get_top_value = get_top_value,
-	.get_max_relative_alarm = get_max_relative_alarm,
 	.get_guard_period = get_guard_period,
 	.set_guard_period = set_guard_period,
 };

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -82,11 +82,6 @@ static uint32_t get_top_value(const struct device *dev)
 	return nrf_timer_cc_get(get_nrfx_config(dev)->timer, TOP_CH);
 }
 
-static uint32_t get_max_relative_alarm(const struct device *dev)
-{
-	return get_top_value(dev);
-}
-
 static uint32_t read(const struct device *dev)
 {
 	NRF_TIMER_Type *timer = get_nrfx_config(dev)->timer;
@@ -379,7 +374,6 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	.set_top_value = set_top_value,
 	.get_pending_int = get_pending_int,
 	.get_top_value = get_top_value,
-	.get_max_relative_alarm = get_max_relative_alarm,
 	.get_guard_period = get_guard_period,
 	.set_guard_period = set_guard_period,
 };

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -305,11 +305,6 @@ static uint32_t counter_sam0_tc32_get_top_value(const struct device *dev)
 	return tc->CC[0].reg;
 }
 
-static uint32_t counter_sam0_tc32_get_max_relative_alarm(const struct device *dev)
-{
-	return counter_sam0_tc32_get_top_value(dev) - 1;
-}
-
 static void counter_sam0_tc32_isr(const struct device *dev)
 {
 	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
@@ -402,7 +397,6 @@ static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 	.set_top_value = counter_sam0_tc32_set_top_value,
 	.get_pending_int = counter_sam0_tc32_get_pending_int,
 	.get_top_value = counter_sam0_tc32_get_top_value,
-	.get_max_relative_alarm = counter_sam0_tc32_get_max_relative_alarm,
 };
 
 

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -256,13 +256,6 @@ static uint32_t xlnx_axi_timer_get_top_value(const struct device *dev)
 	return xlnx_axi_timer_read32(dev, TLR0_OFFSET);
 }
 
-static uint32_t xlnx_axi_timer_get_max_relative_alarm(const struct device *dev)
-{
-	const struct xlnx_axi_timer_config *config = dev->config;
-
-	return config->info.max_top_value;
-}
-
 static void xlnx_axi_timer_isr(const struct device *dev)
 {
 	struct xlnx_axi_timer_data *data = dev->data;
@@ -323,7 +316,6 @@ static const struct counter_driver_api xlnx_axi_timer_driver_api = {
 	.set_top_value = xlnx_axi_timer_set_top_value,
 	.get_pending_int = xlnx_axi_timer_get_pending_int,
 	.get_top_value = xlnx_axi_timer_get_top_value,
-	.get_max_relative_alarm = xlnx_axi_timer_get_max_relative_alarm,
 };
 
 #define XLNX_AXI_TIMER_INIT(n)						\

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1281,11 +1281,6 @@ static int ds3231_counter_set_top_value(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static uint32_t ds3231_counter_get_max_relative_alarm(const struct device *dev)
-{
-	return UINT32_MAX;
-}
-
 static const struct counter_driver_api ds3231_api = {
 	.start = ds3231_counter_start,
 	.stop = ds3231_counter_stop,
@@ -1295,7 +1290,6 @@ static const struct counter_driver_api ds3231_api = {
 	.set_top_value = ds3231_counter_set_top_value,
 	.get_pending_int = ds3231_counter_get_pending_int,
 	.get_top_value = ds3231_counter_get_top_value,
-	.get_max_relative_alarm = ds3231_counter_get_max_relative_alarm,
 };
 
 static const struct ds3231_config ds3231_0_config = {

--- a/include/drivers/counter.h
+++ b/include/drivers/counter.h
@@ -183,7 +183,6 @@ typedef int (*counter_api_set_top_value)(const struct device *dev,
 					 const struct counter_top_cfg *cfg);
 typedef uint32_t (*counter_api_get_pending_int)(const struct device *dev);
 typedef uint32_t (*counter_api_get_top_value)(const struct device *dev);
-typedef uint32_t (*counter_api_get_max_relative_alarm)(const struct device *dev);
 typedef uint32_t (*counter_api_get_guard_period)(const struct device *dev,
 						 uint32_t flags);
 typedef int (*counter_api_set_guard_period)(const struct device *dev,
@@ -199,7 +198,6 @@ __subsystem struct counter_driver_api {
 	counter_api_set_top_value set_top_value;
 	counter_api_get_pending_int get_pending_int;
 	counter_api_get_top_value get_top_value;
-	counter_api_get_max_relative_alarm get_max_relative_alarm;
 	counter_api_get_guard_period get_guard_period;
 	counter_api_set_guard_period set_guard_period;
 };
@@ -516,24 +514,6 @@ static inline uint32_t z_impl_counter_get_top_value(const struct device *dev)
 }
 
 /**
- * @brief Function to retrieve maximum relative value that can be set by @ref
- *        counter_set_channel_alarm.
- *
- * @param[in]  dev    Pointer to the device structure for the driver instance.
- *
- * @return Max alarm value.
- */
-__deprecated __syscall uint32_t counter_get_max_relative_alarm(const struct device *dev);
-
-static inline uint32_t z_impl_counter_get_max_relative_alarm(const struct device *dev)
-{
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
-
-	return api->get_max_relative_alarm(dev);
-}
-
-/**
  * @brief Set guard period in counter ticks.
  *
  * Setting non-zero guard period enables detection of setting absolute alarm
@@ -599,21 +579,6 @@ static inline uint32_t z_impl_counter_get_guard_period(const struct device *dev,
 				(struct counter_driver_api *)dev->api;
 
 	return (api->get_guard_period) ? api->get_guard_period(dev, flags) : 0;
-}
-
-/* Deprecated counter callback. */
-typedef void (*counter_callback_t)(const struct device *dev, void *user_data);
-
-/* Deprecated counter read function. Use counter_get_value() instead. */
-__deprecated static inline uint32_t counter_read(const struct device *dev)
-{
-	uint32_t ticks;
-
-	if (counter_get_value(dev, &ticks) == 0) {
-		return ticks;
-	}
-
-	return 0;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Remove support for counter_read and counter_get_max_relative_alarm as
they have been deprecated for at least 2 releases.  As part of the
removal of counter_get_max_relative_alarm remove the code in all
counter drivers that implemented the API.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>