### PR TITLE
tests: kernel: pipe: second part of testcases to improve pipes coverage

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -18,6 +18,7 @@ extern void test_pipe_get_fail(void);
 extern void test_pipe_block_put(void);
 extern void test_pipe_block_put_sema(void);
 extern void test_pipe_get_put(void);
+extern void test_pipe_get_large(void);
 
 extern void test_half_pipe_put_get(void);
 extern void test_half_pipe_saturating_block_put(void);
@@ -78,6 +79,7 @@ void test_main(void)
 			 ztest_unit_test(test_pipe_get_fail),
 			 ztest_unit_test(test_half_pipe_put_get),
 			 ztest_unit_test(test_pipe_get_put),
+			 ztest_unit_test(test_pipe_get_large),
 			 ztest_1cpu_unit_test(test_pipe_alloc),
 			 ztest_unit_test(test_pipe_cleanup),
 			 ztest_unit_test(test_pipe_reader_wait),

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_avail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_avail.c
@@ -20,11 +20,16 @@ static struct k_pipe pipe = {
 
 static struct k_pipe bufferless;
 
+static struct k_pipe bufferless1 = {
+	.buffer = data,
+	.size = 0,
+};
+
 /**
- * @brief Ensure that bufferless pipes return 0 bytes available
+ * @brief Pipes with no buffer or size 0 should return 0 bytes available
  *
  * Pipes can be created to be bufferless (i.e. @ref k_pipe.buffer is `NULL`
- * and @ref k_pipe.size is 0).
+ * or @ref k_pipe.size is 0).
  *
  * If either of those conditions is true, then @ref k_pipe_read_avail and
  * @ref k_pipe_write_avail should return 0.
@@ -44,6 +49,12 @@ void test_pipe_avail_no_buffer(void)
 	zassert_equal(r_avail, 0, "read: expected: 0 actual: %u", r_avail);
 
 	w_avail = k_pipe_write_avail(&bufferless);
+	zassert_equal(w_avail, 0, "write: expected: 0 actual: %u", w_avail);
+
+	r_avail = k_pipe_read_avail(&bufferless1);
+	zassert_equal(r_avail, 0, "read: expected: 0 actual: %u", r_avail);
+
+	w_avail = k_pipe_write_avail(&bufferless1);
 	zassert_equal(w_avail, 0, "write: expected: 0 actual: %u", w_avail);
 }
 


### PR DESCRIPTION
Added test_pipe_get_large to cover branches in both k_pipe_put and k_pipe_get. 
Added trivial testcases in test_pipe_avail_no_buffer to cover trivial branches for k_pipe_read_avail and k_pipe_write_avail.

This is the second patch as the continuation of #31037.

Signed-off-by: Shihao Shen <shihao.shen@intel.com>