### PR TITLE
boards: arm: Enable flash storage on mimxrt1060_evk

### DIFF
--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -16,6 +16,12 @@ endchoice
 config DISK_DRIVER_SDMMC
 	default y if DISK_DRIVERS
 
+config FLASH_MCUX_FLEXSPI_NOR
+	default y if FLASH
+
+config FLASH_MCUX_FLEXSPI_XIP
+	default y if FLASH
+
 config I2C
 	default y if KSCAN
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -92,6 +92,10 @@
 arduino_serial: &lpuart3 {};
 
 &flexspi {
+	status = "okay";
+	ahb-prefetch;
+	ahb-read-addr-opt;
+	rx-clock-source = <1>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
@@ -101,6 +105,17 @@ arduino_serial: &lpuart3 {};
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+	};
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@700000 {
+			label = "storage";
+			reg = <0x00700000 DT_SIZE_M(1)>;
+		};
 	};
 };
 

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -4,5 +4,5 @@ tests:
   sample.filesystem.littlefs:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 particle_xenon disco_l475_iot1
-      mimxrt1064_evk qemu_x86 native_posix
+      mimxrt1060_evk mimxrt1064_evk qemu_x86 native_posix
     tags: filesystem


### PR DESCRIPTION
Enables the FlexSPI flash driver and adds a flash storage partition on
the mimxrt1060_evk board. Unlike the mimxrt1064_evk, this board does not
have an internal QSPI flash. Therefore we reserve the first 7 MB of the
external QSPI flash for code and only use the last 1 MB for storage.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>