### PR TITLE
drivers: remove usage of device_pm_control_nop (3)

### DIFF
--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -425,7 +425,7 @@ static const struct dac_driver_api dacx0508_driver_api = {
 		.gain[7] = DT_PROP(INST_DT_DACX0508(n, t), channel7_gain), \
 	}; \
 	DEVICE_DT_DEFINE(INST_DT_DACX0508(n, t), \
-			    &dacx0508_init, device_pm_control_nop, \
+			    &dacx0508_init, NULL, \
 			    &dac##t##_data_##n, \
 			    &dac##t##_config_##n, POST_KERNEL, \
 			    CONFIG_DAC_DACX0508_INIT_PRIORITY, \

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -255,7 +255,7 @@ static const struct dac_driver_api dacx3608_driver_api = {
 		.resolution = res, \
 	}; \
 	DEVICE_DT_DEFINE(INST_DT_DACX3608(n, t), \
-				&dacx3608_init, device_pm_control_nop, \
+				&dacx3608_init, NULL, \
 				&dac##t##_data_##n, \
 				&dac##t##_config_##n, POST_KERNEL, \
 				CONFIG_DAC_DACX3608_INIT_PRIORITY, \

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -105,7 +105,7 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, mcux_dac_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, mcux_dac_init, NULL,			\
 			&mcux_dac_data_##n,				\
 			&mcux_dac_config_##n,				\
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -111,7 +111,7 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, mcux_dac32_init, device_pm_control_nop,\
+	DEVICE_DT_INST_DEFINE(n, mcux_dac32_init, NULL,			\
 			&mcux_dac32_data_##n,				\
 			&mcux_dac32_config_##n,				\
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -106,7 +106,7 @@ static const struct dac_driver_api api_sam0_driver_api = {
 		.refsel = UTIL_CAT(SAM0_DAC_REFSEL_, SAM0_DAC_REFSEL(n)),      \
 	};								       \
 									       \
-	DEVICE_DT_INST_DEFINE(n, &dac_sam0_init, device_pm_control_nop, NULL,  \
+	DEVICE_DT_INST_DEFINE(n, &dac_sam0_init, NULL, NULL,		       \
 			    &dac_sam0_cfg_##n, POST_KERNEL,		       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 			    &api_sam0_driver_api)

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -165,7 +165,7 @@ static struct dac_stm32_data dac_stm32_data_##index = {			\
 	.channel_count = STM32_CHANNEL_COUNT				\
 };									\
 									\
-DEVICE_DT_INST_DEFINE(index, &dac_stm32_init, device_pm_control_nop,	\
+DEVICE_DT_INST_DEFINE(index, &dac_stm32_init, NULL,			\
 		    &dac_stm32_data_##index,				\
 		    &dac_stm32_cfg_##index, POST_KERNEL,		\
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\

--- a/drivers/disk/sdmmc_spi.c
+++ b/drivers/disk/sdmmc_spi.c
@@ -1010,7 +1010,7 @@ static const struct sdhc_spi_config sdhc_spi_cfg_0 = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, sdhc_spi_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, sdhc_spi_init, NULL,
 	&sdhc_spi_data_0, &sdhc_spi_cfg_0,
 	POST_KERNEL, CONFIG_SDMMC_INIT_PRIORITY, NULL);
 #endif

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -428,7 +428,7 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 	}
 };
 
-DEVICE_DT_INST_DEFINE(0, disk_stm32_sdmmc_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, disk_stm32_sdmmc_init, NULL,
 		    &stm32_sdmmc_priv_1, NULL, POST_KERNEL,
 		    CONFIG_SDMMC_INIT_PRIORITY,
 		    NULL);

--- a/drivers/disk/usdhc.c
+++ b/drivers/disk/usdhc.c
@@ -2851,7 +2851,7 @@ static int disk_usdhc_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &disk_usdhc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &usdhc_priv_##n,				\
 			    &usdhc_config_##n,				\
 			    POST_KERNEL,				\

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -124,7 +124,7 @@ static const struct display_driver_api dummy_display_api = {
 };
 
 DEVICE_DEFINE(dummy_display, CONFIG_DUMMY_DISPLAY_DEV_NAME,
-		    &dummy_display_init, device_pm_control_nop,
+		    &dummy_display_init, NULL,
 		    &dummy_display_data, NULL,
 		    APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &dummy_display_api);

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -486,7 +486,7 @@ static const struct display_driver_api ili9xxx_api = {
 	static struct ili9xxx_data ili9xxx_data_##n;                           \
 									       \
 	DEVICE_DT_DEFINE(INST_DT_ILI9XXX(n, t), ili9xxx_init,                  \
-			    device_pm_control_nop, &ili9xxx_data_##n,          \
+			    NULL, &ili9xxx_data_##n,                           \
 			    &ili9xxx_config_##n, POST_KERNEL,                  \
 			    CONFIG_APPLICATION_INIT_PRIORITY, &ili9xxx_api);
 

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -258,7 +258,7 @@ static struct mcux_elcdif_data mcux_elcdif_data_1;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_elcdif_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &mcux_elcdif_data_1, &mcux_elcdif_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_elcdif_api);

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -416,7 +416,7 @@ static const struct display_driver_api sdl_display_api = {
 };
 
 DEVICE_DEFINE(sdl_display, CONFIG_SDL_DISPLAY_DEV_NAME, &sdl_display_init,
-		device_pm_control_nop, &sdl_display_data, NULL, APPLICATION,
+		NULL, &sdl_display_data, NULL, APPLICATION,
 		CONFIG_APPLICATION_INIT_PRIORITY, &sdl_display_api);
 
 

--- a/drivers/display/gd7965.c
+++ b/drivers/display/gd7965.c
@@ -466,7 +466,7 @@ static struct display_driver_api gd7965_driver_api = {
 };
 
 
-DEVICE_DT_INST_DEFINE(0, gd7965_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, gd7965_init, NULL,
 		    &gd7965_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &gd7965_driver_api);

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -343,6 +343,6 @@ static struct glcd_data grove_lcd_driver = {
 	 * since grove_lcd_driver struct is available, populating with it
 	 */
 DEVICE_DEFINE(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
-		device_pm_control_nop, &grove_lcd_driver, &grove_lcd_config,
+		NULL, &grove_lcd_driver, &grove_lcd_config,
 		POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		(void *)&grove_lcd_driver);

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -354,7 +354,7 @@ static struct display_driver_api ls0xx_driver_api = {
 	.set_orientation = ls0xx_set_orientation,
 };
 
-DEVICE_DT_INST_DEFINE(0, ls0xx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ls0xx_init, NULL,
 		      &ls0xx_driver, NULL,
 		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		      &ls0xx_driver_api);

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -455,7 +455,7 @@ static struct display_driver_api ssd1306_driver_api = {
 	.set_orientation = ssd1306_set_orientation,
 };
 
-DEVICE_DT_INST_DEFINE(0, ssd1306_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ssd1306_init, NULL,
 		    &ssd1306_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &ssd1306_driver_api);

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -717,7 +717,7 @@ static struct display_driver_api ssd16xx_driver_api = {
 };
 
 
-DEVICE_DT_INST_DEFINE(0, ssd16xx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ssd16xx_init, NULL,
 		    &ssd16xx_driver, NULL,
 		    POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
 		    &ssd16xx_driver_api);

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -410,7 +410,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    &dw_dma_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &dw_dma##inst##_data,			\
 			    &dw_dma##inst##_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -991,7 +991,7 @@ static const struct dma_iproc_pax_cfg pax_dma_cfg = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &dma_iproc_pax_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &pax_dma_data,
 		    &pax_dma_cfg,
 		    POST_KERNEL,

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -1107,7 +1107,7 @@ static const struct dma_iproc_pax_cfg pax_dma_cfg = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &dma_iproc_pax_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &pax_dma_data,
 		    &pax_dma_cfg,
 		    POST_KERNEL,

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -454,7 +454,7 @@ struct dma_mcux_edma_data dma_data;
 /*
  * define the dma
  */
-DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &dma_mcux_edma_init, NULL,
 		    &dma_data, &dma_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_mcux_edma_api);
 

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -469,7 +469,7 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &dma_mcux_lpc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &dma_data_##n, &dma_##n##_config,\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,\
 			    &dma_mcux_lpc_api);			\

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -234,5 +234,5 @@ static struct nios2_msgdma_dev_cfg dma0_nios2_config = {
 };
 
 DEVICE_DT_INST_DEFINE(0, &nios2_msgdma0_initialize,
-		device_pm_control_nop, NULL, &dma0_nios2_config, POST_KERNEL,
+		NULL, NULL, &dma0_nios2_config, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &nios2_msgdma_driver_api);

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -588,7 +588,7 @@ static const struct dma_pl330_config pl330_config = {
 
 static struct dma_pl330_dev_data pl330_data;
 
-DEVICE_DT_INST_DEFINE(0, &dma_pl330_initialize, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &dma_pl330_initialize, NULL,
 		    &pl330_data, &pl330_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &pl330_driver_api);

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -457,6 +457,6 @@ static const struct dma_driver_api dma_sam0_api = {
 	.get_status = dma_sam0_get_status,
 };
 
-DEVICE_DT_INST_DEFINE(0, &dma_sam0_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &dma_sam0_init, NULL,
 		    &dmac_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_sam0_api);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -362,6 +362,6 @@ static const struct sam_xdmac_dev_cfg dma0_sam_config = {
 
 static struct sam_xdmac_dev_data dma0_sam_data;
 
-DEVICE_DT_INST_DEFINE(0, &sam_xdmac_initialize, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &sam_xdmac_initialize, NULL,
 		    &dma0_sam_data, &dma0_sam_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &sam_xdmac_driver_api);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -674,7 +674,7 @@ static struct dma_stm32_data dma_stm32_data_##index = {			\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
 		    &dma_stm32_init,					\
-		    device_pm_control_nop,				\
+		    NULL,						\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &dma_funcs)

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -277,7 +277,7 @@ static struct dmamux_stm32_data dmamux_stm32_data_##index;		\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
 		    &dmamux_stm32_init,					\
-		    device_pm_control_nop,				\
+		    NULL,						\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &dma_funcs);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `dac`
- `disk`
- `display`
- `dma`