### PR TITLE
boards: stm32f429i_disc1 remove usart2 node

### DIFF
--- a/boards/arm/stm32f429i_disc1/doc/index.rst
+++ b/boards/arm/stm32f429i_disc1/doc/index.rst
@@ -117,8 +117,6 @@ Default Zephyr Peripheral Mapping:
 ----------------------------------
 - UART_1_TX : PA9
 - UART_1_RX : PA10
-- UART_2_TX : PA2
-- UART_2_RX : PA3
 - USER_PB : PA0
 - LD3 : PG13
 - LD4 : PG12

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -74,12 +74,6 @@
 	status = "okay";
 };
 
-&usart2 {
-	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
-	current-speed = <115200>;
-	status = "okay";
-};
-
 &rtc {
 	status = "okay";
 };


### PR DESCRIPTION
Hi, hit this while troubleshooting some suspiciously high power consumption readings on the board, turns out the current default config is causing the MCU to sink about 60mA into PA2, which is driven low by another chip (the line sits at about 1V). Looked into replace this with any of the other other 6 UARTs on this chip, but it looks like none of them have a usable TX/RX pair available, between the display and the SDRAM all the pins gets used, so I ended up just removing the node.

![f429-disc1-pa2](https://user-images.githubusercontent.com/891546/119267521-f0b1fa00-bbe6-11eb-9439-b0f7a0960562.png)