### PR TITLE
Add support for litex_vexriscv GPIO interrupts

### DIFF
--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Antmicro <www.antmicro.com>
+ * Copyright (c) 2019-2021 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,8 @@
 #include <sys/util.h>
 #include <string.h>
 #include <logging/log.h>
+
+#include "gpio_utils.h"
 
 #define SUPPORTED_FLAGS (GPIO_INPUT | GPIO_OUTPUT | \
 			GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH | \
@@ -38,12 +40,21 @@ struct gpio_litex_cfg {
 
 struct gpio_litex_data {
 	struct gpio_driver_data common;
+	const struct device *dev;
+	sys_slist_t cb;
 };
 
 /* Helper macros for GPIO */
 
 #define DEV_GPIO_CFG(dev)						\
 	((const struct gpio_litex_cfg *)(dev)->config)
+
+/* Helper macros for GPIO interrupts */
+
+#define GPIO_EV_PENDING(dev) \
+		((volatile uint32_t *)((uint32_t)DEV_GPIO_CFG(dev)->reg_addr + 0x0008))
+#define GPIO_EV_ENABLE(dev) \
+		((volatile uint32_t *)((uint32_t)DEV_GPIO_CFG(dev)->reg_addr + 0x000c))
 
 /* Helper functions for bit / port access */
 
@@ -77,19 +88,6 @@ static inline uint32_t get_port(const struct gpio_litex_cfg *config)
 }
 
 /* Driver functions */
-
-static int gpio_litex_init(const struct device *dev)
-{
-	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
-
-	/* each 4-byte register is able to handle 8 GPIO pins */
-	if (gpio_config->nr_gpios > (gpio_config->reg_size * 8)) {
-		LOG_ERR("%s", LITEX_LOG_REG_SIZE_NGPIOS_MISMATCH);
-		return -EINVAL;
-	}
-
-	return 0;
-}
 
 static int gpio_litex_configure(const struct device *dev,
 				gpio_pin_t pin, gpio_flags_t flags)
@@ -191,17 +189,49 @@ static int gpio_litex_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
+static void gpio_litex_irq_handler(const struct device *dev)
+{
+	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
+	struct gpio_litex_data *data = dev->data;
+
+	uint8_t int_status =
+		litex_read(GPIO_EV_PENDING(dev), gpio_config->reg_size);
+
+	/* clear events */
+	litex_write(GPIO_EV_PENDING(dev), gpio_config->reg_size,
+			int_status);
+
+	gpio_fire_callbacks(&data->cb, dev, int_status);
+}
+
+static int gpio_litex_manage_callback(const struct device *dev,
+				      struct gpio_callback *callback, bool set)
+{
+	struct gpio_litex_data *data = dev->data;
+
+	return gpio_manage_callback(&data->cb, callback, set);
+}
+
 static int gpio_litex_pin_interrupt_configure(const struct device *dev,
 					      gpio_pin_t pin,
 					      enum gpio_int_mode mode,
 					      enum gpio_int_trig trig)
 {
-	int ret = 0;
+	const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev);
 
-	if (mode != GPIO_INT_MODE_DISABLED) {
-		ret = -ENOTSUP;
+	if (gpio_config->port_is_output == true) {
+		return -ENOTSUP;
 	}
-	return ret;
+
+	if (mode == GPIO_INT_MODE_EDGE) {
+		uint8_t ev_enabled = litex_read(GPIO_EV_ENABLE(dev),
+				gpio_config->reg_size);
+		litex_write(GPIO_EV_ENABLE(dev), gpio_config->reg_size,
+			    ev_enabled | BIT(pin));
+		return 0;
+	}
+
+	return -ENOTSUP;
 }
 
 static const struct gpio_driver_api gpio_litex_driver_api = {
@@ -212,11 +242,21 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 	.port_clear_bits_raw = gpio_litex_port_clear_bits_raw,
 	.port_toggle_bits = gpio_litex_port_toggle_bits,
 	.pin_interrupt_configure = gpio_litex_pin_interrupt_configure,
+	.manage_callback = gpio_litex_manage_callback,
 };
 
 /* Device Instantiation */
+#define GPIO_LITEX_IRQ_INIT(n) \
+	do { \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), \
+			    gpio_litex_irq_handler, \
+			    DEVICE_DT_INST_GET(n), 0); \
+\
+		irq_enable(DT_INST_IRQN(n)); \
+	} while (0)
 
 #define GPIO_LITEX_INIT(n) \
+	static int gpio_litex_port_init_##n(const struct device *dev); \
 	BUILD_ASSERT(DT_INST_REG_SIZE(n) != 0 \
 		     && DT_INST_REG_SIZE(n) % 4 == 0, \
 		     "Register size must be a multiple of 4"); \
@@ -231,13 +271,28 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 	static struct gpio_litex_data gpio_litex_data_##n; \
 \
 	DEVICE_DT_INST_DEFINE(n, \
-			    gpio_litex_init, \
+			    gpio_litex_port_init_##n, \
 			    NULL, \
 			    &gpio_litex_data_##n, \
 			    &gpio_litex_cfg_##n, \
 			    POST_KERNEL, \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &gpio_litex_driver_api \
-			   );
+			   ); \
+\
+	static int gpio_litex_port_init_##n(const struct device *dev) \
+	{ \
+		const struct gpio_litex_cfg *gpio_config = DEV_GPIO_CFG(dev); \
+\
+		/* each 4-byte register is able to handle 8 GPIO pins */ \
+		if (gpio_config->nr_gpios > (gpio_config->reg_size * 8)) { \
+			LOG_ERR("%s", LITEX_LOG_REG_SIZE_NGPIOS_MISMATCH); \
+			return -EINVAL; \
+		} \
+\
+		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0), \
+			   (GPIO_LITEX_IRQ_INIT(n);)) \
+		return 0; \
+	}
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_LITEX_INIT)

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
+ * Copyright (c) 2018 - 2021 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +24,9 @@
 
 #define I2S_RX_IRQ		DT_IRQN(DT_NODELABEL(i2s_rx))
 #define I2S_TX_IRQ		DT_IRQN(DT_NODELABEL(i2s_tx))
+
+#define GPIO_IRQ		DT_IRQN(DT_NODELABEL(gpio_in))
+
 static inline void vexriscv_litex_irq_setmask(uint32_t mask)
 {
 	__asm__ volatile ("csrw %0, %1" :: "i"(IRQ_MASK), "r"(mask));
@@ -96,6 +99,11 @@ static void vexriscv_litex_irq_handler(const void *device)
 		ite->isr(ite->arg);
 	}
 #endif
+
+	if (irqs & (1 << GPIO_IRQ)) {
+		ite = &_sw_isr_table[GPIO_IRQ];
+		ite->isr(ite->arg);
+	}
 }
 
 void arch_irq_enable(unsigned int irq)

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -114,10 +114,10 @@
 		};
 		gpio_in: gpio@e0006000 {
 			compatible = "litex,gpio";
-			reg = <0xe0006000 0x4>;
+			reg = <0xe0006000 0x4 0xe0006008 0x1 0xe000600c 0x1>;
 			interrupt-parent = <&intc0>;
 			interrupts = <4 2>;
-			reg-names = "control";
+			reg-names = "control", "irq_pend", "irq_en";
 			ngpios = <4>;
 			label = "gpio_in";
 			status = "disabled";

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -114,10 +114,18 @@
 		};
 		gpio_in: gpio@e0006000 {
 			compatible = "litex,gpio";
-			reg = <0xe0006000 0x4 0xe0006008 0x1 0xe000600c 0x1>;
+			reg = <0xe0006000 0x4
+				0xe0006004 0x1
+				0xe0006008 0x1
+				0xe0006010 0x1
+				0xe0006014 0x1>;
 			interrupt-parent = <&intc0>;
 			interrupts = <4 2>;
-			reg-names = "control", "irq_pend", "irq_en";
+			reg-names = "base",
+				"irq_mode",
+				"irq_edge",
+				"irq_pend",
+				"irq_en";
 			ngpios = <4>;
 			label = "gpio_in";
 			status = "disabled";

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -115,6 +115,8 @@
 		gpio_in: gpio@e0006000 {
 			compatible = "litex,gpio";
 			reg = <0xe0006000 0x4>;
+			interrupt-parent = <&intc0>;
+			interrupts = <4 2>;
 			reg-names = "control";
 			ngpios = <4>;
 			label = "gpio_in";


### PR DESCRIPTION
This adds support for GPIO interrupts which has been added to LiteX recently: https://github.com/enjoy-digital/litex/blob/master/litex/soc/cores/gpio.py#L21