### PR TITLE
[RFC] arch: arm: aarch32: make initial mpu configuration dynamic

### DIFF
--- a/include/arch/arm/aarch32/mpu/arm_mpu.h
+++ b/include/arch/arm/aarch32/mpu/arm_mpu.h
@@ -54,7 +54,7 @@ struct arm_mpu_config {
  * for Thread Stack, Stack Guards, etc.) are programmed during runtime, thus,
  * not kept here.
  */
-extern const struct arm_mpu_config mpu_config;
+extern  struct arm_mpu_config mpu_config;
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
Remove const from mpu configuraton to make initial configuration
set during runtime.

Signed-off-by: Nachiketa Kumar <nachiketa.kumar@intel.com>