### PR TITLE
Logging: Fix issues that leads to failures when compiling for C++

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -107,13 +107,7 @@ extern "C" {
  *  @param _addr Address of the element.
  */
 #define LOG_CONST_ID_GET(_addr) \
-	Z_LOG_EVAL(\
-	  CONFIG_LOG,\
-	  (__log_level ? \
-	  log_const_source_id((const struct log_source_const_data *)_addr) : \
-	  0),\
-	  (0)\
-	)
+	COND_CODE_1(CONFIG_LOG, ((__log_level ? log_const_source_id(_addr) : 0)), (0))
 
 /**
  * @def LOG_CURRENT_MODULE_ID
@@ -134,12 +128,7 @@ extern "C" {
  *  @param _addr Address of the element.
  */
 #define LOG_DYNAMIC_ID_GET(_addr) \
-	Z_LOG_EVAL(\
-	  CONFIG_LOG,\
-	  (__log_level ? \
-	  log_dynamic_source_id((struct log_source_dynamic_data *)_addr) : 0),\
-	  (0)\
-	)
+	COND_CODE_1(CONFIG_LOG, ((__log_level ? log_dynamic_source_id(_addr) : 0)), (0))
 
 /* Set of defines that are set to 1 if function name prefix is enabled for given level. */
 #define Z_LOG_FUNC_PREFIX_0U 0
@@ -215,10 +204,10 @@ extern "C" {
 	} \
 } while (false)
 
-#define Z_LOG_INTERNAL(is_user_context, _level, _source, ...) do { \
+#define Z_LOG_INTERNAL(is_user_context, _level, _source, _dsource, ...) do { \
 	uint16_t src_id = \
 		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
+		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source); \
 	struct log_msg_ids src_level = { \
 		.level = _level, \
 		.domain_id = CONFIG_LOG_DOMAIN_ID, \
@@ -303,7 +292,7 @@ static inline char z_log_minimal_level_to_char(int level)
 /*****************************************************************************/
 /****************** Macros for standard logging ******************************/
 /*****************************************************************************/
-#define Z_LOG2(_level, _source, ...) do { \
+#define Z_LOG2(_level, _source, _dsource, ...) do { \
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
 		break; \
 	} \
@@ -314,17 +303,20 @@ static inline char z_log_minimal_level_to_char(int level)
 	\
 	bool is_user_context = k_is_user_context(); \
 	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
+						(_dsource)->filters : 0;\
 	if (!LOG_CHECK_CTX_LVL_FILTER(is_user_context, _level, filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
 		int _mode; \
+		void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+			(void *)_dsource : (void *)_source; \
 		Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
-				  CONFIG_LOG_DOMAIN_ID, _source, _level, NULL,\
+				  CONFIG_LOG_DOMAIN_ID, _src, _level, NULL,\
 				  0, __VA_ARGS__); \
 	} else { \
-		Z_LOG_INTERNAL(is_user_context,	_level, _source, __VA_ARGS__);\
+		Z_LOG_INTERNAL(is_user_context,	_level, \
+				_source, _dsource, __VA_ARGS__);\
 	} \
 	if (false) { \
 		/* Arguments checker present but never evaluated.*/ \
@@ -335,27 +327,27 @@ static inline char z_log_minimal_level_to_char(int level)
 } while (false)
 
 #define Z_LOG(_level, ...) \
-	Z_LOG2(_level, \
-	      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	      (void *)__log_current_dynamic_data : \
-	      (void *)__log_current_const_data, \
-	      __VA_ARGS__)
+	Z_LOG2(_level, __log_current_const_data, __log_current_dynamic_data, __VA_ARGS__)
 
 #define Z_LOG_INSTANCE(_level, _inst, ...) \
-	Z_LOG2(_level, Z_LOG_INST(_inst), __VA_ARGS__)
-
+	Z_LOG2(_level, \
+		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
+		(struct log_source_dynamic_data *)COND_CODE_1( \
+						CONFIG_LOG_RUNTIME_FILTERING, \
+						(Z_LOG_INST(_inst)), (NULL)), \
+		__VA_ARGS__)
 
 /*****************************************************************************/
 /****************** Macros for hexdump logging *******************************/
 /*****************************************************************************/
-#define Z_LOG_HEXDUMP2(_level, _source, _data, _len, ...) do { \
+#define Z_LOG_HEXDUMP2(_level, _source, _dsource, _data, _len, ...) do { \
 	const char *_str = GET_ARG_N(1, __VA_ARGS__); \
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) {	\
 		break; \
 	} \
 	bool is_user_context = k_is_user_context(); \
 	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
+						(_dsource)->filters : 0;\
 	\
 	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, "%s", _str); \
@@ -368,8 +360,10 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
 		int mode; \
+		void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+			(void *)_dsource : (void *)_source; \
 		Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
-				  CONFIG_LOG_DOMAIN_ID, _source, _level, \
+				  CONFIG_LOG_DOMAIN_ID, _src, _level, \
 				  _data, _len, \
 				COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 					(), \
@@ -379,7 +373,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	uint16_t src_id = \
 		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
+		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source);\
 	struct log_msg_ids src_level = { \
 		.level = _level, \
 		.domain_id = CONFIG_LOG_DOMAIN_ID, \
@@ -396,13 +390,18 @@ static inline char z_log_minimal_level_to_char(int level)
 } while (false)
 
 #define Z_LOG_HEXDUMP(_level, _data, _length, ...) \
-	Z_LOG_HEXDUMP2(_level, IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		      (void *)__log_current_dynamic_data : \
-		      (void *)__log_current_const_data, \
+	Z_LOG_HEXDUMP2(_level, \
+		      __log_current_const_data, \
+		      __log_current_dynamic_data, \
 		      _data, _length, __VA_ARGS__)
 
 #define Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str) \
-	Z_LOG_HEXDUMP2(_level, Z_LOG_INST(_inst), _data, _length, _str)
+	Z_LOG_HEXDUMP2(_level, \
+		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
+		(struct log_source_dynamic_data *)COND_CODE_1( \
+						CONFIG_LOG_RUNTIME_FILTERING, \
+						(Z_LOG_INST(_inst)), (NULL)), \
+		_data, _length, _str)
 
 /*****************************************************************************/
 /****************** Filtering macros *****************************************/
@@ -798,12 +797,11 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 /******************************************************************************/
 #define Z_LOG_VA(_level, _str, _valist, _argnum, _strdup_action)\
 	__LOG_VA(_level, \
-		 IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		 (void *)__log_current_dynamic_data : \
-		 (void *)__log_current_const_data, \
+		 __log_current_const_data, \
+		 __log_current_dynamic_data, \
 		 _str, _valist, _argnum, _strdup_action)
 
-#define __LOG_VA(_level, _source, _str, _valist, _argnum, _strdup_action) do { \
+#define __LOG_VA(_level, _source, _dsource, _str, _valist, _argnum, _strdup_action) do { \
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
 		break; \
 	} \
@@ -814,7 +812,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 	\
 	bool is_user_context = k_is_user_context(); \
 	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
+						_dsource->filters : 0;\
 	if (!LOG_CHECK_CTX_LVL_FILTER(is_user_context, _level, filters)) { \
 		break; \
 	} \
@@ -825,7 +823,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 	} \
 	uint16_t _id = \
 		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
+		LOG_DYNAMIC_ID_GET(_dsource) : LOG_CONST_ID_GET(_source);\
 	struct log_msg_ids src_level = { \
 		.level = _level, \
 		.domain_id = CONFIG_LOG_DOMAIN_ID, \

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -186,13 +186,12 @@ enum z_log_msg2_mode {
 /* Messages are aligned to alignment required by cbprintf package. */
 #define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
 
-
 #if CONFIG_LOG2_USE_VLA
 #define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf[ceiling_fraction(len, sizeof(long long))]; \
 	long double _ld_buf[ceiling_fraction(len, sizeof(long double))]; \
 	ptr = (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) ? \
-			(void *)_ld_buf : (void *)_ll_buf; \
+			(struct log_msg2 *)_ld_buf : (struct log_msg2 *)_ll_buf; \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
 		memset(ptr, 0, len); \
@@ -215,15 +214,17 @@ enum z_log_msg2_mode {
 	long double _ld_buf128[128 / sizeof(long double)]; \
 	long double _ld_buf256[256 / sizeof(long double)]; \
 	if (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) { \
-		ptr = (len > 128) ? (void *)_ld_buf256 : \
-			((len > 64) ? (void *)_ld_buf128 : \
-			((len > 48) ? (void *)_ld_buf64 : \
-			((len > 32) ? (void *)_ld_buf48 : (void *)_ld_buf32)));\
+		ptr = (len > 128) ? (struct log_msg2 *)_ld_buf256 : \
+			((len > 64) ? (struct log_msg2 *)_ld_buf128 : \
+			((len > 48) ? (struct log_msg2 *)_ld_buf64 : \
+			((len > 32) ? (struct log_msg2 *)_ld_buf48 : \
+				      (struct log_msg2 *)_ld_buf32)));\
 	} else { \
-		ptr = (len > 128) ? (void *)_ll_buf256 : \
-			((len > 64) ? (void *)_ll_buf128 : \
-			((len > 48) ? (void *)_ll_buf64 : \
-			((len > 32) ? (void *)_ll_buf48 : (void *)_ll_buf32)));\
+		ptr = (len > 128) ? (struct log_msg2 *)_ll_buf256 : \
+			((len > 64) ? (struct log_msg2 *)_ll_buf128 : \
+			((len > 48) ? (struct log_msg2 *)_ll_buf64 : \
+			((len > 32) ? (struct log_msg2 *)_ll_buf48 : \
+				      (struct log_msg2 *)_ll_buf32)));\
 	} \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
@@ -254,7 +255,7 @@ enum z_log_msg2_mode {
 	} \
 	struct log_msg2_desc _desc = \
 		     Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, \
-			   _plen, _dlen); \
+			   (uint32_t)_plen, _dlen); \
 	z_log_msg2_finalize(_msg, _source, _desc, _data); \
 } while (0)
 
@@ -276,7 +277,7 @@ do { \
 	} \
 	struct log_msg2_desc _desc = \
 		Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, \
-					   _plen, _dlen); \
+					   (uint32_t)_plen, _dlen); \
 	LOG_MSG2_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
 	z_log_msg2_static_create((void *)_source, _desc, _msg->data, _data); \
@@ -289,7 +290,7 @@ do { \
 	size_t _msg_wlen = Z_LOG_MSG2_ALIGNED_WLEN(_plen, 0); \
 	struct log_msg2 *_msg = z_log_msg2_alloc(_msg_wlen); \
 	struct log_msg2_desc _desc = \
-		Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, _plen, 0); \
+		Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, (uint32_t)_plen, 0); \
 	LOG_MSG2_DBG("creating message zero copy: package len: %d, msg: %p\n", \
 			_plen, _msg); \
 	if (_msg) { \
@@ -437,11 +438,9 @@ do { \
 
 #define Z_LOG_MSG2_CREATE(_try_0cpy, _mode,  _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
-do { \
 	Z_LOG_MSG2_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
 			   _domain_id, _source, _level, _data, _dlen, \
-			   Z_LOG_STR(_level, __VA_ARGS__));\
-} while (0)
+			   Z_LOG_STR(_level, __VA_ARGS__))
 
 #define Z_TRACING_LOG_HDR_INIT(name, id) \
 	struct log_msg2_trace name = { \

--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -26,9 +26,9 @@ extern "C" {
  * - Clang 3.0 https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html
  */
 #ifndef Z_C_GENERIC
-#if ((__STDC_VERSION__ >= 201112L) || \
+#if !defined(__cplusplus) && (((__STDC_VERSION__ >= 201112L) || \
 	((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40900) || \
-	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30000))
+	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30000)))
 #define Z_C_GENERIC 1
 #else
 #define Z_C_GENERIC 0


### PR DESCRIPTION
Solving few casting issues in logging headers.

Limiting `_Generic` usage in cbprintf to C only.

I will work towards extending logging tests to validate C++ case.
Note, that for now logging v2 will work slower for C++ because `_Generic` cannot be used. This will also be fixed.

Fixes #34495.
Fixes #34527.