### PR TITLE
boards: testing: limit default platforms to those we can run

### DIFF
--- a/boards/arc/nsim/nsim_em.yaml
+++ b/boards/arc/nsim/nsim_em.yaml
@@ -7,7 +7,6 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/nsim/nsim_hs.yaml
+++ b/boards/arc/nsim/nsim_hs.yaml
@@ -7,7 +7,6 @@ toolchain:
   - zephyr
   - arcmwdt
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
The idea of having default platforms is to prioritize running tests over
just build them. We do not have NSIM in CI and thus we are just building
for those platforms without running the tests, so, we spend lots of time
building on PRs which is slows everything down.

We now have Qemu covering ARC. If we can get NSIM into CI, then we
should reconsider enabling some NSIM platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
