### PR TITLE
driver: gpio: npcx: force io type as open-drain if select to 1p8v.

### DIFF
--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -127,6 +127,18 @@ void npcx_lvol_suspend_io_pads(void)
 	}
 }
 
+bool npcx_lvol_is_enabled(int port, int pin)
+{
+	for (int i = 0; i < ARRAY_SIZE(def_lvols); i++) {
+		if (def_lvols[i].io_port == port &&
+		    def_lvols[i].io_bit == pin) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void npcx_pinctrl_i2c_port_sel(int controller, int port)
 {
 	struct glue_reg *const inst_glue = HAL_GLUE_INST();

--- a/soc/arm/nuvoton_npcx/common/soc_pins.h
+++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
@@ -158,6 +158,15 @@ void npcx_lvol_restore_io_pads(void);
  */
 void npcx_lvol_suspend_io_pads(void);
 
+/**
+ * @brief Get the low-voltage power supply status of GPIO pads
+ *
+ * @param port port index of GPIO device
+ * @param pin pin of GPIO device
+ * @return 1 means the low-voltage power supply is enabled, otherwise disabled.
+ */
+bool npcx_lvol_is_enabled(int port, int pin);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
During configuring the low-voltage power supply of IO pads, the npcx GPIO driver needs to set the related PORTx_OUT_TYPE bit to 1, i.e. select to 'Open Drain IO type', also. This CL provides a mechanism that configuring these bits via 'def-lvol-io-list' node automatically in case the flag of gpios that have been configured to low-voltage power supply doesn't contain GPIO_OPEN_DRAIN.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>