### PR TITLE
Fix C++ exception handling on NIOS2

### DIFF
--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -226,6 +226,8 @@ SECTIONS
 
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+#include <linker/cplusplus-ram.ld>
+
     __data_ram_end = .;
 
 	SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
@@ -249,8 +251,6 @@ SECTIONS
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
 #include <linker/common-noinit.ld>
-
-#include <linker/cplusplus-ram.ld>
 
     /* Define linker symbols */
     _image_ram_end = .;

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -54,7 +54,6 @@ if LIB_CPLUSPLUS
 
 config EXCEPTIONS
 	bool "Enable C++ exceptions support"
-	depends on !NIOS2
 	help
 	  This option enables support of C++ exceptions.
 

--- a/tests/subsys/cpp/libcxx/testcase.yaml
+++ b/tests/subsys/cpp/libcxx/testcase.yaml
@@ -9,7 +9,6 @@ tests:
     min_flash: 54
     tags: cpp
   cpp.libcxx.exceptions:
-    arch_exclude: nios2
     toolchain_exclude: xcc
     min_flash: 54
     tags: cpp


### PR DESCRIPTION
**Summary**

```
nios2: Fix C++ exception handling info linking

The NIOS2 architecture linker script was including `cplusplus-ram.ld`
linker script after `__data_ram_end`, and this caused the content of
`.gcc_except_table` section to be not copied to the RAM by the
`z_data_copy` function; leading to the C++ exception handling
malfunction.

This commit relocates the `cplusplus-ram.ld` linker script inclusion
such that the contents of the relevant sections are properly copied by
the `z_data_copy` function.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

**Test Result**

```
[110/111] Linking CXX executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           RESET:          0 GB         32 B      0.00%
           FLASH:      158544 B   16777184 B      0.94%
            SRAM:       10824 B   16777184 B      0.06%
        IDT_LIST:          0 GB         2 KB      0.00%
[110/111] To exit from QEMU enter: 'CTRL+a, x'[QEMU] CPU: nios2
        cpu->env.reset_addr:            0
        cpu->env.exception_addr:        400020
*** Booting Zephyr OS build v2.6.0-rc2-57-g053ff6fa0e72  ***
version 201703
Running test suite libcxx_tests
===================================================================
START - test_array
 PASS - test_array in 0.0 seconds
===================================================================
START - test_vector
 PASS - test_vector in 0.0 seconds
===================================================================
START - test_make_unique
 PASS - test_make_unique in 0.0 seconds
===================================================================
START - test_exception
 PASS - test_exception in 0.0 seconds
===================================================================
Test suite libcxx_tests succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
```

Note that, in order to test this in `qemu_nios2`, you must do so with a patched QEMU: see https://github.com/zephyrproject-rtos/zephyr/issues/35772#issuecomment-850402529.

Fixes #35772.