### PR TITLE
[TOPIC-BLE-LLCP] Integrating Min Number of Used chans into controller.

### DIFF
--- a/include/bluetooth/hci_vs.h
+++ b/include/bluetooth/hci_vs.h
@@ -201,6 +201,15 @@ struct bt_hci_cp_vs_set_usb_transport_mode {
 	uint8_t  mode;
 } __packed;
 
+#define BT_HCI_OP_VS_SET_MIN_NUM_USED_CHANS    BT_OP(BT_OGF_VS, 0x0012)
+
+struct bt_hci_cp_vs_set_min_num_used_chans {
+	uint16_t handle;
+	uint8_t  phys;
+	uint8_t  min_used_chans;
+} __packed;
+
+
 /* Events */
 
 struct bt_hci_evt_vs {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3783,7 +3783,20 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 	rp->status = 0x00;
 	hci_vendor_read_key_hierarchy_roots(rp->ir, rp->er);
 }
+#if !defined(CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY)
+#if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
+static void vs_set_min_used_chans(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_cp_vs_set_min_num_used_chans *cmd = (void *)buf->data;
+	uint16_t handle = sys_le16_to_cpu(cmd->handle);
+	uint8_t status;
 
+	status = ll_set_min_used_chans(handle, cmd->phys, cmd->min_used_chans);
+
+	*evt = cmd_complete_status(status);
+}
+#endif
+#endif
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 static void vs_write_tx_power_level(struct net_buf *buf, struct net_buf **evt)
 {
@@ -4037,6 +4050,14 @@ int hci_vendor_cmd_handle_common(uint16_t ocf, struct net_buf *cmd,
 		mesh_cmd_handle(cmd, evt);
 		break;
 #endif /* CONFIG_BT_HCI_MESH_EXT */
+
+#if !defined(CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY)
+#if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
+	case BT_OCF(BT_HCI_OP_VS_SET_MIN_NUM_USED_CHANS):
+		vs_set_min_used_chans(cmd, evt);
+		break;
+#endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
+#endif
 
 	default:
 		return -EINVAL;

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -277,6 +277,9 @@ uint8_t ll_phy_get(uint16_t handle, uint8_t *const tx, uint8_t *const rx);
 uint8_t ll_phy_default_set(uint8_t tx, uint8_t rx);
 uint8_t ll_phy_req_send(uint16_t handle, uint8_t tx, uint8_t flags, uint8_t rx);
 
+uint8_t ll_set_min_used_chans(uint16_t handle, uint8_t const phys,
+		     uint8_t const min_used_chans);
+
 /* Direction Finding */
 /* Sets CTE transmission parameters for periodic advertising */
 uint8_t ll_df_set_cl_cte_tx_params(uint8_t adv_handle, uint8_t cte_len,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
@@ -21,6 +21,7 @@ uint16_t ull_conn_default_tx_octets_get(void);
 uint16_t ull_conn_default_tx_time_get(void);
 void ull_conn_default_tx_octets_set(uint16_t tx_octets);
 void ull_conn_default_tx_time_set(uint16_t tx_time);
+uint8_t ull_conn_lll_phy_active(struct ll_conn *conn, uint8_t phy);
 uint8_t ull_conn_default_phy_tx_get(void);
 uint8_t ull_conn_default_phy_rx_get(void);
 void ull_conn_default_phy_tx_set(uint8_t tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_connections.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_connections.c
@@ -869,6 +869,19 @@ uint16_t ull_conn_lll_max_tx_octets_get(struct lll_conn *lll)
 	return max_tx_octets;
 }
 
+uint8_t ull_conn_lll_phy_active(struct ll_conn *conn, uint8_t phys)
+{
+#if defined(CONFIG_BT_CTLR_PHY)
+	if (!(phys & (conn->lll.phy_tx |
+			 conn->lll.phy_rx))) {
+#else /* !CONFIG_BT_CTLR_PHY */
+	if (!(phys & 0x01)) {
+#endif /* !CONFIG_BT_CTLR_PHY */
+		return 0;
+	}
+	return 1;
+}
+
 static int init_reset(void)
 {
 	/* Initialize conn pool. */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -473,7 +473,7 @@ uint8_t ull_cp_chan_map_update(struct ll_conn *conn, uint8_t chm[5])
 	}
 
 	/* RFU bits */
-	if (chm[4] & 0x07) {
+	if (chm[4] & 0xE0) {
 		return BT_HCI_ERR_INVALID_PARAM;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -571,6 +571,7 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		break;
 	case PROC_MIN_USED_CHANS:
 		/* No response */
+		rr_complete(conn);
 		ctx->state = RP_COMMON_STATE_IDLE;
 		break;
 	case PROC_TERMINATE:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
@@ -884,6 +884,25 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand,
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+#if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
+uint8_t ll_set_min_used_chans(uint16_t handle, uint8_t const phys,
+		     uint8_t const min_used_chans)
+{
+	struct ll_conn *conn;
+
+	conn = ll_connected_get(handle);
+	if (!conn) {
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
+	}
+
+	if (!conn->lll.role) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	return ull_cp_min_used_chans(conn, phys, min_used_chans);
+}
+#endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
+
 /*
  * EGON: the ll_tx_mem routines should go to their own module
  */

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -102,7 +102,7 @@ void test_min_used_chans_sla_loc(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
-	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_min_used_chans_mas_loc(void)
@@ -156,7 +156,7 @@ void test_min_used_chans_mas_rem(void)
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();
 
-	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM-1, "Free CTX buffers %d", ctx_buffers_free());
+	zassert_equal(ctx_buffers_free(), PROC_CTX_BUF_NUM, "Free CTX buffers %d", ctx_buffers_free());
 }
 
 void test_main(void)


### PR DESCRIPTION
Integrating Min Number of used Channels procedure into controller.

This a work in progress, as testing cannot be completed until Channel Map procedure is completed. The functionality was ported over from legacy code. 

Testing so far was made using a hacked EDTT test, confirming that a periph initiated MNUC procedure, resulted in a ChMapUpd arriving at the Central. 