### PR TITLE
net: shell: Fix crash when invoking dns command in shell

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2159,7 +2159,7 @@ static void print_dns_info(const struct shell *shell,
 	for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
 		int32_t remaining;
 
-		if (!ctx->queries[i].cb) {
+		if (!ctx->queries[i].cb || !ctx->queries[i].query) {
 			continue;
 		}
 


### PR DESCRIPTION
This fixes a crash when typing "net dns" command in net-shell

Fixes #35041

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>