### PR TITLE
Bluetooth: host: Fix issues in use of big-handle from HCI events

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1415,6 +1415,7 @@ void hci_le_big_complete(struct net_buf *buf)
 
 	if (evt->num_bis != big->num_bis) {
 		BT_ERR("Invalid number of BIS, was %u expected %u", evt->num_bis, big->num_bis);
+		big_disconnect(big);
 		cleanup_big(big);
 		return;
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1116,7 +1116,7 @@ static struct bt_iso_big *get_free_big(void)
 	 */
 
 	for (int i = 0; i < ARRAY_SIZE(bigs); i++) {
-		if (atomic_get(&bigs[i].initialized) == false) {
+		if (!atomic_test_and_set_bit(bigs[i].flags, BT_BIG_INITIALIZED)) {
 			bigs[i].handle = i;
 			return &bigs[i];
 		}
@@ -1138,9 +1138,7 @@ static void cleanup_big(struct bt_iso_big *big)
 		}
 	}
 
-	big->bis = NULL;
-	big->num_bis = 0;
-	atomic_clear(&big->initialized);
+	memset(big, 0, sizeof(*big));
 }
 
 static void big_disconnect(struct bt_iso_big *big)
@@ -1279,8 +1277,6 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 		return err;
 	}
 
-	atomic_set(&big->initialized, true);
-
 	*out_big = big;
 
 	return err;
@@ -1338,7 +1334,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 	int err;
 	bool broadcaster;
 
-	if (atomic_get(&big->initialized) == false || !big->num_bis || !big->bis) {
+	if (!atomic_test_bit(big->flags, BT_BIG_INITIALIZED) || !big->num_bis || !big->bis) {
 		BT_DBG("BIG not initialized");
 		return -EINVAL;
 	}
@@ -1564,8 +1560,6 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 	for (int i = 0; i < big->num_bis; i++) {
 		bt_iso_chan_set_state(big->bis[i], BT_ISO_CONNECT);
 	}
-
-	atomic_set(&big->initialized, true);
 
 	*out_big = big;
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1401,8 +1401,7 @@ void hci_le_big_complete(struct net_buf *buf)
 void hci_le_big_terminate(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_terminate *evt = (void *)buf->data;
-	uint16_t handle = sys_le16_to_cpu(evt->big_handle);
-	struct bt_iso_big *big = &bigs[handle];
+	struct bt_iso_big *big = &bigs[evt->big_handle];
 
 	BT_DBG("BIG[%u] %p terminated", big->handle, big);
 
@@ -1413,8 +1412,7 @@ void hci_le_big_terminate(struct net_buf *buf)
 void hci_le_big_sync_established(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_sync_established *evt = (void *)buf->data;
-	uint16_t big_handle = sys_le16_to_cpu(evt->big_handle);
-	struct bt_iso_big *big = &bigs[big_handle];
+	struct bt_iso_big *big = &bigs[evt->big_handle];
 
 	BT_DBG("BIG[%u] %p sync established", big->handle, big);
 
@@ -1442,8 +1440,7 @@ void hci_le_big_sync_established(struct net_buf *buf)
 void hci_le_big_sync_lost(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_sync_lost *evt = (void *)buf->data;
-	uint16_t handle = sys_le16_to_cpu(evt->big_handle);
-	struct bt_iso_big *big = &bigs[handle];
+	struct bt_iso_big *big = &bigs[evt->big_handle];
 
 	BT_DBG("BIG[%u] %p sync lost", big->handle, big);
 

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -26,6 +26,12 @@ struct iso_data {
 	uint32_t ts;
 };
 
+enum {
+	BT_BIG_INITIALIZED,
+
+	BT_BIG_NUM_FLAGS,
+};
+
 struct bt_iso_big {
 	/** Array of ISO channels to setup as BIS (the BIG). */
 	struct bt_iso_chan **bis;
@@ -36,7 +42,7 @@ struct bt_iso_big {
 	/** The BIG handle */
 	uint8_t handle;
 
-	atomic_t initialized;
+	ATOMIC_DEFINE(flags, BT_BIG_NUM_FLAGS);
 };
 
 #define iso(buf) ((struct iso_data *)net_buf_user_data(buf))

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -29,6 +29,11 @@ struct iso_data {
 enum {
 	BT_BIG_INITIALIZED,
 
+	/* Creating a BIG as a broadcaster */
+	BT_BIG_PENDING,
+	/* Creating a BIG as a receiver */
+	BT_BIG_SYNCING,
+
 	BT_BIG_NUM_FLAGS,
 };
 


### PR DESCRIPTION
Fix parsing BIG handle which is just one octet as a two octet field,
which could have caused problems on big-endian systems.

Validate the big_handle before received from the controller before
using it as an array into the bigs array.

Discover by coverity: Insecure data handling  (TAINTED_SCALAR)
  Using tainted variable "big_handle" as an index into an array "bigs".

Fixes: #33312
Fixes: #33313
