### PR TITLE
drivers: can: mcan: add missing devicetree property for event fifo depth

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -151,7 +151,7 @@ struct can_mcan_msg_sram {
 	volatile struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
-	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_BUF_ELEMENTS];
+	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
 	volatile struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
 } __packed;
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -355,6 +355,7 @@
 			rx-fifo1-elements = <3>;
 			rx-buffer-elements = <0>;
 			tx-buffer-elements = <3>;
+			tx-event-fifo-elements = <3>;
 
 			can1: can@40006400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/bindings/can/bosch,m-can-base.yaml
+++ b/dts/bindings/can/bosch,m-can-base.yaml
@@ -26,3 +26,7 @@ properties:
     tx-buffer-elements:
       type: int
       required: true
+
+    tx-event-fifo-elements:
+      type: int
+      required: true


### PR DESCRIPTION
Add missing devicetree property for the Bosch M-CAN Tx Event FIFO depth.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>