### PR TITLE
drivers/ADC: STM32: This solves coverity reported in ADC driver.

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -567,8 +567,8 @@ static int adc_stm32_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (channel_cfg->channel_id == ADC_CHANNEL_TEMPSENSOR ||
-		channel_cfg->channel_id == ADC_CHANNEL_VREFINT) {
+	if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(ADC_CHANNEL_TEMPSENSOR) == channel_cfg->channel_id) ||
+		(__LL_ADC_CHANNEL_TO_DECIMAL_NB(ADC_CHANNEL_VREFINT) == channel_cfg->channel_id)) {
 		adc_stm32_set_common_path(dev);
 	}
 


### PR DESCRIPTION
This commit it to resolve following bugs:
* Operands don't affect result.
* Logical dead code in stm32_adc driver.

Above mentioned bugs were solved by adding parenthesis and changed the method of comparing. 
Since comparison of ADC channel_id with the channel may cause loss of value. So instead of direct comparison, introduced a mechanism to convert channel constant to a decimal using __LL_ADC_CHANNEL_TO_DECIMAL_NB() and strips away the INTERNAL_CH bit and compare with channel_id. 

fix:
* #35130
* #35136

Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>