### PR TITLE
tests: arm_no_multithreading: confirm IRQ index being non-negative

### DIFF
--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -96,24 +96,26 @@ void test_main(void)
 		}
 	}
 
-	__ASSERT(i >= 0,
-		"No available IRQ line to use in the test\n");
+	if (i >= 0) {
 
-	printk("Available IRQ line: %u\n", i);
+		printk("Available IRQ line: %u\n", i);
 
-	arch_irq_connect_dynamic(i, 0 /* highest priority */,
-		arm_isr_handler,
-		NULL,
-		0);
+		arch_irq_connect_dynamic(i, 0 /* highest priority */,
+			arm_isr_handler,
+			NULL,
+			0);
 
-	NVIC_EnableIRQ(i);
+		NVIC_EnableIRQ(i);
 
-	__DSB();
-	__ISB();
+		__DSB();
+		__ISB();
 
-	flag = test_flag;
+		flag = test_flag;
 
-	__ASSERT(flag > 0, "Test flag not set by IRQ\n");
+		__ASSERT(flag > 0, "Test flag not set by IRQ\n");
 
-	printk("ARM no multithreading test successful\n");
+		printk("ARM no multithreading test successful\n");
+	} else {
+		__ASSERT(0, "No available IRQ line to use in the test\n");
+	}
 }


### PR DESCRIPTION
Check that the index returned by the function that looks
for an available IRQ line is non-negative, and do not just
rely on catching this with an ASSERT. That suppresses a
Coverity out-of-bounds warning.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #34007