### PR TITLE
Include Secure and Non-Secure TF-M regression tests

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -30,7 +30,10 @@ set(TFM_VALID_PARTITIONS
 # IPC: Build TFM IPC library. This library allows a non-secure application to
 #      interface to secure domain using IPC.
 # ISOLATION_LEVEL: The TF-M isolation level to use
-# REGRESSION: Boolean if TF-M build includes building the TF-M regression tests
+# REGRESSION_S: Boolean if TF-M build includes building the secure TF-M
+#               regression tests
+# REGRESSION_NS: Boolean if TF-M build includes building the non-secure
+#                TF-M regression tests
 # BL2: Boolean if the TF-M build uses MCUboot. Default: True
 # ENABLED_PARTITIONS: List of TFM partitions to enable.
 #
@@ -41,12 +44,13 @@ set(TFM_VALID_PARTITIONS
 #                        CMAKE_BUILD_TYPE Release
 #                        IPC
 #                        ISOLATION_LEVEL 2
-#                        REGRESSION
+#                        REGRESSION_S
+#                        REGRESSION_NS
 #                        BL2
 #                        BUILD_PROFILE profile_small
 #                        ENABLED_PARTITIONS TFM_PARTITION_PLATFORM TFM_PARTITION_CRYPTO)
 function(trusted_firmware_build)
-  set(options IPC REGRESSION BL2)
+  set(options IPC BL2 REGRESSION_S REGRESSION_NS)
   set(oneValueArgs BINARY_DIR BOARD ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE
     MCUBOOT_IMAGE_NUMBER PSA_TEST_SUITE)
   set(multiValueArgs ENABLED_PARTITIONS)
@@ -68,12 +72,12 @@ function(trusted_firmware_build)
     target_compile_definitions(app PRIVATE "TFM_PSA_API")
   endif()
 
-  if(DEFINED TFM_ISOLATION_LEVEL)
-    set(TFM_ISOLATION_LEVEL_ARG -DTFM_ISOLATION_LEVEL=${TFM_ISOLATION_LEVEL})
+  if (TFM_REGRESSION_S)
+    set(TFM_REGRESSION_S_ARG -DTEST_S=ON)
   endif()
 
-  if(TFM_REGRESSION)
-    set(TFM_REGRESSION_ARG -DTEST_S=ON)
+  if (TFM_REGRESSION_NS)
+    set(TFM_REGRESSION_NS_ARG -DTEST_NS=ON)
   endif()
 
   if(DEFINED TFM_CMAKE_BUILD_TYPE)
@@ -169,7 +173,8 @@ function(trusted_firmware_build)
                -DBL2=${TFM_BL2}
                ${TFM_IPC_ARG}
                ${TFM_ISOLATION_LEVEL_ARG}
-               ${TFM_REGRESSION_ARG}
+               ${TFM_REGRESSION_S_ARG}
+               ${TFM_REGRESSION_NS_ARG}
                ${TFM_PROFILE_ARG}
                ${MCUBOOT_IMAGE_NUM_ARG}
                ${PSA_TEST_ARG}
@@ -243,8 +248,11 @@ if (CONFIG_BUILD_WITH_TFM)
   if (CONFIG_TFM_IPC)
     set(TFM_IPC_ARG IPC)
   endif()
-  if (CONFIG_TFM_REGRESSION)
-    set(TFM_REGRESSION_ARG REGRESSION)
+  if (CONFIG_TFM_REGRESSION_S)
+    set(TFM_REGRESSION_S_ARG REGRESSION_S)
+  endif()
+  if (CONFIG_TFM_REGRESSION_NS)
+    set(TFM_REGRESSION_NS_ARG REGRESSION_NS)
   endif()
   if (CONFIG_TFM_BL2)
     set(TFM_BL2_ARG BL2)
@@ -295,7 +303,8 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_IMAGE_NUMBER_ARG}
     ${TFM_BL2_ARG}
     ${TFM_IPC_ARG}
-    ${TFM_REGRESSION_ARG}
+    ${TFM_REGRESSION_S_ARG}
+    ${TFM_REGRESSION_NS_ARG}
     ENABLED_PARTITIONS ${TFM_ENABLED_PARTITIONS_ARG}
     ${TFM_PSA_TEST_ARG}
     CMAKE_BUILD_TYPE ${TFM_CMAKE_BUILD_TYPE}
@@ -375,11 +384,17 @@ if (CONFIG_BUILD_WITH_TFM)
   elseif(CONFIG_TFM_MCUBOOT_IMAGE_NUMBER STREQUAL "1")
     tfm_sign(sign_cmd NS TRUE ${S_NS_FILE} ${S_NS_SIGNED_FILE})
 
+    if (CONFIG_TFM_REGRESSION_NS)
+      set(NS_APP_FILE $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE>)
+    else()
+      set(NS_APP_FILE ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME})
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/mergehex.py
         -o ${S_NS_FILE}
         $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
-        ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+        ${NS_APP_FILE}
 
       COMMAND ${sign_cmd}
 
@@ -396,7 +411,12 @@ if (CONFIG_BUILD_WITH_TFM)
     )
 
   else()
-    tfm_sign(sign_cmd_ns NS FALSE ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME} ${NS_SIGNED_FILE})
+    if (CONFIG_TFM_REGRESSION_NS)
+      tfm_sign(sign_cmd_ns NS TRUE $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE> ${NS_SIGNED_FILE})
+    else()
+      tfm_sign(sign_cmd_ns NS FALSE ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME} ${NS_SIGNED_FILE})
+    endif()
+
     tfm_sign(sign_cmd_s S TRUE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE> ${S_SIGNED_FILE})
 
     #Create and sign for concatenated binary image, should align with the TF-M BL2

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -229,11 +229,17 @@ config TFM_IPC
 	  TF-M Profile option is supplied, do not allow manual setting of
 	  the IPC mode, as it is determined by the profile setting.
 
-config TFM_REGRESSION
-	bool "Regression tests"
+config TFM_REGRESSION_S
+	bool "TF-M Secure Regression tests"
 	help
 	  When enabled, this option signifies that the TF-M build includes
-	  the Secure and the Non-Secure regression tests.
+	  the Secure domain regression tests.
+
+config TFM_REGRESSION_NS
+	bool "Use the TF-M Non-Secure Regression test application"
+	help
+	  When this is enabled, the Zephyr application as a whole will be
+	  replaced with the TF-M Non-Secure Regression test application.
 
 choice TFM_PSA_TEST
 	prompt "Enable a PSA test suite"

--- a/samples/tfm_integration/tfm_ipc/prj.conf
+++ b/samples/tfm_integration/tfm_ipc/prj.conf
@@ -1,6 +1,6 @@
 CONFIG_BUILD_WITH_TFM=y
 CONFIG_TFM_IPC=y
-CONFIG_TFM_REGRESSION=y
+CONFIG_TFM_REGRESSION_S=y
 CONFIG_TFM_PARTITION_AUDIT_LOG=n
 
 # The Zephyr CMSIS emulation assumes that ticks are ms, currently

--- a/samples/tfm_integration/tfm_regression_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_regression_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(tfm_regression_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/tfm_integration/tfm_regression_test/README.rst
+++ b/samples/tfm_integration/tfm_regression_test/README.rst
@@ -1,0 +1,117 @@
+.. _tfm_regression_test:
+
+TF-M Regression Test Sample
+###########################
+
+Overview
+********
+
+Run both the Secure and Non-secure TF-M Regression tests using the Zephyr build system.
+
+The build system will replace the Zephyr application with the Non-Secure TF-M test application,
+while the Secure tests will be included in the TF-M build itself.
+
+The TF-M regression tests are implemented in the tf-m-tests repo: https://git.trustedfirmware.org/TF-M/tf-m-tests.git/
+
+This sample is available for platforms that are supported in the trusted-firmware-m repo: https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/
+See sample.yaml for a list of supported platforms.
+
+Building and Running
+********************
+
+Tests for both the secure and non-secure domain are enabled by default, controlled via the CONFIG_TFM_REGRESSION_S and CONFIG_TFM_REGRESSION_NS configs.
+
+On Target
+=========
+
+Refer to :ref:`tfm_ipc` for detailed instructions.
+
+On QEMU:
+========
+
+Refer to :ref:`tfm_ipc` for detailed instructions.
+Following is an example based on ``west build``
+
+   .. code-block:: bash
+
+      $ west build samples/tfm_integration/tfm_regression_test/ -p -b mps2_an521_nonsecure -t run
+
+Sample Output
+=============
+
+   .. code-block:: console
+
+      Non-Secure system starting...
+
+      #### Execute test suites for the Secure area ####
+
+      [...]
+
+      Running Test Suite PS reliability tests (TFM_PS_TEST_3XXX)...
+      > Executing 'TFM_PS_TEST_3001'
+      Description: 'repetitive sets and gets in/from an asset'
+      > Iteration 15 of 15
+      TEST: TFM_PS_TEST_3001 - PASSED!
+      > Executing 'TFM_PS_TEST_3002'
+      Description: 'repetitive sets, gets and removes'
+      > Iteration 15 of 15
+      TEST: TFM_PS_TEST_3002 - PASSED!
+      TESTSUITE PASSED!
+
+      [...]
+
+      *** Secure test suites summary ***
+      Test suite 'PSA protected storage S interface tests (TFM_PS_TEST_2XXX)' has  PASSED
+      Test suite 'PS reliability tests (TFM_PS_TEST_3XXX)' has  PASSED
+      Test suite 'PS rollback protection tests (TFM_PS_TEST_4XXX)' has  PASSED
+      Test suite 'PSA internal trusted storage S interface tests (TFM_ITS_TEST_2XXX)' has  PASSED
+      Test suite 'ITS reliability tests (TFM_ITS_TEST_3XXX)' has  PASSED
+      Test suite 'Crypto secure interface tests (TFM_CRYPTO_TEST_5XXX)' has  PASSED
+      Test suite 'Initial Attestation Service secure interface tests(TFM_ATTEST_TEST_1XXX)' has  PASSED
+      Test suite 'Platform Service Secure interface tests(TFM_PLATFORM_TEST_1XXX)' has  PASSED
+      Test suite 'IPC secure interface test (TFM_IPC_TEST_1XXX)' has  PASSED
+
+      *** End of Secure test suites ***
+
+      #### Execute test suites for the Non-secure area ####
+
+      [...]
+
+      Running Test Suite Core non-secure positive tests (TFM_CORE_TEST_1XXX)...
+      > Executing 'TFM_CORE_TEST_1001'
+      Description: 'Test service request from NS thread mode'
+      TEST: TFM_CORE_TEST_1001 - PASSED!
+      > Executing 'TFM_CORE_TEST_1003'
+      Description: 'Test the success of service init'
+      TEST: TFM_CORE_TEST_1003 - PASSED!
+      > Executing 'TFM_CORE_TEST_1007'
+      Description: 'Test secure service buffer accesses'
+      TEST: TFM_CORE_TEST_1007 - PASSED!
+      > Executing 'TFM_CORE_TEST_1008'
+      Description: 'Test secure service to service call'
+      TEST: TFM_CORE_TEST_1008 - PASSED!
+      > Executing 'TFM_CORE_TEST_1010'
+      Description: 'Test secure service to service call with buffer handling'
+      TEST: TFM_CORE_TEST_1010 - PASSED!
+      > Executing 'TFM_CORE_TEST_1015'
+      Description: 'Test service parameter sanitization'
+      TEST: TFM_CORE_TEST_1015 - PASSED!
+      > Executing 'TFM_CORE_TEST_1016'
+      Description: 'Test outvec write'
+      TEST: TFM_CORE_TEST_1016 - PASSED!
+      TESTSUITE PASSED!
+
+      [...]
+
+      *** Non-secure test suites summary ***
+      Test suite 'PSA protected storage NS interface tests (TFM_PS_TEST_1XXX)' has  PASSED
+      Test suite 'PSA internal trusted storage NS interface tests (TFM_ITS_TEST_1XXX)' has  PASSED
+      Test suite 'Crypto non-secure interface test (TFM_CRYPTO_TEST_6XXX)' has  PASSED
+      Test suite 'Platform Service Non-Secure interface tests(TFM_PLATFORM_TEST_2XXX)' has  PASSED
+      Test suite 'Initial Attestation Service non-secure interface tests(TFM_ATTEST_TEST_2XXX)' has  PASSED
+      Test suite 'QCBOR regression test(TFM_QCBOR_TEST_7XXX)' has  PASSED
+      Test suite 'T_COSE regression test(TFM_T_COSE_TEST_8XXX)' has  PASSED
+      Test suite 'Core non-secure positive tests (TFM_CORE_TEST_1XXX)' has  PASSED
+      Test suite 'IPC non-secure interface test (TFM_IPC_TEST_1XXX)' has  PASSED
+
+      *** End of Non-secure test suites ***

--- a/samples/tfm_integration/tfm_regression_test/prj.conf
+++ b/samples/tfm_integration/tfm_regression_test/prj.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_TEST=y
+CONFIG_BUILD_WITH_TFM=y
+CONFIG_TFM_REGRESSION_S=y
+CONFIG_TFM_REGRESSION_NS=y

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -1,0 +1,19 @@
+common:
+    tags: tfm
+    platform_allow: mps2_an521_nonsecure v2m_musca_s1_nonsecure
+                    nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Non-Secure system starting..."
+        - "\\#\\#\\#\\# Execute test suites for the Non-secure area \\#\\#\\#\\#"
+        - "\\*\\*\\* End of Non-secure test suites \\*\\*\\*"
+
+sample:
+  name: "TFM Regression Test"
+
+tests:
+  sample.tfm.tfm_regression:
+    extra_args: ""
+    timeout: 200

--- a/samples/tfm_integration/tfm_regression_test/src/main.c
+++ b/samples/tfm_integration/tfm_regression_test/src/main.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+__attribute__((noreturn))
+void main(void)
+{
+	printk("Should not be printed, expected TF-M's NS application to be run instead.\n");
+	k_panic();
+
+	for (;;) {
+	}
+}


### PR DESCRIPTION
~~Based on #31910~~

The PR adds the option to run the TF-M regressions tests _directly_ using the Zephyr build system, in the form of a regular Zephyr sample
