### PR TITLE
Revert "doc: move 'getting help' to contrib guidelines"

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -12,53 +12,6 @@ This document explains how to participate in project conversations, log bugs
 and enhancement requests, and submit patches to the project so your patch will
 be accepted quickly in the codebase.
 
-
-.. _help:
-
-Asking for Help
-***************
-
-You can ask for help on a mailing list or on Slack. Please send bug reports and
-feature requests to GitHub.
-
-* **Mailing Lists**: users@lists.zephyrproject.org is usually the right list to
-  ask for help. `Search archives and sign up here`_.
-* **Slack**: Zephyr's workspace is https://zephyrproject.slack.com; you can
-  register with this `Slack invite`_.
-* **GitHub**: Use `GitHub issues`_ for bugs and feature requests.
-
-How to Ask
-===========
-
-.. important::
-
-   Please search this documentation and the mailing list archives first. Your
-   question may have an answer there.
-
-Don't just say "this isn't working" or ask "is this working?". Include as much
-detail as you can about:
-
-#. What you want to do
-#. What you tried (commands you typed, etc.)
-#. What happened (output of each command, etc.)
-
-Use Copy/Paste
-==============
-
-Please **copy/paste text** instead of taking a picture or a screenshot of it.
-Text includes source code, terminal commands, and their output.
-
-Doing this makes it easier for people to help you, and also helps other users
-search the archives.
-
-When copy/pasting more than 5 lines of text into Slack, create a `snippet`_.
-
-.. _Search archives and sign up here: https://lists.zephyrproject.org/g/users
-.. _Slack invite: https://tinyurl.com/y5glwylp
-.. _GitHub issues: https://github.com/zephyrproject-rtos/zephyr/issues
-.. _snippet: https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet
-
-
 Licensing
 *********
 

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -422,3 +422,48 @@ Here are some next steps for exploring Zephyr:
 * Check out :ref:`beyond-GSG` for additional setup alternatives and ideas
 * Discover :ref:`project-resources` for getting help from the Zephyr
   community
+
+.. _help:
+
+Asking for Help
+***************
+
+You can ask for help on a mailing list or on Slack. Please send bug reports and
+feature requests to GitHub.
+
+* **Mailing Lists**: users@lists.zephyrproject.org is usually the right list to
+  ask for help. `Search archives and sign up here`_.
+* **Slack**: Zephyr's workspace is https://zephyrproject.slack.com; you can
+  register with this `Slack invite`_.
+* **GitHub**: Use `GitHub issues`_ for bugs and feature requests.
+
+How to Ask
+==========
+
+.. important::
+
+   Please search this documentation and the mailing list archives first. Your
+   question may have an answer there.
+
+Don't just say "this isn't working" or ask "is this working?". Include as much
+detail as you can about:
+
+#. What you want to do
+#. What you tried (commands you typed, etc.)
+#. What happened (output of each command, etc.)
+
+Use Copy/Paste
+==============
+
+Please **copy/paste text** instead of taking a picture or a screenshot of it.
+Text includes source code, terminal commands, and their output.
+
+Doing this makes it easier for people to help you, and also helps other users
+search the archives.
+
+When copy/pasting more than 5 lines of text into Slack, create a `snippet`_.
+
+.. _Search archives and sign up here: https://lists.zephyrproject.org/g/users
+.. _Slack invite: https://tinyurl.com/y5glwylp
+.. _GitHub issues: https://github.com/zephyrproject-rtos/zephyr/issues
+.. _snippet: https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet


### PR DESCRIPTION
This reverts commit 05ccdd7c4086d940d2cfd311ae8102f2d905b6e7.

I put it in a standalone place so that it would be easy for beginners
to find.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>