### PR TITLE
doc: release-notes-2.6: add release notes for disk drivers and USB

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -478,6 +478,13 @@ Drivers and Sensors
 
   * Added support for ST7735R
 
+* Disk
+
+  * Moved disk drivers (``disk_access_*.c``) to ``drivers/disk`` and renamed
+    according to their function.
+  * Fixed CMD6 support in USDHC driver.
+  * Fixed clock frequency switching after initialization in ``sdmmc_spi.c`` driver.
+
 * DMA
 
   * Added support on STM32G0 and STM32H7

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -623,6 +623,7 @@ Drivers and Sensors
 * USB
 
   * Added support on STM32H7
+  * Added attached event delay to usb_dc_nrfx driver
 
 * Watchdog
 
@@ -754,6 +755,23 @@ Networking
 
   * Fixed userspace access to TLS socket.
   * Added socket option support for setting and getting DTLS handshake timeout.
+
+USB
+***
+
+* Reworked USB classes configuration. Various minor fixes in USB DFU class.
+
+* USB HID class
+
+  * Removed get_protocol/set_protocol from USB HID class API.
+  * Allowed boot interface Protocol Code to be set per device.
+  * Rework idle report implementation.
+
+* Samples
+
+  * Allowed to build USB Audio sampe for different platforms.
+  * Added SD card support to USB MSC sample.
+  * Reworked USB HID sample.
 
 Build and Infrastructure
 ************************


### PR DESCRIPTION
Add release notes for disk drivers.
Add release notes for USB.