### PR TITLE
kernel: add an architecture specific structs header

### DIFF
--- a/include/arch/arm64/structs.h
+++ b/include/arch/arm64/structs.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARM64_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARM64_STRUCTS_H_
+
+/* Per CPU architecture specifics */
+struct _cpu_arch {
+	/* content coming soon */
+};
+
+#endif /* ZEPHYR_INCLUDE_ARM64_STRUCTS_H_ */

--- a/include/arch/structs.h
+++ b/include/arch/structs.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The purpose of this file is to provide essential/minimal architecture-
+ * specific structure definitions to be included in generic kernel
+ * structures.
+ *
+ * The following rules must be observed:
+ *  1. arch/structs.h shall not depend on kernel.h both directly and
+ *     indirectly (i.e. it shall not include any header files that include
+ *     kernel.h in their dependency chain).
+ *  2. kernel.h shall imply arch/structs.h via kernel_structs.h , such that
+ *     it shall not be necessary to include arch/structs.h explicitly when
+ *     kernel.h is included.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_STRUCTS_H_
+
+#if !defined(_ASMLANGUAGE)
+
+#if defined(CONFIG_ARM64)
+#include <arch/arm64/structs.h>
+#else
+
+/* Default definitions when no architecture specific definitions exist. */
+
+/* Per CPU architecture specifics (empty) */
+struct _cpu_arch {
+};
+
+#endif
+
+/* typedefs to be used with GEN_OFFSET_SYM(), etc. */
+typedef struct _cpu_arch _cpu_arch_t;
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_STRUCTS_H_ */

--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -27,6 +27,7 @@
 #include <sys/dlist.h>
 #include <sys/util.h>
 #include <sys/sys_heap.h>
+#include <arch/structs.h>
 #endif
 
 #define K_NUM_PRIORITIES \
@@ -125,6 +126,9 @@ struct _cpu {
 	/* True when _current is allowed to context switch */
 	uint8_t swap_ok;
 #endif
+
+	/* Per CPU architecture specifics */
+	struct _cpu_arch arch;
 };
 
 typedef struct _cpu _cpu_t;

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -26,6 +26,7 @@ GEN_ABS_SYM_BEGIN(_OffsetAbsSyms)
 GEN_OFFSET_SYM(_cpu_t, current);
 GEN_OFFSET_SYM(_cpu_t, nested);
 GEN_OFFSET_SYM(_cpu_t, irq_stack);
+GEN_OFFSET_SYM(_cpu_t, arch);
 
 GEN_ABSOLUTE_SYM(___cpu_t_SIZEOF, sizeof(struct _cpu));
 

--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -1,3 +1,4 @@
+_cpu_arch_t
 k_mem_partition_attr_t
 mbedtls_pk_context
 z_arch_esf_t


### PR DESCRIPTION
Add the ability to define architecture specific structures, notably
the ability to extend struct _cpu with per-CPU arch-specific stuff that
can be accessed with _current_cpu->arch.* similarly to _current->arch.*
for per-thead architecture data.

This is opt-in for architectures that want to benefit from this,
otherwise empty defaults are provided. A placeholder for ARM64 is
included to show the pattern.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
