### PR TITLE
Bluetooth: controller: Various coverity related fixes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -892,6 +892,8 @@ void ll_rx_dequeue(void)
 		struct lll_adv_aux *lll_aux;
 
 		adv = ull_adv_set_get(rx->handle);
+		LL_ASSERT(adv);
+
 		lll_aux = adv->lll.aux;
 		if (lll_aux) {
 			struct ll_adv_aux_set *aux;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1060,6 +1060,7 @@ static void mfy_aux_offset_get(void *param)
 		uint32_t volatile ret_cb;
 		uint32_t ticks_previous;
 		uint32_t ret;
+		bool success;
 
 		ticks_previous = ticks_current;
 
@@ -1076,7 +1077,8 @@ static void mfy_aux_offset_get(void *param)
 			}
 		}
 
-		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
+		success = (ret_cb == TICKER_STATUS_SUCCESS);
+		LL_ASSERT(success);
 
 		LL_ASSERT((ticks_current == ticks_previous) || retry--);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -907,6 +907,7 @@ static void mfy_sync_offset_get(void *param)
 		uint32_t volatile ret_cb;
 		uint32_t ticks_previous;
 		uint32_t ret;
+		bool success;
 
 		ticks_previous = ticks_current;
 
@@ -923,7 +924,8 @@ static void mfy_sync_offset_get(void *param)
 			}
 		}
 
-		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
+		success = (ret_cb == TICKER_STATUS_SUCCESS);
+		LL_ASSERT(success);
 
 		LL_ASSERT((ticks_current == ticks_previous) || retry--);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1149,8 +1149,8 @@ static void target_resolve(struct k_work *work)
 	if (twork->cb) {
 		mfy.fp = twork->cb;
 		mfy.param = (void *) ((unsigned int) j);
-		mayfly_enqueue(TICKER_USER_ID_THREAD,
-			       TICKER_USER_ID_LLL, 1, &mfy);
+		(void)mayfly_enqueue(TICKER_USER_ID_THREAD,
+				     TICKER_USER_ID_LLL, 1, &mfy);
 	}
 }
 
@@ -1219,8 +1219,8 @@ static void prpa_cache_resolve(struct k_work *work)
 	if (rwork->cb) {
 		mfy.fp = rwork->cb;
 		mfy.param = (void *) ((unsigned int) j);
-		mayfly_enqueue(TICKER_USER_ID_THREAD,
-			       TICKER_USER_ID_LLL, 1, &mfy);
+		(void)mayfly_enqueue(TICKER_USER_ID_THREAD,
+				     TICKER_USER_ID_LLL, 1, &mfy);
 	}
 }
 


### PR DESCRIPTION
Fix side effect in assertion when checking a volatile
variable inside assert check.

Fixes #32904.
Fixes #32923.

Explicitly ignore return value from call to mayfly_enqueue.

Fixes #32917.
Fixes #32961.

Add assert check to avoid deferencing null return value by
ull_adv_set_get() function.

Fixes #35347.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>