### PR TITLE
tests: kernel: workq: critical: replace to-be-deprecated k_work API use

### DIFF
--- a/tests/kernel/workq/critical/src/main.c
+++ b/tests/kernel/workq/critical/src/main.c
@@ -196,10 +196,10 @@ void test_offload_workqueue(void)
 	critical_var = 0U;
 	alt_thread_iterations = 0U;
 
-	k_work_q_start(&offload_work_q,
+	k_work_queue_start(&offload_work_q,
 		       offload_work_q_stack,
 		       K_THREAD_STACK_SIZEOF(offload_work_q_stack),
-		       CONFIG_MAIN_THREAD_PRIORITY);
+		       CONFIG_MAIN_THREAD_PRIORITY, NULL);
 
 	k_thread_create(&thread1, stack1, STACK_SIZE,
 			alternate_thread, NULL, NULL, NULL,


### PR DESCRIPTION
The new standard API has a different name with an additional parameter.

Partial fix for #34105 along with #32888 or #34112