### PR TITLE
logging: fix comments for final else in if...else if structures

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -137,6 +137,7 @@ uint32_t z_log_get_s_mask(const char *str, uint32_t nargs)
 			arm = false;
 			arg++;
 		} else {
+			; /* standard character, continue walk */
 		}
 	}
 
@@ -233,6 +234,11 @@ static void z_log_msg_post_finalize(void)
 			k_sem_give(&log_process_thread_sem);
 		}
 	} else {
+		/* No action needed. Message processing will be triggered by the
+		 * timeout or when number of upcoming messages exceeds the
+		 * threshold.
+		 */
+		;
 	}
 }
 
@@ -411,6 +417,7 @@ uint32_t log_count_args(const char *fmt)
 			args++;
 			prev = false;
 		} else {
+			; /* standard character, continue walk */
 		}
 		fmt++;
 	}

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -150,6 +150,10 @@ static void msg_free(struct log_msg *msg)
 			log_free((void *)(str));
 		}
 	} else {
+		/* Message does not contain any arguments that might be a transient
+		 * string. No action required.
+		 */
+		;
 	}
 
 	if (msg->hdr.params.generic.ext == 1) {


### PR DESCRIPTION
The final else {} in the if...else if is missing required
comment (non-empty, ';' is not sufficient). This adds a comment
to comply with CG 15.7.