### PR TITLE
drivers: flash_stm32_v1: fix a potential unaligned access

### DIFF
--- a/drivers/flash/flash_stm32_v1.c
+++ b/drivers/flash/flash_stm32_v1.c
@@ -210,11 +210,13 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 			    const void *data, unsigned int len)
 {
 	int i, rc = 0;
-	const flash_prg_t *values = (const flash_prg_t *)data;
+	flash_prg_t value;
 
 	for (i = 0; i < len / sizeof(flash_prg_t); i++) {
-		rc = write_value(dev, offset + i * sizeof(flash_prg_t),
-				 values[i]);
+		memcpy(&value,
+		       (const uint8_t *)data + i * sizeof(flash_prg_t),
+		       sizeof(flash_prg_t));
+		rc = write_value(dev, offset + i * sizeof(flash_prg_t), value);
 		if (rc < 0) {
 			return rc;
 		}


### PR DESCRIPTION
Hi, found an alignment problem triggering a hardfault while messing with the settings framework backed by NVS on an STM32L072. If a string with the setting name is constant and stored in flash, its address makes it through the flash_stm32_write_range() call, and it may not be aligned correctly for the flash_prg_t storage size, causing a fault (on M0 specifically).

Using a temporary variable on the stack fixes the problem.