### PR TITLE
tests/kernel/common: Fix test test_nop for ARMV7_M_ARMV8_M_MAINLINE

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -118,16 +118,18 @@ __no_optimization void test_nop(void)
 	arch_nop();
 
 #if defined(CONFIG_RISCV)
-	/* do 2 nop instructions to cost cycles */
+	/* do 2 nop instructions more to cost cycles */
 	arch_nop();
 	arch_nop();
-#elif defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	/* do 4 nop instructions to cost cycles */
+#elif defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
+	defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	/* do 4 nop instructions more to cost cycles */
+	arch_nop();
 	arch_nop();
 	arch_nop();
 	arch_nop();
 #elif defined(CONFIG_ARC)
-	/* do 8 nop instructions to cost cycles */
+	/* do 7 nop instructions more to cost cycles */
 	arch_nop();
 	arch_nop();
 	arch_nop();
@@ -136,7 +138,7 @@ __no_optimization void test_nop(void)
 	arch_nop();
 	arch_nop();
 #elif defined(CONFIG_SPARC)
-	/* do 9 nop instructions to cost cycles */
+	/* do 9 nop instructions more to cost cycles */
 	arch_nop();
 	arch_nop();
 	arch_nop();


### PR DESCRIPTION
Treat ARMV7_M_ARMV8_M_MAINLINE similarly to ARMV6_M_ARMV8_M_BASELINE
and add arch_nop() calls to test_nop function.
Additionally do 4 arch_nop calls in conformance to comment.

Fixes #35060

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>