### PR TITLE
drivers/serial/uart_nrfx_uarte: compile CONFIG_MULTITHREADING=y

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -490,9 +490,9 @@ static int wait_tx_ready(const struct device *dev)
 
 			irq_unlock(key);
 		}
-		if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-			k_msleep(1);
-		}
+#ifdef CONFIG_MULTITHREADING
+		k_msleep(1);
+#endif
 	} while (1);
 
 	return key;


### PR DESCRIPTION
Allow to compile when multithreadin is disabled.
Needed for fix #35048.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>