### PR TITLE
logging: Add empty Z_LOG_MSG2_SIMPLE_CREATE version

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -283,6 +283,7 @@ do { \
 	z_log_msg2_static_create((void *)_source, _desc, _msg->data, _data); \
 } while (0)
 
+#if CONFIG_LOG_SPEED
 #define Z_LOG_MSG2_SIMPLE_CREATE(_domain_id, _source, _level, ...) do { \
 	int _plen; \
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG2_ALIGN_OFFSET, \
@@ -299,6 +300,12 @@ do { \
 	} \
 	z_log_msg2_finalize(_msg, (void *)_source, _desc, NULL); \
 } while (0)
+#else
+/* Alternative empty macro created to speed up compilation when LOG_SPEED is
+ * disabled (default).
+ */
+#define Z_LOG_MSG2_SIMPLE_CREATE(...)
+#endif
 
 /* Macro handles case when local variable with log message string is created.It
  * replaces origing string literal with that variable.


### PR DESCRIPTION
Add empty Z_LOG_MSG2_SIMPLE_CREATE when CONFIG_LOG_SPEED=n. It
allows to reduce compilation time by removing code at preprocessor
stage. Previously functionality was the same, compiler was removing
unused code but because logging is widely use that had a visible
impact on compile time.

This optimization speeds up compilation and cuts ~40% of logging compile time. I don't see a place where logging v2 compilation could be further improved.

I've been testing with:
```
 ccache -C; time scripts/twister -p frdm_k64f -b -c -s tests/kernel/common/kernel.common
```
And getting following results:

Before | After | Without logging v2 | v2.5.0
------------ | ------------- | ------------ | ------------
35.17s | 32,6 | 29.6 | 23.25

It means that something else contributed to the build time increase from v2.5.0.

Fixes #34419.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>