### PR TITLE
coding guidelines rule 14.3: add explicit case check

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -669,7 +669,7 @@ int z_object_validate(struct z_object *ko, enum k_objects otype,
 		if (unlikely((ko->flags & K_OBJ_FLAG_INITIALIZED) == 0U)) {
 			return -EINVAL;
 		}
-	} else if (init < _OBJ_INIT_TRUE) { /* _OBJ_INIT_FALSE case */
+	} else if (init == _OBJ_INIT_FALSE) { /* _OBJ_INIT_FALSE case */
 		/* Object MUST NOT be initialized */
 		if (unlikely((ko->flags & K_OBJ_FLAG_INITIALIZED) != 0U)) {
 			return -EADDRINUSE;


### PR DESCRIPTION
<b>MISRA violation:</b>
MISRAC-2012 Rule 14.3 Boolean operations whose results are invariant
shall not be permitted
<b>Zephyr Coding Guideline Main Rules violation:</b>
Rule 14.3 | Required | Controlling expressions shall not be invariant

<b>Solution:</b>
Probably in that part of code is a misprint.
Added to check _OBJ_INIT_FALSE case explicitly

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>