### PR TITLE
Bluetooth: controller: Moved sdu_interval field members

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5468,8 +5468,6 @@ static uint8_t cis_req_recv(struct ll_conn *conn, memq_link_t *link,
 	conn->llcp_cis.framed = req->framed;
 	conn->llcp_cis.c_max_sdu = sys_le16_to_cpu(req->c_max_sdu);
 	conn->llcp_cis.p_max_sdu = sys_le16_to_cpu(req->p_max_sdu);
-	conn->llcp_cis.c_sdu_interval = sys_get_le24(req->c_sdu_interval);
-	conn->llcp_cis.p_sdu_interval = sys_get_le24(req->p_sdu_interval);
 	conn->llcp_cis.cis_offset_min = sys_get_le24(req->cis_offset_min);
 	conn->llcp_cis.cis_offset_max = sys_get_le24(req->cis_offset_max);
 	conn->llcp_cis.conn_event_count =

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -36,6 +36,8 @@ struct ll_conn_iso_group {
 				 * (FT_S_To_M) × ISO_Interval +
 				 * SDU_Interval_S_To_M
 				 */
+	uint32_t c_sdu_interval;
+	uint32_t p_sdu_interval;
 	uint16_t iso_interval;
 	uint8_t  cig_id;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -331,8 +331,6 @@ struct ll_conn {
 		uint32_t c_max_sdu:12;
 		uint32_t p_max_sdu:12;
 		uint32_t framed:1;
-		uint32_t c_sdu_interval;
-		uint32_t p_sdu_interval;
 		uint32_t cis_offset_min;
 		uint32_t cis_offset_max;
 		uint16_t conn_event_count;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -128,7 +128,9 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
-	cig->iso_interval = sys_le16_to_cpu(req->iso_interval);
+	cig->iso_interval   = sys_le16_to_cpu(req->iso_interval);
+	cig->c_sdu_interval = sys_get_le24(req->c_sdu_interval);
+	cig->p_sdu_interval = sys_get_le24(req->p_sdu_interval);
 
 	cis->cis_id = req->cis_id;
 	cis->established = 0;


### PR DESCRIPTION
Moved sdu_interval struct members from llcp_cis to cis group,
to match spec and enable access by ULL

Signed-off-by: Asger Munk Nielsen <asmk@oticon.com>