### PR TITLE
sys: ring_buffer: allow data to be discarded

### DIFF
--- a/include/sys/ring_buffer.h
+++ b/include/sys/ring_buffer.h
@@ -254,7 +254,7 @@ int ring_buf_item_put(struct ring_buf *buf, uint16_t type, uint8_t value,
  * @param buf Address of ring buffer.
  * @param type Area to store the data item's type identifier.
  * @param value Area to store the data item's integer value.
- * @param data Area to store the data item.
+ * @param data Area to store the data item. Can be NULL to discard data.
  * @param size32 Size of the data item storage area (number of 32-bit chunks).
  *
  * @retval 0 Data item was fetched; @a size32 now contains the number of
@@ -399,7 +399,7 @@ int ring_buf_get_finish(struct ring_buf *buf, uint32_t size);
  * (calls prefixed with ring_buf_item_).
  *
  * @param buf  Address of ring buffer.
- * @param data Address of the output buffer.
+ * @param data Address of the output buffer. Can be NULL to discard data.
  * @param size Data size (in bytes).
  *
  * @retval Number of bytes written to the output buffer.

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -130,7 +130,7 @@ int ring_buf_item_get(struct ring_buf *buf, uint16_t *type, uint8_t *value,
 
 	header = (struct ring_element *) &buf->buf.buf32[mod(buf, buf->head)];
 
-	if (header->length > *size32) {
+	if (data && (header->length > *size32)) {
 		*size32 = header->length;
 		return -EMSGSIZE;
 	}
@@ -139,15 +139,17 @@ int ring_buf_item_get(struct ring_buf *buf, uint16_t *type, uint8_t *value,
 	*type = header->type;
 	*value = header->value;
 
-	if (likely(buf->mask)) {
-		for (i = 0U; i < header->length; ++i) {
-			index = (i + buf->head + 1) & buf->mask;
-			data[i] = buf->buf.buf32[index];
-		}
-	} else {
-		for (i = 0U; i < header->length; ++i) {
-			index = (i + buf->head + 1) % buf->size;
-			data[i] = buf->buf.buf32[index];
+	if (data) {
+		if (likely(buf->mask)) {
+			for (i = 0U; i < header->length; ++i) {
+				index = (i + buf->head + 1) & buf->mask;
+				data[i] = buf->buf.buf32[index];
+			}
+		} else {
+			for (i = 0U; i < header->length; ++i) {
+				index = (i + buf->head + 1) % buf->size;
+				data[i] = buf->buf.buf32[index];
+			}
 		}
 	}
 
@@ -269,10 +271,12 @@ uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size)
 
 	do {
 		partial_size = ring_buf_get_claim(buf, &src, size);
-		memcpy(data, src, partial_size);
+		if (data) {
+			memcpy(data, src, partial_size);
+			data += partial_size;
+		}
 		total_size += partial_size;
 		size -= partial_size;
-		data += partial_size;
 	} while (size && partial_size);
 
 	err = ring_buf_get_finish(buf, total_size);

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -209,6 +209,20 @@ static void tringbuf_get(const void *p)
 	zassert_equal(memcmp(rx_data, data[index].buffer, size32), 0, NULL);
 }
 
+static void tringbuf_get_discard(const void *p)
+{
+	uint16_t type;
+	uint8_t value, size32;
+	int ret, index = POINTER_TO_INT(p);
+
+	/**TESTPOINT: ring buffer get*/
+	ret = ring_buf_item_get(pbuf, &type, &value, NULL, &size32);
+	zassert_equal(ret, 0, NULL);
+	zassert_equal(type, data[index].type, NULL);
+	zassert_equal(value, data[index].value, NULL);
+	zassert_equal(size32, data[index].length, NULL);
+}
+
 /*test cases*/
 void test_ringbuffer_init(void)
 {
@@ -308,6 +322,17 @@ void test_ringbuffer_put_get_thread_isr(void)
 	irq_offload(tringbuf_get, (const void *)1);
 	tringbuf_put((const void *)2);
 	irq_offload(tringbuf_get, (const void *)2);
+}
+
+void test_ringbuffer_put_get_discard(void)
+{
+	pbuf = &ringbuf;
+	tringbuf_put((const void *)0);
+	tringbuf_put((const void *)1);
+	zassert_false(ring_buf_is_empty(pbuf), NULL);
+	tringbuf_get_discard((const void *)0);
+	tringbuf_get_discard((const void *)1);
+	zassert_true(ring_buf_is_empty(pbuf), NULL);
 }
 
 /**
@@ -505,6 +530,21 @@ void test_ringbuffer_raw(void)
 	out_size = ring_buf_get(&ringbuf_raw, outbuf,
 					RINGBUFFER_SIZE + 1);
 	zassert_true(out_size == 0, NULL);
+	zassert_true(ring_buf_is_empty(&ringbuf_raw), NULL);
+
+	/* Validate that raw bytes can be discarded */
+	in_size = ring_buf_put(&ringbuf_raw, inbuf,
+				       RINGBUFFER_SIZE);
+	zassert_equal(in_size, RINGBUFFER_SIZE, NULL);
+
+	out_size = ring_buf_get(&ringbuf_raw, NULL,
+					RINGBUFFER_SIZE);
+	zassert_true(out_size == RINGBUFFER_SIZE, NULL);
+
+	out_size = ring_buf_get(&ringbuf_raw, NULL,
+					RINGBUFFER_SIZE + 1);
+	zassert_true(out_size == 0, NULL);
+	zassert_true(ring_buf_is_empty(&ringbuf_raw), NULL);
 }
 
 void test_ringbuffer_alloc_put(void)
@@ -917,6 +957,7 @@ void test_main(void)
 		       ztest_unit_test(test_ringbuffer_put_get_thread),
 		       ztest_unit_test(test_ringbuffer_put_get_isr),
 		       ztest_unit_test(test_ringbuffer_put_get_thread_isr),
+		       ztest_unit_test(test_ringbuffer_put_get_discard),
 		       ztest_unit_test(test_ringbuffer_pow2_put_get_thread_isr),
 		       ztest_unit_test(test_ringbuffer_size_put_get_thread_isr),
 		       ztest_unit_test(test_ringbuffer_array_perf),


### PR DESCRIPTION
Allow NULL data buffers to be provided to `ring_buf_get` and
`ring_buf_item_get`, in which case data will be discarded instead of
copied out to the user.

Fixes #33488.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>