### PR TITLE
samples: net: txtime: Address length was not init

### DIFF
--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -130,7 +130,7 @@ static void rx(struct app_data *data)
 {
 	static uint8_t recv_buf[sizeof(txtime_str)];
 	struct sockaddr src;
-	socklen_t addr_len;
+	socklen_t addr_len = data->peer_addr_len;
 	ssize_t len = 0;
 
 	while (true) {


### PR DESCRIPTION
The sockaddr address length was not initialized properly
when receiving packets.

Coverity-CID: 232698
Fixes #35159

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>