### PR TITLE
drivers: intc: shared_irq: remove internal structs from header

### DIFF
--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -18,6 +18,24 @@
 #include <drivers/interrupt_controller/ioapic.h>
 #endif
 
+typedef void (*shared_irq_config_irq_t)(void);
+
+struct shared_irq_config {
+	uint32_t irq_num;
+	shared_irq_config_irq_t config;
+	uint32_t client_count;
+};
+
+struct shared_irq_client {
+	const struct device *isr_dev;
+	isr_t isr_func;
+	uint32_t enabled;
+};
+
+struct shared_irq_runtime {
+	struct shared_irq_client client[CONFIG_SHARED_IRQ_NUM_CLIENTS];
+};
+
 /**
  *  @brief Register a device ISR
  *  @param dev Pointer to device structure for SHARED_IRQ driver instance.

--- a/include/shared_irq.h
+++ b/include/shared_irq.h
@@ -32,26 +32,6 @@ struct shared_irq_driver_api {
 	shared_irq_disable_t disable;
 };
 
-extern int shared_irq_initialize(const struct device *port);
-
-typedef void (*shared_irq_config_irq_t)(void);
-
-struct shared_irq_config {
-	uint32_t irq_num;
-	shared_irq_config_irq_t config;
-	uint32_t client_count;
-};
-
-struct shared_irq_client {
-	const struct device *isr_dev;
-	isr_t isr_func;
-	uint32_t enabled;
-};
-
-struct shared_irq_runtime {
-	struct shared_irq_client client[CONFIG_SHARED_IRQ_NUM_CLIENTS];
-};
-
 /**
  *  @brief Register a device ISR
  *  @param dev Pointer to device structure for SHARED_IRQ driver instance.


### PR DESCRIPTION
Move the internal structs used by the generic, shared interrupt driver from the public header file into the implementation file.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>