### PR TITLE
arch: Kconfig: Add option for reserved VM size

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -674,6 +674,15 @@ config KERNEL_VM_SIZE
 	  implement a notion of "high" memory in Zephyr to work around physical
 	  RAM size larger than the defined bounds of the virtual address space.
 
+config VM_RESERVED_PAGES
+	int "Size of kernel address space reserved in pages"
+	default 1
+	help
+	  Size of the address space reserved at the end of the kernel address
+	  space. By default the reserved size is one page which is used for scratch
+	  page. When system needs static fixed virtual to physical mapping such as
+	  fixed mmio mapping, then reserved address space can be changed and used.
+
 menuconfig DEMAND_PAGING
 	bool "Enable demand paging [EXPERIMENTAL]"
 	depends on ARCH_HAS_DEMAND_PAGING

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -221,7 +221,7 @@ extern size_t z_free_page_count;
 /* We reserve a virtual page as a scratch area for page-ins/outs at the end
  * of the address space
  */
-#define Z_VM_RESERVED	CONFIG_MMU_PAGE_SIZE
+#define Z_VM_RESERVED	(CONFIG_VM_RESERVED_PAGES * CONFIG_MMU_PAGE_SIZE)
 #define Z_SCRATCH_PAGE	((void *)((uintptr_t)CONFIG_KERNEL_VM_BASE + \
 				     (uintptr_t)CONFIG_KERNEL_VM_SIZE - \
 				     CONFIG_MMU_PAGE_SIZE))


### PR DESCRIPTION
Add Kconfig option for definition of reserved kernel address
space which by default is used to map scratch page but can
be used for static fixed mappings such as fixed mmio mapping.

Signed-off-by: Leifu Zhao <leifu.zhao@intel.com>