### PR TITLE
samples: tensorflow: Fix sample path

### DIFF
--- a/samples/modules/tensorflow/hello_world/README.rst
+++ b/samples/modules/tensorflow/hello_world/README.rst
@@ -34,7 +34,7 @@ on any sensors.
 This application can be built and executed on QEMU as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/tensorflow/hello_world
+   :zephyr-app: samples/modules/tensorflow/hello_world
    :host-os: unix
    :board: qemu_x86
    :goals: run


### PR DESCRIPTION
Otherwise documentation mentions wrong path in the `west`  options.