### PR TITLE
doc: guides: porting: shields: fix Arduino header name

### DIFF
--- a/doc/guides/porting/shields.rst
+++ b/doc/guides/porting/shields.rst
@@ -144,7 +144,7 @@ GPIO nexus nodes
 ****************
 
 GPIOs accessed by the shield peripherals must be identified using the
-shield GPIO abstraction, for example from the ``arduino-r3-header``
+shield GPIO abstraction, for example from the ``arduino-header-r3``
 compatible.  Boards that provide the header must map the header pins
 to SOC-specific pins.  This is accomplished by including a `nexus
 node`_ that looks like the following into the board devicetree file:


### PR DESCRIPTION
``arduino-header-r3`` was incorrectly referred to as ``arduino-r3-header``.

Signed-off-by: Ievgenii Meshcheriakov <ievgenii.meshcheriakov@nordicsemi.no>