### PR TITLE
arch: arm: Disallow FP_HARDABI when building with TFM

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -225,7 +225,10 @@ config FP_HARDABI
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
-	  conventions
+	  conventions.
+	  Note: the option is disabled for Zephyr builds with TF-M, as TF-M
+	  does not currently support building with Hard ABI, hence linking
+	  Zephyr with TF-M libraries would not be possible.
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"

--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -221,6 +221,7 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
+	depends on !BUILD_WITH_TFM
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling


### PR DESCRIPTION
When building with TFM, the app is linked with libraries built by the
TFM build system. TFM is always built with -msoft-float which is
equivalent to -mfloat-abi=soft. FP_HARDABI adds -mfloat-abi=hard
which gives errors when linking with the libs from TFM since they are
built with a different ABI.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/33956

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>