### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: Make data length update procedure code Kconfig'able

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_connections.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_connections.c
@@ -386,9 +386,7 @@ void ull_dle_init(struct ll_conn *conn, uint8_t phy)
 		conn->lll.dle.update = 1;
 	}
 }
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
-#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 void ull_conn_default_tx_octets_set(uint16_t tx_octets)
 {
        default_tx_octets = tx_octets;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -213,9 +213,11 @@ struct proc_ctx *ull_cp_priv_create_local_procedure(enum llcp_proc proc)
 	case PROC_CHAN_MAP_UPDATE:
 		lp_chmu_init_proc(ctx);
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		lp_comm_init_proc(ctx);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -261,9 +263,11 @@ struct proc_ctx *ull_cp_priv_create_remote_procedure(enum llcp_proc proc)
 	case PROC_TERMINATE:
 		rp_comm_init_proc(ctx);
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		rp_comm_init_proc(ctx);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -554,6 +558,7 @@ uint8_t ull_cp_chan_map_update(struct ll_conn *conn, uint8_t chm[5])
 	return BT_HCI_ERR_SUCCESS;
 }
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, uint16_t max_tx_time)
 {
 	struct proc_ctx *ctx;
@@ -571,6 +576,7 @@ uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, 
 
 	return BT_HCI_ERR_SUCCESS;
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 void ull_cp_ltk_req_reply(struct ll_conn *conn, const uint8_t ltk[16])
 {
@@ -618,7 +624,7 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 	return BT_HCI_ERR_SUCCESS;
 }
 
-
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;
@@ -627,6 +633,7 @@ uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn)
 
 	return (ctx && ctx->proc == PROC_DATA_LENGTH_UPDATE);
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 void ull_cp_conn_param_req_reply(struct ll_conn *conn)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -131,8 +131,10 @@ uint8_t ull_cp_terminate(struct ll_conn *conn, uint8_t error_code);
  */
 uint8_t ull_cp_chan_map_update(struct ll_conn *conn, uint8_t chm[5]);
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /**
  * @brief Initiate a Data Length Update Procedure.
  */
 uint8_t ull_cp_data_length_update(struct ll_conn *conn, uint16_t max_tx_octets, uint16_t max_tx_time);
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -131,10 +131,12 @@ static void lp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 		ctx->tx_ack = tx;
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		pdu_encode_length_req(conn, pdu);
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -180,10 +182,12 @@ static void lp_comm_ntf_version_ind(struct ll_conn *conn,  struct proc_ctx *ctx,
 	}
 }
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 static void lp_comm_ntf_length_change(struct ll_conn *conn, struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ntf_encode_length_change(conn, pdu);
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 static void lp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 {
@@ -204,9 +208,11 @@ static void lp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	case PROC_VERSION_EXCHANGE:
 		lp_comm_ntf_version_ind(conn, ctx, pdu);
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		lp_comm_ntf_length_change(conn, ctx, pdu);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		LL_ASSERT(0);
 		break;
@@ -261,6 +267,7 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		/* Mark the connection for termination */
 		conn->terminate.reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		if (ctx->response_opcode != PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP) {
 			/* Apply changes in data lengths/times */
@@ -291,6 +298,7 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 			tx_resume_data(conn);
 		}
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -348,6 +356,7 @@ static void lp_comm_send_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 			ctx->state = LP_COMMON_STATE_WAIT_TX_ACK;
 		}
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		if (!ull_cp_remote_dle_pending(conn)) {
 			if (ctx->pause || !tx_alloc_is_available()) {
@@ -371,6 +380,7 @@ static void lp_comm_send_req(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		}
 
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -458,9 +468,11 @@ static void lp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 		/* No response expected */
 		LL_ASSERT(0);
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_RSP:
 		pdu_decode_length_rsp(conn, pdu);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown opcode */
 		LL_ASSERT(0);
@@ -486,6 +498,7 @@ static void lp_comm_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint
 	switch (evt) {
 	case LP_COMMON_EVT_RUN:
 		switch (ctx->proc) {
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		case PROC_DATA_LENGTH_UPDATE:
 			if (ntf_alloc_is_available()) {
 				lp_comm_ntf(conn, ctx);
@@ -493,6 +506,7 @@ static void lp_comm_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint
 				ctx->state = LP_COMMON_STATE_IDLE;
 			}
 			break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 		default:
 			break;
 		}
@@ -570,6 +584,7 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 	case PDU_DATA_LLCTRL_TYPE_TERMINATE_IND:
 		pdu_decode_terminate_ind(ctx, pdu);
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_REQ:
 		pdu_decode_length_req(conn, pdu);
 		/* On reception of REQ mark RSP open for local piggy-back
@@ -579,6 +594,7 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 		 */
 		tx_pause_data(conn);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown opcode */
 		LL_ASSERT(0);
@@ -610,11 +626,13 @@ static void rp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 		pdu_encode_version_ind(pdu);
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_VERSION_IND;
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		pdu_encode_length_rsp(conn, pdu);
 		ctx->tx_ack = tx;
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -637,7 +655,7 @@ static void rp_comm_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t 
 		break;
 	}
 }
-
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 static void rp_comm_ntf_length_change(struct ll_conn *conn, struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	ntf_encode_length_change(conn, pdu);
@@ -648,6 +666,7 @@ static void rp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
 
+	ARG_UNUSED(pdu);
 	/* Allocate ntf node */
 	ntf = ntf_alloc();
 	LL_ASSERT(ntf);
@@ -656,9 +675,12 @@ static void rp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	ntf->hdr.handle = conn->lll.handle;
 	pdu = (struct pdu_data *) ntf->pdu;
 	switch (ctx->proc) {
+/* Note: the 'double' ifdef in case this switch case expands in the future and the function is re-instated */
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		rp_comm_ntf_length_change(conn, ctx, pdu);
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		LL_ASSERT(0);
 		break;
@@ -668,6 +690,7 @@ static void rp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	ll_rx_put(ntf->hdr.link, ntf);
 	ll_rx_sched();
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
@@ -738,6 +761,7 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		/* Mark the connection for termination */
 		conn->terminate.reason = ctx->data.term.error_code;
 		break;
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		if (ctx->pause || !tx_alloc_is_available()) {
 			ctx->state = RP_COMMON_STATE_WAIT_TX;
@@ -749,6 +773,7 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 			ctx->state = RP_COMMON_STATE_WAIT_TX_ACK;
 		}
 		break;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -785,6 +810,7 @@ static void rp_comm_st_wait_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, u
 	switch (evt) {
 	case RP_COMMON_EVT_ACK:
 		switch (ctx->proc) {
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		case PROC_DATA_LENGTH_UPDATE:
 			{
 				/* Apply changes in data lengths/times */
@@ -803,6 +829,7 @@ static void rp_comm_st_wait_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, u
 				}
 				break;
 			}
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 		default:
 			/* Ignore other procedures */
 			break;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
@@ -57,7 +57,7 @@ static inline bool feature_le_ping(struct ll_conn *conn)
 
 static inline bool feature_dle(struct ll_conn *conn)
 {
-#if defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX)
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	return conn->llcp.fex.features_used & LL_FEAT_BIT_DLE;
 #else
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -1094,6 +1094,8 @@ static inline void rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void 
 {
 	return ull_cp_priv_rp_chmu_run(conn, ctx, param);
 }
+
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /*
  * Data Length Update Procedure Helper
  */
@@ -1133,6 +1135,7 @@ static inline void ntf_encode_length_change(struct ll_conn *conn,
 {
 	return ull_cp_priv_ntf_encode_length_change(conn, pdu);
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 #ifdef ZTEST_UNITTEST
 bool lr_is_disconnected(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -492,6 +492,7 @@ void ull_cp_priv_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu
 	memcpy(ctx->data.chmu.chm, pdu->llctrl.chan_map_ind.chm, sizeof(ctx->data.chmu.chm));
 }
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /*
  * Data Length Update Procedure Helpers
 */
@@ -557,3 +558,5 @@ void ull_cp_priv_pdu_decode_length_rsp(struct ll_conn *conn,
 	conn->lll.dle.remote.max_rx_time = sys_le16_to_cpu(p->max_rx_time);
 	conn->lll.dle.remote.max_tx_time = sys_le16_to_cpu(p->max_tx_time);
 }
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -18,40 +18,7 @@ BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}
 
-function compile(){
-  local app_root="${app_root:-${ZEPHYR_BASE}}"
-  local conf_file="${conf_file:-prj.conf}"
-  local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y \
-    -DCONFIG_DEBUG_OPTIMIZATIONS=y \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"}"
-  local ninja_args="${ninja_args:-""}"
-
-  local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
-  local exe_name=${exe_name//\//_}
-  local exe_name=${exe_name//./_}
-  local exe_name=${BSIM_OUT_PATH}/bin/$exe_name
-  local map_file_name=${exe_name}.Tsymbols
-
-  local this_dir=${WORK_DIR}/${app}/${conf_file}
-
-  echo "Building $exe_name"
-
-  # Set INCR_BUILD when calling to only do an incremental build
-  if [ ! -v INCR_BUILD ] || [ ! -d "${this_dir}" ]; then
-      [ -d "${this_dir}" ] && rm ${this_dir} -rf
-      mkdir -p ${this_dir} && cd ${this_dir}
-      cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${conf_file} ${cmake_args} ${app_root}/${app} \
-            &> cmake.out || { cat cmake.out && return 0; }
-  else
-      cd ${this_dir}
-  fi
-  ninja ${ninja_args} &> ninja.out || { cat ninja.out && return 0; }
-  cp ${this_dir}/zephyr/zephyr.exe ${exe_name}
-
-  nm ${exe_name} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${map_file_name}
-  sed -i "1i $(wc -l ${map_file_name} | cut -d" " -f1)" ${map_file_name}
-}
+source tests/bluetooth/bsim_bt/compile.source
 
 app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split.conf \
 	compile

--- a/tests/bluetooth/bsim_bt/compile.source
+++ b/tests/bluetooth/bsim_bt/compile.source
@@ -1,0 +1,36 @@
+function compile(){
+  local app_root="${app_root:-${ZEPHYR_BASE}}"
+  local conf_file="${conf_file:-prj.conf}"
+  local conf_overlay="${conf_overlay:-""}"
+
+  local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y \
+    -DCONFIG_DEBUG_OPTIMIZATIONS=y \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"}"
+  local ninja_args="${ninja_args:-""}"
+
+  local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
+  local exe_name=${exe_name//\//_}
+  local exe_name=${exe_name//./_}
+  local exe_name=${BSIM_OUT_PATH}/bin/$exe_name
+  local map_file_name=${exe_name}.Tsymbols
+
+  local this_dir=${WORK_DIR}/${app}/${conf_file}
+
+  echo "Building $exe_name"
+
+  # Set INCR_BUILD when calling to only do an incremental build
+  if [ ! -v INCR_BUILD ] || [ ! -d "${this_dir}" ]; then
+      [ -d "${this_dir}" ] && rm ${this_dir} -rf
+      mkdir -p ${this_dir} && cd ${this_dir}
+      cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
+            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} ${cmake_args} ${app_root}/${app} \
+            &> cmake.out || { cat cmake.out && return 0; }
+  else
+      cd ${this_dir}
+  fi
+  ninja ${ninja_args} &> ninja.out || { cat ninja.out && return 0; }
+  cp ${this_dir}/zephyr/zephyr.exe ${exe_name}
+
+  nm ${exe_name} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${map_file_name}
+  sed -i "1i $(wc -l ${map_file_name} | cut -d" " -f1)" ${map_file_name}
+}

--- a/tests/bluetooth/bsim_bt/compile_permutate_kconfigs.sh
+++ b/tests/bluetooth/bsim_bt/compile_permutate_kconfigs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2018 Oticon A/S
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim_bt tests
+
+#set -x #uncomment this line for debugging
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+BOARD="${BOARD:-nrf52_bsim}"
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source tests/bluetooth/bsim_bt/compile.source
+
+declare -a list=(
+#"CONFIG_BT_DATA_LEN_UPDATE=n"
+#"CONFIG_BT_PHY_UPDATE=n"
+#"CONFIG_BT_CTLR_MIN_USED_CHAN=n"
+#"CONFIG_BT_CTLR_LE_PING=n"
+#"CONFIG_BT_CTLR_LE_ENC=n"
+#"CONFIG_BT_CTLR_CONN_PARAM_REQ=n"
+)
+
+perm_compile() {
+    local -a results=()
+    let idx=$2
+    for (( j = 0; j < $1; j++ )); do
+        if (( idx % 2 )); then results=("${results[@]}" "${list[$j]}"); fi
+        let idx\>\>=1
+    done
+	printf '%s\n' "${results[@]}" > /tmp/overlay_conf
+	echo "Compile with config overlay:"
+	cat /tmp/overlay_conf
+	app=tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app conf_file=prj.conf conf_overlay=/tmp/overlay_conf \
+	  compile
+}
+let n=${#list[@]}
+for (( i = 1; i < 2**n; i++ )); do
+    perm_compile $n $i
+done

--- a/tests/bluetooth/bsim_bt/compile_permutate_kconfigs.sh
+++ b/tests/bluetooth/bsim_bt/compile_permutate_kconfigs.sh
@@ -20,7 +20,7 @@ mkdir -p ${WORK_DIR}
 source tests/bluetooth/bsim_bt/compile.source
 
 declare -a list=(
-#"CONFIG_BT_DATA_LEN_UPDATE=n"
+"CONFIG_BT_DATA_LEN_UPDATE=n"
 #"CONFIG_BT_PHY_UPDATE=n"
 #"CONFIG_BT_CTLR_MIN_USED_CHAN=n"
 #"CONFIG_BT_CTLR_LE_PING=n"


### PR DESCRIPTION
Adding defined() clauses to not compile in DLE related code, when data length update procedure is not supported 
Adding compile script to test building with misc. kconfig overrides. - specifically building without CONFIG_BT_DATA_LEN_UPDATE

Still to sort out:
* Should we check the compile with automated permutation of features?
* How ought we check functionality? Run EDTT (minus unsupported features) on a selection of builds/featuresets?
