### PR TITLE
doc: fix display of the ISR_DIRECT_DECLARE example usage

### DIFF
--- a/include/irq.h
+++ b/include/irq.h
@@ -163,16 +163,17 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
  *
  * Example usage:
  *
- * ISR_DIRECT_DECLARE(my_isr)
- * {
- *	bool done = do_stuff();
- *	ISR_DIRECT_PM(); <-- done after do_stuff() due to latency concerns
- *	if (!done) {
- *		return 0;  <-- Don't bother checking if we have to z_swap()
- *	}
- *	k_sem_give(some_sem);
- *	return 1;
- * }
+ *     ISR_DIRECT_DECLARE(my_isr)
+ *     {
+ *             bool done = do_stuff();
+ *             ISR_DIRECT_PM(); // done after do_stuff() due to latency concerns
+ *             if (!done) {
+ *                 return 0; // don't bother checking if we have to z_swap()
+ *             }
+ *
+ *             k_sem_give(some_sem);
+ *             return 1;
+ *      }
  *
  * @param name symbol name of the ISR
  */


### PR DESCRIPTION
In the ISR docs page ISR_DIRECT_DECLARE example usage
was not displayed correctly.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>