### PR TITLE
Pointer type to have assignment of NULL instead of numeric zero

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -81,7 +81,7 @@ static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
 
 	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, set_alarm));
 	Z_OOPS(z_user_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(cfg_copy.callback == 0,
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
 	return z_impl_counter_set_channel_alarm((const struct device *)dev,
 						(uint8_t)chan_id,
@@ -107,7 +107,7 @@ static inline int z_vrfy_counter_set_top_value(const struct device *dev,
 
 	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, set_top_value));
 	Z_OOPS(z_user_from_copy(&cfg_copy, cfg, sizeof(cfg_copy)));
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(cfg_copy.callback == 0,
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
 	return z_impl_counter_set_top_value((const struct device *)dev,
 					    (const struct counter_top_cfg *)

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -143,7 +143,7 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 
 	if (z_user_string_copy(name_copy, (char *)name, sizeof(name_copy))
 	    != 0) {
-		return 0;
+		return NULL;
 	}
 
 	return z_impl_device_get_binding(name_copy);

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -135,7 +135,7 @@ void k_work_init(struct k_work *work,
 		  k_work_handler_t handler)
 {
 	__ASSERT_NO_MSG(work != NULL);
-	__ASSERT_NO_MSG(handler != 0);
+	__ASSERT_NO_MSG(handler != NULL);
 
 	*work = (struct k_work)Z_WORK_INITIALIZER(handler);
 }
@@ -669,7 +669,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			bool yield;
 			k_work_handler_t handler = work->handler;
 
-			__ASSERT_NO_MSG(handler != 0);
+			__ASSERT_NO_MSG(handler != NULL);
 
 			if (work_set_running(work, queue)) {
 				handler(work);
@@ -810,7 +810,7 @@ void k_work_init_delayable(struct k_work_delayable *dwork,
 			    k_work_handler_t handler)
 {
 	__ASSERT_NO_MSG(dwork != NULL);
-	__ASSERT_NO_MSG(handler != 0);
+	__ASSERT_NO_MSG(handler != NULL);
 
 	*dwork = (struct k_work_delayable){
 		.work = {

--- a/lib/os/notify.c
+++ b/lib/os/notify.c
@@ -49,7 +49,7 @@ sys_notify_generic_callback sys_notify_finalize(struct sys_notify *notify,
 						    int res)
 {
 	struct k_poll_signal *sig = NULL;
-	sys_notify_generic_callback rv = 0;
+	sys_notify_generic_callback rv = NULL;
 	uint32_t method = sys_notify_get_method(notify);
 
 	/* Store the result and capture secondary notification

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -928,7 +928,7 @@ uint32_t z_vrfy_log_filter_set(struct log_backend const *const backend,
 			    int16_t src_id,
 			    uint32_t level)
 {
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(backend == 0,
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(backend == NULL,
 		"Setting per-backend filters from user mode is not supported"));
 	Z_OOPS(Z_SYSCALL_VERIFY_MSG(domain_id == CONFIG_LOG_DOMAIN_ID,
 		"Invalid log domain_id"));


### PR DESCRIPTION
Changes assignment of numeric zero to NULL for pointer type.

Current usage is a violation of MISRA 11.9.