### PR TITLE
drivers: espi: xec: Reduce buffer allocation to minimum required

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -37,6 +37,23 @@ config ESPI_PERIPHERAL_UART_SOC_MAPPING
 	  This tells the driver to which SoC UART to direct the UART traffic
 	  send over eSPI from host.
 
+config ESPI_OOB_BUFFER_SIZE
+	int "eSPI OOB channel buffer size in bytes"
+	default 128
+	depends on ESPI_OOB_CHANNEL
+	help
+	  Use minimum RAM buffer size by default but allow applications to
+	  override the value.
+	  Maximum OOB payload is 73 bytes.
+
+config ESPI_FLASH_BUFFER_SIZE
+	int "eSPI Flash channel buffer size in bytes"
+	default 256
+	depends on ESPI_FLASH_CHANNEL
+	help
+	  Use maximum RAM buffer size defined by spec but allow applications
+	  to override if eSPI host doesn't support it.
+
 config ESPI_SAF
 	bool "XEC Microchip ESPI SAF driver"
 	depends on ESPI_FLASH_CHANNEL

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -14,9 +14,8 @@
 #include <drivers/spi.h>
 #include <logging/log_ctrl.h>
 #include <logging/log.h>
-#ifdef CONFIG_ESPI_OOB_CHANNEL
+/* OOB operations will be attempted regardless of channel enabled or not */
 #include "espi_oob_handler.h"
-#endif
 LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);
 
 /* eSPI flash parameters */


### PR DESCRIPTION
Reduce buffer allocation to minimum required to reduce RAM usage
Optimize eSPI buffer allocation to minimum required per eSPI specification.
Note that flash buffer size could be reduce further to 64 bytes only since it's maximum supported in current eSPI host.

Also add fix #32457 

```
Current RAM usage 
¦   ¦   +-- espi_mchp_xec.c                                                                      1604 6.89%
¦   ¦       +-- espi_xec_data                                                                      60 0.26%
¦   ¦       +-- target_mem                                                                         512 2.20%
¦   ¦       +-- target_rx_mem                                                                      512 2.20%
¦   ¦       +-- target_tx_mem                                                                      512 2.20%
```
After driver changes and app override when needed
```
 │   ├── espi_mchp_xec.c                                                                       388 1.74%
│   │   │   ├── espi_xec_data                                                                      60 0.27%
│   │   │   ├── target_mem                                                                          64 0.29%
│   │   │   ├── target_rx_mem                                                                      128 0.57%
│   │   │   ├── target_tx_mem                                                                      128 0.57%
│   │   │   └── vw_wires_int_en                                                                     8 0.04%
```