### PR TITLE
storage/stream: Move fill value handling to flash_sync

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -196,6 +196,11 @@ static void test_stream_flash_buffered_write_unaligned(void)
 			       0, stream_flash_callback);
 	zassert_equal(rc, 0, "expected success");
 
+	/* Trigger verification in callback */
+	cb_buf = buf;
+	cb_len = BUF_LEN - 1;
+	cb_offset = FLASH_BASE + BUF_LEN;
+
 	/* Test unaligned data size */
 	rc = stream_flash_buffered_write(&ctx, write_buf, BUF_LEN - 1, true);
 	zassert_equal(rc, 0, "expected success");


### PR DESCRIPTION
Move the code responsible for aligning the flash write by writing fill
values - from `stream_flash_buffered_write()` to `flash_sync()`. This avoids
having to correct `buf_bytes`/`buf_written` after the write and thus
simplifies error handling.

Ref https://github.com/zephyrproject-rtos/zephyr/pull/32488#issuecomment-785721776

Signed-off-by: Jonathan Nilsen <Jonathan.Nilsen@nordicsemi.no>