### PR TITLE
samples: sensor: Fix logically dead code in adxl372 and bmg160 samples

### DIFF
--- a/samples/sensor/adxl372/src/main.c
+++ b/samples/sensor/adxl372/src/main.c
@@ -10,6 +10,10 @@
 
 #define pow2(x) ((x) * (x))
 
+#if !DT_HAS_COMPAT_STATUS_OKAY(adi_adxl372)
+#error "No adi,adxl372 compatible node found in the device tree"
+#endif
+
 static double sqrt(double value)
 {
 	int i;
@@ -50,10 +54,6 @@ void main(void)
 
 	const struct device *dev = DEVICE_DT_GET_ANY(adi_adxl372);
 
-	if (!dev) {
-		printf("Devicetree has no adi,adxl372 node\n");
-		return;
-	}
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
 		return;

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -17,6 +17,10 @@
 #define MAX_TEST_TIME	15000
 #define SLEEPTIME	300
 
+#if !DT_HAS_COMPAT_STATUS_OKAY(bosch_bmg160)
+#error "No bosch,bmg160 compatible node found in the device tree"
+#endif
+
 static void print_gyro_data(const struct device *bmg160)
 {
 	struct sensor_value val[3];
@@ -173,10 +177,6 @@ void main(void)
 	struct sensor_value attr;
 #endif
 
-	if (!bmg160) {
-		printf("Device not found.\n");
-		return;
-	}
 	if (!device_is_ready(bmg160)) {
 		printf("Device %s is not ready.\n", bmg160->name);
 		return;


### PR DESCRIPTION
Converts the adxl372 and bmg160 sample applications to check the sensor device at
build time instead of runtime. This fixes Coverity issues for logically
dead code introduced in #34589.

Fixes #35118
Fixes #35119