### PR TITLE
thread analyzer: fix formatting for unsigned int

### DIFF
--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -37,11 +37,11 @@ LOG_MODULE_REGISTER(thread_analyzer, CONFIG_THREAD_ANALYZER_LOG_LEVEL);
 
 static void thread_print_cb(struct thread_analyzer_info *info)
 {
-	unsigned int pcnt = (info->stack_used * 100U) / info->stack_size;
+	uint32_t pcnt = (info->stack_used * 100U) / info->stack_size;
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	THREAD_ANALYZER_PRINT(
 		THREAD_ANALYZER_FMT(
-			" %-20s: STACK: unused %zu usage %zu / %zu (%zu %%); CPU: %zu %%"),
+			" %-20s: STACK: unused %zu usage %zu / %zu (%u %%); CPU: %u %%"),
 		THREAD_ANALYZER_VSTR(info->name),
 		info->stack_size - info->stack_used, info->stack_used,
 		info->stack_size, pcnt,
@@ -49,7 +49,7 @@ static void thread_print_cb(struct thread_analyzer_info *info)
 #else
 	THREAD_ANALYZER_PRINT(
 		THREAD_ANALYZER_FMT(
-			" %-20s: unused %zu usage %zu / %zu (%zu %%)"),
+			" %-20s: unused %zu usage %zu / %zu (%u %%)"),
 		THREAD_ANALYZER_VSTR(info->name),
 		info->stack_size - info->stack_used, info->stack_used,
 		info->stack_size, pcnt);


### PR DESCRIPTION
On 64bit systems, this was issuing warnings due to wrong formatting.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
