### PR TITLE
tests: error_hook: Fix header name in README

### DIFF
--- a/tests/ztest/error_hook/README.txt
+++ b/tests/ztest/error_hook/README.txt
@@ -41,7 +41,7 @@ Step4: Call ztest_set_fault_valid(true) before where your target function
 
 Step1: Add CONFIG_ZTEST_ASSERT_HOOK=y into prj.conf
 
-Step2: Include <ztest_assert_hook.h> in your C code.
+Step2: Include <ztest_error_hook.h> in your C code.
 
 Step3: (optional) Define a hook function call ztest_post_assert_fail_hook().
 


### PR DESCRIPTION
ztest_assert_hook.h does not exist, ztest_error_hook.h should be
included.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>