### PR TITLE
soc: riscv: riscv-ite serie enable config

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -4,6 +4,7 @@
 config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
+	select COMPRESSED_ISA
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2


### PR DESCRIPTION
Enable the config of COMPRESSED_ISA, this can work fine on
32-bit architecture.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>