### PR TITLE
drivers: remove usage of device_pm_control_nop (2)

### DIFF
--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -244,7 +244,7 @@ static const struct beetle_clock_control_cfg_t beetle_cc_cfg = {
  */
 DEVICE_DEFINE(clock_control_beetle, CONFIG_ARM_CLOCK_CONTROL_DEV_NAME,
 		    &beetle_clock_control_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &beetle_cc_cfg,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_BEETLE_DEVICE_INIT_PRIORITY,

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -365,7 +365,7 @@ static const struct esp32_clock_config esp32_clock_config0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &clock_control_esp32_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &esp32_clock_config0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &clock_control_esp32_api);

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1786,6 +1786,6 @@ static const struct litex_clk_device ldev_init = {
 	.nclkout = NCLKOUT
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clock0), &litex_clk_init, device_pm_control_nop,
+DEVICE_DT_DEFINE(DT_NODELABEL(clock0), &litex_clk_init, NULL,
 		    NULL, &ldev_init, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &litex_clk_api);

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -395,7 +395,7 @@ static struct lpc11u6x_syscon_data syscon_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &lpc11u6x_syscon_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &syscon_data, &syscon_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &lpc11u6x_clock_control_api);

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -153,7 +153,7 @@ static const struct clock_control_driver_api mcux_ccm_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_ccm_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_ccm_driver_api);

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -66,7 +66,7 @@ static const struct clock_control_driver_api mcux_mcg_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_mcg_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_mcg_driver_api);

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -76,7 +76,7 @@ static const struct clock_control_driver_api mcux_pcc_api = {
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    &mcux_pcc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL, &mcux_pcc##inst##_config,		\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	\

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -125,7 +125,7 @@ static const struct clock_control_driver_api mcux_scg_driver_api = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_scg_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_scg_driver_api);

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -101,7 +101,7 @@ static const struct clock_control_driver_api mcux_sim_driver_api = {
 
 DEVICE_DT_DEFINE(NXP_KINETIS_SIM_NODE,
 		    &mcux_sim_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_sim_driver_api);

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -93,7 +93,7 @@ static const struct clock_control_driver_api mcux_lpc_syscon_api = {
 	\
 DEVICE_DT_INST_DEFINE(n, \
 		    &mcux_lpc_syscon_clock_control_init, \
-		    device_pm_control_nop, \
+		    NULL, \
 		    NULL, NULL, \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 		    &mcux_lpc_syscon_api);

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -193,7 +193,7 @@ const struct npcx_pcc_config pcc_config = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &npcx_clock_control_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pcc_config,
 		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -702,7 +702,7 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, device_pm_control_nop,
+DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, NULL,
 		 &data, &config,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		 &clock_control_api);

--- a/drivers/clock_control/clock_control_rcar_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_rcar_cpg_mssr.c
@@ -218,7 +218,7 @@ static const struct clock_control_driver_api rcar_cpg_mssr_api = {
 								    \
 	DEVICE_DT_INST_DEFINE(inst,				    \
 			      &rcar_cpg_mssr_init,		    \
-			      device_pm_control_nop,		    \
+			      NULL,				    \
 			      NULL, &rcar_mssr##inst##_config,	    \
 			      PRE_KERNEL_1,			    \
 			      CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,  \

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -69,7 +69,7 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    &rv32m1_pcc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL, &rv32m1_pcc##inst##_config,		\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	\

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -624,7 +624,7 @@ int stm32_clock_control_init(const struct device *dev)
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
 		    &stm32_clock_control_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -735,7 +735,7 @@ static int stm32_clock_control_init(const struct device *dev)
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
 		    &stm32_clock_control_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -411,7 +411,7 @@ static int stm32_clock_control_init(const struct device *dev)
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
 		    &stm32_clock_control_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,
 		    CONFIG_CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY,

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -886,7 +886,7 @@ void uart_mux_foreach(uart_mux_cb_t cb, void *user_data)
 	DEVICE_DEFINE(uart_mux_##x,					  \
 			    CONFIG_UART_MUX_DEVICE_NAME "_" #x,		  \
 			    &uart_mux_init,				  \
-			    device_pm_control_nop,			  \
+			    NULL,					  \
 			    &uart_mux_dev_data_##x,			  \
 			    &uart_mux_config_##x,			  \
 			    POST_KERNEL,				  \

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -208,5 +208,5 @@ static const struct counter_driver_api api = {
 	.get_value = get_value
 };
 
-DEVICE_DEFINE(counter_cmos, "CMOS", init, device_pm_control_nop, NULL, &info,
+DEVICE_DEFINE(counter_cmos, "CMOS", init, NULL, NULL, &info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api);

--- a/drivers/counter/counter_esp32.c
+++ b/drivers/counter/counter_esp32.c
@@ -273,7 +273,7 @@ static void counter_esp32_isr(struct device *dev)
 										 \
 	DEVICE_DT_INST_DEFINE(n,						 \
 			      counter_esp32_init,				 \
-			      device_pm_control_nop, &counter_data_##n,		 \
+			      NULL, &counter_data_##n,				 \
 			      &counter_config_##n, PRE_KERNEL_1,		 \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &counter_api);
 

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -382,7 +382,7 @@ static const struct counter_gecko_config counter_gecko_0_config = {
 
 static struct counter_gecko_data counter_gecko_0_data;
 
-DEVICE_DT_INST_DEFINE(0, counter_gecko_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, counter_gecko_init, NULL,
 	&counter_gecko_0_data, &counter_gecko_0_config,
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	&counter_gecko_driver_api);

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -158,7 +158,7 @@ static const struct imx_epit_config imx_epit_##idx##z_config = {	       \
 static struct imx_epit_data imx_epit_##idx##_data;			       \
 DEVICE_DT_INST_DEFINE(idx,						       \
 		    &imx_epit_config_func_##idx,			       \
-		    device_pm_control_nop,				       \
+		    NULL,						       \
 		    &imx_epit_##idx##_data, &imx_epit_##idx##z_config.info,    \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 		    &imx_epit_driver_api);				       \

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -418,7 +418,7 @@ static const struct counter_driver_api rtc_stm32_driver_api = {
 		.get_top_value = rtc_stm32_get_top_value,
 };
 
-DEVICE_DT_INST_DEFINE(0, &rtc_stm32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &rtc_stm32_init, NULL,
 		    &rtc_data, &rtc_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &rtc_stm32_driver_api);
 

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -324,7 +324,7 @@ static int counter_xec_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    counter_xec_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &counter_xec_dev_data_##inst,		\
 			    &counter_xec_dev_config_##inst,		\
 			    POST_KERNEL,				\

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -219,7 +219,7 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	static int mcux_gpt_## n ##_init(const struct device *dev);	\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    mcux_gpt_## n ##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_gpt_data_ ## n,			\
 			    &mcux_gpt_config_ ## n,			\
 			    POST_KERNEL,				\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -232,7 +232,7 @@ static struct mcux_lptmr_config mcux_lptmr_config_0 = {
 	.irq_config_func = mcux_lptmr_irq_config_0,
 };
 
-DEVICE_DT_INST_DEFINE(0, &mcux_lptmr_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &mcux_lptmr_init, NULL,
 		    &mcux_lptmr_data_0,
 		    &mcux_lptmr_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -225,7 +225,7 @@ static const struct mcux_pit_config mcux_pit_config_0 = {
 	.irq_config_func = mcux_pit_irq_config_0,
 };
 
-DEVICE_DT_INST_DEFINE(0, &mcux_pit_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &mcux_pit_init, NULL,
 		    &mcux_pit_data_0, &mcux_pit_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcux_pit_driver_api);
 

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -269,7 +269,7 @@ static struct mcux_rtc_config mcux_rtc_config_0 = {
 	},
 };
 
-DEVICE_DT_INST_DEFINE(0, &mcux_rtc_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &mcux_rtc_init, NULL,
 		    &mcux_rtc_data_0, &mcux_rtc_config_0.info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_rtc_driver_api);

--- a/drivers/counter/counter_native_posix.c
+++ b/drivers/counter/counter_native_posix.c
@@ -149,5 +149,5 @@ static const struct counter_config_info ctr_config = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(DT_COUNTER_LABEL), ctr_init,
-		    device_pm_control_nop, NULL, &ctr_config, PRE_KERNEL_1,
+		    NULL, NULL, &ctr_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ctr_api);

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -688,7 +688,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	};								       \
 	DEVICE_DT_DEFINE(RTC(idx),					       \
 			    counter_##idx##_init,			       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &counter_##idx##_data,			       \
 			    &nrfx_counter_##idx##_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -423,7 +423,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	};								       \
 	DEVICE_DT_DEFINE(TIMER(idx),					       \
 			    counter_##idx##_init,			       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &counter_##idx##_data,			       \
 			    &nrfx_counter_##idx##_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -438,7 +438,7 @@ static const struct counter_driver_api counter_sam0_tc32_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &counter_sam0_tc32_initialize,		\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &counter_sam0_tc32_dev_data_##n,		\
 			    &counter_sam0_tc32_dev_config_##n,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -338,7 +338,7 @@ static const struct counter_driver_api xlnx_axi_timer_driver_api = {
 	static struct xlnx_axi_timer_data xlnx_axi_timer_data_##n;	\
 									\
 	DEVICE_DT_INST_DEFINE(n, &xlnx_axi_timer_init,			\
-			device_pm_control_nop,				\
+			NULL,						\
 			&xlnx_axi_timer_data_##n,			\
 			&xlnx_axi_timer_config_##n,			\
 			POST_KERNEL,					\

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1317,7 +1317,7 @@ static struct ds3231_data ds3231_0_data;
 #error COUNTER_MAXIM_DS3231_INIT_PRIORITY must be greater than I2C_INIT_PRIORITY
 #endif
 
-DEVICE_DT_INST_DEFINE(0, ds3231_init, device_pm_control_nop, &ds3231_0_data,
+DEVICE_DT_INST_DEFINE(0, ds3231_init, NULL, &ds3231_0_data,
 		    &ds3231_0_config,
 		    POST_KERNEL, CONFIG_COUNTER_MAXIM_DS3231_INIT_PRIORITY,
 		    &ds3231_api);

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -193,7 +193,7 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    dtmr_cmsdk_apb_init,			\
-			    device_pm_control_nop,			\
+			    NULL,			\
 			    &dtmr_cmsdk_apb_dev_data_##inst,		\
 			    &dtmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -188,7 +188,7 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    tmr_cmsdk_apb_init,				\
-			    device_pm_control_nop,			\
+			    NULL,			\
 			    &tmr_cmsdk_apb_dev_data_##inst,		\
 			    &tmr_cmsdk_apb_cfg_##inst, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -899,6 +899,6 @@ static struct crypto_driver_api crypto_enc_funcs = {
 struct ataes132a_device_data ataes132a_data;
 
 DEVICE_DEFINE(ataes132a, CONFIG_CRYPTO_ATAES132A_DRV_NAME, ataes132a_init,
-		device_pm_control_nop, &ataes132a_data, &ataes132a_config,
+		NULL, &ataes132a_data, &ataes132a_config,
 		POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		(void *)&crypto_enc_funcs);

--- a/drivers/crypto/crypto_mtls_shim.c
+++ b/drivers/crypto/crypto_mtls_shim.c
@@ -469,6 +469,6 @@ static struct crypto_driver_api mtls_crypto_funcs = {
 };
 
 DEVICE_DEFINE(crypto_mtls, CONFIG_CRYPTO_MBEDTLS_SHIM_DRV_NAME,
-		    &mtls_shim_init, device_pm_control_nop, NULL, NULL,
+		    &mtls_shim_init, NULL, NULL, NULL,
 		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		    (void *)&mtls_crypto_funcs);

--- a/drivers/crypto/crypto_nrf_ecb.c
+++ b/drivers/crypto/crypto_nrf_ecb.c
@@ -139,7 +139,7 @@ static const struct crypto_driver_api crypto_enc_funcs = {
 	.query_hw_caps = nrf_ecb_query_caps,
 };
 
-DEVICE_DT_INST_DEFINE(0, nrf_ecb_driver_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, nrf_ecb_driver_init, NULL,
 		      NULL, NULL,
 		      POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		      &crypto_enc_funcs);

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -463,7 +463,7 @@ static struct crypto_stm32_config crypto_stm32_dev_config = {
 	}
 };
 
-DEVICE_DT_INST_DEFINE(0, crypto_stm32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, crypto_stm32_init, NULL,
 		    &crypto_stm32_dev_data,
 		    &crypto_stm32_dev_config, POST_KERNEL,
 		    CONFIG_CRYPTO_INIT_PRIORITY, (void *)&crypto_enc_funcs);

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -322,6 +322,6 @@ static struct crypto_driver_api crypto_enc_funcs = {
 };
 
 DEVICE_DEFINE(crypto_tinycrypt, CONFIG_CRYPTO_TINYCRYPT_SHIM_DRV_NAME,
-		    &tc_shim_init, device_pm_control_nop, NULL, NULL,
+		    &tc_shim_init, NULL, NULL, NULL,
 		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		    (void *)&crypto_enc_funcs);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `clock_control`
- `console`
- `counter`
- `crypto`