### PR TITLE
lib: os: cbprintf: Add C++ support for static packaging

### DIFF
--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -16,17 +16,16 @@
 #include <stdio.h>
 #endif /* CONFIG_CBPRINTF_LIBC_SUBSTS */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Determine if _Generic is supported.
  * In general it's a C11 feature but it was added also in:
  * - GCC 4.9.0 https://gcc.gnu.org/gcc-4.9/changes.html
  * - Clang 3.0 https://releases.llvm.org/3.0/docs/ClangReleaseNotes.html
+ *
+ * @note Z_C_GENERIC is also set for C++ where functionality is implemented
+ * using overloading and templates.
  */
 #ifndef Z_C_GENERIC
-#if !defined(__cplusplus) && (((__STDC_VERSION__ >= 201112L) || \
+#if defined(__cplusplus) || (((__STDC_VERSION__ >= 201112L) || \
 	((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40900) || \
 	((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) >= 30000)))
 #define Z_C_GENERIC 1
@@ -37,6 +36,10 @@ extern "C" {
 
 /* Z_C_GENERIC is used there */
 #include <sys/cbprintf_internal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup cbprintf_apis Formatted Output APIs

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_CBPRINTF_CXX_H_
+#define ZEPHYR_INCLUDE_SYS_CBPRINTF_CXX_H_
+#ifdef __cplusplus
+
+/* C++ version for detecting a pointer to a string. */
+static inline int z_cbprintf_cxx_is_pchar(char *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(const char *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(volatile char *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(const volatile char *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(wchar_t *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(const wchar_t *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(volatile wchar_t *)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_pchar(const volatile wchar_t *)
+{
+	return 1;
+}
+
+template < typename T >
+static inline int z_cbprintf_cxx_is_pchar(T arg)
+{
+	return 0;
+}
+
+/* C++ version for calculating argument size. */
+static inline size_t z_cbprintf_cxx_arg_size(float f)
+{
+	return sizeof(double);
+}
+
+template < typename T >
+static inline size_t z_cbprintf_cxx_arg_size(T arg)
+{
+	return sizeof(arg + 0);
+}
+
+/* C++ version for storing arguments. */
+static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, float arg)
+{
+	double d = (double)arg;
+
+	z_cbprintf_wcpy((int *)dst, (int *)&d, sizeof(d) / sizeof(int));
+}
+
+template < typename T >
+static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, T arg)
+{
+	size_t wlen = z_cbprintf_cxx_arg_size(arg) / sizeof(int);
+
+	z_cbprintf_wcpy((int *)dst, (int *)&arg, wlen);
+}
+
+/* C++ version for long double detection. */
+static inline int z_cbprintf_cxx_is_longdouble(long double arg)
+{
+	return 1;
+}
+
+template < typename T >
+static inline int z_cbprintf_cxx_is_longdouble(T arg)
+{
+	return 0;
+}
+
+/* C++ version for caluculating argument alignment. */
+static inline size_t z_cbprintf_cxx_alignment(float arg)
+{
+	return VA_STACK_ALIGN(double);
+}
+
+static inline size_t z_cbprintf_cxx_alignment(double arg)
+{
+	return VA_STACK_ALIGN(double);
+}
+
+static inline size_t z_cbprintf_cxx_alignment(long double arg)
+{
+	return VA_STACK_ALIGN(long double);
+}
+
+static inline size_t z_cbprintf_cxx_alignment(long long arg)
+{
+	return VA_STACK_ALIGN(long long);
+}
+
+static inline size_t z_cbprintf_cxx_alignment(unsigned long long arg)
+{
+	return VA_STACK_ALIGN(long long);
+}
+
+template < typename T >
+static inline size_t z_cbprintf_cxx_alignment(T arg)
+{
+	return MAX(__alignof__(arg), VA_STACK_MIN_ALIGN);
+}
+
+#endif /* __cplusplus */
+#endif /* ZEPHYR_INCLUDE_SYS_CBPRINTF_CXX_H_ */

--- a/tests/lib/cbprintf_package/CMakeLists.txt
+++ b/tests/lib/cbprintf_package/CMakeLists.txt
@@ -4,5 +4,4 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cbprintf_package)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/main.c src/maincxx.cxx)

--- a/tests/lib/cbprintf_package/src/maincxx.cxx
+++ b/tests/lib/cbprintf_package/src/maincxx.cxx
@@ -7,12 +7,3 @@
 #include <string.h>
 
 #include "test.inc"
-
-void test_cxx(void);
-void test_cc(void);
-
-void test_main(void)
-{
-	test_cc();
-	test_cxx();
-}

--- a/tests/lib/cbprintf_package/src/test.inc
+++ b/tests/lib/cbprintf_package/src/test.inc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <sys/cbprintf.h>
+
+#define CBPRINTF_DEBUG 1
+
+#ifndef CBPRINTF_PACKAGE_ALIGN_OFFSET
+#define CBPRINTF_PACKAGE_ALIGN_OFFSET 0
+#endif
+
+#define ALIGN_OFFSET (sizeof(void *) * CBPRINTF_PACKAGE_ALIGN_OFFSET)
+
+struct out_buffer {
+	char *buf;
+	size_t idx;
+	size_t size;
+};
+
+static int out(int c, void *dest)
+{
+	int rv = EOF;
+	struct out_buffer *buf = (struct out_buffer *)dest;
+
+	if (buf->idx < buf->size) {
+		buf->buf[buf->idx++] = (char)(unsigned char)c;
+		rv = (int)(unsigned char)c;
+	}
+	return rv;
+}
+
+static char static_buf[512];
+static char runtime_buf[512];
+static char compare_buf[128];
+
+void dump(const char *desc, uint8_t *package, size_t len)
+{
+	printk("%s package %p:\n", desc, package);
+	for (size_t i = 0; i < len; i++) {
+		printk("%02x ", package[i]);
+	}
+	printk("\n");
+}
+
+void unpack(const char *desc, struct out_buffer *buf,
+	    uint8_t *package, size_t len)
+{
+	cbpprintf((cbprintf_cb)out, buf, package);
+	buf->buf[buf->idx] = 0;
+	zassert_equal(strcmp(buf->buf, compare_buf), 0,
+		      "Strings differ\nexp: |%s|\ngot: |%s|\n",
+		      compare_buf, buf->buf);
+}
+
+#define TEST_PACKAGING(fmt, ...) do { \
+	snprintf(compare_buf, sizeof(compare_buf), fmt, __VA_ARGS__); \
+	printk("-----------------------------------------\n"); \
+	printk("%s\n", compare_buf); \
+	uint8_t *pkg; \
+	struct out_buffer rt_buf = { \
+		.buf = runtime_buf, .idx = 0, .size = sizeof(runtime_buf) \
+	}; \
+	int rc = cbprintf_package(NULL, ALIGN_OFFSET, fmt, __VA_ARGS__); \
+	zassert_true(rc > 0, "cbprintf_package() returned %d", rc); \
+	int len = rc; \
+	/* Aligned so the package is similar to the static one. */ \
+	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) \
+			rt_package[len + ALIGN_OFFSET]; \
+	memset(rt_package, 0, len + ALIGN_OFFSET); \
+	pkg = &rt_package[ALIGN_OFFSET]; \
+	rc = cbprintf_package(pkg, len, fmt, __VA_ARGS__); \
+	zassert_equal(rc, len, "cbprintf_package() returned %d, expected %d", \
+		      rc, len); \
+	dump("runtime", pkg, len); \
+	unpack("runtime", &rt_buf, pkg, len); \
+	struct out_buffer st_buf = { \
+		.buf = static_buf, .idx = 0, .size = sizeof(static_buf) \
+	}; \
+	CBPRINTF_STATIC_PACKAGE(NULL, 0, len, ALIGN_OFFSET, fmt, __VA_ARGS__); \
+	zassert_true(len > 0, "CBPRINTF_STATIC_PACKAGE() returned %d", len); \
+	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) \
+		package[len + ALIGN_OFFSET];\
+	int outlen; \
+	pkg = &package[ALIGN_OFFSET]; \
+	CBPRINTF_STATIC_PACKAGE(pkg, len, outlen, ALIGN_OFFSET, fmt, __VA_ARGS__);\
+	zassert_equal(len, outlen, NULL); \
+	dump("static", pkg, len); \
+	unpack("static", &st_buf, pkg, len); \
+} while (0)
+
+void test_cbprintf_package(void)
+{
+	volatile signed char sc = -11;
+	int i = 100;
+	char c = 'a';
+	static const short s = -300;
+	long li = -1111111111;
+	long long lli = 0x1122334455667788;
+	unsigned char uc = 100;
+	unsigned int ui = 0x12345;
+	unsigned short us = 0x1234;
+	unsigned long ul = 0xaabbaabb;
+	unsigned long long ull = 0xaabbaabbaabb;
+
+
+	/* tests to exercize different element alignments */
+	TEST_PACKAGING("test long %x %lx %x", 0xb1b2b3b4, li, 0xe4e3e2e1);
+	TEST_PACKAGING("test long long %x %llx %x", 0xb1b2b3b4, lli, 0xe4e3e2e1);
+
+	/* tests with varied elements */
+	TEST_PACKAGING("test %d %hd %hhd", i, s, sc);
+	TEST_PACKAGING("test %ld %llx %hhu %hu %u", li, lli, uc, us, ui);
+	TEST_PACKAGING("test %lu %llu", ul, ull);
+	TEST_PACKAGING("test %c %p", c, &c);
+
+	if (IS_ENABLED(CONFIG_CBPRINTF_FP_SUPPORT)) {
+		float f = -1.234;
+		double d = 1.2333;
+
+		TEST_PACKAGING("test double %x %f %x", 0xb1b2b3b4, d, 0xe4e3e2e1);
+		TEST_PACKAGING("test %f %a", f, d);
+#if CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE
+		long double ld = 1.2333;
+
+		TEST_PACKAGING("test %Lf", ld);
+#endif
+	}
+}
+
+#if __cplusplus
+extern "C" void test_cxx(void);
+void test_cxx(void)
+#else
+void test_cc(void)
+#endif
+{
+#ifdef __cplusplus
+	printk("C++\n");
+#else
+	printk("sizeof:  int=%zu long=%zu ptr=%zu long long=%zu double=%zu long double=%zu\n",
+	       sizeof(int), sizeof(long), sizeof(void *), sizeof(long long),
+	       sizeof(double), sizeof(long double));
+	printk("alignof: int=%zu long=%zu ptr=%zu long long=%zu double=%zu long double=%zu\n",
+	       __alignof__(int), __alignof__(long), __alignof__(void *),
+	       __alignof__(long long), __alignof__(double), __alignof__(long double));
+	printk("%s C11 _Generic\n", Z_C_GENERIC ? "With" : "Without");
+#endif
+
+	ztest_test_suite(cbprintf_package,
+			 ztest_unit_test(test_cbprintf_package)
+			 );
+
+	ztest_run_test_suite(cbprintf_package);
+}


### PR DESCRIPTION
Static packaging was using `_Generic` C11 keyword which is not supported by C++. 
#34516 forced always runtime packaging in C++ which results in slower packaging (finally logging) from C++ files.

`_Generic` can be implemented in C++ using function overloading and template. Extended cbprintf_package test to be run for c++ (main.c content copied to test.inc).