### PR TITLE
x86: acpi: use memory mapping/unmapping to access ACPI tables

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -224,7 +224,6 @@ endchoice
 config ACPI
 	bool "ACPI (Advanced Configuration and Power Interface) support"
 	depends on X86_PC_COMPATIBLE
-	select ARCH_MAPS_ALL_RAM
 	help
 	  Allow retrieval of platform configuration at runtime.
 

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -236,7 +236,7 @@ config PCIE_MMIO_CFG
 	  IO Port registers.
 
 config KERNEL_VM_SIZE
-	default 0xC0000000 if ACPI
+	default 0x40000000 if ACPI
 
 config X86_PC_COMPATIBLE
 	bool

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -50,8 +50,11 @@ static void find_rsdp(void)
 	bda_seg = 0x040e + zero_page_base;
 	uint64_t *search = (void *)(long)(((int)*(uint16_t *)bda_seg) << 4);
 
-	/* Might be nothing there, check before we inspect */
-	if (search != NULL) {
+	/* Might be nothing there, check before we inspect.
+	 * Note that EBDA usually is in 0x80000 to 0x100000.
+	 */
+	if ((POINTER_TO_UINT(search) >= 0x80000UL) &&
+	    (POINTER_TO_UINT(search) < 0x100000UL)) {
 		for (int i = 0; i < 1024/8; i++) {
 			if (search[i] == ACPI_RSDP_SIGNATURE) {
 				rsdp = (void *)&search[i];


### PR DESCRIPTION
Instead of accessing ACPI tables through physical address, do memory mapping/unmapping so they can be accessed via virtual addresses. This allows us to avoid identity mapping all physical memory, and thus no need for a page table large enough to map everything.

And, since physical memory is no longer wholly identity mapped, it is not needed to set the VM size to be larger than physical memory size. The VM size was 2GB (max physical memory size of x86 boards) + 1GB (for memory mappings). So simply shrink the size to 1GB, as the kernel size is small and we still have a large chunk of space to do memory mapping.