### PR TITLE
tests: drivers: dma set correct type for the chan_id

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -88,7 +88,7 @@ static void dma_user_callback(const struct device *dma_dev, void *arg,
 static int test_loop(void)
 {
 	const struct device *dma;
-	static uint32_t chan_id;
+	static int chan_id;
 
 	TC_PRINT("DMA memory to memory transfer started on %s\n",
 	       DMA_DEVICE_NAME);
@@ -124,13 +124,14 @@ static int test_loop(void)
 #ifdef CONFIG_DMA_MCUX_TEST_SLOT_START
 	dma_cfg.dma_slot = CONFIG_DMA_MCUX_TEST_SLOT_START;
 #endif
+
 	chan_id = dma_request_channel(dma, NULL);
 	if (chan_id < 0) {
 		TC_PRINT("this platform do not support the dma channel\n");
 		chan_id = CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR;
 	}
 	transfer_count = 0;
-	TC_PRINT("Starting the transfer and waiting for 1 second\n");
+	TC_PRINT("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
 	dma_block_cfg.block_size = strlen(tx_data);
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];


### PR DESCRIPTION
The chan_id value returned by dma_request_channel
can be negative, changing the type of chan_id to int.

This will fix error when running  test/drivers/dma/loop_transfer for stm32 with dmamux.
especially on nucleo_g071rb, 

Signed-off-by: Francois Ramu <francois.ramu@st.com>