### PR TITLE
doc: release-notes-2.6: on k_mem_unmap and demand paging stats

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -159,6 +159,12 @@ Stable API changes in this release
 Kernel
 ******
 
+* Added :c:func:`k_mem_unmap()` so anonymous memory mapped via :c:func:`k_mem_map()`
+  can be unmapped and virtual address reclaimed.
+
+* Added the ability to gather more statistics for demand paging, including execution
+  time histograms for eviction algorithms and backing stores.
+
 Architectures
 *************
 


### PR DESCRIPTION
This mentions the new k_mem_unmap() and the ability to gather more
statistics for demand paging.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>