### PR TITLE
Bluetooth: controller: Move LLL done handling from ULL to LLL 

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -312,6 +312,7 @@ config BT_CTLR_ULL_LOW_PRIO
 
 config BT_CTLR_LOW_LAT
 	bool "Low latency non-negotiating event preemption"
+	select BT_CTLR_LOW_LAT_ULL_DONE
 	default y if SOC_SERIES_NRF51X
 	help
 	  Use low latency non-negotiating event preemption. This reduces
@@ -327,6 +328,12 @@ config BT_CTLR_LOW_LAT_ULL
 	help
 	  Low latency ULL implementation that uses tailchaining instead of while
 	  loop to demux rx messages from LLL.
+
+config BT_CTLR_LOW_LAT_ULL_DONE
+	prompt "Low latency ULL prepare dequeue"
+	bool
+	help
+	  Done events be processed and dequeued in ULL context.
 
 config BT_CTLR_CONN_META
 	prompt "Enable connection meta data extension"

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -385,6 +385,7 @@ int lll_init(void);
 int lll_reset(void);
 void lll_resume(void *param);
 void lll_disable(void *param);
+void lll_done_sync(void);
 uint32_t lll_radio_is_idle(void);
 uint32_t lll_radio_tx_ready_delay_get(uint8_t phy, uint8_t flags);
 uint32_t lll_radio_rx_ready_delay_get(uint8_t phy, uint8_t flags);
@@ -404,6 +405,7 @@ int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 			       uint8_t is_resume);
 void *ull_prepare_dequeue_get(void);
 void *ull_prepare_dequeue_iter(uint8_t *idx);
+void ull_prepare_dequeue(uint8_t caller_id);
 void *ull_pdu_rx_alloc_peek(uint8_t count);
 void *ull_pdu_rx_alloc_peek_iter(uint8_t *idx);
 void *ull_pdu_rx_alloc(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -562,6 +562,21 @@ void lll_isr_cleanup(void *param)
 	lll_done(NULL);
 }
 
+void lll_isr_early_abort(void *param)
+{
+	int err;
+
+	radio_isr_set(isr_race, param);
+	if (!radio_is_idle()) {
+		radio_disable();
+	}
+
+	err = lll_hfclock_off();
+	LL_ASSERT(err >= 0);
+
+	lll_done(NULL);
+}
+
 static int init_reset(void)
 {
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -745,14 +745,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	 * ULL.
 	 */
 	if (unlikely(lll->conn && lll->conn->slave.initiated)) {
-		int err;
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
 
-		err = lll_hfclock_off();
-		LL_ASSERT(err >= 0);
-
-		lll_done(NULL);
-
-		DEBUG_RADIO_CLOSE_A(0);
 		return 0;
 	}
 #endif /* CONFIG_BT_PERIPHERAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -233,14 +233,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	/* Abort if no aux_ptr filled */
 	if (unlikely(!pri_hdr->aux_ptr || !aux_ptr->offs)) {
-		int err;
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
 
-		err = lll_hfclock_off();
-		LL_ASSERT(err >= 0);
-
-		lll_done(NULL);
-
-		DEBUG_RADIO_CLOSE_A(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -24,3 +24,4 @@ void lll_isr_status_reset(void);
 void lll_isr_abort(void *param);
 void lll_isr_done(void *param);
 void lll_isr_cleanup(void *param);
+void lll_isr_early_abort(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -111,14 +111,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on disconnection between prepare and pre-empt)
 	 */
 	if (unlikely(lll->handle == 0xFFFF)) {
-		int err;
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
 
-		err = lll_hfclock_off();
-		LL_ASSERT(err >= 0);
-
-		lll_done(NULL);
-
-		DEBUG_RADIO_CLOSE_M(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -143,14 +143,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	if (unlikely(lll->conn &&
 		     (lll->conn->master.initiated ||
 		      lll->conn->master.cancelled))) {
-		int err;
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
 
-		err = lll_hfclock_off();
-		LL_ASSERT(err >= 0);
-
-		lll_done(NULL);
-
-		DEBUG_RADIO_CLOSE_O(0);
 		return 0;
 	}
 #endif /* CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -119,14 +119,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Check if stopped (on disconnection between prepare and pre-empt)
 	 */
 	if (unlikely(lll->handle == 0xFFFF)) {
-		int err;
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
 
-		err = lll_hfclock_off();
-		LL_ASSERT(err >= 0);
-
-		lll_done(NULL);
-
-		DEBUG_RADIO_CLOSE_S(0);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -197,7 +197,6 @@
 /* Define ticker user operations */
 #if defined(CONFIG_BT_CTLR_LOW_LAT) && \
 	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
-#define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
 /* NOTE: When ticker job is disabled inside radio events then all advertising,
  *       scanning, and slave latency cancel ticker operations will be deferred,
  *       requiring increased ticker thread context operation queue count.
@@ -208,12 +207,13 @@
 				  TICKER_USER_THREAD_FLASH_OPS + \
 				  1)
 #else /* !CONFIG_BT_CTLR_LOW_LAT */
-#define TICKER_USER_LLL_OPS      (2 + TICKER_USER_LLL_VENDOR_OPS + 1)
 /* NOTE: As ticker job is not disabled inside radio events, no need for extra
  *       thread operations queue element for flash driver.
  */
 #define TICKER_USER_THREAD_OPS   (1 + TICKER_USER_THREAD_VENDOR_OPS + 1)
 #endif /* !CONFIG_BT_CTLR_LOW_LAT */
+
+#define TICKER_USER_ULL_LOW_OPS  (1 + 1)
 
 /* NOTE: When ULL_LOW priority is configured to lower than ULL_HIGH, then extra
  *       ULL_HIGH operations queue elements are required to buffer the
@@ -222,7 +222,7 @@
 #define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
 				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
 
-#define TICKER_USER_ULL_LOW_OPS  (1 + 1)
+#define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
 
 #define TICKER_USER_OPS           (TICKER_USER_LLL_OPS + \
 				   TICKER_USER_ULL_HIGH_OPS + \
@@ -2374,11 +2374,13 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	release = done_release(link, done);
 	LL_ASSERT(release == done);
 
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
 	/* dequeue prepare pipeline */
 	ull_prepare_dequeue(TICKER_USER_ID_ULL_HIGH);
 
 	/* LLL done synchronized */
 	lll_done_sync();
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
 	/* ull instance will resume, dont decrement ref */
 	if (!ull_hdr) {


### PR DESCRIPTION
There is a race between the pipeline enqueue by the ULL
context when processing the LLL done event, and the
pipeline queue by the ticker timeout for a new radio
event. This caused an already enqueued event prepare to be
placed after the newly arrived request to enqueue a prepare
by ticker timeout.

Fix this race by placing the new prepare in the pipeline
instead of starting the event, when ULL is still processing
the LLL done event.

As ticker timeout and ULL processing of LLL done event are
in the same ULL_HIGH context, the pipeline handling is safe
with the order of prepares maintained correctly.

Defer the event early abort so that lll_done does not get
recursively invoked when called inside prepare callback.

Move the LLL done event handling from ULL to LLL, this
reduces CPU utilization and reduces overhead between radio
events.

Fixes #21993.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>