### PR TITLE
Bluetooth: ISO: Add misisng disconnect reason to big_disconnect

### DIFF
--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -133,9 +133,9 @@ static void iso_connected(struct bt_iso_chan *chan)
 	k_delayed_work_submit(&iso_send_work, K_MSEC(0));
 }
 
-static void iso_disconnected(struct bt_iso_chan *chan)
+static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	printk("ISO Channel %p disconnected\n", chan);
+	printk("ISO Channel %p disconnected (reason 0x%02x)\n", chan, reason);
 	k_delayed_work_cancel(&iso_send_work);
 }
 

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -98,9 +98,9 @@ static void iso_connected(struct bt_iso_chan *chan)
 	printk("ISO Channel %p connected\n", chan);
 }
 
-static void iso_disconnected(struct bt_iso_chan *chan)
+static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	printk("ISO Channel %p disconnected\n", chan);
+	printk("ISO Channel %p disconnected (reason 0x%02x)\n", chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1490,7 +1490,7 @@ void hci_le_big_complete(struct net_buf *buf)
 
 		big = big_lookup_flag(BT_BIG_PENDING);
 		if (big) {
-			big_disconnect(big);
+			big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 			cleanup_big(big);
 		}
 
@@ -1502,9 +1502,9 @@ void hci_le_big_complete(struct net_buf *buf)
 
 	BT_DBG("BIG[%u] %p completed, status %u", big->handle, big, evt->status);
 
-	if (evt->num_bis != big->num_bis) {
+	if (evt->status || evt->num_bis != big->num_bis) {
 		BT_ERR("Invalid number of BIS, was %u expected %u", evt->num_bis, big->num_bis);
-		big_disconnect(big);
+		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 		cleanup_big(big);
 		return;
 	}
@@ -1545,7 +1545,7 @@ void hci_le_big_sync_established(struct net_buf *buf)
 		BT_WARN("Invalid BIG handle");
 		big = big_lookup_flag(BT_BIG_SYNCING);
 		if (big) {
-			big_disconnect(big);
+			big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 			cleanup_big(big);
 		}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1503,7 +1503,10 @@ void hci_le_big_complete(struct net_buf *buf)
 	BT_DBG("BIG[%u] %p completed, status %u", big->handle, big, evt->status);
 
 	if (evt->status || evt->num_bis != big->num_bis) {
-		BT_ERR("Invalid number of BIS, was %u expected %u", evt->num_bis, big->num_bis);
+		if (evt->num_bis != big->num_bis) {
+			BT_ERR("Invalid number of BIS, was %u expected %u",
+			       evt->num_bis, big->num_bis);
+		}
 		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 		cleanup_big(big);
 		return;
@@ -1558,6 +1561,10 @@ void hci_le_big_sync_established(struct net_buf *buf)
 	BT_DBG("BIG[%u] %p sync established", big->handle, big);
 
 	if (evt->status || evt->num_bis != big->num_bis) {
+		if (evt->num_bis != big->num_bis) {
+			BT_ERR("Invalid number of BIS, was %u expected %u",
+			       evt->num_bis, big->num_bis);
+		}
 		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
 		cleanup_big(big);
 		return;


### PR DESCRIPTION
A few calls to big_disconnect was missing the disconnect reason
due to a bad rebase.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>