### PR TITLE
twister: Add ICCM/DCCM to list of overflow regions

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1995,7 +1995,7 @@ class CMake():
                     log.write(log_msg)
 
             if log_msg:
-                res = re.findall("region `(FLASH|RAM|SRAM)' overflowed by", log_msg)
+                res = re.findall("region `(FLASH|RAM|ICCM|DCCM|SRAM)' overflowed by", log_msg)
                 if res and not self.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(res[0]))
                     self.instance.status = "skipped"


### PR DESCRIPTION
On ARC some platforms utilize ICCM/DCCM for their "flash" and "ram"
storage.  So we might get errors about overflowing one of these regions.
So treat them similar to how we treat FLASH and SRAM.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>