### PR TITLE
net: lwm2m: Fix unitialized variable error in Link Format writer

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
@@ -51,7 +51,7 @@ struct link_format_out_formatter_data {
 static size_t put_begin(struct lwm2m_output_context *out,
 			struct lwm2m_obj_path *path)
 {
-	char init_string[MAX(sizeof(ENABLER_VERSION), sizeof(REG_PREFACE))];
+	char init_string[MAX(sizeof(ENABLER_VERSION), sizeof(REG_PREFACE))] = "";
 	struct link_format_out_formatter_data *fd;
 	int ret;
 


### PR DESCRIPTION
The `init_string` array could have been used uninitialized, fix this
by initializing it as an empty string, which is a desired content in
case it's not overwritten.

CID: 220302
Fixes #33839

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>