### PR TITLE
edtlib: validate compatible properties

### DIFF
--- a/boards/arm/96b_carbon/96b_lscon.dtsi
+++ b/boards/arm/96b_carbon/96b_lscon.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	lscon_96b: connector {
-		compatible = "96b-lscon-3v3";
+		compatible = "linaro,96b-lscon-3v3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/arm/96b_nitrogen/96b_lscon.dtsi
+++ b/boards/arm/96b_nitrogen/96b_lscon.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	lscon_96b: connector {
-		compatible = "96b-lscon-1v8";
+		compatible = "linaro,96b-lscon-1v8";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/arm/96b_wistrio/96b_lscon.dtsi
+++ b/boards/arm/96b_wistrio/96b_lscon.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	lscon_96b: connector {
-		compatible = "96b-lscon-3v3";
+		compatible = "linaro,96b-lscon-3v3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "u-blox BMD-300-EVAL EVK nRF52832";
-	compatible = "u-blox, ubx_bmd300eval_nrf52832";
+	compatible = "u-blox,ubx-bmd300eval-nrf52832";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "u-blox BMD-330-EVAL EVK nRF52810";
-	compatible = "u-blox, ubx_bmd330eval_nrf52810";
+	compatible = "u-blox,ubx-bmd330eval-nrf52810";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "u-blox BMD-340-EVAL EVK nRF52840";
-	compatible = "u-blox, ubx_bmd340eval_nrf52840";
+	compatible = "u-blox,ubx-bmd340eval-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "u-blox BMD-345-EVAL EVK nRF52840";
-	compatible = "u-blox, ubx_bmd345eval_nrf52840";
+	compatible = "u-blox,ubx-bmd345eval-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "u-blox BMD-360-EVAL EVK nRF52811";
-	compatible = "u-blox, ubx_bmd360eval_nrf52811";
+	compatible = "u-blox,ubx-bmd360eval-nrf52811";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "u-blox BMD-380-EVAL EVK nRF52840";
-	compatible = "u-blox, ubx_bmd380eval_nrf52840";
+	compatible = "u-blox,ubx-bmd380eval-nrf52840";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "IT8XXX2 EV-Board";
-	compatible = "riscv, it8xxx2_evb";
+	compatible = "riscv,it8xxx2-evb";
 	chosen {
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;

--- a/boards/xtensa/qemu_xtensa/qemu_xtensa.dts
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "qemu_xtensa";
-	compatible = "xtensa, sample_controller";
+	compatible = "xtensa,sample-controller";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/xtensa/xt-sim/xt-sim.dts
+++ b/boards/xtensa/xt-sim/xt-sim.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "xt-sim";
-	compatible = "xtensa,sample_controller";
+	compatible = "xtensa,sample-controller";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -566,6 +566,14 @@ Build and Infrastructure
 * Devicetree
 
   - :c:macro:`DT_COMPAT_GET_ANY_STATUS_OKAY`: new macro
+  - the ``96b-lscon-3v3`` and ``96b-lscon-1v8`` :ref:`compatible properties
+    <dt-important-props>` now have ``linaro,`` vendor prefixes, i.e. they are
+    now respectively :dtcompatible:`linaro,96b-lscon-3v3` and
+    :dtcompatible:`linaro,96b-lscon-1v8`.
+
+    This change was made to bring Zephyr's devicetrees into compliance with an
+    upstream Linux regular expression used to validate compatible properties.
+    This regular expression requires a letter as the first character.
 
 * West
 

--- a/dts/bindings/gpio/96boards-lscon-1v8.yaml
+++ b/dts/bindings/gpio/96boards-lscon-1v8.yaml
@@ -3,6 +3,6 @@
 
 description: Represents GPIO pin nodes exposed on the 96Boards 1.8v low-speed header
 
-compatible: "96b-lscon-1v8"
+compatible: "linaro,96b-lscon-1v8"
 
 include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/gpio/96boards-lscon-3v3.yaml
+++ b/dts/bindings/gpio/96boards-lscon-3v3.yaml
@@ -4,6 +4,6 @@
 description: |
     Represents GPIO pin nodes exposed on the 96Boards 3.3v low-speed header
 
-compatible: "96b-lscon-3v3"
+compatible: "linaro,96b-lscon-3v3"
 
 include: [gpio-nexus.yaml, base.yaml]

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -475,6 +475,30 @@ class EDT:
                         'in lowercase: ' +
                         ', '.join(repr(x) for x in spec.enum))
 
+        # Validate the contents of compatible properties.
+        # The regular expression comes from dt-schema.
+        compat_re = r'^[a-zA-Z][a-zA-Z0-9,+\-._]+$'
+        for node in self.nodes:
+            if 'compatible' not in node.props:
+                continue
+
+            compatibles = node.props['compatible'].val
+
+            # _check() runs after _init_compat2binding() has called
+            # _dt_compats(), which already converted every compatible
+            # property to a list of strings. So we know 'compatibles'
+            # is a list, but add an assert for future-proofing.
+            assert isinstance(compatibles, list)
+
+            for compat in compatibles:
+                # This is also just for future-proofing.
+                assert isinstance(compat, str)
+
+                if not re.match(compat_re, compat):
+                    _err(f"node '{node.path}' compatible '{compat}' "
+                         'must match this regular expression: '
+                         f"'{compat_re}'")
+
 class Node:
     """
     Represents a devicetree node, augmented with information from bindings, and

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -498,6 +498,24 @@ def test_slice_errs(tmp_path):
                  dts_file,
                  f"'ranges' property in <Node /sub-1 in '{dts_file}'> has length 8, which is not evenly divisible by 24 (= 4*(<#address-cells> (= 2) + <#address-cells for parent> (= 1) + <#size-cells> (= 3))). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
 
+def test_bad_compatible(tmp_path):
+    # An invalid compatible should cause an error, even on a node with
+    # no binding.
+
+    dts_file = tmp_path / "error.dts"
+
+    verify_error("""
+/dts-v1/;
+
+/ {
+	foo {
+		compatible = "no, whitespace";
+	};
+};
+""",
+                 dts_file,
+                 r"node '/foo' compatible 'no, whitespace' must match this regular expression: '^[a-zA-Z][a-zA-Z0-9,+\-._]+$'")
+
 def verify_error(dts, dts_file, expected_err):
     # Verifies that parsing a file 'dts_file' with the contents 'dts'
     # (a string) raises an EDTError with the message 'expected_err'.


### PR DESCRIPTION
Error out on compatible properties with invalid values. The regular
expression used to validate them matches what's used in dt-schema.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>