### PR TITLE
shell: Add missing dependency to shell log backend

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -197,7 +197,7 @@ config SHELL_CMDS_SELECT
 
 config SHELL_LOG_BACKEND
 	bool "Enable shell log backend"
-	depends on !LOG_MINIMAL
+	depends on LOG && !LOG_MINIMAL
 	default y if LOG
 	help
 	  When enabled, backend will use the shell for logging.


### PR DESCRIPTION
Shell log backend depends on logging being enabled. Lack of this
dependency leads to compilation failure when logging is disabled.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>