### PR TITLE
tests: coredump: use undefined instruction to trigger CPU fault

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -9,8 +9,17 @@
 
 void func_3(uint32_t *addr)
 {
+#if !defined(CONFIG_CPU_CORTEX_M)
 	/* For null pointer reference */
 	*addr = 0;
+#else
+	ARG_UNUSED(addr);
+	/* Dereferencing null-pointer in TrustZone-enabled
+	 * builds may crash the system, so use, instead an
+	 * undefined instruction to trigger a CPU fault.
+	 */
+	__asm__ volatile("udf #0" : : : );
+#endif
 }
 
 void func_2(uint32_t *addr)


### PR DESCRIPTION
When building the test for Cortex-M, use an undefined
instruction to trigger a CPU fault, instead of null
pointer de-referencing. That's because null-pointer
access may, in TrustZone-enabled platforms, lead to
a system crash (due to security violation).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>