### PR TITLE
tests: flash: Enable flash driver and file system tests on mimxrt1060_evk

### DIFF
--- a/samples/subsys/fs/littlefs/boards/mimxrt1060_evk.conf
+++ b/samples/subsys/fs/littlefs/boards/mimxrt1060_evk.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 NXP.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Need this when storage is on flash
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/samples/subsys/shell/fs/boards/mimxrt1060_evk.conf
+++ b/samples/subsys/shell/fs/boards/mimxrt1060_evk.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2021 NXP.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -5,4 +5,4 @@ tests:
   sample.filesystem.shell:
     tags: shell filesystem
     harness: keyboard
-    platform_allow: reel_board
+    platform_allow: reel_board mimxrt1060_evk

--- a/tests/drivers/flash/boards/mimxrt1060_evk.conf
+++ b/tests/drivers/flash/boards/mimxrt1060_evk.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2021 NXP.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM_SRAM=y

--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -14,6 +14,12 @@
 #define FLASH_DEVICE DT_LABEL(DT_INST(0, nordic_qspi_nor))
 #define FLASH_TEST_REGION_OFFSET 0xff000
 #define TEST_AREA_MAX DT_PROP(DT_INST(0, nordic_qspi_nor), size)
+
+#elif defined(CONFIG_FLASH_MCUX_FLEXSPI_NOR)
+
+#define FLASH_DEVICE DT_LABEL(DT_INST(0, nxp_imx_flexspi_nor))
+#define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(storage)
+#define TEST_AREA_MAX ((FLASH_AREA_SIZE(storage)) + (FLASH_TEST_REGION_OFFSET))
 #else
 
 /* SoC emebded NVM */

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -11,3 +11,6 @@ tests:
     platform_allow: nrf52840dk_nrf52840
     tags: nrf52 soc_flash_nrf
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
+  drivers.flash.default:
+    platform_allow: mimxrt1060_evk
+    tags: mcux

--- a/tests/subsys/fs/littlefs/boards/mimxrt1060_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1060_evk.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&is25wp064 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+		partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_M(3)>;
+		};
+		partition@310000 {
+			label = "large";
+			reg = <0x00310000 DT_SIZE_M(3)>;
+		};
+		partition@610000 {
+			label = "image-scratch";
+			reg = <0x00610000 DT_SIZE_K(128)>;
+		};
+		partition@630000 {
+			label = "small";
+			reg = <0x00630000 DT_SIZE_K(64)>;
+		};
+		partition@640000 {
+			label = "medium";
+			reg = <0x00640000 DT_SIZE_K(960)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -1,6 +1,6 @@
 common:
     tags: filesystem
-    platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64
+    platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64 mimxrt1060_evk
 
 tests:
   filesystem.littlefs.default:


### PR DESCRIPTION
now the XIP feature can work in NXP RT series boards
so enable below cases on mimxrt1060_evk with XIP
tests/kernel/xip
tests/drivers/flash
tests/subsys/fs/littlefs
samples/shell/fs
samples/subsys/fs/littlefs

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>