### PR TITLE
drivers: ieee802154: make keys management API generic

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -96,6 +96,14 @@ struct ieee802154_filter {
 /* @endcond */
 };
 
+struct ieee802154_key {
+	uint8_t *key_value;
+	uint32_t key_frame_counter;
+	bool frame_counter_per_key;
+	uint8_t key_id_mode;
+	uint8_t key_index;
+};
+
 /** IEEE802.15.4 Transmission mode. */
 enum ieee802154_tx_mode {
 	/** Transmit packet immediately, no CCA. */
@@ -203,14 +211,18 @@ struct ieee802154_config {
 		/** ``IEEE802154_CONFIG_EVENT_HANDLER`` */
 		ieee802154_event_cb_t event_handler;
 
-		/** ``IEEE802154_CONFIG_MAC_KEYS`` */
-		struct {
-			uint8_t key_id_mode;
-			uint8_t key_id;
-			uint8_t *prev_key;
-			uint8_t *curr_key;
-			uint8_t *next_key;
-		} mac_keys;
+		/** ``IEEE802154_CONFIG_MAC_KEYS``
+		 *  Pointer to an array containing a list of keys used
+		 *  for MAC encryption. Refer to secKeyIdLookupDescriptor and
+		 *  secKeyDescriptor in IEEE 802.15.4
+		 *
+		 *  key_value field points to a buffer containing the 16 byte
+		 *  key. The buffer is copied by the callee.
+		 *
+		 *  The variable length array is terminated by key_value field
+		 *  set to NULL.
+		 */
+		struct ieee802154_key *mac_keys;
 
 		/** ``IEEE802154_CONFIG_FRAME_COUNTER`` */
 		uint32_t frame_counter;

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -958,12 +958,34 @@ void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode,
 	__ASSERT_NO_MSG(aPrevKey != NULL && aCurrKey != NULL &&
 			aNextKey != NULL);
 
+	uint8_t key_id_mode = aKeyIdMode >> 3;
+
+	struct ieee802154_key keys[] = {
+		{
+			.key_id_mode = key_id_mode,
+			.key_index = aKeyId == 1 ? 0x80 : aKeyId - 1,
+			.key_value = (uint8_t *)aPrevKey->m8,
+			.frame_counter_per_key = false,
+		},
+		{
+			.key_id_mode = key_id_mode,
+			.key_index = aKeyId,
+			.key_value = (uint8_t *)aCurrKey->m8,
+			.frame_counter_per_key = false,
+		},
+		{
+			.key_id_mode = key_id_mode,
+			.key_index = aKeyId == 0x80 ? 1 : aKeyId + 1,
+			.key_value = (uint8_t *)aNextKey->m8,
+			.frame_counter_per_key = false,
+		},
+		{
+			.key_value = NULL,
+		},
+	};
+
 	struct ieee802154_config config = {
-		.mac_keys.key_id_mode = aKeyIdMode,
-		.mac_keys.key_id = aKeyId,
-		.mac_keys.prev_key = (uint8_t *)aPrevKey->m8,
-		.mac_keys.curr_key = (uint8_t *)aCurrKey->m8,
-		.mac_keys.next_key = (uint8_t *)aNextKey->m8,
+		.mac_keys = keys
 	};
 
 	(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_MAC_KEYS,


### PR DESCRIPTION
Keys management API for IEEE 802.15.4 drivers was specific for Thread
protocol. With this change API is more generic and aligned with Thread
needs.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>