### PR TITLE
Bluetooth: host: Fix ECC thread stack size too small

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -100,7 +100,7 @@ config BT_HCI_ECC_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be
 	# changed if required by architecture
 	int "HCI ECC thread stack size"
-	default 1100
+	default 1140
 	help
 	  NOTE: This is an advanced setting and should not be changed unless
 	  absolutely necessary


### PR DESCRIPTION
Fix ECC thread stack size which is to small to account for the worst
case scenario. When an interrupt happens at the point where the ECC
thread is at the highest stack size usage pushing the thread context
to service the ISR causes a stack overflow.

Increase the ECC thread stack size by atleast the size of the basic
stack frame of 32 bytes aligned on 8 byte for ARM architectures.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>