### PR TITLE
ieee802154: add TX retry logic to nRF5 802.15.4 shim layer

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -471,6 +471,7 @@ static int nrf5_tx(const struct device *dev,
 	uint8_t payload_len = frag->len;
 	uint8_t *payload = frag->data;
 	bool ret = true;
+	int result;
 
 	LOG_DBG("%p (%u)", payload, payload_len);
 
@@ -528,19 +529,32 @@ static int nrf5_tx(const struct device *dev,
 		/* Handle ACK packet. */
 		return handle_ack(nrf5_radio);
 	case NRF_802154_TX_ERROR_NO_MEM:
-		return -ENOBUFS;
+		result = -ENOBUFS;
 	case NRF_802154_TX_ERROR_BUSY_CHANNEL:
-		return -EBUSY;
+		result = -EBUSY;
 	case NRF_802154_TX_ERROR_INVALID_ACK:
 	case NRF_802154_TX_ERROR_NO_ACK:
-		return -ENOMSG;
+		result = -ENOMSG;
 	case NRF_802154_TX_ERROR_ABORTED:
 	case NRF_802154_TX_ERROR_TIMESLOT_DENIED:
 	case NRF_802154_TX_ERROR_TIMESLOT_ENDED:
-		return -EIO;
+	default:
+		result = -EIO;
 	}
 
-	return -EIO;
+#if NRF_802154_ENCRYPTION_ENABLED
+	/*
+	 * When frame encryption by the radio driver is enabled,
+	 * the frame stored in the tx_psdu buffer is authenticated
+	 * and encrypted in place. After an unsuccessful TX attempt,
+	 * this frame must be propagated back to the upper layer
+	 * for retransmission. The upper layer must ensure that the
+	 * excact same secured frame is used for retransmission.
+	 */
+	memcpy(payload, nrf5_radio->tx_psdu + 1, payload_len);
+#endif
+
+	return result;
 }
 
 static uint64_t nrf5_get_time(const struct device *dev)

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -239,6 +239,7 @@ struct net_pkt {
 	uint8_t ieee802154_lqi;  /* Link Quality Indicator */
 	uint8_t ieee802154_arb : 1; /* ACK Request Bit is set in the frame */
 	uint8_t ieee802154_ack_fpb : 1; /* Frame Pending Bit was set in the ACK */
+	uint8_t ieee802154_frame_retry : 1; /* The frame is being retransmitted. */
 #if defined(CONFIG_IEEE802154_2015)
 	uint8_t ieee802154_fv2015 : 1; /* Frame version is IEEE 802.15.4-2015 */
 	uint8_t ieee802154_ack_seb : 1; /* Security Enabled Bit was set in the ACK */
@@ -1005,6 +1006,17 @@ static inline void net_pkt_set_ieee802154_ack_fpb(struct net_pkt *pkt,
 						  bool fpb)
 {
 	pkt->ieee802154_ack_fpb = fpb;
+}
+
+static inline bool net_pkt_ieee802154_frame_retry(struct net_pkt *pkt)
+{
+	return pkt->ieee802154_frame_retry;
+}
+
+static inline void net_pkt_set_ieee802154_frame_retry(struct net_pkt *pkt,
+						     bool frame_retry)
+{
+	pkt->ieee802154_frame_retry = frame_retry;
 }
 
 #if defined(CONFIG_IEEE802154_2015)

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -268,6 +268,9 @@ void transmit_message(struct k_work *tx_job)
 	radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
 	radio_api->set_txpower(radio_dev, tx_power);
 
+	net_pkt_set_ieee802154_frame_retry(tx_pkt,
+					   sTransmitFrame.mInfo.mTxInfo.mIsARetx);
+
 	if ((radio_api->get_capabilities(radio_dev) & IEEE802154_HW_TXTIME) &&
 	    (sTransmitFrame.mInfo.mTxInfo.mTxDelay != 0)) {
 		uint64_t tx_at = sTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime +

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: d533671f46feddd5079ed39946417df1e6c2080b
+      revision: 74b3b21f60aa3dc9a4364ffc28dbb47ad8b699a9
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This patch series introduces a new flag to `net_pkt` structure, `ieee802154_frame_retry`.
The flag indicates that a frame transmission is being retried, which instructs the driver implementations
to skip certain modifications that may be performed on the transmitted frame. 

The new flag is used in the ieee802154_nrf5 shim layer to make calls to the proper API.

The OpenThread glue layer was modified to use the new flag to indicate reattempted transmissions.