### PR TITLE
tests: kernel: key has wrong type in test_prevent_interruption

### DIFF
--- a/tests/kernel/interrupt/src/prevent_irq.c
+++ b/tests/kernel/interrupt/src/prevent_irq.c
@@ -32,7 +32,7 @@ static void timer_handler(struct k_timer *timer)
  */
 void test_prevent_interruption(void)
 {
-	int key;
+	unsigned int key;
 
 	printk("locking interrupts\n");
 	key = irq_lock();


### PR DESCRIPTION
The test_prevent_interruption() uses a key for the irq_lock(),
but the key has incorrect data type. This commit makes the key
unsigned int according to API docs.

Fixes #34023

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>