### PR TITLE
drivers: wifi: eswifi: fix swapped protocols in eswifi_off_getaddrinfo

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -632,7 +632,7 @@ static int eswifi_off_getaddrinfo(const char *node, const char *service,
 
 	ai->ai_family = AF_INET;
 	ai->ai_socktype = hints ? hints->ai_socktype : SOCK_STREAM;
-	ai->ai_protocol = ai->ai_socktype == SOCK_STREAM ? IPPROTO_UDP : IPPROTO_TCP;
+	ai->ai_protocol = ai->ai_socktype == SOCK_STREAM ? IPPROTO_TCP : IPPROTO_UDP;
 
 	ai_addr->sin_family = ai->ai_family;
 	ai_addr->sin_port = htons(port);


### PR DESCRIPTION
As a result, when the socket was created using values returned by `getaddrinfo`, the wrong protocol was used.

Signed-off-by: Kamil Panek <kamil.panek@wbudowane.pl>