### PR TITLE
tests: net: igmp: Remove device_pm_control_nop

### DIFF
--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -146,7 +146,7 @@ static struct dummy_api net_test_if_api = {
 #define _ETH_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
 
 NET_DEVICE_INIT(net_test_igmp, "net_test_igmp",
-		net_test_dev_init, device_pm_control_nop, &net_test_data, NULL,
+		net_test_dev_init, NULL, &net_test_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&net_test_if_api, _ETH_L2_LAYER, _ETH_L2_CTX_TYPE,
 		127);


### PR DESCRIPTION
The use of device_pm_control_nop is deprecated so remove it
from the test as it will give warning in CI.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>