### PR TITLE
fix: dsa: Initialize ethernet contexts for DSA switch lan interfaces

### DIFF
--- a/drivers/ethernet/dsa_ksz8794.c
+++ b/drivers/ethernet/dsa_ksz8794.c
@@ -695,7 +695,6 @@ static void dsa_delayed_work(struct k_work *item)
 
 int dsa_port_init(const struct device *dev)
 {
-	struct dsa_context *context = dev->data;
 	struct dsa_ksz8794_spi *swspi = &phy_spi;
 
 	if (swspi->is_init) {
@@ -703,9 +702,6 @@ int dsa_port_init(const struct device *dev)
 	}
 
 	dsa_hw_init(NULL);
-	k_delayed_work_init(&context->dsa_work, dsa_delayed_work);
-	k_delayed_work_submit(&context->dsa_work, DSA_STATUS_PERIOD_MS);
-
 	return 0;
 }
 
@@ -961,10 +957,27 @@ static void dsa_iface_init(struct net_if *iface)
 				     NET_LINK_ETHERNET);
 		ctx->dsa_port_idx = i;
 		ctx->dsa_ctx = context;
+
+		/*
+		 * Initialize ethernet context 'work' for this iface to
+		 * be able to monitor the carrier status.
+		 */
+		ethernet_init(iface);
 	}
 
 	i++;
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+
+	/*
+	 * Start DSA work to monitor status of ports (read from switch IC)
+	 * only when carrier_work is properly initialized for each iface.
+	 */
+	if (context->iface_slave[KSZ8794_PORT1] &&
+	    context->iface_slave[KSZ8794_PORT2] &&
+	    context->iface_slave[KSZ8794_PORT3]) {
+		k_delayed_work_init(&context->dsa_work, dsa_delayed_work);
+		k_delayed_work_submit(&context->dsa_work, DSA_STATUS_PERIOD_MS);
+	}
 }
 
 static enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)


### PR DESCRIPTION
After the commit c1f7b9f45a78 ("net: l2: ethernet: fix k_work API usage
in carrier on/off handling") each ethernet interface has its own worker
thread (carrier_work in this case) to serialize access to ethernet_mgnt*
functions via carrier_on_of() static function.

As DSA ethernet interfaces (lan{123}) have their own kernel work thread
to monitor the carrier status, it was necessary to move functions, which
initialize it after the code which sets up the worker for those
interfaces.

In that way the error when accessing uninitialized members of ethernet
context is avoided.

Signed-off-by: Lukasz Majewski <lukma@denx.de>