### PR TITLE
Cortex-R: Use .macro for common assembly code

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/exc.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc.S
@@ -38,6 +38,64 @@ GTEXT(z_arm_undef_instruction)
 GTEXT(z_arm_prefetch_abort)
 GTEXT(z_arm_data_abort)
 
+.macro exception_entry mode
+	/*
+	 * Store r0-r3, r12, lr, lr_und and spsr_und into the stack to
+	 * construct an exception stack frame.
+	 */
+	srsdb sp!, #\mode
+	stmfd sp, {r0-r3, r12, lr}^
+	sub sp, #24
+
+	/*
+	 * Create new esf struct for exception handler debug.  The first
+	 * time the basic stack frame is saved is for getting in and out
+	 * of the exception.
+	 */
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	sub sp, #___callee_saved_t_SIZEOF
+	sub sp, #___extra_esf_info_t_SIZEOF
+#endif
+
+	srsdb sp!, #\mode
+	stmfd sp, {r0-r3, r12, lr}^
+	sub sp, #24
+
+	/* Increment exception nesting count */
+	ldr r2, =_kernel
+	ldr r0, [r2, #_kernel_offset_to_nested]
+	add r0, r0, #1
+	str r0, [r2, #_kernel_offset_to_nested]
+
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	/* Pointer to extra esf info */
+	add r0, sp, #___basic_sf_t_SIZEOF
+	mov r1, #0
+	str r1, [r0, #4]
+	str r1, [r0, #8]
+
+	/* Pointer to callee saved registers */
+	add r1, r0, #___extra_esf_info_t_SIZEOF
+	str r1, [r0]
+
+	cps #MODE_SYS
+	stm r1, {r4-r11, sp}
+	cps #\mode
+#endif
+
+	/* Invoke fault handler */
+	mov r0, sp
+.endm
+
+.macro exception_exit
+	/* Exit exception */
+	add sp, sp, #___basic_sf_t_SIZEOF
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	add sp, #___extra_esf_info_t_SIZEOF
+	add sp, #___callee_saved_t_SIZEOF
+#endif
+.endm
+
 /**
  * @brief Undefined instruction exception handler
  *
@@ -57,60 +115,10 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	subne lr, #2	/* Thumb (T_BIT) */
 	pop {r0}
 
-	/*
-	 * Store r0-r3, r12, lr, lr_und and spsr_und into the stack to
-	 * construct an exception stack frame.
-	 */
-	srsdb sp!, #MODE_UND
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/*
-	 * Create new esf struct for exception handler debug.  The first
-	 * time the basic stack frame is saved is for getting in and out
-	 * of the exception.
-	 */
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	sub sp, #___callee_saved_t_SIZEOF
-	sub sp, #___extra_esf_info_t_SIZEOF
-#endif
-
-	srsdb sp!, #MODE_UND
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/* Increment exception nesting count */
-	ldr r2, =_kernel
-	ldr r0, [r2, #_kernel_offset_to_nested]
-	add r0, r0, #1
-	str r0, [r2, #_kernel_offset_to_nested]
-
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	/* Pointer to extra esf info */
-	add r0, sp, #___basic_sf_t_SIZEOF
-	mov r1, #0
-	str r1, [r0, #4]
-	str r1, [r0, #8]
-
-	/* Pointer to callee saved registers */
-	add r1, r0, #___extra_esf_info_t_SIZEOF
-	str r1, [r0]
-
-	cps #MODE_SYS
-	stm r1, {r4-r11, sp}
-	cps #MODE_UND
-#endif
-
-	/* Invoke fault handler */
-	mov r0, sp
+	exception_entry MODE_UND
 	bl z_arm_fault_undef_instruction
+	exception_exit
 
-	/* Exit exception */
-	add sp, sp, #___basic_sf_t_SIZEOF
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	add sp, #___extra_esf_info_t_SIZEOF
-	add sp, #___callee_saved_t_SIZEOF
-#endif
 	b z_arm_exc_exit
 
 /**
@@ -126,60 +134,10 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_prefetch_abort)
 	 */
 	sub lr, #4
 
-	/*
-	 * Store r0-r3, r12, lr, lr_abt and spsr_abt into the stack to
-	 * construct an exception stack frame.
-	 */
-	srsdb sp!, #MODE_ABT
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/*
-	 * Create new esf struct for exception handler debug.  The first
-	 * time the basic stack frame is saved is for getting in and out
-	 * of the exception.
-	 */
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	sub sp, #___callee_saved_t_SIZEOF
-	sub sp, #___extra_esf_info_t_SIZEOF
-#endif
-
-	srsdb sp!, #MODE_ABT
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/* Increment exception nesting count */
-	ldr r2, =_kernel
-	ldr r0, [r2, #_kernel_offset_to_nested]
-	add r0, r0, #1
-	str r0, [r2, #_kernel_offset_to_nested]
-
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	/* Pointer to extra esf info */
-	add r0, sp, #___basic_sf_t_SIZEOF
-	mov r1, #0
-	str r1, [r0, #4]
-	str r1, [r0, #8]
-
-	/* Pointer to callee saved registers */
-	add r1, r0, #___extra_esf_info_t_SIZEOF
-	str r1, [r0]
-
-	cps #MODE_SYS
-	stm r1, {r4-r11, sp}
-	cps #MODE_ABT
-#endif
-
-	/* Invoke fault handler */
-	mov r0, sp
+	exception_entry MODE_ABT
 	bl z_arm_fault_prefetch
+	exception_exit
 
-	/* Exit exception */
-	add sp, sp, #___basic_sf_t_SIZEOF
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	add sp, #___extra_esf_info_t_SIZEOF
-	add sp, #___callee_saved_t_SIZEOF
-#endif
 	b z_arm_exc_exit
 
 /**
@@ -196,58 +154,8 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_data_abort)
 	 */
 	sub lr, #8
 
-	/*
-	 * Store r0-r3, r12, lr, lr_abt and spsr_abt into the stack to
-	 * construct an exception stack frame.
-	 */
-	srsdb sp!, #MODE_ABT
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/*
-	 * Create new esf struct for exception handler debug.  The first
-	 * time the basic stack frame is saved is for getting in and out
-	 * of the exception.
-	 */
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	sub sp, #___callee_saved_t_SIZEOF
-	sub sp, #___extra_esf_info_t_SIZEOF
-#endif
-
-	srsdb sp!, #MODE_ABT
-	stmfd sp, {r0-r3, r12, lr}^
-	sub sp, #24
-
-	/* Increment exception nesting count */
-	ldr r2, =_kernel
-	ldr r0, [r2, #_kernel_offset_to_nested]
-	add r0, r0, #1
-	str r0, [r2, #_kernel_offset_to_nested]
-
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	/* Pointer to extra esf info */
-	add r0, sp, #___basic_sf_t_SIZEOF
-	mov r1, #0
-	str r1, [r0, #4]
-	str r1, [r0, #8]
-
-	/* Pointer to callee saved registers */
-	add r1, r0, #___extra_esf_info_t_SIZEOF
-	str r1, [r0]
-
-	cps #MODE_SYS
-	stm r1, {r4-r11, sp}
-	cps #MODE_ABT
-#endif
-
-	/* Invoke fault handler */
-	mov r0, sp
+	exception_entry MODE_ABT
 	bl z_arm_fault_data
+	exception_exit
 
-	/* Exit exception */
-	add sp, sp, #___basic_sf_t_SIZEOF
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	add sp, #___extra_esf_info_t_SIZEOF
-	add sp, #___callee_saved_t_SIZEOF
-#endif
 	b z_arm_exc_exit

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -680,7 +680,7 @@ _oops:
 
 GTEXT(z_arm_cortex_r_svc)
 SECTION_FUNC(TEXT, z_arm_cortex_r_svc)
-    svc #0
+    svc #_SVC_CALL_CONTEXT_SWITCH
     bx lr
 
 #else


### PR DESCRIPTION
A couple of cleanups for Cortex-R.  Use a define for the svc call instead of a hardcoded number.  Factor out some exception code into an assembly macro to make exception handling clearer.