### PR TITLE
drivers: wifi: esp: stop using pkt->work in TX path

### DIFF
--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -93,6 +93,8 @@ void esp_socket_init(struct esp_data *data)
 		k_work_init(&sock->connect_work, esp_connect_work);
 		k_work_init(&sock->recvdata_work, esp_recvdata_work);
 		k_work_init(&sock->close_work, esp_close_work);
+		k_work_init(&sock->send_work, esp_send_work);
+		k_fifo_init(&sock->tx_fifo);
 	}
 }
 


### PR DESCRIPTION
Usage of k_work object from within net_pkt results in undefined behavior
in case when net_pkt is deallocated (by net_pkt_unref()) before work has
been finished.

Use per socket k_work object (sock->send_work) to submit send work and
put net_pkt objects onto k_fifo (sock->tx_fifo). Add a helper function
esp_socket_queue_tx() for that, which will make sure that packets are
enqueued (and consumed/dereferenced later on) only when send work
handler will be successfully submitted.

Can replace part of #34703.