### PR TITLE
dts: nxp: kinetis: ke1xf: Add chip specific dtsi files

### DIFF
--- a/dts/arm/nxp/MKE14F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE14F256VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke14f256vlx16.dtsi>

--- a/dts/arm/nxp/MKE14F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE14F256VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke14f256vlx16.dtsi>

--- a/dts/arm/nxp/MKE14F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE14F512VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke14f512vlx16.dtsi>

--- a/dts/arm/nxp/MKE14F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE14F512VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke14f512vlx16.dtsi>

--- a/dts/arm/nxp/MKE16F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE16F256VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke16f256vlx16.dtsi>

--- a/dts/arm/nxp/MKE16F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE16F256VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke16f256vlx16.dtsi>

--- a/dts/arm/nxp/MKE16F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE16F512VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke16f512vlx16.dtsi>

--- a/dts/arm/nxp/MKE16F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE16F512VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke16f512vlx16.dtsi>

--- a/dts/arm/nxp/MKE18F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE18F256VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke18f256vlx16.dtsi>

--- a/dts/arm/nxp/MKE18F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE18F256VLL16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke18f512vlx16.dtsi>

--- a/dts/arm/nxp/MKE18F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE18F512VLH16.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_ke18f512vlx16.dtsi>


### PR DESCRIPTION
Add remaining NXP KE1xF SoC dtsi files to support out-of-tree boards using other variants of the KE1xF than the single in-tree board.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>