### PR TITLE
lib: put dereferencing expression after pointer null check

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -597,7 +597,6 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			work = CONTAINER_OF(node, struct k_work, node);
 			flag_set(&work->flags, K_WORK_RUNNING_BIT);
 			flag_clear(&work->flags, K_WORK_QUEUED_BIT);
-			handler = work->handler;
 		} else if (flag_test_and_clear(&queue->flags,
 					       K_WORK_QUEUE_DRAIN_BIT)) {
 			/* Not busy and draining: move threads waiting for
@@ -633,7 +632,8 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 
 		if (work != NULL) {
 			bool yield;
-
+			
+			handler = work->handler;
 			__ASSERT_NO_MSG(handler != NULL);
 			handler(work);
 


### PR DESCRIPTION
Dereferencing of the "work" pointer in the expression "work->handler"
necessary to move after we check if "work" is null.

Found as a coding guideline violation (MISRA R4.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>