### PR TITLE
tests: common: fix newly added test_nop failing the CI

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -117,7 +117,11 @@ __no_optimization void test_nop(void)
 
 	arch_nop();
 
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+#if defined(CONFIG_RISCV)
+	/* do 2 nop instructions to cost cycles */
+	arch_nop();
+	arch_nop();
+#elif defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	/* do 4 nop instructions to cost cycles */
 	arch_nop();
 	arch_nop();

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -17,7 +17,6 @@ tests:
       - CONFIG_MISRA_SANE=y
   kernel.common.nano32:
     tags: kernel userspace
-    skip: true
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
The newly added testcase test_nop failed the CI. Give RISCV more
arch_nop() instructions to achieve one cycle.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>