### PR TITLE
log:include:fix NO OPTIMIZATIONS build fail

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -71,17 +71,6 @@ extern "C" {
 #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
 
 /**
- * @brief Unconditionally print raw log message.
- *
- * The result is same as if printk was used but it goes through logging
- * infrastructure thus utilizes logging mode, e.g. deferred mode.
- *
- * @param ... A string optionally containing printk valid conversion specifier,
- * followed by as many values as specifiers.
- */
-#define LOG_PRINTK(...) Z_LOG_PRINTK(__VA_ARGS__)
-
-/**
  * @brief Writes an ERROR level message associated with the instance to the log.
  *
  * Message is associated with specific instance of the module which has
@@ -263,12 +252,9 @@ extern "C" {
  * @param fmt Formatted string to output.
  * @param ap  Variable parameters.
  */
-void z_log_printk(const char *fmt, va_list ap);
-static inline void log_printk(const char *fmt, va_list ap)
-{
-	z_log_printk(fmt, ap);
-}
+void log_printk(const char *fmt, va_list ap);
 
+#ifndef CONFIG_LOG_MINIMAL
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *
  * Function should be used when transient string is intended to be logged.
@@ -286,15 +272,14 @@ static inline void log_printk(const char *fmt, va_list ap)
  *	   a buffer from the pool (see CONFIG_LOG_STRDUP_MAX_STRING). In
  *	   some configurations, the original string pointer is returned.
  */
-char *z_log_strdup(const char *str);
+char *log_strdup(const char *str);
+#else
+
 static inline char *log_strdup(const char *str)
 {
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || IS_ENABLED(CONFIG_LOG2)) {
-		return (char *)str;
-	}
-
-	return z_log_strdup(str);
+	return (char *)str;
 }
+#endif /* CONFIG_LOG_MINIMAL */
 
 #ifdef __cplusplus
 }

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -7,7 +7,6 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_CORE_H_
 
 #include <logging/log_msg.h>
-#include <logging/log_core2.h>
 #include <logging/log_instance.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -141,7 +140,6 @@ extern "C" {
 	  (0)\
 	)
 
-
 /**
  * @brief Macro for optional injection of function name as first argument of
  *	  formatted string. COND_CODE_0() macro is used to handle no arguments
@@ -152,28 +150,19 @@ extern "C" {
  *	  argument. In order to handle string with no arguments _LOG_Z_EVAL is
  *	  used.
  */
-#define Z_LOG_STR2(...) "%s: " GET_ARG_N(1, __VA_ARGS__), \
-				(const char *)__func__\
+
+#define Z_LOG_STR(...) "%s: " GET_ARG_N(1, __VA_ARGS__), __func__\
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
 			    (),\
 			    (, GET_ARGS_LESS_N(1, __VA_ARGS__))\
 			   )
 
-/**
- * @brief Handle optional injection of function name as the first argument.
- *
- * Additionally, macro is handling the empty message case.
- */
-#define Z_LOG_STR(...) \
-	COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
-		("%s", (const char *)__func__), \
-		(Z_LOG_STR2(__VA_ARGS__)))
 
 /******************************************************************************/
 /****************** Internal macros for log frontend **************************/
 /******************************************************************************/
 /**@brief Second stage for Z_LOG_NARGS_POSTFIX */
-#define Z_LOG_NARGS_POSTFIX_IMPL(				\
+#define _LOG_NARGS_POSTFIX_IMPL(				\
 	_ignored,						\
 	_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,		\
 	_11, _12, _13, _14, N, ...) N
@@ -187,38 +176,22 @@ extern "C" {
  * @retval  Postfix, number of arguments or _LONG when more than 3 arguments.
  */
 #define Z_LOG_NARGS_POSTFIX(...) \
-	Z_LOG_NARGS_POSTFIX_IMPL(__VA_ARGS__, LONG, LONG, LONG, LONG, LONG, \
+	_LOG_NARGS_POSTFIX_IMPL(__VA_ARGS__, LONG, LONG, LONG, LONG, LONG, \
 			LONG, LONG, LONG, LONG, LONG, LONG, LONG, 3, 2, 1, 0, ~)
 
 #define Z_LOG_INTERNAL_X(N, ...)  UTIL_CAT(_LOG_INTERNAL_, N)(__VA_ARGS__)
 
-#define Z_LOG_INTERNAL2(is_user_context, _src_level, ...) do { \
-	if (is_user_context) { \
-		log_from_user(_src_level, __VA_ARGS__); \
-	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
-		log_string_sync(_src_level, __VA_ARGS__); \
-	} else { \
-		Z_LOG_INTERNAL_X(Z_LOG_NARGS_POSTFIX(__VA_ARGS__), \
-					_src_level, __VA_ARGS__); \
-	} \
-} while (false)
-
-#define Z_LOG_INTERNAL(is_user_context, _level, _source, ...) do { \
-	uint16_t src_id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
-	struct log_msg_ids src_level = { \
-		.level = _level, \
-		.domain_id = CONFIG_LOG_DOMAIN_ID, \
-		.source_id = src_id \
-	}; \
-	if (BIT(_level) & LOG_FUNCTION_PREFIX_MASK) {\
-		Z_LOG_INTERNAL2(is_user_context, src_level, \
-				Z_LOG_STR(__VA_ARGS__)); \
-	} else { \
-		Z_LOG_INTERNAL2(is_user_context, src_level, __VA_ARGS__); \
-	} \
-} while (0)
+#define __LOG_INTERNAL(is_user_context, _src_level, ...)		 \
+	do {								 \
+		if (is_user_context) {					 \
+			log_from_user(_src_level, __VA_ARGS__);		 \
+		} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {		 \
+			log_string_sync(_src_level, __VA_ARGS__);	 \
+		} else {						 \
+			Z_LOG_INTERNAL_X(Z_LOG_NARGS_POSTFIX(__VA_ARGS__), \
+						_src_level, __VA_ARGS__);\
+		}							 \
+	} while (false)
 
 #define _LOG_INTERNAL_0(_src_level, _str) \
 	log_0(_str, _src_level)
@@ -246,18 +219,17 @@ extern "C" {
 	(_level <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
 
 #define Z_LOG_CONST_LEVEL_CHECK(_level)					    \
-	(IS_ENABLED(CONFIG_LOG) &&					    \
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
 	((IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) == false) &&		    \
 	(_level <= __log_level) &&					    \
 	(_level <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
-	))
+	)
 
-/*****************************************************************************/
-/****************** Defiinitions used by minimal logging *********************/
-/*****************************************************************************/
+/******************************************************************************/
+/****************** Defiinitions used by minimal logging **********************/
+/******************************************************************************/
 void z_log_minimal_hexdump_print(int level, const void *data, size_t size);
 void z_log_minimal_vprintk(const char *fmt, va_list ap);
 void z_log_minimal_printk(const char *fmt, ...);
@@ -266,12 +238,6 @@ void z_log_minimal_printk(const char *fmt, ...);
 	z_log_minimal_printk("%c: " fmt "\n", \
 			     z_log_minimal_level_to_char(_level), \
 			     ##__VA_ARGS__); \
-} while (false)
-
-#define Z_LOG_TO_VPRINTK(_level, fmt, valist) do { \
-	z_log_minimal_printk("%c: ", z_log_minimal_level_to_char(_level)); \
-	z_log_minimal_vprintk(fmt, valist); \
-	z_log_minimal_printk("\n"); \
 } while (false)
 
 static inline char z_log_minimal_level_to_char(int level)
@@ -289,116 +255,135 @@ static inline char z_log_minimal_level_to_char(int level)
 		return '?';
 	}
 }
+/******************************************************************************/
+/****************** Macros for standard logging *******************************/
+/******************************************************************************/
+#ifdef CONFIG_LOG
+#ifdef CONFIG_LOG_MINIMAL
+#define __LOG(_level, _id, _filter, ...)		       \
+	Z_LOG_TO_PRINTK(_level, __VA_ARGS__)	\
+#else
+#define __LOG(_level, _id, _filter, ...)				       \
+	do {								       \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
+			bool is_user_context = k_is_user_context();	       \
+			if (LOG_CHECK_CTX_LVL_FILTER(is_user_context,   \
+					_level, _filter)) {		       \
+				struct log_msg_ids src_level = {	       \
+					.level = _level,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID,     \
+					.source_id = _id		       \
+				};					       \
+									       \
+				if ((BIT(_level) &			       \
+				     LOG_FUNCTION_PREFIX_MASK) != 0U) {        \
+					__LOG_INTERNAL(is_user_context,	       \
+						       src_level,	       \
+						       Z_LOG_STR(__VA_ARGS__));\
+				} else {				       \
+					__LOG_INTERNAL(is_user_context,	       \
+						       src_level,	       \
+						       __VA_ARGS__);	       \
+				}					       \
+			} else {					       \
+			}						       \
+		}							       \
+	} while (false)
+#endif /* CONFIG_LOG_MINIMAL */
+#else
+#define __LOG(_level, _id, _filter, ...)                          \
+	do {								       \
+		if (false) {						       \
+			/* Arguments checker present but never evaluated.*/    \
+			/* Placed here to ensure that __VA_ARGS__ are*/        \
+			/* evaluated once when log is enabled.*/	       \
+			log_printf_arg_checker(__VA_ARGS__);		       \
+		}							       \
+	} while (false)
+#endif /* CONFIG_LOG */
 
-#define Z_LOG_INST(_inst) COND_CODE_1(CONFIG_LOG, (_inst), NULL)
-
-/*****************************************************************************/
-/****************** Macros for standard logging ******************************/
-/*****************************************************************************/
-#define Z_LOG2(_level, _source, ...) do { \
-	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
-		Z_LOG_TO_PRINTK(_level, __VA_ARGS__); \
-		break; \
-	} \
-	\
-	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
-	if (!LOG_CHECK_CTX_LVL_FILTER(is_user_context, _level, filters)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG2)) { \
-		int _mode; \
-		Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
-				  CONFIG_LOG_DOMAIN_ID, _source, _level, NULL,\
-				  0, __VA_ARGS__); \
-	} else { \
-		Z_LOG_INTERNAL(is_user_context,	_level, _source, __VA_ARGS__);\
-	} \
-	if (false) { \
-		/* Arguments checker present but never evaluated.*/ \
-		/* Placed here to ensure that __VA_ARGS__ are*/ \
-		/* evaluated once when log is enabled.*/ \
-		z_log_printf_arg_checker(__VA_ARGS__); \
-	} \
-} while (false)
-
-#define Z_LOG(_level, ...) \
-	Z_LOG2(_level, \
-	      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	      (void *)__log_current_dynamic_data : \
-	      (void *)__log_current_const_data, \
+#define Z_LOG(_level, ...)			       \
+	__LOG(_level,				       \
+	      (uint16_t)LOG_CURRENT_MODULE_ID(),	       \
+	      LOG_CURRENT_DYNAMIC_DATA_ADDR(),	       \
 	      __VA_ARGS__)
 
-#define Z_LOG_INSTANCE(_level, _inst, ...) \
-	Z_LOG2(_level, Z_LOG_INST(_inst), __VA_ARGS__)
+#define Z_LOG_INSTANCE(_level, _inst, ...)		 \
+	__LOG(_level,					 \
+	      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
+	      LOG_DYNAMIC_ID_GET(_inst) :		 \
+	      LOG_CONST_ID_GET(_inst),			 \
+	      _inst,					 \
+	      __VA_ARGS__)
 
 
-/*****************************************************************************/
-/****************** Macros for hexdump logging *******************************/
-/*****************************************************************************/
-#define Z_LOG_HEXDUMP2(_level, _source, _data, _len, ...) do { \
-	const char *_str = GET_ARG_N(1, __VA_ARGS__); \
-	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) {	\
-		break; \
-	} \
-	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
-	\
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
-		Z_LOG_TO_PRINTK(_level, "%s", _str); \
-		z_log_minimal_hexdump_print(_level, \
-					    (const char *)_data, _len);\
-		break; \
-	} \
-	if (!LOG_CHECK_CTX_LVL_FILTER(is_user_context, _level, filters)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG2)) { \
-		int mode; \
-		Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode, \
-				  CONFIG_LOG_DOMAIN_ID, _source, _level, \
-				  _data, _len, \
-				COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
-					(), \
-				  (COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
-					  ("%s", __VA_ARGS__), (__VA_ARGS__)))));\
-		break; \
-	} \
-	uint16_t src_id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
-	struct log_msg_ids src_level = { \
-		.level = _level, \
-		.domain_id = CONFIG_LOG_DOMAIN_ID, \
-		.source_id = src_id, \
-	}; \
-	if (is_user_context) { \
-		log_hexdump_from_user(src_level, _str, \
-				      (const char *)_data, _len); \
-	} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
-		log_hexdump_sync(src_level, _str, (const char *)_data, _len); \
-	} else { \
-		log_hexdump(_str, (const char *)_data, _len, src_level); \
-	} \
-} while (false)
+/******************************************************************************/
+/****************** Macros for hexdump logging ********************************/
+/******************************************************************************/
+#ifdef CONFIG_LOG
+#ifdef CONFIG_LOG_MINIMAL
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	       \
+	do {										\
+				Z_LOG_TO_PRINTK(_level, "%s", _str);	       \
+				z_log_minimal_hexdump_print(_level,	       \
+							  (const char *)_data, \
+							  _length);	       \
+	} while (false)
+#else
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	       \
+	do {								       \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
+			bool is_user_context = k_is_user_context();	       \
+									       \
+			if (LOG_CHECK_CTX_LVL_FILTER(is_user_context,   \
+					_level, _filter)) {		       \
+				struct log_msg_ids src_level = {	       \
+					.level = _level,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID,     \
+					.source_id = _id,		       \
+				};					       \
+									       \
+				if (is_user_context) {			       \
+					log_hexdump_from_user(src_level, _str, \
+							      (const char *)_data, \
+							      _length);	       \
+				} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
+					log_hexdump_sync(src_level, _str,      \
+							 (const char *)_data,  \
+							  _length);	       \
+				} else {				       \
+					log_hexdump(_str, (const char *)_data, \
+						    _length,		       \
+						    src_level);		       \
+				}					       \
+			} else {				       \
+			}						       \
+		}							       \
+	} while (false)
+#endif /* CONFIG_LOG_MINIMAL */
+#else
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)
+#endif /* CONFIG_LOG */
 
-#define Z_LOG_HEXDUMP(_level, _data, _length, ...) \
-	Z_LOG_HEXDUMP2(_level, IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		      (void *)__log_current_dynamic_data : \
-		      (void *)__log_current_const_data, \
-		      _data, _length, __VA_ARGS__)
+#define Z_LOG_HEXDUMP(_level, _data, _length, _str)	       \
+	__LOG_HEXDUMP(_level,				       \
+		      (uint16_t)LOG_CURRENT_MODULE_ID(),	       \
+		      LOG_CURRENT_DYNAMIC_DATA_ADDR(),	       \
+		      _data, _length, _str)
 
 #define Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str) \
-	Z_LOG_HEXDUMP2(_level, Z_LOG_INST(_inst), _data, _length, _str)
+	__LOG_HEXDUMP(_level,					   \
+		      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?   \
+		      LOG_DYNAMIC_ID_GET(_inst) :		   \
+		      LOG_CONST_ID_GET(_inst),			   \
+		      _inst,					   \
+		      _data,					   \
+		      _length,					   \
+		      _str)
 
-/*****************************************************************************/
-/****************** Filtering macros *****************************************/
-/*****************************************************************************/
+/******************************************************************************/
+/****************** Filtering macros ******************************************/
+/******************************************************************************/
 
 /** @brief Number of bits used to encode log level. */
 #define LOG_LEVEL_BITS 3U
@@ -440,9 +425,9 @@ static inline char z_log_minimal_level_to_char(int level)
 #define LOG_CHECK_CTX_LVL_FILTER(ctx, _level, _filter) \
 	(ctx || (_level <= LOG_RUNTIME_FILTER(_filter)))
 #define LOG_RUNTIME_FILTER(_filter) \
-	LOG_FILTER_SLOT_GET(&_filter, LOG_FILTER_AGGR_SLOT_IDX)
+	LOG_FILTER_SLOT_GET(&(_filter)->filters, LOG_FILTER_AGGR_SLOT_IDX)
 #else
-#define LOG_CHECK_CTX_LVL_FILTER(ctx, _level, _filter) ((true) | _filter)
+#define LOG_CHECK_CTX_LVL_FILTER(ctx, _level, _filter) (true)
 #define LOG_RUNTIME_FILTER(_filter) LOG_LEVEL_DBG
 #endif
 
@@ -460,21 +445,6 @@ enum log_strdup_action {
 	LOG_STRDUP_EXEC,     /**< Always duplicate RAM strings. */
 	LOG_STRDUP_CHECK_EXEC/**< Duplicate RAM strings, if not dupl. before.*/
 };
-
-#define Z_LOG_PRINTK(...) do { \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || !IS_ENABLED(CONFIG_LOG2)) { \
-		z_log_minimal_printk(__VA_ARGS__); \
-		break; \
-	} \
-	int _mode; \
-	if (0) {\
-		z_log_printf_arg_checker(__VA_ARGS__); \
-	} \
-	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
-			  CONFIG_LOG_DOMAIN_ID, NULL, \
-			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
-} while (0)
-
 
 /** @brief Get name of the log source.
  *
@@ -554,7 +524,7 @@ static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 
 /** @brief Dummy function to trigger log messages arguments type checking. */
 static inline __printf_like(1, 2)
-void z_log_printf_arg_checker(const char *fmt, ...)
+void log_printf_arg_checker(const char *fmt, ...)
 {
 	ARG_UNUSED(fmt);
 }
@@ -656,21 +626,6 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap,
 		 enum log_strdup_action strdup_action);
 
 /**
- * @brief Writes a generic log message to the logging v2.
- *
- * @note This function is intended to be used when porting other log systems.
- *
- * @param level          Log level..
- * @param fmt            String to format.
- * @param ap             Poiner to arguments list.
- */
-static inline void log2_generic(uint8_t level, const char *fmt, va_list ap)
-{
-	z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, NULL, level,
-				   NULL, 0, fmt, ap);
-}
-
-/**
  * @brief Returns number of arguments visible from format string.
  *
  * @note This function is intended to be used when porting other log systems.
@@ -721,20 +676,7 @@ uint32_t log_get_strdup_longest_string(void);
 
 /** @brief Indicate to the log core that one log message has been dropped.
  */
-void z_log_dropped(void);
-
-/** @brief Read and clear current drop indications counter.
- *
- * @return Dropped count.
- */
-uint32_t z_log_dropped_read_and_clear(void);
-
-/** @brief Check if there are any pending drop notifications.
- *
- * @retval true Pending unreported drop indications.
- * @retval false No pending unreported drop indications.
- */
-bool z_log_dropped_pending(void);
+void log_dropped(void);
 
 /** @brief Log a message from user mode context.
  *
@@ -748,9 +690,6 @@ bool z_log_dropped_pending(void);
 void __printf_like(2, 3) log_from_user(struct log_msg_ids src_level,
 				       const char *fmt, ...);
 
-/* Internal function used by log_from_user(). */
-__syscall void z_log_string_from_user(uint32_t src_level_val, const char *str);
-
 /**
  * @brief Create mask with occurences of a string format specifiers (%s).
  *
@@ -763,6 +702,9 @@ __syscall void z_log_string_from_user(uint32_t src_level_val, const char *str);
  * @return Mask with %s format specifiers found.
  */
 uint32_t z_log_get_s_mask(const char *str, uint32_t nargs);
+
+/* Internal function used by log_from_user(). */
+__syscall void z_log_string_from_user(uint32_t src_level_val, const char *str);
 
 /** @brief Log binary data (displayed as hexdump) from user mode context.
  *
@@ -789,45 +731,39 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 /*********  Speed optimized for up to three arguments number.   ***************/
 /******************************************************************************/
 #define Z_LOG_VA(_level, _str, _valist, _argnum, _strdup_action)\
-	__LOG_VA(_level, \
-		 IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		 (void *)__log_current_dynamic_data : \
-		 (void *)__log_current_const_data, \
-		 _str, _valist, _argnum, _strdup_action)
+	__LOG_VA(_level,					\
+		  (uint16_t)LOG_CURRENT_MODULE_ID(),		\
+		  LOG_CURRENT_DYNAMIC_DATA_ADDR(),		\
+		  _str, _valist, _argnum, _strdup_action)
 
-#define __LOG_VA(_level, _source, _str, _valist, _argnum, _strdup_action) do { \
-	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
-		Z_LOG_TO_VPRINTK(_level, _str, _valist); \
-		break; \
-	} \
-	\
-	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-	     ((struct log_source_dynamic_data *)(void *)(_source))->filters : 0;\
-	if (!LOG_CHECK_CTX_LVL_FILTER(is_user_context, _level, filters)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG2)) { \
-		z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, _source, \
-					   _level, NULL, 0, _str, _valist); \
-		break; \
-	} \
-	uint16_t _id = \
-		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		LOG_DYNAMIC_ID_GET(_source) : LOG_CONST_ID_GET(_source);\
-	struct log_msg_ids src_level = { \
-		.level = _level, \
-		.domain_id = CONFIG_LOG_DOMAIN_ID, \
-		.source_id = _id \
-	}; \
-	__LOG_INTERNAL_VA(is_user_context, \
-			src_level, \
-			_str, _valist, _argnum, \
-			_strdup_action); \
-} while (false)
+#ifdef CONFIG_LOG
+#ifdef CONFIG_LOG_MINIMAL
+#define __LOG_VA(_level, _id, _filter, _str, _valist, _argnum, _strdup_action) \
+	z_log_minimal_printk(_str, _valist);
+#else
+#define __LOG_VA(_level, _id, _filter, _str, _valist, _argnum, _strdup_action) \
+	do {								       \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
+			bool is_user_context = k_is_user_context();	       \									       \
+			if (LOG_CHECK_CTX_LVL_FILTER(is_user_context, \
+					_level, _filter)) {  \
+				struct log_msg_ids src_level = {	       \
+					.level = _level,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID,     \
+					.source_id = _id		       \
+				};					       \
+				__LOG_INTERNAL_VA(is_user_context,	       \
+						src_level,		       \
+						_str, _valist, _argnum,        \
+						_strdup_action);	       \
+			} else {				       \
+			}						       \
+		}							       \
+	} while (false)
+#endif /* CONFIG_LOG_MINIMAL */
+#else
+#define __LOG_VA(_level, _id, _filter, _str, _valist, _argnum, _strdup_action)
+#endif /* CONFIG_LOG */
 
 /**
  * @brief Inline function to perform strdup, used in __LOG_INTERNAL_VA macro
@@ -846,7 +782,7 @@ static inline log_arg_t z_log_do_strdup(uint32_t msk, uint32_t idx,
 					enum log_strdup_action action)
 {
 #ifndef CONFIG_LOG_MINIMAL
-	char *z_log_strdup(const char *str);
+	char *log_strdup(const char *str);
 
 	if (msk & (1 << idx)) {
 		const char *str = (const char *)param;
@@ -856,7 +792,7 @@ static inline log_arg_t z_log_do_strdup(uint32_t msk, uint32_t idx,
 		 * if already not duplicated.
 		 */
 		if (action == LOG_STRDUP_EXEC || !log_is_strdup(str)) {
-			param = (log_arg_t)z_log_strdup(str);
+			param = (log_arg_t)log_strdup(str);
 		}
 	}
 #else
@@ -878,7 +814,7 @@ do {									       \
 		_LOG_INTERNAL_0(_src_level, _str);			       \
 	} else {							       \
 		uint32_t mask = (_strdup_action != LOG_STRDUP_SKIP) ?	       \
-			z_log_get_s_mask(_str, _argnum)			       \
+			z_log_get_s_mask(_str, _argnum) 		       \
 			: 0;						       \
 									       \
 		if (_argnum == 1) {					       \


### PR DESCRIPTION
fix https://github.com/zephyrproject-rtos/zephyr/issues/34269
LOG related macros are always used in the zephyr.
When the program does not enable log and does not optimize the code,
the corresponding function in the log macro definition will be
considered by the compiler as being used, and the corresponding
function is not implemented, resulting in a compilation error.
The patch code adjusts the definition of the LOG macro to meet
various compilation conditions.

Signed-off-by: Yang XiaoHua <yangxiaohuamail@gmail.com>