### PR TITLE
boards: arm: Seeeduino XIAO enable i2c interface on sercom2

### DIFF
--- a/boards/arm/seeeduino_xiao/doc/index.rst
+++ b/boards/arm/seeeduino_xiao/doc/index.rst
@@ -44,6 +44,8 @@ features:
 +-----------+------------+------------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports        |
 +-----------+------------+------------------------------------------+
+| I2C       | on-chip    | Inter-Integrated Circuit                 |
++-----------+------------+------------------------------------------+
 | SYSTICK   | on-chip    | systick                                  |
 +-----------+------------+------------------------------------------+
 | USART     | on-chip    | Serial ports                             |
@@ -78,6 +80,12 @@ SPI Port
 The SAMD21 MCU has 6 SERCOM based SPIs.  On the XIAO, SERCOM0 can be put
 into SPI mode and used to connect to devices over pin 9 (MISO), pin 10
 (MOSI), and pin 8 (SCK).
+
+I2C Port
+========
+
+The SAMD21 MCU has 6 SERCOM based USARTs. On the XIAO, SERCOM2 is available on
+pin 4 (SDA) and pin 5 (SCL).
 
 Serial Port
 ===========

--- a/boards/arm/seeeduino_xiao/pinmux.c
+++ b/boards/arm/seeeduino_xiao/pinmux.c
@@ -40,6 +40,28 @@ static int board_pinmux_init(const struct device *dev)
 #warning Pin mapping may not be configured
 #endif
 
+#if ATMEL_SAM0_DT_SERCOM_CHECK(2, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+	/* SERCOM2 on SDA=PA08, SCL=PA09 */
+	pinmux_pin_set(muxa, 8, PINMUX_FUNC_D);
+	pinmux_pin_set(muxa, 9, PINMUX_FUNC_D);
+#endif
+
+#if ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(1, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(3, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(4, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+#warning Pin mapping may not be configured
+#endif
+#if ATMEL_SAM0_DT_SERCOM_CHECK(5, atmel_sam0_i2c) && defined(CONFIG_I2C_SAM0)
+#warning Pin mapping may not be configured
+#endif
+
 #if ATMEL_SAM0_DT_SERCOM_CHECK(0, atmel_sam0_spi) && defined(CONFIG_SPI_SAM0)
 	/* SPI SERCOM0 on MISO=PA5/pad 1, MOSI=PA6/pad 2, SCK=PA7/pad 3 */
 	pinmux_pin_set(muxa, 5, PINMUX_FUNC_D);

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -64,6 +64,14 @@
 	#size-cells = <0>;
 };
 
+&sercom2 {
+	status = "okay";
+	compatible = "atmel,sam0-i2c";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+};
+
 &usb0 {
 	status = "okay";
 };

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.yaml
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.yaml
@@ -14,6 +14,7 @@ supported:
   - hwinfo
   - pinmux
   - spi
+  - i2c
   - uart
   - usb_device
   - watchdog


### PR DESCRIPTION
This enables the i2c interface on the Seeeduino XIAO.

This is my first pull-request to this repository. I hope it's ok to just send a pull request without opening an issue beforehand.

Signed-off-by: Leonard Pollak <leonardp@tr-host.de>
