### PR TITLE
net: lwm2m: no duplicate device error codes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -185,6 +185,11 @@ int lwm2m_device_add_err(uint8_t error_code)
 		if (error_code_ri[i].res_inst_id == RES_INSTANCE_NOT_CREATED) {
 			break;
 		}
+
+		/* No duplicate error codes allowed */
+		if (*(uint8_t *)error_code_ri[i].data_ptr == error_code) {
+			return 0;
+		}
 	}
 
 	if (i >= DEVICE_ERROR_CODE_MAX) {


### PR DESCRIPTION
The resource description on the OMA LwM2M registry states that only the
first instance of a particular error should trigger creation of a new
error code instance.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>