### PR TITLE
Bluetooth: host: Add ISO disconnect reason

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -32,6 +32,8 @@ API Changes
 * The :c:func:`wait_for_usb_dfu` function now accepts a ``k_timeout_t`` argument instead of
   using the ``CONFIG_USB_DFU_WAIT_DELAY_MS`` macro.
 
+* Added disconnect reason to the :c:func:`disconnected` callback of :c:struct:`bt_iso_chan_ops`.
+
 Deprecated in this release
 
 * :c:macro:`DT_CLOCKS_LABEL_BY_IDX`, :c:macro:`DT_CLOCKS_LABEL_BY_NAME`,

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -238,9 +238,10 @@ struct bt_iso_chan_ops {
 	 *  channel is disconnected, including when a connection gets
 	 *  rejected.
 	 *
-	 *  @param chan The channel that has been Disconnected
+	 *  @param chan   The channel that has been Disconnected
+	 *  @param reason HCI reason for the disconnection.
 	 */
-	void (*disconnected)(struct bt_iso_chan *chan);
+	void (*disconnected)(struct bt_iso_chan *chan, uint8_t reason);
 
 	/** @brief Channel alloc_buf callback
 	 *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1590,6 +1590,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			iso = conn_lookup_iso(conn);
 			if (iso) {
+				iso->err = conn->err;
+
 				bt_iso_disconnected(iso);
 				bt_iso_cleanup(iso);
 				bt_conn_unref(iso);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -760,9 +760,9 @@ static void bt_iso_remove_data_path(struct bt_conn *conn)
 	hci_le_remove_iso_data_path(conn, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
 }
 
-static void bt_iso_chan_disconnected(struct bt_iso_chan *chan)
+static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	BT_DBG("%p", chan);
+	BT_DBG("%p, reason 0x%02x", chan, reason);
 
 	if (!chan->conn) {
 		bt_iso_chan_set_state(chan, BT_ISO_DISCONNECTED);
@@ -778,7 +778,7 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan)
 	}
 
 	if (chan->ops->disconnected) {
-		chan->ops->disconnected(chan);
+		chan->ops->disconnected(chan, reason);
 	}
 }
 
@@ -801,7 +801,7 @@ void bt_iso_disconnected(struct bt_conn *conn)
 	bt_iso_remove_data_path(conn);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->channels, chan, next, node) {
-		bt_iso_chan_disconnected(chan);
+		bt_iso_chan_disconnected(chan, conn->err);
 	}
 }
 
@@ -1015,7 +1015,7 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 
 	if (chan->state == BT_ISO_BOUND) {
 		bt_iso_chan_remove(chan->conn, chan);
-		bt_iso_chan_disconnected(chan);
+		bt_iso_chan_disconnected(chan, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 		return 0;
 	}
 
@@ -1225,9 +1225,11 @@ static void cleanup_big(struct bt_iso_big *big)
 	atomic_clear(&big->initialized);
 }
 
-static void big_disconnect(struct bt_iso_big *big)
+static void big_disconnect(struct bt_iso_big *big, uint8_t reason)
 {
 	for (int i = 0; i < big->num_bis; i++) {
+		big->bis[i]->conn->err = reason;
+
 		bt_iso_disconnected(big->bis[i]->conn);
 	}
 }
@@ -1449,7 +1451,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 		err = hci_le_big_sync_term(big);
 
 		if (!err) {
-			big_disconnect(big);
+			big_disconnect(big, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 			cleanup_big(big);
 		}
 	}
@@ -1491,7 +1493,7 @@ void hci_le_big_terminate(struct net_buf *buf)
 
 	BT_DBG("BIG[%u] %p terminated", big->handle, big);
 
-	big_disconnect(big);
+	big_disconnect(big, evt->reason);
 	cleanup_big(big);
 }
 
@@ -1504,7 +1506,7 @@ void hci_le_big_sync_established(struct net_buf *buf)
 	BT_DBG("BIG[%u] %p sync established", big->handle, big);
 
 	if (evt->status || evt->num_bis != big->num_bis) {
-		big_disconnect(big);
+		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 		cleanup_big(big);
 		return;
 	}
@@ -1532,7 +1534,7 @@ void hci_le_big_sync_lost(struct net_buf *buf)
 
 	BT_DBG("BIG[%u] %p sync lost", big->handle, big);
 
-	big_disconnect(big);
+	big_disconnect(big, evt->reason);
 	cleanup_big(big);
 }
 

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -34,9 +34,9 @@ static void iso_connected(struct bt_iso_chan *chan)
 	printk("ISO Channel %p connected\n", chan);
 }
 
-static void iso_disconnected(struct bt_iso_chan *chan)
+static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	printk("ISO Channel %p disconnected\n", chan);
+	printk("ISO Channel %p disconnected with reason 0x%02x\n", chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {


### PR DESCRIPTION
Adds a disconnect reason in the ISO disconnect callback.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/33203