### PR TITLE
Fix RISC-V unshared FP mode: enable FPU of threads

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -86,10 +86,14 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* CONFIG_PMP_STACK_GUARD */
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	/* Shared FP mode: enable FPU of threads with K_FP_REGS. */
 	if ((thread->base.user_options & K_FP_REGS) != 0) {
 		stack_init->mstatus |= MSTATUS_FS_INIT;
 	}
 	stack_init->fp_state = 0;
+#elif defined(CONFIG_FPU)
+	/* Unshared FP mode: enable FPU of each thread. */
+	stack_init->mstatus |= MSTATUS_FS_INIT;
 #endif
 
 	stack_init->mepc = (ulong_t)z_thread_entry_wrapper;


### PR DESCRIPTION
In unshared FP mode, RISC-V arch currently doesn't enable FPU of any thread, but there should be a thread using FPU. To fix this bug, enable FPU of each thread because kernel doesn't know which one will use FPU. 
(p.s. SPARC arch also does in same way.)

`tests/lib/sprintf` test will hit this bug if compiler generates floating instruction. For example, RV64D ISA platform (qemu_riscv64 + double-precision FPU) will hit it, but RV32F ISA platform (in-tree qemu_riscv32) doesn't by GCC in current Zephyr SDK

Also, I will open another PR to enable double-precision FPU in qemu_riscv64 to improve coverage of RISC-V FPU ISA.
