### PR TITLE
drivers: flash: atmel SAM fix write-block-size

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -65,7 +65,7 @@ static const struct flash_parameters flash_sam0_parameters = {
 #if CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
 	.write_block_size = 1,
 #else
-	.write_block_size = FLASH_PAGE_SIZE,
+	.write_block_size = DT_PROP(DT_INST(0, soc_nv_flash), write_block_size),
 #endif
 	.erase_value = 0xff,
 };

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -49,6 +49,8 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				reg = <0x00080000 0x80000>;
+
+				write-block-size = <16>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -56,6 +56,8 @@
 			flash0: flash@400000 {
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
+
+				write-block-size = <16>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -63,6 +63,8 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
+
+				write-block-size = <16>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -57,6 +57,8 @@
 			flash0: flash@400000 {
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
+
+				write-block-size = <16>;
 			};
 		};
 

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -72,7 +72,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				reg = <0 0x40000>;
-				write-block-size = <64>;
+				write-block-size = <4>;
 			};
 		};
 

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -112,7 +112,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
-				write-block-size = <512>;
+				write-block-size = <8>;
 			};
 		};
 


### PR DESCRIPTION
`write-block-size` property in multiple Atmel SAM SoCs was either missing or
set incorrectly.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>