### PR TITLE
logging: Do not set CYCCNTENA to zero in swo backend

### DIFF
--- a/subsys/logging/log_backend_swo.c
+++ b/subsys/logging/log_backend_swo.c
@@ -91,7 +91,8 @@ static void log_backend_swo_init(void)
 	/* Enable unprivileged access to ITM stimulus ports */
 	ITM->TPR  = 0x0;
 	/* Configure Debug Watchpoint and Trace */
-	DWT->CTRL = 0x400003FE;
+	DWT->CTRL &= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk | DWT_CTRL_CYCCNTENA_Msk);
+	DWT->CTRL |= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk);
 	/* Configure Formatter and Flush Control Register */
 	TPI->FFCR = 0x00000100;
 	/* Enable ITM, set TraceBusID=1, no local timestamp generation */


### PR DESCRIPTION
The log_backend_swo_init function sets the CYCCNTENA bit of the DWT
register to 0, disabling the counter (which is necessary for the timing
functions.
Avoid overwriting the CYCCNTENA bit.
Do not try to set read-only bits.

Fixes #34341

Signed-off-by: Andrés Manelli <am@toroid.io>