### PR TITLE
scripts: list_boards: handle boards dirs with subset of architectures

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -75,6 +75,9 @@ def find_arch2board_set_in(root, arches):
     boards = root / 'boards'
 
     for arch in arches:
+        if not (boards / arch).is_dir():
+            continue
+
         for maybe_board in (boards / arch).iterdir():
             if not maybe_board.is_dir():
                 continue


### PR DESCRIPTION
Out-of-tree boards directory is likely to have boards within subset of
architectures (e.g. only 'arm' boards) that are supported by Zephyr.
Currently script iterates over all architectures and tries to list
contents of `boards/<arch>/`, which might not be existing. This results in
'FileNotFoundError' exception:

```
  Traceback (most recent call last):
    File "/project/zephyr/scripts/list_boards.py", line 113, in <module>
      dump_boards(find_arch2boards(parse_args()))
    File "/project/zephyr/scripts/list_boards.py", line 32, in find_arch2boards
      arch2board_set = find_arch2board_set(args)
    File "/project/zephyr/scripts/list_boards.py", line 45, in find_arch2board_set
      for arch, boards in find_arch2board_set_in(root, arches).items():
    File "/project/zephyr/scripts/list_boards.py", line 78, in find_arch2board_set_in
      for maybe_board in (boards / arch).iterdir():
    File "/usr/lib/python3.9/pathlib.py", line 1149, in iterdir
      for name in self._accessor.listdir(self):
  FileNotFoundError: [Errno 2] No such file or directory: '/project/app/boards/arc'
```

Simply ignore missing `boards/<arch>/` directories and skip to the next
arch.