### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: updating procedure timeout handling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_llcp_internal.h
@@ -58,3 +58,13 @@ void ull_conn_pause_rx_data(struct ll_conn *conn);
  * @brief Resume the data path of a rx queue.
  */
 void ull_conn_resume_rx_data(struct ll_conn *conn);
+
+/**
+ * @brief Restart procedure timeout timer
+ */
+void ull_conn_prt_reload(struct ll_conn *conn, uint16_t procedure_reload);
+
+/**
+ * @brief Clear procedure timeout timer
+ */
+void ull_conn_prt_clear(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_connections.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_connections.c
@@ -191,6 +191,22 @@ void ull_conn_resume_rx_data(struct ll_conn *conn)
 	conn->pause_rx_data = 0U;
 }
 
+/**
+ * @brief Restart procedure timeout 'timer'
+ */
+void ull_conn_prt_reload(struct ll_conn *conn, uint16_t procedure_reload)
+{
+	conn->procedure_expire = procedure_reload;
+}
+
+/**
+ * @brief Clear procedure timeout 'timer'
+ */
+void ull_conn_prt_clear(struct ll_conn *conn)
+{
+	conn->procedure_expire = 0U;
+}
+
 /*
  * EGON: following 2 functions need to be removed when implementing tx/rx path
  * ll_rx_enqueue needs to be replaced with calls to ll_rx_put/ll_rx_sched

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -144,6 +144,9 @@ static void lp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	/* Enqueue LL Control PDU towards LLL */
 	tx_enqueue(conn, tx);
+
+	/* Update procedure timout. For TERMINATE supervision_timeout is used */
+	ull_conn_prt_reload(conn, (ctx->proc != PROC_TERMINATE)?conn->procedure_reload:conn->supervision_reload);
 }
 
 static void lp_comm_ntf_feature_exchange(struct ll_conn *conn, struct proc_ctx *ctx, struct pdu_data *pdu)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -167,6 +167,9 @@ static struct node_tx *lp_enc_tx(struct ll_conn *conn, struct proc_ctx *ctx, uin
 	/* Enqueue LL Control PDU towards LLL */
 	tx_enqueue(conn, tx);
 
+	/* Update procedure timout */
+	ull_conn_prt_reload(conn, conn->procedure_reload);
+
 	return tx;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -28,6 +28,7 @@
 #include "ull_conn_types.h"
 #include "ull_llcp.h"
 #include "ull_llcp_internal.h"
+#include "ull_conn_llcp_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_local
@@ -71,6 +72,11 @@ static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 		LL_ASSERT(ctx_header == ctx);
 
 		lr_dequeue(conn);
+
+		if ((ctx->proc != PROC_CHAN_MAP_UPDATE) && (ctx->proc != PROC_CONN_UPDATE)) {
+			ull_conn_prt_clear(conn);
+		}
+
 		ull_cp_priv_proc_ctx_release(ctx);
 	}
 }
@@ -388,6 +394,7 @@ void ull_cp_priv_lr_abort(struct ll_conn *conn)
 	}
 
 	/* TODO(thoh): Whats missing here ??? */
+	ull_conn_prt_clear(conn);
 	rr_set_incompat(conn, 0U);
 	lr_set_state(conn, LR_STATE_IDLE);
 }


### PR DESCRIPTION
Adding hooks to drive procedure timeout mechanism.

Concept initially tested by running a modified ll_con_sla_bv_19_c against a version of the VERSION_EXCHANGE where the remote 'omits' sending the VERSION_IND, thus tricking the initiator into procedure timeout condition.
Also tested with a pre-timeout TERMINATE to confirm that the termination takes effect during the procedure-timeout period