### PR TITLE
usb: increase default serial number to 96 bits on STM32

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -44,6 +44,7 @@ config USB_DEVICE_PRODUCT
 
 config USB_DEVICE_SN
 	string "USB device Serial Number String"
+	default "0123456789ABCDEF01234567" if HWINFO_STM32
 	default "0123456789ABCDEF"
 	help
 	  Placeholder for USB device Serial Number String.


### PR DESCRIPTION
The STM32 Unique device ID is a 96-bit number based to lot number, the
wafer number and the X and Y coordinates on the wafer. The default USB
serial number is currently 64 bits long, which doesn't include the X and
Y coordinates on the wafer.

In practice it means that I have 2 Zephyr based devices with the same
USB serial number on my desk.

Fix that by defaulting to a 96-bit long USB serial number on STM32
devices.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>