### PR TITLE
drivers: modem: Fix build errors on 64-bit platforms

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1077,7 +1077,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 	/* start sending data */
 	k_sem_reset(&sock->sock_send_sem);
 	if (sock->type == SOCK_STREAM) {
-		snprintk(buf, sizeof(buf), "AT+KTCPSND=%d,%u", sock->socket_id,
+		snprintk(buf, sizeof(buf), "AT+KTCPSND=%d,%zu", sock->socket_id,
 			 send_len);
 	} else {
 		if (!net_addr_ntop(sock->family, &net_sin(&sock->dst)->sin_addr,
@@ -1085,7 +1085,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 			LOG_ERR("Invalid dst addr");
 			return -EINVAL;
 		}
-		snprintk(buf, sizeof(buf), "AT+KUDPSND=%d,\"%s\",%u,%u",
+		snprintk(buf, sizeof(buf), "AT+KUDPSND=%d,\"%s\",%u,%zu",
 			 sock->socket_id, dst_addr,
 			 net_sin(&sock->dst)->sin_port, send_len);
 	}
@@ -1111,10 +1111,10 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 		frag = frag->frags;
 	}
 	if (actual_send_len != send_len) {
-		LOG_WRN("AT+K**PSND act: %d exp: %d", actual_send_len,
+		LOG_WRN("AT+K**PSND act: %zd exp: %zd", actual_send_len,
 			send_len);
 	}
-	LOG_DBG("Sent %u bytes", actual_send_len);
+	LOG_DBG("Sent %zu bytes", actual_send_len);
 
 	/* Send EOF pattern to terminate data */
 	k_sem_reset(&sock->sock_send_sem);
@@ -2813,7 +2813,7 @@ static void sock_read(struct net_buf **buf, uint16_t len)
 		wait_for_modem_data(buf, 0, sock->rx_size);
 	}
 
-	LOG_DBG("Processing RX, buf len: %d", net_buf_frags_len(*buf));
+	LOG_DBG("Processing RX, buf len: %zd", net_buf_frags_len(*buf));
 
 	/* allocate an RX pkt */
 	sock->recv_pkt = net_pkt_rx_alloc_with_buffer(
@@ -2852,7 +2852,7 @@ static void sock_read(struct net_buf **buf, uint16_t len)
 		}
 	}
 
-	LOG_DBG("Got all data, get EOF and OK (buf len:%d)",
+	LOG_DBG("Got all data, get EOF and OK (buf len:%zd)",
 		net_buf_frags_len(*buf));
 
 	if (!*buf || (net_buf_frags_len(*buf) < strlen(EOF_PATTERN))) {
@@ -3161,7 +3161,7 @@ static size_t hl7800_read_rx(struct net_buf **buf)
 					     BUF_ALLOC_TIMEOUT,
 					     read_rx_allocator, &mdm_recv_pool);
 		if (rx_len < bytes_read) {
-			LOG_ERR("Data was lost! read %u of %u!", rx_len,
+			LOG_ERR("Data was lost! read %u of %zu!", rx_len,
 				bytes_read);
 		}
 		total_read += bytes_read;
@@ -4650,7 +4650,7 @@ int32_t mdm_hl7800_update_fw(char *file_path)
 	/* get file info */
 	ret = fs_stat(file_path, &file_info);
 	if (ret >= 0) {
-		LOG_DBG("file '%s' size %u", log_strdup(file_info.name),
+		LOG_DBG("file '%s' size %zu", log_strdup(file_info.name),
 			file_info.size);
 	} else {
 		LOG_ERR("Failed to get file [%s] info: %d",
@@ -4678,10 +4678,10 @@ int32_t mdm_hl7800_update_fw(char *file_path)
 	}
 
 	/* start firmware update process */
-	LOG_INF("Initiate FW update, total packets: %d",
+	LOG_INF("Initiate FW update, total packets: %zd",
 		((file_info.size / XMODEM_DATA_SIZE) + 1));
 	set_fota_state(HL7800_FOTA_START);
-	snprintk(cmd1, sizeof(cmd1), "AT+WDSD=%d", file_info.size);
+	snprintk(cmd1, sizeof(cmd1), "AT+WDSD=%zd", file_info.size);
 	send_at_cmd(NULL, cmd1, K_NO_WAIT, 0, false);
 
 	goto done;

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -354,7 +354,7 @@ static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 					      data->rx_buf, 0, len);
 		if ((data->match_buf_len - 1) < match_len) {
 			LOG_ERR("Match buffer size (%zu) is too small for "
-				"incoming command size: %u!  Truncating!",
+				"incoming command size: %zu!  Truncating!",
 				data->match_buf_len - 1, match_len);
 		}
 
@@ -366,7 +366,7 @@ static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 
 		cmd = find_cmd_match(data);
 		if (cmd) {
-			LOG_DBG("match cmd [%s] (len:%u)",
+			LOG_DBG("match cmd [%s] (len:%zu)",
 				log_strdup(cmd->cmd), match_len);
 
 			if (process_cmd(cmd, match_len, data) == -EAGAIN) {

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -584,7 +584,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 		return -1;
 	}
 
-	snprintk(sendbuf, sizeof(sendbuf), "AT+QIRD=%d,%d", sock->sock_fd, len);
+	snprintk(sendbuf, sizeof(sendbuf), "AT+QIRD=%d,%zd", sock->sock_fd, len);
 
 	/* Socket read settings */
 	(void) memset(&sock_data, 0, sizeof(sock_data));
@@ -815,7 +815,7 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 	ssize_t sent = 0;
 	int rc;
 
-	LOG_DBG("msg_iovlen:%d flags:%d", msg->msg_iovlen, flags);
+	LOG_DBG("msg_iovlen:%zd flags:%d", msg->msg_iovlen, flags);
 
 	for (int i = 0; i < msg->msg_iovlen; i++) {
 		const char *buf = msg->msg_iov[i].iov_base;

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1589,7 +1589,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 		next_packet_size = MDM_MAX_DATA_LENGTH;
 	}
 
-	snprintk(sendbuf, sizeof(sendbuf), "AT+USO%s=%d,%d",
+	snprintk(sendbuf, sizeof(sendbuf), "AT+USO%s=%d,%zd",
 		 sock->ip_proto == IPPROTO_UDP ? "RF" : "RD", sock->id,
 		 len < next_packet_size ? len : next_packet_size);
 
@@ -1708,7 +1708,7 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 		full_len += msg->msg_iov[i].iov_len;
 	}
 
-	LOG_DBG("msg_iovlen:%d flags:%d, full_len:%d",
+	LOG_DBG("msg_iovlen:%zd flags:%d, full_len:%zd",
 		msg->msg_iovlen, flags, full_len);
 
 	while (full_len > sent) {

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -390,7 +390,7 @@ static int send_data(struct wncm14a2a_socket *sock, struct net_pkt *pkt)
 
 	frag = pkt->frags;
 	/* use SOCKWRITE with binary mode formatting */
-	snprintk(buf, sizeof(buf), "AT@SOCKWRITE=%d,%u,1\r",
+	snprintk(buf, sizeof(buf), "AT@SOCKWRITE=%d,%zu,1\r",
 		 sock->socket_id, net_buf_frags_len(frag));
 	mdm_receiver_send(&ictx.mdm_ctx, buf, strlen(buf));
 
@@ -1091,7 +1091,7 @@ static void wncm14a2a_read_rx(struct net_buf **buf)
 					      read_rx_allocator,
 					      &mdm_recv_pool);
 		if (rx_len < bytes_read) {
-			LOG_ERR("Data was lost! read %u of %u!",
+			LOG_ERR("Data was lost! read %u of %zu!",
 				    rx_len, bytes_read);
 		}
 	}


### PR DESCRIPTION
If the modem drivers are built on a 64-bit platform we get errors with
the logging code due to use of size_t.  Update to use %zX to handle this
correctly between 32-bit and 64-bit platforms.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>