### PR TITLE
sensor: use function properties to document the context

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -451,7 +451,7 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
  * driver.  It is currently up to the caller to ensure that the handler
  * does not overflow the stack.
  *
- * This API is not permitted for user threads.
+ * @funcprops \supervisor
  *
  * @param dev Pointer to the sensor device
  * @param trig The trigger to activate


### PR DESCRIPTION
We now have function properties which can replace the confusing message
in the doxygen docs.

Fixes #10499

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
