### PR TITLE
nvs: fix initialization of fs->data_wra on alignment change

### DIFF
--- a/doc/reference/storage/nvs/nvs.rst
+++ b/doc/reference/storage/nvs/nvs.rst
@@ -94,6 +94,14 @@ the expected device life (in minutes) can be calculated as::
 From this formula it is also clear what to do in case the expected life is too
 short: increase ``SECTOR_COUNT`` or ``SECTOR_SIZE``.
 
+Flash write block size migration
+********************************
+It is possible that during a DFU process, the flash driver used by the NVS
+changes the supported minimal write block size.
+The NVS in-flash image will stay compatible unless the
+physical ATE size changes.
+Especially, migration between 1,2,4,8-bytes write block sizes is allowed.
+
 Sample
 ******
 

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -632,6 +632,12 @@ static int nvs_startup(struct nvs_fs *fs)
 		if (!nvs_ate_crc8_check(&last_ate)) {
 			/* crc8 is ok, complete write of ate was performed */
 			fs->data_wra = addr & ADDR_SECT_MASK;
+			/* Align the data write address to the current
+			 * write block size so that it is possible to write to
+			 * the sector even if the block size has changed after
+			 * a software upgrade (unless the physical ATE size
+			 * will change)."
+			 */
 			fs->data_wra += nvs_al_size(fs, last_ate.offset + last_ate.len);
 
 			/* ate on the last possition within the sector is

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -632,8 +632,7 @@ static int nvs_startup(struct nvs_fs *fs)
 		if (!nvs_ate_crc8_check(&last_ate)) {
 			/* crc8 is ok, complete write of ate was performed */
 			fs->data_wra = addr & ADDR_SECT_MASK;
-			fs->data_wra += last_ate.offset;
-			fs->data_wra += nvs_al_size(fs, last_ate.len);
+			fs->data_wra += nvs_al_size(fs, last_ate.offset + last_ate.len);
 
 			/* ate on the last possition within the sector is
 			 * reserved for deletion an entry


### PR DESCRIPTION
    When existing records stored in the NVS are not properly
    aligned according to the current flash driver requirements,
    fs->data_wra may be initialized with an unaligned address.
    Fix the initialization code, so that fs->data_wra is rounded
    up to the nearest multiple of the current flash driver block
    size.
    
    The situation may occur during a firmware upgrade which
    introduces a new flash driver or changes its parameters.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>