### PR TITLE
dts: virt: Move sram node to DT board files

### DIFF
--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
@@ -24,6 +24,14 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};
+
+	soc {
+		sram0: memory@40000000 {
+			compatible = "mmio-sram";
+			reg = <0x40000000 DT_SIZE_M(128)>;
+		};
+
+	};
 };
 
 &uart0 {

--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_xip.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_xip.dts
@@ -5,22 +5,4 @@
  *
  */
 
-/dts-v1/;
-#include <arm64/qemu-virt/qemu-virt-a53.dtsi>
-
-/ {
-	model = "QEMU Cortex-A53";
-	compatible = "qemu,arm-cortex-a53";
-
-	chosen {
-		zephyr,sram = &sram0;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,flash = &flash0;
-	};
-};
-
-&uart0 {
-	status = "okay";
-	current-speed = <115200>;
-};
+#include "qemu_cortex_a53.dts"

--- a/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
@@ -58,11 +58,6 @@
 	soc {
 		interrupt-parent = <&gic>;
 
-		sram0: memory@40000000 {
-			compatible = "mmio-sram";
-			reg = <0x40000000 DT_SIZE_M(128)>;
-		};
-
 		gic: interrupt-controller@8000000 {
 			compatible = "arm,gic";
 			reg = <0x8000000 0x010000>,


### PR DESCRIPTION
Currently the SRAM location is fixed for all the boards derived from qemu_cortex_a53. While this is acceptable when the image is directly loaded in SRAM by QEMU, in some cases Zephyr can be loaded in RAM by another piece of software or by semihosting at a different address before jumping into it.

When for example TF-A is used and Zephyr is run as BL33 payload using QEMU, in this case the default location in RAM is at a different address (when preloaded BL33 base address is not used).

To address these cases, move the SRAM location into the board-specific DTS so that it can be adjusted on a board by board basis.

More details:

I'm working on having Zephyr running as BL33 payload for TF-A. When using the standard QEMU platform in TF-A the BL33 is supposed to be at `0x60000000`. While this problem can be probably solved in a different way (using `PRELOADED_BL33_BASE` in TF-A and in some smart way in Zephyr I guess) the one proposed here is a painless solution because we can define new boards with the SRAM mapping at a different address.