### PR TITLE
Bluetooth: tester: Revert "Fix an error response in tester"

### DIFF
--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -861,7 +861,7 @@ static void passkey_entry(const uint8_t *data, uint16_t len)
 	status = err < 0 ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS;
 
 rsp:
-	tester_rsp(BTP_SERVICE_ID_GAP, GAP_CONN_PARAM_UPDATE, CONTROLLER_INDEX,
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_PASSKEY_ENTRY, CONTROLLER_INDEX,
 		   status);
 }
 


### PR DESCRIPTION
This reverts commit 24784b14521379b047979987d31e42ccb4b87f7b.

The change appears to have been submitted twice in different PRs.
The correct change is: 76789883e2ca6e159e8caa080af0e0305ef848eb

Follow up to https://github.com/zephyrproject-rtos/zephyr/pull/30419#pullrequestreview-625926617