### PR TITLE
net: http: update status if no status text is provided

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -169,6 +169,8 @@ static int on_status(struct http_parser *parser, const char *at, size_t length)
 	len = MIN(length, sizeof(req->internal.response.http_status) - 1);
 	memcpy(req->internal.response.http_status, at, len);
 	req->internal.response.http_status[len] = 0;
+	req->internal.response.http_status_code =
+		(uint16_t)parser->status_code;
 
 	NET_DBG("HTTP response status %d %s", parser->status_code,
 		log_strdup(req->internal.response.http_status));
@@ -176,8 +178,6 @@ static int on_status(struct http_parser *parser, const char *at, size_t length)
 	if (req->internal.response.http_cb &&
 	    req->internal.response.http_cb->on_status) {
 		req->internal.response.http_cb->on_status(parser, at, length);
-		req->internal.response.http_status_code =
-			(uint16_t)parser->status_code;
 	}
 
 	return 0;

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -992,6 +992,19 @@ reexecute:
 
 		case s_res_status_code: {
 			if (!IS_NUM(ch)) {
+				/* Numeric status only */
+				if ((ch == CR) || (ch == LF)) {
+					const char *no_status_txt = "";
+
+					rc = cb_data(parser,
+					     settings->on_status,
+					     HPE_CB_status, &p_state, parsed,
+					     p - data + 1, &no_status_txt, 0);
+					if (rc != 0) {
+						return rc;
+					}
+				}
+
 				switch (ch) {
 				case ' ':
 					UPDATE_STATE(s_res_status_start);
@@ -1021,6 +1034,18 @@ reexecute:
 		}
 
 		case s_res_status_start: {
+			if (!status_mark && ((ch == CR) || (ch == LF))) {
+				/* Numeric status only */
+				const char *no_status_txt = "";
+
+				rc = cb_data(parser,
+					settings->on_status,
+					HPE_CB_status, &p_state, parsed,
+					p - data + 1, &no_status_txt, 0);
+				if (rc != 0) {
+					return rc;
+				}
+			}
 			if (ch == CR) {
 				UPDATE_STATE(s_res_line_almost_done);
 				break;


### PR DESCRIPTION
Call on_status if the Reason-Phrase is not provided.
This allows for the numeric status code to be set.
Also, ensure the numeric status code is always set
in on_status, not just if the specific callback is set.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>