### PR TITLE
net: sockets: Add locking to receive callback

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -117,8 +117,7 @@ static void zsock_received_cb(struct net_context *ctx,
 			      int status,
 			      void *user_data);
 
-static inline int k_fifo_wait_non_empty(struct k_fifo *fifo,
-					k_timeout_t timeout)
+static int fifo_wait_non_empty(struct k_fifo *fifo, k_timeout_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -1014,7 +1013,7 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 	if (flags & ZSOCK_MSG_PEEK) {
 		int res;
 
-		res = k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		res = fifo_wait_non_empty(&ctx->recv_q, timeout);
 		/* EAGAIN when timeout expired, EINTR when cancelled */
 		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -344,6 +344,10 @@ static void zsock_received_cb(struct net_context *ctx,
 			      int status,
 			      void *user_data)
 {
+	if (ctx->cond.lock) {
+		(void)k_mutex_lock(ctx->cond.lock, K_FOREVER);
+	}
+
 	NET_DBG("ctx=%p, pkt=%p, st=%d, user_data=%p", ctx, pkt, status,
 		user_data);
 
@@ -364,8 +368,7 @@ static void zsock_received_cb(struct net_context *ctx,
 			NET_DBG("Set EOF flag on pkt %p", last_pkt);
 		}
 
-		(void)k_condvar_signal(&ctx->cond.recv);
-		return;
+		goto unlock;
 	}
 
 	/* Normal packet */
@@ -378,6 +381,11 @@ static void zsock_received_cb(struct net_context *ctx,
 	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
 
 	k_fifo_put(&ctx->recv_q, pkt);
+
+unlock:
+	if (ctx->cond.lock) {
+		(void)k_mutex_unlock(ctx->cond.lock);
+	}
 
 	/* Let reader to wake if it was sleeping */
 	(void)k_condvar_signal(&ctx->cond.recv);
@@ -964,15 +972,13 @@ static int wait_data(struct net_context *ctx, k_timeout_t *timeout)
 		 * lock at this point so skip it.
 		 */
 		NET_WARN("No lock pointer set for context %p", ctx);
+		return -EINVAL;
+	}
 
-	} else if (!k_fifo_peek_head(&ctx->recv_q)) {
-		int ret;
-
+	if (k_fifo_is_empty(&ctx->recv_q)) {
 		/* Wait for the data to arrive but without holding a lock */
-		ret = k_condvar_wait(&ctx->cond.recv, ctx->cond.lock, *timeout);
-		if (ret < 0) {
-			return ret;
-		}
+		return k_condvar_wait(&ctx->cond.recv, ctx->cond.lock,
+				      *timeout);
 	}
 
 	return 0;


### PR DESCRIPTION
Fix a regression when application is waiting data but does
not notice that because socket layer is not woken up.

This could happen because application was waiting condition
variable but the signal to wake the condvar came before the
wait started. Normally if there is constant flow of incoming
data to the socket, the signal would be given later. But if
the peer is waiting that Zephyr replies, there might be a
timeout at peer.

The solution is to add locking in socket receive callback so
that we only signal the condition variable after we have made
sure that the condition variable is actually waiting the data.

Fixes #34964

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>