### PR TITLE
shell: telnet: Update to the new k_work API

### DIFF
--- a/include/shell/shell_telnet.h
+++ b/include/shell/shell_telnet.h
@@ -46,6 +46,7 @@ struct shell_telnet {
 	 *  to send the shell prompt for instance.
 	 */
 	struct k_work_delayable send_work;
+	struct k_work_sync work_sync;
 
 	/** If set, no output is sent to the TELNET client. */
 	bool output_lock;

--- a/include/shell/shell_telnet.h
+++ b/include/shell/shell_telnet.h
@@ -45,7 +45,7 @@ struct shell_telnet {
 	 *  been around for "too long". This will prove to be useful
 	 *  to send the shell prompt for instance.
 	 */
-	struct k_delayed_work send_work;
+	struct k_work_delayable send_work;
 
 	/** If set, no output is sent to the TELNET client. */
 	bool output_lock;


### PR DESCRIPTION
Update the shell telnet backend to use the new k_work_delayable API. Additionally, make sure that the delayed worked is actually idle after canceling by using the synchronous API.

Fixes #34100