### PR TITLE
Fix failing logging.log_benchmark_v2 test when CONFIG_LOG_PRINTK=y

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -142,6 +142,7 @@ extern "C" {
 	)
 
 /* Set of defines that are set to 1 if function name prefix is enabled for given level. */
+#define Z_LOG_FUNC_PREFIX_0U 0
 #define Z_LOG_FUNC_PREFIX_1U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_ERR, (1), (0))
 #define Z_LOG_FUNC_PREFIX_2U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_WRN, (1), (0))
 #define Z_LOG_FUNC_PREFIX_3U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_INF, (1), (0))

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -438,7 +438,7 @@ do { \
 #define Z_LOG_MSG2_CREATE(_try_0cpy, _mode,  _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do { \
-	Z_LOG_MSG2_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_##_level), \
+	Z_LOG_MSG2_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
 			   _domain_id, _source, _level, _data, _dlen, \
 			   Z_LOG_STR(_level, __VA_ARGS__));\
 } while (0)


### PR DESCRIPTION
Fixing failing test.

Fixes #34526.
Fixes #34558.