### PR TITLE
driver/uart: add parity enum element on devicetree bindings

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1568,7 +1568,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 		    .enr = DT_INST_CLOCKS_CELL(index, bits)		\
 	},								\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
-	.parity = DT_INST_PROP_OR(index, parity, UART_CFG_PARITY_NONE),	\
+	.parity = DT_ENUM_IDX_OR(DT_DRV_INST(index), parity, UART_CFG_PARITY_NONE),	\
 	.pinctrl_list = uart_pins_##index,				\
 	.pinctrl_list_size = ARRAY_SIZE(uart_pins_##index),		\
 };									\

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -14,13 +14,6 @@ properties:
     clocks:
       required: true
 
-    parity:
-      required: false
-      type: int
-      description: |
-        Configures the parity of the adapter. Value 0 for none, 1 for odd
-        and 2 for even parity.  Default to none if not specified.
-
     pinctrl-0:
       type: phandles
       required: false

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -11,13 +11,6 @@ properties:
     interrupts:
       required: true
 
-    parity:
-      required: false
-      type: int
-      description: |
-        Configures the parity of the adapter. Value 0 for none, 1 for odd
-        and 2 for even parity.  Default to none if not specified.
-
     pinctrl-0:
       type: phandles
       required: false

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -11,13 +11,6 @@ properties:
     interrupts:
       required: true
 
-    parity:
-      required: false
-      type: int
-      description: |
-        Configures the parity of the adapter. Value 0 for none, 1 for odd
-        and 2 for even parity.  Default to none if not specified.
-
     pinctrl-0:
       type: phandles
       required: false

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -19,3 +19,13 @@ properties:
       type: boolean
       required: false
       description: Set to enable RTS/CTS flow control at boot time
+    parity:
+      required: false
+      type: string
+      description: |
+        Configures the parity of the adapter. Enumeration id 0 for none, 1 for odd
+        and 2 for even parity. Default to none if not specified.
+      enum:
+        - "none"
+        - "odd"
+        - "even"


### PR DESCRIPTION
It helps configuring the parity mode for UART interface

Signed-off-by: Luc Viala <lviala@zaack.io>