### PR TITLE
Bluetooth: shell: Fix null check in cmd_per_adv_sync_delete

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1653,25 +1653,25 @@ static int cmd_per_adv_sync_delete(const struct shell *shell, size_t argc,
 {
 	int err;
 	int index = 0;
-	struct bt_le_per_adv_sync **per_adv_sync = NULL;
+	struct bt_le_per_adv_sync *per_adv_sync = NULL;
 
 	if (argc > 1) {
 		index = strtol(argv[1], NULL, 10);
 	}
 
-	per_adv_sync = &per_adv_syncs[index];
+	per_adv_sync = per_adv_syncs[index];
 
 	if (!per_adv_sync) {
 		return -EINVAL;
 	}
 
-	err = bt_le_per_adv_sync_delete(*per_adv_sync);
+	err = bt_le_per_adv_sync_delete(per_adv_sync);
 
 	if (err) {
 		shell_error(shell, "Per adv sync delete failed (%d)", err);
 	} else {
 		shell_print(shell, "Per adv sync deleted");
-		*per_adv_sync = NULL;
+		per_adv_syncs[index] = NULL;
 	}
 
 	return 0;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1651,12 +1651,19 @@ static int cmd_per_adv_sync_create(const struct shell *shell, size_t argc,
 static int cmd_per_adv_sync_delete(const struct shell *shell, size_t argc,
 				   char *argv[])
 {
-	int err;
-	int index = 0;
 	struct bt_le_per_adv_sync *per_adv_sync = NULL;
+	int index;
+	int err;
 
 	if (argc > 1) {
 		index = strtol(argv[1], NULL, 10);
+	} else {
+		index = 0;
+	}
+
+	if (index >= ARRAY_SIZE(per_adv_syncs)) {
+		shell_error(shell, "Maximum index is %u but %u was requested",
+			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 
 	per_adv_sync = per_adv_syncs[index];
@@ -1789,6 +1796,11 @@ static int cmd_per_adv_sync_transfer(const struct shell *shell, size_t argc,
 		index = strtol(argv[1], NULL, 10);
 	} else {
 		index = 0;
+	}
+
+	if (index >= ARRAY_SIZE(per_adv_syncs)) {
+		shell_error(shell, "Maximum index is %u but %u was requested",
+			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 
 	per_adv_sync = per_adv_syncs[index];


### PR DESCRIPTION
The check for NULL was on the pointer to the pointer,
rather than the pointer. The pointer of the pointer would
always be non-null, but the pointer might not be.

Moved from using a pointer of a pointer to just a
pointer to make it easier to read and understand.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>