### PR TITLE
tests: net: tcp2: Perform tests on DUMMY interface

### DIFF
--- a/tests/net/tcp2/src/main.c
+++ b/tests/net/tcp2/src/main.c
@@ -1,4 +1,10 @@
-/* main.c - Application main entry point */
+/* main.c - Application main entry point
+ *
+ * This is a self-contained test for exercising the TCP2 protocol stack. Both
+ * the server and client side run on ths same device using a DUMMY interface
+ * as a loopback of the IP packets.
+ *
+ */
 
 /*
  * Copyright (c) 2020 Intel Corporation
@@ -432,7 +438,7 @@ static void test_presetup(void)
 {
 	struct net_if_addr *ifaddr;
 
-	iface = net_if_get_default();
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 	if (!iface) {
 		zassert_true(false, "Interface not available");
 	}


### PR DESCRIPTION
Tests are designed to run over the DUMMY interface but when run on
hardware, net_if_get_default() can return the actual hardware
interface.

Fixes: #31969

Signed-off-by: David Leach <david.leach@nxp.com>