### PR TITLE
Bluetooth: services: Call OTS selected callback for all selections

### DIFF
--- a/subsys/bluetooth/services/ots/ots_olcp.c
+++ b/subsys/bluetooth/services/ots/ots_olcp.c
@@ -276,7 +276,7 @@ ssize_t bt_gatt_ots_olcp_write(struct bt_conn *conn,
 
 	if (olcp_status != BT_GATT_OTS_OLCP_RES_SUCCESS) {
 		LOG_WRN("OLCP Write error status: 0x%02X", olcp_status);
-	} else if (old_obj != ots->cur_obj) {
+	} else {
 		char id[BT_OTS_OBJ_ID_STR_LEN];
 
 		bt_ots_obj_id_to_str(ots->cur_obj->id, id,


### PR DESCRIPTION
Call the OTS selected callback even if the selection does not change
the selected object.

This solves a startup issue where the selected callback is not called
if the first object selected by the client happens to be the same
object as the OTS has set as selected during initialization and setup.
In that case, the user of the OTS does not know which object is
selected, and therefore may not be able to supply the correct data
later.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>

Alternative solution: https://github.com/zephyrproject-rtos/zephyr/pull/34334 - merge only one of them.