### PR TITLE
Bluetooth: tester: Implement Provisioning Node Added event

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -1004,6 +1004,14 @@ struct mesh_lpn_polled_ev {
 	uint8_t retry;
 } __packed;
 
+#define MESH_EV_PROV_NODE_ADDED		0x8e
+struct mesh_prov_node_added_ev {
+	uint16_t net_idx;
+	uint16_t addr;
+	uint8_t uuid[16];
+	uint8_t num_elems;
+} __packed;
+
 void tester_init(void);
 void tester_rsp(uint8_t service, uint8_t opcode, uint8_t index, uint8_t status);
 void tester_send(uint8_t service, uint8_t opcode, uint8_t index, uint8_t *data,

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -343,6 +343,23 @@ static void prov_complete(uint16_t net_idx, uint16_t addr)
 		    NULL, 0);
 }
 
+static void prov_node_added(uint16_t net_idx, uint8_t uuid[16], uint16_t addr,
+			    uint8_t num_elem)
+{
+	struct mesh_prov_node_added_ev ev;
+
+	LOG_DBG("net_idx 0x%04x addr 0x%04x num_elem %d", net_idx, addr,
+		num_elem);
+
+	ev.net_idx = net_idx;
+	ev.addr = addr;
+	ev.num_elems = num_elem;
+	memcpy(&ev.uuid, uuid, sizeof(ev.uuid));
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_PROV_NODE_ADDED,
+		    CONTROLLER_INDEX, (void *)&ev, sizeof(ev));
+}
+
 static void prov_reset(void)
 {
 	LOG_DBG("");
@@ -366,6 +383,7 @@ static struct bt_mesh_prov prov = {
 	.link_open = link_open,
 	.link_close = link_close,
 	.complete = prov_complete,
+	.node_added = prov_node_added,
 	.reset = prov_reset,
 };
 


### PR DESCRIPTION
This information is useful to the automation framework when implementing
tests where the IUT is the provisioner and the test uses two PTS
instances.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>