### PR TITLE
[Backport v1.14-branch] Bluetooth: controller: legacy: Fix dev assert in CPR implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3289,7 +3289,10 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *node_rx,
 				_radio.conn_upd = conn;
 			}
 		} else {
-			LL_ASSERT(0);
+			/* Ignore duplicate request as peripheral is busy
+			 * processing the previously initiated connection
+			 * update request procedure.
+			 */
 		}
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4437,7 +4437,12 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn_upd_curr = conn;
 			}
 		} else {
-			LL_ASSERT(0);
+			/* Ignore duplicate request as peripheral is busy
+			 * processing the previously initiated connection
+			 * update request procedure.
+			 */
+			/* Mark for buffer for release */
+			(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
 		}
 		break;
 


### PR DESCRIPTION
Replace a development assertion in the implementation of
Connection Parameter Request Procedure with an internal
comment and handle transaction violation be ignoring the
PDU.

Relates to commit dec6140685b4 ("Bluetooth: controller: Fix
dev assert in CPR implementation").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>