### PR TITLE
Add more platforms to no multithreading tests

### DIFF
--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -6,3 +6,4 @@ tests:
   arch.arm.no_multithreading:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     platform_allow: qemu_cortex_m0 qemu_cortex_m3 mps2_an385 mps2_an521
+      nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422

--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   kernel.threads.no-multithreading:
     tags: kernel
     filter: not CONFIG_SMP
-    platform_allow: qemu_cortex_m3
+    platform_allow: qemu_cortex_m0 qemu_cortex_m3 mps2_an385 mps2_an521
+      nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422


### PR DESCRIPTION
Add physical platforms to no multithreading tests. 2 nordic boards were added with Cortex-m4 and cortex-m33 cores.

Platforms cannot be added freely because some by default are fetching modules which depends on multithreading and compilation fails in that case.

Fixes #34840.