### PR TITLE
doc: flexibilize sphinx-rtd-theme allowed versions

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -3,7 +3,7 @@
 breathe>=4.23.0
 docutils>=0.16
 sphinx>=3.3.0,<3.4.0
-sphinx_rtd_theme==0.5.2
+sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 


### PR DESCRIPTION
Allow versions starting from 0.5.2 up to < 1.0, the next major
releases. Major releases tend to include breaking changes, so better
restrict such releases until they are manually tested for potential
regressions.