### PR TITLE
adc_emul: case can only run on native_posix board

### DIFF
--- a/tests/drivers/adc/adc_emul/testcase.yaml
+++ b/tests/drivers/adc/adc_emul/testcase.yaml
@@ -3,3 +3,4 @@ common:
 tests:
   drivers.adc.emul:
     depends_on: adc
+    platform_allow: native_posix


### PR DESCRIPTION
we meet hardfault when run on real board.
as the device is a virtual device, this 

I: adc init done

*** Booting Zephyr OS build zephyr-v2.5.0-3761-g730acbd6ed85  ***

Running test suite adc_basic_test

===================================================================

START - test_adc_emul_single_value

E: ***** BUS FAULT *****

E:   Precise data bus error

E:   BFAR Address: 0x20002d00

E:   NXP MPU error, port 3

E:     Mode: User, Data Address: 0x20002d00

E:     Type: Read, Master: 0, Regions: 0x8100

E: r0/a1:  0x20002cfc  r1/a2:  0x00000000  r2/a3:  0x000005dc

E: r3/a4:  0x00000040 r12/ip:  0x0000c67d r14/lr:  0x00001319

E:  xpsr:  0x41000000

E: Faulting instruction address (r15/pc): 0x000045c6

E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0

E: Current thread: 0x200000e0 (unknown)

E: Halting system

Fixes #35027

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>