### PR TITLE
i2s: add test config helper for mximrt685_evk

### DIFF
--- a/tests/drivers/i2s/i2s_api/Kconfig
+++ b/tests/drivers/i2s/i2s_api/Kconfig
@@ -12,3 +12,4 @@ config I2S_TEST_SEPARATE_DEVICES
 	bool "Use two separate I2S ports for loopback"
 	help
 	  Use separate I2S ports for transmit and receive.
+	  e.g for mimxrt685_evk short JP7-2 to JP8-2

--- a/tests/drivers/i2s/i2s_speed/Kconfig
+++ b/tests/drivers/i2s/i2s_speed/Kconfig
@@ -12,3 +12,4 @@ config I2S_TEST_SEPARATE_DEVICES
 	bool "Use two separate I2S ports for loopback"
 	help
 	  Use separate I2S ports for transmit and receive.
+	  e.g for mimxrt685_evk short JP7-2 to JP8-2


### PR DESCRIPTION
i2s test need loopback tx and rx.

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>