### PR TITLE
west: sign.py: force maximum alignment supported by the tool

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -220,7 +220,11 @@ class ImgtoolSigner(Signer):
         flash = self.edt_flash_node(b, args.quiet)
         align, addr, size = self.edt_flash_params(flash)
 
+<<<<<<< HEAD
         if build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
+=======
+        if not build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
+>>>>>>> 0dede00f15... sign alignment fix
             log.wrn("CONFIG_BOOTLOADER_MCUBOOT is not set to y in "
                     f"{build_conf.path}; this probably won't work")
 
@@ -371,6 +375,13 @@ class ImgtoolSigner(Signer):
         if align == 0:
             log.die('expected nonzero flash alignment, but got '
                     'DT flash device write-block-size {}'.format(align))
+
+        # If write-block-size > 8 force alignment to 8 bytes since higher
+        # value is not yet supported by the tool.
+        if align > 8:
+            log.wrn('device alignment {} is > 8 bytes. '
+                    'Forcing 8 byte alignment'.format(align))
+            align = 8
 
         # The partitions node, and its subnode, must provide
         # the size of image-1 or image-0 partition via the regs property.


### PR DESCRIPTION
mcuboot's `imgtool.py` only supports maximum alignment of 8-bytes. `sign.py` looks at the `write-block-size` property of the flash controller to calculate the alignment value to pass to `imgtool.py`. However some drivers report values higher than 8-bytes, such as 16 or 512. This should eventually be fixed in the driver where it is an incorrectly set, or `imgtool.py` should support larger alignment values.

Without this patch the signing process dies, which is not useful behaviour. With this PR if the calculated alignment exceeds the value supported by `imgtool.py` we force it to 8 and print a warning. In almost all cases `image-0` address is set to a very large alignment by the user e.g. `0x10000` therefore the alignment issue is moot in a majority of scenarios.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>