### PR TITLE
net: socket: packet: Fix memory leak

### DIFF
--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -186,6 +186,16 @@ static int send_packet_socket(struct packet_data *packet)
 			}
 		}
 
+		/* If we have received any data, flush it here in order to
+		 * not to leak memory in IP stack.
+		 */
+		do {
+			static char recv_buffer[RECV_BUFFER_SIZE];
+
+			ret = recv(packet->send_sock, recv_buffer,
+				   sizeof(recv_buffer), MSG_DONTWAIT);
+		} while (ret > 0);
+
 		if (!FLOOD) {
 			k_msleep(WAIT_TIME);
 		}


### PR DESCRIPTION
The conn_raw_input() in connection.c will clone the incoming
packet so that it is possible to receive socket data in
multiple packet sockets. This is all fine except that if the
socket is never calling recv(), then the cloned net_pkt is never
processed and we will have a memory leak.

What this all means in practice, is that we should call recv()
to every packet socket in order to flush the socket for any
incoming data even if the socket is just sending data.

Fixes #34462

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>