### PR TITLE
doc: scripts: gen_devicetree_rest: use utf-8 encoding

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -78,7 +78,7 @@ class VndLookup:
             None: GENERIC_OR_VENDOR_INDEPENDENT,
         }
         found_separator = False     # have we found the '-----' separator?
-        with open(vendor_prefixes, 'r') as f:
+        with open(vendor_prefixes, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line and found_separator:


### PR DESCRIPTION
Use utf-8 encoding when opening vendor prefix files. Note that utf-8 is enforced in other scripts, e.g. gen_kconfig_rest, gen_helpers, etc.

Fixes #34076

Alternative to #35234