### PR TITLE
Pwm api introduce PWM_FORCE_UPDATE flag

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -254,6 +254,9 @@ static int pwm_stm32_pin_set(const struct device *dev, uint32_t pwm,
 		LL_TIM_OC_SetPolarity(cfg->timer, channel, get_polarity(flags));
 		set_timer_compare[pwm - 1u](cfg->timer, pulse_cycles);
 		LL_TIM_SetAutoReload(cfg->timer, period_cycles - 1u);
+		if (flags & PWM_FORCE_UPDATE) {
+			LL_TIM_GenerateEvent_UPDATE(cfg->timer);
+		}
 	}
 
 	return 0;

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -42,6 +42,8 @@ extern "C" {
 #define PWM_CAPTURE_TYPE_MASK		(3U << PWM_CAPTURE_TYPE_SHIFT)
 #define PWM_CAPTURE_MODE_SHIFT		3U
 #define PWM_CAPTURE_MODE_MASK		(1U << PWM_CAPTURE_MODE_SHIFT)
+#define PWM_FORCE_UPDATE_SHIFT		4U
+#define PWM_FORCE_UPDATE_MASK		(1U << PWM_FORCE_UPDATE_SHIFT)
 /** @endcond */
 
 /** PWM pin capture captures period. */
@@ -59,6 +61,12 @@ extern "C" {
 
 /** PWM pin capture captures period/pulse width continuously. */
 #define PWM_CAPTURE_MODE_CONTINUOUS	(1U << PWM_CAPTURE_MODE_SHIFT)
+
+/**
+ * PWM pin force update applies pin configuration immediately, this
+ * may reset the timer counter register.
+ */
+#define PWM_FORCE_UPDATE		(1U << PWM_FORCE_UPDATE_SHIFT)
 
 /** @} */
 

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -51,14 +51,14 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 		TC_PRINT("Testing PWM capture @ %u/%u nsec\n",
 			 pulse, period);
 		err = pwm_pin_set_nsec(out.dev, out.pwm, period,
-				       pulse, out.flags);
+				       pulse, out.flags | PWM_FORCE_UPDATE);
 		break;
 
 	case TEST_PWM_UNIT_USEC:
 		TC_PRINT("Testing PWM capture @ %u/%u usec\n",
 			 pulse, period);
 		err = pwm_pin_set_usec(out.dev, out.pwm, period,
-				       pulse, out.flags);
+				       pulse, out.flags | PWM_FORCE_UPDATE);
 		break;
 
 	default:
@@ -170,7 +170,8 @@ void test_capture_timeout(void)
 
 	get_test_pwms(&out, &in);
 
-	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
+	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0,
+				 out.flags | PWM_FORCE_UPDATE);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
 	err = pwm_pin_capture_cycles(in.dev, in.pwm,
@@ -243,7 +244,7 @@ void test_continuous_capture(void)
 	k_sem_init(&data.sem, 0, 1);
 
 	err = pwm_pin_set_usec(out.dev, out.pwm, period_usec, pulse_usec,
-			       out.flags);
+			       out.flags | PWM_FORCE_UPDATE);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
 	err = pwm_pin_configure_capture(in.dev, in.pwm,
@@ -310,7 +311,8 @@ void test_capture_busy(void)
 	memset(buffer, 0, sizeof(buffer));
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
+	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0,
+			out.flags | PWM_FORCE_UPDATE);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
 	err = pwm_pin_configure_capture(in.dev, in.pwm,


### PR DESCRIPTION
This pr introduces the PWM_FORCE_UPDATE flag.
The stm32 driver is updated to use this flag in the pin_set function
and the looopback test are updated to pass this flag to the pin_set functions.

The PWM_FORCE_UPDATE flag enforces that the new parameters are immediately applied.
This can be necessary when the applied pwm period is significantly
shorter than the time after which the timer overflows.
One case where this can be problematic is when the current counter is higher
than the new period. Here the new parameters won't have effect until the
timer has overflown.

I have started working on a pwm capture driver for stm32, but a few tests fail because, the pulse/period are already measured before they are applied to the output, which can lead to a wrong measurement or a capture timeout.

**Alternatives I have considered**
Instead of introducing a new flag to enforce the update, change the driver to force an update each time the period is changed.
