### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: Fix encryption stall

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -285,6 +285,15 @@ void ull_cp_priv_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *p
  * Encryption Start Procedure Helper
  */
 
+static int csrand_get(void *buf, size_t len)
+{
+	if (k_is_in_isr()) {
+		return lll_csrand_isr_get(buf, len);
+	} else {
+		return lll_csrand_get(buf, len);
+	}
+}
+
 void ull_cp_priv_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_enc_req *p;
@@ -298,8 +307,8 @@ void ull_cp_priv_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	p->ediv[0] = ctx->data.enc.ediv[0];
 	p->ediv[1] = ctx->data.enc.ediv[1];
 	/* TODO(thoh): Optimize getting random data */
-	lll_csrand_get(p->skdm, sizeof(p->skdm));
-	lll_csrand_get(p->ivm, sizeof(p->ivm));
+	csrand_get(p->skdm, sizeof(p->skdm));
+	csrand_get(p->ivm, sizeof(p->ivm));
 }
 
 void ull_cp_priv_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
@@ -326,8 +335,8 @@ void ull_cp_priv_pdu_encode_enc_rsp(struct pdu_data *pdu)
 
 	p = &pdu->llctrl.enc_rsp;
 	/* TODO(thoh): Optimize getting random data */
-	lll_csrand_get(p->skds, sizeof(p->skds));
-	lll_csrand_get(p->ivs, sizeof(p->ivs));
+	csrand_get(p->skds, sizeof(p->skds));
+	csrand_get(p->ivs, sizeof(p->ivs));
 }
 
 void ull_cp_priv_pdu_encode_start_enc_req(struct pdu_data *pdu)

--- a/tests/bluetooth/controller/common/defaults_cmake.txt
+++ b/tests/bluetooth/controller/common/defaults_cmake.txt
@@ -36,6 +36,7 @@ FILE(GLOB ll_sw_sources
 )
 
 FILE(GLOB mock_sources
+        ${ZEPHYR_BASE}/tests/bluetooth/controller/mock_ctrl/src/kernel.c
         ${ZEPHYR_BASE}/tests/bluetooth/controller/mock_ctrl/src/ecb.c
         ${ZEPHYR_BASE}/tests/bluetooth/controller/mock_ctrl/src/mayfly.c
         ${ZEPHYR_BASE}/tests/bluetooth/controller/mock_ctrl/src/lll.c

--- a/tests/bluetooth/controller/mock_ctrl/src/kernel.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/kernel.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <ztest.h>
+
+bool k_is_in_isr(void)
+{
+	return 0;
+}

--- a/tests/bluetooth/controller/mock_ctrl/src/lll.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/lll.c
@@ -38,6 +38,13 @@ __attribute__((weak)) int lll_csrand_get(void *buf, size_t len)
 	* (int *) buf = 0;
 	return 0;
 }
+
+__attribute__((weak)) int lll_csrand_isr_get(void *buf, size_t len)
+{
+	* (int *) buf = 0;
+	return 0;
+}
+
 uint32_t lll_radio_tx_ready_delay_get(uint8_t phy, uint8_t flags)
 {
 	return 0;


### PR DESCRIPTION
When ull_cp_priv_pdu_encode_enc_req is called, the code is currently in
ISR context and lll_csrand_isr_get() should be used when getting random
numbers.

Abstract the deep knowledge of which context the LLCP code is running in
away behind a helper function that uses k_is_in_isr() to select either
lll_csrand_get() or lll_csrand_isr_get().

Add mocked version of missing functions and newly introduced kernel
function k_is_in_isr (unit tests defaults to being non-isr).

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>