### PR TITLE
drivers: ieee802154: add support for secured transmission in nRF5

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -43,6 +43,10 @@ config NRF_802154_MULTIPROTOCOL_SUPPORT
 	  in the driver, this option must be enabled. Otherwise, the driver
 	  assumes that access to the radio peripheral is granted indefinitely.
 
+config NRF_802154_ENCRYPTION
+	bool "nRF 802.15.4 AES-CCM* authentication & encryption"
+	depends on !CRYPTO_NRF_ECB
+
 choice NRF_802154_CCA_MODE
 	prompt "nRF IEEE 802.15.4 CCA mode"
 	default NRF_802154_CCA_MODE_ED

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -68,6 +68,16 @@ target_compile_definitions(zephyr-802154-interface
     NRF_802154_ACK_TIMEOUT_ENABLED=1
 )
 
+if (CONFIG_NRF_802154_ENCRYPTION)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_ENCRYPTION_ENABLED=1)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_SECURITY_WRITER_ENABLED=1)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_IE_WRITER_ENABLED=1)
+else ()
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_ENCRYPTION_ENABLED=0)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_SECURITY_WRITER_ENABLED=0)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_IE_WRITER_ENABLED=0)
+endif()
+
 if (CONFIG_NRF_802154_CCA_MODE_ED)
   target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_CCA_MODE_DEFAULT=NRF_RADIO_CCA_MODE_ED)
 elseif (CONFIG_NRF_802154_CCA_MODE_CARRIER)


### PR DESCRIPTION
Configure radio driver with MAC key pairs and frame counter.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>