### PR TITLE
Bluetooth: audio: Fix compilation issue with BT_AUDIO

### DIFF
--- a/subsys/bluetooth/audio/CMakeLists.txt
+++ b/subsys/bluetooth/audio/CMakeLists.txt
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-zephyr_library_link_libraries(subsys__bluetooth)
-
 if (CONFIG_BT_VOCS OR CONFIG_BT_VOCS_CLIENT)
 	zephyr_library_sources(vocs.c)
 endif()


### PR DESCRIPTION
Fix bluetooth audio compilation issue when BT_AUDIO is enabled but
no Bluetooth host services has been enabled.
This leads to an empty library file.
Instead of creating a new library for audio add the sources to the
parent library, similar to how bluetooth services are added.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>