### PR TITLE
net: lib: sockets: Fix zsock_select

### DIFF
--- a/subsys/net/lib/sockets/sockets_select.c
+++ b/subsys/net/lib/sockets/sockets_select.c
@@ -92,6 +92,7 @@ int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
 
 		ored_mask = read_mask | write_mask | except_mask;
 		if (ored_mask == 0U) {
+			fd_no += sizeof(ored_mask) * 8;
 			continue;
 		}
 


### PR DESCRIPTION
zsock_select() cannot poll file descriptors with number >= 32.

When a whole word in FD_SET was skipped due to being empty,
corresponding fd number was not updated, leading to wrong
fd's being passed to poll().

Fixes #34563

Signed-off-by: Chih Hung Yu <chyu313@gmail.com>