### PR TITLE
tests: ztest: Fix assert hook dependency

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_error_hook.h
+++ b/subsys/testsuite/ztest/include/ztest_error_hook.h
@@ -68,7 +68,7 @@ void ztest_post_assert_fail_hook(void);
 
 #endif
 
-#if defined(CONFIG_ZTEST_FATAL_HOOK)
+#if defined(CONFIG_ZTEST_FATAL_HOOK) || defined(CONFIG_ZTEST_ASSERT_HOOK)
 #include <syscalls/ztest_error_hook.h>
 #endif
 


### PR DESCRIPTION
Without this fix, ztest_set_assert_valid() can only be used when
CONFIG_ZTEST_FATAL_HOOK is set.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>