### PR TITLE
Bluetooth: Mesh: Add proxy send callback 

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -41,8 +41,17 @@ const uint8_t bt_mesh_adv_type[BT_MESH_ADV_TYPES] = {
 
 K_FIFO_DEFINE(bt_mesh_adv_queue);
 
+static void adv_buf_destroy(struct net_buf *buf)
+{
+	struct bt_mesh_adv adv = *BT_MESH_ADV(buf);
+
+	net_buf_destroy(buf);
+
+	bt_mesh_adv_send_end(0, &adv);
+}
+
 NET_BUF_POOL_DEFINE(adv_buf_pool, CONFIG_BT_MESH_ADV_BUF_COUNT,
-		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE, NULL);
+		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE, adv_buf_destroy);
 
 static struct bt_mesh_adv adv_pool[CONFIG_BT_MESH_ADV_BUF_COUNT];
 

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -35,7 +35,9 @@ struct bt_mesh_adv {
 	void *cb_data;
 
 	uint8_t      type:2,
+		  started:1,
 		  busy:1;
+
 	uint8_t      xmit;
 };
 
@@ -75,18 +77,25 @@ int bt_mesh_adv_start(const struct bt_le_adv_param *param, int32_t duration,
 		      const struct bt_data *sd, size_t sd_len);
 
 static inline void bt_mesh_adv_send_start(uint16_t duration, int err,
-					  const struct bt_mesh_send_cb *cb,
-					  void *cb_data)
+					  struct bt_mesh_adv *adv)
 {
-	if (cb && cb->start) {
-		cb->start(duration, err, cb_data);
+	if (!adv->started) {
+		adv->started = 1;
+
+		if (adv->cb && adv->cb->start) {
+			adv->cb->start(duration, err, adv->cb_data);
+		}
+
+		if (err) {
+			adv->cb = NULL;
+		}
 	}
 }
 
 static inline void bt_mesh_adv_send_end(
-	int err, const struct bt_mesh_send_cb *cb, void *cb_data)
+	int err, struct bt_mesh_adv const *adv)
 {
-	if (cb && cb->end) {
-		cb->end(err, cb_data);
+	if (adv->started && adv->cb && adv->cb->end) {
+		adv->cb->end(err, adv->cb_data);
 	}
 }

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -55,8 +55,7 @@ enum {
 static struct {
 	ATOMIC_DEFINE(flags, ADV_FLAGS_NUM);
 	struct bt_le_ext_adv *instance;
-	const struct bt_mesh_send_cb *cb;
-	void *cb_data;
+	struct net_buf *buf;
 	uint64_t timestamp;
 	struct k_work_delayable work;
 } adv;
@@ -140,12 +139,12 @@ static int buf_send(struct net_buf *buf)
 		atomic_set_bit(adv.flags, ADV_FLAG_UPDATE_PARAMS);
 	}
 
-	adv.cb = BT_MESH_ADV(buf)->cb;
-	adv.cb_data = BT_MESH_ADV(buf)->cb_data;
-
 	err = adv_start(&adv_param, &start, &ad, 1, NULL, 0);
-	net_buf_unref(buf);
-	bt_mesh_adv_send_start(duration, err, adv.cb, adv.cb_data);
+	if (!err) {
+		adv.buf = net_buf_ref(buf);
+	}
+
+	bt_mesh_adv_send_start(duration, err, BT_MESH_ADV(buf));
 
 	return err;
 }
@@ -166,6 +165,9 @@ static void send_pending_adv(struct k_work *work)
 
 		BT_MESH_ADV(buf)->busy = 0U;
 		err = buf_send(buf);
+
+		net_buf_unref(buf);
+
 		if (!err) {
 			return; /* Wait for advertising to finish */
 		}
@@ -235,7 +237,7 @@ static void adv_sent(struct bt_le_ext_adv *instance,
 	atomic_clear_bit(adv.flags, ADV_FLAG_ACTIVE);
 
 	if (!atomic_test_and_clear_bit(adv.flags, ADV_FLAG_PROXY)) {
-		bt_mesh_adv_send_end(0, adv.cb, adv.cb_data);
+		net_buf_unref(adv.buf);
 	}
 
 	schedule_send();

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -46,8 +46,6 @@ static inline void adv_send(struct net_buf *buf)
 		((bt_dev.hci_version >= BT_HCI_VERSION_5_0) ?
 			       ADV_INT_FAST_MS :
 			       ADV_INT_DEFAULT_MS);
-	const struct bt_mesh_send_cb *cb = BT_MESH_ADV(buf)->cb;
-	void *cb_data = BT_MESH_ADV(buf)->cb_data;
 	struct bt_le_adv_param param = {};
 	uint16_t duration, adv_int;
 	struct bt_data ad;
@@ -82,8 +80,9 @@ static inline void adv_send(struct net_buf *buf)
 	uint64_t time = k_uptime_get();
 
 	err = bt_le_adv_start(&param, &ad, 1, NULL, 0);
-	net_buf_unref(buf);
-	bt_mesh_adv_send_start(duration, err, cb, cb_data);
+
+	bt_mesh_adv_send_start(duration, err, BT_MESH_ADV(buf));
+
 	if (err) {
 		BT_ERR("Advertising failed: err %d", err);
 		return;
@@ -94,7 +93,6 @@ static inline void adv_send(struct net_buf *buf)
 	k_sleep(K_MSEC(duration));
 
 	err = bt_le_adv_stop();
-	bt_mesh_adv_send_end(err, cb, cb_data);
 	if (err) {
 		BT_ERR("Stopping advertising failed: err %d", err);
 		return;
@@ -137,9 +135,9 @@ static void adv_thread(void *p1, void *p2, void *p3)
 		if (BT_MESH_ADV(buf)->busy) {
 			BT_MESH_ADV(buf)->busy = 0U;
 			adv_send(buf);
-		} else {
-			net_buf_unref(buf);
 		}
+
+		net_buf_unref(buf);
 
 		/* Give other threads a chance to run */
 		k_yield();

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1970,11 +1970,27 @@ send_list:
 	}
 }
 
+static void reset_send_start(uint16_t duration, int err, void *cb_data)
+{
+	if (err) {
+		BT_ERR("Sending Node Reset Status failed (err %d)", err);
+		bt_mesh_reset();
+	}
+}
+
+static void reset_send_end(int err, void *cb_data)
+{
+	bt_mesh_reset();
+}
+
 static void node_reset(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	static struct bt_mesh_proxy_idle_cb proxy_idle = {.cb = bt_mesh_reset};
+	static const struct bt_mesh_send_cb reset_cb = {
+		.start = reset_send_start,
+		.end = reset_send_end,
+	};
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET_STATUS, 0);
 
@@ -1982,25 +1998,11 @@ static void node_reset(struct bt_mesh_model *model,
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-
 	bt_mesh_model_msg_init(&msg, OP_NODE_RESET_STATUS);
 
-	/* Send the response first since we wont have any keys left to
-	 * send it later.
-	 */
-	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, &reset_cb, NULL)) {
 		BT_ERR("Unable to send Node Reset Status");
 	}
-
-	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
-		bt_mesh_reset();
-		return;
-	}
-
-	/* If the response goes to a proxy node, we'll wait for the sending to
-	 * complete before moving on.
-	 */
-	bt_mesh_proxy_on_idle(&proxy_idle);
 }
 
 static void send_friend_status(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -530,12 +530,13 @@ int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct net_buf *buf,
 		goto done;
 	}
 
+	BT_MESH_ADV(buf)->cb = cb;
+	BT_MESH_ADV(buf)->cb_data = cb_data;
+
 	/* Deliver to GATT Proxy Clients if necessary. */
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-	    bt_mesh_proxy_relay(&buf->b, tx->ctx->addr) &&
+	    bt_mesh_proxy_relay(buf, tx->ctx->addr) &&
 	    BT_MESH_ADDR_IS_UNICAST(tx->ctx->addr)) {
-		/* Notify completion if this only went through the Mesh Proxy */
-		send_cb_finalize(cb, cb_data);
 
 		err = 0;
 		goto done;
@@ -702,7 +703,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf,
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
 	    (rx->friend_cred ||
 	     bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED)) {
-		bt_mesh_proxy_relay(&buf->b, rx->ctx.recv_dst);
+		bt_mesh_proxy_relay(buf, rx->ctx.recv_dst);
 	}
 
 	if (relay_to_adv(rx->net_if) || rx->friend_cred) {

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -6,19 +6,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_
+#define ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_
+
+#include <bluetooth/gatt.h>
+
+int bt_mesh_pb_gatt_send(struct bt_conn *conn, struct net_buf_simple *buf,
+			 bt_gatt_complete_func_t end, void *user_data);
+
 #define BT_MESH_PROXY_NET_PDU   0x00
 #define BT_MESH_PROXY_BEACON    0x01
 #define BT_MESH_PROXY_CONFIG    0x02
 #define BT_MESH_PROXY_PROV      0x03
-
-
-struct bt_mesh_proxy_idle_cb {
-	sys_snode_t n;
-	void (*cb)(void);
-};
-
-int bt_mesh_proxy_send(struct bt_conn *conn, uint8_t type,
-		       struct net_buf_simple *msg);
 
 int bt_mesh_proxy_prov_enable(void);
 int bt_mesh_proxy_prov_disable(bool disconnect);
@@ -36,8 +35,9 @@ int bt_mesh_proxy_adv_start(void);
 void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
 
-bool bt_mesh_proxy_relay(struct net_buf_simple *buf, uint16_t dst);
+bool bt_mesh_proxy_relay(struct net_buf *buf, uint16_t dst);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, uint16_t addr);
 
 int bt_mesh_proxy_init(void);
-void bt_mesh_proxy_on_idle(struct bt_mesh_proxy_idle_cb *cb);
+
+#endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_H_ */


### PR DESCRIPTION
Zephyr Bluetooth Mesh did not check whether the proxy message
was actually sent out, so that the response message could
not be received during reset. It did not solve the status
callback of the proxy sending message, so a new problem was
introduced after PR(#28457) merged.

bt_mesh_prov_send(&buf, public_key_sent))

This PR will try to solve the above problem, and will fix
the problem due to thread competition, and PR(#26668) will
not be necessary.

Compared with PR(#30138), it no longer consumes extra RAM
space and supports synchronization of group addresses

This is a resubmission of PR(#32666)

Fixes #36100. 

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>