### PR TITLE
drivers/flash: stm32h7: Fixed range validation

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -100,7 +100,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 #endif
 
 	if (write) {
-		if ((offset % FLASH_NB_32BITWORD_IN_FLASHWORD * 4) != 0) {
+		if ((offset % (FLASH_NB_32BITWORD_IN_FLASHWORD * 4)) != 0) {
 			LOG_ERR("Write offset not aligned on flashword length. "
 				"Offset: 0x%lx, flashword length: %d",
 				(unsigned long) offset, FLASH_NB_32BITWORD_IN_FLASHWORD * 4);


### PR DESCRIPTION
drivers/flash: stm32h7: Fixed range validation

The range validation routine is not able to detect unaligned memory blocks as it should.  

Signed-off-by: Raphael Löffel <loeffel@rte-ag.ch>