### PR TITLE
kernel: poll: fix comments for final else in if...else if structures

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -230,6 +230,10 @@ static inline int register_events(struct k_poll_event *events,
 			register_event(&events[ii], poller);
 			events_registered += 1;
 		} else {
+			/* Event is not one of those identified in is_condition_met()
+			 * catching non-polling events, or is marked for just check,
+			 * or not marked for polling. No action needed.
+			 */
 			;
 		}
 		k_spin_unlock(&lock, key);
@@ -424,6 +428,7 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 		} else if (poller->mode == MODE_TRIGGERED) {
 			retcode = signal_triggered_work(event, state);
 		} else {
+			/* Poller is not poll or triggered mode. No action needed.*/
 			;
 		}
 


### PR DESCRIPTION
The final else {} in the if...else if is missing required
comment (non-empty, ';' is not sufficient). This adds a comment
to comply with CG 15.7.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>