### PR TITLE
nrf9160 Non-Secure: use TF-M by default, and flash the combined binary when executing tests

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -8,6 +8,23 @@ if BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160NS
 config BOARD
 	default "nrf9160dk_nrf9160"
 
+# By default, if we build for a Non-Secure version of the board,
+# force building with TF-M as the Secure Execution Environment.
+
+config BUILD_WITH_TFM
+	default y if BOARD_NRF9160DK_NRF9160NS
+
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+# (when building in-tree tests).
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y if TEST_ARM_CORTEX_M
+
+endif # BUILD_WITH_TFM
+
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-

--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -4,6 +4,10 @@ if(CONFIG_BOARD_NRF9160DK_NRF9160NS)
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 
+if(CONFIG_TFM_FLASH_MERGED_BINARY)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+endif()
+
 board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160dk_nrf9160/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf9160/doc/index.rst
@@ -156,13 +156,17 @@ image. The Secure image can be built using either Zephyr or
 `Trusted Firmware M`_ (TF-M). Non-Secure firmware images are always built
 using Zephyr. The two alternatives are described below.
 
+.. note::
+
+   By default the Secure image for nRF9160 is built using TF-M.
+
 Building the Secure firmware using Zephyr
 -----------------------------------------
 
 The process requires the following steps:
 
 1. Build the Secure Zephyr application using ``-DBOARD=nrf9160dk_nrf9160`` and
-   ``CONFIG_TRUSTED_EXECUTION_SECURE=y`` in the the application project configuration file.
+   ``CONFIG_TRUSTED_EXECUTION_SECURE=y`` in the application project configuration file.
 2. Build the Non-Secure Zephyr application using ``-DBOARD=nrf9160dk_nrf9160ns``.
 3. Merge the two binaries together.
 
@@ -172,9 +176,11 @@ Building the Secure firmware with TF-M
 The process to build the Secure firmware image using TF-M and the Non-Secure
 firmware image using Zephyr requires the following action:
 
-* Build the Non-Secure Zephyr application
-   using ``-DBOARD=nrf9160dk_nrf9160ns`` and
-   ``CONFIG_BUILD_WITH_TFM=y`` in the application project configuration file.
+1. Build the Non-Secure Zephyr application
+   using ``-DBOARD=nrf9160dk_nrf9160ns``.
+   To invoke the building of TF-M the Zephyr build system requires the
+   Kconfig option ``BUILD_WITH_TFM`` to be enabled, which is done by
+   default when building Zephyr as a Non-Secure application.
    The Zephyr build system will perform the following steps automatically:
 
       * Build the Non-Secure firmware image as a regular Zephyr application

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
@@ -6,7 +6,7 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
-ram: 64
+ram: 88
 flash: 256
 supported:
   - gpio

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -214,8 +214,8 @@
 			/* Secure image memory */
 		};
 
-		sram0_bsd: image_bsd@20010000 {
-			/* BSD (shared) memory */
+		sram0_modem: image_modem@20016000 {
+			/* Modem (shared) memory */
 		};
 
 		sram0_ns: image_ns@20020000 {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
@@ -39,18 +39,20 @@
 
 /* Default SRAM planning when building for nRF9160 with
  * ARM TrustZone-M support
- * - Lowest 64 kB SRAM allocated to Secure image (sram0_s).
- * - 64 kB SRAM reserved for and used by the BSD socket
- *   library (sram0_bsd).
+ * - Lowest 88 kB SRAM allocated to Secure image (sram0_s).
+ * - 40 kB SRAM reserved for and used by the modem library
+ *   (sram0_modem). This memory is Non-Secure.
  * - Upper 128 kB allocated to Non-Secure image (sram0_ns).
+ *   When building with TF-M, both sram0_modem and sram0_ns
+ *   are allocated to the Non-Secure image.
  */
 
 &sram0_s {
-	reg = <0x20000000 DT_SIZE_K(64)>;
+	reg = <0x20000000 DT_SIZE_K(88)>;
 };
 
-&sram0_bsd {
-	reg = <0x20010000 DT_SIZE_K(64)>;
+&sram0_modem {
+	reg = <0x20016000 DT_SIZE_K(40)>;
 };
 
 &sram0_ns {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.dts
@@ -15,3 +15,8 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
+
+/* Disable UART1, because it is used by default in TF-M */
+&uart1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Adding TF-M as the default Secure Firmware solution for nRF9160 Non-Secure builds.
- Requires re-sizing the default secure partition size in device tree, to match the TF-M secure firmware size.