### PR TITLE
samples: pm: Fix device pm sample

### DIFF
--- a/samples/subsys/pm/device_pm/sample.yaml
+++ b/samples/subsys/pm/device_pm/sample.yaml
@@ -10,8 +10,8 @@ tests:
       regex:
         - "Device PM sample app start"
         - "parent resuming\\.\\."
-        - "child resuming\\.\\."
         - "Async wakeup request queued"
+        - "child resuming\\.\\."
         - "Dummy device resumed"
         - "child suspending\\.\\."
         - "parent suspending\\.\\."

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -83,7 +83,7 @@ static int dummy_close(const struct device *dev)
 
 	/* Parent can be suspended */
 	if (parent) {
-		pm_device_put(parent);
+		pm_device_put_sync(parent);
 	}
 
 	return ret;


### PR DESCRIPTION
"child resuming" text is printed when dummy_device_pm_ctrl is
called. The driver is using the async api, this means that this call
will happen only when the worqueue runs what will happen only when
this thread blocks waiting on the conditional variable.

The last thing is, the dummy driver was putting the parent driver
asynchronously consequently the "parent suspending" message would just
print after "Device PM sample app complete". Just use the sync API to
get these messages printed in the expected order.

Fixes #35336

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>