### PR TITLE
boards: arm: nrf5340: Add pwm-led0 alias

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -34,6 +34,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 28>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -100,6 +107,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;


### PR DESCRIPTION
The `pwm-led0` alias is required for building fade_led and blinky_pwm
samples.

Signed-off-by: Sigurd Olav Nevstad <sigurdolav.nevstad@nordicsemi.no>