### PR TITLE
MAINTAINERS: CODEOWNERS: Add NXP collaborators

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@
 /soc/arm/cypress/                         @nandojve
 /soc/arm/bcm*/                            @sbranden
 /soc/arm/infineon_xmc/                    @parthitce
-/soc/arm/nxp*/                            @MaureenHelm
+/soc/arm/nxp*/                            @MaureenHelm @mmahadevan108 @dleach02
 /soc/arm/nordic_nrf/                      @ioannisg
 /soc/arm/nuvoton/                         @ssekar15
 /soc/arm/nuvoton_npcx/                    @MulinChao @WealianLiao @ChiHuaL
@@ -87,16 +87,16 @@
 /boards/arm/disco_l475_iot1/              @erwango
 /boards/arm/efm32pg_stk3401a/             @rdmeneze
 /boards/arm/faze/                         @mbittan @simonguinot
-/boards/arm/frdm*/                        @MaureenHelm
+/boards/arm/frdm*/                        @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/frdm*/doc/                    @MaureenHelm @MeganHansen
 /boards/arm/google_*/                     @jackrosenthal
-/boards/arm/hexiwear*/                    @MaureenHelm
+/boards/arm/hexiwear*/                    @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/hexiwear*/doc/                @MaureenHelm @MeganHansen
 /boards/arm/ip_k66f/                      @parthitce
-/boards/arm/lpcxpresso*/                  @MaureenHelm
+/boards/arm/lpcxpresso*/                  @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/lpcxpresso*/doc/              @MaureenHelm @MeganHansen
 /boards/arm/mimx8mm_evk/                  @Mani-Sadhasivam
-/boards/arm/mimxrt*/                      @MaureenHelm
+/boards/arm/mimxrt*/                      @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/mimxrt*/doc/                  @MaureenHelm @MeganHansen
 /boards/arm/mps2_an385/                   @fvincenzo
 /boards/arm/msp_exp432p401r_launchxl/     @Mani-Sadhasivam
@@ -161,7 +161,7 @@
 /drivers/*/*sam4l*                        @nandojve
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*litex*                        @mateusz-holenko @kgugala @pgielda
-/drivers/*/*mcux*                         @MaureenHelm
+/drivers/*/*mcux*                         @MaureenHelm @mmahadevan108 @dleach02
 /drivers/*/*stm32*                        @erwango @ABOSTM @FRASTM
 /drivers/*/*native_posix*                 @aescolar @daor-oti
 /drivers/*/*lpc11u6x*                     @mbittan @simonguinot
@@ -333,7 +333,7 @@
 /dts/arm/nordic/                          @ioannisg @carlescufi
 /dts/arm/nuvoton/                         @ssekar15
 /dts/arm/nuvoton/npcx/                    @MulinChao @WealianLiao @ChiHuaL
-/dts/arm/nxp/                             @MaureenHelm
+/dts/arm/nxp/                             @MaureenHelm @mmahadevan108 @dleach02
 /dts/arm/microchip/                       @franciscomunoz @albertofloyd @scottwcpg
 /dts/arm/silabs/efm32_pg_1b.dtsi          @rdmeneze
 /dts/arm/silabs/efm32gg11b*               @oanerer
@@ -368,7 +368,7 @@
 /dts/bindings/*/*npcx*                    @MulinChao @WealianLiao @ChiHuaL
 /dts/bindings/*/*psoc6*                   @nandojve
 /dts/bindings/*/nordic*                   @anangl
-/dts/bindings/*/nxp*                      @MaureenHelm
+/dts/bindings/*/nxp*                      @MaureenHelm @mmahadevan108 @dleach02
 /dts/bindings/*/openisa*                  @MaureenHelm
 /dts/bindings/*/st*                       @erwango
 /dts/bindings/sensor/ams*                 @alexanderwachter

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1323,6 +1323,9 @@ NXP Platforms:
   status: maintained
   maintainers:
     - MaureenHelm
+  collaborators:
+    - mmahadevan108
+    - dleach02
   files:
     - boards/arm/mimx*/
     - boards/arm/frdm_k*/


### PR DESCRIPTION
Add @mmahadevan108 and @dleach02 as collaborators for NXP SoCs, boards,
and drivers.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>