### PR TITLE
Bluetooth: controller: Fix adv/scan context access post release

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -20,7 +20,7 @@ uint8_t ull_conn_default_phy_tx_get(void);
 uint8_t ull_conn_default_phy_rx_get(void);
 bool ull_conn_peer_connected(uint8_t own_addr_type, uint8_t *own_addr,
 			     uint8_t peer_addr_type, uint8_t *peer_addr);
-void ull_conn_setup(memq_link_t *link, struct node_rx_hdr *rx);
+void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx);
 int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx);
 int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire, uint16_t lazy);
 void ull_conn_done(struct node_rx_event_done *done);

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -665,8 +665,8 @@ void ull_master_cleanup(struct node_rx_hdr *rx_free)
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_PHY_CODED */
 }
 
-void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
-		      struct node_rx_ftr *ftr, struct lll_conn *lll)
+void ull_master_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+		      struct lll_conn *lll)
 {
 	uint32_t conn_offset_us, conn_interval_us;
 	uint8_t ticker_id_scan, ticker_id_conn;
@@ -679,6 +679,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	uint32_t ticker_status;
 	struct node_rx_cc *cc;
 	struct ll_conn *conn;
+	memq_link_t *link;
 	uint8_t chan_sel;
 
 	/* Get reference to Tx-ed CONNECT_IND PDU */
@@ -740,6 +741,11 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	lll->tx_pwr_lvl = RADIO_TXP_DEFAULT;
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
+
+	/* Use the link stored in the node rx to enqueue connection
+	 * complete node rx towards LL context.
+	 */
+	link = rx->link;
 
 	/* Use Channel Selection Algorithm #2 if peer too supports it */
 	if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_master_internal.h
@@ -5,7 +5,7 @@
  */
 
 void ull_master_cleanup(struct node_rx_hdr *rx_free);
-void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
-		      struct node_rx_ftr *ftr, struct lll_conn *lll);
-void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
-			  uint8_t force, void *param);
+void ull_master_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+		      struct lll_conn *lll);
+void ull_master_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
+			  uint16_t lazy, uint8_t force, void *param);

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -54,8 +54,8 @@ static void ticker_op_cb(uint32_t status, void *param);
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 					       void *param);
 
-void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
-		     struct node_rx_ftr *ftr, struct lll_conn *lll)
+void ull_slave_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+		     struct lll_conn *lll)
 {
 	uint32_t conn_offset_us, conn_interval_us;
 	uint8_t ticker_id_adv, ticker_id_conn;
@@ -72,6 +72,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	struct node_rx_cc *cc;
 	struct ll_conn *conn;
 	uint16_t win_offset;
+	memq_link_t *link;
 	uint16_t timeout;
 	uint8_t chan_sel;
 
@@ -98,6 +99,11 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 		memcpy(peer_id_addr, peer_addr, BDADDR_SIZE);
 	}
+
+	/* Use the link stored in the node rx to enqueue connection
+	 * complete node rx towards LL context.
+	 */
+	link = rx->link;
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
 	uint8_t own_addr_type = pdu_adv->rx_addr;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
-		     struct node_rx_ftr *ftr, struct lll_conn *lll);
+void ull_slave_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+		     struct lll_conn *lll);
 void ull_slave_latency_cancel(struct ll_conn *conn, uint16_t handle);
 void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 			 uint16_t lazy, uint8_t force, void *param);


### PR DESCRIPTION
Fix advertiser and scanning context being accessed on done
event when connection complete node rx that is processed
earlier has release them.

Relates to #30735.
Fixes #35013.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>