### PR TITLE
Bluetooth: controller: Fix missing EVENT_TICKER_RES_MARGIN_US

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -424,6 +424,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	sync_offset_us += (si->offs_adjust ? OFFS_ADJUST_US : 0U);
 	sync_offset_us -= PKT_AC_US(pdu->len, 0, lll->phy);
 	sync_offset_us -= EVENT_OVERHEAD_START_US;
+	sync_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	sync_offset_us -= EVENT_JITTER_US;
 	sync_offset_us -= ready_delay_us;
 


### PR DESCRIPTION
Fix missing use of EVENT_TICKER_RES_MARGIN_US in Periodic
Synchronization.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>