### PR TITLE
Fix qdec_sam driver implementation

### DIFF
--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT atmel_sam_tc
+#define DT_DRV_COMPAT atmel_sam_tc_qdec
 
 /** @file
  * @brief Atmel SAM MCU family Quadrature Decoder (QDEC/TC) driver.

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -357,7 +357,7 @@
 
 		tc0: tc@4000C000 {
 			compatible = "atmel,sam-tc";
-			reg = <0x4000C000 0x100>;
+			reg = <0x4000c000 0x100>;
 			interrupts = <23 0
 				      24 0
 				      25 0>;

--- a/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
+++ b/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAM Timer Counter (TC) QDEC node
+
+compatible: "atmel,sam-tc-qdec"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    label:
+      required: true
+
+    peripheral-id:
+      type: array
+      description: peripheral ID
+      required: true
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        PIO pin configuration for Timer Counter signals.  We expect that
+        the phandles will reference pinctrl nodes.  These nodes will
+        have a nodelabel that matches the Atmel SoC HAL defines and
+        be of the form p<port><pin><periph>_<inst>_<signal>.
+
+        In Quadrature Decoder mode TIOA0 & TIOB0 signals are expected
+
+        For example the TC0 on SAME7x would be
+           pinctrl-0 = <&pa0b_tc0_tioa0 &pa1b_tc0_tiob0>;

--- a/samples/sensor/qdec/boards/sam_e70_xplained.overlay
+++ b/samples/sensor/qdec/boards/sam_e70_xplained.overlay
@@ -5,6 +5,7 @@
  */
 
 &tc0 {
+	compatible = "atmel,sam-tc-qdec";
 	status = "okay";
 	pinctrl-0 = <&pa0b_tc0_tioa0 &pa1b_tc0_tiob0>;
 	label = "QDEC_0";


### PR DESCRIPTION
This fixes the original implementation introduced in #33360.

The driver used incorrectly compatible `atmel,sam-tc` which should be reserved for the future counter driver. This PR changes the compatible to `atmel,sam-tc-qdec`. This will allow mixing QDEC and counter driver instances.

The PR fixes also one minor DTS warning where an uppercase letter has been used in the value of reg address property.
```
Warning: /soc/tc@4000C000: simple-bus unit address format error, expected "4000c000"
```