### PR TITLE
drivers: serial: stm32: Fixes uart_event_tx len calculation

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -923,13 +923,13 @@ void uart_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 
 	(void)k_work_cancel_delayable(&data->dma_tx.timeout_work);
 
-	data->dma_tx.buffer_length = 0;
-
 	if (!dma_get_status(data->dma_tx.dma_dev,
 				data->dma_tx.dma_channel, &stat)) {
 		data->dma_tx.counter = data->dma_tx.buffer_length -
 					stat.pending_length;
 	}
+
+	data->dma_tx.buffer_length = 0;
 
 	irq_unlock(key);
 }


### PR DESCRIPTION
Resetting the dma_tx.buffer_length after the dma_tx.counter calculation, instead of before.
We need to reset the buffer_length when the transmission is finished, but in order to give the correct value to
the uart_event_tx struct, we use the dma_tx.buffer_length in the calculation of the dma_tx.counter, used for the len of the event (number of bytes sent).
I found this problem, when I wanted to use the uart_event_tx.len for freeing the used space inside a ring buffer (ring_buf_get_finish),
and it didn't work, I logged the values of the uart_event_tx struct, and found out it always was 0, because the buffer_length was 0, and the whole buffer
was transmitted (stat.pending_length also 0).
Signed-off-by: Prema Jonathan van Win <grandearbol@gmail.com>

Fixes #35036
