### PR TITLE
Bluetooth: HCI: add api for getting advertising handle

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -2673,6 +2673,15 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
  */
 int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
 
+/** @brief Get advertising handle for an advertising set.
+ *
+ * @param adv Advertising set.
+ * @param adv_handle Place to store the advertising handle.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle);
+
 /** @typedef bt_hci_vnd_evt_cb_t
   * @brief Callback type for vendor handling of HCI Vendor-Specific Events.
   *

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2043,6 +2043,18 @@ int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle)
 	return 0;
 }
 
+#if defined(CONFIG_BT_EXT_ADV)
+int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle)
+{
+	if (!atomic_test_bit(adv->flags, BT_ADV_CREATED)) {
+		return -EINVAL;
+	}
+
+	*adv_handle = adv->handle;
+	return 0;
+}
+#endif /* CONFIG_BT_EXT_ADV */
+
 #if defined(CONFIG_BT_HCI_VS_EVT_USER)
 int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 {


### PR DESCRIPTION
Added an API to the HCI header that can be used to retrieve advertising handle information from a given advertising set.