### PR TITLE
power: npcx: Fix compile error if !CONFIG_ARM_MPU

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx7/power.c
+++ b/soc/arm/nuvoton_npcx/npcx7/power.c
@@ -45,6 +45,7 @@
  * INCLUDE FILES: soc_clock.h
  */
 
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr.h>
 #include <drivers/espi.h>
 #include <power/power.h>


### PR DESCRIPTION
The NPCX power management code gets a compile error if CONFIG_PM is
enabled but CONFIG_ARM_MPU is disabled.

Signed-off-by: Keith Short <keithshort@google.com>