### PR TITLE
samples: display: Limit lvgl sample execution to boards with shield

### DIFF
--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -11,6 +11,9 @@ tests:
     platform_exclude: reel_board reel_board_v2 ubx_evkannab1_nrf52832
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
+    harness: console
+    harness_config:
+      fixture: fixture_shield_adafruit_2_8_tft_touch_v2
   sample.display.waveshare_epaper_gdeh0213b1:
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=waveshare_epaper_gdeh0213b1


### PR DESCRIPTION
Similar to commit c6ff61220e8af1c444d0d23210830c5131cd53b3, use a
harness config to limit execution of the adafruit_2_8_tft_touch_v2
sample variant to boards that have this shield attached.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #35543