### PR TITLE
soc: power: npcx: Clear host access IRQ pending bit before enabling

### DIFF
--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -964,6 +964,8 @@ void npcx_host_init_subs_host_domain(void)
 
 void npcx_host_enable_access_interrupt(void)
 {
+	npcx_miwu_irq_get_and_clear_pending(&host_sub_cfg.host_acc_wui);
+
 	npcx_miwu_irq_enable(&host_sub_cfg.host_acc_wui);
 }
 

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -177,6 +177,18 @@ bool npcx_miwu_irq_get_state(const struct npcx_wui *wui)
 	return IS_BIT_SET(NPCX_WKEN(base, wui->group), wui->bit);
 }
 
+bool npcx_miwu_irq_get_and_clear_pending(const struct npcx_wui *wui)
+{
+	const uint32_t base = DRV_CONFIG(miwu_devs[wui->table])->base;
+	bool pending = IS_BIT_SET(NPCX_WKPND(base, wui->group), wui->bit);
+
+	if (pending) {
+		NPCX_WKPCL(base, wui->group) = BIT(wui->bit);
+	}
+
+	return pending;
+}
+
 int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
 		enum miwu_int_mode mode, enum miwu_int_trig trig)
 {

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -140,6 +140,15 @@ void npcx_miwu_irq_disable(const struct npcx_wui *wui);
 bool npcx_miwu_irq_get_state(const struct npcx_wui *wui);
 
 /**
+ * @brief Get & clear interrupt pending bit of the wake-up input source
+ *
+ * @param wui A pointer on wake-up input source
+ *
+ * @retval 1 if interrupt is pending
+ */
+bool npcx_miwu_irq_get_and_clear_pending(const struct npcx_wui *wui);
+
+/**
  * @brief Configure interrupt type of the wake-up input source
  *
  * @param wui Pointer to wake-up input source for configuring


### PR DESCRIPTION
NPCX host access IRQ enables before entering deep sleep. The pending
bit lets chip wake up from sleep immediately. Clear host access IRQ
pending bit before enabling.

Signed-off-by: Wealian Liao <WHLIAO@nuvoton.com>