### PR TITLE
linker: clarify CONFIG_KOBJECT_TEXT_AREA too small message

### DIFF
--- a/include/linker/kobject-text.ld
+++ b/include/linker/kobject-text.ld
@@ -32,11 +32,7 @@
 
 	ASSERT(
 		CONFIG_KOBJECT_TEXT_AREA >= _kobject_text_area_used,
-"The configuration system has incorrectly set \
-'CONFIG_KOBJECT_TEXT_AREA' to \
-CONFIG_KOBJECT_TEXT_AREA, which is not big enough. You must \
-through Kconfig either disable 'CONFIG_USERSPACE', or set \
-'CONFIG_KOBJECT_TEXT_AREA' to a value larger than \
-CONFIG_KOBJECT_TEXT_AREA."
+"Reserved space for kobject text area is too small. \
+Please change CONFIG_KOBJECT_TEXT_AREA to a larger number."
 		);
 #endif /* CONFIG_USERSPACE */


### PR DESCRIPTION
The assert error message when CONFIG_KOBJECT_TEXT_AREA is
too small is confusing. Probably the original idea is for
the linker to substitue CONFIG_KOBJECT_TEXT_AREA with
the actual value. However, linker does not do that.
So change the message to say that the kconfig value needs
to be increased.

Fixes #34387

Signed-off-by: Daniel Leung <daniel.leung@intel.com>