### PR TITLE
samples/tests: remove unused and wrong implemented USB HID callbacks

### DIFF
--- a/samples/boards/intel_s1000_crb/audio/src/usb_transport.c
+++ b/samples/boards/intel_s1000_crb/audio/src/usb_transport.c
@@ -16,33 +16,13 @@ LOG_MODULE_REGISTER(usb_transport);
 #include "usb_transport.h"
 
 /* callback function list */
-static int usb_transport_get_report(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data);
-static int usb_transport_get_idle(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data);
-static int usb_transport_get_protocol(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data);
 static int usb_transport_set_report(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data);
-static int usb_transport_set_idle(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data);
-static int usb_transport_set_protocol(const struct device *dev,
 		struct usb_setup_packet *setup,
 		int32_t *len, uint8_t **data);
 static void usb_transport_host_ready(const struct device *dev);
 
 static const struct hid_ops usb_transport_callbacks = {
-	.get_report	= usb_transport_get_report,
-	.get_idle	= usb_transport_get_idle,
-	.get_protocol	= usb_transport_get_protocol,
 	.set_report	= usb_transport_set_report,
-	.set_idle	= usb_transport_set_idle,
-	.set_protocol	= usb_transport_set_protocol,
 	.int_in_ready	= usb_transport_host_ready,
 };
 
@@ -161,30 +141,6 @@ int usb_transport_send_reply(uint8_t *data, uint32_t len)
 	return ret;
 }
 
-static int usb_transport_get_report(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data)
-{
-	LOG_DBG("usb_transport_get_report");
-	return 0;
-}
-
-static int usb_transport_get_idle(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data)
-{
-	LOG_DBG("usb_transport_get_idle");
-	return 0;
-}
-
-static int usb_transport_get_protocol(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data)
-{
-	LOG_DBG("usb_transport_get_protocol");
-	return 0;
-}
-
 static int usb_transport_set_report(const struct device *dev,
 		struct usb_setup_packet *setup,
 		int32_t *len, uint8_t **data)
@@ -197,22 +153,6 @@ static int usb_transport_set_report(const struct device *dev,
 	size = *len - sizeof(union usb_hid_report_hdr);
 
 	receive_data_cb(buffer, size);
-	return 0;
-}
-
-static int usb_transport_set_idle(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data)
-{
-	LOG_DBG("usb_transport_set_idle");
-	return 0;
-}
-
-static int usb_transport_set_protocol(const struct device *dev,
-		struct usb_setup_packet *setup,
-		int32_t *len, uint8_t **data)
-{
-	LOG_DBG("usb_transport_set_protocol");
 	return 0;
 }
 

--- a/tests/boards/intel_s1000_crb/main/src/test_hid.c
+++ b/tests/boards/intel_s1000_crb/main/src/test_hid.c
@@ -58,43 +58,6 @@ static const uint8_t hid_report_desc[] = {
 	HID_MI_COLLECTION_END,
 };
 
-int debug_cb(struct usb_setup_packet *setup, int32_t *len,
-	     uint8_t **data)
-{
-	LOG_DBG("Debug callback");
-
-	return -ENOTSUP;
-}
-
-int set_idle_cb(struct usb_setup_packet *setup, int32_t *len,
-		uint8_t **data)
-{
-	LOG_DBG("Set Idle callback");
-
-	/* TODO: Do something */
-
-	return 0;
-}
-
-int get_report_cb(struct usb_setup_packet *setup, int32_t *len,
-		  uint8_t **data)
-{
-	LOG_DBG("Get report callback");
-
-	/* TODO: Do something */
-
-	return 0;
-}
-
-static struct hid_ops ops = {
-	.get_report = get_report_cb,
-	.get_idle = debug_cb,
-	.get_protocol = debug_cb,
-	.set_report = debug_cb,
-	.set_idle = set_idle_cb,
-	.set_protocol = debug_cb,
-};
-
 void hid_thread(void)
 {
 	uint8_t report_1[2] = { REPORT_ID_1, 0x00 };
@@ -110,7 +73,7 @@ void hid_thread(void)
 	}
 
 	usb_hid_register_device(hid_dev, hid_report_desc,
-				sizeof(hid_report_desc), &ops);
+				sizeof(hid_report_desc), NULL);
 
 	usb_hid_init(hid_dev);
 


### PR DESCRIPTION
samples/test has implemented USB HID class callbacks that
actually have no function and should not return 0.
Remove unused and wrong implemented USB HID callbacks.

taken out from #33659