### PR TITLE
tests: pm: Remove a platform from power_mgmt test

### DIFF
--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -2,9 +2,5 @@ tests:
   subsys.pm.device_pm:
     # arch_irq_unlock(0) can't work correctly on these arch
     arch_exclude: arc xtensa
-    platform_exclude: rv32m1_vega_ri5cy rv32m1_vega_zero_riscy litex_vexriscv
-       nrf5340dk_nrf5340_cpunet thingy53_nrf5340_cpunet bl5340_dvk_cpunet
-    integration_platforms:
-      - qemu_x86
-      - mps2_an385
+    platform_allow: qemu_x86 mps2_an385 native_posix
     tags: power


### PR DESCRIPTION
frdm_k64f does not implement power management, so just exclude it from
this test.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>