### PR TITLE
JLink: Support JLink V7 Version String

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -151,7 +151,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     def supports_nogui(self):
         ver = self.read_version()
         # -nogui was introduced in J-Link Commander v6.80
-        return version.parse(ver) >= version.parse("6.80")
+        return version.LegacyVersion(ver) >= version.LegacyVersion("6.80")
 
     def do_run(self, command, **kwargs):
         if MISSING_REQUIREMENTS:


### PR DESCRIPTION
JLink V7.0a does not conform to the PEP440 version conventions and
therefore is parsed to a legacy type by the packaging library which
always is treated as a lower value when compared with a conforming
version string.  Just use the legacy version type for both to ensure
consistency.

Signed-off-by: Jake Mercer <jake.mercer@civica.co.uk>