### PR TITLE
dma: spi: stm32: solution for dma circular mode for spi

### DIFF
--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -42,6 +42,12 @@ description: |
                0x2: high
                0x3: very high
     4. Features. Not used. Kept for binding compatibility with "st,stm32-dma-v1"
+        - bit 3: Source Reload
+               0x0: disable source reload
+               0x1: enable source reload
+        - bit 4: Dest Reload
+               0x0: disable dest reload
+               0x1: enable dest reload
 
   Example of dma node for stm32wb55x
      dma2: dma-controller@40020400 {

--- a/include/dt-bindings/dma/stm32_dma.h
+++ b/include/dt-bindings/dma/stm32_dma.h
@@ -30,5 +30,7 @@
 
 /* macros for features */
 #define STM32_DMA_FEATURES_FIFO_THRESHOLD(features)	(features & 0x3)
+#define STM32_DMA_FEATURES_SOURCE_RELOAD(features)      ((features >> 2) & 0x1)
+#define STM32_DMA_FEATURES_DEST_RELOAD(features)        ((features >> 3) & 0x1)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_DMA_STM32_DMA_H_ */


### PR DESCRIPTION
This draft PR is my solution for the dma circular mode for the spi bus, tested on the disco_l475_iot1 board. 

In the bindings i used bit 3 and 4 of features, because bit 1 and 2 is used in st,stm32-dma-v1 binding for the fifo mode. 