### PR TITLE
timer: HPET timer rework to allow custom register access functions

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -82,7 +82,7 @@ config HPET_TIMER
 	depends on X86
 	select IOAPIC if X86
 	select LOAPIC if X86
-	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	select TICKLESS_CAPABLE
 	help
 	  This option selects High Precision Event Timer (HPET) as a

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -40,6 +40,11 @@ DEVICE_MMIO_TOPLEVEL_STATIC(hpet_regs, DT_DRV_INST(0));
 #define TCONF_MODE32     BIT(8)
 #define TCONF_FSB_EN     BIT(14) /* FSB interrupt delivery enable */
 
+#ifndef HPET_COUNTER_CLK_PERIOD
+/* COUNTER_CLK_PERIOD (CLK_PERIOD_REG) is in femtoseconds (1e-15 sec) */
+#define HPET_COUNTER_CLK_PERIOD		(1000000000000000ULL)
+#endif
+
 #define MIN_DELAY 1000
 
 static __pinned_bss struct k_spinlock lock;
@@ -125,8 +130,7 @@ int sys_clock_driver_init(const struct device *dev)
 	set_timer0_irq(DT_INST_IRQN(0));
 	irq_enable(DT_INST_IRQN(0));
 
-	/* CLK_PERIOD_REG is in femtoseconds (1e-15 sec) */
-	hz = (uint32_t)(1000000000000000ULL / CLK_PERIOD_REG);
+	hz = (uint32_t)(HPET_COUNTER_CLK_PERIOD / CLK_PERIOD_REG);
 	z_clock_hw_cycles_per_sec = hz;
 	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -45,7 +45,10 @@ DEVICE_MMIO_TOPLEVEL_STATIC(hpet_regs, DT_DRV_INST(0));
 #define HPET_COUNTER_CLK_PERIOD		(1000000000000000ULL)
 #endif
 
-#define MIN_DELAY 1000
+#ifndef HPET_CMP_MIN_DELAY
+/* Minimal delay for comparator before the next timer event */
+#define HPET_CMP_MIN_DELAY		(1000)
+#endif
 
 static __pinned_bss struct k_spinlock lock;
 static __pinned_bss unsigned int max_ticks;
@@ -90,7 +93,7 @@ static void hpet_isr(const void *arg)
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t next = last_count + cyc_per_tick;
 
-		if ((int32_t)(next - now) < MIN_DELAY) {
+		if ((int32_t)(next - now) < HPET_CMP_MIN_DELAY) {
 			next += cyc_per_tick;
 		}
 		TIMER0_COMPARATOR_REG = next;
@@ -192,7 +195,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	cyc = (cyc / cyc_per_tick) * cyc_per_tick;
 	cyc += last_count;
 
-	if ((cyc - now) < MIN_DELAY) {
+	if ((cyc - now) < HPET_CMP_MIN_DELAY) {
 		cyc += cyc_per_tick;
 	}
 


### PR DESCRIPTION
This reworks the HPET driver to allow the SoC layer to define how the HPET registers are accessed. Some SoCs may need special care when accessing HPET registers, and/or need to perform initialization differently.

Also, this allows HPET driver to use kconfig to define timer frequency instead of determining it at runtime. This can help in quicker calculations as toolchain can optimize them due to numbers being constants.