### PR TITLE
sensor: mcp9808: Bug fix for setting resolution

### DIFF
--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -132,11 +132,11 @@ static struct mcp9808_data mcp9808_data;
 static const struct mcp9808_config mcp9808_cfg = {
 	.i2c_bus = DT_INST_BUS_LABEL(0),
 	.i2c_addr = DT_INST_REG_ADDR(0),
+	.resolution = DT_INST_PROP(0, resolution),
 #ifdef CONFIG_MCP9808_TRIGGER
 	.alert_pin = DT_INST_GPIO_PIN(0, int_gpios),
 	.alert_flags = DT_INST_GPIO_FLAGS(0, int_gpios),
 	.alert_controller = DT_INST_GPIO_LABEL(0, int_gpios),
-	.resolution = DT_INST_PROP(0, resolution),
 #endif /* CONFIG_MCP9808_TRIGGER */
 };
 


### PR DESCRIPTION
Resolution currently only gets set if CONFIG_MCP9808_TRIGGER is also
set. If CONFIG_MCP9808_TRIGGER is not set, resolution gets to '0'.

This small bug fix moves resolution to before CONFIG_MCP9808_TRIGGER is
checked, so that the resolution is changed as required.