### PR TITLE
net: openthread: complete CSL receiver API

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -162,6 +162,14 @@ enum ieee802154_config_type {
 
 	/** Configure a radio reception slot */
 	IEEE802154_CONFIG_RX_SLOT,
+
+	/** Enable CSL receiver (Endpoint) */
+	IEEE802154_CONFIG_CSL_RECEIVER,
+
+	/** Configure the next CSL receive window center, in units of microseconds,
+	 *  based on the radio time.
+	 */
+	IEEE802154_CONFIG_CSL_RX_TIME,
 };
 
 /** IEEE802.15.4 driver configuration data. */
@@ -208,6 +216,15 @@ struct ieee802154_config {
 			uint32_t start;
 			uint32_t duration;
 		} rx_slot;
+
+		/** ``IEEE802154_CONFIG_CSL_RECEIVER`` */
+		struct {
+			uint32_t period;
+			uint8_t *addr;
+		} csl_recv;
+
+		/** ``IEEE802154_CONFIG_CSL_RX_TIME`` */
+		uint32_t csl_rx_time;
 	};
 };
 
@@ -270,6 +287,13 @@ struct ieee802154_radio_api {
 
 	/** Get the current radio time in microseconds */
 	uint64_t (*get_time)(const struct device *dev);
+
+	/** Get the current accuracy, in units of ± ppm, of the clock used for
+	 *  scheduling CSL transmissions or receive windows.
+	 *  Note: Implementations may optimize this value based on operational
+	 *  conditions (i.e.: temperature).
+	 */
+	uint8_t (*get_csl_acc)(const struct device *dev);
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -979,3 +979,41 @@ void otPlatRadioSetMacFrameCounter(otInstance *aInstance,
 				   &config);
 }
 #endif
+
+#if defined(CONFIG_OPENTHREAD_CSL_RECEIVER)
+otError otPlatRadioEnableCsl(otInstance *aInstance, uint32_t aCslPeriod,
+			     const otExtAddress *aExtAddr)
+{
+	int result;
+
+	ARG_UNUSED(aInstance);
+
+	struct ieee802154_config config = {
+		.csl_recv.period = aCslPeriod,
+		.csl_recv.addr = aExtAddr,
+	};
+
+	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_CSL_RECEIVER,
+				      &config);
+
+	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
+}
+
+void otPlatRadioUpdateCslSampleTime(otInstance *aInstance,
+				    uint32_t aCslSampleTime)
+{
+	ARG_UNUSED(aInstance);
+
+	struct ieee802154_config config = { .csl_rx_time = aCslSampleTime };
+
+	(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_CSL_RX_TIME,
+				   &config);
+}
+#endif /* CONFIG_OPENTHREAD_CSL_RECEIVER */
+
+uint8_t otPlatRadioGetCslAccuracy(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+
+	return radio_api->get_csl_acc(radio_dev);
+}


### PR DESCRIPTION
This commit implements the missing OpenThread APIs related to CSL receiver configuration.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>