### PR TITLE
kernel: mmu: remove un-needed call to virt_to_bitmap_offset

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -210,8 +210,6 @@ static void virt_region_init(void)
 
 	if (Z_VM_RESERVED > 0) {
 		/* Mark reserved region at end of virtual address space */
-		offset = virt_to_bitmap_offset(Z_VIRT_REGION_END_ADDR,
-					       Z_VM_RESERVED);
 		num_bits = Z_VM_RESERVED / CONFIG_MMU_PAGE_SIZE;
 		(void)sys_bitarray_set_region(&virt_region_bitmap,
 					      num_bits, 0);


### PR DESCRIPTION
When marking the reserved region at the end of virtual address
space, call virt_to_bitmap_offset() is not needed as we already
know the offset. So remove it.

Coverity-CID: 235930
Fixes #35160

Signed-off-by: Daniel Leung <daniel.leung@intel.com>