### PR TITLE
Bluetooth: controller: Fix minor typo in Periodic Sync PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -199,7 +199,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_gpio_lna_setup();
 
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(lll->phy_rx, 1) -
+				 radio_rx_ready_delay_get(lll->phy, 1) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 


### PR DESCRIPTION
Fix minor typo in Periodic Advertising Sync implementation
when PA/LNA is enabled.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>