### PR TITLE
arm: Add code owner for the Segger's ip_k66f board

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,7 +92,7 @@
 /boards/arm/google_*/                     @jackrosenthal
 /boards/arm/hexiwear*/                    @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/hexiwear*/doc/                @MaureenHelm @MeganHansen
-/boards/arm/ip_k66f/                      @parthitce
+/boards/arm/ip_k66f/                      @parthitce @lmajewski
 /boards/arm/lpcxpresso*/                  @MaureenHelm @mmahadevan108 @dleach02
 /boards/arm/lpcxpresso*/doc/              @MaureenHelm @MeganHansen
 /boards/arm/mimx8mm_evk/                  @Mani-Sadhasivam


### PR DESCRIPTION
I would like to add myself as a co-maintainer for the ip_k66f
board.

Signed-off-by: Lukasz Majewski <lukma@denx.de>