### PR TITLE
soc: nordic_nrf: move NFCT_PINS_AS_GPIOS to common nRF definitions

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -38,4 +38,18 @@ config NRF_ACL_FLASH_REGION_SIZE
 	help
 	  FLASH region size for the NRF_ACL peripheral.
 
+config NFCT_PINS_AS_GPIOS
+	bool "NFCT pins as GPIOs"
+	depends on HAS_HW_NRF_NFCT
+	help
+	  Two pins are usually reserved for NFC in SoCs that implement the
+	  NFCT peripheral. This option switches them to normal GPIO mode.
+	  HW enabling happens once in the device lifetime, during the first
+	  system startup. Disabling this option will not switch back these
+	  pins to NFCT mode. Doing this requires UICR erase prior to
+	  flashing device using the image which has this option disabled.
+
+	  NFC pins in nRF52 series: P0.09 and P0.10
+	  NFC pins in nRF5340: P0.02 and P0.03
+
 endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -460,17 +460,6 @@ config SOC_DCDC_NRF52X
 	help
 	  Enable nRF52 series System on Chip DC/DC converter.
 
-config NFCT_PINS_AS_GPIOS
-	bool "NFCT pins as GPIOs"
-	depends on HAS_HW_NRF_NFCT
-	help
-	  P0.9 and P0.10 are usually reserved for NFC. This option switch
-	  them to normal GPIO mode. HW enabling happens once in the device
-	  lifetime, during the first system startup. Disabling this option will
-	  not switch back these pins to NFCT mode. Doing this requires UICR
-	  erase prior to flashing device using the image which has
-	  this option disabled.
-
 config GPIO_AS_PINRESET
 	bool "GPIO as pin reset (reset button)"
 	depends on SOC_SERIES_NRF52X


### PR DESCRIPTION
Kconfig symbol NFCT_PINS_AS_GPIOS may be defined for all
Nordic nRF SoCs that have the NFCT hardware, so we move
the option definition in nRF common Kconfig.soc file. We
also correct the help text to reflect that nRF52-based
DKs and nRF5340 DK have different pins for NFC.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #32485
