### PR TITLE
runners: jlink: Add support for thread info

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -18,6 +18,7 @@ canopen
 packaging
 progress
 psutil
+pylink
 
 # for ram/rom reports
 anytree

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -122,7 +122,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         if 'CONFIG_BOARD' not in build_conf:
             return '<board>'
 
-        return build_conf['CONFIG_BOARD'][0].replace('"', '')
+        return build_conf['CONFIG_BOARD']
 
     def get_dts_img_offset(self):
         build_conf = BuildConfiguration(self.cfg.build_dir)

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -10,7 +10,7 @@ import pickle
 import platform
 import subprocess
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 # This is needed to load edt.pickle files.
 try:
@@ -79,22 +79,16 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         return False
 
     def is_extended_samba_protocol(self):
-        build_conf = BuildConfiguration(self.cfg.build_dir)
         ext_samba_versions = ['CONFIG_BOOTLOADER_BOSSA_ARDUINO',
                               'CONFIG_BOOTLOADER_BOSSA_ADAFRUIT_UF2']
 
         for x in ext_samba_versions:
-            if x in build_conf:
+            if self.build_conf.getboolean(x):
                 return True
         return False
 
     def is_partition_enabled(self):
-        build_conf = BuildConfiguration(self.cfg.build_dir)
-
-        if 'CONFIG_USE_DT_CODE_PARTITION' not in build_conf:
-            return False
-
-        return True
+        return self.build_conf.getboolean('CONFIG_USE_DT_CODE_PARTITION')
 
     def get_chosen_code_partition_node(self):
         # Get the EDT Node corresponding to the zephyr,code-partition
@@ -117,18 +111,14 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         return edt.chosen_node('zephyr,code-partition')
 
     def get_board_name(self):
-        build_conf = BuildConfiguration(self.cfg.build_dir)
-
-        if 'CONFIG_BOARD' not in build_conf:
+        if 'CONFIG_BOARD' not in self.build_conf:
             return '<board>'
 
-        return build_conf['CONFIG_BOARD']
+        return self.build_conf['CONFIG_BOARD']
 
     def get_dts_img_offset(self):
-        build_conf = BuildConfiguration(self.cfg.build_dir)
-
-        if build_conf['CONFIG_HAS_FLASH_LOAD_OFFSET']:
-            return build_conf['CONFIG_FLASH_LOAD_OFFSET']
+        if self.build_conf.getboolean('CONFIG_HAS_FLASH_LOAD_OFFSET'):
+            return self.build_conf['CONFIG_FLASH_LOAD_OFFSET']
 
         return 0
 

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -552,7 +552,7 @@ class ZephyrBinaryRunner(abc.ABC):
         else:
             self.logger.info(escaped)
 
-    def call(self, cmd: List[str]) -> int:
+    def call(self, cmd: List[str], **kwargs) -> int:
         '''Subclass subprocess.call() wrapper.
 
         Subclasses should use this method to run command in a
@@ -562,9 +562,9 @@ class ZephyrBinaryRunner(abc.ABC):
         self._log_cmd(cmd)
         if _DRY_RUN:
             return 0
-        return subprocess.call(cmd)
+        return subprocess.call(cmd, **kwargs)
 
-    def check_call(self, cmd: List[str]):
+    def check_call(self, cmd: List[str], **kwargs):
         '''Subclass subprocess.check_call() wrapper.
 
         Subclasses should use this method to run command in a
@@ -574,7 +574,7 @@ class ZephyrBinaryRunner(abc.ABC):
         self._log_cmd(cmd)
         if _DRY_RUN:
             return
-        subprocess.check_call(cmd)
+        subprocess.check_call(cmd, **kwargs)
 
     def check_output(self, cmd: List[str], **kwargs) -> bytes:
         '''Subclass subprocess.check_output() wrapper.

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -413,9 +413,9 @@ class ZephyrBinaryRunner(abc.ABC):
         if caps.flash_addr:
             parser.add_argument('--dt-flash', default='n', choices=_YN_CHOICES,
                                 action=_DTFlashAction,
-                                help='''If 'yes', use configuration generated
-                                by device tree (DT) to compute flash
-                                addresses.''')
+                                help='''If 'yes', try to use flash address
+                                information from devicetree when flash
+                                addresses are unknown (e.g. when flashing a .bin)''')
         else:
             parser.add_argument('--dt-flash', help=argparse.SUPPRESS)
 

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -521,6 +521,15 @@ class ZephyrBinaryRunner(abc.ABC):
             self._build_conf = BuildConfiguration(self.cfg.build_dir)
         return self._build_conf
 
+    @property
+    def thread_info_enabled(self) -> bool:
+        '''Returns True if self.build_conf has
+        CONFIG_DEBUG_THREAD_INFO enabled. This supports the
+        CONFIG_OPENOCD_SUPPORT fallback as well for now.
+        '''
+        return (self.build_conf.getboolean('CONFIG_DEBUG_THREAD_INFO') or
+                self.build_conf.getboolean('CONFIG_OPENOCD_SUPPORT'))
+
     @staticmethod
     def require(program: str) -> str:
         '''Require that a program is installed before proceeding.

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -497,7 +497,7 @@ class ZephyrBinaryRunner(abc.ABC):
         In case of an unsupported command, raise a ValueError.'''
 
     @staticmethod
-    def require(program: str):
+    def require(program: str) -> str:
         '''Require that a program is installed before proceeding.
 
         :param program: name of the program that is required,
@@ -507,9 +507,12 @@ class ZephyrBinaryRunner(abc.ABC):
         binary, this call succeeds. Otherwise, try to find the program
         by name on the system PATH.
 
-        On error, raises MissingProgram.'''
-        if shutil.which(program) is None:
+        If the program can be found, its path is returned.
+        Otherwise, raises MissingProgram.'''
+        ret = shutil.which(program)
+        if ret is None:
             raise MissingProgram(program)
+        return ret
 
     def run_server_and_client(self, server, client):
         '''Run a server that ignores SIGINT, and a client that handles it.

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -501,6 +501,13 @@ class ZephyrBinaryRunner(abc.ABC):
 
         In case of an unsupported command, raise a ValueError.'''
 
+    @property
+    def build_conf(self) -> BuildConfiguration:
+        '''Get a BuildConfiguration for the build directory.'''
+        if not hasattr(self, '_build_conf'):
+            self._build_conf = BuildConfiguration(self.cfg.build_dir)
+        return self._build_conf
+
     @staticmethod
     def require(program: str) -> str:
         '''Require that a program is installed before proceeding.

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -457,28 +457,33 @@ class ZephyrBinaryRunner(abc.ABC):
                   args: argparse.Namespace) -> 'ZephyrBinaryRunner':
         '''Hook for instance creation from command line arguments.'''
 
-    @classmethod
-    def get_flash_address(cls, args: argparse.Namespace,
+    @staticmethod
+    def get_flash_address(args: argparse.Namespace,
                           build_conf: BuildConfiguration,
                           default: int = 0x0) -> int:
         '''Helper method for extracting a flash address.
 
-        If args.dt_flash is true, get the address from the
-        BoardConfiguration, build_conf. (If
-        CONFIG_HAS_FLASH_LOAD_OFFSET is n in that configuration, it
-        returns CONFIG_FLASH_BASE_ADDRESS. Otherwise, it returns
-        CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET.)
+        If args.dt_flash is true, returns the address obtained from
+        ZephyrBinaryRunner.flash_address_from_build_conf(build_conf).
 
         Otherwise (when args.dt_flash is False), the default value is
         returned.'''
         if args.dt_flash:
-            if build_conf['CONFIG_HAS_FLASH_LOAD_OFFSET']:
-                return (build_conf['CONFIG_FLASH_BASE_ADDRESS'] +
-                        build_conf['CONFIG_FLASH_LOAD_OFFSET'])
-            else:
-                return build_conf['CONFIG_FLASH_BASE_ADDRESS']
+            return ZephyrBinaryRunner.flash_address_from_build_conf(build_conf)
         else:
             return default
+
+    @staticmethod
+    def flash_address_from_build_conf(build_conf: BuildConfiguration):
+        '''If CONFIG_HAS_FLASH_LOAD_OFFSET is n in build_conf,
+        return the CONFIG_FLASH_BASE_ADDRESS value. Otherwise, return
+        CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET.
+        '''
+        if build_conf['CONFIG_HAS_FLASH_LOAD_OFFSET']:
+            return (build_conf['CONFIG_FLASH_BASE_ADDRESS'] +
+                    build_conf['CONFIG_FLASH_LOAD_OFFSET'])
+        else:
+            return build_conf['CONFIG_FLASH_BASE_ADDRESS']
 
     def run(self, command: str, **kwargs):
         '''Runs command ('flash', 'debug', 'debugserver', 'attach').

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -162,6 +162,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             self._jlink_version_str = f'{major}.{minor:02}{rev_str}'
         return self._jlink_version_str
 
+    @property
     def supports_nogui(self):
         # -nogui was introduced in J-Link Commander v6.80
         return self.jlink_version >= (6, 80, 0)
@@ -186,6 +187,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                        '-device', self.device,
                        '-silent',
                        '-singlerun'] +
+                      (['-nogui'] if self.supports_nogui else []) +
                       self.tool_opt)
 
         if command == 'flash':
@@ -268,16 +270,13 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             with open(fname, 'wb') as f:
                 f.writelines(bytes(line + '\n', 'utf-8') for line in lines)
 
-            if self.supports_nogui():
-                nogui = ['-nogui', '1']
-            else:
-                nogui = []
-
-            cmd = ([self.commander] + nogui +
+            cmd = ([self.commander] +
+                   (['-nogui', '1'] if self.supports_nogui else []) +
                    ['-if', self.iface,
                     '-speed', self.speed,
                     '-device', self.device,
                     '-CommanderScript', fname] +
+                   (['-nogui', '1'] if self.supports_nogui else []) +
                    self.tool_opt)
 
             self.logger.info('Flashing file: {}'.format(flash_file))

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -93,7 +93,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='''Additional options for JLink Commander,
                             e.g. \'-autoconnect 1\' ''')
         parser.add_argument('--commander', default=DEFAULT_JLINK_EXE,
-                            help='J-Link Commander, default is JLinkExe')
+                            help=f'''J-Link Commander, default is
+                            {DEFAULT_JLINK_EXE}''')
         parser.add_argument('--reset-after-load', '--no-reset-after-load',
                             dest='reset_after_load', nargs=0,
                             action=ToggleAction,

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -13,8 +13,7 @@ import subprocess
 import sys
 import tempfile
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, \
-    BuildConfiguration
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 try:
     from pylink.library import Library

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -5,9 +5,11 @@
 '''Runner for debugging with J-Link.'''
 
 import argparse
+import logging
 import os
 from pathlib import Path
 import shlex
+import subprocess
 import sys
 import tempfile
 
@@ -280,4 +282,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                    self.tool_opt)
 
             self.logger.info('Flashing file: {}'.format(flash_file))
-            self.check_call(cmd)
+            kwargs = {}
+            if not self.logger.isEnabledFor(logging.DEBUG):
+                kwargs['stdout'] = subprocess.DEVNULL
+            self.check_call(cmd, **kwargs)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -254,8 +254,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         lines.append('q') # Close the connection and quit
 
-        self.logger.debug('JLink commander script:')
-        self.logger.debug('\n'.join(lines))
+        self.logger.debug('JLink commander script:\n' +
+                          '\n'.join(lines))
 
         # Don't use NamedTemporaryFile: the resulting file can't be
         # opened again on Windows.

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from re import fullmatch, escape
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 try:
     from intelhex import IntelHex
@@ -169,13 +169,13 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         if self.family is not None:
             return
 
-        if self.build_conf.get('CONFIG_SOC_SERIES_NRF51X', 'n') == 'y':
+        if self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF51X'):
             self.family = 'NRF51'
-        elif self.build_conf.get('CONFIG_SOC_SERIES_NRF52X', 'n') == 'y':
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF52X'):
             self.family = 'NRF52'
-        elif self.build_conf.get('CONFIG_SOC_SERIES_NRF53X', 'n') == 'y':
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF53X'):
             self.family = 'NRF53'
-        elif self.build_conf.get('CONFIG_SOC_SERIES_NRF91X', 'n') == 'y':
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF91X'):
             self.family = 'NRF91'
         else:
             raise RuntimeError(f'unknown nRF; update {__file__}')
@@ -352,7 +352,6 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         self.require('nrfjprog')
-        self.build_conf = BuildConfiguration(self.cfg.build_dir)
 
         self.ensure_output('hex')
         self.ensure_snr()

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -150,11 +150,11 @@ class Sign(Forceable):
         self.check_force(is_zephyr_build(build_dir),
                          "build directory {} doesn't look like a Zephyr build "
                          'directory'.format(build_dir))
-        bcfg = BuildConfiguration(build_dir)
+        build_conf = BuildConfiguration(build_dir)
 
         # Decide on output formats.
         formats = []
-        bin_exists = 'CONFIG_BUILD_OUTPUT_BIN' in bcfg
+        bin_exists = build_conf.getboolean('CONFIG_BUILD_OUTPUT_BIN')
         if args.gen_bin:
             self.check_force(bin_exists,
                              '--bin given but CONFIG_BUILD_OUTPUT_BIN not set '
@@ -164,10 +164,9 @@ class Sign(Forceable):
         elif args.gen_bin is None and bin_exists:
             formats.append('bin')
 
-        hex_exists = 'CONFIG_BUILD_OUTPUT_HEX' in bcfg
+        hex_exists = build_conf.getboolean('CONFIG_BUILD_OUTPUT_HEX')
         if args.gen_hex:
             self.check_force(hex_exists,
-
                              '--hex given but CONFIG_BUILD_OUTPUT_HEX not set '
                              "in build directory's ({}) .config".
                              format(build_dir))
@@ -184,7 +183,7 @@ class Sign(Forceable):
         else:
             raise RuntimeError("can't happen")
 
-        signer.sign(self, build_dir, bcfg, formats)
+        signer.sign(self, build_dir, build_conf, formats)
 
 
 class Signer(abc.ABC):
@@ -194,19 +193,19 @@ class Signer(abc.ABC):
     it in the Sign.do_run() method.'''
 
     @abc.abstractmethod
-    def sign(self, command, build_dir, bcfg, formats):
+    def sign(self, command, build_dir, build_conf, formats):
         '''Abstract method to perform a signature; subclasses must implement.
 
         :param command: the Sign instance
         :param build_dir: the build directory
-        :param bcfg: BuildConfiguration for build directory
+        :param build_conf: BuildConfiguration for build directory
         :param formats: list of formats to generate ('bin', 'hex')
         '''
 
 
 class ImgtoolSigner(Signer):
 
-    def sign(self, command, build_dir, bcfg, formats):
+    def sign(self, command, build_dir, build_conf, formats):
         if not formats:
             return
 
@@ -215,17 +214,17 @@ class ImgtoolSigner(Signer):
 
         imgtool = self.find_imgtool(command, args)
         # The vector table offset is set in Kconfig:
-        vtoff = self.get_cfg(command, bcfg, 'CONFIG_ROM_START_OFFSET')
+        vtoff = self.get_cfg(command, build_conf, 'CONFIG_ROM_START_OFFSET')
         # Flash device write alignment and the partition's slot size
         # come from devicetree:
         flash = self.edt_flash_node(b, args.quiet)
         align, addr, size = self.edt_flash_params(flash)
 
-        if bcfg.get('CONFIG_BOOTLOADER_MCUBOOT', 'n') != 'y':
+        if build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
             log.wrn("CONFIG_BOOTLOADER_MCUBOOT is not set to y in "
-                    f"{bcfg.path}; this probably won't work")
+                    f"{build_conf.path}; this probably won't work")
 
-        kernel = bcfg.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
+        kernel = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         if 'bin' in formats:
             in_bin = b / 'zephyr' / f'{kernel}.bin'
@@ -303,9 +302,9 @@ class ImgtoolSigner(Signer):
         return [imgtool]
 
     @staticmethod
-    def get_cfg(command, bcfg, item):
+    def get_cfg(command, build_conf, item):
         try:
-            return bcfg[item]
+            return build_conf[item]
         except KeyError:
             command.check_force(
                 False, "build .config is missing a {} value".format(item))
@@ -404,7 +403,7 @@ class RimageSigner(Signer):
 
         log.die('Signing not supported for board ' + board)
 
-    def sign(self, command, build_dir, bcfg, formats):
+    def sign(self, command, build_dir, build_conf, formats):
         args = command.args
 
         if args.tool_path:

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -161,11 +161,12 @@ def bcfg_check_cond5(item):
 def bcfg_get_cond5(item):
     return dict(BC_DICT_COND5)[item]
 
+os_path_isfile = os.path.isfile
+
 def os_path_isfile_patch(filename):
     if filename == RC_KERNEL_BIN:
         return True
-    return os.path.isfile(filename)
-
+    return os_path_isfile(filename)
 
 @patch('runners.bossac.BossacBinaryRunner.supports',
 	return_value=False)

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -71,95 +71,69 @@ EXPECTED_COMMANDS_WITH_EXTENDED = [
     ],
 ]
 
-BC_DICT_STD = [
-	# SAM-BA ROM without offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	# No code partition Kconfig
-	# No zephyr,code-partition (defined on DT)
-	('CONFIG_FLASH_LOAD_OFFSET', 0x162e)
-]
+# SAM-BA ROM without offset
+# No code partition Kconfig
+# No zephyr,code-partition (defined on DT)
+DOTCONFIG_STD = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_FLASH_LOAD_OFFSET=0x162e
+'''
 
-BC_DICT_COND1 = [
-	# SAM-BA ROM/FLASH with offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	('CONFIG_USE_DT_CODE_PARTITION', 'y'),
-	('CONFIG_HAS_FLASH_LOAD_OFFSET', 'y'),
-	('CONFIG_FLASH_LOAD_OFFSET', 0x162e)
-]
+# SAM-BA ROM/FLASH with offset
+DOTCONFIG_COND1 = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_HAS_FLASH_LOAD_OFFSET=y
+CONFIG_FLASH_LOAD_OFFSET=0x162e
+'''
 
-BC_DICT_COND2 = [
-	# SAM-BA ROM/FLASH without offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	# No code partition Kconfig
-	('CONFIG_HAS_FLASH_LOAD_OFFSET', 'y'),
-	('CONFIG_FLASH_LOAD_OFFSET', 0x162e)
-]
+# SAM-BA ROM/FLASH without offset
+# No code partition Kconfig
+DOTCONFIG_COND2 = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_HAS_FLASH_LOAD_OFFSET=y
+CONFIG_FLASH_LOAD_OFFSET=0x162e
+'''
 
-BC_DICT_COND3 = [
-	# SAM-BA Extended Arduino with offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	('CONFIG_USE_DT_CODE_PARTITION', 'y'),
-	('CONFIG_BOOTLOADER_BOSSA_ARDUINO', 'y'),
-	('CONFIG_HAS_FLASH_LOAD_OFFSET', 'y'),
-	('CONFIG_FLASH_LOAD_OFFSET', 0x162e)
-]
+# SAM-BA Extended Arduino with offset
+DOTCONFIG_COND3 = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_BOOTLOADER_BOSSA_ARDUINO=y
+CONFIG_HAS_FLASH_LOAD_OFFSET=y
+CONFIG_FLASH_LOAD_OFFSET=0x162e
+'''
 
-BC_DICT_COND4 = [
-	# SAM-BA Extended Adafruit with offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	('CONFIG_USE_DT_CODE_PARTITION', 'y'),
-	('CONFIG_BOOTLOADER_BOSSA_ADAFRUIT_UF2', 'y'),
-	('CONFIG_HAS_FLASH_LOAD_OFFSET', 'y'),
-	('CONFIG_FLASH_LOAD_OFFSET', 0x162e)
-]
+# SAM-BA Extended Adafruit with offset
+DOTCONFIG_COND4 = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_BOOTLOADER_BOSSA_ADAFRUIT_UF2=y
+CONFIG_HAS_FLASH_LOAD_OFFSET=y
+CONFIG_FLASH_LOAD_OFFSET=0x162e
+'''
 
-BC_DICT_COND5 = [
-	# SAM-BA omit offset
-	('CONFIG_BOARD', TEST_BOARD_NAME.split()),
-	('CONFIG_USE_DT_CODE_PARTITION', 'y'),
-	('CONFIG_HAS_FLASH_LOAD_OFFSET', 'y'),
-	('CONFIG_FLASH_LOAD_OFFSET', 0x0)
-]
+# SAM-BA omit offset
+DOTCONFIG_COND5 = f'''
+CONFIG_BOARD="{TEST_BOARD_NAME}"
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_HAS_FLASH_LOAD_OFFSET=y
+CONFIG_FLASH_LOAD_OFFSET=0x0
+'''
 
+def adjust_runner_config(runner_config, tmpdir, dotconfig):
+    # Adjust a RunnerConfig object, 'runner_config', by
+    # replacing its build directory with 'tmpdir' after writing
+    # the contents of 'dotconfig' to tmpdir/zephyr/.config.
+
+    zephyr = tmpdir / 'zephyr'
+    zephyr.mkdir()
+    with open(zephyr / '.config', 'w') as f:
+        f.write(dotconfig)
+    return runner_config._replace(build_dir=os.fspath(tmpdir))
 
 def require_patch(program):
     assert program in ['bossac', 'stty']
-
-def bcfg_check_std(item):
-    return item in dict(BC_DICT_STD)
-
-def bcfg_get_std(item):
-    return dict(BC_DICT_STD)[item]
-
-def bcfg_check_cond1(item):
-    return item in dict(BC_DICT_COND1)
-
-def bcfg_get_cond1(item):
-    return dict(BC_DICT_COND1)[item]
-
-def bcfg_check_cond2(item):
-    return item in dict(BC_DICT_COND2)
-
-def bcfg_get_cond2(item):
-    return dict(BC_DICT_COND2)[item]
-
-def bcfg_check_cond3(item):
-    return item in dict(BC_DICT_COND3)
-
-def bcfg_get_cond3(item):
-    return dict(BC_DICT_COND3)[item]
-
-def bcfg_check_cond4(item):
-    return item in dict(BC_DICT_COND4)
-
-def bcfg_get_cond4(item):
-    return dict(BC_DICT_COND4)[item]
-
-def bcfg_check_cond5(item):
-    return item in dict(BC_DICT_COND5)
-
-def bcfg_get_cond5(item):
-    return dict(BC_DICT_COND5)[item]
 
 os_path_isfile = os.path.isfile
 
@@ -172,16 +146,10 @@ def os_path_isfile_patch(filename):
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=None)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_std)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_std)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_init(cc, req, bcfg_ini, bcfg_check, bcfg_val,
-		     get_cod_par, sup, runner_config):
+def test_bossac_init(cc, req, get_cod_par, sup, runner_config, tmpdir):
     """
     Test commands using a runner created by constructor.
 
@@ -199,6 +167,7 @@ def test_bossac_init(cc, req, bcfg_ini, bcfg_check, bcfg_val,
     Output:
 	no --offset
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir, DOTCONFIG_STD)
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -209,16 +178,10 @@ def test_bossac_init(cc, req, bcfg_ini, bcfg_check, bcfg_val,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=None)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_std)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_std)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create(cc, req, bcfg_ini, bcfg_check, bcfg_val,
-		       get_cod_par, sup, runner_config):
+def test_bossac_create(cc, req, get_cod_par, sup, runner_config, tmpdir):
     """
     Test commands using a runner created from command line parameters.
 
@@ -240,6 +203,7 @@ def test_bossac_create(cc, req, bcfg_ini, bcfg_check, bcfg_val,
     parser = argparse.ArgumentParser()
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
+    runner_config = adjust_runner_config(runner_config, tmpdir, DOTCONFIG_STD)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -250,16 +214,10 @@ def test_bossac_create(cc, req, bcfg_ini, bcfg_check, bcfg_val,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=None)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_std)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_std)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_speed(cc, req, bcfg_ini, bcfg_check, bcfg_val,
-                                  get_cod_par, sup, runner_config):
+def test_bossac_create_with_speed(cc, req, get_cod_par, sup, runner_config, tmpdir):
     """
     Test commands using a runner created from command line parameters.
 
@@ -283,6 +241,7 @@ def test_bossac_create_with_speed(cc, req, bcfg_ini, bcfg_check, bcfg_val,
     parser = argparse.ArgumentParser()
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
+    runner_config = adjust_runner_config(runner_config, tmpdir, DOTCONFIG_STD)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -293,17 +252,11 @@ def test_bossac_create_with_speed(cc, req, bcfg_ini, bcfg_check, bcfg_val,
 	return_value=True)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond1)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond1)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_flash_address(cc, req, bcfg_ini, bcfg_check,
-					  bcfg_val, get_cod_par, sup,
-					  runner_config):
+def test_bossac_create_with_flash_address(cc, req, get_cod_par, sup,
+					  runner_config, tmpdir):
     """
     Test command with offset parameter
 
@@ -328,6 +281,8 @@ def test_bossac_create_with_flash_address(cc, req, bcfg_ini, bcfg_check,
     parser = argparse.ArgumentParser()
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND1)
     runner = BossacBinaryRunner.create(runner_config, arg_namespace)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -340,17 +295,11 @@ def test_bossac_create_with_flash_address(cc, req, bcfg_ini, bcfg_check,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond5)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond5)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_omit_address(cc, req, bcfg_ini, bcfg_check,
-					  bcfg_val, get_cod_par, sup,
-					  runner_config):
+def test_bossac_create_with_omit_address(cc, req, bcfg_ini, sup,
+                                         runner_config, tmpdir):
     """
     Test command that will omit offset because CONFIG_FLASH_LOAD_OFFSET is 0.
     This case is valid for ROM bootloaders that define image start at 0 and
@@ -370,6 +319,8 @@ def test_bossac_create_with_omit_address(cc, req, bcfg_ini, bcfg_check,
     Output:
 	no --offset
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND5)
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -380,17 +331,11 @@ def test_bossac_create_with_omit_address(cc, req, bcfg_ini, bcfg_check,
 	return_value=True)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond3)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond3)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_arduino(cc, req, bcfg_ini, bcfg_check,
-				    bcfg_val, get_cod_par, sup,
-				    runner_config):
+def test_bossac_create_with_arduino(cc, req, get_cod_par, sup,
+				    runner_config, tmpdir):
     """
     Test SAM-BA extended protocol with Arduino variation
 
@@ -409,6 +354,8 @@ def test_bossac_create_with_arduino(cc, req, bcfg_ini, bcfg_check,
     Output:
 	--offset
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND3)
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -418,17 +365,11 @@ def test_bossac_create_with_arduino(cc, req, bcfg_ini, bcfg_check,
 	return_value=True)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond4)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond4)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_adafruit(cc, req, bcfg_ini, bcfg_check,
-				     bcfg_val, get_cod_par, sup,
-				     runner_config):
+def test_bossac_create_with_adafruit(cc, req, get_cod_par, sup,
+				     runner_config, tmpdir):
     """
     Test SAM-BA extended protocol with Adafruit UF2 variation
 
@@ -447,6 +388,8 @@ def test_bossac_create_with_adafruit(cc, req, bcfg_ini, bcfg_check,
     Output:
 	--offset
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND4)
     runner = BossacBinaryRunner(runner_config, port=TEST_BOSSAC_PORT)
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
@@ -457,17 +400,11 @@ def test_bossac_create_with_adafruit(cc, req, bcfg_ini, bcfg_check,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond1)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond1)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_with_oldsdk(cc, req, bcfg_ini, bcfg_check,
-				   bcfg_val, get_cod_par, sup,
-				   runner_config):
+def test_bossac_create_with_oldsdk(cc, req, get_cod_par, sup,
+				   runner_config, tmpdir):
     """
     Test old SDK and ask user to upgrade
 
@@ -484,6 +421,8 @@ def test_bossac_create_with_oldsdk(cc, req, bcfg_ini, bcfg_check,
     Output:
 	Abort
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND1)
     runner = BossacBinaryRunner(runner_config)
     with pytest.raises(RuntimeError) as rinfo:
         with patch('os.path.isfile', side_effect=os_path_isfile_patch):
@@ -497,17 +436,11 @@ def test_bossac_create_with_oldsdk(cc, req, bcfg_ini, bcfg_check,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=None)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond1)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond1)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_error_missing_dt_info(cc, req, bcfg_ini, bcfg_check,
-					     bcfg_val, get_cod_par, sup,
-					     runner_config):
+def test_bossac_create_error_missing_dt_info(cc, req, get_cod_par, sup,
+					     runner_config, tmpdir):
     """
     Test SAM-BA offset wrong configuration. No chosen code partition.
 
@@ -524,6 +457,8 @@ def test_bossac_create_error_missing_dt_info(cc, req, bcfg_ini, bcfg_check,
     Output:
 	Abort
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND1)
     runner = BossacBinaryRunner(runner_config)
     with pytest.raises(RuntimeError) as rinfo:
         with patch('os.path.isfile', side_effect=os_path_isfile_patch):
@@ -536,17 +471,11 @@ def test_bossac_create_error_missing_dt_info(cc, req, bcfg_ini, bcfg_check,
 	return_value=False)
 @patch('runners.bossac.BossacBinaryRunner.get_chosen_code_partition_node',
 	return_value=True)
-@patch('runners.core.BuildConfiguration.__getitem__',
-	side_effect=bcfg_get_cond2)
-@patch('runners.core.BuildConfiguration.__contains__',
-	side_effect=bcfg_check_cond2)
-@patch('runners.core.BuildConfiguration._init')
 @patch('runners.core.ZephyrBinaryRunner.require',
 	side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_bossac_create_error_missing_kconfig(cc, req, bcfg_ini, bcfg_check,
-					     bcfg_val, get_cod_par, sup,
-					     runner_config):
+def test_bossac_create_error_missing_kconfig(cc, req, get_cod_par, sup,
+					     runner_config, tmpdir):
     """
     Test SAM-BA offset wrong configuration. No CONFIG_USE_DT_CODE_PARTITION
     Kconfig definition.
@@ -564,6 +493,8 @@ def test_bossac_create_error_missing_kconfig(cc, req, bcfg_ini, bcfg_check,
     Output:
 	Abort
     """
+    runner_config = adjust_runner_config(runner_config, tmpdir,
+                                         DOTCONFIG_COND2)
     runner = BossacBinaryRunner(runner_config)
     with pytest.raises(RuntimeError) as rinfo:
         with patch('os.path.isfile', side_effect=os_path_isfile_patch):

--- a/scripts/west_commands/tests/test_canopen_program.py
+++ b/scripts/west_commands/tests/test_canopen_program.py
@@ -30,10 +30,12 @@ TEST_CASES = [(n, x, p, c, o, t)
               for o in (False, True)
               for t in range(1, 3)]
 
+os_path_isfile = os.path.isfile
+
 def os_path_isfile_patch(filename):
     if filename == RC_KERNEL_BIN:
         return True
-    return os.path.isfile(filename)
+    return os_path_isfile(filename)
 
 @pytest.mark.parametrize('test_case', TEST_CASES)
 @patch('runners.canopen_program.CANopenProgramDownloader')

--- a/scripts/west_commands/tests/test_dfu_util.py
+++ b/scripts/west_commands/tests/test_dfu_util.py
@@ -55,10 +55,12 @@ def find_device_patch():
 def require_patch(program):
     assert program in [DFU_UTIL, TEST_EXE]
 
+os_path_isfile = os.path.isfile
+
 def os_path_isfile_patch(filename):
     if filename == RC_KERNEL_BIN:
         return True
-    return os.path.isfile(filename)
+    return os_path_isfile(filename)
 
 def id_fn(tc):
     return 'exe={},alt={},dfuse_config={},img={}'.format(*tc)

--- a/scripts/west_commands/tests/test_dfu_util.py
+++ b/scripts/west_commands/tests/test_dfu_util.py
@@ -102,14 +102,13 @@ def get_flash_address_patch(args, bcfg):
     (None, TEST_ALT_INT, True, None, None),
 
 ], ids=id_fn)
-@patch('runners.core.BuildConfiguration._init',)
 @patch('runners.dfu.DfuUtilBinaryRunner.find_device',
        side_effect=find_device_patch)
 @patch('runners.core.ZephyrBinaryRunner.get_flash_address',
        side_effect=get_flash_address_patch)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_dfu_util_create(cc, req, gfa, find_device, bcfg, tc, runner_config):
+def test_dfu_util_create(cc, req, gfa, find_device, tc, runner_config, tmpdir):
     '''Test commands using a runner created from command line parameters.'''
     exe, alt, dfuse, modifiers, img = tc
     args = ['--pid', TEST_PID, '--alt', alt]
@@ -123,6 +122,11 @@ def test_dfu_util_create(cc, req, gfa, find_device, bcfg, tc, runner_config):
             args.extend(['--dfuse-modifiers', ''])
     if exe:
         args.extend(['--dfu-util', exe])
+
+    (tmpdir / 'zephyr').mkdir()
+    with open(os.fspath(tmpdir / 'zephyr' / '.config'), 'w') as f:
+        f.write('\n')
+    runner_config = runner_config._replace(build_dir=os.fspath(tmpdir))
 
     parser = argparse.ArgumentParser()
     DfuUtilBinaryRunner.add_parser(parser)

--- a/scripts/west_commands/tests/test_stm32flash.py
+++ b/scripts/west_commands/tests/test_stm32flash.py
@@ -65,10 +65,12 @@ def os_path_getsize_patch(filename):
         return TEST_BIN_SIZE
     return os.path.isfile(filename)
 
+os_path_isfile = os.path.isfile
+
 def os_path_isfile_patch(filename):
     if filename == RC_KERNEL_BIN:
         return True
-    return os.path.isfile(filename)
+    return os_path_isfile(filename)
 
 @pytest.mark.parametrize('action', EXPECTED_COMMANDS)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)


### PR DESCRIPTION
Starting with J-Link v7.11b, The J-Link Software and Documentation Pack
supports Zephyr RTOS awareness, aka thread info.
For this to work, the Zephyr application needs to be built with
CONFIG_DEBUG_THREAD_INFO=y.

This patch adds the corresponding JLinkGDBServer option when invoking
it, in order to activate the plugin.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>