### PR TITLE
dts: npcx: Fixed the name of nodes in device-tree files.

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -35,14 +35,14 @@
 	};
 
 	power-states {
-		suspend_to_idle0: suspend_to_idle0 {
+		suspend_to_idle0: suspend-to-idle0 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
 			substate-id = <0>;
 			min-residency-us = <1000>;
 		};
 
-		suspend_to_idle1: suspend_to_idle1 {
+		suspend_to_idle1: suspend-to-idle1 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
 			substate-id = <1>;
@@ -93,6 +93,6 @@
 	status = "okay";
 	pinctrl-0 = <&alt3_ta1_sl1>; /* Use TA1_SL1 (PIN40) as input pin */
 	port = <NPCX_TACH_PORT_A>; /* port-A is selected */
-	sample_clk = <NPCX_TACH_FREQ_LFCLK>; /* Use LFCLK as sampling clock */
-	pulses_per_round = <1>; /* number of pulses per round of encoder */
+	sample-clk = <NPCX_TACH_FREQ_LFCLK>; /* Use LFCLK as sampling clock */
+	pulses-per-round = <1>; /* number of pulses per round of encoder */
 };

--- a/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-alts-map.dtsi
@@ -8,146 +8,362 @@
 	npcx7_alts_map {
 		compatible = "nuvoton,npcx-pinctrl-conf";
 
-		/******** SCFG device alternative table *******/
+		/* SCFG device alternative table */
 		/* SCFG DEVALT 0 */
-		alt0_spip_sl:      alt00     { alts = <&scfg 0x00 0x0 0>; };
-		alt0_gpio_no_spip: alt03_inv { alts = <&scfg 0x00 0x3 1>; };
-		/* FPIP (FIU SPI Interface Peripheral) for external flash. */
-		alt0_gpio_no_fpip: alt07_inv { alts = <&scfg 0x00 0x7 1>; };
+		alt0_spip_sl: alt00 {
+			alts = <&scfg 0x00 0x0 0>;
+		};
+		alt0_gpio_no_spip: alt03-inv {
+			alts = <&scfg 0x00 0x3 1>;
+		};
+		alt0_gpio_no_fpip: alt07-inv {
+			/* FPIP (FIU SPI Interface Peripheral) for external flash. */
+			alts = <&scfg 0x00 0x7 1>;
+		};
 
 		/* SCFG DEVALT 1 */
-		alt1_kbrst_sl:     alt10     { alts = <&scfg 0x01 0x0 0>; };
-		alt1_a20m_sl:      alt11     { alts = <&scfg 0x01 0x1 0>; };
-		alt1_smi_sl:       alt12     { alts = <&scfg 0x01 0x2 0>; };
-		alt1_ec_sci_sl:    alt13     { alts = <&scfg 0x01 0x3 0>; };
-		alt1_no_pwrgd:     alt14_inv { alts = <&scfg 0x01 0x4 1>; };
-		alt1_pwroff:       alt15     { alts = <&scfg 0x01 0x5 0>; };
-		alt1_clkrn_sl:     alt16     { alts = <&scfg 0x01 0x6 0>; };
-		alt1_no_lpc_espi:  alt17_inv { alts = <&scfg 0x01 0x7 1>; };
+		alt1_kbrst_sl: alt10 {
+			alts = <&scfg 0x01 0x0 0>;
+		};
+		alt1_a20m_sl: alt11 {
+			alts = <&scfg 0x01 0x1 0>;
+		};
+		alt1_smi_sl: alt12 {
+			alts = <&scfg 0x01 0x2 0>;
+		};
+		alt1_ec_sci_sl: alt13 {
+			alts = <&scfg 0x01 0x3 0>;
+		};
+		alt1_no_pwrgd: alt14-inv {
+			alts = <&scfg 0x01 0x4 1>;
+		};
+		alt1_pwroff: alt15 {
+			alts = <&scfg 0x01 0x5 0>;
+		};
+		alt1_clkrn_sl: alt16 {
+			alts = <&scfg 0x01 0x6 0>;
+		};
+		alt1_no_lpc_espi: alt17-inv {
+			alts = <&scfg 0x01 0x7 1>;
+		};
 
 		/* SCFG DEVALT 2 */
-		alt2_i2c0_0_sl:    alt20     { alts = <&scfg 0x02 0x0 0>; };
-		alt2_i2c7_0_sl:    alt21     { alts = <&scfg 0x02 0x1 0>; };
-		alt2_i2c1_0_sl:    alt22     { alts = <&scfg 0x02 0x2 0>; };
-		alt2_i2c6_0_sl:    alt23     { alts = <&scfg 0x02 0x3 0>; };
-		alt2_i2c2_0_sl:    alt24     { alts = <&scfg 0x02 0x4 0>; };
-		alt2_i2c5_0_sl:    alt25     { alts = <&scfg 0x02 0x5 0>; };
-		alt2_i2c3_0_sl:    alt26     { alts = <&scfg 0x02 0x6 0>; };
+		alt2_i2c0_0_sl: alt20 {
+			alts = <&scfg 0x02 0x0 0>;
+		};
+		alt2_i2c7_0_sl: alt21 {
+			alts = <&scfg 0x02 0x1 0>;
+		};
+		alt2_i2c1_0_sl: alt22 {
+			alts = <&scfg 0x02 0x2 0>;
+		};
+		alt2_i2c6_0_sl: alt23 {
+			alts = <&scfg 0x02 0x3 0>;
+		};
+		alt2_i2c2_0_sl: alt24 {
+			alts = <&scfg 0x02 0x4 0>;
+		};
+		alt2_i2c5_0_sl: alt25 {
+			alts = <&scfg 0x02 0x5 0>;
+		};
+		alt2_i2c3_0_sl: alt26 {
+			alts = <&scfg 0x02 0x6 0>;
+		};
 
 		/* SCFG DEVALT 3 */
-		alt3_ps2_0_sl:     alt30     { alts = <&scfg 0x03 0x0 0>; };
-		alt3_ps2_1_sl:     alt31     { alts = <&scfg 0x03 0x1 0>; };
-		alt3_ps2_2_sl:     alt32     { alts = <&scfg 0x03 0x2 0>; };
-		alt3_ta1_sl1:      alt34     { alts = <&scfg 0x03 0x4 0>; };
-		alt3_tb1_sl1:      alt35     { alts = <&scfg 0x03 0x5 0>; };
-		alt3_ta2_sl1:      alt36     { alts = <&scfg 0x03 0x6 0>; };
+		alt3_ps2_0_sl: alt30 {
+			alts = <&scfg 0x03 0x0 0>;
+		};
+		alt3_ps2_1_sl: alt31 {
+			alts = <&scfg 0x03 0x1 0>;
+		};
+		alt3_ps2_2_sl: alt32 {
+			alts = <&scfg 0x03 0x2 0>;
+		};
+		alt3_ta1_sl1: alt34 {
+			alts = <&scfg 0x03 0x4 0>;
+		};
+		alt3_tb1_sl1: alt35 {
+			alts = <&scfg 0x03 0x5 0>;
+		};
+		alt3_ta2_sl1: alt36 {
+			alts = <&scfg 0x03 0x6 0>;
+		};
 
 		/* SCFG DEVALT 4 */
-		alt4_pwm0_sl:      alt40     { alts = <&scfg 0x04 0x0 0>; };
-		alt4_pwm1_sl:      alt41     { alts = <&scfg 0x04 0x1 0>; };
-		alt4_pwm2_sl:      alt42     { alts = <&scfg 0x04 0x2 0>; };
-		alt4_pwm3_sl:      alt43     { alts = <&scfg 0x04 0x3 0>; };
-		alt4_pwm4_sl:      alt44     { alts = <&scfg 0x04 0x4 0>; };
-		alt4_pwm5_sl:      alt45     { alts = <&scfg 0x04 0x5 0>; };
-		alt4_pwm6_sl:      alt46     { alts = <&scfg 0x04 0x6 0>; };
-		alt4_pwm7_sl:      alt47     { alts = <&scfg 0x04 0x7 0>; };
+		alt4_pwm0_sl: alt40 {
+			alts = <&scfg 0x04 0x0 0>;
+		};
+		alt4_pwm1_sl: alt41 {
+			alts = <&scfg 0x04 0x1 0>;
+		};
+		alt4_pwm2_sl: alt42 {
+			alts = <&scfg 0x04 0x2 0>;
+		};
+		alt4_pwm3_sl: alt43 {
+			alts = <&scfg 0x04 0x3 0>;
+		};
+		alt4_pwm4_sl: alt44 {
+			alts = <&scfg 0x04 0x4 0>;
+		};
+		alt4_pwm5_sl: alt45 {
+			alts = <&scfg 0x04 0x5 0>;
+		};
+		alt4_pwm6_sl: alt46 {
+			alts = <&scfg 0x04 0x6 0>;
+		};
+		alt4_pwm7_sl: alt47 {
+			alts = <&scfg 0x04 0x7 0>;
+		};
 
 		/* SCFG DEVALT 5 */
-		alt5_trace_en:     alt50     { alts = <&scfg 0x05 0x0 0>; };
-		alt5_njen1_en:     alt51     { alts = <&scfg 0x05 0x1 1>; };
-		alt5_njen0_en:     alt52     { alts = <&scfg 0x05 0x2 1>; };
-		alt5_strace_en:    alt54     { alts = <&scfg 0x05 0x4 0>; };
+		alt5_trace_en: alt50 {
+			alts = <&scfg 0x05 0x0 0>;
+		};
+		alt5_njen1_en: alt51-inv {
+			alts = <&scfg 0x05 0x1 1>;
+		};
+		alt5_njen0_en: alt52-inv {
+			alts = <&scfg 0x05 0x2 1>;
+		};
+		alt5_strace_en: alt54 {
+			alts = <&scfg 0x05 0x4 0>;
+		};
 
 		/* SCFG DEVALT 6 */
-		alt6_adc0_sl:      alt60     { alts = <&scfg 0x06 0x0 0>; };
-		alt6_adc1_sl:      alt61     { alts = <&scfg 0x06 0x1 0>; };
-		alt6_adc2_sl:      alt62     { alts = <&scfg 0x06 0x2 0>; };
-		alt6_adc3_sl:      alt63     { alts = <&scfg 0x06 0x3 0>; };
-		alt6_adc4_sl:      alt64     { alts = <&scfg 0x06 0x4 0>; };
-		alt6_i2c6_1_sl:    alt65     { alts = <&scfg 0x06 0x5 0>; };
-		alt6_i2c5_1_sl:    alt66     { alts = <&scfg 0x06 0x6 0>; };
-		alt6_i2c4_1_sl:    alt67     { alts = <&scfg 0x06 0x7 0>; };
+		alt6_adc0_sl: alt60 {
+			alts = <&scfg 0x06 0x0 0>;
+		};
+		alt6_adc1_sl: alt61 {
+			alts = <&scfg 0x06 0x1 0>;
+		};
+		alt6_adc2_sl: alt62 {
+			alts = <&scfg 0x06 0x2 0>;
+		};
+		alt6_adc3_sl: alt63 {
+			alts = <&scfg 0x06 0x3 0>;
+		};
+		alt6_adc4_sl: alt64 {
+			alts = <&scfg 0x06 0x4 0>;
+		};
+		alt6_i2c6_1_sl: alt65 {
+			alts = <&scfg 0x06 0x5 0>;
+		};
+		alt6_i2c5_1_sl: alt66 {
+			alts = <&scfg 0x06 0x6 0>;
+		};
+		alt6_i2c4_1_sl: alt67 {
+			alts = <&scfg 0x06 0x7 0>;
+		};
 
 		/* SCFG DEVALT 7 */
-		alt7_no_ksi0_sl:   alt70_inv { alts = <&scfg 0x07 0x0 1>; };
-		alt7_no_ksi1_sl:   alt71_inv { alts = <&scfg 0x07 0x1 1>; };
-		alt7_no_ksi2_sl:   alt72_inv { alts = <&scfg 0x07 0x2 1>; };
-		alt7_no_ksi3_sl:   alt73_inv { alts = <&scfg 0x07 0x3 1>; };
-		alt7_no_ksi4_sl:   alt74_inv { alts = <&scfg 0x07 0x4 1>; };
-		alt7_no_ksi5_sl:   alt75_inv { alts = <&scfg 0x07 0x5 1>; };
-		alt7_no_ksi6_sl:   alt76_inv { alts = <&scfg 0x07 0x6 1>; };
-		alt7_no_ksi7_sl:   alt77_inv { alts = <&scfg 0x07 0x7 1>; };
+		alt7_no_ksi0_sl: alt70-inv {
+			alts = <&scfg 0x07 0x0 1>;
+		};
+		alt7_no_ksi1_sl: alt71-inv {
+			alts = <&scfg 0x07 0x1 1>;
+		};
+		alt7_no_ksi2_sl: alt72-inv {
+			alts = <&scfg 0x07 0x2 1>;
+		};
+		alt7_no_ksi3_sl: alt73-inv {
+			alts = <&scfg 0x07 0x3 1>;
+		};
+		alt7_no_ksi4_sl: alt74-inv {
+			alts = <&scfg 0x07 0x4 1>;
+		};
+		alt7_no_ksi5_sl: alt75-inv {
+			alts = <&scfg 0x07 0x5 1>;
+		};
+		alt7_no_ksi6_sl: alt76-inv {
+			alts = <&scfg 0x07 0x6 1>;
+		};
+		alt7_no_ksi7_sl: alt77-inv {
+			alts = <&scfg 0x07 0x7 1>;
+		};
 
 		/* SCFG DEVALT 8 */
-		alt8_no_kso00_sl:  alt80_inv { alts = <&scfg 0x08 0x0 1>; };
-		alt8_no_kso01_sl:  alt81_inv { alts = <&scfg 0x08 0x1 1>; };
-		alt8_no_kso02_sl:  alt82_inv { alts = <&scfg 0x08 0x2 1>; };
-		alt8_no_kso03_sl:  alt83_inv { alts = <&scfg 0x08 0x3 1>; };
-		alt8_no_kso04_sl:  alt84_inv { alts = <&scfg 0x08 0x4 1>; };
-		alt8_no_kso05_sl:  alt85_inv { alts = <&scfg 0x08 0x5 1>; };
-		alt8_no_kso06_sl:  alt86_inv { alts = <&scfg 0x08 0x6 1>; };
-		alt8_no_kso07_sl:  alt87_inv { alts = <&scfg 0x08 0x7 1>; };
+		alt8_no_kso00_sl: alt80-inv {
+			alts = <&scfg 0x08 0x0 1>;
+		};
+		alt8_no_kso01_sl: alt81-inv {
+			alts = <&scfg 0x08 0x1 1>;
+		};
+		alt8_no_kso02_sl: alt82-inv {
+			alts = <&scfg 0x08 0x2 1>;
+		};
+		alt8_no_kso03_sl: alt83-inv {
+			alts = <&scfg 0x08 0x3 1>;
+		};
+		alt8_no_kso04_sl: alt84-inv {
+			alts = <&scfg 0x08 0x4 1>;
+		};
+		alt8_no_kso05_sl: alt85-inv {
+			alts = <&scfg 0x08 0x5 1>;
+		};
+		alt8_no_kso06_sl: alt86-inv {
+			alts = <&scfg 0x08 0x6 1>;
+		};
+		alt8_no_kso07_sl: alt87-inv {
+			alts = <&scfg 0x08 0x7 1>;
+		};
 
 		/* SCFG DEVALT 9 */
-		alt9_no_kso08_sl:  alt90_inv { alts = <&scfg 0x09 0x0 1>; };
-		alt9_no_kso09_sl:  alt91_inv { alts = <&scfg 0x09 0x1 1>; };
-		alt9_no_kso10_sl:  alt92_inv { alts = <&scfg 0x09 0x2 1>; };
-		alt9_no_kso11_sl:  alt93_inv { alts = <&scfg 0x09 0x3 1>; };
-		alt9_no_kso12_sl:  alt94_inv { alts = <&scfg 0x09 0x4 1>; };
-		alt9_no_kso13_sl:  alt95_inv { alts = <&scfg 0x09 0x5 1>; };
-		alt9_no_kso14_sl:  alt96_inv { alts = <&scfg 0x09 0x6 1>; };
-		alt9_no_kso15_sl:  alt97_inv { alts = <&scfg 0x09 0x7 1>; };
+		alt9_no_kso08_sl: alt90-inv {
+			alts = <&scfg 0x09 0x0 1>;
+		};
+		alt9_no_kso09_sl: alt91-inv {
+			alts = <&scfg 0x09 0x1 1>;
+		};
+		alt9_no_kso10_sl: alt92-inv {
+			alts = <&scfg 0x09 0x2 1>;
+		};
+		alt9_no_kso11_sl: alt93-inv {
+			alts = <&scfg 0x09 0x3 1>;
+		};
+		alt9_no_kso12_sl: alt94-inv {
+			alts = <&scfg 0x09 0x4 1>;
+		};
+		alt9_no_kso13_sl: alt95-inv {
+			alts = <&scfg 0x09 0x5 1>;
+		};
+		alt9_no_kso14_sl: alt96-inv {
+			alts = <&scfg 0x09 0x6 1>;
+		};
+		alt9_no_kso15_sl: alt97-inv {
+			alts = <&scfg 0x09 0x7 1>;
+		};
 
 		/* SCFG DEVALT A */
-		alta_no_kso16_sl:  alta0_inv { alts = <&scfg 0x0A 0x0 1>; };
-		alta_no_kso17_sl:  alta1_inv { alts = <&scfg 0x0A 0x1 1>; };
-		alta_32k_out_sl:   alta2     { alts = <&scfg 0x0A 0x2 0>; };
-		alta_32kclkin_sl:  alta3     { alts = <&scfg 0x0A 0x3 0>; };
-		alta_no_vcc1_rst:  alta4_inv { alts = <&scfg 0x0A 0x4 1>; };
-		alta_uart2_sl:     alta5     { alts = <&scfg 0x0A 0x5 0>; };
-		alta_no_peci_en:   alta6_inv { alts = <&scfg 0x0A 0x6 1>; };
-		alta_uart1_sl1:    alta7     { alts = <&scfg 0x0A 0x7 0>; };
+		alta_no_kso16_sl: alta0-inv {
+			alts = <&scfg 0x0A 0x0 1>;
+		};
+		alta_no_kso17_sl: alta1-inv {
+			alts = <&scfg 0x0A 0x1 1>;
+		};
+		alta_32k_out_sl: alta2 {
+			alts = <&scfg 0x0A 0x2 0>;
+		};
+		alta_32kclkin_sl: alta3 {
+			alts = <&scfg 0x0A 0x3 0>;
+		};
+		alta_no_vcc1_rst: alta4-inv {
+			alts = <&scfg 0x0A 0x4 1>;
+		};
+		alta_uart2_sl: alta5 {
+			alts = <&scfg 0x0A 0x5 0>;
+		};
+		alta_no_peci_en: alta6-inv {
+			alts = <&scfg 0x0A 0x6 1>;
+		};
+		alta_uart1_sl1: alta7 {
+			alts = <&scfg 0x0A 0x7 0>;
+		};
 
 		/* SCFG DEVALT B */
-		altb_rxd_sl:       altb0     { alts = <&scfg 0x0B 0x0 0>; };
-		altb_txd_sl:       altb1     { alts = <&scfg 0x0B 0x1 0>; };
-		altb_rts_sl:       altb2     { alts = <&scfg 0x0B 0x2 0>; };
-		altb_cts_sl:       altb3     { alts = <&scfg 0x0B 0x3 0>; };
-		altb_ri_sl:        altb4     { alts = <&scfg 0x0B 0x4 0>; };
-		altb_dtr_bout_sl:  altb5     { alts = <&scfg 0x0B 0x5 0>; };
-		altb_dcd_sl:       altb6     { alts = <&scfg 0x0B 0x6 0>; };
-		altb_dsr_sl:       altb7     { alts = <&scfg 0x0B 0x7 0>; };
+		altb_rxd_sl: altb0 {
+			alts = <&scfg 0x0B 0x0 0>;
+		};
+		altb_txd_sl: altb1 {
+			alts = <&scfg 0x0B 0x1 0>;
+		};
+		altb_rts_sl: altb2 {
+			alts = <&scfg 0x0B 0x2 0>;
+		};
+		altb_cts_sl: altb3 {
+			alts = <&scfg 0x0B 0x3 0>;
+		};
+		altb_ri_sl:  altb4 {
+			alts = <&scfg 0x0B 0x4 0>;
+		};
+		altb_dtr_bout_sl: altb5 {
+			alts = <&scfg 0x0B 0x5 0>;
+		};
+		altb_dcd_sl: altb6 {
+			alts = <&scfg 0x0B 0x6 0>;
+		};
+		altb_dsr_sl: altb7 {
+			alts = <&scfg 0x0B 0x7 0>;
+		};
 
 		/* SCFG DEVALT C */
-		altc_uart1_sl2:    altc0     { alts = <&scfg 0x0C 0x0 0>; };
-		altc_shi_sl:       altc1     { alts = <&scfg 0x0C 0x1 0>; };
-		altc_ps2_3_sl2:    altc3     { alts = <&scfg 0x0C 0x3 0>; };
-		altc_ta1_sl2:      altc4     { alts = <&scfg 0x0C 0x4 0>; };
-		altc_tb1_sl2:      altc5     { alts = <&scfg 0x0C 0x5 0>; };
-		altc_ta2_sl2:      altc6     { alts = <&scfg 0x0C 0x6 0>; };
-		altc_tb2_sl2:      altc7     { alts = <&scfg 0x0C 0x7 0>; };
+		altc_uart1_sl2: altc0 {
+			alts = <&scfg 0x0C 0x0 0>;
+		};
+		altc_shi_sl: altc1 {
+			alts = <&scfg 0x0C 0x1 0>;
+		};
+		altc_ps2_3_sl2: altc3 {
+			alts = <&scfg 0x0C 0x3 0>;
+		};
+		altc_ta1_sl2: altc4 {
+			alts = <&scfg 0x0C 0x4 0>;
+		};
+		altc_tb1_sl2: altc5 {
+			alts = <&scfg 0x0C 0x5 0>;
+		};
+		altc_ta2_sl2: altc6 {
+			alts = <&scfg 0x0C 0x6 0>;
+		};
+		altc_tb2_sl2: altc7 {
+			alts = <&scfg 0x0C 0x7 0>;
+		};
 
 		/* SCFG DEVALT D */
-		altd_psl_in1_ahi:  altd0     { alts = <&scfg 0x0D 0x0 0>; };
-		altd_npsl_in1_sl:  altd1_inv { alts = <&scfg 0x0D 0x1 1>; };
-		altd_psl_in2_ahi:  altd2     { alts = <&scfg 0x0D 0x2 0>; };
-		altd_npsl_in2_sl:  altd3_inv { alts = <&scfg 0x0D 0x3 1>; };
-		altd_psl_in3_ahi:  altd4     { alts = <&scfg 0x0D 0x4 0>; };
-		altd_psl_in3_sl:   altd5     { alts = <&scfg 0x0D 0x5 0>; };
-		altd_psl_in4_ahi:  altd6     { alts = <&scfg 0x0D 0x6 0>; };
-		altd_psl_in4_sl:   altd7     { alts = <&scfg 0x0D 0x7 0>; };
+		altd_psl_in1_ahi: altd0 {
+			alts = <&scfg 0x0D 0x0 0>;
+		};
+		altd_npsl_in1_sl: altd1-inv {
+			alts = <&scfg 0x0D 0x1 1>;
+		};
+		altd_psl_in2_ahi: altd2 {
+			alts = <&scfg 0x0D 0x2 0>;
+		};
+		altd_npsl_in2_sl: altd3-inv {
+			alts = <&scfg 0x0D 0x3 1>;
+		};
+		altd_psl_in3_ahi: altd4 {
+			alts = <&scfg 0x0D 0x4 0>;
+		};
+		altd_psl_in3_sl: altd5 {
+			alts = <&scfg 0x0D 0x5 0>;
+		};
+		altd_psl_in4_ahi: altd6 {
+			alts = <&scfg 0x0D 0x6 0>;
+		};
+		altd_psl_in4_sl: altd7 {
+			alts = <&scfg 0x0D 0x7 0>;
+		};
 
 		/* SCFG DEVALT E */
-		alte_wov_sl:       alte0     { alts = <&scfg 0x0E 0x0 0>; };
-		alte_i2s_sl:       alte1     { alts = <&scfg 0x0E 0x1 0>; };
-		alte_dmclk_fast:   alte2     { alts = <&scfg 0x0E 0x2 0>; };
+		alte_wov_sl: alte0 {
+			alts = <&scfg 0x0E 0x0 0>;
+		};
+		alte_i2s_sl: alte1 {
+			alts = <&scfg 0x0E 0x1 0>;
+		};
+		alte_dmclk_fast: alte2 {
+			alts = <&scfg 0x0E 0x2 0>;
+		};
 
 		/* SCFG DEVALT F */
-		altf_adc5_sl:      altf0     { alts = <&scfg 0x0F 0x0 0>; };
-		altf_adc6_sl:      altf1     { alts = <&scfg 0x0F 0x1 0>; };
-		altf_adc7_sl:      altf2     { alts = <&scfg 0x0F 0x2 0>; };
-		altf_adc8_sl:      altf3     { alts = <&scfg 0x0F 0x3 0>; };
-		altf_adc9_sl:      altf4     { alts = <&scfg 0x0F 0x4 0>; };
-		altf_shi_new:      altf7     { alts = <&scfg 0x0F 0x7 0>; };
+		altf_adc5_sl: altf0 {
+			alts = <&scfg 0x0F 0x0 0>;
+		};
+		altf_adc6_sl: altf1 {
+			alts = <&scfg 0x0F 0x1 0>;
+		};
+		altf_adc7_sl: altf2 {
+			alts = <&scfg 0x0F 0x2 0>;
+		};
+		altf_adc8_sl: altf3 {
+			alts = <&scfg 0x0F 0x3 0>;
+		};
+		altf_adc9_sl: altf4 {
+			alts = <&scfg 0x0F 0x4 0>;
+		};
+		altf_shi_new: altf7 {
+			alts = <&scfg 0x0F 0x7 0>;
+		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx7-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-espi-vws-map.dtsi
@@ -28,66 +28,100 @@
  */
 
 / {
-	npcx7_espi_vws_map {
+	npcx7-espi-vws-map {
 		compatible = "nuvoton,npcx-espi-vw-conf";
 
 		/* eSPI Virtual Vire (VW) input configuration */
 		/* index 02h (In) */
-		vw_slp_s3 { vw_reg =
-			<NPCX_VWEVMS0 0x01>; wui_map = <&wui_vw_slp_s3>; };
-		vw_slp_s4 { vw_reg =
-			<NPCX_VWEVMS0 0x02>; wui_map = <&wui_vw_slp_s4>; };
-		vw_slp_s5 { vw_reg =
-			<NPCX_VWEVMS0 0x04>; wui_map = <&wui_vw_slp_s5>; };
+		vw-slp-s3 {
+			vw_reg = <NPCX_VWEVMS0 0x01>; wui_map = <&wui_vw_slp_s3>;
+		};
+		vw-slp-s4 {
+			vw_reg = <NPCX_VWEVMS0 0x02>; wui_map = <&wui_vw_slp_s4>;
+		};
+		vw-slp-s5 {
+			vw_reg = <NPCX_VWEVMS0 0x04>; wui_map = <&wui_vw_slp_s5>;
+		};
 
 		/* index 03h (In) */
-		vw_sus_stat { vw_reg =
-			<NPCX_VWEVMS1 0x01>; wui_map = <&wui_vw_sus_stat>; };
-		vw_plt_rst { vw_reg =
-			<NPCX_VWEVMS1 0x02>; wui_map = <&wui_vw_plt_rst>; };
-		vw_oob_rst_warn { vw_reg =
-			<NPCX_VWEVMS1 0x04>; wui_map = <&wui_vw_oob_rst_warn>;};
+		vw-sus-stat {
+			vw_reg = <NPCX_VWEVMS1 0x01>; wui_map = <&wui_vw_sus_stat>;
+		};
+		vw-plt-rst {
+			vw_reg = <NPCX_VWEVMS1 0x02>; wui_map = <&wui_vw_plt_rst>;
+		};
+		vw-oob-rst-warn {
+			vw_reg = <NPCX_VWEVMS1 0x04>; wui_map = <&wui_vw_oob_rst_warn>;
+		};
 
 		/* index 07h (In) */
-		vw_host_rst_warn { vw_reg =
-			<NPCX_VWEVMS2 0x01>; wui_map =<&wui_vw_host_rst_warn>;};
+		vw-host-rst-warn {
+			vw_reg = <NPCX_VWEVMS2 0x01>; wui_map =<&wui_vw_host_rst_warn>;
+		};
 
 		/* index 41h (In) */
-		vw_sus_warn { vw_reg =
-			<NPCX_VWEVMS3 0x01>; wui_map = <&wui_vw_sus_warn>; };
-		vw_sus_pwrdn_ack { vw_reg =
-			<NPCX_VWEVMS3 0x02>; wui_map =<&wui_vw_sus_pwrdn_ack>;};
-		vw_slp_a { vw_reg =
-			<NPCX_VWEVMS3 0x08>; wui_map = <&wui_vw_slp_a>; };
+		vw-sus-warn {
+			vw_reg = <NPCX_VWEVMS3 0x01>; wui_map = <&wui_vw_sus_warn>;
+		};
+		vw-sus-pwrdn-ack {
+			vw_reg = <NPCX_VWEVMS3 0x02>; wui_map =<&wui_vw_sus_pwrdn_ack>;
+		};
+		vw-slp-a {
+			vw_reg = <NPCX_VWEVMS3 0x08>; wui_map = <&wui_vw_slp_a>;
+		};
 
 		/* index 42h (In) */
-		vw_slp_lan { vw_reg =
-			<NPCX_VWEVMS4 0x01>; wui_map = <&wui_vw_slp_lan>; };
-		vw_slp_wlan { vw_reg =
-			<NPCX_VWEVMS4 0x02>; wui_map = <&wui_vw_slp_wlan>; };
+		vw-slp-lan {
+			vw_reg = <NPCX_VWEVMS4 0x01>; wui_map = <&wui_vw_slp_lan>;
+		};
+		vw-slp-wlan {
+			vw_reg = <NPCX_VWEVMS4 0x02>; wui_map = <&wui_vw_slp_wlan>;
+		};
 
 		/* eSPI Virtual Vire (VW) output configuration */
 		/* index 04h (Out) */
-		vw_oob_rst_ack   { vw_reg = <NPCX_VWEVSM0 0x01>; };
-		vw_wake          { vw_reg = <NPCX_VWEVSM0 0x04>; };
-		vw_pme           { vw_reg = <NPCX_VWEVSM0 0x08>; };
+		vw-oob-rst-ack {
+			vw_reg = <NPCX_VWEVSM0 0x01>;
+		};
+		vw-wake {
+			vw_reg = <NPCX_VWEVSM0 0x04>;
+		};
+		vw-pme {
+			vw_reg = <NPCX_VWEVSM0 0x08>;
+		};
 
 		/* index 05h (Out) */
-		vw_slv_boot_done { vw_reg = <NPCX_VWEVSM1 0x01>; };
-		vw_err_fatal     { vw_reg = <NPCX_VWEVSM1 0x02>; };
-		vw_err_non_fatal { vw_reg = <NPCX_VWEVSM1 0x04>; };
-		/*
-		 * SLAVE_BOOT_DONE & SLAVE_LOAD_STS bits (bit 0 & bit 3) have
-		 * to be sent together. Hence its bitmask is 0x09.
-		 */
-		vw_slv_boot_sts_with_done { vw_reg = <NPCX_VWEVSM1 0x09>; };
+		vw-slv-boot-done {
+			vw_reg = <NPCX_VWEVSM1 0x01>;
+		};
+		vw-err-fatal {
+			vw_reg = <NPCX_VWEVSM1 0x02>;
+		};
+		vw-err-non-fatal {
+			vw_reg = <NPCX_VWEVSM1 0x04>;
+		};
+		vw-slv-boot-sts-with-done {
+			/*
+			 * SLAVE_BOOT_DONE & SLAVE_LOAD_STS bits (bit 0 & bit 3)
+			 * have to be sent together. Hence its bitmask is 0x09.
+			 */
+			vw_reg = <NPCX_VWEVSM1 0x09>;
+		};
 
 		/* index 06h (Out) */
-		vw_sci           { vw_reg = <NPCX_VWEVSM2 0x01>; };
-		vw_smi           { vw_reg = <NPCX_VWEVSM2 0x02>; };
-		vw_host_rst_ack  { vw_reg = <NPCX_VWEVSM2 0x08>; };
+		vw-sci {
+			vw_reg = <NPCX_VWEVSM2 0x01>;
+		};
+		vw-smi {
+			vw_reg = <NPCX_VWEVSM2 0x02>;
+		};
+		vw-host-rst-ack {
+			vw_reg = <NPCX_VWEVSM2 0x08>;
+		};
 
 		/* index 40h (Out) */
-		vw_sus_ack       { vw_reg = <NPCX_VWEVSM3 0x01>; };
+		vw-sus-ack {
+			vw_reg = <NPCX_VWEVSM3 0x01>;
+		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx7-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-lvol-ctrl-map.dtsi
@@ -5,50 +5,127 @@
  */
 
 / {
-	def_lvol_conf_list {
+	def-lvol-conf-list {
 		compatible = "nuvoton,npcx-lvolctrl-conf";
 
 		/* Low-Voltage IO Control 0 */
-		lvol_iob5: lvol00 { lvols = <&scfg 0x0b 5 0 0>; };
-		lvol_iob4: lvol01 { lvols = <&scfg 0x0b 4 0 1>; };
-		lvol_iob3: lvol02 { lvols = <&scfg 0x0b 3 0 2>; };
-		lvol_iob2: lvol03 { lvols = <&scfg 0x0b 2 0 3>; };
-		lvol_io90: lvol04 { lvols = <&scfg 0x09 0 0 4>; };
-		lvol_io87: lvol05 { lvols = <&scfg 0x08 7 0 5>; };
-		lvol_io00: lvol06 { lvols = <&scfg 0x00 0 0 6>; };
-		lvol_io33: lvol07 { lvols = <&scfg 0x03 3 0 7>; };
+		lvol_iob5: lvol00 {
+			lvols = <&scfg 0x0b 5 0 0>;
+		};
+		lvol_iob4: lvol01 {
+			lvols = <&scfg 0x0b 4 0 1>;
+		};
+		lvol_iob3: lvol02 {
+			lvols = <&scfg 0x0b 3 0 2>;
+		};
+		lvol_iob2: lvol03 {
+			lvols = <&scfg 0x0b 2 0 3>;
+		};
+		lvol_io90: lvol04 {
+			lvols = <&scfg 0x09 0 0 4>;
+		};
+		lvol_io87: lvol05 {
+			lvols = <&scfg 0x08 7 0 5>;
+		};
+		lvol_io00: lvol06 {
+			lvols = <&scfg 0x00 0 0 6>;
+		};
+		lvol_io33: lvol07 {
+			lvols = <&scfg 0x03 3 0 7>;
+		};
+
 		/* Low-Voltage IO Control 1 */
-		lvol_io92: lvol10 { lvols = <&scfg 0x09 2 1 0>; };
-		lvol_io91: lvol11 { lvols = <&scfg 0x09 1 1 1>; };
-		lvol_iod1: lvol12 { lvols = <&scfg 0x0d 1 1 2>; };
-		lvol_iod0: lvol13 { lvols = <&scfg 0x0d 0 1 3>; };
-		lvol_io36: lvol14 { lvols = <&scfg 0x03 6 1 4>; };
-		lvol_io64: lvol15 { lvols = <&scfg 0x06 4 1 5>; };
+		lvol_io92: lvol10 {
+			lvols = <&scfg 0x09 2 1 0>;
+		};
+		lvol_io91: lvol11 {
+			lvols = <&scfg 0x09 1 1 1>;
+		};
+		lvol_iod1: lvol12 {
+			lvols = <&scfg 0x0d 1 1 2>;
+		};
+		lvol_iod0: lvol13 {
+			lvols = <&scfg 0x0d 0 1 3>;
+		};
+		lvol_io36: lvol14 {
+			lvols = <&scfg 0x03 6 1 4>;
+		};
+		lvol_io64: lvol15 {
+			lvols = <&scfg 0x06 4 1 5>;
+		};
+
 		/* Low-Voltage IO Control 2 */
-		lvol_io74: lvol20 { lvols = <&scfg 0x07 4 2 0>; };
-		lvol_io73: lvol23 { lvols = <&scfg 0x07 3 2 3>; };
-		lvol_ioc1: lvol24 { lvols = <&scfg 0x0c 1 2 4>; };
-		lvol_ioc7: lvol25 { lvols = <&scfg 0x0c 7 2 5>; };
-		lvol_io34: lvol27 { lvols = <&scfg 0x03 4 2 7>; };
+		lvol_io74: lvol20 {
+			lvols = <&scfg 0x07 4 2 0>;
+		};
+		lvol_io73: lvol23 {
+			lvols = <&scfg 0x07 3 2 3>;
+		};
+		lvol_ioc1: lvol24 {
+			lvols = <&scfg 0x0c 1 2 4>;
+		};
+		lvol_ioc7: lvol25 {
+			lvols = <&scfg 0x0c 7 2 5>;
+		};
+		lvol_io34: lvol27 {
+			lvols = <&scfg 0x03 4 2 7>;
+		};
+
 		/* Low-Voltage IO Control 3 */
-		lvol_ioc6: lvol30 { lvols = <&scfg 0x0c 6 3 0>; };
-		lvol_io37: lvol31 { lvols = <&scfg 0x03 7 3 1>; };
-		lvol_io40: lvol32 { lvols = <&scfg 0x04 0 3 2>; };
-		lvol_io82: lvol34 { lvols = <&scfg 0x08 2 3 4>; };
-		lvol_io75: lvol35 { lvols = <&scfg 0x07 5 3 5>; };
-		lvol_io80: lvol36 { lvols = <&scfg 0x08 0 3 6>; };
-		lvol_ioc5: lvol37 { lvols = <&scfg 0x0c 5 3 7>; };
+		lvol_ioc6: lvol30 {
+			lvols = <&scfg 0x0c 6 3 0>;
+		};
+		lvol_io37: lvol31 {
+			lvols = <&scfg 0x03 7 3 1>;
+		};
+		lvol_io40: lvol32 {
+			lvols = <&scfg 0x04 0 3 2>;
+		};
+		lvol_io82: lvol34 {
+			lvols = <&scfg 0x08 2 3 4>;
+		};
+		lvol_io75: lvol35 {
+			lvols = <&scfg 0x07 5 3 5>;
+		};
+		lvol_io80: lvol36 {
+			lvols = <&scfg 0x08 0 3 6>;
+		};
+		lvol_ioc5: lvol37 {
+			lvols = <&scfg 0x0c 5 3 7>;
+		};
+
 		/* Low-Voltage IO Control 4 */
-		lvol_io86: lvol40 { lvols = <&scfg 0x08 6 4 0>; };
-		lvol_ioc2: lvol41 { lvols = <&scfg 0x0c 2 4 1>; };
-		lvol_iof3: lvol42 { lvols = <&scfg 0x0f 3 4 2>; };
-		lvol_iof2: lvol43 { lvols = <&scfg 0x0f 2 4 3>; };
-		lvol_iof5: lvol44 { lvols = <&scfg 0x0f 5 4 4>; };
-		lvol_iof4: lvol45 { lvols = <&scfg 0x0f 4 4 5>; };
-		lvol_ioe4: lvol46 { lvols = <&scfg 0x0e 4 4 6>; };
-		lvol_ioe6: lvol47 { lvols = <&scfg 0x0e 6 4 7>; };
+		lvol_io86: lvol40 {
+			lvols = <&scfg 0x08 6 4 0>;
+		};
+		lvol_ioc2: lvol41 {
+			lvols = <&scfg 0x0c 2 4 1>;
+		};
+		lvol_iof3: lvol42 {
+			lvols = <&scfg 0x0f 3 4 2>;
+		};
+		lvol_iof2: lvol43 {
+			lvols = <&scfg 0x0f 2 4 3>;
+		};
+		lvol_iof5: lvol44 {
+			lvols = <&scfg 0x0f 5 4 4>;
+		};
+		lvol_iof4: lvol45 {
+			lvols = <&scfg 0x0f 4 4 5>;
+		};
+		lvol_ioe4: lvol46 {
+			lvols = <&scfg 0x0e 4 4 6>;
+		};
+		lvol_ioe6: lvol47 {
+			lvols = <&scfg 0x0e 6 4 7>;
+		};
+
 		/* Low-Voltage IO Control 5 */
-		lvol_io72: lvol50 { lvols = <&scfg 0x07 2 5 0>; };
-		lvol_io50: lvol53 { lvols = <&scfg 0x05 0 5 3>; };
+		lvol_io72: lvol50 {
+			lvols = <&scfg 0x07 2 5 0>;
+		};
+		lvol_io50: lvol53 {
+			lvols = <&scfg 0x05 0 5 3>;
+		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
@@ -6,27 +6,27 @@
 
 / {
 	/* Mapping between MIWU group and interrupts */
-	npcx7_miwus_int_map {
+	npcx7-miwus-int-map {
 		map_miwu0_groups: map-miwu0-groups {
 			compatible = "nuvoton,npcx-miwu-int-map";
 			parent = <&miwu0>;
 
-			group_ad0: group_ad0_map {
+			group_ad0: group-ad0-map {
 				irq        = <7>;
 				irq_prio   = <0>;
 				group_mask = <0x09>;
 			};
-			group_b0: group_b0_map {
+			group_b0: group-b0-map {
 				irq        = <31>;
 				irq_prio   = <0>;
 				group_mask = <0x02>;
 			};
-			group_c0: group_c0_map {
+			group_c0: group-c0-map {
 				irq        = <15>;
 				irq_prio   = <0>;
 				group_mask = <0x04>;
 			};
-			group_efgh0: group_efgh0_map {
+			group_efgh0: group-efgh0-map {
 				irq        = <11>;
 				irq_prio   = <0>;
 				group_mask = <0xF0>;
@@ -37,42 +37,42 @@
 			compatible = "nuvoton,npcx-miwu-int-map";
 			parent = <&miwu1>;
 
-			group_a1: group_a1_map {
+			group_a1: group-a1-map {
 				irq        = <47>;
 				irq_prio   = <0>;
 				group_mask = <0x01>;
 			};
-			group_b1: group_b1_map {
+			group_b1: group-b1-map {
 				irq        = <48>;
 				irq_prio   = <0>;
 				group_mask = <0x02>;
 			};
-			group_c1: group_c1_map {
+			group_c1: group-c1-map {
 				irq        = <49>;
 				irq_prio   = <0>;
 				group_mask = <0x04>;
 			};
-			group_d1: group_d1_map {
+			group_d1: group-d1-map {
 				irq        = <50>;
 				irq_prio   = <0>;
 				group_mask = <0x08>;
 			};
-			group_e1: group_e1_map {
+			group_e1: group-e1-map {
 				irq        = <51>;
 				irq_prio   = <0>;
 				group_mask = <0x10>;
 			};
-			group_f1: group_f1_map {
+			group_f1: group-f1-map {
 				irq        = <52>;
 				irq_prio   = <0>;
 				group_mask = <0x20>;
 			};
-			group_g1: group_g1_map {
+			group_g1: group-g1-map {
 				irq        = <53>;
 				irq_prio   = <0>;
 				group_mask = <0x40>;
 			};
-			group_h1: group_h1_map {
+			group_h1: group-h1-map {
 				irq        = <54>;
 				irq_prio   = <0>;
 				group_mask = <0x80>;
@@ -83,27 +83,27 @@
 			compatible = "nuvoton,npcx-miwu-int-map";
 			parent = <&miwu2>;
 
-			group_a2: group_a2_map {
+			group_a2: group-a2-map {
 				irq        = <60>;
 				irq_prio   = <0>;
 				group_mask = <0x01>;
 			};
-			group_b2: group_b2_map {
+			group_b2: group-b2-map {
 				irq        = <61>;
 				irq_prio   = <0>;
 				group_mask = <0x02>;
 			};
-			group_c2: group_c2_map {
+			group_c2: group-c2-map {
 				irq        = <62>;
 				irq_prio   = <0>;
 				group_mask = <0x04>;
 			};
-			group_d2: group_d2_map {
+			group_d2: group-d2-map {
 				irq        = <63>;
 				irq_prio   = <0>;
 				group_mask = <0x08>;
 			};
-			group_fg2: group_fg2_map {
+			group_fg2: group-fg2-map {
 				irq        = <59>;
 				irq_prio   = <0>;
 				group_mask = <0x60>;

--- a/dts/arm/nuvoton/npcx/npcx7-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-miwus-wui-map.dtsi
@@ -9,205 +9,500 @@
 	npcx7_miwus_wui {
 		compatible = "nuvoton,npcx-miwu-wui-map";
 
-		/********************** * MIWU table 0 ************************/
+		/* MIWU table 0 */
 		/* MIWU group A */
-		wui_io80:    wui0_1_0 { miwus = <&miwu0 0 0>; }; /* GPIO80 */
-		wui_io81:    wui0_1_1 { miwus = <&miwu0 0 1>; }; /* GPIO81 */
-		wui_io82:    wui0_1_2 { miwus = <&miwu0 0 2>; }; /* GPIO82 */
-		wui_io83:    wui0_1_3 { miwus = <&miwu0 0 3>; }; /* GPIO83 */
-		wui_io86:    wui0_1_6 { miwus = <&miwu0 0 6>; }; /* GPIO86 */
-		wui_cr_sin2: wui0_1_6_2 { miwus = <&miwu0 0 6>; }; /* CR_SIN2 */
-		wui_io87:    wui0_1_7 { miwus = <&miwu0 0 7>; }; /* GPIO87 */
+		wui_io80: wui0-1-0 {
+			miwus = <&miwu0 0 0>; /* GPIO80 */
+		};
+		wui_io81: wui0-1-1 {
+			miwus = <&miwu0 0 1>; /* GPIO81 */
+		};
+		wui_io82: wui0-1-2 {
+			miwus = <&miwu0 0 2>; /* GPIO82 */
+		};
+		wui_io83: wui0-1-3 {
+			miwus = <&miwu0 0 3>; /* GPIO83 */
+		};
+		wui_io86: wui0-1-6 {
+			miwus = <&miwu0 0 6>; /* GPIO86 */
+		};
+		wui_cr_sin2: wui0-1-6-2 {
+			miwus = <&miwu0 0 6>; /* CR_SIN2 */
+		};
+		wui_io87: wui0-1-7 {
+			miwus = <&miwu0 0 7>; /* GPIO87 */
+		};
 
 		/* MIWU group B */
-		wui_io90:    wui0_2_0 { miwus = <&miwu0 1 0>; }; /* GPIO90 */
-		wui_io91:    wui0_2_1 { miwus = <&miwu0 1 1>; }; /* GPIO91 */
-		wui_io92:    wui0_2_2 { miwus = <&miwu0 1 2>; }; /* GPIO92 */
-		wui_io93:    wui0_2_3 { miwus = <&miwu0 1 3>; }; /* GPIO93 */
-		wui_io94:    wui0_2_4 { miwus = <&miwu0 1 4>; }; /* GPIO94 */
-		wui_io95:    wui0_2_5 { miwus = <&miwu0 1 5>; }; /* GPIO95 */
-		wui_mswc:    wui0_2_6 { miwus = <&miwu0 1 6>; }; /* MSWC */
-		wui_t0out:   wui0_2_7 { miwus = <&miwu0 1 7>; }; /* T0OUT */
+		wui_io90: wui0-2-0 {
+			miwus = <&miwu0 1 0>; /* GPIO90 */
+		};
+		wui_io91: wui0-2-1 {
+			miwus = <&miwu0 1 1>; /* GPIO91 */
+		};
+		wui_io92: wui0-2-2 {
+			miwus = <&miwu0 1 2>; /* GPIO92 */
+		};
+		wui_io93: wui0-2-3 {
+			miwus = <&miwu0 1 3>; /* GPIO93 */
+		};
+		wui_io94: wui0-2-4 {
+			miwus = <&miwu0 1 4>; /* GPIO94 */
+		};
+		wui_io95: wui0-2-5 {
+			miwus = <&miwu0 1 5>; /* GPIO95 */
+		};
+		wui_mswc: wui0-2-6 {
+			miwus = <&miwu0 1 6>; /* MSWC */
+		};
+		wui_t0out: wui0-2-7 {
+			miwus = <&miwu0 1 7>; /* T0OUT */
+		};
 
 		/* MIWU group C */
-		wui_io96:    wui0_3_0 { miwus = <&miwu0 2 0>; }; /* GPIO96 */
-		wui_io97:    wui0_3_1 { miwus = <&miwu0 2 1>; }; /* GPIO97 */
-		wui_ioa0:    wui0_3_2 { miwus = <&miwu0 2 2>; }; /* GPIOA0 */
-		wui_ioa1:    wui0_3_3 { miwus = <&miwu0 2 3>; }; /* GPIOA1 */
-		wui_ioa2:    wui0_3_4 { miwus = <&miwu0 2 4>; }; /* GPIOA2 */
-		wui_ioa3:    wui0_3_5 { miwus = <&miwu0 2 5>; }; /* GPIOA3 */
-		wui_ioa4:    wui0_3_6 { miwus = <&miwu0 2 6>; }; /* GPIOA4 */
-		wui_ioa5:    wui0_3_7 { miwus = <&miwu0 2 7>; }; /* GPIOA5 */
+		wui_io96: wui0-3-0 {
+			miwus = <&miwu0 2 0>; /* GPIO96 */
+		};
+		wui_io97: wui0-3-1 {
+			miwus = <&miwu0 2 1>; /* GPIO97 */
+		};
+		wui_ioa0: wui0-3-2 {
+			miwus = <&miwu0 2 2>; /* GPIOA0 */
+		};
+		wui_ioa1: wui0-3-3 {
+			miwus = <&miwu0 2 3>; /* GPIOA1 */
+		};
+		wui_ioa2: wui0-3-4 {
+			miwus = <&miwu0 2 4>; /* GPIOA2 */
+		};
+		wui_ioa3: wui0-3-5 {
+			miwus = <&miwu0 2 5>; /* GPIOA3 */
+		};
+		wui_ioa4: wui0-3-6 {
+			miwus = <&miwu0 2 6>; /* GPIOA4 */
+		};
+		wui_ioa5: wui0-3-7 {
+			miwus = <&miwu0 2 7>; /* GPIOA5 */
+		};
 
 		/* MIWU group D */
-		wui_ioa6:    wui0_4_0 { miwus = <&miwu0 3 0>; }; /* GPIOA6 */
-		wui_ioa7:    wui0_4_1 { miwus = <&miwu0 3 1>; }; /* GPIOA7 */
-		wui_iob0:    wui0_4_2 { miwus = <&miwu0 3 2>; }; /* GPIOB0 */
-		wui_smb0_2:  wui0_4_3 { miwus = <&miwu0 3 3>; }; /* SMB0/2 */
-		wui_smb1_3:  wui0_4_4 { miwus = <&miwu0 3 4>; }; /* SMB1/3 */
-		wui_iob1:    wui0_4_5 { miwus = <&miwu0 3 5>; }; /* GPIOB1 */
-		wui_iob2:    wui0_4_6 { miwus = <&miwu0 3 6>; }; /* GPIOB2 */
-		wui_mtc:     wui0_4_7 { miwus = <&miwu0 3 7>; }; /* MTC */
+		wui_ioa6: wui0-4-0 {
+			miwus = <&miwu0 3 0>; /* GPIOA6 */
+		};
+		wui_ioa7: wui0-4-1 {
+			miwus = <&miwu0 3 1>; /* GPIOA7 */
+		};
+		wui_iob0: wui0-4-2 {
+			miwus = <&miwu0 3 2>; /* GPIOB0 */
+		};
+		wui_smb0_2: wui0-4-3 {
+			miwus = <&miwu0 3 3>; /* SMB0/2 */
+		};
+		wui_smb1_3: wui0-4-4 {
+			miwus = <&miwu0 3 4>; /* SMB1/3 */
+		};
+		wui_iob1: wui0-4-5 {
+			miwus = <&miwu0 3 5>; /* GPIOB1 */
+		};
+		wui_iob2: wui0-4-6 {
+			miwus = <&miwu0 3 6>; /* GPIOB2 */
+		};
+		wui_mtc: wui0-4-7 {
+			miwus = <&miwu0 3 7>; /* MTC */
+		};
 
 		/* MIWU group E */
-		wui_iob3:    wui0_5_0 { miwus = <&miwu0 4 0>; }; /* GPIOB3 */
-		wui_iob4:    wui0_5_1 { miwus = <&miwu0 4 1>; }; /* GPIOB4 */
-		wui_iob5:    wui0_5_2 { miwus = <&miwu0 4 2>; }; /* GPIOB5 */
-		wui_smb4:    wui0_5_3 { miwus = <&miwu0 4 3>; }; /* SMB4 */
-		wui_iob7:    wui0_5_4 { miwus = <&miwu0 4 4>; }; /* GPIOB7 */
-		wui_espi_rst:wui0_5_5 { miwus = <&miwu0 4 5>; }; /* ESPI_RST */
-		wui_host_acc:wui0_5_6 { miwus = <&miwu0 4 6>; }; /* HOST_ACC */
-		wui_plt_rst: wui0_5_7 { miwus = <&miwu0 4 7>; }; /* PLT_RST */
+		wui_iob3: wui0-5-0 {
+			miwus = <&miwu0 4 0>; /* GPIOB3 */
+		};
+		wui_iob4: wui0-5-1 {
+			miwus = <&miwu0 4 1>; /* GPIOB4 */
+		};
+		wui_iob5: wui0-5-2 {
+			miwus = <&miwu0 4 2>; /* GPIOB5 */
+		};
+		wui_smb4: wui0-5-3 {
+			miwus = <&miwu0 4 3>; /* SMB4 */
+		};
+		wui_iob7: wui0-5-4 {
+			miwus = <&miwu0 4 4>; /* GPIOB7 */
+		};
+		wui_espi_rst: wui0-5-5 {
+			miwus = <&miwu0 4 5>; /* ESPI_RST */
+		};
+		wui_host_acc: wui0-5-6 {
+			miwus = <&miwu0 4 6>; /* HOST_ACC */
+		};
+		wui_plt_rst: wui0-5-7 {
+			miwus = <&miwu0 4 7>; /* PLT_RST */
+		};
 
 		/* MIWU group F */
-		wui_ioc0:    wui0_6_0 { miwus = <&miwu0 5 0>; }; /* GPIOC0 */
-		wui_ioc1:    wui0_6_1 { miwus = <&miwu0 5 1>; }; /* GPIOC1 */
-		wui_ioc2:    wui0_6_2 { miwus = <&miwu0 5 2>; }; /* GPIOC2 */
-		wui_ioc3:    wui0_6_3 { miwus = <&miwu0 5 3>; }; /* GPIOC3 */
-		wui_ioc4:    wui0_6_4 { miwus = <&miwu0 5 4>; }; /* GPIOC4 */
-		wui_ioc5:    wui0_6_5 { miwus = <&miwu0 5 5>; }; /* GPIOC5 */
-		wui_ioc6:    wui0_6_6 { miwus = <&miwu0 5 6>; }; /* GPIOC6 */
-		wui_ioc7:    wui0_6_7 { miwus = <&miwu0 5 7>; }; /* GPIOC7 */
+		wui_ioc0: wui0-6-0 {
+			miwus = <&miwu0 5 0>; /* GPIOC0 */
+		};
+		wui_ioc1: wui0-6-1 {
+			miwus = <&miwu0 5 1>; /* GPIOC1 */
+		};
+		wui_ioc2: wui0-6-2 {
+			miwus = <&miwu0 5 2>; /* GPIOC2 */
+		};
+		wui_ioc3: wui0-6-3 {
+			miwus = <&miwu0 5 3>; /* GPIOC3 */
+		};
+		wui_ioc4: wui0-6-4 {
+			miwus = <&miwu0 5 4>; /* GPIOC4 */
+		};
+		wui_ioc5: wui0-6-5 {
+			miwus = <&miwu0 5 5>; /* GPIOC5 */
+		};
+		wui_ioc6: wui0-6-6 {
+			miwus = <&miwu0 5 6>; /* GPIOC6 */
+		};
+		wui_ioc7: wui0-6-7 {
+			miwus = <&miwu0 5 7>; /* GPIOC7 */
+		};
 
 		/* MIWU group G */
-		wui_iod0:    wui0_7_0 { miwus = <&miwu0 6 0>; }; /* GPIOD0 */
-		wui_iod1:    wui0_7_1 { miwus = <&miwu0 6 1>; }; /* GPIOD1 */
-		wui_iod2:    wui0_7_2 { miwus = <&miwu0 6 2>; }; /* GPIOD2 */
-		wui_iod3:    wui0_7_3 { miwus = <&miwu0 6 3>; }; /* GPIOD3 */
-		wui_iod4:    wui0_7_4 { miwus = <&miwu0 6 4>; }; /* GPIOD4 */
-		wui_iod5:    wui0_7_5 { miwus = <&miwu0 6 5>; }; /* GPIOD5 */
-		wui_iod7:    wui0_7_6 { miwus = <&miwu0 6 6>; }; /* GPIOD7 */
-		wui_ioe0:    wui0_7_7 { miwus = <&miwu0 6 7>; }; /* GPIOE0 */
+		wui_iod0: wui0-7-0 {
+			miwus = <&miwu0 6 0>; /* GPIOD0 */
+		};
+		wui_iod1: wui0-7-1 {
+			miwus = <&miwu0 6 1>; /* GPIOD1 */
+		};
+		wui_iod2: wui0-7-2 {
+			miwus = <&miwu0 6 2>; /* GPIOD2 */
+		};
+		wui_iod3: wui0-7-3 {
+			miwus = <&miwu0 6 3>; /* GPIOD3 */
+		};
+		wui_iod4: wui0-7-4 {
+			miwus = <&miwu0 6 4>; /* GPIOD4 */
+		};
+		wui_iod5: wui0-7-5 {
+			miwus = <&miwu0 6 5>; /* GPIOD5 */
+		};
+		wui_iod7: wui0-7-6 {
+			miwus = <&miwu0 6 6>; /* GPIOD7 */
+		};
+		wui_ioe0: wui0-7-7 {
+			miwus = <&miwu0 6 7>; /* GPIOE0 */
+		};
 
 		/* MIWU group H */
-		wui_ioe1:    wui0_8_0 { miwus = <&miwu0 7 0>; }; /* GPIOE1 */
-		wui_ioe2:    wui0_8_1 { miwus = <&miwu0 7 1>; }; /* GPIOE2 */
-		wui_ioe3:    wui0_8_2 { miwus = <&miwu0 7 2>; }; /* GPIOE3 */
-		wui_ioe4:    wui0_8_3 { miwus = <&miwu0 7 3>; }; /* GPIOE4 */
-		wui_ioe5:    wui0_8_4 { miwus = <&miwu0 7 4>; }; /* GPIOE5 */
-		wui_iof0:    wui0_8_5 { miwus = <&miwu0 7 5>; }; /* GPIOF0 */
-		wui_iof3:    wui0_8_6 { miwus = <&miwu0 7 6>; }; /* GPIOF3 */
+		wui_ioe1: wui0-8-0 {
+			miwus = <&miwu0 7 0>; /* GPIOE1 */
+		};
+		wui_ioe2: wui0-8-1 {
+			miwus = <&miwu0 7 1>; /* GPIOE2 */
+		};
+		wui_ioe3: wui0-8-2 {
+			miwus = <&miwu0 7 2>; /* GPIOE3 */
+		};
+		wui_ioe4: wui0-8-3 {
+			miwus = <&miwu0 7 3>; /* GPIOE4 */
+		};
+		wui_ioe5: wui0-8-4 {
+			miwus = <&miwu0 7 4>; /* GPIOE5 */
+		};
+		wui_iof0: wui0-8-5 {
+			miwus = <&miwu0 7 5>; /* GPIOF0 */
+		};
+		wui_iof3: wui0-8-6 {
+			miwus = <&miwu0 7 6>; /* GPIOF3 */
+		};
 
-		/************************ MIWU table 1 ************************/
+		/* MIWU table 1 */
 		/* MIWU group A */
-		wui_io00:    wui1_1_0 { miwus = <&miwu1 0 0>; }; /* GPIO00 */
-		wui_io01:    wui1_1_1 { miwus = <&miwu1 0 1>; }; /* GPIO01 */
-		wui_io02:    wui1_1_2 { miwus = <&miwu1 0 2>; }; /* GPIO02 */
-		wui_io03:    wui1_1_3 { miwus = <&miwu1 0 3>; }; /* GPIO03 */
-		wui_io04:    wui1_1_4 { miwus = <&miwu1 0 4>; }; /* GPIO04 */
-		wui_io05:    wui1_1_5 { miwus = <&miwu1 0 5>; }; /* GPIO05 */
-		wui_io06:    wui1_1_6 { miwus = <&miwu1 0 6>; }; /* GPIO06 */
-		wui_io07:    wui1_1_7 { miwus = <&miwu1 0 7>; }; /* GPIO07 */
+		wui_io00: wui1-1-0 {
+			miwus = <&miwu1 0 0>; /* GPIO00 */
+		};
+		wui_io01: wui1-1-1 {
+			miwus = <&miwu1 0 1>; /* GPIO01 */
+		};
+		wui_io02: wui1-1-2 {
+			miwus = <&miwu1 0 2>; /* GPIO02 */
+		};
+		wui_io03: wui1-1-3 {
+			miwus = <&miwu1 0 3>; /* GPIO03 */
+		};
+		wui_io04: wui1-1-4 {
+			miwus = <&miwu1 0 4>; /* GPIO04 */
+		};
+		wui_io05: wui1-1-5 {
+			miwus = <&miwu1 0 5>; /* GPIO05 */
+		};
+		wui_io06: wui1-1-6 {
+			miwus = <&miwu1 0 6>; /* GPIO06 */
+		};
+		wui_io07: wui1-1-7 {
+			miwus = <&miwu1 0 7>; /* GPIO07 */
+		};
 
 		/* MIWU group B */
-		wui_io10:    wui1_2_0 { miwus = <&miwu1 1 0>; }; /* GPIO10 */
-		wui_io11:    wui1_2_1 { miwus = <&miwu1 1 1>; }; /* GPIO11 */
-		wui_iof4:    wui1_2_2 { miwus = <&miwu1 1 2>; }; /* GPIOF4 */
-		wui_io14:    wui1_2_4 { miwus = <&miwu1 1 4>; }; /* GPIO14 */
-		wui_io15:    wui1_2_5 { miwus = <&miwu1 1 5>; }; /* GPIO15 */
-		wui_io16:    wui1_2_6 { miwus = <&miwu1 1 6>; }; /* GPIO16 */
-		wui_io17:    wui1_2_7 { miwus = <&miwu1 1 7>; }; /* GPIO17 */
+		wui_io10: wui1-2-0 {
+			miwus = <&miwu1 1 0>; /* GPIO10 */
+		};
+		wui_io11: wui1-2-1 {
+			miwus = <&miwu1 1 1>; /* GPIO11 */
+		};
+		wui_iof4: wui1-2-2 {
+			miwus = <&miwu1 1 2>; /* GPIOF4 */
+		};
+		wui_io14: wui1-2-4 {
+			miwus = <&miwu1 1 4>; /* GPIO14 */
+		};
+		wui_io15: wui1-2-5 {
+			miwus = <&miwu1 1 5>; /* GPIO15 */
+		};
+		wui_io16: wui1-2-6 {
+			miwus = <&miwu1 1 6>; /* GPIO16 */
+		};
+		wui_io17: wui1-2-7 {
+			miwus = <&miwu1 1 7>; /* GPIO17 */
+		};
 
 		/* MIWU group C */
-		wui_io31:    wui1_3_0 { miwus = <&miwu1 2 0>; }; /* GPIO31 */
-		wui_io30:    wui1_3_1 { miwus = <&miwu1 2 1>; }; /* GPIO30 */
-		wui_io27:    wui1_3_2 { miwus = <&miwu1 2 2>; }; /* GPIO27 */
-		wui_io26:    wui1_3_3 { miwus = <&miwu1 2 3>; }; /* GPIO26 */
-		wui_io25:    wui1_3_4 { miwus = <&miwu1 2 4>; }; /* GPIO25 */
-		wui_io24:    wui1_3_5 { miwus = <&miwu1 2 5>; }; /* GPIO24 */
-		wui_io23:    wui1_3_6 { miwus = <&miwu1 2 6>; }; /* GPIO23 */
-		wui_io22:    wui1_3_7 { miwus = <&miwu1 2 7>; }; /* GPIO22 */
+		wui_io31: wui1-3-0 {
+			miwus = <&miwu1 2 0>; /* GPIO31 */
+		};
+		wui_io30: wui1-3-1 {
+			miwus = <&miwu1 2 1>; /* GPIO30 */
+		};
+		wui_io27: wui1-3-2 {
+			miwus = <&miwu1 2 2>; /* GPIO27 */
+		};
+		wui_io26: wui1-3-3 {
+			miwus = <&miwu1 2 3>; /* GPIO26 */
+		};
+		wui_io25: wui1-3-4 {
+			miwus = <&miwu1 2 4>; /* GPIO25 */
+		};
+		wui_io24: wui1-3-5 {
+			miwus = <&miwu1 2 5>; /* GPIO24 */
+		};
+		wui_io23: wui1-3-6 {
+			miwus = <&miwu1 2 6>; /* GPIO23 */
+		};
+		wui_io22: wui1-3-7 {
+			miwus = <&miwu1 2 7>; /* GPIO22 */
+		};
 
 		/* MIWU group D */
-		wui_io20:    wui1_4_0 { miwus = <&miwu1 3 0>; }; /* GPIO20 */
-		wui_io21:    wui1_4_1 { miwus = <&miwu1 3 1>; }; /* GPIO21 */
-		wui_iof5:    wui1_4_2 { miwus = <&miwu1 3 2>; }; /* GPIOF5 */
-		wui_io33:    wui1_4_3 { miwus = <&miwu1 3 3>; }; /* GPIO33 */
-		wui_io34:    wui1_4_4 { miwus = <&miwu1 3 4>; }; /* GPIO34 */
-		wui_io36:    wui1_4_6 { miwus = <&miwu1 3 6>; }; /* GPIO36 */
-		wui_io37:    wui1_4_7 { miwus = <&miwu1 3 7>; }; /* GPIO37 */
+		wui_io20: wui1-4-0 {
+			miwus = <&miwu1 3 0>; /* GPIO20 */
+		};
+		wui_io21: wui1-4-1 {
+			miwus = <&miwu1 3 1>; /* GPIO21 */
+		};
+		wui_iof5: wui1-4-2 {
+			miwus = <&miwu1 3 2>; /* GPIOF5 */
+		};
+		wui_io33: wui1-4-3 {
+			miwus = <&miwu1 3 3>; /* GPIO33 */
+		};
+		wui_io34: wui1-4-4 {
+			miwus = <&miwu1 3 4>; /* GPIO34 */
+		};
+		wui_io36: wui1-4-6 {
+			miwus = <&miwu1 3 6>; /* GPIO36 */
+		};
+		wui_io37: wui1-4-7 {
+			miwus = <&miwu1 3 7>; /* GPIO37 */
+		};
 
 		/* MIWU group E */
-		wui_io40:    wui1_5_0 { miwus = <&miwu1 4 0>; }; /* GPIO40 */
-		wui_io41:    wui1_5_1 { miwus = <&miwu1 4 1>; }; /* GPIO41 */
-		wui_io42:    wui1_5_2 { miwus = <&miwu1 4 2>; }; /* GPIO42 */
-		wui_io43:    wui1_5_3 { miwus = <&miwu1 4 3>; }; /* GPIO43 */
-		wui_io44:    wui1_5_4 { miwus = <&miwu1 4 4>; }; /* GPIO44 */
-		wui_io45:    wui1_5_5 { miwus = <&miwu1 4 5>; }; /* GPIO45 */
-		wui_io46:    wui1_5_6 { miwus = <&miwu1 4 6>; }; /* GPIO46 */
-		wui_io47:    wui1_5_7 { miwus = <&miwu1 4 7>; }; /* GPIO47 */
+		wui_io40: wui1-5-0 {
+			miwus = <&miwu1 4 0>; /* GPIO40 */
+		};
+		wui_io41: wui1-5-1 {
+			miwus = <&miwu1 4 1>; /* GPIO41 */
+		};
+		wui_io42: wui1-5-2 {
+			miwus = <&miwu1 4 2>; /* GPIO42 */
+		};
+		wui_io43: wui1-5-3 {
+			miwus = <&miwu1 4 3>; /* GPIO43 */
+		};
+		wui_io44: wui1-5-4 {
+			miwus = <&miwu1 4 4>; /* GPIO44 */
+		};
+		wui_io45: wui1-5-5 {
+			miwus = <&miwu1 4 5>; /* GPIO45 */
+		};
+		wui_io46: wui1-5-6 {
+			miwus = <&miwu1 4 6>; /* GPIO46 */
+		};
+		wui_io47: wui1-5-7 {
+			miwus = <&miwu1 4 7>; /* GPIO47 */
+		};
 
 		/* MIWU group F */
-		wui_io50:    wui1_6_0 { miwus = <&miwu1 5 0>; }; /* GPIO50 */
-		wui_io51:    wui1_6_1 { miwus = <&miwu1 5 1>; }; /* GPIO51 */
-		wui_io52:    wui1_6_2 { miwus = <&miwu1 5 2>; }; /* GPIO52 */
-		wui_io53:    wui1_6_3 { miwus = <&miwu1 5 3>; }; /* GPIO53 */
-		wui_io54:    wui1_6_4 { miwus = <&miwu1 5 4>; }; /* GPIO54 */
-		wui_io55:    wui1_6_5 { miwus = <&miwu1 5 5>; }; /* GPIO55 */
-		wui_io56:    wui1_6_6 { miwus = <&miwu1 5 6>; }; /* GPIO56 */
-		wui_io57:    wui1_6_7 { miwus = <&miwu1 5 7>; }; /* GPIO57 */
+		wui_io50: wui1-6-0 {
+			miwus = <&miwu1 5 0>; /* GPIO50 */
+		};
+		wui_io51: wui1-6-1 {
+			miwus = <&miwu1 5 1>; /* GPIO51 */
+		};
+		wui_io52: wui1-6-2 {
+			miwus = <&miwu1 5 2>; /* GPIO52 */
+		};
+		wui_io53: wui1-6-3 {
+			miwus = <&miwu1 5 3>; /* GPIO53 */
+		};
+		wui_io54: wui1-6-4 {
+			miwus = <&miwu1 5 4>; /* GPIO54 */
+		};
+		wui_io55: wui1-6-5 {
+			miwus = <&miwu1 5 5>; /* GPIO55 */
+		};
+		wui_io56: wui1-6-6 {
+			miwus = <&miwu1 5 6>; /* GPIO56 */
+		};
+		wui_io57: wui1-6-7 {
+			miwus = <&miwu1 5 7>; /* GPIO57 */
+		};
 
 		/* MIWU group G */
-		wui_io60:    wui1_7_0 { miwus = <&miwu1 6 0>; }; /* GPIO60 */
-		wui_io61:    wui1_7_1 { miwus = <&miwu1 6 1>; }; /* GPIO61 */
-		wui_io62:    wui1_7_2 { miwus = <&miwu1 6 2>; }; /* GPIO62 */
-		wui_io63:    wui1_7_3 { miwus = <&miwu1 6 3>; }; /* GPIO63 */
-		wui_io64:    wui1_7_4 { miwus = <&miwu1 6 4>; }; /* GPIO64 */
+		wui_io60: wui1-7-0 {
+			miwus = <&miwu1 6 0>; /* GPIO60 */
+		};
+		wui_io61: wui1-7-1 {
+			miwus = <&miwu1 6 1>; /* GPIO61 */
+		};
+		wui_io62: wui1-7-2 {
+			miwus = <&miwu1 6 2>; /* GPIO62 */
+		};
+		wui_io63: wui1-7-3 {
+			miwus = <&miwu1 6 3>; /* GPIO63 */
+		};
+		wui_io64: wui1-7-4 {
+			miwus = <&miwu1 6 4>; /* GPIO64 */
+		};
 
 		/* MIWU group H */
-		wui_io70:    wui1_8_0 { miwus = <&miwu1 7 0>; }; /* GPIO70 */
-		wui_io67:    wui1_8_1 { miwus = <&miwu1 7 1>; }; /* GPIO67 */
-		wui_io72:    wui1_8_2 { miwus = <&miwu1 7 2>; }; /* GPIO72 */
-		wui_io73:    wui1_8_3 { miwus = <&miwu1 7 3>; }; /* GPIO73 */
-		wui_io74:    wui1_8_4 { miwus = <&miwu1 7 4>; }; /* GPIO74 */
-		wui_io75:    wui1_8_5 { miwus = <&miwu1 7 5>; }; /* GPIO75 */
-		wui_io76:    wui1_8_6 { miwus = <&miwu1 7 6>; }; /* GPIO76 */
-		wui_cr_sin1: wui1_8_7 { miwus = <&miwu1 7 7>; }; /* CR_SIN1 */
+		wui_io70: wui1-8-0 {
+			miwus = <&miwu1 7 0>; /* GPIO70 */
+		};
+		wui_io67: wui1-8-1 {
+			miwus = <&miwu1 7 1>; /* GPIO67 */
+		};
+		wui_io72: wui1-8-2 {
+			miwus = <&miwu1 7 2>; /* GPIO72 */
+		};
+		wui_io73: wui1-8-3 {
+			miwus = <&miwu1 7 3>; /* GPIO73 */
+		};
+		wui_io74: wui1-8-4 {
+			miwus = <&miwu1 7 4>; /* GPIO74 */
+		};
+		wui_io75: wui1-8-5 {
+			miwus = <&miwu1 7 5>; /* GPIO75 */
+		};
+		wui_io76: wui1-8-6 {
+			miwus = <&miwu1 7 6>; /* GPIO76 */
+		};
+		wui_cr_sin1: wui1-8-7 {
+			miwus = <&miwu1 7 7>; /* CR_SIN1 */
+		};
 
-		/************************ MIWU table 2 ************************/
+		/* MIWU table 2 */
 		/* MIWU group A */
 		/* eSPI VW Events */
-		wui_vw_slp_s3:       wui2_1_0 { miwus = <&miwu2 0 0>; };
-		wui_vw_slp_s4:       wui2_1_1 { miwus = <&miwu2 0 1>; };
-		wui_vw_slp_s5:       wui2_1_2 { miwus = <&miwu2 0 2>; };
-		wui_vw_sus_stat:     wui2_1_4 { miwus = <&miwu2 0 4>; };
-		wui_vw_plt_rst:      wui2_1_5 { miwus = <&miwu2 0 5>; };
-		wui_vw_oob_rst_warn: wui2_1_6 { miwus = <&miwu2 0 6>; };
+		wui_vw_slp_s3: wui2-1-0 {
+			miwus = <&miwu2 0 0>; /* SLP_S3_L */
+		};
+		wui_vw_slp_s4: wui2-1-1 {
+			miwus = <&miwu2 0 1>; /* SLP_S4_L */
+		};
+		wui_vw_slp_s5: wui2-1-2 {
+			miwus = <&miwu2 0 2>; /* SLP_S5_L */
+		};
+		wui_vw_sus_stat: wui2-1-4 {
+			miwus = <&miwu2 0 4>; /* SUS_STAT_L */
+		};
+		wui_vw_plt_rst: wui2-1-5 {
+			miwus = <&miwu2 0 5>; /* PLTRST_L */
+		};
+		wui_vw_oob_rst_warn: wui2-1-6 {
+			miwus = <&miwu2 0 6>; /* OOB_RST_WARN */
+		};
 
 		/* MIWU group B */
-		/* eSPI VW Events */
-		wui_vw_host_rst_warn: wui2_2_0 { miwus = <&miwu2 1 0>; };
-		wui_vw_sus_warn:      wui2_2_4 { miwus = <&miwu2 1 4>; };
-		wui_vw_sus_pwrdn_ack: wui2_2_5 { miwus = <&miwu2 1 5>; };
-		wui_vw_slp_a:         wui2_2_7 { miwus = <&miwu2 1 7>; };
+		wui_vw_host_rst_warn: wui2-2-0 {
+			miwus = <&miwu2 1 0>; /* HOST_RST_WARN */
+		};
+		wui_vw_sus_warn: wui2-2-4 {
+			miwus = <&miwu2 1 4>; /* SUS_WARN_L */
+		};
+		wui_vw_sus_pwrdn_ack: wui2-2-5 {
+			miwus = <&miwu2 1 5>; /* SUS_PWRDN_ACK */
+		};
+		wui_vw_slp_a: wui2-2-7 {
+			miwus = <&miwu2 1 7>; /* SLP_A_L */
+		};
 
 		/* MIWU group C */
 		/* eSPI VW Events */
-		wui_vw_slp_lan:         wui2_3_0 { miwus = <&miwu2 2 0>; };
-		wui_vw_slp_wlan:        wui2_3_1 { miwus = <&miwu2 2 1>; };
-		wui_vw_fl_ack:          wui2_3_4 { miwus = <&miwu2 2 4>; };
-		wui_vw_pch_to_ec_gen_1: wui2_3_5 { miwus = <&miwu2 2 5>; };
-		wui_vw_pch_to_ec_gen_2: wui2_3_6 { miwus = <&miwu2 2 6>; };
-		wui_vw_pch_to_ec_gen_3: wui2_3_7 { miwus = <&miwu2 2 7>; };
+		wui_vw_slp_lan: wui2-3-0 {
+			miwus = <&miwu2 2 0>; /* SLP_LAN_L */
+		};
+		wui_vw_slp_wlan: wui2-3-1 {
+			miwus = <&miwu2 2 1>; /* SLP_WLAN_L) */
+		};
+		wui_vw_fl_ack: wui2-3-4 {
+			miwus = <&miwu2 2 4>; /* FL_ACK */
+		};
+		wui_vw_pch_to_ec_gen_1: wui2-3-5 {
+			miwus = <&miwu2 2 5>; /* PCH_TO_EC_GENERIC_1 */
+		};
+		wui_vw_pch_to_ec_gen_2: wui2-3-6 {
+			miwus = <&miwu2 2 6>; /* PCH_TO_EC_GENERIC_2 */
+		};
+		wui_vw_pch_to_ec_gen_3: wui2-3-7 {
+			miwus = <&miwu2 2 7>; /* PCH_TO_EC_GENERIC_3 */
+		};
 
 		/* MIWU group D */
-		wui_vw_pch_to_ec_gen_4: wui2_4_0 { miwus = <&miwu2 3 0>; };
-		wui_vw_pch_to_ec_gen_5: wui2_4_1 { miwus = <&miwu2 3 1>; };
-		wui_vw_pch_to_ec_gen_6: wui2_4_2 { miwus = <&miwu2 3 2>; };
-		wui_vw_pch_to_ec_gen_7: wui2_4_3 { miwus = <&miwu2 3 3>; };
-		wui_vw_host_c10:        wui2_4_4 { miwus = <&miwu2 3 4>; };
+		wui_vw_pch_to_ec_gen_4: wui2-4-0 {
+			miwus = <&miwu2 3 0>; /* PCH_TO_EC_GENERIC_4 */
+		};
+		wui_vw_pch_to_ec_gen_5: wui2-4-1 {
+			miwus = <&miwu2 3 1>; /* PCH_TO_EC_GENERIC_5 */
+		};
+		wui_vw_pch_to_ec_gen_6: wui2-4-2 {
+			miwus = <&miwu2 3 2>; /* PCH_TO_EC_GENERIC_6 */
+		};
+		wui_vw_pch_to_ec_gen_7: wui2-4-3 {
+			miwus = <&miwu2 3 3>; /* PCH_TO_EC_GENERIC_7 */
+		};
+		wui_vw_host_c10: wui2-4-4 {
+			miwus = <&miwu2 3 4>; /* HOST_C10 */
+		};
 
 		/* MIWU group F */
-		wui_iof1: wui2_6_1 { miwus = <&miwu2 5 1>; }; /* GPIOF1 */
-		wui_iof2: wui2_6_2 { miwus = <&miwu2 5 2>; }; /* GPIOF2 */
+		wui_iof1: wui2-6-1 {
+			miwus = <&miwu2 5 1>; /* GPIOF1 */
+		};
+		wui_iof2: wui2-6-2 {
+			miwus = <&miwu2 5 2>; /* GPIOF2 */
+		};
 
 		/* MIWU group G */
-		wui_smb5: wui2_7_0 { miwus = <&miwu2 6 0>; }; /* SMB5 */
-		wui_smb6: wui2_7_1 { miwus = <&miwu2 6 1>; }; /* SMB6 */
-		wui_smb7: wui2_7_2 { miwus = <&miwu2 6 2>; }; /* SMB7 */
+		wui_smb5: wui2-7-0 {
+			miwus = <&miwu2 6 0>; /* SMB5 */
+		};
+		wui_smb6: wui2-7-1 {
+			miwus = <&miwu2 6 1>; /* SMB6 */
+		};
+		wui_smb7: wui2-7-2 {
+			miwus = <&miwu2 6 2>; /* SMB7 */
+		};
 
 		/* Pseudo wui item means no mapping between source and wui */
-		wui_none: wui_pseudo { miwus = <&miwu_none 7 7>; };
+		wui_none: wui_pseudo {
+			miwus = <&miwu_none 7 7>;
+		};
 	};
 
 	/* Pseudo MIWU device to present no mapping relationship */

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -39,7 +39,7 @@
 		};
 	};
 
-	def_io_conf: def_io_conf_list {
+	def-io-conf-list {
 		compatible = "nuvoton,npcx-pinctrl-def";
 		/* Change default functional pads to GPIOs
 		 * no_spip - PIN95.97.A1.A3
@@ -88,14 +88,14 @@
 			   &alta_no_kso17_sl>;
 	};
 
-	def_lvol_io_list {
+	def-lvol-io-list {
 		compatible = "nuvoton,npcx-lvolctrl-def";
-		/* Put low-voltage io pads into "lvol_io_pads" property if the
+		/* Put low-voltage io pads into "lvol-io-pads" property if the
 		 * detection level of them is 1.8V, For example, if the bus
 		 * voltage of i2c1_0 port is 1.8V, this property should be:
-		 * lvol_io_pads = <&lvol_io90 &lvol_io87>;
+		 * lvol-io-pads = <&lvol_io90 &lvol_io87>;
 		 */
-		lvol_io_pads = <>;
+		lvol-io-pads = <>;
 	};
 
 	vsby-psl-in-list {
@@ -156,7 +156,7 @@
 			interrupts = <33 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL1 4>;
 			pinctrl-0 = <&alta_uart1_sl1>; /* PIN10.11 */
-			uart_rx = <&wui_cr_sin1>;
+			uart-rx = <&wui_cr_sin1>;
 			status = "disabled";
 			label = "UART_1";
 		};
@@ -167,7 +167,7 @@
 			interrupts = <32 0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 6>;
 			pinctrl-0 = <&alta_uart2_sl>; /* PIN75.86 */
-			uart_rx = <&wui_cr_sin2>;
+			uart-rx = <&wui_cr_sin2>;
 			status = "disabled";
 			label = "UART_2";
 		};
@@ -201,7 +201,7 @@
 			reg = <0x40081000 0x2000>;
 			gpio-controller;
 			index = <0x0>;
-			wui_maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03
+			wui-maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03
 				    &wui_io04 &wui_io05 &wui_io06 &wui_io07>;
 			#gpio-cells=<2>;
 			label="GPIO_0";
@@ -212,7 +212,7 @@
 			reg = <0x40083000 0x2000>;
 			gpio-controller;
 			index = <0x1>;
-			wui_maps = <&wui_io10 &wui_io11 &wui_none &wui_none
+			wui-maps = <&wui_io10 &wui_io11 &wui_none &wui_none
 				    &wui_io14 &wui_io15 &wui_io16 &wui_io17>;
 			#gpio-cells=<2>;
 			label="GPIO_1";
@@ -223,7 +223,7 @@
 			reg = <0x40085000 0x2000>;
 			gpio-controller;
 			index = <0x2>;
-			wui_maps = <&wui_io20 &wui_io21 &wui_io22 &wui_io23
+			wui-maps = <&wui_io20 &wui_io21 &wui_io22 &wui_io23
 				    &wui_io24 &wui_io25 &wui_io26 &wui_io27>;
 			#gpio-cells=<2>;
 			label="GPIO_2";
@@ -234,7 +234,7 @@
 			reg = <0x40087000 0x2000>;
 			gpio-controller;
 			index = <0x3>;
-			wui_maps = <&wui_io30 &wui_io31 &wui_none &wui_io33
+			wui-maps = <&wui_io30 &wui_io31 &wui_none &wui_io33
 				    &wui_io34 &wui_none &wui_io36 &wui_io37>;
 			#gpio-cells=<2>;
 			label="GPIO_3";
@@ -245,7 +245,7 @@
 			reg = <0x40089000 0x2000>;
 			gpio-controller;
 			index = <0x4>;
-			wui_maps = <&wui_io40 &wui_io41 &wui_io42 &wui_io43
+			wui-maps = <&wui_io40 &wui_io41 &wui_io42 &wui_io43
 				    &wui_io44 &wui_io45 &wui_io46 &wui_io47>;
 			#gpio-cells=<2>;
 			label="GPIO_4";
@@ -256,7 +256,7 @@
 			reg = <0x4008b000 0x2000>;
 			gpio-controller;
 			index = <0x5>;
-			wui_maps = <&wui_io50 &wui_io51 &wui_io52 &wui_io53
+			wui-maps = <&wui_io50 &wui_io51 &wui_io52 &wui_io53
 				    &wui_io54 &wui_io55 &wui_io56 &wui_io57>;
 			#gpio-cells=<2>;
 			label="GPIO_5";
@@ -267,7 +267,7 @@
 			reg = <0x4008d000 0x2000>;
 			gpio-controller;
 			index = <0x6>;
-			wui_maps = <&wui_io60 &wui_io61 &wui_io62 &wui_io63
+			wui-maps = <&wui_io60 &wui_io61 &wui_io62 &wui_io63
 				    &wui_io64 &wui_none &wui_none &wui_io67>;
 			#gpio-cells=<2>;
 			label="GPIO_6";
@@ -278,7 +278,7 @@
 			reg = <0x4008f000 0x2000>;
 			gpio-controller;
 			index = <0x7>;
-			wui_maps = <&wui_io70 &wui_none &wui_io72 &wui_io73
+			wui-maps = <&wui_io70 &wui_none &wui_io72 &wui_io73
 				    &wui_io74 &wui_io75 &wui_io76 &wui_none>;
 			#gpio-cells=<2>;
 			label="GPIO_7";
@@ -289,7 +289,7 @@
 			reg = <0x40091000 0x2000>;
 			gpio-controller;
 			index = <0x8>;
-			wui_maps = <&wui_io80 &wui_io81 &wui_io82 &wui_io83
+			wui-maps = <&wui_io80 &wui_io81 &wui_io82 &wui_io83
 				    &wui_none &wui_none &wui_io86 &wui_io87>;
 			#gpio-cells=<2>;
 			label="GPIO_8";
@@ -300,7 +300,7 @@
 			reg = <0x40093000 0x2000>;
 			gpio-controller;
 			index = <0x9>;
-			wui_maps = <&wui_io90 &wui_io91 &wui_io92 &wui_io93
+			wui-maps = <&wui_io90 &wui_io91 &wui_io92 &wui_io93
 				    &wui_io94 &wui_io95 &wui_io96 &wui_io97>;
 			#gpio-cells=<2>;
 			label="GPIO_9";
@@ -311,7 +311,7 @@
 			reg = <0x40095000 0x2000>;
 			gpio-controller;
 			index = <0xA>;
-			wui_maps = <&wui_ioa0 &wui_ioa1 &wui_ioa2 &wui_ioa3
+			wui-maps = <&wui_ioa0 &wui_ioa1 &wui_ioa2 &wui_ioa3
 				    &wui_ioa4 &wui_ioa5 &wui_ioa6 &wui_ioa7>;
 			#gpio-cells=<2>;
 			label="GPIO_A";
@@ -322,7 +322,7 @@
 			reg = <0x40097000 0x2000>;
 			gpio-controller;
 			index = <0xB>;
-			wui_maps = <&wui_iob0 &wui_iob1 &wui_iob2 &wui_iob3
+			wui-maps = <&wui_iob0 &wui_iob1 &wui_iob2 &wui_iob3
 				    &wui_iob4 &wui_iob5 &wui_none &wui_iob7>;
 			#gpio-cells=<2>;
 			label="GPIO_B";
@@ -333,7 +333,7 @@
 			reg = <0x40099000 0x2000>;
 			gpio-controller;
 			index = <0xC>;
-			wui_maps = <&wui_ioc0 &wui_ioc1 &wui_ioc2 &wui_ioc3
+			wui-maps = <&wui_ioc0 &wui_ioc1 &wui_ioc2 &wui_ioc3
 				    &wui_ioc4 &wui_ioc5 &wui_ioc6 &wui_ioc7>;
 			#gpio-cells=<2>;
 			label="GPIO_C";
@@ -344,7 +344,7 @@
 			reg = <0x4009b000 0x2000>;
 			gpio-controller;
 			index = <0xD>;
-			wui_maps = <&wui_iod0 &wui_iod1 &wui_iod2 &wui_iod3
+			wui-maps = <&wui_iod0 &wui_iod1 &wui_iod2 &wui_iod3
 				    &wui_iod4 &wui_iod5 &wui_none &wui_iod7>;
 			#gpio-cells=<2>;
 			label="GPIO_D";
@@ -355,7 +355,7 @@
 			reg = <0x4009d000 0x2000>;
 			gpio-controller;
 			index = <0xE>;
-			wui_maps = <&wui_ioe0 &wui_ioe1 &wui_ioe2 &wui_ioe3
+			wui-maps = <&wui_ioe0 &wui_ioe1 &wui_ioe2 &wui_ioe3
 				    &wui_ioe4 &wui_ioe5 &wui_none &wui_none>;
 			#gpio-cells=<2>;
 			label="GPIO_E";
@@ -366,7 +366,7 @@
 			reg = <0x4009f000 0x2000>;
 			gpio-controller;
 			index = <0xF>;
-			wui_maps = <&wui_iof0 &wui_iof1 &wui_iof2 &wui_iof3
+			wui-maps = <&wui_iof0 &wui_iof1 &wui_iof2 &wui_iof3
 				    &wui_iof4 &wui_iof5 &wui_none &wui_none>;
 			#gpio-cells=<2>;
 			label="GPIO_F";
@@ -476,7 +476,7 @@
 		twd0: watchdog@400d8000 {
 			compatible = "nuvoton,npcx-watchdog";
 			reg = <0x400d8000 0x2000>;
-			t0_out = <&wui_t0out>;
+			t0-out = <&wui_t0out>;
 			label = "TWD_0";
 		};
 
@@ -490,7 +490,7 @@
 			/* PIN46.47.51.52.53.54.55.57 */
 			pinctrl-0 = <&alt1_no_lpc_espi>;
 			/* WUI maps for eSPI signals */
-			espi_rst_wui = <&wui_espi_rst>;
+			espi-rst-wui = <&wui_espi_rst>;
 			label = "ESPI_0";
 
 			#address-cells = <1>;
@@ -521,7 +521,7 @@
 					  "pmch_obe", "p80_fifo";
 
 			/* WUI map for accessing host sub-modules */
-			host_acc_wui = <&wui_host_acc>;
+			host-acc-wui = <&wui_host_acc>;
 
 			/* clocks for host sub-modules */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 3>,

--- a/dts/bindings/espi/nuvoton,npcx-espi.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-espi.yaml
@@ -21,11 +21,11 @@ properties:
         required: true
         description: configurations of pinmux controllers
 
-    espi_rst_wui:
+    espi-rst-wui:
         type: phandle
         required: true
         description: |
             Mapping table between Wake-Up Input (WUI) and ESPI_RST signal.
 
             For example the WUI mapping on NPCX7 would be
-               espi_rst_wui = <&wui_cr_sin1>;
+               espi-rst-wui = <&wui_cr_sin1>;

--- a/dts/bindings/espi/nuvoton,npcx-host-sub.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-host-sub.yaml
@@ -16,7 +16,7 @@ properties:
         required: true
         description: configurations of device source clock controller
 
-    host_acc_wui:
+    host-acc-wui:
         type: phandle
         required: true
         description: |
@@ -24,4 +24,4 @@ properties:
             access transactions.
 
             For example the WUI mapping on NPCX7 would be
-               host_acc_wui = <&wui_host_acc>;
+               host-acc-wui = <&wui_host_acc>;

--- a/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
@@ -19,7 +19,7 @@ properties:
         required: true
         description: index of gpio device
 
-    wui_maps:
+    wui-maps:
         type: phandles
         required: true
         description: |
@@ -28,7 +28,7 @@ properties:
             In this case, it will be presented by wui_none.
 
             For example the WUI mapping on NPCX7 GPIO8 would be
-               wui_maps = <&wui_io80 &wui_io81 &wui_io82 &wui_io83
+               wui-maps = <&wui_io80 &wui_io81 &wui_io82 &wui_io83
                            &wui_none &wui_none &wui_io86 &wui_io87>;
 
     "#gpio-cells":

--- a/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-def.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-def.yaml
@@ -8,7 +8,7 @@ compatible: "nuvoton,npcx-lvolctrl-def"
 include: [base.yaml]
 
 properties:
-    lvol_io_pads:
+    lvol-io-pads:
         type: phandles
         required: false
         description: list of low-voltage configurations that need to set by default

--- a/dts/bindings/serial/nuvoton,npcx-uart.yaml
+++ b/dts/bindings/serial/nuvoton,npcx-uart.yaml
@@ -16,11 +16,11 @@ properties:
         type: phandles
         required: true
         description: configurations of pinmux controllers
-    uart_rx:
+    uart-rx:
         type: phandle
         required: true
         description: |
             Mapping table between Wake-Up Input (WUI) and uart rx START signal.
 
             For example the WUI mapping on NPCX7 UART1 would be
-               uart_rx = <&wui_cr_sin1>;
+               uart-rx = <&wui_cr_sin1>;

--- a/dts/bindings/tach/nuvoton,npcx-tach.yaml
+++ b/dts/bindings/tach/nuvoton,npcx-tach.yaml
@@ -16,7 +16,7 @@ properties:
         type: phandles
         required: false
         description: configurations of pinmux controllers in tachometers
-    sample_clk:
+    sample-clk:
         type: int
         required: false
         description: |
@@ -26,7 +26,7 @@ properties:
         type: int
         required: false
         description: selected port of tachometer (port-A is 0 and port-B is 1)
-    pulses_per_round:
+    pulses-per-round:
         type: int
         required: false
         description: number of pulses (holes) per round of tachometer's input (encoder)

--- a/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
+++ b/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
@@ -12,10 +12,10 @@ properties:
         required: true
     label:
         required: true
-    t0_out:
+    t0-out:
         type: phandle
         required: true
         description: |
             Mapping table between Wake-Up Input (WUI) and t0-out timer expired signal.
             For example, the WUI mapping on NPCX7 t0-out timer would be
-               t0_out = <&wui_t0out>;
+               t0-out = <&wui_t0out>;

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -23,7 +23,7 @@ struct npcx_scfg_config {
  * Get io list which default functionality are not IOs. Then switch them to
  * GPIO in pin-mux init function.
  *
- * def_io_conf: def_io_conf_list {
+ * def_io_conf: def-io-conf-list {
  *               compatible = "nuvoton,npcx-pinctrl-def";
  *               pinctrl-0 = <&alt0_gpio_no_spip
  *                            &alt0_gpio_no_fpip

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -293,20 +293,20 @@
 	}
 
 /**
- * @brief Get phandle from 'wui_maps' prop which type is 'phandles' at index 'i'
+ * @brief Get phandle from 'wui-maps' prop which type is 'phandles' at index 'i'
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @param i index of 'wui_maps' prop which type is 'phandles'
- * @return phandle from 'wui_maps' prop at index 'i'
+ * @param i index of 'wui-maps' prop which type is 'phandles'
+ * @return phandle from 'wui-maps' prop at index 'i'
  */
 #define NPCX_DT_PHANDLE_FROM_WUI_MAPS(inst, i) \
 	DT_INST_PHANDLE_BY_IDX(inst, wui_maps, i)
 
 /**
- * @brief Construct a npcx_wui structure from wui_maps property at index 'i'
+ * @brief Construct a npcx_wui structure from wui-maps property at index 'i'
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @param i index of 'wui_maps' prop which type is 'phandles'
+ * @param i index of 'wui-maps' prop which type is 'phandles'
  * @return npcx_wui item at index 'i'
  */
 #define NPCX_DT_WUI_ITEM_BY_IDX(inst, i) \
@@ -319,10 +319,10 @@
 	},
 
 /**
- * @brief Length of npcx_wui structures in 'wui_maps' property
+ * @brief Length of npcx_wui structures in 'wui-maps' property
  *
  * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @return length of 'wui_maps' prop which type is 'phandles'
+ * @return length of 'wui-maps' prop which type is 'phandles'
  */
 #define NPCX_DT_WUI_ITEMS_LEN(inst) DT_INST_PROP_LEN(inst, wui_maps)
 
@@ -342,12 +342,12 @@
  * Example devicetree fragment:
  *    / {
  *		uart1: serial@400c4000 {
- *			uart_rx = <&wui_cr_sin1>;
+ *			uart-rx = <&wui_cr_sin1>;
  *			...
  *		};
  *
  *		gpio0: gpio@40081000 {
- *			wui_maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03
+ *			wui-maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03
  *				    &wui_io04 &wui_io05 &wui_io06 &wui_io07>;
  *			...
  *		};
@@ -406,9 +406,9 @@
 	} while (0)
 
 /**
- * @brief Get a child node from path '/npcx7_espi_vws_map/name'.
+ * @brief Get a child node from path '/npcx7-espi-vws-map/name'.
  *
- * @param name a path which name is /npcx7_espi_vws_map/'name'.
+ * @param name a path which name is /npcx7-espi-vws-map/'name'.
  * @return child node identifier with that path.
  */
 #define NPCX_DT_NODE_FROM_VWTABLE(name) DT_CHILD(DT_PATH(npcx7_espi_vws_map),  \
@@ -417,7 +417,7 @@
 /**
  * @brief Get phandle from wui_map property of child node with that path.
  *
- * @param name path which name is /npcx7_espi_vws_map/'name'.
+ * @param name path which name is /npcx7-espi-vws-map/'name'.
  * @return phandle from "wui_map" prop of child node with that path.
  */
 #define NPCX_DT_PHANDLE_VW_WUI(name) DT_PHANDLE(NPCX_DT_NODE_FROM_VWTABLE(     \
@@ -427,7 +427,7 @@
  * @brief Construct a npcx_wui structure from wui_map property of a child node
  * with that path.
  *
- * @param name a path which name is /npcx7_espi_vws_map/'name'.
+ * @param name a path which name is /npcx7-espi-vws-map/'name'.
  * @return npcx_wui item with that path.
  */
 #define NPCX_DT_VW_WUI_ITEM(name)			                       \
@@ -443,7 +443,7 @@
  * a child node with that path.
  *
  * @signal vw input signal name.
- * @param name a path which name is /npcx7_espi_vws_map/'name'.
+ * @param name a path which name is /npcx7-espi-vws-map/'name'.
  * @return npcx_vw_in_config item with that path.
  */
 #define NPCX_DT_VW_IN_CONF(signal, name)                                       \
@@ -461,7 +461,7 @@
  * a child node with that path.
  *
  * @signal vw output signal name.
- * @param name a path which name is /npcx7_espi_vws_map/'name'.
+ * @param name a path which name is /npcx7-espi-vws-map/'name'.
  * @return npcx_vw_in_config item with that path.
  */
 #define NPCX_DT_VW_OUT_CONF(signal, name)                                      \
@@ -475,7 +475,7 @@
 
 /**
  * @brief Get a node from path '/def_lvol_io_list' which has a property
- *        'lvol_io_pads' contains low-voltage configurations and need to set
+ *        'lvol-io-pads' contains low-voltage configurations and need to set
  *        by default.
  *
  * @return node identifier with that path.
@@ -483,29 +483,29 @@
 #define NPCX_DT_NODE_DEF_LVOL_LIST  DT_PATH(def_lvol_io_list)
 
 /**
- * @brief Length of npcx_lvol structures in 'lvol_io_pads' property
+ * @brief Length of npcx_lvol structures in 'lvol-io-pads' property
  *
- * @return length of 'lvol_io_pads' prop which type is 'phandles'
+ * @return length of 'lvol-io-pads' prop which type is 'phandles'
  */
 #define NPCX_DT_LVOL_ITEMS_LEN DT_PROP_LEN(NPCX_DT_NODE_DEF_LVOL_LIST, \
 								lvol_io_pads)
 
 /**
- * @brief Get phandle from 'lvol_io_pads' prop which type is 'phandles' at index
+ * @brief Get phandle from 'lvol-io-pads' prop which type is 'phandles' at index
  *        'i'
  *
- * @param i index of 'lvol_io_pads' prop which type is 'phandles'
- * @return phandle from 'lvol_io_pads' prop at index 'i'
+ * @param i index of 'lvol-io-pads' prop which type is 'phandles'
+ * @return phandle from 'lvol-io-pads' prop at index 'i'
  */
 #define NPCX_DT_PHANDLE_FROM_LVOL_IO_PADS(i) \
 	DT_PHANDLE_BY_IDX(NPCX_DT_NODE_DEF_LVOL_LIST, lvol_io_pads, i)
 
 /**
- * @brief Construct a npcx_lvol structure from 'lvol_io_pads' property at index
+ * @brief Construct a npcx_lvol structure from 'lvol-io-pads' property at index
  *        'i'.
  *
- * @param i index of 'lvol_io_pads' prop which type is 'phandles'
- * @return npcx_lvol item from 'lvol_io_pads' property at index 'i'
+ * @param i index of 'lvol-io-pads' prop which type is 'phandles'
+ * @return npcx_lvol item from 'lvol-io-pads' property at index 'i'
  */
 #define NPCX_DT_LVOL_ITEMS_BY_IDX(i, _)                                        \
 	{                                                                      \
@@ -527,7 +527,7 @@
  *    / {
  *          def_lvol_io_list {
  *              compatible = "nuvoton,npcx-lvolctrl-def";
- *              lvol_io_pads = <&lvol_io90   // I2C1_SCL0 1.8V support
+ *              lvol-io-pads = <&lvol_io90   // I2C1_SCL0 1.8V support
  *                              &lvol_io87>; // I2C1_SDA0 1,8V support
  *          };
  *	};


### PR DESCRIPTION
Fixed the name of nodes in device-tree files by following rules:

If object is 'phandles', use underscores for object name.
If not, such as 'node' or 'property', use hyphens for object name.

This CL also applies normal style for all nodes in npcx device-tree
files.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>