### PR TITLE
coding guidelines: add to function prototypes form named parameters

### DIFF
--- a/include/arch/x86/multiboot.h
+++ b/include/arch/x86/multiboot.h
@@ -36,7 +36,7 @@ struct multiboot_info {
 
 extern struct multiboot_info multiboot_info;
 
-extern void z_multiboot_init(struct multiboot_info *);
+extern void z_multiboot_init(struct multiboot_info *info_pa);
 
 /*
  * the mmap_addr field points to a series of entries of the following form.

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -48,7 +48,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 struct k_spinlock sched_spinlock;
 
-static void update_cache(int);
+static void update_cache(int preempt_ok);
 static void end_thread(struct k_thread *thread);
 
 static inline int is_preempt(struct k_thread *thread)

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -22,7 +22,7 @@
 /* newlib doesn't declare this function unless __POSIX_VISIBLE >= 200809.  No
  * idea how to make that happen, so lets put it right here.
  */
-size_t strnlen(const char *, size_t);
+size_t strnlen(const char *s, size_t maxlen);
 
 /* Provide typedefs used for signed and unsigned integral types
  * capable of holding all convertable integral values.


### PR DESCRIPTION
Function types shall be in prototype form with named parameters

Found as a coding guideline violation (MISRA R8.2) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>