### PR TITLE
doc: extensions: external_content: only ignore absolute paths

### DIFF
--- a/doc/_extensions/zephyr/external_content.py
+++ b/doc/_extensions/zephyr/external_content.py
@@ -73,8 +73,8 @@ def adjust_includes(
     def _adjust(m):
         directive, fpath = m.groups()
 
-        # ignore absolute paths or existing files
-        if fpath.startswith("/") or (dstpath / fpath).exists():
+        # ignore absolute paths
+        if fpath.startswith("/"):
             fpath_adj = fpath
         else:
             fpath_adj = Path(os.path.relpath(basepath / fpath, dstpath)).as_posix()


### PR DESCRIPTION
When including other rst files (via .. include::) the existence of the
included file may depend on when the _adjust routine is called, so only
ignore absolute paths.