### PR TITLE
samples: tensorflow: fix cmakelists.txt files

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -173,6 +173,9 @@ set_compiler_property(PROPERTY security_fortify "")
 # Required C++ flags when using mwdt
 set_property(TARGET compiler-cpp PROPERTY required "")
 
+# Compiler flag for turning off thread-safe initialization of local statics
+set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe-statics")
+
 #################################
 # This section covers asm flags #
 #################################

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -98,5 +98,8 @@ set_compiler_property(PROPERTY sanitize_address)
 
 set_compiler_property(PROPERTY sanitize_undefined)
 
+# Compiler flag for turning off thread-safe initialization of local statics
+set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics)
+
 # Required ASM flags when compiling
 set_property(TARGET asm PROPERTY required)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -177,6 +177,9 @@ set_compiler_property(PROPERTY sanitize_address -fsanitize=address)
 
 set_compiler_property(PROPERTY sanitize_undefined -fsanitize=undefined)
 
+# GCC compiler flag for turning off thread-safe initialization of local statics
+set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe-statics")
+
 # Required ASM flags when using gcc
 set_property(TARGET asm PROPERTY required "-xassembler-with-cpp")
 

--- a/samples/modules/tensorflow/hello_world/CMakeLists.txt
+++ b/samples/modules/tensorflow/hello_world/CMakeLists.txt
@@ -9,15 +9,5 @@ project(tensorflow_hello_world)
 set(NO_THREADSAFE_STATICS $<TARGET_PROPERTY:compiler-cpp,no_threadsafe_statics>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${NO_THREADSAFE_STATICS}>)
 
-target_sources(app PRIVATE
-  src/assert.cc
-  src/main.c
-  src/main_functions.cc
-  src/constants.c
-  src/output_handler.cc
-  src/model.cc
-  src/model.h
-  src/output_handler.h
-  src/constants.h
-  src/main_functions.h
-)
+file(GLOB app_sources src/*)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/modules/tensorflow/hello_world/CMakeLists.txt
+++ b/samples/modules/tensorflow/hello_world/CMakeLists.txt
@@ -3,8 +3,11 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tensorflow_hello_world)
 
-# Required for TensorFlow to compile properly
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
+# These samples use local static initialization. Since Zephyr doesn't support the
+# C++ ABI for thread-safe initialization of local statics and the constructors don't
+# appear to require thread safety, we turn it off in the C++ compiler.
+set(NO_THREADSAFE_STATICS $<TARGET_PROPERTY:compiler-cpp,no_threadsafe_statics>)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${NO_THREADSAFE_STATICS}>)
 
 target_sources(app PRIVATE
   src/assert.cc

--- a/samples/modules/tensorflow/hello_world/README.rst
+++ b/samples/modules/tensorflow/hello_world/README.rst
@@ -68,8 +68,7 @@ Modifying Sample for Your Own Project
 
 It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
-TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`
-and set a flag in your :file:`CMakeLists.txt`.
+TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`.
 
 :file:`prj.conf`:
 
@@ -78,12 +77,6 @@ and set a flag in your :file:`CMakeLists.txt`.
     CONFIG_CPLUSPLUS=y
     CONFIG_NEWLIB_LIBC=y
     CONFIG_TENSORFLOW_LITE_MICRO=y
-
-:file:`CMakeLists.txt`:
-
-.. code-block:: console
-
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
 
 Training
 ********

--- a/samples/modules/tensorflow/magic_wand/CMakeLists.txt
+++ b/samples/modules/tensorflow/magic_wand/CMakeLists.txt
@@ -3,8 +3,11 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tensorflow_magic_wand)
 
-# Required for TensorFlow to compile properly
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
+# These samples use local static initialization. Since Zephyr doesn't support the
+# C++ ABI for thread-safe initialization of local statics and the constructors don't
+# appear to require thread safety, we turn it off in the C++ compiler.
+set(NO_THREADSAFE_STATICS $<TARGET_PROPERTY:compiler-cpp,no_threadsafe_statics>)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${NO_THREADSAFE_STATICS}>)
 
 target_sources(app PRIVATE
   src/main_functions.h

--- a/samples/modules/tensorflow/magic_wand/CMakeLists.txt
+++ b/samples/modules/tensorflow/magic_wand/CMakeLists.txt
@@ -9,19 +9,5 @@ project(tensorflow_magic_wand)
 set(NO_THREADSAFE_STATICS $<TARGET_PROPERTY:compiler-cpp,no_threadsafe_statics>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${NO_THREADSAFE_STATICS}>)
 
-target_sources(app PRIVATE
-  src/main_functions.h
-  src/constants.h
-  src/magic_wand_model_data.h
-  src/gesture_predictor.h
-  src/output_handler.h
-  src/assert.cc
-  src/accelerometer_handler.cc
-  src/accelerometer_handler.h
-  src/main.cc
-  src/main_functions.cc
-  src/magic_wand_model_data.cc
-  src/gesture_predictor.cc
-  src/output_handler.cc
-  boards/litex_vexriscv.overlay
-)
+file(GLOB app_sources src/*)
+target_sources(app PRIVATE ${app_sources} boards/litex_vexriscv.overlay)

--- a/samples/modules/tensorflow/magic_wand/README.rst
+++ b/samples/modules/tensorflow/magic_wand/README.rst
@@ -102,8 +102,7 @@ Modifying Sample for Your Own Project
 
 It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
-TensorFlow, you must enable at least the below Kconfig options in
-your :file:`prj.conf` and set a flag in your :file:`CMakeLists.txt`.
+TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`.
 
 :file:`prj.conf`:
 
@@ -112,12 +111,6 @@ your :file:`prj.conf` and set a flag in your :file:`CMakeLists.txt`.
     CONFIG_CPLUSPLUS=y
     CONFIG_NEWLIB_LIBC=y
     CONFIG_TENSORFLOW_LITE_MICRO=y
-
-:file:`CMakeLists.txt`:
-
-.. code-block:: console
-
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
 
 Training
 ********


### PR DESCRIPTION
Adds no-threadsafe-statics to compiler flags per [discussion](https://github.com/zephyrproject-rtos/zephyr/pull/34057#pullrequestreview-647564622) in #34057 and updates documentation to remove note that implied the flag is required to compile the module. The flag is only required to compile the samples. Changes from explicit file list in CMakeLists.txt to GLOB.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>