### PR TITLE
Enabling I2C for STM32F2 platforms

### DIFF
--- a/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
@@ -35,5 +35,6 @@
 	};
 };
 
+arduino_i2c: &i2c1 {};
 arduino_spi: &spi1 {};
 arduino_serial: &usart6 {};

--- a/boards/arm/nucleo_f207zg/doc/index.rst
+++ b/boards/arm/nucleo_f207zg/doc/index.rst
@@ -86,6 +86,8 @@ The Zephyr nucleo_207zg board configuration supports the following hardware feat
 +-------------+------------+-------------------------------------+
 | ETHERNET    | on-chip    | Ethernet                            |
 +-------------+------------+-------------------------------------+
+| I2C         | on-chip    | i2c                                 |
++-------------+------------+-------------------------------------+
 | USB         | on-chip    | USB device                          |
 +-------------+------------+-------------------------------------+
 | SPI         | on-chip    | spi                                 |
@@ -141,6 +143,7 @@ Default Zephyr Peripheral Mapping:
 
 - UART_3 TX/RX : PD8/PD9 (ST-Link Virtual Port Com)
 - UART_6 TX/RX : PG14/PG9 (Arduino Serial)
+- I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
 - SPI1 NSS/SCK/MISO/MOSI : PA4/PA5/PA6/PA7 (Arduino SPI)
 - ETH : PA1, PA2, PA7, PB13, PC1, PC4, PC5, PG11, PG13
 - USB_DM : PA11

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -58,6 +58,12 @@
 	status = "okay";
 };
 
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -10,7 +10,9 @@ toolchain:
   - xtools
 supported:
   - arduino_gpio
+  - arduino_i2c
   - arduino_spi
+  - i2c
   - spi
   - gpio
   - usb_device

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -7,6 +7,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/stm32_clock.h>
+#include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -260,6 +261,45 @@
 			interrupts = <51 5>;
 			status = "disabled";
 			label = "SPI_3";
+		};
+
+		i2c1: i2c@40005400 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
+			interrupts = <31 0>, <32 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label= "I2C_1";
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label= "I2C_2";
+		};
+
+		i2c3: i2c@40005c00 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			interrupts = <72 0>, <73 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label= "I2C_3";
 		};
 
 		usbotg_fs: usb@50000000 {


### PR DESCRIPTION
These commits enable I2C for STM32F2 platforms.
The same has been tested using MPU6050 sample application on I2C-1.