### PR TITLE
allocate struct devices in ROM

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -22,21 +22,6 @@
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 
-	SECTION_DATA_PROLOGUE(devices,,)
-	{
-		/* link in devices objects, which are tied to the init ones;
-		 * the objects are thus sorted the same way as their init
-		 * object parent see include/device.h
-		 */
-		__device_start = .;
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)
-		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)
-		CREATE_OBJ_LEVEL(device, POST_KERNEL)
-		CREATE_OBJ_LEVEL(device, APPLICATION)
-		CREATE_OBJ_LEVEL(device, SMP)
-		__device_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 #if CONFIG_PM_DEVICE
 	SECTION_DATA_PROLOGUE(pm_device_slots, (NOLOAD),)
 	{

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -17,6 +17,21 @@
 		__init_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+	SECTION_PROLOGUE(devices,,)
+	{
+		/* Link in devices objects, which are tied to the init ones;
+		 * the objects are thus sorted the same way as their init
+		 * object parent. See above and include/device.h.
+		 */
+		__device_start = .;
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_1)
+		CREATE_OBJ_LEVEL(device, PRE_KERNEL_2)
+		CREATE_OBJ_LEVEL(device, POST_KERNEL)
+		CREATE_OBJ_LEVEL(device, APPLICATION)
+		CREATE_OBJ_LEVEL(device, SMP)
+		__device_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)
 	{


### PR DESCRIPTION
Move the linker sections where devices end up into ROM, saving RAM since the devices themselves are all const qualified and therefore should not be mutated.

Unless I'm missing something ...

Fixes: #36035

Results of:

```
$ west build -b nrf52840dk_nrf52840 samples/hello_world/
```

Without this patch:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       16860 B         1 MB      1.61%
            SRAM:        5600 B       256 KB      2.14%
        IDT_LIST:          0 GB         2 KB      0.00%
```

With this patch:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       16860 B         1 MB      1.61%
            SRAM:        5440 B       256 KB      2.08%
        IDT_LIST:          0 GB         2 KB      0.00%
```

5600B - 5440B is 160B savings.

There are 6 struct devices in this build. At 24 B each, that's 144B of expected savings. I'm assuming the remaining 16B is just due to saved padding.
