### PR TITLE
canbus: isotp: use new k_work API

### DIFF
--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -1333,11 +1333,12 @@ int isotp_send_buf(const struct device *can_dev,
 static int isotp_workq_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
 	LOG_DBG("Starting workqueue");
-	k_work_q_start(&isotp_workq,
-		       tx_stack,
-		       K_KERNEL_STACK_SIZEOF(tx_stack),
-		       CONFIG_ISOTP_WORKQUEUE_PRIO);
+	k_work_queue_start(&isotp_workq, tx_stack,
+			   K_KERNEL_STACK_SIZEOF(tx_stack),
+			   CONFIG_ISOTP_WORKQUEUE_PRIO, NULL);
+
 	k_thread_name_set(&isotp_workq.thread, "isotp_work");
 
 	return 0;


### PR DESCRIPTION
Replace soon-to-be-deprecated call to start queue.

Delayed work is not used here.

**Remark:**
While implementing the work queue changes, I realized that the local work queue is actually not used in the ISO-TP implementation. Instead, the work is always submitted to the system work queue with `k_work_submit`. A trivial fix did not work, so I opened issue #34862 to leave it for a separate PR.