### PR TITLE
pm: device: check for ENOSYS

### DIFF
--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -34,7 +34,7 @@ int __weak sys_clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
 			       uint32_t *context, pm_device_cb cb, void *arg)
 {
-	return -ENOTSUP;
+	return -ENOSYS;
 }
 
 void __weak sys_clock_set_timeout(int32_t ticks, bool idle)

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -70,7 +70,7 @@ static bool should_suspend(const struct device *dev, uint32_t state)
 	}
 
 	rc = pm_device_state_get(dev, &current_state);
-	if ((rc != -ENOTSUP) && (rc != 0)) {
+	if ((rc != -ENOSYS) && (rc != 0)) {
 		LOG_DBG("Was not possible to get device %s state: %d",
 			dev->name, rc);
 		return true;
@@ -105,7 +105,7 @@ static int _pm_devices(uint32_t state)
 			 * in the right state.
 			 */
 			rc = pm_device_state_set(dev, state, NULL, NULL);
-			if ((rc != -ENOTSUP) && (rc != 0)) {
+			if ((rc != -ENOSYS) && (rc != 0)) {
 				LOG_DBG("%s did not enter %s state: %d",
 					dev->name, pm_device_state_str(state),
 					rc);


### PR DESCRIPTION
If feature is not available -ENOSYS is used instead of -ENOTSUP.

Fixes #34827