### PR TITLE
posix: pthread_exit: check for null before dereferencing

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -379,9 +379,11 @@ void pthread_exit(void *retval)
 
 	SYS_SLIST_FOR_EACH_NODE(&self->key_list, node_l) {
 		thread_spec_data = (pthread_thread_data *)node_l;
-		key_obj = thread_spec_data->key;
-		if ((key_obj->destructor != NULL) && (thread_spec_data != NULL)) {
-			(key_obj->destructor)(thread_spec_data->spec_data);
+		if (thread_spec_data != NULL) {
+			key_obj = thread_spec_data->key;
+			if (key_obj->destructor != NULL) {
+				(key_obj->destructor)(thread_spec_data->spec_data);
+			}
 		}
 	}
 


### PR DESCRIPTION
In a primitive SYS_SLIST_FOR_EACH_NODE check for null was
after dereferencing. Place check for null of the "thread_spec_data"
before its dereferencing.

Found as a coding guideline violation (MISRA R4.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>