### PR TITLE
drivers: watchdog: mcux_wwdt: fix validating window min vs max

### DIFF
--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -97,8 +97,9 @@ static int mcux_wwdt_install_timeout(const struct device *dev,
 	}
 
 	if ((data->wwdt_config.timeoutValue < MIN_TIMEOUT) ||
-	    (data->wwdt_config.timeoutValue > data->wwdt_config.windowValue)) {
-		LOG_ERR("Invalid timeout");
+	    ((data->wwdt_config.windowValue != 0xFFFFFFU) &&
+	     (data->wwdt_config.timeoutValue <
+	      data->wwdt_config.windowValue))) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The comparison was inverted before so configuring a valid window providing min and max was not possible.

Now the comparison is corrected and only done if the watchdog is used in windowed mode.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>