### PR TITLE
tests: ztest: fix testcase might fail when assertion fail in ISR

### DIFF
--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -341,8 +341,8 @@ void test_main(void)
 	ztest_test_suite(error_hook_tests,
 			 ztest_user_unit_test(test_catch_assert_fail),
 			 ztest_user_unit_test(test_catch_fatal_error),
-			 ztest_unit_test(test_catch_assert_in_isr),
-			 ztest_unit_test(test_catch_z_oops)
+			 ztest_unit_test(test_catch_z_oops),
+			 ztest_unit_test(test_catch_assert_in_isr)
 			 );
 	ztest_run_test_suite(error_hook_tests);
 #else


### PR DESCRIPTION
Put the testcase test_catch_assert_in_isr() to execute last, to prevent
it affects other test cases. Because when we caught an assert failure
in the ISR handler, it cannot be guaranteed that all the current
program status would be recovered.

Fixes #34844.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>