### PR TITLE
drivers: flash: at45: Add Reset and WP pins

### DIFF
--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -62,3 +62,19 @@ properties:
       Time, in nanoseconds, needed by the chip to exit from the Deep Power-Down
       mode (or Ultra-Deep Power-Down mode when the "use-udpd" property is set)
       after the corresponding command is issued.
+
+  reset-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      The RESET pin of AT45 is active low.
+      If connected directly the MCU pin should be configured
+      as active low.
+
+  wp-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      The WP pin of AT45 is active low.
+      If connected directly the MCU pin should be configured
+      as active low.


### PR DESCRIPTION
Adding Reset and Write-protect pins initialization during AT45 driver
start-up. Usually, these pins are driven high when not used.
The AT45 device incorporates an internal power-on reset circuit, so
there is no initial on-off reset sequence.

This PR should replace my earlier PR with only Reset pin control
https://github.com/zephyrproject-rtos/zephyr/pull/32417

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>