### PR TITLE
samples: tfm_integration: Enable psa_level_1 on stm32l562e_dk

### DIFF
--- a/samples/tfm_integration/psa_level_1/boards/stm32l562e_dk_ns.conf
+++ b/samples/tfm_integration/psa_level_1/boards/stm32l562e_dk_ns.conf
@@ -1,0 +1,2 @@
+# Force isolation level to 1
+CONFIG_TFM_ISOLATION_LEVEL=1

--- a/samples/tfm_integration/psa_level_1/boards/stm32l562e_dk_ns.overlay
+++ b/samples/tfm_integration/psa_level_1/boards/stm32l562e_dk_ns.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Yestin Sun
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* This partition table should be used along with TFM configuration:
+  * - TFM_PSA_API=ON (IPC)
+  */
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot1_partition;
+	};
+};
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00019000>;
+			read-only;
+		};
+		/* Secure image primary slot */
+		slot0_partition: partition@19000 {
+			label = "image-0";
+			reg = <0x00019000 0x00038000>;
+		};
+		/* Non-secure image primary slot */
+		slot1_partition: partition@51000 {
+			label = "image-1";
+			reg = <0x00051000 0x0002A000>;
+		};
+		/*
+		 * The flash starting at 0x7F000 and ending at
+		 * 0x80000 is reserved for the application.
+		 */
+		storage_partition: partition@7f000 {
+			label = "storage";
+			reg = <0x0007F000 0x00001000>;
+		};
+	};
+};

--- a/samples/tfm_integration/psa_level_1/sample.yaml
+++ b/samples/tfm_integration/psa_level_1/sample.yaml
@@ -6,7 +6,7 @@ tests:
     sample.psa_level_1:
         tags: introduction tfm
         platform_allow: mps2_an521_nonsecure lpcxpresso55s69_ns nrf5340dk_nrf5340_cpuappns
-          nrf9160dk_nrf9160ns v2m_musca_s1_nonsecure
+          nrf9160dk_nrf9160ns v2m_musca_s1_nonsecure stm32l562e_dk_ns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
@@ -35,12 +35,12 @@
 			read-only;
 		};
 		/* Secure image primary slot */
-		slot0_partition: partition@00013000 {
+		slot0_partition: partition@13000 {
 			label = "image-0";
 			reg = <0x00013000 0x00038000>;
 		};
 		/* Non-secure image primary slot */
-		slot1_partition: partition@0004B000 {
+		slot1_partition: partition@4b000 {
 			label = "image-1";
 			reg = <0x0004B000 0x0002A000>;
 		};
@@ -48,7 +48,7 @@
 		 * The flash starting at 0x7F000 and ending at
 		 * 0x80000 is reserved for the application.
 		 */
-		storage_partition: partition@7F000 {
+		storage_partition: partition@7f000 {
 			label = "storage";
 			reg = <0x0007F000 0x00001000>;
 		};

--- a/samples/tfm_integration/tfm_ipc/boards/stm32l562e_dk_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/stm32l562e_dk_ns.overlay
@@ -34,12 +34,12 @@
 			read-only;
 		};
 		/* Secure image primary slot */
-		slot0_partition: partition@00019000 {
+		slot0_partition: partition@19000 {
 			label = "image-0";
 			reg = <0x00019000 0x00038000>;
 		};
 		/* Non-secure image primary slot */
-		slot1_partition: partition@00051000 {
+		slot1_partition: partition@51000 {
 			label = "image-1";
 			reg = <0x00051000 0x0002A000>;
 		};
@@ -47,7 +47,7 @@
 		 * The flash starting at 0x7F000 and ending at
 		 * 0x80000 is reserved for the application.
 		 */
-		storage_partition: partition@7F000 {
+		storage_partition: partition@7f000 {
 			label = "storage";
 			reg = <0x0007F000 0x00001000>;
 		};


### PR DESCRIPTION
Force TFM_ISOLATION_LEVEL and reuse memory mapping from tfm_ipc