### PR TITLE
drivers: cc13xx_cc26xx: Fix pm.h include breakage

### DIFF
--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -10,6 +10,7 @@
 #include <device.h>
 #include <drivers/entropy.h>
 #include <irq.h>
+#include <pm/pm.h>
 #include <pm/device.h>
 
 #include <sys/ring_buffer.h>

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -9,6 +9,7 @@
 #include <kernel.h>
 #include <drivers/i2c.h>
 #include <pm/device.h>
+#include <pm/pm.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <sys/__assert.h>
 #include <pm/device.h>
+#include <pm/pm.h>
 #include <drivers/uart.h>
 
 #include <driverlib/ioc.h>

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(spi_cc13xx_cc26xx);
 
 #include <drivers/spi.h>
 #include <pm/device.h>
+#include <pm/pm.h>
 
 #include <driverlib/prcm.h>
 #include <driverlib/ssi.h>


### PR DESCRIPTION
Simple fix for #35916 regarding missing `<pm/pm.h>` include (build fails on TI CC13xx/26xx uart / i2c / spi / entropy drivers).