### PR TITLE
Fix issues with RTT locking and header inclusion of trace recorder

### DIFF
--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -20,11 +20,8 @@ that has implied:
 5. Writing the PC-side deserializer/parser,
 6. Writing custom ad-hoc tools for filtering and presentation.
 
-An application can use one of the existing formats or define a custom
-format by overriding the macros declared
-in :zephyr_file:`include/tracing/tracing.h`.
-
-.. doxygengroup:: tracing_apis
+An application can use one of the existing formats or define a custom format by
+overriding the macros declared in :zephyr_file:`include/tracing/tracing.h`.
 
 Different formats, transports and host tools are avialable and supported in
 Zephyr.
@@ -323,3 +320,94 @@ Locking may not be needed if multiple independent channels are available.
         E.g. native_posix or board with multi-channel DMA. Lock-free.
 
         ``emit(a ## b ## c, thread_id);``
+
+
+API
+***
+
+
+Common
+======
+
+.. doxygengroup:: tracing_apis
+
+Threads
+=======
+
+.. doxygengroup:: thread_tracing_apis
+
+
+Work Queues
+===========
+
+.. doxygengroup:: work_tracing_apis
+
+
+Poll
+====
+
+.. doxygengroup:: poll_tracing_apis
+
+Semaphore
+=========
+
+.. doxygengroup:: sem_tracing_apis
+
+Mutex
+=====
+
+.. doxygengroup:: mutex_tracing_apis
+
+Condition Variables
+===================
+
+.. doxygengroup:: condvar_tracing_apis
+
+Queues
+======
+
+.. doxygengroup:: queue_tracing_apis
+
+FIFO
+====
+
+.. doxygengroup:: fifo_tracing_apis
+
+LIFO
+====
+.. doxygengroup:: lifo_tracing_apis
+
+Stacks
+======
+
+.. doxygengroup:: stack_tracing_apis
+
+Message Queues
+==============
+
+.. doxygengroup:: msgq_tracing_apis
+
+Mailbox
+=======
+
+.. doxygengroup:: mbox_tracing_apis
+
+Pipes
+======
+
+.. doxygengroup:: pipe_tracing_apis
+
+Heaps
+=====
+
+.. doxygengroup:: heap_tracing_apis
+
+Memory Slabs
+============
+
+.. doxygengroup:: mslab_tracing_apis
+
+Timers
+======
+
+.. doxygengroup:: timer_tracing_apis

--- a/doc/guides/tracing/index.rst
+++ b/doc/guides/tracing/index.rst
@@ -135,6 +135,15 @@ latest data from the internal RAM buffer can be loaded into SystemView::
 .. _SEGGER SystemView: https://www.segger.com/products/development-tools/systemview/
 
 
+Recent versions of `SEGGER SystemView`_ come with an API translation table for
+Zephyr which is incomplete and does not match the current level of support
+available in Zephyr. To use the latest Zephyr API description table, copy the
+file available in the tree to your local configuration directory to override the
+builtin table::
+
+        # On Linux and MacOS
+        cp ZEPHYR_BASE/subsys/tracing/sysview/SYSVIEW_Zephyr.txt ~/.config/SEGGER/
+
 Transport Backends
 ******************
 

--- a/drivers/debug/Kconfig.rtt
+++ b/drivers/debug/Kconfig.rtt
@@ -16,6 +16,11 @@ config USE_SEGGER_RTT
 
 if USE_SEGGER_RTT
 
+config SEGGER_RTT_CUSTOM_LOCKING
+	bool "Enable custom locking"
+	help
+	  Enable custom locking using a mutex.
+
 config SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	int "Maximum number of up-buffers"
 	default 3

--- a/drivers/serial/Kconfig.rtt
+++ b/drivers/serial/Kconfig.rtt
@@ -6,6 +6,7 @@
 menuconfig UART_RTT
 	bool "Enable UART RTT driver"
 	depends on USE_SEGGER_RTT
+	select SEGGER_RTT_CUSTOM_LOCKING
 	help
 	  This option enables access RTT channel as UART device.
 

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -8,21 +8,7 @@
 
 #include <kernel.h>
 
-#if defined CONFIG_PERCEPIO_TRACERECORDER
-#include "tracing_tracerecorder.h"
-
-/* Wait for those to be implemented by Tracealyzer */
-#define sys_port_trace_pm_system_suspend_enter(ticks)
-#define sys_port_trace_pm_system_suspend_exit(ticks, ret)
-#define sys_port_trace_pm_device_request_enter(dev, target_state)
-#define sys_port_trace_pm_device_request_exit(dev, ret)
-
-#define sys_port_trace_pm_device_enable_enter(dev)
-#define sys_port_trace_pm_device_enable_exit(dev)
-#define sys_port_trace_pm_device_disable_enter(dev)
-#define sys_port_trace_pm_device_disable_exit(dev)
-
-#elif defined CONFIG_SEGGER_SYSTEMVIEW
+#if defined CONFIG_SEGGER_SYSTEMVIEW
 #include "tracing_sysview.h"
 
 #elif defined CONFIG_TRACING_CTF
@@ -60,13 +46,6 @@
 #define sys_trace_idle()
 /**
  * @}
- */
-
-
-/**
- * @brief Tracing APIs
- * @defgroup tracing_apis Tracing APIs
- * @{
  */
 
 
@@ -1938,10 +1917,26 @@
  * @}
  */ /* end of timer_tracing_apis */
 
+#define sys_port_trace_pm_system_suspend_enter(ticks)
 
-/**
- * @}
- */
+#define sys_port_trace_pm_system_suspend_exit(ticks, ret)
+
+#define sys_port_trace_pm_device_request_enter(dev, target_state)
+
+#define sys_port_trace_pm_device_request_exit(dev, ret)
+
+#define sys_port_trace_pm_device_enable_enter(dev)
+
+#define sys_port_trace_pm_device_enable_exit(dev)
+
+#define sys_port_trace_pm_device_disable_enter(dev)
+
+#define sys_port_trace_pm_device_disable_exit(dev)
+
+
+#if defined CONFIG_PERCEPIO_TRACERECORDER
+#include "tracing_tracerecorder.h"
+#endif
 
 #endif
 #endif

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -89,6 +89,7 @@ config LOG_BACKEND_RTT
 	bool "Enable Segger J-Link RTT backend"
 	depends on USE_SEGGER_RTT
 	default y if !SHELL_BACKEND_RTT
+	select SEGGER_RTT_CUSTOM_LOCKING
 	help
 	  When enabled, backend will use RTT for logging. This backend works on a per
 	  message basis. Only a whole message (terminated with a carriage return: '\r')

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -197,109 +197,111 @@ config TRACING_CMD_BUFFER_SIZE
 	  Size of tracing command buffer.
 
 menu "Tracing Configuration"
-	config SYSCALL_TRACING
+
+config SYSCALL_TRACING
 	bool "Enable tracing Syscalls"
 	default y
 	help
 	  Enable tracing Syscalls.
 
-	config TRACING_THREAD
+config TRACING_THREAD
 	bool "Enable tracing Threads"
 	default y
 	help
 	  Enable tracing Threads.
 
-	config TRACING_WORK
+config TRACING_WORK
 	bool "Enable tracing Work"
 	default y
 	help
 	  Enable tracing Work and Work queue events
 
-	config TRACING_ISR
+config TRACING_ISR
 	bool "Enable tracing ISRs"
 	default y
 	help
 	  Enable tracing ISRs. This requires the backend to be
 	  very low-latency.
 
-	config TRACING_SEMAPHORE
+config TRACING_SEMAPHORE
 	bool "Enable tracing Semaphores"
 	default y
 	help
 	  Enable tracing Semaphores.
 
-	config TRACING_MUTEX
+config TRACING_MUTEX
 	bool "Enable tracing Mutexes"
 	default y
 	help
 	  Enable tracing Mutexes.
 
-	config TRACING_CONDVAR
+config TRACING_CONDVAR
 	bool "Enable tracing Condition Variables"
 	default y
 	help
 	  Enable tracing Condition Variables
 
-	config TRACING_QUEUE
+config TRACING_QUEUE
 	bool "Enable tracing Queues"
 	default y
 	help
 	  Enable tracing Queues.
 
-	config TRACING_FIFO
+config TRACING_FIFO
 	bool "Enable tracing FIFO queues"
 	default y
 	help
 	  Enable tracing FIFO queues.
 
-	config TRACING_LIFO
+config TRACING_LIFO
 	bool "Enable tracing LIFO queues"
 	default y
 	help
 	  Enable tracing LIFO queues.
 
-	config TRACING_STACK
+config TRACING_STACK
 	bool "Enable tracing Memory Stacks"
 	default y
 	help
 	  Enable tracing Memory Stacks.
 
-	config TRACING_MESSAGE_QUEUE
+config TRACING_MESSAGE_QUEUE
 	bool "Enable tracing Message Queues"
 	default y
 	help
 	  Enable tracing Message Queues.
 
-	config TRACING_MAILBOX
+config TRACING_MAILBOX
 	bool "Enable tracing Mailboxes"
 	default y
 	help
 	  Enable tracing Mailboxes.
 
-	config TRACING_PIPE
+config TRACING_PIPE
 	bool "Enable tracing Pipes"
 	default y
 	help
 	  Enable tracing Pipes.
 
-	config TRACING_HEAP
+config TRACING_HEAP
 	bool "Enable tracing Memory Heaps"
 	default y
 	help
 	  Enable tracing Memory Heaps.
 
-	config TRACING_MEMORY_SLAB
+config TRACING_MEMORY_SLAB
 	bool "Enable tracing Memory Slabs"
 	default y
 	help
 	  Enable tracing Memory Slabs.
 
-	config TRACING_TIMER
+config TRACING_TIMER
 	bool "Enable tracing Timers"
 	default y
 	help
 	  Enable tracing Timers.
-endmenu
+
+endmenu  # Tracing Configuration
 
 endif
 

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -45,6 +45,7 @@ config SEGGER_SYSTEMVIEW
 	select RTT_CONSOLE
 	select USE_SEGGER_RTT
 	select THREAD_MONITOR
+	select SEGGER_RTT_CUSTOM_LOCKING
 
 config TRACING_CTF
 	bool "Tracing via Common Trace Format support"

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
       revision: cdb9570901e87ab247aed0a96ccd8f94beee5834
       path: modules/lib/openthread
     - name: segger
-      revision: 2aa031c081426dcd0626185af45c40bd05811b68
+      revision: 7d78f7121dc4c59396c12e60e34f3617bac5efcb
       path: modules/debug/segger
     - name: sof
       revision: 52dc9c5ad8d0d2a5df0bb51ea30e54f8d7890639
@@ -134,7 +134,7 @@ manifest:
       revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
     - name: TraceRecorderSource
       path: modules/debug/TraceRecorder
-      revision: 41daf89c15ff841ed63fa882a916ec97089141ce
+      revision: d9889883abb4657d71e15ff055517a9b032f8212
     - name: hal_xtensa
       revision: 2f04b615cd5ad3a1b8abef33f9bdd10cc1990ed6
       path: modules/hal/xtensa


### PR DESCRIPTION
- tracing: fix indentation of config entries
- tracing: fix conflict with RTT locking
- tracing: rearrange tool header inclusion
