### PR TITLE
samples/subsys/fs: fat_fs: Limit test execution on boards with shield

### DIFF
--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -14,3 +14,6 @@ tests:
     depends_on: arduino_spi arduino_gpio
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
+    harness: console
+    harness_config:
+        fixture: fixture_shield_adafruit_2_8_tft_touch_v2


### PR DESCRIPTION
Limit adafruit_2_8_tft_touch_v2 sample variant execution to the boards
that have this shield available.

In order to run the test in CI bench, add the following in
twister map.yml file on matching board:
  fixtures:
  - fixture_shield_adafruit_2_8_tft_touch_v2

For instance:
- connected: true
  fixtures:
  - fixture_shield_adafruit_2_8_tft_touch_v2
  id: 0673FF323535474B43171415
  platform: nucleo_f429zi
  product: STM32 STLink
  runner: openocd
  serial: /dev/ttyACM0


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>