### PR TITLE
doc: release: add remaining release notes for TF-M, and list of new boards

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -373,9 +373,14 @@ HALs
 Trusted Firmware-m
 ******************
 
+* Synchronized Trusted-Firmware-M module to the upstream v1.3.0 release.
 * Configured QEMU to run Zephyr samples and tests in CI on mps2_an521_nonsecure
   (Cortex-M33 Non-Secure) with TF-M as the secure firmware component.
-* Synchronized Trusted-Firmware-M module to the upstream v1.3.0 release.
+* Added Kconfig options for selecting the desired TF-M profile and build type
+* Added Kconfig options for enabling the desired TF-M secure partitions
+* Added a new sample to run the PSA tests with Zephyr
+* Added a new sample to run the TF-M regression tests using the Zephyr build system
+
 
 
 Documentation

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -380,7 +380,10 @@ Trusted Firmware-m
 * Added Kconfig options for enabling the desired TF-M secure partitions
 * Added a new sample to run the PSA tests with Zephyr
 * Added a new sample to run the TF-M regression tests using the Zephyr build system
+* Added support for new platforms
 
+   * BL5340 DVK
+   * STM32L562E DK
 
 
 Documentation


### PR DESCRIPTION
Add remaining release notes entries for TF-M for Zephyr
v2.6.0 release, mentioning the added samples and platforms.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>