### PR TITLE
tests: Make few non-ztest tests match the standard testsuite output

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -154,6 +154,25 @@ static inline void test_time_ms(void)
 	Z_TC_END_RESULT((result), __func__)
 #endif
 
+#ifndef TC_SUITE_START
+#define TC_SUITE_START(name)					\
+	do {							\
+		TC_PRINT("Running test suite %s\n", name);	\
+		PRINT_LINE;					\
+	} while (0)
+#endif
+
+#ifndef TC_SUITE_END
+#define TC_SUITE_END(name, result)				\
+	do {								\
+		if (result == TC_PASS) {					\
+			TC_PRINT("Test suite %s succeeded\n", name);	\
+		} else {						\
+			TC_PRINT("Test suite %s failed.\n", name);	\
+		}							\
+	} while (0)
+#endif
+
 #if defined(CONFIG_ARCH_POSIX)
 #define TC_END_POST(result) posix_exit(result)
 #else

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -372,8 +372,7 @@ void z_ztest_run_test_suite(const char *name, struct unit_test *suite)
 
 	init_testing();
 
-	PRINT("Running test suite %s\n", name);
-	PRINT_LINE;
+	TC_SUITE_START(name);
 	while (suite->test) {
 		fail += run_test(suite);
 		suite++;
@@ -382,11 +381,7 @@ void z_ztest_run_test_suite(const char *name, struct unit_test *suite)
 			break;
 		}
 	}
-	if (fail) {
-		TC_PRINT("Test suite %s failed.\n", name);
-	} else {
-		TC_PRINT("Test suite %s succeeded\n", name);
-	}
+	TC_SUITE_END(name, (fail > 0 ? TC_FAIL : TC_PASS));
 
 	test_status = (test_status || fail) ? 1 : 0;
 }

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -79,7 +79,8 @@ void main(void)
 	int rv, i;
 	const struct device *ipm;
 
-	TC_START("Test IPM");
+	TC_SUITE_START("test_ipm");
+	TC_START(__func__);
 	ipm = device_get_binding("ipm_dummy0");
 
 	/* Try sending a raw string to the IPM device to show that the
@@ -105,5 +106,6 @@ void main(void)
 
 	rv = TC_PASS;
 	TC_END_RESULT(rv);
+	TC_SUITE_END("test_ipm", rv);
 	TC_END_REPORT(rv);
 }

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -4,15 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
+#include <tc_util.h>
 
 /* The only point to CONFIG_MULTITHREADING=n is to use Zephyr's
  * multiplatform toolchain, linkage and boostrap integration to arrive
  * here so the user can run C code unimpeded.  In general, we don't
  * promise that *any* Zephyr APIs are going to work properly, so don't
  * try to test any.  That means we can't even use the ztest suite
- * framework (which spawns threads internally).
+ * framework (which spawns threads internally). Instead, just use
+ * tc_util.h helpers.
  */
 void test_main(void)
 {
+	TC_SUITE_START("test_kernel_no_multithread");
+	TC_START(__func__);
 	printk("It works\n");
+	TC_END_RESULT(TC_PASS);
+	TC_SUITE_END("test_kernel_no_multithread", TC_PASS);
 }


### PR DESCRIPTION
We have a few tests in the testsuite which don't use ztest framework for various reasons. However, make them produce output compatible with ztest output. This is useful for automated CI systems (which e.g. use regexes to validate test output).
