### PR TITLE
tests: add min_ram to test applications

### DIFF
--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     # see #26646
     platform_exclude: m2gl025_miv
     tags: kernel
+    min_ram: 20

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   timeout: 180
+  min_ram: 34
 tests:
   kernel.scheduler:
     filter: not CONFIG_SCHED_MULTIQ


### PR DESCRIPTION
add min_ram to some test applications

TWR_KE18F and FRDM_KL25Z

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>