### PR TITLE
ipc: rpmsg_service: Add missing log_strdup

### DIFF
--- a/subsys/ipc/rpmsg_service/rpmsg_service.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_service.c
@@ -61,7 +61,7 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 
 			if (err != 0) {
 				LOG_ERR("Creating remote endpoint %s"
-					" failed wirh error %d", name, err);
+					" failed wirh error %d", log_strdup(name), err);
 			} else {
 				endpoints[i].bound = true;
 			}
@@ -70,7 +70,7 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 		}
 	}
 
-	LOG_ERR("Remote endpoint %s not registered locally", name);
+	LOG_ERR("Remote endpoint %s not registered locally", log_strdup(name));
 }
 
 #endif
@@ -146,7 +146,7 @@ int rpmsg_service_register_endpoint(const char *name, rpmsg_ept_cb cb)
 		}
 	}
 
-	LOG_ERR("No free slots to register endpoint %s", name);
+	LOG_ERR("No free slots to register endpoint %s", log_strdup(name));
 
 	return -ENOMEM;
 }


### PR DESCRIPTION
Add missing log_strdup to %s parameters.

Fixes #35580.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>