### PR TITLE
drivers: dma: stm32 dmamux accepts request ID =0 

### DIFF
--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -94,8 +94,7 @@ int dmamux_stm32_configure(const struct device *dev, uint32_t id,
 	 */
 	int request_id = config->dma_slot;
 
-	if (request_id == 0 ||
-	    request_id > dev_config->req_nb + dev_config->gen_nb) {
+	if (request_id > dev_config->req_nb + dev_config->gen_nb) {
 		LOG_ERR("request ID %d is not valid.", request_id);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The DMAMUX request ID = 0 means Memory to Memory transfer.
So this NULL value must be allowed in the list of request IDs.
This will make tests/drivers/dma/loop_transfer pass


Signed-off-by: Francois Ramu francois.ramu@st.com

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/35219