### PR TITLE
nxp: boards: Add device specific pinctrl data to boards

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -124,6 +124,7 @@
 };
 arduino_i2c: &i2c0 {
 	status = "okay";
+	pinctrl-0 = <&I2C0_SCL_PTB2 &I2C0_SDA_PTB3>;
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -134,19 +135,35 @@ arduino_i2c: &i2c0 {
 	};
 };
 
+&I2C0_SCL_PTB2 {
+	drive-open-drain;
+};
+
+&I2C0_SDA_PTB3 {
+	drive-open-drain;
+};
+
 arduino_spi: &spi0 {
 	status = "okay";
+	pinctrl-0 = <&SPI0_PCS4_PTC0 &SPI0_SCK_PTD1
+		     &SPI0_SOUT_PTD2 &SPI0_SIN_PTD3>;
 };
 
 &ftm0 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM0_CH6_PTA1 &FTM0_CH7_PTA2 &FTM0_CH5_PTD5>;
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART1_RX_PTE1 &UART1_TX_PTE0>;
+};
+
+&uart2 {
+	pinctrl-0 = <&UART2_RX_PTD2 &UART2_TX_PTD3>;
 };
 
 &usbotg {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -95,6 +95,7 @@
 arduino_serial: &uart3 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART3_RX_PTC16 &UART3_TX_PTC17>;
 };
 
 &cpu0 {
@@ -120,6 +121,7 @@ arduino_serial: &uart3 {
 
 arduino_i2c: &i2c0 {
 	status = "okay";
+	pinctrl-0 = <&I2C0_SCL_PTE24 &I2C0_SDA_PTE25>;
 
 	fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -132,23 +134,31 @@ arduino_i2c: &i2c0 {
 
 arduino_spi: &spi0 {
 	status = "okay";
+	pinctrl-0 = <&SPI0_PCS0_PTD0 &SPI0_SCK_PTD1 &SPI0_SOUT_PTD2 &SPI0_SIN_PTD3>;
 };
 
 &ftm0 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM0_CH0_PTC1>;
 };
 
 &ftm3 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9>;
 };
 
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTB16 &UART0_TX_PTB17>;
+};
+
+&uart2 {
+	pinctrl-0 = <&UART2_RTS_b_PTD0 &UART2_CTS_b_PTD1 &UART2_RX_PTD2 &UART2_TX_PTD3>;
 };
 
 &usbotg {
@@ -217,14 +227,31 @@ arduino_spi: &spi0 {
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&RMII0_RXER_PTA5 &RMII0_RXD1_PTA12
+		     &RMII0_RXD0_PTA13 &RMII0_CRS_DV_PTA14
+		     &RMII0_TXEN_PTA15 &RMII0_TXD0_PTA16
+		     &RMII0_TXD1_PTA17 &RMII0_MDIO_PTB0
+		     &RMII0_MDC_PTB1>;
 	ptp {
 		status = "okay";
+		pinctrl-0 = <&ENET0_1588_TMR0_PTC16 &ENET0_1588_TMR1_PTC17
+			     &ENET0_1588_TMR2_PTC18>;
 	};
+};
+
+&RMII0_MDIO_PTB0 {
+	bias-pull-up;
+	drive-open-drain;
 };
 
 &flexcan0 {
 	status = "okay";
+	pinctrl-0 = <&CAN0_TX_PTB18 &CAN0_RX_PTB19>;
 	bus-speed = <125000>;
+};
+
+&CAN0_RX_PTB19 {
+	bias-pull-up;
 };
 
 &edma0 {

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -113,6 +113,7 @@
 
 &adc0 {
 	status = "okay";
+	pinctrl-0 = <&ADC0_SE15_PTC1>;
 };
 
 &gpioa {
@@ -167,6 +168,7 @@
 
 &i2c3 {
 	status = "okay";
+	pinctrl-0 = <&I2C3_SDA_PTA1 &I2C3_SCL_PTA2>;
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -176,8 +178,17 @@
 	};
 };
 
+&I2C3_SDA_PTA1 {
+	drive-open-drain;
+};
+
+&I2C3_SCL_PTA2 {
+	drive-open-drain;
+};
+
 &lpuart4 {
 	status = "okay";
+	pinctrl-0 = <&LPUART4_RX_PTC14 &LPUART4_TX_PTC15>;
 	current-speed = <115200>;
 };
 
@@ -185,10 +196,14 @@
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9 &FTM3_CH6_PTC10>;
 };
 
 &spi1 {
 	status = "okay";
+
+	pinctrl-0 = <&SPI1_SCK_PTE1 &SPI1_SOUT_PTE2
+		     &SPI1_SIN_PTE4 &SPI1_PCS0_PTE5>;
 
 	mx25u32: mx25u3235f@0 {
 		compatible = "jedec,spi-nor";

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -92,10 +92,13 @@
 
 &adc0 {
 	status = "okay";
+	pinctrl-0 = <&ADC0_SE12_PTB2>;
 };
 
 &i2c0 {
 	status = "okay";
+	pinctrl-0 = <&I2C0_SCL_PTE24 &I2C0_SDA_PTE25>;
+
 	mma8451q@1d {
 		compatible = "nxp,fxos8700","nxp,mma8451q";
 		reg = <0x1d>;
@@ -105,9 +108,18 @@
 	};
 };
 
+&I2C0_SCL_PTE24 {
+	bias-pull-up;
+};
+
+&I2C0_SDA_PTE25 {
+	bias-pull-up;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTA1 &UART0_TX_PTA2>;
 };
 
 &gpioa {

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -109,10 +109,12 @@
 
 &adc0 {
 	status = "okay";
+	pinctrl-0 = <&ADC0_SE3_PTB2>;
 };
 
 &i2c1 {
 	status = "okay";
+	pinctrl-0 = <&I2C1_SCL_PTC2 &I2C1_SDA_PTC3>;
 
 	fxos8700@1f {
 		compatible = "nxp,fxos8700";
@@ -122,8 +124,17 @@
 	};
 };
 
+&I2C1_SCL_PTC2 {
+	bias-pull-up;
+};
+
+&I2C1_SDA_PTC3 {
+	bias-pull-up;
+};
+
 &lpuart0 {
 	status = "okay";
+	pinctrl-0 = <&UART0_RX_PTC6 &UART0_TX_PTC7>;
 	current-speed = <115200>;
 };
 
@@ -135,8 +146,14 @@
 	status = "okay";
 };
 
+&spi0 {
+	pinctrl-0 = <&SPI0_SCK_PTC16 &SPI0_SOUT_PTC17
+		     &SPI0_SIN_PTC18 &SPI0_PCS0_PTC19>;
+};
+
 &tpm0 {
 	status = "okay";
+	pinctrl-0 = <&TPM0_CH2_PTC1>;
 };
 
 &tpm1 {
@@ -145,4 +162,5 @@
 
 &tpm2 {
 	status = "okay";
+	pinctrl-0 = <&TPM2_CH1_PTA19 &TPM2_CH0_PTA18>;
 };

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -80,10 +80,12 @@
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM3_CH4_PTC8 &FTM3_CH5_PTC9 &FTM3_CH0_PTD0>;
 };
 
 &i2c0 {
 	status = "okay";
+	pinctrl-0 = <&I2C0_SCL_PTB0 &I2C0_SDA_PTB1>;
 
 	max30101@57 {
 		status = "disabled";
@@ -93,8 +95,17 @@
 	};
 };
 
+&I2C0_SCL_PTB0 {
+	drive-open-drain;
+};
+
+&I2C0_SDA_PTB1 {
+	drive-open-drain;
+};
+
 &i2c1 {
 	status = "okay";
+	pinctrl-0 = <&I2C1_SCL_PTC10 &I2C1_SDA_PTC11>;
 
 	fxos8700@1e {
 		compatible = "nxp,fxos8700";
@@ -113,14 +124,24 @@
 	};
 };
 
+&I2C1_SCL_PTC10 {
+	drive-open-drain;
+};
+
+&I2C1_SDA_PTC11 {
+	drive-open-drain;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTB16 &UART0_TX_PTB17>;
 };
 
 &uart4 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART4_RX_PTE25 &UART4_TX_PTE24>;
 };
 
 &gpiob {

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -21,11 +21,13 @@
 
 &adc0 {
 	status = "okay";
+	pinctrl-0 = <&ADC0_SE1_PTB1>;
 };
 
 &lpuart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTC6 &UART0_TX_PTC7>;
 };
 
 &gpioa {

--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -103,6 +103,10 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&RMII0_RXD1_PTA12 &RMII0_RXD0_PTA13
+		     &RMII0_CRS_DV_PTA14 &RMII0_TXEN_PTA15
+		     &RMII0_TXD0_PTA16 &RMII0_TXD1_PTA17
+		     &ENET_1588_CLKIN_PTE26 /* used for RMII ref clk */>;
 
 	fixed-link {
 		speed = <100>;
@@ -112,6 +116,8 @@
 
 &spi1 {
 	status = "okay";
+	pinctrl-0 = <&SPI1_PCS0_PTB10 &SPI1_SCK_PTB11
+		     &SPI1_SOUT_PTB16 &SPI1_SIN_PTB17>;
 
 	clock-frequency = <44000000>;
 	cs-gpios = <&gpioe 4 GPIO_ACTIVE_LOW>;

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -131,6 +131,7 @@
 
 &i2c1 {
 	status = "okay";
+	pinctrl-0 = <&I2C1_SCL_PTD8 &I2C1_SDA_PTD9>;
 
 	fxos8700@1c {
 		compatible = "nxp,fxos8700";
@@ -141,7 +142,16 @@
 	};
 };
 
+&I2C1_SCL_PTD8 {
+	drive-open-drain;
+};
+
+&I2C1_SDA_PTD9 {
+	drive-open-drain;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTB0 &UART0_TX_PTB1>;
 };

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -69,6 +69,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&UART0_RX_PTA1 &UART0_TX_PTA2>;
 };
 
 &usbd {

--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127
       path: tools/net-tools
     - name: hal_nxp
-      revision: ad8de4f9743aa7500f184bcf6c2cea07c041fe69
+      revision: 4560b0a0106bbe47eded4d7af775998c4f6d05c0
       path: modules/hal/nxp
     - name: open-amp
       revision: de1b85a13032a2de1d8b6695ae5f800b613e739d


### PR DESCRIPTION
Add pinctrl-0 nodes to various nxp boards.  The set of boards selected here is based on which boards utilize the `nxp,kinetis-uart`