### PR TITLE
Update libmetal & openamp v2021.04 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
       revision: 27a464e4885f393dc376a53d9fc8d52078848496
       path: modules/hal/nxp
     - name: open-amp
-      revision: de1b85a13032a2de1d8b6695ae5f800b613e739d
+      revision: 6010f0523cbc75f551d9256cf782f173177acdef
       path: modules/lib/open-amp
     - name: loramac-node
       revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e

--- a/west.yml
+++ b/west.yml
@@ -78,7 +78,7 @@ manifest:
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e
       path: modules/hal/ti
     - name: libmetal
-      revision: 9d4ee2c3cfd5f49861939447990f3b7d7bf9bf94
+      revision: 39d049d4ae68e6f6d595fce7de1dcfc1024fb4eb
       path: modules/hal/libmetal
     - name: hal_quicklogic
       repo-path: hal_quicklogic


### PR DESCRIPTION
update of the west.yml to  integrate to the new OpenAMP release