### PR TITLE
Kconfig: Increase default thread analyzer stack size

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -76,7 +76,7 @@ config THREAD_ANALYZER_AUTO_INTERVAL
 
 config THREAD_ANALYZER_AUTO_STACK_SIZE
 	int "Stack size for the periodic thread analysis thread"
-	default 512
+	default 1024
 
 endif # THREAD_ANALYZER_AUTO
 


### PR DESCRIPTION
Increase the default thread analyzer stack size. On ARM systems the
stack usage is higher with CONFIG_FPU enabled.
The default of 512 is not enough in this case and lead to stack
overflow.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>