### PR TITLE
Gecko pwm support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -252,6 +252,7 @@
 /drivers/pwm/*xlnx*                       @henrikbrixandersen
 /drivers/pwm/pwm_capture.c                @henrikbrixandersen
 /drivers/pwm/pwm_shell.c                  @henrikbrixandersen
+/drivers/pwm/*gecko*                      @sun681
 /drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter

--- a/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
@@ -12,10 +12,31 @@
 	model = "Silicon Labs BRD4250B (Flex Gecko Radio Board)";
 	compatible = "silabs,efr32_radio_brd4250b", "silabs,efr32fg1p";
 
+	pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+		pwm_led0: pwm_led0 {
+			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
 };
 
 &cpu0 {
 	clock-frequency = <38400000>;
+};
+
+&timer0 {
+	status = "okay";
+
+	pwm0: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(28) GECKO_PORT_F GECKO_PIN(4)>;
+		prescaler = <1024>;
+	};
 };
 
 &flash0 {

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -19,6 +19,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_SAM0_TCC	pwm_sam0_tcc.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_NPCX		pwm_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_XLNX_AXI_TIMER	pwm_xlnx_axi_timer.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_PWT 	pwm_mcux_pwt.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_GECKO   pwm_gecko.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -61,4 +61,6 @@ source "drivers/pwm/Kconfig.xlnx"
 
 source "drivers/pwm/Kconfig.mcux_pwt"
 
+source "drivers/pwm/Kconfig.gecko"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.gecko
+++ b/drivers/pwm/Kconfig.gecko
@@ -1,0 +1,13 @@
+# GECKO PWM configuration options
+
+# Copyright (c) 2021 Sun Amar.
+# SPDX-License-Identifier: Apache-2.0
+
+config PWM_GECKO
+	bool "GECKO MCU PWM driver"
+	depends on SOC_FAMILY_EXX32
+	select SOC_GECKO_TIMER
+	help
+	  This option enables the PWM driver for EXX32 GECKO family of
+	  processors. Say y if you wish to use PWM port on EXX32
+	  MCU.

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Sun Amar.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT silabs_gecko_pwm
+
+#include <drivers/pwm.h>
+#include <dt-bindings/pwm/pwm.h>
+#include "em_cmu.h"
+#include "em_timer.h"
+
+/** PWM configuration. */
+struct pwm_gecko_config {
+	TIMER_TypeDef *timer;
+	CMU_Clock_TypeDef clock;
+	uint16_t prescaler;
+	TIMER_Prescale_TypeDef prescale_enum;
+	uint8_t channel;
+	uint8_t location;
+	uint8_t port;
+	uint8_t pin;
+};
+
+#define DEV_CFG(dev) \
+	((const struct pwm_gecko_config * const)(dev)->config)
+
+static int pwm_gecko_pin_set(const struct device *dev, uint32_t pwm,
+			     uint32_t period_cycles, uint32_t pulse_cycles,
+			     pwm_flags_t flags)
+{
+	TIMER_InitCC_TypeDef compare_config = TIMER_INITCC_DEFAULT;
+	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+
+	if (BUS_RegMaskedRead(&cfg->timer->CC[pwm].CTRL,
+		_TIMER_CC_CTRL_MODE_MASK) != timerCCModePWM) {
+
+#ifdef _TIMER_ROUTE_MASK
+		BUS_RegMaskedWrite(&cfg->timer->ROUTE,
+			_TIMER_ROUTE_LOCATION_MASK,
+			cfg->location << _TIMER_ROUTE_LOCATION_SHIFT);
+		BUS_RegMaskedSet(&pwm->timer->ROUTE, 1 << pwm);
+#elif defined(_TIMER_ROUTELOC0_MASK)
+		BUS_RegMaskedWrite(&cfg->timer->ROUTELOC0,
+			_TIMER_ROUTELOC0_CC0LOC_MASK << (pwm * _TIMER_ROUTELOC0_CC1LOC_SHIFT),
+			cfg->location << (pwm * _TIMER_ROUTELOC0_CC1LOC_SHIFT));
+		BUS_RegMaskedSet(&cfg->timer->ROUTEPEN, 1 << pwm);
+#else
+#error Unsupported device
+#endif
+
+		compare_config.mode = timerCCModePWM;
+		TIMER_InitCC(cfg->timer, pwm, &compare_config);
+	}
+
+	cfg->timer->CC[pwm].CTRL |= (flags & PWM_POLARITY_INVERTED) ?
+		TIMER_CC_CTRL_OUTINV : 0;
+
+	TIMER_TopSet(cfg->timer, period_cycles);
+
+	TIMER_CompareBufSet(cfg->timer, pwm, pulse_cycles);
+
+	return 0;
+}
+
+static int pwm_gecko_get_cycles_per_sec(const struct device *dev,
+					uint32_t pwm,
+					uint64_t *cycles)
+{
+	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+
+	*cycles = CMU_ClockFreqGet(cfg->clock) / cfg->prescaler;
+
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_gecko_driver_api = {
+	.pin_set = pwm_gecko_pin_set,
+	.get_cycles_per_sec = pwm_gecko_get_cycles_per_sec
+};
+
+static int pwm_gecko_init(const struct device *dev)
+{
+	TIMER_Init_TypeDef timer = TIMER_INIT_DEFAULT;
+	const struct pwm_gecko_config *cfg = DEV_CFG(dev);
+
+	CMU_ClockEnable(cfg->clock, true);
+
+	CMU_ClockEnable(cmuClock_GPIO, true);
+	GPIO_PinModeSet(cfg->port, cfg->pin, gpioModePushPull, 0);
+
+	timer.prescale = cfg->prescale_enum;
+	TIMER_Init(cfg->timer, &timer);
+
+	return 0;
+}
+
+#define CLOCK_TIMER(id) _CONCAT(cmuClock_TIMER, id)
+#define PRESCALING_FACTOR(factor) \
+	((_CONCAT(timerPrescale, factor)))
+
+#define PWM_GECKO_INIT(index)							\
+	static const struct pwm_gecko_config pwm_gecko_config_##index = {	\
+		.timer = (TIMER_TypeDef *)DT_REG_ADDR(                          \
+			DT_PARENT(DT_DRV_INST(index))),				\
+		.clock = CLOCK_TIMER(index),					\
+		.prescaler = DT_INST_PROP(index, prescaler),			\
+		.prescale_enum = (TIMER_Prescale_TypeDef)			\
+			PRESCALING_FACTOR(DT_INST_PROP(index, prescaler)),	\
+		.location = DT_INST_PROP_BY_IDX(index, pin_location, 0),	\
+		.port = (GPIO_Port_TypeDef)					\
+			DT_INST_PROP_BY_IDX(index, pin_location, 1),		\
+		.pin = DT_INST_PROP_BY_IDX(index, pin_location, 2),		\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(index, &pwm_gecko_init, device_pm_control_nop,	\
+				NULL,						\
+				&pwm_gecko_config_##index, POST_KERNEL,		\
+				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+				&pwm_gecko_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PWM_GECKO_INIT)

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -4,6 +4,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {
@@ -172,6 +173,21 @@
 			interrupts = <2 0>;
 			status = "disabled";
 		};
+
+		timer0: timer@40018000 {
+			compatible = "silabs,gecko-timers";
+			reg = <0x40018000 0x400>;
+			status = "disabled";
+			label = "TIMER_0";
+
+			pwm {
+				compatible = "silabs,gecko-pwm";
+				status = "disabled";
+				label = "PWM_0";
+				#pwm-cells = <2>;
+			};
+		};
+
 	};
 };
 

--- a/dts/bindings/pwm/silabs,gecko-pwm.yaml
+++ b/dts/bindings/pwm/silabs,gecko-pwm.yaml
@@ -1,0 +1,36 @@
+description: Silabs Gecko PWM port
+
+compatible: "silabs,gecko-pwm"
+
+include: [pwm-controller.yaml, base.yaml]
+
+properties:
+    pin-location:
+      type: array
+      required: true
+      description: pwm pin configuration defined as <location port pin>
+
+    prescaler:
+      type: int
+      required: false
+      default: 1
+      description: prescaling factor from the HFPERCLK clock
+      enum:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+        - 512
+        - 1024
+
+    "#pwm-cells":
+      const: 2
+
+pwm-cells:
+  - channel
+  - flags

--- a/dts/bindings/timer/silabs,gecko-timer.yaml
+++ b/dts/bindings/timer/silabs,gecko-timer.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021, Sun Amar
+# SPDX-License-Identifier: Apache-2.0
+
+description: Silabs gecko timer node
+
+compatible: "silabs,gecko-timer"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true
+
+    reg:
+      required: true

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -22,3 +22,7 @@ config SOC_FLASH_GECKO
 config SPI_GECKO
 	default y
 	depends on SPI
+
+config PWM_GECKO
+	default y
+	depends on PWM


### PR DESCRIPTION
Pwm support for the the gecko family.

I tested it on unsupported boards (silabs original board kinda expensive) so i didnt include any changes in the cuurent supported boards dts files.
I'm adding dts file I have coppied from supported board to use for my e180_zg120b_tb board. it includes the
timer and pwm specific description + the pwm-led0 alias for the blinky_pwm example.

[tested_board.zip](https://github.com/zephyrproject-rtos/zephyr/files/6178602/tested_board.zip)



