### PR TITLE
Bluetooth: Mesh: Align capitalization for BT mesh

### DIFF
--- a/boards/arm/nrf52840_mdk/doc/index.rst
+++ b/boards/arm/nrf52840_mdk/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The nRF52840-MDK is a versatile, easy-to-use IoT hardware platform for
-Bluetooth 5, Bluetooth Mesh, Thread, IEEE 802.15.4, ANT and 2.4GHz proprietary
+Bluetooth 5, Bluetooth mesh, Thread, IEEE 802.15.4, ANT and 2.4GHz proprietary
 applications using the nRF52840 SoC.
 
 The development kit comes with a fully integrated debugger (also known as

--- a/doc/guides/bluetooth/bluetooth-arch.rst
+++ b/doc/guides/bluetooth/bluetooth-arch.rst
@@ -248,7 +248,7 @@ Each role comes with its own build-time configuration option:
 connection-oriented roles central implicitly enables observer role, and
 peripheral implicitly enables broadcaster role. Usually the first step
 when creating an application is to decide which roles are needed and go
-from there. Bluetooth Mesh is a slightly special case, requiring at
+from there. Bluetooth mesh is a slightly special case, requiring at
 least the observer and broadcaster roles, and possibly also the
 Peripheral role. This will be described in more detail in a later
 section.
@@ -376,7 +376,7 @@ default, mesh requires both observer and broadcaster role to be enabled.
 If the optional GATT Proxy feature is desired, then peripheral role
 should also be enabled.
 
-The API reference for Mesh can be found in the
+The API reference for mesh can be found in the
 :ref:`Mesh API reference section <bluetooth_mesh>`.
 
 .. _bluetooth-persistent-storage:

--- a/doc/guides/bluetooth/overview.rst
+++ b/doc/guides/bluetooth/overview.rst
@@ -69,7 +69,7 @@ Bluetooth stack.
   * Non-volatile storage support for permanent storage of Bluetooth-specific
     settings and data
 
-  * Bluetooth Mesh support
+  * Bluetooth mesh support
 
     * Relay, Friend Node, Low-Power Node (LPN) and GATT Proxy features
     * Both Provisioning bearers supported (PB-ADV & PB-GATT)

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -120,8 +120,8 @@ Zephyr offers a large and ever growing number of features including:
 
 **Bluetooth Low Energy 5.0 support**
    Bluetooth 5.0 compliant (ESR10) and Bluetooth Low Energy Controller support
-   (LE Link Layer). Includes BLE Mesh and a Bluetooth qualification-ready BLE
-   controller.
+   (LE Link Layer). Includes Bluetooth mesh and a Bluetooth qualification-ready
+   Bluetooth controller.
 
    * Generic Access Profile (GAP) with all possible LE roles.
    * GATT (Generic Attribute Profile)

--- a/doc/reference/bluetooth/mesh.rst
+++ b/doc/reference/bluetooth/mesh.rst
@@ -3,11 +3,11 @@
 Bluetooth Mesh Profile
 ######################
 
-The Bluetooth Mesh Profile adds secure wireless multi-hop communication for
+The Bluetooth mesh profile adds secure wireless multi-hop communication for
 Bluetooth Low Energy. This module implements the
 `Bluetooth Mesh Profile Specification v1.0.1 <https://www.bluetooth.com/specifications/mesh-specifications/>`_.
 
-Read more about Bluetooth Mesh on the
+Read more about Bluetooth mesh on the
 `Bluetooth SIG Website <https://www.bluetooth.com/bluetooth-resources/?tags=mesh>`_.
 
 .. toctree::

--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -1,11 +1,11 @@
 .. _bluetooth_mesh_access:
 
-Access
-######
+Access layer
+############
 
-The Bluetooth Mesh access layer is the application's interface to the mesh
-network. The access layer provides mechanisms for compartmentalizing the node
-behavior into elements and models, which are implemented by the application.
+The access layer is the application's interface to the Bluetooth mesh network.
+The access layer provides mechanisms for compartmentalizing the node behavior
+into elements and models, which are implemented by the application.
 
 Mesh models
 ***********
@@ -29,7 +29,7 @@ behavior in the `Bluetooth Mesh Model Specification
 not specified by the Bluetooth SIG are vendor models, and must be tied to a
 Company ID.
 
-Mesh Models have several parameters that can be configured either through
+Mesh models have several parameters that can be configured either through
 initialization of the mesh stack or with the
 :ref:`bluetooth_mesh_models_cfg_srv`:
 
@@ -103,7 +103,7 @@ current state.
 Extended models
 ===============
 
-The Bluetooth Mesh specification allows the Mesh models to extend each other.
+The Bluetooth mesh specification allows the mesh models to extend each other.
 When a model extends another, it inherits that model's functionality, and
 extension can be used to construct complex models out of simple ones,
 leveraging the existing model functionality to avoid defining new opcodes.

--- a/doc/reference/bluetooth/mesh/cfg.rst
+++ b/doc/reference/bluetooth/mesh/cfg.rst
@@ -1,17 +1,16 @@
 .. _bluetooth_mesh_cfg:
 
-Runtime configuration
+Runtime Configuration
 #####################
 
-The Bluetooth Mesh runtime configuration API allows applications to change
-their runtime configuration directly, without going through the Configuration
-models.
+The runtime configuration API allows applications to change their runtime
+configuration directly, without going through the Configuration models.
 
-Bluetooth Mesh nodes should generally be configured by a central network
+Bluetooth mesh nodes should generally be configured by a central network
 configurator device with a :ref:`bluetooth_mesh_models_cfg_cli` model. Each
 mesh node instantiates a :ref:`bluetooth_mesh_models_cfg_srv` model that the
-Config Client can communicate with to change the node configuration. In some
-cases, the mesh node can't rely on the Config Client to detect or determine
+Configuration Client can communicate with to change the node configuration. In some
+cases, the mesh node can't rely on the Configuration Client to detect or determine
 local constraints, such as low battery power or changes in topology. For these
 scenarios, this API can be used to change the configuration locally.
 

--- a/doc/reference/bluetooth/mesh/cfg_cli.rst
+++ b/doc/reference/bluetooth/mesh/cfg_cli.rst
@@ -3,7 +3,7 @@
 Configuration Client
 ####################
 
-Configuration Client model is a foundation model defined by the Bluetooth Mesh
+The Configuration Client model is a foundation model defined by the Bluetooth mesh
 specification. It provides functionality for configuring most parameters of a
 mesh node, including encryption keys, model configuration and feature
 enabling.

--- a/doc/reference/bluetooth/mesh/cfg_srv.rst
+++ b/doc/reference/bluetooth/mesh/cfg_srv.rst
@@ -3,7 +3,7 @@
 Configuration Server
 ####################
 
-Configuration Server model is a foundation model defined by the Bluetooth Mesh
+The Configuration Server model is a foundation model defined by the Bluetooth mesh
 specification. The Configuration Server model controls most parameters of the
 mesh node. It does not have an API of its own, but relies on a
 :ref:`bluetooth_mesh_models_cfg_cli` to control it.
@@ -14,7 +14,7 @@ mesh node. It does not have an API of its own, but relies on a
    should be set through Kconfig, and the Heartbeat feature should be
    controlled through the :ref:`bluetooth_mesh_heartbeat` API.
 
-The Configuration Server model is mandatory on all Bluetooth Mesh nodes, and
+The Configuration Server model is mandatory on all Bluetooth mesh nodes, and
 should be instantiated in the first element.
 
 API reference

--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -1,10 +1,10 @@
 .. _bluetooth_mesh_core:
 
-Core API
-########
+Core
+####
 
-The Bluetooth Mesh Core API provides functionality for managing the general
-Bluetooth Mesh state.
+The core provides functionality for managing the general Bluetooth mesh
+state.
 
 Low Power Node
 **************

--- a/doc/reference/bluetooth/mesh/health_srv.rst
+++ b/doc/reference/bluetooth/mesh/health_srv.rst
@@ -19,7 +19,7 @@ necessarily damaging to the device. Errors indicate conditions that are
 outside of the node's design limits, and may have caused invalid behavior or
 permanent damage to the device.
 
-Fault values ``0x01`` to ``0x7f`` are reserved for the Bluetooth Mesh
+Fault values ``0x01`` to ``0x7f`` are reserved for the Bluetooth mesh
 specification, and the full list of specification defined faults are available
 in :ref:`bluetooth_mesh_health_faults`. Fault values ``0x80`` to ``0xff`` are
 vendor specific. The list of faults are always reported with a company ID to
@@ -52,9 +52,9 @@ API reference
 
 .. _bluetooth_mesh_health_faults:
 
-Bluetooth Mesh Health Faults
-============================
+Health faults
+=============
 
-Fault values defined by the Bluetooth Mesh specification.
+Fault values defined by the Bluetooth mesh specification.
 
 .. doxygengroup:: bt_mesh_health_faults

--- a/doc/reference/bluetooth/mesh/heartbeat.rst
+++ b/doc/reference/bluetooth/mesh/heartbeat.rst
@@ -3,8 +3,8 @@
 Heartbeat
 #########
 
-The Bluetooth Mesh Heartbeat feature provides functionality for monitoring mesh
-nodes and determining the distance between nodes.
+The Heartbeat feature provides functionality for monitoring Bluetooth mesh nodes
+and determining the distance between nodes.
 
 The Heartbeat feature is configured through the :ref:`bluetooth_mesh_models_cfg_srv` model.
 

--- a/doc/reference/bluetooth/mesh/models.rst
+++ b/doc/reference/bluetooth/mesh/models.rst
@@ -3,7 +3,7 @@
 Foundation models
 #################
 
-The Bluetooth Mesh specification defines four foundation models that can be
+The Bluetooth mesh specification defines four foundation models that can be
 used by network administrators to configure and diagnose mesh nodes.
 
 .. toctree::

--- a/doc/reference/bluetooth/mesh/msg.rst
+++ b/doc/reference/bluetooth/mesh/msg.rst
@@ -1,10 +1,11 @@
 .. _bluetooth_mesh_msg:
 
-Message API
-###########
+Message
+#######
 
-The Bluetooth Mesh message API provides set of structures, macros and functions
-used for preparing message buffers, managing message and acknowledged message contexts.
+The Bluetooth mesh message provides set of structures, macros and functions used
+for preparing message buffers, managing message and acknowledged message
+contexts.
 
 API reference
 *************

--- a/doc/reference/bluetooth/mesh/provisioning.rst
+++ b/doc/reference/bluetooth/mesh/provisioning.rst
@@ -12,15 +12,15 @@ two devices operating in the following roles:
   Provisioning process. Before the provisioning process starts, the
   provisionee is an *unprovisioned device*.
 
-The Provisioning module in the Zephyr Bluetooth Mesh stack supports both the
+The Provisioning module in the Zephyr Bluetooth mesh stack supports both the
 Advertising and GATT Provisioning bearers for the provisionee role, as well as
 the Advertising Provisioning bearer for the provisioner role.
 
 The Provisioning process
 ************************
 
-All Bluetooth Mesh nodes must be provisioned before they can participate in a
-Bluetooth Mesh network. The Provisioning API provides all the functionality
+All Bluetooth mesh nodes must be provisioned before they can participate in a
+Bluetooth mesh network. The Provisioning API provides all the functionality
 necessary for a device to become a provisioned mesh node.
 Provisioning is a five-step process, involving the following steps:
 
@@ -173,7 +173,7 @@ Depending on the choice of public key exchange mechanism and authentication meth
 the provisioning process can be secure or insecure.
 
 On May 24th 2021, ANSSI `disclosed <https://kb.cert.org/vuls/id/799380>`_
-a set of vulnerabilities in the Bluetooth Mesh Provisioning protocol that showcased
+a set of vulnerabilities in the Bluetooth mesh provisioning protocol that showcased
 how the low entropy provided by the Blink, Vibrate, Push, Twist and
 Input/Output numeric OOB methods could be exploited in impersonation and MITM
 attacks. In response, the Bluetooth SIG has reclassified these OOB methods as

--- a/doc/reference/bluetooth/mesh/proxy.rst
+++ b/doc/reference/bluetooth/mesh/proxy.rst
@@ -3,8 +3,8 @@
 Proxy
 #####
 
-The Bluetooth Mesh Proxy feature allows legacy devices like phones to access
-the Mesh network through GATT. The Proxy feature is only compiled in if the
+The Proxy feature allows legacy devices like phones to access the Bluetooth
+mesh network through GATT. The Proxy feature is only compiled in if the
 :kconfig:`CONFIG_BT_MESH_GATT_PROXY` option is set. The Proxy feature state is
 controlled by the :ref:`bluetooth_mesh_models_cfg_srv`, and the initial value
 can be set with :c:member:`bt_mesh_cfg_srv.gatt_proxy`.

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -1,28 +1,28 @@
 .. _bluetooth_mesh_shell:
 
-Shell
-#####
+Bluetooth Mesh Shell
+####################
 
-The Bluetooth Mesh Shell subsystem provides a set of Bluetooth Mesh commands for the :ref:`shell_api` module.
-It allows for testing and exploring the Bluetooth Mesh API through an interactive interface, without having to write an application.
+The Bluetooth mesh shell subsystem provides a set of Bluetooth mesh shell commands for the :ref:`shell_api` module.
+It allows for testing and exploring the Bluetooth mesh API through an interactive interface, without having to write an application.
 
-The Bluetooth Mesh Shell interface provides access to most Bluetooth Mesh features, including provisioning, configuration, and message sending.
+The Bluetooth mesh shell interface provides access to most Bluetooth mesh features, including provisioning, configuration, and message sending.
 
 Prerequisites
 *************
 
-The Mesh Shell subsystem depends on the :ref:`bluetooth_mesh_models_cfg_cli` and :ref:`bluetooth_mesh_models_health_cli` models.
+The Bluetooth mesh shell subsystem depends on the :ref:`bluetooth_mesh_models_cfg_cli` and :ref:`bluetooth_mesh_models_health_cli` models.
 
-Mesh Shell application
-**********************
+Application
+***********
 
-The Mesh Shell subsystem is most easily used through the Mesh Shell application under ``tests/bluetooth/mesh_shell``.
-See :ref:`shell_api` for information on how to connect and interact with the shell application.
+The Bluetooth mesh shell subsystem is most easily used through the Bluetooth mesh shell application under ``tests/bluetooth/mesh_shell``.
+See :ref:`shell_api` for information on how to connect and interact with the Bluetooth mesh shell application.
 
 Basic usage
 ***********
 
-The Mesh Shell subsystem adds a single ``mesh`` command, which holds a set of sub-commands. Every time the device boots up, make sure to call ``mesh init`` before any of the other Mesh Shell commands can be called::
+The Bluetooth mesh shell subsystem adds a single ``mesh`` command, which holds a set of sub-commands. Every time the device boots up, make sure to call ``mesh init`` before any of the other Bluetooth mesh shell commands can be called::
 
 	uart:~$ mesh init
 
@@ -35,7 +35,7 @@ The simplest way to provision the device is through self-provisioning. To provis
 
 	uart:~$ mesh provision 0 0x0001
 
-Since all mesh shell nodes use the same values for the default network key, this can be done on multiple devices, as long as they're assigned non-overlapping unicast addresses. Alternatively, to provision the device into an existing network, the unprovisioned beacon can be enabled with ``mesh pb-adv on`` or ``mesh pb-gatt on``. The beacons can be picked up by an external provisioner, which can provision the node into its network.
+Since all mesh nodes use the same values for the default network key, this can be done on multiple devices, as long as they're assigned non-overlapping unicast addresses. Alternatively, to provision the device into an existing network, the unprovisioned beacon can be enabled with ``mesh pb-adv on`` or ``mesh pb-gatt on``. The beacons can be picked up by an external provisioner, which can provision the node into its network.
 
 Once the mesh node is part of a network, its transmission parameters can be controlled by the general configuration commands:
 
@@ -63,7 +63,7 @@ Next, since the device has no application keys by default, it's a good idea to a
 Message sending
 ===============
 
-With an application key added (see above), the mesh node's transition parameters are all valid, and the Mesh Shell can send raw mesh messages through the network.
+With an application key added (see above), the mesh node's transition parameters are all valid, and the Bluetooth mesh shell can send raw mesh messages through the network.
 
 For example, to send a Generic OnOff Set message, call::
 
@@ -81,12 +81,12 @@ With the destination address set to ``0xffff``, any other mesh nodes in the netw
 .. note::
 	To change the configuration of the device, the destination address must be set back to the local unicast address before issuing any configuration commands.
 
-Sending raw mesh packets is a good way to test model message handler implementations during development, as it can be done without having to implement the sending model. By default, only the reception of the model messages can be tested this way, as the Mesh Shell only includes the foundation models. To receive a packet in the Mesh Shell node, you have to add a model with a valid opcode handler list to the composition data in ``subsys/bluetooth/mesh/shell.c``, and print the incoming message to the shell in the handler callback.
+Sending raw mesh packets is a good way to test model message handler implementations during development, as it can be done without having to implement the sending model. By default, only the reception of the model messages can be tested this way, as the Bluetooth mesh shell only includes the foundation models. To receive a packet in the mesh node, you have to add a model with a valid opcode handler list to the composition data in ``subsys/bluetooth/mesh/shell.c``, and print the incoming message to the shell in the handler callback.
 
 Parameter formats
 *****************
 
-The Mesh Shell commands are parsed with a variety of formats:
+The Bluetooth mesh shell commands are parsed with a variety of formats:
 
 .. list-table:: Parameter formats
 	:widths: 1 4 2
@@ -105,19 +105,19 @@ The Mesh Shell commands are parsed with a variety of formats:
 	  - Boolean values are denoted in the API documentation as ``<val: on, off>``.
 	  - ``on``, ``off``, ``enabled``, ``disabled``, ``1``, ``0``
 
-Mesh Shell commands
-*******************
+Commands
+********
 
-The Mesh shell implements a large set of commands. Some of the commands accept parameters, which are mentioned in brackets after the command name. For example, ``mesh lpn <value: off, on>``. Mandatory parameters are marked with angle brackets (e.g. ``<NetKeyIndex>``), and optional parameters are marked with square brackets (e.g. ``[destination address]``).
+The Bluetooth mesh shell implements a large set of commands. Some of the commands accept parameters, which are mentioned in brackets after the command name. For example, ``mesh lpn <value: off, on>``. Mandatory parameters are marked with angle brackets (e.g. ``<NetKeyIndex>``), and optional parameters are marked with square brackets (e.g. ``[destination address]``).
 
-The Mesh Shell commands are divided into the following groups:
+The Bluetooth mesh shell commands are divided into the following groups:
 
 .. contents::
 	:depth: 1
 	:local:
 
 .. note::
-	Some commands depend on specific features being enabled in the compile time configuration of the application. Not all features are enabled by default. The list of available Mesh Shell commands can be shown in the shell by calling ``mesh`` without any arguments.
+	Some commands depend on specific features being enabled in the compile time configuration of the application. Not all features are enabled by default. The list of available Bluetooth mesh shell commands can be shown in the shell by calling ``mesh`` without any arguments.
 
 General configuration
 =====================
@@ -166,7 +166,7 @@ General configuration
 ``mesh netidx [NetIdx]``
 ------------------------
 
-	Get or set the message network index. The network index determines which network key is used to encrypt mesh packets that are sent with the shell, but has no effect on modules outside the shell's control. The network key must already be added to the device, either through provisioning or by a Config Client.
+	Get or set the message network index. The network index determines which network key is used to encrypt mesh packets that are sent with the shell, but has no effect on modules outside the shell's control. The network key must already be added to the device, either through provisioning or by a Configuration Client.
 
 	* ``NetIdx``: If present, sets the new network index. If omitted, the current network index is printed.
 
@@ -174,7 +174,7 @@ General configuration
 ``mesh appidx [AppIdx]``
 ------------------------
 
-	Get or set the message application index. The application index determines which application key is used to encrypt mesh packets that are sent with the shell, but has no effect on modules outside the shell's control. The application key must already be added to the device by a Config Client, and must be bound to the current network index.
+	Get or set the message application index. The application index determines which application key is used to encrypt mesh packets that are sent with the shell, but has no effect on modules outside the shell's control. The application key must already be added to the device by a Configuration Client, and must be bound to the current network index.
 
 	* ``AppIdx``: If present, sets the new application index. If omitted, the current application index is printed.
 
@@ -298,9 +298,9 @@ Provisioning
 Configuration Client model
 ==========================
 
-The Mesh Shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
+The Bluetooth mesh shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
 
-The Configuration Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Mesh Shell node is provisioned, the Configuration Client model targets itself by default. When another node has been provisioned by the Mesh Shell, the Configuration Client model targets the new node. The Configuration Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
+The Configuration Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Configuration Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Configuration Client model targets the new node. The Configuration Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 
 ``mesh timeout [timeout in seconds]``
 -------------------------------------
@@ -583,9 +583,9 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 Health Client model
 ===================
 
-The Mesh Shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
+The Bluetooth mesh shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
 
-The Health Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Mesh Shell node is provisioned, the Health Client model targets itself by default. When another node has been provisioned by the Mesh Shell, the Health Client model targets the new node. The Health Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
+The Health Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Health Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Health Client model targets the new node. The Health Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 
 ``mesh fault-get <Company ID>``
 -------------------------------
@@ -695,7 +695,7 @@ Health Server model
 Configuration database
 ======================
 
-The Configuration database is an optional Mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_CDB` configuration option. The Configuration database is only available on provisioner devices, and allows them to store all information about the mesh network. To avoid conflicts, there should only be one mesh node in the network with the Configuration database enabled. This node is the Configurator, and is responsible for adding new nodes to the network and configuring them.
+The Configuration database is an optional mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_CDB` configuration option. The Configuration database is only available on provisioner devices, and allows them to store all information about the mesh network. To avoid conflicts, there should only be one mesh node in the network with the Configuration database enabled. This node is the Configurator, and is responsible for adding new nodes to the network and configuring them.
 
 ``mesh cdb-create [NetKey]``
 ----------------------------

--- a/include/bluetooth/mesh.h
+++ b/include/bluetooth/mesh.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Profile APIs.
+ *  @brief Bluetooth mesh Profile APIs.
  */
 
 /*

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Access Layer APIs.
+ *  @brief Access layer APIs.
  */
 
 /*
@@ -25,8 +25,8 @@
 		       BT_MESH_ADDR_UNASSIGNED_ELT_) }
 
 /**
- * @brief Bluetooth Mesh Access Layer
- * @defgroup bt_mesh_access Bluetooth Mesh Access Layer
+ * @brief Access layer
+ * @defgroup bt_mesh_access Access layer
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/cfg.h
+++ b/include/bluetooth/mesh/cfg.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Runtime Configuration APIs.
+ *  @brief Runtime configuration APIs.
  */
 
 /*
@@ -15,8 +15,8 @@
 #include <sys/types.h>
 
 /**
- * @brief Bluetooth Mesh Runtime Configuration API
- * @defgroup bt_mesh_cfg Bluetooth Mesh Runtime Configuration
+ * @brief Runtime Configuration
+ * @defgroup bt_mesh_cfg Runtime Configuration
  * @ingroup bt_mesh
  * @{
  */
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-/** Bluetooth Mesh Feature states */
+/** Bluetooth mesh feature states */
 enum bt_mesh_feat_state {
 	/** Feature is supported, but disabled. */
 	BT_MESH_FEATURE_DISABLED,
@@ -207,8 +207,8 @@ int bt_mesh_friend_set(enum bt_mesh_feat_state friendship);
 enum bt_mesh_feat_state bt_mesh_friend_get(void);
 
 /**
- * @brief Bluetooth Mesh Subnet Configuration
- * @defgroup bt_mesh_cfg_subnet Bluetooth Mesh Subnet Configuration
+ * @brief Subnet Configuration
+ * @defgroup bt_mesh_cfg_subnet Subnet Configuration
  * @{
  */
 
@@ -369,8 +369,8 @@ ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, off_t skip);
  */
 
 /**
- * @brief Bluetooth Mesh Application Configuration
- * @defgroup bt_mesh_cfg_app Bluetooth Mesh Application Configuration
+ * @brief Application Configuration
+ * @defgroup bt_mesh_cfg_app Application Configuration
  * @{
  */
 

--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Configuration Client Model APIs.
+ *  @brief Configuration Client Model APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_CFG_CLI_H_
 
 /**
- * @brief Bluetooth Mesh
- * @defgroup bt_mesh_cfg_cli Bluetooth Mesh Configuration Client Model
+ * @brief Configuration Client Model
+ * @defgroup bt_mesh_cfg_cli Configuration Client Model
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/cfg_srv.h
+++ b/include/bluetooth/mesh/cfg_srv.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Configuration Server Model APIs.
+ *  @brief Configuration Server Model APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_CFG_SRV_H_
 
 /**
- * @brief Bluetooth Mesh
- * @defgroup bt_mesh_cfg_srv Bluetooth Mesh Configuration Server Model
+ * @brief Configuration Server Model
+ * @defgroup bt_mesh_cfg_srv Configuration Server Model
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Health Client Model APIs.
+ *  @brief Health Client Model APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_CLI_H_
 
 /**
- * @brief Bluetooth Mesh
- * @defgroup bt_mesh_health_cli Bluetooth Mesh Health Client Model
+ * @brief Health Client Model
+ * @defgroup bt_mesh_health_cli Health Client Model
  * @ingroup bt_mesh
  * @{
  */
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-/** Mesh Health Client Model Context */
+/** Health Client Model Context */
 struct bt_mesh_health_cli {
 	/** Composition data model entry pointer. */
 	struct bt_mesh_model *model;

--- a/include/bluetooth/mesh/health_faults.h
+++ b/include/bluetooth/mesh/health_faults.h
@@ -1,5 +1,5 @@
 /** @file
- * @brief Bluetooth Mesh Health faults
+ * @brief Health faults
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_FAULTS_H__
 
 /**
- * @brief List of specification defined Health Fault values.
- * @defgroup bt_mesh_health_faults Bluetooth Mesh Health Faults
+ * @brief List of specification defined Health fault values.
+ * @defgroup bt_mesh_health_faults Health faults
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/health_srv.h
+++ b/include/bluetooth/mesh/health_srv.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Health Server Model APIs.
+ *  @brief Health Server Model APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_SRV_H_
 
 /**
- * @brief Bluetooth Mesh Health Server Model
- * @defgroup bt_mesh_health_srv Bluetooth Mesh Health Server Model
+ * @brief Health Server Model
+ * @defgroup bt_mesh_health_srv Health Server Model
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/heartbeat.h
+++ b/include/bluetooth/mesh/heartbeat.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Heartbeat API.
+ *  @brief Heartbeat APIs.
  */
 
 /*
@@ -13,8 +13,8 @@
 #include <sys/slist.h>
 
 /**
- * @brief Bluetooth Mesh
- * @defgroup bt_mesh_heartbeat Bluetooth Mesh Heartbeat
+ * @brief Heartbeat
+ * @defgroup bt_mesh_heartbeat Heartbeat
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Profile APIs.
+ *  @brief Bluetooth mesh Profile APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_MAIN_H_
 
 /**
- * @brief Bluetooth Mesh Provisioning
- * @defgroup bt_mesh_prov Bluetooth Mesh Provisioning
+ * @brief Provisioning
+ * @defgroup bt_mesh_prov Provisioning
  * @ingroup bt_mesh
  * @{
  */
@@ -440,8 +440,8 @@ bool bt_mesh_is_provisioned(void);
  */
 
 /**
- * @brief Bluetooth Mesh
- * @defgroup bt_mesh Bluetooth Mesh
+ * @brief Bluetooth mesh
+ * @defgroup bt_mesh Bluetooth mesh
  * @ingroup bluetooth
  * @{
  */

--- a/include/bluetooth/mesh/msg.h
+++ b/include/bluetooth/mesh/msg.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Message APIs.
+ *  @brief Message APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_MSG_H_
 
 /**
- * @brief Bluetooth Mesh Message API
- * @defgroup bt_mesh_msg Bluetooth Mesh Message API
+ * @brief Message
+ * @defgroup bt_mesh_msg Message
  * @ingroup bt_mesh
  * @{
  */

--- a/include/bluetooth/mesh/proxy.h
+++ b/include/bluetooth/mesh/proxy.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Mesh Proxy APIs.
+ *  @brief Proxy APIs.
  */
 
 /*
@@ -11,8 +11,8 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PROXY_H_
 
 /**
- * @brief Bluetooth Mesh Proxy
- * @defgroup bt_mesh_proxy Bluetooth Mesh Proxy
+ * @brief Proxy
+ * @defgroup bt_mesh_proxy Proxy
  * @ingroup bt_mesh
  * @{
  */

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -6,8 +6,8 @@ Bluetooth: Mesh
 Overview
 ********
 
-This sample demonstrates Bluetooth Mesh functionality. It has several
-standard Mesh models, and supports provisioning over both the
+This sample demonstrates Bluetooth mesh functionality. It has several
+standard mesh models, and supports provisioning over both the
 Advertising and the GATT Provisioning Bearers (i.e. PB-ADV and PB-GATT).
 The application also needs a functioning serial console, since that's
 used for the Out-of-Band provisioning procedure.

--- a/samples/bluetooth/mesh_demo/README.rst
+++ b/samples/bluetooth/mesh_demo/README.rst
@@ -6,7 +6,7 @@ Bluetooth: Mesh Demo
 Overview
 ********
 
-This sample is a Bluetooth Mesh application intended for demonstration
+This sample is a Bluetooth mesh application intended for demonstration
 purposes only. The application provisions and configures itself (i.e. no
 external provisioner needed) with hard-coded network and application key
 values. The local unicast address can be set using a NODE_ADDR build
@@ -14,7 +14,7 @@ variable (e.g. NODE_ADDR=0x0001 for unicast address 0x0001), or by
 manually editing the value in the ``board.h`` file.
 
 Because of the hard-coded values, the application is not suitable for
-production use, but is quite convenient for quick demonstrations of Mesh
+production use, but is quite convenient for quick demonstrations of mesh
 functionality.
 
 The application has some features especially designed for the BBC

--- a/samples/bluetooth/mesh_provisioner/README.rst
+++ b/samples/bluetooth/mesh_provisioner/README.rst
@@ -6,7 +6,7 @@ Bluetooth: Mesh Provisioner
 Overview
 ********
 
-This sample demonstrates how to use the Bluetooth Mesh APIs related to
+This sample demonstrates how to use the Bluetooth mesh APIs related to
 provisioning and using the Configuration Database (CDB). It is intended to be
 tested together with a device capable of being provisioned. For
 example, one could use the sample in :zephyr_file:`samples/bluetooth/mesh` or

--- a/samples/boards/reel_board/mesh_badge/README.rst
+++ b/samples/boards/reel_board/mesh_badge/README.rst
@@ -6,7 +6,7 @@ Mesh Badge
 Overview
 ********
 
-This sample app for the reel board showcases Bluetooth Mesh
+This sample app for the reel board showcases Bluetooth mesh
 
 The app starts off as a regular Bluetooth GATT peripheral application.
 Install the the "nRF Connect" app on your phone (available both for
@@ -34,7 +34,7 @@ Steps to set up
    you're not happy with it you can try writing something else.
 #. When you're happy with the text, disconnect from the board (exit the app or
    go back to the device scan page)
-#. Once disconnected the board switches over to Bluetooth Mesh mode, and you
+#. Once disconnected the board switches over to Bluetooth mesh mode, and you
    can't connect to it anymore over GATT.
 
 If you configure multiple boards like this they can communicate with

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -223,7 +223,7 @@ config BT_HCI_MESH_EXT
 	bool "Mesh HCI Command support"
 	depends on BT_BROADCASTER && BT_OBSERVER && !BT_LL_SW_SPLIT
 	help
-	  Enable support for the Bluetooth Mesh HCI Commands.
+	  Enable support for the Bluetooth mesh HCI Commands.
 
 config BT_WAIT_NOP
 	bool "Wait for \"NOP\" Command Complete event during init"

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1,17 +1,17 @@
-# Bluetooth Mesh configuration options
+# Bluetooth mesh configuration options
 
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_MESH
-	bool "Bluetooth Mesh support"
+	bool "Bluetooth mesh support"
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC
 	select BT_HOST_CCM
 	depends on BT_OBSERVER && BT_BROADCASTER
 	help
-	  This option enables Bluetooth Mesh support. The specific
+	  This option enables Bluetooth mesh support. The specific
 	  features that are available may depend on other features
 	  that have been enabled in the stack, such as GATT support.
 
@@ -682,19 +682,19 @@ config BT_MESH_HEALTH_CLI
 	  Enable support for the health client model.
 
 config BT_MESH_SHELL
-	bool "Enable Bluetooth Mesh shell"
+	bool "Enable Bluetooth mesh shell"
 	select SHELL
 	depends on BT_MESH_CFG_CLI
 	depends on BT_MESH_HEALTH_CLI
 	help
-	  Activate shell module that provides Bluetooth Mesh commands to
+	  Activate shell module that provides Bluetooth mesh commands to
 	  the console.
 
 config BT_MESH_MODEL_EXTENSIONS
 	bool "Support for Model extensions"
 	help
 	  Enable support for the model extension concept, allowing the Access
-	  layer to know about Mesh model relationships.
+	  layer to know about mesh model relationships.
 
 if BT_SETTINGS
 
@@ -766,55 +766,55 @@ config BT_MESH_DEBUG_NET
 	bool "Network layer debug"
 	help
 	  Use this option to enable Network layer debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_RPL
 	bool "Replay protection list debug"
 	help
 	  Use this option to enable Replay protection list debug logs
-	  for the Bluetooth Mesh functionality.
+	  for the Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_TRANS
 	bool "Transport layer debug"
 	help
 	  Use this option to enable Transport layer debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_BEACON
 	bool "Beacon debug"
 	help
 	  Use this option to enable Beacon-related debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_CRYPTO
 	bool "Crypto debug"
 	help
 	  Use this option to enable cryptographic debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_KEYS
 	bool "Key management debug"
 	help
 	  Use this option to enable key management debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_PROV
 	bool "Provisioning debug"
 	help
 	  Use this option to enable Provisioning debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_PROVISIONER
 	bool "Provisioner debug"
 	help
 	  Use this option to enable Provisioner debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_ACCESS
 	bool "Access layer debug"
 	help
 	  Use this option to enable Access layer and device composition
-	  related debug logs for Bluetooth Mesh.
+	  related debug logs for Bluetooth mesh.
 
 config BT_MESH_DEBUG_MODEL
 	bool "Foundation model debug"
@@ -826,19 +826,19 @@ config BT_MESH_DEBUG_ADV
 	bool "Advertising debug"
 	help
 	  Use this option to enable advertising debug logs for
-	  the Bluetooth Mesh functionality.
+	  the Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_LOW_POWER
 	bool "Low Power debug"
 	help
 	  Use this option to enable Low Power debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_FRIEND
 	bool "Friend debug"
 	help
 	  Use this option to enable Friend debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 config BT_MESH_DEBUG_PROXY
 	bool "Proxy debug"
@@ -862,7 +862,7 @@ config BT_MESH_DEBUG_CFG
 	bool "Configuration debug"
 	help
 	  Use this option to enable node configuration debug logs for the
-	  Bluetooth Mesh functionality.
+	  Bluetooth mesh functionality.
 
 endif # BT_MESH_DEBUG
 

--- a/subsys/bluetooth/mesh/TODO
+++ b/subsys/bluetooth/mesh/TODO
@@ -1,4 +1,4 @@
-Bluetooth Mesh implementation tasks
+Bluetooth mesh implementation tasks
 ===================================
 
  * Ability to act as provisioner

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2017 Intel Corporation

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2017 Intel Corporation

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2017 Intel Corporation

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/beacon.h
+++ b/subsys/bluetooth/mesh/beacon.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/crypto.h
+++ b/subsys/bluetooth/mesh/crypto.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/friend.h
+++ b/subsys/bluetooth/mesh/friend.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2021 Lingao Meng

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/lpn.h
+++ b/subsys/bluetooth/mesh/lpn.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/mesh.h
+++ b/subsys/bluetooth/mesh/mesh.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/msg.c
+++ b/subsys/bluetooth/mesh/msg.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Nordic Semiconductor ASA

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Nordic Semiconductor ASA

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/provisioner.h
+++ b/subsys/bluetooth/mesh/provisioner.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/rpl.h
+++ b/subsys/bluetooth/mesh/rpl.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020 Lingao Meng

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -1,8 +1,3 @@
-/** @file
- *  @brief Bluetooth Mesh shell
- *
- */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *
@@ -2806,5 +2801,5 @@ static int cmd_mesh(const struct shell *shell, size_t argc, char **argv)
 	return -EINVAL;
 }
 
-SHELL_CMD_ARG_REGISTER(mesh, &mesh_cmds, "Bluetooth Mesh shell commands",
+SHELL_CMD_ARG_REGISTER(mesh, &mesh_cmds, "Bluetooth mesh shell commands",
 			cmd_mesh, 1, 1);

--- a/subsys/bluetooth/mesh/test.c
+++ b/subsys/bluetooth/mesh/test.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/test.h
+++ b/subsys/bluetooth/mesh/test.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -1,5 +1,3 @@
-/*  Bluetooth Mesh */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/README.rst
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/README.rst
@@ -1,16 +1,16 @@
-Bluetooth Mesh BabbleSim tests
+Bluetooth mesh BabbleSim tests
 ##############################
 
-This directory contains a set of high level system tests for the Bluetooth Mesh
+This directory contains a set of high level system tests for the Bluetooth mesh
 subsystem. The tests run on the BabbleSim simulator, using the BabbleSim test
 framework.
 
 Tests are organized into bash scripts under the test_scripts folder. Each
 subfolder of test_scripts contains tests for a specific module in the Bluetooth
-Mesh subsystem, and each folder has a corresponding test_<subfolder>.c under the
+mesh subsystem, and each folder has a corresponding test_<subfolder>.c under the
 src/ directory containing the necessary test harnesses to execute the tests.
 
-There's only a single test application for all the Bluetooth Mesh BabbleSim
+There's only a single test application for all the Bluetooth mesh BabbleSim
 tests. The test application is built from this directory, and includes all test
 harnesses in every build. The overlying bsim test framework selects the harness
 to use at runtime, using the test identifiers passed in the test scripts.
@@ -18,7 +18,7 @@ to use at runtime, using the test identifiers passed in the test scripts.
 Running the tests
 *****************
 
-The Bluetooth Mesh tests have no extra requirements, and can be run using the
+The Bluetooth mesh tests have no extra requirements, and can be run using the
 procedure described in the parent folder.
 
 To only run the mesh tests, set ``SEARCH_PATH`` to point to this folder before
@@ -57,13 +57,13 @@ Then separately, call
 Framework
 *********
 
-The Bluetooth Mesh BabbleSim tests mainly operate on the test framework for the
-BabbleSim platform, but with some Mesh specific additions:
+The Bluetooth mesh BabbleSim tests mainly operate on the test framework for the
+BabbleSim platform, but with some mesh specific additions:
 
 mesh_test.sh
 =============
 
-All test scripts in the Bluetooth Mesh BabbleSim test suite follow a common
+All test scripts in the Bluetooth mesh BabbleSim test suite follow a common
 pattern for running a single test across N devices with different test
 harnesses. ``mesh_test.sh`` is sourced in each test script, and its ``RunTest``
 function is called once in each script with the following parameters:
@@ -113,6 +113,6 @@ has been called - otherwise, it will fail.
    The Bluetooth stack must be initialized in the ``test_main_f`` function of
    the harness, as the previous callbacks are all executed in hardware threads.
 
-The Bluetooth Mesh tests include the entire Bluetooth host and controller
+The Bluetooth mesh tests include the entire Bluetooth host and controller
 subsystems, so timing requirements should generally be kept fairly liberal to
 avoid regressions on changes in the underlying layers.

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Common functionality for Bluetooth Mesh BabbleSim tests.
+ *  @brief Common functionality for Bluetooth mesh BabbleSim tests.
  */
 
 /*

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -1,7 +1,3 @@
-/** @file
- *  @brief Interactive Bluetooth Mesh shell application
- */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -1,5 +1,3 @@
-/* mesh.c - Bluetooth Mesh Tester */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  *


### PR DESCRIPTION
Align the capitalization of the term "Bluetooth Mesh" to Bluetooth mesh"
in the documentation. This is done to to match the new updated naming
convention done in Bluetooth SIG. In the upcoming spec versions, it its
used "Bluetooth mesh" with the lower case convention.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>