### PR TITLE
lib: c_lib: add a check logic to verify overflow in fwrite

### DIFF
--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -65,6 +65,10 @@ size_t z_impl_zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 		return 0;
 	}
 
+	if ((strlen(ptr) + 1) < (size * nitems)) {
+		return 0;
+	}
+
 	p = ptr;
 	i = nitems;
 	do {

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -914,7 +914,7 @@ void test_fwrite(void)
 	zassert_equal(ret, 0, "fwrite failed!");
 
 	ret = fwrite("This 3", 4, 4, stdout);
-	zassert_not_equal(ret, 0, "fwrite failed!");
+	zassert_equal(ret, 0, "fwrite failed!");
 
 	ret = fwrite("This 3", 4, 4, stdin);
 	zassert_equal(ret, 0, "fwrite failed!");


### PR DESCRIPTION
Add a simple logic to validate parameters of fwrite(). If the result
of size times nitems greater than the string length, return zero.

Fixes #33491.

Here is root cause of the issue:
When we call "fwrite("This 3", -1, 1, stdout) or fwrite("This 3", 1, -1, stdout), the size_t -1 means 4294967295, so actually parameter is:
```
Breakpoint 2, fwrite (ptr=0x1130a1, size=4294967295, nitems=1, stream=0x2) at 
lib/libc/minimal/source/stdout/stdout_console.c:102
102             return zephyr_fwrite(ptr, size, nitems, stream);
```
And this incorrect size cannot be detected by either userspace z_vrfy_zephyr_fwrite()'s
```
Z_OOPS(Z_SYSCALL_MEMORY_ARRAY_READ(ptr, nitems, size));
```
or z_impl_zephyr_fwrite() itself, so the fwrite() still works, and overflow happens.


So, I think one possible solution is Z_SYSCALL_MEMORY_ARRAY_READ(ptr, nitems, size)) should be refined to detect this.
But this only works for user mode.

My solution is simply to check "the size * nitems cannot greater than string length" in z_impl_zephyr_fwrite().
One advantage of doing this is both kernel mode and user mode can detect this error.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>