### PR TITLE
tests: pwm: led: Fix pwm_led sample

### DIFF
--- a/samples/drivers/led_pwm/sample.yaml
+++ b/samples/drivers/led_pwm/sample.yaml
@@ -7,17 +7,17 @@ tests:
     tags: LED
     depends_on: pwm
     platform_exclude: reel_board
-    timeout: 15
+    timeout: 20
     harness: console
     harness_config:
       type: multi_line
       ordered: true
       regex:
-        - "Found device LED_PWM_\\d+"
+        - "Found device \\S+"
         - "Testing LED \\d+"
-        - "Turning on"
-        - "Turning off"
+        - "Turned on"
+        - "Turned off"
         - "Increasing brightness gradually"
         - "Blinking on: 0.1 sec, off: 0.1 sec"
-        - "Blinking on: 1 sec, off: 1 sec"
-        - "Turning off"
+        - "(Blinking on: 1 sec, off: 1 sec|Cycle period not supported)"
+        - "Turned off, loop end"

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -48,20 +48,20 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 
 	/* Turn LED on. */
 	err = led_on(led_pwm, led);
-	LOG_INF("  Turning on");
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
 		return;
 	}
+	LOG_INF("  Turned on");
 	k_sleep(K_MSEC(1000));
 
 	/* Turn LED off. */
 	err = led_off(led_pwm, led);
-	LOG_INF("  Turning off");
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
 		return;
 	}
+	LOG_INF("  Turned off");
 	k_sleep(K_MSEC(1000));
 
 	/* Increase LED brightness gradually up to the maximum level. */
@@ -77,30 +77,31 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	k_sleep(K_MSEC(1000));
 
 	/* Set LED blinking (on: 0.1 sec, off: 0.1 sec) */
-	LOG_INF("  Blinking on: 0.1 sec, off: 0.1 sec");
 	err = led_blink(led_pwm, led, 100, 100);
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
 		return;
 	}
+	LOG_INF("  Blinking on: 0.1 sec, off: 0.1 sec");
 	k_sleep(K_MSEC(5000));
 
 	/* Enable LED blinking (on: 1 sec, off: 1 sec) */
-	LOG_INF("  Blinking on: 1 sec, off: 1 sec");
 	err = led_blink(led_pwm, led, 1000, 1000);
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
-		return;
+		LOG_INF("  Cycle period not supported - on: 1 sec, off: 1 sec");
+	} else {
+		LOG_INF("  Blinking on: 1 sec, off: 1 sec");
 	}
 	k_sleep(K_MSEC(5000));
 
 	/* Turn LED off. */
-	LOG_INF("  Turning off");
 	err = led_off(led_pwm, led);
 	if (err < 0) {
 		LOG_ERR("err=%d", err);
 		return;
 	}
+	LOG_INF("  Turned off, loop end");
 }
 
 void main(void)


### PR DESCRIPTION
The PR fixes the pwm_led sample:
- now test doesn't rely on any specific device name
- Logs which are scanned with regex in the test are printed
  only after a command passes (before failures were not
  affecting the test verdict)
- If 1 sec cycle is not supported appropriate info is printed
  and won't cause the test to failed
- Changed second "Turned off" msg so regex doesn't mix it with the
  the first one.

Fixes #35524

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>