### PR TITLE
requirements-doc: add PyYAML which removes dependency on -base (v2)

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -45,7 +45,6 @@ jobs:
     - name: install-pip
       run: |
         sudo pip3 install -U setuptools wheel pip
-        pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
         pip3 install west==0.11.0
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -8,5 +8,6 @@ sphinxcontrib-svg2pdfconverter
 pygments~=2.9
 sphinx-notfound-page>=0.6
 
-# Used by zephyr_module
+# YAML validation. Used by zephyr_module.
+PyYAML>=5.1
 pykwalify

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -12,13 +12,13 @@ _logger = logging.getLogger('runners')
 def _import_runner_module(runner_name):
     try:
         importlib.import_module(f'runners.{runner_name}')
-    except ImportError:
+    except ImportError as ie:
         # Runners are supposed to gracefully handle failures when they
         # import anything outside of stdlib, but they sometimes do
         # not. Catch ImportError to handle this.
         _logger.warning(f'The module for runner "{runner_name}" '
-                        'could not be imported. This most likely means '
-                        'it is not handling its dependencies properly. '
+                        f'could not be imported ({ie}). This most likely '
+                        'means it is not handling its dependencies properly. '
                         'Please report this to the zephyr developers.')
 
 # We import these here to ensure the ZephyrBinaryRunner subclasses are


### PR DESCRIPTION
This is "version 2" of #31239 rebased after #32593 which made many of the comments and discussions in #31239 obsolete.

~3 commits~ 2 commits, the main one:

This means a light requirements-doc.txt is enough for doc writers. See
previous discussions in PR #31199 and PR #31239

Also add comment that a west-less doc build is possible since the
spurious, indirect dependency on west was removed by commit
a56e1fa52d63a0 ("scripts: runners: bossac: handle edtlib ImportError")
which removed the `zephyr_ext_common` import from `bossac.py`.


Pro tip/note to self: changes to `bossac.py` do not trigger a fast, incremental doc build. Instead: `printf '\n' >> doc/guides/west/build-flash-debug.rst` does it (for bossac.py)