### PR TITLE
subsys: stats: fix avoid potential overflow

### DIFF
--- a/subsys/stats/stats.c
+++ b/subsys/stats/stats.c
@@ -280,5 +280,5 @@ stats_init_and_reg(struct stats_hdr *shdr, uint8_t size, uint16_t cnt,
 void
 stats_reset(struct stats_hdr *hdr)
 {
-	(void)memset((uint8_t *)hdr + sizeof(*hdr), 0, hdr->s_size * hdr->s_cnt);
+	(void)memset((uint8_t *)hdr, 0, sizeof(*hdr));
 }


### PR DESCRIPTION
Function stats_reset() had wrong usage of the memset() to reset
and zero values of the structure members.

Found as a coding guideline violation (MISRA R4.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>