### PR TITLE
Get flash clock settings from DT for STM32

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -348,14 +348,11 @@ flash_stm32_get_parameters(const struct device *dev)
 
 static struct flash_stm32_priv flash_data = {
 	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
-#if defined(CONFIG_SOC_SERIES_STM32L4X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32G0X) || \
-	defined(CONFIG_SOC_SERIES_STM32G4X)
-	.pclken = { .bus = STM32_CLOCK_BUS_AHB1,
-		    .enr = LL_AHB1_GRP1_PERIPH_FLASH },
+#if DT_INST_NODE_HAS_PROP(0, clocks)
+	.pclken = {
+		.enr = DT_INST_CLOCKS_CELL(0, bits),
+		.bus = DT_INST_CLOCKS_CELL(0, bus),
+	}
 #endif
 };
 
@@ -372,17 +369,15 @@ static const struct flash_driver_api flash_stm32_api = {
 static int stm32_flash_init(const struct device *dev)
 {
 	int rc;
-#if defined(CONFIG_SOC_SERIES_STM32L4X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32G0X)
+	/* Below is applicable to L4, F0, F1, F3, G0*/
+#if DT_INST_NODE_HAS_PROP(0, clocks)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/*
 	 * On STM32F0, Flash interface clock source is always HSI,
 	 * so statically enable HSI here.
+	 * Below is applicable to F0, F1 and F3 as HSI is the source
 	 */
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32F1X) || \

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -348,6 +348,9 @@ flash_stm32_get_parameters(const struct device *dev)
 
 static struct flash_stm32_priv flash_data = {
 	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
+	/* Getting clocks information from device tree description depending
+	 * on the presence of 'clocks' property.
+	 */
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	.pclken = {
 		.enr = DT_INST_CLOCKS_CELL(0, bits),
@@ -369,19 +372,21 @@ static const struct flash_driver_api flash_stm32_api = {
 static int stm32_flash_init(const struct device *dev)
 {
 	int rc;
-	/* Below is applicable to L4, F0, F1, F3, G0*/
+	/* Below is applicable to F0, F1, F3, G0, G4, L1, L4 & WB55 series.
+	 * For F2, F4, F7 & H7 series, this is not applicable.
+	 */
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/*
-	 * On STM32F0, Flash interface clock source is always HSI,
-	 * so statically enable HSI here.
-	 * Below is applicable to F0, F1 and F3 as HSI is the source
+	 * On STM32 F0, F1, F3 & L1 series, flash interface clock source is
+	 * always HSI, so statically enable HSI here.
 	 */
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X)
+	defined(CONFIG_SOC_SERIES_STM32F3X) || \
+	defined(CONFIG_SOC_SERIES_STM32L1X)
 	LL_RCC_HSI_Enable();
 
 	while (!LL_RCC_HSI_IsReady()) {

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -8,26 +8,14 @@
 #ifndef ZEPHYR_DRIVERS_FLASH_FLASH_STM32_H_
 #define ZEPHYR_DRIVERS_FLASH_FLASH_STM32_H_
 
-#if defined(CONFIG_SOC_SERIES_STM32L4X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32G0X) || \
-	defined(CONFIG_SOC_SERIES_STM32G4X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks)
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #endif
 
 struct flash_stm32_priv {
 	FLASH_TypeDef *regs;
-#if defined(CONFIG_SOC_SERIES_STM32L4X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32G0X) || \
-	defined(CONFIG_SOC_SERIES_STM32G4X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks)
 	/* clock subsystem driving this peripheral */
 	struct stm32_pclken pclken;
 #endif

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -37,6 +37,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000010>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -39,6 +39,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000010>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -37,6 +37,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <4 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000010>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -39,6 +39,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000100>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -79,6 +79,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000100>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -38,6 +38,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40023c00 0x400>;
 			interrupts = <4 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00008000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -39,6 +39,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			interrupts = <4 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000100>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -47,6 +47,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x58004000 0x400>;
 			interrupts = <4 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x02000000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
These commits will do the following:

1. Add 'clocks' property in device tree files of f0, f1, f3, g0, g4, l1, l4 and wb series.
2. Modify the stm32 flash driver to use device tree APIs to get the clock settings from the dtsi file.
