### PR TITLE
doc: release: Add sensor and NXP-related changes to v2.6.0 release notes

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -413,6 +413,11 @@ Boards & SoC Support
     (TF-M) support.
   * lpcxpresso55s28: Removed lpcxpresso55s28_ns config since the board
     does not have Trusted Firmware M (TF-M) support.
+  * mimxrt685_evk: Added support for octal SPI flash storage, LittleFS, I2S, OS
+    timer, and power management.
+  * mimxrt1060_evk: Added support for QSPI flash storage, LittleFS, and
+    mcuboot.
+  * mimxrt1064_evk: Added support for mcuboot.
 
 * Added support for these following shields:
 

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -604,7 +604,21 @@ Drivers and Sensors
 
 * Sensor
 
-  * Added support for STM32 internal (CPU) temperature sensor
+  * Added support for STM32 internal (CPU) temperature sensor.
+  * Refactored mulitple ST sensor drivers to use gpio_dt_spec macros and common
+    stmemc routines, support multiple instances, and configure ODR/range
+    properties in device tree.
+  * Added SBS 1.1 compliant fuel gauge driver.
+  * Added MAX17262 fuel gauge driver.
+  * Added BMP388 pressure sensor driver.
+  * Added Atmel SAM QDEC driver.
+  * Added TI FDC2X1X driver.
+  * Added support for MPU9250 to existing MPU6050 6-axis motion tracking driver.
+  * Refactored BME280 temperature/pressure sensor driver.
+  * Added BMI270 IMU driver.
+  * Added Nuvoton tachometer sensor driver.
+  * Added MAX6675 cold-junction-compensated K-thermocouple to digital
+    converter.
 
 * Serial
 


### PR DESCRIPTION
Adds v2.6.0 release notes for sensor drivers and NXP boards.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>