### PR TITLE
CIS/CIG teardown at ACL disconnect

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -43,13 +43,15 @@
 
 #include "ll_sw/pdu.h"
 #include "ll_sw/lll.h"
+#include "ll_sw/lll_conn.h"
 #include "ll.h"
 
 #include "isoal.h"
 #include "lll_conn_iso.h"
-#include "ull_conn_iso_internal.h"
 #include "ull_conn_iso_types.h"
 #include "ull_iso_types.h"
+#include "ull_conn_internal.h"
+#include "ull_conn_iso_internal.h"
 
 #include "hci_internal.h"
 

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -60,12 +60,9 @@ struct lll_conn_iso_group {
 	uint8_t  num_cis : 5;   /* Number of CISes in this CIG */
 	uint8_t  role : 1;      /* 0: CENTRAL, 1: PERIPHERAL*/
 	uint8_t  paused : 1;    /* 1: CIG is paused */
-#if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP)
-	uint16_t cis_handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
-#endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 
 	/* Resumption information */
-	uint8_t  resume_cis;    /* CIS index to schedule at resume */
+	uint16_t resume_cis;    /* CIS handle to schedule at resume */
 };
 
 int lll_conn_iso_init(void);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -59,10 +59,11 @@
 #include "ull_master_internal.h"
 #include "ull_conn_internal.h"
 #include "lll_conn_iso.h"
-#include "ull_conn_iso_internal.h"
 #include "ull_conn_iso_types.h"
 #include "ull_iso_types.h"
 #include "ull_central_iso_internal.h"
+
+#include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -19,9 +19,9 @@
 #include "lll_conn.h"
 #include "ull_conn_types.h"
 #include "lll_conn_iso.h"
-
 #include "ull_conn_iso_types.h"
 #include "ull_conn_internal.h"
+#include "ull_conn_iso_internal.h"
 #include "ull_internal.h"
 #include "lll/lll_vendor.h"
 
@@ -114,6 +114,51 @@ struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle)
 	return cis;
 }
 
+struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_acl(struct ll_conn *conn, uint16_t *cis_iter)
+{
+	uint8_t cis_iter_start = (cis_iter == NULL) || (*cis_iter) == UINT16_MAX;
+	uint8_t cig_handle;
+
+	/* Find CIS associated with ACL conn */
+	for (cig_handle = 0; cig_handle < CONFIG_BT_CTLR_CONN_ISO_GROUPS; cig_handle++) {
+		struct ll_conn_iso_stream *cis;
+		struct ll_conn_iso_group *cig;
+		uint16_t handle_iter;
+		int8_t cis_idx;
+
+		cig = ll_conn_iso_group_get(cig_handle);
+		if (!cig) {
+			continue;
+		}
+
+		handle_iter = UINT16_MAX;
+
+		for (cis_idx = 0; cis_idx < cig->lll.num_cis; cis_idx++) {
+			cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
+			LL_ASSERT(cis);
+
+			uint16_t cis_handle = cis->lll.handle;
+
+			cis = ll_iso_stream_connected_get(cis_handle);
+			if (!cis) {
+				continue;
+			}
+
+			if (!cis_iter_start) {
+				/* Look for iterator start handle */
+				cis_iter_start = cis_handle == (*cis_iter);
+			} else if (cis->lll.acl_handle == conn->lll.handle) {
+				if (cis_iter) {
+					(*cis_iter) = cis_handle;
+				}
+				return cis;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_group *cig,
 							   uint16_t *handle_iter)
 {
@@ -127,7 +172,7 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_gr
 	for (handle = handle_start; handle <= LAST_VALID_CIS_HANDLE; handle++) {
 		cis = ll_conn_iso_stream_get(handle);
 		if (cis->group == cig) {
-			if (*handle_iter) {
+			if (handle_iter) {
 				(*handle_iter) = handle;
 			}
 			return cis;
@@ -348,4 +393,156 @@ void ull_conn_iso_resume_ticker_start(struct lll_event *resume_event,
 
 	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
 		  (ret == TICKER_STATUS_BUSY));
+}
+
+static void disabled_cig_cb(void *param)
+{
+	struct ll_conn_iso_group *cig;
+
+	cig = param;
+
+	ll_conn_iso_group_release(cig);
+
+	/* TODO: Flush pending TX in LLL */
+}
+
+static void ticker_stop_op_cb(uint32_t status, void *param)
+{
+	static memq_link_t link;
+	static struct mayfly mfy = {0, 0, &link, NULL, NULL};
+	struct ll_conn_iso_group *cig;
+	struct ull_hdr *hdr;
+	uint32_t ret;
+
+	/* Assert if race between thread and ULL */
+	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
+
+	cig = param;
+	hdr = &cig->ull;
+	mfy.param = cig;
+
+	if (ull_ref_get(hdr)) {
+		/* Event active (prepare/done ongoing) - wait for done and
+		 * disable there. Abort the ongoing event in LLL.
+		 */
+		LL_ASSERT(!hdr->disabled_cb);
+		hdr->disabled_param = mfy.param;
+		hdr->disabled_cb = disabled_cig_cb;
+
+		mfy.fp = lll_disable;
+		ret = mayfly_enqueue(TICKER_USER_ID_ULL_LOW,
+				     TICKER_USER_ID_LLL, 0, &mfy);
+		LL_ASSERT(!ret);
+	} else {
+		/* Disable now */
+		mfy.fp = disabled_cig_cb;
+		ret = mayfly_enqueue(TICKER_USER_ID_ULL_LOW,
+				     TICKER_USER_ID_ULL_HIGH, 0, &mfy);
+		LL_ASSERT(!ret);
+	}
+}
+
+static void disabled_cis_cb(void *param)
+{
+	struct ll_conn_iso_group *cig;
+	struct ll_conn_iso_stream *cis;
+	uint32_t ticker_status;
+	uint16_t handle_iter;
+	uint8_t cis_idx;
+	uint8_t num_cis;
+
+	cig = param;
+	num_cis = cig->lll.num_cis;
+	handle_iter = UINT16_MAX;
+
+	/* Remove all CISes marked for teardown */
+	for (cis_idx = 0; cis_idx < cig->lll.num_cis; cis_idx++) {
+		cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
+		LL_ASSERT(cis);
+
+		if (cis->teardown) {
+			struct ll_conn *conn;
+			ll_iso_stream_released_cb_t cis_released_cb;
+
+			conn = ll_conn_get(cis->lll.acl_handle);
+			cis_released_cb = cis->released_cb;
+
+			ll_conn_iso_stream_release(cis);
+			cig->lll.num_cis--;
+
+			/* Check if removed CIS had an ACL disassociation callback. Invoke
+			 * the callback to allow cleanup.
+			 */
+			if (cis_released_cb) {
+				/* CIS removed - notify caller */
+				cis_released_cb(conn);
+			}
+		}
+	}
+
+	if (num_cis && cig->lll.num_cis == 0) {
+		/* This was the last CIS of the CIG. Initiate CIG teardown by
+		 * stopping ticker.
+		 */
+		ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
+					    TICKER_USER_ID_ULL_HIGH,
+					    TICKER_ID_CONN_ISO_BASE +
+					    ll_conn_iso_group_handle_get(cig),
+					    ticker_stop_op_cb,
+					    cig);
+
+		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+			  (ticker_status == TICKER_STATUS_BUSY));
+	}
+}
+
+/**
+ * @brief Stop and tear down a connected ISO stream
+ * This function may be called to tear down a CIS. When the CIS teardown
+ * has completed and the stream is released and callback is provided, the
+ * cis_released_cb callback is invoked.
+ *
+ * @param cis		 Pointer to connected ISO stream to stop
+ * @param cis_relased_cb Callback to invoke when the CIS has been released.
+ *                       NULL to ignore.
+ */
+void ull_conn_iso_cis_stop(struct ll_conn_iso_stream *cis,
+			   ll_iso_stream_released_cb_t cis_relased_cb)
+{
+	struct ll_conn_iso_group *cig;
+	struct ull_hdr *hdr;
+
+	cig = cis->group;
+	hdr = &cig->ull;
+
+	if (cis->teardown) {
+		/* Teardown already started */
+		return;
+	}
+	cis->teardown = 1;
+	cis->released_cb = cis_relased_cb;
+
+	if (ull_ref_get(hdr)) {
+		/* Event is active (prepare/done ongoing) - wait for done and
+		 * continue CIS teardown from there. The disabled_cb cannot be
+		 * reserved for other use.
+		 */
+		LL_ASSERT(!hdr->disabled_cb || hdr->disabled_cb == disabled_cis_cb);
+
+		hdr->disabled_param = cig;
+		hdr->disabled_cb = disabled_cis_cb;
+	} else {
+		static memq_link_t link;
+		static struct mayfly mfy = {0, 0, &link, NULL, NULL};
+
+		/* Tear down CIS now in ULL_HIGH context. Ignore enqueue
+		 * error (already enqueued) as all CISes marked for teardown
+		 * will be handled in disabled_cis_cb. Use mayfly chaining to
+		 * prevent recursive stop calls.
+		 */
+		mfy.fp = disabled_cis_cb;
+		mfy.param = cig;
+		mayfly_enqueue(TICKER_USER_ID_ULL_LOW,
+			       TICKER_USER_ID_ULL_HIGH, 1, &mfy);
+	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -19,11 +19,15 @@ void ll_conn_iso_stream_release(struct ll_conn_iso_stream *cis);
 uint16_t ll_conn_iso_stream_handle_get(struct ll_conn_iso_stream *cis);
 struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle);
 struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle);
+struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_acl(struct ll_conn *conn,
+							 uint16_t *cis_iter);
 struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_group *cig,
 							   uint16_t *handle_iter);
 
 void ull_conn_iso_done(struct node_rx_event_done *done);
 void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis);
+void ull_conn_iso_cis_stop(struct ll_conn_iso_stream *cis,
+			   ll_iso_stream_released_cb_t cis_released_cb);
 
 void ull_conn_iso_resume_ticker_start(struct lll_event *resume_event,
 				      uint16_t cis_handle,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -19,11 +19,13 @@ void ll_conn_iso_stream_release(struct ll_conn_iso_stream *cis);
 uint16_t ll_conn_iso_stream_handle_get(struct ll_conn_iso_stream *cis);
 struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle);
 struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle);
+struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_group *cig,
+							   uint16_t *handle_iter);
 
 void ull_conn_iso_done(struct node_rx_event_done *done);
 void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis);
 
 void ull_conn_iso_resume_ticker_start(struct lll_event *resume_event,
-				      uint8_t  resume_cis,
+				      uint16_t cis_handle,
 				      uint32_t ticks_anchor,
 				      uint32_t resume_timeout);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -40,10 +40,6 @@ struct ll_conn_iso_group {
 	uint32_t p_sdu_interval;
 	uint16_t iso_interval;
 	uint8_t  cig_id;
-
-#if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP)
-	uint16_t cis_handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
-#endif /* CONFIG_BT_CTLR_CONN_ISO_STREAMS */
 };
 
 struct node_rx_conn_iso_req {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+struct ll_conn;
+
+typedef void (*ll_iso_stream_released_cb_t)(struct ll_conn *conn);
+
  #define LL_CIS_HANDLE_BASE CONFIG_BT_MAX_CONN
 
  #define LL_CIS_IDX_FROM_HANDLE(_handle) \
@@ -16,11 +20,13 @@ struct ll_conn_iso_stream {
 	uint8_t  cis_id;
 	struct ll_iso_datapath *datapath_in;
 	struct ll_iso_datapath *datapath_out;
-	uint32_t offset;        /* Offset of CIS from ACL event in us */
-	uint8_t  established;	/* 0 if CIS has not yet been established.
-				 * 1 if CIS has been established and host
-				 * notified.
-				 */
+	uint32_t offset;          /* Offset of CIS from ACL event in us */
+	ll_iso_stream_released_cb_t released_cb; /* CIS release callback */
+	uint8_t  established : 1; /* 0 if CIS has not yet been established.
+				   * 1 if CIS has been established and host
+				   * notified.
+				   */
+	uint8_t teardown : 1;     /* 1 if CIS teardown has been initiated */
 };
 
 struct ll_conn_iso_group {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -25,10 +25,11 @@
 #include "hal/debug.h"
 
 #include "lll_conn_iso.h"
-#include "ull_conn_iso_internal.h"
 #include "ull_conn_iso_types.h"
 #include "isoal.h"
 #include "ull_iso_types.h"
+#include "ull_conn_internal.h"
+#include "ull_conn_iso_internal.h"
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS)
 /* Allocate data path pools for RX/TX directions for each stream */

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -106,12 +106,6 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		cig->lll.handle = 0xFFFF;
 		cig->lll.role = acl->lll.role;
 
-		for (int i = 0; i < CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP;
-		     i++) {
-			cig->cis_handles[i] = 0xFFFF;
-			cig->lll.cis_handles[cig->lll.num_cis] = 0xFFFF;
-		}
-
 		ull_hdr_init(&cig->ull);
 		lll_hdr_init(&cig->lll, cig);
 	}
@@ -155,10 +149,7 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.tx.flush_timeout = req->p_ft;
 	cis->lll.tx.max_octets = sys_le16_to_cpu(req->p_max_pdu);
 
-
 	*cis_handle = ll_conn_iso_stream_handle_get(cis);
-	cig->lll.cis_handles[cig->lll.num_cis] = *cis_handle;
-	cig->cis_handles[cig->lll.num_cis] = *cis_handle;
 	cig->lll.num_cis++;
 
 	return 0;
@@ -179,16 +170,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cig->lll.handle = ll_conn_iso_group_handle_get(cig);
 	cig->sync_delay = sys_get_le24(ind->cig_sync_delay);
 
-	/* Find CIS in CIG. NOTE: We could look up via handle, but we want to
-	 * sanity check the CIG/CIS link.
-	 */
-	for (int i = 0; i < CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP; i++) {
-		if (cig->cis_handles[i] == cis_handle) {
-			cis = ll_conn_iso_stream_get(cig->cis_handles[i]);
-			break;
-		}
-	}
-
+	cis = ll_conn_iso_stream_get(cis_handle);
 	if (!cis) {
 		return BT_HCI_ERR_UNSPECIFIED;
 	}
@@ -210,6 +192,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 	static struct lll_prepare_param p;
 	struct ll_conn_iso_group *cig;
 	struct ll_conn_iso_stream *cis;
+	uint16_t handle_iter;
 	uint32_t err;
 	uint8_t ref;
 
@@ -221,9 +204,12 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 		return;
 	}
 
+	handle_iter = UINT16_MAX;
+
 	/* Increment CIS event counters */
 	for (int i = 0; i < cig->lll.num_cis; i++)  {
-		cis = ll_conn_iso_stream_get(cig->cis_handles[i]);
+		cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
+		LL_ASSERT(cis);
 
 		/* New CIS may become available by creation prior to the CIG
 		 * event in which it has event_count == 0. Don't increment
@@ -270,6 +256,7 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	uint32_t ticks_interval;
 	uint32_t ticker_status;
 	int32_t cig_offset_us;
+	uint16_t handle_iter;
 	uint16_t cis_handle;
 	uint8_t ticker_id;
 
@@ -279,23 +266,29 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	cis = ll_conn_iso_stream_get(cis_handle);
 
 	cis_offs_to_cig_ref = cig->sync_delay - cis->sync_delay;
-
-	for (int i = 0; i < cig->lll.num_cis; i++) {
-		uint16_t handle = cig->cis_handles[i];
-
-		/* Find valid CIS handle, but exclude incoming */
-		if ((handle != 0xFFFF) && (handle != cis_handle)) {
-			/* Ticker already started - just set the offset and
-			 * assign LLL handle (now valid).
-			 */
-			cis->lll.offset = cis_offs_to_cig_ref;
-			cis->lll.handle = cis_handle;
-			return;
-		}
-	}
+	handle_iter = UINT16_MAX;
 
 	cis->lll.offset = cis_offs_to_cig_ref;
 	cis->lll.handle = cis_handle;
+
+	/* Check if another CIS was already started and CIG ticker is
+	 * running. If so, we just return with updated offset and
+	 * validated handle.
+	 */
+	for (int i = 0; i < cig->lll.num_cis; i++) {
+		struct ll_conn_iso_stream *other_cis;
+
+		other_cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
+		LL_ASSERT(other_cis);
+
+		if (other_cis == cis || other_cis->lll.handle == 0xFFFF) {
+			/* Same CIS or not valid - skip */
+			continue;
+		}
+
+		/* We're done */
+		return;
+	}
 
 	ticker_id = TICKER_ID_CONN_ISO_BASE +
 		    ll_conn_iso_group_handle_get(cig);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -24,11 +24,11 @@
 #include "lll_conn_iso.h"
 
 #include "ull_conn_types.h"
-#include "ull_conn_internal.h"
 #include "ull_conn_iso_types.h"
-#include "ull_conn_iso_internal.h"
 #include "ull_internal.h"
 
+#include "ull_conn_internal.h"
+#include "ull_conn_iso_internal.h"
 #include "lll_peripheral_iso.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
@@ -129,6 +129,8 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->cis_id = req->cis_id;
 	cis->established = 0;
 	cis->group = cig;
+	cis->teardown = 0;
+	cis->released_cb = NULL;
 
 	cis->lll.handle = 0xFFFF;
 	cis->lll.acl_handle = acl->lll.handle;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -376,17 +376,21 @@ static void deferred_work(struct k_work *work)
 		if (IS_ENABLED(CONFIG_BT_ISO)) {
 			struct bt_conn *iso;
 
+			/* Disconnect all ISO channels associated
+			 * with ACL conn.
+			 */
 			iso = conn_lookup_iso(conn);
-			if (iso) {
+			while (iso) {
 				iso->err = conn->err;
 
 				bt_iso_disconnected(iso);
 				bt_conn_unref(iso);
-			}
 
-			/* Stop if only ISO was Disconnected */
-			if (conn->type == BT_CONN_TYPE_ISO) {
-				return;
+				/* Stop if only ISO was Disconnected */
+				if (conn->type == BT_CONN_TYPE_ISO) {
+					return;
+				}
+				iso = conn_lookup_iso(conn);
 			}
 		}
 


### PR DESCRIPTION
Bluetooth: controller: CIS/CIG teardown at ACL disconnect
    
When an ACL connection with active CISes terminates, inject CIS/CIG
teardown to ensure CIS is stopped before ACL disconnection completes.
This includes stopping CIG ticker when last CIS has stopped.

Bluetooth: controller: Remove cis_handles array from ISO groups

Maintaining the cis_handles array in ULL/LLL ISO group data amounts to
double book-keeping. This commit eliminates the array and introduces a
'getter' for obtaining CISes owned by a specific CIG, and iterate
through them.

Bluetooth: host: Disconnect all ISO channels on BT_CONN_DISCONNECTED

When an ACL changes state to disconnected, all associated ISO channels
must be disconnected and cleaned up. This commit ensures that.

Signed-off-by: Morten Priess <mtpr@oticon.com>