### PR TITLE
Bluetooth: controller: Support for multiple CISes in a CIG

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -14,6 +14,7 @@ struct ll_conn_iso_stream {
 	struct lll_conn_iso_stream lll;
 	uint32_t sync_delay;
 	uint8_t  cis_id;
+	uint32_t offset;        /* Offset of CIS from ACL event in us */
 	uint8_t  established;	/* 0 if CIS has not yet been established.
 				 * 1 if CIS has been established and host
 				 * notified.

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -333,8 +333,6 @@ struct ll_conn {
 		uint32_t cis_offset_min;
 		uint32_t cis_offset_max;
 		uint16_t conn_event_count;
-		uint32_t cig_sync_delay;
-		uint32_t cis_sync_delay;
 	} llcp_cis;
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 };


### PR DESCRIPTION
When a CIS indication is received and CIG ticker is already started,
calculate the absolute time of the first subevent of the new CIS,
and validate the handle. This will allow the LLL prepare to see a new
valid CIS, and calculate the offset within the CIG event, where the new
CIS should start. This offset is then valid for all following events for
the duration of the CIS.

Signed-off-by: Morten Priess <mtpr@oticon.com>
