### PR TITLE
Toolchain support for bluetooth headers

### DIFF
--- a/include/bluetooth/a2dp-codec.h
+++ b/include/bluetooth/a2dp-codec.h
@@ -57,14 +57,14 @@ extern "C" {
 #define BT_A2DP_SBC_ALLOC_MTHD(preset)   ((preset->config[1]) & 0x03)
 
 /** @brief SBC Codec */
-struct bt_a2dp_codec_sbc_params {
+__packed_struct bt_a2dp_codec_sbc_params {
 	/** First two octets of configuration */
 	uint8_t config[2];
 	/** Minimum Bitpool Value */
 	uint8_t min_bitpool;
 	/** Maximum Bitpool Value */
 	uint8_t max_bitpool;
-} __packed;
+};
 
 #ifdef __cplusplus
 }

--- a/include/bluetooth/avdtp.h
+++ b/include/bluetooth/avdtp.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <bluetooth/l2cap.h>
 
 /** @brief AVDTP SEID Information */
-struct bt_avdtp_seid_info {
+__packed_struct bt_avdtp_seid_info {
 	/** Stream End Point ID */
 	uint8_t id:6;
 	/** End Point usage status */
@@ -30,7 +30,7 @@ struct bt_avdtp_seid_info {
 	uint8_t tsep:1;
 	/** Reserved */
 	uint8_t rfa1:3;
-} __packed;
+};
 
 /** @brief AVDTP Local SEP*/
 struct bt_avdtp_seid_lsep {

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -33,10 +33,10 @@ extern "C" {
 #define BT_ENC_KEY_SIZE_MIN                     0x07
 #define BT_ENC_KEY_SIZE_MAX                     0x10
 
-struct bt_hci_evt_hdr {
+__packed_struct bt_hci_evt_hdr {
 	uint8_t  evt;
 	uint8_t  len;
-} __packed;
+};
 #define BT_HCI_EVT_HDR_SIZE             2
 
 #define BT_ACL_START_NO_FLUSH           0x00
@@ -55,10 +55,10 @@ struct bt_hci_evt_hdr {
 #define bt_acl_flags_bc(f)              ((f) >> 2)
 #define bt_acl_handle_pack(h, f)        ((h) | ((f) << 12))
 
-struct bt_hci_acl_hdr {
+__packed_struct bt_hci_acl_hdr {
 	uint16_t handle;
 	uint16_t len;
-} __packed;
+};
 #define BT_HCI_ACL_HDR_SIZE             4
 
 #define BT_ISO_START                    0x00
@@ -83,28 +83,28 @@ struct bt_hci_acl_hdr {
 #define bt_iso_pkt_flags(h)              ((h) >> 14)
 #define bt_iso_pkt_len_pack(h, f)        ((h) | ((f) << 14))
 
-struct bt_hci_iso_data_hdr {
+__packed_struct bt_hci_iso_data_hdr {
 	uint16_t sn;
 	uint16_t slen;
-} __packed;
+};
 #define BT_HCI_ISO_DATA_HDR_SIZE	4
 
-struct bt_hci_iso_ts_data_hdr {
+__packed_struct bt_hci_iso_ts_data_hdr {
 	uint32_t ts;
 	struct bt_hci_iso_data_hdr data;
-} __packed;
+};
 #define BT_HCI_ISO_TS_DATA_HDR_SIZE     8
 
-struct bt_hci_iso_hdr {
+__packed_struct bt_hci_iso_hdr {
 	uint16_t handle;
 	uint16_t len;
-} __packed;
+};
 #define BT_HCI_ISO_HDR_SIZE             4
 
-struct bt_hci_cmd_hdr {
+__packed_struct bt_hci_cmd_hdr {
 	uint16_t opcode;
 	uint8_t  param_len;
-} __packed;
+};
 #define BT_HCI_CMD_HDR_SIZE             3
 
 /* Supported Commands */
@@ -294,47 +294,47 @@ struct bt_hci_cmd_hdr {
 #define BT_OCF(opcode)                          ((opcode) & BIT_MASK(10))
 
 #define BT_HCI_OP_INQUIRY                       BT_OP(BT_OGF_LINK_CTRL, 0x0001)
-struct bt_hci_op_inquiry {
+__packed_struct bt_hci_op_inquiry {
 	uint8_t lap[3];
 	uint8_t length;
 	uint8_t num_rsp;
-} __packed;
+};
 
 #define BT_HCI_OP_INQUIRY_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0002)
 
 #define BT_HCI_OP_CONNECT                       BT_OP(BT_OGF_LINK_CTRL, 0x0005)
-struct bt_hci_cp_connect {
+__packed_struct bt_hci_cp_connect {
 	bt_addr_t bdaddr;
 	uint16_t  packet_type;
 	uint8_t   pscan_rep_mode;
 	uint8_t   reserved;
 	uint16_t  clock_offset;
 	uint8_t   allow_role_switch;
-} __packed;
+};
 
 #define BT_HCI_OP_DISCONNECT                    BT_OP(BT_OGF_LINK_CTRL, 0x0006)
-struct bt_hci_cp_disconnect {
+__packed_struct bt_hci_cp_disconnect {
 	uint16_t handle;
 	uint8_t  reason;
-} __packed;
+};
 
 #define BT_HCI_OP_CONNECT_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0008)
-struct bt_hci_cp_connect_cancel {
+__packed_struct bt_hci_cp_connect_cancel {
 	bt_addr_t bdaddr;
-} __packed;
-struct bt_hci_rp_connect_cancel {
+};
+__packed_struct bt_hci_rp_connect_cancel {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_ACCEPT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x0009)
-struct bt_hci_cp_accept_conn_req {
+__packed_struct bt_hci_cp_accept_conn_req {
 	bt_addr_t bdaddr;
 	uint8_t   role;
-} __packed;
+};
 
 #define BT_HCI_OP_SETUP_SYNC_CONN               BT_OP(BT_OGF_LINK_CTRL, 0x0028)
-struct bt_hci_cp_setup_sync_conn {
+__packed_struct bt_hci_cp_setup_sync_conn {
 	uint16_t  handle;
 	uint32_t  tx_bandwidth;
 	uint32_t  rx_bandwidth;
@@ -342,10 +342,10 @@ struct bt_hci_cp_setup_sync_conn {
 	uint16_t  content_format;
 	uint8_t   retrans_effort;
 	uint16_t  pkt_type;
-} __packed;
+};
 
 #define BT_HCI_OP_ACCEPT_SYNC_CONN_REQ          BT_OP(BT_OGF_LINK_CTRL, 0x0029)
-struct bt_hci_cp_accept_sync_conn_req {
+__packed_struct bt_hci_cp_accept_sync_conn_req {
 	bt_addr_t bdaddr;
 	uint32_t  tx_bandwidth;
 	uint32_t  rx_bandwidth;
@@ -353,135 +353,135 @@ struct bt_hci_cp_accept_sync_conn_req {
 	uint16_t  content_format;
 	uint8_t   retrans_effort;
 	uint16_t  pkt_type;
-} __packed;
+};
 
 #define BT_HCI_OP_REJECT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x000a)
-struct bt_hci_cp_reject_conn_req {
+__packed_struct bt_hci_cp_reject_conn_req {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
-} __packed;
+};
 
 #define BT_HCI_OP_LINK_KEY_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000b)
-struct bt_hci_cp_link_key_reply {
+__packed_struct bt_hci_cp_link_key_reply {
 	bt_addr_t bdaddr;
 	uint8_t   link_key[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LINK_KEY_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000c)
-struct bt_hci_cp_link_key_neg_reply {
+__packed_struct bt_hci_cp_link_key_neg_reply {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_PIN_CODE_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000d)
-struct bt_hci_cp_pin_code_reply {
+__packed_struct bt_hci_cp_pin_code_reply {
 	bt_addr_t bdaddr;
 	uint8_t   pin_len;
 	uint8_t   pin_code[16];
-} __packed;
-struct bt_hci_rp_pin_code_reply {
+};
+__packed_struct bt_hci_rp_pin_code_reply {
 	uint8_t      status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_PIN_CODE_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000e)
-struct bt_hci_cp_pin_code_neg_reply {
+__packed_struct bt_hci_cp_pin_code_neg_reply {
 	bt_addr_t bdaddr;
-} __packed;
-struct bt_hci_rp_pin_code_neg_reply {
+};
+__packed_struct bt_hci_rp_pin_code_neg_reply {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_AUTH_REQUESTED                BT_OP(BT_OGF_LINK_CTRL, 0x0011)
-struct bt_hci_cp_auth_requested {
+__packed_struct bt_hci_cp_auth_requested {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_SET_CONN_ENCRYPT              BT_OP(BT_OGF_LINK_CTRL, 0x0013)
-struct bt_hci_cp_set_conn_encrypt {
+__packed_struct bt_hci_cp_set_conn_encrypt {
 	uint16_t handle;
 	uint8_t  encrypt;
-} __packed;
+};
 
 #define BT_HCI_OP_REMOTE_NAME_REQUEST           BT_OP(BT_OGF_LINK_CTRL, 0x0019)
-struct bt_hci_cp_remote_name_request {
+__packed_struct bt_hci_cp_remote_name_request {
 	bt_addr_t bdaddr;
 	uint8_t   pscan_rep_mode;
 	uint8_t   reserved;
 	uint16_t  clock_offset;
-} __packed;
+};
 
 #define BT_HCI_OP_REMOTE_NAME_CANCEL            BT_OP(BT_OGF_LINK_CTRL, 0x001a)
-struct bt_hci_cp_remote_name_cancel {
+__packed_struct bt_hci_cp_remote_name_cancel {
 	bt_addr_t bdaddr;
-} __packed;
-struct bt_hci_rp_remote_name_cancel {
+};
+__packed_struct bt_hci_rp_remote_name_cancel {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_REMOTE_FEATURES          BT_OP(BT_OGF_LINK_CTRL, 0x001b)
-struct bt_hci_cp_read_remote_features {
+__packed_struct bt_hci_cp_read_remote_features {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_REMOTE_EXT_FEATURES      BT_OP(BT_OGF_LINK_CTRL, 0x001c)
-struct bt_hci_cp_read_remote_ext_features {
+__packed_struct bt_hci_cp_read_remote_ext_features {
 	uint16_t handle;
 	uint8_t  page;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_REMOTE_VERSION_INFO      BT_OP(BT_OGF_LINK_CTRL, 0x001d)
-struct bt_hci_cp_read_remote_version_info {
+__packed_struct bt_hci_cp_read_remote_version_info {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_IO_CAPABILITY_REPLY           BT_OP(BT_OGF_LINK_CTRL, 0x002b)
-struct bt_hci_cp_io_capability_reply {
+__packed_struct bt_hci_cp_io_capability_reply {
 	bt_addr_t bdaddr;
 	uint8_t   capability;
 	uint8_t   oob_data;
 	uint8_t   authentication;
-} __packed;
+};
 
 #define BT_HCI_OP_USER_CONFIRM_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002c)
 #define BT_HCI_OP_USER_CONFIRM_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002d)
-struct bt_hci_cp_user_confirm_reply {
+__packed_struct bt_hci_cp_user_confirm_reply {
 	bt_addr_t bdaddr;
-} __packed;
-struct bt_hci_rp_user_confirm_reply {
+};
+__packed_struct bt_hci_rp_user_confirm_reply {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_USER_PASSKEY_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002e)
-struct bt_hci_cp_user_passkey_reply {
+__packed_struct bt_hci_cp_user_passkey_reply {
 	bt_addr_t bdaddr;
 	uint32_t  passkey;
-} __packed;
+};
 
 #define BT_HCI_OP_USER_PASSKEY_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002f)
-struct bt_hci_cp_user_passkey_neg_reply {
+__packed_struct bt_hci_cp_user_passkey_neg_reply {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_OP_IO_CAPABILITY_NEG_REPLY       BT_OP(BT_OGF_LINK_CTRL, 0x0034)
-struct bt_hci_cp_io_capability_neg_reply {
+__packed_struct bt_hci_cp_io_capability_neg_reply {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
-} __packed;
+};
 
 #define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001)
-struct bt_hci_cp_set_event_mask {
+__packed_struct bt_hci_cp_set_event_mask {
 	uint8_t  events[8];
-} __packed;
+};
 
 #define BT_HCI_OP_RESET                         BT_OP(BT_OGF_BASEBAND, 0x0003)
 
 #define BT_HCI_OP_WRITE_LOCAL_NAME              BT_OP(BT_OGF_BASEBAND, 0x0013)
-struct bt_hci_write_local_name {
+__packed_struct bt_hci_write_local_name {
 	uint8_t local_name[248];
-} __packed;
+};
 
 #define BT_HCI_OP_WRITE_PAGE_TIMEOUT            BT_OP(BT_OGF_BASEBAND, 0x0018)
 
@@ -491,109 +491,109 @@ struct bt_hci_write_local_name {
 #define BT_BREDR_SCAN_PAGE                      0x02
 
 #define BT_HCI_OP_WRITE_CLASS_OF_DEVICE         BT_OP(BT_OGF_BASEBAND, 0x0024)
-struct bt_hci_cp_write_class_of_device {
+__packed_struct bt_hci_cp_write_class_of_device {
 	uint8_t  class_of_device[3];
-} __packed;
+};
 
 #define BT_TX_POWER_LEVEL_CURRENT               0x00
 #define BT_TX_POWER_LEVEL_MAX                   0x01
 #define BT_HCI_OP_READ_TX_POWER_LEVEL           BT_OP(BT_OGF_BASEBAND, 0x002d)
-struct bt_hci_cp_read_tx_power_level {
+__packed_struct bt_hci_cp_read_tx_power_level {
 	uint16_t handle;
 	uint8_t  type;
-} __packed;
+};
 
-struct bt_hci_rp_read_tx_power_level {
+__packed_struct bt_hci_rp_read_tx_power_level {
 	uint8_t  status;
 	uint16_t handle;
 	int8_t   tx_power_level;
-} __packed;
+};
 
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031)
-struct bt_hci_cp_set_ctl_to_host_flow {
+__packed_struct bt_hci_cp_set_ctl_to_host_flow {
 	uint8_t  flow_enable;
-} __packed;
+};
 
 #define BT_HCI_OP_HOST_BUFFER_SIZE              BT_OP(BT_OGF_BASEBAND, 0x0033)
-struct bt_hci_cp_host_buffer_size {
+__packed_struct bt_hci_cp_host_buffer_size {
 	uint16_t acl_mtu;
 	uint8_t  sco_mtu;
 	uint16_t acl_pkts;
 	uint16_t sco_pkts;
-} __packed;
+};
 
-struct bt_hci_handle_count {
+__packed_struct bt_hci_handle_count {
 	uint16_t handle;
 	uint16_t count;
-} __packed;
+};
 
 #define BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS    BT_OP(BT_OGF_BASEBAND, 0x0035)
-struct bt_hci_cp_host_num_completed_packets {
+__packed_struct bt_hci_cp_host_num_completed_packets {
 	uint8_t  num_handles;
 	struct bt_hci_handle_count h[0];
-} __packed;
+};
 
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045)
-struct bt_hci_cp_write_inquiry_mode {
+__packed_struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;
-} __packed;
+};
 
 #define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056)
-struct bt_hci_cp_write_ssp_mode {
+__packed_struct bt_hci_cp_write_ssp_mode {
 	uint8_t mode;
-} __packed;
+};
 
 #define BT_HCI_OP_SET_EVENT_MASK_PAGE_2         BT_OP(BT_OGF_BASEBAND, 0x0063)
-struct bt_hci_cp_set_event_mask_page_2 {
+__packed_struct bt_hci_cp_set_event_mask_page_2 {
 	uint8_t  events_page_2[8];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_WRITE_LE_HOST_SUPP         BT_OP(BT_OGF_BASEBAND, 0x006d)
-struct bt_hci_cp_write_le_host_supp {
+__packed_struct bt_hci_cp_write_le_host_supp {
 	uint8_t  le;
 	uint8_t  simul;
-} __packed;
+};
 
 #define BT_HCI_OP_WRITE_SC_HOST_SUPP            BT_OP(BT_OGF_BASEBAND, 0x007a)
-struct bt_hci_cp_write_sc_host_supp {
+__packed_struct bt_hci_cp_write_sc_host_supp {
 	uint8_t  sc_support;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_AUTH_PAYLOAD_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x007b)
-struct bt_hci_cp_read_auth_payload_timeout {
+__packed_struct bt_hci_cp_read_auth_payload_timeout {
 	uint16_t handle;
-} __packed;
+};
 
-struct bt_hci_rp_read_auth_payload_timeout {
+__packed_struct bt_hci_rp_read_auth_payload_timeout {
 	uint8_t  status;
 	uint16_t handle;
 	uint16_t auth_payload_timeout;
-} __packed;
+};
 
 #define BT_HCI_OP_WRITE_AUTH_PAYLOAD_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x007c)
-struct bt_hci_cp_write_auth_payload_timeout {
+__packed_struct bt_hci_cp_write_auth_payload_timeout {
 	uint16_t handle;
 	uint16_t auth_payload_timeout;
-} __packed;
+};
 
-struct bt_hci_rp_write_auth_payload_timeout {
+__packed_struct bt_hci_rp_write_auth_payload_timeout {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_CONFIGURE_DATA_PATH           BT_OP(BT_OGF_BASEBAND, 0x0083)
-struct bt_hci_cp_configure_data_path {
+__packed_struct bt_hci_cp_configure_data_path {
 	uint8_t  data_path_dir;
 	uint8_t  data_path_id;
 	uint8_t  vs_config_len;
 	uint8_t  vs_config[0];
-} __packed;
+};
 
-struct bt_hci_rp_configure_data_path {
+__packed_struct bt_hci_rp_configure_data_path {
 	uint8_t  status;
-} __packed;
+};
 
 /* HCI version from Assigned Numbers */
 #define BT_HCI_VERSION_1_0B                     0
@@ -610,23 +610,23 @@ struct bt_hci_rp_configure_data_path {
 #define BT_HCI_VERSION_5_2                      11
 
 #define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001)
-struct bt_hci_rp_read_local_version_info {
+__packed_struct bt_hci_rp_read_local_version_info {
 	uint8_t  status;
 	uint8_t  hci_version;
 	uint16_t hci_revision;
 	uint8_t  lmp_version;
 	uint16_t manufacturer;
 	uint16_t lmp_subversion;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_SUPPORTED_COMMANDS       BT_OP(BT_OGF_INFO, 0x0002)
-struct bt_hci_rp_read_supported_commands {
+__packed_struct bt_hci_rp_read_supported_commands {
 	uint8_t  status;
 	uint8_t  commands[64];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_LOCAL_EXT_FEATURES       BT_OP(BT_OGF_INFO, 0x0004)
-struct bt_hci_cp_read_local_ext_features {
+__packed_struct bt_hci_cp_read_local_ext_features {
 	uint8_t page;
 };
 struct bt_hci_rp_read_local_ext_features {
@@ -634,28 +634,28 @@ struct bt_hci_rp_read_local_ext_features {
 	uint8_t  page;
 	uint8_t  max_page;
 	uint8_t  ext_features[8];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_LOCAL_FEATURES           BT_OP(BT_OGF_INFO, 0x0003)
-struct bt_hci_rp_read_local_features {
+__packed_struct bt_hci_rp_read_local_features {
 	uint8_t  status;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_BUFFER_SIZE              BT_OP(BT_OGF_INFO, 0x0005)
-struct bt_hci_rp_read_buffer_size {
+__packed_struct bt_hci_rp_read_buffer_size {
 	uint8_t  status;
 	uint16_t acl_max_len;
 	uint8_t  sco_max_len;
 	uint16_t acl_max_num;
 	uint16_t sco_max_num;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_BD_ADDR                  BT_OP(BT_OGF_INFO, 0x0009)
-struct bt_hci_rp_read_bd_addr {
+__packed_struct bt_hci_rp_read_bd_addr {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 /* logic transport type bits as returned when reading supported codecs */
 #define BT_HCI_CODEC_TRANSPORT_MASK_BREDR_ACL BIT(0)
@@ -690,135 +690,135 @@ struct bt_hci_rp_read_bd_addr {
 
 
 #define BT_HCI_OP_READ_CODECS                   BT_OP(BT_OGF_INFO, 0x000b)
-struct bt_hci_std_codec_info {
+__packed_struct bt_hci_std_codec_info {
 	uint8_t codec_id;
-} __packed;
-struct bt_hci_std_codecs {
+};
+__packed_struct bt_hci_std_codecs {
 	uint8_t num_codecs;
 	struct bt_hci_std_codec_info codec_info[0];
-} __packed;
-struct bt_hci_vs_codec_info {
+};
+__packed_struct bt_hci_vs_codec_info {
 	uint16_t company_id;
 	uint16_t codec_id;
-} __packed;
-struct bt_hci_vs_codecs {
+};
+__packed_struct bt_hci_vs_codecs {
 	uint8_t num_codecs;
 	struct bt_hci_vs_codec_info codec_info[0];
-} __packed;
-struct bt_hci_rp_read_codecs {
+};
+__packed_struct bt_hci_rp_read_codecs {
 	uint8_t status;
 	/* other fields filled in dynamically */
 	uint8_t codecs[0];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_CODECS_V2                BT_OP(BT_OGF_INFO, 0x000d)
-struct bt_hci_std_codec_info_v2 {
+__packed_struct bt_hci_std_codec_info_v2 {
 	uint8_t codec_id;
 	uint8_t transports; /* bitmap */
-} __packed;
-struct bt_hci_std_codecs_v2 {
+};
+__packed_struct bt_hci_std_codecs_v2 {
 	uint8_t num_codecs;
 	struct bt_hci_std_codec_info_v2 codec_info[0];
-} __packed;
-struct bt_hci_vs_codec_info_v2 {
+};
+__packed_struct bt_hci_vs_codec_info_v2 {
 	uint16_t company_id;
 	uint16_t codec_id;
 	uint8_t transports; /* bitmap */
-} __packed;
-struct bt_hci_vs_codecs_v2 {
+};
+__packed_struct bt_hci_vs_codecs_v2 {
 	uint8_t num_codecs;
 	struct bt_hci_vs_codec_info_v2 codec_info[0];
-} __packed;
-struct bt_hci_rp_read_codecs_v2 {
+};
+__packed_struct bt_hci_rp_read_codecs_v2 {
 	uint8_t status;
 	/* other fields filled in dynamically */
 	uint8_t codecs[0];
-} __packed;
+};
 
-struct bt_hci_cp_codec_id {
+__packed_struct bt_hci_cp_codec_id {
 	uint8_t coding_format;
 	uint16_t company_id;
 	uint16_t vs_codec_id;
-} __packed;
+};
 
 #define BT_HCI_OP_READ_CODEC_CAPABILITIES       BT_OP(BT_OGF_INFO, 0x000e)
-struct bt_hci_cp_read_codec_capabilities {
+__packed_struct bt_hci_cp_read_codec_capabilities {
 	struct bt_hci_cp_codec_id codec_id;
 	uint8_t transport;
 	uint8_t direction;
-} __packed;
-struct bt_hci_codec_capability_info {
+};
+__packed_struct bt_hci_codec_capability_info {
 	uint8_t length;
 	uint8_t data[0];
-} __packed;
-struct bt_hci_rp_read_codec_capabilities {
+};
+__packed_struct bt_hci_rp_read_codec_capabilities {
 	uint8_t status;
 	uint8_t num_capabilities;
 	/* other fields filled in dynamically */
 	uint8_t capabilities[0];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_CTLR_DELAY               BT_OP(BT_OGF_INFO, 0x000f)
-struct bt_hci_cp_read_ctlr_delay {
+__packed_struct bt_hci_cp_read_ctlr_delay {
 	struct bt_hci_cp_codec_id codec_id;
 	uint8_t transport;
 	uint8_t direction;
 	uint8_t codec_config_len;
 	uint8_t codec_config[0];
-} __packed;
-struct bt_hci_rp_read_ctlr_delay {
+};
+__packed_struct bt_hci_rp_read_ctlr_delay {
 	uint8_t status;
 	uint8_t min_ctlr_delay[3];
 	uint8_t max_ctlr_delay[3];
-} __packed;
+};
 
 #define BT_HCI_OP_READ_RSSI                     BT_OP(BT_OGF_STATUS, 0x0005)
-struct bt_hci_cp_read_rssi {
+__packed_struct bt_hci_cp_read_rssi {
 	uint16_t handle;
-} __packed;
-struct bt_hci_rp_read_rssi {
+};
+__packed_struct bt_hci_rp_read_rssi {
 	uint8_t  status;
 	uint16_t handle;
 	int8_t   rssi;
-} __packed;
+};
 
 #define BT_HCI_ENCRYPTION_KEY_SIZE_MIN          7
 #define BT_HCI_ENCRYPTION_KEY_SIZE_MAX          16
 
 #define BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE      BT_OP(BT_OGF_STATUS, 0x0008)
-struct bt_hci_cp_read_encryption_key_size {
+__packed_struct bt_hci_cp_read_encryption_key_size {
 	uint16_t handle;
-} __packed;
-struct bt_hci_rp_read_encryption_key_size {
+};
+__packed_struct bt_hci_rp_read_encryption_key_size {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  key_size;
-} __packed;
+};
 
 /* BLE */
 
 #define BT_HCI_OP_LE_SET_EVENT_MASK             BT_OP(BT_OGF_LE, 0x0001)
-struct bt_hci_cp_le_set_event_mask {
+__packed_struct bt_hci_cp_le_set_event_mask {
 	uint8_t events[8];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_BUFFER_SIZE           BT_OP(BT_OGF_LE, 0x0002)
-struct bt_hci_rp_le_read_buffer_size {
+__packed_struct bt_hci_rp_le_read_buffer_size {
 	uint8_t  status;
 	uint16_t le_max_len;
 	uint8_t  le_max_num;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_LOCAL_FEATURES        BT_OP(BT_OGF_LE, 0x0003)
-struct bt_hci_rp_le_read_local_features {
+__packed_struct bt_hci_rp_le_read_local_features {
 	uint8_t  status;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_RANDOM_ADDRESS         BT_OP(BT_OGF_LE, 0x0005)
-struct bt_hci_cp_le_set_random_address {
+__packed_struct bt_hci_cp_le_set_random_address {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_ADV_IND                          0x00
 #define BT_HCI_ADV_DIRECT_IND                   0x01
@@ -842,7 +842,7 @@ struct bt_hci_cp_le_set_random_address {
 #define BT_LE_ADV_FP_WHITELIST_BOTH             0x03
 
 #define BT_HCI_OP_LE_SET_ADV_PARAM              BT_OP(BT_OGF_LE, 0x0006)
-struct bt_hci_cp_le_set_adv_param {
+__packed_struct bt_hci_cp_le_set_adv_param {
 	uint16_t     min_interval;
 	uint16_t     max_interval;
 	uint8_t      type;
@@ -850,33 +850,33 @@ struct bt_hci_cp_le_set_adv_param {
 	bt_addr_le_t direct_addr;
 	uint8_t      channel_map;
 	uint8_t      filter_policy;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_ADV_CHAN_TX_POWER     BT_OP(BT_OGF_LE, 0x0007)
-struct bt_hci_rp_le_read_chan_tx_power {
+__packed_struct bt_hci_rp_le_read_chan_tx_power {
 	uint8_t status;
 	int8_t  tx_power_level;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_ADV_DATA               BT_OP(BT_OGF_LE, 0x0008)
-struct bt_hci_cp_le_set_adv_data {
+__packed_struct bt_hci_cp_le_set_adv_data {
 	uint8_t  len;
 	uint8_t  data[31];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_SCAN_RSP_DATA          BT_OP(BT_OGF_LE, 0x0009)
-struct bt_hci_cp_le_set_scan_rsp_data {
+__packed_struct bt_hci_cp_le_set_scan_rsp_data {
 	uint8_t  len;
 	uint8_t  data[31];
-} __packed;
+};
 
 #define BT_HCI_LE_ADV_DISABLE                   0x00
 #define BT_HCI_LE_ADV_ENABLE                    0x01
 
 #define BT_HCI_OP_LE_SET_ADV_ENABLE             BT_OP(BT_OGF_LE, 0x000a)
-struct bt_hci_cp_le_set_adv_enable {
+__packed_struct bt_hci_cp_le_set_adv_enable {
 	uint8_t  enable;
-} __packed;
+};
 
 /* Scan types */
 #define BT_HCI_OP_LE_SET_SCAN_PARAM             BT_OP(BT_OGF_LE, 0x000b)
@@ -886,13 +886,13 @@ struct bt_hci_cp_le_set_adv_enable {
 #define BT_HCI_LE_SCAN_FP_NO_WHITELIST          0x00
 #define BT_HCI_LE_SCAN_FP_USE_WHITELIST         0x01
 
-struct bt_hci_cp_le_set_scan_param {
+__packed_struct bt_hci_cp_le_set_scan_param {
 	uint8_t  scan_type;
 	uint16_t interval;
 	uint16_t window;
 	uint8_t  addr_type;
 	uint8_t  filter_policy;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_SCAN_ENABLE            BT_OP(BT_OGF_LE, 0x000c)
 
@@ -902,17 +902,17 @@ struct bt_hci_cp_le_set_scan_param {
 #define BT_HCI_LE_SCAN_FILTER_DUP_DISABLE       0x00
 #define BT_HCI_LE_SCAN_FILTER_DUP_ENABLE        0x01
 
-struct bt_hci_cp_le_set_scan_enable {
+__packed_struct bt_hci_cp_le_set_scan_enable {
 	uint8_t  enable;
 	uint8_t  filter_dup;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CREATE_CONN                BT_OP(BT_OGF_LE, 0x000d)
 
 #define BT_HCI_LE_CREATE_CONN_FP_DIRECT         0x00
 #define BT_HCI_LE_CREATE_CONN_FP_WHITELIST      0x01
 
-struct bt_hci_cp_le_create_conn {
+__packed_struct bt_hci_cp_le_create_conn {
 	uint16_t     scan_interval;
 	uint16_t     scan_window;
 	uint8_t      filter_policy;
@@ -924,30 +924,30 @@ struct bt_hci_cp_le_create_conn {
 	uint16_t     supervision_timeout;
 	uint16_t     min_ce_len;
 	uint16_t     max_ce_len;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CREATE_CONN_CANCEL         BT_OP(BT_OGF_LE, 0x000e)
 
 #define BT_HCI_OP_LE_READ_WL_SIZE               BT_OP(BT_OGF_LE, 0x000f)
-struct bt_hci_rp_le_read_wl_size {
+__packed_struct bt_hci_rp_le_read_wl_size {
 	uint8_t  status;
 	uint8_t  wl_size;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CLEAR_WL                   BT_OP(BT_OGF_LE, 0x0010)
 
 #define BT_HCI_OP_LE_ADD_DEV_TO_WL              BT_OP(BT_OGF_LE, 0x0011)
-struct bt_hci_cp_le_add_dev_to_wl {
+__packed_struct bt_hci_cp_le_add_dev_to_wl {
 	bt_addr_le_t  addr;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REM_DEV_FROM_WL            BT_OP(BT_OGF_LE, 0x0012)
-struct bt_hci_cp_le_rem_dev_from_wl {
+__packed_struct bt_hci_cp_le_rem_dev_from_wl {
 	bt_addr_le_t  addr;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CONN_UPDATE                BT_OP(BT_OGF_LE, 0x0013)
-struct hci_cp_le_conn_update {
+__packed_struct hci_cp_le_conn_update {
 	uint16_t handle;
 	uint16_t conn_interval_min;
 	uint16_t conn_interval_max;
@@ -955,97 +955,97 @@ struct hci_cp_le_conn_update {
 	uint16_t supervision_timeout;
 	uint16_t min_ce_len;
 	uint16_t max_ce_len;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF      BT_OP(BT_OGF_LE, 0x0014)
-struct bt_hci_cp_le_set_host_chan_classif {
+__packed_struct bt_hci_cp_le_set_host_chan_classif {
 	uint8_t  ch_map[5];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_CHAN_MAP              BT_OP(BT_OGF_LE, 0x0015)
-struct bt_hci_cp_le_read_chan_map {
+__packed_struct bt_hci_cp_le_read_chan_map {
 	uint16_t handle;
-} __packed;
-struct bt_hci_rp_le_read_chan_map {
+};
+__packed_struct bt_hci_rp_le_read_chan_map {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  ch_map[5];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_REMOTE_FEATURES       BT_OP(BT_OGF_LE, 0x0016)
-struct bt_hci_cp_le_read_remote_features {
+__packed_struct bt_hci_cp_le_read_remote_features {
 	uint16_t  handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ENCRYPT                    BT_OP(BT_OGF_LE, 0x0017)
-struct bt_hci_cp_le_encrypt {
+__packed_struct bt_hci_cp_le_encrypt {
 	uint8_t  key[16];
 	uint8_t  plaintext[16];
-} __packed;
-struct bt_hci_rp_le_encrypt {
+};
+__packed_struct bt_hci_rp_le_encrypt {
 	uint8_t  status;
 	uint8_t  enc_data[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_RAND                       BT_OP(BT_OGF_LE, 0x0018)
-struct bt_hci_rp_le_rand {
+__packed_struct bt_hci_rp_le_rand {
 	uint8_t  status;
 	uint8_t  rand[8];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_START_ENCRYPTION           BT_OP(BT_OGF_LE, 0x0019)
-struct bt_hci_cp_le_start_encryption {
+__packed_struct bt_hci_cp_le_start_encryption {
 	uint16_t handle;
 	uint64_t rand;
 	uint16_t ediv;
 	uint8_t  ltk[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_LTK_REQ_REPLY              BT_OP(BT_OGF_LE, 0x001a)
-struct bt_hci_cp_le_ltk_req_reply {
+__packed_struct bt_hci_cp_le_ltk_req_reply {
 	uint16_t handle;
 	uint8_t  ltk[16];
-} __packed;
-struct bt_hci_rp_le_ltk_req_reply {
+};
+__packed_struct bt_hci_rp_le_ltk_req_reply {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_LTK_REQ_NEG_REPLY          BT_OP(BT_OGF_LE, 0x001b)
-struct bt_hci_cp_le_ltk_req_neg_reply {
+__packed_struct bt_hci_cp_le_ltk_req_neg_reply {
 	uint16_t handle;
-} __packed;
-struct bt_hci_rp_le_ltk_req_neg_reply {
+};
+__packed_struct bt_hci_rp_le_ltk_req_neg_reply {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_SUPP_STATES           BT_OP(BT_OGF_LE, 0x001c)
-struct bt_hci_rp_le_read_supp_states {
+__packed_struct bt_hci_rp_le_read_supp_states {
 	uint8_t  status;
 	uint8_t  le_states[8];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_RX_TEST                    BT_OP(BT_OGF_LE, 0x001d)
-struct bt_hci_cp_le_rx_test {
+__packed_struct bt_hci_cp_le_rx_test {
 	uint8_t  rx_ch;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_TX_TEST                    BT_OP(BT_OGF_LE, 0x001e)
-struct bt_hci_cp_le_tx_test {
+__packed_struct bt_hci_cp_le_tx_test {
 	uint8_t  tx_ch;
 	uint8_t  test_data_len;
 	uint8_t  pkt_payload;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_TEST_END                   BT_OP(BT_OGF_LE, 0x001f)
-struct bt_hci_rp_le_test_end {
+__packed_struct bt_hci_rp_le_test_end {
 	uint8_t  status;
 	uint16_t rx_pkt_count;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CONN_PARAM_REQ_REPLY       BT_OP(BT_OGF_LE, 0x0020)
-struct bt_hci_cp_le_conn_param_req_reply {
+__packed_struct bt_hci_cp_le_conn_param_req_reply {
 	uint16_t handle;
 	uint16_t interval_min;
 	uint16_t interval_max;
@@ -1053,52 +1053,52 @@ struct bt_hci_cp_le_conn_param_req_reply {
 	uint16_t timeout;
 	uint16_t min_ce_len;
 	uint16_t max_ce_len;
-} __packed;
-struct bt_hci_rp_le_conn_param_req_reply {
+};
+__packed_struct bt_hci_rp_le_conn_param_req_reply {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CONN_PARAM_REQ_NEG_REPLY   BT_OP(BT_OGF_LE, 0x0021)
-struct bt_hci_cp_le_conn_param_req_neg_reply {
+__packed_struct bt_hci_cp_le_conn_param_req_neg_reply {
 	uint16_t handle;
 	uint8_t  reason;
-} __packed;
-struct bt_hci_rp_le_conn_param_req_neg_reply {
+};
+__packed_struct bt_hci_rp_le_conn_param_req_neg_reply {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_DATA_LEN               BT_OP(BT_OGF_LE, 0x0022)
-struct bt_hci_cp_le_set_data_len {
+__packed_struct bt_hci_cp_le_set_data_len {
 	uint16_t handle;
 	uint16_t tx_octets;
 	uint16_t tx_time;
-} __packed;
-struct bt_hci_rp_le_set_data_len {
+};
+__packed_struct bt_hci_rp_le_set_data_len {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_DEFAULT_DATA_LEN      BT_OP(BT_OGF_LE, 0x0023)
-struct bt_hci_rp_le_read_default_data_len {
+__packed_struct bt_hci_rp_le_read_default_data_len {
 	uint8_t  status;
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN     BT_OP(BT_OGF_LE, 0x0024)
-struct bt_hci_cp_le_write_default_data_len {
+__packed_struct bt_hci_cp_le_write_default_data_len {
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_P256_PUBLIC_KEY            BT_OP(BT_OGF_LE, 0x0025)
 
 #define BT_HCI_OP_LE_GENERATE_DHKEY             BT_OP(BT_OGF_LE, 0x0026)
-struct bt_hci_cp_le_generate_dhkey {
+__packed_struct bt_hci_cp_le_generate_dhkey {
 	uint8_t key[64];
-} __packed;
+};
 
 
 #define BT_HCI_OP_LE_GENERATE_DHKEY_V2          BT_OP(BT_OGF_LE, 0x005e)
@@ -1106,86 +1106,86 @@ struct bt_hci_cp_le_generate_dhkey {
 #define BT_HCI_LE_KEY_TYPE_GENERATED            0x00
 #define BT_HCI_LE_KEY_TYPE_DEBUG                0x01
 
-struct bt_hci_cp_le_generate_dhkey_v2 {
+__packed_struct bt_hci_cp_le_generate_dhkey_v2 {
 	uint8_t key[64];
 	uint8_t key_type;
-} __packed;
+};
 
 
 #define BT_HCI_OP_LE_ADD_DEV_TO_RL              BT_OP(BT_OGF_LE, 0x0027)
-struct bt_hci_cp_le_add_dev_to_rl {
+__packed_struct bt_hci_cp_le_add_dev_to_rl {
 	bt_addr_le_t  peer_id_addr;
 	uint8_t       peer_irk[16];
 	uint8_t       local_irk[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REM_DEV_FROM_RL            BT_OP(BT_OGF_LE, 0x0028)
-struct bt_hci_cp_le_rem_dev_from_rl {
+__packed_struct bt_hci_cp_le_rem_dev_from_rl {
 	bt_addr_le_t  peer_id_addr;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CLEAR_RL                   BT_OP(BT_OGF_LE, 0x0029)
 
 #define BT_HCI_OP_LE_READ_RL_SIZE               BT_OP(BT_OGF_LE, 0x002a)
-struct bt_hci_rp_le_read_rl_size {
+__packed_struct bt_hci_rp_le_read_rl_size {
 	uint8_t  status;
 	uint8_t  rl_size;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_PEER_RPA              BT_OP(BT_OGF_LE, 0x002b)
-struct bt_hci_cp_le_read_peer_rpa {
+__packed_struct bt_hci_cp_le_read_peer_rpa {
 	bt_addr_le_t  peer_id_addr;
-} __packed;
-struct bt_hci_rp_le_read_peer_rpa {
+};
+__packed_struct bt_hci_rp_le_read_peer_rpa {
 	uint8_t    status;
 	bt_addr_t  peer_rpa;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_LOCAL_RPA             BT_OP(BT_OGF_LE, 0x002c)
-struct bt_hci_cp_le_read_local_rpa {
+__packed_struct bt_hci_cp_le_read_local_rpa {
 	bt_addr_le_t  peer_id_addr;
-} __packed;
-struct bt_hci_rp_le_read_local_rpa {
+};
+__packed_struct bt_hci_rp_le_read_local_rpa {
 	uint8_t    status;
 	bt_addr_t  local_rpa;
-} __packed;
+};
 
 #define BT_HCI_ADDR_RES_DISABLE                 0x00
 #define BT_HCI_ADDR_RES_ENABLE                  0x01
 
 #define BT_HCI_OP_LE_SET_ADDR_RES_ENABLE        BT_OP(BT_OGF_LE, 0x002d)
-struct bt_hci_cp_le_set_addr_res_enable {
+__packed_struct bt_hci_cp_le_set_addr_res_enable {
 	uint8_t  enable;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_RPA_TIMEOUT            BT_OP(BT_OGF_LE, 0x002e)
-struct bt_hci_cp_le_set_rpa_timeout {
+__packed_struct bt_hci_cp_le_set_rpa_timeout {
 	uint16_t rpa_timeout;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_MAX_DATA_LEN          BT_OP(BT_OGF_LE, 0x002f)
-struct bt_hci_rp_le_read_max_data_len {
+__packed_struct bt_hci_rp_le_read_max_data_len {
 	uint8_t  status;
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
 	uint16_t max_rx_octets;
 	uint16_t max_rx_time;
-} __packed;
+};
 
 #define BT_HCI_LE_PHY_1M                        0x01
 #define BT_HCI_LE_PHY_2M                        0x02
 #define BT_HCI_LE_PHY_CODED                     0x03
 
 #define BT_HCI_OP_LE_READ_PHY                   BT_OP(BT_OGF_LE, 0x0030)
-struct bt_hci_cp_le_read_phy {
+__packed_struct bt_hci_cp_le_read_phy {
 	uint16_t handle;
-} __packed;
-struct bt_hci_rp_le_read_phy {
+};
+__packed_struct bt_hci_rp_le_read_phy {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  tx_phy;
 	uint8_t  rx_phy;
-} __packed;
+};
 
 #define BT_HCI_LE_PHY_TX_ANY                    BIT(0)
 #define BT_HCI_LE_PHY_RX_ANY                    BIT(1)
@@ -1195,52 +1195,52 @@ struct bt_hci_rp_le_read_phy {
 #define BT_HCI_LE_PHY_PREFER_CODED              BIT(2)
 
 #define BT_HCI_OP_LE_SET_DEFAULT_PHY            BT_OP(BT_OGF_LE, 0x0031)
-struct bt_hci_cp_le_set_default_phy {
+__packed_struct bt_hci_cp_le_set_default_phy {
 	uint8_t all_phys;
 	uint8_t tx_phys;
 	uint8_t rx_phys;
-} __packed;
+};
 
 #define BT_HCI_LE_PHY_CODED_ANY                 0x00
 #define BT_HCI_LE_PHY_CODED_S2                  0x01
 #define BT_HCI_LE_PHY_CODED_S8                  0x02
 
 #define BT_HCI_OP_LE_SET_PHY                    BT_OP(BT_OGF_LE, 0x0032)
-struct bt_hci_cp_le_set_phy {
+__packed_struct bt_hci_cp_le_set_phy {
 	uint16_t  handle;
 	uint8_t   all_phys;
 	uint8_t   tx_phys;
 	uint8_t   rx_phys;
 	uint16_t  phy_opts;
-} __packed;
+};
 
 #define BT_HCI_LE_MOD_INDEX_STANDARD            0x00
 #define BT_HCI_LE_MOD_INDEX_STABLE              0x01
 
 #define BT_HCI_OP_LE_ENH_RX_TEST                BT_OP(BT_OGF_LE, 0x0033)
-struct bt_hci_cp_le_enh_rx_test {
+__packed_struct bt_hci_cp_le_enh_rx_test {
 	uint8_t  rx_ch;
 	uint8_t  phy;
 	uint8_t  mod_index;
-} __packed;
+};
 
 /* Extends BT_HCI_LE_PHY */
 #define BT_HCI_LE_TX_PHY_CODED_S8               0x03
 #define BT_HCI_LE_TX_PHY_CODED_S2               0x04
 
 #define BT_HCI_OP_LE_ENH_TX_TEST                BT_OP(BT_OGF_LE, 0x0034)
-struct bt_hci_cp_le_enh_tx_test {
+__packed_struct bt_hci_cp_le_enh_tx_test {
 	uint8_t  tx_ch;
 	uint8_t  test_data_len;
 	uint8_t  pkt_payload;
 	uint8_t  phy;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR    BT_OP(BT_OGF_LE, 0x0035)
-struct bt_hci_cp_le_set_adv_set_random_addr {
+__packed_struct bt_hci_cp_le_set_adv_set_random_addr {
 	uint8_t   handle;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_LE_ADV_PROP_CONN                 BIT(0)
 #define BT_HCI_LE_ADV_PROP_SCAN                 BIT(1)
@@ -1258,7 +1258,7 @@ struct bt_hci_cp_le_set_adv_set_random_addr {
 #define BT_HCI_LE_ADV_HANDLE_MAX       0xEF
 
 #define BT_HCI_OP_LE_SET_EXT_ADV_PARAM          BT_OP(BT_OGF_LE, 0x0036)
-struct bt_hci_cp_le_set_ext_adv_param {
+__packed_struct bt_hci_cp_le_set_ext_adv_param {
 	uint8_t      handle;
 	uint16_t     props;
 	uint8_t      prim_min_interval[3];
@@ -1273,11 +1273,11 @@ struct bt_hci_cp_le_set_ext_adv_param {
 	uint8_t      sec_adv_phy;
 	uint8_t      sid;
 	uint8_t      scan_req_notify_enable;
-} __packed;
-struct bt_hci_rp_le_set_ext_adv_param {
+};
+__packed_struct bt_hci_rp_le_set_ext_adv_param {
 	uint8_t status;
 	int8_t  tx_power;
-} __packed;
+};
 
 #define BT_HCI_LE_EXT_ADV_OP_INTERM_FRAG        0x00
 #define BT_HCI_LE_EXT_ADV_OP_FIRST_FRAG         0x01
@@ -1291,62 +1291,62 @@ struct bt_hci_rp_le_set_ext_adv_param {
 #define BT_HCI_LE_EXT_ADV_FRAG_MAX_LEN          251
 
 #define BT_HCI_OP_LE_SET_EXT_ADV_DATA           BT_OP(BT_OGF_LE, 0x0037)
-struct bt_hci_cp_le_set_ext_adv_data {
+__packed_struct bt_hci_cp_le_set_ext_adv_data {
 	uint8_t  handle;
 	uint8_t  op;
 	uint8_t  frag_pref;
 	uint8_t  len;
 	uint8_t  data[251];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_EXT_SCAN_RSP_DATA      BT_OP(BT_OGF_LE, 0x0038)
-struct bt_hci_cp_le_set_ext_scan_rsp_data {
+__packed_struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	uint8_t  handle;
 	uint8_t  op;
 	uint8_t  frag_pref;
 	uint8_t  len;
 	uint8_t  data[251];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039)
-struct bt_hci_ext_adv_set {
+__packed_struct bt_hci_ext_adv_set {
 	uint8_t  handle;
 	uint16_t duration;
 	uint8_t  max_ext_adv_evts;
-} __packed;
+};
 
-struct bt_hci_cp_le_set_ext_adv_enable {
+__packed_struct bt_hci_cp_le_set_ext_adv_enable {
 	uint8_t  enable;
 	uint8_t  set_num;
 	struct bt_hci_ext_adv_set s[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN      BT_OP(BT_OGF_LE, 0x003a)
-struct bt_hci_rp_le_read_max_adv_data_len {
+__packed_struct bt_hci_rp_le_read_max_adv_data_len {
 	uint8_t  status;
 	uint16_t max_adv_data_len;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_NUM_ADV_SETS          BT_OP(BT_OGF_LE, 0x003b)
-struct bt_hci_rp_le_read_num_adv_sets {
+__packed_struct bt_hci_rp_le_read_num_adv_sets {
 	uint8_t  status;
 	uint8_t  num_sets;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REMOVE_ADV_SET             BT_OP(BT_OGF_LE, 0x003c)
-struct bt_hci_cp_le_remove_adv_set {
+__packed_struct bt_hci_cp_le_remove_adv_set {
 	uint8_t  handle;
-} __packed;
+};
 
 #define BT_HCI_OP_CLEAR_ADV_SETS                BT_OP(BT_OGF_LE, 0x003d)
 
 #define BT_HCI_OP_LE_SET_PER_ADV_PARAM          BT_OP(BT_OGF_LE, 0x003e)
-struct bt_hci_cp_le_set_per_adv_param {
+__packed_struct bt_hci_cp_le_set_per_adv_param {
 	uint8_t  handle;
 	uint16_t min_interval;
 	uint16_t max_interval;
 	uint16_t props;
-} __packed;
+};
 
 #define BT_HCI_LE_PER_ADV_OP_INTERM_FRAG        0x00
 #define BT_HCI_LE_PER_ADV_OP_FIRST_FRAG         0x01
@@ -1356,50 +1356,50 @@ struct bt_hci_cp_le_set_per_adv_param {
 #define BT_HCI_LE_PER_ADV_FRAG_MAX_LEN          252
 
 #define BT_HCI_OP_LE_SET_PER_ADV_DATA           BT_OP(BT_OGF_LE, 0x003f)
-struct bt_hci_cp_le_set_per_adv_data {
+__packed_struct bt_hci_cp_le_set_per_adv_data {
 	uint8_t  handle;
 	uint8_t  op;
 	uint8_t  len;
 	uint8_t  data[251];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_PER_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0040)
-struct bt_hci_cp_le_set_per_adv_enable {
+__packed_struct bt_hci_cp_le_set_per_adv_enable {
 	uint8_t  enable;
 	uint8_t  handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_EXT_SCAN_PARAM         BT_OP(BT_OGF_LE, 0x0041)
-struct bt_hci_ext_scan_phy {
+__packed_struct bt_hci_ext_scan_phy {
 	uint8_t  type;
 	uint16_t interval;
 	uint16_t window;
-} __packed;
+};
 
 #define BT_HCI_LE_EXT_SCAN_PHY_1M               BIT(0)
 #define BT_HCI_LE_EXT_SCAN_PHY_2M               BIT(1)
 #define BT_HCI_LE_EXT_SCAN_PHY_CODED            BIT(2)
 
-struct bt_hci_cp_le_set_ext_scan_param {
+__packed_struct bt_hci_cp_le_set_ext_scan_param {
 	uint8_t  own_addr_type;
 	uint8_t  filter_policy;
 	uint8_t  phys;
 	struct bt_hci_ext_scan_phy p[0];
-} __packed;
+};
 
 /* Extends BT_HCI_LE_SCAN_FILTER_DUP */
 #define BT_HCI_LE_EXT_SCAN_FILTER_DUP_ENABLE_RESET  0x02
 
 #define BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE        BT_OP(BT_OGF_LE, 0x0042)
-struct bt_hci_cp_le_set_ext_scan_enable {
+__packed_struct bt_hci_cp_le_set_ext_scan_enable {
 	uint8_t  enable;
 	uint8_t  filter_dup;
 	uint16_t duration;
 	uint16_t period;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_EXT_CREATE_CONN            BT_OP(BT_OGF_LE, 0x0043)
-struct bt_hci_ext_conn_phy {
+__packed_struct bt_hci_ext_conn_phy {
 	uint16_t scan_interval;
 	uint16_t scan_window;
 	uint16_t conn_interval_min;
@@ -1408,15 +1408,15 @@ struct bt_hci_ext_conn_phy {
 	uint16_t supervision_timeout;
 	uint16_t min_ce_len;
 	uint16_t max_ce_len;
-} __packed;
+};
 
-struct bt_hci_cp_le_ext_create_conn {
+__packed_struct bt_hci_cp_le_ext_create_conn {
 	uint8_t      filter_policy;
 	uint8_t      own_addr_type;
 	bt_addr_le_t peer_addr;
 	uint8_t      phys;
 	struct bt_hci_ext_conn_phy p[0];
-} __packed;
+};
 
 #define BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_USE_LIST               BIT(0)
 #define BT_HCI_LE_PER_ADV_CREATE_SYNC_FP_REPORTS_DISABLED       BIT(1)
@@ -1428,70 +1428,70 @@ struct bt_hci_cp_le_ext_create_conn {
 #define BT_HCI_LE_PER_ADV_CREATE_SYNC_CTE_TYPE_ONLY_CTE         BIT(4)
 
 #define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC        BT_OP(BT_OGF_LE, 0x0044)
-struct bt_hci_cp_le_per_adv_create_sync {
+__packed_struct bt_hci_cp_le_per_adv_create_sync {
 	uint8_t      options;
 	uint8_t      sid;
 	bt_addr_le_t addr;
 	uint16_t     skip;
 	uint16_t     sync_timeout;
 	uint8_t      cte_type;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC_CANCEL BT_OP(BT_OGF_LE, 0x0045)
 
 #define BT_HCI_OP_LE_PER_ADV_TERMINATE_SYNC     BT_OP(BT_OGF_LE, 0x0046)
-struct bt_hci_cp_le_per_adv_terminate_sync {
+__packed_struct bt_hci_cp_le_per_adv_terminate_sync {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ADD_DEV_TO_PER_ADV_LIST    BT_OP(BT_OGF_LE, 0x0047)
-struct bt_hci_cp_le_add_dev_to_per_adv_list {
+__packed_struct bt_hci_cp_le_add_dev_to_per_adv_list {
 	bt_addr_le_t addr;
 	uint8_t      sid;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REM_DEV_FROM_PER_ADV_LIST  BT_OP(BT_OGF_LE, 0x0048)
-struct bt_hci_cp_le_rem_dev_from_per_adv_list {
+__packed_struct bt_hci_cp_le_rem_dev_from_per_adv_list {
 	bt_addr_le_t addr;
 	uint8_t      sid;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CLEAR_PER_ADV_LIST         BT_OP(BT_OGF_LE, 0x0049)
 
 #define BT_HCI_OP_LE_READ_PER_ADV_LIST_SIZE     BT_OP(BT_OGF_LE, 0x004a)
-struct bt_hci_rp_le_read_per_adv_list_size {
+__packed_struct bt_hci_rp_le_read_per_adv_list_size {
 	uint8_t  status;
 	uint8_t  list_size;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_TX_POWER              BT_OP(BT_OGF_LE, 0x004b)
-struct bt_hci_rp_le_read_tx_power {
+__packed_struct bt_hci_rp_le_read_tx_power {
 	uint8_t status;
 	int8_t  min_tx_power;
 	int8_t  max_tx_power;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_RF_PATH_COMP          BT_OP(BT_OGF_LE, 0x004c)
-struct bt_hci_rp_le_read_rf_path_comp {
+__packed_struct bt_hci_rp_le_read_rf_path_comp {
 	uint8_t status;
 	int16_t tx_path_comp;
 	int16_t rx_path_comp;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_WRITE_RF_PATH_COMP         BT_OP(BT_OGF_LE, 0x004d)
-struct bt_hci_cp_le_write_rf_path_comp {
+__packed_struct bt_hci_cp_le_write_rf_path_comp {
 	int16_t  tx_path_comp;
 	int16_t  rx_path_comp;
-} __packed;
+};
 
 #define BT_HCI_LE_PRIVACY_MODE_NETWORK          0x00
 #define BT_HCI_LE_PRIVACY_MODE_DEVICE           0x01
 
 #define BT_HCI_OP_LE_SET_PRIVACY_MODE           BT_OP(BT_OGF_LE, 0x004e)
-struct bt_hci_cp_le_set_privacy_mode {
+__packed_struct bt_hci_cp_le_set_privacy_mode {
 	bt_addr_le_t id_addr;
 	uint8_t         mode;
-} __packed;
+};
 
 /* Min and max Constant Tone Extension length in 8us units */
 #define BT_HCI_LE_CTE_LEN_MIN                  0x2
@@ -1505,20 +1505,20 @@ struct bt_hci_cp_le_set_privacy_mode {
 #define BT_HCI_LE_CTE_COUNT_MAX                0x10
 
 #define BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS      BT_OP(BT_OGF_LE, 0x0051)
-struct bt_hci_cp_le_set_cl_cte_tx_params {
+__packed_struct bt_hci_cp_le_set_cl_cte_tx_params {
 	uint8_t handle;
 	uint8_t cte_len;
 	uint8_t cte_type;
 	uint8_t cte_count;
 	uint8_t switch_pattern_len;
 	uint8_t ant_ids[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE      BT_OP(BT_OGF_LE, 0x0052)
-struct bt_hci_cp_le_set_cl_cte_tx_enable {
+__packed_struct bt_hci_cp_le_set_cl_cte_tx_enable {
 	uint8_t handle;
 	uint8_t cte_enable;
-} __packed;
+};
 
 #define BT_HCI_LE_ANTENNA_SWITCHING_SLOT_1US   0x1
 #define BT_HCI_LE_ANTENNA_SWITCHING_SLOT_2US   0x2
@@ -1528,33 +1528,33 @@ struct bt_hci_cp_le_set_cl_cte_tx_enable {
 #define BT_HCI_LE_SAMPLE_CTE_COUNT_MAX         0x10
 
 #define BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE BT_OP(BT_OGF_LE, 0x0053)
-struct bt_hci_cp_le_set_cl_cte_sampling_enable {
+__packed_struct bt_hci_cp_le_set_cl_cte_sampling_enable {
 	uint16_t sync_handle;
 	uint8_t  sampling_enable;
 	uint8_t  slot_durations;
 	uint8_t  max_sampled_cte;
 	uint8_t  switch_pattern_len;
 	uint8_t  ant_ids[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_set_cl_cte_sampling_enable {
+__packed_struct bt_hci_rp_le_set_cl_cte_sampling_enable {
 	uint8_t  status;
 	uint16_t sync_handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS BT_OP(BT_OGF_LE, 0x0054)
-struct bt_hci_cp_le_set_conn_cte_rx_params {
+__packed_struct bt_hci_cp_le_set_conn_cte_rx_params {
 	uint16_t handle;
 	uint8_t  sampling_enable;
 	uint8_t  slot_durations;
 	uint8_t  switch_pattern_len;
 	uint8_t  ant_ids[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_set_conn_cte_rx_params {
+__packed_struct bt_hci_rp_le_set_conn_cte_rx_params {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_LE_AOA_CTE_RSP                   BIT(0)
 #define BT_HCI_LE_AOD_CTE_RSP_1US               BIT(1)
@@ -1564,17 +1564,17 @@ struct bt_hci_rp_le_set_conn_cte_rx_params {
 #define BT_HCI_LE_SWITCH_PATTERN_LEN_MAX        0x4B
 
 #define BT_HCI_OP_LE_SET_CONN_CTE_TX_PARAMS     BT_OP(BT_OGF_LE, 0x0055)
-struct bt_hci_cp_le_set_conn_cte_tx_params {
+__packed_struct bt_hci_cp_le_set_conn_cte_tx_params {
 	uint16_t handle;
 	uint8_t  cte_types;
 	uint8_t  switch_pattern_len;
 	uint8_t  ant_ids[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_set_conn_cte_tx_params {
+__packed_struct bt_hci_rp_le_set_conn_cte_tx_params {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 /* Interval between consecutive CTE request procedure starts in number of connection events. */
 #define BT_HCI_REQUEST_CTE_ONCE                0x0
@@ -1582,29 +1582,29 @@ struct bt_hci_rp_le_set_conn_cte_tx_params {
 #define BT_HCI_REQUEST_CTE_INTERVAL_MAX        0xFFFF
 
 #define BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE       BT_OP(BT_OGF_LE, 0x0056)
-struct bt_hci_cp_le_conn_cte_req_enable {
+__packed_struct bt_hci_cp_le_conn_cte_req_enable {
 	uint16_t handle;
 	uint8_t  enable;
 	uint8_t  cte_request_interval;
 	uint8_t  requested_cte_length;
 	uint8_t  requested_cte_type;
-} __packed;
+};
 
-struct bt_hci_rp_le_conn_cte_req_enable {
+__packed_struct bt_hci_rp_le_conn_cte_req_enable {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CONN_CTE_RSP_ENABLE       BT_OP(BT_OGF_LE, 0x0057)
-struct bt_hci_cp_le_conn_cte_rsp_enable {
+__packed_struct bt_hci_cp_le_conn_cte_rsp_enable {
 	uint16_t handle;
 	uint8_t  enable;
-} __packed;
+};
 
-struct bt_hci_rp_le_conn_cte_rsp_enable {
+__packed_struct bt_hci_rp_le_conn_cte_rsp_enable {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_LE_1US_AOD_TX                    BIT(0)
 #define BT_HCI_LE_1US_AOD_RX                    BIT(1)
@@ -1629,34 +1629,34 @@ struct bt_hci_rp_le_read_ant_info {
 };
 
 #define BT_HCI_OP_LE_SET_PER_ADV_RECV_ENABLE     BT_OP(BT_OGF_LE, 0x0059)
-struct bt_hci_cp_le_set_per_adv_recv_enable {
+__packed_struct bt_hci_cp_le_set_per_adv_recv_enable {
 	uint16_t handle;
 	uint8_t  enable;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER      BT_OP(BT_OGF_LE, 0x005a)
-struct bt_hci_cp_le_per_adv_sync_transfer {
+__packed_struct bt_hci_cp_le_per_adv_sync_transfer {
 	uint16_t conn_handle;
 	uint16_t service_data;
 	uint16_t sync_handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_per_adv_sync_transfer {
+__packed_struct bt_hci_rp_le_per_adv_sync_transfer {
 	uint8_t  status;
 	uint16_t conn_handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER  BT_OP(BT_OGF_LE, 0x005b)
-struct bt_hci_cp_le_per_adv_set_info_transfer {
+__packed_struct bt_hci_cp_le_per_adv_set_info_transfer {
 	uint16_t conn_handle;
 	uint16_t service_data;
 	uint8_t  adv_handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_per_adv_set_info_transfer {
+__packed_struct bt_hci_rp_le_per_adv_set_info_transfer {
 	uint8_t  status;
 	uint16_t conn_handle;
-} __packed;
+};
 
 #define BT_HCI_LE_PAST_MODE_NO_SYNC              0x00
 #define BT_HCI_LE_PAST_MODE_NO_REPORTS           0x01
@@ -1669,55 +1669,55 @@ struct bt_hci_rp_le_per_adv_set_info_transfer {
 #define BT_HCI_LE_PAST_CTE_TYPE_ONLY_CTE         BIT(4)
 
 #define BT_HCI_OP_LE_PAST_PARAM                 BT_OP(BT_OGF_LE, 0x005c)
-struct bt_hci_cp_le_past_param {
+__packed_struct bt_hci_cp_le_past_param {
 	uint16_t conn_handle;
 	uint8_t  mode;
 	uint16_t skip;
 	uint16_t timeout;
 	uint8_t  cte_type;
-} __packed;
+};
 
-struct bt_hci_rp_le_past_param {
+__packed_struct bt_hci_rp_le_past_param {
 	uint8_t  status;
 	uint16_t conn_handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_DEFAULT_PAST_PARAM         BT_OP(BT_OGF_LE, 0x005d)
-struct bt_hci_cp_le_default_past_param {
+__packed_struct bt_hci_cp_le_default_past_param {
 	uint8_t  mode;
 	uint16_t skip;
 	uint16_t timeout;
 	uint8_t  cte_type;
-} __packed;
+};
 
-struct bt_hci_rp_le_default_past_param {
+__packed_struct bt_hci_rp_le_default_past_param {
 	uint8_t  status;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_BUFFER_SIZE_V2        BT_OP(BT_OGF_LE, 0x0060)
-struct bt_hci_rp_le_read_buffer_size_v2 {
+__packed_struct bt_hci_rp_le_read_buffer_size_v2 {
 	uint8_t  status;
 	uint16_t acl_max_len;
 	uint8_t  acl_max_num;
 	uint16_t iso_max_len;
 	uint8_t  iso_max_num;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_ISO_TX_SYNC           BT_OP(BT_OGF_LE, 0x0061)
-struct bt_hci_cp_le_read_iso_tx_sync {
+__packed_struct bt_hci_cp_le_read_iso_tx_sync {
 	uint16_t handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_read_iso_tx_sync {
+__packed_struct bt_hci_rp_le_read_iso_tx_sync {
 	uint8_t  status;
 	uint16_t handle;
 	uint16_t seq;
 	uint32_t timestamp;
 	uint8_t  offset[3];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_CIG_PARAMS             BT_OP(BT_OGF_LE, 0x0062)
-struct bt_hci_cis_params {
+__packed_struct bt_hci_cis_params {
 	uint8_t  cis_id;
 	uint16_t m_sdu;
 	uint16_t s_sdu;
@@ -1725,9 +1725,9 @@ struct bt_hci_cis_params {
 	uint8_t  s_phy;
 	uint8_t  m_rtn;
 	uint8_t  s_rtn;
-} __packed;
+};
 
-struct bt_hci_cp_le_set_cig_params {
+__packed_struct bt_hci_cp_le_set_cig_params {
 	uint8_t  cig_id;
 	uint8_t  m_interval[3];
 	uint8_t  s_interval[3];
@@ -1738,17 +1738,17 @@ struct bt_hci_cp_le_set_cig_params {
 	uint16_t s_latency;
 	uint8_t  num_cis;
 	struct bt_hci_cis_params cis[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_set_cig_params {
+__packed_struct bt_hci_rp_le_set_cig_params {
 	uint8_t  status;
 	uint8_t  cig_id;
 	uint8_t  num_handles;
 	uint16_t handle[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_CIG_PARAMS_TEST        BT_OP(BT_OGF_LE, 0x0063)
-struct bt_hci_cis_params_test {
+__packed_struct bt_hci_cis_params_test {
 	uint8_t  cis_id;
 	uint8_t  nse;
 	uint16_t m_sdu;
@@ -1759,9 +1759,9 @@ struct bt_hci_cis_params_test {
 	uint8_t  s_phy;
 	uint8_t  m_bn;
 	uint8_t  s_bn;
-} __packed;
+};
 
-struct bt_hci_cp_le_set_cig_params_test {
+__packed_struct bt_hci_cp_le_set_cig_params_test {
 	uint8_t  cig_id;
 	uint8_t  m_interval[3];
 	uint8_t  s_interval[3];
@@ -1773,54 +1773,54 @@ struct bt_hci_cp_le_set_cig_params_test {
 	uint8_t  framing;
 	uint8_t  num_cis;
 	struct bt_hci_cis_params_test cis[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_set_cig_params_test {
+__packed_struct bt_hci_rp_le_set_cig_params_test {
 	uint8_t  status;
 	uint8_t  cig_id;
 	uint8_t  num_handles;
 	uint16_t handle[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CREATE_CIS                 BT_OP(BT_OGF_LE, 0x0064)
-struct bt_hci_cis {
+__packed_struct bt_hci_cis {
 	uint16_t  cis_handle;
 	uint16_t  acl_handle;
-} __packed;
+};
 
-struct bt_hci_cp_le_create_cis {
+__packed_struct bt_hci_cp_le_create_cis {
 	uint8_t  num_cis;
 	struct bt_hci_cis cis[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REMOVE_CIG                 BT_OP(BT_OGF_LE, 0x0065)
-struct bt_hci_cp_le_remove_cig {
+__packed_struct bt_hci_cp_le_remove_cig {
 	uint8_t  cig_id;
-} __packed;
+};
 
-struct bt_hci_rp_le_remove_cig {
+__packed_struct bt_hci_rp_le_remove_cig {
 	uint8_t  status;
 	uint8_t  cig_id;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ACCEPT_CIS                 BT_OP(BT_OGF_LE, 0x0066)
-struct bt_hci_cp_le_accept_cis {
+__packed_struct bt_hci_cp_le_accept_cis {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REJECT_CIS                 BT_OP(BT_OGF_LE, 0x0067)
-struct bt_hci_cp_le_reject_cis {
+__packed_struct bt_hci_cp_le_reject_cis {
 	uint16_t handle;
 	uint8_t  reason;
-} __packed;
+};
 
-struct bt_hci_rp_le_reject_cis {
+__packed_struct bt_hci_rp_le_reject_cis {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CREATE_BIG                 BT_OP(BT_OGF_LE, 0x0068)
-struct bt_hci_cp_le_create_big {
+__packed_struct bt_hci_cp_le_create_big {
 	uint8_t  big_handle;
 	uint8_t  adv_handle;
 	uint8_t  num_bis;
@@ -1833,10 +1833,10 @@ struct bt_hci_cp_le_create_big {
 	uint8_t  framing;
 	uint8_t  encryption;
 	uint8_t  bcode[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_CREATE_BIG_TEST            BT_OP(BT_OGF_LE, 0x0069)
-struct bt_hci_cp_le_create_big_test {
+__packed_struct bt_hci_cp_le_create_big_test {
 	uint8_t  big_handle;
 	uint8_t  adv_handle;
 	uint8_t  num_bis;
@@ -1853,16 +1853,16 @@ struct bt_hci_cp_le_create_big_test {
 	uint8_t  pto;
 	uint8_t  encryption;
 	uint8_t  bcode[16];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_TERMINATE_BIG              BT_OP(BT_OGF_LE, 0x006a)
-struct bt_hci_cp_le_terminate_big {
+__packed_struct bt_hci_cp_le_terminate_big {
 	uint8_t  big_handle;
 	uint8_t  reason;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_BIG_CREATE_SYNC            BT_OP(BT_OGF_LE, 0x006b)
-struct bt_hci_cp_le_big_create_sync {
+__packed_struct bt_hci_cp_le_big_create_sync {
 	uint8_t  big_handle;
 	uint16_t sync_handle;
 	uint8_t  encryption;
@@ -1871,25 +1871,25 @@ struct bt_hci_cp_le_big_create_sync {
 	uint16_t sync_timeout;
 	uint8_t  num_bis;
 	uint8_t  bis[0];
-} __packed;
+};
 
 #define BT_HCI_OP_LE_BIG_TERMINATE_SYNC         BT_OP(BT_OGF_LE, 0x006c)
-struct bt_hci_cp_le_big_terminate_sync {
+__packed_struct bt_hci_cp_le_big_terminate_sync {
 	uint8_t  big_handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_big_terminate_sync {
+__packed_struct bt_hci_rp_le_big_terminate_sync {
 	uint8_t  status;
 	uint8_t  big_handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REQ_PEER_SC                BT_OP(BT_OGF_LE, 0x006d)
-struct bt_hci_cp_le_req_peer_sca {
+__packed_struct bt_hci_cp_le_req_peer_sca {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SETUP_ISO_PATH             BT_OP(BT_OGF_LE, 0x006e)
-struct bt_hci_cp_le_setup_iso_path {
+__packed_struct bt_hci_cp_le_setup_iso_path {
 	uint16_t handle;
 	uint8_t  path_dir;
 	uint8_t  path_id;
@@ -1897,88 +1897,88 @@ struct bt_hci_cp_le_setup_iso_path {
 	uint8_t  controller_delay[3];
 	uint8_t  codec_config_len;
 	uint8_t  codec_config[0];
-} __packed;
+};
 
-struct bt_hci_rp_le_setup_iso_path {
+__packed_struct bt_hci_rp_le_setup_iso_path {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_REMOVE_ISO_PATH            BT_OP(BT_OGF_LE, 0x006f)
-struct bt_hci_cp_le_remove_iso_path {
+__packed_struct bt_hci_cp_le_remove_iso_path {
 	uint16_t handle;
 	uint8_t  path_dir;
-} __packed;
+};
 
-struct bt_hci_rp_le_remove_iso_path {
+__packed_struct bt_hci_rp_le_remove_iso_path {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ISO_TRANSMIT_TEST          BT_OP(BT_OGF_LE, 0x0070)
-struct bt_hci_cp_le_iso_transmit_test {
+__packed_struct bt_hci_cp_le_iso_transmit_test {
 	uint16_t handle;
 	uint8_t  payload_type;
-} __packed;
+};
 
-struct bt_hci_rp_le_iso_transmit_test {
+__packed_struct bt_hci_rp_le_iso_transmit_test {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ISO_RECEIVE_TEST           BT_OP(BT_OGF_LE, 0x0071)
-struct bt_hci_cp_le_iso_receive_test {
+__packed_struct bt_hci_cp_le_iso_receive_test {
 	uint16_t handle;
 	uint8_t  payload_type;
-} __packed;
+};
 
-struct bt_hci_rp_le_iso_receive_test {
+__packed_struct bt_hci_rp_le_iso_receive_test {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ISO_READ_TEST_COUNTERS     BT_OP(BT_OGF_LE, 0x0072)
-struct bt_hci_cp_le_read_test_counters {
+__packed_struct bt_hci_cp_le_read_test_counters {
 	uint16_t handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_read_test_counters {
+__packed_struct bt_hci_rp_le_read_test_counters {
 	uint8_t  status;
 	uint16_t handle;
 	uint32_t received_cnt;
 	uint32_t missed_cnt;
 	uint32_t failed_cnt;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_ISO_TEST_END               BT_OP(BT_OGF_LE, 0x0073)
-struct bt_hci_cp_le_iso_test_end {
+__packed_struct bt_hci_cp_le_iso_test_end {
 	uint16_t handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_iso_test_end {
+__packed_struct bt_hci_rp_le_iso_test_end {
 	uint8_t  status;
 	uint16_t handle;
 	uint32_t received_cnt;
 	uint32_t missed_cnt;
 	uint32_t failed_cnt;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_SET_HOST_FEATURE           BT_OP(BT_OGF_LE, 0x0074)
-struct bt_hci_cp_le_set_host_feature {
+__packed_struct bt_hci_cp_le_set_host_feature {
 	uint8_t  bit_number;
 	uint8_t  bit_value;
-} __packed;
+};
 
-struct bt_hci_rp_le_set_host_feature {
+__packed_struct bt_hci_rp_le_set_host_feature {
 	uint8_t  status;
-} __packed;
+};
 
 #define BT_HCI_OP_LE_READ_ISO_LINK_QUALITY      BT_OP(BT_OGF_LE, 0x0075)
-struct bt_hci_cp_le_read_iso_link_quality {
+__packed_struct bt_hci_cp_le_read_iso_link_quality {
 	uint16_t handle;
-} __packed;
+};
 
-struct bt_hci_rp_le_read_iso_link_quality {
+__packed_struct bt_hci_rp_le_read_iso_link_quality {
 	uint8_t  status;
 	uint16_t handle;
 	uint32_t tx_unacked_packets;
@@ -1988,7 +1988,7 @@ struct bt_hci_rp_le_read_iso_link_quality {
 	uint32_t crc_error_packets;
 	uint32_t rx_unreceived_packets;
 	uint32_t duplicate_packets;
-} __packed;
+};
 
 /* Event definitions */
 
@@ -1996,113 +1996,113 @@ struct bt_hci_rp_le_read_iso_link_quality {
 #define BT_HCI_EVT_VENDOR                       0xff
 
 #define BT_HCI_EVT_INQUIRY_COMPLETE             0x01
-struct bt_hci_evt_inquiry_complete {
+__packed_struct bt_hci_evt_inquiry_complete {
 	uint8_t status;
-} __packed;
+};
 
 #define BT_HCI_EVT_CONN_COMPLETE                0x03
-struct bt_hci_evt_conn_complete {
+__packed_struct bt_hci_evt_conn_complete {
 	uint8_t   status;
 	uint16_t  handle;
 	bt_addr_t bdaddr;
 	uint8_t   link_type;
 	uint8_t   encr_enabled;
-} __packed;
+};
 
 #define BT_HCI_EVT_CONN_REQUEST                 0x04
-struct bt_hci_evt_conn_request {
+__packed_struct bt_hci_evt_conn_request {
 	bt_addr_t bdaddr;
 	uint8_t   dev_class[3];
 	uint8_t   link_type;
-} __packed;
+};
 
 #define BT_HCI_EVT_DISCONN_COMPLETE             0x05
-struct bt_hci_evt_disconn_complete {
+__packed_struct bt_hci_evt_disconn_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  reason;
-} __packed;
+};
 
 #define BT_HCI_EVT_AUTH_COMPLETE                0x06
-struct bt_hci_evt_auth_complete {
+__packed_struct bt_hci_evt_auth_complete {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_EVT_REMOTE_NAME_REQ_COMPLETE     0x07
-struct bt_hci_evt_remote_name_req_complete {
+__packed_struct bt_hci_evt_remote_name_req_complete {
 	uint8_t   status;
 	bt_addr_t bdaddr;
 	uint8_t   name[248];
-} __packed;
+};
 
 #define BT_HCI_EVT_ENCRYPT_CHANGE               0x08
-struct bt_hci_evt_encrypt_change {
+__packed_struct bt_hci_evt_encrypt_change {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  encrypt;
-} __packed;
+};
 
 #define BT_HCI_EVT_REMOTE_FEATURES              0x0b
-struct bt_hci_evt_remote_features {
+__packed_struct bt_hci_evt_remote_features {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_EVT_REMOTE_VERSION_INFO          0x0c
-struct bt_hci_evt_remote_version_info {
+__packed_struct bt_hci_evt_remote_version_info {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  version;
 	uint16_t manufacturer;
 	uint16_t subversion;
-} __packed;
+};
 
 #define BT_HCI_EVT_CMD_COMPLETE                 0x0e
-struct bt_hci_evt_cmd_complete {
+__packed_struct bt_hci_evt_cmd_complete {
 	uint8_t  ncmd;
 	uint16_t opcode;
-} __packed;
+};
 
-struct bt_hci_evt_cc_status {
+__packed_struct bt_hci_evt_cc_status {
 	uint8_t  status;
-} __packed;
+};
 
 #define BT_HCI_EVT_CMD_STATUS                   0x0f
-struct bt_hci_evt_cmd_status {
+__packed_struct bt_hci_evt_cmd_status {
 	uint8_t  status;
 	uint8_t  ncmd;
 	uint16_t opcode;
-} __packed;
+};
 
 #define BT_HCI_EVT_HARDWARE_ERROR               0x10
-struct bt_hci_evt_hardware_error {
+__packed_struct bt_hci_evt_hardware_error {
 	uint8_t  hardware_code;
-} __packed;
+};
 
 #define BT_HCI_EVT_ROLE_CHANGE                  0x12
-struct bt_hci_evt_role_change {
+__packed_struct bt_hci_evt_role_change {
 	uint8_t   status;
 	bt_addr_t bdaddr;
 	uint8_t   role;
-} __packed;
+};
 
 #define BT_HCI_EVT_NUM_COMPLETED_PACKETS        0x13
-struct bt_hci_evt_num_completed_packets {
+__packed_struct bt_hci_evt_num_completed_packets {
 	uint8_t  num_handles;
 	struct bt_hci_handle_count h[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_PIN_CODE_REQ                 0x16
-struct bt_hci_evt_pin_code_req {
+__packed_struct bt_hci_evt_pin_code_req {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_EVT_LINK_KEY_REQ                 0x17
-struct bt_hci_evt_link_key_req {
+__packed_struct bt_hci_evt_link_key_req {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 /* Link Key types */
 #define BT_LK_COMBINATION                       0x00
@@ -2116,42 +2116,42 @@ struct bt_hci_evt_link_key_req {
 #define BT_LK_AUTH_COMBINATION_P256             0x08
 
 #define BT_HCI_EVT_LINK_KEY_NOTIFY              0x18
-struct bt_hci_evt_link_key_notify {
+__packed_struct bt_hci_evt_link_key_notify {
 	bt_addr_t bdaddr;
 	uint8_t   link_key[16];
 	uint8_t   key_type;
-} __packed;
+};
 
 /* Overflow link types */
 #define BT_OVERFLOW_LINK_SYNCH                  0x00
 #define BT_OVERFLOW_LINK_ACL                    0x01
 
 #define BT_HCI_EVT_DATA_BUF_OVERFLOW            0x1a
-struct bt_hci_evt_data_buf_overflow {
+__packed_struct bt_hci_evt_data_buf_overflow {
 	uint8_t  link_type;
-} __packed;
+};
 
 #define BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI     0x22
-struct bt_hci_evt_inquiry_result_with_rssi {
+__packed_struct bt_hci_evt_inquiry_result_with_rssi {
 	bt_addr_t addr;
 	uint8_t   pscan_rep_mode;
 	uint8_t   reserved;
 	uint8_t   cod[3];
 	uint16_t  clock_offset;
 	int8_t    rssi;
-} __packed;
+};
 
 #define BT_HCI_EVT_REMOTE_EXT_FEATURES          0x23
-struct bt_hci_evt_remote_ext_features {
+__packed_struct bt_hci_evt_remote_ext_features {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  page;
 	uint8_t  max_page;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_EVT_SYNC_CONN_COMPLETE           0x2c
-struct bt_hci_evt_sync_conn_complete {
+__packed_struct bt_hci_evt_sync_conn_complete {
 	uint8_t    status;
 	uint16_t   handle;
 	bt_addr_t  bdaddr;
@@ -2161,10 +2161,10 @@ struct bt_hci_evt_sync_conn_complete {
 	uint16_t   rx_pkt_length;
 	uint16_t   tx_pkt_length;
 	uint8_t    air_mode;
-} __packed;
+};
 
 #define BT_HCI_EVT_EXTENDED_INQUIRY_RESULT      0x2f
-struct bt_hci_evt_extended_inquiry_result {
+__packed_struct bt_hci_evt_extended_inquiry_result {
 	uint8_t    num_reports;
 	bt_addr_t  addr;
 	uint8_t    pscan_rep_mode;
@@ -2173,65 +2173,65 @@ struct bt_hci_evt_extended_inquiry_result {
 	uint16_t   clock_offset;
 	int8_t     rssi;
 	uint8_t    eir[240];
-} __packed;
+};
 
 #define BT_HCI_EVT_ENCRYPT_KEY_REFRESH_COMPLETE 0x30
-struct bt_hci_evt_encrypt_key_refresh_complete {
+__packed_struct bt_hci_evt_encrypt_key_refresh_complete {
 	uint8_t  status;
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_EVT_IO_CAPA_REQ                  0x31
-struct bt_hci_evt_io_capa_req {
+__packed_struct bt_hci_evt_io_capa_req {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_EVT_IO_CAPA_RESP                 0x32
-struct bt_hci_evt_io_capa_resp {
+__packed_struct bt_hci_evt_io_capa_resp {
 	bt_addr_t bdaddr;
 	uint8_t   capability;
 	uint8_t   oob_data;
 	uint8_t   authentication;
-} __packed;
+};
 
 #define BT_HCI_EVT_USER_CONFIRM_REQ             0x33
-struct bt_hci_evt_user_confirm_req {
+__packed_struct bt_hci_evt_user_confirm_req {
 	bt_addr_t bdaddr;
 	uint32_t  passkey;
-} __packed;
+};
 
 #define BT_HCI_EVT_USER_PASSKEY_REQ             0x34
-struct bt_hci_evt_user_passkey_req {
+__packed_struct bt_hci_evt_user_passkey_req {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_EVT_SSP_COMPLETE                 0x36
-struct bt_hci_evt_ssp_complete {
+__packed_struct bt_hci_evt_ssp_complete {
 	uint8_t   status;
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_EVT_USER_PASSKEY_NOTIFY          0x3b
-struct bt_hci_evt_user_passkey_notify {
+__packed_struct bt_hci_evt_user_passkey_notify {
 	bt_addr_t bdaddr;
 	uint32_t  passkey;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_META_EVENT                0x3e
-struct bt_hci_evt_le_meta_event {
+__packed_struct bt_hci_evt_le_meta_event {
 	uint8_t  subevent;
-} __packed;
+};
 
 #define BT_HCI_EVT_AUTH_PAYLOAD_TIMEOUT_EXP     0x57
-struct bt_hci_evt_auth_payload_timeout_exp {
+__packed_struct bt_hci_evt_auth_payload_timeout_exp {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_ROLE_MASTER                      0x00
 #define BT_HCI_ROLE_SLAVE                       0x01
 
 #define BT_HCI_EVT_LE_CONN_COMPLETE             0x01
-struct bt_hci_evt_le_conn_complete {
+__packed_struct bt_hci_evt_le_conn_complete {
 	uint8_t      status;
 	uint16_t     handle;
 	uint8_t      role;
@@ -2240,77 +2240,77 @@ struct bt_hci_evt_le_conn_complete {
 	uint16_t     latency;
 	uint16_t     supv_timeout;
 	uint8_t      clock_accuracy;
-} __packed;
+};
 
 #define BT_HCI_LE_RSSI_NOT_AVAILABLE            0x7F
 
 #define BT_HCI_EVT_LE_ADVERTISING_REPORT        0x02
-struct bt_hci_evt_le_advertising_info {
+__packed_struct bt_hci_evt_le_advertising_info {
 	uint8_t      evt_type;
 	bt_addr_le_t addr;
 	uint8_t      length;
 	uint8_t      data[0];
-} __packed;
-struct bt_hci_evt_le_advertising_report {
+};
+__packed_struct bt_hci_evt_le_advertising_report {
 	uint8_t num_reports;
 	struct bt_hci_evt_le_advertising_info adv_info[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CONN_UPDATE_COMPLETE      0x03
-struct bt_hci_evt_le_conn_update_complete {
+__packed_struct bt_hci_evt_le_conn_update_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint16_t interval;
 	uint16_t latency;
 	uint16_t supv_timeout;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_REMOTE_FEAT_COMPLETE      0x04
-struct bt_hci_evt_le_remote_feat_complete {
+__packed_struct bt_hci_evt_le_remote_feat_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_LTK_REQUEST               0x05
-struct bt_hci_evt_le_ltk_request {
+__packed_struct bt_hci_evt_le_ltk_request {
 	uint16_t handle;
 	uint64_t rand;
 	uint16_t ediv;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CONN_PARAM_REQ            0x06
-struct bt_hci_evt_le_conn_param_req {
+__packed_struct bt_hci_evt_le_conn_param_req {
 	uint16_t handle;
 	uint16_t interval_min;
 	uint16_t interval_max;
 	uint16_t latency;
 	uint16_t timeout;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_DATA_LEN_CHANGE           0x07
-struct bt_hci_evt_le_data_len_change {
+__packed_struct bt_hci_evt_le_data_len_change {
 	uint16_t handle;
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
 	uint16_t max_rx_octets;
 	uint16_t max_rx_time;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_P256_PUBLIC_KEY_COMPLETE  0x08
-struct bt_hci_evt_le_p256_public_key_complete {
+__packed_struct bt_hci_evt_le_p256_public_key_complete {
 	uint8_t status;
 	uint8_t key[64];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_GENERATE_DHKEY_COMPLETE   0x09
-struct bt_hci_evt_le_generate_dhkey_complete {
+__packed_struct bt_hci_evt_le_generate_dhkey_complete {
 	uint8_t status;
 	uint8_t dhkey[32];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_ENH_CONN_COMPLETE         0x0a
-struct bt_hci_evt_le_enh_conn_complete {
+__packed_struct bt_hci_evt_le_enh_conn_complete {
 	uint8_t      status;
 	uint16_t     handle;
 	uint8_t      role;
@@ -2321,27 +2321,27 @@ struct bt_hci_evt_le_enh_conn_complete {
 	uint16_t     latency;
 	uint16_t     supv_timeout;
 	uint8_t      clock_accuracy;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_DIRECT_ADV_REPORT         0x0b
-struct bt_hci_evt_le_direct_adv_info {
+__packed_struct bt_hci_evt_le_direct_adv_info {
 	uint8_t      evt_type;
 	bt_addr_le_t addr;
 	bt_addr_le_t dir_addr;
 	int8_t       rssi;
-} __packed;
-struct bt_hci_evt_le_direct_adv_report {
+};
+__packed_struct bt_hci_evt_le_direct_adv_report {
 	uint8_t num_reports;
 	struct bt_hci_evt_le_direct_adv_info direct_adv_info[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_PHY_UPDATE_COMPLETE       0x0c
-struct bt_hci_evt_le_phy_update_complete {
+__packed_struct bt_hci_evt_le_phy_update_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  tx_phy;
 	uint8_t  rx_phy;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT    0x0d
 
@@ -2356,7 +2356,7 @@ struct bt_hci_evt_le_phy_update_complete {
 #define BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL    1
 #define BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE 2
 
-struct bt_hci_evt_le_ext_advertising_info {
+__packed_struct bt_hci_evt_le_ext_advertising_info {
 	uint16_t     evt_type;
 	bt_addr_le_t addr;
 	uint8_t      prim_phy;
@@ -2368,14 +2368,14 @@ struct bt_hci_evt_le_ext_advertising_info {
 	bt_addr_le_t direct_addr;
 	uint8_t      length;
 	uint8_t      data[0];
-} __packed;
-struct bt_hci_evt_le_ext_advertising_report {
+};
+__packed_struct bt_hci_evt_le_ext_advertising_report {
 	uint8_t num_reports;
 	struct bt_hci_evt_le_ext_advertising_info adv_info[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_ESTABLISHED  0x0e
-struct bt_hci_evt_le_per_adv_sync_established {
+__packed_struct bt_hci_evt_le_per_adv_sync_established {
 	uint8_t      status;
 	uint16_t     handle;
 	uint8_t      sid;
@@ -2383,10 +2383,10 @@ struct bt_hci_evt_le_per_adv_sync_established {
 	uint8_t      phy;
 	uint16_t     interval;
 	uint8_t      clock_accuracy;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_PER_ADVERTISING_REPORT    0x0f
-struct bt_hci_evt_le_per_advertising_report {
+__packed_struct bt_hci_evt_le_per_advertising_report {
 	uint16_t handle;
 	int8_t   tx_power;
 	int8_t   rssi;
@@ -2394,37 +2394,37 @@ struct bt_hci_evt_le_per_advertising_report {
 	uint8_t  data_status;
 	uint8_t  length;
 	uint8_t  data[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_LOST         0x10
-struct bt_hci_evt_le_per_adv_sync_lost {
+__packed_struct bt_hci_evt_le_per_adv_sync_lost {
 	uint16_t handle;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_SCAN_TIMEOUT              0x11
 
 #define BT_HCI_EVT_LE_ADV_SET_TERMINATED        0x12
-struct bt_hci_evt_le_adv_set_terminated {
+__packed_struct bt_hci_evt_le_adv_set_terminated {
 	uint8_t  status;
 	uint8_t  adv_handle;
 	uint16_t conn_handle;
 	uint8_t  num_completed_ext_adv_evts;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_SCAN_REQ_RECEIVED         0x13
-struct bt_hci_evt_le_scan_req_received {
+__packed_struct bt_hci_evt_le_scan_req_received {
 	uint8_t      handle;
 	bt_addr_le_t addr;
-} __packed;
+};
 
 #define BT_HCI_LE_CHAN_SEL_ALGO_1               0x00
 #define BT_HCI_LE_CHAN_SEL_ALGO_2               0x01
 
 #define BT_HCI_EVT_LE_CHAN_SEL_ALGO             0x14
-struct bt_hci_evt_le_chan_sel_algo {
+__packed_struct bt_hci_evt_le_chan_sel_algo {
 	uint16_t handle;
 	uint8_t  chan_sel_algo;
-} __packed;
+};
 
 #define BT_HCI_LE_CTE_CRC_OK                    0x0
 #define BT_HCI_LE_CTE_CRC_ERR_CTE_BASED_TIME    0x1
@@ -2442,7 +2442,7 @@ struct bt_hci_le_iq_sample {
 	int8_t q;
 };
 
-struct bt_hci_evt_le_connectionless_iq_report {
+__packed_struct bt_hci_evt_le_connectionless_iq_report {
 	uint16_t sync_handle;
 	uint8_t  chan_idx;
 	int16_t  rssi;
@@ -2453,10 +2453,10 @@ struct bt_hci_evt_le_connectionless_iq_report {
 	uint16_t per_evt_counter;
 	uint8_t  sample_count;
 	struct bt_hci_le_iq_sample sample[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CONNECTION_IQ_REPORT      0x16
-struct bt_hci_evt_le_connection_iq_report {
+__packed_struct bt_hci_evt_le_connection_iq_report {
 	uint16_t conn_handle;
 	uint8_t  rx_phy;
 	uint8_t  data_chan_idx;
@@ -2468,16 +2468,16 @@ struct bt_hci_evt_le_connection_iq_report {
 	uint16_t conn_evt_counter;
 	uint8_t  sample_count;
 	struct bt_hci_le_iq_sample sample[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CTE_REQUEST_FAILED       0x17
-struct bt_hci_evt_le_cte_req_failed {
+__packed_struct bt_hci_evt_le_cte_req_failed {
 	uint8_t  status;
 	uint16_t conn_handle;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_PAST_RECEIVED                0x18
-struct bt_hci_evt_le_past_received {
+__packed_struct bt_hci_evt_le_past_received {
 	uint8_t      status;
 	uint16_t     conn_handle;
 	uint16_t     service_data;
@@ -2487,10 +2487,10 @@ struct bt_hci_evt_le_past_received {
 	uint8_t      phy;
 	uint16_t     interval;
 	uint8_t      clock_accuracy;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CIS_ESTABLISHED           0x19
-struct bt_hci_evt_le_cis_established {
+__packed_struct bt_hci_evt_le_cis_established {
 	uint8_t  status;
 	uint16_t conn_handle;
 	uint8_t  cig_sync_delay[3];
@@ -2507,18 +2507,18 @@ struct bt_hci_evt_le_cis_established {
 	uint16_t m_max_pdu;
 	uint16_t s_max_pdu;
 	uint16_t interval;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_CIS_REQ                   0x1a
-struct bt_hci_evt_le_cis_req {
+__packed_struct bt_hci_evt_le_cis_req {
 	uint16_t acl_handle;
 	uint16_t cis_handle;
 	uint8_t  cig_id;
 	uint8_t  cis_id;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_BIG_COMPLETE              0x1b
-struct bt_hci_evt_le_big_complete {
+__packed_struct bt_hci_evt_le_big_complete {
 	uint8_t  status;
 	uint8_t  big_handle;
 	uint8_t  sync_delay[3];
@@ -2532,16 +2532,16 @@ struct bt_hci_evt_le_big_complete {
 	uint16_t iso_interval;
 	uint8_t  num_bis;
 	uint16_t handle[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_BIG_TERMINATE             0x1c
-struct bt_hci_evt_le_big_terminate {
+__packed_struct bt_hci_evt_le_big_terminate {
 	uint8_t  big_handle;
 	uint8_t  reason;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_BIG_SYNC_ESTABLISHED      0x1d
-struct bt_hci_evt_le_big_sync_established {
+__packed_struct bt_hci_evt_le_big_sync_established {
 	uint8_t  status;
 	uint8_t  big_handle;
 	uint8_t  latency[3];
@@ -2553,23 +2553,23 @@ struct bt_hci_evt_le_big_sync_established {
 	uint16_t iso_interval;
 	uint8_t  num_bis;
 	uint16_t handle[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_BIG_SYNC_LOST             0x1e
-struct bt_hci_evt_le_big_sync_lost {
+__packed_struct bt_hci_evt_le_big_sync_lost {
 	uint8_t  big_handle;
 	uint8_t  reason;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_REQ_PEER_SCA_COMPLETE     0x1f
-struct bt_hci_evt_le_req_peer_sca_complete {
+__packed_struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  sca;
-} __packed;
+};
 
 #define BT_HCI_EVT_LE_BIGINFO_ADV_REPORT        0x22
-struct bt_hci_evt_le_biginfo_adv_report {
+__packed_struct bt_hci_evt_le_biginfo_adv_report {
 	uint16_t sync_handle;
 	uint8_t  num_bis;
 	uint8_t  nse;
@@ -2583,7 +2583,7 @@ struct bt_hci_evt_le_biginfo_adv_report {
 	uint8_t  phy;
 	uint8_t  framing;
 	uint8_t  encryption;
-} __packed;
+};
 
 /* Event mask bits */
 

--- a/include/bluetooth/hci_vs.h
+++ b/include/bluetooth/hci_vs.h
@@ -51,7 +51,7 @@ extern "C" {
 #define BT_HCI_VS_FW_VAR_FW_LOADER              0x0003
 #define BT_HCI_VS_FW_VAR_RESCUE_IMG             0x0004
 #define BT_HCI_OP_VS_READ_VERSION_INFO		BT_OP(BT_OGF_VS, 0x0001)
-struct bt_hci_rp_vs_read_version_info {
+__packed_struct bt_hci_rp_vs_read_version_info {
 	uint8_t  status;
 	uint16_t hw_platform;
 	uint16_t hw_variant;
@@ -59,36 +59,36 @@ struct bt_hci_rp_vs_read_version_info {
 	uint8_t  fw_version;
 	uint16_t fw_revision;
 	uint32_t fw_build;
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_SUPPORTED_COMMANDS	BT_OP(BT_OGF_VS, 0x0002)
-struct bt_hci_rp_vs_read_supported_commands {
+__packed_struct bt_hci_rp_vs_read_supported_commands {
 	uint8_t  status;
 	uint8_t  commands[64];
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_SUPPORTED_FEATURES	BT_OP(BT_OGF_VS, 0x0003)
-struct bt_hci_rp_vs_read_supported_features {
+__packed_struct bt_hci_rp_vs_read_supported_features {
 	uint8_t  status;
 	uint8_t  features[8];
-} __packed;
+};
 
 #define BT_HCI_OP_VS_SET_EVENT_MASK             BT_OP(BT_OGF_VS, 0x0004)
-struct bt_hci_cp_vs_set_event_mask {
+__packed_struct bt_hci_cp_vs_set_event_mask {
 	uint8_t  event_mask[8];
-} __packed;
+};
 
 #define BT_HCI_VS_RESET_SOFT                    0x00
 #define BT_HCI_VS_RESET_HARD                    0x01
 #define BT_HCI_OP_VS_RESET                      BT_OP(BT_OGF_VS, 0x0005)
-struct bt_hci_cp_vs_reset {
+__packed_struct bt_hci_cp_vs_reset {
 	uint8_t  type;
-} __packed;
+};
 
 #define BT_HCI_OP_VS_WRITE_BD_ADDR              BT_OP(BT_OGF_VS, 0x0006)
-struct bt_hci_cp_vs_write_bd_addr {
+__packed_struct bt_hci_cp_vs_write_bd_addr {
 	bt_addr_t bdaddr;
-} __packed;
+};
 
 #define BT_HCI_VS_TRACE_DISABLED                0x00
 #define BT_HCI_VS_TRACE_ENABLED                 0x01
@@ -96,122 +96,118 @@ struct bt_hci_cp_vs_write_bd_addr {
 #define BT_HCI_VS_TRACE_HCI_EVTS                0x00
 #define BT_HCI_VS_TRACE_VDC                     0x01
 #define BT_HCI_OP_VS_SET_TRACE_ENABLE           BT_OP(BT_OGF_VS, 0x0007)
-struct bt_hci_cp_vs_set_trace_enable {
+__packed_struct bt_hci_cp_vs_set_trace_enable {
 	uint8_t  enable;
 	uint8_t  type;
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_BUILD_INFO            BT_OP(BT_OGF_VS, 0x0008)
-struct bt_hci_rp_vs_read_build_info {
+__packed_struct bt_hci_rp_vs_read_build_info {
 	uint8_t  status;
 	uint8_t  info[0];
-} __packed;
+};
 
-struct bt_hci_vs_static_addr {
+__packed_struct bt_hci_vs_static_addr {
 	bt_addr_t bdaddr;
 	uint8_t      ir[16];
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_STATIC_ADDRS          BT_OP(BT_OGF_VS, 0x0009)
-struct bt_hci_rp_vs_read_static_addrs {
+__packed_struct bt_hci_rp_vs_read_static_addrs {
 	uint8_t   status;
 	uint8_t   num_addrs;
 	struct bt_hci_vs_static_addr a[0];
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS   BT_OP(BT_OGF_VS, 0x000a)
-struct bt_hci_rp_vs_read_key_hierarchy_roots {
+__packed_struct bt_hci_rp_vs_read_key_hierarchy_roots {
 	uint8_t  status;
 	uint8_t  ir[16];
 	uint8_t  er[16];
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_CHIP_TEMP             BT_OP(BT_OGF_VS, 0x000b)
-struct bt_hci_rp_vs_read_chip_temp {
+__packed_struct bt_hci_rp_vs_read_chip_temp {
 	uint8_t  status;
 	int8_t  temps;
-} __packed;
+};
 
-struct bt_hci_vs_cmd {
+__packed_struct bt_hci_vs_cmd {
 	uint16_t vendor_id;
 	uint16_t opcode_base;
-} __packed;
+};
 
 #define BT_HCI_VS_VID_ANDROID                   0x0001
 #define BT_HCI_VS_VID_MICROSOFT                 0x0002
 #define BT_HCI_OP_VS_READ_HOST_STACK_CMDS       BT_OP(BT_OGF_VS, 0x000c)
-struct bt_hci_rp_vs_read_host_stack_cmds {
+__packed_struct bt_hci_rp_vs_read_host_stack_cmds {
 	uint8_t   status;
 	uint8_t   num_cmds;
 	struct bt_hci_vs_cmd c[0];
-} __packed;
+};
 
 #define BT_HCI_VS_SCAN_REQ_REPORTS_DISABLED     0x00
 #define BT_HCI_VS_SCAN_REQ_REPORTS_ENABLED      0x01
 #define BT_HCI_OP_VS_SET_SCAN_REQ_REPORTS       BT_OP(BT_OGF_VS, 0x000d)
-struct bt_hci_cp_vs_set_scan_req_reports {
+__packed_struct bt_hci_cp_vs_set_scan_req_reports {
 	uint8_t  enable;
-} __packed;
+};
 
 #define BT_HCI_VS_LL_HANDLE_TYPE_ADV       0x00
 #define BT_HCI_VS_LL_HANDLE_TYPE_SCAN      0x01
 #define BT_HCI_VS_LL_HANDLE_TYPE_CONN      0x02
 #define BT_HCI_VS_LL_TX_POWER_LEVEL_NO_PREF     0x7F
 #define BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL       BT_OP(BT_OGF_VS, 0x000e)
-struct bt_hci_cp_vs_write_tx_power_level {
+__packed_struct bt_hci_cp_vs_write_tx_power_level {
 	uint8_t  handle_type;
 	uint16_t handle;
 	int8_t  tx_power_level;
-} __packed;
-
-struct bt_hci_rp_vs_write_tx_power_level {
+};
+__packed_struct bt_hci_rp_vs_write_tx_power_level {
 	uint8_t  status;
 	uint8_t  handle_type;
 	uint16_t handle;
 	int8_t  selected_tx_power;
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_TX_POWER_LEVEL        BT_OP(BT_OGF_VS, 0x000f)
-struct bt_hci_cp_vs_read_tx_power_level {
+__packed_struct bt_hci_cp_vs_read_tx_power_level {
 	uint8_t  handle_type;
 	uint16_t handle;
-} __packed;
-
-struct bt_hci_rp_vs_read_tx_power_level {
+};
+__packed_struct bt_hci_rp_vs_read_tx_power_level {
 	uint8_t  status;
 	uint8_t  handle_type;
 	uint16_t handle;
 	int8_t  tx_power_level;
-} __packed;
+};
 
 #define BT_HCI_OP_VS_READ_USB_TRANSPORT_MODE    BT_OP(BT_OGF_VS, 0x0010)
-
-struct bt_hci_rp_vs_read_usb_transport_mode {
+__packed_struct bt_hci_rp_vs_read_usb_transport_mode {
 	uint8_t  status;
 	uint8_t  num_supported_modes;
 	uint8_t  supported_mode[0];
-} __packed;
+};
 
 #define BT_HCI_VS_USB_H2_MODE                  0x00
 #define BT_HCI_VS_USB_H4_MODE                  0x01
 
 #define BT_HCI_OP_VS_SET_USB_TRANSPORT_MODE    BT_OP(BT_OGF_VS, 0x0011)
-
-struct bt_hci_cp_vs_set_usb_transport_mode {
+__packed_struct bt_hci_cp_vs_set_usb_transport_mode {
 	uint8_t  mode;
-} __packed;
+};
 
 /* Events */
 
-struct bt_hci_evt_vs {
+__packed_struct bt_hci_evt_vs {
 	uint8_t  subevent;
-} __packed;
+};
 
 #define BT_HCI_EVT_VS_FATAL_ERROR              0x02
-struct bt_hci_evt_vs_fatal_error {
+__packed_struct bt_hci_evt_vs_fatal_error {
 	uint64_t pc;
 	uint8_t  err_info[0];
-} __packed;
+};
 
 #define BT_HCI_VS_TRACE_LMP_TX                 0x01
 #define BT_HCI_VS_TRACE_LMP_RX                 0x02
@@ -219,16 +215,16 @@ struct bt_hci_evt_vs_fatal_error {
 #define BT_HCI_VS_TRACE_LLCP_RX                0x04
 #define BT_HCI_VS_TRACE_LE_CONN_IND            0x05
 #define BT_HCI_EVT_VS_TRACE_INFO               0x03
-struct bt_hci_evt_vs_trace_info {
+__packed_struct bt_hci_evt_vs_trace_info {
 	uint8_t  type;
 	uint8_t  data[0];
-} __packed;
+};
 
 #define BT_HCI_EVT_VS_SCAN_REQ_RX              0x04
-struct bt_hci_evt_vs_scan_req_rx {
+__packed_struct bt_hci_evt_vs_scan_req_rx {
 	bt_addr_le_t addr;
 	int8_t         rssi;
-} __packed;
+};
 
 /* Event mask bits */
 
@@ -242,12 +238,12 @@ struct bt_hci_evt_vs_scan_req_rx {
 #define BT_HCI_OP_VS_MESH                      BT_OP(BT_OGF_VS, 0x0042)
 #define BT_HCI_MESH_EVT_PREFIX                 0xF0
 
-struct bt_hci_cp_mesh {
+__packed_struct bt_hci_cp_mesh {
 	uint8_t         opcode;
-} __packed;
+};
 
 #define BT_HCI_OC_MESH_GET_OPTS                0x00
-struct bt_hci_rp_mesh_get_opts {
+__packed_struct bt_hci_rp_mesh_get_opts {
 	uint8_t      status;
 	uint8_t      opcode;
 	uint8_t      revision;
@@ -260,30 +256,30 @@ struct bt_hci_rp_mesh_get_opts {
 	uint8_t      max_tx_window;
 	uint8_t      evt_prefix_len;
 	uint8_t      evt_prefix;
-} __packed;
+};
 
 #define BT_HCI_MESH_PATTERN_LEN_MAX            0x0f
 
 #define BT_HCI_OC_MESH_SET_SCAN_FILTER         0x01
-struct bt_hci_mesh_pattern {
+__packed_struct bt_hci_mesh_pattern {
 	uint8_t pattern_len;
 	uint8_t pattern[0];
-} __packed;
+};
 
-struct bt_hci_cp_mesh_set_scan_filter {
+__packed_struct bt_hci_cp_mesh_set_scan_filter {
 	uint8_t      scan_filter;
 	uint8_t      filter_dup;
 	uint8_t      num_patterns;
 	struct    bt_hci_mesh_pattern patterns[0];
-} __packed;
-struct bt_hci_rp_mesh_set_scan_filter {
+};
+__packed_struct bt_hci_rp_mesh_set_scan_filter {
 	uint8_t      status;
 	uint8_t      opcode;
 	uint8_t      scan_filter;
-} __packed;
+};
 
 #define BT_HCI_OC_MESH_ADVERTISE               0x02
-struct bt_hci_cp_mesh_advertise {
+__packed_struct bt_hci_cp_mesh_advertise {
 	uint8_t      adv_slot;
 	uint8_t      own_addr_type;
 	bt_addr_t random_addr;
@@ -298,15 +294,15 @@ struct bt_hci_cp_mesh_advertise {
 	uint8_t      scan_filter;
 	uint8_t      data_len;
 	uint8_t      data[31];
-} __packed;
-struct bt_hci_rp_mesh_advertise {
+};
+__packed_struct bt_hci_rp_mesh_advertise {
 	uint8_t      status;
 	uint8_t      opcode;
 	uint8_t      adv_slot;
-} __packed;
+};
 
 #define BT_HCI_OC_MESH_ADVERTISE_TIMED         0x03
-struct bt_hci_cp_mesh_advertise_timed {
+__packed_struct bt_hci_cp_mesh_advertise_timed {
 	uint8_t      adv_slot;
 	uint8_t      own_addr_type;
 	bt_addr_t random_addr;
@@ -319,58 +315,58 @@ struct bt_hci_cp_mesh_advertise_timed {
 	uint16_t     tx_window;
 	uint8_t      data_len;
 	uint8_t      data[31];
-} __packed;
-struct bt_hci_rp_mesh_advertise_timed {
+};
+__packed_struct bt_hci_rp_mesh_advertise_timed {
 	uint8_t      status;
 	uint8_t      opcode;
 	uint8_t      adv_slot;
-} __packed;
+};
 
 #define BT_HCI_OC_MESH_ADVERTISE_CANCEL        0x04
-struct bt_hci_cp_mesh_advertise_cancel {
+__packed_struct bt_hci_cp_mesh_advertise_cancel {
 	uint8_t      adv_slot;
-} __packed;
-struct bt_hci_rp_mesh_advertise_cancel {
+};
+__packed_struct bt_hci_rp_mesh_advertise_cancel {
 	uint8_t      status;
 	uint8_t      opcode;
 	uint8_t      adv_slot;
-} __packed;
+};
 
 #define BT_HCI_OC_MESH_SET_SCANNING            0x05
-struct bt_hci_cp_mesh_set_scanning {
+__packed_struct bt_hci_cp_mesh_set_scanning {
 	uint8_t      enable;
 	uint8_t      ch_map;
 	uint8_t      scan_filter;
-} __packed;
-struct bt_hci_rp_mesh_set_scanning {
+};
+__packed_struct bt_hci_rp_mesh_set_scanning {
 	uint8_t      status;
 	uint8_t      opcode;
-} __packed;
+};
 
 /* Events */
-struct bt_hci_evt_mesh {
+__packed_struct bt_hci_evt_mesh {
 	uint8_t  prefix;
 	uint8_t  subevent;
-} __packed;
+};
 
 #define BT_HCI_EVT_MESH_ADV_COMPLETE           0x00
-struct bt_hci_evt_mesh_adv_complete {
+__packed_struct bt_hci_evt_mesh_adv_complete {
 	uint8_t         adv_slot;
-} __packed;
+};
 
 #define BT_HCI_EVT_MESH_SCANNING_REPORT        0x01
-struct bt_hci_evt_mesh_scan_report {
+__packed_struct bt_hci_evt_mesh_scan_report {
 	bt_addr_le_t addr;
 	uint8_t         chan;
 	int8_t         rssi;
 	uint32_t        instant;
 	uint8_t         data_len;
 	uint8_t         data[0];
-} __packed;
-struct bt_hci_evt_mesh_scanning_report {
+};
+__packed_struct bt_hci_evt_mesh_scanning_report {
 	uint8_t num_reports;
 	struct bt_hci_evt_mesh_scan_report reports[0];
-} __packed;
+};
 
 #ifdef __cplusplus
 }

--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -197,13 +197,13 @@ enum {
 	((prop) & BIT(BT_OTS_OBJ_PROP_MARKED))
 
 /** @brief Descriptor for OTS Object Size parameter. */
-struct bt_ots_obj_size {
+__packed_struct bt_ots_obj_size {
 	/* Current Size */
 	uint32_t cur;
 
 	/* Allocated Size */
 	uint32_t alloc;
-} __packed;
+};
 
 /** @brief Descriptor for OTS object initialization. */
 struct bt_ots_obj_metadata {
@@ -465,13 +465,13 @@ enum {
 	((feat) & BIT(BT_OTS_OLCP_FEAT_CLEAR))
 
 /**@brief Features of the OTS. */
-struct bt_ots_feat {
+__packed_struct bt_ots_feat {
 	/* OACP Features */
 	uint32_t oacp;
 
 	/* OLCP Features */
 	uint32_t olcp;
-} __packed;
+};
 
 /** @brief Opaque OTS instance. */
 struct bt_ots;

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -180,6 +180,11 @@ do {                                                                    \
 #ifndef __packed
 #define __packed        __attribute__((__packed__))
 #endif
+
+#ifndef __packed_struct
+#define __packed_struct struct __attribute__((__packed__))
+#endif
+
 #ifndef __aligned
 #define __aligned(x)	__attribute__((__aligned__(x)))
 #endif


### PR DESCRIPTION
Add STRUCT_PACKED_PRE/_POST and ENUM_PACKED_PRE/_POST to support different tool-chain.