### PR TITLE
trusted-firmware-m: update to upstream release v.1.3.0

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -323,6 +323,7 @@ Trusted Firmware-m
 
 * Configured QEMU to run Zephyr samples and tests in CI on mps2_an521_nonsecure
   (Cortex-M33 Non-Secure) with TF-M as the secure firmware component.
+* Synchronized Trusted-Firmware-M module to the upstream v1.3.0 release.
 
 
 Documentation

--- a/west.yml
+++ b/west.yml
@@ -140,7 +140,7 @@ manifest:
       revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: d07d72c64e4b3d8594829eea302b88e51709861f
+      revision: 33216b0d61a6bc585a87e548c4a345d3fd0d2177
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update TF-M module to the upstream release v1.3.0.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>