### PR TITLE
doc: clarify ENOSYS and ENOTSUP

### DIFF
--- a/doc/guides/design_guidelines.rst
+++ b/doc/guides/design_guidelines.rst
@@ -102,3 +102,21 @@ practices should be followed.
 The Kconfig flag used to enable the feature should be added to the
 ``PREDEFINED`` variable in :file:`doc/zephyr.doxyfile.in` to ensure the
 conditional API and functions appear in generated documentation.
+
+Return Codes
+************
+
+Implementations of an API, for example an API for accessing a peripheral might
+implement only a subset of the functions that is required for minimal operation.
+A distinction is needed between APIs that are not supported and those that are
+not implemented or optional:
+
+- APIs that are supported but not implemented shall return ``-ENOSYS``.
+
+- Optional APIs that are not supported by the hardware should be implemented and
+  the return code in this case shall be ``-ENOTSUP``.
+
+- When an API is implemented, but the particular combination of options
+  requested in the call cannot be satisfied by the implementation the call shall
+  return -ENOTSUP. (For example, a request for a level-triggered GPIO interrupt on
+  hardware that supports only edge-triggered interrupts)

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -29,6 +29,11 @@ interface and listing all issues with the `bug label
 API Changes
 ***********
 
+* Driver APIs now return ``-ENOSYS`` if optional functions are not implemented.
+  If the feature is not supported by the hardware ``-ENOTSUP`` will be returned.
+  Formerly ``-ENOTSUP`` was returned for both failure modes, meaning this change
+  may require existing code that tests only for that value to be changed.
+
 * The :c:func:`wait_for_usb_dfu` function now accepts a ``k_timeout_t`` argument instead of
   using the ``CONFIG_USB_DFU_WAIT_DELAY_MS`` macro.
 


### PR DESCRIPTION
Clarify usage of ENOSYS vs ENOTSUP and add comment in the release notes
about the recent changes to the APIs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
