### PR TITLE
serial: nrfx_uarte: check size before writing to buffer

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1452,7 +1452,7 @@ static int uarte_nrfx_fifo_read(const struct device *dev,
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	const struct uarte_nrfx_data *data = get_dev_data(dev);
 
-	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
+	if (size > 0 && nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDRX)) {
 		/* Clear the interrupt */
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
 


### PR DESCRIPTION
NRFX UARTE would write to user supplied buffer on IRQ without checking
whether or not the supplied buffer had available space left to write
one char

Signed-off-by: Arne Edholm <arne.edholm@assaabloy.com>