### PR TITLE
Doc build fixes

### DIFF
--- a/doc/_extensions/zephyr/external_content.py
+++ b/doc/_extensions/zephyr/external_content.py
@@ -154,7 +154,7 @@ def sync_contents(app: Sphinx) -> None:
 
                 if not filecmp.cmp(src_adjusted, dst):
                     dst.unlink()
-                    src_adjusted.rename(dst)
+                    shutil.move(os.fspath(src_adjusted), os.fspath(dst))
 
     # remove any previously copied file not present in the origin folder,
     # excepting those marked to be kept.

--- a/doc/custom-doxygen/mainpage.md
+++ b/doc/custom-doxygen/mainpage.md
@@ -1,4 +1,4 @@
-# API Documentation   {#index}
+# API Documentation
 
 ## Introduction
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1021,13 +1021,6 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 2
-
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
 # can be used to specify a prefix (or a list of prefixes) that should be ignored


### PR DESCRIPTION
I can't build the docs right now on Arch Linux due to 2 issues:

- a doxygen 1.9.1 warning being treated as an error
- a bug in external_content.py

This PR has fixes for those.

I also am getting a warning about an obsolete Doxygen configuration variable now, so there's a patch removing it as well.