### PR TITLE
cmake: Support coverage flags on all archs

### DIFF
--- a/arch/arc/core/CMakeLists.txt
+++ b/arch/arc/core/CMakeLists.txt
@@ -2,11 +2,6 @@
 
 zephyr_library()
 
-if(CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
-endif()
-
 zephyr_library_sources(
   thread.c
   thread_entry_wrapper.S

--- a/arch/arm/core/aarch32/CMakeLists.txt
+++ b/arch/arm/core/aarch32/CMakeLists.txt
@@ -2,11 +2,6 @@
 
 zephyr_library()
 
-if (CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
-endif ()
-
 zephyr_library_sources(
   swap.c
   swap_helper.S

--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -2,11 +2,6 @@
 
 zephyr_library()
 
-if (CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
-endif ()
-
 zephyr_library_sources(
   cpu_idle.S
   fatal.c

--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -52,3 +52,8 @@ if (CONFIG_GEN_ISR_TABLES)
   target_link_libraries(isr_tables zephyr_interface)
   zephyr_library_link_libraries(isr_tables)
 endif()
+
+if(CONFIG_COVERAGE)
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
+  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
+endif()

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -24,11 +24,6 @@ zephyr_compile_options($<TARGET_PROPERTY:compiler,hosted>)
 
 zephyr_include_directories(${BOARD_DIR})
 
-if (CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
-endif ()
-
 if (CONFIG_ASAN)
   zephyr_compile_options($<TARGET_PROPERTY:compiler,sanitize_address>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,sanitize_address>)

--- a/arch/x86/core/CMakeLists.txt
+++ b/arch/x86/core/CMakeLists.txt
@@ -3,11 +3,6 @@
 
 zephyr_library()
 
-if (CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,coverage>)
-endif ()
-
 zephyr_library_sources(cpuhalt.c)
 zephyr_library_sources(prep_c.c)
 zephyr_library_sources(fatal.c)


### PR DESCRIPTION
Most arch's CMakeLists.txt contain rules to add compiler and linker
flags for coverage if CONFIG_COVERAGE is enabled, but 4 of them were
missing this.

Signed-off-by: Jeremy Bettis <jbettis@chromium.org>