### PR TITLE
TF-M: Add path for MBEDCRYPTO for TF-M builds without pulling external trees

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -150,6 +150,7 @@ function(trusted_firmware_build)
                ${TFM_PROFILE_ARG}
                ${MCUBOOT_IMAGE_NUM_ARG}
                -DTFM_TEST_REPO_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/tf-m-tests
+               -DMBEDCRYPTO_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/../tfm-mbedcrypto
                -DMCUBOOT_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/../tfm-mcuboot
                ${TFM_PARTITIONS_ARGS}
     BUILD_ALWAYS True

--- a/west.yml
+++ b/west.yml
@@ -145,6 +145,10 @@ manifest:
       repo-path: mcuboot
       path: modules/tee/tfm-mcuboot
       revision: v1.7.2
+    - name: tfm-mbedcrypto # This is used by the trusted-firmware-m module.
+      repo-path: mbedtls
+      path: modules/tee/tfm-mbedcrypto
+      revision: v2.25.0
     - name: nanopb
       path: modules/lib/nanopb
       revision: d148bd26718e4c10414f07a7eb1bd24c62e56c5d


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/32252