### PR TITLE
ci: github: Update for deprecation of add-path (backport some fixes to doc/zephyr.doxyfile.in)

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Update PATH for west
       run: |
-        echo "::add-path::$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: checkout
       uses: actions/checkout@v2

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -756,8 +756,7 @@ INPUT                  = @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/include/arch/nios2/ \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \
                          @ZEPHYR_BASE@/include/net/dns_resolve.h \
-			 @ZEPHYR_BASE@/subsys/testsuite/ztest/include/ \
-			 @ZEPHYR_BASE@/tests/kernel/
+			 @ZEPHYR_BASE@/subsys/testsuite/ztest/include/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -229,12 +229,6 @@ ALIASES                = "rst=\verbatim embed:rst" \
 
 ALIASES 	       += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              = YES
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2066,12 +2066,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2084,15 +2078,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = NO
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/include/irq_nextlevel.h
+++ b/include/irq_nextlevel.h
@@ -84,10 +84,6 @@ static inline unsigned int irq_is_enabled_next_level(struct device *dev)
 	return api->intr_get_state(dev);
 }
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -66,8 +66,6 @@ struct log_source_dynamic_data {
  * @brief Macro for initializing a pointer to the logger instance.
  */
 
-/** @} */
-
 #ifdef CONFIG_LOG
 
 #define LOG_INSTANCE_FULL_NAME(_module_name, _inst_name) \

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
@@ -102,8 +102,3 @@ void test_pipe_user_get_fail(void)
 	get_fail(p);
 }
 #endif
-
-
-/**
- * @}
- */


### PR DESCRIPTION
Github has deprecated add-path, so update the workflows that use it to
the new method of setting the PATH.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>