### PR TITLE
log: Align the log_strdup_buf properly

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -50,7 +50,7 @@ LOG_MODULE_REGISTER(log);
 struct log_strdup_buf {
 	atomic_t refcount;
 	char buf[CONFIG_LOG_STRDUP_MAX_STRING + 1]; /* for termination */
-};
+} __aligned(sizeof(uintptr_t));
 
 #define LOG_STRDUP_POOL_BUFFER_SIZE \
 	(sizeof(struct log_strdup_buf) * CONFIG_LOG_STRDUP_BUF_COUNT)


### PR DESCRIPTION
The k_mem_slab_init() calls create_free_list() which checks
the slab block alignment. Noticed with Intel ehl_crb board,
which is 64-bit architecture, that the k_mem_slab_init() fails
because the log_strdup_buf items were not aligned properly.
This commit adds the alignment requirement to log_strdup_buf so
that the elements are alignment properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>