### PR TITLE
Kconfig: clean up FPU and FPU_SHARING entries

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -807,7 +807,6 @@ menu "Floating Point Options"
 config FPU
 	bool "Enable floating point unit (FPU)"
 	depends on CPU_HAS_FPU
-	depends on ARC || ARM || RISCV || SPARC || X86
 	help
 	  This option enables the hardware Floating Point Unit (FPU), in order to
 	  support using the floating point registers and instructions.
@@ -828,20 +827,19 @@ config FPU
 config FPU_SHARING
 	bool "FPU register sharing"
 	depends on FPU && MULTITHREADING
-	default y if ARM && ARMV7_M_ARMV8_M_FP
 	help
 	  This option enables preservation of the hardware floating point registers
 	  across context switches to allow multiple threads to perform concurrent
 	  floating point operations.
 
-	  Note that on Cortex-M processors with the floating point extension we
-	  enable by default the FPU register sharing mode, as some GCC compilers
-	  may activate a floating point context by generating FP instructions for
-	  any thread, and that context must be preserved when switching such
-	  threads in and out. The developers can still disable the FP sharing
-	  mode in their application projects, and switch to Unshared FP registers
-	  mode, if it is guaranteed that the image code does not generate FP
-	  instructions outside the single thread context that is allowed to do so.
+	  Note that some compiler configurations may activate a floating point
+	  context by generating FP instructions for any thread, and that
+	  context must be preserved when switching such threads in and out.
+	  The developers can still disable the FP sharing mode in their
+	  application projects, and switch to Unshared FP registers mode,
+	  if it is guaranteed that the image code does not generate FP
+	  instructions outside the single thread context that is allowed
+	  to do so.
 
 endmenu
 

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -244,6 +244,7 @@ config ARMV8_M_SE
 config ARMV7_M_ARMV8_M_FP
 	bool
 	depends on ARMV7_M_ARMV8_M_MAINLINE && !CPU_CORTEX_M3
+	imply FPU_SHARING
 	help
 	  This option signifies the use of an ARMv7-M processor
 	  implementation, or the use of an ARMv8-M processor


### PR DESCRIPTION
CONFIG_FPU: The architecture dependency list is redundant.
Having CPU_HAS_FPU being selected by those archs as a dependency
is sufficient.

CONFIG_FPU_SHARING: This really ought to always default to y when FPU
and MULTITHREADING are set. Turning this off is unsafe and should be
a conscious choice from people who know what they're doing.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
