### PR TITLE
tests: test_build: Exclude lpcxpresso55s69_ns from debug builds

### DIFF
--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   buildsystem.debug.build:
+    platform_exclude: lpcxpresso55s69_ns
     build_only: true
     extra_args: CONF_FILE=debug.conf
     tags: debug


### PR DESCRIPTION
When `CONFIG_TFM_BL2` is enabled on the LPC55S69 there isn't
enough memory left for TF-M to perform a debug build. Excludes this
platform from this specific test case.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>