### PR TITLE
samples/boards: stm32 pm blinky: Run with twister device testing

### DIFF
--- a/samples/boards/stm32/power_mgmt/blinky/prj.conf
+++ b/samples/boards/stm32/power_mgmt/blinky/prj.conf
@@ -4,12 +4,7 @@ CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y
 
-# Disable debug to enter core low power states
+# DEBUG is enabled in order to ease testing in CI
+# Disable DEBUG in order to enter core low power states.
 # Warning: requires to erase the device for next flashing actions
 CONFIG_DEBUG=y
-
-
-# FIXME: Early console not supported due to uart init postponed
-CONFIG_BOOT_BANNER=n
-# Disable serial to ease debug
-CONFIG_SERIAL=n

--- a/samples/boards/stm32/power_mgmt/blinky/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/blinky/sample.yaml
@@ -3,7 +3,11 @@ sample:
 tests:
   sample.boards.stm32.power_mgmt.blinky:
     tags: LED power
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Device ready"
     filter: dt_compat_enabled("zephyr,power-state") and
             dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_compat_enabled("st,stm32-lptim")
-    depends_on: gpio

--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -8,7 +8,7 @@
 #include <device.h>
 #include <devicetree.h>
 #include <drivers/gpio.h>
-
+#include <sys/printk.h>
 
 #define SLEEP_TIME_MS   2000
 
@@ -20,6 +20,8 @@ void main(void)
 	bool led_is_on = true;
 
 	__ASSERT_NO_MSG(device_is_ready(led.port));
+
+	printk("Device ready\n");
 
 	/* Don't let the system power off / low power this device */
 	device_busy_set(led.port);


### PR DESCRIPTION
Add minimum harness and to get the sample passed when run using
twister.
Adding console validates uart init with DEVICE_RUTIME=y.

Additionally, clarify comment about DEBUG activation.

Fixes #35033

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>