### PR TITLE
Bluetooth: controller: Set buffer size default for BT_HCI_RAW

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -7,6 +7,7 @@
 config BT_BUF_ACL_TX_SIZE
 	int "Maximum supported ACL size for outgoing data"
 	range 27 251
+	default 251 if BT_HCI_RAW
 	default 27
 	help
 	  Maximum supported ACL size of data packets sent from the Host to the
@@ -53,6 +54,7 @@ config BT_BUF_ACL_RX_SIZE
 	default 73 if BT_MESH_PROXY
 	default 70 if BT_EATT
 	default 69 if BT_SMP
+	default 251 if BT_HCI_RAW
 	default 27
 	range 70 1300 if BT_EATT
 	range 69 1300 if BT_SMP

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -322,9 +322,10 @@ config BT_CTLR_DATA_LENGTH
 config BT_CTLR_DATA_LENGTH_MAX
 	int "Maximum data length supported"
 	depends on BT_CTLR_DATA_LENGTH
-	default 27
 	range 27 BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
 	range 27 251
+	default 251 if BT_HCI_RAW
+	default 27
 	help
 	  Set the maximum data length of PDU supported in the Controller.
 


### PR DESCRIPTION
Set default Rx, Tx and Data Length exchange PDU sizes to
251 bytes when building BT_HCI_RAW.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>