### PR TITLE
boards: native_posix: Add i2c & spi to supporte features

### DIFF
--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -10,5 +10,7 @@ supported:
   - netif:eth
   - usb_device
   - adc
+  - i2c
+  - spi
 testing:
   default: true


### PR DESCRIPTION
We have I2C & SPI controllers on native posix, so list them as
supported features in the board YAML.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>