### PR TITLE
kconfig: soc and shield cleanup

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -14,9 +14,17 @@
 # precedence over SoC defaults, so include them in that order.
 #
 # $ARCH and $BOARD_DIR will be glob patterns when building documentation.
-source "$(KCONFIG_BINARY_DIR)/Kconfig.shield.defconfig"
+# This loads custom shields defconfigs (from BOARD_ROOT)
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.shield.defconfig"
+# This loads Zephyr base shield defconfigs
+source "boards/shields/*/Kconfig.defconfig"
+
 source "$(BOARD_DIR)/Kconfig.defconfig"
-source "$(KCONFIG_BINARY_DIR)/Kconfig.soc.defconfig"
+
+# This loads custom SoC root defconfigs
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.soc.defconfig"
+# This loads Zephyr base SoC root defconfigs
+osource "soc/$(ARCH)/*/Kconfig.defconfig"
 
 menu "Modules"
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -25,7 +25,10 @@ endchoice
 
 # Parse shields references
 # Don't do it as a menuconfig, as shield selection is a CMake feature.
-source "$(KCONFIG_BINARY_DIR)/Kconfig.shield"
+# This loads custom shields Kconfig (from BOARD_ROOT)
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.shield"
+# This loads Zephyr base shield defconfigs
+rsource "shields/*/Kconfig.shield"
 
 menu "Board Options"
 config QEMU_ICOUNT

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -5,9 +5,11 @@
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/generated)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/config)
 
-# Support multiple SOC_ROOT
+# Support multiple SOC_ROOT, remove ZEPHYR_BASE as that is always sourced.
+set(kconfig_soc_root ${SOC_ROOT})
+list(REMOVE_ITEM kconfig_soc_root ${ZEPHYR_BASE})
 set(OPERATION WRITE)
-foreach(root ${SOC_ROOT})
+foreach(root ${kconfig_soc_root})
   file(${OPERATION} ${KCONFIG_BINARY_DIR}/Kconfig.soc.defconfig
        "osource \"${root}/soc/$(ARCH)/*/Kconfig.defconfig\"\n"
   )
@@ -21,9 +23,11 @@ foreach(root ${SOC_ROOT})
   set(OPERATION APPEND)
 endforeach()
 
-# Support multiple shields in BOARD_ROOT
+# Support multiple shields in BOARD_ROOT, remove ZEPHYR_BASE as that is always sourced.
+set(kconfig_board_root ${BOARD_ROOT})
+list(REMOVE_ITEM kconfig_board_root ${ZEPHYR_BASE})
 set(OPERATION WRITE)
-foreach(root ${BOARD_ROOT})
+foreach(root ${kconfig_board_root})
   file(${OPERATION} ${KCONFIG_BINARY_DIR}/Kconfig.shield.defconfig
        "osource \"${root}/boards/shields/*/Kconfig.defconfig\"\n"
   )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -118,23 +118,6 @@ set(FIX_TEX_SCRIPT ${ZEPHYR_BASE}/doc/_scripts/fix_tex.py)
 # Generated Kconfig .rst documents
 #
 
-file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc.defconfig
-     "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.defconfig\"\n"
-)
-file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc
-     "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig.soc\"\n"
-)
-file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.shield.defconfig
-     "osource \"${ZEPHYR_BASE}/boards/shields/*/Kconfig.defconfig\"\n"
-)
-file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.shield
-     "osource \"${ZEPHYR_BASE}/boards/shields/*/Kconfig.shield\"\n"
-)
-file(WRITE ${KCONFIG_BINARY_DIR}/Kconfig.soc.arch
-     "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/Kconfig\"\n"
-     "osource \"${ZEPHYR_BASE}/soc/$(ARCH)/*/Kconfig\"\n"
-)
-
 foreach(module_name ${ZEPHYR_MODULE_NAMES})
   zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
   list(APPEND

--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -3,13 +3,19 @@
 choice
 	prompt "SoC/CPU/Configuration Selection"
 
-source "$(KCONFIG_BINARY_DIR)/Kconfig.soc"
+# This loads custom SoC root Kconfig (only available if custom SoC root are defined)
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.soc"
+# This loads Zephyr base SoC root Kconfig
+osource "soc/$(ARCH)/*/Kconfig.soc"
 
 endchoice
 
 menu "Hardware Configuration"
-source "$(KCONFIG_BINARY_DIR)/Kconfig.soc.arch"
-
+# This loads custom SoC root Kconfig (only available if custom SoC root are defined)
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.soc.arch"
+# This loads Zephyr base SoC Kconfigs
+osource "soc/$(ARCH)/Kconfig"
+osource "soc/$(ARCH)/*/Kconfig"
 
 module = SOC
 module-str = SOC


### PR DESCRIPTION
Always source the Zephyr base soc and shield (board root) Kconfigs
directly from Kconfig instead of generated Kconfig files.

This has the benefit that it is no longer necessary to generate Kconfig
files to source SoC root and shield (board root) when no custom roots
are provided.

Also this cleans up the doc/CMakeLists.txt and ensures that the
doc/CMakeLists.txt is not getting out of sync with the Kconfig.cmake.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>