### PR TITLE
net: http: add numeric http status code to response struct

### DIFF
--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -146,6 +146,11 @@ struct http_response {
 	 */
 	char http_status[HTTP_STATUS_STR_SIZE];
 
+	/** Numeric HTTP status code which corresponds to the
+	 * textual description.
+	 */
+	uint16_t http_status_code;
+
 	uint8_t cl_present : 1;
 	uint8_t body_found : 1;
 	uint8_t message_complete : 1;

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -176,6 +176,8 @@ static int on_status(struct http_parser *parser, const char *at, size_t length)
 	if (req->internal.response.http_cb &&
 	    req->internal.response.http_cb->on_status) {
 		req->internal.response.http_cb->on_status(parser, at, length);
+		req->internal.response.http_status_code =
+			(uint16_t)parser->status_code;
 	}
 
 	return 0;


### PR DESCRIPTION
Add numeric http status code to the response struct. Textual status already exists.