### PR TITLE
samples: clock_skew: conversion of k_work API

### DIFF
--- a/samples/boards/nrf/clock_skew/src/main.c
+++ b/samples/boards/nrf/clock_skew/src/main.c
@@ -21,7 +21,7 @@ static const struct device *timer0;
 static struct timeutil_sync_config sync_config;
 static uint64_t counter_ref;
 static struct timeutil_sync_state sync_state;
-static struct k_delayed_work sync_work;
+static struct k_work_delayable sync_work;
 
 /* Convert local time in ticks to microseconds. */
 uint64_t local_to_us(uint64_t local)
@@ -166,7 +166,7 @@ static void sync_work_handler(struct k_work *work)
 			printf("Sync update error: %d\n", rc);
 		}
 	}
-	k_delayed_work_submit(&sync_work, K_SECONDS(UPDATE_INTERVAL_S));
+	k_work_reschedule(&sync_work, K_SECONDS(UPDATE_INTERVAL_S));
 }
 
 void main(void)
@@ -227,8 +227,8 @@ void main(void)
 	printf("Timer wraps every %u s\n",
 	       (uint32_t)(BIT64(32) / sync_config.ref_Hz));
 
-	k_delayed_work_init(&sync_work, sync_work_handler);
-	rc = k_delayed_work_submit(&sync_work, K_NO_WAIT);
+	k_work_init_delayable(&sync_work, sync_work_handler);
+	rc = k_work_reschedule(&sync_work, K_NO_WAIT);
 
 	printk("Started sync: %d\n", rc);
 }


### PR DESCRIPTION
Replace all existing deprecated API with the recommended alternative.

Fixes #34096