### PR TITLE
testsuite: Allow user to override minimal logging

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -79,7 +79,7 @@ config TEST_LOGGING_DEFAULTS
 	bool "Enable test case logging defaults"
 	depends on TEST
 	select LOG
-	select LOG_MINIMAL
+	imply LOG_MINIMAL
 	default y
 	help
 	  Option which implements default policy of enabling logging in


### PR DESCRIPTION
The testsuite was always forcing minimal logging. This is problematic
as it does not allow user to see full logging string. Allow user to
override the minimal logging if needed, the default is still to
enable minimal logging.

[DL: Commit 7f08061f0c4d341f37b206a95b7e1a4c0b292253 reverts this.
     Since this is useful, let's re-apply this.]

Fixes #34696

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>
Signed-off-by: Daniel Leung <daniel.leung@intel.com>