### PR TITLE
kernel/swap: Add assertion to catch lock-breaking context switches

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -65,6 +65,27 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 	ARG_UNUSED(lock);
 	struct k_thread *new_thread, *old_thread;
 
+#ifdef CONFIG_SPIN_VALIDATE
+	/* Make sure the key acts to unmask interrupts, if it doesn't,
+	 * then we are context switching out of a nested lock
+	 * (i.e. breaking the lock of someone up the stack) which is
+	 * forbidden!  The sole exception are dummy threads used
+	 * during initialization (where we start with interrupts
+	 * masked and switch away to begin scheduling) and the case of
+	 * a dead current thread that was just aborted (where the
+	 * damage was already done by the abort anyway).
+	 *
+	 * (Note that this is disabled on ARM64, where system calls
+	 * can sometimes run with interrupts masked in ways that don't
+	 * represent lock state.  See #35307)
+	 */
+# ifndef CONFIG_ARM64
+	__ASSERT(arch_irq_unlocked(key) ||
+		 _current->base.thread_state & (_THREAD_DUMMY | _THREAD_DEAD),
+		 "Context switching while holding lock!");
+# endif
+#endif
+
 	old_thread = _current;
 
 	z_check_stack_sentinel();

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -154,7 +154,7 @@ void test_main(void)
 			 ztest_unit_test(test_bitarray_region_set_clear),
 			 ztest_unit_test(test_printk),
 			 ztest_1cpu_unit_test(test_timeout_order),
-			 ztest_1cpu_user_unit_test(test_clock_uptime),
+			 ztest_user_unit_test(test_clock_uptime),
 			 ztest_unit_test(test_clock_cycle),
 			 ztest_unit_test(test_version),
 			 ztest_unit_test(test_multilib),

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -246,10 +246,9 @@ void stack_sentinel_swap(void *p1, void *p2, void *p3)
 	/* Test that stack overflow check due to swap works */
 	blow_up_stack();
 	TC_PRINT("swapping...\n");
-	z_swap_unlocked();
+	z_swap_irqlock(key);
 	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
-	irq_unlock(key);
 }
 
 void stack_hw_overflow(void *p1, void *p2, void *p3)


### PR DESCRIPTION
Our z_swap() API takes a key returned from arch_irq_lock() and
releases it atomically with the context switch.  Make sure that the
action of the unlocking is to unmask interrupts globally.  If
interrupts would still be masked then that means there is an OUTER
interrupt lock still held, and the code that locked it surely doesn't
expect the thread to be suspended and interrupts unmasked while it's
held!

Unfortunately, this kind of mistake is very easy to make.  We should
catch that with a simple assertion.  This is essentially a crude
Zephyr equivalent of the extremely common "BUG: scheduling while
atomic" error in Linux drivers (just google it).

The one exception made is the circumstance where a thread aborts
itself.  This can happen in all sorts of contexts like error handling
where, indeed, a lock might be held (our own test suite does this
pervasively).  But if that's the case, the application error that
needs to be caught is being caught, so we don't want to fail early
with a less informative assertion.

Finally, there was one change to tests/kernel/fatal/exception where
code really was calling z_swap_unlocked() with a lock needlessly held,
so that's been fixed.

Fixes #33319

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>