### PR TITLE
subsys: Bluetooth: controller: Fix wrong chan idx in iq samples report

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2658,7 +2658,7 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 	sep->rssi_ant_id = iq_report->rssi_ant_id;
 	sep->cte_type = iq_report->cte_info.type;
 
-	sep->chan_idx = lll->data_chan_id;
+	sep->chan_idx = iq_report->chan_idx;
 	sep->per_evt_counter = sys_cpu_to_le16(lll->event_counter);
 
 	if (sep->cte_type == BT_HCI_LE_AOA_CTE) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -171,14 +171,15 @@ void lll_df_conf_cte_tx_disable(void)
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 /* @brief Function initializes reception of Constant Tone Extension.
  *
- * @param[in] slot_duration     Switching and sampling slots duration (1us or 2us).
- * @param[in] ant_num           Number of antennas in switch pattern.
- * @param[in] ant_ids           Antenna identifiers that create switch pattern.
+ * @param slot_duration     Switching and sampling slots duration (1us or 2us).
+ * @param ant_num           Number of antennas in switch pattern.
+ * @param ant_ids           Antenna identifiers that create switch pattern.
+ * @param chan_idx          Channel used to receive PDU with CTE
  *
  * In case of AoA mode ant_num and ant_ids parameters are not used.
  */
-void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num,
-			       uint8_t *ant_ids)
+void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num, uint8_t *ant_ids,
+			       uint8_t chan_idx)
 {
 	struct node_rx_iq_report *node_rx;
 
@@ -202,6 +203,7 @@ void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num,
 	LL_ASSERT(node_rx);
 
 	radio_df_iq_data_packet_set(node_rx->pdu, IQ_SAMPLE_TOTAL_CNT);
+	node_rx->chan_idx = chan_idx;
 }
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
@@ -53,5 +53,5 @@ static inline uint8_t lll_df_sync_cfg_is_modified(struct lll_df_sync *df_cfg)
 }
 
 /* Enables CTE reception according to provided configuration */
-void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num,
-			       uint8_t *ant_ids);
+void lll_df_conf_cte_rx_enable(uint8_t slot_duration, uint8_t ant_num, uint8_t *ant_ids,
+			       uint8_t chan_idx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -70,6 +70,7 @@ struct node_rx_iq_report {
 	uint8_t local_slot_durations;
 	uint8_t packet_status;
 	uint8_t rssi_ant_id;
+	uint8_t chan_idx;
 	union {
 		uint8_t pdu[0] __aligned(4);
 		struct iq_sample sample[0];

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -175,9 +175,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	cfg = lll_df_sync_cfg_latest_get(&lll->df_cfg, NULL);
 
 	if (cfg->is_enabled) {
-		lll_df_conf_cte_rx_enable(cfg->slot_durations,
-					  cfg->ant_sw_len,
-					  cfg->ant_ids);
+		lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len, cfg->ant_ids,
+					  data_chan_use);
 		cfg->cte_count = 0;
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */


### PR DESCRIPTION
Fix wrong channel index send by controller in connectionless
IQ samples report. Former implementation reported value from
lll->data_chan_id which is not valid channel index.
Updated implementation reports value stored in IQ samples receive
node during periodic scanning event preparation.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>