### PR TITLE
Bluetooth: Mesh: Add h_export support

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -494,6 +494,16 @@ struct bt_mesh_model_cb {
 				  const char *name, size_t len_rd,
 				  settings_read_cb read_cb, void *cb_arg);
 
+	/** @brief Callback called when the stack requests the model to store the user data
+	 * tied to the model in persistent storage.
+	 *
+	 * This happens when @ref settings_save gets called. To store the user data,
+	 * use @ref bt_mesh_model_data_store.
+	 *
+	 *  @param model      Model this callback belongs to.
+	 */
+	void (*const settings_store)(struct bt_mesh_model *model);
+
 	/** @brief Callback called when the mesh is started.
 	 *
 	 *  This handler gets called after the node has been provisioned, or

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -660,7 +660,17 @@ config BT_MESH_MODEL_EXTENSIONS
 	  Enable support for the model extension concept, allowing the Access
 	  layer to know about Mesh model relationships.
 
-if BT_SETTINGS
+menuconfig BT_MESH_AUTO_STORE
+	bool "Store mesh settings automatically"
+	default y
+	depends on BT_SETTINGS
+	help
+	  When enabled, the mesh settings are stored automatically by timer.
+	  Otherwise, call settings_save() to store the mesh settings.
+	  The mesh settings can still be stored by settings_save() call
+	  when this options is enabled.
+
+if BT_MESH_AUTO_STORE
 
 config BT_MESH_STORE_TIMEOUT
 	int "Delay (in seconds) before storing anything persistently"
@@ -703,7 +713,7 @@ config BT_MESH_RPL_STORE_TIMEOUT
 	  writing to storage exposes the node to potential message
 	  replay attacks).
 
-endif # BT_SETTINGS
+endif # BT_MESH_AUTO_STORE
 
 config BT_MESH_DEBUG
 	bool "Enable debug logs"

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1224,6 +1224,20 @@ int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
 	return err;
 }
 
+static void store_model_user_data(struct bt_mesh_model *mod,
+				  struct bt_mesh_elem *elem, bool vnd,
+				  bool primary, void *user_data)
+{
+	if (mod->cb && mod->cb->settings_store) {
+		mod->cb->settings_store(mod);
+	}
+}
+
+void bt_mesh_model_user_data_store_request(void)
+{
+	bt_mesh_model_foreach(store_model_user_data, NULL);
+}
+
 static void commit_mod(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		       bool vnd, bool primary, void *user_data)
 {

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -53,4 +53,5 @@ void bt_mesh_model_pending_store(void);
 void bt_mesh_model_bind_store(struct bt_mesh_model *mod);
 void bt_mesh_model_sub_store(struct bt_mesh_model *mod);
 void bt_mesh_model_pub_store(struct bt_mesh_model *mod);
+void bt_mesh_model_user_data_store_request(void);
 void bt_mesh_model_settings_commit(void);

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -57,7 +57,7 @@
 /** Define CONFIG_BT_MESH_SEQ_STORE_RATE even if settings are disabled to
  * compile the code.
  */
-#ifndef CONFIG_BT_SETTINGS
+#ifndef CONFIG_BT_MESH_AUTO_STORE
 #define CONFIG_BT_MESH_SEQ_STORE_RATE 1
 #endif
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -165,6 +165,7 @@ static int mesh_export(int (*export_func)(const char *name, const void *val,
 	 * to use export_func when implementing h_export, use settings_save_one directly.
 	 */
 	store_pending();
+	bt_mesh_model_user_data_store_request();
 
 	return 0;
 }


### PR DESCRIPTION
In the current approach the mesh settings will be stored after
the configured timeout. However, there are some cases that require the
settings to be stored immediately, e.g. when power failure has been
detected.

This change allows storing the mesh settings by settings_save() call
by implementing h_export settings handler.

It also adds ability to switch off periodic saving of the settings to
rely only on settings_save() call.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>