### PR TITLE
include:fix function does not match the declaration

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -930,7 +930,7 @@ void *z_get_next_switch_handle(void *interrupted)
 }
 #endif
 
-ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
+void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
 {
 	struct k_thread *t;
 


### PR DESCRIPTION
The z_priq_dumb_add function implementation and declaration
do not match, the compiler will generate a warning, modify
it here to make the declaration consistent with the implementation

Signed-off-by: Yang XiaoHua <yangxiaohuamail@gmail.com>