### PR TITLE
doc: some more fixes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,10 +166,7 @@ doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE)}
 
 # -- Options for Breathe plugin -------------------------------------------
 
-breathe_projects = {
-    "Zephyr": str(doxyrunner_outdir / "xml"),
-    "doc-examples": str(doxyrunner_outdir / "xml"),
-}
+breathe_projects = {"Zephyr": str(doxyrunner_outdir / "xml")}
 breathe_default_project = "Zephyr"
 breathe_domain_by_extension = {
     "h": "c",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,15 +118,15 @@ html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme_options = {"prev_next_buttons_location": None}
 html_title = "Zephyr Project Documentation"
-html_logo = "_static/images/logo.svg"
-html_favicon = "images/zp_favicon.png"
+html_logo = str(ZEPHYR_BASE / "doc" / "_static" / "images" / "logo.svg")
+html_favicon = str(ZEPHYR_BASE / "doc" / "images" / "zp_favicon.png")
 html_static_path = [str(ZEPHYR_BASE / "doc" / "_static")]
 html_last_updated_fmt = "%b %d, %Y"
 html_domain_indices = False
 html_split_index = True
 html_show_sourcelink = False
 html_show_sphinx = False
-html_search_scorer = "_static/js/scorer.js"
+html_search_scorer = str(ZEPHYR_BASE / "doc" / "_static" / "js" / "scorer.js")
 
 is_release = tags.has("release")  # pylint: disable=undefined-variable
 docs_title = "Docs / {}".format(version if is_release else "Latest")

--- a/doc/guides/flash_debug/coredump.rst
+++ b/doc/guides/flash_debug/coredump.rst
@@ -341,7 +341,5 @@ API documentation
 *****************
 
 .. doxygengroup:: coredump_apis
-   :project: Zephyr
 
 .. doxygengroup:: arch-coredump
-   :project: Zephyr

--- a/doc/guides/flash_debug/thread-analyzer.rst
+++ b/doc/guides/flash_debug/thread-analyzer.rst
@@ -85,4 +85,3 @@ API documentation
 *****************
 
 .. doxygengroup:: thread_analyzer
-   :project: Zephyr

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -842,49 +842,40 @@ Timing
 ======
 
 .. doxygengroup:: arch-timing
-   :project: Zephyr
 
 Threads
 =======
 
 .. doxygengroup:: arch-threads
-   :project: Zephyr
 
 .. doxygengroup:: arch-tls
-   :project: Zephyr
 
 Power Management
 ================
 
 .. doxygengroup:: arch-pm
-   :project: Zephyr
 
 Symmetric Multi-Processing
 ==========================
 
 .. doxygengroup:: arch-smp
-   :project: Zephyr
 
 Interrupts
 ==========
 
 .. doxygengroup:: arch-irq
-   :project: Zephyr
 
 Userspace
 =========
 
 .. doxygengroup:: arch-userspace
-   :project: Zephyr
 
 Memory Management
 =================
 
 .. doxygengroup:: arch-mmu
-   :project: Zephyr
 
 Miscellaneous Architecture APIs
 ===============================
 
 .. doxygengroup:: arch-misc
-   :project: Zephyr

--- a/doc/guides/test/ztest.rst
+++ b/doc/guides/test/ztest.rst
@@ -300,7 +300,6 @@ Running tests
 =============
 
 .. doxygengroup:: ztest_test
-   :project: Zephyr
 
 Assertions
 ==========
@@ -320,7 +319,6 @@ Example output for a failed macro from
     Aborted at unit test function
 
 .. doxygengroup:: ztest_assert
-   :project: Zephyr
 
 Mocking
 =======
@@ -340,7 +338,6 @@ expect the values ``a=2`` and ``b=3``, and telling ``returns_int`` to return
    :linenos:
 
 .. doxygengroup:: ztest_mock
-   :project: Zephyr
 
 Customizing Test Output
 ***********************

--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -25,7 +25,6 @@ format by overriding the macros declared
 in :zephyr_file:`include/tracing/tracing.h`.
 
 .. doxygengroup:: tracing_apis
-   :project: Zephyr
 
 Different formats, transports and host tools are avialable and supported in
 Zephyr.

--- a/doc/reference/audio/codec.rst
+++ b/doc/reference/audio/codec.rst
@@ -19,4 +19,3 @@ API Reference
 *************
 
 .. doxygengroup:: audio_codec_interface
-   :project: Zephyr

--- a/doc/reference/audio/dmic.rst
+++ b/doc/reference/audio/dmic.rst
@@ -19,4 +19,3 @@ API Reference
 *************
 
 .. doxygengroup:: audio_dmic_interface
-   :project: Zephyr

--- a/doc/reference/audio/i2s.rst
+++ b/doc/reference/audio/i2s.rst
@@ -22,4 +22,3 @@ API Reference
 *************
 
 .. doxygengroup:: i2s_interface
-   :project: Zephyr

--- a/doc/reference/bluetooth/connection_mgmt.rst
+++ b/doc/reference/bluetooth/connection_mgmt.rst
@@ -28,4 +28,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_conn
-   :project: Zephyr

--- a/doc/reference/bluetooth/controller.rst
+++ b/doc/reference/bluetooth/controller.rst
@@ -8,4 +8,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_ctrl
-   :project: Zephyr

--- a/doc/reference/bluetooth/crypto.rst
+++ b/doc/reference/bluetooth/crypto.rst
@@ -8,4 +8,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_crypto
-   :project: Zephyr

--- a/doc/reference/bluetooth/data_buffer.rst
+++ b/doc/reference/bluetooth/data_buffer.rst
@@ -8,4 +8,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_buf
-   :project: Zephyr

--- a/doc/reference/bluetooth/gap.rst
+++ b/doc/reference/bluetooth/gap.rst
@@ -7,10 +7,7 @@ API Reference
 *************
 
 .. doxygengroup:: bt_gap
-   :project: Zephyr
 
 .. doxygengroup:: bt_addr
-   :project: Zephyr
 
 .. doxygengroup:: bt_gap_defines
-   :project: Zephyr

--- a/doc/reference/bluetooth/gatt.rst
+++ b/doc/reference/bluetooth/gatt.rst
@@ -96,16 +96,13 @@ API Reference
 *************
 
 .. doxygengroup:: bt_gatt
-   :project: Zephyr
 
 GATT Server
 ===========
 
 .. doxygengroup:: bt_gatt_server
-   :project: Zephyr
 
 GATT Client
 ===========
 
 .. doxygengroup:: bt_gatt_client
-   :project: Zephyr

--- a/doc/reference/bluetooth/hci_drivers.rst
+++ b/doc/reference/bluetooth/hci_drivers.rst
@@ -9,4 +9,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_hci_driver
-   :project: Zephyr

--- a/doc/reference/bluetooth/hci_raw.rst
+++ b/doc/reference/bluetooth/hci_raw.rst
@@ -16,4 +16,3 @@ API Reference
 *************
 
 .. doxygengroup:: hci_raw
-   :project: Zephyr

--- a/doc/reference/bluetooth/hfp.rst
+++ b/doc/reference/bluetooth/hfp.rst
@@ -8,4 +8,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_hfp
-   :project: Zephyr

--- a/doc/reference/bluetooth/l2cap.rst
+++ b/doc/reference/bluetooth/l2cap.rst
@@ -39,4 +39,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_l2cap
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -143,4 +143,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_access
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/cfg.rst
+++ b/doc/reference/bluetooth/mesh/cfg.rst
@@ -19,4 +19,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_cfg
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/cfg_cli.rst
+++ b/doc/reference/bluetooth/mesh/cfg_cli.rst
@@ -24,4 +24,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_cfg_cli
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/cfg_srv.rst
+++ b/doc/reference/bluetooth/mesh/cfg_srv.rst
@@ -21,4 +21,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_cfg_srv
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -25,4 +25,3 @@ API reference
 **************
 
 .. doxygengroup:: bt_mesh
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/health_cli.rst
+++ b/doc/reference/bluetooth/mesh/health_cli.rst
@@ -21,4 +21,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_health_cli
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/health_srv.rst
+++ b/doc/reference/bluetooth/mesh/health_srv.rst
@@ -49,7 +49,6 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_health_srv
-   :project: Zephyr
 
 .. _bluetooth_mesh_health_faults:
 
@@ -59,4 +58,3 @@ Bluetooth Mesh Health Faults
 Fault values defined by the Bluetooth Mesh specification.
 
 .. doxygengroup:: bt_mesh_health_faults
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/heartbeat.rst
+++ b/doc/reference/bluetooth/mesh/heartbeat.rst
@@ -63,4 +63,3 @@ API reference
 **************
 
 .. doxygengroup:: bt_mesh_heartbeat
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/msg.rst
+++ b/doc/reference/bluetooth/mesh/msg.rst
@@ -10,4 +10,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_msg
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/provisioning.rst
+++ b/doc/reference/bluetooth/mesh/provisioning.rst
@@ -132,4 +132,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_prov
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/proxy.rst
+++ b/doc/reference/bluetooth/mesh/proxy.rst
@@ -13,4 +13,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_proxy
-   :project: Zephyr

--- a/doc/reference/bluetooth/rfcomm.rst
+++ b/doc/reference/bluetooth/rfcomm.rst
@@ -9,4 +9,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_rfcomm
-   :project: Zephyr

--- a/doc/reference/bluetooth/sdp.rst
+++ b/doc/reference/bluetooth/sdp.rst
@@ -7,4 +7,3 @@ API Reference
 **************
 
 .. doxygengroup:: bt_sdp
-   :project: Zephyr

--- a/doc/reference/bluetooth/uuid.rst
+++ b/doc/reference/bluetooth/uuid.rst
@@ -8,4 +8,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_uuid
-   :project: Zephyr

--- a/doc/reference/crypto/index.rst
+++ b/doc/reference/crypto/index.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: crypto_cipher
-   :project: Zephyr

--- a/doc/reference/data_structures/dlist.rst
+++ b/doc/reference/data_structures/dlist.rst
@@ -98,4 +98,3 @@ Doubly-linked List API Reference
 --------------------------------
 
 .. doxygengroup:: doubly-linked-list_apis
-   :project: Zephyr

--- a/doc/reference/data_structures/rbtree.rst
+++ b/doc/reference/data_structures/rbtree.rst
@@ -119,4 +119,3 @@ Red/Black Tree API Reference
 --------------------------------
 
 .. doxygengroup:: rbtree_apis
-   :project: Zephyr

--- a/doc/reference/data_structures/ring_buffers.rst
+++ b/doc/reference/data_structures/ring_buffers.rst
@@ -413,4 +413,3 @@ API Reference
 The following ring buffer APIs are provided by :zephyr_file:`include/sys/ring_buffer.h`:
 
 .. doxygengroup:: ring_buffer_apis
-   :project: Zephyr

--- a/doc/reference/data_structures/slist.rst
+++ b/doc/reference/data_structures/slist.rst
@@ -118,10 +118,8 @@ Single-linked List API Reference
 --------------------------------
 
 .. doxygengroup:: single-linked-list_apis
-   :project: Zephyr
 
 Flagged List API Reference
 --------------------------------
 
 .. doxygengroup:: flagged-single-linked-list_apis
-   :project: Zephyr

--- a/doc/reference/devicetree/api.rst
+++ b/doc/reference/devicetree/api.rst
@@ -39,7 +39,6 @@ child node, respectively.
 The following macros create or operate on node identifiers.
 
 .. doxygengroup:: devicetree-generic-id
-   :project: Zephyr
 
 .. _devicetree-property-access:
 
@@ -54,7 +53,6 @@ Property values can be read using these macros even if the node is disabled,
 as long as it has a matching binding.
 
 .. doxygengroup:: devicetree-generic-prop
-   :project: Zephyr
 
 .. _devicetree-reg-property:
 
@@ -67,7 +65,6 @@ devicetree specification, these macros can be used even for nodes without
 matching bindings.
 
 .. doxygengroup:: devicetree-reg-prop
-   :project: Zephyr
 
 .. _devicetree-interrupts-property:
 
@@ -82,7 +79,6 @@ some of these macros can be used even for nodes without matching bindings. This
 does not apply to macros which take cell names as arguments.
 
 .. doxygengroup:: devicetree-interrupts-prop
-   :project: Zephyr
 
 For-each macros
 ===============
@@ -96,7 +92,6 @@ There are special-purpose for-each macros, like
 be defined before use.
 
 .. doxygengroup:: devicetree-generic-foreach
-   :project: Zephyr
 
 Existence checks
 ================
@@ -108,7 +103,6 @@ properties, etc. Some macros used for special purposes (such as
 documented elsewhere on this page.
 
 .. doxygengroup:: devicetree-generic-exist
-   :project: Zephyr
 
 .. _devicetree-dep-ord:
 
@@ -146,7 +140,6 @@ There are instance number-based conveniences as well; see
 :c:func:`DT_INST_DEP_ORD` and subsequent documentation.
 
 .. doxygengroup:: devicetree-dep-ord
-   :project: Zephyr
 
 Bus helpers
 ===========
@@ -157,7 +150,6 @@ In this case, child nodes are considered to be on a bus of the given type, and
 the following APIs may be used.
 
 .. doxygengroup:: devicetree-generic-bus
-   :project: Zephyr
 
 .. _devicetree-inst-apis:
 
@@ -207,7 +199,6 @@ Note that there are also helpers available for
 specific hardware; these are documented in :ref:`devicetree-hw-api`.
 
 .. doxygengroup:: devicetree-inst
-   :project: Zephyr
 
 .. _devicetree-hw-api:
 
@@ -224,7 +215,6 @@ These conveniences may be used for nodes which describe clock sources, and
 properties related to them.
 
 .. doxygengroup:: devicetree-clocks
-   :project: Zephyr
 
 DMA
 ===
@@ -233,7 +223,6 @@ These conveniences may be used for nodes which describe direct memory access
 controllers or channels, and properties related to them.
 
 .. doxygengroup:: devicetree-dmas
-   :project: Zephyr
 
 .. _devicetree-flash-api:
 
@@ -246,7 +235,6 @@ device tree. See :zephyr_file:`dts/bindings/mtd/partition.yaml` for this
 compatible's binding.
 
 .. doxygengroup:: devicetree-fixed-partition
-   :project: Zephyr
 
 .. _devicetree-gpio-api:
 
@@ -257,7 +245,6 @@ These conveniences may be used for nodes which describe GPIO controllers/pins,
 and properties related to them.
 
 .. doxygengroup:: devicetree-gpio
-   :project: Zephyr
 
 IO channels
 ===========
@@ -266,7 +253,6 @@ These are commonly used by device drivers which need to use IO
 channels (e.g. ADC or DAC channels) for conversion.
 
 .. doxygengroup:: devicetree-io-channels
-   :project: Zephyr
 
 PWM
 ===
@@ -275,7 +261,6 @@ These conveniences may be used for nodes which describe PWM controllers and
 properties related to them.
 
 .. doxygengroup:: devicetree-pwms
-   :project: Zephyr
 
 SPI
 ===
@@ -284,7 +269,6 @@ These conveniences may be used for nodes which describe either SPI controllers
 or devices, depending on the case.
 
 .. doxygengroup:: devicetree-spi
-   :project: Zephyr
 
 .. _devicetree-chosen-nodes:
 

--- a/doc/reference/display/index.rst
+++ b/doc/reference/display/index.rst
@@ -16,22 +16,18 @@ Generic Display Interface
 =========================
 
 .. doxygengroup:: display_interface
-   :project: Zephyr
 
 Grove LCD Display
 =================
 
 .. doxygengroup:: grove_display
-   :project: Zephyr
 
 BBC micro:bit Display
 =====================
 
 .. doxygengroup:: mb_display
-   :project: Zephyr
 
 Monochrome Character Framebuffer
 ================================
 
 .. doxygengroup:: monochrome_character_framebuffer
-   :project: Zephyr

--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -593,4 +593,3 @@ API Reference
 **************
 
 .. doxygengroup:: device_model
-   :project: Zephyr

--- a/doc/reference/edac/index.rst
+++ b/doc/reference/edac/index.rst
@@ -7,4 +7,3 @@ API Reference
 *************
 
 .. doxygengroup:: edac
-   :project: Zephyr

--- a/doc/reference/file_system/index.rst
+++ b/doc/reference/file_system/index.rst
@@ -61,4 +61,3 @@ API Reference
 *************
 
 .. doxygengroup:: file_system_api
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/fifos.rst
+++ b/doc/reference/kernel/data_passing/fifos.rst
@@ -160,4 +160,3 @@ API Reference
 *************
 
 .. doxygengroup:: fifo_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/lifos.rst
+++ b/doc/reference/kernel/data_passing/lifos.rst
@@ -148,4 +148,3 @@ API Reference
 *************
 
 .. doxygengroup:: lifo_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/mailboxes.rst
+++ b/doc/reference/kernel/data_passing/mailboxes.rst
@@ -635,4 +635,3 @@ API Reference
 *************
 
 .. doxygengroup:: mailbox_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/message_queues.rst
+++ b/doc/reference/kernel/data_passing/message_queues.rst
@@ -221,4 +221,3 @@ API Reference
 *************
 
 .. doxygengroup:: msgq_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/pipes.rst
+++ b/doc/reference/kernel/data_passing/pipes.rst
@@ -178,4 +178,3 @@ API Reference
 *************
 
 .. doxygengroup:: pipe_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/queues.rst
+++ b/doc/reference/kernel/data_passing/queues.rst
@@ -15,4 +15,3 @@ API Reference
 *************
 
 .. doxygengroup:: queue_apis
-   :project: Zephyr

--- a/doc/reference/kernel/data_passing/stacks.rst
+++ b/doc/reference/kernel/data_passing/stacks.rst
@@ -140,4 +140,3 @@ API Reference
 *************
 
 .. doxygengroup:: stack_apis
-   :project: Zephyr

--- a/doc/reference/kernel/memory/heap.rst
+++ b/doc/reference/kernel/memory/heap.rst
@@ -181,4 +181,3 @@ API Reference
 =============
 
 .. doxygengroup:: heap_apis
-   :project: Zephyr

--- a/doc/reference/kernel/memory/slabs.rst
+++ b/doc/reference/kernel/memory/slabs.rst
@@ -145,4 +145,3 @@ API Reference
 *************
 
 .. doxygengroup:: mem_slab_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/atomic.rst
+++ b/doc/reference/kernel/other/atomic.rst
@@ -117,4 +117,3 @@ API Reference
     All atomic services APIs can be used by both threads and ISRs.
 
 .. doxygengroup:: atomic_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/cpu_idle.rst
+++ b/doc/reference/kernel/other/cpu_idle.rst
@@ -139,4 +139,3 @@ API Reference
 *************
 
 .. doxygengroup:: cpu_idle_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/fatal.rst
+++ b/doc/reference/kernel/other/fatal.rst
@@ -257,4 +257,3 @@ API Reference
 *************
 
 .. doxygengroup:: fatal_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/float.rst
+++ b/doc/reference/kernel/other/float.rst
@@ -352,4 +352,3 @@ API Reference
 *************
 
 .. doxygengroup:: float_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/interrupts.rst
+++ b/doc/reference/kernel/other/interrupts.rst
@@ -479,4 +479,3 @@ API Reference
 *************
 
 .. doxygengroup:: isr_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/polling.rst
+++ b/doc/reference/kernel/other/polling.rst
@@ -283,4 +283,3 @@ API Reference
 *************
 
 .. doxygengroup:: poll_apis
-   :project: Zephyr

--- a/doc/reference/kernel/other/version.rst
+++ b/doc/reference/kernel/other/version.rst
@@ -9,5 +9,4 @@ API Reference
 **************
 
 .. doxygengroup:: version_apis
-   :project: Zephyr
    :content-only:

--- a/doc/reference/kernel/synchronization/condvar.rst
+++ b/doc/reference/kernel/synchronization/condvar.rst
@@ -136,4 +136,3 @@ API Reference
 **************
 
 .. doxygengroup:: condvar_apis
-   :project: Zephyr

--- a/doc/reference/kernel/synchronization/mutexes.rst
+++ b/doc/reference/kernel/synchronization/mutexes.rst
@@ -165,7 +165,6 @@ API Reference
 *************
 
 .. doxygengroup:: mutex_apis
-   :project: Zephyr
 
 Futex API Reference
 *******************
@@ -177,7 +176,6 @@ user memory so that any access bypasses the kernel object permission
 management mechanism.
 
 .. doxygengroup:: futex_apis
-   :project: Zephyr
 
 User Mode Mutex API Reference
 *****************************
@@ -187,4 +185,3 @@ that a sys_mutex instance can reside in user memory. When user mode isn't
 enabled, sys_mutex behaves like k_mutex.
 
 .. doxygengroup:: user_mutex_apis
-   :project: Zephyr

--- a/doc/reference/kernel/synchronization/semaphores.rst
+++ b/doc/reference/kernel/synchronization/semaphores.rst
@@ -129,7 +129,6 @@ API Reference
 **************
 
 .. doxygengroup:: semaphore_apis
-   :project: Zephyr
 
 User Mode Semaphore API Reference
 *********************************
@@ -139,4 +138,3 @@ thread when user mode enabled. When user mode isn't enabled, sys_sem behaves
 like k_sem.
 
 .. doxygengroup:: user_semaphore_apis
-   :project: Zephyr

--- a/doc/reference/kernel/threads/index.rst
+++ b/doc/reference/kernel/threads/index.rst
@@ -541,7 +541,5 @@ API Reference
 **************
 
 .. doxygengroup:: thread_apis
-   :project: Zephyr
 
 .. doxygengroup:: thread_stack_api
-   :project: Zephyr

--- a/doc/reference/kernel/threads/workqueue.rst
+++ b/doc/reference/kernel/threads/workqueue.rst
@@ -546,4 +546,3 @@ API Reference
 **************
 
 .. doxygengroup:: workqueue_apis
-   :project: Zephyr

--- a/doc/reference/kernel/timing/timers.rst
+++ b/doc/reference/kernel/timing/timers.rst
@@ -243,4 +243,3 @@ API Reference
 *************
 
 .. doxygengroup:: timer_apis
-   :project: Zephyr

--- a/doc/reference/libc/index.rst
+++ b/doc/reference/libc/index.rst
@@ -56,7 +56,6 @@ Below is a list of the error number definitions. For the actual numeric values
 please refer to `errno.h`_.
 
 .. doxygengroup:: system_errno
-   :project: Zephyr
 
 .. _`POSIX errno.h specification`: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html
 .. _`errno.h`: https://github.com/zephyrproject-rtos/zephyr/blob/main/lib/libc/minimal/include/errno.h

--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -796,28 +796,23 @@ Logger API
 ==========
 
 .. doxygengroup:: log_api
-   :project: Zephyr
 
 Logger control
 ==============
 
 .. doxygengroup:: log_ctrl
-   :project: Zephyr
 
 Log message
 ===========
 
 .. doxygengroup:: log_msg
-   :project: Zephyr
 
 Logger backend interface
 ========================
 
 .. doxygengroup:: log_backend
-   :project: Zephyr
 
 Logger output formatting
 ========================
 
 .. doxygengroup:: log_output
-   :project: Zephyr

--- a/doc/reference/misc/formatted_output.rst
+++ b/doc/reference/misc/formatted_output.rst
@@ -130,4 +130,3 @@ API Reference
 *************
 
 .. doxygengroup:: cbprintf_apis
-   :project: Zephyr

--- a/doc/reference/misc/index.rst
+++ b/doc/reference/misc/index.rst
@@ -15,7 +15,6 @@ CRC
 =====
 
 .. doxygengroup:: crc
-   :project: Zephyr
 
 Structured Data APIs
 ********************
@@ -24,7 +23,6 @@ JSON
 ====
 
 .. doxygengroup:: json
-   :project: Zephyr
 
 JWT
 ===
@@ -36,4 +34,3 @@ this API is limited to creating the simplistic tokens needed to
 authenticate with the Google Core IoT infrastructure.
 
 .. doxygengroup:: jwt
-   :project: Zephyr

--- a/doc/reference/misc/notify.rst
+++ b/doc/reference/misc/notify.rst
@@ -35,4 +35,3 @@ API Reference
 *************
 
 .. doxygengroup:: sys_notify_apis
-   :project: Zephyr

--- a/doc/reference/misc/timeutil.rst
+++ b/doc/reference/misc/timeutil.rst
@@ -66,7 +66,6 @@ information about time zones.  Zephyr provides this transformation with
 :c:func:`timeutil_timegm` and :c:func:`timeutil_timegm64`.
 
 .. doxygengroup:: timeutil_repr_apis
-   :project: Zephyr
 
 .. _timeutil_sync:
 
@@ -106,7 +105,6 @@ process:
   :c:func:`timeutil_sync_estimate_skew`.
 
 .. doxygengroup:: timeutil_sync_apis
-   :project: Zephyr
 
 .. _timeutil_concepts:
 

--- a/doc/reference/modbus/index.rst
+++ b/doc/reference/modbus/index.rst
@@ -38,6 +38,5 @@ API Reference
 *************
 
 .. doxygengroup:: modbus
-   :project: Zephyr
 
 .. _`MODBUS Protocol Specifications`: https://www.modbus.org/specs.php

--- a/doc/reference/networking/can_api.rst
+++ b/doc/reference/networking/can_api.rst
@@ -376,4 +376,3 @@ API Reference
 *************
 
 .. doxygengroup:: can_interface
-   :project: Zephyr

--- a/doc/reference/networking/can_isotp.rst
+++ b/doc/reference/networking/can_isotp.rst
@@ -45,4 +45,3 @@ API Reference
 *************
 
 .. doxygengroup:: can_isotp
-   :project: Zephyr

--- a/doc/reference/networking/capture.rst
+++ b/doc/reference/networking/capture.rst
@@ -26,4 +26,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_capture
-   :project: Zephyr

--- a/doc/reference/networking/coap.rst
+++ b/doc/reference/networking/coap.rst
@@ -204,4 +204,3 @@ API Reference
 *************
 
 .. doxygengroup:: coap
-   :project: Zephyr

--- a/doc/reference/networking/dhcpv4.rst
+++ b/doc/reference/networking/dhcpv4.rst
@@ -29,4 +29,3 @@ API Reference
 *************
 
 .. doxygengroup:: dhcpv4
-   :project: Zephyr

--- a/doc/reference/networking/dns_resolve.rst
+++ b/doc/reference/networking/dns_resolve.rst
@@ -41,4 +41,3 @@ API Reference
 *************
 
 .. doxygengroup:: dns_resolve
-   :project: Zephyr

--- a/doc/reference/networking/ethernet.rst
+++ b/doc/reference/networking/ethernet.rst
@@ -43,7 +43,5 @@ API Reference
 *************
 
 .. doxygengroup:: ethernet
-   :project: Zephyr
 
 .. doxygengroup:: ethernet_mii
-   :project: Zephyr

--- a/doc/reference/networking/ethernet_mgmt.rst
+++ b/doc/reference/networking/ethernet_mgmt.rst
@@ -31,4 +31,3 @@ API Reference
 *************
 
 .. doxygengroup:: ethernet_mgmt
-   :project: Zephyr

--- a/doc/reference/networking/gptp.rst
+++ b/doc/reference/networking/gptp.rst
@@ -73,4 +73,3 @@ API Reference
 *************
 
 .. doxygengroup:: gptp
-   :project: Zephyr

--- a/doc/reference/networking/ieee802154.rst
+++ b/doc/reference/networking/ieee802154.rst
@@ -29,10 +29,8 @@ IEEE 802.15.4
 =============
 
 .. doxygengroup:: ieee802154
-   :project: Zephyr
 
 IEEE 802.15.4 Management
 ========================
 
 .. doxygengroup:: ieee802154_mgmt
-   :project: Zephyr

--- a/doc/reference/networking/ip_4_6.rst
+++ b/doc/reference/networking/ip_4_6.rst
@@ -16,4 +16,3 @@ API Reference
 *************
 
 .. doxygengroup:: ip_4_6
-   :project: Zephyr

--- a/doc/reference/networking/lldp.rst
+++ b/doc/reference/networking/lldp.rst
@@ -21,4 +21,3 @@ API Reference
 *************
 
 .. doxygengroup:: lldp
-   :project: Zephyr

--- a/doc/reference/networking/lwm2m.rst
+++ b/doc/reference/networking/lwm2m.rst
@@ -416,7 +416,6 @@ API Reference
 *************
 
 .. doxygengroup:: lwm2m_api
-   :project: Zephyr
 
 .. _LwM2M:
    https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/

--- a/doc/reference/networking/mqtt.rst
+++ b/doc/reference/networking/mqtt.rst
@@ -170,4 +170,3 @@ API Reference
 *************
 
 .. doxygengroup:: mqtt_socket
-   :project: Zephyr

--- a/doc/reference/networking/net_buf.rst
+++ b/doc/reference/networking/net_buf.rst
@@ -137,4 +137,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_buf
-   :project: Zephyr

--- a/doc/reference/networking/net_config.rst
+++ b/doc/reference/networking/net_config.rst
@@ -72,4 +72,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_config
-   :project: Zephyr

--- a/doc/reference/networking/net_core.rst
+++ b/doc/reference/networking/net_core.rst
@@ -24,4 +24,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_core
-   :project: Zephyr

--- a/doc/reference/networking/net_hostname.rst
+++ b/doc/reference/networking/net_hostname.rst
@@ -36,4 +36,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_hostname
-   :project: Zephyr

--- a/doc/reference/networking/net_if.rst
+++ b/doc/reference/networking/net_if.rst
@@ -59,4 +59,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_if
-   :project: Zephyr

--- a/doc/reference/networking/net_l2.rst
+++ b/doc/reference/networking/net_l2.rst
@@ -154,4 +154,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_l2
-   :project: Zephyr

--- a/doc/reference/networking/net_linkaddr.rst
+++ b/doc/reference/networking/net_linkaddr.rst
@@ -19,4 +19,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_linkaddr
-   :project: Zephyr

--- a/doc/reference/networking/net_mgmt.rst
+++ b/doc/reference/networking/net_mgmt.rst
@@ -171,4 +171,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_mgmt
-   :project: Zephyr

--- a/doc/reference/networking/net_offload.rst
+++ b/doc/reference/networking/net_offload.rst
@@ -22,7 +22,6 @@ API Reference
 *************
 
 .. doxygengroup:: net_offload
-   :project: Zephyr
 
 .. _net_socket_offloading:
 

--- a/doc/reference/networking/net_pkt.rst
+++ b/doc/reference/networking/net_pkt.rst
@@ -360,4 +360,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_pkt
-   :project: Zephyr

--- a/doc/reference/networking/net_stats.rst
+++ b/doc/reference/networking/net_stats.rst
@@ -36,4 +36,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_stats
-   :project: Zephyr

--- a/doc/reference/networking/net_timeout.rst
+++ b/doc/reference/networking/net_timeout.rst
@@ -59,4 +59,3 @@ API Reference
 *************
 
 .. doxygengroup:: net_timeout
-   :project: Zephyr

--- a/doc/reference/networking/promiscuous.rst
+++ b/doc/reference/networking/promiscuous.rst
@@ -77,4 +77,3 @@ API Reference
 *************
 
 .. doxygengroup:: promiscuous
-   :project: Zephyr

--- a/doc/reference/networking/ptp_time.rst
+++ b/doc/reference/networking/ptp_time.rst
@@ -20,4 +20,3 @@ API Reference
 *************
 
 .. doxygengroup:: ptp_time
-   :project: Zephyr

--- a/doc/reference/networking/sntp.rst
+++ b/doc/reference/networking/sntp.rst
@@ -20,4 +20,3 @@ API Reference
 *************
 
 .. doxygengroup:: sntp
-   :project: Zephyr

--- a/doc/reference/networking/sockets.rst
+++ b/doc/reference/networking/sockets.rst
@@ -155,10 +155,8 @@ BSD Sockets
 ===========
 
 .. doxygengroup:: bsd_sockets
-   :project: Zephyr
 
 TLS Credentials
 ===============
 
 .. doxygengroup:: tls_credentials
-   :project: Zephyr

--- a/doc/reference/networking/trickle.rst
+++ b/doc/reference/networking/trickle.rst
@@ -22,4 +22,3 @@ API Reference
 *************
 
 .. doxygengroup:: trickle
-   :project: Zephyr

--- a/doc/reference/networking/vlan.rst
+++ b/doc/reference/networking/vlan.rst
@@ -52,4 +52,3 @@ API Reference
 *************
 
 .. doxygengroup:: vlan_api
-   :project: Zephyr

--- a/doc/reference/networking/websocket.rst
+++ b/doc/reference/networking/websocket.rst
@@ -75,4 +75,3 @@ API Reference
 *************
 
 .. doxygengroup:: websocket
-   :project: Zephyr

--- a/doc/reference/peripherals/adc.rst
+++ b/doc/reference/peripherals/adc.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: adc_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/clock_control.rst
+++ b/doc/reference/peripherals/clock_control.rst
@@ -20,4 +20,3 @@ API Reference
 *************
 
 .. doxygengroup:: clock_control_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/counter.rst
+++ b/doc/reference/peripherals/counter.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: counter_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/dac.rst
+++ b/doc/reference/peripherals/dac.rst
@@ -19,4 +19,3 @@ API Reference
 *************
 
 .. doxygengroup:: dac_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/dma.rst
+++ b/doc/reference/peripherals/dma.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: dma_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/ec_host_cmd_periph.rst
+++ b/doc/reference/peripherals/ec_host_cmd_periph.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: ec_host_cmd_periph_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/eeprom.rst
+++ b/doc/reference/peripherals/eeprom.rst
@@ -23,4 +23,3 @@ API Reference
 *************
 
 .. doxygengroup:: eeprom_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/entropy.rst
+++ b/doc/reference/peripherals/entropy.rst
@@ -15,4 +15,3 @@ API Reference
 *************
 
 .. doxygengroup:: entropy_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/flash.rst
+++ b/doc/reference/peripherals/flash.rst
@@ -22,9 +22,7 @@ API for retrieving the layout of pages).
 User API Reference
 ******************
 .. doxygengroup:: flash_interface
-   :project: Zephyr
 
 Implementation interface API Reference
 **************************************
 .. doxygengroup:: flash_internal_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/gna.rst
+++ b/doc/reference/peripherals/gna.rst
@@ -20,4 +20,3 @@ API Reference
 *************
 
 .. doxygengroup:: gna_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/gpio.rst
+++ b/doc/reference/peripherals/gpio.rst
@@ -18,4 +18,3 @@ API Reference
 *************
 
 .. doxygengroup:: gpio_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/hwinfo.rst
+++ b/doc/reference/peripherals/hwinfo.rst
@@ -20,4 +20,3 @@ API Reference
 *************
 
 .. doxygengroup:: hwinfo_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/i2c.rst
+++ b/doc/reference/peripherals/i2c.rst
@@ -63,7 +63,6 @@ API Reference
 *************
 
 .. doxygengroup:: i2c_interface
-   :project: Zephyr
 
 .. _i2c-specification:
    https://www.nxp.com/docs/en/user-guide/UM10204.pdf

--- a/doc/reference/peripherals/i2c_eeprom_slave.rst
+++ b/doc/reference/peripherals/i2c_eeprom_slave.rst
@@ -10,4 +10,3 @@ API Reference
 **************
 
 .. doxygengroup:: i2c_eeprom_slave_api
-   :project: Zephyr

--- a/doc/reference/peripherals/ipm.rst
+++ b/doc/reference/peripherals/ipm.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: ipm_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/kscan.rst
+++ b/doc/reference/peripherals/kscan.rst
@@ -29,4 +29,3 @@ API Reference
 *************
 
 .. doxygengroup:: kscan_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/led.rst
+++ b/doc/reference/peripherals/led.rst
@@ -24,10 +24,8 @@ LED
 ===
 
 .. doxygengroup:: led_interface
-   :project: Zephyr
 
 LED Strip
 =========
 
 .. doxygengroup:: led_strip_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/peci.rst
+++ b/doc/reference/peripherals/peci.rst
@@ -25,4 +25,3 @@ API Reference
 *************
 
 .. doxygengroup:: peci_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/pinmux.rst
+++ b/doc/reference/peripherals/pinmux.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: pinmux_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/ps2.rst
+++ b/doc/reference/peripherals/ps2.rst
@@ -25,4 +25,3 @@ API Reference
 *************
 
 .. doxygengroup:: ps2_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/pwm.rst
+++ b/doc/reference/peripherals/pwm.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: pwm_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/regulators.rst
+++ b/doc/reference/peripherals/regulators.rst
@@ -41,4 +41,3 @@ API Reference
 **************
 
 .. doxygengroup:: regulator_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/rtc.rst
+++ b/doc/reference/peripherals/rtc.rst
@@ -14,4 +14,3 @@ API Reference
 *************
 
 .. doxygengroup:: rtc_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/sensor.rst
+++ b/doc/reference/peripherals/sensor.rst
@@ -121,4 +121,3 @@ API Reference
 **************
 
 .. doxygengroup:: sensor_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/spi.rst
+++ b/doc/reference/peripherals/spi.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: spi_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/uart.rst
+++ b/doc/reference/peripherals/uart.rst
@@ -10,4 +10,3 @@ API Reference
 *************
 
 .. doxygengroup:: uart_interface
-   :project: Zephyr

--- a/doc/reference/peripherals/video.rst
+++ b/doc/reference/peripherals/video.rst
@@ -54,7 +54,5 @@ API Reference
 *************
 
 .. doxygengroup:: video_interface
-   :project: Zephyr
 
 .. doxygengroup:: video_controls
-   :project: Zephyr

--- a/doc/reference/peripherals/watchdog.rst
+++ b/doc/reference/peripherals/watchdog.rst
@@ -11,4 +11,3 @@ API Reference
 *************
 
 .. doxygengroup:: watchdog_interface
-   :project: Zephyr

--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -73,25 +73,18 @@ general power states with higher indexes will offer greater power savings and
 have higher wake latencies. Following is a thorough list of available states:
 
 .. doxygenenumvalue:: PM_STATE_ACTIVE
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_RUNTIME_IDLE
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_SUSPEND_TO_IDLE
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_STANDBY
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_SUSPEND_TO_RAM
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_SUSPEND_TO_DISK
-   :project: Zephyr
 
 .. doxygenenumvalue:: PM_STATE_SOFT_OFF
-   :project: Zephyr
 
 .. _pm_constraints:
 
@@ -106,13 +99,10 @@ lose context. Constraints can be set, released and checked using the
 follow APIs:
 
 .. doxygenfunction:: pm_constraint_set
-   :project: Zephyr
 
 .. doxygenfunction:: pm_constraint_release
-   :project: Zephyr
 
 .. doxygenfunction:: pm_constraint_get
-   :project: Zephyr
 
 Power Management Policies
 =========================
@@ -491,16 +481,13 @@ Power Management Hook Interface
 ===============================
 
 .. doxygengroup:: power_management_hook_interface
-   :project: Zephyr
 
 System Power Management APIs
 ============================
 
 .. doxygengroup:: system_power_management_api
-   :project: Zephyr
 
 Device Power Management APIs
 ============================
 
 .. doxygengroup:: device_power_management_api
-   :project: Zephyr

--- a/doc/reference/random/index.rst
+++ b/doc/reference/random/index.rst
@@ -90,4 +90,3 @@ API Reference
 *************
 
 .. doxygengroup:: random_api
-   :project: Zephyr

--- a/doc/reference/resource_management/index.rst
+++ b/doc/reference/resource_management/index.rst
@@ -85,4 +85,3 @@ state.
    (primarily no support for the monitor API).
 
 .. doxygengroup:: resource_mgmt_onoff_apis
-   :project: Zephyr

--- a/doc/reference/settings/index.rst
+++ b/doc/reference/settings/index.rst
@@ -305,19 +305,15 @@ The Settings subsystem APIs are provided by ``settings.h``:
 API for general settings usage
 ==============================
 .. doxygengroup:: settings
-   :project: Zephyr
 
 API for key-name processing
 ===========================
 .. doxygengroup:: settings_name_proc
-   :project: Zephyr
 
 API for runtime settings manipulation
 =====================================
 .. doxygengroup:: settings_rt
-   :project: Zephyr
 
 API of backend interface
 ========================
 ..  doxygengroup:: settings_backend
-   :project: Zephyr

--- a/doc/reference/shell/index.rst
+++ b/doc/reference/shell/index.rst
@@ -642,4 +642,3 @@ API Reference
 *************
 
 .. doxygengroup:: shell_api
-   :project: Zephyr

--- a/doc/reference/storage/disk/access.rst
+++ b/doc/reference/storage/disk/access.rst
@@ -63,7 +63,6 @@ API Reference
 *************
 
 .. doxygengroup:: disk_access_interface
-   :project: Zephyr
 
 Disk Driver Configuration Options
 *********************************
@@ -76,4 +75,3 @@ Disk Driver Interface
 *********************
 
 .. doxygengroup:: disk_driver_interface
-   :project: Zephyr

--- a/doc/reference/storage/fcb/fcb.rst
+++ b/doc/reference/storage/fcb/fcb.rst
@@ -72,9 +72,7 @@ The FCB subsystem APIs are provided by ``fcb.h``:
 Data structures
 ===============
 .. doxygengroup:: fcb_data_structures
-   :project: Zephyr
 
 API functions
 =============
 .. doxygengroup:: fcb_api
-   :project: Zephyr

--- a/doc/reference/storage/flash_map/flash_map.rst
+++ b/doc/reference/storage/flash_map/flash_map.rst
@@ -95,4 +95,3 @@ API Reference
 *************
 
 .. doxygengroup:: flash_area_api
-   :project: Zephyr

--- a/doc/reference/storage/nvs/nvs.rst
+++ b/doc/reference/storage/nvs/nvs.rst
@@ -126,10 +126,8 @@ API Reference
 The NVS subsystem APIs are provided by ``nvs.h``:
 
 .. doxygengroup:: nvs_data_structures
-   :project: Zephyr
 
 .. doxygengroup:: nvs_high_level_api
-   :project: Zephyr
 
 .. comment
    not documenting

--- a/doc/reference/storage/stream/stream_flash.rst
+++ b/doc/reference/storage/stream/stream_flash.rst
@@ -32,4 +32,3 @@ API Reference
 *************
 
 .. doxygengroup:: stream_flash
-   :project: Zephyr

--- a/doc/reference/task_wdt/index.rst
+++ b/doc/reference/task_wdt/index.rst
@@ -52,4 +52,3 @@ API Reference
 *************
 
 .. doxygengroup:: task_wdt_api
-   :project: Zephyr

--- a/doc/reference/timing_functions/index.rst
+++ b/doc/reference/timing_functions/index.rst
@@ -78,4 +78,3 @@ API documentation
 *****************
 
 .. doxygengroup:: timing_api
-   :project: Zephyr

--- a/doc/reference/usb/index.rst
+++ b/doc/reference/usb/index.rst
@@ -52,7 +52,6 @@ USB Device Controller API
 =========================
 
 .. doxygengroup:: _usb_device_controller_api
-   :project: Zephyr
 
 USB device core layer
 *********************
@@ -95,7 +94,6 @@ High level API
   generic usb_transfer_ep_callback.
 
 .. doxygengroup:: _usb_device_core_api
-   :project: Zephyr
 
 USB device class drivers
 ************************
@@ -235,10 +233,8 @@ Example of a HID Report Descriptor:
 
 
 .. doxygengroup:: usb_hid_items
-   :project: Zephyr
 
 .. doxygengroup:: usb_hid_types
-   :project: Zephyr
 
 HID Mouse and Keyboard report descriptors
 =========================================
@@ -247,7 +243,6 @@ The pre-defined Mouse and Keyboard report descriptors can be used by
 a HID device implementation or simply as examples.
 
 .. doxygengroup:: usb_hid_mk_report_desc
-   :project: Zephyr
 
 HID Class Device API
 ********************
@@ -255,4 +250,3 @@ HID Class Device API
 USB HID devices like mouse, keyboard, or any other specific device use this API.
 
 .. doxygengroup:: usb_hid_device_api
-   :project: Zephyr

--- a/doc/reference/usermode/kernelobjects.rst
+++ b/doc/reference/usermode/kernelobjects.rst
@@ -270,4 +270,3 @@ API Reference
 *************
 
 .. doxygengroup:: usermode_apis
-   :project: Zephyr

--- a/doc/reference/usermode/memory_domain.rst
+++ b/doc/reference/usermode/memory_domain.rst
@@ -441,4 +441,3 @@ API Reference
 The following memory domain APIs are provided by :zephyr_file:`include/kernel.h`:
 
 .. doxygengroup:: mem_domain_apis
-   :project: Zephyr

--- a/doc/reference/util/index.rst
+++ b/doc/reference/util/index.rst
@@ -7,4 +7,3 @@ This page contains reference documentation for ``<sys/util.h>``, which provides
 miscellaneous utility functions and macros.
 
 .. doxygengroup:: sys-util
-   :project: Zephyr

--- a/doc/reference/virtualization/ivshmem.rst
+++ b/doc/reference/virtualization/ivshmem.rst
@@ -42,4 +42,3 @@ API Reference
 *************
 
 .. doxygengroup:: ivshmem
-   :project: Zephyr


### PR DESCRIPTION
```
doc: make some Sphinx config path absolute
Make all paths absolute.

doc: conf: remove unused breathe project
the `doc-examples` project is not used and, in fact, is a duplicate of
the Zephyr project.

doc: remove redundant breathe project
The default breathe project is `Zephyr`, so there is no need to specify
it.
```