### PR TITLE
tests: eventfd_basic: Fix build issue

### DIFF
--- a/tests/posix/eventfd_basic/src/main.c
+++ b/tests/posix/eventfd_basic/src/main.c
@@ -7,13 +7,13 @@
 
 #include <ztest.h>
 
-#include <net/socket.h>
-
 #ifdef CONFIG_POSIX_API
 #include <sys/eventfd.h>
 #else
 #include <posix/sys/eventfd.h>
 #endif
+
+#include <net/socket.h>
 
 static void test_eventfd(void)
 {


### PR DESCRIPTION
With having CONFIG_NET_SOCKETS_POSIX_NAMES now as the default we get
a build error on frdm_kw41z with this test.

We need to include net/socket.h after eventfd.h as we redefine fcntl
in net/socket.h and thus eventfd.h (which includes fcntl.h) needs
to get included first.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>