### PR TITLE
net: dns: add dns_resolve_reconfigure() API

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1492,9 +1492,8 @@ static void dns_work_cb(struct k_work *work)
 	/* set new DNS addr in DNS resolver */
 	LOG_DBG("Refresh DNS resolver");
 	dnsCtx = dns_resolve_get_default();
-	dns_resolve_close(dnsCtx);
 
-	ret = dns_resolve_init(dnsCtx, dns_servers_str, NULL);
+	ret = dns_resolve_reconfigure(dnsCtx, dns_servers_str, NULL);
 	if (ret < 0) {
 		LOG_ERR("dns_resolve_init fail (%d)", ret);
 		return;

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -302,17 +302,7 @@ static void esp_dns_work(struct k_work *work)
 	}
 
 	dnsctx = dns_resolve_get_default();
-	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
-		if (!dnsctx->queries[i].cb) {
-			continue;
-		}
-
-		dns_resolve_cancel(dnsctx, dnsctx->queries[i].id);
-	}
-
-	dns_resolve_close(dnsctx);
-
-	err = dns_resolve_init(dnsctx, NULL, dns_servers);
+	err = dns_resolve_reconfigure(dnsctx, NULL, dns_servers);
 	if (err) {
 		LOG_ERR("Could not set DNS servers: %d", err);
 	}

--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -157,6 +157,12 @@ typedef void (*dns_resolve_cb_t)(enum dns_resolve_status status,
 				 struct dns_addrinfo *info,
 				 void *user_data);
 
+enum dns_resolve_context_state {
+	DNS_RESOLVE_CONTEXT_ACTIVE,
+	DNS_RESOLVE_CONTEXT_DEACTIVATING,
+	DNS_RESOLVE_CONTEXT_INACTIVE,
+};
+
 /**
  * DNS resolve context structure.
  */
@@ -237,7 +243,7 @@ struct dns_resolve_context {
 	} queries[CONFIG_DNS_NUM_CONCUR_QUERIES];
 
 	/** Is this context in use */
-	bool is_used;
+	enum dns_resolve_context_state state;
 };
 
 /**
@@ -282,6 +288,29 @@ int dns_resolve_init(struct dns_resolve_context *ctx,
  * @return 0 if ok, <0 if error.
  */
 int dns_resolve_close(struct dns_resolve_context *ctx);
+
+/**
+ * @brief Reconfigure DNS resolving context.
+ *
+ * @details Reconfigures DNS context with new server list.
+ *
+ * @param ctx DNS context
+ * @param dns_servers_str DNS server addresses using textual strings. The
+ * array is NULL terminated. The port number can be given in the string.
+ * Syntax for the server addresses with or without port numbers:
+ *    IPv4        : 10.0.9.1
+ *    IPv4 + port : 10.0.9.1:5353
+ *    IPv6        : 2001:db8::22:42
+ *    IPv6 + port : [2001:db8::22:42]:5353
+ * @param dns_servers_sa DNS server addresses as struct sockaddr. The array
+ * is NULL terminated. Port numbers are optional in struct sockaddr, the
+ * default will be used if set to 0.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
+			    const char *servers_str[],
+			    const struct sockaddr *servers_sa[]);
 
 /**
  * @brief Cancel a pending DNS query.

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -736,7 +736,6 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 		}
 #if defined(CONFIG_DNS_RESOLVER)
 		case DHCPV4_OPTIONS_DNS_SERVER: {
-			int i;
 			struct dns_resolve_context *ctx;
 			struct sockaddr_in dns;
 			const struct sockaddr *dns_servers[] = {
@@ -764,17 +763,8 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			}
 
 			ctx = dns_resolve_get_default();
-			for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
-				if (!ctx->queries[i].cb) {
-					continue;
-				}
-
-				dns_resolve_cancel(ctx, ctx->queries[i].id);
-			}
-			dns_resolve_close(ctx);
-
 			dns.sin_family = AF_INET;
-			status = dns_resolve_init(ctx, NULL, dns_servers);
+			status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
 			if (status < 0) {
 				NET_DBG("options_dns, failed to set "
 					"resolve address: %d", status);

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -327,7 +327,7 @@ static void ipcp_set_dns_servers(struct ppp_fsm *fsm)
 		(struct sockaddr *) &dns2,
 		NULL
 	};
-	int i, ret;
+	int ret;
 
 	if (!dns1.sin_addr.s_addr) {
 		return;
@@ -338,16 +338,7 @@ static void ipcp_set_dns_servers(struct ppp_fsm *fsm)
 	}
 
 	dnsctx = dns_resolve_get_default();
-	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
-		if (!dnsctx->queries[i].cb) {
-			continue;
-		}
-
-		dns_resolve_cancel(dnsctx, dnsctx->queries[i].id);
-	}
-	dns_resolve_close(dnsctx);
-
-	ret = dns_resolve_init(dnsctx, NULL, dns_servers);
+	ret = dns_resolve_reconfigure(dnsctx, NULL, dns_servers);
 	if (ret < 0) {
 		NET_ERR("Could not set DNS servers");
 		return;

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -183,8 +183,10 @@ static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 	}
 }
 
-int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
-		     const struct sockaddr *servers_sa[])
+/* Must be invoked with context lock held */
+static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
+				   const char *servers[],
+				   const struct sockaddr *servers_sa[])
 {
 #if defined(CONFIG_NET_IPV6)
 	struct sockaddr_in6 local_addr6 = {
@@ -208,14 +210,10 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
 		return -ENOENT;
 	}
 
-	if (ctx->is_used) {
+	if (ctx->state != DNS_RESOLVE_CONTEXT_INACTIVE) {
 		ret = -ENOTEMPTY;
 		goto fail;
 	}
-
-	(void)memset(ctx, 0, sizeof(*ctx));
-
-	(void)k_mutex_init(&ctx->lock);
 
 	if (servers) {
 		for (i = 0; idx < SERVER_COUNT && servers[i]; i++) {
@@ -331,12 +329,30 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
 		goto fail;
 	}
 
-	ctx->is_used = true;
+	ctx->state = DNS_RESOLVE_CONTEXT_ACTIVE;
 	ctx->buf_timeout = DNS_BUF_TIMEOUT;
 	ret = 0;
 
 fail:
 	return ret;
+}
+
+int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
+		     const struct sockaddr *servers_sa[])
+{
+	if (!ctx) {
+		return -ENOENT;
+	}
+
+	(void)memset(ctx, 0, sizeof(*ctx));
+
+	(void)k_mutex_init(&ctx->lock);
+	ctx->state = DNS_RESOLVE_CONTEXT_INACTIVE;
+
+	/* As this function is called only once during system init, there is no
+	 * reason to acquire lock.
+	 */
+	return dns_resolve_init_locked(ctx, servers, servers_sa);
 }
 
 /* Check whether a slot is available for use, or optionally whether it can be
@@ -767,6 +783,10 @@ static void cb_recv(struct net_context *net_ctx,
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 
+	if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
+		goto unlock;
+	}
+
 	if (status) {
 		ret = DNS_EAI_SYSTEM;
 		goto quit;
@@ -845,6 +865,7 @@ free_buf:
 		net_buf_unref(dns_cname);
 	}
 
+unlock:
 	k_mutex_unlock(&ctx->lock);
 }
 
@@ -925,31 +946,57 @@ static int dns_write(struct dns_resolve_context *ctx,
 	return 0;
 }
 
+/* Must be invoked with context lock held */
+static void dns_resolve_cancel_slot(struct dns_resolve_context *ctx, int slot)
+{
+	invoke_query_callback(DNS_EAI_CANCELED, NULL, &ctx->queries[slot]);
+
+	release_query(&ctx->queries[slot]);
+}
+
+/* Must be invoked with context lock held */
+static void dns_resolve_cancel_all(struct dns_resolve_context *ctx)
+{
+	int i;
+
+	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
+		if (ctx->queries[i].cb && ctx->queries[i].query) {
+			dns_resolve_cancel_slot(ctx, i);
+		}
+	}
+}
+
 static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 					uint16_t dns_id,
 					uint16_t query_hash,
 					const char *query_name)
 {
-	int ret;
+	int ret = 0;
 	int i;
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 
+	if (ctx->state == DNS_RESOLVE_CONTEXT_DEACTIVATING) {
+		/*
+		 * Cancel is part of context "deactivating" process, so no need
+		 * to do anything more.
+		 */
+		goto unlock;
+	}
+
 	i = get_slot_by_id(ctx, dns_id, query_hash);
 	if (i < 0) {
 		ret = -ENOENT;
-		goto fail;
+		goto unlock;
 	}
 
 	NET_DBG("Cancelling DNS req %u (name %s type %d hash %u)", dns_id,
 		log_strdup(query_name), ctx->queries[i].query_type,
 		query_hash);
 
-	invoke_query_callback(DNS_EAI_CANCELED, NULL, &ctx->queries[i]);
+	dns_resolve_cancel_slot(ctx, i);
 
-	release_query(&ctx->queries[i]);
-
-fail:
+unlock:
 	k_mutex_unlock(&ctx->lock);
 
 	return 0;
@@ -1134,7 +1181,7 @@ int dns_resolve_name(struct dns_resolve_context *ctx,
 try_resolve:
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 
-	if (!ctx->is_used) {
+	if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
 		ret = -EINVAL;
 		goto fail;
 	}
@@ -1279,9 +1326,22 @@ static int dns_resolve_close_locked(struct dns_resolve_context *ctx)
 {
 	int i;
 
-	if (!ctx->is_used) {
+	if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
 		return -ENOENT;
 	}
+
+	ctx->state = DNS_RESOLVE_CONTEXT_DEACTIVATING;
+
+	/* ctx->net_ctx is never used in "deactivating" state. Additionally
+	 * following code is guaranteed to be executed only by one thread at a
+	 * time, due to required "active" -> "deactivating" state change. This
+	 * means that it is safe to put net_ctx with mutex released.
+	 *
+	 * Released mutex will prevent lower networking layers from deadlock
+	 * when calling cb_recv() (which acquires ctx->lock) just before closing
+	 * network context.
+	 */
+	k_mutex_unlock(&ctx->lock);
 
 	for (i = 0; i < SERVER_COUNT; i++) {
 		if (ctx->servers[i].net_ctx) {
@@ -1301,10 +1361,13 @@ static int dns_resolve_close_locked(struct dns_resolve_context *ctx)
 			}
 
 			net_context_put(ctx->servers[i].net_ctx);
+			ctx->servers[i].net_ctx = NULL;
 		}
 	}
 
-	ctx->is_used = false;
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+
+	ctx->state = DNS_RESOLVE_CONTEXT_INACTIVE;
 
 	return 0;
 }
@@ -1318,6 +1381,40 @@ int dns_resolve_close(struct dns_resolve_context *ctx)
 	k_mutex_unlock(&ctx->lock);
 
 	return ret;
+}
+
+int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
+			    const char *servers[],
+			    const struct sockaddr *servers_sa[])
+{
+	int err;
+
+	if (!ctx) {
+		return -ENOENT;
+	}
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+
+	if (ctx->state == DNS_RESOLVE_CONTEXT_DEACTIVATING) {
+		err = -EBUSY;
+		goto unlock;
+	}
+
+	if (ctx->state == DNS_RESOLVE_CONTEXT_ACTIVE) {
+		dns_resolve_cancel_all(ctx);
+
+		err = dns_resolve_close_locked(ctx);
+		if (err) {
+			goto unlock;
+		}
+	}
+
+	err = dns_resolve_init_locked(ctx, servers, servers_sa);
+
+unlock:
+	k_mutex_unlock(&ctx->lock);
+
+	return err;
 }
 
 struct dns_resolve_context *dns_resolve_get_default(void)

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -322,9 +322,11 @@ static void test_dns_add_remove_two_callback6(void)
 			     "Timeout while waiting for DNS added callback");
 	}
 
-	/* Check both DNS servers are used */
-	zassert_true(resv_ipv6.is_used, "DNS server #1 is missing");
-	zassert_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
+	/* Check both DNS servers are active */
+	zassert_equal(resv_ipv6.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #1 is missing");
+	zassert_equal(resv_ipv6_2.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #2 is missing");
 
 	/* Remove first DNS server */
 	dnsCtx = &resv_ipv6;
@@ -338,9 +340,11 @@ static void test_dns_add_remove_two_callback6(void)
 			"Received DNS removed callback when should not have");
 	}
 
-	/* Check second DNS servers is used */
-	zassert_false(resv_ipv6.is_used, "DNS server #1 is active");
-	zassert_true(resv_ipv6_2.is_used, "DNS server #2 is missing");
+	/* Check second DNS server is active */
+	zassert_equal(resv_ipv6.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #1 is active");
+	zassert_equal(resv_ipv6_2.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #2 is missing");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
@@ -362,8 +366,10 @@ static void test_dns_add_remove_two_callback6(void)
 	}
 
 	/* Check neither DNS server is used */
-	zassert_false(resv_ipv6.is_used, "DNS server #1 isa ctive");
-	zassert_false(resv_ipv6_2.is_used, "DNS server #2 is active");
+	zassert_equal(resv_ipv6.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #1 is active");
+	zassert_equal(resv_ipv6_2.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #2 is active");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
@@ -490,8 +496,10 @@ static void test_dns_add_remove_two_callback(void)
 	}
 
 	/* Check both DNS servers are used */
-	zassert_true(resv_ipv4.is_used, "DNS server #1 is missing");
-	zassert_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
+	zassert_equal(resv_ipv4.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #1 is missing");
+	zassert_equal(resv_ipv4_2.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #2 is missing");
 
 	/* Remove first DNS server */
 	dnsCtx = &resv_ipv4;
@@ -506,8 +514,10 @@ static void test_dns_add_remove_two_callback(void)
 	}
 
 	/* Check second DNS servers is used */
-	zassert_false(resv_ipv4.is_used, "DNS server #1 is active");
-	zassert_true(resv_ipv4_2.is_used, "DNS server #2 is missing");
+	zassert_equal(resv_ipv4.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #1 is active");
+	zassert_equal(resv_ipv4_2.state, DNS_RESOLVE_CONTEXT_ACTIVE,
+		      "DNS server #2 is missing");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);
@@ -529,8 +539,10 @@ static void test_dns_add_remove_two_callback(void)
 	}
 
 	/* Check neither DNS server is used */
-	zassert_false(resv_ipv4.is_used, "DNS server #1 isa ctive");
-	zassert_false(resv_ipv4_2.is_used, "DNS server #2 is active");
+	zassert_equal(resv_ipv4.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #1 is active");
+	zassert_equal(resv_ipv4_2.state, DNS_RESOLVE_CONTEXT_INACTIVE,
+		      "DNS server #2 is active");
 
 	/* Check first DNS server cannot be removed once removed */
 	ret = dns_resolve_close(dnsCtx);

--- a/tests/net/lib/dns_packet/src/main.c
+++ b/tests/net/lib/dns_packet/src/main.c
@@ -1063,7 +1063,7 @@ static void setup_dns_context(struct dns_resolve_context *ctx,
 	ctx->queries[idx].query = query;
 	ctx->queries[idx].query_type = query_type;
 	ctx->queries[idx].query_hash = crc16_ansi(query, query_len);
-	ctx->is_used = true;
+	ctx->state = DNS_RESOLVE_CONTEXT_ACTIVE;
 
 }
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -347,7 +347,7 @@ static void test_dns_query_server_count(void)
 	int i, count = 0;
 
 	for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
-		if (!ctx->is_used) {
+		if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
 			continue;
 		}
 
@@ -368,7 +368,7 @@ static void test_dns_query_ipv4_server_count(void)
 	int i, count = 0, port = 0;
 
 	for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
-		if (!ctx->is_used) {
+		if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
 			continue;
 		}
 
@@ -398,7 +398,7 @@ static void test_dns_query_ipv6_server_count(void)
 	int i, count = 0, port = 0;
 
 	for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
-		if (!ctx->is_used) {
+		if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {
 			continue;
 		}
 


### PR DESCRIPTION
So far there was no dedicated mechanism for replacing DNS servers with
new list. Add dns_resolve_reconfigure() API that allows to achieve that
in a thread-safe manner.

Update all components that reconfigured DNS server list (like DHCPv4,
PPP, ESP-AT WiFi and hl7800 modem) to use that API.