### PR TITLE
tests: benchmarks: increase timeout

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,19 +1,18 @@
+common:
+  tags: benchmark
+  timeout: 420
 tests:
   benchmark.kernel.application:
     arch_allow: x86 arm riscv32 riscv64
     min_flash: 34
     min_ram: 32
-    tags: benchmark
-    timeout: 300
   benchmark.kernel.application.fp.arm:
     extra_args: CONF_FILE=prj_fp.conf
     arch_allow: arm
     filter: CONFIG_ARMV7_M_ARMV8_M_FP
     min_flash: 34
     min_ram: 32
-    tags: benchmark
     slow: true
-    timeout: 300
   benchmark.kernel.application.fp.x86.fpu:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
@@ -23,9 +22,7 @@ tests:
     filter: CONFIG_CPU_HAS_FPU
     min_flash: 34
     min_ram: 32
-    tags: benchmark
     slow: true
-    timeout: 300
   benchmark.kernel.application.fp.x86.sse:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
@@ -35,10 +32,7 @@ tests:
     filter: CONFIG_CPU_HAS_FPU
     min_flash: 34
     min_ram: 32
-    tags: benchmark
     slow: true
-    timeout: 300
   benchmark.kernel.application.posix:
     arch_allow: posix
     min_ram: 32
-    tags: benchmark


### PR DESCRIPTION
benchmark times out on some platforms, give it some more time.