### PR TITLE
driver: wdt: npcx: correct the drawing of npcx watchdog module.

### DIFF
--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -16,10 +16,10 @@
  * failure detection. Please refer the block diagram for more detail.
  *
  *            +---------------------+    +-----------------+
- *  LFCLK --->| T0 Prescale Counter |--->| 16-Bit T0 Timer |---+----> T0 Timer
- * (32kHz)    |     (TWCP 1:32)     |    |     (TWDT0)     |   |       Event
- *            +---------------------+    +-----------------+   |
- *  +----------------------------------------------------------+
+ *  LFCLK --->| T0 Prescale Counter |-+->| 16-Bit T0 Timer |--------> T0 Timer
+ * (32kHz)    |     (TWCP 1:32)     | |  |     (TWDT0)     |           Event
+ *            +---------------------+ |  +-----------------+
+ *  +---------------------------------+
  *  |
  *  |    +-------------------+    +-----------------+
  *  +--->| Watchdog Prescale |--->| 8-Bit Watchdog  |-----> Watchdog Event/Reset


### PR DESCRIPTION
The source clock of the watchdog module is selected to the input of T0
timer, not output. Correct the drawing in case confusing the users.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>