### PR TITLE
dts: pcc: npcx: add ram-pd-depth property in npcx-pcc node.

### DIFF
--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -92,6 +92,11 @@
 			label = "UART_2";
 		};
 
+		/* Valid bit-depth of RAM_PDn registers in npcx7 series */
+		pcc: clock-controller@4000d000 {
+			ram-pd-depth = <12>;
+		};
+
 		/* Wake-up input source mapping for GPIOs in npcx7 series */
 		gpio0: gpio@40081000 {
 			wui-maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -115,6 +115,11 @@
 			label = "UART_4";
 		};
 
+		/* Valid bit-depth of RAM_PDn registers in npcx9 series */
+		pcc: clock-controller@4000d000 {
+			ram-pd-depth = <15>;
+		};
+
 		/* Wake-up input source mapping for GPIOs in npcx9 series */
 		gpio0: gpio@40081000 {
 			wui-maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03

--- a/dts/bindings/clock/nuvoton,npcx-pcc.yaml
+++ b/dts/bindings/clock/nuvoton,npcx-pcc.yaml
@@ -11,6 +11,18 @@ properties:
     reg:
         required: true
 
+    ram-pd-depth:
+        required: false
+        type: int
+        enum:
+        - 12
+        - 15
+        description: |
+          Valid bit-depth of RAM block Power-Down control (RAM_PD) registers.
+          Each bit in RAM_PDn can power down the relevant RAM block by setting
+          itself to 1 for better power consumption and this valid bit-depth
+          varies in different NPCX series.
+
 clock-cells:
     - bus
     - ctl


### PR DESCRIPTION
Since the valid bit-depth of RAM_PDn registers are different, this CL
introduces a 'ram-pd-depth' property in 'nuvoton,npcx-pcc' node if the
application needs to turn off the partial ram blocks for better power
consumption.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>