### PR TITLE
arm64: Use syscall frame and fix bad syscall handling

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -272,9 +272,7 @@ void z_arm64_do_kernel_oops(z_arch_esf_t *esf)
 #ifdef CONFIG_USERSPACE
 FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr)
 {
-	ARG_UNUSED(ssf_ptr);
-
-	z_arm64_fatal_error(K_ERR_KERNEL_OOPS, NULL);
+	z_arm64_fatal_error(K_ERR_KERNEL_OOPS, ssf_ptr);
 	CODE_UNREACHABLE;
 }
 #endif

--- a/arch/arm64/core/userspace.S
+++ b/arch/arm64/core/userspace.S
@@ -96,6 +96,9 @@ SECTION_FUNC(TEXT, z_arm64_do_syscall)
 	ldp	x2, x3, [sp, ___esf_t_x2_x3_OFFSET]
 	ldp	x4, x5, [sp, ___esf_t_x4_x5_OFFSET]
 
+	/* Use the ESF as SSF */
+	mov	x6, sp
+
 	/* Recover the syscall ID */
 	ldr	x8, [sp, ___esf_t_x8_x9_OFFSET]
 
@@ -103,6 +106,9 @@ SECTION_FUNC(TEXT, z_arm64_do_syscall)
 	ldr	x9, =K_SYSCALL_LIMIT
 	cmp	x8, x9
 	blo	valid_syscall_id
+
+	/* Save the bad ID for handler_bad_syscall() */
+	mov	x0, x8
 	ldr	x8, =K_SYSCALL_BAD
 
 valid_syscall_id:


### PR DESCRIPTION
This patch is fixing three related problems:

1. When calling a syscall the marshalling function is using the ssf
   parameter as value to be saved in _current->syscall_frame to mark the
   beginning and the end of the syscall. This ssf value is not currently
   being explictly set and instead the syscall code is using whatever
   value is stored in x6 when the syscall is called. If it happens that
   x6 is 0 at the time the syscall is called, this causes the
   z_is_in_user_syscall() function to fail. Fix this passing the ESF as
   value for ssf.

2. Given that in the ssf is now present the ESF, we can fix
   arch_syscall_oops() using the ESF to print a more detailed error
   message with registers dump.

3. When a wrong syscall number is used, handler_bad_syscall() is called.
   This function expects the ID number as first parameter to print the
   error message, fix this.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>