### PR TITLE
tests: condvar: fix one testcase failure on qemu_cortex_a53_smp

### DIFF
--- a/tests/kernel/condvar/condvar_api/src/main.c
+++ b/tests/kernel/condvar/condvar_api/src/main.c
@@ -153,7 +153,7 @@ void test_condvar_wait_forever_wake(void)
 
 	k_thread_create(&condvar_wake_tid, condvar_wake_stack, STACK_SIZE,
 			condvar_wake_task, &woken, NULL, NULL,
-			PRIO_WAKE, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
+			PRIO_WAKE, K_USER | K_INHERIT_PERMS, K_MSEC(1));
 
 	/* giving time for the condvar_wake_task
 	 * and condvar_wait_wake_task to execute


### PR DESCRIPTION
After enabled FPU context switch, one condvar testcase failed due to
the order of spawning thread cannot be guaranteed. Add a delay to
make sure the thread which initializing the condvar run first.

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>