### PR TITLE
net: igmp: Fix uninitialized variable

### DIFF
--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -120,7 +120,7 @@ static int send_igmp_report(struct net_if *iface,
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
 	struct net_pkt *pkt = NULL;
 	int i, count = 0;
-	int ret;
+	int ret = 0;
 
 	if (!ipv4) {
 		return -ENOENT;


### PR DESCRIPTION
The return value might be uninitialized if there was no
suitable IPv4 address found for the network interface.

Coverity-CID: 224630
Fixes #35158

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>