### PR TITLE
Bluetooth: host: Add check for already enabled in advertising set start

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -769,6 +769,11 @@ struct bt_conn_cb {
 	 *  In case the err parameter is non-zero it means that the
 	 *  connection establishment failed.
 	 *
+	 *  @note If the connection was established from an advertising set then
+	 *        the advertising set cannot be restarted directly from this
+	 *        callback. Instead use the connected callback of the
+	 *        advertising set.
+	 *
 	 *  @param conn New connection object.
 	 *  @param err HCI error. Zero for success, non-zero otherwise.
 	 *

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1223,6 +1223,10 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 	struct bt_conn *conn = NULL;
 	int err;
 
+	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
+		return -EALREADY;
+	}
+
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 	    atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
 		err = le_adv_start_add_conn(adv, &conn);


### PR DESCRIPTION
Add check for the advertising already being enabled when attempting to
start the advertising set.
Document that the advertising set cannot be started from the connection
connected callback, and instead has to be started from the advertising
set connected callback.

Fixes: #33897

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>