### PR TITLE
doc/guides/dts: bindings: Fix code snippet for 'signal-gpios'

### DIFF
--- a/doc/guides/dts/bindings.rst
+++ b/doc/guides/dts/bindings.rst
@@ -1013,6 +1013,8 @@ gpio_dt_spec``, then use it like this:
 
    #include <drivers/gpio.h>
 
+   #define ZEPHYR_USER_NODE DT_PATH(zephyr_user)
+
    const struct gpio_dt_spec signal =
            GPIO_DT_SPEC_GET(ZEPHYR_USER_NODE, signal_gpios);
 


### PR DESCRIPTION
Code snippet to demonstrate use of 'zephyr,user' binding
for gpio pin was missing a #define to easily get the code
compiling.
Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>