### PR TITLE
lib: os: add braces to 'if' statements

### DIFF
--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -114,8 +114,9 @@ static FUNC_NORETURN void p4wq_loop(void *p0, void *p1, void *p2)
 /* Must be called to regain ownership of the work item */
 int k_p4wq_wait(struct k_p4wq_work *work, k_timeout_t timeout)
 {
-	if (work->sync)
+	if (work->sync) {
 		return k_sem_take(&work->done_sem, timeout);
+	}
 
 	return k_sem_count_get(&work->done_sem) ? 0 : -EBUSY;
 }
@@ -148,8 +149,9 @@ static int static_init(const struct device *dev)
 			struct k_p4wq *q = pp->flags & K_P4WQ_QUEUE_PER_THREAD ?
 				pp->queue + i : pp->queue;
 
-			if (!i || (pp->flags & K_P4WQ_QUEUE_PER_THREAD))
+			if (!i || (pp->flags & K_P4WQ_QUEUE_PER_THREAD)) {
 				k_p4wq_init(q);
+			}
 
 			q->flags = pp->flags;
 
@@ -157,15 +159,17 @@ static int static_init(const struct device *dev)
 			 * If the user wants to specify CPU affinity, we have to
 			 * delay starting threads until that has been done
 			 */
-			if (q->flags & K_P4WQ_USER_CPU_MASK)
+			if (q->flags & K_P4WQ_USER_CPU_MASK) {
 				q->flags |= K_P4WQ_DELAYED_START;
+			}
 
 			k_p4wq_add_thread(q, &pp->threads[i],
 					  &pp->stacks[ssz * i],
 					  pp->stack_size);
 
-			if (pp->flags & K_P4WQ_DELAYED_START)
+			if (pp->flags & K_P4WQ_DELAYED_START) {
 				z_mark_thread_as_suspended(&pp->threads[i]);
+			}
 
 #ifdef CONFIG_SCHED_CPU_MASK
 			if (pp->flags & K_P4WQ_USER_CPU_MASK) {


### PR DESCRIPTION
An 'if' (expression) construct shall be followed by a compound statement.
Add braces to improve readability and maintainability.

Found as a coding guideline violation (MISRA R15.6) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>