### PR TITLE
k_work conversion for network related components

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -91,7 +91,7 @@ struct gsm_mux {
 	uint16_t msg_len;     /* message length */
 	uint16_t received;    /* bytes so far received */
 
-	struct k_delayed_work t2_timer;
+	struct k_work_delayable t2_timer;
 	sys_slist_t pending_ctrls;
 
 	uint16_t t1_timeout_value; /* T1 default value */
@@ -169,7 +169,7 @@ static struct gsm_mux muxes[CONFIG_GSM_MUX_MAX];
 static struct gsm_dlci dlcis[CONFIG_GSM_MUX_DLCI_MAX];
 static sys_slist_t dlci_free_entries;
 static sys_slist_t dlci_active_t1_timers;
-static struct k_delayed_work t1_timer;
+static struct k_work_delayable t1_timer;
 
 static struct gsm_control_msg ctrls[CONFIG_GSM_MUX_PENDING_CMD_MAX];
 static sys_slist_t ctrls_free_entries;
@@ -454,9 +454,7 @@ static void dlci_run_timer(uint32_t current_time)
 	struct gsm_dlci *dlci, *next;
 	uint32_t new_timer = UINT_MAX;
 
-	if (k_delayed_work_remaining_get(&t1_timer)) {
-		k_delayed_work_cancel(&t1_timer);
-	}
+	(void)k_work_cancel_delayable(&t1_timer);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&dlci_active_t1_timers,
 					  dlci, next, node) {
@@ -467,7 +465,7 @@ static void dlci_run_timer(uint32_t current_time)
 	}
 
 	if (new_timer != UINT_MAX) {
-		k_delayed_work_submit(&t1_timer, K_MSEC(new_timer));
+		k_work_reschedule(&t1_timer, K_MSEC(new_timer));
 	}
 }
 
@@ -631,9 +629,9 @@ static void gsm_mux_t2_timeout(struct k_work *work)
 	}
 
 	if (entry) {
-		k_delayed_work_submit(&mux->t2_timer,
-				      K_MSEC(entry->req_start + T2_MSEC -
-					     current_time));
+		k_work_reschedule(
+			&mux->t2_timer,
+			K_MSEC(entry->req_start + T2_MSEC - current_time));
 	}
 }
 
@@ -674,8 +672,8 @@ static int gsm_mux_send_control_message(struct gsm_mux *mux, uint8_t dlci_addres
 	ctrl->req_start = k_uptime_get_32();
 
 	/* Let's start the timer if necessary */
-	if (!k_delayed_work_remaining_get(&mux->t2_timer)) {
-		k_delayed_work_submit(&mux->t2_timer, K_MSEC(T2_MSEC));
+	if (!k_work_delayable_remaining_get(&mux->t2_timer)) {
+		k_work_reschedule(&mux->t2_timer, K_MSEC(T2_MSEC));
 	}
 
 	return gsm_mux_modem_send(mux, buf->data, buf->len);
@@ -692,9 +690,9 @@ static int gsm_dlci_opening_or_closing(struct gsm_dlci *dlci,
 	dlci->command_cb = cb;
 
 	/* Let's start the timer if necessary */
-	if (!k_delayed_work_remaining_get(&t1_timer)) {
-		k_delayed_work_submit(&t1_timer,
-				      K_MSEC(dlci->mux->t1_timeout_value));
+	if (!k_work_delayable_remaining_get(&t1_timer)) {
+		k_work_reschedule(&t1_timer,
+				  K_MSEC(dlci->mux->t1_timeout_value));
 	}
 
 	sys_slist_append(&dlci_active_t1_timers, &dlci->node);
@@ -739,7 +737,7 @@ int gsm_mux_disconnect(struct gsm_mux *mux, k_timeout_t timeout)
 	(void)gsm_mux_send_control_message(dlci->mux, dlci->num,
 					   CMD_CLD, NULL, 0);
 
-	k_delayed_work_cancel(&mux->t2_timer);
+	(void)k_work_cancel_delayable(&mux->t2_timer);
 
 	(void)gsm_dlci_closing(dlci, NULL);
 
@@ -1474,7 +1472,7 @@ struct gsm_mux *gsm_mux_create(const struct device *uart)
 		mux->state = GSM_MUX_SOF;
 		mux->buf = NULL;
 
-		k_delayed_work_init(&mux->t2_timer, gsm_mux_t2_timeout);
+		k_work_init_delayable(&mux->t2_timer, gsm_mux_t2_timeout);
 		sys_slist_init(&mux->pending_ctrls);
 
 		/* The system will continue after the control DLCI is
@@ -1538,5 +1536,5 @@ void gsm_mux_init(void)
 		sys_slist_prepend(&dlci_free_entries, &dlcis[i].node);
 	}
 
-	k_delayed_work_init(&t1_timer, dlci_t1_timeout);
+	k_work_init_delayable(&t1_timer, dlci_t1_timeout);
 }

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -901,9 +901,9 @@ static int init_uart_mux(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	k_work_q_start(&uart_mux_workq, uart_mux_stack,
-		       K_KERNEL_STACK_SIZEOF(uart_mux_stack),
-		       K_PRIO_COOP(UART_MUX_WORKQ_PRIORITY));
+	k_work_queue_start(&uart_mux_workq, uart_mux_stack,
+			   K_KERNEL_STACK_SIZEOF(uart_mux_stack),
+			   K_PRIO_COOP(UART_MUX_WORKQ_PRIORITY), NULL);
 	k_thread_name_set(&uart_mux_workq.thread, "uart_mux_workq");
 
 	return 0;

--- a/drivers/ethernet/dsa_ksz8794.c
+++ b/drivers/ethernet/dsa_ksz8794.c
@@ -690,7 +690,7 @@ static void dsa_delayed_work(struct k_work *item)
 		context->link_up[i] = link_state;
 	}
 
-	k_delayed_work_submit(&context->dsa_work, DSA_STATUS_PERIOD_MS);
+	k_work_reschedule(&context->dsa_work, DSA_STATUS_PERIOD_MS);
 }
 
 int dsa_port_init(const struct device *dev)
@@ -975,8 +975,8 @@ static void dsa_iface_init(struct net_if *iface)
 	if (context->iface_slave[KSZ8794_PORT1] &&
 	    context->iface_slave[KSZ8794_PORT2] &&
 	    context->iface_slave[KSZ8794_PORT3]) {
-		k_delayed_work_init(&context->dsa_work, dsa_delayed_work);
-		k_delayed_work_submit(&context->dsa_work, DSA_STATUS_PERIOD_MS);
+		k_work_init_delayable(&context->dsa_work, dsa_delayed_work);
+		k_work_reschedule(&context->dsa_work, DSA_STATUS_PERIOD_MS);
 	}
 }
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -141,7 +141,7 @@ struct eth_context {
 	uint8_t mac_addr[6];
 	void (*generate_mac)(uint8_t *);
 	struct k_work phy_work;
-	struct k_delayed_work delayed_phy_work;
+	struct k_work_delayable delayed_phy_work;
 	/* TODO: FIXME. This Ethernet frame sized buffer is used for
 	 * interfacing with MCUX. How it works is that hardware uses
 	 * DMA scatter buffers to receive a frame, and then public
@@ -381,7 +381,7 @@ void eth_mcux_phy_stop(struct eth_context *context)
 		context->phy_state = eth_mcux_phy_state_closing;
 		break;
 	case eth_mcux_phy_state_wait:
-		k_delayed_work_cancel(&context->delayed_phy_work);
+		k_work_cancel_delayable(&context->delayed_phy_work);
 		/* @todo, actually power downt he PHY ? */
 		context->phy_state = eth_mcux_phy_state_initial;
 		break;
@@ -437,7 +437,7 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		       context->phy_state = eth_mcux_phy_state_reset;
 		}
 
-		k_delayed_work_submit(&context->delayed_phy_work, K_MSEC(1));
+		k_work_reschedule(&context->delayed_phy_work, K_MSEC(1));
 #endif
 		break;
 	case eth_mcux_phy_state_closing:
@@ -520,13 +520,13 @@ static void eth_mcux_phy_event(struct eth_context *context)
 		} else if (!link_up && context->link_up) {
 			LOG_INF("%s link down", eth_name(context->base));
 			context->link_up = link_up;
-			k_delayed_work_submit(&context->delayed_phy_work,
-					K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
+			k_work_reschedule(&context->delayed_phy_work,
+					  K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
 			context->phy_state = eth_mcux_phy_state_wait;
 			net_eth_carrier_off(context->iface);
 		} else {
-			k_delayed_work_submit(&context->delayed_phy_work,
-					K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
+			k_work_reschedule(&context->delayed_phy_work,
+					  K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
 			context->phy_state = eth_mcux_phy_state_wait;
 		}
 
@@ -555,8 +555,8 @@ static void eth_mcux_phy_event(struct eth_context *context)
 			eth_name(context->base),
 			(phy_speed ? "100" : "10"),
 			(phy_duplex ? "full" : "half"));
-		k_delayed_work_submit(&context->delayed_phy_work,
-				      K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
+		k_work_reschedule(&context->delayed_phy_work,
+				  K_MSEC(CONFIG_ETH_MCUX_PHY_TICK_MS));
 		context->phy_state = eth_mcux_phy_state_wait;
 		break;
 	}
@@ -1005,8 +1005,8 @@ static int eth_init(const struct device *dev)
 	k_sem_init(&context->tx_buf_sem,
 		   0, CONFIG_ETH_MCUX_TX_BUFFERS);
 	k_work_init(&context->phy_work, eth_mcux_phy_work);
-	k_delayed_work_init(&context->delayed_phy_work,
-			    eth_mcux_delayed_phy_work);
+	k_work_init_delayable(&context->delayed_phy_work,
+			      eth_mcux_delayed_phy_work);
 
 	if (context->generate_mac) {
 		context->generate_mac(context->mac_addr);

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1852,8 +1852,8 @@ static void monitor_work_handler(struct k_work *work)
 
 finally:
 	/* Submit delayed work */
-	k_delayed_work_submit(&dev_data->monitor_work,
-			      K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
+	k_work_reschedule(&dev_data->monitor_work,
+			  K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
 }
 
 static void eth0_iface_init(struct net_if *iface)
@@ -1970,9 +1970,9 @@ static void eth0_iface_init(struct net_if *iface)
 	}
 
 	/* Initialise monitor */
-	k_delayed_work_init(&dev_data->monitor_work, monitor_work_handler);
-	k_delayed_work_submit(&dev_data->monitor_work,
-			      K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
+	k_work_init_delayable(&dev_data->monitor_work, monitor_work_handler);
+	k_work_reschedule(&dev_data->monitor_work,
+			  K_MSEC(CONFIG_ETH_SAM_GMAC_MONITOR_PERIOD));
 
 	/* Do not start the interface until PHY link is up */
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -275,7 +275,7 @@ struct eth_sam_dev_data {
 	const struct device *ptp_clock;
 #endif
 	uint8_t mac_addr[6];
-	struct k_delayed_work monitor_work;
+	struct k_work_delayable monitor_work;
 	bool link_up;
 	struct gmac_queue queue_list[GMAC_QUEUE_NUM];
 };

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1607,10 +1607,9 @@ static int dw1000_init(const struct device *dev)
 			  DWT_SYS_MASK_MRXSFDTO);
 
 	/* Initialize IRQ event work queue */
-	k_work_q_start(&dwt_work_queue,
-		       dwt_work_queue_stack,
-		       K_KERNEL_STACK_SIZEOF(dwt_work_queue_stack),
-		       CONFIG_SYSTEM_WORKQUEUE_PRIORITY);
+	k_work_queue_start(&dwt_work_queue, dwt_work_queue_stack,
+			   K_KERNEL_STACK_SIZEOF(dwt_work_queue_stack),
+			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
 
 	k_work_init(&ctx->irq_cb_work, dwt_irq_work_handler);
 

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -89,7 +89,7 @@ struct modem_data {
 	struct modem_socket sockets[MDM_MAX_SOCKETS];
 
 	/* RSSI work */
-	struct k_delayed_work rssi_query_work;
+	struct k_work_delayable rssi_query_work;
 
 	/* modem data */
 	char mdm_manufacturer[MDM_MANUFACTURER_LENGTH];

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -141,7 +141,7 @@ struct modem_data {
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* RSSI work */
-	struct k_delayed_work rssi_query_work;
+	struct k_work_delayable rssi_query_work;
 #endif
 
 	/* modem data */
@@ -924,8 +924,8 @@ static void modem_rssi_query_work(struct k_work *work)
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* re-start RSSI query work */
 	if (work) {
-		k_delayed_work_submit_to_queue(&modem_workq,
-			&mdata.rssi_query_work,
+		k_work_reschedule_for_queue(
+			&modem_workq, &mdata.rssi_query_work,
 			K_SECONDS(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK_PERIOD));
 	}
 #endif
@@ -954,9 +954,9 @@ static void modem_rssi_query_work(struct k_work *work)
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* re-start RSSI query work */
 	if (work) {
-		k_delayed_work_submit_to_queue(&modem_workq,
-					       &mdata.rssi_query_work,
-					       K_SECONDS(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK_PERIOD));
+		k_work_reschedule_for_queue(
+			&modem_workq, &mdata.rssi_query_work,
+			K_SECONDS(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK_PERIOD));
 	}
 #endif
 }
@@ -1039,7 +1039,7 @@ restart:
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* stop RSSI delay work */
-	k_delayed_work_cancel(&mdata.rssi_query_work);
+	k_work_cancel_delayable(&mdata.rssi_query_work);
 #endif
 
 	pin_init();
@@ -1208,9 +1208,9 @@ restart:
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* start RSSI query */
-	k_delayed_work_submit_to_queue(&modem_workq,
-				       &mdata.rssi_query_work,
-				       K_SECONDS(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK_PERIOD));
+	k_work_reschedule_for_queue(
+		&modem_workq, &mdata.rssi_query_work,
+		K_SECONDS(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK_PERIOD));
 #endif
 
 error:
@@ -1839,10 +1839,9 @@ static int modem_init(const struct device *dev)
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* initialize the work queue */
-	k_work_q_start(&modem_workq,
-		       modem_workq_stack,
-		       K_KERNEL_STACK_SIZEOF(modem_workq_stack),
-		       K_PRIO_COOP(7));
+	k_work_queue_start(&modem_workq, modem_workq_stack,
+			   K_KERNEL_STACK_SIZEOF(modem_workq_stack),
+			   K_PRIO_COOP(7), NULL);
 #endif
 
 	/* socket config */
@@ -1908,7 +1907,7 @@ static int modem_init(const struct device *dev)
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_RSSI_WORK)
 	/* init RSSI query */
-	k_delayed_work_init(&mdata.rssi_query_work, modem_rssi_query_work);
+	k_work_init_delayable(&mdata.rssi_query_work, modem_rssi_query_work);
 #endif
 
 	modem_reset();

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -197,7 +197,7 @@ struct wncm14a2a_iface_ctx {
 	struct k_sem response_sem;
 
 	/* RSSI work */
-	struct k_delayed_work rssi_query_work;
+	struct k_work_delayable rssi_query_work;
 
 	/* modem data */
 	char mdm_manufacturer[MDM_MANUFACTURER_LENGTH];
@@ -1322,9 +1322,8 @@ static void wncm14a2a_rssi_query_work(struct k_work *work)
 	}
 
 	/* re-start RSSI query work */
-	k_delayed_work_submit_to_queue(&wncm14a2a_workq,
-				       &ictx.rssi_query_work,
-				       K_SECONDS(RSSI_TIMEOUT_SECS));
+	k_work_reschedule_for_queue(&wncm14a2a_workq, &ictx.rssi_query_work,
+				    K_SECONDS(RSSI_TIMEOUT_SECS));
 }
 
 static void wncm14a2a_modem_reset(void)
@@ -1336,7 +1335,7 @@ static void wncm14a2a_modem_reset(void)
 
 restart:
 	/* stop RSSI delay work */
-	k_delayed_work_cancel(&ictx.rssi_query_work);
+	k_work_cancel_delayable(&ictx.rssi_query_work);
 
 	modem_pin_init();
 
@@ -1402,7 +1401,7 @@ restart:
 	       (ictx.mdm_ctx.data_rssi <= -1000 ||
 		ictx.mdm_ctx.data_rssi == 0)) {
 		/* stop RSSI delay work */
-		k_delayed_work_cancel(&ictx.rssi_query_work);
+		k_work_cancel_delayable(&ictx.rssi_query_work);
 		wncm14a2a_rssi_query_work(NULL);
 		k_sleep(K_SECONDS(2));
 	}
@@ -1460,10 +1459,9 @@ static int wncm14a2a_init(const struct device *dev)
 	k_sem_init(&ictx.response_sem, 0, 1);
 
 	/* initialize the work queue */
-	k_work_q_start(&wncm14a2a_workq,
-		       wncm14a2a_workq_stack,
-		       K_KERNEL_STACK_SIZEOF(wncm14a2a_workq_stack),
-		       K_PRIO_COOP(7));
+	k_work_queue_start(&wncm14a2a_workq, wncm14a2a_workq_stack,
+			   K_KERNEL_STACK_SIZEOF(wncm14a2a_workq_stack),
+			   K_PRIO_COOP(7), NULL);
 
 	ictx.last_socket_id = 0;
 
@@ -1503,7 +1501,7 @@ static int wncm14a2a_init(const struct device *dev)
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	/* init RSSI query */
-	k_delayed_work_init(&ictx.rssi_query_work, wncm14a2a_rssi_query_work);
+	k_work_init_delayable(&ictx.rssi_query_work, wncm14a2a_rssi_query_work);
 
 	wncm14a2a_modem_reset();
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -716,9 +716,9 @@ static int ppp_driver_init(const struct device *dev)
 	ring_buf_init(&ppp->rx_ringbuf, sizeof(ppp->rx_buf), ppp->rx_buf);
 	k_work_init(&ppp->cb_work, ppp_isr_cb_work);
 
-	k_work_q_start(&ppp->cb_workq, ppp_workq,
-		       K_KERNEL_STACK_SIZEOF(ppp_workq),
-		       K_PRIO_COOP(PPP_WORKQ_PRIORITY));
+	k_work_queue_start(&ppp->cb_workq, ppp_workq,
+			   K_KERNEL_STACK_SIZEOF(ppp_workq),
+			   K_PRIO_COOP(PPP_WORKQ_PRIORITY), NULL);
 	k_thread_name_set(&ppp->cb_workq.thread, "ppp_workq");
 #endif
 

--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -218,7 +218,7 @@ struct esp_data {
 	/* work */
 	struct k_work_q workq;
 	struct k_work init_work;
-	struct k_delayed_work ip_addr_work;
+	struct k_work_delayable ip_addr_work;
 	struct k_work scan_work;
 	struct k_work connect_work;
 	struct k_work mode_switch_work;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -669,9 +669,9 @@ static int eswifi_init(const struct device *dev)
 			   DT_INST_GPIO_FLAGS(0, wakeup_gpios) |
 			   GPIO_OUTPUT_ACTIVE);
 
-	k_work_q_start(&eswifi->work_q, eswifi_work_q_stack,
-		       K_KERNEL_STACK_SIZEOF(eswifi_work_q_stack),
-		       CONFIG_SYSTEM_WORKQUEUE_PRIORITY - 1);
+	k_work_queue_start(&eswifi->work_q, eswifi_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(eswifi_work_q_stack),
+			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY - 1, NULL);
 
 	k_work_init(&eswifi->request_work, eswifi_request_work);
 

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -433,8 +433,8 @@ static int eswifi_off_get(sa_family_t family,
 	k_sem_init(&socket->read_sem, 1, 1);
 	k_sem_init(&socket->accept_sem, 1, 1);
 
-	k_delayed_work_submit_to_queue(&eswifi->work_q, &socket->read_work,
-				       K_MSEC(500));
+	k_work_reschedule_for_queue(&eswifi->work_q, &socket->read_work,
+				    K_MSEC(500));
 
 unlock:
 	eswifi_unlock(eswifi);

--- a/drivers/wifi/eswifi/eswifi_offload.h
+++ b/drivers/wifi/eswifi/eswifi_offload.h
@@ -42,7 +42,7 @@ struct eswifi_off_socket {
 	struct net_pkt *tx_pkt;
 	struct k_work connect_work;
 	struct k_work send_work;
-	struct k_delayed_work read_work;
+	struct k_work_delayable read_work;
 	struct sockaddr peer_addr;
 	struct k_sem read_sem;
 	struct k_sem accept_sem;

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -150,9 +150,8 @@ do_recv_cb:
 	next_timeout_ms = 0;
 
 done:
-	err = k_delayed_work_submit_to_queue(&eswifi->work_q,
-					     &socket->read_work,
-					     K_MSEC(next_timeout_ms));
+	err = k_work_reschedule_for_queue(&eswifi->work_q, &socket->read_work,
+					  K_MSEC(next_timeout_ms));
 	if (err) {
 		LOG_ERR("Rescheduling socket read error");
 	}
@@ -237,7 +236,7 @@ int __eswifi_socket_free(struct eswifi_dev *eswifi,
 			 struct eswifi_off_socket *socket)
 {
 	__select_socket(eswifi, socket->index);
-	k_delayed_work_cancel(&socket->read_work);
+	k_work_cancel_delayable(&socket->read_work);
 
 	__select_socket(eswifi, socket->index);
 	__stop_socket(eswifi, socket);
@@ -298,7 +297,7 @@ int __eswifi_socket_new(struct eswifi_dev *eswifi, int family, int type,
 		return -EIO;
 	}
 
-	k_delayed_work_init(&socket->read_work, eswifi_off_read_work);
+	k_work_init_delayable(&socket->read_work, eswifi_off_read_work);
 	socket->usage = 1;
 	LOG_DBG("Socket index %d", socket->index);
 

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -410,8 +410,8 @@ static int eswifi_socket_open(int family, int type, int proto)
 	socket->recv_cb = __process_received;
 	socket->recv_data = socket;
 
-	k_delayed_work_submit_to_queue(&eswifi->work_q, &socket->read_work,
-					K_MSEC(500));
+	k_work_reschedule_for_queue(&eswifi->work_q, &socket->read_work,
+				    K_MSEC(500));
 
 unlock:
 	eswifi_unlock(eswifi);

--- a/include/net/dsa.h
+++ b/include/net/dsa.h
@@ -140,7 +140,7 @@ struct dsa_context {
 	struct dsa_api *dapi;
 
 	/** DSA related work (e.g. monitor if network interface is up) */
-	struct k_delayed_work dsa_work;
+	struct k_work_delayable dsa_work;
 
 	/** The switch_id, which equals to the reg property number from
 	 * DTS is used to distinct between many connected switches.

--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -155,7 +155,7 @@ struct http_response {
  */
 struct http_client_internal_data {
 	/** Work for handling timeout */
-	struct k_delayed_work work;
+	struct k_work_delayable work;
 
 	/** HTTP parser context */
 	struct http_parser parser;

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -77,7 +77,7 @@ struct lwm2m_ctx {
 	/** Private CoAP and networking structures */
 	struct coap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
 	struct coap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
-	struct k_delayed_work retransmit_work;
+	struct k_work_delayable retransmit_work;
 	struct sys_mutex send_lock;
 
 	/** A pointer to currently processed request, for internal LwM2M engine

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -223,7 +223,7 @@ struct ppp_my_option_info;
  */
 struct ppp_fsm {
 	/** Timeout timer */
-	struct k_delayed_work timer;
+	struct k_work_delayable timer;
 
 	struct {
 		/** Acknowledge Configuration Information */
@@ -382,7 +382,7 @@ struct ppp_context {
 	atomic_t flags;
 
 	/** PPP startup worker. */
-	struct k_delayed_work startup;
+	struct k_work_delayable startup;
 
 	/** Carrier ON/OFF handler worker. This is used to create
 	 * network interface UP/DOWN event when PPP L2 driver

--- a/include/net/trickle.h
+++ b/include/net/trickle.h
@@ -61,7 +61,7 @@ struct net_trickle {
 
 	uint32_t Imax_abs;	/**< Max interval size in ms (not doublings) */
 
-	struct k_delayed_work timer;
+	struct k_work_delayable timer;
 	net_trickle_cb_t cb;	/**< Callback to be called when timer expires */
 	void *user_data;
 };

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -19,11 +19,11 @@ LOG_MODULE_REGISTER(net_dns_resolve_client_sample, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_MDNS_RESOLVER)
 #if defined(CONFIG_NET_IPV4)
-static struct k_delayed_work mdns_ipv4_timer;
+static struct k_work_delayable mdns_ipv4_timer;
 static void do_mdns_ipv4_lookup(struct k_work *work);
 #endif
 #if defined(CONFIG_NET_IPV6)
-static struct k_delayed_work mdns_ipv6_timer;
+static struct k_work_delayable mdns_ipv6_timer;
 static void do_mdns_ipv6_lookup(struct k_work *work);
 #endif
 #endif
@@ -130,7 +130,7 @@ void mdns_result_cb(enum dns_resolve_status status,
 
 #if defined(CONFIG_NET_DHCPV4)
 static struct net_mgmt_event_callback mgmt4_cb;
-static struct k_delayed_work ipv4_timer;
+static struct k_work_delayable ipv4_timer;
 
 static void do_ipv4_lookup(struct k_work *work)
 {
@@ -192,12 +192,12 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 	 * management event thread stack is very small by default.
 	 * So run it from work queue instead.
 	 */
-	k_delayed_work_init(&ipv4_timer, do_ipv4_lookup);
-	k_delayed_work_submit(&ipv4_timer, K_NO_WAIT);
+	k_work_init_delayable(&ipv4_timer, do_ipv4_lookup);
+	k_work_reschedule(&ipv4_timer, K_NO_WAIT);
 
 #if defined(CONFIG_MDNS_RESOLVER)
-	k_delayed_work_init(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
-	k_delayed_work_submit(&mdns_ipv4_timer, K_NO_WAIT);
+	k_work_init_delayable(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
+	k_work_reschedule(&mdns_ipv4_timer, K_NO_WAIT);
 #endif
 }
 
@@ -274,8 +274,8 @@ static void setup_ipv4(struct net_if *iface)
 	do_ipv4_lookup();
 
 #if defined(CONFIG_MDNS_RESOLVER) && defined(CONFIG_NET_IPV4)
-	k_delayed_work_init(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
-	k_delayed_work_submit(&mdns_ipv4_timer, K_NO_WAIT);
+	k_work_init_delayable(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
+	k_work_reschedule(&mdns_ipv4_timer, K_NO_WAIT);
 #endif
 }
 
@@ -316,8 +316,8 @@ static void setup_ipv6(struct net_if *iface)
 	do_ipv6_lookup();
 
 #if defined(CONFIG_MDNS_RESOLVER) && defined(CONFIG_NET_IPV6)
-	k_delayed_work_init(&mdns_ipv6_timer, do_mdns_ipv6_lookup);
-	k_delayed_work_submit(&mdns_ipv6_timer, K_NO_WAIT);
+	k_work_init_delayable(&mdns_ipv6_timer, do_mdns_ipv6_lookup);
+	k_work_reschedule(&mdns_ipv6_timer, K_NO_WAIT);
 #endif
 }
 

--- a/samples/net/gptp/src/gptp.c
+++ b/samples/net/gptp/src/gptp.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(net_gptp_sample);
 #include "ethernet/gptp/gptp_data_set.h"
 
 static int run_duration = CONFIG_NET_SAMPLE_RUN_DURATION;
-static struct k_delayed_work stop_sample;
+static struct k_work_delayable stop_sample;
 static struct k_sem quit_lock;
 
 static void stop_handler(struct k_work *work)
@@ -82,8 +82,8 @@ void init_testing(void)
 
 	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
-	k_delayed_work_init(&stop_sample, stop_handler);
-	k_delayed_work_submit(&stop_sample, K_SECONDS(run_duration));
+	k_work_init_delayable(&stop_sample, stop_handler);
+	k_work_reschedule(&stop_sample, K_SECONDS(run_duration));
 
 	k_sem_take(&quit_lock, K_FOREVER);
 

--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -33,8 +33,8 @@ struct data {
 	struct {
 		int sock;
 		/* Work controlling udp data sending */
-		struct k_delayed_work recv;
-		struct k_delayed_work transmit;
+		struct k_work_delayable recv;
+		struct k_work_delayable transmit;
 		uint32_t expecting;
 		uint32_t counter;
 		uint32_t mtu;

--- a/samples/net/sockets/echo_server/src/common.h
+++ b/samples/net/sockets/echo_server/src/common.h
@@ -42,13 +42,13 @@ struct data {
 		char recv_buffer[RECV_BUFFER_SIZE];
 		uint32_t counter;
 		atomic_t bytes_received;
-		struct k_delayed_work stats_print;
+		struct k_work_delayable stats_print;
 	} udp;
 
 	struct {
 		int sock;
 		atomic_t bytes_received;
-		struct k_delayed_work stats_print;
+		struct k_work_delayable stats_print;
 
 		struct {
 			int sock;

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -305,8 +305,7 @@ static void process_tcp4(void)
 		return;
 	}
 
-	k_delayed_work_submit(&conf.ipv4.tcp.stats_print,
-			      K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&conf.ipv4.tcp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv4);
@@ -334,8 +333,7 @@ static void process_tcp6(void)
 		return;
 	}
 
-	k_delayed_work_submit(&conf.ipv6.tcp.stats_print,
-			      K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&conf.ipv6.tcp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv6);
@@ -364,7 +362,7 @@ static void print_stats(struct k_work *work)
 		atomic_set(&data->tcp.bytes_received, 0);
 	}
 
-	k_delayed_work_submit(&data->tcp.stats_print, K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&data->tcp.stats_print, K_SECONDS(STATS_TIMER));
 }
 
 void start_tcp(void)
@@ -395,7 +393,7 @@ void start_tcp(void)
 	}
 #endif
 
-	k_delayed_work_init(&conf.ipv6.tcp.stats_print, print_stats);
+	k_work_init_delayable(&conf.ipv6.tcp.stats_print, print_stats);
 	k_thread_start(tcp6_thread_id);
 #endif
 
@@ -411,7 +409,7 @@ void start_tcp(void)
 	}
 #endif
 
-	k_delayed_work_init(&conf.ipv4.tcp.stats_print, print_stats);
+	k_work_init_delayable(&conf.ipv4.tcp.stats_print, print_stats);
 	k_thread_start(tcp4_thread_id);
 #endif
 }

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -156,8 +156,7 @@ static void process_udp4(void)
 		return;
 	}
 
-	k_delayed_work_submit(&conf.ipv4.udp.stats_print,
-			      K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&conf.ipv4.udp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_udp(&conf.ipv4);
@@ -183,8 +182,7 @@ static void process_udp6(void)
 		return;
 	}
 
-	k_delayed_work_submit(&conf.ipv6.udp.stats_print,
-			      K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&conf.ipv6.udp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_udp(&conf.ipv6);
@@ -211,7 +209,7 @@ static void print_stats(struct k_work *work)
 		atomic_set(&data->udp.bytes_received, 0);
 	}
 
-	k_delayed_work_submit(&data->udp.stats_print, K_SECONDS(STATS_TIMER));
+	k_work_reschedule(&data->udp.stats_print, K_SECONDS(STATS_TIMER));
 }
 
 void start_udp(void)
@@ -221,7 +219,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp6_thread_id);
 #endif
 
-		k_delayed_work_init(&conf.ipv6.udp.stats_print, print_stats);
+		k_work_init_delayable(&conf.ipv6.udp.stats_print, print_stats);
 		k_thread_name_set(udp6_thread_id, "udp6");
 		k_thread_start(udp6_thread_id);
 	}
@@ -231,7 +229,7 @@ void start_udp(void)
 		k_mem_domain_add_thread(&app_domain, udp4_thread_id);
 #endif
 
-		k_delayed_work_init(&conf.ipv4.udp.stats_print, print_stats);
+		k_work_init_delayable(&conf.ipv4.udp.stats_print, print_stats);
 		k_thread_name_set(udp4_thread_id, "udp4");
 		k_thread_start(udp4_thread_id);
 	}

--- a/samples/net/stats/src/main.c
+++ b/samples/net/stats/src/main.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(net_stats_sample, LOG_LEVEL_DBG);
 #include <net/net_if.h>
 #include <net/net_stats.h>
 
-static struct k_delayed_work stats_timer;
+static struct k_work_delayable stats_timer;
 
 #if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
 #define GET_STAT(iface, s) (iface ? iface->stats.s : data->s)
@@ -177,13 +177,13 @@ static void stats(struct k_work *work)
 	net_if_foreach(eth_iface_cb, &data);
 #endif
 
-	k_delayed_work_submit(&stats_timer, K_SECONDS(CONFIG_SAMPLE_PERIOD));
+	k_work_reschedule(&stats_timer, K_SECONDS(CONFIG_SAMPLE_PERIOD));
 }
 
 static void init_app(void)
 {
-	k_delayed_work_init(&stats_timer, stats);
-	k_delayed_work_submit(&stats_timer, K_SECONDS(CONFIG_SAMPLE_PERIOD));
+	k_work_init_delayable(&stats_timer, stats);
+	k_work_reschedule(&stats_timer, K_SECONDS(CONFIG_SAMPLE_PERIOD));
 }
 
 void main(void)

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -404,7 +404,7 @@ struct net_ipv6_reassembly {
 	 * Timeout for cancelling the reassembly. The timer is used
 	 * also to detect if this reassembly slot is used or not.
 	 */
-	struct k_delayed_work timer;
+	struct k_work_delayable timer;
 
 	/** Pointers to pending fragments */
 	struct net_pkt *pkt[NET_IPV6_FRAGMENTS_MAX_PKT];

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -128,15 +128,14 @@ static struct net_ipv6_reassembly *reassembly_get(uint32_t id,
 	int i, avail = -1;
 
 	for (i = 0; i < CONFIG_NET_IPV6_FRAGMENT_MAX_COUNT; i++) {
-
-		if (k_delayed_work_remaining_get(&reassembly[i].timer) &&
+		if (k_work_delayable_remaining_get(&reassembly[i].timer) &&
 		    reassembly[i].id == id &&
 		    net_ipv6_addr_cmp(src, &reassembly[i].src) &&
 		    net_ipv6_addr_cmp(dst, &reassembly[i].dst)) {
 			return &reassembly[i];
 		}
 
-		if (k_delayed_work_remaining_get(&reassembly[i].timer)) {
+		if (k_work_delayable_remaining_get(&reassembly[i].timer)) {
 			continue;
 		}
 
@@ -149,8 +148,7 @@ static struct net_ipv6_reassembly *reassembly_get(uint32_t id,
 		return NULL;
 	}
 
-	k_delayed_work_submit(&reassembly[avail].timer,
-			      IPV6_REASSEMBLY_TIMEOUT);
+	k_work_reschedule(&reassembly[avail].timer, IPV6_REASSEMBLY_TIMEOUT);
 
 	net_ipaddr_copy(&reassembly[avail].src, src);
 	net_ipaddr_copy(&reassembly[avail].dst, dst);
@@ -177,10 +175,9 @@ static bool reassembly_cancel(uint32_t id,
 			continue;
 		}
 
-		remaining = k_delayed_work_remaining_get(&reassembly[i].timer);
-		if (remaining) {
-			k_delayed_work_cancel(&reassembly[i].timer);
-		}
+		remaining = k_ticks_to_ms_ceil32(
+			k_work_delayable_remaining_get(&reassembly[i].timer));
+		k_work_cancel_delayable(&reassembly[i].timer);
 
 		NET_DBG("IPv6 reassembly id 0x%x remaining %d ms",
 			reassembly[i].id, remaining);
@@ -211,7 +208,8 @@ static void reassembly_info(char *str, struct net_ipv6_reassembly *reass)
 	NET_DBG("%s id 0x%x src %s dst %s remain %d ms", str, reass->id,
 		log_strdup(net_sprint_ipv6_addr(&reass->src)),
 		log_strdup(net_sprint_ipv6_addr(&reass->dst)),
-		k_delayed_work_remaining_get(&reass->timer));
+		k_ticks_to_ms_ceil32(
+			k_work_delayable_remaining_get(&reass->timer)));
 }
 
 static void reassembly_timeout(struct k_work *work)
@@ -238,7 +236,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	uint8_t next_hdr;
 	int i, len;
 
-	k_delayed_work_cancel(&reass->timer);
+	k_work_cancel_delayable(&reass->timer);
 
 	NET_ASSERT(reass->pkt[0]);
 
@@ -355,7 +353,7 @@ void net_ipv6_frag_foreach(net_ipv6_frag_cb_t cb, void *user_data)
 
 	for (i = 0; reassembly_init_done &&
 		     i < CONFIG_NET_IPV6_FRAGMENT_MAX_COUNT; i++) {
-		if (!k_delayed_work_remaining_get(&reassembly[i].timer)) {
+		if (!k_work_delayable_remaining_get(&reassembly[i].timer)) {
 			continue;
 		}
 
@@ -441,8 +439,8 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 		 * so we must do it at runtime.
 		 */
 		for (i = 0; i < CONFIG_NET_IPV6_FRAGMENT_MAX_COUNT; i++) {
-			k_delayed_work_init(&reassembly[i].timer,
-					    reassembly_timeout);
+			k_work_init_delayable(&reassembly[i].timer,
+					      reassembly_timeout);
 		}
 
 		reassembly_init_done = true;

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -67,7 +67,7 @@ static struct k_sem nbr_lock;
 #endif
 
 #if defined(CONFIG_NET_IPV6_ND)
-static struct k_delayed_work ipv6_nd_reachable_timer;
+static struct k_work_delayable ipv6_nd_reachable_timer;
 static void ipv6_nd_reachable_timeout(struct k_work *work);
 static void ipv6_nd_restart_reachable_timer(struct net_nbr *nbr, int64_t time);
 #endif
@@ -84,7 +84,7 @@ extern void net_neighbor_data_remove(struct net_nbr *nbr);
 extern void net_neighbor_table_clear(struct net_nbr_table *table);
 
 /** Neighbor Solicitation reply timer */
-static struct k_delayed_work ipv6_ns_reply_timer;
+static struct k_work_delayable ipv6_ns_reply_timer;
 
 NET_NBR_POOL_INIT(net_neighbor_pool,
 		  CONFIG_NET_IPV6_MAX_NEIGHBORS,
@@ -364,10 +364,10 @@ static void ipv6_ns_reply_timeout(struct k_work *work)
 		remaining = data->send_ns + NS_REPLY_TIMEOUT - current;
 
 		if (remaining > 0) {
-			if (!k_delayed_work_remaining_get(
-						&ipv6_ns_reply_timer)) {
-				k_delayed_work_submit(&ipv6_ns_reply_timer,
-						      K_MSEC(remaining));
+			if (!k_work_delayable_remaining_get(
+				    &ipv6_ns_reply_timer)) {
+				k_work_reschedule(&ipv6_ns_reply_timer,
+						  K_MSEC(remaining));
 			}
 
 			continue;
@@ -1402,9 +1402,10 @@ static void ipv6_nd_restart_reachable_timer(struct net_nbr *nbr, int64_t time)
 		net_ipv6_nbr_data(nbr)->reachable_timeout = time;
 	}
 
-	remaining = k_delayed_work_remaining_get(&ipv6_nd_reachable_timer);
+	remaining = k_ticks_to_ms_ceil32(
+		k_work_delayable_remaining_get(&ipv6_nd_reachable_timer));
 	if (!remaining || remaining > time) {
-		k_delayed_work_submit(&ipv6_nd_reachable_timer, K_MSEC(time));
+		k_work_reschedule(&ipv6_nd_reachable_timer, K_MSEC(time));
 	}
 }
 
@@ -1926,9 +1927,9 @@ int net_ipv6_send_ns(struct net_if *iface,
 		net_ipv6_nbr_data(nbr)->send_ns = k_uptime_get();
 
 		/* Let's start the timer if necessary */
-		if (!k_delayed_work_remaining_get(&ipv6_ns_reply_timer)) {
-			k_delayed_work_submit(&ipv6_ns_reply_timer,
-					      K_MSEC(NS_REPLY_TIMEOUT));
+		if (!k_work_delayable_remaining_get(&ipv6_ns_reply_timer)) {
+			k_work_reschedule(&ipv6_ns_reply_timer,
+					  K_MSEC(NS_REPLY_TIMEOUT));
 		}
 	}
 
@@ -2487,12 +2488,12 @@ void net_ipv6_nbr_init(void)
 #if defined(CONFIG_NET_IPV6_NBR_CACHE)
 	net_icmpv6_register_handler(&ns_input_handler);
 	net_icmpv6_register_handler(&na_input_handler);
-	k_delayed_work_init(&ipv6_ns_reply_timer, ipv6_ns_reply_timeout);
+	k_work_init_delayable(&ipv6_ns_reply_timer, ipv6_ns_reply_timeout);
 #endif
 #if defined(CONFIG_NET_IPV6_ND)
 	net_icmpv6_register_handler(&ra_input_handler);
-	k_delayed_work_init(&ipv6_nd_reachable_timer,
-			    ipv6_nd_reachable_timeout);
+	k_work_init_delayable(&ipv6_nd_reachable_timer,
+			      ipv6_nd_reachable_timeout);
 	k_sem_init(&nbr_lock, 1, K_SEM_MAX_LIMIT);
 #endif
 }

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1574,9 +1574,8 @@ static void ipv6_frag_cb(struct net_ipv6_reassembly *reass,
 
 	snprintk(src, ADDR_LEN, "%s", net_sprint_ipv6_addr(&reass->src));
 
-	PR("%p      0x%08x  %5d %16s\t%16s\n",
-	   reass, reass->id,
-	   k_delayed_work_remaining_get(&reass->timer),
+	PR("%p      0x%08x  %5d %16s\t%16s\n", reass, reass->id,
+	   k_ticks_to_ms_ceil32(k_work_delayable_remaining_get(&reass->timer)),
 	   src, net_sprint_ipv6_addr(&reass->dst));
 
 	for (i = 0; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -224,10 +224,9 @@ void net_tc_tx_init(void)
 							"coop" : "preempt",
 			priority);
 
-		k_work_q_start(&tx_classes[i].work_q,
-			       tx_stack[i],
-			       K_KERNEL_STACK_SIZEOF(tx_stack[i]),
-			       priority);
+		k_work_queue_start(&tx_classes[i].work_q, tx_stack[i],
+				   K_KERNEL_STACK_SIZEOF(tx_stack[i]), priority,
+				   NULL);
 
 		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 			char name[MAX_NAME_LEN];
@@ -267,10 +266,9 @@ void net_tc_rx_init(void)
 							"coop" : "preempt",
 			priority);
 
-		k_work_q_start(&rx_classes[i].work_q,
-			       rx_stack[i],
-			       K_KERNEL_STACK_SIZEOF(rx_stack[i]),
-			       priority);
+		k_work_queue_start(&rx_classes[i].work_q, rx_stack[i],
+				   K_KERNEL_STACK_SIZEOF(rx_stack[i]), priority,
+				   NULL);
 
 		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 			char name[MAX_NAME_LEN];

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -122,18 +122,20 @@
 	(_conn)->state = _s;						\
 })
 
-#define conn_send_data_dump(_conn)					\
-({									\
-	NET_DBG("conn: %p total=%zd, unacked_len=%d, "			\
-		"send_win=%hu, mss=%hu",				\
-		(_conn), net_pkt_get_len((_conn)->send_data),		\
-		conn->unacked_len, conn->send_win,			\
-		(uint16_t)conn_mss((_conn)));				\
-	NET_DBG("conn: %p send_data_timer=%hu, send_data_retries=%hu",	\
-		(_conn),						\
-		(bool)k_delayed_work_remaining_get(&(_conn)->send_data_timer),\
-		(_conn)->send_data_retries);				\
-})
+#define conn_send_data_dump(_conn)                                             \
+	({                                                                     \
+		NET_DBG("conn: %p total=%zd, unacked_len=%d, "                 \
+			"send_win=%hu, mss=%hu",                               \
+			(_conn), net_pkt_get_len((_conn)->send_data),          \
+			conn->unacked_len, conn->send_win,                     \
+			(uint16_t)conn_mss((_conn)));                          \
+		NET_DBG("conn: %p send_data_timer=%hu, send_data_retries=%hu", \
+			(_conn),                                               \
+			(bool)k_ticks_to_ms_ceil32(                            \
+				k_work_delayable_remaining_get(                \
+					&(_conn)->send_data_timer)),           \
+			(_conn)->send_data_retries);                           \
+	})
 
 #define TCPOPT_END	0
 #define TCPOPT_NOP	1
@@ -223,17 +225,17 @@ struct tcp { /* TCP connection */
 	struct k_sem connect_sem; /* semaphore for blocking connect */
 	struct k_fifo recv_data;  /* temp queue before passing data to app */
 	struct tcp_options recv_options;
-	struct k_delayed_work send_timer;
-	struct k_delayed_work recv_queue_timer;
-	struct k_delayed_work send_data_timer;
-	struct k_delayed_work timewait_timer;
+	struct k_work_delayable send_timer;
+	struct k_work_delayable recv_queue_timer;
+	struct k_work_delayable send_data_timer;
+	struct k_work_delayable timewait_timer;
 	union {
 		/* Because FIN and establish timers are never happening
 		 * at the same time, share the timer between them to
 		 * save memory.
 		 */
-		struct k_delayed_work fin_timer;
-		struct k_delayed_work establish_timer;
+		struct k_work_delayable fin_timer;
+		struct k_work_delayable establish_timer;
 	};
 	union tcp_endpoint src;
 	union tcp_endpoint dst;

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -80,8 +80,8 @@ static void double_interval_timeout(struct k_work *work)
 	NET_DBG("doubling time %u", rand_time);
 
 	trickle->Istart = k_uptime_get_32() + rand_time;
-	k_delayed_work_init(&trickle->timer, trickle_timeout);
-	k_delayed_work_submit(&trickle->timer, K_MSEC(rand_time));
+	k_work_init_delayable(&trickle->timer, trickle_timeout);
+	k_work_reschedule(&trickle->timer, K_MSEC(rand_time));
 
 	NET_DBG("last end %u new end %u for %u I %u",
 		last_end, get_end(trickle), trickle->Istart, trickle->I);
@@ -100,8 +100,8 @@ static inline void reschedule(struct net_trickle *trickle)
 		NET_DBG("Clock wrap");
 	}
 
-	k_delayed_work_init(&trickle->timer, double_interval_timeout);
-	k_delayed_work_submit(&trickle->timer, K_MSEC(diff));
+	k_work_init_delayable(&trickle->timer, double_interval_timeout);
+	k_work_reschedule(&trickle->timer, K_MSEC(diff));
 }
 
 static void trickle_timeout(struct k_work *work)
@@ -135,7 +135,7 @@ static void setup_new_interval(struct net_trickle *trickle)
 
 	trickle->Istart = k_uptime_get_32();
 
-	k_delayed_work_submit(&trickle->timer, K_MSEC(t));
+	k_work_reschedule(&trickle->timer, K_MSEC(t));
 
 	NET_DBG("new interval at %d ends %d t %d I %d",
 		trickle->Istart,
@@ -167,7 +167,7 @@ int net_trickle_create(struct net_trickle *trickle,
 		trickle->Imin, trickle->Imax, trickle->k,
 		trickle->Imax_abs);
 
-	k_delayed_work_init(&trickle->timer, trickle_timeout);
+	k_work_init_delayable(&trickle->timer, trickle_timeout);
 
 	return 0;
 }
@@ -198,7 +198,7 @@ int net_trickle_stop(struct net_trickle *trickle)
 {
 	NET_ASSERT(trickle);
 
-	k_delayed_work_cancel(&trickle->timer);
+	k_work_cancel_delayable(&trickle->timer);
 
 	trickle->I = 0U;
 

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -1741,9 +1741,9 @@ void net_6locan_init(struct net_if *iface)
 		thread_priority = K_PRIO_PREEMPT(6);
 	}
 
-	k_work_q_start(&net_canbus_workq, net_canbus_stack,
-		       K_KERNEL_STACK_SIZEOF(net_canbus_stack),
-		       thread_priority);
+	k_work_queue_start(&net_canbus_workq, net_canbus_stack,
+			   K_KERNEL_STACK_SIZEOF(net_canbus_stack),
+			   thread_priority, NULL);
 	k_thread_name_set(&net_canbus_workq.thread, "isotp_work");
 	NET_DBG("Workq started. Thread ID: %p", &net_canbus_workq.thread);
 }

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -30,7 +30,7 @@ static sys_slist_t arp_free_entries;
 static sys_slist_t arp_pending_entries;
 static sys_slist_t arp_table;
 
-struct k_delayed_work arp_request_timer;
+struct k_work_delayable arp_request_timer;
 
 static void arp_entry_cleanup(struct arp_entry *entry, bool pending)
 {
@@ -122,7 +122,7 @@ static struct arp_entry *arp_entry_get_pending(struct net_if *iface,
 	}
 
 	if (sys_slist_is_empty(&arp_pending_entries)) {
-		k_delayed_work_cancel(&arp_request_timer);
+		k_work_cancel_delayable(&arp_request_timer);
 	}
 
 	return entry;
@@ -171,9 +171,9 @@ static void arp_entry_register_pending(struct arp_entry *entry)
 	entry->req_start = k_uptime_get_32();
 
 	/* Let's start the timer if necessary */
-	if (!k_delayed_work_remaining_get(&arp_request_timer)) {
-		k_delayed_work_submit(&arp_request_timer,
-				      K_MSEC(ARP_REQUEST_TIMEOUT));
+	if (!k_work_delayable_remaining_get(&arp_request_timer)) {
+		k_work_reschedule(&arp_request_timer,
+				  K_MSEC(ARP_REQUEST_TIMEOUT));
 	}
 }
 
@@ -200,9 +200,9 @@ static void arp_request_timeout(struct k_work *work)
 	}
 
 	if (entry) {
-		k_delayed_work_submit(&arp_request_timer,
-				      K_MSEC(entry->req_start +
-					     ARP_REQUEST_TIMEOUT - current));
+		k_work_reschedule(&arp_request_timer,
+				  K_MSEC(entry->req_start +
+					 ARP_REQUEST_TIMEOUT - current));
 	}
 }
 
@@ -709,7 +709,7 @@ void net_arp_clear_cache(struct net_if *iface)
 	}
 
 	if (sys_slist_is_empty(&arp_pending_entries)) {
-		k_delayed_work_cancel(&arp_request_timer);
+		k_work_cancel_delayable(&arp_request_timer);
 	}
 }
 
@@ -743,7 +743,7 @@ void net_arp_init(void)
 		sys_slist_prepend(&arp_free_entries, &arp_entries[i].node);
 	}
 
-	k_delayed_work_init(&arp_request_timer, arp_request_timeout);
+	k_work_init_delayable(&arp_request_timer, arp_request_timeout);
 
 	arp_cache_initialized = true;
 }

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.c
@@ -42,7 +42,7 @@ static uint16_t datagram_tag;
  *  IPv6 packets simultaneously.
  */
 struct frag_cache {
-	struct k_delayed_work timer;	/* Reassemble timer */
+	struct k_work_delayable timer; /* Reassemble timer */
 	struct net_pkt *pkt;		/* Reassemble packet */
 	uint16_t size;			/* Datagram size */
 	uint16_t tag;			/* Datagram tag */
@@ -277,7 +277,7 @@ static inline void clear_reass_cache(uint16_t size, uint16_t tag)
 		cache[i].size = 0U;
 		cache[i].tag = 0U;
 		cache[i].used = false;
-		k_delayed_work_cancel(&cache[i].timer);
+		k_work_cancel_delayable(&cache[i].timer);
 	}
 }
 
@@ -319,8 +319,8 @@ static inline struct frag_cache *set_reass_cache(struct net_pkt *pkt,
 		cache[i].tag = tag;
 		cache[i].used = true;
 
-		k_delayed_work_init(&cache[i].timer, reass_timeout);
-		k_delayed_work_submit(&cache[i].timer, FRAG_REASSEMBLY_TIMEOUT);
+		k_work_init_delayable(&cache[i].timer, reass_timeout);
+		k_work_reschedule(&cache[i].timer, FRAG_REASSEMBLY_TIMEOUT);
 		return &cache[i];
 	}
 

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -451,10 +451,10 @@ void net_ppp_init(struct net_if *iface)
 	 * system. The issue is not very likely as typically there
 	 * would be only one PPP network interface in the system.
 	 */
-	k_delayed_work_init(&ctx->startup, ppp_startup);
+	k_work_init_delayable(&ctx->startup, ppp_startup);
 
 	ctx->is_startup_pending = true;
 
-	k_delayed_work_submit(&ctx->startup,
-			      K_MSEC(CONFIG_NET_L2_PPP_DELAY_STARTUP_MS));
+	k_work_reschedule(&ctx->startup,
+			  K_MSEC(CONFIG_NET_L2_PPP_DELAY_STARTUP_MS));
 }

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -652,9 +652,9 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (!K_TIMEOUT_EQ(req->internal.timeout, K_FOREVER) &&
 	    !K_TIMEOUT_EQ(req->internal.timeout, K_NO_WAIT)) {
-		k_delayed_work_init(&req->internal.work, http_timeout);
-		(void)k_delayed_work_submit(&req->internal.work,
-					    req->internal.timeout);
+		k_work_init_delayable(&req->internal.work, http_timeout);
+		(void)k_work_reschedule(&req->internal.work,
+					req->internal.timeout);
 	}
 
 	/* Request is sent, now wait data to be received */
@@ -667,7 +667,7 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (!K_TIMEOUT_EQ(req->internal.timeout, K_FOREVER) &&
 	    !K_TIMEOUT_EQ(req->internal.timeout, K_NO_WAIT)) {
-		(void)k_delayed_work_cancel(&req->internal.work);
+		(void)k_work_cancel_delayable(&req->internal.work);
 	}
 
 	return total_sent;

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -49,7 +49,7 @@ struct ipso_buzzer_data {
 
 	uint64_t trigger_offset;
 
-	struct k_delayed_work buzzer_work;
+	struct k_work_delayable buzzer_work;
 
 	uint16_t obj_inst_id;
 	bool onoff; /* toggle from resource */
@@ -129,7 +129,7 @@ static int start_buzzer(struct ipso_buzzer_data *buzzer)
 	lwm2m_engine_set_bool(path, true);
 
 	float2ms(&buzzer->delay_duration, &temp);
-	k_delayed_work_submit(&buzzer->buzzer_work, K_MSEC(temp));
+	k_work_reschedule(&buzzer->buzzer_work, K_MSEC(temp));
 
 	return 0;
 }
@@ -148,7 +148,7 @@ static int stop_buzzer(struct ipso_buzzer_data *buzzer, bool cancel)
 	lwm2m_engine_set_bool(path, false);
 
 	if (cancel) {
-		k_delayed_work_cancel(&buzzer->buzzer_work);
+		k_work_cancel_delayable(&buzzer->buzzer_work);
 	}
 
 	return 0;
@@ -209,7 +209,7 @@ static struct lwm2m_engine_obj_inst *buzzer_create(uint16_t obj_inst_id)
 
 	/* Set default values */
 	(void)memset(&buzzer_data[avail], 0, sizeof(buzzer_data[avail]));
-	k_delayed_work_init(&buzzer_data[avail].buzzer_work, buzzer_work_cb);
+	k_work_init_delayable(&buzzer_data[avail].buzzer_work, buzzer_work_cb);
 	buzzer_data[avail].level.val1 = 50; /* 50% */
 	buzzer_data[avail].delay_duration.val1 = 1; /* 1 seconds */
 	buzzer_data[avail].obj_inst_id = obj_inst_id;

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -55,7 +55,7 @@ struct ipso_timer_data {
 	uint32_t trigger_counter;
 	uint32_t cumulative_time_ms;
 
-	struct k_delayed_work timer_work;
+	struct k_work_delayable timer_work;
 
 	uint16_t obj_inst_id;
 	uint8_t timer_mode;
@@ -144,7 +144,7 @@ static int start_timer(struct ipso_timer_data *timer)
 	lwm2m_engine_set_bool(path, true);
 
 	float2ms(&timer->delay_duration, &temp);
-	k_delayed_work_submit(&timer->timer_work, K_MSEC(temp));
+	k_work_reschedule(&timer->timer_work, K_MSEC(temp));
 
 	return 0;
 }
@@ -164,7 +164,7 @@ static int stop_timer(struct ipso_timer_data *timer, bool cancel)
 	lwm2m_engine_set_bool(path, false);
 
 	if (cancel) {
-		k_delayed_work_cancel(&timer->timer_work);
+		k_work_cancel_delayable(&timer->timer_work);
 	}
 
 	return 0;
@@ -317,7 +317,7 @@ static struct lwm2m_engine_obj_inst *timer_create(uint16_t obj_inst_id)
 
 	/* Set default values */
 	(void)memset(&timer_data[avail], 0, sizeof(timer_data[avail]));
-	k_delayed_work_init(&timer_data[avail].timer_work, timer_work_cb);
+	k_work_init_delayable(&timer_data[avail].timer_work, timer_work_cb);
 	timer_data[avail].delay_duration.val1 = 5; /* 5 seconds */
 	timer_data[avail].enabled = true;
 	timer_data[avail].timer_mode = TIMER_MODE_ONE_SHOT;

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -222,9 +222,9 @@ void platformRadioInit(void)
 		return;
 	}
 
-	k_work_q_start(&ot_work_q, ot_task_stack,
-		       K_KERNEL_STACK_SIZEOF(ot_task_stack),
-		       OT_WORKER_PRIORITY);
+	k_work_queue_start(&ot_work_q, ot_task_stack,
+			   K_KERNEL_STACK_SIZEOF(ot_task_stack),
+			   OT_WORKER_PRIORITY, NULL);
 	k_thread_name_set(&ot_work_q.thread, "ot_radio_workq");
 
 	if ((radio_api->get_capabilities(radio_dev) &

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -708,7 +708,7 @@ void test_v6_so_rcvtimeo(void)
 }
 
 struct test_msg_waitall_data {
-	struct k_delayed_work tx_work;
+	struct k_work_delayable tx_work;
 	int sock;
 	const uint8_t *data;
 	size_t offset;
@@ -724,7 +724,7 @@ static void test_msg_waitall_tx_work_handler(struct k_work *work)
 		test_send(test_data->sock, test_data->data + test_data->offset, 1, 0);
 		test_data->offset++;
 		test_data->retries--;
-		k_delayed_work_submit(&test_data->tx_work, K_MSEC(10));
+		k_work_reschedule(&test_data->tx_work, K_MSEC(10));
 	}
 }
 
@@ -767,14 +767,15 @@ void test_v4_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf);
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf), MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf), "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf),
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	/* MSG_WAITALL + SO_RCVTIMEO - make sure recv returns the amount of data
 	 * received so far
@@ -787,14 +788,15 @@ void test_v4_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf) - 1;
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf) - 1, MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf) - 1, "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf) - 1,
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -839,14 +841,15 @@ void test_v6_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf);
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf), MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf), "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf),
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	/* MSG_WAITALL + SO_RCVTIMEO - make sure recv returns the amount of data
 	 * received so far
@@ -859,14 +862,15 @@ void test_v6_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf) - 1;
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf) - 1, MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf) - 1, "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf) - 1,
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	test_close(new_sock);
 	test_close(s_sock);

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -191,7 +191,7 @@ void test_so_protocol(void)
 }
 
 struct test_msg_waitall_data {
-	struct k_delayed_work tx_work;
+	struct k_work_delayable tx_work;
 	int sock;
 	const uint8_t *data;
 	size_t offset;
@@ -207,7 +207,7 @@ static void test_msg_waitall_tx_work_handler(struct k_work *work)
 		test_send(test_data->sock, test_data->data + test_data->offset, 1, 0);
 		test_data->offset++;
 		test_data->retries--;
-		k_delayed_work_submit(&test_data->tx_work, K_MSEC(10));
+		k_work_reschedule(&test_data->tx_work, K_MSEC(10));
 	}
 }
 
@@ -253,14 +253,15 @@ void test_v4_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf);
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf), MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf), "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf),
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	/* MSG_WAITALL + SO_RCVTIMEO - make sure recv returns the amount of data
 	 * received so far
@@ -273,14 +274,15 @@ void test_v4_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf) - 1;
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf) - 1, MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf) - 1, "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf) - 1,
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -329,14 +331,15 @@ void test_v6_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf);
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf), MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf), "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf),
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	/* MSG_WAITALL + SO_RCVTIMEO - make sure recv returns the amount of data
 	 * received so far
@@ -349,14 +352,15 @@ void test_v6_msg_waitall(void)
 	test_data.offset = 0;
 	test_data.retries = sizeof(rx_buf) - 1;
 	test_data.sock = c_sock;
-	k_delayed_work_init(&test_data.tx_work, test_msg_waitall_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_waitall_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	ret = recv(new_sock, rx_buf, sizeof(rx_buf) - 1, MSG_WAITALL);
 	zassert_equal(ret, sizeof(rx_buf) - 1, "Invalid length received");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(rx_buf) - 1,
 			  "Invalid data received");
-	k_delayed_work_cancel(&test_data.tx_work);
+	k_work_cancel_delayable(&test_data.tx_work);
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -364,7 +368,7 @@ void test_v6_msg_waitall(void)
 }
 
 struct test_msg_trunc_data {
-	struct k_delayed_work tx_work;
+	struct k_work_delayable tx_work;
 	int sock;
 	const uint8_t *data;
 	size_t datalen;
@@ -407,8 +411,9 @@ void test_msg_trunc(int sock_c, int sock_s, struct sockaddr *addr_c,
 	/* MSG_TRUNC */
 
 	test_data.sock = sock_c;
-	k_delayed_work_init(&test_data.tx_work, test_msg_trunc_tx_work_handler);
-	k_delayed_work_submit(&test_data.tx_work, K_MSEC(10));
+	k_work_init_delayable(&test_data.tx_work,
+			      test_msg_trunc_tx_work_handler);
+	k_work_reschedule(&test_data.tx_work, K_MSEC(10));
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 	rv = recv(sock_s, rx_buf, 2, ZSOCK_MSG_TRUNC);

--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -108,7 +108,7 @@ enum test_state {
 
 static enum test_state t_state;
 
-static struct k_delayed_work test_server;
+static struct k_work_delayable test_server;
 static void test_server_timeout(struct k_work *work);
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt);
@@ -447,7 +447,7 @@ static void test_presetup(void)
 		zassert_true(false, "Failed to add IPv6 address");
 	}
 
-	k_delayed_work_init(&test_server, test_server_timeout);
+	k_work_init_delayable(&test_server, test_server_timeout);
 }
 
 static void handle_client_test(sa_family_t af, struct tcphdr *th)
@@ -760,7 +760,7 @@ static void test_server_ipv4(void)
 	}
 
 	/* Trigger the peer to send SYN */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_accept(ctx, test_tcp_accept_cb, K_FOREVER, NULL);
 	if (ret < 0) {
@@ -773,7 +773,7 @@ static void test_server_ipv4(void)
 	test_sem_take(K_MSEC(100), __LINE__);
 
 	/* Trigger the peer to send DATA  */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_recv(ctx, test_tcp_recv_cb, K_MSEC(200), NULL);
 	if (ret < 0) {
@@ -781,7 +781,7 @@ static void test_server_ipv4(void)
 	}
 
 	/* Trigger the peer to send FIN after timeout */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	net_context_put(ctx);
 }
@@ -823,7 +823,7 @@ static void test_server_with_options_ipv4(void)
 	}
 
 	/* Trigger the peer to send SYN */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_accept(ctx, test_tcp_accept_cb, K_FOREVER, NULL);
 	if (ret < 0) {
@@ -836,7 +836,7 @@ static void test_server_with_options_ipv4(void)
 	test_sem_take(K_MSEC(100), __LINE__);
 
 	/* Trigger the peer to send DATA  */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_recv(ctx, test_tcp_recv_cb, K_MSEC(200), NULL);
 	if (ret < 0) {
@@ -844,7 +844,7 @@ static void test_server_with_options_ipv4(void)
 	}
 
 	/* Trigger the peer to send FIN after timeout */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	net_context_put(ctx);
 }
@@ -886,7 +886,7 @@ static void test_server_ipv6(void)
 	}
 
 	/* Trigger the peer to send SYN  */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_accept(ctx, test_tcp_accept_cb, K_FOREVER, NULL);
 	if (ret < 0) {
@@ -899,7 +899,7 @@ static void test_server_ipv6(void)
 	test_sem_take(K_MSEC(100), __LINE__);
 
 	/* Trigger the peer to send DATA  */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_recv(ctx, test_tcp_recv_cb, K_MSEC(200), NULL);
 	if (ret < 0) {
@@ -907,7 +907,7 @@ static void test_server_ipv6(void)
 	}
 
 	/* Trigger the peer to send FIN after timeout */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	net_context_put(ctx);
 }
@@ -1230,7 +1230,7 @@ static struct net_context *create_server_socket(uint32_t my_seq,
 	}
 
 	/* Trigger the peer to send SYN  */
-	k_delayed_work_submit(&test_server, K_NO_WAIT);
+	k_work_reschedule(&test_server, K_NO_WAIT);
 
 	ret = net_context_accept(ctx, test_tcp_accept_cb, K_FOREVER, NULL);
 	if (ret < 0) {


### PR DESCRIPTION
This is related to #33104 and takes relevant patches from #33924. I did slight changes to some of the commits from #33824, those ones have my signed-off-by added.
Only minimal testing done for those components that I could, but overall the original rote conversion by @pabigot looked good. 
