### PR TITLE
kernel: mem_domain: test max available partitions on add_partition

### DIFF
--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -155,6 +155,8 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 		}
 	}
 
+	__ASSERT((p_idx < arch_mem_domain_max_partitions_get()),
+		"no free partition slots available");
 	__ASSERT(p_idx < max_partitions,
 		 "no free partition slots available");
 

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -431,7 +431,10 @@ void test_mem_part_assert_add_overmax(void)
 	/* Add one more partition will trigger assert due to exceeding */
 	k_mem_domain_add_partition(&test_domain, &exceed_part);
 
-	/* should not reach here */
+	/* should not reach here but if it does clean up flag before
+	 * indicating failure
+	 */
+	need_recover_spinlock = false;
 	ztest_test_fail();
 }
 


### PR DESCRIPTION
- Add an __ASSERT() test in k_mem_domain_add_partition() to check for available slots
- clean up the to ensure the test_mem_part_assert_add_overmax() clears the need_recover_spinlock flag to avoid future test failures.

Fixes: zephyrproject-rtos#34911

Signed-off-by: David Leach <david.leach@nxp.com>