### PR TITLE
doc: link-roles: fix :zephyr_file: default revision

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -24,7 +24,7 @@ def get_github_rev():
     if tag:
         return tag.decode("utf-8")
     else:
-        return 'master'
+        return 'main'
 
 
 def setup(app):


### PR DESCRIPTION
This needs to use 'main' for its default now.

Without this patch, GitHub redirects to main, but displays a banner
that says 'Branch not found, redirected to default branch' at the top.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>