### PR TITLE
drivers: gpio: mmio32: Make GPIO_MMIO32_INIT dt aware

### DIFF
--- a/include/drivers/gpio/gpio_mmio32.h
+++ b/include/drivers/gpio/gpio_mmio32.h
@@ -34,39 +34,37 @@ int gpio_mmio32_init(const struct device *dev);
  * Create a device object for accessing a simple 32-bit i/o register using the
  * same APIs as GPIO drivers.
  *
- * @param _dev_name Device name.
- * @param _drv_name The name this instance of the driver exposes to the system.
+ * @param node_id   The devicetree node identifier.
  * @param _address  The address of the 32-bit i/o register the device will
  *		    provide access to.
  * @param _mask     Mask of bits in the register that it is valid to access.
  *		    E.g. 0xffffffffu to allow access to all of them.
  *
- * @see DEVICE_INIT
  */
-#define GPIO_MMIO32_INIT(_dev_name, _drv_name, _address, _mask)		\
-									\
-static struct gpio_mmio32_context _dev_name##_dev_data;			\
-									\
-static const struct gpio_mmio32_config _dev_name##_dev_cfg = {		\
-	.common = {							\
-		 .port_pin_mask = _mask,				\
-	},								\
-	.reg	= (volatile uint32_t *)_address,				\
-	.mask	= _mask,						\
-};									\
-									\
-DEVICE_DEFINE(_dev_name, _drv_name,					\
-		    &gpio_mmio32_init,					\
-		    device_pm_control_nop,				\
-		    &_dev_name##_dev_data,				\
-		    &_dev_name##_dev_cfg,				\
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+#define GPIO_MMIO32_INIT(node_id, _address, _mask)					\
+static struct gpio_mmio32_context _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _ctx);		\
+											\
+static const struct gpio_mmio32_config _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _cfg) = {	\
+	.common = {									\
+		 .port_pin_mask = _mask,						\
+	},										\
+	.reg	= (volatile uint32_t *)_address,					\
+	.mask	= _mask,								\
+};											\
+											\
+DEVICE_DT_DEFINE(node_id,								\
+		    &gpio_mmio32_init,							\
+		    device_pm_control_nop,						\
+		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _ctx),			\
+		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _cfg),			\
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
 		    &gpio_mmio32_api)
+
 
 #else /* CONFIG_GPIO_MMIO32 */
 
 /* Null definition for when support not configured into kernel */
-#define GPIO_MMIO32_INIT(_dev_name, _drv_name, _address, _mask)
+#define GPIO_MMIO32_INIT(node_id, _address, _mask)
 
 #endif
 

--- a/soc/arm/arm/mps2/soc.c
+++ b/soc/arm/arm/mps2/soc.c
@@ -17,7 +17,7 @@
 /* Setup GPIO drivers for accessing FPGAIO registers */
 #define FPGAIO_NODE(n) DT_INST(n, arm_mps2_fpgaio_gpio)
 #define FPGAIO_INIT(n)						\
-	GPIO_MMIO32_INIT(fpgaio_##n, DT_LABEL(FPGAIO_NODE(n)),	\
+	GPIO_MMIO32_INIT(FPGAIO_NODE(n),			\
 			DT_REG_ADDR(FPGAIO_NODE(n)),		\
 			BIT_MASK(DT_PROP(FPGAIO_NODE(n), ngpios)))
 

--- a/soc/arm/arm/mps3/soc.c
+++ b/soc/arm/arm/mps3/soc.c
@@ -14,7 +14,7 @@
 /* Setup GPIO drivers for accessing FPGAIO registers */
 #define FPGAIO_NODE(n) DT_INST(n, arm_mps3_fpgaio_gpio)
 #define FPGAIO_INIT(n)						\
-	GPIO_MMIO32_INIT(fpgaio_##n, DT_LABEL(FPGAIO_NODE(n)),	\
+	GPIO_MMIO32_INIT(FPGAIO_NODE(n),			\
 			DT_REG_ADDR(FPGAIO_NODE(n)),		\
 			BIT_MASK(DT_PROP(FPGAIO_NODE(n), ngpios)))
 


### PR DESCRIPTION
Change the GPIO_MMIO32_INIT to take a devicetree node since we want
to use DEVICE_DT_DEFINE.  This makes it so that code using
GPIO_DT_SPEC_GET works correctly with GPIO controllers that utilize
GPIO MMIO32.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>