### PR TITLE
lifo_usage: set the min_ram requirements

### DIFF
--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   kernel.lifo.usage:
     # see #26646
     platform_exclude: m2gl025_miv
+    min_ram: 18
     tags: kernel


### PR DESCRIPTION
in FRDM_KL25Z we meet compilation error

/opt/zephyr-sdk/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/10.2.0/../../../../arm-zephyr-eabi/bin/ld: zephyr_prebuilt.elf section `noinit' will not fit in region `SRAM'

/opt/zephyr-sdk/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/10.2.0/../../../../arm-zephyr-eabi/bin/ld: section .intList VMA [0000000020003000,0000000020003027] overlaps section noinit VMA [000000001ffffc30,000000002000392f]

/opt/zephyr-sdk/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/10.2.0/../../../../arm-zephyr-eabi/bin/ld: region `SRAM' overflowed by 2352 bytes

collect2: error: ld returned 1 exit status

make[2]: *** [zephyr/CMakeFiles/zephyr_prebuilt.dir/build.make:101: zephyr/zephyr_prebuilt.elf] Error 1

make[1]: *** [CMakeFiles/Makefile2:2997: zephyr/CMakeFiles/zephyr_prebuilt.dir/all] Error 2

make: *** [Makefile:84: all] Error 2

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>