### PR TITLE
boards: particle_*: fix antenna initialization

### DIFF
--- a/boards/arm/particle_argon/board.c
+++ b/boards/arm/particle_argon/board.c
@@ -49,6 +49,7 @@ static int board_particle_argon_init(const struct device *dev)
 	return 0;
 }
 
-/* needs to be done after GPIO driver init */
-SYS_INIT(board_particle_argon_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* needs to be done after GPIO driver init, which is at
+ * POST_KERNEL:KERNEL_INIT_PRIORITY_DEFAULT.
+ */
+SYS_INIT(board_particle_argon_init, POST_KERNEL, 99);

--- a/boards/arm/particle_boron/board.c
+++ b/boards/arm/particle_boron/board.c
@@ -56,6 +56,7 @@ static int board_particle_boron_init(const struct device *dev)
 	return 0;
 }
 
-/* needs to be done after GPIO driver init */
-SYS_INIT(board_particle_boron_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* needs to be done after GPIO driver init, which is at
+ * POST_KERNEL:KERNEL_INIT_PRIORITY_DEFAULT.
+ */
+SYS_INIT(board_particle_boron_init, POST_KERNEL, 99);

--- a/boards/arm/particle_xenon/board.c
+++ b/boards/arm/particle_xenon/board.c
@@ -49,6 +49,7 @@ static int board_particle_xenon_init(const struct device *dev)
 	return 0;
 }
 
-/* needs to be done after GPIO driver init */
-SYS_INIT(board_particle_xenon_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* needs to be done after GPIO driver init, which is at
+ * POST_KERNEL:KERNEL_INIT_PRIORITY_DEFAULT.
+ */
+SYS_INIT(board_particle_xenon_init, POST_KERNEL, 99);


### PR DESCRIPTION
The GPIO drivers are initialized in the POST_KERNEL level with the
default priority, so whether they're available at the time the sysinit
function requires them depends on how the linker orders the init
records.  Since we can't set a priority relative to the default
priority, hard-code the maximum priority and hope it's good enough.

Relates to #24416