### PR TITLE
Bluetooth: controller: Fix race in create connection cancel

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -61,7 +61,10 @@ struct lll_adv {
 	struct lll_hdr hdr;
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	/* NOTE: conn context has to be after lll_hdr */
+	/* NOTE: conn context SHALL be after lll_hdr,
+	 *       check ull_conn_setup how it access the connection LLL
+	 *       context.
+	 */
 	struct lll_conn *conn;
 	uint8_t is_hdcd:1;
 #endif /* CONFIG_BT_PERIPHERAL */

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -59,6 +59,7 @@ struct lll_conn {
 	union {
 		struct {
 			uint8_t initiated:1;
+			uint8_t cancelled:1;
 		} master;
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -46,7 +46,6 @@ struct lll_conn {
 	uint8_t data_chan_count:6;
 	uint8_t data_chan_sel:1;
 	uint8_t role:1;
-	uint8_t initiated:1;
 
 	union {
 		struct {
@@ -57,18 +56,24 @@ struct lll_conn {
 		uint16_t data_chan_id;
 	};
 
+	union {
+		struct {
+			uint8_t initiated:1;
+		} master;
 #if defined(CONFIG_BT_PERIPHERAL)
-	struct {
-		uint8_t  latency_enabled:1;
+		struct {
+			uint8_t  initiated:1;
+			uint8_t  latency_enabled:1;
 
-		uint32_t window_widening_periodic_us;
-		uint32_t window_widening_max_us;
-		uint32_t window_widening_prepare_us;
-		uint32_t window_widening_event_us;
-		uint32_t window_size_prepare_us;
-		uint32_t window_size_event_us;
-	} slave;
+			uint32_t window_widening_periodic_us;
+			uint32_t window_widening_max_us;
+			uint32_t window_widening_prepare_us;
+			uint32_t window_widening_event_us;
+			uint32_t window_size_prepare_us;
+			uint32_t window_size_event_us;
+		} slave;
 #endif /* CONFIG_BT_PERIPHERAL */
+	};
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	uint16_t max_tx_octets;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -12,7 +12,7 @@ struct lll_scan {
 	 *       check ull_conn_setup how it access the connection LLL
 	 *       context.
 	 */
-	struct lll_conn *conn;
+	struct lll_conn *volatile conn;
 
 	uint8_t  adv_addr[BDADDR_SIZE];
 	uint32_t conn_win_offset_us;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -8,8 +8,13 @@ struct lll_scan {
 	struct lll_hdr hdr;
 
 #if defined(CONFIG_BT_CENTRAL)
-	/* NOTE: conn context has to be after lll_hdr */
+	/* NOTE: conn context SHALL be after lll_hdr,
+	 *       check ull_conn_setup how it access the connection LLL
+	 *       context.
+	 */
 	struct lll_conn *conn;
+
+	uint8_t  adv_addr[BDADDR_SIZE];
 	uint32_t conn_win_offset_us;
 	uint16_t conn_timeout;
 #endif /* CONFIG_BT_CENTRAL */
@@ -17,9 +22,11 @@ struct lll_scan {
 	uint8_t  state:1;
 	uint8_t  chan:2;
 	uint8_t  filter_policy:2;
-	uint8_t  adv_addr_type:1;
-	uint8_t  init_addr_type:1;
 	uint8_t  type:1;
+	uint8_t  init_addr_type:1;
+#if defined(CONFIG_BT_CENTRAL)
+	uint8_t  adv_addr_type:1;
+#endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	uint16_t duration_reload;
@@ -35,7 +42,6 @@ struct lll_scan {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	uint8_t  init_addr[BDADDR_SIZE];
-	uint8_t  adv_addr[BDADDR_SIZE];
 
 	uint16_t interval;
 	uint32_t ticks_window;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -744,7 +744,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->initiated)) {
+	if (unlikely(lll->conn && lll->conn->slave.initiated)) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -1364,7 +1364,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->slave.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -685,7 +685,7 @@ static void isr_tx_connect_rsp(void *param)
 
 	if (is_done) {
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->slave.initiated = 1;
 	}
 
 	/* Clear radio status and events */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -138,7 +138,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->initiated)) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -371,7 +371,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 		} else if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
-			   lll->conn && lll->conn->initiated) {
+			   lll->conn && lll->conn->master.initiated) {
 			while (!radio_has_disabled()) {
 				cpu_sleep();
 			}
@@ -930,7 +930,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		 */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -140,7 +140,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (unlikely(lll->conn && lll->conn->master.initiated)) {
+	if (unlikely(lll->conn &&
+		     (lll->conn->master.initiated ||
+		      lll->conn->master.cancelled))) {
 		int err;
 
 		err = lll_hfclock_off();
@@ -779,7 +781,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
-	} else if (lll->conn &&
+	} else if (lll->conn && !lll->conn->master.cancelled &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -66,10 +66,12 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 			     uint8_t devmatch_ok, uint8_t devmatch_id,
 			     uint8_t irkmatch_ok, uint8_t irkmatch_id,
 			     uint8_t rl_idx, uint8_t rssi_ready);
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx);
 static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 					    struct pdu_adv *pdu, uint8_t rl_idx);
+#endif /* CONFIG_BT_CENTRAL */
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,
 				       bool *dir_report);
@@ -1104,6 +1106,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	return -ECANCELED;
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx)
 {
@@ -1133,6 +1136,7 @@ static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 	return ((lll->adv_addr_type == pdu->tx_addr) &&
 		!memcmp(lll->adv_addr, &pdu->adv_ind.addr[0], BDADDR_SIZE));
 }
+#endif /* CONFIG_BT_CENTRAL */
 
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -330,7 +330,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll->conn && lll->conn->initiated) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_clk_off();
@@ -928,7 +928,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		}
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -132,7 +132,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	/* Check if stopped (on connection establishment race between LLL and
 	 * ULL.
 	 */
-	if (lll->conn && lll->conn->initiated) {
+	if (unlikely(lll->conn && lll->conn->master.initiated)) {
 		int err;
 
 		err = lll_clk_off();
@@ -827,7 +827,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		 */
 
 		/* Stop further LLL radio events */
-		lll->conn->initiated = 1;
+		lll->conn->master.initiated = 1;
 
 		rx = ull_pdu_rx_alloc();
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -873,7 +873,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 		/* FIXME: BEGIN: Move to ULL? */
 		conn_lll->role = 1;
-		conn_lll->initiated = 0;
+		conn_lll->slave.initiated = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
 		conn_lll->event_counter = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -800,6 +800,9 @@ void ull_conn_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	ftr = &(rx->rx_ftr);
 
+	/* NOTE: LLL conn context SHALL be after lll_hdr in
+	 *       struct lll_adv and struct lll_scan.
+	 */
 	lll = *((struct lll_conn **)((uint8_t *)ftr->param +
 				     sizeof(struct lll_hdr)));
 	switch (lll->role) {

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -221,7 +221,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->data_chan_sel = 0;
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
-	conn_lll->initiated = 0;
+	conn_lll->master.initiated = 0;
 	/* FIXME: END: Move to ULL? */
 #if defined(CONFIG_BT_CTLR_CONN_META)
 	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -130,7 +130,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	lll->interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
 	if ((lll->data_chan_count < 2) || (lll->data_chan_hop < 5) ||
 	    (lll->data_chan_hop > 16) || !lll->interval) {
-		lll->initiated = 0U;
+		lll->slave.initiated = 0U;
 
 		/* Mark for buffer for release */
 		rx->type = NODE_RX_TYPE_RELEASE;


### PR DESCRIPTION
Fix race conditional when create connection cancel is called
and actually a connection did get setup while initiator is
being stopped.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>