### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: rename private functions 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -83,17 +83,17 @@ static struct proc_ctx *proc_ctx_acquire(void)
 	return ctx;
 }
 
-void ull_cp_priv_proc_ctx_release(struct proc_ctx *ctx)
+void llcp_proc_ctx_release(struct proc_ctx *ctx)
 {
 	mem_release(ctx, &mem_ctx.free);
 }
 
-bool ull_cp_priv_tx_alloc_is_available(void)
+bool llcp_tx_alloc_is_available(void)
 {
 	return mem_tx.free != NULL;
 }
 
-struct node_tx *ull_cp_priv_tx_alloc(void)
+struct node_tx *llcp_tx_alloc(void)
 {
 	struct node_tx *tx;
 
@@ -106,17 +106,17 @@ static void tx_release(struct node_tx *tx)
 	mem_release(tx, &mem_tx.free);
 }
 
-bool ull_cp_priv_ntf_alloc_is_available(void)
+bool llcp_ntf_alloc_is_available(void)
 {
 	return ll_pdu_rx_alloc_peek(1) != NULL;
 }
 
-bool ull_cp_priv_ntf_alloc_num_available(uint8_t count)
+bool llcp_ntf_alloc_num_available(uint8_t count)
 {
 	return ll_pdu_rx_alloc_peek(count) != NULL;
 }
 
-struct node_rx_pdu *ull_cp_priv_ntf_alloc(void)
+struct node_rx_pdu *llcp_ntf_alloc(void)
 {
 	return ll_pdu_rx_alloc();
 }
@@ -125,22 +125,22 @@ struct node_rx_pdu *ull_cp_priv_ntf_alloc(void)
  * ULL -> LLL Interface
  */
 
-void ull_cp_priv_tx_enqueue(struct ll_conn *conn, struct node_tx *tx)
+void llcp_tx_enqueue(struct ll_conn *conn, struct node_tx *tx)
 {
 	ull_tx_q_enqueue_ctrl(&conn->tx_q, tx);
 }
 
-void ull_cp_priv_tx_pause_data(struct ll_conn *conn)
+void llcp_tx_pause_data(struct ll_conn *conn)
 {
 	ull_tx_q_pause_data(&conn->tx_q);
 }
 
-void ull_cp_priv_tx_resume_data(struct ll_conn *conn)
+void llcp_tx_resume_data(struct ll_conn *conn)
 {
 	ull_tx_q_resume_data(&conn->tx_q);
 }
 
-void ull_cp_priv_tx_flush(struct ll_conn *conn)
+void llcp_tx_flush(struct ll_conn *conn)
 {
 	/* TODO(thoh): do something here to flush the TX Q */
 }
@@ -174,7 +174,7 @@ static struct proc_ctx *create_procedure(enum llcp_proc proc)
 	return ctx;
 }
 
-struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc)
+struct proc_ctx *llcp_create_local_procedure(enum llcp_proc proc)
 {
 	struct proc_ctx *ctx;
 
@@ -186,46 +186,46 @@ struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc)
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined (CONFIG_BT_CENTRAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		lp_enc_init_proc(ctx);
+		llcp_lp_enc_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_CENTRAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		lp_pu_init_proc(ctx);
+		llcp_lp_pu_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		lp_cu_init_proc(ctx);
+		llcp_lp_cu_init_proc(ctx);
 		break;
 	case PROC_TERMINATE:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #if defined(CONFIG_BT_CENTRAL)
 	case PROC_CHAN_MAP_UPDATE:
-		lp_chmu_init_proc(ctx);
+		llcp_lp_chmu_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CENTRAL */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		lp_comm_init_proc(ctx);
+		llcp_lp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -237,7 +237,7 @@ struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc)
 	return ctx;
 }
 
-struct proc_ctx *ull_cp_priv_create_remote_procedure(enum llcp_proc proc)
+struct proc_ctx *llcp_create_remote_procedure(enum llcp_proc proc)
 {
 	struct proc_ctx *ctx;
 
@@ -249,46 +249,46 @@ struct proc_ctx *ull_cp_priv_create_remote_procedure(enum llcp_proc proc)
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined (CONFIG_BT_PERIPHERAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		rp_enc_init_proc(ctx);
+		llcp_rp_enc_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_PERIPHERAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		rp_pu_init_proc(ctx);
+		llcp_rp_pu_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		rp_cu_init_proc(ctx);
+		llcp_rp_cu_init_proc(ctx);
 		break;
 	case PROC_TERMINATE:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #if defined(CONFIG_BT_PERIPHERAL)
 	case PROC_CHAN_MAP_UPDATE:
-		rp_chmu_init_proc(ctx);
+		llcp_rp_chmu_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_PERIPHERAL */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		rp_comm_init_proc(ctx);
+		llcp_rp_comm_init_proc(ctx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -313,11 +313,11 @@ void ull_cp_init(void)
 void ll_conn_init(struct ll_conn *conn)
 {
 	/* Reset local request fsm */
-	lr_init(conn);
+	llcp_lr_init(conn);
 	sys_slist_init(&conn->llcp.local.pend_proc_list);
 
 	/* Reset remote request fsm */
-	rr_init(conn);
+	llcp_rr_init(conn);
 	sys_slist_init(&conn->llcp.remote.pend_proc_list);
 	conn->llcp.remote.incompat = INCOMPAT_NO_COLLISION;
 	conn->llcp.remote.collision = 0U;
@@ -341,8 +341,8 @@ void ll_conn_init(struct ll_conn *conn)
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	conn->lll.event_counter = 0;
-	lr_init(conn);
-	rr_init(conn);
+	llcp_lr_init(conn);
+	llcp_rr_init(conn);
 }
 
 void ull_cp_release_tx(struct node_tx *tx)
@@ -358,20 +358,20 @@ void ull_cp_release_ntf(struct node_rx_pdu *ntf)
 
 void ull_cp_run(struct ll_conn *conn)
 {
-	rr_run(conn);
-	lr_run(conn);
+	llcp_rr_run(conn);
+	llcp_lr_run(conn);
 }
 
 void ull_cp_state_set(struct ll_conn *conn, uint8_t state)
 {
 	switch (state) {
 	case ULL_CP_CONNECTED:
-		rr_connect(conn);
-		lr_connect(conn);
+		llcp_rr_connect(conn);
+		llcp_lr_connect(conn);
 		break;
 	case ULL_CP_DISCONNECTED:
-		rr_disconnect(conn);
-		lr_disconnect(conn);
+		llcp_rr_disconnect(conn);
+		llcp_lr_disconnect(conn);
 		break;
 	default:
 		break;
@@ -387,7 +387,7 @@ uint8_t ull_cp_min_used_chans(struct ll_conn *conn, uint8_t phys, uint8_t min_us
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	ctx = create_local_procedure(PROC_MIN_USED_CHANS);
+	ctx = llcp_create_local_procedure(PROC_MIN_USED_CHANS);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -395,7 +395,7 @@ uint8_t ull_cp_min_used_chans(struct ll_conn *conn, uint8_t phys, uint8_t min_us
 	ctx->data.muc.phys = phys;
 	ctx->data.muc.min_used_chans = min_used_chans;
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -406,12 +406,12 @@ uint8_t ull_cp_le_ping(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = create_local_procedure(PROC_LE_PING);
+	ctx = llcp_create_local_procedure(PROC_LE_PING);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -422,12 +422,12 @@ uint8_t ull_cp_feature_exchange(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = create_local_procedure(PROC_FEATURE_EXCHANGE);
+	ctx = llcp_create_local_procedure(PROC_FEATURE_EXCHANGE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -437,12 +437,12 @@ uint8_t ull_cp_version_exchange(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = create_local_procedure(PROC_VERSION_EXCHANGE);
+	ctx = llcp_create_local_procedure(PROC_VERSION_EXCHANGE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -454,7 +454,7 @@ uint8_t ull_cp_encryption_start(struct ll_conn *conn, const uint8_t rand[8], con
 
 	/* TODO(thoh): Proper checks for role, parameters etc. */
 
-	ctx = create_local_procedure(PROC_ENCRYPTION_START);
+	ctx = llcp_create_local_procedure(PROC_ENCRYPTION_START);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -466,7 +466,7 @@ uint8_t ull_cp_encryption_start(struct ll_conn *conn, const uint8_t rand[8], con
 	memcpy(ctx->data.enc.ltk, ltk, sizeof(ctx->data.enc.ltk));
 
 	/* Enqueue request */
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -477,7 +477,7 @@ uint8_t ull_cp_encryption_pause(struct ll_conn *conn, const uint8_t rand[8], con
 
 	/* TODO(thoh): Proper checks for role, parameters etc. */
 
-	ctx = create_local_procedure(PROC_ENCRYPTION_PAUSE);
+	ctx = llcp_create_local_procedure(PROC_ENCRYPTION_PAUSE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -489,7 +489,7 @@ uint8_t ull_cp_encryption_pause(struct ll_conn *conn, const uint8_t rand[8], con
 	memcpy(ctx->data.enc.ltk, ltk, sizeof(ctx->data.enc.ltk));
 
 	/* Enqueue request */
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -499,12 +499,12 @@ uint8_t ull_cp_encryption_paused(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_ENCRYPTION_PAUSE) {
 		return 1;
 	}
 
-	ctx = lr_peek(conn);
+	ctx = llcp_lr_peek(conn);
 	if (ctx && ctx->proc == PROC_ENCRYPTION_PAUSE) {
 		return 1;
 	}
@@ -520,7 +520,7 @@ uint8_t ull_cp_phy_update(struct ll_conn *conn, uint8_t tx, uint8_t flags, uint8
 
 	/* TODO(thoh): Proper checks for role, parameters etc. */
 
-	ctx = create_local_procedure(PROC_PHY_UPDATE);
+	ctx = llcp_create_local_procedure(PROC_PHY_UPDATE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -530,7 +530,7 @@ uint8_t ull_cp_phy_update(struct ll_conn *conn, uint8_t tx, uint8_t flags, uint8
 	ctx->data.pu.rx = rx;
 	ctx->data.pu.host_initiated = host_initiated;
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -540,9 +540,9 @@ uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code)
 {
 	struct proc_ctx *ctx;
 
-	lr_abort(conn);
+	llcp_lr_abort(conn);
 
-	ctx = create_local_procedure(PROC_TERMINATE);
+	ctx = llcp_create_local_procedure(PROC_TERMINATE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -553,7 +553,7 @@ uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code)
 	 * Termination procedure may be initiated at any time, even if other
 	 * LLCP is active.
 	 */
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -567,14 +567,14 @@ uint8_t ull_cp_chan_map_update(struct ll_conn *conn, const uint8_t chm[5])
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	ctx = create_local_procedure(PROC_CHAN_MAP_UPDATE);
+	ctx = llcp_create_local_procedure(PROC_CHAN_MAP_UPDATE);
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	memcpy(ctx->data.chmu.chm, chm, sizeof(ctx->data.chmu.chm));
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -585,9 +585,9 @@ const uint8_t *ull_cp_chan_map_update_pending(struct ll_conn *conn)
 	struct proc_ctx *ctx;
 
 	if (conn->lll.role == BT_HCI_ROLE_MASTER) {
-		ctx = lr_peek(conn);
+		ctx = llcp_lr_peek(conn);
 	} else {
-		ctx = rr_peek(conn);
+		ctx = llcp_rr_peek(conn);
 	}
 
 	if (ctx && ctx->proc == PROC_CHAN_MAP_UPDATE) {
@@ -602,7 +602,7 @@ uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, 
 {
 	struct proc_ctx *ctx;
 
-	ctx = create_local_procedure(PROC_DATA_LENGTH_UPDATE);
+	ctx = llcp_create_local_procedure(PROC_DATA_LENGTH_UPDATE);
 
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
@@ -611,7 +611,7 @@ uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, 
 	/* Apply update to local */
 	ull_dle_local_tx_update(conn, max_tx_octets, max_tx_time);
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -623,10 +623,10 @@ void ull_cp_ltk_req_reply(struct ll_conn *conn, const uint8_t ltk[16])
 	/* TODO(thoh): Call rp_enc to query if LTK request reply is allowed */
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && (ctx->proc == PROC_ENCRYPTION_START || ctx->proc == PROC_ENCRYPTION_PAUSE)) {
 		memcpy(ctx->data.enc.ltk, ltk, sizeof(ctx->data.enc.ltk));
-		rp_enc_ltk_req_reply(conn, ctx);
+		llcp_rp_enc_ltk_req_reply(conn, ctx);
 	}
 }
 
@@ -635,9 +635,9 @@ void ull_cp_ltk_req_neq_reply(struct ll_conn *conn)
 	/* TODO(thoh): Call rp_enc to query if LTK negative request reply is allowed */
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && (ctx->proc == PROC_ENCRYPTION_START || ctx->proc == PROC_ENCRYPTION_PAUSE)) {
-		rp_enc_ltk_req_neg_reply(conn, ctx);
+		llcp_rp_enc_ltk_req_neg_reply(conn, ctx);
 	}
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -648,9 +648,9 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	if (feature_conn_param_req(conn)) {
-		ctx = create_local_procedure(PROC_CONN_PARAM_REQ);
+		ctx = llcp_create_local_procedure(PROC_CONN_PARAM_REQ);
 	} else if (conn->lll.role == BT_HCI_ROLE_MASTER) {
-		ctx = create_local_procedure(PROC_CONN_UPDATE);
+		ctx = llcp_create_local_procedure(PROC_CONN_UPDATE);
 	} else {
 		return BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
 	}
@@ -658,7 +658,7 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 	if (conn->lll.role == BT_HCI_ROLE_SLAVE) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
-	ctx = create_local_procedure(PROC_CONN_UPDATE);
+	ctx = llcp_create_local_procedure(PROC_CONN_UPDATE);
 #endif /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 	if (!ctx) {
@@ -691,7 +691,7 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 	/* TODO(tosk): Check what to handle (ADV_SCHED) from this legacy fct. */
 	/* event_conn_upd_prep() (event_conn_upd_init()) */
 
-	lr_enqueue(conn, ctx);
+	llcp_lr_enqueue(conn, ctx);
 
 	return BT_HCI_ERR_SUCCESS;
 }
@@ -701,7 +701,7 @@ uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 
 	return (ctx && ctx->proc == PROC_DATA_LENGTH_UPDATE);
 }
@@ -711,9 +711,9 @@ void ull_cp_conn_param_req_reply(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_CONN_PARAM_REQ) {
-		rp_conn_param_req_reply(conn, ctx);
+		llcp_rp_conn_param_req_reply(conn, ctx);
 	}
 }
 
@@ -721,10 +721,10 @@ void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn, uint8_t error_code)
 {
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_CONN_PARAM_REQ) {
 		ctx->data.cu.error = error_code;
-		rp_conn_param_req_neg_reply(conn, ctx);
+		llcp_rp_conn_param_req_neg_reply(conn, ctx);
 	}
 }
 
@@ -753,16 +753,16 @@ void ull_cp_tx_ack(struct ll_conn *conn, struct node_tx *tx)
 {
 	struct proc_ctx *ctx;
 
-	ctx = lr_peek(conn);
+	ctx = llcp_lr_peek(conn);
 	if (ctx && ctx->tx_ack == tx) {
 		/* TX ack re. local request */
-		lr_tx_ack(conn, ctx, tx);
+		llcp_lr_tx_ack(conn, ctx, tx);
 	}
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->tx_ack == tx) {
 		/* TX ack re. remote response */
-		rr_tx_ack(conn, ctx, tx);
+		llcp_rr_tx_ack(conn, ctx, tx);
 	}
 }
 
@@ -777,23 +777,23 @@ void ull_cp_rx(struct ll_conn *conn, struct node_rx_pdu *rx)
 		/* Process non LL_TERMINATE_IND PDU's as responses to active
 		 * procedures */
 
-		ctx = lr_peek(conn);
+		ctx = llcp_lr_peek(conn);
 		if (ctx && (pdu_is_expected(pdu, ctx) || pdu_is_unknown(pdu, ctx) || pdu_is_reject(pdu, ctx))) {
 			/* Response on local procedure */
-			lr_rx(conn, ctx, rx);
+			llcp_lr_rx(conn, ctx, rx);
 			return;
 		}
 
-		ctx = rr_peek(conn);
+		ctx = llcp_rr_peek(conn);
 		if (ctx && (pdu_is_expected(pdu, ctx) || pdu_is_unknown(pdu, ctx) || pdu_is_reject(pdu, ctx))) {
 			/* Response on remote procedure */
-			rr_rx(conn, ctx, rx);
+			llcp_rr_rx(conn, ctx, rx);
 			return;
 		}
 	}
 
 	/* New remote request */
-	rr_new(conn, rx);
+	llcp_rr_new(conn, rx);
 }
 
 #ifdef ZTEST_UNITTEST
@@ -833,7 +833,7 @@ void test_int_mem_proc_ctx(void)
 	/* The last acquire should fail */
 	zassert_is_null(ctx2, NULL);
 
-	proc_ctx_release(ctx1);
+	llcp_proc_ctx_release(ctx1);
 	nr_of_free_ctx = ctx_buffers_free();
 	zassert_equal(nr_of_free_ctx, 1, NULL);
 
@@ -852,23 +852,23 @@ void test_int_mem_tx(void)
 	ull_cp_init();
 
 	for (int i = 0U; i < TX_CTRL_BUF_NUM; i++) {
-		peek = tx_alloc_is_available();
+		peek = llcp_tx_alloc_is_available();
 
 		/* The previous tx alloc peek should be valid */
 		zassert_true(peek, NULL);
 
-		txl[i] = tx_alloc();
+		txl[i] = llcp_tx_alloc();
 
 		/* The previous alloc should be valid */
 		zassert_not_null(txl[i], NULL);
 	}
 
-	peek = tx_alloc_is_available();
+	peek = llcp_tx_alloc_is_available();
 
 	/* The last tx alloc peek should fail */
 	zassert_false(peek, NULL);
 
-	tx = tx_alloc();
+	tx = llcp_tx_alloc();
 
 	/* The last tx alloc should fail */
 	zassert_is_null(tx, NULL);
@@ -879,23 +879,23 @@ void test_int_mem_tx(void)
 	}
 
 	for (int i = 0U; i < TX_CTRL_BUF_NUM; i++) {
-		peek = tx_alloc_is_available();
+		peek = llcp_tx_alloc_is_available();
 
 		/* The previous tx alloc peek should be valid */
 		zassert_true(peek, NULL);
 
-		txl[i] = tx_alloc();
+		txl[i] = llcp_tx_alloc();
 
 		/* The previous alloc should be valid */
 		zassert_not_null(txl[i], NULL);
 	}
 
-	peek = tx_alloc_is_available();
+	peek = llcp_tx_alloc_is_available();
 
 	/* The last tx alloc peek should fail */
 	zassert_false(peek, NULL);
 
-	tx = tx_alloc();
+	tx = llcp_tx_alloc();
 
 	/* The last tx alloc should fail */
 	zassert_is_null(tx, NULL);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -273,941 +273,262 @@ static inline bool is_instant_reached_or_passed(uint16_t instant, uint16_t event
 /*
  * LLCP Resource Management
  */
-bool ull_cp_priv_tx_alloc_is_available(void);
-
-static inline bool tx_alloc_is_available(void)
-{
-	return ull_cp_priv_tx_alloc_is_available();
-}
-
-struct node_tx *ull_cp_priv_tx_alloc(void);
-
-static inline struct node_tx *tx_alloc(void)
-{
-	return ull_cp_priv_tx_alloc();
-}
-
-bool ull_cp_priv_ntf_alloc_is_available(void);
-
-static inline bool ntf_alloc_is_available(void)
-{
-	return ull_cp_priv_ntf_alloc_is_available();
-}
-
-bool ull_cp_priv_ntf_alloc_num_available(uint8_t count);
-
-static inline bool ntf_alloc_num_available(uint8_t count)
-{
-	return ull_cp_priv_ntf_alloc_num_available(count);
-}
-
-struct node_rx_pdu *ull_cp_priv_ntf_alloc(void);
-
-static inline struct node_rx_pdu *ntf_alloc(void)
-{
-	return ull_cp_priv_ntf_alloc();
-}
-
-struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc);
-
-static inline struct proc_ctx *create_local_procedure(enum llcp_proc proc)
-{
-	return ull_cp_priv_create_local_procedure(proc);
-}
-
-struct proc_ctx *ull_cp_priv_create_remote_procedure(enum llcp_proc proc);
-
-static inline struct proc_ctx *create_remote_procedure(enum llcp_proc proc)
-{
-	return ull_cp_priv_create_remote_procedure(proc);
-}
-
+bool llcp_tx_alloc_is_available(void);
+struct node_tx *llcp_tx_alloc(void);
+bool llcp_ntf_alloc_is_available(void);
+bool llcp_ntf_alloc_num_available(uint8_t count);
+struct node_rx_pdu *llcp_ntf_alloc(void);
+struct proc_ctx *llcp_create_local_procedure(enum llcp_proc proc);
+struct proc_ctx *llcp_create_remote_procedure(enum llcp_proc proc);
 
 /*
  * ULL -> LLL Interface
  */
-void ull_cp_priv_tx_enqueue(struct ll_conn *conn, struct node_tx *tx);
-
-static inline void tx_enqueue(struct ll_conn *conn, struct node_tx *tx)
-{
-	return ull_cp_priv_tx_enqueue(conn, tx);
-}
-
-void ull_cp_priv_tx_pause_data(struct ll_conn *conn);
-
-static inline void tx_pause_data(struct ll_conn *conn)
-{
-	return ull_cp_priv_tx_pause_data(conn);
-}
-
-void ull_cp_priv_tx_resume_data(struct ll_conn *conn);
-
-static inline void tx_resume_data(struct ll_conn *conn)
-{
-	return ull_cp_priv_tx_resume_data(conn);
-}
-
-void ull_cp_priv_tx_flush(struct ll_conn *conn);
-
-static inline void tx_flush(struct ll_conn *conn)
-{
-	return ull_cp_priv_tx_flush(conn);
-}
-
+void llcp_tx_enqueue(struct ll_conn *conn, struct node_tx *tx);
+void llcp_tx_pause_data(struct ll_conn *conn);
+void llcp_tx_resume_data(struct ll_conn *conn);
+void llcp_tx_flush(struct ll_conn *conn);
 
 /*
  * LLCP Local Procedure Common
  */
-void ull_cp_priv_lp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
-
-static inline void lp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
-{
-	return ull_cp_priv_lp_comm_tx_ack(conn, ctx, tx);
-}
-
-void ull_cp_priv_lp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void lp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_lp_comm_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_lp_comm_init_proc(struct proc_ctx *ctx);
-
-static inline void lp_comm_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lp_comm_init_proc(ctx);
-}
-
-void ull_cp_priv_lp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_comm_run(conn, ctx, param);
-}
+void llcp_lp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
+void llcp_lp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_lp_comm_init_proc(struct proc_ctx *ctx);
+void llcp_lp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 /*
  * LLCP Remote Procedure Common
  */
-void ull_cp_priv_rp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
-
-static inline void rp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
-{
-	return ull_cp_priv_rp_comm_tx_ack(conn, ctx, tx);
-}
-
-void ull_cp_priv_rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rp_comm_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rp_comm_init_proc(struct proc_ctx *ctx);
-
-static inline void rp_comm_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_comm_init_proc(ctx);
-}
-
-void ull_cp_priv_rp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_comm_run(conn, ctx, param);
-}
-
+void llcp_rp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
+void llcp_rp_comm_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rp_comm_init_proc(struct proc_ctx *ctx);
+void llcp_rp_comm_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 #if defined (CONFIG_BT_CTLR_LE_ENC)
 /*
  * LLCP Local Procedure Encryption
  */
-void ull_cp_priv_lp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void lp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_lp_enc_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_lp_enc_init_proc(struct proc_ctx *ctx);
-
-static inline void lp_enc_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lp_enc_init_proc(ctx);
-}
-
-void ull_cp_priv_lp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_enc_run(conn, ctx, param);
-}
-
+void llcp_lp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_lp_enc_init_proc(struct proc_ctx *ctx);
+void llcp_lp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 /*
  * LLCP Remote Procedure Encryption
  */
-void ull_cp_priv_rp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rp_enc_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rp_enc_init_proc(struct proc_ctx *ctx);
-
-static inline void rp_enc_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_enc_init_proc(ctx);
-}
-
-void ull_cp_priv_rp_enc_ltk_req_reply(struct ll_conn *conn, struct proc_ctx *ctx);
-
-static inline void rp_enc_ltk_req_reply(struct ll_conn *conn, struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_enc_ltk_req_reply(conn, ctx);
-}
-
-void ull_cp_priv_rp_enc_ltk_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx);
-
-static inline void rp_enc_ltk_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_enc_ltk_req_neg_reply(conn, ctx);
-}
-
-void ull_cp_priv_rp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_enc_run(conn, ctx, param);
-}
-
+void llcp_rp_enc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rp_enc_init_proc(struct proc_ctx *ctx);
+void llcp_rp_enc_ltk_req_reply(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_rp_enc_ltk_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_rp_enc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_PHY)
 /*
  * LLCP Local Procedure PHY Update
  */
-void ull_cp_priv_lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_lp_pu_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_lp_pu_init_proc(struct proc_ctx *ctx);
-
-static inline void lp_pu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lp_pu_init_proc(ctx);
-}
-
-void ull_cp_priv_lp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_pu_run(conn, ctx, param);
-}
-
-void ull_cp_priv_lp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_pu_tx_ack(conn, ctx, param);
-}
+void llcp_lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_lp_pu_init_proc(struct proc_ctx *ctx);
+void llcp_lp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+void llcp_lp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 #endif /* CONFIG_BT_CTLR_PHY */
 
 /*
  * LLCP Local Procedure Connection Update
  */
-void ull_cp_priv_lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_lp_cu_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_lp_cu_init_proc(struct proc_ctx *ctx);
-
-static inline void lp_cu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lp_cu_init_proc(ctx);
-}
-
-void ull_cp_priv_lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_cu_run(conn, ctx, param);
-}
+void llcp_lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_lp_cu_init_proc(struct proc_ctx *ctx);
+void llcp_lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 /*
  * LLCP Local Channel Map Update
  */
-void ull_cp_priv_lp_chmu_init_proc(struct proc_ctx *ctx);
-
-static inline void lp_chmu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lp_chmu_init_proc(ctx);
-}
-
-void ull_cp_priv_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_lp_chmu_run(conn, ctx, param);
-}
+void llcp_lp_chmu_init_proc(struct proc_ctx *ctx);
+void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 /*
  * LLCP Remote Procedure PHY Update
  */
-void ull_cp_priv_rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rp_pu_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rp_pu_init_proc(struct proc_ctx *ctx);
-
-static inline void rp_pu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_pu_init_proc(ctx);
-}
-
-void ull_cp_priv_rp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_pu_run(conn, ctx, param);
-}
-
-void ull_cp_priv_rp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_pu_tx_ack(conn, ctx, param);
-}
+void llcp_rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rp_pu_init_proc(struct proc_ctx *ctx);
+void llcp_rp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+void llcp_rp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 #endif /* CONFIG_BT_CTLR_PHY */
 
 /*
  * LLCP Remote Procedure Connection Update
  */
-void ull_cp_priv_rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rp_cu_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rp_cu_init_proc(struct proc_ctx *ctx);
-
-static inline void rp_cu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_cu_init_proc(ctx);
-}
-
-void ull_cp_priv_rp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_cu_run(conn, ctx, param);
-}
-
-void ull_cp_priv_rp_conn_param_req_reply(struct ll_conn *conn, struct proc_ctx *ctx);
-
-static inline void rp_conn_param_req_reply(struct ll_conn *conn, struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_conn_param_req_reply(conn, ctx);
-}
-
-void ull_cp_priv_rp_conn_param_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx);
-
-static inline void rp_conn_param_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_conn_param_req_neg_reply(conn, ctx);
-}
+void llcp_rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rp_cu_init_proc(struct proc_ctx *ctx);
+void llcp_rp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+void llcp_rp_conn_param_req_reply(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_rp_conn_param_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx);
 
 /*
  * Terminate Helper
  */
-void ull_cp_priv_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_terminate_ind(ctx, pdu);
-}
-
-void ull_cp_priv_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_terminate_ind(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_terminate_ind(ctx, pdu);
-}
+void llcp_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 
 /*
  * LLCP Local Request
  */
-struct proc_ctx *lr_peek(struct ll_conn *conn);
-void ull_cp_priv_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
-
-static inline void lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
-{
-	return ull_cp_priv_lr_tx_ack(conn, ctx, tx);
-}
-
-void ull_cp_priv_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_lr_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx);
-
-static inline void lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx)
-{
-	return ull_cp_priv_lr_enqueue(conn, ctx);
-}
-
-void ull_cp_priv_lr_init(struct ll_conn *conn);
-
-static inline void lr_init(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_init(conn);
-}
-
-void ull_cp_priv_lr_run(struct ll_conn *conn);
-
-static inline void lr_run(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_run(conn);
-}
-
-void ull_cp_priv_lr_complete(struct ll_conn *conn);
-
-static inline void lr_complete(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_complete(conn);
-}
-
-void ull_cp_priv_lr_connect(struct ll_conn *conn);
-
-static inline void lr_connect(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_connect(conn);
-}
-
-void ull_cp_priv_lr_disconnect(struct ll_conn *conn);
-
-static inline void lr_disconnect(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_disconnect(conn);
-}
-
-void ull_cp_priv_lr_abort(struct ll_conn *conn);
-
-static inline void lr_abort(struct ll_conn *conn)
-{
-	return ull_cp_priv_lr_abort(conn);
-}
+struct proc_ctx *llcp_lr_peek(struct ll_conn *conn);
+void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
+void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_lr_init(struct ll_conn *conn);
+void llcp_lr_run(struct ll_conn *conn);
+void llcp_lr_complete(struct ll_conn *conn);
+void llcp_lr_connect(struct ll_conn *conn);
+void llcp_lr_disconnect(struct ll_conn *conn);
+void llcp_lr_abort(struct ll_conn *conn);
 
 /*
  * LLCP Remote Request
  */
-void ull_cp_priv_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat);
-
-static inline void rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat)
-{
-	return ull_cp_priv_rr_set_incompat(conn, incompat);
-}
-
-bool ull_cp_priv_rr_get_collision(struct ll_conn *conn);
-
-static inline bool rr_get_collision(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_get_collision(conn);
-}
-
-struct proc_ctx *rr_peek(struct ll_conn *conn);
-void ull_cp_priv_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
-
-static inline void rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
-{
-	return ull_cp_priv_rr_tx_ack(conn, ctx, tx);
-}
-
-void ull_cp_priv_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rr_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rr_init(struct ll_conn *conn);
-
-static inline void rr_init(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_init(conn);
-}
-
-void ull_cp_priv_rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx);
-
-static inline void rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rr_prepare(conn, rx);
-}
-
-void ull_cp_priv_rr_run(struct ll_conn *conn);
-
-static inline void rr_run(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_run(conn);
-}
-
-void ull_cp_priv_rr_complete(struct ll_conn *conn);
-
-static inline void rr_complete(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_complete(conn);
-}
-
-void ull_cp_priv_rr_connect(struct ll_conn *conn);
-
-static inline void rr_connect(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_connect(conn);
-}
-
-void ull_cp_priv_rr_disconnect(struct ll_conn *conn);
-
-static inline void rr_disconnect(struct ll_conn *conn)
-{
-	return ull_cp_priv_rr_disconnect(conn);
-}
-
-void ull_cp_priv_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx);
-
-static inline void rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rr_new(conn, rx);
-}
+void llcp_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat);
+bool llcp_rr_get_collision(struct ll_conn *conn);
+struct proc_ctx *llcp_rr_peek(struct ll_conn *conn);
+void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);
+void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rr_init(struct ll_conn *conn);
+void llcp_rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx);
+void llcp_rr_run(struct ll_conn *conn);
+void llcp_rr_complete(struct ll_conn *conn);
+void llcp_rr_connect(struct ll_conn *conn);
+void llcp_rr_disconnect(struct ll_conn *conn);
+void llcp_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx);
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 /*
  * LE Ping Procedure Helper
  */
-void ull_cp_priv_pdu_encode_ping_req(struct pdu_data *pdu);
-
-static inline void pdu_encode_ping_req(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_ping_req(pdu);
-}
-
-void ull_cp_priv_pdu_encode_ping_rsp(struct pdu_data *pdu);
-
-static inline void pdu_encode_ping_rsp(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_ping_rsp(pdu);
-}
+void llcp_pdu_encode_ping_req(struct pdu_data *pdu);
+void llcp_pdu_encode_ping_rsp(struct pdu_data *pdu);
 #endif /* CONFIG_BT_CTLR_LE_PING */
 /*
  * Unknown response helper
  */
 
-void ull_cp_priv_pdu_encode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_pdu_encode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu);
-static inline void pdu_encode_unknown_rsp(struct proc_ctx *ctx,
-					   struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_encode_unknown_rsp(ctx, pdu);
-}
-
-
-void ull_cp_priv_pdu_decode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_pdu_decode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu);
-static inline void pdu_decode_unknown_rsp(struct proc_ctx *ctx,
-					   struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_unknown_rsp(ctx, pdu);
-}
-
-void ull_cp_priv_ntf_encode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_ntf_encode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu);
-
-static inline void ntf_encode_unknown_rsp(struct proc_ctx *ctx,
-					  struct pdu_data *pdu)
-
-{
-	return ull_cp_priv_ntf_encode_unknown_rsp(ctx, pdu);
-}
-
 
 /*
  * Feature Exchange Procedure Helper
  */
-void ull_cp_priv_pdu_encode_feature_req(struct ll_conn *conn,
+void llcp_pdu_encode_feature_req(struct ll_conn *conn,
 					struct pdu_data *pdu);
-
-static inline void pdu_encode_feature_req(struct ll_conn *conn,
-					   struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_feature_req(conn, pdu);
-}
-
-void ull_cp_priv_pdu_encode_feature_rsp(struct ll_conn *conn,
+void llcp_pdu_encode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu);
-
-static inline void pdu_encode_feature_rsp(struct ll_conn *conn,
-					struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_feature_rsp(conn, pdu);
-}
-
-void ull_cp_priv_ntf_encode_feature_rsp(struct ll_conn *conn,
+void llcp_ntf_encode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu);
-
-static inline void ntf_encode_feature_rsp(struct ll_conn *conn,
-				    struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_feature_rsp(conn, pdu);
-}
-
-void ull_cp_priv_ntf_encode_feature_req(struct ll_conn *conn,
+void llcp_ntf_encode_feature_req(struct ll_conn *conn,
 					      struct pdu_data *pdu);
-
-static inline void ntf_encode_feature_req(struct ll_conn *conn,
-					  struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_feature_req(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_feature_req(struct ll_conn *conn,
+void llcp_pdu_decode_feature_req(struct ll_conn *conn,
 					struct pdu_data *pdu);
-
-static inline void pdu_decode_feature_req(struct ll_conn *conn,
-					  struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_feature_req(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_feature_rsp(struct ll_conn *conn,
+void llcp_pdu_decode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu);
-
-static inline void pdu_decode_feature_rsp(struct ll_conn *conn,
-					  struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_feature_rsp(conn, pdu);
-}
 
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 /*
  * Minimum number of used channels Procedure Helper
  */
 #if defined (CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_min_used_chans_ind(ctx, pdu);
-}
+void llcp_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_PERIPHERAL */
-#if defined (CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu);
 
-static inline void pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_min_used_chans_ind(conn, pdu);
-}
+#if defined (CONFIG_BT_CENTRAL)
+void llcp_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 
 /*
  * Version Exchange Procedure Helper
  */
-void ull_cp_priv_pdu_encode_version_ind(struct pdu_data *pdu);
-
-static inline void pdu_encode_version_ind(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_version_ind(pdu);
-}
-
-void ull_cp_priv_ntf_encode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void ntf_encode_version_ind(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_version_ind(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_version_ind(conn, pdu);
-}
-
+void llcp_pdu_encode_version_ind(struct pdu_data *pdu);
+void llcp_ntf_encode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu);
 
 #if defined (CONFIG_BT_CTLR_LE_ENC)
 /*
  * Encryption Start Procedure Helper
  */
 #if defined (CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_enc_req(ctx, pdu);
-}
+void llcp_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined (CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_enc_req(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_encode_enc_rsp(struct pdu_data *pdu);
-
-static inline void pdu_encode_enc_rsp(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_enc_rsp(pdu);
-}
-
-void ull_cp_priv_pdu_encode_start_enc_req(struct pdu_data *pdu);
-
-static inline void pdu_encode_start_enc_req(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_start_enc_req(pdu);
-}
+void llcp_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu);
+void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu);
 #endif /* CONFIG_BT_PERIPHERAL */
 
-void ull_cp_priv_pdu_encode_start_enc_rsp(struct pdu_data *pdu);
-
-static inline void pdu_encode_start_enc_rsp(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_start_enc_rsp(pdu);
-}
+void llcp_pdu_encode_start_enc_rsp(struct pdu_data *pdu);
 
 #if defined (CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_pause_enc_req(struct pdu_data *pdu);
-
-static inline void pdu_encode_pause_enc_req(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_pause_enc_req(pdu);
-}
+void llcp_pdu_encode_pause_enc_req(struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 
-void ull_cp_priv_pdu_encode_pause_enc_rsp(struct pdu_data *pdu);
-
-static inline void pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_pause_enc_rsp(pdu);
-}
+void llcp_pdu_encode_pause_enc_rsp(struct pdu_data *pdu);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code);
-
-static inline void pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
-{
-	return ull_cp_priv_pdu_encode_reject_ind(pdu, error_code);
-}
-
-void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code);
-
-static inline void pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
-{
-	return ull_cp_priv_pdu_encode_reject_ext_ind(pdu, reject_opcode, error_code);
-}
-
+void llcp_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code);
+void llcp_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code);
 
 /*
  * PHY Update Procedure Helper
  */
-void ull_cp_priv_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_phy_req(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_phy_req(ctx, pdu);
-}
+void llcp_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 
 #if defined(CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_phy_rsp(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_phy_update_ind(ctx, pdu);
-}
+void llcp_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_phy_update_ind(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_phy_rsp(ctx, pdu);
-}
+void llcp_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
 #endif /* CONFIG_BT_CENTRAL */
 
 /*
  * Connection Update Procedure Helper
  */
-void ull_cp_priv_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_encode_conn_param_req(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_decode_conn_param_req(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_encode_conn_param_rsp(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_decode_conn_param_rsp(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_encode_conn_update_ind(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-
-static inline void pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	ull_cp_priv_pdu_decode_conn_update_ind(ctx, pdu);
-}
-
-void ull_cp_priv_proc_ctx_release(struct proc_ctx *ctx);
-
-static inline void proc_ctx_release(struct proc_ctx *ctx)
-{
-	ull_cp_priv_proc_ctx_release(ctx);
-}
+void llcp_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_proc_ctx_release(struct proc_ctx *ctx);
 
 /*
  * Remote Channel Map Update Procedure Helper
  */
-
-void ull_cp_priv_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-static inline void pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_chan_map_update_ind(ctx, pdu);
-}
-
-void ull_cp_priv_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
-static inline void pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_chan_map_update_ind(ctx, pdu);
-}
-
-void ull_cp_priv_rp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
-
-static inline void rp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
-{
-	return ull_cp_priv_rp_chmu_rx(conn, ctx, rx);
-}
-
-void ull_cp_priv_rp_chmu_init_proc(struct proc_ctx *ctx);
-
-static inline void rp_chmu_init_proc(struct proc_ctx *ctx)
-{
-	return ull_cp_priv_rp_chmu_init_proc(ctx);
-}
-
-void ull_cp_priv_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
-
-static inline void rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
-{
-	return ull_cp_priv_rp_chmu_run(conn, ctx, param);
-}
+void llcp_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_rp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
+void llcp_rp_chmu_init_proc(struct proc_ctx *ctx);
+void llcp_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /*
  * Data Length Update Procedure Helper
  */
-void ull_cp_priv_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_length_req(conn, pdu);
-}
-
-void ull_cp_priv_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_encode_length_rsp(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_length_req(conn, pdu);
-}
-
-void ull_cp_priv_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
-
-static inline void pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
-{
-	return ull_cp_priv_pdu_decode_length_rsp(conn, pdu);
-}
-
-void ull_cp_priv_ntf_encode_length_change(struct ll_conn *conn,
+void llcp_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_ntf_encode_length_change(struct ll_conn *conn,
 					struct pdu_data *pdu);
 
-static inline void ntf_encode_length_change(struct ll_conn *conn,
-				    struct pdu_data *pdu)
-{
-	return ull_cp_priv_ntf_encode_length_change(conn, pdu);
-}
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #ifdef ZTEST_UNITTEST

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -68,7 +68,7 @@ static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 	if (ctx->done) {
 		struct proc_ctx *ctx_header;
 
-		ctx_header = lr_peek(conn);
+		ctx_header = llcp_lr_peek(conn);
 		LL_ASSERT(ctx_header == ctx);
 
 		lr_dequeue(conn);
@@ -77,7 +77,7 @@ static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 			ull_conn_prt_clear(conn);
 		}
 
-		ull_cp_priv_proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 	}
 }
 /*
@@ -89,7 +89,7 @@ static void lr_set_state(struct ll_conn *conn, enum lr_state state)
 	conn->llcp.local.state = state;
 }
 
-void ull_cp_priv_lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx)
+void llcp_lr_enqueue(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	sys_slist_append(&conn->llcp.local.pend_proc_list, &ctx->node);
 }
@@ -102,7 +102,7 @@ static struct proc_ctx *lr_dequeue(struct ll_conn *conn)
 	return ctx;
 }
 
-struct proc_ctx *lr_peek(struct ll_conn *conn)
+struct proc_ctx *llcp_lr_peek(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -110,46 +110,46 @@ struct proc_ctx *lr_peek(struct ll_conn *conn)
 	return ctx;
 }
 
-void ull_cp_priv_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
+void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		lp_enc_rx(conn, ctx, rx);
+		llcp_lp_enc_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_CENTRAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		lp_pu_rx(conn, ctx, rx);
+		llcp_lp_pu_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		lp_cu_rx(conn, ctx, rx);
+		llcp_lp_cu_rx(conn, ctx, rx);
 		break;
 	case PROC_TERMINATE:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		lp_comm_rx(conn, ctx, rx);
+		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -161,25 +161,25 @@ void ull_cp_priv_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_r
 	lr_check_done(conn, ctx);
 }
 
-void ull_cp_priv_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
+void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
 {
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		lp_comm_tx_ack(conn, ctx, tx);
+		llcp_lp_comm_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_TERMINATE:
-		lp_comm_tx_ack(conn, ctx, tx);
+		llcp_lp_comm_tx_ack(conn, ctx, tx);
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		lp_comm_tx_ack(conn, ctx, tx);
+		llcp_lp_comm_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		lp_pu_tx_ack(conn, ctx, tx);
+		llcp_lp_pu_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	default:
@@ -193,49 +193,49 @@ static void lr_act_run(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = lr_peek(conn);
+	ctx = llcp_lr_peek(conn);
 
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		lp_enc_run(conn, ctx, NULL);
+		llcp_lp_enc_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_CENTRAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		lp_pu_run(conn, ctx, NULL);
+		llcp_lp_pu_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		lp_cu_run(conn, ctx, NULL);
+		llcp_lp_cu_run(conn, ctx, NULL);
 		break;
 	case PROC_TERMINATE:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 	case PROC_CHAN_MAP_UPDATE:
-		lp_chmu_run(conn, ctx, NULL);
+		llcp_lp_chmu_run(conn, ctx, NULL);
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		lp_comm_run(conn, ctx, NULL);
+		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -251,7 +251,7 @@ static void lr_act_complete(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = lr_peek(conn);
+	ctx = llcp_lr_peek(conn);
 
 	ctx->done = 1U;
 }
@@ -273,7 +273,7 @@ static void lr_act_disconnect(struct ll_conn *conn)
 	 * which case we need to release context
 	 */
 	while (ctx != NULL) {
-		proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 		ctx = lr_dequeue(conn);
 	}
 }
@@ -297,7 +297,7 @@ static void lr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 
 	switch (evt) {
 	case LR_EVT_RUN:
-		if ((ctx = lr_peek(conn))) {
+		if ((ctx = llcp_lr_peek(conn))) {
 			lr_act_run(conn);
 			if (ctx->proc != PROC_TERMINATE) {
 				lr_set_state(conn, LR_STATE_ACTIVE);
@@ -320,7 +320,7 @@ static void lr_st_active(struct ll_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LR_EVT_RUN:
-		if (lr_peek(conn)) {
+		if (llcp_lr_peek(conn)) {
 			lr_act_run(conn);
 		}
 		break;
@@ -342,7 +342,7 @@ static void lr_st_terminate(struct ll_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LR_EVT_RUN:
-		if (lr_peek(conn)) {
+		if (llcp_lr_peek(conn)) {
 			lr_act_run(conn);
 		}
 		break;
@@ -381,45 +381,45 @@ static void lr_execute_fsm(struct ll_conn *conn, uint8_t evt, void *param)
 	}
 }
 
-void ull_cp_priv_lr_init(struct ll_conn *conn)
+void llcp_lr_init(struct ll_conn *conn)
 {
 	lr_set_state(conn, LR_STATE_DISCONNECT);
 }
 
-void ull_cp_priv_lr_run(struct ll_conn *conn)
+void llcp_lr_run(struct ll_conn *conn)
 {
 	lr_execute_fsm(conn, LR_EVT_RUN, NULL);
 }
 
-void ull_cp_priv_lr_complete(struct ll_conn *conn)
+void llcp_lr_complete(struct ll_conn *conn)
 {
 	lr_execute_fsm(conn, LR_EVT_COMPLETE, NULL);
 }
 
-void ull_cp_priv_lr_connect(struct ll_conn *conn)
+void llcp_lr_connect(struct ll_conn *conn)
 {
 	lr_execute_fsm(conn, LR_EVT_CONNECT, NULL);
 }
 
-void ull_cp_priv_lr_disconnect(struct ll_conn *conn)
+void llcp_lr_disconnect(struct ll_conn *conn)
 {
 	lr_execute_fsm(conn, LR_EVT_DISCONNECT, NULL);
 }
 
-void ull_cp_priv_lr_abort(struct ll_conn *conn)
+void llcp_lr_abort(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
 	/* Flush all pending procedures */
 	ctx = lr_dequeue(conn);
 	while (ctx) {
-		proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 		ctx = lr_dequeue(conn);
 	}
 
 	/* TODO(thoh): Whats missing here ??? */
 	ull_conn_prt_clear(conn);
-	rr_set_incompat(conn, 0U);
+	llcp_rr_set_incompat(conn, 0U);
 	lr_set_state(conn, LR_STATE_IDLE);
 }
 
@@ -446,23 +446,23 @@ void test_int_local_pending_requests(void)
 	ull_tx_q_init(&conn.tx_q);
 	ll_conn_init(&conn);
 
-	peek_ctx = lr_peek(&conn);
+	peek_ctx = llcp_lr_peek(&conn);
 	zassert_is_null(peek_ctx, NULL);
 
 	dequeue_ctx = lr_dequeue(&conn);
 	zassert_is_null(dequeue_ctx, NULL);
 
-	lr_enqueue(&conn, &ctx);
+	llcp_lr_enqueue(&conn, &ctx);
 	peek_ctx = (struct proc_ctx *) sys_slist_peek_head(&conn.llcp.local.pend_proc_list);
 	zassert_equal_ptr(peek_ctx, &ctx, NULL);
 
-	peek_ctx = lr_peek(&conn);
+	peek_ctx = llcp_lr_peek(&conn);
 	zassert_equal_ptr(peek_ctx, &ctx, NULL);
 
 	dequeue_ctx = lr_dequeue(&conn);
 	zassert_equal_ptr(dequeue_ctx, &ctx, NULL);
 
-	peek_ctx = lr_peek(&conn);
+	peek_ctx = llcp_lr_peek(&conn);
 	zassert_is_null(peek_ctx, NULL);
 
 	dequeue_ctx = lr_dequeue(&conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -48,14 +48,14 @@
  * LE Ping Procedure Helpers
  */
 
-void ull_cp_priv_pdu_encode_ping_req(struct pdu_data *pdu)
+void llcp_pdu_encode_ping_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, ping_req) + sizeof(struct pdu_data_llctrl_ping_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PING_REQ;
 }
 
-void ull_cp_priv_pdu_encode_ping_rsp(struct pdu_data *pdu)
+void llcp_pdu_encode_ping_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, ping_rsp) + sizeof(struct pdu_data_llctrl_ping_rsp);
@@ -66,7 +66,7 @@ void ull_cp_priv_pdu_encode_ping_rsp(struct pdu_data *pdu)
  * Unknown response helper
  */
 
-void ull_cp_priv_pdu_encode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_pdu_encode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
@@ -76,13 +76,13 @@ void ull_cp_priv_pdu_encode_unknown_rsp(struct proc_ctx *ctx,
 	pdu->llctrl.unknown_rsp.type = ctx->unknown_response.type;
 }
 
-void ull_cp_priv_pdu_decode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_pdu_decode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu)
 {
 	ctx->unknown_response.type = pdu->llctrl.unknown_rsp.type;
 }
 
-void ull_cp_priv_ntf_encode_unknown_rsp(struct proc_ctx *ctx,
+void llcp_ntf_encode_unknown_rsp(struct proc_ctx *ctx,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_unknown_rsp *p;
@@ -114,7 +114,7 @@ static void feature_filter(uint8_t *featuresin, uint64_t *featuresout)
 	*featuresout = feat;
 }
 
-void ull_cp_priv_pdu_encode_feature_req(struct ll_conn *conn,
+void llcp_pdu_encode_feature_req(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_feature_req *p;
@@ -134,7 +134,7 @@ void ull_cp_priv_pdu_encode_feature_req(struct ll_conn *conn,
 	sys_put_le64(LL_FEAT, p->features);
 }
 
-void ull_cp_priv_pdu_encode_feature_rsp(struct ll_conn *conn,
+void llcp_pdu_encode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_feature_rsp *p;
@@ -156,7 +156,7 @@ void ull_cp_priv_pdu_encode_feature_rsp(struct ll_conn *conn,
 	sys_put_le64(feature_rsp, p->features);
 }
 
-void ull_cp_priv_ntf_encode_feature_rsp(struct ll_conn *conn,
+void llcp_ntf_encode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_feature_rsp *p;
@@ -170,7 +170,7 @@ void ull_cp_priv_ntf_encode_feature_rsp(struct ll_conn *conn,
 	sys_put_le64(conn->llcp.fex.features_peer, p->features);
 }
 
-void ull_cp_priv_pdu_decode_feature_req(struct ll_conn *conn,
+void llcp_pdu_decode_feature_req(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	uint64_t featureset;
@@ -184,7 +184,7 @@ void ull_cp_priv_pdu_decode_feature_req(struct ll_conn *conn,
 	conn->llcp.fex.valid = 1;
 }
 
-void ull_cp_priv_pdu_decode_feature_rsp(struct ll_conn *conn,
+void llcp_pdu_decode_feature_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	uint64_t featureset;
@@ -201,7 +201,7 @@ void ull_cp_priv_pdu_decode_feature_rsp(struct ll_conn *conn,
  * Minimum used channels Procedure Helpers
  */
 #if defined (CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_min_used_chans_ind *p;
 
@@ -215,7 +215,7 @@ void ull_cp_priv_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_
 #endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined (CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu)
+void llcp_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	conn->llcp.muc.phys = pdu->llctrl.min_used_chans_ind.phys;
 	conn->llcp.muc.min_used_chans = pdu->llctrl.min_used_chans_ind.min_used_chans;
@@ -226,7 +226,7 @@ void ull_cp_priv_pdu_decode_min_used_chans_ind(struct ll_conn *conn, struct pdu_
 /*
  * Termination Procedure Helper
  */
-void ull_cp_priv_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_terminate_ind *p;
 
@@ -237,7 +237,7 @@ void ull_cp_priv_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data 
 	p->error_code = ctx->data.term.error_code;
 }
 
-void ull_cp_priv_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_terminate_ind *p;
 
@@ -248,7 +248,7 @@ void ull_cp_priv_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data 
 	p->error_code = ctx->data.term.error_code;
 }
 
-void ull_cp_priv_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ctx->data.term.error_code = pdu->llctrl.terminate_ind.error_code;
 }
@@ -256,7 +256,7 @@ void ull_cp_priv_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data 
 /*
  * Version Exchange Procedure Helper
  */
-void ull_cp_priv_pdu_encode_version_ind(struct pdu_data *pdu)
+void llcp_pdu_encode_version_ind(struct pdu_data *pdu)
 {
 	uint16_t cid;
 	uint16_t svn;
@@ -276,7 +276,7 @@ void ull_cp_priv_pdu_encode_version_ind(struct pdu_data *pdu)
 	p->sub_version_number = svn;
 }
 
-void ull_cp_priv_ntf_encode_version_ind(struct ll_conn *conn,
+void llcp_ntf_encode_version_ind(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_version_ind *p;
@@ -292,7 +292,7 @@ void ull_cp_priv_ntf_encode_version_ind(struct ll_conn *conn,
 	p->sub_version_number = sys_cpu_to_le16(conn->llcp.vex.cached.sub_version_number);
 }
 
-void ull_cp_priv_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu)
+void llcp_pdu_decode_version_ind(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	conn->llcp.vex.valid = 1;
 	conn->llcp.vex.cached.version_number = pdu->llctrl.version_ind.version_number;
@@ -315,7 +315,7 @@ static int csrand_get(void *buf, size_t len)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_enc_req *p;
 
@@ -334,7 +334,7 @@ void ull_cp_priv_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined (CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_enc_req *p;
 
@@ -348,7 +348,7 @@ void ull_cp_priv_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	p->ediv[1] = ctx->data.enc.ediv[1];
 }
 
-void ull_cp_priv_pdu_encode_enc_rsp(struct pdu_data *pdu)
+void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_enc_rsp *p;
 
@@ -362,7 +362,7 @@ void ull_cp_priv_pdu_encode_enc_rsp(struct pdu_data *pdu)
 	csrand_get(p->ivs, sizeof(p->ivs));
 }
 
-void ull_cp_priv_pdu_encode_start_enc_req(struct pdu_data *pdu)
+void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, start_enc_req) + sizeof(struct pdu_data_llctrl_start_enc_req);
@@ -370,7 +370,7 @@ void ull_cp_priv_pdu_encode_start_enc_req(struct pdu_data *pdu)
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
-void ull_cp_priv_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
+void llcp_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, start_enc_rsp) + sizeof(struct pdu_data_llctrl_start_enc_rsp);
@@ -378,7 +378,7 @@ void ull_cp_priv_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 }
 
 #if defined (CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_pause_enc_req(struct pdu_data *pdu)
+void llcp_pdu_encode_pause_enc_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, pause_enc_req) + sizeof(struct pdu_data_llctrl_pause_enc_req);
@@ -386,7 +386,7 @@ void ull_cp_priv_pdu_encode_pause_enc_req(struct pdu_data *pdu)
 }
 #endif /* CONFIG_BT_CENTRAL */
 
-void ull_cp_priv_pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
+void llcp_pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, pause_enc_rsp) + sizeof(struct pdu_data_llctrl_pause_enc_rsp);
@@ -394,7 +394,7 @@ void ull_cp_priv_pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
+void llcp_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, reject_ind) + sizeof(struct pdu_data_llctrl_reject_ind);
@@ -402,7 +402,7 @@ void ull_cp_priv_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 	pdu->llctrl.reject_ind.error_code = error_code;
 }
 
-void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
+void llcp_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, reject_ext_ind) + sizeof(struct pdu_data_llctrl_reject_ext_ind);
@@ -416,7 +416,7 @@ void ull_cp_priv_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_
  * PHY Update Procedure Helper
  */
 
-void ull_cp_priv_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, phy_req) + sizeof(struct pdu_data_llctrl_phy_req);
@@ -425,14 +425,14 @@ void ull_cp_priv_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	pdu->llctrl.phy_req.tx_phys = ctx->data.pu.tx;
 }
 
-void ull_cp_priv_pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ctx->data.pu.rx = pdu->llctrl.phy_req.tx_phys;
 	ctx->data.pu.tx = pdu->llctrl.phy_req.rx_phys;
 }
 
 #if defined(CONFIG_BT_PERIPHERAL)
-void ull_cp_priv_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu)
+void llcp_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, phy_rsp) + sizeof(struct pdu_data_llctrl_phy_rsp);
@@ -440,7 +440,7 @@ void ull_cp_priv_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 	pdu->llctrl.phy_rsp.rx_phys = conn->phy_pref_rx;
 	pdu->llctrl.phy_rsp.tx_phys = conn->phy_pref_tx;
 }
-void ull_cp_priv_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ctx->data.pu.instant = sys_le16_to_cpu(pdu->llctrl.phy_upd_ind.instant);
 	ctx->data.pu.m_to_s_phy = pdu->llctrl.phy_upd_ind.m_to_s_phy;
@@ -449,7 +449,7 @@ void ull_cp_priv_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data
 #endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CENTRAL)
-void ull_cp_priv_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
 	pdu->len = offsetof(struct pdu_data_llctrl, phy_upd_ind) + sizeof(struct pdu_data_llctrl_phy_upd_ind);
@@ -458,7 +458,7 @@ void ull_cp_priv_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data
 	pdu->llctrl.phy_upd_ind.m_to_s_phy = ctx->data.pu.m_to_s_phy;
 	pdu->llctrl.phy_upd_ind.s_to_m_phy = ctx->data.pu.s_to_m_phy;
 }
-void ull_cp_priv_pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ctx->data.pu.rx = pdu->llctrl.phy_rsp.tx_phys;
 	ctx->data.pu.tx = pdu->llctrl.phy_rsp.rx_phys;
@@ -469,7 +469,7 @@ void ull_cp_priv_pdu_decode_phy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 /*
  * Connection Update Procedure Helper
  */
-void ull_cp_priv_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_param_req *p;
 
@@ -493,7 +493,7 @@ void ull_cp_priv_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data
 	p->offset5 = sys_cpu_to_le16(ctx->data.cu.offset5);
 }
 
-void ull_cp_priv_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_param_req *p;
 
@@ -517,7 +517,7 @@ void ull_cp_priv_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data
 	p->offset5 = sys_cpu_to_le16(ctx->data.cu.offset5);
 }
 
-void ull_cp_priv_pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_param_req *p;
 
@@ -537,7 +537,7 @@ void ull_cp_priv_pdu_decode_conn_param_req(struct proc_ctx *ctx, struct pdu_data
 	ctx->data.cu.offset5 = sys_le16_to_cpu(p->offset5);
 }
 
-void ull_cp_priv_pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_param_rsp *p;
 
@@ -557,7 +557,7 @@ void ull_cp_priv_pdu_decode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data
 	ctx->data.cu.offset5 = sys_le16_to_cpu(p->offset5);
 }
 
-void ull_cp_priv_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_update_ind *p;
 
@@ -574,7 +574,7 @@ void ull_cp_priv_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_dat
 	p->instant = sys_cpu_to_le16(ctx->data.cu.instant);
 }
 
-void ull_cp_priv_pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_conn_update_ind *p;
 
@@ -590,7 +590,7 @@ void ull_cp_priv_pdu_decode_conn_update_ind(struct proc_ctx *ctx, struct pdu_dat
 /*
  * Channel Map Update Procedure Helpers
  */
-void ull_cp_priv_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_chan_map_ind *p;
 
@@ -602,7 +602,7 @@ void ull_cp_priv_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu
 	memcpy(p->chm, ctx->data.chmu.chm, sizeof(p->chm));
 }
 
-void ull_cp_priv_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+void llcp_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ctx->data.chmu.instant = sys_le16_to_cpu(pdu->llctrl.chan_map_ind.instant);
 	memcpy(ctx->data.chmu.chm, pdu->llctrl.chan_map_ind.chm, sizeof(ctx->data.chmu.chm));
@@ -612,7 +612,7 @@ void ull_cp_priv_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu
 /*
  * Data Length Update Procedure Helpers
 */
-void ull_cp_priv_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
+void llcp_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
 
@@ -626,7 +626,7 @@ void ull_cp_priv_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pd
 	p->max_tx_time = sys_cpu_to_le16(conn->lll.dle.local.max_tx_time);
 }
 
-void ull_cp_priv_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
+void llcp_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
 
@@ -640,7 +640,7 @@ void ull_cp_priv_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pd
 	p->max_tx_time = sys_cpu_to_le16(conn->lll.dle.local.max_tx_time);
 }
 
-void ull_cp_priv_ntf_encode_length_change(struct ll_conn *conn,
+void llcp_ntf_encode_length_change(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
@@ -655,7 +655,7 @@ void ull_cp_priv_ntf_encode_length_change(struct ll_conn *conn,
 	p->max_tx_time   = sys_cpu_to_le16(conn->lll.dle.eff.max_tx_time);
 }
 
-void ull_cp_priv_pdu_decode_length_req(struct ll_conn *conn,
+void llcp_pdu_decode_length_req(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
@@ -665,7 +665,7 @@ void ull_cp_priv_pdu_decode_length_req(struct ll_conn *conn,
 	conn->lll.dle.remote.max_tx_time = sys_le16_to_cpu(p->max_tx_time);
 }
 
-void ull_cp_priv_pdu_decode_length_rsp(struct ll_conn *conn,
+void llcp_pdu_decode_length_rsp(struct ll_conn *conn,
 					struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -116,11 +116,11 @@ static void rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 	if (ctx->done) {
 		struct proc_ctx *ctx_header;
 
-		ctx_header = rr_peek(conn);
+		ctx_header = llcp_rr_peek(conn);
 		LL_ASSERT(ctx_header == ctx);
 
 		rr_dequeue(conn);
-		ull_cp_priv_proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 	}
 }
 /*
@@ -132,7 +132,7 @@ static void rr_set_state(struct ll_conn *conn, enum rr_state state)
 	conn->llcp.remote.state = state;
 }
 
-void ull_cp_priv_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat)
+void llcp_rr_set_incompat(struct ll_conn *conn, enum proc_incompat incompat)
 {
 	conn->llcp.remote.incompat = incompat;
 }
@@ -147,7 +147,7 @@ static void rr_set_collision(struct ll_conn *conn, bool collision)
 	conn->llcp.remote.collision = collision;
 }
 
-bool ull_cp_priv_rr_get_collision(struct ll_conn *conn)
+bool llcp_rr_get_collision(struct ll_conn *conn)
 {
 	return conn->llcp.remote.collision;
 }
@@ -165,7 +165,7 @@ static struct proc_ctx *rr_dequeue(struct ll_conn *conn)
 	return ctx;
 }
 
-struct proc_ctx *rr_peek(struct ll_conn *conn)
+struct proc_ctx *llcp_rr_peek(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
@@ -173,49 +173,49 @@ struct proc_ctx *rr_peek(struct ll_conn *conn)
 	return ctx;
 }
 
-void ull_cp_priv_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
+void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #if defined (CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined (CONFIG_BT_PERIPHERAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		rp_enc_rx(conn, ctx, rx);
+		llcp_rp_enc_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_PERIPHERAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		rp_pu_rx(conn, ctx, rx);
+		llcp_rp_pu_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		rp_cu_rx(conn, ctx, rx);
+		llcp_rp_cu_rx(conn, ctx, rx);
 		break;
 	case PROC_TERMINATE:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 	case PROC_CHAN_MAP_UPDATE:
-		rp_chmu_rx(conn, ctx,rx);
+		llcp_rp_chmu_rx(conn, ctx,rx);
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		rp_comm_rx(conn, ctx, rx);
+		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -226,17 +226,17 @@ void ull_cp_priv_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_r
 	rr_check_done(conn, ctx);
 }
 
-void ull_cp_priv_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
+void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
 {
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		rp_comm_tx_ack(conn, ctx, tx);
+		llcp_rp_comm_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		rp_pu_tx_ack(conn, ctx, tx);
+		llcp_rp_pu_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	default:
@@ -251,49 +251,49 @@ static void rr_act_run(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
 
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #if defined (CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PROC_MIN_USED_CHANS:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN */
 	case PROC_VERSION_EXCHANGE:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #if defined (CONFIG_BT_CTLR_LE_ENC) && defined (CONFIG_BT_PERIPHERAL)
 	case PROC_ENCRYPTION_START:
 	case PROC_ENCRYPTION_PAUSE:
-		rp_enc_run(conn, ctx, NULL);
+		llcp_rp_enc_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_PERIPHERAL */
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
-		rp_pu_run(conn, ctx, NULL);
+		llcp_rp_pu_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_PHY */
 	case PROC_CONN_UPDATE:
 	case PROC_CONN_PARAM_REQ:
-		rp_cu_run(conn, ctx, NULL);
+		llcp_rp_cu_run(conn, ctx, NULL);
 		break;
 	case PROC_TERMINATE:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 	case PROC_CHAN_MAP_UPDATE:
-		rp_chmu_run(conn, ctx, NULL);
+		llcp_rp_chmu_run(conn, ctx, NULL);
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		rp_comm_run(conn, ctx, NULL);
+		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
@@ -311,7 +311,7 @@ static void rr_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 	struct pdu_data *pdu;
 
 	/* Allocate tx node */
-	tx = tx_alloc();
+	tx = llcp_tx_alloc();
 	LL_ASSERT(tx);
 
 	pdu = (struct pdu_data *)tx->pdu;
@@ -320,7 +320,7 @@ static void rr_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 	switch (opcode) {
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* TODO(thoh): Select between LL_REJECT_IND and LL_REJECT_EXT_IND */
-		pdu_encode_reject_ext_ind(pdu, conn->llcp.remote.reject_opcode, BT_HCI_ERR_LL_PROC_COLLISION);
+		llcp_pdu_encode_reject_ext_ind(pdu, conn->llcp.remote.reject_opcode, BT_HCI_ERR_LL_PROC_COLLISION);
 		break;
 	default:
 		LL_ASSERT(0);
@@ -329,15 +329,15 @@ static void rr_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 	ctx->tx_opcode = pdu->llctrl.opcode;
 
 	/* Enqueue LL Control PDU towards LLL */
-	tx_enqueue(conn, tx);
+	llcp_tx_enqueue(conn, tx);
 }
 
 static void rr_act_reject(struct ll_conn *conn)
 {
-	if (!tx_alloc_is_available()) {
+	if (!llcp_tx_alloc_is_available()) {
 		rr_set_state(conn, RR_STATE_REJECT);
 	} else {
-		struct proc_ctx *ctx = rr_peek(conn);
+		struct proc_ctx *ctx = llcp_rr_peek(conn);
 
 		LL_ASSERT(ctx != NULL);
 		rr_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_REJECT_IND);
@@ -354,7 +354,7 @@ static void rr_act_complete(struct ll_conn *conn)
 	rr_set_collision(conn, 0U);
 
 	/* Dequeue pending request that just completed */
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	LL_ASSERT(ctx != NULL);
 
 	ctx->done = 1U;
@@ -377,7 +377,7 @@ static void rr_act_disconnect(struct ll_conn *conn)
 	 * case we need to release all contexts
 	 */
 	while (ctx != NULL) {
-		proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 		ctx = rr_dequeue(conn);
 	}
 }
@@ -401,7 +401,7 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 
 	switch (evt) {
 	case RR_EVT_PREPARE:
-		ctx = rr_peek(conn);
+		ctx = llcp_rr_peek(conn);
 		if (ctx) {
 			const enum proc_incompat incompat = rr_get_incompat(conn);
 			const bool slave = !!(conn->lll.role == BT_HCI_ROLE_SLAVE);
@@ -479,7 +479,7 @@ static void rr_st_active(struct ll_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RR_EVT_RUN:
-		if (rr_peek(conn)) {
+		if (llcp_rr_peek(conn)) {
 			rr_act_run(conn);
 		}
 		break;
@@ -501,7 +501,7 @@ static void rr_st_terminate(struct ll_conn *conn, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case RR_EVT_RUN:
-		if (rr_peek(conn)) {
+		if (llcp_rr_peek(conn)) {
 			rr_act_run(conn);
 		}
 		break;
@@ -543,37 +543,37 @@ static void rr_execute_fsm(struct ll_conn *conn, uint8_t evt, void *param)
 	}
 }
 
-void ull_cp_priv_rr_init(struct ll_conn *conn)
+void llcp_rr_init(struct ll_conn *conn)
 {
 	rr_set_state(conn, RR_STATE_DISCONNECT);
 }
 
-void ull_cp_priv_rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx)
+void llcp_rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx)
 {
 	rr_execute_fsm(conn, RR_EVT_PREPARE, rx);
 }
 
-void ull_cp_priv_rr_run(struct ll_conn *conn)
+void llcp_rr_run(struct ll_conn *conn)
 {
 	rr_execute_fsm(conn, RR_EVT_RUN, NULL);
 }
 
-void ull_cp_priv_rr_complete(struct ll_conn *conn)
+void llcp_rr_complete(struct ll_conn *conn)
 {
 	rr_execute_fsm(conn, RR_EVT_COMPLETE, NULL);
 }
 
-void ull_cp_priv_rr_connect(struct ll_conn *conn)
+void llcp_rr_connect(struct ll_conn *conn)
 {
 	rr_execute_fsm(conn, RR_EVT_CONNECT, NULL);
 }
 
-void ull_cp_priv_rr_disconnect(struct ll_conn *conn)
+void llcp_rr_disconnect(struct ll_conn *conn)
 {
 	rr_execute_fsm(conn, RR_EVT_DISCONNECT, NULL);
 }
 
-void ull_cp_priv_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
+void llcp_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
 {
 	struct proc_ctx *ctx;
 	struct pdu_data *pdu;
@@ -629,7 +629,7 @@ void ull_cp_priv_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
 		rr_abort(conn);
 	}
 
-	ctx = create_remote_procedure(proc);
+	ctx = llcp_create_remote_procedure(proc);
 	if (!ctx) {
 		return;
 	}
@@ -638,12 +638,12 @@ void ull_cp_priv_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx)
 	rr_enqueue(conn, ctx);
 
 	/* Prepare procedure */
-	rr_prepare(conn, rx);
+	llcp_rr_prepare(conn, rx);
 
 	/* Handle PDU */
-	ctx = rr_peek(conn);
+	ctx = llcp_rr_peek(conn);
 	if (ctx) {
-		rr_rx(conn, ctx, rx);
+		llcp_rr_rx(conn, ctx, rx);
 	}
 }
 
@@ -654,7 +654,7 @@ static void rr_abort(struct ll_conn *conn)
 	/* Flush all pending procedures */
 	ctx = rr_dequeue(conn);
 	while (ctx) {
-		proc_ctx_release(ctx);
+		llcp_proc_ctx_release(ctx);
 		ctx = rr_dequeue(conn);
 	}
 
@@ -686,7 +686,7 @@ void test_int_remote_pending_requests(void)
 	ull_tx_q_init(&conn.tx_q);
 	ll_conn_init(&conn);
 
-	peek_ctx = rr_peek(&conn);
+	peek_ctx = llcp_rr_peek(&conn);
 	zassert_is_null(peek_ctx, NULL);
 
 	dequeue_ctx = rr_dequeue(&conn);
@@ -696,13 +696,13 @@ void test_int_remote_pending_requests(void)
 	peek_ctx = (struct proc_ctx *) sys_slist_peek_head(&conn.llcp.remote.pend_proc_list);
 	zassert_equal_ptr(peek_ctx, &ctx, NULL);
 
-	peek_ctx = rr_peek(&conn);
+	peek_ctx = llcp_rr_peek(&conn);
 	zassert_equal_ptr(peek_ctx, &ctx, NULL);
 
 	dequeue_ctx = rr_dequeue(&conn);
 	zassert_equal_ptr(dequeue_ctx, &ctx, NULL);
 
-	peek_ctx = rr_peek(&conn);
+	peek_ctx = llcp_rr_peek(&conn);
 	zassert_is_null(peek_ctx, NULL);
 
 	dequeue_ctx = rr_dequeue(&conn);

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -497,8 +497,8 @@ void test_data_length_update_sla_rem_and_loc(void)
 	ull_dle_init(&conn, PHY_1M);
 
 	/* Steal all tx buffers, so as to hold back length_rsp */
-	while (ull_cp_priv_tx_alloc_is_available()) {
-		tx = ull_cp_priv_tx_alloc();
+	while (llcp_tx_alloc_is_available()) {
+		tx = llcp_tx_alloc();
 	}
 
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -372,7 +372,7 @@ void test_encryption_start_mas_loc_limited_memory(void)
 
 	/* Steal all tx buffers */
 	for (int i = 0U; i < TX_CTRL_BUF_NUM; i++) {
-		tx = tx_alloc();
+		tx = llcp_tx_alloc();
 		zassert_not_null(tx, NULL);
 	}
 
@@ -1042,7 +1042,7 @@ void test_encryption_start_sla_rem_limited_memory(void)
 
 	/* Steal all tx buffers */
 	for (int i = 0U; i < TX_CTRL_BUF_NUM; i++) {
-		tx = tx_alloc();
+		tx = llcp_tx_alloc();
 		zassert_not_null(tx, NULL);
 	}
 

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
@@ -157,7 +157,7 @@ void test_hci_feature_exchange_wrong_handle(void)
 
 	ctx_counter = 0;
 	do {
-		ctx = create_local_procedure(PROC_FEATURE_EXCHANGE);
+		ctx = llcp_create_local_procedure(PROC_FEATURE_EXCHANGE);
 		ctx_counter++;
 	} while (ctx != NULL);
 	zassert_equal(ctx_counter, PROC_CTX_BUF_NUM + 1,

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -141,7 +141,7 @@ void test_hci_feature_exchange_wrong_handle(void)
 
 	ctx_counter = 0;
 	do {
-		ctx = create_local_procedure(PROC_FEATURE_EXCHANGE);
+		ctx = llcp_create_local_procedure(PROC_FEATURE_EXCHANGE);
 		ctx_counter++;
 	} while (ctx != NULL);
 	zassert_equal(ctx_counter, PROC_CTX_BUF_NUM + 1,
@@ -211,7 +211,7 @@ void test_hci_version_ind_wrong_handle(void)
 
 	ctx_counter = 0;
 	do {
-		ctx = create_local_procedure(PROC_VERSION_EXCHANGE);
+		ctx = llcp_create_local_procedure(PROC_VERSION_EXCHANGE);
 		ctx_counter++;
 	} while (ctx != NULL);
 	zassert_equal(ctx_counter, PROC_CTX_BUF_NUM + 1,


### PR DESCRIPTION
Renamed the functions in ull_llcp_internal, renaming the ull_cp_priv into llcp prefix

Update 2 july 2021: for verification I ran the unit tests for bt_ull_llcp and compiled the shell sample from tests/bluetooth/shell

Signed off by: Andries Kruithof (andries.kruithof@nordicsemi.no)