### PR TITLE
tests/kernel/common: Skip bitarray tests when KERNEL_COHERENCE

### DIFF
--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -131,6 +131,11 @@ void test_bitarray_set_clear(void)
 	int bit_val;
 	size_t bit, bundle_idx, bit_idx_in_bundle;
 
+	/* Bitarrays have embedded spinlocks and can't on the stack. */
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
+
 	SYS_BITARRAY_DEFINE(ba, 234);
 
 	for (bit = 0U; bit < ba.num_bits; ++bit) {
@@ -465,6 +470,11 @@ void test_bitarray_alloc_free(void)
 {
 	int i;
 
+	/* Bitarrays have embedded spinlocks and can't on the stack. */
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
+
 	alloc_and_free_predefined();
 
 	i = 1;
@@ -480,6 +490,11 @@ void test_bitarray_alloc_free(void)
 void test_bitarray_region_set_clear(void)
 {
 	int ret;
+
+	/* Bitarrays have embedded spinlocks and can't on the stack. */
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
 
 	uint32_t ba_expected[4];
 


### PR DESCRIPTION
Kernel objects that contain embedded synchronization structures like
spinlocks can't be palced in the (cached/incoherent) stack memory on
coherence platforms like intel_adsp.

The normal fix in a test case is just to make the offending data
static, but that's painful here because SYS_BITARRAY_DEFINE declares
two objects (i.e. you can't put a "static" in front of it as with
similar macros) and it happens to be used in this case to define local
variables with collliding names, so I'd have to go in and rename
everything.

And there's little value anyway.  Bitarrays are nearly-pure data
structures and extremely unlikely to show up platform-dependent
behavior.

Fixes #35242

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>