### PR TITLE
tests: posix: common: fix k_usleep() tick alignment

### DIFF
--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -63,7 +63,7 @@ void test_posix_realtime(void)
 	 * which may break, in which case follow the suggestion in the
 	 * comment above.
 	 */
-	k_usleep(1);
+	k_usleep(100);
 
 	ret = clock_gettime(CLOCK_MONOTONIC, &mts);
 	zassert_equal(ret, 0, "Fail to get monotonic clock");


### PR DESCRIPTION
The kusleep(1) in test_posix_realtime() is not sufficient for all
boards. Extend it by the difference between rts.tv_nsec and
mts.tv_nsec on ehl_crb is 100000 (100 microseconds).

Fixes #33544.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>