### PR TITLE
tests: posix: common: clock.c: rephrase comment on tick alignment

### DIFF
--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -59,8 +59,8 @@ void test_posix_realtime(void)
 
 	/* Minimal sleep to align us to the next tick interval. This
 	 * helps with a case that 2 consecutive calls to clock_gettime()
-	 * below return different values. Note that it's still a workaround,
-	 * which may break, in which case follow the suggestion in the
+	 * below return different values. Note that the tick alignment
+	 * approach may break, in which case follow the suggestion in the
 	 * comment above.
 	 */
 	k_usleep(1);


### PR DESCRIPTION
This k_usleep(1) is a tick alignment, not a workaround. Simple
reword to avoid confusion.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>