### PR TITLE
scripts: gen_syscall: ignore Coverity overrun check

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -193,6 +193,12 @@ def wrapper_defs(func_name, func_type, args):
               % (len(mrsh_args),
                  ", ".join(mrsh_args + [syscall_id])))
 
+    # Coverity does not understand syscall mechanism
+    # and will already complain when any function argument
+    # is not of exact size as uintptr_t. So tell Coverity
+    # to ignore this particular rule here.
+    wrap += "\t\t/* coverity[OVERRUN] */\n"
+
     if ret64:
         wrap += "\t\t" + "(void)%s;\n" % invoke
         wrap += "\t\t" + "return (%s)ret64;\n" % func_type


### PR DESCRIPTION
Coverity does not understand syscall mechanism and will already
complain when any function argument is not of exact size as
uintptr_t. So tell Coverity to ignore this particular rule here.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>