### PR TITLE
Fix BIG iso data path

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -33,6 +33,9 @@ extern "C" {
 				  BT_HCI_ISO_HDR_SIZE + \
 				  BT_HCI_ISO_DATA_HDR_SIZE)
 
+/** Value to set the ISO data path over HCi. */
+#define BT_ISO_DATA_PATH_HCI     0x00
+
 struct bt_iso_chan;
 
 /** @brief Life-span states of ISO channel. Used only by internal APIs
@@ -79,8 +82,10 @@ struct bt_iso_chan_io_qos {
 	uint8_t				phy;
 	/** Channel Retransmission Number. Value range 0x00 - 0x0F. */
 	uint8_t				rtn;
-	/** Channel data path reference.
-	 *  Setting to NULL default to HCI data path.
+	/** @brief Channel data path reference
+	 *
+	 *  Setting to NULL default to HCI data path (same as setting path.pid
+	 *  to BT_ISO_DATA_PATH_HCI).
 	 */
 	struct bt_iso_chan_path		*path;
 };
@@ -97,12 +102,20 @@ struct bt_iso_chan_qos {
 	uint8_t				packing;
 	/** Channel framing mode. 0 for unframed, 1 for framed. */
 	uint8_t				framing;
-	/** Channel Receiving QoS:
-	 *  Setting NULL disables data path BT_HCI_DATAPATH_DIR_CTLR_TO_HOST
+	/** @brief Channel Receiving QoS.
+	 *
+	 *  Setting NULL disables data path BT_HCI_DATAPATH_DIR_CTLR_TO_HOST.
+	 *
+	 *  Can only be set for a connected isochronous channel, or a broadcast
+	 *  isochronous receiver.
 	 */
 	struct bt_iso_chan_io_qos	*rx;
-	/** Channel Transmission QoS:
-	 *  Setting NULL disables data path BT_HCI_DATAPATH_DIR_HOST_TO_CTRL
+	/** @brief Channel Transmission QoS
+	 *
+	 *  Setting NULL disables data path BT_HCI_DATAPATH_DIR_HOST_TO_CTRL.
+	 *
+	 *  Can only be set for a connected isochronous channel, or a broadcast
+	 *  isochronous transmitter.
 	 */
 	struct bt_iso_chan_io_qos	*tx;
 };

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -719,7 +719,7 @@ static int bt_iso_setup_data_path(struct bt_conn *conn)
 {
 	int err;
 	struct bt_iso_chan *chan;
-	struct bt_iso_chan_path default_path = { 0 };
+	struct bt_iso_chan_path default_path = { .pid = BT_ISO_DATA_PATH_HCI };
 	struct bt_iso_data_path out_path = {
 		.dir = BT_HCI_DATAPATH_DIR_CTLR_TO_HOST };
 	struct bt_iso_data_path in_path = {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -532,7 +532,7 @@ static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
+	shell_print(ctx_shell, "BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
 		    "nse 0x%02x, interval 0x%04x (%u ms), bn 0x%02x, pto 0x%02x, irc 0x%02x, "
 		    "max_pdu 0x%04x, sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, "
 		    "%sencrypted",


### PR DESCRIPTION
The iso data path can only be set for one direction when dealing with BISs, so the CIS way of setting the data path can not be fully reused. 

Also adds a small update to the BIGinfo reports in the shell. 