### PR TITLE
Bluetooth: Mesh: Allow to be NODE when PROVISIONER is enabled

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -69,17 +69,11 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 	 * FIXME:
 	 * Should net_key and iv_index be over-ridden?
 	 */
-	if (IS_ENABLED(CONFIG_BT_MESH_CDB)) {
+	if (IS_ENABLED(CONFIG_BT_MESH_CDB) &&
+	    atomic_test_bit(bt_mesh_cdb.flags, BT_MESH_CDB_VALID)) {
 		const struct bt_mesh_comp *comp;
 		const struct bt_mesh_prov *prov;
 		struct bt_mesh_cdb_node *node;
-
-		if (!atomic_test_bit(bt_mesh_cdb.flags,
-				     BT_MESH_CDB_VALID)) {
-			BT_ERR("No valid network");
-			atomic_clear_bit(bt_mesh.flags, BT_MESH_VALID);
-			return -EINVAL;
-		}
 
 		comp = bt_mesh_comp_get();
 		if (comp == NULL) {


### PR DESCRIPTION
When PROVISIONER and CDB is enabled then IUT couldn't be a NODE.
This patch fixes this by not returning an error when CDB is not
configured. This is useful especially in testing environment, when all
the features are compiled in and we can choose role in runtime.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>