### PR TITLE
misc fixes: match implementation to prototype

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -54,7 +54,7 @@ int z_unpend_all(_wait_q_t *wait_q);
 void z_thread_priority_set(struct k_thread *thread, int prio);
 bool z_set_prio(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
-void idle(void *a, void *b, void *c);
+void idle(void *unused1, void *unused2, void *unused3);
 void z_time_slice(int ticks);
 void z_reset_time_slice(void);
 void z_sched_abort(struct k_thread *thread);
@@ -216,7 +216,7 @@ static inline bool z_is_prio_lower_or_equal(int prio1, int prio2)
 	return z_is_prio1_lower_than_or_equal_to_prio2(prio1, prio2);
 }
 
-int32_t z_sched_prio_cmp(struct k_thread *t1, struct k_thread *t2);
+int32_t z_sched_prio_cmp(struct k_thread *thread_1, struct k_thread *thread_2);
 
 static inline bool _is_valid_prio(int prio, void *entry_point)
 {

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -32,19 +32,19 @@ typedef int  FILE;
 #define stderr ((FILE *) 3)
 
 int __printf_like(1, 2) printf(const char *_MLIBC_RESTRICT fmt, ...);
-int __printf_like(3, 4) snprintf(char *_MLIBC_RESTRICT s, size_t len,
+int __printf_like(3, 4) snprintf(char *_MLIBC_RESTRICT str, size_t len,
 				 const char *_MLIBC_RESTRICT fmt, ...);
-int __printf_like(2, 3) sprintf(char *_MLIBC_RESTRICT s,
+int __printf_like(2, 3) sprintf(char *_MLIBC_RESTRICT str,
 				const char *_MLIBC_RESTRICT fmt, ...);
 int __printf_like(2, 3) fprintf(FILE * _MLIBC_RESTRICT stream,
 				const char *_MLIBC_RESTRICT format, ...);
 
 
 int __printf_like(1, 0) vprintf(const char *_MLIBC_RESTRICT fmt, va_list list);
-int __printf_like(3, 0) vsnprintf(char *_MLIBC_RESTRICT s, size_t len,
+int __printf_like(3, 0) vsnprintf(char *_MLIBC_RESTRICT str, size_t len,
 				  const char *_MLIBC_RESTRICT fmt,
 				  va_list list);
-int __printf_like(2, 0) vsprintf(char *_MLIBC_RESTRICT s,
+int __printf_like(2, 0) vsprintf(char *_MLIBC_RESTRICT str,
 				 const char *_MLIBC_RESTRICT fmt, va_list list);
 int __printf_like(2, 0) vfprintf(FILE * _MLIBC_RESTRICT stream,
 				 const char *_MLIBC_RESTRICT format,

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -31,21 +31,21 @@ typedef int  FILE;
 #define stdout ((FILE *) 2)
 #define stderr ((FILE *) 3)
 
-int __printf_like(1, 2) printf(const char *_MLIBC_RESTRICT fmt, ...);
+int __printf_like(1, 2) printf(const char *_MLIBC_RESTRICT format, ...);
 int __printf_like(3, 4) snprintf(char *_MLIBC_RESTRICT str, size_t len,
-				 const char *_MLIBC_RESTRICT fmt, ...);
+				 const char *_MLIBC_RESTRICT format, ...);
 int __printf_like(2, 3) sprintf(char *_MLIBC_RESTRICT str,
-				const char *_MLIBC_RESTRICT fmt, ...);
+				const char *_MLIBC_RESTRICT format, ...);
 int __printf_like(2, 3) fprintf(FILE * _MLIBC_RESTRICT stream,
 				const char *_MLIBC_RESTRICT format, ...);
 
 
-int __printf_like(1, 0) vprintf(const char *_MLIBC_RESTRICT fmt, va_list list);
+int __printf_like(1, 0) vprintf(const char *_MLIBC_RESTRICT format, va_list list);
 int __printf_like(3, 0) vsnprintf(char *_MLIBC_RESTRICT str, size_t len,
-				  const char *_MLIBC_RESTRICT fmt,
+				  const char *_MLIBC_RESTRICT format,
 				  va_list list);
 int __printf_like(2, 0) vsprintf(char *_MLIBC_RESTRICT str,
-				 const char *_MLIBC_RESTRICT fmt, va_list list);
+				 const char *_MLIBC_RESTRICT format, va_list list);
 int __printf_like(2, 0) vfprintf(FILE * _MLIBC_RESTRICT stream,
 				 const char *_MLIBC_RESTRICT format,
 				 va_list ap);

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -14,8 +14,8 @@
 extern "C" {
 #endif
 
-unsigned long int strtoul(const char *str, char **endptr, int base);
-long int strtol(const char *str, char **endptr, int base);
+unsigned long strtoul(const char *nptr, char **endptr, int base);
+long strtol(const char *nptr, char **endptr, int base);
 int atoi(const char *s);
 
 void *malloc(size_t size);

--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -28,7 +28,7 @@ extern int    strncmp(const char *s1, const char *s2, size_t n);
 extern char  *strtok_r(char *str, const char *sep, char **state);
 extern char *strcat(char *_MLIBC_RESTRICT dest,
 		    const char *_MLIBC_RESTRICT src);
-extern char  *strncat(char *_MLIBC_RESTRICT d, const char *_MLIBC_RESTRICT s,
+extern char  *strncat(char *_MLIBC_RESTRICT dest, const char *_MLIBC_RESTRICT src,
 		      size_t n);
 extern char *strstr(const char *s, const char *find);
 

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -123,10 +123,10 @@ void free(void *ptr)
 	ARG_UNUSED(ptr);
 }
 
-void *realloc(void *ptr, size_t requested_size)
+void *realloc(void *ptr, size_t size)
 {
 	ARG_UNUSED(ptr);
-	return malloc(requested_size);
+	return malloc(size);
 }
 #endif
 

--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -12,24 +12,24 @@
 
 #define DESC(d) ((void *)d)
 
-int fprintf(FILE *_MLIBC_RESTRICT F, const char *_MLIBC_RESTRICT format, ...)
+int fprintf(FILE *_MLIBC_RESTRICT stream, const char *_MLIBC_RESTRICT format, ...)
 {
 	va_list vargs;
 	int     r;
 
 	va_start(vargs, format);
-	r = cbvprintf(fputc, DESC(F), format, vargs);
+	r = cbvprintf(fputc, DESC(stream), format, vargs);
 	va_end(vargs);
 
 	return r;
 }
 
-int vfprintf(FILE *_MLIBC_RESTRICT F, const char *_MLIBC_RESTRICT format,
+int vfprintf(FILE *_MLIBC_RESTRICT stream, const char *_MLIBC_RESTRICT format,
 	     va_list vargs)
 {
 	int r;
 
-	r = cbvprintf(fputc, DESC(F), format, vargs);
+	r = cbvprintf(fputc, DESC(stream), format, vargs);
 
 	return r;
 }

--- a/lib/libc/minimal/source/stdout/sprintf.c
+++ b/lib/libc/minimal/source/stdout/sprintf.c
@@ -25,7 +25,7 @@ static int sprintf_out(int c, struct emitter *p)
 	return 0; /* indicate keep going so we get the total count */
 }
 
-int snprintf(char *_MLIBC_RESTRICT s, size_t len,
+int snprintf(char *_MLIBC_RESTRICT str, size_t len,
 	     const char *_MLIBC_RESTRICT format, ...)
 {
 	va_list vargs;
@@ -35,10 +35,10 @@ int snprintf(char *_MLIBC_RESTRICT s, size_t len,
 	char    dummy;
 
 	if (len == 0) {
-		s = &dummy; /* write final NUL to dummy, can't change *s */
+		str = &dummy; /* write final NUL to dummy, can't change *s */
 	}
 
-	p.ptr = s;
+	p.ptr = str;
 	p.len = (int) len;
 
 	va_start(vargs, format);
@@ -49,14 +49,14 @@ int snprintf(char *_MLIBC_RESTRICT s, size_t len,
 	return r;
 }
 
-int sprintf(char *_MLIBC_RESTRICT s, const char *_MLIBC_RESTRICT format, ...)
+int sprintf(char *_MLIBC_RESTRICT str, const char *_MLIBC_RESTRICT format, ...)
 {
 	va_list vargs;
 
 	struct emitter p;
 	int     r;
 
-	p.ptr = s;
+	p.ptr = str;
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
 	va_start(vargs, format);
@@ -67,7 +67,7 @@ int sprintf(char *_MLIBC_RESTRICT s, const char *_MLIBC_RESTRICT format, ...)
 	return r;
 }
 
-int vsnprintf(char *_MLIBC_RESTRICT s, size_t len,
+int vsnprintf(char *_MLIBC_RESTRICT str, size_t len,
 	      const char *_MLIBC_RESTRICT format, va_list vargs)
 {
 	struct emitter p;
@@ -75,10 +75,10 @@ int vsnprintf(char *_MLIBC_RESTRICT s, size_t len,
 	char    dummy;
 
 	if (len == 0) {
-		s = &dummy; /* write final NUL to dummy, can't change * *s */
+		str = &dummy; /* write final NUL to dummy, can't change * *s */
 	}
 
-	p.ptr = s;
+	p.ptr = str;
 	p.len = (int) len;
 
 	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);
@@ -87,13 +87,13 @@ int vsnprintf(char *_MLIBC_RESTRICT s, size_t len,
 	return r;
 }
 
-int vsprintf(char *_MLIBC_RESTRICT s, const char *_MLIBC_RESTRICT format,
+int vsprintf(char *_MLIBC_RESTRICT str, const char *_MLIBC_RESTRICT format,
 	     va_list vargs)
 {
 	struct emitter p;
 	int     r;
 
-	p.ptr = s;
+	p.ptr = str;
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
 	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -43,12 +43,12 @@ int fputc(int c, FILE *stream)
 	return zephyr_fputc(c, stream);
 }
 
-int fputs(const char *_MLIBC_RESTRICT string, FILE *_MLIBC_RESTRICT stream)
+int fputs(const char *_MLIBC_RESTRICT s, FILE *_MLIBC_RESTRICT stream)
 {
-	int len = strlen(string);
+	int len = strlen(s);
 	int ret;
 
-	ret = fwrite(string, 1, len, stream);
+	ret = fwrite(s, 1, len, stream);
 
 	return len == ret ? 0 : EOF;
 }
@@ -103,9 +103,9 @@ size_t fwrite(const void *_MLIBC_RESTRICT ptr, size_t size, size_t nitems,
 }
 
 
-int puts(const char *string)
+int puts(const char *s)
 {
-	if (fputs(string, stdout) == EOF) {
+	if (fputs(s, stdout) == EOF) {
 		return EOF;
 	}
 

--- a/lib/libc/minimal/source/time/gmtime.c
+++ b/lib/libc/minimal/source/time/gmtime.c
@@ -78,22 +78,22 @@ static void time_civil_from_days(bigint_type z,
  * applied to @p time before invoking this function.
  */
 struct tm *gmtime_r(const time_t *_MLIBC_RESTRICT timep,
-		    struct tm *_MLIBC_RESTRICT tp)
+		    struct tm *_MLIBC_RESTRICT result)
 {
 	time_t z = *timep;
 	bigint_type days = (z >= 0 ? z : z - 86399) / 86400;
 	unsigned int rem = z - days * 86400;
 
-	*tp = (struct tm){ 0 };
+	*result = (struct tm){ 0 };
 
-	time_civil_from_days(days, tp);
+	time_civil_from_days(days, result);
 
-	tp->tm_hour = rem / 60U / 60U;
-	rem -= tp->tm_hour * 60 * 60;
-	tp->tm_min = rem / 60;
-	tp->tm_sec = rem - tp->tm_min * 60;
+	result->tm_hour = rem / 60U / 60U;
+	rem -= result->tm_hour * 60 * 60;
+	result->tm_min = rem / 60;
+	result->tm_sec = rem - result->tm_min * 60;
 
-	return tp;
+	return result;
 }
 
 struct tm *gmtime(const time_t *timep)

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -12,7 +12,7 @@
 #define ACTIVE 1
 #define NOT_ACTIVE 0
 
-static void zephyr_timer_wrapper(struct k_timer *timer);
+static void zephyr_timer_wrapper(struct k_timer *ztimer);
 
 struct timer_obj {
 	struct k_timer ztimer;


### PR DESCRIPTION
The identifiers used in the declaration and definition of a function shall be identical [MISRAC2012-RULE_8_3-b] 


﻿- libc: strtol/strtoul: match implementation to declaration
- libc: fputs/puts: match implementation to declaration
- libc: snprintf/..: match implementation to declaration
- libc: printf/..: match implementation to declaration
- libc: gmtime_r: match implementation to declaration
- posix: timer: match implementation to declaration
- libc: malloc: match implementation to declaration
- libc: strncat: match implementation to declaration
- kernel: idle/z_sched_prio_cmp: match implementation to prototype
