### PR TITLE
pm: policy: Fix residency policy math

### DIFF
--- a/subsys/pm/policy/policy_residency.c
+++ b/subsys/pm/policy/policy_residency.c
@@ -34,7 +34,7 @@ struct pm_state_info pm_policy_next_state(int32_t ticks)
 				"min_residency_us < exit_latency_us");
 
 		if ((ticks == K_TICKS_FOREVER) ||
-		    (ticks >= (min_residency - exit_latency))) {
+		    (ticks >= (min_residency + exit_latency))) {
 			LOG_DBG("Selected power state %d "
 				"(ticks: %d, min_residency: %u)",
 				pm_min_residency[i].state, ticks,


### PR DESCRIPTION
The time necessary to resume from a power state has to be added to the
minimal residency time to check if there is enough time to go to a
particular state.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>