### PR TITLE
arm: stm32f411e_disco: add dt node for leds and sensors

### DIFF
--- a/boards/arm/stm32f411e_disco/doc/index.rst
+++ b/boards/arm/stm32f411e_disco/doc/index.rst
@@ -14,9 +14,9 @@ Here are some highlights of the STM32F411E-DISCO board:
 - On-board ST-LINK/V2 with selection mode switch to use the kit as a standalone STLINK/V2 (with SWD connector for programming and debugging)
 - Board power supply: through USB bus or from an external 5 V supply voltage
 - External application power supply: 3 V and 5 V
-- L3GD20, ST MEMS motion sensor, 3-axis digital output gyroscope.
-- LSM303DLHC, ST MEMS system-in-package featuring a 3D digital linear acceleration sensor and a 3D digital magnetic sensor.
-- MP45DT02, ST MEMS audio sensor, omnidirectional digital microphone
+- L3GD20(rev B) or I3G4250D(rev D): ST MEMS motion sensor, 3-axis digital output gyroscope.
+- LSM303DLHC(rev B) or LSM303AGR(rev D): ST MEMS system-in-package featuring a 3D digital linear acceleration sensor and a 3D digital magnetic sensor.
+- MP45DT02(rev B) or IMP34DT05(rev D), ST MEMS audio sensor, omnidirectional digital microphone
 - CS43L22, audio DAC with integrated class D speaker driver
 - Eight LEDs:
     - LD1 (red/green) for USB communication
@@ -104,10 +104,10 @@ Default Zephyr Peripheral Mapping:
 ----------------------------------
 - UART_2_TX : PA2
 - UART_2_RX : PA3
-- LD3 : PD13
+- LD3 : PD13 (PWM4 CH2)
 - LD4 : PD12 (PWM4 CH1)
-- LD5 : PD14
-- LD6 : PD15
+- LD5 : PD14 (PWM4 CH3)
+- LD6 : PD15 (PWM4 CH4)
 
 System Clock
 ============
@@ -148,6 +148,14 @@ Here is an example for the :ref:`blinky-sample` application.
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: stm32f411e_disco
+   :goals: build flash
+
+Incase you are using PCB revision B, you have to use an
+adapted board definition as the default PCB rev here is D:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32f411e_disco@B
    :goals: build flash
 
 You should see the orange led (LD3) blinking every second.

--- a/boards/arm/stm32f411e_disco/revision.cmake
+++ b/boards/arm/stm32f411e_disco/revision.cmake
@@ -1,0 +1,4 @@
+board_check_revision(
+        FORMAT LETTER
+        DEFAULT_REVISION D
+)

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -44,6 +44,15 @@
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm4 1 0 PWM_POLARITY_NORMAL>;
 		};
+		orange_pwm_led: orange_pwm_led {
+			pwms = <&pwm4 2 0 PWM_POLARITY_NORMAL>;
+		};
+		red_pwm_led: red_pwm_led {
+			pwms = <&pwm4 3 0 PWM_POLARITY_NORMAL>;
+		};
+		blue_pwm_led: blue_pwm_led {
+			pwms = <&pwm4 4 0 PWM_POLARITY_NORMAL>;
+		};
 	};
 
 	gpio_keys {
@@ -61,6 +70,9 @@
 		led3 = &blue_led_6;
 		sw0 = &user_button;
 		pwm-led0 = &green_pwm_led;
+		pwm-led1 = &orange_pwm_led;
+		pwm-led2 = &red_pwm_led;
+		pwm-led3 = &blue_pwm_led;
 	};
 };
 
@@ -69,7 +81,33 @@
 
 	pwm4: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim4_ch1_pd12>;
+		pinctrl-0 = <&tim4_ch1_pd12
+			     &tim4_ch2_pd13
+			     &tim4_ch3_pd14
+			     &tim4_ch4_pd15>;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	lsm303agr-magn@1e {
+		compatible = "st,lis2mdl", "st,lsm303agr-magn";
+		status = "okay";
+		reg = <0x1e>;
+		irq-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+		label = "LSM303AGR-MAGN";
+	};
+
+	lsm303agr-accel@19 {
+		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		status = "okay";
+		reg = <0x19>;
+		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
+			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
+		label = "LSM303AGR-ACCEL";
 	};
 };
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_B.conf
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_B.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c1 {
+    /delete-node/ lsm303agr-magn@1e;
+    /delete-node/ lsm303agr-accel@19;
+
+	lsm303dlhc-magn@1e {
+		compatible = "st,lsm303dlhc-magn";
+        status = "okay";
+		reg = <0x1e>;
+		label = "LSM303DLHC-MAGN";
+	};
+
+	lsm303dlhc-accel@19 {
+		compatible = "st,lis2dh", "st,lsm303dlhc-accel";
+        status = "okay";
+		reg = <0x19>;
+		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
+			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
+		label = "LSM303DLHC-ACCEL";
+	};
+};

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_D.conf
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_D.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Add dts nodes for onboard devices that have drivers in zerphyr src
- Add PWM for all leds
- Add LSM303AGR sensor node

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>