### PR TITLE
net: lwm2m: Fix Registration Update sending on object creation via API

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -42,6 +42,8 @@ API Changes
 * Align error handling of :c:func:bt_l2cap_chan_send and
   :c:func:bt_iso_chan_send so when an error occur the buffer is not unref.
 
+* Added c:func:`lwm2m_engine_delete_obj_inst` function to the LwM2M library API.
+
 Deprecated in this release
 
 * :c:macro:`DT_CLOCKS_LABEL_BY_IDX`, :c:macro:`DT_CLOCKS_LABEL_BY_NAME`,

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -442,6 +442,17 @@ int lwm2m_engine_update_observer_max_period(char *pathstr, uint32_t period_s);
 int lwm2m_engine_create_obj_inst(char *pathstr);
 
 /**
+ * @brief Delete an LwM2M object instance.
+ *
+ * LwM2M clients use this function to delete LwM2M objects.
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst"
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_delete_obj_inst(char *pathstr);
+
+/**
  * @brief Set resource (instance) value (opaque buffer)
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1456,6 +1456,37 @@ int lwm2m_engine_create_obj_inst(char *pathstr)
 	return 0;
 }
 
+int lwm2m_engine_delete_obj_inst(char *pathstr)
+{
+	struct lwm2m_obj_path path;
+	int ret = 0;
+
+	LOG_DBG("path: %s", log_strdup(pathstr));
+
+	/* translate path -> path_obj */
+	ret = string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (path.level != 2U) {
+		LOG_ERR("path must have 2 parts");
+		return -EINVAL;
+	}
+
+	ret = lwm2m_delete_obj_inst(path.obj_id, path.obj_inst_id);
+	if (ret < 0) {
+		return ret;
+	}
+
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
+	engine_trigger_update(true);
+#endif
+
+	return 0;
+}
+
+
 int lwm2m_engine_set_res_data(char *pathstr, void *data_ptr, uint16_t data_len,
 			      uint8_t data_flags)
 {
@@ -3116,13 +3147,17 @@ static int lwm2m_delete_handler(struct lwm2m_message *msg)
 	}
 
 	ret = lwm2m_delete_obj_inst(msg->path.obj_id, msg->path.obj_inst_id);
+	if (ret < 0) {
+		return ret;
+	}
+
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
-	if (!ret) {
+	if (!msg->ctx->bootstrap_mode) {
 		engine_trigger_update(true);
 	}
 #endif
 
-	return ret;
+	return 0;
 }
 
 static int do_read_op(struct lwm2m_message *msg, uint16_t content_format)

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1444,7 +1444,16 @@ int lwm2m_engine_create_obj_inst(char *pathstr)
 		return -EINVAL;
 	}
 
-	return lwm2m_create_obj_inst(path.obj_id, path.obj_inst_id, &obj_inst);
+	ret = lwm2m_create_obj_inst(path.obj_id, path.obj_inst_id, &obj_inst);
+	if (ret < 0) {
+		return ret;
+	}
+
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
+	engine_trigger_update(true);
+#endif
+
+	return 0;
 }
 
 int lwm2m_engine_set_res_data(char *pathstr, void *data_ptr, uint16_t data_len,


### PR DESCRIPTION
The Registration Update message should be sent whenever an object
instance is created or deleted. Currently this was only the case when an
object instance was created by the server and not by the application.
Fix this by triggerng the Registration Update from the API function
as well.
