### PR TITLE
doc: fix style issues

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -50,10 +50,6 @@ legend,
     max-width: 480px;
 }
 
-.rst-content div.figure img {
-    border: 1px solid var(--body-color);
-}
-
 p,
 article ul,
 article ol,

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -899,7 +899,7 @@ kbd, .kbd {
     padding-left: 0 !important;
 }
 
-.rst-content dl:not(.docutils) dl dt, dl:not(.docutils,.rst-other-versions) dt {
+.rst-content dl:not(.docutils) dl:not(.rst-other-versions) dt {
     background: var(--admonition-note-background-color) !important;
     border-top: none !important;
     border-left: none !important;


### PR DESCRIPTION
```
doc: css: remove images black border
Remove the black border present on images.

doc: css: fix versions menu style
Versions menu dl > dt background color was not correct.
```

before:

![image](https://user-images.githubusercontent.com/25011557/119110635-abdd6600-ba22-11eb-893a-cb7f42b5477c.png)

![image](https://user-images.githubusercontent.com/25011557/119110560-92d4b500-ba22-11eb-9bce-067f323f11b7.png)


after:

![image](https://user-images.githubusercontent.com/25011557/119110809-c283bd00-ba22-11eb-8e26-ce77bcafad8a.png)

![image](https://user-images.githubusercontent.com/25011557/119110906-d8917d80-ba22-11eb-9219-a00fc9530ee8.png)