### PR TITLE
drivers: can: init timing.sjw also in canfd mode

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -343,11 +343,11 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 	}
 #endif
 
+	timing.sjw = cfg->sjw;
 #ifdef CONFIG_CAN_FD_MODE
 	timing_data.sjw = cfg->sjw_data;
 	can_mcan_configure_timing(can, &timing, &timing_data);
 #else
-	timing.sjw = cfg->sjw;
 	can_mcan_configure_timing(can, &timing, NULL);
 #endif
 


### PR DESCRIPTION
This commit resolves the undefined behavior caused by missing timing.sjw
initialization.

As suggested in #35487 include only the bug-fix, such that it can still be merged in 2.6.
Fixes: #35737