### PR TITLE
boards: arm: bl5340: Fix LIS3DH IRQ levels

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -64,7 +64,7 @@
 		compatible = "st,lis2dh";
 		label = "LIS3DH";
 		reg = <0x18>;
-		irq-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>, <&gpio0 24 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>, <&gpio0 24 GPIO_ACTIVE_HIGH>;
 	};
 
 	ft5336@38 {


### PR DESCRIPTION
Levels were wrongly assigned to being active low instead of active high

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>