### PR TITLE
Bluetooth: GATT: Verify security when notifiying or indicating

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1887,6 +1887,11 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 	}
 #endif
 
+	/* Confirm that the connection has the correct level of security */
+	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT)) {
+		return -EPERM;
+	}
+
 #if defined(CONFIG_BT_GATT_NOTIFY_MULTIPLE)
 	if (gatt_cf_notify_multi(conn)) {
 		int err;
@@ -2013,6 +2018,12 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 		return -EAGAIN;
 	}
 #endif
+
+	/* Confirm that the connection has the correct level of security */
+	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT)) {
+		return -EPERM;
+	}
+
 	len = sizeof(*ind) + params->len;
 
 	req = gatt_req_alloc(gatt_indicate_rsp, params, NULL,
@@ -2112,6 +2123,11 @@ static uint8_t notify_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 		/* Confirm match if cfg is managed by application */
 		if (ccc->cfg_match && !ccc->cfg_match(conn, attr)) {
 			bt_conn_unref(conn);
+			continue;
+		}
+
+		/* Confirm that the connection has the correct level of security */
+		if (bt_gatt_check_perm(conn, attr, BT_GATT_PERM_READ_ENCRYPT)) {
 			continue;
 		}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1888,7 +1888,9 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 #endif
 
 	/* Confirm that the connection has the correct level of security */
-	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT)) {
+	if (bt_gatt_check_perm(conn, params->attr,
+			       BT_GATT_PERM_READ_ENCRYPT | BT_GATT_PERM_READ_AUTHEN)) {
+		BT_WARN("Link is not encrypted");
 		return -EPERM;
 	}
 
@@ -2020,7 +2022,9 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 #endif
 
 	/* Confirm that the connection has the correct level of security */
-	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT)) {
+	if (bt_gatt_check_perm(conn, params->attr,
+			       BT_GATT_PERM_READ_ENCRYPT | BT_GATT_PERM_READ_AUTHEN)) {
+		BT_WARN("Link is not encrypted");
 		return -EPERM;
 	}
 
@@ -2127,7 +2131,9 @@ static uint8_t notify_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 		}
 
 		/* Confirm that the connection has the correct level of security */
-		if (bt_gatt_check_perm(conn, attr, BT_GATT_PERM_READ_ENCRYPT)) {
+		if (bt_gatt_check_perm(conn, attr,
+				       BT_GATT_PERM_READ_ENCRYPT | BT_GATT_PERM_READ_AUTHEN)) {
+			BT_WARN("Link is not encrypted");
 			continue;
 		}
 


### PR DESCRIPTION
Adds a security checks when notifying or indicating, such
that we don't send notifications for characteristics that
require encryption on an unencrypted link.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>