### PR TITLE
pinmux: s1000: Change to use ENOTSUP

### DIFF
--- a/drivers/pinmux/pinmux_intel_s1000.c
+++ b/drivers/pinmux/pinmux_intel_s1000.c
@@ -73,12 +73,12 @@ static int pinmux_get(const struct device *dev, uint32_t pin, uint32_t *func)
 
 static int pinmux_pullup(const struct device *dev, uint32_t pin, uint8_t func)
 {
-	return -ENOSYS;
+	return -ENOTSUP;
 }
 
 static int pinmux_input(const struct device *dev, uint32_t pin, uint8_t func)
 {
-	return -ENOSYS;
+	return -ENOTSUP;
 }
 
 static struct pinmux_driver_api apis = {


### PR DESCRIPTION
Changed to use -ENOTSUP instead of -ENOSYS to be consistent with
other driver APIs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>