### PR TITLE
Fix C++ compilation warnings in cbprintf and logging

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -176,11 +176,14 @@ enum z_log_msg2_mode {
 
 #define Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, _plen, _dlen) \
 { \
+	.valid = 0, \
+	.busy = 0, \
 	.type = Z_LOG_MSG2_LOG, \
 	.domain = _domain_id, \
 	.level = _level, \
 	.package_len = _plen, \
 	.data_len = _dlen, \
+	.reserved = 0, \
 }
 
 /* Messages are aligned to alignment required by cbprintf package. */

--- a/include/sys/cbprintf_cxx.h
+++ b/include/sys/cbprintf_cxx.h
@@ -61,11 +61,15 @@ static inline int z_cbprintf_cxx_is_pchar(T arg)
 /* C++ version for calculating argument size. */
 static inline size_t z_cbprintf_cxx_arg_size(float f)
 {
+	ARG_UNUSED(f);
+
 	return sizeof(double);
 }
 
 static inline size_t z_cbprintf_cxx_arg_size(void *p)
 {
+	ARG_UNUSED(p);
+
 	return sizeof(void *);
 }
 
@@ -136,38 +140,51 @@ static inline void z_cbprintf_cxx_store_arg(uint8_t *dst, T arg)
 /* C++ version for long double detection. */
 static inline int z_cbprintf_cxx_is_longdouble(long double arg)
 {
+	ARG_UNUSED(arg);
 	return 1;
 }
 
 template < typename T >
 static inline int z_cbprintf_cxx_is_longdouble(T arg)
 {
+	ARG_UNUSED(arg);
+
 	return 0;
 }
 
 /* C++ version for caluculating argument alignment. */
 static inline size_t z_cbprintf_cxx_alignment(float arg)
 {
+	ARG_UNUSED(arg);
+
 	return VA_STACK_ALIGN(double);
 }
 
 static inline size_t z_cbprintf_cxx_alignment(double arg)
 {
+	ARG_UNUSED(arg);
+
 	return VA_STACK_ALIGN(double);
 }
 
 static inline size_t z_cbprintf_cxx_alignment(long double arg)
 {
+	ARG_UNUSED(arg);
+
 	return VA_STACK_ALIGN(long double);
 }
 
 static inline size_t z_cbprintf_cxx_alignment(long long arg)
 {
+	ARG_UNUSED(arg);
+
 	return VA_STACK_ALIGN(long long);
 }
 
 static inline size_t z_cbprintf_cxx_alignment(unsigned long long arg)
 {
+	ARG_UNUSED(arg);
+
 	return VA_STACK_ALIGN(long long);
 }
 

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -360,7 +360,10 @@ do { \
 	/* Store length in the header, set number of dumped strings to 0 */ \
 	if (_pbuf) { \
 		union z_cbprintf_hdr hdr = { \
-			.desc = {.len = (uint8_t)(_pkg_len / sizeof(int)) } \
+			.desc = { \
+				.len = (uint8_t)(_pkg_len / sizeof(int)), \
+				.str_cnt = 0, \
+			} \
 		}; \
 		*_len_loc = hdr; \
 	} \


### PR DESCRIPTION
Reported by downstream project, not seen on in tree C++ tests.