### PR TITLE
Rt1060 am457 bt support

### DIFF
--- a/boards/arm/mimxrt1060_evk/pinmux.c
+++ b/boards/arm/mimxrt1060_evk/pinmux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NXP
+ * Copyright (c) 2018,2021 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -144,6 +144,21 @@ static int mimxrt1060_evk_init(const struct device *dev)
 			    IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
 			    IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
 			    IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+
+#if IS_ENABLED(DT_PROP(DT_NODELABEL(lpuart3), hw_flow_control))
+	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B, 0U);
+	IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B, 0U);
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B,
+			IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+			IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+
+	IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B,
+			IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
+			IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+			IOMUXC_SW_PAD_CTL_PAD_DSE(6));
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpi2c1), okay) && CONFIG_I2C

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright (c) 2017,2021 NXP
  * Copyright (c) 2020 Softube
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -19,6 +19,7 @@ struct mcux_lpuart_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	uint32_t baud_rate;
+	uint8_t flow_ctrl;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
 #endif
@@ -357,7 +358,7 @@ static int mcux_lpuart_init(const struct device *dev)
 	uart_api_config->parity = UART_CFG_PARITY_NONE;
 	uart_api_config->stop_bits = UART_CFG_STOP_BITS_1;
 	uart_api_config->data_bits = UART_CFG_DATA_BITS_8;
-	uart_api_config->flow_ctrl = UART_CFG_FLOW_CTRL_NONE;
+	uart_api_config->flow_ctrl = config->flow_ctrl;
 
 	/* set initial configuration */
 	mcux_lpuart_configure_init(dev, uart_api_config);
@@ -430,6 +431,8 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {	\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\
+	.flow_ctrl = DT_INST_PROP(n, hw_flow_control) ?	\
+		UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE,\
 	IRQ_FUNC_INIT							\
 }
 


### PR DESCRIPTION
with the three PRs: https://github.com/zephyrproject-rtos/zephyr/pull/31583, https://github.com/zephyrproject-rtos/zephyr/pull/35536 and this PR, the a2dp samples can run in the RT1060+ AW-AM457-D-uSD