### PR TITLE
bluetooth: Add flag to force device name to appear in AD data

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -389,6 +389,9 @@ enum {
 	 *  advertising data.
 	 *  If the GAP device name does not fit into advertising data it will be
 	 *  converted to a shortened name if possible.
+	 *  @ref BT_LE_ADV_OPT_FORCE_NAME_IN_AD can be used to force the device
+	 *  name to appear in the advertising data of an advert with scan
+	 *  response data.
 	 *
 	 *  The application can set the device name itself by including the
 	 *  following in the advertising data.
@@ -513,6 +516,16 @@ enum {
 
 	/** Disable advertising on channel index 39. */
 	BT_LE_ADV_OPT_DISABLE_CHAN_39 = BIT(17),
+
+	/**
+	 * @brief Put GAP device name into advert data
+	 *
+	 * Will place the GAP device name into the advertising data rather
+	 * than the scan response data.
+	 *
+	 * @note Requires @ref BT_LE_ADV_OPT_USE_NAME
+	 */
+	BT_LE_ADV_OPT_FORCE_NAME_IN_AD = BIT(18),
 };
 
 /** LE Advertising Parameters. */
@@ -656,6 +669,12 @@ struct bt_le_per_adv_param {
 
 #define BT_LE_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
 					    BT_LE_ADV_OPT_USE_NAME, \
+					    BT_GAP_ADV_FAST_INT_MIN_2, \
+					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+
+#define BT_LE_ADV_CONN_NAME_AD BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
+					    BT_LE_ADV_OPT_USE_NAME | \
+					    BT_LE_ADV_OPT_FORCE_NAME_IN_AD, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \
 					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -445,7 +445,8 @@ static inline bool ad_has_name(const struct bt_data *ad, size_t ad_len)
 static int le_adv_update(struct bt_le_ext_adv *adv,
 			 const struct bt_data *ad, size_t ad_len,
 			 const struct bt_data *sd, size_t sd_len,
-			 bool ext_adv, bool scannable, bool use_name)
+			 bool ext_adv, bool scannable, bool use_name,
+			 bool force_name_in_ad)
 {
 	struct bt_ad d[2] = {};
 	struct bt_data data;
@@ -466,12 +467,12 @@ static int le_adv_update(struct bt_le_ext_adv *adv,
 			name, strlen(name));
 	}
 
-	if (!(ext_adv && scannable)) {
+	if (!(ext_adv && scannable) || force_name_in_ad) {
 		d_len = 1;
 		d[0].data = ad;
 		d[0].len = ad_len;
 
-		if (use_name && !scannable) {
+		if (use_name && (!scannable || force_name_in_ad)) {
 			d[1].data = &data;
 			d[1].len = 1;
 			d_len = 2;
@@ -488,7 +489,7 @@ static int le_adv_update(struct bt_le_ext_adv *adv,
 		d[0].data = sd;
 		d[0].len = sd_len;
 
-		if (use_name) {
+		if (use_name && !force_name_in_ad) {
 			d[1].data = &data;
 			d[1].len = 1;
 			d_len = 2;
@@ -508,7 +509,7 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 			  const struct bt_data *sd, size_t sd_len)
 {
 	struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
-	bool scannable, use_name;
+	bool scannable, use_name, force_name_in_ad;
 
 	if (!adv) {
 		return -EINVAL;
@@ -520,9 +521,10 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 
 	scannable = atomic_test_bit(adv->flags, BT_ADV_SCANNABLE);
 	use_name = atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME);
+	force_name_in_ad = atomic_test_bit(adv->flags, BT_ADV_FORCE_NAME_IN_AD);
 
 	return le_adv_update(adv, ad, ad_len, sd, sd_len, false, scannable,
-			     use_name);
+			     use_name, force_name_in_ad);
 }
 
 static uint8_t get_filter_policy(uint32_t options)
@@ -710,7 +712,8 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 	if (!dir_adv) {
 		err = le_adv_update(adv, ad, ad_len, sd, sd_len, false,
 				    scannable,
-				    param->options & BT_LE_ADV_OPT_USE_NAME);
+				    param->options & BT_LE_ADV_OPT_USE_NAME,
+				    param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD);
 		if (err) {
 			return err;
 		}
@@ -755,6 +758,9 @@ set_adv_state:
 
 	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME,
 			  param->options & BT_LE_ADV_OPT_USE_NAME);
+
+	atomic_set_bit_to(adv->flags, BT_ADV_FORCE_NAME_IN_AD,
+			  param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
@@ -889,6 +895,9 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 
 	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME,
 			  param->options & BT_LE_ADV_OPT_USE_NAME);
+
+	atomic_set_bit_to(adv->flags, BT_ADV_FORCE_NAME_IN_AD,
+			  param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
@@ -1293,14 +1302,15 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len,
 			   const struct bt_data *sd, size_t sd_len)
 {
-	bool ext_adv, scannable, use_name;
+	bool ext_adv, scannable, use_name, force_name_in_ad;
 
 	ext_adv = atomic_test_bit(adv->flags, BT_ADV_EXT_ADV);
 	scannable = atomic_test_bit(adv->flags, BT_ADV_SCANNABLE);
 	use_name = atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME);
+	force_name_in_ad = atomic_test_bit(adv->flags, BT_ADV_FORCE_NAME_IN_AD);
 
 	return le_adv_update(adv, ad, ad_len, sd, sd_len, ext_adv, scannable,
-			     use_name);
+			     use_name, force_name_in_ad);
 }
 
 int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -114,6 +114,10 @@ enum {
 	 * in the controller.
 	 */
 	BT_PER_ADV_CTE_ENABLED,
+	/* The device name has been forced to appear in the advertising data
+	 * instead of in the scan response data
+	 */
+	BT_ADV_FORCE_NAME_IN_AD,
 
 	BT_ADV_NUM_FLAGS,
 };


### PR DESCRIPTION
This adds a new flag, BT_LE_ADV_OPT_FORCE_NAME_IN_AD, which can be used to
force the Bluetooth GAP device name to appear in the advertising data rather
than the scan response data of an advert with scan response data.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>

I looked into adding a test but it seems the only way to do that is using babblesim which isn't supported on windows so I'm open to suggestions on how to create such a test and actually test it.