### PR TITLE
tests/logging/log_backend_fs: Fix test failed on dirty file system

### DIFF
--- a/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
+++ b/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
@@ -219,9 +219,8 @@ static void test_log_fs_files_max(void)
 		}
 		if (strstr(ent.name, log_prefix) != NULL) {
 			++file_ctr;
+			test_mask |= 1 << atoi(&ent.name[strlen(log_prefix)]);
 		}
-
-		test_mask |= 1 << atoi(&ent.name[strlen(log_prefix)]);
 	}
 	(void)fs_closedir(&dir);
 	zassert_equal(file_ctr, CONFIG_LOG_BACKEND_FS_FILES_LIMIT,


### PR DESCRIPTION
One of subtests had been supposed to check if log files are numbered
properly and in continuous manner, but due to logic error it would
also count non-log files.

Fixes: #33629

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>