### PR TITLE
doc: kernel: workqueue: various updates

### DIFF
--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -148,7 +148,7 @@ kernel submits the work item to the specified workqueue, where it remains
 queued until it is processed in the standard manner.
 
 Note that work handler used for delayable still receives a pointer to the
-underlying non-delayed work structure, which is not publicly accessible from
+underlying non-delayable work structure, which is not publicly accessible from
 :c:struct:`k_work_delayable`.  To get access to an object that contains the
 delayable work object use this idiom:
 
@@ -226,7 +226,7 @@ and then calling :c:func:`k_work_queue_start`. The stack area must be defined
 using :c:macro:`K_THREAD_STACK_DEFINE` to ensure it is properly set up in
 memory.
 
-The following code defines and initializes a workqueue.
+The following code defines and initializes a workqueue:
 
 .. code-block:: c
 
@@ -253,6 +253,9 @@ The following API can be used to interact with a workqueue:
   thread or ISR are rejected.  The restriction on submitting more work can be
   extended past the completion of the drain operation in order to allow the
   blocking thread to perform additional work while the queue is "plugged".
+  Note that draining a queue has no effect on scheduling or processing
+  delayable items, but if the queue is plugged and the deadline expires the
+  item will silently fail to be submitted.
 * :c:func:`k_work_queue_unplug()` removes any previous block on submission to
   the queue due to a previous drain operation.
 

--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -102,12 +102,12 @@ operations that are potentially blocking (e.g. taking a semaphore) must be
 used with care, since the workqueue cannot process subsequent work items in
 its queue until the handler function finishes executing.
 
-The single argument that is passed to a handler function can be ignored if
-it is not required. If the handler function requires additional information
-about the work it is to perform, the work item can be embedded in a larger
-data structure. The handler function can then use the argument value to compute
-the address of the enclosing data structure, and thereby obtain access to the
-additional information it needs.
+The single argument that is passed to a handler function can be ignored if it
+is not required. If the handler function requires additional information about
+the work it is to perform, the work item can be embedded in a larger data
+structure. The handler function can then use the argument value to compute the
+address of the enclosing data structure with :c:macro:`CONTAINER_OF`, and
+thereby obtain access to the additional information it needs.
 
 A work item is typically initialized once and then submitted to a specific
 workqueue whenever work needs to be performed. If an ISR or a thread attempts
@@ -146,6 +146,21 @@ the schedule request is made the kernel initiates a timeout mechanism that is
 triggered after the specified delay has elapsed. Once the timeout occurs the
 kernel submits the work item to the specified workqueue, where it remains
 queued until it is processed in the standard manner.
+
+Note that work handler used for delayable still receives a pointer to the
+underlying non-delayed work structure, which is not publicly accessible from
+:c:struct:`k_work_delayable`.  To get access to an object that contains the
+delayable work object use this idiom:
+
+.. code-block:: c
+
+   static void work_handler(struct k_work *work)
+   {
+           struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+           struct work_context *ctx = CONTAINER_OF(dwork, struct work_context,
+	                                           timed_work);
+           ...
+
 
 Triggered Work
 **************

--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -245,7 +245,9 @@ Submitting a Work Item
 ======================
 
 A work item is defined using a variable of type :c:struct:`k_work`.  It must
-be initialized by calling :c:func:`k_work_init`.
+be initialized by calling :c:func:`k_work_init`, unless it is defined using
+:c:macro:`K_WORK_DEFINE` in which case initialization is performed at
+compile-time.
 
 An initialized work item can be submitted to the system workqueue by
 calling :c:func:`k_work_submit`, or to a specified workqueue by


### PR DESCRIPTION
General cleanup, particularly in precise usage of terminology like scheduled, queued, running, and pending.  Integration of the Best Practices section from #33104.  A tweak that may help with the concerns of #33761.