### PR TITLE
kernel: k_sleep: fix return value for absolute timeout

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1246,8 +1246,11 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 	}
 
 	k_timeout_t timeout = Z_TIMEOUT_TICKS(ticks);
-
-	expected_wakeup_ticks = ticks + sys_clock_tick_get_32();
+	if (Z_TICK_ABS(ticks) <= 0) {
+		expected_wakeup_ticks = ticks + sys_clock_tick_get_32();
+	} else {
+		expected_wakeup_ticks = Z_TICK_ABS(ticks);
+	}
 
 	k_spinlock_key_t key = k_spin_lock(&sched_spinlock);
 


### PR DESCRIPTION
Fixes calculation of remaining ticks returned from z_tick_sleep
so that it takes absolute timeouts into account.

Fixes #32506

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>