### PR TITLE
drivers: i2s: Introduce I2S_DIR_BOTH and add missing const qualifiers

### DIFF
--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -642,6 +642,10 @@ static int i2s_cavs_trigger(const struct device *dev, enum i2s_dir dir,
 	unsigned int key;
 	int ret = 0;
 
+	if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
+	}
+
 	strm = (dir == I2S_DIR_TX) ? &dev_data->tx : &dev_data->rx;
 
 	key = irq_lock();

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -227,7 +227,7 @@ static void i2s_dma_rx_callback(const struct device *dma_dev, void *arg,
 }
 
 static int i2s_cavs_configure(const struct device *dev, enum i2s_dir dir,
-			      struct i2s_config *i2s_cfg)
+			      const struct i2s_config *i2s_cfg)
 {
 	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
 	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);

--- a/drivers/i2s/i2s_common.c
+++ b/drivers/i2s/i2s_common.c
@@ -16,8 +16,9 @@ int z_impl_i2s_buf_read(const struct device *dev, void *buf, size_t *size)
 	ret = i2s_read((const struct device *)dev, &mem_block, size);
 
 	if (!ret) {
-		struct i2s_config *rx_cfg =
-			i2s_config_get((const struct device *)dev, I2S_DIR_RX);
+		const struct i2s_config *rx_cfg;
+
+		rx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_RX);
 
 		memcpy(buf, mem_block, *size);
 		k_mem_slab_free(rx_cfg->mem_slab, &mem_block);
@@ -29,7 +30,7 @@ int z_impl_i2s_buf_read(const struct device *dev, void *buf, size_t *size)
 int z_impl_i2s_buf_write(const struct device *dev, void *buf, size_t size)
 {
 	int ret;
-	struct i2s_config *tx_cfg;
+	const struct i2s_config *tx_cfg;
 	void *mem_block;
 
 	tx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_TX);

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -11,7 +11,7 @@
 
 static inline int z_vrfy_i2s_configure(const struct device *dev,
 				       enum i2s_dir dir,
-				       struct i2s_config *cfg_ptr)
+				       const struct i2s_config *cfg_ptr)
 {
 	struct i2s_config config;
 	int ret = -EINVAL;
@@ -20,7 +20,7 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 		goto out;
 	}
 
-	Z_OOPS(z_user_from_copy(&config, (void *)cfg_ptr,
+	Z_OOPS(z_user_from_copy(&config, (const void *)cfg_ptr,
 				sizeof(struct i2s_config)));
 
 	/* Check that the k_mem_slab provided is a valid pointer and that
@@ -55,14 +55,13 @@ static inline int z_vrfy_i2s_buf_read(const struct device *dev,
 	ret = i2s_read((const struct device *)dev, &mem_block, &data_size);
 
 	if (!ret) {
-		struct i2s_config *rx_cfg;
+		const struct i2s_config *rx_cfg;
 		int copy_success;
 
 		/* Presumed to be configured otherwise the i2s_read() call
 		 * would have failed.
 		 */
-		rx_cfg = i2s_config_get((const struct device *)dev,
-					I2S_DIR_RX);
+		rx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_RX);
 
 		copy_success = z_user_to_copy((void *)buf, mem_block,
 					      data_size);
@@ -81,7 +80,7 @@ static inline int z_vrfy_i2s_buf_write(const struct device *dev,
 				       void *buf, size_t size)
 {
 	int ret;
-	struct i2s_config *tx_cfg;
+	const struct i2s_config *tx_cfg;
 	void *mem_block;
 
 	Z_OOPS(Z_SYSCALL_DRIVER_I2S(dev, write));

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -351,6 +351,8 @@ static int i2s_litex_configure(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->tx;
 		channels_concatenated = litex_read8(I2S_TX_STATUS_REG) &
 					I2S_TX_STAT_CHANNEL_CONCATENATED_MASK;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("either RX or TX direction must be selected");
 		return -EINVAL;
@@ -498,6 +500,8 @@ static int i2s_litex_trigger(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("either RX or TX direction must be selected");
 		return -EINVAL;

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -334,7 +334,7 @@ static int i2s_litex_initialize(const struct device *dev)
 }
 
 static int i2s_litex_configure(const struct device *dev, enum i2s_dir dir,
-			       struct i2s_config *i2s_cfg)
+			       const struct i2s_config *i2s_cfg)
 {
 	struct i2s_litex_data *const dev_data = DEV_DATA(dev);
 	const struct i2s_litex_cfg *const cfg = DEV_CFG(dev);
@@ -393,7 +393,9 @@ static int i2s_litex_configure(const struct device *dev, enum i2s_dir dir,
 			"only %"
 			"i bytes of data are valid ",
 			req_buf_s);
-		i2s_cfg->block_size = req_buf_s;
+		/* The block_size field will be corrected to req_buf_s in the
+		 * structure copied as stream configuration (see below).
+		 */
 	}
 
 	int dev_sample_width = i2s_get_sample_width(cfg->base);
@@ -434,6 +436,8 @@ static int i2s_litex_configure(const struct device *dev, enum i2s_dir dir,
 #endif
 
 	memcpy(&stream->cfg, i2s_cfg, sizeof(struct i2s_config));
+	stream->cfg.block_size = req_buf_s;
+
 	stream->state = I2S_STATE_READY;
 	return 0;
 }

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -193,6 +193,8 @@ static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;
@@ -296,6 +298,8 @@ static int i2s_stm32_trigger(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -181,7 +181,7 @@ static int i2s_stm32_set_clock(const struct device *dev,
 }
 
 static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
-			       struct i2s_config *i2s_cfg)
+			       const struct i2s_config *i2s_cfg)
 {
 	const struct i2s_stm32_cfg *const cfg = DEV_CFG(dev);
 	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -48,7 +48,7 @@ struct i2s_mcux_data {
 
 static int i2s_mcux_flexcomm_cfg_convert(uint32_t base_frequency,
 					 enum i2s_dir dir,
-					 struct i2s_config *i2s_cfg,
+					 const struct i2s_config *i2s_cfg,
 					 i2s_config_t *fsl_cfg)
 {
 	if (dir == I2S_DIR_RX) {
@@ -149,8 +149,8 @@ static int i2s_mcux_flexcomm_cfg_convert(uint32_t base_frequency,
 	return 0;
 }
 
-static struct i2s_config *i2s_mcux_config_get(const struct device *dev,
-				enum i2s_dir dir)
+static const struct i2s_config *i2s_mcux_config_get(const struct device *dev,
+						    enum i2s_dir dir)
 {
 	struct i2s_mcux_data *dev_data = dev->data;
 	struct stream *stream;
@@ -169,7 +169,7 @@ static struct i2s_config *i2s_mcux_config_get(const struct device *dev,
 }
 
 static int i2s_mcux_configure(const struct device *dev, enum i2s_dir dir,
-			       struct i2s_config *i2s_cfg)
+			      const struct i2s_config *i2s_cfg)
 {
 	const struct i2s_mcux_config *cfg = dev->config;
 	struct i2s_mcux_data *dev_data = dev->data;

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -185,6 +185,8 @@ static int i2s_mcux_configure(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;
@@ -643,6 +645,8 @@ static int i2s_mcux_trigger(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -551,6 +551,8 @@ static int i2s_sam_configure(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;
@@ -763,6 +765,8 @@ static int i2s_sam_trigger(const struct device *dev, enum i2s_dir dir,
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
+	} else if (dir == I2S_DIR_BOTH) {
+		return -ENOSYS;
 	} else {
 		LOG_ERR("Either RX or TX direction must be selected");
 		return -EINVAL;

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -311,7 +311,7 @@ tx_disable:
 }
 
 static int set_rx_data_format(const struct i2s_sam_dev_cfg *const dev_cfg,
-			      struct i2s_config *i2s_cfg)
+			      const struct i2s_config *i2s_cfg)
 {
 	Ssc *const ssc = dev_cfg->regs;
 	const bool pin_rk_en = IS_ENABLED(CONFIG_I2S_SAM_SSC_0_PIN_RK_EN);
@@ -404,7 +404,7 @@ static int set_rx_data_format(const struct i2s_sam_dev_cfg *const dev_cfg,
 }
 
 static int set_tx_data_format(const struct i2s_sam_dev_cfg *const dev_cfg,
-			      struct i2s_config *i2s_cfg)
+			      const struct i2s_config *i2s_cfg)
 {
 	Ssc *const ssc = dev_cfg->regs;
 	uint8_t word_size_bits = i2s_cfg->word_size;
@@ -515,8 +515,8 @@ static int bit_clock_set(Ssc *const ssc, uint32_t bit_clk_freq)
 	return 0;
 }
 
-static struct i2s_config *i2s_sam_config_get(const struct device *dev,
-					     enum i2s_dir dir)
+static const struct i2s_config *i2s_sam_config_get(const struct device *dev,
+						   enum i2s_dir dir)
 {
 	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);
 	struct stream *stream;
@@ -535,7 +535,7 @@ static struct i2s_config *i2s_sam_config_get(const struct device *dev,
 }
 
 static int i2s_sam_configure(const struct device *dev, enum i2s_dir dir,
-			     struct i2s_config *i2s_cfg)
+			     const struct i2s_config *i2s_cfg)
 {
 	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
 	struct i2s_sam_dev_data *const dev_data = DEV_DATA(dev);

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -316,9 +316,9 @@ struct i2s_config {
  */
 __subsystem struct i2s_driver_api {
 	int (*configure)(const struct device *dev, enum i2s_dir dir,
-			 struct i2s_config *cfg);
-	struct i2s_config *(*config_get)(const struct device *dev,
-					 enum i2s_dir dir);
+			 const struct i2s_config *cfg);
+	const struct i2s_config *(*config_get)(const struct device *dev,
+				  enum i2s_dir dir);
 	int (*read)(const struct device *dev, void **mem_block, size_t *size);
 	int (*write)(const struct device *dev, void *mem_block, size_t size);
 	int (*trigger)(const struct device *dev, enum i2s_dir dir,
@@ -351,11 +351,11 @@ __subsystem struct i2s_driver_api {
  * @retval -ENOSYS I2S_DIR_BOTH value is not supported.
  */
 __syscall int i2s_configure(const struct device *dev, enum i2s_dir dir,
-			    struct i2s_config *cfg);
+			    const struct i2s_config *cfg);
 
 static inline int z_impl_i2s_configure(const struct device *dev,
 				       enum i2s_dir dir,
-				       struct i2s_config *cfg)
+				       const struct i2s_config *cfg)
 {
 	const struct i2s_driver_api *api =
 		(const struct i2s_driver_api *)dev->api;
@@ -371,8 +371,8 @@ static inline int z_impl_i2s_configure(const struct device *dev,
  * @retval Pointer to the structure containing configuration parameters,
  *         or NULL if un-configured
  */
-static inline struct i2s_config *i2s_config_get(const struct device *dev,
-						enum i2s_dir dir)
+static inline const struct i2s_config *i2s_config_get(const struct device *dev,
+						      enum i2s_dir dir)
 {
 	const struct i2s_driver_api *api =
 		(const struct i2s_driver_api *)dev->api;

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -207,6 +207,8 @@ enum i2s_dir {
 	I2S_DIR_RX,
 	/** Transmit data */
 	I2S_DIR_TX,
+	/** Both receive and transmit data */
+	I2S_DIR_BOTH,
 };
 
 /** Interface state */
@@ -339,11 +341,14 @@ __subsystem struct i2s_driver_api {
  * the interface state will be changed to NOT_READY.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param dir Stream direction: RX or TX as defined by I2S_DIR_*
+ * @param dir Stream direction: RX, TX, or both, as defined by I2S_DIR_*.
+ *            The I2S_DIR_BOTH value may not be supported by some drivers.
+ *            For those, the RX and TX streams need to be configured separately.
  * @param cfg Pointer to the structure containing configuration parameters.
  *
  * @retval 0 If successful.
  * @retval -EINVAL Invalid argument.
+ * @retval -ENOSYS I2S_DIR_BOTH value is not supported.
  */
 __syscall int i2s_configure(const struct device *dev, enum i2s_dir dir,
 			    struct i2s_config *cfg);
@@ -501,7 +506,10 @@ __syscall int i2s_buf_write(const struct device *dev, void *buf, size_t size);
  * @brief Send a trigger command.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param dir Stream direction: RX or TX.
+ * @param dir Stream direction: RX, TX, or both, as defined by I2S_DIR_*.
+ *            The I2S_DIR_BOTH value may not be supported by some drivers.
+ *            For those, triggering need to be done separately for the RX
+ *            and TX streams.
  * @param cmd Trigger command.
  *
  * @retval 0 If successful.
@@ -509,6 +517,7 @@ __syscall int i2s_buf_write(const struct device *dev, void *buf, size_t size);
  * @retval -EIO The trigger cannot be executed in the current state or a DMA
  *         channel cannot be allocated.
  * @retval -ENOMEM RX/TX memory block not available.
+ * @retval -ENOSYS I2S_DIR_BOTH value is not supported.
  */
 __syscall int i2s_trigger(const struct device *dev, enum i2s_dir dir,
 			  enum i2s_trigger_cmd cmd);


### PR DESCRIPTION
Introduce a new enumeration value that allows setting configuration
and triggering commands for both I2S streams simultaneously.
Such possibility is especially important on hardware where the streams
can be only enabled/disabled (but not started/stopped) independently,
like it is in nRF SoCs.

The i2s_config structure passed to the i2s_configure() function is
not supposed to be modified by the driver. Similarly, the structure
returned by the i2s_config_get() function is not supposed to be
modified outside the driver.
Decorate the pointers to those structures with the const qualifier
and correct one driver that actually modified the structure passed
to i2s_configure().