### PR TITLE
scripts: coccinelle: Fix parse error

### DIFF
--- a/scripts/coccinelle/deref_null.cocci
+++ b/scripts/coccinelle/deref_null.cocci
@@ -16,7 +16,7 @@ virtual report
 
 // The following two rules are separate, because both can match a single
 // expression in different ways
-@pr1 depends on !(file in "ext")@
+@pr1 depends on !(file in "ext") expression@
 expression E;
 identifier f;
 position p1;
@@ -212,7 +212,7 @@ else S3
 // The following three rules are duplicates of ifm, pr1 and pr2 respectively.
 // It is need because the previous rule as already made a "change".
 
-@pr11 depends on context && !org && !report && !(file in "ext") && pr1@
+@pr11 depends on context && !org && !report && !(file in "ext") && pr1 expression@
 expression E;
 identifier f;
 position p1;


### PR DESCRIPTION
The commit coccinelle/coccinelle@47bd4cae522 changed a behavior of
parsing right before coccinelle v1.1.0.  With the commit, the current
scripts under scripts/coccinelle/ errors out with:

   minus: parse error:
     File ".../zephyr/scripts/coccinelle/deref_null.cocci",
     line 25, column 42, charpos = 666
     around = '...',
     whole content =  (E != NULL && ...) ? <+...E->f@p1...+> : ...

I've already raised an issue upstream coccinelle/coccinelle#257.  But
Debian is already shipping v1.1.0 and we need a fix.

The proposed fix doesn't change the semantics, it just explicitly
states that the rule is an expression.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>