### PR TITLE
tests: kernel: timer: Add a new testcase for timer

### DIFF
--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -8,6 +8,14 @@
 #include <tc_util.h>
 #include <ztest.h>
 
+#define DURATION 50
+#define PERIOD   50
+#define EXPIRE_TIMES 5
+
+static ZTEST_BMEM uint32_t t_start, t_delta, t_end, d_cycle;
+static ZTEST_BMEM uint32_t flag1, flag2;
+static struct k_timer timer;
+
 int test_frequency(void)
 {
 	uint32_t start, end, delta, pct;
@@ -80,8 +88,67 @@ void test_timer(void)
 	zassert_false(test_frequency(), "test frequency failed");
 }
 
+static void stop_duration(struct k_timer *timer)
+{
+	flag2++;
+}
+
+static void expiry_entry(struct k_timer *timer)
+{
+	t_end = k_cycle_get_32();
+	t_delta = t_end - t_start;
+	printk("start = %d, end = %d, delta = %d, d_cycle = %d\n",
+	       t_start, t_end, t_delta, d_cycle);
+	zassert_true(t_delta >= d_cycle, "expiry duration error");
+
+	flag1++;
+	/* Get the current cycle */
+	t_start = k_cycle_get_32();
+}
+
+static void timer_init(struct k_timer *timer)
+{
+	/* init timer object and data */
+	k_timer_init(timer, expiry_entry, stop_duration);
+	flag1 = 0;
+	flag2 = 0;
+}
+
+/**
+ * @brief Test timer duration precise
+ *
+ * @details Define and init a timer. Get cycle before start timer,
+ * Every timer duration need to get cycle and verify duration equal
+ * with cycle or not.
+ *
+ * @ingroup kernel_timer_tests
+ *
+ * @see k_cycle_get_32(), k_timer_init(), k_timer_start(), k_timer_stop()
+ */
+void test_timer_cycle(void)
+{
+	/* convert ms to cyc is not exactly correct */
+	d_cycle = k_ms_to_cyc_floor32(45);
+
+	/* get current cycle */
+	t_start = k_cycle_get_32();
+	k_timer_start(&timer, K_MSEC(DURATION), K_MSEC(PERIOD));
+
+	k_busy_wait(PERIOD * EXPIRE_TIMES * 1000 + PERIOD / 2 * 1000);
+	k_timer_stop(&timer);
+
+	/* check flag count */
+	zassert_equal(flag1, EXPIRE_TIMES, "expiry count error");
+	zassert_equal(flag2, 1, "stop count error");
+}
+
 void test_main(void)
 {
-	ztest_test_suite(timer_fn, ztest_unit_test(test_timer));
+	timer_init(&timer);
+	k_thread_access_grant(k_current_get(), &timer);
+
+	ztest_test_suite(timer_fn,
+			ztest_unit_test(test_timer),
+			ztest_unit_test(test_timer_cycle));
 	ztest_run_test_suite(timer_fn);
 }


### PR DESCRIPTION
Add a new testcase to testing the timer duration is precise or not.
Convert timer duration to cycle, then verify the duration and cycle
value that get by k_cycle_get() are equal.

Signed-off-by: Jian Kang <jianx.kang@intel.com>