### PR TITLE
subsys: power: remove device_pm_control_nop function

### DIFF
--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -177,7 +177,7 @@ static int multiboot_framebuf_init(const struct device *dev)
 DEVICE_DEFINE(multiboot_framebuf,
 		    "FRAMEBUF",
 		    multiboot_framebuf_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &multiboot_framebuf_data,
 		    NULL,
 		    PRE_KERNEL_1,

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2235,7 +2235,7 @@ struct net_if_api {
  * the system.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2262,7 +2262,7 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2317,7 +2317,7 @@ struct net_if_api {
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2349,7 +2349,7 @@ struct net_if_api {
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2401,7 +2401,7 @@ struct net_if_api {
  * the system.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2427,7 +2427,7 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/include/net/virtual.h
+++ b/include/net/virtual.h
@@ -295,7 +295,7 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * the system.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -193,15 +193,6 @@ int device_required_foreach(const struct device *dev,
 }
 
 #ifdef CONFIG_PM_DEVICE
-int device_pm_control_nop(const struct device *unused_device,
-			  uint32_t unused_ctrl_command,
-			  void *unused_context,
-			  device_pm_cb cb,
-			  void *unused_arg)
-{
-	return -ENOTSUP;
-}
-
 int device_any_busy_check(void)
 {
 	const struct device *dev = __device_start;

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -53,6 +53,5 @@ static const struct stm32_backup_sram_config config = {
 		    .enr = DT_INST_CLOCKS_CELL(0, bits) },
 };
 
-DEVICE_DT_INST_DEFINE(0, stm32_backup_sram_init, device_pm_control_nop,
-		      NULL, &config, POST_KERNEL,
-		      CONFIG_APPLICATION_INIT_PRIORITY, NULL);
+DEVICE_DT_INST_DEFINE(0, stm32_backup_sram_init, NULL, NULL, &config,
+		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY, NULL);

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -630,8 +630,7 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_BT_SCAN, bt_scan);
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_BT_DISCONNECT, bt_disconnect);
 #endif
 
-DEVICE_DEFINE(net_bt, "net_bt", net_bt_init, device_pm_control_nop,
-	      &bt_context_data, NULL, POST_KERNEL,
-	      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &bt_if_api);
+DEVICE_DEFINE(net_bt, "net_bt", net_bt_init, NULL, &bt_context_data, NULL,
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &bt_if_api);
 NET_L2_DATA_INIT(net_bt, 0, NET_L2_GET_CTX_TYPE(BLUETOOTH_L2));
 NET_IF_INIT(net_bt, 0, BLUETOOTH_L2, L2CAP_IPSP_MTU, CONFIG_BT_MAX_CONN);

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -564,8 +564,7 @@ static const struct virtual_interface_api ipip_iface_api = {
 
 #define NET_IPIP_INTERFACE_INIT(x, _)					\
 	NET_VIRTUAL_INTERFACE_INIT(ipip##x, "IP_TUNNEL" #x, ipip_init,	\
-				   device_pm_control_nop,		\
-				   &ipip_context_data_##x, NULL,	\
+				   NULL, &ipip_context_data_##x, NULL,	\
 				   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 				   &ipip_iface_api, IPIPV4_MTU);
 

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -700,7 +700,7 @@ static const struct net_capture_interface_api capture_interface_api = {
 	DEVICE_DEFINE(net_capture_##x,					\
 		      "NET_CAPTURE" #x,					\
 		      &capture_dev_init,				\
-		      device_pm_control_nop,				\
+		      NULL,						\
 		      &capture_dev_data_##x,				\
 		      NULL,						\
 		      POST_KERNEL,					\

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -142,8 +142,7 @@ void pm_create_device_list(void)
 		const struct device *dev = &all_devices[pmi];
 
 		/* Ignore "device"s that don't support PM */
-		if ((dev->device_pm_control == NULL) ||
-		    (dev->device_pm_control == device_pm_control_nop)) {
+		if (dev->device_pm_control == NULL) {
 			continue;
 		}
 

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -937,7 +937,7 @@ void usb_audio_register(const struct device *dev,
 	};								  \
 	DEVICE_DT_DEFINE(DT_INST(i, COMPAT_##dev),			  \
 			    &usb_audio_device_init,			  \
-			    device_pm_control_nop,			  \
+			    NULL,					  \
 			    &dev##_audio_dev_data_##i,			  \
 			    &dev##_audio_config_##i, APPLICATION,	  \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		  \

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -1108,7 +1108,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 #define DEFINE_CDC_ACM_DEVICE(x, _)					\
 	DEVICE_DEFINE(cdc_acm_##x,					\
 			    CONFIG_USB_CDC_ACM_DEVICE_NAME "_" #x,	\
-			    &cdc_acm_init, device_pm_control_nop,	\
+			    &cdc_acm_init, NULL,			\
 			    &cdc_acm_dev_data_##x,			\
 			    &cdc_acm_config_##x,			\
 			    POST_KERNEL,				\

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -767,7 +767,7 @@ static int usb_hid_device_init(const struct device *dev)
 	DEVICE_DEFINE(usb_hid_device_##x,				\
 			    CONFIG_USB_HID_DEVICE_NAME "_" #x,		\
 			    &usb_hid_device_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &usb_hid_dev_data_##x,			\
 			    &hid_config_##x, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -152,7 +152,6 @@ static int netusb_init_dev(const struct device *dev)
 	return 0;
 }
 
-NET_DEVICE_INIT(eth_netusb, "eth_netusb", netusb_init_dev,
-		device_pm_control_nop, NULL, NULL,
+NET_DEVICE_INIT(eth_netusb, "eth_netusb", netusb_init_dev, NULL, NULL, NULL,
 		CONFIG_ETH_INIT_PRIORITY, &netusb_api_funcs, ETHERNET_L2,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -256,7 +256,7 @@ static void test_enable_and_disable_automatic_idle_pm(void)
 	/* check its status at first */
 	/* for cases that cannot run IDLE power, we skip it now */
 	ret = device_get_power_state(dev, &device_power_state);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOSYS) {
 		TC_PRINT("Power management not supported on device");
 		ztest_test_skip();
 		return;
@@ -317,7 +317,7 @@ void test_dummy_device_pm(void)
 
 	/* Set device state to DEVICE_PM_ACTIVE_STATE */
 	ret = device_set_power_state(dev, DEVICE_PM_ACTIVE_STATE, NULL, NULL);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOSYS) {
 		TC_PRINT("Power management not supported on device");
 		ztest_test_skip();
 		return;

--- a/tests/kernel/device/src/test_driver_init.c
+++ b/tests/kernel/device/src/test_driver_init.c
@@ -135,19 +135,19 @@ static int my_driver_pri_4_init(const struct device *dev)
  * @ingroup kernel_device_tests
  */
 DEVICE_DEFINE(my_driver_level_1, MY_DRIVER_LV_1, &my_driver_lv_1_init,
-		device_pm_control_nop, NULL, NULL, PRE_KERNEL_1,
+		NULL, NULL, NULL, PRE_KERNEL_1,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_level_2, MY_DRIVER_LV_2, &my_driver_lv_2_init,
-		device_pm_control_nop, NULL, NULL, PRE_KERNEL_2,
+		NULL, NULL, NULL, PRE_KERNEL_2,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_level_3, MY_DRIVER_LV_3, &my_driver_lv_3_init,
-		device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		NULL, NULL, NULL, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_level_4, MY_DRIVER_LV_4, &my_driver_lv_4_init,
-		device_pm_control_nop, NULL, NULL, APPLICATION,
+		NULL, NULL, NULL, APPLICATION,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
 /* We use priority value of 20 to create a possible sorting conflict with
@@ -155,17 +155,17 @@ DEVICE_DEFINE(my_driver_level_4, MY_DRIVER_LV_4, &my_driver_lv_4_init,
  * we'll find out.
  */
 DEVICE_DEFINE(my_driver_priority_4, MY_DRIVER_PRI_4,
-		&my_driver_pri_4_init, device_pm_control_nop,
-		NULL, NULL, POST_KERNEL, 20, &funcs_my_drivers);
+		&my_driver_pri_4_init, NULL, NULL, NULL, POST_KERNEL, 20,
+		&funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_priority_1, MY_DRIVER_PRI_1,
-		&my_driver_pri_1_init, device_pm_control_nop,
-		NULL, NULL, POST_KERNEL, 1, &funcs_my_drivers);
+		&my_driver_pri_1_init, NULL, NULL, NULL, POST_KERNEL, 1,
+		&funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_priority_2, MY_DRIVER_PRI_2,
-		&my_driver_pri_2_init, device_pm_control_nop,
-		NULL, NULL, POST_KERNEL, 2, &funcs_my_drivers);
+		&my_driver_pri_2_init, NULL, NULL, NULL, POST_KERNEL, 2,
+		&funcs_my_drivers);
 
 DEVICE_DEFINE(my_driver_priority_3, MY_DRIVER_PRI_3,
-		&my_driver_pri_3_init, device_pm_control_nop,
-		NULL, NULL, POST_KERNEL, 3, &funcs_my_drivers);
+		&my_driver_pri_3_init, NULL, NULL, NULL, POST_KERNEL, 3,
+		&funcs_my_drivers);


### PR DESCRIPTION
Devices that do not require PM should just use `NULL`. `device_pm_control_nop` is still kept as an alias to `NULL` untill all
in-tree usage is replaced with `NULL`. After that it can be either removed or deprecated to make out-of-tree users transition smoother.

Some devices have been ported (everything except `drivers/*`, the main user of `device_pm_control_nop`). I'll take care of porting remaining devices if this PR moves forward.