### PR TITLE
drivers: remove usage of device_pm_control_nop (5)

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -610,7 +610,7 @@ static const struct flash_esp32_dev_config flash_esp32_config = {
 };
 
 DEVICE_DT_INST_DEFINE(0, flash_esp32_init,
-		      device_pm_control_nop,
+		      NULL,
 		      &flash_esp32_data, &flash_esp32_config,
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		      &flash_esp32_driver_api);

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -223,6 +223,6 @@ static const struct flash_driver_api flash_gecko_driver_api = {
 
 static struct flash_gecko_data flash_gecko_0_data;
 
-DEVICE_DT_INST_DEFINE(0, flash_gecko_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_gecko_init, NULL,
 		    &flash_gecko_0_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_gecko_driver_api);

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -555,7 +555,7 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      flash_flexspi_nor_init,			\
-			      device_pm_control_nop,			\
+			      NULL,					\
 			      &flash_flexspi_nor_data_##n,		\
 			      &flash_flexspi_nor_config_##n,		\
 			      POST_KERNEL,				\

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -382,7 +382,7 @@ static const struct flash_sam_dev_cfg flash_sam_cfg = {
 
 static struct flash_sam_dev_data flash_sam_data;
 
-DEVICE_DT_INST_DEFINE(0, flash_sam_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_sam_init, NULL,
 		    &flash_sam_data, &flash_sam_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sam_api);

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -466,6 +466,6 @@ static const struct flash_driver_api flash_sam0_api = {
 
 static struct flash_sam0_data flash_sam0_data_0;
 
-DEVICE_DT_INST_DEFINE(0, flash_sam0_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_sam0_init, NULL,
 		    &flash_sam0_data_0, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_sam0_api);

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -414,7 +414,7 @@ static int flash_init(const struct device *dev)
 	return flash_mock_init(dev);
 }
 
-DEVICE_DT_INST_DEFINE(0, flash_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_init, NULL,
 		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &flash_sim_api);
 

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -429,6 +429,6 @@ static int stm32_flash_init(const struct device *dev)
 	return flash_stm32_write_protection(dev, false);
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL,
 		    &flash_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32_api);

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -892,7 +892,7 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 	QSPI_DMA_CHANNEL(STM32_QSPI_NODE, tx_rx)
 };
 
-DEVICE_DT_INST_DEFINE(0, &flash_stm32_qspi_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &flash_stm32_qspi_init, NULL,
 		      &flash_stm32_qspi_dev_data, &flash_stm32_qspi_cfg,
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		      &flash_stm32_qspi_driver_api);

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -650,6 +650,6 @@ static int stm32h7_flash_init(const struct device *dev)
 }
 
 
-DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, NULL,
 		    &flash_data, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_stm32h7_api);

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1066,7 +1066,7 @@ static const struct qspi_nor_config flash_id = {
 	.size = INST_0_BYTES,
 };
 
-DEVICE_DT_INST_DEFINE(0, &qspi_nor_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &qspi_nor_init, NULL,
 		&qspi_nor_memory_data, &flash_id,
 		POST_KERNEL, CONFIG_NORDIC_QSPI_NOR_INIT_PRIORITY,
 		&qspi_nor_api);

--- a/drivers/flash/soc_flash_lpc.c
+++ b/drivers/flash/soc_flash_lpc.c
@@ -170,6 +170,6 @@ static int flash_lpc_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, flash_lpc_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_lpc_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_lpc_api);

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -282,6 +282,6 @@ static int flash_mcux_init(const struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_DT_INST_DEFINE(0, flash_mcux_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_mcux_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -522,6 +522,6 @@ struct flash_nios2_qspi_config flash_cfg = {
 
 DEVICE_DEFINE(flash_nios2_qspi,
 		CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME,
-		flash_nios2_qspi_init, device_pm_control_nop, &flash_cfg, NULL,
+		flash_nios2_qspi_init, NULL, &flash_cfg, NULL,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&flash_nios2_qspi_api);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -287,7 +287,7 @@ static int nrf_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, nrf_flash_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, nrf_flash_init, NULL,
 		 NULL, NULL,
 		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		 &flash_nrf_api);

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -161,6 +161,6 @@ static int flash_mcux_init(const struct device *dev)
 	return (rc == kStatus_Success) ? 0 : -EIO;
 }
 
-DEVICE_DT_INST_DEFINE(0, flash_mcux_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, flash_mcux_init, NULL,
 			&flash_data, NULL, POST_KERNEL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_mcux_api);

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1267,7 +1267,7 @@ static const struct spi_nor_config spi_nor_config_0 = {
 
 static struct spi_nor_data spi_nor_data_0;
 
-DEVICE_DT_INST_DEFINE(0, &spi_nor_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &spi_nor_init, NULL,
 		 &spi_nor_data_0, &spi_nor_config_0,
 		 POST_KERNEL, CONFIG_SPI_NOR_INIT_PRIORITY,
 		 &spi_nor_api);

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -281,7 +281,7 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0, gpio_cc13xx_cc26xx_init,
-		    device_pm_control_nop, &gpio_cc13xx_cc26xx_data_0,
+		    NULL, &gpio_cc13xx_cc26xx_data_0,
 		    &gpio_cc13xx_cc26xx_cfg_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_cc13xx_cc26xx_driver_api);

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -261,7 +261,7 @@ static const struct gpio_driver_api api_funcs = {
 
 #define GPIO_CC32XX_DEVICE_INIT(n)					     \
 	DEVICE_DT_INST_DEFINE(n, &gpio_cc32xx_a##n##_init,		     \
-			device_pm_control_nop, &gpio_cc32xx_a##n##_data,     \
+			NULL, &gpio_cc32xx_a##n##_data,			     \
 			&gpio_cc32xx_a##n##_config,			     \
 			POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
 			&api_funcs)

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -274,7 +274,7 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
 			    gpio_cmsdk_ahb_init,				\
-			    device_pm_control_nop,				\
+			    NULL,						\
 			    &gpio_cmsdk_port_##n##_data,			\
 			    &gpio_cmsdk_port_## n ##_config,			\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -696,7 +696,7 @@ static int gpio_emul_init(const struct device *dev)
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(_num, gpio_emul_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -400,7 +400,7 @@ static struct gpio_eos_s3_data gpio_eos_s3_data = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    gpio_eos_s3_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_eos_s3_data,
 		    &gpio_eos_s3_config,
 		    POST_KERNEL,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -342,7 +342,7 @@ static struct gpio_esp32_data gpio_1_data = { /* 32..39 */
 	}; \
 	DEVICE_DT_INST_DEFINE(_id,					\
 			    gpio_esp32_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_##_id##_data, &gpio_##_id##_cfg,	\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -284,7 +284,7 @@ static struct gpio_gecko_common_data gpio_gecko_common_data;
 
 DEVICE_DT_DEFINE(DT_INST(0, silabs_gecko_gpio),
 		    gpio_gecko_common_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_gecko_common_data, &gpio_gecko_common_config,
 		    POST_KERNEL, CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY,
 		    &gpio_gecko_common_driver_api);
@@ -322,7 +322,7 @@ static struct gpio_gecko_data gpio_gecko_port##idx##_data; \
 \
 DEVICE_DT_INST_DEFINE(idx, \
 		    gpio_gecko_port##idx##_init, \
-		    device_pm_control_nop, \
+		    NULL, \
 		    &gpio_gecko_port##idx##_data, \
 		    &gpio_gecko_port##idx##_config, \
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -195,7 +195,7 @@ static const struct gpio_driver_api gpio_ht16k33_api = {
 									\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    &gpio_ht16k33_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_ht16k33_##id##_data,			\
 			    &gpio_ht16k33_##id##_cfg, POST_KERNEL,	\
 			    CONFIG_GPIO_HT16K33_INIT_PRIORITY,		\

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -222,7 +222,7 @@ static const struct gpio_driver_api imx_gpio_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    imx_gpio_##n##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &imx_gpio_##n##_data,			\
 			    &imx_gpio_##n##_config,			\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -573,7 +573,7 @@ static struct gpio_intel_apl_data gpio_intel_apl_data_##n;		\
 									\
 DEVICE_DT_INST_DEFINE(n,						\
 		    gpio_intel_apl_init,				\
-		    device_pm_control_nop,				\
+		    NULL,						\
 		    &gpio_intel_apl_data_##n,				\
 		    &gpio_intel_apl_cfg_##n,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -457,7 +457,7 @@ static const struct gpio_ite_cfg gpio_ite_cfg_##inst = {           \
 	};                                                         \
 DEVICE_DT_INST_DEFINE(inst,                                        \
 		gpio_ite_init,                                     \
-		device_pm_control_nop,                             \
+		NULL,                                              \
 		&gpio_ite_data_##inst,                             \
 		&gpio_ite_cfg_##inst,                              \
 		POST_KERNEL,                                       \

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -232,7 +232,7 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 \
 	DEVICE_DT_INST_DEFINE(n, \
 			    gpio_litex_init, \
-			    device_pm_control_nop, \
+			    NULL, \
 			    &gpio_litex_data_##n, \
 			    &gpio_litex_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -179,7 +179,7 @@ BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 									\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    &gpio_lmp90xxx_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_lmp90xxx_##id##_data,			\
 			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\
 			    CONFIG_GPIO_LMP90XXX_INIT_PRIORITY,		\

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -590,7 +590,7 @@ static struct gpio_lpc11u6x_data gpio_lpc11u6x_data_##id;		\
 									\
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio##id),				\
 		    &gpio_lpc11u6x_init,				\
-		    device_pm_control_nop,				\
+		    NULL,						\
 		    &gpio_lpc11u6x_data_##id,				\
 		    &gpio_lpc11u6x_config_##id,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -346,7 +346,7 @@ static struct gpio_xec_data gpio_xec_port000_036_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_000_036),
 		    gpio_xec_port000_036_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port000_036_data, &gpio_xec_port000_036_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -392,7 +392,7 @@ static struct gpio_xec_data gpio_xec_port040_076_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_040_076),
 		    gpio_xec_port040_076_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port040_076_data, &gpio_xec_port040_076_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -438,7 +438,7 @@ static struct gpio_xec_data gpio_xec_port100_136_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_100_136),
 		    gpio_xec_port100_136_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port100_136_data, &gpio_xec_port100_136_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -484,7 +484,7 @@ static struct gpio_xec_data gpio_xec_port140_176_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_140_176),
 		    gpio_xec_port140_176_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port140_176_data, &gpio_xec_port140_176_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -530,7 +530,7 @@ static struct gpio_xec_data gpio_xec_port200_236_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_200_236),
 		    gpio_xec_port200_236_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port200_236_data, &gpio_xec_port200_236_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);
@@ -576,7 +576,7 @@ static struct gpio_xec_data gpio_xec_port240_276_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(gpio_240_276),
 		    gpio_xec_port240_276_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_xec_port240_276_data, &gpio_xec_port240_276_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_xec_driver_api);

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -442,7 +442,7 @@ static int mcp23s17_init(const struct device *dev)
 									\
 	/* This has to init after SPI master */				\
 	DEVICE_DT_INST_DEFINE(inst, mcp23s17_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcp23s17_##inst##_drvdata,			\
 			    &mcp23s17_##inst##_config,			\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -284,7 +284,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    gpio_mcux_port## n ##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_mcux_port## n ##_data,		\
 			    &gpio_mcux_port## n##_config,		\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -225,7 +225,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    mcux_igpio_##n##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_igpio_##n##_data,			\
 			    &mcux_igpio_##n##_config,			\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -379,7 +379,7 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port0_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port0_data;
 
-DEVICE_DT_INST_DEFINE(0, lpc_gpio_0_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lpc_gpio_0_init, NULL,
 		    &gpio_mcux_lpc_port0_data,
 		    &gpio_mcux_lpc_port0_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -453,7 +453,7 @@ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port1_config = {
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port1_data;
 
-DEVICE_DT_INST_DEFINE(1, lpc_gpio_1_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(1, lpc_gpio_1_init, NULL,
 		    &gpio_mcux_lpc_port1_data,
 		    &gpio_mcux_lpc_port1_config, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -294,7 +294,7 @@ int gpio_npcx_init(const struct device *dev)
 									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
 			    gpio_npcx_init,                                    \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &gpio_npcx_data_##inst,                            \
 			    &gpio_npcx_cfg_##inst,                             \
 			    POST_KERNEL,                                       \

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -599,7 +599,7 @@ static int gpio_nrfx_init(const struct device *port)
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
 	DEVICE_DT_DEFINE(GPIO(id), gpio_nrfx_init,			\
-			 device_pm_control_nop,				\
+			 NULL,						\
 			 &gpio_nrfx_p##id##_data,			\
 			 &gpio_nrfx_p##id##_cfg,			\
 			 POST_KERNEL,					\

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -774,7 +774,7 @@ static struct gpio_pca95xx_drv_data gpio_pca95xx_##inst##_drvdata = {	\
 									\
 DEVICE_DT_INST_DEFINE(inst,						\
 	gpio_pca95xx_init,						\
-	device_pm_control_nop,						\
+	NULL,								\
 	&gpio_pca95xx_##inst##_drvdata,					\
 	&gpio_pca95xx_##inst##_cfg,					\
 	POST_KERNEL, CONFIG_GPIO_PCA95XX_INIT_PRIORITY,			\

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -648,7 +648,7 @@ static const struct gpio_driver_api pcal6408a_drv_api = {
 		.dev = DEVICE_DT_INST_GET(idx),				   \
 	};								   \
 	DEVICE_DT_INST_DEFINE(idx, pcal6408a_init,			   \
-			      device_pm_control_nop,			   \
+			      NULL,					   \
 			      &pcal6408a_data##idx, &pcal6408a_cfg##idx,   \
 			      POST_KERNEL,				   \
 			      CONFIG_GPIO_PCAL6408A_INIT_PRIORITY,	   \

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -266,7 +266,7 @@ int gpio_psoc6_init(const struct device *dev)
 									\
 	static struct gpio_psoc6_runtime port_##n##_psoc6_runtime = { 0 }; \
 									\
-	DEVICE_DT_INST_DEFINE(n, gpio_psoc6_init, device_pm_control_nop, \
+	DEVICE_DT_INST_DEFINE(n, gpio_psoc6_init, NULL,			\
 			    &port_##n##_psoc6_runtime,			\
 			    &port_##n##_psoc6_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -306,7 +306,7 @@ static const struct gpio_driver_api gpio_rcar_driver_api = {
 								    \
 	DEVICE_DT_INST_DEFINE(n,				    \
 			      gpio_rcar_init,			    \
-			      device_pm_control_nop,		    \
+			      NULL,				    \
 			      &gpio_rcar_data_##n,		    \
 			      &gpio_rcar_cfg_##n,		    \
 			      POST_KERNEL,			    \

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -314,7 +314,7 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    gpio_rv32m1_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &gpio_rv32m1_##n##_data,			\
 			    &gpio_rv32m1_##n##_config,			\
 			    POST_KERNEL,				\

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -322,7 +322,7 @@ int gpio_sam_init(const struct device *dev)
 									\
 	static struct gpio_sam_runtime port_##n##_sam_runtime;		\
 									\
-	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -304,7 +304,7 @@ static const struct gpio_sam0_config gpio_sam0_config_0 = {
 static struct gpio_sam0_data gpio_sam0_data_0;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(porta),
-		    gpio_sam0_init, device_pm_control_nop,
+		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_0, &gpio_sam0_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
@@ -326,7 +326,7 @@ static const struct gpio_sam0_config gpio_sam0_config_1 = {
 static struct gpio_sam0_data gpio_sam0_data_1;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(portb),
-		    gpio_sam0_init, device_pm_control_nop,
+		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_1, &gpio_sam0_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
@@ -348,7 +348,7 @@ static const struct gpio_sam0_config gpio_sam0_config_2 = {
 static struct gpio_sam0_data gpio_sam0_data_2;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(portc),
-		    gpio_sam0_init, device_pm_control_nop,
+		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_2, &gpio_sam0_config_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
@@ -370,7 +370,7 @@ static const struct gpio_sam0_config gpio_sam0_config_3 = {
 static struct gpio_sam0_data gpio_sam0_data_3;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(portd),
-		    gpio_sam0_init, device_pm_control_nop,
+		    gpio_sam0_init, NULL,
 		    &gpio_sam0_data_3, &gpio_sam0_config_3,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -264,7 +264,7 @@ int gpio_sam_init(const struct device *dev)
 									\
 	static struct gpio_sam_runtime port_##n##_sam_runtime;		\
 									\
-	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, gpio_sam_init, NULL,			\
 			    &port_##n##_sam_runtime,			\
 			    &port_##n##_sam_config, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -359,7 +359,7 @@ static struct gpio_sifive_data gpio_sifive_data0;
 
 DEVICE_DT_INST_DEFINE(0,
 		    gpio_sifive_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &gpio_sifive_data0, &gpio_sifive_config0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sifive_driver);

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -252,7 +252,7 @@ static const struct gpio_driver_api gpio_stellaris_driver_api = {
 											\
 	DEVICE_DT_INST_DEFINE(n,							\
 			    gpio_stellaris_init,					\
-			    device_pm_control_nop,					\
+			    NULL,							\
 			    &port_## n ##_stellaris_runtime,				\
 			    &gpio_stellaris_port_## n ##_config,			\
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -592,7 +592,7 @@ static int gpio_stm32_init(const struct device *dev)
 	static struct gpio_stm32_data gpio_stm32_data_## __suffix;	       \
 	DEVICE_DT_DEFINE(__node,					       \
 			    gpio_stm32_init,				       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &gpio_stm32_data_## __suffix,		       \
 			    &gpio_stm32_cfg_## __suffix,		       \
 			    POST_KERNEL,				       \

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -784,7 +784,7 @@ static struct sx1509b_drv_data sx1509b_drvdata = {
 	.lock = Z_SEM_INITIALIZER(sx1509b_drvdata.lock, 1, 1),
 };
 
-DEVICE_DT_INST_DEFINE(0, sx1509b_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, sx1509b_init, NULL,
 		 &sx1509b_drvdata, &sx1509b_cfg,
 		 POST_KERNEL, CONFIG_GPIO_SX1509B_INIT_PRIORITY,
 		 &api_table);

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -283,7 +283,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 									\
 	DEVICE_DT_DEFINE(DT_CHILD(DT_DRV_INST(n), gpio2),		\
 			&gpio_xlnx_axi_init,				\
-			device_pm_control_nop,				\
+			NULL,						\
 			&gpio_xlnx_axi_##n##_2_data,			\
 			&gpio_xlnx_axi_##n##_2_config,			\
 			POST_KERNEL,					\
@@ -311,7 +311,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			&gpio_xlnx_axi_init,				\
-			device_pm_control_nop,				\
+			NULL,						\
 			&gpio_xlnx_axi_##n##_data,			\
 			&gpio_xlnx_axi_##n##_config,			\
 			POST_KERNEL,					\


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `flash`
- `gpio`