### PR TITLE
Fix x_nucleo_iks02a1 microphone test

### DIFF
--- a/drivers/audio/Kconfig
+++ b/drivers/audio/Kconfig
@@ -42,7 +42,7 @@ if AUDIO_DMIC
 
 config AUDIO_DMIC_INIT_PRIORITY
 	int "Init priority"
-	default 60
+	default 80
 	help
 	  Audio Digital Microphone device driver initialization priority.
 

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -869,7 +869,7 @@ static const struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 		.channel_direction = src_dev##_TO_##dest_dev,		\
 		.source_data_size = 2,  /* 16bit default */		\
 		.dest_data_size = 2,    /* 16bit default */		\
-		.source_burst_length = 0, /* SINGLE transfer */		\
+		.source_burst_length = 1, /* SINGLE transfer */		\
 		.dest_burst_length = 1,					\
 		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
 	 DT_DMAS_CELL_BY_NAME(DT_NODELABEL(i2s##index), dir, channel_config)),\

--- a/samples/shields/x_nucleo_iks02a1/microphone/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/microphone/README.rst
@@ -18,13 +18,14 @@ Requirements
 ************
 
 This sample communicates over I2C with the X-NUCLEO-IKS02A1 shield
-stacked on a board with an Arduino connector. The board's I2C must be
-configured for the I2C Arduino connector (both for pin muxing
-and device tree). See for example the :ref:`nucleo_f411re_board` board
-source code:
+stacked on a board with an Arduino connector.
 
-- :zephyr_file:`boards/arm/nucleo_f411re/nucleo_f411re.dts`
-- :zephyr_file:`boards/arm/nucleo_f411re/pinmux.c`
+.. note::
+
+   Please note that, in order to make the shield working on top of this board,
+   it is needed to have SB24 and SB29 solder bridges properly closed. In this way
+   the PDM microphone clock and data lines get connected to SPI clock and MOSI.
+   Similar consideration may apply to other boards as well.
 
 References
 **********
@@ -44,19 +45,18 @@ To build the sample you can use following command:
    :goals: build
    :compact:
 
-Please note that, in order to make the shield working on top of this board, it is needed to have
-SB24 and SB29 solder bridges properly closed. In this way the PDM
-microphone clock and data lines get connected to SPI clock and MOSI.
-Similar consideration may apply to other boards as well.
+.. note::
 
-One of the things that must be verified before building the sample is the I2S output clock frequency
-configuration. For example, for nucleo_f441re board, we have the following shield file that
-configures the I2SPLL and have a dependency on HSE/HSI:
-:zephyr_file:`boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.defconfig`
+   In case a different board is used, one of the things that must be verified before
+   building the sample is the I2S output clock frequency configuration. For example,
+   for nucleo_f411re board, we have the following file that configures the I2SPLL and
+   have a dependency on HSE/HSI:
+   :zephyr_file:`boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.defconfig`
 
-The user is invited to to verify which osci is configured on the used host board defconfig file
-and calculate the final I2SClk frequency:
-:zephyr_file:`boards/arm/nucleo_f411re/nucleo_f411re_defconfig`
+   The user is invited to to verify which osci is configured on the used host board
+   defconfig file and calculate the final I2SClk frequency, e.g.
+   :zephyr_file:`boards/arm/nucleo_f411re/nucleo_f411re.dts`
+
 
 Sample Output
 =============
@@ -91,7 +91,7 @@ as a USB CDC class, and will use ``/dev/ttyACM0``
 device for communication. The ``/dev/ttyACM0`` port
 must be configured in raw mode to avoid having
 special characters (such as :kbd:`CTRL-Z` or :kbd:`CTRL-D`)
-processed or 'cooked' out.
+processed and 'cooked out'.
 
 .. code-block:: console
 
@@ -99,9 +99,20 @@ processed or 'cooked' out.
    cat /dev/ttyACM0 > /tmp/sound.raw
    dos2unix -f /tmp/sound.raw
 
-.. note:: The dos2unix command is used to recover the situation in which the character 0x0a is
+.. note::
+
+   The dos2unix command is used to recover the situation in which the character 0x0a is
    interpreted as NL and an 0x0d (CR) is added. If you don't remove it the audio stream would
    get corrupted.
+
+.. warning::
+
+   The /tmp/sound.raw file final size should result exactly of 32000 byte, but sometimes may
+   happen that 1 or 2 spurious 0x00 bytes are put at the beginning. In this case the user
+   may get rid of them using the following linux command (change ``skip`` value according
+   to number of spurious bytes to be removed):
+
+   dd if=sound.raw of=sound_clean.raw bs=1 skip=1
 
 
 ASCII PCM Output


### PR DESCRIPTION
Few issues fixed at various level, including i2s, audio_dmic and sample documentations that was preventing the iks02a1 mic sample code to be used properly.