### PR TITLE
arch: arm64: mpu: Fix mpu init assertion fail

### DIFF
--- a/arch/arm64/core/cortex_r/mpu/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/mpu/arm_mpu.c
@@ -26,8 +26,9 @@ LOG_MODULE_DECLARE(mpu);
  * ID_AA64MMFR0_MSA_FRAC, bits[55:52]
  * ID_AA64MMFR0_MSA, bits [51:48]
  */
-#define ID_AA64MMFR0_MSA_msk	(0xFFUL << 48U)
-#define ID_AA64MMFR0_PMSA_EN	(0x1FUL << 48U)
+#define ID_AA64MMFR0_MSA_msk		(0xFFUL << 48U)
+#define ID_AA64MMFR0_PMSA_EN		(0x1FUL << 48U)
+#define ID_AA64MMFR0_PMSA_VMSA_EN	(0x2FUL << 48U)
 
 /*
  * Global status variable holding the number of HW MPU region indices, which
@@ -143,8 +144,9 @@ static int arm_mpu_init(const struct device *arg)
 		 "Exception level not EL1, MPU not enabled!\n");
 
 	/* Check whether the processor supports MPU */
-	val = read_id_aa64mmfr0_el1();
-	if ((val & ID_AA64MMFR0_MSA_msk) != ID_AA64MMFR0_PMSA_EN) {
+	val = read_id_aa64mmfr0_el1() & ID_AA64MMFR0_MSA_msk;
+	if ((val != ID_AA64MMFR0_PMSA_EN) &&
+	    (val != ID_AA64MMFR0_PMSA_VMSA_EN)) {
 		__ASSERT(0, "MPU not supported!\n");
 		return -1;
 	}


### PR DESCRIPTION
During mpu init, we check MSA_frac bits[55:52] and MSA bits[51:48] of
the ID_AA64MMFR0_EL1 register. Currently we only allow 1F to pass the
check. But according to Armv8-R AArch64 manual [1], both 1F and 2F
indicates the processor supports MPU. This commit aims at fixing this.

[1]: https://developer.arm.com/documentation/ddi0600/latest/

Signed-off-by: Jaxson Han <jaxson.han@arm.com>