### PR TITLE
ite: drivers/adc: enable keeping ADC data buffer

### DIFF
--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -314,6 +314,11 @@ static int adc_it8xxx2_init(const struct device *dev)
 	 * SCLKDIV has to be equal to or greater than 1h;
 	 */
 	IT83XX_ADC_ADCCTL = 1;
+	/*
+	 * Enable this bit, and data of VCHxDATL/VCHxDATM will be
+	 * kept until data valid is cleared.
+	 */
+	IT83XX_ADC_ADCGCR |= IT83XX_ADC_DBKEN;
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    adc_it8xxx2_isr, DEVICE_DT_INST_GET(0), 0);

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1954,6 +1954,8 @@
 #define IT83XX_ADC_ADCEN			BIT(0)
 #define IT83XX_ADC_ADCCTL       ECREG(IT83XX_ADC_BASE + 0x02)
 #define IT83XX_ADC_ADCGCR       ECREG(IT83XX_ADC_BASE + 0x03)
+/* ADC data buffer keep enable. */
+#define IT83XX_ADC_DBKEN			BIT(7)
 #define IT83XX_ADC_VCH0CTL      ECREG(IT83XX_ADC_BASE + 0x04)
 /* W/C data valid flag */
 #define IT83XX_ADC_DATVAL			BIT(7)


### PR DESCRIPTION
it8xxx2's ADC data is 10-bit and saving in two registers
(VCHxDATL/bit7-0 and VCHxDATM/bit9-8).
The CL enables the function of keeping ADC data buffer to prevent
reporting incorrect ADC raw data due to the following race condition:
1) adc data valided: 0 0xf8 (voltage is 3x248/1024=0.72v)
2) ec read VCHxDATM(0x0)
3) next adc conversion done: 0x1 0x08 (voltage is 3x264/1024=0.77v)
4) ec read VCHxDATL(0x8)
EC will return incorrect voltage (3x8/1024=0.02v) to caller for above
conditions.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>