### PR TITLE
Bluetooth: Mesh: Change friend_cred decision point to friend selection

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -388,7 +388,7 @@ static void bt_mesh_net_local(struct k_work *work)
 static const struct bt_mesh_net_cred *net_tx_cred_get(struct bt_mesh_net_tx *tx)
 {
 #if defined(CONFIG_BT_MESH_LOW_POWER)
-	if (tx->friend_cred && bt_mesh_lpn_established()) {
+	if (tx->friend_cred && bt_mesh.lpn.frnd) {
 		return &bt_mesh.lpn.cred[SUBNET_KEY_TX_IDX(tx->sub)];
 	}
 #endif


### PR DESCRIPTION
The network layer previously decided to use the friend credentials if
there was an established friendship. During the friendship setup phase,
the friendship is not considered established until the LPN receives the
first friend poll. Before this happens, the LPN should send a friend
poll message, encrypted with the friendship credentials. This wrongly
gets encrypted with the master credentials.

Change the decision point to whether the LPN has selected a friend,
which happens after the friend offer, and before the friend poll. This
will remain set for the duration of the friendship.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>