### PR TITLE
boards: nrf9160dk: Remove empty .conf files

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_14_0.conf
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_14_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_7_0.conf
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840_0_7_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf52840/revision.cmake
+++ b/boards/arm/nrf9160dk_nrf52840/revision.cmake
@@ -4,4 +4,5 @@
 board_check_revision(
   FORMAT MAJOR.MINOR.PATCH
   DEFAULT_REVISION 0.7.0
+  VALID_REVISIONS 0.7.0 0.14.0
 )

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_0_14_0.conf
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_0_14_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_0_7_0.conf
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_0_7_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_0_14_0.conf
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_0_14_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_0_7_0.conf
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns_0_7_0.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is required by the multiple board revisions mechanism.

--- a/boards/arm/nrf9160dk_nrf9160/revision.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/revision.cmake
@@ -4,4 +4,5 @@
 board_check_revision(
   FORMAT MAJOR.MINOR.PATCH
   DEFAULT_REVISION 0.7.0
+  VALID_REVISIONS 0.7.0 0.14.0
 )


### PR DESCRIPTION
After 3a58b45ced53ce4c601c3c2ac8b7c2f1d5a57aeb introduced the option
of specifying valid board revisions, it is no longer needed to provide
a .conf file for each revision. Remove then the files that were added
solely for this reason and use the VALID_REVISIONS parameter instead.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>