### PR TITLE
arch: arm64: Fix the assertion failed when MP_NUM_CPUS >= 3

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -99,6 +99,11 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	if (pm_cpu_on(cpu_mpid, (uint64_t)&__start)) {
 		printk("Failed to boot secondary CPU core %d (MPID:%#llx)\n",
 		       cpu_num, cpu_mpid);
+		/*
+		 * If pm_cpu_on failed on core cpu_mpid, Primary core also
+		 * should prepare for up next core
+		 */
+		arm64_cpu_boot_params.mpid = master_core_mpid;
 		return;
 	}
 
@@ -106,6 +111,8 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	while (arm64_cpu_boot_params.fn) {
 		wfe();
 	}
+	/* Prepare for up next core */
+	arm64_cpu_boot_params.mpid = master_core_mpid;
 	printk("Secondary CPU core %d (MPID:%#llx) is up\n", cpu_num, cpu_mpid);
 }
 


### PR DESCRIPTION
"arm64_cpu_boot_params.mpid" should be assigned to "master_core_mpid"
after secondary CPU core up.

Because "arm64_cpu_boot_params.mpid" is used to check the next up CPU
core's mpid is the excepted mpid. After excepted CPU core up, the
"arm64_cpu_boot_params.mpid" doesn't restore to primary CPU core's mpid
and then the primary CPU core try to up third CPU core will crash in
assertion.

Signed-off-by: Huifeng Zhang <Huifeng.Zhang@arm.com>

Fixes: #35652 