### PR TITLE
boards: arm: Remove unneeded zephyr_include_directories

### DIFF
--- a/boards/arm/cc3220sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3220sf_launchxl/CMakeLists.txt
@@ -5,4 +5,3 @@ zephyr_library_sources(
     pinmux.c
     dbghdr.c
     )
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/cc3235sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3235sf_launchxl/CMakeLists.txt
@@ -5,4 +5,3 @@ zephyr_library_sources(
     pinmux.c
     dbghdr.c
     )
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/quick_feather/CMakeLists.txt
+++ b/boards/arm/quick_feather/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Copyright (c) 2020 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(board.c)
 zephyr_include_directories(.)

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -6,4 +6,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/v2m_musca_b1/pinmux.c
+++ b/boards/arm/v2m_musca_b1/pinmux.c
@@ -10,9 +10,6 @@
 #include <drivers/pinmux.h>
 #include <soc.h>
 #include <sys/sys_io.h>
-#include <gpio/gpio_cmsdk_ahb.h>
-
-#include "pinmux/pinmux.h"
 
 #define IOMUX_MAIN_INSEL	(0x68 >> 2)
 #define IOMUX_MAIN_OUTSEL	(0x70 >> 2)

--- a/boards/arm/v2m_musca_s1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_s1/CMakeLists.txt
@@ -6,4 +6,3 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/v2m_musca_s1/pinmux.c
+++ b/boards/arm/v2m_musca_s1/pinmux.c
@@ -10,9 +10,6 @@
 #include <drivers/pinmux.h>
 #include <soc.h>
 #include <sys/sys_io.h>
-#include <gpio/gpio_cmsdk_ahb.h>
-
-#include "pinmux/pinmux.h"
 
 #define IOMUX_MAIN_INSEL        (0x868 >> 2)
 #define IOMUX_MAIN_OUTSEL       (0x870 >> 2)


### PR DESCRIPTION
The include of ${ZEPHYR_BASE}/drivers isn't needed anymore for
board code so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>