### PR TITLE
drivers: remove usage of device_pm_control_nop (11)

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -352,7 +352,7 @@ static const struct leuart_gecko_config leuart_gecko_0_config = {
 static struct leuart_gecko_data leuart_gecko_0_data;
 
 DEVICE_DT_INST_DEFINE(0, &leuart_gecko_init,
-		    device_pm_control_nop, &leuart_gecko_0_data,
+		    NULL, &leuart_gecko_0_data,
 		    &leuart_gecko_0_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);
@@ -405,7 +405,7 @@ static const struct leuart_gecko_config leuart_gecko_1_config = {
 static struct leuart_gecko_data leuart_gecko_1_data;
 
 DEVICE_DT_INST_DEFINE(1, &leuart_gecko_init,
-		    device_pm_control_nop, &leuart_gecko_1_data,
+		    NULL, &leuart_gecko_1_data,
 		    &leuart_gecko_1_config, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &leuart_gecko_driver_api);

--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -58,7 +58,7 @@ static const struct uart_device_config uart_altera_jtag_dev_cfg_0 = {
 };
 
 DEVICE_DEFINE(uart_altera_jtag_0, "jtag_uart0",
-		    uart_altera_jtag_init, device_pm_control_nop, NULL,
+		    uart_altera_jtag_init, NULL, NULL,
 		    &uart_altera_jtag_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_altera_jtag_driver_api);

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -530,7 +530,7 @@ static const struct uart_driver_api apbuart_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(index,					\
 			    &apbuart_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &apbuart##index##_data,			\
 			    &apbuart##index##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -329,7 +329,7 @@ static struct uart_cc32xx_dev_data_t uart_cc32xx_dev_data_##idx = { \
 	IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN, (.cb = NULL,)) \
 }; \
 DEVICE_DT_INST_DEFINE(idx, uart_cc32xx_init, \
-	device_pm_control_nop, &uart_cc32xx_dev_data_##idx, \
+	NULL, &uart_cc32xx_dev_data_##idx, \
 	&uart_cc32xx_dev_cfg_##idx, \
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 	(void *)&uart_cc32xx_driver_api); \

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -505,7 +505,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &uart_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -570,7 +570,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
 
 DEVICE_DT_INST_DEFINE(1,
 		    &uart_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -635,7 +635,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
 
 DEVICE_DT_INST_DEFINE(2,
 		    &uart_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -700,7 +700,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
 
 DEVICE_DT_INST_DEFINE(3,
 		    &uart_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -765,7 +765,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
 
 DEVICE_DT_INST_DEFINE(4,
 		    &uart_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -536,7 +536,7 @@ static struct uart_esp32_data uart_esp32_data_##idx = {			       \
 									       \
 DEVICE_DT_INST_DEFINE(idx,						       \
 		    uart_esp32_init,					       \
-		    device_pm_control_nop,				       \
+		    NULL,						       \
 		    &uart_esp32_data_##idx,				       \
 		    &uart_esp32_cfg_port_##idx,				       \
 		    PRE_KERNEL_1,					       \

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -547,7 +547,7 @@ static const struct uart_driver_api uart_gecko_driver_api = {
 	static struct uart_gecko_data uart_gecko_data_##idx;		       \
 									       \
 	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, 			       \
-			    device_pm_control_nop, &uart_gecko_data_##idx,     \
+			    NULL, &uart_gecko_data_##idx,		       \
 			    &uart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \
 			    &uart_gecko_driver_api);			       \
@@ -604,7 +604,7 @@ DT_INST_FOREACH_STATUS_OKAY(GECKO_UART_INIT)
 									       \
 	static struct uart_gecko_data usart_gecko_data_##idx;		       \
 									       \
-	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, device_pm_control_nop,    \
+	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, NULL,		       \
 			    &usart_gecko_data_##idx,			       \
 			    &usart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -316,7 +316,7 @@ static const struct uart_driver_api uart_imx_driver_api = {
 									\
 	static const struct imx_uart_config imx_uart_##n##_config;	\
 									\
-	DEVICE_DT_INST_DEFINE(n, &uart_imx_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &uart_imx_init, NULL,			\
 			&imx_uart_##n##_data, &imx_uart_##n##_config,	\
 			PRE_KERNEL_1,					\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -319,7 +319,7 @@ static const struct uart_liteuart_device_config uart_liteuart_dev_cfg_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		uart_liteuart_init,
-		device_pm_control_nop,
+		NULL,
 		&uart_liteuart_data_0, &uart_liteuart_dev_cfg_0,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		(void *)&uart_liteuart_driver_api);

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -440,7 +440,7 @@ static struct lpc11u6x_uart0_data uart0_data;
 
 DEVICE_DT_DEFINE(DT_NODELABEL(uart0),
 		    &lpc11u6x_uart0_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart0_data, &uart0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &uart0_api);
@@ -894,7 +894,7 @@ static const struct lpc11u6x_uartx_config uart_cfg_##idx = {	              \
 static struct lpc11u6x_uartx_data uart_data_##idx;                            \
 									      \
 DEVICE_DT_DEFINE(DT_NODELABEL(uart##idx), 				      \
-		    &lpc11u6x_uartx_init, device_pm_control_nop,	      \
+		    &lpc11u6x_uartx_init, NULL,				      \
 		    &uart_data_##idx, &uart_cfg_##idx,			      \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	      \
 		    &uartx_api)

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -406,7 +406,7 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &uart_mcux_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &uart_mcux_##n##_data,			\
 			    &uart_mcux_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -332,7 +332,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_flexcomm_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_flexcomm_##n##_data,			\
 			    &mcux_flexcomm_##n##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -313,7 +313,7 @@ static const struct mcux_iuart_config mcux_iuart_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_iuart_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_iuart_##n##_data,			\
 			    &mcux_iuart_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -317,7 +317,7 @@ static const struct mcux_lpsci_config mcux_lpsci_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_lpsci_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_lpsci_##n##_data,			\
 			    &mcux_lpsci_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -437,7 +437,7 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &mcux_lpuart_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &mcux_lpuart_##n##_data,			\
 			    &mcux_lpuart_##n##_config,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -408,7 +408,7 @@ static const struct uart_miv_device_config uart_miv_dev_cfg_0 = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, uart_miv_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, uart_miv_init, NULL,
 		    &uart_miv_data_0, &uart_miv_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_miv_driver_api);

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -359,7 +359,7 @@ static const struct uart_driver_api uart_msp432p4xx_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-			uart_msp432p4xx_init, device_pm_control_nop,
+			uart_msp432p4xx_init, NULL,
 			&uart_msp432p4xx_dev_data_0,
 			&uart_msp432p4xx_dev_cfg_0,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -365,14 +365,14 @@ static int np_uart_tty_poll_in(const struct device *dev,
 }
 
 DEVICE_DT_INST_DEFINE(0,
-	    &np_uart_0_init, device_pm_control_nop,
+	    &np_uart_0_init, NULL,
 	    (void *)&native_uart_status_0, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_0);
 
 #if defined(CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE)
 DEVICE_DT_INST_DEFINE(1,
-	    &np_uart_1_init, device_pm_control_nop,
+	    &np_uart_1_init, NULL,
 	    (void *)&native_uart_status_1, NULL,
 	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 	    &np_uart_driver_api_1);

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1088,7 +1088,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 		.uart_config.flow_ctrl = DEV_DATA_FLOW_CTRL(n),                      \
 		DEV_DATA_DLF_INIT(n)                                                 \
 	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, device_pm_control_nop,          \
+	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,      \
 			      &uart_ns16550_driver_api);                             \

--- a/drivers/serial/uart_nuvoton.c
+++ b/drivers/serial/uart_nuvoton.c
@@ -200,7 +200,7 @@ static struct uart_numicro_data uart_numicro_data_##index = {		\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
 		    &uart_numicro_init,					\
-		    device_pm_control_nop,				\
+		    NULL,						\
 		    &uart_numicro_data_##index,				\
 		    &uart_numicro_cfg_##index,				\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -440,7 +440,7 @@ static struct pl011_data pl011_data_port_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &pl011_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &pl011_data_port_0,
 		    &pl011_cfg_port_0, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -503,7 +503,7 @@ static struct pl011_data pl011_data_port_1 = {
 
 DEVICE_DT_INST_DEFINE(1,
 		    &pl011_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &pl011_data_port_1,
 		    &pl011_cfg_port_1, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
@@ -568,7 +568,7 @@ static struct pl011_data pl011_data_sbsa = {
 
 DEVICE_DT_INST_DEFINE(0,
 		      &pl011_init,
-		      device_pm_control_nop,
+		      NULL,
 		      &pl011_data_sbsa,
 		      &pl011_cfg_sbsa, PRE_KERNEL_1,
 		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -358,7 +358,7 @@ static const struct uart_driver_api uart_psoc6_driver_api = {
 										\
 		CY_PSOC6_UART_IRQ_SET_FUNC(n)					\
 	};									\
-	DEVICE_DT_INST_DEFINE(n, &uart_psoc6_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &uart_psoc6_init, NULL,			\
 			      CY_PSOC6_UART_DECL_DATA_PTR(n),			\
 			      &cy_psoc6_uart##n##_config, PRE_KERNEL_1,		\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -215,7 +215,7 @@ static const struct uart_driver_api uart_rtt_driver_api = {
 #define UART_RTT_INIT(idx, config)					      \
 	struct uart_rtt_data uart_rtt##idx##_data;			      \
 									      \
-	DEVICE_DT_DEFINE(UART_RTT(idx), uart_rtt_init, device_pm_control_nop, \
+	DEVICE_DT_DEFINE(UART_RTT(idx), uart_rtt_init, NULL, \
 			    &uart_rtt##idx##_data, config,		      \
 			    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			    &uart_rtt_driver_api)

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -330,7 +330,7 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &rv32m1_lpuart_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &rv32m1_lpuart_##n##_data,			\
 			    &rv32m1_lpuart_##n##_cfg,			\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -362,7 +362,7 @@ static const struct uart_driver_api uart_sam_driver_api = {
 	static const struct uart_sam_dev_cfg uart##n##_sam_config;	\
 									\
 	DEVICE_DT_INST_DEFINE(n, &uart_sam_init, 			\
-			    device_pm_control_nop, &uart##n##_sam_data,	\
+			    NULL, &uart##n##_sam_data,			\
 			    &uart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &uart_sam_driver_api);			\

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1137,7 +1137,7 @@ static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		\
 static struct uart_sam0_dev_data uart_sam0_data_##n;			\
 UART_SAM0_IRQ_HANDLER_DECL(n);						\
 UART_SAM0_CONFIG_DEFN(n);						\
-DEVICE_DT_INST_DEFINE(n, uart_sam0_init, device_pm_control_nop,		\
+DEVICE_DT_INST_DEFINE(n, uart_sam0_init, NULL,				\
 		    &uart_sam0_data_##n,				\
 		    &uart_sam0_config_##n, PRE_KERNEL_1,		\
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -394,7 +394,7 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    uart_sifive_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_sifive_data_0, &uart_sifive_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);
@@ -433,7 +433,7 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_1 = {
 
 DEVICE_DT_INST_DEFINE(1,
 		    uart_sifive_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_sifive_data_1, &uart_sifive_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    (void *)&uart_sifive_driver_api);

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -650,7 +650,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_0 = {
 
 DEVICE_DT_INST_DEFINE(0,
 		    &uart_stellaris_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_stellaris_dev_data_0, &uart_stellaris_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
@@ -689,7 +689,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_1 = {
 
 DEVICE_DT_INST_DEFINE(1,
 		    &uart_stellaris_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_stellaris_dev_data_1, &uart_stellaris_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);
@@ -728,7 +728,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_2 = {
 
 DEVICE_DT_INST_DEFINE(2,
 		    &uart_stellaris_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &uart_stellaris_dev_data_2, &uart_stellaris_dev_cfg_2,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_stellaris_driver_api);

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -1205,7 +1205,7 @@ static struct uart_xlnx_ps_dev_config uart_xlnx_ps_dev_cfg_##port = { \
 #define UART_XLNX_PS_INIT(port) \
 DEVICE_DT_INST_DEFINE(port, \
 	uart_xlnx_ps_init, \
-	device_pm_control_nop, \
+	NULL, \
 	&uart_xlnx_ps_dev_data_##port, \
 	&uart_xlnx_ps_dev_cfg_##port, \
 	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -375,7 +375,7 @@ static const struct xlnx_uartlite_config xlnx_uartlite_##n##_config = {	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    &xlnx_uartlite_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &xlnx_uartlite_##n##_data,			\
 			    &xlnx_uartlite_##n##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -74,7 +74,7 @@ static const struct uart_device_config xmc4xxx_config_##index = {	\
 };									\
 									\
 	DEVICE_DT_INST_DEFINE(index, &uart_xmc4xxx_init,		\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &xmc4xxx_data_##index,			\
 			    &xmc4xxx_config_##index, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -363,7 +363,7 @@ static const struct uart_driver_api usart_sam_driver_api = {
 	static const struct usart_sam_dev_cfg usart##n##_sam_config;	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &usart_sam_init, device_pm_control_nop,	\
+			    &usart_sam_init, NULL,			\
 			    &usart##n##_sam_data,			\
 			    &usart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -557,7 +557,7 @@ const struct spi_dw_config spi_dw_config_0 = {
 	.op_modes = SPI_CTX_RUNTIME_OP_MODE_MASTER
 };
 
-DEVICE_DT_INST_DEFINE(0, spi_dw_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, spi_dw_init, NULL,
 		    &spi_dw_data_port_0, &spi_dw_config_0,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -620,7 +620,7 @@ static const struct spi_dw_config spi_dw_config_1 = {
 	.op_modes = SPI_CTX_RUNTIME_OP_MODE_MASTER
 };
 
-DEVICE_DT_INST_DEFINE(1, spi_dw_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(1, spi_dw_init, NULL,
 		    &spi_dw_data_port_1, &spi_dw_config_1,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -683,7 +683,7 @@ static const struct spi_dw_config spi_dw_config_2 = {
 	.op_modes = SPI_CTX_RUNTIME_OP_MODE_MASTER
 };
 
-DEVICE_DT_INST_DEFINE(2, spi_dw_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(2, spi_dw_init, NULL,
 		    &spi_dw_data_port_2, &spi_dw_config_2,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);
@@ -746,7 +746,7 @@ static const struct spi_dw_config spi_dw_config_3 = {
 	.op_modes = SPI_CTX_RUNTIME_OP_MODE_MASTER
 };
 
-DEVICE_DT_INST_DEFINE(3, spi_dw_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(3, spi_dw_init, NULL,
 		    &spi_dw_data_port_3, &spi_dw_config_3,
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,
 		    &dw_spi_api);

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -132,7 +132,7 @@ static struct spi_driver_api spi_emul_api = {
 	static struct spi_emul_data spi_emul_data_##n; \
 	DEVICE_DT_INST_DEFINE(n, \
 			    spi_emul_init, \
-			    device_pm_control_nop, \
+			    NULL, \
 			    &spi_emul_data_##n, \
 			    &spi_emul_cfg_##n, \
 			    POST_KERNEL, \

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -311,7 +311,7 @@ static struct spi_driver_api spi_gecko_api = {
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \
 			spi_gecko_init, \
-			device_pm_control_nop, \
+			NULL, \
 			&spi_gecko_data_##n, \
 			&spi_gecko_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -177,7 +177,7 @@ static struct spi_driver_api spi_litespi_api = {
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \
 			spi_litespi_init, \
-			device_pm_control_nop, \
+			NULL, \
 			&spi_litespi_data_##n, \
 			&spi_litespi_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -931,7 +931,7 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 	SPI_DMA_STATUS_SEM(id)						\
 };									\
 									\
-DEVICE_DT_INST_DEFINE(id, &spi_stm32_init, device_pm_control_nop,	\
+DEVICE_DT_INST_DEFINE(id, &spi_stm32_init, NULL,			\
 		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
 		    &api_funcs);					\

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -306,7 +306,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	};								\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    &spi_mcux_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -766,7 +766,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 	};								\
 	DEVICE_DT_INST_DEFINE(id,					\
 			    &spi_mcux_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -303,7 +303,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n, POST_KERNEL,		\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -289,7 +289,7 @@ static int init_spis(const struct device *dev,
 	};								       \
 	DEVICE_DT_DEFINE(SPIS(idx),					       \
 			    spi_##idx##_init,				       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &spi_##idx##_data,				       \
 			    &spi_##idx##z_config,			       \
 			    POST_KERNEL,				       \

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -216,7 +216,7 @@ int spi_oc_simple_init(const struct device *dev)
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			    spi_oc_simple_init,				\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &spi_oc_simple_data_##inst,			\
 			    &spi_oc_simple_cfg_##inst,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -295,7 +295,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -467,7 +467,7 @@ static const struct spi_driver_api spi_sam_driver_api = {
 		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &spi_sam_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_sam_init, NULL,			\
 			    &spi_sam_dev_data_##n,			\
 			    &spi_sam_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -764,7 +764,7 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, NULL,			\
 			    &spi_sam0_dev_data_##n,			\
 			    &spi_sam0_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -250,7 +250,7 @@ static struct spi_driver_api spi_sifive_api = {
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \
 			spi_sifive_init, \
-			device_pm_control_nop, \
+			NULL, \
 			&spi_sifive_data_##n, \
 			&spi_sifive_cfg_##n, \
 			POST_KERNEL, \

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -53,7 +53,7 @@ static int vnd_spi_init(const struct device *dev)
 }
 
 #define VND_SPI_INIT(n)						\
-	DEVICE_DT_INST_DEFINE(n, &vnd_spi_init, device_pm_control_nop,	\
+	DEVICE_DT_INST_DEFINE(n, &vnd_spi_init, NULL,			\
 			      NULL, NULL, POST_KERNEL,			\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      &vnd_spi_api);

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -675,7 +675,7 @@ static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &qmspi_init, device_pm_control_nop, &spi_qmspi_0_dev_data,
+		    &qmspi_init, NULL, &spi_qmspi_0_dev_data,
 		    &spi_qmspi_0_config, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_qmspi_driver_api);
 

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -478,7 +478,7 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &xlnx_quadspi_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &xlnx_quadspi_data_##n,			\
 			    &xlnx_quadspi_config_##n, POST_KERNEL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -411,7 +411,7 @@ static int mt9m114_init_0(const struct device *dev)
 	return mt9m114_init(dev);
 }
 
-DEVICE_DT_INST_DEFINE(0, &mt9m114_init_0, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &mt9m114_init_0, NULL,
 		    &mt9m114_data_0, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mt9m114_driver_api);

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -649,7 +649,7 @@ static int ov7725_init_0(const struct device *dev)
 	return ov7725_init(dev);
 }
 
-DEVICE_DT_INST_DEFINE(0, &ov7725_init_0, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, &ov7725_init_0, NULL,
 		    &ov7725_data_0, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &ov7725_driver_api);

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -432,7 +432,7 @@ static int video_mcux_csi_init_0(const struct device *dev)
 }
 
 DEVICE_DT_INST_DEFINE(0, &video_mcux_csi_init_0,
-		    device_pm_control_nop, &video_mcux_csi_data_0,
+		    NULL, &video_mcux_csi_data_0,
 		    &video_mcux_csi_config_0,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_mcux_csi_driver_api);

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -275,7 +275,7 @@ static int video_sw_generator_init(const struct device *dev)
 }
 
 DEVICE_DEFINE(video_sw_generator, "VIDEO_SW_GENERATOR",
-		    &video_sw_generator_init, device_pm_control_nop,
+		    &video_sw_generator_init, NULL,
 		    &video_sw_generator_data_0, NULL,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_sw_generator_driver_api);

--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -243,5 +243,5 @@ static int ivshmem_init(const struct device *dev)
 static struct ivshmem ivshmem_data;
 
 DEVICE_DEFINE(ivshmem, CONFIG_IVSHMEM_DEV_NAME,
-	      ivshmem_init, device_pm_control_nop, &ivshmem_data, NULL,
+	      ivshmem_init, NULL, &ivshmem_data, NULL,
 	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ivshmem_api);

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -189,7 +189,7 @@ static const struct wdt_driver_api wdt_cc32xx_api = {
 	};									 \
 										 \
 	DEVICE_DT_INST_DEFINE(index,						 \
-			      &wdt_cc32xx_init, device_pm_control_nop,		 \
+			      &wdt_cc32xx_init, NULL,				 \
 			      &wdt_cc32xx_data_##index, &wdt_cc32xx_cfg_##index, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	 \
 			      &wdt_cc32xx_api);

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -201,7 +201,7 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0,
 		    wdog_cmsdk_apb_init,
-		    device_pm_control_nop,
+		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdog_cmsdk_apb_api);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -252,7 +252,7 @@ static const struct wdt_driver_api wdt_api = {
 													   \
 	DEVICE_DT_INST_DEFINE(idx,									   \
 			    wdt_esp32_init,								   \
-			    device_pm_control_nop,							   \
+			    NULL,									   \
 			    &wdt##idx##_data,								   \
 			    &wdt_esp32_config##idx,							   \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				   \

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -224,38 +224,38 @@ static const struct wdt_driver_api wdt_api = {
 	.feed = wdt_esp32_feed
 };
 
-#define ESP32_WDT_INIT(idx)										   \
-	static void wdt_esp32_connect_irq_func##idx(void)						   \
-	{												   \
-		esp32_rom_intr_matrix_set(0, ETS_TG##idx##_WDT_LEVEL_INTR_SOURCE,			   \
-					  CONFIG_WDT##idx##_ESP32_IRQ);					   \
-		IRQ_CONNECT(CONFIG_WDT##idx##_ESP32_IRQ,						   \
-			    4,										   \
-			    wdt_esp32_isr,								   \
-			    DEVICE_DT_INST_GET(idx),							   \
-			    0);										   \
-	}												   \
-													   \
-	static struct wdt_esp32_data wdt##idx##_data;							   \
-	static struct wdt_esp32_config wdt_esp32_config##idx = {					   \
-		.base = (struct wdt_esp32_regs_t *) DT_INST_REG_ADDR(idx), \
-		.irq_regs = {										   \
-			.timer_int_ena = (uint32_t *)TIMG_INT_ENA_TIMERS_REG(idx),				   \
-			.timer_int_clr = (uint32_t *)TIMG_INT_CLR_TIMERS_REG(idx),				   \
-		},											   \
-		.irq = {										   \
-			.source =  ETS_TG##idx##_WDT_LEVEL_INTR_SOURCE,					   \
-			.line =  CONFIG_WDT##idx##_ESP32_IRQ,						   \
-		},											   \
-		.connect_irq = wdt_esp32_connect_irq_func##idx						   \
-	};												   \
-													   \
-	DEVICE_DT_INST_DEFINE(idx,									   \
-			    wdt_esp32_init,								   \
-			    NULL,									   \
-			    &wdt##idx##_data,								   \
-			    &wdt_esp32_config##idx,							   \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				   \
+#define ESP32_WDT_INIT(idx)								\
+	static void wdt_esp32_connect_irq_func##idx(void)				\
+	{										\
+		esp32_rom_intr_matrix_set(0, ETS_TG##idx##_WDT_LEVEL_INTR_SOURCE,	\
+					  CONFIG_WDT##idx##_ESP32_IRQ);			\
+		IRQ_CONNECT(CONFIG_WDT##idx##_ESP32_IRQ,				\
+			    4,								\
+			    wdt_esp32_isr,						\
+			    DEVICE_DT_INST_GET(idx),					\
+			    0);								\
+	}										\
+											\
+	static struct wdt_esp32_data wdt##idx##_data;					\
+	static struct wdt_esp32_config wdt_esp32_config##idx = {			\
+		.base = (struct wdt_esp32_regs_t *) DT_INST_REG_ADDR(idx),		\
+		.irq_regs = {								\
+			.timer_int_ena = (uint32_t *)TIMG_INT_ENA_TIMERS_REG(idx),	\
+			.timer_int_clr = (uint32_t *)TIMG_INT_CLR_TIMERS_REG(idx),	\
+		},									\
+		.irq = {								\
+			.source =  ETS_TG##idx##_WDT_LEVEL_INTR_SOURCE,			\
+			.line =  CONFIG_WDT##idx##_ESP32_IRQ,				\
+		},									\
+		.connect_irq = wdt_esp32_connect_irq_func##idx				\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(idx,							\
+			    wdt_esp32_init,						\
+			    NULL,							\
+			    &wdt##idx##_data,						\
+			    &wdt_esp32_config##idx,					\
+			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &wdt_api)
 
 static void wdt_esp32_isr(const struct device *dev)

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -293,7 +293,7 @@ static const struct wdt_driver_api wdt_gecko_driver_api = {
 	static struct wdt_gecko_data wdt_gecko_data_##index;		\
 									\
 	DEVICE_DT_INST_DEFINE(index,					\
-				&wdt_gecko_init, device_pm_control_nop,	\
+				&wdt_gecko_init, NULL,			\
 				&wdt_gecko_data_##index,		\
 				&wdt_gecko_cfg_##index, POST_KERNEL,	\
 				CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -196,7 +196,7 @@ static struct iwdg_stm32_data iwdg_stm32_dev_data = {
 	.Instance = (IWDG_TypeDef *)DT_INST_REG_ADDR(0)
 };
 
-DEVICE_DT_INST_DEFINE(0, iwdg_stm32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, iwdg_stm32_init, NULL,
 		    &iwdg_stm32_dev_data, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &iwdg_stm32_api);

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -175,7 +175,7 @@ static int wdt_xec_init(const struct device *dev)
 
 static struct wdt_xec_data wdt_xec_dev_data;
 
-DEVICE_DT_INST_DEFINE(0, wdt_xec_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wdt_xec_init, NULL,
 		    &wdt_xec_dev_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdt_xec_api);

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -153,7 +153,7 @@ static struct mcux_wdog_data mcux_wdog_data;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_wdog_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &mcux_wdog_data, &mcux_wdog_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog_api);

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -171,7 +171,7 @@ static struct mcux_wdog_data mcux_wdog_data_0;
 
 DEVICE_DT_INST_DEFINE(0,
 		    &mcux_wdog_init,
-		    device_pm_control_nop,
+		    NULL,
 		    &mcux_wdog_data_0, &mcux_wdog_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog_api);

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -203,7 +203,7 @@ static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 static struct mcux_wdog32_data mcux_wdog32_data_0;
 
 DEVICE_DT_INST_DEFINE(0, &mcux_wdog32_init,
-		    device_pm_control_nop, &mcux_wdog32_data_0,
+		    NULL, &mcux_wdog32_data_0,
 		    &mcux_wdog32_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wdog32_api);

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -175,7 +175,7 @@ static const struct mcux_wwdt_config mcux_wwdt_config_0 = {
 static struct mcux_wwdt_data mcux_wwdt_data_0;
 
 DEVICE_DT_INST_DEFINE(0, &mcux_wwdt_init,
-		    device_pm_control_nop, &mcux_wwdt_data_0,
+		    NULL, &mcux_wwdt_data_0,
 		    &mcux_wwdt_config_0, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_wwdt_api);

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -349,7 +349,7 @@ static const struct wdt_npcx_config wdt_npcx_cfg_0 = {
 
 static struct wdt_npcx_data wdt_npcx_data_0;
 
-DEVICE_DT_INST_DEFINE(0, wdt_npcx_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wdt_npcx_init, NULL,
 			&wdt_npcx_data_0, &wdt_npcx_cfg_0,
 			PRE_KERNEL_1,
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -183,7 +183,7 @@ static void wdt_event_handler(const struct device *dev)
 	};								       \
 	DEVICE_DT_DEFINE(WDT(idx),					       \
 			    wdt_##idx##_init,				       \
-			    device_pm_control_nop,			       \
+			    NULL,					       \
 			    &wdt_##idx##_data,				       \
 			    &wdt_##idx##z_config,			       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -249,6 +249,6 @@ static int wdt_sam_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, wdt_sam_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wdt_sam_init, NULL,
 		    &wdt_sam_data, &wdt_sam_cfg, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam_api);

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -278,6 +278,6 @@ static int wdt_sam0_init(const struct device *dev)
 
 static struct wdt_sam0_dev_data wdt_sam0_data;
 
-DEVICE_DT_INST_DEFINE(0, wdt_sam0_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wdt_sam0_init, NULL,
 		    &wdt_sam0_data, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam0_api);

--- a/drivers/watchdog/wdt_sifive.c
+++ b/drivers/watchdog/wdt_sifive.c
@@ -282,6 +282,6 @@ static const struct wdt_sifive_device_config wdt_sifive_cfg = {
 	.regs = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, wdt_sifive_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wdt_sifive_init, NULL,
 		      &wdt_sifive_data, &wdt_sifive_cfg, PRE_KERNEL_1,
 		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sifive_api);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -289,7 +289,7 @@ static struct wwdg_stm32_config wwdg_stm32_dev_config = {
 	.Instance = (WWDG_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, wwdg_stm32_init, device_pm_control_nop,
+DEVICE_DT_INST_DEFINE(0, wwdg_stm32_init, NULL,
 		    &wwdg_stm32_dev_data, &wwdg_stm32_dev_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wwdg_stm32_api);

--- a/drivers/wifi/esp/esp.c
+++ b/drivers/wifi/esp/esp.c
@@ -1155,7 +1155,7 @@ error:
 	return ret;
 }
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, esp_init, device_pm_control_nop,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, esp_init, NULL,
 				  &esp_driver_data, NULL,
 				  CONFIG_WIFI_INIT_PRIORITY, &esp_api,
 				  ESP_MTU);

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -178,7 +178,7 @@ static const struct ethernet_api eth_esp32_apis = {
 };
 
 NET_DEVICE_DT_INST_DEFINE(0,
-		eth_esp32_dev_init, device_pm_control_nop,
+		eth_esp32_dev_init, NULL,
 		&eth_data, NULL, CONFIG_ETH_INIT_PRIORITY,
 		&eth_esp32_apis, ETHERNET_L2,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -689,7 +689,7 @@ static const struct net_wifi_mgmt_offload eswifi_offload_api = {
 	.ap_disable	= eswifi_mgmt_ap_disable,
 };
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, eswifi_init, device_pm_control_nop,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, eswifi_init, NULL,
 				  &eswifi0, NULL,
 				  CONFIG_WIFI_INIT_PRIORITY,
 				  &eswifi_offload_api,

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -283,7 +283,7 @@ static int simplelink_init(const struct device *dev)
 }
 
 NET_DEVICE_OFFLOAD_INIT(simplelink, CONFIG_WIFI_SIMPLELINK_NAME,
-			simplelink_init, device_pm_control_nop,
+			simplelink_init, NULL,
 			&simplelink_data, NULL,
 			CONFIG_WIFI_INIT_PRIORITY, &simplelink_api,
 			CONFIG_WIFI_SIMPLELINK_MAX_PACKET_SIZE);

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -1167,6 +1167,6 @@ static int winc1500_init(const struct device *dev)
 }
 
 NET_DEVICE_OFFLOAD_INIT(winc1500, CONFIG_WIFI_WINC1500_NAME,
-			winc1500_init, device_pm_control_nop, &w1500_data, NULL,
+			winc1500_init, NULL, &w1500_data, NULL,
 			CONFIG_WIFI_INIT_PRIORITY, &winc1500_api,
 			CONFIG_WIFI_WINC1500_MAX_PACKET_SIZE);


### PR DESCRIPTION
`device_pm_control_nop` is now deprecated in favor of `NULL`.

Ported drivers:

- `serial`
- `spi`
- `video`
- `virtualization`
- `watchdog`
- `wifi`

Others:
- Fixed compliance checks for wdt_esp32 driver.