### PR TITLE
soc: npcx: fix warning message for psl function

### DIFF
--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -127,11 +127,11 @@ void npcx_pinctrl_psl_output_set_inactive(void)
 	inst->PDOUT |= BIT(pin);
 }
 
-bool npcx_pinctrl_psl_input_asserted(int i)
+bool npcx_pinctrl_psl_input_asserted(uint32_t i)
 {
 	struct glue_reg *const inst_glue = HAL_GLUE_INST();
 
-	if (i >=  ARRAY_SIZE(psl_in_confs)) {
+	if (i >= ARRAY_SIZE(psl_in_confs)) {
 		return false;
 	}
 

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -127,7 +127,7 @@ void npcx_pinctrl_psl_input_configure(void);
  * @param i index of 'psl-in-pads' prop
  * @return 1 is asserted, otherwise de-asserted.
  */
-bool npcx_pinctrl_psl_input_asserted(int i);
+bool npcx_pinctrl_psl_input_asserted(uint32_t i);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The compiler shows the array bounds warning message for some boards
which don't set the PSL function.
```
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c: In function 'npcx_pinctrl_psl_input_asserted':
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:139:40: warning: array subscript 0 is above array bounds of 'const struct npcx_psl_in[0]' [-Warray-bounds]
  139 |     NPCX_PSL_CTS_EVENT_BIT(psl_in_confs[i].offset));
      |                            ~~~~~~~~~~~~^~~
../soc/arm/nuvoton_npcx/common/./reg/reg_access.h:13:47: note: in definition of macro 'IS_BIT_SET'
   13 | #define IS_BIT_SET(reg, bit)        (((reg >> bit) & (0x1)) != 0)
      |                                               ^~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:53:37: note: in expansion of macro 'BIT'
   53 | #define NPCX_PSL_CTS_EVENT_BIT(bit) BIT(bit)
      |                                     ^~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:139:5: note: in expansion of macro 'NPCX_PSL_CTS_EVENT_BIT'
  139 |     NPCX_PSL_CTS_EVENT_BIT(psl_in_confs[i].offset));
      |     ^~~~~~~~~~~~~~~~~~~~~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:139:40: warning: array subscript -1 is below array bounds of 'const struct npcx_psl_in[0]' [-Warray-bounds]
  139 |     NPCX_PSL_CTS_EVENT_BIT(psl_in_confs[i].offset));
      |                            ~~~~~~~~~~~~^~~
../soc/arm/nuvoton_npcx/common/./reg/reg_access.h:13:47: note: in definition of macro 'IS_BIT_SET'
   13 | #define IS_BIT_SET(reg, bit)        (((reg >> bit) & (0x1)) != 0)
      |                                               ^~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:53:37: note: in expansion of macro 'BIT'
   53 | #define NPCX_PSL_CTS_EVENT_BIT(bit) BIT(bit)
      |                                     ^~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:139:5: note: in expansion of macro 'NPCX_PSL_CTS_EVENT_BIT'
  139 |     NPCX_PSL_CTS_EVENT_BIT(psl_in_confs[i].offset));
      |     ^~~~~~~~~~~~~~~~~~~~~~
/home/wealian/zephyrproject/zephyr/soc/arm/nuvoton_npcx/common/scfg.c:38:33: note: while referencing 'psl_in_confs'
   38 | static const struct npcx_psl_in psl_in_confs[] = NPCX_DT_PSL_IN_ITEMS_LIST;
      |                                 ^~~~~~~~~~~~
```
Change npcx_pinctrl_psl_input_asserted() input parameter from int to
uint32_t to fix it.