### PR TITLE
Bluetooth: Mesh: LPN: Delayable work 

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -513,6 +513,14 @@ void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx)
 		return;
 	}
 
+	/* If the message was a Friend control message, it's possible that a
+	 * Poll was already queued for sending. In this case, we're already in
+	 * a different state.
+	 */
+	if (lpn->state != BT_MESH_LPN_WAIT_UPDATE) {
+		return;
+	}
+
 	if (lpn->sent_req != TRANS_CTL_OP_FRIEND_POLL) {
 		BT_WARN("Unexpected message withouth a preceding Poll");
 		return;

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -101,6 +101,24 @@ static const char *state2str(int state)
 }
 #endif /* CONFIG_BT_MESH_DEBUG_LOW_POWER */
 
+static int32_t poll_timeout(struct bt_mesh_lpn *lpn)
+{
+	/* If we're waiting for segment acks keep polling at high freq */
+	if (bt_mesh_tx_in_progress()) {
+		return MIN(POLL_TIMEOUT_MAX(lpn), 1 * MSEC_PER_SEC);
+	}
+
+	if (lpn->poll_timeout < POLL_TIMEOUT_MAX(lpn)) {
+		lpn->poll_timeout *= 2;
+		lpn->poll_timeout =
+			MIN(lpn->poll_timeout, POLL_TIMEOUT_MAX(lpn));
+	}
+
+	BT_DBG("Poll Timeout is %ums", lpn->poll_timeout);
+
+	return lpn->poll_timeout;
+}
+
 static inline void lpn_set_state(int state)
 {
 #if defined(CONFIG_BT_MESH_DEBUG_LOW_POWER)
@@ -166,7 +184,7 @@ static void friend_clear_sent(int err, void *user_data)
 	}
 
 	lpn_set_state(BT_MESH_LPN_CLEAR);
-	k_delayed_work_submit(&lpn->timer, K_MSEC(FRIEND_REQ_TIMEOUT));
+	k_work_reschedule(&lpn->timer, K_MSEC(FRIEND_REQ_TIMEOUT));
 }
 
 static const struct bt_mesh_send_cb clear_sent_cb = {
@@ -213,7 +231,10 @@ static void clear_friendship(bool force, bool disable)
 
 	bt_mesh_rx_reset();
 
-	k_delayed_work_cancel(&lpn->timer);
+	/* Disable LPN while clearing, in case the work handler gets a chance to fire. */
+	lpn_set_state(BT_MESH_LPN_DISABLED);
+	/* The timer handler returns without any actions if this fails. */
+	(void)k_work_cancel_delayable(&lpn->timer);
 
 	if (lpn->clear_success) {
 		lpn->old_friend = BT_MESH_ADDR_UNASSIGNED;
@@ -250,13 +271,10 @@ static void clear_friendship(bool force, bool disable)
 
 	bt_mesh_hb_feature_changed(BT_MESH_FEAT_LOW_POWER);
 
-	if (disable) {
-		lpn_set_state(BT_MESH_LPN_DISABLED);
-		return;
+	if (!disable) {
+		lpn_set_state(BT_MESH_LPN_ENABLED);
+		k_work_reschedule(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);
 	}
-
-	lpn_set_state(BT_MESH_LPN_ENABLED);
-	k_delayed_work_submit(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);
 }
 
 static void friend_req_sent(uint16_t duration, int err, void *user_data)
@@ -271,11 +289,11 @@ static void friend_req_sent(uint16_t duration, int err, void *user_data)
 	lpn->adv_duration = duration;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
-		k_delayed_work_submit(&lpn->timer, K_MSEC(FRIEND_REQ_WAIT));
+		k_work_reschedule(&lpn->timer, K_MSEC(FRIEND_REQ_WAIT));
 		lpn_set_state(BT_MESH_LPN_REQ_WAIT);
 	} else {
-		k_delayed_work_submit(&lpn->timer,
-				      K_MSEC(duration + FRIEND_REQ_TIMEOUT));
+		k_work_reschedule(&lpn->timer,
+				  K_MSEC(duration + FRIEND_REQ_TIMEOUT));
 		lpn_set_state(BT_MESH_LPN_WAIT_OFFER);
 	}
 }
@@ -354,13 +372,13 @@ static void req_sent(uint16_t duration, int err, void *user_data)
 		/* We start scanning a bit early to elimitate risk of missing
 		 * response data due to HCI and other latencies.
 		 */
-		k_delayed_work_submit(&lpn->timer,
-				      K_MSEC(LPN_RECV_DELAY - SCAN_LATENCY));
+		k_work_reschedule(&lpn->timer,
+				  K_MSEC(LPN_RECV_DELAY - SCAN_LATENCY));
 	} else {
 		lpn_set_state(BT_MESH_LPN_WAIT_UPDATE);
-		k_delayed_work_submit(&lpn->timer,
-				      K_MSEC(LPN_RECV_DELAY + duration +
-					     lpn->recv_win));
+		k_work_reschedule(&lpn->timer,
+				  K_MSEC(LPN_RECV_DELAY + duration +
+					 lpn->recv_win));
 	}
 }
 
@@ -451,7 +469,10 @@ int bt_mesh_lpn_set(bool enable)
 	} else {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_AUTO) &&
 		    lpn->state == BT_MESH_LPN_TIMER) {
-			k_delayed_work_cancel(&lpn->timer);
+			/* If this fails, the work handler will just exit on the
+			 * next timeout.
+			 */
+			(void)k_work_cancel_delayable(&lpn->timer);
 			lpn_set_state(BT_MESH_LPN_DISABLED);
 		} else {
 			bt_mesh_lpn_disable(false);
@@ -469,11 +490,17 @@ static void friend_response_received(struct bt_mesh_lpn *lpn)
 		lpn->fsn++;
 	}
 
-	k_delayed_work_cancel(&lpn->timer);
 	bt_mesh_scan_disable();
 	lpn_set_state(BT_MESH_LPN_ESTABLISHED);
 	lpn->req_attempts = 0U;
 	lpn->sent_req = 0U;
+
+	/* Schedule the next poll. This may be overridden by additional
+	 * processing of the received response.
+	 */
+	int32_t timeout = poll_timeout(lpn);
+
+	k_work_reschedule(&lpn->timer, K_MSEC(timeout));
 }
 
 void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx)
@@ -482,7 +509,7 @@ void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx)
 
 	if (lpn->state == BT_MESH_LPN_TIMER) {
 		BT_DBG("Restarting establishment timer");
-		k_delayed_work_submit(&lpn->timer, K_MSEC(LPN_AUTO_TIMEOUT));
+		k_work_reschedule(&lpn->timer, K_MSEC(LPN_AUTO_TIMEOUT));
 		return;
 	}
 
@@ -556,13 +583,13 @@ int bt_mesh_lpn_friend_offer(struct bt_mesh_net_rx *rx,
 	}
 
 	/* TODO: Add offer acceptance criteria check */
-	k_delayed_work_cancel(&lpn->timer);
 
 	lpn->recv_win = msg->recv_win;
 	lpn->queue_size = msg->queue_size;
 
 	err = send_friend_poll();
 	if (err) {
+		/* Will retry sending later */
 		lpn->sub = NULL;
 		lpn->frnd = BT_MESH_ADDR_UNASSIGNED;
 		lpn->recv_win = 0U;
@@ -741,7 +768,7 @@ static void update_timeout(struct bt_mesh_lpn *lpn)
 		BT_WARN("No response from Friend during ReceiveWindow");
 		bt_mesh_scan_disable();
 		lpn_set_state(BT_MESH_LPN_ESTABLISHED);
-		k_delayed_work_submit(&lpn->timer, K_MSEC(POLL_RETRY_TIMEOUT));
+		k_work_reschedule(&lpn->timer, K_MSEC(POLL_RETRY_TIMEOUT));
 	} else {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
@@ -786,7 +813,7 @@ static void lpn_timeout(struct k_work *work)
 		break;
 	case BT_MESH_LPN_REQ_WAIT:
 		bt_mesh_scan_enable();
-		k_delayed_work_submit(&lpn->timer, K_MSEC(lpn->adv_duration +
+		k_work_reschedule(&lpn->timer, K_MSEC(lpn->adv_duration +
 							  FRIEND_REQ_SCAN));
 		lpn_set_state(BT_MESH_LPN_WAIT_OFFER);
 		break;
@@ -798,7 +825,7 @@ static void lpn_timeout(struct k_work *work)
 
 		lpn_set_state(BT_MESH_LPN_ENABLED);
 		lpn->sent_req = 0U;
-		k_delayed_work_submit(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);
+		k_work_reschedule(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);
 		break;
 	case BT_MESH_LPN_ESTABLISHED:
 		if (lpn->req_attempts < REQ_ATTEMPTS(lpn)) {
@@ -821,7 +848,7 @@ static void lpn_timeout(struct k_work *work)
 		clear_friendship(false, false);
 		break;
 	case BT_MESH_LPN_RECV_DELAY:
-		k_delayed_work_submit(&lpn->timer,
+		k_work_reschedule(&lpn->timer,
 				      K_MSEC(lpn->adv_duration + SCAN_LATENCY +
 					     lpn->recv_win));
 		bt_mesh_scan_enable();
@@ -865,24 +892,6 @@ void bt_mesh_lpn_group_del(uint16_t *groups, size_t group_count)
 	}
 
 	sub_update(TRANS_CTL_OP_FRIEND_SUB_REM);
-}
-
-static int32_t poll_timeout(struct bt_mesh_lpn *lpn)
-{
-	/* If we're waiting for segment acks keep polling at high freq */
-	if (bt_mesh_tx_in_progress()) {
-		return MIN(POLL_TIMEOUT_MAX(lpn), 1 * MSEC_PER_SEC);
-	}
-
-	if (lpn->poll_timeout < POLL_TIMEOUT_MAX(lpn)) {
-		lpn->poll_timeout *= 2;
-		lpn->poll_timeout = MIN(lpn->poll_timeout,
-					POLL_TIMEOUT_MAX(lpn));
-	}
-
-	BT_DBG("Poll Timeout is %ums", lpn->poll_timeout);
-
-	return lpn->poll_timeout;
 }
 
 int bt_mesh_lpn_friend_sub_cfm(struct bt_mesh_net_rx *rx,
@@ -941,12 +950,6 @@ int bt_mesh_lpn_friend_sub_cfm(struct bt_mesh_net_rx *rx,
 
 	if (lpn->pending_poll) {
 		send_friend_poll();
-	}
-
-	if (!lpn->sent_req) {
-		int32_t timeout = poll_timeout(lpn);
-
-		k_delayed_work_submit(&lpn->timer, K_MSEC(timeout));
 	}
 
 	return 0;
@@ -1034,12 +1037,6 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 		send_friend_poll();
 	}
 
-	if (!lpn->sent_req) {
-		int32_t timeout = poll_timeout(lpn);
-
-		k_delayed_work_submit(&lpn->timer, K_MSEC(timeout));
-	}
-
 	return 0;
 }
 
@@ -1080,7 +1077,7 @@ int bt_mesh_lpn_init(void)
 
 	BT_DBG("");
 
-	k_delayed_work_init(&lpn->timer, lpn_timeout);
+	k_work_init_delayable(&lpn->timer, lpn_timeout);
 
 	if (lpn->state == BT_MESH_LPN_ENABLED) {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
@@ -1096,8 +1093,8 @@ int bt_mesh_lpn_init(void)
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_AUTO)) {
 			BT_DBG("Waiting %u ms for messages", LPN_AUTO_TIMEOUT);
 			lpn_set_state(BT_MESH_LPN_TIMER);
-			k_delayed_work_submit(&lpn->timer,
-					      K_MSEC(LPN_AUTO_TIMEOUT));
+			k_work_reschedule(&lpn->timer,
+					  K_MSEC(LPN_AUTO_TIMEOUT));
 		}
 	}
 

--- a/subsys/bluetooth/mesh/lpn.h
+++ b/subsys/bluetooth/mesh/lpn.h
@@ -43,14 +43,6 @@ static inline bool bt_mesh_lpn_waiting_update(void)
 #endif
 }
 
-static inline bool bt_mesh_lpn_timer(void)
-{
-#if defined(CONFIG_BT_MESH_LPN_AUTO)
-	return (bt_mesh.lpn.state == BT_MESH_LPN_TIMER);
-#else
-	return false;
-#endif
-}
 
 void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx);
 

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -152,7 +152,7 @@ struct bt_mesh_lpn {
 	uint16_t adv_duration;
 
 	/* Next LPN related action timer */
-	struct k_delayed_work timer;
+	struct k_work_delayable timer;
 
 	/* Subscribed groups */
 	uint16_t groups[LPN_GROUPS];

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1576,20 +1576,8 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 		err = trans_unseg(buf, rx, &seq_auth);
 	}
 
-	/* Notify LPN state machine so a Friend Poll will be sent. If the
-	 * message was a Friend Update it's possible that a Poll was already
-	 * queued for sending, however that's fine since then the
-	 * bt_mesh_lpn_waiting_update() function will return false:
-	 * we still need to go through the actual sending to the bearer and
-	 * wait for ReceiveDelay before transitioning to WAIT_UPDATE state.
-	 * Another situation where we want to notify the LPN state machine
-	 * is if it's configured to use an automatic Friendship establishment
-	 * timer, in which case we want to reset the timer at this point.
-	 *
-	 */
-	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
-	    (bt_mesh_lpn_timer() ||
-	     (bt_mesh_lpn_established() && bt_mesh_lpn_waiting_update()))) {
+	/* Notify LPN state machine so a Friend Poll will be sent. */
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
 		bt_mesh_lpn_msg_received(rx);
 	}
 


### PR DESCRIPTION
### Bluetooth: Mesh: LPN: Rework poll timeout scheduling

Switch to the new delayed work API. Puts the scheduling for the next
poll in the response_received function instead of cancelling it, then
optionally scheduling it again later.

Split out from #33782.

### Move lpn logic for msg_received inside lpn.c

The Transport layer implements some checks surrounding the
lpn_msg_received call, with an accompanying comment that explains the
logic. Move this inside the msg_received call instead