### PR TITLE
Bluetooth: host: Fix buffer leak trying to send when disconnected

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -427,10 +427,27 @@ static struct net_buf *l2cap_create_le_sig_pdu(struct net_buf *buf,
 	return buf;
 }
 
+/* Send the buffer and release it in case of failure.
+ * Any other cleanup in failure to send should be handled by the disconnected
+ * handler.
+ */
+static inline void l2cap_send(struct bt_conn *conn, uint16_t cid,
+			      struct net_buf *buf)
+{
+	if (bt_l2cap_send(conn, cid, buf)) {
+		net_buf_unref(buf);
+	}
+}
+
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 static void l2cap_chan_send_req(struct bt_l2cap_chan *chan,
 				struct net_buf *buf, k_timeout_t timeout)
 {
+	if (bt_l2cap_send(chan->conn, BT_L2CAP_CID_LE_SIG, buf)) {
+		net_buf_unref(buf);
+		return;
+	}
+
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part A] page 126:
 	 *
 	 * The value of this timer is implementation-dependent but the minimum
@@ -441,8 +458,6 @@ static void l2cap_chan_send_req(struct bt_l2cap_chan *chan,
 	 * link is lost.
 	 */
 	k_delayed_work_submit(&chan->rtx_work, timeout);
-
-	bt_l2cap_send(chan->conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
 static int l2cap_le_conn_req(struct bt_l2cap_le_chan *ch)
@@ -619,7 +634,7 @@ static void l2cap_send_reject(struct bt_conn *conn, uint8_t ident,
 		net_buf_add_mem(buf, data, data_len);
 	}
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
 static void le_conn_param_rsp(struct bt_l2cap *l2cap, struct net_buf *buf)
@@ -678,7 +693,7 @@ static void le_conn_param_update_req(struct bt_l2cap *l2cap, uint8_t ident,
 		rsp->result = sys_cpu_to_le16(BT_L2CAP_CONN_PARAM_REJECTED);
 	}
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 
 	if (accepted) {
 		bt_conn_le_conn_update(conn, &param);
@@ -1083,7 +1098,7 @@ static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	rsp->result = BT_L2CAP_LE_SUCCESS;
 
 rsp:
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
 #if defined(CONFIG_BT_L2CAP_ECRED)
@@ -1187,7 +1202,7 @@ response:
 
 	rsp->result = sys_cpu_to_le16(result);
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
 static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
@@ -1262,7 +1277,7 @@ response:
 	rsp = net_buf_add(buf, sizeof(*rsp));
 	rsp->result = sys_cpu_to_le16(result);
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 #endif /* defined(CONFIG_BT_L2CAP_ECRED) */
 
@@ -1331,7 +1346,7 @@ static void le_disconn_req(struct bt_l2cap *l2cap, uint8_t ident,
 
 	bt_l2cap_chan_del(&chan->chan);
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
 static int l2cap_change_security(struct bt_l2cap_le_chan *chan, uint16_t err)
@@ -2038,7 +2053,7 @@ static void l2cap_chan_send_credits(struct bt_l2cap_le_chan *chan,
 	ev->cid = sys_cpu_to_le16(chan->rx.cid);
 	ev->credits = sys_cpu_to_le16(credits);
 
-	bt_l2cap_send(chan->chan.conn, BT_L2CAP_CID_LE_SIG, buf);
+	l2cap_send(chan->chan.conn, BT_L2CAP_CID_LE_SIG, buf);
 
 	BT_DBG("chan %p credits %u", chan, atomic_get(&chan->rx.credits));
 }
@@ -2319,6 +2334,7 @@ int bt_l2cap_update_conn_param(struct bt_conn *conn,
 {
 	struct bt_l2cap_conn_param_req *req;
 	struct net_buf *buf;
+	int err;
 
 	buf = l2cap_create_le_sig_pdu(NULL, BT_L2CAP_CONN_PARAM_REQ,
 				      get_ident(), sizeof(*req));
@@ -2332,7 +2348,11 @@ int bt_l2cap_update_conn_param(struct bt_conn *conn,
 	req->latency = sys_cpu_to_le16(param->latency);
 	req->timeout = sys_cpu_to_le16(param->timeout);
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	err = bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	if (err) {
+		net_buf_unref(buf);
+		return err;
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -305,10 +305,10 @@ struct net_buf *bt_l2cap_create_rsp(struct net_buf *buf, size_t reserve);
 int bt_l2cap_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 		     bt_conn_tx_cb_t cb, void *user_data);
 
-static inline void bt_l2cap_send(struct bt_conn *conn, uint16_t cid,
-				 struct net_buf *buf)
+static inline int bt_l2cap_send(struct bt_conn *conn, uint16_t cid,
+				struct net_buf *buf)
 {
-	bt_l2cap_send_cb(conn, cid, buf, NULL, NULL);
+	return bt_l2cap_send_cb(conn, cid, buf, NULL, NULL);
 }
 
 /* Receive a new L2CAP PDU from a connection */

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -300,10 +300,7 @@ struct net_buf *bt_l2cap_create_rsp(struct net_buf *buf, size_t reserve);
 
 /* Send L2CAP PDU over a connection
  *
- * Buffer ownership is transferred to stack in case of success
- *
- * Calling this from RX thread is assumed to never fail so the return can be
- * ignored.
+ * Buffer ownership is transferred to stack in case of success.
  */
 int bt_l2cap_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 		     bt_conn_tx_cb_t cb, void *user_data);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1017,8 +1017,11 @@ static void smp_br_timeout(struct k_work *work)
 static void smp_br_send(struct bt_smp_br *smp, struct net_buf *buf,
 			bt_conn_tx_cb_t cb)
 {
-	bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_BR_SMP, buf, cb,
-			 NULL);
+	if (bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_BR_SMP, buf, cb, NULL)) {
+		net_buf_unref(buf);
+		return;
+	}
+
 	k_delayed_work_submit(&smp->work, SMP_TIMEOUT);
 }
 
@@ -1575,7 +1578,9 @@ static int smp_br_error(struct bt_smp_br *smp, uint8_t reason)
 	 * SMP timer is not restarted for PairingFailed so don't use
 	 * smp_br_send
 	 */
-	bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf);
+	if (bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf)) {
+		net_buf_unref(buf);
+	}
 
 	return 0;
 }
@@ -1893,7 +1898,11 @@ static void smp_timeout(struct k_work *work)
 static void smp_send(struct bt_smp *smp, struct net_buf *buf,
 		     bt_conn_tx_cb_t cb, void *user_data)
 {
-	bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf, cb, NULL);
+	if (bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf, cb, NULL)) {
+		net_buf_unref(buf);
+		return;
+	}
+
 	k_delayed_work_submit(&smp->work, SMP_TIMEOUT);
 }
 
@@ -1918,7 +1927,9 @@ static int smp_error(struct bt_smp *smp, uint8_t reason)
 	rsp->reason = reason;
 
 	/* SMP timer is not restarted for PairingFailed so don't use smp_send */
-	bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf);
+	if (bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf)) {
+		net_buf_unref(buf);
+	}
 
 	return 0;
 }
@@ -2875,6 +2886,7 @@ static int smp_send_security_req(struct bt_conn *conn)
 	struct bt_smp *smp;
 	struct bt_smp_security_request *req;
 	struct net_buf *req_buf;
+	int err;
 
 	BT_DBG("");
 	smp = smp_chan_get(conn);
@@ -2922,7 +2934,11 @@ static int smp_send_security_req(struct bt_conn *conn)
 	req->auth_req = get_auth(conn, BT_SMP_AUTH_DEFAULT);
 
 	/* SMP timer is not restarted for SecRequest so don't use smp_send */
-	bt_l2cap_send(conn, BT_L2CAP_CID_SMP, req_buf);
+	err = bt_l2cap_send(conn, BT_L2CAP_CID_SMP, req_buf);
+	if (err) {
+		net_buf_unref(req_buf);
+		return err;
+	}
 
 	atomic_set_bit(smp->flags, SMP_FLAG_SEC_REQ);
 	atomic_set_bit(smp->allowed_cmds, BT_SMP_CMD_PAIRING_REQ);

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -39,11 +39,14 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 	return -ENOTSUP;
 }
 
-static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *req_buf)
 {
 	struct bt_conn *conn = chan->conn;
 	struct bt_smp_pairing_fail *rsp;
 	struct bt_smp_hdr *hdr;
+	struct net_buf *buf;
+
+	ARG_UNUSED(req_buf);
 
 	/* If a device does not support pairing then it shall respond with
 	 * a Pairing Failed command with the reason set to "Pairing Not
@@ -60,7 +63,9 @@ static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	rsp = net_buf_add(buf, sizeof(*rsp));
 	rsp->reason = BT_SMP_ERR_PAIRING_NOTSUPP;
 
-	bt_l2cap_send(conn, BT_L2CAP_CID_SMP, buf);
+	if (bt_l2cap_send(conn, BT_L2CAP_CID_SMP, buf)) {
+		net_buf_unref(buf);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Fix buffer leak in L2CAP and SMP when attempting to send over a
a connection that has been disconnected.
Both L2CAP and SMP now have ownership of the buffer in case of failure
to send it and need to unref it in case of send failure.

Change the return type of bt_l2cap_send since the user of this function
has to handle releasing of the buffer when this fails.

Regression from: a77f809