### PR TITLE
dts/bindings: pinctrl: Include pincfg-node in st,stm32-pinctrl.yaml

### DIFF
--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -1,11 +1,26 @@
 # Copyright (c) 2020 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 Pin controller Node
+description: |
+    STM32 Pin controller Node
+    Based on pincfg-node.yaml binding.
+
+    Note: `bias-disable` and `drive-push-pull` are default pin configurations.
+           They will be applied in case no `bias-foo` or `driver-bar` properties
+           are set.
 
 compatible: "st,stm32-pinctrl"
 
-include: [base.yaml]
+include:
+    - name: base.yaml
+    - name: pincfg-node.yaml
+      child-binding:
+        property-allowlist:
+          - bias-disable
+          - bias-pull-down
+          - bias-pull-up
+          - drive-push-pull
+          - drive-open-drain
 
 properties:
     reg:
@@ -45,33 +60,6 @@ child-binding:
             ... {
                      pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
             };
-
-        bias-disable:
-          required: false
-          type: boolean
-          description: Pin bias (push-pull) disabled. This is the default pin
-            configuration and will be applied if no bias- property is set.
-
-        bias-pull-down:
-          required: false
-          type: boolean
-          description: Pull down on pin.
-
-        bias-pull-up:
-          required: false
-          type: boolean
-          description: Pull up on pin.
-
-        drive-push-pull:
-          required: false
-          type: boolean
-          description: Pin driven actively high and low. This is the default pin
-            configuration and will be applied if no drive- property is set.
-
-        drive-open-drain:
-          required: false
-          type: boolean
-          description: Pin driven in open drain.
 
         slew-rate:
           required: false


### PR DESCRIPTION
Make use of bindings filtering to inlcude pincfg-node.yaml in
st,stm32-pinctrl.yaml

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>