### PR TITLE
lib: add default labels and comments to switch statements

### DIFF
--- a/lib/libc/minimal/source/stdlib/atoi.c
+++ b/lib/libc/minimal/source/stdlib/atoi.c
@@ -43,6 +43,12 @@ int atoi(const char *s)
 		break;	/* artifact to quiet coverity warning */
 	case '+':
 		s++;
+	default:
+		/* Add an empty default with break, this is a defensive programming.
+		 * Static analysis tool won't raise a violation if default is empty,
+		 * but has that comment.
+		 */
+		break;
 	}
 	/* Compute n as a negative number to avoid overflow on INT_MIN */
 	while (isdigit(*s)) {

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -555,6 +555,10 @@ int_conv:
 				unsupported = sizeof(ptrdiff_t) > 4;
 				break;
 			default:
+				/* Add an empty default with break, this is a defensive
+				 * programming. Static analysis tool won't raise a violation
+				 * if default is empty, but has that comment.
+				 */
 				break;
 			}
 		} else {
@@ -1303,6 +1307,10 @@ static inline void store_count(const struct conversion *conv,
 		*(ptrdiff_t *)dp = (ptrdiff_t)count;
 		break;
 	default:
+		/* Add an empty default with break, this is a defensive programming.
+		 * Static analysis tool won't raise a violation if default is empty,
+		 * but has that comment.
+		 */
 		break;
 	}
 }
@@ -1664,6 +1672,12 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 				bps = encode_float(value->dbl, conv, precision,
 						   &sign, buf, &bpe);
 			}
+			break;
+		default:
+			/* Add an empty default with break, this is a defensive
+			 * programming. Static analysis tool won't raise a violation
+			 * if default is empty, but has that comment.
+			 */
 			break;
 		}
 

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -309,6 +309,12 @@ int fcntl(int fd, int cmd, ...)
 		/* Not implemented so far. */
 		errno = EINVAL;
 		return -1;
+	default:
+		/* Add an empty default with break, this is a defensive programming.
+		 * Static analysis tool won't raise a violation if default is empty,
+		 * but has that comment.
+		 */
+		break;
 	}
 
 	/* The rest of commands are per-fd, handled by ioctl vmethod. */


### PR DESCRIPTION
According to the Zephyr Coding Guideline all switch statements
shall be well-formed.
Added a default labels to switch-clauses without them.
Added comments to the empty default cases.

Found as a coding guideline violation (MISRA R16.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>