### PR TITLE
cmake: fix isystem_include_dir path for windows

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -44,7 +44,7 @@ if(NOT "${ARCH}" STREQUAL "posix")
   endforeach()
 
   foreach(isystem_include_dir ${NOSTDINC})
-    list(APPEND isystem_include_flags -isystem ${isystem_include_dir})
+    list(APPEND isystem_include_flags -isystem "\"${isystem_include_dir}\"")
   endforeach()
 
   if(CONFIG_X86)

--- a/cmake/compiler/icx/target.cmake
+++ b/cmake/compiler/icx/target.cmake
@@ -36,7 +36,7 @@ foreach(file_name include/stddef.h)
 endforeach()
 
 foreach(isystem_include_dir ${NOSTDINC})
-  list(APPEND isystem_include_flags -isystem ${isystem_include_dir})
+  list(APPEND isystem_include_flags -isystem "\"${isystem_include_dir}\"")
 endforeach()
 
 if(CONFIG_64BIT)


### PR DESCRIPTION
The system include directory might include spaces on windows, so quote
it.

related to #32111

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
