### PR TITLE
driver: usdhc: add option to disable 1.8v

### DIFF
--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -170,6 +170,7 @@
 &usdhc1 {
 	status = "okay";
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
+	no-1-8-v;
 };
 
 &csi {

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -27,5 +27,12 @@ properties:
         property value should ensure the flags properly describe the signal
         that is presented to the driver.
 
+    no-1-8-v:
+      type: boolean
+      required: false
+      description:
+        When the external SD card circuit does not support 1.8V, add this
+        property to disable 1.8v card voltage of SD card controller.
+
     label:
       required: true


### PR DESCRIPTION
When 1.8V is disabled, sdhc can only
communicate at low speed. But this can
save the external circuit for switching
between 3.3V and 1.8V, which is very
practical in costdown scenarios.

Signed-off-by: Frank Li <lgl88911@163.com>