### PR TITLE
drivers/flash: STM32: A generic change and enabling flash support.

### DIFF
--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -30,8 +30,8 @@
 #define TEST_AREA_MAX (FLASH_TEST_REGION_OFFSET +\
 		       FLASH_AREA_SIZE(image_1_nonsecure))
 #else
-#define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(image_1)
-#define TEST_AREA_MAX (FLASH_TEST_REGION_OFFSET + FLASH_AREA_SIZE(image_1))
+#define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(storage)
+#define TEST_AREA_MAX (FLASH_TEST_REGION_OFFSET + FLASH_AREA_SIZE(storage))
 #endif
 
 #endif
@@ -48,7 +48,7 @@ static void test_setup(void)
 	int rc;
 
 	flash_dev = device_get_binding(FLASH_DEVICE);
-	const struct flash_parameters *qspi_flash_parameters =
+	const struct flash_parameters *flash_params =
 			flash_get_parameters(flash_dev);
 
 	/* For tests purposes use page (in nrf_qspi_nor page = 64 kB) */
@@ -75,7 +75,7 @@ static void test_setup(void)
 	bool is_buf_clear = true;
 
 	for (off_t i = 0; i < EXPECTED_SIZE; i++) {
-		if (buf[i] != qspi_flash_parameters->erase_value) {
+		if (buf[i] != flash_params->erase_value) {
 			is_buf_clear = false;
 			break;
 		}

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -14,3 +14,7 @@ tests:
   drivers.flash.default:
     platform_allow: mimxrt1060_evk
     tags: mcux
+  drivers.flash.stm32:
+    filter: dt_compat_enabled("st,stm32-flash-controller") and
+       dt_compat_enabled_with_label("fixed-partitions", "storage_partition")
+    tags: drivers flash


### PR DESCRIPTION
This commit makes the flash test generic for both qspi-flash and
soc-flash. For STM32 based platforms, the flast test will look for
storage partition in the soc-flash for testing.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>