### PR TITLE
arch: arm64: Refine the assertion in arch_start_cpu

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -60,8 +60,8 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	uint64_t master_core_mpid;
 
 	/* Now it is on master core */
+	__ASSERT(arch_curr_cpu()->id == 0, "");
 	master_core_mpid = MPIDR_TO_CORE(GET_MPIDR());
-	__ASSERT(arm64_cpu_boot_params.mpid == master_core_mpid, "");
 
 	cpu_count = ARRAY_SIZE(cpu_node_list);
 	__ASSERT(cpu_count == CONFIG_MP_NUM_CPUS,
@@ -99,11 +99,6 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	if (pm_cpu_on(cpu_mpid, (uint64_t)&__start)) {
 		printk("Failed to boot secondary CPU core %d (MPID:%#llx)\n",
 		       cpu_num, cpu_mpid);
-		/*
-		 * If pm_cpu_on failed on core cpu_mpid, Primary core also
-		 * should prepare for up next core
-		 */
-		arm64_cpu_boot_params.mpid = master_core_mpid;
 		return;
 	}
 
@@ -111,8 +106,6 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	while (arm64_cpu_boot_params.fn) {
 		wfe();
 	}
-	/* Prepare for up next core */
-	arm64_cpu_boot_params.mpid = master_core_mpid;
 	printk("Secondary CPU core %d (MPID:%#llx) is up\n", cpu_num, cpu_mpid);
 }
 


### PR DESCRIPTION
When SMP enabled, the primary core calls arch_start_cpu to start
secondary cores. There is an assertion checking the core mpid to make
sure it is called by primary core.

But the checking is bogus. After the first secondary core is brought
up, `arm64_cpu_boot_params.mpid` will be changed, which will fail the
assertion.

The current solution restores the arm64_cpu_boot_params.mpid. #35652

However, using the `arch_curr_cpu()->id == 0` as the assertion will be
better. Suggested by @npitre at #35652

The _current_cpu->id will always fail assertion inside this macro
(`__ASSERT_NO_MSG(!z_smp_cpu_mobile()`), so I use `arch_curr_cpu()->id`
instead.

Signed-off-by: Jaxson Han <jaxson.han@arm.com>