### PR TITLE
cmake: gcc/clang: enable colour diagnostics in terminal output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ zephyr_compile_options($<TARGET_PROPERTY:compiler,no_common>)
 # @Intent: Set compiler specific flag for production of debug information
 zephyr_compile_options($<TARGET_PROPERTY:compiler,debug>)
 
-if($ENV{ZEPHYR_BUILD_COLOUR_DIAGNOSTIC})
+if(CONFIG_COMPILER_COLOR_DIAGNOSTICS)
 # @Intent: Set compiler specific flag for diagnostic messages
 zephyr_compile_options($<TARGET_PROPERTY:compiler,diagnostic>)
 endif()

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -235,6 +235,12 @@ config NO_OPTIMIZATIONS
 
 endchoice
 
+config COMPILER_COLOR_DIAGNOSTICS
+	bool "Enable colored diganostics"
+	default y
+	help
+	  Compiler diagnostic messages are colorized.
+
 config COMPILER_OPT
 	string "Custom compiler options"
 	help


### PR DESCRIPTION
This PR addresses issues raised in #25557

---
When compiler results are piped through a non-terminal (e.g. ninja)
the compiler disables colour diagnostics. Using `-fdiagnostics-color`
forces the compiler to enable colour output. This flag is always
enabled for clang and gcc.

Setting `CONFIG_COMPILER_COLOR_DIAGNOSTICS=n` disables this
feature and reverts to plain diagnostic messages with no formatting.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>