### PR TITLE
cmake: check zephyr version if specified and ZEPHYR_BASE is set

### DIFF
--- a/share/zephyr-package/cmake/ZephyrConfigVersion.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfigVersion.cmake
@@ -54,8 +54,26 @@ if((DEFINED ZEPHYR_BASE) OR (DEFINED ENV_ZEPHYR_BASE))
   # ZEPHYR_BASE is to be used regardless of version.
   if (${ZEPHYR_BASE}/share/zephyr-package/cmake STREQUAL ${CMAKE_CURRENT_LIST_DIR})
     # We are the Zephyr to be used
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-    set(PACKAGE_VERSION_EXACT TRUE)
+
+    set(NO_PRINT_VERSION True)
+    include(${ZEPHYR_BASE}/cmake/version.cmake)
+    # Zephyr uses project version, but CMake package uses PACKAGE_VERSION
+    set(PACKAGE_VERSION ${PROJECT_VERSION})
+    check_zephyr_version()
+
+    if(IS_INCLUDED)
+      # We are included, so we need to ensure that the version of the top-level
+      # package file is returned. This Zephyr version has already been printed
+      # as part of `check_zephyr_version()`
+      if(NOT ${PACKAGE_VERSION_COMPATIBLE}
+        OR (Zephyr_FIND_VERSION_EXACT AND NOT PACKAGE_VERSION_EXACT)
+      )
+        # When Zephyr base is set and we are checked as an included file
+        # (IS_INCLUDED=True), then we are unable to retrieve the version of the
+        # parent Zephyr, therefore just mark it as ignored.
+        set(PACKAGE_VERSION "ignored (ZEPHYR_BASE is set)")
+      endif()
+    endif()
   elseif ((NOT IS_INCLUDED) AND (DEFINED ZEPHYR_BASE))
     check_zephyr_package(ZEPHYR_BASE ${ZEPHYR_BASE} VERSION_CHECK)
   else()


### PR DESCRIPTION
Fixes: #35187

This extends the Zephyr package to also honor version when ZEPHYR_BASE
is set in environment.

Specifying `find_package(Zephyr 2.x.y)` without using ZEPHYR_BASE will
lookup a Zephyr in following order:
- Current repo, if that is a Zephyr repo
- Current west workspace
- Exported Zephyr CMake package for freestanding application
and ensure that the chosen Zephyr meets the version criteria.

When setting ZEPHYR_BASE in environment the version check is disabled
and the Zephyr referenced by ZEPHYR_BASE will always be used regardless
of its version.

A user doing `find_package(Zephyr 2.6.0)` and using ZEPHYR_BASE
presumable still want to ensure that the Zephyr referenced by
ZEPHYR_BASE is v2.6.0 or newer.

Also, `west build` with a freestanding application requires ZEPHYR_BASE
in order for west to lookup the `west build` extension command.

This practically means a user cannot both specify a Zephyr version for a
freestanding application and at the same time use `west build` but has
to use plain CMake to ensure correct version check, see #35187.

With this commit, users will have complete Zephyr package version
checking with freestanding applications
find_package(Zephyr 2.6.0 REQUIRED HINTS $ENV{ZEPHYR_BASE})
find_package(Zephyr 2.6.0 EXACT REQUIRED HINTS $ENV{ZEPHYR_BASE})
when also having ZEPHYR_BASE in environment.

This commit has no behavioral change for those patterns:
find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
find_package(Zephyr 2.6.0 REQUIRED HINTS $ENV{ZEPHYR_BASE})
find_package(Zephyr 2.6.0 EXACT REQUIRED HINTS $ENV{ZEPHYR_BASE})
when ZEPHYR_BASE is not in environment.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>