### PR TITLE
kernel: prioritize C atomic functions if selected

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -103,7 +103,7 @@ config XTENSA
 	select HAS_DTS
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
-	select ATOMIC_OPERATIONS_ARCH
+	imply ATOMIC_OPERATIONS_ARCH
 	help
 	  Xtensa architecture
 

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -24,9 +24,9 @@ typedef void *atomic_ptr_t;
 
 /* Low-level primitives come in several styles: */
 
-#if defined(CONFIG_ATOMIC_OPERATIONS_BUILTIN)
-/* Default.  See this file for the Doxygen reference: */
-#include <sys/atomic_builtin.h>
+#if defined(CONFIG_ATOMIC_OPERATIONS_C)
+/* Generic-but-slow implementation based on kernel locking and syscalls */
+#include <sys/atomic_c.h>
 #elif defined(CONFIG_ATOMIC_OPERATIONS_ARCH)
 /* Some architectures need their own implementation */
 # ifdef CONFIG_XTENSA
@@ -34,8 +34,8 @@ typedef void *atomic_ptr_t;
 # include <arch/xtensa/atomic_xtensa.h>
 # endif
 #else
-/* Generic-but-slow implementation based on kernel locking and syscalls */
-#include <sys/atomic_c.h>
+/* Default.  See this file for the Doxygen reference: */
+#include <sys/atomic_builtin.h>
 #endif
 
 /* Portable higher-level utilities: */

--- a/include/sys/atomic_builtin.h
+++ b/include/sys/atomic_builtin.h
@@ -300,8 +300,4 @@ static inline atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value)
 }
 #endif
 
-#ifdef CONFIG_ATOMIC_OPERATIONS_C
-#include <syscalls/atomic.h>
-#endif
-
 #endif /* ZEPHYR_INCLUDE_SYS_ATOMIC_BUILTIN_H_ */


### PR DESCRIPTION
Usually, GCC builtin or arch-specific atomic functions are being used. The corresponding kconfigs are "selected" by architecture
or SoC kconfigs. CONFIG_ATOMIC_OPERATIONS_C is usually used to override the GCC built-in or arch-specific atomic unctions when these two are not supported. So change the priority of #include so that C version is included first if selected, and skips the inline versions of the other two variants. Or else there will be two compiled versions of atomic functions: inline version and the compiled C version.

Also remove the incorrectly included generated syscall header in `atomic_builtin.h`, and changes `CONFIG_ATOMIC_OPERATIONS_ARCH` to `imply` for Xtensa.

Fixes #33857