### PR TITLE
pm: weak: Fix clash of weak functions

### DIFF
--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -101,7 +101,7 @@ static void z_power_soc_sleep(void)
  * For deep sleep pm_system_suspend has executed all the driver
  * power management call backs.
  */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
@@ -123,7 +123,7 @@ void pm_power_state_set(struct pm_state_info info)
  * an ISR on wake except for faults. We re-enable interrupts by setting PRIMASK
  * to 0.
  */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SUSPEND_TO_IDLE:

--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -11,7 +11,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:
@@ -24,7 +24,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -11,7 +11,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:
@@ -24,7 +24,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:

--- a/soc/arm/nordic_nrf/nrf53/power.c
+++ b/soc/arm/nordic_nrf/nrf53/power.c
@@ -13,7 +13,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:
@@ -26,7 +26,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:

--- a/soc/arm/nordic_nrf/nrf91/power.c
+++ b/soc/arm/nordic_nrf/nrf91/power.c
@@ -12,7 +12,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:
@@ -25,7 +25,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	switch (info.state) {
 	case PM_STATE_SOFT_OFF:

--- a/soc/arm/nuvoton_npcx/common/power.c
+++ b/soc/arm/nuvoton_npcx/common/power.c
@@ -159,7 +159,7 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 }
 
 /* Invoke when enter "Suspend/Low Power" mode. */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);
@@ -188,7 +188,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle soc specific activity after exiting "Suspend/Low Power" mode. */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);

--- a/soc/arm/nxp_imx/rt6xx/power.c
+++ b/soc/arm/nxp_imx/rt6xx/power.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 	APP_DEEPSLEEP_RAM_APD, APP_DEEPSLEEP_RAM_PPD}))
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	/* FIXME: When this function is entered the Kernel has disabled
 	 * interrupts using BASEPRI register. This is incorrect as it prevents
@@ -50,7 +50,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	ARG_UNUSED(info);
 

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	LOG_DBG("SoC entering power state %d", info.state);
 
@@ -56,7 +56,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	ARG_UNUSED(info);
 }

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);
@@ -73,7 +73,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power substate-id %u", info.state);

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);
@@ -73,7 +73,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power substate-id %u", info.state);

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -19,7 +19,7 @@
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);
@@ -64,7 +64,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	if (info.state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", info.state);

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -56,7 +56,7 @@ extern PowerCC26X2_ModuleState PowerCC26X2_module;
  */
 
 /* Invoke Low Power/System Off specific Tasks */
-void pm_power_state_set(struct pm_state_info info)
+__weak void pm_power_state_set(struct pm_state_info info)
 {
 	uint32_t modeVIMS;
 	uint32_t constraints;
@@ -124,7 +124,7 @@ void pm_power_state_set(struct pm_state_info info)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void pm_power_state_exit_post_ops(struct pm_state_info info)
+__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	/*
 	 * System is now in active mode. Reenable interrupts which were disabled

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -69,24 +69,33 @@ static void pm_log_debug_info(enum pm_state state) { }
 void pm_dump_debug_info(void) { }
 #endif
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+static inline void exit_pos_ops(struct pm_state_info info)
 {
-	/*
-	 * This function is supposed to be overridden to do SoC or
-	 * architecture specific post ops after sleep state exits.
-	 *
-	 * The kernel expects that irqs are unlocked after this.
-	 */
+	extern __weak void
+		pm_power_state_exit_post_ops(struct pm_state_info info);
 
-	irq_unlock(0);
+	if (pm_power_state_exit_post_ops != NULL) {
+		pm_power_state_exit_post_ops(info);
+	} else {
+		/*
+		 * This function is supposed to be overridden to do SoC or
+		 * architecture specific post ops after sleep state exits.
+		 *
+		 * The kernel expects that irqs are unlocked after this.
+		 */
+
+		irq_unlock(0);
+	}
 }
 
-__weak void pm_power_state_set(struct pm_state_info info)
+static inline void pm_state_set(struct pm_state_info info)
 {
-	/*
-	 * This function is supposed to be overridden to do SoC or
-	 * architecture specific post ops after sleep state exits.
-	 */
+	extern __weak void
+		pm_power_state_set(struct pm_state_info info);
+
+	if (pm_power_state_set != NULL) {
+		pm_power_state_set(info);
+	}
 }
 
 /*
@@ -133,7 +142,7 @@ void pm_system_resume(void)
 	 */
 	if (!post_ops_done) {
 		post_ops_done = 1;
-		pm_power_state_exit_post_ops(z_power_state);
+		exit_pos_ops(z_power_state);
 		pm_state_notify(false);
 	}
 }
@@ -155,7 +164,7 @@ void pm_power_state_force(struct pm_state_info info)
 	k_sched_lock();
 	pm_debug_start_timer();
 	/* Enter power state */
-	pm_power_state_set(z_power_state);
+	pm_state_set(z_power_state);
 	pm_debug_stop_timer();
 
 	pm_system_resume();
@@ -245,7 +254,7 @@ enum pm_state pm_system_suspend(int32_t ticks)
 	pm_debug_start_timer();
 	/* Enter power state */
 	pm_state_notify(true);
-	pm_power_state_set(z_power_state);
+	pm_state_set(z_power_state);
 	pm_debug_stop_timer();
 
 	/* Wake up sequence starts here */

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -22,22 +22,6 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 	log_stack_usage(thread);
 }
 
-/*
- * Weak power hook functions. Used on systems that have not implemented
- * power management.
- */
-__weak void pm_power_state_set(struct pm_state_info info)
-{
-	/* Never called. */
-	__ASSERT_NO_MSG(false);
-}
-
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
-{
-	/* Never called. */
-	__ASSERT_NO_MSG(false);
-}
-
 /* Our PM policy handler */
 struct pm_state_info pm_policy_next_state(int32_t ticks)
 {

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -26,11 +26,8 @@ static bool idle_entered;
 
 static const struct device *dev;
 static struct dummy_driver_api *api;
-/*
- * Weak power hook functions. Used on systems that have not implemented
- * power management.
- */
-__weak void pm_power_state_set(struct pm_state_info info)
+
+void pm_power_state_set(struct pm_state_info info)
 {
 	/* at this point, notify_pm_state_entry() implemented in
 	 * this file has been called and set_pm should have been set
@@ -51,7 +48,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		      "Entering low power state with a wrong parameter");
 }
 
-__weak void pm_power_state_exit_post_ops(struct pm_state_info info)
+void pm_power_state_exit_post_ops(struct pm_state_info info)
 {
 	/* pm_system_suspend is entered with irq locked
 	 * unlock irq before leave pm_system_suspend


### PR DESCRIPTION
The power subsystem is implementing weak stubs for SoC hooks. The problem is that is allowed applications to implement it too, in this situation it may lead to two weak implementations. The compiler will not raise an error since they are not implemented in the same object file, but the behavior (which implementation will be executed) depends in the order that these files are built.

Just remove it from the subsystem and let SoC and applications defined them.