### PR TITLE
Fix flash stm32h7 build failure, by adding dt flash clocks property

### DIFF
--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -8,14 +8,16 @@
 #ifndef ZEPHYR_DRIVERS_FLASH_FLASH_STM32_H_
 #define ZEPHYR_DRIVERS_FLASH_FLASH_STM32_H_
 
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32h7_flash_controller), clocks)
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #endif
 
 struct flash_stm32_priv {
 	FLASH_TypeDef *regs;
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32h7_flash_controller), clocks)
 	/* clock subsystem driving this peripheral */
 	struct stm32_pclken pclken;
 #endif

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -605,8 +605,8 @@ void flash_stm32_page_layout(const struct device *dev,
 
 static struct flash_stm32_priv flash_data = {
 	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
-	.pclken = { .bus = STM32_CLOCK_BUS_AHB3,
-		    .enr = LL_AHB3_GRP1_PERIPH_FLASH },
+	.pclken = { .bus = DT_INST_CLOCKS_CELL(0, bus),
+		    .enr = DT_INST_CLOCKS_CELL(0, bits)},
 };
 
 static const struct flash_driver_api flash_stm32h7_api = {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -44,6 +44,7 @@
 			label = "FLASH_CTRL";
 			reg = <0x52002000 0x400>;
 			interrupts = <4 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000100>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
Add device tree clocks property for stm32h7 series to fix issue #34605 build failure.
Continuation of  #34344.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/34605

Remark: Couldn't run it as I don't have the board.