### PR TITLE
Renesas R-Car: Add Pinmux driver

### DIFF
--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -51,6 +51,7 @@
 };
 
 &can0 {
+	pinctrl-0 = <&can0_data_a_tx &can0_data_a_rx>;
 	status = "okay";
 };
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -179,6 +179,8 @@ struct can_rcar_cfg {
 	uint8_t phase_seg1;
 	uint8_t phase_seg2;
 	uint16_t sample_point;
+	const struct rcar_pin *pin_list;
+	uint8_t pin_list_size;
 };
 
 struct can_rcar_tx_cb {
@@ -863,6 +865,8 @@ static int can_rcar_init(const struct device *dev)
 	data->state = CAN_ERROR_ACTIVE;
 	data->state_change_isr = NULL;
 
+	pinmux_rcar_set_pingroup(config->pin_list, config->pin_list_size);
+
 	/* reset the registers */
 	ret = clock_control_off(config->clock_dev,
 				(clock_control_subsys_t *)&config->mod_clk);
@@ -1012,6 +1016,7 @@ static const struct can_driver_api can_rcar_driver_api = {
 /* Device Instantiation */
 #define CAN_RCAR_INIT(n)							\
 	static void can_rcar_##n##_init(const struct device *dev);		\
+	static const struct rcar_pin pins_can##n[] = RCAR_DT_INST_PINS(n);      \
 	static const struct can_rcar_cfg can_rcar_cfg_##n = {			\
 		.reg_addr = DT_INST_REG_ADDR(n),				\
 		.reg_size = DT_INST_REG_SIZE(n),				\
@@ -1032,6 +1037,8 @@ static const struct can_driver_api can_rcar_driver_api = {
 		.phase_seg1 = DT_INST_PROP_OR(n, phase_seg1, 0),		\
 		.phase_seg2 = DT_INST_PROP_OR(n, phase_seg2, 0),		\
 		.sample_point = DT_INST_PROP_OR(n, sample_point, 0),		\
+		.pin_list = pins_can##n,                                        \
+		.pin_list_size = ARRAY_SIZE(pins_can##n),		        \
 	};									\
 	static struct can_rcar_data can_rcar_data_##n;				\
 										\

--- a/dts/arm/renesas/gen3/r8a77951.dtsi
+++ b/dts/arm/renesas/gen3/r8a77951.dtsi
@@ -5,3 +5,36 @@
  */
 
 #include <renesas/gen3/rcar_gen3_cr7.dtsi>
+#include <dt-bindings/pinctrl/rcar-pinctrl.h>
+
+&pfc {
+	can0_data_a_tx: can0_data_a_tx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(4,6,8)
+					RCAR_PINMUX_GPSR(1,23,1) >;
+	};
+
+	can0_data_a_rx: can0_data_a_rx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(4,7,8)
+					RCAR_PINMUX_GPSR(1,24,1) >;
+	};
+
+	scif1_data_a_tx: scif1_data_a_tx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(12,4,0)
+					RCAR_PINMUX_GPSR(5,6,1) >;
+	};
+
+	scif1_data_a_rx: scif1_data_a_rx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(12,3,0)
+					RCAR_PINMUX_GPSR(5,5,1) >;
+	};
+
+	scif2_data_a_tx: scif2_data_a_tx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(13,0,0)
+					RCAR_PINMUX_GPSR(5,10,1) >;
+	};
+
+	scif2_data_a_rx: scif2_data_a_rx {
+		renesas,rcar-pins = < RCAR_PINMUX_IPSR(13,1,0)
+					RCAR_PINMUX_GPSR(5,11,1) >;
+	};
+};

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -65,6 +65,11 @@
 			label = "gpio6";
 		};
 
+		pfc: pin-controller@e6060000 {
+			compatible = "renesas,rcar-pinmux";
+			reg = <0xe6060000 0x508>;
+		};
+
 		cmt0: timer@e60f0500 {
 			compatible = "renesas,rcar-cmt";
 			interrupt-parent = <&gic>;

--- a/dts/bindings/can/renesas,rcar-can.yaml
+++ b/dts/bindings/can/renesas,rcar-can.yaml
@@ -13,3 +13,12 @@ properties:
 
     clocks:
       required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        GPIO pin configuration for CAN RX and TX. The phandles are
+        expected to reference pinctrl nodes, e.g.
+
+          pinctrl-0 = <&can0_data_tx &can0_data_rx>;

--- a/dts/bindings/pinctrl/renesas,rcar-pinmux.yaml
+++ b/dts/bindings/pinctrl/renesas,rcar-pinmux.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 IoT.bzh
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas R-Car pinmux node
+
+compatible: "renesas,rcar-pinmux"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+child-binding:
+  description: |
+     This binding gives a base representation of the R-Car pins configuration
+  properties:
+    renesas,rcar-pins:
+      type: array
+      required: true

--- a/include/dt-bindings/pinctrl/rcar-pinctrl.h
+++ b/include/dt-bindings/pinctrl/rcar-pinctrl.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RCAR_PINCTRL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RCAR_PINCTRL_H_
+
+#define RCAR_PINMUX_IPSR(bank, cell, func) ((bank << 10) | (cell << 4) | (func))
+#define RCAR_PINMUX_GPSR(bank, bit, val)   ((bank << 7)  | (bit << 1)  | val)
+
+#endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RCAR_PINCTRL_H_ */

--- a/soc/arm/renesas_rcar/gen3/CMakeLists.txt
+++ b/soc/arm/renesas_rcar/gen3/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 zephyr_sources(
   soc.c
+  pinmux_rcar.c
 )

--- a/soc/arm/renesas_rcar/gen3/Kconfig.series
+++ b/soc/arm/renesas_rcar/gen3/Kconfig.series
@@ -10,5 +10,12 @@ config SOC_SERIES_RCAR_GEN3
 	select CPU_HAS_DCLS
 	select SOC_FAMILY_RCAR
 	select CLOCK_CONTROL_RCAR_CPG_MSSR if CLOCK_CONTROL
+	select PINMUX_RCAR if PINMUX
 	help
 	  Enable support for Renesas RCar Gen3 SoC series
+
+config PINMUX_RCAR
+	bool "Renesas RCar Gen3 pinmux driver"
+	depends on SOC_SERIES_RCAR_GEN3
+	help
+	  Enable the Renesas RCar Gen3 pinmux driver.

--- a/soc/arm/renesas_rcar/gen3/pinmux-rcar.h
+++ b/soc/arm/renesas_rcar/gen3/pinmux-rcar.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _PINMUX_RCAR__H_
+#define _PINMUX_RCAR__H_
+#include <stdint.h>
+#include <stdbool.h>
+#include <devicetree.h>
+#include <sys/util.h>
+
+struct rcar_pin {
+	/* select pin function */
+	uint8_t ipsr_bank;      /* bank number 0 - 18 */
+	uint8_t ipsr_shift;     /* bit shift 0 - 28 */
+	uint8_t ipsr_val;       /* choice from 0x0 to 0xF */
+	/* Select gpio or function */
+	uint8_t gpsr_bank;      /* bank number 0 - 7 */
+	uint8_t gpsr_num;       /* pin index < 32 */
+	bool gpsr_val;          /* gpio:false, peripheral:true */
+};
+
+void pinmux_rcar_set_pingroup(const struct rcar_pin *pins, size_t num_pins);
+
+/* Get PIN associated with pinctrl-0 pin at index 'i' */
+#define RCAR_IPSR(node_id, i) \
+	DT_PROP_BY_IDX(DT_PINCTRL_0(node_id, i), renesas_rcar_pins, 0)
+
+/* Get PIN associated with pinctrl-0 pin at index 'i' */
+#define RCAR_GPSR(node_id, i) \
+	DT_PROP_BY_IDX(DT_PINCTRL_0(node_id, i), renesas_rcar_pins, 1)
+
+#define RCAR_DT_PIN(node_id, idx)			\
+	{                                               \
+	  ((RCAR_IPSR(node_id, idx) >> 10) & 0x1F),	\
+	  (((RCAR_IPSR(node_id, idx) >> 4) & 0x7) * 4),	\
+	  ((RCAR_IPSR(node_id, idx) & 0xF)),		\
+	  ((RCAR_GPSR(node_id, idx) >> 7) & 0x7),	\
+	  ((RCAR_GPSR(node_id, idx) >> 1) & 0x1F),	\
+	  ((RCAR_GPSR(node_id, idx) & 0x1)),		\
+	}
+
+#define RCAR_DT_INST_PIN(inst, idx) \
+	RCAR_DT_PIN(DT_DRV_INST(inst), idx)
+
+/* Get the number of pins for pinctrl-0 */
+#define RCAR_DT_NUM_PINS(node_id) DT_NUM_PINCTRLS_BY_IDX(node_id, 0)
+
+#define RCAR_DT_INST_NUM_PINS(inst) \
+	RCAR_DT_NUM_PINS(DT_DRV_INST(inst))
+
+/* internal macro to structure things for use with UTIL_LISTIFY */
+#define RCAR_DT_PIN_ELEM(idx, node_id) RCAR_DT_PIN(node_id, idx),
+
+/* Construct an array intializer for rcar_pin for a device instance */
+#define RCAR_DT_PINS(node_id)					\
+	{ UTIL_LISTIFY(RCAR_DT_NUM_PINS(node_id),		\
+		       RCAR_DT_PIN_ELEM, node_id)		\
+	}
+
+#define RCAR_DT_INST_PINS(inst) \
+	RCAR_DT_PINS(DT_DRV_INST(inst))
+
+#endif /* _PINMUX_RCAR__H_ */

--- a/soc/arm/renesas_rcar/gen3/pinmux_rcar.c
+++ b/soc/arm/renesas_rcar/gen3/pinmux_rcar.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_rcar_pinmux
+
+#include <devicetree.h>
+#include <soc.h>
+#include <device.h>
+
+#define PINMUX_REG_BASE  DT_INST_REG_ADDR(0)
+#define PINMUX_RCAR_PMMR 0x0
+#define PINMUX_RCAR_GPSR 0x100
+#define PINMUX_RCAR_IPSR 0x200
+
+/* Any write to IPSR or GPSR must be precede to a write to PMMR with
+ * the inverse value.
+ */
+static void pinmux_rcar_write(uint32_t offs, uint32_t val)
+{
+	sys_write32(~val, PINMUX_REG_BASE + PINMUX_RCAR_PMMR);
+	sys_write32(val, PINMUX_REG_BASE + offs);
+}
+
+/* Set the pin either in gpio or peripheral */
+static void pinmux_rcar_set_gpsr(uint8_t bank, uint8_t pos, bool peripheral)
+{
+	uint32_t reg = sys_read32(PINMUX_REG_BASE + PINMUX_RCAR_GPSR +
+				  bank * sizeof(uint32_t));
+
+	if (peripheral) {
+		reg |= BIT(pos);
+	} else {
+		reg &= ~BIT(pos);
+	}
+	pinmux_rcar_write(PINMUX_RCAR_GPSR + bank * sizeof(uint32_t), reg);
+}
+
+/* Set peripheral function */
+static void pinmux_rcar_set_ipsr(uint8_t bank, uint8_t shift, uint8_t val)
+{
+	uint32_t reg = sys_read32(PINMUX_REG_BASE + PINMUX_RCAR_IPSR +
+				  bank * sizeof(uint32_t));
+
+	reg &= ~(0xF << shift);
+	reg |= (val << shift);
+	pinmux_rcar_write(PINMUX_RCAR_IPSR + bank * sizeof(uint32_t), reg);
+}
+
+void pinmux_rcar_set_pingroup(const struct rcar_pin *pins, size_t num_pins)
+{
+	size_t i;
+
+	for (i = 0; i < num_pins; i++, pins++) {
+		pinmux_rcar_set_gpsr(pins->gpsr_bank, pins->gpsr_num,
+				     pins->gpsr_val);
+		pinmux_rcar_set_ipsr(pins->ipsr_bank, pins->ipsr_shift,
+				     pins->ipsr_val);
+	}
+}

--- a/soc/arm/renesas_rcar/gen3/soc.h
+++ b/soc/arm/renesas_rcar/gen3/soc.h
@@ -15,4 +15,6 @@
 #define __GIC_PRESENT 0
 #define __TIM_PRESENT 0
 
+#include "pinmux-rcar.h"
+
 #endif /* _SOC__H_ */


### PR DESCRIPTION
This PR allows to select alternate functions for Renesas R-Car multiplexed pins.
With this driver will be able to add CAN and Serial driver.

Each SoC of the gen 3 family will have to define the PFC configuration for a set of pin:
e.g 
can0_data_a, scif1_data_a, scif2_data_a
Then a board will be able to enable these function thanks to pinmux_rcar_set_pingroup.