### PR TITLE
boards: arm: add new rev. for STM32F3Disco board

### DIFF
--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -28,9 +28,12 @@ started quickly. Here are some highlights of the STM32F3DISCOVERY board:
 
 - Two push-buttons: USER and RESET
 - USB USER with Mini-B connector
-- L3GD20, ST MEMS motion sensor, 3-axis digital output gyroscope
-- LSM303DLHC, ST MEMS system-in-package featuring a 3D digital linear
-  acceleration sensor and a 3D digital magnetic sensor
+- L3GD20 or I3G4250D, ST MEMS motion sensor, 3-axis digital output gyroscope
+- LSM303DLHC or LSM303AGR, ST MEMS system-in-package featuring a 3D digital linear
+  acceleration sensor and a 3D digital magnetic sensor;
+
+.. HINT::
+   Recent PCB revisions (E and newer) are shiped with I3G4250D and LSM303AGR.
 
 .. image:: img/stm32f3_disco.jpg
      :width: 350px
@@ -213,6 +216,15 @@ Here is an example for the :ref:`hello_world` application.
    :board: stm32f3_disco
    :goals: build flash
 
+
+In case you are using a recent PCB revision (E or newer), you have to use an
+adapted board definition:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f3_disco@E
+   :goals: build flash
+
 Run a serial host program to connect with your board. For PCB version A or B a
 TTL(3.3V) serial adapter is required. For PCB version C and newer a Virtual Com
 Port (VCP) is available on the  USB ST-LINK port.
@@ -240,6 +252,13 @@ You can debug an application in the usual way.  Here is an example for the
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: stm32f3_disco
+   :goals: debug
+
+Again you have to use the adapted command for newer PCB revisions (E and newer):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f3_disco@E
    :goals: debug
 
 .. _STM32F3DISCOVERY website:

--- a/boards/arm/stm32f3_disco/revision.cmake
+++ b/boards/arm/stm32f3_disco/revision.cmake
@@ -1,0 +1,4 @@
+board_check_revision(
+        FORMAT LETTER
+        DEFAULT_REVISION B
+)

--- a/boards/arm/stm32f3_disco/stm32f3_disco_B.conf
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_B.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Jonathan Hahn
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/stm32f3_disco/stm32f3_disco_E.conf
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_E.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Jonathan Hahn
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/stm32f3_disco/stm32f3_disco_E.overlay
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_E.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, Jonathan Hahn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c1 {
+    /delete-node/ lsm303dlhc-magn@1e;
+    /delete-node/ lsm303dlhc-accel@19;
+
+	lsm303agr-magn@1e {
+		compatible = "st,lis2mdl", "st,lsm303agr-magn";
+		reg = <0x1e>;
+		label = "LSM303AGR-MAGN";
+	};
+
+    lsm303agr-accel@19 {
+		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		reg = <0x19>;
+		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
+			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
+		label = "LSM303AGR-ACCEL";
+	};
+};


### PR DESCRIPTION
New STM32F3 Discovery boards are shipped with different
sensors. This PR adds a new revision for the board, supporting
the new acceloremeter/magnetometer sensor.