### PR TITLE
kernel: fix error in synchronous work cancellation return value

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3020,8 +3020,9 @@ int k_work_cancel(struct k_work *work);
  * one completes.  On architectures with CONFIG_KERNEL_COHERENCE the object
  * must be allocated in coherent memory.
  *
- * @retval true if work was not idle (call had to wait for cancellation to
- * complete);
+ * @retval true if work was pending (call had to wait for cancellation of a
+ * running handler to complete, or scheduled or submitted operations were
+ * cancelled);
  * @retval false otherwise
  */
 bool k_work_cancel_sync(struct k_work *work, struct k_work_sync *sync);
@@ -3357,8 +3358,9 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork);
  * one completes.  On architectures with CONFIG_KERNEL_COHERENCE the object
  * must be allocated in coherent memory.
  *
- * @retval true if work was not idle (call had to wait for cancellation to
- * complete);
+ * @retval true if work was not idle (call had to wait for cancellation of a
+ * running handler to complete, or scheduled or submitted operations were
+ * cancelled);
  * @retval false otherwise
  */
 bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -537,8 +537,10 @@ static void test_1cpu_queued_cancel_sync(void)
 	zassert_equal(rc, 1, NULL);
 	zassert_equal(coophi_counter(), 0, NULL);
 
-	/* Cancellation should complete immediately. */
-	zassert_false(k_work_cancel_sync(&work, &work_sync), NULL);
+	/* Cancellation should complete immediately, indicating that
+	 * work was pending.
+	 */
+	zassert_true(k_work_cancel_sync(&work, &work_sync), NULL);
 
 	/* Shouldn't have run. */
 	zassert_equal(coophi_counter(), 0, NULL);
@@ -582,8 +584,10 @@ static void test_1cpu_delayed_cancel_sync(void)
 	zassert_equal(rc, 1, NULL);
 	zassert_equal(coophi_counter(), 0, NULL);
 
-	/* Cancellation should complete immediately. */
-	zassert_false(k_work_cancel_delayable_sync(&dwork, &work_sync), NULL);
+	/* Cancellation should complete immediately, indicating that
+	 * work was pending.
+	 */
+	zassert_true(k_work_cancel_delayable_sync(&dwork, &work_sync), NULL);
 
 	/* Shouldn't have run. */
 	zassert_equal(coophi_counter(), 0, NULL);


### PR DESCRIPTION
The return value is documented to be true if the work was pending, but
the implementation returned true only if the work was actually running
(i.e. the caller had to wait).  It should also return true if
scheduled or submitted work was cancelled.

Note that this means the return value cannot be used to determine
whether the call slept.

Fixes #34363

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>