### PR TITLE
samples: sensor: add integration_platforms

### DIFF
--- a/samples/sensor/adxl362/sample.yaml
+++ b/samples/sensor/adxl362/sample.yaml
@@ -6,4 +6,6 @@ tests:
     harness: sensor
     tags: sensors
     depends_on: spi
+    integration_platforms:
+      - nrf52dk_nrf52832
     platform_allow: nrf52dk_nrf52832

--- a/samples/sensor/adxl372/sample.yaml
+++ b/samples/sensor/adxl372/sample.yaml
@@ -6,9 +6,13 @@ tests:
     tags: sensors
     depends_on: spi
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832
   sample.sensor.adxl372.i2c:
     harness: sensor
     tags: sensors
     depends_on: i2c
     platform_allow: frdm_k64f
+    integration_platforms:
+      - frdm_k64f
     extra_args: "CONF_FILE=prj_i2c.conf"

--- a/samples/sensor/apds9960/sample.yaml
+++ b/samples/sensor/apds9960/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.sensor.apds9960:
     harness: console
     platform_allow: reel_board
+    integration_platforms:
+      - reel_board
     tags: sensors
     depends_on: i2c gpio
     harness_config:
@@ -16,6 +18,8 @@ tests:
   sample.sensor.apds9960.trigger:
     harness: console
     platform_allow: reel_board
+    integration_platforms:
+      - reel_board
     tags: sensors
     depends_on: i2c gpio
     extra_configs:

--- a/samples/sensor/bme280/sample.yaml
+++ b/samples/sensor/bme280/sample.yaml
@@ -5,6 +5,8 @@ tests:
     harness: console
     tags: sensors
     platform_allow: adafruit_feather_m0_basic_proto
+    integration_platforms:
+      - adafruit_feather_m0_basic_proto
     harness_config:
         type: one_line
         regex:

--- a/samples/sensor/bme680/sample.yaml
+++ b/samples/sensor/bme680/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.sensor.bme680:
     harness: sensor
     tags: samples sensor
+    integration_platforms:
+      - nrf52840dk_nrf52840
     platform_allow: nrf52840dk_nrf52840 adafruit_feather_nrf52840

--- a/samples/sensor/bq274xx/sample.yaml
+++ b/samples/sensor/bq274xx/sample.yaml
@@ -5,5 +5,7 @@ tests:
   sample.sensor.bq274xx:
     harness: sensor
     platform_allow: nrf9160_innblue22
+    integration_platforms:
+      - nrf9160_innblue22
     tags: sensors
     depends_on: i2c

--- a/samples/sensor/ccs811/sample.yaml
+++ b/samples/sensor/ccs811/sample.yaml
@@ -12,4 +12,6 @@ tests:
     harness: sensor
     tags: sensors
     platform_allow: thingy52_nrf52832 efr32mg_sltb004a
+    integration_platforms:
+      - efr32mg_sltb004a
     depends_on: i2c

--- a/samples/sensor/dht/sample.yaml
+++ b/samples/sensor/dht/sample.yaml
@@ -12,4 +12,6 @@ tests:
   sample.sensor.dht:
     build_only: true
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832
     tags: sensors

--- a/samples/sensor/fdc2x1x/sample.yaml
+++ b/samples/sensor/fdc2x1x/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: sensor
     tags: sensors
     platform_allow: nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf9160dk_nrf9160

--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: sensor
     tags: sensors
     platform_allow: hexiwear_k64 warp7_m4
+    integration_platforms:
+      - warp7_m4

--- a/samples/sensor/fxos8700/sample.yaml
+++ b/samples/sensor/fxos8700/sample.yaml
@@ -9,6 +9,8 @@ tests:
     platform_allow: frdm_k64f hexiwear_k64 warp7_m4 frdm_kw41z
                         rv32m1_vega_ri5cy twr_ke18f lpcxpresso55s16_ns
                         mimxrt685_evk_cm33 frdm_k22f
+    integration_platforms:
+      - frdm_k64f
     extra_configs:
       - CONFIG_FXOS8700_PULSE=y
       - CONFIG_FXOS8700_PULSE_INT1=y
@@ -18,4 +20,6 @@ tests:
   sample.sensor.fxos8700.accel:
     platform_allow: frdm_kl25z bbc_microbit lpcxpresso55s69_cpu0 reel_board
                         mimxrt685_evk_cm33
+    integration_platforms:
+      - bbc_microbit
     extra_args: CONF_FILE=prj_accel.conf

--- a/samples/sensor/grove_light/sample.yaml
+++ b/samples/sensor/grove_light/sample.yaml
@@ -6,5 +6,7 @@ tests:
   sample.sensor.grove_light:
     tags: drivers sensor grove light
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832
     harness: grove
     depends_on: adc

--- a/samples/sensor/grove_temperature/sample.yaml
+++ b/samples/sensor/grove_temperature/sample.yaml
@@ -7,5 +7,7 @@ tests:
     min_flash: 33
     tags: drivers sensor grove temperature
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832
     harness: grove
     depends_on: adc

--- a/samples/sensor/icm42605/sample.yaml
+++ b/samples/sensor/icm42605/sample.yaml
@@ -10,4 +10,6 @@ tests:
   sample.sensor.icm42605:
     build_only: true
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832
     tags: sensors

--- a/samples/sensor/isl29035/sample.yaml
+++ b/samples/sensor/isl29035/sample.yaml
@@ -5,3 +5,5 @@ tests:
     tags: sensors
     depends_on: i2c
     platform_allow: nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52dk_nrf52832

--- a/samples/sensor/max30101/sample.yaml
+++ b/samples/sensor/max30101/sample.yaml
@@ -7,3 +7,5 @@ tests:
     tags: sensors
     platform_allow: hexiwear_k64
     depends_on: i2c
+    integration_platforms:
+      - hexiwear_k64

--- a/samples/sensor/mcp9808/sample.yaml
+++ b/samples/sensor/mcp9808/sample.yaml
@@ -7,3 +7,5 @@ tests:
     depends_on: i2c
     filter: dt_compat_enabled("microchip,mcp9808")
     platform_allow: nucleo_l053r8
+    integration_platforms:
+      - nucleo_l053r8

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -3,6 +3,8 @@ sample:
   name: NXP MCUX ACMP sample
 common:
   platform_allow: twr_ke18f
+  integration_platforms:
+    - twr_ke18f
   tags: drivers
 tests:
   sample.sensor.mcux_acmp:

--- a/samples/sensor/mpr/sample.yaml
+++ b/samples/sensor/mpr/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: sensors
     depends_on: i2c
     platform_allow: arduino_due
+    integration_platforms:
+      - arduino_due

--- a/samples/sensor/mpu6050/sample.yaml
+++ b/samples/sensor/mpu6050/sample.yaml
@@ -11,3 +11,5 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832
     tags: sensors
+    integration_platforms:
+      - nrf52dk_nrf52832

--- a/samples/sensor/ms5837/sample.yaml
+++ b/samples/sensor/ms5837/sample.yaml
@@ -5,4 +5,6 @@ tests:
   sample.sensor.ms5837:
     build_only: true
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: sensors

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -5,3 +5,5 @@ tests:
     tags: sensors
     harness: sensor
     platform_allow: sam_e70_xplained
+    integration_platforms:
+      - sam_e70_xplained

--- a/samples/sensor/ti_hdc/sample.yaml
+++ b/samples/sensor/ti_hdc/sample.yaml
@@ -4,5 +4,7 @@ tests:
   sample.sensor.ti_hdc:
     harness: sensor
     platform_allow: reel_board nucleo_l496zg
+    integration_platforms:
+      - reel_board
     tags: sensors
     depends_on: i2c

--- a/samples/sensor/tmp116/sample.yaml
+++ b/samples/sensor/tmp116/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.sensor.tmp116:
     harness: console
     platform_allow: nucleo_f401re
+    integration_platforms:
+      - nucleo_f401re
     tags: sensors
     depends_on: i2c
     harness_config:

--- a/samples/sensor/vcnl4040/sample.yaml
+++ b/samples/sensor/vcnl4040/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.sensor.vcnl4040:
     harness: sensor
     platform_allow: adafruit_feather_stm32f405
+    integration_platforms:
+      - adafruit_feather_stm32f405
     tags: sensors
     depends_on: i2c gpio
     filter: dt_compat_enabled("vishay,vcnl4040")


### PR DESCRIPTION
Add one integration_platforms based on platform_allow to ensure these
tests get coverage in CI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>