### PR TITLE
[RFC]uart: Add support for RS485

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -46,6 +46,12 @@ config UART_USE_RUNTIME_CONFIGURE
 	  Say y if unsure. Disable this to reduce footprint for
 	  applications that do not require runtime UART configuration.
 
+config SERIAL_SUPPORT_RS485
+	bool
+	help
+	  This is an option to be enabled by individual serial driver
+	  to signal that the driver and hardware supports RS485.
+
 config UART_ASYNC_API
 	bool "Enable new asynchronous UART API [EXPERIMENTAL]"
 	depends on SERIAL_SUPPORT_ASYNC

--- a/dts/bindings/serial/uart-rs485-controller.yaml
+++ b/dts/bindings/serial/uart-rs485-controller.yaml
@@ -1,0 +1,38 @@
+#Common fields for uart-rs485 controllers
+
+include: uart-controller.yaml
+
+properties:
+    rs485-enable:
+      type: int
+      required: true
+      description: Enable or disable rs485, 0 - disable , 1 - enable
+    transfer-mode:
+      type: int
+      required: true
+      description: Full / Half Duplex transfer mode
+    de-polarity:
+      type: int
+      required: true
+      description: Polarity for driver enable 0-Active Low,1-Active High
+    re-polarity:
+      type: int
+      required: true
+      description: Polarity for receiver enable 0-Active Low,1-Active High
+    de-assertion-time-ns:
+      type: int
+      required: true
+      description: De assertion time for driver enable signal in nanoseconds
+    de-deassertion-time-ns:
+      type: int
+      required: true
+      description: De-deassertion time for driver enable signal in nanoseconds
+    de-re-tat-ns:
+      type: int
+      required: true
+      description: Receiver enable /driver enable turnaround time in nanoseconds
+    re-de-tat-ns:
+      type: int
+      required: true
+      description: Driver enable/ receiver enable turnaround time in nanoseconds
+

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -36,6 +36,8 @@ enum uart_line_ctrl {
 	UART_LINE_CTRL_DTR = BIT(2),
 	UART_LINE_CTRL_DCD = BIT(3),
 	UART_LINE_CTRL_DSR = BIT(4),
+	/* Enable/disable rs485 mode */
+	UART_LINE_CTRL_RS485 = BIT(5),
 };
 
 /**


### PR DESCRIPTION
Adds support for configuring and enabling RS485 signalling
on supported uarts.

Signed-off-by: Nachiketa Kumar <nachiketa.kumar@intel.com>