### PR TITLE
Bluetooth/tester: fix coverity issue in l2cap

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -205,9 +205,10 @@ static void connect(uint8_t *data, uint16_t len)
 	return;
 
 fail:
-	while (i >= 0) {
-		channels[i].in_use = false;
-		i--;
+	for (i = 0U; i < ARRAY_SIZE(allocated_channels); i++) {
+		if (allocated_channels[i]) {
+			channels[allocated_channels[i]->ident].in_use = false;
+		}
 	}
 	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_CONNECT, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);


### PR DESCRIPTION
i is of uint type, so it'll never be negative. Thus, while loop
condition i >= 0 will always be true.
This patch also fixes issue with marking unused l2cap channels
as free by freeing only these that were marked as in_use by
get_free_channel(), and not all of them.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>