### PR TITLE
Add user data pointer support to SYS_INIT

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -80,10 +80,10 @@ void z_sys_init_run_level(int32_t level)
 	const struct init_entry *entry;
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
-		const struct device *dev = entry->dev;
-		int rc = entry->init(dev);
+		int rc = entry->init(entry->user_data);
+		const struct device *dev = entry->user_data;
 
-		if (dev != NULL) {
+		if (dev >= __device_start && dev < __device_end) {
 			/* Mark device initialized.  If initialization
 			 * failed, record the error condition.
 			 */


### PR DESCRIPTION
Hi!

This is adding an extra SYS_INIT type of macro to reuse the existing dev pointer in `struct sys_init`, making it generic, allowing to reuse a system initialization function with different arguments. It should be useful for an application that has to runtime initialize a bunch of similar objects.

The patch maintains the current behavior for device initialization tracking by checking if the pointer argument is within the device data sections, so that should be safe as long as the argument is a valid pointer (or NULL). Alternatively, an extra pointer could be added to `struct sys_init`, or maybe to `struct device` and then have a separate common device init function to call the actual one and track the return value, but both would add extra storage space for every device in the system.

I'm open to alternatives for this, ultimately if none of these is considered acceptable I guess one more option would be to use custom Z_ITERABLE_SECTION at application level (are Z_ macro ok to use in external application or are those considered unstable?).