### PR TITLE
disable long time case from NXP FRDM_KW41Z

### DIFF
--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -15,3 +15,6 @@ supported:
   - ieee802154
   - spi
   - pwm
+testing:
+  ignore_tags:
+    - bluetooth

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -35,19 +35,21 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
   libraries.cmsis_dsp.matrix.binary_q15:
-    platform_exclude: mps2_an521
+    platform_exclude: mps2_an521 frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q15=y
   libraries.cmsis_dsp.matrix.binary_q31:
+    platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q31=y
   libraries.cmsis_dsp.matrix.binary_f32:
+    platform_exclude: frdm_kw41z
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags: net socket userspace
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   platform_exclude: intel_adsp_cavs15
+  depends_on: netif
 tests:
   net.socket.socketpair:
     min_ram: 21


### PR DESCRIPTION
CMSIS_DSP and net_socket tests are either too
slow or too large for this platform

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>