### PR TITLE
arm64: mitigate FPU-in-exception usage side effects

### DIFF
--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -16,15 +16,6 @@
 #define TEST_NESTED_ISR
 #endif
 
-#if defined(CONFIG_ARM64) && defined(CONFIG_FPU_SHARING)
-/*
- * The various log outputs trigger FP access due to the va_list used by
- * printk() and friends. IRQs are masked to prevent further IRQ nesting
- * when that happens.
- */
-#undef TEST_NESTED_ISR
-#endif
-
 #define DURATION	5
 
 #define ISR0_TOKEN	0xDEADBEEF


### PR DESCRIPTION
Every `va_start()` currently triggers a FPU access trap if FPU is not
already used. This is due to the fact that `va_start()` must copy FPU
registers that are used for float argument passing into the `va_list`
object. Flushing the FPU context to its owner and granting access to
the current thread is wasteful if this is only for `va_start()`,
especially since in most cases there are simply no FP arguments
being passed by the caller.

This is made even worse with exception code (syscalls, IRQ handlers,
etc.) where the exception code has to be resumed with interrupts
disabled upon FPU access as there is no provision for preserving an
interrupted exception mode's FPU context.

Fix those issues by simply simulating the sequence of STR instructions
that the `va_start()` generates without actually granting FPU access.
We limit ourselves only to exception context to keep changes to a
minimum for now.

This also allows for reverting the ARM64 exception in the nested IRQ
test as it now works properly even if FPU_SHARING is enabled.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
