### PR TITLE
ci: Handle twister.xml junit files being empty

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -27,15 +27,8 @@ steps:
       - junit-annotate#v1.7.0:
           artifacts: twister-*.xml
 
-  - command: |
-      buildkite-agent artifact download twister-*.xml .
-      junitparser merge twister-*.xml junit.xml
-      buildkite-agent artifact upload junit.xml
-      junit2html junit.xml
-      buildkite-agent artifact upload junit.xml.html
-      cat << EOF | buildkite-agent annotate --style "info"
-        Read the <a href="artifact://junit.xml.html">JUnit test report</a>
-      EOF
+  - command:
+    - .buildkite/mergejunit.sh
 
 notify:
   - email: "builds+int+399+7809482394022958124@lists.zephyrproject.org"

--- a/.buildkite/mergejunit.sh
+++ b/.buildkite/mergejunit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) 2021 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+set -eE
+
+buildkite-agent artifact download twister-*.xml .
+
+xmls=""
+
+for f in twister-*xml; do [ -s ${f} ] && xmls+="${f} "; done
+
+if [ "${xmls}" ]; then
+   junitparser merge ${xmls} junit.xml
+   buildkite-agent artifact upload junit.xml
+   junit2html junit.xml
+   buildkite-agent artifact upload junit.xml.html
+   buildkite-agent annotate --style "info" "Read the <a href=\"artifact://junit.xml.html\">JUnit test report</a>"
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,12 +27,5 @@ steps:
       - junit-annotate#v1.7.0:
           artifacts: twister-*.xml
 
-  - command: |
-      buildkite-agent artifact download twister-*.xml .
-      junitparser merge twister-*.xml junit.xml
-      buildkite-agent artifact upload junit.xml
-      junit2html junit.xml
-      buildkite-agent artifact upload junit.xml.html
-      cat << EOF | buildkite-agent annotate --style "info"
-        Read the <a href="artifact://junit.xml.html">JUnit test report</a>
-      EOF
+  - command:
+    - .buildkite/mergejunit.sh


### PR DESCRIPTION
junitparse doesn't deal well with being given an empty file.  So build
a filterted list of non-empty files to pass to junitparser.

Additionally handle the case that all junit xml files are empty, if
that is the case skip calling junitparser and junit2html.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>