### PR TITLE
tests: condvar_api: fix permissions to multiple condvar

### DIFF
--- a/tests/kernel/condvar/condvar_api/src/main.c
+++ b/tests/kernel/condvar/condvar_api/src/main.c
@@ -369,7 +369,7 @@ void test_multiple_condvar_wait_wake(void)
 	}
 
 	/* giving time for the other threads to execute */
-	k_yield();
+	k_msleep(10);
 
 	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 		k_thread_create(&multiple_wake_tid[i], multiple_wake_stack[i],
@@ -581,6 +581,7 @@ void test_main(void)
 				      &multiple_tid[i],
 				      &multiple_wake_tid[i],
 				      &multiple_stack[i],
+				      &multiple_condvar[i],
 				      &multiple_wake_stack[i]);
 	}
 	ztest_test_suite(test_condvar,

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -585,6 +585,8 @@ void test_sem_take_timeout_isr(void)
 	k_sem_reset(&simple_sem);
 
 	expect_k_sem_take_nomsg(&simple_sem, SEM_TIMEOUT, 0);
+
+	k_thread_join(&sem_tid_1, K_FOREVER);
 }
 
 /**


### PR DESCRIPTION
The permission to use multiple_condvar is not granted to test
test_condvar_multiple_threads_wait_wake, which results in
bunch or permission error messages, and actually not testing
the conditional variables. This grants the permission to
the those conditional variables to the test threads. Also,
replace the k_yield() with k_msleep() to allow all created
threads time to run. A simply k_yield() might let a few to
run before the next batch of "waking" threads start to run,
resulting in some conditional variables not being initialized
but trying to wake.

Fixes #34777

Signed-off-by: Daniel Leung <daniel.leung@intel.com>