### PR TITLE
dts: nxp: kinetis: Add pinmux data

### DIFF
--- a/dts/arm/nxp/MK22FN512VLH12.dtsi
+++ b/dts/arm/nxp/MK22FN512VLH12.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_k2x.dtsi>
+
+#include <nxp/kinetis/MK22FN512VLH12-pinctrl.dtsi>

--- a/dts/arm/nxp/MK64FN1M0VDC12.dtsi
+++ b/dts/arm/nxp/MK64FN1M0VDC12.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_k6x.dtsi>
+
+#include <nxp/kinetis/MK64FN1M0VDC12-pinctrl.dtsi>

--- a/dts/arm/nxp/MK64FN1M0VLL12.dtsi
+++ b/dts/arm/nxp/MK64FN1M0VLL12.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_k6x.dtsi>
+
+#include <nxp/kinetis/MK64FN1M0VLL12-pinctrl.dtsi>

--- a/dts/arm/nxp/MK66FN2M0VMD18.dtsi
+++ b/dts/arm/nxp/MK66FN2M0VMD18.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_k66.dtsi>
+
+#include <nxp/kinetis/MK66FN2M0VMD18-pinctrl.dtsi>

--- a/dts/arm/nxp/MK82FN256VLL15.dtsi
+++ b/dts/arm/nxp/MK82FN256VLL15.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_k82fn256vxx15.dtsi>
+
+#include <nxp/kinetis/MK82FN256VLL15-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE14F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE14F256VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke14f256vlx16.dtsi>
+
+#include <nxp/kinetis/MKE14F256VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE14F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE14F256VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke14f256vlx16.dtsi>
+
+#include <nxp/kinetis/MKE14F256VLL16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE14F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE14F512VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke14f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE14F512VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE14F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE14F512VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke14f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE14F512VLL16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE16F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE16F256VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke16f256vlx16.dtsi>
+
+#include <nxp/kinetis/MKE16F256VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE16F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE16F256VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke16f256vlx16.dtsi>
+
+#include <nxp/kinetis/MKE16F256VLL16-pinctrl.dtsi"

--- a/dts/arm/nxp/MKE16F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE16F512VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke16f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE16F512VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE16F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE16F512VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke16f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE16F512VLL16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE18F256VLH16.dtsi
+++ b/dts/arm/nxp/MKE18F256VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke18f256vlx16.dtsi>
+
+#include <nxp/kinetis/MKE18F256VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE18F256VLL16.dtsi
+++ b/dts/arm/nxp/MKE18F256VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke18f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE18F256VLL16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE18F512VLH16.dtsi
+++ b/dts/arm/nxp/MKE18F512VLH16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke18f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE18F512VLH16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKE18F512VLL16.dtsi
+++ b/dts/arm/nxp/MKE18F512VLL16.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_ke18f512vlx16.dtsi>
+
+#include <nxp/kinetis/MKE18F512VLL16-pinctrl.dtsi>

--- a/dts/arm/nxp/MKL25Z128VLK4.dtsi
+++ b/dts/arm/nxp/MKL25Z128VLK4.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_kl25z.dtsi>
+
+#include <nxp/kinetis/MKL25Z128VLK4-pinctrl.dtsi>

--- a/dts/arm/nxp/MKV58F1M0VLQ24.dtsi
+++ b/dts/arm/nxp/MKV58F1M0VLQ24.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_kv58f1m0vlx24.dtsi>
+
+#include <nxp/kinetis/MKV58F1M0VLQ24-pinctrl.dtsi>

--- a/dts/arm/nxp/MKW24D512VHA5.dtsi
+++ b/dts/arm/nxp/MKW24D512VHA5.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_kw2xd.dtsi>
+
+#include <nxp/kinetis/MKW24D512VHA5-pinctrl.dtsi>

--- a/dts/arm/nxp/MKW40Z160VHT4.dtsi
+++ b/dts/arm/nxp/MKW40Z160VHT4.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_kw40z.dtsi>
+
+#include <nxp/kinetis/MKW40Z160VHT4-pinctrl.dtsi>

--- a/dts/arm/nxp/MKW41Z512VHT4.dtsi
+++ b/dts/arm/nxp/MKW41Z512VHT4.dtsi
@@ -5,3 +5,5 @@
  */
 
 #include <nxp/nxp_kw41z.dtsi>
+
+#include <nxp/kinetis/MKW41Z512VHT4-pinctrl.dtsi>

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -2,7 +2,9 @@ description: Kinetis pinmux node
 
 compatible: "nxp,kinetis-pinmux"
 
-include: base.yaml
+include:
+  - name: base.yaml
+  - name: pincfg-node.yaml
 
 properties:
     reg:
@@ -11,6 +13,27 @@ properties:
     clocks:
       required: true
 
-pinmux-cells:
-  - pin
-  - function
+child-binding:
+    description: |
+      NXP Kinetis Pin data.  A series of child nodes that describe each pin
+      configuration supported by the SoC.  Each node is expected to named as
+      follows - <periph>_<signal>_pt<port><pin>
+
+      The node will have a matching node label that board dtsi files can
+      utilized to reference in pinctrl-<N> properties.
+
+      The following is an example for UART0 CTS signal on pin 0, with mux
+      value of 2.
+
+      uart0_cts_pta0: uart0_cts_pta0 {
+           nxp,kinetis-port-pins = < 0 2 >;
+      };
+
+    properties:
+      "nxp,kinetis-port-pins":
+        description: |
+          The array is expected to have two elements. The first element is the
+          pin number and the second element is the mux value (i.e. PCR[MUX]).
+
+        type: array
+        required: true

--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
       revision: 244d685184e7e983f47569be276d9d4c1b133016
       path: tools/net-tools
     - name: hal_nxp
-      revision: 6f587556a98b5167b1f301c1e10fed1443942906
+      revision: ad8de4f9743aa7500f184bcf6c2cea07c041fe69
       path: modules/hal/nxp
     - name: open-amp
       revision: de1b85a13032a2de1d8b6695ae5f800b613e739d


### PR DESCRIPTION
Add pinmux data to devicetree for NXP Kinetis SoCs as a start towards supporting pinmux data being specified completely from the devicetree at a board level.