### PR TITLE
drivers: flash: nrf_qspi_nor: Fix no multithreading configuration

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -399,15 +399,19 @@ static void anomaly_122_uninit(const struct device *dev)
 
 	qspi_lock(dev);
 
-#ifdef CONFIG_MULTITHREADING
-	/* The last thread to finish using the driver uninit the QSPI */
-	(void) k_sem_take(&dev_data->count, K_NO_WAIT);
-	last = (k_sem_count_get(&dev_data->count) == 0);
-#endif
+	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+		/* The last thread to finish using the driver uninit the QSPI */
+		(void) k_sem_take(&dev_data->count, K_NO_WAIT);
+		last = (k_sem_count_get(&dev_data->count) == 0);
+	}
 
 	if (last) {
 		while (nrfx_qspi_mem_busy_check() != NRFX_SUCCESS) {
-			k_msleep(50);
+			if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+				k_msleep(50);
+			} else {
+				k_busy_wait(50000);
+			}
 		}
 
 		nrf_gpio_cfg_output(QSPI_PROP_AT(csn_pins, 0));


### PR DESCRIPTION
File was failing to compile when multithreading was off.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>