### PR TITLE
net: dns: Fix multiple IP DNS resolution

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -43,6 +43,14 @@ config DNS_RESOLVER_ADDITIONAL_QUERIES
 	  The maximum value of this variable is constrained to avoid
 	  'alias loops'.
 
+config DNS_RESOLVER_AI_MAX_ENTRIES
+	int "Maximum number of IP addresses for DNS name"
+	default 2
+	help
+	  Defines the max number of IP addresses per domain name
+	  resolution the DNS resolver can handle.
+
+
 config DNS_RESOLVER_MAX_SERVERS
 	int "Number of DNS server addresses"
 	range 1 NET_MAX_CONTEXTS

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -106,7 +106,8 @@ static int skip_fqdn(uint8_t *answer, int buf_sz)
 	return i;
 }
 
-int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl)
+int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
+		      enum dns_rr_type *type)
 {
 	int dname_len;
 	uint16_t rem_size;
@@ -155,8 +156,9 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl)
 		DNS_COMMON_UINT_SIZE + /* type length */
 		DNS_TTL_LEN +
 		DNS_RDLENGTH_LEN;
+	*type = dns_answer_type(dname_len, answer);
 
-	switch (dns_answer_type(dname_len, answer)) {
+	switch (*type) {
 	case DNS_RR_TYPE_A:
 	case DNS_RR_TYPE_AAAA:
 		set_dns_msg_response(dns_msg, DNS_RESPONSE_IP, pos, len);

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -340,10 +340,12 @@ int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
  * @param dname_ptr An index to the previous CNAME. For example for the
  *        first answer, ptr must be 0x0c, the DNAME at the question.
  * @param ttl TTL answer parameter.
+ * @param type Answer type parameter.
  * @retval 0 on success
  * @retval -ENOMEM on error
  */
-int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl);
+int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
+		      enum dns_rr_type *type);
 
 /**
  * @brief Unpacks the header's response.

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -20,11 +20,15 @@ LOG_MODULE_REGISTER(net_sock_addr, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <net/socket_offload.h>
 #include <syscall_handler.h>
 
-#define AI_ARR_MAX	2
-
 #if defined(CONFIG_DNS_RESOLVER) || \
 	defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
 #define ANY_RESOLVER
+
+#if defined(CONFIG_DNS_RESOLVER_AI_MAX_ENTRIES)
+#define AI_ARR_MAX CONFIG_DNS_RESOLVER_AI_MAX_ENTRIES
+#else
+#define AI_ARR_MAX 1
+#endif /* defined(CONFIG_DNS_RESOLVER_AI_MAX_ENTRIES) */
 
 /* Initialize static fields of addrinfo structure. A macro to let it work
  * with any sockaddr_* type.
@@ -56,7 +60,6 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 	struct getaddrinfo_state *state = user_data;
 	struct zsock_addrinfo *ai;
 	int socktype = SOCK_STREAM;
-	int proto;
 
 	NET_DBG("dns status: %d", status);
 
@@ -75,6 +78,10 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 	}
 
 	ai = &state->ai_arr[state->idx];
+	if (state->idx > 0) {
+		state->ai_arr[state->idx - 1].ai_next = ai;
+	}
+
 	memcpy(&ai->_ai_addr, &info->ai_addr, info->ai_addrlen);
 	net_sin(&ai->_ai_addr)->sin_port = state->port;
 	ai->ai_addr = &ai->_ai_addr;
@@ -90,13 +97,8 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 		}
 	}
 
-	proto = IPPROTO_TCP;
-	if (socktype == SOCK_DGRAM) {
-		proto = IPPROTO_UDP;
-	}
-
 	ai->ai_socktype = socktype;
-	ai->ai_protocol = proto;
+	ai->ai_protocol = (socktype == SOCK_DGRAM) ? IPPROTO_UDP : IPPROTO_TCP;
 
 	state->idx++;
 }
@@ -198,9 +200,6 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	ai_state.ai_arr = res;
 	k_sem_init(&ai_state.sem, 0, K_SEM_MAX_LIMIT);
 
-	/* Link entries in advance */
-	ai_state.ai_arr[0].ai_next = &ai_state.ai_arr[1];
-
 	/* If the family is AF_UNSPEC, then we query IPv4 address first */
 	ret = exec_query(host, family, &ai_state);
 	if (ret == 0) {
@@ -285,8 +284,7 @@ static inline int z_vrfy_z_zsock_getaddrinfo_internal(const char *host,
 		Z_OOPS(z_user_from_copy(&hints_copy, (void *)hints,
 					sizeof(hints_copy)));
 	}
-	Z_OOPS(Z_SYSCALL_MEMORY_ARRAY_WRITE(res, AI_ARR_MAX,
-					    sizeof(struct zsock_addrinfo)));
+	Z_OOPS(Z_SYSCALL_MEMORY_ARRAY_WRITE(res, AI_ARR_MAX, sizeof(struct zsock_addrinfo)));
 
 	if (service) {
 		service_copy = z_user_string_alloc_copy((char *)service, 64);

--- a/tests/net/lib/dns_packet/src/main.c
+++ b/tests/net/lib/dns_packet/src/main.c
@@ -339,12 +339,13 @@ static int eval_response1(struct dns_response_test *resp, bool unpack_answer)
 	if (unpack_answer) {
 		uint32_t ttl;
 		struct dns_msg_t msg;
+		enum dns_rr_type answer_type;
 
 		msg.msg = resp->res;
 		msg.msg_size = resp->res_len;
 		msg.answer_offset = offset;
 
-		if (dns_unpack_answer(&msg, DNS_ANSWER_MIN_SIZE, &ttl) < 0) {
+		if (dns_unpack_answer(&msg, DNS_ANSWER_MIN_SIZE, &ttl, &answer_type) < 0) {
 			rc = __LINE__;
 			goto lb_exit;
 		}


### PR DESCRIPTION
Fixed mutli-IP DNS resolution as previously the same IP address was
used to populate all AI entries and added DNS_RESOLVER_AI_MAX_ENTRIES
config entry to define max number of IP addresses per DNS name to be
handled.