### PR TITLE
net: lwm2m: Fix lwm2m_path_log_strdup buffer usage

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -68,6 +68,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define MAX_TOKEN_LEN		8
 
+#define LWM2M_MAX_PATH_STR_LEN sizeof("65535/65535/65535/65535")
+
 struct observe_node {
 	sys_snode_t node;
 	struct lwm2m_ctx *ctx;
@@ -556,9 +558,8 @@ static int engine_remove_observer(const uint8_t *token, uint8_t tkl)
 }
 
 #if defined(CONFIG_LOG)
-char *lwm2m_path_log_strdup(struct lwm2m_obj_path *path)
+char *lwm2m_path_log_strdup(char *buf, struct lwm2m_obj_path *path)
 {
-	char buf[sizeof("65535/65535/65535/65535")];
 	size_t cur = sprintf(buf, "%u", path->obj_id);
 
 	if (path->level > 1) {
@@ -578,6 +579,7 @@ char *lwm2m_path_log_strdup(struct lwm2m_obj_path *path)
 #if defined(CONFIG_LWM2M_CANCEL_OBSERVE_BY_PATH)
 static int engine_remove_observer_by_path(struct lwm2m_obj_path *path)
 {
+	char buf[LWM2M_MAX_PATH_STR_LEN];
 	struct observe_node *obs, *found_obj = NULL;
 	sys_snode_t *prev_node = NULL;
 
@@ -595,7 +597,8 @@ static int engine_remove_observer_by_path(struct lwm2m_obj_path *path)
 		return -ENOENT;
 	}
 
-	LOG_INF("Removing observer for path %s", lwm2m_path_log_strdup(path));
+	LOG_INF("Removing observer for path %s",
+		lwm2m_path_log_strdup(buf, path));
 	sys_slist_remove(&engine_observer_list, prev_node, &found_obj->node);
 	(void)memset(found_obj, 0, sizeof(*found_obj));
 


### PR DESCRIPTION
Currently the lwm2m_path_log_strdup allocates a temporary buffer on a
stack, and then passes it to the log_strdup function to create a copy
of the string for the logger. log_strdup however will not copy the
string if for instance immediate logging is used, therefore the logging
function will still use the memory address of the already invalid buffer
allocated within lwm2m_path_log_strdup.

Fix this by passing an addittional `buf` parameter to the
lwm2m_path_log_strdup function, therefore allowing the user to provide
the buffer within a valid scope.

CID: 220536
Fixes #34005

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>