### PR TITLE
include: Move ptp_clock.h to drivers/ptp_clock.h

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -457,7 +457,7 @@
 /include/net/mqtt.h                       @jukkar @rlubos
 /include/posix/                           @pfalcon
 /include/power/power.h                    @nashif @ceolin
-/include/ptp_clock.h                      @jukkar
+/include/drivers/ptp_clock.h              @jukkar
 /include/shared_irq.h                     @dcpleung @nashif @andyross
 /include/shell/                           @jakub-uC @nordic-krch
 /include/sw_isr_table.h                   @dcpleung @nashif @andyross

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -734,7 +734,7 @@ Documentation:
         - jukkar
     files:
         - drivers/ptp_clock/
-        - include/ptp_clock.h
+        - include/drivers/ptp_clock.h
     labels:
         - "area: Clocks"
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ethernet/eth_stats.h>
 
 #if defined(CONFIG_PTP_CLOCK_MCUX)
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/gptp.h>
 #endif
 

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ethernet.h>
 #include <ethernet/eth_stats.h>
 
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/gptp.h>
 #include <net/lldp.h>
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -48,7 +48,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #endif
 
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/gptp.h>
 #endif
 

--- a/drivers/ptp_clock/ptp_clock.c
+++ b/drivers/ptp_clock/ptp_clock.c
@@ -5,7 +5,7 @@
  */
 
 #include <syscall_handler.h>
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 
 #ifdef CONFIG_USERSPACE
 int z_vrfy_ptp_clock_get(const struct device *dev,

--- a/include/drivers/ptp_clock.h
+++ b/include/drivers/ptp_clock.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
+
+#include <kernel.h>
+#include <stdint.h>
+#include <device.h>
+#include <sys/util.h>
+#include <net/ptp_time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Name of the PTP clock driver */
+#if !defined(PTP_CLOCK_NAME)
+#define PTP_CLOCK_NAME "PTP_CLOCK"
+#endif
+
+__subsystem struct ptp_clock_driver_api {
+	int (*set)(const struct device *dev, struct net_ptp_time *tm);
+	int (*get)(const struct device *dev, struct net_ptp_time *tm);
+	int (*adjust)(const struct device *dev, int increment);
+	int (*rate_adjust)(const struct device *dev, float ratio);
+};
+
+/**
+ * @brief Set the time of the PTP clock.
+ *
+ * @param dev PTP clock device
+ * @param tm Time to set
+ *
+ * @return 0 if ok, <0 if error
+ */
+static inline int ptp_clock_set(const struct device *dev,
+				struct net_ptp_time *tm)
+{
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->api;
+
+	return api->set(dev, tm);
+}
+
+/**
+ * @brief Get the time of the PTP clock.
+ *
+ * @param dev PTP clock device
+ * @param tm Where to store the current time.
+ *
+ * @return 0 if ok, <0 if error
+ */
+__syscall int ptp_clock_get(const struct device *dev, struct net_ptp_time *tm);
+
+static inline int z_impl_ptp_clock_get(const struct device *dev,
+				       struct net_ptp_time *tm)
+{
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->api;
+
+	return api->get(dev, tm);
+}
+
+/**
+ * @brief Adjust the PTP clock time.
+ *
+ * @param dev PTP clock device
+ * @param increment Increment of the clock in nanoseconds
+ *
+ * @return 0 if ok, <0 if error
+ */
+static inline int ptp_clock_adjust(const struct device *dev, int increment)
+{
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->api;
+
+	return api->adjust(dev, increment);
+}
+
+/**
+ * @brief Adjust the PTP clock time change rate when compared to its neighbor.
+ *
+ * @param dev PTP clock device
+ * @param rate Rate of the clock time change
+ *
+ * @return 0 if ok, <0 if error
+ */
+static inline int ptp_clock_rate_adjust(const struct device *dev, float rate)
+{
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->api;
+
+	return api->rate_adjust(dev, rate);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/ptp_clock.h>
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_ */

--- a/include/ptp_clock.h
+++ b/include/ptp_clock.h
@@ -7,100 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_PTP_CLOCK_H_
 #define ZEPHYR_INCLUDE_PTP_CLOCK_H_
 
-#include <kernel.h>
-#include <stdint.h>
-#include <device.h>
-#include <sys/util.h>
-#include <net/ptp_time.h>
-
-#ifdef __cplusplus
-extern "C" {
+#ifndef CONFIG_COMPAT_INCLUDES
+#warning "This header file has moved, include <drivers/ptp_clock.h> instead."
 #endif
 
-/* Name of the PTP clock driver */
-#if !defined(PTP_CLOCK_NAME)
-#define PTP_CLOCK_NAME "PTP_CLOCK"
-#endif
-
-__subsystem struct ptp_clock_driver_api {
-	int (*set)(const struct device *dev, struct net_ptp_time *tm);
-	int (*get)(const struct device *dev, struct net_ptp_time *tm);
-	int (*adjust)(const struct device *dev, int increment);
-	int (*rate_adjust)(const struct device *dev, float ratio);
-};
-
-/**
- * @brief Set the time of the PTP clock.
- *
- * @param dev PTP clock device
- * @param tm Time to set
- *
- * @return 0 if ok, <0 if error
- */
-static inline int ptp_clock_set(const struct device *dev,
-				struct net_ptp_time *tm)
-{
-	const struct ptp_clock_driver_api *api =
-		(const struct ptp_clock_driver_api *)dev->api;
-
-	return api->set(dev, tm);
-}
-
-/**
- * @brief Get the time of the PTP clock.
- *
- * @param dev PTP clock device
- * @param tm Where to store the current time.
- *
- * @return 0 if ok, <0 if error
- */
-__syscall int ptp_clock_get(const struct device *dev, struct net_ptp_time *tm);
-
-static inline int z_impl_ptp_clock_get(const struct device *dev,
-				       struct net_ptp_time *tm)
-{
-	const struct ptp_clock_driver_api *api =
-		(const struct ptp_clock_driver_api *)dev->api;
-
-	return api->get(dev, tm);
-}
-
-/**
- * @brief Adjust the PTP clock time.
- *
- * @param dev PTP clock device
- * @param increment Increment of the clock in nanoseconds
- *
- * @return 0 if ok, <0 if error
- */
-static inline int ptp_clock_adjust(const struct device *dev, int increment)
-{
-	const struct ptp_clock_driver_api *api =
-		(const struct ptp_clock_driver_api *)dev->api;
-
-	return api->adjust(dev, increment);
-}
-
-/**
- * @brief Adjust the PTP clock time change rate when compared to its neighbor.
- *
- * @param dev PTP clock device
- * @param rate Rate of the clock time change
- *
- * @return 0 if ok, <0 if error
- */
-static inline int ptp_clock_rate_adjust(const struct device *dev, float rate)
-{
-	const struct ptp_clock_driver_api *api =
-		(const struct ptp_clock_driver_api *)dev->api;
-
-	return api->rate_adjust(dev, rate);
-}
-
-#ifdef __cplusplus
-}
-#endif
-
-#include <syscalls/ptp_clock.h>
+#include <drivers/ptp_clock.h>
 
 #endif /* ZEPHYR_INCLUDE_PTP_CLOCK_H_ */

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -8,7 +8,7 @@
 LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
 #include <net/net_pkt.h>
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/ethernet_mgmt.h>
 #include <random/rand32.h>
 

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -7,7 +7,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 
 #include "gptp_messages.h"
 #include "gptp_data_set.h"

--- a/subsys/net/l2/ethernet/gptp/gptp_user_api.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_user_api.c
@@ -7,7 +7,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/gptp.h>
 
 #include "gptp_messages.h"

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 
 #include <ztest.h>
 
-#include <ptp_clock.h>
+#include <drivers/ptp_clock.h>
 #include <net/ptp_time.h>
 
 #include <net/ethernet.h>


### PR DESCRIPTION
Move ptp_clock.h out of the top level include/ dir into
include/drivers/ptp_clock.h and deprecated the old location.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>