### PR TITLE
drivers: serial: uart_miv: Fix build errors

### DIFF
--- a/drivers/serial/Kconfig.miv
+++ b/drivers/serial/Kconfig.miv
@@ -7,5 +7,6 @@ config UART_MIV
 	bool "Mi-V serial driver"
 	depends on SOC_RISCV32_MIV
 	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables the Mi-V serial driver.

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -295,9 +295,8 @@ static int uart_miv_irq_update(const struct device *dev)
 	return 1;
 }
 
-static void uart_miv_irq_handler(void *arg)
+static void uart_miv_irq_handler(const struct device *dev)
 {
-	const struct device *dev = (const struct device *)arg;
 	struct uart_miv_data *data = DEV_DATA(dev);
 
 	if (data->callback) {
@@ -329,7 +328,7 @@ void uart_miv_rx_thread(void *arg1, void *arg2, void *arg3)
 		if (uart->status & STATUS_RXFULL_MASK) {
 			uart_miv_irq_handler(dev);
 		}
-		k_sleep(delay);
+		k_sleep(K_USEC(delay));
 	}
 }
 


### PR DESCRIPTION
If we try and build the MiV uart driver with interrupt support enabled
we get some errors related to code that hasn't been updated.  Fix the
compile errors and add SERIAL_SUPPORT_INTERRUPT to the Kconfig to
hopefully catch these issues in the future

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>