### PR TITLE
Bluetooth: Host: Add status check BIG sync/create events

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1571,8 +1571,8 @@ void hci_le_big_complete(struct net_buf *buf)
 	BT_DBG("BIG[%u] %p completed, status %u", big->handle, big, evt->status);
 
 	if (evt->status || evt->num_bis != big->num_bis) {
-		if (evt->num_bis != big->num_bis) {
-			BT_ERR("Invalid number of BIS, was %u expected %u",
+		if (evt->status == BT_HCI_ERR_SUCCESS && evt->num_bis != big->num_bis) {
+			BT_ERR("Invalid number of BIS created, was %u expected %u",
 			       evt->num_bis, big->num_bis);
 		}
 		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);
@@ -1626,11 +1626,11 @@ void hci_le_big_sync_established(struct net_buf *buf)
 	big = &bigs[evt->big_handle];
 	atomic_clear_bit(big->flags, BT_BIG_SYNCING);
 
-	BT_DBG("BIG[%u] %p sync established", big->handle, big);
+	BT_DBG("BIG[%u] %p sync established, status %u", big->handle, big, evt->status);
 
 	if (evt->status || evt->num_bis != big->num_bis) {
-		if (evt->num_bis != big->num_bis) {
-			BT_ERR("Invalid number of BIS, was %u expected %u",
+		if (evt->status == BT_HCI_ERR_SUCCESS && evt->num_bis != big->num_bis) {
+			BT_ERR("Invalid number of BIS synced, was %u expected %u",
 			       evt->num_bis, big->num_bis);
 		}
 		big_disconnect(big, evt->status ? evt->status : BT_HCI_ERR_UNSPECIFIED);


### PR DESCRIPTION
Add a status check for the BIG sync established and
BIG sync created events such that we don't log a warning
of invalid BIS count when it is an error event.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>