### PR TITLE
Bluetooth: ATT: Fix crash if bt_l2cap_send_cb fails

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -130,6 +130,13 @@ void att_sent(struct bt_conn *conn, void *user_data)
 	}
 }
 
+/* In case of success the ownership of the buffer is transferred to the stack
+ * which takes care of releasing it when it completes transmitting to the
+ * controller.
+ *
+ * In case bt_l2cap_send_cb fails the buffer state and ownership are retained
+ * so the buffer can be safely pushed back to the queue to be processed later.
+ */
 static int chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 		     bt_att_chan_sent_t cb)
 {


### PR DESCRIPTION
This fixes a regression introduced by
10841b9a14b748a34c05cdebf0e9a278433a6ddc as it did remove a call to
net_buf_ref which was used not only to keep a reference for resending
but also to prevent bt_l2cap_send_cb to unref the buffer in case it
fails.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>