### PR TITLE
drivers: clock_control: stm32wl doesn't have HSE bypass

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -475,9 +475,15 @@ int stm32_clock_control_init(const struct device *dev)
 	if (LL_RCC_HSE_IsReady() != 1) {
 		/* Check if need to enable HSE bypass feature or not */
 		if (IS_ENABLED(STM32_HSE_BYPASS)) {
+#ifdef CONFIG_SOC_SERIES_STM32WLX
+			LL_RCC_HSE_EnableTcxo();
+		} else {
+			LL_RCC_HSE_DisableTcxo();
+#else
 			LL_RCC_HSE_EnableBypass();
 		} else {
 			LL_RCC_HSE_DisableBypass();
+#endif
 		}
 
 		/* Enable HSE */


### PR DESCRIPTION
drivers: clock_control: stm32wl doesn't have HSE bypass

LL_RCC_HSE_EnableBypass() doesn't exist on stm32wl,
but can be replaced by LL_RCC_HSE_EnableTcxo()
