### PR TITLE
arc/swap: move registers load operation after sys trace call.

### DIFF
--- a/arch/arc/core/swap.S
+++ b/arch/arc/core/swap.S
@@ -179,9 +179,11 @@ return_loc:
 #ifdef CONFIG_TRACING
 	push_s blink
 	push_s r1
+	push_s r0
 
 	bl sys_trace_thread_switched_in
 
+	pop_s r0
 	pop_s r1
 	pop_s blink
 #endif


### PR DESCRIPTION
when enable tracing, the register r0 which saves the return value
of __swap will be changed by sys_trace_thread_switched_in function,
casuing some unexpected return value, so add operation to save register
r0 value.

fix: #33649 

Signed-off-by: peng1 chen <peng1.chen@intel.com>