### PR TITLE
usb: add Chapter 9 (USB Device Framework) header

### DIFF
--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -462,8 +462,7 @@ static void update_control_stage(usb_device_callback_message_struct_t *cb_msg,
 	if (cb_msg->isSetup) {
 		if (usbd_setup->wLength == 0) {
 			dev_data.setupDataStage = SETUP_DATA_STAGE_DONE;
-		} else if (REQTYPE_GET_DIR(usbd_setup->bmRequestType)
-			   == REQTYPE_DIR_TO_HOST) {
+		} else if (usb_reqtype_is_to_host(usbd_setup)) {
 			dev_data.setupDataStage = SETUP_DATA_STAGE_IN;
 		} else {
 			dev_data.setupDataStage = SETUP_DATA_STAGE_OUT;

--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -513,8 +513,7 @@ int handle_usb_control(struct usbip_header *hdr)
 	}
 
 	if ((ntohl(hdr->common.direction) == USBIP_DIR_IN) ^
-	    (REQTYPE_GET_DIR(hdr->u.submit.bmRequestType) ==
-	     REQTYPE_DIR_TO_HOST)) {
+	    USB_REQTYPE_GET_DIR(hdr->u.submit.bmRequestType)) {
 		LOG_ERR("Failed to verify bmRequestType");
 		return -EIO;
 	}

--- a/drivers/usb/device/usb_dc_native_posix_adapt.c
+++ b/drivers/usb/device/usb_dc_native_posix_adapt.c
@@ -25,8 +25,6 @@
 
 /* Zephyr headers */
 #include <kernel.h>
-#include <usb/usb_common.h>
-#include <usb/usbstruct.h>
 #include <usb/usb_device.h>
 
 #include <posix_board_if.h>
@@ -75,7 +73,7 @@ static void usbip_header_dump(struct usbip_header *hdr)
 void get_interface(uint8_t *descriptors)
 {
 	while (descriptors[0]) {
-		if (descriptors[1] == USB_INTERFACE_DESC) {
+		if (descriptors[1] == USB_DESC_INTERFACE) {
 			LOG_DBG("interface found");
 		}
 
@@ -94,7 +92,7 @@ static int send_interfaces(const uint8_t *descriptors, int connfd)
 	} __packed iface;
 
 	while (descriptors[0]) {
-		if (descriptors[1] == USB_INTERFACE_DESC) {
+		if (descriptors[1] == USB_DESC_INTERFACE) {
 			struct usb_if_descriptor *desc = (void *)descriptors;
 
 			iface.bInterfaceClass = desc->bInterfaceClass;

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -796,9 +796,7 @@ static inline void usbd_work_process_setup(struct nrf_usbd_ep_ctx *ep_ctx)
 
 	struct nrf_usbd_ctx *ctx = get_usbd_ctx();
 
-	if ((REQTYPE_GET_DIR(usbd_setup->bmRequestType)
-	     == REQTYPE_DIR_TO_DEVICE)
-	    && (usbd_setup->wLength)) {
+	if (usb_reqtype_is_to_device(usbd_setup) && usbd_setup->wLength) {
 		ctx->ctrl_read_len = usbd_setup->wLength;
 		/* Allow data chunk on EP0 OUT */
 		nrfx_usbd_setup_data_clear();
@@ -1127,9 +1125,9 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 		nrfx_usbd_setup_t drv_setup;
 
 		nrfx_usbd_setup_get(&drv_setup);
-		if ((drv_setup.bRequest != REQ_SET_ADDRESS)
-		    || (REQTYPE_GET_TYPE(drv_setup.bmRequestType)
-			!= REQTYPE_TYPE_STANDARD)) {
+		if ((drv_setup.bRequest != USB_SREQ_SET_ADDRESS)
+		    || (USB_REQTYPE_GET_TYPE(drv_setup.bmRequestType)
+			!= USB_REQTYPE_TYPE_STANDARD)) {
 			/* SetAddress is habdled by USBD hardware.
 			 * No software action required.
 			 */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1042,8 +1042,7 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 		ep_state->cb(EP0_OUT, USB_DC_EP_SETUP);
 
 		if (!(setup->wLength == 0U) &&
-		    !(REQTYPE_GET_DIR(setup->bmRequestType) ==
-		    REQTYPE_DIR_TO_HOST)) {
+		    usb_reqtype_is_to_device(setup)) {
 			usb_dc_ep_start_read(EP0_OUT,
 					     usb_dc_stm32_state.ep_buf[EP0_IDX],
 					     setup->wLength);

--- a/include/usb/bos.h
+++ b/include/usb/bos.h
@@ -13,8 +13,11 @@
 #define USB_DEVICE_BOS_DESC_DEFINE_CAP \
 	static __in_section(usb, bos_desc_area, 1) __aligned(1) __used
 
-/* BOS descriptor type */
-#define DESCRIPTOR_TYPE_BOS		0x0F
+/*
+ * DESCRIPTOR_TYPE_BOS macro is deprecated in 2.7 release.
+ * Please replace with macros from Chapter 9 header, include/usb/usb_ch9.h
+ */
+#define DESCRIPTOR_TYPE_BOS		__DEPRECATED_MACRO 0x0F
 
 #define USB_BOS_CAPABILITY_EXTENSION	0x02
 #define USB_BOS_CAPABILITY_PLATFORM	0x05

--- a/include/usb/class/usb_audio.h
+++ b/include/usb/class/usb_audio.h
@@ -21,7 +21,7 @@
 #ifndef ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_
 #define ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_
 
-#include <usb/usb_common.h>
+#include <usb/usb_ch9.h>
 #include <device.h>
 #include <net/buf.h>
 #include <sys/util.h>

--- a/include/usb/class/usb_cdc.h
+++ b/include/usb/class/usb_cdc.h
@@ -32,6 +32,7 @@
 /** Communications Class Protocol Codes */
 #define AT_CMD_V250_PROTOCOL		0x01
 #define EEM_PROTOCOL			0x07
+#define ACM_VENDOR_PROTOCOL		0xFF
 
 /**
  * @brief Data Class Interface Codes

--- a/include/usb/usb_ch9.h
+++ b/include/usb/usb_ch9.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2020 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief USB Chapter 9 structures and definitions
+ *
+ * This file contains the USB Chapter 9 structures definitions
+ * and follows, with few exceptions, the USB Specification 2.0.
+ */
+
+#include <version.h>
+#include <sys/util.h>
+
+#ifndef ZEPHYR_INCLUDE_USB_CH9_H_
+#define ZEPHYR_INCLUDE_USB_CH9_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct usb_req_type_field {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	uint8_t recipient : 5;
+	uint8_t type : 2;
+	uint8_t direction : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	uint8_t direction : 1;
+	uint8_t type : 2;
+	uint8_t recipient : 5;
+#endif
+} __packed;
+
+/** USB Setup Data packet defined in spec. Table 9-2 */
+struct usb_setup_packet {
+	union {
+		uint8_t bmRequestType;
+		struct usb_req_type_field RequestType;
+	};
+	uint8_t bRequest;
+	uint16_t wValue;
+	uint16_t wIndex;
+	uint16_t wLength;
+};
+
+/** USB Setup packet RequestType Direction values (from Table 9-2) */
+#define USB_REQTYPE_DIR_TO_DEVICE	0
+#define USB_REQTYPE_DIR_TO_HOST		1
+
+/** USB Setup packet RequestType Type values (from Table 9-2) */
+#define USB_REQTYPE_TYPE_STANDARD	0
+#define USB_REQTYPE_TYPE_CLASS		1
+#define USB_REQTYPE_TYPE_VENDOR		2
+#define USB_REQTYPE_TYPE_RESERVED	3
+
+/** USB Setup packet RequestType Recipient values (from Table 9-2) */
+#define USB_REQTYPE_RECIPIENT_DEVICE	0
+#define USB_REQTYPE_RECIPIENT_INTERFACE	1
+#define USB_REQTYPE_RECIPIENT_ENDPOINT	2
+#define USB_REQTYPE_RECIPIENT_OTHER	3
+
+/** Get data transfer direction from bmRequestType */
+#define USB_REQTYPE_GET_DIR(bmRequestType) (((bmRequestType) >> 7) & 0x01U)
+/** Get request type from bmRequestType */
+#define USB_REQTYPE_GET_TYPE(bmRequestType) (((bmRequestType) >> 5) & 0x03U)
+/** Get request recipient from bmRequestType */
+#define USB_REQTYPE_GET_RECIPIENT(bmRequestType) ((bmRequestType) & 0x1FU)
+
+/**
+ * @brief Check if request transfer direction is to host.
+ *
+ * @param setup Pointer to USB Setup packet
+ * @return true If transfer direction is to host
+ */
+static inline bool usb_reqtype_is_to_host(struct usb_setup_packet *setup)
+{
+	return setup->RequestType.direction == USB_REQTYPE_DIR_TO_HOST;
+}
+
+/**
+ * @brief Check if request transfer direction is to device.
+ *
+ * @param setup Pointer to USB Setup packet
+ * @return true If transfer direction is to device
+ */
+static inline bool usb_reqtype_is_to_device(struct usb_setup_packet *setup)
+{
+	return setup->RequestType.direction == USB_REQTYPE_DIR_TO_DEVICE;
+}
+
+/** USB Standard Request Codes defined in spec. Table 9-4 */
+#define USB_SREQ_GET_STATUS		0x00
+#define USB_SREQ_CLEAR_FEATURE		0x01
+#define USB_SREQ_SET_FEATURE		0x03
+#define USB_SREQ_SET_ADDRESS		0x05
+#define USB_SREQ_GET_DESCRIPTOR		0x06
+#define USB_SREQ_SET_DESCRIPTOR		0x07
+#define USB_SREQ_GET_CONFIGURATION	0x08
+#define USB_SREQ_SET_CONFIGURATION	0x09
+#define USB_SREQ_GET_INTERFACE		0x0A
+#define USB_SREQ_SET_INTERFACE		0x0B
+#define USB_SREQ_SYNCH_FRAME		0x0C
+
+/** Descriptor Types defined in spec. Table 9-5 */
+#define USB_DESC_DEVICE			1
+#define USB_DESC_CONFIGURATION		2
+#define USB_DESC_STRING			3
+#define USB_DESC_INTERFACE		4
+#define USB_DESC_ENDPOINT		5
+#define USB_DESC_DEVICE_QUALIFIER	6
+#define USB_DESC_OTHER_SPEED		7
+#define USB_DESC_INTERFACE_POWER	8
+/** Additional Descriptor Types defined in USB 3 spec. Table 9-5 */
+#define USB_DESC_OTG			9
+#define USB_DESC_DEBUG			10
+#define USB_DESC_INTERFACE_ASSOC	11
+#define USB_DESC_BOS			15
+#define USB_DESC_DEVICE_CAPABILITY	16
+
+/** Class-Specific Descriptor Types as defined by
+ *  USB Common Class Specification
+ */
+#define USB_DESC_CS_DEVICE		0x21
+#define USB_DESC_CS_CONFIGURATION	0x22
+#define USB_DESC_CS_STRING		0x23
+#define USB_DESC_CS_INTERFACE		0x24
+#define USB_DESC_CS_ENDPOINT		0x25
+
+/** USB Standard Feature Selectors defined in spec. Table 9-6 */
+#define USB_SFS_ENDPOINT_HALT		0x00
+#define USB_SFS_REMOTE_WAKEUP		0x01
+#define USB_SFS_TEST_MODE		0x02
+
+/** Bits used for GetStatus response defined in spec. Figure 9-4 */
+#define USB_GET_STATUS_SELF_POWERED	BIT(0)
+#define USB_GET_STATUS_REMOTE_WAKEUP	BIT(1)
+
+/** Header of an USB descriptor */
+struct usb_desc_header {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+} __packed;
+
+/** USB Standard Device Descriptor defined in spec. Table 9-8 */
+struct usb_device_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint16_t bcdUSB;
+	uint8_t bDeviceClass;
+	uint8_t bDeviceSubClass;
+	uint8_t bDeviceProtocol;
+	uint8_t bMaxPacketSize0;
+	uint16_t idVendor;
+	uint16_t idProduct;
+	uint16_t bcdDevice;
+	uint8_t iManufacturer;
+	uint8_t iProduct;
+	uint8_t iSerialNumber;
+	uint8_t bNumConfigurations;
+} __packed;
+
+/** USB Standard Configuration Descriptor defined in spec. Table 9-10 */
+struct usb_cfg_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint16_t wTotalLength;
+	uint8_t bNumInterfaces;
+	uint8_t bConfigurationValue;
+	uint8_t iConfiguration;
+	uint8_t bmAttributes;
+	uint8_t bMaxPower;
+} __packed;
+
+/** USB Standard Interface Descriptor defined in spec. Table 9-12 */
+struct usb_if_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bInterfaceNumber;
+	uint8_t bAlternateSetting;
+	uint8_t bNumEndpoints;
+	uint8_t bInterfaceClass;
+	uint8_t bInterfaceSubClass;
+	uint8_t bInterfaceProtocol;
+	uint8_t iInterface;
+} __packed;
+
+/** USB Standard Endpoint Descriptor defined in spec. Table 9-13 */
+struct usb_ep_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bEndpointAddress;
+	uint8_t bmAttributes;
+	uint16_t wMaxPacketSize;
+	uint8_t bInterval;
+} __packed;
+
+/** USB Unicode (UTF16LE) String Descriptor defined in spec. Table 9-15 */
+struct usb_string_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint16_t bString;
+} __packed;
+
+/** USB Association Descriptor defined in USB 3 spec. Table 9-16 */
+struct usb_association_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bFirstInterface;
+	uint8_t bInterfaceCount;
+	uint8_t bFunctionClass;
+	uint8_t bFunctionSubClass;
+	uint8_t bFunctionProtocol;
+	uint8_t iFunction;
+} __packed;
+
+/** USB Standard Configuration Descriptor Characteristics from Table 9-10 */
+#define USB_SCD_RESERVED	BIT(7)
+#define USB_SCD_SELF_POWERED	BIT(6)
+#define USB_SCD_REMOTE_WAKEUP	BIT(5)
+#define USB_SCD_ATTRIBUTES	(USB_SCD_RESERVED |			      \
+				 COND_CODE_1(CONFIG_USB_SELF_POWERED,	      \
+					     (USB_SCD_SELF_POWERED), (0)) |   \
+				 COND_CODE_1(CONFIG_USB_DEVICE_REMOTE_WAKEUP, \
+					     (USB_SCD_REMOTE_WAKEUP), (0)))
+
+/** USB Defined Base Class Codes from https://www.usb.org/defined-class-codes */
+#define USB_BCC_AUDIO			0x01
+#define USB_BCC_CDC_CONTROL		0x02
+#define USB_BCC_HID			0x03
+#define USB_BCC_MASS_STORAGE		0x08
+#define USB_BCC_CDC_DATA		0x0A
+#define USB_BCC_VIDEO			0x0E
+#define USB_BCC_WIRELESS_CONTROLLER	0xE0
+#define USB_BCC_MISCELLANEOUS		0xEF
+#define USB_BCC_APPLICATION		0xFE
+#define USB_BCC_VENDOR			0xFF
+
+/** USB Specification Release Numbers (bcdUSB Descriptor field) */
+#define USB_SRN_1_1			0x0110
+#define USB_SRN_2_0			0x0200
+#define USB_SRN_2_1			0x0210
+
+#define USB_DEC_TO_BCD(dec)	((((dec) / 10) << 4) | ((dec) % 10))
+
+/** USB Device release number (bcdDevice Descriptor field) */
+#define USB_BCD_DRN		(USB_DEC_TO_BCD(KERNEL_VERSION_MAJOR) << 8 | \
+				 USB_DEC_TO_BCD(KERNEL_VERSION_MINOR))
+
+/** Macro to obtain descriptor type from USB_SREQ_GET_DESCRIPTOR request */
+#define USB_GET_DESCRIPTOR_TYPE(wValue)		((uint8_t)((wValue) >> 8))
+
+/** Macro to obtain descriptor index from USB_SREQ_GET_DESCRIPTOR request */
+#define USB_GET_DESCRIPTOR_INDEX(wValue)	((uint8_t)(wValue))
+
+/** USB Control Endpoints OUT and IN Address */
+#define USB_CONTROL_EP_OUT		0
+#define USB_CONTROL_EP_IN		0x80
+
+/** USB Control Endpoints maximum packet size (MPS) */
+#define USB_CONTROL_EP_MPS		64
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_USB_CH9_H_ */

--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -43,53 +43,59 @@
  */
 
 #include <version.h>
+#include <usb/usb_ch9.h>
 
 #ifndef ZEPHYR_INCLUDE_USB_USB_COMMON_H_
 #define ZEPHYR_INCLUDE_USB_USB_COMMON_H_
 
-#define BCD(x) ((((x) / 10) << 4) | ((x) % 10))
+/*
+ * This header and macros below are deprecated in 2.7 release.
+ * Please replace with macros from Chapter 9 header, include/usb/usb_ch9.h
+ */
+#warning "<usb/usb_common.h> header is deprecated, use <usb/usb_ch9.h> instead"
+
+#define BCD(x) __DEPRECATED_MACRO USB_DEC_TO_BCD(dec)
 
 /* Descriptor size in bytes */
-#define USB_DEVICE_DESC_SIZE		18
-#define USB_CONFIGURATION_DESC_SIZE	9
-#define USB_INTERFACE_DESC_SIZE		9
-#define USB_ENDPOINT_DESC_SIZE		7
-#define USB_STRING_DESC_SIZE		4
-#define USB_HID_DESC_SIZE		9
-#define USB_DFU_DESC_SIZE		9
-#define USB_DEVICE_QUAL_DESC_SIZE	10
-#define USB_INTERFACE_ASSOC_DESC_SIZE	8
+#define USB_DEVICE_DESC_SIZE		__DEPRECATED_MACRO 18
+#define USB_CONFIGURATION_DESC_SIZE	__DEPRECATED_MACRO 9
+#define USB_INTERFACE_DESC_SIZE		__DEPRECATED_MACRO 9
+#define USB_ENDPOINT_DESC_SIZE		__DEPRECATED_MACRO 7
+#define USB_STRING_DESC_SIZE		__DEPRECATED_MACRO 4
+#define USB_HID_DESC_SIZE		__DEPRECATED_MACRO 9
+#define USB_DFU_DESC_SIZE		__DEPRECATED_MACRO 9
+#define USB_DEVICE_QUAL_DESC_SIZE	__DEPRECATED_MACRO 10
+#define USB_INTERFACE_ASSOC_DESC_SIZE	__DEPRECATED_MACRO 8
 
 /* Descriptor type */
-#define USB_DEVICE_DESC			0x01U
-#define USB_CONFIGURATION_DESC		0x02U
-#define USB_STRING_DESC			0x03U
-#define USB_INTERFACE_DESC		0x04U
-#define USB_ENDPOINT_DESC		0x05U
-#define USB_DEVICE_QUAL_DESC		0x06U
-#define USB_OTHER_SPEED			0x07U
-#define USB_INTERFACE_POWER		0x08U
-#define USB_INTERFACE_ASSOC_DESC	0x0BU
-#define USB_DEVICE_CAPABILITY_DESC	0x10U
-#define USB_HID_DESC			0x21U
-#define USB_HID_REPORT_DESC		0x22U
-#define USB_CS_INTERFACE_DESC		0x24U
-#define USB_CS_ENDPOINT_DESC		0x25U
-#define USB_DFU_FUNCTIONAL_DESC		0x21U
-#define USB_ASSOCIATION_DESC		0x0BU
-#define USB_BINARY_OBJECT_STORE_DESC	0x0FU
+#define USB_DEVICE_DESC			__DEPRECATED_MACRO 0x01U
+#define USB_CONFIGURATION_DESC		__DEPRECATED_MACRO 0x02U
+#define USB_STRING_DESC			__DEPRECATED_MACRO 0x03U
+#define USB_INTERFACE_DESC		__DEPRECATED_MACRO 0x04U
+#define USB_ENDPOINT_DESC		__DEPRECATED_MACRO 0x05U
+#define USB_DEVICE_QUAL_DESC		__DEPRECATED_MACRO 0x06U
+#define USB_OTHER_SPEED			__DEPRECATED_MACRO 0x07U
+#define USB_INTERFACE_POWER		__DEPRECATED_MACRO 0x08U
+#define USB_INTERFACE_ASSOC_DESC	__DEPRECATED_MACRO 0x0BU
+#define USB_DEVICE_CAPABILITY_DESC	__DEPRECATED_MACRO 0x10U
+#define USB_HID_DESC			__DEPRECATED_MACRO 0x21U
+#define USB_HID_REPORT_DESC		__DEPRECATED_MACRO 0x22U
+#define USB_CS_INTERFACE_DESC		__DEPRECATED_MACRO 0x24U
+#define USB_CS_ENDPOINT_DESC		__DEPRECATED_MACRO 0x25U
+#define USB_DFU_FUNCTIONAL_DESC		__DEPRECATED_MACRO 0x21U
+#define USB_ASSOCIATION_DESC		__DEPRECATED_MACRO 0x0BU
+#define USB_BINARY_OBJECT_STORE_DESC	__DEPRECATED_MACRO 0x0FU
 
 /* Useful define */
-#define USB_1_1				0x0110
-#define USB_2_0				0x0200
+#define USB_1_1				__DEPRECATED_MACRO 0x0110
+#define USB_2_0				__DEPRECATED_MACRO 0x0200
 /* Set USB version to 2.1 so that the host will request the BOS descriptor */
-#define USB_2_1				0x0210
+#define USB_2_1				__DEPRECATED_MACRO 0x0210
 
-#define BCDDEVICE_RELNUM		(BCD(KERNEL_VERSION_MAJOR) << 8 | \
-					BCD(KERNEL_VERSION_MINOR))
+#define BCDDEVICE_RELNUM		__DEPRECATED_MACRO USB_BCD_DRN
 
 /* Highest value of Frame Number in SOF packets. */
-#define USB_SOF_MAX			2047
+#define USB_SOF_MAX			__DEPRECATED_MACRO 2047
 
 /* bmAttributes:
  * D7:Reserved, always 1,
@@ -97,117 +103,45 @@
  * D5:Remote Wakeup -> 0,
  * D4...0:Reserved -> 0
  */
-#define USB_CONFIGURATION_ATTRIBUTES_REMOTE_WAKEUP	BIT(5)
-#define USB_CONFIGURATION_ATTRIBUTES_SELF_POWERED	BIT(6)
-#define USB_CONFIGURATION_ATTRIBUTES BIT(7) \
+#define USB_CONFIGURATION_ATTRIBUTES_REMOTE_WAKEUP	__DEPRECATED_MACRO BIT(5)
+#define USB_CONFIGURATION_ATTRIBUTES_SELF_POWERED	__DEPRECATED_MACRO BIT(6)
+#define USB_CONFIGURATION_ATTRIBUTES BIT(7)		__DEPRECATED_MACRO \
 	| ((COND_CODE_1(CONFIG_USB_SELF_POWERED, \
 	   (USB_CONFIGURATION_ATTRIBUTES_SELF_POWERED), (0)))   \
 	| (COND_CODE_1(CONFIG_USB_DEVICE_REMOTE_WAKEUP,         \
 	   (USB_CONFIGURATION_ATTRIBUTES_REMOTE_WAKEUP), (0))))
 
 /* Classes */
-#define AUDIO_CLASS			0x01
-#define COMMUNICATION_DEVICE_CLASS	0x02
-#define COMMUNICATION_DEVICE_CLASS_DATA	0x0A
-#define HID_CLASS			0x03
-#define MASS_STORAGE_CLASS		0x08
-#define WIRELESS_DEVICE_CLASS		0xE0
-#define MISC_CLASS			0xEF
-#define CUSTOM_CLASS			0xFF
-#define DFU_DEVICE_CLASS		0xFE
+#define AUDIO_CLASS			__DEPRECATED_MACRO 0x01
+#define COMMUNICATION_DEVICE_CLASS	__DEPRECATED_MACRO 0x02
+#define COMMUNICATION_DEVICE_CLASS_DATA	__DEPRECATED_MACRO 0x0A
+#define HID_CLASS			__DEPRECATED_MACRO 0x03
+#define MASS_STORAGE_CLASS		__DEPRECATED_MACRO 0x08
+#define WIRELESS_DEVICE_CLASS		__DEPRECATED_MACRO 0xE0
+#define MISC_CLASS			__DEPRECATED_MACRO 0xEF
+#define CUSTOM_CLASS			__DEPRECATED_MACRO 0xFF
+#define DFU_DEVICE_CLASS		__DEPRECATED_MACRO 0xFE
 
 /* Sub-classes */
-#define CDC_NCM_SUBCLASS		0x0d
-#define BOOT_INTERFACE_SUBCLASS		0x01
-#define SCSI_TRANSPARENT_SUBCLASS	0x06
-#define DFU_INTERFACE_SUBCLASS		0x01
-#define RF_SUBCLASS			0x01
-#define CUSTOM_SUBCLASS			0xFF
+#define CDC_NCM_SUBCLASS		__DEPRECATED_MACRO 0x0d
+#define BOOT_INTERFACE_SUBCLASS		__DEPRECATED_MACRO 0x01
+#define SCSI_TRANSPARENT_SUBCLASS	__DEPRECATED_MACRO 0x06
+#define DFU_INTERFACE_SUBCLASS		__DEPRECATED_MACRO 0x01
+#define RF_SUBCLASS			__DEPRECATED_MACRO 0x01
+#define CUSTOM_SUBCLASS			__DEPRECATED_MACRO 0xFF
 /* Misc subclasses */
-#define MISC_RNDIS_SUBCLASS		0x04
+#define MISC_RNDIS_SUBCLASS		__DEPRECATED_MACRO 0x04
 
 /* Protocols */
-#define V25TER_PROTOCOL			0x01
-#define MOUSE_PROTOCOL			0x02
-#define BULK_ONLY_PROTOCOL		0x50
-#define DFU_RUNTIME_PROTOCOL		0x01
-#define DFU_MODE_PROTOCOL		0x02
-#define BLUETOOTH_PROTOCOL		0x01
+#define V25TER_PROTOCOL			__DEPRECATED_MACRO 0x01
+#define MOUSE_PROTOCOL			__DEPRECATED_MACRO 0x02
+#define BULK_ONLY_PROTOCOL		__DEPRECATED_MACRO 0x50
+#define DFU_RUNTIME_PROTOCOL		__DEPRECATED_MACRO 0x01
+#define DFU_MODE_PROTOCOL		__DEPRECATED_MACRO 0x02
+#define BLUETOOTH_PROTOCOL		__DEPRECATED_MACRO 0x01
 /* CDC ACM protocols */
-#define ACM_VENDOR_PROTOCOL		0xFF
+#define ACM_VENDOR_PROTOCOL		__DEPRECATED_MACRO 0xFF
 /* Misc protocols */
-#define MISC_ETHERNET_PROTOCOL		0x01
-
-/** Standard Device Descriptor */
-struct usb_device_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint16_t bcdUSB;
-	uint8_t bDeviceClass;
-	uint8_t bDeviceSubClass;
-	uint8_t bDeviceProtocol;
-	uint8_t bMaxPacketSize0;
-	uint16_t idVendor;
-	uint16_t idProduct;
-	uint16_t bcdDevice;
-	uint8_t iManufacturer;
-	uint8_t iProduct;
-	uint8_t iSerialNumber;
-	uint8_t bNumConfigurations;
-} __packed;
-
-/** Unicode (UTF16LE) String Descriptor */
-struct usb_string_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint16_t bString;
-} __packed;
-
-/** Association Descriptor */
-struct usb_association_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint8_t bFirstInterface;
-	uint8_t bInterfaceCount;
-	uint8_t bFunctionClass;
-	uint8_t bFunctionSubClass;
-	uint8_t bFunctionProtocol;
-	uint8_t iFunction;
-} __packed;
-
-/** Standard Configuration Descriptor */
-struct usb_cfg_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint16_t wTotalLength;
-	uint8_t bNumInterfaces;
-	uint8_t bConfigurationValue;
-	uint8_t iConfiguration;
-	uint8_t bmAttributes;
-	uint8_t bMaxPower;
-} __packed;
-
-/** Standard Interface Descriptor */
-struct usb_if_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint8_t bInterfaceNumber;
-	uint8_t bAlternateSetting;
-	uint8_t bNumEndpoints;
-	uint8_t bInterfaceClass;
-	uint8_t bInterfaceSubClass;
-	uint8_t bInterfaceProtocol;
-	uint8_t iInterface;
-} __packed;
-
-/** Standard Endpoint Descriptor */
-struct usb_ep_descriptor {
-	uint8_t bLength;
-	uint8_t bDescriptorType;
-	uint8_t bEndpointAddress;
-	uint8_t bmAttributes;
-	uint16_t wMaxPacketSize;
-	uint8_t bInterval;
-} __packed;
+#define MISC_ETHERNET_PROTOCOL		__DEPRECATED_MACRO 0x01
 
 #endif /* ZEPHYR_INCLUDE_USB_USB_COMMON_H_ */

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -39,7 +39,7 @@
 #define ZEPHYR_INCLUDE_USB_USB_DEVICE_H_
 
 #include <drivers/usb/usb_dc.h>
-#include <usb/usbstruct.h>
+#include <usb/usb_ch9.h>
 #include <logging/log.h>
 
 #ifdef __cplusplus
@@ -82,15 +82,6 @@ extern "C" {
 /*************************************************************************
  *  USB application interface
  **************************************************************************/
-
-/** setup packet definitions */
-struct usb_setup_packet {
-	uint8_t bmRequestType;  /**< characteristics of the specific request */
-	uint8_t bRequest;       /**< specific request */
-	uint16_t wValue;        /**< request specific parameter */
-	uint16_t wIndex;        /**< request specific parameter */
-	uint16_t wLength;       /**< length of data transferred in data phase */
-};
 
 /**
  * @brief USB Device Core Layer API

--- a/include/usb/usbstruct.h
+++ b/include/usb/usbstruct.h
@@ -28,6 +28,11 @@
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * This header and macros below are deprecated in 2.7 release.
+ * Please replace with macros from Chapter 9 header, include/usb/usb_ch9.h
+ */
+
 /**
  * @file
  * @brief standard USB packet structures and defines
@@ -35,58 +40,52 @@
  * This file contains structures and defines of the standard USB packets
  */
 
+#include <usb/usb_ch9.h>
+
 #ifndef ZEPHYR_INCLUDE_USB_USBSTRUCT_H_
 #define ZEPHYR_INCLUDE_USB_USBSTRUCT_H_
 
-#define REQTYPE_GET_DIR(x)          (((x)>>7)&0x01)
-#define REQTYPE_GET_TYPE(x)         (((x)>>5)&0x03U)
-#define REQTYPE_GET_RECIP(x)        ((x)&0x1F)
+#warning "<usb/usbstruct.h> header is deprecated, use <usb/usb_ch9.h> instead"
 
-#define REQTYPE_DIR_TO_DEVICE       0
-#define REQTYPE_DIR_TO_HOST         1
+#define REQTYPE_GET_DIR(x)          __DEPRECATED_MACRO USB_REQTYPE_GET_DIR(x)
+#define REQTYPE_GET_TYPE(x)         __DEPRECATED_MACRO USB_REQTYPE_GET_TYPE(x)
+#define REQTYPE_GET_RECIP(x)        __DEPRECATED_MACRO USB_REQTYPE_GET_RECIPIENT(x)
 
-#define REQTYPE_TYPE_STANDARD       0
-#define REQTYPE_TYPE_CLASS          1
-#define REQTYPE_TYPE_VENDOR         2
-#define REQTYPE_TYPE_RESERVED       3
+#define REQTYPE_DIR_TO_DEVICE       __DEPRECATED_MACRO 0
+#define REQTYPE_DIR_TO_HOST         __DEPRECATED_MACRO 1
 
-#define REQTYPE_RECIP_DEVICE        0
-#define REQTYPE_RECIP_INTERFACE     1
-#define REQTYPE_RECIP_ENDPOINT      2
-#define REQTYPE_RECIP_OTHER         3
+#define REQTYPE_TYPE_STANDARD       __DEPRECATED_MACRO 0
+#define REQTYPE_TYPE_CLASS          __DEPRECATED_MACRO 1
+#define REQTYPE_TYPE_VENDOR         __DEPRECATED_MACRO 2
+#define REQTYPE_TYPE_RESERVED       __DEPRECATED_MACRO 3
+
+#define REQTYPE_RECIP_DEVICE        __DEPRECATED_MACRO 0
+#define REQTYPE_RECIP_INTERFACE     __DEPRECATED_MACRO 1
+#define REQTYPE_RECIP_ENDPOINT      __DEPRECATED_MACRO 2
+#define REQTYPE_RECIP_OTHER         __DEPRECATED_MACRO 3
 
 /* standard requests */
-#define REQ_GET_STATUS              0x00
-#define REQ_CLEAR_FEATURE           0x01
-#define REQ_SET_FEATURE             0x03
-#define REQ_SET_ADDRESS             0x05
-#define REQ_GET_DESCRIPTOR          0x06
-#define REQ_SET_DESCRIPTOR          0x07
-#define REQ_GET_CONFIGURATION       0x08
-#define REQ_SET_CONFIGURATION       0x09
-#define REQ_GET_INTERFACE           0x0A
-#define REQ_SET_INTERFACE           0x0B
-#define REQ_SYNCH_FRAME             0x0C
+#define REQ_GET_STATUS              __DEPRECATED_MACRO 0x00
+#define REQ_CLEAR_FEATURE           __DEPRECATED_MACRO 0x01
+#define REQ_SET_FEATURE             __DEPRECATED_MACRO 0x03
+#define REQ_SET_ADDRESS             __DEPRECATED_MACRO 0x05
+#define REQ_GET_DESCRIPTOR          __DEPRECATED_MACRO 0x06
+#define REQ_SET_DESCRIPTOR          __DEPRECATED_MACRO 0x07
+#define REQ_GET_CONFIGURATION       __DEPRECATED_MACRO 0x08
+#define REQ_SET_CONFIGURATION       __DEPRECATED_MACRO 0x09
+#define REQ_GET_INTERFACE           __DEPRECATED_MACRO 0x0A
+#define REQ_SET_INTERFACE           __DEPRECATED_MACRO 0x0B
+#define REQ_SYNCH_FRAME             __DEPRECATED_MACRO 0x0C
 
 /* feature selectors */
-#define FEA_ENDPOINT_HALT           0x00
-#define FEA_REMOTE_WAKEUP           0x01
-#define FEA_TEST_MODE               0x02
+#define FEA_ENDPOINT_HALT           __DEPRECATED_MACRO 0x00
+#define FEA_REMOTE_WAKEUP           __DEPRECATED_MACRO 0x01
+#define FEA_TEST_MODE               __DEPRECATED_MACRO 0x02
 
-#define DEVICE_STATUS_SELF_POWERED  0x01
-#define DEVICE_STATUS_REMOTE_WAKEUP 0x02
+#define DEVICE_STATUS_SELF_POWERED  __DEPRECATED_MACRO 0x01
+#define DEVICE_STATUS_REMOTE_WAKEUP __DEPRECATED_MACRO 0x02
 
-/*
- *  USB descriptors
- */
-
-/** USB descriptor header */
-struct usb_desc_header {
-	uint8_t bLength;               /**< descriptor length */
-	uint8_t bDescriptorType;       /**< descriptor type */
-};
-
-#define GET_DESC_TYPE(x)            (((x)>>8)&0xFFU)
-#define GET_DESC_INDEX(x)           ((x)&0xFFU)
+#define GET_DESC_TYPE(x)            __DEPRECATED_MACRO USB_GET_DESCRIPTOR_TYPE(x)
+#define GET_DESC_INDEX(x)           __DEPRECATED_MACRO USB_GET_DESCRIPTOR_INDEX(x)
 
 #endif /* ZEPHYR_INCLUDE_USB_USBSTRUCT_H_ */

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -9,7 +9,6 @@
 LOG_MODULE_REGISTER(wpanusb);
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #include <net/buf.h>
@@ -50,7 +49,7 @@ static struct k_thread tx_thread_data;
 #define INITIALIZER_IF(num_ep, iface_class)				\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = num_ep,				\
@@ -63,7 +62,7 @@ static struct k_thread tx_thread_data;
 #define INITIALIZER_IF_EP(addr, attr, mps, interval)			\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\
@@ -74,7 +73,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct {
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
 } __packed wpanusb_desc = {
-	.if0 = INITIALIZER_IF(1, CUSTOM_CLASS),
+	.if0 = INITIALIZER_IF(1, USB_BCC_VENDOR),
 	.if0_in_ep = INITIALIZER_IF_EP(AUTO_EP_IN, USB_DC_EP_BULK,
 				       WPANUSB_BULK_EP_MPS, 0),
 };

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -18,7 +18,6 @@
 LOG_MODULE_REGISTER(main);
 
 #include <sys/byteorder.h>
-#include <usb/usb_common.h>
 #include <usb/usb_device.h>
 #include <usb/bos.h>
 
@@ -60,7 +59,7 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_webusb_desc {
 	.platform = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor)
 			+ sizeof(struct usb_bos_capability_webusb),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		/* WebUSB Platform Capability UUID
@@ -95,7 +94,7 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_msosv2_desc {
 	.platform = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor)
 			+ sizeof(struct usb_bos_capability_msos),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		.PlatformCapabilityUUID = {
@@ -122,7 +121,7 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_msosv2_desc {
 
 USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_capability_lpm bos_cap_lpm = {
 	.bLength = sizeof(struct usb_bos_capability_lpm),
-	.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+	.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 	.bDevCapabilityType = USB_BOS_CAPABILITY_EXTENSION,
 	/**
 	 * BIT(1) - LPM support
@@ -171,7 +170,7 @@ static struct string_desc {
 
 } __packed msos1_string_descriptor = {
 	.bLength = MSOS_STRING_LENGTH,
-	.bDescriptorType = USB_STRING_DESC,
+	.bDescriptorType = USB_DESC_STRING,
 	/* Signature MSFT100 */
 	.bString = {
 		'M', 0x00, 'S', 0x00, 'F', 0x00, 'T', 0x00,
@@ -213,8 +212,8 @@ static const uint8_t msos1_compatid_descriptor[] = {
 int custom_handle_req(struct usb_setup_packet *pSetup,
 		      int32_t *len, uint8_t **data)
 {
-	if (GET_DESC_TYPE(pSetup->wValue) == USB_STRING_DESC &&
-	    GET_DESC_INDEX(pSetup->wValue) == 0xEE) {
+	if (USB_GET_DESCRIPTOR_TYPE(pSetup->wValue) == USB_DESC_STRING &&
+	    USB_GET_DESCRIPTOR_INDEX(pSetup->wValue) == 0xEE) {
 		*data = (uint8_t *)(&msos1_string_descriptor);
 		*len = sizeof(msos1_string_descriptor);
 
@@ -249,7 +248,7 @@ int vendor_handle_req(struct usb_setup_packet *pSetup,
 		return 0;
 	} else if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x02) {
 		/* Get URL request */
-		uint8_t index = GET_DESC_INDEX(pSetup->wValue);
+		uint8_t index = USB_GET_DESCRIPTOR_INDEX(pSetup->wValue);
 
 		if (index == 0U || index > NUMBER_OF_ALLOWED_ORIGINS) {
 			return -ENOTSUP;

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -18,7 +18,6 @@ LOG_MODULE_REGISTER(webusb);
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #include "webusb.h"
@@ -40,7 +39,7 @@ uint8_t rx_buf[64];
 #define INITIALIZER_IF(num_ep, iface_class)				\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = num_ep,				\
@@ -53,7 +52,7 @@ uint8_t rx_buf[64];
 #define INITIALIZER_IF_EP(addr, attr, mps, interval)			\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\
@@ -65,7 +64,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct {
 	struct usb_ep_descriptor if0_in_ep;
 	struct usb_ep_descriptor if0_out_ep;
 } __packed webusb_desc = {
-	.if0 = INITIALIZER_IF(WEBUSB_NUM_EP, CUSTOM_CLASS),
+	.if0 = INITIALIZER_IF(WEBUSB_NUM_EP, USB_BCC_VENDOR),
 	.if0_in_ep = INITIALIZER_IF_EP(AUTO_EP_IN, USB_DC_EP_BULK,
 				       WEBUSB_BULK_EP_MPS, 0),
 	.if0_out_ep = INITIALIZER_IF_EP(AUTO_EP_OUT, USB_DC_EP_BULK,

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -9,7 +9,6 @@
 #include <sys/__assert.h>
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_backend.h>
@@ -35,11 +34,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_device_desc dev_desc = {
 	 */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = CUSTOM_CLASS,
+		.bInterfaceClass = USB_BCC_VENDOR,
 		.bInterfaceSubClass = 0,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -50,7 +49,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_device_desc dev_desc = {
 	 */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = TRACING_IF_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(CONFIG_TRACING_USB_MPS),
@@ -62,7 +61,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_device_desc dev_desc = {
 	 */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = TRACING_IF_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(CONFIG_TRACING_USB_MPS),

--- a/subsys/usb/bos.c
+++ b/subsys/usb/bos.c
@@ -11,7 +11,6 @@ LOG_MODULE_REGISTER(usb_bos);
 #include <zephyr.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 
 #include <usb/bos.h>
 
@@ -20,7 +19,7 @@ extern const uint8_t __usb_bos_desc_end[];
 
 USB_DEVICE_BOS_DESC_DEFINE_HDR struct usb_bos_descriptor bos_hdr = {
 	.bLength = sizeof(struct usb_bos_descriptor),
-	.bDescriptorType = USB_BINARY_OBJECT_STORE_DESC,
+	.bDescriptorType = USB_DESC_BOS,
 	.wTotalLength = 0, /* should be corrected with register */
 	.bNumDeviceCaps = 0, /* should be set with register */
 };
@@ -51,7 +50,7 @@ void usb_bos_register_cap(struct usb_bos_platform_descriptor *desc)
 int usb_handle_bos(struct usb_setup_packet *setup,
 		   int32_t *len, uint8_t **data)
 {
-	if (GET_DESC_TYPE(setup->wValue) == DESCRIPTOR_TYPE_BOS) {
+	if (USB_GET_DESCRIPTOR_TYPE(setup->wValue) == USB_DESC_BOS) {
 		LOG_DBG("Read BOS descriptor");
 		*data = (uint8_t *)usb_bos_get_header();
 		*len = usb_bos_get_length();

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -12,10 +12,8 @@
  */
 
 #include <kernel.h>
-#include <usb/usb_common.h>
 #include <usb/usb_device.h>
 #include <usb_descriptor.h>
-#include <usb/usbstruct.h>
 #include <usb/class/usb_audio.h>
 #include "usb_audio_internal.h"
 
@@ -693,8 +691,7 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 
 	uint8_t iface = (pSetup->wIndex) & 0xFF;
 
-	if (REQTYPE_GET_RECIP(pSetup->bmRequestType) !=
-	    REQTYPE_RECIP_INTERFACE) {
+	if (pSetup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
 		return -EINVAL;
 	}
 
@@ -733,7 +730,7 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 						USB_FORMAT_TYPE_I_DESC_SIZE);
 	}
 
-	if (pSetup->bRequest == REQ_SET_INTERFACE) {
+	if (pSetup->bRequest == USB_SREQ_SET_INTERFACE) {
 		if (ep_desc->bEndpointAddress & USB_EP_DIR_MASK) {
 			audio_dev_data->tx_enable = pSetup->wValue;
 		} else {
@@ -760,8 +757,8 @@ static int audio_class_handle_req(struct usb_setup_packet *pSetup,
 		pSetup->bmRequestType, pSetup->bRequest, pSetup->wValue,
 		pSetup->wIndex, pSetup->wLength);
 
-	switch (REQTYPE_GET_RECIP(pSetup->bmRequestType)) {
-	case REQTYPE_RECIP_INTERFACE:
+	switch (pSetup->RequestType.recipient) {
+	case USB_REQTYPE_RECIPIENT_INTERFACE:
 		return handle_interface_req(pSetup, len, data);
 	default:
 		LOG_ERR("Request recipient invalid");

--- a/subsys/usb/class/audio/usb_audio_internal.h
+++ b/subsys/usb/class/audio/usb_audio_internal.h
@@ -319,10 +319,10 @@ struct dev##_feature_unit_descriptor_##i {	\
 #define INIT_IAD(iface_subclass, if_cnt)			\
 {								\
 	.bLength = sizeof(struct usb_association_descriptor),	\
-	.bDescriptorType = USB_ASSOCIATION_DESC,		\
+	.bDescriptorType = USB_DESC_INTERFACE_ASSOC,		\
 	.bFirstInterface = 0,					\
 	.bInterfaceCount = if_cnt,				\
-	.bFunctionClass = AUDIO_CLASS,				\
+	.bFunctionClass = USB_BCC_AUDIO,			\
 	.bFunctionSubClass = iface_subclass,			\
 	.bFunctionProtocol = 0,					\
 	.iFunction = 0,						\
@@ -385,11 +385,11 @@ struct dev##_descriptor_##i {						\
 #define INIT_STD_IF(iface_subclass, iface_num, alt_setting, eps_num)	\
 {									\
 	.bLength = sizeof(struct usb_if_descriptor),			\
-	.bDescriptorType = USB_INTERFACE_DESC,				\
+	.bDescriptorType = USB_DESC_INTERFACE,				\
 	.bInterfaceNumber = iface_num,					\
 	.bAlternateSetting = alt_setting,				\
 	.bNumEndpoints = eps_num,					\
-	.bInterfaceClass = AUDIO_CLASS,					\
+	.bInterfaceClass = USB_BCC_AUDIO,				\
 	.bInterfaceSubClass = iface_subclass,				\
 	.bInterfaceProtocol = 0,					\
 	.iInterface = 0,						\
@@ -398,7 +398,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_CS_AC_IF(dev, i, ifaces)					\
 {									\
 	.bLength = sizeof(struct dev##_cs_ac_if_descriptor_##i),	\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,			\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,			\
 	.bDescriptorSubtype = USB_AUDIO_HEADER,				\
 	.bcdADC = sys_cpu_to_le16(0x0100),				\
 	.wTotalLength = sys_cpu_to_le16(				\
@@ -413,7 +413,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_CS_AC_IF_BIDIR(dev, i, ifaces)				\
 {									\
 	.bLength = sizeof(struct dev##_cs_ac_if_descriptor_##i),	\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,			\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,			\
 	.bDescriptorSubtype = USB_AUDIO_HEADER,				\
 	.bcdADC = sys_cpu_to_le16(0x0100),				\
 	.wTotalLength = sys_cpu_to_le16(				\
@@ -429,7 +429,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_IN_TERMINAL(dev, i, terminal_id, type)		\
 {								\
 	.bLength = INPUT_TERMINAL_DESC_SIZE,			\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 	.bDescriptorSubtype = USB_AUDIO_INPUT_TERMINAL,		\
 	.bTerminalID = terminal_id,				\
 	.wTerminalType = sys_cpu_to_le16(type),			\
@@ -443,7 +443,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_OUT_TERMINAL(terminal_id, source_id, type)	\
 {							\
 	.bLength = OUTPUT_TERMINAL_DESC_SIZE,		\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,	\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,	\
 	.bDescriptorSubtype = USB_AUDIO_OUTPUT_TERMINAL,\
 	.bTerminalID = terminal_id,			\
 	.wTerminalType = sys_cpu_to_le16(type),		\
@@ -457,7 +457,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_FEATURE_UNIT(dev, i, unit_id, source_id)			\
 {									\
 	.bLength = sizeof(struct dev##_feature_unit_descriptor_##i),	\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,			\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,			\
 	.bDescriptorSubtype = USB_AUDIO_FEATURE_UNIT,			\
 	.bUnitID = unit_id,						\
 	.bSourceID = source_id,						\
@@ -470,7 +470,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_AS_GENERAL(link)				\
 {							\
 	.bLength = USB_AC_CS_IF_DESC_SIZE,		\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,	\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,	\
 	.bDescriptorSubtype = USB_AUDIO_AS_GENERAL,	\
 	.bTerminalLink = link,				\
 	.bDelay = 0,					\
@@ -484,7 +484,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_AS_FORMAT_I(ch_cnt, res)				\
 {								\
 	.bLength = sizeof(struct format_type_i_descriptor),	\
-	.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+	.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 	.bDescriptorSubtype = USB_AUDIO_FORMAT_TYPE,		\
 	.bFormatType = 0x01,					\
 	.bNrChannels = MAX(1, ch_cnt),				\
@@ -497,7 +497,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_STD_AS_AD_EP(dev, i, addr)					\
 {									\
 	.bLength = sizeof(struct std_as_ad_endpoint_descriptor),	\
-	.bDescriptorType = USB_ENDPOINT_DESC,				\
+	.bDescriptorType = USB_DESC_ENDPOINT,				\
 	.bEndpointAddress = addr,					\
 	.bmAttributes = (USB_DC_EP_ISOCHRONOUS | SYNC_TYPE(dev, i)),	\
 	.wMaxPacketSize = sys_cpu_to_le16(EP_SIZE(dev, i)),		\
@@ -509,7 +509,7 @@ struct dev##_descriptor_##i {						\
 #define INIT_CS_AS_AD_EP					\
 {								\
 	.bLength = sizeof(struct cs_as_ad_ep_descriptor),	\
-	.bDescriptorType = USB_CS_ENDPOINT_DESC,		\
+	.bDescriptorType = USB_DESC_CS_ENDPOINT,		\
 	.bDescriptorSubtype = 0x01,				\
 	.bmAttributes = 0x00,					\
 	.bLockDelayUnits = 0x00,				\

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -10,7 +10,6 @@
 #include <sys/byteorder.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #include <net/buf.h>
@@ -24,6 +23,9 @@
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(usb_bluetooth);
+
+#define USB_RF_SUBCLASS			0x01
+#define USB_BLUETOOTH_PROTOCOL		0x01
 
 static K_FIFO_DEFINE(rx_queue);
 static K_FIFO_DEFINE(tx_queue);
@@ -56,20 +58,20 @@ USBD_CLASS_DESCR_DEFINE(primary, 0)
 	/* Interface descriptor 0 */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 3,
-		.bInterfaceClass = WIRELESS_DEVICE_CLASS,
-		.bInterfaceSubClass = RF_SUBCLASS,
-		.bInterfaceProtocol = BLUETOOTH_PROTOCOL,
+		.bInterfaceClass = USB_BCC_WIRELESS_CONTROLLER,
+		.bInterfaceSubClass = USB_RF_SUBCLASS,
+		.bInterfaceProtocol = USB_BLUETOOTH_PROTOCOL,
 		.iInterface = 0,
 	},
 
 	/* Interrupt Endpoint */
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = BLUETOOTH_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize = sys_cpu_to_le16(USB_MAX_FS_INT_MPS),
@@ -79,7 +81,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0)
 	/* Data Endpoint OUT */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = BLUETOOTH_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(USB_MAX_FS_BULK_MPS),
@@ -89,7 +91,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0)
 	/* Data Endpoint IN */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = BLUETOOTH_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(USB_MAX_FS_BULK_MPS),

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -10,7 +10,6 @@
 #include <sys/byteorder.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #include <net/buf.h>
@@ -52,11 +51,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_bt_h4_config bt_h4_cfg = {
 	/* Interface descriptor 0 */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = CUSTOM_CLASS, /* TBD */
+		.bInterfaceClass = USB_BCC_VENDOR, /* TBD */
 		.bInterfaceSubClass = 0,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -65,7 +64,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_bt_h4_config bt_h4_cfg = {
 	/* Data Endpoint OUT */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = BT_H4_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(USB_MAX_FS_BULK_MPS),
@@ -75,7 +74,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_bt_h4_config bt_h4_cfg = {
 	/* Data Endpoint IN */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = BT_H4_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(USB_MAX_FS_BULK_MPS),
@@ -203,17 +202,17 @@ static int bt_h4_vendor_handler(struct usb_setup_packet *setup,
 	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
-	if (REQTYPE_GET_RECIP(setup->bmRequestType) != REQTYPE_RECIP_DEVICE) {
+	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
 		return -ENOTSUP;
 	}
 
-	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_DEVICE &&
+	if (usb_reqtype_is_to_device(setup) &&
 	    setup->bRequest == 0x5b) {
 		LOG_DBG("Host-to-Device, data %p", *data);
 		return 0;
 	}
 
-	if ((REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) &&
+	if ((usb_reqtype_is_to_host(setup)) &&
 	    (setup->bRequest == 0x5c)) {
 		LOG_DBG("Device-to-Host, wLength %d, data %p",
 			setup->wLength, *data);

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -46,7 +46,6 @@
 #include <sys/byteorder.h>
 #include <usb/class/usb_cdc.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 #include <usb_work_q.h>
 
@@ -95,10 +94,10 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IAD							\
 	{								\
 		.bLength = sizeof(struct usb_association_descriptor),	\
-		.bDescriptorType = USB_ASSOCIATION_DESC,		\
+		.bDescriptorType = USB_DESC_INTERFACE_ASSOC,		\
 		.bFirstInterface = 0,					\
 		.bInterfaceCount = 0x02,				\
-		.bFunctionClass = COMMUNICATION_DEVICE_CLASS,		\
+		.bFunctionClass = USB_BCC_CDC_CONTROL,			\
 		.bFunctionSubClass = ACM_SUBCLASS,			\
 		.bFunctionProtocol = 0,					\
 		.iFunction = 0,						\
@@ -107,7 +106,7 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IF(iface_num, num_ep, class, subclass)		\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = iface_num,				\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = num_ep,				\
@@ -120,15 +119,15 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IF_HDR						\
 	{								\
 		.bFunctionLength = sizeof(struct cdc_header_descriptor),\
-		.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+		.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 		.bDescriptorSubtype = HEADER_FUNC_DESC,			\
-		.bcdCDC = sys_cpu_to_le16(USB_1_1),			\
+		.bcdCDC = sys_cpu_to_le16(USB_SRN_1_1),			\
 	}
 
 #define INITIALIZER_IF_CM						\
 	{								\
 		.bFunctionLength = sizeof(struct cdc_cm_descriptor),	\
-		.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+		.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 		.bDescriptorSubtype = CALL_MANAGEMENT_FUNC_DESC,	\
 		.bmCapabilities = 0x02,					\
 		.bDataInterface = 1,					\
@@ -143,7 +142,7 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IF_ACM						\
 	{								\
 		.bFunctionLength = sizeof(struct cdc_acm_descriptor),	\
-		.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+		.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 		.bDescriptorSubtype = ACM_FUNC_DESC,			\
 		.bmCapabilities = 0x02,					\
 	}
@@ -151,7 +150,7 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IF_UNION						\
 	{								\
 		.bFunctionLength = sizeof(struct cdc_union_descriptor),	\
-		.bDescriptorType = USB_CS_INTERFACE_DESC,		\
+		.bDescriptorType = USB_DESC_CS_INTERFACE,		\
 		.bDescriptorSubtype = UNION_FUNC_DESC,			\
 		.bControlInterface = 0,					\
 		.bSubordinateInterface0 = 1,				\
@@ -160,7 +159,7 @@ struct usb_cdc_acm_config {
 #define INITIALIZER_IF_EP(addr, attr, mps, interval)			\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\
@@ -1044,11 +1043,11 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 	};
 
 #if (CONFIG_USB_COMPOSITE_DEVICE || CONFIG_CDC_ACM_IAD)
-#define DEFINE_CDC_ACM_DESCR(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
+#define DEFINE_CDC_ACM_DESC(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
 	USBD_CLASS_DESCR_DEFINE(primary, x)				\
 	struct usb_cdc_acm_config cdc_acm_cfg_##x = {			\
 	.iad_cdc = INITIALIZER_IAD,					\
-	.if0 = INITIALIZER_IF(0, 1, COMMUNICATION_DEVICE_CLASS,		\
+	.if0 = INITIALIZER_IF(0, 1, USB_BCC_CDC_CONTROL,		\
 			      ACM_SUBCLASS),				\
 	.if0_header = INITIALIZER_IF_HDR,				\
 	.if0_cm = INITIALIZER_IF_CM,					\
@@ -1058,7 +1057,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 					USB_DC_EP_INTERRUPT,		\
 					CONFIG_CDC_ACM_INTERRUPT_EP_MPS,\
 					0x0A),				\
-	.if1 = INITIALIZER_IF(1, 2, COMMUNICATION_DEVICE_CLASS_DATA, 0),\
+	.if1 = INITIALIZER_IF(1, 2, USB_BCC_CDC_DATA, 0),		\
 	.if1_in_ep = INITIALIZER_IF_EP(in_ep_addr,			\
 				       USB_DC_EP_BULK,			\
 				       CONFIG_CDC_ACM_BULK_EP_MPS,	\
@@ -1069,10 +1068,10 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 					0x00),				\
 }
 #else /* (CONFIG_USB_COMPOSITE_DEVICE || CONFIG_CDC_ACM_IAD) */
-#define DEFINE_CDC_ACM_DESCR(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
+#define DEFINE_CDC_ACM_DESC(x, int_ep_addr, out_ep_addr, in_ep_addr)	\
 	USBD_CLASS_DESCR_DEFINE(primary, x)				\
 	struct usb_cdc_acm_config cdc_acm_cfg_##x = {			\
-	.if0 = INITIALIZER_IF(0, 1, COMMUNICATION_DEVICE_CLASS,		\
+	.if0 = INITIALIZER_IF(0, 1, USB_BCC_CDC_CONTROL,		\
 			      ACM_SUBCLASS),				\
 	.if0_header = INITIALIZER_IF_HDR,				\
 	.if0_cm = INITIALIZER_IF_CM,					\
@@ -1082,7 +1081,7 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 					USB_DC_EP_INTERRUPT,		\
 					CONFIG_CDC_ACM_INTERRUPT_EP_MPS,\
 					0x0A),				\
-	.if1 = INITIALIZER_IF(1, 2, COMMUNICATION_DEVICE_CLASS_DATA, 0),\
+	.if1 = INITIALIZER_IF(1, 2, USB_BCC_CDC_DATA, 0),		\
 	.if1_in_ep = INITIALIZER_IF_EP(in_ep_addr,			\
 				       USB_DC_EP_BULK,			\
 				       CONFIG_CDC_ACM_BULK_EP_MPS,	\
@@ -1115,13 +1114,13 @@ static const struct uart_driver_api cdc_acm_driver_api = {
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 			    &cdc_acm_driver_api);
 
-#define DEFINE_CDC_ACM_DESCR_AUTO(x, _) \
-	DEFINE_CDC_ACM_DESCR(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
+#define DEFINE_CDC_ACM_DESC_AUTO(x, _) \
+	DEFINE_CDC_ACM_DESC(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
 #define DEFINE_CDC_ACM_EP_AUTO(x, _) \
 	DEFINE_CDC_ACM_EP(x, AUTO_EP_IN, AUTO_EP_OUT, AUTO_EP_IN);
 
-UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DESCR_AUTO, _)
+UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DESC_AUTO, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_EP_AUTO, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_CFG_DATA, _)
 UTIL_LISTIFY(CONFIG_USB_CDC_ACM_DEVICE_COUNT, DEFINE_CDC_ACM_DEV_DATA, _)

--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -48,7 +48,6 @@
 #include <dfu/flash_img.h>
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb/class/usb_dfu.h>
 #include <usb_descriptor.h>
 #include <usb_work_q.h>
@@ -89,11 +88,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_dfu_config dfu_cfg = {
 	/* Interface descriptor */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 0,
-		.bInterfaceClass = DFU_DEVICE_CLASS,
+		.bInterfaceClass = USB_BCC_APPLICATION,
 		.bInterfaceSubClass = DFU_SUBCLASS,
 		.bInterfaceProtocol = DFU_RT_PROTOCOL,
 		.iInterface = 0,
@@ -133,8 +132,8 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 	/* Device descriptor */
 	.device_descriptor = {
 		.bLength = sizeof(struct usb_device_descriptor),
-		.bDescriptorType = USB_DEVICE_DESC,
-		.bcdUSB = sys_cpu_to_le16(USB_2_0),
+		.bDescriptorType = USB_DESC_DEVICE,
+		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_0),
 		.bDeviceClass = 0,
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = 0,
@@ -142,7 +141,7 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 		.idVendor = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_VID),
 		.idProduct =
 			sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_DFU_PID),
-		.bcdDevice = sys_cpu_to_le16(BCDDEVICE_RELNUM),
+		.bcdDevice = sys_cpu_to_le16(USB_BCD_DRN),
 		.iManufacturer = 1,
 		.iProduct = 2,
 		.iSerialNumber = 3,
@@ -151,23 +150,23 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 	/* Configuration descriptor */
 	.cfg_descr = {
 		.bLength = sizeof(struct usb_cfg_descriptor),
-		.bDescriptorType = USB_CONFIGURATION_DESC,
+		.bDescriptorType = USB_DESC_CONFIGURATION,
 		.wTotalLength = 0,
 		.bNumInterfaces = 1,
 		.bConfigurationValue = 1,
 		.iConfiguration = 0,
-		.bmAttributes = USB_CONFIGURATION_ATTRIBUTES,
+		.bmAttributes = USB_SCD_ATTRIBUTES,
 		.bMaxPower = CONFIG_USB_MAX_POWER,
 	},
 	.sec_dfu_cfg = {
 		/* Interface descriptor */
 		.if0 = {
 			.bLength = sizeof(struct usb_if_descriptor),
-			.bDescriptorType = USB_INTERFACE_DESC,
+			.bDescriptorType = USB_DESC_INTERFACE,
 			.bInterfaceNumber = 0,
 			.bAlternateSetting = 0,
 			.bNumEndpoints = 0,
-			.bInterfaceClass = DFU_DEVICE_CLASS,
+			.bInterfaceClass = USB_BCC_APPLICATION,
 			.bInterfaceSubClass = DFU_SUBCLASS,
 			.bInterfaceProtocol = DFU_MODE_PROTOCOL,
 			.iInterface = 4,
@@ -175,11 +174,11 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 #if FLASH_AREA_LABEL_EXISTS(image_1)
 		.if1 = {
 			.bLength = sizeof(struct usb_if_descriptor),
-			.bDescriptorType = USB_INTERFACE_DESC,
+			.bDescriptorType = USB_DESC_INTERFACE,
 			.bInterfaceNumber = 0,
 			.bAlternateSetting = 1,
 			.bNumEndpoints = 0,
-			.bInterfaceClass = DFU_DEVICE_CLASS,
+			.bInterfaceClass = USB_BCC_APPLICATION,
 			.bInterfaceSubClass = DFU_SUBCLASS,
 			.bInterfaceProtocol = DFU_MODE_PROTOCOL,
 			.iInterface = 5,
@@ -241,34 +240,34 @@ USBD_STRING_DESCR_DEFINE(secondary)
 struct usb_string_desription string_descr = {
 	.lang_descr = {
 		.bLength = sizeof(struct usb_string_descriptor),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = sys_cpu_to_le16(0x0409),
 	},
 	/* Manufacturer String Descriptor */
 	.utf16le_mfr = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				CONFIG_USB_DEVICE_MANUFACTURER),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_MANUFACTURER,
 	},
 	/* Product String Descriptor */
 	.utf16le_product = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				CONFIG_USB_DEVICE_PRODUCT),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_PRODUCT,
 	},
 	/* Serial Number String Descriptor */
 	.utf16le_sn = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(CONFIG_USB_DEVICE_SN),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_SN,
 	},
 	/* Image 0 String Descriptor */
 	.utf16le_image0 = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				FIRMWARE_IMAGE_0_LABEL),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = FIRMWARE_IMAGE_0_LABEL,
 	},
 #if FLASH_AREA_LABEL_EXISTS(image_1)
@@ -276,7 +275,7 @@ struct usb_string_desription string_descr = {
 	.utf16le_image1 = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				FIRMWARE_IMAGE_1_LABEL),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = FIRMWARE_IMAGE_1_LABEL,
 	},
 #endif
@@ -681,9 +680,8 @@ static int dfu_custom_handle_req(struct usb_setup_packet *pSetup,
 {
 	ARG_UNUSED(data);
 
-	if (REQTYPE_GET_RECIP(pSetup->bmRequestType) ==
-	    REQTYPE_RECIP_INTERFACE) {
-		if (pSetup->bRequest == REQ_SET_INTERFACE) {
+	if (pSetup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE) {
+		if (pSetup->bRequest == USB_SREQ_SET_INTERFACE) {
 			LOG_DBG("DFU alternate setting %d", pSetup->wValue);
 
 			const struct flash_area *fa;

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(usb_hid);
 
 #include <sys/byteorder.h>
 #include <usb_device.h>
-#include <usb_common.h>
 
 #include <usb_descriptor.h>
 #include <class/usb_hid.h>
@@ -55,11 +54,11 @@ struct usb_hid_config {
 #define INITIALIZER_IF							\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = 1,					\
-		.bInterfaceClass = HID_CLASS,				\
+		.bInterfaceClass = USB_BCC_HID,				\
 		.bInterfaceSubClass = 1,				\
 		.bInterfaceProtocol = CONFIG_USB_HID_PROTOCOL_CODE,	\
 		.iInterface = 0,					\
@@ -68,11 +67,11 @@ struct usb_hid_config {
 #define INITIALIZER_IF							\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = 1,					\
-		.bInterfaceClass = HID_CLASS,				\
+		.bInterfaceClass = USB_BCC_HID,				\
 		.bInterfaceSubClass = 0,				\
 		.bInterfaceProtocol = 0,				\
 		.iInterface = 0,					\
@@ -83,12 +82,12 @@ struct usb_hid_config {
 #define INITIALIZER_IF_HID						\
 	{								\
 		.bLength = sizeof(struct usb_hid_descriptor),		\
-		.bDescriptorType = USB_HID_DESC,			\
-		.bcdHID = sys_cpu_to_le16(USB_1_1),			\
+		.bDescriptorType = USB_DESC_HID,			\
+		.bcdHID = sys_cpu_to_le16(USB_SRN_1_1),			\
 		.bCountryCode = 0,					\
 		.bNumDescriptors = 1,					\
 		.subdesc[0] = {						\
-			.bDescriptorType = USB_HID_REPORT_DESC,		\
+			.bDescriptorType = USB_DESC_HID_REPORT,	\
 			.wDescriptorLength = 0,				\
 		},							\
 	}
@@ -96,7 +95,7 @@ struct usb_hid_config {
 #define INITIALIZER_IF_EP(addr, attr, mps)				\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\
@@ -449,7 +448,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	dev_data = CONTAINER_OF(common, struct hid_device_info, common);
 	dev = common->dev;
 
-	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) {
+	if (usb_reqtype_is_to_host(setup)) {
 		switch (setup->bRequest) {
 		case USB_HID_GET_IDLE:
 			return hid_on_get_idle(dev_data, setup, len, data);
@@ -499,10 +498,9 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 		"bRequest 0x%02x, bmRequestType 0x%02x, len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
-	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST &&
-	    REQTYPE_GET_RECIP(setup->bmRequestType) ==
-					REQTYPE_RECIP_INTERFACE &&
-					setup->bRequest == REQ_GET_DESCRIPTOR) {
+	if (usb_reqtype_is_to_host(setup) &&
+	    setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE &&
+	    setup->bRequest == USB_SREQ_GET_DESCRIPTOR) {
 		uint8_t value = (uint8_t)(setup->wValue >> 8);
 		uint8_t iface_num = (uint8_t)setup->wIndex;
 		struct hid_device_info *dev_data;

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -10,7 +10,6 @@
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
@@ -36,11 +35,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_loopback_config loopback_cfg = {
 	/* Interface descriptor 0 */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = CUSTOM_CLASS,
+		.bInterfaceClass = USB_BCC_VENDOR,
 		.bInterfaceSubClass = 0,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -49,7 +48,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_loopback_config loopback_cfg = {
 	/* Data Endpoint OUT */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = LOOPBACK_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(CONFIG_LOOPBACK_BULK_EP_MPS),
@@ -59,7 +58,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_loopback_config loopback_cfg = {
 	/* Data Endpoint IN */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = LOOPBACK_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize = sys_cpu_to_le16(CONFIG_LOOPBACK_BULK_EP_MPS),
@@ -129,17 +128,17 @@ static int loopback_vendor_handler(struct usb_setup_packet *setup,
 	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
-	if (REQTYPE_GET_RECIP(setup->bmRequestType) != REQTYPE_RECIP_DEVICE) {
+	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
 		return -ENOTSUP;
 	}
 
-	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_DEVICE &&
+	if (usb_reqtype_is_to_device(setup) &&
 	    setup->bRequest == 0x5b) {
 		LOG_DBG("Host-to-Device, data %p", *data);
 		return 0;
 	}
 
-	if ((REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) &&
+	if ((usb_reqtype_is_to_host(setup)) &&
 	    (setup->bRequest == 0x5c)) {
 		LOG_DBG("Device-to-Host, wLength %d, data %p",
 			setup->wLength, *data);

--- a/subsys/usb/class/msc.c
+++ b/subsys/usb/class/msc.c
@@ -41,7 +41,6 @@
 #include <storage/disk_access.h>
 #include <usb/class/usb_msc.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #define LOG_LEVEL CONFIG_USB_MASS_STORAGE_LOG_LEVEL
@@ -71,19 +70,19 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_mass_config mass_cfg = {
 	/* Interface descriptor */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = MASS_STORAGE_CLASS,
+		.bInterfaceClass = USB_BCC_MASS_STORAGE,
 		.bInterfaceSubClass = SCSI_TRANSPARENT_SUBCLASS,
-		.bInterfaceProtocol = BULK_ONLY_PROTOCOL,
+		.bInterfaceProtocol = BULK_ONLY_TRANSPORT_PROTOCOL,
 		.iInterface = 0,
 	},
 	/* First Endpoint IN */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = MASS_STORAGE_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -93,7 +92,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_mass_config mass_cfg = {
 	/* Second Endpoint OUT */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = MASS_STORAGE_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(usb_ecm);
 #include <net_private.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb/class/usb_cdc.h>
 #include <usb_descriptor.h>
 
@@ -53,10 +52,10 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
 	.iad = {
 		.bLength = sizeof(struct usb_association_descriptor),
-		.bDescriptorType = USB_ASSOCIATION_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE_ASSOC,
 		.bFirstInterface = 0,
 		.bInterfaceCount = 0x02,
-		.bFunctionClass = COMMUNICATION_DEVICE_CLASS,
+		.bFunctionClass = USB_BCC_CDC_CONTROL,
 		.bFunctionSubClass = ECM_SUBCLASS,
 		.bFunctionProtocol = 0,
 		.iFunction = 0,
@@ -66,11 +65,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* CDC Communication interface */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 1,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS,
+		.bInterfaceClass = USB_BCC_CDC_CONTROL,
 		.bInterfaceSubClass = ECM_SUBCLASS,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -78,14 +77,14 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* Header Functional Descriptor */
 	.if0_header = {
 		.bFunctionLength = sizeof(struct cdc_header_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = HEADER_FUNC_DESC,
-		.bcdCDC = sys_cpu_to_le16(USB_1_1),
+		.bcdCDC = sys_cpu_to_le16(USB_SRN_1_1),
 	},
 	/* Union Functional Descriptor */
 	.if0_union = {
 		.bFunctionLength = sizeof(struct cdc_union_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = UNION_FUNC_DESC,
 		.bControlInterface = 0,
 		.bSubordinateInterface0 = 1,
@@ -93,7 +92,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* Ethernet Networking Functional descriptor */
 	.if0_netfun_ecm = {
 		.bFunctionLength = sizeof(struct cdc_ecm_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC,
 		.iMACAddress = 4,
 		.bmEthernetStatistics = sys_cpu_to_le32(0), /* None */
@@ -104,7 +103,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* Notification EP Descriptor */
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = CDC_ECM_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
@@ -117,11 +116,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* CDC Data Interface */
 	.if1_0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 1,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 0,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS_DATA,
+		.bInterfaceClass = USB_BCC_CDC_DATA,
 		.bInterfaceSubClass = 0,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -131,11 +130,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* CDC Data Interface */
 	.if1_1 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 1,
 		.bAlternateSetting = 1,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS_DATA,
+		.bInterfaceClass = USB_BCC_CDC_DATA,
 		.bInterfaceSubClass = ECM_SUBCLASS,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -143,7 +142,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* Data Endpoint IN */
 	.if1_1_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = CDC_ECM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -154,7 +153,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	/* Data Endpoint OUT */
 	.if1_1_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = CDC_ECM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -402,7 +401,7 @@ struct usb_cdc_ecm_mac_descr {
 USBD_STRING_DESCR_DEFINE(primary) struct usb_cdc_ecm_mac_descr utf16le_mac = {
 	.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 			CONFIG_USB_DEVICE_NETWORK_ECM_MAC),
-	.bDescriptorType = USB_STRING_DESC,
+	.bDescriptorType = USB_DESC_STRING,
 	.bString = CONFIG_USB_DEVICE_NETWORK_ECM_MAC
 };
 

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(usb_eem);
 #include <net_private.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb/class/usb_cdc.h>
 
 #include "netusb.h"
@@ -36,11 +35,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_eem_config cdc_eem_cfg = {
 	/* CDC Communication interface */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS,
+		.bInterfaceClass = USB_BCC_CDC_CONTROL,
 		.bInterfaceSubClass = EEM_SUBCLASS,
 		.bInterfaceProtocol = EEM_PROTOCOL,
 		.iInterface = 0,
@@ -49,7 +48,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_eem_config cdc_eem_cfg = {
 	/* Data Endpoint IN */
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = CDC_EEM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -60,7 +59,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_eem_config cdc_eem_cfg = {
 	/* Data Endpoint OUT */
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = CDC_EEM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -17,7 +17,6 @@ LOG_MODULE_REGISTER(usb_rndis);
 #include <net_private.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb/class/usb_cdc.h>
 #include <os_desc.h>
 
@@ -64,10 +63,10 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
 	.iad = {
 		.bLength = sizeof(struct usb_association_descriptor),
-		.bDescriptorType = USB_ASSOCIATION_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE_ASSOC,
 		.bFirstInterface = 0,
 		.bInterfaceCount = 0x02,
-		.bFunctionClass = COMMUNICATION_DEVICE_CLASS,
+		.bFunctionClass = USB_BCC_CDC_CONTROL,
 		.bFunctionSubClass = 6,
 		.bFunctionProtocol = 0,
 		.iFunction = 0,
@@ -77,11 +76,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* CDC Communication interface */
 	.if0 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 1,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS,
+		.bInterfaceClass = USB_BCC_CDC_CONTROL,
 		.bInterfaceSubClass = ACM_SUBCLASS,
 		.bInterfaceProtocol = ACM_VENDOR_PROTOCOL,
 		.iInterface = 0,
@@ -89,14 +88,14 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* Header Functional Descriptor */
 	.if0_header = {
 		.bFunctionLength = sizeof(struct cdc_header_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = HEADER_FUNC_DESC,
-		.bcdCDC = sys_cpu_to_le16(USB_1_1),
+		.bcdCDC = sys_cpu_to_le16(USB_SRN_1_1),
 	},
 	/* Call Management Functional Descriptor */
 	.if0_cm = {
 		.bFunctionLength = sizeof(struct cdc_cm_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = CALL_MANAGEMENT_FUNC_DESC,
 		.bmCapabilities = 0x00,
 		.bDataInterface = 1,
@@ -104,7 +103,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* ACM Functional Descriptor */
 	.if0_acm = {
 		.bFunctionLength = sizeof(struct cdc_acm_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = ACM_FUNC_DESC,
 		/* Device supports the request combination of:
 		 *	Set_Line_Coding,
@@ -117,7 +116,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* Union Functional Descriptor */
 	.if0_union = {
 		.bFunctionLength = sizeof(struct cdc_union_descriptor),
-		.bDescriptorType = USB_CS_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_CS_INTERFACE,
 		.bDescriptorSubtype = UNION_FUNC_DESC,
 		.bControlInterface = 0,
 		.bSubordinateInterface0 = 1,
@@ -125,7 +124,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* Notification EP Descriptor */
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = RNDIS_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
@@ -137,11 +136,11 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* CDC Data Interface */
 	.if1 = {
 		.bLength = sizeof(struct usb_if_descriptor),
-		.bDescriptorType = USB_INTERFACE_DESC,
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 1,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 2,
-		.bInterfaceClass = COMMUNICATION_DEVICE_CLASS_DATA,
+		.bInterfaceClass = USB_BCC_CDC_DATA,
 		.bInterfaceSubClass = 0,
 		.bInterfaceProtocol = 0,
 		.iInterface = 0,
@@ -149,7 +148,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* Data Endpoint IN */
 	.if1_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = RNDIS_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -159,7 +158,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_rndis_config rndis_cfg = {
 	/* Data Endpoint OUT */
 	.if1_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
-		.bDescriptorType = USB_ENDPOINT_DESC,
+		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = RNDIS_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
@@ -903,15 +902,14 @@ static int rndis_class_handler(struct usb_setup_packet *setup, int32_t *len,
 	}
 
 	if (setup->bRequest == CDC_SEND_ENC_CMD &&
-	    REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_DEVICE) {
+	    usb_reqtype_is_to_device(setup)) {
 		/*
 		 * Instead of handling here, queue
 		 * handle_encapsulated_cmd(*data, *len);
 		 */
 		queue_encapsulated_cmd(*data, *len);
 	} else if (setup->bRequest == CDC_GET_ENC_RSP &&
-		   REQTYPE_GET_DIR(setup->bmRequestType) ==
-		   REQTYPE_DIR_TO_HOST) {
+		   usb_reqtype_is_to_host(setup)) {
 		handle_encapsulated_rsp(data, len);
 	} else {
 		*len = 0; /* FIXME! */
@@ -1015,7 +1013,7 @@ static struct string_desc {
 	uint8_t bPad;
 } __packed msosv1_string_descriptor = {
 	.bLength = MSOS_STRING_LENGTH,
-	.bDescriptorType = USB_STRING_DESC,
+	.bDescriptorType = USB_DESC_STRING,
 	/* Signature MSFT100 */
 	.bString = {
 		'M', 0x00, 'S', 0x00, 'F', 0x00, 'T', 0x00,

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(usb_net);
 #include <net_private.h>
 
 #include <usb_device.h>
-#include <usb_common.h>
 #include <usb_descriptor.h>
 
 #include "netusb.h"

--- a/subsys/usb/os_desc.c
+++ b/subsys/usb/os_desc.c
@@ -11,7 +11,6 @@ LOG_MODULE_REGISTER(usb_os_desc);
 #include <zephyr.h>
 
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <os_desc.h>
 
 static struct usb_os_descriptor *os_desc;
@@ -23,8 +22,8 @@ int usb_handle_os_desc(struct usb_setup_packet *setup,
 		return -ENOTSUP;
 	}
 
-	if (GET_DESC_TYPE(setup->wValue) == USB_STRING_DESC &&
-	    GET_DESC_INDEX(setup->wValue) == USB_OSDESC_STRING_DESC_INDEX) {
+	if (USB_GET_DESCRIPTOR_TYPE(setup->wValue) == USB_DESC_STRING &&
+	    USB_GET_DESCRIPTOR_INDEX(setup->wValue) == USB_OSDESC_STRING_DESC_INDEX) {
 		LOG_DBG("MS OS Descriptor string read");
 		*data = os_desc->string;
 		*len = os_desc->string_len;

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -10,9 +10,7 @@
 #include <string.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
-#include <usb/usbstruct.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include "usb_descriptor.h"
 #include <drivers/hwinfo.h>
 
@@ -59,14 +57,14 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 	/* Device descriptor */
 	.device_descriptor = {
 		.bLength = sizeof(struct usb_device_descriptor),
-		.bDescriptorType = USB_DEVICE_DESC,
+		.bDescriptorType = USB_DESC_DEVICE,
 #ifdef CONFIG_USB_DEVICE_BOS
-		.bcdUSB = sys_cpu_to_le16(USB_2_1),
+		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_1),
 #else
-		.bcdUSB = sys_cpu_to_le16(USB_2_0),
+		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_0),
 #endif
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
-		.bDeviceClass = MISC_CLASS,
+		.bDeviceClass = USB_BCC_MISCELLANEOUS,
 		.bDeviceSubClass = 0x02,
 		.bDeviceProtocol = 0x01,
 #else
@@ -77,7 +75,7 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 		.bMaxPacketSize0 = USB_MAX_CTRL_MPS,
 		.idVendor = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_VID),
 		.idProduct = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_PID),
-		.bcdDevice = sys_cpu_to_le16(BCDDEVICE_RELNUM),
+		.bcdDevice = sys_cpu_to_le16(USB_BCD_DRN),
 		.iManufacturer = USB_DESC_MANUFACTURER_IDX,
 		.iProduct = USB_DESC_PRODUCT_IDX,
 		.iSerialNumber = USB_DESC_SERIAL_NUMBER_IDX,
@@ -86,13 +84,13 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 	/* Configuration descriptor */
 	.cfg_descr = {
 		.bLength = sizeof(struct usb_cfg_descriptor),
-		.bDescriptorType = USB_CONFIGURATION_DESC,
+		.bDescriptorType = USB_DESC_CONFIGURATION,
 		/*wTotalLength will be fixed in usb_fix_descriptor() */
 		.wTotalLength = 0,
 		.bNumInterfaces = 0,
 		.bConfigurationValue = 1,
 		.iConfiguration = 0,
-		.bmAttributes = USB_CONFIGURATION_ATTRIBUTES,
+		.bmAttributes = USB_SCD_ATTRIBUTES,
 		.bMaxPower = CONFIG_USB_MAX_POWER,
 	},
 };
@@ -127,27 +125,27 @@ struct usb_string_desription {
 USBD_STRING_DESCR_DEFINE(primary) struct usb_string_desription string_descr = {
 	.lang_descr = {
 		.bLength = sizeof(struct usb_string_descriptor),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = sys_cpu_to_le16(0x0409),
 	},
 	/* Manufacturer String Descriptor */
 	.utf16le_mfr = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				CONFIG_USB_DEVICE_MANUFACTURER),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_MANUFACTURER,
 	},
 	/* Product String Descriptor */
 	.utf16le_product = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(
 				CONFIG_USB_DEVICE_PRODUCT),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_PRODUCT,
 	},
 	/* Serial Number String Descriptor */
 	.utf16le_sn = {
 		.bLength = USB_STRING_DESCRIPTOR_LENGTH(CONFIG_USB_DEVICE_SN),
-		.bDescriptorType = USB_STRING_DESC,
+		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_SN,
 	},
 };
@@ -198,7 +196,7 @@ int usb_get_str_descriptor_idx(void *ptr)
 
 	while (head->bLength != 0U) {
 		switch (head->bDescriptorType) {
-		case USB_STRING_DESC:
+		case USB_DESC_STRING:
 			if (head == (struct usb_desc_header *)str) {
 				return str_descr_idx;
 			}
@@ -380,14 +378,14 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 	while (head->bLength != 0U) {
 		switch (head->bDescriptorType) {
-		case USB_CONFIGURATION_DESC:
+		case USB_DESC_CONFIGURATION:
 			cfg_descr = (struct usb_cfg_descriptor *)head;
 			LOG_DBG("Configuration descriptor %p", head);
 			break;
-		case USB_ASSOCIATION_DESC:
+		case USB_DESC_INTERFACE_ASSOC:
 			LOG_DBG("Association descriptor %p", head);
 			break;
-		case USB_INTERFACE_DESC:
+		case USB_DESC_INTERFACE:
 			if_descr = (struct usb_if_descriptor *)head;
 			LOG_DBG("Interface descriptor %p", head);
 			if (if_descr->bAlternateSetting) {
@@ -411,7 +409,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 			numof_ifaces++;
 			break;
-		case USB_ENDPOINT_DESC:
+		case USB_DESC_ENDPOINT:
 			if (!cfg_data) {
 				LOG_ERR("Uninitialized usb_cfg_data pointer, "
 					"corrupted device descriptor?");
@@ -429,7 +427,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 			break;
 		case 0:
-		case USB_STRING_DESC:
+		case USB_DESC_STRING:
 			/*
 			 * Copy runtime SN string descriptor first, if has
 			 */

--- a/tests/subsys/usb/bos/src/test_bos.c
+++ b/tests/subsys/usb/bos/src/test_bos.c
@@ -9,7 +9,6 @@
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 
 #include <usb/bos.h>
 
@@ -33,7 +32,7 @@ static struct webusb_bos_desc {
 } __packed webusb_bos_descriptor = {
 	.bos = {
 		.bLength = sizeof(struct usb_bos_descriptor),
-		.bDescriptorType = USB_BINARY_OBJECT_STORE_DESC,
+		.bDescriptorType = USB_DESC_BOS,
 		.wTotalLength = sizeof(struct webusb_bos_desc),
 		.bNumDeviceCaps = 2,
 	},
@@ -43,7 +42,7 @@ static struct webusb_bos_desc {
 	.platform_webusb = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor)
 			+ sizeof(struct usb_bos_capability_webusb),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		/* WebUSB Platform Capability UUID
@@ -72,7 +71,7 @@ static struct webusb_bos_desc {
 	.platform_msos = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor)
 			+ sizeof(struct usb_bos_capability_msos),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		.PlatformCapabilityUUID = {
@@ -113,7 +112,7 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_webusb {
 	.platform = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor) +
 			sizeof(struct usb_bos_capability_webusb),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		/* WebUSB Platform Capability UUID
@@ -141,7 +140,7 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_msosv2 {
 	.platform = {
 		.bLength = sizeof(struct usb_bos_platform_descriptor)
 			+ sizeof(struct usb_bos_capability_msos),
-		.bDescriptorType = USB_DEVICE_CAPABILITY_DESC,
+		.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 		.bDevCapabilityType = USB_BOS_CAPABILITY_PLATFORM,
 		.bReserved = 0,
 		.PlatformCapabilityUUID = {
@@ -203,7 +202,7 @@ static void test_usb_bos(void)
 
 	/* Already registered due to previous test */
 
-	setup.wValue = (DESCRIPTOR_TYPE_BOS & 0xFF) << 8;
+	setup.wValue = (USB_DESC_BOS & 0xFF) << 8;
 
 	ret = usb_handle_bos(&setup, &len, &data);
 

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -9,7 +9,6 @@
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
 #include <logging/log.h>
@@ -40,11 +39,11 @@ struct usb_test_config {
 #define INITIALIZER_IF							\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = 3,					\
-		.bInterfaceClass = CUSTOM_CLASS,			\
+		.bInterfaceClass = USB_BCC_VENDOR,			\
 		.bInterfaceSubClass = 0,				\
 		.bInterfaceProtocol = 0,				\
 		.iInterface = 0,					\
@@ -53,7 +52,7 @@ struct usb_test_config {
 #define INITIALIZER_IF_EP(addr, attr, mps)				\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\
@@ -163,7 +162,7 @@ static void check_endpoint_allocation(struct usb_desc_header *head)
 	uint8_t ep_count = 0;
 
 	while (head->bLength != 0) {
-		if (head->bDescriptorType == USB_INTERFACE_DESC) {
+		if (head->bDescriptorType == USB_DESC_INTERFACE) {
 			struct usb_if_descriptor *if_descr = (void *)head;
 
 			ep_count = 0;
@@ -180,7 +179,7 @@ static void check_endpoint_allocation(struct usb_desc_header *head)
 			zassert_not_null(cfg_data, "Check available cfg data");
 		}
 
-		if (head->bDescriptorType == USB_ENDPOINT_DESC) {
+		if (head->bDescriptorType == USB_DESC_ENDPOINT) {
 			struct usb_ep_descriptor *ep_descr =
 				(struct usb_ep_descriptor *)head;
 

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -9,7 +9,6 @@
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 
 /* Max packet size for endpoints */
 #define BULK_EP_MPS		64
@@ -27,11 +26,11 @@ struct usb_device_desc {
 #define INITIALIZER_IF							\
 	{								\
 		.bLength = sizeof(struct usb_if_descriptor),		\
-		.bDescriptorType = USB_INTERFACE_DESC,			\
+		.bDescriptorType = USB_DESC_INTERFACE,			\
 		.bInterfaceNumber = 0,					\
 		.bAlternateSetting = 0,					\
 		.bNumEndpoints = 1,					\
-		.bInterfaceClass = CUSTOM_CLASS,			\
+		.bInterfaceClass = USB_BCC_VENDOR,			\
 		.bInterfaceSubClass = 0,				\
 		.bInterfaceProtocol = 0,				\
 		.iInterface = 0,					\
@@ -40,7 +39,7 @@ struct usb_device_desc {
 #define INITIALIZER_IF_EP(addr, attr, mps, interval)			\
 	{								\
 		.bLength = sizeof(struct usb_ep_descriptor),		\
-		.bDescriptorType = USB_ENDPOINT_DESC,			\
+		.bDescriptorType = USB_DESC_ENDPOINT,			\
 		.bEndpointAddress = addr,				\
 		.bmAttributes = attr,					\
 		.wMaxPacketSize = sys_cpu_to_le16(mps),			\

--- a/tests/subsys/usb/os_desc/src/usb_osdesc.c
+++ b/tests/subsys/usb/os_desc/src/usb_osdesc.c
@@ -9,7 +9,6 @@
 
 #include <sys/byteorder.h>
 #include <usb/usb_device.h>
-#include <usb/usb_common.h>
 #include <os_desc.h>
 
 #define MSOS_STRING_LENGTH	18
@@ -21,7 +20,7 @@ static struct string_desc {
 	uint8_t bPad;
 } __packed msosv1_string_descriptor = {
 	.bLength = MSOS_STRING_LENGTH,
-	.bDescriptorType = USB_STRING_DESC,
+	.bDescriptorType = USB_DESC_STRING,
 	/* Signature MSFT100 */
 	.bString = {
 		'M', 0x00, 'S', 0x00, 'F', 0x00, 'T', 0x00,
@@ -94,7 +93,7 @@ static void test_handle_os_desc(void)
 	uint8_t *data = NULL;
 	int ret;
 
-	setup.wValue = (USB_STRING_DESC & 0xFF) << 8;
+	setup.wValue = (USB_DESC_STRING & 0xFF) << 8;
 	setup.wValue |= USB_OSDESC_STRING_DESC_INDEX;
 
 	ret = usb_handle_os_desc(&setup, &len, &data);


### PR DESCRIPTION
Add header file where all defines and structures
from Chapter 9 (USB Device Framework) should be included.

Replace all macros and types in the tree with the new ones from
usb/usb_ch9.h header.

Deprecate usb_common.h and usbstruct.h headers.
Deprecate DESCRIPTOR_TYPE_BOS macro.