### PR TITLE
kconfig: add support for warnings when using experimental features

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -507,6 +507,20 @@ config MAKEFILE_EXPORTS
 	  third party Makefile-based build systems.
 
 endmenu
+
+config EXPERIMENTAL
+	bool
+	help
+	  Symbol that must be selected by a feature if it is considered to be
+	  at an experimental implementation stage.
+
+config WARN_EXPERIMENTAL
+	bool
+	prompt "Warn on experimental usage"
+	help
+	  Print a warning when the Kconfig tree is parsed if any experimental
+	  features are enabled.
+
 endmenu
 
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -605,6 +605,28 @@ The other pages in the :ref:`Kconfig section of the manual <kconfig>` are also
 worth going through, especially if you planning to add new configuration
 options.
 
+Experimental features
+*********************
+
+Zephyr is a project under constant development and thus there are features that
+are still in early stages of their development cycle. Such features will be
+marked ``[EXPERIMENTAL]`` in their Kconfig title.
+
+The :kconfig:`CONFIG_WARN_EXPERIMENTAL` setting can be used to enable warnings
+at CMake configure time if any experimental feature is enabled.
+
+.. code-block:: none
+
+   CONFIG_WARN_EXPERIMENTAL=y
+
+For example, enabling experimental warnings and building a sample which enables
+:kconfig:`CONFIG_BT_EXT_ADV` will print the following warning at CMake
+configure time.
+
+.. code-block:: shell
+
+   warning: Experimental symbol BT_EXT_ADV is enabled.
+
 Devicetree Overlays
 ===================
 

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -25,6 +25,7 @@ config BT_H5
 	bool "H:5 UART [EXPERIMENTAL]"
 	select UART_INTERRUPT_DRIVEN
 	select BT_UART
+	select EXPERIMENTAL
 	depends on SERIAL
 	help
 	  Bluetooth three-wire (H:5) UART driver. Implementation of HCI

--- a/drivers/can/Kconfig.net
+++ b/drivers/can/Kconfig.net
@@ -5,6 +5,7 @@
 
 config CAN_NET
 	bool "Enable 6loCAN network interface [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enable IPv6 Networking over can (6loCAN)
 

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -17,7 +17,7 @@ import textwrap
 # Zephyr doesn't use tristate symbols. They're supported here just to make the
 # script a bit more generic.
 from kconfiglib import Kconfig, split_expr, expr_value, expr_str, BOOL, \
-                       TRISTATE, TRI_TO_STR, AND
+                       TRISTATE, TRI_TO_STR, AND, OR
 
 
 def main():
@@ -61,6 +61,9 @@ def main():
         # when using an old configuration and updating Kconfig files.
         check_assigned_sym_values(kconf)
         check_assigned_choice_values(kconf)
+
+    if kconf.syms['WARN_EXPERIMENTAL'].tri_value == 2:
+        check_experimental(kconf)
 
     # Hack: Force all symbols to be evaluated, to catch warnings generated
     # during evaluation. Wait till the end to write the actual output files, so
@@ -200,6 +203,17 @@ and/or look up {0.name} in the menuconfig/guiconfig interface. The Application
 Development Primer, Setting Configuration Values, and Kconfig - Tips and Best
 Practices sections of the manual might be helpful too.\
 """
+
+
+def check_experimental(kconf):
+    experimental = kconf.syms['EXPERIMENTAL']
+    dep_expr = experimental.rev_dep
+
+    if dep_expr is not kconf.n:
+        selectors = [s for s in split_expr(dep_expr, OR) if expr_value(s) == 2]
+        for selector in selectors:
+            selector_name = split_expr(selector, AND)[0].name
+            warn(f'Experimental symbol {selector_name} is enabled.')
 
 
 def promptless(sym):

--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -16,6 +16,7 @@ config BT_LIM_ADV_TIMEOUT
 
 config BT_EXT_ADV
 	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Select this to enable Extended Advertising API support.
 	  This enables support for advertising with multiple advertising sets,
@@ -45,6 +46,7 @@ config BT_EXT_ADV_MAX_ADV_SET
 
 config BT_PER_ADV
 	bool "Periodic Advertising and Scanning support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Select this to enable Periodic Advertising API support. This allows
 	  the device to send advertising data periodically at deterministic
@@ -54,6 +56,7 @@ config BT_PER_ADV
 config BT_PER_ADV_SYNC
 	bool "Periodic advertising sync support [EXPERIMENTAL]"
 	depends on BT_OBSERVER
+	select EXPERIMENTAL
 	help
 	  Select this to enable Periodic Advertising Sync API support.
 	  Syncing with a periodic advertiser allows the device to periodically

--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -12,6 +12,7 @@ config BT_ISO_UNICAST
 	bool "Bluetooth Isochronous Channel Unicast Support [EXPERIMENTAL]"
 	depends on BT_CONN
 	select BT_ISO
+	select EXPERIMENTAL
 	help
 	  This option enables support for Bluetooth Broadcast
 	  Isochronous channels.
@@ -34,6 +35,7 @@ config BT_ISO_SYNC_RECEIVER
 	select BT_ISO_BROADCAST
 	select BT_OBSERVER
 	select BT_PER_ADV_SYNC
+	select EXPERIMENTAL
 	help
 	  This option enables support for the Bluetooth Isochronous
 	  Synchronized Receiver.

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -7,7 +7,8 @@
 #
 
 menuconfig BT_AUDIO
-	bool "Bluetooth Audio support [Experimental]"
+	bool "Bluetooth Audio support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  This option enables Bluetooth Audio support. The specific
 	  features that are available may depend on other features

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -454,6 +454,7 @@ config BT_CTLR_ADV_EXT
 
 config BT_CTLR_ADV_EXT
 	prompt "LE Advertising Extensions [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 if BT_CTLR_ADV_EXT
 
@@ -490,6 +491,7 @@ config BT_CTLR_ADV_PERIODIC
 
 config BT_CTLR_ADV_PERIODIC
 	bool "LE Periodic Advertising in Advertising State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_SYNC_PERIODIC
 	bool "LE Periodic Advertising in Synchronization State" if !BT_LL_SW_SPLIT
@@ -502,6 +504,7 @@ config BT_CTLR_SYNC_PERIODIC
 
 config BT_CTLR_SYNC_PERIODIC
 	bool "LE Periodic Advertising in Synchronization State [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_SYNC_PERIODIC_ADV_LIST
 	bool "LE Periodic Advertiser List support"
@@ -538,6 +541,7 @@ config BT_CTLR_ADV_ISO
 
 config BT_CTLR_ADV_ISO
 	bool "LE Broadcast Isochronous Channel advertising [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_SYNC_ISO
 	bool "LE Broadcast Isochronous Channel advertising sync" if !BT_LL_SW_SPLIT
@@ -550,6 +554,7 @@ config BT_CTLR_SYNC_ISO
 
 config BT_CTLR_SYNC_ISO
 	bool "LE Broadcast Isochronous Channel advertising sync [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_BROADCAST_ISO
 	bool
@@ -584,6 +589,7 @@ endif # BT_CTLR_ADV_EXT
 
 config BT_CTLR_SET_HOST_FEATURE
 	bool "LE Set Host Feature Command [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enables optional LE Set Host Feature Command
 
@@ -597,6 +603,7 @@ config BT_CTLR_CENTRAL_ISO
 config BT_CTLR_CENTRAL_ISO
 	bool "LE Connected Isochronous Stream Central [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select BT_CTLR_SET_HOST_FEATURE
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_PERIPHERAL_ISO
 	bool "LE Connected Isochronous Stream Peripheral" if !BT_LL_SW_SPLIT
@@ -608,6 +615,7 @@ config BT_CTLR_PERIPHERAL_ISO
 config BT_CTLR_PERIPHERAL_ISO
 	bool "LE Connected Isochronous Stream Peripheral [EXPERIMENTAL]" if BT_LL_SW_SPLIT
 	select BT_CTLR_SET_HOST_FEATURE
+	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
 config BT_CTLR_CONN_ISO
 	bool

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -30,8 +30,9 @@ config BT_CTLR_CTEINLINE_SUPPORT
 	bool
 
 menuconfig BT_CTLR_DF
-	bool "LE Direction Finding [Experimental]"
+	bool "LE Direction Finding [EXPERIMENTAL]"
 	depends on BT_CTLR_DF_SUPPORT
+	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -551,6 +551,7 @@ config BT_ID_MAX
 
 config BT_DF
 	bool "Enable Direction Finding support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding.
 	  It will allow to: get information about antennae, configure
@@ -752,6 +753,7 @@ config BT_BREDR
 	select BT_CENTRAL
 	select BT_SMP
 	select BT_L2CAP_DYNAMIC_CHANNEL
+	select EXPERIMENTAL
 	help
 	  This option enables Bluetooth BR/EDR support
 
@@ -766,6 +768,7 @@ config BT_MAX_SCO_CONN
 
 config BT_RFCOMM
 	bool "Bluetooth RFCOMM protocol support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  This option enables Bluetooth RFCOMM support
 
@@ -782,17 +785,20 @@ config BT_HFP_HF
 	bool "Bluetooth Handsfree profile HF Role support [EXPERIMENTAL]"
 	depends on PRINTK
 	select BT_RFCOMM
+	select EXPERIMENTAL
 	help
 	  This option enables Bluetooth HF support
 
 config BT_AVDTP
 	bool "Bluetooth AVDTP protocol support [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  This option enables Bluetooth AVDTP support
 
 config BT_A2DP
 	bool "Bluetooth A2DP Profile [EXPERIMENTAL]"
 	select BT_AVDTP
+	select EXPERIMENTAL
 	help
 	  This option enables the A2DP profile
 

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -27,6 +27,7 @@ config BT_ATT_PREPARE_COUNT
 config BT_EATT
 	bool "Enhanced ATT Bearers support [EXPERIMENTAL]"
 	depends on BT_L2CAP_ECRED
+	select EXPERIMENTAL
 	help
 	  This option enables support for Enhanced ATT bearers support. When
 	  enabled additional L2CAP channels can be connected as bearers enabling

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -69,6 +69,7 @@ config BT_MESH_PROVISIONER
 config BT_MESH_CDB
 	bool "Mesh Configuration Database [EXPERIMENTAL]"
 	default y if BT_MESH_PROVISIONER
+	select EXPERIMENTAL
 
 if BT_MESH_CDB
 

--- a/subsys/bluetooth/services/ots/Kconfig
+++ b/subsys/bluetooth/services/ots/Kconfig
@@ -8,6 +8,7 @@ config BT_OTS
 	select BT_L2CAP_DYNAMIC_CHANNEL
 	select BT_GATT_DYNAMIC_DB
 	select BT_SMP
+	select EXPERIMENTAL
 	help
 	  Enable Object Transfer Service.
 

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -7,6 +7,7 @@ menuconfig ISOTP
 	bool "ISO-TP Transport [EXPERIMENTAL]"
 	select NET_BUF
 	select POLL
+	select EXPERIMENTAL
 	help
 	  Enable ISO TP support for CAN
 

--- a/subsys/net/l2/canbus/Kconfig
+++ b/subsys/net/l2/canbus/Kconfig
@@ -5,6 +5,7 @@ config NET_L2_CANBUS
 	bool "Enable CANBUS L2 layer [EXPERIMENTAL]"
 	depends on CAN_NET
 	select NET_6LO
+	select EXPERIMENTAL
 	help
 	  Add a CANBUS L2 layer driver. This is the layer for IPv6 over CAN
 	  (6loCAN). It uses IPHC to compress the IP header and ISO-TP for


### PR DESCRIPTION
This PR allows a user to have a warning printed if any experimental features are used in Zephyr.

As example, building `samples/hello_world` with `THREAD_MONITOR` which is experimental will look as:
```
$ cmake -GNinja -DBOARD=nrf52840dk_nrf52840 -Bbuild samples/hello_world/ -DCONFIG_THREAD_MONITOR=y
Parsing /projects/github/ncs/zephyr/Kconfig
Loaded configuration '/projects/github/ncs/zephyr/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig'
Merged configuration '/projects/github/ncs/zephyr/samples/hello_world/prj.conf'
Merged configuration '/projects/github/ncs/zephyr/build/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/projects/github/ncs/zephyr/build/zephyr/.config'
Kconfig header saved to '/projects/github/ncs/zephyr/build/zephyr/include/generated/autoconf.h'
-- The C compiler identification is GNU 7.3.1
....
```

Enabling this new warning together with `THREAD_MONITOR`, will give:
```
$ cmake -GNinja -DBOARD=nrf52840dk_nrf52840 -Bbuild samples/hello_world/ -DCONFIG_WARN_EXPERIMENTAL=y -DCONFIG_THREAD_MONITOR=y
Parsing /projects/github/ncs/zephyr/Kconfig
Loaded configuration '/projects/github/ncs/zephyr/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig'
Merged configuration '/projects/github/ncs/zephyr/samples/hello_world/prj.conf'
Merged configuration '/projects/github/ncs/zephyr/build/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/projects/github/ncs/zephyr/build/zephyr/.config'
Kconfig header saved to '/projects/github/ncs/zephyr/build/zephyr/include/generated/autoconf.h'

warning: Experimental symbol THREAD_MONITOR is enabled.

.....
```

--------

This adds a new setting which allows a user to print a warning when
a feature that is marked `[EXPERIMENTAL]` is enabled.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>