### PR TITLE
.github: doc-build: run on scripts/dts change

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -18,6 +18,7 @@ on:
     - '**/Kconfig*'
     - 'west.yml'
     - '.github/workflows/doc-build.yml'
+    - 'scripts/dts/**'
 
 jobs:
   doc-build:


### PR DESCRIPTION
Some of the generated documentation depends on the devicetree scripts.
E.g. the bindings index uses edtlib.

We don't have a well-defined interface boundary here for managing
dependencies, so let's just add the entire dts directory to the
'paths' glob list in doc-build.yml. This will ensure we don't
accidentally change some DT implementation detail in a way that breaks
the docs.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>