### PR TITLE
serial: introduce CONFIG_UART_USE_RUNTIME_CONFIGURE

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -31,6 +31,21 @@ config SERIAL_SUPPORT_INTERRUPT
 	  This is an option to be enabled by individual serial driver
 	  to signal that the driver and hardware supports interrupts.
 
+config UART_USE_RUNTIME_CONFIGURE
+	bool "Enable runtime configuration for UART controllers"
+	default y
+	help
+	  Enable runtime configuration of UART controllers.
+	  This allows applications to call uart_configure() to
+	  configure the UART controllers at runtime, and calling
+	  uart_config_get() to retrieve configuration. If this is
+	  disabled, UART controllers rely on UART driver's
+	  initialization function to properly configure
+	  the controller.
+
+	  Say y if unsure. Disable this to reduce footprint for
+	  applications that do not require runtime UART configuration.
+
 config UART_ASYNC_API
 	bool "Enable new asynchronous UART API [EXPERIMENTAL]"
 	depends on SERIAL_SUPPORT_ASYNC

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -199,6 +199,7 @@ static int apbuart_err_check(const struct device *dev)
 	return err;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int get_baud(volatile struct apbuart_regs *const regs)
 {
 	unsigned int core_clk_hz;
@@ -302,6 +303,7 @@ static int apbuart_config_get(const struct device *dev, struct uart_config *cfg)
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void apbuart_isr(const struct device *dev);
@@ -499,8 +501,10 @@ static const struct uart_driver_api apbuart_driver_api = {
 	.poll_in                = apbuart_poll_in,
 	.poll_out               = apbuart_poll_out,
 	.err_check              = apbuart_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure              = apbuart_configure,
 	.config_get             = apbuart_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill              = apbuart_fifo_fill,
 	.fifo_read              = apbuart_fifo_read,

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -186,12 +186,14 @@ static int uart_cc13xx_cc26xx_configure(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_cc13xx_cc26xx_config_get(const struct device *dev,
 					 struct uart_config *cfg)
 {
 	*cfg = get_dev_data(dev)->uart_config;
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
@@ -473,8 +475,10 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 	.poll_in = uart_cc13xx_cc26xx_poll_in,
 	.poll_out = uart_cc13xx_cc26xx_poll_out,
 	.err_check = uart_cc13xx_cc26xx_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_cc13xx_cc26xx_configure,
 	.config_get = uart_cc13xx_cc26xx_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_cc13xx_cc26xx_fifo_fill,
 	.fifo_read = uart_cc13xx_cc26xx_fifo_read,

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -161,6 +161,7 @@ static int uart_esp32_err_check(const struct device *dev)
 	return err;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_esp32_config_get(const struct device *dev,
 				 struct uart_config *cfg)
 {
@@ -186,6 +187,7 @@ static int uart_esp32_config_get(const struct device *dev,
 	}
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_esp32_set_baudrate(const struct device *dev, int baudrate)
 {
@@ -441,8 +443,10 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 	.poll_in = uart_esp32_poll_in,
 	.poll_out = uart_esp32_poll_out,
 	.err_check = uart_esp32_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure =  uart_esp32_configure,
 	.config_get = uart_esp32_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_esp32_fifo_fill,
 	.fifo_read = uart_esp32_fifo_read,

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -100,6 +100,7 @@ static void lpc11u6x_uart0_config_baudrate(const struct device *clk_drv,
 	lpc11u6x_uart0_write_fdr(cfg->uart0, div, mul);
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int lpc11u6x_uart0_configure(const struct device *dev,
 				    const struct uart_config *cfg)
 {
@@ -199,6 +200,7 @@ static int lpc11u6x_uart0_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static int lpc11u6x_uart0_fifo_fill(const struct device *dev,
@@ -416,8 +418,10 @@ static const struct uart_driver_api uart0_api = {
 	.poll_in = lpc11u6x_uart0_poll_in,
 	.poll_out = lpc11u6x_uart0_poll_out,
 	.err_check = lpc11u6x_uart0_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = lpc11u6x_uart0_configure,
 	.config_get = lpc11u6x_uart0_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = lpc11u6x_uart0_fifo_fill,
 	.fifo_read = lpc11u6x_uart0_fifo_read,
@@ -518,6 +522,7 @@ static void lpc11u6x_uartx_config_baud(const struct lpc11u6x_uartx_config *cfg,
 	cfg->base->brg = div & LPC11U6X_UARTX_BRG_MASK;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int lpc11u6x_uartx_configure(const struct device *dev,
 				    const struct uart_config *cfg)
 {
@@ -622,6 +627,7 @@ static int lpc11u6x_uartx_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static int lpc11u6x_uartx_fifo_fill(const struct device *dev,
@@ -847,8 +853,10 @@ static const struct uart_driver_api uartx_api = {
 	.poll_in = lpc11u6x_uartx_poll_in,
 	.poll_out = lpc11u6x_uartx_poll_out,
 	.err_check = lpc11u6x_uartx_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = lpc11u6x_uartx_configure,
 	.config_get = lpc11u6x_uartx_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = lpc11u6x_uartx_fifo_fill,
 	.fifo_read = lpc11u6x_uartx_fifo_read,

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -102,6 +102,7 @@ FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_mcux_config_get(const struct device *dev,
 				struct uart_config *cfg)
 {
@@ -111,6 +112,7 @@ static int uart_mcux_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_mcux_poll_in(const struct device *dev, unsigned char *c)
 {
@@ -334,8 +336,10 @@ static const struct uart_driver_api uart_mcux_driver_api = {
 	.poll_in = uart_mcux_poll_in,
 	.poll_out = uart_mcux_poll_out,
 	.err_check = uart_mcux_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_mcux_configure,
 	.config_get = uart_mcux_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_mcux_fifo_fill,
 	.fifo_read = uart_mcux_fifo_read,

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -319,6 +319,7 @@ static int mcux_lpuart_configure_init(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int mcux_lpuart_config_get(const struct device *dev, struct uart_config *cfg)
 {
 	struct mcux_lpuart_data *data = dev->data;
@@ -344,6 +345,7 @@ static int mcux_lpuart_configure(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int mcux_lpuart_init(const struct device *dev)
 {
@@ -371,8 +373,10 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 	.poll_in = mcux_lpuart_poll_in,
 	.poll_out = mcux_lpuart_poll_out,
 	.err_check = mcux_lpuart_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = mcux_lpuart_configure,
 	.config_get = mcux_lpuart_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = mcux_lpuart_fifo_fill,
 	.fifo_read = mcux_lpuart_fifo_read,

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -389,13 +389,14 @@ static int uart_nrfx_configure(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_nrfx_config_get(const struct device *dev,
 				struct uart_config *cfg)
 {
 	*cfg = get_dev_data(dev)->uart_config;
 	return 0;
 }
-
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_0_ASYNC
 
@@ -1073,8 +1074,10 @@ static const struct uart_driver_api uart_nrfx_uart_driver_api = {
 	.poll_in          = uart_nrfx_poll_in,
 	.poll_out         = uart_nrfx_poll_out,
 	.err_check        = uart_nrfx_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure        = uart_nrfx_configure,
 	.config_get       = uart_nrfx_config_get,
+#endif
 #ifdef CONFIG_UART_0_INTERRUPT_DRIVEN
 	.fifo_fill        = uart_nrfx_fifo_fill,
 	.fifo_read        = uart_nrfx_fifo_read,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -440,12 +440,14 @@ static int uarte_nrfx_configure(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uarte_nrfx_config_get(const struct device *dev,
 				 struct uart_config *cfg)
 {
 	*cfg = get_dev_data(dev)->uart_config;
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 
 static int uarte_nrfx_err_check(const struct device *dev)
@@ -1597,8 +1599,10 @@ static const struct uart_driver_api uart_nrfx_uarte_driver_api = {
 	.poll_in		= uarte_nrfx_poll_in,
 	.poll_out		= uarte_nrfx_poll_out,
 	.err_check		= uarte_nrfx_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure              = uarte_nrfx_configure,
 	.config_get             = uarte_nrfx_config_get,
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_ASYNC_API
 	.callback_set		= uarte_nrfx_callback_set,
 	.tx			= uarte_nrfx_tx,

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -479,6 +479,7 @@ out:
 	return ret;
 };
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_ns16550_config_get(const struct device *dev,
 				   struct uart_config *cfg)
 {
@@ -492,6 +493,7 @@ static int uart_ns16550_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 /**
  * @brief Initialize individual UART port
@@ -949,8 +951,10 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	.poll_in = uart_ns16550_poll_in,
 	.poll_out = uart_ns16550_poll_out,
 	.err_check = uart_ns16550_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_ns16550_configure,
 	.config_get = uart_ns16550_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
 	.fifo_fill = uart_ns16550_fifo_fill,

--- a/drivers/serial/uart_nuvoton.c
+++ b/drivers/serial/uart_nuvoton.c
@@ -101,6 +101,7 @@ static inline uint32_t uart_numicro_convert_parity(enum uart_config_parity parit
 	}
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_numicro_configure(const struct device *dev,
 				  const struct uart_config *cfg)
 {
@@ -145,6 +146,7 @@ static int uart_numicro_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_numicro_init(const struct device *dev)
 {
@@ -178,8 +180,10 @@ static const struct uart_driver_api uart_numicro_driver_api = {
 	.poll_in          = uart_numicro_poll_in,
 	.poll_out         = uart_numicro_poll_out,
 	.err_check        = uart_numicro_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure        = uart_numicro_configure,
 	.config_get       = uart_numicro_config_get,
+#endif
 };
 
 #define NUMICRO_INIT(index)						\

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -228,6 +228,7 @@ static int uart_rcar_configure(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_rcar_config_get(const struct device *dev,
 				struct uart_config *cfg)
 {
@@ -237,6 +238,7 @@ static int uart_rcar_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_rcar_init(const struct device *dev)
 {
@@ -263,8 +265,10 @@ static int uart_rcar_init(const struct device *dev)
 static const struct uart_driver_api uart_rcar_driver_api = {
 	.poll_in = uart_rcar_poll_in,
 	.poll_out = uart_rcar_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_rcar_configure,
 	.config_get = uart_rcar_config_get,
+#endif
 };
 
 /* Device Instantiation */

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -401,6 +401,7 @@ static void uart_sam0_rx_timeout(struct k_work *work)
 
 #endif
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_sam0_configure(const struct device *dev,
 			       const struct uart_config *new_cfg)
 {
@@ -513,6 +514,7 @@ static int uart_sam0_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_sam0_init(const struct device *dev)
 {
@@ -1115,8 +1117,10 @@ static int uart_sam0_rx_disable(const struct device *dev)
 static const struct uart_driver_api uart_sam0_driver_api = {
 	.poll_in = uart_sam0_poll_in,
 	.poll_out = uart_sam0_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_sam0_configure,
 	.config_get = uart_sam0_config_get,
+#endif
 	.err_check = uart_sam0_err_check,
 #if CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_sam0_fifo_fill,

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -320,6 +320,7 @@ static inline enum uart_config_flow_control uart_stm32_ll2cfg_hwctrl(uint32_t fc
 	return UART_CFG_FLOW_CTRL_NONE;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_stm32_configure(const struct device *dev,
 				const struct uart_config *cfg)
 {
@@ -425,6 +426,7 @@ static int uart_stm32_config_get(const struct device *dev,
 		uart_stm32_get_hwctrl(dev));
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static int uart_stm32_poll_in(const struct device *dev, unsigned char *c)
 {
@@ -1290,8 +1292,10 @@ static const struct uart_driver_api uart_stm32_driver_api = {
 	.poll_in = uart_stm32_poll_in,
 	.poll_out = uart_stm32_poll_out,
 	.err_check = uart_stm32_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_stm32_configure,
 	.config_get = uart_stm32_config_get,
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_stm32_fifo_fill,
 	.fifo_read = uart_stm32_fifo_read,

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -583,6 +583,7 @@ static inline bool uart_xlnx_ps_cfg2ll_hwctrl(
 	return true;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 /**
  * @brief Configures the UART device at run-time.
  *
@@ -639,6 +640,7 @@ static int uart_xlnx_ps_configure(const struct device *dev,
 
 	return 0;
 };
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 /**
  * @brief Converts a Mode Register bit mask to a parity configuration
@@ -787,6 +789,7 @@ static inline enum uart_config_flow_control uart_xlnx_ps_ll2cfg_hwctrl(
 	return UART_CFG_FLOW_CTRL_NONE;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 /**
  * @brief Returns the current configuration of the UART at run-time.
  *
@@ -824,6 +827,7 @@ static int uart_xlnx_ps_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #if CONFIG_UART_INTERRUPT_DRIVEN
 
@@ -1147,8 +1151,10 @@ static void uart_xlnx_ps_isr(const struct device *dev)
 static const struct uart_driver_api uart_xlnx_ps_driver_api = {
 	.poll_in = uart_xlnx_ps_poll_in,
 	.poll_out = uart_xlnx_ps_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_xlnx_ps_configure,
 	.config_get = uart_xlnx_ps_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_xlnx_ps_fifo_fill,
 	.fifo_read = uart_xlnx_ps_fifo_read,


### PR DESCRIPTION
This kconfig option enables runtime configuration of UART
controllers. This allows application to call uart_configure()
to configure the UART controllers and calling uart_config_get()
to retrieve configuration. If this is disabled, UART controllers
rely on UART driver's initialization function to properly
configure the controller. The main use of this option is mainly
code size reduction.

Fixes #16231

Signed-off-by: Daniel Leung <daniel.leung@intel.com>