### PR TITLE
samples: display: Convert driver and lvgl sample.yaml to use depends_on

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.yaml
+++ b/boards/arm/frdm_k22f/frdm_k22f.yaml
@@ -10,6 +10,7 @@ supported:
   - adc
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - dac
   - gpio
   - i2c

--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
+  - arduino_spi
   - can
   - counter
   - dac

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -3,7 +3,8 @@ sample:
   name: display_sample
 tests:
   sample.display.shield.adafruit_2_8_tft_touch_v2:
-    platform_allow: nrf52840dk_nrf52840 mimxrt685_evk_cm33 frdm_k64f
+    depends_on: arduino_gpio arduino_i2c arduino_spi
+    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: display shield
     harness: console

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -7,7 +7,8 @@ tests:
     platform_allow: reel_board mimxrt1050_evk mimxrt1060_evk mimxrt1064_evk
     tags: samples display gui
   sample.display.adafruit_2_8_tft_touch_v2:
-    platform_allow: nrf52840dk_nrf52840 mimxrt685_evk_cm33 frdm_k64f
+    depends_on: arduino_gpio arduino_i2c arduino_spi
+    platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
   sample.display.waveshare_epaper_gdeh0213b1:


### PR DESCRIPTION
Converts the display driver and lvgl sample.yaml to select boards for
the adafruit_2_8_tft_touch_v2 shield configuration by depending on the
arduino_{gpio,i2c,spi} features instead of using an explicit
platform_allow list. This will enable twister to automatically select
new boards that add support for Arduino ports.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>