### PR TITLE
drivers: led_gpio: minor tweaks

### DIFF
--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -24,7 +24,6 @@ struct led_gpio_config {
 	const struct gpio_dt_spec *led;
 };
 
-
 static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
 
@@ -37,7 +36,7 @@ static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8
 
 	led_gpio = &config->led[led];
 
-	return gpio_pin_set(led_gpio->port, led_gpio->pin, (value >= 50));
+	return gpio_pin_set(led_gpio->port, led_gpio->pin, value > 0);
 }
 
 static int led_gpio_on(const struct device *dev, uint32_t led)
@@ -64,8 +63,7 @@ static int led_gpio_init(const struct device *dev)
 		const struct gpio_dt_spec *led = &config->led[i];
 
 		if (device_is_ready(led->port)) {
-			err = gpio_pin_configure(led->port, led->pin,
-						 led->dt_flags | GPIO_OUTPUT_INACTIVE);
+			err = gpio_pin_configure_dt(led, GPIO_OUTPUT_INACTIVE);
 
 			if (err) {
 				LOG_ERR("Cannot configure GPIO (err %d)", err);

--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -179,6 +179,10 @@ static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
  * This optional routine sets the brightness of a LED to the given value.
  * Calling this function after led_blink() won't affect blinking.
  *
+ * LEDs which can only be turned on or off may provide this function.
+ * These should simply turn the LED on if @p value is nonzero, and off
+ * if @p value is zero.
+ *
  * @param dev LED device
  * @param led LED number
  * @param value Brightness value to set in percent


### PR DESCRIPTION
A follow-up PR since I did not review https://github.com/zephyrproject-rtos/zephyr/pull/34417 in time.

Two minor tweaks and a semantics change:

- fix a whitespace nit
- use gpio_pin_configure_dt()
- turn the LED on in case the percentage is nonzero

The last change patterns this driver after behavior in the Android
lights HAL, which recommends analogous behavior when the user requests
a color change in a non-RGB LED:

    Do your best here. [...] If you can only do on or off, 0 is off,
    anything else is on.

    https://source.android.com/reference/hal/structlight__state__t

I think this behavior makes more sense.
