### PR TITLE
twister: fix binary size not being calculated

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1199,6 +1199,7 @@ class SizeCalculator:
         "nocache",
         "devices",
         "k_heap_area",
+        "pagetables",
     ]
 
     # These get copied into RAM only on non-XIP
@@ -1223,6 +1224,7 @@ class SizeCalculator:
         "shell_area",
         "tracing_backend_area",
         "ppp_protocol_handler_area",
+        "device_handles",
     ]
 
     def __init__(self, filename, extra_sections):

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -16,13 +16,11 @@ import shutil
 import shlex
 import signal
 import threading
-import concurrent.futures
 from collections import OrderedDict
 import queue
 import time
 import csv
 import glob
-import concurrent
 import xml.etree.ElementTree as ET
 import logging
 import pty

--- a/scripts/twister
+++ b/scripts/twister
@@ -1162,7 +1162,10 @@ def main():
                 break
             else:
                 inst.metrics["handler_time"] = inst.handler.duration if inst.handler else 0
-                inst.metrics["unrecognized"] = []
+
+                if "unrecognized" not in inst.metrics:
+                    inst.metrics["unrecognized"] = []
+
                 suite.instances[inst.name] = inst
 
         print("")

--- a/scripts/twister
+++ b/scripts/twister
@@ -175,7 +175,6 @@ import shutil
 from collections import OrderedDict
 import multiprocessing
 from itertools import islice
-import csv
 from colorama import Fore
 from pathlib import Path
 from multiprocessing.managers import BaseManager

--- a/scripts/twister
+++ b/scripts/twister
@@ -206,43 +206,10 @@ except ImportError:
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
 from twisterlib import HardwareMap, TestSuite, SizeCalculator, CoverageTool, ExecutionCounter
+from twisterlib import export_tests, size_report
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
-
-def size_report(sc):
-    logger.info(sc.filename)
-    logger.info("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
-    for i in range(len(sc.sections)):
-        v = sc.sections[i]
-
-        logger.info("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
-                    (v["name"], v["virt_addr"], v["load_addr"], v["size"], v["size"],
-                     v["type"]))
-
-    logger.info("Totals: %d bytes (ROM), %d bytes (RAM)" %
-                (sc.rom_size, sc.ram_size))
-    logger.info("")
-
-
-def export_tests(filename, tests):
-    with open(filename, "wt") as csvfile:
-        fieldnames = ['section', 'subsection', 'title', 'reference']
-        cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
-        for test in tests:
-            data = test.split(".")
-            if len(data) > 1:
-                subsec = " ".join(data[1].split("_")).title()
-                rowdict = {
-                    "section": data[0].capitalize(),
-                    "subsection": subsec,
-                    "title": test,
-                    "reference": test
-                }
-                cw.writerow(rowdict)
-            else:
-                logger.error("{} can't be exported: ".format(test))
-
 
 def parse_arguments():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This fixes an issue where the binary size is not being calculated even though size report is enabled.
