### PR TITLE
wifi: esp32: allow wifi symbols into flash

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -225,4 +225,20 @@ config ESP32_WIFI_SW_COEXIST_ENABLE
 	help
 	  Software controls WiFi/Bluetooth coexistence. Not supported yet.
 
+config ESP32_WIFI_IRAM_OPT
+	bool "WiFi IRAM speed optimization"
+	default y
+	help
+	  Select this option to place frequently called Wi-Fi library functions in IRAM.
+	  When this option is disabled, more than 10Kbytes of IRAM memory will be saved
+	  but Wi-Fi throughput will be reduced.
+
+config ESP32_WIFI_RX_IRAM_OPT
+	bool "WiFi RX IRAM speed optimization"
+	default y
+	help
+	  Select this option to place frequently called Wi-Fi library RX functions in IRAM.
+	  When this option is disabled, more than 17Kbytes of IRAM memory will be saved
+	  but Wi-Fi performance will be reduced.
+
 endif # WIFI_ESP32

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -398,10 +398,17 @@ __shell_root_cmds_end = __esp_shell_root_cmds_end;
     *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
+
+#if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.*)
+#endif
+
+#if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
     *libnet80211.a:( .wifirxiram  .wifirxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.*)
+#endif
+
     _iram_text_end = ABSOLUTE(.);
   } GROUP_LINK_IN(IRAM_REGION)
 
@@ -409,6 +416,16 @@ __shell_root_cmds_end = __esp_shell_root_cmds_end;
   {
     _stext = .;
     _text_start = ABSOLUTE(.);
+
+#if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
+    *libnet80211.a:( .wifi0iram  .wifi0iram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.*)
+#endif
+
+#if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
+    *libnet80211.a:( .wifirxiram  .wifirxiram.*)
+    *libpp.a:( .wifirxiram  .wifirxiram.*)
+#endif
 
     *(.literal .text .literal.* .text.*)
     _text_end = ABSOLUTE(.);


### PR DESCRIPTION
When BT and WiFi coexists, IRAM usage increases a lot.
Add configuration that allow wifi symbols
to be placed in flash, freeing space in IRAM.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>