### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       revision: 5f004461f9ad4041080a1975f58b043aa3031b65
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 9f09bae7c0ad7df5e0a72731061125913fba61c7
+      revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e
       path: modules/lib/mcumgr
     - name: net-tools
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127


### PR DESCRIPTION
The mcumgr version has been updated to 0.2.0

Commits affecting Zephyr that are included with the new revision:
    62009e0 img_mgmt_state_set_pending: corrected error handling
	    (bug fix)

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

In test.