### PR TITLE
net: ip: net_shell: Wrap iface_flags2str in #ifdef to silence warning

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -287,6 +287,7 @@ static void print_supported_ethernet_capabilities(
 }
 #endif /* CONFIG_NET_L2_ETHERNET */
 
+#if defined(CONFIG_NET_NATIVE)
 static const char *iface_flags2str(struct net_if *iface)
 {
 	static char str[sizeof("POINTOPOINT") + sizeof("PROMISC") +
@@ -333,6 +334,7 @@ static const char *iface_flags2str(struct net_if *iface)
 
 	return str;
 }
+#endif
 
 static void iface_cb(struct net_if *iface, void *user_data)
 {


### PR DESCRIPTION
The net_shell only uses iface_flags2str when CONFIG_NET_NATIVE is
enabled. Disabling this produces an "unused function" warning for this
function. Wrap the function in an #ifdef to silence the warning for this
configuration.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>