### PR TITLE
boards: lpc: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/lpcxpresso54114/CMakeLists.txt
+++ b/boards/arm/lpcxpresso54114/CMakeLists.txt
@@ -6,6 +6,5 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s16/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s16/CMakeLists.txt
@@ -6,6 +6,5 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s28/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s28/CMakeLists.txt
@@ -6,6 +6,5 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso55s69/CMakeLists.txt
+++ b/boards/arm/lpcxpresso55s69/CMakeLists.txt
@@ -7,7 +7,6 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()
 


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>