### PR TITLE
tests: power_mgmt: exclude bl5340_dvk_cpunet

### DIFF
--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     # arch_irq_unlock(0) can't work correctly on these arch
     arch_exclude: arc xtensa
     platform_exclude: rv32m1_vega_ri5cy rv32m1_vega_zero_riscy litex_vexriscv
-       nrf5340dk_nrf5340_cpunet thingy53_nrf5340_cpunet
+       nrf5340dk_nrf5340_cpunet thingy53_nrf5340_cpunet bl5340_dvk_cpunet
     integration_platforms:
       - qemu_x86
       - mps2_an385


### PR DESCRIPTION
The nrf5340 cpunet based builds are excluded from this test and a new
platform bl5340_dvk_cpunet was added that needs to be excluded.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>