### PR TITLE
MAINTAINERS: Add collaborators on STM32 Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1375,9 +1375,13 @@ STM32 Platforms:
     status: maintained
     maintainers:
         - erwango
+    collaborators:
+        - ABOSTM
+        - FRASTM
     files:
         - boards/arm/nucleo_*/
         - boards/arm/stm32*_disco/
+        - boards/arm/stm32*_dk*/
         - boards/arm/stm32*_eval/
         - drivers/*/*stm32*/
         - drivers/*/*stm32*


### PR DESCRIPTION
Add Alexandre and François as collaborators on STM32 Platforms.
Additionally, add one naming for stm32 boards.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>