### PR TITLE
twister: Fix ram/rom reporting

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3651,14 +3651,15 @@ class TestSuite(DisablePyTestCollectionMixin):
                                 "arch": instance.platform.arch,
                                 "platform": p,
                                 }
+                    if ram_size:
+                        testcase["ram_size"] = ram_size
+                    if rom_size:
+                        testcase["rom_size"] = rom_size
+
                     if instance.results[k] in ["PASS"]:
                         testcase["status"] = "passed"
                         if instance.handler:
                             testcase["execution_time"] =  handler_time
-                        if ram_size:
-                            testcase["ram_size"] = ram_size
-                        if rom_size:
-                            testcase["rom_size"] = rom_size
 
                     elif instance.results[k] in ['FAIL', 'BLOCK'] or instance.status in ["error", "failed", "timeout"]:
                         testcase["status"] = "failed"

--- a/scripts/twister
+++ b/scripts/twister
@@ -1215,6 +1215,7 @@ def main():
             except queue.Empty:
                 break
             else:
+                inst.metrics.update(suite.instances[inst.name].metrics)
                 inst.metrics["handler_time"] = inst.handler.duration if inst.handler else 0
                 inst.metrics["unrecognized"] = []
                 suite.instances[inst.name] = inst


### PR DESCRIPTION
The info of rom/ram usage by an application was lost along the
way of data processing in twister. The PR add a line which
pass further these metrices as well.
In addition a logic for memory footprint reporting is fixed. 
With the previous logic memory footprint can only be saved in a report
if a given test/sample was fully executed and passed (built and run),
hence build-only tests were not providing these metrics. This PR
modifies the logic so that it is enough to have the build successful
to be able to get the memory footprint.

Fixes #34272

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>