### PR TITLE
driver: pwm: npcx: Add output open drain support

### DIFF
--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -72,6 +72,7 @@
 };
 
 &pwm6 {
+	drive-open-drain;
 	status = "okay";
 };
 

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -38,6 +38,8 @@ struct pwm_npcx_config {
 	uintptr_t base;
 	/* clock configuration */
 	struct npcx_clk_cfg clk_cfg;
+	/* Output buffer - open drain */
+	const bool is_od;
 	/* pinmux configuration */
 	const uint8_t alts_size;
 	const struct npcx_alt *alts_list;
@@ -59,6 +61,7 @@ struct pwm_npcx_data {
 /* PWM local functions */
 static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 {
+	const struct pwm_npcx_config *const config = DRV_CONFIG(dev);
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
 
 	/* Disable PWM for module configuration first */
@@ -80,6 +83,12 @@ static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 		inst->PWMCTL |= BIT(NPCX_PWMCTL_CKSEL);
 	else
 		inst->PWMCTL &= ~BIT(NPCX_PWMCTL_CKSEL);
+
+	/* Select output buffer type of io pad */
+	if (config->is_od)
+		inst->PWMCTLEX |= BIT(NPCX_PWMCTLEX_OD_OUT);
+	else
+		inst->PWMCTLEX &= ~BIT(NPCX_PWMCTLEX_OD_OUT);
 }
 
 /* PWM api functions */
@@ -202,6 +211,7 @@ static int pwm_npcx_init(const struct device *dev)
 	static const struct pwm_npcx_config pwm_npcx_cfg_##inst = {            \
 		.base = DT_INST_REG_ADDR(inst),                                \
 		.clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst),                         \
+		.is_od = DT_INST_PROP(inst, drive_open_drain),                 \
 		.alts_size = ARRAY_SIZE(pwm_alts##inst),                       \
 		.alts_list = pwm_alts##inst,                                   \
 	};                                                                     \

--- a/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
+++ b/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
@@ -18,6 +18,11 @@ properties:
         type: phandles
         required: true
         description: configurations of pinmux controllers
+    drive-open-drain:
+        type: boolean
+        description: |
+            The PWM output will be configured as open-drain. If not set,
+            defaults to push-pull.
 
 pwm-cells:
     - channel


### PR DESCRIPTION
NPCX PWM supports output buffet select to push-pull or open-drain. Add
output buffer select option 'drive-open-drain' in devicetree for NPCX
PWM. If set, the PWM output will be configured as open-drain. If not
set, defaults to push-pull.