### PR TITLE
tests: bluetooth: init: Add integration_platforms

### DIFF
--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -77,18 +77,33 @@ tests:
     extra_args: CONF_FILE=prj_ctlr.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422 rv32m1_vega_ri5cy
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_4_0:
     extra_args: CONF_FILE=prj_ctlr_4_0.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_tiny:
     extra_args: CONF_FILE=prj_ctlr_tiny.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_dbg:
     extra_args: CONF_FILE=prj_ctlr_dbg.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_broadcaster:
     extra_args: CONF_FILE=prj_ctlr_broadcaster.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
@@ -105,54 +120,96 @@ tests:
     extra_args: CONF_FILE=prj_ctlr_observer.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422 rv32m1_vega_ri5cy
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_central:
     extra_args: CONF_FILE=prj_ctlr_central.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422 rv32m1_vega_ri5cy
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_central_priv:
     extra_args: CONF_FILE=prj_ctlr_central_priv.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422 rv32m1_vega_ri5cy
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - rv32m1_vega_ri5cy
   bluetooth.init.test_ctlr_broadcaster_ext:
     extra_args: CONF_FILE=prj_ctlr_broadcaster_ext.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_peripheral_ext:
     extra_args: CONF_FILE=prj_ctlr_peripheral_ext.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_peripheral_ext_priv:
     extra_args: CONF_FILE=prj_ctlr_peripheral_ext_priv.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_oberver_ext:
     extra_args: CONF_FILE=prj_ctlr_observer_ext.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_central_ext:
     extra_args: CONF_FILE=prj_ctlr_central_ext.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_central_ext_priv:
     extra_args: CONF_FILE=prj_ctlr_central_ext_priv.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_per_adv:
     extra_args: CONF_FILE=prj_ctlr_per_adv.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_per_sync:
     extra_args: CONF_FILE=prj_ctlr_per_sync.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_peripheral_iso:
     extra_args: CONF_FILE=prj_ctlr_peripheral_iso.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_ctlr_central_iso:
     extra_args: CONF_FILE=prj_ctlr_central_iso.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf51dk_nrf51422
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
   bluetooth.init.test_h5:
     extra_args: CONF_FILE=prj_h5.conf
     platform_allow: qemu_cortex_m3


### PR DESCRIPTION
Add integration_platforms to testcase.yaml to catch issues during CI.
With out this change these tests only get build during the nightly CI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>