### PR TITLE
Add temperature platform for nrf ieee 802154 radio driver

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -72,6 +72,8 @@ choice NRF_802154_SL_TYPE
 
 config NRF_802154_SL_OPENSOURCE
 	bool "Open source"
+	select SENSOR
+	select TEMP_NRF5
 
 endchoice
 
@@ -111,6 +113,24 @@ config NRF_802154_RX_BUFFERS
 	help
 	  Number of buffers in nRF 802.15.4 driver receive queue. If this value is modified,
 	  its serialization host counterpart must be set to the exact same value.
+
+config NRF_802154_TEMPERATURE_UPDATE_PRIO
+	int "nRF 802.15.4 temperature update priority"
+	default 5
+	help
+	  Priority of a thread updating current temperature for nRF 802.15.4 driver.
+
+config NRF_802154_TEMPERATURE_UPDATE_STACK_SIZE
+	int "nRF 802.15.4 temperature update stack size"
+	default 128
+	help
+	  Stack size of a thread updating current temperature for nRF 802.15.4 driver.
+
+config NRF_802154_TEMPERATURE_UPDATE_PERIOD
+	int "nRF 802.15.4 temperature update period in milliseconds"
+	default 60000
+	help
+	  Period of a temperature update for nRF 802.15.4 driver in milliseconds
 
 endif # NRF_802154_RADIO_DRIVER
 

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -12,6 +12,7 @@ if (CONFIG_NRF_802154_RADIO_DRIVER)
       ${CMAKE_CURRENT_SOURCE_DIR}/sl_opensource/platform/nrf_802154_clock_zephyr.c
       ${CMAKE_CURRENT_SOURCE_DIR}/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
       ${CMAKE_CURRENT_SOURCE_DIR}/sl_opensource/platform/nrf_802154_irq_zephyr.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/sl_opensource/platform/nrf_802154_temperature_zephyr.c
   )
 
   if (CONFIG_SOC_SERIES_NRF53X AND NOT CONFIG_NRF_802154_SL_OPENSOURCE)

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *   This file implements the thermometer abstraction that uses Zephyr sensor
+ *   API for the die termomether.
+ *
+ */
+
+#include "platform/nrf_802154_temperature.h"
+
+#include <device.h>
+#include <drivers/sensor.h>
+#include <kernel.h>
+#include <logging/log.h>
+#include <stdbool.h>
+
+#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_MODULE_NAME nrf_802154_temperature
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+/** @brief Value of the last temperature measurement in degree Celsius. */
+static int8_t temperature;
+
+void nrf_802154_temperature_init(void)
+{
+	/* Intentionally empty. */
+}
+
+void nrf_802154_temperature_deinit(void)
+{
+	/* Intentionally empty. */
+}
+
+int8_t nrf_802154_temperature_get(void)
+{
+	return temperature;
+}
+
+/** @brief Thread handler for temperature update. */
+static void temperature_update_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	static struct sensor_value  temperature_value;
+	static const struct device *temperature_dev;
+
+	temperature_dev = DEVICE_DT_GET(DT_NODELABEL(temp));
+
+	if (!device_is_ready(temperature_dev)) {
+		LOG_ERR("Setup of temperature sensor for nRF 802.15.4 driver failed");
+		__ASSERT_NO_MSG(false);
+	}
+
+	while (true) {
+		sensor_sample_fetch(temperature_dev);
+		sensor_channel_get(temperature_dev, SENSOR_CHAN_DIE_TEMP, &temperature_value);
+
+		if (temperature != temperature_value.val1) {
+			temperature = temperature_value.val1;
+
+			nrf_802154_temperature_changed();
+		}
+
+		k_sleep(K_MSEC(CONFIG_NRF_802154_TEMPERATURE_UPDATE_PERIOD));
+	}
+}
+
+K_THREAD_DEFINE(temperature_update_tid,
+		CONFIG_NRF_802154_TEMPERATURE_UPDATE_STACK_SIZE,
+		temperature_update_thread,
+		NULL,
+		NULL,
+		NULL,
+		CONFIG_NRF_802154_TEMPERATURE_UPDATE_PRIO,
+		0,
+		0);

--- a/west.yml
+++ b/west.yml
@@ -82,7 +82,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d979c8dc313e4dc3e52d5606c28622e5278be50c
+      revision: 00fd2aa97a22ea1052d9dabe1b18ab396daab93a
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Patches introduce new, Zephyr specific, temperature platform for nRF IEEE 802.15.4 driver. The die temperature sensor is used to obtain current temperature.