### PR TITLE
lib/os: fix the problem of vsnprintk

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -259,7 +259,7 @@ int vsnprintk(char *str, size_t size, const char *fmt, va_list ap)
 
 	cbvprintf(str_out, &ctx, fmt, ap);
 
-	if (ctx.count < ctx.max) {
+	if (str != NULL && ctx.count < ctx.max) {
 		str[ctx.count] = '\0';
 	}
 


### PR DESCRIPTION
Fix the problem that the parameter str of vsnprintk is equal to NULL.

Signed-off-by: Ailson Jack <jackailson@foxmail.com>