### PR TITLE
doc: board_porting: Remove unneeded zephyr_include_directories

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -173,7 +173,6 @@ The optional files are:
      if(CONFIG_PINMUX)
        zephyr_library()
        zephyr_library_sources(pinmux.c)
-       zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
      endif()
 
 - :file:`doc/index.rst`, :file:`doc/plank.png`: documentation for and a picture


### PR DESCRIPTION
Remove zephyr_include_directories from example in docs as its not
needed.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>