### PR TITLE
nrf52_bsim: Fix LOG_MODE_IMMEDIATE kconfig warning

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -24,6 +24,12 @@ if LOG
 config LOG_BACKEND_NATIVE_POSIX
 	default y if !SERIAL
 
+# For this board we can log synchronously without any problem
+# Doing so will be nicer for debugging
+choice LOG_MODE
+	default LOG_MODE_IMMEDIATE
+endchoice
+
 endif # LOG
 
 endif # BOARD_NRF52_BSIM

--- a/boards/posix/nrf52_bsim/nrf52_bsim_defconfig
+++ b/boards/posix/nrf52_bsim/nrf52_bsim_defconfig
@@ -5,6 +5,3 @@ CONFIG_BOARD_NRF52_BSIM=y
 CONFIG_CONSOLE=y
 CONFIG_NO_OPTIMIZATIONS=y
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=32768
-# For this board we can log immediately without any problem
-# Doing so will be nicer for debugging
-CONFIG_LOG_MODE_IMMEDIATE=y


### PR DESCRIPTION
The board _defconfig file was trying to set
LOG_MODE_IMMEDIATE unconditionally by default, which
caused a warning when LOG wasn't enabled.
Instead set it only when LOG is enabled.

Same fix as in #34141

