### PR TITLE
arm64: Load MPID for secondary cores using BOOT_PARAM_MPID_OFFSET exp…

### DIFF
--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -115,7 +115,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 	/* loop until our turn comes */
 1:	dmb	ld
-	ldr	x2, [x0]
+	ldr	x2, [x0, #BOOT_PARAM_MPID_OFFSET]
 	cmp	x1, x2
 	bne	1b
 


### PR DESCRIPTION
…licitly

Currently the code load MPID for secondary cores from offset 0x0 of
struct arm64_cpu_boot_params, it works as currently the macro
BOOT_PARAM_MPID_OFFSET has value 0x0, but the location change of
the member "mpid" can result in SMP booting failure and the build
assert won't throw out any warning.

Signed-off-by: Hou Zhiqiang <Zhiqiang.Hou@nxp.com>