### PR TITLE
soc: arm: stm32l5xx config the DWT for this soc

### DIFF
--- a/soc/arm/st_stm32/stm32l5/Kconfig.series
+++ b/soc/arm/st_stm32/stm32l5/Kconfig.series
@@ -13,6 +13,7 @@ config SOC_SERIES_STM32L5X
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
+	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
 	help
 	  Enable support for STM32L5 MCU series


### PR DESCRIPTION
This config CPU_CORTEX_M_HAS_DWT, is to avoid the
pragma message "Null-Pointer exception detection cannot be configured on un-mapped flash areas"
When testing the kernel/timer : _west build -p auto -b stm32l562e_dk tests/kernel/timer/timer_api_

```
./arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c: In function 'arm_mpu_init':
./arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c:356:9: note: #pragma message: Null-Pointer exception detection cannot be configured on un-mapped flash areas
  356 | #pragma message "Null-Pointer exception detection cannot be configured on un-mapped flash areas"
      |         ^~~~~~~

```
Signed-off-by: Francois Ramu <francois.ramu@st.com>