### PR TITLE
soc: stm32: Remove redudant zephyr_include_directories

### DIFF
--- a/soc/arm/st_stm32/common/CMakeLists.txt
+++ b/soc/arm/st_stm32/common/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(.)
-
 zephyr_sources(stm32cube_hal.c)
 
 zephyr_linker_sources_ifdef(CONFIG_STM32_CCM SECTIONS ccm.ld)


### PR DESCRIPTION
soc/arm/st_stm32/CMakeLists.txt already has a
zephyr_include_directories(common) so including in again
soc/arm/st_stm32/common/CMakeLists.txt is redudant.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>