### PR TITLE
[TOPIC-BLE-LLCP] Adding support for test-specific kconfig

### DIFF
--- a/tests/bluetooth/controller/common/defaults_cmake.txt
+++ b/tests/bluetooth/controller/common/defaults_cmake.txt
@@ -3,6 +3,7 @@
 #
 
 include_directories(
+        src
         ${ZEPHYR_BASE}/tests/bluetooth/controller/mock_ctrl/include
         ${ZEPHYR_BASE}/tests/bluetooth/controller/common/include
         ${ZEPHYR_BASE}/include/bluetooth
@@ -54,5 +55,9 @@ FILE(GLOB common_sources
 )
 
 add_definitions(-include kconfig.h)
+if(KCONFIG_OVERRIDE_FILE)
+  add_definitions(-include ${KCONFIG_OVERRIDE_FILE})
+endif()
+
 add_definitions(-include ztest.h)
 add_definitions(-include soc.h)


### PR DESCRIPTION
Adding 'extra_args: KCONFIG_OVERRIDE_FILE=<file>' to testcase.yaml
will result in <file> being included after mock_ctrl/include/kconfig.h
This allows test specific allows override of kconfigs

Signed-off-by: Erik Brockhoff <erbr@oticon.com>