### PR TITLE
boards: shields: Fix adafruit_2_8_tft_touch_v2 Arduino D4 pin (SDMMC CS)

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -167,6 +167,7 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 #endif
 
 #if CONFIG_SHIELD_ADAFRUIT_2_8_TFT_TOUCH_V2
+	pinmux_pin_set(portb, 23, PORT_PCR_MUX(kPORT_MuxAsGpio));
 	pinmux_pin_set(portc,  4, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 

--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SHIELD_ADAFRUIT_2_8_TFT_TOUCH_V2
 
+config GPIO
+	default y
+
 if DISPLAY
 
 config SPI

--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -71,4 +71,11 @@ endif # LVGL
 
 endif # DISPLAY
 
+if DISK_DRIVERS
+
+config DISK_DRIVER_SDMMC
+	default y
+
+endif # DISK_DRIVERS
+
 endif # SHIELD_ADAFRUIT_2_8_TFT_TOUCH_V2

--- a/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2.overlay
@@ -9,7 +9,7 @@
 &arduino_spi {
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
-		   <&arduino_header 12 GPIO_ACTIVE_LOW>;	/* D04 */
+		   <&arduino_header 10 GPIO_ACTIVE_LOW>;	/* D04 */
 
 
 	ili9340@0 {

--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -10,3 +10,7 @@ tests:
       fixture: fixture_sdhc
   sample.filesystem.fat_fs.overlay:
     platform_allow: nrf52840_blip
+  sample.filesystem.fat_fs.adafruit_2_8_tft_touch_v2:
+    depends_on: arduino_spi arduino_gpio
+    extra_args: SHIELD=adafruit_2_8_tft_touch_v2
+    tags: shield


### PR DESCRIPTION
The device tree overlay for the adafruit_2_8_tft_touch_v2 shield board
was incorrectly mapping the Arduino D4 pin, used for SDMMC chip select.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>