### PR TITLE
doc: fix doxygen grouping

### DIFF
--- a/include/drivers/edac.h
+++ b/include/drivers/edac.h
@@ -43,7 +43,8 @@ typedef int (*edac_api_notify_cb_set_f)(const struct device *dev,
 				      edac_notify_callback_f cb);
 
 /**
- * @defgroup edac Zephyr API
+ * @defgroup edac EDAC API
+ * @ingroup io_interfaces
  * @{
  */
 

--- a/include/pm/state.h
+++ b/include/pm/state.h
@@ -15,7 +15,8 @@ extern "C" {
 #endif
 
 /**
- * @defgroup pm_states Power Management states
+ * @defgroup pm_states Power Management States
+ * @ingroup power_management_api
  * @{
  */
 

--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 /**
- * @defgroup sys-util Zephyr utilities
+ * @defgroup sys-util Utility Functions
  * @{
  */
 

--- a/subsys/testsuite/ztest/include/ztest.h
+++ b/subsys/testsuite/ztest/include/ztest.h
@@ -7,11 +7,11 @@
 /**
  * @file
  *
- * @brief Zephyr testing suite
+ * @brief Zephyr Testsuite
  */
 
 /**
- * @brief Zephyr Tests
+ * @brief Zephyr Tests (ZTest)
  * @defgroup all_tests Zephyr Tests
  * @{
  * @}

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -62,9 +62,11 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	k_sem_give(&sema);
 }
 /**
- * @addtogroup kernel_tickless_tests
+ * @defgroup  kernel_tickless_tests Tickless
+ * @ingroup all_tests
  * @{
  */
+
 
 /**
  * @brief Verify system clock with and without tickless idle


### PR DESCRIPTION
Fix various grouping issues in doxygen and name groups correctly in some
cases.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
