### PR TITLE
Bluetooth: services: Fix ID check for bt_gatt_ots_obj_manager_obj_get

### DIFF
--- a/subsys/bluetooth/services/ots/ots_obj_manager.c
+++ b/subsys/bluetooth/services/ots/ots_obj_manager.c
@@ -161,7 +161,7 @@ int bt_gatt_ots_obj_manager_obj_get(
 		return -ENOENT;
 	}
 
-	if (id < OTS_OBJ_ID_START_RANGE ||
+	if (id < OTS_OBJ_ID_START_RANGE &&
 	    (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ) &&
 		id != OTS_OBJ_ID_DIR_LIST)) {
 		return -EINVAL;


### PR DESCRIPTION
The ID validation check would always fail with IDs less than
OTS_OBJ_ID_START_RANGE, where the intention was that it should
allow the OTS_OBJ_ID_DIR_LIST (0) value as well if
CONFIG_BT_OTS_DIR_LIST_OBJ was enabled.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/33831