### PR TITLE
scripts: west sign: fix devicetree module include

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -23,7 +23,7 @@ from zephyr_ext_common import Forceable, load_dot_config, \
     ZEPHYR_SCRIPTS
 
 # This is needed to load edt.pickle files.
-sys.path.append(str(ZEPHYR_SCRIPTS / 'dts'))
+sys.path.append(str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src'))
 
 SIGN_DESCRIPTION = '''\
 This command automates some of the drudgery of creating signed Zephyr


### PR DESCRIPTION
PR #33746 introduced changes to the devicetree python file
that requires changes in the python code that imports the
devicetree module.

This was omitted in the west sign command implementation.

Signed-off-by: Mikkel Jakobsen <mikkel.aunsbjerg@prevas.dk>