### PR TITLE
lib: os: cbprintf: Suppress coverity false positive

### DIFF
--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -127,7 +127,8 @@ extern "C" {
 	_Generic((v), \
 		float : sizeof(double), \
 		default : \
-			sizeof((v)+0) \
+			/* coverity[bad_sizeof] */ \
+			sizeof((v) + 0) \
 		)
 
 static inline void cbprintf_wcpy(int *dst, int *src, size_t len)


### PR DESCRIPTION
Coverity is complaining about sizeof(v + 0) and it is used
here intentionally to promote variable. Added comment that should
suppress this error in the future.

Note that this macro will be used in all log messages so without
solving it before logging v2 is merged there will be a flood of
errors.

Fixes #33840.
Fixes #33815.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>