### PR TITLE
Bluetooth: Host: Disable BLE scan before setting random address

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -382,7 +382,6 @@ static void le_update_private_addr(void)
 	bool scan_enabled = false;
 
 	if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN) &&
 	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	      atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED))) {
 		bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
@@ -1535,10 +1534,9 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			/* If active scan with NRPA is ongoing refresh NRPA */
 			if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-			    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-			    atomic_test_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN)) {
+			    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
 				scan_enabled = true;
-				bt_le_scan_set_enable(false);
+				bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 			}
 #endif /* defined(CONFIG_BT_OBSERVER) */
 			err = bt_id_set_adv_private_addr(adv);
@@ -1546,7 +1544,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 
 #if defined(CONFIG_BT_OBSERVER)
 			if (scan_enabled) {
-				bt_le_scan_set_enable(true);
+				bt_le_scan_set_enable(BT_HCI_LE_SCAN_ENABLE);
 			}
 #endif /* defined(CONFIG_BT_OBSERVER) */
 		} else {

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -337,6 +337,8 @@ static void test_friend_group(void)
 
 	k_sleep(K_SECONDS(2));
 
+	evt_clear(FRIEND_POLLED);
+
 	/* Send a group message to the LPN */
 	ASSERT_OK(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),
 		  "Failed to send to LPN");
@@ -399,7 +401,7 @@ static void test_lpn_msg_frnd(void)
 	evt_clear(LPN_POLLED);
 
 	/* Give friend time to prepare the message */
-	k_sleep(K_SECONDS(2));
+	k_sleep(K_SECONDS(3));
 
 	/* Receive unsegmented message */
 	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
@@ -407,7 +409,7 @@ static void test_lpn_msg_frnd(void)
 		  "Failed to receive message");
 
 	/* Give friend time to prepare the message */
-	k_sleep(K_SECONDS(2));
+	k_sleep(K_SECONDS(3));
 
 	/* Receive segmented message */
 	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
@@ -623,6 +625,13 @@ static void test_lpn_group(void)
 		  "LPN not established");
 	evt_clear(LPN_POLLED);
 
+	/* Send a message to the other mesh device to indicate that the
+	 * friendship has been established. Give the other device a time to
+	 * start up first.
+	 */
+	k_sleep(K_MSEC(10));
+	ASSERT_OK(bt_mesh_test_send(other_cfg.addr, 5, 0, K_SECONDS(1)));
+
 	k_sleep(K_SECONDS(5));
 	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
 
@@ -793,6 +802,9 @@ static void test_other_group(void)
 	bt_mesh_test_setup();
 
 	ASSERT_OK(bt_mesh_va_add(test_va_uuid, &virtual_addr));
+
+	/* Wait for LPN to send us a message after establishing the friendship */
+	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(1)));
 
 	/* Send a group message to the LPN */
 	ASSERT_OK(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),


### PR DESCRIPTION
According to Bluetooth core specification v5.2, if Host set
random address when any of scanning (passive or active), the
Controller shall return the error code Command Disallowed (0x0C).