### PR TITLE
boards: arm: stm32f103_mini: Enable USB for stm32f103_mini board

### DIFF
--- a/boards/arm/stm32f103_mini/doc/index.rst
+++ b/boards/arm/stm32f103_mini/doc/index.rst
@@ -100,14 +100,19 @@ Board connectors:
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
-- UART_1 TX/RX : PA9/PA10
-- UART_2 TX/RX : PA2/PA3 (ST-Link Virtual COM Port)
-- SPI1 NSS/SCK/MISO/MOSI : PA4/PA5/PA6/PA7
-- SPI2 NSS/SCK/MISO/MOSI : PB12/PB13/PB14/PB15
+- UART_1 TX/RX: PA9/PA10
+- UART_2 TX/RX: PA2/PA3 (ST-Link Virtual COM Port)
+- SPI1 NSS/SCK/MISO/MOSI: PA4/PA5/PA6/PA7
+- SPI2 NSS/SCK/MISO/MOSI: PB12/PB13/PB14/PB15
 - I2C1 SDA/SCL: PB9/PB8
 - PWM1_CH1: PA8
-- USER_PB : PC13
-- LD1 : PA5
+- USER_PB: PC13
+- LD1: PA5
+
+System Clock
+------------
+
+The on-board 8MHz crystal is used to produce a 72MHz system clock with PLL.
 
 Programming and Debugging
 *************************

--- a/boards/arm/stm32f103_mini/doc/index.rst
+++ b/boards/arm/stm32f103_mini/doc/index.rst
@@ -75,6 +75,8 @@ The Zephyr stm32f103_mini board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB device                          |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 
@@ -108,6 +110,7 @@ Default Zephyr Peripheral Mapping:
 - PWM1_CH1: PA8
 - USER_PB: PC13
 - LD1: PA5
+- USB_DC DM/DP: PA11/PA12
 
 System Clock
 ------------

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -32,19 +32,20 @@
 	};
 };
 
-&clk_hsi {
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
 };
 
 &pll {
 	mul = <9>;
-	clocks = <&clk_hsi>;
+	clocks = <&clk_hse>;
 	status = "okay";
 };
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(36)>;
+	clock-frequency = <DT_FREQ_M(72)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -99,6 +99,11 @@
 	};
 };
 
+&usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	status = "okay";
+};
+
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	status = "okay";


### PR DESCRIPTION
Update stm32f103_mini board dts to enable USB. Change clock freqency to 72MHz and source to HSE.

Signed-off-by: Michał Mieszczak <michal@mieszczak.com.pl>