### PR TITLE
mgmt/mcumgr: Fixing use of k_fifo function on net buf

### DIFF
--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -273,7 +273,7 @@ zephyr_smp_handle_reqs(struct k_work *work)
 
 	zst = (void *)work;
 
-	while ((nb = k_fifo_get(&zst->zst_fifo, K_NO_WAIT)) != NULL) {
+	while ((nb = net_buf_get(&zst->zst_fifo, K_NO_WAIT)) != NULL) {
 		zephyr_smp_process_packet(zst, nb);
 	}
 }
@@ -299,6 +299,6 @@ zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 void
 zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb)
 {
-	k_fifo_put(&zst->zst_fifo, nb);
+	net_buf_put(&zst->zst_fifo, nb);
 	k_work_submit(&zst->zst_work);
 }


### PR DESCRIPTION
Fixing problem where k_fifo functions have been used to get/put
data from/info net buf, where documentation it has been strictly
forbidding so.

Found, reported and solution suggested by jrhees-cae.

Fixes: #32579

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

