### PR TITLE
Qemu mps2 an521 nonsecure kernel

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -15,6 +15,14 @@ config BOARD
 	default "mps2_an521_nonsecure" if TRUSTED_EXECUTION_NONSECURE
 	default "mps2_an521"
 
+# By default, if we build for a Non-Secure version of the board,
+# force building with TF-M as the Secure Execution Environment.
+# Openamp samples assume the non-secure build is the remote
+# core image, so do not build with TF-M in this case.
+config BUILD_WITH_TFM
+	default y if TRUSTED_EXECUTION_NONSECURE && !OPENAMP
+
+
 if GPIO
 
 config GPIO_CMSDK_AHB

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -11,3 +11,12 @@ set(QEMU_FLAGS_${ARCH}
   -vga none
   )
 board_set_debugger_ifnset(qemu)
+
+if (CONFIG_BUILD_WITH_TFM AND NOT CONFIG_OPENAMP AND NOT CONFIG_OPENAMP_SLAVE)
+  # Override the binary used by qemu, to use the combined
+  # TF-M (Secure) & Zephyr (Non Secure) image (when running
+  # in-tree tests).
+  # Openamp samples assume the non-secure build is the remote
+  # core image, so do not use the merged .hex in this case.
+  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_merged.hex")
+endif()

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
@@ -10,4 +10,6 @@ toolchain:
 testing:
   default: true
   only_tags:
+     - arm
      - tfm
+     - userspace

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.yaml
@@ -11,5 +11,6 @@ testing:
   default: true
   only_tags:
      - arm
+     - kernel
      - tfm
      - userspace

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -51,13 +51,19 @@ static void trigger_fault_illegal_instruction(void)
 
 static void trigger_fault_access(void)
 {
-#if defined(CONFIG_SOC_ARC_IOT) || defined(CONFIG_SOC_NSIM) || defined(CONFIG_CPU_CORTEX_M)
+#if defined(CONFIG_SOC_ARC_IOT) || defined(CONFIG_SOC_NSIM)
 	/* For iotdk and ARC/nSIM, nSIM simulates full address space of memory,
 	 * so all accesses outside of CCMs are valid and access to 0x0 address
 	 * doesn't generate any exception.So we access it 0XFFFFFFFF instead to
 	 * trigger exception. See issue #31419.
 	 */
 	void *a = (void *)0xFFFFFFFF;
+#elif defined(CONFIG_CPU_CORTEX_M)
+	/* As this test case only runs when User Mode is enabled,
+	 * accessing _current always triggers a memory access fault,
+	 * and is guaranteed not to trigger SecureFault exceptions.
+	 */
+	void *a = (void *)_current;
 #else
 	/* For most arch which support userspace, dereferencing NULL
 	 * pointer will be caught by exception.
@@ -225,7 +231,7 @@ static int run_trigger_thread(int i)
  */
 void test_catch_fatal_error(void)
 {
-#if defined(CONFIG_ARCH_HAS_USERSPACE)
+#if defined(CONFIG_USERSPACE)
 	run_trigger_thread(ZTEST_CATCH_FATAL_ACCESS);
 	run_trigger_thread(ZTEST_CATCH_FATAL_ILLEAGAL_INSTRUCTION);
 	run_trigger_thread(ZTEST_CATCH_FATAL_DIVIDE_ZERO);


### PR DESCRIPTION
On top of #33707 adding the -kernel tag to MPS2 AN521 Non-secure