### PR TITLE
drivers: gsm adding support for rssi readout for the PPP link

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -78,6 +78,19 @@ config MODEM_GSM_MANUAL_MCCMNO
 	  the network provider and may need to be changed if auto is not
 	  selected.
 
+config MODEM_GSM_RSSI_POLLING_PERIOD
+	int "Configure RSSI polling period (in seconds)"
+	default 30
+	help
+	  This settings is used to configure the period of RSSI polling
+
+config MODEM_GSM_ENABLE_CESQ_RSSI
+	bool "Enable +CESQ RSSI measurement"
+	help
+	   If this is enabled, RSRP, RSCP and RXREL values are read from the
+	   modem with +CESQ. Otherwise only RSSI value is read with +CSQ
+	   from the modem.
+
 config MODEM_GSM_FACTORY_RESET_AT_BOOT
 	bool "Factory reset modem at boot"
 	help

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -72,7 +72,7 @@ struct modem_context {
 	int   data_cellid;
 #endif
 	int   data_rssi;
-
+	bool  is_automatic_oper;
 	/* pin config */
 	struct modem_pin *pins;
 	size_t pins_len;


### PR DESCRIPTION
This PR addresses radio signal stength measurement during and before
    PPP session. The PR provides provides facility of readout for both +CSQ and +CESQ
    versions depending upon the modems.
    This PR follows the idea of rssi readout of PR#35496.
    Additionally, this PR also considers the issue #33773 and it has been observed with 
    SARA R410M modem, the avoiding sending AT+COPS=0,0 improves the
    performance slightly if the modem is already in automatic operator selection mode.
    
