### PR TITLE
native_posix: kconfig: Set logging mode conditionally

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -43,6 +43,12 @@ if LOG
 config LOG_BACKEND_NATIVE_POSIX
 	default y if !SERIAL
 
+# For native_posix we can log synchronously without any problem
+# Doing so will be nicer for debugging
+choice LOG_MODE
+	default LOG_MODE_IMMEDIATE
+endchoice
+
 endif # LOG
 
 if CONSOLE

--- a/boards/posix/native_posix/native_posix_defconfig
+++ b/boards/posix/native_posix/native_posix_defconfig
@@ -4,6 +4,3 @@ CONFIG_SOC_POSIX=y
 CONFIG_BOARD_NATIVE_POSIX_32BIT=y
 CONFIG_CONSOLE=y
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=1000000
-# For native_posix we can log synchronously without any problem
-# Doing so will be nicer for debugging
-CONFIG_LOG_MODE_IMMEDIATE=y


### PR DESCRIPTION
Projects based on native_posix get a warning indicating that the
LOG_MODE_IMMEDIATE choice symbol is selected but no symbol ended up as
the choice selection.

Only set the logging mode if logging is enabled.

Signed-off-by: Keith Short <keithshort@google.com>