### PR TITLE
Bluetooth: host: Fix BT_LOG_SNIFFER_INFO option without BT_SMP enabled

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2969,7 +2969,8 @@ static void bt_dev_show_info(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) &&
+	    IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
 		bt_keys_foreach(BT_KEYS_ALL, bt_keys_show_sniffer_info, NULL);
 	}
 


### PR DESCRIPTION
Fix undefined reference to bt_key_foreach when BT_LOG_SNIFFER_INFO has
been enabled but BT_SMP is not enabled.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>