### PR TITLE
west.yml: Update SoF to pull in MAX workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -115,8 +115,7 @@ manifest:
       revision: 38c79a447e4a47d413b4e8d34448316a5cece77c
       path: modules/debug/segger
     - name: sof
-      url: https://github.com/nordic-krch/sof
-      revision: 2f8ef204454d278f0c189e8c7cc70e84f745561a
+      revision: pull/9/head
       path: modules/audio/sof
     - name: tinycbor
       path: modules/lib/tinycbor


### PR DESCRIPTION
We need the MAX workaround to build able to build with the new
logging code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>