### PR TITLE
tests: kernel: gen_isr_table: do not use IRQ 57 on NXP LPC55S16

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -59,6 +59,12 @@ extern uint32_t _irq_vector_table[];
  * test suite to solve the issue.
  */
 #define TEST_NUM_IRQS	46
+#elif defined(CONFIG_SOC_LPC55S16)
+/* IRQ 57 is reserved in the NXP LPC55S16 SoC. Thus, limit the number
+ * of interrupts reported to the test, so that it does not try to use
+ * it.
+ */
+#define TEST_NUM_IRQS	57
 #else
 #define TEST_NUM_IRQS	CONFIG_NUM_IRQS
 #endif


### PR DESCRIPTION
IRQ 57 is reserved in the NXP LPC55S16 SoC. Thus, limit the number of interrupts reported to the test, so that it does not try to use it.

Fixes #34915

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>