### PR TITLE
AArch64: Do not use CONFIG_GEN_PRIV_STACKS

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -32,7 +32,7 @@ config ARM
 	select HAS_DTS
 	# FIXME: current state of the code for all ARM requires this, but
 	# is really only necessary for Cortex-M with ARM MPU!
-	select GEN_PRIV_STACKS
+	select GEN_PRIV_STACKS if !ARM64
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if ARM64 || CPU_CORTEX_R || CPU_CORTEX_M
 	help
 	  ARM architecture

--- a/include/arch/arm/aarch64/thread_stack.h
+++ b/include/arch/arm/aarch64/thread_stack.h
@@ -47,4 +47,12 @@
 #define ARCH_KERNEL_STACK_RESERVED		0
 #define ARCH_KERNEL_STACK_OBJ_ALIGN		ARCH_STACK_PTR_ALIGN
 
+#ifndef _ASMLANGUAGE
+
+struct z_arm64_thread_stack_header {
+	char privilege_stack[CONFIG_PRIVILEGED_STACK_SIZE];
+} __packed __aligned(Z_ARM64_STACK_BASE_ALIGN);
+
+#endif /* _ASMLANGUAGE */
+
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH64_THREAD_STACK_H_ */

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -666,7 +666,8 @@ static void test_init_and_access_other_memdomain(void)
 	spawn_user(&default_bool);
 }
 
-#if defined(CONFIG_ARM) || (defined(CONFIG_GEN_PRIV_STACKS) && defined(CONFIG_RISCV))
+#if (defined(CONFIG_ARM) || (defined(CONFIG_GEN_PRIV_STACKS) && defined(CONFIG_RISCV)) && \
+	!defined(CONFIG_ARM64))
 extern uint8_t *z_priv_stack_find(void *obj);
 #endif
 extern k_thread_stack_t ztest_thread_stack[];
@@ -942,7 +943,13 @@ void test_main(void)
 	/* Most of these scenarios use the default domain */
 	k_mem_domain_add_partition(&k_mem_domain_default, &default_part);
 
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_ARM64)
+	struct z_arm64_thread_stack_header *hdr;
+
+	hdr = ((struct z_arm64_thread_stack_header *)ztest_thread_stack);
+	priv_stack_ptr = (((char *)&hdr->privilege_stack) +
+			  (sizeof(hdr->privilege_stack) - 1));
+#elif defined(CONFIG_ARM)
 	priv_stack_ptr = (char *)z_priv_stack_find(ztest_thread_stack);
 #elif defined(CONFIG_X86)
 	struct z_x86_thread_stack_header *hdr;


### PR DESCRIPTION
We are setting CONFIG_GEN_PRIV_STACKS when AArch64 actually uses a
statically allocated privileged stack.

This error was not captured by the tests because we only verify whether
a read/write to a privileged stack is failing, but it can fail for a lot
of reasons including when the pointer to the privileged stack is not
initialized at all, like in this case.

With this patch we deselect CONFIG_GEN_PRIV_STACKS and we fix the
mem_protect/userspace test to correctly probe the privileged stack.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>