### PR TITLE
mps2_an521_nonsecure: set up running samples and tests in CI

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -15,6 +15,14 @@ config BOARD
 	default "mps2_an521_nonsecure" if TRUSTED_EXECUTION_NONSECURE
 	default "mps2_an521"
 
+# By default, if we build for a Non-Secure version of the board,
+# force building with TF-M as the Secure Execution Environment.
+# Openamp samples assume the non-secure build is the remote
+# core image, so do not build with TF-M in this case.
+config BUILD_WITH_TFM
+	default y if TRUSTED_EXECUTION_NONSECURE && !OPENAMP
+
+
 if GPIO
 
 config GPIO_CMSDK_AHB

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -11,3 +11,12 @@ set(QEMU_FLAGS_${ARCH}
   -vga none
   )
 board_set_debugger_ifnset(qemu)
+
+if (CONFIG_BUILD_WITH_TFM AND NOT CONFIG_OPENAMP)
+  # Override the binary used by qemu, to use the combined
+  # TF-M (Secure) & Zephyr (Non Secure) image (when running
+  # in-tree tests).
+  # Openamp samples assume the non-secure build is the remote
+  # core image, so do not use the merged .hex in this case.
+  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_merged.hex")
+endif()

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
@@ -10,4 +10,7 @@ toolchain:
 testing:
   default: true
   only_tags:
+     - arm
+     - kernel
      - tfm
+     - userspace

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -310,6 +310,14 @@ HALs
 * HALs are now moved out of the main tree as external modules and reside in
   their own standalone repositories.
 
+
+Trusted Firmware-m
+******************
+
+* Configured QEMU to run Zephyr samples and tests in CI on mps2_an521_nonsecure
+  (Cortex-M33 Non-Secure) with TF-M as the secure firmware component.
+
+
 Documentation
 *************
 

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -51,13 +51,19 @@ static void trigger_fault_illegal_instruction(void)
 
 static void trigger_fault_access(void)
 {
-#if defined(CONFIG_SOC_ARC_IOT) || defined(CONFIG_SOC_NSIM) || defined(CONFIG_CPU_CORTEX_M)
+#if defined(CONFIG_SOC_ARC_IOT) || defined(CONFIG_SOC_NSIM)
 	/* For iotdk and ARC/nSIM, nSIM simulates full address space of memory,
 	 * so all accesses outside of CCMs are valid and access to 0x0 address
 	 * doesn't generate any exception.So we access it 0XFFFFFFFF instead to
 	 * trigger exception. See issue #31419.
 	 */
 	void *a = (void *)0xFFFFFFFF;
+#elif defined(CONFIG_CPU_CORTEX_M)
+	/* As this test case only runs when User Mode is enabled,
+	 * accessing _current always triggers a memory access fault,
+	 * and is guaranteed not to trigger SecureFault exceptions.
+	 */
+	void *a = (void *)_current;
 #else
 	/* For most arch which support userspace, dereferencing NULL
 	 * pointer will be caught by exception.
@@ -225,7 +231,7 @@ static int run_trigger_thread(int i)
  */
 void test_catch_fatal_error(void)
 {
-#if defined(CONFIG_ARCH_HAS_USERSPACE)
+#if defined(CONFIG_USERSPACE)
 	run_trigger_thread(ZTEST_CATCH_FATAL_ACCESS);
 	run_trigger_thread(ZTEST_CATCH_FATAL_ILLEAGAL_INSTRUCTION);
 	run_trigger_thread(ZTEST_CATCH_FATAL_DIVIDE_ZERO);


### PR DESCRIPTION
Allow samples and tests tagged with `-arm` and `-kernel` tags to build and run for Cortex-M33 Non-Secure. The QEMU target is `mps2_an521_nonsecure`.
- this will prevent developers from introducing new or modifying existing test-cases that - by design - cannot run on non-secure domains
- the focus is on Cortex-M specific ARCH tests, as well as userspace tests.
- Non-secure builds need to be combined with TF-M as the secure component; this is set up by default on mps2_an521_nonsecure