### PR TITLE
tests: ztest: Use #if defined()

### DIFF
--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -111,8 +111,8 @@ __no_optimization static void trigger_fault_divide_zero(void)
  * zero exception. We only skip the QEMU board here, this means this
  * test will still apply on the physical board.
  */
-#if (defined(CONFIG_SOC_SERIES_MPS2) && (CONFIG_QEMU_TARGET)) || \
-	(CONFIG_BOARD_QEMU_CORTEX_A53) || (CONFIG_SOC_QEMU_ARC)
+#if (defined(CONFIG_SOC_SERIES_MPS2) && defined(CONFIG_QEMU_TARGET)) || \
+	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || defined(CONFIG_SOC_QEMU_ARC)
 	ztest_test_skip();
 #endif
 }


### PR DESCRIPTION
This compile test should be checking if a symbol has been defined,
otherwise it is using the kconfig value directly.  This fixes a warning

../src/main.c:115:37: warning: "CONFIG_SOC_QEMU_ARC" is not defined,
evaluates to 0 [-Wundef]

when using the -Wundef flag.

Signed-off-by: Bradley Bolen <bbolen@lexmark.com>