### PR TITLE
random: rand32_timer: Avoid alignment faults by using memcpy

### DIFF
--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -62,20 +62,16 @@ uint32_t z_impl_sys_rand32_get(void)
 
 void z_impl_sys_rand_get(void *dst, size_t outlen)
 {
-	uint32_t len = 0;
-	uint32_t blocksize = 4;
+	uint8_t *udst = dst;
+	uint32_t blocksize;
 	uint32_t ret;
-	uint32_t *udst = (uint32_t *)dst;
 
-	while (len < outlen) {
+	while (outlen) {
 		ret = sys_rand32_get();
-		if ((outlen-len) < sizeof(ret)) {
-			blocksize = len;
-			(void)memcpy(udst, &ret, blocksize);
-		} else {
-			(*udst++) = ret;
-		}
-		len += blocksize;
+		blocksize = MIN(outlen, sizeof(ret));
+		(void)memcpy((void *)udst, &ret, blocksize);
+		udst += blocksize;
+		outlen -= blocksize;
 	}
 }
 #endif /* __GNUC__ */


### PR DESCRIPTION
The previous implementation assumed that the dst pointer was always
aligned to a 4-byte boundary in platforms that require alignment for
storage of 32-bit integers. Since this is required for certain platforms
(eg. Arm Cortex-M0), use memcpy() instead, which always takes
alignment into account.

Fixes #33969.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>