### PR TITLE
dts:arm:st:h7  Add usart10 device node in stm32h723.dtsi as per #33475

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -23,7 +23,7 @@
 			label = "UART_9";
 		};
 
-		usart10: serial@40011C00 {
+		usart10: serial@40011c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011C00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -22,6 +22,15 @@
 			status = "disabled";
 			label = "UART_9";
 		};
+
+		usart10: serial@40011C00 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40011C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			interrupts = <156 0>;
+			status = "disabled";
+			label = "UART_10";
+		};
 	};
 	/* DTCM memory directly coppled to CPU */
 	dtcm: memory@20000000 {


### PR DESCRIPTION
In this PR, I have tried to add usart10 device node in stm32h723.dtsi.

The property values for this node was pulled from stm32h723 technical reference manual.

Memory mapped location:
![image](https://user-images.githubusercontent.com/36400253/111676067-cab55580-8843-11eb-8cac-9ea6e3d55e28.png)

RCC register value:
![image](https://user-images.githubusercontent.com/36400253/111676254-02bc9880-8844-11eb-852f-6be427de510f.png)

Interrupt:
![image](https://user-images.githubusercontent.com/36400253/111676539-47e0ca80-8844-11eb-8a26-1fabb9640e1c.png)
![image](https://user-images.githubusercontent.com/36400253/111676590-562ee680-8844-11eb-9371-af8c848964d2.png)

