### PR TITLE
boards: arm: twr_ke18f: Add pinctrl dts properties

### DIFF
--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -125,6 +125,7 @@
 &sim {
 	clkout-source = <1>;
 	clkout-divider = <0>;
+	pinctrl-0 = <&CLKOUT_PTE10>;
 };
 
 &scg {
@@ -191,22 +192,27 @@
 &lpuart0 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&LPUART0_RX_PTB0 &LPUART0_TX_PTB1>;
 };
 
 &ftm0 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM0_CH0_PTD15 &FTM0_CH1_PTD16 &FTM0_CH5_PTB5>;
 };
 
 &ftm3 {
 	status = "okay";
 	compatible = "nxp,kinetis-ftm-pwm";
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM3_CH4_PTC10 &FTM3_CH5_PTC11
+		     &FTM3_CH6_PTC12 &FTM3_CH7_PTC13>;
 };
 
 &lpi2c0 {
 	status = "okay";
+	pinctrl-0 = <&LPI2C0_SDA_PTA2 &LPI2C0_SCL_PTA3>;
 
 	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -218,23 +224,30 @@
 
 &lpi2c1 {
 	status = "okay";
+	pinctrl-0 = <&LPI2C1_SDA_PTD8 &LPI2C1_SCL_PTD9>;
 };
 
 &lpspi0 {
 	status = "okay";
+	pinctrl-0 = <&LPSPI0_SCK_PTE0 &LPSPI0_SIN_PTE1
+		     &LPSPI0_SOUT_PTE2 &LPSPI0_PCS2_PTE6>;
 };
 
 &lpspi1 {
 	status = "okay";
+	pinctrl-0 = <&LPSPI1_SCK_PTD0 &LPSPI1_SIN_PTD1
+		     &LPSPI1_SOUT_PTD2 &LPSPI1_PCS0_PTD3>;
 };
 
 &dac0 {
 	status = "okay";
+	pinctrl-0 = <&DAC0_OUT_PTE9>;
 };
 
 &adc0 {
 	status = "okay";
 	sample-time = <12>;
+	pinctrl-0 = <&ADC0_SE0_PTA0 &ADC0_SE1_PTA1 &ADC0_SE12_PTC14>;
 };
 
 &temp0 {
@@ -244,6 +257,7 @@
 &flexcan0 {
 	status = "okay";
 	bus-speed = <125000>;
+	pinctrl-0 = <&CAN0_RX_PTE4 &CAN0_TX_PTE5>;
 };
 
 &gpioa {

--- a/samples/sensor/mcux_acmp/boards/twr_ke18f.overlay
+++ b/samples/sensor/mcux_acmp/boards/twr_ke18f.overlay
@@ -6,4 +6,5 @@
 
 &cmp2 {
 	status = "okay";
+	pinctrl-0 = <&ADC0_SE12_PTC14>;
 };

--- a/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
@@ -17,6 +17,7 @@
 &pwt {
 	status = "okay";
 	prescaler = <32>;
+	pinctrl-0 = <&PWT_IN1_PTE11>;
 };
 
 &ftm2 {
@@ -24,4 +25,5 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	prescaler = <128>;
 	#pwm-cells = <3>;
+	pinctrl-0 = <&FTM2_CH6_PTE15>;
 };


### PR DESCRIPTION
Add pinctrl-0 properties for configuration of peripherals like UARTs, I2C, SPI, FTMs, etc.  These settings are based on what is defined in the board/pinmux.c file.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>