### PR TITLE
lib: os: cbprintf: fix different signedness comparison warning

### DIFF
--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -132,7 +132,7 @@ extern "C" {
 
 static inline void cbprintf_wcpy(int *dst, int *src, size_t len)
 {
-	for (int i = 0; i < len; i++) {
+	for (unsigned int i = 0; i < len; i++) {
 		dst[i] = src[i];
 	}
 }


### PR DESCRIPTION
Comparison between int & unsigned type causes warning when building with the warning enabled. Convert one side to unsigned.

Signed-off-by: Emil Lindqvist <emil@lindq.gr>