### PR TITLE
arch: arc: _reset and _start section fix

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -44,8 +44,8 @@ GTEXT(__start)
  * @return N/A
  */
 
-SECTION_FUNC(TEXT,__reset)
-SECTION_FUNC(TEXT,__start)
+SECTION_SUBSEC_FUNC(TEXT,_reset_and__start,__reset)
+SECTION_SUBSEC_FUNC(TEXT,_reset_and__start,__start)
 	/* lock interrupts: will get unlocked when switch to main task
 	 * also make sure the processor in the correct status
 	 */


### PR DESCRIPTION
SECTION_FUNC allows only one function to reside in a sub-section.
SECTION_SUBSEC_FUNC allows multiple functions to reside in a sub-section.
we should use SECTION_SUBSEC_FUNC for _reset and _start.

Fix: #35653 