### PR TITLE
tests: libc: Update libc testcases to solve coverity issues

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -528,8 +528,8 @@ void test_memchr(void)
 void test_memcpy(void)
 {
 	/* make sure the buffer is word aligned */
-	uintptr_t mem_dest[3] = {0};
-	uintptr_t mem_src[3] = {0};
+	uintptr_t mem_dest[4] = {0};
+	uintptr_t mem_src[4] = {0};
 	unsigned char *mem_dest_tmp = NULL;
 	unsigned char *mem_src_tmp = NULL;
 


### PR DESCRIPTION
The coverity report "Out-of-bounds access". The reason is
The room of src and dest buffer is less than the count wanted
to be copyied. So enlarged the src and dest buffer to solve this
issue.

Fixes #35345
Fixes #35346

Signed-off-by: Ying ming <mingx.ying@intel.com>