### PR TITLE
tests: net: socket: Add userspace tests to SO_BINDTODEVICE

### DIFF
--- a/tests/net/socket/misc/testcase.yaml
+++ b/tests/net/socket/misc/testcase.yaml
@@ -1,7 +1,12 @@
 common:
   depends_on: netif
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  min_ram: 21
+  tags: net socket userspace
 tests:
   net.socket.misc:
-    min_ram: 21
-    tags: net socket userspace
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=n
+  net.socket.misc.userspace:
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y


### PR DESCRIPTION
Change the SO_BINDTODEVICE tests so that we test also userspace
mode.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>