### PR TITLE
tfm: cmake: added CMAKE_ARGS as argument to trusted_firmware_build

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -58,7 +58,7 @@ function(trusted_firmware_build)
   set(options IPC BL2 REGRESSION_S REGRESSION_NS)
   set(oneValueArgs BINARY_DIR BOARD ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE
     MCUBOOT_IMAGE_NUMBER PSA_TEST_SUITE)
-  set(multiValueArgs ENABLED_PARTITIONS)
+  set(multiValueArgs ENABLED_PARTITIONS CMAKE_ARGS)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   foreach(partition ${TFM_VALID_PARTITIONS})


### PR DESCRIPTION
Follow-up: #34868

The CMAKE_ARGS was accidentally lost during work on #34868.
This commit fixes that by re-adding `CMAKE_ARGS` as multi value arg.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>