### PR TITLE
logging: Enable SWO pin for STM32 SoCs 

### DIFF
--- a/soc/arm/st_stm32/common/CMakeLists.txt
+++ b/soc/arm/st_stm32/common/CMakeLists.txt
@@ -6,3 +6,5 @@ zephyr_linker_sources_ifdef(CONFIG_STM32_CCM SECTIONS ccm.ld)
 
 zephyr_sources_ifdef(CONFIG_STM32_BACKUP_SRAM stm32_backup_sram.c)
 zephyr_linker_sources_ifdef(CONFIG_STM32_BACKUP_SRAM SECTIONS stm32_backup_sram.ld)
+
+zephyr_sources(soc_config.c)

--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Andrés Manelli <am@toroid.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief System module to support early STM32 MCU configuration
+ */
+
+#include <device.h>
+#include <init.h>
+#include <soc.h>
+#include <arch/cpu.h>
+
+/**
+ * @brief Perform SoC configuration at boot.
+ *
+ * This should be run early during the boot process but after basic hardware
+ * initialization is done.
+ *
+ * @return 0
+ */
+static int st_stm32_common_config(const struct device *dev)
+{
+#ifdef CONFIG_LOG_BACKEND_SWO
+	/* TRACE pin assignment for asynchronous mode */
+	DBGMCU->CR &= ~DBGMCU_CR_TRACE_MODE_Msk;
+	/* Enable the SWO pin */
+	DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
+#endif
+
+	return 0;
+}
+
+SYS_INIT(st_stm32_common_config, PRE_KERNEL_1, 1);


### PR DESCRIPTION
Set TRACE_MODE to asynchronous and enable trace output pin.

Fixes #34342

Signed-off-by: Andrés Manelli <am@toroid.io>