### PR TITLE
drivers: modem: BG9X wait for RDY instead of polling AT

### DIFF
--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -40,7 +40,7 @@
 #define MDM_WAIT_FOR_RSSI_COUNT		  10
 #define MDM_WAIT_FOR_RSSI_DELAY		  K_SECONDS(2)
 #define BUF_ALLOC_TIMEOUT		  K_SECONDS(1)
-#define MDM_MAX_AT_RETRIES		  50
+#define MDM_MAX_BOOT_TIME		  K_SECONDS(50)
 
 /* Default lengths of certain things. */
 #define MDM_MANUFACTURER_LENGTH		  10


### PR DESCRIPTION
BG9X modem sends 'RDY' to indicate that the initialization is successful. We can use that instead of polling 'AT' command.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>