### PR TITLE
drivers: wifi: esp: do not wait at the end of ESP chip reset

### DIFF
--- a/drivers/wifi/esp/esp.h
+++ b/drivers/wifi/esp/esp.h
@@ -230,7 +230,6 @@ struct esp_data {
 	struct k_sem sem_tx_ready;
 	struct k_sem sem_response;
 	struct k_sem sem_if_ready;
-	struct k_sem sem_if_up;
 };
 
 int esp_offload_init(struct net_if *iface);


### PR DESCRIPTION
esp_reset() is called from net_if init function, which holds net_if lock
after commit 24b49f439970 ("net: if: Add locking"). At the end of
esp_reset() there is a blocking wait on `sem_if_up` semaphore. This
semaphore can be release only by esp_init_work(). esp_init_work()
however blocks on net_if operations, because net_if init function (which
invokes esp_reset() underneath) is still holding net_if lock. As a
result there is a deadlock, because esp_reset() and esp_init_work() are
both waiting on each other.

Remove waiting for `sem_if_up`, so that net_if init can exit and release
net_if lock.

Fixes: #34369