### PR TITLE
lib: replace one case switch with if operator

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -304,8 +304,7 @@ int fcntl(int fd, int cmd, ...)
 	}
 
 	/* Handle fdtable commands. */
-	switch (cmd) {
-	case F_DUPFD:
+	if (cmd == F_DUPFD) {
 		/* Not implemented so far. */
 		errno = EINVAL;
 		return -1;


### PR DESCRIPTION
Current "switch" operator with one case replace with the "if"
operator, because every switch statement shall have at least
two case-clauses.

Found as a coding guideline violation (MISRA R16.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>