### PR TITLE
Bluetooth: Align error handling of send functions

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -39,6 +39,9 @@ API Changes
 
 * Added disconnect reason to the :c:func:`disconnected` callback of :c:struct:`bt_iso_chan_ops`.
 
+* Align error handling of :c:func:bt_l2cap_chan_send and
+  :c:func:bt_iso_chan_send so when an error occur the buffer is not unref.
+
 Deprecated in this release
 
 * :c:macro:`DT_CLOCKS_LABEL_BY_IDX`, :c:macro:`DT_CLOCKS_LABEL_BY_NAME`,

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -356,6 +356,9 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *  Regarding to first input parameter, to get details see reference description
  *  to bt_iso_chan_connect() API above.
  *
+ *  @note Buffer ownership is transferred to the stack in case of success, in
+ *  case of an error the caller retains the ownership of the buffer.
+ *
  *  @param chan Channel object.
  *  @param buf Buffer containing data to be sent.
  *

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -402,6 +402,9 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  Regarding to first input parameter, to get details see reference description
  *  to bt_l2cap_chan_connect() API above.
  *
+ *  @note Buffer ownership is transferred to the stack in case of success, in
+ *  case of an error the caller retains the ownership of the buffer.
+ *
  *  @return Bytes sent in case of success or negative value in case of error.
  */
 int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -196,23 +196,12 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 
 	chan->sent = cb ? cb : chan_cb(buf);
 
-	/* bt_l2cap_send_cb takes onwership of the buffer so take another
-	 * reference to restore the state in case an error is returned.
-	 */
-	net_buf_ref(buf);
-
 	err = bt_l2cap_send_cb(chan->att->conn, BT_L2CAP_CID_ATT,
 			       buf, att_cb(chan->sent),
 			       &chan->chan.chan);
 	if (err) {
-		/* In case of an error has occurred restore the buffer state as
-		 * the extra reference shall have prevented the buffer to be
-		 * freed.
-		 */
+		/* In case of an error has occurred restore the buffer state */
 		net_buf_simple_restore(&buf->b, &state);
-	} else {
-		/* In case of success unref the extra reference taken */
-		net_buf_unref(buf);
 	}
 
 	return err;

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -66,6 +66,7 @@ static int avdtp_send(struct bt_avdtp *session,
 	result = bt_l2cap_chan_send(&session->br_chan.chan, buf);
 	if (result < 0) {
 		BT_ERR("Error:L2CAP send fail - result = %d", result);
+		net_buf_unref(buf);
 		return result;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1022,7 +1022,6 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 
 	if (conn->state != BT_CONN_CONNECTED) {
 		BT_ERR("not connected!");
-		net_buf_unref(buf);
 		return -ENOTCONN;
 	}
 
@@ -1030,14 +1029,12 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 		tx = conn_tx_alloc();
 		if (!tx) {
 			BT_ERR("Unable to allocate TX context");
-			net_buf_unref(buf);
 			return -ENOBUFS;
 		}
 
 		/* Verify that we're still connected after blocking */
 		if (conn->state != BT_CONN_CONNECTED) {
 			BT_WARN("Disconnected while allocating context");
-			net_buf_unref(buf);
 			tx_free(tx);
 			return -ENOTCONN;
 		}

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -218,7 +218,13 @@ void bt_conn_reset_rx_state(struct bt_conn *conn);
 /* Process incoming data for a connection */
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags);
 
-/* Send data over a connection */
+/* Send data over a connection
+ *
+ * Buffer ownership is transferred to stack in case of success.
+ *
+ * Calling this from RX thread is assumed to never fail so the return can be
+ * ignored.
+ */
 int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 		    bt_conn_tx_cb_t cb, void *user_data);
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1748,6 +1748,13 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 		BT_WARN("Unable to send seg %d", err);
 		atomic_inc(&ch->tx.credits);
 
+		/* If the segment is not the original buffer release it since it
+		 * won't be needed anymore.
+		 */
+		if (seg != buf) {
+			net_buf_unref(seg);
+		}
+
 		if (err == -ENOBUFS) {
 			/* Restore state since segment could not be sent */
 			net_buf_simple_restore(&buf->b, &state);

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1321,9 +1321,7 @@ int bt_l2cap_br_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return -EMSGSIZE;
 	}
 
-	bt_l2cap_send(ch->chan.conn, ch->tx.cid, buf);
-
-	return buf->len;
+	return bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, buf, NULL, NULL);
 }
 
 static int l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -300,8 +300,7 @@ struct net_buf *bt_l2cap_create_rsp(struct net_buf *buf, size_t reserve);
 
 /* Send L2CAP PDU over a connection
  *
- * Buffer ownership is transferred to stack so either in case of success
- * or error the buffer will be unref internally.
+ * Buffer ownership is transferred to stack in case of success
  *
  * Calling this from RX thread is assumed to never fail so the return can be
  * ignored.

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -317,6 +317,18 @@ struct net_buf *bt_rfcomm_create_pdu(struct net_buf_pool *pool)
 				  sizeof(struct bt_rfcomm_hdr) + 1);
 }
 
+static int rfcomm_send(struct bt_rfcomm_session *session, struct net_buf *buf)
+{
+	int err;
+
+	err = bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	if (err < 0) {
+		net_buf_unref(buf);
+	}
+
+	return err;
+}
+
 static int rfcomm_send_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	struct bt_rfcomm_hdr *hdr;
@@ -334,7 +346,7 @@ static int rfcomm_send_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_NON_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
@@ -355,7 +367,7 @@ static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_NON_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static void rfcomm_session_disconnect(struct bt_rfcomm_session *session)
@@ -502,7 +514,7 @@ static int rfcomm_send_dm(struct bt_rfcomm_session *session, uint8_t dlci)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_NON_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static void rfcomm_check_fc(struct bt_rfcomm_dlc *dlc)
@@ -558,10 +570,9 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 			break;
 		}
 
-		if (bt_l2cap_chan_send(&dlc->session->br_chan.chan, buf) < 0) {
+		if (rfcomm_send(dlc->session, buf) < 0) {
 			/* This fails only if channel is disconnected */
 			dlc->state = BT_RFCOMM_STATE_DISCONNECTED;
-			net_buf_unref(buf);
 			break;
 		}
 
@@ -608,7 +619,7 @@ static int rfcomm_send_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_NON_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_msc(struct bt_rfcomm_dlc *dlc, uint8_t cr,
@@ -629,7 +640,7 @@ static int rfcomm_send_msc(struct bt_rfcomm_dlc *dlc, uint8_t cr,
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&dlc->session->br_chan.chan, buf);
+	return rfcomm_send(dlc->session, buf);
 }
 
 static int rfcomm_send_rls(struct bt_rfcomm_dlc *dlc, uint8_t cr,
@@ -650,7 +661,7 @@ static int rfcomm_send_rls(struct bt_rfcomm_dlc *dlc, uint8_t cr,
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&dlc->session->br_chan.chan, buf);
+	return rfcomm_send(dlc->session, buf);
 }
 
 static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
@@ -666,7 +677,7 @@ static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr,
@@ -682,7 +693,7 @@ static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr,
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_nsc(struct bt_rfcomm_session *session, uint8_t cmd_type)
@@ -698,7 +709,7 @@ static int rfcomm_send_nsc(struct bt_rfcomm_session *session, uint8_t cmd_type)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_fcon(struct bt_rfcomm_session *session, uint8_t cr)
@@ -711,7 +722,7 @@ static int rfcomm_send_fcon(struct bt_rfcomm_session *session, uint8_t cr)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static int rfcomm_send_fcoff(struct bt_rfcomm_session *session, uint8_t cr)
@@ -724,7 +735,7 @@ static int rfcomm_send_fcoff(struct bt_rfcomm_session *session, uint8_t cr)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
+	return rfcomm_send(session, buf);
 }
 
 static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
@@ -926,7 +937,7 @@ static int rfcomm_send_pn(struct bt_rfcomm_dlc *dlc, uint8_t cr)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&dlc->session->br_chan.chan, buf);
+	return rfcomm_send(dlc->session, buf);
 }
 
 static int rfcomm_send_credit(struct bt_rfcomm_dlc *dlc, uint8_t credits)
@@ -949,7 +960,7 @@ static int rfcomm_send_credit(struct bt_rfcomm_dlc *dlc, uint8_t credits)
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
 
-	return bt_l2cap_chan_send(&dlc->session->br_chan.chan, buf);
+	return rfcomm_send(dlc->session, buf);
 }
 
 static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -119,6 +119,7 @@ static int net_bt_send(struct net_if *iface, struct net_pkt *pkt)
 	if (ret < 0) {
 		NET_ERR("Unable to send packet: %d", ret);
 		bt_l2cap_chan_disconnect(&conn->ipsp_chan.chan);
+		net_buf_unref(buffer);
 		return ret;
 	}
 


### PR DESCRIPTION
This aligns the error handling of send function to never unref the
buffer in place so the caller retain the ownership of the buffer
whenever there is an error.