### PR TITLE
Add support for flash controller with XIP on i.MX RT series

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -21,6 +21,10 @@ zephyr_library_sources_ifdef(CONFIG_FLASH_STM32_QSPI flash_stm32_qspi.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_MCUX_FLEXSPI_NOR flash_mcux_flexspi_nor.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_ESP32 flash_esp32.c)
 
+if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+  zephyr_code_relocate(flash_mcux_flexspi_nor.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
+endif()
+
 if(CONFIG_SOC_FLASH_STM32)
   if(CONFIG_SOC_SERIES_STM32H7X)
     zephyr_sources_ifdef(CONFIG_SOC_SERIES_STM32H7X flash_stm32h7x.c)

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -34,6 +34,15 @@ config FLASH_MCUX_FLEXSPI_NOR
 	select MEMC
 	select MEMC_MCUX_FLEXSPI
 
+config FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
+	bool "MCUX FlexSPI NOR write RAM buffer"
+	default y
+	depends on FLASH_MCUX_FLEXSPI_NOR
+	help
+	  Copy the data to a RAM buffer before writing it to the flash.
+	  This prevents faults when the data to write would be located on the
+	  flash itself.
+
 config FLASH_MCUX_FLEXSPI_XIP
 	bool "MCUX FlexSPI flash access with xip"
 	depends on MEMC_MCUX_FLEXSPI

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -34,4 +34,38 @@ config FLASH_MCUX_FLEXSPI_NOR
 	select MEMC
 	select MEMC_MCUX_FLEXSPI
 
+config FLASH_MCUX_FLEXSPI_XIP
+	bool "MCUX FlexSPI flash access with xip"
+	depends on MEMC_MCUX_FLEXSPI
+	depends on (CODE_FLEXSPI || CODE_FLEXSPI2)
+	select XIP
+	select CODE_DATA_RELOCATION
+	help
+	  Allows using the flash API while running in XIP.
+	  WARNING: It is possible to overwrite the running application itself.
+
+if FLASH_MCUX_FLEXSPI_XIP
+
+choice FLASH_MCUX_FLEXSPI_XIP_MEM_TARGET
+	prompt "FlexSPI drivers relocation target"
+	default FLASH_MCUX_FLEXSPI_XIP_MEM_ITCM
+	help
+	  Select the location to run the FlexSPI drivers when using
+	  the flash API.
+
+config FLASH_MCUX_FLEXSPI_XIP_MEM_ITCM
+	bool "ITCM"
+
+config FLASH_MCUX_FLEXSPI_XIP_MEM_SRAM
+	bool "SRAM"
+
+endchoice
+
+config FLASH_MCUX_FLEXSPI_XIP_MEM
+	string
+	default "ITCM" if FLASH_MCUX_FLEXSPI_XIP_MEM_ITCM
+	default "SRAM" if FLASH_MCUX_FLEXSPI_XIP_MEM_SRAM
+
+endif # FLASH_MCUX_FLEXSPI_XIP
+
 endif # HAS_MCUX_FLEXSPI

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -19,6 +19,10 @@
 #define NOR_WRITE_SIZE	1
 #define NOR_ERASE_VALUE	0xff
 
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
+static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
+#endif
+
 LOG_MODULE_REGISTER(flash_flexspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 enum {
@@ -346,8 +350,15 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 
 	while (len) {
 		i = MIN(SPI_NOR_PAGE_SIZE, len);
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
+		memcpy(nor_write_buf, src, i);
+#endif
 		flash_flexspi_nor_write_enable(dev);
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
+		flash_flexspi_nor_page_program(dev, offset, nor_write_buf, i);
+#else
 		flash_flexspi_nor_page_program(dev, offset, src, i);
+#endif
 		flash_flexspi_nor_wait_bus_busy(dev);
 		memc_flexspi_reset(data->controller);
 		src += i;

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -350,6 +350,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		flash_flexspi_nor_page_program(dev, offset, src, i);
 		flash_flexspi_nor_wait_bus_busy(dev);
 		memc_flexspi_reset(data->controller);
+		src += i;
 		offset += i;
 		len -= i;
 	}

--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -6,3 +6,7 @@ zephyr_linker_sources_ifdef(CONFIG_MEMC_STM32_SDRAM SECTIONS memc_stm32_sdram.ld
 
 zephyr_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI memc_mcux_flexspi.c)
 zephyr_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI_HYPERRAM memc_mcux_flexspi_hyperram.c)
+
+if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+  zephyr_code_relocate(memc_mcux_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
+endif()

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <fsl_flexspi.h>
 
+bool memc_flexspi_is_running_xip(const struct device *dev);
+
 int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
 		const uint32_t *cmd, uint32_t count);
 

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -17,5 +17,7 @@
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [ef 40 16];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 	};
 };

--- a/dts/bindings/mtd/nxp,imx-flexspi-nor.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-nor.yaml
@@ -5,4 +5,4 @@ description: NXP FlexSPI NOR
 
 compatible: "nxp,imx-flexspi-nor"
 
-include: nxp,imx-flexspi-device.yaml
+include: ["nxp,imx-flexspi-device.yaml", soc-nv-flash.yaml]

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -9,6 +9,7 @@ config SOC_SERIES
 	default "rt"
 
 config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
 config CAN_MCUX_FLEXCAN

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -385,6 +385,7 @@ config IPG_DIV
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
 	bool "Enable the boot header"
+	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the
 	  application from an external flash device.
@@ -448,11 +449,11 @@ config CODE_ITCM
 
 config CODE_FLEXSPI
 	bool "Link code into external FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER
+	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_FLEXSPI2
 	bool "Link code into internal FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER
+	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 endchoice
 

--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -216,7 +216,9 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetMux(kCLOCK_CanMux, 2); /* Set Can clock source. */
 #endif
 
-#if defined(CONFIG_MEMC_MCUX_FLEXSPI) && DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
+#if !(defined(CONFIG_CODE_FLEXSPI) || defined(CONFIG_CODE_FLEXSPI2)) && \
+	defined(CONFIG_MEMC_MCUX_FLEXSPI) && \
+	DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
 	CLOCK_DisableClock(kCLOCK_FlexSpi);
 	CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 24);
 	CLOCK_SetMux(kCLOCK_FlexspiMux, 3);

--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127
       path: tools/net-tools
     - name: hal_nxp
-      revision: 4560b0a0106bbe47eded4d7af775998c4f6d05c0
+      revision: 27a464e4885f393dc376a53d9fc8d52078848496
       path: modules/hal/nxp
     - name: open-amp
       revision: de1b85a13032a2de1d8b6695ae5f800b613e739d


### PR DESCRIPTION
This change allows writing to the flash while running in XIP mode, and enables `mcuboot` or NVS settings to be used on i.MX RT socs with a single flash chip.
The bootloader application itself should contain the IVT/DCD in the header, but the chainable application doesn't.
The ROM_START_OFFSET defaults to 0x400 otherwise the linker alignment isn't taken into account.

It is required when running with XIP to enable code relocation, because accessing the flash needs to run in RAM.

Tested on i.MX RT1064 internal flash