### PR TITLE
k_heap: Clamp to a minimum heap size (and add test)

### DIFF
--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -403,7 +403,7 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	chunksz_t chunk0_size = chunksz(sizeof(struct z_heap) +
 				     nb_buckets * sizeof(struct z_heap_bucket));
 
-	__ASSERT(chunk0_size + min_chunk_size(h) < heap_sz, "heap size is too small");
+	__ASSERT(chunk0_size + min_chunk_size(h) <= heap_sz, "heap size is too small");
 
 	for (int i = 0; i < nb_buckets; i++) {
 		h->buckets[i].next = 0;

--- a/tests/kernel/mem_heap/k_heap_api/src/main.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <ztest.h>
+extern void test_k_heap_min_size(void);
 extern void test_k_heap_alloc(void);
 extern void test_k_heap_alloc_fail(void);
 extern void test_k_heap_free(void);
@@ -24,6 +25,7 @@ extern void test_k_heap_alloc_pending(void);
 void test_main(void)
 {
 	ztest_test_suite(k_heap_api,
+			 ztest_unit_test(test_k_heap_min_size),
 			 ztest_unit_test(test_k_heap_alloc),
 			 ztest_unit_test(test_k_heap_alloc_fail),
 			 ztest_unit_test(test_k_heap_free),


### PR DESCRIPTION
k_heap: Clamp to a minimum heap size

The K_HEAP_DEFINE macro would allow users to specify heaps that are
too small, leading to potential corruption events (though at least
there were __ASSERTs that would catch this at runtime if enabled).

It would be nice to put the logic to compute this value into the heap
code, but that isn't available in kernel.h (and we don't want to pull
it in as this header is already WAY to thick).  So instead we just
hand-compute and document the choice.  We can address bitrot problems
with a test.

Fixes #33009
