### PR TITLE
net: sntp: Depend on NET_SOCKETS_POSIX_NAMES || POSIX_API

### DIFF
--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SNTP
-	bool "SNTP"
-	select NET_SOCKETS
+	bool "SNTP (Simple Network Time Protocol)"
+	depends on NET_SOCKETS
+	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API
 	help
 	  Enable SNTP client library
 


### PR DESCRIPTION
This library is coded with standard POSIX names for socket functions,
so make that requirement explicit.

Also, switch it from select'ing NET_SOCKETS, to depend'ing on it. This
follows the general approach of avoiding unneeded select's in Zephyr,
which lead to conflicting dependencies and make debugging dependencies
complex overall. In this particular case, it's fair (for a user) to
expect that "simple network time protocol" requires networking API,
namely sockets, and have that explicitly on in their app configuration,
giving better overview of their app config overall.

Fixes: #34165

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>