### PR TITLE
MAINTAINERS.yml: Fix a few renamed directories

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -136,11 +136,8 @@ ARM arch:
         - MaureenHelm
         - stephanosio
     files:
-        - arch/arm/aarch32/
-        - arch/arm/common/
-        - arch/arm/offsets/
-        - include/arch/arm/aarch32
-        - include/arch/arm/*
+        - arch/arm/
+        - include/arch/arm/
         - tests/arch/arm/
     labels:
         - "area: ARM"
@@ -178,12 +175,13 @@ Bluetooth:
         - include/bluetooth/
         - include/drivers/bluetooth/
         - samples/bluetooth/
-        - subsys/bluetooth/*
+        - subsys/bluetooth/CMakeLists.txt
+        - subsys/bluetooth/Kconfig
+        - subsys/bluetooth/audio/
         - subsys/bluetooth/common/
         - subsys/bluetooth/host/
         - subsys/bluetooth/services/
         - subsys/bluetooth/shell/
-        - subsys/bluetooth/audio/
         - tests/bluetooth/
     labels:
         - "area: Bluetooth"
@@ -358,7 +356,7 @@ Display drivers:
         - include/drivers/display.h
         - lib/gui/
         - subsys/fb/
-        - samples/display/
+        - samples/subsys/display/
     labels:
         - "area: Display"
 
@@ -372,13 +370,16 @@ Documentation:
         - jocelyn-li
         - mbolivar-nordic
     files:
-        - doc/*
-        - doc/static/
-        - doc/templates/
+        - doc/CMakeLists.txt
+        - doc/Makefile
+        - doc/conf.py
+        - doc/known-warnings.txt
+        - doc/substitutions.txt
+        - doc/zephyr.doxyfile.in
+        - doc/_*/
         - doc/custom-doxygen/
-        - doc/scripts/
+        - doc/templates/
         - README.rst
-        - Makefile
     labels:
         - "area: Documentation"
 
@@ -406,7 +407,7 @@ Documentation:
     files:
         - drivers/audio/
         - include/audio/
-        - samples/audio/
+        - samples/subsys/audio/
     labels:
         - "area: Audio"
 
@@ -575,7 +576,8 @@ Documentation:
         - include/drivers/gpio.h
         - include/dt-bindings/gpio/
         - tests/drivers/gpio/
-        - samples/drivers/gpio/
+        - samples/basic/button/
+        - samples/basic/blinky/
     labels:
         - "area: GPIO"
 
@@ -694,7 +696,7 @@ Documentation:
         - samples/drivers/lora/
         - include/lorawan/
         - subsys/lorawan/
-        - samples/lorawan/
+        - samples/subsys/lorawan/
     labels:
         - "area: LoRa"
 
@@ -770,7 +772,7 @@ Documentation:
         - drivers/pm_cpu_ops/
         - include/drivers/pm_cpu_ops/
         - include/drivers/pm_cpu_ops.h
-        - include/arch/arm/arm-smccc.h
+        - include/arch/arm64/arm-smccc.h
     labels:
         - "area: PM CPU ops"
 
@@ -1279,7 +1281,7 @@ Nuvoton Platforms:
         - soc/arm/nuvoton/
         - boards/arm/npcx*/
         - dts/arm/nuvoton/
-        - dts/bindings/*/nuvoton/*
+        - dts/bindings/*/nuvoton*
         - drivers/*/*_npcx*
     labels:
         - "platform: Nuvoton"
@@ -1335,7 +1337,7 @@ NXP Platforms:
     - boards/arm/mimx*/
     - boards/arm/frdm_k*/
     - boards/arm/lpcxpress*/
-    - boards/arm/twr_*
+    - boards/arm/twr_*/
     - soc/arm/nxp_*/
     - drivers/*/*imx*
     - drivers/*/*lpc*
@@ -1442,7 +1444,6 @@ Tracing:
         - subsys/timing/
         - samples/subsys/tracing/
         - doc/guides/tracing/
-        - tests/subsys/tracing/
     labels:
         - "area: tracing"
 


### PR DESCRIPTION
In the course of out development, we move directories around but the
MAINTAINERS.yml is often left behind.  It's unusable with the
non-existing paths because ./scripts/get_maintainer.py just bails out
with the following message:

     error: MAINTAINERS.yml: glob pattern 'foo/*' in 'files' in area
     'Bar' does not match any files

This commit fixes renamed directories in MAINTAINERS.yml.  We still
have some issues with it and won't be able to use the script just yet.

See #32531

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>