### PR TITLE
arc: mwdt: linker script fix

### DIFF
--- a/include/linker/intlist.ld
+++ b/include/linker/intlist.ld
@@ -34,8 +34,8 @@
 #ifndef LINKER_PASS2
 SECTION_PROLOGUE(.intList,,)
 {
-	KEEP(*(.irq_info))
-	KEEP(*(.intList))
+	KEEP(*(.irq_info*))
+	KEEP(*(.intList*))
 } GROUP_ROM_LINK_IN(IDT_LIST, IDT_LIST)
 #else
 /DISCARD/ :

--- a/include/linker/linker-tool-mwdt.h
+++ b/include/linker/linker-tool-mwdt.h
@@ -46,6 +46,14 @@
  */
 #define GROUP_LINK_IN(where) > where
 
+/**
+ * The GROUP_ROM_LINK_IN() macro is located at the end of the section
+ * description and tells the linker that this a read-only section
+ * that is physically placed at the 'lregion` argument.
+ *
+ */
+#define GROUP_ROM_LINK_IN(vregion, lregion) > lregion
+
 /*
  * As GROUP_LINK_IN(), but takes a second argument indicating the
  * memory region (e.g. "ROM") for the load address.  Used for
@@ -63,13 +71,15 @@
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
 #endif
 
-/*
- * The GROUP_FOLLOWS_AT() macro is located at the end of the section
- * and indicates that the section does not specify an address at which
- * it is to be loaded, but that it follows a section which did specify
- * such an address
+/**
+ * Route memory for read-write sections that are NOT loaded; typically this
+ * is only used for 'BSS' and 'noinit'.
  */
-#define GROUP_FOLLOWS_AT(where) AT > where
+#ifdef CONFIG_XIP
+#define GROUP_NOLOAD_LINK_IN(vregion, lregion) > vregion AT > vregion
+#else
+#define GROUP_NOLOAD_LINK_IN(vregion, lregion) > vregion
+#endif
 
 /*
  * The SECTION_PROLOGUE() macro is used to define the beginning of a section.


### PR DESCRIPTION
There are some adjustment in zephyr's linker script in commit: [linker-tool-gcc: revise for MMU support](https://github.com/zephyrproject-rtos/zephyr/commit/acda9bf9cec8cc366e5a319f7f35cc234a6e34d3), which cause mwdt toolchain didn't work. we need to do some compliant adjustment with mwdt toohchain. 

- New macro GROUP_ROM_LINK_IN for text/rodata sections

- New macro GROUP_NOLOAD_LINK_IN for bss/noinit sections

- GROUP_FOLLOWS_AT is unused anywhere in the kernel for years now and has been removed.

- tweak section naming to feet all linkers. mwdt toolchain adds additional suffix to sections name in case of ffunction-sections / fdata-sections are enabled. Let's pick a single set of rules and syntax that work.


Fix: #33457 