### PR TITLE
Add missing net_buf_unref for non-recoverable errors while sending l2cap data

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -872,6 +872,8 @@ static void l2cap_chan_tx_process(struct k_work *work)
 		if (sent < 0) {
 			if (sent == -EAGAIN) {
 				ch->tx_buf = buf;
+			} else {
+				net_buf_unref(buf);
 			}
 			break;
 		}


### PR DESCRIPTION
In case the connection breaks while transmitting, the net_buf while be dequeued but not unreferenced.