### PR TITLE
shell: fix tab in shell_log_backend.c

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -32,7 +32,7 @@ void z_shell_log_backend_enable(const struct shell_log_backend *backend,
 	if (err == 0) {
 		log_backend_enable(backend->backend, ctx, init_log_level);
 		log_output_ctx_set(backend->log_output, ctx);
-	backend->control_block->dropped_cnt = 0;
+		backend->control_block->dropped_cnt = 0;
 		backend->control_block->state = SHELL_LOG_BACKEND_ENABLED;
 	}
 }


### PR DESCRIPTION
This is a trivial fix to add a tab to an under-indented line.

Signed-off-by: Jack Rosenthal <jrosenth@chromium.org>