### PR TITLE
drivers: ethernet: enc424j600: Fix interrupt handling

### DIFF
--- a/drivers/ethernet/Kconfig.enc424j600
+++ b/drivers/ethernet/Kconfig.enc424j600
@@ -1,6 +1,7 @@
 # ENC424J600 Ethernet driver configuration options
 
 # Copyright (c) 2019 PHYTEC Messtechnik GmbH
+# Copyright (c) 2021 Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_ENC424J600
@@ -33,5 +34,12 @@ config ETH_ENC424J600_TIMEOUT
 	  Given timeout in milliseconds. Maximum amount of time
 	  that the driver will wait from the IP stack to get
 	  a memory buffer before the Ethernet frame is dropped.
+
+config ETH_ENC424J600_DEBUG_UNKNOWN_INTERRUPT
+	bool "Debug unknown interrupts"
+	help
+	  Will stop the driver from responding to interrupts when an
+	  unknown interrupt has been detected. Useful for debugging the
+	  ethernet driver.
 
 endif


### PR DESCRIPTION
This fixes an issue with interrupts being triggered before the
enc424j600 driver is ready to receive them or has configured the
interrupt sources which would prevent the driver from loading. An
optional Kconfig option has been added to allow not re-enabling
interrupts after an unknown interrupt has occured, this brings the
driver in-line with all other Zephyr ethernet drivers and the Linux
kernel encx24j600 driver.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/35091

Output after change using dumb_http_server sample app:
```
*** Booting Zephyr OS build zephyr-v2.4.0-3426-g70ec734b87c3  ***
[00:00:00.646,453] <dbg> ethdrv.enc424j600_init_filters: ERXFCON: 0x005b
[00:00:00.646,789] <dbg> ethdrv.enc424j600_init_phy: PHANA: 0x05e1
[00:00:00.647,003] <dbg> ethdrv.enc424j600_init_phy: PHCON1: 0x1200
[00:00:00.647,216] <dbg> ethdrv.enc424j600_init: EIE: 0x8850
[00:00:00.647,277] <dbg> ethdrv.enc424j600_init: ECON1: 0x0001
[00:00:00.647,277] <err> ethdrv: handling int
[00:00:00.647,399] <inf> ethdrv: ENC424J600 Initialized
[00:00:00.647,430] <dbg> ethdrv.enc424j600_rx_thread: ESTAT: 0xda00
[00:00:00.647,491] <inf> ethdrv: Link down
[00:00:00.647,521] <err> ethdrv: handling int
[00:00:00.647,613] <dbg> ethdrv.enc424j600_rx_thread: ESTAT: 0x5a00
[00:00:00.647,644] <err> ethdrv: Unknown Interrupt, EIR: 0x0700
[00:00:00.653,533] <inf> net_config: Initializing network
[00:00:00.653,533] <inf> net_config: Waiting interface 1 (0x20000f0c) to be up...
Single-threaded dumb HTTP server waits for a connection on port 8080...
[00:00:02.244,201] <err> ethdrv: handling int
[00:00:02.244,323] <dbg> ethdrv.enc424j600_rx_thread: ESTAT: 0xdf00
[00:00:02.244,354] <inf> ethdrv: Link up
[00:00:02.244,537] <dbg> ethdrv.enc424j600_setup_mac: PHANLPA: 0x85e1
[00:00:02.244,750] <inf> ethdrv: 100Mbps
[00:00:02.244,750] <inf> ethdrv: full duplex
[00:00:02.244,873] <dbg> ethdrv.enc424j600_setup_mac: MACON2: 0x40b3
[00:00:02.244,934] <dbg> ethdrv.enc424j600_setup_mac: MAMXFL (maximum frame length): 1518
[00:00:02.244,964] <inf> ethdrv: Not suspended
[00:00:02.244,995] <inf> net_config: Interface 1 (0x20000f0c) coming up
[00:00:02.245,086] <inf> net_config: IPv4 address: 192.168.1.55
```