### PR TITLE
manifest: update trusted-firmware-m to latest upstream

### DIFF
--- a/samples/tfm_integration/psa_level_1/src/main.c
+++ b/samples/tfm_integration/psa_level_1/src/main.c
@@ -23,9 +23,6 @@ static struct cfg_data cfg;
 
 void main(void)
 {
-	/* Initialize the TFM NS interface */
-	tfm_ns_interface_init();
-
 	/* Initialise the logger subsys and dump the current buffer. */
 	log_init();
 

--- a/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   filter: (CONFIG_TFM_BOARD != "") and CONFIG_ARM_NONSECURE_FIRMWARE
-  tags: arm
+  tags: arm tfm
   arch_allow: arm
 tests:
   arch.arm.swap.tz: {}

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
       revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 2c2aa3724a040233095a5c41ab79c8ad36134c8e
+      revision: 51cdecd6f9e6b0aa66da45db22f4b478183d472f
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Synchronize TF-M to the latest ustream main branch.
This brings TF-M support for BL5340 Dev Kit in Zephyr.

The PR fixes also a minor issue in the psa_level1 sample.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>