### PR TITLE
LwM2M: fix block transfer with TLV

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -414,6 +414,7 @@ struct lwm2m_block_context {
 	uint8_t token[8];
 	uint8_t tkl;
 	bool last_block : 1;
+	uint16_t res_id;
 };
 
 struct lwm2m_output_context {


### PR DESCRIPTION
Follow-up packets do not contain the TLV header but just continuations of the value. Tested with a Leshan server and a custom opaque resource.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/34935

Signed-off-by: Jan Bünker <jan.buenker@grandcentrix.net>