### PR TITLE
modules: tfm: add option for selecting crypto modules

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -14,6 +14,19 @@ set(TFM_VALID_PARTITIONS
   TFM_PARTITION_AUDIT_LOG
   )
 
+# List of all crypto modules that can be enabled/disabled
+# Corresponds to the *_MODULE_DISABLED configs in 'trusted-firmware-m/config/config_default.cmake'
+set(TFM_CRYPTO_MODULES
+  CRYPTO_KEY_MODULE
+  CRYPTO_AEAD_MODULE
+  CRYPTO_MAC_MODULE
+  CRYPTO_HASH_MODULE
+  CRYPTO_CIPHER_MODULE
+  CRYPTO_GENERATOR_MODULE
+  CRYPTO_ASYMMETRIC_MODULE
+  CRYPTO_KEY_DERIVATION_MODULE
+  )
+
 # Adds trusted-firmware-m as an external project.
 # Also creates a target called 'tfm_api'
 # which can be linked into the app.
@@ -53,12 +66,14 @@ set(TFM_VALID_PARTITIONS
 #                        REGRESSION_NS
 #                        BL2
 #                        BUILD_PROFILE profile_small
-#                        ENABLED_PARTITIONS TFM_PARTITION_PLATFORM TFM_PARTITION_CRYPTO)
+#                        ENABLED_PARTITIONS TFM_PARTITION_PLATFORM TFM_PARTITION_CRYPTO
+#                        ENABLED_CRYPTO_MODULES CRYPTO_KEY_MODULE CRYPTO_MAC_MODULE
+#                        )
 function(trusted_firmware_build)
   set(options IPC BL2 REGRESSION_S REGRESSION_NS)
   set(oneValueArgs BINARY_DIR BOARD ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE
     MCUBOOT_IMAGE_NUMBER PSA_TEST_SUITE)
-  set(multiValueArgs ENABLED_PARTITIONS CMAKE_ARGS)
+  set(multiValueArgs ENABLED_PARTITIONS CMAKE_ARGS ENABLED_CRYPTO_MODULES)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   foreach(partition ${TFM_VALID_PARTITIONS})
@@ -69,6 +84,19 @@ function(trusted_firmware_build)
       set(val "ON")
     endif()
     list(APPEND TFM_PARTITIONS_ARGS -D${partition}=${val})
+  endforeach()
+
+  foreach(module ${TFM_CRYPTO_MODULES})
+    list(FIND TFM_ENABLED_CRYPTO_MODULES ${module} idx)
+    if (idx EQUAL -1)
+      set(val "TRUE") # Module is not enabled, set DISABLED option to TRUE
+    else()
+      set(val "FALSE") # Module is enabled, set DISABLED option to FALSE
+    endif()
+    list(APPEND
+      TFM_DISABLED_MODULES_ARGS
+      -D${module}_DISABLED=${val}
+      )
   endforeach()
 
   if(TFM_IPC)
@@ -187,6 +215,7 @@ function(trusted_firmware_build)
       -DMCUBOOT_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/../tfm-mcuboot
       -DPSA_ARCH_TESTS_PATH=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/psa-arch-tests
       ${TFM_PARTITIONS_ARGS}
+      ${TFM_DISABLED_MODULES_ARGS}
       ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m
     WORKING_DIRECTORY ${TFM_BINARY_DIR}
     COMMAND_EXPAND_LISTS
@@ -312,6 +341,13 @@ if (CONFIG_BUILD_WITH_TFM)
     endif()
   endforeach()
 
+  # Enable TFM crypto modules as specified in Kconfig
+  foreach(module ${TFM_CRYPTO_MODULES})
+    if (CONFIG_TFM_${module}_ENABLED)
+      list(APPEND TFM_ENABLED_CRYPTO_MODULES_ARG ${module})
+    endif()
+  endforeach()
+
   trusted_firmware_build(
     BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
     BOARD ${CONFIG_TFM_BOARD}
@@ -324,6 +360,7 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_REGRESSION_NS_ARG}
     CMAKE_ARGS $<GENEX_EVAL:$<TARGET_PROPERTY:zephyr_property_target,TFM_CMAKE_OPTIONS>>
     ENABLED_PARTITIONS ${TFM_ENABLED_PARTITIONS_ARG}
+    ENABLED_CRYPTO_MODULES ${TFM_ENABLED_CRYPTO_MODULES_ARG}
     ${TFM_PSA_TEST_ARG}
     CMAKE_BUILD_TYPE ${TFM_CMAKE_BUILD_TYPE}
   )

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -178,7 +178,7 @@ config TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
 	  options are handled by the build system in the trusted-firmware-m
 	  repository.
 
-config TFM_PARTITION_CRYPTO
+menuconfig TFM_PARTITION_CRYPTO
 	bool "Enable secure partition 'Crypto'"
 	default y
 	help
@@ -188,6 +188,74 @@ config TFM_PARTITION_CRYPTO
 	  parameter. Any dependencies between the various TFM_PARTITION_*
 	  options are handled by the build system in the trusted-firmware-m
 	  repository.
+
+if TFM_PARTITION_CRYPTO
+
+config TFM_CRYPTO_KEY_MODULE_ENABLED
+	bool "Enable KEY crypto module"
+	default y
+	help
+	  Enables the KEY crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_key.c'
+	  is not used.
+
+config TFM_CRYPTO_AEAD_MODULE_ENABLED
+	bool "Enable AEAD crypto module"
+	default y
+	help
+	  Enables the AEAD crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_aead.c'
+	  is not used.
+
+config TFM_CRYPTO_MAC_MODULE_ENABLED
+	bool "Enable MAC crypto module"
+	default y
+	help
+	  Enables the MAC crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_mac.c'
+	  is not used.
+
+config TFM_CRYPTO_HASH_MODULE_ENABLED
+	bool "Enable HASH crypto module"
+	default y
+	help
+	  Enables the HASH crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_hash.c'
+	  is not used.
+
+config TFM_CRYPTO_CIPHER_MODULE_ENABLED
+	bool "Enable CIPHER crypto module"
+	default y
+	help
+	  Enables the CIPHER crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_cipher.c'
+	  is not used.
+
+config TFM_CRYPTO_GENERATOR_MODULE_ENABLED
+	bool "Enable GENERATOR crypto module"
+	default y
+	help
+	  Enables the GENERATOR crypto module within the crypto partition.
+	  Unset this option if the key generation, generate, raw key and
+	  key derivation features from 'tfm_crypto_secure_api.c' is not used.
+
+config TFM_CRYPTO_ASYMMETRIC_MODULE_ENABLED
+	bool "Enable ASYMMETRIC crypto module"
+	default y
+	help
+	  Enables the ASYMMETRIC crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_asymmetric.c'
+	  is not used.
+
+config TFM_CRYPTO_KEY_DERIVATION_MODULE_ENABLED
+	bool "Enable KEY DERIVATION crypto module"
+	default y
+	help
+	  Enables the KEY_DERIVATION crypto module within the crypto partition.
+	  Unset this option if the functionality provided by 'crypto_key_derivation.c'
+	  is not used.
+
+endif # TFM_PARTITION_CRYPTO
 
 config TFM_PARTITION_INITIAL_ATTESTATION
 	bool "Enable secure partition 'Initial Attestation'"


### PR DESCRIPTION
The added configurations are mapping existing TFM CMake variables in Kconfig, trying to make the build more configurable. The additional options are needed to disable not needed crypto modules in the trusted-firmware-m module.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>