### PR TITLE
smp: shell: consume all pending buffers in smp_shell_process()

### DIFF
--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -137,19 +137,21 @@ void smp_shell_process(struct smp_shell_data *data)
 	struct net_buf *buf;
 	struct net_buf *nb;
 
-	buf = net_buf_get(&data->buf_ready, K_NO_WAIT);
-	if (!buf) {
-		return;
-	}
+	while (true) {
+		buf = net_buf_get(&data->buf_ready, K_NO_WAIT);
+		if (!buf) {
+			break;
+		}
 
-	nb = mcumgr_serial_process_frag(&smp_shell_rx_ctxt,
-					buf->data,
-					buf->len);
-	if (nb != NULL) {
-		zephyr_smp_rx_req(&smp_shell_transport, nb);
-	}
+		nb = mcumgr_serial_process_frag(&smp_shell_rx_ctxt,
+						buf->data,
+						buf->len);
+		if (nb != NULL) {
+			zephyr_smp_rx_req(&smp_shell_transport, nb);
+		}
 
-	net_buf_unref(buf);
+		net_buf_unref(buf);
+	}
 }
 
 static uint16_t smp_shell_get_mtu(const struct net_buf *nb)


### PR DESCRIPTION
smp_shell_process() is called only once after receiving new bytes over
shell. If multiple MCUMGR frames were received over UART one after the
other, then calling smp_shell_process() resulted in consuming only the
first one. All subsequent frames were not processed unless there was
some more RX traffic.

Process received frames in smp_shell_process() in a loop until there is
no frame left. This will make sure that received packets are not stalled
waiting for more RX traffic to trigger processing again.

Fixes: #34891