### PR TITLE
sensor: max17262: Fix CI build failure

### DIFF
--- a/drivers/sensor/max17262/max17262.c
+++ b/drivers/sensor/max17262/max17262.c
@@ -334,7 +334,7 @@ static const struct sensor_driver_api max17262_battery_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &max17262_gauge_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    &max17262_data_##n,				\
 			    &max17262_config_##n, POST_KERNEL,		\
 			    CONFIG_SENSOR_INIT_PRIORITY,		\


### PR DESCRIPTION
device_pm_control_nop has been marked deprecated so we get a CI
build error due to its use.  Replace with NULL to fix the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>