### PR TITLE
storage/flash_map: Fix flash area bounds checking

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -80,7 +80,7 @@ void flash_area_close(const struct flash_area *fa)
 static inline bool is_in_flash_area_bounds(const struct flash_area *fa,
 					   off_t off, size_t len)
 {
-	return (off <= fa->fa_size && off + len <= fa->fa_size);
+	return (off >= 0) && ((off + len) <= fa->fa_size);
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)


### PR DESCRIPTION
The commit adds check if offset is positive; previously negative
offset would be allowed, which means that writing flash before flash
area start was possible.


Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>