### PR TITLE
WIP Add scanning for periodic advertising chains with short regular PDU intervals

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -19,6 +19,8 @@
 #include "hal/radio.h"
 #include "hal/ticker.h"
 
+#include "hal/debug.h"
+
 #include "ll_sw/pdu.h"
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
@@ -681,6 +683,19 @@ void radio_switch_complete_and_b2b_tx(uint8_t phy_curr, uint8_t flags_curr,
 
 	sw_switch(SW_SWITCH_PREV_TX, SW_SWITCH_NEXT_TX,
 		  phy_curr, flags_curr, phy_next, flags_next);
+#endif /* !CONFIG_BT_CTLR_TIFS_HW */
+}
+
+void radio_switch_complete_and_end_b2b_rx(uint8_t phy_curr, uint8_t flags_curr, uint8_t phy_next,
+					  uint8_t flags_next)
+{
+#if defined(CONFIG_BT_CTLR_TIFS_HW)
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk |
+			    RADIO_SHORTS_DISABLED_RXEN_Msk;
+#else /* !CONFIG_BT_CTLR_TIFS_HW */
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk;
+
+	sw_switch(SW_SWITCH_PREV_RX, SW_SWITCH_NEXT_RX, phy_curr, flags_curr, phy_next, flags_next);
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -50,6 +50,8 @@ void radio_switch_complete_and_tx(uint8_t phy_rx, uint8_t flags_rx, uint8_t phy_
 				  uint8_t flags_tx);
 void radio_switch_complete_and_b2b_tx(uint8_t phy_curr, uint8_t flags_curr,
 				      uint8_t phy_next, uint8_t flags_next);
+void radio_switch_complete_and_end_b2b_rx(uint8_t phy_curr, uint8_t flags_curr, uint8_t phy_next,
+					  uint8_t flags_next);
 void radio_switch_complete_and_disable(void);
 
 void radio_rssi_measure(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -373,3 +373,15 @@ uint8_t radio_df_cte_status_get(void)
 {
 	return NRF_RADIO->CTESTATUS;
 }
+
+void radio_switch_complete_and_phy_end_b2b_rx(uint8_t phy_curr, uint8_t flags_curr,
+					      uint8_t phy_next, uint8_t flags_next)
+{
+#if defined(CONFIG_BT_CTLR_TIFS_HW)
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_PHYEND_DISABLE_Msk |
+			    RADIO_SHORTS_DISABLED_RXEN_Msk;
+#else /* !CONFIG_BT_CTLR_TIFS_HW */
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_PHYEND_DISABLE_Msk;
+	sw_switch(SW_SWITCH_PREV_RX, SW_SWITCH_NEXT_RX, phy_curr, flags_curr, phy_next, flags_next);
+#endif /* !CONFIG_BT_CTLR_TIFS_HW */
+}

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
@@ -60,3 +60,6 @@ void radio_df_iq_data_packet_set(uint8_t *buffer, size_t len);
 uint32_t radio_df_iq_samples_amount_get(void);
 /* Get CTE status (CTEInfo) parsed by Radio from received PDU */
 uint8_t radio_df_cte_status_get(void);
+
+void radio_switch_complete_and_phy_end_b2b_rx(uint8_t phy_curr, uint8_t flags_curr,
+					      uint8_t phy_next, uint8_t flags_next);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -322,12 +322,12 @@ static struct {
 /* No. of node rx for LLL to ULL.
  * Reserve 3, 1 for adv data, 1 for scan response and 1 for empty PDU reception.
  */
-#define PDU_RX_CNT    (3 + BT_CTLR_ADV_EXT_RX_CNT + CONFIG_BT_CTLR_RX_BUFFERS)
+#define PDU_RX_CNT (3 + BT_CTLR_ADV_EXT_RX_CNT + CONFIG_BT_CTLR_RX_BUFFERS + 10)
 
 /* Part sum of LLL to ULL and ULL to LL/HCI thread node rx count.
  * Will be used below in allocating node rx pool.
  */
-#define RX_CNT        (PDU_RX_CNT + LL_PDU_RX_CNT)
+#define RX_CNT (PDU_RX_CNT + LL_PDU_RX_CNT)
 
 static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -453,11 +453,9 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	sync->ull.ticks_preempt_to_start =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	sync->ull.ticks_slot =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
-				       ready_delay_us +
-				       PKT_AC_US(PDU_AC_EXT_PAYLOAD_SIZE_MAX,
-						 0, lll->phy) +
-				       EVENT_OVERHEAD_END_US);
+		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US + ready_delay_us +
+				       PKT_AC_US(PDU_AC_EXT_PAYLOAD_SIZE_MAX, 0, lll->phy) +
+				       CTE_LEN_US(LLL_DF_MAX_CTE_LEN) + EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,
 				sync->ull.ticks_prepare_to_start);


### PR DESCRIPTION
This is a very limited implementation that is able to synchronize and receive periodic advertising trains where PDUs in a train are:
- send in short intervals e.g. 500us
- intervals between PDUs are always constant.