### PR TITLE
requirements: bump west to >=0.10.1

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -211,7 +211,7 @@ additional Python dependencies.
 
          .. code-block:: bash
 
-            pip3 install west
+            pip3 install -U west
 
       #. Get the Zephyr source code:
 
@@ -242,7 +242,7 @@ additional Python dependencies.
 
          .. code-block:: bash
 
-            pip3 install west
+            pip3 install -U west
 
       #. Get the Zephyr source code:
 

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -27,7 +27,7 @@ anytree
 intelhex
 
 # it's west
-west>=0.7.2
+west>=0.10.1
 
 # used for windows based 'menuconfig'
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
We are in the process of changing the HEAD branch in the zephyr
repository from 'master' to 'main'. Users will need west version at
least 0.10.1 for the plain 'west init' line in the getting started
guide to still work after that change.

To avoid problems:

- add -U to the macOS and Windows lines for installing west (this
  option is already there for Ubuntu). Upgrading west will make
  the guide 'just work' for users who have an old version.

- bump the minimum version in the relevant requirements file,
  in case anybody is doing something like basing a CI setup
  on those versions.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>