### PR TITLE
boards: i.mx: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/colibri_imx7d_m4/CMakeLists.txt
+++ b/boards/arm/colibri_imx7d_m4/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimx8mm_evk/CMakeLists.txt
+++ b/boards/arm/mimx8mm_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/pico_pi_m4/CMakeLists.txt
+++ b/boards/arm/pico_pi_m4/CMakeLists.txt
@@ -1,9 +1,7 @@
-
 #
 # Copyright (c) 2019, Joris Offouga
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/udoo_neo_full_m4/CMakeLists.txt
+++ b/boards/arm/udoo_neo_full_m4/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/warp7_m4/CMakeLists.txt
+++ b/boards/arm/warp7_m4/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>