### PR TITLE
Bluetooth: Audio: Rename bt_vcs to bt_vcs_included

### DIFF
--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -52,13 +52,13 @@ struct bt_vcs_register_param {
 };
 
 /**
- * @brief Volume Control Service service instance
+ * @brief Volume Control Service included services
  *
- * Used for to represent a Volume Control Service instance, for either a client
- * or a server. The instance pointers either represent local server instances,
- * or remote service instances.
+ * Used for to represent the Volume Control Service included service instances,
+ * for either a client or a server. The instance pointers either represent
+ * local server instances, or remote service instances.
  */
-struct bt_vcs {
+struct bt_vcs_included {
 	/** Number of Volume Offset Control Service instances */
 	uint8_t vocs_cnt;
 	/** Array of pointers to Volume Offset Control Service instances */
@@ -83,19 +83,19 @@ struct bt_vcs {
 int bt_vcs_register(struct bt_vcs_register_param *param);
 
 /**
- * @brief Get Volume Control Service service pointer.
+ * @brief Get Volume Control Service included services.
  *
  * Returns a pointer to a struct that contains information about the
- * Volume Control Service instance, such as pointers to the
+ * Volume Control Service included service instances, such as pointers to the
  * Volume Offset Control Service (Volume Offset Control Service) or
  * Audio Input Control Service (AICS) instances.
  *
  * @param conn          Connection to peer device, or NULL to get server value.
- * @param[out] service  Pointer to store the result in.
+ * @param[out] included Pointer to store the result in.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_get(struct bt_conn *conn, struct bt_vcs *service);
+int bt_vcs_included_get(struct bt_conn *conn, struct bt_vcs_included *included);
 
 /**
  * @brief Callback function for bt_vcs_discover.

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -423,26 +423,26 @@ static bool valid_aics_inst(struct bt_aics *aics)
 	return false;
 }
 
-int bt_vcs_get(struct bt_conn *conn, struct bt_vcs *service)
+int bt_vcs_included_get(struct bt_conn *conn, struct bt_vcs_included *included)
 {
 	if (conn != NULL) {
 		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_get(conn, service);
+			return bt_vcs_client_included_get(conn, included);
 		} else {
 			return -EOPNOTSUPP;
 		}
 	}
 
 #if defined(CONFIG_BT_VCS)
-	if (service == NULL) {
+	if (included == NULL) {
 		return -EINVAL;
 	}
 
-	service->vocs_cnt = ARRAY_SIZE(vcs_inst.vocs_insts);
-	service->vocs = vcs_inst.vocs_insts;
+	included->vocs_cnt = ARRAY_SIZE(vcs_inst.vocs_insts);
+	included->vocs = vcs_inst.vocs_insts;
 
-	service->aics_cnt = ARRAY_SIZE(vcs_inst.aics_insts);
-	service->aics = vcs_inst.aics_insts;
+	included->aics_cnt = ARRAY_SIZE(vcs_inst.aics_insts);
+	included->aics = vcs_inst.aics_insts;
 
 	return 0;
 #else

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -807,12 +807,13 @@ int bt_vcs_client_cb_register(struct bt_vcs_cb *cb)
 	return 0;
 }
 
-int bt_vcs_client_get(struct bt_conn *conn, struct bt_vcs *client)
+int bt_vcs_client_included_get(struct bt_conn *conn,
+			       struct bt_vcs_included *included)
 {
 	uint8_t conn_index;
 	struct vcs_instance *vcs_inst;
 
-	CHECKIF(!client || !conn) {
+	CHECKIF(!included || !conn) {
 		return -EINVAL;
 	}
 
@@ -820,11 +821,11 @@ int bt_vcs_client_get(struct bt_conn *conn, struct bt_vcs *client)
 
 	conn_index = bt_conn_index(conn);
 
-	client->vocs_cnt = vcs_inst->vocs_inst_cnt;
-	client->vocs = vcs_insts[conn_index].vocs;
+	included->vocs_cnt = vcs_inst->vocs_inst_cnt;
+	included->vocs = vcs_insts[conn_index].vocs;
 
-	client->aics_cnt = vcs_inst->aics_inst_cnt;
-	client->aics = vcs_insts[conn_index].aics;
+	included->aics_cnt = vcs_inst->aics_inst_cnt;
+	included->aics = vcs_insts[conn_index].aics;
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/vcs_internal.h
+++ b/subsys/bluetooth/audio/vcs_internal.h
@@ -36,7 +36,8 @@ struct vcs_control_vol {
 	uint8_t volume;
 } __packed;
 
-int bt_vcs_client_get(struct bt_conn *conn, struct bt_vcs *client);
+int bt_vcs_client_included_get(struct bt_conn *conn,
+			       struct bt_vcs_included *included);
 int bt_vcs_client_read_vol_state(struct bt_conn *conn);
 int bt_vcs_client_read_flags(struct bt_conn *conn);
 int bt_vcs_client_vol_down(struct bt_conn *conn);

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -16,7 +16,7 @@
 
 #include "bt.h"
 
-static struct bt_vcs vcs;
+static struct bt_vcs_included vcs_included;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 			 uint8_t mute)
@@ -204,7 +204,11 @@ static int cmd_vcs_init(const struct shell *sh, size_t argc, char **argv)
 		return result;
 	}
 
-	bt_vcs_get(NULL, &vcs);
+	result = bt_vcs_included_get(NULL, &vcs_included);
+	if (result != 0) {
+		shell_error(sh, "Failed to get included services: %d", result);
+		return result;
+	}
 
 	return result;
 }
@@ -358,7 +362,7 @@ static int cmd_vcs_vocs_state_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_get(NULL, vcs.vocs[index]);
+	result = bt_vcs_vocs_state_get(NULL, vcs_included.vocs[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -378,7 +382,7 @@ static int cmd_vcs_vocs_location_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_location_get(NULL, vcs.vocs[index]);
+	result = bt_vcs_vocs_location_get(NULL, vcs_included.vocs[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -405,7 +409,8 @@ static int cmd_vcs_vocs_location_set(const struct shell *sh, size_t argc,
 
 	}
 
-	result = bt_vcs_vocs_location_set(NULL, vcs.vocs[index], location);
+	result = bt_vcs_vocs_location_set(NULL, vcs_included.vocs[index],
+					  location);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -432,7 +437,7 @@ static int cmd_vcs_vocs_offset_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_set(NULL, vcs.vocs[index], offset);
+	result = bt_vcs_vocs_state_set(NULL, vcs_included.vocs[index], offset);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -452,7 +457,7 @@ static int cmd_vcs_vocs_output_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_get(NULL, vcs.vocs[index]);
+	result = bt_vcs_vocs_description_get(NULL, vcs_included.vocs[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -473,7 +478,7 @@ static int cmd_vcs_vocs_output_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_set(NULL, vcs.vocs[index],
+	result = bt_vcs_vocs_description_set(NULL, vcs_included.vocs[index],
 					     description);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -488,13 +493,13 @@ static int cmd_vcs_aics_input_state_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_state_get(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_state_get(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -508,13 +513,13 @@ static int cmd_vcs_aics_gain_setting_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_setting_get(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_gain_setting_get(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -528,13 +533,13 @@ static int cmd_vcs_aics_input_type_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_type_get(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_type_get(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -548,13 +553,13 @@ static int cmd_vcs_aics_input_status_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_status_get(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_status_get(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -568,13 +573,13 @@ static int cmd_vcs_aics_input_unmute(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_unmute(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_unmute(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -588,13 +593,13 @@ static int cmd_vcs_aics_input_mute(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_mute(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_mute(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -608,13 +613,13 @@ static int cmd_vcs_aics_manual_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_manual_gain_set(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_manual_gain_set(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -628,13 +633,13 @@ static int cmd_vcs_aics_automatic_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_automatic_gain_set(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_automatic_gain_set(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -649,9 +654,9 @@ static int cmd_vcs_aics_gain_set(const struct shell *sh, size_t argc,
 	int index = strtol(argv[1], NULL, 0);
 	int gain = strtol(argv[2], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -661,7 +666,7 @@ static int cmd_vcs_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_set(NULL, vcs.aics[index], gain);
+	result = bt_vcs_aics_gain_set(NULL, vcs_included.aics[index], gain);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -675,13 +680,13 @@ static int cmd_vcs_aics_input_description_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_get(NULL, vcs.aics[index]);
+	result = bt_vcs_aics_description_get(NULL, vcs_included.aics[index]);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -696,13 +701,14 @@ static int cmd_vcs_aics_input_description_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	char *description = argv[2];
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_set(NULL, vcs.aics[index], description);
+	result = bt_vcs_aics_description_set(NULL, vcs_included.aics[index],
+					     description);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -15,7 +15,7 @@
 
 #include "bt.h"
 
-static struct bt_vcs vcs;
+static struct bt_vcs_included vcs_included;
 
 static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 			    uint8_t aics_count)
@@ -26,7 +26,7 @@ static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 		shell_print(ctx_shell, "VCS discover done with %u AICS",
 			    aics_count);
 
-		if (bt_vcs_get(conn, &vcs)) {
+		if (bt_vcs_included_get(conn, &vcs_included)) {
 			shell_error(ctx_shell, "Could not get VCS context");
 		}
 	}
@@ -540,13 +540,13 @@ static int cmd_vcs_client_vocs_state_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_get(default_conn, vcs.vocs[index]);
+	result = bt_vcs_vocs_state_get(default_conn, vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -565,13 +565,14 @@ static int cmd_vcs_client_vocs_location_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_location_get(default_conn, vcs.vocs[index]);
+	result = bt_vcs_vocs_location_get(default_conn,
+					  vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -591,9 +592,9 @@ static int cmd_vcs_client_vocs_location_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -604,7 +605,8 @@ static int cmd_vcs_client_vocs_location_set(const struct shell *sh,
 
 	}
 
-	result = bt_vcs_vocs_location_set(default_conn, vcs.vocs[index],
+	result = bt_vcs_vocs_location_set(default_conn,
+					  vcs_included.vocs[index],
 					  location);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -625,9 +627,9 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -637,7 +639,9 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_set(default_conn, vcs.vocs[index], offset);
+	result = bt_vcs_vocs_state_set(default_conn,
+				       vcs_included.vocs[index],
+				       offset);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -656,13 +660,14 @@ static int cmd_vcs_client_vocs_output_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_get(default_conn, vcs.vocs[index]);
+	result = bt_vcs_vocs_description_get(default_conn,
+					     vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -682,13 +687,14 @@ static int cmd_vcs_client_vocs_output_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.vocs_cnt) {
+	if (index >= vcs_included.vocs_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.vocs_cnt, index);
+			    vcs_included.vocs_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_set(default_conn, vcs.vocs[index],
+	result = bt_vcs_vocs_description_set(default_conn,
+					     vcs_included.vocs[index],
 					     description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -708,13 +714,13 @@ static int cmd_vcs_client_aics_input_state_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_state_get(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_state_get(default_conn, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -733,13 +739,14 @@ static int cmd_vcs_client_aics_gain_setting_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_setting_get(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_gain_setting_get(default_conn,
+					      vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -758,13 +765,13 @@ static int cmd_vcs_client_aics_input_type_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_type_get(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_type_get(default_conn, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -783,13 +790,13 @@ static int cmd_vcs_client_aics_input_status_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_status_get(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_status_get(default_conn, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -808,13 +815,13 @@ static int cmd_vcs_client_aics_input_unmute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_unmute(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_unmute(default_conn, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -833,13 +840,13 @@ static int cmd_vcs_client_aics_input_mute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_mute(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_mute(default_conn, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -858,13 +865,14 @@ static int cmd_vcs_client_aics_manual_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_manual_gain_set(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_manual_gain_set(default_conn,
+					     vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -883,13 +891,14 @@ static int cmd_vcs_client_aics_auto_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_automatic_gain_set(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_automatic_gain_set(default_conn,
+						vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -909,9 +918,9 @@ static int cmd_vcs_client_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -921,7 +930,8 @@ static int cmd_vcs_client_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_set(default_conn, vcs.aics[index], gain);
+	result = bt_vcs_aics_gain_set(default_conn,
+				      vcs_included.aics[index], gain);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -940,13 +950,14 @@ static int cmd_vcs_client_aics_input_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_get(default_conn, vcs.aics[index]);
+	result = bt_vcs_aics_description_get(default_conn,
+					     vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -966,13 +977,14 @@ static int cmd_vcs_client_aics_input_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (index >= vcs.aics_cnt) {
+	if (index >= vcs_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcs.aics_cnt, index);
+			    vcs_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_set(default_conn, vcs.aics[index],
+	result = bt_vcs_aics_description_set(default_conn,
+					     vcs_included.aics[index],
 					     description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -18,7 +18,7 @@
 static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 
-static struct bt_vcs vcs;
+static struct bt_vcs_included vcs_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
 static volatile bool g_mtu_exchanged;
@@ -314,7 +314,7 @@ static int test_aics(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_vcs_aics_state_get(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_state_get(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -324,7 +324,7 @@ static int test_aics(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_vcs_aics_gain_setting_get(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_gain_setting_get(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -335,7 +335,7 @@ static int test_aics(void)
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	g_cb = false;
-	err = bt_vcs_aics_type_get(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_type_get(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -346,7 +346,7 @@ static int test_aics(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_vcs_aics_status_get(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_status_get(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -356,7 +356,7 @@ static int test_aics(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_vcs_aics_description_get(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_description_get(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -367,7 +367,7 @@ static int test_aics(void)
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_mute(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_mute(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -379,7 +379,7 @@ static int test_aics(void)
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_unmute(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_unmute(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -391,7 +391,7 @@ static int test_aics(void)
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_automatic_gain_set(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_automatic_gain_set(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -402,7 +402,7 @@ static int test_aics(void)
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_manual_gain_set(g_conn, vcs.aics[0]);
+	err = bt_vcs_aics_manual_gain_set(g_conn, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -413,7 +413,7 @@ static int test_aics(void)
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_gain_set(g_conn, vcs.aics[0], expected_gain);
+	err = bt_vcs_aics_gain_set(g_conn, vcs_included.aics[0], expected_gain);
 	if (err) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -426,7 +426,7 @@ static int test_aics(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_aics_description_set(g_conn, vcs.aics[0],
+	err = bt_vcs_aics_description_set(g_conn, vcs_included.aics[0],
 					  expected_aics_desc);
 	if (err) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
@@ -450,7 +450,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS state\n");
 	g_cb = false;
-	err = bt_vcs_vocs_state_get(g_conn, vcs.vocs[0]);
+	err = bt_vcs_vocs_state_get(g_conn, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
@@ -460,7 +460,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS location\n");
 	g_cb = false;
-	err = bt_vcs_vocs_location_get(g_conn, vcs.vocs[0]);
+	err = bt_vcs_vocs_location_get(g_conn, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
@@ -470,7 +470,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS description\n");
 	g_cb = false;
-	err = bt_vcs_vocs_description_get(g_conn, vcs.vocs[0]);
+	err = bt_vcs_vocs_description_get(g_conn, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
@@ -481,7 +481,8 @@ static int test_vocs(void)
 	printk("Setting VOCS location\n");
 	expected_location = g_vocs_location + 1;
 	g_cb = false;
-	err = bt_vcs_vocs_location_set(g_conn, vcs.vocs[0], expected_location);
+	err = bt_vcs_vocs_location_set(g_conn, vcs_included.vocs[0],
+				       expected_location);
 	if (err) {
 		FAIL("Could not set VOCS location (err %d)\n", err);
 		return err;
@@ -492,7 +493,7 @@ static int test_vocs(void)
 	printk("Setting VOCS state\n");
 	expected_offset = g_vocs_offset + 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_vocs_state_set(g_conn, vcs.vocs[0], expected_offset);
+	err = bt_vcs_vocs_state_set(g_conn, vcs_included.vocs[0], expected_offset);
 	if (err) {
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
@@ -505,7 +506,7 @@ static int test_vocs(void)
 		sizeof(expected_description));
 	expected_description[sizeof(expected_description) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_vocs_description_set(g_conn, vcs.vocs[0],
+	err = bt_vcs_vocs_description_set(g_conn, vcs_included.vocs[0],
 					  expected_description);
 	if (err) {
 		FAIL("Could not set VOCS description (err %d)\n", err);
@@ -571,9 +572,9 @@ static void test_main(void)
 
 	WAIT_FOR(g_discovery_complete);
 
-	err = bt_vcs_get(g_conn, &vcs);
+	err = bt_vcs_included_get(g_conn, &vcs_included);
 	if (err) {
-		FAIL("Failed to get VCS context (err %d)\n", err);
+		FAIL("Failed to get VCS included services (err %d)\n", err);
 		return;
 	}
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -22,7 +22,7 @@ extern enum bst_result_t bst_result;
 #define AICS_DESC_SIZE 0
 #endif /* CONFIG_BT_AICS */
 
-static struct bt_vcs vcs;
+static struct bt_vcs_included vcs_included;
 
 static volatile uint8_t g_volume;
 static volatile uint8_t g_mute;
@@ -251,7 +251,7 @@ static int test_aics_standalone(void)
 
 	printk("Deactivating AICS\n");
 	expected_aics_active = false;
-	err = bt_vcs_aics_deactivate(vcs.aics[0]);
+	err = bt_vcs_aics_deactivate(vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
@@ -261,7 +261,7 @@ static int test_aics_standalone(void)
 
 	printk("Activating AICS\n");
 	expected_aics_active = true;
-	err = bt_vcs_aics_activate(vcs.aics[0]);
+	err = bt_vcs_aics_activate(vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
@@ -271,7 +271,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_vcs_aics_state_get(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_state_get(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -281,7 +281,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_vcs_aics_gain_setting_get(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_gain_setting_get(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -291,7 +291,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
-	err = bt_vcs_aics_type_get(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_type_get(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -302,7 +302,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_vcs_aics_status_get(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_status_get(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -312,7 +312,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_vcs_aics_description_get(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_description_get(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -322,7 +322,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
-	err = bt_vcs_aics_mute(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_mute(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -332,7 +332,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
-	err = bt_vcs_aics_unmute(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_unmute(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -342,7 +342,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
-	err = bt_vcs_aics_automatic_gain_set(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_automatic_gain_set(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -352,7 +352,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
-	err = bt_vcs_aics_manual_gain_set(NULL, vcs.aics[0]);
+	err = bt_vcs_aics_manual_gain_set(NULL, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -362,7 +362,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
-	err = bt_vcs_aics_gain_set(NULL, vcs.aics[0], expected_gain);
+	err = bt_vcs_aics_gain_set(NULL, vcs_included.aics[0], expected_gain);
 	if (err) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -375,7 +375,8 @@ static int test_aics_standalone(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_aics_description_set(NULL, vcs.aics[0], expected_aics_desc);
+	err = bt_vcs_aics_description_set(NULL, vcs_included.aics[0],
+					  expected_aics_desc);
 	if (err) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
@@ -396,7 +397,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS state\n");
 	g_cb = false;
-	err = bt_vcs_vocs_state_get(NULL, vcs.vocs[0]);
+	err = bt_vcs_vocs_state_get(NULL, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
@@ -406,7 +407,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS location\n");
 	g_cb = false;
-	err = bt_vcs_vocs_location_get(NULL, vcs.vocs[0]);
+	err = bt_vcs_vocs_location_get(NULL, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
@@ -416,7 +417,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS description\n");
 	g_cb = false;
-	err = bt_vcs_vocs_description_get(NULL, vcs.vocs[0]);
+	err = bt_vcs_vocs_description_get(NULL, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
@@ -426,7 +427,7 @@ static int test_vocs_standalone(void)
 
 	printk("Setting VOCS location\n");
 	expected_location = g_vocs_location + 1;
-	err = bt_vcs_vocs_location_set(NULL, vcs.vocs[0], expected_location);
+	err = bt_vcs_vocs_location_set(NULL, vcs_included.vocs[0], expected_location);
 	if (err) {
 		FAIL("Could not set VOCS location (err %d)\n", err);
 		return err;
@@ -436,7 +437,7 @@ static int test_vocs_standalone(void)
 
 	printk("Setting VOCS state\n");
 	expected_offset = g_vocs_offset + 1;
-	err = bt_vcs_vocs_state_set(NULL, vcs.vocs[0], expected_offset);
+	err = bt_vcs_vocs_state_set(NULL, vcs_included.vocs[0], expected_offset);
 	if (err) {
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
@@ -449,7 +450,7 @@ static int test_vocs_standalone(void)
 		sizeof(expected_description) - 1);
 	expected_description[sizeof(expected_description) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_vocs_description_set(NULL, vcs.vocs[0],
+	err = bt_vcs_vocs_description_set(NULL, vcs_included.vocs[0],
 					  expected_description);
 	if (err) {
 		FAIL("Could not set VOCS description (err %d)\n", err);
@@ -513,9 +514,9 @@ static void test_standalone(void)
 		return;
 	}
 
-	err = bt_vcs_get(NULL, &vcs);
+	err = bt_vcs_included_get(NULL, &vcs_included);
 	if (err) {
-		FAIL("VCS get failed (err %d)\n", err);
+		FAIL("VCS included get failed (err %d)\n", err);
 		return;
 	}
 
@@ -708,9 +709,9 @@ static void test_main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_vcs_get(NULL, &vcs);
+	err = bt_vcs_included_get(NULL, &vcs_included);
 	if (err) {
-		FAIL("VCS get failed (err %d)\n", err);
+		FAIL("VCS included get failed (err %d)\n", err);
 		return;
 	}
 


### PR DESCRIPTION
Rename the struct from bt_vcs to bt_vcs_included, and
rename bt_vcs_get to bt_vcs_included_get as that is more
descriptive of the value returned.

Furthermore, this will also allow us to use bt_vcs as
an opaque pointer to a VCS service instance (local
or remote) to match the service instance pointers of
AICS and VOCS.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>