### PR TITLE
Make dummy shell backend configurable

### DIFF
--- a/include/shell/shell_dummy.h
+++ b/include/shell/shell_dummy.h
@@ -24,7 +24,7 @@ struct shell_dummy {
 	size_t len;
 
 	/** output buffer to collect shell output */
-	char buf[300];
+	char buf[CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE];
 };
 
 #define SHELL_DUMMY_DEFINE(_name)					\

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -134,6 +134,9 @@ config MCUMGR_CMD_SHELL_MGMT
 	  physical interfaces outside of the scope of the user.
 	  It is possible to use additional shell backends in coordination
 	  with this handler and they will not interfere.
+	  The SHELL_BACKEND_DUMMY_BUF_SIZE will affect how many characters
+	  will be returned from command output, if your output gets cut, then
+	  increase the value. Remember to set MCUMGR_BUF_SIZE accordingly.
 
 menuconfig MCUMGR_CMD_IMG_MGMT
 	bool "Enable mcumgr handlers for image management"
@@ -357,6 +360,8 @@ config MCUMGR_BUF_SIZE
 	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
 	  the following relation:
 	  MCUMGR_BUF_SIZE >= transport-specific-MTU + transport-overhead
+	  In case when MCUMGR_SMP_SHELL is enabled this value should be set to
+	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
 
 config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -291,11 +291,21 @@ config SHELL_BACKEND_DUMMY
 	  Enable dummy backend which can be used to execute commands with no
 	  need for physical transport interface.
 
+if SHELL_BACKEND_DUMMY
+
 config SHELL_PROMPT_DUMMY
 	string "Displayed prompt name"
-	depends on SHELL_BACKEND_DUMMY
 	default "~$ "
 	help
 	  Displayed prompt name for DUMMY backend.
+
+config SHELL_BACKEND_DUMMY_BUF_SIZE
+	int "Size of dummy buffer size"
+	default 300
+	help
+	  This is size of output buffer that will be used by dummy backend, this limits number of
+	  characters that will be captured from command output.
+
+endif # SHELL_BACKEND_DUMMY
 
 endif # SHELL_BACKENDS

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -8,7 +8,9 @@
 #include <stdlib.h>
 #include <sys/atomic.h>
 #include <shell/shell.h>
+#if defined(CONFIG_SHELL_BACKEND_DUMMY)
 #include <shell/shell_dummy.h>
+#endif
 #include "shell_ops.h"
 #include "shell_help.h"
 #include "shell_utils.h"


### PR DESCRIPTION
The PR consists of two PRs:
-  **shell: Parametrize dummy shell buffer size**
 that introduces new Kconfig option `SHELL_BACKEND_DUMMY_BUF_SIZE`, enabling user to select number of characters the backend will be able to catch from an executed command;
- **mgmt/mcumgr: Info on `SHELL_BACKEND_DUMMY_BUF_SIZE` impact on mcumgr**
 that adds notes to Mcumgr Kconfig options, which area affected by introduction of `CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE`, how to properly set them.

Fixes: #32755