### PR TITLE
ci: Update to docker image v0.17.1

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.0"
+          image: "zephyrprojectrtos/ci:v0.17.1"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.0"
+          image: "zephyrprojectrtos/ci:v0.17.1"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bsim-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.0-rc1
+      image: zephyrprojectrtos/ci:v0.17.1
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.0
+      image: zephyrprojectrtos/ci:v0.17.1
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
Update docker image to v0.17.1 to get SDK 0.13.0-alpha-1 to
allow testing of ARC64 as well as the SDK update to gcc-10.3 and
qemu 6.0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>