### PR TITLE
drivers: ieee802154: include timestamp in acks

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -389,6 +389,15 @@ static int handle_ack(struct nrf5_802154_data *nrf5_radio)
 	net_pkt_set_ieee802154_lqi(ack_pkt, nrf5_radio->ack_frame.lqi);
 	net_pkt_set_ieee802154_rssi(ack_pkt, nrf5_radio->ack_frame.rssi);
 
+#if defined(CONFIG_NET_PKT_TIMESTAMP) && !defined(CONFIG_NRF_802154_SER_HOST)
+	struct net_ptp_time timestamp = {
+		.second = nrf5_radio->ack_frame.time / USEC_PER_SEC,
+		.nanosecond = (nrf5_radio->ack_frame.time % USEC_PER_SEC) * NSEC_PER_USEC
+	};
+
+	net_pkt_set_timestamp(ack_pkt, &timestamp);
+#endif
+
 	net_pkt_cursor_init(ack_pkt);
 
 	if (ieee802154_radio_handle_ack(nrf5_radio->iface, ack_pkt) != NET_OK) {
@@ -755,17 +764,21 @@ void nrf_802154_tx_ack_started(const uint8_t *data)
 				data[FRAME_PENDING_BYTE] & FRAME_PENDING_BIT;
 }
 
-void nrf_802154_transmitted_raw(const uint8_t *frame, uint8_t *ack,
-				int8_t power, uint8_t lqi)
+void nrf_802154_transmitted_timestamp_raw(const uint8_t *frame, uint8_t *ack,
+				int8_t power, uint8_t lqi, uint32_t ack_time)
 {
 	ARG_UNUSED(frame);
-	ARG_UNUSED(power);
-	ARG_UNUSED(lqi);
+	ARG_UNUSED(ack_time);
 
 	nrf5_data.tx_result = NRF_802154_TX_ERROR_NONE;
 	nrf5_data.ack_frame.psdu = ack;
 	nrf5_data.ack_frame.rssi = power;
 	nrf5_data.ack_frame.lqi = lqi;
+
+#if defined(CONFIG_NET_PKT_TIMESTAMP) && !defined(CONFIG_NRF_802154_SER_HOST)
+	nrf5_data.ack_frame.time =
+		nrf_802154_first_symbol_timestamp_get(ack_time, nrf5_data.ack_frame.psdu[0]);
+#endif
 
 	k_sem_give(&nrf5_data.tx_wait);
 }

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -157,6 +157,13 @@ enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 	ack_frame.mInfo.mRxInfo.mLqi = net_pkt_ieee802154_lqi(pkt);
 	ack_frame.mInfo.mRxInfo.mRssi = net_pkt_ieee802154_rssi(pkt);
 
+#if defined(CONFIG_NET_PKT_TIMESTAMP)
+	struct net_ptp_time *pkt_time = net_pkt_timestamp(pkt);
+
+	ack_frame.mInfo.mRxInfo.mTimestamp =
+		pkt_time->second * USEC_PER_SEC + pkt_time->nanosecond / NSEC_PER_USEC;
+#endif
+
 	return NET_OK;
 }
 
@@ -326,10 +333,10 @@ static void openthread_handle_received_frame(otInstance *instance,
 	recv_frame.mInfo.mRxInfo.mAckedWithFramePending = net_pkt_ieee802154_ack_fpb(pkt);
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
-	struct net_ptp_time *time = net_pkt_timestamp(pkt);
+	struct net_ptp_time *pkt_time = net_pkt_timestamp(pkt);
 
 	recv_frame.mInfo.mRxInfo.mTimestamp =
-		time->second * USEC_PER_SEC + time->nanosecond / NSEC_PER_USEC;
+		pkt_time->second * USEC_PER_SEC + pkt_time->nanosecond / NSEC_PER_USEC;
 #endif
 
 #if defined(CONFIG_IEEE802154_2015)


### PR DESCRIPTION
Fill the ACK timestamp field in nRF5 driver. This is required by OpenThread for the proper CSL transmitter functioning.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>