### PR TITLE
[Backport v1.4-branch] Bluetooth: controller: Fix channel map and interval check in CONNECT_IND PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1037,7 +1037,6 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 
 		/* acquire the slave context from advertiser */
 		conn = _radio.advertiser.conn;
-		_radio.advertiser.conn = NULL;
 
 		/* Populate the slave context */
 		conn->handle = mem_index_get(conn, _radio.conn_pool,
@@ -1054,13 +1053,14 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 		conn->data_chan_count =
 			util_ones_count_get(&conn->data_chan_map[0],
 					    sizeof(conn->data_chan_map));
-		if (conn->data_chan_count < 2) {
-			return 1;
-		}
 		conn->data_chan_hop = pdu_adv->connect_ind.hop;
-		if ((conn->data_chan_hop < 5) || (conn->data_chan_hop > 16)) {
+		if ((conn->data_chan_count < 2) || (conn->data_chan_hop < 5) ||
+		    (conn->data_chan_hop > 16)) {
 			return 1;
 		}
+
+		_radio.advertiser.conn = NULL;
+
 		conn->conn_interval =
 			pdu_adv->connect_ind.interval;
 		conn_interval_us =

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1054,15 +1054,14 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 			util_ones_count_get(&conn->data_chan_map[0],
 					    sizeof(conn->data_chan_map));
 		conn->data_chan_hop = pdu_adv->connect_ind.hop;
+		conn->conn_interval = pdu_adv->connect_ind.interval;
 		if ((conn->data_chan_count < 2) || (conn->data_chan_hop < 5) ||
-		    (conn->data_chan_hop > 16)) {
+		    (conn->data_chan_hop > 16) || !conn->conn_interval) {
 			return 1;
 		}
 
 		_radio.advertiser.conn = NULL;
 
-		conn->conn_interval =
-			pdu_adv->connect_ind.interval;
 		conn_interval_us =
 			pdu_adv->connect_ind.interval * 1250;
 		conn->latency = pdu_adv->connect_ind.latency;


### PR DESCRIPTION
Fix channel map check regression introduced in
commit 2ca0b01 ("Bluetooth: controller: legacy:
Validate chan map and hop value"), that caused further
connection initiation to fail.

Relates to commit 94d5f08 ("Bluetooth: controller:
fixing error re. all zero chmap in conn-ind").

Check for interval value in received CONNECT_IND PDU and
ignore connection setup.

Relates to commit 813b241 ("Bluetooth: controller: Fix
interval check in CONNECT_IND PDU").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>