### PR TITLE
manifest: Update trusted-firmware-m to enable cache in nRF SoCs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -143,7 +143,7 @@ manifest:
       revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 51cdecd6f9e6b0aa66da45db22f4b478183d472f
+      revision: pull/51/head
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update the trusted-firmware-m module revision to enable the instruction
cache in platforms that use nRF SoCs.

Fixes #33423.
Fixes #33667.