### PR TITLE
Fix the uart_ns16550.c buffer underflow issue. 

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -339,7 +339,7 @@ static int uart_ns16550_configure(const struct device *dev,
 {
 	struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
 	const struct uart_ns16550_device_config * const dev_cfg = DEV_CFG(dev);
-
+	uint8_t lcr_cache;
 	uint8_t mdc = 0U;
 
 	/* temp for return value if error occurs in this locked region */
@@ -466,7 +466,10 @@ static int uart_ns16550_configure(const struct device *dev,
 		);
 
 	/* clear the port */
+	lcr_cache = INBYTE(LCR(dev));
+	OUTBYTE(LCR(dev), LCR_DLAB | lcr_cache);
 	INBYTE(RDR(dev));
+	OUTBYTE(LCR(dev), lcr_cache);
 
 	/* disable interrupts  */
 	OUTBYTE(IER(dev), 0x00);


### PR DESCRIPTION
driver: serial: uart_ns16550: fixed the buffer underflow issue when clearing the port. 

To clear the port by reading the RDR register, the DLAB bit should be set, otherwise, the Synopsys UART IP reports a buffer underflow error.

Signed-off-by: Li, Peng <lipengit@gmail.com>

Fixes #34234