### PR TITLE
checkpatch: correct diagnostic for ENOSYS use

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4255,12 +4255,11 @@ sub process {
 			     "Prefer dev_$level(... to dev_printk(KERN_$orig, ...\n" . $herecurr);
 		}
 
-# ENOSYS means "bad syscall nr" and nothing else.  This will have a small
-# number of false positives, but assembly files are not checked, so at
-# least the arch entry code will not trigger this warning.
+# Zephyr uses ENOTSUP for cases where ENOTSUP or ENOSYS would be more appropriate;
+# See: https://github.com/zephyrproject-rtos/zephyr/issues/23727
 		if ($line =~ /\bENOSYS\b/) {
 			WARN("ENOSYS",
-			     "ENOSYS means 'invalid syscall nr' and nothing else\n" . $herecurr);
+			     "Use ENOTSUP instead of ENOSYS in Zephyr API\n" . $herecurr);
 		}
 
 # ENOTSUPP is not a standard error code and should be avoided in new patches.


### PR DESCRIPTION
The rationale is for Linux; use the rationale for Zephyr.

See #23727

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>