### PR TITLE
tests: lib: mem_alloc: Fix test names

### DIFF
--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -4,14 +4,14 @@ tests:
     arch_exclude: posix
     platform_exclude: twr_ke18f native_posix_64 nrf52_bsim
     tags: clib minimal_libc userspace
-  libraries.libc.newlib:
+  libraries.libc.newlib.mem_alloc:
     min_ram: 16
     extra_args: CONF_FILE=prj_newlib.conf
     arch_exclude: posix
     platform_exclude: twr_ke18f native_posix_64 nrf52_bsim
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: clib newlib userspace
-  libraries.libc.newlibnano:
+  libraries.libc.newlib_nano.mem_alloc:
     extra_args: CONF_FILE=prj_newlibnano.conf
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     tags: clib newlib userspace


### PR DESCRIPTION
This commit fixes the ambiguous test names used by the `mem_alloc`
test.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>