### PR TITLE
pm: compile time device list

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -702,7 +702,7 @@ static const struct nrf_clock_control_config config = {
 	}
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, pm_device_none,
 		 &data, &config,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		 &clock_control_api);

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -599,7 +599,7 @@ static int gpio_nrfx_init(const struct device *port)
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
 	DEVICE_DT_DEFINE(GPIO(id), gpio_nrfx_init,			\
-			 NULL,						\
+			 pm_device_none,				\
 			 &gpio_nrfx_p##id##_data,			\
 			 &gpio_nrfx_p##id##_cfg,			\
 			 POST_KERNEL,					\

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -37,6 +37,19 @@
 		__device_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+#if CONFIG_PM_DEVICE
+	SECTION_DATA_PROLOGUE(pm_devices,,)
+	{
+		__pm_device_start = .;
+		CREATE_OBJ_LEVEL(pm_device, PRE_KERNEL_1)
+		CREATE_OBJ_LEVEL(pm_device, PRE_KERNEL_2)
+		CREATE_OBJ_LEVEL(pm_device, POST_KERNEL)
+		CREATE_OBJ_LEVEL(pm_device, APPLICATION)
+		CREATE_OBJ_LEVEL(pm_device, SMP)
+		__pm_device_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
+
 	SECTION_DATA_PROLOGUE(initshell,,)
 	{
 		/* link in shell initialization objects for all modules that

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -127,6 +127,19 @@ struct pm_device {
 #define PM_DEVICE_ATOMIC_FLAGS_BUSY_BIT 0
 
 /**
+ * @brief Function to be used when devices do not provide power management.
+ *
+ * @param dev Not used
+ * @param ctrl_command Not used
+ * @param context Not used
+ * @param cb Not used
+ * @param arg Not used
+ * @return -ENOSYS
+ */
+int pm_device_none(const struct device *dev, uint32_t ctrl_command,
+		   uint32_t *context, pm_device_cb cb, void *arg);
+
+/**
  * @brief Get name of device PM state
  *
  * @param state State id which name should be returned

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -24,6 +24,16 @@ extern "C" {
 
 struct device;
 
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Utility macro used to check for device power-management availability
+ * in Z_DEVICE_DEFINE_PM_ENTRY
+ */
+#define __pm_device_none 1
+
+/** @endcond */
+
 /** @def PM_DEVICE_STATE_ACTIVE
  *
  * @brief device is in ACTIVE power state

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,1 +1,2 @@
 # nothing here
+CONFIG_PM_DEVICE=y

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,9 +5,28 @@
  */
 
 #include <zephyr.h>
+#include <device.h>
 #include <sys/printk.h>
+
+extern const struct device *__pm_device_start[];
+extern const struct device *__pm_device_end[];
+
+extern const struct device __device_start[];
+extern const struct device __device_end[];
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	size_t pm_devices_cnt = __pm_device_end - __pm_device_start;
+
+	printk("%d devices provide power management\n", pm_devices_cnt);
+	for (size_t i = 0U; i < pm_devices_cnt; i++) {
+		printk("- %s\n", __pm_device_start[i]->name);
+	}
+
+	size_t devices_cnt = __device_end - __device_start;
+
+	printk("%d devices available\n", devices_cnt);
+	for (size_t i = 0U; i < devices_cnt; i++) {
+		printk("- %s\n", __device_start[i].name);
+	}
 }

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -60,11 +60,6 @@ config DEVICE_POWER_MANAGEMENT
 	help
 	  This option is deprecated, please use CONFIG_PM_DEVICE instead.
 
-config PM_MAX_DEVICES
-	int "Max number of devices support power management"
-	depends on PM_DEVICE
-	default 15
-
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"
 	depends on PM_DEVICE

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -15,50 +15,12 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-/*
- * FIXME: Remove the conditional inclusion of
- * core_devices array once we enble the capability
- * to build the device list based on devices power
- * and clock domain dependencies.
- */
-
-__weak const char *const z_pm_core_devices[] = {
-#if defined(CONFIG_SOC_FAMILY_NRF)
-	"CLOCK",
-	"sys_clock",
-	"UART_0",
-#elif defined(CONFIG_SOC_SERIES_CC13X2_CC26X2)
-	"sys_clock",
-	"UART_0",
-#elif defined(CONFIG_SOC_SERIES_KINETIS_K6X)
-	DT_LABEL(DT_INST(0, nxp_kinetis_ethernet)),
-#elif defined(CONFIG_NET_TEST)
-	"",
-#elif defined(CONFIG_SOC_SERIES_STM32L4X) || defined(CONFIG_SOC_SERIES_STM32WBX)
-	"sys_clock",
-#endif
-	NULL
-};
-
-/* Ordinal of sufficient size to index available devices. */
-typedef uint16_t device_idx_t;
-
-/* The maximum value representable with a device_idx_t. */
-#define DEVICE_IDX_MAX ((device_idx_t)(-1))
-
-/* An array of all devices in the application. */
-static const struct device *all_devices;
-
-/* Indexes into all_devices for devices that support pm,
- * in dependency order (later may depend on earlier).
- */
-static device_idx_t pm_devices[CONFIG_PM_MAX_DEVICES];
-
-/* Number of devices that support pm */
-static device_idx_t num_pm;
-
-/* Number of devices successfully suspended. */
-static device_idx_t num_susp;
+/** Start of devices supporting power management. */
+extern const struct device *__pm_device_start[];
+/** End of devices supporting power management. */
+extern const struct device *__pm_device_end[];
+/** Number of suspended devices. */
+static size_t pm_device_susp;
 
 static bool should_suspend(const struct device *dev, uint32_t state)
 {
@@ -90,11 +52,12 @@ static bool should_suspend(const struct device *dev, uint32_t state)
 
 static int _pm_devices(uint32_t state)
 {
-	num_susp = 0;
+	size_t pm_device_cnt = __pm_device_end - __pm_device_start;
 
-	for (int i = num_pm - 1; i >= 0; i--) {
-		device_idx_t idx = pm_devices[i];
-		const struct device *dev = &all_devices[idx];
+	pm_device_susp = 0U;
+
+	for (size_t i = pm_device_cnt - 1U; i >= 0U; i--) {
+		const struct device *dev = __pm_device_start[i];
 		bool suspend;
 		int rc;
 
@@ -119,7 +82,7 @@ static int _pm_devices(uint32_t state)
 			 * This still not optimal, since we are not distinguishing
 			 * between other states like DEVICE_PM_LOW_POWER_STATE.
 			 */
-			++num_susp;
+			++pm_device_susp;
 		}
 	}
 
@@ -143,65 +106,14 @@ int pm_force_suspend_devices(void)
 
 void pm_resume_devices(void)
 {
-	device_idx_t pmi = num_pm - num_susp;
+	size_t pm_device_cnt = __pm_device_end - __pm_device_start;
+	size_t i = pm_device_cnt - pm_device_susp;
 
-	num_susp = 0;
-	while (pmi < num_pm) {
-		device_idx_t idx = pm_devices[pmi];
-
-		pm_device_state_set(&all_devices[idx],
-				       PM_DEVICE_STATE_ACTIVE,
-				       NULL, NULL);
-		++pmi;
-	}
-}
-
-void pm_create_device_list(void)
-{
-	size_t count = z_device_get_all_static(&all_devices);
-	device_idx_t pmi, core_dev;
-
-	/*
-	 * Create an ordered list of devices that will be suspended.
-	 * Ordering should be done based on dependencies. Devices
-	 * in the beginning of the list will be resumed first.
-	 */
-
-	__ASSERT_NO_MSG(count <= DEVICE_IDX_MAX);
-
-	/* Reserve initial slots for core devices. */
-	core_dev = 0;
-	while (z_pm_core_devices[core_dev]) {
-		core_dev++;
-	}
-
-	num_pm = core_dev;
-	__ASSERT_NO_MSG(num_pm <= CONFIG_PM_MAX_DEVICES);
-
-	for (pmi = 0; pmi < count; pmi++) {
-		device_idx_t cdi = 0;
-		const struct device *dev = &all_devices[pmi];
-
-		/* Ignore "device"s that don't support PM */
-		if (dev->pm_control == NULL) {
-			continue;
-		}
-
-		/* Check if the device is a core device, which has a
-		 * reserved slot.
-		 */
-		while (z_pm_core_devices[cdi]) {
-			if (strcmp(dev->name, z_pm_core_devices[cdi]) == 0) {
-				pm_devices[cdi] = pmi;
-				break;
-			}
-			++cdi;
-		}
-
-		/* Append the device if it doesn't have a reserved slot. */
-		if (cdi == core_dev) {
-			pm_devices[num_pm++] = pmi;
-		}
+	pm_device_susp = 0U;
+	while (i < pm_device_cnt) {
+		pm_device_state_set(__pm_device_start[i],
+				    PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+		++i;
 	}
 }
 #endif /* defined(CONFIG_PM) */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -239,20 +239,12 @@ const char *pm_device_state_str(uint32_t state)
 int pm_device_state_set(const struct device *dev, uint32_t device_power_state,
 			pm_device_cb cb, void *arg)
 {
-	if (dev->pm_control == NULL) {
-		return -ENOSYS;
-	}
-
 	return dev->pm_control(dev, PM_DEVICE_STATE_SET,
 			       &device_power_state, cb, arg);
 }
 
 int pm_device_state_get(const struct device *dev, uint32_t *device_power_state)
 {
-	if (dev->pm_control == NULL) {
-		return -ENOSYS;
-	}
-
 	return dev->pm_control(dev, PM_DEVICE_STATE_GET,
 			       device_power_state, NULL, NULL);
 }

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -206,6 +206,18 @@ void pm_create_device_list(void)
 }
 #endif /* defined(CONFIG_PM) */
 
+int pm_device_none(const struct device *dev, uint32_t ctrl_command,
+		   uint32_t *context, pm_device_cb cb, void *arg)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl_command);
+	ARG_UNUSED(context);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(arg);
+
+	return -ENOSYS;
+}
+
 const char *pm_device_state_str(uint32_t state)
 {
 	switch (state) {

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -275,14 +275,3 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 
 	return ret;
 }
-
-#if CONFIG_PM_DEVICE
-static int pm_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	pm_create_device_list();
-	return 0;
-}
-SYS_INIT(pm_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif /* CONFIG_PM_DEVICE */


### PR DESCRIPTION
Store the list of devices that support device power management at
compile time. If a device uses a function signature other than
`pm_device_none` it will be included in the list. The resulting list is
sorted by the linker by using sections named using init levels and
priorities.

These changes should allow getting rid of most (or al) init code in https://github.com/zephyrproject-rtos/zephyr/blob/master/subsys/pm/device.c#L25.

This method requires to not use `NULL` (recently introduced), so please, don't kill me...