### PR TITLE
drivers/clock_controller: misc. fixes for stm32WB and stm32WL

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -574,13 +574,13 @@ int stm32_clock_control_init(const struct device *dev)
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
 #ifdef CONFIG_SOC_SERIES_STM32WBX
 	/* Set C2 AHB & AHB4 prescalers */
-	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct->CPU2CLKDivider);
-	LL_RCC_SetAHB4Prescaler(s_ClkInitStruct->AHB4CLKDivider);
+	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
+	LL_RCC_SetAHB4Prescaler(s_ClkInitStruct.AHB4CLKDivider);
 #endif /* CONFIG_SOC_SERIES_STM32WBX */
 #ifdef CONFIG_SOC_SERIES_STM32WLX
 	/* Set C2 AHB & AHB3 prescalers */
-	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct->CPU2CLKDivider);
-	LL_RCC_SetAHB3Prescaler(s_ClkInitStruct->AHB3CLKDivider);
+	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
+	LL_RCC_SetAHB3Prescaler(s_ClkInitStruct.AHB3CLKDivider);
 #endif /* CONFIG_SOC_SERIES_STM32WLX */
 	/* If freq not increased, set flash latency after all clock setting */
 	if (new_hclk_freq <= old_hclk_freq) {

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -56,13 +56,14 @@
  */
 static void config_bus_clk_init(LL_UTILS_ClkInitTypeDef *clk_init)
 {
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+	clk_init->CPU2CLKDivider = ahb_prescaler(STM32_CPU2_PRESCALER);
+#endif
 #if defined(CONFIG_SOC_SERIES_STM32WBX)
 	clk_init->CPU1CLKDivider = ahb_prescaler(STM32_CPU1_PRESCALER);
-	clk_init->CPU2CLKDivider = ahb_prescaler(STM32_CPU2_PRESCALER);
 	clk_init->AHB4CLKDivider = ahb_prescaler(STM32_AHB4_PRESCALER);
 #elif defined(CONFIG_SOC_SERIES_STM32WLX)
 	clk_init->CPU1CLKDivider = ahb_prescaler(STM32_CPU1_PRESCALER);
-	clk_init->CPU2CLKDivider = ahb_prescaler(STM32_CPU2_PRESCALER);
 	clk_init->AHB3CLKDivider = ahb_prescaler(STM32_AHB3_PRESCALER);
 #else
 	clk_init->AHBCLKDivider = ahb_prescaler(STM32_AHB_PRESCALER);
@@ -572,16 +573,15 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set APB1 & APB2 prescaler*/
 	LL_RCC_SetAPB1Prescaler(s_ClkInitStruct.APB1CLKDivider);
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
+#endif
 #ifdef CONFIG_SOC_SERIES_STM32WBX
-	/* Set C2 AHB & AHB4 prescalers */
-	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
 	LL_RCC_SetAHB4Prescaler(s_ClkInitStruct.AHB4CLKDivider);
-#endif /* CONFIG_SOC_SERIES_STM32WBX */
+#endif
 #ifdef CONFIG_SOC_SERIES_STM32WLX
-	/* Set C2 AHB & AHB3 prescalers */
-	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
 	LL_RCC_SetAHB3Prescaler(s_ClkInitStruct.AHB3CLKDivider);
-#endif /* CONFIG_SOC_SERIES_STM32WLX */
+#endif
 	/* If freq not increased, set flash latency after all clock setting */
 	if (new_hclk_freq <= old_hclk_freq) {
 		LL_SetFlashLatency(new_hclk_freq);

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 2017 Linaro Limited.
  * Copyright (c) 2017 RnDity Sp. z o.o.
  *
@@ -19,22 +18,22 @@
 #include "clock_stm32_ll_common.h"
 
 /* Macros to fill up prescaler values */
-#define z_ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
-#define ahb_prescaler(v) z_ahb_prescaler(v)
+#define fn_ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
+#define ahb_prescaler(v) fn_ahb_prescaler(v)
 
-#define z_apb1_prescaler(v) LL_RCC_APB1_DIV_ ## v
-#define apb1_prescaler(v) z_apb1_prescaler(v)
+#define fn_apb1_prescaler(v) LL_RCC_APB1_DIV_ ## v
+#define apb1_prescaler(v) fn_apb1_prescaler(v)
 
 #ifndef CONFIG_SOC_SERIES_STM32F0X
-#define z_apb2_prescaler(v) LL_RCC_APB2_DIV_ ## v
-#define apb2_prescaler(v) z_apb2_prescaler(v)
+#define fn_apb2_prescaler(v) LL_RCC_APB2_DIV_ ## v
+#define apb2_prescaler(v) fn_apb2_prescaler(v)
 #endif /* CONFIG_SOC_SERIES_STM32F0X  */
 
-#define z_mco1_prescaler(v) LL_RCC_MCO1_DIV_ ## v
-#define mco1_prescaler(v) z_mco1_prescaler(v)
+#define fn_mco1_prescaler(v) LL_RCC_MCO1_DIV_ ## v
+#define mco1_prescaler(v) fn_mco1_prescaler(v)
 
-#define z_mco2_prescaler(v) LL_RCC_MCO2_DIV_ ## v
-#define mco2_prescaler(v) z_mco2_prescaler(v)
+#define fn_mco2_prescaler(v) LL_RCC_MCO2_DIV_ ## v
+#define mco2_prescaler(v) fn_mco2_prescaler(v)
 
 /* Calculate MSI freq for the given range(at RUN range, not after standby) */
 #if defined(CONFIG_SOC_SERIES_STM32WBX)
@@ -307,7 +306,7 @@ static struct clock_control_driver_api stm32_clock_control_api = {
  * Unconditionally switch the system clock source to HSI.
  */
 __unused
-static void stm32_clock_switch_to_hsi(uint32_t ahb_prescaler)
+static void stm32_clock_switch_to_hsi(uint32_t new_ahb_prescaler)
 {
 	/* Enable HSI if not enabled */
 	if (LL_RCC_HSI_IsReady() != 1) {
@@ -320,7 +319,7 @@ static void stm32_clock_switch_to_hsi(uint32_t ahb_prescaler)
 
 	/* Set HSI as SYSCLCK source */
 	LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_HSI);
-	LL_RCC_SetAHBPrescaler(ahb_prescaler);
+	LL_RCC_SetAHBPrescaler(new_ahb_prescaler);
 	while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI) {
 	}
 }

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -520,6 +520,15 @@ int stm32_clock_control_init(const struct device *dev)
 	!defined (CONFIG_SOC_SERIES_STM32G0X)
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
 #endif
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
+#endif
+#ifdef CONFIG_SOC_SERIES_STM32WBX
+	LL_RCC_SetAHB4Prescaler(s_ClkInitStruct.AHB4CLKDivider);
+#endif /* CONFIG_SOC_SERIES_STM32WBX */
+#ifdef CONFIG_SOC_SERIES_STM32WLX
+	LL_RCC_SetAHB3Prescaler(s_ClkInitStruct.AHB3CLKDivider);
+#endif /* CONFIG_SOC_SERIES_STM32WLX */
 
 	/* If freq not increased, set flash latency after all clock setting */
 	if (new_hclk_freq <= old_hclk_freq) {
@@ -614,6 +623,15 @@ int stm32_clock_control_init(const struct device *dev)
 	!defined (CONFIG_SOC_SERIES_STM32G0X)
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
 #endif /* CONFIG_SOC_SERIES_STM32F0X && CONFIG_SOC_SERIES_STM32G0X */
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
+#endif
+#ifdef CONFIG_SOC_SERIES_STM32WBX
+	LL_RCC_SetAHB4Prescaler(s_ClkInitStruct.AHB4CLKDivider);
+#endif /* CONFIG_SOC_SERIES_STM32WBX */
+#ifdef CONFIG_SOC_SERIES_STM32WLX
+	LL_RCC_SetAHB3Prescaler(s_ClkInitStruct.AHB3CLKDivider);
+#endif /* CONFIG_SOC_SERIES_STM32WLX */
 
 	/* Set flash latency */
 	/* HSI used as SYSCLK, set latency to 0 */


### PR DESCRIPTION
In specific configurations the stm32 clock control driver has a few issues. which this pr intends to solve.

- stm32wb and stm32wl: fix struct wrongly de-referenced(in case msi is selected as system clock)
- stm32wl: restructure cpu2 prescaler assignment
- stm32wb: only has a single msi range: therefore hal macros differ. This must be taken account for to avoid build errors.
- stm32wb and stm32wl: fix missing initialization of ahb prescalers in case HSI or HSE are selected as system clock.
- stm32wb and stm32wl: fix flash latency calculation in the initialization function by using the correct prescaler
  (it is not the same as cpu1 prescaler).