### PR TITLE
Do not reuse tag names (misra 5.7)

### DIFF
--- a/boards/arc/em_starterkit/pmodmux.c
+++ b/boards/arc/em_starterkit/pmodmux.c
@@ -124,7 +124,7 @@
 #define PM6_LR_CSS_STAT		((1 << BIT2) << PM6_OFFSET)
 
 
-static int pmod_mux_init(const struct device *device)
+static int pmod_mux_init(const struct device *dev)
 {
 	volatile uint32_t *mux_regs = (uint32_t *)(PMODMUX_BASE_ADDR);
 

--- a/boards/arc/hsdk/pinmux.c
+++ b/boards/arc/hsdk/pinmux.c
@@ -8,9 +8,9 @@
 #include <init.h>
 #include <drivers/pinmux.h>
 
-static int board_pinmux_init(const struct device *device)
+static int board_pinmux_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	const struct device *pinmux = DEVICE_DT_GET(DT_NODELABEL(pinctrl));
 

--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -160,9 +160,9 @@ void timer0_nrf_isr(void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	/* FIXME switch to 1 MHz once this is fixed in QEMU */
 	nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_2MHz);

--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -307,7 +307,7 @@ Device Set Power State
 
 .. code-block:: c
 
-   int device_set_power_state(const struct device *device, uint32_t device_power_state, device_pm_cb cb, void *arg);
+   int device_set_power_state(const struct device *dev, uint32_t device_power_state, device_pm_cb cb, void *arg);
 
 Calls the :c:func:`device_pm_control()` handler function implemented by the
 device driver with DEVICE_PM_SET_POWER_STATE command.
@@ -317,7 +317,7 @@ Device Get Power State
 
 .. code-block:: c
 
-   int device_get_power_state(const struct device *device, uint32_t * device_power_state);
+   int device_get_power_state(const struct device *dev, uint32_t * device_power_state);
 
 Calls the :c:func:`device_pm_control()` handler function implemented by the
 device driver with DEVICE_PM_GET_POWER_STATE command.

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -897,9 +897,9 @@ UTIL_LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_CFG_DATA, _)
 UTIL_LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_DEV_DATA, _)
 UTIL_LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_DEVICE, _)
 
-static int init_uart_mux(const struct device *device)
+static int init_uart_mux(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	k_work_q_start(&uart_mux_workq, uart_mux_stack,
 		       K_KERNEL_STACK_SIZEOF(uart_mux_stack),

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -43,7 +43,7 @@ static inline uint32_t entropy_esp32_get_u32(void)
 	return REG_READ(WDEV_RND_REG);
 }
 
-static int entropy_esp32_get_entropy(const struct device *device, uint8_t *buf,
+static int entropy_esp32_get_entropy(const struct device *dev, uint8_t *buf,
 				     uint16_t len)
 {
 	assert(buf != NULL);
@@ -61,7 +61,7 @@ static int entropy_esp32_get_entropy(const struct device *device, uint8_t *buf,
 	return 0;
 }
 
-static int entropy_esp32_init(const struct device *device)
+static int entropy_esp32_init(const struct device *dev)
 {
 	/* clock initialization handled by clock manager */
 	return 0;

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -84,7 +84,7 @@ static int entropy_gecko_trng_get_entropy_isr(const struct device *dev,
 	}
 }
 
-static int entropy_gecko_trng_init(const struct device *device)
+static int entropy_gecko_trng_init(const struct device *dev)
 {
 	/* Enable the TRNG0 clock. */
 	CMU_ClockEnable(cmuClock_TRNG0, true);

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -227,11 +227,11 @@ static void isr(const void *arg)
 	}
 }
 
-static int entropy_nrf5_get_entropy(const struct device *device, uint8_t *buf,
+static int entropy_nrf5_get_entropy(const struct device *dev, uint8_t *buf,
 				    uint16_t len)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(device));
+	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(dev));
 
 	while (len) {
 		uint16_t bytes;
@@ -324,7 +324,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 	return cnt;
 }
 
-static int entropy_nrf5_init(const struct device *device);
+static int entropy_nrf5_init(const struct device *dev);
 
 static const struct entropy_driver_api entropy_nrf5_api_funcs = {
 	.get_entropy = entropy_nrf5_get_entropy,
@@ -337,10 +337,10 @@ DEVICE_DT_INST_DEFINE(0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_nrf5_api_funcs);
 
-static int entropy_nrf5_init(const struct device *device)
+static int entropy_nrf5_init(const struct device *dev)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(device));
+	__ASSERT_NO_MSG(&entropy_nrf5_data == DEV_DATA(dev));
 
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&entropy_nrf5_data.sem_lock, 1, 1);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -249,12 +249,12 @@ static void stm32_rng_isr(const void *arg)
 	}
 }
 
-static int entropy_stm32_rng_get_entropy(const struct device *device,
+static int entropy_stm32_rng_get_entropy(const struct device *dev,
 					 uint8_t *buf,
 					 uint16_t len)
 {
 	/* Check if this API is called on correct driver instance. */
-	__ASSERT_NO_MSG(&entropy_stm32_rng_data == DEV_DATA(device));
+	__ASSERT_NO_MSG(&entropy_stm32_rng_data == DEV_DATA(dev));
 
 	while (len) {
 		uint16_t bytes;

--- a/drivers/espi/espi_utils.h
+++ b/drivers/espi/espi_utils.h
@@ -45,11 +45,11 @@ static inline int espi_manage_callback(sys_slist_t *callbacks,
  * @brief Generic function to go through and fire callback from a callback list.
  *
  * @param list A pointer on the espi callback list.
- * @param device A pointer on the espi driver instance.
+ * @param dev A pointer on the espi driver instance.
  * @param pins The details on the event that triggered the callback.
  */
 static inline void espi_send_callbacks(sys_slist_t *list,
-				       const struct device *device,
+				       const struct device *dev,
 				       struct espi_event evt)
 {
 	struct espi_callback *cb, *tmp;
@@ -57,7 +57,7 @@ static inline void espi_send_callbacks(sys_slist_t *list,
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(list, cb, tmp, node) {
 		if (cb->evt_type & evt.evt_type) {
 			__ASSERT(cb->handler, "No callback handler!");
-			cb->handler(device, cb, evt);
+			cb->handler(dev, cb, evt);
 		}
 	}
 }

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -108,9 +108,9 @@ static int e1000_tx(struct e1000_dev *dev, void *buf, size_t len)
 	return (dev->tx.sta & TDESC_STA_DD) ? 0 : -EIO;
 }
 
-static int e1000_send(const struct device *device, struct net_pkt *pkt)
+static int e1000_send(const struct device *ddev, struct net_pkt *pkt)
 {
-	struct e1000_dev *dev = device->data;
+	struct e1000_dev *dev = ddev->data;
 	size_t len = net_pkt_get_len(pkt);
 
 	if (net_pkt_read(pkt, dev->txb, len)) {
@@ -160,9 +160,9 @@ out:
 	return pkt;
 }
 
-static void e1000_isr(const struct device *device)
+static void e1000_isr(const struct device *ddev)
 {
-	struct e1000_dev *dev = device->data;
+	struct e1000_dev *dev = ddev->data;
 	uint32_t icr = ior32(dev, ICR); /* Cleared upon read */
 	uint16_t vlan_tag = NET_VLAN_TAG_UNSPEC;
 
@@ -210,10 +210,10 @@ static void e1000_isr(const struct device *device)
 #define PCI_VENDOR_ID_INTEL	0x8086
 #define PCI_DEVICE_ID_I82540EM	0x100e
 
-int e1000_probe(const struct device *device)
+int e1000_probe(const struct device *ddev)
 {
 	const pcie_bdf_t bdf = PCIE_BDF(0, 3, 0);
-	struct e1000_dev *dev = device->data;
+	struct e1000_dev *dev = ddev->data;
 	uint32_t ral, rah;
 	struct pcie_mbar mbar;
 

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -253,21 +253,21 @@ static int gpio_esp32_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
-static void gpio_esp32_fire_callbacks(const struct device *device)
+static void gpio_esp32_fire_callbacks(const struct device *dev)
 {
-	struct gpio_esp32_data *data = device->data;
+	struct gpio_esp32_data *data = dev->data;
 	uint32_t irq_status = *data->port.irq_status_reg;
 
 	*data->port.irq_ack_reg = irq_status;
 
-	gpio_fire_callbacks(&data->cb, device, irq_status);
+	gpio_fire_callbacks(&data->cb, dev, irq_status);
 }
 
 static void gpio_esp32_isr(const void *param);
 
-static int gpio_esp32_init(const struct device *device)
+static int gpio_esp32_init(const struct device *dev)
 {
-	struct gpio_esp32_data *data = device->data;
+	struct gpio_esp32_data *data = dev->data;
 	static bool isr_connected;
 
 	data->pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -571,13 +571,13 @@ static const struct gpio_driver_api gpio_stm32_driver = {
  *
  * @return 0
  */
-static int gpio_stm32_init(const struct device *device)
+static int gpio_stm32_init(const struct device *dev)
 {
-	struct gpio_stm32_data *data = device->data;
+	struct gpio_stm32_data *data = dev->data;
 
-	data->dev = device;
+	data->dev = dev;
 
-	return gpio_stm32_clock_request(device, true);
+	return gpio_stm32_clock_request(dev, true);
 }
 
 #define GPIO_DEVICE_INIT(__node, __suffix, __base_addr, __port, __cenr, __bus) \
@@ -654,9 +654,9 @@ GPIO_DEVICE_INIT_STM32(k, K);
 
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 
-static int gpio_stm32_afio_init(const struct device *device)
+static int gpio_stm32_afio_init(const struct device *dev)
 {
-	UNUSED(device);
+	UNUSED(dev);
 
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
 

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -547,16 +547,16 @@ static int i2c_esp32_transfer(const struct device *dev, struct i2c_msg *msgs,
 	return ret;
 }
 
-static void i2c_esp32_isr(const struct device *device)
+static void i2c_esp32_isr(const struct device *dev)
 {
 	const int fifo_give_mask = I2C_ACK_ERR_INT_ST |
 				   I2C_TIME_OUT_INT_ST |
 				   I2C_TRANS_COMPLETE_INT_ST |
 				   I2C_ARBITRATION_LOST_INT_ST;
-	const struct i2c_esp32_config *config = device->config;
+	const struct i2c_esp32_config *config = dev->config;
 
 	if (sys_read32(I2C_INT_STATUS_REG(config->index)) & fifo_give_mask) {
-		struct i2c_esp32_data *data = device->data;
+		struct i2c_esp32_data *data = dev->data;
 
 		/* Only give the semaphore if a watched interrupt happens.
 		 * Error checking is performed at the other side of the

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -191,7 +191,7 @@ static int arc_v2_irq_unit_get_state(const struct device *dev)
  *
  * @return operation result
  */
-static int arc_v2_irq_unit_device_ctrl(const struct device *device,
+static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 				       uint32_t ctrl_command, void *context,
 				       device_pm_cb cb, void *arg)
 {
@@ -200,18 +200,18 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *device,
 
 	if (ctrl_command == DEVICE_PM_SET_POWER_STATE) {
 		if (*((uint32_t *)context) == DEVICE_PM_SUSPEND_STATE) {
-			ret = arc_v2_irq_unit_suspend(device);
+			ret = arc_v2_irq_unit_suspend(dev);
 		} else if (*((uint32_t *)context) == DEVICE_PM_ACTIVE_STATE) {
-			ret = arc_v2_irq_unit_resume(device);
+			ret = arc_v2_irq_unit_resume(dev);
 		}
 	} else if (ctrl_command == DEVICE_PM_GET_POWER_STATE) {
-		*((uint32_t *)context) = arc_v2_irq_unit_get_state(device);
+		*((uint32_t *)context) = arc_v2_irq_unit_get_state(dev);
 	}
 
 	arch_irq_unlock(key);
 
 	if (cb) {
-		cb(device, ret, context, arg);
+		cb(dev, ret, context, arg);
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -303,7 +303,7 @@ int ioapic_resume_from_suspend(const struct device *port)
 * Implements the driver control management functionality
 * the *context may include IN data or/and OUT data
 */
-static int ioapic_device_ctrl(const struct device *device,
+static int ioapic_device_ctrl(const struct device *dev,
 			      uint32_t ctrl_command,
 			      void *context, device_pm_cb cb, void *arg)
 {
@@ -311,16 +311,16 @@ static int ioapic_device_ctrl(const struct device *device,
 
 	if (ctrl_command == DEVICE_PM_SET_POWER_STATE) {
 		if (*((uint32_t *)context) == DEVICE_PM_SUSPEND_STATE) {
-			ret = ioapic_suspend(device);
+			ret = ioapic_suspend(dev);
 		} else if (*((uint32_t *)context) == DEVICE_PM_ACTIVE_STATE) {
-			ret = ioapic_resume_from_suspend(device);
+			ret = ioapic_resume_from_suspend(dev);
 		}
 	} else if (ctrl_command == DEVICE_PM_GET_POWER_STATE) {
 		*((uint32_t *)context) = ioapic_device_power_state;
 	}
 
 	if (cb) {
-		cb(device, ret, context, arg);
+		cb(dev, ret, context, arg);
 	}
 
 	return ret;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -689,9 +689,9 @@ static void gsm_configure(struct k_work *work)
 	gsm_finalize_connection(gsm);
 }
 
-void gsm_ppp_start(const struct device *device)
+void gsm_ppp_start(const struct device *dev)
 {
-	struct gsm_modem *gsm = device->data;
+	struct gsm_modem *gsm = dev->data;
 
 	/* Re-init underlying UART comms */
 	int r = modem_iface_uart_init_dev(&gsm->context.iface,
@@ -705,9 +705,9 @@ void gsm_ppp_start(const struct device *device)
 	(void)k_delayed_work_submit(&gsm->gsm_configure_work, K_NO_WAIT);
 }
 
-void gsm_ppp_stop(const struct device *device)
+void gsm_ppp_stop(const struct device *dev)
 {
-	struct gsm_modem *gsm = device->data;
+	struct gsm_modem *gsm = dev->data;
 	struct net_if *iface = gsm->iface;
 
 	net_if_l2(iface)->enable(iface, false);
@@ -727,9 +727,9 @@ void gsm_ppp_stop(const struct device *device)
 	}
 }
 
-static int gsm_init(const struct device *device)
+static int gsm_init(const struct device *dev)
 {
-	struct gsm_modem *gsm = device->data;
+	struct gsm_modem *gsm = dev->data;
 	int r;
 
 	LOG_DBG("Generic GSM modem (%p)", gsm);
@@ -795,7 +795,7 @@ static int gsm_init(const struct device *device)
 	}
 
 	if (IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART)) {
-		gsm_ppp_start(device);
+		gsm_ppp_start(dev);
 	}
 
 	return 0;

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -167,9 +167,9 @@ static struct pinmux_driver_api api_funcs = {
 	.input = pinmux_input
 };
 
-static int pinmux_initialize(const struct device *device)
+static int pinmux_initialize(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 #if !CONFIG_BOOTLOADER_ESP_IDF
 	uint32_t pin;

--- a/drivers/pinmux/pinmux_intel_s1000.c
+++ b/drivers/pinmux/pinmux_intel_s1000.c
@@ -88,9 +88,9 @@ static struct pinmux_driver_api apis = {
 	.input = pinmux_input
 };
 
-static int pinmux_init(const struct device *device)
+static int pinmux_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 	return 0;
 }
 

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -42,9 +42,9 @@ static void timer_irq_handler(const void *unused)
 	wrapped_announce(_sys_idle_elapsed_ticks);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	IOWR_ALTERA_AVALON_TIMER_PERIODL(TIMER_0_BASE,
 			k_ticks_to_cyc_floor32(1) & 0xFFFF);

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -213,11 +213,11 @@ uint32_t sys_clock_cycle_get_32(void)
 
 #endif
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
 	uint32_t val;
 
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	val = x86_read_loapic(LOAPIC_TIMER_CONFIG);	/* set divider */
 	val &= ~DCR_DIVIDER_MASK;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -277,9 +277,9 @@ static void timer_int_handler(const void *unused)
  *
  * @return 0
  */
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	/* ensure that the timer will not generate interrupts */
 	timer0_control_register_set(0);

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -46,9 +46,9 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
 		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);

--- a/drivers/timer/cavs_timer.c
+++ b/drivers/timer/cavs_timer.c
@@ -121,7 +121,7 @@ static void compare_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
 	uint64_t curr = count();
 

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -183,9 +183,9 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	rtc_last = 0U;
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -149,9 +149,9 @@ void sys_clock_isr(void *arg)
 	z_arm_int_exit();
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 	last_load = CYC_PER_TICK - 1;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -106,12 +106,12 @@ static void set_timer0_irq(unsigned int irq)
 	TIMER0_CONF_REG = val;
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
 	extern int z_clock_hw_cycles_per_sec;
 	uint32_t hz;
 
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	DEVICE_MMIO_TOPLEVEL_MAP(hpet_regs, K_MEM_CACHE_NONE);
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -204,7 +204,7 @@ static void timer_isr(const void *unused)
 	sys_clock_announce(dticks);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
 	timer_init_combine(CTIMER_HW_TIMER_INDEX, TRUE);
 	timer_init(CTIMER_HW_TIMER_INDEX, ET_PSR_32K, TRUE, FALSE, 0);

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -101,8 +101,9 @@ static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
 	tmr->ctrl = GPTIMER_CTRL_LD | GPTIMER_CTRL_RS | GPTIMER_CTRL_EN;
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
+	ARG_UNUSED(dev);
 	const int timer_interrupt = get_timer_irq();
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -30,7 +30,6 @@
 
 static void litex_timer_irq_handler(const void *device)
 {
-	ARG_UNUSED(device);
 	int key = irq_lock();
 
 	sys_write8(TIMER_EV, TIMER_EV_PENDING_ADDR);
@@ -59,9 +58,9 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority),
 			litex_timer_irq_handler, NULL, 0);
 	irq_enable(TIMER_IRQ);

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -314,9 +314,9 @@ void sys_clock_disable(void)
 	TIMER_REGS->CTRL = 0U;
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	mchp_pcr_periph_slp_ctrl(PCR_RTMR, MCHP_PCR_SLEEP_DIS);
 

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -60,9 +60,9 @@ void np_timer_isr_test_hook(const void *arg)
  *
  * Enable the hw timer, setting its tick period, and setup its interrupt
  */
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -265,9 +265,9 @@ uint32_t sys_clock_cycle_get_32(void)
 	return (uint32_t)(current);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 	int ret;
 	const struct device *const clk_dev =
 					device_get_binding(NPCX_CLK_CTRL_NAME);

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -299,9 +299,9 @@ void z_nrf_rtc_timer_chan_free(uint32_t chan)
 	atomic_or(&alloc_mask, BIT(chan));
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 	static const enum nrf_lfclk_start_mode mode =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT) ?
 			CLOCK_CONTROL_NRF_LF_START_NOWAIT :

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -79,9 +79,9 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
 	last_count = mtime();

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -175,9 +175,9 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 #ifdef MCLK
 	MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -78,9 +78,9 @@ static void lptim_irq_handler(const struct device *unused)
 	}
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	/* enable LPTIM clock source */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LPTIM1);

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -23,14 +23,14 @@ void __weak sys_clock_isr(void *arg)
 	__ASSERT_NO_MSG(false);
 }
 
-int __weak sys_clock_driver_init(const struct device *device)
+int __weak sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	return 0;
 }
 
-int __weak sys_clock_device_ctrl(const struct device *device,
+int __weak sys_clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
 			       void *context, device_pm_cb cb, void *arg)
 {

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -96,9 +96,10 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
 	uint32_t reg_val;
+	ARG_UNUSED(dev);
 
 	/* Stop timer */
 	sys_write32(XTTCPS_CNT_CNTRL_DIS_MASK,

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -56,9 +56,9 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
-int sys_clock_driver_init(const struct device *device)
+int sys_clock_driver_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
 	set_ccompare(ccount() + CYC_PER_TICK);

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -1040,7 +1040,7 @@ static int winc1500_mgmt_connect(const struct device *dev,
 	return 0;
 }
 
-static int winc1500_mgmt_disconnect(const struct device *device)
+static int winc1500_mgmt_disconnect(const struct device *dev)
 {
 	if (!w1500_data.connected) {
 		return -EALREADY;

--- a/include/drivers/gsm_ppp.h
+++ b/include/drivers/gsm_ppp.h
@@ -11,8 +11,8 @@
 
 /** @cond INTERNAL_HIDDEN */
 struct device;
-void gsm_ppp_start(const struct device *device);
-void gsm_ppp_stop(const struct device *device);
+void gsm_ppp_start(const struct device *dev);
+void gsm_ppp_stop(const struct device *dev);
 /** @endcond */
 
 #endif /* GSM_PPP_H_ */

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -36,7 +36,7 @@ extern "C" {
  * initialization callback.  It is a weak symbol that will be
  * implemented as a noop if undefined in the clock driver.
  */
-extern int sys_clock_driver_init(const struct device *device);
+extern int sys_clock_driver_init(const struct device *dev);
 
 /**
  * @brief Initialize system clock driver
@@ -46,7 +46,7 @@ extern int sys_clock_driver_init(const struct device *device);
  * management.  It is a weak symbol that will be implemented as a noop
  * if undefined in the clock driver.
  */
-extern int clock_device_ctrl(const struct device *device,
+extern int clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
 			       void *context, device_pm_cb cb, void *arg);
 

--- a/include/logging/log_backend_std.h
+++ b/include/logging/log_backend_std.h
@@ -23,12 +23,12 @@ extern "C" {
 
 /** @brief Put log message to a standard logger backend.
  *
- * @param log_output	Log output instance.
+ * @param output	Log output instance.
  * @param flags		Formatting flags.
  * @param msg		Log message.
  */
 static inline void
-log_backend_std_put(const struct log_output *const log_output, uint32_t flags,
+log_backend_std_put(const struct log_output *const output, uint32_t flags,
 		    struct log_msg *msg)
 {
 	log_msg_get(msg);
@@ -43,35 +43,35 @@ log_backend_std_put(const struct log_output *const log_output, uint32_t flags,
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
-	log_output_msg_process(log_output, msg, flags);
+	log_output_msg_process(output, msg, flags);
 
 	log_msg_put(msg);
 }
 
 /** @brief Put a standard logger backend into panic mode.
  *
- * @param log_output	Log output instance.
+ * @param output	Log output instance.
  */
 static inline void
-log_backend_std_panic(const struct log_output *const log_output)
+log_backend_std_panic(const struct log_output *const output)
 {
-	log_output_flush(log_output);
+	log_output_flush(output);
 }
 
 /** @brief Report dropped messages to a standard logger backend.
  *
- * @param log_output	Log output instance.
+ * @param output	Log output instance.
  * @param cnt		Number of dropped messages.
  */
 static inline void
-log_backend_std_dropped(const struct log_output *const log_output, uint32_t cnt)
+log_backend_std_dropped(const struct log_output *const output, uint32_t cnt)
 {
-	log_output_dropped_process(log_output, cnt);
+	log_output_dropped_process(output, cnt);
 }
 
 /** @brief Synchronously process log message by a standard logger backend.
  *
- * @param log_output	Log output instance.
+ * @param output	Log output instance.
  * @param flags		Formatting flags.
  * @param src_level	Log message source and level.
  * @param timestamp	Timestamp.
@@ -79,7 +79,7 @@ log_backend_std_dropped(const struct log_output *const log_output, uint32_t cnt)
  * @param ap		Log string arguments.
  */
 static inline void
-log_backend_std_sync_string(const struct log_output *const log_output,
+log_backend_std_sync_string(const struct log_output *const output,
 			    uint32_t flags, struct log_msg_ids src_level,
 			    uint32_t timestamp, const char *fmt, va_list ap)
 {
@@ -102,7 +102,7 @@ log_backend_std_sync_string(const struct log_output *const log_output,
 		key = irq_lock();
 	}
 
-	log_output_string(log_output, src_level, timestamp, fmt, ap, flags);
+	log_output_string(output, src_level, timestamp, fmt, ap, flags);
 
 	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&
 		IS_ENABLED(CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT)) {
@@ -112,7 +112,7 @@ log_backend_std_sync_string(const struct log_output *const log_output,
 
 /** @brief Synchronously process hexdump message by a standard logger backend.
  *
- * @param log_output	Log output instance.
+ * @param output	Log output instance.
  * @param flags		Formatting flags.
  * @param src_level	Log message source and level.
  * @param timestamp	Timestamp.
@@ -121,7 +121,7 @@ log_backend_std_sync_string(const struct log_output *const log_output,
  * @param length	Length of the buffer.
  */
 static inline void
-log_backend_std_sync_hexdump(const struct log_output *const log_output,
+log_backend_std_sync_hexdump(const struct log_output *const output,
 			     uint32_t flags, struct log_msg_ids src_level,
 			     uint32_t timestamp, const char *metadata,
 			     const uint8_t *data, uint32_t length)
@@ -145,7 +145,7 @@ log_backend_std_sync_hexdump(const struct log_output *const log_output,
 		key = irq_lock();
 	}
 
-	log_output_hexdump(log_output, src_level, timestamp,
+	log_output_hexdump(output, src_level, timestamp,
 			metadata, data, length, flags);
 
 	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&

--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -101,11 +101,11 @@ struct log_output {
  * Function is using provided context with the buffer and output function to
  * process formatted string and output the data.
  *
- * @param log_output Pointer to the log output instance.
+ * @param output Pointer to the log output instance.
  * @param msg Log message.
  * @param flags Optional flags.
  */
-void log_output_msg_process(const struct log_output *log_output,
+void log_output_msg_process(const struct log_output *output,
 			    struct log_msg *msg,
 			    uint32_t flags);
 
@@ -114,7 +114,7 @@ void log_output_msg_process(const struct log_output *log_output,
  * Function is formatting provided string adding optional prefixes and
  * postfixes.
  *
- * @param log_output Pointer to log_output instance.
+ * @param output Pointer to log_output instance.
  * @param src_level  Log source and level structure.
  * @param timestamp  Timestamp.
  * @param fmt        String.
@@ -122,7 +122,7 @@ void log_output_msg_process(const struct log_output *log_output,
  * @param flags      Optional flags.
  *
  */
-void log_output_string(const struct log_output *log_output,
+void log_output_string(const struct log_output *output,
 		       struct log_msg_ids src_level, uint32_t timestamp,
 		       const char *fmt, va_list ap, uint32_t flags);
 
@@ -131,7 +131,7 @@ void log_output_string(const struct log_output *log_output,
  * Function is formatting provided hexdump adding optional prefixes and
  * postfixes.
  *
- * @param log_output Pointer to log_output instance.
+ * @param output Pointer to log_output instance.
  * @param src_level  Log source and level structure.
  * @param timestamp  Timestamp.
  * @param metadata   String.
@@ -140,7 +140,7 @@ void log_output_string(const struct log_output *log_output,
  * @param flags      Optional flags.
  *
  */
-void log_output_hexdump(const struct log_output *log_output,
+void log_output_hexdump(const struct log_output *output,
 			     struct log_msg_ids src_level, uint32_t timestamp,
 			     const char *metadata, const uint8_t *data,
 			     uint32_t length, uint32_t flags);
@@ -149,37 +149,37 @@ void log_output_hexdump(const struct log_output *log_output,
  *
  * Function prints error message indicating lost log messages.
  *
- * @param log_output Pointer to the log output instance.
+ * @param output Pointer to the log output instance.
  * @param cnt        Number of dropped messages.
  */
-void log_output_dropped_process(const struct log_output *log_output, uint32_t cnt);
+void log_output_dropped_process(const struct log_output *output, uint32_t cnt);
 
 /** @brief Flush output buffer.
  *
- * @param log_output Pointer to the log output instance.
+ * @param output Pointer to the log output instance.
  */
-void log_output_flush(const struct log_output *log_output);
+void log_output_flush(const struct log_output *output);
 
 /** @brief Function for setting user context passed to the output function.
  *
- * @param log_output	Pointer to the log output instance.
+ * @param output	Pointer to the log output instance.
  * @param ctx		User context.
  */
-static inline void log_output_ctx_set(const struct log_output *log_output,
+static inline void log_output_ctx_set(const struct log_output *output,
 				      void *ctx)
 {
-	log_output->control_block->ctx = ctx;
+	output->control_block->ctx = ctx;
 }
 
 /** @brief Function for setting hostname of this device
  *
- * @param log_output	Pointer to the log output instance.
+ * @param output	Pointer to the log output instance.
  * @param hostname	Hostname of this device
  */
-static inline void log_output_hostname_set(const struct log_output *log_output,
+static inline void log_output_hostname_set(const struct log_output *output,
 					   const char *hostname)
 {
-	log_output->control_block->hostname = hostname;
+	output->control_block->hostname = hostname;
 }
 
 /** @brief Set timestamp frequency.

--- a/include/net/net_config.h
+++ b/include/net/net_config.h
@@ -87,14 +87,14 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
  *          the config option and call the function manually when the
  *          application starts.
  *
- * @param device Network device to use. The function will figure out what
+ * @param dev Network device to use. The function will figure out what
  *        network interface to use based on the device. If the device is NULL,
  *        then default network interface is used by the function.
  * @param app_info String describing this application.
  *
  * @return 0 if ok, <0 if error.
  */
-int net_config_init_app(const struct device *device, const char *app_info);
+int net_config_init_app(const struct device *dev, const char *app_info);
 
 /**
  * @}

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -120,34 +120,34 @@ static int _check_fd(int fd)
 
 void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err)
 {
-	struct fd_entry *fd_entry;
+	struct fd_entry *entry;
 
 	if (_check_fd(fd) < 0) {
 		return NULL;
 	}
 
-	fd_entry = &fdtable[fd];
+	entry = &fdtable[fd];
 
-	if (vtable != NULL && fd_entry->vtable != vtable) {
+	if (vtable != NULL && entry->vtable != vtable) {
 		errno = err;
 		return NULL;
 	}
 
-	return fd_entry->obj;
+	return entry->obj;
 }
 
 void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable)
 {
-	struct fd_entry *fd_entry;
+	struct fd_entry *entry;
 
 	if (_check_fd(fd) < 0) {
 		return NULL;
 	}
 
-	fd_entry = &fdtable[fd];
-	*vtable = fd_entry->vtable;
+	entry = &fdtable[fd];
+	*vtable = entry->vtable;
 
-	return fd_entry->obj;
+	return entry->obj;
 }
 
 int z_reserve_fd(void)

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -66,7 +66,7 @@ static struct rpmsg_endpoint rcv_ept;
 static K_SEM_DEFINE(data_sem, 0, 1);
 static K_SEM_DEFINE(data_rx_sem, 0, 1);
 
-static void platform_ipm_callback(const struct device *device, void *context,
+static void platform_ipm_callback(const struct device *dev, void *context,
 				  uint32_t id, volatile void *data)
 {
 	LOG_DBG("%s: msg received from mb %d\n", __func__, id);

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -651,9 +651,9 @@ ipv4_out:
 	return !ok;
 }
 
-static int llmnr_responder_init(const struct device *device)
+static int llmnr_responder_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	return init_listener();
 }

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -603,9 +603,9 @@ ipv4_out:
 	return !ok;
 }
 
-static int mdns_responder_init(const struct device *device)
+static int mdns_responder_init(const struct device *dev)
 {
-	ARG_UNUSED(device);
+	ARG_UNUSED(dev);
 
 	return init_listener();
 }

--- a/tests/kernel/device/src/mmio.c
+++ b/tests/kernel/device/src/mmio.c
@@ -28,9 +28,9 @@ const struct foo_single_config_info foo0_config = {
 	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
 };
 
-int foo_single_init(const struct device *device)
+int foo_single_init(const struct device *dev)
 {
-	DEVICE_MMIO_MAP(device, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 
 	return 0;
 }
@@ -122,10 +122,10 @@ const struct foo_mult_config_info foo12_config = {
 #define DEV_DATA(dev)	((struct foo_mult_dev_data *)((dev)->data))
 #define DEV_CFG(dev)	((struct foo_mult_config_info *)((dev)->config))
 
-int foo_mult_init(const struct device *device)
+int foo_mult_init(const struct device *dev)
 {
-	DEVICE_MMIO_NAMED_MAP(device, courge, K_MEM_CACHE_NONE);
-	DEVICE_MMIO_NAMED_MAP(device, grault, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, courge, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, grault, K_MEM_CACHE_NONE);
 
 	return 0;
 }


### PR DESCRIPTION
Do not reuse tag name following zephyr coding guidelines (misra 5.7)

this is just the first pass.

﻿- fdtable: fdtable: do not use tag name fd_entry
- logging : do not reuse tag name log_output
- doc: device: follow coding guidelines
- drivers: device: do not reuse tag name 'device'
