### PR TITLE
tests/bluetooth/tester: fix build with BT_SMP_SC_ONLY

### DIFF
--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -274,7 +274,7 @@ static void oob_data_request(struct bt_conn *conn,
 
 		return;
 	}
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
+#else /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
 	LOG_DBG("Legacy OOB TK requested from remote %s", log_strdup(addr));
 
@@ -282,6 +282,7 @@ static void oob_data_request(struct bt_conn *conn,
 	if (err < 0) {
 		LOG_ERR("Failed to set OOB Temp Key: %d", err);
 	}
+#endif
 }
 
 #if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)


### PR DESCRIPTION
bt_le_oob_set_legacy_tk is not defined with this setting and this code is reachable only
for legacy pairing

signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>