### PR TITLE
drivers: modem: wncm14a2a: Explicitly ignore unused return value

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1145,7 +1145,7 @@ static void wncm14a2a_rx(void)
 
 	while (true) {
 		/* wait for incoming data */
-		k_sem_take(&ictx.mdm_ctx.rx_sem, K_FOREVER);
+		(void)k_sem_take(&ictx.mdm_ctx.rx_sem, K_FOREVER);
 
 		wncm14a2a_read_rx(&rx_buf);
 


### PR DESCRIPTION
Coverity complains about unchecked return value for `k_sem_take` which
is called with `K_FOREVER` and thus cannot expire/timeout. Explicity
ingore the return value to silence Coverity.

CID: 219676
Fixes #33019

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>