### PR TITLE
doc: fix dependency resolution issues

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: install-pip
       run: |
-        pip3 install setuptools wheel
+        sudo pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
         pip3 install west==0.10.1

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: install-pip
       run: |
-        pip3 install setuptools
+        sudo pip3 install -U setuptools wheel pip
         pip3 install -r scripts/requirements-base.txt
         pip3 install -r scripts/requirements-doc.txt
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,6 @@
 # DOC: used to generate docs
 
 breathe>=4.23.0
-docutils>=0.16
 sphinx>=3.3.0,<3.4.0
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs


### PR DESCRIPTION
Summary:

It looks like some old versions of `pip` (20.x) do not resolve the dependency chain correctly, so even though we had the conditions `docutils>=0.12`, `docutils<0.17` and `docutils>=0.16`, 0.17 was still installed. Core dependencies (`setuptools`, `wheel`, `pip`) are now upgraded so that this issue does not happen.

`docutils` has been removed as a direct dependency, since it is not needed. The only user of the dependency was a custom Sphinx extension, and Sphinx already has `docutils` as a core dependency.

Fixes #34082