### PR TITLE
samples: sensor: max17262: Fix NULL pointer dereference

### DIFF
--- a/samples/sensor/max17262/src/main.c
+++ b/samples/sensor/max17262/src/main.c
@@ -23,7 +23,7 @@ void main(void)
 	const struct device *dev = device_get_binding(MAX17262_LABEL);
 
 	if (dev == NULL) {
-		printk("No device %s found...\n", dev->name);
+		printk("No device found...\n");
 		return;
 	}
 	printk("Found device %s\n", dev->name);


### PR DESCRIPTION
If we don't get a dev pointer from device_get_binding() we should
not dereference it.  Just drop the name from the printk message
as in the future this is likely to use DEVICE_DT_GET().

Fixes #35112

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>