### PR TITLE
doc: make some dependency version specifiers more flexible

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 breathe~=4.23,!=4.29.0
-sphinx>=3.3.0,<3.4.0
+sphinx~=3.3
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-breathe>=4.23.0,<4.29.0
+breathe~=4.23,!=4.29.0
 sphinx>=3.3.0,<3.4.0
 sphinx_rtd_theme>=0.5.2,<1.0
 sphinx-tabs


### PR DESCRIPTION
- Breathe project has released version 4.29.1, a fix release for the issues found in 4.29.0. Relax version requirements by just skipping the buggy version and staying to compatible releases.
- Sphinx: allow all compatible versions starting from 3.3, that is >=3.3.0,<4.0.