### PR TITLE
drivers: i2s: i2s_sam_ssc: Fix build issue

### DIFF
--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -88,7 +88,7 @@ struct stream {
 			       const struct device *);
 	void (*queue_drop)(struct stream *);
 	int (*set_data_format)(const struct i2s_sam_dev_cfg *const,
-			       struct i2s_config *);
+			       const struct i2s_config *);
 };
 
 /* Device run time data */


### PR DESCRIPTION
Change to make i2s_config const missed a case in the SAM driver.
Without this we get build errors when building in CI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>