### PR TITLE
drivers: gpio: Fix when psoc6 gpio driver is built

### DIFF
--- a/drivers/gpio/Kconfig.psoc6
+++ b/drivers/gpio/Kconfig.psoc6
@@ -1,9 +1,12 @@
 # Copyright (c) 2020 ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_CYPRESS_PSOC6_GPIO := cypress,psoc6-gpio
+
 config GPIO_PSOC6
 	bool "Cypress PSoC-6 GPIO driver"
-	default y
+	default y if $(dt_compat_enabled,$(DT_COMPAT_CYPRESS_PSOC6_GPIO))
 	depends on SOC_FAMILY_PSOC6
 	help
 	  Enable support for the Cypress PSoC-6 GPIO controllers.


### PR DESCRIPTION
Add check to see that the GPIO devicetree node is actually enabled
before we build the PSoC6 GPIO driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>