### PR TITLE
boards/intel_adsp_cavs15: add generic ADSP detection to adsplog.py

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
+++ b/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
@@ -6,7 +6,6 @@
 import os
 import sys
 import time
-import subprocess
 import mmap
 
 # Log reader for the trace output buffer on a ADSP device.
@@ -40,31 +39,29 @@ WIN_IDX = 3
 WIN_SIZE = 0x20000
 LOG_OFFSET = WIN_OFFSET + WIN_IDX * WIN_SIZE
 
-# List of known ADSP devices by their PCI IDs
-DEVICES = ["8086:5a98"]
-
 mem = None
+sys_devices = "/sys/bus/pci/devices"
 
-for dev in DEVICES:
-    # Find me a way to do this detection as cleanly in python as shell, I
-    # dare you.
-    barfile = subprocess.Popen(["sh", "-c",
-                                "echo -n "
-                                "$(dirname "
-                                f"  $(fgrep PCI_ID={dev.upper()} "
-                                "    /sys/bus/pci/devices/*/uevent))"
-                                "/resource4"],
-                               stdout=subprocess.PIPE).stdout.read()
-    if not os.path.exists(barfile):
+for dev_addr in os.listdir(sys_devices):
+    class_file = sys_devices + "/" + dev_addr + "/class"
+    pciclass = open(class_file).read()
+
+    vendor_file = sys_devices + "/" + dev_addr + "/vendor"
+    pcivendor = open(vendor_file).read()
+
+    if not "0x8086" in pcivendor:
         continue
 
-    if not os.access(barfile, os.R_OK):
-        sys.stderr.write(f"ERROR: Cannot open {barfile} for reading.\n")
-        sys.exit(1)
+    # Intel Multimedia audio controller
+    #   0x040100 -> DSP is present
+    #   0x040380 -> DSP is present but optional
+    if "0x040100" in pciclass or "0x040380" in pciclass:
+        barfile = sys_devices + "/" + dev_addr + "/resource4"
 
-    fd = open(barfile)
-    mem = mmap.mmap(fd.fileno(), MAP_SIZE, offset=LOG_OFFSET,
+        fd = open(barfile)
+        mem = mmap.mmap(fd.fileno(), MAP_SIZE, offset=LOG_OFFSET,
                     prot=mmap.PROT_READ)
+        break
 
 if mem is None:
     sys.stderr.write("ERROR: No ADSP device found.\n")


### PR DESCRIPTION
As there are a lot of PCI IDs for various devices, identifying
the ADSP this way will be hard to maintain.

Implement a more generic device look-up using the PCI vendor and class
information to detect a compatible ADSP.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>