### PR TITLE
modules: mbedTLS: Add separate Kconfig entry for MBEDTLS_HAVE_TIME_DATE

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -354,4 +354,11 @@ config MBEDTLS_PK_WRITE_C
 	help
 	  Enable generic public key write functions.
 
+config MBEDTLS_HAVE_TIME_DATE
+	bool "Enable date/time validation in mbed TLS"
+	help
+	  System has time.h, time(), and an implementation for gmtime_r().
+	  There also need to be a valid time source in the system, as mbedTLS
+	  expects a valid date/time for certificate validation."
+
 endmenu

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -23,8 +23,7 @@
 #define MBEDTLS_HAVE_ASM
 #endif
 
-/* If we build with POSIX API, automatically use time(), etc. */
-#if defined(CONFIG_POSIX_API)
+#if defined(CONFIG_MBEDTLS_HAVE_TIME_DATE)
 #define MBEDTLS_HAVE_TIME
 #define MBEDTLS_HAVE_TIME_DATE
 #endif


### PR DESCRIPTION
Currently the MBEDTLS_HAVE_TIME_DATE mbedTLS option is enabled based on
the CONFIG_POSIX_API option. This doesn't seem right, since enabling
the POSIX API does not guarantee that there is a valid time source in
the system. This was the case for the qemu_x86 platform, where enabling
POSIX_API caused TLS handshake failures due to certificate validation
errors caused by no valid time avaialble in the system.

Fix this by adding a specific KConfig entry for date/time configuration
in mbedTLS. Applications that need to enforce date verification in
mbedTLS should enable it explicitly instead of relying on the
non-obvious implicit configuration.

Fixes #35401

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>