### PR TITLE
doc: samples: bme280: fix missing end of sentence

### DIFF
--- a/samples/sensor/bme280/README.rst
+++ b/samples/sensor/bme280/README.rst
@@ -21,7 +21,8 @@ Building and Running
 
 The sample can be configured to support BME280 sensors connected via either I2C
 or SPI. Configuration is done via :ref:`devicetree <dt-guide>`. The devicetree
-must have an enabled node with ``compatible = "bosch,bme280";``. See below for
+must have an enabled node with ``compatible = "bosch,bme280";``. See
+:dtcompatible:`bosch,bme280` for the devicetree binding and see below for
 examples and common configurations.
 
 If the sensor is not built into your board, start by wiring the sensor pins
@@ -75,8 +76,9 @@ peripheral.
 Board-specific overlays
 =======================
 
-You can create a board-specific devicetree overlay for any board in the
-:file:`boards` directory. This sample must provide
+If your board's devicetree does not have a BME280 node already, you can create
+a board-specific devicetree overlay adding one in the :file:`boards` directory.
+See existing overlays for examples.
 
 The build system uses these overlays by default when targeting those boards, so
 no ``DTC_OVERLAY_FILE`` setting is needed when building and running.


### PR DESCRIPTION
Looks like I forgot to finish a sentence. There's nothing really
special besides the top level requirement for an enabled node which is
mentioned at the top of the page. Add a reference to the bindings
index while we're here to make it clearer what such nodes contain.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>