### PR TITLE
drivers: ethernet: enc424j600: Add config get support for driver

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 2016 Intel Corporation
  * Copyright (c) 2019 PHYTEC Messtechnik GmbH
+ * Copyright (c) 2021 Laird Connectivity
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -498,6 +499,54 @@ static void enc424j600_rx_thread(struct enc424j600_runtime *context)
 	}
 }
 
+static int enc424j600_get_config(const struct device *dev,
+				 enum ethernet_config_type type,
+				 struct ethernet_config *config)
+{
+	uint16_t tmp;
+	int rc = 0;
+	struct enc424j600_runtime *context = dev->data;
+
+	if (type != ETHERNET_CONFIG_TYPE_LINK &&
+	    type != ETHERNET_CONFIG_TYPE_DUPLEX) {
+		/* Unsupported configuration query */
+		return -ENOTSUP;
+	}
+
+	k_sem_take(&context->tx_rx_sem, K_FOREVER);
+
+	if (type == ETHERNET_CONFIG_TYPE_LINK) {
+		/* Query active link speed */
+		enc424j600_read_phy(dev, ENC424J600_PSFR_PHSTAT3, &tmp);
+
+		if (tmp & ENC424J600_PHSTAT3_SPDDPX_100) {
+			/* 100Mbps link speed */
+			config->l.link_100bt = true;
+		} else if (tmp & ENC424J600_PHSTAT3_SPDDPX_10) {
+			/* 10Mbps link speed */
+			config->l.link_10bt = true;
+		} else {
+			/* Unknown link speed */
+			rc = -EINVAL;
+		}
+	} else if (type == ETHERNET_CONFIG_TYPE_DUPLEX) {
+		/* Query if half or full duplex */
+		enc424j600_read_phy(dev, ENC424J600_PSFR_PHSTAT3, &tmp);
+
+		/* Assume operating in half duplex mode */
+		config->full_duplex = false;
+
+		if (tmp & ENC424J600_PHSTAT3_SPDDPX_FD) {
+			/* Operating in full duplex mode */
+			config->full_duplex = true;
+		}
+	}
+
+	k_sem_give(&context->tx_rx_sem);
+
+	return rc;
+}
+
 static enum ethernet_hw_caps enc424j600_get_capabilities(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -592,7 +641,7 @@ static int enc424j600_stop_device(const struct device *dev)
 
 static const struct ethernet_api api_funcs = {
 	.iface_api.init		= enc424j600_iface_init,
-
+	.get_config		= enc424j600_get_config,
 	.get_capabilities	= enc424j600_get_capabilities,
 	.send			= enc424j600_tx,
 	.start			= enc424j600_start_device,


### PR DESCRIPTION
This allows the current speed of the connection (100Mbps/10Mbps) and
if it is operating in half or full duplex to be queried

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>