### PR TITLE
 net: openthread: add CSL receiver API

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -56,6 +56,7 @@ enum ieee802154_hw_caps {
 	IEEE802154_HW_TXTIME	  = BIT(8), /* TX at specified time supported */
 	IEEE802154_HW_SLEEP_TO_TX = BIT(9), /* TX directly from sleep supported */
 	IEEE802154_HW_TX_SEC	  = BIT(10), /* TX security hadling supported */
+	IEEE802154_HW_RXTIME	  = BIT(11), /* RX at specified time supported */
 };
 
 enum ieee802154_filter_type {
@@ -158,6 +159,9 @@ enum ieee802154_config_type {
 
 	/** Sets the current MAC frame counter value for radios supporting transmit security. */
 	IEEE802154_CONFIG_FRAME_COUNTER,
+
+	/** Configure a radio reception slot */
+	IEEE802154_CONFIG_RX_SLOT,
 };
 
 /** IEEE802.15.4 driver configuration data. */
@@ -197,6 +201,13 @@ struct ieee802154_config {
 
 		/** ``IEEE802154_CONFIG_FRAME_COUNTER`` */
 		uint32_t frame_counter;
+
+		/** ``IEEE802154_CONFIG_RX_SLOT`` */
+		struct {
+			uint8_t channel;
+			uint32_t start;
+			uint32_t duration;
+		} rx_slot;
 	};
 };
 

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -103,6 +103,17 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+ *
+ * Define to 1 to enable software reception target time logic.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE                        \
+	(OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
  *
  * Define as 1 to support IEEE 802.15.4-2015 Header IE (Information Element) generation and parsing,

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -581,6 +581,25 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 	return OT_ERROR_NONE;
 }
 
+otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel,
+			     uint32_t aStart, uint32_t aDuration)
+{
+	int result;
+
+	ARG_UNUSED(aInstance);
+
+	struct ieee802154_config config = {
+		.rx_slot.channel = aChannel,
+		.rx_slot.start = aStart,
+		.rx_slot.duration = aDuration,
+	};
+
+	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_RX_SLOT,
+				      &config);
+
+	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
+}
+
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
 {
 	otError error = OT_ERROR_INVALID_STATE;
@@ -689,6 +708,10 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 		caps |= OT_RADIO_CAPS_TRANSMIT_TIMING;
 	}
 #endif
+
+	if (radio_caps & IEEE802154_HW_RXTIME) {
+		caps |= OT_RADIO_CAPS_RECEIVE_TIMING;
+	}
 
 	return caps;
 }


### PR DESCRIPTION
This commit implements the OpenThread APIs to configure a radio reception slot at a specific time. This is needed for the correct functioning of a CSL receiver.

This only adds the radio API, the actual delayed reception should be implemented by each driver.

`otPlatRadioReceiveAt` is only used by OpenThread if the radio provides the `OT_RADIO_CAPS_RECEIVE_TIMING`.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>