### PR TITLE
Bluetooth: Host: Adds periodic advertising min/max interval macros

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -614,10 +614,20 @@ enum {
 };
 
 struct bt_le_per_adv_param {
-	/** Minimum Periodic Advertising Interval (N * 1.25 ms) */
+	/**
+	 * @brief Minimum Periodic Advertising Interval (N * 1.25 ms)
+	 *
+	 * Shall be greater or equal to BT_GAP_PER_ADV_MIN_INTERVAL and
+	 * less or equal to interval_max.
+	 */
 	uint16_t interval_min;
 
-	/** Maximum Periodic Advertising Interval (N * 1.25 ms) */
+	/**
+	 * @brief Maximum Periodic Advertising Interval (N * 1.25 ms)
+	 *
+	 * Shall be less or equal to BT_GAP_PER_ADV_MAX_INTERVAL and
+	 * greater or equal to interval_min.
+	 */
 	uint16_t interval_max;
 
 	/** Bit-field of periodic advertising options */

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -149,6 +149,10 @@ enum {
 #define BT_GAP_PER_ADV_MAX_SKIP                 0x01F3
 #define BT_GAP_PER_ADV_MIN_TIMEOUT              0x000A
 #define BT_GAP_PER_ADV_MAX_TIMEOUT              0x4000
+/** Minimum Periodic Advertising Interval (N * 1.25 ms) */
+#define BT_GAP_PER_ADV_MIN_INTERVAL             0x0006
+/** Maximum Periodic Advertising Interval (N * 1.25 ms) */
+#define BT_GAP_PER_ADV_MAX_INTERVAL             0xFFFF
 
 
 /** Constant Tone Extension (CTE) types */

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1369,8 +1369,8 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (param->interval_min < 0x0006 ||
-	    param->interval_max > 0xFFFF ||
+	if (param->interval_min < BT_GAP_PER_ADV_MIN_INTERVAL ||
+	    param->interval_max > BT_GAP_PER_ADV_MAX_INTERVAL ||
 	    param->interval_min > param->interval_max) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Add the BT_GAP_PER_ADV_MIN_INTERVAL and BT_GAP_PER_ADV_MAX_INTERVAL
macros in gap.h that are also reference in bluetooth.h and
used for parameter validation in adv.c.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>