### PR TITLE
Bluetooth: host: Add feature check for periodic adv functions

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1347,6 +1347,10 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 	struct net_buf *buf;
 	int err;
 
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	}
+
 	if (atomic_test_bit(adv->flags, BT_ADV_SCANNABLE)) {
 		return -EINVAL;
 	} else if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
@@ -1394,6 +1398,10 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 	struct net_buf *buf;
 	struct bt_ad d = { .data = ad, .len = ad_len };
 	int err;
+
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	}
 
 	if (!atomic_test_bit(adv->flags, BT_PER_ADV_PARAMS_SET)) {
 		return -EINVAL;
@@ -1444,6 +1452,10 @@ static int bt_le_per_adv_enable(struct bt_le_ext_adv *adv, bool enable)
 	struct bt_hci_cmd_state_set state;
 	int err;
 
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	}
+
 	/* TODO: We could setup some default ext adv params if not already set*/
 	if (!atomic_test_bit(adv->flags, BT_PER_ADV_PARAMS_SET)) {
 		return -EINVAL;
@@ -1493,8 +1505,11 @@ int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
 	struct bt_hci_cp_le_per_adv_set_info_transfer *cp;
 	struct net_buf *buf;
 
-	if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
-		return -EOPNOTSUPP;
+
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	} else if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
+		return -ENOTSUP;
 	}
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER,

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1246,6 +1246,10 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 {
 	int err = 0;
 
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	}
+
 	if (atomic_test_bit(per_adv_sync->flags, BT_PER_ADV_SYNC_SYNCED)) {
 		err = bt_le_per_adv_sync_terminate(per_adv_sync);
 
@@ -1349,8 +1353,11 @@ int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
 	struct bt_hci_cp_le_per_adv_sync_transfer *cp;
 	struct net_buf *buf;
 
-	if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
-		return -EOPNOTSUPP;
+
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	} else if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
+		return -ENOTSUP;
 	}
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER,
@@ -1433,8 +1440,10 @@ int bt_le_per_adv_sync_transfer_subscribe(
 {
 	uint8_t cte_type = 0;
 
-	if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
-		return -EOPNOTSUPP;
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	} else if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
+		return -ENOTSUP;
 	}
 
 	if (!valid_past_param(param)) {
@@ -1469,8 +1478,10 @@ int bt_le_per_adv_sync_transfer_subscribe(
 
 int bt_le_per_adv_sync_transfer_unsubscribe(const struct bt_conn *conn)
 {
-	if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
-		return -EOPNOTSUPP;
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+		return -ENOTSUP;
+	} else if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
+		return -ENOTSUP;
 	}
 
 	if (conn) {


### PR DESCRIPTION
Adds a check for the BT_LE_FEAT_BIT_PER_ADV bit for each
function related to periodic advertising, including sync and
PAST transfer.

Also updated some of the similar return codes from ENOTSUP
to EOPNOTSUPP as that is more descriptive as to why the
function returns an error.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fixed https://github.com/zephyrproject-rtos/zephyr/issues/33421