### PR TITLE
arm64: gic: Enable access to ICC_* registers

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -87,6 +87,13 @@ void z_arm64_el3_init(void)
 		SCR_SMD_BIT);		/* Do not trap SMC */
 	write_scr_el3(reg);
 
+#if defined(CONFIG_GIC_V3)
+	reg = read_sysreg(ICC_SRE_EL3);
+	reg = (ICC_SRE_ELx_SRE_BIT |	/* System register interface is used */
+	       ICC_SRE_EL3_EN_BIT);	/* Enables lower Exception level access to ICC_SRE_EL1 */
+	write_sysreg(reg, ICC_SRE_EL3);
+#endif
+
 	z_arm64_el3_plat_init();
 
 	isb();


### PR DESCRIPTION
Thi GICv3 driver is configuring the controller accessing the system
registers ICC_*. To be able to do that without trapping we have to
explicitly set at boot in EL3 the value of the ICC_SRE_EL3 register that
is architecturally set to UNKNOWN value on warm reset.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>