### PR TITLE
Bluetooth: controller: Fix ULL reference decrement on done event

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2346,8 +2346,12 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	struct ull_hdr *ull_hdr;
 	void *release;
 
-	/* Get the ull instance */
+	/* Decrement prepare reference if ULL will not resume */
 	ull_hdr = done->param;
+	if (ull_hdr) {
+		LL_ASSERT(ull_ref_get(ull_hdr));
+		ull_ref_dec(ull_hdr);
+	}
 
 	/* Process role dependent event done */
 	switch (done->extra.type) {
@@ -2416,17 +2420,8 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	lll_done_sync();
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
-	/* ull instance will resume, dont decrement ref */
-	if (!ull_hdr) {
-		return;
-	}
-
-	/* Decrement prepare reference */
-	LL_ASSERT(ull_ref_get(ull_hdr));
-	ull_ref_dec(ull_hdr);
-
 	/* If disable initiated, signal the semaphore */
-	if (!ull_ref_get(ull_hdr) && ull_hdr->disabled_cb) {
+	if (ull_hdr && !ull_ref_get(ull_hdr) && ull_hdr->disabled_cb) {
 		ull_hdr->disabled_cb(ull_hdr->disabled_param);
 	}
 }


### PR DESCRIPTION
Fix ULL reference count decrement to be performed before the
done events are handled, so that correct reference count is
used to determine if events are pending in the pipeline.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>