### PR TITLE
linker-defs: Fix sorting order of objects by priority

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -1040,7 +1040,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)"_"))) = { \
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\

--- a/include/init.h
+++ b/include/init.h
@@ -85,7 +85,7 @@ void z_sys_init_run_level(int32_t _level);
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
 		_CONCAT(__init_, _entry_name) __used			\
-	__attribute__((__section__(".init_" #_level STRINGIFY(_prio)))) = { \
+	__attribute__((__section__(".init_" #_level STRINGIFY(_prio)"_"))) = { \
 		.init = (_init_fn),					\
 		.dev = (_device),					\
 	}

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -116,8 +116,8 @@
  */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.object##_##level[0-9]*)));		\
-		KEEP(*(SORT(.object##_##level[1-9][0-9]*)));
+		KEEP(*(SORT(.object##_##level[0-9]_*)));		\
+		KEEP(*(SORT(.object##_##level[1-9][0-9]_*)));
 
 /*
  * link in shell initialization objects for all modules that use shell and


### PR DESCRIPTION
Commit 0a7b65e tweaked the CREATE_OBJ_LEVEL macro in such a way that it would break the expected sorting order.

For example if you had 2, 19, 20, 30 as the level, we'd end up sort these to be 19, 2, 20, 30.

Fix this by adding aditional "_" symbol after the init level counter and before the `*` wildcard. That allows to keep correct sort order (for both GNU and MWDT toolchains) and distinguish init level counter from section suffix (for MWDT toolchain).

Fixes zephyrproject-rtos#33464