### PR TITLE
drivers: serial: nrf: fix compilation when system clock is disabled

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -77,6 +77,7 @@ config UART_0_NRF_HW_ASYNC
 	bool "Use hardware RX byte counting"
 	depends on UART_0_NRF_UARTE
 	depends on UART_ASYNC_API
+	depends on SYS_CLOCK_EXISTS
 	help
 	  If default driver uses interrupts to count incoming bytes, it is possible
 	  that with higher speeds and/or high cpu load some data can be lost.
@@ -155,6 +156,7 @@ config UART_1_NRF_TX_BUFFER_SIZE
 config UART_1_NRF_HW_ASYNC
 	bool "Use hardware RX byte counting"
 	depends on UART_1_ASYNC
+	depends on SYS_CLOCK_EXISTS
 	help
 	  If default driver uses interrupts to count incoming bytes, it is possible
 	  that with higher speeds and/or high cpu load some data can be lost.
@@ -231,6 +233,7 @@ config UART_2_NRF_TX_BUFFER_SIZE
 config UART_2_NRF_HW_ASYNC
 	bool "Use hardware RX byte counting"
 	depends on UART_2_ASYNC
+	depends on SYS_CLOCK_EXISTS
 	help
 	  If default driver uses interrupts to count incoming bytes, it is possible
 	  that with higher speeds and/or high cpu load some data can be lost.
@@ -307,6 +310,7 @@ config UART_3_NRF_TX_BUFFER_SIZE
 config UART_3_NRF_HW_ASYNC
 	bool "Use hardware RX byte counting"
 	depends on UART_3_ASYNC
+	depends on SYS_CLOCK_EXISTS
 	help
 	  If default driver uses interrupts to count incoming bytes, it is possible
 	  that with higher speeds and/or high cpu load some data can be lost.

--- a/modules/hal_nordic/nrfx/nrfx_glue.c
+++ b/modules/hal_nordic/nrfx/nrfx_glue.c
@@ -6,6 +6,8 @@
 
 #include <nrfx.h>
 #include <kernel.h>
+#include <soc/nrfx_coredep.h>
+
 
 void nrfx_isr(const void *irq_handler)
 {
@@ -14,7 +16,11 @@ void nrfx_isr(const void *irq_handler)
 
 void nrfx_busy_wait(uint32_t usec_to_wait)
 {
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 	k_busy_wait(usec_to_wait);
+#else
+	nrfx_coredep_delay_us(usec_to_wait); 
+#endif
 }
 
 char const *nrfx_error_string_get(nrfx_err_t code)

--- a/tests/drivers/uart/uart_async_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_async_api/src/test_uart.h
@@ -40,6 +40,8 @@
 #define UART_DEVICE_NAME CONFIG_UART_CONSOLE_ON_DEV_NAME
 #endif
 
+#define TIMEOUTS_AVAILABLE IS_ENABLED(CONFIG_SYS_CLOCK_EXISTS)
+
 void init_test(void);
 
 void test_single_read(void);

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -29,6 +29,7 @@ void set_permissions(void)
 }
 #endif
 
+#if TIMEOUTS_AVAILABLE
 void test_single_read_callback(const struct device *dev,
 			       struct uart_event *evt, void *user_data)
 {
@@ -314,10 +315,12 @@ void test_read_abort(void)
 		;
 	uart_rx_disable(uart_dev);
 }
+#endif
 
 ZTEST_BMEM volatile size_t sent;
 ZTEST_BMEM volatile size_t received;
 
+#if TIMEOUTS_AVAILABLE
 void test_write_abort_callback(const struct device *dev,
 			       struct uart_event *evt, void *user_data)
 {
@@ -383,6 +386,48 @@ void test_write_abort(void)
 		      "RX_DISABLED timeout");
 }
 
+#else
+void test_single_read_setup(void)
+{
+	ztest_test_skip();
+}
+void test_single_read(void)
+{
+	ztest_test_skip();
+}
+void test_chained_read_setup(void)
+{
+	ztest_test_skip();
+}
+void test_chained_read(void)
+{
+	ztest_test_skip();
+}
+void test_double_buffer_setup(void)
+{
+	ztest_test_skip();
+}
+void test_double_buffer(void)
+{
+	ztest_test_skip();
+}
+void test_read_abort_setup(void)
+{
+	ztest_test_skip();
+}
+void test_read_abort(void)
+{
+	ztest_test_skip();
+}
+void test_write_abort_setup(void)
+{
+	ztest_test_skip();
+}
+void test_write_abort(void)
+{
+	ztest_test_skip();
+}
+#endif
 
 void test_forever_timeout_callback(const struct device *dev,
 				   struct uart_event *evt, void *user_data)
@@ -452,7 +497,7 @@ void test_forever_timeout(void)
 		      "RX_DISABLED timeout");
 }
 
-
+#if TIMEOUTS_AVAILABLE
 ZTEST_DMEM uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
 ZTEST_DMEM bool chained_write_next_buf = true;
 ZTEST_BMEM volatile uint8_t tx_sent;
@@ -604,3 +649,21 @@ void test_long_buffers(void)
 	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
 		      "RX_DISABLED timeout");
 }
+#else
+void test_chained_write_setup(void)
+{
+	ztest_test_skip();
+}
+void test_chained_write(void)
+{
+	ztest_test_skip();
+}
+void test_long_buffers_setup(void)
+{
+	ztest_test_skip();
+}
+void test_long_buffers(void)
+{
+	ztest_test_skip();
+}
+#endif

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -18,3 +18,12 @@ tests:
       - CONFIG_USE_SEGGER_RTT=y
       - CONFIG_UART_RTT=y
     build_only: true
+  drivers.uart.uart_async_api.noclock:
+    tags: drivers
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback
+    extra_configs:
+      - CONFIG_SYS_CLOCK_EXISTS=n
+    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422


### PR DESCRIPTION

When SYS_CLOCK_EXISTS is disabled, k_timers functions are not available. This fix simply removes all those calls mainly by using a bunch of #ifdef. In that case, obviously, timeout values are simply ignored, but this is the expected behavior anyway, as mentioned in the SYS_CLOCK_EXISTS documentation. If SYS_CLOCK_EXISTS is enabled (which is generally the case), this fix does not change previous behavior.

Signed-off-by: Matthieu Speder <mspeder@users.sourceforge.net>