### PR TITLE
net: if: Do not check IPv4 multicast addr when selecting src addr

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3186,7 +3186,7 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	if (!net_ipv4_is_ll_addr(dst) && !net_ipv4_is_addr_mcast(dst)) {
+	if (!net_ipv4_is_ll_addr(dst)) {
 
 		/* If caller has supplied interface, then use that */
 		if (dst_iface) {


### PR DESCRIPTION
When destination address is a multicast address, select the source
address from non link local address first.

This means that for example if we are responding to mDNS query,
and we have both normal IPv4 and LL (169.254.x.y) address set for
the interface, we are now able to select the normal address instead
of the LL one.

Fixes #34409

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>