### PR TITLE
Fix bug: missing return parameter for connectionless CTE receive enable

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1537,6 +1537,11 @@ struct bt_hci_cp_le_set_cl_cte_sampling_enable {
 	uint8_t  ant_ids[0];
 } __packed;
 
+struct bt_hci_rp_le_set_cl_cte_sampling_enable {
+	uint8_t  status;
+	uint16_t sync_handle;
+} __packed;
+
 #define BT_HCI_LE_AOA_CTE_RSP                   BIT(0)
 #define BT_HCI_LE_AOD_CTE_RSP_1US               BIT(1)
 #define BT_HCI_LE_AOD_CTE_RSP_2US               BIT(2)

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2590,6 +2590,7 @@ static void le_df_set_cl_cte_enable(struct net_buf *buf, struct net_buf **evt)
 static void le_df_set_cl_iq_sampling_enable(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_cl_cte_sampling_enable *cmd = (void *)buf->data;
+	struct bt_hci_rp_le_set_cl_cte_sampling_enable *rp;
 	uint16_t sync_handle;
 	uint8_t status;
 
@@ -2602,7 +2603,10 @@ static void le_df_set_cl_iq_sampling_enable(struct net_buf *buf, struct net_buf 
 						 cmd->switch_pattern_len,
 						 cmd->ant_ids);
 
-	*evt = cmd_complete_status(status);
+	rp = hci_cmd_complete(evt, sizeof(*rp));
+
+	rp->status = status;
+	rp->sync_handle = sys_cpu_to_le16(sync_handle);
 }
 
 static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,


### PR DESCRIPTION
Fixes #35781

Add fixes for 
- controller, to send correct event parameters as a return values for HCI_LE_Set_Connectionless_IQ_Sampling_Enable
- host, to check if `sync_handle` value is correct.

Adds missing return parameters declaration: `struct bt_hci_rp_le_set_cl_cte_sampling_enable`.