### PR TITLE
posix: Add missing include

### DIFF
--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -7,6 +7,7 @@
 #ifndef _POSIX_SOC_INF_CLOCK_SOC_H
 #define _POSIX_SOC_INF_CLOCK_SOC_H
 
+#include <toolchain.h>
 #include "board_soc.h"
 #include "posix_soc.h"
 


### PR DESCRIPTION
The NATIVE_TASK macro uses macros from the toolchain header.
Instead of relaying on the header to be included by somebody else,
include it explicity here.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>