### PR TITLE
Minor fixes on labels for GPIO and PWM LEDs

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -232,13 +232,9 @@ static const struct led_pwm_config led_pwm_config_##id = {	\
 								\
 static struct led_pwm_data led_pwm_data_##id;			\
 								\
-DEVICE_DEFINE(led_pwm_##id,					\
-		    DT_INST_PROP_OR(id, label, "LED_PWM_"#id),	\
-		    &led_pwm_init,				\
-		    led_pwm_pm_control,				\
-		    &led_pwm_data_##id,				\
-		    &led_pwm_config_##id,			\
-		    POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
-		    &led_pwm_api);
+DEVICE_DT_INST_DEFINE(id, &led_pwm_init, led_pwm_pm_control,	\
+		      &led_pwm_data_##id, &led_pwm_config_##id,	\
+		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
+		      &led_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LED_PWM_DEVICE)

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -5,6 +5,18 @@ description: GPIO LEDs parent node
 
 compatible: "gpio-leds"
 
+include:
+    - name: base.yaml
+      property-allowlist: [label]
+
+properties:
+    label:
+      description: |
+        Human readable string describing the device and used to set the device
+        name. It can be passed as argument to device_get_binding() to retrieve
+        the device. If this property is omitted, then the device name is set
+        from the node full name.
+
 child-binding:
     description: GPIO LED child node
     properties:
@@ -12,6 +24,9 @@ child-binding:
           type: phandle-array
           required: true
        label:
-          required: true
+          required: false
           type: string
-          description: Human readable string describing the device (used as device_get_binding() argument)
+          description: |
+            Human readable string describing the LED. It can be used by an
+            application to identify this LED or to retrieve its number/index
+            (i.e. child node number) on the parent device.

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -5,14 +5,29 @@ description: PWM LEDs parent node
 
 compatible: "pwm-leds"
 
+include:
+    - name: base.yaml
+      property-allowlist: [label]
+
+properties:
+    label:
+      description: |
+        Human readable string describing the device and used to set the device
+        name. It can be passed as argument to device_get_binding() to retrieve
+        the device. If this property is omitted, then the device name is set
+        from the node full name.
+
 child-binding:
     description: PWM LED child node
     properties:
         pwms:
-          type: phandle-array
           required: true
+          type: phandle-array
 
         label:
           required: false
           type: string
-          description: Human readable string describing the device (used as device_get_binding() argument)
+          description: |
+            Human readable string describing the LED. It can be used by an
+            application to identify this LED or to retrieve its number/index
+            (i.e. child node number) on the parent device.

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if DT_NODE_HAS_STATUS(DT_INST(0, pwm_leds), okay)
 #define LED_PWM_NODE_ID		DT_INST(0, pwm_leds)
-#define LED_PWM_DEV_NAME	DT_INST_PROP_OR(0, label, "LED_PWM_0")
+#define LED_PWM_DEV_NAME	DEVICE_DT_NAME(LED_PWM_NODE_ID)
 #else
 #error "No LED PWM device found"
 #endif


### PR DESCRIPTION
The first patch fixes/improves the name of a PWM LED device when the label property is missing in its DT node.

And the last two patches fix some minor issues about label properties in the DTS bindings of both GPIO and PWM LEDs (#34275).
