### PR TITLE
[C LIB]:Add some constant macro definitions in the libc

### DIFF
--- a/lib/libc/minimal/include/math.h
+++ b/lib/libc/minimal/include/math.h
@@ -34,6 +34,23 @@ extern "C" {
 	typedef double double_t;
 #endif
 
+/* Useful constants.  */
+#define MAXFLOAT    3.40282347e+38F
+
+#define M_E         2.7182818284590452354
+#define M_LOG2E     1.4426950408889634074
+#define M_LOG10E    0.43429448190325182765
+#define M_LN2       0.693147180559945309417
+#define M_LN10      2.30258509299404568402
+#define M_PI        3.14159265358979323846
+#define M_PI_2      1.57079632679489661923
+#define M_PI_4      0.78539816339744830962
+#define M_1_PI      0.31830988618379067154
+#define M_2_PI      0.63661977236758134308
+#define M_2_SQRTPI  1.12837916709551257390
+#define M_SQRT2     1.41421356237309504880
+#define M_SQRT1_2   0.70710678118654752440
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When I was using the sof module, I found that the PI variable was missing. Hope to add some macro definitions to the minimal library。
fix https://github.com/thesofproject/sof/issues/4045
Signed-off-by: yxh <yangxiaohuamail@gmail.com>