### PR TITLE
clang-format: Change lines length limit from 80 to 100

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ BreakConstructorInitializersBeforeComma: false
 #BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 80
+ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 #CompactNamespaces: false # Unknown to clang-format-4.0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false


### PR DESCRIPTION
Change line length limit from former 80 characters to current 100.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>