### PR TITLE
boards: frdm_k64f: Remove settings pins that don't actually exist

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -146,7 +146,6 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 	pinmux_pin_set(porta, 15, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(porta, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(porta, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
-	pinmux_pin_set(porta, 28, PORT_PCR_MUX(kPORT_MuxAlt4));
 
 	pinmux_pin_set(portb,  0, PORT_PCR_MUX(kPORT_MuxAlt4)
 		| PORT_PCR_ODE_MASK | PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
@@ -156,7 +155,6 @@ static int frdm_k64f_pinmux_init(const struct device *dev)
 	pinmux_pin_set(portc, 16, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 17, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
-	pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcan0), okay) && CONFIG_CAN


### PR DESCRIPTION
On the FRDM-K64F board the SoC uses the 100 pin LQFP package version of
the SoC (MK64FN1M0VLL12).  This pacakge doesn't pin out PTA28 or PTC19.
So remove setting them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>