### PR TITLE
arm64: a few alignment fixes

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -30,8 +30,7 @@ volatile struct {
 	void *sp; /* Fixed at the first entry */
 	arch_cpustart_t fn;
 	void *arg;
-	char pad[] __aligned(L1_CACHE_BYTES);
-} arm64_cpu_init[CONFIG_MP_NUM_CPUS];
+} __aligned(L1_CACHE_BYTES) arm64_cpu_init[CONFIG_MP_NUM_CPUS];
 
 extern void __start(void);
 

--- a/include/arch/arm64/exc.h
+++ b/include/arch/arm64/exc.h
@@ -50,7 +50,7 @@ struct __esf {
 #ifdef CONFIG_USERSPACE
 	uint64_t tpidrro_el0;
 #endif
-};
+} __aligned(16);
 
 typedef struct __esf z_arch_esf_t;
 


### PR DESCRIPTION
The structure for the arm64_cpu_init array has to carry the cache
alignment on the whole structure and not on some internal padding
to achieve the desired effect.

And align struct __esf to a 16-byte boundary which will also align
its size accordingly. This structure is allocated on the stack on
exception entry and the ABI prescribed 16-byte stack alignment
should be preserved.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
