### PR TITLE
linker-defs: Fix sorting order of objects by priority

### DIFF
--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -116,8 +116,8 @@
  */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.object##_##level[0-9]*)));		\
-		KEEP(*(SORT(.object##_##level[1-9][0-9]*)));
+		KEEP(*(SORT(.object##_##level[0-9])));		\
+		KEEP(*(SORT(.object##_##level[1-9][0-9])));
 
 /*
  * link in shell initialization objects for all modules that use shell and


### PR DESCRIPTION
Commit 0a7b65ef5e965c1e4a85e414129e3006e69b3c30 tweaked the
CREATE_OBJ_LEVEL macro in such a way that it would break the expected
sorting order.

For example if you had 2, 19, 20, 30 as the level, we'd end up sort
these to be 19, 2, 20, 30.

Fix the regex by dropping the '*' from the level so we properly sort
levels 0-99.

Fixes #33464

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>