### PR TITLE
power: unlock the scheduler in the pm_system_suspend

### DIFF
--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -133,7 +133,6 @@ void pm_system_resume(void)
 		post_ops_done = 1;
 		pm_power_state_exit_post_ops(z_power_state);
 		pm_state_notify(false);
-		k_sched_unlock();
 	}
 }
 
@@ -231,6 +230,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 #endif
 	pm_log_debug_info(z_power_state.state);
 	pm_system_resume();
+	k_sched_unlock();
 
 	return z_power_state.state;
 }


### PR DESCRIPTION
move `k_sched_unlock` from the `pm_system_resume` to the the `pm_system_suspend`.

This fixes the https://github.com/zephyrproject-rtos/zephyr/issues/33665 and applies on the power: Documentation updates and general fixes #33222

Signed-off-by: Francois Ramu <francois.ramu@st.com>