### PR TITLE
Twister: Improve set balancing

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -82,8 +82,9 @@ jobs:
         run: ls -R
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
         with:
           check_name: Unit Test Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/twister.xml"
+          comment_on_pr: false

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -19,10 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        subset: [1, 2, 3, 4, 5, 6, 7 , 8, 9, 10]
+        subset: [1, 2, 3, 4, 5]
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
       CLANG_ROOT_DIR: /usr/lib/llvm-12
+      MATRIX_SIZE: 5
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -55,7 +56,7 @@ jobs:
           #source zephyr-env.sh
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
-          ./scripts/twister --inline-logs -N -v -p native_posix --subset ${{matrix.subset}}/10 --retry-failed 3
+          ./scripts/twister --inline-logs -N -v -p native_posix --subset ${{matrix.subset}}/${MATRIX_SIZE} --retry-failed 3
 
       - name: Upload Unit Test Results
         if: always()

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -55,7 +55,7 @@ jobs:
           #source zephyr-env.sh
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
-          ./scripts/twister --inline-logs -N -v --integration -p native_posix --subset ${{matrix.subset}}/10 --retry-failed 3
+          ./scripts/twister --inline-logs -N -v -p native_posix --subset ${{matrix.subset}}/10 --retry-failed 3
 
       - name: Upload Unit Test Results
         if: always()

--- a/scripts/twister
+++ b/scripts/twister
@@ -1146,10 +1146,16 @@ def main():
         else:
             suite.instances = OrderedDict(sorted(suite.instances.items()))
 
+        # Do calculation based on what is actually going to be run and evaluated
+        # at runtime, ignore the cases we already know going to be skipped.
+        # This fixes an issue where some sets would get majority of skips and
+        # basically run nothing beside filtering.
+        to_run = {k : v for k,v in suite.instances.items() if v.status is None}
+
         subset, sets = options.subset.split("/")
         subset = int(subset)
         sets = int(sets)
-        total = len(suite.instances)
+        total = len(to_run)
         per_set = int(total / sets)
         num_extra_sets = total - (per_set * sets)
 
@@ -1164,8 +1170,13 @@ def main():
             start = ((subset - num_extra_sets - 1) * per_set) + base
             end = start + per_set
 
-        sliced_instances = islice(suite.instances.items(), start, end)
+        sliced_instances = islice(to_run.items(), start, end)
+        skipped = {k : v for k,v in suite.instances.items() if v.status == 'skipped'}
         suite.instances = OrderedDict(sliced_instances)
+        if subset == 1:
+            # add all pre-filtered tests that are skipped to the first set to
+            # allow for better distribution among all sets.
+            suite.instances.update(skipped)
 
     if options.save_tests:
         suite.csv_report(options.save_tests)


### PR DESCRIPTION
Do calculation based on what is actually going to be run and evaluated at
runtime, ignore the cases we already know going to be skipped.

This fixes an issue where some sets would get majority of skips and
basically run nothing beside filtering.

Few clang actions improvements.