### PR TITLE
tests: posix: common: clock: exclude ehl_crb from test posix realtime

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -6,22 +6,22 @@ common:
 
 tests:
   portability.posix.common:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.common.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   portability.posix.common.tls:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
   portability.posix.common.tls.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard ehl_crb
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
> The ehl_crb board uses HPET timer which is susceptible to the bug
> of nonequal monotonic clock and realtime clock at the nanosecond
> level because it is slower. This excludes the board from ns-level
> check. Other boards can still use the ns-level check.

Edit: 
The ehl_crb board has hardware issue that prevents this test from
being able to pass this otherwise-correct test. So exclude ehl_crb
from the testcase.yaml.

Fixes #33544.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>