### PR TITLE
logging: dictionary format output to file

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -309,6 +309,31 @@ config LOG_BACKEND_FS
 
 if LOG_BACKEND_FS
 
+config LOG_BACKEND_FS_OUTPUT_DICTIONARY
+	bool
+	depends on LOG2
+	select LOG_DICTIONARY_SUPPORT
+	help
+	  FS backend is in dictionary-based logging output mode.
+
+choice
+	prompt "FS Backend Output Mode"
+	default LOG_BACKEND_FS_OUTPUT_TEXT
+
+config LOG_BACKEND_FS_OUTPUT_TEXT
+	bool "Text"
+	help
+	  Output in text.
+
+config LOG_BACKEND_FS_OUTPUT_DICTIONARY_BIN
+	bool "Dictionary (binary)"
+	depends on LOG2
+	select LOG_BACKEND_FS_OUTPUT_DICTIONARY
+	help
+	  Dictionary-based logging output in binary.
+
+endchoice
+
 config LOG_BACKEND_FS_OVERWRITE
 	bool "Enable old log files overwrite"
 	default y

--- a/subsys/logging/log_backend_fs.c
+++ b/subsys/logging/log_backend_fs.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <logging/log_backend.h>
+#include <logging/log_output_dict.h>
 #include <logging/log_backend_std.h>
 #include <assert.h>
 #include <fs/fs.h>
@@ -432,7 +433,7 @@ static void put(const struct log_backend *const backend,
 	log_backend_std_put(&log_output, 0, msg);
 }
 
-static void log_backend_fs_init(void)
+static void log_backend_fs_init(const struct log_backend *const backend)
 {
 }
 
@@ -448,10 +449,28 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 {
 	ARG_UNUSED(backend);
 
-	log_backend_std_dropped(&log_output, cnt);
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_FS_OUTPUT_DICTIONARY)) {
+		log_dict_output_dropped_process(&log_output, cnt);
+	} else {
+		log_backend_std_dropped(&log_output, cnt);
+	}
+}
+
+static void process(const struct log_backend *const backend,
+		union log_msg2_generic *msg)
+{
+	uint32_t flags = log_backend_std_get_flags();
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_FS_OUTPUT_DICTIONARY)) {
+		log_dict_output_msg2_process(&log_output,
+					     &msg->log, flags);
+	} else {
+		log_output_msg2_process(&log_output, &msg->log, flags);
+	}
 }
 
 static const struct log_backend_api log_backend_fs_api = {
+	.process = IS_ENABLED(CONFIG_LOG2) ? process : NULL,
 	.put = put,
 	.put_sync_string = NULL,
 	.put_sync_hexdump = NULL,


### PR DESCRIPTION
Add the option to send logs to fs backend using new dictionary
formatting.
This can result in much better use of filesystem space

Signed-off-by: Elliot Revell-Nash <elliot.revellnash@wdtl.com>