### PR TITLE
Kconfig: `ROM_START_OFFSET` fix

### DIFF
--- a/soc/arm/atmel_sam0/samd51/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.defconfig.series
@@ -25,6 +25,9 @@ config NUM_IRQS
 	int
 	default 137
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 120000000

--- a/soc/arm/atmel_sam0/same51/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.defconfig.series
@@ -21,6 +21,9 @@ config NUM_IRQS
 	int
 	default 137
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 120000000

--- a/soc/arm/atmel_sam0/same53/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.defconfig.series
@@ -21,6 +21,9 @@ config NUM_IRQS
 	int
 	default 137
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 120000000

--- a/soc/arm/atmel_sam0/same54/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same54/Kconfig.defconfig.series
@@ -20,6 +20,9 @@ config NUM_IRQS
 	int
 	default 137
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 120000000


### PR DESCRIPTION
This PR addresses a mischievous bug that prevents firmware from booting on some platforms when mcuboot is used.

When `CONFIG_BOOTLOADER_MCUBOOT` is enabled `CONFIG_ROM_START_OFFSET` is set to `0x200`. This value is used as padding at the start of the output file -- by shifting `_vector_start` in the linker file -- to make room for the image header to be generated by `imgtool.py`. This value is also passed to `imgtool.py` and eventually used by the bootloader to set the vector table address before jumping to user firmware.

It so happens that `/arch/arm/core/aarch32/vector_table.ld` forces an alignment on `_vector_start` that is proportional to the size of the vector table and therefore the number of IRQs (`. = ALIGN( 1 << LOG2CEIL(4 * (16 + CONFIG_NUM_IRQS)) )`). This alignment is needed for *some* Cortex-M platforms that use address ORing to calculate the vector offset, but not all.

The end result is that the if the number of IRQs on the SoC is > 112 the vector table will end up at `0x400` or higher, and not `0x200` as expected. The bootloader programs the wrong vector table offset and fails to jump to the user firmware. 

This bug was reproduced on the `SAME54` platform which has 137 IRQs. 

The fix calculates  `CONFIG_ROM_START_OFFSET` based on the number of IRQs on the chip (up to 1008) to match the value calculated by the linker.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>