### PR TITLE
coding guidelines 15.7:  add missing final else in lib os

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -557,6 +557,8 @@ int_conv:
 			default:
 				break;
 			}
+		} else {
+			;
 		}
 		break;
 
@@ -586,6 +588,8 @@ int_conv:
 		} else if ((conv->length_mod != LENGTH_NONE)
 			   && (conv->length_mod != LENGTH_UPPER_L)) {
 			conv->invalid = true;
+		} else {
+			;
 		}
 
 		break;
@@ -802,6 +806,8 @@ static char *encode_uint(uint_value_type value,
 			conv->altform_0 = true;
 		} else if (radix == 16) {
 			conv->altform_0c = true;
+		} else {
+			;
 		}
 	}
 
@@ -878,6 +884,8 @@ static char *encode_float(double value,
 		*sign = '+';
 	} else if (conv->flag_space) {
 		*sign = ' ';
+	} else {
+		;
 	}
 
 	/* Extract the non-negative offset exponent and fraction.  Record
@@ -1392,6 +1400,8 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			}
 		} else if (conv->width_present) {
 			width = conv->width_value;
+		} else {
+			;
 		}
 
 		/* If dynamic precision is specified, process it, otherwise
@@ -1408,6 +1418,8 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			}
 		} else if (conv->prec_present) {
 			precision = conv->prec_value;
+		} else {
+			;
 		}
 
 		/* Reuse width and precision memory in conv for value

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -204,6 +204,8 @@ start:
 			} else if (special == '+') {
 				prefix = "+";
 				min_width--;
+			} else {
+				;
 			}
 			data_len = convert_value(d, 10, 0, buf + sizeof(buf));
 			data = buf + sizeof(buf) - data_len;

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -207,33 +207,34 @@ static bool rand_alloc_choice(struct z_heap_stress_rec *sr)
 		return true;
 	} else if (sr->blocks_alloced >= sr->nblocks) {
 		return false;
+	} else {
+
+		/* The way this works is to scale the chance of choosing to
+		 * allocate vs. free such that it's even odds when the heap is
+		 * at the target percent, with linear tapering on the low
+		 * slope (i.e. we choose to always allocate with an empty
+		 * heap, allocate 50% of the time when the heap is exactly at
+		 * the target, and always free when above the target).  In
+		 * practice, the operations aren't quite symmetric (you can
+		 * always free, but your allocation might fail), and the units
+		 * aren't matched (we're doing math based on bytes allocated
+		 * and ignoring the overhead) but this is close enough.  And
+		 * yes, the math here is coarse (in units of percent), but
+		 * that's good enough and fits well inside 32 bit quantities.
+		 * (Note precision issue when heap size is above 40MB
+		 * though!).
+		 */
+		__ASSERT(sr->total_bytes < 0xffffffffU / 100, "too big for u32!");
+		uint32_t full_pct = (100 * sr->bytes_alloced) / sr->total_bytes;
+		uint32_t target = sr->target_percent ? sr->target_percent : 1;
+		uint32_t free_chance = 0xffffffffU;
+
+		if (full_pct < sr->target_percent) {
+			free_chance = full_pct * (0x80000000U / target);
+		}
+
+		return rand32() > free_chance;
 	}
-
-	/* The way this works is to scale the chance of choosing to
-	 * allocate vs. free such that it's even odds when the heap is
-	 * at the target percent, with linear tapering on the low
-	 * slope (i.e. we choose to always allocate with an empty
-	 * heap, allocate 50% of the time when the heap is exactly at
-	 * the target, and always free when above the target).  In
-	 * practice, the operations aren't quite symmetric (you can
-	 * always free, but your allocation might fail), and the units
-	 * aren't matched (we're doing math based on bytes allocated
-	 * and ignoring the overhead) but this is close enough.  And
-	 * yes, the math here is coarse (in units of percent), but
-	 * that's good enough and fits well inside 32 bit quantities.
-	 * (Note precision issue when heap size is above 40MB
-	 * though!).
-	 */
-	__ASSERT(sr->total_bytes < 0xffffffffU / 100, "too big for u32!");
-	uint32_t full_pct = (100 * sr->bytes_alloced) / sr->total_bytes;
-	uint32_t target = sr->target_percent ? sr->target_percent : 1;
-	uint32_t free_chance = 0xffffffffU;
-
-	if (full_pct < sr->target_percent) {
-		free_chance = full_pct * (0x80000000U / target);
-	}
-
-	return rand32() > free_chance;
 }
 
 /* Chooses a size of block to allocate, logarithmically favoring

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -361,6 +361,8 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 		merge_chunks(h, c, rc);
 		set_chunk_used(h, c, true);
 		return ptr;
+	} else {
+		;
 	}
 
 	/* Fallback: allocate and copy */

--- a/lib/os/onoff.c
+++ b/lib/os/onoff.c
@@ -222,6 +222,8 @@ static int process_recheck(struct onoff_manager *mgr)
 	} else if ((state == ONOFF_STATE_ERROR)
 		   && !sys_slist_is_empty(&mgr->clients)) {
 		evt = EVT_RESET;
+	} else {
+		;
 	}
 
 	return evt;
@@ -406,6 +408,8 @@ static void process_event(struct onoff_manager *mgr,
 		} else if ((mgr->flags & ONOFF_FLAG_RECHECK) != 0) {
 			mgr->flags &= ~ONOFF_FLAG_RECHECK;
 			evt = EVT_RECHECK;
+		} else {
+			;
 		}
 
 		state = mgr->flags & ONOFF_STATE_MASK;

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -63,6 +63,8 @@ static inline bool item_lessthan(struct k_p4wq_work *a, struct k_p4wq_work *b)
 	} else if ((a->priority == b->priority) &&
 		   (a->deadline != b->deadline)) {
 		return a->deadline - b->deadline > 0;
+	} else {
+		;
 	}
 	return false;
 }

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -74,8 +74,9 @@ int sys_sem_give(struct sys_sem *sem)
 		}
 	} else if (old_value >= sem->limit) {
 		return -EAGAIN;
+	} else {
+		;
 	}
-
 	return ret;
 }
 


### PR DESCRIPTION
Fresh attempt - The cbprintf_*.c changes in previous commit 163b7f0 caused test failures had to be reverted. This is a fresh submit for the files in that lib/os patch, incorporating feedback to not refactor, especially the cbprintf.

CG 15.7 requires a final non-empty else {} for if else if constructs. The lib/os/ had several places missing final else. This commit meets minimum requirement and can be improved upon by code owners. 
- cbprintf_complete.c &  cbprintf_nano.c
- heap-validate.c & heap.c
- onoff.c, p4wq.c, and sem.c