### PR TITLE
boards: arm: Enable mcuboot on mimxrt1064_evk

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -49,7 +49,7 @@ arduino_serial: &lpuart1 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
 		label = "AT25SF128A";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(16)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &at25sf128a;
 		zephyr,sram = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
@@ -44,7 +45,6 @@
 arduino_serial: &lpuart1 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1010_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1010_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &at25sf128a;
 		zephyr,sram = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
@@ -73,7 +74,6 @@
 arduino_serial: &lpuart4 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -78,7 +78,7 @@ arduino_serial: &lpuart4 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
 		label = "AT25SF128A";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(16)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];

--- a/boards/arm/mimxrt1015_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1015_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -85,7 +85,7 @@ arduino_serial: &lpuart2 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -18,6 +18,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &is25wp064;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -80,7 +81,6 @@
 arduino_serial: &lpuart2 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1020_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1020_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -96,7 +96,7 @@ arduino_serial: &lpuart3 {};
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		label = "S26KS512S";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(64)>;
 		spi-max-frequency = <166000000>;
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -20,6 +20,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &s26ks512s0;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -91,7 +92,6 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	s26ks512s0: s26ks512s@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -8,8 +8,13 @@
 
 /delete-node/ &s26ks512s0;
 
+/ {
+	chosen {
+		zephyr,flash = &is25wp064;
+	};
+};
+
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -14,7 +14,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1050_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1050_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -20,6 +20,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &is25wp064;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -92,7 +93,6 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -97,7 +97,7 @@ arduino_serial: &lpuart3 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -13,7 +13,7 @@
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		label = "S26KS512S";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(64)>;
 		spi-max-frequency = <166000000>;
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -7,8 +7,14 @@
 #include "mimxrt1060_evk.dts"
 
 /delete-node/ &is25wp064;
+
+/ {
+	chosen {
+		zephyr,flash = &s26ks512s0;
+	};
+};
+
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 	s26ks512s0: s26ks512s@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;

--- a/boards/arm/mimxrt1060_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1060_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -18,6 +18,9 @@ config DISK_DRIVER_SDMMC
 config FLASH_MCUX_FLEXSPI_NOR
 	default y if FLASH
 
+config FLASH_MCUX_FLEXSPI_XIP
+	default y if FLASH
+
 config I2C
 	default y if KSCAN
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -20,6 +20,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &w25q32jvwj0;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -137,7 +138,6 @@ arduino_i2c: &lpi2c1 {};
 	ahb-prefetch;
 	ahb-read-addr-opt;
 	rx-clock-source = <1>;
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -20,7 +20,9 @@
 	};
 
 	chosen {
+		zephyr,flash-controller = &flexspi2;
 		zephyr,flash = &w25q32jvwj0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -156,6 +158,35 @@ arduino_i2c: &lpi2c1 {};
 				label = "storage";
 				reg = <0x00000000 DT_SIZE_M(8)>;
 			};
+		};
+	};
+};
+
+&flexspi2 {
+	status = "okay";
+};
+
+&w25q32jvwj0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(1984)>;
+		};
+		slot1_partition: partition@200000 {
+			label = "image-1";
+			reg = <0x00200000 DT_SIZE_K(1984)>;
+		};
+		scratch_partition: partition@3f0000 {
+			label = "image-scratch";
+			reg = <0x003f0000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -142,7 +142,7 @@ arduino_i2c: &lpi2c1 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mimxrt1064_evk/pre_dt_board.cmake
+++ b/boards/arm/mimxrt1064_evk/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -19,6 +19,7 @@
 	};
 
 	chosen {
+		zephyr,flash = &is25wp064;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
@@ -53,7 +54,6 @@
 
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -58,7 +58,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		label = "IS25WP064";
-		reg = <0>;
+		reg = <0 0x1000>, <0x60000000 DT_SIZE_M(8)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];

--- a/boards/arm/mm_swiftio/pre_dt_board.cmake
+++ b/boards/arm/mm_swiftio/pre_dt_board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Allow non-zero #size-cells so we can define the size of memory-mapped FlexSPI
+# devices
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -67,7 +67,7 @@
 
 		flexspi: spi@402a8000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a8000 0x4000>;
+			reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(256)>;
 			interrupts = <108 0>;
 			label = "FLEXSPI";
 			#address-cells = <1>;
@@ -79,7 +79,7 @@
 
 		flexspi2: spi@402a4000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a4000 0x4000>;
+			reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(240)>;
 			interrupts = <107 0>;
 			label = "FLEXSPI1";
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -71,7 +71,7 @@
 			interrupts = <108 0>;
 			label = "FLEXSPI";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			ahb-bufferable;
 			ahb-cacheable;
 			status = "disabled";
@@ -83,7 +83,7 @@
 			interrupts = <107 0>;
 			label = "FLEXSPI1";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			ahb-bufferable;
 			ahb-cacheable;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -7,7 +7,6 @@
 #include <nxp/nxp_rt1060.dtsi>
 
 &flexspi2 {
-	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
 	/* WINBOND */
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "nxp,imx-flexspi-nor";

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -13,7 +13,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <33554432>;
 		label = "W25Q32JVWJ0";
-		reg = <0>;
+		reg = <0 0x1000>, <0x70000000 DT_SIZE_M(4)>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [ef 40 16];

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -18,7 +18,6 @@ properties:
       const: 1
     "#size-cells":
       required: true
-      const: 0
     label:
       required: true
     cs-gpios:

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -63,45 +63,13 @@ config WDT_MCUX_IMX_WDOG
 	default y
 	depends on WATCHDOG
 
-if CODE_SEMC
+DT_CHOSEN_Z_FLASH := zephyr,flash
 
 config FLASH_SIZE
-	default $(dt_node_reg_size_int,/memory@80000000,0,K)
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),1,K) if XIP
 
 config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/memory@80000000)
-
-endif # CODE_SEMC
-
-if CODE_ITCM
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flexram@400b0000/itcm@0,0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/itcm@0)
-
-endif # CODE_ITCM
-
-if CODE_FLEXSPI
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@402a8000,1,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@402a8000,1)
-
-endif # CODE_FLEXSPI
-
-if CODE_FLEXSPI2
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@402a4000,1,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@402a4000,1)
-
-endif # CODE_FLEXSPI2
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH),1) if XIP
 
 config USB_DC_NXP_EHCI
 	default y

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -12,6 +12,9 @@ config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
+config BUILD_OUTPUT_HEX
+	default y
+
 config CAN_MCUX_FLEXCAN
 	default y if HAS_MCUX_FLEXCAN
 	depends on CAN


### PR DESCRIPTION
Reworks device tree bindings for the NXP FlexSPI controller to allow defining both the chip select and the memory-mapped address for each device on the bus. This allows us to convert i.MX RT boards to use a zephyr,flash chosen node and to use west to sign images for mcuboot.

mcuboot can now boot a zephyr application from the internal QSPI flash on the `mimxrt1064_evk` board. The slot sizes are large, so we need to modify the build instructions in `doc/guides/west/sign.rst` to increase `CONFIG_BOOT_MAX_IMG_SECTORS`:

```
$ west build -b mimxrt1064_evk -s bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DCONFIG_BOOT_MAX_IMG_SECTORS=512
$ west build -b mimxrt1064_evk -s zephyr/samples/hello_world -d build-hello-signed -- -DCONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"bootloader/mcuboot/root-rsa-2048.pem\"

$ west flash -d build-mcuboot
$ west flash -d build-hello-signed
```

```
*** Booting Zephyr OS build zephyr-v2.5.0-2422-g8c0a1a67565c  ***
I: Starting bootloader
I: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Boot source: primary slot
I: Swap type: none
I: Bootloader chainload address offset: 0x10000
I: Jumping to the first image slot
*** Booting Zephyr OS build zephyr-v2.5.0-2422-g8c0a1a67565c  ***
Hello World! mimxrt1064_evk
```

This is an alternative to #30065

~~I have not yet tested swapping images~~
I confirmed that [Device Firmware Upgrade](https://docs.zephyrproject.org/latest/samples/subsys/mgmt/mcumgr/smp_svr/README.html#device-firmware-upgrade-dfu) works over the shell transport.