### PR TITLE
Bluetooth: SMP: Adds Kconfig for minimum encryption key size

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -509,6 +509,15 @@ config BT_KEYS_SAVE_AGING_COUNTER_ON_PAIRING
 	  time a successful pairing occurs. This increases flash wear out but offers
 	  a more correct finding of the oldest unused pairing info.
 
+config BT_SMP_MIN_ENC_KEY_SIZE
+	int
+	prompt "Minimum encryption key size accepted in octets" if !BT_SMP_SC_ONLY
+	range 7 16
+	default 7
+	default 16 if BT_SMP_SC_ONLY
+	help
+	  This option sets the minimum encryption key size accepted during pairing.
+
 endif # BT_SMP
 
 source "subsys/bluetooth/host/Kconfig.l2cap"

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -38,7 +38,7 @@ struct bt_smp_hdr {
 #define BT_SMP_OOB_NOT_PRESENT			0x00
 #define BT_SMP_OOB_PRESENT			0x01
 
-#define BT_SMP_MIN_ENC_KEY_SIZE			7
+#define BT_SMP_MIN_ENC_KEY_SIZE			CONFIG_BT_SMP_MIN_ENC_KEY_SIZE
 #define BT_SMP_MAX_ENC_KEY_SIZE			16
 
 #define BT_SMP_DIST_ENC_KEY			0x01


### PR DESCRIPTION
Adds a Kconfig option to set the minimum key size accepted
by this device. This can be used to e.g. enforce 128-bit keys.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>