### PR TITLE
heap: create unique variable name

### DIFF
--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -231,9 +231,9 @@ static inline chunksz_t min_chunk_size(struct z_heap *h)
 	return bytes_to_chunksz(h, 1);
 }
 
-static inline size_t chunksz_to_bytes(struct z_heap *h, chunksz_t chunksz)
+static inline size_t chunksz_to_bytes(struct z_heap *h, chunksz_t chunksz_in)
 {
-	return chunksz * CHUNK_UNIT - chunk_header_bytes(h);
+	return chunksz_in * CHUNK_UNIT - chunk_header_bytes(h);
 }
 
 static inline int bucket_idx(struct z_heap *h, chunksz_t sz)


### PR DESCRIPTION
In code is a variable "chunksz_t chunksz" that has the same name as
function "chunksz_t chunksz()" in the one heap.h file.
Create unique variable name to avoid misreading in the future.

Found as a coding guideline violation (MISRA R5.9) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>