### PR TITLE
GCC-11: Set DWARF to version 4 and ignore array bound warnings for generated syscalls functions

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -167,6 +167,10 @@ set_compiler_property(PROPERTY freestanding -ffreestanding)
 # Flag to enable debugging
 set_compiler_property(PROPERTY debug -g)
 
+# GCC 11 by default emits DWARF version 5 which cannot be parsed by
+# pyelftools. Can be removed once pyelftools supports v5.
+check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
+
 set_compiler_property(PROPERTY no_common -fno-common)
 
 # GCC compiler flags for imacros. The specific header must be appended by user.

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -86,6 +86,7 @@ syscall_template = """
 
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
* GCC 11 defaults to output DWARF version 5 which pyelftools cannot currently parse. So keep output at version 4 for the time being.
* Compilers and static code analyzers do not understand Zephyr's syscall mechanism so they always complain about out of bound array access inside the generated syscall header functions. So add a flag for GCC to ignore this type of warning for these functions.

Related to #35707 