### PR TITLE
soc: stm32l5: Don't disable PWR clock in soc init.

### DIFF
--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -46,7 +46,6 @@ static int stm32l5_init(const struct device *arg)
 	/* Enable Scale 0 to achieve 110MHz */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
-	LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_PWR);
 
 	return 0;
 }


### PR DESCRIPTION
PWR clock is required for various operations.
It is enabled by default in clock control driver,
but disabled at clock init.
It appears soc init is run after clock control driver init
and hence PWR is disabled to to this piece of code at
soc init level.
Don't disable PWR here.
(But keep PWR clock enable in case of ...).

A whole clock clean up will be required later on,
but waiting for that to happen, this is the safest we can do.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>