### PR TITLE
shell: fix tab for dynamic commands

### DIFF
--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -290,7 +290,19 @@ const struct shell_static_entry *z_shell_find_cmd(
 					struct shell_static_entry *dloc)
 {
 	const struct shell_static_entry *entry;
+	struct shell_static_entry parent_cpy;
 	size_t idx = 0;
+
+	/* Dynamic command operates on shared memory. If we are processing two
+	 * dynamic commands at the same time (current and subcommand) they
+	 * will operate on the same memory region what can cause undefined
+	 * behaviour.
+	 * Hence we need a separate memory for each of them.
+	 */
+	if (parent) {
+		memcpy(&parent_cpy, parent, sizeof(struct shell_static_entry));
+		parent = &parent_cpy;
+	}
 
 	while ((entry = z_shell_cmd_get(parent, idx++, dloc)) != NULL) {
 		if (strcmp(cmd_str, entry->syntax) == 0) {


### PR DESCRIPTION
The tabulator handler creates a single structure if it is handling dynamic
commands. If the currently processed dynamic command has a dynamic
subcommand they both share the same structure.
As a result tabulation operation may result in undefined behaviour.

As a solution, a new structure was introduced to keep subcommand
information.

Fixes #35926.