### PR TITLE
usb: hid: remove get_protocol/set_protocol from USB HID class API

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -79,6 +79,10 @@ Deprecated in this release
   USB_HID_PROTOCOL_CODE does not allow to set boot protocol code for specific
   HID device. USB HID API function usb_hid_set_proto_code() can be used instead.
 
+* USB HID class API is changed by removing get_protocol/set_protocol and
+  get_idle/set_idle callbacks. These callbacks are redundant or do not provide
+  any additional value and have led to incorrect usage of HID class API.
+
 * The ``CONFIG_OPENOCD_SUPPORT`` Kconfig option has been deprecated in favor
   of ``CONFIG_DEBUG_THREAD_INFO``.
 

--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -44,11 +44,7 @@ typedef void (*hid_idle_cb_t)(const struct device *dev, uint16_t report_id);
  */
 struct hid_ops {
 	hid_cb_t get_report;
-	hid_cb_t get_idle;
-	hid_cb_t get_protocol;
 	hid_cb_t set_report;
-	hid_cb_t set_idle;
-	hid_cb_t set_protocol;
 	hid_protocol_cb_t protocol_change;
 	hid_idle_cb_t on_idle;
 	/*

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -201,14 +201,14 @@ static int hid_on_get_protocol(struct hid_device_info *dev_data,
 			       uint8_t **data)
 {
 #ifdef CONFIG_USB_HID_BOOT_PROTOCOL
+	uint32_t size = sizeof(dev_data->protocol);
+
 	if (setup->wValue) {
 		LOG_ERR("wValue should be 0");
 		return -ENOTSUP;
 	}
 
-	uint32_t size = sizeof(dev_data->protocol);
-
-	LOG_DBG("Get Protocol callback, protocol: %d", dev_data->protocol);
+	LOG_DBG("Get Protocol: %d", dev_data->protocol);
 
 	*data = &dev_data->protocol;
 	*len = size;
@@ -274,7 +274,7 @@ static int hid_on_set_protocol(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	LOG_DBG("Set Protocol callback, protocol: %u", protocol);
+	LOG_DBG("Set Protocol: %u", protocol);
 
 	if (dev_data->protocol != protocol) {
 		dev_data->protocol = protocol;
@@ -452,14 +452,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) {
 		switch (setup->bRequest) {
 		case USB_HID_GET_IDLE:
-			if (dev_data->ops && dev_data->ops->get_idle) {
-				return dev_data->ops->get_idle(dev, setup, len,
-							       data);
-			} else {
-				return hid_on_get_idle(dev_data, setup, len,
-						       data);
-			}
-			break;
+			return hid_on_get_idle(dev_data, setup, len, data);
 		case USB_HID_GET_REPORT:
 			if (dev_data->ops && dev_data->ops->get_report) {
 				return dev_data->ops->get_report(dev, setup,
@@ -470,14 +463,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 			}
 			break;
 		case USB_HID_GET_PROTOCOL:
-			if (dev_data->ops && dev_data->ops->get_protocol) {
-				return dev_data->ops->get_protocol(dev, setup,
-								   len, data);
-			} else {
-				return hid_on_get_protocol(dev_data, setup, len,
-							   data);
-			}
-			break;
+			return hid_on_get_protocol(dev_data, setup, len, data);
 		default:
 			LOG_ERR("Unhandled request 0x%02x", setup->bRequest);
 			break;
@@ -485,14 +471,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	} else {
 		switch (setup->bRequest) {
 		case USB_HID_SET_IDLE:
-			if (dev_data->ops && dev_data->ops->set_idle) {
-				return dev_data->ops->set_idle(dev, setup, len,
-							       data);
-			} else {
-				return hid_on_set_idle(dev_data, setup, len,
-						       data);
-			}
-			break;
+			return hid_on_set_idle(dev_data, setup, len, data);
 		case USB_HID_SET_REPORT:
 			if (dev_data->ops && dev_data->ops->set_report) {
 				return dev_data->ops->set_report(dev, setup,
@@ -503,14 +482,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 			}
 			break;
 		case USB_HID_SET_PROTOCOL:
-			if (dev_data->ops && dev_data->ops->set_protocol) {
-				return dev_data->ops->set_protocol(dev, setup,
-								   len, data);
-			} else {
-				return hid_on_set_protocol(dev, dev_data,
-							   setup);
-			}
-			break;
+			return hid_on_set_protocol(dev, dev_data, setup);
 		default:
 			LOG_ERR("Unhandled request 0x%02x", setup->bRequest);
 			break;


### PR DESCRIPTION
The USB HID class API offers the possibility to register callbacks
for Get/SetIdle, Get/SetProtocol to the application.
Rules for these callbacks are neither obvious nor documented.

This patch remove this possibility to register Get/SetProtocol
and Get/SetIdle callbacks for the following reasons:

The possibility to call unknown application code while processing
control requests should be avoided or reduced to a minimum.

The Get/SetProtocol callbacks are redundant and do not provide any
additional value since the way to inform the application
about the change of the protocol exists via the callback
hid_protocol_cb_t protocol_change.

The core provides implementation to handle Get/SetIdle requests and
on idle reports. If this is not suitable in any way then the application
should implement everything itself.

Fixes #34426 