### PR TITLE
samples: usb: dfu: exclude platforms sample can't be built on

### DIFF
--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -3,7 +3,9 @@ sample:
 tests:
   sample.usb.dfu:
     build_only: True
-    platform_exclude: native_posix native_posix_64
+    platform_exclude: native_posix native_posix_64 mimxrt1010_evk
+      mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk
+      mimxrt1050_evk mimxrt1060_evk_hyperflash nucleo_f207zg
     depends_on: usb_device
     filter: dt_compat_enabled_with_label("fixed-partitions", "slot0_partition") and
             dt_compat_enabled_with_label("fixed-partitions", "slot1_partition") and


### PR DESCRIPTION
Several platforms don't have flash drivers and these platforms the DFU
sample will not build or even pass Kconfig on.  Exclude them until they
have flash driver support.

Fixes #33422

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>