### PR TITLE
arch: x86: core: pcie: rephrase use of ain't

### DIFF
--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -97,7 +97,7 @@ static inline void pcie_mm_conf(pcie_bdf_t bdf, unsigned int reg,
 
 /*
  * Helper function for exported configuration functions. Configuration access
- * ain't atomic, so spinlock to keep drivers from clobbering each other.
+ * is not atomic, so spinlock to keep drivers from clobbering each other.
  */
 static inline void pcie_io_conf(pcie_bdf_t bdf, unsigned int reg,
 				bool write, uint32_t *data)


### PR DESCRIPTION
Rephrasing away from ain't, which is informal, uncommon, and can
be viewed as substandard or 'slang'.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>