### PR TITLE
Revert nordic I2C sda-gpios, scl-gpios changes

### DIFF
--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -30,8 +30,8 @@
 
 &i2c0 {
 	status = "okay";
-	sda-gpios = <&gpio0 28 0>;
-	scl-gpios = <&gpio0 2 0>;
+	sda-pin = <28>;
+	scl-pin = <2>;
 };
 
 &uart0 {

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -75,8 +75,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 20 0>;
-	scl-gpios = <&gpio0 22 0>;
+	sda-pin = <20>;
+	scl-pin = <22>;
 };
 
 &spi1 {

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -123,8 +123,8 @@
 	status = "okay";
 
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 
 	lis2dh12-accel@19 {
 		compatible = "st,lis2dh12", "st,lis2dh";

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -78,8 +78,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 12 0>;
-	scl-gpios = <&gpio0 11 0>;
+	sda-pin = <12>;
+	scl-pin = <11>;
 };
 
 &spi1 {

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -69,14 +69,14 @@
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 31 0>;
-	scl-gpios = <&gpio0 2 0>;
+	sda-pin = <31>; //P0.31
+	scl-pin = <2>; //P0.02
 };
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 14 0>;
-	scl-gpios = <&gpio0 15 0>;
+	sda-pin = <14>; //P0.14
+	scl-pin = <15>; //P0.15
 };
 // we use SPI2 because SPI1/0 shares conflicts with I2C1/0
 &spi2 {

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -60,8 +60,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 0 0>;
+	sda-pin = <30>;
+	scl-pin = <0>;
 
 	/* See https://tech.microbit.org/hardware/i2c/ for board variants */
 

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -91,8 +91,8 @@
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 16 0>;
-	scl-gpios = <&gpio0 8 0>;
+	sda-pin = <16>;
+	scl-pin = <8>;
 
 	/* See https://tech.microbit.org/hardware/i2c/ for board variants */
 

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -80,8 +80,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -104,8 +104,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -104,8 +104,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/bmd_345_eval/bmd_345_eval.dts
+++ b/boards/arm/bmd_345_eval/bmd_345_eval.dts
@@ -154,16 +154,16 @@
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &spi0 {

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -110,8 +110,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 
 	lis2dh12@18 {
 		compatible = "st,lis2dh12", "st,lis2dh";

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -108,8 +108,8 @@
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 
 	pcf85063a@51 {
 			compatible = "nxp,pcf85063a";

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -69,8 +69,8 @@ arduino_serial: &uart1 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 27 0>;
-	scl-gpios = <&gpio0 26 0>;
+	sda-pin = <27>;
+	scl-pin = <26>;
 };
 
 &spi2 {

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -98,8 +98,8 @@
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 29 0>;
-	scl-gpios = <&gpio0 28 0>;
+	sda-pin = <29>;
+	scl-pin = <28>;
 
 	lis2dh12: lis2dh12@19 {
 		compatible = "st,lis2dh12", "st,lis2dh";

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -94,15 +94,15 @@
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 20 0>;
-	scl-gpios = <&gpio0 22 0>;
+	sda-pin = <20>;
+	scl-pin = <22>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio1 9 0>;
-	scl-gpios = <&gpio0 11 0>;
+	sda-pin = <41>;
+	scl-pin = <11>;
 };
 
 &flash0 {

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -171,16 +171,16 @@ arduino_serial: &uart1 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -81,8 +81,8 @@
 
 &i2c0 {
 	status = "okay";
-	sda-gpios = <&gpio0 0 0>;
-	scl-gpios = <&gpio0 1 0>;
+	sda-pin = <0>;
+	scl-pin = <1>;
 	/* smba-pin = <2>; */
 };
 

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -66,6 +66,6 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 29 0>;
-	scl-gpios = <&gpio0 30 0>;
+	sda-pin = <29>;
+	scl-pin = <30>;
 };

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -107,15 +107,15 @@
 
 &i2c0 {
 	status = "okay";
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 7 0>;
+	sda-pin = <30>;
+	scl-pin = <7>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 5 0>;
-	scl-gpios = <&gpio0 6 0>;
+	sda-pin = <5>;
+	scl-pin = <6>;
 };
 
 &spi0 {

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -103,15 +103,15 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -104,8 +104,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 28 0>;
-	scl-gpios = <&gpio0 29 0>;
+	sda-pin = <28>;
+	scl-pin = <29>;
 };
 
 &i2c1 {

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -149,16 +149,16 @@ arduino_serial: &uart1 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -86,16 +86,16 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 12 0>;
-	scl-gpios = <&gpio0 11 0>;
+	sda-pin = <12>;
+	scl-pin = <11>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 2 0>;
-	scl-gpios = <&gpio0 3 0>;
+	sda-pin = <2>;
+	scl-pin = <3>;
 };
 
 &spi0 {

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -109,15 +109,15 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -103,8 +103,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 5 0>;
-	scl-gpios = <&gpio0 6 0>;
+	sda-pin = <5>;
+	scl-pin = <6>;
 };
 
 &spi1 {

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -110,8 +110,8 @@
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	/* Arduino compatible PINs */
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -160,16 +160,16 @@ arduino_serial: &uart1 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -113,16 +113,16 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -84,8 +84,8 @@
 
 &i2c0 {
 	compatible = "nordic,nrf-twi";
-	sda-gpios = <&gpio0 25 0>;
-	scl-gpios = <&gpio0 26 0>;
+	sda-pin = <25>;
+	scl-pin = <26>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -56,8 +56,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 28 0>;
-	scl-gpios = <&gpio0 2 0>;
+	sda-pin = <28>;
+	scl-pin = <2>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -67,6 +67,6 @@
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -91,8 +91,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &spi0 {

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -103,8 +103,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &spi0 {

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -150,16 +150,16 @@ arduino_serial: &uart0 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -135,8 +135,8 @@
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio1 2 0>;
-	scl-gpios = <&gpio1 3 0>;
+	sda-pin = <34>;
+	scl-pin = <35>;
 };
 
 &uart0 {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -132,8 +132,8 @@ arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twim";
 	/* Cannot be used together with uart0. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio1 2 0>;
-	scl-gpios = <&gpio1 3 0>;
+	sda-pin = <34>;
+	scl-pin = <35>;
 };
 
 arduino_spi: &spi0 {

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -87,8 +87,8 @@
 &i2c2 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 25 0>;
-	scl-gpios = <&gpio0 26 0>;
+	sda-pin = <25>;
+	scl-pin = <26>;
 
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -89,8 +89,8 @@
 &i2c2 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 25 0>;
-	scl-gpios = <&gpio0 26 0>;
+	sda-pin = <25>;
+	scl-pin = <26>;
 
 	clock-frequency = <I2C_BITRATE_FAST>;
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -140,8 +140,8 @@
 &i2c2 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
@@ -24,8 +24,8 @@
 &i2c2 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 
 	pcal6408a: pcal6408a@20 {
 		compatible = "nxp,pcal6408a";

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -179,8 +179,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 feather_i2c: &i2c0 { };

--- a/boards/arm/particle_argon/dts/mesh_feather_i2c1_twi1.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather_i2c1_twi1.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 &i2c1 { /* feather I2C1 */
 	status = "okay";
-	sda-gpios = <&gpio1 1 0>;
-	scl-gpios = <&gpio1 2 0>;
+	sda-pin = <33>;
+	scl-pin = <34>;
 };
 

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -179,8 +179,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 feather_i2c: &i2c0 { };

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -27,8 +27,8 @@
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 24 0>;
-	scl-gpios = <&gpio1 9 0>;
+	sda-pin = <24>;
+	scl-pin = <41>;
 };
 
 &uart1 { /* u-blox SARA-U2 or SARA-R4 */

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -179,8 +179,8 @@ arduino_i2c: &i2c0 { /* feather I2C */
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 feather_i2c: &i2c0 { };

--- a/boards/arm/particle_xenon/dts/mesh_feather_i2c1_twi1.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather_i2c1_twi1.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 &i2c1 { /* feather I2C1 */
 	status = "okay";
-	sda-gpios = <&gpio1 1 0>;
-	scl-gpios = <&gpio1 2 0>;
+	sda-pin = <33>;
+	scl-pin = <34>;
 };
 

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -86,8 +86,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	sda-gpios = <&gpio0 6 0>;
-	scl-gpios = <&gpio0 7 0>;
+	sda-pin = <6>;
+	scl-pin = <7>;
 	clock-frequency = <I2C_BITRATE_FAST>; /* 400KHz */
 
 	/* BOSCH BMA421 Triaxial Acceleration Sensor (1000KHz) */

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -127,8 +127,8 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 
 	bme680@76 {
 		compatible = "bosch,bme680";

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -77,16 +77,16 @@
 &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 13 0>;
-	scl-gpios = <&gpio0 14 0>;
+	sda-pin = <13>;
+	scl-pin = <14>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 24 0>;
-	scl-gpios = <&gpio0 25 0>;
+	sda-pin = <24>;
+	scl-pin = <25>;
 };
 
 &spi1 {

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -84,8 +84,8 @@
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 14 0>;
-	scl-gpios = <&gpio0 13 0>;
+	sda-pin = <14>;
+	scl-pin = <13>;
 
 	/* TI OPT3001 light sensor */
 	opt3001@44 {

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -117,8 +117,8 @@ arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 
 	mma8652fc@1d {
 		compatible = "nxp,fxos8700","nxp,mma8652fc";

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -127,8 +127,8 @@
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 7 0>;
-	scl-gpios = <&gpio0 8 0>;
+	sda-pin = <7>;
+	scl-pin = <8>;
 
 	sx1509b: sx1509b@3e {
 		compatible = "semtech,sx1509b";
@@ -173,8 +173,8 @@
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-gpios = <&gpio0 14 0>;
-	scl-gpios = <&gpio0 15 0>;
+	sda-pin = <14>;
+	scl-pin = <15>;
 
 	lis2dh12: lis2dh12@19 {
 		compatible = "st,lis2dh12", "st,lis2dh";

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -153,16 +153,16 @@ arduino_serial: &uart0 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -153,8 +153,8 @@ arduino_serial: &uart0 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -164,16 +164,16 @@ arduino_serial: &uart1 {
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &i2c1 {
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -154,8 +154,8 @@ arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	/* Arduino compatible PINs */
-	sda-gpios = <&gpio0 26 0>;
-	scl-gpios = <&gpio0 27 0>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 &pwm0 {

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -119,8 +119,8 @@
 	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
-	sda-gpios = <&gpio0 30 0>;
-	scl-gpios = <&gpio0 31 0>;
+	sda-pin = <30>;
+	scl-pin = <31>;
 };
 
 &pwm0 {

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -150,8 +150,8 @@
 arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
-	sda-gpios = <&gpio0 16 0>;
-	scl-gpios = <&gpio0 24 0>;
+	sda-pin = <16>;
+	scl-pin = <24>;
 };
 
 &spi0 {

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -8,7 +8,6 @@
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <nrfx_twi.h>
-#include <soc.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
@@ -277,14 +276,6 @@ static int twi_nrfx_pm_control(const struct device *dev,
 	BUILD_ASSERT(I2C_FREQUENCY(idx)	!=				       \
 		     I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
 		     "Wrong I2C " #idx " frequency setting in dts");	       \
-	NRF_DT_PSEL_CHECK_EXACTLY_ONE(I2C(idx),				       \
-				      sda_pin, "sda-pin",		       \
-				      sda_gpios, "sda-gpios");		       \
-	NRF_DT_PSEL_CHECK_EXACTLY_ONE(I2C(idx),				       \
-				      scl_pin, "scl-pin",		       \
-				      scl_gpios, "scl-gpios");		       \
-	NRF_DT_CHECK_GPIO_CTLR_IS_SOC(I2C(idx), sda_gpios, "sda-gpios");       \
-	NRF_DT_CHECK_GPIO_CTLR_IS_SOC(I2C(idx), scl_gpios, "scl-gpios");       \
 	static int twi_##idx##_init(const struct device *dev)		\
 	{								       \
 		IRQ_CONNECT(DT_IRQN(I2C(idx)), DT_IRQ(I2C(idx), priority),     \
@@ -300,8 +291,8 @@ static int twi_nrfx_pm_control(const struct device *dev,
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx),				       \
 		.config = {						       \
-			.scl = NRF_DT_PSEL(I2C(idx), scl_pin, scl_gpios, 0),   \
-			.sda = NRF_DT_PSEL(I2C(idx), sda_pin, sda_gpios, 0),   \
+			.scl       = DT_PROP(I2C(idx), scl_pin),	       \
+			.sda       = DT_PROP(I2C(idx), sda_pin),	       \
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -9,7 +9,6 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <nrfx_twim.h>
 #include <sys/util.h>
-#include <soc.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
@@ -325,14 +324,6 @@ static int twim_nrfx_pm_control(const struct device *dev,
 	BUILD_ASSERT(I2C_FREQUENCY(idx) !=				       \
 		     I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \
 		     "Wrong I2C " #idx " frequency setting in dts");	       \
-	NRF_DT_PSEL_CHECK_EXACTLY_ONE(I2C(idx),				       \
-				      sda_pin, "sda-pin",		       \
-				      sda_gpios, "sda-gpios");		       \
-	NRF_DT_PSEL_CHECK_EXACTLY_ONE(I2C(idx),				       \
-				      scl_pin, "scl-pin",		       \
-				      scl_gpios, "scl-gpios");		       \
-	NRF_DT_CHECK_GPIO_CTLR_IS_SOC(I2C(idx), sda_gpios, "sda-gpios");       \
-	NRF_DT_CHECK_GPIO_CTLR_IS_SOC(I2C(idx), scl_gpios, "scl-gpios");       \
 	static int twim_##idx##_init(const struct device *dev)		       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(I2C(idx)), DT_IRQ(I2C(idx), priority),     \
@@ -353,8 +344,8 @@ static int twim_nrfx_pm_control(const struct device *dev,
 	static const struct i2c_nrfx_twim_config twim_##idx##z_config = {      \
 		.twim = NRFX_TWIM_INSTANCE(idx),			       \
 		.config = {						       \
-			.scl = NRF_DT_PSEL(I2C(idx), scl_pin, scl_gpios, 0),   \
-			.sda = NRF_DT_PSEL(I2C(idx), sda_pin, sda_gpios, 0),   \
+			.scl       = DT_PROP(I2C(idx), scl_pin),	       \
+			.sda       = DT_PROP(I2C(idx), sda_pin),	       \
 			.frequency = I2C_FREQUENCY(idx),		       \
 		}							       \
 	};								       \

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -13,36 +13,10 @@ properties:
     interrupts:
       required: true
 
-    sda-gpios:
-      type: phandle-array
-      required: false
-      description: |
-        The SDA pin to use. The value is "<&gpioX Y flags>".
-        Pin PX.Y will be used for SDA. The "flags" portion currently
-        has no effect, but must be set to zero.
-
-        For example, to use P0.16 for SDA, set:
-
-          sda-gpios = <&gpio0 16 0>;
-
-        To use P1.2 for SDA, set:
-
-          sda-gpios = <&gpio1 2 0>;
-
-    scl-gpios:
-      type: phandle-array
-      required: false
-      description: |
-        The SCL pin to use. The value should be set in the same
-        way as the sda-gpios property.
-
     sda-pin:
       type: int
-      required: false
-      deprecated: true
+      required: true
       description: |
-        Deprecated; use sda-gpios instead.
-
         The SDA pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -57,10 +31,7 @@ properties:
 
     scl-pin:
       type: int
-      required: false
-      deprecated: true
+      required: true
       description: |
-        Deprecated; use scl-gpios instead.
-
         The SCL pin to use. The pin numbering scheme is the same as
         the sda-pin property's.

--- a/samples/sensor/ccs811/boards/nrf51_ble400.overlay
+++ b/samples/sensor/ccs811/boards/nrf51_ble400.overlay
@@ -6,8 +6,8 @@
 
 &i2c0 {
 	status = "okay";
-	sda-gpios = <&gpio0 0 0>;
-	scl-gpios = <&gpio0 1 0>;
+	sda-pin = <0>;
+	scl-pin = <1>;
 
 	/* Sparkfun Environment Combo uses second I2C address */
 	ccs811: ccs811@5b {


### PR DESCRIPTION
This reverts https://github.com/zephyrproject-rtos/zephyr/pull/31965 and follow-on changes that depend on it.

See discussion in that PR for why; the short answer is that it's incompatible with the way the pinmux framework is evolving.
