### PR TITLE
soc: mchp: Deep sleep exit sequence update

### DIFF
--- a/soc/arm/microchip_mec/mec1501/device_power.c
+++ b/soc/arm/microchip_mec/mec1501/device_power.c
@@ -53,8 +53,15 @@ void soc_deep_sleep_enable(void)
 	PCR_REGS->SYS_SLP_CTRL = MCHP_PCR_SYS_SLP_HEAVY;
 }
 
+/*
+ * Clear PCR Sleep control sleep all causing HW to de-assert all peripheral
+ * SLP_EN signals. HW will does this automatically only if it vectors to an
+ * ISR after wake. We are masking ISR's from running until we restore
+ * peripheral state therefore we force HW to de-assert the SLP_EN signals.
+ */
 void soc_deep_sleep_disable(void)
 {
+	PCR_REGS->SYS_SLP_CTRL = 0U;
 	SCB->SCR &= ~(1ul << 2); /* disable Cortex-M4 SLEEPDEEP */
 }
 


### PR DESCRIPTION
Zephyr kernel masks interrupts before calling the SoC PM
sleep entry point. On the Cortex-Mx family this prevents
wake from peripheral interrupts. The SoC PM layer requires
interrupts to wake the SoC and must prevent the CPU from
vectoring to an interrup until PM exit. The SoC does this
by setting ARM NVIC PRIMASK to 1 and BASEPRI to 0. On
return to the kernel SoC sets PRIMASK to 0 allowing ISR's
to fire. In addition the MEC HW only clears its peripheral
sleep enables if the CPU vectors to an ISR. On wake we
clear the MEC PCR sleep control register which clears all
the peripheral sleep enables so peripherals will be active
before exiting the SoC PM layer.

Signed-off-by: Scott Worley <scott.worley@microchip.com>