### PR TITLE
west.yml: Update Mbed TLS to 2.26.0

### DIFF
--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -62,7 +62,7 @@ static sec_tag_t m_sec_tags[] = {
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 		1,
 #endif
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 		APP_PSK_TAG,
 #endif
 };

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -67,7 +67,7 @@ static APP_DMEM sec_tag_t m_sec_tags[] = {
 #if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(CONFIG_NET_SOCKETS_OFFLOAD)
 		APP_CA_CERT_TAG,
 #endif
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 		APP_PSK_TAG,
 #endif
 };
@@ -85,7 +85,7 @@ static int tls_init(void)
 	}
 #endif
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 	err = tls_credential_add(APP_PSK_TAG, TLS_CREDENTIAL_PSK,
 				 client_psk, sizeof(client_psk));
 	if (err < 0) {

--- a/samples/net/mqtt_publisher/src/test_certs.h
+++ b/samples/net/mqtt_publisher/src/test_certs.h
@@ -127,7 +127,7 @@ static const unsigned char ca_certificate[] = {
 };
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 /* Avoid leading zero in psk because there's a potential issue of mosquitto
  * that leading zero of psk will be skipped and it leads to TLS handshake
  * failure

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -731,7 +731,7 @@ static int tls_set_psk(struct tls_context *tls,
 		       struct tls_credential *psk,
 		       struct tls_credential *psk_id)
 {
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 	int err = mbedtls_ssl_conf_psk(&tls->config,
 				       psk->buf, psk->len,
 				       (const unsigned char *)psk_id->buf,

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       revision: 31acbaa36e9e74ab88ac81e3d21e7f1d00a71136
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 53044168b43f06ec5654b906a2cdd260bf477edd
+      revision: pull/22/head
       path: modules/crypto/mbedtls
     - name: mcuboot
       revision: 6eca8bbc2bdbf16d5ebbfd89ca27aaa9b3d88400


### PR DESCRIPTION
Move to the latest release of Mbed TLS.

Signed-off-by: David Brown <david.brown@linaro.org>