### PR TITLE
userspace: remove dead code

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -81,7 +81,7 @@ const char *otype_to_str(enum k_objects otype)
 	}
 #else
 	ARG_UNUSED(otype);
-	return NULL;
+	ret = NULL;
 #endif
 	return ret;
 }


### PR DESCRIPTION
File userspace.c contains dead code in function char *otype_to_str()
Remove "return NULL" and replace with "ret = NULL".

Found as a coding guideline violation (MISRA R2.1) by static
coding scanning tool.