### PR TITLE
Bluetooth: host:l2cap: fix sending error in le_ecred_reconf_req

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1219,7 +1219,7 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_ecred_reconf_req *req;
 	struct bt_l2cap_ecred_reconf_rsp *rsp;
 	uint16_t mtu, mps;
-	uint16_t scid, result;
+	uint16_t scid, result = BT_L2CAP_RECONF_SUCCESS;
 
 	if (buf->len < sizeof(*req)) {
 		BT_ERR("Too small ecred reconf req packet size");
@@ -1231,12 +1231,12 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 	mtu = sys_le16_to_cpu(req->mtu);
 	mps = sys_le16_to_cpu(req->mps);
 
-	if (mtu < L2CAP_ECRED_MIN_MTU) {
-		result = BT_L2CAP_RECONF_INVALID_MTU;
+	if (mps < L2CAP_ECRED_MIN_MTU) {
+		result = BT_L2CAP_RECONF_OTHER_UNACCEPT;
 		goto response;
 	}
 
-	if (mps < L2CAP_ECRED_MIN_MTU) {
+	if (mtu < L2CAP_ECRED_MIN_MTU) {
 		result = BT_L2CAP_RECONF_INVALID_MTU;
 		goto response;
 	}
@@ -1254,6 +1254,7 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 
 		chan = bt_l2cap_le_lookup_tx_cid(conn, scid);
 		if (!chan) {
+			result = BT_L2CAP_RECONF_INVALID_CID;
 			continue;
 		}
 
@@ -1274,8 +1275,6 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 	}
 
 	BT_DBG("mtu %u mps %u", mtu, mps);
-
-	result = BT_L2CAP_RECONF_SUCCESS;
 
 response:
 	buf = l2cap_create_le_sig_pdu(buf, BT_L2CAP_ECRED_RECONF_RSP, ident,

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -219,6 +219,8 @@ struct bt_l2cap_ecred_reconf_req {
 #define BT_L2CAP_RECONF_SUCCESS         0x0000
 #define BT_L2CAP_RECONF_INVALID_MTU     0x0001
 #define BT_L2CAP_RECONF_INVALID_MPS     0x0002
+#define BT_L2CAP_RECONF_INVALID_CID     0x0003
+#define BT_L2CAP_RECONF_OTHER_UNACCEPT  0x0004
 
 #define BT_L2CAP_ECRED_RECONF_RSP       0x1a
 struct bt_l2cap_ecred_reconf_rsp {


### PR DESCRIPTION
Result to send was overwritten by BT_L2CAP_RECONF_SUCCESS just after
exiting while loop. This caused to send success response even if
reconfiguration failed. Now, result is initialized to success value,
and if reconfiguration fails, this value will be overwritten with
appropriate one. Added BT_L2CAP_RECONF_INVALID_CID (0x0003) for invalid
cid in request. Added BT_L2CAP_RECONF_OTHER_UNACCEPT (0x0004) to return
if MPS is to small. Reordered checks for mps/mtu as
BT_L2CAP_RECONF_OTHER_UNACCEPT is expected to be returned if both mps
and mtu are to small.

This was affecting L2CAP/ECFC/BI-05-C and L2CAP/ECFC/BI-05-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>