### PR TITLE
drivers: uart: stm32: fix handling interrupt and async api in isr

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -791,6 +791,12 @@ static void uart_stm32_isr(const struct device *dev)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	if (data->user_cb) {
+		data->user_cb(dev, data->user_data);
+	}
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
 #ifdef CONFIG_UART_ASYNC_API
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
@@ -820,12 +826,6 @@ static void uart_stm32_isr(const struct device *dev)
 	/* Clear errors */
 	uart_stm32_err_check(dev);
 #endif /* CONFIG_UART_ASYNC_API */
-
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	if (data->user_cb) {
-		data->user_cb(dev, data->user_data);
-	}
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 }
 
 #endif /* (CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) */


### PR DESCRIPTION
When using the uart driver with interrupt and async api
at the same time (instance for interrupt and instance for async),
the transmission complete interrupt was handled in the async
handling section, even when interrupt driven api is used.
This caused transmission to not work properly in interrupt mode.
The fix is to move the interrupt mode handling to the begginning
of the isr. If async mode is used then interrupt mode code
will not be run.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>

Fixes: #35321