### PR TITLE
ARC: allow to configure the RGF_NUM_BANKS only if ARC_FIRQ is enabled

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -110,6 +110,7 @@ config NUM_IRQS
 
 config RGF_NUM_BANKS
 	int "Number of General Purpose Register Banks"
+	depends on ARC_FIRQ
 	range 1 2
 	default 2
 	help


### PR DESCRIPTION
As of today we use second register bank only if fast interrupts are enabled. So don't show the 'number of register bank' configuration option if fast interrupts are disabled to avoid user confusion.