### PR TITLE
ci: Reduce number of workers back to 20

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
       ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
-    parallelism: 40
+    parallelism: 20
     timeout_in_minutes: 180
     retry:
       manual: true


### PR DESCRIPTION
Now that we've past 2.6.0-rc1 reduce number of works back to 20.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>