### PR TITLE
bttester: add key-size and authorization based l2cap conn reject

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -26,6 +26,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 NET_BUF_POOL_FIXED_DEFINE(data_pool, CHANNELS, DATA_BUF_SIZE, NULL);
 
+static bool authorize_flag;
+static uint8_t req_keysize;
+
 static struct channel {
 	uint8_t chan_id; /* Internal number that identifies L2CAP channel. */
 	struct bt_l2cap_le_chan le;
@@ -308,6 +311,19 @@ static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
 		return -ENOMEM;
 	}
 
+	if (bt_conn_enc_key_size(conn) < req_keysize) {
+		/* TSPX_psm_encryption_key_size_required */
+		req_keysize = 0;
+		return -EPERM;
+	} else if (authorize_flag) {
+		/* TSPX_psm_authorization_required
+		 * we never authorize this connection, so return error
+		 * everytime this psm is used
+		 */
+		authorize_flag = false;
+		return -EACCES;
+	}
+
 	chan->le.chan.ops = &l2cap_ops;
 	chan->le.rx.mtu = DATA_MTU;
 
@@ -337,7 +353,10 @@ static void listen(uint8_t *data, uint16_t len)
 
 	if (server->psm == 0x00F4) {
 		/* TSPX_psm_encryption_key_size_required */
-		server->sec_level = BT_SECURITY_L4;
+		req_keysize = 16;
+	} else if (server->psm == 0x00F3) {
+		/* TSPX_psm_authentication_required */
+		authorize_flag = true;
 	} else if (server->psm == 0x00F2) {
 		/* TSPX_psm_authentication_required */
 		server->sec_level = BT_SECURITY_L3;


### PR DESCRIPTION
In tests that expect returning error in response for l2cap
connection request we use predefined PSMs. This commit adds
check for required keysize (which will always return error,
as connection is not secure and key size will always be 0)
instead of setting security level 4 (which would return
insufficient authentication, not insufficient key size).
It also adds suport for PSM used in insufficient authorization
tests - choosing this PSM will set flag that triggers error
on channel accept.

This affects tests L2CAP/LE/CFC/BV-[10-15]-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>