### PR TITLE
Tracing: TRACING_NONE Compilation Fix

### DIFF
--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -20,36 +20,6 @@
 #else
 
 /**
- * @brief Tracing APIs
- * @defgroup tracing_apis Tracing APIs
- * @{
- */
-
-/**
- * @brief Called when entering an ISR
- */
-#define sys_trace_isr_enter()
-
-/**
- * @brief Called when exiting an ISR
- */
-#define sys_trace_isr_exit()
-
-/**
- * @brief Called when exiting an ISR and switching to scheduler
- */
-#define sys_trace_isr_exit_to_scheduler()
-
-/**
- * @brief Called when the cpu enters the idle state
- */
-#define sys_trace_idle()
-/**
- * @}
- */
-
-
-/**
  * @brief Thread Tracing APIs
  * @defgroup thread_tracing_apis Thread Tracing APIs
  * @ingroup tracing_apis
@@ -190,16 +160,32 @@
 #define sys_port_trace_k_thread_priority_set(thread)
 
 /**
- * @brief Called when a thread is being suspended
+ * @brief Called when a thread enters the k_thread_suspend
+ * function.
  * @param thread Thread object
  */
-#define sys_port_trace_k_thread_suspend(thread)
+#define sys_port_trace_k_thread_suspend_enter(thread)
 
 /**
- * @brief Called when a thread is being resumed from suspension
+ * @brief Called when a thread exits the k_thread_suspend
+ * function.
  * @param thread Thread object
  */
-#define sys_port_trace_k_thread_resume(thread)
+#define sys_port_trace_k_thread_suspend_exit(thread)
+
+/**
+ * @brief Called when a thread enters the resume from suspension
+ * function.
+ * @param thread Thread object
+ */
+#define sys_port_trace_k_thread_resume_enter(thread)
+
+/**
+ * @brief Called when a thread exits the resumed from suspension
+ * function.
+ * @param thread Thread object
+ */
+#define sys_port_trace_k_thread_resume_exit(thread)
 
 /**
  * @brief Called when the thread scheduler is locked
@@ -1067,7 +1053,7 @@
  * @param queue Queue object
  * @param ret Return value
  */
-#define sys_port_trace_queue_remove_exit(queue, ret)
+#define sys_port_trace_k_queue_remove_exit(queue, ret)
 
 /**
  * @brief Trace Queue unique append enter
@@ -1936,7 +1922,38 @@
 
 #if defined CONFIG_PERCEPIO_TRACERECORDER
 #include "tracing_tracerecorder.h"
+#else
+/**
+ * @brief Tracing APIs
+ * @defgroup tracing_apis Tracing APIs
+ * @{
+ */
+
+/**
+ * @brief Called when entering an ISR
+ */
+void sys_trace_isr_enter(void);
+
+/**
+ * @brief Called when exiting an ISR
+ */
+void sys_trace_isr_exit(void);
+
+/**
+ * @brief Called when exiting an ISR and switching to scheduler
+ */
+void sys_trace_isr_exit_to_scheduler(void);
+
+/**
+ * @brief Called when the cpu enters the idle state
+ */
+void sys_trace_idle(void);
+
+/**
+ * @}
+ */
 #endif
+
 
 #endif
 #endif

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -39,6 +39,11 @@ zephyr_sources_ifdef(
 
 endif()
 
+if(NOT CONFIG_PERCEPIO_TRACERECORDER AND NOT CONFIG_TRACING_CTF
+  AND NOT CONFIG_SEGGER_SYSTEMVIEW AND NOT CONFIG_TRACING_TEST)
+  zephyr_sources(tracing_none.c)
+endif()
+
 zephyr_include_directories_ifdef(
   CONFIG_TRACING
   ${ZEPHYR_BASE}/kernel/include

--- a/subsys/tracing/tracing_none.c
+++ b/subsys/tracing/tracing_none.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Intel corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+#include <string.h>
+#include <kernel.h>
+
+void sys_trace_isr_enter(void) {}
+
+void sys_trace_isr_exit(void) {}
+
+void sys_trace_isr_exit_to_scheduler(void) {}
+
+void sys_trace_idle(void) {}


### PR DESCRIPTION
Fixed several compilation errors that resulted from selecting
TRACING without specifying a tracing system (Tracerecorder,
CTF, Systemview). In this case (TRACING_NONE), some default trace hooks
(in tracing.h) were incorrectly named resulting in compilation errors.
The legacy sys_trace_isr_enter, sys_trace_isr_exit, and sys_trace_idle
also caused problems since these were only given as defines, resulting
in undefined reference errors since they are required by the assembly
files calling these. To solve this issue I've added a stub file
"tracing_none.c" (only compiled if TRACING_NONE) and declared the
functions in tracing.h if no tracing system is selected.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>