### PR TITLE
cmake: drivers: Always add base library directory to include path

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -416,6 +416,7 @@ macro(zephyr_library_named name)
   add_library(${name} STATIC "")
 
   zephyr_append_cmake_library(${name})
+  target_include_directories(${name} PRIVATE .)
 
   target_link_libraries(${name} PUBLIC zephyr_interface)
 endmacro()


### PR DESCRIPTION
This will allow to use private headers from out-of-tree
drivers added to libraries using zephyr_library_amend

It's an alternative of #35770. It might be a bit overkill since not only drivers but also subsystem and arch seems to use `zephyr_library()`