### PR TITLE
arm64: improve CONFIG_MAX_XLAT_TABLES default value

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -134,20 +134,6 @@ if ARM_MMU
 config MMU_PAGE_SIZE
 	default 0x1000
 
-config MAX_XLAT_TABLES
-	int "Maximum numbers of translation tables"
-	default 16 if USERSPACE
-	default 8
-	help
-	  This option specifies the maximum numbers of translation tables.
-	  Based on this, translation tables are allocated at compile time and
-	  used at runtime as needed.  If the runtime need exceeds preallocated
-	  numbers of translation tables, it will result in assert. Number of
-	  translation tables required is decided based on how many discrete
-	  memory regions (both normal and device memory) are present on given
-	  platform and how much granularity is required while assigning
-	  attributes to these memory regions.
-
 choice
 	prompt "Virtual address space size"
 	default ARM64_VA_BITS_32
@@ -202,6 +188,22 @@ config ARM64_PA_BITS
 	default 36 if ARM64_PA_BITS_36
 	default 42 if ARM64_PA_BITS_42
 	default 48 if ARM64_PA_BITS_48
+
+config MAX_XLAT_TABLES
+	int "Maximum numbers of translation tables"
+	default 20 if USERSPACE && (ARM64_VA_BITS >= 40)
+	default 16 if USERSPACE
+	default 12 if (ARM64_VA_BITS >= 40)
+	default 8
+	help
+	  This option specifies the maximum numbers of translation tables.
+	  Based on this, translation tables are allocated at compile time and
+	  used at runtime as needed.  If the runtime need exceeds preallocated
+	  numbers of translation tables, it will result in assert. Number of
+	  translation tables required is decided based on how many discrete
+	  memory regions (both normal and device memory) are present on given
+	  platform and how much granularity is required while assigning
+	  attributes to these memory regions.
 
 endif # ARM_MMU
 

--- a/arch/arm64/core/mmu.h
+++ b/arch/arm64/core/mmu.h
@@ -61,10 +61,10 @@
  * Calculate the initial translation table level from CONFIG_ARM64_VA_BITS
  * For a 4 KB page size:
  *
- * (va_bits <= 20)	 - base level 3
- * (21 <= va_bits <= 29) - base level 2
- * (30 <= va_bits <= 38) - base level 1
- * (39 <= va_bits <= 47) - base level 0
+ * (va_bits <= 21)	 - base level 3
+ * (22 <= va_bits <= 30) - base level 2
+ * (31 <= va_bits <= 39) - base level 1
+ * (40 <= va_bits <= 48) - base level 0
  */
 #define GET_BASE_XLAT_LEVEL(va_bits)				\
 	 ((va_bits > L0_XLAT_VA_SIZE_SHIFT) ? 0U		\


### PR DESCRIPTION
The typical number of needed translation tables depends on memory
domain usage and userspace support, but also on the virtual address
space width due to the number of translation levels involved.
Reflect that in the default value.

Also fix a related comment where values were off by 1.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
