### PR TITLE
doc: fix all doxygen warnings

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -726,6 +726,12 @@ WARN_IF_DOC_ERROR      = YES
 
 WARN_NO_PARAMDOC       = NO
 
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered.
+# The default value is: NO.
+
+WARN_AS_ERROR          = YES
+
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
 # will be replaced by the file and line number from which the warning originated

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -35,9 +35,7 @@ extern "C" {
 /** Maximum Transmission Unit (MTU) for an incoming L2CAP PDU. */
 #define BT_L2CAP_RX_MTU (CONFIG_BT_BUF_ACL_RX_SIZE - BT_L2CAP_HDR_SIZE)
 
-/** @def BT_L2CAP_BUF_SIZE
- *
- *  @brief Helper to calculate needed buffer size for L2CAP PDUs.
+/** @brief Helper to calculate needed buffer size for L2CAP PDUs.
  *         Useful for creating buffer pools.
  *
  *  @param mtu Needed L2CAP PDU MTU.
@@ -460,7 +458,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  When sending L2CAP data over an BR/EDR connection the application is sending
  *  L2CAP PDUs. The application is required to have reserved
  *  @ref BT_L2CAP_CHAN_SEND_RESERVE bytes in the buffer before sending.
- *  The application should use the @def BT_L2CAP_BUF_SIZE helper to correctly
+ *  The application should use the BT_L2CAP_BUF_SIZE() helper to correctly
  *  size the buffers for the for the outgoing buffer pool.
  *
  *  When sending L2CAP data over an LE connection the applicatios is sending
@@ -470,7 +468,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  directly, otherwise it will have to allocate a new segment for the first
  *  segment.
  *  If the application is reserving the bytes it should use the
- *  @def BT_L2CAP_BUF_SIZE helper to correctly size the buffers for the for the
+ *  BT_L2CAP_BUF_SIZE() helper to correctly size the buffers for the for the
  *  outgoing buffer pool.
  *  When segmenting an L2CAP SDU into L2CAP PDUs the stack will first attempt
  *  to allocate buffers from the original buffer pool of the L2CAP SDU before

--- a/include/device.h
+++ b/include/device.h
@@ -615,10 +615,6 @@ static inline bool device_is_ready(const struct device *dev)
 }
 
 /**
- * @}
- */
-
-/**
  * @brief Indicate that the device is in the middle of a transaction
  *
  * Called by a device driver to indicate that it is in the middle of a

--- a/include/linker/devicetree_regions.h
+++ b/include/linker/devicetree_regions.h
@@ -17,7 +17,7 @@
  *
  * @param name name of the generated memory region
  * @param attr region attributes to use (rx, rw, ...)
- * @param node devicetree node with a <reg> property defining region location
+ * @param node devicetree node with a \<reg\> property defining region location
  *             and size.
  */
 #define DT_REGION_FROM_NODE_STATUS_OKAY(name, attr, node) \

--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -295,14 +295,14 @@ int dns_resolve_close(struct dns_resolve_context *ctx);
  * @details Reconfigures DNS context with new server list.
  *
  * @param ctx DNS context
- * @param dns_servers_str DNS server addresses using textual strings. The
+ * @param servers_str DNS server addresses using textual strings. The
  * array is NULL terminated. The port number can be given in the string.
  * Syntax for the server addresses with or without port numbers:
  *    IPv4        : 10.0.9.1
  *    IPv4 + port : 10.0.9.1:5353
  *    IPv6        : 2001:db8::22:42
  *    IPv6 + port : [2001:db8::22:42]:5353
- * @param dns_servers_sa DNS server addresses as struct sockaddr. The array
+ * @param servers_sa DNS server addresses as struct sockaddr. The array
  * is NULL terminated. Port numbers are optional in struct sockaddr, the
  * default will be used if set to 0.
  *

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -913,7 +913,8 @@ size_t arch_icache_line_size_get(void);
 #include <timing/types.h>
 
 /**
- * @ingroup arch-interface timing_api
+ * @ingroup arch-timing
+ * @{
  */
 
 /**
@@ -1008,7 +1009,7 @@ uint64_t arch_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count);
  */
 uint32_t arch_timing_freq_get_mhz(void);
 
-/* @} */
+/** @} */
 
 #endif /* CONFIG_TIMING_FUNCTIONS */
 

--- a/include/sys/p4wq.h
+++ b/include/sys/p4wq.h
@@ -120,6 +120,7 @@ struct k_p4wq_initparam {
  * @param name Symbol name of the struct k_p4wq array that will be defined
  * @param n_threads Number of threads and work queues
  * @param stack_sz Requested stack size of each thread, in bytes
+ * @param flg Flags
  */
 #define K_P4WQ_ARRAY_DEFINE(name, n_threads, stack_sz, flg)		\
 	static K_THREAD_STACK_ARRAY_DEFINE(_p4stacks_##name,		\


### PR DESCRIPTION
This PR fixes all current Doxygen warnings. It also enables the flag to treat warnings as errors. Since we already disable warnings for undocumented members (the major source of warnings), reported warnings are in all cases real problems that should be fixed.