### PR TITLE
init: tweak Zephyr .init* section name to avoid name conflict with toolchain's library section

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -1040,7 +1040,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)"_"))) = { \
+	__attribute__((__section__(".z_device_" #level STRINGIFY(prio)"_"))) = { \
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\

--- a/include/init.h
+++ b/include/init.h
@@ -85,7 +85,7 @@ void z_sys_init_run_level(int32_t level);
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
 		_CONCAT(__init_, _entry_name) __used			\
-	__attribute__((__section__(".init_" #_level STRINGIFY(_prio)"_"))) = { \
+	__attribute__((__section__(".z_init_" #_level STRINGIFY(_prio)"_"))) = { \
 		.init = (_init_fn),					\
 		.dev = (_device),					\
 	}

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -30,10 +30,10 @@
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 
-	/* verify we don't have rogue .init_<something> initlevel sections */
+	/* verify we don't have rogue .z_init_<something> initlevel sections */
 	SECTION_PROLOGUE(initlevel_error,,)
 	{
-		KEEP(*(SORT(.init_[_A-Z0-9]*)))
+		KEEP(*(SORT(.z_init_[_A-Z0-9]*)))
 	}
 	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -116,8 +116,8 @@
  */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.object##_##level[0-9]_*)));		\
-		KEEP(*(SORT(.object##_##level[1-9][0-9]_*)));
+		KEEP(*(SORT(.z_##object##_##level[0-9]_*)));		\
+		KEEP(*(SORT(.z_##object##_##level[1-9][0-9]_*)));
 
 /*
  * link in shell initialization objects for all modules that use shell and


### PR DESCRIPTION
In case of ARC MWDT toolchain and C++ support enabled the Zephyr .init* section conflicts with .init* sections derived from toolchain libs.

Let's add `z_` prefix to Zephyr .init* section (and therefore .device section as they share the same macros) to make Zephyr section name unique.