### PR TITLE
doc: security: Add CVE-2021-3581 to docs

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -31,6 +31,8 @@ The following CVEs are addressed by this release:
 More detailed information can be found in:
 https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 
+* CVE-2021-3581: Under embargo until 2021-09-04
+
 Known issues
 ************
 

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -820,3 +820,8 @@ Integer Underflow in 6LoWPAN IPHC Header Uncompression
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-116>`_
 
 - This issue has not been fixed.
+
+CVE-2021-3581
+-------------
+
+Under embargo until 2021/09/04


### PR DESCRIPTION
Update release notes for 2.6, and the vulnerabilities page to mention
CVE-2021-3581.  This CVE is under embargo until Sept 4, 2021.

Signed-off-by: David Brown <david.brown@linaro.org>