### PR TITLE
drivers: adc: samd5x/same5x interrupt fix

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -586,6 +586,14 @@ do {									\
 
 #endif
 
+#define ADC_SAM0_IRQ_INIT(n, name, fn) \
+	do {								\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, name, irq),		\
+			    DT_INST_IRQ_BY_NAME(n, name, priority),	\
+			    fn,	DEVICE_DT_INST_GET(n), 0);				\
+		irq_enable(DT_INST_IRQ_BY_NAME(n, name, irq));		\
+	} while (0)
+
 #define ADC_SAM0_DEVICE(n)						\
 	static void adc_sam0_config_##n(const struct device *dev);	\
 	static const struct adc_sam0_cfg adc_sam_cfg_##n = {		\
@@ -609,11 +617,9 @@ do {									\
 			    &adc_sam0_api);				\
 	static void adc_sam0_config_##n(const struct device *dev)	\
 	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n),				\
-			    DT_INST_IRQ(n, priority),			\
-			    adc_sam0_isr,				\
-			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQN(n));				\
+		COND_CODE_1(DT_INST_IRQ_HAS_NAME(n, resrdy), \
+				(ADC_SAM0_IRQ_INIT(n, resrdy, adc_sam0_isr)), \
+				(ADC_SAM0_IRQ_INIT(n, all, adc_sam0_isr))); \
 		ADC_SAM0_CONFIGURE(n);					\
 	}
 

--- a/dts/arm/atmel/samd20.dtsi
+++ b/dts/arm/atmel/samd20.dtsi
@@ -93,6 +93,7 @@
 
 &adc {
 	interrupts = <21 0>;
+	interrupt-names = "all";
 	clocks = <&gclk 0x17>, <&pm 0x20 16>;
 	clock-names = "GCLK", "PM";
 };

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -128,4 +128,5 @@
 	clocks = <&gclk 0x1e>, <&pm 0x20 16>;
 	clock-names = "GCLK", "PM";
 	interrupts = <23 0>;
+	interrupt-names = "all";
 };

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -303,6 +303,7 @@
 			compatible = "atmel,sam0-adc";
 			reg = <0x43001C00 0x4A>;
 			interrupts = <118 0>, <119 0>;
+			interrupt-names= "overrun-winmon", "resrdy";
 			label = "ADC_0";
 
 			/*
@@ -323,6 +324,7 @@
 			compatible = "atmel,sam0-adc";
 			reg = <0x43002000 0x4A>;
 			interrupts = <120 0>, <121 0>;
+			interrupt-names= "overrun-winmon", "resrdy";
 			label = "ADC_1";
 
 			/*

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -126,4 +126,5 @@
 	clocks = <&gclk 0x1e>, <&pm 0x20 16>;
 	clock-names = "GCLK", "PM";
 	interrupts = <23 0>;
+	interrupt-names = "all";
 };


### PR DESCRIPTION
The samd5x/same5x ADCs use two interrupts instead of one, and the
later is used to indicate a result. The driver didn't account for this,
using only the first. Now the correct interrupt is selected using names.

Signed-off-by: Abram Early <abram.early@gmail.com>