### PR TITLE
drivers/serial/uart_stm32 converted to use the new kwork API.

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -724,13 +724,13 @@ static inline void async_evt_rx_buf_release(struct uart_stm32_data *data)
 	async_user_callback(data, &evt);
 }
 
-static inline void async_timer_start(struct k_delayed_work *work,
+static inline void async_timer_start(struct k_work_delayable *work,
 				     int32_t timeout)
 {
 	if ((timeout != SYS_FOREVER_MS) && (timeout != 0)) {
 		/* start timer */
 		LOG_DBG("async timer started for %d ms", timeout);
-		k_delayed_work_submit(work, K_MSEC(timeout));
+		k_work_reschedule(work, K_MSEC(timeout));
 	}
 }
 
@@ -857,7 +857,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 
 	uart_stm32_dma_rx_disable(dev);
 
-	k_delayed_work_cancel(&data->dma_rx.timeout_work);
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
 
 	dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 
@@ -882,7 +882,7 @@ void uart_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 	/* Disable TX */
 	uart_stm32_dma_tx_disable(uart_dev);
 
-	k_delayed_work_cancel(&data->dma_tx.timeout_work);
+	(void)k_work_cancel_delayable(&data->dma_tx.timeout_work);
 
 	data->dma_tx.buffer_length = 0;
 
@@ -940,7 +940,7 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 		return;
 	}
 
-	k_delayed_work_cancel(&data->dma_rx.timeout_work);
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
 
 	/* true since this functions occurs when buffer if full */
 	data->dma_rx.counter = data->dma_rx.buffer_length;
@@ -962,7 +962,7 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 		 * called in ISR context. So force the RX timeout
 		 * to minimum value and let the RX timeout to do the job.
 		 */
-		k_delayed_work_submit(&data->dma_rx.timeout_work, K_TICKS(1));
+		k_work_reschedule(&data->dma_rx.timeout_work, K_TICKS(1));
 	}
 }
 
@@ -1086,7 +1086,7 @@ static int uart_stm32_async_tx_abort(const struct device *dev)
 		return -EFAULT;
 	}
 
-	k_delayed_work_cancel(&data->dma_tx.timeout_work);
+	(void)k_work_cancel_delayable(&data->dma_tx.timeout_work);
 	if (!dma_get_status(data->dma_tx.dma_dev,
 				data->dma_tx.dma_channel, &stat)) {
 		data->dma_tx.counter = tx_buffer_length - stat.pending_length;
@@ -1163,9 +1163,9 @@ static int uart_stm32_async_init(const struct device *dev)
 	uart_stm32_dma_rx_disable(dev);
 	uart_stm32_dma_tx_disable(dev);
 
-	k_delayed_work_init(&data->dma_rx.timeout_work,
+	k_work_init_delayable(&data->dma_rx.timeout_work,
 			    uart_stm32_async_rx_timeout);
-	k_delayed_work_init(&data->dma_tx.timeout_work,
+	k_work_init_delayable(&data->dma_tx.timeout_work,
 			    uart_stm32_async_tx_timeout);
 
 	/* Configure dma rx config */

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -42,7 +42,7 @@ struct uart_dma_stream {
 	size_t offset;
 	volatile size_t counter;
 	int32_t timeout;
-	struct k_delayed_work timeout_work;
+	struct k_work_delayable timeout_work;
 	bool enabled;
 };
 #endif


### PR DESCRIPTION
Convert drivers/serial/uart_stm32.{c.h} to use new kwork API.
See the following issue for details: #33104

The structure is now k_work_delayable.
The init function is now the k_work_init_delayable.
The submit function is now the k_work_schedule.
The cancel function is now the k_work_cancel_delayable.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/34091

Signed-off-by: Francois Ramu <francois.ramu@st.com>