### PR TITLE
sys: sflist: include missing sys/__assert.h

### DIFF
--- a/include/sys/sflist.h
+++ b/include/sys/sflist.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <sys/__assert.h>
 #include "list_gen.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
__ASSERT() macro is used in sys/sflist.h while sys/__assert.h was not
included. Fix that now.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>