### PR TITLE
arch: riscv: linker script: add support for rom_start section

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1079,7 +1079,8 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    RODATA       Inside the rodata output section.
 #    ROM_START    Inside the first output section of the image. This option is
 #                 currently only available on ARM Cortex-M, ARM Cortex-R,
-#                 x86, ARC, and openisa_rv32m1.
+#                 x86, ARC, openisa_rv32m1, and RISC-V.
+#                 Note: On RISC-V the rom_start section will be after vector section.
 #    RAM_SECTIONS Inside the RAMABLE_REGION GROUP.
 #    SECTIONS     Near the end of the file. Don't use this when linking into
 #                 RAMABLE_REGION, use RAM_SECTIONS instead.

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -108,6 +108,15 @@ SECTIONS
 		KEEP(*(.vectors.*))
     } GROUP_LINK_IN(ROMABLE_REGION)
 
+    SECTION_PROLOGUE(rom_start,,)
+    {
+		. = ALIGN(16);
+/* Located in generated directory. This file is populated by calling
+ * zephyr_linker_sources(ROM_START ...).
+ */
+#include <snippets-rom-start.ld>
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
     SECTION_PROLOGUE(_RESET_SECTION_NAME,,)
     {
 		KEEP(*(.reset.*))


### PR DESCRIPTION
With this change, we can put contents into rom_start section
by calling zephyr_linker_sources(ROM_START ...)

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>
Change-Id: If1169423b013d3e4df52d91cdb2fbdddc3bace7b