### PR TITLE
stm32 devices with USB-C PD cannot use CC1 and CC2 pins by default

### DIFF
--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -16,6 +16,10 @@
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <linker/linker-defs.h>
 #include <string.h>
+#if defined(SYSCFG_CFGR1_UCPD1_STROBE) || defined(SYSCFG_CFGR1_UCPD2_STROBE)
+#include <stm32_ll_system.h>
+#include <stm32_ll_bus.h>
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -43,6 +47,12 @@ static int stm32g0_init(const struct device *arg)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */
 	SystemCoreClock = 16000000;
+
+#if defined(SYSCFG_CFGR1_UCPD1_STROBE) || defined(SYSCFG_CFGR1_UCPD2_STROBE)
+	/* Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
+	LL_SYSCFG_DisableDBATT(LL_SYSCFG_UCPD1_STROBE | LL_SYSCFG_UCPD2_STROBE);
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
 
 	return 0;
 }

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -15,6 +15,11 @@
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 
+#if defined(PWR_CR3_UCPD_DBDIS)
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#endif /* PWR_CR3_UCPD_DBDIS */
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *
@@ -45,6 +50,11 @@ static int stm32g4_init(const struct device *arg)
 	/* allow reflashing board */
 	LL_DBGMCU_EnableDBGSleepMode();
 
+#if defined(PWR_CR3_UCPD_DBDIS)
+	/* Disable USB Type-C dead battery pull-down behavior */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+	LL_PWR_DisableUCPDDeadBattery();
+#endif /* PWR_CR3_UCPD_DBDIS */
 	return 0;
 }
 

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -47,6 +47,9 @@ static int stm32l5_init(const struct device *arg)
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 
+	/* Disable USB Type-C dead battery pull-down behavior */
+	LL_PWR_DisableUCPDDeadBattery();
+
 	return 0;
 }
 


### PR DESCRIPTION
It disables USB Type-C dead battery pull-down behavior on UCPDx_CC1 and UCPDx_CC2 pins
of the stm32G4 and stm32L5  and stm32G0 soc series which have the USB type C Power Delivery feature. 

After exiting reset, the USB Type-C “dead battery” behavior is enabled, which may have a
pulldown effect on CC1 and CC2 pins. It is recommended to disable it in all cases, either to
stop this pull-down or to hand over control to the UCPD (which should therefore be initialized
before doing the disable).

For stm32l5 and stm32g4, the UCPD DBDIS is controlled by the UCPD1_DBDIS bit of the PWR CR3 register.
For stm32g0, the UCPD DBDIS are controlled by the strobe bits of the SYSCFG CFGR1 register

Fix  #33253  

Signed-off-by: Francois Ramu <francois.ramu@st.com>
