### PR TITLE
scripts: series-push-hook: Use main as base comparison branch

### DIFF
--- a/scripts/series-push-hook.sh
+++ b/scripts/series-push-hook.sh
@@ -22,8 +22,8 @@ then
 	# Handle delete
 	:
 else
-	# At each (forced) push, examine all commits since $remote/master
-	base_commit=`git rev-parse $remote/master`
+	# At each (forced) push, examine all commits since $remote/main
+	base_commit=`git rev-parse $remote/main`
 	range="$base_commit..$local_sha"
 
 	echo "Perform check patch"


### PR DESCRIPTION
Following master branch renaming to "main", update this script
to use $remote/main as base comparison branch

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>