### PR TITLE
Move bsim tests to a dedicated action

### DIFF
--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -1,0 +1,85 @@
+name: Bluetooth Tests
+
+on:
+  pull_request_target:
+    paths:
+      - "west.yml"
+      - "subsys/bluetooth/**"
+      - "tests/bluetooth/bsim_bt/**"
+      - "boards/posix/**"
+      - "soc/posix/**"
+      - "arch/posix/**"
+
+jobs:
+  bsim-build-cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+  bsim-build:
+    runs-on: ubuntu-latest
+    needs: bsim-build-cancel
+    container:
+      image: zephyrprojectrtos/ci:v0.17.0-rc1
+      options: '--entrypoint /bin/bash'
+    env:
+      ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      CLANG_ROOT_DIR: /usr/lib/llvm-12
+      BSIM_OUT_PATH: /opt/bsim/
+      BSIM_COMPONENTS_PATH: /opt/bsim/components
+      EDTT_PATH: ../tools/edtt
+      bsim_bt_test_results_file: ./bsim_bt_out/bsim_results.xml
+    steps:
+      - name: Update PATH for west
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: west setup
+        run: |
+          west init -l . || true
+          west update
+
+      - name: Run Bluetooth Tests with BSIM
+        run: |
+          #source zephyr-env.sh
+          export ZEPHYR_BASE=${PWD}
+          WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
+          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_test_results_file} \
+          SEARCH_PATH=tests/bluetooth/bsim_bt/ tests/bluetooth/bsim_bt/run_parallel.sh
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Bluetooth Test Results
+          path: ./bsim_bt_out/bsim_results.xml
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: bsim-build
+    runs-on: ubuntu-20.04
+      # the build-and-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
+        with:
+          check_name: Bluetooth Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/bsim_results.xml"
+          omment_on_pr: false

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -21,14 +21,7 @@
 set -xe
 
 twister_options=" --inline-logs -N -v --integration"
-export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
-if [ ! -d "${BSIM_OUT_PATH}" ]; then
-        unset BSIM_OUT_PATH
-fi
-export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
-export EDTT_PATH="${EDTT_PATH:-../tools/edtt}"
 
-bsim_bt_test_results_file="./bsim_bt_out/bsim_results.xml"
 west_commands_results_file="./pytest_out/west_commands.xml"
 
 matrix_builds=1
@@ -44,7 +37,6 @@ function handle_coverage() {
 			--directory twister-out/native_posix/ \
 			--directory twister-out/nrf52_bsim/ \
 			--directory twister-out/unit_testing/ \
-			--directory bsim_bt_out/ \
 			--output-file lcov.pre.info -q --rc lcov_branch_coverage=1
 
 		# Remove noise
@@ -93,13 +85,6 @@ function on_complete() {
 	else
 		rm -rf twister-out out-2nd-pass
 	fi
-}
-
-function run_bsim_bt_tests() {
-	WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
-	RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_test_results_file} \
-	SEARCH_PATH=tests/bluetooth/bsim_bt/ \
-	tests/bluetooth/bsim_bt/run_parallel.sh
 }
 
 function get_tests_to_run() {
@@ -218,17 +203,6 @@ if [ -n "$main_ci" ]; then
 		SC="full"
 	fi
 	$short_git_log
-
-
-	if [ -n "${BSIM_OUT_PATH}" -a -d "${BSIM_OUT_PATH}" ]; then
-		echo "Build and run BT simulator tests"
-		# Run BLE tests in simulator on the 1st CI instance:
-		if [ "$matrix" = "1" ]; then
-			run_bsim_bt_tests
-		fi
-	else
-		echo "Skipping BT simulator tests"
-	fi
 
 	# cleanup
 	rm -f test_file.txt


### PR DESCRIPTION
Move BSIM testing to its own action.

This actions workflow:

https://github.com/zephyrproject-rtos/zephyr-testing/runs/2412359004?check_suite_focus=true

and the results:

https://github.com/zephyrproject-rtos/zephyr-testing/runs/2412447938?check_suite_focus=true


Signed-off-by: Anas Nashif <anas.nashif@intel.com>