### PR TITLE
subsys/fcb: support for partial element CRC calculation

### DIFF
--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -95,11 +95,12 @@ struct fcb {
 	 */
 
 	uint8_t f_version; /**<  Current version number of the data */
-	uint8_t f_sector_cnt; /**< Number of elements in sector array */
 	uint8_t f_scratch_cnt;
 	/**< Number of sectors to keep empty. This can be used if you need
 	 * to have scratch space for garbage collecting when FCB fills up.
 	 */
+	uint16_t f_crc_cnt; /**< Number of first bytes to skip for element data CRC calculation */
+	uint32_t f_sector_cnt; /**< Number of elements in sector array */
 
 	struct flash_sector *f_sectors;
 	/**< Array of sectors, must be contiguous */

--- a/subsys/fs/fcb/fcb_elem_info.c
+++ b/subsys/fs/fcb/fcb_elem_info.c
@@ -44,8 +44,9 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *c8p)
 	crc8 = CRC8_CCITT_INITIAL_VALUE;
 	crc8 = crc8_ccitt(crc8, tmp_str, cnt);
 
-	off = loc->fe_data_off;
-	end = loc->fe_data_off + len;
+	len = len > fcb->f_crc_cnt ? len - fcb->f_crc_cnt : 0;
+	off = loc->fe_data_off + fcb->f_crc_cnt;
+	end = loc->fe_data_off + len + fcb->f_crc_cnt;
 	for (; off < end; off += blk_sz) {
 		blk_sz = end - off;
 		if (blk_sz > sizeof(tmp_str)) {


### PR DESCRIPTION
First 'f_crc_cnt' bytes of FCB element is skipped during element
CRC calculation. Since many serial flash chips support Single Byte
Programming, skipped bytes can later be written without violating
CRC calculation during element reading.
'f_sector_cnt' type changed to uint32_t to support FCBs larger
than 255 sectors.

Signed-off-by: Alexey Kurbanov <alexius.kur@gmail.com>