### PR TITLE
dts: stm32: fix adc1 reg and clocks properties

### DIFF
--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -348,16 +348,6 @@
 			phase-seg2 = <6>;
 		};
 
-		adc1: adc@50000000 {
-			compatible = "st,stm32-adc";
-			reg = <0x50000000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
-			interrupts = <18 0>;
-			status = "disabled";
-			label = "ADC_1";
-			#io-channel-cells = <1>;
-		};
-
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma-v2";
 			#dma-cells = <4>;

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -78,5 +78,15 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		adc1: adc@50000000 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			interrupts = <18 0>;
+			status = "disabled";
+			label = "ADC_1";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -120,5 +120,15 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		adc1: adc@50000000 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			interrupts = <18 0>;
+			status = "disabled";
+			label = "ADC_1";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -25,6 +25,16 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		adc1: adc@50000000 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			interrupts = <18 0>;
+			status = "disabled";
+			label = "ADC_1";
+			#io-channel-cells = <1>;
+		};
 	};
 };
 

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -179,5 +179,16 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		adc1: adc@40012400 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
+			interrupts = <18 0>;
+			status = "disabled";
+			label = "ADC_1";
+			#io-channel-cells = <1>;
+		};
+
 	};
 };


### PR DESCRIPTION
Set the correct address space and the bus settings to enable its clock.

Signed-off-by: Dario Binacchi <dariobin@libero.it>