### PR TITLE
watchdog / task_wdt: Pause if halted by debugger

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -123,7 +123,7 @@ void main(void)
 		return;
 	}
 
-	err = wdt_setup(wdt, 0);
+	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		printk("Watchdog setup error\n");
 		return;

--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -131,7 +131,8 @@ int task_wdt_add(uint32_t reload_period, task_wdt_callback_t callback,
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
 			if (!hw_wdt_started && hw_wdt_dev) {
 				/* also start fallback hw wdt */
-				wdt_setup(hw_wdt_dev, 0);
+				wdt_setup(hw_wdt_dev,
+					WDT_OPT_PAUSE_HALTED_BY_DBG);
 				hw_wdt_started = true;
 			}
 #endif


### PR DESCRIPTION
Enabling this option by default should not cause any harm in the watchdog driver sample.

For the task watchdog, the option is currently not user-configurable, so it will always be enabled if the hardware watchdog fallback is used. However, I don't see any use case where it would be desirable that the watchdog kicks in during debugging, so in my opinion this is a safe change.

Fixes #33509 