### PR TITLE
boards: nrf: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/degu_evk/CMakeLists.txt
+++ b/boards/arm/degu_evk/CMakeLists.txt
@@ -3,4 +3,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nrf52840dongle_nrf52840/CMakeLists.txt
+++ b/boards/arm/nrf52840dongle_nrf52840/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nrf9160_innblue21/CMakeLists.txt
+++ b/boards/arm/nrf9160_innblue21/CMakeLists.txt
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 zephyr_library()
 zephyr_library_sources(innblue21_board_init.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nrf9160_innblue22/CMakeLists.txt
+++ b/boards/arm/nrf9160_innblue22/CMakeLists.txt
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 zephyr_library()
 zephyr_library_sources(innblue22_board_init.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/reel_board/CMakeLists.txt
+++ b/boards/arm/reel_board/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/thingy52_nrf52832/CMakeLists.txt
+++ b/boards/arm/thingy52_nrf52832/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>