### PR TITLE
samples: bluetooth: Change periodic adv to use identity address

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -692,6 +692,17 @@ struct bt_le_per_adv_param {
 						 BT_GAP_ADV_FAST_INT_MAX_2, \
 						 NULL)
 
+/** Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME and
+ *  @ref BT_LE_ADV_OPT_USE_IDENTITY
+ */
+#define BT_LE_EXT_ADV_NCONN_NAME_IDENTITY \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
+			BT_LE_ADV_OPT_USE_NAME | \
+			BT_LE_ADV_OPT_USE_IDENTITY, \
+			BT_GAP_ADV_FAST_INT_MIN_2, \
+			BT_GAP_ADV_FAST_INT_MAX_2, \
+			NULL)
+
 /** Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
 #define BT_LE_EXT_ADV_NCONN_IDENTITY \
 		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \

--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -26,8 +26,11 @@ void main(void)
 		return;
 	}
 
-	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	/* Create a non-connectable non-scannable advertising set using the
+	 * identity address
+	 */
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME_IDENTITY, NULL,
+				   &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return;


### PR DESCRIPTION
Changes the periodic advertising sample to use the identity address so that it is static, as well as logged on boot, to make it easier to sniff and find.


fixes https://github.com/zephyrproject-rtos/zephyr/issues/32721