### PR TITLE
drivers: sensors: stmemsc: Don't use i2c_burst_write on Nordic

### DIFF
--- a/drivers/sensor/stmemsc/stmemsc_i2c.c
+++ b/drivers/sensor/stmemsc/stmemsc_i2c.c
@@ -8,6 +8,7 @@
  */
 
 #include "stmemsc.h"
+#include <string.h>
 
 int stmemsc_i2c_read(const struct stmemsc_cfg_i2c *stmemsc,
 			     uint8_t reg_addr, uint8_t *value, uint8_t len)
@@ -19,6 +20,12 @@ int stmemsc_i2c_read(const struct stmemsc_cfg_i2c *stmemsc,
 int stmemsc_i2c_write(const struct stmemsc_cfg_i2c *stmemsc,
 			      uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	return i2c_burst_write(stmemsc->bus, stmemsc->i2c_slv_addr,
-			       reg_addr, value, len);
+	/* Largest stmemsc driver write is 9 bytes */
+	uint8_t buffer[10];
+
+	__ASSERT((1U + len) <= sizeof(buffer), "stmemsc i2c buffer too small");
+	buffer[0] = reg_addr;
+	memcpy(buffer + 1, value, len);
+	return i2c_write(stmemsc->bus, buffer, 1 + len,
+			 stmemsc->i2c_slv_addr);
 }


### PR DESCRIPTION
The TWIM peripheral in Nordic SoCs (nRF5{1,2,3}) cannot correctly
support the i2c_burst_write API. Using it results in a repeated start,
rather than a single I2C write transaction.

This implements the workaround noted in #20154.

Fixes #33440

Signed-off-by: Rich Barlow <rich@bennellick.com>