### PR TITLE
nordic_nrf: Kconfig.peripherals: Get Kconfig setting from DT

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.board
+++ b/boards/posix/nrf52_bsim/Kconfig.board
@@ -13,15 +13,11 @@ config BOARD_NRF52_BSIM
 	# Indicate that the nRF RNG peripheral is present (actually a model
 	# of it), so that the corresponding driver becomes available (see
 	# dependencies of the ENTROPY_NRF5_RNG option).
-	select HAS_HW_NRF_RNG
 	# Indicate that CCM supports 8 bit length field, to support full
 	# length LL PDUs.
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
 	# Indicate 2M support so that Phy procedure can be enabled.
 	select HAS_HW_NRF_RADIO_BLE_2M
-	# Do the same for the CLOCK and POWER peripherals, so that the nrfx
-	# drivers for them can be used.
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_POWER
 	select HAS_NRFX
 	help

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -372,6 +372,17 @@ def dt_node_int_prop(kconf, name, path, prop):
         return hex(_node_int_prop(node, prop))
 
 
+def dt_has_compat(kconf, _, compat):
+    """
+    This function takes a 'compat' and returns "y" if there are nodes with that
+    compat in the EDT otherwise we return "n"
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    return "y" if compat in edt.compat2nodes else "n"
+
+
 def dt_compat_enabled(kconf, _, compat):
     """
     This function takes a 'compat' and returns "y" if we find a status "okay"
@@ -454,6 +465,7 @@ def shields_list_contains(kconf, _, shield):
 #
 # See the kconfiglib documentation for more details.
 functions = {
+        "dt_has_compat": (dt_has_compat, 1, 1),
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),
         "dt_chosen_label": (dt_chosen_label, 1, 1),

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -125,6 +125,11 @@ config HAS_HW_NRF_IPC
 	bool
 	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_IPC))
 
+DT_COMPAT_NORDIC_NRF_KMU := nordic,nrf-kmu
+config HAS_HW_NRF_KMU
+	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_KMU))
+
 # DT_COMPAT_NORDIC_NRF_LPCOMP := nordic,nrf-lpcomp
 config HAS_HW_NRF_LPCOMP
 	bool

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -3,285 +3,542 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+
+
+# DT_COMPAT_NORDIC_NRF_ACL := nordic,nrf-acl
 config HAS_HW_NRF_ACL
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_ACL))
 
+DT_COMPAT_NORDIC_NRF_ADC := nordic,nrf-adc
 config HAS_HW_NRF_ADC
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_ADC))
 
+# DT_COMPAT_NORDIC_NRF_BPROT := nordic,nrf-bprot
 config HAS_HW_NRF_BPROT
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_BPROT))
 
+DT_COMPAT_NORDIC_NRF_CC310 := nordic,nrf-cc310
 config HAS_HW_NRF_CC310
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_CC310))
 
+DT_COMPAT_NORDIC_NRF_CC312 := nordic,nrf-cc312
 config HAS_HW_NRF_CC312
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_CC312))
 
+# DT_COMPAT_NORDIC_NRF_CCM := nordic,nrf-ccm
 config HAS_HW_NRF_CCM
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_CCM))
 
+# DT_COMPAT_NORDIC_NRF_CCM_LFLEN_8BIT := nordic,nrf-CCM_LFLEN_8BIT
 config HAS_HW_NRF_CCM_LFLEN_8BIT
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_CCM_LFLEN_8BIT))
 
+DT_COMPAT_NORDIC_NRF_CLOCK := nordic,nrf-clock
 config HAS_HW_NRF_CLOCK
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_CLOCK))
 
+# DT_COMPAT_NORDIC_NRF_COMP := nordic,nrf-COMP
 config HAS_HW_NRF_COMP
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_COMP))
 
+DT_COMPAT_NORDIC_NRF_DPPIC := nordic,nrf-dppic
 config HAS_HW_NRF_DPPIC
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_DPPIC))
 
+DT_COMPAT_NORDIC_NRF_ECB := nordic,nrf-ecb
 config HAS_HW_NRF_ECB
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_ECB))
 
+DT_COMPAT_NORDIC_NRF_EGU := nordic,nrf-egu
+DT_NODELABEL_NORDIC_NRF_EGU0 := egu0
 config HAS_HW_NRF_EGU0
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_NODELABEL_NORDIC_NRF_EGU1 := egu1
 config HAS_HW_NRF_EGU1
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_NODELABEL_NORDIC_NRF_EGU2 := egu2
 config HAS_HW_NRF_EGU2
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_NODELABEL_NORDIC_NRF_EGU3 := egu3
 config HAS_HW_NRF_EGU3
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_NODELABEL_NORDIC_NRF_EGU4 := egu4
 config HAS_HW_NRF_EGU4
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU4))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_NODELABEL_NORDIC_NRF_EGU5 := egu5
 config HAS_HW_NRF_EGU5
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_EGU5))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_EGU))
 
+DT_COMPAT_NORDIC_NRF_GPIO := nordic,nrf-gpio
+DT_NODELABEL_NORDIC_NRF_GPIO0 := gpio0
 config HAS_HW_NRF_GPIO0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_GPIO0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_GPIO))
 
+DT_NODELABEL_NORDIC_NRF_GPIO1 := gpio1
 config HAS_HW_NRF_GPIO1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_GPIO1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_GPIO))
 
+DT_COMPAT_NORDIC_NRF_GPIOTE := nordic,nrf-gpiote
 config HAS_HW_NRF_GPIOTE
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
 
+DT_COMPAT_NORDIC_NRF_I2S := nordic,nrf-i2s
 config HAS_HW_NRF_I2S
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_I2S))
 
+DT_COMPAT_NORDIC_NRF_IPC := nordic,nrf-ipc
 config HAS_HW_NRF_IPC
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_IPC))
 
+# DT_COMPAT_NORDIC_NRF_LPCOMP := nordic,nrf-lpcomp
 config HAS_HW_NRF_LPCOMP
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_LPCOMP))
 
+# DT_COMPAT_NORDIC_NRF_MPU := nordic,nrf-mpu
 config HAS_HW_NRF_MPU
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MPU))
 
+# DT_COMPAT_NORDIC_NRF_MWU := nordic,nrf-mwu
 config HAS_HW_NRF_MWU
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MWU))
 
+# DT_COMPAT_NORDIC_NRF_NFCT := nordic,nrf-nfct
 config HAS_HW_NRF_NFCT
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NFCT))
 
 # NVMC supports partial erase
+# DT_COMPAT_NORDIC_NRF_NVMC_PE := nordic,nrf-NVMC_PE
 config HAS_HW_NRF_NVMC_PE
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NVMC_PE))
 
+DT_COMPAT_NORDIC_NRF_PDM := nordic,nrf-pdm
 config HAS_HW_NRF_PDM
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PDM))
 
+# DT_COMPAT_NORDIC_NRF_POWER := nordic,nrf-power
 config HAS_HW_NRF_POWER
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_POWER))
 
+# DT_COMPAT_NORDIC_NRF_PPI := nordic,nrf-ppi
 config HAS_HW_NRF_PPI
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PPI))
 
+DT_COMPAT_NORDIC_NRF_PWM := nordic,nrf-pwm
+DT_NODELABEL_NORDIC_NRF_PWM0 := pwm0
 config HAS_HW_NRF_PWM0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_PWM0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PWM))
 
+DT_NODELABEL_NORDIC_NRF_PWM1 := pwm1
 config HAS_HW_NRF_PWM1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_PWM1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PWM))
 
+DT_NODELABEL_NORDIC_NRF_PWM2 := pwm2
 config HAS_HW_NRF_PWM2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_PWM2))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PWM))
 
+DT_NODELABEL_NORDIC_NRF_PWM3 := pwm3
 config HAS_HW_NRF_PWM3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_PWM3))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_PWM))
 
+DT_COMPAT_NORDIC_NRF_QDEC := nordic,nrf-qdec
 config HAS_HW_NRF_QDEC
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_QDEC))
 
+DT_NODELABEL_NORDIC_NRF_QDEC0 := qdec0
 config HAS_HW_NRF_QDEC0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_QDEC0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_QDEC))
 
+DT_NODELABEL_NORDIC_NRF_QDEC1 := qdec1
 config HAS_HW_NRF_QDEC1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_QDEC1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_QDEC))
 
+DT_COMPAT_NORDIC_NRF_QSPI := nordic,nrf-qspi
 config HAS_HW_NRF_QSPI
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_QSPI))
 
+# DT_COMPAT_NORDIC_NRF_RADIO_BLE_2M := nordic,nrf-RADIO_BLE_2M
 config HAS_HW_NRF_RADIO_BLE_2M
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RADIO_BLE_2M))
 
+# DT_COMPAT_NORDIC_NRF_RADIO_TX_PWR_HIGH := nordic,nrf-RADIO_TX_PWR_HIGH
 config HAS_HW_NRF_RADIO_TX_PWR_HIGH
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RADIO_TX_PWR_HIGH))
 
+# DT_COMPAT_NORDIC_NRF_RADIO_BLE_CODED := nordic,nrf-RADIO_BLE_CODED
 config HAS_HW_NRF_RADIO_BLE_CODED
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RADIO_BLE_CODED))
 
+DT_COMPAT_NORDIC_NRF_RADIO_IEEE802154 := nordic,nrf-RADIO_IEEE8021544
 config HAS_HW_NRF_RADIO_IEEE802154
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RADIO_IEEE802154))
 
+# DT_COMPAT_NORDIC_NRF_RADIO_BLE_DF := nordic,nrf-RADIO_BLE_DF
 config HAS_HW_NRF_RADIO_BLE_DF
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RADIO_BLE_DF))
 
+DT_COMPAT_NORDIC_NRF_RNG := nordic,nrf-rng
 config HAS_HW_NRF_RNG
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RNG))
 
+DT_COMPAT_NORDIC_NRF_RTC := nordic,nrf-rtc
+DT_NODELABEL_NORDIC_NRF_RTC0 := rtc0
 config HAS_HW_NRF_RTC0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_RTC0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RTC))
 
+DT_NODELABEL_NORDIC_NRF_RTC1 := rtc1
 config HAS_HW_NRF_RTC1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_RTC1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RTC))
 
+DT_NODELABEL_NORDIC_NRF_RTC2 := rtc2
 config HAS_HW_NRF_RTC2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_RTC2))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_RTC))
 
+DT_COMPAT_NORDIC_NRF_SAADC := nordic,nrf-saadc
 config HAS_HW_NRF_SAADC
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SAADC))
 
+DT_COMPAT_NORDIC_NRF_SPI := nordic,nrf-spi
+DT_NODELABEL_NORDIC_NRF_SPI0 := spi0
 config HAS_HW_NRF_SPI0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPI0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPI))
 
+DT_NODELABEL_NORDIC_NRF_SPI1 := spi1
 config HAS_HW_NRF_SPI1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPI1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPI))
 
+DT_NODELABEL_NORDIC_NRF_SPI2 := spi2
 config HAS_HW_NRF_SPI2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPI2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPI))
 
+DT_COMPAT_NORDIC_NRF_SPIM := nordic,nrf-spim
+DT_NODELABEL_NORDIC_NRF_SPIM0 := spi0
 config HAS_HW_NRF_SPIM0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIM0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
 
+DT_NODELABEL_NORDIC_NRF_SPIM1 := spi1
 config HAS_HW_NRF_SPIM1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIM1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
 
+DT_NODELABEL_NORDIC_NRF_SPIM2 := spi2
 config HAS_HW_NRF_SPIM2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIM2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
 
+DT_NODELABEL_NORDIC_NRF_SPIM3 := spi3
 config HAS_HW_NRF_SPIM3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIM3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
 
+DT_NODELABEL_NORDIC_NRF_SPIM4 := spi4
 config HAS_HW_NRF_SPIM4
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIM4))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
 
+DT_COMPAT_NORDIC_NRF_SPIS := nordic,nrf-spis
+DT_NODELABEL_NORDIC_NRF_SPIS0 := spi0
 config HAS_HW_NRF_SPIS0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIS0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIS))
 
+DT_NODELABEL_NORDIC_NRF_SPIS1 := spi1
 config HAS_HW_NRF_SPIS1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIS1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIS))
 
+DT_NODELABEL_NORDIC_NRF_SPIS2 := spi2
 config HAS_HW_NRF_SPIS2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIS2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIS))
 
+DT_NODELABEL_NORDIC_NRF_SPIS3 := spi3
 config HAS_HW_NRF_SPIS3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SPIS3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIS))
 
+DT_COMPAT_NORDIC_NRF_SPU := nordic,nrf-spu
 config HAS_HW_NRF_SPU
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPU))
 
+DT_COMPAT_NORDIC_NRF_SWI := nordic,nrf-swi
+DT_NODELABEL_NORDIC_NRF_SWI0 := swi0
 config HAS_HW_NRF_SWI0
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_NODELABEL_NORDIC_NRF_SWI1 := swi1
 config HAS_HW_NRF_SWI1
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_NODELABEL_NORDIC_NRF_SWI2 := swi2
 config HAS_HW_NRF_SWI2
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_NODELABEL_NORDIC_NRF_SWI3 := swi3
 config HAS_HW_NRF_SWI3
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_NODELABEL_NORDIC_NRF_SWI4 := swi4
 config HAS_HW_NRF_SWI4
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI4))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_NODELABEL_NORDIC_NRF_SWI5 := swi5
 config HAS_HW_NRF_SWI5
 	bool
+	# default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_SWI5))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SWI))
 
+DT_COMPAT_NORDIC_NRF_TEMP := nordic,nrf-temp
 config HAS_HW_NRF_TEMP
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TEMP))
 
+DT_COMPAT_NORDIC_NRF_TIMER := nordic,nrf-timer
+DT_NODELABEL_NORDIC_NRF_TIMER0 := timer0
 config HAS_HW_NRF_TIMER0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TIMER0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TIMER))
 
+DT_NODELABEL_NORDIC_NRF_TIMER1 := timer1
 config HAS_HW_NRF_TIMER1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TIMER1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TIMER))
 
+DT_NODELABEL_NORDIC_NRF_TIMER2 := timer2
 config HAS_HW_NRF_TIMER2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TIMER2))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TIMER))
 
+DT_NODELABEL_NORDIC_NRF_TIMER3 := timer3
 config HAS_HW_NRF_TIMER3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TIMER3))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TIMER))
 
+DT_NODELABEL_NORDIC_NRF_TIMER4 := timer4
 config HAS_HW_NRF_TIMER4
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TIMER4))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TIMER))
 
+DT_COMPAT_NORDIC_NRF_TWI := nordic,nrf-twi
+DT_NODELABEL_NORDIC_NRF_TWI0 := i2c0
 config HAS_HW_NRF_TWI0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWI0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWI))
 
+DT_NODELABEL_NORDIC_NRF_TWI1 := i2c1
 config HAS_HW_NRF_TWI1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWI1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWI))
 
+DT_COMPAT_NORDIC_NRF_TWIM := nordic,nrf-twim
+DT_NODELABEL_NORDIC_NRF_TWIM0 := i2c0
 config HAS_HW_NRF_TWIM0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIM0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIM))
 
+DT_NODELABEL_NORDIC_NRF_TWIM1 := i2c1
 config HAS_HW_NRF_TWIM1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIM1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIM))
 
+DT_NODELABEL_NORDIC_NRF_TWIM2 := i2c2
 config HAS_HW_NRF_TWIM2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIM2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIM))
 
+DT_NODELABEL_NORDIC_NRF_TWIM3 := i2c3
 config HAS_HW_NRF_TWIM3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIM3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIM))
 
+DT_COMPAT_NORDIC_NRF_TWIS := nordic,nrf-twis
+DT_NODELABEL_NORDIC_NRF_TWIS0 := i2c0
 config HAS_HW_NRF_TWIS0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIS0))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIS))
 
+DT_NODELABEL_NORDIC_NRF_TWIS1 := i2c1
 config HAS_HW_NRF_TWIS1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIS1))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIS))
 
+DT_NODELABEL_NORDIC_NRF_TWIS2 := i2c2
 config HAS_HW_NRF_TWIS2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIS2))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIS))
 
+DT_NODELABEL_NORDIC_NRF_TWIS3 := i2c3
 config HAS_HW_NRF_TWIS3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_TWIS3))
+	# depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_TWIS))
 
+DT_COMPAT_NORDIC_NRF_UART0 := nordic,nrf-uart
 config HAS_HW_NRF_UART0
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_UART0))
 
+DT_COMPAT_NORDIC_NRF_UARTE := nordic,nrf-uarte
+DT_NODELABEL_NORDIC_NRF_UARTE0 := uart0
 config HAS_HW_NRF_UARTE0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_UARTE0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_UARTE))
 
+DT_NODELABEL_NORDIC_NRF_UARTE1 := uart1
 config HAS_HW_NRF_UARTE1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_UARTE1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_UARTE))
 
+DT_NODELABEL_NORDIC_NRF_UARTE2 := uart2
 config HAS_HW_NRF_UARTE2
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_UARTE2))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_UARTE))
 
+DT_NODELABEL_NORDIC_NRF_UARTE3 := uart3
 config HAS_HW_NRF_UARTE3
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_UARTE3))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_UARTE))
 
+DT_COMPAT_NORDIC_NRF_USBD := nordic,nrf-usbd
 config HAS_HW_NRF_USBD
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_USBD))
 
+# DT_COMPAT_NORDIC_NRF_USBREG := nordic,nrf-usbreg
 config HAS_HW_NRF_USBREG
 	bool
+	# default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_USBREG))
 
+DT_COMPAT_NORDIC_NRF_WDT := nordic,nrf-watchdog
 config HAS_HW_NRF_WDT
 	bool
+	default y if $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_WDT))
 
+DT_NODELABEL_NORDIC_NRF_WDT0 := wdt0
 config HAS_HW_NRF_WDT0
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_WDT0))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_WDT))
 
+DT_NODELABEL_NORDIC_NRF_WDT1 := wdt1
 config HAS_HW_NRF_WDT1
 	bool
+	default y if $(dt_nodelabel_enabled,$(DT_NODELABEL_NORDIC_NRF_WDT1))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_WDT))
 
 # Reserved HW peripherals
 config NRF_HW_TIMER0_RESERVED

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.soc
@@ -9,86 +9,29 @@ choice
 
 config SOC_NRF51822_QFAA
 	bool "NRF51822_QFAA"
-	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF51822_QFAB
 	bool "NRF51822_QFAB"
-	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF51822_QFAC
 	bool "NRF51822_QFAC"
-	select HAS_HW_NRF_ADC
 	select HAS_HW_NRF_CCM
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MPU
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_WDT
 
 endchoice

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -9,40 +9,19 @@ config SOC_NRF52805
 	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_NVMC_PE
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIS0
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52810
 	depends on SOC_SERIES_NRF52X
@@ -50,43 +29,20 @@ config SOC_NRF52810
 	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIS0
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52811
 	depends on SOC_SERIES_NRF52X
@@ -94,48 +50,22 @@ config SOC_NRF52811
 	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
 	select HAS_HW_NRF_RADIO_BLE_CODED
 	select HAS_HW_NRF_RADIO_IEEE802154
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIS1
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52820
 	depends on SOC_SERIES_NRF52X
@@ -143,7 +73,6 @@ config SOC_NRF52820
 	select HAS_HW_NRF_ACL
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
@@ -152,43 +81,17 @@ config SOC_NRF52820
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
 	select HAS_HW_NRF_RADIO_TX_PWR_HIGH
 	select HAS_HW_NRF_RADIO_BLE_CODED
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_USBD
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52832
 	depends on SOC_SERIES_NRF52X
@@ -199,7 +102,6 @@ config SOC_NRF52832
 	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
@@ -208,55 +110,18 @@ config SOC_NRF52832
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MWU
 	select HAS_HW_NRF_NFCT
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_PWM1
-	select HAS_HW_NRF_PWM2
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_RTC2
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPI2
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIM2
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_SPIS2
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TIMER3
-	select HAS_HW_NRF_TIMER4
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52833
 	depends on SOC_SERIES_NRF52X
@@ -266,7 +131,6 @@ config SOC_NRF52833
 	select HAS_HW_NRF_ACL
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
@@ -275,65 +139,23 @@ config SOC_NRF52833
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIO1
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MWU
 	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_PWM1
-	select HAS_HW_NRF_PWM2
-	select HAS_HW_NRF_PWM3
-	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_RADIO_BLE_2M
 	select HAS_HW_NRF_RADIO_TX_PWR_HIGH
 	select HAS_HW_NRF_RADIO_BLE_CODED
 	select HAS_HW_NRF_RADIO_IEEE802154
 	select HAS_HW_NRF_RADIO_BLE_DF
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_RTC2
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPI2
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIM2
-	select HAS_HW_NRF_SPIM3
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_SPIS2
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TIMER3
-	select HAS_HW_NRF_TIMER4
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_UARTE1
-	select HAS_HW_NRF_USBD
-	select HAS_HW_NRF_WDT
 
 config SOC_NRF52840
 	depends on SOC_SERIES_NRF52X
@@ -341,10 +163,8 @@ config SOC_NRF52840
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
 	select HAS_HW_NRF_ACL
-	select HAS_HW_NRF_CC310
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_ECB
 	select HAS_HW_NRF_EGU0
@@ -353,65 +173,22 @@ config SOC_NRF52840
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIO1
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_LPCOMP
 	select HAS_HW_NRF_MWU
 	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PPI
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_PWM1
-	select HAS_HW_NRF_PWM2
-	select HAS_HW_NRF_PWM3
-	select HAS_HW_NRF_QDEC
-	select HAS_HW_NRF_QSPI
 	select HAS_HW_NRF_RADIO_BLE_2M
 	select HAS_HW_NRF_RADIO_TX_PWR_HIGH
 	select HAS_HW_NRF_RADIO_BLE_CODED
 	select HAS_HW_NRF_RADIO_IEEE802154
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_RTC2
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPI0
-	select HAS_HW_NRF_SPI1
-	select HAS_HW_NRF_SPI2
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIM2
-	select HAS_HW_NRF_SPIM3
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_SPIS2
 	select HAS_HW_NRF_SWI0
 	select HAS_HW_NRF_SWI1
 	select HAS_HW_NRF_SWI2
 	select HAS_HW_NRF_SWI3
 	select HAS_HW_NRF_SWI4
 	select HAS_HW_NRF_SWI5
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TIMER3
-	select HAS_HW_NRF_TIMER4
-	select HAS_HW_NRF_TWI0
-	select HAS_HW_NRF_TWI1
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_UART0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_UARTE1
-	select HAS_HW_NRF_USBD
-	select HAS_HW_NRF_WDT
 
 choice
 	prompt "nRF52x MCU Selection"

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -9,8 +9,6 @@ config SOC_NRF5340_CPUAPP
 	select CPU_HAS_NRF_IDAU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select HAS_HW_NRF_CC312
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
@@ -18,86 +16,24 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIO1
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_I2S
-	select HAS_HW_NRF_IPC
 	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_PWM1
-	select HAS_HW_NRF_PWM2
-	select HAS_HW_NRF_PWM3
-	select HAS_HW_NRF_QDEC0
-	select HAS_HW_NRF_QDEC1
-	select HAS_HW_NRF_QSPI
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIM2
-	select HAS_HW_NRF_SPIM3
-	select HAS_HW_NRF_SPIM4
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_SPIS2
-	select HAS_HW_NRF_SPIS3
-	select HAS_HW_NRF_SPU
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIM2
-	select HAS_HW_NRF_TWIM3
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_TWIS2
-	select HAS_HW_NRF_TWIS3
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_UARTE1
-	select HAS_HW_NRF_UARTE2
-	select HAS_HW_NRF_UARTE3
-	select HAS_HW_NRF_USBD
 	select HAS_HW_NRF_USBREG
-	select HAS_HW_NRF_WDT0
-	select HAS_HW_NRF_WDT1
 
 config SOC_NRF5340_CPUNET
 	depends on SOC_SERIES_NRF53X
 	bool
 	select HAS_HW_NRF_ACL
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CCM_LFLEN_8BIT
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIO1
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_IPC
 	select HAS_HW_NRF_NVMC_PE
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_RADIO_BLE_2M
 	select HAS_HW_NRF_RADIO_BLE_CODED
 	select HAS_HW_NRF_RADIO_IEEE802154
-	select HAS_HW_NRF_RNG
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_TEMP
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_WDT
 	select HAS_NO_SYS_PM
 
 choice

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -6,8 +6,6 @@
 config SOC_NRF9160
 	depends on SOC_SERIES_NRF91X
 	bool
-	select HAS_HW_NRF_CC310
-	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1
@@ -15,45 +13,8 @@ config SOC_NRF9160
 	select HAS_HW_NRF_EGU3
 	select HAS_HW_NRF_EGU4
 	select HAS_HW_NRF_EGU5
-	select HAS_HW_NRF_GPIO0
-	select HAS_HW_NRF_GPIOTE
-	select HAS_HW_NRF_I2S
-	select HAS_HW_NRF_IPC
 	select HAS_HW_NRF_NVMC_PE
-	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
-	select HAS_HW_NRF_PWM0
-	select HAS_HW_NRF_PWM1
-	select HAS_HW_NRF_PWM2
-	select HAS_HW_NRF_PWM3
-	select HAS_HW_NRF_RTC0
-	select HAS_HW_NRF_RTC1
-	select HAS_HW_NRF_SAADC
-	select HAS_HW_NRF_SPIM0
-	select HAS_HW_NRF_SPIM1
-	select HAS_HW_NRF_SPIM2
-	select HAS_HW_NRF_SPIM3
-	select HAS_HW_NRF_SPIS0
-	select HAS_HW_NRF_SPIS1
-	select HAS_HW_NRF_SPIS2
-	select HAS_HW_NRF_SPIS3
-	select HAS_HW_NRF_SPU
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TWIM0
-	select HAS_HW_NRF_TWIM1
-	select HAS_HW_NRF_TWIM2
-	select HAS_HW_NRF_TWIM3
-	select HAS_HW_NRF_TWIS0
-	select HAS_HW_NRF_TWIS1
-	select HAS_HW_NRF_TWIS2
-	select HAS_HW_NRF_TWIS3
-	select HAS_HW_NRF_UARTE0
-	select HAS_HW_NRF_UARTE1
-	select HAS_HW_NRF_UARTE2
-	select HAS_HW_NRF_UARTE3
-	select HAS_HW_NRF_WDT
 
 choice
 	prompt "nRF91x MCU Selection"


### PR DESCRIPTION
Remove 'select' statements when the info is retrieved from DT.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>