### PR TITLE
drivers: kscan: ft5336 hogs resources in interrupt mode

### DIFF
--- a/drivers/kscan/Kconfig.ft5336
+++ b/drivers/kscan/Kconfig.ft5336
@@ -14,14 +14,22 @@ if KSCAN_FT5336
 
 config KSCAN_FT5336_PERIOD
 	int "Sample period"
-	depends on !KSCAN_FT5336_INTERRUPT
 	default 10
 	help
-	  Sample period in milliseconds when in polling mode.
+	  Sample period in milliseconds when in polling or
+	  interrupt polling mode.
 
 config KSCAN_FT5336_INTERRUPT
 	bool "Enable interrupt"
 	help
 	  Enable interrupt support (requires GPIO).
+
+config KSCAN_FT5336_INTERRUPT_POLLING_MODE
+	bool "Enable interrupt polling mode"
+	depends on KSCAN_FT5336_INTERRUPT
+	help
+	  After interrupt detects a down event, use timer-based polling
+	  until the up event. If KSCAN_FT5336_PERIOD is zero, detect down
+	  and up events, but do not poll in between.
 
 endif # KSCAN_FT5336


### PR DESCRIPTION
Allow the interrupt line to be used to correctly detect quick
press/release events, while using the timer to sample at a
configurable rate between the press/down and release/up events,
reducing resource use.

Fixes #33994

Signed-off-by: David Hoover <39233766+dhoove@users.noreply.github.com>