### PR TITLE
drivers: uart_sam0: add support for collision detection error

### DIFF
--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -27,6 +27,10 @@ properties:
       required: true
       description: Transmit Data Pinout
 
+    collision-detection:
+      type: boolean
+      description: Enable collision detection for half-duplex mode.
+
     dmas:
       description: |
         Optional TX & RX dma specifiers.  Each specifier will have a phandle

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -167,6 +167,16 @@ enum uart_rx_stop_reason {
 	 * start time + data bits + parity + stop bits.
 	 */
 	UART_BREAK = (1 << 3),
+	/**
+	 * @brief Collision error
+	 *
+	 * This error is raised when transmitted data does not match
+	 * received data. Typically this is useful in scenarios where
+	 * the TX and RX lines maybe connected together such as
+	 * RS-485 half-duplex. This error is only valid on UARTs that
+	 * support collision checking.
+	 */
+	UART_ERROR_COLLISION = (1 << 4),
 };
 
 /** @brief UART TX event data. */


### PR DESCRIPTION
This PR adds support for UART collision error to sam0 uart driver.

Certain uarts support collision detection. This is mainly used in half-duplex scenarios, like RS-485 and raises an error when the bits output on the TX line do not match the bits received on the RX line.

Automatic collision detection in sam0_uart can be enabled by setting collision-detection proprety for in the dts file. If the transmitted bit does not match the received bit an error is raised.