### PR TITLE
tests: logging: log_backend_fs: Fix coverity issues

### DIFF
--- a/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
+++ b/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
@@ -150,6 +150,8 @@ static void test_log_fs_file_size(void)
 		  sizeof(to_log);
 	     i++) {
 		rc = write_log_to_file(to_log, sizeof(to_log), NULL);
+		/* Written length not tracked here. */
+		ARG_UNUSED(rc);
 	}
 
 	zassert_equal(fs_stat(fname, &entry), 0, "Can not get file info.");
@@ -202,6 +204,8 @@ static void test_log_fs_files_max(void)
 		  sizeof(to_log) * (CONFIG_LOG_BACKEND_FS_FILES_LIMIT - 1);
 	     i++) {
 		rc = write_log_to_file(to_log, sizeof(to_log), NULL);
+		/* Written length not tracked here. */
+		ARG_UNUSED(rc);
 	}
 
 	rc = fs_opendir(&dir, CONFIG_LOG_BACKEND_FS_DIR);


### PR DESCRIPTION
Explicitly ignore return value. Coverity was reporting that return
value assigned to rc was never used.

Fixes #33821
Fixes #33787

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>