### PR TITLE
Add --verify and --verify-only option to west flash

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -27,7 +27,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, pre_init=None, reset_halt_cmd=DEFAULT_OPENOCD_RESET_HALT_CMD,
                  pre_load=None, load_cmd=None, verify_cmd=None, post_verify=None,
-                 do_verify=False,
+                 do_verify=False, do_verify_only=False,
                  tui=None, config=None, serial=None, use_elf=None,
                  no_halt=False, no_init=False, no_targets=False,
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
@@ -69,6 +69,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.verify_cmd = verify_cmd
         self.post_verify = post_verify or []
         self.do_verify = do_verify or False
+        self.do_verify_only = do_verify_only or False
         self.tcl_port = tcl_port
         self.telnet_port = telnet_port
         self.gdb_port = gdb_port
@@ -115,6 +116,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                             may be given multiple times''')
         parser.add_argument('--verify', action='store_true',
                             help='if given, verify after flash')
+        parser.add_argument('--verify-only', action='store_true',
+                            help='if given, do verify and verify only. No flashing')
 
         # Options for debugging:
         parser.add_argument('--tui', default=False, action='store_true',
@@ -144,7 +147,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init=args.cmd_pre_init, reset_halt_cmd=args.cmd_reset_halt,
             pre_load=args.cmd_pre_load, load_cmd=args.cmd_load,
             verify_cmd=args.cmd_verify, post_verify=args.cmd_post_verify,
-            do_verify=args.verify,
+            do_verify=args.verify, do_verify_only=args.verify_only,
             tui=args.tui, config=args.config, serial=args.serial,
             use_elf=args.use_elf, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,
@@ -266,8 +269,12 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append("-c")
             pre_init_cmd.append(i)
 
+        load_image = []
+        if not self.do_verify_only:
+            load_image = ['-c', 'load_image ' + self.elf_name]
+
         verify_image = []
-        if self.do_verify:
+        if self.do_verify or self.do_verify_only:
             verify_image = ['-c', 'verify_image ' + self.elf_name]
 
         prologue = ['-c', 'resume ' + ep_addr,
@@ -275,8 +282,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
         cmd = (self.openocd_cmd + self.serial + self.cfg_cmd +
                pre_init_cmd + self.init_arg + self.targets_arg +
-               ['-c', self.reset_halt_cmd,
-                '-c', 'load_image ' + self.elf_name] +
+               ['-c', self.reset_halt_cmd] +
+               load_image +
                verify_image +
                prologue)
 


### PR DESCRIPTION
These commits add `--verify` and `--verify-only` options to `west flash`.  These commits are only modifying `do_flash_elf()` for now.

Also I saw that `do_flash()` uses `self.load_cmd` and `self.verify_cmd` but `do_flash_elf()` doesn't.  I haven't look into it yet.