### PR TITLE
west.yml: Update mcuboot to include mimxrt106x_evk board configs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -91,7 +91,7 @@ manifest:
       revision: 53044168b43f06ec5654b906a2cdd260bf477edd
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 6eca8bbc2bdbf16d5ebbfd89ca27aaa9b3d88400
+      revision: pull/49/head
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e


### PR DESCRIPTION
Updates mcuboot to include configuration overlays for the mimxrt1060_evk
and mimxrt1064_evk boards.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>