### PR TITLE
dts: arm: nxp: Fix CORE and Flash clock divider values

### DIFF
--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -87,14 +87,14 @@
 			core_clk {
 				compatible = "fixed-factor-clock";
 				clocks = <&mcg KINETIS_MCG_OUT_CLK>;
-				clock-div = <10>;
+				clock-div = <2>;
 				#clock-cells = <0>;
 			};
 
 			flash_clk {
 				compatible = "fixed-factor-clock";
 				clocks = <&mcg KINETIS_MCG_OUT_CLK>;
-				clock-div = <1>;
+				clock-div = <2>;
 				#clock-cells = <0>;
 			};
 		};


### PR DESCRIPTION
In the change to DTS driven clock divider values wrong values
were used in the dts file.

Fixes: #33559

Signed-off-by: David Leach <david.leach@nxp.com>