### PR TITLE
tests: mheap_api_concept: fix non-reentrant thread_id

### DIFF
--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -14,7 +14,6 @@
 struct k_sem sync_sema;
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREAD_NUM, STACK_SIZE);
 static struct k_thread tdata[THREAD_NUM];
-static int thread_id;
 static void *block[BLK_NUM_MAX];
 
 /*test cases*/
@@ -54,7 +53,7 @@ void test_mheap_malloc_align4(void)
 
 static void tmheap_handler(void *p1, void *p2, void *p3)
 {
-	thread_id = POINTER_TO_INT(p1);
+	int thread_id = POINTER_TO_INT(p1);
 
 	block[thread_id] = k_malloc(BLOCK_SIZE);
 


### PR DESCRIPTION
in test case `test_mheap_threadsafe`, we will create 3 threads using
same thread handler `tmheap_handler`, we should make `thread_id`
to be a local variable, otherwise `tmheap_handler` is non-reentrant.

Fix: #35209 