### PR TITLE
tests: kernel: fix two semaphroe testcases failed on ADSP

### DIFF
--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -988,7 +988,7 @@ void sem_multiple_take_and_timeouts_helper(void *p1, void *p2, void *p3)
  */
 void test_sem_multiple_take_and_timeouts(void)
 {
-	uint32_t timeout;
+	static uint32_t timeout;
 	size_t bytes_read;
 
 	k_sem_reset(&simple_sem);
@@ -1061,7 +1061,7 @@ void test_sem_multi_take_timeout_diff_sem(void)
 		{ SEC2MS(4), &simple_sem },
 	};
 
-	struct timeout_info retrieved_info;
+	static struct timeout_info retrieved_info;
 
 	k_sem_reset(&simple_sem);
 	k_sem_reset(&multiple_thread_sem);


### PR DESCRIPTION
Two testcases of semaphore failed in ADSP due to the timeout value
we got back from the child thread is invalid. We put the variable in
the bss instead of in a stack, trying to avoid this.

Fixes #34687 

Signed-off-by: Enjia Mai <enjiax.mai@intel.com>