### PR TITLE
drivers: remove usage of device_pm_control_nop (8)

### DIFF
--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -163,7 +163,7 @@ static int memc_flexspi_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      memc_flexspi_init,			\
-			      device_pm_control_nop,			\
+			      NULL,					\
 			      &memc_flexspi_data_##n,			\
 			      &memc_flexspi_config_##n,			\
 			      POST_KERNEL,				\

--- a/drivers/memc/memc_mcux_flexspi_hyperram.c
+++ b/drivers/memc/memc_mcux_flexspi_hyperram.c
@@ -181,7 +181,7 @@ static int memc_flexspi_hyperram_init(const struct device *dev)
 								  \
 	DEVICE_DT_INST_DEFINE(n,				  \
 			      memc_flexspi_hyperram_init,	  \
-			      device_pm_control_nop,		  \
+			      NULL,				  \
 			      &memc_flexspi_hyperram_data_##n,	  \
 			      &memc_flexspi_hyperram_config_##n,  \
 			      POST_KERNEL,			  \

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -58,5 +58,5 @@ static const struct memc_stm32_config config = {
 	.pinctrl_len = ARRAY_SIZE(pinctrl),
 };
 
-DEVICE_DT_INST_DEFINE(0, memc_stm32_init, device_pm_control_nop, NULL,
+DEVICE_DT_INST_DEFINE(0, memc_stm32_init, NULL, NULL,
 	      &config, POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);

--- a/drivers/memc/memc_stm32_sdram.c
+++ b/drivers/memc/memc_stm32_sdram.c
@@ -129,5 +129,5 @@ static const struct memc_stm32_sdram_config config = {
 	.banks_len = ARRAY_SIZE(bank_config),
 };
 
-DEVICE_DT_INST_DEFINE(0, memc_stm32_sdram_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, memc_stm32_sdram_init, NULL,
 	      NULL, &config, POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -4878,6 +4878,6 @@ static struct net_if_api api_funcs = {
 	.init = offload_iface_init,
 };
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, hl7800_init, device_pm_control_nop, &ictx,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, hl7800_init, NULL, &ictx,
 				  NULL, CONFIG_MODEM_HL7800_INIT_PRIORITY,
 				  &api_funcs, MDM_MTU);

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1197,7 +1197,7 @@ error:
 }
 
 /* Register the device with the Networking stack. */
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, device_pm_control_nop,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, NULL,
 				  &mdata, NULL,
 				  CONFIG_MODEM_QUECTEL_BG9X_INIT_PRIORITY,
 				  &api_funcs, MDM_MAX_DATA_LENGTH);

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2125,7 +2125,7 @@ error:
 	return ret;
 }
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, device_pm_control_nop,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, modem_init, NULL,
 				  &mdata, NULL,
 				  CONFIG_MODEM_UBLOX_SARA_R4_INIT_PRIORITY,
 				  &api_funcs,

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1846,7 +1846,7 @@ static struct net_if_api api_funcs = {
 	.init	= offload_iface_init,
 };
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, wncm14a2a_init, device_pm_control_nop,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, wncm14a2a_init, NULL,
 				  &ictx, NULL,
 				  CONFIG_MODEM_WNCM14A2A_INIT_PRIORITY,
 				  &api_funcs,

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -100,7 +100,7 @@ static struct dummy_api loopback_api = {
 };
 
 NET_DEVICE_INIT(loopback, "lo",
-		loopback_dev_init, device_pm_control_nop, NULL, NULL,
+		loopback_dev_init, NULL, NULL, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&loopback_api, DUMMY_L2,
 		NET_L2_GET_CTX_TYPE(DUMMY_L2), 536);

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -914,6 +914,6 @@ static const struct ppp_api ppp_if_api = {
 };
 
 NET_DEVICE_INIT(ppp, CONFIG_NET_PPP_DRV_NAME, ppp_driver_init,
-		device_pm_control_nop, &ppp_driver_context_data, NULL,
+		NULL, &ppp_driver_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &ppp_if_api,
 		PPP_L2, NET_L2_GET_CTX_TYPE(PPP_L2), PPP_MTU);

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -457,7 +457,7 @@ static const struct ethernet_api slip_if_api = {
 #define _SLIP_MTU 1500
 
 ETH_NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME,
-		    slip_init, device_pm_control_nop,
+		    slip_init, NULL,
 		    &slip_context_data, NULL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &slip_if_api, _SLIP_MTU);
@@ -473,7 +473,7 @@ static const struct dummy_api slip_if_api = {
 #define _SLIP_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
 #define _SLIP_MTU 576
 
-NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME, slip_init, device_pm_control_nop,
+NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME, slip_init, NULL,
 		&slip_context_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&slip_if_api, _SLIP_L2_LAYER, _SLIP_L2_CTX_TYPE, _SLIP_MTU);
 #endif

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -525,7 +525,7 @@ static struct intel_gna_data intel_gna_driver_data = {
 };
 
 DEVICE_DT_INST_DEFINE(0, intel_gna_initialize,
-		      device_pm_control_nop,
+		      NULL,
 		      (void *)&intel_gna_driver_data, NULL,
 		      POST_KERNEL, CONFIG_INTEL_GNA_INIT_PRIORITY,
 		      &gna_driver_api);

--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -490,7 +490,7 @@ static struct pcie_ep_driver_api iproc_pcie_ep_api = {
 	.dma_xfer = iproc_pcie_pl330_dma_xfer,
 };
 
-DEVICE_DT_INST_DEFINE(0, &iproc_pcie_ep_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &iproc_pcie_ep_init, NULL,
 		    &iproc_pcie_ep_ctx_0,
 		    &iproc_pcie_ep_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -398,7 +398,7 @@ static int peci_xec_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0,
 		    &peci_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    POST_KERNEL, CONFIG_PECI_INIT_PRIORITY,
 		    &peci_xec_driver_api);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `memc`
- `modem`
- `net`
- `neural_net`
- `pcie`
- `peci`