### PR TITLE
[RFC] Kconfig: Configure IRQ_NUMS using edt

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -95,7 +95,13 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
-			reg = <0x40013c00 0x400>;
+			reg = <0x40013C00 0x400>;
+			interrupts = <6 0>, <7 0>, <8 0>, <9 0>, <10 0>, <23 0>,
+				     <40 0>, <41 0>, <42 0>, <1 0>, <2 0>, <3 0>;
+			interrupt-names = "EXTI0", "EXTI1", "EXTI2", "EXTI3",
+					  "EXTI4", "EXTI9_5", "EXTI15_10",
+					  "RTC_Alarm", "OTG_FS_WKUP", "PVD",
+					  "TAMP_STAMP", "RTC_WKUP";
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1336,6 +1336,11 @@ class ControllerAndData:
 
         return "<ControllerAndData, {}>".format(", ".join(fields))
 
+    @property
+    def type(self):
+        "See the class docstring"
+        return self.data
+
 
 class PinCtrl:
     """

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -196,6 +196,8 @@ class EDT:
 
         self._init_compat2binding()
         self._init_nodes()
+        self.InterruptControllers = []
+        self.GpioControllers = []
         self._init_graph()
         self._init_luts()
 
@@ -1176,6 +1178,11 @@ class Node:
             interrupt.controller = self.edt._node2enode[controller_node]
             interrupt.data = self._named_cells(interrupt.controller, data,
                                                "interrupt")
+            interrupt_ctl = InterruptController()
+            interrupt_ctl.node = interrupt.controller
+
+            if interrupt.controller not in self.edt.InterruptControllers:
+                self.edt.InterruptControllers.append(interrupt.controller)
 
             self.interrupts.append(interrupt)
 
@@ -1263,6 +1270,41 @@ class Node:
 
         return OrderedDict(zip(cell_names, data_list))
 
+class Controller(Node):
+    """
+    """
+
+    def is_interrupt_controller(self):
+        node = self._node
+
+        if node in self.edt.InterruptControllers:
+        	return True
+        else:
+            return False
+
+    def is_gpio_controller(self):
+        node = self._node
+
+        if node in self.edt.GpioControllers:
+        	return True
+        else:
+            return False
+
+    def get
+
+class GpioController(Controller):
+    """
+    """
+
+    def gpio_controller_function(self):
+        return True
+
+class InterruptController(Controller):
+    """
+    """
+
+    def interrupt_controller_function(self):
+        return False
 
 class Register:
     """
@@ -1474,55 +1516,7 @@ class Property:
 
 class Controller:
     """
-    Represents a property on a Node, as set in its DT node and with
-    additional info from the 'properties:' section of the binding.
 
-    These attributes are available on Property objects. Several are
-    just convenience accessors for attributes on the PropertySpec object
-    accessible via the 'spec' attribute.
-
-    These attributes are available on Property objects:
-
-    node:
-      The Node instance the property is on
-
-    spec:
-      The PropertySpec object which specifies this property.
-
-    name:
-      Convenience for spec.name.
-
-    description:
-      Convenience for spec.name with leading and trailing whitespace
-      (including newlines) removed.
-
-    type:
-      Convenience for spec.type.
-
-    val:
-      The value of the property, with the format determined by spec.type,
-      which comes from the 'type:' string in the binding.
-
-        - For 'type: int/array/string/string-array', 'val' is what you'd expect
-          (a Python integer or string, or a list of them)
-
-        - For 'type: phandle' and 'type: path', 'val' is the pointed-to Node
-          instance
-
-        - For 'type: phandles', 'val' is a list of the pointed-to Node
-          instances
-
-        - For 'type: phandle-array', 'val' is a list of ControllerAndData
-          instances. See the documentation for that class.
-
-    val_as_token:
-      The value of the property as a token, i.e. with non-alphanumeric
-      characters replaced with underscores. This is only safe to access
-      if self.enum_tokenizable returns True.
-
-    enum_index:
-      The index of 'val' in 'spec.enum' (which comes from the 'enum:' list
-      in the binding), or None if spec.enum is None.
     """
 
     def __init__(self, spec, val, node):

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1467,6 +1467,84 @@ class Property:
 
         return "<Property, {}>".format(", ".join(fields))
 
+class Controller:
+    """
+    Represents a property on a Node, as set in its DT node and with
+    additional info from the 'properties:' section of the binding.
+
+    These attributes are available on Property objects. Several are
+    just convenience accessors for attributes on the PropertySpec object
+    accessible via the 'spec' attribute.
+
+    These attributes are available on Property objects:
+
+    node:
+      The Node instance the property is on
+
+    spec:
+      The PropertySpec object which specifies this property.
+
+    name:
+      Convenience for spec.name.
+
+    description:
+      Convenience for spec.name with leading and trailing whitespace
+      (including newlines) removed.
+
+    type:
+      Convenience for spec.type.
+
+    val:
+      The value of the property, with the format determined by spec.type,
+      which comes from the 'type:' string in the binding.
+
+        - For 'type: int/array/string/string-array', 'val' is what you'd expect
+          (a Python integer or string, or a list of them)
+
+        - For 'type: phandle' and 'type: path', 'val' is the pointed-to Node
+          instance
+
+        - For 'type: phandles', 'val' is a list of the pointed-to Node
+          instances
+
+        - For 'type: phandle-array', 'val' is a list of ControllerAndData
+          instances. See the documentation for that class.
+
+    val_as_token:
+      The value of the property as a token, i.e. with non-alphanumeric
+      characters replaced with underscores. This is only safe to access
+      if self.enum_tokenizable returns True.
+
+    enum_index:
+      The index of 'val' in 'spec.enum' (which comes from the 'enum:' list
+      in the binding), or None if spec.enum is None.
+    """
+
+    def __init__(self, spec, val, node):
+        self.val = val
+        self.spec = spec
+        self.node = node
+
+    @property
+    def type(self):
+        "See the class docstring"
+        return self.spec.name
+
+    @property
+    def description(self):
+        "See the class docstring"
+        return self.spec.description.strip()
+
+    def __repr__(self):
+        fields = ["name: " + self.name,
+                  # repr() to deal with lists
+                  "type: " + self.type,
+                  "value: " + repr(self.val)]
+
+        if self.enum_index is not None:
+            fields.append("enum index: {}".format(self.enum_index))
+
+        return "<Property, {}>".format(", ".join(fields))
 
 class Binding:
     """

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -6,6 +6,7 @@
 import os
 import pickle
 import sys
+import pprint
 
 ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts",
@@ -439,6 +440,9 @@ def dt_irq_highest_number(kconf, _, irq_parent_label):
     if doc_mode or edt is None:
         return "0"
 
+    pp = pprint.PrettyPrinter(width=41, compact=True)
+    # pp.pprint(edt.scc_order)
+
     irq_parent_node = edt.label2node.get(irq_parent_label)
     highest_irq_number = 0
 
@@ -450,6 +454,11 @@ def dt_irq_highest_number(kconf, _, irq_parent_label):
 	# Iterate over interrupt-parent depending nodes
     for node in node_using_irqs:
         node_irqs = node.props["interrupts"].val
+
+        try:
+            pp.pprint(node.interrupts)
+        except:
+            pp.pprint("No parent")
 
         try:
             node_status = node.props["status"].val

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -455,10 +455,33 @@ def dt_irq_highest_number(kconf, _, irq_parent_label):
     for node in node_using_irqs:
         node_irqs = node.props["interrupts"].val
 
-        try:
-            pp.pprint(node.interrupts)
-        except:
-            pp.pprint("No parent")
+        #pp.pprint(node.interrupts)
+
+        for i, entry in enumerate(node.interrupts):
+            if entry is None:
+                continue
+
+            #pp.pprint("i")
+            #pp.pprint(i)
+            #pp.pprint(entry)
+            data = entry.data
+
+            pp.pprint("data")
+            pp.pprint(data)
+            pp.pprint("controller")
+            pp.pprint(entry.controller)
+            pp.pprint("type")
+            pp.pprint(entry.type)
+
+            pp.pprint(entry.controller.required_by)
+
+
+    #        for cell, val in data.items():
+
+    #            try:
+    #                pp.pprint(data.items())
+    #            except:
+    #                pp.pprint("No parent")
 
         try:
             node_status = node.props["status"].val

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -12,4 +12,7 @@ source "soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 config SOC_SERIES
 	default "stm32f4"
 
+config NUM_IRQS
+	default $(dt_irq_highest_number,nvic)
+
 endif # SOC_SERIES_STM32F4X

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
@@ -8,7 +8,4 @@ if SOC_STM32F401XC
 config SOC
 	default	"stm32f401xc"
 
-config NUM_IRQS
-	default 85
-
 endif # SOC_STM32F401XC

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
@@ -8,7 +8,4 @@ if SOC_STM32F401XE
 config SOC
 	default "stm32f401xe"
 
-config NUM_IRQS
-	default 85
-
 endif # SOC_STM32F401XE

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -8,7 +8,4 @@ if SOC_STM32F405XG
 config SOC
 	default "stm32f405xx"
 
-config NUM_IRQS
-	default 82
-
 endif # SOC_STM32F405XG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -8,17 +8,11 @@ if SOC_STM32F407XE
 config SOC
 	default "stm32f407xx"
 
-config NUM_IRQS
-	default 82
-
 endif # SOC_STM32F407XE
 
 if SOC_STM32F407XG
 
 config SOC
 	default "stm32f407xx"
-
-config NUM_IRQS
-	default 82
 
 endif # SOC_STM32F407XG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f410xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f410xx
@@ -8,7 +8,4 @@ if SOC_STM32F410RX
 config SOC
 	default "stm32f410rx"
 
-config NUM_IRQS
-	default 97
-
 endif # SOC_STM32F410RX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -8,7 +8,4 @@ if SOC_STM32F411XE
 config SOC
 	default "stm32f411xe"
 
-config NUM_IRQS
-	default 86
-
 endif # SOC_STM32F411XE

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
@@ -8,7 +8,4 @@ if SOC_STM32F412CG
 config SOC
 	default "stm32f412cx"
 
-config NUM_IRQS
-	default 97
-
 endif # SOC_STM32F412CG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -8,7 +8,4 @@ if SOC_STM32F412ZG
 config SOC
 	default "stm32f412zx"
 
-config NUM_IRQS
-	default 97
-
 endif # SOC_STM32F412ZG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -8,7 +8,4 @@ if SOC_STM32F413XX
 config SOC
 	default "stm32f413xx"
 
-config NUM_IRQS
-	default 102
-
 endif # SOC_STM32F413XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
@@ -8,9 +8,6 @@ if SOC_STM32F415XX
 config SOC
 	default "stm32f415xx"
 
-config NUM_IRQS
-	default 82
-
 config CRYPTO_STM32
 	default y
 	depends on CRYPTO

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -8,9 +8,6 @@ if SOC_STM32F417XX
 config SOC
 	default "stm32f417xx"
 
-config NUM_IRQS
-	default 82
-
 config CRYPTO_STM32
 	default y
 	depends on CRYPTO

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f427xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f427xx
@@ -8,9 +8,6 @@ if SOC_STM32F427XX
 config SOC
 	default "stm32f427xx"
 
-config NUM_IRQS
-	default 91
-
 if ENTROPY_GENERATOR
 
 config ENTROPY_STM32_RNG

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -8,7 +8,4 @@ if SOC_STM32F429XX
 config SOC
 	default "stm32f429xx"
 
-config NUM_IRQS
-	default 91
-
 endif # SOC_STM32F429XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
@@ -8,9 +8,6 @@ if SOC_STM32F437XX
 config SOC
 	default "stm32f437xx"
 
-config NUM_IRQS
-	default 91
-
 config CRYPTO_STM32
 	default y
 	depends on CRYPTO

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
@@ -8,7 +8,4 @@ if SOC_STM32F446XX
 config SOC
 	default "stm32f446xx"
 
-config NUM_IRQS
-	default 97
-
 endif # SOC_STM32F446XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
@@ -8,7 +8,4 @@ if SOC_STM32F469XX
 config SOC
 	default "stm32f469xx"
 
-config NUM_IRQS
-	default 93
-
 endif # SOC_STM32F469XX


### PR DESCRIPTION
Each soc should provide IRQ_NUMS as the highest IRQ number used in the binary to set the size of the irq table.
Provide a utility function to get this information from device tree.

Simplify SoC porting and saves a few binary bytes by setting IRQ_NUM value that reflects the exact needs of the application