### PR TITLE
net: openthread: add microseconds timer API

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -286,10 +286,4 @@ config OPENTHREAD_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
 	  Set y to enable software CSMA backoff. The option can be disabled if
 	  the radio has hardware support for this feature (IEEE802154_HW_CSMA).
 
-config OPENTHREAD_PLATFORM_USEC_TIMER_ENABLE
-	bool "Enable microsecond backoff timer implemented in platform"
-	help
-	  Set y if the platform provides microsecond backoff timer implementation.
-
-
 endif # NET_L2_OPENTHREAD

--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -15,27 +15,51 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <inttypes.h>
 
 #include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/alarm-micro.h>
 #include <openthread-system.h>
 
 #include <stdio.h>
 
 #include "platform-zephyr.h"
 
-static bool timer_fired;
+static bool timer_ms_fired, timer_us_fired;
 
-static void ot_timer_fired(struct k_timer *timer)
+static void ot_timer_ms_fired(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
 
-	timer_fired = true;
+	timer_ms_fired = true;
 	otSysEventSignalPending();
 }
 
-K_TIMER_DEFINE(ot_timer, ot_timer_fired, NULL);
+static void ot_timer_us_fired(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	timer_us_fired = true;
+	otSysEventSignalPending();
+}
+
+K_TIMER_DEFINE(ot_ms_timer, ot_timer_ms_fired, NULL);
+K_TIMER_DEFINE(ot_us_timer, ot_timer_us_fired, NULL);
 
 void platformAlarmInit(void)
 {
 	/* Intentionally empty */
+}
+
+void platformAlarmProcess(otInstance *aInstance)
+{
+	if (timer_ms_fired) {
+		timer_ms_fired = false;
+		otPlatAlarmMilliFired(aInstance);
+	}
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+	if (timer_us_fired) {
+		timer_us_fired = false;
+		otPlatAlarmMicroFired(aInstance);
+	}
+#endif
 }
 
 uint32_t otPlatAlarmMilliGetNow(void)
@@ -43,17 +67,17 @@ uint32_t otPlatAlarmMilliGetNow(void)
 	return k_uptime_get_32();
 }
 
-void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
+void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
 	ARG_UNUSED(aInstance);
 
-	int64_t reftime = (int64_t)t0 + (int64_t)dt;
+	int64_t reftime = (int64_t)aT0 + (int64_t)aDt;
 	int64_t delta = -k_uptime_delta(&reftime);
 
 	if (delta > 0) {
-		k_timer_start(&ot_timer, K_MSEC(delta), K_NO_WAIT);
+		k_timer_start(&ot_ms_timer, K_MSEC(delta), K_NO_WAIT);
 	} else {
-		ot_timer_fired(NULL);
+		ot_timer_ms_fired(NULL);
 	}
 }
 
@@ -61,14 +85,32 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);
 
-	k_timer_stop(&ot_timer);
+	k_timer_stop(&ot_ms_timer);
 }
 
-
-void platformAlarmProcess(otInstance *aInstance)
+void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
-	if (timer_fired) {
-		timer_fired = false;
-		otPlatAlarmMilliFired(aInstance);
+	ARG_UNUSED(aInstance);
+
+	uint64_t reftime = aT0 + aDt;
+	uint64_t curtime = k_ticks_to_us_floor64(k_uptime_ticks());
+	int64_t delta = reftime - curtime;
+
+	if (delta > 0) {
+		k_timer_start(&ot_us_timer, K_USEC(delta), K_NO_WAIT);
+	} else {
+		ot_timer_us_fired(NULL);
 	}
+}
+
+void otPlatAlarmMicroStop(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+
+	k_timer_stop(&ot_us_timer);
+}
+
+uint32_t otPlatAlarmMicroGetNow(void)
+{
+	return (uint32_t)k_ticks_to_us_floor64(k_uptime_ticks());
 }

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -98,11 +98,11 @@
  * in platform.
  *
  */
-#ifdef CONFIG_OPENTHREAD_PLATFORM_USEC_TIMER_ENABLE
-#define OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE 1
-#endif
+#define OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE                           \
+	(OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE &&                          \
+	 (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2))
 
-/* Zephyr does not use OpenThreads heap. mbedTLS will use heap memory allocated
+/* Zephyr does not use OpenThread's heap. mbedTLS will use heap memory allocated
  * by Zephyr. Here, we use some dummy values to prevent OpenThread warnings.
  */
 


### PR DESCRIPTION
Add OpenThread API to handle microseconds timer, to be used initially by CSL receiver.

`CONFIG_OPENTHREAD_PLATFORM_USEC_TIMER_ENABLE` is removed and microseconds timer enabling is tied now to the functionalities that use it (currently CSL receiver)

The attached patch can be used to verify the correctness of the new API. It just substitutes the milliseconds timer API implementation by microseconds timer calls.

[timer_replace_patch.txt](https://github.com/zephyrproject-rtos/zephyr/files/6295784/timer_replace_patch.txt)


Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>