### PR TITLE
cmake: arm64: Bail out if the old SDK is used

### DIFF
--- a/cmake/verify-toolchain.cmake
+++ b/cmake/verify-toolchain.cmake
@@ -16,7 +16,11 @@
 # FORMAT=json: Print the output as a json formatted string, useful for Python
 
 # This is the minimum required Zephyr-SDK version which supports CMake package
-set(TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION 0.11.3)
+if("${ARCH}" STREQUAL "arm64")
+  set(TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION 0.12.4)
+else()
+  set(TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION 0.12)
+endif()
 
 # Set internal variables if set in environment.
 if(NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT)
@@ -67,12 +71,12 @@ if(("zephyr" STREQUAL ${ZEPHYR_TOOLCHAIN_VARIANT}) OR
     # To support Zephyr SDK tools (DTC, and other tools) with 3rd party toolchains
     # then we keep track of current toolchain variant.
     set(ZEPHYR_CURRENT_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT})
-    find_package(Zephyr-sdk ${TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION} QUIET HINTS $ENV{ZEPHYR_SDK_INSTALL_DIR})
+    find_package(Zephyr-sdk ${TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION} REQUIRED QUIET HINTS $ENV{ZEPHYR_SDK_INSTALL_DIR})
     if(DEFINED ZEPHYR_CURRENT_TOOLCHAIN_VARIANT)
       set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_CURRENT_TOOLCHAIN_VARIANT})
     endif()
   else()
-    find_package(Zephyr-sdk ${TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION} QUIET PATHS
+    find_package(Zephyr-sdk ${TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION} REQUIRED QUIET PATHS
                  /usr
 		 /usr/local
 		 /opt


### PR DESCRIPTION
After the ARM/ARM64 split the SDK 0.12.4 is needed to be able to compile
the ARM64 arch code. Bail out if an old SDK is detected at compile time.

Closes: #34046 