### PR TITLE
ci: Cleanup files on exit

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -24,6 +24,9 @@ function cleanup()
 	echo "--- ccache stats at finish"
 	ccache -s
 
+	# Cleanup on exit
+	rm -fr *
+
 	# disk usage
 	echo "--- disk usage at finish"
 	df -h


### PR DESCRIPTION
Remove files to cleanup disk space so if the machine gets
re-used we aren't wasting disk space.  This can happen when different
build types (zephyr, bluetooth, and daily) all happen on the same
machine.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>