### PR TITLE
toolchain: arcmwdt: linker: fix placeholders for arcmwdt toolchain

### DIFF
--- a/include/linker/kobject-data.ld
+++ b/include/linker/kobject-data.ld
@@ -15,7 +15,7 @@
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 	PROVIDE(_thread_idx_map = .);
-	. += CONFIG_MAX_THREAD_BYTES;
+	. = . + CONFIG_MAX_THREAD_BYTES;
 #endif
 
 #endif /* !LINKER_ZEPHYR_PREBUILT && !LINKER_ZEPHYR_FINAL */
@@ -40,7 +40,7 @@
 #endif
 #ifdef KOBJECT_DATA_ALIGN
 	. = ALIGN(KOBJECT_DATA_ALIGN);
-	. += KOBJECT_DATA_SZ;
+	. = . + KOBJECT_DATA_SZ;
 #endif
 #endif /* LINKER_ZEPHYR_PREBUILT */
 

--- a/include/linker/kobject-priv-stacks.ld
+++ b/include/linker/kobject-priv-stacks.ld
@@ -23,7 +23,7 @@
 #include <linker-kobject-prebuilt-priv-stacks.h>
 #ifdef KOBJECT_PRIV_STACKS_ALIGN
 	. = ALIGN(KOBJECT_PRIV_STACKS_ALIGN);
-	. += KOBJECT_PRIV_STACKS_SZ;
+	. = . + KOBJECT_PRIV_STACKS_SZ;
 #endif
 #endif /* LINKER_ZEPHYR_PREBUILT */
 

--- a/include/linker/kobject-rom.ld
+++ b/include/linker/kobject-rom.ld
@@ -22,7 +22,7 @@
 
 	_kobject_rodata_area_start = .;
 
-	. += KOBJECT_RODATA_SZ;
+	. = . + KOBJECT_RODATA_SZ;
 
 	_kobject_rodata_area_end = .;
 #endif


### PR DESCRIPTION
syntax ". += length;" not work with arcmwdt toolchain, let's using
". = . + length;", which both work with gnu and arcmwdt toolchain.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

Fix: #35479 