### PR TITLE
doc: fix typo in driver documentation

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -486,7 +486,7 @@ Device Model Drivers with multiple MMIO regions
 ===============================================
 
 Some drivers may have multiple MMIO regions. In addition, some drivers
-may already be implementing a form of inheritance whice requires some other
+may already be implementing a form of inheritance which requires some other
 data to be placed first in the  ``config_info`` and ``driver_data``
 structures.
 


### PR DESCRIPTION
'whice' is replaced with 'which', which makes more sense in the
given context.

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>