### PR TITLE
dts/arm: st: g0: closes parenthesis for soc

### DIFF
--- a/dts/arm/st/g0/stm32g050.dtsi
+++ b/dts/arm/st/g0/stm32g050.dtsi
@@ -36,4 +36,5 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <7>;
 		};
+	};
 };


### PR DESCRIPTION
This commit adds a closing parenthesis, missing for soc model of stm32g050.
Resolves issue #36014

Signed-off-by: Bhavesh Bhojwani <bhaavesh.bhojwaani@gmail.com>