### PR TITLE
doc: release notes: added oneApi toolchain to release notes

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -656,6 +656,7 @@ Build and Infrastructure
 ************************
 
 * Improved support for additional toolchains:
+  * Support for the Intel oneApi toolchain.
 
 * Devicetree
 


### PR DESCRIPTION
Adding Intel oneApi as new toolchain supported in Zephyr.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>