### PR TITLE
dts/arm: STM32: Move i2s1 to right dtsi files for stm32f4 series.

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -216,20 +216,6 @@
 			label = "SPI_1";
 		};
 
-		i2s1: i2s@40013000 {
-			compatible = "st,stm32-i2s";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
-			interrupts = <35 5>;
-			dmas = <&dma2 3 3 0x400 0x3
-				&dma2 2 3 0x400 0x3>;
-			dma-names = "tx", "rx";
-			status = "disabled";
-			label = "I2S_1";
-		};
-
 		usbotg_fs: usb@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -29,6 +29,20 @@
 			label = "SPI_5";
 		};
 
+		i2s1: i2s@40013000 {
+			compatible = "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			interrupts = <35 5>;
+			dmas = <&dma2 3 3 0x400 0x3
+				&dma2 2 3 0x400 0x3>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+			label = "I2S_1";
+		};
+
 		i2s2: i2s@40003800 {
 			compatible = "st,stm32-i2s";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -28,6 +28,20 @@
 			label = "SPI_5";
 		};
 
+		i2s1: i2s@40013000 {
+			compatible = "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			interrupts = <35 5>;
+			dmas = <&dma2 3 3 0x400 0x3
+				&dma2 2 3 0x400 0x3>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+			label = "I2S_1";
+		};
+
 		i2s4: i2s@40013400 {
 			compatible = "st,stm32-i2s";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -8,6 +8,20 @@
 
 / {
 	soc {
+		i2s1: i2s@40013000 {
+			compatible = "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			interrupts = <35 5>;
+			dmas = <&dma2 3 3 0x400 0x3
+				&dma2 2 3 0x400 0x3>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+			label = "I2S_1";
+		};
+
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;


### PR DESCRIPTION
i2s1 is not present in all stm32f4 series. So moving the i2s1 node
from the top level stm32f4 dtsi file to the stm32fxx specific dtsi
files. i2s1 is present only in stm32f410, stm32f411, stm32f412, 
stm32f413, stm32f446. i2s1 is not present in stm32f429 and the 
sequence starts from i2s2, this commit helps in having the right 
channel number.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>