### PR TITLE
Bluetooth: Mesh: Check the CID field before opcode compare

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -204,6 +204,13 @@ config BT_MESH_MODEL_GROUP_COUNT
 	  This option specifies how many group addresses each model can
 	  at most be subscribed to.
 
+config BT_MESH_MODEL_VND_MSG_CID_FORCE
+	bool "Force vendor model to use the corresponding CID field message"
+	default y
+	help
+	  This option forces vendor model to use messages for the
+	  corresponding CID field.
+
 config BT_MESH_LABEL_COUNT
 	int "Maximum number of Label UUIDs used for Virtual Addresses"
 	default 1


### PR DESCRIPTION
Bluetooth Mesh Vendor model hava company id field.

Accordin MeshPRFV1.0.1 3.7.3.1 Operation codes.

The 3-octet opcodes are used for manufacturer-specific opcodes.
The company identifiers are 16-bit values defined by the
Bluetooth SIG and are coded into the second and third octets of
the 3-octet opcodes.

Therefore, we can speed up the search process by checking whether
CID fields match, rather than comparing opcodes one by one.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>