### PR TITLE
tests: arch: arm: no_multithreading: Limit platforms allowed

### DIFF
--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -5,4 +5,4 @@ common:
 tests:
   arch.arm.no_multithreading:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
-    platform_exclude: degu_evk
+    platform_allow: qemu_cortex_m0 qemu_cortex_m3 mps2_an385 mps2_an521


### PR DESCRIPTION
When multithreading is off, kernel source files like sem.c (samphore
implementation) are not present in the build. Some platforms by default
fetch modules or drivers that are using multithreading primitives and
because of that fails to compile when multithreading is off.

Limit the test to only qemu platforms since test is arch specific.

Fixes #34739.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>