### PR TITLE
cmake: allow color output from GCC/Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,17 @@ if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)
   endif()
 endif()
 
+if($ENV{ZEPHYR_BUILD_COLOR_OUTPUT})
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # Need to force color output (=always) for GCC because of
+    # output pipe used by Ninja, which is not regarded as
+    # color-capable terminal by GCC.
+    zephyr_compile_options(-fdiagnostics-color=always)
+  elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    zephyr_cc_options(-fcolor-diagnostics)
+  endif()
+endif()
+
 separate_arguments(COMPILER_OPT_AS_LIST UNIX_COMMAND ${CONFIG_COMPILER_OPT})
 zephyr_compile_options(${COMPILER_OPT_AS_LIST})
 


### PR DESCRIPTION
This enables color output from GCC and Clang if the environment
variable ZEPHYR_BUILD_COLOR_OUTPUT is set. This makes it a bit
easier to identify compilation errors.

Note that this is enabled manually rather than as default simply
to avoid complications with build systems or various tools which
may not like ANSI color tags.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>