### PR TITLE
logging: Add name to the mode choice in kconfig

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice LOG_MODE
 	prompt "Mode"
 	default LOG_MODE_DEFERRED
 


### PR DESCRIPTION
Adding name allows to modify default choice by other modules.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>