### PR TITLE
Setup MPU for code relocated to SRAM

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -62,15 +62,6 @@ config LINKER_ORPHAN_SECTION_ERROR
 
 endchoice
 
-config CODE_DATA_RELOCATION
-	bool "Relocate code/data sections"
-	depends on ARM
-	help
-	  When selected this will relocate .text, data and .bss sections from
-	  the specified files and places it in the required memory region. The
-	  files should be specified in the CMakeList.txt file with
-	  a cmake API zephyr_code_relocate().
-
 config HAS_FLASH_LOAD_OFFSET
 	bool
 	help

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -34,6 +34,26 @@ config ARM_CUSTOM_INTERRUPT_CONTROLLER
 	       family cores. The Cortex-M family cores are always equipped with
 	       the ARM Nested Vectored Interrupt Controller (NVIC).
 
+config CODE_DATA_RELOCATION
+	bool "Relocate code/data sections"
+	depends on CPU_CORTEX_M
+	help
+	  When selected this will relocate .text, data and .bss sections from
+	  the specified files and places it in the required memory region. The
+	  files should be specified in the CMakeList.txt file with
+	  a cmake API zephyr_code_relocate().
+
+config CODE_DATA_RELOCATION_SRAM
+	bool "Relocate code/data sections to SRAM"
+	depends on CPU_CORTEX_M
+	select CODE_DATA_RELOCATION
+	help
+	  When selected this will relocate .text, data and .bss sections from
+	  the specified files and places it in SRAM. The files should be specified
+	  in the CMakeList.txt file with a cmake API zephyr_code_relocate(). This
+	  config is used to create an MPU entry for the SRAM space used for code
+	  relocation.
+
 rsource "core/aarch32/Kconfig"
 
 endmenu

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_core_mpu.c
@@ -55,6 +55,11 @@ extern K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread);
 #endif
 
+#if defined(CONFIG_CODE_DATA_RELOCATION_SRAM)
+extern char __sram_text_start[];
+extern char __sram_text_size[];
+#endif
+
 static const struct z_arm_mpu_partition static_regions[] = {
 #if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
 		{
@@ -82,6 +87,14 @@ static const struct z_arm_mpu_partition static_regions[] = {
 		.attr = K_MEM_PARTITION_P_RX_U_RX,
 		},
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
+#if defined(CONFIG_CODE_DATA_RELOCATION_SRAM)
+		{
+		/* RAM area for relocated text */
+		.start = (uint32_t)&__sram_text_start,
+		.size = (uint32_t)&__sram_text_size,
+		.attr = K_MEM_PARTITION_P_RX_U_RX,
+		},
+#endif /* CONFIG_CODE_DATA_RELOCATION_SRAM */
 #if !defined(CONFIG_MULTITHREADING) && defined(CONFIG_MPU_STACK_GUARD)
 		/* Main stack MPU guard to detect overflow.
 		 * Note:

--- a/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/arm_mpu.c
@@ -302,7 +302,7 @@ void arm_core_mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int arm_mpu_init(const struct device *arg)
+int z_arm_mpu_init(void)
 {
 	uint32_t r_index;
 
@@ -416,8 +416,6 @@ static int arm_mpu_init(const struct device *arg)
 		NUM_MPU_REGIONS,
 		"Invalid number of MPU regions\n");
 #endif /* CORTEX_M0PLUS || CPU_CORTEX_M3 || CPU_CORTEX_M4 */
+
 	return 0;
 }
-
-SYS_INIT(arm_mpu_init, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/arch/arm/core/aarch32/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/aarch32/cortex_m/mpu/nxp_mpu.c
@@ -601,10 +601,8 @@ void arm_core_mpu_configure_dynamic_mpu_regions(
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int nxp_mpu_init(const struct device *arg)
+int z_arm_mpu_init(void)
 {
-	ARG_UNUSED(arg);
-
 	uint32_t r_index;
 
 	if (mpu_config.num_regions > get_num_regions()) {
@@ -640,15 +638,5 @@ static int nxp_mpu_init(const struct device *arg)
 
 	arm_core_mpu_enable();
 
-
 	return 0;
 }
-
-#if defined(CONFIG_LOG)
-/* To have logging the driver needs to be initialized later */
-SYS_INIT(nxp_mpu_init, PRE_KERNEL_2,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#else
-SYS_INIT(nxp_mpu_init, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -484,16 +484,6 @@ static void z_arm_prepare_switch_to_main(void)
 	__ISB();
 #endif /* CONFIG_FPU_SHARING */
 #endif /* CONFIG_FPU */
-
-#ifdef CONFIG_ARM_MPU
-	/* Configure static memory map. This will program MPU regions,
-	 * to set up access permissions for fixed memory sections, such
-	 * as Application Memory or No-Cacheable SRAM area.
-	 *
-	 * This function is invoked once, upon system initialization.
-	 */
-	z_arm_configure_static_mpu_regions();
-#endif
 }
 
 void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,

--- a/arch/arm/include/aarch32/kernel_arch_func.h
+++ b/arch/arm/include/aarch32/kernel_arch_func.h
@@ -33,6 +33,7 @@ extern void z_arm_cpu_idle_init(void);
 #ifdef CONFIG_ARM_MPU
 extern void z_arm_configure_static_mpu_regions(void);
 extern void z_arm_configure_dynamic_mpu_regions(struct k_thread *thread);
+extern int z_arm_mpu_init(void);
 #endif /* CONFIG_ARM_MPU */
 
 static ALWAYS_INLINE void arch_kernel_init(void)
@@ -42,6 +43,16 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	z_arm_fault_init();
 	z_arm_cpu_idle_init();
 	z_arm_clear_faults();
+#if defined(CONFIG_ARM_MPU)
+	z_arm_mpu_init();
+	/* Configure static memory map. This will program MPU regions,
+	 * to set up access permissions for fixed memory sections, such
+	 * as Application Memory or No-Cacheable SRAM area.
+	 *
+	 * This function is invoked once, upon system initialization.
+	 */
+	z_arm_configure_static_mpu_regions();
+#endif
 }
 
 static ALWAYS_INLINE void

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -48,7 +48,6 @@ config FLASH_MCUX_FLEXSPI_XIP
 	depends on MEMC_MCUX_FLEXSPI
 	depends on (CODE_FLEXSPI || CODE_FLEXSPI2)
 	select XIP
-	select CODE_DATA_RELOCATION
 	help
 	  Allows using the flash API while running in XIP.
 	  WARNING: It is possible to overwrite the running application itself.
@@ -64,9 +63,11 @@ choice FLASH_MCUX_FLEXSPI_XIP_MEM_TARGET
 
 config FLASH_MCUX_FLEXSPI_XIP_MEM_ITCM
 	bool "ITCM"
+	select CODE_DATA_RELOCATION
 
 config FLASH_MCUX_FLEXSPI_XIP_MEM_SRAM
 	bool "SRAM"
+	select CODE_DATA_RELOCATION_SRAM
 
 endchoice
 

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -257,9 +257,13 @@ def string_create_helper(region, memory_type,
                 linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(), region, memory_type.upper(),
                                                                region.upper(), tmp, load_address_string, align_size)
             else:
-                linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region, memory_type.upper(),
-                                                           region.upper(), tmp, load_address_string)
-
+                if memory_type == 'SRAM' and region == 'text':
+                    align_size = 0
+                    linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(), region, memory_type.upper(),
+                                                                   region.upper(), tmp, load_address_string, align_size)
+                else:
+                    linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region, memory_type.upper(),
+                                                               region.upper(), tmp, load_address_string)
             if load_address_in_flash:
                 linker_string += SECTION_LOAD_MEMORY_SEQ.format(memory_type.lower(), region, memory_type.upper(),
                                                                 region.upper())


### PR DESCRIPTION
1. Create a static MPU map for code relocated to SRAM
2. Update the python script to provide proper alignment for the SRAM region
3. Setup the static MPU regions before PRE_KERNEL_1 and PRE_KERNEL_2 functions are invoked. This will setup the MPU for SRAM regions in case code relocated to SRAM and invoked from any of these functions.