### PR TITLE
dts: arm: stm32f{2,4,7}: fix device tree warning

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -91,11 +91,11 @@
 			reg = <0x40023800 0x400>;
 		};
 
-		exti: interrupt-controller@40013C00 {
+		exti: interrupt-controller@40013c00 {
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
-			reg = <0x40013C00 0x400>;
+			reg = <0x40013c00 0x400>;
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -95,7 +95,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
-			reg = <0x40013C00 0x400>;
+			reg = <0x40013c00 0x400>;
 		};
 
 		pinctrl: pin-controller@40020000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -96,11 +96,11 @@
 			reg = <0x40023800 0x400>;
 		};
 
-		exti: interrupt-controller@40013C00 {
+		exti: interrupt-controller@40013c00 {
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
-			reg = <0x40013C00 0x400>;
+			reg = <0x40013c00 0x400>;
 		};
 
 		pinctrl: pin-controller@40020000 {


### PR DESCRIPTION
Switch the interrupt controller address to lower case to avoid this
warning:

  stm32f723e_disco.dts.pre.tmp:97.39-102.5: Warning (simple_bus_reg):
  /soc/interrupt-controller@40013C00: simple-bus unit address format
  error, expected "40013c00"

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>