### PR TITLE
arch: arm: cortex_m: z_arm_pendsv in vector table when multithreading

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.S
@@ -70,7 +70,11 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
     .word 0
+#if defined(CONFIG_MULTITHREADING)
     .word z_arm_pendsv
+#else
+    .word 0
+#endif
 #if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK)
 #if defined(CONFIG_SYS_CLOCK_EXISTS)
     /* Install sys_clock_isr even if CORTEX_M_SYSTICK is not set


### PR DESCRIPTION
When CONFIG_MULTITHREADING=n kernel specific pendsv is not used. Remove
from vector table.

Part of improving support for no multithreading. Extracted from #34279.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>