### PR TITLE
doc: kernel: add documentation for queues

### DIFF
--- a/doc/reference/kernel/data_passing/queues.rst
+++ b/doc/reference/kernel/data_passing/queues.rst
@@ -3,6 +3,12 @@
 Queues
 ######
 
+A Queue in Zephyr is a kernel object that implements a traditional queue, allowing
+threads and ISRs to add and remove data items of any size. The queue is similar
+to a FIFO and serves as the underlying implementation for both :ref:`k_fifo
+<fifos_v2>` and :ref:`k_lifo <lifos_v2>`. For more information on usage see
+:ref:`k_fifo <fifos_v2>`.
+
 
 Configuration Options
 *********************


### PR DESCRIPTION
Add missing introduction to queues which are basically FIFOs and in
zephyr are used to implement both FIFO and LIFO objects.

Fixes zephyrproject-rtos#35199