### PR TITLE
arch: add comments to empty default case, add default LOG_ERR

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -285,6 +285,7 @@ static void log_exception(uintptr_t vector, uintptr_t code)
 		LOG_ERR("Security exception");
 		break;
 	default:
+		LOG_ERR("Exception not handled (code 0x%lx)", code);
 		break;
 	}
 }

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1906,6 +1906,9 @@ void arch_reserved_pages_update(void)
 		case X86_MEMMAP_ENTRY_DEFECTIVE:
 			__fallthrough;
 		default:
+			/* If any of three above cases satisfied, exit switch
+			 * and mark page reserved
+			 */
 			break;
 		}
 


### PR DESCRIPTION
According to the Zephyr Coding Guideline all switch statements
shall be well-formed.
Add a comment to the empty default case.
Add a LOG_ERR to the default case.

Found as a coding guideline violation (MISRA R16.1) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>