### PR TITLE
Fix GSM modem compilation when muxing is enabled

### DIFF
--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -374,7 +374,7 @@ static int init_real_uart(const struct device *mux, const struct device *uart,
 		real_uart->mux = gsm_mux_create(mux);
 
 		LOG_DBG("Initializing UART %s and GSM mux %p",
-			real_uart->uart->name, real_uart->mux);
+			real_uart->uart->name, (void *)real_uart->mux);
 
 		if (!real_uart->mux) {
 			real_uart->uart = NULL;
@@ -826,7 +826,7 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 	struct uart_mux_dev_data *dev_data = DEV_DATA(mux);
 	size_t wrote = 0;
 
-	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, dlci,
+	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, (void *)dlci,
 		data, len);
 
 	if (IS_ENABLED(CONFIG_UART_MUX_VERBOSE_DEBUG)) {

--- a/samples/net/gsm_modem/sample.yaml
+++ b/samples/net/gsm_modem/sample.yaml
@@ -9,3 +9,8 @@ tests:
   sample.net.ppp.gsm.modem:
     extra_configs:
       - CONFIG_TEST_RANDOM_GENERATOR=y
+  sample.net.ppp.gsm.modem.mux:
+    extra_configs:
+      - CONFIG_TEST_RANDOM_GENERATOR=y
+      - CONFIG_GSM_MUX=y
+      - CONFIG_UART_MUX=y


### PR DESCRIPTION
The logging macros use _Generic() atm and it started to complain when we are trying to print pointer value of gsm_dlci and gsm_mux structs. Cast the pointer value to (void *) to overcome this.

Add also compilation test to GSM modem sample so that we can catch this issue earlier.

Fixes #35329
