### PR TITLE
drivers: flash: nrf_qspi_nor: Fix no multithreading compilation

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -390,7 +390,6 @@ static int anomaly_122_init(const struct device *dev)
 
 static void anomaly_122_uninit(const struct device *dev)
 {
-	struct qspi_nor_data *dev_data = get_dev_data(dev);
 	bool last = true;
 
 	if (!nrf52_errata_122()) {
@@ -399,11 +398,13 @@ static void anomaly_122_uninit(const struct device *dev)
 
 	qspi_lock(dev);
 
-	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-		/* The last thread to finish using the driver uninit the QSPI */
-		(void) k_sem_take(&dev_data->count, K_NO_WAIT);
-		last = (k_sem_count_get(&dev_data->count) == 0);
-	}
+#ifdef CONFIG_MULTITHREADING
+	struct qspi_nor_data *dev_data = get_dev_data(dev);
+
+	/* The last thread to finish using the driver uninit the QSPI */
+	(void) k_sem_take(&dev_data->count, K_NO_WAIT);
+	last = (k_sem_count_get(&dev_data->count) == 0);
+#endif
 
 	if (last) {
 		while (nrfx_qspi_mem_busy_check() != NRFX_SUCCESS) {


### PR DESCRIPTION
Fixing error introduced in 951e72b94769f55b0c2f2cf70f81d063ec81d11e where
ifdef was converted to IS_ENABLED. Ifdef was required because element in
the struct does not exist when multithreading is disabled.

My bad: https://github.com/zephyrproject-rtos/zephyr/pull/35634/files#r638799709

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>