### PR TITLE
arm64: Fix maybe-uninitialized error

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -55,7 +55,8 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	int cpu_count, i, j;
-	uint64_t cpu_mpid, master_core_mpid;
+	uint64_t cpu_mpid = 0;
+	uint64_t master_core_mpid;
 
 	/* Now it is on master core */
 	master_core_mpid = MPIDR_TO_CORE(GET_MPIDR());


### PR DESCRIPTION
Fix:
 arch/arm64/core/smp.c:98:3: error: 'cpu_mpid' may be used uninitialized in this function [-Werror=maybe-uninitialized]

Signed-off-by: Carlo Caione <ccaione@baylibre.com>