### PR TITLE
tests: device: tweak test to test linker sorting

### DIFF
--- a/tests/kernel/device/src/test_driver_init.c
+++ b/tests/kernel/device/src/test_driver_init.c
@@ -150,6 +150,14 @@ DEVICE_DEFINE(my_driver_level_4, MY_DRIVER_LV_4, &my_driver_lv_4_init,
 		device_pm_control_nop, NULL, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
+/* We use priority value of 20 to create a possible sorting conflict with
+ * priority value of 2.  So if the linker sorting isn't woring correctly
+ * we'll find out.
+ */
+DEVICE_DEFINE(my_driver_priority_4, MY_DRIVER_PRI_4,
+		&my_driver_pri_4_init, device_pm_control_nop,
+		NULL, NULL, POST_KERNEL, 20, &funcs_my_drivers);
+
 DEVICE_DEFINE(my_driver_priority_1, MY_DRIVER_PRI_1,
 		&my_driver_pri_1_init, device_pm_control_nop,
 		NULL, NULL, POST_KERNEL, 1, &funcs_my_drivers);
@@ -161,7 +169,3 @@ DEVICE_DEFINE(my_driver_priority_2, MY_DRIVER_PRI_2,
 DEVICE_DEFINE(my_driver_priority_3, MY_DRIVER_PRI_3,
 		&my_driver_pri_3_init, device_pm_control_nop,
 		NULL, NULL, POST_KERNEL, 3, &funcs_my_drivers);
-
-DEVICE_DEFINE(my_driver_priority_4, MY_DRIVER_PRI_4,
-		&my_driver_pri_4_init, device_pm_control_nop,
-		NULL, NULL, POST_KERNEL, 4, &funcs_my_drivers);


### PR DESCRIPTION
There was a linker script change the broke the sorting such that
priority 2 and 20 would not necessary get sorted correctly.  Modify
the test to try and catch any such issues in the future.

We modify the DEVICE_DEFINE of the larger priority first, so if the
linker isn't sorting it would get linked first in theory, and we also
tweak the priority value from 4 to 20 so if we aren't sorting correctly
between 2 and 20 we'll catch that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>