### PR TITLE
samples: metairq_dispatch: use name msgdev.h instead of main.h

### DIFF
--- a/samples/kernel/metairq_dispatch/src/main.c
+++ b/samples/kernel/metairq_dispatch/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
-#include "main.h"
+#include "msgdev.h"
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);

--- a/samples/kernel/metairq_dispatch/src/msgdev.c
+++ b/samples/kernel/metairq_dispatch/src/msgdev.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <timeout_q.h>
-#include "main.h"
+#include "msgdev.h"
 
 /* This file implements a fake device that creates and enqueues
  * "struct msg" messages for handling by the rest of the test.  It's

--- a/samples/kernel/metairq_dispatch/src/msgdev.h
+++ b/samples/kernel/metairq_dispatch/src/msgdev.h
@@ -3,7 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef SAMPLE_METAIRQ_MAIN_H
+#ifndef __MSGDEV_H__
+#define __MSGDEV_H__
 
 /* Define this to enable logging of every event as it is processed to
  * carefully inspect behavior.  Note that at high event rates (see
@@ -67,4 +68,4 @@ void message_dev_init(void);
  */
 void message_dev_fetch(struct msg *m);
 
-#endif
+#endif /* __MSGDEV_H__ */


### PR DESCRIPTION
Normally main.c file doesn't have a header, beacuse it doesn't need to
be declared to other modules.

And in this sample it makes more sense to use name msgdev.h instead of
main.h as the header file for msgdev.c.

Signed-off-by: Paul He <pawpawhe@gmail.com>