### PR TITLE
x86: multiboot: Fix NULL pointer dereferences

### DIFF
--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -47,9 +47,11 @@ void z_multiboot_init(struct multiboot_info *info_pa)
 		   sizeof(*info_pa), K_MEM_CACHE_NONE);
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
-	if (info != NULL) {
-		memcpy(&multiboot_info, info, sizeof(*info));
+	if (info == NULL) {
+		return;
 	}
+
+	memcpy(&multiboot_info, info, sizeof(*info));
 
 #ifdef CONFIG_MULTIBOOT_MEMMAP
 	/*


### PR DESCRIPTION
From the point of checking the info pointer value all code in the
z_multiboot_init() function depends on it being non-NULL. Therefore,
simply return from the function if it's NULL.

Fixes #33084

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>