### PR TITLE
tests/drivers: stm32 nucleo_f207zg: Assign prescaler value to 10000

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nucleo_f207zg.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers1 {
+	pwm {
+		st,prescaler = <10000>;
+	};
+};


### PR DESCRIPTION
This commit modifies st prescaler value from 0 to 10000 for 
STM32 nucleo_f207zg. Following this change, pwm_api test 
results in successful execution on nucleo_f207zg board.

Closes [https://github.com/zephyrproject-rtos/zephyr/issues/35108](https://github.com/zephyrproject-rtos/zephyr/issues/35108)

Signed-off-by: Sidhdharth Yadav <sidhdharth.yadav@hcl.com>