### PR TITLE
device: remove deprecated device_list_get

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -73,6 +73,8 @@ Removed APIs in this release
 
 * Removed support for counter_read and counter_get_max_relative_alarm
 
+* Removed support for device_list_get
+
 ============================
 
 Stable API changes in this release

--- a/include/device.h
+++ b/include/device.h
@@ -813,25 +813,6 @@ static inline int device_get_power_state(const struct device *dev,
 }
 
 /**
- * @brief Gets the device structure list array and device count
- *
- * Called by the Power Manager application to get the list of
- * device structures associated with the devices in the system.
- * The PM app would use this list to create its own sorted list
- * based on the order it wishes to suspend or resume the devices.
- *
- * @param device_list Pointer to receive the device list array
- * @param device_count Pointer to receive the device count
- *
- * @deprecated in 2.4 release, replace with z_device_get_all_static()
- */
-__deprecated static inline void device_list_get(const struct device * *device_list,
-						int *device_count)
-{
-	*device_count = z_device_get_all_static(device_list);
-}
-
-/**
  * @brief Check if any device is in the middle of a transaction
  *
  * Called by an application to see if any device is in the middle

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -224,7 +224,7 @@ void test_pre_kernel_detection(void)
  * It queries the list of devices in the system, used to suspend or
  * resume the devices in PM applications.
  *
- * @see device_list_get()
+ * @see z_device_get_all_static()
  */
 static void test_build_suspend_device_list(void)
 {
@@ -284,7 +284,7 @@ static void test_enable_and_disable_automatic_idle_pm(void)
  *
  * @see device_get_binding(), device_busy_set(), device_busy_clear(),
  * device_busy_check(), device_any_busy_check(),
- * device_list_get(), device_set_power_state()
+ * device_set_power_state()
  */
 void test_dummy_device_pm(void)
 {


### PR DESCRIPTION
device_list_get has been deprecated for 2 releases so remove the code
associated with it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>