### PR TITLE
Bluetooth: controller: Implement LE Set Host Feature Command

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -20,6 +20,7 @@ zephyr_library_sources_ifdef(
 
 if(CONFIG_BT_LL_SW_SPLIT)
   zephyr_library_sources(
+    ll_sw/ll_feat.c
     ll_sw/ull.c
     ll_sw/lll_common.c
     )
@@ -85,12 +86,11 @@ if(CONFIG_BT_LL_SW_SPLIT)
       )
     endif()
   endif()
-  if(CONFIG_BT_CTLR_SET_HOST_FEATURE)
+  if(CONFIG_BT_CTLR_DF)
     zephyr_library_sources(
-      ll_sw/ll_feat.c
+      ll_sw/ull_df.c
       )
   endif()
-
   if(CONFIG_BT_CTLR_CONN_ISO)
     zephyr_library_sources(
       ll_sw/ull_conn_iso.c
@@ -108,11 +108,6 @@ if(CONFIG_BT_LL_SW_SPLIT)
     zephyr_library_sources(
       ll_sw/ull_chan.c
       ll_sw/lll_chan.c
-      )
-  endif()
-  if(CONFIG_BT_CTLR_DF)
-    zephyr_library_sources(
-      ll_sw/ull_df.c
       )
   endif()
   zephyr_library_sources_ifdef(

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -476,6 +476,7 @@ config BT_CTLR_ADV_ISO
 	bool "LE Broadcast Isochronous Channel advertising" if !BT_LL_SW_SPLIT
 	depends on BT_BROADCASTER && BT_CTLR_ADV_ISO_SUPPORT
 	select BT_CTLR_ADV_PERIODIC
+	select BT_CTLR_SET_HOST_FEATURE
 	help
 	  Enable support for Bluetooth 5.2 LE Isochronous Advertising in the
 	  Controller.
@@ -487,6 +488,7 @@ config BT_CTLR_SYNC_ISO
 	bool "LE Broadcast Isochronous Channel advertising sync" if !BT_LL_SW_SPLIT
 	depends on BT_OBSERVER && BT_CTLR_SYNC_ISO_SUPPORT
 	select BT_CTLR_SYNC_PERIODIC
+	select BT_CTLR_SET_HOST_FEATURE
 	help
 	  Enable support for Bluetooth 5.2 LE Isochronous Advertising sync in
 	  the Controller.

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1195,7 +1195,7 @@ static void le_read_local_features(struct net_buf *buf, struct net_buf **evt)
 	rp->status = 0x00;
 
 	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
-	sys_put_le64(LL_FEAT, rp->features);
+	sys_put_le64(ll_feat_get(), rp->features);
 }
 
 static void le_set_random_address(struct net_buf *buf, struct net_buf **evt)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -12,6 +12,8 @@
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
 
+uint64_t ll_feat_get(void);
+
 uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *p_bdaddr);
 uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const p_bdaddr);
 

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -12,6 +12,7 @@
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
 
+uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value);
 uint64_t ll_feat_get(void);
 
 uint8_t *ll_addr_get(uint8_t addr_type, uint8_t *p_bdaddr);
@@ -191,7 +192,6 @@ uint8_t ll_read_iso_link_quality(uint16_t  handle,
 				 uint32_t *crc_error_packets,
 				 uint32_t *rx_unreceived_packets,
 				 uint32_t *duplicate_packets);
-uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value);
 uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 			  uint8_t coding_format, uint16_t company_id,
 			  uint16_t vs_codec_id, uint32_t controller_delay,

--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -173,6 +173,9 @@
 /* Mask to filter away octet 0 for feature exchange */
 #define LL_FEAT_FILTER_OCTET0    (LL_FEAT_BIT_MASK & ~0xFFULL)
 
+/* Mask for host controlled features */
+#define LL_FEAT_HOST_BIT_MASK    0x100000000ULL
+
 /* Feature bits of this controller */
 #define LL_FEAT                  (LL_FEAT_BIT_ENC | \
 				  LL_FEAT_BIT_CONN_PARAM_REQ | \

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -6,6 +6,8 @@
 
 #include <zephyr.h>
 
+#include "ll_feat.h"
+
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ll_feat
 #include "common/log.h"
@@ -17,4 +19,9 @@ uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value)
 	ARG_UNUSED(bit_value);
 
 	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+
+uint64_t ll_feat_get(void)
+{
+	return LL_FEAT;
 }

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -1,10 +1,22 @@
 /*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
  * Copyright (c) 2020 Demant
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr.h>
+
+#include "util/memq.h"
+
+#include "hal/ccm.h"
+
+#include "pdu.h"
+
+#include "lll.h"
+#include "lll_conn.h"
+
+#include "ull_conn_internal.h"
 
 #include "ll_feat.h"
 
@@ -13,15 +25,55 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+#if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
+static uint64_t host_features;
+
 uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value)
 {
-	ARG_UNUSED(bit_number);
-	ARG_UNUSED(bit_value);
+	uint64_t feature;
 
-	return BT_HCI_ERR_CMD_DISALLOWED;
+	/* Check if Bit_Number is not controlled by the Host */
+	feature = BIT64(bit_number);
+	if (!(feature & LL_FEAT_HOST_BIT_MASK)) {
+		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;
+	}
+
+#if defined(CONFIG_BT_CONN)
+	/* Check if the Controller has an established ACL */
+	uint16_t conn_free_count = ll_conn_free_count_get();
+
+	/* Check if any connection contexts where allocated */
+	if (conn_free_count != CONFIG_BT_MAX_CONN) {
+		uint16_t handle;
+
+		/* Check if there are established connections */
+		for (handle = 0U; handle < CONFIG_BT_MAX_CONN; handle++) {
+			if (ll_connected_get(handle)) {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+		}
+	}
+#endif /* CONFIG_BT_CONN */
+
+	/* Set or Clear the Host feature bit */
+	if (bit_value) {
+		host_features |= feature;
+	} else {
+		host_features &= ~feature;
+	}
+
+	return BT_HCI_ERR_SUCCESS;
 }
 
 uint64_t ll_feat_get(void)
 {
+	return LL_FEAT | (host_features & LL_FEAT_HOST_BIT_MASK);
+}
+
+#else /* !CONFIG_BT_CTLR_SET_HOST_FEATURE */
+uint64_t ll_feat_get(void)
+{
 	return LL_FEAT;
 }
+
+#endif /* !CONFIG_BT_CTLR_SET_HOST_FEATURE */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -909,7 +909,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_rx = NULL;
 		conn->llcp_cu.req = conn->llcp_cu.ack = 0;
 		conn->llcp_feature.req = conn->llcp_feature.ack = 0;
-		conn->llcp_feature.features_conn = LL_FEAT;
+		conn->llcp_feature.features_conn = ll_feat_get();
 		conn->llcp_feature.features_peer = 0;
 		conn->llcp_version.req = conn->llcp_version.ack = 0;
 		conn->llcp_version.tx = conn->llcp_version.rx = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -237,6 +237,11 @@ struct ll_conn *ll_connected_get(uint16_t handle)
 	}
 
 	return conn;
+}
+
+uint16_t ll_conn_free_count_get(void)
+{
+	return mem_free_count_get(conn_free);
 }
 
 void *ll_tx_mem_acquire(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@ void ll_conn_release(struct ll_conn *conn);
 uint16_t ll_conn_handle_get(struct ll_conn *conn);
 struct ll_conn *ll_conn_get(uint16_t handle);
 struct ll_conn *ll_connected_get(uint16_t handle);
+uint16_t ll_conn_free_count_get(void);
 void ll_tx_ack_put(uint16_t handle, struct node_tx *node_tx);
 int ull_conn_init(void);
 int ull_conn_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -172,6 +172,7 @@ struct ll_conn {
 	struct {
 		uint8_t  req;
 		uint8_t  ack;
+		/* TODO: 8, 16, 32 or 64 based on local supported features */
 		uint64_t features_conn;
 		uint64_t features_peer;
 	} llcp_feature;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -257,7 +257,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_rx = NULL;
 	conn->llcp_cu.req = conn->llcp_cu.ack = 0;
 	conn->llcp_feature.req = conn->llcp_feature.ack = 0;
-	conn->llcp_feature.features_conn = LL_FEAT;
+	conn->llcp_feature.features_conn = ll_feat_get();
 	conn->llcp_feature.features_peer = 0;
 	conn->llcp_version.req = conn->llcp_version.ack = 0;
 	conn->llcp_version.tx = conn->llcp_version.rx = 0U;


### PR DESCRIPTION
Replace the use of LL_FEAT define with ll_feat_get() so that
feature set value can be updated at runtime with host
feature bit values.

Added implementation of HCI LE Set Host Feature command.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>