### PR TITLE
soc: nrf9160: Remove incorrect indication of SWO availability

### DIFF
--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -18,7 +18,6 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			swo-ref-frequency = <32000000>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -18,7 +18,6 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			swo-ref-frequency = <32000000>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -16,6 +16,5 @@ config SOC_SERIES_NRF91X
 	select XIP
 	select HAS_NRFX
 	select HAS_SEGGER_RTT
-	select HAS_SWO
 	help
 	  Enable support for NRF91 MCU series


### PR DESCRIPTION
Serial Wire Output functionality is not implemented in nRF9160.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>