### PR TITLE
net: tcp2: Ack any data received in FIN_WAIT_1 state

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1884,6 +1884,9 @@ next_state:
 		do_close = true;
 		break;
 	case TCP_FIN_WAIT_1:
+		/* Acknowledge but drop any data */
+		conn_ack(conn, + len);
+
 		if (th && FL(&fl, ==, (FIN | ACK), th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
 			conn_ack(conn, + 1);


### PR DESCRIPTION
If we receive any data in FIN_WAIT_1, then ack it even if we
are discarding it.

Fixes #33986

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>
Signed-off-by: Jim Paris <jim@jim.sh>