### PR TITLE
pm: device: Several fixes

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -409,14 +409,14 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 }
 
 static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 void *context, pm_device_cb cb, void *arg)
+				 uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
 	switch (ctrl_command) {
-	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+	case DEVICE_PM_SET_POWER_STATE:
+		if (*state == PM_DEVICE_ACTIVE_STATE) {
 			st7789v_exit_sleep(data);
 			data->pm_state = PM_DEVICE_ACTIVE_STATE;
 			ret = 0;
@@ -427,14 +427,14 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 		break;
 	default:
 		ret = -EINVAL;
 	}
 
 	if (cb != NULL) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 	return ret;
 }

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -293,14 +293,14 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    uint32_t ctrl_command,
-					    void *context, pm_device_cb cb,
+					    uint32_t *state, pm_device_cb cb,
 					    void *arg)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != data->pm_state) {
 			ret = entropy_cc13xx_cc26xx_set_power_state(dev,
@@ -308,11 +308,11 @@ static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -186,7 +186,8 @@ void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
 				      uint32_t command,
-				      void *context, pm_device_cb cb, void *arg)
+				      uint32_t *state, pm_device_cb cb,
+				      void *arg)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
 	int ret = 0;
@@ -199,7 +200,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 	}
 
 	if (command == PM_DEVICE_STATE_SET) {
-		if (*(uint32_t *)context == PM_DEVICE_SUSPEND_STATE) {
+		if (*state == PM_DEVICE_SUSPEND_STATE) {
 			LOG_DBG("Suspending");
 
 			ret = net_if_suspend(eth_ctx->iface);
@@ -214,7 +215,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 			ENET_Deinit(eth_ctx->base);
 			clock_control_off(eth_ctx->clock_dev,
 				(clock_control_subsys_t)eth_ctx->clock);
-		} else if (*(uint32_t *)context == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*state == PM_DEVICE_ACTIVE_STATE) {
 			LOG_DBG("Resuming");
 
 			clock_control_on(eth_ctx->clock_dev,
@@ -228,7 +229,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 
 out:
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -570,14 +570,15 @@ static int spi_flash_at45_init(const struct device *dev)
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
 				     uint32_t ctrl_command,
-				     void *context, pm_device_cb cb, void *arg)
+				     uint32_t *state, pm_device_cb cb,
+				     void *arg)
 {
 	struct spi_flash_at45_data *dev_data = get_dev_data(dev);
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);
 	int err = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != dev_data->pm_state) {
 			switch (new_state) {
@@ -607,11 +608,11 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = dev_data->pm_state;
+		*state = dev_data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, err, context, arg);
+		cb(dev, err, state, arg);
 	}
 
 	return err;

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -605,7 +605,7 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     uint32_t ctrl_command,
-				     void *context, pm_device_cb cb, void *arg)
+				     uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct gpio_stm32_data *data = dev->data;
 	uint32_t new_state;
@@ -613,13 +613,13 @@ static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		new_state = *((const uint32_t *)context);
+		new_state = *state;
 		if (new_state != data->power_state) {
 			ret = gpio_stm32_set_power_state(dev, new_state);
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = gpio_stm32_get_power_state(dev);
+		*state = gpio_stm32_get_power_state(dev);
 		break;
 	default:
 		ret = -EINVAL;
@@ -627,7 +627,7 @@ static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -368,13 +368,13 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					void *context, pm_device_cb cb,
+					uint32_t *state, pm_device_cb cb,
 					void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != get_dev_data(dev)->pm_state) {
 			ret = i2c_cc13xx_cc26xx_set_power_state(dev,
@@ -382,11 +382,11 @@ static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = get_dev_data(dev)->pm_state;
+		*state = get_dev_data(dev)->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -215,13 +215,13 @@ static int init_twi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	uint32_t pm_current_state = get_dev_data(dev)->pm_state;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {
@@ -251,11 +251,11 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = get_dev_data(dev)->pm_state;
+		*state = get_dev_data(dev)->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -254,13 +254,13 @@ static int init_twim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	uint32_t pm_current_state = get_dev_data(dev)->pm_state;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {
@@ -291,11 +291,11 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = get_dev_data(dev)->pm_state;
+		*state = get_dev_data(dev)->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -192,7 +192,7 @@ static int arc_v2_irq_unit_get_state(const struct device *dev)
  * @return operation result
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
-				       uint32_t ctrl_command, void *context,
+				       uint32_t ctrl_command, uint32_t *context,
 				       pm_device_cb cb, void *arg)
 {
 	int ret = 0;

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -305,7 +305,7 @@ int ioapic_resume_from_suspend(const struct device *port)
 */
 static int ioapic_device_ctrl(const struct device *dev,
 			      uint32_t ctrl_command,
-			      void *context, pm_device_cb cb, void *arg)
+			      uint32_t *context, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -404,18 +404,18 @@ int loapic_resume(const struct device *port)
 */
 static int loapic_device_ctrl(const struct device *port,
 			      uint32_t ctrl_command,
-			      void *context, pm_device_cb cb, void *arg)
+			      uint32_t *context, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*((uint32_t *)context) == PM_DEVICE_SUSPEND_STATE) {
+		if (*context == PM_DEVICE_SUSPEND_STATE) {
 			ret = loapic_suspend(port);
-		} else if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*context == PM_DEVICE_ACTIVE_STATE) {
 			ret = loapic_resume(port);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = loapic_device_power_state;
+		*context = loapic_device_power_state;
 	}
 
 	if (cb) {

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -317,25 +317,25 @@ static int pwm_nrfx_set_power_state(uint32_t new_state,
 
 static int pwm_nrfx_pm_control(const struct device *dev,
 			       uint32_t ctrl_command,
-			       void *context,
+			       uint32_t *state,
 			       uint32_t *current_state)
 {
 	int err = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *((const uint32_t *)state);
 
 		if (new_state != (*current_state)) {
 			err = pwm_nrfx_set_power_state(new_state,
 						       *current_state,
 						       dev);
 			if (!err) {
-				(*current_state) = new_state;
+				*current_state = new_state;
 			}
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = (*current_state);
+		*state = *current_state;
 	}
 
 	return err;
@@ -344,16 +344,16 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 #define PWM_NRFX_PM_CONTROL(idx)					\
 	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,	\
 					       uint32_t ctrl_command,	\
-					       void *context,		\
+					       uint32_t *state,		\
 					       pm_device_cb cb,		\
 					       void *arg)		\
 	{								\
 		static uint32_t current_state = PM_DEVICE_ACTIVE_STATE;	\
 		int ret = 0;                                            \
-		ret = pwm_nrfx_pm_control(dev, ctrl_command, context,	\
+		ret = pwm_nrfx_pm_control(dev, ctrl_command, state,	\
 					   &current_state);		\
 		if (cb) {                                               \
-			cb(dev, ret, context, arg);                     \
+			cb(dev, ret, state, arg);                       \
 		}                                                       \
 		return ret;                                             \
 	}

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -520,7 +520,7 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 }
 
 static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
@@ -530,14 +530,14 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		new_state = *((const uint32_t *)context);
+		new_state = *state;
 		if (new_state != current_state) {
 			status = lis2mdl_set_power_state(lis2mdl, config,
 							new_state);
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = current_state;
+		*state = current_state;
 		break;
 	default:
 		LOG_ERR("Got unknown power management control command");
@@ -545,7 +545,7 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 	}
 
 	if (cb) {
-		cb(dev, status, context, arg);
+		cb(dev, status, state, arg);
 	}
 
 	return status;

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -218,7 +218,7 @@ static int qdec_nrfx_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 
 static int qdec_nrfx_pm_get_state(struct qdec_nrfx_data *data,
-				  uint32_t                 *state)
+				  uint32_t *state)
 {
 	unsigned int key = irq_lock();
 	*state = data->pm_state;
@@ -228,7 +228,7 @@ static int qdec_nrfx_pm_get_state(struct qdec_nrfx_data *data,
 }
 
 static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
-				  uint32_t                  new_state)
+				  uint32_t new_state)
 {
 	uint32_t old_state;
 	unsigned int key;
@@ -268,7 +268,7 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 
 static int qdec_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;
 	int err;
@@ -277,11 +277,11 @@ static int qdec_nrfx_pm_control(const struct device *dev,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_GET:
-		err = qdec_nrfx_pm_get_state(data, context);
+		err = qdec_nrfx_pm_get_state(data, state);
 		break;
 
 	case PM_DEVICE_STATE_SET:
-		err = qdec_nrfx_pm_set_state(data, *((uint32_t *)context));
+		err = qdec_nrfx_pm_set_state(data, *state);
 		break;
 
 	default:
@@ -290,7 +290,7 @@ static int qdec_nrfx_pm_control(const struct device *dev,
 	}
 
 	if (cb) {
-		cb(dev, err, context, arg);
+		cb(dev, err, state, arg);
 	}
 
 	return err;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -444,13 +444,13 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 void *context, pm_device_cb cb,
+					 uint32_t *state, pm_device_cb cb,
 					 void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != get_dev_data(dev)->pm_state) {
 			ret = uart_cc13xx_cc26xx_set_power_state(dev,
@@ -458,11 +458,11 @@ static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = get_dev_data(dev)->pm_state;
+		*state = get_dev_data(dev)->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -470,23 +470,23 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 
 /* Implements the device power management control functionality */
 static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 void *context, pm_device_cb cb, void *arg)
+				 uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		ret = uart_npcx_set_power_state(dev, *((uint32_t *)context));
+		ret = uart_npcx_set_power_state(dev, *state);
 		break;
 	case PM_DEVICE_STATE_GET:
-		ret = uart_npcx_get_power_state(dev, (uint32_t *)context);
+		ret = uart_npcx_get_power_state(dev, state);
 		break;
 	default:
 		ret = -EINVAL;
 	}
 
 	if (cb != NULL) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 	return ret;
 }

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1158,12 +1158,12 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 
 static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	static uint32_t current_state = PM_DEVICE_ACTIVE_STATE;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != current_state) {
 			uart_nrfx_set_power_state(dev, new_state);
@@ -1171,11 +1171,11 @@ static int uart_nrfx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = current_state;
+		*state = current_state;
 	}
 
 	if (cb) {
-		cb(dev, 0, context, arg);
+		cb(dev, 0, state, arg);
 	}
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1863,23 +1863,23 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 
 static int uarte_nrfx_pm_control(const struct device *dev,
 				 uint32_t ctrl_command,
-				 void *context, pm_device_cb cb, void *arg)
+				 uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != data->pm_state) {
 			uarte_nrfx_set_power_state(dev, new_state);
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, 0, context, arg);
+		cb(dev, 0, state, arg);
 	}
 
 	return 0;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1461,24 +1461,24 @@ static int uart_stm32_set_power_state(const struct device *dev,
  */
 static int uart_stm32_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 void *context, pm_device_cb cb,
+					 uint32_t *state, pm_device_cb cb,
 					 void *arg)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != data->pm_state) {
 			uart_stm32_set_power_state(dev, new_state);
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, 0, context, arg);
+		cb(dev, 0, state, arg);
 	}
 
 	return 0;

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -251,13 +251,13 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					void *context, pm_device_cb cb,
+					uint32_t *state, pm_device_cb cb,
 					void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != get_dev_data(dev)->pm_state) {
 			ret = spi_cc13xx_cc26xx_set_power_state(dev,
@@ -265,11 +265,11 @@ static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = get_dev_data(dev)->pm_state;
+		*state = get_dev_data(dev)->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -286,14 +286,14 @@ static int init_spi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {
@@ -320,11 +320,11 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -334,14 +334,14 @@ static int init_spim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)context);
+		uint32_t new_state = *state;
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {
@@ -368,11 +368,11 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		}
 	} else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -32,7 +32,7 @@ int __weak sys_clock_driver_init(const struct device *dev)
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
-			       void *context, pm_device_cb cb, void *arg)
+			       uint32_t *context, pm_device_cb cb, void *arg)
 {
 	return -ENOTSUP;
 }

--- a/include/device.h
+++ b/include/device.h
@@ -387,7 +387,7 @@ struct device {
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
 	int (*pm_control)(const struct device *dev, uint32_t command,
-				 void *context, pm_device_cb cb, void *arg);
+				 uint32_t *state, pm_device_cb cb, void *arg);
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;
 #endif

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -78,7 +78,7 @@ struct device;
 #define PM_DEVICE_STATE_GET       2
 
 typedef void (*pm_device_cb)(const struct device *dev,
-			     int status, void *context, void *arg);
+			     int status, uint32_t *state, void *arg);
 
 /**
  * @brief Device PM info

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -96,7 +96,7 @@ struct pm_device {
 	/** Device usage count */
 	atomic_t usage;
 	/** Device idle internal power state */
-	atomic_t fsm_state;
+	atomic_t state;
 	/** Work object for asynchronous calls */
 	struct k_work_delayable work;
 	/** Event conditional var to listen to the sync request events */

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -87,7 +87,7 @@ struct pm_device {
 	/** Pointer to the device */
 	const struct device *dev;
 	/** Lock to synchronize the get/put operations */
-	struct k_sem lock;
+	struct k_spinlock lock;
 	/* Following are packed fields protected by #lock. */
 	/** Device pm enable flag */
 	bool enable : 1;

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -98,11 +98,9 @@ struct pm_device {
 	/** Device idle internal power state */
 	atomic_t fsm_state;
 	/** Work object for asynchronous calls */
-	struct k_work work;
-	/** Event object to listen to the sync request events */
-	struct k_poll_event event;
-	/** Signal to notify the Async API callers */
-	struct k_poll_signal signal;
+	struct k_work_delayable work;
+	/** Event conditional var to listen to the sync request events */
+	struct k_condvar condvar;
 };
 
 /** Bit position in device_pm::atomic_flags that records whether the

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -31,11 +31,7 @@ static inline void device_pm_state_init(const struct device *dev)
 	*dev->pm = (struct pm_device){
 		.usage = ATOMIC_INIT(0),
 		.lock = Z_SEM_INITIALIZER(dev->pm->lock, 1, 1),
-		.signal = K_POLL_SIGNAL_INITIALIZER(dev->pm->signal),
-		.event = K_POLL_EVENT_INITIALIZER(
-			K_POLL_TYPE_SIGNAL,
-			K_POLL_MODE_NOTIFY_ONLY,
-			&dev->pm->signal),
+		.condvar = Z_CONDVAR_INITIALIZER(dev->pm->condvar),
 	};
 #endif /* CONFIG_PM_DEVICE */
 }

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -30,7 +30,7 @@ static inline void device_pm_state_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 	*dev->pm = (struct pm_device){
 		.usage = ATOMIC_INIT(0),
-		.lock = Z_SEM_INITIALIZER(dev->pm->lock, 1, 1),
+		.lock = {},
 		.condvar = Z_CONDVAR_INITIALIZER(dev->pm->condvar),
 	};
 #endif /* CONFIG_PM_DEVICE */

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -117,27 +117,27 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_ACTIVE_STATE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = dummy_get_power_state(dev);
+		*state = dummy_get_power_state(dev);
 		break;
 	default:
 		ret = -EINVAL;
 
 	}
 
-	cb(dev, ret, context, arg);
+	cb(dev, ret, state, arg);
 
 	return ret;
 }

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -37,7 +37,7 @@ static int dummy_open(const struct device *dev)
 	(void) k_condvar_wait(&dev->pm->condvar, &wait_mutex, K_FOREVER);
 	k_mutex_unlock(&wait_mutex);
 
-	if (atomic_get(&dev->pm->fsm_state) == PM_DEVICE_ACTIVE_STATE) {
+	if (atomic_get(&dev->pm->state) == PM_DEVICE_ACTIVE_STATE) {
 		printk("Dummy device resumed\n");
 		ret = 0;
 	} else {

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -48,27 +48,27 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_ACTIVE_STATE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = dummy_get_power_state(dev);
+		*state = dummy_get_power_state(dev);
 		break;
 	default:
 		ret = -EINVAL;
 
 	}
 
-	cb(dev, ret, context, arg);
+	cb(dev, ret, state, arg);
 	return ret;
 }
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -65,6 +65,10 @@ static bool should_suspend(const struct device *dev, uint32_t state)
 	int rc;
 	uint32_t current_state;
 
+	if (device_busy_check(dev) != 0) {
+		return false;
+	}
+
 	rc = pm_device_state_get(dev, &current_state);
 	if ((rc != -ENOTSUP) && (rc != 0)) {
 		LOG_DBG("Was not possible to get device %s state: %d",

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -27,12 +27,12 @@ enum device_pm_state {
 #define PM_DEVICE_ASYNC			(1 << 0)
 
 static void device_pm_callback(const struct device *dev,
-			       int retval, void *context, void *arg)
+			       int retval, uint32_t *state, void *arg)
 {
 	__ASSERT(retval == 0, "Device set power state failed");
 
 	/* Set the fsm_state */
-	if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+	if (*state == PM_DEVICE_ACTIVE_STATE) {
 		atomic_set(&dev->pm->fsm_state,
 			   PM_DEVICE_STATE_ACTIVE);
 	} else {

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -23,8 +23,8 @@ enum device_pm_state {
 };
 
 /* Device PM request type */
-#define PM_DEVICE_SYNC			(0 << 0)
-#define PM_DEVICE_ASYNC			(1 << 0)
+#define PM_DEVICE_SYNC          BIT(0)
+#define PM_DEVICE_ASYNC         BIT(1)
 
 static void device_pm_callback(const struct device *dev,
 			       int retval, uint32_t *state, void *arg)

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -124,6 +124,22 @@ static int pm_device_request(const struct device *dev,
 		 * satisfied and this call just incremented the reference count
 		 * for this device.
 		 */
+
+		/* Unfortunately this is not what is happening yet. There are
+		 * cases, for example, like the pinmux being initialized before
+		 * the gpio. For that reason let's power on/off the device
+		 * here until we don't have it properly fixed.
+		 */
+		if (dev->pm->usage == 1) {
+			(void)pm_device_state_set(dev,
+						  PM_DEVICE_ACTIVE_STATE,
+						  NULL, NULL);
+		} else if (dev->pm->usage == 0) {
+			(void)pm_device_state_set(dev,
+						  PM_DEVICE_SUSPEND_STATE,
+						  NULL, NULL);
+		}
+
 		return 0;
 	}
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -40,7 +40,11 @@ static void device_pm_callback(const struct device *dev,
 			   PM_DEVICE_STATE_SUSPENDED);
 	}
 
-	k_work_submit(&dev->pm->work);
+	/*
+	 * This function returns the number of woken threads on success. There
+	 * is nothing we can do with this information. Just ignore it.
+	 */
+	(void)k_condvar_broadcast(&dev->pm->condvar);
 }
 
 static void pm_work_handler(struct k_work *work)
@@ -49,7 +53,6 @@ static void pm_work_handler(struct k_work *work)
 					struct pm_device, work);
 	const struct device *dev = pm->dev;
 	int ret = 0;
-	uint8_t pm_state;
 
 	switch (atomic_get(&dev->pm->fsm_state)) {
 	case PM_DEVICE_STATE_ACTIVE:
@@ -60,7 +63,6 @@ static void pm_work_handler(struct k_work *work)
 			ret = pm_device_state_set(dev, PM_DEVICE_SUSPEND_STATE,
 						  device_pm_callback, NULL);
 		} else {
-			pm_state = PM_DEVICE_ACTIVE_STATE;
 			goto fsm_out;
 		}
 		break;
@@ -72,7 +74,6 @@ static void pm_work_handler(struct k_work *work)
 			ret = pm_device_state_set(dev, PM_DEVICE_ACTIVE_STATE,
 						  device_pm_callback, NULL);
 		} else {
-			pm_state = PM_DEVICE_SUSPEND_STATE;
 			goto fsm_out;
 		}
 		break;
@@ -85,17 +86,20 @@ static void pm_work_handler(struct k_work *work)
 	}
 
 	__ASSERT(ret == 0, "Set Power state error");
-
 	return;
 
 fsm_out:
-	k_poll_signal_raise(&dev->pm->signal, pm_state);
+	/*
+	 * This function returns the number of woken threads on success. There
+	 * is nothing we can do with this information. Just ignoring it.
+	 */
+	(void)k_condvar_broadcast(&dev->pm->condvar);
 }
 
 static int pm_device_request(const struct device *dev,
 			     uint32_t target_state, uint32_t pm_flags)
 {
-	int result, signaled = 0;
+	struct k_mutex request_mutex;
 
 	__ASSERT((target_state == PM_DEVICE_ACTIVE_STATE) ||
 			(target_state == PM_DEVICE_SUSPEND_STATE),
@@ -121,25 +125,24 @@ static int pm_device_request(const struct device *dev,
 		return 0;
 	}
 
-	k_work_submit(&dev->pm->work);
+	(void)k_work_schedule(&dev->pm->work, K_NO_WAIT);
 
 	/* Return in case of Async request */
 	if (pm_flags & PM_DEVICE_ASYNC) {
 		return 0;
 	}
 
-	/* Incase of Sync request wait for completion event */
-	do {
-		(void)k_poll(&dev->pm->event, 1, K_FOREVER);
-		k_poll_signal_check(&dev->pm->signal,
-						&signaled, &result);
-	} while (!signaled);
+	k_mutex_init(&request_mutex);
+	k_mutex_lock(&request_mutex, K_FOREVER);
+	(void)k_condvar_wait(&dev->pm->condvar, &request_mutex, K_FOREVER);
+	k_mutex_unlock(&request_mutex);
 
-	dev->pm->event.state = K_POLL_STATE_NOT_READY;
-	k_poll_signal_reset(&dev->pm->signal);
-
-
-	return result == target_state ? 0 : -EIO;
+	/*
+	 * dev->pm->fsm_state was set in device_pm_callback(). As the device
+	 * may not have been properly changed to the target_state or another
+	 * thread we check it here before returning.
+	 */
+	return target_state == atomic_get(&dev->pm->fsm_state) ? 0 : -EIO;
 }
 
 int pm_device_get(const struct device *dev)
@@ -170,7 +173,7 @@ void pm_device_enable(const struct device *dev)
 		dev->pm->dev = dev;
 		dev->pm->enable = true;
 		atomic_set(&dev->pm->fsm_state, PM_DEVICE_STATE_SUSPENDED);
-		k_work_init(&dev->pm->work, pm_work_handler);
+		k_work_init_delayable(&dev->pm->work, pm_work_handler);
 		return;
 	}
 
@@ -185,9 +188,9 @@ void pm_device_enable(const struct device *dev)
 		dev->pm->dev = dev;
 		atomic_set(&dev->pm->fsm_state,
 			   PM_DEVICE_STATE_SUSPENDED);
-		k_work_init(&dev->pm->work, pm_work_handler);
+		k_work_init_delayable(&dev->pm->work, pm_work_handler);
 	} else {
-		k_work_submit(&dev->pm->work);
+		k_work_schedule(&dev->pm->work, K_NO_WAIT);
 	}
 	k_sem_give(&dev->pm->lock);
 }
@@ -200,6 +203,6 @@ void pm_device_disable(const struct device *dev)
 	k_sem_take(&dev->pm->lock, K_FOREVER);
 	dev->pm->enable = false;
 	/* Bring up the device before disabling the Idle PM */
-	k_work_submit(&dev->pm->work);
+	k_work_schedule(&dev->pm->work, K_NO_WAIT);
 	k_sem_give(&dev->pm->lock);
 }

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -78,6 +78,7 @@ static void pm_work_handler(struct k_work *work)
 		}
 		break;
 	case PM_DEVICE_STATE_SUSPENDING:
+		__fallthrough;
 	case PM_DEVICE_STATE_RESUMING:
 		/* Do nothing: We are waiting for device_pm_callback() */
 		break;

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -22,18 +22,18 @@ struct fake_dev_context {
 };
 
 static int fake_dev_pm_control(const struct device *dev, uint32_t command,
-			       void *context, pm_device_cb cb, void *arg)
+			       uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;
 
 	if (command == PM_DEVICE_STATE_SET) {
-		if (*(uint32_t *)context == PM_DEVICE_SUSPEND_STATE) {
+		if (*state == PM_DEVICE_SUSPEND_STATE) {
 			ret = net_if_suspend(ctx->iface);
 			if (ret == -EBUSY) {
 				goto out;
 			}
-		} else if (*(uint32_t *)context == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*state == PM_DEVICE_ACTIVE_STATE) {
 			ret = net_if_resume(ctx->iface);
 		}
 	} else {
@@ -42,7 +42,7 @@ static int fake_dev_pm_control(const struct device *dev, uint32_t command,
 
 out:
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -40,20 +40,20 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_ACTIVE_STATE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);
 		}
 		break;
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = dummy_get_power_state(dev);
+		*state = dummy_get_power_state(dev);
 		break;
 	default:
 		ret = -EINVAL;
@@ -61,7 +61,7 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;


### PR DESCRIPTION
 - Don't wake up devices unnecessarily
 - Fix concurrence issues with `k_poll_signal`. Using `k_condvar` instead.
 - Fix pre-kernel API usage
 - Some code guideline fixes
 - Use spin lock instead of semaphore to protect critical sessions, since it was the semaphore with K_FOREVER which is not allowed from ISR.
 - Change API signature for clarity sake