### PR TITLE
wifi: driver: esp32: fix reconnection issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -42,7 +42,7 @@ manifest:
       path: modules/lib/civetweb
     - name: hal_espressif
       west-commands: west/west-commands.yml
-      revision: 086d305202390589a206523c239e604718759402
+      revision: 22e757632677e3579e6f20bb9955fffb2e1b3e1c
       path: modules/hal/espressif
     - name: fatfs
       revision: 1d1fcc725aa1cb3c32f366e0c53d7490d0fe1109


### PR DESCRIPTION
Device won't reconnect automatically even if
AP station is available. This fix adds the carrier event, indicating
that network is present again enabling DHCP bound event.
Also, internal wifi event callback  was added into wifi driver to enable proper
event handling.

Fixes #33843