### PR TITLE
manifest: update MCUboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -91,7 +91,7 @@ manifest:
       revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 3ad36f82d5884c9792d6470b1e7f55011a03c4f1
+      revision: 2fce9769b191411d580bbc65b043956c2ae9307e
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e


### PR DESCRIPTION
* boot_serial: allow to build when CONFIG_MULTITHREADING=n
* allow to not provide scratch area definition if scratch
algorithm is not used.

fixes #35048

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>