### PR TITLE
Bluetooth: Mesh: Report configured LPNTimeout in cfg_srv

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2045,8 +2045,8 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_LPN_TIMEOUT_STATUS, 5);
 	struct bt_mesh_friend *frnd;
+	int32_t timeout_steps;
 	uint16_t lpn_addr;
-	int32_t timeout_ms;
 
 	lpn_addr = net_buf_simple_pull_le16(buf);
 
@@ -2062,20 +2062,21 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, lpn_addr);
 
 	if (!IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
-		timeout_ms = 0;
+		timeout_steps = 0;
 		goto send_rsp;
 	}
 
 	frnd = bt_mesh_friend_find(BT_MESH_KEY_ANY, lpn_addr, true, true);
 	if (!frnd) {
-		timeout_ms = 0;
+		timeout_steps = 0;
 		goto send_rsp;
 	}
 
-	timeout_ms = k_delayed_work_remaining_get(&frnd->timer) / 100;
+	/* PollTimeout should be reported in steps of 100ms. */
+	timeout_steps = frnd->poll_to / 100;
 
 send_rsp:
-	net_buf_simple_add_le24(&msg, timeout_ms);
+	net_buf_simple_add_le24(&msg, timeout_steps);
 
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send LPN PollTimeout Status");


### PR DESCRIPTION
Changes lpn_timeout_get behavior in the config server to report the
configured LPN timeout, instead of the currently remaining timeout time.
According to the Bluetooth Mesh Profile specification, section 4.2.21,
the PollTimeout list is a list of the PollTimeout timer values, and
according to table 4.32 in this section, values 1-9 are prohibited.
Although this is not explicitly stated, this indicates that the
PollTimeout value is the configured poll timeout time - not the time
remaining until the timeout value expires. This patch changes the
implementation to reflect this.

Split out from #33782.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>