### PR TITLE
Fix C++ exception handling for 64-bit architectures

### DIFF
--- a/include/linker/cplusplus-ram.ld
+++ b/include/linker/cplusplus-ram.ld
@@ -18,14 +18,14 @@
 
     SECTION_PROLOGUE(.eh_frame,,)
 	{
-	KEEP (*(EXCLUDE_FILE (*crtend.o) .eh_frame))
-	KEEP (*(.eh_frame))
+	KEEP (*(SORT_NONE(EXCLUDE_FILE (*crtend.o) .eh_frame)))
+	KEEP (*(SORT_NONE(.eh_frame)))
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
     SECTION_PROLOGUE(.tm_clone_table,,)
 	{
-	KEEP (*(EXCLUDE_FILE (*crtend.o) .tm_clone_table))
-	KEEP (*(.tm_clone_table))
+	KEEP (*(SORT_NONE(EXCLUDE_FILE (*crtend.o) .tm_clone_table)))
+	KEEP (*(SORT_NONE(.tm_clone_table)))
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_EXCEPTIONS */
 

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -54,6 +54,7 @@ if LIB_CPLUSPLUS
 
 config EXCEPTIONS
 	bool "Enable C++ exceptions support"
+	depends on !NIOS2 && !SPARC
 	help
 	  This option enables support of C++ exceptions.
 

--- a/tests/subsys/cpp/libcxx/testcase.yaml
+++ b/tests/subsys/cpp/libcxx/testcase.yaml
@@ -9,8 +9,7 @@ tests:
     min_flash: 54
     tags: cpp
   cpp.libcxx.exceptions:
-    # FIXME: change when issue is resolved #32448
-    platform_allow: mps2_an385 qemu_arc_em qemu_arc_hs qemu_cortex_m0 qemu_cortex_m3 qemu_cortex_r5 qemu_riscv32 qemu_x86 qemu_xtensa
+    arch_exclude: nios2 sparc
     toolchain_exclude: xcc
     min_flash: 54
     tags: cpp


### PR DESCRIPTION
This series fixes the C++ exception handling support for 64-bit architectures (ARM64, RISCV64, x86_64).

```
linker: cpp: Disable sorting of C++ exception handling info sections

The `CONFIG_LINKER_SORT_BY_ALIGNMENT` config, which is enabled by
default, causes the sections containing C++ exception handling
information to be re-ordered for certain targets (in particular, the
64-bit arch targets). This effectively breaks the required "crtbegin.o
-> others -> crtend.o" order and causes the address of the
__EH_FRAME_BEGIN__ symbol to be invalid; thereby, causing C++
exception unwinding to fail.

This commit adds SORT_NONE property to these sections in order to
ensure that the linking order specified in the linker command line is
maintained.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

Note that ~~SPARC is still broken~~, and NIOS2 cannot be verified without a real hardware due to the limitations of `qemu_nios2` (it would be very helpful if anyone with NIOS2 hardware environment can verify if C++ exception handling works on it).

EDIT: #35733 supposedly fixes SPARC. It should be reviewed separately by the SPARC maintainers.