### PR TITLE
tests: mem_protect/mem_map: remove unused assignment to cnt

### DIFF
--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -383,7 +383,6 @@ void test_k_mem_map_exhaustion(void)
 		      "free memory should be %zu", free_mem_expected);
 
 	/* Now free all of them */
-	cnt = expected_cnt;
 	cnt = 0;
 	while (last_mapped != NULL) {
 		addr = last_mapped;


### PR DESCRIPTION
The variable cnt is assigned twice in a row, so remove
the first one.

Coverity-CID: 235962
Fixes #35161

Signed-off-by: Daniel Leung <daniel.leung@intel.com>