### PR TITLE
ztest: Improve zassert_equal macro

### DIFF
--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -33,6 +33,15 @@
 #define HAS_BUILTIN(x) HAS_BUILTIN_##x
 #endif
 
+/* Determine if _Generic is supported based.
+ * In general it's a C11 feature but it was added also in:
+ * - GCC 4.9.0 https://gcc.gnu.org/gcc-4.9/changes.html
+ * - Clang 3.0 https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html
+ */
+#if (__STDC_VERSION__ >= 201112L)
+#define Z_C_GENERIC 1
+#endif
+
 #if defined(__XCC__)
 #include <toolchain/xcc.h>
 #elif defined(__CCAC__)

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -222,6 +222,20 @@ do {                                                                    \
 #define HAS_BUILTIN___builtin_ctzll 1
 #endif
 
+/* Determine if _Generic is supported.
+ * In general it's a C11 feature but it was added also in:
+ * - GCC 4.9.0 https://gcc.gnu.org/gcc-4.9/changes.html
+ * - Clang 3.0 https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html
+ */
+#ifndef Z_C_GENERIC
+#if (((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40900) || \
+	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30000))
+#define Z_C_GENERIC 1
+#else
+#define Z_C_GENERIC 0
+#endif
+#endif
+
 /*
  * Be *very* careful with these. You cannot filter out __DEPRECATED_MACRO with
  * -wno-deprecated, which has implications for -Werror.

--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -25,21 +25,6 @@ extern "C" {
 
 const char *ztest_relative_filename(const char *file);
 void ztest_test_fail(void);
-#if CONFIG_ZTEST_ASSERT_VERBOSE == 0
-
-static inline void z_zassert_(bool cond, const char *file, int line)
-{
-	if (cond == false) {
-		PRINT("\n    Assertion failed at %s:%d\n",
-		      ztest_relative_filename(file), line);
-		ztest_test_fail();
-	}
-}
-
-#define z_zassert(cond, default_msg, file, line, func, msg, ...)	\
-	z_zassert_(cond, file, line)
-
-#else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
 static inline void z_zassert(bool cond,
 			    const char *default_msg,
@@ -48,26 +33,26 @@ static inline void z_zassert(bool cond,
 			    const char *msg, ...)
 {
 	if (cond == false) {
-		va_list vargs;
+		if (CONFIG_ZTEST_ASSERT_VERBOSE == 0) {
+			PRINT("\n    Assertion failed at %s:%d\n",
+				ztest_relative_filename(file), line);
+		} else {
+			va_list vargs;
 
-		va_start(vargs, msg);
-		PRINT("\n    Assertion failed at %s:%d: %s: %s\n",
-		      ztest_relative_filename(file), line, func, default_msg);
-		vprintk(msg, vargs);
-		printk("\n");
-		va_end(vargs);
+			va_start(vargs, msg);
+			PRINT("\n    Assertion failed at %s:%d: %s: %s\n",
+			      ztest_relative_filename(file), line, func,
+			      default_msg);
+			vprintk(msg, vargs);
+			printk("\n");
+			va_end(vargs);
+		}
 		ztest_test_fail();
-	}
-#if CONFIG_ZTEST_ASSERT_VERBOSE == 2
-	else {
+	} else if (CONFIG_ZTEST_ASSERT_VERBOSE == 2) {
 		PRINT("\n   Assertion succeeded at %s:%d (%s)\n",
 		      ztest_relative_filename(file), line, func);
 	}
-#endif
 }
-
-#endif /* CONFIG_ZTEST_ASSERT_VERBOSE */
-
 
 /**
  * @defgroup ztest_assert Ztest assertion macros

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -31,6 +31,43 @@ ZTEST_DMEM enum {
 
 static ZTEST_BMEM int test_status;
 
+static const char *arg_formatter[] = {
+	"%c (0x%02x)",
+	"%hhd (0x%02x) ",
+	"%hhu (0x%02x)",
+	"%hd (0x%04x)",
+	"%hu (0x%04x)",
+	"%d (0x%08x)",
+	"%u (0x%08x)",
+	"%ld (0x%08x)",
+	"%lu (0x%08x)",
+	"%lld (0x%016x)",
+	"%llu (0x%016x)",
+	"%f (0x%08a)",
+	"%f (0x%08a)",
+	"%Lf (0x%08a)",
+	"%p %n"
+};
+
+void ztest_print_values(const char *msg, const char *a_name, const char *b_name,
+			int a_type, int b_type, ...)
+{
+	char _buf[64];
+	int cnt;
+	va_list ap;
+
+	va_start(ap, b_type);
+	cnt = snprintf(_buf, sizeof(_buf), "%s = %s %s%s = %s",
+			a_name, arg_formatter[a_type], msg,
+			b_name, arg_formatter[b_type]);
+	if (cnt > sizeof(_buf)) {
+		PRINT("Buffer too small\n");
+	}
+	vprintk(_buf, ap);
+	va_end(ap);
+}
+
+
 /**
  * @brief Try to shorten a filename by removing the current directory
  *

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -19,7 +19,7 @@ static void thread_entry_params(void *p1, void *p2, void *p3)
 	/* checkpoint: check parameter 1, 2, 3 */
 	zassert_equal(p1, tp1, NULL);
 	zassert_equal(POINTER_TO_INT(p2), tp2, NULL);
-	zassert_equal(p3, tp3, NULL);
+	zassert_equal(p3, (void *)tp3, NULL);
 }
 
 static void thread_entry_priority(void *p1, void *p2, void *p3)

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -117,6 +117,7 @@
 #endif
 
 #if AVOID_C_GENERIC
+#undef Z_C_GENERIC
 #define Z_C_GENERIC 0
 #endif
 


### PR DESCRIPTION
I was always irritated when using `zassert_equal` that i need to add an explicit string to get the values printed. If user message is null output does not tell much for code like `zassert_equal(x, y, NULL)`:

```
Assertion failed at ../src/main.c:99: test_cbprintf_package: x not equal to y
```

However, until `_Generic` keyword did not appear it was tricky to print those values as their type is unknown. Added macro `zassert_2args` which takes two args and combine them with default string to create report which contains names, values and hex values of 2 arguments used for that macro. After that change output looks like:
```
x = -124 (0xffffff84) not equal to y = 124 (0x007c)
    Assertion failed at ../src/main.c:99: test_cbprintf_package
```

If `_Generic` is not available it behaves as before.

`_Generic` support detection moved from cbprintf to toolchain (not sure if location is correct).