### PR TITLE
Various coding guideline fixes

### DIFF
--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -147,7 +147,7 @@ struct acpi_cpu *z_acpi_get_cpu(int n)
 		if (entry->type == ACPI_MADT_ENTRY_CPU) {
 			struct acpi_cpu *cpu = (struct acpi_cpu *)entry;
 
-			if (cpu->flags & ACPI_CPU_FLAGS_ENABLED) {
+			if ((cpu->flags & ACPI_CPU_FLAGS_ENABLED) != 0) {
 				if (n == 0) {
 					return cpu;
 				}

--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -110,7 +110,7 @@ void z_x86_early_serial_init(void)
 
 	early_serial_init_done = true;
 
-	if (suppressed_chars) {
+	if (suppressed_chars != 0U) {
 		printk("WARNING: %u chars lost before early serial init\n",
 		       suppressed_chars);
 	}

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -40,18 +40,18 @@ void z_x86_spurious_irq(const z_arch_esf_t *esf)
 	z_x86_fatal_error(K_ERR_SPURIOUS_IRQ, esf);
 }
 
-void arch_syscall_oops(void *ssf_ptr)
+void arch_syscall_oops(void *ssf)
 {
-	struct _x86_syscall_stack_frame *ssf =
-		(struct _x86_syscall_stack_frame *)ssf_ptr;
+	struct _x86_syscall_stack_frame *ssf_ptr =
+		(struct _x86_syscall_stack_frame *)ssf;
 	z_arch_esf_t oops = {
-		.eip = ssf->eip,
-		.cs = ssf->cs,
-		.eflags = ssf->eflags
+		.eip = ssf_ptr->eip,
+		.cs = ssf_ptr->cs,
+		.eflags = ssf_ptr->eflags
 	};
 
 	if (oops.cs == USER_CODE_SEG) {
-		oops.esp = ssf->esp;
+		oops.esp = ssf_ptr->esp;
 	}
 
 	z_x86_fatal_error(K_ERR_KERNEL_OOPS, &oops);

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -518,7 +518,7 @@ static void print_entries(pentry_t entries_array[], uint8_t *base, int level,
 		uintptr_t virt =
 			(uintptr_t)base + (get_entry_scope(level) * i);
 
-		if (entry & MMU_P) {
+		if ((entry & MMU_P) != 0U) {
 			if (is_leaf(level, entry)) {
 				if (phys == virt) {
 					/* Identity mappings */

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -476,7 +476,7 @@ static void litex_clk_print_all_params(void)
 		litex_clk_print_params(&ldev->clkouts[c]);
 	}
 }
-#endif /* #ifdef CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
+#endif /* CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
 
 /* Returns raw value ready to be written into MMCM */
 static inline uint16_t litex_clk_calc_DI(uint16_t DO_val, uint16_t mask,
@@ -1480,7 +1480,7 @@ int litex_clk_set_rate(struct litex_clk_clkout *lcko, unsigned long rate)
 #ifdef CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG
 	litex_clk_print_all_params();
 	litex_clk_print_all_regs();
-#endif /* #ifdef CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
+#endif /* CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
 
 	return 0;
 }
@@ -1769,7 +1769,7 @@ static int litex_clk_init(const struct device *dev)
 #ifdef CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG
 	litex_clk_print_all_params();
 	litex_clk_print_all_regs();
-#endif /* #ifdef CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
+#endif /* CONFIG_CLOCK_CONTROL_LOG_LEVEL_DBG */
 
 	LOG_INF("LiteX Clock Control driver initialized");
 	return 0;

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -154,14 +154,14 @@ int get_value(const struct device *dev, uint32_t *ticks)
 	 * the HOUR_PM flag before we adjust for BCD.
 	 */
 
-	if (state.status_b & STATUS_B_24HR) {
+	if ((state.status_b & STATUS_B_24HR) != 0U) {
 		pm = false;
 	} else {
 		pm = ((state.hour & HOUR_PM) == HOUR_PM);
 		state.hour &= ~HOUR_PM;
 	}
 
-	if (!(state.status_b & STATUS_B_BIN)) {
+	if ((state.status_b & STATUS_B_BIN) == 0U) {
 		uint8_t *cp = (uint8_t *) &state;
 		int i;
 

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -147,4 +147,4 @@ static struct modem_pin modem_pins[] = {
 #endif
 };
 
-#endif /* #ifndef QUECTEL_BG9X_H */
+#endif /* QUECTEL_BG9X_H */

--- a/include/arch/riscv/error.h
+++ b/include/arch/riscv/error.h
@@ -36,7 +36,7 @@ extern "C" {
  */
 
 #define ARCH_EXCEPT(reason_p)	do {			\
-		if (_is_user_context()) {		\
+		if (k_is_user_context()) {		\
 			arch_syscall_invoke1(reason_p,	\
 				K_SYSCALL_USER_FAULT);	\
 		} else {				\

--- a/include/device.h
+++ b/include/device.h
@@ -726,18 +726,18 @@ const char *device_pm_state_str(uint32_t state);
  * Called by a device driver to indicate that it is in the middle of a
  * transaction.
  *
- * @param busy_dev Pointer to device structure of the driver instance.
+ * @param dev Pointer to device structure of the driver instance.
  */
-void device_busy_set(const struct device *busy_dev);
+void device_busy_set(const struct device *dev);
 
 /**
  * @brief Indicate that the device has completed its transaction
  *
  * Called by a device driver to indicate the end of a transaction.
  *
- * @param busy_dev Pointer to device structure of the driver instance.
+ * @param dev Pointer to device structure of the driver instance.
  */
-void device_busy_clear(const struct device *busy_dev);
+void device_busy_clear(const struct device *dev);
 
 #ifdef CONFIG_PM_DEVICE
 /*

--- a/include/init.h
+++ b/include/init.h
@@ -51,7 +51,7 @@ struct init_entry {
 	const struct device *dev;
 };
 
-void z_sys_init_run_level(int32_t _level);
+void z_sys_init_run_level(int32_t level);
 
 /* A counter is used to avoid issues when two or more system devices
  * are declared in the same C file with the same init function.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1016,29 +1016,29 @@ __syscall void *k_thread_custom_data_get(void);
  * Set the name of the thread to be used when @option{CONFIG_THREAD_MONITOR}
  * is enabled for tracing and debugging.
  *
- * @param thread_id Thread to set name, or NULL to set the current thread
- * @param value Name string
+ * @param thread Thread to set name, or NULL to set the current thread
+ * @param str Name string
  * @retval 0 on success
  * @retval -EFAULT Memory access error with supplied string
  * @retval -ENOSYS Thread name configuration option not enabled
  * @retval -EINVAL Thread name too long
  */
-__syscall int k_thread_name_set(k_tid_t thread_id, const char *value);
+__syscall int k_thread_name_set(k_tid_t thread, const char *str);
 
 /**
  * @brief Get thread name
  *
  * Get the name of a thread
  *
- * @param thread_id Thread ID
+ * @param thread Thread ID
  * @retval Thread name, or NULL if configuration not enabled
  */
-const char *k_thread_name_get(k_tid_t thread_id);
+const char *k_thread_name_get(k_tid_t thread);
 
 /**
  * @brief Copy the thread name into a supplied buffer
  *
- * @param thread_id Thread to obtain name information
+ * @param thread Thread to obtain name information
  * @param buf Destination buffer
  * @param size Destination buffer size
  * @retval -ENOSPC Destination buffer too small
@@ -1046,7 +1046,7 @@ const char *k_thread_name_get(k_tid_t thread_id);
  * @retval -ENOSYS Thread name feature not enabled
  * @retval 0 Success
  */
-__syscall int k_thread_name_copy(k_tid_t thread_id, char *buf,
+__syscall int k_thread_name_copy(k_tid_t thread, char *buf,
 				 size_t size);
 
 /**
@@ -4207,14 +4207,14 @@ struct k_msgq_attrs {
  * that each message is similarly aligned to this boundary, @a q_msg_size
  * must also be a multiple of N.
  *
- * @param q Address of the message queue.
+ * @param msgq Address of the message queue.
  * @param buffer Pointer to ring buffer that holds queued messages.
  * @param msg_size Message size (in bytes).
  * @param max_msgs Maximum number of messages that can be queued.
  *
  * @return N/A
  */
-void k_msgq_init(struct k_msgq *q, char *buffer, size_t msg_size,
+void k_msgq_init(struct k_msgq *msgq, char *buffer, size_t msg_size,
 		 uint32_t max_msgs);
 
 /**

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -262,7 +262,7 @@ static inline char z_log_minimal_level_to_char(int level)
 #define __LOG(_level, _id, _filter, ...)				       \
 	do {								       \
 		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
-			bool is_user_context = _is_user_context();	       \
+			bool is_user_context = k_is_user_context();	       \
 									       \
 			if (IS_ENABLED(CONFIG_LOG_MINIMAL)) {		       \
 				Z_LOG_TO_PRINTK(_level, __VA_ARGS__);	       \
@@ -316,7 +316,7 @@ static inline char z_log_minimal_level_to_char(int level)
 #define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	       \
 	do {								       \
 		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
-			bool is_user_context = _is_user_context();	       \
+			bool is_user_context = k_is_user_context();	       \
 									       \
 			if (IS_ENABLED(CONFIG_LOG_MINIMAL)) {		       \
 				Z_LOG_TO_PRINTK(_level, "%s", _str);	       \
@@ -723,7 +723,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 #define __LOG_VA(_level, _id, _filter, _str, _valist, _argnum, _strdup_action) \
 	do {								       \
 		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
-			bool is_user_context = _is_user_context();	       \
+			bool is_user_context = k_is_user_context();	       \
 									       \
 			if (IS_ENABLED(CONFIG_LOG_MINIMAL)) {		       \
 				z_log_minimal_printk(_str, _valist);	       \

--- a/include/sys/sys_heap.h
+++ b/include/sys/sys_heap.h
@@ -65,11 +65,11 @@ struct z_heap_stress_result {
  *
  * Initializes a sys_heap struct to manage the specified memory.
  *
- * @param h Heap to initialize
+ * @param heap Heap to initialize
  * @param mem Untyped pointer to unused memory
  * @param bytes Size of region pointed to by @a mem
  */
-void sys_heap_init(struct sys_heap *h, void *mem, size_t bytes);
+void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes);
 
 /** @brief Allocate memory from a sys_heap
  *
@@ -84,11 +84,11 @@ void sys_heap_init(struct sys_heap *h, void *mem, size_t bytes);
  * No two sys_heap functions should operate on the same heap at the
  * same time.  All locking must be provided by the user.
  *
- * @param h Heap from which to allocate
+ * @param heap Heap from which to allocate
  * @param bytes Number of bytes requested
  * @return Pointer to memory the caller can now use
  */
-void *sys_heap_alloc(struct sys_heap *h, size_t bytes);
+void *sys_heap_alloc(struct sys_heap *heap, size_t bytes);
 
 /** @brief Allocate aligned memory from a sys_heap
  *
@@ -98,12 +98,12 @@ void *sys_heap_alloc(struct sys_heap *h, size_t bytes);
  * bytes.  With align=0 this behaves exactly like sys_heap_alloc().
  * The resulting memory can be returned to the heap using sys_heap_free().
  *
- * @param h Heap from which to allocate
+ * @param heap Heap from which to allocate
  * @param align Alignment in bytes, must be a power of two
  * @param bytes Number of bytes requested
  * @return Pointer to memory the caller can now use
  */
-void *sys_heap_aligned_alloc(struct sys_heap *h, size_t align, size_t bytes);
+void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes);
 
 /** @brief Free memory into a sys_heap
  *
@@ -115,10 +115,10 @@ void *sys_heap_aligned_alloc(struct sys_heap *h, size_t align, size_t bytes);
  * No two sys_heap functions should operate on the same heap at the
  * same time.  All locking must be provided by the user.
  *
- * @param h Heap to which to return the memory
+ * @param heap Heap to which to return the memory
  * @param mem A pointer previously returned from sys_heap_alloc()
  */
-void sys_heap_free(struct sys_heap *h, void *mem);
+void sys_heap_free(struct sys_heap *heap, void *mem);
 
 /** @brief Expand the size of an existing allocation
  *
@@ -159,10 +159,10 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
  * handle any sys_heap_alloc() request and free any live pointer
  * returned from a previou allocation.
  *
- * @param h Heap to validate
+ * @param heap Heap to validate
  * @return true, if the heap is valid, otherwise false
  */
-bool sys_heap_validate(struct sys_heap *h);
+bool sys_heap_validate(struct sys_heap *heap);
 
 /** @brief sys_heap stress test rig
  *
@@ -175,9 +175,9 @@ bool sys_heap_validate(struct sys_heap *h);
  * Results, including counts of frees and successful/unsuccessful
  * allocations, are returnewd via the @result struct.
  *
- * @param alloc Callback to perform an allocation.  Passes back the @a
+ * @param alloc_fn Callback to perform an allocation.  Passes back the @a
  *              arg parameter as a context handle.
- * @param free Callback to perform a free of a pointer returned from
+ * @param free_fn Callback to perform a free of a pointer returned from
  *             @a alloc.  Passes back the @a arg parameter as a
  *             context handle.
  * @param arg Context handle to pass back to the callbacks
@@ -193,8 +193,8 @@ bool sys_heap_validate(struct sys_heap *h);
  *                       failures and a very fragmented heap.
  * @param result Struct into which to store test results.
  */
-void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
-		     void (*free)(void *arg, void *p),
+void sys_heap_stress(void *(*alloc_fn)(void *arg, size_t bytes),
+		     void (*free_fn)(void *arg, void *p),
 		     void *arg, size_t total_bytes,
 		     uint32_t op_count,
 		     void *scratch_mem, size_t scratch_bytes,
@@ -206,9 +206,9 @@ void sys_heap_stress(void *(*alloc)(void *arg, size_t bytes),
  * Print information on the heap structure such as its size, chunk buckets,
  * chunk list and some statistics for debugging purpose.
  *
- * @param h Heap to print information about
+ * @param heap Heap to print information about
  * @param dump_chunks True to print the entire heap chunk list
  */
-void sys_heap_print_info(struct sys_heap *h, bool dump_chunks);
+void sys_heap_print_info(struct sys_heap *heap, bool dump_chunks);
 
 #endif /* ZEPHYR_INCLUDE_SYS_SYS_HEAP_H_ */

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -110,7 +110,7 @@ static ALWAYS_INLINE bool z_syscall_trap(void)
  *
  * @return true if the CPU is currently running with user permissions
  */
-static inline bool _is_user_context(void)
+static inline bool k_is_user_context(void)
 {
 #ifdef CONFIG_USERSPACE
 	return arch_is_user_context();

--- a/include/timeout_q.h
+++ b/include/timeout_q.h
@@ -22,9 +22,9 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
-static inline void z_init_timeout(struct _timeout *t)
+static inline void z_init_timeout(struct _timeout *to)
 {
-	sys_dnode_init(&t->node);
+	sys_dnode_init(&to->node);
 }
 
 void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
@@ -32,9 +32,9 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 
 int z_abort_timeout(struct _timeout *to);
 
-static inline bool z_is_inactive_timeout(const struct _timeout *t)
+static inline bool z_is_inactive_timeout(const struct _timeout *to)
 {
-	return !sys_dnode_is_linked(&t->node);
+	return !sys_dnode_is_linked(&to->node);
 }
 
 static inline void z_init_thread_timeout(struct _thread_base *thread_base)
@@ -42,11 +42,11 @@ static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 	z_init_timeout(&thread_base->timeout);
 }
 
-extern void z_thread_timeout(struct _timeout *to);
+extern void z_thread_timeout(struct _timeout *timeout);
 
-static inline void z_add_thread_timeout(struct k_thread *th, k_timeout_t ticks)
+static inline void z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
 {
-	z_add_timeout(&th->base.timeout, z_thread_timeout, ticks);
+	z_add_timeout(&thread->base.timeout, z_thread_timeout, ticks);
 }
 
 static inline int z_abort_thread_timeout(struct k_thread *thread)
@@ -56,22 +56,22 @@ static inline int z_abort_thread_timeout(struct k_thread *thread)
 
 int32_t z_get_next_timeout_expiry(void);
 
-void z_set_timeout_expiry(int32_t ticks, bool idle);
+void z_set_timeout_expiry(int32_t ticks, bool is_idle);
 
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 #else
 
 /* Stubs when !CONFIG_SYS_CLOCK_EXISTS */
-#define z_init_thread_timeout(t) do {} while (false)
-#define z_abort_thread_timeout(t) (0)
-#define z_is_inactive_timeout(t) 0
+#define z_init_thread_timeout(thread_base) do {} while (false)
+#define z_abort_thread_timeout(to) (0)
+#define z_is_inactive_timeout(to) 0
 #define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
-#define z_set_timeout_expiry(t, i) do {} while (false)
+#define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 
-static inline void z_add_thread_timeout(struct k_thread *th, k_timeout_t ticks)
+static inline void z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
 {
-	ARG_UNUSED(th);
+	ARG_UNUSED(thread);
 	ARG_UNUSED(ticks);
 }
 

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -137,7 +137,7 @@
 #define __syscall static inline
 #else
 #define __syscall
-#endif /* #ifndef ZTEST_UNITTEST */
+#endif /* ZTEST_UNITTEST */
 
 /* Definitions for struct declaration tags. These are sentinel values used by
  * parse_syscalls.py to gather a list of names of struct declarations that

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -112,7 +112,7 @@ const struct device *z_impl_device_get_binding(const char *name)
 	/* A null string identifies no device.  So does an empty
 	 * string.
 	 */
-	if ((name == NULL) || (*name == 0)) {
+	if ((name == NULL) || (*name == 0U)) {
 		return NULL;
 	}
 
@@ -167,7 +167,7 @@ size_t z_device_get_all_static(struct device const **devices)
 
 bool z_device_ready(const struct device *dev)
 {
-	return dev->state->initialized && (dev->state->init_res == 0);
+	return dev->state->initialized && (dev->state->init_res == 0U);
 }
 
 int device_required_foreach(const struct device *dev,

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -112,7 +112,7 @@ const struct device *z_impl_device_get_binding(const char *name)
 	/* A null string identifies no device.  So does an empty
 	 * string.
 	 */
-	if ((name == NULL) || (*name == 0U)) {
+	if ((name == NULL) || (name[0] == '\0')) {
 		return NULL;
 	}
 

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -48,9 +48,9 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 
 static const char *thread_name_get(struct k_thread *thread)
 {
-	const char *thread_name = thread ? k_thread_name_get(thread) : NULL;
+	const char *thread_name = (thread != NULL) ? k_thread_name_get(thread) : NULL;
 
-	if (thread_name == NULL || thread_name[0] == '\0') {
+	if ((thread_name == NULL) || (thread_name[0] == '\0')) {
 		thread_name = "unknown";
 	}
 

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -40,7 +40,7 @@ int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 
 	do {
 		thread = z_unpend_first_thread(&futex_data->wait_q);
-		if (thread) {
+		if (thread != NULL) {
 			woken++;
 			arch_thread_return_value_set(thread, 0);
 			z_ready_thread(thread);

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -275,12 +275,12 @@ static inline bool arch_is_in_isr(void);
  * This API is part of infrastructure still under development and may
  * change.
  *
- * @param dest Page-aligned Destination virtual address to map
- * @param addr Page-aligned Source physical address to map
+ * @param virt Page-aligned Destination virtual address to map
+ * @param phys Page-aligned Source physical address to map
  * @param size Page-aligned size of the mapped memory region in bytes
  * @param flags Caching, access and control flags, see K_MAP_* macros
  */
-void arch_mem_map(void *dest, uintptr_t addr, size_t size, uint32_t flags);
+void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
 
 /**
  * Remove mappings for a provided virtual address range

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -250,7 +250,7 @@ static inline void z_sched_lock(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
 	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(_current->base.sched_locked != 1, "");
+	__ASSERT(_current->base.sched_locked != 1U, "");
 
 	--_current->base.sched_locked;
 
@@ -263,7 +263,7 @@ static ALWAYS_INLINE void z_sched_unlock_no_reschedule(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
 	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(_current->base.sched_locked != 0, "");
+	__ASSERT(_current->base.sched_locked != 0U, "");
 
 	compiler_barrier();
 

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -28,7 +28,7 @@
 #define Z_PHYS_RAM_START	((uintptr_t)CONFIG_SRAM_BASE_ADDRESS)
 #define Z_PHYS_RAM_SIZE		((size_t)KB(CONFIG_SRAM_SIZE))
 #define Z_PHYS_RAM_END		(Z_PHYS_RAM_START + Z_PHYS_RAM_SIZE)
-#define Z_NUM_PAGE_FRAMES	(Z_PHYS_RAM_SIZE / CONFIG_MMU_PAGE_SIZE)
+#define Z_NUM_PAGE_FRAMES	(Z_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 
 /** End virtual address of virtual address space */
 #define Z_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
@@ -118,27 +118,27 @@ struct z_page_frame {
 
 static inline bool z_page_frame_is_pinned(struct z_page_frame *pf)
 {
-	return (pf->flags & Z_PAGE_FRAME_PINNED) != 0;
+	return (pf->flags & Z_PAGE_FRAME_PINNED) != 0U;
 }
 
 static inline bool z_page_frame_is_reserved(struct z_page_frame *pf)
 {
-	return (pf->flags & Z_PAGE_FRAME_RESERVED) != 0;
+	return (pf->flags & Z_PAGE_FRAME_RESERVED) != 0U;
 }
 
 static inline bool z_page_frame_is_mapped(struct z_page_frame *pf)
 {
-	return (pf->flags & Z_PAGE_FRAME_MAPPED) != 0;
+	return (pf->flags & Z_PAGE_FRAME_MAPPED) != 0U;
 }
 
 static inline bool z_page_frame_is_busy(struct z_page_frame *pf)
 {
-	return (pf->flags & Z_PAGE_FRAME_BUSY) != 0;
+	return (pf->flags & Z_PAGE_FRAME_BUSY) != 0U;
 }
 
 static inline bool z_page_frame_is_backed(struct z_page_frame *pf)
 {
-	return (pf->flags & Z_PAGE_FRAME_BACKED) != 0;
+	return (pf->flags & Z_PAGE_FRAME_BACKED) != 0U;
 }
 
 static inline bool z_page_frame_is_evictable(struct z_page_frame *pf)
@@ -152,12 +152,12 @@ static inline bool z_page_frame_is_evictable(struct z_page_frame *pf)
  */
 static inline bool z_page_frame_is_available(struct z_page_frame *page)
 {
-	return page->flags == 0;
+	return page->flags == 0U;
 }
 
 static inline void z_assert_phys_aligned(uintptr_t phys)
 {
-	__ASSERT(phys % CONFIG_MMU_PAGE_SIZE == 0,
+	__ASSERT(phys % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "physical address 0x%lx is not page-aligned", phys);
 	(void)phys;
 }
@@ -193,9 +193,9 @@ static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
 
 static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 {
-	__ASSERT((uintptr_t)addr % CONFIG_MMU_PAGE_SIZE == 0,
+	__ASSERT((uintptr_t)addr % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned addr %p", addr);
-	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0,
+	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned size %zu", size);
 	__ASSERT(addr + size > addr,
 		 "region %p size %zu zero or wraps around", addr, size);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -332,7 +332,7 @@ sys_rand_fallback:
 	 * those devices without a HWRNG entropy driver.
 	 */
 
-	while (length > 0) {
+	while (length > 0U) {
 		uint32_t rndbits;
 		uint8_t *p_rndbits = (uint8_t *)&rndbits;
 

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -97,12 +97,12 @@ SYS_INIT(init_mbox_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 #endif /* CONFIG_NUM_MBOX_ASYNC_MSGS or CONFIG_OBJECT_TRACING */
 
-void k_mbox_init(struct k_mbox *mbox_ptr)
+void k_mbox_init(struct k_mbox *mbox)
 {
-	z_waitq_init(&mbox_ptr->tx_msg_queue);
-	z_waitq_init(&mbox_ptr->rx_msg_queue);
-	mbox_ptr->lock = (struct k_spinlock) {};
-	SYS_TRACING_OBJ_INIT(k_mbox, mbox_ptr);
+	z_waitq_init(&mbox->tx_msg_queue);
+	z_waitq_init(&mbox->rx_msg_queue);
+	mbox->lock = (struct k_spinlock) {};
+	SYS_TRACING_OBJ_INIT(k_mbox, mbox);
 }
 
 /**

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -343,7 +343,7 @@ void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer)
 	}
 
 	/* copy message data to buffer, then dispose of message */
-	if ((rx_msg->tx_data != NULL) && (rx_msg->size > 0)) {
+	if ((rx_msg->tx_data != NULL) && (rx_msg->size > 0U)) {
 		(void)memcpy(buffer, rx_msg->tx_data, rx_msg->size);
 	}
 	mbox_message_dispose(rx_msg);
@@ -370,7 +370,7 @@ static int mbox_message_data_check(struct k_mbox_msg *rx_msg, void *buffer)
 	if (buffer != NULL) {
 		/* retrieve data now, then dispose of message */
 		k_mbox_data_get(rx_msg, buffer);
-	} else if (rx_msg->size == 0) {
+	} else if (rx_msg->size == 0U) {
 		/* there is no data to get, so just dispose of message */
 		mbox_message_dispose(rx_msg);
 	} else {

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -45,7 +45,7 @@ static bool check_add_partition(struct k_mem_domain *domain,
 	}
 #endif
 
-	if (part->size == 0) {
+	if (part->size == 0U) {
 		LOG_ERR("zero sized partition at %p with base 0x%lx",
 			part, part->start);
 		return false;
@@ -66,7 +66,7 @@ static bool check_add_partition(struct k_mem_domain *domain,
 	for (i = 0; i < domain->num_partitions; i++) {
 		struct k_mem_partition *dpart = &domain->partitions[i];
 
-		if (dpart->size == 0) {
+		if (dpart->size == 0U) {
 			/* Unused slot */
 			continue;
 		}

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -36,7 +36,7 @@ static int create_free_list(struct k_mem_slab *slab)
 
 	/* blocks must be word aligned */
 	CHECKIF(((slab->block_size | (uintptr_t)slab->buffer) &
-				(sizeof(void *) - 1)) != 0) {
+				(sizeof(void *) - 1)) != 0U) {
 		return -EINVAL;
 	}
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -103,7 +103,7 @@ void *z_thread_aligned_alloc(size_t align, size_t size)
 		heap = _current->resource_pool;
 	}
 
-	if (heap) {
+	if (heap != NULL) {
 		ret = z_heap_aligned_alloc(heap, align, size);
 	} else {
 		ret = NULL;

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -293,8 +293,8 @@ static int map_anon_page(void *addr, uint32_t flags)
 {
 	struct z_page_frame *pf;
 	uintptr_t phys;
-	bool lock = (flags & K_MEM_MAP_LOCK) != 0;
-	bool uninit = (flags & K_MEM_MAP_UNINIT) != 0;
+	bool lock = (flags & K_MEM_MAP_LOCK) != 0U;
+	bool uninit = (flags & K_MEM_MAP_UNINIT) != 0U;
 
 	pf = free_page_frame_list_get();
 	if (pf == NULL) {
@@ -346,17 +346,17 @@ void *k_mem_map(size_t size, uint32_t flags)
 	size_t total_size = size;
 	int ret;
 	k_spinlock_key_t key;
-	bool guard = (flags & K_MEM_MAP_GUARD) != 0;
+	bool guard = (flags & K_MEM_MAP_GUARD) != 0U;
 	uint8_t *pos;
 
-	__ASSERT(!(((flags & K_MEM_PERM_USER) != 0) &&
-		   ((flags & K_MEM_MAP_UNINIT) != 0)),
+	__ASSERT(!(((flags & K_MEM_PERM_USER) != 0U) &&
+		   ((flags & K_MEM_MAP_UNINIT) != 0U)),
 		 "user access to anonymous uninitialized pages is forbidden");
-	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0,
+	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned size %zu passed to %s", size, __func__);
 	__ASSERT(size != 0, "zero sized memory mapping");
 	__ASSERT(page_frames_initialized, "%s called too early", __func__);
-	__ASSERT((flags & K_MEM_CACHE_MASK) == 0,
+	__ASSERT((flags & K_MEM_CACHE_MASK) == 0U,
 		 "%s does not support explicit cache settings", __func__);
 
 	key = k_spin_lock(&z_mm_lock);
@@ -406,7 +406,7 @@ size_t k_mem_free_get(void)
 	ret = z_free_page_count;
 	k_spin_unlock(&z_mm_lock, key);
 
-	return ret * CONFIG_MMU_PAGE_SIZE;
+	return ret * (size_t)CONFIG_MMU_PAGE_SIZE;
 }
 
 /* This may be called from arch early boot code before z_cstart() is invoked.
@@ -423,7 +423,7 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
 	addr_offset = k_mem_region_align(&aligned_phys, &aligned_size,
 					 phys, size,
 					 CONFIG_MMU_PAGE_SIZE);
-	__ASSERT(aligned_size != 0, "0-length mapping at 0x%lx", aligned_phys);
+	__ASSERT(aligned_size != 0U, "0-length mapping at 0x%lx", aligned_phys);
 	__ASSERT(aligned_phys < (aligned_phys + (aligned_size - 1)),
 		 "wraparound for physical address 0x%lx (size %zu)",
 		 aligned_phys, aligned_size);
@@ -497,7 +497,7 @@ void z_kernel_map_fixup(void)
 				      CONFIG_MMU_PAGE_SIZE);
 	size_t kobject_size = (size_t)(Z_KERNEL_VIRT_END - kobject_page_begin);
 
-	if (kobject_size != 0) {
+	if (kobject_size != 0U) {
 		arch_mem_map(kobject_page_begin,
 			     Z_BOOT_VIRT_TO_PHYS(kobject_page_begin),
 			     kobject_size, K_MEM_PERM_RW | K_MEM_CACHE_WB);

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -466,16 +466,16 @@ fail:
  * Miscellaneous
  */
 
-size_t k_mem_region_align(uintptr_t *aligned_phys, size_t *aligned_size,
-			  uintptr_t phys_addr, size_t size, size_t align)
+size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
+			  uintptr_t addr, size_t size, size_t align)
 {
 	size_t addr_offset;
 
 	/* The actual mapped region must be page-aligned. Round down the
 	 * physical address and pad the region size appropriately
 	 */
-	*aligned_phys = ROUND_DOWN(phys_addr, align);
-	addr_offset = phys_addr - *aligned_phys;
+	*aligned_addr = ROUND_DOWN(addr, align);
+	addr_offset = addr - *aligned_addr;
 	*aligned_size = ROUND_UP(size + addr_offset, align);
 
 	return addr_offset;

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -105,7 +105,7 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 		return -EBUSY;
 	}
 
-	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0) {
+	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0U) {
 		k_free(msgq->buffer_start);
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
@@ -199,7 +199,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 
 	key = k_spin_lock(&msgq->lock);
 
-	if (msgq->used_msgs > 0) {
+	if (msgq->used_msgs > 0U) {
 		/* take first available message from queue */
 		(void)memcpy(data, msgq->read_ptr, msgq->msg_size);
 		msgq->read_ptr += msgq->msg_size;
@@ -260,7 +260,7 @@ int z_impl_k_msgq_peek(struct k_msgq *msgq, void *data)
 
 	key = k_spin_lock(&msgq->lock);
 
-	if (msgq->used_msgs > 0) {
+	if (msgq->used_msgs > 0U) {
 		/* take first available message from queue */
 		(void)memcpy(data, msgq->read_ptr, msgq->msg_size);
 		result = 0;

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -89,12 +89,12 @@ int z_impl_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 }
 
 #ifdef CONFIG_USERSPACE
-int z_vrfy_k_msgq_alloc_init(struct k_msgq *q, size_t msg_size,
+int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 			    uint32_t max_msgs)
 {
-	Z_OOPS(Z_SYSCALL_OBJ_NEVER_INIT(q, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_OBJ_NEVER_INIT(msgq, K_OBJ_MSGQ));
 
-	return z_impl_k_msgq_alloc_init(q, msg_size, max_msgs);
+	return z_impl_k_msgq_alloc_init(msgq, msg_size, max_msgs);
 }
 #include <syscalls/k_msgq_alloc_init_mrsh.c>
 #endif
@@ -160,13 +160,13 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_msgq_put(struct k_msgq *q, const void *data,
+static inline int z_vrfy_k_msgq_put(struct k_msgq *msgq, const void *data,
 				    k_timeout_t timeout)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(data, q->msg_size));
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(data, msgq->msg_size));
 
-	return z_impl_k_msgq_put(q, data, timeout);
+	return z_impl_k_msgq_put(msgq, data, timeout);
 }
 #include <syscalls/k_msgq_put_mrsh.c>
 #endif
@@ -179,12 +179,12 @@ void z_impl_k_msgq_get_attrs(struct k_msgq *msgq, struct k_msgq_attrs *attrs)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_msgq_get_attrs(struct k_msgq *q,
+static inline void z_vrfy_k_msgq_get_attrs(struct k_msgq *msgq,
 					   struct k_msgq_attrs *attrs)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(attrs, sizeof(struct k_msgq_attrs)));
-	z_impl_k_msgq_get_attrs(q, attrs);
+	z_impl_k_msgq_get_attrs(msgq, attrs);
 }
 #include <syscalls/k_msgq_get_attrs_mrsh.c>
 #endif
@@ -242,13 +242,13 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_msgq_get(struct k_msgq *q, void *data,
+static inline int z_vrfy_k_msgq_get(struct k_msgq *msgq, void *data,
 				    k_timeout_t timeout)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, q->msg_size));
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, msgq->msg_size));
 
-	return z_impl_k_msgq_get(q, data, timeout);
+	return z_impl_k_msgq_get(msgq, data, timeout);
 }
 #include <syscalls/k_msgq_get_mrsh.c>
 #endif
@@ -275,12 +275,12 @@ int z_impl_k_msgq_peek(struct k_msgq *msgq, void *data)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_msgq_peek(struct k_msgq *q, void *data)
+static inline int z_vrfy_k_msgq_peek(struct k_msgq *msgq, void *data)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, q->msg_size));
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, msgq->msg_size));
 
-	return z_impl_k_msgq_peek(q, data);
+	return z_impl_k_msgq_peek(msgq, data);
 }
 #include <syscalls/k_msgq_peek_mrsh.c>
 #endif
@@ -305,24 +305,24 @@ void z_impl_k_msgq_purge(struct k_msgq *msgq)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_msgq_purge(struct k_msgq *q)
+static inline void z_vrfy_k_msgq_purge(struct k_msgq *msgq)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	z_impl_k_msgq_purge(q);
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	z_impl_k_msgq_purge(msgq);
 }
 #include <syscalls/k_msgq_purge_mrsh.c>
 
-static inline uint32_t z_vrfy_k_msgq_num_free_get(struct k_msgq *q)
+static inline uint32_t z_vrfy_k_msgq_num_free_get(struct k_msgq *msgq)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	return z_impl_k_msgq_num_free_get(q);
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	return z_impl_k_msgq_num_free_get(msgq);
 }
 #include <syscalls/k_msgq_num_free_get_mrsh.c>
 
-static inline uint32_t z_vrfy_k_msgq_num_used_get(struct k_msgq *q)
+static inline uint32_t z_vrfy_k_msgq_num_used_get(struct k_msgq *msgq)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(q, K_OBJ_MSGQ));
-	return z_impl_k_msgq_num_used_get(q);
+	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	return z_impl_k_msgq_num_used_get(msgq);
 }
 #include <syscalls/k_msgq_num_used_get_mrsh.c>
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -116,7 +116,7 @@ int z_impl_k_pipe_alloc_init(struct k_pipe *pipe, size_t size)
 	void *buffer;
 	int ret;
 
-	if (size != 0) {
+	if (size != 0U) {
 		buffer = z_thread_malloc(size);
 		if (buffer != NULL) {
 			k_pipe_init(pipe, buffer, size);
@@ -150,7 +150,7 @@ int k_pipe_cleanup(struct k_pipe *pipe)
 		return -EAGAIN;
 	}
 
-	if ((pipe->flags & K_PIPE_FLAG_ALLOC) != 0) {
+	if ((pipe->flags & K_PIPE_FLAG_ALLOC) != 0U) {
 		k_free(pipe->buffer);
 		pipe->buffer = NULL;
 		pipe->flags &= ~K_PIPE_FLAG_ALLOC;
@@ -493,7 +493,7 @@ int z_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)
 	    && num_bytes_written >= min_xfer
-	    && min_xfer > 0) {
+	    && min_xfer > 0U) {
 		*bytes_written = num_bytes_written;
 		k_sched_unlock();
 		return 0;
@@ -647,7 +647,7 @@ int z_impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)
 	    && num_bytes_read >= min_xfer
-	    && min_xfer > 0) {
+	    && min_xfer > 0U) {
 		k_sched_unlock();
 
 		*bytes_read = num_bytes_read;
@@ -725,7 +725,7 @@ size_t z_impl_k_pipe_read_avail(struct k_pipe *pipe)
 	k_spinlock_key_t key;
 
 	/* Buffer and size are fixed. No need to spin. */
-	if (pipe->buffer == NULL || pipe->size == 0) {
+	if (pipe->buffer == NULL || pipe->size == 0U) {
 		res = 0;
 		goto out;
 	}
@@ -762,7 +762,7 @@ size_t z_impl_k_pipe_write_avail(struct k_pipe *pipe)
 	k_spinlock_key_t key;
 
 	/* Buffer and size are fixed. No need to spin. */
-	if (pipe->buffer == NULL || pipe->size == 0) {
+	if (pipe->buffer == NULL || pipe->size == 0U) {
 		res = 0;
 		goto out;
 	}

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -387,7 +387,7 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 	struct z_poller *poller = event->poller;
 	int retcode = 0;
 
-	if (poller) {
+	if (poller != NULL) {
 		if (poller->mode == MODE_POLL) {
 			retcode = signal_poller(event, state);
 		} else if (poller->mode == MODE_TRIGGERED) {

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -316,7 +316,7 @@ static inline int z_vrfy_k_poll(struct k_poll_event *events,
 	/* Validate the events buffer and make a copy of it in an
 	 * allocated kernel-side buffer.
 	 */
-	if (Z_SYSCALL_VERIFY(num_events >= 0)) {
+	if (Z_SYSCALL_VERIFY(num_events >= 0U)) {
 		ret = -EINVAL;
 		goto out;
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -235,7 +235,7 @@ void z_requeue_current(struct k_thread *curr)
 
 static inline bool is_aborting(struct k_thread *thread)
 {
-	return (thread->base.thread_state & _THREAD_ABORTING) != 0;
+	return (thread->base.thread_state & _THREAD_ABORTING) != 0U;
 }
 
 static ALWAYS_INLINE struct k_thread *next_up(void)
@@ -776,7 +776,7 @@ void z_thread_priority_set(struct k_thread *thread, int prio)
 	arch_sched_ipi();
 #endif
 
-	if (need_sched && _current->base.sched_locked == 0) {
+	if (need_sched && _current->base.sched_locked == 0U) {
 		z_reschedule_unlocked();
 	}
 }
@@ -837,7 +837,7 @@ void k_sched_unlock(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
 	LOCKED(&sched_spinlock) {
-		__ASSERT(_current->base.sched_locked != 0, "");
+		__ASSERT(_current->base.sched_locked != 0U, "");
 		__ASSERT(!arch_is_in_isr(), "");
 
 		++_current->base.sched_locked;
@@ -1452,7 +1452,7 @@ static void end_thread(struct k_thread *thread)
 	/* We hold the lock, and the thread is known not to be running
 	 * anywhere.
 	 */
-	if ((thread->base.thread_state & _THREAD_DEAD) == 0) {
+	if ((thread->base.thread_state & _THREAD_DEAD) == 0U) {
 		thread->base.thread_state |= _THREAD_DEAD;
 		thread->base.thread_state &= ~_THREAD_ABORTING;
 		if (z_is_thread_queued(thread)) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1124,7 +1124,7 @@ static inline int z_vrfy_k_thread_priority_get(k_tid_t thread)
 #include <syscalls/k_thread_priority_get_mrsh.c>
 #endif
 
-void z_impl_k_thread_priority_set(k_tid_t tid, int prio)
+void z_impl_k_thread_priority_set(k_tid_t thread, int prio)
 {
 	/*
 	 * Use NULL, since we cannot know what the entry point is (we do not
@@ -1133,9 +1133,9 @@ void z_impl_k_thread_priority_set(k_tid_t tid, int prio)
 	Z_ASSERT_VALID_PRIO(prio, NULL);
 	__ASSERT(!arch_is_in_isr(), "");
 
-	struct k_thread *thread = (struct k_thread *)tid;
+	struct k_thread *th = (struct k_thread *)thread;
 
-	z_thread_priority_set(thread, prio);
+	z_thread_priority_set(th, prio);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -844,7 +844,7 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 {
 	uintptr_t thread_cpu = l->thread_cpu;
 
-	if (thread_cpu) {
+	if (thread_cpu != 0U) {
 		if ((thread_cpu & 3U) == _current_cpu->id) {
 			return false;
 		}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -123,7 +123,7 @@ bool z_is_thread_essential(void)
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 void z_impl_k_busy_wait(uint32_t usec_to_wait)
 {
-	if (usec_to_wait == 0) {
+	if (usec_to_wait == 0U) {
 		return;
 	}
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -234,13 +234,13 @@ int z_impl_k_thread_name_set(struct k_thread *thread, const char *value)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_thread_name_set(struct k_thread *t, const char *str)
+static inline int z_vrfy_k_thread_name_set(struct k_thread *thread, const char *str)
 {
 #ifdef CONFIG_THREAD_NAME
 	char name[CONFIG_THREAD_MAX_NAME_LEN];
 
-	if (t != NULL) {
-		if (Z_SYSCALL_OBJ(t, K_OBJ_THREAD) != 0) {
+	if (thread != NULL) {
+		if (Z_SYSCALL_OBJ(thread, K_OBJ_THREAD) != 0) {
 			return -EINVAL;
 		}
 	}
@@ -253,7 +253,7 @@ static inline int z_vrfy_k_thread_name_set(struct k_thread *t, const char *str)
 		return -EFAULT;
 	}
 
-	return z_impl_k_thread_name_set(t, name);
+	return z_impl_k_thread_name_set(thread, name);
 #else
 	return -ENOSYS;
 #endif /* CONFIG_THREAD_NAME */
@@ -271,13 +271,13 @@ const char *k_thread_name_get(struct k_thread *thread)
 #endif /* CONFIG_THREAD_NAME */
 }
 
-int z_impl_k_thread_name_copy(k_tid_t thread_id, char *buf, size_t size)
+int z_impl_k_thread_name_copy(k_tid_t thread, char *buf, size_t size)
 {
 #ifdef CONFIG_THREAD_NAME
-	strncpy(buf, thread_id->name, size);
+	strncpy(buf, thread->name, size);
 	return 0;
 #else
-	ARG_UNUSED(thread_id);
+	ARG_UNUSED(thread);
 	ARG_UNUSED(buf);
 	ARG_UNUSED(size);
 	return -ENOSYS;

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -806,7 +806,7 @@ char *z_user_string_alloc_copy(const char *src, size_t maxlen)
 	 * properly.
 	 */
 	if (ret != NULL) {
-		ret[actual_len - 1] = '\0';
+		ret[actual_len - 1U] = '\0';
 	}
 out:
 	return ret;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -395,7 +395,7 @@ static bool work_flush_locked(struct k_work *work,
 			      struct z_work_flusher *flusher)
 {
 	bool need_flush = (flags_get(&work->flags)
-			   & (K_WORK_QUEUED | K_WORK_RUNNING)) != 0;
+			   & (K_WORK_QUEUED | K_WORK_RUNNING)) != 0U;
 
 	if (need_flush) {
 		struct k_work_q *queue = work->queue;

--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -37,7 +37,7 @@ __weak void assert_post_action(const char *file, unsigned int line)
 	/* User threads aren't allowed to induce kernel panics; generate
 	 * an oops instead.
 	 */
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		k_oops();
 	}
 #endif

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -120,7 +120,7 @@ static int char_out(int c, void *ctx_p)
 #ifdef CONFIG_USERSPACE
 void vprintk(const char *fmt, va_list ap)
 {
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		struct buf_out_context ctx = { 0 };
 
 		cbvprintf(buf_char_out, &ctx, fmt, ap);

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -778,7 +778,7 @@ int espi_saf_test1(uint32_t spi_addr)
 
 	return rc;
 }
-#endif /* #ifdef CONFIG_ESPI_SAF */
+#endif /* CONFIG_ESPI_SAF */
 
 static void host_warn_handler(uint32_t signal, uint32_t status)
 {

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -278,7 +278,7 @@ static void external_log_system_showcase(void)
 
 static void log_demo_thread(void *p1, void *p2, void *p3)
 {
-	bool usermode = _is_user_context();
+	bool usermode = k_is_user_context();
 
 	k_sleep(K_MSEC(100));
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -338,7 +338,7 @@ void log_printk(const char *fmt, va_list ap)
 			}
 		};
 
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			uint8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
 
 			vsnprintk(str, sizeof(str), fmt, ap);
@@ -391,7 +391,7 @@ uint32_t log_count_args(const char *fmt)
 void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap,
 		 enum log_strdup_action strdup_action)
 {
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		log_generic_from_user(src_level, fmt, ap);
 	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&
 	    (!IS_ENABLED(CONFIG_LOG_FRONTEND))) {
@@ -895,7 +895,7 @@ char *log_strdup(const char *str)
 	int err;
 
 	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) ||
-	    is_rodata(str) || _is_user_context()) {
+	    is_rodata(str) || k_is_user_context()) {
 		return (char *)str;
 	}
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -156,7 +156,7 @@ static int cmd_device_list(const struct shell *shell,
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, " (%s)\n", state);
-		if (!_is_user_context()) {
+		if (!k_is_user_context()) {
 			struct cmd_device_list_visitor_context ctx = {
 				.shell = shell,
 				.buf = buf,

--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -101,7 +101,7 @@ static inline void get_start_time_cyc(void)
 	 * TC_START() in their code. But the caller thread cannot be
 	 * in userspace.
 	 */
-	if (!_is_user_context()) {
+	if (!k_is_user_context()) {
 		tc_start_time = k_cycle_get_32();
 	}
 }

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -137,7 +137,7 @@ void assert_post_action(const char *file, unsigned int line)
 	/* User threads aren't allowed to induce kernel panics; generate
 	 * an oops instead.
 	 */
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			k_oops();
 		}
 #endif

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -144,7 +144,7 @@ void test_errno(void)
 	k_tid_t tid;
 	uint32_t perm = K_INHERIT_PERMS;
 
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		perm = perm | K_USER;
 	}
 

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -1104,7 +1104,7 @@ void test_kobject_free_error(void)
 {
 	uint32_t perm = K_INHERIT_PERMS;
 
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		perm = perm | K_USER;
 	}
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -97,7 +97,7 @@ static void test_is_usermode(void)
 	/* Confirm that we are in fact running in user mode. */
 	clear_fault();
 
-	zassert_true(_is_user_context(), "thread left in kernel mode");
+	zassert_true(k_is_user_context(), "thread left in kernel mode");
 }
 
 /**
@@ -547,7 +547,7 @@ static void test_access_after_revoke(void)
 
 static void umode_enter_func(void)
 {
-	zassert_true(_is_user_context(),
+	zassert_true(k_is_user_context(),
 		     "Thread did not enter user mode");
 }
 

--- a/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
+++ b/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
@@ -95,7 +95,7 @@ static int create_negative_test_thread(int choice)
 	int ret;
 	uint32_t perm = K_INHERIT_PERMS;
 
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		perm = perm | K_USER;
 	}
 

--- a/tests/kernel/spinlock/src/spinlock_error_case.c
+++ b/tests/kernel/spinlock/src/spinlock_error_case.c
@@ -52,7 +52,7 @@ void assert_post_action(const char *file, unsigned int line)
 	/* User threads aren't allowed to induce kernel panics; generate
 	 * an oops instead.
 	 */
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			k_oops();
 		}
 #endif

--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -62,7 +62,7 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 		break;
 	case THREAD_CREATE_NEWTHREAD_NULL:
 		ztest_set_fault_valid(true);
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			perm = perm | K_USER;
 		}
 
@@ -73,7 +73,7 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 		break;
 	case THREAD_CREATE_STACK_NULL:
 		ztest_set_fault_valid(true);
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			perm = perm | K_USER;
 		}
 
@@ -84,7 +84,7 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 		break;
 	case THREAD_CTEATE_STACK_SIZE_OVERFLOW:
 		ztest_set_fault_valid(true);
-		if (_is_user_context()) {
+		if (k_is_user_context()) {
 			perm = perm | K_USER;
 		}
 		k_thread_create(&test_tdata, test_stack, -1,
@@ -108,7 +108,7 @@ static void create_negative_test_thread(int choice)
 	int ret;
 	uint32_t perm = K_INHERIT_PERMS;
 
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		perm = perm | K_USER;
 	}
 

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -195,7 +195,7 @@ static int check_values(void *p1, void *p2, void *p3)
 
 #if defined(CONFIG_USERSPACE)
 	TC_PRINT("Test communication in user mode thread\n");
-	zassert_true(_is_user_context(), "thread left in kernel mode");
+	zassert_true(k_is_user_context(), "thread left in kernel mode");
 #endif
 
 	/* Load to local variables to avoid using volatile in assert */

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -201,7 +201,7 @@ static int run_trigger_thread(int i)
 
 	case_type = i;
 
-	if (_is_user_context()) {
+	if (k_is_user_context()) {
 		perm = perm | K_USER;
 	}
 


### PR DESCRIPTION

﻿- kernel: Make both operands of operators of same essential type category
- kernel/arch: cleanup function definitions
- userspace: rename _is_user_context -> k_is_user_context
- x86: make tests of a value against zero should be made explicit
- kernel: make tests of a value against zero should be made explicit
