### PR TITLE
PM: Consider the time required to exit an idle state

### DIFF
--- a/dts/bindings/power/state.yaml
+++ b/dts/bindings/power/state.yaml
@@ -29,3 +29,8 @@ properties:
             Minimum residency duration in microseconds. It is the minimum time for a
             given idle state to be worthwhile energywise. It includes the time to enter
             in this state.
+    exit-latency-us:
+        type: int
+        required: false
+        description: |
+            Worst case latency in microseconds required to exit the idle state.

--- a/dts/bindings/power/state.yaml
+++ b/dts/bindings/power/state.yaml
@@ -27,4 +27,5 @@ properties:
         required: false
         description: |
             Minimum residency duration in microseconds. It is the minimum time for a
-            given idle state to be worthwhile energywise.
+            given idle state to be worthwhile energywise. It includes the time to enter
+            in this state.

--- a/include/power/power_state.h
+++ b/include/power/power_state.h
@@ -120,13 +120,15 @@ struct pm_state_info {
 	 *			compatible = "zephyr,power-state";
 	 *			power-state-name = "suspend-to-idle";
 	 *			substate-id = <1>;
-	 *			min-residency-us = <1>;
+	 *			min-residency-us = <10000>;
+	 *			exit-latency-us = <100>;
 	 *		};
 	 *		state1: state1 {
 	 *			compatible = "zephyr,power-state";
 	 *			power-state-name = "suspend-to-idle";
 	 *			substate-id = <2>;
-	 *			min-residency-us = <1>;
+	 *			min-residency-us = <20000>;
+	 *			exit-latency-us = <200>;
 	 *		};
 	 *	}
 	 */
@@ -139,6 +141,13 @@ struct pm_state_info {
 	 * @note 0 means that this property is not available for this state.
 	 */
 	uint32_t min_residency_us;
+
+	/**
+	 * Worst case latency in microseconds required to exit the idle state.
+	 *
+	 * @note 0 means that this property is not available for this state.
+	 */
+	uint32_t exit_latency_us;
 };
 
 /**
@@ -156,6 +165,8 @@ struct pm_state_info {
 			cpu_power_states, i, substate_id, 0),   \
 		.min_residency_us = DT_PROP_BY_PHANDLE_IDX_OR(node_id, \
 				cpu_power_states, i, min_residency_us, 0),\
+		.exit_latency_us = DT_PROP_BY_PHANDLE_IDX_OR(node_id, \
+				cpu_power_states, i, exit_latency_us, 0),\
 	},
 
 /**
@@ -197,13 +208,15 @@ struct pm_state_info {
  *		state0: state0 {
  *			compatible = "zephyr,power-state";
  *			power-state-name = "suspend-to-idle";
- *			min-residency-us = <1>;
+ *			min-residency-us = <10000>;
+ *		        exit-latency-us = <100>;
  *		};
  *
  *		state1: state1 {
  *			compatible = "zephyr,power-state";
  *			power-state-name = "suspend-to-ram";
- *			min-residency-us = <5>;
+ *			min-residency-us = <50000>;
+ *		        exit-latency-us = <500>;
  *		};
  *	};
  *
@@ -262,13 +275,15 @@ struct pm_state_info {
  *	state0: state0 {
  *		compatible = "zephyr,power-state";
  *		power-state-name = "suspend-to-idle";
- *		min-residency-us = <1>;
+ *		min-residency-us = <10000>;
+ *		exit-latency-us = <100>;
  *	};
  *
  *	state1: state1 {
  *		compatible = "zephyr,power-state";
  *		power-state-name = "suspend-to-ram";
- *		min-residency-us = <5>;
+ *		min-residency-us = <50000>;
+ *		exit-latency-us = <500>;
  *	};
  *
  * Example usage: *

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -91,7 +91,6 @@ void main(void)
 	 * force entry to deep sleep on any delay.
 	 */
 	pm_power_state_force((struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
-	k_sleep(K_MSEC(1));
 
 	printk("ERROR: System off failed\n");
 	while (true) {

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -68,7 +68,6 @@ void main(void)
 	 * Force the SOFT_OFF state.
 	 */
 	pm_power_state_force((struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
-	k_sleep(K_MSEC(1));
 
 	printk("ERROR: System off failed\n");
 	while (true) {

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -20,13 +20,21 @@ struct pm_state_info pm_policy_next_state(int32_t ticks)
 	int i;
 
 	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
+		uint32_t min_residency, exit_latency;
+
 		if (!pm_constraint_get(pm_min_residency[i].state)) {
 			continue;
 		}
 
+		min_residency = k_us_to_ticks_ceil32(
+			    pm_min_residency[i].min_residency_us);
+		exit_latency = k_us_to_ticks_ceil32(
+			    pm_min_residency[i].exit_latency_us);
+		__ASSERT(min_residency > exit_latency,
+				"min_residency_us < exit_latency_us");
+
 		if ((ticks == K_TICKS_FOREVER) ||
-		    (ticks >= k_us_to_ticks_ceil32(
-			    pm_min_residency[i].min_residency_us))) {
+		    (ticks >= (min_residency - exit_latency))) {
 			LOG_DBG("Selected power state %d "
 				"(ticks: %d, min_residency: %u)",
 				pm_min_residency[i].state, ticks,

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -183,6 +183,14 @@ enum pm_state pm_system_suspend(int32_t ticks)
 
 	if (ticks != K_TICKS_FOREVER) {
 		/*
+		 * Just a sanity check in case the policy manager does not
+		 * handle this error condition properly.
+		 */
+		__ASSERT(z_power_state.min_residency_us >=
+			z_power_state.exit_latency_us,
+			"min_residency_us < exit_latency_us");
+
+		/*
 		 * We need to set the timer to interrupt a little bit early to
 		 * accommodate the time required by the CPU to fully wake up.
 		 */

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <kernel.h>
+#include <timeout_q.h>
 #include <init.h>
 #include <string.h>
 #include <power/power.h>
@@ -179,6 +180,15 @@ enum pm_state pm_system_suspend(int32_t ticks)
 		return z_power_state.state;
 	}
 	post_ops_done = 0;
+
+	if (ticks != K_TICKS_FOREVER) {
+		/*
+		 * We need to set the timer to interrupt a little bit early to
+		 * accommodate the time required by the CPU to fully wake up.
+		 */
+		z_set_timeout_expiry(ticks -
+		     k_us_to_ticks_ceil32(z_power_state.exit_latency_us), true);
+	}
 
 #if CONFIG_PM_DEVICE
 

--- a/tests/subsys/power/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/power/power_states_api/boards/native_posix.overlay
@@ -13,13 +13,13 @@
 	state0: state0 {
 		compatible = "zephyr,power-state";
 		power-state-name = "suspend-to-idle";
-		min-residency-us = <1>;
+		min-residency-us = <10000>;
 	};
 
 	state1: state1 {
 		compatible = "zephyr,power-state";
 		power-state-name = "suspend-to-ram";
-		min-residency-us = <5>;
+		min-residency-us = <50000>;
 	};
 
 	state2: state2 {

--- a/tests/subsys/power/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/power/power_states_api/boards/native_posix.overlay
@@ -14,12 +14,14 @@
 		compatible = "zephyr,power-state";
 		power-state-name = "suspend-to-idle";
 		min-residency-us = <10000>;
+		exit-latency-us = <100>;
 	};
 
 	state1: state1 {
 		compatible = "zephyr,power-state";
 		power-state-name = "suspend-to-ram";
 		min-residency-us = <50000>;
+		exit-latency-us = <500>;
 	};
 
 	state2: state2 {

--- a/tests/subsys/power/power_states_api/src/main.c
+++ b/tests/subsys/power/power_states_api/src/main.c
@@ -11,8 +11,8 @@
 /* Last state has not declared a minimum residency, so it should be
  * set the default 0 value
  */
-static struct pm_state_info infos[] = {{PM_STATE_SUSPEND_TO_IDLE, 0, 1},
-		{PM_STATE_SUSPEND_TO_RAM, 0, 5}, {PM_STATE_STANDBY, 0, 0}};
+static struct pm_state_info infos[] = {{PM_STATE_SUSPEND_TO_IDLE, 0, 10000},
+		{PM_STATE_SUSPEND_TO_RAM, 0, 50000}, {PM_STATE_STANDBY, 0, 0}};
 static enum pm_state states[] = {PM_STATE_SUSPEND_TO_IDLE,
 			PM_STATE_SUSPEND_TO_RAM, PM_STATE_STANDBY};
 static enum pm_state wrong_states[] = {PM_STATE_SUSPEND_TO_DISK,

--- a/tests/subsys/power/power_states_api/src/main.c
+++ b/tests/subsys/power/power_states_api/src/main.c
@@ -11,8 +11,8 @@
 /* Last state has not declared a minimum residency, so it should be
  * set the default 0 value
  */
-static struct pm_state_info infos[] = {{PM_STATE_SUSPEND_TO_IDLE, 0, 10000},
-		{PM_STATE_SUSPEND_TO_RAM, 0, 50000}, {PM_STATE_STANDBY, 0, 0}};
+static struct pm_state_info infos[] = {{PM_STATE_SUSPEND_TO_IDLE, 0, 10000, 100},
+	       {PM_STATE_SUSPEND_TO_RAM, 0, 50000, 500}, {PM_STATE_STANDBY, 0, 0}};
 static enum pm_state states[] = {PM_STATE_SUSPEND_TO_IDLE,
 			PM_STATE_SUSPEND_TO_RAM, PM_STATE_STANDBY};
 static enum pm_state wrong_states[] = {PM_STATE_SUSPEND_TO_DISK,


### PR DESCRIPTION
- Add support for exit-latency-us on dts
   - This is the time required the CPU become ACTIVE from a given state
   - Wake up  the system this time earlier to be able to attend the scheduled event
- Remove some unnecessary code in samples 