### PR TITLE
actions: limit issue tracker to main project

### DIFF
--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -15,6 +15,7 @@ jobs:
   track-issues:
     name: "Collect Issue Stats"
     runs-on: ubuntu-latest
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
     - name: Download configuration file


### PR DESCRIPTION
Run this action only on the main zephyr tree. Do not run in forks.