### PR TITLE
arc: interrupt_controller: increase irq unit init priority

### DIFF
--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -218,9 +218,7 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 }
 
 SYS_DEVICE_DEFINE("arc_v2_irq_unit", arc_v2_irq_unit_init,
-		  arc_v2_irq_unit_device_ctrl, PRE_KERNEL_1,
-		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+		  arc_v2_irq_unit_device_ctrl, PRE_KERNEL_1, 0);
 #else
-SYS_INIT(arc_v2_irq_unit_init, PRE_KERNEL_1,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(arc_v2_irq_unit_init, PRE_KERNEL_1, 0);
 #endif   /* CONFIG_PM_DEVICE */


### PR DESCRIPTION
arc_v2_irq_unit_init function will init all interrupts and disable
they, we must make sure we call it first before we use interrupts.
so we need to increase its priority to highest in PRE_KERNEL_1 stage.

for example, before we config same priority for `arc_v2_irq_unit_init` and `arc_smp_init`:

```
SYS_INIT(arc_v2_irq_unit_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
```
```
SYS_INIT(arc_smp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
```

it's fine for gnu toolchain:

```
                0x0000000000003968                __init_PRE_KERNEL_1_start = .
 *(SORT_BY_NAME(SORT_BY_ALIGNMENT(.z_init_PRE_KERNEL_1[0-9]_*)))
 *(SORT_BY_NAME(SORT_BY_ALIGNMENT(.z_init_PRE_KERNEL_1[1-9][0-9]_*)))
 .z_init_PRE_KERNEL_140_
                0x0000000000003968        0x8 zephyr/libzephyr.a(soc.c.obj)
 .z_init_PRE_KERNEL_140_
                0x0000000000003970        0x8 zephyr/libzephyr.a(intc_arcv2_irq_unit.c.obj)
 .z_init_PRE_KERNEL_140_
                0x0000000000003978        0x8 zephyr/arch/arch/arc/core/libarch__arc__core.a(cache.c.obj)
 .z_init_PRE_KERNEL_140_
                0x0000000000003980        0x8 zephyr/arch/arch/arc/core/libarch__arc__core.a(arc_smp.c.obj)
```

but for mwdt toolchain:
```
    36a4     36a4        0     1         __init_PRE_KERNEL_1_start = .
    36a4     36a4        8     4         zephyr/libzephyr.a(soc.c.obj):(.z_init_PRE_KERNEL_140_.__init_sys_init_arc_nsim_init0)
    36a4     36a4        8     1                 __init_sys_init_arc_nsim_init0
    36ac     36ac        8     4         zephyr/arch/arch/arc/core/libarch__arc__core.a(arc_smp.c.obj):(.z_init_PRE_KERNEL_140_.__init_sys_init_arc_smp_init2)
    36ac     36ac        8     1                 __init_sys_init_arc_smp_init2
    36b4     36b4        8     4         zephyr/libzephyr.a(intc_arcv2_irq_unit.c.obj):(.z_init_PRE_KERNEL_140_.__init_sys_init_arc_v2_irq_unit_init0)
```

we will call `arc_smp_init` before `arc_v2_irq_unit_init`, `arc_v2_irq_unit_init` will disable the interrupt enabled in `arc_smp_init`.



