### PR TITLE
soc: arm: Set lpc55xxx flash wait states unconditionally

### DIFF
--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -50,7 +50,7 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Enable FRO HF(96MHz) output */
 	CLOCK_SetupFROClocking(96000000U);
 
-#if defined(CONFIG_SOC_FLASH_MCUX)
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/*!< Set FLASH wait states for core */
 	CLOCK_SetFLASHAccessCyclesForFreq(96000000U);
 #endif


### PR DESCRIPTION
Always set lpc55xxx flash wait states during SoC initialization,
regardless of whether the flash driver is enabled. This was
conditionalized in commit f5c6afeccb53e4121ba5e97294cf589a752623d9,
which caused applications without the flash driver enabled (e.g.,
hello_world on lpcxpresso55s69_cpu0) to not boot or show any console
output.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

@microbuilder I think this change reopens the possibility of a non-secure target accessing the IAP flash peripheral, which you were trying to avoid. Should we conditionalize SoC clock initialization on `CONFIG_TRUSTED_EXECUTION_SECURE`?