### PR TITLE
doc: samples: restore :maxdepth: 2

### DIFF
--- a/samples/index.rst
+++ b/samples/index.rst
@@ -5,7 +5,7 @@ Samples and Demos
 
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
    :glob:
 
    classic


### PR DESCRIPTION
Commit 09ba258b051b5f91c30cf836e63312e70bc1878f changed the maxdepth
of the entire samples toctree to 4 from 2 while making a fix to the
tensorflow docs.

Unfortunately that makes the docs index page for the samples too long,
as there are a lot of samples. It's better to just link each one by
one and let the user click to the one they want to find out
information on building and running the sample. Since the individual
README for each sample is usually quite short, it's not a lot of
scrolling, and the per-sample toctree is already available in the
sidebar anyway.

Fix this issue with the index page by restoring the original maxdepth.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>