### PR TITLE
drivers: interrupt: refactor shared irq instantiation

### DIFF
--- a/drivers/interrupt_controller/Kconfig.shared_irq
+++ b/drivers/interrupt_controller/Kconfig.shared_irq
@@ -25,17 +25,3 @@ config SHARED_IRQ_INIT_PRIORITY
 	help
 	  Shared IRQ are initialized on POST_KERNEL init level. They
 	  have to be initialized before any device that uses them.
-
-config SHARED_IRQ_0
-	bool "Shared interrupt instance 0"
-	depends on SHARED_IRQ
-	help
-	  Provide an instance of the shared interrupt driver when system
-	  configuration requires that multiple devices share an interrupt.
-
-config SHARED_IRQ_1
-	bool "Shared interrupt instance 1"
-	depends on SHARED_IRQ
-	help
-	  Provide an instance of the shared interrupt driver when system
-	  configuration requires that multiple devices share an interrupt.

--- a/drivers/interrupt_controller/Kconfig.shared_irq
+++ b/drivers/interrupt_controller/Kconfig.shared_irq
@@ -9,15 +9,6 @@ menuconfig SHARED_IRQ
 	  Include shared interrupt support in system. Shared interrupt
 	  support is NOT required in most systems. If in doubt answer no.
 
-config SHARED_IRQ_NUM_CLIENTS
-	int "The number of clients per instance"
-	depends on SHARED_IRQ
-	default 5
-	help
-	  Configures the maximum number of clients allowed per shared
-	  instance of the shared interrupt driver. To conserve RAM set
-	  this value to the lowest practical value.
-
 config SHARED_IRQ_INIT_PRIORITY
 	int "Shared IRQ init priority"
 	depends on SHARED_IRQ

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -159,7 +159,9 @@ void shared_irq_config_func_##n(void)					\
 		    DT_INST_IRQ(n, priority),				\
 		    shared_irq_isr,					\
 		    DEVICE_DT_INST_GET(n),				\
-		    DT_INST_IRQ(n, sense));				\
+		    COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),		\
+				(DT_INST_IRQ(n, sense)),		\
+				(0)));					\
 }
 
 #define SHARED_IRQ_INIT(n)						\

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -143,54 +143,30 @@ int shared_irq_initialize(const struct device *dev)
 	return 0;
 }
 
-#if CONFIG_SHARED_IRQ_0
-void shared_irq_config_0_irq(void);
-
-const struct shared_irq_config shared_irq_config_0 = {
-	.irq_num = DT_INST_IRQN(0),
-	.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,
-	.config = shared_irq_config_0_irq
-};
-
-struct shared_irq_runtime shared_irq_0_runtime;
-
-DEVICE_DT_INST_DEFINE(0, shared_irq_initialize,
-		NULL, &shared_irq_0_runtime,
-		&shared_irq_config_0, POST_KERNEL,
-		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
-
-void shared_irq_config_0_irq(void)
-{
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    shared_irq_isr, DEVICE_DT_INST_GET(0),
-		    DT_INST_IRQ(0, sense));
+#define SHARED_IRQ_CONFIG_FUNC(n)					\
+void shared_irq_config_func_##n(void)					\
+{									\
+	IRQ_CONNECT(DT_INST_IRQN(n),					\
+		    DT_INST_IRQ(n, priority),				\
+		    shared_irq_isr,					\
+		    DEVICE_DT_INST_GET(n),				\
+		    DT_INST_IRQ(n, sense));				\
 }
 
-#endif /* CONFIG_SHARED_IRQ_0 */
+#define SHARED_IRQ_INIT(n)						\
+	SHARED_IRQ_CONFIG_FUNC(n)					\
+	struct shared_irq_runtime shared_irq_data_##n;			\
+									\
+	const struct shared_irq_config shared_irq_config_##n = {	\
+		.irq_num = DT_INST_IRQN(n),				\
+		.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,		\
+		.config = shared_irq_config_func_##n			\
+	};								\
+	DEVICE_DT_INST_DEFINE(n, shared_irq_initialize,			\
+			      NULL,					\
+			      &shared_irq_data_##n,			\
+			      &shared_irq_config_##n, POST_KERNEL,	\
+			      CONFIG_SHARED_IRQ_INIT_PRIORITY,		\
+			      &api_funcs);
 
-#if CONFIG_SHARED_IRQ_1
-void shared_irq_config_1_irq(void);
-
-const struct shared_irq_config shared_irq_config_1 = {
-	.irq_num = DT_INST_IRQN(1),
-	.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,
-	.config = shared_irq_config_1_irq
-};
-
-struct shared_irq_runtime shared_irq_1_runtime;
-
-DEVICE_DT_INST_DEFINE(1, shared_irq_initialize,
-		NULL, &shared_irq_1_runtime,
-		&shared_irq_config_1, POST_KERNEL,
-		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
-
-void shared_irq_config_1_irq(void)
-{
-	IRQ_CONNECT(DT_INST_IRQN(1),
-		    DT_INST_IRQ(1, priority),
-		    shared_irq_isr, DEVICE_DT_INST_GET(1),
-		    DT_INST_IRQ(1, sense));
-}
-
-#endif /* CONFIG_SHARED_IRQ_1 */
+DT_INST_FOREACH_STATUS_OKAY(SHARED_IRQ_INIT)

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -33,7 +33,7 @@ struct shared_irq_client {
 };
 
 struct shared_irq_runtime {
-	struct shared_irq_client client[CONFIG_SHARED_IRQ_NUM_CLIENTS];
+	struct shared_irq_client *const client;
 };
 
 /**
@@ -164,7 +164,10 @@ void shared_irq_config_func_##n(void)					\
 
 #define SHARED_IRQ_INIT(n)						\
 	SHARED_IRQ_CONFIG_FUNC(n)					\
-	struct shared_irq_runtime shared_irq_data_##n;			\
+	struct shared_irq_client clients_##n[INST_SUPPORTS_DEP_ORDS_CNT(n)]; \
+	struct shared_irq_runtime shared_irq_data_##n = {		\
+		.client = clients_##n					\
+	};								\
 									\
 	const struct shared_irq_config shared_irq_config_##n = {	\
 		.irq_num = DT_INST_IRQN(n),				\

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -143,6 +143,15 @@ int shared_irq_initialize(const struct device *dev)
 	return 0;
 }
 
+/*
+ * INST_SUPPORTS_DEP_ORDS_CNT: Counts the number of "elements" in
+ * DT_SUPPORTS_DEP_ORDS(n). There is a comma after each ordinal(inc. the last)
+ * Hence FOR_EACH adds "+1" once too often which has to be subtracted in the end.
+ */
+#define F1(x) 1
+#define INST_SUPPORTS_DEP_ORDS_CNT(n)  \
+	(FOR_EACH(F1, (+), DT_INST_SUPPORTS_DEP_ORDS(n)) - 1)
+
 #define SHARED_IRQ_CONFIG_FUNC(n)					\
 void shared_irq_config_func_##n(void)					\
 {									\
@@ -159,7 +168,7 @@ void shared_irq_config_func_##n(void)					\
 									\
 	const struct shared_irq_config shared_irq_config_##n = {	\
 		.irq_num = DT_INST_IRQN(n),				\
-		.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,		\
+		.client_count = INST_SUPPORTS_DEP_ORDS_CNT(n),		\
 		.config = shared_irq_config_func_##n			\
 	};								\
 	DEVICE_DT_INST_DEFINE(n, shared_irq_initialize,			\


### PR DESCRIPTION
Convert the intc_shared interrupt controller driver to use DT_INST_FOREACH_STATUS_OKAY.
Additionally move the configuration from kconfig to device tree.
The driver unconditionally passed the "sense" interrupt-cell therefore it couldn't be used for interrupt-controllers that don't define
the property. Now the driver passes 0 as flags to IRQ_CONNECT if the sense property does not exist.

In tree it seems the designware gpio driver(drivers/gpio/gpio_dw.c)  is currently the only driver that uses the shared irq driver,
but I haven't seen socs, boards, or samples instantiating it, therefore no changes had to be made.
I have tested it using an ARM CM0 Soc.

edit:
a commit with changes in dw_gpio was added once, but is removed again. Changes are only made to the shared irq driver.