### PR TITLE
aarch64: smp: make the cross-CPU swap_ptables call use its own IPI

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -996,7 +996,7 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	} else {
 #ifdef CONFIG_SMP
 		/* the thread could be running on another CPU right now */
-		arch_sched_ipi();
+		z_arm64_ptable_ipi();
 #endif
 	}
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -24,6 +24,7 @@
 #include <sys/arch_interface.h>
 
 #define SGI_SCHED_IPI	0
+#define SGI_PTABLE_IPI	1
 
 volatile struct {
 	void *sp; /* Fixed at the first entry */
@@ -71,6 +72,9 @@ void z_arm64_secondary_start(void)
 	arm_gic_secondary_init();
 
 	irq_enable(SGI_SCHED_IPI);
+#ifdef CONFIG_USERSPACE
+	irq_enable(SGI_PTABLE_IPI);
+#endif
 #endif
 
 	fn = arm64_cpu_init[cpu_num].fn;
@@ -88,17 +92,21 @@ void z_arm64_secondary_start(void)
 }
 
 #ifdef CONFIG_SMP
+
+static void broadcast_ipi(unsigned int ipi)
+{
+	const uint64_t mpidr = GET_MPIDR();
+
+	/*
+	 * Send SGI to all cores except itself
+	 * Note: Assume only one Cluster now.
+	 */
+	gic_raise_sgi(ipi, mpidr, SGIR_TGT_MASK & ~(1 << MPIDR_TO_CORE(mpidr)));
+}
+
 void sched_ipi_handler(const void *unused)
 {
 	ARG_UNUSED(unused);
-
-#ifdef CONFIG_USERSPACE
-	/*
-	 * Make sure a domain switch by another CPU is effective on this CPU.
-	 * This is a no-op if the page table is already the right one.
-	 */
-	z_arm64_swap_ptables(_current);
-#endif
 
 	z_sched_ipi();
 }
@@ -106,13 +114,26 @@ void sched_ipi_handler(const void *unused)
 /* arch implementation of sched_ipi */
 void arch_sched_ipi(void)
 {
-	const uint64_t mpidr = GET_MPIDR();
-	/*
-	 * Send SGI to all cores except itself
-	 * Note: Assume only one Cluster now.
-	 */
-	gic_raise_sgi(SGI_SCHED_IPI, mpidr, SGIR_TGT_MASK & ~(1 << MPIDR_TO_CORE(mpidr)));
+	broadcast_ipi(SGI_SCHED_IPI);
 }
+
+#ifdef CONFIG_USERSPACE
+void ptable_ipi_handler(const void *unused)
+{
+	ARG_UNUSED(unused);
+
+	/*
+	 * Make sure a domain switch by another CPU is effective on this CPU.
+	 * This is a no-op if the page table is already the right one.
+	 */
+	z_arm64_swap_ptables(_current);
+}
+
+void z_arm64_ptable_ipi(void)
+{
+	broadcast_ipi(SGI_PTABLE_IPI);
+}
+#endif
 
 static int arm64_smp_init(const struct device *dev)
 {
@@ -123,10 +144,15 @@ static int arm64_smp_init(const struct device *dev)
 	 * option
 	 */
 	IRQ_CONNECT(SGI_SCHED_IPI, IRQ_DEFAULT_PRIORITY, sched_ipi_handler, NULL, 0);
-
 	irq_enable(SGI_SCHED_IPI);
+
+#ifdef CONFIG_USERSPACE
+	IRQ_CONNECT(SGI_PTABLE_IPI, IRQ_DEFAULT_PRIORITY, ptable_ipi_handler, NULL, 0);
+	irq_enable(SGI_PTABLE_IPI);
+#endif
 
 	return 0;
 }
 SYS_INIT(arm64_smp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
 #endif

--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -42,6 +42,7 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 extern void z_arm64_fatal_error(z_arch_esf_t *esf, unsigned int reason);
 extern void z_arm64_userspace_enter(z_arch_esf_t *esf);
 extern void z_arm64_set_ttbr0(uintptr_t ttbr0);
+extern void z_arm64_ptable_ipi(void);
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
Let's disentangle this from arch_sched_ipi() with an SGI for its
own purpose.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
