### PR TITLE
tests: portability: cmsis_rtos_v2: relax main test thread sleep time for mutex test-suite

### DIFF
--- a/tests/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/portability/cmsis_rtos_v2/src/mutex.c
@@ -138,6 +138,8 @@ void tThread_entry_lock_timeout(void *arg)
 	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS);
 	zassert_true(status == osOK, NULL);
 	osMutexRelease((osMutexId_t)arg);
+	zassert_true(status == osOK, "Mutex release failure");
+
 }
 
 static K_THREAD_STACK_DEFINE(test_stack, STACKSZ);
@@ -176,4 +178,5 @@ void test_mutex_lock_timeout(void)
 	osDelay(TIMEOUT_TICKS);
 
 	osMutexDelete(mutex_id);
+	zassert_true(status == osOK, "Mutex delete failure");
 }

--- a/tests/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/portability/cmsis_rtos_v2/src/mutex.c
@@ -175,7 +175,10 @@ void test_mutex_lock_timeout(void)
 
 	/* Release the mutex to be used by the other thread */
 	osMutexRelease(mutex_id);
-	osDelay(TIMEOUT_TICKS);
+	/* This delay ensures that the tThread_entry_lock_timeout thread
+	 * gets to execute the mutex operations.
+	 */
+	osDelay(TIMEOUT_TICKS * 2);
 
 	osMutexDelete(mutex_id);
 	zassert_true(status == osOK, "Mutex delete failure");


### PR DESCRIPTION
Fixes #33423 

Fix by relax the sleep time for the main test thread, to guarantee the alternative thread gets to perform the mutex operations in time.