### PR TITLE
shell: kernel: fix reset command echo abrupt termination

### DIFF
--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -14,6 +14,18 @@ config KERNEL_SHELL
 	  This shell provides access to basic kernel data like version, uptime
 	  and other useful information.
 
+config KERNEL_SHELL_REBOOT_DELAY
+	int "Delay between reception of shell reboot command and reboot (ms)"
+	depends on KERNEL_SHELL
+	depends on REBOOT
+	default 0
+	help
+	  This delay allows time for the shell to successfully echo the reboot
+	  command input before the reboot abruptly terminates it. This can help
+	  external systems that interact with the shell and require the reboot
+	  command's echo to successfully complete to synchronise with the
+	  device.
+
 config DEVICE_SHELL
 	bool "Enable device shell"
 	default y if !SHELL_MINIMAL

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -220,6 +220,9 @@ static int cmd_kernel_reboot_warm(const struct shell *shell,
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
+#if (CONFIG_KERNEL_SHELL_REBOOT_DELAY > 0)
+	k_sleep(K_MSEC(CONFIG_KERNEL_SHELL_REBOOT_DELAY));
+#endif
 	sys_reboot(SYS_REBOOT_WARM);
 	return 0;
 }
@@ -229,6 +232,9 @@ static int cmd_kernel_reboot_cold(const struct shell *shell,
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
+#if (CONFIG_KERNEL_SHELL_REBOOT_DELAY > 0)
+	k_sleep(K_MSEC(CONFIG_KERNEL_SHELL_REBOOT_DELAY));
+#endif
 	sys_reboot(SYS_REBOOT_COLD);
 	return 0;
 }


### PR DESCRIPTION
Allow time for the shell to successfully echo the reboot command input
before the reboot abruptly terminates it. This can help external
systems that interact with the shell and require the reboot command's
echo to successfully complete to synchronise with the device.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/35325

Signed-off-by: Nick Ward <nick.ward@setec.com.au>