### PR TITLE
boards/arm: stm32h747i_disco_m7: Enabling flash support in device tree.

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -63,6 +63,8 @@ The current Zephyr stm32h747i_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
+| FLASH     | on-chip    | flash memory                        |
++-----------+------------+-------------------------------------+
 | ETHERNET  | on-chip    | ethernet  (*)                       |
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -60,6 +60,19 @@
 	status = "okay";
 };
 
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 2KB of storage at the end of first 1MB flash */
+		storage_partition: partition@ff800 {
+			label = "storage";
+			reg = <0x000ff800 0x00000800>;
+		};
+	};
+};
 
 &mac {
 	/*


### PR DESCRIPTION
This commit enables flash support for stm32h747i_disco_m7
in device tree. This has been tested with flash sample
application on stm32h747i_disco platform with m7 core.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>