### PR TITLE
samples: bluetooth: Convert peripheral_hr sample.yaml to use depends_on

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -10,6 +10,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
+  - arduino_serial
   - can
   - counter
   - dac

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
 supported:
+  - arduino_serial
   - clock_controller
   - pinmux
   - gpio

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 32
 flash: 16384
 supported:
+  - arduino_serial
   - i2c
   - counter
   - usb_device

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -16,6 +16,7 @@ ram: 32
 flash: 16384
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - gpio
   - i2c

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - gpio
   - i2c

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 65536
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 65536
 supported:
   - arduino_gpio
+  - arduino_serial
   - counter
   - display
   - gpio

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -12,6 +12,6 @@ tests:
     build_only: true
   sample.bluetooth.peripheral_hr.frdm_kw41z_shield:
     harness: bluetooth
-    platform_allow: mimxrt1020_evk mimxrt1050_evk mimxrt1060_evk frdm_k64f
+    depends_on: arduino_serial
     tags: bluetooth
     extra_args: SHIELD=frdm_kw41z


### PR DESCRIPTION
Converts the Bluetooth peripheral_hr sample.yaml to select boards for
the frdm_kw41z shield configuration by depending on the arduino_serial
feature instead of using an explicit platform_allow list. This will
enable twister to automatically select new boards that add support for
an Arduino serial port.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>