### PR TITLE
samples: flash_shell: fix SHELL_CMD_REGISTER typo

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -772,4 +772,4 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_flash,
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 
-SHELL_CMD_REGISTER(flash, &sub_flash, "Flash realated commands.", NULL);
+SHELL_CMD_REGISTER(flash, &sub_flash, "Flash related commands.", NULL);


### PR DESCRIPTION
help parameter inside of SHELL_CMD_REGISTER contained a typo

Signed-off-by: Akash Patel <akash.patel@nordicsemi.no>