### PR TITLE
net: openthread: switch radio off when stopping diags

### DIFF
--- a/subsys/net/lib/openthread/platform/diag.c
+++ b/subsys/net/lib/openthread/platform/diag.c
@@ -34,6 +34,10 @@ otError otPlatDiagProcess(otInstance *aInstance,
 void otPlatDiagModeSet(bool aMode)
 {
 	sDiagMode = aMode;
+
+	if (!sDiagMode) {
+		otPlatRadioSleep(NULL);
+	}
 }
 
 bool otPlatDiagModeGet(void)


### PR DESCRIPTION
This commit puts the radio in sleep mode when the diagnostics are stopped.

This fixes an assert on MAC code when `ot diag stop` command is issued while `ot diag send` is still ongoing.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>