### PR TITLE
net: icmpv4: fix broadcast ping reply bug

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -445,7 +445,8 @@ static enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	if (net_ipv4_is_addr_mcast(&ip_hdr->dst)) {
+	if (net_ipv4_is_addr_mcast(&ip_hdr->dst) ||
+	    net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &ip_hdr->dst)) {
 		src = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 						  &ip_hdr->dst);
 	} else {


### PR DESCRIPTION
If `CONFIG_NET_ICMPV4_ACCEPT_BROADCAST` is enabled ICMPv4 should reply to
request packets sent to the broadcast address of an interface with the
unicast address of that interface from the same subnet.

Previously the code blindly copied the ICMP source address which meant it
would reply to broadcast packets with a broadcast source address.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>