### PR TITLE
Bluetooth: Audio: AICS remove need for bt_conn pointer

### DIFF
--- a/include/bluetooth/audio/aics.h
+++ b/include/bluetooth/audio/aics.h
@@ -144,13 +144,11 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 /**
  * @brief Callback function for writes.
  *
- * @param conn         Connection to peer device, or NULL if local server write.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  */
-typedef void (*bt_aics_write_cb)(struct bt_conn *conn, struct bt_aics *inst,
-				 int err);
+typedef void (*bt_aics_write_cb)(struct bt_aics *inst, int err);
 
 /**
  * @brief Callback function for the input state.
@@ -158,7 +156,6 @@ typedef void (*bt_aics_write_cb)(struct bt_conn *conn, struct bt_aics *inst,
  * Called when the value is read,
  * or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
@@ -167,9 +164,8 @@ typedef void (*bt_aics_write_cb)(struct bt_conn *conn, struct bt_aics *inst,
  * @param mute         The mute value.
  * @param mode         The mode value.
  */
-typedef void (*bt_aics_state_cb)(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, int8_t gain, uint8_t mute,
-				 uint8_t mode);
+typedef void (*bt_aics_state_cb)(struct bt_aics *inst, int err, int8_t gain,
+				 uint8_t mute, uint8_t mode);
 
 /**
  * @brief Callback function for the gain settings.
@@ -177,7 +173,6 @@ typedef void (*bt_aics_state_cb)(struct bt_conn *conn, struct bt_aics *inst,
  * Called when the value is read,
  * or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
@@ -187,8 +182,7 @@ typedef void (*bt_aics_state_cb)(struct bt_conn *conn, struct bt_aics *inst,
  * @param minimum      The minimum gain allowed for the gain setting.
  * @param maximum      The maximum gain allowed for the gain setting.
  */
-typedef void (*bt_aics_gain_setting_cb)(struct bt_conn *conn,
-					struct bt_aics *inst, int err,
+typedef void (*bt_aics_gain_setting_cb)(struct bt_aics *inst, int err,
 					uint8_t units, int8_t minimum,
 					int8_t maximum);
 
@@ -197,45 +191,39 @@ typedef void (*bt_aics_gain_setting_cb)(struct bt_conn *conn,
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  * @param type   The input type.
  */
-typedef void (*bt_aics_type_cb)(struct bt_conn *conn, struct bt_aics *inst,
-				int err, uint8_t type);
+typedef void (*bt_aics_type_cb)(struct bt_aics *inst, int err, uint8_t type);
 
 /**
  * @brief Callback function for the input status.
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  * @param active       Whether the instance is active or inactive.
  */
-typedef void (*bt_aics_status_cb)(struct bt_conn *conn, struct bt_aics *inst,
-				  int err, bool active);
+typedef void (*bt_aics_status_cb)(struct bt_aics *inst, int err, bool active);
 
 /**
  * @brief Callback function for the description.
  *
  * Called when the value is read, or if the value is changed by either the server or client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  * @param description  The description as an UTF-8 encoded string (may have been clipped).
  */
-typedef void (*bt_aics_description_cb)(struct bt_conn *conn,
-				       struct bt_aics *inst, int err,
+typedef void (*bt_aics_description_cb)(struct bt_aics *inst, int err,
 				       char *description);
 
 /**
@@ -244,14 +232,12 @@ typedef void (*bt_aics_description_cb)(struct bt_conn *conn,
  * This callback will usually be overwritten by the primary service that
  * includes the Audio Input Control Service client.
  *
- * @param conn         Connection to peer device, or NULL if local server read.
  * @param inst         The instance pointer.
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
  */
-typedef void (*bt_aics_discover_cb)(struct bt_conn *conn, struct bt_aics *inst,
-				    int err);
+typedef void (*bt_aics_discover_cb)(struct bt_aics *inst, int err);
 
 struct bt_aics_cb {
 	bt_aics_state_cb                 state;
@@ -314,116 +300,104 @@ int bt_aics_activate(struct bt_aics *inst);
 /**
  * @brief Read the Audio Input Control Service input state.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_state_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_state_get(struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service gain settings.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_gain_setting_get(struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input type.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_type_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_type_get(struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input status.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_status_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_status_get(struct bt_aics *inst);
 
 /**
  * @brief Unmute the Audio Input Control Service input.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_unmute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_unmute(struct bt_aics *inst);
 
 /**
  * @brief Mute the Audio Input Control Service input.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_mute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_mute(struct bt_aics *inst);
 
 /**
  * @brief Set input gain to manual.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_manual_gain_set(struct bt_aics *inst);
 
 /**
  * @brief Set the input gain to automatic.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_automatic_gain_set(struct bt_aics *inst);
 
 /**
  * @brief Set the input gain.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          The instance pointer.
  * @param gain          The gain to set (-128 to 127) in gain setting units
  *                      (see @ref bt_aics_gain_setting_cb).
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t gain);
+int bt_aics_gain_set(struct bt_aics *inst, int8_t gain);
 
 /**
  * @brief Read the Audio Input Control Service description.
  *
- * @param conn          Connection to peer device, or NULL to read local server value.
  * @param inst          The instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_description_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_aics_description_get(struct bt_aics *inst);
 
 /**
  * @brief Set the Audio Input Control Service description.
  *
- * @param conn          Connection to peer device, or NULL to set local server value.
  * @param inst          The instance pointer.
  * @param description   The description as an UTF-8 encoded string.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
-			    const char *description);
+int bt_aics_description_set(struct bt_aics *inst, const char *description);
 
 /**
  * @brief Get a new Audio Input Control Service client instance.

--- a/include/bluetooth/audio/aics.h
+++ b/include/bluetooth/audio/aics.h
@@ -132,6 +132,19 @@ struct bt_aics *bt_aics_free_instance_get(void);
 void *bt_aics_svc_decl_get(struct bt_aics *aics);
 
 /**
+ * @brief Get the connection pointer of a client instance
+ *
+ * Get the Bluetooth connection pointer of a Audio Input Control Service
+ * client instance.
+ *
+ * @param aics    Audio Input Control Service client instance pointer.
+ * @param conn    Connection pointer.
+ *
+ * @return 0 if success, errno on failure.
+ */
+int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn);
+
+/**
  * @brief Initialize the Audio Input Control Service instance.
  *
  * @param aics      Audio Input Control Service instance.

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -270,8 +270,8 @@ static ssize_t write_aics_control(struct bt_conn *conn,
 				    sizeof(inst->srv.state));
 
 		if (inst->srv.cb && inst->srv.cb->state) {
-			inst->srv.cb->state(NULL, (struct bt_aics *)inst, 0,
-					inst->srv.state.gain, inst->srv.state.mute,
+			inst->srv.cb->state(inst, 0, inst->srv.state.gain,
+					inst->srv.state.mute,
 					inst->srv.state.gain_mode);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
@@ -312,8 +312,8 @@ static ssize_t write_description(struct bt_conn *conn,
 				    strlen(inst->srv.description));
 
 		if (inst->srv.cb && inst->srv.cb->description) {
-			inst->srv.cb->description(NULL, (struct bt_aics *)inst, 0,
-					      inst->srv.description);
+			inst->srv.cb->description(inst, 0,
+						  inst->srv.description);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
 		}
@@ -499,7 +499,7 @@ int bt_aics_deactivate(struct bt_aics *inst)
 				    sizeof(inst->srv.status));
 
 		if (inst->srv.cb && inst->srv.cb->status) {
-			inst->srv.cb->status(NULL, inst, 0, inst->srv.status);
+			inst->srv.cb->status(inst, 0, inst->srv.status);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
 		}
@@ -525,7 +525,7 @@ int bt_aics_activate(struct bt_aics *inst)
 				    sizeof(inst->srv.status));
 
 		if (inst->srv.cb && inst->srv.cb->status) {
-			inst->srv.cb->status(NULL, inst, 0, inst->srv.status);
+			inst->srv.cb->status(inst, 0, inst->srv.status);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
 		}
@@ -536,18 +536,18 @@ int bt_aics_activate(struct bt_aics *inst)
 
 #endif /* CONFIG_BT_AICS */
 
-int bt_aics_state_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_state_get(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_state_get(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_state_get(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		if (inst->srv.cb && inst->srv.cb->state) {
-			inst->srv.cb->state(NULL, inst, 0, inst->srv.state.gain,
+			inst->srv.cb->state(inst, 0, inst->srv.state.gain,
 					    inst->srv.state.mute,
 					    inst->srv.state.gain_mode);
 		} else {
@@ -559,18 +559,18 @@ int bt_aics_state_get(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_gain_setting_get(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_gain_setting_get(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_gain_setting_get(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		if (inst->srv.cb && inst->srv.cb->gain_setting) {
-			inst->srv.cb->gain_setting(NULL, inst, 0,
+			inst->srv.cb->gain_setting(inst, 0,
 						   inst->srv.gain_settings.units,
 						   inst->srv.gain_settings.minimum,
 						   inst->srv.gain_settings.maximum);
@@ -583,18 +583,18 @@ int bt_aics_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_type_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_type_get(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_type_get(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_type_get(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		if (inst->srv.cb && inst->srv.cb->type) {
-			inst->srv.cb->type(NULL, inst, 0, inst->srv.type);
+			inst->srv.cb->type(inst, 0, inst->srv.type);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
 		}
@@ -604,18 +604,18 @@ int bt_aics_type_get(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_status_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_status_get(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_status_get(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_status_get(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		if (inst->srv.cb && inst->srv.cb->status) {
-			inst->srv.cb->status(NULL, inst, 0, inst->srv.status);
+			inst->srv.cb->status(inst, 0, inst->srv.status);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
 		}
@@ -625,16 +625,16 @@ int bt_aics_status_get(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_unmute(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_unmute(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_unmute(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_unmute(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		struct bt_aics_control cp;
 		int err;
@@ -652,16 +652,16 @@ int bt_aics_unmute(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_mute(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_mute(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_mute(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_mute(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		struct bt_aics_control cp;
 		int err;
@@ -679,16 +679,16 @@ int bt_aics_mute(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_manual_gain_set(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_manual_gain_set(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_manual_gain_set(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		struct bt_aics_control cp;
 		int err;
@@ -706,16 +706,16 @@ int bt_aics_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_automatic_gain_set(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_automatic_gain_set(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_automatic_gain_set(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		struct bt_aics_control cp;
 		int err;
@@ -733,16 +733,16 @@ int bt_aics_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t gain)
+int bt_aics_gain_set(struct bt_aics *inst, int8_t gain)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_gain_set(conn, inst, gain);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_gain_set(inst, gain);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		struct bt_aics_gain_control cp;
 		int err;
@@ -761,18 +761,18 @@ int bt_aics_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t gain)
 	return -ENOTSUP;
 }
 
-int bt_aics_description_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_description_get(struct bt_aics *inst)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_description_get(conn, inst);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_description_get(inst);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		if (inst->srv.cb && inst->srv.cb->description) {
-			inst->srv.cb->description(NULL, inst, 0,
+			inst->srv.cb->description(inst, 0,
 						  inst->srv.description);
 		} else {
 			BT_DBG("Callback not registered for instance %p", inst);
@@ -783,8 +783,7 @@ int bt_aics_description_get(struct bt_conn *conn, struct bt_aics *inst)
 	return -ENOTSUP;
 }
 
-int bt_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
-			    const char *description)
+int bt_aics_description_set(struct bt_aics *inst, const char *description)
 {
 	CHECKIF(!inst) {
 		BT_DBG("NULL instance");
@@ -796,9 +795,9 @@ int bt_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && conn) {
-		return bt_aics_client_description_set(conn, inst, description);
-	} else if (IS_ENABLED(CONFIG_BT_AICS) && !conn) {
+	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) && inst->client_instance) {
+		return bt_aics_client_description_set(inst, description);
+	} else if (IS_ENABLED(CONFIG_BT_AICS) && !inst->client_instance) {
 		struct bt_gatt_attr attr;
 		int err;
 

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -29,7 +29,7 @@
 
 static struct bt_aics aics_insts[CONFIG_BT_MAX_CONN * CONFIG_BT_AICS_CLIENT_MAX_INSTANCE_COUNT];
 
-static int aics_client_common_control(struct bt_conn *conn, uint8_t opcode, struct bt_aics *inst);
+static int aics_client_common_control(uint8_t opcode, struct bt_aics *inst);
 
 static struct bt_aics *lookup_aics_by_handle(struct bt_conn *conn, uint16_t handle)
 {
@@ -74,8 +74,9 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 			inst->cli.change_counter = state->change_counter;
 
 			if (inst->cli.cb && inst->cli.cb->state) {
-				inst->cli.cb->state(conn, inst, 0, state->gain,
-						    state->mute, state->gain_mode);
+				inst->cli.cb->state(inst, 0, state->gain,
+						    state->mute,
+						    state->gain_mode);
 			}
 		}
 	} else if (handle == inst->cli.status_handle) {
@@ -83,7 +84,7 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 			status = (uint8_t *)data;
 			BT_DBG("Inst %p: Status %u", inst, *status);
 			if (inst->cli.cb && inst->cli.cb->status) {
-				inst->cli.cb->status(conn, inst, 0, *status);
+				inst->cli.cb->status(inst, 0, *status);
 			}
 		}
 	} else if (handle == inst->cli.desc_handle) {
@@ -100,7 +101,7 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 		desc[length] = '\0';
 		BT_DBG("Inst %p: Input description: %s", inst, log_strdup(desc));
 		if (inst->cli.cb && inst->cli.cb->description) {
-			inst->cli.cb->description(conn, inst, 0, desc);
+			inst->cli.cb->description(inst, 0, desc);
 		}
 	}
 
@@ -128,7 +129,7 @@ static uint8_t aics_client_read_state_cb(struct bt_conn *conn, uint8_t err,
 	if (cb_err) {
 		BT_DBG("State read failed: %d", err);
 		if (inst->cli.cb && inst->cli.cb->state) {
-			inst->cli.cb->state(conn, inst, cb_err, 0, 0, 0);
+			inst->cli.cb->state(inst, cb_err, 0, 0, 0);
 		}
 		return BT_GATT_ITER_STOP;
 	}
@@ -151,7 +152,7 @@ static uint8_t aics_client_read_state_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (inst->cli.cb && inst->cli.cb->state) {
-		inst->cli.cb->state(conn, inst, cb_err, state->gain,
+		inst->cli.cb->state(inst, cb_err, state->gain,
 				    state->mute, state->gain_mode);
 	}
 
@@ -179,7 +180,7 @@ static uint8_t aics_client_read_gain_settings_cb(struct bt_conn *conn, uint8_t e
 	if (cb_err) {
 		BT_DBG("Gain settings read failed: %d", err);
 		if (inst->cli.cb && inst->cli.cb->gain_setting) {
-			inst->cli.cb->gain_setting(conn, inst, cb_err, 0, 0, 0);
+			inst->cli.cb->gain_setting(inst, cb_err, 0, 0, 0);
 		}
 		return BT_GATT_ITER_STOP;
 	}
@@ -198,8 +199,9 @@ static uint8_t aics_client_read_gain_settings_cb(struct bt_conn *conn, uint8_t e
 	}
 
 	if (inst->cli.cb && inst->cli.cb->gain_setting) {
-		inst->cli.cb->gain_setting(conn, inst, cb_err, gain_settings->units,
-					   gain_settings->minimum, gain_settings->maximum);
+		inst->cli.cb->gain_setting(inst, cb_err, gain_settings->units,
+					   gain_settings->minimum,
+					   gain_settings->maximum);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -226,7 +228,7 @@ static uint8_t aics_client_read_type_cb(struct bt_conn *conn, uint8_t err,
 	if (cb_err) {
 		BT_DBG("Type read failed: %d", err);
 		if (inst->cli.cb && inst->cli.cb->type) {
-			inst->cli.cb->type(conn, inst, cb_err, 0);
+			inst->cli.cb->type(inst, cb_err, 0);
 		}
 		return BT_GATT_ITER_STOP;
 	}
@@ -244,7 +246,7 @@ static uint8_t aics_client_read_type_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (inst->cli.cb && inst->cli.cb->type) {
-		inst->cli.cb->type(conn, inst, cb_err, *type);
+		inst->cli.cb->type(inst, cb_err, *type);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -271,7 +273,7 @@ static uint8_t aics_client_read_status_cb(struct bt_conn *conn, uint8_t err,
 	if (cb_err) {
 		BT_DBG("Status read failed: %d", err);
 		if (inst->cli.cb && inst->cli.cb->status) {
-			inst->cli.cb->status(conn, inst, cb_err, 0);
+			inst->cli.cb->status(inst, cb_err, 0);
 		}
 		return BT_GATT_ITER_STOP;
 	}
@@ -289,13 +291,13 @@ static uint8_t aics_client_read_status_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (inst->cli.cb && inst->cli.cb->status) {
-		inst->cli.cb->status(conn, inst, cb_err, *status);
+		inst->cli.cb->status(inst, cb_err, *status);
 	}
 
 	return BT_GATT_ITER_STOP;
 }
 
-static void aics_cp_notify_app(struct bt_conn *conn, struct bt_aics *inst, uint8_t err)
+static void aics_cp_notify_app(struct bt_aics *inst, uint8_t err)
 {
 	if (!inst->cli.cb) {
 		return;
@@ -304,27 +306,27 @@ static void aics_cp_notify_app(struct bt_conn *conn, struct bt_aics *inst, uint8
 	switch (inst->cli.cp_val.cp.opcode) {
 	case BT_AICS_OPCODE_SET_GAIN:
 		if (inst->cli.cb->set_gain) {
-			inst->cli.cb->set_gain(conn, inst, err);
+			inst->cli.cb->set_gain(inst, err);
 		}
 		break;
 	case BT_AICS_OPCODE_UNMUTE:
 		if (inst->cli.cb->unmute) {
-			inst->cli.cb->unmute(conn, inst, err);
+			inst->cli.cb->unmute(inst, err);
 		}
 		break;
 	case BT_AICS_OPCODE_MUTE:
 		if (inst->cli.cb->mute) {
-			inst->cli.cb->mute(conn, inst, err);
+			inst->cli.cb->mute(inst, err);
 		}
 		break;
 	case BT_AICS_OPCODE_SET_MANUAL:
 		if (inst->cli.cb->set_manual_mode) {
-			inst->cli.cb->set_manual_mode(conn, inst, err);
+			inst->cli.cb->set_manual_mode(inst, err);
 		}
 		break;
 	case BT_AICS_OPCODE_SET_AUTO:
 		if (inst->cli.cb->set_auto_mode) {
-			inst->cli.cb->set_auto_mode(conn, inst, err);
+			inst->cli.cb->set_auto_mode(inst, err);
 		}
 		break;
 	default:
@@ -363,11 +365,10 @@ static uint8_t internal_read_state_cb(struct bt_conn *conn, uint8_t err,
 			inst->cli.busy = false;
 
 			if (inst->cli.cp_val.cp.opcode == BT_AICS_OPCODE_SET_GAIN) {
-				write_err = bt_aics_client_gain_set(conn, inst,
+				write_err = bt_aics_client_gain_set(inst,
 								    inst->cli.cp_val.gain_setting);
 			} else {
-				write_err = aics_client_common_control(conn,
-								       inst->cli.cp_val.cp.opcode,
+				write_err = aics_client_common_control(inst->cli.cp_val.cp.opcode,
 								       inst);
 			}
 
@@ -382,7 +383,7 @@ static uint8_t internal_read_state_cb(struct bt_conn *conn, uint8_t err,
 
 	if (cb_err) {
 		inst->cli.busy = false;
-		aics_cp_notify_app(conn, inst, cb_err);
+		aics_cp_notify_app(inst, cb_err);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -432,17 +433,29 @@ static void aics_client_write_aics_cp_cb(struct bt_conn *conn, uint8_t err,
 	inst->cli.busy = false;
 	inst->cli.cp_retried = false;
 
-	aics_cp_notify_app(conn, inst, cb_err);
+	aics_cp_notify_app(inst, cb_err);
 }
 
-static int aics_client_common_control(struct bt_conn *conn, uint8_t opcode, struct bt_aics *inst)
+static int aics_client_common_control(uint8_t opcode, struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
 		BT_DBG("NULL conn");
 		return -EINVAL;
-	} else if (!inst->cli.control_handle) {
+	}
+
+	if (!inst->cli.control_handle) {
 		BT_DBG("Handle not set for opcode %u", opcode);
 		return -EINVAL;
 	} else if (inst->cli.busy) {
@@ -458,7 +471,7 @@ static int aics_client_common_control(struct bt_conn *conn, uint8_t opcode, stru
 	inst->cli.write_params.handle = inst->cli.control_handle;
 	inst->cli.write_params.func = aics_client_write_aics_cp_cb;
 
-	err = bt_gatt_write(conn, &inst->cli.write_params);
+	err = bt_gatt_write(inst->cli.conn, &inst->cli.write_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -487,7 +500,7 @@ static uint8_t aics_client_read_desc_cb(struct bt_conn *conn, uint8_t err,
 	if (cb_err) {
 		BT_DBG("Description read failed: %d", err);
 		if (inst->cli.cb && inst->cli.cb->description) {
-			inst->cli.cb->description(conn, inst, cb_err, NULL);
+			inst->cli.cb->description(inst, cb_err, NULL);
 		}
 		return BT_GATT_ITER_STOP;
 	}
@@ -511,7 +524,7 @@ static uint8_t aics_client_read_desc_cb(struct bt_conn *conn, uint8_t err,
 	BT_DBG("Input description: %s", log_strdup(desc));
 
 	if (inst->cli.cb && inst->cli.cb->description) {
-		inst->cli.cb->description(conn, inst, cb_err, desc);
+		inst->cli.cb->description(inst, cb_err, desc);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -530,8 +543,10 @@ static bool valid_inst_discovered(struct bt_aics *inst)
 static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				  struct bt_gatt_discover_params *params)
 {
-	struct bt_aics *inst = (struct bt_aics *)CONTAINER_OF(
-				params, struct bt_aics_client, discover_params);
+	struct bt_aics_client *client_inst = CONTAINER_OF(params,
+							  struct bt_aics_client,
+							  discover_params);
+	struct bt_aics *inst = CONTAINER_OF(client_inst, struct bt_aics, cli);
 
 	if (!attr) {
 		BT_DBG("Discovery complete for AICS %p", inst);
@@ -543,7 +558,7 @@ static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		if (inst->cli.cb && inst->cli.cb->discover) {
 			int err = valid_inst_discovered(inst) ? 0 : -ENOENT;
 
-			inst->cli.cb->discover(conn, inst, err);
+			inst->cli.cb->discover(inst, err);
 		}
 
 		return BT_GATT_ITER_STOP;
@@ -657,6 +672,7 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 	aics_client_reset(inst, conn);
 
 	(void)memset(&inst->cli.discover_params, 0, sizeof(inst->cli.discover_params));
+
 	inst->cli.conn = conn;
 	inst->cli.discover_params.start_handle = param->start_handle;
 	inst->cli.discover_params.end_handle = param->end_handle;
@@ -677,6 +693,7 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 {
 	for (int i = 0; i < ARRAY_SIZE(aics_insts); i++) {
 		if (!aics_insts[i].cli.active) {
+			aics_insts[i].client_instance = true;
 			aics_insts[i].cli.active = true;
 			return &aics_insts[i];
 		}
@@ -685,17 +702,22 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 	return NULL;
 }
 
-int bt_aics_client_state_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_state_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -710,7 +732,7 @@ int bt_aics_client_state_get(struct bt_conn *conn, struct bt_aics *inst)
 	inst->cli.read_params.handle_count = 1;
 	inst->cli.read_params.single.handle = inst->cli.state_handle;
 
-	err = bt_gatt_read(conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -718,17 +740,22 @@ int bt_aics_client_state_get(struct bt_conn *conn, struct bt_aics *inst)
 	return err;
 }
 
-int bt_aics_client_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_gain_setting_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -743,7 +770,7 @@ int bt_aics_client_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst)
 	inst->cli.read_params.handle_count = 1;
 	inst->cli.read_params.single.handle = inst->cli.gain_handle;
 
-	err = bt_gatt_read(conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -751,17 +778,22 @@ int bt_aics_client_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst)
 	return err;
 }
 
-int bt_aics_client_type_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_type_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -776,7 +808,7 @@ int bt_aics_client_type_get(struct bt_conn *conn, struct bt_aics *inst)
 	inst->cli.read_params.handle_count = 1;
 	inst->cli.read_params.single.handle = inst->cli.type_handle;
 
-	err = bt_gatt_read(conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -784,17 +816,22 @@ int bt_aics_client_type_get(struct bt_conn *conn, struct bt_aics *inst)
 	return err;
 }
 
-int bt_aics_client_status_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_status_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -809,7 +846,7 @@ int bt_aics_client_status_get(struct bt_conn *conn, struct bt_aics *inst)
 	inst->cli.read_params.handle_count = 1;
 	inst->cli.read_params.single.handle = inst->cli.status_handle;
 
-	err = bt_gatt_read(conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -817,37 +854,42 @@ int bt_aics_client_status_get(struct bt_conn *conn, struct bt_aics *inst)
 	return err;
 }
 
-int bt_aics_client_unmute(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_unmute(struct bt_aics *inst)
 {
-	return aics_client_common_control(conn, BT_AICS_OPCODE_UNMUTE, inst);
+	return aics_client_common_control(BT_AICS_OPCODE_UNMUTE, inst);
 }
 
-int bt_aics_client_mute(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_mute(struct bt_aics *inst)
 {
-	return aics_client_common_control(conn, BT_AICS_OPCODE_MUTE, inst);
+	return aics_client_common_control(BT_AICS_OPCODE_MUTE, inst);
 }
 
-int bt_aics_client_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_manual_gain_set(struct bt_aics *inst)
 {
-	return aics_client_common_control(conn, BT_AICS_OPCODE_SET_MANUAL, inst);
+	return aics_client_common_control(BT_AICS_OPCODE_SET_MANUAL, inst);
 }
 
-int bt_aics_client_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_automatic_gain_set(struct bt_aics *inst)
 {
-	return aics_client_common_control(conn, BT_AICS_OPCODE_SET_AUTO, inst);
+	return aics_client_common_control(BT_AICS_OPCODE_SET_AUTO, inst);
 }
 
-int bt_aics_client_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t gain)
+int bt_aics_client_gain_set(struct bt_aics *inst, int8_t gain)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -867,7 +909,7 @@ int bt_aics_client_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t g
 	inst->cli.write_params.handle = inst->cli.control_handle;
 	inst->cli.write_params.func = aics_client_write_aics_cp_cb;
 
-	err = bt_gatt_write(conn, &inst->cli.write_params);
+	err = bt_gatt_write(inst->cli.conn, &inst->cli.write_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -875,17 +917,22 @@ int bt_aics_client_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t g
 	return err;
 }
 
-int bt_aics_client_description_get(struct bt_conn *conn, struct bt_aics *inst)
+int bt_aics_client_description_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -900,7 +947,7 @@ int bt_aics_client_description_get(struct bt_conn *conn, struct bt_aics *inst)
 	inst->cli.read_params.handle_count = 1;
 	inst->cli.read_params.single.handle = inst->cli.desc_handle;
 
-	err = bt_gatt_read(conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
 	if (!err) {
 		inst->cli.busy = true;
 	}
@@ -908,16 +955,21 @@ int bt_aics_client_description_get(struct bt_conn *conn, struct bt_aics *inst)
 	return err;
 }
 
-int bt_aics_client_description_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_aics_client_description_set(struct bt_aics *inst,
 				   const char *description)
 {
-	CHECKIF(conn == NULL) {
-		BT_DBG("NULL conn");
+	CHECKIF(!inst) {
+		BT_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst) {
-		BT_DBG("NULL instance");
+	CHECKIF(!inst->client_instance) {
+		BT_DBG("Not a client instance instance");
+		return -EINVAL;
+	}
+
+	CHECKIF(inst->cli.conn == NULL) {
+		BT_DBG("NULL conn");
 		return -EINVAL;
 	}
 
@@ -931,7 +983,7 @@ int bt_aics_client_description_set(struct bt_conn *conn, struct bt_aics *inst,
 		return -EPERM;
 	}
 
-	return bt_gatt_write_without_response(conn, inst->cli.desc_handle,
+	return bt_gatt_write_without_response(inst->cli.conn, inst->cli.desc_handle,
 					      description, strlen(description),
 					      false);
 }

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -702,6 +702,28 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 	return NULL;
 }
 
+int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn)
+{
+	CHECKIF(aics == NULL) {
+		BT_DBG("NULL aics pointer");
+		return -EINVAL;
+	}
+
+	if (!aics->client_instance) {
+		BT_DBG("aics pointer shall be client instance");
+		return -EINVAL;
+	}
+
+	if (aics->cli.conn == NULL) {
+		BT_DBG("aics pointer not associated with a connection. "
+		       "Do discovery first");
+		return -ENOTCONN;
+	}
+
+	*conn = aics->cli.conn;
+	return 0;
+}
+
 int bt_aics_client_state_get(struct bt_aics *inst)
 {
 	int err;

--- a/subsys/bluetooth/audio/aics_internal.h
+++ b/subsys/bluetooth/audio/aics_internal.h
@@ -104,6 +104,7 @@ struct bt_aics_server {
 
 /* Struct used as a common type for the api */
 struct bt_aics {
+	bool client_instance;
 	union {
 		struct bt_aics_server srv;
 		struct bt_aics_client cli;
@@ -116,17 +117,17 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn,
 				   const void *data, uint16_t length);
 int bt_aics_client_register(struct bt_aics *inst);
 int bt_aics_client_unregister(struct bt_aics *inst);
-int bt_aics_client_state_get(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_type_get(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_status_get(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_unmute(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_mute(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_gain_set(struct bt_conn *conn, struct bt_aics *inst, int8_t gain);
-int bt_aics_client_description_get(struct bt_conn *conn, struct bt_aics *inst);
-int bt_aics_client_description_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_aics_client_state_get(struct bt_aics *inst);
+int bt_aics_client_gain_setting_get(struct bt_aics *inst);
+int bt_aics_client_type_get(struct bt_aics *inst);
+int bt_aics_client_status_get(struct bt_aics *inst);
+int bt_aics_client_unmute(struct bt_aics *inst);
+int bt_aics_client_mute(struct bt_aics *inst);
+int bt_aics_client_manual_gain_set(struct bt_aics *inst);
+int bt_aics_client_automatic_gain_set(struct bt_aics *inst);
+int bt_aics_client_gain_set(struct bt_aics *inst, int8_t gain);
+int bt_aics_client_description_get(struct bt_aics *inst);
+int bt_aics_client_description_set(struct bt_aics *inst,
 				   const char *description);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_AICS_INTERNAL_ */

--- a/subsys/bluetooth/audio/mics.c
+++ b/subsys/bluetooth/audio/mics.c
@@ -363,12 +363,12 @@ int bt_mics_aics_state_get(struct bt_mics *mics, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_state_get(mics->cli.conn, inst);
+		return bt_aics_state_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_state_get(NULL, inst);
+		return bt_aics_state_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -378,12 +378,12 @@ int bt_mics_aics_gain_setting_get(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_gain_setting_get(mics->cli.conn, inst);
+		return bt_aics_gain_setting_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_gain_setting_get(NULL, inst);
+		return bt_aics_gain_setting_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -393,12 +393,12 @@ int bt_mics_aics_type_get(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_type_get(mics->cli.conn, inst);
+		return bt_aics_type_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_type_get(NULL, inst);
+		return bt_aics_type_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -408,12 +408,12 @@ int bt_mics_aics_status_get(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_status_get(mics->cli.conn, inst);
+		return bt_aics_status_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_status_get(NULL, inst);
+		return bt_aics_status_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -422,12 +422,12 @@ int bt_mics_aics_unmute(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_unmute(mics->cli.conn, inst);
+		return bt_aics_unmute(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_unmute(NULL, inst);
+		return bt_aics_unmute(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -437,12 +437,12 @@ int bt_mics_aics_mute(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_mute(mics->cli.conn, inst);
+		return bt_aics_mute(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_mute(NULL, inst);
+		return bt_aics_mute(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -452,12 +452,12 @@ int bt_mics_aics_manual_gain_set(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_manual_gain_set(mics->cli.conn, inst);
+		return bt_aics_manual_gain_set(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_manual_gain_set(NULL, inst);
+		return bt_aics_manual_gain_set(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -467,12 +467,12 @@ int bt_mics_aics_automatic_gain_set(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_automatic_gain_set(mics->cli.conn, inst);
+		return bt_aics_automatic_gain_set(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_automatic_gain_set(NULL, inst);
+		return bt_aics_automatic_gain_set(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -483,12 +483,12 @@ int bt_mics_aics_gain_set(struct bt_mics *mics, struct bt_aics *inst,
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_gain_set(mics->cli.conn, inst, gain);
+		return bt_aics_gain_set(inst, gain);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_gain_set(NULL, inst, gain);
+		return bt_aics_gain_set(inst, gain);
 	}
 
 	return -EOPNOTSUPP;
@@ -498,12 +498,12 @@ int bt_mics_aics_description_get(struct bt_mics *mics, struct bt_aics *inst)
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_description_get(mics->cli.conn, inst);
+		return bt_aics_description_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_description_get(NULL, inst);
+		return bt_aics_description_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -514,13 +514,12 @@ int bt_mics_aics_description_set(struct bt_mics *mics, struct bt_aics *inst,
 {
 	if (IS_ENABLED(CONFIG_BT_MICS_CLIENT_AICS) &&
 	    bt_mics_client_valid_aics_inst(mics, inst)) {
-		return bt_aics_description_set(mics->cli.conn, inst,
-					       description);
+		return bt_aics_description_set(inst, description);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MICS_AICS) &&
 	    valid_aics_inst(mics, inst)) {
-		return bt_aics_description_set(NULL, inst, description);
+		return bt_aics_description_set(inst, description);
 	}
 
 	return -EOPNOTSUPP;

--- a/subsys/bluetooth/audio/vcs.c
+++ b/subsys/bluetooth/audio/vcs.c
@@ -828,11 +828,11 @@ int bt_vcs_aics_state_get(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_state_get(vcs->cli.conn, inst);
+		return bt_aics_state_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_state_get(NULL, inst);
+		return bt_aics_state_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -847,11 +847,11 @@ int bt_vcs_aics_gain_setting_get(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_gain_setting_get(vcs->cli.conn, inst);
+		return bt_aics_gain_setting_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_gain_setting_get(NULL, inst);
+		return bt_aics_gain_setting_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -866,11 +866,11 @@ int bt_vcs_aics_type_get(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_type_get(vcs->cli.conn, inst);
+		return bt_aics_type_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_type_get(NULL, inst);
+		return bt_aics_type_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -885,11 +885,11 @@ int bt_vcs_aics_status_get(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_status_get(vcs->cli.conn, inst);
+		return bt_aics_status_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_status_get(NULL, inst);
+		return bt_aics_status_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -904,11 +904,11 @@ int bt_vcs_aics_unmute(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_unmute(vcs->cli.conn, inst);
+		return bt_aics_unmute(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_unmute(NULL, inst);
+		return bt_aics_unmute(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -923,11 +923,11 @@ int bt_vcs_aics_mute(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_mute(vcs->cli.conn, inst);
+		return bt_aics_mute(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_mute(NULL, inst);
+		return bt_aics_mute(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -942,11 +942,11 @@ int bt_vcs_aics_manual_gain_set(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_manual_gain_set(vcs->cli.conn, inst);
+		return bt_aics_manual_gain_set(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_manual_gain_set(NULL, inst);
+		return bt_aics_manual_gain_set(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -961,11 +961,11 @@ int bt_vcs_aics_automatic_gain_set(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_automatic_gain_set(vcs->cli.conn, inst);
+		return bt_aics_automatic_gain_set(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_automatic_gain_set(NULL, inst);
+		return bt_aics_automatic_gain_set(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -981,11 +981,11 @@ int bt_vcs_aics_gain_set(struct bt_vcs *vcs, struct bt_aics *inst,
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_gain_set(vcs->cli.conn, inst, gain);
+		return bt_aics_gain_set(inst, gain);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_gain_set(NULL, inst, gain);
+		return bt_aics_gain_set(inst, gain);
 	}
 
 	return -EOPNOTSUPP;
@@ -1000,11 +1000,11 @@ int bt_vcs_aics_description_get(struct bt_vcs *vcs, struct bt_aics *inst)
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_description_get(vcs->cli.conn, inst);
+		return bt_aics_description_get(inst);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_description_get(NULL, inst);
+		return bt_aics_description_get(inst);
 	}
 
 	return -EOPNOTSUPP;
@@ -1020,11 +1020,11 @@ int bt_vcs_aics_description_set(struct bt_vcs *vcs, struct bt_aics *inst,
 
 	if (IS_ENABLED(CONFIG_BT_VCS_CLIENT_AICS) &&
 	    bt_vcs_client_valid_aics_inst(vcs, inst)) {
-		return bt_aics_description_set(vcs->cli.conn, inst, description);
+		return bt_aics_description_set(inst, description);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VCS_AICS) && valid_aics_inst(vcs, inst)) {
-		return bt_aics_description_set(NULL, inst, description);
+		return bt_aics_description_set(inst, description);
 	}
 
 	return -EOPNOTSUPP;

--- a/subsys/bluetooth/shell/mics.c
+++ b/subsys/bluetooth/shell/mics.c
@@ -28,9 +28,8 @@ static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 	}
 }
 
-static void mics_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, int8_t gain, uint8_t mute,
-			       uint8_t mode)
+static void mics_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			       uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS state get failed (%d) for "
@@ -41,8 +40,7 @@ static void mics_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 }
-static void mics_aics_gain_setting_cb(struct bt_conn *conn,
-				      struct bt_aics *inst, int err,
+static void mics_aics_gain_setting_cb(struct bt_aics *inst, int err,
 				      uint8_t units, int8_t minimum,
 				      int8_t maximum)
 {
@@ -56,8 +54,8 @@ static void mics_aics_gain_setting_cb(struct bt_conn *conn,
 	}
 
 }
-static void mics_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-				    int err, uint8_t input_type)
+static void mics_aics_input_type_cb(struct bt_aics *inst, int err,
+				    uint8_t input_type)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS input type get failed (%d) for "
@@ -68,8 +66,7 @@ static void mics_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 }
-static void mics_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, bool active)
+static void mics_aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS status get failed (%d) for "
@@ -80,8 +77,7 @@ static void mics_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 }
-static void mics_aics_description_cb(struct bt_conn *conn,
-				     struct bt_aics *inst, int err,
+static void mics_aics_description_cb(struct bt_aics *inst, int err,
 				     char *description)
 {
 	if (err != 0) {

--- a/subsys/bluetooth/shell/mics_client.c
+++ b/subsys/bluetooth/shell/mics_client.c
@@ -52,8 +52,7 @@ static void mics_unmute_write_cb(struct bt_mics *mics, int err)
 	}
 }
 
-static void mics_aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
-				  int err)
+static void mics_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
@@ -63,8 +62,7 @@ static void mics_aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void mics_aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err)
+static void mics_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
@@ -74,8 +72,7 @@ static void mics_aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void mics_aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst,
-			      int err)
+static void mics_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
@@ -85,9 +82,7 @@ static void mics_aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void mics_aics_set_manual_mode_cb(struct bt_conn *conn,
-					 struct bt_aics *inst,
-					 int err)
+static void mics_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -98,9 +93,7 @@ static void mics_aics_set_manual_mode_cb(struct bt_conn *conn,
 	}
 }
 
-static void mics_aics_automatic_mode_cb(struct bt_conn *conn,
-					struct bt_aics *inst,
-					int err)
+static void mics_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -121,9 +114,8 @@ static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 	}
 }
 
-static void mics_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, int8_t gain, uint8_t mute,
-			       uint8_t mode)
+static void mics_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			       uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS state get failed (%d) for "
@@ -135,8 +127,7 @@ static void mics_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
 
 }
 
-static void mics_aics_gain_setting_cb(struct bt_conn *conn,
-				      struct bt_aics *inst, int err,
+static void mics_aics_gain_setting_cb(struct bt_aics *inst, int err,
 				      uint8_t units, int8_t minimum,
 				      int8_t maximum)
 {
@@ -151,9 +142,8 @@ static void mics_aics_gain_setting_cb(struct bt_conn *conn,
 
 }
 
-static void mics_aics_input_type_cb(struct bt_conn *conn,
-				    struct bt_aics *inst,
-				    int err, uint8_t input_type)
+static void mics_aics_input_type_cb(struct bt_aics *inst, int err,
+				    uint8_t input_type)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS input type get failed (%d) for "
@@ -165,8 +155,7 @@ static void mics_aics_input_type_cb(struct bt_conn *conn,
 
 }
 
-static void mics_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, bool active)
+static void mics_aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS status get failed (%d) for "
@@ -178,8 +167,7 @@ static void mics_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
 
 }
 
-static void mics_aics_description_cb(struct bt_conn *conn,
-				     struct bt_aics *inst, int err,
+static void mics_aics_description_cb(struct bt_aics *inst, int err,
 				     char *description)
 {
 	if (err != 0) {

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -38,8 +38,8 @@ static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 	}
 }
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			  uint8_t mute, uint8_t mode)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -52,9 +52,8 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	}
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
+				 int8_t minimum, int8_t maximum)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -67,8 +66,8 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err,
+			       uint8_t input_type)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -80,8 +79,7 @@ static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			   bool active)
+static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -93,8 +91,8 @@ static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	}
 
 }
-static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, char *description)
+static void aics_description_cb(struct bt_aics *inst, int err,
+				char *description)
 {
 	if (err) {
 		shell_error(ctx_shell,

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -116,8 +116,7 @@ static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 }
 
 #if CONFIG_BT_VCS_CLIENT_MAX_AICS_INST > 0
-static void vcs_aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err)
+static void vcs_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
@@ -127,8 +126,7 @@ static void vcs_aics_set_gain_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err)
+static void vcs_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
@@ -138,8 +136,7 @@ static void vcs_aics_unmute_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst,
-			     int err)
+static void vcs_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
@@ -149,9 +146,7 @@ static void vcs_aics_mute_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_set_manual_mode_cb(struct bt_conn *conn,
-					struct bt_aics *inst,
-					int err)
+static void vcs_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -162,9 +157,7 @@ static void vcs_aics_set_manual_mode_cb(struct bt_conn *conn,
 	}
 }
 
-static void vcs_aics_automatic_mode_cb(struct bt_conn *conn,
-				       struct bt_aics *inst,
-				       int err)
+static void vcs_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -176,8 +169,8 @@ static void vcs_aics_automatic_mode_cb(struct bt_conn *conn,
 	}
 }
 
-static void vcs_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
-			      int err, int8_t gain, uint8_t mute, uint8_t mode)
+static void vcs_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			      uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "AICS state get failed (%d) for inst %p",
@@ -189,8 +182,8 @@ static void vcs_aics_state_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				     int err, uint8_t units, int8_t minimum,
+static void vcs_aics_gain_setting_cb(struct bt_aics *inst, int err,
+				     uint8_t units, int8_t minimum,
 				     int8_t maximum)
 {
 	if (err != 0) {
@@ -204,8 +197,8 @@ static void vcs_aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-				   int err, uint8_t input_type)
+static void vcs_aics_input_type_cb(struct bt_aics *inst, int err,
+				   uint8_t input_type)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -217,8 +210,7 @@ static void vcs_aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 }
 
-static void vcs_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, bool active)
+static void vcs_aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,
@@ -230,8 +222,8 @@ static void vcs_aics_status_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 }
-static void vcs_aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				    int err, char *description)
+static void vcs_aics_description_cb(struct bt_aics *inst, int err,
+				    char *description)
 {
 	if (err != 0) {
 		shell_error(ctx_shell,

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -235,6 +235,18 @@ static int test_aics(void)
 	uint8_t expected_mode;
 	uint8_t expected_input_type;
 	char expected_aics_desc[AICS_DESC_SIZE];
+	struct bt_conn *cached_conn;
+
+	printk("Getting AICS client conn\n");
+	err = bt_aics_client_conn_get(mics_included.aics[0], &cached_conn);
+	if (err != 0) {
+		FAIL("Could not get AICS client conn (err %d)\n", err);
+		return err;
+	}
+	if (cached_conn != g_conn) {
+		FAIL("Cached conn was not the conn used to discover");
+		return -ENOTCONN;
+	}
 
 	printk("Getting AICS state\n");
 	g_cb = false;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -40,8 +40,8 @@ static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
 static struct bt_conn *g_conn;
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			  uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
@@ -55,9 +55,8 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_cb = true;
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
+				 int8_t minimum, int8_t maximum)
 {
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
@@ -71,8 +70,8 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err,
+			       uint8_t input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -84,8 +83,7 @@ static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			   bool active)
+static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
@@ -97,8 +95,8 @@ static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_cb = true;
 }
 
-static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, char *description)
+static void aics_description_cb(struct bt_aics *inst, int err,
+				char *description)
 {
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
@@ -116,7 +114,7 @@ static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_write_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
+static void aics_write_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
 		FAIL("AICS write failed (%d)\n", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -44,8 +44,8 @@ static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 	g_cb = true;
 }
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			  uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
@@ -55,15 +55,11 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_aics_gain = gain;
 	g_aics_input_mute = mute;
 	g_aics_mode = mode;
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
+				 int8_t minimum, int8_t maximum)
 {
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
@@ -73,14 +69,11 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_aics_units = units;
 	g_aics_gain_min = minimum;
 	g_aics_gain_max = maximum;
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err,
+			       uint8_t input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -88,14 +81,10 @@ static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 	g_aics_input_type = input_type;
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			   bool active)
+static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
@@ -103,14 +92,11 @@ static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	}
 
 	g_aics_active = active;
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, char *description)
+static void aics_description_cb(struct bt_aics *inst, int err,
+				char *description)
 {
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
@@ -120,10 +106,7 @@ static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 
 	strncpy(g_aics_desc, description, sizeof(g_aics_desc) - 1);
 	g_aics_desc[sizeof(g_aics_desc) - 1] = '\0';
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
 static struct bt_mics_cb mics_cb = {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -308,6 +308,18 @@ static int test_aics(void)
 	uint8_t expected_mode;
 	uint8_t expected_input_type;
 	char expected_aics_desc[AICS_DESC_SIZE];
+	struct bt_conn *cached_conn;
+
+	printk("Getting AICS client conn\n");
+	err = bt_aics_client_conn_get(vcs_included.aics[0], &cached_conn);
+	if (err != 0) {
+		FAIL("Could not get AICS client conn (err %d)\n", err);
+		return err;
+	}
+	if (cached_conn != g_conn) {
+		FAIL("Cached conn was not the conn used to discover");
+		return -ENOTCONN;
+	}
 
 	printk("Getting AICS state\n");
 	g_cb = false;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -123,8 +123,8 @@ static void vocs_write_cb(struct bt_vocs *inst, int err)
 	g_write_complete = true;
 }
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			  uint8_t mute, uint8_t mode)
 {
 	if (err) {
 		FAIL("AICS state cb err (%d)", err);
@@ -138,9 +138,8 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_cb = true;
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
+				 int8_t minimum, int8_t maximum)
 {
 	if (err) {
 		FAIL("AICS gain setting cb err (%d)", err);
@@ -154,8 +153,8 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err,
+			       uint8_t input_type)
 {
 	if (err) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -167,8 +166,7 @@ static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			   bool active)
+static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err) {
 		FAIL("AICS status cb err (%d)", err);
@@ -180,8 +178,8 @@ static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_cb = true;
 }
 
-static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, char *description)
+static void aics_description_cb(struct bt_aics *inst, int err,
+				char *description)
 {
 	if (err) {
 		FAIL("AICS description cb err (%d)", err);
@@ -199,7 +197,7 @@ static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_cb = true;
 }
 
-static void aics_write_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
+static void aics_write_cb(struct bt_aics *inst, int err)
 {
 	if (err) {
 		FAIL("AICS write failed (%d)\n", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -103,8 +103,8 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 	g_cb = true;
 }
 
-static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			  int8_t gain, uint8_t mute, uint8_t mode)
+static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
+			  uint8_t mute, uint8_t mode)
 {
 	if (err) {
 		FAIL("AICS state cb err (%d)", err);
@@ -114,15 +114,11 @@ static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	g_aics_gain = gain;
 	g_aics_input_mute = mute;
 	g_aics_mode = mode;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
-				 int err, uint8_t units, int8_t minimum,
-				 int8_t maximum)
+static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
+				 int8_t minimum, int8_t maximum)
 {
 	if (err) {
 		FAIL("AICS gain setting cb err (%d)", err);
@@ -132,14 +128,11 @@ static void aics_gain_setting_cb(struct bt_conn *conn, struct bt_aics *inst,
 	g_aics_units = units;
 	g_aics_gain_min = minimum;
 	g_aics_gain_max = maximum;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
-			       int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err,
+			       uint8_t input_type)
 {
 	if (err) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -147,14 +140,10 @@ static void aics_input_type_cb(struct bt_conn *conn, struct bt_aics *inst,
 	}
 
 	g_aics_input_type = input_type;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
-			   bool active)
+static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err) {
 		FAIL("AICS status cb err (%d)", err);
@@ -162,14 +151,11 @@ static void aics_status_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
 	}
 
 	g_aics_active = active;
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
-static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
-				int err, char *description)
+static void aics_description_cb(struct bt_aics *inst, int err,
+				char *description)
 {
 	if (err) {
 		FAIL("AICS description cb err (%d)", err);
@@ -178,10 +164,7 @@ static void aics_description_cb(struct bt_conn *conn, struct bt_aics *inst,
 
 	strncpy(g_aics_desc, description, sizeof(g_aics_desc) - 1);
 	g_aics_desc[sizeof(g_aics_desc) - 1] = '\0';
-
-	if (!conn) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
 static struct bt_vcs_cb vcs_cb = {


### PR DESCRIPTION
Remove the bt_conn pointer from the AICS API, as the
instance pointer is enough to determine if it is a client
and perform client operations on the cached connection pointer.
    
Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>