### PR TITLE
stm32: soc: Fix log usage

### DIFF
--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -14,6 +14,11 @@
 #include <init.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <logging/log.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -16,6 +16,11 @@
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
 
+#include <logging/log.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -13,6 +13,10 @@
 #include <init.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <logging/log.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
 
 /**
  * @brief Perform basic hardware initialization at boot.


### PR DESCRIPTION
Some SOC were using log without register the domain.