### PR TITLE
bluetooth/tester: give data buffer for each L2CAP channel

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define CHANNELS 2
 #define SERVERS 1
 
-NET_BUF_POOL_FIXED_DEFINE(data_pool, 1, DATA_BUF_SIZE, NULL);
+NET_BUF_POOL_FIXED_DEFINE(data_pool, CHANNELS, DATA_BUF_SIZE, NULL);
 
 static struct channel {
 	uint8_t chan_id; /* Internal number that identifies L2CAP channel. */


### PR DESCRIPTION
L2CAP channels are allocating buffers from common data_pool. For that
pool buffer count was hard-coded as 1. This count should be set to value
CHANNELS, allowing each channel to allocate buffer for incoming
data. Without this change, execution would stuck at l2cap_chan_le_recv()
as we give net_buf_alloc() in alloc_buf_cb() no timeout.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>