### PR TITLE
samples/boards/stm32: blinky: Limit execution on stm32 lptim enabled

### DIFF
--- a/samples/boards/stm32/power_mgmt/blinky/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/blinky/sample.yaml
@@ -4,5 +4,6 @@ tests:
   sample.boards.stm32.power_mgmt.blinky:
     tags: LED power
     filter: dt_compat_enabled("zephyr,power-state") and
-            dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
+            dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+            dt_compat_enabled("st,stm32-lptim")
     depends_on: gpio


### PR DESCRIPTION
Restrict sample execution in CI to boards that have
"st,stm32-lptim" enabled so we're sure it is a STM32 target.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>