### PR TITLE
[DNM] lib: os: heap: Assume at least one bucket

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4981,7 +4981,7 @@ void k_heap_free(struct k_heap *h, void *mem);
 /* Hand-calculated minimum heap sizes needed to return a successful
  * 1-byte allocation.  See details in lib/os/heap.[ch]
  */
-#define Z_HEAP_MIN_SIZE (sizeof(void *) > 4 ? 56 : 44)
+#define Z_HEAP_MIN_SIZE (sizeof(void *) > 4 ? 56 : 36)
 
 /**
  * @brief Define a static k_heap

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -93,7 +93,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	 * should be correct, and all chunk entries should point into
 	 * valid unused chunks.  Mark those chunks USED, temporarily.
 	 */
-	for (int b = 0; b <= bucket_idx(h, h->end_chunk); b++) {
+	for (int b = 0; b <= bucket_idx_max(h); b++) {
 		chunkid_t c0 = h->buckets[b].next;
 		uint32_t n = 0;
 
@@ -145,7 +145,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	 * pass caught all the blocks and that they now show UNUSED.
 	 * Mark them USED.
 	 */
-	for (int b = 0; b <= bucket_idx(h, h->end_chunk); b++) {
+	for (int b = 0; b <= bucket_idx_max(h); b++) {
 		chunkid_t c0 = h->buckets[b].next;
 		int n = 0;
 
@@ -319,11 +319,11 @@ void sys_heap_stress(void *(*alloc_fn)(void *arg, size_t bytes),
  */
 void heap_print_info(struct z_heap *h, bool dump_chunks)
 {
-	int i, nb_buckets = bucket_idx(h, h->end_chunk) + 1;
+	int i, nb_buckets = bucket_idx_max(h) + 1;
 	size_t free_bytes, allocated_bytes, total, overhead;
 
 	printk("Heap at %p contains %d units in %d buckets\n\n",
-	       chunk_buf(h), h->end_chunk, nb_buckets);
+	       chunk_buf(h), h->end_chunk - chunk_size(h, 0), nb_buckets);
 
 	printk("  bucket#    min units        total      largest      largest\n"
 	       "             threshold       chunks      (units)      (bytes)\n"

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -242,6 +242,11 @@ static inline int bucket_idx(struct z_heap *h, chunksz_t sz)
 	return 31 - __builtin_clz(usable_sz);
 }
 
+static inline int bucket_idx_max(struct z_heap *h)
+{
+	return bucket_idx(h, h->end_chunk - chunk_size(h, 0));
+}
+
 static inline bool size_too_big(struct z_heap *h, size_t bytes)
 {
 	/*


### PR DESCRIPTION
sys_heap needs at least one bucket to operate correctly.  Reserve one
bucket when you calculate the number of buckets for the given heap.
This saves one chunk by removing unused buckets for small heaps.

With this change, we can go down to 36 bytes of heap to allocate the
first byte from it.

I was not sure why a big heap needs 56 bytes.  Could someone please
enlighten me?

sys_heap_print_info() now prints:

```
Heap at 0x5b78 contains 1 units in 1 buckets

  bucket#    min units        total      largest      largest
             threshold       chunks      (units)      (bytes)
  -----------------------------------------------------------
        0            1            1            1            4

Chunk dump:
chunk    0: [*] size=3    left=0    right=3
chunk    3: [-] size=1    left=0    right=4
chunk    4: [*] size=0    left=3    right=4
```

instead of:

```
Heap at 0x5b70 contains 5 units in 3 buckets

  bucket#    min units        total      largest      largest
             threshold       chunks      (units)      (bytes)
  -----------------------------------------------------------
        0            1            1            1            4

Chunk dump:
chunk    0: [*] size=4    left=0    right=4
chunk    4: [-] size=1    left=0    right=5
chunk    5: [*] size=0    left=4    right=5
```

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>