### PR TITLE
irq_offload: Remove ifdef from the api

### DIFF
--- a/include/irq_offload.h
+++ b/include/irq_offload.h
@@ -15,8 +15,7 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_IRQ_OFFLOAD
-	typedef void (*irq_offload_routine_t)(const void *parameter);
+typedef void (*irq_offload_routine_t)(const void *parameter);
 
 /**
  * @brief Run a function in interrupt context
@@ -31,7 +30,6 @@ extern "C" {
  * interrupt
  */
 void irq_offload(irq_offload_routine_t routine, const void *parameter);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Removed #ifdef that guarded irq_offload API.

Aligning with https://docs.zephyrproject.org/2.5.0/guides/coding_guidelines/index.html#rule-a-1-conditional-compilation

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>