### PR TITLE
doc: release: 2.6: Add notes about support for ST Nucleo L412RB-P

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -198,6 +198,7 @@ Boards & SoC Support
 * Added support for these ARM boards:
 
    * MPS3-AN547
+   * ST Nucleo L412RB-P
 
 * Removed support for these ARM boards:
 


### PR DESCRIPTION
Board support for ST Nucleo L412RB-P was added recently
with PR #33976

Signed-off-by: Guðni Már Gilbert <gudni.m.g@gmail.com>