### PR TITLE
Bluetooth: controller: Improve ticker_by_next_slot_get

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -553,6 +553,15 @@ config BT_TICKER_LAZY_GET
 	  ticker nodes, returning tick to expire and lazy count from a reference
 	  tick.
 
+config BT_TICKER_NEXT_SLOT_GET_MATCH
+	bool "Ticker Next Slot Get with match callback"
+	default y if BT_TICKER_SLOT_AGNOSTIC
+	help
+	  This option enables ticker interface to iterate through active
+	  ticker nodes with a callback for every found ticker node. When
+	  returning true in the callback, iteration will stop and the normal
+	  operation callback invoked.
+
 config BT_TICKER_EXT
 	bool "Ticker extensions"
 	depends on !BT_TICKER_LOW_LAT && !BT_TICKER_SLOT_AGNOSTIC

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -925,6 +925,7 @@ static void mfy_sync_offset_get(void *param)
 					       TICKER_USER_ID_ULL_LOW,
 					       &id, &ticks_current,
 					       &ticks_to_expire, &lazy,
+					       NULL, NULL,
 					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {
 			while (ret_cb == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -103,6 +103,11 @@ typedef void (*ticker_timeout_func) (uint32_t ticks_at_expire, uint32_t remainde
  */
 typedef void (*ticker_op_func) (uint32_t status, void *op_context);
 
+/** \brief Timer operation match callback function type.
+ */
+typedef bool (*ticker_op_match_func) (uint8_t ticker_id, uint32_t ticks_slot,
+				      uint32_t ticks_to_expire, void *op_context);
+
 #if defined(CONFIG_BT_TICKER_EXT)
 struct ticker_ext {
 	uint32_t ticks_slot_window;/* Window in which the slot
@@ -158,6 +163,8 @@ uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
 uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 				  uint8_t *ticker_id, uint32_t *ticks_current,
 				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  ticker_op_match_func fp_op_match_func,
+				  void *match_op_context,
 				  ticker_op_func fp_op_func, void *op_context);
 uint32_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 			  ticker_op_func fp_op_func, void *op_context);


### PR DESCRIPTION
Fixes ticker_by_next_slot_get for JIT scheduler by allowing iterating
through ticker nodes without ticks_slot information, and improves
performance for legacy ticker scheduling use.

To reduce the processing and context switching overhead, a new feature
is introduced via BT_TICKER_NEXT_SLOT_GET_MATCH, by which an operation
callback may be added via the ticker_next_slot_get_ext interface, and
the match function is then called when the ticker_job is processing the
request.
By returning true in this callback, iteration stops and normal operation
callback is invoked. If the match function returns false, node iteration
continues. This reduces the number of ticker_job executions for node
iteration.

Signed-off-by: Morten Priess <mtpr@oticon.com>