### PR TITLE
Changes to bluetooth mesh for k_work API

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -58,7 +58,7 @@ static struct {
 	const struct bt_mesh_send_cb *cb;
 	void *cb_data;
 	uint64_t timestamp;
-	struct k_delayed_work work;
+	struct k_work_delayable work;
 } adv;
 
 static int adv_start(const struct bt_le_adv_param *param,
@@ -201,7 +201,7 @@ static void schedule_send(void)
 	 * to the previous packet than what's permitted by the specification.
 	 */
 	delta = k_uptime_delta(&timestamp);
-	k_delayed_work_submit(&adv.work, K_MSEC(ADV_INT_FAST_MS - delta));
+	k_work_reschedule(&adv.work, K_MSEC(ADV_INT_FAST_MS - delta));
 }
 
 void bt_mesh_adv_update(void)
@@ -218,7 +218,7 @@ void bt_mesh_adv_buf_ready(void)
 
 void bt_mesh_adv_init(void)
 {
-	k_delayed_work_init(&adv.work, send_pending_adv);
+	k_work_init_delayable(&adv.work, send_pending_adv);
 }
 
 static void adv_sent(struct bt_le_ext_adv *instance,

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -67,6 +67,11 @@ static struct bt_mesh_adv *adv_alloc(int id)
 	return &adv_pool[id].adv;
 }
 
+static bool friend_is_allocated(const struct bt_mesh_friend *frnd)
+{
+	return frnd->subnet != NULL;
+}
+
 static bool is_lpn_unicast(struct bt_mesh_friend *frnd, uint16_t addr)
 {
 	if (frnd->lpn == BT_MESH_ADDR_UNASSIGNED) {
@@ -86,7 +91,7 @@ struct bt_mesh_friend *bt_mesh_friend_find(uint16_t net_idx, uint16_t lpn_addr,
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
 
-		if (valid && !frnd->subnet) {
+		if (valid && !friend_is_allocated(frnd)) {
 			continue;
 		}
 
@@ -197,7 +202,7 @@ void bt_mesh_friends_clear(void)
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
 
-		if (!frnd->subnet) {
+		if (!friend_is_allocated(frnd)) {
 			continue;
 		}
 
@@ -216,7 +221,7 @@ void bt_mesh_friend_sec_update(uint16_t net_idx)
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
 
-		if (!frnd->subnet) {
+		if (!friend_is_allocated(frnd)) {
 			continue;
 		}
 
@@ -531,7 +536,7 @@ static struct net_buf *encode_update(struct bt_mesh_friend *frnd, uint8_t md)
 	struct bt_mesh_ctl_friend_update *upd;
 	NET_BUF_SIMPLE_DEFINE(sdu, 1 + sizeof(*upd));
 
-	__ASSERT_NO_MSG(frnd->subnet);
+	__ASSERT_NO_MSG(friend_is_allocated(frnd));
 
 	BT_DBG("lpn 0x%04x md 0x%02x", frnd->lpn, md);
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -174,7 +174,11 @@ void bt_mesh_reset(void)
 
 	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
 
-	k_delayed_work_cancel(&bt_mesh.ivu_timer);
+	/* If this fails, the work handler will return early on the next
+	 * execution, as the device is not provisioned. If the device is
+	 * reprovisioned, the timer is always restarted.
+	 */
+	(void)k_work_cancel_delayable(&bt_mesh.ivu_timer);
 
 	bt_mesh_cfg_reset();
 	bt_mesh_trans_reset();

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -66,7 +66,7 @@ struct bt_mesh_friend {
 
 	uint16_t sub_list[FRIEND_SUB_LIST_SIZE];
 
-	struct k_delayed_work timer;
+	struct k_work_delayable timer;
 
 	struct bt_mesh_friend_seg {
 		sys_slist_t queue;
@@ -88,7 +88,7 @@ struct bt_mesh_friend {
 		uint32_t start;                  /* Clear Procedure start */
 		uint16_t frnd;                   /* Previous Friend's address */
 		uint16_t repeat_sec;             /* Repeat timeout in seconds */
-		struct k_delayed_work timer;  /* Repeat timer */
+		struct k_work_delayable timer;   /* Repeat timer */
 	} clear;
 };
 
@@ -213,7 +213,7 @@ struct bt_mesh_net {
 	uint8_t default_ttl;
 
 	/* Timer to track duration in current IV Update state */
-	struct k_delayed_work ivu_timer;
+	struct k_work_delayable ivu_timer;
 
 	uint8_t dev_key[16];
 };

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -22,7 +22,7 @@ struct prov_link {
 	const struct prov_bearer_cb *cb;
 	void *cb_data;
 	struct net_buf_simple *rx_buf;
-	struct k_delayed_work prot_timer;
+	struct k_work_delayable prot_timer;
 };
 
 static struct prov_link link;
@@ -34,7 +34,8 @@ static void reset_state(void)
 		link.conn = NULL;
 	}
 
-	k_delayed_work_cancel(&link.prot_timer);
+	/* If this fails, the protocol timeout handler will exit early. */
+	(void)k_work_cancel_delayable(&link.prot_timer);
 
 	link.rx_buf = bt_mesh_proxy_get_buf();
 }
@@ -51,8 +52,12 @@ static void link_closed(enum prov_bearer_link_status status)
 
 static void protocol_timeout(struct k_work *work)
 {
-	BT_DBG("Protocol timeout");
+	if (!link.conn) {
+		/* Already disconnected */
+		return;
+	}
 
+	BT_DBG("Protocol timeout");
 	link_closed(PROV_BEARER_LINK_STATUS_TIMEOUT);
 }
 
@@ -70,7 +75,7 @@ int bt_mesh_pb_gatt_recv(struct bt_conn *conn, struct net_buf_simple *buf)
 		return -EINVAL;
 	}
 
-	k_delayed_work_submit(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
 
 	link.cb->recv(&pb_gatt, link.cb_data, buf);
 
@@ -86,7 +91,7 @@ int bt_mesh_pb_gatt_open(struct bt_conn *conn)
 	}
 
 	link.conn = bt_conn_ref(conn);
-	k_delayed_work_submit(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
 
 	link.cb->link_opened(&pb_gatt, link.cb_data);
 
@@ -125,7 +130,7 @@ static int buf_send(struct net_buf_simple *buf, prov_bearer_send_complete_t cb,
 		return -ENOTCONN;
 	}
 
-	k_delayed_work_submit(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
 
 	return bt_mesh_proxy_send(link.conn, BT_MESH_PROXY_PROV, buf);
 }
@@ -137,7 +142,7 @@ static void clear_tx(void)
 
 void pb_gatt_init(void)
 {
-	k_delayed_work_init(&link.prot_timer, protocol_timeout);
+	k_work_init_delayable(&link.prot_timer, protocol_timeout);
 }
 
 void pb_gatt_reset(void)

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -96,7 +96,7 @@ static struct bt_mesh_proxy_client {
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
 	struct k_work send_beacons;
 #endif
-	struct k_delayed_work    sar_timer;
+	struct k_work_delayable  sar_timer;
 	struct net_buf_simple    buf;
 } clients[CONFIG_BT_MAX_CONN] = {
 	[0 ... (CONFIG_BT_MAX_CONN - 1)] = {
@@ -132,15 +132,22 @@ static struct bt_mesh_proxy_client *find_client(struct bt_conn *conn)
 
 static void proxy_sar_timeout(struct k_work *work)
 {
-	struct bt_mesh_proxy_client *client;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_mesh_proxy_client *client =
+		CONTAINER_OF(dwork, struct bt_mesh_proxy_client, sar_timer);
+
+	if (!client->conn) {
+		return;
+	}
+
+	if (!client->buf.len) {
+		BT_DBG("No pending Proxy SAR message");
+		return;
+	}
 
 	BT_WARN("Proxy SAR timeout");
 
-	client = CONTAINER_OF(work, struct bt_mesh_proxy_client, sar_timer);
-	if (client->conn) {
-		bt_conn_disconnect(client->conn,
-				   BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	}
+	bt_conn_disconnect(client->conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 }
 
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
@@ -501,7 +508,7 @@ static ssize_t proxy_recv(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		k_delayed_work_submit(&client->sar_timer, PROXY_SAR_TIMEOUT);
+		k_work_reschedule(&client->sar_timer, PROXY_SAR_TIMEOUT);
 		client->msg_type = PDU_TYPE(data);
 		net_buf_simple_add_mem(&client->buf, data + 1, len - 1);
 		break;
@@ -517,7 +524,7 @@ static ssize_t proxy_recv(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		k_delayed_work_submit(&client->sar_timer, PROXY_SAR_TIMEOUT);
+		k_work_reschedule(&client->sar_timer, PROXY_SAR_TIMEOUT);
 		net_buf_simple_add_mem(&client->buf, data + 1, len - 1);
 		break;
 
@@ -532,7 +539,10 @@ static ssize_t proxy_recv(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		k_delayed_work_cancel(&client->sar_timer);
+		/* If this fails, the work handler exits early, as there's no
+		 * active SAR buffer.
+		 */
+		(void)k_work_cancel_delayable(&client->sar_timer);
 		net_buf_simple_add_mem(&client->buf, data + 1, len - 1);
 		proxy_complete_pdu(client);
 		break;
@@ -592,7 +602,10 @@ static void proxy_disconnected(struct bt_conn *conn, uint8_t reason)
 				bt_mesh_pb_gatt_close(conn);
 			}
 
-			k_delayed_work_cancel(&client->sar_timer);
+			/* If this fails, the work handler exits early, as
+			 * there's no active connection.
+			 */
+			(void)k_work_cancel_delayable(&client->sar_timer);
 			bt_conn_unref(client->conn);
 			client->conn = NULL;
 			break;
@@ -1368,7 +1381,7 @@ int bt_mesh_proxy_init(void)
 		client->buf.size = CLIENT_BUF_SIZE;
 		client->buf.__buf = client_buf_data + (i * CLIENT_BUF_SIZE);
 
-		k_delayed_work_init(&client->sar_timer, proxy_sar_timeout);
+		k_work_init_delayable(&client->sar_timer, proxy_sar_timeout);
 	}
 
 	bt_conn_cb_register(&conn_callbacks);


### PR DESCRIPTION
This PR supports #33104 in updating the use of k_work delayable timers in the Bluetooth mesh implementation.  The API has been updated, and appears to work on one sample with limited testing.

It is in draft format, and all commits tagged DNM, because this needs significant review and rework from domain experts to address the following concerns.  More details are in comments in the code, and in the individual commit messages.  At least one unrelated probable bug has been highlighted (in cfg_srv).  Overall:

On the whole this code does not appear to be correct in the presence of preemptive threads or SMP systems.  The use of atomic flags without an enclosing lock for operations that are not read-modify-write is not robust in those contexts.

There were many uses of `k_delayed_work_cancel()`, none of which took into account the possibility that cancellation can fail, and several of which would likely cause faults if the work item continued to be after the post-cancellation state updates were made.

It is generally not clear whether schedule or reschedule operations are appropriate.

My preferred path forward is for a mesh maintainer to take these commits and rework them as necessary.

(NB: This is currently based on and incorporates #33614 to support the sample.)