### PR TITLE
net: doc: Add net_capture API documentation

### DIFF
--- a/doc/guides/networking/network_monitoring.rst
+++ b/doc/guides/networking/network_monitoring.rst
@@ -192,7 +192,8 @@ be cleared like this:
    net capture cleanup
 
 It is not necessary to use ``net-shell`` for configuring the monitoring.
-The network capture API functions can be called by the application if needed.
+The :ref:`network capture API <net_capture_interface>` functions can be called
+by the application if needed.
 
 Wireshark Configuration
 ***********************

--- a/doc/reference/networking/apis.rst
+++ b/doc/reference/networking/apis.rst
@@ -18,3 +18,4 @@ Network APIs
    socks5.rst
    trickle.rst
    websocket.rst
+   capture.rst

--- a/doc/reference/networking/capture.rst
+++ b/doc/reference/networking/capture.rst
@@ -1,0 +1,29 @@
+.. _net_capture_interface:
+
+Network Packet Capture
+######################
+
+.. contents::
+    :local:
+    :depth: 2
+
+Overview
+********
+
+The ``net_capture`` API allows user to monitor the network
+traffic in one of the Zephyr network interfaces and send that traffic to
+external system for analysis. The monitoring can be setup either manually
+using ``net-shell`` or automatically by using the ``net_capture`` API.
+
+Sample usage
+************
+
+See :ref:`Network capture sample application <net-capture-sample>` and
+:ref:`network_monitoring` for details.
+
+
+API Reference
+*************
+
+.. doxygengroup:: net_capture
+   :project: Zephyr

--- a/include/net/capture.h
+++ b/include/net/capture.h
@@ -21,7 +21,7 @@ extern "C" {
 
 /**
  * @brief Network packet capture support functions
- * @defgroup capture Network packet capture
+ * @defgroup net_capture Network packet capture
  * @ingroup networking
  * @{
  */


### PR DESCRIPTION
The net_capture API documentation was not referenced by
network documentation so the API reference documentation
was not generated for it. This commit adds links to the
net_capture API.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>