### PR TITLE
pm: npcx: consider host wake-up features only if espi is selected.

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx7/power.c
+++ b/soc/arm/nuvoton_npcx/npcx7/power.c
@@ -124,8 +124,10 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 		npcx_lvol_suspend_io_pads();
 	}
 
-	/* Turn on host access wake-up interrupt. */
-	npcx_host_enable_access_interrupt();
+	/* Turn on eSPI/LPC host access wake-up interrupt. */
+	if (IS_ENABLED(CONFIG_ESPI_NPCX)) {
+		npcx_host_enable_access_interrupt();
+	}
 
 	/*
 	 * Capture the reading of low-freq timer for compensation before ec
@@ -142,8 +144,10 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 	 */
 	npcx_clock_compensate_system_timer();
 
-	/* Turn off host access wake-up interrupt. */
-	npcx_host_disable_access_interrupt();
+	/* Turn off eSPI/LPC host access wake-up interrupt. */
+	if (IS_ENABLED(CONFIG_ESPI_NPCX)) {
+		npcx_host_disable_access_interrupt();
+	}
 
 	/* A bypass in npcx7 series to prevent leakage in low-voltage pads */
 	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {


### PR DESCRIPTION
This CL limits the compiler to consider the eSPI/LPC host wake-up
functions, such as npcx_host_disable_access_interrupt and
npcx_host_disable_access_interrupt, only if eSPI bus module is selected.
Otherwise, we will encounter compiler errors if the communication
between host and ec is via SPI, not eSPI/LPC bus.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>