### PR TITLE
module: add option to add syscalls include dirs

### DIFF
--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -690,6 +690,12 @@ Build settings supported in the :file:`module.yml` file are:
 - ``arch_root``: Contains additional architectures that are available to the
   build system. Additional architectures must be located in a
   :file:`<arch_root>/arch` folder.
+- ``syscall_include_dirs``: Contains additional syscall include paths
+  that are available to the build system. Additional syscalls must be located
+  in a :file:`<syscall_include_dirs>` folder. The system calls in zephyr are
+  generated automatically using python script. If you have your own syscalls
+  and you want zephyr to automatically generate them, then you can define this
+  variable in your module file.
 - ``module_ext_root``: Contains :file:`CMakeLists.txt` and :file:`Kconfig` files
   for Zephyr modules, see also :ref:`modules_module_ext_root`.
 
@@ -704,6 +710,7 @@ corresponding file system layout.
        dts_root: .
        soc_root: .
        arch_root: .
+       syscall_include_dirs: [.]
        module_ext_root: .
 
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -70,6 +70,11 @@ mapping:
           dts_root:
             required: false
             type: str
+          syscall_include_dirs:
+            required: false
+            type: seq
+            sequence:
+              - type: str
           soc_root:
             required: false
             type: str
@@ -184,6 +189,13 @@ def process_settings(module, meta):
                 root_path = PurePath(module) / setting
                 out_text += f'"{root.upper()}_ROOT":'
                 out_text += f'"{root_path.as_posix()}"\n'
+
+        setting = build_settings.get('syscall_include_dirs')
+        if setting is not None:
+            for path in setting:
+                path = PurePath(module) / path
+                out_text += f'"SYSCALL_INCLUDE_DIRS":'
+                out_text += f'"{path.as_posix()}"\n'
 
     return out_text
 


### PR DESCRIPTION
The system calls in zephyr are generated automatically
using python script. The cmake looks for the syscalls
in files that are present in `SYSCALL_INCLUDE_DIRS`
variable. This commit adds an option to add more syscalls
paths in the module yaml file.