### PR TITLE
cmake: DTS post-processing of ELF file depends on CONFIG_HAS_DTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,19 +768,21 @@ if(CONFIG_GEN_ISR_TABLES)
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)
 endif()
 
-# dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
-# gen_handles.py
-add_custom_command(
-  OUTPUT dev_handles.c
-  COMMAND
-  ${PYTHON_EXECUTABLE}
-  ${ZEPHYR_BASE}/scripts/gen_handles.py
-  --output-source dev_handles.c
-  --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
-  --zephyr-base ${ZEPHYR_BASE}
-  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
-  )
-set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+if(CONFIG_HAS_DTS)
+  # dev_handles.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+  # gen_handles.py
+  add_custom_command(
+    OUTPUT dev_handles.c
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/gen_handles.py
+    --output-source dev_handles.c
+    --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
+    --zephyr-base ${ZEPHYR_BASE}
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
+    )
+  set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES dev_handles.c)
+endif()
 
 if(CONFIG_CODE_DATA_RELOCATION)
   # @Intent: Linker script to relocate .text, data and .bss sections

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -52,6 +52,7 @@ config ARM64
 config SPARC
 	bool
 	select ARCH_IS_SET
+	select HAS_DTS
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select BIG_ENDIAN


### PR DESCRIPTION
Only run gen_handles.py if CONFIG_HAS_DTS is set. This enables vendors
without device tree implementations to compile without the generated
dependencies.

Fixes #34416.

Signed-off-by: Morten Priess <mtpr@oticon.com>