### PR TITLE
Enabling PWM support for STM32 L152RE Platform

### DIFF
--- a/boards/arm/nucleo_l152re/doc/index.rst
+++ b/boards/arm/nucleo_l152re/doc/index.rst
@@ -96,6 +96,8 @@ The Zephyr nucleo_l152re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | PWM                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 
@@ -126,6 +128,7 @@ Default Zephyr Peripheral Mapping:
 - B1 (USER/blue) : PC13
 - LD1 : PA5
 - DAC : PA4
+- PWM_3_CH1 : PA6
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -89,3 +89,12 @@
 		};
 	};
 };
+
+&timers3 {
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pa6>;
+	};
+};

--- a/boards/arm/nucleo_l152re/nucleo_l152re.yaml
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.yaml
@@ -18,3 +18,4 @@ supported:
   - counter
   - adc
   - dac
+  - pwm

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -322,7 +322,7 @@ static int pwm_stm32_init(const struct device *dev)
 		return -EIO;
 	}
 
-#ifndef CONFIG_SOC_SERIES_STM32L0X
+#if !defined(CONFIG_SOC_SERIES_STM32L0X) && !defined(CONFIG_SOC_SERIES_STM32L1X)
 	/* enable outputs and counter */
 	if (IS_TIM_BREAK_INSTANCE(cfg->timer)) {
 		LL_TIM_EnableAllOutputs(cfg->timer);

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -32,6 +32,30 @@
 	};
 
 	soc {
+
+		flash: flash-controller@40023c00 {
+			compatible = "st,stm32-flash-controller", "st,stm32l1-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40023c00 0x400>;
+			interrupts = <4 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+
+				write-block-size = <4>;
+			};
+		};
+
+		rcc: rcc@40023800 {
+			compatible = "st,stm32-rcc";
+			#clock-cells = <2>;
+			reg = <0x40023800 0x400>;
+		};
+
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
@@ -236,29 +260,6 @@
 			interrupts = <0 7>;
 			status = "disabled";
 			label = "WWDG";
-		};
-
-		rcc: rcc@40023800 {
-			compatible = "st,stm32-rcc";
-			#clock-cells = <2>;
-			reg = <0x40023800 0x400>;
-		};
-
-		flash: flash-controller@40023c00 {
-			compatible = "st,stm32-flash-controller", "st,stm32l1-flash-controller";
-			label = "FLASH_CTRL";
-			reg = <0x40023c00 0x400>;
-			interrupts = <4 0>;
-
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				label = "FLASH_STM32";
-
-				write-block-size = <4>;
-			};
 		};
 
 		eeprom: eeprom@8080000{

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -185,6 +185,114 @@
 			reg = <0x40010400 0x400>;
 		};
 
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000001>;
+			interrupts = <28 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_2";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_2";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000002>;
+			interrupts = <29 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_3";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_3";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000004>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_4";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_4";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers9: timers@40010800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40010800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000004>;
+			interrupts = <25 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_9";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_9";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers10: timers@40010c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40010c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000008>;
+			interrupts = <26 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_10";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_10";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers11: timers@40011400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
+			interrupts = <27 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_11";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_11";
+				#pwm-cells = <3>;
+			};
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -18,6 +18,25 @@
 				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
+
+		timers5: timers@40000C00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_5";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_5";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(8)>;
 		};

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -18,6 +18,25 @@
 				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
+
+		timers5: timers@40000C00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_5";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_5";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(8)>;
 		};

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -19,6 +19,24 @@
 			};
 		};
 
+		timers5: timers@40000C00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_5";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_5";
+				#pwm-cells = <3>;
+			};
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(16)>;
 		};


### PR DESCRIPTION
Enabled PWM support for STM32 L152RE target platform.

Verified PWM signals on timer3 using test application `tests/drivers/pwm`