### PR TITLE
Bluetooth: Mesh: Fix bugs in settings.c when storing RPL

### DIFF
--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -88,7 +88,8 @@ SETTINGS_STATIC_HANDLER_DEFINE(bt_mesh, "bt/mesh", NULL, NULL, mesh_commit,
 			      BIT(BT_MESH_SETTINGS_APP_KEYS_PENDING) |      \
 			      BIT(BT_MESH_SETTINGS_HB_PUB_PENDING)   |      \
 			      BIT(BT_MESH_SETTINGS_CFG_PENDING)      |      \
-			      BIT(BT_MESH_SETTINGS_MOD_PENDING))
+			      BIT(BT_MESH_SETTINGS_MOD_PENDING)      |      \
+			      BIT(BT_MESH_SETTINGS_VA_PENDING))
 
 void bt_mesh_settings_store_schedule(enum bt_mesh_settings_flag flag)
 {

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -100,7 +100,7 @@ void bt_mesh_settings_store_schedule(enum bt_mesh_settings_flag flag)
 		timeout_ms = 0;
 	} else if (atomic_test_bit(pending_flags,
 				   BT_MESH_SETTINGS_RPL_PENDING) &&
-		   (!(atomic_get(bt_mesh.flags) & GENERIC_PENDING_BITS) ||
+		   (!(atomic_get(pending_flags) & GENERIC_PENDING_BITS) ||
 		    (CONFIG_BT_MESH_RPL_STORE_TIMEOUT <
 		     CONFIG_BT_MESH_STORE_TIMEOUT))) {
 		timeout_ms = CONFIG_BT_MESH_RPL_STORE_TIMEOUT * MSEC_PER_SEC;


### PR DESCRIPTION
This PR fixes 2 issues regarding RPL:
1. Fixes a bug that was introduced in PR #31176, where setting's flags were
moved out from bt_mesh.flags to pending_flags.
2. Adds BT_MESH_SETTINGS_VA_PENDING to GENERIC_PENDING_BITS
so that it is considered when scheduling store with RPL flag set.