### PR TITLE
Enabling PWM support for STM32 F207ZG Platform

### DIFF
--- a/boards/arm/nucleo_f207zg/doc/index.rst
+++ b/boards/arm/nucleo_f207zg/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr nucleo_207zg board configuration supports the following hardware feat
 +-------------+------------+-------------------------------------+
 | Backup SRAM | on-chip    | Backup SRAM                         |
 +-------------+------------+-------------------------------------+
+| PWM         | on-chip    | PWM                                 |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -154,6 +156,7 @@ Default Zephyr Peripheral Mapping:
 - LD3 : PB14
 - DAC: PA4
 - ADC: PA0
+- PWM_1_CH1 : PE9
 
 System Clock
 ------------

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -115,3 +115,12 @@
 &backup_sram {
 	status = "okay";
 };
+
+&timers1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pe9>;
+	};
+};

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -21,3 +21,4 @@ supported:
   - adc
   - dac
   - backup_sram
+  - pwm

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -356,6 +356,150 @@
 			#io-channel-cells = <1>;
 		};
 
+		timers1: timers@40010000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40010000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000001>;
+			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+			label = "TIMERS_1";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_1";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000001>;
+			interrupts = <28 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_2";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_2";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000002>;
+			interrupts = <29 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_3";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_3";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000004>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_4";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_4";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers5: timers@40000c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
+			interrupts = <50 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_5";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_5";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers8: timers@40010400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40010400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000002>;
+			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+			label = "TIMERS_8";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_8";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers9: timers@40014000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00010000>;
+			interrupts = <24 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_9";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_9";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers12: timers@40001800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000040>;
+			interrupts = <43 0>;
+			interrupt-names = "global";
+			status = "disabled";
+			label = "TIMERS_12";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				st,prescaler = <0>;
+				label = "PWM_12";
+				#pwm-cells = <3>;
+			};
+		};
+
 		backup_sram: memory@40024000 {
 			compatible = "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;


### PR DESCRIPTION
Enabled PWM support for STM32 F207ZG target platform.

Verified PWM signals on timer1 using test application `tests/drivers/pwm`