### PR TITLE
Fix mc2515 BRP register value

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -333,7 +333,8 @@ static int mcp2515_set_timing(const struct device *dev,
 	uint8_t reset_mode;
 
 	/* CNF1; SJW<7:6> | BRP<5:0> */
-	uint8_t brp = timing->prescaler;
+	__ASSERT(timing->prescaler > 0, "Prescaler should be bigger than zero");
+	uint8_t brp = timing->prescaler - 1;
 	const uint8_t sjw = (timing->sjw - 1) << 6;
 	uint8_t cnf1 = sjw | brp;
 


### PR DESCRIPTION
The real value for BRP bits in CNF1 register should be 'prescaler - 1'(like in previous versions).
 
Some Evidences from MCP2515( DS20001801J) Datasheet:
5.7.1 CNF1
The BRP[5:0] bits control the Baud Rate Prescaler. These bits set the length of TQ relative to the OSC1 input frequency, with the minimum TQ length being 2 TOSC (when BRP[5:0] = b000000). 

REGISTER 5-1: CNF1: CONFIGURATION REGISTER 1 (ADDRESS: 2Ah)
bit 5-0
BRP[5:0]: Baud Rate Prescaler bits
TQ = 2 x (BRP[5:0] + 1)/FOSC.

You can see when BRP[5:0] are equal to b000000 the prescaler value isn't zero.

 8b6c1bd4b7a0  commit broke it.