### PR TITLE
tfm: interface: Fix bug where FPU registers were not restored correctly

### DIFF
--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -87,7 +87,7 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 
 		__asm__ volatile(
 			"vldmia %0, {s0-s15}\n"
-			"vldmia %0, {s16-s31}\n"
+			"vldmia %1, {s16-s31}\n"
 			:: "r" (fp_ctx_caller_saved), "r" (fp_ctx_callee_saved) :
 		);
 	}


### PR DESCRIPTION
The caller saved registers were restored both as caller saved and
callee saved registers, i.e. register 0-15 were restored into
both register 0-15 and 15-31.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>