### PR TITLE
Add low power support for STM32L0 family

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -57,6 +57,22 @@
 		eeprom-0 = &eeprom;
 		lora0 = &lora;
 	};
+
+	power-states {
+		stop: stop {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <100>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&stop>;
+};
+
+&lptim1 {
+	status = "okay";
 };
 
 &clk_hsi {

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -5,7 +5,7 @@
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
-	depends on (SOC_SERIES_STM32L4X || SOC_SERIES_STM32L5X || SOC_SERIES_STM32WBX)
+	depends on "$(dt_nodelabel_enabled,lptim1)"
 	depends on CLOCK_CONTROL && PM
 	select TICKLESS_CAPABLE
 	help

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -21,7 +21,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;

--- a/soc/arm/st_stm32/stm32l0/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32l0/CMakeLists.txt
@@ -4,3 +4,7 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
   )
+
+zephyr_sources_ifdef(CONFIG_PM
+  power.c
+  )

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -12,4 +12,12 @@ source "soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 config SOC_SERIES
 	default "stm32l0"
 
+if PM
+config PM_DEVICE
+	default y
+
+config STM32_LPTIM_TIMER
+	default y
+endif # PM
+
 endif # SOC_SERIES_STM32L0X

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Fabio Baltieri
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <pm/pm.h>
+#include <soc.h>
+#include <init.h>
+
+#include <stm32l0xx_ll_utils.h>
+#include <stm32l0xx_ll_bus.h>
+#include <stm32l0xx_ll_cortex.h>
+#include <stm32l0xx_ll_pwr.h>
+#include <stm32l0xx_ll_rcc.h>
+#include <stm32l0xx_ll_system.h>
+#include <clock_control/clock_stm32_ll_common.h>
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Select MSI as wake-up system clock if configured, HSI otherwise */
+#if STM32_SYSCLK_SRC_MSI
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_MSI
+#else
+#define RCC_STOP_WAKEUPCLOCK_SELECTED LL_RCC_STOP_WAKEUPCLOCK_HSI
+#endif
+
+/* Invoke Low Power/System Off specific Tasks */
+void pm_power_state_set(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		LL_RCC_SetClkAfterWakeFromStop(RCC_STOP_WAKEUPCLOCK_SELECTED);
+		LL_PWR_ClearFlag_WU();
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP);
+		LL_PWR_SetRegulModeLP(LL_PWR_REGU_LPMODES_LOW_POWER);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+	case PM_STATE_SOFT_OFF:
+		LL_PWR_ClearFlag_WU();
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+	default:
+		LOG_DBG("Unsupported power state %u", info.state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void pm_power_state_exit_post_ops(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		LL_LPM_DisableSleepOnExit();
+		LL_LPM_EnableSleep();
+
+		/* Restore the clock setup. */
+		stm32_clock_control_init(NULL);
+		break;
+	case PM_STATE_SOFT_OFF:
+		/* Nothing to do. */
+		break;
+	default:
+		LOG_DBG("Unsupported power substate-id %u", info.state);
+		break;
+	}
+
+	/*
+	 * System is now in active mode. Reenable interrupts which were
+	 * disabled when OS started idling code.
+	 */
+	irq_unlock(0);
+}
+
+/* Initialize STM32 Power */
+static int stm32_power_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/* Enable Power clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+#ifdef CONFIG_DEBUG
+	/* Enable the Debug Module during STOP mode */
+	LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Hi, this adds low power support for the STM32L0 family. Tested this against the LoRaWAN stack on a custom board based on the CMWX1ZZABZ, seems to work fine, the CPU power consumption goes in the microamps between cycles.

Standby (soft off) can be entered with pm_power_state_force() and seems to work fine as well, tested with both the RTC and the wakeup pin, which need to be enabled  by the application with LL_PWR_EnableWakeUpPin().