### PR TITLE
net: coap: Parse option no longer crashes with no options to parse

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -627,6 +627,11 @@ int coap_find_options(const struct coap_packet *cpkt, uint16_t code,
 	uint8_t num;
 	int r;
 
+	/* Check if there are options to parse */
+	if (cpkt->hdr_len == cpkt->max_len) {
+		return 0;
+	}
+
 	offset = cpkt->hdr_len;
 	opt_len = 0U;
 	delta = 0U;


### PR DESCRIPTION
parse_option() now first checks if there is actual data to parse,
returning 0 if there is none.

Fixes #34463.

Signed-off-by: Maik Vermeulen <maik.vermeulen@innotractor.com>