### PR TITLE
devicetree: spi: clean up DT_SPI_DEV_CS_GPIOS_CTLR

### DIFF
--- a/include/devicetree/spi.h
+++ b/include/devicetree/spi.h
@@ -148,7 +148,7 @@ extern "C" {
  * @return node identifier for spi_dev's chip select GPIO controller
  */
 #define DT_SPI_DEV_CS_GPIOS_CTLR(spi_dev) \
-	DT_PHANDLE_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
  * @brief Get a SPI device's chip select GPIO controller's label property


### PR DESCRIPTION
Write this in terms of DT_GPIO_CTLR_BY_IDX instead of the lower level
DT_PHANDLE_BY_IDX for clarity and parallelism with things like
DT_SPI_DEV_CS_GPIOS_PIN, which is written using DT_GPIO_PIN_BY_IDX
instead of DT_PHA_BY_IDX.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>