### PR TITLE
tfm: Fix TFM_BOARD for MUSCA_B1

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -15,7 +15,7 @@ config TFM_BOARD
 	default "mps2/an521" if BOARD_MPS2_AN521
 	default "stm/nucleo_l552ze_q" if BOARD_NUCLEO_L552ZE_Q
 	default "stm/stm32l562e_dk" if BOARD_STM32L562E_DK
-	default "musca_b1" if BOARD_MUSCA_B1
+	default "musca_b1/sse_200" if BOARD_MUSCA_B1
 	default "musca_s1" if BOARD_MUSCA_S1
 	help
 	  The board name used for building TFM. Building with TFM requires that

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -7,7 +7,7 @@ tests:
         tags: introduction tfm
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns
           nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns nucleo_l552ze_q_ns
-          stm32l562e_dk_ns v2m_musca_s1_nonsecure
+          stm32l562e_dk_ns v2m_musca_s1_nonsecure v2m_musca_b1_nonsecure
         harness: console
         harness_config:
           type: multi_line


### PR DESCRIPTION
Also add it to tfm_ipc so it is built by CI

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>