### PR TITLE
boards: mimxrt1010_evk: Point SRAM to OCRAM

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -18,7 +18,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &dtcm;
+		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;


### PR DESCRIPTION
Point the SRAM reference to the larger OCRAM memory block.

Fixes: #33726

Signed-off-by: David Leach <david.leach@nxp.com>