### PR TITLE
tests: drivers: Fix dma channel link test

### DIFF
--- a/tests/drivers/dma/chan_link_transfer/Kconfig
+++ b/tests/drivers/dma/chan_link_transfer/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "DMA Link Transfer Test"
+
+source "Kconfig.zephyr"
+
+config DMA_LINK_TRANSFER_DRV_NAME
+	string "DMA device name to use for test"
+	default "DMA_0"

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -21,7 +21,7 @@
 #include <drivers/dma.h>
 #include <ztest.h>
 
-#define DMA_DEVICE_NAME CONFIG_DMA_0_NAME
+#define DMA_DEVICE_NAME CONFIG_DMA_LINK_TRANSFER_DRV_NAME
 #define TEST_DMA_CHANNEL_0 (0)
 #define TEST_DMA_CHANNEL_1 (1)
 #define RX_BUFF_SIZE (48)


### PR DESCRIPTION
The Kconfig symbol CONFIG_DMA_0_NAME was recently removed. Update the
dma channel link transfer test to get the device name from an
application level Kconfig instead, similar to other dma driver tests.

This fixes a CI compliance failure that checks for references to
undefined Kconfig symbols.

Tested on the mimxrt1050_evk board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>