### PR TITLE
Various fixes for NIOS2 MAX10

### DIFF
--- a/boards/nios2/altera_max10/doc/index.rst
+++ b/boards/nios2/altera_max10/doc/index.rst
@@ -235,7 +235,7 @@ You will see output similar to the following:
    63      GEN_ABSOLUTE_SYM(__ISR_LIST_SIZEOF, sizeof(struct _isr_list));
    (gdb) b _PrepC
    Breakpoint 1 at 0xdf0: file /projects/zephyr/arch/nios2/core/prep_c.c, line 36.
-   (gdb) b _Cstart
+   (gdb) b z_cstart
    Breakpoint 2 at 0x1254: file /projects/zephyr/kernel/init.c, line 348.
    (gdb) c
    Continuing.

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -34,9 +34,9 @@
 		interrupt-parent = <&cpu>;
 		ranges;
 
-		uart0: uart@f0008000 {
+		uart0: uart@100000 {
 			compatible = "ns16550";
-			reg = <0xf0008000 0x400>;
+			reg = <0x100000 0x400>;
 			clock-frequency = <50000000>;
 			interrupts = <1 0>;
 			label = "UART_0";

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -22,7 +22,7 @@
 #include <devicetree.h>
 #include <arch/nios2/nios2.h>
 #include <arch/common/sys_bitops.h>
-#include <arch/common/sys_io.h>
+#include <sys/sys_io.h>
 #include <arch/common/ffs.h>
 
 #define ARCH_STACK_PTR_ALIGN  4

--- a/include/arch/nios2/asm_inline_gcc.h
+++ b/include/arch/nios2/asm_inline_gcc.h
@@ -14,7 +14,43 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
+#include <sys/sys_io.h>
 #include <toolchain.h>
+
+/* Using the *io variants of these instructions to prevent issues on
+ * devices that have an instruction/data cache
+ */
+
+static ALWAYS_INLINE void sys_write32(uint32_t data, mm_reg_t addr)
+{
+	__builtin_stwio((void *)addr, data);
+}
+
+static ALWAYS_INLINE uint32_t sys_read32(mm_reg_t addr)
+{
+	return __builtin_ldwio((void *)addr);
+}
+
+static ALWAYS_INLINE void sys_write8(uint8_t data, mm_reg_t addr)
+{
+	sys_write32(data, addr);
+}
+
+static ALWAYS_INLINE uint8_t sys_read8(mm_reg_t addr)
+{
+	return __builtin_ldbuio((void *)addr);
+}
+
+static ALWAYS_INLINE void sys_write16(uint16_t data, mm_reg_t addr)
+{
+	sys_write32(data, addr);
+}
+
+static ALWAYS_INLINE uint16_t sys_read16(mm_reg_t addr)
+{
+	return __builtin_ldhuio((void *)addr);
+}
+
 #endif /* _ASMLANGUAGE */
 
 #endif /* _ASM_INLINE_GCC_PUBLIC_GCC_H */

--- a/include/arch/nios2/nios2.h
+++ b/include/arch/nios2/nios2.h
@@ -55,7 +55,7 @@ extern "C"
 
 #include <zephyr/types.h>
 #include <arch/cpu.h>
-#include <arch/common/sys_io.h>
+#include <sys/sys_io.h>
 
 /*
  * Functions for accessing select Nios II general-purpose registers.


### PR DESCRIPTION

﻿- nios2: max10: fix uart0 base register
- nios2: revert back to builtin sys_io functions
- boards: max10: fix function name in debug section

Fixes #35694