### PR TITLE
Bluetooth: Audio: Fix VCS client shell missing compile

### DIFF
--- a/subsys/bluetooth/shell/CMakeLists.txt
+++ b/subsys/bluetooth/shell/CMakeLists.txt
@@ -29,6 +29,10 @@ zephyr_library_sources_ifdef(
   CONFIG_BT_VCS
   vcs.c
   )
+zephyr_library_sources_ifdef(
+  CONFIG_BT_VCS_CLIENT
+  vcs_client.c
+  )
 
 if(CONFIG_BT_CTLR AND CONFIG_BT_LL_SW_SPLIT)
   zephyr_library_sources(

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/types.h>
 #include <bluetooth/conn.h>
-#include <bluetooth/services/vcs.h>
+#include <bluetooth/audio/vcs.h>
 #include <shell/shell.h>
 #include <stdlib.h>
 
@@ -20,7 +20,7 @@ static struct bt_vcs vcs;
 static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 			    uint8_t aics_count)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS discover failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS discover done with %u AICS",
@@ -34,7 +34,7 @@ static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 
 static void vcs_vol_down_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_down failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS vol_down done");
@@ -43,7 +43,7 @@ static void vcs_vol_down_cb(struct bt_conn *conn, int err)
 
 static void vcs_vol_up_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_up failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS vol_up done");
@@ -52,7 +52,7 @@ static void vcs_vol_up_cb(struct bt_conn *conn, int err)
 
 static void vcs_mute_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS mute failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS mute done");
@@ -61,7 +61,7 @@ static void vcs_mute_cb(struct bt_conn *conn, int err)
 
 static void vcs_unmute_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS unmute failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS unmute done");
@@ -70,7 +70,7 @@ static void vcs_unmute_cb(struct bt_conn *conn, int err)
 
 static void vcs_vol_down_unmute_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_down_unmute failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS vol_down_unmute done");
@@ -79,7 +79,7 @@ static void vcs_vol_down_unmute_cb(struct bt_conn *conn, int err)
 
 static void vcs_vol_up_unmute_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_up_unmute failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS vol_up_unmute done");
@@ -88,7 +88,7 @@ static void vcs_vol_up_unmute_cb(struct bt_conn *conn, int err)
 
 static void vcs_vol_set_cb(struct bt_conn *conn, int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_set failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS vol_set done");
@@ -98,7 +98,7 @@ static void vcs_vol_set_cb(struct bt_conn *conn, int err)
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 			    uint8_t mute)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS state get failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS volume %u, mute %u", volume, mute);
@@ -107,7 +107,7 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VCS flags get failed (%d)", err);
 	} else {
 		shell_print(ctx_shell, "VCS flags 0x%02X", flags);
@@ -115,10 +115,10 @@ static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 }
 
 #if CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0
-static void aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
-			     int err)
+static void vcs_aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
+				 int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -126,9 +126,10 @@ static void aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
+static void vcs_aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst,
+			       int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -136,9 +137,10 @@ static void aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
 	}
 }
 
-static void aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
+static void vcs_aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst,
+			     int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -146,10 +148,11 @@ static void aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
 	}
 }
 
-static void aics_set_manual_mode_cb(struct bt_conn *conn, struct bt_aics *inst,
-				    int err)
+static void vcs_aics_set_manual_mode_cb(struct bt_conn *conn,
+					struct bt_aics *inst,
+					int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "Set manual mode failed (%d) for inst %p",
 			    err, inst);
@@ -158,10 +161,11 @@ static void aics_set_manual_mode_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void aics_automatic_mode_cb(struct bt_conn *conn, struct bt_aics *inst,
-				   int err)
+static void vcs_aics_automatic_mode_cb(struct bt_conn *conn,
+				       struct bt_aics *inst,
+				       int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "Set automatic mode failed (%d) for inst %p",
 			    err, inst);
@@ -171,10 +175,10 @@ static void aics_automatic_mode_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void vcs_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
+			      int err, int8_t gain, uint8_t mute, uint8_t mode)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "AICS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -184,11 +188,11 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	}
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void vcs_aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
+				     int err, uint8_t units, int8_t minimum,
+				     int8_t maximum)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "AICS gain settings get failed (%d) for inst %p",
 			    err, inst);
@@ -202,7 +206,7 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 static void vcs_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 				   int err, uint8_t input_type)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "AICS input type get failed (%d) for inst %p",
 			    err, inst);
@@ -215,7 +219,7 @@ static void vcs_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 static void vcs_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
 			       int err, bool active)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "AICS status get failed (%d) for inst %p",
 			    err, inst);
@@ -228,7 +232,7 @@ static void vcs_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
 static void vcs_aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 				    int err, char *description)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "AICS description get failed (%d) for inst %p",
 			    err, inst);
@@ -240,10 +244,10 @@ static void vcs_aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 #endif /* CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0 */
 
 #if CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST > 0
-static void vocs_set_offset_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			       int err)
+static void vcs_vocs_set_offset_cb(struct bt_conn *conn, struct bt_vocs *inst,
+				   int err)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "Set offset failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -251,10 +255,10 @@ static void vocs_set_offset_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
-			  int16_t offset)
+static void vcs_vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst,
+			      int err, int16_t offset)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
@@ -262,10 +266,10 @@ static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
 	}
 }
 
-static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			     int err, uint32_t location)
+static void vcs_vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
+				 int err, uint32_t location)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "VOCS location get failed (%d) for inst %p",
 			    err, inst);
@@ -275,10 +279,10 @@ static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				int err, char *description)
+static void vcs_vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
+				    int err, char *description)
 {
-	if (err) {
+	if (err != 0) {
 		shell_error(ctx_shell,
 			    "VOCS description get failed (%d) for inst %p",
 			    err, inst);
@@ -305,24 +309,24 @@ static struct bt_vcs_cb vcs_cbs = {
 	/* Audio Input Control Service */
 #if CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0
 	.aics_cb = {
-		.state = aics_state_cb,
-		.gain_setting = aics_gain_setting_cb,
-		.type = aics_input_type_cb,
-		.status = aics_status_cb,
-		.description = aics_description_cb,
-		.set_gain = aics_set_gain_cb,
-		.unmute = aics_unmute_cb,
-		.mute = aics_mute_cb,
-		.set_manual_mode = aics_set_manual_mode_cb,
-		.set_auto_mode = aics_automatic_mode_cb,
+		.state = vcs_aics_state_cb,
+		.gain_setting = vcs_aics_gain_setting_cb,
+		.type = vcs_aics_input_type_cb,
+		.status = vcs_aics_status_cb,
+		.description = vcs_aics_description_cb,
+		.set_gain = vcs_aics_set_gain_cb,
+		.unmute = vcs_aics_unmute_cb,
+		.mute = vcs_aics_mute_cb,
+		.set_manual_mode = vcs_aics_set_manual_mode_cb,
+		.set_auto_mode = vcs_aics_automatic_mode_cb,
 	},
 #endif /* CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0 */
 #if CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST > 0
 	.vocs_cb = {
-		.state = vocs_state_cb,
-		.location = vocs_location_cb,
-		.description = vocs_description_cb,
-		.set_offset = vocs_set_offset_cb,
+		.state = vcs_vocs_state_cb,
+		.location = vcs_vocs_location_cb,
+		.description = vcs_vocs_description_cb,
+		.set_offset = vcs_vocs_set_offset_cb,
 	}
 #endif /* CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST > 0 */
 };
@@ -333,22 +337,22 @@ static int cmd_vcs_client_discover(const struct shell *sh, size_t argc,
 	int result;
 
 	if (!ctx_shell) {
-		ctx_shell = shell;
+		ctx_shell = sh;
 	}
 
 	result = bt_vcs_client_cb_register(&vcs_cbs);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "CB register failed: %d", result);
 		return result;
 	}
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
 	result = bt_vcs_discover(default_conn);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -360,13 +364,13 @@ static int cmd_vcs_client_state_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_volume_get(default_conn);
-	if (result) {
+	result = bt_vcs_vol_get(default_conn);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -378,13 +382,13 @@ static int cmd_vcs_client_flags_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
 	result = bt_vcs_flags_get(default_conn);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -396,13 +400,13 @@ static int cmd_vcs_client_volume_down(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_volume_down(default_conn);
-	if (result) {
+	result = bt_vcs_vol_down(default_conn);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -415,13 +419,13 @@ static int cmd_vcs_client_volume_up(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_volume_up(default_conn);
-	if (result) {
+	result = bt_vcs_vol_up(default_conn);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -433,13 +437,13 @@ static int cmd_vcs_client_unmute_volume_down(const struct shell *sh,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_unmute_volume_down(default_conn);
-	if (result) {
+	result = bt_vcs_unmute_vol_down(default_conn);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -451,13 +455,13 @@ static int cmd_vcs_client_unmute_volume_up(const struct shell *sh,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_unmute_volume_up(default_conn);
-	if (result) {
+	result = bt_vcs_unmute_vol_up(default_conn);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -471,7 +475,7 @@ static int cmd_vcs_client_volume_set(const struct shell *sh, size_t argc,
 	int result;
 	int volume = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -481,8 +485,8 @@ static int cmd_vcs_client_volume_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_volume_set(default_conn, volume);
-	if (result) {
+	result = bt_vcs_vol_set(default_conn, volume);
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -495,13 +499,13 @@ static int cmd_vcs_client_unmute(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
 	result = bt_vcs_unmute(default_conn);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -512,13 +516,13 @@ static int cmd_vcs_client_mute(const struct shell *sh, size_t argc, char **argv)
 {
 	int result;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
 	result = bt_vcs_mute(default_conn);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -531,7 +535,7 @@ static int cmd_vcs_client_vocs_state_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -543,7 +547,7 @@ static int cmd_vcs_client_vocs_state_get(const struct shell *sh, size_t argc,
 	}
 
 	result = bt_vcs_vocs_state_get(default_conn, vcs.vocs[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -556,7 +560,7 @@ static int cmd_vcs_client_vocs_location_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -568,7 +572,7 @@ static int cmd_vcs_client_vocs_location_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_vocs_location_get(default_conn, vcs.vocs[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -582,7 +586,7 @@ static int cmd_vcs_client_vocs_location_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	int location = strtol(argv[2], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -602,7 +606,7 @@ static int cmd_vcs_client_vocs_location_set(const struct shell *sh,
 
 	result = bt_vcs_vocs_location_set(default_conn, vcs.vocs[index],
 					  location);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -616,7 +620,7 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	int offset = strtol(argv[2], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -634,7 +638,7 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 	}
 
 	result = bt_vcs_vocs_state_set(default_conn, vcs.vocs[index], offset);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -647,7 +651,7 @@ static int cmd_vcs_client_vocs_output_description_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -659,7 +663,7 @@ static int cmd_vcs_client_vocs_output_description_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_vocs_description_get(default_conn, vcs.vocs[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -673,7 +677,7 @@ static int cmd_vcs_client_vocs_output_description_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	char *description = argv[2];
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -686,7 +690,7 @@ static int cmd_vcs_client_vocs_output_description_set(const struct shell *sh,
 
 	result = bt_vcs_vocs_description_set(default_conn, vcs.vocs[index],
 					     description);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -699,7 +703,7 @@ static int cmd_vcs_client_aics_input_state_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -711,7 +715,7 @@ static int cmd_vcs_client_aics_input_state_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_state_get(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -724,7 +728,7 @@ static int cmd_vcs_client_aics_gain_setting_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -736,7 +740,7 @@ static int cmd_vcs_client_aics_gain_setting_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_gain_setting_get(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -749,7 +753,7 @@ static int cmd_vcs_client_aics_input_type_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -761,7 +765,7 @@ static int cmd_vcs_client_aics_input_type_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_type_get(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -774,7 +778,7 @@ static int cmd_vcs_client_aics_input_status_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -786,7 +790,7 @@ static int cmd_vcs_client_aics_input_status_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_status_get(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -799,7 +803,7 @@ static int cmd_vcs_client_aics_input_unmute(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -811,7 +815,7 @@ static int cmd_vcs_client_aics_input_unmute(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_unmute(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -824,7 +828,7 @@ static int cmd_vcs_client_aics_input_mute(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -836,7 +840,7 @@ static int cmd_vcs_client_aics_input_mute(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_mute(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -849,7 +853,7 @@ static int cmd_vcs_client_aics_manual_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -861,7 +865,7 @@ static int cmd_vcs_client_aics_manual_input_gain_set(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_manual_gain_set(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -874,7 +878,7 @@ static int cmd_vcs_client_aics_auto_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -886,7 +890,7 @@ static int cmd_vcs_client_aics_auto_input_gain_set(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_automatic_gain_set(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -900,7 +904,7 @@ static int cmd_vcs_client_aics_gain_set(const struct shell *sh, size_t argc,
 	int index = strtol(argv[1], NULL, 0);
 	int gain = strtol(argv[2], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -918,7 +922,7 @@ static int cmd_vcs_client_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	result = bt_vcs_aics_gain_set(default_conn, vcs.aics[index], gain);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -931,7 +935,7 @@ static int cmd_vcs_client_aics_input_description_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -943,7 +947,7 @@ static int cmd_vcs_client_aics_input_description_get(const struct shell *sh,
 	}
 
 	result = bt_vcs_aics_description_get(default_conn, vcs.aics[index]);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 
@@ -957,7 +961,7 @@ static int cmd_vcs_client_aics_input_description_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	char *description = argv[2];
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -970,7 +974,7 @@ static int cmd_vcs_client_aics_input_description_set(const struct shell *sh,
 
 	result = bt_vcs_aics_description_set(default_conn, vcs.aics[index],
 					     description);
-	if (result) {
+	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
 


### PR DESCRIPTION
The VCS client shell was never compiled before, and thus
the implementation had a few undetected errors.

This commit adds the VCS client to the shell CMakelists
as well as fixing the issues.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>