### PR TITLE
docs: Change a number of 'master' branch refers to 'main'

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -11,7 +11,7 @@ there is no LICENSE file or way to put a LICENSE file there, so we describe the
 licensing in this document.
 
 .. _Apache 2.0 License:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+   https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
 
 .. _GPLv2 License:
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/COPYING

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -7,7 +7,7 @@
     </div>
   {% else %}
     <div class="wy-alert wy-alert-danger">
-     This is the documentation for the latest (master) development branch of
+     This is the documentation for the latest (main) development branch of
      Zephyr. If you are looking for the documentation of previous releases, use
      the drop-down menu on the left and select the desired version.
     </div>

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -19,7 +19,7 @@ Licensing is very important to open source projects. It helps ensure the
 software continues to be available under the terms that the author desired.
 
 .. _Apache 2.0 license:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+   https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
 
 .. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
 
@@ -428,14 +428,14 @@ workflow here:
      upstream https://github.com/zephyrproject-rtos/zephyr (fetch)
      upstream https://github.com/zephyrproject-rtos/zephyr (push)
 
-#. Create a topic branch (off of master) for your work (if you're addressing
+#. Create a topic branch (off of main) for your work (if you're addressing
    an issue, we suggest including the issue number in the branch name)::
 
-     git checkout master
+     git checkout main
      git checkout -b fix_comment_typo
 
    Some Zephyr subsystems do development work on a separate branch from
-   master so you may need to indicate this in your checkout::
+   main so you may need to indicate this in your checkout::
 
      git checkout -b fix_out_of_date_patch origin/net
 
@@ -477,9 +477,9 @@ workflow here:
    pull request for the appropriate branch. The title and message from your
    commit message should appear as well.
 
-#. If you're working on a subsystem branch that's not ``master``,
+#. If you're working on a subsystem branch that's not ``main``,
    you may need to change the intended branch for the pull request
-   here, for example, by changing the base branch from ``master`` to ``net``.
+   here, for example, by changing the base branch from ``main`` to ``net``.
 
 #. GitHub will assign one or more suggested reviewers (based on the
    CODEOWNERS file in the repo). If you are a project member, you can
@@ -491,9 +491,9 @@ workflow here:
 
 #. While you're waiting for your pull request to be accepted and merged, you
    can create another branch to work on another issue. (Be sure to make your
-   new branch off of master and not the previous branch.)::
+   new branch off of main and not the previous branch.)::
 
-     git checkout master
+     git checkout main
      git checkout -b fix_another_issue
 
    and use the same process described above to work on this new topic branch.
@@ -502,7 +502,7 @@ workflow here:
    commit(s) to fix review issues.  In your development repo::
 
      git fetch --all
-     git rebase --ignore-whitespace upstream/master
+     git rebase --ignore-whitespace upstream/main
 
    The ``--ignore-whitespace`` option stops ``git apply`` (called by rebase)
    from changing any whitespace. Continuing::
@@ -586,7 +586,7 @@ The description body of the commit message must include:
 * **how** you know it works -- for example, which tests you ran.
 
 For examples of accepted commit messages, you can refer to the Zephyr GitHub
-`changelog <https://github.com/zephyrproject-rtos/zephyr/commits/master>`__.
+`changelog <https://github.com/zephyrproject-rtos/zephyr/commits/main>`__.
 
 Other Commit Expectations
 =========================

--- a/doc/custom-doxygen/mainpage.md
+++ b/doc/custom-doxygen/mainpage.md
@@ -23,7 +23,7 @@ documentation](https://docs.zephyrproject.org/latest/boards/index.html).
 
 Zephyr is permissively licensed using the Apache 2.0 license (as found
 in the [project's GitHub LICENSE
-file](https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE).
+file](https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE).
 There are some imported or reused components of the Zephyr project that
 use other licensing, as described in [Licensing of Zephyr Project
 components](https://docs.zephyrproject.org/latest/LICENSING.html#zephyr-licensing).

--- a/doc/development_process/code_flow.rst
+++ b/doc/development_process/code_flow.rst
@@ -8,7 +8,7 @@ Introduction
 
 The zephyr Git repository has three types of branches:
 
-master
+main
   Which contains the latest state of development
 
 topic-\*

--- a/doc/development_process/dev_env_and_tools.rst
+++ b/doc/development_process/dev_env_and_tools.rst
@@ -23,7 +23,7 @@ submitting a change or an enhancement to any Zephyr component, a developer
 should use GitHub. GitHub automatically assigns a responsible reviewer on a
 component basis, as defined in the :zephyr_file:`CODEOWNERS` file stored with the code
 tree in the Zephyr project repository. A limited set of release managers are
-allowed to merge a pull request into the master branch once reviews are complete.
+allowed to merge a pull request into the main branch once reviews are complete.
 
 .. _review_time:
 

--- a/doc/development_process/project_roles.rst
+++ b/doc/development_process/project_roles.rst
@@ -47,7 +47,7 @@ Contributors are granted the following rights and responsibilities:
 * Responsibility to provide constructive advice whenever participating in
   discussions and in the review of contributions.
 * Responsibility to follow the project’s code of conduct
-  (https://github.com/zephyrproject-rtos/zephyr/blob/master/CODE_OF_CONDUCT.md)
+  (https://github.com/zephyrproject-rtos/zephyr/blob/main/CODE_OF_CONDUCT.md)
 
 Collaborator
 ++++++++++++

--- a/doc/development_process/proposals.rst
+++ b/doc/development_process/proposals.rst
@@ -158,5 +158,5 @@ and main stakeholders of the project can make progress on.
 Items labeled as ``features`` are short or long term release items that shall
 have an assignee and a milestone set.
 
-.. _`RFC template`: https://github.com/zephyrproject-rtos/zephyr/blob/master/.github/ISSUE_TEMPLATE/rfc-proposal.md
+.. _`RFC template`: https://github.com/zephyrproject-rtos/zephyr/blob/main/.github/ISSUE_TEMPLATE/rfc-proposal.md
 .. _`Zephyr meetings`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings

--- a/doc/guides/coding_guidelines/index.rst
+++ b/doc/guides/coding_guidelines/index.rst
@@ -883,7 +883,7 @@ Offensive terms do not create an inclusive community environment and therefore
 violate the Zephyr Project `Code of Conduct`_. This coding rule was inspired by
 a similar rule in `Linux`_.
 
-.. _Code of Conduct: https://github.com/zephyrproject-rtos/zephyr/blob/master/CODE_OF_CONDUCT.md
+.. _Code of Conduct: https://github.com/zephyrproject-rtos/zephyr/blob/main/CODE_OF_CONDUCT.md
 .. _Linux: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49decddd39e5f6132ccd7d9fdc3d7c470b0061bb
 
 Status

--- a/doc/guides/device_mgmt/index.rst
+++ b/doc/guides/device_mgmt/index.rst
@@ -543,4 +543,4 @@ Currently only the MCUboot bootloader is supported. See :ref:`mcuboot` for more
 information.
 
 .. _MCUmgr: https://github.com/apache/mynewt-mcumgr
-.. _MCUboot design: https://github.com/mcu-tools/mcuboot/blob/master/docs/design.md
+.. _MCUboot design: https://github.com/mcu-tools/mcuboot/blob/main/docs/design.md

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 ..
-    Zephyr Project documentation master file
+    Zephyr Project documentation main file
 
 .. _zephyr-home:
 
@@ -10,13 +10,13 @@ Zephyr Project Documentation
 
    Welcome to the Zephyr Project's documentation for version |version|.
 
-   Documentation for the latest (master) development branch of Zephyr
+   Documentation for the latest (main) development branch of Zephyr
    can be found at https://docs.zephyrproject.org/
 
 .. only:: (development or daily)
 
    **Welcome to the Zephyr Project's documentation
-   for the master tree under development** (version |version|).
+   for the main tree under development** (version |version|).
 
 Use the version selection menu on the left to view
 documentation for a specific version of Zephyr.
@@ -30,7 +30,7 @@ imports or reuses packages, scripts, and other files that use other
 licensing, as described in :ref:`Zephyr_Licensing`.
 
 .. _Apache 2.0 license:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+   https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
 
 .. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
 

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -31,7 +31,7 @@ imported or reused components of the Zephyr project that use other licensing,
 as described in :ref:`Zephyr_Licensing`.
 
 .. _Apache 2.0 license:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+   https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
 
 .. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
 


### PR DESCRIPTION
Now that we use 'main' for git development, update the docs to reflect
or point there instead of 'master'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>