### PR TITLE
boards: arm: Enable NXP boards with adafruit_2_8_tft_touch_v2 shield

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -166,6 +166,10 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 		       PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
 #endif
 
+#if CONFIG_SHIELD_ADAFRUIT_2_8_TFT_TOUCH_V2
+	pinmux_pin_set(portc,  4, PORT_PCR_MUX(kPORT_MuxAsGpio));
+#endif
+
 #if CONFIG_SHIELD_ADAFRUIT_WINC1500
 	/* IRQ, ENable, RST */
 	pinmux_pin_set(portc,  3, PORT_PCR_MUX(kPORT_MuxAsGpio));

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -60,6 +60,35 @@
 			label = "User LED_RED";
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &gpio0 5 0>,	/* A0 */
+				<1 0 &gpio0 6 0>,	/* A1 */
+				<2 0 &gpio0 19 0>,	/* A2 */
+				<3 0 &gpio0 20 0>,	/* A3 */
+				<4 0 &gpio0 17 0>,	/* A4 */
+				<5 0 &gpio0 18 0>,	/* A5 */
+				<6 0 &gpio0 30 0>,	/* D0 */
+				<7 0 &gpio0 29 0>,	/* D1 */
+				<8 0 &gpio0 28 0>,	/* D2 */
+				<9 0 &gpio0 27 0>,	/* D3 */
+				<10 0 &gpio1 0 0>,	/* D4 */
+				<11 0 &gpio1 10 0>,	/* D5 */
+				<12 0 &gpio1 2 0>,	/* D6 */
+				<13 0 &gpio1 8 0>,	/* D7 */
+				<14 0 &gpio1 9 0>,	/* D8 */
+				<15 0 &gpio1 7 0>,	/* D9 */
+				<16 0 &gpio1 6 0>,	/* D10 */
+				<17 0 &gpio1 5 0>,	/* D11 */
+				<18 0 &gpio1 4 0>,	/* D12 */
+				<19 0 &gpio1 3 0>,	/* D13 */
+				<20 0 &gpio0 17 0>,	/* D14 */
+				<21 0 &gpio0 18 0>;	/* D15 */
+	};
 };
 
 &flexcomm0 {

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.yaml
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 4608
 flash: 65536
 supported:
+  - arduino_gpio
   - arduino_i2c
   - arduino_spi
   - counter

--- a/boards/shields/adafruit_2_8_tft_touch_v2/doc/index.rst
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/doc/index.rst
@@ -60,7 +60,7 @@ Programming
 Set ``-DSHIELD=adafruit_2_8_tft_touch_v2`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: adafruit_2_8_tft_touch_v2
    :goals: build

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/doc/index.rst
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/doc/index.rst
@@ -60,7 +60,7 @@ Set ``-DSHIELD=buydisplay_2_8_tft_touch_arduino`` when you invoke
 ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: buydisplay_2_8_tft_touch_arduino
    :goals: build

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/doc/index.rst
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/doc/index.rst
@@ -62,7 +62,7 @@ Set ``-DSHIELD=buydisplay_3_5_tft_touch_arduino`` when you invoke
 ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: buydisplay_3_5_tft_touch_arduino
    :goals: build

--- a/boards/shields/ls0xx_generic/doc/index.rst
+++ b/boards/shields/ls0xx_generic/doc/index.rst
@@ -91,7 +91,7 @@ Programming
 Set ``-DSHIELD=ls013b7dh03`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: ls013b7dh03
    :goals: build

--- a/boards/shields/ssd1306/doc/index.rst
+++ b/boards/shields/ssd1306/doc/index.rst
@@ -41,7 +41,7 @@ Programming
 Set ``-DSHIELD=ssd1306_128x64`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: frdm_k64f
    :shield: ssd1306_128x64
    :goals: build

--- a/boards/shields/st7789v_generic/doc/index.rst
+++ b/boards/shields/st7789v_generic/doc/index.rst
@@ -56,7 +56,7 @@ Programming
 Set ``-DSHIELD=st7789v_tl019fqv01`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: st7789v_tl019fqv01
    :goals: build

--- a/boards/shields/waveshare_epaper/doc/index.rst
+++ b/boards/shields/waveshare_epaper/doc/index.rst
@@ -79,7 +79,7 @@ be entered when you invoke ``west build``.
 For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: waveshare_epaper_gdeh0213b1
    :goals: build

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -3,7 +3,7 @@ sample:
   name: display_sample
 tests:
   sample.display.shield.adafruit_2_8_tft_touch_v2:
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 mimxrt685_evk_cm33 frdm_k64f
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: display shield
     harness: console

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -7,7 +7,7 @@ tests:
     platform_allow: reel_board mimxrt1050_evk mimxrt1060_evk mimxrt1064_evk
     tags: samples display gui
   sample.display.adafruit_2_8_tft_touch_v2:
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 mimxrt685_evk_cm33 frdm_k64f
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
   sample.display.waveshare_epaper_gdeh0213b1:


### PR DESCRIPTION
Enables the `mimxrt685_evk` and `frdm_k64f` boards with the `adafruit_2_8_tft_touch_v2` display shield.

Tested with:
- `samples/drivers/display`
- `samples/subsys/display/lvgl`

The touch input doesn't quite work correctly yet, but I suspect an issue with the ft5336 driver when we set the swap/invert configs. I can see touches detected in the debug log (`CONFIG_KSCAN_LOG_LEVEL_DBG=y`), but the lvgl button doesn't change to the toggled state.