### PR TITLE
intel_adsp_cavs15/ logtool.py: fix support for multiple NULLs

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/lib/loglist.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/lib/loglist.py
@@ -36,7 +36,8 @@ class Loglist:
 
         if magic == MAGIC:
             id_num = read_bytes(slot[2:4])
-            logstr = slot[4:].decode(errors='replace')
+            before_first_zero = slot[4:].split(b'\x00')[0]
+            logstr = before_first_zero.decode(errors='replace')
             self.loglist.append((id_num, logstr))
 
     def parse(self):


### PR DESCRIPTION
Stop printing garbage when strings are terminated with more than one
zero byte.

Thanks Andy for the diagnosis (and the better adsplog.py)

Fixes #34492

Signed-off-by: Marc Herbert <marc.herbert@intel.com>