### PR TITLE
drivers: remove usage of device_pm_control_nop (1)

### DIFF
--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -311,9 +311,9 @@ static const struct adc_driver_api cc32xx_driver_api = {
 	};									 \
 										 \
 	DEVICE_DT_INST_DEFINE(index,						 \
-			      &adc_cc32xx_init, device_pm_control_nop,		 \
-			      &adc_cc32xx_data_##index, &adc_cc32xx_cfg_##index, \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	 \
+			      &adc_cc32xx_init, NULL, &adc_cc32xx_data_##index,	 \
+			      &adc_cc32xx_cfg_##index, POST_KERNEL,		 \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		 \
 			      &cc32xx_driver_api);				 \
 										 \
 	static void adc_cc32xx_cfg_func_##index(void)				 \

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -329,7 +329,7 @@ static struct adc_it8xxx2_data adc_it8xxx2_data_0 = {
 		ADC_CONTEXT_INIT_SYNC(adc_it8xxx2_data_0, ctx),
 };
 DEVICE_DT_INST_DEFINE(0, adc_it8xxx2_init,
-				device_pm_control_nop,
+				NULL,
 				&adc_it8xxx2_data_0,
 				NULL, POST_KERNEL,
 				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1130,7 +1130,7 @@ static const struct adc_driver_api lmp90xxx_adc_api = {
 		.channels = ch, \
 	}; \
 	DEVICE_DT_DEFINE(DT_INST_LMP90XXX(n, t), \
-			 &lmp90xxx_init, device_pm_control_nop, \
+			 &lmp90xxx_init, NULL, \
 			 &lmp##t##_data_##n, \
 			 &lmp##t##_config_##n, POST_KERNEL, \
 			 CONFIG_ADC_LMP90XXX_INIT_PRIORITY, \

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -307,7 +307,7 @@ static struct adc_xec_data adc_xec_dev_data_0 = {
 	ADC_CONTEXT_INIT_SYNC(adc_xec_dev_data_0, ctx),
 };
 
-DEVICE_DT_INST_DEFINE(0, adc_xec_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, adc_xec_init, NULL,
 		    &adc_xec_dev_data_0, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_xec_api);

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -357,7 +357,7 @@ static const struct adc_driver_api mcp320x_adc_api = {
 		.channels = ch, \
 	}; \
 	DEVICE_DT_DEFINE(INST_DT_MCP320X(n, t), \
-			 &mcp320x_init, device_pm_control_nop, \
+			 &mcp320x_init, NULL, \
 			 &mcp##t##_data_##n, \
 			 &mcp##t##_config_##n, POST_KERNEL, \
 			 CONFIG_ADC_MCP320X_INIT_PRIORITY, \

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -284,7 +284,7 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &mcux_adc12_init,			\
-			    device_pm_control_nop, &mcux_adc12_data_##n,\
+			    NULL, &mcux_adc12_data_##n,			\
 			    &mcux_adc12_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &mcux_adc12_driver_api);			\

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -294,7 +294,7 @@ static const struct adc_driver_api mcux_adc16_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &mcux_adc16_init,			\
-			    device_pm_control_nop, &mcux_adc16_data_##n,\
+			    NULL, &mcux_adc16_data_##n,			\
 			    &mcux_adc16_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &mcux_adc16_driver_api);			\

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -394,7 +394,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 	};														\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-		&mcux_lpadc_init, device_pm_control_nop, &mcux_lpadc_data_##n,	\
+		&mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
 		&mcux_lpadc_config_##n, POST_KERNEL,				\
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					\
 		&mcux_lpadc_driver_api);							\

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -322,7 +322,7 @@ static struct adc_npcx_data adc_npcx_data_0 = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    adc_npcx_init, device_pm_control_nop,
+		    adc_npcx_init, NULL,
 		    &adc_npcx_data_0, &adc_npcx_cfg_0,
 		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -290,7 +290,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
 	DEVICE_DT_INST_DEFINE(0,					\
-			    init_adc, device_pm_control_nop, NULL, NULL,\
+			    init_adc, NULL, NULL, NULL,			\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &adc_nrfx_driver_api);

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -429,7 +429,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 		     "multiple instances not supported");		\
 	DEVICE_DT_INST_DEFINE(0,					\
 			    init_saadc,					\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL,					\
 			    NULL,					\
 			    POST_KERNEL,				\

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -602,7 +602,7 @@ do {									\
 		ADC_CONTEXT_INIT_LOCK(adc_sam_data_##n, ctx),		\
 		ADC_CONTEXT_INIT_SYNC(adc_sam_data_##n, ctx),		\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, adc_sam0_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, adc_sam0_init, NULL,			\
 			    &adc_sam_data_##n,				\
 			    &adc_sam_cfg_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -365,7 +365,7 @@ static void adc_sam_isr(const struct device *dev)
 		ADC_CONTEXT_INIT_SYNC(adc##n##_sam_data, ctx),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, adc_sam_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, adc_sam_init, NULL,			\
 			    &adc##n##_sam_data,				\
 			    &adc##n##_sam_cfg, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -785,7 +785,7 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &adc_stm32_init, device_pm_control_nop,		\
+		    &adc_stm32_init, NULL,				\
 		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &api_stm32_driver_api);				\

--- a/drivers/audio/intel_dmic.c
+++ b/drivers/audio/intel_dmic.c
@@ -1450,7 +1450,5 @@ static struct _dmic_ops dmic_ops = {
 	.read = dmic_read_device,
 };
 
-DEVICE_DT_INST_DEFINE(0, &dmic_initialize_device, device_pm_control_nop,
-		      NULL, NULL,
-		      POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY,
-		      &dmic_ops);
+DEVICE_DT_INST_DEFINE(0, &dmic_initialize_device, NULL, NULL, NULL, POST_KERNEL,
+		      CONFIG_AUDIO_DMIC_INIT_PRIORITY, &dmic_ops);

--- a/drivers/audio/mpxxdtyy.c
+++ b/drivers/audio/mpxxdtyy.c
@@ -165,6 +165,6 @@ static int mpxxdtyy_initialize(const struct device *dev)
 
 static struct mpxxdtyy_data mpxxdtyy_data;
 
-DEVICE_DT_INST_DEFINE(0, mpxxdtyy_initialize, device_pm_control_nop,
-		&mpxxdtyy_data, NULL, POST_KERNEL,
-		CONFIG_AUDIO_DMIC_INIT_PRIORITY, &mpxxdtyy_driver_api);
+DEVICE_DT_INST_DEFINE(0, mpxxdtyy_initialize, NULL, &mpxxdtyy_data, NULL,
+		POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY,
+		&mpxxdtyy_driver_api);

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -543,6 +543,6 @@ static const struct audio_codec_api codec_driver_api = {
 	.apply_properties	= codec_apply_properties,
 };
 
-DEVICE_DT_INST_DEFINE(0, codec_initialize, device_pm_control_nop,
-		&codec_device_data, &codec_device_config, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, codec_initialize, NULL, &codec_device_data,
+		&codec_device_config, POST_KERNEL,
 		CONFIG_AUDIO_CODEC_INIT_PRIORITY, &codec_driver_api);

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -293,7 +293,7 @@ static int can_loopback_init(const struct device *dev)
 static struct can_loopback_data can_loopback_dev_data_1;
 
 DEVICE_DEFINE(can_loopback_1, CONFIG_CAN_LOOPBACK_DEV_NAME,
-		    &can_loopback_init, device_pm_control_nop,
+		    &can_loopback_init, NULL,
 		    &can_loopback_dev_data_1, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
@@ -327,7 +327,7 @@ static int socket_can_init_1(const struct device *dev)
 }
 
 NET_DEVICE_INIT(socket_can_loopback_1, SOCKET_CAN_NAME_1, socket_can_init_1,
-		device_pm_control_nop, &socket_can_context_1, NULL,
+		NULL, &socket_can_context_1, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&socket_can_api,
 		CANBUS_RAW_L2, NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2), CAN_MTU);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -970,7 +970,7 @@ static const struct mcp2515_config mcp2515_config_1 = {
 	.sample_point = DT_INST_PROP_OR(0, sample_point, 0)
 };
 
-DEVICE_DT_INST_DEFINE(0, &mcp2515_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &mcp2515_init, NULL,
 		    &mcp2515_data_1, &mcp2515_config_1, POST_KERNEL,
 		    CONFIG_CAN_MCP2515_INIT_PRIORITY, &can_api_funcs);
 
@@ -1002,7 +1002,7 @@ static int socket_can_init(const struct device *dev)
 }
 
 NET_DEVICE_INIT(socket_can_mcp2515_1, SOCKET_CAN_NAME_1, socket_can_init,
-		device_pm_control_nop, &socket_can_context_1, NULL,
+		NULL, &socket_can_context_1, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&socket_can_api,
 		CANBUS_RAW_L2, NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2), CAN_MTU);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -794,7 +794,7 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 	static struct mcux_flexcan_data mcux_flexcan_data_##id;		\
 									\
 	DEVICE_DT_INST_DEFINE(id, &mcux_flexcan_init,			\
-			device_pm_control_nop, &mcux_flexcan_data_##id,	\
+			NULL, &mcux_flexcan_data_##id,	\
 			&mcux_flexcan_config_##id, POST_KERNEL,		\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			&mcux_flexcan_driver_api);			\
@@ -835,7 +835,7 @@ DT_INST_FOREACH_STATUS_OKAY(FLEXCAN_DEVICE_INIT_MCUX)
 	}								\
 									\
 	NET_DEVICE_INIT(socket_can_flexcan_##id, SOCKET_CAN_NAME_##id,	\
-		socket_can_init_##id, device_pm_control_nop,		\
+		socket_can_init_##id, NULL,				\
 		&socket_can_context_##id, NULL,				\
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &socket_can_api,	\
 		CANBUS_RAW_L2, NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2),	\

--- a/drivers/can/can_net.c
+++ b/drivers/can/can_net.c
@@ -401,7 +401,7 @@ static int net_can_init(const struct device *dev)
 static struct net_can_context net_can_context_1;
 
 NET_DEVICE_INIT(net_can_1, CONFIG_CAN_NET_NAME, net_can_init,
-		device_pm_control_nop, &net_can_context_1, NULL,
+		NULL, &net_can_context_1, NULL,
 		CONFIG_CAN_NET_INIT_PRIORITY,
 		&net_can_api_inst,
 		CANBUS_L2, NET_L2_GET_CTX_TYPE(CANBUS_L2), NET_CAN_MTU);

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1150,7 +1150,7 @@ static const struct can_stm32_config can_stm32_cfg_1 = {
 
 static struct can_stm32_data can_stm32_dev_data_1;
 
-DEVICE_DT_DEFINE(DT_NODELABEL(can1), &can_stm32_init, device_pm_control_nop,
+DEVICE_DT_DEFINE(DT_NODELABEL(can1), &can_stm32_init, NULL,
 		    &can_stm32_dev_data_1, &can_stm32_cfg_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
@@ -1212,7 +1212,7 @@ static int socket_can_init_1(const struct device *dev)
 }
 
 NET_DEVICE_INIT(socket_can_stm32_1, SOCKET_CAN_NAME_1, socket_can_init_1,
-		device_pm_control_nop, &socket_can_context_1, NULL,
+		NULL, &socket_can_context_1, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&socket_can_api,
 		CANBUS_RAW_L2, NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2), CAN_MTU);
@@ -1249,7 +1249,7 @@ static const struct can_stm32_config can_stm32_cfg_2 = {
 
 static struct can_stm32_data can_stm32_dev_data_2;
 
-DEVICE_DT_DEFINE(DT_NODELABEL(can2), &can_stm32_init, device_pm_control_nop,
+DEVICE_DT_DEFINE(DT_NODELABEL(can2), &can_stm32_init, NULL,
 		    &can_stm32_dev_data_2, &can_stm32_cfg_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &can_api_funcs);
@@ -1304,7 +1304,7 @@ static int socket_can_init_2(const struct device *dev)
 }
 
 NET_DEVICE_INIT(socket_can_stm32_2, SOCKET_CAN_NAME_2, socket_can_init_2,
-		device_pm_control_nop, &socket_can_context_2, NULL,
+		NULL, &socket_can_context_2, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&socket_can_api,
 		CANBUS_RAW_L2, NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2), CAN_MTU);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:
- `adc`
- `audio`
- `can`