### PR TITLE
boards: arm: bl5340_dvk: Add MCP4725 dac to bl5340_dvk_cpuapp dts file

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -79,6 +79,13 @@
 		reg = <0x76>;
 		label = "BME680";
 	};
+
+	dac0: mcp4725@60 {
+		compatible = "microchip,mcp4725";
+		reg = <0x60>;
+		label = "dac0";
+		#io-channel-cells = <1>;
+	};
 };
 
 &spi2 {

--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -89,7 +89,7 @@ follows:
 DAC output is available on connector J4 pin 11.
 
 Building and Running for BL652
-======================================
+==============================
 The BL652 DVK PCB contains a footprint for a MCP4725 to use as an external
 DAC. Note this is not populated by default. The sample can be built and
 executed for the :ref:`bl652_dvk` as follows:
@@ -103,7 +103,7 @@ executed for the :ref:`bl652_dvk` as follows:
 DAC output is available on pin 1 of the MCP4725.
 
 Building and Running for BL653
-======================================
+==============================
 The BL653 DVK PCB contains a footprint for a MCP4725 to use as an external
 DAC. Note this is not populated by default. The sample can be built and
 executed for the :ref:`bl653_dvk` as follows:
@@ -117,7 +117,7 @@ executed for the :ref:`bl653_dvk` as follows:
 DAC output is available on pin 1 of the MCP4725.
 
 Building and Running for BL654
-======================================
+==============================
 The BL654 DVK PCB contains a footprint for a MCP4725 to use as an external
 DAC. Note this is not populated by default. The sample can be built and
 executed for the :ref:`bl654_dvk` as follows:
@@ -125,6 +125,19 @@ executed for the :ref:`bl654_dvk` as follows:
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/dac
    :board: bl654_dvk
+   :goals: build flash
+   :compact:
+
+DAC output is available on pin 1 of the MCP4725.
+
+Building and Running for BL5340
+===============================
+The BL5340 DVK PCB contains a MCP4725 to use as a DAC. The sample can be
+built and executed for the :ref:`bl5340_dvk` as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: bl5340_dvk_cpuapp
    :goals: build flash
    :compact:
 

--- a/samples/drivers/dac/boards/bl5340_dvk_cpuapp.conf
+++ b/samples/drivers/dac/boards/bl5340_dvk_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Laird Connectivity
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_I2C=y
+CONFIG_DAC_MCP4725=y

--- a/samples/drivers/dac/boards/bl5340_dvk_cpuapp.overlay
+++ b/samples/drivers/dac/boards/bl5340_dvk_cpuapp.overlay
@@ -1,0 +1,7 @@
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/sample.yaml
+++ b/samples/drivers/dac/sample.yaml
@@ -6,7 +6,7 @@ tests:
     platform_allow: |
       arduino_zero frdm_k22f frdm_k64f nucleo_f091rc nucleo_g071rb nucleo_g431rb
       nucleo_l073rz nucleo_l152re twr_ke18f nucleo_f767zi nucleo_f429zi bl652_dvk
-      bl653_dvk bl654_dvk
+      bl653_dvk bl654_dvk bl5340_dvk_cpuapp
     depends_on: dac
     harness: console
     harness_config:

--- a/tests/drivers/dac/dac_api/boards/bl5340_dvk_cpuapp.conf
+++ b/tests/drivers/dac/dac_api/boards/bl5340_dvk_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Laird Connectivity
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_I2C=y
+CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -39,7 +39,8 @@
 
 #elif defined(CONFIG_BOARD_BL652_DVK) || \
 	defined(CONFIG_BOARD_BL653_DVK) || \
-	defined(CONFIG_BOARD_BL654_DVK)
+	defined(CONFIG_BOARD_BL654_DVK) || \
+	defined(CONFIG_BOARD_BL5340_DVK_CPUAPP)
  /* Note external DAC MCP4725 is not populated on BL652_DVK, BL653_DVK and
   * BL654_DVK at factory
   */

--- a/tests/drivers/dac/dac_api/testcase.yaml
+++ b/tests/drivers/dac/dac_api/testcase.yaml
@@ -4,5 +4,5 @@ tests:
   drivers.dac:
     platform_allow:
       frdm_k22f frdm_k64f nucleo_l073rz nucleo_l152re twr_ke18f nucleo_f767zi
-      nucleo_f429zi bl652_dvk bl653_dvk bl654_dvk
+      nucleo_f429zi bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp
     depends_on: dac

--- a/tests/drivers/dac/dac_loopback/boards/bl5340_dvk_cpuapp.conf
+++ b/tests/drivers/dac/dac_loopback/boards/bl5340_dvk_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Laird Connectivity
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_I2C=y
+CONFIG_DAC_MCP4725=y

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -113,10 +113,12 @@
 
 #elif defined(CONFIG_BOARD_BL652_DVK) || \
 	defined(CONFIG_BOARD_BL653_DVK) || \
-	defined(CONFIG_BOARD_BL654_DVK)
+	defined(CONFIG_BOARD_BL654_DVK)  || \
+	defined(CONFIG_BOARD_BL5340_DVK_CPUAPP)
 #include <hal/nrf_saadc.h>
  /* DAC output from MCP4725 pin 1
-  * ADC_1 input read from pin SIO_3
+  * On BL65x ADC_1 input is read from pin SIO_3
+  * On BL5340 ADC_1 input is read from pin SIO_5
   * Note external DAC MCP4725 is not populated on BL652_DVK, BL653_DVK and
   * BL654_DVK at factory
   */
@@ -150,7 +152,8 @@ static const struct adc_channel_cfg adc_ch_cfg = {
 
 #if defined(CONFIG_BOARD_BL652_DVK) || \
 	defined(CONFIG_BOARD_BL653_DVK) || \
-	defined(CONFIG_BOARD_BL654_DVK)
+	defined(CONFIG_BOARD_BL654_DVK) || \
+	defined(CONFIG_BOARD_BL5340_DVK_CPUAPP)
 	.input_positive   = ADC_1ST_CHANNEL_INPUT,
 #endif
 };

--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -8,4 +8,4 @@ tests:
       fixture: dac_adc_loopback
     platform_allow: |
       frdm_k22f frdm_k64f nucleo_f207zg nucleo_l073rz nucleo_l152re twr_ke18f
-      bl652_dvk bl653_dvk bl654_dvk
+      bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp


### PR DESCRIPTION
MCP4725 is an I2C dac that was added with PR #33481. This can now be
added to the bl5340_dvk device tree.

Signed-off-by: Kieran Mackey <kieran.mackey@lairdconnect.com>