### PR TITLE
logging: kconfig: Give the log mode choice a name

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice LOG_MODE
 	prompt "Mode"
 	default LOG_MODE_DEFERRED
 


### PR DESCRIPTION
... so that it is possible to change its default value in certain
configurations.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>