### PR TITLE
drivers: remove usage of device_pm_control_nop (7)

### DIFF
--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -223,7 +223,7 @@ static const struct ipm_driver_api cavs_idc_driver_api = {
 	.set_enabled = cavs_idc_set_enabled,
 };
 
-DEVICE_DT_INST_DEFINE(0, &cavs_idc_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &cavs_idc_init, NULL,
 		    &cavs_idc_device_data, NULL,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &cavs_idc_driver_api);

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -216,7 +216,7 @@ static struct imx_mu_data imx_mu_b_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &imx_mu_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &imx_mu_b_data, &imx_mu_b_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &imx_mu_driver_api);

--- a/drivers/ipm/ipm_intel_adsp.c
+++ b/drivers/ipm/ipm_intel_adsp.c
@@ -207,7 +207,7 @@ static struct ipm_adsp_data ipm_adsp_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &ipm_adsp_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &ipm_adsp_data, &ipm_adsp_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_adsp_driver_api);

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -174,7 +174,7 @@ static struct mcux_mailbox_data mcux_mailbox_0_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_mailbox_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &mcux_mailbox_0_data, &mcux_mailbox_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &mcux_mailbox_driver_api);

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -187,7 +187,7 @@ static struct ipm_mhu_data ipm_mhu_data_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 			&ipm_mhu_init,
-			device_pm_control_nop,
+			NULL,
 			&ipm_mhu_data_0,
 			&ipm_mhu_cfg_0, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -218,7 +218,7 @@ static struct ipm_mhu_data ipm_mhu_data_1 = {
 
 DEVICE_DT_INST_DEFINE(1,
 			&ipm_mhu_init,
-			device_pm_control_nop,
+			NULL,
 			&ipm_mhu_data_1,
 			&ipm_mhu_cfg_1, PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -108,7 +108,7 @@ static const struct ipm_driver_api ipm_nrf_driver_api = {
 	.set_enabled = ipm_nrf_set_enabled
 };
 
-DEVICE_DT_INST_DEFINE(0, ipm_nrf_init, device_pm_control_nop, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, ipm_nrf_init, NULL, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &ipm_nrf_driver_api);
 
@@ -226,7 +226,7 @@ static const struct ipm_driver_api vipm_nrf_##_idx##_driver_api = {	\
 };									\
 									\
 DEVICE_DEFINE(vipm_nrf_##_idx, "IPM_"#_idx,				\
-		    vipm_nrf_init, device_pm_control_nop, NULL, NULL,	\
+		    vipm_nrf_init, NULL, NULL, NULL,			\
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 		    &vipm_nrf_##_idx##_driver_api)
 

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -296,7 +296,7 @@ static const struct stm32_ipcc_mailbox_config stm32_ipcc_mailbox_0_config = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &stm32_ipcc_mailbox_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &stm32_IPCC_data, &stm32_ipcc_mailbox_0_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &stm32_ipcc_mailbox_driver_api);

--- a/drivers/kscan/kscan_ft5336.c
+++ b/drivers/kscan/kscan_ft5336.c
@@ -267,7 +267,7 @@ static const struct kscan_driver_api ft5336_driver_api = {
 #define FT5336_INIT(index)                                                     \
 	FT5336_DEFINE_CONFIG(index);					       \
 	static struct ft5336_data ft5336_data_##index;			       \
-	DEVICE_DT_INST_DEFINE(index, ft5336_init, device_pm_control_nop,       \
+	DEVICE_DT_INST_DEFINE(index, ft5336_init, NULL,			       \
 			    &ft5336_data_##index, &ft5336_config_##index,      \
 			    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,	       \
 			    &ft5336_driver_api);

--- a/drivers/kscan/kscan_mchp_xec.c
+++ b/drivers/kscan/kscan_mchp_xec.c
@@ -374,7 +374,7 @@ static int kscan_xec_init(const struct device *dev);
 
 DEVICE_DT_INST_DEFINE(0,
 		    &kscan_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &kscan_xec_driver_api);

--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -107,6 +107,6 @@ static const struct kscan_driver_api sdl_driver_api = {
 static struct sdl_data sdl_data;
 
 DEVICE_DEFINE(sdl, CONFIG_SDL_POINTER_KSCAN_DEV_NAME, sdl_init,
-		    device_pm_control_nop, &sdl_data, NULL,
+		    NULL, &sdl_data, NULL,
 		    POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 		    &sdl_driver_api);

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -473,7 +473,7 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, NULL,			\
 			    &ht16k33_##id##_data,			\
 			    &ht16k33_##id##_cfg, POST_KERNEL,		\
 			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)
@@ -493,7 +493,7 @@ static const struct led_driver_api ht16k33_leds_api = {
 									\
 	static struct ht16k33_data ht16k33_##id##_data;			\
 									\
-	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(id, &ht16k33_init, NULL,			\
 			    &ht16k33_##id##_data,			\
 			    &ht16k33_##id##_cfg, POST_KERNEL,		\
 			    CONFIG_LED_INIT_PRIORITY, &ht16k33_leds_api)

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -99,7 +99,7 @@ static const struct led_gpio_config led_gpio_config_##i = {	\
 	.led		= gpio_dt_spec_##i,			\
 };								\
 								\
-DEVICE_DT_INST_DEFINE(i, &led_gpio_init, device_pm_control_nop,	\
+DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
 		      NULL, &led_gpio_config_##i,		\
 		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
 		      &led_gpio_api);

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -279,7 +279,7 @@ static const struct led_driver_api lp3943_led_api = {
 	.off = lp3943_led_off,
 };
 
-DEVICE_DT_INST_DEFINE(0, &lp3943_led_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &lp3943_led_init, NULL,
 		    &lp3943_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &lp3943_led_api);

--- a/drivers/led/lp503x.c
+++ b/drivers/led/lp503x.c
@@ -278,7 +278,7 @@ static struct lp503x_data lp503x_data_##id = {			\
 								\
 DEVICE_DT_INST_DEFINE(id,					\
 		    &lp503x_init,				\
-		    device_pm_control_nop,			\
+		    NULL,					\
 		    &lp503x_data_##id,				\
 		    &lp503x_config_##id,			\
 		    POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -953,7 +953,7 @@ static const struct led_driver_api lp5562_led_api = {
 	.off = lp5562_led_off,
 };
 
-DEVICE_DT_INST_DEFINE(0, &lp5562_led_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &lp5562_led_init, NULL,
 		&lp5562_led_data,
 		NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		&lp5562_led_api);

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -203,7 +203,7 @@ static const struct led_driver_api pca9633_led_api = {
 	.off = pca9633_led_off,
 };
 
-DEVICE_DT_INST_DEFINE(0, &pca9633_led_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &pca9633_led_init, NULL,
 		    &pca9633_led_data,
 		    NULL, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
 		    &pca9633_led_api);

--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -121,6 +121,6 @@ static const struct led_strip_driver_api apa102_api = {
 	.update_channels = apa102_update_channels,
 };
 
-DEVICE_DT_INST_DEFINE(0, apa102_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, apa102_init, NULL,
 		    &apa102_data_0, NULL, POST_KERNEL,
 		    CONFIG_LED_STRIP_INIT_PRIORITY, &apa102_api);

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -154,7 +154,7 @@ static const struct led_strip_driver_api lpd880x_strip_api = {
 	.update_channels = lpd880x_strip_update_channels,
 };
 
-DEVICE_DT_INST_DEFINE(0, lpd880x_strip_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lpd880x_strip_init, NULL,
 		    &lpd880x_strip_data,
 		    NULL, POST_KERNEL, CONFIG_LED_STRIP_INIT_PRIORITY,
 		    &lpd880x_strip_api);

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -236,7 +236,7 @@ static const struct led_strip_driver_api ws2812_gpio_api = {
 									\
 	DEVICE_DT_INST_DEFINE(idx,					\
 			    ws2812_gpio_##idx##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &ws2812_gpio_##idx##_data,			\
 			    &ws2812_gpio_##idx##_cfg, POST_KERNEL,	\
 			    CONFIG_LED_STRIP_INIT_PRIORITY,		\

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -223,7 +223,7 @@ static const struct led_strip_driver_api ws2812_spi_api = {
 									\
 	DEVICE_DT_INST_DEFINE(idx,					\
 			    ws2812_spi_##idx##_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &ws2812_spi_##idx##_data,			\
 			    &ws2812_spi_##idx##_cfg,			\
 			    POST_KERNEL,				\

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -530,6 +530,6 @@ static const struct lora_driver_api sx126x_lora_api = {
 	.test_cw = sx12xx_lora_test_cw,
 };
 
-DEVICE_DT_INST_DEFINE(0, &sx126x_lora_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, &sx126x_lora_init, NULL, NULL,
 		    NULL, POST_KERNEL, CONFIG_LORA_INIT_PRIORITY,
 		    &sx126x_lora_api);

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -646,6 +646,6 @@ static const struct lora_driver_api sx127x_lora_api = {
 	.test_cw = sx12xx_lora_test_cw,
 };
 
-DEVICE_DT_INST_DEFINE(0, &sx127x_lora_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, &sx127x_lora_init, NULL, NULL,
 		      NULL, POST_KERNEL, CONFIG_LORA_INIT_PRIORITY,
 		      &sx127x_lora_api);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `ipm`
- `kscan`
- `led`
- `led_strip`
- `lora`