### PR TITLE
cmake: warn if a Zephyr library is empty instead of CMake failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,8 +691,27 @@ add_subdirectory(kernel)
 get_property(ZEPHYR_LIBS_PROPERTY GLOBAL PROPERTY ZEPHYR_LIBS)
 
 foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
-  # TODO: Could this become an INTERFACE property of zephyr_interface?
-  add_dependencies(${zephyr_lib} zephyr_generated_headers)
+  get_property(source_list  TARGET ${zephyr_lib} PROPERTY SOURCES)
+  get_property(lib_type     TARGET ${zephyr_lib} PROPERTY TYPE)
+  get_property(lib_imported TARGET ${zephyr_lib} PROPERTY IMPORTED)
+
+  # To prevent CMake failure when a driver is enabled, for example: REGULATOR=y
+  # we disable any Zephyr libraries without sources and adds the `empty_file.c`.
+  if(${lib_type} STREQUAL STATIC_LIBRARY
+     AND NOT ${lib_imported}
+     AND NOT source_list
+     AND NOT ${zephyr_lib} STREQUAL app
+  )
+    message(WARNING
+      "No SOURCES given to Zephyr library: ${zephyr_lib}\nExcluding target from build."
+    )
+    target_sources(${zephyr_lib} PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
+    set_property(TARGET ${zephyr_lib} PROPERTY EXCLUDE_FROM_ALL TRUE)
+    list(REMOVE_ITEM ZEPHYR_LIBS_PROPERTY ${zephyr_lib})
+  else()
+    # TODO: Could this become an INTERFACE property of zephyr_interface?
+    add_dependencies(${zephyr_lib} zephyr_generated_headers)
+  endif()
 endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)


### PR DESCRIPTION
Several driver libraries uses:
```
zephyr_sources_ifdef()
```
instead of
```
zephyr_library()
zephyr_library_sources_ifdef()
```
This results in a messy Zephyr lib as described in: #8825

One reason for drivers to use the first approach is because an empty
Zephyr library results in a CMake build failure which again leads to
twister issues when just enabling a driver and build for all known
boards and then process the DTS result.

Secondly, a CMake build failure prevents the user from launching
menuconfig and disable the driver that creates the empty library.
See #9573 for extra details.

This commit verifies all Zephyr libraries, and if a library is found to
have no source files it will be excluded from the build and a warning
will be printed to the user.

Printing a warning instead of a hard failure ensures that:
- menuconfig can still be opened
- CMake does not fail which allows twister to advance in the test case
- Makes it possible to cleanup CMakeLists driver files

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>