### PR TITLE
lib: newlib: fix _gettimeofday hook

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -18,6 +18,7 @@
 #include <sys/sem.h>
 #include <sys/mutex.h>
 #include <sys/mem_manage.h>
+#include <sys/time.h>
 
 #define LIBC_BSS	K_APP_BMEM(z_libc_partition)
 #define LIBC_DATA	K_APP_DMEM(z_libc_partition)
@@ -402,12 +403,7 @@ void *_sbrk_r(struct _reent *r, int count)
 }
 #endif /* CONFIG_XTENSA */
 
-struct timeval;
-
 int _gettimeofday(struct timeval *__tp, void *__tzp)
 {
-	ARG_UNUSED(__tp);
-	ARG_UNUSED(__tzp);
-
-	return -1;
+	return gettimeofday(__tp, __tzp);
 }


### PR DESCRIPTION
The time() function works correctly with the minimal libc, but always
returns -1 with the newlib libc. This is due to the _gettimeofday hook
being implemented that way.

Fix that by calling gettimeofday in the _gettimeofday hook instead of
returning -1.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>


The bug can be reproducing easily with the `posix/gettimeofday` sample:

```
*** Booting Zephyr OS build zephyr-v2.5.0-3948-g1b129c50c2fd  ***
[00:00:00.091,000] <inf> eth_sam_phy: PHYID: 0x221561 at addr: 0
[00:00:00.097,000] <inf> net_config: Initializing network
[00:00:00.097,000] <inf> net_config: Waiting interface 1 (0x20400df8) to be up...
[00:00:03.122,000] <inf> eth_sam: Link up
gettimeofday(): HI(tv_sec)=0, LO(tv_sec)=1621365601, tv_usec=988440
        Wed Dec 31 23:59:59 1969

[00:00:05.697,000] <inf> eth_sam_phy: common abilities: speed 100 Mb, full duplex
[00:00:05.697,000] <inf> net_config: Interface 1 (0x20400df8) coming up
[00:00:05.697,000] <inf> net_config: IPv4 address: XX.XX.XX.XX
gettimeofday(): HI(tv_sec)=0, LO(tv_sec)=1621365602, tv_usec=997240
        Wed Dec 31 23:59:59 1969

gettimeofday(): HI(tv_sec)=0, LO(tv_sec)=1621365604, tv_usec=5940
        Wed Dec 31 23:59:59 1969

gettimeofday(): HI(tv_sec)=0, LO(tv_sec)=1621365605, tv_usec=14440
        Wed Dec 31 23:59:59 1969

gettimeofday(): HI(tv_sec)=0, LO(tv_sec)=1621365606, tv_usec=23040
        Wed Dec 31 23:59:59 1969
```