### PR TITLE
net: ip: select src ip address with valid scope for mcast dst

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2686,9 +2686,7 @@ const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *dst_iface,
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	if (!net_ipv6_is_ll_addr(dst) && (!net_ipv6_is_addr_mcast(dst) ||
-	    net_ipv6_is_addr_mcast_mesh(dst))) {
-
+	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast_link(dst)) {
 		/* If caller has supplied interface, then use that */
 		if (dst_iface) {
 			src = net_if_ipv6_get_best_match(dst_iface, dst,


### PR DESCRIPTION
IPv6 source address selection procedure selected link-local address
for any muticast destination with other scope than mesh-local. It
was a cause of problems for broader multicast scopes like admin-, or
site-local. For such broader scopes source address must be at least
as broad as the scope of multicast destination.

This patch updates IPv6 source address selection procedure. Now
link-local address is selected only for link-local destinations,
including multicast destinations. For broader destination scope,
source address with broader scope is selected.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>