### PR TITLE
boards: arm: lpcxpresso55s69: Disable flash access for NS

### DIFF
--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
@@ -23,6 +23,7 @@ config UART_MCUX_FLEXCOMM
 config SOC_FLASH_MCUX
 	default y
 	depends on FLASH
+	depends on !TRUSTED_EXECUTION_NONSECURE
 
 config WDT_MCUX_WWDT
 	default y

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -50,8 +50,10 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Enable FRO HF(96MHz) output */
 	CLOCK_SetupFROClocking(96000000U);
 
+#if defined(CONFIG_SOC_FLASH_MCUX)
 	/*!< Set FLASH wait states for core */
 	CLOCK_SetFLASHAccessCyclesForFreq(96000000U);
+#endif
 
     /*!< Set up dividers */
 	CLOCK_SetClkDiv(kCLOCK_DivAhbClk, 1U, false);


### PR DESCRIPTION
When using the LPC55S69 with TF-M, the ROM-based flash
controller is restricted to the secure processing environment
to prevent NS access to flash memory. Any access to the
flash controller will cause a secure fault, and the NS
application will halt execution.

This commit disables access to the IAP flash peripheral
when using the lpcxpresso55s69_ns target, enabling TF-M
to restrict IAP access to the secure side.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>