### PR TITLE
boards: stm32f412g_disco: Add arduino headers

### DIFF
--- a/boards/arm/stm32f412g_disco/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32f412g_disco/arduino_r3_connector.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Kim Bøndergaard <kim.boendergaard@escoglobal.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 1 0>,	/* A0 */
+			   <1 0 &gpioc 1 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 4 0>,	/* A3 */
+			   <4 0 &gpioc 5 0>,	/* A4 */
+			   <5 0 &gpiob 0 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiog 13 0>,	/* D2 */
+			   <9 0 &gpiof 4 0>,	/* D3 */
+			   <10 0 &gpiog 12 0>,	/* D4 */
+			   <11 0 &gpiof 10 0>,	/* D5 */
+			   <12 0 &gpiof 3 0>,	/* D6 */
+			   <13 0 &gpiog 11 0>,	/* D7 */
+			   <14 0 &gpiog 10 0>,	/* D8 */
+			   <15 0 &gpiob 8 0>,	/* D9 */
+			   <16 0 &gpioa 15 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 10 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c2 {};
+arduino_spi: &spi1 {};
+arduino_serial: &usart6 {};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/f4/stm32f412Xg.dtsi>
 #include <st/f4/stm32f412z(e-g)tx-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F412G-DISCO board";
@@ -98,6 +99,24 @@
 &usart2 {
 	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart6 {
+	pinctrl-0 = <&usart6_tx_pg14 &usart6_rx_pg9>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb9>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa15 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
@@ -7,4 +7,8 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
+  - arduino_serial
+  - arduino_i2c
+  - arduino_spi
   - counter


### PR DESCRIPTION
Added arduino gpios, and the typically used aliases for
arduino_spi, arduino serial and arduino_i2c

