### PR TITLE
Bluetooth: controller: Add function to calculate seed access address

### DIFF
--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -16,3 +16,4 @@
 uint8_t util_ones_count_get(uint8_t *octets, uint8_t octets_len);
 int util_aa_le32(uint8_t *dst);
 void util_saa_le32(uint8_t *dst, uint8_t handle);
+void util_bis_aa_le32(uint8_t bis, uint8_t *saa, uint8_t *dst);

--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -15,3 +15,4 @@
 
 uint8_t util_ones_count_get(uint8_t *octets, uint8_t octets_len);
 int util_aa_le32(uint8_t *dst);
+void util_saa_le32(uint8_t *dst, uint8_t handle);


### PR DESCRIPTION
Added utility function to calculate seed access address.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>