### PR TITLE
ci: disable identifier_length scripts for now

### DIFF
--- a/scripts/ci/guideline_check.py
+++ b/scripts/ci/guideline_check.py
@@ -20,7 +20,7 @@ sh_special_args = {
 
 coccinelle_scripts = ["/scripts/coccinelle/reserved_names.cocci",
                       "/scripts/coccinelle/same_identifier.cocci",
-                      "/scripts/coccinelle/identifier_length.cocci",
+                      #"/scripts/coccinelle/identifier_length.cocci",
                       ]
 
 


### PR DESCRIPTION
This rules is not working as expected, so remove it for now.