### PR TITLE
soc: xtensa: linker: Update linker scripts for C++ build

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v15/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v15/linker.ld
@@ -474,6 +474,11 @@ SECTIONS
     *(.cached .cached.*)
   } >ram :ram_phdr
 
+  .tm_clone_table SEGSTART_UNCACHED :
+  {
+    *(.tm_clone_table)
+  } >ram :ram_phdr
+
   . = ALIGN(4096);
 
   .bss SEGSTART_UNCACHED (NOLOAD) :

--- a/soc/xtensa/intel_adsp/cavs_v18/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v18/linker.ld
@@ -479,6 +479,11 @@ SECTIONS
     *(.cached .cached.*)
   } >ram :ram_phdr
 
+  .tm_clone_table SEGSTART_UNCACHED :
+  {
+    *(.tm_clone_table)
+  } >ram :ram_phdr
+
   . = ALIGN(4096);
 
   .bss SEGSTART_UNCACHED (NOLOAD) :

--- a/soc/xtensa/intel_adsp/cavs_v20/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v20/linker.ld
@@ -446,6 +446,11 @@ SECTIONS
   } >ram :ram_phdr
 #include <linker/common-ram.ld>
 
+  .tm_clone_table :
+  {
+    *(.tm_clone_table)
+  } >ram :ram_phdr
+
   .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN(4096);

--- a/soc/xtensa/intel_adsp/cavs_v25/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v25/linker.ld
@@ -515,6 +515,11 @@ SECTIONS
 	_loader_storage_manifest_end = ABSOLUTE(.);
   } >ram :ram_phdr
 
+  .tm_clone_table :
+  {
+    *(.tm_clone_table)
+  } >ram :ram_phdr
+
   .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN(4096);

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -426,6 +426,11 @@ SECTIONS
   } >ram :ram_phdr
 #include <linker/common-ram.ld>
 
+  .tm_clone_table :
+  {
+    *(.tm_clone_table)
+  } >ram :ram_phdr
+
   .bss (NOLOAD) : ALIGN(8)
   {
     . = ALIGN (8);


### PR DESCRIPTION
When we link in crtbegin.o for C++ exception support we end up pulling
in the .tm_clone_table section.  We need to update the linker scripts
to handle this.  soc/xtensa/sample_controller/linker.ld was already
updated, this fixes the others.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>