### PR TITLE
[TOPIC-BLE-LLCP] Fix enc. pause key refresh

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -184,8 +184,17 @@ static void lp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	pdu = (struct pdu_data *) ntf->pdu;
 
 	if (ctx->data.enc.error == BT_HCI_ERR_SUCCESS) {
-		/* TODO(thoh): is this correct? */
-		pdu_encode_start_enc_rsp(pdu);
+		if (ctx->proc == PROC_ENCRYPTION_START) {
+			/* Encryption Change Event */
+			/* TODO(thoh): is this correct? */
+			pdu_encode_start_enc_rsp(pdu);
+		} else if (ctx->proc == PROC_ENCRYPTION_PAUSE) {
+			/* Encryption Key Refresh Complete Event */
+			ntf->hdr.type = NODE_RX_TYPE_ENC_REFRESH;
+		} else {
+			/* Should never happen */
+			LL_ASSERT(0);
+		}
 	} else {
 		pdu_encode_reject_ind(pdu, ctx->data.enc.error);
 	}
@@ -652,8 +661,17 @@ static void rp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	ntf->hdr.handle = conn->lll.handle;
 	pdu = (struct pdu_data *) ntf->pdu;
 
-	/* TODO(thoh): is this correct? */
-	pdu_encode_start_enc_rsp(pdu);
+	if (ctx->proc == PROC_ENCRYPTION_START) {
+		/* Encryption Change Event */
+		/* TODO(thoh): is this correct? */
+		pdu_encode_start_enc_rsp(pdu);
+	} else if (ctx->proc == PROC_ENCRYPTION_PAUSE) {
+		/* Encryption Key Refresh Complete Event */
+		ntf->hdr.type = NODE_RX_TYPE_ENC_REFRESH;
+	} else {
+		/* Should never happen */
+		LL_ASSERT(0);
+	}
 
 	/* Enqueue notification towards LL */
 	ll_rx_put(ntf->hdr.link, ntf);

--- a/tests/bluetooth/controller/common/include/helper_pdu.h
+++ b/tests/bluetooth/controller/common/include/helper_pdu.h
@@ -74,6 +74,8 @@ void helper_pdu_verify_pause_enc_req(const char *file, uint32_t line, struct pdu
 
 void helper_pdu_verify_pause_enc_rsp(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
+void helper_node_verify_enc_refresh(const char *file, uint32_t line, struct node_rx_pdu *rx, void *param);
+
 void helper_pdu_verify_reject_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
 
 void helper_pdu_verify_reject_ext_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param);
@@ -129,7 +131,8 @@ typedef enum {
 
 typedef enum {
 	NODE_PHY_UPDATE,
-	NODE_CONN_UPDATE
+	NODE_CONN_UPDATE,
+	NODE_ENC_REFRESH,
 } helper_node_opcode_t;
 
 typedef void (helper_pdu_encode_func_t) (struct pdu_data *data, void *param);

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -438,6 +438,11 @@ void helper_pdu_verify_pause_enc_rsp(const char *file, uint32_t line, struct pdu
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_RSP, "Not a LL_PAUSE_ENC_RSP.\nCalled at %s:%d\n", file, line);
 }
 
+void helper_node_verify_enc_refresh(const char *file, uint32_t line, struct node_rx_pdu *rx, void *param)
+{
+	zassert_equal(rx->hdr.type, NODE_RX_TYPE_ENC_REFRESH, "Not an ENC_REFRESH node.\nCalled at %s:%d\n", file, line);
+}
+
 void helper_pdu_verify_reject_ind(const char *file, uint32_t line, struct pdu_data *pdu, void *param)
 {
 	struct pdu_data_llctrl_reject_ind *p = param;

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -136,6 +136,7 @@ helper_pdu_ntf_verify_func_t *const helper_pdu_ntf_verify[] = {
 helper_node_verify_func_t * const helper_node_verify[] = {
 	[NODE_PHY_UPDATE]  = helper_node_verify_phy_update,
 	[NODE_CONN_UPDATE] = helper_node_verify_conn_update,
+	[NODE_ENC_REFRESH] = helper_node_verify_enc_refresh,
 };
 
 /*

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -1418,7 +1418,7 @@ void test_encryption_pause_mas_loc(void)
 	event_done(&conn);
 
 	/* There should be one host notification */
-	ut_rx_pdu(LL_START_ENC_RSP, &ntf, NULL);
+	ut_rx_node(NODE_ENC_REFRESH, &ntf, NULL);
 	ut_rx_q_is_empty();
 
 	/* Release Ntf */
@@ -1580,7 +1580,7 @@ void test_encryption_pause_sla_rem(void)
 	event_done(&conn);
 
 	/* There should be a host notification */
-	ut_rx_pdu(LL_START_ENC_RSP, &ntf, NULL);
+	ut_rx_node(NODE_ENC_REFRESH, &ntf, NULL);
 	ut_rx_q_is_empty();
 
 	/* Prepare */


### PR DESCRIPTION
The Encryption Pause procedure should trigger a
"Encryption Key Refresh Complete Event" when finished.

Add NODE_RX_TYPE_ENC_REFRESH support and unit test handler for
verifying.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>