### PR TITLE
logging: Tweaks to speed up compilation

### DIFF
--- a/lib/gui/lvgl/lvgl.c
+++ b/lib/gui/lvgl/lvgl.c
@@ -60,13 +60,26 @@ static void lvgl_log(lv_log_level_t level, const char *file, uint32_t line,
 	 * * LOG_LEVEL_INF 3
 	 * * LOG_LEVEL_DBG 4
 	 */
-	uint8_t zephyr_level = LOG_LEVEL_DBG - level;
+	char *dupdsc = log_strdup(dsc);
 
 	ARG_UNUSED(file);
 	ARG_UNUSED(line);
 	ARG_UNUSED(func);
 
-	Z_LOG(zephyr_level, "%s", log_strdup(dsc));
+	switch (level) {
+	case LV_LOG_LEVEL_TRACE:
+		Z_LOG(LOG_LEVEL_DBG, "%s", dupdsc);
+		break;
+	case LV_LOG_LEVEL_INFO:
+		Z_LOG(LOG_LEVEL_INF, "%s", dupdsc);
+		break;
+	case LV_LOG_LEVEL_WARN:
+		Z_LOG(LOG_LEVEL_WRN, "%s", dupdsc);
+		break;
+	case LV_LOG_LEVEL_ERROR:
+		Z_LOG(LOG_LEVEL_ERR, "%s", dupdsc);
+		break;
+	}
 }
 #endif
 


### PR DESCRIPTION
Logging attempts to do most of the work at compile time instead
of preprocessor by using conditions which can be resolved at
compile time (e.g. if (IS_ENABLED(...))). Apparently, such extensive
use significantly loads the compiler since all paths are compiled
even though cut from final binary. Patch reduces it by replacing
some compile time switch with preprocessor.

Handling of function name prefix has been moved to preprocessor.
Immediate logging v2 has also been moved to preprocessor.

Fixes #34419.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>