### PR TITLE
logging: z_vrfy_log_filter_set: remove extra check

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -948,7 +948,7 @@ uint32_t z_vrfy_log_filter_set(struct log_backend const *const backend,
 	Z_OOPS(Z_SYSCALL_VERIFY_MSG(src_id < log_sources_count(),
 		"Invalid log source id"));
 	Z_OOPS(Z_SYSCALL_VERIFY_MSG(
-		(level <= LOG_LEVEL_DBG) && (level >= LOG_LEVEL_NONE),
+		(level <= LOG_LEVEL_DBG),
 		"Invalid log level"));
 
 	return z_impl_log_filter_set(NULL, domain_id, src_id, level);


### PR DESCRIPTION
Variable "level" in function z_vrfy_log_filter_set() has type unsigned.
But it is been checked if "level >=LOG_LEVEL_NONE" and
LOG_LEVEL_NONE is 0. It means check if unsigned is ">= 0" in Z_OOPS().
That is logically wrong, because unsigned is ">=0" by default.
Remove that check, to avoid static analysis tool raise
violation

Found as a coding guideline violation (MISRA R14.3) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>