### PR TITLE
Bluetooth: controller: Add LE Read Buffer Size v2 support

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1625,10 +1625,10 @@ struct bt_hci_rp_le_default_past_param {
 #define BT_HCI_OP_LE_READ_BUFFER_SIZE_V2        BT_OP(BT_OGF_LE, 0x0060)
 struct bt_hci_rp_le_read_buffer_size_v2 {
 	uint8_t  status;
-	uint16_t acl_mtu;
-	uint8_t  acl_max_pkt;
-	uint16_t iso_mtu;
-	uint8_t  iso_max_pkt;
+	uint16_t acl_max_len;
+	uint8_t  acl_max_num;
+	uint16_t iso_max_len;
+	uint8_t  iso_max_num;
 } __packed;
 
 #define BT_HCI_OP_LE_READ_ISO_TX_SYNC           BT_OP(BT_OGF_LE, 0x0061)

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -174,15 +174,16 @@ config BT_CTLR_RX_BUFFERS
 
 config BT_CTLR_ISO_TX_BUFFERS
 	int "Number of Isochronous Tx buffers"
-	default 3
-	range 1 19
 	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
+	range 1 19
+	default 3
 	help
 	  Set the number of Isochronous Tx PDUs to be queued for transmission
 	  in the controller.
 
 config BT_CTLR_ISO_TX_BUFFER_SIZE
 	int "Isochronous Tx buffer size"
+	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
 	range 1 4095
 	default 27
 	help

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -794,6 +794,12 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	/* LE Read TX Power. */
 	rp->commands[38] |= BIT(7);
 
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+	/* LE Read Buffer Size v2 */
+	rp->commands[41] |= BIT(5);
+
+#endif /* CONFIG_BT_CTLR_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
 #if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
 	/* Read Supported Codecs */
 	rp->commands[29] |= BIT(5);
@@ -1160,6 +1166,22 @@ static void le_read_buffer_size(struct net_buf *buf, struct net_buf **evt)
 	rp->le_max_len = sys_cpu_to_le16(CONFIG_BT_BUF_ACL_TX_SIZE);
 	rp->le_max_num = CONFIG_BT_BUF_ACL_TX_COUNT;
 }
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+static void le_read_buffer_size_v2(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_rp_le_read_buffer_size_v2 *rp;
+
+	rp = hci_cmd_complete(evt, sizeof(*rp));
+
+	rp->status = 0x00;
+
+	rp->acl_max_len = sys_cpu_to_le16(CONFIG_BT_BUF_ACL_TX_SIZE);
+	rp->acl_max_num = CONFIG_BT_BUF_ACL_TX_COUNT;
+	rp->iso_max_len = sys_cpu_to_le16(CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE);
+	rp->iso_max_num = CONFIG_BT_CTLR_ISO_TX_BUFFERS;
+}
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 static void le_read_local_features(struct net_buf *buf, struct net_buf **evt)
 {
@@ -3260,6 +3282,12 @@ static int controller_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 	case BT_OCF(BT_HCI_OP_LE_READ_BUFFER_SIZE):
 		le_read_buffer_size(cmd, evt);
 		break;
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+	case BT_OCF(BT_HCI_OP_LE_READ_BUFFER_SIZE_V2):
+		le_read_buffer_size_v2(cmd, evt);
+		break;
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 	case BT_OCF(BT_HCI_OP_LE_READ_LOCAL_FEATURES):
 		le_read_local_features(cmd, evt);

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1574,7 +1574,7 @@ static void le_big_terminate_sync(struct net_buf *buf, struct net_buf **evt,
 
 	*evt = cmd_complete_status(status);
 }
-#endif /* CONFIG_BT_CTLR_ADV_ISO */
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 #endif /* CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_CONN)
@@ -6220,6 +6220,7 @@ uint8_t hci_get_class(struct node_rx_pdu *node_rx)
 #if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
 		case NODE_RX_TYPE_CIS_REQUEST:
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 		case NODE_RX_TYPE_CIS_ESTABLISHED:
 #endif /* CONFIG_BT_CTLR_CONN_ISO */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2423,27 +2423,27 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 
 	BT_DBG("status %u", rp->status);
 
-	bt_dev.le.acl_mtu = sys_le16_to_cpu(rp->acl_mtu);
+	bt_dev.le.acl_mtu = sys_le16_to_cpu(rp->acl_max_len);
 	if (!bt_dev.le.acl_mtu) {
 		return;
 	}
 
-	BT_DBG("ACL LE buffers: pkts %u mtu %u", rp->acl_max_pkt,
+	BT_DBG("ACL LE buffers: pkts %u mtu %u", rp->acl_max_num,
 		bt_dev.le.acl_mtu);
 
-	max_num = MIN(rp->acl_max_pkt, CONFIG_BT_CONN_TX_MAX);
+	max_num = MIN(rp->acl_max_num, CONFIG_BT_CONN_TX_MAX);
 	k_sem_init(&bt_dev.le.acl_pkts, max_num, max_num);
 
-	bt_dev.le.iso_mtu = sys_le16_to_cpu(rp->iso_mtu);
+	bt_dev.le.iso_mtu = sys_le16_to_cpu(rp->iso_max_len);
 	if (!bt_dev.le.iso_mtu) {
 		BT_ERR("ISO buffer size not set");
 		return;
 	}
 
-	BT_DBG("ISO buffers: pkts %u mtu %u", rp->iso_max_pkt,
+	BT_DBG("ISO buffers: pkts %u mtu %u", rp->iso_max_num,
 		bt_dev.le.iso_mtu);
 
-	max_num = MIN(rp->iso_max_pkt, CONFIG_BT_ISO_TX_BUF_COUNT);
+	max_num = MIN(rp->iso_max_num, CONFIG_BT_ISO_TX_BUF_COUNT);
 	k_sem_init(&bt_dev.le.iso_pkts, max_num, max_num);
 #endif /* CONFIG_BT_ISO */
 }


### PR DESCRIPTION
Add LE Read Buffer Size v2 support in the controller
implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>