### PR TITLE
net: openthread: kconfig fixes

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -185,3 +185,9 @@ config OPENTHREAD_FULL_LOGS
 
 config OPENTHREAD_MLE_LINK_METRICS_ENABLE
 	bool "Enable Link Metrics support"
+
+config OPENTHREAD_SRP_CLIENT
+	bool "Enable SRP Client support"
+
+config OPENTHREAD_SRP_SERVER
+	bool "Enable SRP Server support"

--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -188,6 +188,8 @@ config OPENTHREAD_MLE_LINK_METRICS_ENABLE
 
 config OPENTHREAD_SRP_CLIENT
 	bool "Enable SRP Client support"
+	select OPENTHREAD_ECDSA
 
 config OPENTHREAD_SRP_SERVER
 	bool "Enable SRP Server support"
+	select OPENTHREAD_ECDSA

--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -89,9 +89,3 @@ config OPENTHREAD_CSL_SAMPLE_WINDOW
 config OPENTHREAD_CSL_RECEIVE_TIME_AHEAD
 	int "CSL receiver wake up margin in units of 10 symbols"
 	default 3
-
-config OPENTHREAD_SRP_CLIENT
-	bool "Enable SRP Client support"
-
-config OPENTHREAD_SRP_SERVER
-	bool "Enable SRP Server support"

--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -63,11 +63,13 @@ config OPENTHREAD_MAX_CHILDREN
 	int "The maximum number of children"
 	range 10 511
 	default 32
+	depends on OPENTHREAD_FTD
 
 config OPENTHREAD_MAX_IP_ADDR_PER_CHILD
 	int "The maximum number of IPv6 address registrations per child"
 	range 4 255
 	default 6
+	depends on OPENTHREAD_FTD
 
 config OPENTHREAD_CONFIG_PLATFORM_INFO
 	string "The platform-specific string to insert into the OpenThread version string"


### PR DESCRIPTION
A few OpenThread kconfig fixes to improve the user experience, notably fixing a build failure when some options are not enabled together.