### PR TITLE
samples: logging/dictionary: fix long double compilation error

### DIFF
--- a/include/sys/cbprintf.h
+++ b/include/sys/cbprintf.h
@@ -47,6 +47,13 @@ extern "C" {
 /** @brief Required alignment of the buffer used for packaging. */
 #ifdef __xtensa__
 #define CBPRINTF_PACKAGE_ALIGNMENT 16
+#elif defined(CONFIG_X86) && !defined(CONFIG_64BIT)
+/* sizeof(long double) is 12 on x86-32, which is not power of 2.
+ * So set it manually.
+ */
+#define CBPRINTF_PACKAGE_ALIGNMENT \
+	(IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE) ? \
+		16 : MAX(sizeof(double), sizeof(long long)))
 #else
 #define CBPRINTF_PACKAGE_ALIGNMENT \
 	(IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE) ? \

--- a/samples/subsys/logging/dictionary/sample.yaml
+++ b/samples/subsys/logging/dictionary/sample.yaml
@@ -1,7 +1,26 @@
 sample:
   description: Dictionary-based Logging Sample Application
   name: logging_dictionary
+common:
+  integration_platforms:
+    - qemu_x86
+    - qemu_x86_64
+    - qemu_cortex_a53
+    - qemu_cortex_a53_smp
 tests:
   sample.logger.basic.dictionary:
     build_only: true
     tags: logging
+  sample.logger.basic.dictionary.fpu:
+    build_only: true
+    tags: logging
+    filter: CONFIG_CPU_HAS_FPU
+    extra_configs:
+      - CONFIG_FPU=y
+  sample.logger.basic.dictionary.fpu.long_double:
+    build_only: true
+    tags: logging
+    filter: CONFIG_CPU_HAS_FPU
+    extra_configs:
+      - CONFIG_FPU=y
+      - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y

--- a/samples/subsys/logging/dictionary/src/main.c
+++ b/samples/subsys/logging/dictionary/src/main.c
@@ -31,13 +31,6 @@ void main(void)
 	char vs1[32];
 	void *p = s;
 
-#ifdef CONFIG_FPU
-	float f = 66.67;
-	double d = 68.69;
-
-	long double ld = 70.71;
-#endif
-
 	printk("Hello World! %s\n", CONFIG_BOARD);
 
 	LOG_ERR("error string");
@@ -66,6 +59,14 @@ void main(void)
 	LOG_HEXDUMP_DBG(hexdump_msg, strlen(hexdump_msg), "For HeXdUmP!");
 
 #ifdef CONFIG_FPU
-	LOG_DBG("float %f, double %f, long double %Lf", f, d, ld);
+	float f = 66.67;
+	double d = 68.69;
+
+	LOG_DBG("float %f, double %f", f, d);
+#ifdef CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE
+	long double ld = 70.71;
+
+	LOG_DBG("long double %Lf", ld);
+#endif
 #endif
 }


### PR DESCRIPTION
The cbprintf packaging needs CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE to be enabled to work with long double. So #ifdef that inside CONFIG_FPU. Also add to the sample.yaml to enable testing with FPU and long doubles.

Also updated the cbprintf_packaged alignment for x86-32. The size of long double on x86-32 is 12 which is not a power of 2, and this results in build error when it is being used for alignment of buf32 in log_core.c. So manually set it to 16.