### PR TITLE
doc: pin sphinx_rtd_theme version

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -19,6 +19,7 @@ on:
     - 'west.yml'
     - '.github/workflows/doc-build.yml'
     - 'scripts/dts/**'
+    - 'scripts/requirements-doc.txt'
 
 jobs:
   doc-build:

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -3,7 +3,7 @@
 breathe>=4.23.0
 docutils>=0.16
 sphinx>=3.3.0,<3.4.0
-sphinx_rtd_theme
+sphinx_rtd_theme==0.5.2
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 


### PR DESCRIPTION
We have recently been hit by an issue between docutils and
sphinx_rtd_theme. The problem is fixed since release 0.5.2. In order to
avoid similar problems in the future, pin the theme version.

Fixes #34082 