### PR TITLE
Implement k_mem_unmap()

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -955,3 +955,9 @@ config BOARD
 	  The Board is the first location where we search for a linker.ld file,
 	  if not found we look for the linker file in
 	  soc/<arch>/<family>/<series>
+
+config TOOLCHAIN_HAS_BUILTIN_FFS
+	bool
+	default y if !(64BIT && RISCV)
+	help
+	  Hidden option to signal that toolchain has __builtin_ffs*().

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1844,6 +1844,29 @@ void arch_reserved_pages_update(void)
 }
 #endif /* CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES */
 
+int arch_page_phys_get(void *virt, uintptr_t *phys)
+{
+	pentry_t pte = 0;
+	int level, ret;
+
+	__ASSERT(POINTER_TO_UINT(virt) % CONFIG_MMU_PAGE_SIZE == 0U,
+		 "unaligned address %p to %s", virt, __func__);
+
+	pentry_get(&level, &pte, z_x86_page_tables_get(), virt);
+
+	if ((pte & MMU_P) != 0) {
+		if (phys != NULL) {
+			*phys = (uintptr_t)get_entry_phys(pte, PTE_LEVEL);
+		}
+		ret = 0;
+	} else {
+		/* Not mapped */
+		ret = -EFAULT;
+	}
+
+	return ret;
+}
+
 #ifdef CONFIG_DEMAND_PAGING
 #define PTE_MASK (paging_levels[PTE_LEVEL].mask)
 

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1784,8 +1784,6 @@ static void mark_addr_page_reserved(uintptr_t addr, size_t len)
 		struct z_page_frame *pf = z_phys_to_page_frame(pos);
 
 		pf->flags |= Z_PAGE_FRAME_RESERVED;
-
-		z_free_page_count--;
 	}
 }
 

--- a/include/arch/common/ffs.h
+++ b/include/arch/common/ffs.h
@@ -52,7 +52,32 @@ static ALWAYS_INLINE unsigned int find_msb_set(uint32_t op)
 
 static ALWAYS_INLINE unsigned int find_lsb_set(uint32_t op)
 {
+#ifdef CONFIG_TOOLCHAIN_HAS_BUILTIN_FFS
 	return __builtin_ffs(op);
+
+#else
+	/*
+	 * Toolchain does not have __builtin_ffs().
+	 * Need to do this manually.
+	 */
+	int bit;
+
+	if (op == 0) {
+		return 0;
+	}
+
+	for (bit = 0; bit < 32; bit++) {
+		if ((op & (1 << bit)) != 0) {
+			return (bit + 1);
+		}
+	}
+
+	/*
+	 * This should never happen but we need to keep
+	 * compiler happy.
+	 */
+	return 0;
+#endif /* CONFIG_TOOLCHAIN_HAS_BUILTIN_FFS */
 }
 
 #ifdef __cplusplus

--- a/include/sys/bitarray.h
+++ b/include/sys/bitarray.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_BITARRAY_H_
+#define ZEPHYR_INCLUDE_SYS_BITARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <kernel.h>
+
+struct sys_bitarray {
+	/* Number of bits */
+	uint32_t num_bits;
+
+	/* Number of bundles */
+	uint32_t num_bundles;
+
+	/* Bundle of bits */
+	uint32_t *bundles;
+
+	/* Spinlock guarding access to this bit array */
+	struct k_spinlock lock;
+};
+
+typedef struct sys_bitarray sys_bitarray_t;
+
+/**
+ * @def SYS_BITARRAY_DEFINE
+ *
+ * @brief Create a bitarray object.
+ *
+ * @param name Name of the bitarray object.
+ * @param total_bits Total number of bits in this bitarray object.
+ */
+#define SYS_BITARRAY_DEFINE(name, total_bits)				\
+	uint32_t _sys_bitarray_bundles_##name				\
+		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
+		 / sizeof(uint32_t)] = {0U};				\
+	sys_bitarray_t name = {						\
+		.num_bits = total_bits,					\
+		.num_bundles = (((total_bits + 8 - 1) / 8)		\
+				+ sizeof(uint32_t) - 1)			\
+			       / sizeof(uint32_t),			\
+		.bundles = _sys_bitarray_bundles_##name,		\
+	}
+
+/**
+ * Set a bit in a bit array
+ *
+ * @param[in] bitarray Bitarray struct
+ * @param[in] bit      The bit to be set
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to set exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_set_bit(sys_bitarray_t *bitarray, size_t bit);
+
+/**
+ * Clear a bit in a bit array
+ *
+ * @param[in] bitarray Bitarray struct
+ * @param[in] bit      The bit to be cleared
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to clear exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_clear_bit(sys_bitarray_t *bitarray, size_t bit);
+
+/**
+ * Test whether a bit is set or not
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  bit      The bit to be tested
+ * @param[out] val      The value of the bit (0 or 1)
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to test exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_test_bit(sys_bitarray_t *bitarray, size_t bit, int *val);
+
+/**
+ * Test the bit and set it
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  bit      The bit to be tested and set
+ * @param[out] prev_val Previous value of the bit (0 or 1)
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to test exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_test_and_set_bit(sys_bitarray_t *bitarray, size_t bit, int *prev_val);
+
+/**
+ * Test the bit and clear it
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  bit      The bit to be tested and cleared
+ * @param[out] prev_val Previous value of the bit (0 or 1)
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to test exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_test_and_clear_bit(sys_bitarray_t *bitarray, size_t bit, int *prev_val);
+
+/**
+ * Allocate bits in a bit array
+ *
+ * This finds a number of bits (@p num_bits) in a contiguous of
+ * previosly unallocated region. If such a region exists, the bits are
+ * marked as allocated and the offset to the start of this region is
+ * returned via @p offset.
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  num_bits Number of bits to allocate
+ * @param[out] offset   Offset to the start of allocated region if
+ *                      successful
+ *
+ * @retval 0       Allocation successful
+ * @retval -EINVAL Invalid argument (e.g. allocating more bits than
+ *                 the bitarray has, trying to allocate 0 bits, etc.)
+ * @retval -ENOSPC No contiguous region big enough to accommodate
+ *                 the allocation
+ */
+int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
+		       size_t *offset);
+
+/**
+ * Free bits in a bit array
+ *
+ * This marks the number of bits (@p num_bits) starting from @p offset
+ * as no longer allocated.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to free
+ * @param offset   Starting bit position to free
+ *
+ * @retval 0       Free is successful
+ * @retval -EINVAL Invalid argument (e.g. try to free more bits than
+ *                 the bitarray has, trying to free 0 bits, etc.)
+ * @retval -EFAULT The bits in the indicated region are not all allocated.
+ */
+int sys_bitarray_free(sys_bitarray_t *bitarray, size_t num_bits,
+		      size_t offset);
+
+/**
+ * Test if bits in a region is all set.
+ *
+ * This tests if the number of bits (@p num_bits) in region starting
+ * from @p offset are all set.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to test
+ * @param offset   Starting bit position to test
+ *
+ * @retval true    All bits are set.
+ * @retval false   Not all bits are set.
+ */
+bool sys_bitarray_is_region_set(sys_bitarray_t *bitarray, size_t num_bits,
+				size_t offset);
+
+/**
+ * Test if bits in a region is all cleared.
+ *
+ * This tests if the number of bits (@p num_bits) in region starting
+ * from @p offset are all cleared.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to test
+ * @param offset   Starting bit position to test
+ *
+ * @retval true    All bits are cleared.
+ * @retval false   Not all bits are cleared.
+ */
+bool sys_bitarray_is_region_cleared(sys_bitarray_t *bitarray, size_t num_bits,
+				    size_t offset);
+
+/**
+ * Set all bits in a region.
+ *
+ * This sets the number of bits (@p num_bits) in region starting
+ * from @p offset.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to test
+ * @param offset   Starting bit position to test
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to set exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_set_region(sys_bitarray_t *bitarray, size_t num_bits,
+			    size_t offset);
+
+/**
+ * Clear all bits in a region.
+ *
+ * This clears the number of bits (@p num_bits) in region starting
+ * from @p offset.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to test
+ * @param offset   Starting bit position to test
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to set exceeds
+ *                 the number of bits in bit array, etc.)
+ */
+int sys_bitarray_clear_region(sys_bitarray_t *bitarray, size_t num_bits,
+			      size_t offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_BITARRAY_H_ */

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -179,8 +179,6 @@ extern "C" {
  * Portable code should never assume that phys_addr and linear_addr will
  * be equal.
  *
- * Once created, mappings are permanent.
- *
  * Caching and access properties are controlled by the 'flags' parameter.
  * Unused bits in 'flags' are reserved for future expansion.
  * A caching mode must be selected. By default, the region is read-only
@@ -209,6 +207,35 @@ extern "C" {
  */
 void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size,
 		uint32_t flags);
+
+/**
+ * Unmap a virtual memory region from kernel's virtual address space.
+ *
+ * This function is intended to be used by drivers and early boot routines
+ * where temporary memory mappings need to be made. This allows these
+ * memory mappings to be discarded once they are no longer needed.
+ *
+ * This function alters the active page tables in the area reserved
+ * for the kernel.
+ *
+ * This will align the input parameters to page boundaries so that
+ * this can be used with the virtual address as returned by
+ * z_phys_map().
+ *
+ * This API is only available if CONFIG_MMU is enabled.
+ *
+ * It is highly discouraged to use this function to unmap memory mappings.
+ * It may conflict with anonymous memory mappings and demand paging and
+ * produce undefined behavior. Do not use this unless you know exactly
+ * what you are doing.
+ *
+ * This API is part of infrastructure still under development and may
+ * change.
+ *
+ * @param virt Starting address of the virtual address region to be unmapped.
+ * @param size Size of the virtual address region
+ */
+void z_phys_unmap(uint8_t *virt, size_t size);
 
 /*
  * k_mem_map() control flags

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -339,6 +339,21 @@ size_t k_mem_free_get(void);
 void *k_mem_map(size_t size, uint32_t flags);
 
 /**
+ * Un-map mapped memory
+ *
+ * This removes a memory mapping for the provided page-aligned region.
+ * Associated page frames will be free and the kernel may re-use the associated
+ * virtual address region. Any paged out data pages may be discarded.
+ *
+ * Calling this function on a region which was not mapped to begin with is
+ * undefined behavior.
+ *
+ * @param addr Page-aligned memory region base virtual address
+ * @param size Page-aligned memory region size
+ */
+void k_mem_unmap(void *addr, size_t size);
+
+/**
  * Given an arbitrary region, provide a aligned region that covers it
  *
  * The returned region will have both its base address and size aligned

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -278,8 +278,11 @@ void z_phys_unmap(uint8_t *virt, size_t size);
  * Zephyr treats page faults on this guard page as a fatal K_ERR_STACK_CHK_FAIL
  * if it determines it immediately precedes a stack buffer, this is
  * implemented in the architecture layer.
+ *
+ * DEPRECATED: k_mem_map() will always allocate guard pages, so this bit
+ * no longer has any effect.
  */
-#define K_MEM_MAP_GUARD		BIT(18)
+#define K_MEM_MAP_GUARD		__DEPRECATED_MACRO BIT(18)
 
 /**
  * Return the amount of free memory available
@@ -319,6 +322,10 @@ size_t k_mem_free_get(void);
  * The returned virtual memory pointer will be page-aligned. The size
  * parameter, and any base address for re-mapping purposes must be page-
  * aligned.
+ *
+ * Note that the allocation includes two guard pages immediately before
+ * and after the requested region. The total size of the allocation will be
+ * the requested size plus the size of these two guard pages.
  *
  * Many K_MEM_MAP_* flags have been implemented to alter the behavior of this
  * function, with details in the documentation for these flags.

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -310,6 +310,29 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
  */
 void arch_mem_unmap(void *addr, size_t size);
 
+/**
+ * Get the mapped physical memory address from virtual address.
+ *
+ * The function only needs to query the current set of page tables as
+ * the information it reports must be common to all of them if multiple
+ * page tables are in use. If multiple page tables are active it is unnecessary
+ * to iterate over all of them.
+ *
+ * Unless otherwise specified, virtual pages have the same mappings
+ * across all page tables. Calling this function on data pages that are
+ * exceptions to this rule (such as the scratch page) is undefined behavior.
+ * Just check the currently installed page tables and return the information
+ * in that.
+ *
+ * @param virt Page-aligned virtual address
+ * @param[out] phys Mapped physical address (can be NULL if only checking
+ *                  if virtual address is mapped)
+ *
+ * @retval 0 if mapping is found and valid
+ * @retval -EFAULT if virtual address is not mapped
+ */
+int arch_page_phys_get(void *virt, uintptr_t *phys);
+
 #ifdef CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES
 /**
  * Update page frame database with reserved pages

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -22,6 +22,7 @@ zephyr_sources(
   timeutil.c
   heap.c
   heap-validate.c
+  bitarray.c
   )
 
 zephyr_sources_ifdef(CONFIG_CBPRINTF_COMPLETE cbprintf_complete.c)

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(app PRIVATE
 endif()
 target_sources(app PRIVATE
 	src/atomic.c
+	src/bitarray.c
 	src/byteorder.c
 	src/clock.c
 	src/main.c

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) 2016,2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <arch/cpu.h>
+
+#include <tc_util.h>
+#include <sys/bitarray.h>
+#include <sys/util.h>
+#include <toolchain.h>
+
+#ifdef CONFIG_BIG_ENDIAN
+#define BIT_INDEX(bit)  ((3 - ((bit >> 3) & 0x3)) + 4*(bit >> 5))
+#else
+#define BIT_INDEX(bit)  (bit >> 3)
+#endif
+#define BIT_VAL(bit)    (1 << (bit & 0x7))
+#define BITFIELD_SIZE   512
+
+/**
+ * @addtogroup kernel_common_tests
+ * @{
+ */
+
+/* Helper function to compare two bitarrays */
+static bool cmp_u32_arrays(uint32_t *a1, uint32_t *a2, size_t sz)
+{
+	bool are_equal = true;
+	size_t i;
+
+	for (i = 0; i < sz; i++) {
+		if (a1[i] != a2[i]) {
+			are_equal = false;
+			printk("%s: [%zu] 0x%x != 0x%x", __func__,
+			       i, a1[i], a2[i]);
+			break;
+		}
+	}
+
+	return are_equal;
+}
+
+#define FAIL_ALLOC_MSG_FMT "sys_bitarray_alloc with region size %i allocated incorrectly"
+#define FAIL_ALLOC_RET_MSG_FMT "sys_bitarray_alloc with region size %i returned incorrect result"
+#define FAIL_ALLOC_OFFSET_MSG_FMT "sys_bitarray_alloc with region size %i gave incorrect offset"
+#define FAIL_FREE_MSG_FMT "sys_bitarray_free with region size %i and offset %i failed"
+#define FREE 0U
+
+void validate_bitarray_define(sys_bitarray_t *ba, size_t num_bits)
+{
+	size_t num_bundles;
+	int i;
+
+	num_bundles = ROUND_UP(ROUND_UP(num_bits, 8) / 8, sizeof(uint32_t))
+		      / sizeof(uint32_t);
+
+	zassert_equal(ba->num_bits, num_bits,
+		      "SYS_BITARRAY_DEFINE num_bits expected %u, got %u",
+		      num_bits, ba->num_bits);
+
+	zassert_equal(ba->num_bundles, num_bundles,
+		      "SYS_BITARRAY_DEFINE num_bundles expected %u, got %u",
+		      num_bundles, ba->num_bundles);
+
+	for (i = 0; i < num_bundles; i++) {
+		zassert_equal(ba->bundles[i], FREE,
+			      "SYS_BITARRAY_DEFINE bundles[%u] not free for num_bits %u",
+			      i, num_bits);
+	}
+}
+
+/**
+ * @brief Test defining of bitarrays
+ *
+ * @see SYS_BITARRAY_DEFINE()
+ */
+void test_bitarray_declare(void)
+{
+	SYS_BITARRAY_DEFINE(ba_1_bit, 1);
+	SYS_BITARRAY_DEFINE(ba_32_bit, 32);
+	SYS_BITARRAY_DEFINE(ba_33_bit, 33);
+	SYS_BITARRAY_DEFINE(ba_64_bit, 64);
+	SYS_BITARRAY_DEFINE(ba_65_bit, 65);
+	SYS_BITARRAY_DEFINE(ba_128_bit, 128);
+	SYS_BITARRAY_DEFINE(ba_129_bit, 129);
+
+	/* Test SYS_BITFIELD_DECLARE by asserting that a sufficent number of uint32_t
+	 * in the declared array are set as free to represent the number of bits
+	 */
+
+	validate_bitarray_define(&ba_1_bit, 1);
+	validate_bitarray_define(&ba_32_bit, 32);
+	validate_bitarray_define(&ba_33_bit, 33);
+	validate_bitarray_define(&ba_64_bit, 64);
+	validate_bitarray_define(&ba_65_bit, 65);
+	validate_bitarray_define(&ba_128_bit, 128);
+	validate_bitarray_define(&ba_129_bit, 129);
+}
+
+bool bitarray_bundles_is_zero(sys_bitarray_t *ba)
+{
+	bool ret = true;
+	unsigned int i;
+
+	for (i = 0; i < ba->num_bundles; i++) {
+		if (ba->bundles[i] != 0) {
+			ret = false;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Test bitarrays set and clear
+ *
+ * @see sys_bitarray_set_bit()
+ * @see sys_bitarray_clear_bit()
+ * @see sys_bitarray_test_bit()
+ * @see sys_bitarray_test_and_set_bit()
+ * @see sys_bitarray_test_and_clear_bit()
+ */
+void test_bitarray_set_clear(void)
+{
+	int ret;
+	int bit_val;
+	size_t bit, bundle_idx, bit_idx_in_bundle;
+
+	SYS_BITARRAY_DEFINE(ba, 234);
+
+	for (bit = 0U; bit < ba.num_bits; ++bit) {
+		bundle_idx = bit / (sizeof(ba.bundles[0]) * 8);
+		bit_idx_in_bundle = bit % (sizeof(ba.bundles[0]) * 8);
+
+		ret = sys_bitarray_set_bit(&ba, bit);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_set_bit failed on bit %d", bit);
+		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
+			      "sys_bitarray_set_bit did not set bit %d\n", bit);
+		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+
+		ret = sys_bitarray_test_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 1,
+			      "sys_bitarray_test_bit did not detect bit %d\n", bit);
+
+		ret = sys_bitarray_clear_bit(&ba, bit);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_clear_bit failed at bit %d", bit);
+		zassert_equal(ba.bundles[bundle_idx], 0,
+			      "sys_bitarray_clear_bit did not clear bit %d\n", bit);
+		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+
+		ret = sys_bitarray_test_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 0,
+			      "sys_bitarray_test_bit erroneously detected bit %d\n",
+			      bit);
+
+		ret = sys_bitarray_test_and_set_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_and_set_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 0,
+			      "sys_bitarray_test_and_set_bit erroneously detected bit %d\n",
+			      bit);
+		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
+			      "sys_bitarray_test_and_set_bit did not set bit %d\n", bit);
+		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+
+		ret = sys_bitarray_test_and_set_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_and_set_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 1,
+			      "sys_bitarray_test_and_set_bit did not detect bit %d\n",
+			      bit);
+		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
+			      "sys_bitarray_test_and_set_bit cleared bit %d\n", bit);
+		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+
+		ret = sys_bitarray_test_and_clear_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_and_clear_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 1,
+			      "sys_bitarray_test_and_clear_bit did not detect bit %d\n",
+			      bit);
+		zassert_equal(ba.bundles[bundle_idx], 0,
+			      "sys_bitarray_test_and_clear_bit did not clear bit %d\n",
+			      bit);
+		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+
+		ret = sys_bitarray_test_and_clear_bit(&ba, bit, &bit_val);
+		zassert_equal(ret, 0,
+			      "sys_bitarray_test_and_clear_bit failed at bit %d", bit);
+		zassert_equal(bit_val, 0,
+			      "sys_bitarray_test_and_clear_bit erroneously detected bit %d\n",
+			      bit);
+		zassert_equal(ba.bundles[bundle_idx], 0,
+			      "sys_bitarray_test_and_clear_bit set bit %d\n",
+			      bit);
+		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
+			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+	}
+
+	/* All this should fail because we go outside of
+	 * total bits in bit array. Also needs to make sure bits
+	 * are not changed.
+	 */
+	ret = sys_bitarray_set_bit(&ba, ba.num_bits);
+	zassert_not_equal(ret, 0, "sys_bitarray_set_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_set_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_clear_bit(&ba, ba.num_bits);
+	zassert_not_equal(ret, 0, "sys_bitarray_clear_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_clear_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_bit(&ba, ba.num_bits, &bit_val);
+	zassert_not_equal(ret, 0, "sys_bitarray_test_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_and_set_bit(&ba, ba.num_bits, &bit_val);
+	zassert_not_equal(ret, 0,
+			  "sys_bitarray_test_and_set_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_and_set_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_and_clear_bit(&ba, ba.num_bits, &bit_val);
+	zassert_not_equal(ret, 0,
+			  "sys_bitarray_test_and_clear_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_and_clear_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_set_bit(&ba, -1);
+	zassert_not_equal(ret, 0, "sys_bitarray_set_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_set_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_clear_bit(&ba, -1);
+	zassert_not_equal(ret, 0, "sys_bitarray_clear_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_clear_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_bit(&ba, -1, &bit_val);
+	zassert_not_equal(ret, 0, "sys_bitarray_test_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_and_set_bit(&ba, -1, &bit_val);
+	zassert_not_equal(ret, 0,
+			  "sys_bitarray_test_and_set_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_and_set_bit() erroneously changed bitarray");
+
+	ret = sys_bitarray_test_and_clear_bit(&ba, -1, &bit_val);
+	zassert_not_equal(ret, 0,
+			  "sys_bitarray_test_and_clear_bit() should fail but not");
+	zassert_true(bitarray_bundles_is_zero(&ba),
+		     "sys_bitarray_test_and_clear_bit() erroneously changed bitarray");
+}
+
+void alloc_and_free_predefined(void)
+{
+	int ret;
+	size_t offset;
+
+	uint32_t ba_128_expected[4];
+
+	SYS_BITARRAY_DEFINE(ba_128, 128);
+
+	printk("Testing bit array alloc and free with predefined patterns\n");
+
+	/* Pre-populate the bits */
+	ba_128.bundles[0] = 0x0F0F070F;
+	ba_128.bundles[1] = 0x0F0F0F0F;
+	ba_128.bundles[2] = 0x0F0F0F0F;
+	ba_128.bundles[3] = 0x0F0F0000;
+
+	/* Expected values */
+	ba_128_expected[0] = 0x0F0FFF0F;
+	ba_128_expected[1] = 0x0F0F0F0F;
+	ba_128_expected[2] = 0x0F0F0F0F;
+	ba_128_expected[3] = 0x0F0F0000;
+
+	ret = sys_bitarray_alloc(&ba_128, 5, &offset);
+	zassert_equal(ret, 0, "sys_bitarray_alloc() failed: %d", ret);
+	zassert_equal(offset, 11, "sys_bitarray_alloc() offset expected %d, got %d", 11, offset);
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_alloc() failed bits comparison");
+
+	ret = sys_bitarray_alloc(&ba_128, 16, &offset);
+	ba_128_expected[2] = 0xFF0F0F0F;
+	ba_128_expected[3] = 0x0F0F0FFF;
+	zassert_equal(ret, 0, "sys_bitarray_alloc() failed: %d", ret);
+	zassert_equal(offset, 92, "sys_bitarray_alloc() offset expected %d, got %d", 92, offset);
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_alloc() failed bits comparison");
+
+	ret = sys_bitarray_free(&ba_128, 5, 11);
+	ba_128_expected[0] = 0x0F0F070F;
+	zassert_equal(ret, 0, "sys_bitarray_free() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_free() failed bits comparison");
+
+	ret = sys_bitarray_free(&ba_128, 5, 0);
+	zassert_not_equal(ret, 0, "sys_bitarray_free() should fail but not");
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_free() failed bits comparison");
+
+	ret = sys_bitarray_free(&ba_128, 24, 92);
+	zassert_not_equal(ret, 0, "sys_bitarray_free() should fail but not");
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_free() failed bits comparison");
+
+	ret = sys_bitarray_free(&ba_128, 16, 92);
+	ba_128_expected[2] = 0x0F0F0F0F;
+	ba_128_expected[3] = 0x0F0F0000;
+	zassert_equal(ret, 0, "sys_bitarray_free() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
+		     "sys_bitarray_free() failed bits comparison");
+}
+
+size_t get_bitarray_popcnt(sys_bitarray_t *ba)
+{
+	size_t popcnt = 0;
+	unsigned int idx;
+
+	for (idx = 0; idx < ba->num_bundles; idx++) {
+		popcnt += popcount(ba->bundles[idx]);
+	}
+
+	return popcnt;
+}
+
+void alloc_and_free_loop(int divisor)
+{
+	int ret;
+	size_t offset;
+	size_t bit;
+	size_t num_bits;
+	size_t cur_popcnt;
+	size_t expected_popcnt = 0;
+
+	SYS_BITARRAY_DEFINE(ba, 234);
+
+	printk("Testing bit array alloc and free with divisor %d\n", divisor);
+
+	for (bit = 0U; bit < ba.num_bits; ++bit) {
+		cur_popcnt = get_bitarray_popcnt(&ba);
+		zassert_equal(cur_popcnt, expected_popcnt,
+			      "bit count expeceted %u, got %u (at bit %u)",
+			      expected_popcnt, cur_popcnt, bit);
+
+		/* Allocate half of remaining bits */
+		num_bits = (ba.num_bits - bit) / divisor;
+
+		ret = sys_bitarray_alloc(&ba, num_bits, &offset);
+		if (num_bits == 0) {
+			zassert_not_equal(ret, 0,
+					  "sys_bitarray_free() should fail but not (bit %u)",
+					  bit);
+		} else {
+			zassert_equal(ret, 0,
+				      "sys_bitarray_alloc() failed (%d) at bit %u",
+				      ret, bit);
+			zassert_equal(offset, bit,
+				      "sys_bitarray_alloc() offset expected %d, got %d",
+				      bit, offset);
+
+			expected_popcnt += num_bits;
+		}
+
+		cur_popcnt = get_bitarray_popcnt(&ba);
+		zassert_equal(cur_popcnt, expected_popcnt,
+			      "bit count expeceted %u, got %u (at bit %u)",
+			      expected_popcnt, cur_popcnt, bit);
+
+		/* Free all but the first bit of allocated region */
+		ret = sys_bitarray_free(&ba, (num_bits - 1), (bit + 1));
+		if ((num_bits == 0) || ((num_bits - 1) == 0)) {
+			zassert_not_equal(ret, 0,
+					  "sys_bitarray_free() should fail but not (bit %u)",
+					  bit);
+		} else {
+			zassert_equal(ret, 0,
+				      "sys_bitarray_free() failed (%d) at bit %u",
+				      ret, (bit + 1));
+
+			expected_popcnt -= num_bits - 1;
+		}
+	}
+}
+
+void alloc_and_free_interval(void)
+{
+	int ret;
+	size_t cnt;
+	size_t offset;
+	size_t expected_offset;
+	size_t expected_popcnt, cur_popcnt;
+
+	/* Make sure number of bits is multiple of 8 */
+	SYS_BITARRAY_DEFINE(ba, 152);
+
+	printk("Testing bit array interval alloc and free\n");
+
+	/* Pre-populate the bits so that 4-bit already allocated,
+	 * then 4 free bits, and repeat.
+	 */
+	for (cnt = 0; cnt < ba.num_bundles; cnt++) {
+		ba.bundles[cnt] = 0x0F0F0F0F;
+	}
+
+	expected_offset = 4;
+	expected_popcnt = get_bitarray_popcnt(&ba);
+	for (cnt = 0; cnt <= (ba.num_bits / 8); cnt++) {
+
+		ret = sys_bitarray_alloc(&ba, 4, &offset);
+		if (cnt == (ba.num_bits / 8)) {
+			zassert_not_equal(ret, 0,
+					  "sys_bitarray_free() should fail but not (cnt %u)",
+					  cnt);
+		} else {
+			zassert_equal(ret, 0,
+				      "sys_bitarray_alloc() failed (%d) (cnt %u)",
+				      ret, cnt);
+
+			zassert_equal(offset, expected_offset,
+				      "offset expeceted %u, got %u (cnt %u)",
+				      expected_offset, offset, cnt);
+
+			expected_popcnt += 4;
+
+			cur_popcnt = get_bitarray_popcnt(&ba);
+			zassert_equal(cur_popcnt, expected_popcnt,
+				      "bit count expeceted %u, got %u (cnt %u)",
+				      expected_popcnt, cur_popcnt, cnt);
+
+
+			expected_offset += 8;
+		}
+	}
+}
+
+/**
+ * @brief Test bitarrays allocation and free
+ *
+ * @see sys_bitarray_alloc()
+ * @see sys_bitarray_free()
+ */
+void test_bitarray_alloc_free(void)
+{
+	int i;
+
+	alloc_and_free_predefined();
+
+	i = 1;
+	while (i < 65) {
+		alloc_and_free_loop(i);
+
+		i *= 2;
+	}
+
+	alloc_and_free_interval();
+}
+
+void test_bitarray_region_set_clear(void)
+{
+	int ret;
+
+	uint32_t ba_expected[4];
+
+	SYS_BITARRAY_DEFINE(ba, 64);
+
+	printk("Testing bit array region bit tests\n");
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0xFF0F0F0F;
+	ba.bundles[1] = 0x0F0F0FFF;
+
+	zassert_true(sys_bitarray_is_region_set(&ba,  4,  0), NULL);
+	zassert_true(sys_bitarray_is_region_set(&ba, 12, 32), NULL);
+	zassert_true(sys_bitarray_is_region_set(&ba,  8, 32), NULL);
+	zassert_true(sys_bitarray_is_region_set(&ba, 14, 30), NULL);
+	zassert_true(sys_bitarray_is_region_set(&ba, 20, 24), NULL);
+
+	zassert_false(sys_bitarray_is_region_cleared(&ba,  4,  0), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 12, 32), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba,  8, 32), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 14, 30), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 20, 24), NULL);
+
+	ba.bundles[0] = ~ba.bundles[0];
+	ba.bundles[1] = ~ba.bundles[1];
+
+	zassert_true(sys_bitarray_is_region_cleared(&ba,  4,  0), NULL);
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 12, 32), NULL);
+	zassert_true(sys_bitarray_is_region_cleared(&ba,  8, 32), NULL);
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 14, 30), NULL);
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 20, 24), NULL);
+
+	zassert_false(sys_bitarray_is_region_set(&ba,  4,  0), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba, 12, 32), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba,  8, 32), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba, 14, 30), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba, 20, 24), NULL);
+
+	zassert_false(sys_bitarray_is_region_set(&ba, 10, 60), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 10, 60), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba, 8, 120), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 8, 120), NULL);
+
+	printk("Testing bit array region bit manipulations\n");
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0xFF0F0F0F;
+	ba.bundles[1] = 0x0F0F0FFF;
+
+	/* Expected values */
+	ba_expected[0] = 0xFF0F0F0F;
+	ba_expected[1] = 0x0F0F0FFF;
+
+	ret = sys_bitarray_set_region(&ba, 4, 0);
+	zassert_equal(ret, 0, "sys_bitarray_set_region() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_set_region() failed bits comparison");
+
+	ret = sys_bitarray_set_region(&ba, 4, 4);
+	ba_expected[0] = 0xFF0F0FFF;
+	zassert_equal(ret, 0, "sys_bitarray_set_region() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_set_region() failed bits comparison");
+
+	ret = sys_bitarray_clear_region(&ba, 4, 4);
+	ba_expected[0] = 0xFF0F0F0F;
+	zassert_equal(ret, 0, "sys_bitarray_clear_region() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_clear_region() failed bits comparison");
+
+	ret = sys_bitarray_clear_region(&ba, 14, 30);
+	ba_expected[0] = 0x3F0F0F0F;
+	ba_expected[1] = 0x0F0F0000;
+	zassert_equal(ret, 0, "sys_bitarray_clear_region() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_clear_region() failed bits comparison");
+
+	ret = sys_bitarray_set_region(&ba, 14, 30);
+	ba_expected[0] = 0xFF0F0F0F;
+	ba_expected[1] = 0x0F0F0FFF;
+	zassert_equal(ret, 0, "sys_bitarray_set_region() failed: %d", ret);
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_set_region() failed bits comparison");
+
+	ret = sys_bitarray_set_region(&ba, 10, 60);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_set_region() should fail but not");
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_set_region() failed bits comparison");
+
+	ret = sys_bitarray_set_region(&ba, 8, 120);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_set_region() should fail but not");
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_set_region() failed bits comparison");
+
+	ret = sys_bitarray_clear_region(&ba, 10, 60);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_clear_region() should fail but not");
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_clear_region() failed bits comparison");
+
+	ret = sys_bitarray_clear_region(&ba, 8, 120);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_clear_region() should fail but not");
+	zassert_true(cmp_u32_arrays(ba.bundles, ba_expected, ba.num_bundles),
+		     "sys_bitarray_clear_region() failed bits comparison");
+}
+
+/**
+ * @}
+ */

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -43,6 +43,10 @@ extern void test_multilib(void);
 extern void test_thread_context(void);
 extern void test_bootdelay(void);
 extern void test_irq_offload(void);
+extern void test_bitarray_declare(void);
+extern void test_bitarray_set_clear(void);
+extern void test_bitarray_alloc_free(void);
+extern void test_bitarray_region_set_clear(void);
 
 /**
  * @defgroup kernel_common_tests Common Tests
@@ -141,6 +145,10 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_le64),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
+			 ztest_unit_test(test_bitarray_declare),
+			 ztest_unit_test(test_bitarray_set_clear),
+			 ztest_unit_test(test_bitarray_alloc_free),
+			 ztest_unit_test(test_bitarray_region_set_clear),
 			 ztest_unit_test(test_printk),
 			 ztest_1cpu_unit_test(test_timeout_order),
 			 ztest_1cpu_user_unit_test(test_clock_uptime),

--- a/tests/kernel/mem_protect/demand_paging/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/demand_paging/boards/qemu_x86_tiny.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# The test is highly sensitive to size of kernel image.
+# However, specifying how many pages used by
+# the backing store must be done in build time.
+# So here we are, tuning this manually.
+CONFIG_BACKING_STORE_RAM_PAGES=14

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -149,6 +149,10 @@ void test_touch_anon_pages(void)
 	zassert_not_equal(stats.eviction.dirty, 0UL,
 			  "there should be dirty pages being evicted.");
 
+#ifdef CONFIG_EVICTION_NRU
+	k_msleep(CONFIG_EVICTION_NRU_PERIOD * 2);
+#endif /* CONFIG_EVICTION_NRU */
+
 	/* There should be some clean pages to be evicted now,
 	 * since the arena is not modified.
 	 */

--- a/tests/kernel/mem_protect/demand_paging/testcase.yaml
+++ b/tests/kernel/mem_protect/demand_paging/testcase.yaml
@@ -7,8 +7,4 @@ tests:
     platform_allow: qemu_x86_tiny
     filter: CONFIG_DEMAND_PAGING
     extra_configs:
-      # The timing functions take up some more memory.
-      # So need to shrink an even number of page to
-      # compensate for that (default is 16).
-      - CONFIG_BACKING_STORE_RAM_PAGES=14
       - CONFIG_DEMAND_PAGING_STATS_USING_TIMING_FUNCTIONS=y

--- a/tests/kernel/mem_protect/mem_map/boards/qemu_cortex_a53.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_cortex_a53.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Simply needs more space for the translation table
+# for the mapping exhaustion test.
+CONFIG_MAX_XLAT_TABLES=16

--- a/tests/kernel/mem_protect/mem_map/boards/qemu_cortex_a53_smp.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_cortex_a53_smp.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Simply needs more space for the translation table
+# for the mapping exhaustion test.
+CONFIG_MAX_XLAT_TABLES=32

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -233,6 +233,62 @@ void test_k_mem_map(void)
 	 */
 }
 
+/**
+ * Test that the "before" guard page is in place for k_mem_map().
+ */
+void test_k_mem_map_guard_before(void)
+{
+	uint8_t *mapped;
+
+	expect_fault = false;
+
+	mapped = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
+	zassert_not_null(mapped, "failed to map memory");
+	printk("mapped a page: %p - %p\n", mapped,
+		mapped + CONFIG_MMU_PAGE_SIZE);
+
+	/* Should NOT fault */
+	mapped[0] = 42;
+
+	/* Should fault here in the guard page location */
+	expect_fault = true;
+	mapped -= sizeof(void *);
+
+	printk("trying to access %p\n", mapped);
+
+	mapped[0] = 42;
+	printk("shouldn't get here\n");
+	ztest_test_fail();
+}
+
+/**
+ * Test that the "after" guard page is in place for k_mem_map().
+ */
+void test_k_mem_map_guard_after(void)
+{
+	uint8_t *mapped;
+
+	expect_fault = false;
+
+	mapped = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
+	zassert_not_null(mapped, "failed to map memory");
+	printk("mapped a page: %p - %p\n", mapped,
+		mapped + CONFIG_MMU_PAGE_SIZE);
+
+	/* Should NOT fault */
+	mapped[0] = 42;
+
+	/* Should fault here in the guard page location */
+	expect_fault = true;
+	mapped += CONFIG_MMU_PAGE_SIZE + sizeof(void *);
+
+	printk("trying to access %p\n", mapped);
+
+	mapped[0] = 42;
+	printk("shouldn't get here\n");
+	ztest_test_fail();
+}
+
 /* ztest main entry*/
 void test_main(void)
 {
@@ -247,7 +303,9 @@ void test_main(void)
 			ztest_unit_test(test_z_phys_map_exec),
 			ztest_unit_test(test_z_phys_map_side_effect),
 			ztest_unit_test(test_z_phys_unmap),
-			ztest_unit_test(test_k_mem_map)
+			ztest_unit_test(test_k_mem_map),
+			ztest_unit_test(test_k_mem_map_guard_before),
+			ztest_unit_test(test_k_mem_map_guard_after)
 			);
 	ztest_run_test_suite(test_mem_map);
 }

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -163,6 +163,35 @@ void test_z_phys_map_side_effect(void)
 }
 
 /**
+ * Test that z_phys_unmap() unmaps the memory and it is no longer
+ * accessible afterwards.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+void test_z_phys_unmap(void)
+{
+	uint8_t *mapped;
+
+	expect_fault = false;
+
+	/* Map in a page that allows writes */
+	z_phys_map(&mapped, z_mem_phys_addr(test_page),
+		   sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
+
+	/* Should NOT fault */
+	mapped[0] = 42;
+
+	/* Unmap the memory */
+	z_phys_unmap(mapped, sizeof(test_page));
+
+	/* Should fault since test_page is no longer accessible */
+	expect_fault = true;
+	mapped[0] = 42;
+	printk("shouldn't get here\n");
+	ztest_test_fail();
+}
+
+/**
  * Basic k_mem_map() functionality
  *
  * Does not exercise K_MEM_MAP_* control flags, just default behavior
@@ -217,6 +246,7 @@ void test_main(void)
 			ztest_unit_test(test_z_phys_map_rw),
 			ztest_unit_test(test_z_phys_map_exec),
 			ztest_unit_test(test_z_phys_map_side_effect),
+			ztest_unit_test(test_z_phys_unmap),
 			ztest_unit_test(test_k_mem_map)
 			);
 	ztest_run_test_suite(test_mem_map);

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -7,6 +7,7 @@
 #include <ztest.h>
 #include <sys/mem_manage.h>
 #include <toolchain.h>
+#include <mmu.h>
 
 /* 32-bit IA32 page tables have no mechanism to restrict execution */
 #if defined(CONFIG_X86) && !defined(CONFIG_X86_64) && !defined(CONFIG_X86_PAE)
@@ -192,45 +193,68 @@ void test_z_phys_unmap(void)
 }
 
 /**
- * Basic k_mem_map() functionality
+ * Basic k_mem_map() and k_mem_unmap() functionality
  *
  * Does not exercise K_MEM_MAP_* control flags, just default behavior
  */
-void test_k_mem_map(void)
+void test_k_mem_map_unmap(void)
 {
-	size_t free_mem, free_mem_after_map;
-	char *mapped;
-	int i;
+	size_t free_mem, free_mem_after_map, free_mem_after_unmap;
+	char *mapped, *last_mapped;
+	int i, repeat;
+
+	expect_fault = false;
+	last_mapped = NULL;
 
 	free_mem = k_mem_free_get();
 	zassert_not_equal(free_mem, 0, "no free memory");
 	printk("Free memory: %zu\n", free_mem);
 
-	mapped = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
-	zassert_not_null(mapped, "failed to map memory");
-	printk("mapped a page to %p\n", mapped);
+	/* Repeat a couple times to make sure everything still works */
+	for (repeat = 1; repeat <= 10; repeat++) {
+		mapped = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
+		zassert_not_null(mapped, "failed to map memory");
+		printk("mapped a page to %p\n", mapped);
 
-	/* Page should be zeroed */
-	for (i = 0; i < CONFIG_MMU_PAGE_SIZE; i++) {
-		zassert_equal(mapped[i], '\x00', "page not zeroed");
+		if (last_mapped != NULL) {
+			zassert_equal(mapped, last_mapped,
+				      "should have mapped at same address");
+		}
+		last_mapped = mapped;
+
+		/* Page should be zeroed */
+		for (i = 0; i < CONFIG_MMU_PAGE_SIZE; i++) {
+			zassert_equal(mapped[i], '\x00', "page not zeroed");
+		}
+
+		free_mem_after_map = k_mem_free_get();
+		printk("Free memory after mapping: %zu\n", free_mem_after_map);
+		zassert_equal(free_mem, free_mem_after_map + CONFIG_MMU_PAGE_SIZE,
+			"incorrect free memory accounting");
+
+		/* Show we can write to page without exploding */
+		(void)memset(mapped, '\xFF', CONFIG_MMU_PAGE_SIZE);
+		for (i = 0; i < CONFIG_MMU_PAGE_SIZE; i++) {
+			zassert_true(mapped[i] == '\xFF',
+				"incorrect value 0x%hhx read at index %d",
+				mapped[i], i);
+		}
+
+		k_mem_unmap(mapped, CONFIG_MMU_PAGE_SIZE);
+
+		free_mem_after_unmap = k_mem_free_get();
+		printk("Free memory after unmapping: %zu\n", free_mem_after_unmap);
+		zassert_equal(free_mem, free_mem_after_unmap,
+			"k_mem_unmap has not freed physical memory");
+
+		if (repeat == 10) {
+			/* Should fault since mapped is no longer accessible */
+			expect_fault = true;
+			mapped[0] = 42;
+			printk("shouldn't get here\n");
+			ztest_test_fail();
+		}
 	}
-
-	free_mem_after_map = k_mem_free_get();
-	printk("Free memory now: %zu\n", free_mem_after_map);
-	zassert_equal(free_mem, free_mem_after_map + CONFIG_MMU_PAGE_SIZE,
-		      "incorrect free memory accounting");
-
-	/* Show we can write to page without exploding */
-	(void)memset(mapped, '\xFF', CONFIG_MMU_PAGE_SIZE);
-	for (i = 0; i < CONFIG_MMU_PAGE_SIZE; i++) {
-		zassert_true(mapped[i] == '\xFF',
-			     "incorrect value 0x%hhx read at index %d",
-			     mapped[i], i);
-	}
-
-	/* TODO: Un-map the mapped page to clean up, once we have that
-	 * capability
-	 */
 }
 
 /**
@@ -289,6 +313,100 @@ void test_k_mem_map_guard_after(void)
 	ztest_test_fail();
 }
 
+void test_k_mem_map_exhaustion(void)
+{
+	/* With demand paging enabled, there is backing store
+	 * which extends available memory. However, we don't
+	 * have a way to figure out how much extra memory
+	 * is available. So skip for now.
+	 */
+#if !defined(CONFIG_DEMAND_PAGING)
+	uint8_t *addr;
+	size_t free_mem, free_mem_now, free_mem_expected;
+	size_t cnt, expected_cnt;
+	uint8_t *last_mapped = NULL;
+
+	free_mem = k_mem_free_get();
+	printk("Free memory: %zu\n", free_mem);
+	zassert_not_equal(free_mem, 0, "no free memory");
+
+	/* Determine how many times we can map */
+	expected_cnt = free_mem / CONFIG_MMU_PAGE_SIZE;
+
+	/* Figure out how many pages we can map within
+	 * the remaining virtual address space by:
+	 *
+	 * 1. Find out the top of available space. This can be
+	 *    done by mapping one page, and use the returned
+	 *    virtual address (plus itself and guard page)
+	 *    to obtain the end address.
+	 * 2. Calculate how big this region is from
+	 *    Z_FREE_VM_START to end address.
+	 * 3. Calculate how many times we can call k_mem_map().
+	 *    Remember there are two guard pages for every
+	 *    mapping call (hence 1 + 2 == 3).
+	 */
+	addr = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
+	zassert_not_null(addr, "fail to map memory");
+	k_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
+
+	cnt = POINTER_TO_UINT(addr) + CONFIG_MMU_PAGE_SIZE * 2;
+	cnt -= POINTER_TO_UINT(Z_FREE_VM_START);
+	cnt /= CONFIG_MMU_PAGE_SIZE * 3;
+
+	/* If we are limited by virtual address space... */
+	if (cnt < expected_cnt) {
+		expected_cnt = cnt;
+	}
+
+	/* Now k_mem_map() until it fails */
+	free_mem_expected = free_mem - (expected_cnt * CONFIG_MMU_PAGE_SIZE);
+	cnt = 0;
+	do {
+		addr = k_mem_map(CONFIG_MMU_PAGE_SIZE, K_MEM_PERM_RW);
+
+		if (addr != NULL) {
+			*((uintptr_t *)addr) = POINTER_TO_UINT(last_mapped);
+			last_mapped = addr;
+			cnt++;
+		}
+	} while (addr != NULL);
+
+	printk("Mapped %zu pages\n", cnt);
+	zassert_equal(cnt, expected_cnt,
+		      "number of pages mapped: expected %u, got %u",
+		      expected_cnt, cnt);
+
+	free_mem_now = k_mem_free_get();
+	printk("Free memory now: %zu\n", free_mem_now);
+	zassert_equal(free_mem_now, free_mem_expected,
+		      "free memory should be %zu", free_mem_expected);
+
+	/* Now free all of them */
+	cnt = expected_cnt;
+	cnt = 0;
+	while (last_mapped != NULL) {
+		addr = last_mapped;
+		last_mapped = UINT_TO_POINTER(*((uintptr_t *)addr));
+		k_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
+
+		cnt++;
+	}
+
+	printk("Unmapped %zu pages\n", cnt);
+	zassert_equal(cnt, expected_cnt,
+		      "number of pages unmapped: expected %u, got %u",
+		      expected_cnt, cnt);
+
+	free_mem_now = k_mem_free_get();
+	printk("Free memory now: %zu\n", free_mem_now);
+	zassert_equal(free_mem_now, free_mem,
+		      "free memory should be %zu", free_mem);
+#else
+	ztest_test_skip();
+#endif /* !CONFIG_DEMAND_PAGING */
+}
+
 /* ztest main entry*/
 void test_main(void)
 {
@@ -303,9 +421,10 @@ void test_main(void)
 			ztest_unit_test(test_z_phys_map_exec),
 			ztest_unit_test(test_z_phys_map_side_effect),
 			ztest_unit_test(test_z_phys_unmap),
-			ztest_unit_test(test_k_mem_map),
+			ztest_unit_test(test_k_mem_map_unmap),
 			ztest_unit_test(test_k_mem_map_guard_before),
-			ztest_unit_test(test_k_mem_map_guard_after)
+			ztest_unit_test(test_k_mem_map_guard_after),
+			ztest_unit_test(test_k_mem_map_exhaustion)
 			);
 	ztest_run_test_suite(test_mem_map);
 }


### PR DESCRIPTION
This implements the counterpart of `k_mem_map()` which allows developers to anonymously map and unmap memory.