### PR TITLE
tests: power_mgmt: Fix CI build failure

### DIFF
--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     # arch_irq_unlock(0) can't work correctly on these arch
     arch_exclude: arc xtensa
     platform_exclude: rv32m1_vega_ri5cy rv32m1_vega_zero_riscy litex_vexriscv
-       nrf5340dk_nrf5340_cpunet
+       nrf5340dk_nrf5340_cpunet thingy53_nrf5340_cpunet
     integration_platforms:
       - qemu_x86
       - mps2_an385


### PR DESCRIPTION
The changes to re-organize the power mgmt header files exposed a
build failure on thingy53_nrf5340_cpunet since CONFIG_PM can't be
set on that platform.  We already exclude nrf5340dk_nrf5340_cpunet
so just add thingy53_nrf5340_cpunet to the platform_exclude list.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>