### PR TITLE
scripts: runners: bossac: Add legacy mode and fix arduino_nano_33_ble

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -561,7 +561,6 @@ config BOOTLOADER_ESP_IDF
 config BOOTLOADER_BOSSA
 	bool "BOSSA bootloader support"
 	select USE_DT_CODE_PARTITION
-	depends on SOC_FAMILY_SAM0
 
 	help
 	  Signifies that the target uses a BOSSA compatible bootloader.  If CDC
@@ -578,6 +577,13 @@ config BOOTLOADER_BOSSA_DEVICE_NAME
 choice
 	prompt "BOSSA bootloader variant"
 	depends on BOOTLOADER_BOSSA
+
+config BOOTLOADER_BOSSA_LEGACY
+	bool "Legacy"
+	help
+	  Select the Legacy variant of the BOSSA bootloader.  This is defined
+	  for compatibility mode only.  The recommendation is use newer
+	  versions like Arduino or Adafruit UF2.
 
 config BOOTLOADER_BOSSA_ARDUINO
 	bool "Arduino"

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -42,6 +42,12 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		boot_partition: partition@0 {
+			label = "sam-ba";
+			reg = <0x0 0x10000>;
+			read-only;
+		};
+
 		code_partition: partition@10000 {
 			label = "code";
 			reg = <0x10000 0xf0000>;

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_defconfig
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_defconfig
@@ -13,8 +13,9 @@ CONFIG_GPIO=y
 CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 
-# enable flashing and linker options
-CONFIG_USE_DT_CODE_PARTITION=y
+# enable sam-ba bootloader on legacy mode
+CONFIG_BOOTLOADER_BOSSA=y
+CONFIG_BOOTLOADER_BOSSA_LEGACY=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y

--- a/doc/guides/flash_debug/host-tools.rst
+++ b/doc/guides/flash_debug/host-tools.rst
@@ -65,11 +65,17 @@ For these devices, the user should:
    automatically select the :option:`CONFIG_USE_DT_CODE_PARTITION` Kconfig
    option which instruct the build system to use these partitions for code
    relocation.  The board :file:`.defconfig` file should have
-   :option:`CONFIG_BOOTLOADER_BOSSA_ARDUINO` or the
-   :option:`CONFIG_BOOTLOADER_BOSSA_ADAFRUIT_UF2` Kconfig option set to ``y``
+   :option:`CONFIG_BOOTLOADER_BOSSA_ARDUINO` ,
+   :option:`CONFIG_BOOTLOADER_BOSSA_ADAFRUIT_UF2` or the
+   :option:`CONFIG_BOOTLOADER_BOSSA_LEGACY` Kconfig option set to ``y``
    to select the right compatible SAM-BA bootloader mode.
    These options can also be set in ``prj.conf`` or any other Kconfig fragment.
 3. Build and flash the SAM-BA bootloader on the device.
+
+.. note::
+
+    The :option:`CONFIG_BOOTLOADER_BOSSA_LEGACY` Kconfig option should be used
+    as last resource.  Try configure first with Devices without ROM bootloader.
 
 
 Typical flash layout and configuration
@@ -176,6 +182,7 @@ As a quick reference, see these three board documentation pages:
   - :ref:`sam4e_xpro` (ROM bootloader)
   - :ref:`adafruit_feather_m0_basic_proto` (Adafruit UF2 bootloader)
   - :ref:`arduino_nano_33_iot` (Arduino bootloader)
+  - :ref:`arduino_nano_33_ble` (Arduino legacy bootloader)
 
 .. _jlink-debug-host-tools:
 

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -121,6 +121,9 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         return self.build_conf['CONFIG_BOARD']
 
     def get_dts_img_offset(self):
+        if self.build_conf.getboolean('CONFIG_BOOTLOADER_BOSSA_LEGACY'):
+            return 0
+
         if self.build_conf.getboolean('CONFIG_HAS_FLASH_LOAD_OFFSET'):
             return self.build_conf['CONFIG_FLASH_LOAD_OFFSET']
 


### PR DESCRIPTION
Add compatibility mode with old sam-ba flash bootloaders that don't have offset capabilities.  These bootloaders flash to a pre-defined flash region.  At end, bossac will suppress --offset parameter.

This fixes arduino_nano_33_ble board that uses an old bootloader version.  The bootloader always relocate code due to flash bootloader.  This imply a wrong behaviour when using --offset.

Fixes #33523

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>