### PR TITLE
doc: fix multiple issues

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -176,6 +176,7 @@ breathe_domain_by_extension = {
     "c": "c",
 }
 breathe_show_enumvalue_initializer = True
+breathe_default_members = ("members", )
 
 cpp_id_attributes = [
     "__syscall",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,7 +175,6 @@ breathe_domain_by_extension = {
     "h": "c",
     "c": "c",
 }
-breathe_separate_member_pages = True
 breathe_show_enumvalue_initializer = True
 
 cpp_id_attributes = [

--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -1,16 +1,16 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
-.*Duplicate C declaration.*\n.*'\.\. c:struct:: dma_config'.*
-.*Duplicate C declaration.*\n.*'\.\. c:struct:: zsock_fd_set'.*
-.*Duplicate C declaration.*\n.*'\.\. c:struct:: net_if_mcast_monitor'.*
-.*Duplicate C declaration.*\n.*'\.\. c:struct:: fs_statvfs'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*dmic_trigger.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:var:: uint16_t id'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*net_if_ipv4_addr_mask_cmp.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*net_if_ipv4_is_addr_bcast.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*net_if_ipv4_addr_lookup.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*net_if_ipv6_addr_lookup.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:function:: .*net_if_ipv6_maddr_lookup.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:None:: .*struct in_addr.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:None:: .*struct in6_addr.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:None:: .*struct net_if.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: dma_config'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: zsock_fd_set'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: net_if_mcast_monitor'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: fs_statvfs'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*dmic_trigger.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: uint16_t id'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_addr_mask_cmp.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_is_addr_bcast.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_addr_lookup.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv6_addr_lookup.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv6_maddr_lookup.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*

--- a/doc/reference/bluetooth/connection_mgmt.rst
+++ b/doc/reference/bluetooth/connection_mgmt.rst
@@ -29,4 +29,3 @@ API Reference
 
 .. doxygengroup:: bt_conn
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/controller.rst
+++ b/doc/reference/bluetooth/controller.rst
@@ -9,4 +9,3 @@ API Reference
 
 .. doxygengroup:: bt_ctrl
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/crypto.rst
+++ b/doc/reference/bluetooth/crypto.rst
@@ -9,4 +9,3 @@ API Reference
 
 .. doxygengroup:: bt_crypto
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/data_buffer.rst
+++ b/doc/reference/bluetooth/data_buffer.rst
@@ -9,4 +9,3 @@ API Reference
 
 .. doxygengroup:: bt_buf
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/gap.rst
+++ b/doc/reference/bluetooth/gap.rst
@@ -8,12 +8,9 @@ API Reference
 
 .. doxygengroup:: bt_gap
    :project: Zephyr
-   :members:
 
 .. doxygengroup:: bt_addr
    :project: Zephyr
-   :members:
 
 .. doxygengroup:: bt_gap_defines
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/gatt.rst
+++ b/doc/reference/bluetooth/gatt.rst
@@ -97,18 +97,15 @@ API Reference
 
 .. doxygengroup:: bt_gatt
    :project: Zephyr
-   :members:
 
 GATT Server
 ===========
 
 .. doxygengroup:: bt_gatt_server
    :project: Zephyr
-   :members:
 
 GATT Client
 ===========
 
 .. doxygengroup:: bt_gatt_client
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/hci_drivers.rst
+++ b/doc/reference/bluetooth/hci_drivers.rst
@@ -10,4 +10,3 @@ API Reference
 
 .. doxygengroup:: bt_hci_driver
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/hci_raw.rst
+++ b/doc/reference/bluetooth/hci_raw.rst
@@ -17,4 +17,3 @@ API Reference
 
 .. doxygengroup:: hci_raw
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/hfp.rst
+++ b/doc/reference/bluetooth/hfp.rst
@@ -9,4 +9,3 @@ API Reference
 
 .. doxygengroup:: bt_hfp
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/l2cap.rst
+++ b/doc/reference/bluetooth/l2cap.rst
@@ -40,4 +40,3 @@ API Reference
 
 .. doxygengroup:: bt_l2cap
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -144,4 +144,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_access
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/cfg.rst
+++ b/doc/reference/bluetooth/mesh/cfg.rst
@@ -20,4 +20,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_cfg
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/cfg_cli.rst
+++ b/doc/reference/bluetooth/mesh/cfg_cli.rst
@@ -25,4 +25,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_cfg_cli
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/cfg_srv.rst
+++ b/doc/reference/bluetooth/mesh/cfg_srv.rst
@@ -22,4 +22,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_cfg_srv
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -26,4 +26,3 @@ API reference
 
 .. doxygengroup:: bt_mesh
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/health_cli.rst
+++ b/doc/reference/bluetooth/mesh/health_cli.rst
@@ -22,4 +22,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_health_cli
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/health_srv.rst
+++ b/doc/reference/bluetooth/mesh/health_srv.rst
@@ -50,7 +50,6 @@ API reference
 
 .. doxygengroup:: bt_mesh_health_srv
    :project: Zephyr
-   :members:
 
 .. _bluetooth_mesh_health_faults:
 
@@ -61,4 +60,3 @@ Fault values defined by the Bluetooth Mesh specification.
 
 .. doxygengroup:: bt_mesh_health_faults
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/heartbeat.rst
+++ b/doc/reference/bluetooth/mesh/heartbeat.rst
@@ -64,4 +64,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_heartbeat
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/msg.rst
+++ b/doc/reference/bluetooth/mesh/msg.rst
@@ -11,4 +11,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_msg
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/provisioning.rst
+++ b/doc/reference/bluetooth/mesh/provisioning.rst
@@ -133,4 +133,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_prov
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/mesh/proxy.rst
+++ b/doc/reference/bluetooth/mesh/proxy.rst
@@ -14,4 +14,3 @@ API reference
 
 .. doxygengroup:: bt_mesh_proxy
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/rfcomm.rst
+++ b/doc/reference/bluetooth/rfcomm.rst
@@ -10,4 +10,3 @@ API Reference
 
 .. doxygengroup:: bt_rfcomm
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/sdp.rst
+++ b/doc/reference/bluetooth/sdp.rst
@@ -8,4 +8,3 @@ API Reference
 
 .. doxygengroup:: bt_sdp
    :project: Zephyr
-   :members:

--- a/doc/reference/bluetooth/uuid.rst
+++ b/doc/reference/bluetooth/uuid.rst
@@ -9,4 +9,3 @@ API Reference
 
 .. doxygengroup:: bt_uuid
    :project: Zephyr
-   :members:

--- a/doc/reference/storage/flash_map/flash_map.rst
+++ b/doc/reference/storage/flash_map/flash_map.rst
@@ -96,4 +96,3 @@ API Reference
 
 .. doxygengroup:: flash_area_api
    :project: Zephyr
-   :members:

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -202,7 +202,7 @@ INHERIT_DOCS           = YES
 # of the file/class/namespace that contains it.
 # The default value is: NO.
 
-SEPARATE_MEMBER_PAGES  = YES
+SEPARATE_MEMBER_PAGES  = NO
 
 # The TAB_SIZE tag can be used to set the number of spaces in a tab. Doxygen
 # uses this value to replace tabs by spaces in code fragments.

--- a/include/drivers/display.h
+++ b/include/drivers/display.h
@@ -81,58 +81,31 @@ enum display_orientation {
 	DISPLAY_ORIENTATION_ROTATED_270,
 };
 
-/**
- * @struct display_capabilities
- * @brief Structure holding display capabilities
- *
- * @var uint16_t display_capabilities::x_resolution
- * Display resolution in the X direction
- *
- * @var uint16_t display_capabilities::y_resolution
- * Display resolution in the Y direction
- *
- * @var uint32_t display_capabilities::supported_pixel_formats
- * Bitwise or of pixel formats supported by the display
- *
- * @var uint32_t display_capabilities::screen_info
- * Information about display panel
- *
- * @var enum display_pixel_format display_capabilities::current_pixel_format
- * Currently active pixel format for the display
- *
- * @var enum display_orientation display_capabilities::current_orientation
- * Current display orientation
- */
+/** @brief Structure holding display capabilities. */
 struct display_capabilities {
+	/** Display resolution in the X direction */
 	uint16_t x_resolution;
+	/** Display resolution in the Y direction */
 	uint16_t y_resolution;
+	/** Bitwise or of pixel formats supported by the display */
 	uint32_t supported_pixel_formats;
+	/** Information about display panel */
 	uint32_t screen_info;
+	/** Currently active pixel format for the display */
 	enum display_pixel_format current_pixel_format;
+	/** Current display orientation */
 	enum display_orientation current_orientation;
 };
 
-/**
- * @struct display_buffer_descriptor
- * @brief Structure to describe display data buffer layout
- *
- * @var uint32_t display_buffer_descriptor::buf_size
- * Data buffer size in bytes
- *
- * @var uint16_t display_buffer_descriptor::width
- * Data buffer row width in pixels
- *
- * @var uint16_t display_buffer_descriptor::height
- * Data buffer column height in pixels
- *
- * @var uint16_t display_buffer_descriptor::pitch
- * Number of pixels between consecutive rows in the data buffer
- *
- */
+/** @brief Structure to describe display data buffer layout */
 struct display_buffer_descriptor {
+	/** Data buffer size in bytes */
 	uint32_t buf_size;
+	/** Data buffer row width in pixels */
 	uint16_t width;
+	/** Data buffer column height in pixels */
 	uint16_t height;
+	/** Number of pixels between consecutive rows in the data buffer */
 	uint16_t pitch;
 };
 


### PR DESCRIPTION
Summary:
```
doc: doxygen: do not use separate member pages
When this option is enabled some data structures have missing pages. Use
the default setting (NO).

doc: warnings: make expressions more generic
When duplicates exist the problem may come from two or more distinct
constructs. When running parallel builds there is no guarantee on which
one will come first (or if all), so allow any C construct.

drivers: display: fix doxygen issues
The way some structures were documented was causing issues on the
Sphinx/Breathe side. Move to a more "standard" format.

doc: enable members option by default when using breathe 
Enable the :members: option by default when using breathe directives.
This exposes automatically stuff like structure fields.

doc: remove redundant usage of :members: in breathe directives
:members: is now enabled by default.
```

ref:https://zephyrproject.slack.com/archives/C18PLHN8H/p1621107917366000