### PR TITLE
workflows: backport: Switch to using main

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,7 @@ on:
       - closed
       - labeled
     branches:
-      - master
+      - main
 
 jobs:
   backport:


### PR DESCRIPTION
The  workflow was pointing to `master` instead of `main`, which
prevented it from running after the branch was renamed.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>