### PR TITLE
dtlib: add static type checking with mypy

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -708,7 +708,7 @@ class DT:
           relative to the .dts file that contains the /include/ or /incbin/.
         """
         self.filename = filename
-        self._include_path = include_path
+        self._include_path = list(include_path)
 
         with open(filename, encoding="utf-8") as f:
             self._file_contents = f.read()

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import textwrap
+from typing import NoReturn
 
 # NOTE: tests/test_dtlib.py is the test suite for this library.
 
@@ -1820,7 +1821,7 @@ def _root_and_path_to_node(cur, path, fullpath):
 
     return cur
 
-def _err(msg):
+def _err(msg) -> NoReturn:
     raise DTError(msg)
 
 _escape_table = str.maketrans({

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -1784,7 +1784,8 @@ class DT:
 # Public functions
 #
 
-def to_num(data, length=None, signed=False):
+def to_num(data: bytes, length: Optional[int] = None,
+           signed: bool = False) -> int:
     """
     Converts the 'bytes' array 'data' to a number. The value is expected to be
     in big-endian format, which is standard in devicetree.
@@ -1800,12 +1801,12 @@ def to_num(data, length=None, signed=False):
     if length is not None:
         _check_length_positive(length)
         if len(data) != length:
-            _err("{} is {} bytes long, expected {}"
+            _err("{!r} is {} bytes long, expected {}"
                  .format(data, len(data), length))
 
     return int.from_bytes(data, "big", signed=signed)
 
-def to_nums(data, length=4, signed=False):
+def to_nums(data: bytes, length: int = 4, signed: bool = False) -> List[int]:
     """
     Like Property.to_nums(), but takes an arbitrary 'bytes' array. The values
     are assumed to be in big-endian format, which is standard in devicetree.
@@ -1814,7 +1815,7 @@ def to_nums(data, length=4, signed=False):
     _check_length_positive(length)
 
     if len(data) % length:
-        _err("{} is {} bytes long, expected a length that's a a multiple of {}"
+        _err("{!r} is {} bytes long, expected a length that's a a multiple of {}"
              .format(data, len(data), length))
 
     return [int.from_bytes(data[i:i + length], "big", signed=signed)

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -23,7 +23,7 @@ import os
 import re
 import sys
 import textwrap
-from typing import NoReturn
+from typing import Dict, Iterable, List, NoReturn, Optional
 
 # NOTE: tests/test_dtlib.py is the test suite for this library.
 
@@ -49,7 +49,7 @@ class Node:
     props:
       A collections.OrderedDict that maps the properties defined on the node to
       their values. 'props' is indexed by property name (a string), and values
-      are represented as 'bytes' arrays.
+      are Property objects.
 
       To convert property values to Python numbers or strings, use
       dtlib.to_num(), dtlib.to_nums(), or dtlib.to_string().
@@ -87,7 +87,7 @@ class Node:
     # Public interface
     #
 
-    def __init__(self, name, parent, dt):
+    def __init__(self, name: str, parent: Optional['Node'], dt: 'DT'):
         """
         Node constructor. Not meant to be called directly by clients.
         """
@@ -95,21 +95,21 @@ class Node:
         self.parent = parent
         self.dt = dt
 
-        self.props = collections.OrderedDict()
-        self.nodes = collections.OrderedDict()
-        self.labels = []
+        self.props: Dict[str, 'Property'] = collections.OrderedDict()
+        self.nodes: Dict[str, 'Node'] = collections.OrderedDict()
+        self.labels: List[str] = []
         self._omit_if_no_ref = False
         self._is_referenced = False
 
     @property
-    def unit_addr(self):
+    def unit_addr(self) -> str:
         """
         See the class documentation.
         """
         return self.name.partition("@")[2]
 
     @property
-    def path(self):
+    def path(self) -> str:
         """
         See the class documentation.
         """
@@ -122,7 +122,7 @@ class Node:
 
         return "/" + "/".join(reversed(node_names))
 
-    def node_iter(self):
+    def node_iter(self) -> Iterable['Node']:
         """
         Returns a generator for iterating over the node and its children,
         recursively.
@@ -137,7 +137,7 @@ class Node:
         for node in self.nodes.values():
             yield from node.node_iter()
 
-    def _get_prop(self, name):
+    def _get_prop(self, name: str) -> 'Property':
         # Returns the property named 'name' on the node, creating it if it
         # doesn't already exist
 
@@ -147,10 +147,9 @@ class Node:
             self.props[name] = prop
         return prop
 
-    def _del(self):
+    def _del(self) -> None:
         # Removes the node from the tree
-
-        self.parent.nodes.pop(self.name)
+        self.parent.nodes.pop(self.name)  # type: ignore
 
     def __str__(self):
         """

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Nordic Semiconductor
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Tip: You can view just the documentation with 'pydoc3 dtlib'
+# Tip: You can view just the documentation with 'pydoc3 devicetree.dtlib'
 
 # _init_tokens() builds names dynamically.
 #
@@ -24,7 +24,7 @@ import re
 import sys
 import textwrap
 
-# NOTE: testdtlib.py is the test suite for this library.
+# NOTE: tests/test_dtlib.py is the test suite for this library.
 
 class DT:
     """

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -79,7 +79,7 @@ try:
     # This makes e.g. gen_defines.py more than twice as fast.
     from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader
+    from yaml import Loader     # type: ignore
 
 from devicetree.dtlib import DT, DTError, to_num, to_nums, Type
 from devicetree.grutils import Graph

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Tip: You can view just the documentation with 'pydoc3 edtlib'
+# Tip: You can view just the documentation with 'pydoc3 devicetree.edtlib'
 
 """
 Library for working with devicetrees at a higher level compared to dtlib. Like
@@ -25,7 +25,7 @@ See their constructor docstrings for details. There is also a
 bindings_from_paths() helper function.
 """
 
-# NOTE: testedtlib.py is the test suite for this library.
+# NOTE: tests/test_edtlib.py is the test suite for this library.
 
 # Implementation notes
 # --------------------

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -2077,7 +2077,7 @@ foo: / {
 def test_reprs():
     '''Test the __repr__() functions.'''
 
-    dt = parse("""
+    dts = """
 /dts-v1/;
 
 / {
@@ -2086,15 +2086,21 @@ def test_reprs():
 		y = < 1 >;
 	};
 };
-""",
-    include_path=("foo", "bar"))
+"""
 
-    assert re.fullmatch(r"DT\(filename='.*', include_path=\('foo', 'bar'\)\)",
+    dt = parse(dts, include_path=("foo", "bar"))
+
+    assert re.fullmatch(r"DT\(filename='.*', include_path=.'foo', 'bar'.\)",
                         repr(dt))
     assert re.fullmatch("<Property 'x' at '/' in '.*'>",
                         repr(dt.root.props["x"]))
     assert re.fullmatch("<Node /sub in '.*'>",
                         repr(dt.root.nodes["sub"]))
+
+    dt = parse(dts, include_path=iter(("foo", "bar")))
+
+    assert re.fullmatch(r"DT\(filename='.*', include_path=.'foo', 'bar'.\)",
+                        repr(dt))
 
 def test_names():
     '''Tests for node/property names.'''

--- a/scripts/dts/python-devicetree/tox.ini
+++ b/scripts/dts/python-devicetree/tox.ini
@@ -5,7 +5,14 @@ envlist=py3
 deps =
     setuptools-scm
     pytest
+    mypy
 setenv =
     TOXTEMPDIR={envtmpdir}
 commands =
   python -m pytest {posargs:tests}
+  python -m mypy --config-file={toxinidir}/tox.ini --package=devicetree
+
+[mypy]
+mypy_path=src
+ignore_missing_imports=True
+


### PR DESCRIPTION
Extend the steps taken in tox.ini by type checking the 'devicetree' package. This will make it easier for callers that use the low level DT module's public APIs, since they can rely on the type checker a bit more.

This will hopefully help avoid bugs in future changes to this module by doing a bit more static analysis in addition to running the existing tests.

Before we can do this, we need to add type annotations to the dtlib module itself, which requires some refactoring.