### PR TITLE
requirements-base.txt: fix pylink package name

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -18,7 +18,7 @@ canopen
 packaging
 progress
 psutil
-pylink
+pylink-square
 
 # for ram/rom reports
 anytree


### PR DESCRIPTION
This should be pylink-square.

Reported-by: Henrik Brix Andersen <henrik@brixandersen.dk>
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>