### PR TITLE
nxp: rt series eth timer clock enable

### DIFF
--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -59,7 +59,11 @@ const clock_enet_pll_config_t ethPllConfig = {
 #ifdef CONFIG_ETH_MCUX
 	.enableClkOutput = true,
 #endif
+#if defined(CONFIG_PTP_CLOCK_MCUX)
+	.enableClkOutput25M = true,
+#else
 	.enableClkOutput25M = false,
+#endif
 	.loopDivider = 1,
 };
 #endif


### PR DESCRIPTION
enable ethernet timer clock when enabling ptp

Fixes: #33747

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>