### PR TITLE
drivers: remove usage of device_pm_control_nop (10)

### DIFF
--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -230,6 +230,6 @@ static const struct adt7420_dev_config adt7420_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, adt7420_init, device_pm_control_nop, &adt7420_driver,
+DEVICE_DT_INST_DEFINE(0, adt7420_init, NULL, &adt7420_driver,
 		    &adt7420_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &adt7420_driver_api);

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -190,6 +190,6 @@ static const struct adxl345_dev_config adxl345_config = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, adxl345_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, adxl345_init, NULL,
 		    &adxl345_data, &adxl345_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl345_api_funcs);

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -818,6 +818,6 @@ static const struct adxl362_config adxl362_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, adxl362_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, adxl362_init, NULL,
 		    &adxl362_data, &adxl362_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl362_api_funcs);

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -1024,6 +1024,6 @@ static const struct adxl372_dev_config adxl372_config = {
 	.op_mode = ADXL372_FULL_BW_MEASUREMENT,
 };
 
-DEVICE_DT_INST_DEFINE(0, adxl372_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, adxl372_init, NULL,
 		    &adxl372_data, &adxl372_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &adxl372_api_funcs);

--- a/drivers/sensor/ak8975/ak8975.c
+++ b/drivers/sensor/ak8975/ak8975.c
@@ -170,7 +170,7 @@ int ak8975_init(const struct device *dev)
 
 struct ak8975_data ak8975_data;
 
-DEVICE_DT_INST_DEFINE(0, ak8975_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ak8975_init, NULL,
 		    &ak8975_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ak8975_driver_api);

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -153,7 +153,7 @@ static const struct amg88xx_config amg88xx_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, amg88xx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, amg88xx_init, NULL,
 		    &amg88xx_driver, &amg88xx_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &amg88xx_driver_api);

--- a/drivers/sensor/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams_iAQcore/iAQcore.c
@@ -114,6 +114,6 @@ static int iaq_core_init(const struct device *dev)
 
 static struct iaq_core_data iaq_core_driver;
 
-DEVICE_DT_INST_DEFINE(0, iaq_core_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, iaq_core_init, NULL,
 		    &iaq_core_driver, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);

--- a/drivers/sensor/bma280/bma280.c
+++ b/drivers/sensor/bma280/bma280.c
@@ -163,6 +163,6 @@ int bma280_init(const struct device *dev)
 
 struct bma280_data bma280_driver;
 
-DEVICE_DT_INST_DEFINE(0, bma280_init, device_pm_control_nop, &bma280_driver,
+DEVICE_DT_INST_DEFINE(0, bma280_init, NULL, &bma280_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bma280_driver_api);

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -607,6 +607,6 @@ static const struct bmc150_magn_config bmc150_magn_config = {
 
 static struct bmc150_magn_data bmc150_magn_data;
 
-DEVICE_DT_INST_DEFINE(0, bmc150_magn_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, bmc150_magn_init, NULL,
 	    &bmc150_magn_data, &bmc150_magn_config, POST_KERNEL,
 	    CONFIG_SENSOR_INIT_PRIORITY, &bmc150_magn_api_funcs);

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -428,6 +428,6 @@ static const struct sensor_driver_api bme680_api_funcs = {
 
 static struct bme680_data bme680_data;
 
-DEVICE_DT_INST_DEFINE(0, bme680_init, device_pm_control_nop, &bme680_data,
+DEVICE_DT_INST_DEFINE(0, bme680_init, NULL, &bme680_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bme680_api_funcs);

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -346,7 +346,7 @@ const struct bmg160_device_config bmg160_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, bmg160_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, bmg160_init, NULL,
 		    &bmg160_data,
 		    &bmg160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &bmg160_api);

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -981,7 +981,7 @@ int bmi160_init(const struct device *dev)
 #endif
 
 #define BMI160_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst, bmi160_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(inst, bmi160_init, NULL,			\
 		&bmi160_data_##inst, &bmi160_cfg_##inst,		\
 		POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
 		&bmi160_api);

--- a/drivers/sensor/bmi270/bmi270.c
+++ b/drivers/sensor/bmi270/bmi270.c
@@ -699,7 +699,7 @@ static const struct sensor_driver_api bmi270_driver_api = {
 								       \
 	DEVICE_DT_INST_DEFINE(inst,				       \
 			      bmi270_init,			       \
-			      device_pm_control_nop,		       \
+			      NULL,				       \
 			      &bmi270_drv_##inst,		       \
 			      &bmi270_config_##inst,		       \
 			      POST_KERNEL,			       \

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -607,6 +607,6 @@ static const struct bmm150_config bmm150_config = {
 
 static struct bmm150_data bmm150_data;
 
-DEVICE_DT_INST_DEFINE(0, bmm150_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, bmm150_init, NULL,
 			&bmm150_data, &bmm150_config, POST_KERNEL,
 			CONFIG_SENSOR_INIT_PRIORITY, &bmm150_api_funcs);

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -655,7 +655,7 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),   \
 	};                                                                     \
 									       \
-	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, device_pm_control_nop,\
+	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init, NULL,                \
 			    &bq274xx_driver_##index,                           \
 			    &bq274xx_config_##index, POST_KERNEL,              \
 			    CONFIG_SENSOR_INIT_PRIORITY,                       \

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -595,7 +595,7 @@ out:
 
 static struct ccs811_data ccs811_driver;
 
-DEVICE_DT_INST_DEFINE(0, ccs811_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ccs811_init, NULL,
 		 &ccs811_driver, NULL,
 		 POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		 &ccs811_driver_api);

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -247,6 +247,6 @@ static const struct dht_config dht_config = {
 	.pin = DT_INST_GPIO_PIN(0, dio_gpios),
 };
 
-DEVICE_DT_INST_DEFINE(0, &dht_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &dht_init, NULL,
 		    &dht_data, &dht_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &dht_api);

--- a/drivers/sensor/dps310/dps310.c
+++ b/drivers/sensor/dps310/dps310.c
@@ -732,7 +732,7 @@ static const struct dps310_cfg dps310_cfg_0 = {
 	.i2c_addr = DT_INST_REG_ADDR(0)
 };
 
-DEVICE_DT_INST_DEFINE(0, dps310_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, dps310_init, NULL,
 		    &dps310_data_0, &dps310_cfg_0, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &dps310_api_funcs);
 #endif
@@ -744,7 +744,7 @@ static const struct dps310_cfg dps310_cfg_1 = {
 	.i2c_addr = DT_INST_REG_ADDR(1)
 };
 
-DEVICE_DT_INST_DEFINE(1, dps310_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(1, dps310_init, NULL,
 		    &dps310_data_1, &dps310_cfg_1, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &dps310_api_funcs);
 #endif

--- a/drivers/sensor/ens210/ens210.c
+++ b/drivers/sensor/ens210/ens210.c
@@ -344,6 +344,6 @@ static int ens210_init(const struct device *dev)
 
 static struct ens210_data ens210_driver;
 
-DEVICE_DT_INST_DEFINE(0, ens210_init, device_pm_control_nop, &ens210_driver,
+DEVICE_DT_INST_DEFINE(0, ens210_init, NULL, &ens210_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &en210_driver_api);

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -310,7 +310,7 @@ static const struct fxas21002_config fxas21002_config = {
 
 static struct fxas21002_data fxas21002_data;
 
-DEVICE_DT_INST_DEFINE(0, fxas21002_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, fxas21002_init, NULL,
 		    &fxas21002_data, &fxas21002_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &fxas21002_driver_api);

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -618,7 +618,7 @@ static const struct sensor_driver_api fxos8700_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    fxos8700_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &fxos8700_data_##n,				\
 			    &fxos8700_config_##n,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -118,6 +118,6 @@ static const struct gls_config gls_cfg = {
 	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, &gls_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &gls_init, NULL,
 		&gls_data, &gls_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		&gls_api);

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -123,6 +123,6 @@ static const struct gts_config gts_cfg = {
 	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, &gts_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &gts_init, NULL,
 		&gts_data, &gts_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		&gts_api);

--- a/drivers/sensor/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/hmc5883l/hmc5883l.c
@@ -161,6 +161,6 @@ int hmc5883l_init(const struct device *dev)
 
 struct hmc5883l_data hmc5883l_driver;
 
-DEVICE_DT_INST_DEFINE(0, hmc5883l_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, hmc5883l_init, NULL,
 		    &hmc5883l_driver, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &hmc5883l_driver_api);

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -318,6 +318,6 @@ static int hp206c_init(const struct device *dev)
 
 static struct hp206c_device_data hp206c_data;
 
-DEVICE_DT_INST_DEFINE(0, hp206c_init, device_pm_control_nop, &hp206c_data,
+DEVICE_DT_INST_DEFINE(0, hp206c_init, NULL, &hp206c_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &hp206c_api);

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -191,6 +191,6 @@ static const struct hts221_config hts221_cfg = {
 #endif /* HTS221_TRIGGER_ENABLED */
 };
 
-DEVICE_DT_INST_DEFINE(0, hts221_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, hts221_init, NULL,
 		    &hts221_driver, &hts221_cfg, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &hts221_driver_api);

--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -461,7 +461,7 @@ static const struct sensor_driver_api icm42605_driver_api = {
 	ICM42605_DEFINE_CONFIG(index);					\
 	static struct icm42605_data icm42605_driver_##index;		\
 	DEVICE_DT_INST_DEFINE(index, icm42605_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &icm42605_driver_##index,			\
 			    &icm42605_cfg_##index, POST_KERNEL,		\
 			    CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/iis2dh/iis2dh.c
+++ b/drivers/sensor/iis2dh/iis2dh.c
@@ -311,6 +311,6 @@ const struct iis2dh_device_config iis2dh_cfg = {
 
 struct iis2dh_data iis2dh_data;
 
-DEVICE_DT_INST_DEFINE(0, iis2dh_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, iis2dh_init, NULL,
 	     &iis2dh_data, &iis2dh_cfg, POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &iis2dh_driver_api);

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -392,7 +392,7 @@ static int iis2dlpc_init(const struct device *dev)
 #define IIS2DLPC_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    iis2dlpc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &iis2dlpc_data_##inst,			\
 			    &iis2dlpc_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/iis2iclx/iis2iclx.c
@@ -631,7 +631,7 @@ static int iis2iclx_init(const struct device *dev)
 #define IIS2ICLX_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    iis2iclx_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &iis2iclx_data_##inst,			\
 			    &iis2iclx_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -332,7 +332,7 @@ static int iis2mdc_init(const struct device *dev)
 #define IIS2MDC_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    iis2mdc_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &iis2mdc_data_##inst,			\
 			    &iis2mdc_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -253,6 +253,6 @@ static const struct iis3dhhc_config iis3dhhc_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, iis3dhhc_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, iis3dhhc_init, NULL,
 		    &iis3dhhc_data, &iis3dhhc_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iis3dhhc_api_funcs);

--- a/drivers/sensor/isl29035/isl29035.c
+++ b/drivers/sensor/isl29035/isl29035.c
@@ -144,6 +144,6 @@ static int isl29035_init(const struct device *dev)
 
 struct isl29035_driver_data isl29035_data;
 
-DEVICE_DT_INST_DEFINE(0, &isl29035_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &isl29035_init, NULL,
 		    &isl29035_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &isl29035_api);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -810,6 +810,6 @@ static int ism330dhcx_init(const struct device *dev)
 
 static struct ism330dhcx_data ism330dhcx_data;
 
-DEVICE_DT_INST_DEFINE(0, ism330dhcx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, ism330dhcx_init, NULL,
 		    &ism330dhcx_data, &ism330dhcx_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &ism330dhcx_api_funcs);

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -361,7 +361,7 @@ int lis2dh_init(const struct device *dev)
 #define LIS2DH_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lis2dh_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &lis2dh_data_##inst,			\
 			    &lis2dh_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -325,6 +325,6 @@ static int lis2ds12_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, lis2ds12_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lis2ds12_init, NULL,
 		    &lis2ds12_data, &lis2ds12_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis2ds12_api_funcs);

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -405,6 +405,6 @@ const struct lis2dw12_device_config lis2dw12_cfg = {
 
 struct lis2dw12_data lis2dw12_data;
 
-DEVICE_DT_INST_DEFINE(0, lis2dw12_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lis2dw12_init, NULL,
 	     &lis2dw12_data, &lis2dw12_cfg, POST_KERNEL,
 	     CONFIG_SENSOR_INIT_PRIORITY, &lis2dw12_driver_api);

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -166,6 +166,6 @@ int lis3mdl_init(const struct device *dev)
 
 struct lis3mdl_data lis3mdl_driver;
 
-DEVICE_DT_INST_DEFINE(0, lis3mdl_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lis3mdl_init, NULL,
 		    &lis3mdl_driver, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lis3mdl_driver_api);

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -159,6 +159,6 @@ static const struct lps22hb_config lps22hb_config = {
 
 static struct lps22hb_data lps22hb_data;
 
-DEVICE_DT_INST_DEFINE(0, lps22hb_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lps22hb_init, NULL,
 		    &lps22hb_data, &lps22hb_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_api_funcs);

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -234,6 +234,6 @@ static const struct lps22hh_config lps22hh_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, lps22hh_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lps22hh_init, NULL,
 		    &lps22hh_data, &lps22hh_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_api_funcs);

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -187,6 +187,6 @@ static const struct lps25hb_config lps25hb_config = {
 
 static struct lps25hb_data lps25hb_data;
 
-DEVICE_DT_INST_DEFINE(0, lps25hb_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lps25hb_init, NULL,
 		    &lps25hb_data, &lps25hb_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lps25hb_api_funcs);

--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -139,7 +139,7 @@ static const struct lsm303dlhc_magn_config lsm303dlhc_magn_config = {
 
 static struct lsm303dlhc_magn_data lsm303dlhc_magn_driver;
 
-DEVICE_DT_INST_DEFINE(0, lsm303dlhc_magn_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lsm303dlhc_magn_init, NULL,
 		    &lsm303dlhc_magn_driver,
 		    &lsm303dlhc_magn_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm303dlhc_magn_driver_api);

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -509,6 +509,6 @@ static const struct lsm6ds0_config lsm6ds0_config = {
 
 static struct lsm6ds0_data lsm6ds0_data;
 
-DEVICE_DT_INST_DEFINE(0, lsm6ds0_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lsm6ds0_init, NULL,
 		    &lsm6ds0_data, &lsm6ds0_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm6ds0_api_funcs);

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -825,7 +825,7 @@ static int lsm6dsl_init(const struct device *dev)
 #define LSM6DSL_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lsm6dsl_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &lsm6dsl_data_##inst,			\
 			    &lsm6dsl_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -797,7 +797,7 @@ static int lsm6dso_init(const struct device *dev)
 #define LSM6DSO_DEVICE_INIT(inst)					\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    lsm6dso_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &lsm6dso_data_##inst,			\
 			    &lsm6dso_config_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -355,7 +355,7 @@ static const struct lsm9ds0_gyro_config lsm9ds0_gyro_config = {
 
 static struct lsm9ds0_gyro_data lsm9ds0_gyro_data;
 
-DEVICE_DT_INST_DEFINE(0, lsm9ds0_gyro_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lsm9ds0_gyro_init, NULL,
 		    &lsm9ds0_gyro_data, &lsm9ds0_gyro_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &lsm9ds0_gyro_api_funcs);

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -798,6 +798,6 @@ static const struct lsm9ds0_mfd_config lsm9ds0_mfd_config = {
 
 static struct lsm9ds0_mfd_data lsm9ds0_mfd_data;
 
-DEVICE_DT_INST_DEFINE(0, lsm9ds0_mfd_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, lsm9ds0_mfd_init, NULL,
 		    &lsm9ds0_mfd_data, &lsm9ds0_mfd_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &lsm9ds0_mfd_api_funcs);

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -401,7 +401,7 @@ static const struct sensor_driver_api max17055_battery_driver_api = {
 	};										   \
 											   \
 	DEVICE_DT_INST_DEFINE(index, &max17055_gauge_init,				   \
-			      device_pm_control_nop,					   \
+			      NULL,							   \
 			      &max17055_driver_##index,					   \
 			      &max17055_config_##index, POST_KERNEL,			   \
 			      CONFIG_SENSOR_INIT_PRIORITY,				   \

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -248,7 +248,7 @@ static struct max30101_config max30101_config = {
 
 static struct max30101_data max30101_data;
 
-DEVICE_DT_INST_DEFINE(0, max30101_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, max30101_init, NULL,
 		    &max30101_data, &max30101_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &max30101_driver_api);

--- a/drivers/sensor/max44009/max44009.c
+++ b/drivers/sensor/max44009/max44009.c
@@ -188,6 +188,6 @@ int max44009_init(const struct device *dev)
 
 static struct max44009_data max44009_drv_data;
 
-DEVICE_DT_INST_DEFINE(0, max44009_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, max44009_init, NULL,
 	    &max44009_drv_data, NULL, POST_KERNEL,
 	    CONFIG_SENSOR_INIT_PRIORITY, &max44009_driver_api);

--- a/drivers/sensor/max6675/max6675.c
+++ b/drivers/sensor/max6675/max6675.c
@@ -136,7 +136,7 @@ static int max6675_init(const struct device *dev)
 			DT_INST_SPI_DEV_CS_GPIOS_FLAGS(n)),		       \
 	};								       \
 									       \
-	DEVICE_DT_INST_DEFINE(n, &max6675_init, device_pm_control_nop,	       \
+	DEVICE_DT_INST_DEFINE(n, &max6675_init, NULL,			       \
 			      &max6675_data_##n, &max6675_config_##n,	       \
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	       \
 			      &max6675_api);

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -126,7 +126,7 @@ static const struct sensor_driver_api tach_xec_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    tach_xec_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &tach_xec_dev_data##id,			\
 			    &tach_xec_dev_config##id,			\
 			    POST_KERNEL,				\

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -140,6 +140,6 @@ static const struct mcp9808_config mcp9808_cfg = {
 #endif /* CONFIG_MCP9808_TRIGGER */
 };
 
-DEVICE_DT_INST_DEFINE(0, mcp9808_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, mcp9808_init, NULL,
 		      &mcp9808_data, &mcp9808_cfg, POST_KERNEL,
 		      CONFIG_SENSOR_INIT_PRIORITY, &mcp9808_api_funcs);

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -432,7 +432,7 @@ static const struct mcux_acmp_config mcux_acmp_config_##n = {		\
 	static const struct mcux_acmp_config mcux_acmp_config_##n;	\
 									\
 	DEVICE_DT_INST_DEFINE(n, &mcux_acmp_init,			\
-			      device_pm_control_nop,			\
+			      NULL,					\
 			      &mcux_acmp_data_##n,			\
 			      &mcux_acmp_config_##n, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/mpr/mpr.c
+++ b/drivers/sensor/mpr/mpr.c
@@ -137,6 +137,6 @@ static const struct mpr_config mpr_cfg = {
 	.i2c_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, mpr_init, device_pm_control_nop, &mpr_data,
+DEVICE_DT_INST_DEFINE(0, mpr_init, NULL, &mpr_data,
 			&mpr_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 			&mpr_api_funcs);

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -237,7 +237,7 @@ static const struct mpu6050_config mpu6050_cfg = {
 #endif /* CONFIG_MPU6050_TRIGGER */
 };
 
-DEVICE_DT_INST_DEFINE(0, mpu6050_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, mpu6050_init, NULL,
 		    &mpu6050_driver, &mpu6050_cfg,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &mpu6050_driver_api);

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -330,7 +330,7 @@ static struct ms5607_data ms5607_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    ms5607_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &ms5607_data,
 		    &ms5607_config,
 		    POST_KERNEL,

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -326,6 +326,6 @@ static const struct ms5837_config ms5837_config = {
 	.i2c_address = DT_INST_REG_ADDR(0)
 };
 
-DEVICE_DT_INST_DEFINE(0, ms5837_init, device_pm_control_nop, &ms5837_data,
+DEVICE_DT_INST_DEFINE(0, ms5837_init, NULL, &ms5837_data,
 		    &ms5837_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ms5837_api_funcs);

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -139,7 +139,7 @@ static struct temp_nrf5_data temp_nrf5_driver;
 
 DEVICE_DT_INST_DEFINE(0,
 		    temp_nrf5_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &temp_nrf5_driver,
 		    NULL,
 		    POST_KERNEL,

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -380,7 +380,7 @@ static const struct sensor_driver_api tach_npcx_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(inst,                                            \
 			      tach_npcx_init,                                  \
-			      device_pm_control_nop,                           \
+			      NULL,                                            \
 			      &tach_data_##inst,                               \
 			      &tach_cfg_##inst,                                \
 			      POST_KERNEL,                                     \

--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -213,7 +213,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst, temp_kinetis_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &temp_kinetis_data_0,			\
 			    &temp_kinetis_config_0, POST_KERNEL,	\
 			    CONFIG_SENSOR_INIT_PRIORITY,		\

--- a/drivers/sensor/opt3001/opt3001.c
+++ b/drivers/sensor/opt3001/opt3001.c
@@ -165,6 +165,6 @@ int opt3001_init(const struct device *dev)
 
 static struct opt3001_data opt3001_drv_data;
 
-DEVICE_DT_INST_DEFINE(0, opt3001_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, opt3001_init, NULL,
 		    &opt3001_drv_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &opt3001_driver_api);

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -185,6 +185,6 @@ static int pms7003_init(const struct device *dev)
 
 static struct pms7003_data pms7003_data;
 
-DEVICE_DT_INST_DEFINE(0, &pms7003_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &pms7003_init, NULL,
 		    &pms7003_data, NULL, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -134,7 +134,7 @@ static const struct sensor_driver_api qdec_sam_driver_api = {
 									\
 	static struct qdec_sam_dev_data qdec##n##_sam_data;		\
 									\
-	DEVICE_DT_INST_DEFINE(n, qdec_sam_initialize, device_pm_control_nop, \
+	DEVICE_DT_INST_DEFINE(n, qdec_sam_initialize, NULL,		\
 			    &qdec##n##_sam_data, &qdec##n##_sam_config, \
 			    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			    &qdec_sam_driver_api);

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -239,7 +239,7 @@ static const struct sht3xd_config sht3xd0_cfg = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, sht3xd_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, sht3xd_init, NULL,
 		    &sht3xd0_driver, &sht3xd0_cfg,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &sht3xd_driver_api);

--- a/drivers/sensor/si7006/si7006.c
+++ b/drivers/sensor/si7006/si7006.c
@@ -165,5 +165,5 @@ static int si7006_init(const struct device *dev)
 
 static struct si7006_data si_data;
 
-DEVICE_DT_INST_DEFINE(0, si7006_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, si7006_init, NULL,
 	&si_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7006_api);

--- a/drivers/sensor/si7055/si7055.c
+++ b/drivers/sensor/si7055/si7055.c
@@ -147,5 +147,5 @@ static int si7055_init(const struct device *dev)
 
 static struct si7055_data si_data;
 
-DEVICE_DT_INST_DEFINE(0, si7055_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, si7055_init, NULL,
 	&si_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7055_api);

--- a/drivers/sensor/si7060/si7060.c
+++ b/drivers/sensor/si7060/si7060.c
@@ -134,5 +134,5 @@ static int si7060_init(const struct device *dev)
 
 static struct si7060_data si_data;
 
-DEVICE_DT_INST_DEFINE(0, si7060_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, si7060_init, NULL,
 	&si_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7060_api);

--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -257,7 +257,7 @@ static int sm351lt_init(const struct device *dev)
 								     \
 	DEVICE_DT_INST_DEFINE(inst,				     \
 			    sm351lt_init,			     \
-			    device_pm_control_nop,		     \
+			    NULL,				     \
 			    &sm351lt_data_##inst,		     \
 			    &sm351lt_config_##inst,		     \
 			    POST_KERNEL,			     \

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -215,6 +215,6 @@ static const struct stts751_config stts751_config = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, stts751_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, stts751_init, NULL,
 		    &stts751_data, &stts751_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -137,6 +137,6 @@ int sx9500_init(const struct device *dev)
 
 struct sx9500_data sx9500_data;
 
-DEVICE_DT_INST_DEFINE(0, sx9500_init, device_pm_control_nop, &sx9500_data,
+DEVICE_DT_INST_DEFINE(0, sx9500_init, NULL, &sx9500_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &sx9500_api_funcs);

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -142,6 +142,6 @@ static int th02_init(const struct device *dev)
 
 static struct th02_data th02_driver;
 
-DEVICE_DT_INST_DEFINE(0, th02_init, device_pm_control_nop, &th02_driver,
+DEVICE_DT_INST_DEFINE(0, th02_init, NULL, &th02_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &th02_driver_api);

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -180,6 +180,6 @@ static int ti_hdc_init(const struct device *dev)
 
 static struct ti_hdc_data ti_hdc_data;
 
-DEVICE_DT_INST_DEFINE(0, ti_hdc_init, device_pm_control_nop, &ti_hdc_data,
+DEVICE_DT_INST_DEFINE(0, ti_hdc_init, NULL, &ti_hdc_data,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &ti_hdc_driver_api);

--- a/drivers/sensor/tmp007/tmp007.c
+++ b/drivers/sensor/tmp007/tmp007.c
@@ -129,7 +129,7 @@ int tmp007_init(const struct device *dev)
 
 struct tmp007_data tmp007_driver;
 
-DEVICE_DT_INST_DEFINE(0, tmp007_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, tmp007_init, NULL,
 		    &tmp007_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &tmp007_driver_api);

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -210,5 +210,5 @@ int tmp112_init(const struct device *dev)
 
 static struct tmp112_data tmp112_driver;
 
-DEVICE_DT_INST_DEFINE(0, tmp112_init, device_pm_control_nop, &tmp112_driver,
+DEVICE_DT_INST_DEFINE(0, tmp112_init, NULL, &tmp112_driver,
 	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -192,7 +192,7 @@ static int tmp116_init(const struct device *dev)
 		.i2c_addr = DT_INST_REG_ADDR(_num), \
 		.i2c_bus_label = DT_INST_BUS_LABEL(_num) \
 	}; \
-	DEVICE_DT_INST_DEFINE(_num, tmp116_init, device_pm_control_nop, \
+	DEVICE_DT_INST_DEFINE(_num, tmp116_init, NULL,			\
 		&tmp116_data_##_num, &tmp116_config_##_num, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &tmp116_driver_api)
 

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -283,6 +283,6 @@ static int vl53l0x_init(const struct device *dev)
 
 static struct vl53l0x_data vl53l0x_driver;
 
-DEVICE_DT_INST_DEFINE(0, vl53l0x_init, device_pm_control_nop, &vl53l0x_driver,
+DEVICE_DT_INST_DEFINE(0, vl53l0x_init, NULL, &vl53l0x_driver,
 		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &vl53l0x_api_funcs);

--- a/drivers/sensor/wsen_itds/itds.c
+++ b/drivers/sensor/wsen_itds/itds.c
@@ -401,7 +401,7 @@ static const struct itds_device_config itds_config_##idx = {		\
 	.def_op_mode = DT_ENUM_IDX(DT_DRV_INST(idx), op_mode),		\
 };									\
 									\
-DEVICE_DT_INST_DEFINE(idx, itds_init, device_pm_control_nop,		\
+DEVICE_DT_INST_DEFINE(idx, itds_init, NULL,				\
 		    &itds_data_##idx, &itds_config_##idx,		\
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
 		    &itds_api);						\


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `sensor`