### PR TITLE
logging: Enable SWO support for nRF SOCs

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -29,6 +29,7 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9160             NRF9160_XXAA)
 
 # Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
 zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
+zephyr_compile_definitions_ifdef(CONFIG_LOG_BACKEND_SWO ENABLE_SWO)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_NRF51X  ${MDK_DIR}/system_nrf51.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_NRF52805       ${MDK_DIR}/system_nrf52805.c)


### PR DESCRIPTION
The nRF SOCs declare support for SWO using the HAS_SWO define. In
addition, the SWO pin has to be configured at runtime, which is done
through the Nordic HAL by defining ENABLE_SWO.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>