### PR TITLE
actions: backport: Update to 1.1.1-1 and enable issue creation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: zephyrproject-rtos/action-backport@v1.1.99
+        uses: zephyrproject-rtos/action-backport@v1.1.1-1
         with:
           github_token: ${{ secrets.ZB_GITHUB_TOKEN }}
+          issue_labels: bug, backport


### PR DESCRIPTION
Update the backport action to 1.1.1-1, which adds support for issue
creation when a backport fails.
In our case, label the issue with the "backport" and "bug" labels.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>