### PR TITLE
bluetooth: ots: Add object name write capability

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -33,9 +33,6 @@ extern "C" {
 /** @brief Length of OTS object ID string (in bytes). */
 #define BT_OTS_OBJ_ID_STR_LEN 15
 
-/** @brief Maximum object name length */
-#define BT_OTS_OBJ_MAX_NAME_LEN 120
-
 /** @brief Type of an OTS object. */
 struct bt_ots_obj_type {
 	union {

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -31,7 +31,10 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_OTS_VAL)),
 };
 
-static uint8_t objects[OBJ_POOL_SIZE][OBJ_MAX_SIZE];
+static struct {
+	uint8_t data[OBJ_MAX_SIZE];
+	char name[CONFIG_BT_OTS_OBJ_MAX_NAME_LEN + 1];
+} objects[OBJ_POOL_SIZE];
 static uint32_t obj_cnt;
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -118,7 +121,7 @@ static uint32_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 		return 0;
 	}
 
-	*data = &objects[obj_index][offset];
+	*data = &objects[obj_index].data[offset];
 
 	/* Send even-indexed objects in 20 byte packets
 	 * to demonstrate fragmented transmission.
@@ -168,16 +171,17 @@ static int ots_init(void)
 	}
 
 	/* Prepare first object demo data and add it to the instance. */
-	for (uint32_t i = 0; i < sizeof(objects[0]); i++) {
-		objects[0][i] = i + 1;
+	for (uint32_t i = 0; i < sizeof(objects[0].data); i++) {
+		objects[0].data[i] = i + 1;
 	}
 
 	memset(&obj_init, 0, sizeof(obj_init));
-	obj_init.name = "first_object.txt";
+	strcpy(objects[0].name, "first_object.txt");
+	obj_init.name = objects[0].name;
 	obj_init.type.uuid.type = BT_UUID_TYPE_16;
 	obj_init.type.uuid_16.val = BT_UUID_OTS_TYPE_UNSPECIFIED_VAL;
-	obj_init.size.cur = sizeof(objects[0]);
-	obj_init.size.alloc = sizeof(objects[0]);
+	obj_init.size.cur = sizeof(objects[0].data);
+	obj_init.size.alloc = sizeof(objects[0].data);
 	BT_OTS_OBJ_SET_PROP_READ(obj_init.props);
 
 	err = bt_ots_obj_add(ots, &obj_init);
@@ -187,16 +191,17 @@ static int ots_init(void)
 	}
 
 	/* Prepare second object demo data and add it to the instance. */
-	for (uint32_t i = 0; i < sizeof(objects[1]); i++) {
-		objects[1][i] = i * 2;
+	for (uint32_t i = 0; i < sizeof(objects[1].data); i++) {
+		objects[1].data[i] = i * 2;
 	}
 
 	memset(&obj_init, 0, sizeof(obj_init));
-	obj_init.name = "second_object.gif";
+	strcpy(objects[1].name, "second_object.gif");
+	obj_init.name = objects[1].name;
 	obj_init.type.uuid.type = BT_UUID_TYPE_16;
 	obj_init.type.uuid_16.val = BT_UUID_OTS_TYPE_UNSPECIFIED_VAL;
-	obj_init.size.cur = sizeof(objects[1]);
-	obj_init.size.alloc = sizeof(objects[1]);
+	obj_init.size.cur = sizeof(objects[1].data);
+	obj_init.size.alloc = sizeof(objects[1].data);
 	BT_OTS_OBJ_SET_PROP_READ(obj_init.props);
 
 	err = bt_ots_obj_add(ots, &obj_init);

--- a/subsys/bluetooth/services/ots/Kconfig
+++ b/subsys/bluetooth/services/ots/Kconfig
@@ -59,6 +59,11 @@ config BT_OTS_L2CAP_CHAN_RX_MTU
 	default BT_BUF_ACL_RX_SIZE
 	range 21 BT_BUF_ACL_RX_SIZE
 
+config BT_OTS_OBJ_MAX_NAME_LEN
+	int "Maximum object name length"
+	default 120
+	range 1 120
+
 module = BT_OTS
 module-str = BT_OTS
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -44,7 +44,7 @@ static void dir_list_object_encode(struct bt_gatt_ots_object *obj,
 
 	/* Name length */
 	obj_name_len = strlen(obj->metadata.name);
-	__ASSERT(obj_name_len > 0 && obj_name_len <= BT_OTS_OBJ_MAX_NAME_LEN,
+	__ASSERT(obj_name_len > 0 && obj_name_len <= CONFIG_BT_OTS_OBJ_MAX_NAME_LEN,
 		 "Dir list object len is incorrect %zu", len);
 	net_buf_simple_add_u8(net_buf, obj_name_len);
 
@@ -220,9 +220,9 @@ void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager)
 
 	__ASSERT(*dir_list, "Could not assign Directory Listing Object");
 
-	__ASSERT(strlen(dir_list_obj_name) <= BT_OTS_OBJ_MAX_NAME_LEN,
+	__ASSERT(strlen(dir_list_obj_name) <= CONFIG_BT_OTS_OBJ_MAX_NAME_LEN,
 		 "BT_OTS_DIR_LIST_OBJ_NAME shall be less than %u octets",
-		 BT_OTS_OBJ_MAX_NAME_LEN);
+		 CONFIG_BT_OTS_OBJ_MAX_NAME_LEN);
 
 	err = bt_gatt_ots_obj_manager_obj_add(obj_manager, &dir_list_obj);
 


### PR DESCRIPTION
Add the ability to perform a write on the object name GATT
Characteristic.

In order for this operation to work the memory backing the
object name must be modifiable. To prevent forcing the user
to always allocate 120 bytes for the name, the maximum name
length is changed from a define to a configuration parameter.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>