### PR TITLE
samples/drivers/eeprom: Add fixture check on x_nucleo_eeprma2 config

### DIFF
--- a/samples/drivers/eeprom/sample.yaml
+++ b/samples/drivers/eeprom/sample.yaml
@@ -18,3 +18,6 @@ tests:
     tags: eeprom shield
     depends_on: arduino_gpio arduino_i2c
     extra_args: SHIELD=x_nucleo_eeprma2
+    harness: console
+    harness_config:
+        fixture: fixture_shield_x_nucleo_eeprma2


### PR DESCRIPTION
sample.drivers.eeprom.shield.x_nucleo_eeprma2 sample variant
should be run in CI bench only if shield is present on board.
Add a harness_config to specify the fixture check

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>