### PR TITLE
Create Github security policy document

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+The Zephyr project supports the following versions with security
+updates:
+
+  - The most recent release, and the release prior to that.
+  - Active LTS releases.
+
+At this time, with the latest release of v2.5.0, the supported
+versions are:
+
+  - 1.14.x: Current LTS
+  - v2.4.0: Prior release
+  - v2.5.0: Current release
+
+## Reporting process
+
+Please see our [Security Vulnerability
+Reporting](https://docs.zephyrproject.org/latest/security/reporting.html)
+page for details on the process.


### PR DESCRIPTION
This document will show up when a viewer selects the "Security" tab, and
selects the "Security Policy".  It has a brief introduction, and directs
to the official documentation of the security policy.

Signed-off-by: David Brown <david.brown@linaro.org>