### PR TITLE
drivers: usb_dc_nrfx: clear endpoint flags during ep_disable()

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1598,6 +1598,11 @@ int usb_dc_ep_disable(const uint8_t ep)
 	LOG_DBG("EP disable: 0x%02x", ep);
 
 	nrfx_usbd_ep_disable(ep_addr_to_nrfx(ep));
+	/* Clear write_in_progress as nrfx_usbd_ep_disable()
+	 * terminates endpoint transaction.
+	 */
+	ep_ctx->write_in_progress = false;
+	ep_ctx_reset(ep_ctx);
 	ep_ctx->cfg.en = false;
 
 	return 0;


### PR DESCRIPTION
If a loaded endpoint was disabled and then reconfigured,
it is not possible to start an IN transfer and
usb_dc_ep_write() returns -EAGAIN.

Call ep_ctx_reset() to clear endpoint operations flags
and reset buffer after endpoint is disabled.