### PR TITLE
size_report: give root node a unique identifier

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -557,7 +557,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
     """
     Generate a symbol tree for output.
     """
-    root = TreeNode('Symbols', ":")
+    root = TreeNode('Symbols', "root")
     node_no_paths = TreeNode('(no paths)', ":", parent=root)
 
     if Path(path_prefix) == Path(args.zephyrbase):


### PR DESCRIPTION
Call the root node 'root', otherwise we end up with two nodes with the
same identifier ':'.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
