### PR TITLE
dts: npcx: arrange default priority of interrupts for ec application.

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx7-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-espi-vws-map.dtsi
@@ -34,94 +34,106 @@
 		/* eSPI Virtual Vire (VW) input configuration */
 		/* index 02h (In) */
 		vw-slp-s3 {
-			vw_reg = <NPCX_VWEVMS0 0x01>; wui_map = <&wui_vw_slp_s3>;
+			vw-reg = <NPCX_VWEVMS0 0x01>;
+			vw-wui = <&wui_vw_slp_s3>;
 		};
 		vw-slp-s4 {
-			vw_reg = <NPCX_VWEVMS0 0x02>; wui_map = <&wui_vw_slp_s4>;
+			vw-reg = <NPCX_VWEVMS0 0x02>;
+			vw-wui = <&wui_vw_slp_s4>;
 		};
 		vw-slp-s5 {
-			vw_reg = <NPCX_VWEVMS0 0x04>; wui_map = <&wui_vw_slp_s5>;
+			vw-reg = <NPCX_VWEVMS0 0x04>;
+			vw-wui = <&wui_vw_slp_s5>;
 		};
 
 		/* index 03h (In) */
 		vw-sus-stat {
-			vw_reg = <NPCX_VWEVMS1 0x01>; wui_map = <&wui_vw_sus_stat>;
+			vw-reg = <NPCX_VWEVMS1 0x01>;
+			vw-wui = <&wui_vw_sus_stat>;
 		};
 		vw-plt-rst {
-			vw_reg = <NPCX_VWEVMS1 0x02>; wui_map = <&wui_vw_plt_rst>;
+			vw-reg = <NPCX_VWEVMS1 0x02>;
+			vw-wui = <&wui_vw_plt_rst>;
 		};
 		vw-oob-rst-warn {
-			vw_reg = <NPCX_VWEVMS1 0x04>; wui_map = <&wui_vw_oob_rst_warn>;
+			vw-reg = <NPCX_VWEVMS1 0x04>;
+			vw-wui = <&wui_vw_oob_rst_warn>;
 		};
 
 		/* index 07h (In) */
 		vw-host-rst-warn {
-			vw_reg = <NPCX_VWEVMS2 0x01>; wui_map =<&wui_vw_host_rst_warn>;
+			vw-reg = <NPCX_VWEVMS2 0x01>;
+			vw-wui = <&wui_vw_host_rst_warn>;
 		};
 
 		/* index 41h (In) */
 		vw-sus-warn {
-			vw_reg = <NPCX_VWEVMS3 0x01>; wui_map = <&wui_vw_sus_warn>;
+			vw-reg = <NPCX_VWEVMS3 0x01>;
+			vw-wui = <&wui_vw_sus_warn>;
 		};
 		vw-sus-pwrdn-ack {
-			vw_reg = <NPCX_VWEVMS3 0x02>; wui_map =<&wui_vw_sus_pwrdn_ack>;
+			vw-reg = <NPCX_VWEVMS3 0x02>;
+			vw-wui = <&wui_vw_sus_pwrdn_ack>;
 		};
 		vw-slp-a {
-			vw_reg = <NPCX_VWEVMS3 0x08>; wui_map = <&wui_vw_slp_a>;
+			vw-reg = <NPCX_VWEVMS3 0x08>;
+			vw-wui = <&wui_vw_slp_a>;
 		};
 
 		/* index 42h (In) */
 		vw-slp-lan {
-			vw_reg = <NPCX_VWEVMS4 0x01>; wui_map = <&wui_vw_slp_lan>;
+			vw-reg = <NPCX_VWEVMS4 0x01>;
+			vw-wui = <&wui_vw_slp_lan>;
 		};
 		vw-slp-wlan {
-			vw_reg = <NPCX_VWEVMS4 0x02>; wui_map = <&wui_vw_slp_wlan>;
+			vw-reg = <NPCX_VWEVMS4 0x02>;
+			vw-wui = <&wui_vw_slp_wlan>;
 		};
 
 		/* eSPI Virtual Vire (VW) output configuration */
 		/* index 04h (Out) */
 		vw-oob-rst-ack {
-			vw_reg = <NPCX_VWEVSM0 0x01>;
+			vw-reg = <NPCX_VWEVSM0 0x01>;
 		};
 		vw-wake {
-			vw_reg = <NPCX_VWEVSM0 0x04>;
+			vw-reg = <NPCX_VWEVSM0 0x04>;
 		};
 		vw-pme {
-			vw_reg = <NPCX_VWEVSM0 0x08>;
+			vw-reg = <NPCX_VWEVSM0 0x08>;
 		};
 
 		/* index 05h (Out) */
 		vw-slv-boot-done {
-			vw_reg = <NPCX_VWEVSM1 0x01>;
+			vw-reg = <NPCX_VWEVSM1 0x01>;
 		};
 		vw-err-fatal {
-			vw_reg = <NPCX_VWEVSM1 0x02>;
+			vw-reg = <NPCX_VWEVSM1 0x02>;
 		};
 		vw-err-non-fatal {
-			vw_reg = <NPCX_VWEVSM1 0x04>;
+			vw-reg = <NPCX_VWEVSM1 0x04>;
 		};
 		vw-slv-boot-sts-with-done {
 			/*
 			 * SLAVE_BOOT_DONE & SLAVE_LOAD_STS bits (bit 0 & bit 3)
 			 * have to be sent together. Hence its bitmask is 0x09.
 			 */
-			vw_reg = <NPCX_VWEVSM1 0x09>;
+			vw-reg = <NPCX_VWEVSM1 0x09>;
 		};
 
 		/* index 06h (Out) */
 		vw-sci {
-			vw_reg = <NPCX_VWEVSM2 0x01>;
+			vw-reg = <NPCX_VWEVSM2 0x01>;
 		};
 		vw-smi {
-			vw_reg = <NPCX_VWEVSM2 0x02>;
+			vw-reg = <NPCX_VWEVSM2 0x02>;
 		};
 		vw-host-rst-ack {
-			vw_reg = <NPCX_VWEVSM2 0x08>;
+			vw-reg = <NPCX_VWEVSM2 0x08>;
 		};
 
 		/* index 40h (Out) */
 		vw-sus-ack {
-			vw_reg = <NPCX_VWEVSM3 0x01>;
+			vw-reg = <NPCX_VWEVSM3 0x01>;
 		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
@@ -13,23 +13,23 @@
 
 			group_ad0: group-ad0-map {
 				irq        = <7>;
-				irq_prio   = <2>;
-				group_mask = <0x09>;
+				irq-prio   = <2>;
+				group-mask = <0x09>;
 			};
 			group_b0: group-b0-map {
 				irq        = <31>;
-				irq_prio   = <2>;
-				group_mask = <0x02>;
+				irq-prio   = <2>;
+				group-mask = <0x02>;
 			};
 			group_c0: group-c0-map {
 				irq        = <15>;
-				irq_prio   = <2>;
-				group_mask = <0x04>;
+				irq-prio   = <2>;
+				group-mask = <0x04>;
 			};
 			group_efgh0: group-efgh0-map {
 				irq        = <11>;
-				irq_prio   = <2>;
-				group_mask = <0xF0>;
+				irq-prio   = <2>;
+				group-mask = <0xF0>;
 			};
 		};
 
@@ -39,43 +39,43 @@
 
 			group_a1: group-a1-map {
 				irq        = <47>;
-				irq_prio   = <2>;
-				group_mask = <0x01>;
+				irq-prio   = <2>;
+				group-mask = <0x01>;
 			};
 			group_b1: group-b1-map {
 				irq        = <48>;
-				irq_prio   = <2>;
-				group_mask = <0x02>;
+				irq-prio   = <2>;
+				group-mask = <0x02>;
 			};
 			group_c1: group-c1-map {
 				irq        = <49>;
-				irq_prio   = <2>;
-				group_mask = <0x04>;
+				irq-prio   = <2>;
+				group-mask = <0x04>;
 			};
 			group_d1: group-d1-map {
 				irq        = <50>;
-				irq_prio   = <2>;
-				group_mask = <0x08>;
+				irq-prio   = <2>;
+				group-mask = <0x08>;
 			};
 			group_e1: group-e1-map {
 				irq        = <51>;
-				irq_prio   = <2>;
-				group_mask = <0x10>;
+				irq-prio   = <2>;
+				group-mask = <0x10>;
 			};
 			group_f1: group-f1-map {
 				irq        = <52>;
-				irq_prio   = <2>;
-				group_mask = <0x20>;
+				irq-prio   = <2>;
+				group-mask = <0x20>;
 			};
 			group_g1: group-g1-map {
 				irq        = <53>;
-				irq_prio   = <2>;
-				group_mask = <0x40>;
+				irq-prio   = <2>;
+				group-mask = <0x40>;
 			};
 			group_h1: group-h1-map {
 				irq        = <54>;
-				irq_prio   = <2>;
-				group_mask = <0x80>;
+				irq-prio   = <2>;
+				group-mask = <0x80>;
 			};
 		};
 
@@ -85,28 +85,28 @@
 
 			group_a2: group-a2-map {
 				irq        = <60>;
-				irq_prio   = <2>;
-				group_mask = <0x01>;
+				irq-prio   = <2>;
+				group-mask = <0x01>;
 			};
 			group_b2: group-b2-map {
 				irq        = <61>;
-				irq_prio   = <2>;
-				group_mask = <0x02>;
+				irq-prio   = <2>;
+				group-mask = <0x02>;
 			};
 			group_c2: group-c2-map {
 				irq        = <62>;
-				irq_prio   = <2>;
-				group_mask = <0x04>;
+				irq-prio   = <2>;
+				group-mask = <0x04>;
 			};
 			group_d2: group-d2-map {
 				irq        = <63>;
-				irq_prio   = <2>;
-				group_mask = <0x08>;
+				irq-prio   = <2>;
+				group-mask = <0x08>;
 			};
 			group_fg2: group-fg2-map {
 				irq        = <59>;
-				irq_prio   = <2>;
-				group_mask = <0x60>;
+				irq-prio   = <2>;
+				group-mask = <0x60>;
 			};
 		};
 	};

--- a/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-miwus-int-map.dtsi
@@ -13,22 +13,22 @@
 
 			group_ad0: group-ad0-map {
 				irq        = <7>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x09>;
 			};
 			group_b0: group-b0-map {
 				irq        = <31>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x02>;
 			};
 			group_c0: group-c0-map {
 				irq        = <15>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x04>;
 			};
 			group_efgh0: group-efgh0-map {
 				irq        = <11>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0xF0>;
 			};
 		};
@@ -39,42 +39,42 @@
 
 			group_a1: group-a1-map {
 				irq        = <47>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x01>;
 			};
 			group_b1: group-b1-map {
 				irq        = <48>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x02>;
 			};
 			group_c1: group-c1-map {
 				irq        = <49>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x04>;
 			};
 			group_d1: group-d1-map {
 				irq        = <50>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x08>;
 			};
 			group_e1: group-e1-map {
 				irq        = <51>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x10>;
 			};
 			group_f1: group-f1-map {
 				irq        = <52>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x20>;
 			};
 			group_g1: group-g1-map {
 				irq        = <53>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x40>;
 			};
 			group_h1: group-h1-map {
 				irq        = <54>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x80>;
 			};
 		};
@@ -85,27 +85,27 @@
 
 			group_a2: group-a2-map {
 				irq        = <60>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x01>;
 			};
 			group_b2: group-b2-map {
 				irq        = <61>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x02>;
 			};
 			group_c2: group-c2-map {
 				irq        = <62>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x04>;
 			};
 			group_d2: group-d2-map {
 				irq        = <63>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x08>;
 			};
 			group_fg2: group-fg2-map {
 				irq        = <59>;
-				irq_prio   = <0>;
+				irq_prio   = <2>;
 				group_mask = <0x60>;
 			};
 		};

--- a/dts/arm/nuvoton/npcx/npcx7-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7-miwus-wui-map.dtsi
@@ -500,13 +500,13 @@
 		};
 
 		/* Pseudo wui item means no mapping between source and wui */
-		wui_none: wui_pseudo {
+		wui_none: wui-pseudo {
 			miwus = <&miwu_none 7 7>;
 		};
 	};
 
 	/* Pseudo MIWU device to present no mapping relationship */
-	miwu_none: miwu_pseudo {
+	miwu_none: miwu-pseudo {
 		compatible = "nuvoton,npcx-miwu";
 		index = <3>;
 		#miwu-cells = <2>;

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -122,7 +122,7 @@
 			reg-names = "evt_itim", "sys_itim";
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 3
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
-			interrupts = <46 0>; /* Event timer interrupt */
+			interrupts = <46 2>; /* Event timer interrupt */
 			label = "ITIM";
 		};
 
@@ -153,7 +153,7 @@
 		uart1: serial@400c4000 {
 			compatible = "nuvoton,npcx-uart";
 			reg = <0x400C4000 0x2000>;
-			interrupts = <33 0>;
+			interrupts = <33 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL1 4>;
 			pinctrl-0 = <&alta_uart1_sl1>; /* PIN10.11 */
 			uart-rx = <&wui_cr_sin1>;
@@ -164,7 +164,7 @@
 		uart2: serial@400c6000 {
 			compatible = "nuvoton,npcx-uart";
 			reg = <0x400C6000 0x2000>;
-			interrupts = <32 0>;
+			interrupts = <32 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 6>;
 			pinctrl-0 = <&alta_uart2_sl>; /* PIN75.86 */
 			uart-rx = <&wui_cr_sin2>;
@@ -456,7 +456,7 @@
 			compatible = "nuvoton,npcx-adc";
 			#io-channel-cells = <1>;
 			reg = <0x400d1000 0x2000>;
-			interrupts = <10 0>;
+			interrupts = <10 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL4 4>;
 			pinctrl-0 = <&alt6_adc0_sl   /* ADC0 - PIN45 */
 				     &alt6_adc1_sl   /* ADC1 - PIN44 */
@@ -547,7 +547,7 @@
 		i2c_ctrl0: i2c@40009000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40009000 0x1000>;
-			interrupts = <13 0>;
+			interrupts = <13 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
 			label = "I2CCTRL_0";
 		};
@@ -555,7 +555,7 @@
 		i2c_ctrl1: i2c@4000b000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <14 0>;
+			interrupts = <14 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
 			label = "I2CCTRL_1";
 		};
@@ -563,7 +563,7 @@
 		i2c_ctrl2: i2c@400c0000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c0000 0x1000>;
-			interrupts = <36 0>;
+			interrupts = <36 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
 			label = "I2CCTRL_2";
 		};
@@ -571,7 +571,7 @@
 		i2c_ctrl3: i2c@400c2000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c2000 0x1000>;
-			interrupts = <37 0>;
+			interrupts = <37 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
 			label = "I2CCTRL_3";
 		};
@@ -579,7 +579,7 @@
 		i2c_ctrl4: i2c@40008000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40008000 0x1000>;
-			interrupts = <19 0>;
+			interrupts = <19 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
 			label = "I2CCTRL_4";
 		};
@@ -587,7 +587,7 @@
 		i2c_ctrl5: i2c@40017000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40017000 0x1000>;
-			interrupts = <20 0>;
+			interrupts = <20 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
 			label = "I2CCTRL_5";
 		};
@@ -595,7 +595,7 @@
 		i2c_ctrl6: i2c@40018000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40018000 0x1000>;
-			interrupts = <16 0>;
+			interrupts = <16 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
 			label = "I2CCTRL_6";
 		};
@@ -603,7 +603,7 @@
 		i2c_ctrl7: i2c@40019000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40019000 0x1000>;
-			interrupts = <8 0>;
+			interrupts = <8 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
 			label = "I2CCTRL_7";
 		};

--- a/dts/bindings/espi/nuvoton,npcx-espi-vw-conf.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-espi-vw-conf.yaml
@@ -8,15 +8,15 @@ compatible: "nuvoton,npcx-espi-vw-conf"
 child-binding:
     description: Child node to to present the mapping between VW signal, its core register and input source of MIWU
     properties:
-       vw_reg:
+       vw-reg:
           type: array
           required: true
           description: vw signal's register index and vw bitmask.
 
-       wui_map:
+       vw-wui:
         type: phandle
         description: |
             Mapping table between Wake-Up Input (WUI) and vw input signal.
 
             For example the WUI mapping on NPCX7 for VW_SLP5 would be
-               wui_map = <&wui_vw_slp_s5>;
+               vw-wui = <&wui_vw_slp_s5>;

--- a/dts/bindings/interrupt-controller/nuvoton,npcx-miwu-int-map.yaml
+++ b/dts/bindings/interrupt-controller/nuvoton,npcx-miwu-int-map.yaml
@@ -18,11 +18,11 @@ child-binding:
           type: int
           required: true
           description: irq for miwu group
-       irq_prio:
+       irq-prio:
           type: int
           required: true
           description: irq's priority for miwu group. The valid number is from 0 to 7.
-       group_mask:
+       group-mask:
           type: int
           required: true
           description: group bit-mask for miwu interrupts

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -415,16 +415,16 @@
 									name)
 
 /**
- * @brief Get phandle from wui_map property of child node with that path.
+ * @brief Get phandle from vw-wui property of child node with that path.
  *
  * @param name path which name is /npcx7-espi-vws-map/'name'.
- * @return phandle from "wui_map" prop of child node with that path.
+ * @return phandle from "vw-wui" prop of child node with that path.
  */
 #define NPCX_DT_PHANDLE_VW_WUI(name) DT_PHANDLE(NPCX_DT_NODE_FROM_VWTABLE(     \
-								name), wui_map)
+								name), vw_wui)
 
 /**
- * @brief Construct a npcx_wui structure from wui_map property of a child node
+ * @brief Construct a npcx_wui structure from vw-wui property of a child node
  * with that path.
  *
  * @param name a path which name is /npcx7-espi-vws-map/'name'.


### PR DESCRIPTION
The following is the interrupt priority plan for ec application.

The original IRQ priority map in Chromium EC is:
-IRQ priority 0:
|-ITIM IRQ for Warning watchdog.

-IRQ priority 1:
|-UART IRQ for signle byte FIFO in npcx5 series.
  (Ignore it since UART has 16 bytes FIFO in npcx7 and later series.)

-IRQ priority 2:
|-SHI IRQ for FIFO FULL and Half FULL event.
|-MIWU IRQ for SHI CS. (Wake-Up ASAP for handling data from SPI bus.)

-IRQ priority 3:
|-All MIWU IRQs for GPIO, MTC and eSPI VW events.
|-ITIM IRQ for task scheduling.
|-ITIM IRQ for time-out.
  (No need in Zephyr since 64-bit timer support.)

IRQ priority 4:
|-All UART FIFO IRQs
|-All I2C controller IRQs
|-ADC IRQ for conversion event.
|-ESPI IRQ for generic eSPI bus events.
|-Host KBC IBF/OBE IRQs
|-Host PM IBF/OBE IRQs
|-Host port80 IRQ
|-PECI IRQ

IRQ priority 5:
|-Keyboard RAW IRQ
|-PS2 IRQ

Then, this CL arranges the priority of npcx interrupts in Zephyr as:
IRQ priority 0:
|-Reserved it for further requirements.

IRQ priority 1:
|-SHI IRQ for FIFO FULL and Half FULL event.  (Will modify it in ec repo.)
|-MIWU IRQ for SHI CS (Will modify it in ec repo.)

IRQ priority 2:
|-MIWU IRQ for GPIO, MTC, T0 timer and eSPI VW events.
|-ITIM IRQ for task scheduling.

IRQ priority 3:
|-All UART FIFO IRQs
|-All I2C controller IRQs
|-ADC IRQ for conversion event.
|-ESPI IRQ for generic eSPI bus events.
|-Host KBC IBF/OBE IRQs
|-Host PM IBF/OBE IRQs
|-Host port80 IRQ

IRQ priority 4:
|-Keyboard RAW IRQ. (Will modify it in ec repo.)

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>