### PR TITLE
drivers: console: uart_mux: fix build issues

### DIFF
--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -374,7 +374,7 @@ static int init_real_uart(const struct device *mux, const struct device *uart,
 		real_uart->mux = gsm_mux_create(mux);
 
 		LOG_DBG("Initializing UART %s and GSM mux %p",
-			real_uart->uart->name, real_uart->mux);
+			real_uart->uart->name, (void *)real_uart->mux);
 
 		if (!real_uart->mux) {
 			real_uart->uart = NULL;
@@ -826,7 +826,7 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 	struct uart_mux_dev_data *dev_data = DEV_DATA(mux);
 	size_t wrote = 0;
 
-	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, dlci,
+	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, (void *)dlci,
 		data, len);
 
 	if (IS_ENABLED(CONFIG_UART_MUX_VERBOSE_DEBUG)) {


### PR DESCRIPTION
With logging enabled, building of uart_mux.c fails with an error
message indicating that struct gsm_dlci is undefined. In fact,
struct gsm_dlci is declared in gsm_mux.h, but defined in gsm_mux.c.

The build error is caused by calls to LOG_DBG, which displays a
pointer to struct gsm_dlci as a generic pointer.

The error is resolved by typecasts to (void *).

Fixes #35489

Signed-off-by: Hans Wilmers <hans@wilmers.no>