### PR TITLE
pm: device: use device list

### DIFF
--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -60,11 +60,6 @@ config DEVICE_POWER_MANAGEMENT
 	help
 	  This option is deprecated, please use CONFIG_PM_DEVICE instead.
 
-config PM_MAX_DEVICES
-	int "Max number of devices support power management"
-	depends on PM_DEVICE
-	default 15
-
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"
 	depends on PM_DEVICE

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -15,112 +15,53 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 
-/*
- * FIXME: Remove the conditional inclusion of
- * core_devices array once we enble the capability
- * to build the device list based on devices power
- * and clock domain dependencies.
- */
-
-__weak const char *const z_pm_core_devices[] = {
-#if defined(CONFIG_SOC_FAMILY_NRF)
-	"CLOCK",
-	"sys_clock",
-	"UART_0",
-#elif defined(CONFIG_SOC_SERIES_CC13X2_CC26X2)
-	"sys_clock",
-	"UART_0",
-#elif defined(CONFIG_SOC_SERIES_KINETIS_K6X)
-	DT_LABEL(DT_INST(0, nxp_kinetis_ethernet)),
-#elif defined(CONFIG_NET_TEST)
-	"",
-#elif defined(CONFIG_SOC_SERIES_STM32L4X) || defined(CONFIG_SOC_SERIES_STM32WBX)
-	"sys_clock",
-#endif
-	NULL
-};
-
-/* Ordinal of sufficient size to index available devices. */
-typedef uint16_t device_idx_t;
-
-/* The maximum value representable with a device_idx_t. */
-#define DEVICE_IDX_MAX ((device_idx_t)(-1))
-
-/* An array of all devices in the application. */
-static const struct device *all_devices;
-
-/* Indexes into all_devices for devices that support pm,
- * in dependency order (later may depend on earlier).
- */
-static device_idx_t pm_devices[CONFIG_PM_MAX_DEVICES];
-
-/* Number of devices that support pm */
-static device_idx_t num_pm;
-
-/* Number of devices successfully suspended. */
-static device_idx_t num_susp;
-
-static bool should_suspend(const struct device *dev, uint32_t state)
-{
-	int rc;
-	uint32_t current_state;
-
-	if (device_busy_check(dev) != 0) {
-		return false;
-	}
-
-	rc = pm_device_state_get(dev, &current_state);
-	if ((rc != -ENOSYS) && (rc != 0)) {
-		LOG_DBG("Was not possible to get device %s state: %d",
-			dev->name, rc);
-		return true;
-	}
-
-	/*
-	 * If the device is currently powered off or the request was
-	 * to go to the same state, just ignore it.
-	 */
-	if ((current_state == PM_DEVICE_STATE_OFF) ||
-			(current_state == state)) {
-		return false;
-	}
-
-	return true;
-}
+/* Number of devices in any suspension state. */
+static size_t num_susp;
+/* Device index from which resume should start */
+static size_t resume_point;
 
 static int _pm_devices(uint32_t state)
 {
-	num_susp = 0;
+	const struct device *devs;
+	size_t devs_cnt;
 
-	for (int i = num_pm - 1; i >= 0; i--) {
-		device_idx_t idx = pm_devices[i];
-		const struct device *dev = &all_devices[idx];
-		bool suspend;
-		int rc;
+	devs_cnt = z_device_get_all_static(&devs);
 
-		suspend = should_suspend(dev, state);
-		if (suspend) {
-			/*
-			 * Don't bother the device if it is currently
-			 * in the right state.
-			 */
-			rc = pm_device_state_set(dev, state, NULL, NULL);
-			if ((rc != -ENOSYS) && (rc != 0)) {
-				LOG_DBG("%s did not enter %s state: %d",
-					dev->name, pm_device_state_str(state),
-					rc);
-				return rc;
-			}
+	num_susp = 0U;
+	resume_point = 0U;
 
-			/*
-			 * Just mark as suspended devices that were suspended now
-			 * otherwise we will resume devices that were already suspended
-			 * and not being used.
-			 * This still not optimal, since we are not distinguishing
-			 * between other states like DEVICE_PM_LOW_POWER_STATE.
-			 */
-			++num_susp;
+	for (size_t i = devs_cnt; i > 0U; i--) {
+		int ret;
+		const struct device *dev;
+		uint32_t curr_state;
+
+		resume_point = i - 1U;
+		dev = &devs[resume_point];
+
+		/* ignore busy devices */
+		if (device_busy_check(dev) != 0) {
+			continue;
 		}
+
+		/* check if already in the given state (or OFF) */
+		ret = pm_device_state_get(dev, &curr_state);
+		if (ret == -ENOSYS) {
+			continue;
+		} else if (ret < 0) {
+			LOG_ERR("Could not get device state (%d)", ret);
+			return ret;
+		}
+
+		if ((curr_state != PM_DEVICE_STATE_OFF) && (curr_state != state)) {
+			ret = pm_device_state_set(dev, state, NULL, NULL);
+			if (ret < 0) {
+				LOG_ERR("Could not set device state (%d)", ret);
+				return ret;
+			}
+		}
+
+		/* if suspended (or already), increase counter */
+		num_susp++;
 	}
 
 	return 0;
@@ -143,65 +84,22 @@ int pm_force_suspend_devices(void)
 
 void pm_resume_devices(void)
 {
-	device_idx_t pmi = num_pm - num_susp;
+	const struct device *devs;
+	size_t devs_cnt;
 
-	num_susp = 0;
-	while (pmi < num_pm) {
-		device_idx_t idx = pm_devices[pmi];
+	devs_cnt = z_device_get_all_static(&devs);
 
-		pm_device_state_set(&all_devices[idx],
-				       PM_DEVICE_STATE_ACTIVE,
-				       NULL, NULL);
-		++pmi;
-	}
-}
+	for (size_t i = resume_point; (i < devs_cnt) && (num_susp > 0U); i++) {
+		int ret;
+		const struct device *dev = &devs[i];
 
-void pm_create_device_list(void)
-{
-	size_t count = z_device_get_all_static(&all_devices);
-	device_idx_t pmi, core_dev;
-
-	/*
-	 * Create an ordered list of devices that will be suspended.
-	 * Ordering should be done based on dependencies. Devices
-	 * in the beginning of the list will be resumed first.
-	 */
-
-	__ASSERT_NO_MSG(count <= DEVICE_IDX_MAX);
-
-	/* Reserve initial slots for core devices. */
-	core_dev = 0;
-	while (z_pm_core_devices[core_dev]) {
-		core_dev++;
-	}
-
-	num_pm = core_dev;
-	__ASSERT_NO_MSG(num_pm <= CONFIG_PM_MAX_DEVICES);
-
-	for (pmi = 0; pmi < count; pmi++) {
-		device_idx_t cdi = 0;
-		const struct device *dev = &all_devices[pmi];
-
-		/* Ignore "device"s that don't support PM */
-		if (dev->pm_control == NULL) {
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+		if (ret == -ENOSYS) {
 			continue;
 		}
+		__ASSERT(ret == 0, "Could not set device state");
 
-		/* Check if the device is a core device, which has a
-		 * reserved slot.
-		 */
-		while (z_pm_core_devices[cdi]) {
-			if (strcmp(dev->name, z_pm_core_devices[cdi]) == 0) {
-				pm_devices[cdi] = pmi;
-				break;
-			}
-			++cdi;
-		}
-
-		/* Append the device if it doesn't have a reserved slot. */
-		if (cdi == core_dev) {
-			pm_devices[num_pm++] = pmi;
-		}
+		num_susp--;
 	}
 }
 #endif /* defined(CONFIG_PM) */

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -283,14 +283,3 @@ int pm_notifier_unregister(struct pm_notifier *notifier)
 
 	return ret;
 }
-
-#if CONFIG_PM_DEVICE
-static int pm_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	pm_create_device_list();
-	return 0;
-}
-SYS_INIT(pm_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif /* CONFIG_PM_DEVICE */


### PR DESCRIPTION
The list of devices is already sorted according to Kconfig priorities which
represent to some extent dependencies, since a device B depending on A
will never have prio(B) < prio(A).

This approach is still not perfect. All devices are iterated, including
those without PM. However, in a system with PM enabled most devices
will likely have PM support.

Fixes #34214

Alternative proposal to #35688