### PR TITLE
ITE dts/riscv/it8xxx2.dtsi: add ecpm node for it8xxx2

### DIFF
--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -624,5 +624,12 @@
 			label = "I2C_5";
 			port-num = <5>;
 		};
+
+		ecpm: clock-controller@f01e00 {
+			compatible = "ite,it8xxx2-ecpm";
+			reg = <0x00f01e00 0x11>;
+			reg-names = "ecpm";
+			label = "EC_PM";
+		};
 	};
 };


### PR DESCRIPTION
Add EC clock and power management (ecpm) node for it8xxx2.

Signed-off-by: Ruibin Chang <ruibin.chang@ite.com.tw>