### PR TITLE
edac: ibecc: Add supported SKU device IDs

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -352,7 +352,19 @@ int edac_ibecc_init(const struct device *dev)
 	LOG_INF("EDAC IBECC initialization");
 
 	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU5)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU6)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
 				     PCI_DEVICE_ID_SKU7)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU8)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU9)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU10)) &&
+	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
+				     PCI_DEVICE_ID_SKU11)) &&
 	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
 				     PCI_DEVICE_ID_SKU12))) {
 		LOG_ERR("PCI Probe failed");

--- a/drivers/edac/ibecc.h
+++ b/drivers/edac/ibecc.h
@@ -9,7 +9,14 @@
 
 #define PCI_VENDOR_ID_INTEL	0x8086
 
+/* Supported SKU map */
+#define PCI_DEVICE_ID_SKU5	0x4514
+#define PCI_DEVICE_ID_SKU6	0x4528
 #define PCI_DEVICE_ID_SKU7	0x452a
+#define PCI_DEVICE_ID_SKU8	0x4516
+#define PCI_DEVICE_ID_SKU9	0x452c
+#define PCI_DEVICE_ID_SKU10	0x452e
+#define PCI_DEVICE_ID_SKU11	0x4532
 #define PCI_DEVICE_ID_SKU12	0x4518
 
 /* TODO: Move to correct place NMI registers */


### PR DESCRIPTION
List all supported device IDs found in External Design Specification
Volume 1 which have IBECC supported.

Fixes #33543