### PR TITLE
shell: uart: Add TX disabling in uninitialization

### DIFF
--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -92,7 +92,6 @@ static void shell_uninit_cb(const struct shell *shell, int res)
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		/* connect uart to my handler */
 		uart_irq_callback_user_data_set(dev, direct_uart_callback, NULL);
-		uart_irq_tx_disable(dev);
 		uart_irq_rx_enable(dev);
 	} else {
 		k_timer_user_data_set(&uart_poll_timer, (void *)dev);

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -201,6 +201,7 @@ static int uninit(const struct shell_transport *transport)
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		const struct device *dev = sh_uart->ctrl_blk->dev;
 
+		uart_irq_tx_disable(dev);
 		uart_irq_rx_disable(dev);
 	} else {
 		k_timer_stop(sh_uart->timer);


### PR DESCRIPTION
Uninitialization of uart transport was missing disabling of TX
interrupt. It had to be done by the user before using uart.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>