### PR TITLE
Bluetooth: controller: Add support for initiator on secondary adv channels

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -709,6 +709,14 @@ struct bt_le_per_adv_param {
 						 BT_GAP_ADV_FAST_INT_MAX_2, \
 						 NULL)
 
+/** Connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
+#define BT_LE_EXT_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
+						BT_LE_ADV_OPT_CONNECTABLE | \
+						BT_LE_ADV_OPT_USE_NAME, \
+						BT_GAP_ADV_FAST_INT_MIN_2, \
+						BT_GAP_ADV_FAST_INT_MAX_2, \
+						NULL)
+
 /** Non-connectable extended advertising with private address */
 #define BT_LE_EXT_ADV_NCONN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3141,12 +3141,20 @@ static void le_ext_create_connection(struct net_buf *buf, struct net_buf **evt)
 						      conn_latency,
 						      supervision_timeout,
 						      phy);
-			if (status) {
-				*evt = cmd_status(status);
-				return;
-			}
-
 			p++;
+		} else {
+			uint8_t type;
+
+			type = (phy << 1);
+			/* NOTE: Pass invalid interval value to not start
+			 *       scanning using this scan instance.
+			 */
+			status = ll_scan_params_set(type, 0, 0, 0, 0);
+		}
+
+		if (status) {
+			*evt = cmd_status(status);
+			return;
 		}
 
 		phys_bitmask &= (phys_bitmask - 1);

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -63,6 +63,10 @@ struct lll_scan_aux {
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	int8_t tx_pwr_lvl;
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
+
+#if defined(CONFIG_BT_CENTRAL)
+	struct node_rx_pdu *node_conn_rx;
+#endif /* CONFIG_BT_CENTRAL */
 };
 
 int lll_scan_init(void);

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -24,9 +24,7 @@ struct lll_scan {
 	uint8_t  filter_policy:2;
 	uint8_t  type:1;
 	uint8_t  init_addr_type:1;
-#if defined(CONFIG_BT_CENTRAL)
-	uint8_t  adv_addr_type:1;
-#endif /* CONFIG_BT_CENTRAL */
+	uint8_t  is_stop:1;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	uint16_t duration_reload;
@@ -34,6 +32,10 @@ struct lll_scan {
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+#if defined(CONFIG_BT_CENTRAL)
+	uint8_t  adv_addr_type:1;
+#endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	uint8_t  rpa_gen:1;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -856,7 +856,11 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	if (0) {
 #if defined(CONFIG_BT_CENTRAL)
 	/* Initiator */
+	/* Note: connectable ADV_EXT_IND is handled as any other ADV_EXT_IND
+	 *       because we need to receive AUX_ADV_IND anyway.
+	 */
 	} else if (lll->conn && !lll->conn->master.cancelled &&
+		   (pdu_adv_rx->type != PDU_ADV_TYPE_EXT_IND) &&
 		   isr_scan_init_check(lll, pdu_adv_rx, rl_idx)) {
 		struct lll_conn *lll_conn;
 		struct node_rx_ftr *ftr;
@@ -1113,7 +1117,11 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		   isr_scan_rsp_adva_matches(pdu_adv_rx))) &&
 		 (pdu_adv_rx->len != 0) &&
 #if defined(CONFIG_BT_CENTRAL)
-		   !lll->conn) {
+		   /* Note: ADV_EXT_IND is allowed here even if initiating
+		    *       because we still need to get AUX_ADV_IND as for any
+		    *       other ADV_EXT_IND.
+		    */
+		   (!lll->conn || (pdu_adv_rx->type == PDU_ADV_TYPE_EXT_IND))) {
 #else /* !CONFIG_BT_CENTRAL */
 		   1) {
 #endif /* !CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -113,6 +113,7 @@ void lll_scan_prepare(void *param)
 	LL_ASSERT(!err || err == -EINPROGRESS);
 }
 
+#if defined(CONFIG_BT_CENTRAL)
 void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 				  uint8_t phy, uint8_t adv_tx_addr,
 				  uint8_t *adv_addr, uint8_t init_tx_addr,
@@ -198,6 +199,7 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 	pdu_tx->connect_ind.hop = lll_conn->data_chan_hop;
 	pdu_tx->connect_ind.sca = lll_clock_sca_local_get();
 }
+#endif /* CONFIG_BT_CENTRAL */
 
 static int init_reset(void)
 {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -153,24 +153,17 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 	 * 1.25ms for a legacy PDU, 2.5ms for an LE Uncoded PHY and 3.75ms for
 	 * an LE Coded PHY.
 	 */
-	switch (phy) {
-	case PHY_LEGACY:
-		conn_offset_us += 1250;
-		break;
+	if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	case PHY_1M:
-	case PHY_2M:
-		conn_offset_us += 2500;
-		break;
-#if defined(CONFIG_BT_CTLR_PHY_CODED)
-	case PHY_CODED:
-		conn_offset_us += 3750;
-		break;
-#endif /* CONFIG_BT_CTLR_PHY_CODED */
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
-	default:
-		LL_ASSERT(0);
-		break;
+	} else if (phy) {
+		if (phy & PHY_CODED) {
+			conn_offset_us += WIN_DELAY_CODED;
+		} else {
+			conn_offset_us += WIN_DELAY_UNCODED;
+		}
+#endif
+	} else {
+		conn_offset_us += WIN_DELAY_LEGACY;
 	}
 
 	if (!IS_ENABLED(CONFIG_BT_CTLR_SCHED_ADVANCED) ||

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -144,7 +144,9 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 	pdu_tx->connect_ind.win_size = 1;
 
 	conn_interval_us = (uint32_t)lll_conn->interval * CONN_INT_UNIT_US;
-	conn_offset_us = radio_tmr_end_get() + 502;
+	conn_offset_us = radio_tmr_end_get() + EVENT_IFS_US +
+			 PKT_AC_US(sizeof(struct pdu_adv_connect_ind), 0,
+				   phy == PHY_LEGACY ? PHY_1M : phy);
 
 	/* Add transmitWindowDelay to default calculated connection offset:
 	 * 1.25ms for a legacy PDU, 2.5ms for an LE Uncoded PHY and 3.75ms for
@@ -981,7 +983,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = conn_space_us -
-				    radio_tx_chain_delay_get(0, 0);
+				    radio_rx_chain_delay_get(PHY_1M, 0);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -23,25 +23,46 @@
 #include "lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_filter.h"
+#include "lll_conn.h"
 #include "lll_scan.h"
 #include "lll_scan_aux.h"
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
+#include "lll_scan_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_scan_aux
 #include "common/log.h"
 #include <soc.h>
+#include <ull_scan_types.h>
 #include "hal/debug.h"
+
+#if defined(CONFIG_BT_CENTRAL)
+static uint8_t lll_scan_connect_req_pdu[PDU_AC_LL_HEADER_SIZE +
+					sizeof(struct pdu_adv_connect_ind)];
+#endif /* CONFIG_BT_CENTRAL */
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void isr_rx(void *param);
-static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t rssi_ready);
+static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
+		      uint8_t devmatch_id, uint8_t irkmatch_ok,
+		      uint8_t irkmatch_id, uint8_t rl_idx, uint8_t rssi_ready);
+#if defined(CONFIG_BT_CENTRAL)
+static void isr_tx_connect_req(void *param);
+static void isr_rx_connect_rsp(void *param);
+#endif /* CONFIG_BT_CENTRAL */
 static void isr_done(void *param);
+
+#if defined(CONFIG_BT_CENTRAL)
+static inline bool isr_scan_init_check(struct lll_scan *lll,
+				       struct pdu_adv *pdu, uint8_t rl_idx);
+static bool isr_scan_connect_rsp_check(struct pdu_adv *pdu_tx,
+				       struct pdu_adv *pdu_rx);
+#endif /* CONFIG_BT_CENTRAL */
 
 static uint16_t trx_cnt; /* TODO: move to a union in lll.c, common to all roles
 			  */
@@ -89,6 +110,9 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *p)
 {
 	struct node_rx_pdu *node_rx;
+	struct ll_scan_aux_set *aux_set;
+	struct ll_scan_set *scan_set;
+	struct lll_scan *lll_scan;
 	struct lll_scan_aux *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
@@ -107,6 +131,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	trx_cnt = 0U;
 
 	lll = p->param;
+	aux_set = HDR_LLL2ULL(lll);
+	scan_set = HDR_LLL2ULL(aux_set->rx_head->rx_ftr.param);
+	lll_scan = &scan_set->lll;
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	radio_tx_power_set(lll->tx_pwr_lvl);
@@ -135,7 +162,30 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(lll->phy, 0, lll->phy, 1);
 
-	/* TODO: privacy */
+	/* TODO: skip filtering if AdvA was already found in previous PDU */
+
+	if (0) {
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	} else if (ull_filter_lll_rl_enabled()) {
+		struct lll_filter *filter = ull_filter_lll_get(
+			!!(lll_scan->filter_policy & 0x1));
+		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
+
+		radio_filter_configure(filter->enable_bitmask,
+				       filter->addr_type_bitmask,
+				       (uint8_t *) filter->bdaddr);
+
+		radio_ar_configure(count, irks, (lll->phy << 2) | BIT(1));
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) &&
+		   lll_scan->filter_policy) {
+		/* Setup Radio Filter */
+		struct lll_filter *wl = ull_filter_lll_get(true);
+
+		radio_filter_configure(wl->enable_bitmask,
+				       wl->addr_type_bitmask,
+				       (uint8_t *)wl->bdaddr);
+	}
 
 	/* Calculate event timings, coarse and fine */
 	ticks_at_event = p->ticks_at_expire;
@@ -218,10 +268,18 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 static void isr_rx(void *param)
 {
-	struct lll_scan_aux *lll;
+	struct lll_scan_aux *lll_aux;
+	struct ll_scan_aux_set *aux;
+	struct ll_scan_set *scan;
+	struct lll_scan *lll;
+	uint8_t devmatch_ok;
+	uint8_t devmatch_id;
+	uint8_t irkmatch_ok;
+	uint8_t irkmatch_id;
 	uint8_t rssi_ready;
 	uint8_t trx_done;
 	uint8_t crc_ok;
+	uint8_t rl_idx;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -231,15 +289,23 @@ static void isr_rx(void *param)
 	trx_done = radio_is_done();
 	if (trx_done) {
 		crc_ok = radio_crc_is_valid();
+		devmatch_ok = radio_filter_has_match();
+		devmatch_id = radio_filter_match_get();
+		irkmatch_ok = radio_ar_has_match();
+		irkmatch_id = radio_ar_match_get();
 		rssi_ready = radio_rssi_is_ready();
 	} else {
-		crc_ok = rssi_ready = 0U;
+		crc_ok = devmatch_ok = irkmatch_ok = rssi_ready = 0U;
+		devmatch_id = irkmatch_id = 0xFF;
 	}
 
 	/* Clear radio rx status and events */
 	lll_isr_rx_status_reset();
 
-	lll = param;
+	lll_aux = param;
+	aux = HDR_LLL2ULL(lll_aux);
+	scan = HDR_LLL2ULL(aux->rx_head->rx_ftr.param);
+	lll = &scan->lll;
 
 	/* No Rx */
 	if (!trx_done) {
@@ -248,10 +314,21 @@ static void isr_rx(void *param)
 		goto isr_rx_do_close;
 	}
 
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	rl_idx = devmatch_ok ?
+		 ull_filter_lll_rl_idx(!!(lll->filter_policy & 0x01),
+				       devmatch_id) :
+		 irkmatch_ok ? ull_filter_lll_rl_irk_idx(irkmatch_id) :
+		 FILTER_IDX_NONE;
+#else
+	rl_idx = FILTER_IDX_NONE;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
 	if (crc_ok) {
 		int err;
 
-		err = isr_rx_pdu(lll, rssi_ready);
+		err = isr_rx_pdu(lll_aux, devmatch_ok, devmatch_id,
+				 irkmatch_ok, irkmatch_ok, rl_idx, rssi_ready);
 		if (!err) {
 			if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 				lll_prof_send();
@@ -262,15 +339,29 @@ static void isr_rx(void *param)
 	}
 
 isr_rx_do_close:
-	radio_isr_set(isr_done, lll);
+	radio_isr_set(isr_done, lll_aux);
 	radio_disable();
 }
 
-static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t rssi_ready)
+static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
+		      uint8_t devmatch_id, uint8_t irkmatch_ok,
+		      uint8_t irkmatch_id, uint8_t rl_idx, uint8_t rssi_ready)
 {
+	struct ll_scan_aux_set *aux;
+	struct ll_scan_set *scan;
 	struct node_rx_pdu *node_rx;
 	struct node_rx_ftr *ftr;
+	struct lll_scan *lll_scan;
 	struct pdu_adv *pdu;
+
+#if defined(CONFIG_BT_CENTRAL)
+	/* AUX_CONNECT_REQ is the same as CONNECT_IND */
+	const uint8_t aux_connect_req_len = sizeof(struct pdu_adv_connect_ind);
+	/* AUX_CONNECT_RSP has only AdvA and TargetA in extended header */
+	const uint8_t aux_connect_rsp_len = PDU_AC_EXT_HEADER_SIZE_MIN +
+					    sizeof(struct pdu_adv_ext_hdr) +
+					    ADVA_SIZE + TARGETA_SIZE;
+#endif
 
 	node_rx = ull_pdu_rx_alloc_peek(3);
 	if (!node_rx) {
@@ -282,31 +373,315 @@ static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t rssi_ready)
 		return -EINVAL;
 	}
 
-	ull_pdu_rx_alloc();
+	aux = HDR_LLL2ULL(lll);
+	scan = HDR_LLL2ULL(aux->rx_head->rx_ftr.param);
+	lll_scan = &scan->lll;
 
-	trx_cnt++;
+	if (0) {
+#if defined(CONFIG_BT_CENTRAL)
+	/* Initiator */
+	} else if (lll_scan->conn &&
+		   (pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_CONN) &&
+		   isr_scan_init_check(lll_scan, pdu, rl_idx)) {
+		struct node_rx_ftr *ftr;
+		struct node_rx_pdu *rx;
+		struct pdu_adv *pdu_tx;
+		uint32_t conn_space_us;
+		struct ull_hdr *ull;
+		uint32_t pdu_end_us;
+		uint8_t init_tx_addr;
+		uint8_t *init_addr;
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+		bt_addr_t *lrpa;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_REPORT;
+		/* Always use CSA#2 on secondary channel, we need 2 nodes for conn
+		 * and CSA#2 events and 2 nodes are always reserved for connection.
+		 */
+		rx = ull_pdu_rx_alloc_peek(4);
 
-	ftr = &(node_rx->hdr.rx_ftr);
-	ftr->param = lll;
-	ftr->ticks_anchor = radio_tmr_start_get();
-	ftr->radio_end_us = radio_tmr_end_get() -
-			    radio_rx_chain_delay_get(lll->phy, 1);
+		if (!rx) {
+			return -ENOBUFS;
+		}
 
-	ftr->rssi = (rssi_ready) ? radio_rssi_get() :
-				   BT_HCI_LE_RSSI_NOT_AVAILABLE;
+		pdu_end_us = radio_tmr_end_get();
+		if (!lll_scan->ticks_window) {
+			uint32_t scan_interval_us;
+
+			/* FIXME: is this correct for continuous scanning? */
+			scan_interval_us = lll_scan->interval * SCAN_INT_UNIT_US;
+			pdu_end_us %= scan_interval_us;
+		}
+
+		ull = HDR_LLL2ULL(lll_scan);
+		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(ull->ticks_slot) -
+				  EVENT_IFS_US -
+				  PKT_AC_US(aux_connect_req_len, 0,
+					    lll->phy) -
+				  EVENT_IFS_US -
+				  PKT_AC_US(aux_connect_rsp_len, 0,
+					    lll->phy) -
+				  EVENT_OVERHEAD_START_US -
+				  EVENT_TICKER_RES_MARGIN_US)) {
+			return -ETIME;
+		}
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	/* TODO: Use correct rl_idx value when privacy support is added */
-	ftr->rl_idx = FILTER_IDX_NONE;
+		lrpa = ull_filter_lll_lrpa_get(rl_idx);
+		if (lll_scan->rpa_gen && lrpa) {
+			init_tx_addr = 1;
+			init_addr = lrpa->val;
+		} else {
+#else
+		if (1) {
+#endif
+			init_tx_addr = lll_scan->init_addr_type;
+			init_addr = lll_scan->init_addr;
+		}
+
+		pdu_tx = (void *)lll_scan_connect_req_pdu;
+
+		lll_scan_prepare_connect_req(lll_scan, pdu_tx, lll->phy,
+					     pdu->tx_addr,
+					     pdu->adv_ext_ind.ext_hdr.data,
+					     init_tx_addr, init_addr,
+					     &conn_space_us);
+
+		radio_pkt_tx_set(pdu_tx);
+
+		/* assert if radio packet ptr is not set and radio started tx */
+		LL_ASSERT(!radio_is_ready());
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			lll_prof_cputime_capture();
+		}
+
+		/* capture end of Tx-ed PDU, used to calculate HCTO. */
+		radio_tmr_end_capture();
+
+		radio_tmr_tifs_set(EVENT_IFS_US);
+		radio_switch_complete_and_rx(PHY_1M);
+		radio_isr_set(isr_tx_connect_req, lll);
+
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			/* PA/LNA enable is overwriting packet end
+			 * used in ISR profiling, hence back it up
+			 * for later use.
+			 */
+			lll_prof_radio_end_backup();
+		}
+		radio_gpio_pa_setup();
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
+					 radio_rx_chain_delay_get(0, 0) -
+					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
+
+#if defined(CONFIG_BT_CTLR_CONN_RSSI)
+		if (rssi_ready) {
+			lll_scan->conn->rssi_latest =  radio_rssi_get();
+		}
+#endif /* CONFIG_BT_CTLR_CONN_RSSI */
+
+		/* block CPU so that there is no CRC error on pdu tx,
+		 * this is only needed if we want the CPU to sleep.
+		 * while(!radio_has_disabled())
+		 * {cpu_sleep();}
+		 * radio_status_reset();
+		 */
+
+		rx = ull_pdu_rx_alloc();
+
+		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
+		rx->hdr.handle = 0xffff;
+
+		memcpy(rx->pdu, pdu_tx, (offsetof(struct pdu_adv, connect_ind) +
+					 sizeof(struct pdu_adv_connect_ind)));
+
+		/* ChSel is RFU in AUX_ADV_IND but we do need to use CSA#2 for
+		 * connections initiated on the secondary advertising channel
+		 * thus overwrise chan_sel to make it work seamlessly.
+		 */
+		pdu = (void *)rx->pdu;
+		pdu->chan_sel = 1;
+
+		ftr = &(rx->hdr.rx_ftr);
+
+		ftr->param = lll_scan;
+		ftr->ticks_anchor = radio_tmr_start_get();
+		ftr->radio_end_us = conn_space_us -
+				    radio_rx_chain_delay_get(lll->phy, 1);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
+		ftr->lrpa_used = lll_scan->rpa_gen && lrpa;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+		ftr->extra = ull_pdu_rx_alloc();
+
+		lll->node_conn_rx = rx;
+
+		return 0;
+#endif /* CONFIG_BT_CENTRAL */
+	} else {
+		ull_pdu_rx_alloc();
+
+		trx_cnt++;
+
+		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_REPORT;
+
+		ftr = &(node_rx->hdr.rx_ftr);
+		ftr->param = lll;
+		ftr->ticks_anchor = radio_tmr_start_get();
+		ftr->radio_end_us = radio_tmr_end_get() -
+				    radio_rx_chain_delay_get(lll->phy, 1);
+
+		ftr->rssi = (rssi_ready) ? radio_rssi_get() :
+			    BT_HCI_LE_RSSI_NOT_AVAILABLE;
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+		/* TODO: Use correct rl_idx value when privacy support is added */
+		ftr->rl_idx = FILTER_IDX_NONE;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+	}
 
 	ull_rx_put(node_rx->hdr.link, node_rx);
 	ull_rx_sched();
 
 	return -ECANCELED;
 }
+
+#if defined(CONFIG_BT_CENTRAL)
+static void isr_tx_connect_req(void *param)
+{
+	struct lll_scan_aux *lll_aux;
+	uint32_t hcto;
+
+	/* Clear radio tx status and events */
+	lll_isr_tx_status_reset();
+
+	lll_aux = param;
+
+	radio_pkt_rx_set(radio_pkt_scratch_get());
+
+	/* assert if radio packet ptr is not set and radio started rx */
+	LL_ASSERT(!radio_is_ready());
+
+	radio_tmr_tifs_set(EVENT_IFS_US);
+	radio_switch_complete_and_disable();
+	radio_isr_set(isr_rx_connect_rsp, param);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	if (ull_filter_lll_rl_enabled()) {
+		uint8_t count, *irks = ull_filter_lll_irks_get(&count);
+
+		radio_ar_configure(count, irks, (lll_aux->phy << 2) | BIT(1));
+	}
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+
+	/* +/- 2us active clock jitter, +1 us hcto compensation */
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
+	hcto += radio_rx_chain_delay_get(lll_aux->phy, 1);
+	hcto += addr_us_get(lll_aux->phy);
+	hcto -= radio_tx_chain_delay_get(lll_aux->phy, 0);
+	radio_tmr_hcto_configure(hcto);
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_REQ_RSSI) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_CONN_RSSI)) {
+		radio_rssi_measure();
+	}
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		/* PA/LNA enable is overwriting packet end used in ISR
+		 * profiling, hence back it up for later use.
+		 */
+		lll_prof_radio_end_backup();
+	}
+
+	radio_gpio_lna_setup();
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
+				 radio_tx_chain_delay_get(lll_aux->phy, 0) -
+				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
+#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		/* NOTE: as scratch packet is used to receive, it is safe to
+		 * generate profile event using rx nodes.
+		 */
+		lll_prof_send();
+	}
+}
+
+static void isr_rx_connect_rsp(void *param)
+{
+	struct node_rx_pdu *rx;
+	struct ll_scan_aux_set *aux;
+	struct lll_scan *lll;
+	struct ll_scan_set *scan;
+	struct lll_scan_aux *lll_aux;
+	struct pdu_adv *pdu_rx;
+	uint8_t trx_done;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_latency_capture();
+	}
+
+	/* Read radio status */
+	trx_done = radio_is_done();
+
+	/* Clear radio rx status and events */
+	lll_isr_rx_status_reset();
+
+	lll_aux = param;
+	aux = HDR_LLL2ULL(lll_aux);
+	scan = HDR_LLL2ULL(aux->rx_head->rx_ftr.param);
+	lll = &scan->lll;
+
+	rx = lll_aux->node_conn_rx;
+	LL_ASSERT(rx);
+	lll_aux->node_conn_rx = NULL;
+
+	if (trx_done) {
+		pdu_rx = radio_pkt_scratch_get();
+
+		trx_done = isr_scan_connect_rsp_check(
+					(void *)lll_scan_connect_req_pdu,
+					pdu_rx);
+	}
+
+	/* No Rx or invalid PDU received */
+	if (!trx_done) {
+		struct node_rx_ftr *ftr;
+
+		ftr = &(rx->hdr.rx_ftr);
+
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
+		ull_rx_put(rx->hdr.link, rx);
+
+		rx = ftr->extra;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
+		goto isr_rx_do_close;
+	}
+
+	/* Stop further LLL radio events */
+	lll->conn->master.initiated = 1;
+
+#if defined(CONFIG_BT_CTLR_PHY)
+	lll->conn->phy_tx = lll_aux->phy;
+	lll->conn->phy_tx_time = lll_aux->phy;
+	lll->conn->phy_rx = lll_aux->phy;
+#endif /* CONFIG_BT_CTLR_PHY */
+
+isr_rx_do_close:
+	ull_rx_put(rx->hdr.link, rx);
+	ull_rx_sched();
+
+	radio_isr_set(isr_done, lll);
+	radio_disable();
+}
+#endif /* CONFIG_BT_CENTRAL */
 
 static void isr_done(void *param)
 {
@@ -323,3 +698,60 @@ static void isr_done(void *param)
 
 	lll_isr_cleanup(param);
 }
+
+#if defined(CONFIG_BT_CENTRAL)
+static inline bool isr_scan_init_check(struct lll_scan *lll,
+				       struct pdu_adv *pdu, uint8_t rl_idx)
+{
+	uint8_t is_directed = pdu->adv_ext_ind.ext_hdr.tgt_addr;
+	uint8_t tx_addr = pdu->tx_addr;
+	uint8_t rx_addr = pdu->rx_addr;
+	uint8_t *adva = &pdu->adv_ext_ind.ext_hdr.data[ADVA_OFFSET];
+	uint8_t *tgta = &pdu->adv_ext_ind.ext_hdr.data[TGTA_OFFSET];
+
+	if (pdu->len <
+	    PDU_AC_EXT_HEADER_SIZE_MIN + sizeof(struct pdu_adv_ext_hdr) +
+	    ADVA_SIZE) {
+		return false;
+	}
+
+	if (is_directed && (pdu->len < PDU_AC_EXT_HEADER_SIZE_MIN +
+				       sizeof(struct pdu_adv_ext_hdr) +
+				       ADVA_SIZE + TARGETA_SIZE)) {
+		return false;
+	}
+
+	return ((((lll->filter_policy & 0x01) != 0U) ||
+		 lll_scan_adva_check(lll, tx_addr, adva, rl_idx)) &&
+		((!is_directed) || (is_directed &&
+				    lll_scan_tgta_check(lll, true, rx_addr,
+							tgta, rl_idx, NULL))));
+}
+
+bool isr_scan_connect_rsp_check(struct pdu_adv *pdu_tx, struct pdu_adv *pdu_rx)
+{
+	if (pdu_rx->type != PDU_ADV_TYPE_AUX_CONNECT_RSP) {
+		return false;
+	}
+
+	if (pdu_rx->len != offsetof(struct pdu_adv_com_ext_adv,
+				    ext_hdr_adv_data) +
+			   offsetof(struct pdu_adv_ext_hdr, data) + ADVA_SIZE +
+			   TARGETA_SIZE) {
+		return false;
+	}
+
+	if (pdu_rx->adv_ext_ind.adv_mode ||
+	    !pdu_rx->adv_ext_ind.ext_hdr.adv_addr ||
+	    !pdu_rx->adv_ext_ind.ext_hdr.tgt_addr) {
+		return false;
+	}
+
+	return (pdu_rx->tx_addr == pdu_tx->rx_addr) &&
+	       (pdu_rx->rx_addr == pdu_tx->tx_addr) &&
+	       (memcmp(&pdu_rx->adv_ext_ind.ext_hdr.data[ADVA_OFFSET],
+		       pdu_tx->connect_ind.adv_addr, BDADDR_SIZE) == 0) &&
+	       (memcmp(&pdu_rx->adv_ext_ind.ext_hdr.data[TGTA_OFFSET],
+		       pdu_tx->connect_ind.init_addr, BDADDR_SIZE) == 0);
+}
+#endif /* CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -546,8 +546,11 @@ static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
 		lll->node_conn_rx = rx;
 
 		return 0;
-#endif /* CONFIG_BT_CENTRAL */
+
+	} else if (!lll_scan->conn) {
+#else /* !CONFIG_BT_CENTRAL */
 	} else {
+#endif /* !CONFIG_BT_CENTRAL */
 		ull_pdu_rx_alloc();
 
 		trx_cnt++;
@@ -567,10 +570,10 @@ static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
 		/* TODO: Use correct rl_idx value when privacy support is added */
 		ftr->rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-	}
 
-	ull_rx_put(node_rx->hdr.link, node_rx);
-	ull_rx_sched();
+		ull_rx_put(node_rx->hdr.link, node_rx);
+		ull_rx_sched();
+	}
 
 	return -ECANCELED;
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
+				  uint8_t adv_tx_addr, uint8_t *adv_addr,
+				  uint8_t init_tx_addr, uint8_t *init_addr,
+				  uint32_t *conn_space_us);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -5,9 +5,9 @@
  */
 
 void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
-				  uint8_t adv_tx_addr, uint8_t *adv_addr,
-				  uint8_t init_tx_addr, uint8_t *init_addr,
-				  uint32_t *conn_space_us);
+				  uint8_t phy, uint8_t adv_tx_addr,
+				  uint8_t *adv_addr, uint8_t init_tx_addr,
+				  uint8_t *init_addr, uint32_t *conn_space_us);
 
 bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
 			 uint8_t rl_idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -8,3 +8,9 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 				  uint8_t adv_tx_addr, uint8_t *adv_addr,
 				  uint8_t init_tx_addr, uint8_t *init_addr,
 				  uint32_t *conn_space_us);
+
+bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
+			 uint8_t rl_idx);
+
+bool lll_scan_tgta_check(struct lll_scan *lll, bool init, uint8_t addr_type,
+			 uint8_t *addr, uint8_t rl_idx, bool *dir_report);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -961,12 +961,32 @@ void ll_rx_dequeue(void)
 			ARG_UNUSED(cc);
 #endif /* !CONFIG_BT_PERIPHERAL */
 
-		} else if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+#if defined(CONFIG_BT_CENTRAL)
+		} else {
 			struct ll_scan_set *scan = HDR_LLL2ULL(ftr->param);
 
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
+			struct ll_scan_set *scan_other =
+				ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+
+			if (scan_other) {
+				if (scan_other == scan) {
+					scan_other = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
+				}
+
+				if (scan_other) {
+					scan_other->lll.conn = NULL;
+					scan_other->is_enabled = 0U;
+				}
+			}
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
+
+			scan->lll.conn = NULL;
 			scan->is_enabled = 0U;
+#else /* !CONFIG_BT_CENTRAL */
 		} else {
 			LL_ASSERT(0);
+#endif /* !CONFIG_BT_CENTRAL */
 		}
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY)) {

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -181,9 +181,15 @@
 #define BT_CTLR_MAX_CONNECTABLE 1
 #endif
 #define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CENTRAL)
+#define BT_CTLR_ADV_EXT_RX_CNT  1
+#else
+#define BT_CTLR_ADV_EXT_RX_CNT  0
+#endif
 #else
 #define BT_CTLR_MAX_CONNECTABLE 0
 #define BT_CTLR_MAX_CONN        0
+#define BT_CTLR_ADV_EXT_RX_CNT  0
 #endif
 
 #if !defined(TICKER_USER_LLL_VENDOR_OPS)
@@ -285,7 +291,7 @@ static struct {
 /* No. of node rx for LLL to ULL.
  * Reserve 3, 1 for adv data, 1 for scan response and 1 for empty PDU reception.
  */
-#define PDU_RX_CNT    (CONFIG_BT_CTLR_RX_BUFFERS + 3)
+#define PDU_RX_CNT    (3 + BT_CTLR_ADV_EXT_RX_CNT + CONFIG_BT_CTLR_RX_BUFFERS)
 
 /* Part sum of LLL to ULL and ULL to LL/HCI thread node rx count.
  * Will be used below in allocating node rx pool.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -61,12 +61,12 @@ static int init_reset(void);
 static inline struct ll_adv_set *is_disabled_get(uint8_t handle);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 		      uint16_t lazy, uint8_t force, void *param);
-static void ticker_op_update_cb(uint32_t status, void *params);
+static void ticker_op_update_cb(uint32_t status, void *param);
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static void ticker_stop_cb(uint32_t ticks_at_expire, uint32_t remainder,
 			   uint16_t lazy, uint8_t force, void *param);
-static void ticker_op_stop_cb(uint32_t status, void *params);
+static void ticker_op_stop_cb(uint32_t status, void *param);
 static void disabled_cb(void *param);
 static void conn_release(struct ll_adv_set *adv);
 #endif /* CONFIG_BT_PERIPHERAL */
@@ -275,7 +275,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 	adv->is_created = 1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
-	/* remember params so that set adv/scan data and adv enable
+	/* remember parameters so that set adv/scan data and adv enable
 	 * interface can correctly update adv/scan data in the
 	 * double buffer between caller and controller context.
 	 */
@@ -1836,7 +1836,7 @@ static void ticker_op_stop_cb(uint32_t status, void *param)
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	/* FIXME: why is this here for Mesh commands? */
-	if (params) {
+	if (param) {
 		return;
 	}
 #endif /* CONFIG_BT_HCI_MESH_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5182,7 +5182,7 @@ static inline int length_req_rsp_recv(struct ll_conn *conn, memq_link_t *link,
 #endif /* CONFIG_BT_CTLR_PHY */
 			}
 
-			/* prepare event params */
+			/* prepare event parameters */
 			lr->max_rx_octets = sys_cpu_to_le16(eff_rx_octets);
 			lr->max_tx_octets = sys_cpu_to_le16(eff_tx_octets);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -152,12 +152,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 	}
 
-	ull_scan_params_set(lll, 0, scan_interval, scan_window, filter_policy);
-
-	lll->adv_addr_type = peer_addr_type;
-	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
-	lll->conn_timeout = timeout;
-
 	conn_lll = &conn->lll;
 
 	err = util_aa_le32(conn_lll->access_addr);
@@ -354,6 +348,11 @@ conn_is_valid:
 #endif
 
 	scan->own_addr_type = own_addr_type;
+	lll->adv_addr_type = peer_addr_type;
+	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
+	lll->conn_timeout = timeout;
+
+	ull_scan_params_set(lll, 0, scan_interval, scan_window, filter_policy);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -55,6 +55,9 @@
 #include "hal/debug.h"
 
 static void ticker_op_stop_scan_cb(uint32_t status, void *param);
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
+static void ticker_op_stop_scan_other_cb(uint32_t status, void *param);
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
 static void ticker_op_cb(uint32_t status, void *param);
 static inline void conn_release(struct ll_scan_set *scan);
 
@@ -669,28 +672,28 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	uint8_t ticker_id_scan, ticker_id_conn;
 	uint8_t peer_addr[BDADDR_SIZE];
 	uint32_t ticks_slot_overhead;
-	struct ll_scan_set *scan;
 	uint32_t ticks_slot_offset;
+	struct ll_scan_set *scan;
 	struct pdu_adv *pdu_tx;
-	struct node_rx_cc *cc;
-	struct ll_conn *conn;
 	uint8_t peer_addr_type;
 	uint32_t ticker_status;
+	struct node_rx_cc *cc;
+	struct ll_conn *conn;
 	uint8_t chan_sel;
 
-	((struct lll_scan *)ftr->param)->conn = NULL;
-
-	scan = ((struct lll_scan *)ftr->param)->hdr.parent;
-	conn = lll->hdr.parent;
-
+	/* Get reference to Tx-ed CONNECT_IND PDU */
 	pdu_tx = (void *)((struct node_rx_pdu *)rx)->pdu;
 
+	/* Backup peer addr and type, as we reuse the Tx-ed PDU to generate
+	 * event towards LL
+	 */
 	peer_addr_type = pdu_tx->rx_addr;
 	memcpy(peer_addr, &pdu_tx->connect_ind.adv_addr[0], BDADDR_SIZE);
 
 	/* This is the chan sel bit from the received adv pdu */
 	chan_sel = pdu_tx->chan_sel;
 
+	/* Populate the fields required for connection complete event */
 	cc = (void *)pdu_tx;
 	cc->status = 0U;
 	cc->role = 0U;
@@ -723,11 +726,14 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		memcpy(cc->peer_addr, &peer_addr[0], BDADDR_SIZE);
 	}
 
+	scan = HDR_LLL2ULL(ftr->param);
+
 	cc->interval = lll->interval;
 	cc->latency = lll->latency;
 	cc->timeout = scan->lll.conn_timeout;
 	cc->sca = lll_clock_sca_local_get();
 
+	conn = lll->hdr.parent;
 	lll->handle = ll_conn_handle_get(conn);
 	rx->handle = lll->handle;
 
@@ -804,8 +810,34 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
 				    ticker_id_scan, ticker_op_stop_scan_cb,
-				    (void *)(uint32_t)ticker_id_scan);
-	ticker_op_stop_scan_cb(ticker_status, (void *)(uint32_t)ticker_id_scan);
+				    scan);
+	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+		  (ticker_status == TICKER_STATUS_BUSY));
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
+	/* Determine if coded PHY was also enabled, if so, reset the assigned
+	 * connection context.
+	 */
+	struct ll_scan_set *scan_other =
+				ull_scan_is_enabled_get(SCAN_HANDLE_PHY_CODED);
+	if (scan_other) {
+		if (scan_other == scan) {
+			scan_other = ull_scan_is_enabled_get(SCAN_HANDLE_1M);
+		}
+
+		if (scan_other) {
+			ticker_id_scan = TICKER_ID_SCAN_BASE +
+					 ull_scan_handle_get(scan_other);
+			ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
+						    TICKER_USER_ID_ULL_HIGH,
+						    ticker_id_scan,
+						    ticker_op_stop_scan_other_cb,
+						    scan_other);
+			LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+				  (ticker_status == TICKER_STATUS_BUSY));
+		}
+	}
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
 
 	/* Scanner stop can expire while here in this ISR.
 	 * Deferred attempt to stop can fail as it would have
@@ -912,8 +944,44 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 
 static void ticker_op_stop_scan_cb(uint32_t status, void *param)
 {
-	/* TODO: */
+	/* NOTE: Nothing to do here, present here to add debug code if required
+	 */
 }
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)
+static void ticker_op_stop_scan_other_cb(uint32_t status, void *param)
+{
+	static memq_link_t link;
+	static struct mayfly mfy = {0, 0, &link, NULL, NULL};
+	struct ll_scan_set *scan;
+	struct ull_hdr *hdr;
+
+	/* Ignore if race between thread and ULL */
+	if (status != TICKER_STATUS_SUCCESS) {
+		/* TODO: detect race */
+
+		return;
+	}
+
+	/* NOTE: We are in ULL_LOW which can be pre-empted by ULL_HIGH.
+	 *       As we are in the callback after successful stop of the
+	 *       ticker, the ULL reference count will not be modified
+	 *       further hence it is safe to check and act on either the need
+	 *       to call lll_disable or not.
+	 */
+	scan = param;
+	hdr = &scan->ull;
+	mfy.param = &scan->lll;
+	if (ull_ref_get(hdr)) {
+		uint32_t ret;
+
+		mfy.fp = lll_disable;
+		ret = mayfly_enqueue(TICKER_USER_ID_ULL_LOW,
+				     TICKER_USER_ID_LLL, 0, &mfy);
+		LL_ASSERT(!ret);
+	}
+}
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
 
 static void ticker_op_cb(uint32_t status, void *param)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -54,8 +54,8 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-static void ticker_op_stop_scan_cb(uint32_t status, void *params);
-static void ticker_op_cb(uint32_t status, void *params);
+static void ticker_op_stop_scan_cb(uint32_t status, void *param);
+static void ticker_op_cb(uint32_t status, void *param);
 static inline void conn_release(struct ll_scan_set *scan);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -910,14 +910,14 @@ void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t
 	DEBUG_RADIO_PREPARE_M(1);
 }
 
-static void ticker_op_stop_scan_cb(uint32_t status, void *params)
+static void ticker_op_stop_scan_cb(uint32_t status, void *param)
 {
 	/* TODO: */
 }
 
-static void ticker_op_cb(uint32_t status, void *params)
+static void ticker_op_cb(uint32_t status, void *param)
 {
-	ARG_UNUSED(params);
+	ARG_UNUSED(param);
 
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -100,7 +100,11 @@ uint8_t ll_scan_params_set(uint8_t type, uint16_t interval, uint16_t window,
 
 	lll = &scan->lll;
 
+	/* NOTE: Pass invalid interval value to not start scanning using this
+	 *       scan instance.
+	 */
 	if (!interval) {
+		/* Set PHY to 0 to not start scanning on this instance */
 		lll->phy = 0U;
 
 		return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -358,9 +358,10 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	uint32_t ticks_anchor;
 	uint32_t ret;
 
-	lll->chan = 0;
 	lll->init_addr_type = scan->own_addr_type;
 	ll_addr_get(lll->init_addr_type, lll->init_addr);
+	lll->chan = 0U;
+	lll->is_stop = 0U;
 
 	ull_hdr_init(&scan->ull);
 	lll_hdr_init(lll, scan);

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -169,10 +169,14 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	win_offset = sys_le16_to_cpu(pdu_adv->connect_ind.win_offset);
 	conn_interval_us = lll->interval * CONN_INT_UNIT_US;
 
+	/* transmitWindowDelay to default calculated connection offset:
+	 * 1.25ms for a legacy PDU, 2.5ms for an LE Uncoded PHY and 3.75ms for
+	 * an LE Coded PHY.
+	 */
 	if (0) {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (adv->lll.aux) {
-		if (adv->lll.phy_s & BIT(2)) {
+		if (adv->lll.phy_s & PHY_CODED) {
 			win_delay_us = WIN_DELAY_CODED;
 		} else {
 			win_delay_us = WIN_DELAY_UNCODED;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -52,7 +52,7 @@
 static void ticker_op_stop_adv_cb(uint32_t status, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
-					       void *params);
+					       void *param);
 
 void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		     struct node_rx_ftr *ftr, struct lll_conn *lll)
@@ -576,9 +576,9 @@ static void ticker_op_cb(uint32_t status, void *param)
 }
 
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
-					       void *params)
+					       void *param)
 {
-	struct ll_conn *conn = params;
+	struct ll_conn *conn = param;
 
 	LL_ASSERT(ticker_status == TICKER_STATUS_SUCCESS);
 

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -94,6 +94,7 @@ static uint8_t per_adv_data2[] = {
 	};
 
 static bool volatile is_connected, is_disconnected;
+static bool volatile connection_to_test;
 
 static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
@@ -735,13 +736,12 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 {
 	printk("%s: type = 0x%x.\n", __func__, adv_type);
 
-	static bool connection_tested;
 	struct bt_conn *conn;
 
-	if (!connection_tested) {
+	if (connection_to_test) {
 		int err;
 
-		connection_tested = true;
+		connection_to_test = false;
 
 		err = bt_le_scan_stop();
 		if (err) {
@@ -941,6 +941,8 @@ static void test_scanx_main(void)
 	printk("Periodic Advertising callbacks register...");
 	bt_le_per_adv_sync_cb_register(&sync_cb);
 	printk("Success.\n");
+
+	connection_to_test = true;
 
 	printk("Start scanning...");
 	err = bt_le_scan_start(&scan_param, scan_cb);

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -201,6 +201,45 @@ static void test_advx_main(void)
 	}
 	printk("success.\n");
 
+	k_sleep(K_MSEC(100));
+
+	is_connected = false;
+	is_disconnected = false;
+
+	printk("Connectable extended advertising...");
+	printk("Create advertising set...");
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_callbacks, &adv);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	printk("Start advertising...");
+	err = bt_le_ext_adv_start(adv, &ext_adv_param);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	printk("Waiting for connection...");
+	while (!is_connected) {
+		k_sleep(K_MSEC(100));
+	}
+
+	printk("Waiting for disconnect...");
+	while (!is_disconnected) {
+		k_sleep(K_MSEC(100));
+	}
+
+	printk("Removing connectable adv aux set...");
+	err = bt_le_ext_adv_delete(adv);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(1000));
+
 	printk("Starting non-connectable advertising...");
 	err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
@@ -942,6 +981,27 @@ static void test_scanx_main(void)
 	bt_le_per_adv_sync_cb_register(&sync_cb);
 	printk("Success.\n");
 
+	connection_to_test = true;
+
+	printk("Start scanning...");
+	err = bt_le_scan_start(&scan_param, scan_cb);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	printk("Waiting for connection...");
+	while (!is_connected) {
+		k_sleep(K_MSEC(100));
+	}
+
+	printk("Waiting for disconnect...");
+	while (!is_disconnected) {
+		k_sleep(K_MSEC(100));
+	}
+
+	is_connected = false;
+	is_disconnected = false;
 	connection_to_test = true;
 
 	printk("Start scanning...");


### PR DESCRIPTION
This adds support to initiate connection on secondary adv channels. Should pass all LL/CON/INI/* test cases.

Fixes #3514