### PR TITLE
net: ppp: dial up with packet raw sockets

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -23,6 +23,12 @@ config NET_PPP_DRV_NAME
 	help
 	  This option sets the driver name
 
+config NET_PPP_MTU_MRU
+	int "PPP MTU and MRU"
+	default 1500
+	help
+	  This options sets MTU and MRU for PPP link.
+
 config NET_PPP_UART_BUF_LEN
 	int "Buffer length when reading from UART"
 	default 8

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -576,6 +576,20 @@ static int ppp_send(const struct device *dev, struct net_pkt *pkt)
 			protocol = htons(PPP_IP);
 		} else if (net_pkt_family(pkt) == AF_INET6) {
 			protocol = htons(PPP_IPV6);
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
+			   net_pkt_family(pkt) == AF_PACKET) {
+			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
+
+			switch (type) {
+			case 0x60:
+				protocol = htons(PPP_IPV6);
+				break;
+			case 0x40:
+				protocol = htons(PPP_IP);
+				break;
+			default:
+				return -EPROTONOSUPPORT;
+			}
 		} else {
 			return -EPROTONOSUPPORT;
 		}

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -25,7 +25,7 @@ extern "C" {
  */
 
 /** PPP maximum receive unit (MRU) */
-#define PPP_MRU 1500
+#define PPP_MRU CONFIG_NET_PPP_MTU_MRU
 
 /** PPP maximum transfer unit (MTU) */
 #define PPP_MTU PPP_MRU
@@ -350,6 +350,10 @@ struct lcp_options {
 	uint16_t auth_proto;
 };
 
+#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
+#define LCP_NUM_MY_OPTIONS	1
+#endif
+
 struct ipcp_options {
 	/** IPv4 address */
 	struct in_addr address;
@@ -400,6 +404,9 @@ struct ppp_context {
 
 		/** Magic-Number value */
 		uint32_t magic;
+#if defined(CONFIG_NET_L2_PPP_OPTION_MRU)
+		struct ppp_my_option_data my_options_data[LCP_NUM_MY_OPTIONS];
+#endif
 	} lcp;
 
 #if defined(CONFIG_NET_IPV4)

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -506,11 +506,10 @@ static bool conn_are_end_points_valid(struct net_pkt *pkt,
 }
 
 static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
-					struct net_conn *conn)
+					struct net_conn *conn, uint8_t proto)
 {
 	if (conn->flags & NET_CONN_LOCAL_ADDR_SET) {
 		struct net_if *pkt_iface = net_pkt_iface(pkt);
-		uint8_t proto = ETH_P_ALL;
 		struct sockaddr_ll *local;
 		struct net_pkt *raw_pkt;
 
@@ -527,6 +526,7 @@ static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
 		raw_pkt = net_pkt_clone(pkt, CLONE_TIMEOUT);
 		if (!raw_pkt) {
 			net_stats_update_per_proto_drop(pkt_iface, proto);
+			NET_WARN("pkt cloning failed, pkt %p dropped", pkt);
 			return NET_DROP;
 		}
 
@@ -574,7 +574,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {
 		if (net_pkt_family(pkt) != AF_PACKET ||
 		    (!IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM) &&
-		     proto != ETH_P_ALL)) {
+		     proto != ETH_P_ALL && proto != IPPROTO_RAW)) {
 			return NET_DROP;
 		}
 
@@ -622,13 +622,14 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn_used, conn, node) {
-		/* For packet socket data, the proto is set to ETH_P_ALL but
-		 * the listener might have a specific protocol set. This is ok
+		/* For packet socket data, the proto is set to ETH_P_ALL or IPPROTO_RAW
+		 * but the listener might have a specific protocol set. This is ok
 		 * and let the packet pass this check in this case.
 		 */
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM) ||
 		    IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {
-			if ((conn->proto != proto) && (proto != ETH_P_ALL)) {
+			if ((conn->proto != proto) && (proto != ETH_P_ALL) &&
+				(proto != IPPROTO_RAW)) {
 				continue;
 			}
 		} else {
@@ -662,14 +663,23 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		 */
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 		    conn->family == AF_PACKET) {
-			ret = conn_raw_socket(pkt, conn);
-			if (ret == NET_DROP) {
-				goto drop;
-			} else if (ret == NET_OK) {
-				raw_pkt_delivered = true;
+			if (proto == ETH_P_ALL) {
+				/* We shall continue with ETH_P_ALL to IPPROTO_RAW: */
+				raw_pkt_continue = true;
 			}
 
-			continue;
+			/* With IPPROTO_RAW deliver only if protocol match: */
+			if ((proto == ETH_P_ALL && conn->proto != IPPROTO_RAW) ||
+			    conn->proto == proto) {
+				ret = conn_raw_socket(pkt, conn, proto);
+				if (ret == NET_DROP) {
+					goto drop;
+				} else if (ret == NET_OK) {
+					raw_pkt_delivered = true;
+				}
+
+				continue;
+			}
 		}
 
 		if (IS_ENABLED(CONFIG_NET_UDP) ||
@@ -757,7 +767,8 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		}
 	}
 
-	if ((is_mcast_pkt && mcast_pkt_delivered) || raw_pkt_delivered) {
+	if ((is_mcast_pkt && mcast_pkt_delivered) || raw_pkt_delivered ||
+		raw_pkt_continue) {
 		if (raw_pkt_continue) {
 			/* When there is open connection different than
 			 * AF_PACKET this packet shall be also handled in

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1740,7 +1740,12 @@ static int context_sendto(struct net_context *context,
 
 		net_pkt_cursor_init(pkt);
 
-		net_if_queue_tx(net_pkt_iface(pkt), pkt);
+		if (net_context_get_ip_proto(context) == IPPROTO_RAW) {
+			/* Pass to L2: */
+			ret = net_send_data(pkt);
+		} else {
+			net_if_queue_tx(net_pkt_iface(pkt), pkt);
+		}
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
 		   net_context_get_family(context) == AF_CAN &&
 		   net_context_get_ip_proto(context) == CAN_RAW) {

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(net_sockets_raw, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "connection.h"
 #include "packet_socket.h"
 
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt)
+enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint8_t proto)
 {
 #if IS_ENABLED(CONFIG_NET_DSA)
 	/*
@@ -48,5 +48,5 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt)
 
 	net_pkt_set_family(pkt, AF_PACKET);
 
-	return net_conn_input(pkt, NULL, ETH_P_ALL, NULL);
+	return net_conn_input(pkt, NULL, proto, NULL);
 }

--- a/subsys/net/ip/packet_socket.h
+++ b/subsys/net/ip/packet_socket.h
@@ -26,9 +26,10 @@
  * disabled, the function will always return NET_DROP.
  */
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt);
+enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint8_t proto);
 #else
-static inline enum net_verdict net_packet_socket_input(struct net_pkt *pkt)
+static inline enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
+	uint8_t proto)
 {
 	return NET_CONTINUE;
 }

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -63,6 +63,21 @@ config NET_L2_PPP_PAP
 	help
 	  Enable support for PAP authentication protocol.
 
+config NET_L2_PPP_OPTION_MRU
+	bool "LCP MRU option support"
+	help
+	  Enable support for LCP MRU option.
+
+config NET_L2_PPP_OPTION_SERVE_IP
+	bool "Serve IP address to peer"
+	help
+	  Enable support for serving IP address to PPP peer.
+
+config NET_L2_PPP_OPTION_SERVE_DNS
+	bool "Serve DNS addresses to peer"
+	help
+	  Enable support for serving DNS addresses to PPP peer.
+
 module = NET_L2_PPP
 module-dep = NET_LOG
 module-str = Log level for ppp L2 layer

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -13,9 +13,10 @@ zephyr_sources(
   getnameinfo.c
   sockets_misc.c
   )
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_PACKET sockets_packet.c)
+
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN sockets_can.c)
 endif()
+zephyr_sources_ifdef(CONFIG_NET_SOCKETS_PACKET      sockets_packet.c)
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD     socket_offload.c)
 
 if (CONFIG_NET_SOCKETS_SOCKOPT_TLS AND NOT CONFIG_NET_SOCKETS_OFFLOAD_TLS)

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -149,7 +149,6 @@ config NET_SOCKETS_OFFLOAD_TLS
 
 config NET_SOCKETS_PACKET
 	bool "Enable packet socket support"
-	depends on NET_L2_ETHERNET
 	help
 	  This is an initial version of packet socket support (special type
 	  raw socket). Packets are passed to and from the device driver

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -386,6 +386,7 @@ static const struct socket_op_vtable packet_sock_fd_op_vtable = {
 static bool packet_is_supported(int family, int type, int proto)
 {
 	if (((type == SOCK_RAW) && (proto == ETH_P_ALL)) ||
+		((type == SOCK_RAW) && (proto == IPPROTO_RAW)) ||
 	    ((type == SOCK_DGRAM) && (proto > 0))) {
 		return true;
 	}


### PR DESCRIPTION
Introducing features to enable e.g. usage of nrf9160
based board as a dialup modem (together with dial up appl/driver) 
for transferring IP data over PPP (e.g. windows dial up), 
i.e. usage of Zephyr PPP as a server for providing link level MTU/MRU, 
IP address and DNS addresses for a PC:
- PPP LCP MRU option (configurable)
- PPP server: IPCP IP and DNS address peer options to enable
providing IP and DNS addresses for PPP peer.

Dial up Zephyr application/driver can use
socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW) for creating
a socket for sending/receiving data to/from PPP link, i.e.
packets are going to/from PPP L2.
