### PR TITLE
kernel: Remove duplicate include of kswap.h

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <sys/dlist.h>
 #include <kernel_internal.h>
-#include <kswap.h>
 #include <drivers/entropy.h>
 #include <logging/log_ctrl.h>
 #include <tracing/tracing.h>


### PR DESCRIPTION
kswap.h was included twice.  Remove the duplication

Fixes #33524

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>