### PR TITLE
Shell: Changes needed to enable shell reinitialization

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -498,6 +498,9 @@ enum shell_transport_evt {
 typedef void (*shell_transport_handler_t)(enum shell_transport_evt evt,
 					  void *context);
 
+
+typedef void (*shell_uninit_cb_t)(const struct shell *shell, int res);
+
 struct shell_transport;
 
 /**
@@ -654,6 +657,11 @@ struct shell_ctx {
 	/*!< VT100 color and cursor position, terminal width.*/
 	struct shell_vt100_ctx vt100_ctx;
 
+	/*!< Callback called from shell thread context when unitialization is
+	 * completed just before aborting shell thread.
+	 */
+	shell_uninit_cb_t uninit_cb;
+
 #if defined CONFIG_SHELL_GETOPT
 	/*!< getopt context for a shell backend. */
 	struct getopt_state getopt_state;
@@ -784,10 +792,11 @@ int shell_init(const struct shell *shell, const void *transport_config,
  * @brief Uninitializes the transport layer and the internal shell state.
  *
  * @param shell Pointer to shell instance.
+ * @param cb Callback called when uninitialization is completed.
  *
  * @return Standard error code.
  */
-int shell_uninit(const struct shell *shell);
+void shell_uninit(const struct shell *shell, shell_uninit_cb_t cb);
 
 /**
  * @brief Function for starting shell processing.

--- a/samples/subsys/shell/shell_module/CMakeLists.txt
+++ b/samples/subsys/shell/shell_module/CMakeLists.txt
@@ -6,3 +6,4 @@ project(shell_module)
 
 target_sources(app PRIVATE src/main.c src/test_module.c)
 target_sources_ifdef(CONFIG_SHELL_DYNAMIC_CMDS app PRIVATE src/dynamic_cmd.c src/qsort.c)
+target_sources_ifdef(CONFIG_SHELL_BACKEND_SERIAL app PRIVATE src/uart_reinit.c)

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <shell/shell.h>
+#include <shell/shell_uart.h>
+#include <drivers/uart.h>
+#include <device.h>
+
+void shell_init_from_work(struct k_work *work)
+{
+	const struct device *dev =
+			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
+	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
+	uint32_t level =
+		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
+		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
+
+	shell_init(shell_backend_uart_get_ptr(), dev, true, log_backend, level);
+}
+
+static void shell_reinit_trigger(void)
+{
+	static struct k_work shell_init_work;
+
+	k_work_init(&shell_init_work, shell_init_from_work);
+	int err = k_work_submit(&shell_init_work);
+
+	(void)err;
+	__ASSERT_NO_MSG(err >= 0);
+}
+
+static void direct_uart_callback(const struct device *dev, void *user_data)
+{
+	static uint8_t buf[1];
+	static bool tx_busy;
+
+	uart_irq_update(dev);
+
+
+	if (uart_irq_rx_ready(dev)) {
+		while (uart_fifo_read(dev, buf, sizeof(buf))) {
+			if (!tx_busy) {
+				uart_irq_tx_enable(dev);
+			}
+		}
+	}
+
+	if (uart_irq_tx_ready(dev)) {
+		if (!tx_busy) {
+			(void)uart_fifo_fill(dev, buf, sizeof(buf));
+			tx_busy = true;
+		} else {
+			tx_busy = false;
+			uart_irq_tx_disable(dev);
+			if (buf[0] == 'x') {
+				uart_irq_rx_disable(dev);
+				shell_reinit_trigger();
+			}
+		}
+	}
+}
+
+static void uart_poll_timer_stopped(struct k_timer *timer)
+{
+	shell_reinit_trigger();
+}
+
+static void uart_poll_timeout(struct k_timer *timer)
+{
+	char c;
+	const struct device *dev = k_timer_user_data_get(timer);
+
+	while (uart_poll_in(dev, &c) == 0) {
+		if (c != 'x') {
+			uart_poll_out(dev, c);
+		} else {
+			k_timer_stop(timer);
+		}
+	}
+}
+
+K_TIMER_DEFINE(uart_poll_timer, uart_poll_timeout, uart_poll_timer_stopped);
+
+static void shell_uninit_cb(const struct shell *shell, int res)
+{
+	__ASSERT_NO_MSG(res >= 0);
+	const struct device *dev =
+			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
+
+	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
+		/* connect uart to my handler */
+		uart_irq_callback_user_data_set(dev, direct_uart_callback, NULL);
+		uart_irq_tx_disable(dev);
+		uart_irq_rx_enable(dev);
+	} else {
+		k_timer_user_data_set(&uart_poll_timer, (void *)dev);
+		k_timer_start(&uart_poll_timer, K_MSEC(10), K_MSEC(10));
+	}
+}
+
+static int cmd_uart_release(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	if (shell != shell_backend_uart_get_ptr()) {
+		shell_error(shell, "Command dedicated for shell over uart");
+		return -EINVAL;
+	}
+
+	shell_print(shell, "Uninitializing shell, use 'x' to reinitialize");
+	shell_uninit(shell, shell_uninit_cb);
+
+	return 0;
+}
+
+SHELL_CMD_REGISTER(shell_uart_release, NULL,
+		"Uninitialize shell instance and release uart, start loopback "
+		"on uart. Shell instance is renitialized when 'x' is pressed",
+		cmd_uart_release);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1232,7 +1232,13 @@ static void shell_signal_handle(const struct shell *shell,
 
 static void kill_handler(const struct shell *shell)
 {
-	(void)instance_uninit(shell);
+	int err = instance_uninit(shell);
+
+	if (shell->ctx->uninit_cb) {
+		shell->ctx->uninit_cb(shell, err);
+	}
+
+	shell->ctx->tid = NULL;
 	k_thread_abort(k_current_get());
 }
 
@@ -1296,6 +1302,10 @@ int shell_init(const struct shell *shell, const void *transport_config,
 	__ASSERT_NO_MSG(shell);
 	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->default_prompt);
 
+	if (shell->ctx->tid) {
+		return -EALREADY;
+	}
+
 	int err = instance_init(shell, transport_config, use_colors);
 
 	if (err != 0) {
@@ -1314,7 +1324,7 @@ int shell_init(const struct shell *shell, const void *transport_config,
 	return 0;
 }
 
-int shell_uninit(const struct shell *shell)
+void shell_uninit(const struct shell *shell, shell_uninit_cb_t cb)
 {
 	__ASSERT_NO_MSG(shell);
 
@@ -1322,12 +1332,19 @@ int shell_uninit(const struct shell *shell)
 		struct k_poll_signal *signal =
 				&shell->ctx->signals[SHELL_SIGNAL_KILL];
 
+		shell->ctx->uninit_cb = cb;
 		/* signal kill message */
 		(void)k_poll_signal_raise(signal, 0);
 
-		return 0;
+		return;
+	}
+
+	int err = instance_uninit(shell);
+
+	if (cb) {
+		cb(shell, err);
 	} else {
-		return instance_uninit(shell);
+		__ASSERT_NO_MSG(0);
 	}
 }
 

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -144,6 +144,9 @@ static void uart_irq_init(const struct shell_uart *sh_uart)
 #ifdef CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	const struct device *dev = sh_uart->ctrl_blk->dev;
 
+	ring_buf_reset(sh_uart->tx_ringbuf);
+	ring_buf_reset(sh_uart->rx_ringbuf);
+	sh_uart->ctrl_blk->tx_busy = 0;
 	uart_irq_callback_user_data_set(dev, uart_callback, (void *)sh_uart);
 	uart_irq_rx_enable(dev);
 #endif


### PR DESCRIPTION
### shell: Add callback to shell_uninit function
    
Shell uninitialization is not synchronous, it is deferred to shell
thread so resources used by the shell (e.g. transport resource like
uart) cannot be used until it is completed. Added callback which
notifies when all resources are released and shell is uninitialized.
Callback is called from shell thread just before it is aborted.

### shell: uart: Fix init function
    
Init function can be called multiple times (after each shell
reinitialization). It was missing reseting ring buffers and tx_busy
flag. When called once proper state of those variable where handled
by ram sections initialization.

### samples: shell_module: Add shell_uart_release command
    
shell_uart_release command shows how shell can be uninitialized and
release transport resources (uart) and reinitialized at runtime.
