### PR TITLE
boards: arm: bl65x and bl5340: enable UART flow control

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -141,6 +141,7 @@
 	rx-pin = <22>;
 	rts-pin = <19>;
 	cts-pin = <21>;
+	hw-flow-control;
 };
 
 &pwm0 {

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -75,6 +75,7 @@
 	rx-pin = <8>;
 	rts-pin = <5>;
 	cts-pin = <7>;
+	hw-flow-control;
 };
 
 &i2c0 {

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -99,6 +99,7 @@
 	rx-pin = <8>;
 	rts-pin = <5>;
 	cts-pin = <7>;
+	hw-flow-control;
 };
 
 &i2c0 {

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -99,6 +99,7 @@
 	rx-pin = <8>;
 	rts-pin = <5>;
 	cts-pin = <7>;
+	hw-flow-control;
 };
 
 &i2c0 {

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -69,6 +69,7 @@
 	rx-pin = <8>;
 	rts-pin = <5>;
 	cts-pin = <7>;
+	hw-flow-control;
 };
 
 &i2c0 {

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -98,6 +98,7 @@
 	rx-pin = <8>;
 	rts-pin = <5>;
 	cts-pin = <7>;
+	hw-flow-control;
 };
 
 &uart1 {
@@ -108,6 +109,7 @@
 	rx-pin = <16>;
 	rts-pin = <13>;
 	cts-pin = <15>;
+	hw-flow-control;
 	hl7800 {
 		compatible = "swir,hl7800";
 		status = "okay";


### PR DESCRIPTION
Flow control was switched from a Kconfig to part of the DTS without
updating existing boards, this addresses the bug by enabling hardware
flow control on Laird Connectivity modules where it should be enabled

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>