### PR TITLE
toolchain: llvm: Find strip command

### DIFF
--- a/cmake/bintools/llvm/target.cmake
+++ b/cmake/bintools/llvm/target.cmake
@@ -11,6 +11,7 @@ find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args}   )
 find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args}   )
 find_program(CMAKE_OBJDUMP llvm-objdump ${find_program_clang_args}   )
 find_program(CMAKE_RANLIB  llvm-ranlib  ${find_program_clang_args}   )
+find_program(CMAKE_STRIP   llvm-strip   ${find_program_clang_args}   )
 find_program(CMAKE_OBJCOPY objcopy      ${find_program_binutils_args})
 find_program(CMAKE_READELF readelf      ${find_program_binutils_args})
 


### PR DESCRIPTION
Some targets require *strip* command. This command was not
being set when selecting llvm toolchain.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>