### PR TITLE
doc: release: v2.6: add note for UART console input expired options

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -355,6 +355,10 @@ Drivers and Sensors
 
 * Console
 
+  * Added ``UART_CONSOLE_INPUT_EXPIRED`` and ``UART_CONSOLE_INPUT_EXPIRED_TIMEOUT``
+    Kconfig options to notify the power management module that UART console is
+    in use now and forbid it to enter low-power states.
+
 * Counter
 
 * Crypto


### PR DESCRIPTION
Add note for UART console input expired mechanism Kconfig options.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>