### PR TITLE
doc: scripts: gen_devicetree_rest: add workaround for page width

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -451,6 +451,14 @@ def print_binding_page(binding, base_names, vnd_lookup, dup_compats,
     print_block(f'''\
     :orphan:
 
+    .. raw:: html
+
+        <!--
+        FIXME: do not limit page width until content uses another representation
+        format other than tables
+        -->
+        <style>.wy-nav-content {{ max-width: none; !important }}</style>
+
     {dtcompatible}
     .. _{binding_ref_target(binding)}:
 


### PR DESCRIPTION
Since Zephyr docs switched to fixed-width, the binding pages are not
displayed correctly. We should move to another data representation
format that works better for fixed-width documents. Until this decision
is made, add a workaround that forces the template to expand page width
to the maximum on binding pages.

Fixes #35882 