### PR TITLE
drivers: hwinfo: add NXP MCUX RCM hwinfo driver

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_sources_ifdef(CONFIG_HWINFO      hwinfo_weak_impl.c)
 
 zephyr_sources_ifdef(CONFIG_HWINFO_STM32      hwinfo_stm32.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_NRF        hwinfo_nrf.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_RCM   hwinfo_mcux_rcm.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_SIM   hwinfo_mcux_sim.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_SYSCON   hwinfo_mcux_syscon.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_ESP32      hwinfo_esp32.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -10,6 +10,10 @@ menuconfig HWINFO
 
 if HWINFO
 
+module = HWINFO
+module-str = HWINFO
+source "subsys/logging/Kconfig.template.log_config"
+
 config HWINFO_SHELL
 	bool "Enable HWINFO Shell"
 	default y
@@ -31,12 +35,19 @@ config HWINFO_NRF
 	help
 	  Enable Nordic NRF hwinfo driver.
 
+config HWINFO_MCUX_RCM
+	bool "NXP kinetis reset cause"
+	default y
+	depends on HAS_MCUX_RCM
+	help
+	  Enable NXP kinetis mcux RCM hwinfo driver.
+
 config HWINFO_MCUX_SIM
-	bool "NXP kinetis device ID"
+	bool "NXP kinetis SIM device ID"
 	default y
 	depends on HAS_MCUX_SIM
 	help
-	  Enable NXP kinetis mcux hwinfo driver.
+	  Enable NXP kinetis mcux SIM hwinfo driver.
 
 config HWINFO_MCUX_SYSCON
 	bool "NXP LPC device ID"

--- a/drivers/hwinfo/hwinfo_mcux_rcm.c
+++ b/drivers/hwinfo/hwinfo_mcux_rcm.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <drivers/hwinfo.h>
+#include <logging/log.h>
+#include <fsl_rcm.h>
+
+LOG_MODULE_REGISTER(hwinfo_rcm, CONFIG_HWINFO_LOG_LEVEL);
+
+/**
+ * @brief Translate from RCM reset source mask to Zephyr hwinfo sources mask.
+ *
+ * Translate bitmask from MCUX RCM reset source bitmask to Zephyr
+ * hwinfo reset source bitmask.
+ *
+ * @param NXP MCUX RCM reset source mask.
+ * @retval Zephyr hwinfo reset source mask.
+ */
+static uint32_t hwinfo_mcux_rcm_xlate_reset_sources(uint32_t sources)
+{
+	uint32_t mask = 0;
+
+#if (defined(FSL_FEATURE_RCM_HAS_WAKEUP) && FSL_FEATURE_RCM_HAS_WAKEUP)
+	if (sources & kRCM_SourceWakeup) {
+		mask |= RESET_LOW_POWER_WAKE;
+	}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_WAKEUP) && FSL_FEATURE_RCM_HAS_WAKEUP) */
+
+	if (sources & kRCM_SourceLvd) {
+		mask |= RESET_BROWNOUT;
+	}
+
+#if (defined(FSL_FEATURE_RCM_HAS_LOC) && FSL_FEATURE_RCM_HAS_LOC)
+	if (sources & kRCM_SourceLoc) {
+		mask |= RESET_CLOCK;
+	}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_LOC) && FSL_FEATURE_RCM_HAS_LOC) */
+
+#if (defined(FSL_FEATURE_RCM_HAS_LOL) && FSL_FEATURE_RCM_HAS_LOL)
+	if (sources & kRCM_SourceLol) {
+		mask |= RESET_PLL;
+	}
+#endif /*  (defined(FSL_FEATURE_RCM_HAS_LOL) && FSL_FEATURE_RCM_HAS_LOL) */
+
+	if (sources & kRCM_SourceWdog) {
+		mask |= RESET_WATCHDOG;
+	}
+
+	if (sources & kRCM_SourcePin) {
+		mask |= RESET_PIN;
+	}
+
+	if (sources & kRCM_SourcePor) {
+		mask |= RESET_POR;
+	}
+
+#if (defined(FSL_FEATURE_RCM_HAS_JTAG) && FSL_FEATURE_RCM_HAS_JTAG)
+	if (sources & kRCM_SourceJtag) {
+		mask |= RESET_DEBUG;
+	}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_JTAG) && FSL_FEATURE_RCM_HAS_JTAG) */
+
+	if (sources & kRCM_SourceLockup) {
+		mask |= RESET_CPU_LOCKUP;
+	}
+
+	if (sources & kRCM_SourceSw) {
+		mask |= RESET_SOFTWARE;
+	}
+
+#if (defined(FSL_FEATURE_RCM_HAS_MDM_AP) && FSL_FEATURE_RCM_HAS_MDM_AP)
+	if (sources & kRCM_SourceMdmap) {
+		mask |= RESET_DEBUG;
+	}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_MDM_AP) && FSL_FEATURE_RCM_HAS_MDM_AP) */
+
+#if (defined(FSL_FEATURE_RCM_HAS_EZPORT) && FSL_FEATURE_RCM_HAS_EZPORT)
+	if (sources & kRCM_SourceEzpt) {
+		mask |= RESET_DEBUG;
+	}
+#endif /*  (defined(FSL_FEATURE_RCM_HAS_EZPORT) && FSL_FEATURE_RCM_HAS_EZPORT) */
+
+	return mask;
+}
+
+int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
+{
+	uint32_t sources;
+
+#if (defined(FSL_FEATURE_RCM_HAS_SSRS) && FSL_FEATURE_RCM_HAS_SSRS)
+	sources = RCM_GetStickyResetSources(RCM) & kRCM_SourceAll;
+#else /* (defined(FSL_FEATURE_RCM_HAS_SSRS) && FSL_FEATURE_RCM_HAS_SSRS) */
+	sources = RCM_GetPreviousResetSources(RCM) & kRCM_SourceAll;
+#endif /* !(defined(FSL_FEATURE_RCM_HAS_PARAM) && FSL_FEATURE_RCM_HAS_PARAM) */
+
+	*cause = hwinfo_mcux_rcm_xlate_reset_sources(sources);
+
+	LOG_DBG("sources = 0x%08x, cause = 0x%08x", sources, *cause);
+
+	return 0;
+}
+
+#if (defined(FSL_FEATURE_RCM_HAS_SSRS) && FSL_FEATURE_RCM_HAS_SSRS)
+int z_impl_hwinfo_clear_reset_cause(void)
+{
+	uint32_t sources;
+
+	sources = RCM_GetStickyResetSources(RCM) & kRCM_SourceAll;
+	RCM_ClearStickyResetSources(RCM, sources);
+
+	LOG_DBG("sources = 0x%08x", sources);
+
+	return 0;
+}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_SSRS) && FSL_FEATURE_RCM_HAS_SSRS) */
+
+#if (defined(FSL_FEATURE_RCM_HAS_PARAM) && FSL_FEATURE_RCM_HAS_PARAM)
+int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
+{
+	uint32_t sources;
+
+	sources = RCM_GetResetSourceImplementedStatus(RCM);
+	*supported = hwinfo_mcux_rcm_xlate_reset_sources(sources);
+
+	LOG_DBG("sources = 0x%08x, supported = 0x%08x", sources, *supported);
+
+	return 0;
+}
+#endif /* (defined(FSL_FEATURE_RCM_HAS_PARAM) && FSL_FEATURE_RCM_HAS_PARAM) */

--- a/include/drivers/hwinfo.h
+++ b/include/drivers/hwinfo.h
@@ -40,6 +40,8 @@ extern "C" {
 #define RESET_LOW_POWER_WAKE			BIT(7)
 #define RESET_CPU_LOCKUP			BIT(8)
 #define RESET_PARITY				BIT(9)
+#define RESET_PLL				BIT(10)
+#define RESET_CLOCK				BIT(11)
 
 /**
  * @brief Copy the device id to a buffer

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -267,4 +267,10 @@ config HAS_MCUX_PWT
 	help
 	  Set if the PWT module is present on the SoC.
 
+config HAS_MCUX_RCM
+	bool
+	help
+	  Set if the Reset Control Module (RCM) module is present in
+	  the SoC.
+
 endif # HAS_MCUX

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.soc
@@ -24,6 +24,7 @@ config SOC_MK22F51212
 	select HAS_MCG
 	select CPU_HAS_FPU
 	select HAS_MCUX_DAC
+	select HAS_MCUX_RCM
 
 endchoice
 

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -23,6 +23,7 @@ config SOC_MK64F12
 	select HAS_MCUX_RTC
 	select HAS_MCUX_DAC
 	select HAS_MCUX_EDMA
+	select HAS_MCUX_RCM
 
 config SOC_MK66F18
 	bool "SOC_MK66F18"
@@ -39,6 +40,7 @@ config SOC_MK66F18
 	select CPU_HAS_FPU
 	select HAS_MCUX_RTC
 	select HAS_MCUX_EDMA
+	select HAS_MCUX_RCM
 
 endchoice
 

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.series
@@ -25,5 +25,6 @@ config SOC_SERIES_KINETIS_K8X
 	select HAS_MCG
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_PIT
+	select HAS_MCUX_RCM
 	help
 	  Enable support for Kinetis K8x MCU series

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
@@ -30,5 +30,6 @@ config SOC_SERIES_KINETIS_KE1XF
 	select HAS_MCUX_EDMA
 	select HAS_MCUX_ACMP
 	select HAS_MCUX_PWT
+	select HAS_MCUX_RCM
 	help
 	  Enable support for Kinetis KE1xF MCU series

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
@@ -17,6 +17,7 @@ config SOC_MKL25Z4
 	select HAS_MCUX_SIM
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 
 endchoice
 

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_KINETIS_KV5X
 	select HAS_MCUX_SIM
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 	help
 	  Enable support for Kinetis KV5x MCU series

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -19,6 +19,7 @@ config SOC_MKW22D5
 	select HAS_MCUX_SIM
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 
 config SOC_MKW24D5
 	bool "SOC_MKW24D5"
@@ -32,6 +33,7 @@ config SOC_MKW24D5
 	select HAS_MCUX_SIM
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 
 config SOC_MKW40Z4
 	bool "SOC_MKW40Z4"
@@ -43,6 +45,7 @@ config SOC_MKW40Z4
 	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 
 config SOC_MKW41Z4
 	bool "SOC_MKW41Z4"
@@ -57,6 +60,7 @@ config SOC_MKW41Z4
 	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
+	select HAS_MCUX_RCM
 
 endchoice
 


### PR DESCRIPTION
Add driver shim for the NXP MCUX Reset Control Module (RCM) for determining reset cause.
