### PR TITLE
net: openthread: Update to the latest revision

### DIFF
--- a/subsys/logging/log_backend_spinel.c
+++ b/subsys/logging/log_backend_spinel.c
@@ -8,7 +8,7 @@
 #include <logging/log_backend_std.h>
 #include <logging/log_output.h>
 #include <openthread/platform/logging.h>
-#include <openthread/platform/uart.h>
+#include <utils/uart.h>
 #include <platform-zephyr.h>
 
 #ifndef CONFIG_LOG_BACKEND_SPINEL_BUFFER_SIZE

--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -137,6 +137,12 @@ config OPENTHREAD_MTD_NETDIAG
 config OPENTHREAD_MULTIPLE_INSTANCE
 	bool "Enable OpenThread multiple instances"
 
+config OPENTHREAD_NEIGHBOR_DISCOVERY_AGENT
+	bool "Enable neighbor discovery agent support"
+
+config OPENTHREAD_PING_SENDER
+	bool "Enable ping sender support"
+
 config OPENTHREAD_PLATFORM_UDP
 	bool "Enable platform UDP support"
 
@@ -161,6 +167,9 @@ config OPENTHREAD_SNTP_CLIENT
 
 config OPENTHREAD_TIME_SYNC
 	bool "Enable the time synchronization service feature"
+
+config OPENTHREAD_TREL
+	bool "Enable TREL radio link for Thread over Infrastructure feature"
 
 config OPENTHREAD_UDP_FORWARD
 	bool "Enable UDP forward support"

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -40,7 +40,6 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 	char *buf_ptr = rx_buffer;
 	size_t buf_len = OT_SHELL_BUFFER_SIZE;
 	size_t arg_len = 0;
-	k_tid_t ot_tid = openthread_thread_id_get();
 	int i;
 
 	for (i = 1; i < argc; i++) {
@@ -67,12 +66,9 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 
 	shell_p = shell;
 
-	/* Halt the OpenThread thread execution. This will prevent from being
-	 * rescheduled into the OT thread in the middle of command processing.
-	 */
-	k_thread_suspend(ot_tid);
+	openthread_api_mutex_lock(openthread_get_default_context());
 	otCliInputLine(rx_buffer);
-	k_thread_resume(ot_tid);
+	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	return 0;
 }

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -22,14 +22,14 @@ static char rx_buffer[OT_SHELL_BUFFER_SIZE];
 
 static const struct shell *shell_p;
 
-int otConsoleOutputCallback(const char *aBuf, uint16_t aBufLength,
-			    void *aContext)
+int otConsoleOutputCallback(void *aContext, const char *aFormat,
+			    va_list aArguments)
 {
 	ARG_UNUSED(aContext);
 
-	shell_fprintf(shell_p, SHELL_NORMAL, "%s", aBuf);
+	shell_vfprintf(shell_p, SHELL_NORMAL, aFormat, aArguments);
 
-	return aBufLength;
+	return 0;
 }
 
 #define SHELL_HELP_OT	"OpenThread subcommands\n" \
@@ -71,7 +71,7 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 	 * rescheduled into the OT thread in the middle of command processing.
 	 */
 	k_thread_suspend(ot_tid);
-	otCliConsoleInputLine(rx_buffer, OT_SHELL_BUFFER_SIZE - buf_len);
+	otCliInputLine(rx_buffer);
 	k_thread_resume(ot_tid);
 
 	return 0;
@@ -81,5 +81,5 @@ SHELL_CMD_ARG_REGISTER(ot, NULL, SHELL_HELP_OT, ot_cmd, 2, 255);
 
 void platformShellInit(otInstance *aInstance)
 {
-	otCliConsoleInit(aInstance, otConsoleOutputCallback, NULL);
+	otCliInit(aInstance, otConsoleOutputCallback, NULL);
 }

--- a/subsys/net/lib/openthread/platform/spi.c
+++ b/subsys/net/lib/openthread/platform/spi.c
@@ -7,7 +7,6 @@
 #include <kernel.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <openthread/platform/uart.h>
 #include <openthread/platform/spi-slave.h>
 
 #include "platform-zephyr.h"

--- a/subsys/net/lib/openthread/platform/uart.c
+++ b/subsys/net/lib/openthread/platform/uart.c
@@ -23,8 +23,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <usb/usb_device.h>
 #endif
 
+#include <openthread/ncp.h>
 #include <openthread-system.h>
-#include <openthread/platform/uart.h>
+#include <utils/uart.h>
 
 #include "platform-zephyr.h"
 
@@ -116,6 +117,16 @@ static void uart_callback(const struct device *dev, void *user_data)
 			uart_tx_handle(dev);
 		}
 	}
+}
+
+void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
+{
+	otNcpHdlcReceive(aBuf, aBufLength);
+}
+
+void otPlatUartSendDone(void)
+{
+	otNcpHdlcSendDone();
 }
 
 void platformUartProcess(otInstance *aInstance)

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
       revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e
       path: modules/lib/loramac-node
     - name: openthread
-      revision: fd27fc3a7758d409e00d0e8d43f3f8364ce6c7e9
+      revision: cdb9570901e87ab247aed0a96ccd8f94beee5834
       path: modules/lib/openthread
     - name: segger
       revision: 38c79a447e4a47d413b4e8d34448316a5cece77c


### PR DESCRIPTION
Update the OpenThread repository to its latest revision.

The most significant changes that impact the Zephyr port are CLI and NCP API changes. The CLI update was pretty straightforward, but for the NCP the changes are more significant.

The NCP module no longer use the UART APIs (which are no longer part of the OT platfrom abstraction layer) but instead provides its own handler to send data and callbacks to report TX/RX completion. For the sake of simplicity of the upmerge, these new APIs are just thin wrappers around the exisiting UART API (just as the upstream NCP example does) but this leaves an opening to re-think the UART component API in the future (and possibly simplify it).