### PR TITLE
cpp: Restrict C++ exceptions usage to supported archs

### DIFF
--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -54,6 +54,7 @@ if LIB_CPLUSPLUS
 
 config EXCEPTIONS
 	bool "Enable C++ exceptions support"
+	depends on ARC || ARM || (RISCV && !64BIT) || (X86 && !64BIT) || XTENSA
 	help
 	  This option enables support of C++ exceptions.
 


### PR DESCRIPTION
`CONFIG_EXCEPTIONS` is currently selectable on all architectures regardless of whether it is actually supported/working on them or not. We must ensure that users cannot enable this feature on the broken/unsupported architectures.

For more details, see #32448 and #35647.

```
This commit makes CONFIG_EXCEPTIONS selectable only for the
architectures that currently support C++ exception handling
(see #32448).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```