### PR TITLE
drivers: wifi: eswifi: Fix err log & NET_SOCKETS_OFFLOAD=n config

### DIFF
--- a/drivers/wifi/eswifi/Kconfig.eswifi
+++ b/drivers/wifi/eswifi/Kconfig.eswifi
@@ -9,7 +9,7 @@ menuconfig WIFI_ESWIFI
 	select WIFI_OFFLOAD
 	select NET_OFFLOAD
 	select NET_SOCKETS
-	select NET_SOCKETS_OFFLOAD
+	imply NET_SOCKETS_OFFLOAD
 	select GPIO
 
 if WIFI_ESWIFI

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -152,7 +152,7 @@ do_recv_cb:
 done:
 	err = k_work_reschedule_for_queue(&eswifi->work_q, &socket->read_work,
 					  K_MSEC(next_timeout_ms));
-	if (err) {
+	if (err < 0) {
 		LOG_ERR("Rescheduling socket read error");
 	}
 
@@ -205,6 +205,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 		LOG_ERR("Unable to start TCP/UDP client");
 		return -EIO;
 	}
+	net_context_set_state(socket->context, NET_CONTEXT_CONNECTED);
 
 	return 0;
 }


### PR DESCRIPTION

- Fix error check after `k_work_reschedule_for_queue`. A value of 1
  means job was scheduled which was resulting in a ton of "<err>
  wifi_eswifi: Rescheduling socket read error" logs getting printed
  due to the erroneous check
- When using the B-L475E-IOT01A, attempts to use a TLS socket result in a
  hang when socket offload is enabled so I'd like to have a way to
  disable the option. To accomplish this, I I switched the
  `CONFIG_NET_SOCKETS_OFFLOAD=n` Kconfig option from `select` to
  `imply`.
- There was a missing `net_context_set_state()` call when
  `CONFIG_NET_SOCKETS_OFFLOAD=n`. I applied the same fix from #30664
  for this case to fix the issue.


Signed-off-by: Chris Coleman <chris@memfault.com>