### PR TITLE
include: disk_access: Add a compat warning

### DIFF
--- a/include/disk/disk_access.h
+++ b/include/disk/disk_access.h
@@ -12,6 +12,10 @@
 #ifndef ZEPHYR_INCLUDE_DISK_DISK_ACCESS_H_
 #define ZEPHYR_INCLUDE_DISK_DISK_ACCESS_H_
 
+#ifndef CONFIG_COMPAT_INCLUDES
+#warning "This header file has moved, include <storage/disk_access.h> instead."
+#endif
+
 #include <storage/disk_access.h>
 
 #endif /* ZEPHYR_INCLUDE_DISK_DISK_ACCESS_H_ */


### PR DESCRIPTION
disk/disk_access.h got moved, but there is no compat warning.
Add that so users know they need to update code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>