### PR TITLE
pm: device: Get rid of core devices list

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -15,8 +15,6 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-typedef uint16_t device_idx_t;
-
 extern const struct device __device_start[];
 extern const struct device __device_end[];
 
@@ -26,7 +24,7 @@ extern const struct device __device_end[];
 static const struct device *pm_devices[CONFIG_PM_MAX_DEVICES];
 
 /* Number of devices successfully suspended. */
-static device_idx_t num_susp = 0;
+static size_t num_susp;
 
 static bool should_suspend(const struct device *dev, uint32_t state)
 {
@@ -106,7 +104,7 @@ int pm_force_suspend_devices(void)
 
 void pm_resume_devices(void)
 {
-	device_idx_t i;
+	size_t i;
 
 	for (i = 0; i < num_susp; i++) {
 		pm_device_state_set(pm_devices[i],

--- a/subsys/pm/policy/pm_policy.h
+++ b/subsys/pm/policy/pm_policy.h
@@ -14,11 +14,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Function to create device PM list
- */
-void pm_create_device_list(void);
-
-/**
  * @brief Function to suspend the devices in PM device list
  */
 int pm_suspend_devices(void);

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -283,14 +283,3 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 
 	return ret;
 }
-
-#if CONFIG_PM_DEVICE
-static int pm_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	pm_create_device_list();
-	return 0;
-}
-SYS_INIT(pm_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif /* CONFIG_PM_DEVICE */


### PR DESCRIPTION
Use device tree dependencies between devices to replace hardcoded core devices.

Fixes zephyrproject-rtos#34214