### PR TITLE
power: Fix unbalanced scheduler lock

### DIFF
--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -157,6 +157,7 @@ void pm_power_state_force(struct pm_state_info info)
 	pm_debug_stop_timer();
 
 	pm_system_resume();
+	k_sched_unlock();
 }
 
 #if CONFIG_PM_DEVICE


### PR DESCRIPTION
Commit 58a0ba6dbb removed the call to k_sched_unlock from
pm_system_resume() consequently the scheduler lock in
pm_power_state_force() was left unbalanced. Just fixing it.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>