### PR TITLE
scripts: gen_relocate_app.py: fix undefined _ADDR

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -60,7 +60,7 @@ LOAD_ADDRESS_LOCATION_BSS = "GROUP_LINK_IN({0})"
 
 MPU_RO_REGION_START = """
 
-     _{0}_mpu_ro_region_start = {1}_ADDR;
+     _{0}_mpu_ro_region_start = ORIGIN({1});
 
 """
 


### PR DESCRIPTION
With the addition of #34185, it is not longer gauranteed that for a
memory region `NAME` there exists a symbol `NAME_ADDR`. Use the linker
builtin function `ORIGIN` to instead directly get the start address of
the selected memory region.

This should fix the issue reported after merging #34185

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>