### PR TITLE
Bluetooth: services: Call OTS selected callback for first object added

### DIFF
--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -202,11 +202,6 @@ int bt_ots_obj_add(struct bt_ots *ots,
 		}
 	}
 
-	/* Make object the Current Object if this is the first one added. */
-	if (!ots->cur_obj) {
-		ots->cur_obj = obj;
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
Call the OTS selected callback for the first object added, as the
first object added also becomes the selected object.

This solves a startup issue where the selected callback is not called
if the first object selected by the client happens to be the same
object as the object that was first added.  In that case, the user of
the OTS does not know which object is selected, and therefore may not
be able to supply the correct data later.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>

This is an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/34333 - merge only one of the.
