### PR TITLE
drivers: sensor: ccs811: fix sw reset delay

### DIFF
--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -490,6 +490,8 @@ static int ccs811_init(const struct device *dev)
 	}
 #endif
 
+	k_msleep(20);            /* t_START assuming recent power-on */
+
 	/* Reset the device.  This saves having to deal with detecting
 	 * and validating any errors or configuration inconsistencies
 	 * after a reset that left the device running.
@@ -512,7 +514,7 @@ static int ccs811_init(const struct device *dev)
 		}
 	}
 #endif
-	k_msleep(20);            /* t_START assuming recent power-on */
+	k_msleep(2);             /* t_START after reset */
 
 	/* Switch device to application mode */
 	ret = switch_to_app_mode(drv_data->i2c);


### PR DESCRIPTION
Before this change, the sw reset did not work after power-on, because I2C
commands are only accepted after 20msec (t_START after power-on).

Now the 20msec delay is moved before performing the reset to ensure that
the SW reset command can be executed. An additional 2msec delay is added
after the reset (see datasheet t_START after reset).

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>