### PR TITLE
include/drivers/clock_control: stm32: Deprecate use of Kconfig

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -67,6 +67,9 @@
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(80)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
 };
 
 &usart1 {

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -59,6 +59,7 @@
 	clock-frequency = <DT_FREQ_M(32)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
 };
 
 &usart2 {

--- a/boards/arm/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_wb55rg/Kconfig.defconfig
@@ -8,9 +8,6 @@ if BOARD_NUCLEO_WB55RG
 config BOARD
 	default "nucleo_wb55rg"
 
-config CLOCK_STM32_LSE
-	default y
-
 choice STM32_LPTIM_CLOCK
 	default STM32_LPTIM_CLOCK_LSE
 	depends on STM32_LPTIM_TIMER

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -88,6 +88,10 @@
 	status = "okay";
 };
 
+&clk_lse{
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&clk_hse>;
 	clock-frequency = <DT_FREQ_M(32)>;

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -61,7 +61,6 @@
 	};
 };
 
-
 &clk_hsi {
 	status = "okay";
 };

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -44,7 +44,7 @@ config CLOCK_STM32_HSE_CLOCK
 
 config CLOCK_CONTROL_STM32_HAS_DTS
 	bool
-	default y if "$(dt_node_has_prop,rcc,clocks)"
+	default y if "$(dt_node_has_prop,rcc,clocks)" || "$(dt_node_has_prop,rcc,d1cpre)"
 	help
 	  This symbol is added to prevent default use of CLOCK_CONTROL_STM32_* symbols
 	  when board make use of device tree to configure clocks.

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -24,6 +24,23 @@ config CLOCK_CONTROL_STM32_DEVICE_INIT_PRIORITY
 	  is initialized earlier in the startup cycle. If unsure, leave
 	  at default value 1
 
+DT_STM32_HSE_CLOCK := $(dt_nodelabel_path,clk_hse)
+DT_STM32_HSE_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_HSE_CLOCK),clock-frequency)
+
+config CLOCK_STM32_HSE_CLOCK
+	int "HSE clock value"
+	default "$(DT_STM32_HSE_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,clk_hse)"
+	default 8000000
+	help
+	  Value of external high-speed clock (HSE). This symbol could be optionally
+	  configured using device tree by setting "clock-frequency" value of clk_hse
+	  node. For instance:
+	  &clk_hse{
+	  status = "okay";
+	  clock-frequency = <DT_FREQ_M(25)>;
+	  };
+	  Note: Device tree configuration is overridden when current symbol is set:
+	  CONFIG_CLOCK_STM32_HSE_CLOCK=32000000
 choice CLOCK_STM32_SYSCLK_SRC
 	prompt "STM32 System Clock Source"
 
@@ -61,26 +78,6 @@ config CLOCK_STM32_HSE_BYPASS
 	depends on CLOCK_STM32_SYSCLK_SRC_HSE || CLOCK_STM32_PLL_SRC_HSE
 	help
 	  Enable this option to bypass external high-speed clock (HSE).
-
-DT_STM32_HSE_CLOCK := $(dt_nodelabel_path,clk_hse)
-DT_STM32_HSE_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_HSE_CLOCK),clock-frequency)
-
-config CLOCK_STM32_HSE_CLOCK
-	int "HSE clock value"
-	depends on CLOCK_STM32_SYSCLK_SRC_HSE || CLOCK_STM32_PLL_SRC_HSE
-	default "$(DT_STM32_HSE_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,clk_hse)"
-	default 8000000
-	help
-	  Value of external high-speed clock (HSE). This symbol could be optionally
-	  configured using device tree by setting "clock-frequency" value of clk_hse
-	  node. For instance:
-	  &clk_hse{
-	  status = "okay";
-	  clock-frequency = <DT_FREQ_M(25)>;
-	  };
-	  Note: Device tree configuration is overridden when current symbol is set:
-	  CONFIG_CLOCK_STM32_HSE_CLOCK=32000000
-
 
 config CLOCK_STM32_MSI_RANGE
 	int "MSI frequency range"

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -41,6 +41,16 @@ config CLOCK_STM32_HSE_CLOCK
 	  };
 	  Note: Device tree configuration is overridden when current symbol is set:
 	  CONFIG_CLOCK_STM32_HSE_CLOCK=32000000
+
+config CLOCK_CONTROL_STM32_HAS_DTS
+	bool
+	default y if "$(dt_node_has_prop,rcc,clocks)"
+	help
+	  This symbol is added to prevent default use of CLOCK_CONTROL_STM32_* symbols
+	  when board make use of device tree to configure clocks.
+
+if !CLOCK_CONTROL_STM32_HAS_DTS
+
 choice CLOCK_STM32_SYSCLK_SRC
 	prompt "STM32 System Clock Source"
 
@@ -213,6 +223,8 @@ config CLOCK_STM32_AHB4_PRESCALER
 	  64, 128, 256, 512.
 
 endif # !SOC_SERIES_STM32H7X
+
+endif # CLOCK_CONTROL_STM32_HAS_DTS
 
 # Micro-controller Clock output configuration options
 

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -49,7 +49,7 @@ config CLOCK_CONTROL_STM32_HAS_DTS
 	  This symbol is added to prevent default use of CLOCK_CONTROL_STM32_* symbols
 	  when board make use of device tree to configure clocks.
 
-if !CLOCK_CONTROL_STM32_HAS_DTS
+if !CLOCK_CONTROL_STM32_HAS_DTS && !SOC_SERIES_STM32MP1X
 
 choice CLOCK_STM32_SYSCLK_SRC
 	prompt "STM32 System Clock Source"
@@ -222,7 +222,7 @@ config CLOCK_STM32_AHB4_PRESCALER
 	  HCLK4 prescaler, allowed values: 1, 2, 3, 4, 5, 6, 8, 10, 16, 32,
 	  64, 128, 256, 512.
 
-endif # !SOC_SERIES_STM32H7X
+endif # !SOC_SERIES_STM32H7X && !SOC_SERIES_STM32MP1X
 
 endif # CLOCK_CONTROL_STM32_HAS_DTS
 

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -95,13 +95,17 @@
 #endif
 
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_rcc), apb1_prescaler) || \
-	DT_NODE_HAS_PROP(DT_INST(0, st_stm32f0_rcc), apb1_prescaler)
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32f0_rcc), apb1_prescaler) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32wb_rcc), apb1_prescaler) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32wl_rcc), apb1_prescaler)
 #define STM32_APB1_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb1_prescaler)
 #else
 #define STM32_APB1_PRESCALER	CONFIG_CLOCK_STM32_APB1_PRESCALER
 #endif
 
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_rcc), apb2_prescaler)
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_rcc), apb2_prescaler) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32wb_rcc), apb2_prescaler) || \
+	DT_NODE_HAS_PROP(DT_INST(0, st_stm32wl_rcc), apb2_prescaler)
 #define STM32_APB2_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb2_prescaler)
 #elif !DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rcc), st_stm32f0_rcc, okay)
 	/* This should not be defined in F0 binding case */

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -135,7 +135,7 @@
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rcc), st_stm32h7_rcc, okay) && \
-	DT_NODE_HAS_PROP(DT_NODELABEL(rcc), clocks)
+	DT_NODE_HAS_PROP(DT_NODELABEL(rcc), d1cpre)
 #define STM32_D1CPRE	DT_PROP(DT_NODELABEL(rcc), d1cpre)
 #define STM32_HPRE	DT_PROP(DT_NODELABEL(rcc), hpre)
 #define STM32_D2PPRE1	DT_PROP(DT_NODELABEL(rcc), d2ppre1)

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -28,6 +28,65 @@
  * Kconfig related symbols.
  */
 
+#if defined(STM32_AHB_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_APB1_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_APB2_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_AHB3_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_AHB4_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_CPU1_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_CPU2_PRESCALER) || \
+	defined(CONFIG_CLOCK_STM32_PLL_M_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER) || \
+	defined(CONFIG_CLOCK_STM32_PLL_P_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL_Q_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL_R_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL_XTPRE) || \
+	defined(CONFIG_CLOCK_STM32_PLL_MULTIPLIER) || \
+	defined(CONFIG_CLOCK_STM32_PLL_PREDIV1) || \
+	defined(CONFIG_CLOCK_STM32_PLL_PREDIV) || \
+	defined(CONFIG_CLOCK_STM32_PLL_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL) || \
+	defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_HSI) || \
+	defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_HSE) || \
+	defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_MSI) || \
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_MSI) || \
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) || \
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_HSE) || \
+	defined(CONFIG_CLOCK_STM32_PLL_SRC_PLL2) || \
+	defined(CONFIG_CLOCK_STM32_LSE) || \
+	defined(CONFIG_CLOCK_STM32_MSI_RANGE) || \
+	defined(CONFIG_CLOCK_STM32_MSI_PLL_MODE) || \
+	defined(CONFIG_CLOCK_STM32_HSE_BYPASS) || \
+	defined(CONFIG_CLOCK_STM32_D1CPRE) || \
+	defined(CONFIG_CLOCK_STM32_HPRE) || \
+	defined(CONFIG_CLOCK_STM32_D2PPRE1) || \
+	defined(CONFIG_CLOCK_STM32_D2PPRE2) || \
+	defined(CONFIG_CLOCK_STM32_D1PPRE) || \
+	defined(CONFIG_CLOCK_STM32_D3PPRE) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_ENABLE) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_M_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_N_MULTIPLIER) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_P_ENABLE) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_P_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_Q_ENABLE) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_Q_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_R_ENABLE) || \
+	defined(CONFIG_CLOCK_STM32_PLL3_R_DIVISOR) || \
+	defined(CONFIG_CLOCK_STM32_SYSCLK_SRC_CSI) || \
+	defined(CONFIG_CLOCK_STM32_HSI_DIVISOR)
+#warning "Deprecated: Please use device tree for STM32 clock_control configuration"
+/*
+ * Use of Kconfig for STM32 clock_control configuration is deprecated.
+ * It is replaced by use of device tree.
+ * For more information, see:
+ * https://github.com/zephyrproject-rtos/zephyr/pull/34120
+ * https://github.com/zephyrproject-rtos/zephyr/pull/34609
+ * https://github.com/zephyrproject-rtos/zephyr/pull/34701
+ * and
+ * https://github.com/zephyrproject-rtos/zephyr/issues/34633
+ */
+#endif
+
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_rcc), ahb_prescaler) || \
 	DT_NODE_HAS_PROP(DT_INST(0, st_stm32f0_rcc), ahb_prescaler)
 #define STM32_AHB_PRESCALER	DT_PROP(DT_NODELABEL(rcc), ahb_prescaler)


### PR DESCRIPTION
Following introduction of dts based drier configuration (cf #34120,
#32609 and #34701), deprecate Kconfig symbols by generating a warning
when one of these symbols is used.

Requires prior merge of #34701