### PR TITLE
Bluetooth: Host: Avoid memcpy'ing bt_addr_t to same pointer

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -171,7 +171,9 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 		return err;
 	}
 
-	bt_addr_copy(&adv->random_addr.a, addr);
+	if (&adv->random_addr.a != addr) {
+		bt_addr_copy(&adv->random_addr.a, addr);
+	}
 	adv->random_addr.type = BT_ADDR_LE_RANDOM;
 	return 0;
 }


### PR DESCRIPTION
From le_ext_adv_param_set we will occasionally attempt
to call bt_addr_copy where the `addr` and &adv->random_addr.a
are the same pointer. Doing a memcpy where source and destination
is the same pointer is undefined behavior and should not be
done.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

See also https://github.com/zephyrproject-rtos/zephyr/issues/34928