### PR TITLE
MAINTAINERS: add more collaborators to the can-bus area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -406,6 +406,9 @@ Documentation:
     collaborators:
         - henrikbrixandersen
         - karstenkoenig
+        - nixward
+        - martinjaeger
+        - legoabram
     files:
         - drivers/can/
         - include/canbus/


### PR DESCRIPTION
Add Martin Jäger, Nick Ward, and Abram Early as collaborators.

They are working/help to maintain the can-bus subsys at the moment.
Having them as collaborators makes it easier to get approvals and reviews in this area.