### PR TITLE
DT: check vendor prefixes

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -23,6 +23,8 @@ set(EDT_PICKLE                  ${PROJECT_BINARY_DIR}/edt.pickle)
 set(DEVICETREE_UNFIXED_H        ${PROJECT_BINARY_DIR}/include/generated/devicetree_unfixed.h)
 set(DEVICE_EXTERN_H             ${PROJECT_BINARY_DIR}/include/generated/device_extern.h)
 set(DTS_POST_CPP                ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp)
+# A list of generally accepted vendor prefixes.
+set_ifndef(VENDOR_PREFIXES      ${ZEPHYR_BASE}/dts/bindings/vendor-prefixes.txt)
 
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
 
@@ -228,6 +230,7 @@ if(SUPPORTS_DTS)
   --device-header-out ${DEVICE_EXTERN_H}
   --dts-out ${ZEPHYR_DTS} # As a debugging aid
   --edt-pickle-out ${EDT_PICKLE}
+  --vendor-prefixes ${VENDOR_PREFIXES}
   ${EXTRA_GEN_DEFINES_ARGS}
   )
 

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -73,20 +73,7 @@ class VndLookup:
         vnd2vendor = {
             None: GENERIC_OR_VENDOR_INDEPENDENT,
         }
-        with open(vendor_prefixes, 'r', encoding='utf-8') as f:
-            for line in f:
-                line = line.strip()
-
-                if not line or line.startswith('#'):
-                    # Comment or empty line.
-                    continue
-
-                # Other lines should be in this form:
-                #
-                # <vnd><TAB><vendor>
-                vnd_vendor = line.split('\t', 1)
-                assert len(vnd_vendor) == 2, line
-                vnd2vendor[vnd_vendor[0]] = vnd_vendor[1]
+        vnd2vendor.update(edtlib.load_vendor_prefixes_txt(vendor_prefixes))
 
         logger.info('found %d vendor prefixes in %s', len(vnd2vendor) - 1,
                     vendor_prefixes)

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -22,10 +22,6 @@ from devicetree import edtlib
 
 import gen_helpers
 
-# A line of '-' characters in vendor-prefixes.txt that separates
-# the data from comments about it.
-VENDOR_PREFIXES_SEPARATOR = '-' * 50
-
 ZEPHYR_BASE = Path(__file__).parents[2]
 
 GENERIC_OR_VENDOR_INDEPENDENT = 'Generic or vendor-independent'
@@ -77,19 +73,20 @@ class VndLookup:
         vnd2vendor = {
             None: GENERIC_OR_VENDOR_INDEPENDENT,
         }
-        found_separator = False     # have we found the '-----' separator?
         with open(vendor_prefixes, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
-                if line and found_separator:
-                    # Every line after the separator should be in this form:
-                    #
-                    # <vnd><TAB><vendor>
-                    vnd_vendor = line.split('\t', 1)
-                    assert len(vnd_vendor) == 2, line
-                    vnd2vendor[vnd_vendor[0]] = vnd_vendor[1]
-                elif line.startswith(VENDOR_PREFIXES_SEPARATOR):
-                    found_separator = True
+
+                if not line or line.startswith('#'):
+                    # Comment or empty line.
+                    continue
+
+                # Other lines should be in this form:
+                #
+                # <vnd><TAB><vendor>
+                vnd_vendor = line.split('\t', 1)
+                assert len(vnd_vendor) == 2, line
+                vnd2vendor[vnd_vendor[0]] = vnd_vendor[1]
 
         logger.info('found %d vendor prefixes in %s', len(vnd2vendor) - 1,
                     vendor_prefixes)

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -56,6 +56,7 @@ arasan	Arasan Chip Systems
 archermind	ArcherMind Technology (Nanjing) Co., Ltd.
 arctic	Arctic Sand
 arcx	arcx Inc. / Archronix Inc.
+arduino	Arduino
 aries	Aries Embedded GmbH
 arm	ARM Ltd.
 armadeus	ARMadeus Systems SARL

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -83,7 +83,7 @@ cdns	Cadence Design Systems Inc.
 cdtech	CDTech(H.K.) Electronics Limited
 ceva	Ceva, Inc.
 chipidea	Chipidea, Inc
-chipone		ChipOne
+chipone	ChipOne
 chipspark	ChipSPARK
 chrp	Common Hardware Reference Platform
 chunghwa	Chunghwa Picture Tubes Ltd.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -12,8 +12,12 @@ non-empty line after that should contain a line in this format:
 
 --------------------------------------------------
 
+abb	ABB
 abilis	Abilis Systems
 abracon	Abracon Corporation
+abt	ShenZhen Asia Better Technology Ltd.
+acer	Acer Inc.
+acme	Acme Systems srl
 actions	Actions Semiconductor Co., Ltd.
 active-semi	Active-Semi International Inc
 ad	Avionic Design GmbH
@@ -24,10 +28,15 @@ adh	AD Holdings Plc.
 adi	Analog Devices, Inc.
 advantech	Advantech Corporation
 aeroflexgaisler	Aeroflex Gaisler AB
+aesop	AESOP Embedded Forum
 al	Annapurna Labs
+alcatel	Alcatel
+allegro	Allegro DVT
 allo	Allo.com
 allwinner	Allwinner Technology Co., Ltd.
 alphascale	AlphaScale Integrated Circuits Systems, Inc.
+alps	Alps Electric Co., Ltd.
+alt	Altus-Escon-Company BV
 altr	Altera Corp.
 amarula	Amarula Solutions
 amazon	Amazon.com, Inc.
@@ -35,16 +44,20 @@ amcc	Applied Micro Circuits Corporation (APM, formally AMCC)
 amd	Advanced Micro Devices (AMD), Inc.
 amediatech	Shenzhen Amediatech Technology Co., Ltd
 amlogic	Amlogic, Inc.
+ampere	Ampere Computing LLC
 ampire	Ampire Co., Ltd.
 ams	AMS AG
 amstaos	AMS-Taos Inc.
 analogix	Analogix Semiconductor, Inc.
 andestech	Andes Technology Corporation
+anvo	Anvo-Systems Dresden GmbH
 apm	Applied Micro Circuits Corporation (APM)
+apple	Apple Inc.
 aptina	Aptina Imaging
 arasan	Arasan Chip Systems
 archermind	ArcherMind Technology (Nanjing) Co., Ltd.
 arctic	Arctic Sand
+arcx	arcx Inc. / Archronix Inc.
 aries	Aries Embedded GmbH
 arm	ARM Ltd.
 armadeus	ARMadeus Systems SARL
@@ -52,6 +65,7 @@ arrow	Arrow Electronics
 artesyn	Artesyn Embedded Technologies Inc.
 asahi-kasei	Asahi Kasei Corp.
 asmedia	ASMedia Technology Inc.
+asc	All Sensors Corporation
 aspeed	ASPEED Technology Inc.
 asus	AsusTek Computer Inc.
 atlas	Atlas Scientific LLC
@@ -62,53 +76,78 @@ avago	Avago Technologies
 avia	avia semiconductor
 avic	Shanghai AVIC Optoelectronics Co., Ltd.
 avnet	Avnet, Inc.
+awinic	Shanghai Awinic Technology Co., Ltd.
 axentia	Axentia Technologies AB
 axis	Axis Communications AB
+azoteq	Azoteq (Pty) Ltd
+azw	Shenzhen AZW Technology Co., Ltd.
+baikal	BAIKAL ELECTRONICS, JSC
 bananapi	BIPAI KEJI LIMITED
+beacon	Compass Electronics Group, LLC
+beagle	BeagleBoard.org Foundation
 bhf	Beckhoff Automation GmbH & Co. KG
 bitmain	Bitmain Technologies
+blutek	BluTek Power
 boe	BOE Technology Group Co., Ltd.
 bosch	Bosch Sensortec GmbH
 boundary	Boundary Devices Inc.
+broadmobi	Shanghai Broadmobi Communication Technology Co.,Ltd.
 brcm	Broadcom Corporation
 buffalo	Buffalo, Inc.
+bur	B&R Industrial Automation GmbH
 bticino	Bticino International
 cadence	Cadence Design Systems, Inc.
+calaosystems	CALAO Systems SAS
 calxeda	Calxeda
+canaan	Canaan, Inc.
+caninos	Caninos Loucos Program
 capella	Capella Microsystems, Inc
 cascoda	Cascoda, Ltd.
 catalyst	Catalyst Semiconductor, Inc.
 cavium	Cavium, Inc.
 cdns	Cadence Design Systems Inc.
 cdtech	CDTech(H.K.) Electronics Limited
+cellwise	CellWise Microelectronics Co., Ltd
 ceva	Ceva, Inc.
+checkpoint	Check Point Software Technologies Ltd.
+chefree	Chefree Technology Corp.
 chipidea	Chipidea, Inc
 chipone	ChipOne
 chipspark	ChipSPARK
+chrontel	Chrontel, Inc.
 chrp	Common Hardware Reference Platform
 chunghwa	Chunghwa Picture Tubes Ltd.
+chuwi	Chuwi Innovation Ltd.
 ciaa	Computadora Industrial Abierta Argentina
 cirrus	Cirrus Logic, Inc.
+cisco	Cisco Systems, Inc.
 cloudengines	Cloud Engines, Inc.
 cnm	Chips&Media, Inc.
 cnxt	Conexant Systems, Inc.
+colorfly	Colorful GRP, Shenzhen Xueyushi Technology Ltd.
 compulab	CompuLab Ltd.
+coreriver	CORERIVER Semiconductor Co.,Ltd.
+corpro	Chengdu Corpro Technology Co., Ltd.
 cortina	Cortina Systems, Inc.
 cosmic	Cosmic Circuits
 crane	Crane Connectivity Solutions
 creative	Creative Technology Ltd
 crystalfontz	Crystalfontz America, Inc.
 csky	Hangzhou C-SKY Microsystems Co., Ltd
+csq	Shenzen Chuangsiqi Technology Co.,Ltd.
 cubietech	Cubietech, Ltd.
 cypress	Cypress Semiconductor Corporation
 cznic	CZ.NIC, z.s.p.o.
 dallas	Maxim Integrated Products (formerly Dallas Semiconductor)
 dataimage	DataImage, Inc.
 davicom	DAVICOM Semiconductor, Inc.
+dell	Dell Inc.
 delta	Delta Electronics, Inc.
 denx	Denx Software Engineering
 devantech	Devantech, Ltd.
+dfi	DFI Inc.
 dh	DH electronics GmbH
+difrnce	Shenzhen Yagu Electronic Technology Co., Ltd.
 digi	Digi International Inc.
 digilent	Diglent, Inc.
 dioo	Dioo Microcircuit Co., Ltd
@@ -120,19 +159,28 @@ domintech	Domintech Co., Ltd.
 dongwoon	Dongwoon Anatech
 dptechnics	DPTechnics
 dragino	Dragino Technology Co., Limited
+dserve	dServe Technology B.V.
+dynaimage	Dyna-Image
 ea	Embedded Artists AB
+ebang	Zhejiang Ebang Communication Co., Ltd
 ebs-systart	EBS-SYSTART GmbH
 ebv	EBV Elektronik
 eckelmann	Eckelmann AG
 edt	Emerging Display Technologies
 eeti	eGalax_eMPIA Technology Inc
+einfochips	Einfochips
 elan	Elan Microelectronic Corp.
+element14	Element14 (A Premier Farnell Company)
 elgin	Elgin S/A.
+elida	Shenzhen Elida Technology Co., Ltd.
+elimo	Elimo Engineering Ltd.
 embest	Shenzhen Embest Technology Co., Ltd.
 emlid	Emlid, Ltd.
 emmicro	EM Microelectronic
+empire-electronix	Empire Electronix
 emtrion	emtrion GmbH
 endless	Endless Mobile, Inc.
+ene	ENE Technology, Inc.
 energymicro	Silicon Laboratories (formerly Energy Micro AS)
 engicam	Engicam S.r.l.
 epcos	EPCOS AG
@@ -144,6 +192,7 @@ ettus	NI Ettus Research
 eukrea	Eukréa Electromatique
 everest	Everest Semiconductor Co. Ltd.
 everspin	Everspin Technologies, Inc.
+evervision	Evervision Electronics Co. Ltd.
 exar	Exar Corporation
 excito	Excito
 ezchip	EZchip Semiconductor
@@ -152,19 +201,24 @@ fairphone	Fairphone B.V.
 faraday	Faraday Technology Corporation
 fastrax	Fastrax Oy
 fcs	Fairchild Semiconductor
+feixin	Shenzhen Feixin Photoelectic Co., Ltd
 feiyang	Shenzhen Fly Young Technology Co.,LTD.
+fii	Foxconn Industrial Internet
 firefly	Firefly
 focaltech	FocalTech Systems Co.,Ltd
+frida	Shenzhen Frida LCD Co., Ltd.
 friendlyarm	Guangzhou FriendlyARM Computer Tech Co., Ltd
 fsl	Freescale Semiconductor
 fujitsu	Fujitsu Ltd.
 gaisler	Gaisler
+gardena	GARDENA GmbH
 gateworks	Gateworks Corporation
 gcw	Game Consoles Worldwide
 ge	General Electric Company
 geekbuying	GeekBuying
 gef	GE Fanuc Intelligent Platforms Embedded Systems, Inc.
 GEFanuc	GE Fanuc Intelligent Platforms Embedded Systems, Inc.
+gemei	Gemei Digital Technology Co., Ltd.
 geniatech	Geniatech, Inc.
 giantec	Giantec Semiconductor, Inc.
 giantplus	Giantplus Technology Co., Ltd.
@@ -176,20 +230,27 @@ google	Google, Inc.
 grinn	Grinn
 grmn	Garmin Limited
 gumstix	Gumstix, Inc.
-gw	Gateworks Corporation
 hannstar	HannStar Display Corporation
 haoyu	Haoyu Microelectronic Co. Ltd.
 hardkernel	Hardkernel Co., Ltd
 hideep	HiDeep Inc.
 himax	Himax Technologies, Inc.
+hirschmann	Hirschmann Automation and Control GmbH
 hisilicon	Hisilicon Limited.
 hit	Hitachi Ltd.
 hitex	Hitex Development Tools
 holt	Holt Integrated Circuits, Inc.
+honestar	Honestar Technologies Co., Ltd.
 honeywell	Honeywell
+hoperun	Jiangsu HopeRun Software Co., Ltd.
 hp	Hewlett Packard
+hsg	HannStar Display Co.
 holtek	Holtek Semiconductor, Inc.
+hugsun	Shenzhen Hugsun Technology Co. Ltd.
 hwacom	HwaCom Systems Inc.
+hycon	Hycon Technology Corp.
+hydis	Hydis Technologies
+hyundai	Hyundai Technology
 i2se	I2SE GmbH
 ibm	International Business Machines (IBM)
 icplus	IC Plus Corp.
@@ -197,11 +258,16 @@ idt	Integrated Device Technologies, Inc.
 ifi	Ingenieurburo Fur Ic-Technologie (I/F/I)
 ilitek	ILI Technology Corporation (ILITEK)
 img	Imagination Technologies Ltd.
+imi	Integrated Micro-Electronics Inc.
+incircuit	In-Circuit GmbH
+inet-tek	Shenzhen iNet Mobile Internet Technology Co., Ltd
 infineon	Infineon Technologies
 inforce	Inforce Computing
+ivo	InfoVision Optoelectronics Kunshan Co. Ltd.
 ingenic	Ingenic Semiconductor
 innolux	Innolux Corporation
 inside-secure	INSIDE Secure
+inspur	Inspur Corporation
 intel	Intel Corporation
 intercontrol	Inter Control Group
 invensense	InvenSense Inc.
@@ -215,7 +281,9 @@ itead	ITEAD Intelligent Systems Co.Ltd
 iwave	iWave Systems Technologies Pvt. Ltd.
 jdi	Japan Display Inc.
 jedec	JEDEC Solid State Technology Association
+jesurun	Shenzhen Jesurun Electronics Business Dept.
 jianda	Jiandangjing Technology Co., Ltd.
+kam	Kamstrup A/S
 karo	Ka-Ro electronics GmbH
 keithkoep	Keith & Koep GmbH
 keymile	Keymile GmbH
@@ -224,35 +292,56 @@ kiebackpeter	Kieback & Peter GmbH
 kinetic	Kinetic Technologies
 kingdisplay	King & Display Technology Co., Ltd.
 kingnovel	Kingnovel Technology Co., Ltd.
+kionix	Kionix, Inc.
+kobo	Rakuten Kobo Inc.
+kobol	Kobol Innovations Pte. Ltd.
 koe	Kaohsiung Opto-Electronics Inc.
+kontron	Kontron S&T AG
 kosagi	Sutajio Ko-Usagi PTE Ltd.
+kvg	Kverneland Group
 kyo	Kyocera Corporation
 lacie	LaCie
 laird	Laird PLC
 lairdconnect	Laird Connectivity
+lamobo	Ketai Huajie Technology Co., Ltd.
 lantiq	Lantiq Semiconductor
 lattice	Lattice Semiconductor
+leadtek	Shenzhen Leadtek Technology Co., Ltd.
+leez	Leez
 lego	LEGO Systems A/S
 lemaker	Shenzhen LeMaker Technology Co., Ltd.
 lenovo	Lenovo Group Ltd.
 lg	LG Corporation
+lgphilips	LG Display
 libretech	Shenzhen Libre Technology Co., Ltd
 licheepi	Lichee Pi
 linaro	Linaro Limited
+linksprite	LinkSprite Technologies, Inc.
 linksys	Belkin International, Inc. (Linksys)
+linutronix	Linutronix GmbH
 linux	Linux-specific binding
 linx	Linx Technologies
 litex	LiteX SoC builder
 lltc	Linear Technology Corporation
 logicpd	Logic PD, Inc.
+logictechno	Logic Technologies Limited
+longcheer	Longcheer Technology (Shanghai) Co., Ltd.
+lontium	Lontium Semiconductor Corporation
+loongson	Loongson Technology Corporation Limited
 lsi	LSI Corp. (LSI Logic)
 lwn	Liebherr-Werk Nenzing GmbH
+lxa	Linux Automation GmbH
+m5stack	M5Stack
 macnica	Macnica Americas
+mantix	Mantix Display Technology Co.,Ltd.
+mapleboard	Mapleboard.org
 marvell	Marvell Technology Group Ltd.
+maxbotix	MaxBotix Inc.
 maxim	Maxim Integrated Products
 mbvl	Mobiveil Inc.
 mcube	mCube
 meas	Measurement Specialties
+mecer	Mustek Limited
 mediatek	MediaTek Inc.
 megachips	MegaChips
 mele	Shenzhen MeLE Digital Technology Ltd.
@@ -260,22 +349,33 @@ melexis	Melexis N.V.
 melfas	MELFAS Inc.
 mellanox	Mellanox Technologies
 memsic	MEMSIC Inc.
+menlo	Menlo Systems GmbH
+mentor	Mentor Graphics
+meraki	Cisco Meraki, LLC
 merrii	Merrii Technology Co., Ltd.
 micrel	Micrel Inc.
 microchip	Microchip Technology Inc.
 microcrystal	Micro Crystal AG
 micron	Micron Technology Inc.
+microsoft	Microsoft Corporation
+microsys	MicroSys Electronics GmbH
 mikroe	MikroElektronika d.o.o.
+mikrotik	MikroTik
+miniand	Miniand Tech
 minix	MINIX Technology Ltd.
 miramems	MiraMEMS Sensing Technology Co., Ltd.
 mitsubishi	Mitsubishi Electric Corporation
+modtronix	Modtronix Engineering
 mosaixtech	Mosaix Technologies, Inc.
 motorola	Motorola, Inc.
 moxa	Moxa Inc.
 mpl	MPL AG
+mps	Monolithic Power Systems Inc.
 mqmaker	mqmaker Inc.
+mrvl	Marvell Technology Group Ltd.
 mscc	Microsemi Corporation
 msi	Micro-Star International Co. Ltd.
+mstar	MStar Semiconductor, Inc. (acquired by MediaTek Inc.)
 mti	Imagination Technologies Ltd. (formerly MIPS Technologies Inc.)
 multi-inno	Multi-Inno Technology Co.,Ltd
 mundoreader	Mundo Reader S.L.
@@ -288,7 +388,9 @@ neonode	Neonode Inc.
 netgear	NETGEAR
 netlogic	Broadcom Corporation (formerly NetLogic Microsystems)
 netron-dy	Netron DY
+netronix	Netronix, Inc.
 netxeon	Shenzhen Netxeon Technology CO., LTD
+neweast	Guangdong Neweast Optoelectronics CO., LTD
 nexbox	Nexbox
 nextthing	Next Thing Co.
 newhaven	Newhaven Display International
@@ -303,6 +405,8 @@ nuvoton	Nuvoton Technology Corporation
 nvd	New Vision Display
 nvidia	NVIDIA
 nxp	NXP Semiconductors
+oceanic	Oceanic Systems (UK) Ltd.
+oct	Octavo Systems LLC
 okaya	Okaya Electric America, Inc.
 oki	Oki Electric Industry Co., Ltd.
 olimex	OLIMEX Ltd.
@@ -320,11 +424,16 @@ oranth	Shenzhen Oranth Technology Co., Ltd.
 ORCL	Oracle Corporation
 orisetech	Orise Technology
 ortustech	Ortus Technology Co., Ltd.
+osddisplays	OSD Displays
+ouya	Ouya Inc.
+overkiz	Overkiz SAS
 ovti	OmniVision Technologies
 oxsemi	Oxford Semiconductor, Ltd.
+ozzmaker	OzzMaker
 panasonic	Panasonic Corporation
 parade	Parade Technologies Inc.
 particle	Particle.io
+parallax	Parallax Inc.
 pda	Precision Design Associates, Inc.
 pericom	Pericom Technology Inc.
 pervasive	Pervasive Displays, Inc.
@@ -332,21 +441,31 @@ phicomm	PHICOMM Co., Ltd.
 phytec	PHYTEC Messtechnik GmbH
 picochip	Picochip Ltd
 pine64	Pine64
+pineriver	Shenzhen PineRiver Designs Co., Ltd.
 pixcir	PIXCIR MICROELECTRONICS Co., Ltd
 plantower	Plantower Co., Ltd
 plathome	Plat'Home Co., Ltd.
 plda	PLDA
 plx	Broadcom Corporation (formerly PLX Technology)
+ply	Plymovent Group BV
 pni	PNI Sensor Corporation
+pocketbook	PocketBook International SA
+polaroid	Polaroid Corporation
 portwell	Portwell Inc.
 poslab	Poslab Technology Co., Ltd.
+pov	Point of View International B.V.
+powertip	Powertip Tech. Corp.
 powervr	PowerVR (deprecated, use img)
+primux	Primux Trading, S.L.
 probox2	PROBOX2 (by W2COMP Co., Ltd.)
+prt	Protonic Holland
 pulsedlight	PulsedLight, Inc
+purism	Purism, SPC
 qca	Qualcomm Atheros, Inc.
 qcom	Qualcomm Technologies, Inc
 qemu	QEMU, a generic and open source machine emulator and virtualizer
 qi	Qi Hardware
+qihua	Chengdu Kaixuan Information Technology Co., Ltd.
 qiaodian	QiaoDian XianShi Corporation
 qnap	QNAP Systems, Inc.
 quicklogic	QuickLogic Corp.
@@ -358,32 +477,46 @@ raspberrypi	Raspberry Pi Foundation
 raydium	Raydium Semiconductor Corp.
 rda	Unisoc Communications, Inc.
 realtek	Realtek Semiconductor Corp.
+remarkable	reMarkable AS
 renesas	Renesas Electronics Corporation
+rex	iMX6 Rex Project
+rervision	Shenzhen Rervision Technology Co., Ltd.
+revotics	Revolution Robotics, Inc. (Revotics)
 richtek	Richtek Technology Corporation
 ricoh	Ricoh Co. Ltd.
 rikomagic	Rikomagic Tech Corp. Ltd
 riscv	RISC-V Foundation
+riot	Embest RIoT
 rockchip	Fuzhou Rockchip Electronics Co., Ltd
-rocktech	Rocktech Displays Limited
+rocktech	ROCKTECH DISPLAYS LIMITED
 rohm	ROHM Semiconductor Co., Ltd
+ronbo	Ronbo Electronics
 roofull	Shenzhen Roofull Technology Co, Ltd
 ruuvi	Ruuvi Innovations Ltd (Oy)
+roseapplepi	RoseapplePi.org
 samsung	Samsung Semiconductor
 samtec	Samtec/Softing company
 sancloud	Sancloud Ltd
 sandisk	Sandisk Corporation
+satoz	Satoz International Co., Ltd
 sbs	Smart Battery System
 schindler	Schindler
 seagate	Seagate Technology PLC
 segger	SEGGER Microcontroller GmbH
+seeed	Seeed Technology Co., Ltd
+seirobotics	Shenzhen SEI Robotics Co., Ltd
 semtech	Semtech Corporation
 sensirion	Sensirion AG
+sensortek	Sensortek Technology Corporation
 sff	Small Form Factor Committee
 sgd	Solomon Goldentek Display Corporation
+sgmicro	SG Micro Corp
 sgx	SGX Sensortech
 sharp	Sharp Corporation
 shimafuji	Shimafuji Electric, Inc.
+shiratech	Shiratech Solutions
 si-en	Si-En Technology Ltd.
+si-linux	Silicon Linux Corporation
 sifive	SiFive, Inc.
 sigma	Sigma Designs, Inc.
 sii	Seiko Instruments, Inc.
@@ -391,14 +524,22 @@ sil	Silicon Image
 silabs	Silicon Laboratories
 silead	Silead Inc.
 silergy	Silergy Corp.
+silex-insight	Silex Insight
+siliconfile	Siliconfile Technologies lnc.
 siliconmitus	Silicon Mitus, Inc.
+siemens	Siemens AG
 simtek	Cypress Semiconductor Corporation (Simtek Corporation)
+sinlinx	Sinlinx Electronics Technology Co., LTD
+sinovoip	SinoVoip Co., Ltd
+sipeed	Shenzhen Sipeed Technology Co., Ltd.
 sirf	SiRF Technology, Inc.
 sis	Silicon Integrated Systems Corp.
 sitronix	Sitronix Technology Corporation
 skyworks	Skyworks Solutions, Inc.
+smartlabs	SmartLabs LLC
 smsc	Standard Microsystems Corporation
 snps	Synopsys, Inc.
+sochip	Shenzhen SoChip Technology Co., Ltd.
 socionext	Socionext Inc.
 solidrun	SolidRun
 solomon	Solomon Systech Limited
@@ -406,14 +547,18 @@ sony	Sony Corporation
 spansion	Spansion Inc.
 sprd	Spreadtrum Communications Inc.
 sst	Silicon Storage Technology, Inc.
+sstar	Xiamen Xingchen(SigmaStar) Technology Co., Ltd. (formerly part of MStar Semiconductor, Inc.)
 st	STMicroelectronics
 starry	Starry Electronic Technology (ShenZhen) Co., LTD
 startek	Startek
 ste	ST-Ericsson
 stericsson	ST-Ericsson
+st-ericsson	ST-Ericsson
 summit	Summit microelectronics
 sunchip	Shenzhen Sunchip Technology Co., Ltd
 SUNW	Sun Microsystems, Inc
+supermicro	Super Micro Computer, Inc.
+silvaco	Silvaco, Inc.
 swir	Sierra Wireless
 syna	Synaptics Inc.
 synology	Synology, Inc.
@@ -421,41 +566,56 @@ tbs	TBS Technologies
 tbs-biometrics	Touchless Biometric Systems AG
 tcg	Trusted Computing Group
 tcl	Toby Churchill Ltd.
+tcs	Shenzhen City Tang Cheng Technology Co., Ltd.
+tdo	Shangai Top Display Optoelectronics Co., Ltd
 technexion	TechNexion
 technologic	Technologic Systems
 tempo	Tempo Semiconductor
 techstar	Shenzhen Techstar Electronics Co., Ltd.
 terasic	Terasic Inc.
+tfc	Three Five Corp
 thine	THine Electronics, Inc.
+thingyjp	thingy.jp
 ti	Texas Instruments
 tianma	Tianma Micro-electronics Co., Ltd.
 tlm	Trusted Logic Mobility
 tmt	Tecon Microprocessor Technologies, LLC.
 topeet	Topeet
+toppoly	TPO (deprecated, use tpo)
+topwise	Topwise Communication Co., Ltd.
 toradex	Toradex AG
 toshiba	Toshiba Corporation
 toumaz	Toumaz
 tpk	TPK U.S.A. LLC
 tplink	TP-LINK Technologies Co., Ltd.
 tpo	TPO
+tq	TQ-Systems GmbH
 tronfy	Tronfy
 tronsmart	Tronsmart
 truly	Truly Semiconductors Limited
+visionox	Visionox
 tsd	Theobroma Systems Design und Consulting GmbH
 tyan	Tyan Computer Corporation
 u-blox	u-blox
+u-boot	U-Boot bootloader
 ucrobotics	uCRobotics
 ubnt	Ubiquiti Networks
 udoo	Udoo
+ugoos	Ugoos Industrial Co., Ltd.
 uniwest	United Western Technologies Corp (UniWest)
 upisemi	uPI Semiconductor Corp.
 urt	United Radiant Technology Corporation
 usi	Universal Scientific Industrial Co., Ltd.
+utoo	Aigo Digital Technology Co., Ltd.
 v3	V3 Semiconductor
+vaisala	Vaisala
 vamrs	Vamrs Ltd.
 variscite	Variscite Ltd.
+vdl	Van der Laan b.v.
 via	VIA Technologies, Inc.
+videostrong	Videostrong Technology Co., Ltd.
 virtio	Virtual I/O Device Specification, developed by the OASIS consortium
+virtual	Used for virtual device without specific vendor.
 vishay	Vishay Intertechnology, Inc
 vitesse	Vitesse Semiconductor Corporation
 vivante	Vivante Corporation
@@ -463,6 +623,9 @@ vnd	A stand-in for a real vendor which can be used in examples and tests
 vocore	VoCore Studio
 voipac	Voipac Technologies s.r.o.
 vot	Vision Optical Technology Co., Ltd.
+vxt	VXT Ltd
+wand	Wandbord (Technexion)
+waveshare	Waveshare Electronics
 wd	Western Digital Corp.
 we	Würth Elektronik GmbH.
 weact	WeAct Studio
@@ -472,18 +635,36 @@ whwave	Shenzhen whwave Electronics, Inc.
 wi2wi	Wi2Wi, Inc.
 winbond	Winbond Electronics corp.
 winstar	Winstar Display Corp.
+wits	Shenzhen Merrii Technology Co., Ltd. (WITS)
 wlf	Wolfson Microelectronics
 wm	Wondermedia Technologies, Inc.
+wobo	Wobo
 x-powers	X-Powers
 xes	Extreme Engineering Solutions (X-ES)
+xiaomi	Xiaomi Technology Co., Ltd.
 xillybus	Xillybus Ltd.
+xingbangda	Shenzhen Xingbangda Display Technology Co., Ltd
+xinpeng	Shenzhen Xinpeng Technology Co., Ltd
+xiphera	Xiphera Ltd.
 xlnx	Xilinx
+xnano	Xnano
 xunlong	Shenzhen Xunlong Software CO.,Limited
+xylon	Xylon
+yamaha	Yamaha Corporation
+yes-optoelectronics	Yes Optoelectronics Co.,Ltd.
+yic	YIC System Co., Ltd.
+ylm	Shenzhen Yangliming Electronic Technology Co., Ltd.
+yna	YSH & ATIL
+yones-toptech	Yones Toptech Co., Ltd.
+ys	Shenzhen Yashi Changhua Intelligent Technology Co., Ltd.
 ysoft	Y Soft Corporation a.s.
+zealz	Zealz
 zarlink	Zarlink Semiconductor
 zeitec	ZEITEC Semiconductor Co., LTD.
 zephyr	Zephyr-specific binding
 zidoo	Shenzhen Zidoo Technology Co., Ltd.
 zii	Zodiac Inflight Innovations
+zinitix	Zinitix Co., Ltd
+zkmagic	Shenzhen Zkmagic Technology Co., Ltd.
 zte	ZTE Corp.
 zyxel	ZyXEL Communications Corp.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -1,16 +1,14 @@
-Device tree binding vendor prefix registry. Keep this list in
-alphabetical order.
-
-This isn't an exhaustive list, but you should add new prefixes to it
-before using them to avoid name-space collisions.
-
-The contents of this file are parsed during documentation generation.
-Anything above the following line of '-' characters is ignored. Every
-non-empty line after that should contain a line in this format:
-
-<vendor-prefix><TAB><Full name of vendor>
-
---------------------------------------------------
+# Device tree binding vendor prefix registry. Keep this list in
+# alphabetical order.
+#
+# This isn't an exhaustive list, but you should add new prefixes to it
+# before using them to avoid name-space collisions.
+#
+# The contents of this file are parsed during documentation generation.
+# Anything that starts with a '#' is treated as a comment and ignored.
+# Non-empty lines should be in this format:
+#
+# <vendor-prefix><TAB><Full name of vendor>
 
 abb	ABB
 abilis	Abilis Systems

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -69,8 +69,7 @@ def main():
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
                          default_prop_types=True,
                          infer_binding_for_paths=["/zephyr,user"],
-                         err_on_deprecated_properties=
-                         args.err_on_deprecated_properties,
+                         werror=args.edtlib_Werror,
                          vendor_prefixes=vendor_prefixes)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
@@ -217,8 +216,10 @@ def parse_args():
                         help="path to write pickled edtlib.EDT object to")
     parser.add_argument("--vendor-prefixes",
                         help="vendor-prefixes.txt path; used for validation")
-    parser.add_argument("--err-on-deprecated-properties", action="store_true",
-                        help="if set, deprecated property usage is an error")
+    parser.add_argument("--edtlib-Werror", action="store_true",
+                        help="if set, edtlib-specific warnings become errors. "
+                             "(this does not apply to warnings shared "
+                             "with dtc.)")
 
     return parser.parse_args()
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -57,6 +57,11 @@ def main():
 
     setup_edtlib_logging()
 
+    if args.vendor_prefixes:
+        vendor_prefixes = edtlib.load_vendor_prefixes_txt(args.vendor_prefixes)
+    else:
+        vendor_prefixes = None
+
     try:
         edt = edtlib.EDT(args.dts, args.bindings_dirs,
                          # Suppress this warning if it's suppressed in dtc
@@ -65,7 +70,8 @@ def main():
                          default_prop_types=True,
                          infer_binding_for_paths=["/zephyr,user"],
                          err_on_deprecated_properties=
-                         args.err_on_deprecated_properties)
+                         args.err_on_deprecated_properties,
+                         vendor_prefixes=vendor_prefixes)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
 
@@ -209,6 +215,8 @@ def parse_args():
                         help="path to write device struct extern header to")
     parser.add_argument("--edt-pickle-out",
                         help="path to write pickled edtlib.EDT object to")
+    parser.add_argument("--vendor-prefixes",
+                        help="vendor-prefixes.txt path; used for validation")
     parser.add_argument("--err-on-deprecated-properties", action="store_true",
                         help="if set, deprecated property usage is an error")
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1976,6 +1976,31 @@ class PropertySpec:
 class EDTError(Exception):
     "Exception raised for devicetree- and binding-related errors"
 
+#
+# Public global functions
+#
+
+
+def load_vendor_prefixes_txt(vendor_prefixes):
+    """Load a vendor-prefixes.txt file and return a dict
+    representation mapping a vendor prefix to the vendor name.
+    """
+    vnd2vendor = {}
+    with open(vendor_prefixes, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+
+            if not line or line.startswith('#'):
+                # Comment or empty line.
+                continue
+
+            # Other lines should be in this form:
+            #
+            # <vnd><TAB><vendor>
+            vnd_vendor = line.split('\t', 1)
+            assert len(vnd_vendor) == 2, line
+            vnd2vendor[vnd_vendor[0]] = vnd_vendor[1]
+    return vnd2vendor
 
 #
 # Private global functions

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2008,7 +2008,7 @@ class CMake():
             ldflags = "-Wl,--fatal-warnings"
             cflags = "-Werror"
             aflags = "-Wa,--fatal-warnings"
-            gen_defines_args = "--err-on-deprecated-properties"
+            gen_defines_args = "--edtlib-Werror"
         else:
             ldflags = cflags = aflags = ""
             gen_defines_args = ""


### PR DESCRIPTION
This is based on https://github.com/zephyrproject-rtos/zephyr/pull/35313.

As suggested by @trond-snekvik, extends the checks in the PR it's based on to also emit warnings when a vendor prefix not in vendor-prefixes.txt or a special list of additional exemptions is present in the DTS.