### PR TITLE
drivers: modem: ublox-sara-r4: add TLS offload support

### DIFF
--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -26,7 +26,7 @@ extern "C" {
 __net_socket struct modem_socket {
 	sa_family_t family;
 	enum net_sock_type type;
-	enum net_ip_protocol ip_proto;
+	int ip_proto;
 	struct sockaddr src;
 	struct sockaddr dst;
 	int id;


### PR DESCRIPTION
Currently it's able to connect to google iot mqtt server. Tested in our private application.
All other use cases are untested.
The only related test to this driver, `drivers/build_all` compiles at least.

I'm not exactly proud of changing the `modem_socket` protocol type to int, but it was the simplest way that needed the least changes elsewhere.

Signed-off-by: Johann Tael <jntael@gmail.com>