### PR TITLE
soc: npcx: scfg: add functions to set/get WP pin status

### DIFF
--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -117,6 +117,25 @@ void npcx_pinctrl_i2c_port_sel(int controller, int port)
 	}
 }
 
+int npcx_pinctrl_flash_write_protect_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	inst_scfg->DEV_CTL4 |= BIT(NPCX_DEV_CTL4_WP_IF);
+	if (!IS_BIT_SET(inst_scfg->DEV_CTL4, NPCX_DEV_CTL4_WP_IF)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+bool npcx_pinctrl_flash_write_protect_is_set(void)
+{
+	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
+
+	return IS_BIT_SET(inst_scfg->DEV_CTL4, NPCX_DEV_CTL4_WP_IF);
+}
+
 void npcx_pinctrl_psl_output_set_inactive(void)
 {
 	struct gpio_reg *const inst = (struct gpio_reg *)

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -102,6 +102,19 @@ void npcx_pinctrl_mux_configure(const struct npcx_alt *alts_list,
 void npcx_pinctrl_i2c_port_sel(int controller, int port);
 
 /**
+ * @brief Force the internal SPI flash write-protect pin (WP) to low level to
+ * protect the flash Status registers.
+ */
+int npcx_pinctrl_flash_write_protect_set(void);
+
+/**
+ * @brief Get write protection status
+ *
+ * @return 1 if write protection is set, 0 otherwise.
+ */
+bool npcx_pinctrl_flash_write_protect_is_set(void);
+
+/**
  * @brief Set PSL output pad to inactive level.
  *
  * The PSL_OUT output pad should be connected to the control pin of either the


### PR DESCRIPTION
The Write Protect pin of the internal SPI flash can be controlled by
WP_IF bit in DEV_CTL4 register. Add functions to set/get the status of
WP pin.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>
Change-Id: I8a0ce131f006f919a3b38a65722d0d312314ff0a