### PR TITLE
drivers: remove usage of device_pm_control_nop (4)

### DIFF
--- a/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
+++ b/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
@@ -80,6 +80,6 @@ static int ec_host_cmd_sim_init(const struct device *dev)
 }
 
 /* Assume only one simulator */
-DEVICE_DT_INST_DEFINE(0, ec_host_cmd_sim_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ec_host_cmd_sim_init, NULL,
 		    NULL, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ec_host_cmd_api);

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -659,7 +659,7 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 	}; \
 	static struct eeprom_at2x_data eeprom_at##t##_data_##n; \
 	DEVICE_DT_DEFINE(INST_DT_AT2X(n, t), &eeprom_at2x_init, \
-			    device_pm_control_nop, &eeprom_at##t##_data_##n, \
+			    NULL, &eeprom_at##t##_data_##n, \
 			    &eeprom_at##t##_config_##n, POST_KERNEL, \
 			    CONFIG_EEPROM_AT2X_INIT_PRIORITY, \
 			    &eeprom_at2x_api)

--- a/drivers/eeprom/eeprom_emulator.c
+++ b/drivers/eeprom/eeprom_emulator.c
@@ -808,7 +808,7 @@ static const struct eeprom_driver_api eeprom_emu_api = {
 	}; \
 	static struct eeprom_emu_data eeprom_emu_##n##_data; \
 	DEVICE_DT_INST_DEFINE(n, &eeprom_emu_init, \
-		device_pm_control_nop, &eeprom_emu_##n##_data, \
+		NULL, &eeprom_emu_##n##_data, \
 		&eeprom_emu_##n##_config, POST_KERNEL, \
 		CONFIG_EEPROM_EMULATOR_INIT_PRIORITY, &eeprom_emu_api); \
 

--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -115,6 +115,6 @@ static const struct eeprom_lpc11u6x_config eeprom_config = {
 	.size = DT_INST_PROP(0, size),
 };
 
-DEVICE_DT_INST_DEFINE(0, &eeprom_lpc11u6x_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, &eeprom_lpc11u6x_init, NULL, NULL,
 		    &eeprom_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_lpc11u6x_api);

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -267,7 +267,7 @@ static int eeprom_sim_init(const struct device *dev)
 	return eeprom_mock_init(dev);
 }
 
-DEVICE_DT_INST_DEFINE(0, &eeprom_sim_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &eeprom_sim_init, NULL,
 		    NULL, &eeprom_sim_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_sim_api);
 

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -122,6 +122,6 @@ static const struct eeprom_stm32_config eeprom_config = {
 	.size = DT_INST_REG_SIZE(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, &eeprom_stm32_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, &eeprom_stm32_init, NULL, NULL,
 		    &eeprom_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_stm32_api);

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -72,6 +72,6 @@ static const struct entropy_driver_api entropy_esp32_api_funcs = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_esp32_init, device_pm_control_nop, NULL, NULL,
+		    entropy_esp32_init, NULL, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_esp32_api_funcs);

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -100,7 +100,7 @@ static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-			entropy_gecko_trng_init, device_pm_control_nop,
+			entropy_gecko_trng_init, NULL,
 			NULL, NULL,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&entropy_gecko_trng_api_funcs);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -60,6 +60,6 @@ static const struct entropy_driver_api entropy_prbs_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_prbs_init, device_pm_control_nop, NULL, NULL,
+		    entropy_prbs_init, NULL, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_prbs_api);

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -43,7 +43,7 @@ static const struct mcux_entropy_config entropy_mcux_config = {
 static int entropy_mcux_rng_init(const struct device *);
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_rng_init, device_pm_control_nop, NULL,
+		    entropy_mcux_rng_init, NULL, NULL,
 		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rng_api_funcs);

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -60,7 +60,7 @@ static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
 static int entropy_mcux_rnga_init(const struct device *);
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_rnga_init, device_pm_control_nop, NULL, NULL,
+		    entropy_mcux_rnga_init, NULL, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_rnga_api_funcs);
 

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -43,7 +43,7 @@ static struct mcux_entropy_config entropy_mcux_config = {
 static int entropy_mcux_trng_init(const struct device *);
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_trng_init, device_pm_control_nop, NULL,
+		    entropy_mcux_trng_init, NULL, NULL,
 		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_mcux_trng_api_funcs);

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -332,7 +332,7 @@ static const struct entropy_driver_api entropy_nrf5_api_funcs = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_nrf5_init, device_pm_control_nop,
+		    entropy_nrf5_init, NULL,
 		    &entropy_nrf5_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_nrf5_api_funcs);

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -43,7 +43,7 @@ static struct rv32m1_entropy_config entropy_rv32m1_config = {
 static int entropy_rv32m1_trng_init(const struct device *);
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_rv32m1_trng_init, device_pm_control_nop,
+		    entropy_rv32m1_trng_init, NULL,
 		    NULL, &entropy_rv32m1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_rv32m1_trng_api_funcs);

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -184,7 +184,7 @@ static const struct trng_sam_dev_cfg trng_sam_cfg = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_sam_init, device_pm_control_nop,
+		    entropy_sam_init, NULL,
 		    NULL, &trng_sam_cfg,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_sam_api);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -449,7 +449,7 @@ static const struct entropy_driver_api entropy_stm32_rng_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_stm32_rng_init, device_pm_control_nop,
+		    entropy_stm32_rng_init, NULL,
 		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_stm32_rng_api);

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -76,7 +76,7 @@ static const struct entropy_driver_api entropy_native_posix_api_funcs = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_native_posix_init, device_pm_control_nop,
+		    entropy_native_posix_init, NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_native_posix_api_funcs);

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -196,7 +196,7 @@ static struct emul_espi_driver_api emul_espi_driver_api = {
 	static struct espi_emul_data espi_emul_data_##n;	      \
 	DEVICE_DT_INST_DEFINE(n,				      \
 			      &espi_emul_init,			      \
-			      device_pm_control_nop,		      \
+			      NULL,				      \
 			      &espi_emul_data_##n,		      \
 			      &espi_emul_cfg_##n,		      \
 			      POST_KERNEL,			      \

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -1374,7 +1374,7 @@ static const struct espi_xec_config espi_xec_config = {
 	.pc_girq_id = DT_INST_PROP(0, pc_girq),
 };
 
-DEVICE_DT_INST_DEFINE(0, &espi_xec_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &espi_xec_init, NULL,
 		    &espi_xec_data, &espi_xec_config,
 		    PRE_KERNEL_2, CONFIG_ESPI_INIT_PRIORITY,
 		    &espi_xec_driver_api);

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -843,7 +843,7 @@ static const struct espi_npcx_config espi_npcx_config = {
 	.alts_list = espi_alts,
 };
 
-DEVICE_DT_INST_DEFINE(0, &espi_npcx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &espi_npcx_init, NULL,
 		    &espi_npcx_data, &espi_npcx_config,
 		    PRE_KERNEL_2, CONFIG_ESPI_INIT_PRIORITY,
 		    &espi_npcx_driver_api);

--- a/drivers/espi/espi_saf_mchp_xec.c
+++ b/drivers/espi/espi_saf_mchp_xec.c
@@ -851,7 +851,7 @@ static const struct espi_saf_xec_config espi_saf_xec_config = {
 					 MCHP_SAF_FLASH_POLL_INTERVAL),
 };
 
-DEVICE_DT_INST_DEFINE(0, &espi_saf_xec_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &espi_saf_xec_init, NULL,
 		      &espi_saf_xec_data, &espi_saf_xec_config, POST_KERNEL,
 		      CONFIG_ESPI_SAF_INIT_PRIORITY, &espi_saf_xec_driver_api);
 

--- a/drivers/ethernet/dsa_ksz8794.c
+++ b/drivers/ethernet/dsa_ksz8794.c
@@ -1041,7 +1041,7 @@ static struct dsa_context dsa_context = {
 	DT_LABEL(slave),                                                   \
 	0,                                                                 \
 	dsa_port_init,                                                     \
-	device_pm_control_nop,                                             \
+	NULL,                                                              \
 	&dsa_context,                                                      \
 	&dsa_0_slave_##slave##_config,                                     \
 	CONFIG_ETH_INIT_PRIORITY,                                          \

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -324,7 +324,7 @@ static const struct ethernet_api e1000_api = {
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
 		    e1000_probe,
-		    device_pm_control_nop,
+		    NULL,
 		    &e1000_dev,
 		    NULL,
 		    CONFIG_ETH_INIT_PRIORITY,
@@ -448,7 +448,7 @@ static int ptp_e1000_init(const struct device *port)
 }
 
 DEVICE_DEFINE(e1000_ptp_clock, PTP_CLOCK_NAME, ptp_e1000_init,
-	      device_pm_control_nop, &ptp_e1000_context, NULL, POST_KERNEL,
+	      NULL, &ptp_e1000_context, NULL, POST_KERNEL,
 	      CONFIG_APPLICATION_INIT_PRIORITY, &api);
 
 #endif /* CONFIG_ETH_E1000_PTP_CLOCK */

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -847,7 +847,7 @@ static const struct eth_enc28j60_config eth_enc28j60_0_config = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
-		    eth_enc28j60_init, device_pm_control_nop,
+		    eth_enc28j60_init, NULL,
 		    &eth_enc28j60_0_runtime, &eth_enc28j60_0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &api_funcs, NET_ETH_MTU);
 

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -771,6 +771,6 @@ static const struct enc424j600_config enc424j600_0_config = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
-		    enc424j600_init, device_pm_control_nop,
+		    enc424j600_init, NULL,
 		    &enc424j600_0_runtime, &enc424j600_0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &api_funcs, NET_ETH_MTU);

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -668,5 +668,5 @@ static struct eth_gecko_dev_data eth0_data = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_init,
-		    device_pm_control_nop, &eth0_data, &eth0_config,
+		    NULL, &eth0_data, &eth0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_GECKO_MTU);

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -255,7 +255,7 @@ static const struct ethernet_api eth_api = {
 	.send = eth_tx
 };
 
-NET_DEVICE_DT_INST_DEFINE(0, eth_initialize, device_pm_control_nop,
+NET_DEVICE_DT_INST_DEFINE(0, eth_initialize, NULL,
 		&eth_data, &eth_config, CONFIG_ETH_INIT_PRIORITY, &eth_api,
 		ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -237,7 +237,7 @@ out:
 #define ETH_MCUX_PM_FUNC eth_mcux_device_pm_control
 
 #else
-#define ETH_MCUX_PM_FUNC device_pm_control_nop
+#define ETH_MCUX_PM_FUNC NULL
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
 
 #if ETH_MCUX_FIXED_LINK
@@ -1536,7 +1536,7 @@ static int ptp_mcux_init(const struct device *port)
 }
 
 DEVICE_DEFINE(mcux_ptp_clock_0, PTP_CLOCK_NAME, ptp_mcux_init,
-		device_pm_control_nop, &ptp_mcux_0_context, NULL, POST_KERNEL,
+		NULL, &ptp_mcux_0_context, NULL, POST_KERNEL,
 		CONFIG_APPLICATION_INIT_PRIORITY, &api);
 
 #endif /* CONFIG_PTP_CLOCK_MCUX */

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -634,7 +634,7 @@ UTIL_LISTIFY(CONFIG_ETH_NATIVE_POSIX_INTERFACE_COUNT, DEFINE_ETH_DEV_DATA, _)
 #define DEFINE_ETH_DEVICE(x, _)						\
 	ETH_NET_DEVICE_INIT(eth_native_posix_##x,			\
 			    CONFIG_ETH_NATIVE_POSIX_DRV_NAME #x,	\
-			    eth_init, device_pm_control_nop,		\
+			    eth_init, NULL,				\
 			    &eth_context_data_##x,			\
 			    NULL,					\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
@@ -733,7 +733,7 @@ UTIL_LISTIFY(CONFIG_ETH_NATIVE_POSIX_INTERFACE_COUNT, PTP_INIT_FUNC, _)
 	DEVICE_DEFINE(eth_native_posix_ptp_clock_##x,			\
 			    PTP_CLOCK_NAME "_" #x,			\
 			    ptp_init_##x,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &ptp_context_##x,				\
 			    NULL,					\
 			    POST_KERNEL,				\

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2396,7 +2396,7 @@ static struct eth_sam_dev_data eth0_data = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
-		    eth_initialize, device_pm_control_nop, &eth0_data,
+		    eth_initialize, NULL, &eth0_data,
 		    &eth0_config, CONFIG_ETH_INIT_PRIORITY, &eth_api,
 		    GMAC_MTU);
 
@@ -2479,7 +2479,7 @@ static int ptp_gmac_init(const struct device *port)
 }
 
 DEVICE_DEFINE(gmac_ptp_clock_0, PTP_CLOCK_NAME, ptp_gmac_init,
-		device_pm_control_nop, &ptp_gmac_0_context, NULL, POST_KERNEL,
+		NULL, &ptp_gmac_0_context, NULL, POST_KERNEL,
 		CONFIG_APPLICATION_INIT_PRIORITY, &ptp_api);
 
 #endif /* CONFIG_PTP_CLOCK_SAM_GMAC */

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -679,6 +679,6 @@ int eth_init(const struct device *dev)
 static struct eth_context eth_0_context;
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
-		eth_init, device_pm_control_nop, &eth_0_context,
+		eth_init, NULL, &eth_0_context,
 		NULL /*&eth_config_0*/, CONFIG_ETH_INIT_PRIORITY, &api_funcs,
 		NET_ETH_MTU /*MTU*/);

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -348,7 +348,7 @@ static const struct ethernet_api eth_stellaris_apis = {
 };
 
 NET_DEVICE_DT_INST_DEFINE(0,
-		eth_stellaris_dev_init, device_pm_control_nop,
+		eth_stellaris_dev_init, NULL,
 		&eth_data, &eth_cfg, CONFIG_ETH_INIT_PRIORITY,
 		&eth_stellaris_apis, ETHERNET_L2,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -912,5 +912,5 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_initialize,
-		    device_pm_control_nop, &eth0_data, &eth0_config,
+		    NULL, &eth0_data, &eth0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -589,6 +589,6 @@ static const struct w5500_config w5500_0_config = {
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
-		    w5500_init, device_pm_control_nop,
+		    w5500_init, NULL,
 		    &w5500_0_runtime, &w5500_0_config,
 		    CONFIG_ETH_INIT_PRIORITY, &w5500_api_funcs, NET_ETH_MTU);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `ec_hist_cmd_periph`
- `eeprom`
- `entropy`
- `espi`
- `ethernet`