### PR TITLE
sample: dictionary: Enable CBPRINTF_PACKAGE_LONGDOUBLE

### DIFF
--- a/samples/subsys/logging/dictionary/sample.yaml
+++ b/samples/subsys/logging/dictionary/sample.yaml
@@ -5,3 +5,5 @@ tests:
   sample.logger.basic.dictionary:
     build_only: true
     tags: logging
+    extra_configs:
+      - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y


### PR DESCRIPTION
To fix AArch64 build failure when FPU is enabled.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>