### PR TITLE
dts: added constraints for baudrates of UARTs in Nordic SOCs

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -43,3 +43,27 @@ properties:
       description: |
         The CTS pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
+
+    current-speed:
+      description: |
+        Initial baud rate setting for UART. Only a fixed set of baud
+        rates are selectable on these devices.
+      enum:
+        - 1200
+        - 2400
+        - 4800
+        - 9600
+        - 14400
+        - 19200
+        - 28800
+        - 31250
+        - 38400
+        - 56000
+        - 57600
+        - 76800
+        - 115200
+        - 230400
+        - 250000
+        - 460800
+        - 921600
+        - 1000000


### PR DESCRIPTION
Signed-off-by: Peter Niebert <peter.niebert@univ-amu.fr>

I previously submitted a related request, but closed it since I messed up the commits and could not get through with it (sorry for wasting your time).

UARTs in Nordic devices only support a specified list of baud rates. Choosing a different baud rate without this patch will cause a runtime error, whereas with the constraint, this mistake is already found in dts construction with a useful error message.