### PR TITLE
Bluetooth: controller: Check length field of scan response data

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1589,6 +1589,10 @@ uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 	struct pdu_adv *pdu;
 	uint8_t idx;
 
+	if (len > PDU_AC_DATA_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
 	/* update scan pdu fields. */
 	prev = lll_adv_scan_rsp_peek(&adv->lll);
 	pdu = lll_adv_scan_rsp_alloc(&adv->lll, &idx);


### PR DESCRIPTION
Check the length field of the scan response data.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>