### PR TITLE
modules: hal_nordic: Update nrfx to version 2.5.0

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -127,17 +127,6 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 			}
 		}
 
-		if (cur_xfer.primary_length == 0) {
-			/* For a zero-length transfer, the STOP task will not
-			 * be triggered automatically by the shortcut with the
-			 * event that signals the transfer end. It needs to be
-			 * done "manually" to prevent the driver getting stuck
-			 * after the address byte is acknowledged.
-			 */
-			nrf_twim_task_trigger(get_dev_config(dev)->twim.p_twim,
-					      NRF_TWIM_TASK_STOP);
-		}
-
 		ret = k_sem_take(&(get_dev_data(dev)->completion_sync),
 				 I2C_TRANSFER_TIMEOUT_MSEC);
 		if (ret != 0) {

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 9bd5891e3c6327471ac6b8cf65e7c80e499da5f1
+      revision: 574493fe29c79140df4827ab5d4a23df79d03681
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
Update the hal_nordic module revision, to switch to nrfx v2.5.0.

Additionaly:
- drivers: i2c_nrfx_twim: Remove extra path for zero-length transfers

nrfx 2.5.0 release includes the patch in the nrfx_twim driver that
fixes the driver behavior for zero-length transfers. No need to keep
the same fix in the shim layer.
This effectively reverts cb86a2b306517847420c4694f42881571bc507c4.