### PR TITLE
logging: Increase thread stack size when net backend in use

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -74,14 +74,15 @@ config LOG_PROCESS_THREAD_SLEEP_MS
 
 config LOG_PROCESS_THREAD_STACK_SIZE
 	int "Stack size for the internal log processing thread"
-	default 2048 if COVERAGE_GCOV
-	default 1024 if NO_OPTIMIZATIONS
-	default 1024 if XTENSA
 	default 4096 if (X86 && X86_64)
 	default 4096 if ARM64
 	default 4096 if SPARC
+	default 2048 if COVERAGE_GCOV
 	default 2048 if (RISCV && 64BIT)
 	default 2048 if LOG_BACKEND_FS
+	default 1152 if LOG_BACKEND_NET
+	default 1024 if NO_OPTIMIZATIONS
+	default 1024 if XTENSA
 	default 768
 	help
 	  Set the internal stack size for log processing thread.


### PR DESCRIPTION
It has been seen that when net backend is enabled stack usage
is around 1080. Setting 1152 as the default.

Fixes #34515.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>