### PR TITLE
ESP32 build fixes

### DIFF
--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -43,6 +43,8 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
   endif()
 
+  set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
+
   add_dependencies(app EspIdfBootloader EspPartitionTable)
 
   board_finalize_runner_args(esp32 "--esp-flash-bootloader=${espidf_build_dir}/bootloader/bootloader.bin")

--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -35,6 +35,14 @@ if(CONFIG_BOOTLOADER_ESP_IDF)
     INSTALL_COMMAND ""
     )
 
+  if(CONFIG_BUILD_OUTPUT_BIN)
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND python ${ESP_IDF_PATH}/components/esptool_py/esptool/esptool.py
+      ARGS --chip esp32 elf2image --flash_mode dio --flash_freq 40m
+      -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+      ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
+  endif()
+
   add_dependencies(app EspIdfBootloader EspPartitionTable)
 
   board_finalize_runner_args(esp32 "--esp-flash-bootloader=${espidf_build_dir}/bootloader/bootloader.bin")

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -80,7 +81,6 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
         self.require(self.espidf)
         bin_name = path.splitext(self.elf)[0] + path.extsep + 'bin'
-        cmd_convert = [self.espidf, '--chip', 'esp32', 'elf2image', self.elf]
         cmd_flash = [self.espidf, '--chip', 'esp32', '--port', self.device,
                      '--baud', self.baud, '--before', 'default_reset',
                      '--after', 'hard_reset', 'write_flash', '-u',
@@ -90,7 +90,6 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
         # Execute Python interpreter if calling a Python script
         if self.espidf.lower().endswith(".py") and sys.executable:
-            cmd_convert.insert(0, sys.executable)
             cmd_flash.insert(0, sys.executable)
 
         if self.bootloader_bin:
@@ -99,9 +98,6 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cmd_flash.extend(['0x10000', bin_name])
         else:
             cmd_flash.extend(['0x1000', bin_name])
-
-        self.logger.info("Converting ELF to BIN")
-        self.check_call(cmd_convert)
 
         self.logger.info("Flashing ESP32 on {} ({}bps)".
                          format(self.device, self.baud))


### PR DESCRIPTION
* Fixes issue where `west build` generates binary of size 13MB. This issue is caused by use of objcopy for elf to bin conversion. Add a esptool command for elf2image for correct binary generation.
* Remove elf to bin generation from runner script as it is handled by build system.
* Adding disassembly output causes issues due to which linking takes a lot of time on macOS. Removing `xtensa-esp32-elf-objdump -d -S zephyr.elf` command from build fixes the issue.