### PR TITLE
boards: hexiwear_k64: Drop SPI as supported board feature

### DIFF
--- a/boards/arm/hexiwear_k64/hexiwear_k64.yaml
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.yaml
@@ -12,5 +12,4 @@ supported:
   - gpio
   - i2c
   - pwm
-  - spi
   - watchdog


### PR DESCRIPTION
We don't currently configure any SPI interface on the hexiwear_k64 so
remove 'spi' as a listed supported feature in the board YAML.

This can be added back if SPI support is added for the board in the
future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>