### PR TITLE
spi: spi_nrfx_spim: option to enable high drive

### DIFF
--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -203,4 +203,7 @@ config SPI_NRFX_RAM_BUFFER_SIZE
 	  supplying buffers located in flash to the driver, otherwise such
 	  transfers will fail.
 
+config SPI_NRFX_HIGH_DRIVE_STRENGTH
+	bool "Use high drive strength for SCLK and MOSI pins"
+
 endif # SPI_NRFX

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -6,6 +6,7 @@
 
 #include <drivers/spi.h>
 #include <nrfx_spim.h>
+#include <hal/nrf_gpio.h>
 #include <string.h>
 
 #define LOG_DOMAIN "spi_nrfx_spim"
@@ -321,6 +322,22 @@ static int init_spim(const struct device *dev)
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s", dev->name);
 		return -EBUSY;
+	}
+	if (IS_ENABLED(CONFIG_SPI_NRFX_HIGH_DRIVE_STRENGTH)) {
+		const nrfx_spim_config_t *cfg = &get_dev_config(dev)->config;
+
+		nrf_gpio_cfg(cfg->sck_pin,
+			     NRF_GPIO_PIN_DIR_OUTPUT,
+			     NRF_GPIO_PIN_INPUT_CONNECT,
+			     NRF_GPIO_PIN_NOPULL,
+			     NRF_GPIO_PIN_H0H1,
+			     NRF_GPIO_PIN_NOSENSE);
+		nrf_gpio_cfg(cfg->mosi_pin,
+			     NRF_GPIO_PIN_DIR_OUTPUT,
+			     NRF_GPIO_PIN_INPUT_DISCONNECT,
+			     NRF_GPIO_PIN_NOPULL,
+			     NRF_GPIO_PIN_H0H1,
+			     NRF_GPIO_PIN_NOSENSE);
 	}
 
 #ifdef CONFIG_PM_DEVICE


### PR DESCRIPTION
Adds a Kconfig option to force the SPI modules to use high drive
strength output for the SCLK and MOSI pins. This can be required to
drive the SPI bus at higher frequencies when there is significant
capacitances on the lines.

This is the recommended solution from: https://devzone.nordicsemi.com/f/nordic-q-a/50064/spi-pin-drive-strength