### PR TITLE
actions: Do not set the bug label on failed backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,4 +16,4 @@ jobs:
         uses: zephyrproject-rtos/action-backport@v1.1.1-1
         with:
           github_token: ${{ secrets.ZB_GITHUB_TOKEN }}
-          issue_labels: bug, backport
+          issue_labels: backport


### PR DESCRIPTION
Failing a backport is not a bug per-se. We create a GitHub issue to be
able to track the Pull Requests that failed to backport, but they should
not be considered bugs.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>