### PR TITLE
Bluetooth: controller: Fix regression in central initiated terminate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -913,6 +913,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_feature.features_peer = 0;
 		conn->llcp_version.req = conn->llcp_version.ack = 0;
 		conn->llcp_version.tx = conn->llcp_version.rx = 0;
+		conn->llcp_terminate.req = conn->llcp_terminate.ack = 0;
 		conn->llcp_terminate.reason_final = 0;
 		/* NOTE: use allocated link for generating dedicated
 		 * terminate ind rx node

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -264,6 +264,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_feature.features_peer = 0;
 	conn->llcp_version.req = conn->llcp_version.ack = 0;
 	conn->llcp_version.tx = conn->llcp_version.rx = 0U;
+	conn->llcp_terminate.req = conn->llcp_terminate.ack = 0U;
 	conn->llcp_terminate.reason_final = 0U;
 	/* NOTE: use allocated link for generating dedicated
 	 * terminate ind rx node


### PR DESCRIPTION
Fix regression in central initiated terminate introduced in
commit 3a8078594799 ("Bluetooth: controller: Fix connection
terminate to happen on event done").

The regression caused an additional central connection event
transmitting PDU  after the previous connection event had
received acknowledgment for the terminate_ind PDU from the
peripheral.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>