### PR TITLE
drivers/spi: STM32: This solves SPI infinite loop on Transceive

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -294,8 +294,14 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		spi_context_update_tx(&data->ctx, 2, 1);
 	}
 
-	while (!ll_func_rx_is_not_empty(spi)) {
-		/* NOP */
+	if (data->ctx.rx_buf) {
+		while (!ll_func_rx_is_not_empty(spi)) {
+			/* NOP */
+		}
+	} else {
+		while (!ll_func_tx_is_empty(spi)) {
+			/* NOP */
+		}
 	}
 
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {


### PR DESCRIPTION
This commit loops on rx not empty only if rx_buf is enabled.
And if rx_buf is not enabled, it loops on tx empty status.

This PR solve #33169.
Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>