### PR TITLE
Bluetooth: ISO: Add packet status flag to iso recv info

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -138,6 +138,19 @@ struct bt_iso_chan_path {
 	uint8_t				cc[0];
 };
 
+/** ISO packet status flags */
+enum {
+	/** The ISO packet is valid. */
+	BT_ISO_FLAGS_VALID,
+	/** @brief The ISO packet may possibly contain errors.
+	 *
+	 * May be caused by a failed CRC check or if missing a part of the SDU.
+	 */
+	BT_ISO_FLAGS_ERROR,
+	/** The ISO packet was lost. */
+	BT_ISO_FLAGS_LOST
+};
+
 /** @brief ISO Meta Data structure for received ISO packets. */
 struct bt_iso_recv_info {
 	/** ISO timestamp - valid only if the Bluetooth controller includes it
@@ -147,6 +160,9 @@ struct bt_iso_recv_info {
 
 	/** ISO packet sequence number of the first fragment in the SDU */
 	uint16_t sn;
+
+	/** ISO packet flags (BT_ISO_FLAGS_*) */
+	uint8_t flags;
 };
 
 /** Opaque type representing an Broadcast Isochronous Group (BIG). */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1136,7 +1136,16 @@ void bt_iso_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 		pkt_seq_no = sys_le16_to_cpu(hdr->sn);
 		iso_info(buf)->sn = pkt_seq_no;
 
-		/* TODO: Drop the packet if NOP? */
+		if (flags == BT_ISO_DATA_VALID) {
+			iso_info(buf)->flags = BT_ISO_FLAGS_VALID;
+		} else if (flags == BT_ISO_DATA_INVALID) {
+			iso_info(buf)->flags = BT_ISO_FLAGS_ERROR;
+		} else if (flags == BT_ISO_DATA_NOP) {
+			iso_info(buf)->flags = BT_ISO_FLAGS_LOST;
+		} else {
+			BT_WARN("Invalid ISO packet status flag: %u", flags);
+			iso_info(buf)->flags = 0;
+		}
 
 		BT_DBG("%s, len %u total %u flags 0x%02x timestamp %u",
 		       pb == BT_ISO_START ? "Start" : "Single", buf->len, len,


### PR DESCRIPTION
Add the packet status flag value to the iso receive info
struct. This will allow an application to handle potential
lost or erroneous messages.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>