### PR TITLE
boards: riscv: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/riscv/hifive1/CMakeLists.txt
+++ b/boards/riscv/hifive1/CMakeLists.txt
@@ -2,4 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/riscv/hifive1_revb/CMakeLists.txt
+++ b/boards/riscv/hifive1_revb/CMakeLists.txt
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/riscv/litex_vexriscv/CMakeLists.txt
+++ b/boards/riscv/litex_vexriscv/CMakeLists.txt
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/riscv/m2gl025_miv/CMakeLists.txt
+++ b/boards/riscv/m2gl025_miv/CMakeLists.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>