### PR TITLE
Tracing: Incorrect Unlock Mutex Trace Hook Fix

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -264,9 +264,9 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 
 
 k_mutex_unlock_return:
-	k_sched_unlock();
-
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mutex, unlock, mutex, 0);
+
+	k_sched_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
Changed location of the last k_mutex_unlock trace hook since it was
being called after k_sched_unlock, which could result in tracing
scenarios (other thread waiting for lock) where it appeared that a
mutex was being locked again before becoming unlocked.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>