### PR TITLE
doc/releases: v2.6.0: Updated Major enhancements section

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -9,6 +9,11 @@ We are pleased to announce the release of Zephyr RTOS version 2.6.0.
 
 Major enhancements with this release include:
 
+* Added support for 64-bit ARCv3
+* Split ARM32 and ARM64, ARM64 is now a top-level architecture
+* Added initial support for Arm v8.1-m and Cortex-M55
+* Removed legacy TCP stack support which was deprecated in 2.4
+
 The following sections provide detailed lists of changes by component.
 
 Security Vulnerability Related


### PR DESCRIPTION
Added bullets for ARC64, ARM32/64 split, TCP legacy removal, and ARM v8.1-m support.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>