### PR TITLE
arch: arm64: add SMP master Core support on any Core

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -785,7 +785,7 @@ static sys_slist_t domain_list;
  * This function provides the default configuration mechanism for the Memory
  * Management Unit (MMU).
  */
-void z_arm64_mmu_init(void)
+void z_arm64_mmu_init(bool is_primary_core)
 {
 	unsigned int flags = 0U;
 
@@ -801,7 +801,7 @@ void z_arm64_mmu_init(void)
 	/*
 	 * Only booting core setup up the page tables.
 	 */
-	if (IS_PRIMARY_CORE()) {
+	if (is_primary_core) {
 		kernel_ptables.base_xlat_table = new_table();
 		setup_page_tables(&kernel_ptables);
 	}

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -29,6 +29,7 @@
 #include <kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
+#include <arch/cpu.h>
 
 #ifdef CONFIG_USERSPACE
 GEN_OFFSET_SYM(_thread_arch_t, priv_stack_start);
@@ -67,6 +68,9 @@ GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a4, a4_a5);
 GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a6, a6_a7);
 
 #endif /* CONFIG_HAS_ARM_SMCCC */
+
+GEN_OFFSET_SYM(arm64_cpu_init_data_t, sp);
+GEN_OFFSET_SYM(arm64_cpu_init_data_t, mpid);
 
 GEN_ABS_SYM_END
 

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -20,9 +20,9 @@
 extern FUNC_NORETURN void z_cstart(void);
 
 #ifdef CONFIG_ARM_MMU
-extern void z_arm64_mmu_init(void);
+extern void z_arm64_mmu_init(bool is_primary_core);
 #else
-static inline void z_arm64_mmu_init(void) { }
+static inline void z_arm64_mmu_init(bool is_primary_core) { }
 #endif
 
 static inline void z_arm64_bss_zero(void)
@@ -52,7 +52,7 @@ void z_arm64_prep_c(void)
 #ifdef CONFIG_XIP
 	z_data_copy();
 #endif
-	z_arm64_mmu_init();
+	z_arm64_mmu_init(true);
 	z_arm64_interrupt_init();
 	z_cstart();
 

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -7,6 +7,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>
+#include <offsets.h>
 #include "vector_table.h"
 #include "macro_priv.inc"
 
@@ -30,6 +31,18 @@ SECTION_FUNC(TEXT,z_arm64_el2_plat_prep_c)
 WTEXT(z_arm64_el1_plat_prep_c)
 SECTION_FUNC(TEXT,z_arm64_el1_plat_prep_c)
 	ret
+
+#if CONFIG_MP_NUM_CPUS > 1
+/*
+ * Global variable secondary_core_boot:
+ * 0: is master Core booting
+ * 1: is secondary Core booting
+ */
+SECTION_VAR(DATA,secondary_core_boot)
+	.align 8
+	.long 0
+	.long 0
+#endif
 
 /*
  * Set the minimum necessary to safely call C code
@@ -76,7 +89,8 @@ out:
 	msr	SPSel, #0
 
 #if CONFIG_MP_NUM_CPUS > 1
-	get_cpu_id x0
+	adr	x0, secondary_core_boot
+	ldr	x0, [x0]
 	cbnz    x0, L_secondary_stack
 #endif
 
@@ -89,16 +103,33 @@ out:
 
 #if CONFIG_MP_NUM_CPUS > 1
 L_secondary_stack:
-	get_cpu_id x1
+	get_cpu_id x3
 	adr	x0, arm64_cpu_init
 	mov	x2, #ARM64_CPU_INIT_SIZE
-	madd	x0, x1, x2, x0
-	ldr	x0, [x0]
-	cbz	x0, L_enable_secondary
+	/* Loop and find its table */
+	mov	x1, xzr
+4:
+	madd	x4, x1, x2, x0
+	add	x4, x4, #(__arm64_cpu_init_data_t_mpid_OFFSET)
+	ldr	x4, [x4]
+	cmp	x4, x3
+	dmb	ld
+	b.eq	5f
+	add	x1, x1, #1
+	cmp	x1, #CONFIG_MP_NUM_CPUS
+	b.lt	4b
+	/* can't find related table */
+	b	L_enable_secondary
+5:
+	/* found related table */
+	madd	x4, x1, x2, x0
+	/* Get SP address */
+	add     x4, x4, #(__arm64_cpu_init_data_t_sp_OFFSET)
+	ldr	x4, [x4]
+	cbz	x4, L_enable_secondary
 	dmb	ld
 
-	mov	sp, x0
-
+	mov	sp, x4
 	ret	x23
 #endif
 
@@ -156,8 +187,17 @@ switch_el:
 	isb
 
 #if CONFIG_MP_NUM_CPUS > 1
-	get_cpu_id x0
+	adr	x0, secondary_core_boot
+	ldr	x0, [x0]
 	cbnz    x0, L_enable_secondary
+
+	/*
+	 * Is booting from master Core, change it to be "1" for all
+	 * secondary core boot.
+	 */
+	adr	x0, secondary_core_boot
+	mov	x1, #1
+	str	x1, [x0]
 #endif
 
 	b	z_arm64_prep_c

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -68,7 +68,7 @@ void z_arm64_secondary_start(void)
 	/* Initialize tpidrro_el0 with our struct _cpu instance address */
 	write_tpidrro_el0((uintptr_t)&_kernel.cpus[cpu_num]);
 
-	z_arm64_mmu_init();
+	z_arm64_mmu_init(false);
 
 #ifdef CONFIG_SMP
 	arm_gic_secondary_init();

--- a/include/arch/arm64/arm_mmu.h
+++ b/include/arch/arm64/arm_mmu.h
@@ -195,7 +195,7 @@ struct arm_mmu_ptables {
 extern const struct arm_mmu_config mmu_config;
 
 struct k_thread;
-void z_arm64_mmu_init(void);
+void z_arm64_mmu_init(bool is_primary_core);
 void z_arm64_thread_pt_init(struct k_thread *thread);
 void z_arm64_swap_ptables(struct k_thread *thread);
 

--- a/include/arch/arm64/cpu.h
+++ b/include/arch/arm64/cpu.h
@@ -207,4 +207,13 @@
 #define L1_CACHE_BYTES		BIT(L1_CACHE_SHIFT)
 #define ARM64_CPU_INIT_SIZE	L1_CACHE_BYTES
 
+#ifndef _ASMLANGUAGE
+typedef struct {
+	void *sp;
+	uint64_t mpid;
+	arch_cpustart_t fn;
+	void *arg;
+} __aligned(L1_CACHE_BYTES) arm64_cpu_init_data_t;
+#endif
+
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_CPU_H_ */


### PR DESCRIPTION
    arm64: smp: booting secondary core provided in dts

    Currently ARM64 SMP can only use physical CPU Core0 as master Core,
    and use the core1, core2 ... as secondary Cores. This patch will
    enable SMP to boot from any CPU Core which will be master Core,
    secondary Core will be specified in child node of "cpus" node in
    dts, "reg" will be hardware ID read from MPIDR, for example on one
    SoC platform which has four a72 Cores, with the following dts,
    we can kick off Zephyr to Core2 which is master Core, and Core3
    will be secondary Core:
            cpus {
                    #address-cells = <1>;
                    #size-cells = <0>;

                    cpu@0 {
                            device_type = "cpu";
                            compatible = "arm,cortex-a72";
                            reg = <2>;
                    };

                    cpu@1 {
                            device_type = "cpu";
                            compatible = "arm,cortex-a72";
                            reg = <3>;
                    };
            }
 
    Signed-off-by: Jiafei Pan <Jiafei.Pan@nxp.com>

