### PR TITLE
doc: bluetooth: Fix a typo in the nRF5340 note.

### DIFF
--- a/samples/bluetooth/bluetooth.rst
+++ b/samples/bluetooth/bluetooth.rst
@@ -20,7 +20,7 @@ documentation and are prefixed with :literal:`hci_` in their folder names.
    ``-DBOARD=nrf5340dk_nrf5340_cpuapp`` or
    ``-DBOARD=nrf5340dk_nrf5340_cpuappns``) you must also build
    and program the corresponding sample for the nRF5340 network core
-   :ref:` bluetooth-hci-rpmsg-sample` which implements the Bluetooth
+   :ref:`bluetooth-hci-rpmsg-sample` which implements the Bluetooth
    Low Energy controller.
 
 .. note::


### PR DESCRIPTION
Fix a typo in the note box, which brakes a reference introduced in https://github.com/zephyrproject-rtos/zephyr/pull/33244.