### PR TITLE
soc: stm32f7 remove cache memory with dma transfer

### DIFF
--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -31,12 +31,12 @@ static int st_stm32f7_init(const struct device *arg)
 	ARG_UNUSED(arg);
 
 	key = irq_lock();
-
+#ifndef CONFIG_NOCACHE_MEMORY
 	SCB_EnableICache();
 	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
 		SCB_EnableDCache();
 	}
-
+#endif
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */


### PR DESCRIPTION
When using the DMA on stm32f7, the cache memory is disabled using the CONFIG_NOCACHE_MEMORY
This must be the case when running dma memory-to-memory transfers test cases
    `tests/driver/dma/chan_blen_transfer` and  `tests/driver/dma/loop_transfer`

on nucleo_f746zg (dma2 is already enabled in the dts of the board)

Signed-off-by: Francois Ramu <francois.ramu@st.com>

Fixes #35220