### PR TITLE
coding guidelines rule 20.4: remove undefined macro

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -16,9 +16,7 @@ typedef unsigned int mode_t;
 #if !defined(__ssize_t_defined)
 #define __ssize_t_defined
 
-#define unsigned signed
 typedef __SIZE_TYPE__ ssize_t;
-#undef unsigned
 
 #endif
 


### PR DESCRIPTION
<b>MISRA violation:</b>
A macro shall not be defined with the same name as a keyword in C99,
C90
<b>Zephyr Coding Guideline Main Rules violation:</b>
Rule 20.4 | Required |A macro shall not be defined with the same name
as a keyword

<b>Solution:</b>
Remove a macro that was defined firstly using keyword name,
and then undefined in the next line.
That doesn't make any sense, so I removed it.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>