### PR TITLE
soc: arm: nxp: ke1xf: use clock nodes for NXP Kinetis SCG clocks

### DIFF
--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2021 Vestas Wind Systems A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -128,31 +128,64 @@
 };
 
 &scg {
-	sosc-freq = <8000000>;
 	sosc-mode = <KINETIS_SCG_SOSC_MODE_LOW_POWER>;
-	sosc-divider-1 = <1>;
-	sosc-divider-2 = <1>;
 
-	sirc-range = <8000000>;
-	sirc-divider-1 = <1>;
-	sirc-divider-2 = <2>;
+	sosc_clk {
+		status = "okay";
+		clock-frequency = <8000000>;
+	};
 
-	firc-range = <48000000>;
-	firc-divider-1 = <1>;
-	firc-divider-2 = <1>;
+	pll {
+		clock-mult = <30>;
+	};
 
-	spll-source = <KINETIS_SCG_SPLL_SRC_SOSC>;
-	spll-divider-pre = <1>;
-	spll-multiplier = <30>;
-	spll-divider-1 = <1>;
-	spll-divider-2 = <2>;
+	core_clk {
+		clocks = <&spll_clk>;
+	};
 
-	clk-source = <KINETIS_SCG_SCLK_SRC_SPLL>;
-	clk-divider-slow = <5>;
-	clk-divider-bus = <2>;
-	clk-divider-core = <1>;
+	bus_clk {
+		clock-div = <2>;
+	};
 
-	clkout-source = <KINETIS_SCG_CLKOUT_SRC_FIRC>;
+	slow_clk {
+		clock-div = <5>;
+	};
+
+	clkout_clk {
+		status = "okay";
+	};
+
+	splldiv1_clk {
+		clock-div = <1>;
+	};
+
+	splldiv2_clk {
+		clock-div = <2>;
+	};
+
+	sircdiv1_clk {
+		clock-div = <1>;
+	};
+
+	sircdiv2_clk {
+		clock-div = <2>;
+	};
+
+	fircdiv1_clk {
+		clock-div = <1>;
+	};
+
+	fircdiv2_clk {
+		clock-div = <1>;
+	};
+
+	soscdiv1_clk {
+		clock-div = <1>;
+	};
+
+	soscdiv2_clk {
+		clock-div = <1>;
+	};
 };
 
 &lpuart0 {

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2021 Vestas Wind Systems A/S
  *
  * Based on clock_control_mcux_sim.c, which is:
  * Copyright (c) 2017, NXP
@@ -17,6 +17,8 @@
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(clock_control_scg);
+
+#define MCUX_SCG_CLOCK_NODE(name) DT_CHILD(DT_DRV_INST(0), name)
 
 static int mcux_scg_on(const struct device *dev,
 		       clock_control_subsys_t sub_system)
@@ -96,9 +98,21 @@ static int mcux_scg_get_rate(const struct device *dev,
 
 static int mcux_scg_init(const struct device *dev)
 {
-#if DT_INST_NODE_HAS_PROP(0, clkout_source)
-	CLOCK_SetClkOutSel(DT_INST_PROP(0, clkout_source));
+#if DT_NODE_HAS_STATUS(MCUX_SCG_CLOCK_NODE(clkout_clk), okay)
+#if DT_SAME_NODE(DT_CLOCKS_CTLR(MCUX_SCG_CLOCK_NODE(clkout_clk)), MCUX_SCG_CLOCK_NODE(slow_clk))
+	CLOCK_SetClkOutSel(kClockClkoutSelScgSlow);
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(MCUX_SCG_CLOCK_NODE(clkout_clk)), MCUX_SCG_CLOCK_NODE(sosc_clk))
+	CLOCK_SetClkOutSel(kClockClkoutSelSysOsc);
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(MCUX_SCG_CLOCK_NODE(clkout_clk)), MCUX_SCG_CLOCK_NODE(sirc_clk))
+	CLOCK_SetClkOutSel(kClockClkoutSelSirc);
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(MCUX_SCG_CLOCK_NODE(clkout_clk)), MCUX_SCG_CLOCK_NODE(firc_clk))
+	CLOCK_SetClkOutSel(kClockClkoutSelFirc);
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(MCUX_SCG_CLOCK_NODE(clkout_clk)), MCUX_SCG_CLOCK_NODE(spll_clk))
+	CLOCK_SetClkOutSel(kClockClkoutSelSysPll);
+#else
+#error Unsupported SCG clkout clock source
 #endif
+#endif /* DT_NODE_HAS_STATUS(MCUX_SCG_CLOCK_NODE(clkout_clk), okay) */
 
 	return 0;
 }

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2021 Vestas Wind Systems A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -100,6 +100,123 @@
 			reg = <0x40064000 0x1000>;
 			label = "SCG";
 			#clock-cells = <1>;
+
+			sosc_clk: sosc_clk {
+				compatible = "fixed-clock";
+				status = "disabled";
+				#clock-cells = <0>;
+			};
+
+			sirc_clk: sirc_clk {
+				compatible = "fixed-clock";
+				clock-frequency = <8000000>;
+				#clock-cells = <0>;
+			};
+
+			firc_clk: firc_clk {
+				compatible = "fixed-clock";
+				clock-frequency = <48000000>;
+				#clock-cells = <0>;
+			};
+
+			pll: pll {
+				compatible = "fixed-factor-clock";
+				clocks = <&sosc_clk>;
+				clock-div = <1>;
+				clock-mult = <16>;
+				#clock-cells = <0>;
+			};
+
+			spll_clk: spll_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&pll>;
+				clock-div = <2>;
+				#clock-cells = <0>;
+			};
+
+			core_clk: core_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&firc_clk>;
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
+			bus_clk: bus_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&core_clk>;
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
+			slow_clk: slow_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&core_clk>;
+				clock-div = <2>;
+				#clock-cells = <0>;
+			};
+
+			clkout_clk: clkout_clk {
+				compatible = "fixed-factor-clock";
+				status = "disabled";
+				clocks = <&firc_clk>;
+				#clock-cells = <0>;
+			};
+
+			splldiv1_clk: splldiv1_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&spll_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			splldiv2_clk: splldiv2_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&spll_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			sircdiv1_clk: sircdiv1_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&sirc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			sircdiv2_clk: sircdiv2_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&sirc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			fircdiv1_clk: fircdiv1_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&firc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			fircdiv2_clk: fircdiv2_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&firc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			soscdiv1_clk: soscdiv1_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&sosc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
+
+			soscdiv2_clk: soscdiv2_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&sosc_clk>;
+				clock-div = <0>;
+				#clock-cells = <0>;
+			};
 		};
 
 		pmc: pmc@4007d000 {

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Vestas Wind Systems A/S
+# Copyright (c) 2019-2021 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP Kinetis SCG (System Clock Generator) IP node
@@ -14,104 +14,9 @@ properties:
     label:
       required: true
 
-    clk-divider-slow:
-      type: int
-      description: system clock to slow clock divider
-      required: true
-
-    clk-divider-bus:
-      type: int
-      description: system clock to bus clock divider
-      required: true
-
-    clk-divider-core:
-      type: int
-      description: system clock to core clock divider
-      required: true
-
-    clk-source:
-      type: int
-      description: system clock source
-      required: false
-
-    sosc-freq:
-      type: int
-      description: system oscillator (e.g. xtal) frequency
-      required: false
-
     sosc-mode:
       type: int
       description: system oscillator mode
-      required: false
-
-    sosc-divider-1:
-      type: int
-      description: system oscillator divider 1
-      required: false
-
-    sosc-divider-2:
-      type: int
-      description: system oscillator divider 2
-      required: false
-
-    sirc-range:
-      type: int
-      description: slow internal reference clock range in MHz
-      required: true
-
-    sirc-divider-1:
-      type: int
-      description: slow internal reference clock divider 1
-      required: true
-
-    sirc-divider-2:
-      type: int
-      description: slow internal reference clock divider 2
-      required: true
-
-    firc-range:
-      type: int
-      description: fast internal reference clock range in MHz
-      required: true
-
-    firc-divider-1:
-      type: int
-      description: fast internal reference clock divider 1
-      required: true
-
-    firc-divider-2:
-      type: int
-      description: fast internal reference clock divider 2
-      required: true
-
-    spll-source:
-      type: int
-      description: system phase-locked loop clock source
-      required: true
-
-    spll-divider-pre:
-      type: int
-      description: system phase-locked loop reference clock divider
-      required: true
-
-    spll-multiplier:
-      type: int
-      description: system phase-locked loop reference clock multiplier
-      required: true
-
-    spll-divider-1:
-      type: int
-      description: system phase-locked loop divider 1
-      required: true
-
-    spll-divider-2:
-      type: int
-      description: system phase-locked loop divider 2
-      required: true
-
-    clkout-source:
-      type: int
-      description: clockout clock source
       required: false
 
     "#clock-cells":

--- a/include/dt-bindings/clock/kinetis_scg.h
+++ b/include/dt-bindings/clock/kinetis_scg.h
@@ -7,27 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_KINETIS_SCG_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_KINETIS_SCG_H_
 
-/* SCG system clock source value */
-#define KINETIS_SCG_SCLK_SRC_SOSC 1U
-#define KINETIS_SCG_SCLK_SRC_SIRC 2U
-#define KINETIS_SCG_SCLK_SRC_FIRC 3U
-#define KINETIS_SCG_SCLK_SRC_SPLL 6U
-
 /* SCG system oscillator mode */
 #define KINETIS_SCG_SOSC_MODE_EXT        0U
 #define KINETIS_SCG_SOSC_MODE_LOW_POWER  4U
 #define KINETIS_SCG_SOSC_MODE_HIGH_GAIN 12U
-
-/* SCG system phase-locked loop source */
-#define KINETIS_SCG_SPLL_SRC_SOSC 0U
-#define KINETIS_SCG_SPLL_SRC_FIRC 1U
-
-/* SCG clockout source */
-#define KINETIS_SCG_CLKOUT_SRC_SLOW 0U
-#define KINETIS_SCG_CLKOUT_SRC_SOSC 1U
-#define KINETIS_SCG_CLKOUT_SRC_SIRC 2U
-#define KINETIS_SCG_CLKOUT_SRC_FIRC 3U
-#define KINETIS_SCG_CLKOUT_SRC_SPLL 6U
 
 /* SCG clock controller clock names */
 #define KINETIS_SCG_CORESYS_CLK          0U

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2021 Vestas Wind Systems A/S
  *
  * Based on NXP k6x soc.c, which is:
  * Copyright (c) 2014-2015 Wind River Systems, Inc.
@@ -27,106 +27,122 @@
 #define kSCG_AsyncClkDivBy0 kSCG_AsyncClkDisable
 #define TO_ASYNC_CLK_DIV(val) _DO_CONCAT(kSCG_AsyncClkDivBy, val)
 
+#define SCG_CLOCK_NODE(name) DT_CHILD(DT_INST(0, nxp_kinetis_scg), name)
+#define SCG_CLOCK_DIV(name) DT_PROP(SCG_CLOCK_NODE(name), clock_div)
+#define SCG_CLOCK_MULT(name) DT_PROP(SCG_CLOCK_NODE(name), clock_mult)
+
 /* System Clock configuration */
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_slow), 2, 8,
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(slow_clk), 2, 8,
 		    "Invalid SCG slow clock divider value");
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_bus), 1, 16,
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(bus_clk), 1, 16,
 		    "Invalid SCG bus clock divider value");
-#if DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_source) == KINETIS_SCG_SCLK_SRC_SPLL
+#if DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(spll_clk))
 /* Core divider range is 1 to 4 with SPLL as clock source */
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_core), 1, 4,
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(core_clk), 1, 4,
 		    "Invalid SCG core clock divider value");
 #else
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_core), 1, 16,
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(core_clk), 1, 16,
 		    "Invalid SCG core clock divider value");
 #endif
 static const scg_sys_clk_config_t scg_sys_clk_config = {
-	.divSlow = TO_SYS_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_slow)),
-	.divBus  = TO_SYS_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_bus)),
-	.divCore = TO_SYS_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_divider_core)),
-	.src     = DT_PROP(DT_INST(0, nxp_kinetis_scg), clk_source)
+	.divSlow = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(slow_clk)),
+	.divBus  = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(bus_clk)),
+	.divCore = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(core_clk)),
+#if DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(sosc_clk))
+	.src     = kSCG_SysClkSrcSysOsc,
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(sirc_clk))
+	.src     = kSCG_SysClkSrcSirc,
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(firc_clk))
+	.src     = kSCG_SysClkSrcFirc,
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(spll_clk))
+	.src     = kSCG_SysClkSrcSysPll,
+#else
+#error Invalid SCG core clock source
+#endif
 };
 
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_scg), sosc_freq)
+#if DT_NODE_HAS_STATUS(SCG_CLOCK_NODE(sosc_clk), okay)
 /* System Oscillator (SOSC) configuration */
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_divider_1),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(soscdiv1_clk),
 		       "Invalid SCG SOSC divider 1 value");
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_divider_2),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(soscdiv2_clk),
 		       "Invalid SCG SOSC divider 2 value");
 static const scg_sosc_config_t scg_sosc_config = {
-	.freq        = DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_freq),
+	.freq        = DT_PROP(SCG_CLOCK_NODE(sosc_clk), clock_frequency),
 	.monitorMode = kSCG_SysOscMonitorDisable,
 	.enableMode  = kSCG_SysOscEnable | kSCG_SysOscEnableInLowPower,
-	.div1        = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_divider_1)),
-	.div2        = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_divider_2)),
+	.div1        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(soscdiv1_clk)),
+	.div2        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(soscdiv2_clk)),
 	.workMode    = DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_mode)
 };
 #endif /* DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_scg), sosc_freq) */
 
 /* Slow Internal Reference Clock (SIRC) configuration */
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_divider_1),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(sircdiv1_clk),
 		       "Invalid SCG SIRC divider 1 value");
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_divider_2),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(sircdiv2_clk),
 		       "Invalid SCG SIRC divider 2 value");
 static const scg_sirc_config_t scg_sirc_config = {
 	.enableMode = kSCG_SircEnable,
-	.div1       = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_divider_1)),
-	.div2       = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_divider_2)),
-#if MHZ(2) == DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_range)
+	.div1       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(sircdiv1_clk)),
+	.div2       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(sircdiv2_clk)),
+#if MHZ(2) == DT_PROP(SCG_CLOCK_NODE(sirc_clk), clock_frequency)
 	.range      = kSCG_SircRangeLow
-#elif MHZ(8) == DT_PROP(DT_INST(0, nxp_kinetis_scg), sirc_range)
+#elif MHZ(8) == DT_PROP(SCG_CLOCK_NODE(sirc_clk), clock_frequency)
 	.range      = kSCG_SircRangeHigh
 #else
-#error Invalid SCG SIRC range
+#error Invalid SCG SIRC clock frequency
 #endif
 };
 
 /* Fast Internal Reference Clock (FIRC) configuration */
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_divider_1),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(fircdiv1_clk),
 		       "Invalid SCG FIRC divider 1 value");
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_divider_2),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(fircdiv2_clk),
 		       "Invalid SCG FIRC divider 2 value");
 static const scg_firc_config_t scg_firc_config = {
 	.enableMode = kSCG_FircEnable,
-	.div1       = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_divider_1)),
-	.div2       = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_divider_2)),
-#if MHZ(48) == DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_range)
+	.div1       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(fircdiv1_clk)),
+	.div2       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(fircdiv2_clk)),
+#if MHZ(48) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
 	.range      = kSCG_FircRange48M,
-#elif MHZ(52) == DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_range)
+#elif MHZ(52) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
 	.range      = kSCG_FircRange52M,
-#elif MHZ(56) == DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_range)
+#elif MHZ(56) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
 	.range      = kSCG_FircRange56M,
-#elif MHZ(60) == DT_PROP(DT_INST(0, nxp_kinetis_scg), firc_range)
+#elif MHZ(60) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
 	.range      = kSCG_FircRange60M,
 #else
-#error Invalid SCG FIRC range
+#error Invalid SCG FIRC clock frequency
 #endif
 	.trimConfig = NULL
 };
 
 /* System Phase-Locked Loop (SPLL) configuration */
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_1),
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(spll_clk), 2, 2,
+		    "Invalid SCG SPLL fixed divider value");
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(splldiv1_clk),
 		       "Invalid SCG SPLL divider 1 value");
-ASSERT_ASYNC_CLK_DIV_VALID(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_2),
+ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(splldiv2_clk),
 		       "Invalid SCG SPLL divider 2 value");
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_pre), 1, 8,
-		    "Invalid SCG SPLL pre divider value");
-ASSERT_WITHIN_RANGE(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_multiplier), 16, 47,
-		    "Invalid SCG SPLL multiplier value");
+ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(pll), 1, 8,
+		    "Invalid SCG PLL pre divider value");
+ASSERT_WITHIN_RANGE(SCG_CLOCK_MULT(pll), 16, 47,
+		    "Invalid SCG PLL multiplier value");
 static const scg_spll_config_t scg_spll_config = {
 	.enableMode  = kSCG_SysPllEnable,
 	.monitorMode = kSCG_SysPllMonitorDisable,
-	.div1        = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_1)),
-	.div2        = TO_ASYNC_CLK_DIV(DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_2)),
-#if DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_source) == KINETIS_SCG_SPLL_SRC_SOSC
+	.div1        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(splldiv1_clk)),
+	.div2        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(splldiv2_clk)),
+#if DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(pll)), SCG_CLOCK_NODE(sosc_clk))
 	.src         = kSCG_SysPllSrcSysOsc,
-#elif DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_source) == KINETIS_SCG_SPLL_SRC_FIRC
+#elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(pll)), SCG_CLOCK_NODE(firc_clk))
 	.src         = kSCG_SysPllSrcFirc,
 #else
-#error Invalid SCG SPLL source
+#error Invalid SCG PLL clock source
 #endif
-	.prediv      = (DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_divider_pre) - 1U),
-	.mult        = (DT_PROP(DT_INST(0, nxp_kinetis_scg), spll_multiplier) - 16U)
+	.prediv      = (SCG_CLOCK_DIV(pll) - 1U),
+	.mult        = (SCG_CLOCK_MULT(pll) - 16U)
 };
 
 static ALWAYS_INLINE void clk_init(void)
@@ -139,7 +155,7 @@ static ALWAYS_INLINE void clk_init(void)
 	};
 	scg_sys_clk_config_t current;
 
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_scg), sosc_freq)
+#if DT_NODE_HAS_STATUS(SCG_CLOCK_NODE(sosc_clk), okay)
 	/* Optionally initialize system oscillator */
 	CLOCK_InitSysOsc(&scg_sosc_config);
 	CLOCK_SetXtal0Freq(scg_sosc_config.freq);


### PR DESCRIPTION
Use a combination of fixed-clock and fixed-factor-clock devicetree nodes for describing the clock dividers/multipliers of the NXP Kinetis System Clock Generator (SCG) present in the KE1xF SoC series.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>