### PR TITLE
tests: mem_alloc: workaround aggressive optimization

### DIFF
--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -146,7 +146,7 @@ void test_malloc(void)
 	iptr = NULL;
 }
 #if (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE == 0)
-void test_no_mem_malloc(void)
+__no_optimization void test_no_mem_malloc(void)
 {
 	int *iptr = NULL;
 
@@ -155,7 +155,7 @@ void test_no_mem_malloc(void)
 	free(iptr);
 	iptr = NULL;
 }
-void test_no_mem_realloc(void)
+__no_optimization void test_no_mem_realloc(void)
 {
 	char *ptr = NULL;
 	char *reloc_ptr = NULL;
@@ -237,7 +237,7 @@ void test_calloc(void)
 #define CALLOC_BUFLEN (200)
 static ZTEST_BMEM unsigned char zerobuf[CALLOC_BUFLEN];
 
-void test_calloc(void)
+__no_optimization void test_calloc(void)
 {
 	char *cptr = NULL;
 


### PR DESCRIPTION
As we don't use memory allocated in test_calloc, test_no_mem_malloc,
and test_no_mem_realloc. malloc call can be optimized away (that really
happens with ARC MWDT toolchain). That breaks the test. So disable
optimization for these functions.

Fix: #35569
Similar fix: #28614