### PR TITLE
fdtable: remove remains of switch

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -308,12 +308,6 @@ int fcntl(int fd, int cmd, ...)
 		/* Not implemented so far. */
 		errno = EINVAL;
 		return -1;
-	default:
-		/* Add an empty default with break, this is a defensive programming.
-		 * Static analysis tool won't raise a violation if default is empty,
-		 * but has that comment.
-		 */
-		break;
 	}
 
 	/* The rest of commands are per-fd, handled by ioctl vmethod. */


### PR DESCRIPTION
a switch was converted to an if statement and still had a default,
something went really wrong here.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
