### PR TITLE
drivers: clock_control: stm32g0 soc requires flash latency

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -625,6 +625,10 @@ int stm32_clock_control_init(const struct device *dev)
 
 #endif /* CONFIG_CLOCK_STM32_SYSCLK_SRC_... */
 
+#ifdef CONFIG_SOC_SERIES_STM32G0X
+	LL_FLASH_SetLatency(LL_FLASH_LATENCY_1);
+#endif /* CONFIG_SOC_SERIES_STM32G0X */
+
 	/* configure MCO1/MCO2 based on Kconfig */
 	stm32_clock_control_mco_init();
 


### PR DESCRIPTION
This patch set a flash latency of 1 wait state for the STM32G0 soc devices, as the default value of 0 wait state is not enough
to pass some test cases.
It fixes the tests/kernel/fifo/fifo_timeout executed on nucleo_g071rb

Fix https://github.com/zephyrproject-rtos/zephyr/issues/32839

Signed-off-by: Francois Ramu <francois.ramu@st.com>