### PR TITLE
x86: mmu: allow page table extra mappings to have cache disabled

### DIFF
--- a/doc/guides/arch/x86.rst
+++ b/doc/guides/arch/x86.rst
@@ -112,6 +112,8 @@ The argument ``--map`` takes the following value:
 
   - ``X``: Allow execution.
 
+  - ``D``: Cache disabled.
+
     - Default is small page (4KB), supervisor only, read only, and
       execution disabled.
 


### PR DESCRIPTION
This adds the bits to the gen_mmu.py script so that extra mappings
can be added with caching disabled. This is useful for mapping
MMIO regions where caching is not desired.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>