### PR TITLE
drivers: dac: mcp4725: remove usage of device_pm_control_nop

### DIFF
--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -139,7 +139,7 @@ static const struct dac_driver_api mcp4725_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(index, dac_mcp4725_init,			\
-			    device_pm_control_nop,			\
+			    NULL,					\
 			    NULL,					\
 			    &mcp4725_config_##index, POST_KERNEL,	\
 			    CONFIG_DAC_MCP4725_INIT_PRIORITY,		\


### PR DESCRIPTION
Fixes issue #35263

Signed-off-by: Kieran Mackey <kieran.mackey@lairdconnect.com>