### PR TITLE
boards: kinetis: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/frdm_k22f/CMakeLists.txt
+++ b/boards/arm/frdm_k22f/CMakeLists.txt
@@ -6,6 +6,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_k64f/CMakeLists.txt
+++ b/boards/arm/frdm_k64f/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_k82f/CMakeLists.txt
+++ b/boards/arm/frdm_k82f/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kl25z/CMakeLists.txt
+++ b/boards/arm/frdm_kl25z/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kw41z/CMakeLists.txt
+++ b/boards/arm/frdm_kw41z/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/hexiwear_k64/CMakeLists.txt
+++ b/boards/arm/hexiwear_k64/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/hexiwear_kw40z/CMakeLists.txt
+++ b/boards/arm/hexiwear_kw40z/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/ip_k66f/CMakeLists.txt
+++ b/boards/arm/ip_k66f/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/twr_ke18f/CMakeLists.txt
+++ b/boards/arm/twr_ke18f/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/twr_kv58f220m/CMakeLists.txt
+++ b/boards/arm/twr_kv58f220m/CMakeLists.txt
@@ -2,6 +2,5 @@
 
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/usb_kw24d512/CMakeLists.txt
+++ b/boards/arm/usb_kw24d512/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
   zephyr_library_sources(pinmux.c)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>