### PR TITLE
xtensa: log: add missing strdup

### DIFF
--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -202,7 +202,7 @@ void *xtensa_excint1_c(int *interrupted_stack)
 		LOG_ERR(" ** FATAL EXCEPTION");
 		LOG_ERR(" ** CPU %d EXCCAUSE %d (%s)",
 			arch_curr_cpu()->id, cause,
-			z_xtensa_exccause(cause));
+			log_strdup(z_xtensa_exccause(cause)));
 		LOG_ERR(" **  PC %p VADDR %p",
 			(void *)bsa[BSA_PC_OFF/4], (void *)vaddr);
 		LOG_ERR(" **  PS %p", (void *)bsa[BSA_PS_OFF/4]);

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -104,7 +104,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * change it without also updating twister
 	 */
 	LOG_ERR(">>> ZEPHYR FATAL ERROR %d: %s on CPU %d", reason,
-		reason_to_str(reason), get_cpu());
+		log_strdup(reason_to_str(reason)), get_cpu());
 
 	/* FIXME: This doesn't seem to work as expected on all arches.
 	 * Need a reliable way to determine whether the fault happened when


### PR DESCRIPTION
Fix missing log_strdup call

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>