### PR TITLE
drivers: pinmux: mchp: Update pinmux based on latest HAL

### DIFF
--- a/drivers/pinmux/pinmux_mchp_xec.c
+++ b/drivers/pinmux/pinmux_mchp_xec.c
@@ -36,7 +36,8 @@ static int pinmux_xec_set(const struct device *dev, uint32_t pin,
 		return -EINVAL;
 	}
 
-	mask |= MCHP_GPIO_CTRL_BUFT_MASK | MCHP_GPIO_CTRL_MUX_MASK;
+	mask |= MCHP_GPIO_CTRL_BUFT_MASK | MCHP_GPIO_CTRL_MUX_MASK |
+		MCHP_GPIO_CTRL_INPAD_DIS_MASK;
 
 	/* Check for open drain/push_pull setting */
 	if (func & MCHP_GPIO_CTRL_BUFT_OPENDRAIN) {


### PR DESCRIPTION
Microchip HAL 1.2.0 fixed a bug in the define of GPIO
control register MUX field. The incorrect MUX defined
cleared by GPIO input pad disable field by accident.
After the MUX definition was corrected the pinmux driver
must be modified to mask off the input pad disable for
the pin to be operational.

Signed-off-by: Scott Worley <scott.worley@microchip.com>