### PR TITLE
drivers/spi: stm32: Revert while loop on tx only

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -294,14 +294,8 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		spi_context_update_tx(&data->ctx, 2, 1);
 	}
 
-	if (data->ctx.rx_buf) {
-		while (!ll_func_rx_is_not_empty(spi)) {
-			/* NOP */
-		}
-	} else {
-		while (!ll_func_tx_is_empty(spi)) {
-			/* NOP */
-		}
+	while (!ll_func_rx_is_not_empty(spi)) {
+		/* NOP */
 	}
 
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {


### PR DESCRIPTION
This commit reverted while loop on tx only.
This commit solves SPI loopback failure and SPI wrong behaviour on RX.

fix:
* zephyrproject-rtos/zephyr#35297
* zephyrproject-rtos/zephyr#35539

Revert "drivers/spi: STM32: This solves SPI infinite loop on Tranceive"

This reverts commit 50c2acbc03e7a48a09880b6fcb8c22256bffa70c.

Signed-off-by: Affrin Pinhero affrin.pinhero@hcl.com