### PR TITLE
dfu: flash_img: Removing conditional compilation from header

### DIFF
--- a/include/dfu/flash_img.h
+++ b/include/dfu/flash_img.h
@@ -20,7 +20,6 @@ struct flash_img_context {
 	struct stream_flash_ctx stream;
 };
 
-#if defined(CONFIG_IMG_ENABLE_IMAGE_CHECK)
 /**
  * @brief Structure for verify flash region integrity
  *
@@ -31,7 +30,6 @@ struct flash_img_check {
 	const uint8_t *match;		/** Match vector data */
 	size_t clen;			/** Content to be compared */
 };
-#endif
 
 /**
  * @brief Initialize context needed for writing the image to the flash.
@@ -81,10 +79,11 @@ size_t flash_img_bytes_written(struct flash_img_context *ctx);
 int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 		    size_t len, bool flush);
 
-#if defined(CONFIG_IMG_ENABLE_IMAGE_CHECK)
 /**
  * @brief  Verify flash memory length bytes integrity from a flash area. The
  * start point is indicated by an offset value.
+ *
+ * The function is enabled via CONFIG_IMG_ENABLE_IMAGE_CHECK Kconfig options.
  *
  * @param[in] ctx context.
  * @param[in] fic flash img check data.
@@ -96,7 +95,6 @@ int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 int flash_img_check(struct flash_img_context *ctx,
 		    const struct flash_img_check *fic,
 		    uint8_t area_id);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Applying Coding Guideline rule A.1: Conditional Compilation.

Update: The rule is Zephyr coding guide line rule, not misra, documented here https://docs.zephyrproject.org/latest/guides/coding_guidelines/index.html?highlight=coding%20guideline#rule-a-1-conditional-compilation

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>