### PR TITLE
coredump_log: coredump log in panic mode

### DIFF
--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -30,9 +30,10 @@ static void coredump_logging_backend_start(void)
 	/* Reset error */
 	error = 0;
 
-	if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
-		LOG_PANIC();
-	}
+	while (LOG_PROCESS())
+		;
+
+	LOG_PANIC();
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
 }
 


### PR DESCRIPTION
Current implementation assumes that CONFIG_LOG_IMMEDIATE=y
guarantees complete transfer, and it is not true.
In my opinion, core dump should always be printed in panic mode.

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>