### PR TITLE
drivers: gpio: gpio_cy8c95xx: Add error check of i2c_reg_read_byte

### DIFF
--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -257,8 +257,11 @@ static int cy8c95xx_init(const struct device *dev)
 		goto out;
 	}
 
-	i2c_reg_read_byte(cfg->i2c_master, cfg->i2c_slave_addr,
+	rc = i2c_reg_read_byte(cfg->i2c_master, cfg->i2c_slave_addr,
 			  CY8C95XX_REG_ID, &data);
+	if (rc) {
+		goto out;
+	}
 	LOG_DBG("cy8c95xx device ID %02X", data & 0xF0);
 	if ((data & 0xF0) != 0x20) {
 		LOG_WRN("driver only support [0-2] ports operations");


### PR DESCRIPTION
Check return value from i2c_reg_read_byte and error out if it
received an error

Fixes #35155

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>