### PR TITLE
doc: porting guide: minor grammar fixups

### DIFF
--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -87,7 +87,7 @@ on its behalf, it raises an interrupt. When a thread does an operation that is
 not handled by the serial flow of the software itself, it raises an exception.
 Both, interrupts and exceptions, pass control to a handler. The handler is
 known as an :abbr:`ISR (Interrupt Service Routine)` in the case of
-interrupts. The handler perform the work required the exception or the
+interrupts. The handler performs the work required by the exception or the
 interrupt.  For interrupts, that work is device-specific. For exceptions, it
 depends on the exception, but most often the core kernel itself is responsible
 for providing the handler.


### PR DESCRIPTION
Fix some minor grammar issues for readability.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>