### PR TITLE
actions: publish docs every 3 hours

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -6,7 +6,7 @@ name: Doc build for Release or Daily
 # Either a daily based on schedule/cron or only on tag push
 on:
   schedule:
-    - cron:  '50 22,11 * * *'
+    - cron:  '50 1/3 * * *'
   push:
     paths:
       - 'VERSION'


### PR DESCRIPTION
Publish docs every 3 hours, this way fixes early in the morning are
reflected online earlier and no need to wait until the next day.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
