### PR TITLE
drivers: timer: fix device PM usage

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -7,6 +7,13 @@
 
 menu "Timer Drivers"
 
+config TIMER_USE_PM_DEVICE
+	bool
+	help
+	  This option must be selected by timer drivers that want to add support
+	  for device power management. When this option is enabled, the weak
+	  function "sys_clock_device_ctrl" is defined for this purpose.
+
 menuconfig APIC_TIMER
 	bool "New local APIC timer"
 	depends on X86

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -30,13 +30,6 @@ int __weak sys_clock_driver_init(const struct device *dev)
 	return 0;
 }
 
-int __weak sys_clock_device_ctrl(const struct device *dev,
-			       uint32_t ctrl_command,
-			       uint32_t *context, pm_device_cb cb, void *arg)
-{
-	return -ENOSYS;
-}
-
 void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 }
@@ -48,6 +41,19 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_disable(void)
 {
 }
+
+#ifdef CONFIG_TIMER_USE_PM_DEVICE
+int __weak sys_clock_device_ctrl(const struct device *dev,
+				 uint32_t ctrl_command, uint32_t *context,
+				 pm_device_cb cb, void *arg)
+{
+	__ASSERT_NO_MSG(false);
+
+	return -ENOSYS;
+}
+#else
+#define sys_clock_device_ctrl NULL
+#endif
 
 SYS_DEVICE_DEFINE("sys_clock", sys_clock_driver_init, sys_clock_device_ctrl,
 		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);


### PR DESCRIPTION
If a device does not implement device PM it needs to provide a NULL
pointer when defining the device. The `sys_clock` driver provided a weak
function returning `-ENOSYS`, so it did not follow the requirements.
This change requires drivers implementing device PM to select the
`TIMER_USE_PM_DEVICE` option. This will enable the
`sys_clock_device_ctrl` weak function, so that the driver can provide an
implementation.