### PR TITLE
Bluetooth: controller: Miscellaneous radio timing tuned

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -587,7 +587,7 @@ static inline void sw_switch(uint8_t dir_curr, uint8_t dir_next,
 		delay = HAL_RADIO_NS2US_CEIL(
 			hal_radio_rx_ready_delay_ns_get(phy_next, flags_next) +
 			hal_radio_tx_chain_delay_ns_get(phy_curr, flags_curr)) +
-			4;
+			(EVENT_CLOCK_JITTER_US << 1);
 
 		hal_radio_rxen_on_sw_switch(ppi);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -582,9 +582,12 @@ static inline void sw_switch(uint8_t dir_curr, uint8_t dir_next,
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	} else {
 		/* RX */
+
+		/* Calculate delay with respect to current and next PHY. */
 		delay = HAL_RADIO_NS2US_CEIL(
-			hal_radio_rx_ready_delay_ns_get(phy_next, flags_next) -
-			hal_radio_tx_chain_delay_ns_get(phy_curr, flags_curr));
+			hal_radio_rx_ready_delay_ns_get(phy_next, flags_next) +
+			hal_radio_tx_chain_delay_ns_get(phy_curr, flags_curr)) +
+			4;
 
 		hal_radio_rxen_on_sw_switch(ppi);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1373,7 +1373,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = radio_tmr_end_get() -
-				    radio_tx_chain_delay_get(0, 0);
+				    radio_rx_chain_delay_get(0, 0);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -384,7 +384,7 @@ static void isr_tx(void *param)
 	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
 	hcto += radio_rx_chain_delay_get(lll->phy_s, 1);
 	hcto += addr_us_get(lll->phy_s);
-	hcto -= radio_tx_chain_delay_get(lll->phy_s, 0);
+	hcto -= radio_tx_chain_delay_get(lll->phy_s, 1);
 	radio_tmr_hcto_configure(hcto);
 
 	/* capture end of CONNECT_IND PDU, used for calculating first

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -625,7 +625,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = radio_tmr_end_get() -
-				    radio_tx_chain_delay_get(lll->phy_s, 0);
+				    radio_rx_chain_delay_get(lll->phy_s, 1);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 		ftr->rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -407,7 +407,7 @@ static void isr_tx(void *param)
 
 	radio_gpio_lna_setup();
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
-				 radio_tx_chain_delay_get(lll->phy_s, 0) -
+				 radio_tx_chain_delay_get(lll->phy_s, 1) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
@@ -557,7 +557,8 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		radio_gpio_pa_setup();
 		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
 					 EVENT_IFS_US -
-					 radio_rx_chain_delay_get(0, 0) -
+					 radio_rx_chain_delay_get(lll->phy_s,
+								  1) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 		return 0;
@@ -609,7 +610,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
 					 EVENT_IFS_US -
 					 radio_rx_chain_delay_get(lll->phy_s,
-								  0) -
+								  1) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -491,7 +491,7 @@ static int isr_rx_pdu(struct lll_scan_aux *lll, uint8_t devmatch_ok,
 		radio_gpio_pa_setup();
 		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
 					 EVENT_IFS_US -
-					 radio_rx_chain_delay_get(0, 0) -
+					 radio_rx_chain_delay_get(lll->phy, 1) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 
@@ -628,7 +628,7 @@ static void isr_tx_connect_req(void *param)
 
 	radio_gpio_lna_setup();
 	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
-				 radio_tx_chain_delay_get(lll_aux->phy, 0) -
+				 radio_tx_chain_delay_get(lll_aux->phy, 1) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -610,7 +610,7 @@ static void isr_tx_connect_req(void *param)
 	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
 	hcto += radio_rx_chain_delay_get(lll_aux->phy, 1);
 	hcto += addr_us_get(lll_aux->phy);
-	hcto -= radio_tx_chain_delay_get(lll_aux->phy, 0);
+	hcto -= radio_tx_chain_delay_get(lll_aux->phy, 1);
 	radio_tmr_hcto_configure(hcto);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_REQ_RSSI) ||

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -81,18 +81,20 @@
 /* Link Layer header size of BIS PDU. Assumes pdu_bis is packed */
 #define PDU_BIS_LL_HEADER_SIZE (offsetof(struct pdu_bis, payload))
 
+/* Event Active Clock Jitter */
+#define EVENT_CLOCK_JITTER_US   2
 /* Event interframe timings */
 #define EVENT_IFS_US            150
 /* Standard allows 2 us timing uncertainty inside the event */
-#define EVENT_IFS_MAX_US        (EVENT_IFS_US + 2)
+#define EVENT_IFS_MAX_US        (EVENT_IFS_US + EVENT_CLOCK_JITTER_US)
 /* Controller will layout extended adv with minimum separation */
 #define EVENT_MAFS_US           300
 /* Standard allows 2 us timing uncertainty inside the event */
-#define EVENT_MAFS_MAX_US       (EVENT_MAFS_US + 2)
+#define EVENT_MAFS_MAX_US       (EVENT_MAFS_US + EVENT_CLOCK_JITTER_US)
 /* Minimum Subevent Space timings */
 #define EVENT_MSS_US            150
 /* Standard allows 2 us timing uncertainty inside the event */
-#define EVENT_MSS_MAX_US        (EVENT_MSS_US + 2)
+#define EVENT_MSS_MAX_US        (EVENT_MSS_US + EVENT_CLOCK_JITTER_US)
 
 /* Offset Units field encoding */
 #define OFFS_UNIT_30_US         30


### PR DESCRIPTION
- In the Tx to Rx switch, fix the delay which should be the
Rx ready delay plus the Tx chain delay and plus 4 us active
clock jitter compensation.
- We need to take RX chain delay and PHY used to receive
CONNECT_IND into account when calculating 1st connection
event offset.
- PA/LNA related timing calculations tuned for extended
advertising and scanning.
- Minor update to calls to get Tx chain delay in extended
advertising and scanning to use S8 encoding delays.