### PR TITLE
usb: dfu: convert z_timeout_end_calc to sys_clock_timeout_end_calc

### DIFF
--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -827,7 +827,7 @@ static bool is_dfu_started(void)
  */
 void wait_for_usb_dfu(k_timeout_t delay)
 {
-	uint64_t end = z_timeout_end_calc(delay);
+	uint64_t end = sys_clock_timeout_end_calc(delay);
 
 	/* Wait for a prescribed duration of time. If DFU hasn't started within
 	 * that time, stop waiting and proceed further.


### PR DESCRIPTION
The z_timeout_end_calc function was replaced by
sys_clock_timeout_end_calc in #33302. A reference to the old function
snuck into master through #30015.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>