### PR TITLE
RISC-V: Enable double precision FPU in qemu_riscv64 to improve coverage

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -37,7 +37,9 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif
 
 	/* Initial stack frame for thread */
-	stack_init = Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr);
+	stack_init = (struct __esf *)Z_STACK_PTR_ALIGN(
+				Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr)
+				);
 
 	/* Setup the initial stack frame */
 	stack_init->a0 = (ulong_t)entry;

--- a/boards/riscv/qemu_riscv64/Kconfig.board
+++ b/boards/riscv/qemu_riscv64/Kconfig.board
@@ -6,3 +6,4 @@ config BOARD_QEMU_RISCV64
 	depends on SOC_RISCV_VIRT
 	select QEMU_TARGET
 	select 64BIT
+	select CPU_HAS_FPU_DOUBLE_PRECISION


### PR DESCRIPTION
Current RISC-V QEMU platforms only contain single-precision FPU (F extension) in qemu_riscv32, so I'd like to enable double-precision FPU in qemu_riscv64 to improve test coverage.

Enabling it will hit 2 bugs [#35830, #29561] in RISC-V porting, so this PR depends on them. I will add commits of dependent PRs to this PR for CI testing, but they will be removed after dependency PRs get merged.

Failed testcases and bugs:

1. tests/lib/sprintf gets failed and is fixed by #35830
    (see #35830 for detail)
      
2. tests/kernel/fpu_sharing/generic/ gets failed and is fixed by #29561
    
    Add more explanation of this bug:
    In RISC-V porting, `__z_arch_esf_t_SIZEOF` is 16-byte aligned, but `sizeof(z_arch_esf_t)` isn't. The former is used in context switch (save/restore) and the latter is used in thread init. Because the stack frame size of context restore is larger than thread init, $sp is overflow the end of thread stack when 1st time switches to one thread. The overflowed $sp causes the pollution of another thread stack's magic value in STACK_SENTINEL and makes it's checking failed. (same as #29535 bug)
