### PR TITLE
cmake: removing map file from BYPRODUCTS as it is being renamed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1118,9 +1118,6 @@ else()
     LIBRARIES_POST_SCRIPT ""
     DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
-  target_byproducts(TARGET ${ZEPHYR_FINAL_EXECUTABLE}
-                    BYPRODUCTS ${PROJECT_BINARY_DIR}/${ZEPHYR_FINAL_EXECUTABLE}.map
-  )
   set_property(TARGET   ${ZEPHYR_FINAL_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
   add_dependencies(     ${ZEPHYR_FINAL_EXECUTABLE} linker_zephyr_final_script_target)
 


### PR DESCRIPTION
Fixes: #33512

The ${ZEPHYR_FINAL_EXECUTABLE}.map file is being renamed at a later
stage.

The renamed, and thus missing file, causes ninja to relink the target
in order to re-create the map file, which then again is renamed.

This is fixed by removing the ${ZEPHYR_FINAL_EXECUTABLE}.map as a
byproduct and only has the byproduct on the renamed file to ensure
proper cleanup, see: #23449.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>