### PR TITLE
include: Move emul.h to drivers/emul.h

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -438,7 +438,7 @@
 /include/dt-bindings/dma/stm32_dma.h      @cybertale
 /include/dt-bindings/pcie/                @dcpleung
 /include/dt-bindings/usb/usb.h            @galak
-/include/emul.h                           @sjg20
+/include/drivers/emul.h                   @sjg20
 /include/fs/                              @nashif @nvlsianpu @de-nordic
 /include/init.h                           @nashif @andyross
 /include/irq.h                            @dcpleung @nashif @andyross

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(espi_emul_ctlr);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/espi.h>
 #include <drivers/espi_emul.h>
 #include "espi_utils.h"

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(i2c_emul_ctlr);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/i2c.h>
 #include <drivers/i2c_emul.h>
 

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(spi_emul_ctlr);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/spi.h>
 #include <drivers/spi_emul.h>
 

--- a/include/drivers/emul.h
+++ b/include/drivers/emul.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright 2020 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EMUL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_EMUL_H_
+
+/**
+ * @brief Emulators used to test drivers and higher-level code that uses them
+ * @defgroup io_emulators Emulator interface
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+struct device;
+struct emul;
+
+/**
+ * Structure uniquely identifying a device to be emulated
+ *
+ * Currently this uses the device node label, but that will go away by 2.5.
+ */
+struct emul_link_for_bus {
+	const char *label;
+};
+
+/** List of emulators attached to a bus */
+struct emul_list_for_bus {
+	/** Identifiers for children of the node */
+	const struct emul_link_for_bus *children;
+	/** Number of children of the node */
+	unsigned int num_children;
+};
+
+/**
+ * Standard callback for emulator initialisation providing the initialiser
+ * record and the device that calls the emulator functions.
+ *
+ * @param emul Emulator to init
+ * @param parent Parent device that is using the emulator
+ */
+typedef int (*emul_init_t)(const struct emul *emul,
+			   const struct device *parent);
+
+/** An emulator instance */
+struct emul {
+	/** function used to initialise the emulator state */
+	emul_init_t init;
+	/** handle to the device for which this provides low-level emulation */
+	const char *dev_label;
+	/** Emulator-specific configuration data */
+	const void *cfg;
+};
+
+/**
+ * Emulators are aggregated into an array at link time, from which emulating
+ * devices can find the emulators that they are to use.
+ */
+extern const struct emul __emul_list_start[];
+extern const struct emul __emul_list_end[];
+
+/* Use the devicetree node identifier as a unique name. */
+#define EMUL_REG_NAME(node_id) (_CONCAT(__emulreg_, node_id))
+
+/**
+ * Define a new emulator
+ *
+ * This adds a new struct emul to the linker list of emulations. This is
+ * typically used in your emulator's DT_INST_FOREACH_STATUS_OKAY() clause.
+ *
+ * @param init_ptr function to call to initialise the emulator (see emul_init
+ *	typedef)
+ * @param node_id Node ID of the driver to emulate (e.g. DT_DRV_INST(n))
+ * @param cfg_ptr emulator-specific configuration data
+ */
+#define EMUL_DEFINE(init_ptr, node_id, cfg_ptr)			\
+	static struct emul EMUL_REG_NAME(node_id)		\
+	__attribute__((__section__(".emulators"))) __used = {	\
+		.init = (init_ptr),				\
+		.dev_label = DT_LABEL(node_id),			\
+		.cfg = (cfg_ptr),				\
+	};
+
+/**
+ * Set up a list of emulators
+ *
+ * @param dev Device the emulators are attached to (e.g. an I2C controller)
+ * @param list List of devices to set up
+ * @return 0 if OK
+ * @return negative value on error
+ */
+int emul_init_for_bus_from_list(const struct device *dev,
+				const struct emul_list_for_bus *list);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_EMUL_H_ */

--- a/include/emul.h
+++ b/include/emul.h
@@ -8,102 +8,10 @@
 #ifndef ZEPHYR_INCLUDE_EMUL_H_
 #define ZEPHYR_INCLUDE_EMUL_H_
 
-/**
- * @brief Emulators used to test drivers and higher-level code that uses them
- * @defgroup io_emulators Emulator interface
- * @{
- */
+#ifndef CONFIG_COMPAT_INCLUDES
+#warning "This header file has moved, include <drivers/emul.h> instead."
+#endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-struct device;
-struct emul;
-
-/**
- * Structure uniquely identifying a device to be emulated
- *
- * Currently this uses the device node label, but that will go away by 2.5.
- */
-struct emul_link_for_bus {
-	const char *label;
-};
-
-/** List of emulators attached to a bus */
-struct emul_list_for_bus {
-	/** Identifiers for children of the node */
-	const struct emul_link_for_bus *children;
-	/** Number of children of the node */
-	unsigned int num_children;
-};
-
-/**
- * Standard callback for emulator initialisation providing the initialiser
- * record and the device that calls the emulator functions.
- *
- * @param emul Emulator to init
- * @param parent Parent device that is using the emulator
- */
-typedef int (*emul_init_t)(const struct emul *emul,
-			   const struct device *parent);
-
-/** An emulator instance */
-struct emul {
-	/** function used to initialise the emulator state */
-	emul_init_t init;
-	/** handle to the device for which this provides low-level emulation */
-	const char *dev_label;
-	/** Emulator-specific configuration data */
-	const void *cfg;
-};
-
-/**
- * Emulators are aggregated into an array at link time, from which emulating
- * devices can find the emulators that they are to use.
- */
-extern const struct emul __emul_list_start[];
-extern const struct emul __emul_list_end[];
-
-/* Use the devicetree node identifier as a unique name. */
-#define EMUL_REG_NAME(node_id) (_CONCAT(__emulreg_, node_id))
-
-/**
- * Define a new emulator
- *
- * This adds a new struct emul to the linker list of emulations. This is
- * typically used in your emulator's DT_INST_FOREACH_STATUS_OKAY() clause.
- *
- * @param init_ptr function to call to initialise the emulator (see emul_init
- *	typedef)
- * @param node_id Node ID of the driver to emulate (e.g. DT_DRV_INST(n))
- * @param cfg_ptr emulator-specific configuration data
- */
-#define EMUL_DEFINE(init_ptr, node_id, cfg_ptr)			\
-	static struct emul EMUL_REG_NAME(node_id)		\
-	__attribute__((__section__(".emulators"))) __used = {	\
-		.init = (init_ptr),				\
-		.dev_label = DT_LABEL(node_id),			\
-		.cfg = (cfg_ptr),				\
-	};
-
-/**
- * Set up a list of emulators
- *
- * @param dev Device the emulators are attached to (e.g. an I2C controller)
- * @param list List of devices to set up
- * @return 0 if OK
- * @return negative value on error
- */
-int emul_init_for_bus_from_list(const struct device *dev,
-				const struct emul_list_for_bus *list);
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-/**
- * @}
- */
+#include <drivers/emul.h>
 
 #endif /* ZEPHYR_INCLUDE_EMUL_H_ */

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -10,7 +10,7 @@
 LOG_MODULE_REGISTER(emul);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <string.h>
 
 /**

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(bosch_bmi160);
 #include <sys/byteorder.h>
 #include <bmi160.h>
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/i2c.h>
 #include <drivers/i2c_emul.h>
 #include <drivers/spi.h>

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -14,7 +14,7 @@
 LOG_MODULE_REGISTER(espi_host);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/espi.h>
 #include <drivers/espi_emul.h>
 

--- a/subsys/emul/i2c/emul_atmel_at24.c
+++ b/subsys/emul/i2c/emul_atmel_at24.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(atmel_at24);
 
 #include <device.h>
-#include <emul.h>
+#include <drivers/emul.h>
 #include <drivers/i2c.h>
 #include <drivers/i2c_emul.h>
 


### PR DESCRIPTION
Move emul.h out of the top level include/ dir into
include/drivers/emul.h and deprecated the old location.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>