### PR TITLE
Bluetooth: controller: Fix event abort on delayed start

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -404,10 +404,13 @@ uint32_t lll_preempt_calc(struct evt_hdr *evt, uint8_t ticker_id,
 	uint32_t diff;
 
 	ticks_now = ticker_ticks_now_get();
-	diff = ticker_ticks_diff_get(ticks_now, ticks_at_event);
+	diff = ticks_now - ticks_at_event;
+	if (diff & BIT(HAL_TICKER_CNTR_MSBIT)) {
+		return 0;
+	}
+
 	diff += HAL_TICKER_CNTR_CMP_OFFSET_MIN;
-	if (!(diff & BIT(HAL_TICKER_CNTR_MSBIT)) &&
-	    (diff > HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US))) {
+	if (diff > HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US)) {
 		/* TODO: for Low Latency Feature with Advanced XTAL feature.
 		 * 1. Release retained HF clock.
 		 * 2. Advance the radio event to accommodate normal prepare


### PR DESCRIPTION
Fix the calculation of event delay when starting a radio
event. The calculation and check was incorrect causing
event abort when radio event was setup before the preempt
timeout by the lll_done when the next prepare was already
in the pipeline.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>