### PR TITLE
kernel/device: check arg before using it in device_is_ready()

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -581,8 +581,8 @@ static inline int z_device_usable_check(const struct device *dev)
  * distinct error values that identify the reason if it cannot.
  *
  * @retval 0 if the device is usable.
- * @retval -ENODEV if the device has not been initialized, or the
- * initialization failed.
+ * @retval -ENODEV if the device has not been initialized, the device pointer
+ * is NULL or the initialization failed.
  * @retval other negative error codes to indicate additional conditions that
  * make the device unusable.
  */
@@ -606,7 +606,8 @@ static inline int z_impl_device_usable_check(const struct device *dev)
  * @param dev pointer to the device in question.
  *
  * @retval true if the device is ready for use.
- * @retval false if the device is not ready for use.
+ * @retval false if the device is not ready for use or if a NULL device pointer
+ * is passed as argument.
  */
 static inline bool device_is_ready(const struct device *dev)
 {

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -163,6 +163,14 @@ size_t z_device_get_all_static(struct device const **devices)
 
 bool z_device_ready(const struct device *dev)
 {
+	/*
+	 * if an invalid device pointer is passed as argument, this call
+	 * reports the `device` as not ready for usage.
+	 */
+	if (dev == NULL) {
+		return false;
+	}
+
 	return dev->state->initialized && (dev->state->init_res == 0U);
 }
 


### PR DESCRIPTION
In device_is_ready() if device pointer passed as argument is
NULL then return false (device is not ready).

There are a lot of cases in which a property is not declared/found in the DT (e.g. a gpio for interrupt) , but still device_is_ready() is called with a NULL device pointer. 