### PR TITLE
lorawan: port oriented downlink

### DIFF
--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -13,6 +13,7 @@
  */
 
 #include <device.h>
+#include <sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -103,6 +104,35 @@ struct lorawan_join_config {
 	enum lorawan_act_type mode;
 };
 
+#define LW_RECV_PORT_ANY UINT16_MAX
+
+struct lorawan_downlink_cb {
+	/* Port to handle messages for:
+	 *               Port 0: TX packet acknowledgements
+	 *          Ports 1-255: Standard downlink port
+	 *     LW_RECV_PORT_ANY: All downlinks
+	 */
+	uint16_t port;
+	/**
+	 * @brief Callback function to run on downlink data
+	 *
+	 * @note Callbacks are run on the system workqueue,
+	 *       and should therefore be as short as possible.
+	 *
+	 * @param port Port message was sent on
+	 * @param data_pending Network server has more downlink packets pending
+	 * @param rssi Received signal strength in dBm
+	 * @param snr Signal to Noise ratio in dBm
+	 * @param len Length of data received, will be 0 for ACKs
+	 * @param data Data received, will be NULL for ACKs
+	 */
+	void (*cb)(uint8_t port, bool data_pending,
+		   int16_t rssi, int8_t snr,
+		   uint8_t len, const uint8_t *data);
+	/** Node for callback list */
+	sys_snode_t node;
+};
+
 /**
  * @brief Add battery level callback function.
  *
@@ -120,6 +150,13 @@ struct lorawan_join_config {
  * @return 0 if successful, negative errno code if failure
  */
 int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
+
+/**
+ * @brief Register a callback to be run on downlink packets
+ *
+ * @param cb Pointer to structure containing callback parameters
+ */
+void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb);
 
 /**
  * @brief Register a callback to be called when the datarate changes

--- a/include/lorawan/lorawan.h
+++ b/include/lorawan/lorawan.h
@@ -198,7 +198,7 @@ int lorawan_set_conf_msg_tries(uint8_t tries);
  * @brief Enable Adaptive Data Rate (ADR)
  *
  * Control whether adaptive data rate (ADR) is enabled. When ADR is enabled,
- * the data rate is treated as a default data rate that wil be used if the
+ * the data rate is treated as a default data rate that will be used if the
  * ADR algorithm has not established a data rate. ADR should normally only
  * be enabled for devices with stable RF conditions (i.e., devices in a mostly
  * static location).
@@ -245,4 +245,4 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 }
 #endif
 
-#endif	/* ZEPHYR_INCLUDE_LORAWAN_LORAWAN_H_ */
+#endif /* ZEPHYR_INCLUDE_LORAWAN_LORAWAN_H_ */

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -32,6 +32,16 @@ LOG_MODULE_REGISTER(lorawan_class_a);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
+static void dl_callback(uint8_t port, bool data_pending,
+			int16_t rssi, int8_t snr,
+			uint8_t len, const uint8_t *data)
+{
+	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm", port, data_pending, rssi, snr);
+	if (data) {
+		LOG_HEXDUMP_INF(data, len, "Payload: ");
+	}
+}
+
 static void lorwan_datarate_changed(enum lorawan_datarate dr)
 {
 	uint8_t unused, max_size;
@@ -49,6 +59,11 @@ void main(void)
 	uint8_t app_key[] = LORAWAN_APP_KEY;
 	int ret;
 
+	struct lorawan_downlink_cb downlink_cb = {
+		.port = LW_RECV_PORT_ANY,
+		.cb = dl_callback
+	};
+
 	lora_dev = device_get_binding(DEFAULT_RADIO);
 	if (!lora_dev) {
 		LOG_ERR("%s Device not found", DEFAULT_RADIO);
@@ -61,6 +76,7 @@ void main(void)
 		return;
 	}
 
+	lorawan_register_downlink_callback(&downlink_cb);
 	lorawan_register_dr_changed_callback(lorwan_datarate_changed);
 
 	join_cfg.mode = LORAWAN_ACT_OTAA;

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -62,7 +62,7 @@ static enum lorawan_datarate current_datarate;
 static uint8_t lorawan_conf_msg_tries = 1;
 static bool lorawan_adr_enable;
 
-
+static sys_slist_t dl_callbacks;
 
 static LoRaMacPrimitives_t macPrimitives;
 static LoRaMacCallback_t macCallbacks;
@@ -129,6 +129,8 @@ static void McpsConfirm(McpsConfirm_t *mcpsConfirm)
 
 static void McpsIndication(McpsIndication_t *mcpsIndication)
 {
+	struct lorawan_downlink_cb *cb;
+
 	LOG_DBG("Received McpsIndication %d", mcpsIndication->McpsIndication);
 
 	if (mcpsIndication->Status != LORAMAC_EVENT_INFO_STATUS_OK) {
@@ -142,17 +144,19 @@ static void McpsIndication(McpsIndication_t *mcpsIndication)
 		datarate_observe(false);
 	}
 
-	/* TODO: Check MCPS Indication type */
-	if (mcpsIndication->RxData == true) {
-		if (mcpsIndication->BufferSize != 0) {
-			LOG_DBG("Rx Data: %s",
-				log_strdup(mcpsIndication->Buffer));
+	/* Iterate over all registered downlink callbacks */
+	SYS_SLIST_FOR_EACH_CONTAINER(&dl_callbacks, cb, node) {
+		if ((cb->port == LW_RECV_PORT_ANY) ||
+		    (cb->port == mcpsIndication->Port)) {
+			cb->cb(mcpsIndication->Port,
+			       !!mcpsIndication->FramePending,
+			       mcpsIndication->Rssi, mcpsIndication->Snr,
+			       mcpsIndication->BufferSize,
+			       mcpsIndication->Buffer);
 		}
 	}
 
 	last_mcps_indication_status = mcpsIndication->Status;
-
-	/* TODO: Compliance test based on FPort value*/
 }
 
 static void MlmeConfirm(MlmeConfirm_t *mlmeConfirm)
@@ -523,6 +527,11 @@ int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void))
 	return 0;
 }
 
+void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)
+{
+	sys_slist_append(&dl_callbacks, &cb->node);
+}
+
 void lorawan_register_dr_changed_callback(void (*cb)(enum lorawan_datarate))
 {
 	dr_change_cb = cb;
@@ -559,6 +568,8 @@ int lorawan_start(void)
 static int lorawan_init(const struct device *dev)
 {
 	LoRaMacStatus_t status;
+
+	sys_slist_init(&dl_callbacks);
 
 	macPrimitives.MacMcpsConfirm = McpsConfirm;
 	macPrimitives.MacMcpsIndication = McpsIndication;


### PR DESCRIPTION
Add downlink callbacks on a per-port basis.
A single message can be handled many times if multiple users have registered for that port (for example directly and via LW_RECV_PORT_ANY).
Callbacks will also be run on "meta" downlink packets on port 0, such as confirmed uplink acknowledgements.

Based on the feedback to @KubaFYI 's PR #29767.