### PR TITLE
pm: deprecate device_pm_control_nop

### DIFF
--- a/doc/guides/dts/howtos.rst
+++ b/doc/guides/dts/howtos.rst
@@ -465,7 +465,7 @@ using instance numbers. Do this after defining ``my_api_funcs``.
    	};								\
    	DEVICE_DT_INST_DEFINE(inst,					\
    			      my_dev_init_function,			\
-			      device_pm_control_nop,			\
+			      NULL,             			\
    			      &my_data_##inst,				\
    			      &my_cfg_##inst,				\
    			      MY_DEV_INIT_LEVEL, MY_DEV_INIT_PRIORITY,	\
@@ -542,7 +542,7 @@ devicetree to operate on specific device nodes:
 	static const struct my_dev_cfg my_cfg_##idx = { /* ... */ };	\
    	DEVICE_DT_DEFINE(MYDEV(idx),					\
    			my_dev_init_function,				\
-			device_pm_control_nop,				\
+			NULL,           				\
 			&my_data_##idx,					\
 			&my_cfg_##idx,					\
 			MY_DEV_INIT_LEVEL, MY_DEV_INIT_PRIORITY,	\

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -326,7 +326,7 @@ Then when the particular instance is declared:
   static struct my_data_0;
 
   DEVICE_DEFINE(my_driver_0, MY_DRIVER_0_NAME, my_driver_init,
-                device_pm_control_nop, &my_data_0, &my_driver_config_0,
+                NULL, &my_data_0, &my_driver_config_0,
                 POST_KERNEL, MY_DRIVER_0_PRIORITY, &my_api_funcs);
 
   #endif /* CONFIG_MY_DRIVER_0 */

--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -264,21 +264,9 @@ Device Model with Power Management Support
 Drivers initialize the devices using macros. See :ref:`device_model_api` for
 details on how these macros are used. Use the DEVICE_DEFINE macro to initialize
 drivers providing power management support via the PM control function.
-One of the macro parameters is the pointer to the device_pm_control handler function.
-
-Default Initializer Function
-----------------------------
-
-.. code-block:: c
-
-   int device_pm_control_nop(const struct device *unused_device, uint32_t unused_ctrl_command, void *unused_context);
-
-
-If the driver doesn't implement any power control operations, the driver can
-initialize the corresponding pointer with this default nop function. This
-default nop function does nothing and should be used instead of
-implementing a dummy function to avoid wasting code memory in the driver.
-
+One of the macro parameters is the pointer to the device_pm_control handler
+function. If the driver doesn't implement any power control operations, it can
+initialize the corresponding pointer with ``NULL``.
 
 Device Power Management API
 ===========================

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -309,6 +309,12 @@ Libraries / Subsystems
 
 * Power management
 
+  * ``device_pm_control_nop`` has been removed in favor of ``NULL`` when device
+    PM is not supported by a device. In order to make transition easier for
+    out-of-tree users a macro with the same name is provided as an alias to
+    ``NULL``. The macro is flagged as deprecated to make users aware of the
+    change.
+
 * Logging
 
 * LVGL

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -306,7 +306,7 @@ static const struct cy8c95xx_config cy8c95xx_##idx##_cfg = { \
 static struct cy8c95xx_drv_data cy8c95xx_##idx##_drvdata = { \
 	.lock = &cy8c95xx_lock, \
 }; \
-DEVICE_DT_INST_DEFINE(idx, cy8c95xx_init, device_pm_control_nop, \
+DEVICE_DT_INST_DEFINE(idx, cy8c95xx_init, NULL, \
 				&cy8c95xx_##idx##_drvdata, &cy8c95xx_##idx##_cfg, \
 				POST_KERNEL, CONFIG_GPIO_CY8C95XX_INIT_PRIORITY, \
 				&api_table);

--- a/include/device.h
+++ b/include/device.h
@@ -922,12 +922,8 @@ static inline int device_pm_put_sync(const struct device *dev) { return -ENOTSUP
 #endif
 #endif
 
-/**
- * @brief Alias for legacy use of device_pm_control_nop.
- *
- * @note Usage of NULL is preferred, this alias will eventually be removed.
- */
-#define device_pm_control_nop NULL
+/** Alias for legacy use of device_pm_control_nop */
+#define device_pm_control_nop __DEPRECATED_MACRO NULL
 
 /**
  * @}

--- a/include/drivers/gpio/gpio_mmio32.h
+++ b/include/drivers/gpio/gpio_mmio32.h
@@ -54,7 +54,7 @@ static const struct gpio_mmio32_config _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _c
 											\
 DEVICE_DT_DEFINE(node_id,								\
 		    &gpio_mmio32_init,							\
-		    device_pm_control_nop,						\
+		    NULL,								\
 		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _ctx),			\
 		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _cfg),			\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -685,7 +685,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * the system.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -709,7 +709,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
  * @param pm_control_fn Pointer to device_pm_control function.
- * Can be empty function (device_pm_control_nop) if not implemented.
+ * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
  * @param cfg The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
@@ -43,6 +43,6 @@ static inline void z_vrfy_hello_world_print(const struct device *dev)
 
 
 DEVICE_DEFINE(hello_world, "CUSTOM_DRIVER",
-		    init, device_pm_control_nop, &data, NULL,
+		    init, NULL, &data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &((struct hello_world_driver_api){ .print = print_impl }));

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -171,7 +171,7 @@ static const struct virtual_interface_api virtual_test_iface_api = {
 };
 
 NET_VIRTUAL_INTERFACE_INIT(virtual_test1, VIRTUAL_TEST,
-			   virtual_test_init, device_pm_control_nop,
+			   virtual_test_init, NULL,
 			   &virtual_test_context_data1,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -179,7 +179,7 @@ NET_VIRTUAL_INTERFACE_INIT(virtual_test1, VIRTUAL_TEST,
 			   VIRTUAL_TEST_MTU);
 
 NET_VIRTUAL_INTERFACE_INIT(virtual_test2, VIRTUAL_TEST2,
-			   virtual_test_init, device_pm_control_nop,
+			   virtual_test_init, NULL,
 			   &virtual_test_context_data2,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -187,7 +187,7 @@ NET_VIRTUAL_INTERFACE_INIT(virtual_test2, VIRTUAL_TEST2,
 			   VIRTUAL_TEST_MTU);
 
 NET_VIRTUAL_INTERFACE_INIT(virtual_test3, VIRTUAL_TEST3,
-			   virtual_test_init, device_pm_control_nop,
+			   virtual_test_init, NULL,
 			   &virtual_test_context_data3,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -112,8 +112,7 @@ static int sample_driver_foo_init(const struct device *dev)
 static struct sample_driver_foo_dev_data sample_driver_foo_dev_data_0;
 
 DEVICE_DEFINE(sample_driver_foo_0, SAMPLE_DRIVER_NAME_0,
-		    &sample_driver_foo_init,
-		    device_pm_control_nop,
+		    &sample_driver_foo_init, NULL,
 		    &sample_driver_foo_dev_data_0, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &sample_driver_foo_api);


### PR DESCRIPTION
- Remove remaining uses
- Update documentation
- Flag alias macro as deprecated