### PR TITLE
boards: imx-rt: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1015_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1020_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1024_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1064_evk/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
 
 if (CONFIG_DISPLAY)

--- a/boards/arm/mimxrt685_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt685_evk/CMakeLists.txt
@@ -5,5 +5,4 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mm_swiftio/CMakeLists.txt
+++ b/boards/arm/mm_swiftio/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR mmswiftio_flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmswiftio_sdram_ini_dcd.c)


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>