### PR TITLE
drivers: change suffix ull to ULL

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -126,7 +126,7 @@ int sys_clock_driver_init(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 
 	/* CLK_PERIOD_REG is in femtoseconds (1e-15 sec) */
-	hz = (uint32_t)(1000000000000000ull / CLK_PERIOD_REG);
+	hz = (uint32_t)(1000000000000000ULL / CLK_PERIOD_REG);
 	z_clock_hw_cycles_per_sec = hz;
 	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 


### PR DESCRIPTION
Replace suffix ull to ULL to increase code readability and prevent
unexpected behaviours, because the lowercase character l shall not be
used in a literal suffix

Found as a coding guideline violation (MISRA R7.3) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>