### PR TITLE
samples: canbus: canopen: use macro to set CO_OD size

### DIFF
--- a/samples/subsys/canbus/canopen/objdict/CO_OD.c
+++ b/samples/subsys/canbus/canopen/objdict/CO_OD.c
@@ -279,7 +279,7 @@ struct sCO_OD_EEPROM CO_OD_EEPROM = {
 /*******************************************************************************
    OBJECT DICTIONARY
 *******************************************************************************/
-const CO_OD_entry_t CO_OD[45] = {
+const CO_OD_entry_t CO_OD[CO_OD_NoOfElements] = {
 
 	{ 0x1000, 0x00, 0x85, 4, (void *)&CO_OD_ROM.deviceType },
 	{ 0x1001, 0x00, 0x26, 1, (void *)&CO_OD_RAM.errorRegister },


### PR DESCRIPTION
If we use the macro CO_OD_NoOfElements (already defined in CO_OD.h) as
the size of the CO_OD array (the object dictionary), any further
extension / reduction will only require updating the value of
CO_OD_NoOfElements.
Without applying the patch you should change both the constant and the
size of the array.

Signed-off-by: Dario Binacchi <dariobin@libero.it>