### PR TITLE
api: gpio: do not support INT flags in gpio_pin_configure

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -235,6 +235,10 @@ Drivers and Sensors
     :c:macro:`GPIO_DT_SPEC_INST_GET`, and :c:macro:`GPIO_DT_SPEC_INST_GET_OR`
   * New helper functions for using ``gpio_dt_spec`` values:
     :c:func:`gpio_pin_configure_dt`, :c:func:`gpio_pin_interrupt_configure_dt`
+  * Remove support for ``GPIO_INT_*`` flags in :c:func:`gpio_pin_configure()`.
+    The feature has been deprecated in the Zephyr 2.2 release. The interrupt
+    flags are now accepted by :c:func:`gpio_pin_interrupt_configure()`
+    function only.
 
 * Hardware Info
 

--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -7,13 +7,16 @@
 #include <drivers/gpio.h>
 #include <syscall_handler.h>
 
-static inline int z_vrfy_gpio_config(const struct device *port,
-				     gpio_pin_t pin, gpio_flags_t flags)
+static inline int z_vrfy_gpio_pin_configure(const struct device *port,
+					    gpio_pin_t pin,
+					    gpio_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, pin_configure));
-	return z_impl_gpio_config((const struct device *)port, pin, flags);
+	return z_impl_gpio_pin_configure((const struct device *)port,
+					  pin,
+					  flags);
 }
-#include <syscalls/gpio_config_mrsh.c>
+#include <syscalls/gpio_pin_configure_mrsh.c>
 
 static inline int z_vrfy_gpio_port_get_raw(const struct device *port,
 					   gpio_port_value_t *value)


### PR DESCRIPTION
To keep compatibility between the old GPIO API implementation and a new
one introduced in the Zephyr 2.2.0 release the gpio_pin_configure()
function was accepting interrupt flags. In the new API implementation
interrupt flags are only accepted by gpio_pin_interrupt_configure()
function.

This temporary support for INT flags in gpio_pin_configure should have
been removed in the Zephyr 2.4.0 release.