### PR TITLE
soc: npcx: setup custom MPU regions for npcx7

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx7/CMakeLists.txt
+++ b/soc/arm/nuvoton_npcx/npcx7/CMakeLists.txt
@@ -5,3 +5,8 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
 )
+
+zephyr_sources_ifdef(
+  CONFIG_ARM_MPU
+  mpu_regions.c
+)

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_NPCX7
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NPCX
+	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	help
 	  Enable support for Nuvoton NPCX7 series

--- a/soc/arm/nuvoton_npcx/npcx7/mpu_regions.c
+++ b/soc/arm/nuvoton_npcx/npcx7/mpu_regions.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../../common/cortex_m/arm_mpu_mem_cfg.h"
+
+static const struct arm_mpu_region mpu_regions[] = {
+	MPU_REGION_ENTRY("FLASH_0_0",
+			 CONFIG_FLASH_BASE_ADDRESS & -KB(256),
+			 REGION_FLASH_ATTR(REGION_256K)),
+#if CONFIG_FLASH_SIZE > 256
+	MPU_REGION_ENTRY("FLASH_0_1",
+			 (CONFIG_FLASH_BASE_ADDRESS + KB(256)) & -KB(256),
+			 REGION_FLASH_ATTR(REGION_256K)),
+#endif
+	MPU_REGION_ENTRY("SRAM_0",
+			 CONFIG_SRAM_BASE_ADDRESS,
+			 REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+};
+
+const struct arm_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+};


### PR DESCRIPTION
Hi, stumbled into this while testing MPU on npcx7. Turns out that the MPU base addresses have to be aligned with the size of the region, which is not the case with the code RAM start addresses on npcx7. This adds a static region mapping for the soc family, which should work on both 192k and 320k devices.

The resulting setup is (mentioned in the patch comment):

```
    - 192kB devices
    
      Code ram: 0x10090000 to 0x100bffff
    MPU region: 0x10080000 to 0x100bffff (256k)
    
    - 320kB devices
    
        Code ram: 0x10070000 to 0x100bffff
    MPU region 0: 0x10040000 to 0x1007ffff (256k)
    MPU region 1: 0x10080000 to 0x100bffff (256k)
```