### PR TITLE
kconfig: TraceRecorder Kconfig file for undefined symbols

### DIFF
--- a/modules/TraceRecorder/Kconfig
+++ b/modules/TraceRecorder/Kconfig
@@ -1,0 +1,10 @@
+# Zephyr module config for TraceRecorder.
+# The real Kconfig for the module is located in the module repository,
+# this file is to ensure ZEPHYR_TRACERECORDER_MODULE is defined also when the
+# module is unavailable.
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_TRACERECORDER_MODULE
+	bool


### PR DESCRIPTION
Follow-up: #34843

This commit is a followup to PR #34843.
The Zephyr subsys/tracing/Kconfig file has a
`depends on ZEPHYR_TRACERECORDER_MODULE` but that symbol is only
available when the module is part of the manifest.

This commit adds the second part of the comment:
https://github.com/zephyrproject-rtos/zephyr/pull/34843#discussion_r628154265

To ensure all Kconfig symbols are defined.

Without this commit, users without TraceRecorder will see following
checkpatch error:
```
ERROR   : Test KconfigBasic failed: Undefined Kconfig symbols:

warning: undefined symbol ZEPHYR_TRACERECORDER_MODULE:

- Referenced at subsys/tracing/Kconfig:35:

config PERCEPIO_TRACERECORDER
        bool "Percepio Tracealyzer support"
        select THREAD_NAME
        select INIT_STACKS
        select THREAD_MONITOR
        depends on ZEPHYR_TRACERECORDER_MODULE && <choice>
```

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>