### PR TITLE
dts:it8xxx2: change flash size to 1M byte

### DIFF
--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -37,18 +37,18 @@
 
 			flash0: flash@80000000 {
 				compatible = "soc-nv-flash";
-				reg = <0x80000000 DT_SIZE_K(512)>;
-				erase-block-size = <1024>;
-				write-block-size = <1>;
+				reg = <0x80000000 DT_SIZE_M(1)>;
+				erase-block-size = <4096>;
+				write-block-size = <4>;
 			};
 		};
 		pinmux: pinmux@f016f0 {
 			compatible = "ite,it8xxx2-pinmux";
 			reg = <0x00f016f0 0x0010>;
 		};
-		sram0: memory@80080000 {
+		sram0: memory@80100000 {
 			compatible = "mmio-sram";
-			reg = <0x80080000 DT_SIZE_K(60)>;
+			reg = <0x80100000 DT_SIZE_K(60)>;
 		};
 		intc: interrupt-controller@f03f00 {
 			#interrupt-cells = <2>;

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -292,6 +292,10 @@
 #define SEMBARH			ECREG(EC_REG_BASE_ADDR + 0x109E)
 #define SCRATH_SRAM		0x08
 
+/* --- General Control (GCTRL) --- */
+#define IT8XXX2_GCTRL_BASE      0x00F02000
+#define IT8XXX2_GCTRL_EIDSR     ECREG(IT8XXX2_GCTRL_BASE + 0x31)
+
 /**
  *
  * (11xxh) Interrupt controller (INTC)

--- a/soc/riscv/riscv-ite/common/vector.S
+++ b/soc/riscv/riscv-ite/common/vector.S
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "chip_chipregs.h"
 #include <toolchain.h>
 
 /* exports */
@@ -24,6 +25,16 @@ SECTION_FUNC(vectors, __start)
 	la t0, __irq_wrapper
 	csrw mtvec, t0
 	csrwi mie, 0
+
+	/*
+	 * bit[3-0]@EIDSR=8: instruction local memory size is 1M byte
+	 * This operation must be done before accessing memory.
+	 */
+	la t0, IT8XXX2_GCTRL_EIDSR
+	lb t1, 0(t0)
+	andi t1, t1, 0xf0
+	ori  t1, t1, 0x8
+	sb t1, 0(t0)
 
 	/* Jump to __initialize */
 	tail __initialize


### PR DESCRIPTION
it81202 and it81302 are all 1M byte.

Change-Id: Ic1464b6e36f16291f14024a6fb49acbf3a243176
Signed-off-by: Dino Li <Dino.Li@ite.com.tw>