### PR TITLE
arm: cortex-m: introduce option to allow non-blocking secure calls

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -215,6 +215,16 @@ config ARM_NONSECURE_FIRMWARE
 	  resources of the Cortex-M MCU, and, therefore, it shall avoid
 	  accessing them.
 
+config ARM_NONSECURE_NON_BLOCK_SECURE_FUNCTION_CALLS
+	bool "Allow secure function calls to be preempted "
+	depends on ARM_NONSECURE_FIRMWARE
+	help
+	  When enabled, this option indicates that preemptible Zephyr
+	  threads performing secure function calls, are allowed to be
+	  preempted. When disabled, the option indicates that such
+	  threads many not be context-switched-out while doing a Secure
+	  function call.
+
 choice
 	prompt "Floating point ABI"
 	default FP_HARDABI

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -28,6 +28,7 @@ menuconfig BUILD_WITH_TFM
 	depends on ARM_TRUSTZONE_M
 	select BUILD_OUTPUT_HEX
 	imply INIT_ARCH_HW_AT_BOOT
+	imply ARM_NONSECURE_NON_BLOCK_SECURE_FUNCTION_CALLS
 	help
 	  When enabled, this option instructs the Zephyr build process to
 	  additionaly generate a TF-M image for the Secure Execution
@@ -38,10 +39,13 @@ menuconfig BUILD_WITH_TFM
 	  TF-M and Zephyr images, as well as the veneer object file that links
 	  them, are generated during the normal Zephyr build process.
 
-	  Note:
+	  Notes:
 	    Building with the "_nonsecure" BOARD variant (e.g.
 	    "mps2_an521_nonsecure") ensures that
 	    CONFIG_TRUSTED_EXECUTION_NONSECURE ie enabled.
+
+	    By default we allow Zephyr preemptible threads be preempted
+	    while performing a secure function call.
 
 if BUILD_WITH_TFM
 


### PR DESCRIPTION
Introduce a Kconfig option to allow Secure function calls
to be pre-empted.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>