### PR TITLE
Decouple ISO and ACL for Broadcast ISO

### DIFF
--- a/samples/bluetooth/iso_broadcast/prj.conf
+++ b/samples/bluetooth/iso_broadcast/prj.conf
@@ -8,4 +8,4 @@ CONFIG_BT_DEVICE_NAME="Test ISO Broadcaster"
 
 # Temporary, enable the following to meet BT_ISO dependencies
 CONFIG_BT_OBSERVER=y
-CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_BROADCASTER=y

--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -77,6 +77,7 @@ if(CONFIG_BT_HCI_HOST)
   zephyr_library_sources_ifdef(
     CONFIG_BT_ISO
     iso.c
+    conn.c
     )
 
   if(CONFIG_BT_DF)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -205,11 +205,11 @@ struct bt_dev_le {
 	struct k_sem		pkts;
 	uint16_t		acl_mtu;
 	struct k_sem		acl_pkts;
+#endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_ISO)
 	uint16_t		iso_mtu;
 	struct k_sem		iso_pkts;
 #endif /* CONFIG_BT_ISO */
-#endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_SMP)
 	/* Size of the the controller resolving list */


### PR DESCRIPTION
Decouples ACL (CONFIG_BT_CONN) from conn.c, such that conn.c can be compiled and used with just CONFIG_BT_ISO. 

This is mainly done to support ISO broadcast, which uses the `bt_conn` structure, without needing support for all the ACL functionality. 

The PR is comprised of basically two commits:
The first (small) commit adds guards on CONFIG_BT_CONN such that it compiles and works without CONFIG_BT_CONN.
The second (large) commit, moves the functions such that all ACL-only functionality is grouped and placed at the bottom of the file. 

The second commit is not necessary, and all the functionality could potentially be moved to an acl.c file, similar to the iso.c file. 

This PR depends on https://github.com/zephyrproject-rtos/zephyr/pull/35493