### PR TITLE
doc: can: fix build commands

### DIFF
--- a/boards/shields/dfrobot_can_bus_v2_0/doc/index.rst
+++ b/boards/shields/dfrobot_can_bus_v2_0/doc/index.rst
@@ -118,11 +118,10 @@ Set ``-DSHIELD=dfrobot_can_bus_v2_0`` when you invoke ``west build`` or ``cmake`
 Zephyr application. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/CAN
+   :zephyr-app: samples/drivers/can
    :tool: all
    :board: nrf52dk_nrf52832
    :shield: dfrobot_can_bus_v2_0
-   :conf: prj.mcp2515.conf
    :goals: build flash
 
 .. _DFRobot Website:

--- a/samples/drivers/can/README.rst
+++ b/samples/drivers/can/README.rst
@@ -29,7 +29,7 @@ Integrated CAN controller
 For the NXP TWR-KE18F board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/CAN
+   :zephyr-app: samples/drivers/can
    :board: twr_ke18f
    :goals: build flash
 
@@ -40,10 +40,9 @@ For the nrf52dk_nrf52832 board combined with the DFRobot CAN bus V2.0 shield tha
 provides the MCP2515 CAN controller:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/CAN
+   :zephyr-app: samples/drivers/can
    :board: nrf52dk_nrf52832
    :shield: dfrobot_can_bus_v2_0
-   :conf: prj.mcp2515.conf
    :goals: build flash
 
 Sample output

--- a/samples/subsys/canbus/isotp/README.rst
+++ b/samples/subsys/canbus/isotp/README.rst
@@ -20,7 +20,7 @@ or Nucleo-F746ZG board.
 For the NXP TWR-KE18F board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/CAN
+   :zephyr-app: samples/drivers/can
    :board: twr_ke18f
    :goals: build flash
 


### PR DESCRIPTION
File prj.mcp2515.conf was previously removed from project as it was
made redundant.

Paths containing uppercase CAN were changed to lowercase.