### PR TITLE
EDAC: Fixing API and API docs generation, fixing static analyzer warnings

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -402,12 +402,12 @@ int edac_ibecc_init(const struct device *dev)
 
 	mchbar &= MCHBAR_MASK;
 
-	/* workaround for 32 bit read */
+	/* TODO: Use 64 bit API when available */
 	touud = pcie_conf_read(bdf, TOUUD_REG);
 	touud |= (uint64_t)pcie_conf_read(bdf, TOUUD_REG + 1) << 32;
 	touud &= TOUUD_MASK;
 
-	/* workaround for 32 bit read */
+	/* TODO: Use 64 bit API when available */
 	tom = pcie_conf_read(bdf, TOM_REG);
 	tom |= (uint64_t)pcie_conf_read(bdf, TOM_REG + 1) << 32;
 	tom &= TOM_MASK;

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -207,9 +207,11 @@ static int inject_set_param1(const struct device *dev, uint64_t addr)
 	return 0;
 }
 
-static uint64_t inject_get_param1(const struct device *dev)
+static int inject_get_param1(const struct device *dev, uint64_t *value)
 {
-	return ibecc_read_reg64(dev, IBECC_INJ_ADDR_BASE);
+	*value = ibecc_read_reg64(dev, IBECC_INJ_ADDR_BASE);
+
+	return 0;
 }
 
 static int inject_set_param2(const struct device *dev, uint64_t mask)
@@ -223,9 +225,11 @@ static int inject_set_param2(const struct device *dev, uint64_t mask)
 	return 0;
 }
 
-static uint64_t inject_get_param2(const struct device *dev)
+static int inject_get_param2(const struct device *dev, uint64_t *value)
 {
-	return ibecc_read_reg64(dev, IBECC_INJ_ADDR_MASK);
+	*value = ibecc_read_reg64(dev, IBECC_INJ_ADDR_MASK);
+
+	return 0;
 }
 
 static int inject_set_error_type(const struct device *dev,
@@ -238,11 +242,14 @@ static int inject_set_error_type(const struct device *dev,
 	return 0;
 }
 
-static uint32_t inject_get_error_type(const struct device *dev)
+static int inject_get_error_type(const struct device *dev,
+				      uint32_t *error_type)
 {
 	struct ibecc_data *data = dev->data;
 
-	return data->error_type;
+	*error_type = data->error_type;
+
+	return 0;
 }
 
 static int inject_error_trigger(const struct device *dev)
@@ -268,9 +275,11 @@ static int inject_error_trigger(const struct device *dev)
 }
 #endif /* CONFIG_EDAC_ERROR_INJECT */
 
-static uint64_t ecc_error_log_get(const struct device *dev)
+static int ecc_error_log_get(const struct device *dev, uint64_t *value)
 {
-	return ibecc_read_reg64(dev, IBECC_ECC_ERROR_LOG);
+	*value = ibecc_read_reg64(dev, IBECC_ECC_ERROR_LOG);
+
+	return 0;
 }
 
 static void ecc_error_log_clear(const struct device *dev)
@@ -280,9 +289,11 @@ static void ecc_error_log_clear(const struct device *dev)
 			  ECC_ERROR_MERRSTS | ECC_ERROR_CERRSTS);
 }
 
-static uint64_t parity_error_log_get(const struct device *dev)
+static int parity_error_log_get(const struct device *dev, uint64_t *value)
 {
-	return ibecc_read_reg64(dev, IBECC_PARITY_ERROR_LOG);
+	*value = ibecc_read_reg64(dev, IBECC_PARITY_ERROR_LOG);
+
+	return 0;
 }
 
 static void parity_error_log_clear(const struct device *dev)
@@ -485,7 +496,10 @@ bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 		goto out;
 	}
 
-	ecclog = edac_ecc_error_log_get(dev);
+	if (edac_ecc_error_log_get(dev, &ecclog)) {
+		goto out;
+	}
+
 	parse_ecclog(dev, ecclog, &error_data);
 
 	if (data->cb) {

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -285,33 +285,23 @@ int edac_ibecc_init(const struct device *dev)
 	uint64_t mchbar;
 	uint32_t conf_data;
 
-	LOG_INF("EDAC IBECC initialization");
-
 	conf_data = pcie_conf_read(bdf, PCIE_CONF_ID);
 	switch (conf_data) {
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU5):
-		LOG_INF("SKU5");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU6):
-		LOG_INF("SKU6");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU7):
-		LOG_INF("SKU7");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU8):
-		LOG_INF("SKU8");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU9):
-		LOG_INF("SKU9");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU10):
-		LOG_INF("SKU10");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU11):
-		LOG_INF("SKU11");
-		break;
+		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU12):
-		LOG_INF("SKU12");
 		break;
 	default:
 		LOG_ERR("PCI Probe failed");

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -361,27 +361,38 @@ int edac_ibecc_init(const struct device *dev)
 {
 	const pcie_bdf_t bdf = PCI_HOST_BRIDGE;
 	struct ibecc_data *data = dev->data;
-	uint32_t tolud;
 	uint64_t touud, tom, mchbar;
+	uint32_t tolud, conf_data;
 
 	LOG_INF("EDAC IBECC initialization");
 
-	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU5)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU6)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU7)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU8)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU9)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU10)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU11)) &&
-	    !pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_SKU12))) {
+	conf_data = pcie_conf_read(bdf, PCIE_CONF_ID);
+	switch (conf_data) {
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU5):
+		LOG_INF("SKU5");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU6):
+		LOG_INF("SKU6");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU7):
+		LOG_INF("SKU7");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU8):
+		LOG_INF("SKU8");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU9):
+		LOG_INF("SKU9");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU10):
+		LOG_INF("SKU10");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU11):
+		LOG_INF("SKU11");
+		break;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU12):
+		LOG_INF("SKU12");
+		break;
+	default:
 		LOG_ERR("PCI Probe failed");
 		return -ENODEV;
 	}

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -282,11 +282,13 @@ static int ecc_error_log_get(const struct device *dev, uint64_t *value)
 	return 0;
 }
 
-static void ecc_error_log_clear(const struct device *dev)
+static int ecc_error_log_clear(const struct device *dev)
 {
 	/* Clear all error bits */
 	ibecc_write_reg64(dev, IBECC_ECC_ERROR_LOG,
 			  ECC_ERROR_MERRSTS | ECC_ERROR_CERRSTS);
+
+	return 0;
 }
 
 static int parity_error_log_get(const struct device *dev, uint64_t *value)
@@ -296,19 +298,21 @@ static int parity_error_log_get(const struct device *dev, uint64_t *value)
 	return 0;
 }
 
-static void parity_error_log_clear(const struct device *dev)
+static int parity_error_log_clear(const struct device *dev)
 {
 	ibecc_write_reg64(dev, IBECC_PARITY_ERROR_LOG, PARITY_ERROR_ERRSTS);
+
+	return 0;
 }
 
-static unsigned int errors_cor_get(const struct device *dev)
+static int errors_cor_get(const struct device *dev)
 {
 	struct ibecc_data *data = dev->data;
 
 	return data->errors_cor;
 }
 
-static unsigned int errors_uc_get(const struct device *dev)
+static int errors_uc_get(const struct device *dev)
 {
 	struct ibecc_data *data = dev->data;
 

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -65,7 +65,7 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -73,19 +73,19 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 	shell_fprintf(shell, SHELL_NORMAL, "Show EDAC status\n");
 
 	err = edac_ecc_error_log_get(dev, &error);
-	if (err) {
+	if (err != 0) {
 		shell_error(shell, "Error getting ecc error log");
 		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "ECC Error Log 0x%llx\n", error);
 
-	if (error) {
+	if (error != 0) {
 		decode_ecc_error(shell, error);
 	}
 
 	err = edac_parity_error_log_get(dev, &error);
-	if (err) {
+	if (err != 0) {
 		shell_error(shell, "Error getting parity error log");
 		return err;
 	}
@@ -106,7 +106,7 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -122,7 +122,7 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 		uint64_t addr;
 
 		err = edac_inject_get_param1(dev, &addr);
-		if (err) {
+		if (err != 0) {
 			shell_error(shell, "Error getting address");
 			return err;
 		}
@@ -136,7 +136,7 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 			      "Set injection address base to: %s\n", argv[1]);
 
 		err = edac_inject_set_param1(dev, value);
-		if (err) {
+		if (err != 0) {
 			shell_error(shell, "Error setting address");
 			return err;
 		}
@@ -151,7 +151,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -167,7 +167,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 		uint64_t mask;
 
 		err = edac_inject_get_param2(dev, &mask);
-		if (err) {
+		if (err != 0) {
 			shell_error(shell, "Error getting mask");
 			return err;
 		}
@@ -181,7 +181,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 			      "Set injection address mask to %lx\n", value);
 
 		err = edac_inject_set_param2(dev, value);
-		if (err) {
+		if (err != 0) {
 			shell_error(shell, "Error setting mask");
 			return err;
 		}
@@ -196,7 +196,7 @@ static int cmd_inject_trigger(const struct shell *shell, size_t argc,
 	const struct device *dev;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -244,13 +244,13 @@ static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
 
 	err = edac_inject_get_error_type(dev, &error_type);
-	if (err) {
+	if (err != 0) {
 		shell_error(shell, "Error getting error type");
 		return err;
 	}
@@ -266,7 +266,7 @@ static int set_error_type(const struct shell *shell, uint32_t error_type)
 	const struct device *dev;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -294,7 +294,7 @@ static int cmd_inject_test(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -339,20 +339,20 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
 
 	err = edac_ecc_error_log_get(dev, &error);
-	if (err) {
+	if (err != 0) {
 		shell_error(shell, "Error getting error log");
 		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "ECC Error: 0x%lx\n", error);
 
-	if (error) {
+	if (error != 0) {
 		decode_ecc_error(shell, error);
 	}
 
@@ -365,7 +365,7 @@ static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
 	const struct device *dev;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
@@ -391,13 +391,13 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}
 
 	err = edac_parity_error_log_get(dev, &error);
-	if (err) {
+	if (err != 0) {
 		shell_error(shell, "Error getting parity error log");
 		return err;
 	}
@@ -413,7 +413,7 @@ static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
 	const struct device *dev;
 
 	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
+	if (dev == NULL) {
 		shell_error(shell, "IBECC device not found");
 		return -ENODEV;
 	}

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -74,7 +74,8 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 
 	err = edac_ecc_error_log_get(dev, &error);
 	if (err != 0) {
-		shell_error(shell, "Error getting ecc error log");
+		shell_error(shell, "Error getting ecc error log (err %d)",
+			    err);
 		return err;
 	}
 
@@ -86,7 +87,8 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 
 	err = edac_parity_error_log_get(dev, &error);
 	if (err != 0) {
-		shell_error(shell, "Error getting parity error log");
+		shell_error(shell, "Error getting parity error log (err %d)",
+			    err);
 		return err;
 	}
 
@@ -123,7 +125,8 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_get_param1(dev, &addr);
 		if (err != 0) {
-			shell_error(shell, "Error getting address");
+			shell_error(shell, "Error getting address (err %d)",
+				    err);
 			return err;
 		}
 
@@ -137,7 +140,8 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_set_param1(dev, value);
 		if (err != 0) {
-			shell_error(shell, "Error setting address");
+			shell_error(shell, "Error setting address (err %d)",
+				    err);
 			return err;
 		}
 	}
@@ -168,7 +172,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_get_param2(dev, &mask);
 		if (err != 0) {
-			shell_error(shell, "Error getting mask");
+			shell_error(shell, "Error getting mask (err %d)", err);
 			return err;
 		}
 
@@ -182,7 +186,7 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_set_param2(dev, value);
 		if (err != 0) {
-			shell_error(shell, "Error setting mask");
+			shell_error(shell, "Error setting mask (err %d)", err);
 			return err;
 		}
 	}
@@ -251,7 +255,7 @@ static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
 
 	err = edac_inject_get_error_type(dev, &error_type);
 	if (err != 0) {
-		shell_error(shell, "Error getting error type");
+		shell_error(shell, "Error getting error type (err %d)", err);
 		return err;
 	}
 
@@ -346,7 +350,7 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 
 	err = edac_ecc_error_log_get(dev, &error);
 	if (err != 0) {
-		shell_error(shell, "Error getting error log");
+		shell_error(shell, "Error getting error log (err %d)", err);
 		return err;
 	}
 
@@ -404,7 +408,8 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 
 	err = edac_parity_error_log_get(dev, &error);
 	if (err != 0) {
-		shell_error(shell, "Error getting parity error log");
+		shell_error(shell, "Error getting parity error log (err %d)",
+			    err);
 		return err;
 	}
 

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -62,7 +62,7 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint64_t error;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -72,10 +72,10 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 
 	shell_fprintf(shell, SHELL_NORMAL, "Show EDAC status\n");
 
-	ret = edac_ecc_error_log_get(dev, &error);
-	if (ret) {
+	err = edac_ecc_error_log_get(dev, &error);
+	if (err) {
 		shell_error(shell, "Error getting ecc error log");
-		return ret;
+		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "ECC Error Log 0x%llx\n", error);
@@ -84,10 +84,10 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 		decode_ecc_error(shell, error);
 	}
 
-	ret = edac_parity_error_log_get(dev, &error);
-	if (ret) {
+	err = edac_parity_error_log_get(dev, &error);
+	if (err) {
 		shell_error(shell, "Error getting parity error log");
-		return ret;
+		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Parity Error Log 0x%llx\n", error);
@@ -96,14 +96,14 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 		      "Errors correctable: %d Errors uncorrectable %d\n",
 		      edac_errors_cor_get(dev), edac_errors_uc_get(dev));
 
-	return ret;
+	return err;
 }
 
 #if defined(CONFIG_EDAC_ERROR_INJECT)
 static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 {
 	const struct device *dev;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -121,10 +121,10 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 	if (argc == 1) {
 		uint64_t addr;
 
-		ret = edac_inject_get_param1(dev, &addr);
-		if (ret) {
+		err = edac_inject_get_param1(dev, &addr);
+		if (err) {
 			shell_error(shell, "Error getting address");
-			return ret;
+			return err;
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
@@ -135,20 +135,20 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "Set injection address base to: %s\n", argv[1]);
 
-		ret = edac_inject_set_param1(dev, value);
-		if (ret) {
+		err = edac_inject_set_param1(dev, value);
+		if (err) {
 			shell_error(shell, "Error setting address");
-			return ret;
+			return err;
 		}
 	}
 
-	return ret;
+	return err;
 }
 
 static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 {
 	const struct device *dev;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -166,10 +166,10 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 	if (argc == 1) {
 		uint64_t mask;
 
-		ret = edac_inject_get_param2(dev, &mask);
-		if (ret) {
+		err = edac_inject_get_param2(dev, &mask);
+		if (err) {
 			shell_error(shell, "Error getting mask");
-			return ret;
+			return err;
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
@@ -180,14 +180,14 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "Set injection address mask to %lx\n", value);
 
-		ret = edac_inject_set_param2(dev, value);
-		if (ret) {
+		err = edac_inject_set_param2(dev, value);
+		if (err) {
 			shell_error(shell, "Error setting mask");
-			return ret;
+			return err;
 		}
 	}
 
-	return ret;
+	return err;
 }
 
 static int cmd_inject_trigger(const struct shell *shell, size_t argc,
@@ -241,7 +241,7 @@ static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
 {
 	const struct device *dev;
 	uint32_t error_type;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -249,16 +249,16 @@ static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
 		return -ENODEV;
 	}
 
-	ret = edac_inject_get_error_type(dev, &error_type);
-	if (ret) {
+	err = edac_inject_get_error_type(dev, &error_type);
+	if (err) {
 		shell_error(shell, "Error getting error type");
-		return ret;
+		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Injection error type: %s\n",
 		      get_error_type(error_type));
 
-	return ret;
+	return err;
 }
 
 static int set_error_type(const struct shell *shell, uint32_t error_type)
@@ -336,7 +336,7 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 {
 	const struct device *dev;
 	uint64_t error;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -344,10 +344,10 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 		return -ENODEV;
 	}
 
-	ret = edac_ecc_error_log_get(dev, &error);
-	if (ret) {
+	err = edac_ecc_error_log_get(dev, &error);
+	if (err) {
 		shell_error(shell, "Error getting error log");
-		return ret;
+		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "ECC Error: 0x%lx\n", error);
@@ -356,7 +356,7 @@ static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
 		decode_ecc_error(shell, error);
 	}
 
-	return ret;
+	return err;
 }
 
 static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
@@ -388,7 +388,7 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 {
 	const struct device *dev;
 	uint64_t error;
-	int ret;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (!dev) {
@@ -396,10 +396,10 @@ static int cmd_parity_error_show(const struct shell *shell, size_t argc,
 		return -ENODEV;
 	}
 
-	ret = edac_parity_error_log_get(dev, &error);
-	if (ret) {
+	err = edac_parity_error_log_get(dev, &error);
+	if (err) {
 		shell_error(shell, "Error getting parity error log");
-		return ret;
+		return err;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Parity Error: 0x%lx\n", error);

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -363,6 +363,7 @@ static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
 			       char **argv)
 {
 	const struct device *dev;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (dev == NULL) {
@@ -370,7 +371,12 @@ static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
 		return -ENODEV;
 	}
 
-	edac_ecc_error_log_clear(dev);
+	err = edac_ecc_error_log_clear(dev);
+	if (err != 0) {
+		shell_error(shell, "Error clear ecc error log (err %d)",
+			    err);
+		return err;
+	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "ECC Error Log cleared\n");
 
@@ -411,6 +417,7 @@ static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
 				  char **argv)
 {
 	const struct device *dev;
+	int err;
 
 	dev = device_get_binding(DEVICE_NAME);
 	if (dev == NULL) {
@@ -418,7 +425,12 @@ static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
 		return -ENODEV;
 	}
 
-	edac_parity_error_log_clear(dev);
+	err = edac_parity_error_log_clear(dev);
+	if (err != 0) {
+		shell_error(shell, "Error clear parity error log (err %d)",
+			    err);
+		return err;
+	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Parity Error Log cleared\n");
 

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -49,18 +49,20 @@ __subsystem struct edac_driver_api {
 
 	/* Error Logging  API */
 	int (*ecc_error_log_get)(const struct device *dev, uint64_t *value);
-	void (*ecc_error_log_clear)(const struct device *dev);
+	int (*ecc_error_log_clear)(const struct device *dev);
 	int (*parity_error_log_get)(const struct device *dev, uint64_t *value);
-	void (*parity_error_log_clear)(const struct device *dev);
+	int (*parity_error_log_clear)(const struct device *dev);
 
 	/* Error stats API */
-	unsigned int (*errors_cor_get)(const struct device *dev);
-	unsigned int (*errors_uc_get)(const struct device *dev);
+	int (*errors_cor_get)(const struct device *dev);
+	int (*errors_uc_get)(const struct device *dev);
 
 	/* Notification callback API */
 	int (*notify_cb_set)(const struct device *dev,
 			     edac_notify_callback_f cb);
 };
+
+/* Optional interfaces */
 
 /**
  * @brief Set injection parameter param1
@@ -227,6 +229,8 @@ static inline int edac_inject_error_trigger(const struct device *dev)
 	return api->inject_error_trigger(dev);
 }
 
+/* Mandatory interfaces */
+
 /**
  * @brief Get ECC Error Log
  *
@@ -236,6 +240,7 @@ static inline int edac_inject_error_trigger(const struct device *dev)
  * @param value Pointer to the ECC Error Log value
  *
  * @retval 0 on success, error code otherwise
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
 static inline int edac_ecc_error_log_get(const struct device *dev,
 					 uint64_t *value)
@@ -243,8 +248,9 @@ static inline int edac_ecc_error_log_get(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->ecc_error_log_get,
-		 "ecc_error_log_get must be implemented by driver");
+	if (!api->ecc_error_log_get) {
+		return -ENOSYS;
+	}
 
 	return api->ecc_error_log_get(dev, value);
 }
@@ -255,16 +261,20 @@ static inline int edac_ecc_error_log_get(const struct device *dev,
  * Clear value of ECC Error Log.
  *
  * @param dev Pointer to the device structure
+ *
+ * @retval 0 on success, error code otherwise
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
-static inline void edac_ecc_error_log_clear(const struct device *dev)
+static inline int edac_ecc_error_log_clear(const struct device *dev)
 {
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->ecc_error_log_clear,
-		 "ecc_error_log_clear must be implemented by driver");
+	if (!api->ecc_error_log_clear) {
+		return -ENOSYS;
+	}
 
-	api->ecc_error_log_clear(dev);
+	return api->ecc_error_log_clear(dev);
 }
 
 /**
@@ -276,6 +286,7 @@ static inline void edac_ecc_error_log_clear(const struct device *dev)
  * @param value Pointer to the parity Error Log value
  *
  * @retval 0 on success, error code otherwise
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
 static inline int edac_parity_error_log_get(const struct device *dev,
 					    uint64_t *value)
@@ -283,8 +294,9 @@ static inline int edac_parity_error_log_get(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->parity_error_log_get,
-		 "parity_error_log_get must be implemented by driver");
+	if (!api->parity_error_log_get) {
+		return -ENOSYS;
+	}
 
 	return api->parity_error_log_get(dev, value);
 }
@@ -295,16 +307,20 @@ static inline int edac_parity_error_log_get(const struct device *dev,
  * Clear value of Parity Error Log.
  *
  * @param dev Pointer to the device structure
+ *
+ * @retval 0 on success, error code otherwise
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
-static inline void edac_parity_error_log_clear(const struct device *dev)
+static inline int edac_parity_error_log_clear(const struct device *dev)
 {
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->parity_error_log_clear,
-		 "parity_error_log_clear must be implemented by driver");
+	if (!api->parity_error_log_clear) {
+		return -ENOSYS;
+	}
 
-	api->parity_error_log_clear(dev);
+	return api->parity_error_log_clear(dev);
 }
 
 /**
@@ -312,15 +328,17 @@ static inline void edac_parity_error_log_clear(const struct device *dev)
  *
  * @param dev Pointer to the device structure
  *
- * @return Number of correctable errors
+ * @retval num Number of correctable errors
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
-static inline unsigned int edac_errors_cor_get(const struct device *dev)
+static inline int edac_errors_cor_get(const struct device *dev)
 {
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->errors_cor_get,
-		 "errors_cor_get must be implemented by driver");
+	if (!api->errors_cor_get) {
+		return -ENOSYS;
+	}
 
 	return api->errors_cor_get(dev);
 }
@@ -330,15 +348,17 @@ static inline unsigned int edac_errors_cor_get(const struct device *dev)
  *
  * @param dev Pointer to the device structure
  *
- * @return Number of uncorrectable errors
+ * @retval num Number of uncorrectable errors
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
-static inline unsigned int edac_errors_uc_get(const struct device *dev)
+static inline int edac_errors_uc_get(const struct device *dev)
 {
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	__ASSERT(api->errors_uc_get,
-		 "errors_uc_get must be implemented by driver");
+	if (!api->errors_uc_get) {
+		return -ENOSYS;
+	}
 
 	return api->errors_uc_get(dev);
 }
@@ -352,14 +372,16 @@ static inline unsigned int edac_errors_uc_get(const struct device *dev)
  * @param cb Callback function pointer
  *
  * @retval 0 on success, error code otherwise
+ * @retval -ENOSYS if the mandatory interface is not implemented
  */
 static inline int edac_notify_callback_set(const struct device *dev,
 					   edac_notify_callback_f cb)
 {
 	const struct edac_driver_api *api = dev->api;
 
-	__ASSERT(api->notify_cb_set,
-		 "notify_cb_set must be implemented by driver");
+	if (!api->notify_cb_set) {
+		return -ENOSYS;
+	}
 
 	return api->notify_cb_set(dev, cb);
 }

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -70,8 +70,8 @@ __subsystem struct edac_driver_api {
  * @param dev Pointer to the device structure
  * @param value First injection parameter
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, other error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, other error code otherwise
  */
 static inline int edac_inject_set_param1(const struct device *dev,
 					 uint64_t value)
@@ -94,8 +94,8 @@ static inline int edac_inject_set_param1(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Pointer to the first injection parameter
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_get_param1(const struct device *dev,
 					 uint64_t *value)
@@ -119,8 +119,8 @@ static inline int edac_inject_get_param1(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Second injection parameter
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_set_param2(const struct device *dev,
 					 uint64_t value)
@@ -141,8 +141,8 @@ static inline int edac_inject_set_param2(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Pointer to the second injection parameter
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline uint64_t edac_inject_get_param2(const struct device *dev,
 					      uint64_t *value)
@@ -165,8 +165,8 @@ static inline uint64_t edac_inject_get_param2(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param error_type Error type value
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_set_error_type(const struct device *dev,
 					     uint32_t error_type)
@@ -189,8 +189,8 @@ static inline int edac_inject_set_error_type(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param error_type Pointer to error type value
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline uint32_t edac_inject_get_error_type(const struct device *dev,
 						  uint32_t *error_type)
@@ -212,8 +212,8 @@ static inline uint32_t edac_inject_get_error_type(const struct device *dev,
  *
  * @param dev Pointer to the device structure
  *
- * @return -ENOTSUP if not supported
- * @return 0 on success, error code otherwise
+ * @retval -ENOTSUP if not supported
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_error_trigger(const struct device *dev)
 {
@@ -235,7 +235,7 @@ static inline int edac_inject_error_trigger(const struct device *dev)
  * @param dev Pointer to the device structure
  * @param value Pointer to the ECC Error Log value
  *
- * @return 0 on success, error code otherwise
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_ecc_error_log_get(const struct device *dev,
 					 uint64_t *value)
@@ -275,7 +275,7 @@ static inline void edac_ecc_error_log_clear(const struct device *dev)
  * @param dev Pointer to the device structure
  * @param value Pointer to the parity Error Log value
  *
- * @return 0 on success, error code otherwise
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_parity_error_log_get(const struct device *dev,
 					    uint64_t *value)
@@ -311,6 +311,7 @@ static inline void edac_parity_error_log_clear(const struct device *dev)
  * @brief Get number of correctable errors
  *
  * @param dev Pointer to the device structure
+ *
  * @return Number of correctable errors
  */
 static inline unsigned int edac_errors_cor_get(const struct device *dev)
@@ -328,6 +329,7 @@ static inline unsigned int edac_errors_cor_get(const struct device *dev)
  * @brief Get number of uncorrectable errors
  *
  * @param dev Pointer to the device structure
+ *
  * @return Number of uncorrectable errors
  */
 static inline unsigned int edac_errors_uc_get(const struct device *dev)
@@ -349,7 +351,7 @@ static inline unsigned int edac_errors_uc_get(const struct device *dev)
  * @param dev EDAC driver device to install callback
  * @param cb Callback function pointer
  *
- * @return 0 Success, nonzero if an error occurred
+ * @retval 0 on success, error code otherwise
  */
 static inline int edac_notify_callback_set(const struct device *dev,
 					   edac_notify_callback_f cb)

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -38,7 +38,6 @@ enum edac_error_type {
  * This is the mandatory API any EDAC driver needs to expose.
  */
 __subsystem struct edac_driver_api {
-#if defined(CONFIG_EDAC_ERROR_INJECT)
 	/* Error Injection API is disabled by default */
 	int (*inject_set_param1)(const struct device *dev, uint64_t value);
 	int (*inject_get_param1)(const struct device *dev, uint64_t *value);
@@ -47,7 +46,6 @@ __subsystem struct edac_driver_api {
 	int (*inject_set_error_type)(const struct device *dev, uint32_t value);
 	int (*inject_get_error_type)(const struct device *dev, uint32_t *value);
 	int (*inject_error_trigger)(const struct device *dev);
-#endif /* CONFIG_EDAC_ERROR_INJECT */
 
 	/* Error Logging  API */
 	int (*ecc_error_log_get)(const struct device *dev, uint64_t *value);
@@ -63,8 +61,6 @@ __subsystem struct edac_driver_api {
 	int (*notify_cb_set)(const struct device *dev,
 			     edac_notify_callback_f cb);
 };
-
-#if defined(CONFIG_EDAC_ERROR_INJECT)
 
 /**
  * @brief Set injection parameter param1
@@ -230,8 +226,6 @@ static inline int edac_inject_error_trigger(const struct device *dev)
 
 	return api->inject_error_trigger(dev);
 }
-
-#endif /* CONFIG_EDAC_ERROR_INJECT */
 
 /**
  * @brief Get ECC Error Log

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -72,7 +72,7 @@ __subsystem struct edac_driver_api {
  * @param dev Pointer to the device structure
  * @param value First injection parameter
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, other error code otherwise
  */
 static inline int edac_inject_set_param1(const struct device *dev,
@@ -82,7 +82,7 @@ static inline int edac_inject_set_param1(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_set_param1 == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_set_param1(dev, value);
@@ -96,7 +96,7 @@ static inline int edac_inject_set_param1(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Pointer to the first injection parameter
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_get_param1(const struct device *dev,
@@ -106,7 +106,7 @@ static inline int edac_inject_get_param1(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_get_param1 == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_get_param1(dev, value);
@@ -121,7 +121,7 @@ static inline int edac_inject_get_param1(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Second injection parameter
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_set_param2(const struct device *dev,
@@ -131,7 +131,7 @@ static inline int edac_inject_set_param2(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_set_param2 == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_set_param2(dev, value);
@@ -143,7 +143,7 @@ static inline int edac_inject_set_param2(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param value Pointer to the second injection parameter
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline uint64_t edac_inject_get_param2(const struct device *dev,
@@ -153,7 +153,7 @@ static inline uint64_t edac_inject_get_param2(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_get_param2 == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_get_param2(dev, value);
@@ -167,7 +167,7 @@ static inline uint64_t edac_inject_get_param2(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param error_type Error type value
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_set_error_type(const struct device *dev,
@@ -177,7 +177,7 @@ static inline int edac_inject_set_error_type(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_set_error_type == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_set_error_type(dev, error_type);
@@ -191,7 +191,7 @@ static inline int edac_inject_set_error_type(const struct device *dev,
  * @param dev Pointer to the device structure
  * @param error_type Pointer to error type value
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline uint32_t edac_inject_get_error_type(const struct device *dev,
@@ -201,7 +201,7 @@ static inline uint32_t edac_inject_get_error_type(const struct device *dev,
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_get_error_type == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_get_error_type(dev, error_type);
@@ -214,7 +214,7 @@ static inline uint32_t edac_inject_get_error_type(const struct device *dev,
  *
  * @param dev Pointer to the device structure
  *
- * @retval -ENOTSUP if not supported
+ * @retval -ENOSYS if the optional interface is not implemented
  * @retval 0 on success, error code otherwise
  */
 static inline int edac_inject_error_trigger(const struct device *dev)
@@ -223,7 +223,7 @@ static inline int edac_inject_error_trigger(const struct device *dev)
 		(const struct edac_driver_api *)dev->api;
 
 	if (api->inject_error_trigger == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->inject_error_trigger(dev);

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -81,7 +81,7 @@ static inline int edac_inject_set_param1(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_set_param1) {
+	if (api->inject_set_param1 == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -105,7 +105,7 @@ static inline int edac_inject_get_param1(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_get_param1) {
+	if (api->inject_get_param1 == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -130,7 +130,7 @@ static inline int edac_inject_set_param2(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_set_param2) {
+	if (api->inject_set_param2 == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -152,7 +152,7 @@ static inline uint64_t edac_inject_get_param2(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_get_param2) {
+	if (api->inject_get_param2 == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -176,7 +176,7 @@ static inline int edac_inject_set_error_type(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_set_error_type) {
+	if (api->inject_set_error_type == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -200,7 +200,7 @@ static inline uint32_t edac_inject_get_error_type(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_get_error_type) {
+	if (api->inject_get_error_type == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -222,7 +222,7 @@ static inline int edac_inject_error_trigger(const struct device *dev)
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->inject_error_trigger) {
+	if (api->inject_error_trigger == NULL) {
 		return -ENOTSUP;
 	}
 
@@ -248,7 +248,7 @@ static inline int edac_ecc_error_log_get(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->ecc_error_log_get) {
+	if (api->ecc_error_log_get == NULL) {
 		return -ENOSYS;
 	}
 
@@ -270,7 +270,7 @@ static inline int edac_ecc_error_log_clear(const struct device *dev)
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->ecc_error_log_clear) {
+	if (api->ecc_error_log_clear == NULL) {
 		return -ENOSYS;
 	}
 
@@ -294,7 +294,7 @@ static inline int edac_parity_error_log_get(const struct device *dev,
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->parity_error_log_get) {
+	if (api->parity_error_log_get == NULL) {
 		return -ENOSYS;
 	}
 
@@ -316,7 +316,7 @@ static inline int edac_parity_error_log_clear(const struct device *dev)
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->parity_error_log_clear) {
+	if (api->parity_error_log_clear == NULL) {
 		return -ENOSYS;
 	}
 
@@ -336,7 +336,7 @@ static inline int edac_errors_cor_get(const struct device *dev)
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->errors_cor_get) {
+	if (api->errors_cor_get == NULL) {
 		return -ENOSYS;
 	}
 
@@ -356,7 +356,7 @@ static inline int edac_errors_uc_get(const struct device *dev)
 	const struct edac_driver_api *api =
 		(const struct edac_driver_api *)dev->api;
 
-	if (!api->errors_uc_get) {
+	if (api->errors_uc_get == NULL) {
 		return -ENOSYS;
 	}
 
@@ -379,7 +379,7 @@ static inline int edac_notify_callback_set(const struct device *dev,
 {
 	const struct edac_driver_api *api = dev->api;
 
-	if (!api->notify_cb_set) {
+	if (api->notify_cb_set == NULL) {
 		return -ENOSYS;
 	}
 

--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -48,10 +48,15 @@ typedef int (*edac_api_notify_cb_set_f)(const struct device *dev,
  * @{
  */
 
-/** @brief Correctable error type */
-#define EDAC_ERROR_TYPE_DRAM_COR	BIT(0)
-/** @brief Uncorrectable error type */
-#define EDAC_ERROR_TYPE_DRAM_UC		BIT(1)
+/**
+ * @brief EDAC error type
+ */
+enum edac_error_type {
+	/** Correctable error type */
+	EDAC_ERROR_TYPE_DRAM_COR = BIT(0),
+	/** Uncorrectable error type */
+	EDAC_ERROR_TYPE_DRAM_UC = BIT(1)
+};
 
 /**
  * @brief EDAC driver API

--- a/tests/subsys/edac/ibecc/src/dummy.c
+++ b/tests/subsys/edac/ibecc/src/dummy.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <ztest.h>
+
+#include <drivers/edac.h>
+
+/**
+ * EDAC dummy is used for coverage tests for -ENOSYS returns
+ */
+
+int edac_dummy_init(const struct device *dev)
+{
+	return 0;
+}
+
+static const struct edac_driver_api edac_dummy_api = { 0 };
+
+DEVICE_DEFINE(dummy_edac, "dummy_edac", edac_dummy_init, NULL,
+	      NULL, NULL,
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+	      &edac_dummy_api);
+
+void test_edac_dummy_api(void)
+{
+	const struct device *dev = device_get_binding("dummy_edac");
+	uint64_t value;
+	int ret;
+
+	zassert_not_null(dev, "Device not found");
+
+	/* Error log API */
+
+	ret = edac_ecc_error_log_get(dev, &value);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_ecc_error_log_clear(dev);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_parity_error_log_get(dev, &value);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_parity_error_log_clear(dev);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	/* Error stat API */
+
+	ret = edac_errors_cor_get(dev);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_errors_uc_get(dev);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	/* Notification API */
+
+	/* It is OK to use NULL as a callback pointer */
+	ret = edac_notify_callback_set(dev, NULL);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	/* Injection API */
+
+	ret = edac_inject_set_param1(dev, 0x0);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_get_param1(dev, &value);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_set_param2(dev, 0x0);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_get_param2(dev, &value);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_set_error_type(dev, 0x0);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_get_error_type(dev, (uint32_t *)&value);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+
+	ret = edac_inject_error_trigger(dev);
+	zassert_equal(ret, -ENOSYS, "dummy api failed");
+}

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -268,6 +268,8 @@ static void test_ibecc_error_inject_test_uc(void)
 }
 #endif
 
+void test_edac_dummy_api(void);
+
 void test_main(void)
 {
 #if defined(CONFIG_USERSPACE)
@@ -277,6 +279,7 @@ void test_main(void)
 	ztest_test_suite(ibecc,
 			 ztest_unit_test(test_ibecc_initialized),
 			 ztest_unit_test(test_ibecc_api),
+			 ztest_unit_test(test_edac_dummy_api),
 			 ztest_unit_test(test_ibecc_error_inject_api),
 			 ztest_unit_test(test_ibecc_error_inject_test_cor),
 			 ztest_unit_test(test_ibecc_error_inject_test_uc)

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -52,19 +52,22 @@ static void callback(const struct device *d, void *data)
 
 static void test_ibecc_api(void)
 {
-	uint64_t ret;
+	uint64_t value;
+	int ret;
 
 	/* Error log API */
 
-	ret = edac_ecc_error_log_get(dev);
-	zassert_equal(ret, 0, "Error log not zero");
+	ret = edac_ecc_error_log_get(dev, &value);
+	zassert_equal(ret, 0, "edac_ecc_error_log_get failed");
 
-	edac_ecc_error_log_clear(dev);
+	ret = edac_ecc_error_log_clear(dev);
+	zassert_equal(ret, 0, "edac_ecc_error_log_clear failed");
 
-	ret = edac_parity_error_log_get(dev);
-	zassert_equal(ret, 0, "Error log not zero");
+	ret = edac_parity_error_log_get(dev, &value);
+	zassert_equal(ret, 0, "edac_parity_error_log_get failed");
 
-	edac_parity_error_log_clear(dev);
+	ret = edac_parity_error_log_clear(dev);
+	zassert_equal(ret, 0, "edac_parity_error_log_clear failed");
 
 	/* Error stat API */
 
@@ -94,7 +97,8 @@ static void test_ibecc_error_inject_api(void)
 	ret = edac_inject_set_param1(dev, UINT64_MAX);
 	zassert_not_equal(ret, 0, "Error setting invalid param1");
 
-	val = edac_inject_get_param1(dev);
+	ret = edac_inject_get_param1(dev, &val);
+	zassert_equal(ret, 0, "Error getting param1");
 	zassert_equal(val, TEST_ADDRESS1, "Read back value differs");
 
 	/* Set correct value of param2 */
@@ -105,7 +109,8 @@ static void test_ibecc_error_inject_api(void)
 	ret = edac_inject_set_param2(dev, UINT64_MAX);
 	zassert_not_equal(ret, 0, "Error setting invalid param1");
 
-	val = edac_inject_get_param2(dev);
+	ret = edac_inject_get_param2(dev, &val);
+	zassert_equal(ret, 0, "Error getting param2");
 	zassert_equal(val, TEST_ADDRESS_MASK, "Read back value differs");
 
 	/* Clearing parameters */
@@ -113,13 +118,15 @@ static void test_ibecc_error_inject_api(void)
 	ret = edac_inject_set_param1(dev, 0);
 	zassert_equal(ret, 0, "Error setting inject address");
 
-	val = edac_inject_get_param1(dev);
+	ret = edac_inject_get_param1(dev, &val);
+	zassert_equal(ret, 0, "Error getting param1");
 	zassert_equal(val, 0, "Read back value differs");
 
 	ret = edac_inject_set_param2(dev, 0);
 	zassert_equal(ret, 0, "Error setting inject address mask");
 
-	val = edac_inject_get_param2(dev);
+	ret = edac_inject_get_param2(dev, &val);
+	zassert_equal(ret, 0, "Error getting param2");
 	zassert_equal(val, 0, "Read back value differs");
 }
 #else
@@ -149,9 +156,9 @@ static void test_inject(uint64_t addr, uint64_t mask, uint8_t type)
 	ret = edac_inject_set_error_type(dev, type);
 	zassert_equal(ret, 0, "Error setting inject error type");
 
-	test_value = edac_inject_get_error_type(dev);
-	zassert_equal(test_value, type,
-		      "Read back value differs");
+	ret = edac_inject_get_error_type(dev, &test_value);
+	zassert_equal(ret, 0, "Error getting error_type");
+	zassert_equal(test_value, type, "Read back value differs");
 
 	ret = edac_inject_error_trigger(dev);
 	zassert_equal(ret, 0, "Error setting ctrl");
@@ -182,7 +189,6 @@ static void test_inject(uint64_t addr, uint64_t mask, uint8_t type)
 		      num_int);
 
 	TC_PRINT("Interrupt %d\n", num_int);
-	TC_PRINT("ECC Error Log 0x%llx\n", edac_ecc_error_log_get(dev));
 	TC_PRINT("Error: type %u, address 0x%llx, syndrome %u\n",
 		 error_type, error_address, error_syndrome);
 }


### PR DESCRIPTION
Make it possible to generate full EDAC API for documentation.
Fixing warnings from static analyzer.