### PR TITLE
Bluetooth: shell: Adds Periodic adv sync transfer shell command

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1777,6 +1777,32 @@ static int cmd_past_unsubscribe(const struct shell *shell, size_t argc,
 
 	return err;
 }
+
+static int cmd_per_adv_sync_transfer(const struct shell *shell, size_t argc,
+				     char *argv[])
+{
+	int err;
+	int index;
+	struct bt_le_per_adv_sync *per_adv_sync;
+
+	if (argc > 1) {
+		index = strtol(argv[1], NULL, 10);
+	} else {
+		index = 0;
+	}
+
+	per_adv_sync = per_adv_syncs[index];
+	if (!per_adv_sync) {
+		return -EINVAL;
+	}
+
+	err = bt_le_per_adv_sync_transfer(per_adv_sync, default_conn, 0);
+	if (err) {
+		shell_error(shell, "Periodic advertising sync transfer failed (%d)", err);
+	}
+
+	return err;
+}
 #endif /* CONFIG_BT_PER_ADV_SYNC */
 
 #if defined(CONFIG_BT_CONN)
@@ -3052,6 +3078,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      cmd_past_subscribe, 1, 7),
 	SHELL_CMD_ARG(past-unsubscribe, NULL, "[conn]",
 		      cmd_past_unsubscribe, 1, 1),
+	SHELL_CMD_ARG(per-adv-sync-transfer, NULL, "[<index>]",
+		      cmd_per_adv_sync_transfer, 1, 1),
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #if defined(CONFIG_BT_CENTRAL)
 	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE EXT_ADV_SCAN_OPT,


### PR DESCRIPTION
Adds a command for tranferring a periodic adv sync to a PAST
receiver.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/32745