### PR TITLE
fs/nvs: hardening against bad offset in close_ate

### DIFF
--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -28,4 +28,12 @@ config NVS_WRITE_RETRY
 	  This option can be enabled only on memories which allow writes to
 	  same location at las twice.
 
+config NVS_ALLOW_ATE_GAPS
+	bool "Allow big gaps in ATE area"
+	help
+	  Allow scanning through empty ATE gaps in ATE area while recovering
+	  the last ate in the sector for. This might help to serve corrupted
+	  writes on devices on which same flash location rewrite attempts are
+	  forbidden or flash malfunction might cause ATE being empty.
+
 endif # NVS

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Laczen
 # SPDX-License-Identifier: Apache-2.0
 
-config NVS
+menuconfig NVS
 	bool "Non-volatile Storage"
 	help
 	  Enable support of Non-volatile Storage.
@@ -13,5 +13,19 @@ if NVS
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"
+
+config NVS_WRITE_CHECK
+	bool "Check written content"
+	help
+	  Check whether flash content match data written. Write API returns
+	  error if check fails as for other flash driver error.
+
+config NVS_WRITE_RETRY
+	bool "Retry write"
+	depends on NVS_WRITE_CHECK
+	help
+	  Retry write operation if flash content doesn't match to data written.
+	  This option can be enabled only on memories which allow writes to
+	  same location at las twice.
 
 endif # NVS

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -483,10 +483,23 @@ static int nvs_gc(struct nvs_fs *fs)
 
 	stop_addr = gc_addr - ate_size;
 
-	if (!nvs_ate_crc8_check(&close_ate)) {
+	if (!nvs_ate_crc8_check(&close_ate) &&
+	    (close_ate.offset <= stop_addr) &&
+	    !(close_ate.offset % ate_size)) {
 		gc_addr &= ADDR_SECT_MASK;
 		gc_addr += close_ate.offset;
 	} else {
+		/**
+		 * - If ate was corrupted or
+		 * - ate.offset has unaligned value
+		 * - If the last data ate offset is greather that allowed
+		 * assume that somehow sector was closed despite it
+		 * doesn't contain any data.
+		 * @todo consider close_ate.offset == stop_addr as designation
+		 * of any empty-closed sector
+		 *
+		 * Consider this sector as to be recovered.
+		 */
 		rc = nvs_recover_last_ate(fs, &gc_addr);
 		if (rc) {
 			return rc;


### PR DESCRIPTION
If closing ate is valid (crc is ok) and close_ate.offset
has not allowed value GC can't be performed.
Such sector might be treated as empty as it is remains after
disturbed nvs write.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>