### PR TITLE
Update MICS API to use instance pointer instead of bt_conn 

### DIFF
--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -88,12 +88,12 @@ int bt_mics_register(struct bt_mics_register_param *param,
  * Microphone Input Control Service included services instances, such as
  * pointers to the Audio Input Control Service instances.
  *
- * @param conn          Connection to peer device, or NULL to get server value.
+ * @param      mics     Microphone Input Control Service instance pointer.
  * @param[out] included Pointer to store the result in.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mics_included_get(struct bt_conn *conn,
+int bt_mics_included_get(struct bt_mics *mics,
 			 struct bt_mics_included *included);
 
 /**
@@ -101,13 +101,12 @@ int bt_mics_included_get(struct bt_conn *conn,
  *
  * This callback is only used for the client.
  *
- * @param conn         The connection that was used to discover
- *                     Microphone Input Control Service.
+ * @param mics         Microphone Input Control Service instance pointer.
  * @param err          Error value. 0 on success, GATT error or errno on fail.
  * @param aics_count   Number of Audio Input Control Service instances on
  *                     peer device.
  */
-typedef void (*bt_mics_discover_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_mics_discover_cb)(struct bt_mics *mics, int err,
 				    uint8_t aics_count);
 
 /**
@@ -116,21 +115,21 @@ typedef void (*bt_mics_discover_cb)(struct bt_conn *conn, int err,
  * Called when the value is read,
  * or if the value is changed by either the server or client.
  *
- * @param conn     Connection to peer device, or NULL if local server read.
+ * @param mics     Microphone Input Control Service instance pointer.
  * @param err      Error value. 0 on success, GATT error or errno on fail.
  *                 For notifications, this will always be 0.
  * @param mute     The mute setting of the Microphone Input Control Service.
  */
-typedef void (*bt_mics_mute_read_cb)(struct bt_conn *conn, int err,
+typedef void (*bt_mics_mute_read_cb)(struct bt_mics *mics, int err,
 				     uint8_t mute);
 
 /**
  * @brief Callback function for Microphone Input Control Service mute/unmute.
  *
- * @param conn      Connection to peer device, or NULL if local server read.
+ * @param mics      Microphone Input Control Service instance pointer.
  * @param err       Error value. 0 on success, GATT error or errno on fail.
  */
-typedef void (*bt_mics_mute_write_cb)(struct bt_conn *conn, int err);
+typedef void (*bt_mics_mute_write_cb)(struct bt_mics *mics, int err);
 
 struct bt_mics_cb {
 	bt_mics_mute_read_cb            mute;
@@ -165,20 +164,20 @@ int bt_mics_discover(struct bt_conn *conn, struct bt_mics **mics);
 /**
  * @brief Unmute the server.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param mics  Microphone Input Control Service instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_unmute(struct bt_conn *conn);
+int bt_mics_unmute(struct bt_mics *mics);
 
 /**
  * @brief Mute the server.
  *
- * @param conn   Connection to peer device, or NULL to set local server value.
+ * @param mics  Microphone Input Control Service instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_mute(struct bt_conn *conn);
+int bt_mics_mute(struct bt_mics *mics);
 
 /**
  * @brief Disable the mute functionality.
@@ -186,142 +185,133 @@ int bt_mics_mute(struct bt_conn *conn);
  * Can be reenabled by called @ref bt_mics_mute or @ref bt_mics_unmute.
  * This can only be done as the server.
  *
+ * @param mics  Microphone Input Control Service instance pointer.
+ *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_mute_disable(void);
+int bt_mics_mute_disable(struct bt_mics *mics);
 
 /**
  * @brief Read the mute state of a Microphone Input Control Service.
  *
- * @param conn   Connection to peer device, or NULL to read local server value.
+ * @param mics  Microphone Input Control Service instance pointer.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_mute_get(struct bt_conn *conn);
+int bt_mics_mute_get(struct bt_mics *mics);
 
 /**
  * @brief Read the Audio Input Control Service input state.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to read local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_state_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_state_get(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service gain settings.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to read local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_gain_setting_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_gain_setting_get(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input type.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to read local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_type_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_type_get(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Read the Audio Input Control Service input status.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to read local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_status_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_status_get(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Unmute the Audio Input Control Service input.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_unmute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_unmute(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Mute the Audio Input Control Service input.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_mute(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_mute(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Set Audio Input Control Service gain mode to manual.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_manual_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_manual_gain_set(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Set Audio Input Control Service gain mode to automatic.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_automatic_gain_set(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_automatic_gain_set(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Set Audio Input Control Service input gain.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  * @param gain          The gain in dB to set (-128 to 127).
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_gain_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_mics_aics_gain_set(struct bt_mics *mics, struct bt_aics *inst,
 			  int8_t gain);
 
 /**
  * @brief Read the Audio Input Control Service description.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to read local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_description_get(struct bt_conn *conn, struct bt_aics *inst);
+int bt_mics_aics_description_get(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Set the Audio Input Control Service description.
  *
- * @param conn          Connection to peer device,
- *                      or NULL to set local server value.
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  * @param description	 The description to set.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
+int bt_mics_aics_description_set(struct bt_mics *mics, struct bt_aics *inst,
 				 const char *description);
 
 /**
@@ -331,11 +321,12 @@ int bt_mics_aics_description_set(struct bt_conn *conn, struct bt_aics *inst,
  * the server to deactivate a Audio Input Control Service.
  * This can only be done as the server.
  *
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mics_aics_deactivate(struct bt_aics *inst);
+int bt_mics_aics_deactivate(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Activates a Audio Input Control Service instance.
@@ -345,11 +336,12 @@ int bt_mics_aics_deactivate(struct bt_aics *inst);
  * been deactivated with @ref bt_mics_aics_deactivate.
  * This can only be done as the server.
  *
+ * @param mics          Microphone Input Control Service instance pointer.
  * @param inst          Pointer to the Audio Input Control Service instance.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mics_aics_activate(struct bt_aics *inst);
+int bt_mics_aics_activate(struct bt_mics *mics, struct bt_aics *inst);
 
 /**
  * @brief Registers the callbacks used by Microphone Input Control Service client.

--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -98,6 +98,19 @@ int bt_mics_included_get(struct bt_mics *mics,
 			 struct bt_mics_included *included);
 
 /**
+ * @brief Get the connection pointer of a client instance
+ *
+ * Get the Bluetooth connection pointer of a Microphone Input Control Service
+ * client instance.
+ *
+ * @param mics    Microphone Input Control Service client instance pointer.
+ * @param conn    Connection pointer.
+ *
+ * @return 0 if success, errno on failure.
+ */
+int bt_mics_client_conn_get(const struct bt_mics *mics, struct bt_conn **conn);
+
+/**
  * @brief Callback function for @ref bt_mics_discover.
  *
  * This callback is only used for the client.

--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -149,16 +149,18 @@ struct bt_mics_cb {
  * @brief Discover Microphone Input Control Service
  *
  * This will start a GATT discovery and setup handles and subscriptions.
- * This shall be called once before any other actions can be executed for
- * the peer device.
+ * This shall be called once before any other actions can be executed for the
+ * peer device, and the @ref bt_mics_discover_cb callback will notify when it
+ * is possible to start remote operations.
  *
  * This shall only be done as the client.
  *
  * @param conn          The connection to initialize the profile for.
+ * @param[out] mics     Valid remote instance object on success.
  *
  * @return 0 on success, GATT error value on fail.
  */
-int bt_mics_discover(struct bt_conn *conn);
+int bt_mics_discover(struct bt_conn *conn, struct bt_mics **mics);
 
 /**
  * @brief Unmute the server.

--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -41,6 +41,9 @@ extern "C" {
 #define BT_MICS_MUTE_MUTED                         0x01
 #define BT_MICS_MUTE_DISABLED                      0x02
 
+/** @brief Opaque Microphone Input Control Service instance. */
+struct bt_mics;
+
 /** @brief Register parameters structure for Microphone Input Control Service */
 struct bt_mics_register_param {
 	/** Register parameter structure for Audio Input Control Services */
@@ -70,11 +73,13 @@ struct bt_mics_included  {
  * This will enable the service and make it discoverable by clients.
  * This can only be done as the server.
  *
- * @param param  Pointer to an initialization structure.
+ * @param      param Pointer to an initialization structure.
+ * @param[out] mics  Pointer to the registered Microphone Input Control Service.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mics_register(struct bt_mics_register_param *param);
+int bt_mics_register(struct bt_mics_register_param *param,
+		     struct bt_mics **mics);
 
 /**
  * @brief Get Microphone Input Control Service included services

--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -75,6 +75,7 @@ struct bt_mics_included  {
  *
  * @param      param Pointer to an initialization structure.
  * @param[out] mics  Pointer to the registered Microphone Input Control Service.
+ *                   This will still be valid if the return value is -EALREADY.
  *
  * @return 0 if success, errno on failure.
  */

--- a/subsys/bluetooth/audio/mics.c
+++ b/subsys/bluetooth/audio/mics.c
@@ -146,6 +146,12 @@ int bt_mics_register(struct bt_mics_register_param *param,
 		     struct bt_mics **mics)
 {
 	int err;
+	static bool registered;
+
+	if (registered) {
+		*mics = &mics_inst;
+		return -EALREADY;
+	}
 
 	__ASSERT(param, "MICS register parameter cannot be NULL");
 
@@ -164,6 +170,7 @@ int bt_mics_register(struct bt_mics_register_param *param,
 	mics_inst.srv.cb = param->cb;
 
 	*mics = &mics_inst;
+	registered = true;
 
 	return err;
 }

--- a/subsys/bluetooth/audio/mics.c
+++ b/subsys/bluetooth/audio/mics.c
@@ -26,14 +26,8 @@
 #include "common/log.h"
 
 #if defined(CONFIG_BT_MICS)
-struct mics_instance {
-	uint8_t mute;
-	struct bt_mics_cb *cb;
-	struct bt_gatt_service *service_p;
-	struct bt_aics *aics_insts[CONFIG_BT_MICS_AICS_INSTANCE_COUNT];
-};
 
-static struct mics_instance mics_inst;
+static struct bt_mics_server mics_inst;
 
 static void mute_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
@@ -148,7 +142,8 @@ static int prepare_aics_inst(struct bt_mics_register_param *param)
 }
 
 /****************************** PUBLIC API ******************************/
-int bt_mics_register(struct bt_mics_register_param *param)
+int bt_mics_register(struct bt_mics_register_param *param,
+		     struct bt_mics **mics)
 {
 	int err;
 
@@ -167,6 +162,8 @@ int bt_mics_register(struct bt_mics_register_param *param)
 	}
 
 	mics_inst.cb = param->cb;
+
+	*mics = (struct bt_mics *)&mics_inst;
 
 	return err;
 }

--- a/subsys/bluetooth/audio/mics.c
+++ b/subsys/bluetooth/audio/mics.c
@@ -27,7 +27,7 @@
 
 #if defined(CONFIG_BT_MICS)
 
-static struct bt_mics_server mics_inst;
+static struct bt_mics mics_inst;
 
 static void mute_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
@@ -38,10 +38,10 @@ static ssize_t read_mute(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr, void *buf,
 			 uint16_t len, uint16_t offset)
 {
-	BT_DBG("Mute %u", mics_inst.mute);
+	BT_DBG("Mute %u", mics_inst.srv.mute);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
-				 &mics_inst.mute, sizeof(mics_inst.mute));
+				 &mics_inst.srv.mute, sizeof(mics_inst.srv.mute));
 }
 
 static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
@@ -54,7 +54,7 @@ static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	if (len != sizeof(mics_inst.mute)) {
+	if (len != sizeof(mics_inst.srv.mute)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
@@ -63,21 +63,21 @@ static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_MICS_ERR_VAL_OUT_OF_RANGE);
 	}
 
-	if (conn != NULL && mics_inst.mute == BT_MICS_MUTE_DISABLED) {
+	if (conn != NULL && mics_inst.srv.mute == BT_MICS_MUTE_DISABLED) {
 		return BT_GATT_ERR(BT_MICS_ERR_MUTE_DISABLED);
 	}
 
 	BT_DBG("%u", *val);
 
-	if (*val != mics_inst.mute) {
-		mics_inst.mute = *val;
+	if (*val != mics_inst.srv.mute) {
+		mics_inst.srv.mute = *val;
 
 		bt_gatt_notify_uuid(NULL, BT_UUID_MICS_MUTE,
-				    mics_inst.service_p->attrs,
-				    &mics_inst.mute, sizeof(mics_inst.mute));
+				    mics_inst.srv.service_p->attrs,
+				    &mics_inst.srv.mute, sizeof(mics_inst.srv.mute));
 
-		if (mics_inst.cb != NULL && mics_inst.cb->mute != NULL) {
-			mics_inst.cb->mute(NULL, 0, mics_inst.mute);
+		if (mics_inst.srv.cb != NULL && mics_inst.srv.cb->mute != NULL) {
+			mics_inst.srv.cb->mute(NULL, 0, mics_inst.srv.mute);
 		}
 	}
 
@@ -113,20 +113,20 @@ static int prepare_aics_inst(struct bt_mics_register_param *param)
 
 	for (j = 0, i = 0; i < ARRAY_SIZE(mics_attrs); i++) {
 		if (bt_uuid_cmp(mics_attrs[i].uuid, BT_UUID_GATT_INCLUDE) == 0) {
-			mics_inst.aics_insts[j] = bt_aics_free_instance_get();
-			if (mics_inst.aics_insts[j] == NULL) {
+			mics_inst.srv.aics_insts[j] = bt_aics_free_instance_get();
+			if (mics_inst.srv.aics_insts[j] == NULL) {
 				BT_DBG("Could not get free AICS instances[%u]", j);
 				return -ENOMEM;
 			}
 
-			err = bt_aics_register(mics_inst.aics_insts[j],
+			err = bt_aics_register(mics_inst.srv.aics_insts[j],
 					       &param->aics_param[j]);
 			if (err != 0) {
 				BT_DBG("Could not register AICS instance[%u]: %d", j, err);
 				return err;
 			}
 
-			mics_attrs[i].user_data = bt_aics_svc_decl_get(mics_inst.aics_insts[j]);
+			mics_attrs[i].user_data = bt_aics_svc_decl_get(mics_inst.srv.aics_insts[j]);
 			j++;
 
 			if (j == CONFIG_BT_MICS_AICS_INSTANCE_COUNT) {
@@ -154,14 +154,14 @@ int bt_mics_register(struct bt_mics_register_param *param,
 	}
 
 	mics_svc = (struct bt_gatt_service)BT_GATT_SERVICE(mics_attrs);
-	mics_inst.service_p = &mics_svc;
+	mics_inst.srv.service_p = &mics_svc;
 	err = bt_gatt_service_register(&mics_svc);
 
 	if (err != 0) {
 		BT_ERR("MICS service register failed: %d", err);
 	}
 
-	mics_inst.cb = param->cb;
+	mics_inst.srv.cb = param->cb;
 
 	*mics = (struct bt_mics *)&mics_inst;
 
@@ -211,8 +211,8 @@ static bool valid_aics_inst(struct bt_aics *aics)
 	}
 
 #if defined(CONFIG_BT_MICS)
-	for (int i = 0; i < ARRAY_SIZE(mics_inst.aics_insts); i++) {
-		if (mics_inst.aics_insts[i] == aics) {
+	for (int i = 0; i < ARRAY_SIZE(mics_inst.srv.aics_insts); i++) {
+		if (mics_inst.srv.aics_insts[i] == aics) {
 			return true;
 		}
 	}
@@ -236,8 +236,8 @@ int bt_mics_included_get(struct bt_conn *conn,
 
 #if defined(CONFIG_BT_MICS)
 	if (conn == NULL) {
-		included->aics_cnt = ARRAY_SIZE(mics_inst.aics_insts);
-		included->aics = mics_inst.aics_insts;
+		included->aics_cnt = ARRAY_SIZE(mics_inst.srv.aics_insts);
+		included->aics = mics_inst.srv.aics_insts;
 
 		return 0;
 	}
@@ -295,8 +295,8 @@ int bt_mics_mute_get(struct bt_conn *conn)
 	}
 
 #if defined(CONFIG_BT_MICS)
-	if (mics_inst.cb && mics_inst.cb->mute) {
-		mics_inst.cb->mute(NULL, 0, mics_inst.mute);
+	if (mics_inst.srv.cb && mics_inst.srv.cb->mute) {
+		mics_inst.srv.cb->mute(NULL, 0, mics_inst.srv.mute);
 	}
 
 	return 0;

--- a/subsys/bluetooth/audio/mics_client.c
+++ b/subsys/bluetooth/audio/mics_client.c
@@ -348,10 +348,12 @@ static void mics_client_reset(struct bt_conn *conn)
 	(void)bt_gatt_unsubscribe(conn, &mics_inst->mute_sub_params);
 }
 
-int bt_mics_discover(struct bt_conn *conn)
+int bt_mics_discover(struct bt_conn *conn, struct bt_mics **mics)
 {
 	static bool initialized;
 	struct bt_mics_client *mics_inst;
+	int err;
+
 	/*
 	 * This will initiate a discover procedure. The procedure will do the
 	 * following sequence:
@@ -397,7 +399,12 @@ int bt_mics_discover(struct bt_conn *conn)
 
 	initialized = true;
 
-	return bt_gatt_discover(conn, &mics_inst->discover_params);
+	err = bt_gatt_discover(conn, &mics_inst->discover_params);
+	if (err == 0) {
+		*mics = (struct bt_mics *)&mics_inst;
+	}
+
+	return err;
 }
 
 int bt_mics_client_cb_register(struct bt_mics_cb *cb)

--- a/subsys/bluetooth/audio/mics_client.c
+++ b/subsys/bluetooth/audio/mics_client.c
@@ -29,7 +29,7 @@
 /* Callback functions */
 static struct bt_mics_cb *mics_client_cb;
 
-static struct bt_mics_client mics_insts[CONFIG_BT_MAX_CONN];
+static struct bt_mics mics_insts[CONFIG_BT_MAX_CONN];
 static struct bt_uuid *mics_uuid = BT_UUID_MICS;
 
 bool bt_mics_client_valid_aics_inst(struct bt_conn *conn, struct bt_aics *aics)
@@ -46,8 +46,8 @@ bool bt_mics_client_valid_aics_inst(struct bt_conn *conn, struct bt_aics *aics)
 
 	conn_index = bt_conn_index(conn);
 
-	for (int i = 0; i < ARRAY_SIZE(mics_insts[conn_index].aics); i++) {
-		if (mics_insts[conn_index].aics[i] == aics) {
+	for (int i = 0; i < ARRAY_SIZE(mics_insts[conn_index].cli.aics); i++) {
+		if (mics_insts[conn_index].cli.aics[i] == aics) {
 			return true;
 		}
 	}
@@ -85,9 +85,9 @@ static uint8_t mics_client_read_mute_cb(struct bt_conn *conn, uint8_t err,
 {
 	uint8_t cb_err = err;
 	uint8_t *mute_val = NULL;
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	mics_inst->busy = false;
+	mics_inst->cli.busy = false;
 
 	if (err > 0) {
 		BT_DBG("err: 0x%02X", err);
@@ -112,12 +112,12 @@ static uint8_t mics_client_read_mute_cb(struct bt_conn *conn, uint8_t err,
 static void mics_client_write_mics_mute_cb(struct bt_conn *conn, uint8_t err,
 					   struct bt_gatt_write_params *params)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
-	uint8_t mute_val = mics_inst->mute_val_buf[0];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
+	uint8_t mute_val = mics_inst->cli.mute_val_buf[0];
 
 	BT_DBG("Write %s (0x%02X)", err ? "failed" : "successful", err);
 
-	mics_inst->busy = false;
+	mics_inst->cli.busy = false;
 
 	if (mute_val == BT_MICS_MUTE_UNMUTED) {
 		if (mics_client_cb != NULL &&
@@ -136,11 +136,11 @@ static void mics_client_write_mics_mute_cb(struct bt_conn *conn, uint8_t err,
 static void aics_discover_cb(struct bt_conn *conn, struct bt_aics *inst,
 			     int err)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
 	if (err == 0) {
 		/* Continue discovery of included services */
-		err = bt_gatt_discover(conn, &mics_inst->discover_params);
+		err = bt_gatt_discover(conn, &mics_inst->cli.discover_params);
 	}
 
 	if (err != 0) {
@@ -156,11 +156,11 @@ static uint8_t mics_discover_include_func(
 	struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	struct bt_gatt_discover_params *params)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
 	if (attr == NULL) {
 		BT_DBG("Discover include complete for MICS: %u AICS",
-		       mics_inst->aics_inst_cnt);
+		       mics_inst->cli.aics_inst_cnt);
 		(void)memset(params, 0, sizeof(*params));
 
 		if (mics_client_cb != NULL &&
@@ -179,7 +179,7 @@ static uint8_t mics_discover_include_func(
 		BT_DBG("Include UUID %s", bt_uuid_str(include->uuid));
 
 		if (bt_uuid_cmp(include->uuid, BT_UUID_AICS) == 0 &&
-		    mics_inst->aics_inst_cnt < CONFIG_BT_MICS_CLIENT_MAX_AICS_INST) {
+		    mics_inst->cli.aics_inst_cnt < CONFIG_BT_MICS_CLIENT_MAX_AICS_INST) {
 			uint8_t inst_idx;
 			int err;
 			struct bt_aics_discover_param param = {
@@ -190,10 +190,10 @@ static uint8_t mics_discover_include_func(
 			/* Update discover params so we can continue where we
 			 * left off after bt_aics_discover
 			 */
-			mics_inst->discover_params.start_handle = attr->handle + 1;
+			mics_inst->cli.discover_params.start_handle = attr->handle + 1;
 
-			inst_idx = mics_inst->aics_inst_cnt++;
-			err = bt_aics_discover(conn, mics_inst->aics[inst_idx],
+			inst_idx = mics_inst->cli.aics_inst_cnt++;
+			err = bt_aics_discover(conn, mics_inst->cli.aics[inst_idx],
 					       &param);
 			if (err != 0) {
 				BT_DBG("AICS Discover failed (err %d)", err);
@@ -218,7 +218,7 @@ static uint8_t mics_discover_func(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  struct bt_gatt_discover_params *params)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
 	if (attr == NULL) {
 		int err = 0;
@@ -227,13 +227,13 @@ static uint8_t mics_discover_func(struct bt_conn *conn,
 		(void)memset(params, 0, sizeof(*params));
 		if (CONFIG_BT_MICS_CLIENT_MAX_AICS_INST > 0) {
 			/* Discover included services */
-			mics_inst->discover_params.start_handle = mics_inst->start_handle;
-			mics_inst->discover_params.end_handle = mics_inst->end_handle;
-			mics_inst->discover_params.type = BT_GATT_DISCOVER_INCLUDE;
-			mics_inst->discover_params.func = mics_discover_include_func;
+			mics_inst->cli.discover_params.start_handle = mics_inst->cli.start_handle;
+			mics_inst->cli.discover_params.end_handle = mics_inst->cli.end_handle;
+			mics_inst->cli.discover_params.type = BT_GATT_DISCOVER_INCLUDE;
+			mics_inst->cli.discover_params.func = mics_discover_include_func;
 
 			err = bt_gatt_discover(conn,
-					       &mics_inst->discover_params);
+					       &mics_inst->cli.discover_params);
 			if (err != 0) {
 				BT_DBG("Discover failed (err %d)", err);
 				if (mics_client_cb != NULL &&
@@ -258,9 +258,9 @@ static uint8_t mics_discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_MICS_MUTE) == 0) {
 			BT_DBG("Mute");
-			mics_inst->mute_handle = chrc->value_handle;
-			sub_params = &mics_inst->mute_sub_params;
-			sub_params->disc_params = &mics_inst->mute_sub_disc_params;
+			mics_inst->cli.mute_handle = chrc->value_handle;
+			sub_params = &mics_inst->cli.mute_sub_params;
+			sub_params->disc_params = &mics_inst->cli.mute_sub_disc_params;
 		}
 
 		if (sub_params != NULL) {
@@ -268,7 +268,7 @@ static uint8_t mics_discover_func(struct bt_conn *conn,
 
 			/* With ccc_handle == 0 it will use auto discovery */
 			sub_params->ccc_handle = 0;
-			sub_params->end_handle = mics_inst->end_handle;
+			sub_params->end_handle = mics_inst->cli.end_handle;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
 			sub_params->notify = mute_notify_handler;
@@ -291,7 +291,7 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     struct bt_gatt_discover_params *params)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
 	if (attr == NULL) {
 		BT_DBG("Could not find a MICS instance on the server");
@@ -310,17 +310,17 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 		int err;
 
 		BT_DBG("Primary discover complete");
-		mics_inst->start_handle = attr->handle + 1;
-		mics_inst->end_handle = prim_service->end_handle;
+		mics_inst->cli.start_handle = attr->handle + 1;
+		mics_inst->cli.end_handle = prim_service->end_handle;
 
 		/* Discover characteristics */
-		mics_inst->discover_params.uuid = NULL;
-		mics_inst->discover_params.start_handle = mics_inst->start_handle;
-		mics_inst->discover_params.end_handle = mics_inst->end_handle;
-		mics_inst->discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-		mics_inst->discover_params.func = mics_discover_func;
+		mics_inst->cli.discover_params.uuid = NULL;
+		mics_inst->cli.discover_params.start_handle = mics_inst->cli.start_handle;
+		mics_inst->cli.discover_params.end_handle = mics_inst->cli.end_handle;
+		mics_inst->cli.discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+		mics_inst->cli.discover_params.func = mics_discover_func;
 
-		err = bt_gatt_discover(conn, &mics_inst->discover_params);
+		err = bt_gatt_discover(conn, &mics_inst->cli.discover_params);
 		if (err != 0) {
 			BT_DBG("Discover failed (err %d)", err);
 			if (mics_client_cb != NULL &&
@@ -337,21 +337,21 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 
 static void mics_client_reset(struct bt_conn *conn)
 {
-	struct bt_mics_client *mics_inst = &mics_insts[bt_conn_index(conn)];
+	struct bt_mics *mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	mics_inst->start_handle = 0;
-	mics_inst->end_handle = 0;
-	mics_inst->mute_handle = 0;
-	mics_inst->aics_inst_cnt = 0;
+	mics_inst->cli.start_handle = 0;
+	mics_inst->cli.end_handle = 0;
+	mics_inst->cli.mute_handle = 0;
+	mics_inst->cli.aics_inst_cnt = 0;
 
 	/* It's okay if this fails */
-	(void)bt_gatt_unsubscribe(conn, &mics_inst->mute_sub_params);
+	(void)bt_gatt_unsubscribe(conn, &mics_inst->cli.mute_sub_params);
 }
 
 int bt_mics_discover(struct bt_conn *conn, struct bt_mics **mics)
 {
 	static bool initialized;
-	struct bt_mics_client *mics_inst;
+	struct bt_mics *mics_inst;
 	int err;
 
 	/*
@@ -371,37 +371,37 @@ int bt_mics_discover(struct bt_conn *conn, struct bt_mics **mics)
 
 	mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	(void)memset(&mics_inst->discover_params, 0,
-		     sizeof(mics_inst->discover_params));
+	(void)memset(&mics_inst->cli.discover_params, 0,
+		     sizeof(mics_inst->cli.discover_params));
 	mics_client_reset(conn);
 
 	if (IS_ENABLED(CONFIG_BT_AICS_CLIENT) &&
 	    CONFIG_BT_MICS_CLIENT_MAX_AICS_INST > 0) {
-		for (int i = 0; i < ARRAY_SIZE(mics_inst->aics); i++) {
+		for (int i = 0; i < ARRAY_SIZE(mics_inst->cli.aics); i++) {
 			if (!initialized) {
-				mics_inst->aics[i] = bt_aics_client_free_instance_get();
+				mics_inst->cli.aics[i] = bt_aics_client_free_instance_get();
 
-				if (mics_inst->aics[i] == NULL) {
+				if (mics_inst->cli.aics[i] == NULL) {
 					return -ENOMEM;
 				}
 
-				bt_aics_client_cb_register(mics_inst->aics[i],
+				bt_aics_client_cb_register(mics_inst->cli.aics[i],
 							   &mics_client_cb->aics_cb);
 			}
 		}
 	}
 
-	mics_inst->discover_params.func = primary_discover_func;
-	mics_inst->discover_params.uuid = mics_uuid;
-	mics_inst->discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	mics_inst->discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
-	mics_inst->discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
+	mics_inst->cli.discover_params.func = primary_discover_func;
+	mics_inst->cli.discover_params.uuid = mics_uuid;
+	mics_inst->cli.discover_params.type = BT_GATT_DISCOVER_PRIMARY;
+	mics_inst->cli.discover_params.start_handle = BT_ATT_FIRST_ATTTRIBUTE_HANDLE;
+	mics_inst->cli.discover_params.end_handle = BT_ATT_LAST_ATTTRIBUTE_HANDLE;
 
 	initialized = true;
 
-	err = bt_gatt_discover(conn, &mics_inst->discover_params);
+	err = bt_gatt_discover(conn, &mics_inst->cli.discover_params);
 	if (err == 0) {
-		*mics = (struct bt_mics *)&mics_inst;
+		*mics = mics_inst;
 	}
 
 	return err;
@@ -425,9 +425,9 @@ int bt_mics_client_cb_register(struct bt_mics_cb *cb)
 		}
 
 		for (i = 0; i < ARRAY_SIZE(mics_insts); i++) {
-			for (j = 0; j < ARRAY_SIZE(mics_insts[i].aics); j++) {
+			for (j = 0; j < ARRAY_SIZE(mics_insts[i].cli.aics); j++) {
 				if (mics_insts[i].aics[j] != NULL) {
-					bt_aics_client_cb_register(mics_insts[i].aics[j],
+					bt_aics_client_cb_register(mics_insts[i].cli.aics[j],
 								   aics_cb);
 				}
 			}
@@ -442,7 +442,7 @@ int bt_mics_client_cb_register(struct bt_mics_cb *cb)
 int bt_mics_client_included_get(struct bt_conn *conn,
 					struct bt_mics_included *included)
 {
-	struct bt_mics_client *mics_inst;
+	struct bt_mics *mics_inst;
 
 	CHECKIF(conn == NULL) {
 		return -EINVAL;
@@ -454,8 +454,8 @@ int bt_mics_client_included_get(struct bt_conn *conn,
 
 	mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	included->aics_cnt = mics_inst->aics_inst_cnt;
-	included->aics = mics_inst->aics;
+	included->aics_cnt = mics_inst->cli.aics_inst_cnt;
+	included->aics = mics_inst->cli.aics;
 
 	return 0;
 }
@@ -463,7 +463,7 @@ int bt_mics_client_included_get(struct bt_conn *conn,
 int bt_mics_client_mute_get(struct bt_conn *conn)
 {
 	int err;
-	struct bt_mics_client *mics_inst;
+	struct bt_mics *mics_inst;
 
 	CHECKIF(conn == NULL) {
 		BT_DBG("NULL conn");
@@ -472,21 +472,21 @@ int bt_mics_client_mute_get(struct bt_conn *conn)
 
 	mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	if (mics_inst->mute_handle == 0) {
+	if (mics_inst->cli.mute_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
-	} else if (mics_inst->busy) {
+	} else if (mics_inst->cli.busy) {
 		return -EBUSY;
 	}
 
-	mics_inst->read_params.func = mics_client_read_mute_cb;
-	mics_inst->read_params.handle_count = 1;
-	mics_inst->read_params.single.handle = mics_inst->mute_handle;
-	mics_inst->read_params.single.offset = 0U;
+	mics_inst->cli.read_params.func = mics_client_read_mute_cb;
+	mics_inst->cli.read_params.handle_count = 1;
+	mics_inst->cli.read_params.single.handle = mics_inst->cli.mute_handle;
+	mics_inst->cli.read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &mics_inst->read_params);
+	err = bt_gatt_read(conn, &mics_inst->cli.read_params);
 	if (err == 0) {
-		mics_inst->busy = true;
+		mics_inst->cli.busy = true;
 	}
 
 	return err;
@@ -495,7 +495,7 @@ int bt_mics_client_mute_get(struct bt_conn *conn)
 int bt_mics_client_write_mute(struct bt_conn *conn, bool mute)
 {
 	int err;
-	struct bt_mics_client *mics_inst;
+	struct bt_mics *mics_inst;
 
 	CHECKIF(conn == NULL) {
 		BT_DBG("NULL conn");
@@ -504,23 +504,23 @@ int bt_mics_client_write_mute(struct bt_conn *conn, bool mute)
 
 	mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	if (mics_inst->mute_handle == 0) {
+	if (mics_inst->cli.mute_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
-	} else if (mics_inst->busy) {
+	} else if (mics_inst->cli.busy) {
 		return -EBUSY;
 	}
 
-	mics_inst->mute_val_buf[0] = mute;
-	mics_inst->write_params.offset = 0;
-	mics_inst->write_params.data = mics_inst->mute_val_buf;
-	mics_inst->write_params.length = sizeof(mute);
-	mics_inst->write_params.handle = mics_inst->mute_handle;
-	mics_inst->write_params.func = mics_client_write_mics_mute_cb;
+	mics_inst->cli.mute_val_buf[0] = mute;
+	mics_inst->cli.write_params.offset = 0;
+	mics_inst->cli.write_params.data = mics_inst->cli.mute_val_buf;
+	mics_inst->cli.write_params.length = sizeof(mute);
+	mics_inst->cli.write_params.handle = mics_inst->cli.mute_handle;
+	mics_inst->cli.write_params.func = mics_client_write_mics_mute_cb;
 
-	err = bt_gatt_write(conn, &mics_inst->write_params);
+	err = bt_gatt_write(conn, &mics_inst->cli.write_params);
 	if (err == 0) {
-		mics_inst->busy = true;
+		mics_inst->cli.busy = true;
 	}
 
 	return err;

--- a/subsys/bluetooth/audio/mics_client.c
+++ b/subsys/bluetooth/audio/mics_client.c
@@ -462,6 +462,28 @@ int bt_mics_client_included_get(struct bt_mics *mics,
 	return 0;
 }
 
+int bt_mics_client_conn_get(const struct bt_mics *mics, struct bt_conn **conn)
+{
+	CHECKIF(mics == NULL) {
+		BT_DBG("NULL mics pointer");
+		return -EINVAL;
+	}
+
+	if (!mics->client_instance) {
+		BT_DBG("mics pointer shall be client instance");
+		return -EINVAL;
+	}
+
+	if (mics->cli.conn == NULL) {
+		BT_DBG("mics pointer not associated with a connection. "
+		       "Do discovery first");
+		return -ENOTCONN;
+	}
+
+	*conn = mics->cli.conn;
+	return 0;
+}
+
 int bt_mics_client_mute_get(struct bt_mics *mics)
 {
 	int err;

--- a/subsys/bluetooth/audio/mics_internal.h
+++ b/subsys/bluetooth/audio/mics_internal.h
@@ -9,6 +9,38 @@
 #include <zephyr/types.h>
 #include <bluetooth/gatt.h>
 
+struct bt_mics_server {
+	uint8_t mute;
+	struct bt_mics_cb *cb;
+	struct bt_gatt_service *service_p;
+	struct bt_aics *aics_insts[CONFIG_BT_MICS_AICS_INSTANCE_COUNT];
+};
+
+struct bt_mics_client {
+	uint16_t start_handle;
+	uint16_t end_handle;
+	uint16_t mute_handle;
+	struct bt_gatt_subscribe_params mute_sub_params;
+	struct bt_gatt_discover_params mute_sub_disc_params;
+
+	bool busy;
+	uint8_t mute_val_buf[1]; /* Mute value is a single octet */
+	struct bt_gatt_write_params write_params;
+	struct bt_gatt_read_params read_params;
+	struct bt_gatt_discover_params discover_params;
+
+	uint8_t aics_inst_cnt;
+	struct bt_aics *aics[CONFIG_BT_MICS_CLIENT_MAX_AICS_INST];
+};
+
+/* Struct used as a common type for the api */
+struct bt_mics {
+	union {
+		struct bt_mics_server srv;
+		struct bt_mics_client cli;
+	};
+};
+
 int bt_mics_client_included_get(struct bt_conn *conn,
 				struct bt_mics_included  *included);
 int bt_mics_client_mute_get(struct bt_conn *conn);

--- a/subsys/bluetooth/audio/mics_internal.h
+++ b/subsys/bluetooth/audio/mics_internal.h
@@ -28,6 +28,7 @@ struct bt_mics_client {
 	struct bt_gatt_write_params write_params;
 	struct bt_gatt_read_params read_params;
 	struct bt_gatt_discover_params discover_params;
+	struct bt_conn *conn;
 
 	uint8_t aics_inst_cnt;
 	struct bt_aics *aics[CONFIG_BT_MICS_CLIENT_MAX_AICS_INST];
@@ -35,17 +36,18 @@ struct bt_mics_client {
 
 /* Struct used as a common type for the api */
 struct bt_mics {
+	bool client_instance;
 	union {
 		struct bt_mics_server srv;
 		struct bt_mics_client cli;
 	};
 };
 
-int bt_mics_client_included_get(struct bt_conn *conn,
+int bt_mics_client_included_get(struct bt_mics *mics,
 				struct bt_mics_included  *included);
-int bt_mics_client_mute_get(struct bt_conn *conn);
-int bt_mics_client_mute(struct bt_conn *conn);
-int bt_mics_client_unmute(struct bt_conn *conn);
-bool bt_mics_client_valid_aics_inst(struct bt_conn *conn, struct bt_aics *aics);
+int bt_mics_client_mute_get(struct bt_mics *mics);
+int bt_mics_client_mute(struct bt_mics *mics);
+int bt_mics_client_unmute(struct bt_mics *mics);
+bool bt_mics_client_valid_aics_inst(struct bt_mics *mics, struct bt_aics *aics);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_MICS_INTERNAL_ */

--- a/subsys/bluetooth/shell/mics.c
+++ b/subsys/bluetooth/shell/mics.c
@@ -16,6 +16,7 @@
 
 #include "bt.h"
 
+static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 
 static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
@@ -132,7 +133,7 @@ static int cmd_mics_param(const struct shell *sh, size_t argc, char **argv)
 
 	mics_param.cb = &mics_cbs;
 
-	result = bt_mics_register(&mics_param);
+	result = bt_mics_register(&mics_param, &mics);
 	if (result != 0) {
 		shell_error(sh, "MICS register failed: %d", result);
 		return result;

--- a/subsys/bluetooth/shell/mics.c
+++ b/subsys/bluetooth/shell/mics.c
@@ -19,7 +19,7 @@
 static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 
-static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
+static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Mute get failed (%d)", err);
@@ -185,7 +185,7 @@ static int cmd_mics_unmute(const struct shell *sh, size_t argc, char **argv)
 static int cmd_mics_mute_disable(const struct shell *sh, size_t argc,
 				 char **argv)
 {
-	int result = bt_mics_mute_disable();
+	int result = bt_mics_mute_disable(mics);
 
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
@@ -206,7 +206,7 @@ static int cmd_mics_aics_deactivate(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_deactivate(mics_included.aics[index]);
+	result = bt_mics_aics_deactivate(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -226,7 +226,7 @@ static int cmd_mics_aics_activate(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_activate(mics_included.aics[index]);
+	result = bt_mics_aics_activate(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/mics_client.c
+++ b/subsys/bluetooth/shell/mics_client.c
@@ -19,7 +19,7 @@
 static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 
-static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
+static void mics_discover_cb(struct bt_mics *mics, int err, uint8_t aics_count)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "MICS discover failed (%d)", err);
@@ -27,13 +27,13 @@ static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
 		shell_print(ctx_shell, "MICS discover done with %u AICS",
 			    aics_count);
 
-		if (bt_mics_included_get(conn, &mics_included) != 0) {
+		if (bt_mics_included_get(mics, &mics_included) != 0) {
 			shell_error(ctx_shell, "Could not get MICS context");
 		}
 	}
 }
 
-static void mics_mute_write_cb(struct bt_conn *conn, int err)
+static void mics_mute_write_cb(struct bt_mics *mics, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Mute write failed (%d)", err);
@@ -43,7 +43,7 @@ static void mics_mute_write_cb(struct bt_conn *conn, int err)
 }
 
 
-static void mics_unmute_write_cb(struct bt_conn *conn, int err)
+static void mics_unmute_write_cb(struct bt_mics *mics, int err)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Unmute write failed (%d)", err);
@@ -112,7 +112,7 @@ static void mics_aics_automatic_mode_cb(struct bt_conn *conn,
 	}
 }
 
-static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
+static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 {
 	if (err != 0) {
 		shell_error(ctx_shell, "Mute get failed (%d)", err);
@@ -243,11 +243,11 @@ static int cmd_mics_client_mute_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_mute_get(default_conn);
+	result = bt_mics_mute_get(mics);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -261,11 +261,11 @@ static int cmd_mics_client_mute(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_mute(default_conn);
+	result = bt_mics_mute(mics);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -279,11 +279,11 @@ static int cmd_mics_client_unmute(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_unmute(default_conn);
+	result = bt_mics_unmute(mics);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -304,11 +304,11 @@ static int cmd_mics_client_aics_input_state_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_state_get(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_state_get(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -328,11 +328,11 @@ static int cmd_mics_client_aics_gain_setting_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_gain_setting_get(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_gain_setting_get(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -352,11 +352,11 @@ static int cmd_mics_client_aics_input_type_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_type_get(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_type_get(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -376,11 +376,11 @@ static int cmd_mics_client_aics_input_status_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_status_get(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_status_get(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -400,11 +400,11 @@ static int cmd_mics_client_aics_input_unmute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_unmute(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_unmute(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -424,11 +424,11 @@ static int cmd_mics_client_aics_input_mute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_mute(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_mute(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -448,11 +448,11 @@ static int cmd_mics_client_aics_manual_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_manual_gain_set(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_manual_gain_set(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -473,11 +473,11 @@ static int cmd_mics_client_aics_automatic_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_automatic_gain_set(default_conn,
+	result = bt_mics_aics_automatic_gain_set(mics,
 						 mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -505,11 +505,11 @@ static int cmd_mics_client_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_gain_set(default_conn, mics_included.aics[index], gain);
+	result = bt_mics_aics_gain_set(mics, mics_included.aics[index], gain);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -529,11 +529,11 @@ static int cmd_mics_client_aics_input_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_description_get(default_conn, mics_included.aics[index]);
+	result = bt_mics_aics_description_get(mics, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -554,11 +554,11 @@ static int cmd_mics_client_aics_input_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (default_conn == NULL) {
-		return -ENOTCONN;
+	if (mics == NULL) {
+		return -ENOENT;
 	}
 
-	result = bt_mics_aics_description_set(default_conn, mics_included.aics[index],
+	result = bt_mics_aics_description_set(mics, mics_included.aics[index],
 					      description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);

--- a/subsys/bluetooth/shell/mics_client.c
+++ b/subsys/bluetooth/shell/mics_client.c
@@ -16,6 +16,7 @@
 
 #include "bt.h"
 
+static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 
 static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
@@ -229,7 +230,7 @@ static int cmd_mics_client_discover(const struct shell *sh, size_t argc,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_discover(default_conn);
+	result = bt_mics_discover(default_conn, &mics);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -18,6 +18,7 @@
 static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 
+static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
@@ -397,7 +398,7 @@ static void test_main(void)
 	}
 	WAIT_FOR(g_mtu_exchanged);
 
-	err = bt_mics_discover(g_conn);
+	err = bt_mics_discover(g_conn, &mics);
 	if (err != 0) {
 		FAIL("Failed to discover MICS %d", err);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -126,7 +126,7 @@ static void aics_write_cb(struct bt_conn *conn, struct bt_aics *inst, int err)
 	g_write_complete = true;
 }
 
-static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
+static void mics_discover_cb(struct bt_mics *mics, int err, uint8_t aics_count)
 {
 	if (err != 0) {
 		FAIL("MICS could not be discovered (%d)\n", err);
@@ -137,7 +137,7 @@ static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
 	g_discovery_complete = true;
 }
 
-static void mics_mute_write_cb(struct bt_conn *conn, int err)
+static void mics_mute_write_cb(struct bt_mics *mics, int err)
 {
 	if (err != 0) {
 		FAIL("MICS mute write failed (%d)\n", err);
@@ -147,7 +147,7 @@ static void mics_mute_write_cb(struct bt_conn *conn, int err)
 	g_write_complete = true;
 }
 
-static void mics_unmute_write_cb(struct bt_conn *conn, int err)
+static void mics_unmute_write_cb(struct bt_mics *mics, int err)
 {
 	if (err != 0) {
 		FAIL("MICS unmute write failed (%d)\n", err);
@@ -157,7 +157,7 @@ static void mics_unmute_write_cb(struct bt_conn *conn, int err)
 	g_write_complete = true;
 }
 
-static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
+static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 {
 	if (err != 0) {
 		FAIL("MICS mute read failed (%d)\n", err);
@@ -240,7 +240,7 @@ static int test_aics(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_mics_aics_state_get(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_state_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -250,7 +250,7 @@ static int test_aics(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_mics_aics_gain_setting_get(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_gain_setting_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -261,7 +261,7 @@ static int test_aics(void)
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	g_cb = false;
-	err = bt_mics_aics_type_get(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_type_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -272,7 +272,7 @@ static int test_aics(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_mics_aics_status_get(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_status_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -282,7 +282,7 @@ static int test_aics(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_mics_aics_description_get(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_description_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -293,7 +293,7 @@ static int test_aics(void)
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_mute(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_mute(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -305,7 +305,7 @@ static int test_aics(void)
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_unmute(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_unmute(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -317,7 +317,7 @@ static int test_aics(void)
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_automatic_gain_set(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_automatic_gain_set(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -328,7 +328,7 @@ static int test_aics(void)
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_manual_gain_set(g_conn, mics_included.aics[0]);
+	err = bt_mics_aics_manual_gain_set(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -339,7 +339,7 @@ static int test_aics(void)
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_gain_set(g_conn, mics_included.aics[0], expected_gain);
+	err = bt_mics_aics_gain_set(mics, mics_included.aics[0], expected_gain);
 	if (err != 0) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -352,7 +352,7 @@ static int test_aics(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_mics_aics_description_set(g_conn, mics_included.aics[0],
+	err = bt_mics_aics_description_set(mics, mics_included.aics[0],
 					   expected_aics_desc);
 	if (err != 0) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
@@ -404,7 +404,7 @@ static void test_main(void)
 	}
 	WAIT_FOR(g_discovery_complete);
 
-	err = bt_mics_included_get(g_conn, &mics_included);
+	err = bt_mics_included_get(mics, &mics_included);
 	if (err != 0) {
 		FAIL("Failed to get MICS context (err %d)\n", err);
 		return;
@@ -412,7 +412,7 @@ static void test_main(void)
 
 	printk("Getting MICS mute state\n");
 	g_cb = false;
-	err = bt_mics_mute_get(g_conn);
+	err = bt_mics_mute_get(mics);
 	if (err != 0) {
 		FAIL("Could not get MICS mute state (err %d)\n", err);
 		return;
@@ -423,7 +423,7 @@ static void test_main(void)
 	printk("Muting MICS\n");
 	expected_mute = 1;
 	g_write_complete = g_cb = false;
-	err = bt_mics_mute(g_conn);
+	err = bt_mics_mute(mics);
 	if (err != 0) {
 		FAIL("Could not mute MICS (err %d)\n", err);
 		return;
@@ -434,7 +434,7 @@ static void test_main(void)
 	printk("Unmuting MICS\n");
 	expected_mute = 0;
 	g_write_complete = g_cb = false;
-	err = bt_mics_unmute(g_conn);
+	err = bt_mics_unmute(mics);
 	if (err != 0) {
 		FAIL("Could not unmute MICS (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -371,6 +371,7 @@ static void test_main(void)
 	int err;
 	uint8_t expected_mute;
 	static struct bt_gatt_exchange_params mtu_params = { .func = mtu_cb };
+	struct bt_conn *cached_conn;
 
 	err = bt_enable(bt_ready);
 
@@ -407,6 +408,17 @@ static void test_main(void)
 	err = bt_mics_included_get(mics, &mics_included);
 	if (err != 0) {
 		FAIL("Failed to get MICS context (err %d)\n", err);
+		return;
+	}
+
+	printk("Getting MICS client conn\n");
+	err = bt_mics_client_conn_get(mics, &cached_conn);
+	if (err != 0) {
+		FAIL("Failed to get MICS client conn (err %d)\n", err);
+		return;
+	}
+	if (cached_conn != g_conn) {
+		FAIL("Cached conn was not the conn used to discover");
 		return;
 	}
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -16,6 +16,7 @@ extern enum bst_result_t bst_result;
 #define AICS_DESC_SIZE 0
 #endif /* CONFIG_BT_AICS */
 
+static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 
 static volatile uint8_t g_mute;
@@ -346,7 +347,7 @@ static void test_server_only(void)
 	}
 	mics_param.cb = &mics_cb;
 
-	err = bt_mics_register(&mics_param);
+	err = bt_mics_register(&mics_param, &mics);
 	if (err != 0) {
 		FAIL("MICS init failed (err %d)\n", err);
 		return;
@@ -440,7 +441,7 @@ static void test_main(void)
 	}
 	mics_param.cb = &mics_cb;
 
-	err = bt_mics_register(&mics_param);
+	err = bt_mics_register(&mics_param, &mics);
 	if (err != 0) {
 		FAIL("MICS init failed (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -33,7 +33,7 @@ static volatile bool g_cb;
 static struct bt_conn *g_conn;
 static bool g_is_connected;
 
-static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
+static void mics_mute_cb(struct bt_mics *mics, int err, uint8_t mute)
 {
 	if (err != 0) {
 		FAIL("MICS mute cb err (%d)", err);
@@ -41,10 +41,7 @@ static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
 	}
 
 	g_mute = mute;
-
-	if (conn == NULL) {
-		g_cb = true;
-	}
+	g_cb = true;
 }
 
 static void aics_state_cb(struct bt_conn *conn, struct bt_aics *inst, int err,
@@ -174,7 +171,7 @@ static int test_aics_server_only(void)
 
 	printk("Deactivating AICS\n");
 	expected_aics_active = false;
-	err = bt_mics_aics_deactivate(mics_included.aics[0]);
+	err = bt_mics_aics_deactivate(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
@@ -184,7 +181,7 @@ static int test_aics_server_only(void)
 
 	printk("Activating AICS\n");
 	expected_aics_active = true;
-	err = bt_mics_aics_activate(mics_included.aics[0]);
+	err = bt_mics_aics_activate(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
@@ -194,7 +191,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_mics_aics_state_get(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_state_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -204,7 +201,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_mics_aics_gain_setting_get(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_gain_setting_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -215,7 +212,7 @@ static int test_aics_server_only(void)
 	printk("Getting AICS input type\n");
 	g_cb = false;
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
-	err = bt_mics_aics_type_get(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_type_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -226,7 +223,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_mics_aics_status_get(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_status_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -236,7 +233,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_mics_aics_description_get(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_description_get(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -247,7 +244,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS mute\n");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_MUTED;
-	err = bt_mics_aics_mute(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_mute(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -258,7 +255,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS unmute\n");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
-	err = bt_mics_aics_unmute(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_unmute(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -269,7 +266,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS auto mode\n");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_AUTO;
-	err = bt_mics_aics_automatic_gain_set(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_automatic_gain_set(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -280,7 +277,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS manual mode\n");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_MANUAL;
-	err = bt_mics_aics_manual_gain_set(NULL, mics_included.aics[0]);
+	err = bt_mics_aics_manual_gain_set(mics, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -291,7 +288,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS gain\n");
 	g_cb = false;
 	expected_gain = g_aics_gain_max - 1;
-	err = bt_mics_aics_gain_set(NULL, mics_included.aics[0], expected_gain);
+	err = bt_mics_aics_gain_set(mics, mics_included.aics[0], expected_gain);
 	if (err != 0) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -304,7 +301,7 @@ static int test_aics_server_only(void)
 	strncpy(expected_aics_desc, "New Input Description",
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
-	err = bt_mics_aics_description_set(NULL, mics_included.aics[0], expected_aics_desc);
+	err = bt_mics_aics_description_set(mics, mics_included.aics[0], expected_aics_desc);
 	if (err != 0) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
@@ -353,7 +350,7 @@ static void test_server_only(void)
 		return;
 	}
 
-	err = bt_mics_included_get(NULL, &mics_included);
+	err = bt_mics_included_get(mics, &mics_included);
 	if (err != 0) {
 		FAIL("MICS get failed (err %d)\n", err);
 		return;
@@ -363,7 +360,7 @@ static void test_server_only(void)
 
 	printk("Getting MICS mute\n");
 	g_cb = false;
-	err = bt_mics_mute_get(NULL);
+	err = bt_mics_mute_get(mics);
 	if (err != 0) {
 		FAIL("Could not get MICS mute (err %d)\n", err);
 		return;
@@ -373,7 +370,7 @@ static void test_server_only(void)
 
 	printk("Setting MICS mute\n");
 	expected_mute = BT_MICS_MUTE_MUTED;
-	err = bt_mics_mute(NULL);
+	err = bt_mics_mute(mics);
 	if (err != 0) {
 		FAIL("MICS mute failed (err %d)\n", err);
 		return;
@@ -383,7 +380,7 @@ static void test_server_only(void)
 
 	printk("Setting MICS unmute\n");
 	expected_mute = BT_MICS_MUTE_UNMUTED;
-	err = bt_mics_unmute(NULL);
+	err = bt_mics_unmute(mics);
 	if (err != 0) {
 		FAIL("MICS unmute failed (err %d)\n", err);
 		return;
@@ -393,7 +390,7 @@ static void test_server_only(void)
 
 	printk("Setting MICS disable\n");
 	expected_mute = BT_MICS_MUTE_DISABLED;
-	err = bt_mics_mute_disable();
+	err = bt_mics_mute_disable(mics);
 	if (err != 0) {
 		FAIL("MICS disable failed (err %d)\n", err);
 		return;
@@ -449,7 +446,7 @@ static void test_main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_mics_included_get(NULL, &mics_included);
+	err = bt_mics_included_get(mics, &mics_included);
 	if (err != 0) {
 		FAIL("MICS get failed (err %d)\n", err);
 		return;


### PR DESCRIPTION
Updates the MICS API to use the bt_mics instance pointer instead of a bt_conn pointer. This was requsted during a recent API discussion, and should make the API simpler, especially since it's the same API for local and remote procedures.

Fixes: #36306 
Fixed #36307 
