### PR TITLE
Bluetooth: host: Fix typo in PA defines and missing min check

### DIFF
--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -146,8 +146,9 @@ enum {
 #define BT_GAP_DATA_TIME_MAX                    0x4290 /* 17040 us */
 
 #define BT_GAP_SID_MAX                          0x0F
-#define BT_GAP_PER_ADV_MAX_MAX_SKIP             0x01F3
-#define BT_GAP_PER_ADV_MAX_MAX_TIMEOUT          0x4000
+#define BT_GAP_PER_ADV_MAX_SKIP                 0x01F3
+#define BT_GAP_PER_ADV_MIN_TIMEOUT              0x000A
+#define BT_GAP_PER_ADV_MAX_TIMEOUT              0x4000
 
 
 /** Constant Tone Extension (CTE) types */

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1150,8 +1150,9 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	}
 
 	if (param->sid > BT_GAP_SID_MAX ||
-		   param->skip > BT_GAP_PER_ADV_MAX_MAX_SKIP ||
-		   param->timeout > BT_GAP_PER_ADV_MAX_MAX_TIMEOUT) {
+		   param->skip > BT_GAP_PER_ADV_MAX_SKIP ||
+		   param->timeout > BT_GAP_PER_ADV_MAX_TIMEOUT ||
+		   param->timeout < BT_GAP_PER_ADV_MIN_TIMEOUT) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fixes a typo where the BT_GAP_PER_ADV macros had MAX twice,
as well as adding a MIN timeout macro and check.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>