### PR TITLE
Bluetooth: controller: Guard against race in connection establishment

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -64,6 +64,7 @@ struct lll_conn {
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
 			uint8_t  initiated:1;
+			uint8_t  cancelled:1;
 			uint8_t  latency_enabled:1;
 
 			uint32_t window_widening_periodic_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1126,25 +1126,6 @@ static void isr_done(void *param)
 		radio_tmr_end_capture();
 
 		return;
-
-#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(BT_CTLR_ADV_EXT_PBACK)
-	} else {
-		struct pdu_adv_com_ext_adv *p;
-		struct pdu_adv_ext_hdr *h;
-		struct pdu_adv *pdu;
-
-		pdu = lll_adv_data_curr_get(lll);
-		p = (void *)&pdu->adv_ext_ind;
-		h = (void *)p->ext_hdr_adv_data;
-
-		if ((pdu->type == PDU_ADV_TYPE_EXT_IND) && h->aux_ptr) {
-			radio_filter_disable();
-
-			lll_adv_aux_pback_prepare(lll);
-
-			return;
-		}
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
 	}
 
 	radio_filter_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -741,10 +741,14 @@ static int prepare_cb(struct lll_prepare_param *p)
 	lll = p->param;
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	/* Check if stopped (on connection establishment race between LLL and
-	 * ULL.
+	/* Check if stopped (on connection establishment- or disabled race
+	 * between LLL and ULL.
+	 * When connectable advertising is disabled in thread context, cancelled
+	 * flag is set, and initiated flag is checked. Here, we avoid
+	 * transmitting connectable advertising event if cancelled flag is set.
 	 */
-	if (unlikely(lll->conn && lll->conn->slave.initiated)) {
+	if (unlikely(lll->conn &&
+		(lll->conn->slave.initiated || lll->conn->slave.cancelled))) {
 		radio_isr_set(lll_isr_early_abort, lll);
 		radio_disable();
 
@@ -1081,7 +1085,14 @@ static void isr_done(void *param)
 	}
 #endif /* CONFIG_BT_PERIPHERAL */
 
-	if (lll->chan_map_curr) {
+	/* NOTE: Do not continue to connectable advertise if advertising is
+	 *       being disabled, by checking the cancelled flag.
+	 */
+	if (lll->chan_map_curr &&
+#if defined(CONFIG_BT_PERIPHERAL)
+	    (!lll->conn || !lll->conn->slave.cancelled) &&
+#endif /* CONFIG_BT_PERIPHERAL */
+	    1) {
 		struct pdu_adv *pdu;
 		uint32_t start_us;
 
@@ -1323,12 +1334,22 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		return 0;
 
 #if defined(CONFIG_BT_PERIPHERAL)
+	/* NOTE: Do not accept CONNECT_IND if cancelled flag is set in thread
+	 *       context when disabling connectable advertising. This is to
+	 *       avoid any race in checking the initiated flags in thread mode
+	 *       which is set here if accepting a connection establishment.
+	 *
+	 *       Under this race, peer central would get failed to establish
+	 *       connection as the disconnect reason. This is an acceptable
+	 *       outcome to keep the thread mode implementation simple when
+	 *       disabling connectable advertising.
+	 */
 	} else if ((pdu_rx->type == PDU_ADV_TYPE_CONNECT_IND) &&
 		   (pdu_rx->len == sizeof(struct pdu_adv_connect_ind)) &&
+		   lll->conn && !lll->conn->slave.cancelled &&
 		   lll_adv_connect_ind_check(lll, pdu_rx, tx_addr, addr,
 					     rx_addr, tgt_addr,
-					     devmatch_ok, &rl_idx) &&
-		   lll->conn) {
+					     devmatch_ok, &rl_idx)) {
 		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -198,11 +198,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	DEBUG_RADIO_START_A(1);
 
-#if !defined(BT_CTLR_ADV_EXT_PBACK)
-	/* Set up Radio H/W */
-	radio_reset();
-#endif  /* !BT_CTLR_ADV_EXT_PBACK */
-
 	lll = p->param;
 
 	/* FIXME: get latest only when primary PDU without Aux PDUs */
@@ -239,6 +234,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 		return 0;
 	}
 
+	/* Set up Radio H/W */
+	radio_reset();
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	radio_tx_power_set(lll->tx_pwr_lvl);
@@ -252,13 +249,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_phy_set(phy_s, 1);
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, (phy_s << 1));
 
-#if !defined(BT_CTLR_ADV_EXT_PBACK)
 	/* Access address and CRC */
 	aa = sys_cpu_to_le32(PDU_AC_ACCESS_ADDR);
 	radio_aa_set((uint8_t *)&aa);
 	radio_crc_configure(((0x5bUL) | ((0x06UL) << 8) | ((0x00UL) << 16)),
 			    0x555555);
-#endif  /* !BT_CTLR_ADV_EXT_PBACK */
 
 	/* Use channel idx in aux_ptr */
 	lll_chan_set(aux_ptr->chan_idx);
@@ -297,11 +292,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 		radio_switch_complete_and_disable();
 	}
 
-#if defined(BT_CTLR_ADV_EXT_PBACK)
-	start_us = 1000;
-	radio_tmr_start_us(1, start_us);
-#else /* !BT_CTLR_ADV_EXT_PBACK */
-
 	ticks_at_event = p->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
@@ -311,7 +301,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);
-#endif /* !BT_CTLR_ADV_EXT_PBACK */
 
 	/* capture end of Tx-ed PDU, used to calculate HCTO. */
 	radio_tmr_end_capture();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -874,6 +874,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		/* FIXME: BEGIN: Move to ULL? */
 		conn_lll->role = 1;
 		conn_lll->slave.initiated = 0;
+		conn_lll->slave.cancelled = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
 		conn_lll->event_counter = 0;
@@ -1994,6 +1995,21 @@ static inline uint8_t disable(uint8_t handle)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+#if defined(CONFIG_BT_PERIPHERAL)
+	if (adv->lll.conn) {
+		/* Indicate to LLL that a cancellation is requested */
+		adv->lll.conn->slave.cancelled = 1U;
+		cpu_dmb();
+
+		/* Check if a connection was initiated (connection
+		 * establishment race between LLL and ULL).
+		 */
+		if (unlikely(adv->lll.conn->slave.initiated)) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
+	}
+#endif /* CONFIG_BT_PERIPHERAL */
+
 	mark = ull_disable_mark(adv);
 	LL_ASSERT(mark == adv);
 
@@ -2011,7 +2027,7 @@ static inline uint8_t disable(uint8_t handle)
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 	}
-#endif
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	ret_cb = TICKER_STATUS_BUSY;
 	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,


### PR DESCRIPTION
In the time between a NODE_RX_TYPE_CONNECTION node is sent from LLL and
demuxed in ULL, an ADV role disable may be executed.
This makes the LLL data referenced in the node NULL/invald, and
ull_conn_setup would operate on invalid data.

This commit introduces a check in ADV disable to disallow the operation
(including conn invalidation), if a connection has been initiated.

To prevent pipeline-queued prepares from advertising after disable has
been initiated, set 'cancelled' flag for immediate signalling to LLL.

Fixes: #33868

Signed-off-by: Morten Priess <mtpr@oticon.com>