### PR TITLE
boards: silabs: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/efm32gg_slwstk6121a/CMakeLists.txt
+++ b/boards/arm/efm32gg_slwstk6121a/CMakeLists.txt
@@ -6,5 +6,4 @@
 if(CONFIG_ETH_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}}/drivers)
 endif()

--- a/boards/arm/efm32gg_stk3701a/CMakeLists.txt
+++ b/boards/arm/efm32gg_stk3701a/CMakeLists.txt
@@ -5,5 +5,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
 endif()

--- a/boards/arm/efm32hg_slstk3400a/CMakeLists.txt
+++ b/boards/arm/efm32hg_slstk3400a/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efm32pg_stk3401a/CMakeLists.txt
+++ b/boards/arm/efm32pg_stk3401a/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efm32pg_stk3402a/CMakeLists.txt
+++ b/boards/arm/efm32pg_stk3402a/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efm32wg_stk3800/CMakeLists.txt
+++ b/boards/arm/efm32wg_stk3800/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efr32_radio/CMakeLists.txt
+++ b/boards/arm/efr32_radio/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efr32mg_sltb004a/CMakeLists.txt
+++ b/boards/arm/efr32mg_sltb004a/CMakeLists.txt
@@ -4,5 +4,4 @@
 if(CONFIG_CCS811)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
 endif()


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>