### PR TITLE
canbus: isotp: remove unused work queue

### DIFF
--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -63,20 +63,6 @@ config ISOTP_ENABLE_TX_PADDING
 	  Add padding bytes 0xCC (as recommended by Bosch) if the PDU payload
 	  does not fit exactly into the CAN frame.
 
-config ISOTP_WORKQUEUE_PRIO
-	int "Priority level of the RX and TX work queue"
-	default 2
-	help
-	  This value defines the priority level of the work queue thread that
-	  handles flow control, consecutive sending, receiving and callbacks.
-
-config ISOTP_WORKQ_STACK_SIZE
-	int "Work queue stack size"
-	default 256
-	help
-	  This value defines the stack size of the work queue thread that
-	  handles flow control, consecutive sending, receiving and callbacks.
-
 config ISOTP_RX_BUF_COUNT
 	int "Number of data buffers for receiving data"
 	default 4

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -39,9 +39,6 @@ NET_BUF_POOL_VAR_DEFINE(isotp_tx_pool, CONFIG_ISOTP_TX_BUF_COUNT,
 			CONFIG_ISOTP_BUF_TX_DATA_POOL_SIZE, NULL);
 #endif
 
-K_KERNEL_STACK_DEFINE(tx_stack, CONFIG_ISOTP_WORKQ_STACK_SIZE);
-static struct k_work_q isotp_workq;
-
 static void receive_state_machine(struct isotp_recv_ctx *ctx);
 
 /*
@@ -1329,19 +1326,3 @@ int isotp_send_buf(const struct device *can_dev,
 }
 #endif  /*CONFIG_ISOTP_USE_TX_BUF*/
 #endif  /*CONFIG_ISOTP_ENABLE_CONTEXT_BUFFERS*/
-
-static int isotp_workq_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	LOG_DBG("Starting workqueue");
-	k_work_queue_start(&isotp_workq, tx_stack,
-			   K_KERNEL_STACK_SIZEOF(tx_stack),
-			   CONFIG_ISOTP_WORKQUEUE_PRIO, NULL);
-
-	k_thread_name_set(&isotp_workq.thread, "isotp_work");
-
-	return 0;
-}
-
-SYS_INIT(isotp_workq_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Remove unused local work queue.

Fixes #34862

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>