### PR TITLE
Bluetooth: host: Fix disconnect priority event handling

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -47,7 +47,9 @@ struct bt_hci_evt_hdr {
 #define BT_ACL_POINT_TO_POINT           0x00
 #define BT_ACL_BROADCAST                0x01
 
-#define bt_acl_handle(h)                ((h) & BIT_MASK(12))
+#define BT_ACL_HANDLE_MASK              BIT_MASK(12)
+
+#define bt_acl_handle(h)                ((h) & BT_ACL_HANDLE_MASK)
 #define bt_acl_flags(h)                 ((h) >> 12)
 #define bt_acl_flags_pb(f)              ((f) & BIT_MASK(2))
 #define bt_acl_flags_bc(f)              ((f) >> 2)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1507,6 +1507,12 @@ struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 #endif /* CONFIG_BT_ISO */
 }
 
+void bt_conn_connected(struct bt_conn *conn)
+{
+	bt_l2cap_connected(conn);
+	notify_connected(conn);
+}
+
 void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 {
 	bt_conn_state_t old_state;
@@ -1557,9 +1563,6 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		}
 
 		sys_slist_init(&conn->channels);
-
-		bt_l2cap_connected(conn);
-		notify_connected(conn);
 
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 		    conn->role == BT_CONN_ROLE_SLAVE) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -321,6 +321,8 @@ struct bt_conn *bt_conn_lookup_state_le(uint8_t id, const bt_addr_le_t *peer,
 /* Set connection object in certain state and perform action related to state */
 void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state);
 
+void bt_conn_connected(struct bt_conn *conn);
+
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);
 


### PR DESCRIPTION
Fix issue is host handling of connected and disconnected event.
Since the host wants the disconnected event to be processed as a
priority event as well as in reguler event context while the connected
event is always in reguler event context we can end up in a situation
where the disconnected priority event is processed before the connected
event.

Since the disconnected priority event is there to release unack'ed TX
pending on the connection in case the RX thread is blocked waiting
for TX resources, we need to keep this behavior. Otherwise this would
be a potential deadlock of the RX thread waiting for resources that can
only be released by the RX thread.
When this situation happens we know that there cannot be any pending TX
on this connection so we can safely skip releasing of unack'ed TX.

The second thing the disconnected priority event does is marking the TX
path on the connection as disconnected. We need to do the same in this
situation, so we make sure that the TX path is already marked
disconnected when providing the connected callback to the application.

This fixes a regression from 4be66bd33dec1edc82d35270c718f81443c42e8a.

Fixes: #32742

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>