### PR TITLE
Fix coverity issues in cbprintf and logging

### DIFF
--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -128,8 +128,9 @@ template < typename T >
 static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, T arg)
 {
 	size_t wlen = z_cbprintf_cxx_arg_size(arg) / sizeof(int);
+	void *p = &arg;
 
-	z_cbprintf_wcpy((int *)dst, (int *)&arg, wlen);
+	z_cbprintf_wcpy((int *)dst, (int *)p, wlen);
 }
 
 /* C++ version for long double detection. */

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -79,8 +79,9 @@ static inline size_t z_cbprintf_cxx_arg_size(T arg)
 static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, float arg)
 {
 	double d = (double)arg;
+	void *p = &d;
 
-	z_cbprintf_wcpy((int *)dst, (int *)&d, sizeof(d) / sizeof(int));
+	z_cbprintf_wcpy((int *)dst, (int *)p, sizeof(d) / sizeof(int));
 }
 
 static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, void *p)

--- a/subsys/logging/log_msg2.c
+++ b/subsys/logging/log_msg2.c
@@ -58,13 +58,15 @@ void z_impl_z_log_msg2_runtime_vcreate(uint8_t domain_id, const void *source,
 				const char *fmt, va_list ap)
 {
 	int plen;
-	va_list ap2;
 
 	if (fmt) {
+		va_list ap2;
+
 		va_copy(ap2, ap);
 		plen = cbvprintf_package(NULL, Z_LOG_MSG2_ALIGN_OFFSET,
 					 fmt, ap2);
 		__ASSERT_NO_MSG(plen >= 0);
+		va_end(ap2);
 	} else {
 		plen = 0;
 	}

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -370,7 +370,7 @@ static void sync_hexdump(const struct log_backend *const backend,
 
 	zassert_equal(0, strcmp(metadata, exp->str), NULL);
 	zassert_equal(length, exp->data_len, NULL);
-	if (length > sizeof(exp->data)) {
+	if (length <= sizeof(exp->data)) {
 		zassert_equal(memcmp(data, exp->data, length), 0, NULL);
 	}
 }

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -296,7 +296,9 @@ static void process(const struct log_backend *const backend,
 
 	data = log_msg2_get_package(&msg->log, &len);
 	len = cbpprintf(out, &s, data);
-	str[len] = '\0';
+	if (len > 0) {
+		str[len] = '\0';
+	}
 
 	zassert_equal(strcmp(str, exp->str), 0, "Got \"%s\", Expected:\"%s\"",
 			str, exp->str);

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -11,7 +11,7 @@
 #include <logging/log_ctrl.h>
 
 #ifndef CONFIG_LOG_BUFFER_SIZE
-#define CONFIG_LOG_BUFFER_SIZE 0
+#define CONFIG_LOG_BUFFER_SIZE 4
 #endif
 
 #define MODULE_NAME test

--- a/tests/subsys/logging/log_api/src/test.inc
+++ b/tests/subsys/logging/log_api/src/test.inc
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(MODULE_NAME, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 #define TIMESTAMP_INIT_VAL 0
 #endif
 
-MOCK_LOG_BACKEND_DEFINE(backend1, true);
+MOCK_LOG_BACKEND_DEFINE(backend1, false);
 MOCK_LOG_BACKEND_DEFINE(backend2, false);
 
 static log_timestamp_t stamp;
@@ -78,6 +78,8 @@ static void log_setup(bool backend2_enable)
 
 	mock_log_backend_reset(&backend1);
 	mock_log_backend_reset(&backend2);
+
+	log_backend_enable(&backend1, backend1.cb->ctx, LOG_LEVEL_DBG);
 
 	if (backend2_enable) {
 		log_backend_enable(&backend2, backend2.cb->ctx, LOG_LEVEL_DBG);
@@ -512,14 +514,17 @@ static void log_n_messages(uint32_t n_msg, uint32_t exp_dropped)
 {
 	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
 
+	log_setup(false);
+
 	stamp = TIMESTAMP_INIT_VAL;
 
 	for (uint32_t i = 0; i < n_msg; i++) {
 		if (i >= exp_dropped) {
 			mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
-				exp_timestamp++, "dummy");
+				exp_timestamp, "dummy");
 		}
+		exp_timestamp++;
 		LOG_INF("dummy");
 	}
 
@@ -548,9 +553,6 @@ static void test_log_msg_dropped_notification(void)
 	}
 
 	uint32_t capacity = get_short_msg_capacity();
-
-	return;
-	log_setup(false);
 
 	log_n_messages(capacity, 0);
 

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -108,8 +108,8 @@ static void basic_validate(struct log_msg2 *msg,
 	d = log_msg2_get_package(msg, &len);
 	if (str) {
 		rv = cbpprintf(out, &tbuf, d);
-		buf[rv] = '\0';
 		zassert_true(rv > 0, NULL);
+		buf[rv] = '\0';
 
 		rv = strncmp(buf, str, sizeof(buf));
 		zassert_equal(rv, 0, "expected:\n%s,\ngot:\n%s", str, buf);


### PR DESCRIPTION
Set of fixes in cbprintf/logging code and tests.

Fixes #35116.
Fixes #35126.
Fixes #35127.
Fixes #35152.
Fixes #35153.
Fixes #35133.
Fixes #35134.
Fixes #35135.
Fixes #35148.
Fixes #35151.
