### PR TITLE
tests: drivers: watchdog: Pause during debugging

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -199,7 +199,7 @@ static int test_wdt_no_callback(void)
 		TC_PRINT("Watchdog install error\n");
 	}
 
-	err = wdt_setup(wdt, 0);
+	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 	}
@@ -252,7 +252,7 @@ static int test_wdt_callback_1(void)
 		return TC_FAIL;
 	}
 
-	err = wdt_setup(wdt, 0);
+	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 		return TC_FAIL;
@@ -312,7 +312,7 @@ static int test_wdt_callback_2(void)
 		return TC_FAIL;
 	}
 
-	err = wdt_setup(wdt, 0);
+	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 		return TC_FAIL;


### PR DESCRIPTION
Enable the option to pause the watchdog if the MCU is halted by a
debugger.

This is similar to https://github.com/zephyrproject-rtos/zephyr/pull/35484
fixes #35229