### PR TITLE
[RFC] pinctrl: stm32: uart low power pinmux (DNM)

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -31,8 +31,18 @@
 	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
+&pinctrl {
+	usart1_lp_tx_pa9: usart1_lp_tx_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+	};
+	usart1_lp_rx_pa10: usart1_lp_rx_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+	};
+};
+
 &usart1 {
 	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-1 = <&usart1_lp_tx_pa9 &usart1_lp_rx_pa10>;
 };
 
 &lptim1 {

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -25,6 +25,8 @@ struct uart_stm32_config {
 	int  parity;
 	const struct soc_gpio_pinctrl *pinctrl_list;
 	size_t pinctrl_list_size;
+	const struct soc_gpio_pinctrl *lp_pinctrl_list;
+	size_t lp_pinctrl_list_size;
 };
 
 #ifdef CONFIG_UART_ASYNC_API


### PR DESCRIPTION
These commits shows how one would add a low power alternate pin configuration to a driver.

Alternate low power pinmux is put directly manualy in board files, but alternatively it could aslo be generated and stored in *-pinctrl.dtsi under hal_stm32.


Note: This change is only meant for support on pinctrl API discussion. It is not done to be merged
