### PR TITLE
Fix return code for unimplemented functions in driver APIs (ENOSYS vs ENOTSUP)

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -27,4 +27,5 @@
 --ignore TRAILING_SEMICOLON
 --ignore COMPLEX_MACRO
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore ENOSYS
 --exclude ext

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -150,7 +150,8 @@ static inline int clock_control_off(const struct device *dev,
  *
  * @retval 0 if start is successfully initiated.
  * @retval -EALREADY if clock was already started and is starting or running.
- * @retval -ENOTSUP if not supported.
+ * @retval -ENOTSUP If the requested mode of operation is not supported.
+ * @retval -ENOSYS if the interface is not implemented.
  * @retval other negative errno on vendor specific error.
  */
 static inline int clock_control_async_on(const struct device *dev,
@@ -161,8 +162,8 @@ static inline int clock_control_async_on(const struct device *dev,
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
-	if (!api->async_on) {
-		return -ENOTSUP;
+	if (api->async_on == NULL) {
+		return -ENOSYS;
 	}
 
 	if (!device_is_ready(dev)) {
@@ -215,8 +216,9 @@ static inline int clock_control_get_rate(const struct device *dev,
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
-	__ASSERT(api->get_rate != NULL, "%s not implemented for device %s",
-		__func__, dev->name);
+	if (api->get_rate == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->get_rate(dev, sys, rate);
 }

--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -367,7 +367,7 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
  * @retval 0 If successful
  * @retval -EBUSY If bus is not clear after recovery attempt.
  * @retval -EIO General input / output error.
- * @retval -ENOTSUP If bus recovery is not supported
+ * @retval -ENOSYS If bus recovery is not implemented
  */
 __syscall int i2c_recover_bus(const struct device *dev);
 
@@ -377,7 +377,7 @@ static inline int z_impl_i2c_recover_bus(const struct device *dev)
 		(const struct i2c_driver_api *)dev->api;
 
 	if (api->recover_bus == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->recover_bus(dev);
@@ -405,7 +405,7 @@ static inline int z_impl_i2c_recover_bus(const struct device *dev)
  * @retval 0 Is successful
  * @retval -EINVAL If parameters are invalid
  * @retval -EIO General input / output error.
- * @retval -ENOTSUP If slave mode is not supported
+ * @retval -ENOSYS If slave mode is not implemented
  */
 static inline int i2c_slave_register(const struct device *dev,
 				     struct i2c_slave_config *cfg)
@@ -414,7 +414,7 @@ static inline int i2c_slave_register(const struct device *dev,
 		(const struct i2c_driver_api *)dev->api;
 
 	if (api->slave_register == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->slave_register(dev, cfg);
@@ -434,7 +434,7 @@ static inline int i2c_slave_register(const struct device *dev,
  *
  * @retval 0 Is successful
  * @retval -EINVAL If parameters are invalid
- * @retval -ENOTSUP If slave mode is not supported
+ * @retval -ENOSYS If slave mode is not implemented
  */
 static inline int i2c_slave_unregister(const struct device *dev,
 				       struct i2c_slave_config *cfg)
@@ -443,7 +443,7 @@ static inline int i2c_slave_unregister(const struct device *dev,
 		(const struct i2c_driver_api *)dev->api;
 
 	if (api->slave_unregister == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->slave_unregister(dev, cfg);

--- a/include/drivers/kscan.h
+++ b/include/drivers/kscan.h
@@ -101,7 +101,7 @@ static inline int z_impl_kscan_enable_callback(const struct device *dev)
 			(const struct kscan_driver_api *)dev->api;
 
 	if (api->enable_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->enable_callback(dev);
@@ -122,7 +122,7 @@ static inline int z_impl_kscan_disable_callback(const struct device *dev)
 			(const struct kscan_driver_api *)dev->api;
 
 	if (api->disable_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->disable_callback(dev);

--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -141,8 +141,8 @@ static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (!api->blink) {
-		return -ENOTSUP;
+	if (api->blink == NULL) {
+		return -ENOSYS;
 	}
 	return api->blink(dev, led, delay_on, delay_off);
 }
@@ -166,9 +166,9 @@ static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (!api->get_info) {
+	if (api->get_info == NULL) {
 		*info = NULL;
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 	return api->get_info(dev, led, info);
 }
@@ -194,8 +194,8 @@ static inline int z_impl_led_set_brightness(const struct device *dev,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (!api->set_brightness) {
-		return -ENOTSUP;
+	if (api->set_brightness == NULL) {
+		return -ENOSYS;
 	}
 	return api->set_brightness(dev, led, value);
 }
@@ -227,8 +227,8 @@ z_impl_led_write_channels(const struct device *dev, uint32_t start_channel,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (!api->write_channels) {
-		return -ENOTSUP;
+	if (api->write_channels == NULL) {
+		return -ENOSYS;
 	}
 	return api->write_channels(dev, start_channel, num_channels, buf);
 }
@@ -279,8 +279,8 @@ static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (!api->set_color) {
-		return -ENOTSUP;
+	if (api->set_color == NULL) {
+		return -ENOSYS;
 	}
 	return api->set_color(dev, led, num_colors, color);
 }

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -176,8 +176,8 @@ static inline int lora_test_cw(const struct device *dev, uint32_t frequency,
 	const struct lora_driver_api *api =
 		(const struct lora_driver_api *)dev->api;
 
-	if (!api->test_cw) {
-		return -ENOTSUP;
+	if (api->test_cw == NULL) {
+		return -ENOSYS;
 	}
 
 	return api->test_cw(dev, frequency, tx_power, duration);

--- a/include/drivers/ps2.h
+++ b/include/drivers/ps2.h
@@ -136,7 +136,7 @@ static inline int z_impl_ps2_enable_callback(const struct device *dev)
 			(const struct ps2_driver_api *)dev->api;
 
 	if (api->enable_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->enable_callback(dev);
@@ -157,7 +157,7 @@ static inline int z_impl_ps2_disable_callback(const struct device *dev)
 			(const struct ps2_driver_api *)dev->api;
 
 	if (api->disable_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->disable_callback(dev);

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -203,7 +203,7 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
  *                  function
  *
  * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOTSUP if PWM capture is not supported or the given flags are not
+ * @retval -ENOSYS if PWM capture is not supported or the given flags are not
  *                  supported
  * @retval -EIO if IO error occurred while configuring
  * @retval -EBUSY if PWM capture is already in progress
@@ -217,8 +217,8 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
 {
 	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
 
-	if (!api->pin_configure_capture) {
-		return -ENOTSUP;
+	if (api->pin_configure_capture == NULL) {
+		return -ENOSYS;
 	}
 
 	return api->pin_configure_capture(dev, pwm, flags, cb, user_data);
@@ -239,7 +239,7 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
  *
  * @retval 0 If successful.
  * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOTSUP if PWM capture is not supported
+ * @retval -ENOSYS if PWM capture is not supported
  * @retval -EIO if IO error occurred while enabling PWM capture
  * @retval -EBUSY if PWM capture is already in progress
  */
@@ -251,8 +251,8 @@ static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
 {
 	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
 
-	if (!api->pin_enable_capture) {
-		return -ENOTSUP;
+	if (api->pin_enable_capture == NULL) {
+		return -ENOSYS;
 	}
 
 	return api->pin_enable_capture(dev, pwm);
@@ -271,7 +271,7 @@ static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
  *
  * @retval 0 If successful.
  * @retval -EINVAL if invalid function parameters were given
- * @retval -ENOTSUP if PWM capture is not supported
+ * @retval -ENOSYS if PWM capture is not supported
  * @retval -EIO if IO error occurred while disabling PWM capture
  */
 __syscall int pwm_pin_disable_capture(const struct device *dev, uint32_t pwm);
@@ -282,8 +282,8 @@ static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
 {
 	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
 
-	if (!api->pin_disable_capture) {
-		return -ENOTSUP;
+	if (api->pin_disable_capture == NULL) {
+		return -ENOSYS;
 	}
 
 	return api->pin_disable_capture(dev, pwm);

--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -405,7 +405,7 @@ static inline int z_impl_sensor_attr_set(const struct device *dev,
 		(const struct sensor_driver_api *)dev->api;
 
 	if (api->attr_set == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->attr_set(dev, chan, attr, val);
@@ -437,7 +437,7 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
 		(const struct sensor_driver_api *)dev->api;
 
 	if (api->attr_get == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->attr_get(dev, chan, attr, val);
@@ -468,7 +468,7 @@ static inline int sensor_trigger_set(const struct device *dev,
 		(const struct sensor_driver_api *)dev->api;
 
 	if (api->trigger_set == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->trigger_set(dev, trig, handler);

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -635,10 +635,10 @@ static inline int z_impl_uart_err_check(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->err_check != NULL) {
-		return api->err_check(dev);
+	if (api->err_check == NULL) {
+		return -ENOSYS;
 	}
-	return 0;
+	return api->err_check(dev);
 }
 
 
@@ -712,11 +712,10 @@ static inline int z_impl_uart_configure(const struct device *dev,
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->api;
 
-	if (api->configure != NULL) {
-		return api->configure(dev, cfg);
+	if (api->configure == NULL) {
+		return -ENOSYS;
 	}
-
-	return -ENOTSUP;
+	return api->configure(dev, cfg);
 }
 
 /**
@@ -740,11 +739,12 @@ static inline int z_impl_uart_config_get(const struct device *dev,
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->api;
 
-	if (api->config_get != NULL) {
-		return api->config_get(dev, cfg);
+	if (api->config_get == NULL) {
+		return -ENOSYS;
 	}
 
-	return -ENOTSUP;
+	return api->config_get(dev, cfg);
+
 }
 
 /**
@@ -773,7 +773,7 @@ static inline int uart_fifo_fill(const struct device *dev,
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->fifo_fill) {
+	if (api->fifo_fill != NULL) {
 		return api->fifo_fill(dev, tx_data, size);
 	}
 #endif
@@ -810,7 +810,7 @@ static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->fifo_read) {
+	if (api->fifo_read != NULL) {
 		return api->fifo_read(dev, rx_data, size);
 	}
 #endif
@@ -833,7 +833,7 @@ static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_tx_enable) {
+	if (api->irq_tx_enable != NULL) {
 		api->irq_tx_enable(dev);
 	}
 #endif
@@ -853,7 +853,7 @@ static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_tx_disable) {
+	if (api->irq_tx_disable != NULL) {
 		api->irq_tx_disable(dev);
 	}
 #endif
@@ -880,7 +880,7 @@ static inline int uart_irq_tx_ready(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_tx_ready) {
+	if (api->irq_tx_ready != NULL) {
 		return api->irq_tx_ready(dev);
 	}
 #endif
@@ -903,7 +903,7 @@ static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_rx_enable) {
+	if (api->irq_rx_enable != NULL) {
 		api->irq_rx_enable(dev);
 	}
 #endif
@@ -924,7 +924,7 @@ static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_rx_disable) {
+	if (api->irq_rx_disable != NULL) {
 		api->irq_rx_disable(dev);
 	}
 #endif
@@ -954,13 +954,15 @@ static inline int uart_irq_tx_complete(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_tx_complete) {
-		return api->irq_tx_complete(dev);
+	if (api->irq_tx_complete == NULL) {
+		return -ENOSYS;
 	}
+	return api->irq_tx_complete(dev);
 #endif
-
 	return -ENOTSUP;
+
 }
+
 
 /**
  * @brief Check if UART RX buffer has a received char
@@ -987,9 +989,10 @@ static inline int uart_irq_rx_ready(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_rx_ready) {
-		return api->irq_rx_ready(dev);
+	if (api->irq_rx_ready == NULL) {
+		return -ENOSYS;
 	}
+	return api->irq_rx_ready(dev);
 #endif
 
 	return 0;
@@ -1053,9 +1056,10 @@ static inline int z_impl_uart_irq_is_pending(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_is_pending)	{
-		return api->irq_is_pending(dev);
+	if (api->irq_is_pending == NULL) {
+		return -ENOSYS;
 	}
+	return api->irq_is_pending(dev);
 #endif
 	return 0;
 }
@@ -1091,9 +1095,10 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->irq_update) {
-		return api->irq_update(dev);
+	if (api->irq_update == NULL) {
+		return -ENOSYS;
 	}
+	return api->irq_update(dev);
 #endif
 	return 0;
 }
@@ -1163,9 +1168,10 @@ static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->line_ctrl_set) {
-		return api->line_ctrl_set(dev, ctrl, val);
+	if (api->line_ctrl_set == NULL) {
+		return -ENOSYS;
 	}
+	return api->line_ctrl_set(dev, ctrl, val);
 #endif
 
 	return -ENOTSUP;
@@ -1191,9 +1197,10 @@ static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api && api->line_ctrl_get) {
-		return api->line_ctrl_get(dev, ctrl, val);
+	if (api->line_ctrl_get == NULL) {
+		return -ENOSYS;
 	}
+	return api->line_ctrl_get(dev, ctrl, val);
 #endif
 
 	return -ENOTSUP;
@@ -1221,9 +1228,10 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->api;
 
-	if (api->drv_cmd) {
-		return api->drv_cmd(dev, cmd, p);
+	if (api->drv_cmd == NULL) {
+		return -ENOSYS;
 	}
+	return api->drv_cmd(dev, cmd, p);
 #endif
 
 	return -ENOTSUP;

--- a/include/drivers/video.h
+++ b/include/drivers/video.h
@@ -265,7 +265,9 @@ static inline int video_set_format(const struct device *dev,
 	const struct video_driver_api *api =
 		(const struct video_driver_api *)dev->api;
 
-	__ASSERT(api->set_format, "set_format must be implemented by driver");
+	if (api->set_format == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_format(dev, ep, fmt);
 }
@@ -288,7 +290,9 @@ static inline int video_get_format(const struct device *dev,
 	const struct video_driver_api *api =
 		(const struct video_driver_api *)dev->api;
 
-	__ASSERT(api->get_format, "get_format must be implemented by driver");
+	if (api->get_format == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->get_format(dev, ep, fmt);
 }
@@ -315,7 +319,7 @@ static inline int video_enqueue(const struct device *dev,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->enqueue == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->enqueue(dev, ep, buf);
@@ -345,7 +349,7 @@ static inline int video_dequeue(const struct device *dev,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->dequeue == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->dequeue(dev, ep, buf, timeout);
@@ -374,7 +378,7 @@ static inline int video_flush(const struct device *dev,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->flush == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->flush(dev, ep, cancel);
@@ -397,8 +401,9 @@ static inline int video_stream_start(const struct device *dev)
 	const struct video_driver_api *api =
 		(const struct video_driver_api *)dev->api;
 
-	__ASSERT(api->stream_start,
-		 "stream_start must be implemented by driver");
+	if (api->stream_start == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->stream_start(dev);
 }
@@ -418,8 +423,9 @@ static inline int video_stream_stop(const struct device *dev)
 		(const struct video_driver_api *)dev->api;
 	int ret;
 
-	__ASSERT(api->stream_stop,
-		 "stream_stop must be implemented by driver");
+	if (api->stream_stop) {
+		return -ENOSYS;
+	}
 
 	ret = api->stream_stop(dev);
 	video_flush(dev, VIDEO_EP_ANY, true);
@@ -443,7 +449,9 @@ static inline int video_get_caps(const struct device *dev,
 	const struct video_driver_api *api =
 		(const struct video_driver_api *)dev->api;
 
-	__ASSERT(api->get_caps, "get_caps must be implemented by driver");
+	if (api->get_caps == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->get_caps(dev, ep, caps);
 }
@@ -470,7 +478,7 @@ static inline int video_set_ctrl(const struct device *dev, unsigned int cid,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->set_ctrl == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->set_ctrl(dev, cid, value);
@@ -498,7 +506,7 @@ static inline int video_get_ctrl(const struct device *dev, unsigned int cid,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->get_ctrl == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->get_ctrl(dev, cid, value);
@@ -525,7 +533,7 @@ static inline int video_set_signal(const struct device *dev,
 		(const struct video_driver_api *)dev->api;
 
 	if (api->set_signal == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->set_signal(dev, ep, signal);

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -245,20 +245,20 @@ void test_sensor_handle_triggers(void)
 				trigger_elements[i].trig.chan,
 				trigger_elements[i].attr,
 				&trigger_elements[i].data),
-				-ENOTSUP, "fail to set attributes");
+				-ENOSYS, "fail to set attributes");
 
 		/* read-back attributes for no trig dev*/
 		zassert_equal(sensor_attr_get(dev_no_trig,
 				trigger_elements[i].trig.chan,
 				trigger_elements[i].attr,
 				&data),
-				-ENOTSUP, "fail to get attributes");
+				-ENOSYS, "fail to get attributes");
 
 		/* setting a sensor's trigger and handler for no trig dev */
 		zassert_equal(sensor_trigger_set(dev_no_trig,
 				&trigger_elements[i].trig,
 				trigger_handler),
-				-ENOTSUP, "fail to set trigger");
+				-ENOSYS, "fail to set trigger");
 	}
 }
 

--- a/tests/drivers/sensor/generic/testcase.yaml
+++ b/tests/drivers/sensor/generic/testcase.yaml
@@ -1,7 +1,10 @@
+common:
+  integration_platforms:
+    - qemu_x86
+    - mps2_an385
 tests:
   driver.sensor:
-    extra_args: CONF_FILE=prj.conf
-    tags: driver sensor subsys
+    tags: driver sensor
   driver.sensor.fpu:
     extra_args: CONF_FILE=prj_fpu.conf
-    tags: driver sensor subsys
+    tags: driver sensor


### PR DESCRIPTION
Fix wrong usage of return codes in driver APIs and remove bogus checkpatch warning.
It turn out, majority of usage of ENOTSUP (~1000) in drivers is correct and we are just using the wrong return code in a few places mostly on the the APIs level and in a few headers only.

This resolves #23727 