### PR TITLE
Bluetooth: Shell: ISO: Broadcast use correct bis_tx_pool

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -327,7 +327,7 @@ static int cmd_broadcast(const struct shell *shell, size_t argc, char *argv[])
 
 	while (count--) {
 		for (int i = 0; i < BIS_ISO_CHAN_COUNT; i++) {
-			buf = net_buf_alloc(&tx_pool, K_FOREVER);
+			buf = net_buf_alloc(&bis_tx_pool, K_FOREVER);
 			net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 			net_buf_add_mem(buf, buf_data, len);


### PR DESCRIPTION
When broadcasting with ISO it would wrongly use the tx_pool defined for CIS, instead of the broadcast TX pool.