### PR TITLE
net: openthread: Fix OT shell crash

### DIFF
--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -22,12 +22,15 @@ static char rx_buffer[OT_SHELL_BUFFER_SIZE];
 
 static const struct shell *shell_p;
 
-int otConsoleOutputCallback(void *aContext, const char *aFormat,
-			    va_list aArguments)
+static int ot_console_cb(void *context, const char *format, va_list arg)
 {
-	ARG_UNUSED(aContext);
+	ARG_UNUSED(context);
 
-	shell_vfprintf(shell_p, SHELL_NORMAL, aFormat, aArguments);
+	if (shell_p == NULL) {
+		return 0;
+	}
+
+	shell_vfprintf(shell_p, SHELL_NORMAL, format, arg);
 
 	return 0;
 }
@@ -77,5 +80,11 @@ SHELL_CMD_ARG_REGISTER(ot, NULL, SHELL_HELP_OT, ot_cmd, 2, 255);
 
 void platformShellInit(otInstance *aInstance)
 {
-	otCliInit(aInstance, otConsoleOutputCallback, NULL);
+	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL)) {
+		shell_p = shell_backend_uart_get_ptr();
+	} else {
+		shell_p = NULL;
+	}
+
+	otCliInit(aInstance, ot_console_cb, NULL);
 }


### PR DESCRIPTION
After the recent OpenThread upmerge, OpenThread changed its behaviour in
terms of CLI handling during commissioning procedure. OpenThread will
now call the registered CLI callback when it recieves the Discovery
message.

This resulted in a crash if no CLI command was executed by the user
before, because the `shell_p` pointer was only set in the command
handler. As it was not set to the actual shell backend instance, it
caused a crash (or assert if enabled) in the `shell_vfprintf()`
function.

Fix this by verifying the `shell_p` pointer in the
`otConsoleOutputCallback()` function before use. Additionally, set the
pointer to the most common UART shell backed (if enabled) in the
initialization function so that the initial messages from OpenThread are
not dropped.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>