### PR TITLE
disk: sdhc: Set LSB of command to 1 as end bit

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -146,7 +146,9 @@ static int sdhc_spi_tx_cmd(struct sdhc_spi_data *data, uint8_t cmd, uint32_t pay
 	/* Encode the command */
 	buf[0] = SDHC_TX | (cmd & ~SDHC_START);
 	sys_put_be32(payload, &buf[1]);
-	buf[SDHC_CMD_BODY_SIZE] = crc7_be(0, buf, SDHC_CMD_BODY_SIZE);
+
+	/* Add CRC and set LSB as 'end bit' */
+	buf[SDHC_CMD_BODY_SIZE] = crc7_be(0, buf, SDHC_CMD_BODY_SIZE) | 0x01;
 
 	return sdhc_spi_tx(data, buf, sizeof(buf));
 }


### PR DESCRIPTION
The SD Card Physical Layer specification states in Table 7-1
(in section 7.3.1.1) that the LSB of the 48 bit command must
be set to 1 to act as an 'end bit'.

Fixes #33479

Signed-off-by: Rich Barlow <rich@bennellick.com>