### PR TITLE
ci: pylint: relax similar lines rule

### DIFF
--- a/scripts/ci/pylintrc
+++ b/scripts/ci/pylintrc
@@ -247,3 +247,17 @@ enable=
     deprecated-str-translate-call,
     deprecated-itertools-function,
     deprecated-types-field,
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=10
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -51,3 +51,4 @@ scripts/ci/version_mgr.py
 scripts/requirements*
 scripts/checkpatch/*
 scripts/checkpatch.pl
+scripts/ci/pylintrc


### PR DESCRIPTION
We are getting hits on similar imports in different files, relax that.

see https://github.com/zephyrproject-rtos/zephyr/pull/34173/checks?check_run_id=2307391423

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
