### PR TITLE
Bluetooth: host: Fix multiple advertisers with different ID support

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -78,18 +78,6 @@ static struct bt_le_ext_adv *bt_adv_lookup_handle(uint8_t handle)
 #endif /* CONFIG_BT_BROADCASTER */
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
-
-static void adv_id_check_connectable_func(struct bt_le_ext_adv *adv, void *data)
-{
-	struct bt_adv_id_check_data *check_data = data;
-
-	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
-	    atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE) &&
-	    check_data->id != adv->id) {
-		check_data->adv_enabled = true;
-	}
-}
-
 void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
 			   void *data)
 {
@@ -565,16 +553,7 @@ static uint8_t get_adv_channel_map(uint32_t options)
 static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 				 struct bt_conn **out_conn)
 {
-	struct bt_adv_id_check_data check_data = {
-		.id = adv->id,
-		.adv_enabled = false
-	};
 	struct bt_conn *conn;
-
-	bt_le_ext_adv_foreach(adv_id_check_connectable_func, &check_data);
-	if (check_data.adv_enabled) {
-		return -ENOTSUP;
-	}
 
 	bt_dev.adv_conn_id = adv->id;
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -354,11 +354,6 @@ struct bt_hci_cmd_state_set {
 	bool val;
 };
 
-struct bt_adv_id_check_data {
-	uint8_t id;
-	bool adv_enabled;
-};
-
 /* Set command state related with the command buffer */
 void bt_hci_cmd_state_set_init(struct net_buf *buf,
 			       struct bt_hci_cmd_state_set *state,

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -27,6 +27,11 @@
 #define LOG_MODULE_NAME bt_id
 #include "common/log.h"
 
+struct bt_adv_id_check_data {
+	uint8_t id;
+	bool adv_enabled;
+};
+
 #if defined(CONFIG_BT_OBSERVER) || defined(CONFIG_BT_BROADCASTER)
 const bt_addr_le_t *bt_lookup_id_addr(uint8_t id, const bt_addr_le_t *addr)
 {


### PR DESCRIPTION
Fix multiple advertisers with different ID support, this was added
in 98321c61fbba0709a7029eade7190dca9cfb7d4d but the guard was never
removed.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>