### PR TITLE
k_current_get(): make it a "const" function

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,6 +180,7 @@ cpp_id_attributes = [
     "__used",
     "__unused",
     "__weak",
+    "__attribute_const__",
     "__DEPRECATED_MACRO",
     "FUNC_NORETURN",
     "__subsystem",

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -528,7 +528,7 @@ __syscall void k_wakeup(k_tid_t thread);
  * @return ID of current thread.
  *
  */
-__syscall k_tid_t k_current_get(void);
+__syscall k_tid_t k_current_get(void) __attribute_const__;
 
 /**
  * @brief Abort a thread.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -190,6 +190,9 @@ do {                                                                    \
 #ifndef __deprecated
 #define __deprecated	__attribute__((deprecated))
 #endif
+#ifndef __attribute_const__
+#define __attribute_const__ __attribute__((__const__))
+#endif
 #define ARG_UNUSED(x) (void)(x)
 
 #define likely(x)   __builtin_expect((bool)!!(x), true)

--- a/tests/arch/x86/cpu_scrubs_regs/src/main.c
+++ b/tests/arch/x86/cpu_scrubs_regs/src/main.c
@@ -27,23 +27,26 @@ void z_impl_test_cpu_write_reg(void)
 #if CONFIG_X86
 #ifndef CONFIG_X86_64
 	__asm__ volatile (
-		"movl $0xDEADBEEF, %eax;\n\t"
-		"movl $0xDEADBEEF, %ebx;\n\t"
-		"movl $0xDEADBEEF, %ecx;\n\t"
-		"movl $0xDEADBEEF, %edx;\n\t"
-		"movl $0xDEADBEEF, %edi;\n\t"
+		"movl $0xDEADBEEF, %%eax;\n\t"
+		"movl $0xDEADBEEF, %%ebx;\n\t"
+		"movl $0xDEADBEEF, %%ecx;\n\t"
+		"movl $0xDEADBEEF, %%edx;\n\t"
+		"movl $0xDEADBEEF, %%edi;\n\t"
+		: : : "eax", "ebx", "ecx", "edx", "edi"
 		);
 #else
 	__asm__ volatile (
-		"movq $0xDEADBEEF, %rax;\n\t"
-		"movq $0xDEADBEEF, %rcx;\n\t"
-		"movq $0xDEADBEEF, %rdx;\n\t"
-		"movq $0xDEADBEEF, %rsi;\n\t"
-		"movq $0xDEADBEEF, %rdi;\n\t"
-		"movq $0xDEADBEEF, %r8;\n\t"
-		"movq $0xDEADBEEF, %r9;\n\t"
-		"movq $0xDEADBEEF, %r10;\n\t"
-		"movq $0xDEADBEEF, %r11;\n\t"
+		"movq $0xDEADBEEF, %%rax;\n\t"
+		"movq $0xDEADBEEF, %%rcx;\n\t"
+		"movq $0xDEADBEEF, %%rdx;\n\t"
+		"movq $0xDEADBEEF, %%rsi;\n\t"
+		"movq $0xDEADBEEF, %%rdi;\n\t"
+		"movq $0xDEADBEEF, %%r8;\n\t"
+		"movq $0xDEADBEEF, %%r9;\n\t"
+		"movq $0xDEADBEEF, %%r10;\n\t"
+		"movq $0xDEADBEEF, %%r11;\n\t"
+		: : : "rax", "rcx", "rdx", "rsi", "rdi",
+		      "r8",  "r9",  "r10", "r11"
 		);
 #endif
 #endif


### PR DESCRIPTION
This function always returns the same value for a given thread.
Add the const attribute to it so the compiler won't call it over and
over needlessly each time _current is referenced, making for far more
efficient code.

The __attribute_const__ symbol is used to mimic the Linux equivalent.
We want to make it clear that this is distinct from the const keyword.

Adjust the syscall generator to propagate function attributes.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
