### PR TITLE
drivers: i2c_nrfx_twim: Fix handling of zero-length transfers

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -130,7 +130,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 
 		res = get_dev_data(dev)->res;
 		if (res != NRFX_SUCCESS) {
-			LOG_ERR("Error %d occurred for message %d", res, i);
+			LOG_ERR("Error 0x%08X occurred for message %d", res, i);
 			ret = -EIO;
 			break;
 		}

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -159,7 +159,7 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 		res = get_dev_data(dev)->res;
 
 		if (res != NRFX_SUCCESS) {
-			LOG_ERR("Error %d occurred for message %d", res, i);
+			LOG_ERR("Error 0x%08X occurred for message %d", res, i);
 			ret = -EIO;
 			break;
 		}

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -127,6 +127,17 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 			}
 		}
 
+		if (cur_xfer.primary_length == 0) {
+			/* For a zero-length transfer, the STOP task will not
+			 * be triggered automatically by the shortcut with the
+			 * event that signals the transfer end. It needs to be
+			 * done "manually" to prevent the driver getting stuck
+			 * after the address byte is acknowledged.
+			 */
+			nrf_twim_task_trigger(get_dev_config(dev)->twim.p_twim,
+					      NRF_TWIM_TASK_STOP);
+		}
+
 		ret = k_sem_take(&(get_dev_data(dev)->completion_sync),
 				 I2C_TRANSFER_TIMEOUT_MSEC);
 		if (ret != 0) {


### PR DESCRIPTION
For a zero-length transfer, the STOP task is not triggered
automatically by the shortcut with the event that signals
the transfer end because such event is not generated.
Trigger this task "manually" to prevent the driver getting
stuck after the address byte is acknowledged.

Fixes #31248.