### PR TITLE
arch: x86: Fix for PCI Multi-MSI support

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -236,6 +236,15 @@ config PCIE_MMIO_CFG
 	  Configuration Space instead of the traditional 0xCF8/0xCFC
 	  IO Port registers.
 
+config MULTI_MSI_ANY_PRIORITY
+	bool "Allow to allocate lower priority interrupt than requested"
+	default y
+	help
+	  Allow to allocate lower priority interrupt than requested for
+	  Multi MSI interrupt. If enabled, allow PCI subsystem to
+	  allocate contigious vectors from lower priority vectors if
+	  not availble in current priority requested.
+
 config KERNEL_VM_SIZE
 	default 0xC0000000 if ACPI
 

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -80,6 +80,14 @@ int z_x86_allocate_vector(unsigned int priority, int prev_vector)
 	return -1;
 }
 
+void z_x86_connect_on_vector(uint8_t vector,
+				 void (*func)(const void *arg),
+				 const void *arg)
+{
+	x86_irq_funcs[vector - IV_IRQS] = func;
+	x86_irq_args[vector - IV_IRQS] = arg;
+}
+
 void z_x86_irq_connect_on_vector(unsigned int irq,
 				 uint8_t vector,
 				 void (*func)(const void *arg),
@@ -87,8 +95,7 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
 {
 	_irq_to_interrupt_vector[irq] = vector;
 	z_irq_controller_irq_config(vector, irq, flags);
-	x86_irq_funcs[vector - IV_IRQS] = func;
-	x86_irq_args[vector - IV_IRQS] = arg;
+	z_x86_connect_on_vector(vector, func, arg);
 }
 
 /*

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -108,6 +108,13 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
 				 void (*func)(const void *arg),
 				 const void *arg, uint32_t flags);
 
+/*
+ * Connect a vector for MSI/MSI-x
+ */
+void z_x86_connect_on_vector(uint8_t vector,
+				 void (*func)(const void *arg),
+				 const void *arg);
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_KERNEL_ARCH_FUNC_H_ */


### PR DESCRIPTION
Currently Multi MSI is not working with PCI device which support
Multi MSI vector and so need to fall back to legacy mode.
This fix will enable PCI driver to use Multi MSI support
for x86 architecture.

Signed-off-by: Najumon B.A <najumon.ba@intel.com>