### PR TITLE
Bluetooth: controller: Fix incorrect common extended header population

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5354,12 +5354,12 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		       p->ext_hdr_len);
 
 		if (!p->ext_hdr_len) {
-			hdr_len = ptr - (uint8_t *)p;
+			hdr_len = PDU_AC_EXT_HEADER_SIZE_MIN;
 
 			goto no_ext_hdr;
 		}
 
-		ptr += sizeof(*h);
+		ptr = h->data;
 
 		/* No AdvA */
 		/* No TargetA */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -214,6 +214,13 @@ static int prepare_cb(struct lll_prepare_param *p)
 	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
 	pri_dptr = pri_hdr->data;
 
+	/* NOTE: We shall be here in auxiliary PDU prepare due to
+	 * aux_ptr flag being set in the extended common header
+	 * flags. Hence, ext_hdr_len is non-zero, an explicit check
+	 * is not needed.
+	 */
+	LL_ASSERT(pri_com_hdr->ext_hdr_len);
+
 	/* traverse through adv_addr, if present */
 	if (pri_hdr->adv_addr) {
 		pri_dptr += BDADDR_SIZE;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -672,10 +672,16 @@ uint8_t ll_adv_enable(uint8_t enable)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
 		struct pdu_adv_com_ext_adv *pri_com_hdr;
+		struct pdu_adv_ext_hdr pri_hdr_flags;
 		struct pdu_adv_ext_hdr *pri_hdr;
 
 		pri_com_hdr = (void *)&pdu_adv->adv_ext_ind;
 		pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
+		if (pri_com_hdr->ext_hdr_len) {
+			pri_hdr_flags = *pri_hdr;
+		} else {
+			*(uint8_t *)&pri_hdr_flags = 0U;
+		}
 
 		if (pri_com_hdr->adv_mode & BT_HCI_LE_ADV_PROP_SCAN) {
 			struct pdu_adv *sr = lll_adv_scan_rsp_peek(lll);
@@ -686,11 +692,12 @@ uint8_t ll_adv_enable(uint8_t enable)
 		}
 
 		/* AdvA, fill here at enable */
-		if (pri_hdr->adv_addr) {
+		if (pri_hdr_flags.adv_addr) {
 			pdu_adv_to_update = pdu_adv;
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
-		} else if (pri_hdr->aux_ptr) {
+		} else if (pri_hdr_flags.aux_ptr) {
 			struct pdu_adv_com_ext_adv *sec_com_hdr;
+			struct pdu_adv_ext_hdr sec_hdr_flags;
 			struct pdu_adv_ext_hdr *sec_hdr;
 			struct pdu_adv *sec_pdu;
 
@@ -698,8 +705,13 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 			sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
 			sec_hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
+			if (sec_com_hdr->ext_hdr_len) {
+				sec_hdr_flags = *sec_hdr;
+			} else {
+				*(uint8_t *)&sec_hdr_flags = 0U;
+			}
 
-			if (sec_hdr->adv_addr) {
+			if (sec_hdr_flags.adv_addr) {
 				pdu_adv_to_update = sec_pdu;
 			}
 #endif /* (CONFIG_BT_CTLR_ADV_AUX_SET > 0) */
@@ -1659,10 +1671,19 @@ void ull_adv_done(struct node_rx_event_done *done)
 const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 					struct pdu_adv *pdu)
 {
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_ext_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
-#endif
 	const uint8_t *adv_addr;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+	struct pdu_adv_com_ext_adv *com_hdr = (void *)&pdu->adv_ext_ind;
+	struct pdu_adv_ext_hdr *hdr = (void *)com_hdr->ext_hdr_adv_data;
+	struct pdu_adv_ext_hdr hdr_flags;
+
+	if (com_hdr->ext_hdr_len) {
+		hdr_flags = *hdr;
+	} else {
+		*(uint8_t *)&hdr_flags = 0U;
+	}
+#endif
 
 	adv_addr = adva_update(adv, pdu);
 
@@ -1672,7 +1693,7 @@ const uint8_t *ull_adv_pdu_update_addrs(struct ll_adv_set *adv,
 	 */
 	if ((pdu->type == PDU_ADV_TYPE_DIRECT_IND) ||
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	    ((pdu->type == PDU_ADV_TYPE_EXT_IND) && hdr->tgt_addr) ||
+	    ((pdu->type == PDU_ADV_TYPE_EXT_IND) && hdr_flags.tgt_addr) ||
 #endif
 	    0) {
 		tgta_update(adv, pdu);
@@ -2117,12 +2138,21 @@ static inline uint8_t disable(uint8_t handle)
 static inline uint8_t *adv_pdu_adva_get(struct pdu_adv *pdu)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct pdu_adv_ext_hdr *hdr = (void *)pdu->adv_ext_ind.ext_hdr_adv_data;
+	struct pdu_adv_com_ext_adv *com_hdr = (void *)&pdu->adv_ext_ind;
+	struct pdu_adv_ext_hdr *hdr = (void *)com_hdr->ext_hdr_adv_data;
+	struct pdu_adv_ext_hdr hdr_flags;
+
+	if (com_hdr->ext_hdr_len) {
+		hdr_flags = *hdr;
+	} else {
+		*(uint8_t *)&hdr_flags = 0U;
+	}
 
 	/* All extended PDUs have AdvA at the same offset in common header */
 	if (pdu->type == PDU_ADV_TYPE_EXT_IND) {
-		LL_ASSERT(hdr->adv_addr);
-		return &pdu->adv_ext_ind.ext_hdr_adv_data[1];
+		LL_ASSERT(hdr_flags.adv_addr);
+
+		return &com_hdr->ext_hdr_adv_data[1];
 	}
 #endif
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -393,11 +393,11 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 
 		/* Zero-init header flags */
 		if (is_pdu_type_changed) {
-			*(uint8_t *)&pri_hdr_prev = 0;
+			*(uint8_t *)&pri_hdr_prev = 0U;
 		} else {
-			*(uint8_t *)&pri_hdr_prev = *(uint8_t *)pri_hdr;
+			pri_hdr_prev = *pri_hdr;
 		}
-		*(uint8_t *)pri_hdr = 0;
+		*(uint8_t *)pri_hdr = 0U;
 
 		/* AdvA flag */
 		if (pri_hdr_prev.adv_addr) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -477,7 +477,11 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
 	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adv_data;
-	pri_hdr_prev = *pri_hdr;
+	if (pri_com_hdr_prev->ext_hdr_len) {
+		pri_hdr_prev = *pri_hdr;
+	} else {
+		*(uint8_t *)&pri_hdr_prev = 0U;
+	}
 	pri_dptr_prev = pri_hdr->data;
 
 	/* Advertising data are not supported by scannable instances */
@@ -700,6 +704,11 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* No AdvData in primary channel PDU */
 	/* Fill AdvData in secondary PDU */
 	memmove(sec_dptr, ad_data, ad_len);
+
+	/* Early exit if no flags set */
+	if (!sec_com_hdr->ext_hdr_len) {
+		return 0;
+	}
 
 	/* No ACAD in primary channel PDU */
 	/* TODO: Fill ACAD in secondary channel PDU */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -801,6 +801,11 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 	/* Fill AdvData in tertiary PDU */
 	memmove(ter_dptr, ad_data, ad_len);
 
+	/* Early exit if no flags set */
+	if (!ter_com_hdr->ext_hdr_len) {
+		return 0;
+	}
+
 	/* Fill ACAD in tertiary PDU */
 	ter_dptr_prev -= acad_len_prev;
 	ter_dptr -= acad_len_prev;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -672,7 +672,11 @@ static uint8_t adv_sync_hdr_set_clear(struct lll_adv_sync *lll_sync,
 	/* Get common pointers from reference to previous tertiary PDU data */
 	ter_com_hdr_prev = (void *)&ter_pdu_prev->adv_ext_ind;
 	ter_hdr = (void *)ter_com_hdr_prev->ext_hdr_adv_data;
-	ter_hdr_prev = *ter_hdr;
+	if (ter_com_hdr_prev->ext_hdr_len) {
+		ter_hdr_prev = *ter_hdr;
+	} else {
+		*(uint8_t *)&ter_hdr_prev = 0U;
+	}
 	ter_dptr_prev = ter_hdr->data;
 
 	/* Set common fields in reference to new tertiary PDU data buffer */

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -500,6 +500,16 @@ static void test_advx_main(void)
 
 	k_sleep(K_MSEC(400));
 
+	printk("Update periodic advertising back to data 2...");
+	err = ll_adv_sync_ad_data_set(handle, AD_OP, sizeof(per_adv_data2),
+				      (void *)per_adv_data2);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	k_sleep(K_MSEC(400));
+
 	printk("Disabling...");
 	err = ll_adv_enable(handle, 0, 0, 0);
 	if (err) {
@@ -1281,6 +1291,20 @@ static void test_scanx_main(void)
 		FAIL("Incorrect Periodic Advertising Report data.");
 	}
 
+	printk("Waiting for Periodic Advertising Report of %u bytes...",
+	       sizeof(per_adv_data1));
+	sync_report_len_prev = sync_report_len;
+	while (!is_sync_report || (sync_report_len == sync_report_len_prev)) {
+		is_sync_report = false;
+		k_sleep(K_MSEC(100));
+	}
+	printk("done.\n");
+
+	if ((sync_report_len != sizeof(per_adv_data2)) ||
+	    memcmp(sync_report_data, per_adv_data2, sizeof(per_adv_data2))) {
+		FAIL("Incorrect Periodic Advertising Report data.");
+	}
+
 	printk("Waiting for sync loss...");
 	while (!is_sync_lost) {
 		k_sleep(K_MSEC(100));
@@ -1340,7 +1364,7 @@ exit:
 
 static void test_advx_init(void)
 {
-	bst_ticker_set_next_tick_absolute(20e6);
+	bst_ticker_set_next_tick_absolute(30e6);
 	bst_result = In_progress;
 }
 


### PR DESCRIPTION
Fix Extended and Periodic Advertising PDU population from incorrectly
populating new PDU when there is no common extended header
flags being set in the previous PDU and/or the new PDU.

Refer to: https://lists.zephyrproject.org/g/devel/message/7793

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>