### PR TITLE
Fix D-Cache invalidation at boot and during MPU setup on Cortex-M7

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/scb.c
+++ b/arch/arm/core/aarch32/cortex_m/scb.c
@@ -93,9 +93,17 @@ void z_arm_init_arch_hw_at_boot(void)
 	}
 
 #if defined(CONFIG_CPU_CORTEX_M7)
-	/* Reset Cache settings */
-	SCB_CleanInvalidateDCache();
-	SCB_DisableDCache();
+	/* Reset D-Cache settings. If the D-Cache was enabled,
+	 * SCB_DisableDCache() takes care of cleaning and invalidating it.
+	 * If it was already disabled, just call SCB_InvalidateDCache() to
+	 * reset it to a known clean state.
+	 */
+	if (SCB->CCR & SCB_CCR_DC_Msk) {
+		SCB_DisableDCache();
+	} else {
+		SCB_InvalidateDCache();
+	}
+	/* Reset I-Cache settings. */
 	SCB_DisableICache();
 #endif /* CONFIG_CPU_CORTEX_M7 */
 

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -326,11 +326,13 @@ int z_arm_mpu_init(void)
 	arm_core_mpu_disable();
 
 #if defined(CONFIG_NOCACHE_MEMORY)
-	/* Clean and invalidate data cache if
+	/* Clean and invalidate data cache if it is enabled and
 	 * that was not already done at boot
 	 */
 #if !defined(CONFIG_INIT_ARCH_HW_AT_BOOT)
-	SCB_CleanInvalidateDCache();
+	if (SCB->CCR & SCB_CCR_DC_Msk) {
+		SCB_CleanInvalidateDCache();
+	}
 #endif
 #endif /* CONFIG_NOCACHE_MEMORY */
 


### PR DESCRIPTION
This PR fixes issues introduced by https://github.com/zephyrproject-rtos/zephyr/commit/d6b50233acc7e27030bfbf1bd069d0f6969a4f68 and reported as  #35089, #35107 and #35220.

It's not clear to me if we should check the status of the D-Cache, or if it is ensured to be disabled at reset, so I took the safe way.