### PR TITLE
stm32f4 add GPIO F/G to device tree

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -149,6 +149,24 @@
 				label = "GPIOE";
 			};
 
+			gpiof: gpio@40021400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40021400 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000020>;
+				label = "GPIOF";
+			};
+
+			gpiog: gpio@40021800 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40021800 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000040>;
+				label = "GPIOG";
+			};
+
 			gpioh: gpio@40021c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;


### PR DESCRIPTION
According to RM0390 Rev 6 p. 58 all stm32f446xx have GPIO F/G. Add them to device tree.