### PR TITLE
boards: doc: Fix building target name

### DIFF
--- a/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
+++ b/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
@@ -89,11 +89,11 @@ The Cortex®-R7 of rcar_h3ulcb board needs to be started by the Cortex®-A cores
 Building
 ========
 
-Applications for the ``rcar_h3ulcb`` board configuration can be built in the usual way (see :ref:`build_an_application` for more details).
+Applications for the ``rcar_h3ulcb_cr7`` board configuration can be built in the usual way (see :ref:`build_an_application` for more details).
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: rcar_h3ulcb
+   :board: rcar_h3ulcb_cr7
    :goals: build
 
 Debugging


### PR DESCRIPTION
This commit fix the documentation for Rensas H3ULC board.
It fixes target name that was not the right one for rcar_h3ulcb board.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>