### PR TITLE
shell: openthread: increase shell stack when used with OpenThread

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -27,7 +27,8 @@ config SHELL_MINIMAL
 
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
-	default 2520 if OPENTHREAD_SHELL
+	default 3168 if OPENTHREAD_SHELL && OPENTHREAD_JOINER
+	default 2616 if OPENTHREAD_SHELL
 	default 2048 if MULTITHREADING
 	default 0 if !MULTITHREADING
 	help


### PR DESCRIPTION
This commit increases the shell stack sizes when used with
OpenThread shell and the joiner to compensate for enlarged
MPU stack guard.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>