### PR TITLE
doc: allow up to breathe 4.28.x

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.23.0
+breathe>=4.23.0,<4.29.0
 sphinx>=3.3.0,<3.4.0
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs


### PR DESCRIPTION
It looks like latest release (4.29.0) breaks docs build.