### PR TITLE
drivers: uart: uart_cmsdk_apb: Fix compile warning.

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -84,7 +84,9 @@ struct uart_cmsdk_apb_dev_data {
 	((volatile struct uart_cmsdk_apb *)(DEV_CFG(dev))->base)
 
 static const struct uart_driver_api uart_cmsdk_apb_driver_api;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cmsdk_apb_isr(const struct device *dev);
+#endif
 
 /**
  * @brief Set the baud rate


### PR DESCRIPTION
If we are building the driver with CONFIG_UART_INTERRUPT_DRIVEN=n
we need to ifdef around the decleration of uart_cmsdk_apb_isr()
or we'll get a compiler warning.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>