### PR TITLE
segger: rtt: No multithreading support for rtt console

### DIFF
--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -25,7 +25,7 @@ static bool host_present;
  */
 static void wait(void)
 {
-	if (k_is_in_isr()) {
+	if (!IS_ENABLED(CONFIG_MULTITHREADING) || k_is_in_isr()) {
 		if (IS_ENABLED(CONFIG_RTT_TX_RETRY_IN_INTERRUPT)) {
 			k_busy_wait(1000*CONFIG_RTT_TX_RETRY_DELAY_MS);
 		}

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -154,9 +154,11 @@ static int line_out_drop_mode(void)
 		}
 	}
 
+	int ret;
+
 	RTT_LOCK();
-	int ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
-					     line_buf, line_pos - line_buf);
+	ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+					 line_buf, line_pos - line_buf);
 	RTT_UNLOCK();
 
 	if (ret == 0) {
@@ -209,12 +211,12 @@ static int data_out_block_mode(uint8_t *data, size_t length, void *ctx)
 	do {
 		if (!is_sync_mode()) {
 			RTT_LOCK();
-		}
-
-		ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
-						 data, length);
-		if (!is_sync_mode()) {
+			ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+							 data, length);
 			RTT_UNLOCK();
+		} else {
+			ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+							 data, length);
 		}
 
 		if (ret) {

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
       revision: 385e19da1ae15f27872c2543b97276a42f102ead
       path: modules/lib/openthread
     - name: segger
-      revision: 7d78f7121dc4c59396c12e60e34f3617bac5efcb
+      revision: 7cbc8446db9e09ed0ca4e60e48f38e2c330223fe
       path: modules/debug/segger
     - name: sof
       revision: 779f28ed465c03899c8a7d4aaf399856f4e51158


### PR DESCRIPTION
Updated rtt to not use mutexes when multithreading is disabled. Removed `k_sleep` call from rtt_console when multithreading is disabled. Those changes fixes the case when RTT console was failing to compile when multithreading was disabled.