### PR TITLE
driver: itim: npcx: check ITEN bit to prevent return fake error.

### DIFF
--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -113,8 +113,11 @@ static inline int npcx_itim_evt_enable(void)
 	while (!IS_BIT_SET(evt_tmr->ITCTS32, NPCX_ITCTSXX_ITEN)) {
 		if (npcx_itim_get_sys_cyc64() - cyc_start >
 						NPCX_ITIM_EN_TIMEOUT_CYCLES) {
-			LOG_ERR("Timeout: enabling EVT timer!");
-			return -ETIMEDOUT;
+			/* ITEN bit is still unset? */
+			if (!IS_BIT_SET(evt_tmr->ITCTS32, NPCX_ITCTSXX_ITEN)) {
+				LOG_ERR("Timeout: enabling EVT timer!");
+				return -ETIMEDOUT;
+			}
 		}
 	}
 


### PR DESCRIPTION
During polling ITEN bit to make sure ITIM timer is enabled, we might
have the chance that npcx_itim_evt_enable() return fake error when
timeout expired but ITEN bit is set already if CONFIG_ZERO_LATENCY_IRQS
is enabled. (Since SVCall's interrupt priority is not the highest, the
other interrupts with IRQ_ZERO_LATENCY flag could preempt CPU resource
at this moment.)

In order to prevent return fake error code, this CL adjusts the check
conditions for ITEN bit and timeout.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>