### PR TITLE
ARC: boards: nsim: adjust default testing for better coverage

### DIFF
--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -6,7 +6,6 @@ arch: arc
 toolchain:
   - zephyr
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_hs.yaml
+++ b/boards/arc/nsim/nsim_hs.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_sem.yaml
+++ b/boards/arc/nsim/nsim_sem.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
+  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
As of today the build-only testing in upstream is enabled for nsim_em and nsim_em7d_v22 which are very similar from the compiler POW. The ARC HS, ARC Secure EM and SMP targets miss any testing.

So adjust default testing for better coverage by enabling build-only testing for nsim_hs, nsim_sem and nsim_hs_smp and drop excessive testing for nsim_em7d_v22.

By that we get good configuration coverage:
 * nsim_em (already enabled) - based on EM processor family, has userspace
 * hsim_hs - based on HS processor family, has only kernelspace
 * nsim_sem - EM configuration with secure features enabled
 * hsim_hs_smp - multicore HS configuration