### PR TITLE
cmake: warn the user if a Zephyr library is created in app-mode

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -514,6 +514,15 @@ endfunction()
 # constructor but must called explicitly on CMake libraries that do
 # not use a zephyr library constructor.
 function(zephyr_append_cmake_library library)
+  if(TARGET zephyr_prebuilt)
+    message(WARNING
+      "zephyr_library() or zephyr_library_named() called in Zephyr CMake "
+      "application mode. `${library}` will not be treated as a Zephyr library."
+      "To create a Zephyr library in Zephyr CMake kernel mode consider "
+      "creating a Zephyr module. See more here: "
+      "https://docs.zephyrproject.org/latest/guides/modules.html"
+    )
+  endif()
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_LIBS ${library})
 endfunction()
 


### PR DESCRIPTION
Fixes: #19582

When `find_package(Zephyr)` completes then all boilerplate code has been
processed and all Zephyr libraries has been placed inside the
whole archive flags.

Also all libs dependencies has been processed.

This is indicated by the presence of the zephyr_prebuilt target.

Thus, warn the user if `zephyr_library()` / `zephyr_library_named()`
is called in app-mode.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>