### PR TITLE
logging: use LOG_MODE_MINIMAL instead of LOG_MINIMAL in code

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -289,7 +289,7 @@ static inline void log_printk(const char *fmt, va_list ap)
 char *z_log_strdup(const char *str);
 static inline char *log_strdup(const char *str)
 {
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || IS_ENABLED(CONFIG_LOG2)) {
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL) || IS_ENABLED(CONFIG_LOG2)) {
 		return (char *)str;
 	}
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -30,7 +30,7 @@ extern "C" {
 #define CONFIG_LOG_MAX_LEVEL 0U
 #endif
 
-#if !defined(CONFIG_LOG) || defined(CONFIG_LOG_MINIMAL)
+#if !defined(CONFIG_LOG) || defined(CONFIG_LOG_MODE_MINIMAL)
 #define CONFIG_LOG_DOMAIN_ID 0U
 #endif
 
@@ -296,7 +296,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
 		break; \
 	} \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, __VA_ARGS__); \
 		break; \
 	} \
@@ -349,7 +349,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
 						(_dsource)->filters : 0;\
 	\
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, "%s", _str); \
 		z_log_minimal_hexdump_print(_level, \
 					    (const char *)_data, _len);\
@@ -469,7 +469,7 @@ enum log_strdup_action {
 };
 
 #define Z_LOG_PRINTK(...) do { \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL) || !IS_ENABLED(CONFIG_LOG2)) { \
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL) || !IS_ENABLED(CONFIG_LOG2)) { \
 		z_log_minimal_printk(__VA_ARGS__); \
 		break; \
 	} \
@@ -805,7 +805,7 @@ __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
 		break; \
 	} \
-	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
+	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		Z_LOG_TO_VPRINTK(_level, _str, _valist); \
 		break; \
 	} \
@@ -851,7 +851,7 @@ static inline log_arg_t z_log_do_strdup(uint32_t msk, uint32_t idx,
 					log_arg_t param,
 					enum log_strdup_action action)
 {
-#ifndef CONFIG_LOG_MINIMAL
+#ifndef CONFIG_LOG_MODE_MINIMAL
 	char *z_log_strdup(const char *str);
 
 	if (msk & (1 << idx)) {

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -169,7 +169,7 @@ void log_backend_enable(struct log_backend const *const backend,
  */
 void log_backend_disable(struct log_backend const *const backend);
 
-#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MINIMAL)
+#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_MINIMAL)
 #define LOG_CORE_INIT() log_core_init()
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -515,8 +515,8 @@ uintptr_t arch_page_info_get(void *addr, uintptr_t *location,
  * Early boot console output hook
  *
  * Definition of this function is optional. If implemented, any invocation
- * of printk() (or logging calls with CONFIG_LOG_MINIMAL which are backed by
- * printk) will default to sending characters to this function. It is
+ * of printk() (or logging calls with CONFIG_LOG_MODE_MINIMAL which are backed
+ * by printk) will default to sending characters to this function. It is
  * useful for early boot debugging before main serial or console drivers
  * come up.
  *

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -237,7 +237,7 @@ extern void __stdout_hook_install(int (*fn)(int));
 #define CONFIG_BT_MONITOR_ON_DEV_NAME CONFIG_UART_CONSOLE_ON_DEV_NAME
 #endif
 
-#ifndef CONFIG_LOG_MINIMAL
+#ifndef CONFIG_LOG_MODE_MINIMAL
 struct monitor_log_ctx {
 	size_t total_len;
 	char msg[MONITOR_MSG_MAX];
@@ -341,7 +341,7 @@ static const struct log_backend_api monitor_log_api = {
 };
 
 LOG_BACKEND_DEFINE(bt_monitor, monitor_log_api, true);
-#endif /* CONFIG_LOG_MINIMAL */
+#endif /* CONFIG_LOG_MODE_MINIMAL */
 
 static int bt_monitor_init(const struct device *d)
 {

--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT CONFIG_LOG_MINIMAL)
+if(NOT CONFIG_LOG_MODE_MINIMAL)
   zephyr_sources_ifdef(
     CONFIG_LOG
     log_list.c

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -14,7 +14,7 @@ rsource "Kconfig.mode"
 
 rsource "Kconfig.filtering"
 
-if !LOG_FRONTEND && !LOG_MINIMAL
+if !LOG_FRONTEND && !LOG_MODE_MINIMAL
 
 rsource "Kconfig.formatting"
 
@@ -22,7 +22,7 @@ rsource "Kconfig.processing"
 
 rsource "Kconfig.backends"
 
-endif # !LOG_FRONTEND && !LOG_MINIMAL
+endif # !LOG_FRONTEND && !LOG_MODE_MINIMAL
 
 rsource "Kconfig.misc"
 

--- a/subsys/logging/Kconfig.filtering
+++ b/subsys/logging/Kconfig.filtering
@@ -5,7 +5,7 @@ menu "Logging levels filtering"
 
 config LOG_RUNTIME_FILTERING
 	bool "Runtime filtering reconfiguration"
-	depends on !LOG_FRONTEND && !LOG_MINIMAL
+	depends on !LOG_FRONTEND && !LOG_MODE_MINIMAL
 	help
 	  Allow runtime configuration of maximal, independent severity
 	  level for instance.

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -5,7 +5,7 @@ menu "Misc"
 
 config LOG_DOMAIN_ID
 	int "Domain ID"
-	depends on !LOG_MINIMAL
+	depends on !LOG_MODE_MINIMAL
 	default 0
 	range 0 7
 	help
@@ -14,7 +14,7 @@ config LOG_DOMAIN_ID
 config LOG_CMDS
 	bool "Enable shell commands"
 	depends on SHELL
-	depends on !LOG_FRONTEND && !LOG_MINIMAL
+	depends on !LOG_FRONTEND && !LOG_MODE_MINIMAL
 	default y if SHELL
 
 config LOG_TEST_CLEAR_MESSAGE_SPACE

--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -3,7 +3,10 @@
 
 choice LOG_MODE
 	prompt "Mode"
+	default LOG_MODE_MINIMAL if LOG_MINIMAL
 	default LOG_MODE_DEFERRED
+
+if !LOG_MINIMAL
 
 config LOG_MODE_DEFERRED
 	bool "Deferred logging"
@@ -41,6 +44,14 @@ config LOG_MODE_IMMEDIATE
 	  flawlessly in that mode because one log operation can be interrupted
 	  by another one in the higher priority context.
 
+config LOG_FRONTEND
+	bool "Frontend"
+	help
+	  When enabled, logs are redirected to a custom frontend instead
+	  of being processed by the logger. In this mode runtime filtering and
+	  multiple backends are not used.
+
+endif # LOG_MINIMAL
 
 config LOG_MODE_MINIMAL
 	bool "Minimal-footprint"
@@ -53,13 +64,6 @@ config LOG_MODE_MINIMAL
 	  but not runtime filtering. There are no timestamps, prefixes,
 	  colors, or asynchronous logging, and all messages are simply
 	  sent to printk().
-
-config LOG_FRONTEND
-	bool "Frontend"
-	help
-	  When enabled, logs are redirected to a custom frontend instead
-	  of being processed by the logger. In this mode runtime filtering and
-	  multiple backends are not used.
 
 endchoice
 
@@ -74,4 +78,6 @@ config LOG_IMMEDIATE
 config LOG_MINIMAL
 	bool
 	imply PRINTK
-	default y if LOG_MODE_MINIMAL
+	help
+	  Hidden option as a redirection to select LOG_MODE_MINIMAL as
+	  a choice cannot be "selected" or "implied".

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -3,7 +3,7 @@
 
 menu "Processing"
 
-if !LOG_MINIMAL
+if !LOG_MODE_MINIMAL
 
 config LOG_PRINTK
 	bool "Process printk messages"
@@ -159,6 +159,6 @@ config LOG_SPEED
 	  If enabled, logging may take more code size to get faster logging.
 endif # LOG2
 
-endif # !LOG_MINIMAL
+endif # !LOG_MODE_MINIMAL
 
 endmenu

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -197,7 +197,7 @@ config SHELL_CMDS_SELECT
 
 config SHELL_LOG_BACKEND
 	bool "Enable shell log backend"
-	depends on !LOG_MINIMAL
+	depends on !LOG_MODE_MINIMAL
 	default y if LOG
 	help
 	  When enabled, backend will use the shell for logging.

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -79,7 +79,7 @@ config TEST_LOGGING_DEFAULTS
 	bool "Enable test case logging defaults"
 	depends on TEST
 	select LOG
-	select LOG_MINIMAL
+	imply LOG_MINIMAL
 	default y
 	help
 	  Option which implements default policy of enabling logging in


### PR DESCRIPTION
`CONFIG_LOG_MINIMAL` is simply being used to enable
`CONFIG_LOG_MODE_MINIMAL` as a redirection. Therefore, it is
better for code to use `CONFIG_LOG_MODE_MINIMAL` so it is more
consistent with other modes.