### PR TITLE
doc: only enable -W option on CI

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: build-docs
       run: |
         source zephyr-env.sh
-        SPHINXOPTS="-q -j auto" make -C doc htmldocs
+        SPHINXOPTS="-q -W -j auto" make -C doc htmldocs
         tar cvf htmldocs.tar --directory=./doc/_build html
 
     - name: upload-build

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -240,7 +240,7 @@ set(SPHINX_BUILD_HTML_COMMAND
   ZEPHYR_BASE=${ZEPHYR_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
   DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-  ${SPHINXBUILD} -W -t ${DOC_TAG} -b html -c ${CMAKE_CURRENT_LIST_DIR} ${ALLSPHINXOPTS} ${RST_OUT} ${SPHINX_OUTPUT_DIR_HTML})
+  ${SPHINXBUILD} -t ${DOC_TAG} -b html -c ${CMAKE_CURRENT_LIST_DIR} ${ALLSPHINXOPTS} ${RST_OUT} ${SPHINX_OUTPUT_DIR_HTML})
 
 # The sphinx-html target is provided as a convenience for incremental
 # re-builds of content files without regenerating the entire docs
@@ -271,7 +271,7 @@ set(SPHINX_BUILD_LATEX_COMMAND
   ZEPHYR_BASE=${ZEPHYR_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
   DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-  ${SPHINXBUILD} -W -t ${DOC_TAG} -b latex -c ${CMAKE_CURRENT_LIST_DIR} -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT} ${SPHINX_OUTPUT_DIR_LATEX})
+  ${SPHINXBUILD} -t ${DOC_TAG} -b latex -c ${CMAKE_CURRENT_LIST_DIR} -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT} ${SPHINX_OUTPUT_DIR_LATEX})
 
 # The sphinx-latex target works similarly to sphinx-html, and carries
 # the same warnings.


### PR DESCRIPTION
The usage of -W may lead to the loss of the Sphinx build environment
even for small typos. Remove this option from the defaults but still
enable it on CI, where the fail-fast behavior given by -W is desired.

Fixes #36033