### PR TITLE
net: dns: add 10ms delay when rescheduling query timeout handler

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1027,7 +1027,15 @@ static void query_timeout(struct k_work *work)
 	if (ret != 0) {
 		struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 
-		k_work_reschedule(dwork, K_NO_WAIT);
+		/*
+		 * Reschedule query timeout handler with some delay, so that all
+		 * threads (including those with lower priorities) have a chance
+		 * to move forward and release DNS context lock.
+		 *
+		 * Timeout value was arbitrarily chosen and can be updated in
+		 * future if needed.
+		 */
+		k_work_reschedule(dwork, K_MSEC(10));
 		return;
 	}
 


### PR DESCRIPTION
Query timeout handler is rescheduled if DNS context mutex is locked. So
far there was no timeout used, which means that work is simply put at
the end of system workqueue. This solves cases when mutex is locked by
any higher priority cooperative threads.

If however mutex was locked in application code within lower priority
thread (which is very likely) and query timeout has expired in the
meantime, then system workqueue is busy looping by calling query timeout
handler and trying to acquire DNS context lock.

Reschedule query timeout handler with 10ms delay, so that all
threads, including those with lower priorities, have a chance to move
forward and release DNS context lock.