### PR TITLE
drivers: Fix STM32F103XE not able to enter master mode

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -241,11 +241,9 @@ static int i2c_stm32_init(const struct device *dev)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
-#if defined(CONFIG_SOC_STM32F103X8) || \
-     defined(CONFIG_SOC_STM32F103XB) || \
-     defined(CONFIG_SOC_STM32F103XE)
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
 	/*
-	 * Force i2c reset for STM32 (F101X8/B, F102X8/B), F103X8/B/E.
+	 * Force i2c reset for STM32F1 series.
 	 * So that they can enter master mode properly.
 	 * Issue described in ES096 2.14.7
 	 */

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -241,7 +241,9 @@ static int i2c_stm32_init(const struct device *dev)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
-#if defined(CONFIG_SOC_STM32F103X8) || defined(CONFIG_SOC_STM32F103XB) || defined(CONFIG_SOC_STM32F103XE)
+#if defined(CONFIG_SOC_STM32F103X8) || \
+     defined(CONFIG_SOC_STM32F103XB) || \
+     defined(CONFIG_SOC_STM32F103XE)
 	/*
 	 * Force i2c reset for STM32 (F101X8/B, F102X8/B), F103X8/B/E.
 	 * So that they can enter master mode properly.

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -241,9 +241,9 @@ static int i2c_stm32_init(const struct device *dev)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
-#if defined(CONFIG_SOC_STM32F103X8) || defined(CONFIG_SOC_STM32F103XB)
+#if defined(CONFIG_SOC_STM32F103X8) || defined(CONFIG_SOC_STM32F103XB) || defined(CONFIG_SOC_STM32F103XE)
 	/*
-	 * Force i2c reset for STM32 (F101X8/B, F102X8/B), F103X8/B.
+	 * Force i2c reset for STM32 (F101X8/B, F102X8/B), F103X8/B/E.
 	 * So that they can enter master mode properly.
 	 * Issue described in ES096 2.14.7
 	 */


### PR DESCRIPTION
This pr fixes the [I2C issue](https://github.com/zephyrproject-rtos/zephyr/issues/33196#issuecomment-795204302) mentioned in #33196

Signed-off-by: Yong Cong Sin yongcong@gtsb.com.my