### PR TITLE
net: telnet: Fix character mode handling

### DIFF
--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -30,7 +30,7 @@ struct shell_telnet *sh_telnet;
 #define TELNET_LINE_SIZE CONFIG_SHELL_TELNET_LINE_BUF_SIZE
 #define TELNET_TIMEOUT   CONFIG_SHELL_TELNET_SEND_TIMEOUT
 
-#define TELNET_MIN_MSG 2
+#define TELNET_MIN_COMMAND_LEN 2
 
 /* Basic TELNET implmentation. */
 
@@ -196,14 +196,12 @@ static void telnet_recv(struct net_context *client,
 	}
 
 	len = net_pkt_remaining_data(pkt);
-	if (len < TELNET_MIN_MSG) {
-		LOG_DBG("Packet smaller than minimum length");
-		goto unref;
-	}
 
-	if (telnet_handle_command(pkt)) {
-		LOG_DBG("Handled command");
-		goto unref;
+	if (len >= TELNET_MIN_COMMAND_LEN) {
+		if (telnet_handle_command(pkt)) {
+			LOG_DBG("Handled command");
+			goto unref;
+		}
 	}
 
 	/* Fifo add */


### PR DESCRIPTION
If the telnet client operates in a character mode, it may send
individual characters in packets. Such packets were dropped in the
telnet shell backend instead of being process by the shell engine.

Fixes #34197

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>