### PR TITLE
soc: x86/ia32: add missing curly braces in soc.h

### DIFF
--- a/soc/x86/ia32/soc.h
+++ b/soc/x86/ia32/soc.h
@@ -53,8 +53,10 @@ static inline int pci_pin2irq(int bus, int dev, int pin)
 {
 	ARG_UNUSED(bus);
 
-	if ((pin < PCI_INTA) || (pin > PCI_INTD))
+	if ((pin < PCI_INTA) || (pin > PCI_INTD)) {
 		return -1;
+	}
+
 	return 10 + (((pin + dev - 1) >> 1) & 1);
 }
 


### PR DESCRIPTION
The if-statement in soc/x86/ia32/soc.h is missing curly braces.
So add them.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>