### PR TITLE
soc: stm32h723: fix number of irqs

### DIFF
--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h723xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h723xx
@@ -9,6 +9,6 @@ config SOC
 	default "stm32h723xx"
 
 config NUM_IRQS
-	default 150
+	default 163
 
 endif # SOC_STM32H723XX


### PR DESCRIPTION
Increase the number of interrupts from 150 to 163.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>

Fixes: #33904