### PR TITLE
boards: stm32: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/96b_wistrio/CMakeLists.txt
+++ b/boards/arm/96b_wistrio/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/nucleo_f429zi/old.CMakeLists.txt
+++ b/boards/arm/nucleo_f429zi/old.CMakeLists.txt
@@ -2,5 +2,4 @@
 
 if(CONFIG_PINMUX)
 zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/nucleo_l552ze_q/CMakeLists.txt
+++ b/boards/arm/nucleo_l552ze_q/CMakeLists.txt
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_PINMUX)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
-endif()
-
 if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "zephyr")
 	set(COMPILER_FULL_PATH ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc)
 elseif(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "gnuarmemb")

--- a/boards/arm/stm32g0316_disco/CMakeLists.txt
+++ b/boards/arm/stm32g0316_disco/CMakeLists.txt
@@ -3,5 +3,4 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>