### PR TITLE
Bluetooth: services: Adds additonal len checks for ots_dir_list

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -33,6 +33,9 @@ extern "C" {
 /** @brief Length of OTS object ID string (in bytes). */
 #define BT_OTS_OBJ_ID_STR_LEN 15
 
+/** @brief Maximum object name length */
+#define BT_OTS_OBJ_MAX_NAME_LEN 120
+
 /** @brief Type of an OTS object. */
 struct bt_ots_obj_type {
 	union {

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -19,6 +19,8 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
+#include <sys/check.h>
+
 #include <bluetooth/services/ots.h>
 #include "ots_internal.h"
 #include "ots_obj_manager_internal.h"
@@ -167,11 +169,19 @@ int bt_ots_obj_add(struct bt_ots *ots,
 {
 	int err;
 	struct bt_gatt_ots_object *obj;
+	size_t name_len;
 
 	if (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ) && ots->dir_list &&
 	    ots->dir_list->dir_list_obj->state.type != BT_GATT_OTS_OBJECT_IDLE_STATE) {
 		LOG_DBG("Directory Listing Object is being read");
 		return -EBUSY;
+	}
+
+	name_len = strlen(obj_init->name);
+
+	CHECKIF(name_len == 0 || name_len > BT_OTS_OBJ_MAX_NAME_LEN) {
+		LOG_DBG("Invalid name length %zu", name_len);
+		return -EINVAL;
 	}
 
 	err = bt_gatt_ots_obj_manager_obj_add(ots->obj_manager, &obj);

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -44,7 +44,7 @@ static void dir_list_object_encode(struct bt_gatt_ots_object *obj,
 
 	/* Name length */
 	obj_name_len = strlen(obj->metadata.name);
-	__ASSERT(obj_name_len > 0 && obj_name_len <= 120,
+	__ASSERT(obj_name_len > 0 && obj_name_len <= BT_OTS_OBJ_MAX_NAME_LEN,
 		 "Dir list object len is incorrect %zu", len);
 	net_buf_simple_add_u8(net_buf, obj_name_len);
 
@@ -220,8 +220,9 @@ void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager)
 
 	__ASSERT(*dir_list, "Could not assign Directory Listing Object");
 
-	__ASSERT(strlen(dir_list_obj_name) < UINT8_MAX,
-		 "BT_OTS_DIR_LIST_OBJ_NAME shall be less than 255 octets");
+	__ASSERT(strlen(dir_list_obj_name) <= BT_OTS_OBJ_MAX_NAME_LEN,
+		 "BT_OTS_DIR_LIST_OBJ_NAME shall be less than %u octets",
+		 BT_OTS_OBJ_MAX_NAME_LEN);
 
 	err = bt_gatt_ots_obj_manager_obj_add(obj_manager, &dir_list_obj);
 

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -27,6 +27,8 @@ static void dir_list_object_encode(struct bt_gatt_ots_object *obj,
 {
 	uint8_t flags = 0;
 	uint8_t *start;
+	uint16_t len;
+	size_t obj_name_len;
 
 	BT_OTS_DIR_LIST_SET_FLAG_PROPERTIES(flags);
 	BT_OTS_DIR_LIST_SET_FLAG_CUR_SIZE(flags);
@@ -41,7 +43,10 @@ static void dir_list_object_encode(struct bt_gatt_ots_object *obj,
 	net_buf_simple_add_le48(net_buf, obj->id);
 
 	/* Name length */
-	net_buf_simple_add_u8(net_buf, strlen(obj->metadata.name));
+	obj_name_len = strlen(obj->metadata.name);
+	__ASSERT(obj_name_len > 0 && obj_name_len <= 120,
+		 "Dir list object len is incorrect %zu", len);
+	net_buf_simple_add_u8(net_buf, obj_name_len);
 
 	/* Name */
 	net_buf_simple_add_mem(net_buf, obj->metadata.name,
@@ -64,8 +69,15 @@ static void dir_list_object_encode(struct bt_gatt_ots_object *obj,
 	/* Object properties */
 	net_buf_simple_add_le32(net_buf, obj->metadata.props);
 
+	len = net_buf_simple_tail(net_buf) - start;
+
+	__ASSERT(len >= DIR_LIST_OBJ_RECORD_MIN_SIZE,
+		 "Dir list object len is too small %u", len);
+	__ASSERT(len <= DIR_LIST_OBJ_RECORD_MAX_SIZE,
+		 "Dir list object len is too large %u", len);
+
 	/* Update the record length at the beginning */
-	sys_put_le16(net_buf_simple_tail(net_buf) - start, start);
+	sys_put_le16(len, start);
 }
 
 void bt_ots_dir_list_obj_add(struct bt_ots_dir_list *dir_list, void *obj_manager,
@@ -112,10 +124,20 @@ void bt_ots_dir_list_obj_remove(struct bt_ots_dir_list *dir_list, void *obj_mana
 	}
 
 	while (offset < dir_list->net_buf.len) {
-		uint16_t len = sys_get_le16(dir_list->net_buf.data + offset);
-		uint64_t id = sys_get_le64(dir_list->net_buf.data + offset + sizeof(len));
+		uint16_t len;
+		uint64_t id;
+
+		__ASSERT((DIR_LIST_OBJ_RECORD_MIN_SIZE + offset) <= dir_list->net_buf.len,
+			 "Invalid dir_list buf length %u, expected at least %u",
+			 dir_list->net_buf.len, DIR_LIST_OBJ_RECORD_MIN_SIZE + offset);
+
+		len = sys_get_le16(dir_list->net_buf.data + offset);
+		id = sys_get_le64(dir_list->net_buf.data + offset + sizeof(len));
 
 		__ASSERT(len, "Invalid object length");
+		__ASSERT((len + offset) <= dir_list->net_buf.len,
+			 "Invalid dir_list buf length %u, expected at least %u",
+			 dir_list->net_buf.len, len + offset);
 
 		if (id == obj->id) {
 			/* Delete object by moving memory after the object to

--- a/subsys/bluetooth/services/ots/ots_internal.h
+++ b/subsys/bluetooth/services/ots/ots_internal.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "ots_olcp_internal.h"
 
 /** Maximum size of the Directory Listing Object Record. Table 4.1 in the OTS spec. */
+#define DIR_LIST_OBJ_RECORD_MIN_SIZE       13
 #define DIR_LIST_OBJ_RECORD_MAX_SIZE       172
 #define DIR_LIST_MAX_SIZE (DIR_LIST_OBJ_RECORD_MAX_SIZE * CONFIG_BT_OTS_MAX_OBJ_CNT)
 


### PR DESCRIPTION
Adds additional length checks for the OTS directory listing
implementation. This will check the object name length and
the total length of the object when encoding,
as well as the length of the objects when removing objects
from the directory listing.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/33830