### PR TITLE
net: lwm2m: Trigger registration update only when registered

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -229,6 +229,11 @@ static void socket_fault_cb(int error)
 /* force re-update with remote peer */
 void engine_trigger_update(bool update_objects)
 {
+	if (client.engine_state < ENGINE_REGISTRATION_SENT ||
+	    client.engine_state > ENGINE_UPDATE_SENT) {
+		return;
+	}
+
 	/* TODO: add locking? */
 	client.trigger_update = true;
 


### PR DESCRIPTION
Add extra check for the LwM2M client state, to allow triggering of the
Registration Update message only when registered.

This fixes an issue, when the `trigger_update` flag could be set during
the bootstrap procedure (when the value of the Lifetime resource was
set), which resulted in an uneccessary Registration Update message just
after the successful registration.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>