### PR TITLE
lib: remove redundant check for null

### DIFF
--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -212,7 +212,7 @@ void mpsc_pbuf_put_word(struct mpsc_pbuf_buffer *buffer,
 
 		k_spin_unlock(&buffer->lock, key);
 
-		if (cont && dropped_item && valid_drop) {
+		if (cont && valid_drop) {
 			/* Notify about item being dropped. */
 			buffer->notify_drop(buffer, dropped_item);
 		}


### PR DESCRIPTION
Statement "cont = dropped_item != NULL" first checks if "dropped_item"
returns null or not null, then assigns to "cont".
If "dropped_item" is null then "cont = 0",
if "dropped_item" is not null then "cont = 1".

As a result in line below no need to check "dropped_item" again
It is enough to check state of the "cont" variable,
to be sure what returned "dropped_item".

Found as a coding guideline violation (MISRA R4.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>