### PR TITLE
Bluetooth: host: Log failure to initiatie security for bonded peer

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4833,7 +4833,12 @@ void bt_gatt_connected(struct bt_conn *conn)
 	 */
 	if (IS_ENABLED(CONFIG_BT_SMP) &&
 	    bt_conn_get_security(conn) < data.sec) {
-		bt_conn_set_security(conn, data.sec);
+		int err = bt_conn_set_security(conn, data.sec);
+
+		if (err) {
+			BT_WARN("Failed to set security for bonded peer (%d)",
+				err);
+		}
 	}
 
 #if defined(CONFIG_BT_GATT_CLIENT)


### PR DESCRIPTION
Log failure to initiatet security for bonded peer when GATT wants to
initiate security for CCCs for the remote.

Fixes: #33028