### PR TITLE
soc: arm: stm32wl: Add STM32WLE5 series support

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -75,7 +75,7 @@
  */
 static void config_bus_clk_init(LL_UTILS_ClkInitTypeDef *clk_init)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_STM32WL55XX)
 	clk_init->CPU2CLKDivider = ahb_prescaler(STM32_CPU2_PRESCALER);
 #endif
 #if defined(CONFIG_SOC_SERIES_STM32WBX)
@@ -545,7 +545,7 @@ int stm32_clock_control_init(const struct device *dev)
 	!defined (CONFIG_SOC_SERIES_STM32G0X)
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
 #endif
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_STM32WL55XX)
 	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
 #endif
 #ifdef CONFIG_SOC_SERIES_STM32WBX
@@ -626,7 +626,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set APB1 & APB2 prescaler*/
 	LL_RCC_SetAPB1Prescaler(s_ClkInitStruct.APB1CLKDivider);
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_STM32WL55XX)
 	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
 #endif
 #ifdef CONFIG_SOC_SERIES_STM32WBX
@@ -659,7 +659,7 @@ int stm32_clock_control_init(const struct device *dev)
 	!defined (CONFIG_SOC_SERIES_STM32G0X)
 	LL_RCC_SetAPB2Prescaler(s_ClkInitStruct.APB2CLKDivider);
 #endif /* CONFIG_SOC_SERIES_STM32F0X && CONFIG_SOC_SERIES_STM32G0X */
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32WLX)
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_STM32WL55XX)
 	LL_C2_RCC_SetAHBPrescaler(s_ClkInitStruct.CPU2CLKDivider);
 #endif
 #ifdef CONFIG_SOC_SERIES_STM32WBX

--- a/dts/arm/st/wl/stm32wle5.dtsi
+++ b/dts/arm/st/wl/stm32wle5.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/wl/stm32wl.dtsi>

--- a/dts/arm/st/wl/stm32wle5Xc.dtsi
+++ b/dts/arm/st/wl/stm32wle5Xc.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/wl/stm32wle5.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(64)>;
+	};
+
+	soc {
+		flash-controller@58004000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(256)>;
+			};
+		};
+	};
+};

--- a/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.stm32wle5xx
+++ b/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.stm32wle5xx
@@ -1,0 +1,14 @@
+# STMicroelectronics STM32WLE5 MCU
+
+# Copyright (c) 2020 STMicroelectronics.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32WLE5XX
+
+config SOC
+	default "stm32wle5xx"
+
+config NUM_IRQS
+	default 62
+
+endif # SOC_STM32WLE5XX

--- a/soc/arm/st_stm32/stm32wl/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32wl/Kconfig.soc
@@ -10,4 +10,7 @@ choice
 config SOC_STM32WL55XX
 	bool "STM32WL55XX"
 
+config SOC_STM32WLE5XX
+	bool "STM32WLE5XX"
+
 endchoice


### PR DESCRIPTION
Added support for STM32WLE5 series.
Corrected assumption that all STM32WL are dual-core.

Signed-off-by: Alexander Mihajlovic <a@abxy.se>