### PR TITLE
Bluetooth: controller: nRF5: Add radio ready time save and restore

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1008,6 +1008,18 @@ uint32_t radio_tmr_ready_get(void)
 	return EVENT_TIMER->CC[0];
 }
 
+static uint32_t radio_tmr_ready;
+
+void radio_tmr_ready_save(uint32_t ready)
+{
+	radio_tmr_ready = ready;
+}
+
+uint32_t radio_tmr_ready_restore(void)
+{
+	return radio_tmr_ready;
+}
+
 void radio_tmr_end_capture(void)
 {
 	/* NOTE: nRF5340 shares the DPPI channel being triggered by Radio End

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -82,6 +82,8 @@ uint32_t radio_tmr_aa_get(void);
 void radio_tmr_aa_save(uint32_t aa);
 uint32_t radio_tmr_aa_restore(void);
 uint32_t radio_tmr_ready_get(void);
+void radio_tmr_ready_save(uint32_t ready);
+uint32_t radio_tmr_ready_restore(void);
 void radio_tmr_end_capture(void);
 uint32_t radio_tmr_end_get(void);
 uint32_t radio_tmr_tifs_base_get(void);


### PR DESCRIPTION
Added radio interface to save and restore radio ready
timestamp. This will be saved between ISO Subevents and
used in done event for anchor point synchronization and
drift compensation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>