### PR TITLE
Bluetooth: controller: Check preempt event on timeout 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -413,11 +413,11 @@ int lll_csrand_isr_get(void *buf, size_t len);
 int lll_rand_get(void *buf, size_t len);
 int lll_rand_isr_get(void *buf, size_t len);
 
-int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
-			       lll_abort_cb_t abort_cb,
-			       struct lll_prepare_param *prepare_param,
-			       lll_prepare_cb_t prepare_cb,
-			       uint8_t is_resume);
+struct lll_event *ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
+				      lll_abort_cb_t abort_cb,
+				      struct lll_prepare_param *prepare_param,
+				      lll_prepare_cb_t prepare_cb,
+				      uint8_t is_resume);
 void *ull_prepare_dequeue_get(void);
 void *ull_prepare_dequeue_iter(uint8_t *idx);
 void ull_prepare_dequeue(uint8_t caller_id);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -65,13 +65,15 @@ static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
 static inline void done_inc(void);
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
-static int resume_enqueue(lll_prepare_cb_t resume_cb);
+static struct lll_event *resume_enqueue(lll_prepare_cb_t resume_cb);
 static void isr_race(void *param);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 static void ticker_stop_op_cb(uint32_t status, void *param);
 static void ticker_start_op_cb(uint32_t status, void *param);
-static void preempt_ticker_start(struct lll_prepare_param *prepare_param);
+static void ticker_start_next_op_cb(uint32_t status, void *param);
+static uint32_t preempt_ticker_start(struct lll_event *event,
+				     ticker_op_func op_cb);
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 			      uint16_t lazy, uint8_t force, void *param);
 static void preempt(void *param);
@@ -304,7 +306,6 @@ int lll_done(void *param)
 	struct lll_event *next;
 	struct ull_hdr *ull;
 	void *evdone;
-	int ret = 0;
 
 	/* Assert if param supplied without a pending prepare to cancel. */
 	next = ull_prepare_dequeue_get();
@@ -352,7 +353,7 @@ int lll_done(void *param)
 	evdone = ull_event_done(ull);
 	LL_ASSERT(evdone);
 
-	return ret;
+	return 0;
 }
 
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -620,8 +621,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	    (p && is_resume)) {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
 		lll_prepare_cb_t resume_cb;
-		struct lll_event *next;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
+		struct lll_event *next;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && event.curr.param) {
 			/* early abort */
@@ -629,16 +630,21 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		}
 
 		/* Store the next prepare for deferred call */
-		err = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
-					  prepare_cb, is_resume);
-		LL_ASSERT(!err);
+		next = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
+					   prepare_cb, is_resume);
+		LL_ASSERT(next);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 		if (is_resume) {
 			return -EINPROGRESS;
 		}
 
-		preempt_ticker_start(prepare_param);
+		/* Start the preempt timeout */
+		uint32_t ret;
+
+		ret  = preempt_ticker_start(next, ticker_start_op_cb);
+		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+			  (ret == TICKER_STATUS_BUSY));
 
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 		next = NULL;
@@ -664,8 +670,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 			LL_ASSERT(err);
 
 			if (err == -EAGAIN) {
-				err = resume_enqueue(resume_cb);
-				LL_ASSERT(!err);
+				next = resume_enqueue(resume_cb);
+				LL_ASSERT(next);
 			} else {
 				LL_ASSERT(err == -ECANCELED);
 			}
@@ -674,6 +680,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 		return -EINPROGRESS;
 	}
+
+	LL_ASSERT(!p || &p->prepare_param == prepare_param);
 
 	event.curr.param = prepare_param->param;
 	event.curr.is_abort_cb = is_abort_cb;
@@ -701,13 +709,16 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		}
 	} while (p->is_aborted || p->is_resume);
 
-	preempt_ticker_start(&p->prepare_param);
+	/* Start the preempt timeout */
+	ret = preempt_ticker_start(p, ticker_start_next_op_cb);
+	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+		  (ret == TICKER_STATUS_BUSY));
 #endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 	return err;
 }
 
-static int resume_enqueue(lll_prepare_cb_t resume_cb)
+static struct lll_event *resume_enqueue(lll_prepare_cb_t resume_cb)
 {
 	struct lll_prepare_param prepare_param = {0};
 
@@ -747,16 +758,26 @@ static void ticker_start_op_cb(uint32_t status, void *param)
 		  (status == TICKER_STATUS_FAILURE));
 }
 
-static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
+static void ticker_start_next_op_cb(uint32_t status, void *param)
 {
+	ARG_UNUSED(param);
+
+	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
+}
+
+static uint32_t preempt_ticker_start(struct lll_event *event,
+				     ticker_op_func op_cb)
+{
+	struct lll_prepare_param *p;
 	uint32_t preempt_anchor;
 	struct ull_hdr *ull;
 	uint32_t preempt_to;
 	uint32_t ret;
 
 	/* Calc the preempt timeout */
-	ull = HDR_LLL2ULL(prepare_param->param);
-	preempt_anchor = prepare_param->ticks_at_expire;
+	p = &event->prepare_param;
+	ull = HDR_LLL2ULL(p->param);
+	preempt_anchor = p->ticks_at_expire;
 	preempt_to = MAX(ull->ticks_active_to_start,
 			 ull->ticks_prepare_to_start) -
 		     ull->ticks_preempt_to_start;
@@ -771,11 +792,10 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 			   TICKER_NULL_REMAINDER,
 			   TICKER_NULL_LAZY,
 			   TICKER_NULL_SLOT,
-			   preempt_ticker_cb, NULL,
-			   ticker_start_op_cb, NULL);
-	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
-		  (ret == TICKER_STATUS_FAILURE) ||
-		  (ret == TICKER_STATUS_BUSY));
+			   preempt_ticker_cb, event,
+			   op_cb, event);
+
+	return ret;
 }
 
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
@@ -785,6 +805,7 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	static struct mayfly mfy = {0, 0, &link, NULL, preempt};
 	uint32_t ret;
 
+	mfy.param = param;
 	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL,
 			     0, &mfy);
 	LL_ASSERT(!ret);
@@ -795,43 +816,63 @@ static void preempt(void *param)
 	lll_prepare_cb_t resume_cb;
 	struct lll_event *next;
 	uint8_t idx;
-	int ret;
+	int err;
 
+	/* No event to abort */
 	if (!event.curr.abort_cb || !event.curr.param) {
 		return;
 	}
 
+	/* Check if any prepare in pipeline */
 	idx = UINT8_MAX;
 	next = ull_prepare_dequeue_iter(&idx);
 	if (!next) {
 		return;
 	}
 
+	/* Find a prepare that is ready and not a resume */
 	while (next && (next->is_aborted || next->is_resume)) {
 		next = ull_prepare_dequeue_iter(&idx);
 	}
 
+	/* No ready prepare */
 	if (!next) {
 		return;
 	}
 
-	ret = event.curr.is_abort_cb(next->prepare_param.param,
+	/* Preemptor not in pipeline */
+	if (next != param) {
+		uint32_t ret;
+
+		/* Start the preempt timeout */
+		ret = preempt_ticker_start(next, ticker_start_next_op_cb);
+		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+			  (ret == TICKER_STATUS_BUSY));
+
+		return;
+	}
+
+	/* Check if current event want to continue */
+	err = event.curr.is_abort_cb(next->prepare_param.param,
 				     event.curr.param,
 				     &resume_cb);
-	if (!ret) {
-		/* Let LLL know about the cancelled prepare */
+	if (!err) {
+		/* Let preemptor LLL know about the cancelled prepare */
 		next->is_aborted = 1;
 		next->abort_cb(&next->prepare_param, next->prepare_param.param);
 
 		return;
 	}
 
+	/* Abort the current event */
 	event.curr.abort_cb(NULL, event.curr.param);
 
-	if (ret == -EAGAIN) {
+	/* Check if resume requested */
+	if (err == -EAGAIN) {
 		struct lll_event *iter;
 		uint8_t iter_idx;
 
+		/* Abort any duplicates so that they get dequeued */
 		iter_idx = UINT8_MAX;
 		iter = ull_prepare_dequeue_iter(&iter_idx);
 		while (iter) {
@@ -853,10 +894,11 @@ static void preempt(void *param)
 			iter = ull_prepare_dequeue_iter(&iter_idx);
 		}
 
-		ret = resume_enqueue(resume_cb);
-		LL_ASSERT(!ret);
+		/* Enqueue as resume event */
+		iter = resume_enqueue(resume_cb);
+		LL_ASSERT(iter);
 	} else {
-		LL_ASSERT(ret == -ECANCELED);
+		LL_ASSERT(err == -ECANCELED);
 	}
 }
 #else /* CONFIG_BT_CTLR_LOW_LAT */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -58,12 +58,14 @@ static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
 static inline void done_inc(void);
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
-static int resume_enqueue(lll_prepare_cb_t resume_cb);
+static struct lll_event *resume_enqueue(lll_prepare_cb_t resume_cb);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 static void ticker_stop_op_cb(uint32_t status, void *param);
 static void ticker_start_op_cb(uint32_t status, void *param);
-static void preempt_ticker_start(struct lll_prepare_param *prepare_param);
+static void ticker_start_next_op_cb(uint32_t status, void *param);
+static uint32_t preempt_ticker_start(struct lll_event *event,
+				     ticker_op_func op_cb);
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 			      uint16_t lazy, uint8_t force, void *param);
 static void preempt(void *param);
@@ -258,7 +260,6 @@ int lll_done(void *param)
 	struct lll_event *next;
 	struct ull_hdr *ull;
 	void *evdone;
-	int ret = 0;
 
 	/* Assert if param supplied without a pending prepare to cancel. */
 	next = ull_prepare_dequeue_get();
@@ -306,7 +307,7 @@ int lll_done(void *param)
 	evdone = ull_event_done(ull);
 	LL_ASSERT(evdone);
 
-	return ret;
+	return 0;
 }
 
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -498,8 +499,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	    (p && is_resume)) {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
 		lll_prepare_cb_t resume_cb;
-		struct lll_event *next;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
+		struct lll_event *next;
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && event.curr.param) {
 			/* early abort */
@@ -507,16 +508,21 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		}
 
 		/* Store the next prepare for deferred call */
-		err = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
-					  prepare_cb, is_resume);
-		LL_ASSERT(!err);
+		next = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
+					   prepare_cb, is_resume);
+		LL_ASSERT(next);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 		if (is_resume) {
 			return -EINPROGRESS;
 		}
 
-		preempt_ticker_start(prepare_param);
+		/* Start the preempt timeout */
+		uint32_t ret;
+
+		ret  = preempt_ticker_start(next, ticker_start_op_cb);
+		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+			  (ret == TICKER_STATUS_BUSY));
 
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 		next = NULL;
@@ -542,8 +548,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 			LL_ASSERT(err);
 
 			if (err == -EAGAIN) {
-				err = resume_enqueue(resume_cb);
-				LL_ASSERT(!err);
+				next = resume_enqueue(resume_cb);
+				LL_ASSERT(next);
 			} else {
 				LL_ASSERT(err == -ECANCELED);
 			}
@@ -552,6 +558,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 		return -EINPROGRESS;
 	}
+
+	LL_ASSERT(!p || &p->prepare_param == prepare_param);
 
 	event.curr.param = prepare_param->param;
 	event.curr.is_abort_cb = is_abort_cb;
@@ -579,13 +587,16 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		}
 	} while (p->is_aborted || p->is_resume);
 
-	preempt_ticker_start(&p->prepare_param);
+	/* Start the preempt timeout */
+	ret = preempt_ticker_start(p, ticker_start_next_op_cb);
+	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+		  (ret == TICKER_STATUS_BUSY));
 #endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 	return err;
 }
 
-static int resume_enqueue(lll_prepare_cb_t resume_cb)
+static struct lll_event *resume_enqueue(lll_prepare_cb_t resume_cb)
 {
 	struct lll_prepare_param prepare_param = {0};
 
@@ -619,16 +630,26 @@ static void ticker_start_op_cb(uint32_t status, void *param)
 		  (status == TICKER_STATUS_FAILURE));
 }
 
-static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
+static void ticker_start_next_op_cb(uint32_t status, void *param)
 {
+	ARG_UNUSED(param);
+
+	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
+}
+
+static uint32_t preempt_ticker_start(struct lll_event *event,
+				     ticker_op_func op_cb)
+{
+	struct lll_prepare_param *p;
 	uint32_t preempt_anchor;
 	struct ull_hdr *ull;
 	uint32_t preempt_to;
 	uint32_t ret;
 
 	/* Calc the preempt timeout */
-	ull = HDR_LLL2ULL(prepare_param->param);
-	preempt_anchor = prepare_param->ticks_at_expire;
+	p = &event->prepare_param;
+	ull = HDR_LLL2ULL(p->param);
+	preempt_anchor = p->ticks_at_expire;
 	preempt_to = MAX(ull->ticks_active_to_start,
 			 ull->ticks_prepare_to_start) -
 		     ull->ticks_preempt_to_start;
@@ -643,11 +664,10 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 			   TICKER_NULL_REMAINDER,
 			   TICKER_NULL_LAZY,
 			   TICKER_NULL_SLOT,
-			   preempt_ticker_cb, NULL,
-			   ticker_start_op_cb, NULL);
-	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
-		  (ret == TICKER_STATUS_FAILURE) ||
-		  (ret == TICKER_STATUS_BUSY));
+			   preempt_ticker_cb, event,
+			   op_cb, event);
+
+	return ret;
 }
 
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
@@ -657,6 +677,7 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	static struct mayfly mfy = {0, 0, &link, NULL, preempt};
 	uint32_t ret;
 
+	mfy.param = param;
 	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL,
 			     0, &mfy);
 	LL_ASSERT(!ret);
@@ -667,43 +688,63 @@ static void preempt(void *param)
 	lll_prepare_cb_t resume_cb;
 	struct lll_event *next;
 	uint8_t idx;
-	int ret;
+	int err;
 
+	/* No event to abort */
 	if (!event.curr.abort_cb || !event.curr.param) {
 		return;
 	}
 
+	/* Check if any prepare in pipeline */
 	idx = UINT8_MAX;
 	next = ull_prepare_dequeue_iter(&idx);
 	if (!next) {
 		return;
 	}
 
+	/* Find a prepare that is ready and not a resume */
 	while (next && (next->is_aborted || next->is_resume)) {
 		next = ull_prepare_dequeue_iter(&idx);
 	}
 
+	/* No ready prepare */
 	if (!next) {
 		return;
 	}
 
-	ret = event.curr.is_abort_cb(next->prepare_param.param,
+	/* Preemptor not in pipeline */
+	if (next != param) {
+		uint32_t ret;
+
+		/* Start the preempt timeout */
+		ret = preempt_ticker_start(next, ticker_start_next_op_cb);
+		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+			  (ret == TICKER_STATUS_BUSY));
+
+		return;
+	}
+
+	/* Check if current event want to continue */
+	err = event.curr.is_abort_cb(next->prepare_param.param,
 				     event.curr.param,
 				     &resume_cb);
-	if (!ret) {
-		/* Let LLL know about the cancelled prepare */
+	if (!err) {
+		/* Let preemptor LLL know about the cancelled prepare */
 		next->is_aborted = 1;
 		next->abort_cb(&next->prepare_param, next->prepare_param.param);
 
 		return;
 	}
 
+	/* Abort the current event */
 	event.curr.abort_cb(NULL, event.curr.param);
 
-	if (ret == -EAGAIN) {
+	/* Check if resume requested */
+	if (err == -EAGAIN) {
 		struct lll_event *iter;
 		uint8_t iter_idx;
 
+		/* Abort any duplicates so that they get dequeued */
 		iter_idx = UINT8_MAX;
 		iter = ull_prepare_dequeue_iter(&iter_idx);
 		while (iter) {
@@ -725,10 +766,11 @@ static void preempt(void *param)
 			iter = ull_prepare_dequeue_iter(&iter_idx);
 		}
 
-		ret = resume_enqueue(resume_cb);
-		LL_ASSERT(!ret);
+		/* Enqueue as resume event */
+		iter = resume_enqueue(resume_cb);
+		LL_ASSERT(iter);
 	} else {
-		LL_ASSERT(ret == -ECANCELED);
+		LL_ASSERT(err == -ECANCELED);
 	}
 }
 #else /* CONFIG_BT_CTLR_LOW_LAT */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -570,6 +570,16 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_FAILURE) ||
 		  (ret == TICKER_STATUS_BUSY));
+
+	/* Find next prepare needing preempt timeout to be setup */
+	do {
+		p = ull_prepare_dequeue_iter(&idx);
+		if (!p) {
+			return err;
+		}
+	} while (p->is_aborted || p->is_resume);
+
+	preempt_ticker_start(&p->prepare_param);
 #endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 	return err;
@@ -685,7 +695,7 @@ static void preempt(void *param)
 		next->is_aborted = 1;
 		next->abort_cb(&next->prepare_param, next->prepare_param.param);
 
-		goto preempt_next;
+		return;
 	}
 
 	event.curr.abort_cb(NULL, event.curr.param);
@@ -720,16 +730,6 @@ static void preempt(void *param)
 	} else {
 		LL_ASSERT(ret == -ECANCELED);
 	}
-
-preempt_next:
-	do {
-		next = ull_prepare_dequeue_iter(&idx);
-		if (!next) {
-			return;
-		}
-	} while (next->is_aborted || next->is_resume);
-
-	preempt_ticker_start(&next->prepare_param);
 }
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -5,13 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+#include <stdbool.h>
 #include <errno.h>
-#include <zephyr/types.h>
-#include <device.h>
-#include <drivers/entropy.h>
-#include <drivers/clock_control.h>
+
+#include <toolchain.h>
 
 #include <soc.h>
+#include <device.h>
+
+#include <drivers/entropy.h>
 
 #include "hal/swi.h"
 #include "hal/ccm.h"
@@ -28,9 +31,9 @@
 #include "lll_vendor.h"
 #include "lll_internal.h"
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll
 #include "common/log.h"
-
 #include "hal/debug.h"
 
 static struct {
@@ -39,19 +42,26 @@ static struct {
 		lll_is_abort_cb_t is_abort_cb;
 		lll_abort_cb_t    abort_cb;
 	} curr;
-} event;
 
-static struct {
-	const struct device *clk;
-} lll;
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+	struct {
+		uint8_t volatile lll_count;
+		uint8_t          ull_count;
+	} done;
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
+} event;
 
 /* Entropy device */
 static const struct device *dev_entropy;
 
 static int init_reset(void);
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+static inline void done_inc(void);
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 static int resume_enqueue(lll_prepare_cb_t resume_cb);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
+static void ticker_stop_op_cb(uint32_t status, void *param);
 static void ticker_start_op_cb(uint32_t status, void *param);
 static void preempt_ticker_start(struct lll_prepare_param *prepare_param);
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
@@ -59,6 +69,7 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 static void preempt(void *param);
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 #if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+static void mfy_ticker_job_idle_get(void *param);
 static void ticker_op_job_disable(uint32_t status, void *op_context);
 #endif
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
@@ -107,10 +118,7 @@ static void swi_ull_low_rv32m1_isr(const void *arg)
 
 int lll_init(void)
 {
-	const struct device *clk_k32;
 	int err;
-
-	ARG_UNUSED(clk_k32);
 
 	/* Get reference to entropy device */
 	dev_entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
@@ -120,9 +128,6 @@ int lll_init(void)
 
 	/* Initialise LLL internals */
 	event.curr.abort_cb = NULL;
-
-	/* Initialize HF CLK */
-	lll.clk = NULL;
 
 	err = init_reset();
 	if (err) {
@@ -155,6 +160,7 @@ int lll_init(void)
 
 	/* Call it after IRQ enable to be able to measure ISR latency */
 	radio_setup();
+
 	return 0;
 }
 
@@ -202,8 +208,9 @@ void lll_disable(void *param)
 	}
 	{
 		struct lll_event *next;
-		uint8_t idx = UINT8_MAX;
+		uint8_t idx;
 
+		idx = UINT8_MAX;
 		next = ull_prepare_dequeue_iter(&idx);
 		while (next) {
 			if (!next->is_aborted &&
@@ -211,6 +218,14 @@ void lll_disable(void *param)
 				next->is_aborted = 1;
 				next->abort_cb(&next->prepare_param,
 					       next->prepare_param.param);
+
+#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+				/* NOTE: abort_cb called lll_done which modifies
+				 *       the prepare pipeline hence re-iterate
+				 *       through the prepare pipeline.
+				 */
+				idx = UINT8_MAX;
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 			}
 
 			next = ull_prepare_dequeue_iter(&idx);
@@ -222,15 +237,17 @@ int lll_prepare_done(void *param)
 {
 #if defined(CONFIG_BT_CTLR_LOW_LAT) && \
 	    (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+	static memq_link_t link;
+	static struct mayfly mfy = {0, 0, &link, NULL, mfy_ticker_job_idle_get};
 	uint32_t ret;
 
-	/* Ticker Job Silence */
-	ret = ticker_job_idle_get(TICKER_INSTANCE_ID_CTLR,
-				  TICKER_USER_ID_LLL,
-				  ticker_op_job_disable, NULL);
+	ret = mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_LOW,
+			     1, &mfy);
+	if (ret) {
+		return -EFAULT;
+	}
 
-	return ((ret == TICKER_STATUS_SUCCESS) ||
-		(ret == TICKER_STATUS_BUSY)) ? 0 : -EFAULT;
+	return 0;
 #else
 	return 0;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
@@ -238,15 +255,17 @@ int lll_prepare_done(void *param)
 
 int lll_done(void *param)
 {
-	struct lll_event *next = ull_prepare_dequeue_get();
-	struct ull_hdr *ull = NULL;
+	struct lll_event *next;
+	struct ull_hdr *ull;
 	void *evdone;
 	int ret = 0;
 
 	/* Assert if param supplied without a pending prepare to cancel. */
+	next = ull_prepare_dequeue_get();
 	LL_ASSERT(!param || next);
 
 	/* check if current LLL event is done */
+	ull = NULL;
 	if (!param) {
 		/* Reset current event instance */
 		LL_ASSERT(event.curr.abort_cb);
@@ -254,6 +273,10 @@ int lll_done(void *param)
 
 		param = event.curr.param;
 		event.curr.param = NULL;
+
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+		done_inc();
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
 		if (param) {
 			ull = HDR_LLL2ULL(param);
@@ -271,12 +294,27 @@ int lll_done(void *param)
 		ull = HDR_LLL2ULL(param);
 	}
 
+#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+	ull_prepare_dequeue(TICKER_USER_ID_LLL);
+#endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
+
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	lll_done_score(param, 0, 0); /* TODO */
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
+
 	/* Let ULL know about LLL event done */
 	evdone = ull_event_done(ull);
 	LL_ASSERT(evdone);
 
 	return ret;
 }
+
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+void lll_done_sync(void)
+{
+	event.done.ull_count = event.done.lll_count;
+}
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
 bool lll_is_done(void *param)
 {
@@ -348,13 +386,17 @@ uint32_t lll_event_offset_get(struct ull_hdr *ull)
 uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 		       uint32_t ticks_at_event)
 {
-	uint32_t ticks_now = ticker_ticks_now_get();
+	uint32_t ticks_now;
 	uint32_t diff;
 
-	diff = ticker_ticks_diff_get(ticks_now, ticks_at_event);
+	ticks_now = ticker_ticks_now_get();
+	diff = ticks_now - ticks_at_event;
+	if (diff & BIT(HAL_TICKER_CNTR_MSBIT)) {
+		return 0;
+	}
+
 	diff += HAL_TICKER_CNTR_CMP_OFFSET_MIN;
-	if (!(diff & BIT(HAL_TICKER_CNTR_MSBIT)) &&
-	    (diff > HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US))) {
+	if (diff > HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US)) {
 		/* TODO: for Low Latency Feature with Advanced XTAL feature.
 		 * 1. Release retained HF clock.
 		 * 2. Advance the radio event to accommodate normal prepare
@@ -418,27 +460,45 @@ static int init_reset(void)
 	return 0;
 }
 
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+static inline void done_inc(void)
+{
+	event.done.lll_count++;
+}
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
+
+static inline bool is_done_sync(void)
+{
+#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+	return event.done.lll_count == event.done.ull_count;
+#else /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
+	return true;
+#endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
+}
+
 int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 			lll_prepare_cb_t prepare_cb,
 			struct lll_prepare_param *prepare_param,
 			uint8_t is_resume, uint8_t is_dequeue)
 {
-	uint8_t idx = UINT8_MAX;
 	struct lll_event *p;
-	int ret, err;
+	uint8_t idx;
+	int err;
 
 	/* Find the ready prepare in the pipeline */
+	idx = UINT8_MAX;
 	p = ull_prepare_dequeue_iter(&idx);
 	while (p && (p->is_aborted || p->is_resume)) {
 		p = ull_prepare_dequeue_iter(&idx);
 	}
 
 	/* Current event active or another prepare is ready in the pipeline */
-	if (event.curr.abort_cb || (p && is_resume)) {
+	if ((!is_dequeue && !is_done_sync()) ||
+	    event.curr.abort_cb ||
+	    (p && is_resume)) {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
 		lll_prepare_cb_t resume_cb;
 		struct lll_event *next;
-		int resume_prio;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && event.curr.param) {
@@ -447,9 +507,9 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		}
 
 		/* Store the next prepare for deferred call */
-		ret = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
+		err = ull_prepare_enqueue(is_abort_cb, abort_cb, prepare_param,
 					  prepare_cb, is_resume);
-		LL_ASSERT(!ret);
+		LL_ASSERT(!err);
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 		if (is_resume) {
@@ -477,15 +537,15 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 		if (next) {
 			/* check if resume requested by curr */
-			ret = event.curr.is_abort_cb(NULL, 0, event.curr.param,
+			err = event.curr.is_abort_cb(NULL, event.curr.param,
 						     &resume_cb);
-			LL_ASSERT(ret);
+			LL_ASSERT(err);
 
-			if (ret == -EAGAIN) {
-				ret = resume_enqueue(resume_cb);
-				LL_ASSERT(!ret);
+			if (err == -EAGAIN) {
+				err = resume_enqueue(resume_cb);
+				LL_ASSERT(!err);
 			} else {
-				LL_ASSERT(ret == -ECANCELED);
+				LL_ASSERT(err == -ECANCELED);
 			}
 		}
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
@@ -499,16 +559,25 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 
 	err = prepare_cb(prepare_param);
 
-	/* NOTE: Should the preempt timeout be stopped, check for any more
-	 *       in pipeline?
-	 */
+#if !defined(CONFIG_BT_CTLR_LOW_LAT)
+	uint32_t ret;
+
+	/* Stop any scheduled preempt ticker */
+	ret = ticker_stop(TICKER_INSTANCE_ID_CTLR,
+			  TICKER_USER_ID_LLL,
+			  TICKER_ID_LLL_PREEMPT,
+			  ticker_stop_op_cb, NULL);
+	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+		  (ret == TICKER_STATUS_FAILURE) ||
+		  (ret == TICKER_STATUS_BUSY));
+#endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 	return err;
 }
 
 static int resume_enqueue(lll_prepare_cb_t resume_cb)
 {
-	struct lll_prepare_param prepare_param;
+	struct lll_prepare_param prepare_param = {0};
 
 	prepare_param.param = event.curr.param;
 	event.curr.param = NULL;
@@ -518,9 +587,20 @@ static int resume_enqueue(lll_prepare_cb_t resume_cb)
 }
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
+static void ticker_stop_op_cb(uint32_t status, void *param)
+{
+	/* NOTE: this callback is present only for addition of debug messages
+	 * when needed, else can be dispensed with.
+	 */
+	ARG_UNUSED(param);
+
+	LL_ASSERT((status == TICKER_STATUS_SUCCESS) ||
+		  (status == TICKER_STATUS_FAILURE));
+}
+
 static void ticker_start_op_cb(uint32_t status, void *param)
 {
-	/* NOTE: this callback is present only for addition debug messages
+	/* NOTE: this callback is present only for addition of debug messages
 	 * when needed, else can be dispensed with.
 	 */
 	ARG_UNUSED(param);
@@ -534,14 +614,14 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 	uint32_t preempt_anchor;
 	struct ull_hdr *ull;
 	uint32_t preempt_to;
-	int ret;
+	uint32_t ret;
 
 	/* Calc the preempt timeout */
 	ull = HDR_LLL2ULL(prepare_param->param);
 	preempt_anchor = prepare_param->ticks_at_expire;
 	preempt_to = MAX(ull->ticks_active_to_start,
 			 ull->ticks_prepare_to_start) -
-			 ull->ticks_preempt_to_start;
+		     ull->ticks_preempt_to_start;
 
 	/* Setup pre empt timeout */
 	ret = ticker_start(TICKER_INSTANCE_ID_CTLR,
@@ -561,7 +641,7 @@ static void preempt_ticker_start(struct lll_prepare_param *prepare_param)
 }
 
 static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
-			      uint16_t lazy, uint8_t force, void *param)
+			       uint16_t lazy, uint8_t force, void *param)
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, preempt};
@@ -574,15 +654,16 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 
 static void preempt(void *param)
 {
-	struct lll_event *next = ull_prepare_dequeue_get();
 	lll_prepare_cb_t resume_cb;
-	uint8_t idx = UINT8_MAX;
+	struct lll_event *next;
+	uint8_t idx;
 	int ret;
 
 	if (!event.curr.abort_cb || !event.curr.param) {
 		return;
 	}
 
+	idx = UINT8_MAX;
 	next = ull_prepare_dequeue_iter(&idx);
 	if (!next) {
 		return;
@@ -611,8 +692,9 @@ static void preempt(void *param)
 
 	if (ret == -EAGAIN) {
 		struct lll_event *iter;
-		uint8_t iter_idx = UINT8_MAX;
+		uint8_t iter_idx;
 
+		iter_idx = UINT8_MAX;
 		iter = ull_prepare_dequeue_iter(&iter_idx);
 		while (iter) {
 			if (!iter->is_aborted &&
@@ -620,6 +702,14 @@ static void preempt(void *param)
 				iter->is_aborted = 1;
 				iter->abort_cb(&iter->prepare_param,
 					       iter->prepare_param.param);
+
+#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
+				/* NOTE: abort_cb called lll_done which modifies
+				 *       the prepare pipeline hence re-iterate
+				 *       through the prepare pipeline.
+				 */
+				idx = UINT8_MAX;
+#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 			}
 
 			iter = ull_prepare_dequeue_iter(&iter_idx);
@@ -644,6 +734,18 @@ preempt_next:
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 
 #if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+static void mfy_ticker_job_idle_get(void *param)
+{
+	uint32_t ret;
+
+	/* Ticker Job Silence */
+	ret = ticker_job_idle_get(TICKER_INSTANCE_ID_CTLR,
+				  TICKER_USER_ID_ULL_LOW,
+				  ticker_op_job_disable, NULL);
+	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+		  (ret == TICKER_STATUS_BUSY));
+}
+
 static void ticker_op_job_disable(uint32_t status, void *op_context)
 {
 	ARG_UNUSED(status);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1637,18 +1637,18 @@ void ull_rx_sched_done(void)
 }
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
 
-int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
-			lll_abort_cb_t abort_cb,
-			struct lll_prepare_param *prepare_param,
-			lll_prepare_cb_t prepare_cb,
-			uint8_t is_resume)
+struct lll_event *ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
+				      lll_abort_cb_t abort_cb,
+				      struct lll_prepare_param *prepare_param,
+				      lll_prepare_cb_t prepare_cb,
+				      uint8_t is_resume)
 {
 	struct lll_event *e;
 	uint8_t idx;
 
 	idx = MFIFO_ENQUEUE_GET(prep, (void **)&e);
 	if (!e) {
-		return -ENOBUFS;
+		return NULL;
 	}
 
 	memcpy(&e->prepare_param, prepare_param, sizeof(e->prepare_param));
@@ -1660,7 +1660,7 @@ int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 
 	MFIFO_ENQUEUE(prep, idx);
 
-	return 0;
+	return e;
 }
 
 void *ull_prepare_dequeue_get(void)


### PR DESCRIPTION
Check whether the preempt event matches with the head of the
pipeline before aborting the currently active event.

This is required to avoid preemption of events that became
active due to done event and there has been a race in
stopping the preempt ticker.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>