### PR TITLE
Bluetooth: OTS: Add TX MTU config and handle receive

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -994,6 +994,11 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 		return le_err_to_result(err);
 	}
 
+	if (!(*chan)->ops->recv) {
+		BT_ERR("Mandatory callback 'recv' missing");
+		return BT_L2CAP_LE_ERR_UNACCEPT_PARAMS;
+	}
+
 	(*chan)->required_sec_level = server->sec_level;
 
 	if (!l2cap_chan_add(conn, *chan, l2cap_chan_destroy)) {

--- a/subsys/bluetooth/services/ots/Kconfig
+++ b/subsys/bluetooth/services/ots/Kconfig
@@ -60,6 +60,11 @@ config BT_OTS_OLCP_GO_TO_SUPPORT
 	bool "Support OLCP Go To Operation"
 	default y
 
+config BT_OTS_L2CAP_CHAN_TX_MTU
+	int "Size of TX MTU for Object Transfer Channel"
+	default 256
+	range 21 65533
+
 config BT_OTS_L2CAP_CHAN_RX_MTU
 	int "Size of RX MTU for Object Transfer Channel"
 	# RX MTU will be truncated to account for the L2CAP PDU and SDU header.

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -105,7 +105,7 @@ static void l2cap_sent(struct bt_l2cap_chan *chan)
 	}
 }
 
-int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_gatt_ots_l2cap *l2cap_ctx;
 

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -26,9 +26,9 @@ LOG_MODULE_DECLARE(bt_ots, CONFIG_BT_OTS_LOG_LEVEL);
  */
 #define BT_GATT_OTS_L2CAP_PSM	0x0025
 
-/* Maximum size of outgoing data. */
-#define OT_TX_MTU 256
-NET_BUF_POOL_FIXED_DEFINE(ot_chan_tx_pool, 1, BT_L2CAP_SDU_BUF_SIZE(OT_TX_MTU),
+
+NET_BUF_POOL_FIXED_DEFINE(ot_chan_tx_pool, 1,
+			  BT_L2CAP_SDU_BUF_SIZE(CONFIG_BT_OTS_L2CAP_CHAN_TX_MTU),
 			  NULL);
 
 #if (CONFIG_BT_OTS_L2CAP_CHAN_RX_MTU > BT_L2CAP_SDU_RX_MTU)
@@ -46,7 +46,7 @@ static int ots_l2cap_send(struct bt_gatt_ots_l2cap *l2cap_ctx)
 	uint32_t len;
 
 	/* Calculate maximum length of data chunk. */
-	len = MIN(l2cap_ctx->ot_chan.tx.mtu, OT_TX_MTU);
+	len = MIN(l2cap_ctx->ot_chan.tx.mtu, CONFIG_BT_OTS_L2CAP_CHAN_TX_MTU);
 	len = MIN(len, l2cap_ctx->tx.len - l2cap_ctx->tx.len_sent);
 
 	/* Prepare buffer for sending. */


### PR DESCRIPTION
Add configuration for OTS channel SDU MTU.
Add mandatory callback recv, which is called without checking if application has provided it.
Check and return error code when establishing L2CAP channels if application has not set mandatory callbacks