### PR TITLE
Fix shub for multi-instance case for LSM6DSO and IIS2ICLX sensor drivers

### DIFF
--- a/drivers/sensor/iis2iclx/iis2iclx.h
+++ b/drivers/sensor/iis2iclx/iis2iclx.h
@@ -75,6 +75,8 @@ struct iis2iclx_data {
 	} hts221;
 
 	bool shub_inited;
+	uint8_t num_ext_dev;
+	uint8_t shub_ext[IIS2ICLX_SHUB_MAX_NUM_SLVS];
 #endif /* CONFIG_IIS2ICLX_SENSORHUB */
 
 	uint16_t accel_freq;
@@ -98,7 +100,7 @@ struct iis2iclx_data {
 #if defined(CONFIG_IIS2ICLX_SENSORHUB)
 int iis2iclx_shub_init(const struct device *dev);
 int iis2iclx_shub_fetch_external_devs(const struct device *dev);
-int iis2iclx_shub_get_idx(enum sensor_channel type);
+int iis2iclx_shub_get_idx(const struct device *dev, enum sensor_channel type);
 int iis2iclx_shub_config(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr,
 			   const struct sensor_value *val);

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -145,6 +145,9 @@ struct lsm6dso_data {
 		int16_t y0;
 		int16_t y1;
 	} hts221;
+	bool shub_inited;
+	uint8_t num_ext_dev;
+	uint8_t shub_ext[LSM6DSO_SHUB_MAX_NUM_SLVS];
 #endif /* CONFIG_LSM6DSO_SENSORHUB */
 
 	uint16_t accel_freq;
@@ -171,7 +174,7 @@ struct lsm6dso_data {
 #if defined(CONFIG_LSM6DSO_SENSORHUB)
 int lsm6dso_shub_init(const struct device *dev);
 int lsm6dso_shub_fetch_external_devs(const struct device *dev);
-int lsm6dso_shub_get_idx(enum sensor_channel type);
+int lsm6dso_shub_get_idx(const struct device *dev, enum sensor_channel type);
 int lsm6dso_shub_config(const struct device *dev, enum sensor_channel chan,
 			enum sensor_attribute attr,
 			const struct sensor_value *val);


### PR DESCRIPTION
In case of multi-instance the driver should take care of
some considerations. Let's suppose we have two instances; it may
happen that one should act as a sensorhub and handle the devices
attached to its SDx/SCx bus, while the other is a standalone IMU.
In this case using the macro CONFIG_LSM6DSO_SENSORHUB is not enough,
since it is configured to 'y' for both. So, the solution adopted
now is to always try to discover possible devices attached to the
shub bus. If at least one has been enumerated correctly the
'shub_inited' variable in the data structure for that particular
LSM6DSO instance is set to 'true', 'false' otherwise.

Moreover, the info found during the enumeration process for a
particular instance (number and types of attached devices) must be
saved again inside the per-instance data structure, so that more
than one LSM6DSO device can be used as a sensorhub without interfering
with the others.

TEST:
Used x_nucleo_iks01a3 with  two LSM6DSO instances configured as sensorhub:
  - 1x instance on I2C on shield itself (2 slaves: LIS2MDL and LPS22HH on shield)
  - 1x instance on DIL24 SPI using STEVAL-MKI217V1 adapter (LSMDSO + 1 slave LIS2MDL)

EDIT:
Aligned also IIS2ICLX device (changing the Title)