### PR TITLE
Bluetooth: Crypto: Fix naming of params

### DIFF
--- a/include/bluetooth/crypto.h
+++ b/include/bluetooth/crypto.h
@@ -102,19 +102,19 @@ int bt_ccm_decrypt(const uint8_t key[16], uint8_t nonce[13], const uint8_t *enc_
  *
  *  @param key       128 bit MS byte first key
  *  @param nonce     13 byte MS byte first nonce
- *  @param enc_data  Buffer to place encrypted data in
+ *  @param plaintext Plaintext buffer to encrypt
  *  @param len       Length of the encrypted data
  *  @param aad       Additional input data
  *  @param aad_len   Additional input data length
- *  @param plaintext Plaintext buffer to encrypt
+ *  @param enc_data  Buffer to place encrypted data in
  *  @param mic_size  Size of the trailing MIC (in bytes)
  *
  *  @retval 0        Successfully encrypted the data.
  *  @retval -EINVAL  Invalid parameters.
  */
-int bt_ccm_encrypt(const uint8_t key[16], uint8_t nonce[13], const uint8_t *enc_data,
-		   size_t len, const uint8_t *aad, size_t aad_len,
-		   uint8_t *plaintext, size_t mic_size);
+int bt_ccm_encrypt(const uint8_t key[16], uint8_t nonce[13],
+		   const uint8_t *plaintext, size_t len, const uint8_t *aad,
+		   size_t aad_len, uint8_t *enc_data, size_t mic_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The naming and documentation of the parameters was inconsistent with their
actual meaning and the implementation - enc_data and plaintext were swapped.