### PR TITLE
driver: pinctrl: add function to set/get WP pin status

### DIFF
--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -139,6 +139,25 @@ bool npcx_pinctrl_psl_input_asserted(uint32_t i)
 				NPCX_PSL_CTS_EVENT_BIT(psl_in_confs[i].offset));
 }
 
+int npcx_pinctrl_flash_write_protect_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	inst_scfg->DEV_CTL4 |= BIT(NPCX_DEV_CTL4_WP_IF);
+	if (!npcx_pinctrl_flash_write_protect_is_set()) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+bool npcx_pinctrl_flash_write_protect_is_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	return IS_BIT_SET(inst_scfg->DEV_CTL4, NPCX_DEV_CTL4_WP_IF);
+}
+
 void npcx_pinctrl_psl_input_configure(void)
 {
 	/* Configure detection type of PSL input pads */

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -129,6 +129,21 @@ void npcx_pinctrl_psl_input_configure(void);
  */
 bool npcx_pinctrl_psl_input_asserted(uint32_t i);
 
+/**
+ * @brief Force the internal SPI flash write-protect pin (WP) to low level to
+ * protect the flash Status register.
+ *
+ * @return Standard error code.
+ */
+int npcx_pinctrl_flash_write_protect_set(void);
+
+/**
+ * @brief Get write protection status.
+ *
+ * @return true if write protection is set, false otherwise.
+ */
+bool npcx_pinctrl_flash_write_protect_is_set(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add function to set the WP_IF bit as well as get the current state of the
bit. This change is an upstream port of
https://chromium-review.googlesource.com/c/chromiumos/third_party/zephyr/+/2704625

Signed-off-by: Yuval Peress <peress@chromium.org>