### PR TITLE
drivers: nrf: uarte: rx flush amount calculation

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1155,7 +1155,7 @@ static uint8_t rx_flush(const struct device *dev, uint8_t *buf, uint32_t len)
 		return rx_amount;
 	}
 
-	for (int i = 0; i < 0; i++) {
+	for (int i = 0; i < flush_len; i++) {
 		if (buf[i] != dirty) {
 			return rx_amount;
 		}


### PR DESCRIPTION
The NRF UARTE has an undocumented feature that when you flush the RX
FIFO, the RXAMOUNT register is not cleared to zero if the FIFO is in
fact empty. This fix is correcting something that was most likely a
typo.

Signed-off-by: Petri Oksanen <petri@iote.ai>