### PR TITLE
git.cmake: print BUILD_VERSION always, simplify and fix error message

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -24,9 +24,9 @@ if(NOT BUILD_VERSION AND GIT_FOUND)
     RESULT_VARIABLE                  return_code
   )
   if(return_code)
-    message(STATUS "git describe failed: ${stderr};
-   BUILD_VERSION is left undefined")
-  elseif(CMAKE_VERBOSE_MAKEFILE)
-    message(STATUS "git describe stderr: ${stderr}")
+    message(STATUS "git describe failed: ${stderr}")
+  elseif(NOT "${stderr}" STREQUAL "")
+    message(STATUS "git describe warned: ${stderr}")
   endif()
+  message(STATUS "BUILD_VERSION=${BUILD_VERSION}")
 endif()

--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -15,7 +15,7 @@
 find_package(Git QUIET)
 if(NOT BUILD_VERSION AND GIT_FOUND)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
+    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always
     WORKING_DIRECTORY                ${ZEPHYR_BASE}
     OUTPUT_VARIABLE                  BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
2 commits. The main one:

In an ideal world, good CIs make it very clear what exact git versions
are getting built. However:

- Zephyr is (re-)used in many projects and they cannot all be expected
  to have ideal CI.

- CI with multiple git repos is complex (#34713) which makes the world
  an even less ideal place: much more chance for some git versions to be
  missing.

- Many developers don't realize that Github and other CIs do not test
  pull/12345/head but the moving target pull/12345/merge instead. While
  not resolving pull/12345/merge completely (maybe another day), this
  commit provides at least evidence that pull/12345/head is NOT the
  commit tested.

So the addition of the following line in the logs is a very small price
to pay that can save enormous amounts of time when trying to understand
some obscure build failures.
```
-- BUILD_VERSION=zephyr-v2.5.0-2957-g6230b5bb66bc
```
Note this obviously does not provide any git information when
BUILD_VERSION is overriden but it does not hurt either in this case:
knowing BUILD_VERSION was overriden is also useful.

The "BUILD_VERSION is left undefined" message was just wrong in
the (unlikely) case `git describe` printed something while also
failing. Remove it; it's so much simpler to just print $BUILD_VERSION
and give the direct, unfiltered information.

Note this simplification is also a partial revert of 1b80f00f
which threw the entire git warnings "baby" with some obscure duplicate
1.13.0 "bathwater" that is not relevant any more and that I guess barely
anyone noticed even at the time.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>