### PR TITLE
some fixes for mwdt toolchain

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -18,10 +18,7 @@ config CPU_ARCEM
 
 config CPU_ARCHS
 	bool
-	# FIXME: ATOMIC_OPERATIONS_BUILTIN still has some problem in arcmwdt
-	# toolchain, so choosing ATOMIC_OPERATIONS_C instead.
-	select ATOMIC_OPERATIONS_C if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
-	select ATOMIC_OPERATIONS_BUILTIN if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
+	select ATOMIC_OPERATIONS_BUILTIN
 	help
 	  This option signifies the use of an ARC HS CPU
 

--- a/boards/arc/hsdk/hsdk.yaml
+++ b/boards/arc/hsdk/hsdk.yaml
@@ -5,6 +5,7 @@ arch: arc
 toolchain:
   - zephyr
   - xtools
+  - arcmwdt
 testing:
   ignore_tags:
     - net

--- a/lib/libc/minimal/include/stdint.h
+++ b/lib/libc/minimal/include/stdint.h
@@ -92,6 +92,88 @@ typedef __UINTPTR_TYPE__	uintptr_t;
 #define UINTMAX_C(_v) __UINTMAX_C(_v)
 #endif /* __GNUC__ */
 
+#ifdef __CCAC__
+#ifndef __INT8_C
+#define __INT8_C(x)	x
+#endif
+
+#ifndef INT8_C
+#define INT8_C(x)	__INT8_C(x)
+#endif
+
+#ifndef __UINT8_C
+#define __UINT8_C(x)	x ## U
+#endif
+
+#ifndef UINT8_C
+#define UINT8_C(x)	__UINT8_C(x)
+#endif
+
+#ifndef __INT16_C
+#define __INT16_C(x)	x
+#endif
+
+#ifndef INT16_C
+#define INT16_C(x)	__INT16_C(x)
+#endif
+
+#ifndef __UINT16_C
+#define __UINT16_C(x)	x ## U
+#endif
+
+#ifndef UINT16_C
+#define UINT16_C(x)	__UINT16_C(x)
+#endif
+
+#ifndef __INT32_C
+#define __INT32_C(x)	x
+#endif
+
+#ifndef INT32_C
+#define INT32_C(x)	__INT32_C(x)
+#endif
+
+#ifndef __UINT32_C
+#define __UINT32_C(x)	x ## U
+#endif
+
+#ifndef UINT32_C
+#define UINT32_C(x)	__UINT32_C(x)
+#endif
+
+#ifndef __INT64_C
+#define __INT64_C(x)	x
+#endif
+
+#ifndef INT64_C
+#define INT64_C(x)	__INT64_C(x)
+#endif
+
+#ifndef __UINT64_C
+#define __UINT64_C(x)	x ## ULL
+#endif
+
+#ifndef UINT64_C
+#define UINT64_C(x)	__UINT64_C(x)
+#endif
+
+#ifndef __INTMAX_C
+#define __INTMAX_C(x)	x
+#endif
+
+#ifndef INTMAX_C
+#define INTMAX_C(x)	__INTMAX_C(x)
+#endif
+
+#ifndef __UINTMAX_C
+#define __UINTMAX_C(x)	x ## ULL
+#endif
+
+#ifndef UINTMAX_C
+#define UINTMAX_C(x)	__UINTMAX_C(x)
+#endif
+#endif /* __CCAC__ */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- define __INT*_C() and __UINT*_C() for mwdt toolchain

    our minimal C library makes an alias of UINT*_C() to be __UINT*_C() and INT*_C() to __INT*_C().
    However, in mwdt, these are not defined by default, so define them ourselves.
    this commit reverts: https://github.com/zephyrproject-rtos/zephyr/commit/b1adc462be6258329ea94bced96e4457a0c4b5cb

- use ATOMIC_OPERATIONS_BUILTIN for mwdt toolchain

    ATOMIC_OPERATIONS_BUILTIN issue (internal jira number: P10019563-43273) has been fixed in 
    new relasese MWDT 2021.03. We can use builtin atomic.
    we have similar fix for xcc: https://github.com/zephyrproject-rtos/zephyr/commit/5ef8db8ac989e683fb1b51572b00074780f82f0a

- add arcmwdt toolchain support in hsdk.yaml, then we can
use arcmwdt for hsdk board with twister tool.