### PR TITLE
lib: os: fix comments for final else in if...else if structures

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -558,7 +558,7 @@ int_conv:
 				break;
 			}
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 		break;
 
@@ -589,7 +589,7 @@ int_conv:
 			   && (conv->length_mod != LENGTH_UPPER_L)) {
 			conv->invalid = true;
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 
 		break;
@@ -807,7 +807,7 @@ static char *encode_uint(uint_value_type value,
 		} else if (radix == 16) {
 			conv->altform_0c = true;
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 	}
 
@@ -885,7 +885,7 @@ static char *encode_float(double value,
 	} else if (conv->flag_space) {
 		*sign = ' ';
 	} else {
-		;
+		; /* Non-empty final else in if ... else if struct */
 	}
 
 	/* Extract the non-negative offset exponent and fraction.  Record
@@ -1401,7 +1401,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 		} else if (conv->width_present) {
 			width = conv->width_value;
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 
 		/* If dynamic precision is specified, process it, otherwise
@@ -1419,7 +1419,7 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 		} else if (conv->prec_present) {
 			precision = conv->prec_value;
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 
 		/* Reuse width and precision memory in conv for value

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -205,7 +205,7 @@ start:
 				prefix = "+";
 				min_width--;
 			} else {
-				;
+				; /* Non-empty final else in if ... else if struct */
 			}
 			data_len = convert_value(d, 10, 0, buf + sizeof(buf));
 			data = buf + sizeof(buf) - data_len;

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -362,7 +362,7 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 		set_chunk_used(h, c, true);
 		return ptr;
 	} else {
-		;
+		; /* Non-empty final else in if ... else if struct */
 	}
 
 	/* Fallback: allocate and copy */

--- a/lib/os/onoff.c
+++ b/lib/os/onoff.c
@@ -223,7 +223,7 @@ static int process_recheck(struct onoff_manager *mgr)
 		   && !sys_slist_is_empty(&mgr->clients)) {
 		evt = EVT_RESET;
 	} else {
-		;
+		; /* Non-empty final else in if ... else if struct */
 	}
 
 	return evt;
@@ -409,7 +409,7 @@ static void process_event(struct onoff_manager *mgr,
 			mgr->flags &= ~ONOFF_FLAG_RECHECK;
 			evt = EVT_RECHECK;
 		} else {
-			;
+			; /* Non-empty final else in if ... else if struct */
 		}
 
 		state = mgr->flags & ONOFF_STATE_MASK;

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -65,7 +65,7 @@ static inline bool item_lessthan(struct k_p4wq_work *a, struct k_p4wq_work *b)
 		   (a->deadline != b->deadline)) {
 		return a->deadline - b->deadline > 0;
 	} else {
-		;
+		; /* Non-empty final else in if ... else if struct */
 	}
 	return false;
 }

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -75,7 +75,7 @@ int sys_sem_give(struct sys_sem *sem)
 	} else if (old_value >= sem->limit) {
 		return -EAGAIN;
 	} else {
-		;
+		; /* Non-empty final else in if ... else if struct */
 	}
 	return ret;
 }


### PR DESCRIPTION
The final else {} in the if...else if is missing required
comment (non-empty, ';' is not sufficient). This adds a comment 
to comply with CG 15.7.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>