### PR TITLE
lib: os: cbprintf: Fixes for sparc and size calculation of void * argument

### DIFF
--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -120,6 +120,26 @@ extern "C" {
  *
  * @param arg Argument.
  */
+#ifdef __sparc__
+static inline void cbprintf_wcpy(int *dst, int *src, uint32_t len)
+{
+	for (int i = 0; i < len; i++) {
+		dst[i] = src[i];
+	}
+}
+/* Sparc is expecting va_list to be packed but don't support unaligned access.*/
+#define Z_CBPRINTF_STORE_ARG(buf, arg) do {\
+	__auto_type _v = (arg) + 0; \
+	double _d = _Generic((arg) + 0, \
+			float : (arg) + 0, \
+			default : \
+				0.0); \
+	uint32_t _wsize = Z_CBPRINTF_ARG_SIZE(arg) / sizeof(int); \
+	cbprintf_wcpy((int *)buf, \
+		      (int *) _Generic((arg) + 0, float : &_d, default : &_v), \
+		      _wsize); \
+} while (0)
+#else /* __sparc__ */
 #define Z_CBPRINTF_STORE_ARG(buf, arg) \
 	*_Generic((arg) + 0, \
 		char : (int *)buf, \
@@ -137,6 +157,7 @@ extern "C" {
 		long double : (long double *)buf, \
 		default : \
 			(const void **)buf) = arg
+#endif
 
 /** @brief Return alignment needed for given argument.
  *

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_SYS_CBPRINTF_INTERNAL_H_
 #define ZEPHYR_INCLUDE_SYS_CBPRINTF_INTERNAL_H_
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -100,9 +101,7 @@ extern "C" {
 /** @brief Get storage size for given argument.
  *
  * Floats are promoted to double so they use size of double, others int storage
- * or it's own storage size if it is bigger than int. Strings are stored in
- * the package with 1 byte header indicating if string is stored as pointer or
- * by value.
+ * or it's own storage size if it is bigger than int.
  *
  * @param x argument.
  *
@@ -112,11 +111,7 @@ extern "C" {
 	_Generic((v), \
 		float : sizeof(double), \
 		default : \
-			_Generic((v), \
-				void * : 0, \
-				default : \
-					sizeof((v)+0) \
-				) \
+			sizeof((v)+0) \
 		)
 
 /** @brief Promote and store argument in the buffer.


### PR DESCRIPTION
Similarly to runtime packaging, sparc architecture needed special treatment for unaligned storing of 64/128 bit arguments.
Additionally, there was an error in calculation of `void *` size in static packaging and description of `Z_CBPRINTF_ARG_SIZE` which relaying on older concept for cbprintf packaging.