### PR TITLE
board: arm64: Add FVP Base RevC 2xAEMv8A board

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,7 @@
 /soc/arm64/nxp_layerscape/                @JiafeiPan
 /soc/arm64/xenvm/                         @lorc
 /soc/arm64/arm/                           @povergoing
+/soc/arm64/arm/fvp_aemv8a/                @carlocaione
 /arch/x86/                                @jhedberg @nashif @jenmwms @aasthagr
 /arch/nios2/                              @nashif
 /arch/posix/                              @aescolar @daor-oti
@@ -154,6 +155,7 @@
 /boards/arm64/nxp_ls1046ardb/             @JiafeiPan
 /boards/arm64/xenvm/                      @lorc
 /boards/arm64/fvp_baser_aemv8r/           @povergoing
+/boards/arm64/fvp_base_revc_2xaemv8a/     @carlocaione
 # All cmake related files
 /cmake/                                   @tejlmand @nashif
 /cmake/*/arcmwdt/                         @abrodkin @evgeniy-paltsev @tejlmand

--- a/boards/arm64/fvp_base_revc_2xaemv8a/Kconfig.board
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/Kconfig.board
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_FVP_BASE_REVC_2XAEMV8A
+	bool "FVP Base RevC AEMv8A simulation board"
+	depends on SOC_FVP_BASE_REVC_2XAEMV8A

--- a/boards/arm64/fvp_base_revc_2xaemv8a/Kconfig.defconfig
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FVP_BASE_REVC_2XAEMV8A
+
+config BUILD_OUTPUT_BIN
+	default y
+
+config BOARD
+	default "fvp_base_revc_2xaemv8a"
+
+endif # BOARD_FVP_BASE_REVC_2XAEMV8A

--- a/boards/arm64/fvp_base_revc_2xaemv8a/board.cmake
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/board.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+set(EMU_PLATFORM armfvp)
+set(ARMFVP_BIN_NAME FVP_Base_RevC-2xAEMvA)
+
+set(ARMFVP_FLAGS
+  -C bp.secure_memory=0
+  -C cluster0.NUM_CORES=1
+  -C bp.refcounter.non_arch_start_at_default=1
+  -C bp.pl011_uart0.out_file=-
+  -C bp.pl011_uart0.unbuffered_output=1
+  -C bp.terminal_0.start_telnet=0
+  -C bp.vis.disable_visualisation=1
+  -C bp.vis.rate_limit-enable=0
+  -C gic_distributor.ARE-fixed-to-one=1
+  )

--- a/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
@@ -1,0 +1,87 @@
+.. _fvp_base_revc_2xaemv8a:
+
+ARM BASE RevC AEMv8A Fixed Virtual Platforms
+############################################
+
+Overview
+********
+
+This board configuration will use ARM Fixed Virtual Platforms(FVP) to emulate
+a generic Armv8-A 64-bit hardware platform.
+
+This configuration provides support for a generic Armv8-A 64-bit CPU and
+these devices:
+
+* GICv3 interrupt controller
+* ARM architected (Generic) timer
+* PL011 UART controller
+
+Hardware
+********
+
+Supported Features
+==================
+
+The following hardware features are supported:
+
++-----------------------+------------+----------------------+
+| Interface             | Controller | Driver/Component     |
++=======================+============+======================+
+| GICv3                 | on-chip    | interrupt controller |
++-----------------------+------------+----------------------+
+| PL011 UART            | on-chip    | serial port          |
++-----------------------+------------+----------------------+
+| ARM GENERIC TIMER     | on-chip    | system clock         |
++-----------------------+------------+----------------------+
+
+The kernel currently does not support other hardware features on this platform.
+
+Devices
+========
+
+System Clock
+------------
+
+This board configuration uses a system clock frequency of 100 MHz.
+
+Serial Port
+-----------
+
+This board configuration uses a single serial communication channel with the
+UART0.
+
+Known Problems or Limitations
+==============================
+
+Programming and Debugging
+*************************
+
+Use this configuration to build basic Zephyr applications and kernel tests in the
+ARM FVP emulated environment, for example, with the :ref:`synchronization_sample`:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: fvp_base_revc_2xaemv8a
+   :goals: build
+
+This will build an image with the synchronization sample app.
+
+To run with FVP, ARMFVP_BIN_PATH must be set before running:
+
+e.g. export ARMFVP_BIN_PATH=<path/to/fvp/dir>
+
+Debugging
+=========
+
+Refer to the detailed overview about :ref:`application_debugging`.
+
+Networking
+==========
+
+References
+**********
+
+1. (ID070919) Arm® Architecture Reference Manual - Armv8, for Armv8-A architecture profile
+2. AArch64 Exception and Interrupt Handling
+3. https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <mem.h>
+#include <arm64/armv8-a.dtsi>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	model = "FVP Base RevC 2xAEMv8A";
+
+	chosen {
+		/*
+		 * The SRAM node is actually located in the
+		 * DRAM region of the FVP Base RevC 2xAEMv8A.
+		 */
+		zephyr,sram = &dram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0>;
+		};
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		label = "arch_timer";
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	soc {
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@2f000000 {
+			compatible = "arm,gic";
+			reg = <0x2f000000 0x10000>, // GICD
+			      <0x2f100000 0x200000>; // GICR
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			label = "GIC";
+			status = "okay";
+		};
+
+		uart0: uart@1c090000 {
+			compatible = "arm,pl011";
+			reg = <0x1c090000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 1 0 IRQ_TYPE_LEVEL>;
+			interrupt-names = "irq_0";
+			label = "UART_0";
+			clocks = <&uartclk>;
+		};
+
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		dram0: memory@88000000 {
+			compatible = "mmio-dram";
+			reg = <0x88000000 DT_SIZE_K(2048)>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+};

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: fvp_base_revc_2xaemv8a
+name: FVP Emulation FVP_Base_RevC-2xAEMvA
+arch: arm64
+type: sim
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 2048
+flash: 64

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_defconfig
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_defconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_FVP_AEMV8A=y
+CONFIG_SOC_FVP_BASE_REVC_2XAEMV8A=y
+CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A=y
+
+CONFIG_XIP=n
+
+CONFIG_THREAD_STACK_INFO=y
+
+# Enable Timer and Sys clock
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+CONFIG_ARM_ARCH_TIMER=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable serial port
+CONFIG_UART_PL011=y
+CONFIG_UART_PL011_PORT0=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
@@ -10,5 +10,3 @@ toolchain:
   - cross-compile
 ram: 2048
 flash: 64
-testing:
-  default: true

--- a/soc/arm64/arm/fvp_aemv8a/CMakeLists.txt
+++ b/soc/arm64/arm/fvp_aemv8a/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)

--- a/soc/arm64/arm/fvp_aemv8a/Kconfig.defconfig.series
+++ b/soc/arm64/arm/fvp_aemv8a/Kconfig.defconfig.series
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_FVP_AEMV8A
+
+config SOC_SERIES
+	default "fvp_aemv8a"
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 100000000
+
+config NUM_IRQS
+	default 128
+
+if SOC_FVP_BASE_REVC_2XAEMV8A
+
+config SOC
+	default "fvp_base_revc_2xaemv8a"
+
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+endif # SOC_FVP_BASE_REVC_2XAEMV8A
+
+endif # SOC_SERIES_FVP_AEMV8A

--- a/soc/arm64/arm/fvp_aemv8a/Kconfig.series
+++ b/soc/arm64/arm/fvp_aemv8a/Kconfig.series
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_FVP_AEMV8A
+	bool "ARM FVP AEMv8A AArch64 Series"
+	select ARM64
+	select SOC_FAMILY_ARM64
+	help
+	  Enable support for ARM FVP AEMv8A AArch64 Series

--- a/soc/arm64/arm/fvp_aemv8a/Kconfig.soc
+++ b/soc/arm64/arm/fvp_aemv8a/Kconfig.soc
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+choice
+	prompt "ARM FVP AEMv8A AArch64 SoCs"
+	depends on SOC_SERIES_FVP_AEMV8A
+
+config SOC_FVP_BASE_REVC_2XAEMV8A
+	bool "ARM FVP Base RevC 2xAEMv8A AArch64 simulation"
+	select CPU_CORTEX_A53
+	select GIC_V3
+
+endchoice

--- a/soc/arm64/arm/fvp_aemv8a/linker.ld
+++ b/soc/arm64/arm/fvp_aemv8a/linker.ld
@@ -1,0 +1,8 @@
+/*
+ * linker.ld - Linker command/script file
+ *
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arch/arm64/scripts/linker.ld>

--- a/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <soc.h>
+#include <arch/arm64/arm_mmu.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("UART",
+			      DT_REG_ADDR(DT_INST(0, arm_pl011)),
+			      DT_REG_SIZE(DT_INST(0, arm_pl011)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/arm64/arm/fvp_aemv8a/soc.h
+++ b/soc/arm64/arm/fvp_aemv8a/soc.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _SOC_H_
+#define _SOC_H_
+
+#include <sys/util.h>
+
+#ifndef _ASMLANGUAGE
+
+#include <device.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* _SOC_H_ */


### PR DESCRIPTION
This PR depends on #34230

Leveraging the work done by @povergoing in #33905 I'm introducing here the FVP Base RevC 2xAEMv8A board. This is basically a virtual platform configured to be the FVP equivalent of the Cortex-A53 QEMU virt board.

This is the twister output when running Zephyr on FVP_Base_RevC-2xAEMvA_11.14_21

```
╰─❯ ./scripts/twister -p fvp_base_revc_2xaemv8a                                                                            
                                                                                                                                      
INFO    - Zephyr version: zephyr-v2.5.0-2188-g0fd6ecf117b8                                                
INFO    - JOBS: 8                                                                                                                                                                                                    
INFO    - Using 'zephyr' toolchain.                                                                                                                                                                                  
INFO    - Building initial testcase list...                                                               
INFO    - 1196 test scenarios (1141 configurations) selected, 885 configurations discarded due to filters.                                                                                                           
INFO    - Adding tasks to the queue...                                                                                                                                                                               
INFO    - Added initial list of jobs to queue                                                             
INFO    - Total complete:  256/ 256  100%  skipped:  933, failed:    0
INFO    - 208 of 208 test configurations passed (100.00%), 0 failed, 933 skipped with 0 warnings in 522.55 seconds
INFO    - In total 1683 test cases were executed, 8170 skipped on 1 out of total 344 platforms (0.29%)    
INFO    - 0 test configurations executed on platforms, 208 test configurations were only built.           
```

Using:
```
╰─❯ ./FVP_Base_RevC-2xAEMvA --version

Fast Models [11.14.21 (Mar 16 2021)]
Copyright 2000-2021 ARM Limited.
All Rights Reserved.
```