### PR TITLE
Bluetooth: GATT: Add documentation for empty notifications in callback

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1454,6 +1454,10 @@ struct bt_gatt_subscribe_params;
 /** @typedef bt_gatt_notify_func_t
  *  @brief Notification callback function
  *
+ *  In the case of an empty notification, the @p data pointer will be non-NULL
+ *  while the @p length will be 0, which is due to the special case where
+ *  a @p data NULL pointer means unsubscribed.
+ *
  *  @param conn Connection object. May be NULL, indicating that the peer is
  *              being unpaired
  *  @param params Subscription parameters.


### PR DESCRIPTION
Adds documentation specifically for empty notification in the
bt_gatt_notify_func_t callback, as that works a bit different
from e.g. reading an empty characteristic.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>