### PR TITLE
drivers/interrupt_controller/intc_ite_it8xxx2: global ite_intc_isr_clear()

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -69,7 +69,7 @@ inline void set_csr(unsigned long bit)
 	}
 }
 
-static void ite_intc_isr_clear(unsigned int irq)
+void ite_intc_isr_clear(unsigned int irq)
 {
 	uint32_t g, i;
 	volatile uint8_t *isr;

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -77,6 +77,7 @@ extern uint8_t ite_intc_get_irq_num(void);
 extern int ite_intc_irq_is_enable(unsigned int irq);
 extern void ite_intc_irq_priority_set(unsigned int irq,
 			unsigned int prio, unsigned int flags);
+extern void ite_intc_isr_clear(unsigned int irq);
 #endif /* CONFIG_ITE_IT8XXX2_INTC */
 
 #endif /* !_ASMLANGUAGE */


### PR DESCRIPTION

We need to clear interrupt status, before we enable the interrupt.
So I let ite_intc_isr_clear() to be global function.

Signed-off-by: Ruibin Chang <ruibin.chang@ite.com.tw>