### PR TITLE
net: lwm2m: Made pmin and pmax attributes optional

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -183,7 +183,7 @@ config LWM2M_SECURITY_KEY_SIZE
 
 config LWM2M_SERVER_DEFAULT_PMIN
 	int "Default server record PMIN"
-	default 10
+	default 0
 	help
 	  Default minimum amount of time in seconds the client must wait
 	  between notifications.  If a resource has to be notified during this
@@ -192,7 +192,7 @@ config LWM2M_SERVER_DEFAULT_PMIN
 
 config LWM2M_SERVER_DEFAULT_PMAX
 	int "Default server record PMAX"
-	default 60
+	default 0
 	help
 	  Default maximum amount of time in seconds the client may wait
 	  between notifications.  When this time period expires a notification


### PR DESCRIPTION
Made the LwM2M engine checks for pmin and pmax optional to adhere to
the LwM2M specificattion. We now first check that pmin and pmax are
actually set. Also changed the default CONFIG values for the attributes
pmin and pmax to 0 to indicate that they are not active by default.

Fixes #34329.

Signed-off-by: Maik Vermeulen <maik.vermeulen@innotractor.com>