### PR TITLE
drivers: i2c: gpio: fix compilation

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -128,8 +128,8 @@ static int i2c_gpio_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	err = gpio_config(context->scl_gpio, config->scl_pin,
-			  config->scl_flags | GPIO_OUTPUT_HIGH);
+	err = gpio_pin_configure(context->scl_gpio, config->scl_pin,
+				 config->scl_flags | GPIO_OUTPUT_HIGH);
 	if (err) {
 		LOG_ERR("failed to configure SCL GPIO pin (err %d)", err);
 		return err;
@@ -141,11 +141,11 @@ static int i2c_gpio_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	err = gpio_config(context->sda_gpio, config->sda_pin,
-			  config->sda_flags | GPIO_INPUT | GPIO_OUTPUT_HIGH);
+	err = gpio_pin_configure(context->sda_gpio, config->sda_pin,
+				 config->sda_flags | GPIO_INPUT | GPIO_OUTPUT_HIGH);
 	if (err == -ENOTSUP) {
-		err = gpio_config(context->sda_gpio, config->sda_pin,
-				  config->sda_flags | GPIO_OUTPUT_HIGH);
+		err = gpio_pin_configure(context->sda_gpio, config->sda_pin,
+					 config->sda_flags | GPIO_OUTPUT_HIGH);
 	}
 	if (err) {
 		LOG_ERR("failed to configure SDA GPIO pin (err %d)", err);


### PR DESCRIPTION
Fix the compilation of i2c_gpio.c after the gpio_config() syscall was removed.

Fixes: 3632815e2e124c0c4b1ed09cd91f60ecbd2fda83

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>