### PR TITLE
arch: arm: cortex-m: add support for clearing NXP MPU regions at boot

### DIFF
--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -52,13 +52,6 @@
 	};
 
 	soc {
-		mpu: mpu@4000d000 {
-			compatible = "nxp,k22f-mpu";
-			reg = <0x4000d000 0x824>;
-
-			status = "disabled";
-		};
-
 		mcg: clock-controller@40064000 {
 			compatible = "nxp,kinetis-mcg";
 			reg = <0x40064000 0xd>;

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.series
@@ -13,7 +13,6 @@ config SOC_SERIES_KINETIS_K2X
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_FAMILY_KINETIS
-	select CPU_HAS_NXP_MPU
 	select CLOCK_CONTROL
 	help
 	  Enable support for Kinetis K2x MCU series

--- a/soc/arm/nxp_kinetis/k2x/soc.c
+++ b/soc/arm/nxp_kinetis/k2x/soc.c
@@ -123,32 +123,12 @@ static int fsl_frdm_k22f_init(const struct device *arg)
 	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
-#if !defined(CONFIG_ARM_MPU)
-#if defined(SYSMPU)
-	uint32_t temp_reg;
-#endif
-#endif /* !CONFIG_ARM_MPU */
 
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
 	/* release I/O power hold to allow normal run state */
 	PMC->REGSC |= PMC_REGSC_ACKISO_MASK;
-
-#if !defined(CONFIG_ARM_MPU)
-	/*
-	 * Disable memory protection and clear slave port errors.
-	 * Note that the K22F does not implement the optional ARMv7-M memory
-	 * protection unit (MPU), specified by the architecture (PMSAv7), in the
-	 * Cortex-M4 core.  Instead, the processor includes its own MPU module.
-	 */
-#if defined(SYSMPU)
-	temp_reg = SYSMPU->CESR;
-	temp_reg &= ~SYSMPU_CESR_VLD_MASK;
-	temp_reg |= SYSMPU_CESR_SPERR_MASK;
-	SYSMPU->CESR = temp_reg;
-#endif
-#endif /* !CONFIG_ARM_MPU */
 
 	/* Initialize PLL/system clock to 120 MHz */
 	clock_init();


### PR DESCRIPTION
Clear NXP MPU regions at boot if CONFIG_INIT_ARCH_HW_AT_BOOT is enabled. Also remove MPU support from the K2x SoC since this leads to compilation issues as the K22F does not contain an MPU.

Fixes: #34045 