### PR TITLE
Enable CAN peripheral on STM32G0

### DIFF
--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -96,6 +96,8 @@ The Zephyr nucleo_g0b1re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | CAN 2.0 and CAN FD compliant        |
++-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
 +-----------+------------+-------------------------------------+
 | COUNTER   | on-chip    | rtc                                 |
@@ -131,6 +133,7 @@ Default Zephyr Peripheral Mapping:
 - I2C2 SCL/SDA : PA11/PA12
 - SPI1 NSS/SCK/MISO/MOSI : PB0/PA5/PA6/PA7 (Arduino SPI)
 - SPI2 NSS/SCK/MISO/MOSI : PB12/PB13/PB14/PB15
+- CAN1 TX/RX : PA11/PA12
 - USER_PB   : PC13
 - LD4       : PA5
 - PWM       : PA6

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -129,8 +129,27 @@
 	pinctrl-0 = <&dac1_out1_pa4>;
 };
 
+&shared_irq21 {
+	status = "okay";
+};
+
+&shared_irq22 {
+	status = "okay";
+};
+
 &can1 {
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+	bus-speed = <125000>;
+	sjw = <1>;
+	sample-point = <875>;
+	bus-speed-data = <1000000>;
+	sjw-data = <1>;
+	sample-point-data = <875>;
+	status = "okay";
+};
+
+&can2 {
+	pinctrl-0 = <&fdcan2_rx_pb5 &fdcan2_tx_pb6>;
 	bus-speed = <125000>;
 	sjw = <1>;
 	sample-point = <875>;

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,can-primary = &can1;
 	};
 
 	leds {
@@ -126,6 +127,17 @@
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
+};
+
+&can1 {
+	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+	bus-speed = <125000>;
+	sjw = <1>;
+	sample-point = <875>;
+	bus-speed-data = <1000000>;
+	sjw-data = <1>;
+	sample-point-data = <875>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
@@ -18,3 +18,5 @@ supported:
   - spi
   - nvs
   - dma
+  - can
+  - canfd

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -10,6 +10,7 @@
 #include <stm32_ll_rcc.h>
 #include "can_stm32fd.h"
 #include <pinmux/pinmux_stm32.h>
+#include <shared_irq.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
@@ -208,18 +209,22 @@ static const struct can_driver_api can_api_funcs = {
 #endif
 };
 
+/*
+ * If a shared-irq with matching name exists and has status okay use the
+ * shared-irq driver, otherwise, connect to normal IRQ.
+ */
 #define CAN_STM32FD_IRQ_CFG_FUNCTION(inst)                                     \
 static void config_can_##inst##_irq(void)                                      \
 {                                                                              \
 	LOG_DBG("Enable CAN" #inst " IRQ");                                    \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_0, irq),                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_0, priority),               \
-		    can_stm32fd_line_0_isr, DEVICE_DT_INST_GET(inst), 0);      \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_0, irq));                    \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_1, irq),                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_1, priority),               \
-		    can_stm32fd_line_1_isr, DEVICE_DT_INST_GET(inst), 0);      \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_1, irq));                    \
+	SHARED_IRQ_CONNECT_IRQ_BY_NAME_COND(DT_DRV_INST(inst), line_0,         \
+						 can_stm32fd_line_0_isr,       \
+						 DEVICE_DT_INST_GET(inst), 0); \
+	SHARED_IRQ_CONNECT_IRQ_BY_NAME_COND(DT_DRV_INST(inst), line_1,         \
+						 can_stm32fd_line_1_isr,       \
+						 DEVICE_DT_INST_GET(inst), 0); \
+	SHARED_IRQ_ENABLE_BY_NAME_COND(DT_DRV_INST(inst), line_0);             \
+	SHARED_IRQ_ENABLE_BY_NAME_COND(DT_DRV_INST(inst), line_1);             \
 }
 
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/interrupt_controller/Kconfig.shared_irq
+++ b/drivers/interrupt_controller/Kconfig.shared_irq
@@ -5,6 +5,7 @@
 
 menuconfig SHARED_IRQ
 	bool "Shared interrupt driver"
+	default $(dt_compat_enabled,shared-irq)
 	help
 	  Include shared interrupt support in system. Shared interrupt
 	  support is NOT required in most systems. If in doubt answer no.

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -104,6 +104,46 @@
 			dma-channels = <12>;
 			dma-requests = <73>;
 		};
+
+		can {
+			compatible = "bosch,m-can-base";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			std-filter-elements = <28>;
+			ext-filter-elements = <8>;
+			rx-fifo0-elements = <3>;
+			rx-fifo1-elements = <3>;
+			rx-buffer-elements = <0>;
+			tx-buffer-elements = <3>;
+
+			can1: can@40006400 {
+				compatible = "st,stm32-fdcan";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x40006400 0x400>, <0x4000B400 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <21 0>, <22 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				shared-irqs = <&shared_irq21 &shared_irq22>;
+				shared-irq-names = "LINE_0", "LINE_1";
+				status = "disabled";
+				label = "CAN_1";
+			};
+
+			can2: can@40006800 {
+				compatible = "st,stm32-fdcan";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x40006800 0x400>, <0x4000B750 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <21 0>, <22 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				shared-irqs = <&shared_irq21 &shared_irq22>;
+				shared-irq-names = "LINE_0", "LINE_1";
+				status = "disabled";
+				label = "CAN_2";
+			};
+		};
 	};
 
 	shared_irq21: shared_irq21 {

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -105,4 +105,28 @@
 			dma-requests = <73>;
 		};
 	};
+
+	shared_irq21: shared_irq21 {
+		compatible = "shared-irq";
+		interrupt-parent = <&nvic>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		interrupts = <21 0>;
+		interrupt-names = "tim16_fdcan_it0";
+		#shared-irq-cells = <0>;
+		status = "disabled";
+		label = "SHARED_IRQ_21";
+	};
+
+	shared_irq22: shared_irq22 {
+		compatible = "shared-irq";
+		interrupt-parent = <&nvic>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		interrupts = <22 0>;
+		interrupt-names = "tim17_fdcan_it1";
+		#shared-irq-cells = <0>;
+		status = "disabled";
+		label = "SHARED_IRQ_22";
+	};
 };

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -14,3 +14,22 @@ properties:
 
         For example the can1 would be
            pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+
+    shared-irq-names:
+      type: string-array
+      required: false
+      description: |
+        Name of each shared-irq in shared-irqs.
+        Required if shared-irqs are used and interrupts are chosen by name.
+
+    shared-irqs:
+      type: phandle-array
+      required: false
+      description: |
+        To avoid interrupt conflicts shared-irq nodes can be referenced.
+        In case the referenced shared_irq phandles have status okay the driver
+        registers the isr with the shared_irq instance instead of connecting to
+        the irq.
+
+        Example for stm32g0 would be
+              shared-irqs = <&shared_irq21 &shared_irq22>;

--- a/include/shared_irq.h
+++ b/include/shared_irq.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2015 Intel corporation
+ * Copyright (c) 2021 Thomas Stranger
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +15,368 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Get a node identifier for a shared-irqs specifier at the index
+ *
+ * @param node_id Node identifier of a device that has a shared-irqs
+ *                phandle-array property.
+ * @param irq_idx logical index into the shared-irqs phandle-array
+ * @return node identifier for the shared-irq node at that index
+ */
+#define SHARED_IRQ_BY_IDX(node_id, irq_idx)                                    \
+	DT_PHANDLE_BY_IDX(node_id, shared_irqs, irq_idx);                      \
+
+/**
+ * @brief Get a node identifier within a shared-irqs specifier by name
+ *
+ * This can be used to get an individual shared-irq when a device generates more
+ * than one, provided that the bindings give each shared-irq specifier a name.
+ *
+ * @param node_id Node identifier of a device that has a shared-irqs
+ *                phandle-array property.
+ * @param irq_name lowercase-and-underscores shared interrupt specifier name
+ * @return node identifier for the shared-irq identified by given by the name
+ */
+#define SHARED_IRQ_BY_NAME(node_id, irq_name)                                  \
+	DT_PHANDLE_BY_NAME(node_id, shared_irqs, irq_name)                     \
+
+/**
+ * @brief Does the node have a shared-irqs element at index?
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array element at index.
+ * @param irq_idx logical index into the shared-irqs phandle-array
+ * @return 1 if the shared-irqs property has an element at index, 0 otherwise
+ */
+#define SHARED_IRQ_HAS_IDX(node_id, irq_idx)                                   \
+	DT_PROP_HAS_IDX(node_id, shared_irqs, irq_idx)                         \
+
+/**
+ * @brief Does the node have a shared-irqs element with a matching name?
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array element with the given name.
+ * @param irq_name lowercase-and-underscores name of a shared-irqs element
+ *             as defined by the node's shared-irq-names property
+ * @return 1 if the shared-irqs property has the named element, 0 otherwise
+ */
+#define SHARED_IRQ_HAS_NAME(node_id, irq_name)                                 \
+	IS_ENABLED(DT_CAT(node_id, _P_shared_irqs_NAME_##irq_name##_EXISTS))
+
+/**
+ * @brief Does the node have an shared-irqs element at index with status okay?
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array element at the given index.
+ * @param irq_idx logical index into the shared-irqs phandle-array
+ * @return 1 if the shared-irqs element at index has status okay,
+ *         0 otherwise
+ */
+#define SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, irq_idx)                    \
+	COND_CODE_1(SHARED_IRQ_HAS_IDX(node_id, irq_idx),                      \
+		   (COND_CODE_1(DT_NODE_HAS_STATUS(                            \
+				  SHARED_IRQ_BY_IDX(node_id, irq_idx), okay),  \
+				(1),                                           \
+				(0)),                                          \
+		    (0)))
+
+/**
+ * @brief Does the node have an shared-irqs element with a matching name and
+ *        status okay?
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array element with the given name.
+ * @param irq_name lowercase-and-underscores name of a shared-irqs element
+ *             as defined by the node's shared-irq-names property
+ * @return 1 if the shared-irqs property has the named element and status okay,
+ *         0 otherwise
+ */
+#define SHARED_IRQ_BY_NAME_HAS_STATUS_OKAY(node_id, irq_name)                  \
+	COND_CODE_1(SHARED_IRQ_HAS_NAME(node_id, irq_name),                    \
+		   (COND_CODE_1(DT_NODE_HAS_STATUS(                            \
+				  SHARED_IRQ_BY_NAME(node_id, irq_name), okay),\
+				(1),                                           \
+				(0))),                                         \
+		    (0))
+
+/**
+ * @brief Connect to a devicetree nodes shared-irq at index.
+ *
+ * The IRQ must be subsequently enabled before the interrupt handler
+ * begins servicing interrupts.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device that has a shared-irqs
+ *                phandle-array property.
+ * @param irq_idx logical index into the shared-irqs phandle-array
+ * @param isr_p Address of interrupt service routine.
+ * @param isr_param_p Parameter passed to interrupt service routine. Should be a
+ *                    pointer to the device that will service the interrupt.
+ */
+#define SHARED_IRQ_CONNECT_BY_IDX(node_id, irq_idx, isr_p, isr_param_p)        \
+	__ASSERT(device_is_ready(                                              \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, irq_idx))),   \
+		 "shared irq ##irq_idx## not ready");                          \
+	shared_irq_isr_register(                                               \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, irq_idx)),    \
+				(isr_t)isr_p, isr_param_p);                    \
+
+/**
+ * @brief Connect to a devicetree nodes shared-irq by name.
+ *
+ * This routine connects to a shared-irqs element, provided the given name
+ * finds a match.
+ *
+ * The IRQ must be subsequently enabled before the interrupt handler
+ * begins servicing interrupts.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device that has a shared-irqs
+ *                phandle-array property.
+ * @param irq_name lowercase-and-underscores shared-irq specifier name
+ * @param isr_p Address of interrupt service routine.
+ * @param isr_param_p Parameter passed to interrupt service routine. Should be a
+ *                    pointer to the device that will service the interrupt.
+ */
+#define SHARED_IRQ_CONNECT_BY_NAME(node_id, irq_name, isr_p, isr_param_p)      \
+	__ASSERT(device_is_ready(                                              \
+			DEVICE_DT_GET(SHARED_IRQ_BY_NAME(node_id, irq_name))), \
+		 "shared-irq ##irq_name## not ready");                         \
+	shared_irq_isr_register(                                               \
+			DEVICE_DT_GET(SHARED_IRQ_BY_NAME(node_id, irq_name)),  \
+				(isr_t)isr_p, isr_param_p)                     \
+
+/**
+ * @brief Connect to a devicetree nodes shared-irqs element at idx if it
+ * exists, else connect to the IRQ in the interrupts array at the same idx.
+ *
+ * This routine registers a device isr with the shared-irq matching the given
+ * index if a shared-irq with index idx exists.
+ * Otherwise, it initializes an interrupt handler for the irq in the interrupts
+ * array at the same idx.
+ * The IRQ must be subsequently enabled before the interrupt handler
+ * begins servicing interrupts.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device that has either a shared-irqs
+ *                phandle-array or a interrupts property.
+ * @param irq_idx logical index into the shared-irqs phandle-array if it exists,
+ *                index into the interrupts array otherwise.
+ * @param isr_p Address of interrupt service routine.
+ * @param isr_param_p Parameter passed to interrupt service routine. Should be a
+ *                    pointer to the device that will service the interrupt.
+ * @param flags_p Architecture-specific IRQ configuration flags (not used for
+ *        shared-irqs).
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_CONNECT_IRQ_BY_IDX_COND(node_id, irq_idx, isr_p,            \
+					   isr_param_p, flags_p)               \
+	COND_CODE_1(SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, irq_idx),       \
+		    (SHARED_IRQ_CONNECT_BY_IDX(node_id, irq_idx, isr_p,        \
+					       isr_param_p)),                  \
+		    (IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, irq_idx, irq),         \
+				 DT_IRQ_BY_IDX(node_id, irq_idx, priority),    \
+				 isr_p, isr_param_p, flags_p)))
+
+/**
+ * @brief Connect to a devicetree nodes (only) shared-irqs element if it
+ * exists, else connect to the single irq in the interrupts array.
+ *
+ * The IRQ must be subsequently enabled before the interrupt handler
+ * begins servicing interrupts.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device that has either a shared-irqs
+ *                phandle-array or a interrupts array.
+ * @param isr_p Address of interrupt service routine.
+ * @param isr_param_p Parameter passed to interrupt service routine. Should be a
+ *                    pointer to the device that will service the interrupt.
+ * @param flags_p Architecture-specific IRQ configuration flags (not used for
+ *        shared-irqs).
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_CONNECT_IRQ_COND(node_id, isr_p, isr_param_p, flags_p)      \
+	SHARED_IRQ_CONNECT_IRQ_BY_IDX_COND(node_id, 0, isr_p, isr_param_p,     \
+					   flags_p)                            \
+
+/**
+ * @brief Connect to a devicetree nodes shared-irqs element by name if it
+ * exists, else connect to a IRQ using the same given name.
+ *
+ * This routine registers a device isr with the shared-irq matching the given
+ * name if such a shared-irq exists.
+ * Otherwise, it initializes an interrupt handler for an IRQ with the given name.
+ * The IRQ must be subsequently enabled before the interrupt handler
+ * begins servicing interrupts.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device that has either a shared-irqs
+ *                phandle-array or a interrupts property.
+ * @param irq_name lowercase-and-underscores device shared-irq-name if it
+ *                 exists, interrupt-name otherwise.
+ * @param isr_p Address of interrupt service routine.
+ * @param isr_param_p Parameter passed to interrupt service routine. Should be a
+ *                    pointer to the device that will service the interrupt.
+ * @param flags_p Architecture-specific IRQ configuration flags (not used for
+ *        shared-irqs).
+ *
+ * @return N/A
+ */
+
+#define SHARED_IRQ_CONNECT_IRQ_BY_NAME_COND(node_id, irq_name, isr_p,          \
+					    isr_param_p, flags_p)              \
+	COND_CODE_1(SHARED_IRQ_BY_NAME_HAS_STATUS_OKAY(node_id, irq_name),     \
+		    (SHARED_IRQ_CONNECT_BY_NAME(node_id, irq_name,             \
+						isr_p, isr_param_p)),          \
+		    (IRQ_CONNECT(DT_IRQ_BY_NAME(node_id, irq_name, irq),       \
+				 DT_IRQ_BY_NAME(node_id, irq_name, priority),  \
+				 isr_p, isr_param_p, flags_p)))
+
+/**
+ * @brief Enable ISR for a devicetree node's shared interrupt at index if it
+ *         exists, or enable interrupts from irq at index otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ * @param irq_idx logical index into the shared-irqs phandle-array if it exists,
+ *                index into the interrupts array otherwise.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_ENABLE_BY_IDX_COND(node_id, irq_idx)                        \
+	COND_CODE_1(SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, irq_idx),       \
+		    (shared_irq_enable(                                        \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, irq_idx)),    \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_enable(DT_IRQ_BY_IDX(node_id, irq_idx, irq))))        \
+
+/**
+ * @brief Enable ISR for a devicetree node's (only) shared-irqs interrupt if it
+ *        exists, or enable interrupts from the single IRQ otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_ENABLE_COND(node_id)                                        \
+	COND_CODE_1(SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, 0),             \
+		    (shared_irq_enable(                                        \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, 0)),          \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_enable(DT_IRQ(node_id, irq))))                        \
+
+/**
+ * @brief Enable ISR for a devicetree node's shared interrupt by name if it
+ *         exists, or enable interrupts from irq by name otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ * @param irq_name lowercase-and-underscores device shared-irqs name if it
+ *                 exists, irq name otherwise.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_ENABLE_BY_NAME_COND(node_id, irq_name)                      \
+	COND_CODE_1(SHARED_IRQ_BY_NAME_HAS_STATUS_OKAY(node_id, irq_name),     \
+		    (shared_irq_enable(                                        \
+			DEVICE_DT_GET(SHARED_IRQ_BY_NAME(node_id, irq_name)),  \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_enable(DT_IRQ_BY_NAME(node_id, irq_name, irq))))      \
+
+/**
+ * @brief Disable ISR for a devicetree node's shared interrupt at index if it
+ *         exists, or disable interrupts from irq at index otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ * @param irq_idx logical index into the shared-irqs phandle-array if it exists,
+ *                index into the interrupts array otherwise.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_DISABLE_BY_IDX_COND(node_id, irq_idx)                       \
+	COND_CODE_1(SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, irq_idx),       \
+		    (shared_irq_disable(                                       \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, irq_idx)),    \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_disable(DT_IRQ_BY_IDX(node_id, irq_idx, irq))))       \
+
+/**
+ * @brief Disable ISR for a devicetree node's (only) shared-irqs interrupt if it
+ *        exists, or disable interrupts from the single IRQ otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_DISABLE_COND(node_id)                                       \
+	COND_CODE_1(SHARED_IRQ_BY_IDX_HAS_STATUS_OKAY(node_id, 0),             \
+		    (shared_irq_disable(                                       \
+			DEVICE_DT_GET(SHARED_IRQ_BY_IDX(node_id, 0)),          \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_disable(DT_IRQ(node_id, irq))))                       \
+
+/**
+ * @brief Disable ISR for a devicetree node's shared interrupt by name if it
+ *         exists, or disable interrupts from irq by name otherwise.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param node_id Node identifier of a device which may have a shared-irqs
+ *                phandle-array property.
+ * @param irq_name lowercase-and-underscores device shared-irqs name if it
+ *                 exists, irq name otherwise.
+ *
+ * @return N/A
+ */
+#define SHARED_IRQ_DISABLE_BY_NAME_COND(node_id, irq_name)                     \
+	COND_CODE_1(SHARED_IRQ_BY_NAME_HAS_STATUS_OKAY(node_id, irq_name),     \
+		    (shared_irq_disable(                                       \
+			DEVICE_DT_GET(SHARED_IRQ_BY_NAME(node_id, irq_name)),  \
+			DEVICE_DT_GET(node_id))),                              \
+		    (irq_disable(DT_IRQ_BY_NAME(node_id, irq_name, irq))))     \
 
 typedef int (*isr_t)(const struct device *dev);
 


### PR DESCRIPTION
This PR enables CAN support for stm32g0.
The driver introduced in #31061 by @alexanderwachter does work for this series as well without issues.
All tests pass with this definitions on nucleo_g0b1re.