### PR TITLE
net: packet: Do not drop net_pkt immediately

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -634,8 +634,9 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		 * but the listener might have a specific protocol set. This is ok
 		 * and let the packet pass this check in this case.
 		 */
-		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM) ||
-		    IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {
+		if ((IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM) ||
+		     IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) &&
+		    net_pkt_family(pkt) == AF_PACKET) {
 			if ((conn->proto != proto) && (proto != ETH_P_ALL) &&
 				(proto != IPPROTO_RAW)) {
 				continue;
@@ -775,8 +776,9 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		}
 	}
 
-	if ((is_mcast_pkt && mcast_pkt_delivered) || raw_pkt_delivered ||
-		raw_pkt_continue) {
+	if ((is_mcast_pkt && mcast_pkt_delivered) ||
+	    (net_pkt_family(pkt) == AF_PACKET && (raw_pkt_delivered ||
+						  raw_pkt_continue))) {
 		if (raw_pkt_continue) {
 			/* When there is open connection different than
 			 * AF_PACKET this packet shall be also handled in

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -22,6 +22,8 @@ LOG_MODULE_REGISTER(net_sockets_raw, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint8_t proto)
 {
+	sa_family_t orig_family;
+
 #if IS_ENABLED(CONFIG_NET_DSA)
 	/*
 	 * For DSA the master port is not supporting raw packets. Only the
@@ -46,7 +48,13 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint8_t proto)
 	 * data part to be feed to non raw socket.
 	 */
 
+	orig_family = net_pkt_family(pkt);
+
 	net_pkt_set_family(pkt, AF_PACKET);
 
-	return net_conn_input(pkt, NULL, proto, NULL);
+	(void)net_conn_input(pkt, NULL, proto, NULL);
+
+	net_pkt_set_family(pkt, orig_family);
+
+	return NET_CONTINUE;
 }


### PR DESCRIPTION
If there are no sockets in the system, then do not drop the
packet immediately as there can be other L2 network handlers
like gPTP in the system. This will also allow ICMP messages
to pass to local handler.

Fixes #34865

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>