### PR TITLE
samples: tensorflow: remove requirements.txt from magic wand sample

### DIFF
--- a/samples/modules/tensorflow/magic_wand/train/README.md
+++ b/samples/modules/tensorflow/magic_wand/train/README.md
@@ -47,7 +47,7 @@ If you'd prefer to run the scripts locally, use the following instructions.
 Use the following command to install the required dependencies:
 
 ```shell
-pip install -r requirements.txt
+pip install numpy==1.16.2 tensorflow==2.0.0-beta1
 ```
 
 There are two ways to train the model:

--- a/samples/modules/tensorflow/magic_wand/train/requirements.txt
+++ b/samples/modules/tensorflow/magic_wand/train/requirements.txt
@@ -1,2 +1,0 @@
-numpy==1.16.2
-tensorflow==2.0.0-beta1


### PR DESCRIPTION
Removes the requirements.txt from the training directory of the
magic wand sample as it is causing issues in CI. Updates README.md
to explicitly state the Python packages listed in requirements.txt.

(Note: Requirement `tensorflow==2.0.0-beta1` was not upgraded to TensorFlow 2.4.0 as this would break the scripts and requirements.txt. See [TensorFlow issue](https://github.com/tensorflow/tensorflow/issues/49473).)

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>