### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
       path: modules/hal/st
     - name: hal_stm32
-      revision: 50283e0438d882a80fb681907664491c7042c817
+      revision: 68bfdabe97aa60934e1519e98593abaa9745501e
       path: modules/hal/stm32
     - name: hal_ti
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e


### PR DESCRIPTION
        STM32Cube updates:
    stm32cube: update stm32l5 to version V1.4.0
    stm32cube: update stm32l4 to version V1.17.0
    stm32cube: update stm32g4 to version V1.4.0
    stm32cube: update stm32f7 to version V1.16.1
    stm32cube: update stm32f4 to version V1.26.0
    stm32cube: update stm32g0 to version V1.4.1
    stm32cube: update stm32h7 to version V1.9.1
    stm32cube: update stm32mp1 to version V1.4.0

    update stm32cube/common_ll
    
    Signed-off-by: Francois Ramu <francois.ramu@st.com>
