### PR TITLE
drivers: eth_enc424j600: explicitly disable INTIE after reset

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -690,6 +690,15 @@ static int enc424j600_init(const struct device *dev)
 		return -EIO;
 	}
 
+	/* Disable INTIE and setup interrupt logic */
+	enc424j600_write_sfru(dev, ENC424J600_SFR3_EIEL,
+			      ENC424J600_EIE_PKTIE | ENC424J600_EIE_LINKIE);
+
+	if (CONFIG_ETHERNET_LOG_LEVEL == LOG_LEVEL_DBG) {
+		enc424j600_read_sfru(dev, ENC424J600_SFR3_EIEL, &tmp);
+		LOG_DBG("EIE: 0x%04x", tmp);
+	}
+
 	/* Configure TX and RX buffer */
 	enc424j600_write_sfru(dev, ENC424J600_SFR0_ETXSTL,
 			      ENC424J600_TXSTART);
@@ -720,15 +729,6 @@ static int enc424j600_init(const struct device *dev)
 
 	enc424j600_init_filters(dev);
 	enc424j600_init_phy(dev);
-
-	/* Setup interrupt logic */
-	enc424j600_set_sfru(dev, ENC424J600_SFR3_EIEL,
-			    ENC424J600_EIE_PKTIE | ENC424J600_EIE_LINKIE);
-
-	if (CONFIG_ETHERNET_LOG_LEVEL == LOG_LEVEL_DBG) {
-		enc424j600_read_sfru(dev, ENC424J600_SFR3_EIEL, &tmp);
-		LOG_DBG("EIE: 0x%04x", tmp);
-	}
 
 	/* Enable Reception */
 	enc424j600_set_sfru(dev, ENC424J600_SFRX_ECON1L, ENC424J600_ECON1_RXEN);

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -484,7 +484,13 @@ static void enc424j600_rx_thread(struct enc424j600_runtime *context)
 			}
 		} else {
 			LOG_ERR("Unknown Interrupt, EIR: 0x%04x", eir);
-			continue;
+			/*
+			 * Terminate interrupt handling thread
+			 * only when debugging.
+			 */
+			if (CONFIG_ETHERNET_LOG_LEVEL == LOG_LEVEL_DBG) {
+				k_oops();
+			}
 		}
 
 		enc424j600_set_sfru(context->dev, ENC424J600_SFR3_EIEL,


### PR DESCRIPTION
After system reset (SETETHRST) interrupt enable register (EIE)
has the default value 0x8010 and global interrupt enable flag (INTIE)
is set. This is not desired and the INTIE flag should be set only at
the end of the initialization.
Disable INTIE flag and set desired interrupts sources in
a single write command just right after system reset.

Also clarify how unknown interrupt source should be handled.

Alternative fix for #35091
Fixes #35091