### PR TITLE
samples: can: fix parenthesis for can_recover call

### DIFF
--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -150,7 +150,7 @@ void state_change_work_handler(struct k_work *work)
 	if (current_state == CAN_BUS_OFF) {
 		printk("Recover from bus-off\n");
 
-		if (can_recover(can_dev, K_MSEC(100) != 0)) {
+		if (can_recover(can_dev, K_MSEC(100)) != 0) {
 			printk("Recovery timed out\n");
 		}
 	}


### PR DESCRIPTION
In the can driver sample a parenthesis was wrongly placed.
This pr fixes the wrongly placed parenthesis in the can bus sample.

closes #34644