### PR TITLE
boards: arm: stm32: clean up dts after clock conversion

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -50,7 +50,7 @@
 	};
 };
 
-&clk_hsi{
+&clk_hsi {
 	status = "okay";
 };
 

--- a/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
+++ b/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
@@ -20,7 +20,6 @@
 		zephyr,ccm = &ccm0;
 	};
 
-
 	leds {
 		compatible = "gpio-leds";
 		ld1: led_1 {
@@ -102,7 +101,6 @@
 	status = "okay";
 };
 
-
 &spi2 {
 	pinctrl-0 = <&spi2_sck_pb13 &spi2_miso_pb14 &spi2_mosi_pb15>;
 	cs-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>;
@@ -129,7 +127,6 @@
 	status ="okay";
 	pinctrl-0 = <&adc1_in2_pa2 &adc1_in3_pa3>;
 };
-
 
 mikrobus_1_i2c: &i2c3 {};
 

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -74,7 +74,6 @@
 	status = "okay";
 };
 
-
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	status = "okay";

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -52,7 +52,7 @@
 	};
 };
 
-&clk_hse{
+&clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
 	status = "okay";

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -42,7 +42,7 @@
 	};
 };
 
-&clk_hse{
+&clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
 	status = "okay";

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -77,7 +77,6 @@
 	apb2-prescaler = <2>;
 };
 
-
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	status = "okay";

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -43,7 +43,7 @@
 	};
 };
 
-&clk_hsi{
+&clk_hsi {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -51,7 +51,7 @@
 	};
 };
 
-&clk_hse{
+&clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -58,7 +58,6 @@
 	};
 };
 
-
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -43,10 +43,10 @@
 	};
 };
 
-&clk_hse{
-	status = "okay";
-	clock-frequency = <DT_FREQ_M(8)>;
+&clk_hse {
 	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
 };
 
 &pll {
@@ -63,7 +63,6 @@
 	apb1-prescaler = <1>;
 	apb2-prescaler = <1>;
 };
-
 
 /* Due to limited available memory, don't enable gpiod and gpiof */
 /* (Test cases fail due to 'SRAM' region overflow) */

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -63,7 +63,7 @@
 	};
 };
 
-&clk_hsi{
+&clk_hsi {
 	status = "okay";
 };
 
@@ -134,7 +134,6 @@
 		     &spi3_miso_pc11 &spi3_mosi_pc12>;
 	status = "okay";
 };
-
 
 &timers2 {
 	status = "okay";

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -9,7 +9,7 @@
 #include "arduino_r3_connector.dtsi"
 
 / {
-    leds {
+	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
@@ -34,7 +34,7 @@
 	};
 };
 
-&clk_msi{
+&clk_msi {
 	status = "okay";
 	msi-range = <6>;
 };

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -83,12 +83,11 @@
 	};
 };
 
-
-&clk_hse{
+&clk_hse {
 	status = "okay";
 };
 
-&clk_lse{
+&clk_lse {
 	status = "okay";
 };
 

--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -141,7 +141,6 @@
 	status = "okay";
 };
 
-
 &iwdg {
 	status = "okay";
 };

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -102,8 +102,6 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-
-
 &spi5 {
 	pinctrl-0 = <&spi5_nss_pf6 &spi5_sck_pf7
 		     &spi5_miso_pf8 &spi5_mosi_pf9>;

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -51,13 +51,13 @@
 	};
 };
 
-&clk_msi{
+&clk_msi {
 	status = "okay";
 	msi-range = <6>;
 	msi-pll-mode;
 };
 
-&clk_lse{
+&clk_lse {
 	status = "okay";
 };
 


### PR DESCRIPTION
Mass conversion of STM32 boards to dts based clock configuration has left some minor whitespace issues. Fix these and some other whitespaces in the affected files.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>