### PR TITLE
doc: colibri board: Add missing empty lines

### DIFF
--- a/boards/arm/colibri_imx7d_m4/doc/index.rst
+++ b/boards/arm/colibri_imx7d_m4/doc/index.rst
@@ -231,6 +231,7 @@ To run Zephyr Binary using J-Link create the following script in order to
 get the Program Counter and Stack Pointer from zephyr.bin.
 
 get-pc-sp.sh:
+
 .. code-block:: console
 
    #!/bin/sh
@@ -245,6 +246,7 @@ get-pc-sp.sh:
 
 
 Get the SP and PC from firmware binary: ``./get-pc-sp.sh zephyr.bin``
+
 .. code-block:: console
 
    pc=00900f01


### PR DESCRIPTION
Two code-blocks were not correctly rendered, due to missing empty lines before them. This commit fixes this.

See https://docs.zephyrproject.org/latest/boards/arm/colibri_imx7d_m4/doc/index.html#debugging for the issue

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>