### PR TITLE
drivers: i2c: ite_it8xxx2: fix typo

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -874,7 +874,7 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 	static struct i2c_it8xxx2_data i2c_it8xxx2_data_##idx;	               \
 	\
 	DEVICE_DT_INST_DEFINE(idx,				               \
-			&i2c_it8xxx2_init, &NULL,			       \
+			&i2c_it8xxx2_init, NULL,			       \
 			&i2c_it8xxx2_data_##idx,	                       \
 			&i2c_it8xxx2_cfg_##idx, POST_KERNEL,		       \
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                    \


### PR DESCRIPTION
Remove '&' from previous usage of `device_pm_control_nop`.