### PR TITLE
Bluetooth: Audio: VOCS: Move callback structure to register function

### DIFF
--- a/include/bluetooth/audio/vocs.h
+++ b/include/bluetooth/audio/vocs.h
@@ -43,8 +43,8 @@ extern "C" {
 /** @brief Opaque Volume Offset Control Service instance. */
 struct bt_vocs;
 
-/** @brief Structure for initializing a Volume Offset Control Service instance. */
-struct bt_vocs_init_param {
+/** @brief Structure for registering a Volume Offset Control Service instance. */
+struct bt_vocs_register_param {
 	/** Audio Location bitmask */
 	uint32_t location;
 
@@ -59,6 +59,9 @@ struct bt_vocs_init_param {
 
 	/** Boolean to set whether the description is writable by clients */
 	bool desc_writable;
+
+	/** Pointer to the callback structure. */
+	struct bt_vocs_cb *cb;
 };
 
 /** @brief Structure for discovering a Volume Offset Control Service instance. */
@@ -96,15 +99,15 @@ struct bt_vocs *bt_vocs_free_instance_get(void);
 void *bt_vocs_svc_decl_get(struct bt_vocs *vocs);
 
 /**
- * @brief Initialize the Volume Offset Control Service instance.
+ * @brief Register the Volume Offset Control Service instance.
  *
  * @param vocs      Volume Offset Control Service instance.
- * @param init      Volume Offset Control Service initialization structure.
- *                  May be NULL to use default values.
+ * @param param     Volume Offset Control Service register parameters.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vocs_init(struct bt_vocs *vocs, const struct bt_vocs_init_param *init);
+int bt_vocs_register(struct bt_vocs *vocs,
+		     const struct bt_vocs_register_param *param);
 
 /**
  * @brief Callback function for the offset state.
@@ -256,16 +259,6 @@ int bt_vocs_description_get(struct bt_conn *conn, struct bt_vocs *inst);
  */
 int bt_vocs_description_set(struct bt_conn *conn, struct bt_vocs *inst,
 			    const char *description);
-
-/**
- * @brief Register callbacks for the Volume Offset Control Service.
- *
- * @param inst          Pointer to the Volume Offset Control Service instance.
- * @param cb            Pointer to the callback structure.
- *
- * @return 0 on success, GATT error value on fail.
- */
-int bt_vocs_cb_register(struct bt_vocs *inst, struct bt_vocs_cb *cb);
 
 /**
  * @brief Registers the callbacks for the Volume Offset Control Service client.


### PR DESCRIPTION
Moves the callback structure for VOCS to the register function
which is renamed from init, as there's no reason to register
the callbacks separately.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>