### PR TITLE
Bluetooth: controller: openisa: Fix missing conditional compile

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -60,10 +60,12 @@ static inline bool isr_rx_scan_check(struct lll_scan *lll, uint8_t irkmatch_ok,
 static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 			       uint8_t devmatch_id, uint8_t irkmatch_ok,
 			       uint8_t irkmatch_id, uint8_t rl_idx, uint8_t rssi_ready);
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx);
 static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 					    struct pdu_adv *pdu, uint8_t rl_idx);
+#endif /* CONFIG_BT_CENTRAL */
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,
 				       bool *dir_report);
@@ -996,6 +998,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 	return 1;
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
 				       struct pdu_adv *pdu, uint8_t rl_idx)
 {
@@ -1025,6 +1028,7 @@ static inline bool isr_scan_init_adva_check(struct lll_scan *lll,
 	return ((lll->adv_addr_type == pdu->tx_addr) &&
 		!memcmp(lll->adv_addr, &pdu->adv_ind.addr[0], BDADDR_SIZE));
 }
+#endif /* CONFIG_BT_CENTRAL */
 
 static inline bool isr_scan_tgta_check(struct lll_scan *lll, bool init,
 				       struct pdu_adv *pdu, uint8_t rl_idx,


### PR DESCRIPTION
Fix missing conditional compile regression introduced by
the commit 34451a997098 ("Bluetooth: controller: Conditional
compile adv addr used by initiator").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>