### PR TITLE
Bluetooth: controller: add apto/appto reset for peripheral

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -894,6 +894,11 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->supervision_expire = 0;
 		conn->procedure_expire = 0;
 
+#if defined(CONFIG_BT_CTLR_LE_PING)
+		conn->apto_expire = 0U;
+		conn->appto_expire = 0U;
+#endif
+
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
 		conn->own_addr_type = BT_ADDR_LE_NONE->type;
 		memcpy(conn->own_addr, BT_ADDR_LE_NONE->a.val, sizeof(conn->own_addr));


### PR DESCRIPTION
Authenticated payload timeout countdown was found, by code inspection, to not be reset for peripheral case, leading to unexpected PING_REQ/RSP and/or APTO events.

Found during debug of LLCP refactoring of LE PING procedure. Unexpected PING_REQ/RSP exchange was noticed in a test run using EDTT. 
  
Signed-off-by: Erik Brockhoff <erbr@oticon.com>