### PR TITLE
drivers: fix pm callback signature

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -520,7 +520,7 @@ static int st7735r_enter_sleep(struct st7735r_data *data)
 }
 
 static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
-			      void *context, pm_device_cb cb, void *arg)
+			      uint32_t *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
@@ -544,7 +544,7 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 		break;
 
 	case PM_DEVICE_STATE_GET:
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 
 		break;
 
@@ -553,7 +553,7 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 	}
 
 	if (cb != NULL) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -410,14 +410,14 @@ static int apds9960_init_interrupt(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+				uint32_t *state, pm_device_cb cb, void *arg)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t device_pm_state = *(uint32_t *)context;
+		uint32_t device_pm_state = *state;
 
 		if (device_pm_state == PM_DEVICE_STATE_ACTIVE) {
 			if (i2c_reg_update_byte(data->i2c, config->i2c_address,
@@ -442,11 +442,11 @@ static int apds9960_device_ctrl(const struct device *dev,
 		}
 
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = PM_DEVICE_STATE_ACTIVE;
+		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -391,7 +391,7 @@ static int bme280_chip_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
-				void *context, pm_device_cb cb, void *arg)
+		   uint32_t *state, pm_device_cb cb, void *arg)
 {
 	struct bme280_data *data = to_data(dev);
 
@@ -399,7 +399,7 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 
 	/* Set power state */
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_pm_state = *((const uint32_t *)context);
+		uint32_t new_pm_state = *state;
 
 		if (new_pm_state != data->pm_state) {
 
@@ -430,12 +430,12 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 	/* Get power state */
 	else {
 		__ASSERT_NO_MSG(ctrl_command == PM_DEVICE_STATE_GET);
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	/* Invoke callback if any */
 	if (cb)
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 
 	return ret;
 }

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -589,20 +589,20 @@ static uint32_t bmp388_get_power_state(const struct device *dev)
 static int bmp388_device_ctrl(
 	const struct device *dev,
 	uint32_t ctrl_command,
-	void *context,
+	uint32_t *state,
 	pm_device_cb cb,
 	void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		ret = bmp388_set_power_state(dev, *((uint32_t *)context));
+		ret = bmp388_set_power_state(dev, *state);
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = bmp388_get_power_state(dev);
+		*state = bmp388_get_power_state(dev);
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 	return ret;
 }

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -543,14 +543,15 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 				  uint32_t ctrl_command,
-				  void *context, pm_device_cb cb, void *arg)
+				  uint32_t *state, pm_device_cb cb,
+				  void *arg)
 {
 	struct fdc2x1x_data *data = dev->data;
 	uint32_t new_state;
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		new_state = *(uint32_t *)context;
+		new_state = *state;
 		if (new_state != data->pm_state) {
 			switch (new_state) {
 			case PM_DEVICE_STATE_ACTIVE:
@@ -564,11 +565,11 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 			}
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = data->pm_state;
+		*state = data->pm_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -219,13 +219,13 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
-				uint32_t ctrl_command, void *context,
+				uint32_t ctrl_command, uint32_t *state,
 				pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t device_pm_state = *(uint32_t *)context;
+		uint32_t device_pm_state = *state;
 		uint16_t ps_conf;
 
 		ret = vcnl4040_read(dev, VCNL4040_REG_PS_CONF, &ps_conf);
@@ -275,11 +275,11 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		}
 
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = PM_DEVICE_STATE_ACTIVE;
+		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -48,7 +48,7 @@ extern int sys_clock_driver_init(const struct device *dev);
  */
 extern int clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
-			       void *context, pm_device_cb cb, void *arg);
+			       uint32_t *state, pm_device_cb cb, void *arg);
 
 /**
  * @brief Set system clock timeout

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -36,13 +36,13 @@ static void trigger_handler(const struct device *dev,
 #ifdef CONFIG_PM_DEVICE
 static void pm_cb(const struct device *dev,
 		  int status,
-		  void *context,
+		  uint32_t *state,
 		  void *arg)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(arg);
 
-	switch (*(uint32_t *)context) {
+	switch (*state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
 		break;


### PR DESCRIPTION
For some reason a few drivers were not converted to the new device PM
callback signature. The reason may be because the device PM part is
compiled only when CONFIG_PM_DEVICE=y on these drivers, a condition not enabled in CI by
default.