### PR TITLE
actions: manifest: Pin to v1.0.0

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@main
+        uses: zephyrproject-rtos/action-manifest@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'


### PR DESCRIPTION
In order to develop further functionality in the action-manifest repo,
pin the version to v1.0.0 here.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>