### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: fix reset of features

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -940,9 +940,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 		 */
 		conn->llcp_terminate.node_rx.hdr.link = link;
 #else
-		conn->llcp.fex.features_used = LL_FEAT;
-		conn->llcp.fex.features_peer = 0;
-		conn->llcp.vex.valid = 0;
+		/* Re-initialize the control procedure data structures */
+		ll_conn_init(conn);
+
 		conn->terminate.reason = 0;
 		/* NOTE: use allocated link for generating dedicated
 		 * terminate ind rx node
@@ -998,9 +998,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 #if (!defined(CONFIG_BT_LL_SW_SPLIT_LLCP_LEGACY))
 		/* Re-initialize the Tx Q */
 		ull_tx_q_init(&conn->tx_q);
-
-		/* Re-initialize the control procedure data structures */
-		ll_conn_init(conn);
 #else
 		conn->tx_head = conn->tx_ctrl = conn->tx_ctrl_last =
 		conn->tx_data = conn->tx_data_last = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -297,6 +297,7 @@ void ll_conn_init(struct ll_conn *conn)
 	 *
 	 */
 	memset(&conn->llcp.fex, 0, sizeof(conn->llcp.fex));
+	conn->llcp.fex.features_used = LL_FEAT;
 
 	/* Reset encryption related state */
 	conn->lll.enc_tx = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_hci.c
@@ -622,11 +622,11 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 			     conn->apto_reload;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
-	conn->llcp.fex.valid = 0U;
 	conn->master.terminate_ack = 0U;
 
-	conn->llcp.fex.features_used = LL_FEAT;
-	conn->llcp.fex.features_peer = 0;
+	/* Re-initialize the control procedure data structures */
+	ll_conn_init(conn);
+
 	conn->terminate.reason = 0U;
 
 	/* NOTE: use allocated link for generating dedicated
@@ -652,9 +652,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 
 	/* Re-initialize the Tx Q */
 	ull_tx_q_init(&conn->tx_q);
-
-	/* Re-initialize the control procedure data structures */
-	ll_conn_init(conn);
 
 	/* TODO: active_to_start feature port */
 	conn->ull.ticks_active_to_start = 0U;


### PR DESCRIPTION
During connection establishment the order of init of llcp subsystem leads to a clearance of initial value of features_used as configured in ll_create_connection() and ll_adv_enable()
