### PR TITLE
toolchain: xcc: nullify __deprecated macro

### DIFF
--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -138,4 +138,13 @@
 #define __builtin_unreachable() do { __ASSERT(false, "Unreachable code"); } \
 	while (true)
 
+#ifdef __deprecated
+/*
+ * XCC does not support using deprecated attribute in enum,
+ * so just nullify it here to avoid compilation errors.
+ */
+#undef __deprecated
+#define __deprecated
+#endif
+
 #endif


### PR DESCRIPTION
XCC does not support using the deprecated attribute for enum
as it is based on old GCC 4.2. So nullify the macro to avoid
compilation errors.

Fixes #33548

Signed-off-by: Daniel Leung <daniel.leung@intel.com>