### PR TITLE
subsys: logging: initialize variable before use

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1159,7 +1159,7 @@ void log_generic_from_user(struct log_msg_ids src_level,
 	char buffer[CONFIG_LOG_STRDUP_MAX_STRING + 1];
 	union {
 		struct log_msg_ids structure;
-		uint32_t value;
+		uint32_t value = 0;
 	} src_level_union;
 
 	vsnprintk(buffer, sizeof(buffer), fmt, ap);
@@ -1244,7 +1244,7 @@ void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
 {
 	union {
 		struct log_msg_ids structure;
-		uint32_t value;
+		uint32_t value = 0;
 	} src_level_union;
 
 	__ASSERT_NO_MSG(sizeof(src_level) <= sizeof(uint32_t));


### PR DESCRIPTION
Variable "uint32_t value" in the union "src_level_union"
is not initialized before use in the functions log_hexdump_from_user()
and log_generic_from_user().
Assign value "uint32_t value = 0" by default.

Found as a coding guideline violation (MISRA R1.3) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>