### PR TITLE
Fix unstable tests involving nRF system timer

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -386,11 +386,7 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = counter_sub(counter(), last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ret;
+	return counter_sub(counter(), last_count) / CYC_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)


### PR DESCRIPTION
Fixes #35509.

*kernel: timeout: Fix adding of an absolute timeout*

Correct the way the relative ticks value is calculated for an absolute
timeout. Previously, elapsed() was called twice and the returned value
was first subtracted from and then added to the ticks value. It could
happen that the HW counter value read by elapsed() changed between the
two calls to this function. This caused the test_timeout_abs test case
from the timer_api test suite to occasionally fail, e.g. on certain nRF
platforms.

*drivers: nrf_rtc_timer: Remove unnecessary locking*

As per description of the sys_clock_elapsed() function, "the kernel
will call this with appropriate locking, the driver needs only provide
an instantaneous answer". Remove then the unnecessary locking from the
function, as it only adds an undesirable delay.

The above delay combined with the disabled instruction cache (the issue
fixed initially by #35455, then by #35510) caused the test_posix_realtime
test case from the posix_apis test suite to fail on some nRF platforms
(see #35509).