### PR TITLE
Pm/device - Extra fixes

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -215,20 +215,20 @@ registers, clocks, memory etc.
 
 The four device power states:
 
-:code:`PM_DEVICE_ACTIVE_STATE`
+:code:`PM_DEVICE_STATE_ACTIVE`
 
    Normal operation of the device. All device context is retained.
 
-:code:`PM_DEVICE_LOW_POWER_STATE`
+:code:`PM_DEVICE_STATE_LOW_POWER`
 
    Device context is preserved by the HW and need not be restored by the driver.
 
-:code:`PM_DEVICE_SUSPEND_STATE`
+:code:`PM_DEVICE_STATE_SUSPEND`
 
    Most device context is lost by the hardware. Device drivers must save and
    restore or reinitialize any context lost by the hardware.
 
-:code:`PM_DEVICE_OFF_STATE`
+:code:`PM_DEVICE_STATE_OFF`
 
    Power has been fully removed from the device. The device context is lost
    when this state is entered. Need to reinitialize the device when powering

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -476,7 +476,7 @@ static int st7735r_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	data->cmd_data_dev = device_get_binding(config->cmd_data.name);
@@ -527,18 +527,18 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		if (*((uint32_t *)context) == PM_DEVICE_STATE_ACTIVE) {
 			ret = st7735r_exit_sleep(data);
 			if (ret < 0) {
 				return ret;
 			}
-			data->pm_state = PM_DEVICE_ACTIVE_STATE;
+			data->pm_state = PM_DEVICE_STATE_ACTIVE;
 		} else {
 			ret = st7735r_enter_sleep(data);
 			if (ret < 0) {
 				return ret;
 			}
-			data->pm_state = PM_DEVICE_LOW_POWER_STATE;
+			data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 		}
 
 		break;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -376,7 +376,7 @@ static int st7789v_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	data->cmd_data_gpio = device_get_binding(
@@ -416,13 +416,13 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 
 	switch (ctrl_command) {
 	case DEVICE_PM_SET_POWER_STATE:
-		if (*state == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			st7789v_exit_sleep(data);
-			data->pm_state = PM_DEVICE_ACTIVE_STATE;
+			data->pm_state = PM_DEVICE_STATE_ACTIVE;
 			ret = 0;
 		} else {
 			st7789v_enter_sleep(data);
-			data->pm_state = PM_DEVICE_LOW_POWER_STATE;
+			data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 			ret = 0;
 		}
 		break;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -272,16 +272,16 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 	int ret = 0;
 
-	if ((new_state == PM_DEVICE_ACTIVE_STATE) &&
+	if ((new_state == PM_DEVICE_STATE_ACTIVE) &&
 		(new_state != data->pm_state)) {
 		Power_setDependency(PowerCC26XX_PERIPH_TRNG);
 		start_trng(data);
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-			new_state == PM_DEVICE_SUSPEND_STATE ||
-			new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+			new_state == PM_DEVICE_STATE_SUSPEND ||
+			new_state == PM_DEVICE_STATE_OFF);
 
-		if (data->pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (data->pm_state == PM_DEVICE_STATE_ACTIVE) {
 			stop_trng(data);
 			Power_releaseDependency(PowerCC26XX_PERIPH_TRNG);
 		}
@@ -324,7 +324,7 @@ static int entropy_cc13xx_cc26xx_init(const struct device *dev)
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 
 #ifdef CONFIG_PM_DEVICE
-	get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;
+	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	/* Initialize driver data */

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -200,7 +200,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 	}
 
 	if (command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_SUSPEND_STATE) {
+		if (*state == PM_DEVICE_STATE_SUSPEND) {
 			LOG_DBG("Suspending");
 
 			ret = net_if_suspend(eth_ctx->iface);
@@ -215,7 +215,7 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 			ENET_Deinit(eth_ctx->base);
 			clock_control_off(eth_ctx->clock_dev,
 				(clock_control_subsys_t)eth_ctx->clock);
-		} else if (*state == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			LOG_DBG("Resuming");
 
 			clock_control_on(eth_ctx->clock_dev,

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -641,16 +641,16 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 
 		if (new_state != dev_data->pm_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
 				acquire(dev);
 				power_down_op(dev, CMD_EXIT_DPD,
 					      dev_config->t_exit_dpd);
 				release(dev);
 				break;
 
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_SUSPEND_STATE:
-			case PM_DEVICE_OFF_STATE:
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_SUSPEND:
+			case PM_DEVICE_STATE_OFF:
 				acquire(dev);
 				power_down_op(dev,
 					dev_config->use_udpd ? CMD_ENTER_UDPD
@@ -721,7 +721,7 @@ static const struct flash_driver_api spi_flash_at45_api = {
 	static struct spi_flash_at45_data inst_##idx##_data = {		     \
 		.lock = Z_SEM_INITIALIZER(inst_##idx##_data.lock, 1, 1),     \
 		IF_ENABLED(CONFIG_PM_DEVICE, (		     \
-			.pm_state = PM_DEVICE_ACTIVE_STATE))		     \
+			.pm_state = PM_DEVICE_STATE_ACTIVE))		     \
 	};						\
 	INST_RESET_GPIO_SPEC(idx)				\
 	INST_WP_GPIO_SPEC(idx)					\

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -37,9 +37,9 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
  * Kconfig option.
  *
  * When mapped to the Zephyr Device Power Management states:
- * * PM_DEVICE_ACTIVE_STATE covers both active and standby modes;
- * * PM_DEVICE_LOW_POWER_STATE, PM_DEVICE_SUSPEND_STATE, and
- *   PM_DEVICE_OFF_STATE all correspond to deep-power-down mode.
+ * * PM_DEVICE_STATE_ACTIVE covers both active and standby modes;
+ * * PM_DEVICE_STATE_LOW_POWER, PM_DEVICE_STATE_SUSPEND, and
+ *   PM_DEVICE_STATE_OFF all correspond to deep-power-down mode.
  */
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -443,7 +443,7 @@ static uint32_t gpio_dw_get_power_state(const struct device *port)
 static inline int gpio_dw_suspend_port(const struct device *port)
 {
 	gpio_dw_clock_off(port);
-	gpio_dw_set_power_state(port, PM_DEVICE_SUSPEND_STATE);
+	gpio_dw_set_power_state(port, PM_DEVICE_STATE_SUSPEND);
 
 	return 0;
 }
@@ -451,7 +451,7 @@ static inline int gpio_dw_suspend_port(const struct device *port)
 static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 {
 	gpio_dw_clock_on(port);
-	gpio_dw_set_power_state(port, PM_DEVICE_ACTIVE_STATE);
+	gpio_dw_set_power_state(port, PM_DEVICE_STATE_ACTIVE);
 	return 0;
 }
 
@@ -466,9 +466,9 @@ static int gpio_dw_device_ctrl(const struct device *port,
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*((uint32_t *)context) == PM_DEVICE_SUSPEND_STATE) {
+		if (*((uint32_t *)context) == PM_DEVICE_STATE_SUSPEND) {
 			ret = gpio_dw_suspend_port(port);
-		} else if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*((uint32_t *)context) == PM_DEVICE_STATE_ACTIVE) {
 			ret = gpio_dw_resume_from_suspend_port(port);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
@@ -544,7 +544,7 @@ static int gpio_dw_initialize(const struct device *port)
 		config->config_func(port);
 	}
 
-	gpio_dw_set_power_state(port, PM_DEVICE_ACTIVE_STATE);
+	gpio_dw_set_power_state(port, PM_DEVICE_STATE_ACTIVE);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -466,7 +466,7 @@ static int gpio_stm32_config(const struct device *dev,
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	/* Enable device clock before configuration (requires bank writes) */
-	if (data->power_state != PM_DEVICE_ACTIVE_STATE) {
+	if (data->power_state != PM_DEVICE_STATE_ACTIVE) {
 		err = pm_device_get_sync(dev);
 		if (err < 0) {
 			return err;
@@ -586,11 +586,11 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 	struct gpio_stm32_data *data = dev->data;
 	int ret = 0;
 
-	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		ret = gpio_stm32_clock_request(dev, true);
-	} else if (new_state == PM_DEVICE_SUSPEND_STATE) {
+	} else if (new_state == PM_DEVICE_STATE_SUSPEND) {
 		ret = gpio_stm32_clock_request(dev, false);
-	} else if (new_state == PM_DEVICE_LOW_POWER_STATE) {
+	} else if (new_state == PM_DEVICE_STATE_LOW_POWER) {
 		ret = gpio_stm32_clock_request(dev, false);
 	}
 
@@ -660,13 +660,13 @@ static int gpio_stm32_init(const struct device *dev)
 #endif
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
-	data->power_state = PM_DEVICE_OFF_STATE;
+	data->power_state = PM_DEVICE_STATE_OFF;
 	pm_device_enable(dev);
 
 	return 0;
 #else
 #ifdef CONFIG_PM_DEVICE
-	data->power_state = PM_DEVICE_ACTIVE_STATE;
+	data->power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 	return gpio_stm32_clock_request(dev, true);
 #endif

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -333,7 +333,7 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 {
 	int ret = 0;
 
-	if ((new_state == PM_DEVICE_ACTIVE_STATE) &&
+	if ((new_state == PM_DEVICE_STATE_ACTIVE) &&
 		(new_state != get_dev_data(dev)->pm_state)) {
 		Power_setDependency(PowerCC26XX_PERIPH_I2C0);
 		IOCPinTypeI2c(get_dev_config(dev)->base,
@@ -346,11 +346,11 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 			get_dev_data(dev)->pm_state = new_state;
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-			new_state == PM_DEVICE_SUSPEND_STATE ||
-			new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+			new_state == PM_DEVICE_STATE_SUSPEND ||
+			new_state == PM_DEVICE_STATE_OFF);
 
-		if (get_dev_data(dev)->pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (get_dev_data(dev)->pm_state == PM_DEVICE_STATE_ACTIVE) {
 			I2CMasterIntDisable(get_dev_config(dev)->base);
 			I2CMasterDisable(get_dev_config(dev)->base);
 			/* Reset pin type to default GPIO configuration */
@@ -399,7 +399,7 @@ static int i2c_cc13xx_cc26xx_init(const struct device *dev)
 	int err;
 
 #ifdef CONFIG_PM_DEVICE
-	get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;
+	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 #ifdef CONFIG_PM

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -215,7 +215,7 @@ static int init_twi(const struct device *dev)
 		return -EBUSY;
 	}
 #ifdef CONFIG_PM_DEVICE
-	get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;
+	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;
@@ -234,7 +234,7 @@ static int twi_nrfx_pm_control(const struct device *dev,
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
 				init_twi(dev);
 				if (get_dev_data(dev)->dev_config) {
 					i2c_nrfx_twi_configure(
@@ -243,10 +243,10 @@ static int twi_nrfx_pm_control(const struct device *dev,
 				}
 				break;
 
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_SUSPEND_STATE:
-			case PM_DEVICE_OFF_STATE:
-				if (pm_current_state == PM_DEVICE_ACTIVE_STATE) {
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_SUSPEND:
+			case PM_DEVICE_STATE_OFF:
+				if (pm_current_state == PM_DEVICE_STATE_ACTIVE) {
 					nrfx_twi_uninit(&get_dev_config(dev)->twi);
 				}
 				break;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -254,7 +254,7 @@ static int init_twim(const struct device *dev)
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;
+	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;
@@ -273,7 +273,7 @@ static int twim_nrfx_pm_control(const struct device *dev,
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
 				init_twim(dev);
 				if (get_dev_data(dev)->dev_config) {
 					i2c_nrfx_twim_configure(
@@ -282,10 +282,10 @@ static int twim_nrfx_pm_control(const struct device *dev,
 				}
 				break;
 
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_SUSPEND_STATE:
-			case PM_DEVICE_OFF_STATE:
-				if (pm_current_state != PM_DEVICE_ACTIVE_STATE) {
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_SUSPEND:
+			case PM_DEVICE_STATE_OFF:
+				if (pm_current_state != PM_DEVICE_STATE_ACTIVE) {
 					break;
 				}
 				nrfx_twim_uninit(&get_dev_config(dev)->twim);

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -32,7 +32,7 @@ extern void *_VectorTable;
 #define _ARC_V2_IRQ_VECT_BASE _ARC_V2_IRQ_VECT_BASE_S
 #endif
 
-static uint32_t _arc_v2_irq_unit_device_power_state = PM_DEVICE_ACTIVE_STATE;
+static uint32_t _arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_ACTIVE;
 struct arc_v2_irq_unit_ctx {
 	uint32_t irq_ctrl; /* Interrupt Context Saving Control Register. */
 	uint32_t irq_vect_base; /* Interrupt Vector Base. */
@@ -120,7 +120,7 @@ static int arc_v2_irq_unit_suspend(const struct device *dev)
 	ctx.irq_ctrl = z_arc_v2_aux_reg_read(_ARC_V2_AUX_IRQ_CTRL);
 	ctx.irq_vect_base = z_arc_v2_aux_reg_read(_ARC_V2_IRQ_VECT_BASE);
 
-	_arc_v2_irq_unit_device_power_state = PM_DEVICE_SUSPEND_STATE;
+	_arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_SUSPEND;
 
 	return 0;
 }
@@ -166,7 +166,7 @@ static int arc_v2_irq_unit_resume(const struct device *dev)
 #endif
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_VECT_BASE, ctx.irq_vect_base);
 
-	_arc_v2_irq_unit_device_power_state = PM_DEVICE_ACTIVE_STATE;
+	_arc_v2_irq_unit_device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }
@@ -199,9 +199,9 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 	unsigned int key = arch_irq_lock();
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*((uint32_t *)context) == PM_DEVICE_SUSPEND_STATE) {
+		if (*((uint32_t *)context) == PM_DEVICE_STATE_SUSPEND) {
 			ret = arc_v2_irq_unit_suspend(dev);
-		} else if (*((uint32_t *)context) == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*((uint32_t *)context) == PM_DEVICE_STATE_ACTIVE) {
 			ret = arc_v2_irq_unit_resume(dev);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -104,7 +104,7 @@ static uint32_t ioapic_rtes;
 #define SUSPEND_BITS_REQD (ROUND_UP((256 * BITS_PER_IRQ), 32))
 
 uint32_t ioapic_suspend_buf[SUSPEND_BITS_REQD / 32] = {0};
-static uint32_t ioapic_device_power_state = PM_DEVICE_ACTIVE_STATE;
+static uint32_t ioapic_device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 #endif
 
@@ -311,17 +311,17 @@ static int ioapic_device_ctrl(const struct device *dev,
 		uint32_t new_state = *((uint32_t *)context);
 
 		switch (new_state) {
-		case PM_DEVICE_LOW_POWER_STATE:
+		case PM_DEVICE_STATE_LOW_POWER:
 			break;
-		case PM_DEVICE_ACTIVE_STATE:
+		case PM_DEVICE_STATE_ACTIVE:
 			if (ioapic_device_power_state !=
-					PM_DEVICE_LOW_POWER_STATE) {
+					PM_DEVICE_STATE_LOW_POWER) {
 				ret = ioapic_resume_from_suspend(dev);
 			}
 			break;
-		case PM_DEVICE_SUSPEND_STATE:
-		case PM_DEVICE_FORCE_SUSPEND_STATE:
-		case PM_DEVICE_OFF_STATE:
+		case PM_DEVICE_STATE_SUSPEND:
+		case PM_DEVICE_STATE_FORCE_SUSPEND:
+		case PM_DEVICE_STATE_OFF:
 			ret = ioapic_suspend(dev);
 			break;
 		default:

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -63,7 +63,7 @@
 #ifdef CONFIG_PM_DEVICE
 #include <pm/device.h>
 uint32_t loapic_suspend_buf[LOPIC_SUSPEND_BITS_REQD / 32] = {0};
-static uint32_t loapic_device_power_state = PM_DEVICE_ACTIVE_STATE;
+static uint32_t loapic_device_power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
@@ -364,7 +364,7 @@ static int loapic_suspend(const struct device *port)
 			}
 		}
 	}
-	loapic_device_power_state = PM_DEVICE_SUSPEND_STATE;
+	loapic_device_power_state = PM_DEVICE_STATE_SUSPEND;
 	return 0;
 }
 
@@ -393,7 +393,7 @@ int loapic_resume(const struct device *port)
 			}
 		}
 	}
-	loapic_device_power_state = PM_DEVICE_ACTIVE_STATE;
+	loapic_device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }
@@ -409,9 +409,9 @@ static int loapic_device_ctrl(const struct device *port,
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*context == PM_DEVICE_SUSPEND_STATE) {
+		if (*context == PM_DEVICE_STATE_SUSPEND) {
 			ret = loapic_suspend(port);
-		} else if (*context == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*context == PM_DEVICE_STATE_ACTIVE) {
 			ret = loapic_resume(port);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -120,7 +120,7 @@ static int led_pwm_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 	struct led_pwm_data *data = DEV_DATA(dev);
 
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3490,7 +3490,7 @@ static void shutdown_uart(void)
 		HL7800_IO_DBG_LOG("Power OFF the UART");
 		uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
 		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_OFF_STATE, NULL, NULL);
+					 PM_DEVICE_STATE_OFF, NULL, NULL);
 		if (rc) {
 			LOG_ERR("Error disabling UART peripheral (%d)", rc);
 		}
@@ -3507,7 +3507,7 @@ static void power_on_uart(void)
 	if (!ictx.uart_on) {
 		HL7800_IO_DBG_LOG("Power ON the UART");
 		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+					 PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 		if (rc) {
 			LOG_ERR("Error enabling UART peripheral (%d)", rc);
 		}

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -198,16 +198,16 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 {
 	uart_irq_rx_disable(ctx->uart_dev);
-#ifdef PM_DEVICE_LOW_POWER_STATE
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_LOW_POWER_STATE, NULL, NULL);
+#ifdef PM_DEVICE_STATE_LOW_POWER
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
 #endif
 	return 0;
 }
 
 int mdm_receiver_wake(struct mdm_receiver_context *ctx)
 {
-#ifdef PM_DEVICE_LOW_POWER_STATE
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+#ifdef PM_DEVICE_STATE_LOW_POWER
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 #endif
 	uart_irq_rx_enable(ctx->uart_dev);
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -297,14 +297,14 @@ static int pwm_nrfx_set_power_state(uint32_t new_state,
 	int err = 0;
 
 	switch (new_state) {
-	case PM_DEVICE_ACTIVE_STATE:
+	case PM_DEVICE_STATE_ACTIVE:
 		err = pwm_nrfx_init(dev);
 		break;
-	case PM_DEVICE_LOW_POWER_STATE:
-	case PM_DEVICE_SUSPEND_STATE:
-	case PM_DEVICE_FORCE_SUSPEND_STATE:
-	case PM_DEVICE_OFF_STATE:
-		if (current_state == PM_DEVICE_ACTIVE_STATE) {
+	case PM_DEVICE_STATE_LOW_POWER:
+	case PM_DEVICE_STATE_SUSPEND:
+	case PM_DEVICE_STATE_FORCE_SUSPEND:
+	case PM_DEVICE_STATE_OFF:
+		if (current_state == PM_DEVICE_STATE_ACTIVE) {
 			pwm_nrfx_uninit(dev);
 		}
 		break;
@@ -348,7 +348,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 					       pm_device_cb cb,		\
 					       void *arg)		\
 	{								\
-		static uint32_t current_state = PM_DEVICE_ACTIVE_STATE;	\
+		static uint32_t current_state = PM_DEVICE_STATE_ACTIVE;	\
 		int ret = 0;                                            \
 		ret = pwm_nrfx_pm_control(dev, ctrl_command, state,	\
 					   &current_state);		\

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -419,7 +419,7 @@ static int apds9960_device_ctrl(const struct device *dev,
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
 		uint32_t device_pm_state = *(uint32_t *)context;
 
-		if (device_pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (device_pm_state == PM_DEVICE_STATE_ACTIVE) {
 			if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 						APDS9960_ENABLE_REG,
 						APDS9960_ENABLE_PON,
@@ -442,7 +442,7 @@ static int apds9960_device_ctrl(const struct device *dev,
 		}
 
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = PM_DEVICE_ACTIVE_STATE;
+		*((uint32_t *)context) = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	if (cb) {

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -183,7 +183,7 @@ static int bme280_sample_fetch(const struct device *dev,
 
 #ifdef CONFIG_PM_DEVICE
 	/* Do not allow sample fetching from OFF state */
-	if (data->pm_state == PM_DEVICE_OFF_STATE)
+	if (data->pm_state == PM_DEVICE_STATE_OFF)
 		return -EIO;
 #endif
 
@@ -383,7 +383,7 @@ static int bme280_chip_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 	/* Set power state to ACTIVE */
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 	LOG_DBG("\"%s\" OK", dev->name);
 	return 0;
@@ -404,13 +404,13 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 		if (new_pm_state != data->pm_state) {
 
 			/* Switching from OFF to any */
-			if (data->pm_state == PM_DEVICE_OFF_STATE) {
+			if (data->pm_state == PM_DEVICE_STATE_OFF) {
 
 				/* Re-initialize the chip */
 				ret = bme280_chip_init(dev);
 			}
 			/* Switching to OFF from any */
-			else if (new_pm_state == PM_DEVICE_OFF_STATE) {
+			else if (new_pm_state == PM_DEVICE_STATE_OFF) {
 
 				/* Put the chip into sleep mode */
 				ret = bme280_reg_write(dev,

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -313,7 +313,7 @@ static int bmp388_attr_set(const struct device *dev,
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	struct bmp388_data *data = DEV_DATA(dev);
 
-	if (data->device_power_state != PM_DEVICE_ACTIVE_STATE) {
+	if (data->device_power_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}
 #endif
@@ -348,7 +348,7 @@ static int bmp388_sample_fetch(const struct device *dev,
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	if (bmp388->device_power_state != PM_DEVICE_ACTIVE_STATE) {
+	if (bmp388->device_power_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}
 #endif
@@ -557,10 +557,10 @@ static int bmp388_set_power_state(const struct device *dev,
 		return 0;
 	}
 
-	if (power_state == PM_DEVICE_ACTIVE_STATE) {
+	if (power_state == PM_DEVICE_STATE_ACTIVE) {
 		reg_val = BMP388_PWR_CTRL_MODE_NORMAL;
-	} else if ((power_state == PM_DEVICE_SUSPEND_STATE) ||
-		   (power_state == PM_DEVICE_OFF_STATE)) {
+	} else if ((power_state == PM_DEVICE_STATE_SUSPEND) ||
+		   (power_state == PM_DEVICE_STATE_OFF)) {
 		reg_val = BMP388_PWR_CTRL_MODE_SLEEP;
 	} else {
 		return 0;
@@ -672,7 +672,7 @@ static int bmp388_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	bmp388->device_power_state = PM_DEVICE_ACTIVE_STATE;
+	bmp388->device_power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	/* Read calibration data */

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -92,7 +92,7 @@ int bmp388_trigger_set(
 	struct bmp388_data *data = DEV_DATA(dev);
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-	if (data->device_power_state != PM_DEVICE_ACTIVE_STATE) {
+	if (data->device_power_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}
 #endif

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -424,7 +424,7 @@ static int fdc2x1x_reset(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 	struct fdc2x1x_data *data = dev->data;
 
-	data->pm_state = PM_DEVICE_LOW_POWER_STATE;
+	data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 #endif
 
 	return ret;
@@ -496,8 +496,8 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 	const struct fdc2x1x_config *cfg = dev->config;
 
 	switch (pm_state) {
-	case PM_DEVICE_ACTIVE_STATE:
-		if (data->pm_state == PM_DEVICE_OFF_STATE) {
+	case PM_DEVICE_STATE_ACTIVE:
+		if (data->pm_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {
 				return ret;
@@ -508,11 +508,11 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 		if (ret) {
 			return ret;
 		}
-		data->pm_state = PM_DEVICE_ACTIVE_STATE;
+		data->pm_state = PM_DEVICE_STATE_ACTIVE;
 
 		break;
-	case PM_DEVICE_LOW_POWER_STATE:
-		if (data->pm_state == PM_DEVICE_OFF_STATE) {
+	case PM_DEVICE_STATE_LOW_POWER:
+		if (data->pm_state == PM_DEVICE_STATE_OFF) {
 			ret = fdc2x1x_set_shutdown(dev, false);
 			if (ret) {
 				return ret;
@@ -522,13 +522,13 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 		if (ret) {
 			return ret;
 		}
-		data->pm_state = PM_DEVICE_LOW_POWER_STATE;
+		data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 
 		break;
-	case PM_DEVICE_OFF_STATE:
+	case PM_DEVICE_STATE_OFF:
 		if (cfg->sd_gpio->name) {
 			ret = fdc2x1x_set_shutdown(dev, true);
-			data->pm_state = PM_DEVICE_OFF_STATE;
+			data->pm_state = PM_DEVICE_STATE_OFF;
 		} else {
 			LOG_ERR("SD pin not defined");
 			ret = -EINVAL;
@@ -553,9 +553,9 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 		new_state = *(uint32_t *)context;
 		if (new_state != data->pm_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_OFF_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_OFF:
 				ret = fdc2x1x_set_pm_state(dev, new_state);
 				break;
 			default:
@@ -655,7 +655,7 @@ static int fdc2x1x_sample_fetch(const struct device *dev,
 #ifdef CONFIG_PM_DEVICE
 	struct fdc2x1x_data *data = dev->data;
 
-	if (data->pm_state != PM_DEVICE_ACTIVE_STATE) {
+	if (data->pm_state != PM_DEVICE_STATE_ACTIVE) {
 		LOG_ERR("Sample fetch failed, device is not in active mode");
 		return -ENXIO;
 	}

--- a/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
@@ -25,7 +25,7 @@ static void fdc2x1x_thread_cb(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 	/* INTB asserts after exiting shutdown mode. Drop this interrupt */
-	if (drv_data->pm_state == PM_DEVICE_OFF_STATE) {
+	if (drv_data->pm_state == PM_DEVICE_STATE_OFF) {
 		return;
 	}
 #endif

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -470,7 +470,7 @@ static int lis2mdl_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	lis2mdl->power_state = PM_DEVICE_ACTIVE_STATE;
+	lis2mdl->power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 #ifdef CONFIG_LIS2MDL_TRIGGER
@@ -490,7 +490,7 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 {
 	int status = 0;
 
-	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		if (config->single_mode) {
 			status = lis2mdl_operating_mode_set(lis2mdl->ctx,
 						LIS2MDL_SINGLE_TRIGGER);
@@ -501,12 +501,12 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		if (status) {
 			LOG_ERR("Power up failed");
 		}
-		lis2mdl->power_state = PM_DEVICE_ACTIVE_STATE;
+		lis2mdl->power_state = PM_DEVICE_STATE_ACTIVE;
 		LOG_DBG("State changed to active");
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-				new_state == PM_DEVICE_SUSPEND_STATE ||
-				new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+				new_state == PM_DEVICE_STATE_SUSPEND ||
+				new_state == PM_DEVICE_STATE_OFF);
 		status = lis2mdl_operating_mode_set(lis2mdl->ctx,
 				LIS2MDL_POWER_DOWN);
 		if (status) {

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -209,7 +209,7 @@ static int qdec_nrfx_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;
 
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;
@@ -242,18 +242,18 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 		return 0;
 	}
 
-	if (old_state == PM_DEVICE_ACTIVE_STATE) {
+	if (old_state == PM_DEVICE_STATE_ACTIVE) {
 		/* device must be suspended */
 		nrfx_qdec_disable();
 		qdec_nrfx_gpio_ctrl(false);
 	}
 
-	if (new_state == PM_DEVICE_OFF_STATE) {
+	if (new_state == PM_DEVICE_STATE_OFF) {
 		/* device must be uninitialized */
 		nrfx_qdec_uninit();
 	}
 
-	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		qdec_nrfx_gpio_ctrl(true);
 		nrfx_qdec_enable();
 	}

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -238,7 +238,7 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		if (ret < 0)
 			return ret;
 #endif
-		if (device_pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (device_pm_state == PM_DEVICE_STATE_ACTIVE) {
 			/* Clear proximity shutdown */
 			ps_conf &= ~VCNL4040_PS_SD_MASK;
 
@@ -275,7 +275,7 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		}
 
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = PM_DEVICE_ACTIVE_STATE;
+		*((uint32_t *)context) = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	if (cb) {

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -402,7 +402,7 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 {
 	int ret = 0;
 
-	if ((new_state == PM_DEVICE_ACTIVE_STATE) &&
+	if ((new_state == PM_DEVICE_STATE_ACTIVE) &&
 		(new_state != get_dev_data(dev)->pm_state)) {
 		if (get_dev_conf(dev)->regs ==
 			DT_INST_REG_ADDR(0)) {
@@ -417,11 +417,11 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 			get_dev_data(dev)->pm_state = new_state;
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-			new_state == PM_DEVICE_SUSPEND_STATE ||
-			new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+			new_state == PM_DEVICE_STATE_SUSPEND ||
+			new_state == PM_DEVICE_STATE_OFF);
 
-		if (get_dev_data(dev)->pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (get_dev_data(dev)->pm_state == PM_DEVICE_STATE_ACTIVE) {
 			UARTDisable(get_dev_conf(dev)->regs);
 			/*
 			 * Release power dependency - i.e. potentially power
@@ -581,7 +581,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 
 #define UART_CC13XX_CC26XX_INIT_PM_STATE				\
 	do {								\
-		get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;	\
+		get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;	\
 	} while (0)
 #else
 #define UART_CC13XX_CC26XX_INIT_PM_STATE

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -453,8 +453,8 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 	struct uart_npcx_data *const data = DRV_DATA(dev);
 
 	/* If next device power state is LOW or SUSPEND power state */
-	if (next_state == PM_DEVICE_LOW_POWER_STATE ||
-	    next_state == PM_DEVICE_SUSPEND_STATE) {
+	if (next_state == PM_DEVICE_STATE_LOW_POWER ||
+	    next_state == PM_DEVICE_STATE_SUSPEND) {
 		/*
 		 * If uart device is busy with transmitting, the driver will
 		 * stay in while loop and wait for the transaction is completed.

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1140,7 +1140,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 static void uart_nrfx_set_power_state(const struct device *dev,
 				      uint32_t new_state)
 {
-	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		if (RX_PIN_USED) {
@@ -1148,9 +1148,9 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 					      NRF_UART_TASK_STARTRX);
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-				new_state == PM_DEVICE_SUSPEND_STATE ||
-				new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+				new_state == PM_DEVICE_STATE_SUSPEND ||
+				new_state == PM_DEVICE_STATE_OFF);
 		nrf_uart_disable(uart0_addr);
 		uart_nrfx_pins_enable(dev, false);
 	}
@@ -1160,7 +1160,7 @@ static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
 				uint32_t *state, pm_device_cb cb, void *arg)
 {
-	static uint32_t current_state = PM_DEVICE_ACTIVE_STATE;
+	static uint32_t current_state = PM_DEVICE_STATE_ACTIVE;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
 		uint32_t new_state = *state;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1377,7 +1377,7 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 	int key;
 
 #ifdef CONFIG_PM_DEVICE
-	if (data->pm_state != PM_DEVICE_ACTIVE_STATE) {
+	if (data->pm_state != PM_DEVICE_STATE_ACTIVE) {
 		return;
 	}
 #endif
@@ -1670,7 +1670,7 @@ static int uarte_instance_init(const struct device *dev,
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	if (IS_ENABLED(CONFIG_UART_ENHANCED_POLL_OUT) &&
@@ -1775,7 +1775,7 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
-	if (new_state == PM_DEVICE_ACTIVE_STATE) {
+	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 
@@ -1803,14 +1803,14 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 #endif
 		}
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-				new_state == PM_DEVICE_SUSPEND_STATE ||
-				new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+				new_state == PM_DEVICE_STATE_SUSPEND ||
+				new_state == PM_DEVICE_STATE_OFF);
 
 		/* if pm is already not active, driver will stay indefinitely
 		 * in while loop waiting for event NRF_UARTE_EVENT_RXTO
 		 */
-		if (data->pm_state != PM_DEVICE_ACTIVE_STATE) {
+		if (data->pm_state != PM_DEVICE_STATE_ACTIVE) {
 			return;
 		}
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1410,7 +1410,7 @@ static int uart_stm32_init(const struct device *dev)
 	config->uconf.irq_config_func(dev);
 #endif
 #ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_UART_ASYNC_API
@@ -1428,7 +1428,7 @@ static int uart_stm32_set_power_state(const struct device *dev,
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	/* setting a low power mode */
-	if (new_state != PM_DEVICE_ACTIVE_STATE) {
+	if (new_state != PM_DEVICE_STATE_ACTIVE) {
 #ifdef USART_ISR_BUSY
 		/* Make sure that no USART transfer is on-going */
 		while (LL_USART_IsActiveFlag_BUSY(UartInstance) == 1) {

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -215,7 +215,7 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 {
 	int ret = 0;
 
-	if ((new_state == PM_DEVICE_ACTIVE_STATE) &&
+	if ((new_state == PM_DEVICE_STATE_ACTIVE) &&
 		(new_state != get_dev_data(dev)->pm_state)) {
 		if (get_dev_config(dev)->base ==
 			DT_INST_REG_ADDR(0)) {
@@ -225,11 +225,11 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 		}
 		get_dev_data(dev)->pm_state = new_state;
 	} else {
-		__ASSERT_NO_MSG(new_state == PM_DEVICE_LOW_POWER_STATE ||
-			new_state == PM_DEVICE_SUSPEND_STATE ||
-			new_state == PM_DEVICE_OFF_STATE);
+		__ASSERT_NO_MSG(new_state == PM_DEVICE_STATE_LOW_POWER ||
+			new_state == PM_DEVICE_STATE_SUSPEND ||
+			new_state == PM_DEVICE_STATE_OFF);
 
-		if (get_dev_data(dev)->pm_state == PM_DEVICE_ACTIVE_STATE) {
+		if (get_dev_data(dev)->pm_state == PM_DEVICE_STATE_ACTIVE) {
 			SSIDisable(get_dev_config(dev)->base);
 			/*
 			 * Release power dependency
@@ -338,7 +338,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 #ifdef CONFIG_PM_DEVICE
 #define SPI_CC13XX_CC26XX_INIT_PM_STATE					    \
 	do {								    \
-		get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;	    \
+		get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;	    \
 	} while (0)
 #else
 #define SPI_CC13XX_CC26XX_INIT_PM_STATE

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -277,7 +277,7 @@ static int init_spi(const struct device *dev)
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	dev_data->pm_state = PM_DEVICE_ACTIVE_STATE;
+	dev_data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;
@@ -297,16 +297,16 @@ static int spi_nrfx_pm_control(const struct device *dev,
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
 				ret = init_spi(dev);
 				/* Force reconfiguration before next transfer */
 				data->ctx.config = NULL;
 				break;
 
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_SUSPEND_STATE:
-			case PM_DEVICE_OFF_STATE:
-				if (data->pm_state == PM_DEVICE_ACTIVE_STATE) {
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_SUSPEND:
+			case PM_DEVICE_STATE_OFF:
+				if (data->pm_state == PM_DEVICE_STATE_ACTIVE) {
 					nrfx_spi_uninit(&config->spi);
 				}
 				break;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -324,8 +324,8 @@ static int init_spim(const struct device *dev)
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_ACTIVE_STATE;
-	get_dev_data(dev)->pm_state = PM_DEVICE_ACTIVE_STATE;
+	data->pm_state = PM_DEVICE_STATE_ACTIVE;
+	get_dev_data(dev)->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
 	return 0;
@@ -345,16 +345,16 @@ static int spim_nrfx_pm_control(const struct device *dev,
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {
-			case PM_DEVICE_ACTIVE_STATE:
+			case PM_DEVICE_STATE_ACTIVE:
 				ret = init_spim(dev);
 				/* Force reconfiguration before next transfer */
 				data->ctx.config = NULL;
 				break;
 
-			case PM_DEVICE_LOW_POWER_STATE:
-			case PM_DEVICE_SUSPEND_STATE:
-			case PM_DEVICE_OFF_STATE:
-				if (data->pm_state == PM_DEVICE_ACTIVE_STATE) {
+			case PM_DEVICE_STATE_LOW_POWER:
+			case PM_DEVICE_STATE_SUSPEND:
+			case PM_DEVICE_STATE_OFF:
+				if (data->pm_state == PM_DEVICE_STATE_ACTIVE) {
 					nrfx_spim_uninit(&config->spim);
 				}
 				break;

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -73,6 +73,24 @@ struct device;
  */
 #define PM_DEVICE_OFF_STATE             5
 
+/** @def PM_DEVICE_RESUMING_STATE
+ *
+ * @brief device is resuming to active state.
+ *
+ * @details - The device was previously suspended and is now
+ * transitioning to become ACTIVE.
+ */
+#define PM_DEVICE_RESUMING_STATE             6
+
+/** @def PM_DEVICE_SUSPENDING_STATE
+ *
+ * @brief device is suspending.
+ *
+ * @details - The device is currently transitioning from ACTIVE
+ * to SUSPEND.
+ */
+#define PM_DEVICE_SUSPENDING_STATE             7
+
 /* Constants defining support device power commands */
 #define PM_DEVICE_STATE_SET       1
 #define PM_DEVICE_STATE_GET       2

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -24,24 +24,24 @@ extern "C" {
 
 struct device;
 
-/** @def PM_DEVICE_ACTIVE_STATE
+/** @def PM_DEVICE_STATE_ACTIVE
  *
  * @brief device is in ACTIVE power state
  *
  * @details Normal operation of the device. All device context is retained.
  */
-#define PM_DEVICE_ACTIVE_STATE          1
+#define PM_DEVICE_STATE_ACTIVE          1
 
-/** @def PM_DEVICE_LOW_POWER_STATE
+/** @def PM_DEVICE_STATE_LOW_POWER
  *
  * @brief device is in LOW power state
  *
  * @details Device context is preserved by the HW and need not be
  * restored by the driver.
  */
-#define PM_DEVICE_LOW_POWER_STATE       2
+#define PM_DEVICE_STATE_LOW_POWER       2
 
-/** @def PM_DEVICE_SUSPEND_STATE
+/** @def PM_DEVICE_STATE_SUSPEND
  *
  * @brief device is in SUSPEND power state
  *
@@ -49,9 +49,9 @@ struct device;
  * Device drivers must save and restore or reinitialize any context
  * lost by the hardware
  */
-#define PM_DEVICE_SUSPEND_STATE         3
+#define PM_DEVICE_STATE_SUSPEND         3
 
-/** @def PM_DEVICE_FORCE_SUSPEND_STATE
+/** @def PM_DEVICE_STATE_FORCE_SUSPEND
  *
  * @brief device is in force SUSPEND power state
  *
@@ -61,9 +61,9 @@ struct device;
  * Most device context is lost by the hardware. Device drivers must
  * save and restore or reinitialize any context lost by the hardware.
  */
-#define PM_DEVICE_FORCE_SUSPEND_STATE	4
+#define PM_DEVICE_STATE_FORCE_SUSPEND	4
 
-/** @def PM_DEVICE_OFF_STATE
+/** @def PM_DEVICE_STATE_OFF
  *
  * @brief device is in OFF power state
  *
@@ -71,25 +71,25 @@ struct device;
  * The device context is lost when this state is entered, so the OS
  * software will reinitialize the device when powering it back on
  */
-#define PM_DEVICE_OFF_STATE             5
+#define PM_DEVICE_STATE_OFF             5
 
-/** @def PM_DEVICE_RESUMING_STATE
+/** @def PM_DEVICE_STATE_RESUMING
  *
  * @brief device is resuming to active state.
  *
  * @details - The device was previously suspended and is now
  * transitioning to become ACTIVE.
  */
-#define PM_DEVICE_RESUMING_STATE             6
+#define PM_DEVICE_STATE_RESUMING             6
 
-/** @def PM_DEVICE_SUSPENDING_STATE
+/** @def PM_DEVICE_STATE_SUSPENDING
  *
  * @brief device is suspending.
  *
  * @details - The device is currently transitioning from ACTIVE
  * to SUSPEND.
  */
-#define PM_DEVICE_SUSPENDING_STATE             7
+#define PM_DEVICE_STATE_SUSPENDING             7
 
 /* Constants defining support device power commands */
 #define PM_DEVICE_STATE_SET       1

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -66,17 +66,17 @@ void main(void)
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 
 	printk("Busy-wait %u s with UART off\n", BUSY_WAIT_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_LOW_POWER_STATE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
-	rc = pm_device_state_set(cons, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 
 	printk("Sleep %u s\n", SLEEP_S);
 	k_sleep(K_SECONDS(SLEEP_S));
 
 	printk("Sleep %u s with UART off\n", SLEEP_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_LOW_POWER_STATE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
 	k_sleep(K_SECONDS(SLEEP_S));
-	rc = pm_device_state_set(cons, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 
 	printk("Entering system off; press BUTTON1 to restart\n");
 

--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -21,6 +21,9 @@ void main(void)
 
 	__ASSERT_NO_MSG(device_is_ready(led.port));
 
+	/* Don't let the system power off / low power this device */
+	device_busy_set(led.port);
+
 	while (true) {
 		gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 		gpio_pin_set(led.port, led.pin, (int)led_is_on);

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -151,7 +151,7 @@ void main(void)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 	printk("Putting the flash device into low power state... ");
-	err = pm_device_state_set(flash_dev, PM_DEVICE_LOW_POWER_STATE,
+	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_LOW_POWER,
 				  NULL, NULL);
 	if (err != 0) {
 		printk("FAILED\n");

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -79,11 +79,11 @@ void main(void)
 #ifdef CONFIG_PM_DEVICE
 		uint32_t p_state;
 
-		p_state = PM_DEVICE_LOW_POWER_STATE;
+		p_state = PM_DEVICE_STATE_LOW_POWER;
 		pm_device_state_set(dev, p_state, NULL, NULL);
 		printk("set low power state for 2s\n");
 		k_sleep(K_MSEC(2000));
-		p_state = PM_DEVICE_ACTIVE_STATE;
+		p_state = PM_DEVICE_STATE_ACTIVE;
 		pm_device_state_set(dev, p_state, NULL, NULL);
 #endif
 	}

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -43,13 +43,13 @@ static void pm_cb(const struct device *dev,
 	ARG_UNUSED(arg);
 
 	switch (*(uint32_t *)context) {
-	case PM_DEVICE_ACTIVE_STATE:
+	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
 		break;
-	case PM_DEVICE_LOW_POWER_STATE:
+	case PM_DEVICE_STATE_LOW_POWER:
 		printk("Enter LOW_POWER_STATE ");
 		break;
-	case PM_DEVICE_OFF_STATE:
+	case PM_DEVICE_STATE_OFF:
 		printk("Enter OFF_STATE ");
 		break;
 	}
@@ -97,13 +97,13 @@ void main(void)
 	/* Testing the power modes */
 	uint32_t p_state;
 
-	p_state = PM_DEVICE_LOW_POWER_STATE;
+	p_state = PM_DEVICE_STATE_LOW_POWER;
 	pm_device_state_set(dev, p_state, pm_cb, NULL);
 
-	p_state = PM_DEVICE_OFF_STATE;
+	p_state = PM_DEVICE_STATE_OFF;
 	pm_device_state_set(dev, p_state, pm_cb, NULL);
 
-	p_state = PM_DEVICE_ACTIVE_STATE;
+	p_state = PM_DEVICE_STATE_ACTIVE;
 	pm_device_state_set(dev, p_state, pm_cb, NULL);
 #endif
 
@@ -132,10 +132,10 @@ void main(void)
 
 
 #ifdef CONFIG_PM_DEVICE
-		p_state = PM_DEVICE_OFF_STATE;
+		p_state = PM_DEVICE_STATE_OFF;
 		pm_device_state_set(dev, p_state, pm_cb, NULL);
 		k_sleep(K_MSEC(2000));
-		p_state = PM_DEVICE_ACTIVE_STATE;
+		p_state = PM_DEVICE_STATE_ACTIVE;
 		pm_device_state_set(dev, p_state, pm_cb, NULL);
 #elif CONFIG_FDC2X1X_TRIGGER_NONE
 		k_sleep(K_MSEC(100));

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -37,7 +37,7 @@ static int dummy_open(const struct device *dev)
 	(void) k_condvar_wait(&dev->pm->condvar, &wait_mutex, K_FOREVER);
 	k_mutex_unlock(&wait_mutex);
 
-	if (atomic_get(&dev->pm->state) == PM_DEVICE_ACTIVE_STATE) {
+	if (atomic_get(&dev->pm->state) == PM_DEVICE_STATE_ACTIVE) {
 		printk("Dummy device resumed\n");
 		ret = 0;
 	} else {
@@ -97,7 +97,7 @@ static uint32_t dummy_get_power_state(const struct device *dev)
 static int dummy_suspend(const struct device *dev)
 {
 	printk("child suspending..\n");
-	device_power_state = PM_DEVICE_SUSPEND_STATE;
+	device_power_state = PM_DEVICE_STATE_SUSPEND;
 
 	return 0;
 }
@@ -105,7 +105,7 @@ static int dummy_suspend(const struct device *dev)
 static int dummy_resume_from_suspend(const struct device *dev)
 {
 	printk("child resuming..\n");
-	device_power_state = PM_DEVICE_ACTIVE_STATE;
+	device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }
@@ -118,7 +118,7 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);
@@ -152,7 +152,7 @@ int dummy_init(const struct device *dev)
 	}
 
 	pm_device_enable(dev);
-	device_power_state = PM_DEVICE_ACTIVE_STATE;
+	device_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -33,7 +33,7 @@ static uint32_t dummy_get_power_state(const struct device *dev)
 static int dummy_suspend(const struct device *dev)
 {
 	printk("parent suspending..\n");
-	parent_power_state = PM_DEVICE_SUSPEND_STATE;
+	parent_power_state = PM_DEVICE_STATE_SUSPEND;
 
 	return 0;
 }
@@ -41,7 +41,7 @@ static int dummy_suspend(const struct device *dev)
 static int dummy_resume_from_suspend(const struct device *dev)
 {
 	printk("parent resuming..\n");
-	parent_power_state = PM_DEVICE_ACTIVE_STATE;
+	parent_power_state = PM_DEVICE_STATE_ACTIVE;
 
 	return 0;
 }
@@ -54,7 +54,7 @@ static int dummy_parent_pm_ctrl(const struct device *dev,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);
@@ -79,7 +79,7 @@ static const struct dummy_parent_api funcs = {
 int dummy_parent_init(const struct device *dev)
 {
 	pm_device_enable(dev);
-	parent_power_state = PM_DEVICE_ACTIVE_STATE;
+	parent_power_state = PM_DEVICE_STATE_ACTIVE;
 	return 0;
 }
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -5529,7 +5529,7 @@ static int cmd_net_suspend(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_SUSPEND_STATE,
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND,
 					  NULL, NULL);
 		if (ret != 0) {
 			PR_INFO("Iface could not be suspended: ");
@@ -5574,7 +5574,7 @@ static int cmd_net_resume(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_ACTIVE_STATE,
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE,
 					  NULL, NULL);
 		if (ret != 0) {
 			PR_INFO("Iface could not be resumed\n");

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -80,7 +80,7 @@ static bool should_suspend(const struct device *dev, uint32_t state)
 	 * If the device is currently powered off or the request was
 	 * to go to the same state, just ignore it.
 	 */
-	if ((current_state == PM_DEVICE_OFF_STATE) ||
+	if ((current_state == PM_DEVICE_STATE_OFF) ||
 			(current_state == state)) {
 		return false;
 	}
@@ -128,17 +128,17 @@ static int _pm_devices(uint32_t state)
 
 int pm_suspend_devices(void)
 {
-	return _pm_devices(PM_DEVICE_SUSPEND_STATE);
+	return _pm_devices(PM_DEVICE_STATE_SUSPEND);
 }
 
 int pm_low_power_devices(void)
 {
-	return _pm_devices(PM_DEVICE_LOW_POWER_STATE);
+	return _pm_devices(PM_DEVICE_STATE_LOW_POWER);
 }
 
 int pm_force_suspend_devices(void)
 {
-	return _pm_devices(PM_DEVICE_FORCE_SUSPEND_STATE);
+	return _pm_devices(PM_DEVICE_STATE_FORCE_SUSPEND);
 }
 
 void pm_resume_devices(void)
@@ -150,7 +150,7 @@ void pm_resume_devices(void)
 		device_idx_t idx = pm_devices[pmi];
 
 		pm_device_state_set(&all_devices[idx],
-				       PM_DEVICE_ACTIVE_STATE,
+				       PM_DEVICE_STATE_ACTIVE,
 				       NULL, NULL);
 		++pmi;
 	}
@@ -209,15 +209,15 @@ void pm_create_device_list(void)
 const char *pm_device_state_str(uint32_t state)
 {
 	switch (state) {
-	case PM_DEVICE_ACTIVE_STATE:
+	case PM_DEVICE_STATE_ACTIVE:
 		return "active";
-	case PM_DEVICE_LOW_POWER_STATE:
+	case PM_DEVICE_STATE_LOW_POWER:
 		return "low power";
-	case PM_DEVICE_SUSPEND_STATE:
+	case PM_DEVICE_STATE_SUSPEND:
 		return "suspend";
-	case PM_DEVICE_FORCE_SUSPEND_STATE:
+	case PM_DEVICE_STATE_FORCE_SUSPEND:
 		return "force suspend";
-	case PM_DEVICE_OFF_STATE:
+	case PM_DEVICE_STATE_OFF:
 		return "off";
 	default:
 		return "";

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -112,8 +112,7 @@ static int pm_device_request(const struct device *dev,
 
 		/* Unfortunately this is not what is happening yet. There are
 		 * cases, for example, like the pinmux being initialized before
-		 * the gpio. For that reason let's power on/off the device
-		 * here until we don't have it properly fixed.
+		 * the gpio. Lets just power on/off the device.
 		 */
 		if (dev->pm->usage == 1) {
 			(void)pm_device_state_set(dev,

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -146,7 +146,7 @@ static int cmd_device_list(const struct shell *shell,
 			state = "DISABLED";
 		} else {
 #ifdef CONFIG_PM_DEVICE
-			uint32_t st = PM_DEVICE_ACTIVE_STATE;
+			uint32_t st = PM_DEVICE_STATE_ACTIVE;
 			int err = pm_device_state_get(dev, &st);
 
 			if (!err) {

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -316,8 +316,8 @@ void test_dummy_device_pm(void)
 
 	test_build_suspend_device_list();
 
-	/* Set device state to PM_DEVICE_ACTIVE_STATE */
-	ret = pm_device_state_set(dev, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+	/* Set device state to PM_DEVICE_STATE_ACTIVE */
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 	if (ret == -ENOSYS) {
 		TC_PRINT("Power management not supported on device");
 		ztest_test_skip();
@@ -330,19 +330,19 @@ void test_dummy_device_pm(void)
 	ret = pm_device_state_get(dev, &device_power_state);
 	zassert_true((ret == 0),
 			"Unable to get active state to device");
-	zassert_true((device_power_state == PM_DEVICE_ACTIVE_STATE),
+	zassert_true((device_power_state == PM_DEVICE_STATE_ACTIVE),
 			"Error power status");
 
-	/* Set device state to PM_DEVICE_FORCE_SUSPEND_STATE */
+	/* Set device state to PM_DEVICE_STATE_FORCE_SUSPEND */
 	ret = pm_device_state_set(dev,
-		PM_DEVICE_FORCE_SUSPEND_STATE, NULL, NULL);
+		PM_DEVICE_STATE_FORCE_SUSPEND, NULL, NULL);
 
 	zassert_true((ret == 0), "Unable to force suspend device");
 
 	ret = pm_device_state_get(dev, &device_power_state);
 	zassert_true((ret == 0),
 			"Unable to get suspend state to device");
-	zassert_true((device_power_state == PM_DEVICE_ACTIVE_STATE),
+	zassert_true((device_power_state == PM_DEVICE_STATE_ACTIVE),
 			"Error power status");
 }
 #else

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -28,12 +28,12 @@ static int fake_dev_pm_control(const struct device *dev, uint32_t command,
 	int ret = 0;
 
 	if (command == PM_DEVICE_STATE_SET) {
-		if (*state == PM_DEVICE_SUSPEND_STATE) {
+		if (*state == PM_DEVICE_STATE_SUSPEND) {
 			ret = net_if_suspend(ctx->iface);
 			if (ret == -EBUSY) {
 				goto out;
 			}
-		} else if (*state == PM_DEVICE_ACTIVE_STATE) {
+		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = net_if_resume(ctx->iface);
 		}
 	} else {
@@ -149,13 +149,13 @@ void test_pm(void)
 	 */
 	k_yield();
 
-	ret = pm_device_state_set(dev, PM_DEVICE_SUSPEND_STATE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND, NULL, NULL);
 	zassert_true(ret == 0, "Could not set state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
 
 	/* Let's try to suspend it again, it should fail relevantly */
-	ret = pm_device_state_set(dev, PM_DEVICE_SUSPEND_STATE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND, NULL, NULL);
 	zassert_true(ret == -EALREADY, "Could change state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
@@ -165,12 +165,12 @@ void test_pm(void)
 		     (struct sockaddr *)&addr4, sizeof(struct sockaddr_in));
 	zassert_true(ret < 0, "Could send data");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 	zassert_true(ret == 0, "Could not set state");
 
 	zassert_false(net_if_is_suspended(iface), "net iface is suspended");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_ACTIVE_STATE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 	zassert_true(ret == -EALREADY, "Could change state");
 
 	/* Let's send some data, it should go through */

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -28,13 +28,13 @@ static uint32_t dummy_get_power_state(const struct device *dev)
 
 static int dummy_suspend(const struct device *dev)
 {
-	device_power_state = PM_DEVICE_SUSPEND_STATE;
+	device_power_state = PM_DEVICE_STATE_SUSPEND;
 	return 0;
 }
 
 static int dummy_resume_from_suspend(const struct device *dev)
 {
-	device_power_state = PM_DEVICE_ACTIVE_STATE;
+	device_power_state = PM_DEVICE_STATE_ACTIVE;
 	return 0;
 }
 
@@ -46,7 +46,7 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*state == PM_DEVICE_ACTIVE_STATE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = dummy_resume_from_suspend(dev);
 		} else {
 			ret = dummy_suspend(dev);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -42,7 +42,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 	uint32_t device_power_state;
 	/* at this point, devices have been deactivated */
 	pm_device_state_get(dev, &device_power_state);
-	zassert_false(device_power_state == PM_DEVICE_ACTIVE_STATE, NULL);
+	zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
 
 	/* this function is called when system entering low power state, so
 	 * parameter state should not be PM_STATE_ACTIVE
@@ -95,7 +95,7 @@ static void notify_pm_state_entry(enum pm_state state)
 
 	/* at this point, devices should not be active */
 	pm_device_state_get(dev, &device_power_state);
-	zassert_false(device_power_state == PM_DEVICE_ACTIVE_STATE, NULL);
+	zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
 	set_pm = true;
 	notify_app_exit = true;
 }
@@ -113,7 +113,7 @@ static void notify_pm_state_exit(enum pm_state state)
 
 	/* at this point, devices are active again*/
 	pm_device_state_get(dev, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_ACTIVE_STATE, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE, NULL);
 	leave_idle = true;
 
 }
@@ -180,11 +180,11 @@ void test_power_state_notification(void)
 	uint32_t device_power_state;
 
 	pm_device_state_get(dev, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_ACTIVE_STATE, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE, NULL);
 
 	api->close(dev);
 	pm_device_state_get(dev, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_SUSPEND_STATE, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_SUSPEND, NULL);
 	/* reopen device as it will be closed in teardown */
 	api->open(dev);
 }


### PR DESCRIPTION
- Change device pm state names to be like system pm states
- Fix stm32 blinky sample (set device busy)
- Remove device pm idle states