### PR TITLE
boards: adafruit_feather_stm32f405: OpenOCD support

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/board.cmake
+++ b/boards/arm/adafruit_feather_stm32f405/board.cmake
@@ -5,3 +5,4 @@ board_runner_args(jlink "--device=STM32F405RG" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/adafruit_feather_stm32f405/support/openocd.cfg
+++ b/boards/arm/adafruit_feather_stm32f405/support/openocd.cfg
@@ -1,0 +1,18 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f4x.cfg]
+
+reset_config srst_only
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
This board has pads for and SWD header as per
https://learn.adafruit.com/adafruit-stm32f405-feather-express/pinouts#swd-port-3050618-16
This commit addes OpenOCD support to the board

Signed-off-by: Richard Osterloh <richard.osterloh@gmail.com>