### PR TITLE
soc: arm: cc32xx: Override Reboot implementation

### DIFF
--- a/soc/arm/ti_simplelink/cc32xx/soc.c
+++ b/soc/arm/ti_simplelink/cc32xx/soc.c
@@ -12,6 +12,12 @@
 #include <driverlib/rom_map.h>
 #include <driverlib/prcm.h>
 
+/* Overrides the weak ARM implementation */
+void sys_arch_reboot(int type)
+{
+	MAP_PRCMMCUReset(!!type);
+}
+
 static int ti_cc32xx_init(const struct device *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
Support cold, hot reboots. Cold will reboot all periherals

Signed-off-by: Pavlo Hamov <pasha.gamov@gmail.com>