### PR TITLE
shell: Don't attempt to access a NULL message queue

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -49,6 +49,10 @@ static struct log_msg *msg_from_fifo(const struct shell_log_backend *backend)
 	struct shell_log_backend_msg msg;
 	int err;
 
+	if (!backend->msgq) {
+		return NULL;
+	}
+
 	err = k_msgq_get(backend->msgq, &msg, K_NO_WAIT);
 
 	return (err == 0) ? msg.msg : NULL;


### PR DESCRIPTION
This resolves bug #34403

Signed-off-by: Timothy Pearson <tpearson@raptorengineering.com>