### PR TITLE
scripts: dts: Produce error for invalid yaml

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -334,7 +334,7 @@ class EDT:
                 # representing the file)
                 raw = yaml.load(contents, Loader=_BindingLoader)
             except yaml.YAMLError as e:
-                _LOG.warning(
+                _err(
                         f"'{binding_path}' appears in binding directories "
                         f"but isn't valid YAML: {e}")
                 continue


### PR DESCRIPTION
I made an alignment error in a dts binding, but the build was successful. After
Some debugging I found the following warning explaining the problem:

    '/home/casper/src/zephyrproject/zephyr/dts/bindings/gpio/gpio-keys.yaml' appears in binding directories but isn't valid YAML: while parsing a block mapping
      in "<unicode string>", line 11, column 8
    did not find expected key
      in "<unicode string>", line 18, column 9

I think this should be an error as there shouldn't be any invalid yaml.

Signed-off-by: Casper Meijn <casper@meijn.net>