### PR TITLE
drivers: can: mcan: Fix DBTP sjw register writes

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -127,9 +127,9 @@ void can_mcan_configure_timing(struct can_mcan_reg  *can,
 				CAN_MCAN_DBTP_DBRP_POS;
 
 		if (timing_data->sjw == CAN_SJW_NO_CHANGE) {
-			can->nbtp |= dbtp_sjw;
+			can->dbtp |= dbtp_sjw;
 		} else {
-			can->nbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F) <<
+			can->dbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F) <<
 				     CAN_MCAN_DBTP_DSJW_POS;
 		}
 	}


### PR DESCRIPTION
The data-sjw value was incorrectly written to the NBTP register when it
should be written to the DBTP register.

This fixes a regression introduced by
5e0ca9b41e5cd4d1d84ceef919510f3f2a22ecfe.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/35949

Signed-off-by: Christoph Steiger <c.steiger@lemonage.de>