### PR TITLE
soc: cc32xx: add MPU support

### DIFF
--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.series
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.series
@@ -7,6 +7,7 @@ config SOC_SERIES_CC32XX
 	select ARM
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_TISIMPLELINK
 	help
 	  Enable support for TI SimpleLink CC32xx

--- a/soc/arm/ti_simplelink/cc32xx/soc.h
+++ b/soc/arm/ti_simplelink/cc32xx/soc.h
@@ -9,6 +9,7 @@
 
 #include <inc/hw_types.h>
 #include <driverlib/prcm.h>
+#include <devicetree.h>
 
 /*
  * CMSIS IRQn_Type enum is broken relative to ARM GNU compiler.
@@ -34,7 +35,7 @@ typedef enum {
 } CMSIS_IRQn_Type;
 
 #define __CM4_REV        0
-#define __MPU_PRESENT                  0 /* Zephyr has no MPU support */
+#define __MPU_PRESENT                  1
 #define __NVIC_PRIO_BITS               NUM_IRQ_PRIO_BITS
 #define __Vendor_SysTickConfig         0 /* Default to standard SysTick */
 


### PR DESCRIPTION
Enable MPU for cc3220/cc3235 devices

Signed-off-by: Pavlo Hamov <pasha.gamov@gmail.com>