### PR TITLE
tests: benchmarks: record benchmark results

### DIFF
--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -5,6 +5,14 @@ tests:
     platform_exclude: qemu_x86_64 qemu_cortex_m0 m2gl025_miv
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
     tags: benchmark
+    harness: console
+    harness_config:
+      type: one_line
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
 
 # Cortex-M has 24bit systick, so default 1 TICK per seconds
 # is achievable only if frequency is below 0x00FFFFFF (around 16MHz)
@@ -16,3 +24,10 @@ tests:
     tags: benchmark
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=20
+    harness: console
+    harness_config:
+      type: one_line
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"


### PR DESCRIPTION
Record benchmark results into a CSV file that can be used for tracking.
The data will be available in recording.csv in the build directory.

cat recording.csv

metric,cycles,nanoseconds
Average thread context switch using yield,11654,11654
Average context switch time between threads (coop),21149,21149
Switch from ISR back to interrupted thread,4928,4927
Time from ISR to executing a different thread,3872,3871
Time to create a thread (without start),4224,4223
Time to start a thread,10784,10783
Time to suspend a thread,10400,10399
Time to resume a thread,10688,10687
Time to abort a thread (not running),1536,1535
Average semaphore signal time,3424,3424
Average semaphore test time,1344,1344
Semaphore take time (context switch),12736,12735
Semaphore give time (context switch),17568,17567
Average time to lock a mutex,1632,1632
Average time to unlock a mutex,4738,4738