### PR TITLE
coding guidelines 11.9: fix literal zero as the null-ptr-constant

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -467,7 +467,7 @@ process_string:
 	}
 
 	/* Clear our buffer header. We made room for it initially. */
-	*(char **)buf0 = 0;
+	*(char **)buf0 = NULL;
 
 	/* Record end of argument list and number of appended strings. */
 	buf0[0] = (buf - buf0) / sizeof(int);


### PR DESCRIPTION
File has next violations:
MISRA 11_9_a
Use NULL instead of literal zero (0) as the null-pointer-constant
MISRA 11_9_b
Literal zero (0) shall not be used as the null-pointer-constant

Signed-off-by: Maksim Masalski maksim.masalski@intel.com