### PR TITLE
samples: net: add integration_platforms

### DIFF
--- a/samples/net/civetweb/websocket_server/sample.yaml
+++ b/samples/net/civetweb/websocket_server/sample.yaml
@@ -4,3 +4,5 @@ sample:
 tests:
   sample.net.civetweb.websocket_server:
     platform_allow: nucleo_h745zi_q_m7
+    integration_platforms:
+      - nucleo_h745zi_q_m7

--- a/samples/net/cloud/tagoio_http_post/sample.yaml
+++ b/samples/net/cloud/tagoio_http_post/sample.yaml
@@ -11,6 +11,8 @@ tests:
   sample.net.cloud.tagoio_http_post.wifi:
     extra_args: OVERLAY_CONFIG="overlay-wifi.conf"
     platform_allow: disco_l475_iot1
+    integration_platforms:
+      - disco_l475_iot1
   sample.net.cloud.tagoio_http_post.wifi.esp:
     extra_args: SHIELD=esp_8266_arduino OVERLAY_CONFIG="overlay-wifi.conf"
     platform_allow: frdm_k64f nucleo_f767zi

--- a/samples/net/dsa/sample.yaml
+++ b/samples/net/dsa/sample.yaml
@@ -8,5 +8,7 @@ tests:
   sample.net.dsa:
     build_only: true
     platform_allow: ip_k66f
+    integration_platforms:
+      - ip_k66f
     depends_on: netif
     tags: tests

--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -32,6 +32,8 @@ tests:
     harness: net
     extra_args: OVERLAY_CONFIG=overlay-bt.conf
     platform_allow: nrf52840dk_nrf52840 disco_l475_iot1
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: net lwm2m
   sample.net.lwm2m_client.queue_mode:
     harness: net

--- a/samples/net/mqtt_publisher/sample.yaml
+++ b/samples/net/mqtt_publisher/sample.yaml
@@ -13,3 +13,5 @@ tests:
   sample.net.mqtt_publisher.bt:
     platform_allow: 96b_nitrogen
     tags: net mqtt bluetooth
+    integration_platforms:
+      - 96b_nitrogen

--- a/samples/net/sockets/echo/sample.yaml
+++ b/samples/net/sockets/echo/sample.yaml
@@ -11,3 +11,5 @@ tests:
   sample.net.sockets.echo.offload.simplelink:
     platform_allow: cc3220sf_launchxl
     tags: net socket offload simplelink
+    integration_platforms:
+      - cc3220sf_launchxl

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -17,21 +17,33 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: atsamr21_xpro
+    integration_platforms:
+      - atsamr21_xpro
   sample.net.sockets.echo_server.802154.rf2xx.xplained:
     extra_args: SHIELD=atmel_rf2xx_xplained OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4s_xplained
+    integration_platforms:
+      - sam4s_xplained
   sample.net.sockets.echo_server.802154.rf2xx.xpro:
     extra_args: SHIELD=atmel_rf2xx_xpro OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam4e_xpro
   sample.net.sockets.echo_server.802154.rf2xx.legacy:
     extra_args: SHIELD=atmel_rf2xx_legacy OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_server.802154.rf2xx.arduino:
     extra_args: SHIELD=atmel_rf2xx_arduino OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam_v71_xult frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - nucleo_f767zi
   sample.net.sockets.echo_server.802154.rf2xx.mikrobus:
     extra_args: SHIELD=atmel_rf2xx_mikrobus OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: lpcxpresso55s69_ns
+    integration_platforms:
+      - lpcxpresso55s69_ns
   sample.net.sockets.echo_client.bt:
     extra_args: OVERLAY_CONFIG="overlay-bt.conf"
     platform_allow: qemu_x86
@@ -42,17 +54,23 @@ tests:
   sample.net.sockets.echo_client.nrf_802154:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
   sample.net.sockets.echo_client.nrf_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_client.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true
     tags: net openthread
     platform_allow: frdm_kw41z
+    integration_platforms:
+      - frdm_kw41z
     filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_client.userspace:
     extra_args: CONFIG_USERSPACE=y OVERLAY_CONFIG="overlay-e1000.conf"

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -17,21 +17,33 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: atsamr21_xpro
+    integration_platforms:
+      - atsamr21_xpro
   sample.net.sockets.echo_server.802154.rf2xx.xplained:
     extra_args: SHIELD=atmel_rf2xx_xplained OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4s_xplained
+    integration_platforms:
+      - sam4s_xplained
   sample.net.sockets.echo_server.802154.rf2xx.xpro:
     extra_args: SHIELD=atmel_rf2xx_xpro OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam4e_xpro
   sample.net.sockets.echo_server.802154.rf2xx.legacy:
     extra_args: SHIELD=atmel_rf2xx_legacy OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_server.802154.rf2xx.arduino:
     extra_args: SHIELD=atmel_rf2xx_arduino OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam_v71_xult frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - nucleo_f767zi
   sample.net.sockets.echo_server.802154.rf2xx.mikrobus:
     extra_args: SHIELD=atmel_rf2xx_mikrobus OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: lpcxpresso55s69_ns
+    integration_platforms:
+      - lpcxpresso55s69_ns
   sample.net.sockets.echo_server.bt:
     extra_args: OVERLAY_CONFIG="overlay-bt.conf"
     platform_allow: qemu_x86
@@ -42,6 +54,8 @@ tests:
   sample.net.sockets.echo_server.nrf_802154:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
   sample.net.sockets.echo_server.usbnet:
     depends_on: usb_device
     harness: net
@@ -59,12 +73,16 @@ tests:
     slow: true
     tags: net openthread
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_server.kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true
     tags: net openthread
     platform_allow: frdm_kw41z
+    integration_platforms:
+      - frdm_kw41z
     filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.net.sockets.echo_server.e1000:
     extra_args: OVERLAY_CONFIG="overlay-e1000.conf"
@@ -74,6 +92,8 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-qemu_cortex_m3_eth.conf"
     tags: net
     platform_allow: qemu_cortex_m3
+    integration_platforms:
+      - qemu_cortex_m3
   sample.net.sockets.echo_server.smsc911x:
     extra_args: OVERLAY_CONFIG="overlay-smsc911x.conf"
     tags: net

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -21,4 +21,6 @@ tests:
       - CONFIG_POSIX_API=y
   sample.net.sockets.http_get.offload.simplelink:
     platform_allow: cc3220sf_launchxl
+    integration_platforms:
+      - cc3220sf_launchxl
     tags: net socket offload simplelink

--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -7,9 +7,13 @@ sample:
 tests:
   sample.net.wifi:
     platform_allow: cc3220sf_launchxl disco_l475_iot1
+    integration_platforms:
+      - disco_l475_iot1
   sample.net.wifi.esp_8266:
     extra_args: SHIELD=esp_8266
     platform_allow: sam4e_xpro
+    integration_platforms:
+      - sam4e_xpro
   sample.net.wifi.esp_8266_arduino:
     extra_args: SHIELD=esp_8266_arduino
     platform_allow: frdm_k64f disco_l475_iot1

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -30,6 +30,8 @@ tests:
     depends_on: usb_device
   sample.net.zperf.shield:
     platform_allow: reel_board
+    integration_platforms:
+      - reel_board
     extra_args: SHIELD=link_board_eth
     tags: shield net zperf
     depends_on: arduino_spi arduino_gpio


### PR DESCRIPTION
Add one integration_platforms based on platform_allow to ensure these
tests get coverage in CI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>