### PR TITLE
drivers: eeprom: shell cmd write can now handle hex data

### DIFF
--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -90,7 +90,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	for (i = 0; i < len; i++) {
-		byte = strtoul(argv[args_indx.data + i], NULL, 0);
+		byte = strtoul(argv[args_indx.data + i], NULL, 16);
 		if (byte > UINT8_MAX) {
 			shell_error(shell, "Error parsing data byte %d", i);
 			return -EINVAL;


### PR DESCRIPTION
Modified eeprom shell write command to be able to handle hex data
bytes.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>