### PR TITLE
net: Use k_fifo instead of k_work in RX and TX processing

### DIFF
--- a/include/net/can.h
+++ b/include/net/can.h
@@ -131,6 +131,14 @@ struct canbus_net_ctx {
 	struct net_if *iface;
 	/** The link layer address chosen for this interface */
 	uint16_t ll_addr;
+	/** TX queue */
+	struct k_fifo tx_queue;
+	/** RX error queue */
+	struct k_fifo rx_err_queue;
+	/** Queue handler thread */
+	struct k_thread queue_handler;
+	/** Queue handler thread stack */
+	K_KERNEL_STACK_MEMBER(queue_stack, 512);
 };
 
 /**

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -396,15 +396,18 @@ struct net_if_config {
  *
  * Traffic classes are used when sending or receiving data that is classified
  * with different priorities. So some traffic can be marked as high priority
- * and it will be sent or received first. There is always at least one work
- * queue in the system for Rx and Tx. Each network packet that is transmitted
- * or received goes through a work queue thread that will transmit it.
+ * and it will be sent or received first. Each network packet that is
+ * transmitted or received goes through a fifo to a thread that will transmit
+ * it.
  */
 struct net_traffic_class {
-	/** Work queue for handling this Tx or Rx packet */
-	struct k_work_q work_q;
+	/** Fifo for handling this Tx or Rx packet */
+	struct k_fifo fifo;
 
-	/** Stack for this work queue */
+	/** Traffic class handler thread */
+	struct k_thread handler;
+
+	/** Stack for this handler */
 	k_thread_stack_t *stack;
 };
 

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -60,18 +60,11 @@ struct net_pkt_cursor {
  * net_pkt_clone() function.
  */
 struct net_pkt {
-	union {
-		/** Internal variable that is used when packet is sent
-		 * or received.
-		 */
-		struct k_work work;
-		/** Socket layer will queue received net_pkt into a k_fifo.
-		 * Since this happens after consuming net_pkt's k_work on
-		 * RX path, it is then fine to have both attributes sharing
-		 * the same memory area.
-		 */
-		intptr_t sock_recv_fifo;
-	};
+	/**
+	 * The fifo is used by RX/TX threads and by socket layer. The net_pkt
+	 * is queued via fifo to the processing thread.
+	 */
+	intptr_t fifo;
 
 	/** Slab pointer from where it belongs to */
 	struct k_mem_slab *slab;
@@ -263,11 +256,6 @@ struct net_pkt {
 };
 
 /** @cond ignore */
-
-static inline struct k_work *net_pkt_work(struct net_pkt *pkt)
-{
-	return &pkt->work;
-}
 
 /* The interface real ll address */
 static inline struct net_linkaddr *net_pkt_lladdr_if(struct net_pkt *pkt)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -316,12 +316,9 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 	return true;
 }
 
-static void process_tx_packet(struct k_work *work)
+void net_process_tx_packet(struct net_pkt *pkt)
 {
 	struct net_if *iface;
-	struct net_pkt *pkt;
-
-	pkt = CONTAINER_OF(work, struct net_pkt, work);
 
 	net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
@@ -354,8 +351,6 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 		net_if_tx(net_pkt_iface(pkt), pkt);
 		return;
 	}
-
-	k_work_init(net_pkt_work(pkt), process_tx_packet);
 
 #if NET_TC_TX_COUNT > 1
 	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -47,6 +47,8 @@ extern void net_if_post_init(void);
 extern void net_if_carrier_down(struct net_if *iface);
 extern void net_if_stats_reset(struct net_if *iface);
 extern void net_if_stats_reset_all(void);
+extern void net_process_rx_packet(struct net_pkt *pkt);
+extern void net_process_tx_packet(struct net_pkt *pkt);
 
 #if defined(CONFIG_NET_NATIVE) || defined(CONFIG_NET_OFFLOAD)
 extern void net_context_init(void);

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -92,4 +92,11 @@ config NET_L2_PPP_MGMT
 	  Enable support net_mgmt ppp interface which can be used to
 	  configure at run-time ppp drivers and L2 settings.
 
+config NET_L2_PPP_TX_STACK_SIZE
+	int "Stack size for TX handler"
+	default 2048 if COVERAGE_GCOV
+	default 1024
+	help
+	  Set the TX handler stack size.
+
 endif # NET_L2_PPP

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -159,18 +159,6 @@ static void ppp_fsm_timeout(struct k_work *work)
 	}
 }
 
-static void ppp_pkt_send(struct k_work *work)
-{
-	struct net_pkt *pkt = CONTAINER_OF(work, struct net_pkt, work);
-	int ret;
-
-	ret = net_send_data(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-	}
-}
-
-
 void ppp_fsm_init(struct ppp_fsm *fsm, uint16_t protocol)
 {
 	fsm->protocol = protocol;
@@ -541,8 +529,7 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 		 * have returned from this function. That is bad because the
 		 * fsm would be in wrong state and the received pkt is dropped.
 		 */
-		k_work_init(net_pkt_work(pkt), ppp_pkt_send);
-		k_work_submit(net_pkt_work(pkt));
+		ppp_queue_pkt(pkt);
 	} else {
 		ret = net_send_data(pkt);
 		if (ret < 0) {

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -101,6 +101,7 @@ int ppp_config_info_req(struct ppp_fsm *fsm,
 		.close = proto_close,					\
 	}
 
+void ppp_queue_pkt(struct net_pkt *pkt);
 const char *ppp_phase_str(enum ppp_phase phase);
 const char *ppp_state_str(enum ppp_state state);
 const char *ppp_proto2str(uint16_t proto);

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -21,6 +21,21 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include "ppp_stats.h"
 #include "ppp_internal.h"
 
+static K_FIFO_DEFINE(tx_queue);
+
+#if IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)
+/* Lowest priority cooperative thread */
+#define THREAD_PRIORITY K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1)
+#else
+#define THREAD_PRIORITY K_PRIO_PREEMPT(CONFIG_NUM_PREEMPT_PRIORITIES - 1)
+#endif
+
+static void tx_handler(void);
+
+static K_THREAD_DEFINE(tx_handler_thread, CONFIG_NET_L2_PPP_TX_STACK_SIZE,
+		       (k_thread_entry_t)tx_handler, NULL, NULL, NULL,
+		       THREAD_PRIORITY, 0, 0);
+
 static const struct ppp_protocol_handler *ppp_lcp;
 
 static void ppp_update_rx_stats(struct net_if *iface,
@@ -426,6 +441,33 @@ bail_out:
 	if (ctx->is_enable_done) {
 		start_ppp(ctx);
 		ctx->is_enable_done = false;
+	}
+}
+
+void ppp_queue_pkt(struct net_pkt *pkt)
+{
+	k_fifo_put(&tx_queue, pkt);
+}
+
+static void tx_handler(void)
+{
+	struct net_pkt *pkt;
+	int ret;
+
+	NET_DBG("PPP TX started");
+
+	k_thread_name_set(NULL, "ppp_tx");
+
+	while (1) {
+		pkt = k_fifo_get(&tx_queue, K_FOREVER);
+		if (pkt == NULL) {
+			continue;
+		}
+
+		ret = net_send_data(pkt);
+		if (ret < 0) {
+			net_pkt_unref(pkt);
+		}
 	}
 }
 


### PR DESCRIPTION
The k_work handler cannot manipulate the used k_work. This means
that it is not easy to cleanup the net_pkt because it contains
k_work in it. Because of this, use k_fifo instead between
RX thread and network driver, and between application and TX
thread.

A echo-server/client run with IPv4 and UDP gave following
results:
```
Using k_work
------------
TX traffic class statistics:
TC  Priority	Sent pkts	bytes	time
[0] BK (1)	21922		5543071	103 us	[0->41->26->34=101 us]
[1] BE (0)	0		0	-
RX traffic class statistics:
TC  Priority	Recv pkts	bytes	time
[0] BK (0)	0		0	-
[1] BE (0)	21925		6039151	97 us	[0->21->16->37->20=94 us]
```
```
Using k_fifo
------------
TX traffic class statistics:
TC  Priority	Sent pkts	bytes	time
[0] BK (1)	15079		3811118	94 us	[0->36->23->32=91 us]
[1] BE (0)	0		0	-
RX traffic class statistics:
TC  Priority	Recv pkts	bytes	time
[0] BK (1)	0		0	-
[1] BE (0)	15073		4150947	79 us	[0->17->12->32->14=75 us]
```
So using k_fifo gives about 10% better performance with same
workload.

Fixes #34690

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>