### PR TITLE
Bluetooth: Update to use the delayable work API

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -98,7 +98,8 @@ struct bt_l2cap_chan {
 	sys_snode_t			node;
 	bt_l2cap_chan_destroy_t		destroy;
 	/* Response Timeout eXpired (RTX) timer */
-	struct k_delayed_work		rtx_work;
+	struct k_work_delayable		rtx_work;
+	struct k_work_sync              rtx_sync;
 	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)

--- a/include/bluetooth/rfcomm.h
+++ b/include/bluetooth/rfcomm.h
@@ -74,7 +74,7 @@ typedef enum bt_rfcomm_role {
 /** @brief RFCOMM DLC structure. */
 struct bt_rfcomm_dlc {
 	/* Response Timeout eXpired (RTX) timer */
-	struct k_delayed_work      rtx_work;
+	struct k_work_delayable    rtx_work;
 
 	/* Queue for outgoing data */
 	struct k_fifo              tx_queue;

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -77,7 +77,7 @@ static int avdtp_send(struct bt_avdtp *session,
 
 	session->req = req;
 	/* Start timeout work */
-	k_delayed_work_submit(&session->req->timeout_work, AVDTP_TIMEOUT);
+	k_work_reschedule(&session->req->timeout_work, AVDTP_TIMEOUT);
 	return result;
 }
 
@@ -126,7 +126,7 @@ void bt_avdtp_l2cap_connected(struct bt_l2cap_chan *chan)
 	session = AVDTP_CHAN(chan);
 	BT_DBG("chan %p session %p", chan, session);
 	/* Init the timer */
-	k_delayed_work_init(&session->req->timeout_work, avdtp_timeout);
+	k_work_init_delayable(&session->req->timeout_work, avdtp_timeout);
 
 }
 

--- a/subsys/bluetooth/host/avdtp_internal.h
+++ b/subsys/bluetooth/host/avdtp_internal.h
@@ -97,7 +97,7 @@ struct bt_avdtp_req {
 	uint8_t sig;
 	uint8_t tid;
 	bt_avdtp_func_t func;
-	struct k_delayed_work timeout_work;
+	struct k_work_delayable timeout_work;
 };
 
 struct bt_avdtp_single_sig_hdr {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -430,7 +430,7 @@ static struct bt_conn *acl_conn_new(void)
 		return conn;
 	}
 
-	k_delayed_work_init(&conn->deferred_work, deferred_work);
+	k_work_init_delayable(&conn->deferred_work, deferred_work);
 
 	k_work_init(&conn->tx_complete_work, tx_complete_work);
 
@@ -1293,7 +1293,7 @@ static void conn_cleanup(struct bt_conn *conn)
 
 	bt_conn_reset_rx_state(conn);
 
-	k_delayed_work_submit(&conn->deferred_work, K_NO_WAIT);
+	k_work_reschedule(&conn->deferred_work, K_NO_WAIT);
 }
 
 static int conn_prepare_events(struct bt_conn *conn,
@@ -1540,7 +1540,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 	case BT_CONN_CONNECT:
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
-			k_delayed_work_cancel(&conn->deferred_work);
+			k_work_cancel_delayable(&conn->deferred_work);
 		}
 		break;
 	default:
@@ -1570,8 +1570,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 		    conn->role == BT_CONN_ROLE_SLAVE) {
-			k_delayed_work_submit(&conn->deferred_work,
-					      CONN_UPDATE_TIMEOUT);
+			k_work_schedule(&conn->deferred_work,
+					CONN_UPDATE_TIMEOUT);
 		}
 
 		break;
@@ -1610,7 +1610,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 			/* Cancel Connection Update if it is pending */
 			if (conn->type == BT_CONN_TYPE_LE) {
-				k_delayed_work_cancel(&conn->deferred_work);
+				k_work_cancel_delayable(&conn->deferred_work);
 			}
 
 			atomic_set_bit(conn->flags, BT_CONN_CLEANUP);
@@ -1687,9 +1687,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		 */
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    conn->type == BT_CONN_TYPE_LE) {
-			k_delayed_work_submit(
-				&conn->deferred_work,
-				K_MSEC(10 * bt_dev.create_param.timeout));
+			k_work_schedule(&conn->deferred_work,
+					K_MSEC(10 * bt_dev.create_param.timeout));
 		}
 
 		break;
@@ -2169,7 +2168,7 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 #endif /* CONFIG_BT_BREDR */
 
 		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-			k_delayed_work_cancel(&conn->deferred_work);
+			k_work_cancel_delayable(&conn->deferred_work);
 			return bt_le_create_conn_cancel();
 		}
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -187,7 +187,7 @@ struct bt_conn {
 	 * - Initiator connect create cancel.
 	 * - Connection cleanup.
 	 */
-	struct k_delayed_work	deferred_work;
+	struct k_work_delayable	deferred_work;
 
 	union {
 		struct bt_conn_le	le;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -43,7 +43,6 @@ enum {
 	BT_DEV_INITIATING,
 
 	BT_DEV_RPA_VALID,
-	BT_DEV_RPA_TIMEOUT_SET,
 
 	BT_DEV_ID_PENDING,
 	BT_DEV_STORE_ID,
@@ -302,7 +301,7 @@ struct bt_dev {
 	uint8_t			irk[CONFIG_BT_ID_MAX][16];
 
 	/* Work used for RPA rotation */
-	struct k_delayed_work rpa_update;
+	struct k_work_delayable rpa_update;
 #endif
 
 	/* Local Name */

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -185,9 +185,6 @@ static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 
 static void le_rpa_invalidate(void)
 {
-	/* RPA must be submitted */
-	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_SET);
-
 	/* Invalidate RPA */
 	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	      atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED))) {
@@ -202,12 +199,7 @@ static void le_rpa_invalidate(void)
 #if defined(CONFIG_BT_PRIVACY)
 static void le_rpa_timeout_submit(void)
 {
-	/* Check if RPA timer is running. */
-	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_SET)) {
-		return;
-	}
-
-	k_delayed_work_submit(&bt_dev.rpa_update, RPA_TIMEOUT);
+	(void)k_work_schedule(&bt_dev.rpa_update, RPA_TIMEOUT);
 }
 
 /* this function sets new RPA only if current one is no longer valid */
@@ -432,6 +424,17 @@ static void le_update_private_addr(void)
 		bt_le_scan_set_enable(BT_HCI_LE_SCAN_ENABLE);
 	}
 #endif
+}
+
+static void le_force_rpa_timeout(void)
+{
+#if defined(CONFIG_BT_PRIVACY)
+	struct k_work_sync sync;
+
+	k_work_cancel_delayable_sync(&bt_dev.rpa_update, &sync);
+#endif
+	le_rpa_invalidate();
+	le_update_private_addr();
 }
 
 #if defined(CONFIG_BT_PRIVACY)
@@ -1344,9 +1347,10 @@ int bt_setup_random_id_addr(void)
 static inline bool rpa_timeout_valid_check(void)
 {
 #if defined(CONFIG_BT_PRIVACY)
+	uint32_t remaining_ms = k_ticks_to_ms_floor32(
+		k_work_delayable_remaining_get(&bt_dev.rpa_update));
 	/* Check if create conn timeout will happen before RPA timeout. */
-	return k_delayed_work_remaining_get(&bt_dev.rpa_update) >
-	       (10 * bt_dev.create_param.timeout);
+	return remaining_ms > (10 * bt_dev.create_param.timeout);
 #else
 	return true;
 #endif
@@ -1366,8 +1370,7 @@ int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type)
 			/* Force new RPA timeout so that RPA timeout is not
 			 * triggered while direct initiator is active.
 			 */
-			le_rpa_invalidate();
-			le_update_private_addr();
+			le_force_rpa_timeout();
 		}
 
 		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
@@ -1627,8 +1630,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 			return -EINVAL;
 		}
 
-		le_rpa_invalidate();
-		le_update_private_addr();
+		le_force_rpa_timeout();
 
 		bt_addr_le_copy(&oob->addr, &bt_dev.random_addr);
 	} else {
@@ -1681,8 +1683,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 				}
 			}
 
-			le_rpa_invalidate();
-			le_update_private_addr();
+			le_force_rpa_timeout();
 		}
 
 		bt_addr_le_copy(&oob->addr, &adv->random_addr);
@@ -1766,7 +1767,7 @@ int bt_id_init(void)
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
-	k_delayed_work_init(&bt_dev.rpa_update, rpa_timeout);
+	k_work_init_delayable(&bt_dev.rpa_update, rpa_timeout);
 #endif
 
 	return 0;

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -11,11 +11,12 @@
 static inline bool bt_id_rpa_is_new(void)
 {
 #if defined(CONFIG_BT_PRIVACY)
+	uint32_t remaining_ms = k_ticks_to_ms_floor32(
+		k_work_delayable_remaining_get(&bt_dev.rpa_update));
 	/* RPA is considered new if there is less than half a second since the
 	 * timeout was started.
 	 */
-	return k_delayed_work_remaining_get(&bt_dev.rpa_update) >
-	       (RPA_TIMEOUT_MS - 500);
+	return remaining_ms > (RPA_TIMEOUT_MS - 500);
 #else
 	return false;
 #endif

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -330,7 +330,13 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		return false;
 	}
 
-	k_delayed_work_init(&chan->rtx_work, l2cap_rtx_timeout);
+	/* All dynamic channels have the destroy handler which makes sure that
+	 * the RTX work structure is properly released with a cancel sync.
+	 * The fixed signal channel is only removed when disconnected and the
+	 * disconnected handler is always called from the workqueue itself so
+	 * canceling from there should always succeed.
+	 */
+	k_work_init_delayable(&chan->rtx_work, l2cap_rtx_timeout);
 	atomic_clear(chan->status);
 
 	bt_l2cap_chan_add(conn, chan, destroy);
@@ -457,7 +463,7 @@ static void l2cap_chan_send_req(struct bt_l2cap_chan *chan,
 	 * final expiration, when the response is received, or the physical
 	 * link is lost.
 	 */
-	k_delayed_work_submit(&chan->rtx_work, timeout);
+	k_work_reschedule(&chan->rtx_work, timeout);
 }
 
 static int l2cap_le_conn_req(struct bt_l2cap_le_chan *ch)
@@ -912,8 +918,11 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 
 	BT_DBG("chan %p cid 0x%04x", ch, ch->rx.cid);
 
-	/* Cancel ongoing work */
-	k_delayed_work_cancel(&chan->rtx_work);
+	/* Cancel ongoing work. Since the channel can be re-used after this
+	 * we need to sync to make sure that the kernel does not have it
+	 * in its queue anymore.
+	 */
+	k_work_cancel_delayable_sync(&chan->rtx_work, &chan->rtx_sync);
 
 	if (ch->tx_buf) {
 		net_buf_unref(ch->tx_buf);
@@ -1421,7 +1430,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	case BT_L2CAP_LE_ERR_ENCRYPTION:
 		while ((chan = l2cap_lookup_ident(conn, ident))) {
 			/* Cancel RTX work */
-			k_delayed_work_cancel(&chan->chan.rtx_work);
+			k_work_cancel_delayable(&chan->chan.rtx_work);
 
 			/* If security needs changing wait it to be completed */
 			if (!l2cap_change_security(chan, result)) {
@@ -1442,7 +1451,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			struct bt_l2cap_chan *c;
 
 			/* Cancel RTX work */
-			k_delayed_work_cancel(&chan->chan.rtx_work);
+			k_work_cancel_delayable(&chan->chan.rtx_work);
 
 			dcid = net_buf_pull_le16(buf);
 
@@ -1539,7 +1548,7 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	}
 
 	/* Cancel RTX work */
-	k_delayed_work_cancel(&chan->chan.rtx_work);
+	k_work_cancel_delayable(&chan->chan.rtx_work);
 
 	/* Reset ident since it got a response */
 	chan->chan.ident = 0U;
@@ -2367,6 +2376,12 @@ static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
 	BT_DBG("ch %p cid 0x%04x", BT_L2CAP_LE_CHAN(chan),
 	       BT_L2CAP_LE_CHAN(chan)->rx.cid);
+
+	/* Cancel RTX work on signal channel.
+	 * Disconnected callback is always called from system worqueue
+	 * so this should always succeed.
+	 */
+	(void)k_work_cancel_delayable(&chan->rtx_work);
 }
 
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -156,8 +156,11 @@ static void l2cap_br_chan_destroy(struct bt_l2cap_chan *chan)
 {
 	BT_DBG("chan %p cid 0x%04x", BR_CHAN(chan), BR_CHAN(chan)->rx.cid);
 
-	/* Cancel ongoing work */
-	k_delayed_work_cancel(&chan->rtx_work);
+	/* Cancel ongoing work. Since the channel can be re-used after this
+	 * we need to sync to make sure that the kernel does not have it
+	 * in its queue anymore.
+	 */
+	k_work_cancel_delayable_sync(&chan->rtx_work, &chan->rtx_sync);
 
 	atomic_clear(BR_CHAN(chan)->flags);
 }
@@ -201,7 +204,13 @@ static bool l2cap_br_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		return false;
 	}
 
-	k_delayed_work_init(&chan->rtx_work, l2cap_br_rtx_timeout);
+	/* All dynamic channels have the destroy handler which makes sure that
+	 * the RTX work structure is properly released with a cancel sync.
+	 * The fixed signal channel is only removed when disconnected and the
+	 * disconnected handler is always called from the workqueue itself so
+	 * canceling from there should always succeed.
+	 */
+	k_work_init_delayable(&chan->rtx_work, l2cap_br_rtx_timeout);
 	bt_l2cap_chan_add(conn, chan, destroy);
 
 	return true;
@@ -250,7 +259,7 @@ static void l2cap_br_chan_send_req(struct bt_l2cap_br_chan *chan,
 	 * final expiration, when the response is received, or the physical
 	 * link is lost.
 	 */
-	k_delayed_work_submit(&chan->chan.rtx_work, timeout);
+	k_work_reschedule(&chan->chan.rtx_work, timeout);
 }
 
 static void l2cap_br_get_info(struct bt_l2cap_br *l2cap, uint16_t info_type)
@@ -332,7 +341,7 @@ static int l2cap_br_info_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		 * Release RTX timer since got the response & there's pending
 		 * command request.
 		 */
-		k_delayed_work_cancel(&l2cap->chan.chan.rtx_work);
+		k_work_cancel_delayable(&l2cap->chan.chan.rtx_work);
 	}
 
 	if (buf->len < sizeof(*rsp)) {
@@ -808,7 +817,7 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	}
 
 	/* Release RTX work since got the response */
-	k_delayed_work_cancel(&chan->rtx_work);
+	k_work_cancel_delayable(&chan->rtx_work);
 
 	/*
 	 * TODO: handle other results than success and parse response data if
@@ -1126,8 +1135,11 @@ static void l2cap_br_disconnected(struct bt_l2cap_chan *chan)
 
 	if (atomic_test_and_clear_bit(BR_CHAN(chan)->flags,
 				      L2CAP_FLAG_SIG_INFO_PENDING)) {
-		/* Cancel RTX work on signal channel */
-		k_delayed_work_cancel(&chan->rtx_work);
+		/* Cancel RTX work on signal channel.
+		 * Disconnected callback is always called from system worqueue
+		 * so this should always succeed.
+		 */
+		(void)k_work_cancel_delayable(&chan->rtx_work);
 	}
 }
 
@@ -1304,7 +1316,7 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	}
 
 	/* Release RTX work since got the response */
-	k_delayed_work_cancel(&chan->rtx_work);
+	k_work_cancel_delayable(&chan->rtx_work);
 
 	if (chan->state != BT_L2CAP_CONNECT) {
 		BT_DBG("Invalid channel %p state %s", chan,
@@ -1321,7 +1333,7 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		atomic_clear_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING);
 		break;
 	case BT_L2CAP_BR_PENDING:
-		k_delayed_work_submit(&chan->rtx_work, L2CAP_BR_CONN_TIMEOUT);
+		k_work_reschedule(&chan->rtx_work, L2CAP_BR_CONN_TIMEOUT);
 		break;
 	default:
 		l2cap_br_chan_cleanup(chan);

--- a/subsys/bluetooth/host/rfcomm_internal.h
+++ b/subsys/bluetooth/host/rfcomm_internal.h
@@ -21,7 +21,7 @@ struct bt_rfcomm_session {
 	/* L2CAP channel this context is associated with */
 	struct bt_l2cap_br_chan br_chan;
 	/* Response Timeout eXpired (RTX) timer */
-	struct k_delayed_work rtx_work;
+	struct k_work_delayable rtx_work;
 	/* Binary sem for aggregate fc */
 	struct k_sem fc;
 	struct bt_rfcomm_dlc *dlcs;


### PR DESCRIPTION
Update to bluetooth host and controller, excluding Bluetooth Mesh, to use the new deleayable work API.
