### PR TITLE
ci: doc: remove unused step

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -65,15 +65,3 @@ jobs:
       with:
         name: htmldocs.tar
         path: htmldocs.tar
-
-    - name: check-warns
-      run: |
-        if [ -s doc/_build/doc.warnings ]; then
-           docwarn=$(cat doc/_build/doc.warnings)
-           docwarn="${docwarn//'%'/'%25'}"
-           docwarn="${docwarn//$'\n'/'%0A'}"
-           docwarn="${docwarn//$'\r'/'%0D'}"
-           # We treat doc warnings as errors
-           echo "::error file=doc.warnings::$docwarn"
-           exit 1
-        fi

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -81,18 +81,6 @@ jobs:
         source zephyr-env.sh
         make DOC_TAG=${DOC_TAG} -C doc htmldocs
 
-    - name: check-warns
-      run: |
-        if [ -s doc/_build/doc.warnings ]; then
-           docwarn=$(cat doc/_build/doc.warnings)
-           docwarn="${docwarn//'%'/'%25'}"
-           docwarn="${docwarn//$'\n'/'%0A'}"
-           docwarn="${docwarn//$'\r'/'%0D'}"
-           # We treat doc warnings as errors
-           echo "::error file=doc.warnings::$docwarn"
-           exit 1
-        fi
-
     - name: Upload to AWS S3
       env:
         RELEASE: ${{ steps.tag.outputs.RELEASE }}


### PR DESCRIPTION
`check-warns` step is no longer used since the introduction of
`warnings_filter` extension.