### PR TITLE
drivers: remove usage of device_pm_control_nop (9)

### DIFF
--- a/drivers/pinmux/pinmux_cc13xx_cc26xx.c
+++ b/drivers/pinmux/pinmux_cc13xx_cc26xx.c
@@ -89,7 +89,7 @@ static const struct pinmux_driver_api pinmux_cc13xx_cc26xx_driver_api = {
 	.input = pinmux_cc13xx_cc26xx_input,
 };
 
-DEVICE_DT_INST_DEFINE(0, &pinmux_cc13xx_cc26xx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &pinmux_cc13xx_cc26xx_init, NULL,
 		    NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_cc13xx_cc26xx_driver_api);

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -187,6 +187,6 @@ static int pinmux_initialize(const struct device *dev)
  * mux driver.
  */
 DEVICE_DT_INST_DEFINE(0, &pinmux_initialize,
-		    device_pm_control_nop, NULL, NULL,
+		    NULL, NULL, NULL,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &api_funcs);

--- a/drivers/pinmux/pinmux_hsdk.c
+++ b/drivers/pinmux/pinmux_hsdk.c
@@ -71,6 +71,6 @@ static const struct pinmux_driver_api pinmux_hsdk_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		&pinmux_hsdk_init, device_pm_control_nop, NULL, NULL,
+		&pinmux_hsdk_init, NULL, NULL, NULL,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&pinmux_hsdk_driver_api);

--- a/drivers/pinmux/pinmux_intel_s1000.c
+++ b/drivers/pinmux/pinmux_intel_s1000.c
@@ -94,5 +94,5 @@ static int pinmux_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, &pinmux_init, device_pm_control_nop, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, &pinmux_init, NULL, NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY, &apis);

--- a/drivers/pinmux/pinmux_ite_it8xxx2.c
+++ b/drivers/pinmux/pinmux_ite_it8xxx2.c
@@ -97,7 +97,7 @@ static const struct pinmux_it8xxx2_config pinmux_it8xxx2_0_config = {
 	.base = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, &pinmux_it8xxx2_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &pinmux_it8xxx2_init, NULL,
 		    NULL, &pinmux_it8xxx2_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_it8xxx2_driver_api);

--- a/drivers/pinmux/pinmux_lpc11u6x.c
+++ b/drivers/pinmux/pinmux_lpc11u6x.c
@@ -109,9 +109,8 @@ static const struct pinmux_lpc11u6x_config			\
 };								\
 								\
 DEVICE_DT_INST_DEFINE(id, &pinmux_lpc11u6x_init,		\
-		    device_pm_control_nop, NULL,		\
-		    &pinmux_lpc11u6x_config_##id, PRE_KERNEL_1,	\
-		    CONFIG_PINMUX_INIT_PRIORITY,		\
+		    NULL, NULL, &pinmux_lpc11u6x_config_##id,	\
+		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,	\
 		    &pinmux_lpc11u6x_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PINMUX_LPC11U6X_INIT)

--- a/drivers/pinmux/pinmux_mchp_xec.c
+++ b/drivers/pinmux/pinmux_mchp_xec.c
@@ -131,7 +131,7 @@ static const struct pinmux_xec_config pinmux_xec_port000_036_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_000_036),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port000_036_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -145,7 +145,7 @@ static const struct pinmux_xec_config pinmux_xec_port040_076_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_040_076),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port040_076_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -159,7 +159,7 @@ static const struct pinmux_xec_config pinmux_xec_port100_136_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_100_136),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port100_136_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -173,7 +173,7 @@ static const struct pinmux_xec_config pinmux_xec_port140_176_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_140_176),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port140_176_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -187,7 +187,7 @@ static const struct pinmux_xec_config pinmux_xec_port200_236_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_200_236),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port200_236_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);
@@ -201,7 +201,7 @@ static const struct pinmux_xec_config pinmux_xec_port240_276_config = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_240_276),
 		    &pinmux_xec_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, &pinmux_xec_port240_276_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_xec_driver_api);

--- a/drivers/pinmux/pinmux_mcux.c
+++ b/drivers/pinmux/pinmux_mcux.c
@@ -84,7 +84,7 @@ static const struct pinmux_driver_api pinmux_mcux_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &pinmux_mcux_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL, &pinmux_mcux_##n##_config,		\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/pinmux/pinmux_mcux_lpc.c
+++ b/drivers/pinmux/pinmux_mcux_lpc.c
@@ -86,7 +86,7 @@ static const struct pinmux_driver_api pinmux_mcux_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &pinmux_mcux_lpc_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL, &pinmux_mcux_lpc_port##n##_cfg,	\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/pinmux/pinmux_rv32m1.c
+++ b/drivers/pinmux/pinmux_rv32m1.c
@@ -77,7 +77,7 @@ static const struct pinmux_driver_api pinmux_rv32m1_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &pinmux_rv32m1_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL, &pinmux_rv32m1_##n##_config,		\
 			    PRE_KERNEL_1,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/pinmux/pinmux_sam0.c
+++ b/drivers/pinmux/pinmux_sam0.c
@@ -79,7 +79,7 @@ static const struct pinmux_sam0_config pinmux_sam0_config_0 = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_a), pinmux_sam0_init,
-		    device_pm_control_nop, NULL, &pinmux_sam0_config_0,
+		    NULL, NULL, &pinmux_sam0_config_0,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -90,7 +90,7 @@ static const struct pinmux_sam0_config pinmux_sam0_config_1 = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_b), pinmux_sam0_init,
-		    device_pm_control_nop, NULL, &pinmux_sam0_config_1,
+		    NULL, NULL, &pinmux_sam0_config_1,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -101,7 +101,7 @@ static const struct pinmux_sam0_config pinmux_sam0_config_2 = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_c), pinmux_sam0_init,
-		    device_pm_control_nop, NULL, &pinmux_sam0_config_2,
+		    NULL, NULL, &pinmux_sam0_config_2,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
@@ -112,7 +112,7 @@ static const struct pinmux_sam0_config pinmux_sam0_config_3 = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pinmux_d), pinmux_sam0_init,
-		    device_pm_control_nop, NULL, &pinmux_sam0_config_3,
+		    NULL, NULL, &pinmux_sam0_config_3,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif

--- a/drivers/pinmux/pinmux_sifive.c
+++ b/drivers/pinmux/pinmux_sifive.c
@@ -100,7 +100,7 @@ static const struct pinmux_sifive_config pinmux_sifive_0_config = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &pinmux_sifive_init, device_pm_control_nop, NULL,
+		    &pinmux_sifive_init, NULL, NULL,
 		    &pinmux_sifive_0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &pinmux_sifive_driver_api);

--- a/drivers/pm_cpu_ops/pm_cpu_ops_psci.c
+++ b/drivers/pm_cpu_ops/pm_cpu_ops_psci.c
@@ -146,6 +146,6 @@ static int psci_init(const struct device *dev)
 	return psci_detect();
 }
 
-DEVICE_DT_INST_DEFINE(0, psci_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, psci_init, NULL,
 	&psci_data, NULL, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	NULL);

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -201,7 +201,7 @@ static struct ps2_xec_data ps2_xec_port_data_0;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &ps2_xec_init_0,
-		    device_pm_control_nop,
+		    NULL,
 		    &ps2_xec_port_data_0, &ps2_xec_config_0,
 		    POST_KERNEL, CONFIG_PS2_INIT_PRIORITY,
 		    &ps2_xec_driver_api);
@@ -240,7 +240,7 @@ static struct ps2_xec_data ps2_xec_port_data_1;
 
 DEVICE_DT_INST_DEFINE(1,
 		    &ps2_xec_init_1,
-		    device_pm_control_nop,
+		    NULL,
 		    &ps2_xec_port_data_1, &ps2_xec_config_1,
 		    POST_KERNEL, CONFIG_PS2_INIT_PRIORITY,
 		    &ps2_xec_driver_api);

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -114,8 +114,7 @@ static int pwm_gecko_init(const struct device *dev)
 		.pin = DT_INST_PROP_BY_IDX(index, pin_location, 2),		\
 	};									\
 										\
-	DEVICE_DT_INST_DEFINE(index, &pwm_gecko_init, device_pm_control_nop,	\
-				NULL,						\
+	DEVICE_DT_INST_DEFINE(index, &pwm_gecko_init, NULL, NULL,		\
 				&pwm_gecko_config_##index, POST_KERNEL,		\
 				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 				&pwm_gecko_driver_api);

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -166,7 +166,7 @@ static const struct pwm_driver_api imx_pwm_driver_api = {
 									\
 	static struct imx_pwm_data imx_pwm_data_##n;			\
 									\
-	DEVICE_DT_INST_DEFINE(n, &imx_pwm_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &imx_pwm_init, NULL,			\
 			    &imx_pwm_data_##n,				\
 			    &imx_pwm_config_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -520,6 +520,6 @@ const static struct pwm_led_esp32_config pwm_led_esp32_config = {
 };
 
 DEVICE_DEFINE(pwm_led_esp32_0, CONFIG_PWM_LED_ESP32_DEV_NAME_0,
-		pwm_led_esp32_init, device_pm_control_nop, NULL,
+		pwm_led_esp32_init, NULL, NULL,
 		&pwm_led_esp32_config, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_led_esp32_api);

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -107,7 +107,7 @@ static const struct pwm_driver_api pwm_litex_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(n,					       \
 			    pwm_litex_init,				       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    NULL,					       \
 			    &pwm_litex_cfg_##n,				       \
 			    POST_KERNEL,				       \

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -389,7 +389,7 @@ static struct pwm_driver_api pwm_xec_api = {
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    pwm_xec_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL,					\
 			    &pwm_xec_dev_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -165,7 +165,7 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 									  \
 	DEVICE_DT_INST_DEFINE(n,					  \
 			    pwm_mcux_init,				  \
-			    device_pm_control_nop,			  \
+			    NULL,					  \
 			    &pwm_mcux_data_ ## n,			  \
 			    &pwm_mcux_config_ ## n,			  \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -476,7 +476,7 @@ static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 	static struct mcux_ftm_data mcux_ftm_data_##n; \
 	static const struct mcux_ftm_config mcux_ftm_config_##n; \
 	DEVICE_DT_INST_DEFINE(n, &mcux_ftm_init,		       \
-			    device_pm_control_nop, &mcux_ftm_data_##n, \
+			    NULL, &mcux_ftm_data_##n, \
 			    &mcux_ftm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &mcux_ftm_driver_api); \

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -324,7 +324,7 @@ static const struct pwm_driver_api mcux_pwt_driver_api = {
 	static struct mcux_pwt_data mcux_pwt_data_##n;			\
 									\
 	DEVICE_DT_INST_DEFINE(n, &mcux_pwt_init,			\
-			device_pm_control_nop, &mcux_pwt_data_##n,	\
+			NULL, &mcux_pwt_data_##n,			\
 			&mcux_pwt_config_##n,				\
 			POST_KERNEL,					\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -186,7 +186,7 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct mcux_tpm_data mcux_tpm_data_##n; \
-	DEVICE_DT_INST_DEFINE(n, &mcux_tpm_init, device_pm_control_nop, \
+	DEVICE_DT_INST_DEFINE(n, &mcux_tpm_init, NULL, \
 			    &mcux_tpm_data_##n, \
 			    &mcux_tpm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -219,7 +219,7 @@ static int pwm_npcx_init(const struct device *dev)
 	static struct pwm_npcx_data pwm_npcx_data_##inst;                      \
 									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
-			    &pwm_npcx_init, device_pm_control_nop,             \
+			    &pwm_npcx_init, NULL,			       \
 			    &pwm_npcx_data_##inst, &pwm_npcx_cfg_##inst,       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    &pwm_npcx_driver_api);

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -386,7 +386,7 @@ static struct pwm_data pwm_nrf5_sw_0_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    pwm_nrf5_sw_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,
 		    POST_KERNEL,

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -186,7 +186,7 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 		.mode = kTPM_EdgeAlignedPwm, \
 	}; \
 	static struct rv32m1_tpm_data rv32m1_tpm_data_##n; \
-	DEVICE_DT_INST_DEFINE(n, &rv32m1_tpm_init, device_pm_control_nop, \
+	DEVICE_DT_INST_DEFINE(n, &rv32m1_tpm_init, NULL, \
 			    &rv32m1_tpm_data_##n, \
 			    &rv32m1_tpm_config_##n, \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -107,7 +107,7 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &sam_pwm_init, device_pm_control_nop	\
+			    &sam_pwm_init, NULL				\
 			    NULL, &sam_pwm_config_##inst,		\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -157,7 +157,7 @@ static const struct pwm_driver_api pwm_sam0_driver_api = {
 		PWM_SAM0_INIT_CLOCKS(inst),				       \
 	};								       \
 									       \
-	DEVICE_DT_INST_DEFINE(inst, &pwm_sam0_init, device_pm_control_nop,     \
+	DEVICE_DT_INST_DEFINE(inst, &pwm_sam0_init, NULL,		       \
 			    NULL, &pwm_sam0_config_##inst,		       \
 			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,   \
 			    &pwm_sam0_driver_api);

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -231,7 +231,7 @@ static const struct pwm_driver_api pwm_sifive_api = {
 		};	\
 	DEVICE_DT_INST_DEFINE(n,	\
 			    pwm_sifive_init,	\
-			    device_pm_control_nop,	\
+			    NULL,	\
 			    &pwm_sifive_data_##n,	\
 			    &pwm_sifive_cfg_##n,	\
 			    POST_KERNEL,	\

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -355,7 +355,7 @@ static int pwm_stm32_init(const struct device *dev)
 		.pinctrl_len = ARRAY_SIZE(pwm_pins_##index),                   \
 	};                                                                     \
 									       \
-	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, device_pm_control_nop,   \
+	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, NULL,                    \
 			    &pwm_stm32_data_##index,                           \
 			    &pwm_stm32_config_##index, POST_KERNEL,            \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                \

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -204,7 +204,7 @@ static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &xlnx_axi_timer_init,			\
-			    device_pm_control_nop, NULL,		\
+			    NULL, NULL,					\
 			    &xlnx_axi_timer_config_##n,			\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -385,7 +385,7 @@ static const struct driver_config regulator_##id##_cfg = { \
 \
 static struct REG_DATA_TAG(id) regulator_##id##_data; \
 \
-DEVICE_DT_INST_DEFINE(id, REG_INIT(id), device_pm_control_nop, \
+DEVICE_DT_INST_DEFINE(id, REG_INIT(id), NULL,			       \
 		 &regulator_##id##_data, &regulator_##id##_cfg,	       \
 		 POST_KERNEL, CONFIG_REGULATOR_FIXED_INIT_PRIORITY,    \
 		 &REG_API(id));


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `pinmux`
- `pm_cpu_ops`
- `ps2`
- `pwm`
- `regulator`