### PR TITLE
drivers: remove usage of device_pm_control_nop (6)

### DIFF
--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -382,7 +382,7 @@ static const struct i2c_cc32xx_config i2c_cc32xx_config = {
 
 static struct i2c_cc32xx_data i2c_cc32xx_data;
 
-DEVICE_DT_INST_DEFINE(0, &i2c_cc32xx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &i2c_cc32xx_init, NULL,
 		    &i2c_cc32xx_data, &i2c_cc32xx_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_cc32xx_driver_api);

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -727,7 +727,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		I2C_DW_INIT_PCIE(n)                                           \
 	};                                                                    \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                    \
-	DEVICE_DT_INST_DEFINE(n, &i2c_dw_initialize, device_pm_control_nop,   \
+	DEVICE_DT_INST_DEFINE(n, &i2c_dw_initialize, NULL,                    \
 			      &i2c_##n##_runtime, &i2c_config_dw_##n,         \
 			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,          \
 			      &funcs);                                        \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -145,7 +145,7 @@ static struct i2c_driver_api i2c_emul_api = {
 	static struct i2c_emul_data i2c_emul_data_##n; \
 	DEVICE_DT_INST_DEFINE(n, \
 			    i2c_emul_init, \
-			    device_pm_control_nop, \
+			    NULL, \
 			    &i2c_emul_data_##n, \
 			    &i2c_emul_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -614,7 +614,7 @@ static const struct i2c_esp32_config i2c_esp32_config_0 = {
 
 static struct i2c_esp32_data i2c_esp32_data_0;
 
-DEVICE_DT_INST_DEFINE(0, &i2c_esp32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &i2c_esp32_init, NULL,
 		    &i2c_esp32_data_0, &i2c_esp32_config_0,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);
@@ -658,7 +658,7 @@ static const struct i2c_esp32_config i2c_esp32_config_1 = {
 
 static struct i2c_esp32_data i2c_esp32_data_1;
 
-DEVICE_DT_INST_DEFINE(1, &i2c_esp32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(1, &i2c_esp32_init, NULL,
 		    &i2c_esp32_data_1, &i2c_esp32_config_1,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -227,7 +227,7 @@ static const struct i2c_gecko_config i2c_gecko_config_##idx = { \
 static struct i2c_gecko_data i2c_gecko_data_##idx; \
 \
 DEVICE_DT_INST_DEFINE(idx, &i2c_gecko_init, \
-		 device_pm_control_nop,	\
+		 NULL, \
 		 &i2c_gecko_data_##idx, &i2c_gecko_config_##idx, \
 		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 		 &i2c_gecko_driver_api);

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -184,7 +184,7 @@ static const struct i2c_gpio_config i2c_gpio_dev_cfg_##_num = {		\
 									\
 DEVICE_DT_INST_DEFINE(_num,						\
 	    i2c_gpio_init,						\
-	    device_pm_control_nop,					\
+	    NULL,							\
 	    &i2c_gpio_dev_data_##_num,					\
 	    &i2c_gpio_dev_cfg_##_num,					\
 	    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &api);

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -373,7 +373,7 @@ static const struct i2c_driver_api i2c_imx_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 				&i2c_imx_init,				\
-				device_pm_control_nop,			\
+				NULL,					\
 				&i2c_imx_data_##n, &i2c_imx_config_##n,	\
 				POST_KERNEL,				\
 				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -874,7 +874,7 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 	static struct i2c_it8xxx2_data i2c_it8xxx2_data_##idx;	               \
 	\
 	DEVICE_DT_INST_DEFINE(idx,				               \
-			&i2c_it8xxx2_init, &device_pm_control_nop,             \
+			&i2c_it8xxx2_init, &NULL,			       \
 			&i2c_it8xxx2_data_##idx,	                       \
 			&i2c_it8xxx2_cfg_##idx, POST_KERNEL,		       \
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                    \

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -126,7 +126,7 @@ static const struct i2c_driver_api i2c_litex_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(n,					       \
 			   i2c_litex_init,				       \
-			   device_pm_control_nop,			       \
+			   NULL,					       \
 			   &i2c_bitbang_##n,	                               \
 			   &i2c_litex_cfg_##n,				       \
 			   POST_KERNEL,					       \

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -349,7 +349,7 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
 static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
 									\
 DEVICE_DT_DEFINE(DT_NODELABEL(name), &i2c_stm32_init,			\
-		    device_pm_control_nop, &i2c_stm32_dev_data_##name,	\
+		    NULL, &i2c_stm32_dev_data_##name,			\
 		    &i2c_stm32_cfg_##name,				\
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 		    &api_funcs);					\

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -403,7 +403,7 @@ static struct lpc11u6x_i2c_data i2c_data_##idx;			              \
 									      \
 DEVICE_DT_INST_DEFINE(idx,						      \
 		    &lpc11u6x_i2c_init,					      \
-		    device_pm_control_nop,				      \
+		    NULL,						      \
 		    &i2c_data_##idx, &i2c_cfg_##idx,			      \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	      \
 		    &i2c_api);						      \

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -654,7 +654,7 @@ static int i2c_xec_init(const struct device *dev)
 		.girq_bit = DT_INST_PROP(n, girq_bit),			\
 		.irq_config_func = i2c_xec_irq_config_func_##n,		\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &i2c_xec_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &i2c_xec_init, NULL,			\
 		&i2c_xec_data_##n, &i2c_xec_config_##n,			\
 		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
 		&i2c_xec_driver_api);					\

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -231,7 +231,7 @@ static const struct i2c_driver_api i2c_mcux_driver_api = {
 	static struct i2c_mcux_data i2c_mcux_data_ ## n;		\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			&i2c_mcux_init, device_pm_control_nop,		\
+			&i2c_mcux_init, NULL,				\
 			&i2c_mcux_data_ ## n,				\
 			&i2c_mcux_config_ ## n, POST_KERNEL,		\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -227,7 +227,7 @@ static const struct i2c_driver_api mcux_flexcomm_driver_api = {
 	static struct mcux_flexcomm_data mcux_flexcomm_data_##id;	\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    &mcux_flexcomm_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_flexcomm_data_##id,			\
 			    &mcux_flexcomm_config_##id,			\
 			    POST_KERNEL,				\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -260,7 +260,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 									\
 	static struct mcux_lpi2c_data mcux_lpi2c_data_##n;		\
 									\
-	DEVICE_DT_INST_DEFINE(n, &mcux_lpi2c_init, device_pm_control_nop,\
+	DEVICE_DT_INST_DEFINE(n, &mcux_lpi2c_init, NULL,		\
 			    &mcux_lpi2c_data_##n,			\
 			    &mcux_lpi2c_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -165,7 +165,7 @@ static struct i2c_nios2_config i2c_nios2_cfg = {
 	},
 };
 
-DEVICE_DT_INST_DEFINE(0, &i2c_nios2_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &i2c_nios2_init, NULL,
 		    NULL, &i2c_nios2_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_nios2_driver_api);

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -920,7 +920,7 @@ static int i2c_ctrl_init(const struct device *dev)
 									       \
 	DEVICE_DT_INST_DEFINE(inst,                                            \
 			    NPCX_I2C_CTRL_INIT_FUNC(inst),                     \
-			    device_pm_control_nop,                             \
+			    NULL,                                              \
 			    &i2c_ctrl_data_##inst, &i2c_ctrl_cfg_##inst,       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    NULL);                                             \

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -174,7 +174,7 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(inst,                                            \
 			    NPCX_I2C_PORT_INIT_FUNC(inst),                     \
-			    device_pm_control_nop,                             \
+			    NULL,                                              \
 			    &i2c_npcx_port_data_##inst,                        \
 			    &i2c_npcx_port_cfg_##inst,                         \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -266,7 +266,7 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 	};                                                                     \
 	DEVICE_DT_INST_DEFINE(id,                                              \
 			    &rv32m1_lpi2c_init,                                \
-			    device_pm_control_nop,                             \
+			    NULL,                                              \
 			    &rv32m1_lpi2c_##id##_data,                         \
 			    &rv32m1_lpi2c_##id##_config,                       \
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,             \

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -789,7 +789,7 @@ static const struct i2c_sam0_dev_config i2c_sam0_dev_config_##n = {	\
 	static struct i2c_sam0_dev_data i2c_sam0_dev_data_##n;		\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &i2c_sam0_initialize,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &i2c_sam0_dev_data_##n,			\
 			    &i2c_sam0_dev_config_##n, POST_KERNEL,	\
 			    CONFIG_I2C_INIT_PRIORITY,			\

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -632,7 +632,7 @@ static const struct i2c_driver_api i2c_sam_twim_driver_api = {
 	static struct i2c_sam_twim_dev_data i2c##n##_sam_data;		\
 									\
 	DEVICE_DT_INST_DEFINE(n, &i2c_sam_twim_initialize,		\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\
 			    &i2c_sam_twim_driver_api)

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -362,7 +362,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 	static struct i2c_sam_twi_dev_data i2c##n##_sam_data;		\
 									\
 	DEVICE_DT_INST_DEFINE(n, &i2c_sam_twi_initialize,		\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\
 			    &i2c_sam_twi_driver_api);

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -349,7 +349,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 	static struct i2c_sam_twihs_dev_data i2c##n##_sam_data;		\
 									\
 	DEVICE_DT_INST_DEFINE(n, &i2c_sam_twihs_initialize, 		\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &i2c##n##_sam_data, &i2c##n##_sam_config,	\
 			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	\
 			    &i2c_sam_twihs_driver_api);

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -118,7 +118,7 @@ static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
 									\
 DEVICE_DT_INST_DEFINE(_num,						\
 	    i2c_sbcon_init,						\
-	    device_pm_control_nop,					\
+	    NULL,							\
 	    &i2c_sbcon_dev_data_##_num,					\
 	    &i2c_sbcon_dev_cfg_##_num,					\
 	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -331,7 +331,7 @@ static struct i2c_driver_api i2c_sifive_api = {
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \
 			    i2c_sifive_init, \
-			    device_pm_control_nop, \
+			    NULL, \
 			    NULL, \
 			    &i2c_sifive_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/i2c/i2c_test.c
+++ b/drivers/i2c/i2c_test.c
@@ -38,7 +38,7 @@ static int vnd_i2c_init(const struct device *dev)
 }
 
 #define VND_I2C_INIT(n)						\
-	DEVICE_DT_INST_DEFINE(n, &vnd_i2c_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &vnd_i2c_init, NULL,			\
 			      NULL, NULL, POST_KERNEL,			\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      &vnd_i2c_api);

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -222,7 +222,7 @@ static int i2c_eeprom_slave_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    &i2c_eeprom_slave_init,			\
-			    device_pm_control_nop,			\
+			    NULL,			\
 			    &i2c_eeprom_slave_##inst##_dev_data,	\
 			    &i2c_eeprom_slave_##inst##_cfg,		\
 			    POST_KERNEL,				\

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -872,7 +872,7 @@ static const struct i2s_driver_api i2s_cavs_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			i2s_cavs_initialize, device_pm_control_nop,	\
+			i2s_cavs_initialize, NULL,			\
 			&i2s_cavs_data_##n,				\
 			&i2s_cavs_config_##n,				\
 			POST_KERNEL, CONFIG_I2S_INIT_PRIORITY,		\

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -625,7 +625,7 @@ static const struct i2s_driver_api i2s_litex_driver_api = {
 		.irq_config = i2s_litex_irq_config_func_##dir                  \
 	};                                                                     \
 	DEVICE_DT_DEFINE(DT_NODELABEL(i2s_##dir), i2s_litex_initialize,        \
-				device_pm_control_nop, &i2s_litex_data_##dir,  \
+				NULL, &i2s_litex_data_##dir,		       \
 				&i2s_litex_cfg_##dir, POST_KERNEL,             \
 				CONFIG_I2S_INIT_PRIORITY,		       \
 				&i2s_litex_driver_api);			       \

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -916,7 +916,7 @@ static struct i2s_stm32_data i2s_stm32_data_##index = {			\
 		I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL)),\
 };									\
 DEVICE_DT_DEFINE(DT_NODELABEL(i2s##index),				\
-		    &i2s_stm32_initialize, device_pm_control_nop,	\
+		    &i2s_stm32_initialize, NULL,			\
 		    &i2s_stm32_data_##index,				\
 		    &i2s_stm32_config_##index, POST_KERNEL,		\
 		    CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_driver_api);	\

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -1024,6 +1024,6 @@ static struct i2s_sam_dev_data i2s0_sam_data = {
 	},
 };
 
-DEVICE_DT_INST_DEFINE(0, &i2s_sam_initialize, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &i2s_sam_initialize, NULL,
 		    &i2s0_sam_data, &i2s0_sam_config, POST_KERNEL,
 		    CONFIG_I2S_INIT_PRIORITY, &i2s_sam_driver_api);

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -856,7 +856,7 @@ static struct ieee802154_radio_api cc1200_radio_api = {
 };
 
 NET_DEVICE_INIT(cc1200, CONFIG_IEEE802154_CC1200_DRV_NAME,
-		cc1200_init, device_pm_control_nop,
+		cc1200_init, NULL,
 		&cc1200_context_data, NULL,
 		CONFIG_IEEE802154_CC1200_INIT_PRIO,
 		&cc1200_radio_api, IEEE802154_L2,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -761,7 +761,7 @@ static struct ieee802154_cc13xx_cc26xx_data ieee802154_cc13xx_cc26xx_data = {
 #if defined(CONFIG_NET_L2_IEEE802154)
 NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx,
 		CONFIG_IEEE802154_CC13XX_CC26XX_DRV_NAME,
-		ieee802154_cc13xx_cc26xx_init, device_pm_control_nop,
+		ieee802154_cc13xx_cc26xx_init, NULL,
 		&ieee802154_cc13xx_cc26xx_data, NULL,
 		CONFIG_IEEE802154_CC13XX_CC26XX_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_radio_api, IEEE802154_L2,
@@ -769,7 +769,7 @@ NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx,
 #else
 DEVICE_DEFINE(ieee802154_cc13xx_cc26xx,
 		CONFIG_IEEE802154_CC13XX_CC26XX_DRV_NAME,
-		ieee802154_cc13xx_cc26xx_init, device_pm_control_nop,
+		ieee802154_cc13xx_cc26xx_init, NULL,
 		&ieee802154_cc13xx_cc26xx_data,
 		NULL, POST_KERNEL, CONFIG_IEEE802154_CC13XX_CC26XX_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_radio_api);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -759,7 +759,7 @@ static struct ieee802154_cc13xx_cc26xx_subg_data
 #if defined(CONFIG_NET_L2_IEEE802154_SUB_GHZ)
 NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx_subg,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DRV_NAME,
-		ieee802154_cc13xx_cc26xx_subg_init, device_pm_control_nop,
+		ieee802154_cc13xx_cc26xx_subg_init, NULL,
 		&ieee802154_cc13xx_cc26xx_subg_data, NULL,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_subg_radio_api, IEEE802154_L2,
@@ -768,7 +768,7 @@ NET_DEVICE_INIT(ieee802154_cc13xx_cc26xx_subg,
 DEVICE_DEFINE(ieee802154_cc13xx_cc26xx_subg,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DRV_NAME,
 		ieee802154_cc13xx_cc26xx_subg_init,
-		device_pm_control_nop,
+		NULL,
 		&ieee802154_cc13xx_cc26xx_subg_data, NULL, POST_KERNEL,
 		CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO,
 		&ieee802154_cc13xx_cc26xx_subg_radio_api);

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1151,12 +1151,12 @@ static struct ieee802154_radio_api cc2520_radio_api = {
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
 DEVICE_DEFINE(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
-		cc2520_init, device_pm_control_nop, &cc2520_context_data, NULL,
+		cc2520_init, NULL, &cc2520_context_data, NULL,
 		POST_KERNEL, CONFIG_IEEE802154_CC2520_INIT_PRIO,
 		&cc2520_radio_api);
 #else
 NET_DEVICE_INIT(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
-		cc2520_init, device_pm_control_nop,
+		cc2520_init, NULL,
 		&cc2520_context_data, NULL,
 		CONFIG_IEEE802154_CC2520_INIT_PRIO,
 		&cc2520_radio_api, IEEE802154_L2,
@@ -1486,7 +1486,7 @@ struct crypto_driver_api cc2520_crypto_api = {
 };
 
 DEVICE_DEFINE(cc2520_crypto, CONFIG_IEEE802154_CC2520_CRYPTO_DRV_NAME,
-		cc2520_crypto_init, device_pm_control_nop,
+		cc2520_crypto_init, NULL,
 		&cc2520_context_data, NULL, POST_KERNEL,
 		CONFIG_IEEE802154_CC2520_CRYPTO_INIT_PRIO, &cc2520_crypto_api);
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1667,14 +1667,14 @@ static struct ieee802154_radio_api dwt_radio_api = {
 #define DWT_PSDU_LENGTH		(127 - DWT_FCS_LENGTH)
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
-DEVICE_DT_INST_DEFINE(0, dw1000_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, dw1000_init, NULL,
 		    &dwt_0_context, &dw1000_0_config,
 		    POST_KERNEL, CONFIG_IEEE802154_DW1000_INIT_PRIO,
 		    &dwt_radio_api);
 #else
 NET_DEVICE_DT_INST_DEFINE(0,
 		dw1000_init,
-		device_pm_control_nop,
+		NULL,
 		&dwt_0_context,
 		&dw1000_0_config,
 		CONFIG_IEEE802154_DW1000_INIT_PRIO,

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1115,7 +1115,7 @@ NET_DEVICE_INIT(
 	kw41z,                              /* Device Name */
 	CONFIG_IEEE802154_KW41Z_DRV_NAME,   /* Driver Name */
 	kw41z_init,                         /* Initialization Function */
-	device_pm_control_nop,              /* No PM API support */
+	NULL,              /* No PM API support */
 	&kw41z_context_data,                /* Context data */
 	NULL,                               /* Configuration info */
 	CONFIG_IEEE802154_KW41Z_INIT_PRIO,  /* Initial priority */

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1478,12 +1478,12 @@ static struct ieee802154_radio_api mcr20a_radio_api = {
 
 #if defined(CONFIG_IEEE802154_RAW_MODE)
 DEVICE_DEFINE(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
-		mcr20a_init, device_pm_control_nop, &mcr20a_context_data, NULL,
+		mcr20a_init, NULL, &mcr20a_context_data, NULL,
 		POST_KERNEL, CONFIG_IEEE802154_MCR20A_INIT_PRIO,
 		&mcr20a_radio_api);
 #else
 NET_DEVICE_INIT(mcr20a, CONFIG_IEEE802154_MCR20A_DRV_NAME,
-		mcr20a_init, device_pm_control_nop, &mcr20a_context_data, NULL,
+		mcr20a_init, NULL, &mcr20a_context_data, NULL,
 		CONFIG_IEEE802154_MCR20A_INIT_PRIO,
 		&mcr20a_radio_api, IEEE802154_L2,
 		NET_L2_GET_CTX_TYPE(IEEE802154_L2),

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -849,13 +849,13 @@ static struct ieee802154_radio_api nrf5_radio_api = {
 
 #if defined(CONFIG_NET_L2_IEEE802154) || defined(CONFIG_NET_L2_OPENTHREAD)
 NET_DEVICE_INIT(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
-		nrf5_init, device_pm_control_nop, &nrf5_data, &nrf5_radio_cfg,
+		nrf5_init, NULL, &nrf5_data, &nrf5_radio_cfg,
 		CONFIG_IEEE802154_NRF5_INIT_PRIO,
 		&nrf5_radio_api, L2,
 		L2_CTX_TYPE, MTU);
 #else
 DEVICE_DEFINE(nrf5_154_radio, CONFIG_IEEE802154_NRF5_DRV_NAME,
-		nrf5_init, device_pm_control_nop, &nrf5_data, &nrf5_radio_cfg,
+		nrf5_init, NULL, &nrf5_data, &nrf5_radio_cfg,
 		POST_KERNEL, CONFIG_IEEE802154_NRF5_INIT_PRIO,
 		&nrf5_radio_api);
 #endif

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -953,7 +953,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 	DEVICE_DT_INST_DEFINE(			   \
 		n,				   \
 		&rf2xx_init,			   \
-		device_pm_control_nop,		   \
+		NULL,				   \
 		&rf2xx_ctx_data_##n,		   \
 		&rf2xx_ctx_config_##n,		   \
 		POST_KERNEL,			   \
@@ -964,7 +964,7 @@ static struct ieee802154_radio_api rf2xx_radio_api = {
 	NET_DEVICE_DT_INST_DEFINE(		   \
 		n,				   \
 		&rf2xx_init,			   \
-		device_pm_control_nop,		   \
+		NULL,				   \
 		&rf2xx_ctx_data_##n,		   \
 		&rf2xx_ctx_config_##n,		   \
 		CONFIG_IEEE802154_RF2XX_INIT_PRIO, \

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -392,7 +392,7 @@ static struct ieee802154_radio_api upipe_radio_api = {
 };
 
 NET_DEVICE_INIT(upipe_15_4, CONFIG_IEEE802154_UPIPE_DRV_NAME,
-		upipe_init, device_pm_control_nop,
+		upipe_init, NULL,
 		&upipe_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&upipe_radio_api, IEEE802154_L2,

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -150,7 +150,7 @@ static const struct irq_next_level_api cavs_apis = {
 	};								\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    cavs_ictl_##n##_initialize,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &cavs_##n##_runtime, &cavs_config_##n,	\
 			    PRE_KERNEL_1,				\
 			    CONFIG_CAVS_ICTL_INIT_PRIORITY, &cavs_apis);\

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -143,7 +143,7 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	.intr_get_line_state = dw_ictl_intr_get_line_state,
 };
 
-DEVICE_DT_INST_DEFINE(0, dw_ictl_initialize, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, dw_ictl_initialize, NULL,
 		NULL, &dw_config, PRE_KERNEL_1,
 		CONFIG_DW_ICTL_INIT_PRIORITY, &dw_ictl_apis);
 

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -417,7 +417,7 @@ static int stm32_exti_init(const struct device *dev)
 
 static struct stm32_exti_data exti_data;
 DEVICE_DT_DEFINE(EXTI_NODE, &stm32_exti_init,
-		 device_pm_control_nop,
+		 NULL,
 		 &exti_data, NULL,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		 NULL);

--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -130,6 +130,6 @@ static const struct vtd_ictl_cfg vtd_ictl_cfg_0 = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-	      vtd_ictl_init, device_pm_control_nop,
+	      vtd_ictl_init, NULL,
 	      &vtd_ictl_data_0, &vtd_ictl_cfg_0,
 	      PRE_KERNEL_1, CONFIG_INTEL_VTD_ICTL_INIT_PRIORITY, &vtd_api);

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -360,7 +360,7 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
 			    NPCX_MIWU_INIT_FUNC(inst),                         \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    NULL, &miwu_config_##inst,                         \
 			    PRE_KERNEL_1,                                      \
 			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS, NULL);        \

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -213,6 +213,6 @@ static int rv32m1_intmux_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, &rv32m1_intmux_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, &rv32m1_intmux_init, NULL, NULL,
 		    &rv32m1_intmux_cfg, PRE_KERNEL_1,
 		    CONFIG_RV32M1_INTMUX_INIT_PRIORITY, &rv32m1_intmux_apis);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -411,6 +411,6 @@ static int sam0_eic_init(const struct device *dev)
 
 static struct sam0_eic_data eic_data;
 DEVICE_DT_INST_DEFINE(0, sam0_eic_init,
-	      device_pm_control_nop, &eic_data, NULL,
+	      NULL, &eic_data, NULL,
 	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 	      NULL);

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -155,7 +155,7 @@ const struct shared_irq_config shared_irq_config_0 = {
 struct shared_irq_runtime shared_irq_0_runtime;
 
 DEVICE_DT_INST_DEFINE(0, shared_irq_initialize,
-		device_pm_control_nop, &shared_irq_0_runtime,
+		NULL, &shared_irq_0_runtime,
 		&shared_irq_config_0, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
@@ -181,7 +181,7 @@ const struct shared_irq_config shared_irq_config_1 = {
 struct shared_irq_runtime shared_irq_1_runtime;
 
 DEVICE_DT_INST_DEFINE(1, shared_irq_initialize,
-		device_pm_control_nop, &shared_irq_1_runtime,
+		NULL, &shared_irq_1_runtime,
 		&shared_irq_config_1, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `i2c`
- `i2s`
- `ieee802154`
- `interrupt_controller`

Fixes #34668 