### PR TITLE
twister: fix hardware map generation

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -533,13 +533,13 @@ command to produce the hardware map::
 The generated hardware map file (map.yml) will have the list of connected
 devices, for example::
 
-  - available: true
+  - connected: true
     id: OSHW000032254e4500128002ab98002784d1000097969900
     platform: unknown
     product: DAPLink CMSIS-DAP
     runner: pyocd
     serial: /dev/cu.usbmodem146114202
-  - available: true
+  - connected: true
     id: 000683759358
     platform: unknown
     product: J-Link
@@ -552,13 +552,13 @@ values, in the above example both the platform names and the runners need to be
 replaced with the correct values corresponding to the connected hardware. In
 this example we are using a reel_board and an nrf52840dk_nrf52840::
 
-  - available: true
+  - connected: true
     id: OSHW000032254e4500128002ab98002784d1000097969900
     platform: reel_board
     product: DAPLink CMSIS-DAP
     runner: pyocd
     serial: /dev/cu.usbmodem146114202
-  - available: true
+  - connected: true
     id: 000683759358
     platform: nrf52840dk_nrf52840
     product: J-Link
@@ -595,8 +595,7 @@ map file.
 
 Fixtures are defined in the hardware map file as a list::
 
-      - available: true
-        connected: true
+      - connected: true
         fixtures:
           - gpio_loopback
         id: 0240000026334e450015400f5e0e000b4eb1000097969900
@@ -619,8 +618,7 @@ It may be useful to annotate board descriptions in the hardware map file
 with additional information.  Use the "notes" keyword to do this.  For
 example::
 
-    - available: true
-      connected: false
+    - connected: false
       fixtures:
         - gpio_loopback
       id: 000683290670
@@ -643,8 +641,7 @@ cases the detected ID is not the correct one to use, for example when
 using an external J-Link probe.  The "probe_id" keyword overrides the
 "id" keyword for this purpose.   For example::
 
-    - available: true
-      connected: false
+    - connected: false
       id: 0229000005d9ebc600000000000000000000000097969905
       platform: mimxrt1060_evk
       probe_id: 000609301751

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -4097,7 +4097,8 @@ class HardwareMap:
                                         id=d.serial_number,
                                         serial=persistent_map.get(d.device, d.device),
                                         product=d.product,
-                                        runner='unknown')
+                                        runner='unknown',
+                                        connected=True)
 
                 for runner, _ in self.runner_mapping.items():
                     products = self.runner_mapping.get(runner)
@@ -4166,7 +4167,8 @@ class HardwareMap:
                     'id': id,
                     'runner': runner,
                     'serial': serial,
-                    'product': product
+                    'product': product,
+                    'connected': _connected.connected
                 }
                 dl.append(d)
             with open(hwm_file, 'w') as yaml_file:


### PR DESCRIPTION
when generating a new map, set the status of the device and whether it
is connected or now. The available key is runtime only and is not part
of the map anymore.
Adapt documentation and remove available as a key in the generated map.

Fixes #35341

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
