### PR TITLE
drivers: Fix missing `auto_attach_cmd`

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -378,6 +378,14 @@ DEVICE_DT_INST_DEFINE(1,
 	    &np_uart_driver_api_1);
 #endif /* CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE */
 
+static void auto_attach_cmd_cb(char *argv, int offset)
+{
+	ARG_UNUSED(argv);
+	ARG_UNUSED(offset);
+
+	auto_attach = true;
+}
+
 static void np_add_uart_options(void)
 {
 	if (!IS_ENABLED(CONFIG_NATIVE_UART_0_ON_OWN_PTY)) {
@@ -398,8 +406,9 @@ static void np_add_uart_options(void)
 		"Automatically attach to the UART terminal"},
 		{false, false, false,
 		"attach_uart_cmd", "\"cmd\"", 's',
-		(void *)&auto_attach_cmd, NULL,
-		"Command used to automatically attach to the terminal, by "
+		(void *)&auto_attach_cmd, auto_attach_cmd_cb,
+		"Command used to automatically attach to the terminal"
+		"(implies auto_attach), by "
 		"default: '" CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD "'"},
 		IF_ENABLED(CONFIG_UART_NATIVE_WAIT_PTS_READY_ENABLE, (
 			{false, false, true,


### PR DESCRIPTION
When run native posix with `-attach_uart_cmd=<cmd>`,
should attach cmd by arguments.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>