### PR TITLE
Bluetooth: Samples: Fix peripheral_iso print data

### DIFF
--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -78,7 +78,7 @@ static void iso_print_data(uint8_t *data, size_t data_len)
 			str_len += strlen(dots);
 		}
 
-		str_len += bin2hex(data + max_octets + (data_len - max_octets),
+		str_len += bin2hex(data + (data_len - MIN(max_octets, data_len - max_octets)),
 				   MIN(max_octets, data_len - max_octets),
 				   data_str + str_len,
 				   sizeof(data_str) - str_len);


### PR DESCRIPTION
The sample would consequently try to print invalid data
the offset into the data was incorrect calculated to
always be at the end of the data, instead of at the
end of the data minus an offset.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>