### PR TITLE
pm: do not use deprecate Kconfig

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -67,7 +67,7 @@ struct st7735r_data {
 	const struct device *reset_dev;
 	uint16_t x_offset;
 	uint16_t y_offset;
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	uint32_t pm_state;
 #endif
 };
@@ -475,7 +475,7 @@ static int st7735r_init(const struct device *dev)
 		}
 	}
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	data->pm_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 
@@ -513,7 +513,7 @@ static int st7735r_init(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 static int st7735r_enter_sleep(struct st7735r_data *data)
 {
 	return st7735r_transmit(data, ST7735R_CMD_SLEEP_IN, NULL, 0);
@@ -558,7 +558,7 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 
 	return ret;
 }
-#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+#endif /* CONFIG_PM_DEVICE */
 
 static const struct display_driver_api st7735r_api = {
 	.blanking_on = st7735r_blanking_on,

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -310,7 +310,7 @@ static int bmp388_attr_set(const struct device *dev,
 {
 	int ret;
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	struct bmp388_data *data = DEV_DATA(dev);
 
 	if (data->device_power_state != PM_DEVICE_STATE_ACTIVE) {
@@ -347,7 +347,7 @@ static int bmp388_sample_fetch(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	if (bmp388->device_power_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}
@@ -544,7 +544,7 @@ static int bmp388_get_calibration_data(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 static int bmp388_set_power_state(const struct device *dev,
 				  uint32_t power_state)
 {
@@ -606,7 +606,7 @@ static int bmp388_device_ctrl(
 	}
 	return ret;
 }
-#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+#endif /* CONFIG_PM_DEVICE */
 
 static const struct sensor_driver_api bmp388_api = {
 	.attr_set = bmp388_attr_set,
@@ -671,7 +671,7 @@ static int bmp388_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	bmp388->device_power_state = PM_DEVICE_STATE_ACTIVE;
 #endif
 

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -163,7 +163,7 @@ struct bmp388_data {
 	uint8_t osr_temp;
 	struct bmp388_cal_data cal;
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	uint32_t device_power_state;
 #endif
 

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -91,7 +91,7 @@ int bmp388_trigger_set(
 {
 	struct bmp388_data *data = DEV_DATA(dev);
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 	if (data->device_power_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EBUSY;
 	}


### PR DESCRIPTION
CONFIG_DEVICE_POWER_MANAGEMENT is deprecated, use CONFIG_PM_DEVICE
instead.

Fixes #35962

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
