### PR TITLE
labels: Rename ARM_64 to ARM64

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -57,7 +57,7 @@
 "area: ARM":
   - "arch/arm/**/*"
   - "include/arch/arm/**/*"
-"area: ARM_64":
+"area: ARM64":
   - "arch/arm64/**/*"
   - "include/arch/arm64/**/*"
 "area: NIOS2":


### PR DESCRIPTION
github labeler is using `ARM_64`, Zephyrbot is using `ARM64` and this is messing up labeling. Make it consistent.