### PR TITLE
buildkite: try to use new SDK (zephyr-sdk-0.13.0-alpha-1)

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -3,7 +3,7 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0-alpha-1"
     parallelism: 400
     timeout_in_minutes: 210
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0-alpha-1"
     parallelism: 20
     timeout_in_minutes: 180
     retry:

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -26,7 +26,7 @@ jobs:
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0-alpha-1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         subset: [1, 2, 3, 4, 5]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.0-alpha-1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       MATRIX_SIZE: 5
     steps:


### PR DESCRIPTION
As discussed at last Toolchain WG meeting [17.05.2021] let's have PR to check what issues we have with new SDK version (zephyr-sdk-0.13.0-alpha-1)