### PR TITLE
net/virtual: test case need have random generator driver

### DIFF
--- a/tests/net/virtual/testcase.yaml
+++ b/tests/net/virtual/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 32
   tags: net tunnel virtual
+  filter: CONFIG_ENTROPY_HAS_DRIVER
 tests:
   net.virtual.tunnel.ipip:
     extra_configs:


### PR DESCRIPTION
add below to fitler out correct platforms
filter: CONFIG_ENTROPY_HAS_DRIVER

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>