### PR TITLE
arch: arm: Fix build warning

### DIFF
--- a/include/arch/arm/aarch32/thread.h
+++ b/include/arch/arm/aarch32/thread.h
@@ -111,7 +111,7 @@ struct _thread_arch {
 		uint32_t mode;
 
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)
-		__packed struct {
+		struct {
 			uint8_t mode_bits;
 			uint8_t mode_exc_return;
 			uint16_t mode_reserved2;


### PR DESCRIPTION
Change fixes a build warning related to attribute ignored in declaration of struct. The attribute must follow the struct keyword.

Signed-off-by: Marek Pieta <Marek.Pieta@nordicsemi.no>