### PR TITLE
tests/subsys/setting/functional: ignore settings_delete() retval

### DIFF
--- a/tests/subsys/settings/functional/src/settings_basic_test.c
+++ b/tests/subsys/settings/functional/src/settings_basic_test.c
@@ -560,7 +560,7 @@ static void test_direct_loading_filter(void)
 	strcpy(buffer, prefix);
 	strcat(buffer, "/to_delete");
 	settings_save_one(buffer, "1", 2);
-	settings_delete(buffer);
+	(void) settings_delete(buffer);
 
 	/* Saving all the data */
 	for (ldata = data_duplicates; ldata->n; ++ldata) {


### PR DESCRIPTION
Explicitly ignore return value of the settings_delete() call.

fixes #32921

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>