### PR TITLE
devicetree.h: fix DT_ENUM_TOKEN docstring

### DIFF
--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -740,9 +740,9 @@
  *
  * Example usage:
  *
- *     DT_ENUM_TOKEN((DT_NODELABEL(n1), prop) // foo
- *     DT_ENUM_TOKEN((DT_NODELABEL(n2), prop) // FOO
- *     DT_ENUM_TOKEN((DT_NODELABEL(n3), prop) // 123_foo
+ *     DT_ENUM_TOKEN(DT_NODELABEL(n1), prop) // foo
+ *     DT_ENUM_TOKEN(DT_NODELABEL(n2), prop) // FOO
+ *     DT_ENUM_TOKEN(DT_NODELABEL(n3), prop) // 123_foo
  *
  * Notice how:
  *


### PR DESCRIPTION
Remove extraneous parentheses.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>