### PR TITLE
boards: update adafruit_feather_nrf52840 dts to add i2c compatible property

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -76,6 +76,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-gpios = <&gpio0 12 0>;
 	scl-gpios = <&gpio0 11 0>;


### PR DESCRIPTION
The board `adafruit_feather_nrf52840` is missing the `compatible` property in the i2c node of the device tree. This PR fixes that.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/33529

Signed-off-by: Jeremy Herbert jeremy.006@gmail.com