### PR TITLE
Update VCS API to use instance pointer instead of bt_conn

### DIFF
--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -81,6 +81,7 @@ struct bt_vcs_included {
  *
  * @param      param  Volume Control Service register parameters.
  * @param[out] vcs    Pointer to the registered Volume Control Service.
+ *                    This will still be valid if the return value is -EALREADY.
  *
  * @return 0 if success, errno on failure.
  */

--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -79,8 +79,8 @@ struct bt_vcs_included {
  * This will register and enable the service and make it discoverable by
  * clients.
  *
- * @param param     Volume Control Service register parameters.
- * @param[out] vcs  Pointer to the registered Volume Control Service.
+ * @param      param  Volume Control Service register parameters.
+ * @param[out] vcs    Pointer to the registered Volume Control Service.
  *
  * @return 0 if success, errno on failure.
  */
@@ -94,20 +94,19 @@ int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs);
  * Volume Offset Control Service (Volume Offset Control Service) or
  * Audio Input Control Service (AICS) instances.
  *
- * @param conn          Connection to peer device, or NULL to get server value.
+ * @param      vcs      Volume Control Service instance pointer.
  * @param[out] included Pointer to store the result in.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_included_get(struct bt_conn *conn, struct bt_vcs_included *included);
+int bt_vcs_included_get(struct bt_vcs *vcs, struct bt_vcs_included *included);
 
 /**
  * @brief Callback function for bt_vcs_discover.
  *
  * This callback is only used for the client.
  *
- * @param conn         The connection that was used to discover
- *                     Volume Control Service.
+ * @param vcs          Volume Control Service instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  * @param vocs_count   Number of Volume Offset Control Service instances
@@ -115,7 +114,7 @@ int bt_vcs_included_get(struct bt_conn *conn, struct bt_vcs_included *included);
  * @param aics_count   Number of Audio Input Control Service instances on
  *                     peer device.
  */
-typedef void (*bt_vcs_discover_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_vcs_discover_cb)(struct bt_vcs *vcs, int err,
 				   uint8_t vocs_count, uint8_t aics_count);
 
 /**
@@ -125,14 +124,13 @@ typedef void (*bt_vcs_discover_cb)(struct bt_conn *conn, int err,
  * Called when the value is remotely read as the client.
  * Called if the value is changed by either the server or client.
  *
- * @param conn    NULL if local server read or write, otherwise the connection
- *                to the peer device if remotely read or written.
+ * @param vcs     Volume Control Service instance pointer.
  * @param err     Error value. 0 on success, GATT error on positive value
  *                or errno on negative value.
  * @param volume  The volume of the Volume Control Service server.
  * @param mute    The mute setting of the Volume Control Service server.
  */
-typedef void (*bt_vcs_state_cb)(struct bt_conn *conn, int err, uint8_t volume,
+typedef void (*bt_vcs_state_cb)(struct bt_vcs *vcs, int err, uint8_t volume,
 				uint8_t mute);
 
 /**
@@ -142,24 +140,22 @@ typedef void (*bt_vcs_state_cb)(struct bt_conn *conn, int err, uint8_t volume,
  * Called when the value is remotely read as the client.
  * Called if the value is changed by either the server or client.
  *
- * @param conn    NULL if local server read or write, otherwise the connection
- *                to the peer device if remotely read or written.
+ * @param vcs     Volume Control Service instance pointer.
  * @param err     Error value. 0 on success, GATT error on positive value
  *                or errno on negative value.
  * @param flags   The flags of the Volume Control Service server.
  */
-typedef void (*bt_vcs_flags_cb)(struct bt_conn *conn, int err, uint8_t flags);
+typedef void (*bt_vcs_flags_cb)(struct bt_vcs *vcs, int err, uint8_t flags);
 
 /**
  * @brief Callback function for writes.
  *
  * This callback is only used for the client.
  *
- * @param conn    NULL if local server read or write, otherwise the connection
- *                to the peer device if remotely read or written.
+ * @param vcs     Volume Control Service instance pointer.
  * @param err     Error value. 0 on success, GATT error on fail.
  */
-typedef void (*bt_vcs_write_cb)(struct bt_conn *conn, int err);
+typedef void (*bt_vcs_write_cb)(struct bt_vcs *vcs, int err);
 
 struct bt_vcs_cb {
 	/* Volume Control Service */
@@ -193,8 +189,8 @@ struct bt_vcs_cb {
  *
  * This shall only be done as the client,
  *
- * @param conn     The connection to discover Volume Control Service for.
- * @param[out] vcs Valid remote instance object on success.
+ * @param      conn  The connection to discover Volume Control Service for.
+ * @param[out] vcs   Valid remote instance object on success.
  *
  * @return 0 if success, errno on failure.
  */
@@ -217,152 +213,149 @@ int bt_vcs_vol_step_set(uint8_t volume_step);
 /**
  * @brief Read the Volume Control Service volume state.
  *
- * @param conn   Connection to the peer device,
- *               or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vol_get(struct bt_conn *conn);
+int bt_vcs_vol_get(struct bt_vcs *vcs);
 
 /**
  * @brief Read the Volume Control Service flags.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_flags_get(struct bt_conn *conn);
+int bt_vcs_flags_get(struct bt_vcs *vcs);
 
 /**
  * @brief Turn the volume down by one step on the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vol_down(struct bt_conn *conn);
+int bt_vcs_vol_down(struct bt_vcs *vcs);
 
 /**
  * @brief Turn the volume up by one step on the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vol_up(struct bt_conn *conn);
+int bt_vcs_vol_up(struct bt_vcs *vcs);
 
 /**
  * @brief Turn the volume down and unmute the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_unmute_vol_down(struct bt_conn *conn);
+int bt_vcs_unmute_vol_down(struct bt_vcs *vcs);
 
 /**
  * @brief Turn the volume up and unmute the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_unmute_vol_up(struct bt_conn *conn);
+int bt_vcs_unmute_vol_up(struct bt_vcs *vcs);
 
 /**
  * @brief Set the volume on the server
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param volume The absolute volume to set.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vol_set(struct bt_conn *conn, uint8_t volume);
+int bt_vcs_vol_set(struct bt_vcs *vcs, uint8_t volume);
 
 /**
  * @brief Unmute the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_unmute(struct bt_conn *conn);
+int bt_vcs_unmute(struct bt_vcs *vcs);
 
 /**
  * @brief Mute the server.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs  Volume Control Service instance pointer.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_mute(struct bt_conn *conn);
+int bt_vcs_mute(struct bt_vcs *vcs);
 
 /**
  * @brief Read the Volume Offset Control Service offset state.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_state_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vcs_vocs_state_get(struct bt_vcs *vcs, struct bt_vocs *inst);
 
 /**
  * @brief Read the Volume Offset Control Service location.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_location_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vcs_vocs_location_get(struct bt_vcs *vcs, struct bt_vocs *inst);
 
 /**
  * @brief Set the Volume Offset Control Service location.
  *
- * @param conn       Connection to peer device, or NULL to set local server
- *                   value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst       Pointer to the Volume Offset Control Service instance.
  * @param location   The location to set.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_location_set(struct bt_conn *conn, struct bt_vocs *inst,
+int bt_vcs_vocs_location_set(struct bt_vcs *vcs, struct bt_vocs *inst,
 			     uint8_t location);
 
 /**
  * @brief Set the Volume Offset Control Service offset state.
  *
- * @param conn    Connection to peer device, or NULL to set local server value.
+ * @param vcs     Volume Control Service instance pointer.
  * @param inst    Pointer to the Volume Offset Control Service instance.
  * @param offset  The offset to set (-255 to 255).
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_state_set(struct bt_conn *conn, struct bt_vocs *inst,
+int bt_vcs_vocs_state_set(struct bt_vcs *vcs, struct bt_vocs *inst,
 			  int16_t offset);
 
 /**
  * @brief Read the Volume Offset Control Service output description.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Volume Offset Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_description_get(struct bt_conn *conn, struct bt_vocs *inst);
+int bt_vcs_vocs_description_get(struct bt_vcs *vcs, struct bt_vocs *inst);
 
 /**
  * @brief Set the Volume Offset Control Service description.
  *
- * @param conn          Connection to peer device, or NULL to set local server
- *                      value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst          Pointer to the Volume Offset Control Service instance.
  * @param description   The description to set.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_vocs_description_set(struct bt_conn *conn, struct bt_vocs *inst,
+int bt_vcs_vocs_description_set(struct bt_vcs *vcs, struct bt_vocs *inst,
 				const char *description);
 
 /**
@@ -371,11 +364,12 @@ int bt_vcs_vocs_description_set(struct bt_conn *conn, struct bt_vocs *inst,
  * Audio Input Control Services are activated by default, but this will allow
  * the server to deactivate an Audio Input Control Service.
  *
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_deactivate(struct bt_aics *inst);
+int bt_vcs_aics_deactivate(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Activates an Audio Input Control Service instance.
@@ -384,125 +378,125 @@ int bt_vcs_aics_deactivate(struct bt_aics *inst);
  * the server to reactivate an Audio Input Control Service instance after it has
  * been deactivated with @ref bt_vcs_aics_deactivate.
  *
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_activate(struct bt_aics *inst);
+int bt_vcs_aics_activate(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input state.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_state_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_state_get(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service gain settings.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_gain_setting_get(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input type.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_type_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_type_get(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input status.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_status_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_status_get(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Mute the Audio Input Control Service input.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_mute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_mute(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Unmute the Audio Input Control Service input.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_unmute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_unmute(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Set input gain to manual.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_manual_gain_set(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Set the input gain to automatic.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_automatic_gain_set(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Set the input gain.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  * @param gain   The gain in dB to set (-128 to 127).
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_gain_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_vcs_aics_gain_set(struct bt_vcs *vcs, struct bt_aics *inst,
 			 int8_t gain);
 
 /**
  * @brief Read the Audio Input Control Service description.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param vcs    Volume Control Service instance pointer.
  * @param inst   Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_description_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_vcs_aics_description_get(struct bt_vcs *vcs, struct bt_aics *inst);
 
 /**
  * @brief Set the Audio Input Control Service description.
  *
- * @param conn          Connection to peer device, or NULL to set local server
- *                      value.
+ * @param vcs           Volume Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  * @param description   The description to set.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_vcs_aics_description_set(struct bt_vcs *vcs, struct bt_aics *inst,
 				const char *description);
 
 /**

--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -39,6 +39,9 @@ extern "C" {
 #define BT_VCS_ERR_INVALID_COUNTER             0x80
 #define BT_VCS_ERR_OP_NOT_SUPPORTED            0x81
 
+/** @brief Opaque Volume Control Service instance. */
+struct bt_vcs;
+
 /** Register structure for Volume Control Service */
 struct bt_vcs_register_param {
 	/** Register parameters for Volume Offset Control Services */
@@ -77,10 +80,11 @@ struct bt_vcs_included {
  * clients.
  *
  * @param param     Volume Control Service register parameters.
+ * @param[out] vcs  Pointer to the registered Volume Control Service.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_register(struct bt_vcs_register_param *param);
+int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs);
 
 /**
  * @brief Get Volume Control Service included services.

--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -188,15 +188,17 @@ struct bt_vcs_cb {
  *
  * This will start a GATT discovery and setup handles and subscriptions.
  * This shall be called once before any other actions can be
- * executed for the peer device.
+ * executed for the peer device, and the @ref bt_vcs_discover_cb callback
+ * will notify when it is possible to start remote operations.
  *
  * This shall only be done as the client,
  *
- * @param conn    The connection to discover Volume Control Service for.
+ * @param conn     The connection to discover Volume Control Service for.
+ * @param[out] vcs Valid remote instance object on success.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_vcs_discover(struct bt_conn *conn);
+int bt_vcs_discover(struct bt_conn *conn, struct bt_vcs **vcs);
 
 /**
  * @brief Set the Volume Control Service volume step size.

--- a/include/bluetooth/audio/vcs.h
+++ b/include/bluetooth/audio/vcs.h
@@ -103,6 +103,19 @@ int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs);
 int bt_vcs_included_get(struct bt_vcs *vcs, struct bt_vcs_included *included);
 
 /**
+ * @brief Get the connection pointer of a client instance
+ *
+ * Get the Bluetooth connection pointer of a Volume Control Service
+ * client instance.
+ *
+ * @param      vcs     Volume Control Service client instance pointer.
+ * @param[out] conn    Connection pointer.
+ *
+ * @return 0 if success, errno on failure.
+ */
+int bt_vcs_client_conn_get(const struct bt_vcs *vcs, struct bt_conn **conn);
+
+/**
  * @brief Callback function for bt_vcs_discover.
  *
  * This callback is only used for the client.

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -34,18 +34,7 @@
 
 #define VALID_VCS_OPCODE(opcode) ((opcode) <= BT_VCS_OPCODE_MUTE)
 
-struct vcs_inst_t {
-	struct vcs_state state;
-	uint8_t flags;
-	struct bt_vcs_cb *cb;
-	uint8_t volume_step;
-
-	struct bt_gatt_service *service_p;
-	struct bt_vocs *vocs_insts[CONFIG_BT_VCS_VOCS_INSTANCE_COUNT];
-	struct bt_aics *aics_insts[CONFIG_BT_VCS_AICS_INSTANCE_COUNT];
-};
-
-static struct vcs_inst_t vcs_inst = {
+static struct bt_vcs_server vcs_inst = {
 	.state.volume = 100,
 	.volume_step = 1,
 };
@@ -335,7 +324,7 @@ static int prepare_aics_inst(struct bt_vcs_register_param *param)
 }
 
 /****************************** PUBLIC API ******************************/
-int bt_vcs_register(struct bt_vcs_register_param *param)
+int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs)
 {
 	int err;
 
@@ -365,6 +354,8 @@ int bt_vcs_register(struct bt_vcs_register_param *param)
 	}
 
 	vcs_inst.cb = param->cb;
+
+	*vcs = (struct bt_vcs *)&vcs_inst;
 
 	return err;
 }

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -450,12 +450,9 @@ int bt_vcs_included_get(struct bt_vcs *vcs, struct bt_vcs_included *included)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_included_get(vcs, included);
-		} else {
-			return -EOPNOTSUPP;
-		}
+
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_included_get(vcs, included);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -496,12 +493,8 @@ int bt_vcs_vol_get(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_read_vol_state(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_read_vol_state(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -523,12 +516,8 @@ int bt_vcs_flags_get(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_read_flags(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_read_flags(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -549,12 +538,8 @@ int bt_vcs_vol_down(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_vol_down(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_vol_down(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -577,12 +562,8 @@ int bt_vcs_vol_up(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_vol_up(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_vol_up(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -605,12 +586,8 @@ int bt_vcs_unmute_vol_down(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_unmute_vol_down(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_unmute_vol_down(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -633,12 +610,8 @@ int bt_vcs_unmute_vol_up(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_unmute_vol_up(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_unmute_vol_up(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -661,12 +634,8 @@ int bt_vcs_vol_set(struct bt_vcs *vcs, uint8_t volume)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_set_volume(vcs, volume);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_set_volume(vcs, volume);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -692,12 +661,8 @@ int bt_vcs_unmute(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_unmute(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_unmute(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)
@@ -720,12 +685,8 @@ int bt_vcs_mute(struct bt_vcs *vcs)
 		return -EINVAL;
 	}
 
-	if (vcs->client_instance) {
-		if (IS_ENABLED(CONFIG_BT_VCS_CLIENT)) {
-			return bt_vcs_client_mute(vcs);
-		} else {
-			return -EOPNOTSUPP;
-		}
+	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT) && vcs->client_instance) {
+		return bt_vcs_client_mute(vcs);
 	}
 
 #if defined(CONFIG_BT_VCS)

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -359,7 +359,13 @@ static int prepare_aics_inst(struct bt_vcs_register_param *param)
 /****************************** PUBLIC API ******************************/
 int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs)
 {
+	static bool registered;
 	int err;
+
+	if (registered) {
+		*vcs = &vcs_inst;
+		return -EALREADY;
+	}
 
 	vcs_svc = (struct bt_gatt_service)BT_GATT_SERVICE(vcs_attrs);
 
@@ -392,6 +398,7 @@ int bt_vcs_register(struct bt_vcs_register_param *param, struct bt_vcs **vcs)
 	vcs_inst.srv.cb = param->cb;
 
 	*vcs = &vcs_inst;
+	registered = true;
 
 	return err;
 }

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -707,10 +707,11 @@ static void bt_vcs_client_init(void)
 	}
 }
 
-int bt_vcs_discover(struct bt_conn *conn)
+int bt_vcs_discover(struct bt_conn *conn, struct bt_vcs **vcs)
 {
 	static bool initialized;
 	struct bt_vcs_client *vcs_inst;
+	int err;
 
 	/*
 	 * This will initiate a discover procedure. The procedure will do the
@@ -749,7 +750,11 @@ int bt_vcs_discover(struct bt_conn *conn)
 	vcs_inst->discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
 	vcs_inst->discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 
-	return bt_gatt_discover(conn, &vcs_inst->discover_params);
+	err = bt_gatt_discover(conn, &vcs_inst->discover_params);
+	if (err == 0) {
+		*vcs = (struct bt_vcs *)&vcs_inst;
+	}
+	return err;
 }
 
 int bt_vcs_client_cb_register(struct bt_vcs_cb *cb)

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -835,6 +835,28 @@ int bt_vcs_client_included_get(struct bt_vcs *vcs,
 	return 0;
 }
 
+int bt_vcs_client_conn_get(const struct bt_vcs *vcs, struct bt_conn **conn)
+{
+	CHECKIF(vcs == NULL) {
+		BT_DBG("NULL vcs pointer");
+		return -EINVAL;
+	}
+
+	if (!vcs->client_instance) {
+		BT_DBG("vcs pointer shall be client instance");
+		return -EINVAL;
+	}
+
+	if (vcs->cli.conn == NULL) {
+		BT_DBG("vcs pointer not associated with a connection. "
+		       "Do discovery first");
+		return -ENOTCONN;
+	}
+
+	*conn = vcs->cli.conn;
+	return 0;
+}
+
 int bt_vcs_client_read_vol_state(struct bt_vcs *vcs)
 {
 	int err;

--- a/subsys/bluetooth/audio/vcs_internal.h
+++ b/subsys/bluetooth/audio/vcs_internal.h
@@ -55,12 +55,12 @@ struct bt_vcs_client {
 	struct bt_gatt_read_params read_params;
 	struct bt_gatt_discover_params discover_params;
 	struct bt_uuid_16 uuid;
+	struct bt_conn *conn;
 
 	uint8_t vocs_inst_cnt;
 	struct bt_vocs *vocs[CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST];
 	uint8_t aics_inst_cnt;
 	struct bt_aics *aics[CONFIG_BT_VCS_CLIENT_MAX_AICS_INST];
-	struct bt_conn *conn;
 };
 
 struct bt_vcs_server {
@@ -76,25 +76,25 @@ struct bt_vcs_server {
 
 /* Struct used as a common type for the api */
 struct bt_vcs {
+	bool client_instance;
 	union {
 		struct bt_vcs_server srv;
 		struct bt_vcs_client cli;
 	};
 };
 
-
-int bt_vcs_client_included_get(struct bt_conn *conn,
+int bt_vcs_client_included_get(struct bt_vcs *vcs,
 			       struct bt_vcs_included *included);
-int bt_vcs_client_read_vol_state(struct bt_conn *conn);
-int bt_vcs_client_read_flags(struct bt_conn *conn);
-int bt_vcs_client_vol_down(struct bt_conn *conn);
-int bt_vcs_client_vol_up(struct bt_conn *conn);
-int bt_vcs_client_unmute_vol_down(struct bt_conn *conn);
-int bt_vcs_client_unmute_vol_up(struct bt_conn *conn);
-int bt_vcs_client_set_volume(struct bt_conn *conn, uint8_t volume);
-int bt_vcs_client_unmute(struct bt_conn *conn);
-int bt_vcs_client_mute(struct bt_conn *conn);
+int bt_vcs_client_read_vol_state(struct bt_vcs *vcs);
+int bt_vcs_client_read_flags(struct bt_vcs *vcs);
+int bt_vcs_client_vol_down(struct bt_vcs *vcs);
+int bt_vcs_client_vol_up(struct bt_vcs *vcs);
+int bt_vcs_client_unmute_vol_down(struct bt_vcs *vcs);
+int bt_vcs_client_unmute_vol_up(struct bt_vcs *vcs);
+int bt_vcs_client_set_volume(struct bt_vcs *vcs, uint8_t volume);
+int bt_vcs_client_unmute(struct bt_vcs *vcs);
+int bt_vcs_client_mute(struct bt_vcs *vcs);
 
-bool bt_vcs_client_valid_vocs_inst(struct bt_conn *conn, struct bt_vocs *vocs);
-bool bt_vcs_client_valid_aics_inst(struct bt_conn *conn, struct bt_aics *aics);
+bool bt_vcs_client_valid_vocs_inst(struct bt_vcs *vcs, struct bt_vocs *vocs);
+bool bt_vcs_client_valid_aics_inst(struct bt_vcs *vcs, struct bt_aics *aics);
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_VCS_INTERNAL_*/

--- a/subsys/bluetooth/audio/vcs_internal.h
+++ b/subsys/bluetooth/audio/vcs_internal.h
@@ -36,6 +36,53 @@ struct vcs_control_vol {
 	uint8_t volume;
 } __packed;
 
+struct bt_vcs_client {
+	struct vcs_state state;
+	uint8_t flags;
+
+	uint16_t start_handle;
+	uint16_t end_handle;
+	uint16_t state_handle;
+	uint16_t control_handle;
+	uint16_t flag_handle;
+	struct bt_gatt_subscribe_params state_sub_params;
+	struct bt_gatt_subscribe_params flag_sub_params;
+	bool cp_retried;
+
+	bool busy;
+	struct vcs_control_vol cp_val;
+	struct bt_gatt_write_params write_params;
+	struct bt_gatt_read_params read_params;
+	struct bt_gatt_discover_params discover_params;
+	struct bt_uuid_16 uuid;
+
+	uint8_t vocs_inst_cnt;
+	struct bt_vocs *vocs[CONFIG_BT_VCS_CLIENT_MAX_VOCS_INST];
+	uint8_t aics_inst_cnt;
+	struct bt_aics *aics[CONFIG_BT_VCS_CLIENT_MAX_AICS_INST];
+	struct bt_conn *conn;
+};
+
+struct bt_vcs_server {
+	struct vcs_state state;
+	uint8_t flags;
+	struct bt_vcs_cb *cb;
+	uint8_t volume_step;
+
+	struct bt_gatt_service *service_p;
+	struct bt_vocs *vocs_insts[CONFIG_BT_VCS_VOCS_INSTANCE_COUNT];
+	struct bt_aics *aics_insts[CONFIG_BT_VCS_AICS_INSTANCE_COUNT];
+};
+
+/* Struct used as a common type for the api */
+struct bt_vcs {
+	union {
+		struct bt_vcs_server srv;
+		struct bt_vcs_client cli;
+	};
+};
+
+
 int bt_vcs_client_included_get(struct bt_conn *conn,
 			       struct bt_vcs_included *included);
 int bt_vcs_client_read_vol_state(struct bt_conn *conn);

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -19,7 +19,7 @@
 static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 
-static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
+static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
 			 uint8_t mute)
 {
 	if (err) {
@@ -29,7 +29,7 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 	}
 }
 
-static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err) {
 		shell_error(ctx_shell, "VCS flags get failed (%d)", err);
@@ -203,7 +203,7 @@ static int cmd_vcs_init(const struct shell *sh, size_t argc, char **argv)
 		return result;
 	}
 
-	result = bt_vcs_included_get(NULL, &vcs_included);
+	result = bt_vcs_included_get(vcs, &vcs_included);
 	if (result != 0) {
 		shell_error(sh, "Failed to get included services: %d", result);
 		return result;
@@ -235,7 +235,7 @@ static int cmd_vcs_volume_step(const struct shell *sh, size_t argc,
 static int cmd_vcs_state_get(const struct shell *sh, size_t argc,
 			     char **argv)
 {
-	int result = bt_vcs_vol_get(NULL);
+	int result = bt_vcs_vol_get(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -247,7 +247,7 @@ static int cmd_vcs_state_get(const struct shell *sh, size_t argc,
 static int cmd_vcs_flags_get(const struct shell *sh, size_t argc,
 			     char **argv)
 {
-	int result = bt_vcs_flags_get(NULL);
+	int result = bt_vcs_flags_get(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -259,7 +259,7 @@ static int cmd_vcs_flags_get(const struct shell *sh, size_t argc,
 static int cmd_vcs_volume_down(const struct shell *sh, size_t argc,
 			       char **argv)
 {
-	int result = bt_vcs_vol_down(NULL);
+	int result = bt_vcs_vol_down(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -272,7 +272,7 @@ static int cmd_vcs_volume_up(const struct shell *sh, size_t argc,
 			     char **argv)
 
 {
-	int result = bt_vcs_vol_up(NULL);
+	int result = bt_vcs_vol_up(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -284,7 +284,7 @@ static int cmd_vcs_volume_up(const struct shell *sh, size_t argc,
 static int cmd_vcs_unmute_volume_down(const struct shell *sh, size_t argc,
 				      char **argv)
 {
-	int result = bt_vcs_unmute_vol_down(NULL);
+	int result = bt_vcs_unmute_vol_down(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -296,7 +296,7 @@ static int cmd_vcs_unmute_volume_down(const struct shell *sh, size_t argc,
 static int cmd_vcs_unmute_volume_up(const struct shell *sh, size_t argc,
 				    char **argv)
 {
-	int result = bt_vcs_unmute_vol_up(NULL);
+	int result = bt_vcs_unmute_vol_up(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -317,7 +317,7 @@ static int cmd_vcs_volume_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vol_set(NULL, volume);
+	result = bt_vcs_vol_set(vcs, volume);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -327,7 +327,7 @@ static int cmd_vcs_volume_set(const struct shell *sh, size_t argc,
 
 static int cmd_vcs_unmute(const struct shell *sh, size_t argc, char **argv)
 {
-	int result = bt_vcs_unmute(NULL);
+	int result = bt_vcs_unmute(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -338,7 +338,7 @@ static int cmd_vcs_unmute(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_vcs_mute(const struct shell *sh, size_t argc, char **argv)
 {
-	int result = bt_vcs_mute(NULL);
+	int result = bt_vcs_mute(vcs);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -16,6 +16,7 @@
 
 #include "bt.h"
 
+static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
@@ -196,7 +197,7 @@ static int cmd_vcs_init(const struct shell *sh, size_t argc, char **argv)
 
 	vcs_param.cb = &vcs_cbs;
 
-	result = bt_vcs_register(&vcs_param);
+	result = bt_vcs_register(&vcs_param, &vcs);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 		return result;

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -18,7 +18,7 @@
 static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 
-static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
+static void vcs_discover_cb(struct bt_vcs *vcs, int err, uint8_t vocs_count,
 			    uint8_t aics_count)
 {
 	if (err != 0) {
@@ -27,13 +27,13 @@ static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 		shell_print(ctx_shell, "VCS discover done with %u AICS",
 			    aics_count);
 
-		if (bt_vcs_included_get(conn, &vcs_included)) {
+		if (bt_vcs_included_get(vcs, &vcs_included)) {
 			shell_error(ctx_shell, "Could not get VCS context");
 		}
 	}
 }
 
-static void vcs_vol_down_cb(struct bt_conn *conn, int err)
+static void vcs_vol_down_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_down failed (%d)", err);
@@ -42,7 +42,7 @@ static void vcs_vol_down_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_vol_up_cb(struct bt_conn *conn, int err)
+static void vcs_vol_up_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_up failed (%d)", err);
@@ -51,7 +51,7 @@ static void vcs_vol_up_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_mute_cb(struct bt_conn *conn, int err)
+static void vcs_mute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS mute failed (%d)", err);
@@ -60,7 +60,7 @@ static void vcs_mute_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_unmute_cb(struct bt_conn *conn, int err)
+static void vcs_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS unmute failed (%d)", err);
@@ -69,7 +69,7 @@ static void vcs_unmute_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_vol_down_unmute_cb(struct bt_conn *conn, int err)
+static void vcs_vol_down_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_down_unmute failed (%d)", err);
@@ -78,7 +78,7 @@ static void vcs_vol_down_unmute_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_vol_up_unmute_cb(struct bt_conn *conn, int err)
+static void vcs_vol_up_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_up_unmute failed (%d)", err);
@@ -87,7 +87,7 @@ static void vcs_vol_up_unmute_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_vol_set_cb(struct bt_conn *conn, int err)
+static void vcs_vol_set_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS vol_set failed (%d)", err);
@@ -96,8 +96,8 @@ static void vcs_vol_set_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
-			    uint8_t mute)
+static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
+			 uint8_t mute)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS state get failed (%d)", err);
@@ -106,7 +106,7 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 	}
 }
 
-static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "VCS flags get failed (%d)", err);
@@ -368,7 +368,7 @@ static int cmd_vcs_client_state_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vol_get(default_conn);
+	result = bt_vcs_vol_get(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -386,7 +386,7 @@ static int cmd_vcs_client_flags_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_flags_get(default_conn);
+	result = bt_vcs_flags_get(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -404,7 +404,7 @@ static int cmd_vcs_client_volume_down(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vol_down(default_conn);
+	result = bt_vcs_vol_down(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -423,7 +423,7 @@ static int cmd_vcs_client_volume_up(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vol_up(default_conn);
+	result = bt_vcs_vol_up(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -441,7 +441,7 @@ static int cmd_vcs_client_unmute_volume_down(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_unmute_vol_down(default_conn);
+	result = bt_vcs_unmute_vol_down(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -459,7 +459,7 @@ static int cmd_vcs_client_unmute_volume_up(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_unmute_vol_up(default_conn);
+	result = bt_vcs_unmute_vol_up(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -484,7 +484,7 @@ static int cmd_vcs_client_volume_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vol_set(default_conn, volume);
+	result = bt_vcs_vol_set(vcs, volume);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -503,7 +503,7 @@ static int cmd_vcs_client_unmute(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_unmute(default_conn);
+	result = bt_vcs_unmute(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -520,7 +520,7 @@ static int cmd_vcs_client_mute(const struct shell *sh, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_mute(default_conn);
+	result = bt_vcs_mute(vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -545,7 +545,7 @@ static int cmd_vcs_client_vocs_state_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_get(default_conn, vcs_included.vocs[index]);
+	result = bt_vcs_vocs_state_get(vcs, vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -570,8 +570,7 @@ static int cmd_vcs_client_vocs_location_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_location_get(default_conn,
-					  vcs_included.vocs[index]);
+	result = bt_vcs_vocs_location_get(vcs, vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -604,8 +603,7 @@ static int cmd_vcs_client_vocs_location_set(const struct shell *sh,
 
 	}
 
-	result = bt_vcs_vocs_location_set(default_conn,
-					  vcs_included.vocs[index],
+	result = bt_vcs_vocs_location_set(vcs, vcs_included.vocs[index],
 					  location);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -638,8 +636,7 @@ static int cmd_vcs_client_vocs_offset_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_state_set(default_conn,
-				       vcs_included.vocs[index],
+	result = bt_vcs_vocs_state_set(vcs, vcs_included.vocs[index],
 				       offset);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -665,8 +662,7 @@ static int cmd_vcs_client_vocs_output_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_get(default_conn,
-					     vcs_included.vocs[index]);
+	result = bt_vcs_vocs_description_get(vcs, vcs_included.vocs[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -692,8 +688,7 @@ static int cmd_vcs_client_vocs_output_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_vocs_description_set(default_conn,
-					     vcs_included.vocs[index],
+	result = bt_vcs_vocs_description_set(vcs, vcs_included.vocs[index],
 					     description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -719,7 +714,7 @@ static int cmd_vcs_client_aics_input_state_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_state_get(default_conn, vcs_included.aics[index]);
+	result = bt_vcs_aics_state_get(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -744,8 +739,7 @@ static int cmd_vcs_client_aics_gain_setting_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_setting_get(default_conn,
-					      vcs_included.aics[index]);
+	result = bt_vcs_aics_gain_setting_get(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -770,7 +764,7 @@ static int cmd_vcs_client_aics_input_type_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_type_get(default_conn, vcs_included.aics[index]);
+	result = bt_vcs_aics_type_get(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -795,7 +789,7 @@ static int cmd_vcs_client_aics_input_status_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_status_get(default_conn, vcs_included.aics[index]);
+	result = bt_vcs_aics_status_get(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -820,7 +814,7 @@ static int cmd_vcs_client_aics_input_unmute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_unmute(default_conn, vcs_included.aics[index]);
+	result = bt_vcs_aics_unmute(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -845,7 +839,7 @@ static int cmd_vcs_client_aics_input_mute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_mute(default_conn, vcs_included.aics[index]);
+	result = bt_vcs_aics_mute(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -870,8 +864,7 @@ static int cmd_vcs_client_aics_manual_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_manual_gain_set(default_conn,
-					     vcs_included.aics[index]);
+	result = bt_vcs_aics_manual_gain_set(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -896,8 +889,7 @@ static int cmd_vcs_client_aics_auto_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_automatic_gain_set(default_conn,
-						vcs_included.aics[index]);
+	result = bt_vcs_aics_automatic_gain_set(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -929,8 +921,7 @@ static int cmd_vcs_client_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_gain_set(default_conn,
-				      vcs_included.aics[index], gain);
+	result = bt_vcs_aics_gain_set(vcs, vcs_included.aics[index], gain);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -955,8 +946,7 @@ static int cmd_vcs_client_aics_input_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_get(default_conn,
-					     vcs_included.aics[index]);
+	result = bt_vcs_aics_description_get(vcs, vcs_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -982,8 +972,7 @@ static int cmd_vcs_client_aics_input_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_aics_description_set(default_conn,
-					     vcs_included.aics[index],
+	result = bt_vcs_aics_description_set(vcs, vcs_included.aics[index],
 					     description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -15,6 +15,7 @@
 
 #include "bt.h"
 
+static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 
 static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
@@ -349,7 +350,7 @@ static int cmd_vcs_client_discover(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcs_discover(default_conn);
+	result = bt_vcs_discover(default_conn, &vcs);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -18,6 +18,7 @@
 static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 
+static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
@@ -575,7 +576,7 @@ static void test_main(void)
 
 	WAIT_FOR(g_mtu_exchanged);
 
-	err = bt_vcs_discover(g_conn);
+	err = bt_vcs_discover(g_conn, &vcs);
 	if (err) {
 		FAIL("Failed to discover VCS %d", err);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -541,6 +541,7 @@ static void test_main(void)
 	static struct bt_gatt_exchange_params mtu_params =  {
 		.func = mtu_cb,
 	};
+	struct bt_conn *cached_conn;
 
 	err = bt_enable(bt_ready);
 
@@ -586,6 +587,17 @@ static void test_main(void)
 	err = bt_vcs_included_get(vcs, &vcs_included);
 	if (err) {
 		FAIL("Failed to get VCS included services (err %d)\n", err);
+		return;
+	}
+
+	printk("Getting VCS client conn\n");
+	err = bt_vcs_client_conn_get(vcs, &cached_conn);
+	if (err != 0) {
+		FAIL("Could not get VCS client conn (err %d)\n", err);
+		return;
+	}
+	if (cached_conn != g_conn) {
+		FAIL("Cached conn was not the conn used to discover");
 		return;
 	}
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -44,7 +44,7 @@ static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
 static struct bt_conn *g_conn;
 
-static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
+static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
 			 uint8_t mute)
 {
 	if (err) {
@@ -58,7 +58,7 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 	g_cb = true;
 }
 
-static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err) {
 		FAIL("VCS flags cb err (%d)", err);
@@ -209,7 +209,7 @@ static void aics_write_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
 	g_write_complete = true;
 }
 
-static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
+static void vcs_discover_cb(struct bt_vcs *vcs, int err, uint8_t vocs_count,
 			    uint8_t aics_count)
 {
 	if (err) {
@@ -220,7 +220,7 @@ static void vcs_discover_cb(struct bt_conn *conn, int err, uint8_t vocs_count,
 	g_discovery_complete = true;
 }
 
-static void vcs_write_cb(struct bt_conn *conn, int err)
+static void vcs_write_cb(struct bt_vcs *vcs, int err)
 {
 	if (err) {
 		FAIL("VCS write failed (%d)\n", err);
@@ -313,7 +313,7 @@ static int test_aics(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_vcs_aics_state_get(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_state_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -323,7 +323,7 @@ static int test_aics(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_vcs_aics_gain_setting_get(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_gain_setting_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -334,7 +334,7 @@ static int test_aics(void)
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	g_cb = false;
-	err = bt_vcs_aics_type_get(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_type_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -345,7 +345,7 @@ static int test_aics(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_vcs_aics_status_get(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_status_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -355,7 +355,7 @@ static int test_aics(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_vcs_aics_description_get(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_description_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -366,7 +366,7 @@ static int test_aics(void)
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_mute(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_mute(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -378,7 +378,7 @@ static int test_aics(void)
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_unmute(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_unmute(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -390,7 +390,7 @@ static int test_aics(void)
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_automatic_gain_set(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_automatic_gain_set(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -401,7 +401,7 @@ static int test_aics(void)
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_manual_gain_set(g_conn, vcs_included.aics[0]);
+	err = bt_vcs_aics_manual_gain_set(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -412,7 +412,7 @@ static int test_aics(void)
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_aics_gain_set(g_conn, vcs_included.aics[0], expected_gain);
+	err = bt_vcs_aics_gain_set(vcs, vcs_included.aics[0], expected_gain);
 	if (err) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -425,7 +425,7 @@ static int test_aics(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_aics_description_set(g_conn, vcs_included.aics[0],
+	err = bt_vcs_aics_description_set(vcs, vcs_included.aics[0],
 					  expected_aics_desc);
 	if (err) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
@@ -461,7 +461,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS state\n");
 	g_cb = false;
-	err = bt_vcs_vocs_state_get(g_conn, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_state_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
@@ -471,7 +471,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS location\n");
 	g_cb = false;
-	err = bt_vcs_vocs_location_get(g_conn, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_location_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
@@ -481,7 +481,7 @@ static int test_vocs(void)
 
 	printk("Getting VOCS description\n");
 	g_cb = false;
-	err = bt_vcs_vocs_description_get(g_conn, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_description_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
@@ -492,7 +492,7 @@ static int test_vocs(void)
 	printk("Setting VOCS location\n");
 	expected_location = g_vocs_location + 1;
 	g_cb = false;
-	err = bt_vcs_vocs_location_set(g_conn, vcs_included.vocs[0],
+	err = bt_vcs_vocs_location_set(vcs, vcs_included.vocs[0],
 				       expected_location);
 	if (err) {
 		FAIL("Could not set VOCS location (err %d)\n", err);
@@ -504,7 +504,7 @@ static int test_vocs(void)
 	printk("Setting VOCS state\n");
 	expected_offset = g_vocs_offset + 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_vocs_state_set(g_conn, vcs_included.vocs[0], expected_offset);
+	err = bt_vcs_vocs_state_set(vcs, vcs_included.vocs[0], expected_offset);
 	if (err) {
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
@@ -517,7 +517,7 @@ static int test_vocs(void)
 		sizeof(expected_description));
 	expected_description[sizeof(expected_description) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_vocs_description_set(g_conn, vcs_included.vocs[0],
+	err = bt_vcs_vocs_description_set(vcs, vcs_included.vocs[0],
 					  expected_description);
 	if (err) {
 		FAIL("Could not set VOCS description (err %d)\n", err);
@@ -583,7 +583,7 @@ static void test_main(void)
 
 	WAIT_FOR(g_discovery_complete);
 
-	err = bt_vcs_included_get(g_conn, &vcs_included);
+	err = bt_vcs_included_get(vcs, &vcs_included);
 	if (err) {
 		FAIL("Failed to get VCS included services (err %d)\n", err);
 		return;
@@ -591,7 +591,7 @@ static void test_main(void)
 
 	printk("Getting VCS volume state\n");
 	g_cb = false;
-	err = bt_vcs_vol_get(g_conn);
+	err = bt_vcs_vol_get(vcs);
 	if (err) {
 		FAIL("Could not get VCS volume (err %d)\n", err);
 		return;
@@ -601,7 +601,7 @@ static void test_main(void)
 
 	printk("Getting VCS flags\n");
 	g_cb = false;
-	err = bt_vcs_flags_get(g_conn);
+	err = bt_vcs_flags_get(vcs);
 	if (err) {
 		FAIL("Could not get VCS flags (err %d)\n", err);
 		return;
@@ -611,7 +611,7 @@ static void test_main(void)
 
 	expected_volume = g_volume != 100 ? 100 : 101; /* ensure change */
 	g_write_complete = g_cb = false;
-	err = bt_vcs_vol_set(g_conn, expected_volume);
+	err = bt_vcs_vol_set(vcs, expected_volume);
 	if (err) {
 		FAIL("Could not set VCS volume (err %d)\n", err);
 		return;
@@ -622,7 +622,7 @@ static void test_main(void)
 	printk("Downing VCS volume\n");
 	previous_volume = g_volume;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_vol_down(g_conn);
+	err = bt_vcs_vol_down(vcs);
 	if (err) {
 		FAIL("Could not get down VCS volume (err %d)\n", err);
 		return;
@@ -633,7 +633,7 @@ static void test_main(void)
 	printk("Upping VCS volume\n");
 	previous_volume = g_volume;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_vol_up(g_conn);
+	err = bt_vcs_vol_up(vcs);
 	if (err) {
 		FAIL("Could not up VCS volume (err %d)\n", err);
 		return;
@@ -644,7 +644,7 @@ static void test_main(void)
 	printk("Muting VCS\n");
 	expected_mute = 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_mute(g_conn);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -656,7 +656,7 @@ static void test_main(void)
 	previous_volume = g_volume;
 	expected_mute = 0;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_unmute_vol_down(g_conn);
+	err = bt_vcs_unmute_vol_down(vcs);
 	if (err) {
 		FAIL("Could not down and unmute VCS (err %d)\n", err);
 		return;
@@ -668,7 +668,7 @@ static void test_main(void)
 	printk("Muting VCS\n");
 	expected_mute = 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_mute(g_conn);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -680,7 +680,7 @@ static void test_main(void)
 	previous_volume = g_volume;
 	expected_mute = 0;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_unmute_vol_up(g_conn);
+	err = bt_vcs_unmute_vol_up(vcs);
 	if (err) {
 		FAIL("Could not up and unmute VCS (err %d)\n", err);
 		return;
@@ -692,7 +692,7 @@ static void test_main(void)
 	printk("Muting VCS\n");
 	expected_mute = 1;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_mute(g_conn);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -703,7 +703,7 @@ static void test_main(void)
 	printk("Unmuting VCS\n");
 	expected_mute = 0;
 	g_write_complete = g_cb = false;
-	err = bt_vcs_unmute(g_conn);
+	err = bt_vcs_unmute(vcs);
 	if (err) {
 		FAIL("Could not unmute VCS (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -44,7 +44,7 @@ static volatile bool g_cb;
 static struct bt_conn *g_conn;
 static bool g_is_connected;
 
-static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
+static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
 			 uint8_t mute)
 {
 	if (err) {
@@ -54,13 +54,10 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 
 	g_volume = volume;
 	g_mute = mute;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err) {
 		FAIL("VCS flags cb err (%d)", err);
@@ -68,10 +65,7 @@ static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 	}
 
 	g_flags = flags;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
@@ -241,7 +235,7 @@ static int test_aics_standalone(void)
 
 	printk("Deactivating AICS\n");
 	expected_aics_active = false;
-	err = bt_vcs_aics_deactivate(vcs_included.aics[0]);
+	err = bt_vcs_aics_deactivate(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
@@ -251,7 +245,7 @@ static int test_aics_standalone(void)
 
 	printk("Activating AICS\n");
 	expected_aics_active = true;
-	err = bt_vcs_aics_activate(vcs_included.aics[0]);
+	err = bt_vcs_aics_activate(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
@@ -261,7 +255,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_vcs_aics_state_get(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_state_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -271,7 +265,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_vcs_aics_gain_setting_get(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_gain_setting_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -281,7 +275,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
-	err = bt_vcs_aics_type_get(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_type_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -292,7 +286,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_vcs_aics_status_get(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_status_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -302,7 +296,7 @@ static int test_aics_standalone(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_vcs_aics_description_get(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_description_get(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -312,7 +306,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
-	err = bt_vcs_aics_mute(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_mute(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -322,7 +316,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
-	err = bt_vcs_aics_unmute(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_unmute(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -332,7 +326,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
-	err = bt_vcs_aics_automatic_gain_set(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_automatic_gain_set(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -342,7 +336,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
-	err = bt_vcs_aics_manual_gain_set(NULL, vcs_included.aics[0]);
+	err = bt_vcs_aics_manual_gain_set(vcs, vcs_included.aics[0]);
 	if (err) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -352,7 +346,7 @@ static int test_aics_standalone(void)
 
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
-	err = bt_vcs_aics_gain_set(NULL, vcs_included.aics[0], expected_gain);
+	err = bt_vcs_aics_gain_set(vcs, vcs_included.aics[0], expected_gain);
 	if (err) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -365,7 +359,7 @@ static int test_aics_standalone(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_aics_description_set(NULL, vcs_included.aics[0],
+	err = bt_vcs_aics_description_set(vcs, vcs_included.aics[0],
 					  expected_aics_desc);
 	if (err) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
@@ -387,7 +381,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS state\n");
 	g_cb = false;
-	err = bt_vcs_vocs_state_get(NULL, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_state_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
@@ -397,7 +391,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS location\n");
 	g_cb = false;
-	err = bt_vcs_vocs_location_get(NULL, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_location_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
@@ -407,7 +401,7 @@ static int test_vocs_standalone(void)
 
 	printk("Getting VOCS description\n");
 	g_cb = false;
-	err = bt_vcs_vocs_description_get(NULL, vcs_included.vocs[0]);
+	err = bt_vcs_vocs_description_get(vcs, vcs_included.vocs[0]);
 	if (err) {
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
@@ -417,7 +411,8 @@ static int test_vocs_standalone(void)
 
 	printk("Setting VOCS location\n");
 	expected_location = g_vocs_location + 1;
-	err = bt_vcs_vocs_location_set(NULL, vcs_included.vocs[0], expected_location);
+	err = bt_vcs_vocs_location_set(vcs, vcs_included.vocs[0],
+				       expected_location);
 	if (err) {
 		FAIL("Could not set VOCS location (err %d)\n", err);
 		return err;
@@ -427,7 +422,7 @@ static int test_vocs_standalone(void)
 
 	printk("Setting VOCS state\n");
 	expected_offset = g_vocs_offset + 1;
-	err = bt_vcs_vocs_state_set(NULL, vcs_included.vocs[0], expected_offset);
+	err = bt_vcs_vocs_state_set(vcs, vcs_included.vocs[0], expected_offset);
 	if (err) {
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
@@ -440,7 +435,7 @@ static int test_vocs_standalone(void)
 		sizeof(expected_description) - 1);
 	expected_description[sizeof(expected_description) - 1] = '\0';
 	g_cb = false;
-	err = bt_vcs_vocs_description_set(NULL, vcs_included.vocs[0],
+	err = bt_vcs_vocs_description_set(vcs, vcs_included.vocs[0],
 					  expected_description);
 	if (err) {
 		FAIL("Could not set VOCS description (err %d)\n", err);
@@ -504,7 +499,7 @@ static void test_standalone(void)
 		return;
 	}
 
-	err = bt_vcs_included_get(NULL, &vcs_included);
+	err = bt_vcs_included_get(vcs, &vcs_included);
 	if (err) {
 		FAIL("VCS included get failed (err %d)\n", err);
 		return;
@@ -523,7 +518,7 @@ static void test_standalone(void)
 
 	printk("Getting VCS volume state\n");
 	g_cb = false;
-	err = bt_vcs_vol_get(NULL);
+	err = bt_vcs_vol_get(vcs);
 	if (err) {
 		FAIL("Could not get VCS volume (err %d)\n", err);
 		return;
@@ -533,7 +528,7 @@ static void test_standalone(void)
 
 	printk("Getting VCS flags\n");
 	g_cb = false;
-	err = bt_vcs_flags_get(NULL);
+	err = bt_vcs_flags_get(vcs);
 	if (err) {
 		FAIL("Could not get VCS flags (err %d)\n", err);
 		return;
@@ -543,7 +538,7 @@ static void test_standalone(void)
 
 	printk("Downing VCS volume\n");
 	expected_volume = g_volume - volume_step;
-	err = bt_vcs_vol_down(NULL);
+	err = bt_vcs_vol_down(vcs);
 	if (err) {
 		FAIL("Could not get down VCS volume (err %d)\n", err);
 		return;
@@ -553,7 +548,7 @@ static void test_standalone(void)
 
 	printk("Upping VCS volume\n");
 	expected_volume = g_volume + volume_step;
-	err = bt_vcs_vol_up(NULL);
+	err = bt_vcs_vol_up(vcs);
 	if (err) {
 		FAIL("Could not up VCS volume (err %d)\n", err);
 		return;
@@ -563,7 +558,7 @@ static void test_standalone(void)
 
 	printk("Muting VCS\n");
 	expected_mute = 1;
-	err = bt_vcs_mute(NULL);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -574,7 +569,7 @@ static void test_standalone(void)
 	printk("Downing and unmuting VCS\n");
 	expected_volume = g_volume - volume_step;
 	expected_mute = 0;
-	err = bt_vcs_unmute_vol_down(NULL);
+	err = bt_vcs_unmute_vol_down(vcs);
 	if (err) {
 		FAIL("Could not down and unmute VCS (err %d)\n", err);
 		return;
@@ -585,7 +580,7 @@ static void test_standalone(void)
 
 	printk("Muting VCS\n");
 	expected_mute = 1;
-	err = bt_vcs_mute(NULL);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -596,7 +591,7 @@ static void test_standalone(void)
 	printk("Upping and unmuting VCS\n");
 	expected_volume = g_volume + volume_step;
 	expected_mute = 0;
-	err = bt_vcs_unmute_vol_up(NULL);
+	err = bt_vcs_unmute_vol_up(vcs);
 	if (err) {
 		FAIL("Could not up and unmute VCS (err %d)\n", err);
 		return;
@@ -607,7 +602,7 @@ static void test_standalone(void)
 
 	printk("Muting VCS\n");
 	expected_mute = 1;
-	err = bt_vcs_mute(NULL);
+	err = bt_vcs_mute(vcs);
 	if (err) {
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
@@ -617,7 +612,7 @@ static void test_standalone(void)
 
 	printk("Unmuting VCS\n");
 	expected_mute = 0;
-	err = bt_vcs_unmute(NULL);
+	err = bt_vcs_unmute(vcs);
 	if (err) {
 		FAIL("Could not unmute VCS (err %d)\n", err);
 		return;
@@ -626,7 +621,7 @@ static void test_standalone(void)
 	printk("VCS volume unmuted\n");
 
 	expected_volume = g_volume - 5;
-	err = bt_vcs_vol_set(NULL, expected_volume);
+	err = bt_vcs_vol_set(vcs, expected_volume);
 	if (err) {
 		FAIL("Could not set VCS volume (err %d)\n", err);
 		return;
@@ -699,7 +694,7 @@ static void test_main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_vcs_included_get(NULL, &vcs_included);
+	err = bt_vcs_included_get(vcs, &vcs_included);
 	if (err) {
 		FAIL("VCS included get failed (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -22,6 +22,7 @@ extern enum bst_result_t bst_result;
 #define AICS_DESC_SIZE 0
 #endif /* CONFIG_BT_AICS */
 
+static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 
 static volatile uint8_t g_volume;
@@ -497,7 +498,7 @@ static void test_standalone(void)
 
 	vcs_param.cb = &vcs_cb;
 
-	err = bt_vcs_register(&vcs_param);
+	err = bt_vcs_register(&vcs_param, &vcs);
 	if (err) {
 		FAIL("VCS register failed (err %d)\n", err);
 		return;
@@ -690,7 +691,7 @@ static void test_main(void)
 
 	vcs_param.cb = &vcs_cb;
 
-	err = bt_vcs_register(&vcs_param);
+	err = bt_vcs_register(&vcs_param, &vcs);
 	if (err) {
 		FAIL("VCS register failed (err %d)\n", err);
 		return;


### PR DESCRIPTION
Updates the VCS API to use the bt_vcs instance pointer instead of a bt_conn pointer. This was requsted during a recent API discussion, and should make the API simpler, especially since it's the same API for local and remote procedures. 

Fixed #36303 