### PR TITLE
VOCS use instance pointer exclusively

### DIFF
--- a/include/bluetooth/audio/vocs.h
+++ b/include/bluetooth/audio/vocs.h
@@ -114,39 +114,36 @@ int bt_vocs_register(struct bt_vocs *vocs,
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn        Connection to peer device, or NULL if local server read.
  * @param inst        The instance pointer.
  * @param err         Error value. 0 on success, GATT error on positive value
  *                    or errno on negative value.
  *                    For notifications, this will always be 0.
  * @param offset      The offset value.
  */
-typedef void (*bt_vocs_state_cb_t)(struct bt_conn *conn, struct bt_vocs *inst,
-				   int err, int16_t offset);
+typedef void (*bt_vocs_state_cb_t)(struct bt_vocs *inst, int err,
+				   int16_t offset);
 
 /**
  * @brief Callback function for setting offset.
  *
- * @param conn        Connection to peer device, or NULL if local server write.
  * @param inst        The instance pointer.
  * @param err         Error value. 0 on success, GATT error on positive value
  *                    or errno on negative value.
  */
-typedef void (*bt_vocs_set_offset_cb_t)(struct bt_conn *conn, struct bt_vocs *inst, int err);
+typedef void (*bt_vocs_set_offset_cb_t)(struct bt_vocs *inst, int err);
 
 /**
  * @brief Callback function for the location.
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  * @param location     The location value.
  */
-typedef void (*bt_vocs_location_cb_t)(struct bt_conn *conn, struct bt_vocs *inst, int err,
+typedef void (*bt_vocs_location_cb_t)(struct bt_vocs *inst, int err,
 				      uint32_t location);
 
 /**
@@ -154,14 +151,13 @@ typedef void (*bt_vocs_location_cb_t)(struct bt_conn *conn, struct bt_vocs *inst
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  * @param description  The description as an UTF-8 encoded string.
  */
-typedef void (*bt_vocs_description_cb_t)(struct bt_conn *conn, struct bt_vocs *inst, int err,
+typedef void (*bt_vocs_description_cb_t)(struct bt_vocs *inst, int err,
 					 char *description);
 
 /**
@@ -171,13 +167,12 @@ typedef void (*bt_vocs_description_cb_t)(struct bt_conn *conn, struct bt_vocs *i
  * includes the Volume Control Offset Service client, and should thus not be
  * set by the application.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  */
-typedef void (*bt_vocs_discover_cb_t)(struct bt_conn *conn, struct bt_vocs *inst, int err);
+typedef void (*bt_vocs_discover_cb_t)(struct bt_vocs *inst, int err);
 
 struct bt_vocs_cb {
 	bt_vocs_state_cb_t              state;
@@ -196,70 +191,63 @@ struct bt_vocs_cb {
  *
  * The value is returned in the bt_vocs_cb.state callback.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_state_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vocs_state_get(struct bt_vocs *inst);
 
 /**
  * @brief Set the Volume Offset Control Service offset state.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param offset        The offset to set (-255 to 255).
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_state_set(struct bt_conn *conn, struct bt_vocs *inst, int16_t offset);
+int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset);
 
 /**
  * @brief Read the Volume Offset Control Service location.
  *
  * The value is returned in the bt_vocs_cb.location callback.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_location_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vocs_location_get(struct bt_vocs *inst);
 
 /**
  * @brief Set the Volume Offset Control Service location.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param location      The location to set.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_location_set(struct bt_conn *conn, struct bt_vocs *inst, uint32_t location);
+int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location);
 
 /**
  * @brief Read the Volume Offset Control Service output description.
  *
  * The value is returned in the bt_vocs_cb.description callback.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_description_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vocs_description_get(struct bt_vocs *inst);
 
 /**
  * @brief Set the Volume Offset Control Service description.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param description   The UTF-8 encoded string description to set.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_vocs_description_set(struct bt_conn *conn, struct bt_vocs *inst,
-			    const char *description);
+int bt_vocs_description_set(struct bt_vocs *inst, const char *description);
 
 /**
  * @brief Registers the callbacks for the Volume Offset Control Service client.

--- a/include/bluetooth/audio/vocs.h
+++ b/include/bluetooth/audio/vocs.h
@@ -120,8 +120,7 @@ int bt_vocs_register(struct bt_vocs *vocs,
  *                    For notifications, this will always be 0.
  * @param offset      The offset value.
  */
-typedef void (*bt_vocs_state_cb_t)(struct bt_vocs *inst, int err,
-				   int16_t offset);
+typedef void (*bt_vocs_state_cb)(struct bt_vocs *inst, int err, int16_t offset);
 
 /**
  * @brief Callback function for setting offset.
@@ -130,7 +129,7 @@ typedef void (*bt_vocs_state_cb_t)(struct bt_vocs *inst, int err,
  * @param err         Error value. 0 on success, GATT error on positive value
  *                    or errno on negative value.
  */
-typedef void (*bt_vocs_set_offset_cb_t)(struct bt_vocs *inst, int err);
+typedef void (*bt_vocs_set_offset_cb)(struct bt_vocs *inst, int err);
 
 /**
  * @brief Callback function for the location.
@@ -143,8 +142,8 @@ typedef void (*bt_vocs_set_offset_cb_t)(struct bt_vocs *inst, int err);
  *                     For notifications, this will always be 0.
  * @param location     The location value.
  */
-typedef void (*bt_vocs_location_cb_t)(struct bt_vocs *inst, int err,
-				      uint32_t location);
+typedef void (*bt_vocs_location_cb)(struct bt_vocs *inst, int err,
+				    uint32_t location);
 
 /**
  * @brief Callback function for the description.
@@ -157,8 +156,8 @@ typedef void (*bt_vocs_location_cb_t)(struct bt_vocs *inst, int err,
  *                     For notifications, this will always be 0.
  * @param description  The description as an UTF-8 encoded string.
  */
-typedef void (*bt_vocs_description_cb_t)(struct bt_vocs *inst, int err,
-					 char *description);
+typedef void (*bt_vocs_description_cb)(struct bt_vocs *inst, int err,
+				       char *description);
 
 /**
  * @brief Callback function for bt_vocs_discover.
@@ -172,17 +171,17 @@ typedef void (*bt_vocs_description_cb_t)(struct bt_vocs *inst, int err,
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  */
-typedef void (*bt_vocs_discover_cb_t)(struct bt_vocs *inst, int err);
+typedef void (*bt_vocs_discover_cb)(struct bt_vocs *inst, int err);
 
 struct bt_vocs_cb {
-	bt_vocs_state_cb_t              state;
-	bt_vocs_location_cb_t           location;
-	bt_vocs_description_cb_t        description;
+	bt_vocs_state_cb                state;
+	bt_vocs_location_cb             location;
+	bt_vocs_description_cb          description;
 
 #if defined(CONFIG_BT_VOCS_CLIENT)
 	/* Client only */
-	bt_vocs_discover_cb_t           discover;
-	bt_vocs_set_offset_cb_t         set_offset;
+	bt_vocs_discover_cb             discover;
+	bt_vocs_set_offset_cb           set_offset;
 #endif /* CONFIG_BT_VOCS_CLIENT */
 };
 

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -675,11 +675,11 @@ int bt_vcs_vocs_state_get(struct bt_conn *conn, struct bt_vocs *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_state_get(conn, inst);
+		return bt_vocs_state_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_state_get(NULL, inst);
+		return bt_vocs_state_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -689,11 +689,11 @@ int bt_vcs_vocs_location_get(struct bt_conn *conn, struct bt_vocs *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_location_get(conn, inst);
+		return bt_vocs_location_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_location_get(NULL, inst);
+		return bt_vocs_location_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -704,11 +704,11 @@ int bt_vcs_vocs_location_set(struct bt_conn *conn, struct bt_vocs *inst,
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_location_set(conn, inst, location);
+		return bt_vocs_location_set(inst, location);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_location_set(NULL, inst, location);
+		return bt_vocs_location_set(inst, location);
 	}
 
 	return -EOPNOTSUPP;
@@ -719,11 +719,11 @@ int bt_vcs_vocs_state_set(struct bt_conn *conn, struct bt_vocs *inst,
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_state_set(conn, inst, offset);
+		return bt_vocs_state_set(inst, offset);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_state_set(NULL, inst, offset);
+		return bt_vocs_state_set(inst, offset);
 	}
 
 	return -EOPNOTSUPP;
@@ -733,11 +733,11 @@ int bt_vcs_vocs_description_get(struct bt_conn *conn, struct bt_vocs *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_description_get(conn, inst);
+		return bt_vocs_description_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_description_get(NULL, inst);
+		return bt_vocs_description_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -748,11 +748,11 @@ int bt_vcs_vocs_description_set(struct bt_conn *conn, struct bt_vocs *inst,
 {
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_VOCS) &&
 	    conn && bt_vcs_client_valid_vocs_inst(conn, inst)) {
-		return bt_vocs_description_set(conn, inst, description);
+		return bt_vocs_description_set(inst, description);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_VOCS) && !conn && valid_vocs_inst(inst)) {
-		return bt_vocs_description_set(NULL, inst, description);
+		return bt_vocs_description_set(inst, description);
 	}
 
 	return -EOPNOTSUPP;

--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -69,18 +69,19 @@ struct bt_vocs_server {
 };
 
 struct bt_vocs {
+	bool client_instance;
 	union {
 		struct bt_vocs_server srv;
 		struct bt_vocs_client cli;
 	};
 };
 
-int bt_vocs_client_state_get(struct bt_conn *conn, struct bt_vocs *inst);
-int bt_vocs_client_state_set(struct bt_conn *conn, struct bt_vocs *inst, int16_t offset);
-int bt_vocs_client_location_get(struct bt_conn *conn, struct bt_vocs *inst);
-int bt_vocs_client_location_set(struct bt_conn *conn, struct bt_vocs *inst, uint32_t location);
-int bt_vocs_client_description_get(struct bt_conn *conn, struct bt_vocs *inst);
-int bt_vocs_client_description_set(struct bt_conn *conn, struct bt_vocs *inst,
+int bt_vocs_client_state_get(struct bt_vocs *inst);
+int bt_vocs_client_state_set(struct bt_vocs *inst, int16_t offset);
+int bt_vocs_client_location_get(struct bt_vocs *inst);
+int bt_vocs_client_location_set(struct bt_vocs *inst, uint32_t location);
+int bt_vocs_client_description_get(struct bt_vocs *inst);
+int bt_vocs_client_description_set(struct bt_vocs *inst,
 				   const char *description);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_VOCS_INTERNAL_ */

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -104,8 +104,7 @@ static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 			    inst, description);
 	}
 }
-static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
-			  int16_t offset)
+static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err) {
 		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
@@ -115,8 +114,7 @@ static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
 	}
 }
 
-static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			     int err, uint32_t location)
+static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -128,8 +126,8 @@ static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				int err, char *description)
+static void vocs_description_cb(struct bt_vocs *inst, int err,
+				char *description)
 {
 	if (err) {
 		shell_error(ctx_shell,

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -244,8 +244,7 @@ static void vcs_aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 #endif /* CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0 */
 
 #if CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST > 0
-static void vcs_vocs_set_offset_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				   int err)
+static void vcs_vocs_set_offset_cb(struct bt_vocs *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Set offset failed (%d) for inst %p",
@@ -255,8 +254,7 @@ static void vcs_vocs_set_offset_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vcs_vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			      int err, int16_t offset)
+static void vcs_vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
@@ -266,8 +264,8 @@ static void vcs_vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vcs_vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				 int err, uint32_t location)
+static void vcs_vocs_location_cb(struct bt_vocs *inst, int err,
+				 uint32_t location)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -279,8 +277,8 @@ static void vcs_vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 }
 
-static void vcs_vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				    int err, char *description)
+static void vcs_vocs_description_cb(struct bt_vocs *inst, int err,
+				    char *description)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -69,8 +69,7 @@ static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 	g_cb = true;
 }
 
-static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
-			  int16_t offset)
+static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err) {
 		FAIL("VOCS state cb err (%d)", err);
@@ -82,8 +81,7 @@ static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
 	g_cb = true;
 }
 
-static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			     int err, uint32_t location)
+static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
 	if (err) {
 		FAIL("VOCS location cb err (%d)", err);
@@ -95,8 +93,8 @@ static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	g_cb = true;
 }
 
-static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				int err, char *description)
+static void vocs_description_cb(struct bt_vocs *inst, int err,
+				char *description)
 {
 	if (err) {
 		FAIL("VOCS description cb err (%d)", err);
@@ -114,7 +112,7 @@ static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	g_cb = true;
 }
 
-static void vocs_write_cb(struct bt_conn *conn, struct bt_vocs *inst, int err)
+static void vocs_write_cb(struct bt_vocs *inst, int err)
 {
 	if (err) {
 		FAIL("VOCS write failed (%d)\n", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -73,8 +73,7 @@ static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 	}
 }
 
-static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
-			  int16_t offset)
+static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err) {
 		FAIL("VOCS state cb err (%d)", err);
@@ -82,14 +81,10 @@ static void vocs_state_cb(struct bt_conn *conn, struct bt_vocs *inst, int err,
 	}
 
 	g_vocs_offset = offset;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
-			     int err, uint32_t location)
+static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
 	if (err) {
 		FAIL("VOCS location cb err (%d)", err);
@@ -97,14 +92,11 @@ static void vocs_location_cb(struct bt_conn *conn, struct bt_vocs *inst,
 	}
 
 	g_vocs_location = location;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
-				int err, char *description)
+static void vocs_description_cb(struct bt_vocs *inst, int err,
+				char *description)
 {
 	if (err) {
 		FAIL("VOCS description cb err (%d)", err);
@@ -113,10 +105,7 @@ static void vocs_description_cb(struct bt_conn *conn, struct bt_vocs *inst,
 
 	strncpy(g_vocs_desc, description, sizeof(g_vocs_desc) - 1);
 	g_vocs_desc[sizeof(g_vocs_desc) - 1] = '\0';
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
 static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,


### PR DESCRIPTION
Instead of using a bt_conn and a bt_vocs pointer, VOCS will now only use the bt_vocs pointer for a simplified API. 

This is part of a larger change to remove the bt_conn pointer from VOCS, AICS, VCS and MICS. 