### PR TITLE
drivers: i2c: it8xxx2: fix i2c_reset issue

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -405,7 +405,7 @@ static int enhanced_i2c_tran_read(const struct device *dev)
 		/* Direct read  */
 		data->i2ccs = I2C_CH_WAIT_READ;
 		/* Send ID */
-		i2c_pio_trans_data(dev, RX_DIRECT, data->addr_16bit, 1);
+		i2c_pio_trans_data(dev, RX_DIRECT, data->addr_16bit << 1, 1);
 	} else {
 		if (data->i2ccs) {
 			if (data->i2ccs == I2C_CH_WAIT_READ) {
@@ -419,7 +419,7 @@ static int enhanced_i2c_tran_read(const struct device *dev)
 				data->i2ccs = I2C_CH_WAIT_READ;
 				/* Send ID */
 				i2c_pio_trans_data(dev, RX_DIRECT,
-					data->addr_16bit, 1);
+					data->addr_16bit << 1, 1);
 			}
 			/* Turn on irq before next direct read */
 			irq_enable(config->i2c_irq_base);
@@ -462,7 +462,7 @@ static int enhanced_i2c_tran_write(const struct device *dev)
 		data->msgs->flags &= ~I2C_MSG_START;
 		enhanced_i2c_start(dev);
 		/* Send ID */
-		i2c_pio_trans_data(dev, TX_DIRECT, data->addr_16bit, 1);
+		i2c_pio_trans_data(dev, TX_DIRECT, data->addr_16bit << 1, 1);
 	} else {
 		/* Host has completed the transmission of a byte */
 		if (data->widx < data->msgs->len) {
@@ -542,7 +542,7 @@ static int i2c_tran_read(const struct device *dev)
 		 * bit0, Direction of the host transfer.
 		 * bit[1:7}, Address of the targeted slave.
 		 */
-		IT83XX_SMB_TRASLA(base) = (uint8_t)data->addr_16bit | 0x01;
+		IT83XX_SMB_TRASLA(base) = (uint8_t)(data->addr_16bit << 1) | 0x01;
 		/* clear start flag */
 		data->msgs->flags &= ~I2C_MSG_START;
 		/*
@@ -617,7 +617,7 @@ static int i2c_tran_write(const struct device *dev)
 		 * bit0, Direction of the host transfer.
 		 * bit[1:7}, Address of the targeted slave.
 		 */
-		IT83XX_SMB_TRASLA(base) = (uint8_t)data->addr_16bit;
+		IT83XX_SMB_TRASLA(base) = (uint8_t)data->addr_16bit << 1;
 		/* Send first byte */
 		IT83XX_SMB_HOBDB(base) = *(data->msgs->buf++);
 


### PR DESCRIPTION
After i2c_reset, there is still no external pull-up I2C bus,
and finishing off the rest of loop causes the code to hang
indefinitely.
This patch fixes that if I2C bus is not available(No external
pull-up), dropping the transaction.

Another issue is fixed the slave address from 7-bit to 8-bit.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>