### PR TITLE
drivers: clock_control of the stm32mp1 remove unknown bits

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -243,7 +243,6 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		case LL_APB3_GRP1_PERIPH_SYSCFG:
 		case LL_APB3_GRP1_PERIPH_VREF:
 		case LL_APB3_GRP1_PERIPH_TMPSENS:
-		case LL_APB3_GRP1_PERIPH_PMBCTRL:
 		case LL_APB3_GRP1_PERIPH_HDP:
 		default:
 			return -ENOTSUP;
@@ -342,7 +341,6 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		case LL_AHB5_GRP1_PERIPH_CRYP1:
 		case LL_AHB5_GRP1_PERIPH_HASH1:
 		case LL_AHB5_GRP1_PERIPH_BKPSRAM:
-		case LL_AHB5_GRP1_PERIPH_AXIMC:
 		default:
 			return -ENOTSUP;
 		}


### PR DESCRIPTION
The bit RCC_MC_APB3ENSETR_PMBCTRL and RCC_MC_AHB5ENSETR_AXIMC
does not exist in the stm32mp1xx ref manual anymore.
They are not present in the stm32mp1xx_ll_bus.h (v1.4.0).

This patch is required to avoid compilation error with the stm32cubemp1 V1.4.0

Signed-off-by: Francois Ramu <francois.ramu@st.com>