### PR TITLE
gitignore: add common Python venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ doc/doc.warnings
 .envrc
 .vscode
 hide-defaults-note
+venv
+.venv
 
 # Tag files
 GPATH


### PR DESCRIPTION
Add common directory names used for Python virtual environments to gitignore.