### PR TITLE
task_wdt: use correct hardware watchdog channel number

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -71,7 +71,7 @@ static void task_wdt_trigger(struct k_timer *timer_id)
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
 	if (channel_id == TASK_WDT_BACKGROUND_CHANNEL) {
 		if (hw_wdt_dev) {
-			wdt_feed(hw_wdt_dev, 0);
+			wdt_feed(hw_wdt_dev, hw_wdt_channel);
 		}
 		return;
 	}
@@ -202,7 +202,7 @@ int task_wdt_feed(int channel_id)
 
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
 	if (hw_wdt_dev) {
-		wdt_feed(hw_wdt_dev, 0);
+		wdt_feed(hw_wdt_dev, hw_wdt_channel);
 	}
 #endif
 


### PR DESCRIPTION
The hardware watchdog was always fed with channel ID 0. This is correct in most cases, but we should still use the actual ID returned from `wdt_install_timeout`.

This issue was detected while looking for a solution of #33509.