### PR TITLE
dts: arm: stm32h723 has usart10 in its dts

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -23,6 +23,15 @@
 			label = "UART_9";
 		};
 
+		usart10: serial@40011c00 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40011c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			interrupts = <156 0>;
+			status = "disabled";
+			label = "UART_10";
+		};
+
 		dmamux1: dmamux@40020800 {
 			dma-requests= <129>;
 		};


### PR DESCRIPTION
adding the device node for UART10 in dts/arm/st/h7/stm32h723.dtsi
from https://github.com/Kshitij4kk/zephyr/commit/1106fdfe5cd01c60ce7fcfeac1f4da2f953a6d91

Fix https://github.com/zephyrproject-rtos/zephyr/issues/33475