### PR TITLE
[Backport v2.5-branch] Bluetooth: controller: Fix flash driver sync regression

### DIFF
--- a/drivers/flash/soc_flash_nrf_ticker.c
+++ b/drivers/flash/soc_flash_nrf_ticker.c
@@ -92,7 +92,8 @@ static void time_slot_delay(uint32_t ticks_at_expire, uint32_t ticks_delay,
 	 * Radio h/w.
 	 */
 	err = ticker_start(instance_index, /* Radio instance ticker */
-			   0, /* user_id */
+			   1, /* user id for link layer ULL_HIGH */
+			      /* (MAYFLY_CALL_ID_WORKER) */
 			   (ticker_id + 1), /* ticker_id */
 			   ticks_at_expire, /* current tick */
 			   ticks_delay, /* one-shot delayed timeout */

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -292,7 +292,8 @@ void ll_rx_dequeue(void);
 void ll_rx_mem_release(void **node_rx);
 
 /* External co-operation */
-void ll_timeslice_ticker_id_get(uint8_t * const instance_index, uint8_t * const user_id);
+void ll_timeslice_ticker_id_get(uint8_t * const instance_index,
+				uint8_t * const ticker_id);
 void ll_radio_state_abort(void);
 uint32_t ll_radio_state_is_idle(void);
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +30,16 @@
 #define XON_BITMASK BIT(31) /* XTAL has been retained from previous prepare */
 #endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
 
+#if defined(CONFIG_BT_BROADCASTER)
+#if defined(CONFIG_BT_CTLR_ADV_SET)
+#define BT_CTLR_ADV_SET CONFIG_BT_CTLR_ADV_SET
+#else /* CONFIG_BT_CTLR_ADV_SET */
+#define BT_CTLR_ADV_SET 1
+#endif /* CONFIG_BT_CTLR_ADV_SET */
+#else /* !CONFIG_BT_BROADCASTER */
+#define BT_CTLR_ADV_SET 0
+#endif /* !CONFIG_BT_BROADCASTER */
+
 #if defined(CONFIG_BT_OBSERVER)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -49,8 +59,7 @@ enum {
 	TICKER_ID_ADV_STOP,
 	TICKER_ID_ADV_BASE,
 #if defined(CONFIG_BT_CTLR_ADV_EXT) || defined(CONFIG_BT_HCI_MESH_EXT)
-	TICKER_ID_ADV_LAST = ((TICKER_ID_ADV_BASE) +
-			      (CONFIG_BT_CTLR_ADV_SET) - 1),
+	TICKER_ID_ADV_LAST = ((TICKER_ID_ADV_BASE) + (BT_CTLR_ADV_SET) - 1),
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 	TICKER_ID_ADV_AUX_BASE,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
@@ -1,14 +1,8 @@
 /*
- * Copyright (c) 2017-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#if defined(CONFIG_BT_CTLR_ADV_SET)
-#define BT_CTLR_ADV_SET CONFIG_BT_CTLR_ADV_SET
-#else /* CONFIG_BT_CTLR_ADV_SET */
-#define BT_CTLR_ADV_SET 1
-#endif /* CONFIG_BT_CTLR_ADV_SET */
 
 /* Structure used to double buffer pointers of AD Data PDU buffer.
  * The first and last members are used to make modification to AD data to be

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -63,6 +63,22 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+/* When both central and peripheral are supported, one each Rx node will be
+ * needed by connectable advertising and the initiator to generate connection
+ * complete event, hence conditionally set the count.
+ */
+#if defined(CONFIG_BT_MAX_CONN)
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
+#define BT_CTLR_MAX_CONNECTABLE 2
+#else
+#define BT_CTLR_MAX_CONNECTABLE 1
+#endif
+#define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
+#else
+#define BT_CTLR_MAX_CONNECTABLE 0
+#define BT_CTLR_MAX_CONN        0
+#endif
+
 #if !defined(TICKER_USER_LLL_VENDOR_OPS)
 #define TICKER_USER_LLL_VENDOR_OPS 0
 #endif /* TICKER_USER_LLL_VENDOR_OPS */
@@ -245,22 +261,6 @@ static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 			  PDU_DATA_SIZE),                     \
 		      PDU_RX_USER_PDU_OCTETS_MAX)              \
 	)
-
-/* When both central and peripheral are supported, one each Rx node will be
- * needed by connectable advertising and the initiator to generate connection
- * complete event, hence conditionally set the count.
- */
-#if defined(CONFIG_BT_MAX_CONN)
-#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
-#define BT_CTLR_MAX_CONNECTABLE 2
-#else
-#define BT_CTLR_MAX_CONNECTABLE 1
-#endif
-#define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
-#else
-#define BT_CTLR_MAX_CONNECTABLE 0
-#define BT_CTLR_MAX_CONN        0
-#endif
 
 #if defined(CONFIG_BT_CTLR_SCAN_SYNC_SET)
 #define BT_CTLR_SCAN_SYNC_SET CONFIG_BT_CTLR_SCAN_SYNC_SET

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -63,53 +63,6 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-/* When both central and peripheral are supported, one each Rx node will be
- * needed by connectable advertising and the initiator to generate connection
- * complete event, hence conditionally set the count.
- */
-#if defined(CONFIG_BT_MAX_CONN)
-#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
-#define BT_CTLR_MAX_CONNECTABLE 2
-#else
-#define BT_CTLR_MAX_CONNECTABLE 1
-#endif
-#define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
-#else
-#define BT_CTLR_MAX_CONNECTABLE 0
-#define BT_CTLR_MAX_CONN        0
-#endif
-
-#if !defined(TICKER_USER_LLL_VENDOR_OPS)
-#define TICKER_USER_LLL_VENDOR_OPS 0
-#endif /* TICKER_USER_LLL_VENDOR_OPS */
-
-#if !defined(TICKER_USER_ULL_HIGH_VENDOR_OPS)
-#define TICKER_USER_ULL_HIGH_VENDOR_OPS 0
-#endif /* TICKER_USER_ULL_HIGH_VENDOR_OPS */
-
-#if !defined(TICKER_USER_THREAD_VENDOR_OPS)
-#define TICKER_USER_THREAD_VENDOR_OPS 0
-#endif /* TICKER_USER_THREAD_VENDOR_OPS */
-
-/* Define ticker nodes and user operations */
-#if defined(CONFIG_BT_CTLR_LOW_LAT) && \
-	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
-#define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
-/* NOTE: When ticker job is disabled inside radio events then all advertising,
- *       scanning, and slave latency cancel ticker operations will be deferred,
- *       requiring increased ticker thread context operation queue count.
- */
-#define TICKER_USER_THREAD_OPS   (BT_CTLR_ADV_SET + BT_CTLR_SCAN_SET + \
-				  BT_CTLR_CONN_MAX + \
-				  TICKER_USER_THREAD_VENDOR_OPS + 1)
-#else /* !CONFIG_BT_CTLR_LOW_LAT */
-#define TICKER_USER_LLL_OPS      (2 + TICKER_USER_LLL_VENDOR_OPS + 1)
-#define TICKER_USER_THREAD_OPS   (1 + TICKER_USER_THREAD_VENDOR_OPS + 1)
-#endif /* !CONFIG_BT_CTLR_LOW_LAT */
-
-#define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + 1)
-#define TICKER_USER_ULL_LOW_OPS  (1 + 1)
-
 #if defined(CONFIG_BT_BROADCASTER)
 #define BT_ADV_TICKER_NODES ((TICKER_ID_ADV_LAST) - (TICKER_ID_ADV_STOP) + 1)
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
@@ -158,20 +111,33 @@
 #define BT_CONN_TICKER_NODES 0
 #endif
 
-#if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER)
-#define FLASH_TICKER_NODES        2 /* No. of tickers reserved for flashing */
-#define FLASH_TICKER_USER_APP_OPS 1 /* No. of additional ticker operations */
-#else
-#define FLASH_TICKER_NODES        0
-#define FLASH_TICKER_USER_APP_OPS 0
-#endif
-
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 #define USER_TICKER_NODES         CONFIG_BT_CTLR_USER_TICKER_ID_RANGE
 #else
 #define USER_TICKER_NODES         0
 #endif
 
+#if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER)
+#define FLASH_TICKER_NODES             2 /* No. of tickers reserved for flash
+					  * driver
+					  */
+#define TICKER_USER_ULL_HIGH_FLASH_OPS 1 /* No. of additional ticker ULL_HIGH
+					  * context operations
+					  */
+#define TICKER_USER_THREAD_FLASH_OPS   1 /* No. of additional ticker thread
+					  * context operations
+					  */
+#else
+#define FLASH_TICKER_NODES             0
+#define TICKER_USER_ULL_HIGH_FLASH_OPS 0
+#define TICKER_USER_THREAD_FLASH_OPS   0
+#endif
+
+/* Define ticker nodes */
+/* NOTE: FLASH_TICKER_NODES shall be after Link Layer's list of ticker id
+ *       allocations, refer to ll_timeslice_ticker_id_get on how ticker id
+ *       used by flash driver is returned.
+ */
 #define TICKER_NODES              (TICKER_ID_ULL_BASE + \
 				   BT_ADV_TICKER_NODES + \
 				   BT_ADV_AUX_TICKER_NODES + \
@@ -180,15 +146,71 @@
 				   BT_SCAN_AUX_TICKER_NODES + \
 				   BT_SCAN_SYNC_TICKER_NODES + \
 				   BT_CONN_TICKER_NODES + \
-				   FLASH_TICKER_NODES + \
-				   USER_TICKER_NODES)
-#define TICKER_USER_APP_OPS       (TICKER_USER_THREAD_OPS + \
-				   FLASH_TICKER_USER_APP_OPS)
+				   USER_TICKER_NODES + \
+				   FLASH_TICKER_NODES)
+
+/* When both central and peripheral are supported, one each Rx node will be
+ * needed by connectable advertising and the initiator to generate connection
+ * complete event, hence conditionally set the count.
+ */
+#if defined(CONFIG_BT_MAX_CONN)
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
+#define BT_CTLR_MAX_CONNECTABLE 2
+#else
+#define BT_CTLR_MAX_CONNECTABLE 1
+#endif
+#define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
+#else
+#define BT_CTLR_MAX_CONNECTABLE 0
+#define BT_CTLR_MAX_CONN        0
+#endif
+
+#if !defined(TICKER_USER_LLL_VENDOR_OPS)
+#define TICKER_USER_LLL_VENDOR_OPS 0
+#endif /* TICKER_USER_LLL_VENDOR_OPS */
+
+#if !defined(TICKER_USER_ULL_HIGH_VENDOR_OPS)
+#define TICKER_USER_ULL_HIGH_VENDOR_OPS 0
+#endif /* TICKER_USER_ULL_HIGH_VENDOR_OPS */
+
+#if !defined(TICKER_USER_THREAD_VENDOR_OPS)
+#define TICKER_USER_THREAD_VENDOR_OPS 0
+#endif /* TICKER_USER_THREAD_VENDOR_OPS */
+
+/* Define ticker user operations */
+#if defined(CONFIG_BT_CTLR_LOW_LAT) && \
+	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+#define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
+/* NOTE: When ticker job is disabled inside radio events then all advertising,
+ *       scanning, and slave latency cancel ticker operations will be deferred,
+ *       requiring increased ticker thread context operation queue count.
+ */
+#define TICKER_USER_THREAD_OPS   (BT_CTLR_ADV_SET + BT_CTLR_SCAN_SET + \
+				  BT_CTLR_MAX_CONN + \
+				  TICKER_USER_THREAD_VENDOR_OPS + \
+				  TICKER_USER_THREAD_FLASH_OPS + \
+				  1)
+#else /* !CONFIG_BT_CTLR_LOW_LAT */
+#define TICKER_USER_LLL_OPS      (2 + TICKER_USER_LLL_VENDOR_OPS + 1)
+/* NOTE: As ticker job is not disabled inside radio events, no need for extra
+ *       thread operations queue element for flash driver.
+ */
+#define TICKER_USER_THREAD_OPS   (1 + TICKER_USER_THREAD_VENDOR_OPS + 1)
+#endif /* !CONFIG_BT_CTLR_LOW_LAT */
+
+/* NOTE: When ULL_LOW priority is configured to lower than ULL_HIGH, then extra
+ *       ULL_HIGH operations queue elements are required to buffer the
+ *       requested ticker operations.
+ */
+#define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
+				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
+
+#define TICKER_USER_ULL_LOW_OPS  (1 + 1)
+
 #define TICKER_USER_OPS           (TICKER_USER_LLL_OPS + \
 				   TICKER_USER_ULL_HIGH_OPS + \
 				   TICKER_USER_ULL_LOW_OPS + \
-				   TICKER_USER_THREAD_OPS + \
-				   FLASH_TICKER_USER_APP_OPS)
+				   TICKER_USER_THREAD_OPS)
 
 /* Memory for ticker nodes/instances */
 static uint8_t MALIGN(4) ticker_nodes[TICKER_NODES][TICKER_NODE_T_SIZE];
@@ -363,7 +385,7 @@ int ll_init(struct k_sem *sem_rx)
 	ticker_users[MAYFLY_CALL_ID_0][0] = TICKER_USER_LLL_OPS;
 	ticker_users[MAYFLY_CALL_ID_1][0] = TICKER_USER_ULL_HIGH_OPS;
 	ticker_users[MAYFLY_CALL_ID_2][0] = TICKER_USER_ULL_LOW_OPS;
-	ticker_users[MAYFLY_CALL_ID_PROGRAM][0] = TICKER_USER_APP_OPS;
+	ticker_users[MAYFLY_CALL_ID_PROGRAM][0] = TICKER_USER_THREAD_OPS;
 
 	err = ticker_init(TICKER_INSTANCE_ID_CTLR,
 			  TICKER_NODES, &ticker_nodes[0],
@@ -1282,10 +1304,10 @@ void ll_tx_ack_put(uint16_t handle, struct node_tx *node_tx)
 #endif /* CONFIG_BT_CONN */
 
 void ll_timeslice_ticker_id_get(uint8_t * const instance_index,
-				uint8_t * const user_id)
+				uint8_t * const ticker_id)
 {
 	*instance_index = TICKER_INSTANCE_ID_CTLR;
-	*user_id = (TICKER_NODES - FLASH_TICKER_NODES);
+	*ticker_id = (TICKER_NODES - FLASH_TICKER_NODES);
 }
 
 void ll_radio_state_abort(void)

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -95,13 +95,20 @@
 #if defined(CONFIG_BT_CTLR_LOW_LAT) && \
 	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 #define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
-#else
+/* NOTE: When ticker job is disabled inside radio events then all advertising,
+ *       scanning, and slave latency cancel ticker operations will be deferred,
+ *       requiring increased ticker thread context operation queue count.
+ */
+#define TICKER_USER_THREAD_OPS   (BT_CTLR_ADV_SET + BT_CTLR_SCAN_SET + \
+				  BT_CTLR_CONN_MAX + \
+				  TICKER_USER_THREAD_VENDOR_OPS + 1)
+#else /* !CONFIG_BT_CTLR_LOW_LAT */
 #define TICKER_USER_LLL_OPS      (2 + TICKER_USER_LLL_VENDOR_OPS + 1)
-#endif /* CONFIG_BT_CTLR_LOW_LAT */
+#define TICKER_USER_THREAD_OPS   (1 + TICKER_USER_THREAD_VENDOR_OPS + 1)
+#endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 #define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + 1)
 #define TICKER_USER_ULL_LOW_OPS  (1 + 1)
-#define TICKER_USER_THREAD_OPS   (1 + TICKER_USER_THREAD_VENDOR_OPS + 1)
 
 #if defined(CONFIG_BT_BROADCASTER)
 #define BT_ADV_TICKER_NODES ((TICKER_ID_ADV_LAST) - (TICKER_ID_ADV_STOP) + 1)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -323,7 +323,7 @@ uint16_t ll_adv_aux_max_data_length_get(void)
 
 uint8_t ll_adv_aux_set_count_get(void)
 {
-	return CONFIG_BT_CTLR_ADV_SET;
+	return BT_CTLR_ADV_SET;
 }
 
 uint8_t ll_adv_aux_set_remove(uint8_t handle)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -33,7 +33,7 @@
 #include "ull_adv_types.h"
 #include "ull_adv_internal.h"
 
-static struct ll_adv_iso ll_adv_iso[CONFIG_BT_CTLR_ADV_SET];
+static struct ll_adv_iso ll_adv_iso[BT_CTLR_ADV_SET];
 static void *adv_iso_free;
 
 static uint32_t ull_adv_iso_start(struct ll_adv_iso *adv_iso,
@@ -238,7 +238,7 @@ uint8_t ll_adv_iso_by_hci_handle_get(uint8_t hci_handle, uint8_t *handle)
 
 	adv_iso =  &ll_adv_iso[0];
 
-	for (idx = 0U; idx < CONFIG_BT_CTLR_ADV_SET; idx++, adv_iso++) {
+	for (idx = 0U; idx < BT_CTLR_ADV_SET; idx++, adv_iso++) {
 		if (adv_iso->is_created &&
 		    (adv_iso->hci_handle == hci_handle)) {
 			*handle = idx;
@@ -257,7 +257,7 @@ uint8_t ll_adv_iso_by_hci_handle_new(uint8_t hci_handle, uint8_t *handle)
 	adv_iso = &ll_adv_iso[0];
 	adv_iso_empty = NULL;
 
-	for (idx = 0U; idx < CONFIG_BT_CTLR_ADV_SET; idx++, adv_iso++) {
+	for (idx = 0U; idx < BT_CTLR_ADV_SET; idx++, adv_iso++) {
 		if (adv_iso->is_created) {
 			if (adv_iso->hci_handle == hci_handle) {
 				return BT_HCI_ERR_CMD_DISALLOWED;
@@ -330,7 +330,7 @@ static uint32_t ull_adv_iso_start(struct ll_adv_iso *adv_iso,
 
 static inline struct ll_adv_iso *ull_adv_iso_get(uint8_t handle)
 {
-	if (handle >= CONFIG_BT_CTLR_ADV_SET) {
+	if (handle >= BT_CTLR_ADV_SET) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix flash driver sync regression introduced due to changed
default ULL_HIGH in the commit 3063433 ("Bluetooth:
controller: Fix ULL_HIGH priority to be lower than LLL").

Fixes #33862.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>