### PR TITLE
boards: hexiwear_kw40z: Remove I2C pins and dts enablement

### DIFF
--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -23,10 +23,6 @@
 	status = "okay";
 };
 
-&i2c1 {
-	status = "okay";
-};
-
 &lpuart0 {
 	status = "okay";
 	current-speed = <115200>;

--- a/boards/arm/hexiwear_kw40z/pinmux.c
+++ b/boards/arm/hexiwear_kw40z/pinmux.c
@@ -29,14 +29,6 @@ static int hexiwear_kw40z_pinmux_init(const struct device *dev)
 	pinmux_pin_set(portc,  7, PORT_PCR_MUX(kPORT_MuxAlt4));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay) && CONFIG_I2C
-	/* I2C1 SCL, SDA */
-	pinmux_pin_set(portc,  6, PORT_PCR_MUX(kPORT_MuxAlt3)
-					| PORT_PCR_PS_MASK);
-	pinmux_pin_set(portc,  6, PORT_PCR_MUX(kPORT_MuxAlt3)
-					| PORT_PCR_PS_MASK);
-#endif
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc0), okay) && CONFIG_ADC
 	/* ADC0_SE1 */
 	pinmux_pin_set(portb,  1, PORT_PCR_MUX(kPORT_PinDisabledOrAnalog));


### PR DESCRIPTION
The pin number should be 7, not 6.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>