### PR TITLE
coding guidelines: 15.7: fix two cases of missing final else

### DIFF
--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -352,12 +352,15 @@ void heap_print_info(struct z_heap *h, bool dump_chunks)
 	}
 	free_bytes = allocated_bytes = 0;
 	for (chunkid_t c = 0; ; c = right_chunk(h, c)) {
-		if (c == 0 || c == h->end_chunk) {
-			/* those are always allocated for internal purposes */
-		} else if (chunk_used(h, c)) {
-			allocated_bytes += chunksz_to_bytes(h, chunk_size(h, c));
-		} else if (!solo_free_header(h, c)) {
-			free_bytes += chunksz_to_bytes(h, chunk_size(h, c));
+		if (chunk_used(h, c)) {
+			if ((c != 0) && (c != h->end_chunk)) {
+				/* 1st and last are always allocated for internal purposes */
+				allocated_bytes += chunksz_to_bytes(h, chunk_size(h, c));
+			}
+		} else {
+			if (!solo_free_header(h, c)) {
+				free_bytes += chunksz_to_bytes(h, chunk_size(h, c));
+			}
 		}
 		if (dump_chunks) {
 			printk("chunk %4d: [%c] size=%-4d left=%-4d right=%d\n",

--- a/soc/arm/cypress/common/soc_gpio.c
+++ b/soc/arm/cypress/common/soc_gpio.c
@@ -30,6 +30,8 @@ static uint32_t soc_gpio_get_drv_mode(uint32_t flags)
 		drv_mode = CY_GPIO_DM_PULLUP_IN_OFF;
 	} else if (flags & SOC_GPIO_PULLDOWN) {
 		drv_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
+	} else {
+		;
 	}
 
 	if (flags & SOC_GPIO_INPUTENABLE) {


### PR DESCRIPTION
The following contained cases of if else if constructs that
were missing a final else. This commit adds non-empty 
else {} to comply with coding guideline 15.7.

- lib/os/heap-validate.c   (heap_print_info)
- soc/arm/cypress/common/soc_gpio.c (soc_gpio_get_drv_mode)

Signed-off-by: Jennifer Williams jennifer.m.williams@intel.com