### PR TITLE
lib: os: heap-validate: Fix wrong chunkid returned by max_chunkid()

### DIFF
--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -17,17 +17,12 @@
  * running one and corrupting it. YMMV.
  */
 
-static chunkid_t max_chunkid(struct z_heap *h)
-{
-	return h->end_chunk - min_chunk_size(h);
-}
-
 #define VALIDATE(cond) do { if (!(cond)) { return false; } } while (0)
 
 static bool in_bounds(struct z_heap *h, chunkid_t c)
 {
 	VALIDATE(c >= right_chunk(h, 0));
-	VALIDATE(c <= max_chunkid(h));
+	VALIDATE(c < h->end_chunk);
 	VALIDATE(chunk_size(h, c) < h->end_chunk);
 	return true;
 }
@@ -80,7 +75,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	/*
 	 * Walk through the chunks linearly, verifying sizes and end pointer.
 	 */
-	for (c = right_chunk(h, 0); c <= max_chunkid(h); c = right_chunk(h, c)) {
+	for (c = right_chunk(h, 0); c < h->end_chunk; c = right_chunk(h, c)) {
 		if (!valid_chunk(h, c)) {
 			return false;
 		}
@@ -126,7 +121,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	 * USED.
 	 */
 	chunkid_t prev_chunk = 0;
-	for (c = right_chunk(h, 0); c <= max_chunkid(h); c = right_chunk(h, c)) {
+	for (c = right_chunk(h, 0); c < h->end_chunk; c = right_chunk(h, c)) {
 		if (!chunk_used(h, c) && !solo_free_header(h, c)) {
 			return false;
 		}
@@ -164,7 +159,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 	/* Now we are valid, but have managed to invert all the in-use
 	 * fields.  One more linear pass to fix them up
 	 */
-	for (c = right_chunk(h, 0); c <= max_chunkid(h); c = right_chunk(h, c)) {
+	for (c = right_chunk(h, 0); c < h->end_chunk; c = right_chunk(h, c)) {
 		set_chunk_used(h, c, !chunk_used(h, c));
 	}
 	return true;

--- a/tests/lib/heap/src/main.c
+++ b/tests/lib/heap/src/main.c
@@ -38,6 +38,7 @@
 
 #define BIG_HEAP_SZ MIN(256 * 1024, MEMSZ / 3)
 #define SMALL_HEAP_SZ MIN(BIG_HEAP_SZ, 2048)
+#define SOLO_FREE_HEADER_HEAP_SZ (64)
 #define SCRATCH_SZ (sizeof(heapmem) / 2)
 
 /* The test memory.  Make them pointer arrays for robust alignment
@@ -204,6 +205,36 @@ static void test_big_heap(void)
 	log_result(BIG_HEAP_SZ, &result);
 }
 
+/* Test a heap with a solo free header.  A solo free header can exist
+ * only on a heap with 64 bit CPU (or chunk_header_bytes() == 8).
+ * With 64 bytes heap and 1 byte allocation on a big heap, we get:
+ *
+ *   0   1   2   3   4   5   6   7
+ * | h | h | b | b | c | 1 | s | f |
+ *
+ * where
+ * - h: chunk0 header
+ * - b: buckets in chunk0
+ * - c: chunk header for the first allocation
+ * - 1: chunk mem
+ * - s: solo free header
+ * - f: end marker / footer
+ */
+static void test_solo_free_header(void)
+{
+	struct sys_heap heap;
+
+	TC_PRINT("Testing solo free header in a heap\n");
+
+	sys_heap_init(&heap, heapmem, SOLO_FREE_HEADER_HEAP_SZ);
+	if (sizeof(void *) > 4U) {
+		sys_heap_alloc(&heap, 1);
+		zassert_true(sys_heap_validate(&heap), "");
+	} else {
+		ztest_test_skip();
+	}
+}
+
 /* Simple clobber detection */
 void realloc_fill_block(uint8_t *p, size_t sz)
 {
@@ -329,7 +360,8 @@ void test_main(void)
 			 ztest_unit_test(test_realloc),
 			 ztest_unit_test(test_small_heap),
 			 ztest_unit_test(test_fragmentation),
-			 ztest_unit_test(test_big_heap)
+			 ztest_unit_test(test_big_heap),
+			 ztest_unit_test(test_solo_free_header)
 			 );
 
 	ztest_run_test_suite(lib_heap_test);


### PR DESCRIPTION
While working on #35637, I've found a bug in heap validation code.  The added test fails if you don't apply this change. Please review.

--- >8 ---

With 64 bytes heap and 1 byte allocation on a big heap, we get:

  0   1   2   3   4   5   6   7
| h | h | b | b | c | 1 | s | f |

where
  - h: chunk0 header
  - b: buckets in chunk0
  - c: chunk header for the first allocation
  - 1: chunk mem
  - s: solo free header
  - f: end marker / footer

max_chunkid() was returning h->end_chunk - min_chunk_size(h), which is
5 because min_chunk_size() on a big heap is 2.  This works if you
don't have the solo free header at 6 and the heap is like:

  0   1   2   3   4   5   6
| h | h | b | b | c | 1 | f |

max_chunkid() in this case gives you 6 - 2 = 4, which is the right
chunkid for the last chunk header.

This commit replaces max_chunkid() with h->end_chunk and "<=" (less
than or equal to) with "<" (less than), so that it always compares
against the end maker chunkid, but the code won't touch the end maker
itself.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>