### PR TITLE
dts/arm: stm32h7: quadspi added

### DIFF
--- a/drivers/flash/Kconfig.stm32_qspi
+++ b/drivers/flash/Kconfig.stm32_qspi
@@ -18,5 +18,7 @@ config FLASH_STM32_QSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select DMA if $(DT_STM32_QUADSPI_HAS_DMA)
 	select USE_STM32_HAL_DMA if $(DT_STM32_QUADSPI_HAS_DMA)
+	select USE_STM32_HAL_MDMA if !$(DT_STM32_QUADSPI_HAS_DMA)
 	help
 	  Enable QSPI-NOR support on the STM32 family of processors.
+	  For STM32H7 devices DMA is not yet supported.

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -30,7 +30,7 @@
 LOG_MODULE_REGISTER(flash_stm32_qspi, CONFIG_FLASH_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_SERIES_STM32H7X
-#if DT_NODE_HAS_PROP(DT_NODELABEL(quadspi),dmas)
+#if DT_NODE_HAS_PROP(DT_NODELABEL(quadspi), dmas)
 #error "STM32H7 QSPI flash driver do not support DMA"
 #endif
 #endif

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -29,6 +29,12 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(flash_stm32_qspi, CONFIG_FLASH_LOG_LEVEL);
 
+#ifdef CONFIG_SOC_SERIES_STM32H7X
+#if DT_NODE_HAS_PROP(DT_NODELABEL(quadspi),dmas)
+#error "STM32H7 QSPI flash driver do not support DMA"
+#endif
+#endif
+
 #define STM32_QSPI_FIFO_THRESHOLD         8
 #define STM32_QSPI_CLOCK_PRESCALER_MAX  255
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -388,7 +388,7 @@
 			status = "disabled";
 			label = "QUADSPI";
 		};
-        
+
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -378,6 +378,17 @@
 			label = "I2C_4";
 		};
 
+		quadspi: quadspi@52005000 {
+			compatible = "st,stm32-qspi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x52005000 0x400>;
+			interrupts = <92 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>;
+			status = "disabled";
+			label = "QUADSPI";
+		};
+        
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -33,7 +33,8 @@ properties:
       description: |
         Optional DMA channel specifier. If DMA should be used, specifier should
         hold a phandle reference to the dma controller, the channel number,
-        the slot number, channel configuration and finally features.
+        the slot number, channel configuration and finally features. For STM32H7
+        devices DMA is not yet supported.
 
         For example dmas for TX/RX on QSPI
            dmas = <&dma1 5 5 0x0000 0x03>;


### PR DESCRIPTION
dts/arm: stm32h7: quadspi added

quadspi added to device tree of stm32h7 family.

validated with samples/subsys/fs/littlefs

Signed-off-by: Raphael Löffel <loeffel@rte-ag.ch>