### PR TITLE
doc: application: Document using west outside of workspace

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -712,6 +712,13 @@ Using CMake directly:
 Basics
 ======
 
+.. note::
+
+   In the below example, ``west`` is used outside of a west workspace. For this
+   to work, you must set the ``ZEPHYR_BASE`` environment variable to the path
+   of your zephyr git repository, using one of the methods on the
+   :ref:`Environment Variables <env_vars>` page.
+
 #. Navigate to the application directory :file:`<home>/app`.
 #. Enter the following commands to build the application's :file:`zephyr.elf`
    image for the board specified in the command-line parameters:


### PR DESCRIPTION
This PR adds a note to the "Application Development" page, explaining that using west outside of a west workspace needs `ZEPHYR_BASE` to be set.

The current instructions on the "Application Development" use `west` outside of a west workspace, but do not tell you to set your `ZEPHYR_BASE` variable. This causes an error when running `west` commands which is difficult to understand.

----

Currently, if you follow the instructions on the "Application Development" page without having `ZEPHYR_BASE` set, you will get the error:

```west: error: argument <command>: invalid choice: 'build' (choose from 'init', 'update', 'list', 'manifest', 'diff', 'status', 'forall', 'help', 'config', 'topdir', 'selfupdate')```

The "Troubleshooting West" has a section for this error, explaining you need to [set the ZEPHYR_BASE environment variable](https://docs.zephyrproject.org/latest/guides/west/troubleshooting.html#invalid-choice-build-or-flash-etc) to build outside of a `.west` workspace.

In Zephyr 2.2.0 and below, the ["Getting Started Guide"](https://docs.zephyrproject.org/2.2.0/getting_started/index.html#build-the-blinky-application) and ["Application Development"](https://docs.zephyrproject.org/2.2.0/application/index.html#important-build-system-variables) pages told you
to run `zephyr-env.sh/zephyr-env.cmd` which would set `ZEPHYR_BASE`, but this documentation was removed
in Zephyr 2.3.0. The Zephyr 2.3.0 changelog states ["registering the Zephyr CMake package in the CMake user package registry removes the need for setting of ZEPHYR_BASE, sourcing zephyr-env.sh, or running zephyr-env.cmd"](https://docs.zephyrproject.org/latest/releases/release-notes-2.3.html#build-and-infrastructure). I'm guessing it was overlooked that `ZEPHYR_BASE` is still required for out-of-workspace usage of `west`.

As a side note, there are still some references to `zephyr-env.sh/zephyr-env.cmd` in the docs, such as on the ["Environment Variables" page](https://docs.zephyrproject.org/latest/guides/env_vars.html?highlight=zephyr_base), so I'm not sure if these scripts are intended to still be used.

I might also issue a PR to the `west` repo to improve the error message when west is run outside of a workspace.
