### PR TITLE
ci: run issue count workflow every 10 minutes

### DIFF
--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -1,8 +1,8 @@
 name: Issue Tracker
 
 on:
-  issues:
-    types: [opened, labeled, closed]
+  schedule:
+    - cron:  '*/10 * * * *'
 
 env:
   OUTPUT_FILE_NAME: IssuesReport.md
@@ -50,4 +50,3 @@ jobs:
       run: |
         mkd2html IssuesReport.md IssuesReport.html
         aws s3 cp --quiet IssuesReport.html s3://testing.zephyrproject.org/issues/$GITHUB_REPOSITORY/index.html
-


### PR DESCRIPTION
Do not run workflow on each issue change, instead run every 10 minutes.
Running this on every issue open/close/label will cause reaching API
call limit very fast when issues are automatically created from coverity
or during bug triaging sessions.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
