### PR TITLE
log: fix log crash due to missing strdup on ESP32

### DIFF
--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -9,3 +9,10 @@ config BOARD
 
 config ENTROPY_ESP32_RNG
 	default y if ENTROPY_GENERATOR
+
+if LOG
+
+config LOG_DETECT_MISSED_STRDUP
+	default n
+
+endif


### PR DESCRIPTION
ESP32 requires some content as fatal.c rodata to be placed into RAM to allow cache disabled exceptions.
The consequence is that it will trigger missing log_strdup call when normal exception is called.
Disabling that by default fix the error and stops terminal output flooding warning event.