### PR TITLE
tests: lib: fix coverity issues of resource leaks for mem_alloc testcase

### DIFF
--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -162,6 +162,8 @@ void test_no_mem_realloc(void)
 
 	reloc_ptr = realloc(ptr, BUF_LEN);
 	zassert_is_null(reloc_ptr, "realloc failed, errno: %d", errno);
+	free(reloc_ptr);
+	reloc_ptr = NULL;
 }
 #endif
 
@@ -241,10 +243,11 @@ void test_calloc(void)
 
 	cptr =  calloc(0x7fffffff, sizeof(int));
 	zassert_is_null((cptr), "calloc failed, errno: %d", errno);
+	free(cptr);
 
 	cptr =  calloc(0x7fffffff, sizeof(char));
 	zassert_is_null((cptr), "calloc failed, errno: %d", errno);
-
+	free(cptr);
 
 	cptr =  calloc(CALLOC_BUFLEN, sizeof(char));
 	zassert_not_null((cptr), "calloc failed, errno: %d", errno);


### PR DESCRIPTION
Fix 2 resource leak issues of coverity scan, actually the return of
NULL pointer is expected, but there is no harm done to free a NULL
pointer in our design, so adding them to pass the scan.

Fixes #33802	CID: 220434
Fixes #33785	CID: 220451

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>