### PR TITLE
testsuite: utils: move the interrupt_util.h into testsuite

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -9,6 +9,7 @@
 #include <irq.h>
 #include <tc_util.h>
 #include <sw_isr_table.h>
+#include <interrupt_util.h>
 
 extern uint32_t _irq_vector_table[];
 
@@ -76,37 +77,6 @@ extern uint32_t _irq_vector_table[];
 
 static volatile int trigger_check[TRIG_CHECK_SIZE];
 
-#if defined(CONFIG_CPU_CORTEX_M)
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-
-void trigger_irq(int irq)
-{
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
-	defined(CONFIG_SOC_TI_LM3S6965_QEMU)
-	/* QEMU does not simulate the STIR register: this is a workaround */
-	NVIC_SetPendingIRQ(irq);
-#else
-	NVIC->STIR = irq;
-#endif
-}
-#elif defined(CONFIG_RISCV)
-void trigger_irq(int irq)
-{
-	uint32_t mip;
-
-	__asm__ volatile ("csrrs %0, mip, %1\n"
-			  : "=r" (mip)
-			  : "r" (1 << irq));
-}
-#elif defined(CONFIG_ARC)
-void trigger_irq(int irq)
-{
-	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, irq);
-}
-#else
-/* So far, Nios II does not support this */
-#define NO_TRIGGER_FROM_SW
-#endif
 
 #ifdef HAS_DIRECT_IRQS
 ISR_DIRECT_DECLARE(isr1)

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -6,7 +6,7 @@
  */
 
 #include <ztest.h>
-#include "interrupt_util.h"
+#include <interrupt_util.h>
 
 /*
  * Run the nested interrupt test for the supported platforms only.

--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include "interrupt_util.h"
+#include <interrupt_util.h>
 
 #define DURATION	5
 #define HANDLER_TOKEN	0xDEADBEEF


### PR DESCRIPTION
The interrupt_util.h provides utils of trigger irq, now move them into
testsuite. All of the needed test cases can make use of them.

The tests/kernel/gen_isr_table and test/kernel/interrupt  testcases both need the function of triggering an interrupt.
Now try to move them info testsuite. Other test cases could also leverage this if necessary. 


Signed-off-by: Enjia Mai <enjiax.mai@intel.com>