### PR TITLE
drivers: flash: Fix FlexSPI NOR log module

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -19,7 +19,7 @@
 #define NOR_WRITE_SIZE	1
 #define NOR_ERASE_VALUE	0xff
 
-LOG_MODULE_DECLARE(flash_flexspi, CONFIG_FLASH_LOG_LEVEL);
+LOG_MODULE_REGISTER(flash_flexspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 enum {
 	/* SPI instructions */


### PR DESCRIPTION
Fixes the FlexSPI NOR flash driver to register a new log module rather
than declare membership in the FlexSPI controller module, which was
recently moved from drivers/flash to drivers/memc.

This fixes build errors with the `mimxrt1064_evk board` in:
  - samples/drivers/flash_shell
  - samples/subsys/fs/littlefs

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

CI failures seen in #33991 and in the [daily](https://buildkite.com/zephyr/zephyr-daily/builds/290).

cc: @pdgendt 