### PR TITLE
dts: arm: stm32l1 has a fixed lsi clock of 37kHz

### DIFF
--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -63,7 +63,7 @@
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <DT_FREQ_K(37)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Correct the clock freq of the LSI for the stm32l1

Based on the RM0038 ref manual.

Signed-off-by: Francois Ramu <francois.ramu@st.com>