### PR TITLE
Bluetooth: Att: Add ATT min/max handle defines

### DIFF
--- a/include/bluetooth/att.h
+++ b/include/bluetooth/att.h
@@ -47,6 +47,11 @@ extern "C" {
 /* Version 5.2, Vol 3, Part F, 3.2.9 defines maximum attribute length to 512 */
 #define BT_ATT_MAX_ATTRIBUTE_LEN		512
 
+/* Handle 0x0000 is reserved for future use */
+#define BT_ATT_FIRST_ATTTRIBUTE_HANDLE          0x0001
+/* 0xffff is defined as the maximum, and thus last, valid attribute handle */
+#define BT_ATT_LAST_ATTTRIBUTE_HANDLE           0xffff
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -205,8 +205,8 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 		memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;
 		discover_params.func = discover_func;
-		discover_params.start_handle = 0x0001;
-		discover_params.end_handle = 0xffff;
+		discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+		discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 		discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 
 		err = bt_gatt_discover(default_conn, &discover_params);

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -146,8 +146,8 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 		memcpy(&uuid, BT_UUID_HTS, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;
 		discover_params.func = discover_func;
-		discover_params.start_handle = 0x0001;
-		discover_params.end_handle = 0xffff;
+		discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+		discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 		discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 
 		err = bt_gatt_discover(default_conn, &discover_params);

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -485,8 +485,8 @@ static void ble_timeout(struct k_work *work)
 	case BLE_CONNECTED:
 		discov_param.uuid = &pong_svc_uuid.uuid;
 		discov_param.func = discover_func;
-		discov_param.start_handle = 0x0001;
-		discov_param.end_handle = 0xffff;
+		discov_param.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+		discov_param.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 		discov_param.type = BT_GATT_DISCOVER_PRIMARY;
 
 		err = bt_gatt_discover(default_conn, &discov_param);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -174,8 +174,8 @@ static int cmd_discover(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	discover_params.func = discover_func;
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = 0xffff;
+	discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 
 	if (argc > 1) {
 		/* Only set the UUID if the value is valid (non zero) */
@@ -320,8 +320,8 @@ static int cmd_read_uuid(const struct shell *shell, size_t argc, char *argv[])
 
 	read_params.func = read_func;
 	read_params.handle_count = 0;
-	read_params.by_uuid.start_handle = 0x0001;
-	read_params.by_uuid.end_handle = 0xffff;
+	read_params.by_uuid.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	read_params.by_uuid.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 
 	if (argc > 1) {
 		uuid.val = strtoul(argv[1], NULL, 16);

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -264,8 +264,8 @@ static void params_updated(struct bt_conn *conn, uint16_t interval,
 	memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
 	discover_params.uuid = &uuid.uuid;
 	discover_params.func = discover_func;
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = 0xffff;
+	discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 
 	err = bt_gatt_discover(conn, &discover_params);

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -989,8 +989,8 @@ static void disc_all_prim(uint8_t *data, uint16_t len)
 	}
 
 	discover_params.uuid = NULL;
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = 0xffff;
+	discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 	discover_params.func = disc_prim_cb;
 
@@ -1032,8 +1032,8 @@ static void disc_prim_uuid(uint8_t *data, uint16_t len)
 	}
 
 	discover_params.uuid = &uuid.uuid;
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = 0xffff;
+	discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
 	discover_params.func = disc_prim_cb;
 
@@ -1736,7 +1736,7 @@ static int enable_subscription(struct bt_conn *conn, uint16_t ccc_handle,
 	}
 
 	/* Discover Characteristic Value this CCC Descriptor refers to */
-	discover_params.start_handle = 0x0001;
+	discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
 	discover_params.end_handle = ccc_handle;
 	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 	discover_params.func = discover_func;


### PR DESCRIPTION
Adds #defines for the minimum and maximum attribute
handles in ATT. These are useful for when setting e.g.
the start and end handle when doing a full GATT discover.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>