### PR TITLE
Various fixes to rule 21.2 (reserved symbols)

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5313,36 +5313,36 @@ __syscall int k_poll(struct k_poll_event *events, int num_events,
  *
  * Ready a poll signal object to be signaled via k_poll_signal_raise().
  *
- * @param signal A poll signal.
+ * @param sig A poll signal.
  *
  * @return N/A
  */
 
-__syscall void k_poll_signal_init(struct k_poll_signal *signal);
+__syscall void k_poll_signal_init(struct k_poll_signal *sig);
 
 /*
  * @brief Reset a poll signal object's state to unsignaled.
  *
- * @param signal A poll signal object
+ * @param sig A poll signal object
  */
-__syscall void k_poll_signal_reset(struct k_poll_signal *signal);
+__syscall void k_poll_signal_reset(struct k_poll_signal *sig);
 
-static inline void z_impl_k_poll_signal_reset(struct k_poll_signal *signal)
+static inline void z_impl_k_poll_signal_reset(struct k_poll_signal *sig)
 {
-	signal->signaled = 0U;
+	sig->signaled = 0U;
 }
 
 /**
  * @brief Fetch the signaled state and result value of a poll signal
  *
- * @param signal A poll signal object
+ * @param sig A poll signal object
  * @param signaled An integer buffer which will be written nonzero if the
  *		   object was signaled
  * @param result An integer destination buffer which will be written with the
  *		   result value if the object was signaled, or an undefined
  *		   value if it was not.
  */
-__syscall void k_poll_signal_check(struct k_poll_signal *signal,
+__syscall void k_poll_signal_check(struct k_poll_signal *sig,
 				   unsigned int *signaled, int *result);
 
 /**
@@ -5362,14 +5362,14 @@ __syscall void k_poll_signal_check(struct k_poll_signal *signal,
  * this function returns an error indicating that an expiring poll was
  * not notified.  The next k_poll() will detect the missed raise.
  *
- * @param signal A poll signal.
+ * @param sig A poll signal.
  * @param result The value to store in the result field of the signal.
  *
  * @retval 0 The signal was delivered successfully.
  * @retval -EAGAIN The polling thread's timeout is in the process of expiring.
  */
 
-__syscall int k_poll_signal_raise(struct k_poll_signal *signal, int result);
+__syscall int k_poll_signal_raise(struct k_poll_signal *sig, int result);
 
 /**
  * @internal

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -415,51 +415,51 @@ void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
 	}
 }
 
-void z_impl_k_poll_signal_init(struct k_poll_signal *signal)
+void z_impl_k_poll_signal_init(struct k_poll_signal *sig)
 {
-	sys_dlist_init(&signal->poll_events);
-	signal->signaled = 0U;
-	/* signal->result is left unitialized */
-	z_object_init(signal);
+	sys_dlist_init(&sig->poll_events);
+	sig->signaled = 0U;
+	/* sig->result is left unitialized */
+	z_object_init(sig);
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_poll_signal_init(struct k_poll_signal *signal)
+static inline void z_vrfy_k_poll_signal_init(struct k_poll_signal *sig)
 {
-	Z_OOPS(Z_SYSCALL_OBJ_INIT(signal, K_OBJ_POLL_SIGNAL));
-	z_impl_k_poll_signal_init(signal);
+	Z_OOPS(Z_SYSCALL_OBJ_INIT(sig, K_OBJ_POLL_SIGNAL));
+	z_impl_k_poll_signal_init(sig);
 }
 #include <syscalls/k_poll_signal_init_mrsh.c>
 #endif
 
-void z_impl_k_poll_signal_check(struct k_poll_signal *signal,
+void z_impl_k_poll_signal_check(struct k_poll_signal *sig,
 			       unsigned int *signaled, int *result)
 {
-	*signaled = signal->signaled;
-	*result = signal->result;
+	*signaled = sig->signaled;
+	*result = sig->result;
 }
 
 #ifdef CONFIG_USERSPACE
-void z_vrfy_k_poll_signal_check(struct k_poll_signal *signal,
+void z_vrfy_k_poll_signal_check(struct k_poll_signal *sig,
 			       unsigned int *signaled, int *result)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(signal, K_OBJ_POLL_SIGNAL));
+	Z_OOPS(Z_SYSCALL_OBJ(sig, K_OBJ_POLL_SIGNAL));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(signaled, sizeof(unsigned int)));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(result, sizeof(int)));
-	z_impl_k_poll_signal_check(signal, signaled, result);
+	z_impl_k_poll_signal_check(sig, signaled, result);
 }
 #include <syscalls/k_poll_signal_check_mrsh.c>
 #endif
 
-int z_impl_k_poll_signal_raise(struct k_poll_signal *signal, int result)
+int z_impl_k_poll_signal_raise(struct k_poll_signal *sig, int result)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_poll_event *poll_event;
 
-	signal->result = result;
-	signal->signaled = 1U;
+	sig->result = result;
+	sig->signaled = 1U;
 
-	poll_event = (struct k_poll_event *)sys_dlist_get(&signal->poll_events);
+	poll_event = (struct k_poll_event *)sys_dlist_get(&sig->poll_events);
 	if (poll_event == NULL) {
 		k_spin_unlock(&lock, key);
 		return 0;
@@ -472,18 +472,18 @@ int z_impl_k_poll_signal_raise(struct k_poll_signal *signal, int result)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_poll_signal_raise(struct k_poll_signal *signal,
+static inline int z_vrfy_k_poll_signal_raise(struct k_poll_signal *sig,
 					     int result)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(signal, K_OBJ_POLL_SIGNAL));
-	return z_impl_k_poll_signal_raise(signal, result);
+	Z_OOPS(Z_SYSCALL_OBJ(sig, K_OBJ_POLL_SIGNAL));
+	return z_impl_k_poll_signal_raise(sig, result);
 }
 #include <syscalls/k_poll_signal_raise_mrsh.c>
 
-static inline void z_vrfy_k_poll_signal_reset(struct k_poll_signal *signal)
+static inline void z_vrfy_k_poll_signal_reset(struct k_poll_signal *sig)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(signal, K_OBJ_POLL_SIGNAL));
-	z_impl_k_poll_signal_reset(signal);
+	Z_OOPS(Z_SYSCALL_OBJ(sig, K_OBJ_POLL_SIGNAL));
+	z_impl_k_poll_signal_reset(sig);
 }
 #include <syscalls/k_poll_signal_reset_mrsh.c>
 

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -148,22 +148,22 @@ static inline void register_event(struct k_poll_event *event,
 /* must be called with interrupts locked */
 static inline void clear_event_registration(struct k_poll_event *event)
 {
-	bool remove = false;
+	bool remove_event = false;
 
 	event->poller = NULL;
 
 	switch (event->type) {
 	case K_POLL_TYPE_SEM_AVAILABLE:
 		__ASSERT(event->sem != NULL, "invalid semaphore\n");
-		remove = true;
+		remove_event = true;
 		break;
 	case K_POLL_TYPE_DATA_AVAILABLE:
 		__ASSERT(event->queue != NULL, "invalid queue\n");
-		remove = true;
+		remove_event = true;
 		break;
 	case K_POLL_TYPE_SIGNAL:
 		__ASSERT(event->signal != NULL, "invalid poll signal\n");
-		remove = true;
+		remove_event = true;
 		break;
 	case K_POLL_TYPE_IGNORE:
 		/* nothing to do */
@@ -172,7 +172,7 @@ static inline void clear_event_registration(struct k_poll_event *event)
 		__ASSERT(false, "invalid event type\n");
 		break;
 	}
-	if (remove && sys_dnode_is_linked(&event->_node)) {
+	if (remove_event && sys_dnode_is_linked(&event->_node)) {
 		sys_dlist_remove(&event->_node);
 	}
 }

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -171,8 +171,8 @@ bool sys_heap_validate(struct sys_heap *heap)
 }
 
 struct z_heap_stress_rec {
-	void *(*alloc)(void *arg, size_t bytes);
-	void (*free)(void *arg, void *p);
+	void *(*alloc_fn)(void *arg, size_t bytes);
+	void (*free_fn)(void *arg, void *p);
 	void *arg;
 	size_t total_bytes;
 	struct z_heap_stress_block *blocks;
@@ -265,8 +265,8 @@ static size_t rand_free_choice(struct z_heap_stress_rec *sr)
  * scratch array is used to store temporary state and should be sized
  * about half as large as the heap itself. Returns true on success.
  */
-void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
-		     void (*free)(void *arg, void *p),
+void sys_heap_stress(void *(*alloc_fn)(void *arg, size_t bytes),
+		     void (*free_fn)(void *arg, void *p),
 		     void *arg, size_t total_bytes,
 		     uint32_t op_count,
 		     void *scratch_mem, size_t scratch_bytes,
@@ -274,8 +274,8 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
 		     struct z_heap_stress_result *result)
 {
 	struct z_heap_stress_rec sr = {
-	       .alloc = alloc,
-	       .free = free,
+	       .alloc_fn = alloc_fn,
+	       .free_fn = free_fn,
 	       .arg = arg,
 	       .total_bytes = total_bytes,
 	       .blocks = scratch_mem,
@@ -288,7 +288,7 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
 	for (uint32_t i = 0; i < op_count; i++) {
 		if (rand_alloc_choice(&sr)) {
 			size_t sz = rand_alloc_size(&sr);
-			void *p = sr.alloc(sr.arg, sz);
+			void *p = sr.alloc_fn(sr.arg, sz);
 
 			result->total_allocs++;
 			if (p != NULL) {
@@ -307,7 +307,7 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
 			sr.blocks[b] = sr.blocks[sr.blocks_alloced - 1];
 			sr.blocks_alloced--;
 			sr.bytes_alloced -= sz;
-			sr.free(sr.arg, p);
+			sr.free_fn(sr.arg, p);
 		}
 		result->accumulated_in_use_bytes += sr.bytes_alloced;
 	}

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -246,7 +246,7 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 {
 	struct z_heap *h = heap->heap;
-	size_t gap, rewind;
+	size_t gap, rew;
 
 	/*
 	 * Split align and rewind values (if any).
@@ -255,15 +255,15 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 	 * So if e.g. align = 0x28 (32 | 8) this means we align to a 32-byte
 	 * boundary and then rewind 8 bytes.
 	 */
-	rewind = align & -align;
-	if (align != rewind) {
-		align -= rewind;
-		gap = MIN(rewind, chunk_header_bytes(h));
+	rew = align & -align;
+	if (align != rew) {
+		align -= rew;
+		gap = MIN(rew, chunk_header_bytes(h));
 	} else {
 		if (align <= chunk_header_bytes(h)) {
 			return sys_heap_alloc(heap, bytes);
 		}
-		rewind = 0;
+		rew = 0;
 		gap = chunk_header_bytes(h);
 	}
 	__ASSERT((align & (align - 1)) == 0, "align must be a power of 2");
@@ -286,7 +286,7 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 	uint8_t *mem = chunk_mem(h, c0);
 
 	/* Align allocated memory */
-	mem = (uint8_t *) ROUND_UP(mem + rewind, align) - rewind;
+	mem = (uint8_t *) ROUND_UP(mem + rew, align) - rew;
 	chunk_unit_t *end = (chunk_unit_t *) ROUND_UP(mem + bytes, CHUNK_UNIT);
 
 	/* Get corresponding chunks */

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -41,19 +41,19 @@ static uint32_t mod(struct ring_buf *buf, uint32_t val)
  */
 static void item_indexes_rewind(struct ring_buf *buf)
 {
-	uint32_t rewind;
+	uint32_t rew;
 	uint32_t threshold = ring_buf_get_rewind_threshold();
 
 	if (buf->head < threshold) {
 		return;
 	}
 
-	rewind = buf->size * (threshold / buf->size);
+	rew = buf->size * (threshold / buf->size);
 
 	k_spinlock_key_t key = k_spin_lock(&buf->lock);
 
-	buf->tail -= rewind;
-	buf->head -= rewind;
+	buf->tail -= rew;
+	buf->head -= rew;
 	k_spin_unlock(&buf->lock, key);
 }
 
@@ -63,7 +63,7 @@ static void item_indexes_rewind(struct ring_buf *buf)
  */
 static void byte_indexes_rewind(struct ring_buf *buf)
 {
-	uint32_t rewind;
+	uint32_t rew;
 	uint32_t threshold = ring_buf_get_rewind_threshold();
 
 	/* Checking head since it is the smallest index. */
@@ -71,14 +71,14 @@ static void byte_indexes_rewind(struct ring_buf *buf)
 		return;
 	}
 
-	rewind = buf->size * (threshold / buf->size);
+	rew = buf->size * (threshold / buf->size);
 
 	k_spinlock_key_t key = k_spin_lock(&buf->lock);
 
-	buf->tail -= rewind;
-	buf->head -= rewind;
-	buf->misc.byte_mode.tmp_head -= rewind;
-	buf->misc.byte_mode.tmp_tail -= rewind;
+	buf->tail -= rew;
+	buf->head -= rew;
+	buf->misc.byte_mode.tmp_head -= rew;
+	buf->misc.byte_mode.tmp_tail -= rew;
 	k_spin_unlock(&buf->lock, key);
 }
 


### PR DESCRIPTION
- kernel: rename reserved symbol 'remove'
- ring_buffer: rename resereved 'rewind' symbol
- kernel: heap: rename resereved 'rewind'
- kernel: heap: rename 'free' and 'alloc'
- kernel: rename reserved 'exp' symbol
- kernel: poll: rename reserved 'signal' symbol
- kernel: rename reserved 'exp' symbol
