### PR TITLE
ci: double number of worker for the day

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
-    parallelism: 20
+    parallelism: 40
     timeout_in_minutes: 180
     retry:
       manual: true


### PR DESCRIPTION
Increase the number of works to help PR throughput as we get
close to code freeze.  Will revert this back after code freeze.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>