### PR TITLE
drivers: serial: nrf_uarte: Fix issues in uart

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -241,7 +241,7 @@ static void uarte_nrfx_isr_int(void *arg)
 #ifdef UARTE_INTERRUPT_DRIVEN
 		struct uarte_nrfx_data *data = get_dev_data(dev);
 
-		if (!data->int_driven)
+		if (!data->int_driven || data->int_driven->fifo_fill_lock == 0)
 #endif
 		{
 			nrf_uarte_int_disable(uarte,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -514,16 +514,19 @@ static void uarte_enable(const struct device *dev, uint32_t mask)
 {
 #ifdef CONFIG_UART_ASYNC_API
 	struct uarte_nrfx_data *data = get_dev_data(dev);
-	bool disabled = data->async->low_power_mask == 0;
 
-	data->async->low_power_mask |= mask;
-	if (hw_rx_counting_enabled(data) && disabled) {
-		const nrfx_timer_t *timer = &get_dev_config(dev)->timer;
+	if (data->async) {
+		bool disabled = data->async->low_power_mask == 0;
 
-		nrfx_timer_enable(timer);
+		data->async->low_power_mask |= mask;
+		if (hw_rx_counting_enabled(data) && disabled) {
+			const nrfx_timer_t *timer = &get_dev_config(dev)->timer;
 
-		for (int i = 0; i < data->async->rx_flush_cnt; i++) {
-			nrfx_timer_increment(timer);
+			nrfx_timer_enable(timer);
+
+			for (int i = 0; i < data->async->rx_flush_cnt; i++) {
+				nrfx_timer_increment(timer);
+			}
 		}
 	}
 #endif

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -34,14 +34,14 @@ LOG_MODULE_REGISTER(uart_nrfx_uarte, LOG_LEVEL_ERR);
 #endif
 
 
-#if (defined(CONFIG_UART_0_NRF_UARTE) &&         \
-     defined(CONFIG_UART_0_INTERRUPT_DRIVEN)) || \
-    (defined(CONFIG_UART_1_NRF_UARTE) &&         \
-     defined(CONFIG_UART_1_INTERRUPT_DRIVEN)) || \
-    (defined(CONFIG_UART_2_NRF_UARTE) &&         \
-     defined(CONFIG_UART_2_INTERRUPT_DRIVEN)) || \
-    (defined(CONFIG_UART_3_NRF_UARTE) &&         \
-     defined(CONFIG_UART_3_INTERRUPT_DRIVEN))
+#if	(defined(CONFIG_UART_0_NRF_UARTE) &&         \
+	 defined(CONFIG_UART_0_INTERRUPT_DRIVEN)) || \
+	(defined(CONFIG_UART_1_NRF_UARTE) &&         \
+	 defined(CONFIG_UART_1_INTERRUPT_DRIVEN)) || \
+	(defined(CONFIG_UART_2_NRF_UARTE) &&         \
+	 defined(CONFIG_UART_2_INTERRUPT_DRIVEN)) || \
+	(defined(CONFIG_UART_3_NRF_UARTE) &&         \
+	 defined(CONFIG_UART_3_INTERRUPT_DRIVEN))
 	#define UARTE_INTERRUPT_DRIVEN	1
 #endif
 
@@ -681,10 +681,9 @@ static int uarte_nrfx_tx(const struct device *dev, const uint8_t *buf,
 	if (data->async->tx_size) {
 		irq_unlock(key);
 		return -EBUSY;
-	} else {
-		data->async->tx_size = len;
 	}
 
+	data->async->tx_size = len;
 	nrf_uarte_int_enable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
 
 	if (!is_tx_ready(dev)) {
@@ -838,7 +837,7 @@ static int uarte_nrfx_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	int key = irq_lock();
 
-	if ((data->async->rx_buf == NULL)) {
+	if (data->async->rx_buf == NULL) {
 		err = -EACCES;
 	} else if (data->async->rx_next_buf == NULL) {
 		data->async->rx_next_buf = buf;
@@ -1857,7 +1856,7 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 			while (!nrf_uarte_event_check(uarte,
 						      NRF_UARTE_EVENT_RXTO) &&
 			       !nrf_uarte_event_check(uarte,
-			                              NRF_UARTE_EVENT_ERROR)) {
+						      NRF_UARTE_EVENT_ERROR)) {
 				/* Busy wait for event to register */
 			}
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);


### PR DESCRIPTION
There were 2 issues in the driver:
- `uarte_enable` was not checking if instance was using async api.
- when interrupt api was enabled but `uart_fifo_fill` was not used instance ended up continuously triggering interrupt

Additionally, cleaned file from checkpatch issues.