### PR TITLE
 Bluetooth: Mesh: Add return value for opcode callback

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -77,6 +77,8 @@ Bluetooth
 
 * Mesh
 
+  * Added return value for opcode callback
+
 * Bluetooth LE split software Controller
 
 * HCI Driver

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -166,8 +166,13 @@ struct bt_mesh_model_op {
 	/** OpCode encoded using the BT_MESH_MODEL_OP_* macros */
 	const uint32_t  opcode;
 
-	/** Minimum required message length */
-	const size_t min_len;
+	/** Message length. If the message has variable length then this value
+	 *  indicates minimum message length and should be positive. Handler
+	 *  function should verify precise length based on the contents of the
+	 *  message. If the message has fixed length then this value should
+	 *  be negative. Use BT_MESH_LEN_* macros when defining this value.
+	 */
+	const ssize_t len;
 
 	/** @brief Handler function for this opcode.
 	 *
@@ -186,6 +191,11 @@ struct bt_mesh_model_op {
 #define BT_MESH_MODEL_OP_1(b0) (b0)
 #define BT_MESH_MODEL_OP_2(b0, b1) (((b0) << 8) | (b1))
 #define BT_MESH_MODEL_OP_3(b0, cid) ((((b0) << 16) | 0xc00000) | (cid))
+
+/** Macro for encoding exact message length for fixed-length messages.  */
+#define BT_MESH_LEN_EXACT(len) (-len)
+/** Macro for encoding minimum message length for variable-length messages.  */
+#define BT_MESH_LEN_MIN(len) (len)
 
 /** End of the opcode list. Must always be present. */
 #define BT_MESH_MODEL_OP_END { 0, 0, NULL }

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -175,10 +175,12 @@ struct bt_mesh_model_op {
 	 *  @param ctx   Message context for the message.
 	 *  @param buf   Message buffer containing the message payload, not
 	 *               including the opcode.
+	 *
+	 *  @return Zero on success or (negative) error code otherwise.
 	 */
-	void (*const func)(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf);
+	int (*const func)(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf);
 };
 
 #define BT_MESH_MODEL_OP_1(b0) (b0)

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -80,22 +80,24 @@ static struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static void vnd_button_pressed(struct bt_mesh_model *model,
+static int vnd_button_pressed(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	printk("src 0x%04x\n", ctx->addr);
 
 	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
-		return;
+		return 0;
 	}
 
 	board_other_dev_pressed(ctx->addr);
 	board_play("100G200 100G");
+
+	return 0;
 }
 
 static const struct bt_mesh_model_op vnd_ops[] = {
-	{ OP_VENDOR_BUTTON, 0, vnd_button_pressed },
+	{ OP_VENDOR_BUTTON, BT_MESH_LEN_EXACT(0), vnd_button_pressed },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -68,9 +68,9 @@ static struct bt_mesh_elem elements[];
 /* message handlers (Start) */
 
 /* Generic OnOff Server message handlers */
-static void gen_onoff_get(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int gen_onoff_get(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 3 + 4);
 
@@ -91,6 +91,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_ONOFF_SRV Status response\n");
 	}
+
+	return 0;
 }
 
 void gen_onoff_publish(struct bt_mesh_model *model)
@@ -117,9 +119,9 @@ void gen_onoff_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void gen_onoff_set_unack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int gen_onoff_set_unack(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	uint8_t tid, onoff, tt, delay;
 	int64_t now;
@@ -128,7 +130,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (onoff > STATE_ON) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -136,7 +138,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -147,13 +149,13 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -171,7 +173,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(ONOFF);
 	} else {
-		return;
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -182,11 +184,13 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	ctl->transition->just_started = true;
 	gen_onoff_publish(model);
 	onoff_handler();
+
+	return 0;
 }
 
-static void gen_onoff_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int gen_onoff_set(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	uint8_t tid, onoff, tt, delay;
 	int64_t now;
@@ -195,7 +199,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (onoff > STATE_ON) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -203,8 +207,8 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		gen_onoff_get(model, ctx, buf);
-		return;
+		(void)gen_onoff_get(model, ctx, buf);
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -215,13 +219,13 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -239,8 +243,8 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(ONOFF);
 	} else {
-		gen_onoff_get(model, ctx, buf);
-		return;
+		(void)gen_onoff_get(model, ctx, buf);
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -249,15 +253,17 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	}
 
 	ctl->transition->just_started = true;
-	gen_onoff_get(model, ctx, buf);
+	(void)gen_onoff_get(model, ctx, buf);
 	gen_onoff_publish(model);
 	onoff_handler();
+
+	return 0;
 }
 
 /* Generic OnOff Client message handlers */
-static void gen_onoff_status(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int gen_onoff_status(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from GEN_ONOFF_SRV\n");
 	printk("Present OnOff = %02x\n", net_buf_simple_pull_u8(buf));
@@ -266,12 +272,14 @@ static void gen_onoff_status(struct bt_mesh_model *model,
 		printk("Target OnOff = %02x\n", net_buf_simple_pull_u8(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
 /* Generic Level (lIGHTNESS) Server message handlers */
-static void gen_level_get(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int gen_level_get(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -292,6 +300,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_LEVEL_SRV Status response\n");
 	}
+
+	return 0;
 }
 
 void gen_level_publish(struct bt_mesh_model *model)
@@ -318,310 +328,15 @@ void gen_level_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void gen_level_set_unack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	int16_t level;
-	int64_t now;
-
-	level = (int16_t) net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-	set_target(LEVEL_LIGHT, &level);
-
-	if (ctl->light->target != ctl->light->current) {
-		set_transition_values(LEVEL_LIGHT);
-	} else {
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->light->current = ctl->light->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_publish(model);
-	level_lightness_handler();
-}
-
-static void gen_level_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	int16_t level;
-	int64_t now;
-
-	level = (int16_t) net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		gen_level_get(model, ctx, buf);
-		return;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-	set_target(LEVEL_LIGHT, &level);
-
-	if (ctl->light->target != ctl->light->current) {
-		set_transition_values(LEVEL_LIGHT);
-	} else {
-		gen_level_get(model, ctx, buf);
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->light->current = ctl->light->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_get(model, ctx, buf);
-	gen_level_publish(model);
-	level_lightness_handler();
-}
-
-static void gen_delta_set_unack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	static int16_t last_level;
-	int32_t target, delta;
-	int64_t now;
-
-	delta = (int32_t) net_buf_simple_pull_le32(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-
-		if (ctl->light->delta == delta) {
-			return;
-		}
-		target = last_level + delta;
-
-	} else {
-		last_level = (int16_t) get_current(LEVEL_LIGHT);
-		target = last_level + delta;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-
-	if (target < INT16_MIN) {
-		target = INT16_MIN;
-	} else if (target > INT16_MAX) {
-		target = INT16_MAX;
-	}
-
-	set_target(DELTA_LEVEL_LIGHT, &target);
-
-	if (ctl->light->target != ctl->light->current) {
-		set_transition_values(LEVEL_LIGHT);
-	} else {
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->light->current = ctl->light->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_publish(model);
-	level_lightness_handler();
-}
-
-static void gen_delta_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	static int16_t last_level;
-	int32_t target, delta;
-	int64_t now;
-
-	delta = (int32_t) net_buf_simple_pull_le32(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-
-		if (ctl->light->delta == delta) {
-			gen_level_get(model, ctx, buf);
-			return;
-		}
-		target = last_level + delta;
-
-	} else {
-		last_level = (int16_t) get_current(LEVEL_LIGHT);
-		target = last_level + delta;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-
-	if (target < INT16_MIN) {
-		target = INT16_MIN;
-	} else if (target > INT16_MAX) {
-		target = INT16_MAX;
-	}
-
-	set_target(DELTA_LEVEL_LIGHT, &target);
-
-	if (ctl->light->target != ctl->light->current) {
-		set_transition_values(LEVEL_LIGHT);
-	} else {
-		gen_level_get(model, ctx, buf);
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->light->current = ctl->light->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_get(model, ctx, buf);
-	gen_level_publish(model);
-	level_lightness_handler();
-}
-
-static void gen_move_set_unack(struct bt_mesh_model *model,
+static int gen_level_set_unack(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
-	int16_t delta;
-	uint16_t target;
+	int16_t level;
 	int64_t now;
 
-	delta = (int16_t) net_buf_simple_pull_le16(buf);
+	level = (int16_t) net_buf_simple_pull_le16(buf);
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
@@ -629,7 +344,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -640,13 +355,13 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -658,36 +373,266 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	ctl->last_msg_timestamp = now;
 	ctl->transition->tt = tt;
 	ctl->transition->delay = delay;
-	ctl->transition->type = MOVE;
-	ctl->light->delta = delta;
-
-	if (delta < 0) {
-		target = ctl->light->range_min;
-	} else if (delta > 0) {
-		target = ctl->light->range_max;
-	} else if (delta == 0) {
-		target = ctl->light->current;
-	}
-	set_target(MOVE_LIGHT, &target);
+	ctl->transition->type = NON_MOVE;
+	set_target(LEVEL_LIGHT, &level);
 
 	if (ctl->light->target != ctl->light->current) {
-		set_transition_values(MOVE_LIGHT);
+		set_transition_values(LEVEL_LIGHT);
 	} else {
-		return;
+		return 0;
 	}
 
+	/* For Instantaneous Transition */
 	if (ctl->transition->counter == 0U) {
-		return;
+		ctl->light->current = ctl->light->target;
 	}
 
 	ctl->transition->just_started = true;
 	gen_level_publish(model);
 	level_lightness_handler();
+
+	return 0;
 }
 
-static void gen_move_set(struct bt_mesh_model *model,
+static int gen_level_set(struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	int16_t level;
+	int64_t now;
+
+	level = (int16_t) net_buf_simple_pull_le16(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+		(void)gen_level_get(model, ctx, buf);
+		return 0;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+	set_target(LEVEL_LIGHT, &level);
+
+	if (ctl->light->target != ctl->light->current) {
+		set_transition_values(LEVEL_LIGHT);
+	} else {
+		(void)gen_level_get(model, ctx, buf);
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->light->current = ctl->light->target;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get(model, ctx, buf);
+	gen_level_publish(model);
+	level_lightness_handler();
+
+	return 0;
+}
+
+static int gen_delta_set_unack(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	static int16_t last_level;
+	int32_t target, delta;
+	int64_t now;
+
+	delta = (int32_t) net_buf_simple_pull_le32(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+
+		if (ctl->light->delta == delta) {
+			return 0;
+		}
+		target = last_level + delta;
+
+	} else {
+		last_level = (int16_t) get_current(LEVEL_LIGHT);
+		target = last_level + delta;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+
+	if (target < INT16_MIN) {
+		target = INT16_MIN;
+	} else if (target > INT16_MAX) {
+		target = INT16_MAX;
+	}
+
+	set_target(DELTA_LEVEL_LIGHT, &target);
+
+	if (ctl->light->target != ctl->light->current) {
+		set_transition_values(LEVEL_LIGHT);
+	} else {
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->light->current = ctl->light->target;
+	}
+
+	ctl->transition->just_started = true;
+	gen_level_publish(model);
+	level_lightness_handler();
+
+	return 0;
+}
+
+static int gen_delta_set(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	static int16_t last_level;
+	int32_t target, delta;
+	int64_t now;
+
+	delta = (int32_t) net_buf_simple_pull_le32(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+
+		if (ctl->light->delta == delta) {
+			(void)gen_level_get(model, ctx, buf);
+			return 0;
+		}
+		target = last_level + delta;
+
+	} else {
+		last_level = (int16_t) get_current(LEVEL_LIGHT);
+		target = last_level + delta;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+
+	if (target < INT16_MIN) {
+		target = INT16_MIN;
+	} else if (target > INT16_MAX) {
+		target = INT16_MAX;
+	}
+
+	set_target(DELTA_LEVEL_LIGHT, &target);
+
+	if (ctl->light->target != ctl->light->current) {
+		set_transition_values(LEVEL_LIGHT);
+	} else {
+		(void)gen_level_get(model, ctx, buf);
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->light->current = ctl->light->target;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get(model, ctx, buf);
+	gen_level_publish(model);
+	level_lightness_handler();
+
+	return 0;
+}
+
+static int gen_move_set_unack(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta;
@@ -702,8 +647,7 @@ static void gen_move_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		gen_level_get(model, ctx, buf);
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -714,13 +658,13 @@ static void gen_move_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -747,24 +691,101 @@ static void gen_move_set(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(MOVE_LIGHT);
 	} else {
-		gen_level_get(model, ctx, buf);
-		return;
+		return 0;
 	}
 
 	if (ctl->transition->counter == 0U) {
-		return;
+		return 0;
 	}
 
 	ctl->transition->just_started = true;
-	gen_level_get(model, ctx, buf);
 	gen_level_publish(model);
 	level_lightness_handler();
+
+	return 0;
+}
+
+static int gen_move_set(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	int16_t delta;
+	uint16_t target;
+	int64_t now;
+
+	delta = (int16_t) net_buf_simple_pull_le16(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+		(void)gen_level_get(model, ctx, buf);
+		return 0;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = MOVE;
+	ctl->light->delta = delta;
+
+	if (delta < 0) {
+		target = ctl->light->range_min;
+	} else if (delta > 0) {
+		target = ctl->light->range_max;
+	} else if (delta == 0) {
+		target = ctl->light->current;
+	}
+	set_target(MOVE_LIGHT, &target);
+
+	if (ctl->light->target != ctl->light->current) {
+		set_transition_values(MOVE_LIGHT);
+	} else {
+		(void)gen_level_get(model, ctx, buf);
+		return 0;
+	}
+
+	if (ctl->transition->counter == 0U) {
+		return 0;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get(model, ctx, buf);
+	gen_level_publish(model);
+	level_lightness_handler();
+
+	return 0;
 }
 
 /* Generic Level Client message handlers */
-static void gen_level_status(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int gen_level_status(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from GEN_LEVEL_SRV\n");
 	printk("Present Level = %04x\n", net_buf_simple_pull_le16(buf));
@@ -773,12 +794,14 @@ static void gen_level_status(struct bt_mesh_model *model,
 		printk("Target Level = %04x\n", net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
 /* Generic Default Transition Time Server message handlers */
-static void gen_def_trans_time_get(struct bt_mesh_model *model,
-				   struct bt_mesh_msg_ctx *ctx,
-				   struct net_buf_simple *buf)
+static int gen_def_trans_time_get(struct bt_mesh_model *model,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
 
@@ -788,6 +811,8 @@ static void gen_def_trans_time_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_DEF_TT_SRV Status response\n");
 	}
+
+	return 0;
 }
 
 static void gen_def_trans_time_publish(struct bt_mesh_model *model)
@@ -808,16 +833,16 @@ static void gen_def_trans_time_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void gen_def_trans_time_set_unack(struct bt_mesh_model *model,
-					 struct bt_mesh_msg_ctx *ctx,
-					 struct net_buf_simple *buf)
+static int gen_def_trans_time_set_unack(struct bt_mesh_model *model,
+					struct bt_mesh_msg_ctx *ctx,
+					struct net_buf_simple *buf)
 {
 	uint8_t tt;
 
 	tt = net_buf_simple_pull_u8(buf);
 
 	if ((tt & 0x3F) == 0x3F) {
-		return;
+		return 0;
 	}
 
 	if (ctl->tt != tt) {
@@ -826,44 +851,50 @@ static void gen_def_trans_time_set_unack(struct bt_mesh_model *model,
 		gen_def_trans_time_publish(model);
 		save_on_flash(GEN_DEF_TRANS_TIME_STATE);
 	}
+
+	return 0;
 }
 
-static void gen_def_trans_time_set(struct bt_mesh_model *model,
-				   struct bt_mesh_msg_ctx *ctx,
-				   struct net_buf_simple *buf)
+static int gen_def_trans_time_set(struct bt_mesh_model *model,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
 {
 	uint8_t tt;
 
 	tt = net_buf_simple_pull_u8(buf);
 
 	if ((tt & 0x3F) == 0x3F) {
-		return;
+		return 0;
 	}
 
 	if (ctl->tt != tt) {
 		ctl->tt = tt;
 
-		gen_def_trans_time_get(model, ctx, buf);
+		(void)gen_def_trans_time_get(model, ctx, buf);
 		gen_def_trans_time_publish(model);
 		save_on_flash(GEN_DEF_TRANS_TIME_STATE);
 	} else {
-		gen_def_trans_time_get(model, ctx, buf);
+		(void)gen_def_trans_time_get(model, ctx, buf);
 	}
+
+	return 0;
 }
 
 /* Generic Default Transition Time Client message handlers */
-static void gen_def_trans_time_status(struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx,
-				      struct net_buf_simple *buf)
+static int gen_def_trans_time_status(struct bt_mesh_model *model,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from GEN_DEF_TT_SRV\n");
 	printk("Transition Time = %02x\n", net_buf_simple_pull_u8(buf));
+
+	return 0;
 }
 
 /* Generic Power OnOff Server message handlers */
-static void gen_onpowerup_get(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int gen_onpowerup_get(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
 
@@ -873,15 +904,19 @@ static void gen_onpowerup_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_POWER_ONOFF_SRV Status response\n");
 	}
+
+	return 0;
 }
 
 /* Generic Power OnOff Client message handlers */
-static void gen_onpowerup_status(struct bt_mesh_model *model,
-				 struct bt_mesh_msg_ctx *ctx,
-				 struct net_buf_simple *buf)
+static int gen_onpowerup_status(struct bt_mesh_model *model,
+				struct bt_mesh_msg_ctx *ctx,
+				struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from GEN_POWER_ONOFF_SRV\n");
 	printk("OnPowerUp = %02x\n", net_buf_simple_pull_u8(buf));
+
+	return 0;
 }
 
 /* Generic Power OnOff Setup Server message handlers */
@@ -904,16 +939,16 @@ static void gen_onpowerup_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void gen_onpowerup_set_unack(struct bt_mesh_model *model,
-				    struct bt_mesh_msg_ctx *ctx,
-				    struct net_buf_simple *buf)
+static int gen_onpowerup_set_unack(struct bt_mesh_model *model,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
 {
 	uint8_t onpowerup;
 
 	onpowerup = net_buf_simple_pull_u8(buf);
 
 	if (onpowerup > STATE_RESTORE) {
-		return;
+		return 0;
 	}
 
 	if (ctl->onpowerup != onpowerup) {
@@ -922,35 +957,38 @@ static void gen_onpowerup_set_unack(struct bt_mesh_model *model,
 		gen_onpowerup_publish(model);
 		save_on_flash(GEN_ONPOWERUP_STATE);
 	}
+
+	return 0;
 }
 
-static void gen_onpowerup_set(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int gen_onpowerup_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	uint8_t onpowerup;
 
 	onpowerup = net_buf_simple_pull_u8(buf);
 
 	if (onpowerup > STATE_RESTORE) {
-		return;
+		return 0;
 	}
 
 	if (ctl->onpowerup != onpowerup) {
 		ctl->onpowerup = onpowerup;
 
-		gen_onpowerup_get(model, ctx, buf);
+		(void)gen_onpowerup_get(model, ctx, buf);
 		gen_onpowerup_publish(model);
 		save_on_flash(GEN_ONPOWERUP_STATE);
 	} else {
-		gen_onpowerup_get(model, ctx, buf);
+		(void)gen_onpowerup_get(model, ctx, buf);
 	}
+
+	return 0;
 }
 
 /* Vendor Model message handlers*/
-static void vnd_get(struct bt_mesh_model *model,
-		    struct bt_mesh_msg_ctx *ctx,
-		    struct net_buf_simple *buf)
+static int vnd_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		   struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(3 + 6 + 4);
 	struct vendor_state *state = model->user_data;
@@ -965,11 +1003,13 @@ static void vnd_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send VENDOR Status response\n");
 	}
+
+	return 0;
 }
 
-static void vnd_set_unack(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int vnd_set_unack(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	uint8_t tid;
 	int current;
@@ -984,7 +1024,7 @@ static void vnd_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	state->last_tid = tid;
@@ -996,29 +1036,33 @@ static void vnd_set_unack(struct bt_mesh_model *model,
 	printk("Vendor model message = %04x\n", state->current);
 
 	update_vnd_led_gpio();
+
+	return 0;
 }
 
-static void vnd_set(struct bt_mesh_model *model,
-		    struct bt_mesh_msg_ctx *ctx,
-		    struct net_buf_simple *buf)
+static int vnd_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		   struct net_buf_simple *buf)
 {
-	vnd_set_unack(model, ctx, buf);
-	vnd_get(model, ctx, buf);
+	(void)vnd_set_unack(model, ctx, buf);
+	(void)vnd_get(model, ctx, buf);
+
+	return 0;
 }
 
-static void vnd_status(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int vnd_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from Vendor\n");
 	printk("cmd = %04x\n", net_buf_simple_pull_le16(buf));
 	printk("response = %08x\n", net_buf_simple_pull_le32(buf));
+
+	return 0;
 }
 
 /* Light Lightness Server message handlers */
-static void light_lightness_get(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int light_lightness_get(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -1039,6 +1083,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessAct Status response\n");
 	}
+
+	return 0;
 }
 
 void light_lightness_publish(struct bt_mesh_model *model)
@@ -1065,9 +1111,9 @@ void light_lightness_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_lightness_set_unack(struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx,
-				      struct net_buf_simple *buf)
+static int light_lightness_set_unack(struct bt_mesh_model *model,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	uint16_t actual;
@@ -1081,7 +1127,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1092,13 +1138,13 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1116,7 +1162,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(ACTUAL);
 	} else {
-		return;
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1127,9 +1173,11 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	ctl->transition->just_started = true;
 	light_lightness_publish(model);
 	light_lightness_actual_handler();
+
+	return 0;
 }
 
-static void light_lightness_set(struct bt_mesh_model *model,
+static int light_lightness_set(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -1145,8 +1193,8 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		light_lightness_get(model, ctx, buf);
-		return;
+		(void)light_lightness_get(model, ctx, buf);
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1157,13 +1205,13 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1181,8 +1229,8 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(ACTUAL);
 	} else {
-		light_lightness_get(model, ctx, buf);
-		return;
+		(void)light_lightness_get(model, ctx, buf);
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1191,14 +1239,16 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	}
 
 	ctl->transition->just_started = true;
-	light_lightness_get(model, ctx, buf);
+	(void)light_lightness_get(model, ctx, buf);
 	light_lightness_publish(model);
 	light_lightness_actual_handler();
+
+	return 0;
 }
 
-static void light_lightness_linear_get(struct bt_mesh_model *model,
-				       struct bt_mesh_msg_ctx *ctx,
-				       struct net_buf_simple *buf)
+static int light_lightness_linear_get(struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -1220,6 +1270,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessLin Status response\n");
 	}
+
+	return 0;
 }
 
 void light_lightness_linear_publish(struct bt_mesh_model *model)
@@ -1247,9 +1299,9 @@ void light_lightness_linear_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
-					     struct bt_mesh_msg_ctx *ctx,
-					     struct net_buf_simple *buf)
+static int light_lightness_linear_set_unack(struct bt_mesh_model *model,
+					    struct bt_mesh_msg_ctx *ctx,
+					    struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	uint16_t linear;
@@ -1263,7 +1315,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1274,13 +1326,13 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1298,7 +1350,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(LINEAR);
 	} else {
-		return;
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1309,11 +1361,13 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	ctl->transition->just_started = true;
 	light_lightness_linear_publish(model);
 	light_lightness_linear_handler();
+
+	return 0;
 }
 
-static void light_lightness_linear_set(struct bt_mesh_model *model,
-				       struct bt_mesh_msg_ctx *ctx,
-				       struct net_buf_simple *buf)
+static int light_lightness_linear_set(struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	uint16_t linear;
@@ -1327,8 +1381,8 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		light_lightness_linear_get(model, ctx, buf);
-		return;
+		(void)light_lightness_linear_get(model, ctx, buf);
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1339,13 +1393,13 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1363,8 +1417,8 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	if (ctl->light->target != ctl->light->current) {
 		set_transition_values(LINEAR);
 	} else {
-		light_lightness_linear_get(model, ctx, buf);
-		return;
+		(void)light_lightness_linear_get(model, ctx, buf);
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1373,14 +1427,16 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	}
 
 	ctl->transition->just_started = true;
-	light_lightness_linear_get(model, ctx, buf);
+	(void)light_lightness_linear_get(model, ctx, buf);
 	light_lightness_linear_publish(model);
 	light_lightness_linear_handler();
+
+	return 0;
 }
 
-static void light_lightness_last_get(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int light_lightness_last_get(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
 
@@ -1390,11 +1446,13 @@ static void light_lightness_last_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessLast Status response\n");
 	}
+
+	return 0;
 }
 
-static void light_lightness_default_get(struct bt_mesh_model *model,
-					struct bt_mesh_msg_ctx *ctx,
-					struct net_buf_simple *buf)
+static int light_lightness_default_get(struct bt_mesh_model *model,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
 
@@ -1405,11 +1463,13 @@ static void light_lightness_default_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessDef Status response\n");
 	}
+
+	return 0;
 }
 
-static void light_lightness_range_get(struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx,
-				      struct net_buf_simple *buf)
+static int light_lightness_range_get(struct bt_mesh_model *model,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -1423,6 +1483,8 @@ static void light_lightness_range_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessRange Status response\n");
 	}
+
+	return 0;
 }
 
 /* Light Lightness Setup Server message handlers */
@@ -1446,9 +1508,9 @@ static void light_lightness_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_lightness_default_set_unack(struct bt_mesh_model *model,
-					      struct bt_mesh_msg_ctx *ctx,
-					      struct net_buf_simple *buf)
+static int light_lightness_default_set_unack(struct bt_mesh_model *model,
+					     struct bt_mesh_msg_ctx *ctx,
+					     struct net_buf_simple *buf)
 {
 	uint16_t lightness;
 
@@ -1461,11 +1523,13 @@ static void light_lightness_default_set_unack(struct bt_mesh_model *model,
 		light_lightness_default_publish(model);
 		save_on_flash(DEF_STATES);
 	}
+
+	return 0;
 }
 
-static void light_lightness_default_set(struct bt_mesh_model *model,
-					struct bt_mesh_msg_ctx *ctx,
-					struct net_buf_simple *buf)
+static int light_lightness_default_set(struct bt_mesh_model *model,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
 {
 	uint16_t lightness;
 
@@ -1475,12 +1539,14 @@ static void light_lightness_default_set(struct bt_mesh_model *model,
 	if (ctl->light->def != lightness) {
 		ctl->light->def = lightness;
 
-		light_lightness_default_get(model, ctx, buf);
+		(void)light_lightness_default_get(model, ctx, buf);
 		light_lightness_default_publish(model);
 		save_on_flash(DEF_STATES);
 	} else {
-		light_lightness_default_get(model, ctx, buf);
+		(void)light_lightness_default_get(model, ctx, buf);
 	}
+
+	return 0;
 }
 
 static void light_lightness_range_publish(struct bt_mesh_model *model)
@@ -1503,9 +1569,9 @@ static void light_lightness_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_lightness_range_set_unack(struct bt_mesh_model *model,
-					    struct bt_mesh_msg_ctx *ctx,
-					    struct net_buf_simple *buf)
+static int light_lightness_range_set_unack(struct bt_mesh_model *model,
+					   struct bt_mesh_msg_ctx *ctx,
+					   struct net_buf_simple *buf)
 {
 	uint16_t min, max;
 
@@ -1513,7 +1579,7 @@ static void light_lightness_range_set_unack(struct bt_mesh_model *model,
 	max = net_buf_simple_pull_le16(buf);
 
 	if (min == 0U || max == 0U) {
-		return;
+		return 0;
 	}
 
 	if (min <= max) {
@@ -1531,13 +1597,15 @@ static void light_lightness_range_set_unack(struct bt_mesh_model *model,
 	} else {
 		/* The provided value for Range Max cannot be set */
 		ctl->light->status_code = CANNOT_SET_RANGE_MAX;
-		return;
+		return 0;
 	}
+
+	return 0;
 }
 
-static void light_lightness_range_set(struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx,
-				      struct net_buf_simple *buf)
+static int light_lightness_range_set(struct bt_mesh_model *model,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
 {
 	uint16_t min, max;
 
@@ -1545,7 +1613,7 @@ static void light_lightness_range_set(struct bt_mesh_model *model,
 	max = net_buf_simple_pull_le16(buf);
 
 	if (min == 0U || max == 0U) {
-		return;
+		return 0;
 	}
 
 	if (min <= max) {
@@ -1557,23 +1625,25 @@ static void light_lightness_range_set(struct bt_mesh_model *model,
 			ctl->light->range_min = min;
 			ctl->light->range_max = max;
 
-			light_lightness_range_get(model, ctx, buf);
+			(void)light_lightness_range_get(model, ctx, buf);
 			light_lightness_range_publish(model);
 			save_on_flash(LIGHTNESS_RANGE);
 		} else {
-			light_lightness_range_get(model, ctx, buf);
+			(void)light_lightness_range_get(model, ctx, buf);
 		}
 	} else {
 		/* The provided value for Range Max cannot be set */
 		ctl->light->status_code = CANNOT_SET_RANGE_MAX;
-		return;
+		return 0;
 	}
+
+	return 0;
 }
 
 /* Light Lightness Client message handlers */
-static void light_lightness_status(struct bt_mesh_model *model,
-				   struct bt_mesh_msg_ctx *ctx,
-				   struct net_buf_simple *buf)
+static int light_lightness_status(struct bt_mesh_model *model,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (Actual)\n");
 	printk("Present Lightness = %04x\n", net_buf_simple_pull_le16(buf));
@@ -1583,11 +1653,13 @@ static void light_lightness_status(struct bt_mesh_model *model,
 		       net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
-static void light_lightness_linear_status(struct bt_mesh_model *model,
-					  struct bt_mesh_msg_ctx *ctx,
-					  struct net_buf_simple *buf)
+static int light_lightness_linear_status(struct bt_mesh_model *model,
+					 struct bt_mesh_msg_ctx *ctx,
+					 struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (Linear)\n");
 	printk("Present Lightness = %04x\n", net_buf_simple_pull_le16(buf));
@@ -1597,38 +1669,46 @@ static void light_lightness_linear_status(struct bt_mesh_model *model,
 		       net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
-static void light_lightness_last_status(struct bt_mesh_model *model,
-					struct bt_mesh_msg_ctx *ctx,
-					struct net_buf_simple *buf)
+static int light_lightness_last_status(struct bt_mesh_model *model,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (Last)\n");
 	printk("Lightness = %04x\n", net_buf_simple_pull_le16(buf));
+
+	return 0;
 }
 
-static void light_lightness_default_status(struct bt_mesh_model *model,
-					   struct bt_mesh_msg_ctx *ctx,
-					   struct net_buf_simple *buf)
+static int light_lightness_default_status(struct bt_mesh_model *model,
+					  struct bt_mesh_msg_ctx *ctx,
+					  struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (Default)\n");
 	printk("Lightness = %04x\n", net_buf_simple_pull_le16(buf));
+
+	return 0;
 }
 
-static void light_lightness_range_status(struct bt_mesh_model *model,
-					 struct bt_mesh_msg_ctx *ctx,
-					 struct net_buf_simple *buf)
+static int light_lightness_range_status(struct bt_mesh_model *model,
+					struct bt_mesh_msg_ctx *ctx,
+					struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (Lightness Range)\n");
 	printk("Status Code = %02x\n", net_buf_simple_pull_u8(buf));
 	printk("Range Min = %04x\n", net_buf_simple_pull_le16(buf));
 	printk("Range Max = %04x\n", net_buf_simple_pull_le16(buf));
+
+	return 0;
 }
 
 /* Light CTL Server message handlers */
-static void light_ctl_get(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int light_ctl_get(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
 
@@ -1652,6 +1732,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Status response\n");
 	}
+
+	return 0;
 }
 
 void light_ctl_publish(struct bt_mesh_model *model)
@@ -1684,9 +1766,9 @@ void light_ctl_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_ctl_set_unack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int light_ctl_set_unack(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta_uv;
@@ -1699,7 +1781,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -1707,7 +1789,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1718,13 +1800,13 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1746,7 +1828,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	    ctl->duv->target != ctl->duv->current) {
 		set_transition_values(CTL_LIGHT);
 	} else {
-		return;
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1759,11 +1841,13 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	ctl->transition->just_started = true;
 	light_ctl_publish(model);
 	light_ctl_handler();
+
+	return 0;
 }
 
-static void light_ctl_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int light_ctl_set(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta_uv;
@@ -1776,7 +1860,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -1784,8 +1868,8 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		light_ctl_get(model, ctx, buf);
-		return;
+		(void)light_ctl_get(model, ctx, buf);
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -1796,13 +1880,13 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -1824,8 +1908,8 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	    ctl->duv->target != ctl->duv->current) {
 		set_transition_values(CTL_LIGHT);
 	} else {
-		light_ctl_get(model, ctx, buf);
-		return;
+		(void)light_ctl_get(model, ctx, buf);
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -1836,14 +1920,16 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	}
 
 	ctl->transition->just_started = true;
-	light_ctl_get(model, ctx, buf);
+	(void)light_ctl_get(model, ctx, buf);
 	light_ctl_publish(model);
 	light_ctl_handler();
+
+	return 0;
 }
 
-static void light_ctl_temp_range_get(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int light_ctl_temp_range_get(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -1857,11 +1943,13 @@ static void light_ctl_temp_range_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Temp Range Status response\n");
 	}
+
+	return 0;
 }
 
-static void light_ctl_default_get(struct bt_mesh_model *model,
-				  struct bt_mesh_msg_ctx *ctx,
-				  struct net_buf_simple *buf)
+static int light_ctl_default_get(struct bt_mesh_model *model,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 6 + 4);
 
@@ -1873,6 +1961,8 @@ static void light_ctl_default_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Default Status response\n");
 	}
+
+	return 0;
 }
 
 /* Light CTL Setup Server message handlers */
@@ -1897,7 +1987,7 @@ static void light_ctl_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_ctl_default_set_unack(struct bt_mesh_model *model,
+static int light_ctl_default_set_unack(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -1909,7 +1999,7 @@ static void light_ctl_default_set_unack(struct bt_mesh_model *model,
 	delta_uv = (int16_t) net_buf_simple_pull_le16(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	lightness = constrain_lightness(lightness);
@@ -1924,11 +2014,13 @@ static void light_ctl_default_set_unack(struct bt_mesh_model *model,
 		light_ctl_default_publish(model);
 		save_on_flash(DEF_STATES);
 	}
+
+	return 0;
 }
 
-static void light_ctl_default_set(struct bt_mesh_model *model,
-				  struct bt_mesh_msg_ctx *ctx,
-				  struct net_buf_simple *buf)
+static int light_ctl_default_set(struct bt_mesh_model *model,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
 {
 	uint16_t lightness, temp;
 	int16_t delta_uv;
@@ -1938,7 +2030,7 @@ static void light_ctl_default_set(struct bt_mesh_model *model,
 	delta_uv = (int16_t) net_buf_simple_pull_le16(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	lightness = constrain_lightness(lightness);
@@ -1950,12 +2042,14 @@ static void light_ctl_default_set(struct bt_mesh_model *model,
 		ctl->temp->def = temp;
 		ctl->duv->def = delta_uv;
 
-		light_ctl_default_get(model, ctx, buf);
+		(void)light_ctl_default_get(model, ctx, buf);
 		light_ctl_default_publish(model);
 		save_on_flash(DEF_STATES);
 	} else {
-		light_ctl_default_get(model, ctx, buf);
+		(void)light_ctl_default_get(model, ctx, buf);
 	}
+
+	return 0;
 }
 
 static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
@@ -1978,9 +2072,9 @@ static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
-					   struct bt_mesh_msg_ctx *ctx,
-					   struct net_buf_simple *buf)
+static int light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
+					  struct bt_mesh_msg_ctx *ctx,
+					  struct net_buf_simple *buf)
 {
 	uint16_t min, max;
 
@@ -1990,7 +2084,7 @@ static void light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
 	/* This is as per 6.1.3.1 in Mesh Model Specification */
 	if (min < TEMP_MIN || min > TEMP_MAX ||
 	    max < TEMP_MIN || max > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	if (min <= max) {
@@ -2008,13 +2102,15 @@ static void light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
 	} else {
 		/* The provided value for Range Max cannot be set */
 		ctl->temp->status_code = CANNOT_SET_RANGE_MAX;
-		return;
+		return 0;
 	}
+
+	return 0;
 }
 
-static void light_ctl_temp_range_set(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int light_ctl_temp_range_set(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	uint16_t min, max;
 
@@ -2024,7 +2120,7 @@ static void light_ctl_temp_range_set(struct bt_mesh_model *model,
 	/* This is as per 6.1.3.1 in Mesh Model Specification */
 	if (min < TEMP_MIN || min > TEMP_MAX ||
 	    max < TEMP_MIN || max > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	if (min <= max) {
@@ -2036,23 +2132,25 @@ static void light_ctl_temp_range_set(struct bt_mesh_model *model,
 			ctl->temp->range_min = min;
 			ctl->temp->range_max = max;
 
-			light_ctl_temp_range_get(model, ctx, buf);
+			(void)light_ctl_temp_range_get(model, ctx, buf);
 			light_ctl_temp_range_publish(model);
 			save_on_flash(TEMPERATURE_RANGE);
 		} else {
-			light_ctl_temp_range_get(model, ctx, buf);
+			(void)light_ctl_temp_range_get(model, ctx, buf);
 		}
 	} else {
 		/* The provided value for Range Max cannot be set */
 		ctl->temp->status_code = CANNOT_SET_RANGE_MAX;
-		return;
+		return 0;
 	}
+
+	return 0;
 }
 
 /* Light CTL Client message handlers */
-static void light_ctl_status(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int light_ctl_status(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_CTL_SRV\n");
 	printk("Present CTL Lightness = %04x\n", net_buf_simple_pull_le16(buf));
@@ -2066,21 +2164,25 @@ static void light_ctl_status(struct bt_mesh_model *model,
 		       net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
-static void light_ctl_temp_range_status(struct bt_mesh_model *model,
-					struct bt_mesh_msg_ctx *ctx,
-					struct net_buf_simple *buf)
+static int light_ctl_temp_range_status(struct bt_mesh_model *model,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_CTL_SRV (Temperature Range)\n");
 	printk("Status Code = %02x\n", net_buf_simple_pull_u8(buf));
 	printk("Range Min = %04x\n", net_buf_simple_pull_le16(buf));
 	printk("Range Max = %04x\n", net_buf_simple_pull_le16(buf));
+
+	return 0;
 }
 
-static void light_ctl_temp_status(struct bt_mesh_model *model,
-				  struct bt_mesh_msg_ctx *ctx,
-				  struct net_buf_simple *buf)
+static int light_ctl_temp_status(struct bt_mesh_model *model,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_CTL_TEMP_SRV\n");
 	printk("Present CTL Temperature = %04x\n",
@@ -2095,22 +2197,26 @@ static void light_ctl_temp_status(struct bt_mesh_model *model,
 		       net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
-static void light_ctl_default_status(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int light_ctl_default_status(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from LIGHT_CTL_SRV (Default)\n");
 	printk("Lightness = %04x\n", net_buf_simple_pull_le16(buf));
 	printk("Temperature = %04x\n", net_buf_simple_pull_le16(buf));
 	printk("Delta UV = %04x\n", net_buf_simple_pull_le16(buf));
+
+	return 0;
 }
 
 /* Light CTL Temp. Server message handlers */
-static void light_ctl_temp_get(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
+static int light_ctl_temp_get(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
 
@@ -2134,6 +2240,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Temp. Status response\n");
 	}
+
+	return 0;
 }
 
 void light_ctl_temp_publish(struct bt_mesh_model *model)
@@ -2162,9 +2270,9 @@ void light_ctl_temp_publish(struct bt_mesh_model *model)
 	}
 }
 
-static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int light_ctl_temp_set_unack(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta_uv;
@@ -2176,7 +2284,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -2184,7 +2292,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -2195,13 +2303,13 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -2221,7 +2329,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	    ctl->duv->target != ctl->duv->current) {
 		set_transition_values(CTL_TEMP);
 	} else {
-		return;
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -2233,11 +2341,13 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	ctl->transition->just_started = true;
 	light_ctl_temp_publish(model);
 	light_ctl_temp_handler();
+
+	return 0;
 }
 
-static void light_ctl_temp_set(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
+static int light_ctl_temp_set(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta_uv;
@@ -2249,7 +2359,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (temp < TEMP_MIN || temp > TEMP_MAX) {
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -2257,8 +2367,8 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		light_ctl_temp_get(model, ctx, buf);
-		return;
+		(void)light_ctl_temp_get(model, ctx, buf);
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -2269,13 +2379,13 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -2295,8 +2405,8 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	    ctl->duv->target != ctl->duv->current) {
 		set_transition_values(CTL_TEMP);
 	} else {
-		light_ctl_temp_get(model, ctx, buf);
-		return;
+		(void)light_ctl_temp_get(model, ctx, buf);
+		return 0;
 	}
 
 	/* For Instantaneous Transition */
@@ -2306,15 +2416,17 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	}
 
 	ctl->transition->just_started = true;
-	light_ctl_temp_get(model, ctx, buf);
+	(void)light_ctl_temp_get(model, ctx, buf);
 	light_ctl_temp_publish(model);
 	light_ctl_temp_handler();
+
+	return 0;
 }
 
 /* Generic Level (TEMPERARTURE) Server message handlers */
-static void gen_level_get_temp(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
+static int gen_level_get_temp(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
 
@@ -2335,6 +2447,8 @@ send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_LEVEL_SRV Status response\n");
 	}
+
+	return 0;
 }
 
 void gen_level_publish_temp(struct bt_mesh_model *model)
@@ -2361,310 +2475,15 @@ void gen_level_publish_temp(struct bt_mesh_model *model)
 	}
 }
 
-static void gen_level_set_unack_temp(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	int16_t level;
-	int64_t now;
-
-	level = (int16_t) net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-	set_target(LEVEL_TEMP, &level);
-
-	if (ctl->temp->target != ctl->temp->current) {
-		set_transition_values(LEVEL_TEMP);
-	} else {
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->temp->current = ctl->temp->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_publish_temp(model);
-	level_temp_handler();
-}
-
-static void gen_level_set_temp(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	int16_t level;
-	int64_t now;
-
-	level = (int16_t) net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		gen_level_get_temp(model, ctx, buf);
-		return;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-	set_target(LEVEL_TEMP, &level);
-
-	if (ctl->temp->target != ctl->temp->current) {
-		set_transition_values(LEVEL_TEMP);
-	} else {
-		gen_level_get_temp(model, ctx, buf);
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->temp->current = ctl->temp->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_get_temp(model, ctx, buf);
-	gen_level_publish_temp(model);
-	level_temp_handler();
-}
-
-static void gen_delta_set_unack_temp(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	static int16_t last_level;
-	int32_t target, delta;
-	int64_t now;
-
-	delta = (int32_t) net_buf_simple_pull_le32(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-
-		if (ctl->temp->delta == delta) {
-			return;
-		}
-		target = last_level + delta;
-
-	} else {
-		last_level = (int16_t) get_current(LEVEL_TEMP);
-		target = last_level + delta;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-
-	if (target < INT16_MIN) {
-		target = INT16_MIN;
-	} else if (target > INT16_MAX) {
-		target = INT16_MAX;
-	}
-
-	set_target(LEVEL_TEMP, &target);
-
-	if (ctl->temp->target != ctl->temp->current) {
-		set_transition_values(LEVEL_TEMP);
-	} else {
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->temp->current = ctl->temp->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_publish_temp(model);
-	level_temp_handler();
-}
-
-static void gen_delta_set_temp(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
-{
-	uint8_t tid, tt, delay;
-	static int16_t last_level;
-	int32_t target, delta;
-	int64_t now;
-
-	delta = (int32_t) net_buf_simple_pull_le32(buf);
-	tid = net_buf_simple_pull_u8(buf);
-
-	now = k_uptime_get();
-	if (ctl->last_tid == tid &&
-	    ctl->last_src_addr == ctx->addr &&
-	    ctl->last_dst_addr == ctx->recv_dst &&
-	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-
-		if (ctl->temp->delta == delta) {
-			gen_level_get_temp(model, ctx, buf);
-			return;
-		}
-		target = last_level + delta;
-
-	} else {
-		last_level = (int16_t) get_current(LEVEL_TEMP);
-		target = last_level + delta;
-	}
-
-	switch (buf->len) {
-	case 0x00:      /* No optional fields are available */
-		tt = ctl->tt;
-		delay = 0U;
-		break;
-	case 0x02:      /* Optional fields are available */
-		tt = net_buf_simple_pull_u8(buf);
-		if ((tt & 0x3F) == 0x3F) {
-			return;
-		}
-
-		delay = net_buf_simple_pull_u8(buf);
-		break;
-	default:
-		return;
-	}
-
-	ctl->transition->counter = 0U;
-	k_timer_stop(&ctl->transition->timer);
-
-	ctl->last_tid = tid;
-	ctl->last_src_addr = ctx->addr;
-	ctl->last_dst_addr = ctx->recv_dst;
-	ctl->last_msg_timestamp = now;
-	ctl->transition->tt = tt;
-	ctl->transition->delay = delay;
-	ctl->transition->type = NON_MOVE;
-
-	if (target < INT16_MIN) {
-		target = INT16_MIN;
-	} else if (target > INT16_MAX) {
-		target = INT16_MAX;
-	}
-
-	set_target(LEVEL_TEMP, &target);
-
-	if (ctl->temp->target != ctl->temp->current) {
-		set_transition_values(LEVEL_TEMP);
-	} else {
-		gen_level_get_temp(model, ctx, buf);
-		return;
-	}
-
-	/* For Instantaneous Transition */
-	if (ctl->transition->counter == 0U) {
-		ctl->temp->current = ctl->temp->target;
-	}
-
-	ctl->transition->just_started = true;
-	gen_level_get_temp(model, ctx, buf);
-	gen_level_publish_temp(model);
-	level_temp_handler();
-}
-
-static void gen_move_set_unack_temp(struct bt_mesh_model *model,
+static int gen_level_set_unack_temp(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
-	int16_t delta;
-	uint16_t target;
+	int16_t level;
 	int64_t now;
 
-	delta = (int16_t) net_buf_simple_pull_le16(buf);
+	level = (int16_t) net_buf_simple_pull_le16(buf);
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
@@ -2672,7 +2491,7 @@ static void gen_move_set_unack_temp(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -2683,13 +2502,13 @@ static void gen_move_set_unack_temp(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -2701,36 +2520,266 @@ static void gen_move_set_unack_temp(struct bt_mesh_model *model,
 	ctl->last_msg_timestamp = now;
 	ctl->transition->tt = tt;
 	ctl->transition->delay = delay;
-	ctl->transition->type = MOVE;
-	ctl->temp->delta = delta;
-
-	if (delta < 0) {
-		target = ctl->temp->range_min;
-	} else if (delta > 0) {
-		target = ctl->temp->range_max;
-	} else if (delta == 0) {
-		target = ctl->temp->current;
-	}
-	set_target(MOVE_TEMP, &target);
+	ctl->transition->type = NON_MOVE;
+	set_target(LEVEL_TEMP, &level);
 
 	if (ctl->temp->target != ctl->temp->current) {
-		set_transition_values(MOVE_TEMP);
+		set_transition_values(LEVEL_TEMP);
 	} else {
-		return;
+		return 0;
 	}
 
+	/* For Instantaneous Transition */
 	if (ctl->transition->counter == 0U) {
-		return;
+		ctl->temp->current = ctl->temp->target;
 	}
 
 	ctl->transition->just_started = true;
 	gen_level_publish_temp(model);
 	level_temp_handler();
+
+	return 0;
 }
 
-static void gen_move_set_temp(struct bt_mesh_model *model,
+static int gen_level_set_temp(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	int16_t level;
+	int64_t now;
+
+	level = (int16_t) net_buf_simple_pull_le16(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+		(void)gen_level_get_temp(model, ctx, buf);
+		return 0;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+	set_target(LEVEL_TEMP, &level);
+
+	if (ctl->temp->target != ctl->temp->current) {
+		set_transition_values(LEVEL_TEMP);
+	} else {
+		(void)gen_level_get_temp(model, ctx, buf);
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->temp->current = ctl->temp->target;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get_temp(model, ctx, buf);
+	gen_level_publish_temp(model);
+	level_temp_handler();
+
+	return 0;
+}
+
+static int gen_delta_set_unack_temp(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	static int16_t last_level;
+	int32_t target, delta;
+	int64_t now;
+
+	delta = (int32_t) net_buf_simple_pull_le32(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+
+		if (ctl->temp->delta == delta) {
+			return 0;
+		}
+		target = last_level + delta;
+
+	} else {
+		last_level = (int16_t) get_current(LEVEL_TEMP);
+		target = last_level + delta;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+
+	if (target < INT16_MIN) {
+		target = INT16_MIN;
+	} else if (target > INT16_MAX) {
+		target = INT16_MAX;
+	}
+
+	set_target(LEVEL_TEMP, &target);
+
+	if (ctl->temp->target != ctl->temp->current) {
+		set_transition_values(LEVEL_TEMP);
+	} else {
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->temp->current = ctl->temp->target;
+	}
+
+	ctl->transition->just_started = true;
+	gen_level_publish_temp(model);
+	level_temp_handler();
+
+	return 0;
+}
+
+static int gen_delta_set_temp(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	static int16_t last_level;
+	int32_t target, delta;
+	int64_t now;
+
+	delta = (int32_t) net_buf_simple_pull_le32(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+
+		if (ctl->temp->delta == delta) {
+			(void)gen_level_get_temp(model, ctx, buf);
+			return 0;
+		}
+		target = last_level + delta;
+
+	} else {
+		last_level = (int16_t) get_current(LEVEL_TEMP);
+		target = last_level + delta;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = NON_MOVE;
+
+	if (target < INT16_MIN) {
+		target = INT16_MIN;
+	} else if (target > INT16_MAX) {
+		target = INT16_MAX;
+	}
+
+	set_target(LEVEL_TEMP, &target);
+
+	if (ctl->temp->target != ctl->temp->current) {
+		set_transition_values(LEVEL_TEMP);
+	} else {
+		(void)gen_level_get_temp(model, ctx, buf);
+		return 0;
+	}
+
+	/* For Instantaneous Transition */
+	if (ctl->transition->counter == 0U) {
+		ctl->temp->current = ctl->temp->target;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get_temp(model, ctx, buf);
+	gen_level_publish_temp(model);
+	level_temp_handler();
+
+	return 0;
+}
+
+static int gen_move_set_unack_temp(struct bt_mesh_model *model,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
 	int16_t delta;
@@ -2745,8 +2794,7 @@ static void gen_move_set_temp(struct bt_mesh_model *model,
 	    ctl->last_src_addr == ctx->addr &&
 	    ctl->last_dst_addr == ctx->recv_dst &&
 	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
-		gen_level_get_temp(model, ctx, buf);
-		return;
+		return 0;
 	}
 
 	switch (buf->len) {
@@ -2757,13 +2805,13 @@ static void gen_move_set_temp(struct bt_mesh_model *model,
 	case 0x02:      /* Optional fields are available */
 		tt = net_buf_simple_pull_u8(buf);
 		if ((tt & 0x3F) == 0x3F) {
-			return;
+			return 0;
 		}
 
 		delay = net_buf_simple_pull_u8(buf);
 		break;
 	default:
-		return;
+		return 0;
 	}
 
 	ctl->transition->counter = 0U;
@@ -2790,24 +2838,102 @@ static void gen_move_set_temp(struct bt_mesh_model *model,
 	if (ctl->temp->target != ctl->temp->current) {
 		set_transition_values(MOVE_TEMP);
 	} else {
-		gen_level_get_temp(model, ctx, buf);
-		return;
+		return 0;
 	}
 
 	if (ctl->transition->counter == 0U) {
-		return;
+		return 0;
 	}
 
 	ctl->transition->just_started = true;
-	gen_level_get_temp(model, ctx, buf);
 	gen_level_publish_temp(model);
 	level_temp_handler();
+
+	return 0;
+}
+
+static int gen_move_set_temp(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	uint8_t tid, tt, delay;
+	int16_t delta;
+	uint16_t target;
+	int64_t now;
+
+	delta = (int16_t) net_buf_simple_pull_le16(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	now = k_uptime_get();
+	if (ctl->last_tid == tid &&
+	    ctl->last_src_addr == ctx->addr &&
+	    ctl->last_dst_addr == ctx->recv_dst &&
+	    (now - ctl->last_msg_timestamp <= (6 * MSEC_PER_SEC))) {
+		(void)gen_level_get_temp(model, ctx, buf);
+		return 0;
+	}
+
+	switch (buf->len) {
+	case 0x00:      /* No optional fields are available */
+		tt = ctl->tt;
+		delay = 0U;
+		break;
+	case 0x02:      /* Optional fields are available */
+		tt = net_buf_simple_pull_u8(buf);
+		if ((tt & 0x3F) == 0x3F) {
+			return 0;
+		}
+
+		delay = net_buf_simple_pull_u8(buf);
+		break;
+	default:
+		return 0;
+	}
+
+	ctl->transition->counter = 0U;
+	k_timer_stop(&ctl->transition->timer);
+
+	ctl->last_tid = tid;
+	ctl->last_src_addr = ctx->addr;
+	ctl->last_dst_addr = ctx->recv_dst;
+	ctl->last_msg_timestamp = now;
+	ctl->transition->tt = tt;
+	ctl->transition->delay = delay;
+	ctl->transition->type = MOVE;
+	ctl->temp->delta = delta;
+
+	if (delta < 0) {
+		target = ctl->temp->range_min;
+	} else if (delta > 0) {
+		target = ctl->temp->range_max;
+	} else if (delta == 0) {
+		target = ctl->temp->current;
+	}
+	set_target(MOVE_TEMP, &target);
+
+	if (ctl->temp->target != ctl->temp->current) {
+		set_transition_values(MOVE_TEMP);
+	} else {
+		(void)gen_level_get_temp(model, ctx, buf);
+		return 0;
+	}
+
+	if (ctl->transition->counter == 0U) {
+		return 0;
+	}
+
+	ctl->transition->just_started = true;
+	(void)gen_level_get_temp(model, ctx, buf);
+	gen_level_publish_temp(model);
+	level_temp_handler();
+
+	return 0;
 }
 
 /* Generic Level (TEMPERATURE) Client message handlers */
-static void gen_level_status_temp(struct bt_mesh_model *model,
-				  struct bt_mesh_msg_ctx *ctx,
-				  struct net_buf_simple *buf)
+static int gen_level_status_temp(struct bt_mesh_model *model,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
 {
 	printk("Acknownledgement from GEN_LEVEL_SRV\n");
 	printk("Present Level = %04x\n", net_buf_simple_pull_le16(buf));
@@ -2816,6 +2942,8 @@ static void gen_level_status_temp(struct bt_mesh_model *model,
 		printk("Target Level = %04x\n", net_buf_simple_pull_le16(buf));
 		printk("Remaining Time = %02x\n", net_buf_simple_pull_u8(buf));
 	}
+
+	return 0;
 }
 
 
@@ -2823,164 +2951,164 @@ static void gen_level_status_temp(struct bt_mesh_model *model,
 
 /* Mapping of message handlers for Generic OnOff Server (0x1000) */
 static const struct bt_mesh_model_op gen_onoff_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x01), 0, gen_onoff_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x02), 2, gen_onoff_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x03), 2, gen_onoff_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x01), BT_MESH_LEN_EXACT(0), gen_onoff_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x02), BT_MESH_LEN_MIN(2),   gen_onoff_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x03), BT_MESH_LEN_MIN(2),   gen_onoff_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic OnOff Client (0x1001) */
 static const struct bt_mesh_model_op gen_onoff_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x04), 1, gen_onoff_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x04), BT_MESH_LEN_MIN(1),   gen_onoff_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Level (Light) Server (0x1002) */
 static const struct bt_mesh_model_op gen_level_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x05), 0, gen_level_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x06), 3, gen_level_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x07), 3, gen_level_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x09), 5, gen_delta_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0A), 5, gen_delta_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0B), 3, gen_move_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0C), 3, gen_move_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x05), BT_MESH_LEN_EXACT(0), gen_level_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x06), BT_MESH_LEN_MIN(3),   gen_level_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x07), BT_MESH_LEN_MIN(3),   gen_level_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x09), BT_MESH_LEN_MIN(5),   gen_delta_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0A), BT_MESH_LEN_MIN(5),   gen_delta_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0B), BT_MESH_LEN_MIN(3),   gen_move_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0C), BT_MESH_LEN_MIN(3),   gen_move_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Level (Light) Client (0x1003) */
 static const struct bt_mesh_model_op gen_level_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x08), 2, gen_level_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x08), BT_MESH_LEN_MIN(2),   gen_level_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Default TT Server (0x1004) */
 static const struct bt_mesh_model_op gen_def_trans_time_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0D), 0, gen_def_trans_time_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0E), 1, gen_def_trans_time_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0F), 1, gen_def_trans_time_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0D), BT_MESH_LEN_EXACT(0), gen_def_trans_time_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0E), BT_MESH_LEN_EXACT(1), gen_def_trans_time_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0F), BT_MESH_LEN_EXACT(1), gen_def_trans_time_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Default TT Client (0x1005) */
 static const struct bt_mesh_model_op gen_def_trans_time_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x10), 1, gen_def_trans_time_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x10), BT_MESH_LEN_EXACT(1), gen_def_trans_time_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Power OnOff Server (0x1006) */
 static const struct bt_mesh_model_op gen_power_onoff_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x11), 0, gen_onpowerup_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x11), BT_MESH_LEN_MIN(0),   gen_onpowerup_get },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Power OnOff Setup Server (0x1007) */
 static const struct bt_mesh_model_op gen_power_onoff_setup_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x13), 1, gen_onpowerup_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x14), 1, gen_onpowerup_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x13), BT_MESH_LEN_EXACT(1), gen_onpowerup_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x14), BT_MESH_LEN_EXACT(1), gen_onpowerup_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Power OnOff Client (0x1008) */
 static const struct bt_mesh_model_op gen_power_onoff_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x12), 1, gen_onpowerup_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x12), BT_MESH_LEN_EXACT(1), gen_onpowerup_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light Lightness Server (0x1300) */
 static const struct bt_mesh_model_op light_lightness_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x4B), 0, light_lightness_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x4C), 3, light_lightness_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x4D), 3, light_lightness_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x4F), 0, light_lightness_linear_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x50), 3, light_lightness_linear_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x51), 3,
+	{ BT_MESH_MODEL_OP_2(0x82, 0x4B), BT_MESH_LEN_EXACT(0), light_lightness_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x4C), BT_MESH_LEN_MIN(3),   light_lightness_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x4D), BT_MESH_LEN_MIN(3),   light_lightness_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x4F), BT_MESH_LEN_EXACT(0), light_lightness_linear_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x50), BT_MESH_LEN_MIN(3),   light_lightness_linear_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x51), BT_MESH_LEN_MIN(3),
 	  light_lightness_linear_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x53), 0, light_lightness_last_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x55), 0, light_lightness_default_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x57), 0, light_lightness_range_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x53), BT_MESH_LEN_EXACT(0), light_lightness_last_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x55), BT_MESH_LEN_EXACT(0), light_lightness_default_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x57), BT_MESH_LEN_EXACT(0), light_lightness_range_get },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light Lightness Setup Server (0x1301) */
 static const struct bt_mesh_model_op light_lightness_setup_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x59), 2, light_lightness_default_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5A), 2,
+	{ BT_MESH_MODEL_OP_2(0x82, 0x59), BT_MESH_LEN_EXACT(2), light_lightness_default_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5A), BT_MESH_LEN_EXACT(2),
 	  light_lightness_default_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5B), 4, light_lightness_range_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5C), 4, light_lightness_range_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5B), BT_MESH_LEN_EXACT(4), light_lightness_range_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5C), BT_MESH_LEN_EXACT(4), light_lightness_range_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light Lightness Client (0x1302) */
 static const struct bt_mesh_model_op light_lightness_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x4E), 2, light_lightness_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x52), 2, light_lightness_linear_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x54), 2, light_lightness_last_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x56), 2, light_lightness_default_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x58), 5, light_lightness_range_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x4E), BT_MESH_LEN_MIN(2),   light_lightness_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x52), BT_MESH_LEN_MIN(2),   light_lightness_linear_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x54), BT_MESH_LEN_EXACT(2), light_lightness_last_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x56), BT_MESH_LEN_EXACT(2), light_lightness_default_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x58), BT_MESH_LEN_EXACT(5), light_lightness_range_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light CTL Server (0x1303) */
 static const struct bt_mesh_model_op light_ctl_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5D), 0, light_ctl_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5E), 7, light_ctl_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x5F), 7, light_ctl_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x62), 0, light_ctl_temp_range_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x67), 0, light_ctl_default_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5D), BT_MESH_LEN_EXACT(0), light_ctl_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5E), BT_MESH_LEN_MIN(7),   light_ctl_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x5F), BT_MESH_LEN_MIN(7),   light_ctl_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x62), BT_MESH_LEN_EXACT(0), light_ctl_temp_range_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x67), BT_MESH_LEN_EXACT(0), light_ctl_default_get },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light CTL Setup Server (0x1304) */
 static const struct bt_mesh_model_op light_ctl_setup_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x69), 6, light_ctl_default_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x6A), 6, light_ctl_default_set_unack },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x6B), 4, light_ctl_temp_range_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x6C), 4, light_ctl_temp_range_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x69), BT_MESH_LEN_EXACT(6), light_ctl_default_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x6A), BT_MESH_LEN_EXACT(6), light_ctl_default_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x6B), BT_MESH_LEN_EXACT(4), light_ctl_temp_range_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x6C), BT_MESH_LEN_EXACT(4), light_ctl_temp_range_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light CTL Client (0x1305) */
 static const struct bt_mesh_model_op light_ctl_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x60), 4, light_ctl_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x63), 5, light_ctl_temp_range_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x66), 4, light_ctl_temp_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x68), 6, light_ctl_default_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x60), BT_MESH_LEN_MIN(4),   light_ctl_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x63), BT_MESH_LEN_EXACT(5), light_ctl_temp_range_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x66), BT_MESH_LEN_MIN(4),   light_ctl_temp_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x68), BT_MESH_LEN_EXACT(6), light_ctl_default_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Light CTL Temp. Server (0x1306) */
 static const struct bt_mesh_model_op light_ctl_temp_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x61), 0, light_ctl_temp_get },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x64), 5, light_ctl_temp_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x65), 5, light_ctl_temp_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x61), BT_MESH_LEN_EXACT(0), light_ctl_temp_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x64), BT_MESH_LEN_MIN(5),   light_ctl_temp_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x65), BT_MESH_LEN_MIN(5),   light_ctl_temp_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Vendor (0x4321) */
 static const struct bt_mesh_model_op vnd_ops[] = {
-	{ BT_MESH_MODEL_OP_3(0x01, CID_ZEPHYR), 0, vnd_get },
-	{ BT_MESH_MODEL_OP_3(0x02, CID_ZEPHYR), 3, vnd_set },
-	{ BT_MESH_MODEL_OP_3(0x03, CID_ZEPHYR), 3, vnd_set_unack },
-	{ BT_MESH_MODEL_OP_3(0x04, CID_ZEPHYR), 6, vnd_status },
+	{ BT_MESH_MODEL_OP_3(0x01, CID_ZEPHYR), BT_MESH_LEN_EXACT(0), vnd_get },
+	{ BT_MESH_MODEL_OP_3(0x02, CID_ZEPHYR), BT_MESH_LEN_EXACT(3), vnd_set },
+	{ BT_MESH_MODEL_OP_3(0x03, CID_ZEPHYR), BT_MESH_LEN_EXACT(3), vnd_set_unack },
+	{ BT_MESH_MODEL_OP_3(0x04, CID_ZEPHYR), BT_MESH_LEN_EXACT(6), vnd_status },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Level (Temp.) Server (0x1002) */
 static const struct bt_mesh_model_op gen_level_srv_op_temp[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x05), 0, gen_level_get_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x06), 3, gen_level_set_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x07), 3, gen_level_set_unack_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x09), 5, gen_delta_set_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0A), 5, gen_delta_set_unack_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0B), 3, gen_move_set_temp },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x0C), 3, gen_move_set_unack_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x05), BT_MESH_LEN_EXACT(0), gen_level_get_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x06), BT_MESH_LEN_MIN(3),   gen_level_set_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x07), BT_MESH_LEN_MIN(3),   gen_level_set_unack_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x09), BT_MESH_LEN_MIN(5),   gen_delta_set_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0A), BT_MESH_LEN_MIN(5),   gen_delta_set_unack_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0B), BT_MESH_LEN_MIN(3),   gen_move_set_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x0C), BT_MESH_LEN_MIN(3),   gen_move_set_unack_temp },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Level (Temp.) Client (0x1003) */
 static const struct bt_mesh_model_op gen_level_cli_op_temp[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x08), 2, gen_level_status_temp },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x08), BT_MESH_LEN_MIN(2), gen_level_status_temp },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -99,9 +99,9 @@ static struct bt_mesh_health_srv health_srv = {
 };
 
 /* Generic OnOff Server message handlers */
-static void gen_onoff_get(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int gen_onoff_get(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct led_onoff_state *state = model->user_data;
@@ -114,11 +114,13 @@ static void gen_onoff_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		printk("Unable to send On Off Status response\n");
 	}
+
+	return 0;
 }
 
-static void gen_onoff_set_unack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int gen_onoff_set_unack(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = model->pub->msg;
 	struct led_onoff_state *state = model->user_data;
@@ -132,7 +134,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (onoff > STATE_ON) {
 		printk("Wrong state received\n");
 
-		return;
+		return 0;
 	}
 
 	now = k_uptime_get();
@@ -152,7 +154,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (set_led_state(state->dev_id, onoff)) {
 		printk("Failed to set led state\n");
 
-		return;
+		return 0;
 	}
 
 	/*
@@ -177,21 +179,26 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 			printk("bt_mesh_model_publish err %d\n", err);
 		}
 	}
+
+	return 0;
 }
 
-static void gen_onoff_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int gen_onoff_set(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
-	gen_onoff_set_unack(model, ctx, buf);
-	gen_onoff_get(model, ctx, buf);
+	(void)gen_onoff_set_unack(model, ctx, buf);
+	(void)gen_onoff_get(model, ctx, buf);
+
+	return 0;
 }
 
-static void sensor_desc_get(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int sensor_desc_get(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	/* TODO */
+	return 0;
 }
 
 static void sens_temperature_celsius_fill(struct net_buf_simple *msg)
@@ -246,9 +253,8 @@ static void sensor_create_status(uint16_t id, struct net_buf_simple *msg)
 	}
 }
 
-static void sensor_get(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int sensor_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 1 + MAX_SENS_STATUS_LEN + 4);
 	uint16_t sensor_id;
@@ -259,20 +265,24 @@ static void sensor_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		printk("Unable to send Sensor get status response\n");
 	}
+
+	return 0;
 }
 
-static void sensor_col_get(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int sensor_col_get(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	/* TODO */
+	return 0;
 }
 
-static void sensor_series_get(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int sensor_series_get(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	/* TODO */
+	return 0;
 }
 
 /* Definitions of models publication context (Start) */
@@ -281,18 +291,18 @@ BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_root, NULL, 2 + 3);
 
 /* Mapping of message handlers for Generic OnOff Server (0x1000) */
 static const struct bt_mesh_model_op gen_onoff_srv_op[] = {
-	{ BT_MESH_MODEL_OP_GEN_ONOFF_GET, 0, gen_onoff_get },
-	{ BT_MESH_MODEL_OP_GEN_ONOFF_SET, 2, gen_onoff_set },
-	{ BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK, 2, gen_onoff_set_unack },
+	{ BT_MESH_MODEL_OP_GEN_ONOFF_GET,       BT_MESH_LEN_EXACT(0), gen_onoff_get },
+	{ BT_MESH_MODEL_OP_GEN_ONOFF_SET,       BT_MESH_LEN_MIN(2),   gen_onoff_set },
+	{ BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK, BT_MESH_LEN_MIN(2),   gen_onoff_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Sensor Server (0x1100) */
 static const struct bt_mesh_model_op sensor_srv_op[] = {
-	{ BT_MESH_MODEL_OP_SENS_DESC_GET, 0, sensor_desc_get },
-	{ BT_MESH_MODEL_OP_SENS_GET, 0, sensor_get },
-	{ BT_MESH_MODEL_OP_SENS_COL_GET, 2, sensor_col_get },
-	{ BT_MESH_MODEL_OP_SENS_SERIES_GET, 2, sensor_series_get },
+	{ BT_MESH_MODEL_OP_SENS_DESC_GET,   BT_MESH_LEN_EXACT(0), sensor_desc_get },
+	{ BT_MESH_MODEL_OP_SENS_GET,        BT_MESH_LEN_EXACT(2), sensor_get },
+	{ BT_MESH_MODEL_OP_SENS_COL_GET,    BT_MESH_LEN_EXACT(2), sensor_col_get },
+	{ BT_MESH_MODEL_OP_SENS_SERIES_GET, BT_MESH_LEN_EXACT(2), sensor_series_get },
 };
 
 static struct bt_mesh_model root_models[] = {
@@ -306,9 +316,8 @@ static struct bt_mesh_model root_models[] = {
 		      sensor_srv_op, NULL, NULL),
 };
 
-static void vnd_hello(struct bt_mesh_model *model,
-		      struct bt_mesh_msg_ctx *ctx,
-		      struct net_buf_simple *buf)
+static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf)
 {
 	char str[32];
 	size_t len;
@@ -317,7 +326,7 @@ static void vnd_hello(struct bt_mesh_model *model,
 
 	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
 		printk("Ignoring message from self\n");
-		return;
+		return 0;
 	}
 
 	len = MIN(buf->len, HELLO_MAX);
@@ -330,11 +339,12 @@ static void vnd_hello(struct bt_mesh_model *model,
 	board_show_text(str, false, K_SECONDS(3));
 
 	board_blink_leds();
+
+	return 0;
 }
 
-static void vnd_baduser(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	char str[32];
 	size_t len;
@@ -343,7 +353,7 @@ static void vnd_baduser(struct bt_mesh_model *model,
 
 	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
 		printk("Ignoring message from self\n");
-		return;
+		return 0;
 	}
 
 	len = MIN(buf->len, HELLO_MAX);
@@ -354,17 +364,19 @@ static void vnd_baduser(struct bt_mesh_model *model,
 	board_show_text(str, false, K_SECONDS(3));
 
 	board_blink_leds();
+
+	return 0;
 }
 
-static void vnd_heartbeat(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int vnd_heartbeat(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	uint8_t init_ttl, hops;
 
 	/* Ignore messages from self */
 	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
-		return;
+		return 0;
 	}
 
 	init_ttl = net_buf_simple_pull_u8(buf);
@@ -374,12 +386,14 @@ static void vnd_heartbeat(struct bt_mesh_model *model,
 	       hops, hops == 1U ? "" : "s");
 
 	board_add_heartbeat(ctx->addr, hops);
+
+	return 0;
 }
 
 static const struct bt_mesh_model_op vnd_ops[] = {
-	{ OP_VND_HELLO, 1, vnd_hello },
-	{ OP_VND_HEARTBEAT, 1, vnd_heartbeat },
-	{ OP_VND_BADUSER, 1, vnd_baduser },
+	{ OP_VND_HELLO,     BT_MESH_LEN_MIN(1), vnd_hello },
+	{ OP_VND_HEARTBEAT, BT_MESH_LEN_MIN(1), vnd_heartbeat },
+	{ OP_VND_BADUSER,   BT_MESH_LEN_MIN(1), vnd_baduser },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -660,8 +660,12 @@ void bt_mesh_model_recv(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 			continue;
 		}
 
-		if (buf->len < op->min_len) {
+		if ((op->len >= 0) && (buf->len < (size_t)op->len)) {
 			BT_ERR("Too short message for OpCode 0x%08x", opcode);
+			continue;
+		} else if ((op->len < 0) && (buf->len != (size_t)(-op->len))) {
+			BT_ERR("Invalid message size for OpCode 0x%08x",
+			       opcode);
 			continue;
 		}
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -670,7 +670,7 @@ void bt_mesh_model_recv(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 		 * receive the message.
 		 */
 		net_buf_simple_save(buf, &state);
-		op->func(model, &rx->ctx, buf);
+		(void)op->func(model, &rx->ctx, buf);
 		net_buf_simple_restore(buf, &state);
 	}
 }

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -38,9 +38,9 @@ static int32_t msg_timeout;
 
 static struct bt_mesh_cfg_cli *cli;
 
-static void comp_data_status(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int comp_data_status(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	struct comp_data *param;
 	size_t to_copy;
@@ -51,7 +51,7 @@ static void comp_data_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_DEV_COMP_DATA_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	if (param->page) {
@@ -62,12 +62,14 @@ static void comp_data_status(struct bt_mesh_model *model,
 	net_buf_simple_add_mem(param->comp, buf->data, to_copy);
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void state_status_u8(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf,
-			    uint32_t expect_status)
+static int state_status_u8(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf,
+			   uint32_t expect_status)
 {
 	uint8_t *status;
 
@@ -77,40 +79,42 @@ static void state_status_u8(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, expect_status, ctx->addr,
 				       (void **)&status)) {
-		return;
+		return -ENOENT;
 	}
 
 	*status = net_buf_simple_pull_u8(buf);
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void beacon_status(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int beacon_status(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
-	state_status_u8(model, ctx, buf, OP_BEACON_STATUS);
+	return state_status_u8(model, ctx, buf, OP_BEACON_STATUS);
 }
 
-static void ttl_status(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int ttl_status(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
-	state_status_u8(model, ctx, buf, OP_DEFAULT_TTL_STATUS);
+	return state_status_u8(model, ctx, buf, OP_DEFAULT_TTL_STATUS);
 }
 
-static void friend_status(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int friend_status(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
-	state_status_u8(model, ctx, buf, OP_FRIEND_STATUS);
+	return state_status_u8(model, ctx, buf, OP_FRIEND_STATUS);
 }
 
-static void gatt_proxy_status(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int gatt_proxy_status(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
-	state_status_u8(model, ctx, buf, OP_GATT_PROXY_STATUS);
+	return state_status_u8(model, ctx, buf, OP_GATT_PROXY_STATUS);
 }
 
 struct relay_param {
@@ -118,9 +122,9 @@ struct relay_param {
 	uint8_t *transmit;
 };
 
-static void relay_status(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int relay_status(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	struct relay_param *param;
 
@@ -130,18 +134,20 @@ static void relay_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_RELAY_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	*param->status = net_buf_simple_pull_u8(buf);
 	*param->transmit = net_buf_simple_pull_u8(buf);
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void net_transmit_status(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int net_transmit_status(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	uint8_t *status;
 
@@ -151,12 +157,14 @@ static void net_transmit_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_NET_TRANSMIT_STATUS, ctx->addr,
 				       (void **)&status)) {
-		return;
+		return -ENOENT;
 	}
 
 	*status = net_buf_simple_pull_u8(buf);
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct net_key_param {
@@ -164,9 +172,9 @@ struct net_key_param {
 	uint16_t net_idx;
 };
 
-static void net_key_status(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int net_key_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	struct net_key_param *param;
 	uint16_t net_idx;
@@ -178,7 +186,7 @@ static void net_key_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_NET_KEY_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -186,7 +194,7 @@ static void net_key_status(struct bt_mesh_model *model,
 
 	if (param->net_idx != net_idx) {
 		BT_WARN("Net Key Status key index does not match");
-		return;
+		return -ENOENT;
 	}
 
 	if (param->status) {
@@ -194,6 +202,8 @@ static void net_key_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct net_key_list_param {
@@ -201,9 +211,9 @@ struct net_key_list_param {
 	size_t *key_cnt;
 };
 
-static void net_key_list(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int net_key_list(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	struct net_key_list_param *param;
 	int i;
@@ -214,7 +224,7 @@ static void net_key_list(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_NET_KEY_LIST, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	for (i = 0; i < *param->key_cnt && buf->len >= 3; i += 2) {
@@ -228,10 +238,13 @@ static void net_key_list(struct bt_mesh_model *model,
 	*param->key_cnt = i;
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void node_reset_status(struct bt_mesh_model *model,
-		struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
+static int node_reset_status(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	bool *param = NULL;
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x",
@@ -239,13 +252,15 @@ static void node_reset_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_NODE_RESET_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	if (param) {
 		*param = true;
 	}
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct app_key_param {
@@ -254,9 +269,9 @@ struct app_key_param {
 	uint16_t app_idx;
 };
 
-static void app_key_status(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int app_key_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	struct app_key_param *param;
 	uint16_t net_idx, app_idx;
@@ -268,7 +283,7 @@ static void app_key_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_APP_KEY_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -276,7 +291,7 @@ static void app_key_status(struct bt_mesh_model *model,
 
 	if (param->net_idx != net_idx || param->app_idx != app_idx) {
 		BT_WARN("App Key Status key indices did not match");
-		return;
+		return -ENOENT;
 	}
 
 	if (param->status) {
@@ -284,6 +299,8 @@ static void app_key_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct app_key_list_param {
@@ -293,9 +310,9 @@ struct app_key_list_param {
 	size_t *key_cnt;
 };
 
-static void app_key_list(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int app_key_list(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	struct app_key_list_param *param;
 	uint16_t net_idx;
@@ -308,7 +325,7 @@ static void app_key_list(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_APP_KEY_LIST, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -316,7 +333,7 @@ static void app_key_list(struct bt_mesh_model *model,
 
 	if (param->net_idx != net_idx) {
 		BT_WARN("App Key List Net Key index did not match");
-		return;
+		return -ENOENT;
 	}
 
 	for (i = 0; i < *param->key_cnt && buf->len >= 3; i += 2) {
@@ -333,6 +350,8 @@ static void app_key_list(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct mod_app_param {
@@ -343,9 +362,9 @@ struct mod_app_param {
 	uint16_t cid;
 };
 
-static void mod_app_status(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_app_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, mod_app_idx, mod_id, cid;
 	struct mod_app_param *param;
@@ -357,7 +376,7 @@ static void mod_app_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_MOD_APP_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -376,7 +395,7 @@ static void mod_app_status(struct bt_mesh_model *model,
 	    param->mod_app_idx != mod_app_idx || param->mod_id != mod_id ||
 	    param->cid != cid) {
 		BT_WARN("Model App Status parameters did not match");
-		return;
+		return -ENOENT;
 	}
 
 	if (param->status) {
@@ -384,6 +403,8 @@ static void mod_app_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct mod_member_list_param {
@@ -395,9 +416,9 @@ struct mod_member_list_param {
 	size_t *member_cnt;
 };
 
-static void mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
-				   struct net_buf_simple *buf, bool vnd,
-				   struct mod_member_list_param *param)
+static int mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf, bool vnd,
+				  struct mod_member_list_param *param)
 {
 	uint16_t elem_addr, mod_id, cid;
 	uint8_t status;
@@ -414,12 +435,12 @@ static void mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
 	if (param->elem_addr != elem_addr || param->mod_id != mod_id ||
 	    (vnd && param->cid != cid)) {
 		BT_WARN("Model Member List parameters did not match");
-		return;
+		return -ENOENT;
 	}
 
 	if (buf->len % 2) {
 		BT_WARN("Model Member List invalid length");
-		return;
+		return -EINVAL;
 	}
 
 	for (i = 0; i < *param->member_cnt && buf->len; i++) {
@@ -432,11 +453,13 @@ static void mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void mod_app_list(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int mod_app_list(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	struct mod_member_list_param *param;
 
@@ -446,15 +469,15 @@ static void mod_app_list(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_SIG_MOD_APP_LIST, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
-	mod_member_list_handle(ctx, buf, false, param);
+	return mod_member_list_handle(ctx, buf, false, param);
 }
 
-static void mod_app_list_vnd(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int mod_app_list_vnd(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	struct mod_member_list_param *param;
 
@@ -464,10 +487,10 @@ static void mod_app_list_vnd(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_VND_MOD_APP_LIST, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
-	mod_member_list_handle(ctx, buf, true, param);
+	return mod_member_list_handle(ctx, buf, true, param);
 }
 
 struct mod_pub_param {
@@ -478,7 +501,7 @@ struct mod_pub_param {
 	struct bt_mesh_cfg_mod_pub *pub;
 };
 
-static void mod_pub_status(struct bt_mesh_model *model,
+static int mod_pub_status(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -492,13 +515,13 @@ static void mod_pub_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_MOD_PUB_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	if (param->cid != CID_NVAL) {
 		if (buf->len < 14) {
 			BT_WARN("Unexpected Mod Pub Status with SIG Model");
-			return;
+			return -ENOENT;
 		}
 
 		cid = sys_get_le16(&buf->data[10]);
@@ -506,7 +529,7 @@ static void mod_pub_status(struct bt_mesh_model *model,
 	} else {
 		if (buf->len > 12) {
 			BT_WARN("Unexpected Mod Pub Status with Vendor Model");
-			return;
+			return -ENOENT;
 		}
 
 		cid = CID_NVAL;
@@ -515,7 +538,7 @@ static void mod_pub_status(struct bt_mesh_model *model,
 
 	if (mod_id != param->mod_id || cid != param->cid) {
 		BT_WARN("Mod Pub Model ID or Company ID mismatch");
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -524,7 +547,7 @@ static void mod_pub_status(struct bt_mesh_model *model,
 	if (elem_addr != param->elem_addr) {
 		BT_WARN("Model Pub Status for unexpected element (0x%04x)",
 			elem_addr);
-		return;
+		return -ENOENT;
 	}
 
 	if (param->status) {
@@ -542,6 +565,8 @@ static void mod_pub_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct mod_sub_param {
@@ -553,9 +578,9 @@ struct mod_sub_param {
 	uint16_t cid;
 };
 
-static void mod_sub_status(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_sub_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr, mod_id, cid;
 	struct mod_sub_param *param;
@@ -567,7 +592,7 @@ static void mod_sub_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_MOD_SUB_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	status = net_buf_simple_pull_u8(buf);
@@ -586,7 +611,7 @@ static void mod_sub_status(struct bt_mesh_model *model,
 	    (param->expect_sub && *param->expect_sub != sub_addr) ||
 	    param->cid != cid) {
 		BT_WARN("Model Subscription Status parameters did not match");
-		return;
+		return -ENOENT;
 	}
 
 	if (param->sub_addr) {
@@ -598,11 +623,13 @@ static void mod_sub_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
-static void mod_sub_list(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int mod_sub_list(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	struct mod_member_list_param *param;
 
@@ -612,15 +639,15 @@ static void mod_sub_list(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_MOD_SUB_LIST, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
-	mod_member_list_handle(ctx, buf, false, param);
+	return mod_member_list_handle(ctx, buf, false, param);
 }
 
-static void mod_sub_list_vnd(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int mod_sub_list_vnd(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	struct mod_member_list_param *param;
 
@@ -630,10 +657,10 @@ static void mod_sub_list_vnd(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_MOD_SUB_LIST_VND, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
-	mod_member_list_handle(ctx, buf, true, param);
+	return mod_member_list_handle(ctx, buf, true, param);
 }
 
 struct hb_sub_param {
@@ -641,9 +668,9 @@ struct hb_sub_param {
 	struct bt_mesh_cfg_hb_sub *sub;
 };
 
-static void hb_sub_status(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int hb_sub_status(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	struct hb_sub_param *param;
 
@@ -653,7 +680,7 @@ static void hb_sub_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_HEARTBEAT_SUB_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	*param->status = net_buf_simple_pull_u8(buf);
@@ -666,6 +693,8 @@ static void hb_sub_status(struct bt_mesh_model *model,
 	param->sub->max = net_buf_simple_pull_u8(buf);
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 struct hb_pub_param {
@@ -673,9 +702,9 @@ struct hb_pub_param {
 	struct bt_mesh_cfg_hb_pub *pub;
 };
 
-static void hb_pub_status(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int hb_pub_status(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	struct hb_pub_param *param;
 
@@ -685,7 +714,7 @@ static void hb_pub_status(struct bt_mesh_model *model,
 
 	if (!bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_HEARTBEAT_PUB_STATUS, ctx->addr,
 				       (void **)&param)) {
-		return;
+		return -ENOENT;
 	}
 
 	*param->status = net_buf_simple_pull_u8(buf);
@@ -700,6 +729,8 @@ static void hb_pub_status(struct bt_mesh_model *model,
 	}
 
 	bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
+
+	return 0;
 }
 
 const struct bt_mesh_model_op bt_mesh_cfg_cli_op[] = {

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -750,6 +750,11 @@ static int mod_pub_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	uint8_t *mod_id, status;
 	bool vnd;
 
+	if ((buf->len != 4U) && (buf->len != 6U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -797,6 +802,11 @@ static int mod_pub_set(struct bt_mesh_model *model,
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	bool vnd;
+
+	if ((buf->len != 11U) && (buf->len != 13U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -892,6 +902,11 @@ static int mod_pub_va_set(struct bt_mesh_model *model,
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
 	bool vnd;
+
+	if ((buf->len != 25U) && (buf->len != 27U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -993,6 +1008,11 @@ static int mod_sub_add(struct bt_mesh_model *model,
 	uint16_t *entry;
 	bool vnd;
 
+	if ((buf->len != 6U) && (buf->len != 8U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1065,6 +1085,11 @@ static int mod_sub_del(struct bt_mesh_model *model,
 	uint16_t *match;
 	uint8_t status;
 	bool vnd;
+
+	if ((buf->len != 6U) && (buf->len != 8U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -1143,6 +1168,11 @@ static int mod_sub_overwrite(struct bt_mesh_model *model,
 	uint8_t status;
 	bool vnd;
 
+	if ((buf->len != 6U) && (buf->len != 8U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1209,6 +1239,11 @@ static int mod_sub_del_all(struct bt_mesh_model *model,
 	uint8_t *mod_id;
 	uint8_t status;
 	bool vnd;
+
+	if ((buf->len != 4U) && (buf->len != 6U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -1414,6 +1449,11 @@ static int mod_sub_va_add(struct bt_mesh_model *model,
 	uint8_t status;
 	bool vnd;
 
+	if ((buf->len != 20U) && (buf->len != 22U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1491,6 +1531,11 @@ static int mod_sub_va_del(struct bt_mesh_model *model,
 	uint8_t status;
 	bool vnd;
 
+	if ((buf->len != 20U) && (buf->len != 22U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1557,6 +1602,11 @@ static int mod_sub_va_overwrite(struct bt_mesh_model *model,
 	uint8_t *mod_id;
 	uint8_t status;
 	bool vnd;
+
+	if ((buf->len != 20U) && (buf->len != 22U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -1833,6 +1883,11 @@ static int mod_app_bind(struct bt_mesh_model *model,
 	uint8_t *mod_id, status;
 	bool vnd;
 
+	if ((buf->len != 6U) && (buf->len != 8U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1892,6 +1947,11 @@ static int mod_app_unbind(struct bt_mesh_model *model,
 	uint8_t *mod_id, status;
 	bool vnd;
 
+	if ((buf->len != 6U) && (buf->len != 8U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
+
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
@@ -1949,6 +2009,11 @@ static int mod_app_get(struct bt_mesh_model *model,
 	uint8_t *mod_id, status;
 	uint16_t elem_addr;
 	bool vnd;
+
+	if ((buf->len != 4U) && (buf->len != 6U)) {
+		BT_ERR("The message size for the application opcode is incorrect.");
+		return -EMSGSIZE;
+	}
 
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
@@ -2404,53 +2469,53 @@ static int heartbeat_sub_set(struct bt_mesh_model *model,
 }
 
 const struct bt_mesh_model_op bt_mesh_cfg_srv_op[] = {
-	{ OP_DEV_COMP_DATA_GET,        1,   dev_comp_data_get },
-	{ OP_APP_KEY_ADD,              19,  app_key_add },
-	{ OP_APP_KEY_UPDATE,           19,  app_key_update },
-	{ OP_APP_KEY_DEL,              3,   app_key_del },
-	{ OP_APP_KEY_GET,              2,   app_key_get },
-	{ OP_BEACON_GET,               0,   beacon_get },
-	{ OP_BEACON_SET,               1,   beacon_set },
-	{ OP_DEFAULT_TTL_GET,          0,   default_ttl_get },
-	{ OP_DEFAULT_TTL_SET,          1,   default_ttl_set },
-	{ OP_GATT_PROXY_GET,           0,   gatt_proxy_get },
-	{ OP_GATT_PROXY_SET,           1,   gatt_proxy_set },
-	{ OP_NET_TRANSMIT_GET,         0,   net_transmit_get },
-	{ OP_NET_TRANSMIT_SET,         1,   net_transmit_set },
-	{ OP_RELAY_GET,                0,   relay_get },
-	{ OP_RELAY_SET,                2,   relay_set },
-	{ OP_MOD_PUB_GET,              4,   mod_pub_get },
-	{ OP_MOD_PUB_SET,              11,  mod_pub_set },
-	{ OP_MOD_PUB_VA_SET,           24,  mod_pub_va_set },
-	{ OP_MOD_SUB_ADD,              6,   mod_sub_add },
-	{ OP_MOD_SUB_VA_ADD,           20,  mod_sub_va_add },
-	{ OP_MOD_SUB_DEL,              6,   mod_sub_del },
-	{ OP_MOD_SUB_VA_DEL,           20,  mod_sub_va_del },
-	{ OP_MOD_SUB_OVERWRITE,        6,   mod_sub_overwrite },
-	{ OP_MOD_SUB_VA_OVERWRITE,     20,  mod_sub_va_overwrite },
-	{ OP_MOD_SUB_DEL_ALL,          4,   mod_sub_del_all },
-	{ OP_MOD_SUB_GET,              4,   mod_sub_get },
-	{ OP_MOD_SUB_GET_VND,          6,   mod_sub_get_vnd },
-	{ OP_NET_KEY_ADD,              18,  net_key_add },
-	{ OP_NET_KEY_UPDATE,           18,  net_key_update },
-	{ OP_NET_KEY_DEL,              2,   net_key_del },
-	{ OP_NET_KEY_GET,              0,   net_key_get },
-	{ OP_NODE_IDENTITY_GET,        2,   node_identity_get },
-	{ OP_NODE_IDENTITY_SET,        3,   node_identity_set },
-	{ OP_MOD_APP_BIND,             6,   mod_app_bind },
-	{ OP_MOD_APP_UNBIND,           6,   mod_app_unbind },
-	{ OP_SIG_MOD_APP_GET,          4,   mod_app_get },
-	{ OP_VND_MOD_APP_GET,          6,   mod_app_get },
-	{ OP_NODE_RESET,               0,   node_reset },
-	{ OP_FRIEND_GET,               0,   friend_get },
-	{ OP_FRIEND_SET,               1,   friend_set },
-	{ OP_LPN_TIMEOUT_GET,          2,   lpn_timeout_get },
-	{ OP_KRP_GET,                  2,   krp_get },
-	{ OP_KRP_SET,                  3,   krp_set },
-	{ OP_HEARTBEAT_PUB_GET,        0,   heartbeat_pub_get },
-	{ OP_HEARTBEAT_PUB_SET,        9,   heartbeat_pub_set },
-	{ OP_HEARTBEAT_SUB_GET,        0,   heartbeat_sub_get },
-	{ OP_HEARTBEAT_SUB_SET,        5,   heartbeat_sub_set },
+	{ OP_DEV_COMP_DATA_GET,        BT_MESH_LEN_EXACT(1),   dev_comp_data_get },
+	{ OP_APP_KEY_ADD,              BT_MESH_LEN_EXACT(19),  app_key_add },
+	{ OP_APP_KEY_UPDATE,           BT_MESH_LEN_EXACT(19),  app_key_update },
+	{ OP_APP_KEY_DEL,              BT_MESH_LEN_EXACT(3),   app_key_del },
+	{ OP_APP_KEY_GET,              BT_MESH_LEN_EXACT(2),   app_key_get },
+	{ OP_BEACON_GET,               BT_MESH_LEN_EXACT(0),   beacon_get },
+	{ OP_BEACON_SET,               BT_MESH_LEN_EXACT(1),   beacon_set },
+	{ OP_DEFAULT_TTL_GET,          BT_MESH_LEN_EXACT(0),   default_ttl_get },
+	{ OP_DEFAULT_TTL_SET,          BT_MESH_LEN_EXACT(1),   default_ttl_set },
+	{ OP_GATT_PROXY_GET,           BT_MESH_LEN_EXACT(0),   gatt_proxy_get },
+	{ OP_GATT_PROXY_SET,           BT_MESH_LEN_EXACT(1),   gatt_proxy_set },
+	{ OP_NET_TRANSMIT_GET,         BT_MESH_LEN_EXACT(0),   net_transmit_get },
+	{ OP_NET_TRANSMIT_SET,         BT_MESH_LEN_EXACT(1),   net_transmit_set },
+	{ OP_RELAY_GET,                BT_MESH_LEN_EXACT(0),   relay_get },
+	{ OP_RELAY_SET,                BT_MESH_LEN_EXACT(2),   relay_set },
+	{ OP_MOD_PUB_GET,              BT_MESH_LEN_MIN(4),     mod_pub_get },
+	{ OP_MOD_PUB_SET,              BT_MESH_LEN_MIN(11),    mod_pub_set },
+	{ OP_MOD_PUB_VA_SET,           BT_MESH_LEN_MIN(25),    mod_pub_va_set },
+	{ OP_MOD_SUB_ADD,              BT_MESH_LEN_MIN(6),     mod_sub_add },
+	{ OP_MOD_SUB_VA_ADD,           BT_MESH_LEN_MIN(20),    mod_sub_va_add },
+	{ OP_MOD_SUB_DEL,              BT_MESH_LEN_MIN(6),     mod_sub_del },
+	{ OP_MOD_SUB_VA_DEL,           BT_MESH_LEN_MIN(20),    mod_sub_va_del },
+	{ OP_MOD_SUB_OVERWRITE,        BT_MESH_LEN_MIN(6),     mod_sub_overwrite },
+	{ OP_MOD_SUB_VA_OVERWRITE,     BT_MESH_LEN_MIN(20),    mod_sub_va_overwrite },
+	{ OP_MOD_SUB_DEL_ALL,          BT_MESH_LEN_MIN(4),     mod_sub_del_all },
+	{ OP_MOD_SUB_GET,              BT_MESH_LEN_EXACT(4),   mod_sub_get },
+	{ OP_MOD_SUB_GET_VND,          BT_MESH_LEN_EXACT(6),   mod_sub_get_vnd },
+	{ OP_NET_KEY_ADD,              BT_MESH_LEN_EXACT(18),  net_key_add },
+	{ OP_NET_KEY_UPDATE,           BT_MESH_LEN_EXACT(18),  net_key_update },
+	{ OP_NET_KEY_DEL,              BT_MESH_LEN_EXACT(2),   net_key_del },
+	{ OP_NET_KEY_GET,              BT_MESH_LEN_EXACT(0),   net_key_get },
+	{ OP_NODE_IDENTITY_GET,        BT_MESH_LEN_EXACT(2),   node_identity_get },
+	{ OP_NODE_IDENTITY_SET,        BT_MESH_LEN_EXACT(3),   node_identity_set },
+	{ OP_MOD_APP_BIND,             BT_MESH_LEN_MIN(6),     mod_app_bind },
+	{ OP_MOD_APP_UNBIND,           BT_MESH_LEN_MIN(6),     mod_app_unbind },
+	{ OP_SIG_MOD_APP_GET,          BT_MESH_LEN_MIN(4),     mod_app_get },
+	{ OP_VND_MOD_APP_GET,          BT_MESH_LEN_MIN(6),     mod_app_get },
+	{ OP_NODE_RESET,               BT_MESH_LEN_EXACT(0),   node_reset },
+	{ OP_FRIEND_GET,               BT_MESH_LEN_EXACT(0),   friend_get },
+	{ OP_FRIEND_SET,               BT_MESH_LEN_EXACT(1),   friend_set },
+	{ OP_LPN_TIMEOUT_GET,          BT_MESH_LEN_EXACT(2),   lpn_timeout_get },
+	{ OP_KRP_GET,                  BT_MESH_LEN_EXACT(2),   krp_get },
+	{ OP_KRP_SET,                  BT_MESH_LEN_EXACT(3),   krp_set },
+	{ OP_HEARTBEAT_PUB_GET,        BT_MESH_LEN_EXACT(0),   heartbeat_pub_get },
+	{ OP_HEARTBEAT_PUB_SET,        BT_MESH_LEN_EXACT(9),   heartbeat_pub_set },
+	{ OP_HEARTBEAT_SUB_GET,        BT_MESH_LEN_EXACT(0),   heartbeat_sub_get },
+	{ OP_HEARTBEAT_SUB_SET,        BT_MESH_LEN_EXACT(5),   heartbeat_sub_set },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -111,12 +111,13 @@ static int comp_get_page_0(struct net_buf_simple *buf)
 	return 0;
 }
 
-static void dev_comp_data_get(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int dev_comp_data_get(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	uint8_t page;
+	int err;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -131,14 +132,17 @@ static void dev_comp_data_get(struct bt_mesh_model *model,
 	bt_mesh_model_msg_init(&sdu, OP_DEV_COMP_DATA_STATUS);
 
 	net_buf_simple_add_u8(&sdu, page);
-	if (comp_get_page_0(&sdu) < 0) {
+	err = comp_get_page_0(&sdu);
+	if (err) {
 		BT_ERR("Unable to get composition page 0");
-		return;
+		return err;
 	}
 
 	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Device Composition Status response");
 	}
+
+	return err;
 }
 
 static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
@@ -319,10 +323,10 @@ static uint8_t mod_unbind(struct bt_mesh_model *model, uint16_t key_idx, bool st
 	return STATUS_SUCCESS;
 }
 
-static void send_app_key_status(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				uint8_t status,
-				uint16_t app_idx, uint16_t net_idx)
+static int send_app_key_status(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       uint8_t status,
+			       uint16_t app_idx, uint16_t net_idx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_STATUS, 4);
 
@@ -333,11 +337,13 @@ static void send_app_key_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send App Key Status response");
 	}
+
+	return 0;
 }
 
-static void app_key_add(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int app_key_add(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t key_net_idx, key_app_idx;
 	uint8_t status;
@@ -348,12 +354,12 @@ static void app_key_add(struct bt_mesh_model *model,
 
 	status = bt_mesh_app_key_add(key_app_idx, key_net_idx, buf->data);
 
-	send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
+	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
-static void app_key_update(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int app_key_update(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint16_t key_net_idx, key_app_idx;
 	uint8_t status;
@@ -365,7 +371,7 @@ static void app_key_update(struct bt_mesh_model *model,
 	status = bt_mesh_app_key_update(key_app_idx, key_net_idx, buf->data);
 	BT_DBG("status 0x%02x", status);
 
-	send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
+	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
 static void mod_app_key_del(struct bt_mesh_model *mod,
@@ -387,9 +393,9 @@ static void app_key_evt(uint16_t app_idx, uint16_t net_idx,
 
 BT_MESH_APP_KEY_CB_DEFINE(app_key_evt);
 
-static void app_key_del(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int app_key_del(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t key_net_idx, key_app_idx;
 	uint8_t status;
@@ -400,15 +406,15 @@ static void app_key_del(struct bt_mesh_model *model,
 
 	status = bt_mesh_app_key_del(key_app_idx, key_net_idx);
 
-	send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
+	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
 /* Index list length: 3 bytes for every pair and 2 bytes for an odd idx */
 #define IDX_LEN(num) (((num) / 2) * 3 + ((num) % 2) * 2)
 
-static void app_key_get(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int app_key_get(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_LIST,
 				 3 + IDX_LEN(CONFIG_BT_MESH_APP_KEY_COUNT));
@@ -421,7 +427,7 @@ static void app_key_get(struct bt_mesh_model *model,
 	get_idx = net_buf_simple_pull_le16(buf);
 	if (get_idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", get_idx);
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("idx 0x%04x", get_idx);
@@ -458,11 +464,13 @@ send_status:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send AppKey List");
 	}
+
+	return 0;
 }
 
-static void beacon_get(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int beacon_get(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BEACON_STATUS, 1);
 
@@ -476,11 +484,13 @@ static void beacon_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Beacon Status response");
 	}
+
+	return 0;
 }
 
-static void beacon_set(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int beacon_set(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BEACON_STATUS, 1);
 
@@ -490,7 +500,7 @@ static void beacon_set(struct bt_mesh_model *model,
 
 	if (buf->data[0] != 0x00 && buf->data[0] != 0x01) {
 		BT_WARN("Invalid Config Beacon value 0x%02x", buf->data[0]);
-		return;
+		return -EINVAL;
 	}
 
 	bt_mesh_beacon_set(buf->data[0]);
@@ -501,11 +511,13 @@ static void beacon_set(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Beacon Status response");
 	}
+
+	return 0;
 }
 
-static void default_ttl_get(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int default_ttl_get(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEFAULT_TTL_STATUS, 1);
 
@@ -519,11 +531,13 @@ static void default_ttl_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Default TTL Status response");
 	}
+
+	return 0;
 }
 
-static void default_ttl_set(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int default_ttl_set(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEFAULT_TTL_STATUS, 1);
 	int err;
@@ -535,7 +549,7 @@ static void default_ttl_set(struct bt_mesh_model *model,
 	err = bt_mesh_default_ttl_set(buf->data[0]);
 	if (err) {
 		BT_WARN("Prohibited Default TTL value 0x%02x", buf->data[0]);
-		return;
+		return err;
 	}
 
 	bt_mesh_model_msg_init(&msg, OP_DEFAULT_TTL_STATUS);
@@ -544,10 +558,12 @@ static void default_ttl_set(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Default TTL Status response");
 	}
+
+	return 0;
 }
 
-static void send_gatt_proxy_status(struct bt_mesh_model *model,
-				   struct bt_mesh_msg_ctx *ctx)
+static int send_gatt_proxy_status(struct bt_mesh_model *model,
+				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_GATT_PROXY_STATUS, 1);
 
@@ -557,22 +573,24 @@ static void send_gatt_proxy_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send GATT Proxy Status");
 	}
+
+	return 0;
 }
 
-static void gatt_proxy_get(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int gatt_proxy_get(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	send_gatt_proxy_status(model, ctx);
+	return send_gatt_proxy_status(model, ctx);
 }
 
-static void gatt_proxy_set(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int gatt_proxy_set(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -580,17 +598,17 @@ static void gatt_proxy_set(struct bt_mesh_model *model,
 
 	if (buf->data[0] != 0x00 && buf->data[0] != 0x01) {
 		BT_WARN("Invalid GATT Proxy value 0x%02x", buf->data[0]);
-		return;
+		return -EINVAL;
 	}
 
 	(void)bt_mesh_gatt_proxy_set(buf->data[0]);
 
-	send_gatt_proxy_status(model, ctx);
+	return send_gatt_proxy_status(model, ctx);
 }
 
-static void net_transmit_get(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int net_transmit_get(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_TRANSMIT_STATUS, 1);
 
@@ -604,11 +622,13 @@ static void net_transmit_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Network Transmit Status");
 	}
+
+	return 0;
 }
 
-static void net_transmit_set(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int net_transmit_set(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_TRANSMIT_STATUS, 1);
 
@@ -628,11 +648,13 @@ static void net_transmit_set(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Network Transmit Status");
 	}
+
+	return 0;
 }
 
-static void relay_get(struct bt_mesh_model *model,
-		      struct bt_mesh_msg_ctx *ctx,
-		      struct net_buf_simple *buf)
+static int relay_get(struct bt_mesh_model *model,
+		     struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_STATUS, 2);
 
@@ -647,11 +669,13 @@ static void relay_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Relay Status response");
 	}
+
+	return 0;
 }
 
-static void relay_set(struct bt_mesh_model *model,
-		      struct bt_mesh_msg_ctx *ctx,
-		      struct net_buf_simple *buf)
+static int relay_set(struct bt_mesh_model *model,
+		     struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_STATUS, 2);
 
@@ -661,7 +685,7 @@ static void relay_set(struct bt_mesh_model *model,
 
 	if (buf->data[0] != 0x00 && buf->data[0] != 0x01) {
 		BT_WARN("Invalid Relay value 0x%02x", buf->data[0]);
-		return;
+		return -EINVAL;
 	}
 
 	(void)bt_mesh_relay_set(buf->data[0], buf->data[1]);
@@ -673,13 +697,15 @@ static void relay_set(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Relay Status response");
 	}
+
+	return 0;
 }
 
-static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
-				struct bt_mesh_msg_ctx *ctx,
-				uint16_t elem_addr, uint16_t pub_addr,
-				bool vnd, struct bt_mesh_model *mod,
-				uint8_t status, uint8_t *mod_id)
+static int send_mod_pub_status(struct bt_mesh_model *cfg_mod,
+			       struct bt_mesh_msg_ctx *ctx, uint16_t elem_addr,
+			       uint16_t pub_addr, bool vnd,
+			       struct bt_mesh_model *mod, uint8_t status,
+			       uint8_t *mod_id)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_STATUS, 14);
 
@@ -711,11 +737,12 @@ static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 	if (bt_mesh_model_send(cfg_mod, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Publication Status");
 	}
+
+	return 0;
 }
 
-static void mod_pub_get(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_pub_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, pub_addr = 0U;
 	struct bt_mesh_model *mod;
@@ -726,7 +753,7 @@ static void mod_pub_get(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	mod_id = buf->data;
@@ -756,13 +783,13 @@ static void mod_pub_get(struct bt_mesh_model *model,
 	status = STATUS_SUCCESS;
 
 send_status:
-	send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
-			    status, mod_id);
+	return send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
+				   status, mod_id);
 }
 
-static void mod_pub_set(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_pub_set(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
@@ -774,7 +801,7 @@ static void mod_pub_set(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	pub_addr = net_buf_simple_pull_le16(buf);
@@ -785,7 +812,7 @@ static void mod_pub_set(struct bt_mesh_model *model,
 	pub_ttl = net_buf_simple_pull_u8(buf);
 	if (pub_ttl > BT_MESH_TTL_MAX && pub_ttl != BT_MESH_TTL_DEFAULT) {
 		BT_ERR("Invalid TTL value 0x%02x", pub_ttl);
-		return;
+		return -EINVAL;
 	}
 
 	pub_period = net_buf_simple_pull_u8(buf);
@@ -818,8 +845,8 @@ static void mod_pub_set(struct bt_mesh_model *model,
 			      pub_period, retransmit, true);
 
 send_status:
-	send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
-			    status, mod_id);
+	return send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
+				   status, mod_id);
 }
 
 static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
@@ -854,9 +881,9 @@ static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 	return clear_count;
 }
 
-static void mod_pub_va_set(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_pub_va_set(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
@@ -869,7 +896,7 @@ static void mod_pub_va_set(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	label_uuid = net_buf_simple_pull_mem(buf, 16);
@@ -879,7 +906,7 @@ static void mod_pub_va_set(struct bt_mesh_model *model,
 	pub_ttl = net_buf_simple_pull_u8(buf);
 	if (pub_ttl > BT_MESH_TTL_MAX && pub_ttl != BT_MESH_TTL_DEFAULT) {
 		BT_ERR("Invalid TTL value 0x%02x", pub_ttl);
-		return;
+		return -EINVAL;
 	}
 
 	pub_period = net_buf_simple_pull_u8(buf);
@@ -921,14 +948,14 @@ static void mod_pub_va_set(struct bt_mesh_model *model,
 	}
 
 send_status:
-	send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
-			    status, mod_id);
+	return send_mod_pub_status(model, ctx, elem_addr, pub_addr, vnd, mod,
+				   status, mod_id);
 }
 
-static void send_mod_sub_status(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx, uint8_t status,
-				uint16_t elem_addr, uint16_t sub_addr, uint8_t *mod_id,
-				bool vnd)
+static int send_mod_sub_status(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
+			       uint16_t elem_addr, uint16_t sub_addr, uint8_t *mod_id,
+			       bool vnd)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_SUB_STATUS, 9);
 
@@ -950,11 +977,13 @@ static void send_mod_sub_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Subscription Status");
 	}
+
+	return 0;
 }
 
-static void mod_sub_add(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_sub_add(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
@@ -967,7 +996,7 @@ static void mod_sub_add(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	sub_addr = net_buf_simple_pull_le16(buf);
@@ -1021,13 +1050,13 @@ static void mod_sub_add(struct bt_mesh_model *model,
 
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
-static void mod_sub_del(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_sub_del(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
@@ -1040,7 +1069,7 @@ static void mod_sub_del(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	sub_addr = net_buf_simple_pull_le16(buf);
@@ -1087,8 +1116,8 @@ static void mod_sub_del(struct bt_mesh_model *model,
 	}
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
 static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod,
@@ -1103,9 +1132,9 @@ static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod,
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static void mod_sub_overwrite(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int mod_sub_overwrite(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
@@ -1117,7 +1146,7 @@ static void mod_sub_overwrite(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	sub_addr = net_buf_simple_pull_le16(buf);
@@ -1166,13 +1195,13 @@ static void mod_sub_overwrite(struct bt_mesh_model *model,
 
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
-static void mod_sub_del_all(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int mod_sub_del_all(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
@@ -1184,7 +1213,7 @@ static void mod_sub_del_all(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("elem_addr 0x%04x", elem_addr);
@@ -1215,8 +1244,8 @@ static void mod_sub_del_all(struct bt_mesh_model *model,
 	status = STATUS_SUCCESS;
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr,
-			    BT_MESH_ADDR_UNASSIGNED, mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr,
+				   BT_MESH_ADDR_UNASSIGNED, mod_id, vnd);
 }
 
 struct mod_sub_list_ctx {
@@ -1256,9 +1285,9 @@ static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod,
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static void mod_sub_get(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_sub_get(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
@@ -1269,7 +1298,7 @@ static void mod_sub_get(struct bt_mesh_model *model,
 	addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	id = net_buf_simple_pull_le16(buf);
@@ -1308,11 +1337,13 @@ send_list:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Subscription List");
 	}
+
+	return 0;
 }
 
-static void mod_sub_get_vnd(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int mod_sub_get_vnd(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
@@ -1323,7 +1354,7 @@ static void mod_sub_get_vnd(struct bt_mesh_model *model,
 	addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	company = net_buf_simple_pull_le16(buf);
@@ -1366,11 +1397,13 @@ send_list:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Vendor Model Subscription List");
 	}
+
+	return 0;
 }
 
-static void mod_sub_va_add(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_sub_va_add(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
@@ -1384,7 +1417,7 @@ static void mod_sub_va_add(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	label_uuid = net_buf_simple_pull_mem(buf, 16);
@@ -1441,13 +1474,13 @@ static void mod_sub_va_add(struct bt_mesh_model *model,
 	status = STATUS_SUCCESS;
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
-static void mod_sub_va_del(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_sub_va_del(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
@@ -1461,7 +1494,7 @@ static void mod_sub_va_del(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	label_uuid = net_buf_simple_pull_mem(buf, 16);
@@ -1509,13 +1542,13 @@ static void mod_sub_va_del(struct bt_mesh_model *model,
 	}
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
-static void mod_sub_va_overwrite(struct bt_mesh_model *model,
-				 struct bt_mesh_msg_ctx *ctx,
-				 struct net_buf_simple *buf)
+static int mod_sub_va_overwrite(struct bt_mesh_model *model,
+				struct bt_mesh_msg_ctx *ctx,
+				struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
 	struct bt_mesh_model *mod;
@@ -1528,7 +1561,7 @@ static void mod_sub_va_overwrite(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	label_uuid = net_buf_simple_pull_mem(buf, 16);
@@ -1573,13 +1606,13 @@ static void mod_sub_va_overwrite(struct bt_mesh_model *model,
 	}
 
 send_status:
-	send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
-			    mod_id, vnd);
+	return send_mod_sub_status(model, ctx, status, elem_addr, sub_addr,
+				   mod_id, vnd);
 }
 
-static void send_net_key_status(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				uint16_t idx, uint8_t status)
+static int send_net_key_status(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx, uint16_t idx,
+			       uint8_t status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_STATUS, 3);
 
@@ -1591,11 +1624,12 @@ static void send_net_key_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send NetKey Status");
 	}
+
+	return 0;
 }
 
-static void net_key_add(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int net_key_add(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint8_t status;
 	uint16_t idx;
@@ -1603,19 +1637,19 @@ static void net_key_add(struct bt_mesh_model *model,
 	idx = net_buf_simple_pull_le16(buf);
 	if (idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("idx 0x%04x", idx);
 
 	status = bt_mesh_subnet_add(idx, buf->data);
 
-	send_net_key_status(model, ctx, idx, status);
+	return send_net_key_status(model, ctx, idx, status);
 }
 
-static void net_key_update(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int net_key_update(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	uint8_t status;
 	uint16_t idx;
@@ -1623,24 +1657,24 @@ static void net_key_update(struct bt_mesh_model *model,
 	idx = net_buf_simple_pull_le16(buf);
 	if (idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	status = bt_mesh_subnet_update(idx, buf->data);
 
-	send_net_key_status(model, ctx, idx, status);
+	return send_net_key_status(model, ctx, idx, status);
 }
 
-static void net_key_del(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int net_key_del(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	uint16_t del_idx;
 
 	del_idx = net_buf_simple_pull_le16(buf);
 	if (del_idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", del_idx);
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("idx 0x%04x", del_idx);
@@ -1649,19 +1683,18 @@ static void net_key_del(struct bt_mesh_model *model,
 	 * The NetKey List must contain a minimum of one NetKey.
 	 */
 	if (ctx->net_idx == del_idx) {
-		send_net_key_status(model, ctx, del_idx,
-				    STATUS_CANNOT_REMOVE);
-		return;
+		return send_net_key_status(model, ctx, del_idx,
+					   STATUS_CANNOT_REMOVE);
 	}
 
-	bt_mesh_subnet_del(del_idx);
+	(void)bt_mesh_subnet_del(del_idx);
 
-	send_net_key_status(model, ctx, del_idx, STATUS_SUCCESS);
+	return send_net_key_status(model, ctx, del_idx, STATUS_SUCCESS);
 }
 
-static void net_key_get(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int net_key_get(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_LIST,
 				 IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
@@ -1687,12 +1720,14 @@ static void net_key_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send NetKey List");
 	}
+
+	return 0;
 }
 
-static void send_node_id_status(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				uint8_t status,
-				uint16_t net_idx, uint8_t node_id)
+static int send_node_id_status(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       uint8_t status,
+			       uint16_t net_idx, uint8_t node_id)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_STATUS, 4);
 
@@ -1704,11 +1739,13 @@ static void send_node_id_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Node Identity Status");
 	}
+
+	return 0;
 }
 
-static void node_identity_get(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int node_identity_get(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	enum bt_mesh_feat_state node_id;
 	uint8_t status;
@@ -1721,17 +1758,17 @@ static void node_identity_get(struct bt_mesh_model *model,
 	idx = net_buf_simple_pull_le16(buf);
 	if (idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	status = bt_mesh_subnet_node_id_get(idx, &node_id);
 
-	send_node_id_status(model, ctx, status, idx, node_id);
+	return send_node_id_status(model, ctx, status, idx, node_id);
 }
 
-static void node_identity_set(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int node_identity_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	uint8_t node_id, status;
 	uint16_t idx;
@@ -1743,30 +1780,28 @@ static void node_identity_set(struct bt_mesh_model *model,
 	idx = net_buf_simple_pull_le16(buf);
 	if (idx > 0xfff) {
 		BT_WARN("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	node_id = net_buf_simple_pull_u8(buf);
 	if (node_id != 0x00 && node_id != 0x01) {
 		BT_WARN("Invalid Node ID value 0x%02x", node_id);
-		return;
+		return -EINVAL;
 	}
 
 	status = bt_mesh_subnet_node_id_set(idx, node_id);
 	if (status == STATUS_INVALID_NETKEY) {
-		send_node_id_status(model, ctx, status, idx,
-				    BT_MESH_NODE_IDENTITY_STOPPED);
-		return;
+		return send_node_id_status(model, ctx, status, idx,
+					   BT_MESH_NODE_IDENTITY_STOPPED);
 	}
 
 	if (status == STATUS_FEAT_NOT_SUPP) {
 		/* Should return success, even if feature isn't supported: */
-		send_node_id_status(model, ctx, STATUS_SUCCESS, idx,
-				    BT_MESH_NODE_IDENTITY_NOT_SUPPORTED);
-		return;
+		return send_node_id_status(model, ctx, STATUS_SUCCESS, idx,
+					   BT_MESH_NODE_IDENTITY_NOT_SUPPORTED);
 	}
 
-	send_node_id_status(model, ctx, status, idx, node_id);
+	return send_node_id_status(model, ctx, status, idx, node_id);
 }
 
 static void create_mod_app_status(struct net_buf_simple *msg,
@@ -1787,9 +1822,9 @@ static void create_mod_app_status(struct net_buf_simple *msg,
 	}
 }
 
-static void mod_app_bind(struct bt_mesh_model *model,
-			 struct bt_mesh_msg_ctx *ctx,
-			 struct net_buf_simple *buf)
+static int mod_app_bind(struct bt_mesh_model *model,
+			struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
@@ -1801,7 +1836,7 @@ static void mod_app_bind(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	key_app_idx = net_buf_simple_pull_le16(buf);
@@ -1842,11 +1877,13 @@ send_status:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model App Bind Status response");
 	}
+
+	return 0;
 }
 
-static void mod_app_unbind(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf)
+static int mod_app_unbind(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
@@ -1858,7 +1895,7 @@ static void mod_app_unbind(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	key_app_idx = net_buf_simple_pull_le16(buf);
@@ -1892,13 +1929,15 @@ send_status:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model App Unbind Status response");
 	}
+
+	return 0;
 }
 
 #define KEY_LIST_LEN (CONFIG_BT_MESH_MODEL_KEY_COUNT * 2)
 
-static void mod_app_get(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx,
-			struct net_buf_simple *buf)
+static int mod_app_get(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg,
 			      MAX(BT_MESH_MODEL_BUF_LEN(OP_VND_MOD_APP_LIST,
@@ -1914,7 +1953,7 @@ static void mod_app_get(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		return -EINVAL;
 	}
 
 	mod_id = buf->data;
@@ -1966,6 +2005,8 @@ send_list:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Application List message");
 	}
+
+	return 0;
 }
 
 static void reset_send_start(uint16_t duration, int err, void *cb_data)
@@ -1981,9 +2022,8 @@ static void reset_send_end(int err, void *cb_data)
 	bt_mesh_reset();
 }
 
-static void node_reset(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	static const struct bt_mesh_send_cb reset_cb = {
 		.start = reset_send_start,
@@ -2001,10 +2041,12 @@ static void node_reset(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, &reset_cb, NULL)) {
 		BT_ERR("Unable to send Node Reset Status");
 	}
+
+	return 0;
 }
 
-static void send_friend_status(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx)
+static int send_friend_status(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_FRIEND_STATUS, 1);
 
@@ -2014,22 +2056,24 @@ static void send_friend_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Friend Status");
 	}
+
+	return 0;
 }
 
-static void friend_get(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int friend_get(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	send_friend_status(model, ctx);
+	return send_friend_status(model, ctx);
 }
 
-static void friend_set(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *ctx,
-		       struct net_buf_simple *buf)
+static int friend_set(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -2037,17 +2081,17 @@ static void friend_set(struct bt_mesh_model *model,
 
 	if (buf->data[0] != 0x00 && buf->data[0] != 0x01) {
 		BT_WARN("Invalid Friend value 0x%02x", buf->data[0]);
-		return;
+		return -EINVAL;
 	}
 
 	(void)bt_mesh_friend_set(buf->data[0]);
 
-	send_friend_status(model, ctx);
+	return send_friend_status(model, ctx);
 }
 
-static void lpn_timeout_get(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    struct net_buf_simple *buf)
+static int lpn_timeout_get(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_LPN_TIMEOUT_STATUS, 5);
 	struct bt_mesh_friend *frnd;
@@ -2061,7 +2105,7 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 
 	if (!BT_MESH_ADDR_IS_UNICAST(lpn_addr)) {
 		BT_WARN("Invalid LPNAddress; ignoring msg");
-		return;
+		return -EINVAL;
 	}
 
 	bt_mesh_model_msg_init(&msg, OP_LPN_TIMEOUT_STATUS);
@@ -2087,11 +2131,13 @@ send_rsp:
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send LPN PollTimeout Status");
 	}
+
+	return 0;
 }
 
-static void send_krp_status(struct bt_mesh_model *model,
-			    struct bt_mesh_msg_ctx *ctx,
-			    uint16_t idx, uint8_t phase, uint8_t status)
+static int send_krp_status(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx, uint16_t idx,
+			   uint8_t phase, uint8_t status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_STATUS, 4);
 
@@ -2104,9 +2150,11 @@ static void send_krp_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Key Refresh State Status");
 	}
+
+	return 0;
 }
 
-static void krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf)
 {
 	uint8_t kr_phase, status;
@@ -2115,18 +2163,18 @@ static void krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	idx = net_buf_simple_pull_le16(buf);
 	if (idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("idx 0x%04x", idx);
 
 	status = bt_mesh_subnet_kr_phase_get(idx, &kr_phase);
 
-	send_krp_status(model, ctx, idx, kr_phase, status);
+	return send_krp_status(model, ctx, idx, kr_phase, status);
 }
 
-static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-		    struct net_buf_simple *buf)
+static int krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		   struct net_buf_simple *buf)
 {
 	uint8_t phase, status;
 	uint16_t idx;
@@ -2136,16 +2184,16 @@ static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	if (idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", idx);
-		return;
+		return -EINVAL;
 	}
 
 	status = bt_mesh_subnet_kr_phase_set(idx, &phase);
 	if (status == STATUS_CANNOT_UPDATE) {
 		BT_ERR("Invalid kr phase transition 0x%02x", phase);
-		return;
+		return -EINVAL;
 	}
 
-	send_krp_status(model, ctx, idx, phase, status);
+	return send_krp_status(model, ctx, idx, phase, status);
 }
 
 static uint8_t hb_pub_count_log(uint16_t val)
@@ -2170,9 +2218,9 @@ struct hb_pub_param {
 	uint16_t net_idx;
 } __packed;
 
-static void hb_pub_send_status(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
-			       const struct bt_mesh_hb_pub *pub)
+static int hb_pub_send_status(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx, uint8_t status,
+			      const struct bt_mesh_hb_pub *pub)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_STATUS, 10);
 
@@ -2192,9 +2240,11 @@ static void hb_pub_send_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Heartbeat Publication Status");
 	}
+
+	return 0;
 }
 
-static void heartbeat_pub_get(struct bt_mesh_model *model,
+static int heartbeat_pub_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2204,12 +2254,12 @@ static void heartbeat_pub_get(struct bt_mesh_model *model,
 
 	bt_mesh_hb_pub_get(&pub);
 
-	hb_pub_send_status(model, ctx, STATUS_SUCCESS, &pub);
+	return hb_pub_send_status(model, ctx, STATUS_SUCCESS, &pub);
 }
 
-static void heartbeat_pub_set(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int heartbeat_pub_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	struct hb_pub_param *param = (void *)buf->data;
 	struct bt_mesh_hb_pub pub;
@@ -2242,23 +2292,23 @@ static void heartbeat_pub_set(struct bt_mesh_model *model,
 
 	if (param->ttl > BT_MESH_TTL_MAX && param->ttl != BT_MESH_TTL_DEFAULT) {
 		BT_ERR("Invalid TTL value 0x%02x", param->ttl);
-		return;
+		return -EINVAL;
 	}
 
 	if (pub.net_idx > 0xfff) {
 		BT_ERR("Invalid NetKeyIndex 0x%04x", pub.net_idx);
-		return;
+		return -EINVAL;
 	}
 
 	status = bt_mesh_hb_pub_set(&pub);
 
 rsp:
-	hb_pub_send_status(model, ctx, status, &pub);
+	return hb_pub_send_status(model, ctx, status, &pub);
 }
 
-static void hb_sub_send_status(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       const struct bt_mesh_hb_sub *sub)
+static int hb_sub_send_status(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_hb_sub *sub)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_STATUS, 9);
 
@@ -2277,9 +2327,11 @@ static void hb_sub_send_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Heartbeat Subscription Status");
 	}
+
+	return 0;
 }
 
-static void heartbeat_sub_get(struct bt_mesh_model *model,
+static int heartbeat_sub_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2289,17 +2341,18 @@ static void heartbeat_sub_get(struct bt_mesh_model *model,
 
 	bt_mesh_hb_sub_get(&sub);
 
-	hb_sub_send_status(model, ctx, &sub);
+	return hb_sub_send_status(model, ctx, &sub);
 }
 
-static void heartbeat_sub_set(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int heartbeat_sub_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	uint8_t period_log, status;
 	struct bt_mesh_hb_sub sub;
 	uint16_t sub_src, sub_dst;
 	uint32_t period;
+	int err;
 
 	BT_DBG("src 0x%04x", ctx->addr);
 
@@ -2312,7 +2365,7 @@ static void heartbeat_sub_set(struct bt_mesh_model *model,
 
 	if (period_log > 0x11) {
 		BT_WARN("Prohibited subscription period 0x%02x", period_log);
-		return;
+		return -EINVAL;
 	}
 
 	period = bt_mesh_hb_pwr2(period_log);
@@ -2322,7 +2375,7 @@ static void heartbeat_sub_set(struct bt_mesh_model *model,
 		/* All errors are caused by invalid packets, which should be
 		 * ignored.
 		 */
-		return;
+		return -EINVAL;
 	}
 
 	bt_mesh_hb_sub_get(&sub);
@@ -2334,7 +2387,10 @@ static void heartbeat_sub_set(struct bt_mesh_model *model,
 		sub.min_hops = BT_MESH_TTL_MAX;
 	}
 
-	hb_sub_send_status(model, ctx, &sub);
+	err = hb_sub_send_status(model, ctx, &sub);
+	if (err) {
+		return err;
+	}
 
 	/* MESH/NODE/CFG/HBS/BV-02-C expects us to return previous
 	 * count value and then reset it to 0.
@@ -2343,6 +2399,8 @@ static void heartbeat_sub_set(struct bt_mesh_model *model,
 	    sub.dst != BT_MESH_ADDR_UNASSIGNED && !period) {
 		bt_mesh_hb_sub_reset_count();
 	}
+
+	return 0;
 }
 
 const struct bt_mesh_model_op bt_mesh_cfg_srv_op[] = {

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -164,10 +164,10 @@ static int health_attention_status(struct bt_mesh_model *model,
 }
 
 const struct bt_mesh_model_op bt_mesh_health_cli_op[] = {
-	{ OP_HEALTH_FAULT_STATUS,    3,   health_fault_status },
-	{ OP_HEALTH_CURRENT_STATUS,  3,   health_current_status },
-	{ OP_HEALTH_PERIOD_STATUS,   1,   health_period_status },
-	{ OP_ATTENTION_STATUS,       1,   health_attention_status },
+	{ OP_HEALTH_FAULT_STATUS,     BT_MESH_LEN_MIN(3),    health_fault_status },
+	{ OP_HEALTH_CURRENT_STATUS,   BT_MESH_LEN_MIN(3),    health_current_status },
+	{ OP_HEALTH_PERIOD_STATUS,    BT_MESH_LEN_EXACT(1),  health_period_status },
+	{ OP_ATTENTION_STATUS,        BT_MESH_LEN_EXACT(1),  health_attention_status },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -279,9 +279,14 @@ static int attention_set(struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
+	int err;
+
 	BT_DBG("");
 
-	attention_set_unrel(model, ctx, buf);
+	err = attention_set_unrel(model, ctx, buf);
+	if (err) {
+		return err;
+	}
 
 	return send_attention_status(model, ctx);
 }
@@ -335,25 +340,30 @@ static int health_period_set(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
+	int err;
+
 	BT_DBG("");
 
-	health_period_set_unrel(model, ctx, buf);
+	err = health_period_set_unrel(model, ctx, buf);
+	if (err) {
+		return err;
+	}
 
 	return send_health_period_status(model, ctx);
 }
 
 const struct bt_mesh_model_op bt_mesh_health_srv_op[] = {
-	{ OP_HEALTH_FAULT_GET,         2,   health_fault_get },
-	{ OP_HEALTH_FAULT_CLEAR,       2,   health_fault_clear },
-	{ OP_HEALTH_FAULT_CLEAR_UNREL, 2,   health_fault_clear_unrel },
-	{ OP_HEALTH_FAULT_TEST,        3,   health_fault_test },
-	{ OP_HEALTH_FAULT_TEST_UNREL,  3,   health_fault_test_unrel },
-	{ OP_HEALTH_PERIOD_GET,        0,   health_period_get },
-	{ OP_HEALTH_PERIOD_SET,        1,   health_period_set },
-	{ OP_HEALTH_PERIOD_SET_UNREL,  1,   health_period_set_unrel },
-	{ OP_ATTENTION_GET,            0,   attention_get },
-	{ OP_ATTENTION_SET,            1,   attention_set },
-	{ OP_ATTENTION_SET_UNREL,      1,   attention_set_unrel },
+	{ OP_HEALTH_FAULT_GET,         BT_MESH_LEN_EXACT(2),   health_fault_get },
+	{ OP_HEALTH_FAULT_CLEAR,       BT_MESH_LEN_EXACT(2),   health_fault_clear },
+	{ OP_HEALTH_FAULT_CLEAR_UNREL, BT_MESH_LEN_EXACT(2),   health_fault_clear_unrel },
+	{ OP_HEALTH_FAULT_TEST,        BT_MESH_LEN_EXACT(3),   health_fault_test },
+	{ OP_HEALTH_FAULT_TEST_UNREL,  BT_MESH_LEN_EXACT(3),   health_fault_test_unrel },
+	{ OP_HEALTH_PERIOD_GET,        BT_MESH_LEN_EXACT(0),   health_period_get },
+	{ OP_HEALTH_PERIOD_SET,        BT_MESH_LEN_EXACT(1),   health_period_set },
+	{ OP_HEALTH_PERIOD_SET_UNREL,  BT_MESH_LEN_EXACT(1),   health_period_set_unrel },
+	{ OP_ATTENTION_GET,            BT_MESH_LEN_EXACT(0),   attention_get },
+	{ OP_ATTENTION_SET,            BT_MESH_LEN_EXACT(1),   attention_set },
+	{ OP_ATTENTION_SET_UNREL,      BT_MESH_LEN_EXACT(1),   attention_set_unrel },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -72,7 +72,6 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 	uint8_t *test_id, *company_ptr;
 	uint16_t company_id;
 	uint8_t fault_count;
-	int err;
 
 	bt_mesh_model_msg_init(msg, OP_HEALTH_CURRENT_STATUS);
 
@@ -82,6 +81,8 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 
 	if (srv->cb && srv->cb->fault_get_cur) {
 		fault_count = net_buf_simple_tailroom(msg);
+		int err;
+
 		err = srv->cb->fault_get_cur(mod, test_id, &company_id,
 					     net_buf_simple_tail(msg),
 					     &fault_count);
@@ -104,9 +105,9 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 	return fault_count;
 }
 
-static void health_fault_get(struct bt_mesh_model *model,
-			     struct bt_mesh_msg_ctx *ctx,
-			     struct net_buf_simple *buf)
+static int health_fault_get(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	uint16_t company_id;
@@ -120,11 +121,13 @@ static void health_fault_get(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
+
+	return 0;
 }
 
-static void health_fault_clear_unrel(struct bt_mesh_model *model,
-				     struct bt_mesh_msg_ctx *ctx,
-				     struct net_buf_simple *buf)
+static int health_fault_clear_unrel(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
 {
 	struct bt_mesh_health_srv *srv = model->user_data;
 	uint16_t company_id;
@@ -134,13 +137,15 @@ static void health_fault_clear_unrel(struct bt_mesh_model *model,
 	BT_DBG("company_id 0x%04x", company_id);
 
 	if (srv->cb && srv->cb->fault_clear) {
-		srv->cb->fault_clear(model, company_id);
+		return srv->cb->fault_clear(model, company_id);
 	}
+
+	return 0;
 }
 
-static void health_fault_clear(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
+static int health_fault_clear(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_health_srv *srv = model->user_data;
@@ -151,7 +156,12 @@ static void health_fault_clear(struct bt_mesh_model *model,
 	BT_DBG("company_id 0x%04x", company_id);
 
 	if (srv->cb && srv->cb->fault_clear) {
-		srv->cb->fault_clear(model, company_id);
+		int err;
+
+		err = srv->cb->fault_clear(model, company_id);
+		if (err) {
+			return err;
+		}
 	}
 
 	health_get_registered(model, company_id, &sdu);
@@ -159,9 +169,11 @@ static void health_fault_clear(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
+
+	return 0;
 }
 
-static void health_fault_test_unrel(struct bt_mesh_model *model,
+static int health_fault_test_unrel(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -175,13 +187,15 @@ static void health_fault_test_unrel(struct bt_mesh_model *model,
 	BT_DBG("test 0x%02x company 0x%04x", test_id, company_id);
 
 	if (srv->cb && srv->cb->fault_test) {
-		srv->cb->fault_test(model, test_id, company_id);
+		return srv->cb->fault_test(model, test_id, company_id);
 	}
+
+	return 0;
 }
 
-static void health_fault_test(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int health_fault_test(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_health_srv *srv = model->user_data;
@@ -201,7 +215,7 @@ static void health_fault_test(struct bt_mesh_model *model,
 		err = srv->cb->fault_test(model, test_id, company_id);
 		if (err) {
 			BT_WARN("Running fault test failed with err %d", err);
-			return;
+			return err;
 		}
 	}
 
@@ -210,10 +224,12 @@ static void health_fault_test(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
+
+	return 0;
 }
 
-static void send_attention_status(struct bt_mesh_model *model,
-				  struct bt_mesh_msg_ctx *ctx)
+static int send_attention_status(struct bt_mesh_model *model,
+				 struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_STATUS, 1);
@@ -231,20 +247,22 @@ static void send_attention_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Attention Status");
 	}
+
+	return 0;
 }
 
-static void attention_get(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int attention_get(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	BT_DBG("");
 
-	send_attention_status(model, ctx);
+	return send_attention_status(model, ctx);
 }
 
-static void attention_set_unrel(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int attention_set_unrel(struct bt_mesh_model *model,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
 {
 	uint8_t time;
 
@@ -253,21 +271,23 @@ static void attention_set_unrel(struct bt_mesh_model *model,
 	BT_DBG("%u second%s", time, (time == 1U) ? "" : "s");
 
 	bt_mesh_attention(model, time);
+
+	return 0;
 }
 
-static void attention_set(struct bt_mesh_model *model,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct net_buf_simple *buf)
+static int attention_set(struct bt_mesh_model *model,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
 	BT_DBG("");
 
 	attention_set_unrel(model, ctx, buf);
 
-	send_attention_status(model, ctx);
+	return send_attention_status(model, ctx);
 }
 
-static void send_health_period_status(struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx)
+static int send_health_period_status(struct bt_mesh_model *model,
+				     struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_STATUS, 1);
@@ -279,18 +299,20 @@ static void send_health_period_status(struct bt_mesh_model *model,
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Health Period Status");
 	}
+
+	return 0;
 }
 
-static void health_period_get(struct bt_mesh_model *model,
+static int health_period_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	BT_DBG("");
 
-	send_health_period_status(model, ctx);
+	return send_health_period_status(model, ctx);
 }
 
-static void health_period_set_unrel(struct bt_mesh_model *model,
+static int health_period_set_unrel(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -299,23 +321,25 @@ static void health_period_set_unrel(struct bt_mesh_model *model,
 	period = net_buf_simple_pull_u8(buf);
 	if (period > 15) {
 		BT_WARN("Prohibited period value %u", period);
-		return;
+		return -EINVAL;
 	}
 
 	BT_DBG("period %u", period);
 
 	model->pub->period_div = period;
+
+	return 0;
 }
 
-static void health_period_set(struct bt_mesh_model *model,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct net_buf_simple *buf)
+static int health_period_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	BT_DBG("");
 
 	health_period_set_unrel(model, ctx, buf);
 
-	send_health_period_status(model, ctx);
+	return send_health_period_status(model, ctx);
 }
 
 const struct bt_mesh_model_op bt_mesh_health_srv_op[] = {


### PR DESCRIPTION
```
3.7.3.4 Message error procedure
When receiving a message that is not understood by an element, it shall
ignore the message.
Note: A message can be falsely identified as a valid message, passing
the NetMIC and TransMIC authentication using a known network key and
application key even though that message was sent using different keys.
The decryption of that message using the wrong keys would result in a
message that is not understood by the element. The probability of such a
situation occurring is small but not insignificant.
A message that is not understood includes messages that have one or more
of the following conditions:
• The application opcode is unknown by the receiving element.
• The access message size for the application opcode is incorrect.
• The application parameters contain values that are currently
Prohibited.
Note: An element that sends an acknowledged message that is not
understood by a peer node will not receive any response message.
```

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>