### PR TITLE
doc: release-notes-2.6: Add issue with mbedtls PSA API and TF-M

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -654,6 +654,11 @@ Trusted Firmware-m
    * BL5340 DVK
    * STM32L562E DK
 
+* NOTE: Trusted-Firmware-M can not currently be used with mbedtls 2.26.0 when
+  PSA APIs are enabled in mbedtls (``MBEDTLS_USE_PSA_CRYPTO`` and
+  ``MBEDTLS_PSA_CRYPTO_C``). If both TF-M and mbedtls are required, mbedtls
+  must be used without the PSA APIs. This will be resolved in a future
+  update to mbedtls.
 
 Documentation
 *************


### PR DESCRIPTION
Adds a note on a known config conflict with mbedtls 2.26.0 and TF-M where
the mbedtls PSA APIs can no be enabled at the same time as TF-M.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>

See #35305 