### PR TITLE
testsuite: ztest: Add missing syscalls/log_msg2.h stub

### DIFF
--- a/subsys/testsuite/ztest/include/syscalls/log_msg2.h
+++ b/subsys/testsuite/ztest/include/syscalls/log_msg2.h
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
This stub is needed when unit testing code that includes log_msg.h or
log_msg2.h.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>