### PR TITLE
Add HCI commands and events for Direction Finding connected mode

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1542,6 +1542,20 @@ struct bt_hci_rp_le_set_cl_cte_sampling_enable {
 	uint16_t sync_handle;
 } __packed;
 
+#define BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS BT_OP(BT_OGF_LE, 0x0054)
+struct bt_hci_cp_le_set_conn_cte_rx_params {
+	uint16_t handle;
+	uint8_t  sampling_enable;
+	uint8_t  slot_durations;
+	uint8_t  switch_pattern_len;
+	uint8_t  ant_ids[0];
+} __packed;
+
+struct bt_hci_rp_le_set_conn_cte_rx_params {
+	uint8_t  status;
+	uint16_t handle;
+} __packed;
+
 #define BT_HCI_LE_AOA_CTE_RSP                   BIT(0)
 #define BT_HCI_LE_AOD_CTE_RSP_1US               BIT(1)
 #define BT_HCI_LE_AOD_CTE_RSP_2US               BIT(2)

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1595,6 +1595,17 @@ struct bt_hci_rp_le_conn_cte_req_enable {
 	uint16_t handle;
 } __packed;
 
+#define BT_HCI_OP_LE_CONN_CTE_RSP_ENABLE       BT_OP(BT_OGF_LE, 0x0057)
+struct bt_hci_cp_le_conn_cte_rsp_enable {
+	uint16_t handle;
+	uint8_t  enable;
+} __packed;
+
+struct bt_hci_rp_le_conn_cte_rsp_enable {
+	uint8_t  status;
+	uint16_t handle;
+} __packed;
+
 #define BT_HCI_LE_1US_AOD_TX                    BIT(0)
 #define BT_HCI_LE_1US_AOD_RX                    BIT(1)
 #define BT_HCI_LE_1US_AOA_RX                    BIT(2)

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1576,6 +1576,25 @@ struct bt_hci_rp_le_set_conn_cte_tx_params {
 	uint16_t handle;
 } __packed;
 
+/* Interval between consecutive CTE request procedure starts in number of connection events. */
+#define BT_HCI_REQUEST_CTE_ONCE                0x0
+#define BT_HCI_REQUEST_CTE_INTERVAL_MIN        0x1
+#define BT_HCI_REQUEST_CTE_INTERVAL_MAX        0xFFFF
+
+#define BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE       BT_OP(BT_OGF_LE, 0x0056)
+struct bt_hci_cp_le_conn_cte_req_enable {
+	uint16_t handle;
+	uint8_t  enable;
+	uint8_t  cte_request_interval;
+	uint8_t  requested_cte_length;
+	uint8_t  requested_cte_type;
+} __packed;
+
+struct bt_hci_rp_le_conn_cte_req_enable {
+	uint8_t  status;
+	uint16_t handle;
+} __packed;
+
 #define BT_HCI_LE_1US_AOD_TX                    BIT(0)
 #define BT_HCI_LE_1US_AOD_RX                    BIT(1)
 #define BT_HCI_LE_1US_AOA_RX                    BIT(2)

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -2455,6 +2455,27 @@ struct bt_hci_evt_le_connectionless_iq_report {
 	struct bt_hci_le_iq_sample sample[0];
 } __packed;
 
+#define BT_HCI_EVT_LE_CONNECTION_IQ_REPORT      0x16
+struct bt_hci_evt_le_connection_iq_report {
+	uint16_t conn_handle;
+	uint8_t  rx_phy;
+	uint8_t  data_chan_idx;
+	int16_t  rssi;
+	uint8_t  rssi_ant_id;
+	uint8_t  cte_type;
+	uint8_t  slot_durations;
+	uint8_t  packet_status;
+	uint16_t conn_evt_counter;
+	uint8_t  sample_count;
+	struct bt_hci_le_iq_sample sample[0];
+} __packed;
+
+#define BT_HCI_EVT_LE_CTE_REQUEST_FAILED       0x17
+struct bt_hci_evt_le_cte_req_failed {
+	uint8_t  status;
+	uint16_t conn_handle;
+} __packed;
+
 #define BT_HCI_EVT_LE_PAST_RECEIVED                0x18
 struct bt_hci_evt_le_past_received {
 	uint8_t      status;
@@ -2644,6 +2665,8 @@ struct bt_hci_evt_le_biginfo_adv_report {
 #define BT_EVT_MASK_LE_SCAN_REQ_RECEIVED         BT_EVT_BIT(18)
 #define BT_EVT_MASK_LE_CHAN_SEL_ALGO             BT_EVT_BIT(19)
 #define BT_EVT_MASK_LE_CONNECTIONLESS_IQ_REPORT  BT_EVT_BIT(21)
+#define BT_EVT_MASK_LE_CONNECTION_IQ_REPORT      BT_EVT_BIT(22)
+#define BT_EVT_MASK_LE_CTE_REQUEST_FAILED        BT_EVT_BIT(23)
 #define BT_EVT_MASK_LE_PAST_RECEIVED             BT_EVT_BIT(23)
 #define BT_EVT_MASK_LE_CIS_ESTABLISHED           BT_EVT_BIT(24)
 #define BT_EVT_MASK_LE_CIS_REQ                   BT_EVT_BIT(25)

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1568,7 +1568,7 @@ struct bt_hci_cp_le_set_conn_cte_tx_params {
 	uint16_t handle;
 	uint8_t  cte_types;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_id[0];
+	uint8_t  ant_ids[0];
 } __packed;
 
 struct bt_hci_rp_le_set_conn_cte_tx_params {

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -559,6 +559,13 @@ config BT_DF_CONNECTIONLESS_CTE_RX
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connectionless mode.
 
+config BT_DF_CONNECTION_CTE_RX
+	bool "Enable support for receive of CTE in connection mode"
+	depends on BT_DF
+	help
+	  Enable support for reception and sampling of Constant Tone Extension
+	  in connection mode.
+
 config BT_DEBUG_DF
 	bool "Bluetooth Direction Finding debug"
 	depends on BT_DF

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2769,6 +2769,11 @@ static int le_set_event_mask(void)
 		mask |= BT_EVT_MASK_LE_CONNECTIONLESS_IQ_REPORT;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_DF_CONNECTION_CTE_RX)) {
+		mask |= BT_EVT_MASK_LE_CONNECTION_IQ_REPORT;
+		mask |= BT_EVT_MASK_LE_CTE_REQUEST_FAILED;
+	}
+
 	sys_put_le64(mask, cp_mask->events);
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EVENT_MASK, buf, NULL);
 }


### PR DESCRIPTION
Add commands:
- HCI_LE_Connection_CTE_Response_Enable,
- HCI_LE_Connection_CTE_Response_Enable,
- HCI_LE_Set_Connection_CTE_Receive_Parameters.

Add events:
- HCI_LE_Connection_IQ_Report,
- HCI_LE_CTE_Request_Failed.

All commands and events are required for operation of Direction Finding in connected mode.