### PR TITLE
boards: arc: explicitly set link lib for hs boards with arcmwdt toolc…

### DIFF
--- a/soc/arc/snps_arc_hsdk/CMakeLists.txt
+++ b/soc/arc/snps_arc_hsdk/CMakeLists.txt
@@ -15,6 +15,8 @@ else()
 		   -Xdiv_rem=radix4 -Xswap -Xbitscan -Xmpy_option=qmpyh
 		   -Xshift_assist -Xbarrel_shifter -Xtimer0 -Xtimer1 -Xrtc)
   zephyr_cc_option_ifdef(CONFIG_FPU -Xfpu_mac -Xfpud_div)
+
+  zephyr_ld_options(-Hlib=hs38_full)
 endif()
 
 zephyr_sources(

--- a/soc/arc/snps_nsim/CMakeLists.txt
+++ b/soc/arc/snps_nsim/CMakeLists.txt
@@ -35,12 +35,15 @@ else()
 			       -Xmpy_option=qmpyh -Xshift_assist -Xbarrel_shifter
 			       -Xtimer0 -Xtimer1)
 
+  zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS -Hlib=hs38_full)
+
   zephyr_compile_options_ifdef(CONFIG_SOC_NSIM_HS_SMP -arcv2hs -core2 -Xatomic
 			       -Xll64 -Xdiv_rem=radix4 -Xunaligned -Xcode_density
 			       -Xswap -Xbitscan -Xmpy_option=qmpyh -Xshift_assist
 			       -Xbarrel_shifter -Xfpud_div -Xfpu_mac -Xrtc
 			       -Xtimer0 -Xtimer1)
 
+  zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS_SMP -Hlib=hs38_full)
 endif()
 
 zephyr_sources(


### PR DESCRIPTION
arcmwdt toolchain has various pre build libraries, we can find it inpath: {METAWARE_HOME}/lib, 
and it will use av2em lib by default. it's OK for em boards, but not suitable for hs boards. I have 
tested hs38_full library for hs boards, it's OK. let's use it.

@evgeniy-paltsev also find this issue during his debugging with cpp support for mwdt toolchain.
