### PR TITLE
drivers: wifi: Remove unncessary zephyr_include_directories

### DIFF
--- a/drivers/wifi/esp/CMakeLists.txt
+++ b/drivers/wifi/esp/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_WIFI_ESP)
-  zephyr_include_directories(./)
 
   zephyr_library_include_directories(
     ${ZEPHYR_BASE}/drivers/modem

--- a/drivers/wifi/eswifi/CMakeLists.txt
+++ b/drivers/wifi/eswifi/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_WIFI_ESWIFI)
-  zephyr_include_directories(./)
 
   zephyr_library_include_directories(
   # IP headers

--- a/drivers/wifi/simplelink/CMakeLists.txt
+++ b/drivers/wifi/simplelink/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 if(CONFIG_WIFI_SIMPLELINK)
   zephyr_include_directories(
-    .
     ${ZEPHYR_BASE}/subsys/net/lib/tls_credentials
     )
   zephyr_sources(


### PR DESCRIPTION
Several wifi drivers add some form of zephyr_include_directories(.)
which isn't needed since the headers in the specific driver dir get
included via #include "foo.h".  So we can remove any uses of
zephyr_include_directories(.)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>