### PR TITLE
dts: nxp: kinetis: Add chip specific dtsi files

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_k2x.dtsi>
+#include <nxp/MK22FN512VLH12.dtsi>
 #include <dt-bindings/pwm/pwm.h>
 
 / {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_k6x.dtsi>
+#include <nxp/MK64FN1M0VLL12.dtsi>
 
 / {
 	model = "NXP Freedom MK64F board";

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <mem.h>
-#include <nxp/nxp_k82fn256vxx15.dtsi>
+#include <nxp/MK82FN256VLL15.dtsi>
 #include <dt-bindings/pwm/pwm.h>
 
 / {

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_kl25z.dtsi>
+#include <nxp/MKL25Z128VLK4.dtsi>
 
 / {
 	model = "NXP Freedom KL25Z board";

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_kw41z.dtsi>
+#include <nxp/MKW41Z512VHT4.dtsi>
 
 / {
 	model = "NXP Freedom KW41Z board";

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_k6x.dtsi>
+#include <nxp/MK64FN1M0VDC12.dtsi>
 #include <dt-bindings/pwm/pwm.h>
 
 / {

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_kw40z.dtsi>
+#include <nxp/MKW40Z160VHT4.dtsi>
 
 / {
 	model = "Hexiwear KW40 board";

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_k66.dtsi>
+#include <nxp/MK66FN2M0VMD18.dtsi>
 
 / {
 	model = "SEGGER MK66F IP Switch board";

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_ke18f512vlx16.dtsi>
+#include <nxp/MKE18F512VLL16.dtsi>
 #include <dt-bindings/clock/kinetis_scg.h>
 #include <dt-bindings/pwm/pwm.h>
 

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_kv58f1m0vlx24.dtsi>
+#include <nxp/MKV58F1M0VLQ24.dtsi>
 
 / {
 	model = "NXP Kinetis KV58 MCU Tower System Module";

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_kw2xd.dtsi>
+#include <nxp/MKW24D512VHA5.dtsi>
 
 / {
 	model = "NXP USB-KW24D512 board";

--- a/dts/arm/nxp/MK22FN512VLH12.dtsi
+++ b/dts/arm/nxp/MK22FN512VLH12.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k2x.dtsi>

--- a/dts/arm/nxp/MK64FN1M0VDC12.dtsi
+++ b/dts/arm/nxp/MK64FN1M0VDC12.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k6x.dtsi>

--- a/dts/arm/nxp/MK64FN1M0VLL12.dtsi
+++ b/dts/arm/nxp/MK64FN1M0VLL12.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k6x.dtsi>

--- a/dts/arm/nxp/MK66FN2M0VMD18.dtsi
+++ b/dts/arm/nxp/MK66FN2M0VMD18.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k66.dtsi>

--- a/dts/arm/nxp/MK82FN256VLL15.dtsi
+++ b/dts/arm/nxp/MK82FN256VLL15.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k82fn256vxx15.dtsi>

--- a/dts/arm/nxp/MKE18F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE18F512VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke18f512vlx16.dtsi>

--- a/dts/arm/nxp/MKL25Z128VLK4.dtsi
+++ b/dts/arm/nxp/MKL25Z128VLK4.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_kl25z.dtsi>

--- a/dts/arm/nxp/MKV58F1M0VLQ24.dtsi
+++ b/dts/arm/nxp/MKV58F1M0VLQ24.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_kv58f1m0vlx24.dtsi>

--- a/dts/arm/nxp/MKW24D512VHA5.dtsi
+++ b/dts/arm/nxp/MKW24D512VHA5.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_kw2xd.dtsi>

--- a/dts/arm/nxp/MKW40Z160VHT4.dtsi
+++ b/dts/arm/nxp/MKW40Z160VHT4.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_kw40z.dtsi>

--- a/dts/arm/nxp/MKW41Z512VHT4.dtsi
+++ b/dts/arm/nxp/MKW41Z512VHT4.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_kw41z.dtsi>


### PR DESCRIPTION
Add dts files for the specific chip instances that are used on the
boards in prep of having pin data in devicetree.  The pin data will
be specific to the given chip instance so we need to distinguish
unique chips for the same SoC as the pin mux will differ.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>