### PR TITLE
usb: conversion of k_work API

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1915,10 +1915,10 @@ static int usb_init(const struct device *arg)
 	(void)nrfx_power_init(&power_config);
 	nrfx_power_usbevt_init(&usbevt_config);
 
-	k_work_q_start(&usbd_work_queue,
-		usbd_work_queue_stack,
-		K_KERNEL_STACK_SIZEOF(usbd_work_queue_stack),
-		CONFIG_SYSTEM_WORKQUEUE_PRIORITY);
+	k_work_queue_start(&usbd_work_queue,
+			   usbd_work_queue_stack,
+			   K_KERNEL_STACK_SIZEOF(usbd_work_queue_stack),
+			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
 
 	k_work_init(&ctx->usb_work, usbd_work_handler);
 

--- a/subsys/usb/usb_work_q.c
+++ b/subsys/usb/usb_work_q.c
@@ -18,10 +18,10 @@ static int z_usb_work_q_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	k_work_q_start(&z_usb_work_q,
-		       z_usb_work_q_stack,
-		       K_KERNEL_STACK_SIZEOF(z_usb_work_q_stack),
-		       CONFIG_USB_WORKQUEUE_PRIORITY);
+	k_work_queue_start(&z_usb_work_q,
+			   z_usb_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(z_usb_work_q_stack),
+			   CONFIG_USB_WORKQUEUE_PRIORITY, NULL);
 	k_thread_name_set(&z_usb_work_q.thread, "usbworkq");
 
 	return 0;


### PR DESCRIPTION
Replace all existing deprecated API with the recommended alternative.

Fixes #34092