### PR TITLE
sched: create unique function name

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -586,7 +586,7 @@ static inline void z_vrfy_k_thread_resume(struct k_thread *thread)
 #include <syscalls/k_thread_resume_mrsh.c>
 #endif
 
-static _wait_q_t *pended_on(struct k_thread *thread)
+static _wait_q_t *pended_on_thread(struct k_thread *thread)
 {
 	__ASSERT_NO_MSG(thread->base.pended_on);
 
@@ -645,7 +645,7 @@ void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 
 static inline void unpend_thread_no_timeout(struct k_thread *thread)
 {
-	_priq_wait_remove(&pended_on(thread)->waitq, thread);
+	_priq_wait_remove(&pended_on_thread(thread)->waitq, thread);
 	z_mark_thread_as_not_pending(thread);
 	thread->base.pended_on = NULL;
 }


### PR DESCRIPTION
In file include/kernel/thread.h in "struct _thread_base" is a member
called "_wait_q_t *pended_on"
At the same time in file kernel/sched.c is function called
"static _wait_q_t *pended_on()"

Coding scanning tool assigns violation (MISRA R5.9) that static
object reused, because thread.h is included in struct.c file.

I think we can rename function to avoid misreading in the future.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>