### PR TITLE
shell: log_backend: Add mpsc_pbuf buffer alignment

### DIFF
--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -75,7 +75,7 @@ int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
 	LOG_OUTPUT_DEFINE(_name##_log_output, z_shell_log_backend_output_func,\
 			  _buf, _size); \
 	static struct shell_log_backend_control_block _name##_control_block; \
-	static uint32_t _name##_buf[128]; \
+	static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT) _name##_buf[128]; \
 	const struct mpsc_pbuf_buffer_config _name##_mpsc_buffer_config = { \
 		.buf = _name##_buf, \
 		.size = ARRAY_SIZE(_name##_buf), \


### PR DESCRIPTION
Buffer used for storing log messages must be aligned as specified
by Z_LOG_MSG2_ALIGNMENT. Added missing alignment.

Fixes #35051.

Note, that buffer is currently fixed size. Must be changed to configurable value in the future.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>