### PR TITLE
Bluetooth: host: Remove unneccesary limit of host to controller packets

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2454,7 +2454,6 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 {
 #if defined(CONFIG_BT_ISO)
 	struct bt_hci_rp_le_read_buffer_size_v2 *rp = (void *)buf->data;
-	uint8_t max_num;
 
 	BT_DBG("status %u", rp->status);
 
@@ -2466,8 +2465,7 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 	BT_DBG("ACL LE buffers: pkts %u mtu %u", rp->acl_max_num,
 		bt_dev.le.acl_mtu);
 
-	max_num = MIN(rp->acl_max_num, CONFIG_BT_CONN_TX_MAX);
-	k_sem_init(&bt_dev.le.acl_pkts, max_num, max_num);
+	k_sem_init(&bt_dev.le.acl_pkts, rp->acl_max_num, rp->acl_max_num);
 
 	bt_dev.le.iso_mtu = sys_le16_to_cpu(rp->iso_max_len);
 	if (!bt_dev.le.iso_mtu) {
@@ -2478,8 +2476,7 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 	BT_DBG("ISO buffers: pkts %u mtu %u", rp->iso_max_num,
 		bt_dev.le.iso_mtu);
 
-	max_num = MIN(rp->iso_max_num, CONFIG_BT_ISO_TX_BUF_COUNT);
-	k_sem_init(&bt_dev.le.iso_pkts, max_num, max_num);
+	k_sem_init(&bt_dev.le.iso_pkts, rp->iso_max_num, rp->iso_max_num);
 #endif /* CONFIG_BT_ISO */
 }
 


### PR DESCRIPTION
Remove unneccesary limit of host to controller packets by the host ISO
buffers and host pending buffers with TX callback.
The host always allocates the buffer before taking the semaphore so this
is already handled by the size of the host buffer pool and the
functionality of the buffer pools to wait for buffers.

In addition the ACL max limit is using the wrong define, as
CONFIG_BT_CONN_TX_MAX is the maximum amount of callback contexts for
transmitting. So the host can have more pending packets than this value.
This is also inconsistent with how the host would handle the V1 reply.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>