### PR TITLE
Bluetooth: host: Document default behavior of le_param_req with no cb

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -819,6 +819,9 @@ struct bt_conn_cb {
 	 *  parameters as returned by previous callbacks, i.e. they are not
 	 *  necessarily the same ones as the remote originally sent.
 	 *
+	 *  If the application does not have this callback then the default
+	 *  is to accept the parameters.
+	 *
 	 *  @param conn Connection object.
 	 *  @param param Proposed connection parameters.
 	 *


### PR DESCRIPTION
Document the default behavior of LE connection parameters request when
the application has not defined a callback.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>