### PR TITLE
drivers: wifi: esp_at: rename driver from esp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -327,7 +327,7 @@
 /drivers/watchdog/wdt_handlers.c          @dcpleung @nashif
 /drivers/watchdog/*cc32xx*                @pavlohamov
 /drivers/wifi/                            @jukkar @tbursztyka @pfalcon
-/drivers/wifi/esp/                        @mniestroj
+/drivers/wifi/esp_at/                     @mniestroj
 /drivers/wifi/eswifi/                     @loicpoulain @nandojve
 /drivers/wifi/winc1500/                   @kludentwo
 /drivers/virtualization/		  @tbursztyka
@@ -385,7 +385,7 @@
 /dts/bindings/adc/st*stm32-adc.yaml       @cybertale
 /dts/bindings/modem/*hl7800.yaml          @rerickson1
 /dts/bindings/serial/ns16550.yaml         @dcpleung @nashif
-/dts/bindings/wifi/*esp.yaml              @mniestroj
+/dts/bindings/wifi/*esp-at.yaml           @mniestroj
 /dts/bindings/*/*npcx*                    @MulinChao @WealianLiao @ChiHuaL
 /dts/bindings/*/*psoc6*                   @nandojve
 /dts/bindings/*/nordic*                   @anangl

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -84,7 +84,7 @@
 	txpo = <0>;
 
 	nina_prog {
-		compatible = "espressif,esp";
+		compatible = "espressif,esp-at";
 		label = "NINA_PROG";
 		reset-gpios = <&porta 8 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/shields/esp_8266/Kconfig.defconfig
+++ b/boards/shields/esp_8266/Kconfig.defconfig
@@ -7,13 +7,13 @@ if SHIELD_ESP_8266 || \
 
 if NETWORKING
 
-config WIFI_ESP
+config WIFI_ESP_AT
 	default y
 	depends on WIFI
 
 choice WIFI_ESP_AT_VERSION
 	default WIFI_ESP_AT_VERSION_1_7
-	depends on WIFI_ESP
+	depends on WIFI_ESP_AT
 endchoice
 
 orsource "boards/*.defconfig"

--- a/boards/shields/esp_8266/boards/sam4e_xpro.overlay
+++ b/boards/shields/esp_8266/boards/sam4e_xpro.overlay
@@ -11,7 +11,7 @@
 	pinctrl-0 = <&pa21a_usart1_rxd1 &pa22a_usart1_txd1>;
 
 	esp8266 {
-		compatible = "espressif,esp";
+		compatible = "espressif,esp-at";
 		label = "esp8266";
 		status = "okay";
 	};

--- a/boards/shields/esp_8266/esp_8266_arduino.overlay
+++ b/boards/shields/esp_8266/esp_8266_arduino.overlay
@@ -9,7 +9,7 @@
 	current-speed = <115200>;
 
 	esp8266 {
-		compatible = "espressif,esp";
+		compatible = "espressif,esp-at";
 		label = "esp8266";
 		status = "okay";
 	};

--- a/boards/shields/esp_8266/esp_8266_mikrobus.overlay
+++ b/boards/shields/esp_8266/esp_8266_mikrobus.overlay
@@ -9,7 +9,7 @@
 	current-speed = <115200>;
 
 	esp8266 {
-		compatible = "espressif,esp";
+		compatible = "espressif,esp-at";
 		label = "esp8266";
 		status = "okay";
 	};

--- a/drivers/wifi/CMakeLists.txt
+++ b/drivers/wifi/CMakeLists.txt
@@ -3,5 +3,5 @@
 add_subdirectory_ifdef(CONFIG_WIFI_WINC1500	winc1500)
 add_subdirectory_ifdef(CONFIG_WIFI_SIMPLELINK	simplelink)
 add_subdirectory_ifdef(CONFIG_WIFI_ESWIFI	eswifi)
-add_subdirectory_ifdef(CONFIG_WIFI_ESP		esp)
+add_subdirectory_ifdef(CONFIG_WIFI_ESP_AT		esp_at)
 add_subdirectory_ifdef(CONFIG_WIFI_ESP32        esp32)

--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -32,7 +32,7 @@ config WIFI_OFFLOAD
 source "drivers/wifi/winc1500/Kconfig.winc1500"
 source "drivers/wifi/simplelink/Kconfig.simplelink"
 source "drivers/wifi/eswifi/Kconfig.eswifi"
-source "drivers/wifi/esp/Kconfig.esp"
+source "drivers/wifi/esp_at/Kconfig.esp_at"
 source "drivers/wifi/esp32/Kconfig.esp32"
 
 endif # WIFI

--- a/drivers/wifi/esp_at/CMakeLists.txt
+++ b/drivers/wifi/esp_at/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_WIFI_ESP)
+if(CONFIG_WIFI_ESP_AT)
 
   zephyr_library_include_directories(
     ${ZEPHYR_BASE}/drivers/modem

--- a/drivers/wifi/esp_at/Kconfig.esp_at
+++ b/drivers/wifi/esp_at/Kconfig.esp_at
@@ -1,30 +1,34 @@
 # Copyright (c) 2019 Tobias Svehagen
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig WIFI_ESP
-	bool "Espressif ESP8266 and ESP32 support"
+menuconfig WIFI_ESP_AT
+	bool "Espressif AT Command support"
 	select MODEM
 	select MODEM_CONTEXT
 	select MODEM_CMD_HANDLER
 	select MODEM_IFACE_UART
 	select NET_L2_WIFI_MGMT
 	select WIFI_OFFLOAD
+	help
+	  Enable Espressif AT Command offloaded WiFi driver. It is supported on
+	  any serial capable platform and communicates with Espressif chips
+	  running ESP-AT firmware (https://github.com/espressif/esp-at).
 
-if WIFI_ESP
+if WIFI_ESP_AT
 
-config WIFI_ESP_RX_STACK_SIZE
+config WIFI_ESP_AT_RX_STACK_SIZE
 	int "Stack size for the Espressif esp wifi driver RX thread"
 	default 1024
 	help
 	  This stack is used by the Espressif ESP RX thread.
 
-config WIFI_ESP_RX_THREAD_PRIORITY
+config WIFI_ESP_AT_RX_THREAD_PRIORITY
 	int "Priority of RX thread"
 	default 7
 	help
 	  Priority of thread used for processing RX data.
 
-config WIFI_ESP_WORKQ_STACK_SIZE
+config WIFI_ESP_AT_WORKQ_STACK_SIZE
 	int "Stack size for the esp driver work queue"
 	default 2048
 	help
@@ -32,38 +36,38 @@ config WIFI_ESP_WORKQ_STACK_SIZE
 	  to the rest of the network stack, letting the rx thread continue
 	  processing data.
 
-config WIFI_ESP_WORKQ_THREAD_PRIORITY
+config WIFI_ESP_AT_WORKQ_THREAD_PRIORITY
 	int "Priority of work queue thread"
 	default 7
 	help
 	  Priority of thread used for processing driver work queue items.
 
-config WIFI_ESP_MDM_RING_BUF_SIZE
+config WIFI_ESP_AT_MDM_RING_BUF_SIZE
 	int "Modem ring buffer size"
 	default 1024
 	help
 	  Ring buffer size used by modem UART interface handler.
 
-config WIFI_ESP_MDM_RX_BUF_COUNT
+config WIFI_ESP_AT_MDM_RX_BUF_COUNT
 	int "Modem RX buffer count"
 	default 30
 	help
 	  Number of preallocated RX buffers used by modem command handler.
 
-config WIFI_ESP_MDM_RX_BUF_SIZE
+config WIFI_ESP_AT_MDM_RX_BUF_SIZE
 	int "Modem RX buffer size"
 	default 128
 	help
 	  Size of preallocated RX buffers used by modem command handler.
 
-config WIFI_ESP_PASSIVE_MODE
+config WIFI_ESP_AT_PASSIVE_MODE
 	bool "Use passive mode"
 	help
 	  This lets the ESP handle the TCP window so that data can flow
 	  at a rate that the driver can handle. Without this, data might get
 	  lost if the driver cannot empty the device buffer quickly enough.
 
-config WIFI_ESP_RESET_TIMEOUT
+config WIFI_ESP_AT_RESET_TIMEOUT
 	int "Reset timeout"
 	default 3000
 	help
@@ -71,7 +75,7 @@ config WIFI_ESP_RESET_TIMEOUT
 	  sent. This can vary with chipset (ESP8266/ESP32) and firmware
 	  version. This is ignored if a reset pin is configured.
 
-config WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT
+config WIFI_ESP_AT_RX_NET_PKT_ALLOC_TIMEOUT
 	int "Network interface RX packet allocation timeout"
 	default 5000
 	help
@@ -79,32 +83,32 @@ config WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT
 
 choice
 	prompt "ESP IP Address configuration"
-	default WIFI_ESP_IP_DHCP
+	default WIFI_ESP_AT_IP_DHCP
 	help
 	  Choose whether to use an IP assigned by DHCP Server or
 	  configure a static IP Address.
 
-config WIFI_ESP_IP_DHCP
+config WIFI_ESP_AT_IP_DHCP
 	bool "DHCP"
 	help
 	  Use DHCP to get an IP Address.
 
-config WIFI_ESP_IP_STATIC
+config WIFI_ESP_AT_IP_STATIC
 	bool "Static"
 	help
 	  Setup Static IP Address.
 
 endchoice
 
-if WIFI_ESP_IP_STATIC
+if WIFI_ESP_AT_IP_STATIC
 
-config WIFI_ESP_IP_ADDRESS
+config WIFI_ESP_AT_IP_ADDRESS
 	string "ESP Station mode IP Address"
 
-config WIFI_ESP_IP_GATEWAY
+config WIFI_ESP_AT_IP_GATEWAY
 	string "Gateway Address"
 
-config WIFI_ESP_IP_MASK
+config WIFI_ESP_AT_IP_MASK
 	string "Network Mask"
 
 endif
@@ -127,11 +131,11 @@ config WIFI_ESP_AT_VERSION_2_0
 
 endchoice
 
-config WIFI_ESP_DNS_USE
+config WIFI_ESP_AT_DNS_USE
 	bool "Use DNS from ESP"
 	depends on DNS_RESOLVER
 	help
 	  Fetch DNS servers from ESP chip with AT+CIPDNS? command and apply that
 	  list to system DNS resolver.
 
-endif # WIFI_ESP
+endif # WIFI_ESP_AT

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_H_
-#define ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_AT_ESP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_AT_ESP_H_
 
 #include <kernel.h>
 #include <net/net_context.h>
@@ -48,7 +48,7 @@ extern "C" {
  * passive mode. For AT version 1.7 passive mode only affects TCP but in AT
  * version 2.0 it affects both TCP and UDP.
  */
-#if defined(CONFIG_WIFI_ESP_PASSIVE_MODE)
+#if defined(CONFIG_WIFI_ESP_AT_PASSIVE_MODE)
 #if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
 #define ESP_PROTO_PASSIVE(proto) (proto == IPPROTO_TCP)
 #else
@@ -57,7 +57,7 @@ extern "C" {
 #endif /* CONFIG_WIFI_ESP_AT_VERSION_1_7 */
 #else
 #define ESP_PROTO_PASSIVE(proto) 0
-#endif /* CONFIG_WIFI_ESP_PASSIVE_MODE */
+#endif /* CONFIG_WIFI_ESP_AT_PASSIVE_MODE */
 
 #define ESP_BUS DT_BUS(DT_DRV_INST(0))
 
@@ -79,7 +79,7 @@ extern "C" {
 #define CONN_CMD_MAX_LEN (sizeof("AT+"_CWJAP"=\"\",\"\"") + \
 			  WIFI_SSID_MAX_LEN + WIFI_PSK_MAX_LEN)
 
-#if defined(CONFIG_WIFI_ESP_DNS_USE)
+#if defined(CONFIG_WIFI_ESP_AT_DNS_USE)
 #define ESP_MAX_DNS	MIN(3, CONFIG_DNS_RESOLVER_MAX_SERVERS)
 #else
 #define ESP_MAX_DNS	0
@@ -93,9 +93,9 @@ extern "C" {
 
 #define INVALID_LINK_ID		255
 
-#define MDM_RING_BUF_SIZE	CONFIG_WIFI_ESP_MDM_RING_BUF_SIZE
-#define MDM_RECV_MAX_BUF	CONFIG_WIFI_ESP_MDM_RX_BUF_COUNT
-#define MDM_RECV_BUF_SIZE	CONFIG_WIFI_ESP_MDM_RX_BUF_SIZE
+#define MDM_RING_BUF_SIZE	CONFIG_WIFI_ESP_AT_MDM_RING_BUF_SIZE
+#define MDM_RECV_MAX_BUF	CONFIG_WIFI_ESP_AT_MDM_RX_BUF_COUNT
+#define MDM_RECV_BUF_SIZE	CONFIG_WIFI_ESP_AT_MDM_RX_BUF_SIZE
 
 #define ESP_CMD_TIMEOUT		K_SECONDS(10)
 #define ESP_SCAN_TIMEOUT	K_SECONDS(10)
@@ -383,4 +383,4 @@ void esp_close_work(struct k_work *work);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_WIFI_ESP_AT_ESP_H_ */

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -6,7 +6,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wifi_esp_offload, CONFIG_WIFI_LOG_LEVEL);
+LOG_MODULE_REGISTER(wifi_esp_at_offload, CONFIG_WIFI_LOG_LEVEL);
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -8,10 +8,10 @@
 #include "esp.h"
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(wifi_esp, CONFIG_WIFI_LOG_LEVEL);
+LOG_MODULE_DECLARE(wifi_esp_at, CONFIG_WIFI_LOG_LEVEL);
 
 #define RX_NET_PKT_ALLOC_TIMEOUT				\
-	K_MSEC(CONFIG_WIFI_ESP_RX_NET_PKT_ALLOC_TIMEOUT)
+	K_MSEC(CONFIG_WIFI_ESP_AT_RX_NET_PKT_ALLOC_TIMEOUT)
 
 struct esp_workq_flush_data {
 	struct k_work work;

--- a/dts/bindings/wifi/espressif,esp-at.yaml
+++ b/dts/bindings/wifi/espressif,esp-at.yaml
@@ -3,7 +3,7 @@
 
 description: Espressif ESP8266/ESP32 WiFi modem (AT Commands)
 
-compatible: "espressif,esp"
+compatible: "espressif,esp-at"
 
 include: uart-device.yaml
 


### PR DESCRIPTION
Recently WiFi ESP32 driver was introduced into
drivers/wifi/esp32/ (utilizing WiFi radio in SoC) and it already caused
confusion as there was existing drivers/wifi/esp/ directory for ESP-AT
driver (utilizing external WiFi chip, by communicating using AT
commands). So question has arisen whether it is good to merge both,
while they are totally different drivers.

Rename ESP-AT driver to be placed in drivers/wifi/esp_at/, so that it is
easier to figure out difference between "esp32" and "esp_at" just by
looking at driver name. Rename also DT compatible and all Kconfig
options for the same reason.

See discussion in #32081 with [this proposal](https://github.com/zephyrproject-rtos/zephyr/pull/32081#issuecomment-785069763).