### PR TITLE
samples: civetweb: websocket_server: Fix build issue

### DIFF
--- a/samples/net/civetweb/websocket_server/CMakeLists.txt
+++ b/samples/net/civetweb/websocket_server/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(app PRIVATE
 set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
 set(web_page_dir web_page)
 
+file(MAKE_DIRECTORY ${gen_dir}/${web_page_dir})
+
 # List of files that are used to generate .h file that can be included
 # into .c file.
 foreach(inc_file


### PR DESCRIPTION
The sample uses generate_inc_file_for_target for some "webpages" that
get included.  However, the directory that the generated files are
put into: ${ZEPHYR_BINARY_DIR}/include/generated/web_page isn't
created and thus the build fails.

Add a simple 'file(MAKE_DIRECTORY ..)' to create the dir.

Fixes #34345

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>