### PR TITLE
pm: do not sleep forever (deadlock)

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -136,7 +136,9 @@ static int pm_device_request(const struct device *dev,
 
 	k_mutex_init(&request_mutex);
 	k_mutex_lock(&request_mutex, K_FOREVER);
-	(void)k_condvar_wait(&dev->pm->condvar, &request_mutex, K_FOREVER);
+	if(k_condvar_wait(&dev->pm->condvar, &request_mutex, K_MSEC(1000)) == -EAGAIN){
+		LOG_ERR("THIS IS A BUG: power management timed out for %s\n", dev->name);
+	}
 	k_mutex_unlock(&request_mutex);
 
 	/*


### PR DESCRIPTION
When CONFIG_PM_DEVICE_RUNTIME option is enabled, this code blocks forever on GPIOC when using ADC. I haven't been able to pinpoint yet what exactly the actual issue is because it goes through for GPIOA twice (stm32) and then hangs when being called from the ADC driver for GPIOC. 

Either way, this code should probably not sleep for ever. There should be a timeout. @ceolin what do you think? 