### PR TITLE
dts: Add description of reg

### DIFF
--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -10,5 +10,6 @@ on-bus: i2c
 properties:
     reg:
       required: true
+      description: device address on i2c bus
     label:
       required: true


### PR DESCRIPTION
For i2c-devices, reg is the address. This took me way to long to
discover and I wanted to leave a breadcrumb for the next Zephyr newbie.

Signed-off-by: Jeremy Bettis <jbettis@chromium.org>