### PR TITLE
drivers: sensors: Support XYZ accel get for adxl362.

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -614,6 +614,11 @@ static int adxl362_channel_get(const struct device *dev,
 	case SENSOR_CHAN_ACCEL_Z: /* Acceleration on the Z axis, in m/s^2. */
 		adxl362_accel_convert(val, data->acc_z,  data->selected_range);
 		break;
+	case SENSOR_CHAN_ACCEL_XYZ: /* Acceleration on the XYZ axis, in m/s^2. */
+		for (size_t i = 0; i < 3; i++) {
+			adxl362_accel_convert(&val[i], data->acc_xyz[i], data->selected_range);
+		}
+		break;
 	case SENSOR_CHAN_DIE_TEMP: /* Temperature in degrees Celsius. */
 		adxl362_temp_convert(val, data->temp);
 		break;

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -194,9 +194,14 @@ struct adxl362_data {
 #if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
 	struct spi_cs_control adxl362_cs_ctrl;
 #endif
-	int16_t acc_x;
-	int16_t acc_y;
-	int16_t acc_z;
+	union {
+		int16_t acc_xyz[3];
+		struct {
+			int16_t acc_x;
+			int16_t acc_y;
+			int16_t acc_z;
+		};
+	} __packed;
 	int16_t temp;
 	uint8_t selected_range;
 


### PR DESCRIPTION
Add a posibility to get values of accelerometer measurement for
all 3 axis of accelerometer with one channel_get().

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>