### PR TITLE
cmake: extensions.cmake: use blocklist instead in comment

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1057,7 +1057,7 @@ endfunction()
 function(zephyr_check_compiler_flag_hardcoded lang option check exists)
   # Various flags that are not supported for CXX may not be testable
   # because they would produce a warning instead of an error during
-  # the test.  Exclude them by toolchain-specific blacklist.
+  # the test.  Exclude them by toolchain-specific blocklist.
   if((${lang} STREQUAL CXX) AND ("${option}" IN_LIST CXX_EXCLUDED_OPTIONS))
     set(check 0 PARENT_SCOPE)
     set(exists 1 PARENT_SCOPE)


### PR DESCRIPTION
There is a comment which needed to be rephrased for inclusive
language. This commit replaces it with the recommended
replacement.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>