### PR TITLE
Bluetooth: Audio: Rename bt_mics to bt_mics_included

### DIFF
--- a/include/bluetooth/audio/mics.h
+++ b/include/bluetooth/audio/mics.h
@@ -51,13 +51,13 @@ struct bt_mics_register_param {
 };
 
 /**
- * @brief Microphone Input Control Service instance
+ * @brief Microphone Input Control Service included services
  *
- * Used for to represent a Microphone Input Control Service, for either
- * a client or a server instance. The instance pointers either represent local
- * server instances, or remote service instances.
+ * Used for to represent the Microphone Input Control Service included service
+ * instances, for either a client or a server instance. The instance pointers
+ * either represent local server instances, or remote service instances.
  */
-struct bt_mics {
+struct bt_mics_included  {
 	/** Number of Audio Input Control Service instances */
 	uint8_t aics_cnt;
 	/** Array of pointers to Audio Input Control Service instances */
@@ -77,18 +77,19 @@ struct bt_mics {
 int bt_mics_register(struct bt_mics_register_param *param);
 
 /**
- * @brief Get Microphone Input Control Service pointer
+ * @brief Get Microphone Input Control Service included services
  *
  * Returns a pointer to a struct that contains information about the
- * Microphone Input Control Service instance, such as pointers to the
- * Audio Input Control Service instances.
+ * Microphone Input Control Service included services instances, such as
+ * pointers to the Audio Input Control Service instances.
  *
  * @param conn          Connection to peer device, or NULL to get server value.
- * @param[out] service  Pointer to store the result in.
+ * @param[out] included Pointer to store the result in.
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mics_get(struct bt_conn *conn, struct bt_mics *service);
+int bt_mics_included_get(struct bt_conn *conn,
+			 struct bt_mics_included *included);
 
 /**
  * @brief Callback function for @ref bt_mics_discover.

--- a/subsys/bluetooth/audio/mics.c
+++ b/subsys/bluetooth/audio/mics.c
@@ -223,23 +223,24 @@ static bool valid_aics_inst(struct bt_aics *aics)
 	return false;
 }
 
-int bt_mics_get(struct bt_conn *conn, struct bt_mics *service)
+int bt_mics_included_get(struct bt_conn *conn,
+			 struct bt_mics_included *included)
 {
-	CHECKIF(service == NULL) {
+	CHECKIF(included == NULL) {
 		BT_DBG("NULL service pointer");
 		return -EINVAL;
 	}
 
 #if defined(CONFIG_BT_MICS_CLIENT)
 	if (conn != NULL) {
-		return bt_mics_client_service_get(conn, service);
+		return bt_mics_client_included_get(conn, included);
 	}
 #endif /* CONFIG_BT_MICS_CLIENT */
 
 #if defined(CONFIG_BT_MICS)
 	if (conn == NULL) {
-		service->aics_cnt = ARRAY_SIZE(mics_inst.aics_insts);
-		service->aics = mics_inst.aics_insts;
+		included->aics_cnt = ARRAY_SIZE(mics_inst.aics_insts);
+		included->aics = mics_inst.aics_insts;
 
 		return 0;
 	}

--- a/subsys/bluetooth/audio/mics_client.c
+++ b/subsys/bluetooth/audio/mics_client.c
@@ -447,7 +447,8 @@ int bt_mics_client_cb_register(struct bt_mics_cb *cb)
 	return 0;
 }
 
-int bt_mics_client_service_get(struct bt_conn *conn, struct bt_mics *service)
+int bt_mics_client_included_get(struct bt_conn *conn,
+					struct bt_mics_included *included)
 {
 	struct mics_instance *mics_inst;
 
@@ -455,14 +456,14 @@ int bt_mics_client_service_get(struct bt_conn *conn, struct bt_mics *service)
 		return -EINVAL;
 	}
 
-	CHECKIF(service == NULL) {
+	CHECKIF(included == NULL) {
 		return -EINVAL;
 	}
 
 	mics_inst = &mics_insts[bt_conn_index(conn)];
 
-	service->aics_cnt = mics_inst->aics_inst_cnt;
-	service->aics = mics_inst->aics;
+	included->aics_cnt = mics_inst->aics_inst_cnt;
+	included->aics = mics_inst->aics;
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/mics_internal.h
+++ b/subsys/bluetooth/audio/mics_internal.h
@@ -9,7 +9,8 @@
 #include <zephyr/types.h>
 #include <bluetooth/gatt.h>
 
-int bt_mics_client_service_get(struct bt_conn *conn, struct bt_mics *service);
+int bt_mics_client_included_get(struct bt_conn *conn,
+				struct bt_mics_included  *included);
 int bt_mics_client_mute_get(struct bt_conn *conn);
 int bt_mics_client_mute(struct bt_conn *conn);
 int bt_mics_client_unmute(struct bt_conn *conn);

--- a/subsys/bluetooth/shell/mics.c
+++ b/subsys/bluetooth/shell/mics.c
@@ -16,7 +16,7 @@
 
 #include "bt.h"
 
-static struct bt_mics mics;
+static struct bt_mics_included mics_included;
 
 static void mics_mute_cb(struct bt_conn *conn, int err, uint8_t mute)
 {
@@ -140,7 +140,7 @@ static int cmd_mics_param(const struct shell *sh, size_t argc, char **argv)
 
 	shell_print(sh, "MICS initialized", result);
 
-	result = bt_mics_get(NULL, &mics);
+	result = bt_mics_included_get(NULL, &mics_included);
 	if (result != 0) {
 		shell_error(sh, "MICS get failed: %d", result);
 	}
@@ -199,13 +199,13 @@ static int cmd_mics_aics_deactivate(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_deactivate(mics.aics[index]);
+	result = bt_mics_aics_deactivate(mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -219,13 +219,13 @@ static int cmd_mics_aics_activate(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_activate(mics.aics[index]);
+	result = bt_mics_aics_activate(mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -239,13 +239,13 @@ static int cmd_mics_aics_input_state_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_state_get(NULL, mics.aics[index]);
+	result = bt_mics_aics_state_get(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -259,13 +259,13 @@ static int cmd_mics_aics_gain_setting_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_gain_setting_get(NULL, mics.aics[index]);
+	result = bt_mics_aics_gain_setting_get(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -279,13 +279,13 @@ static int cmd_mics_aics_input_type_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_type_get(NULL, mics.aics[index]);
+	result = bt_mics_aics_type_get(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -299,13 +299,13 @@ static int cmd_mics_aics_input_status_get(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_status_get(NULL, mics.aics[index]);
+	result = bt_mics_aics_status_get(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -319,13 +319,13 @@ static int cmd_mics_aics_input_unmute(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_unmute(NULL, mics.aics[index]);
+	result = bt_mics_aics_unmute(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -339,13 +339,13 @@ static int cmd_mics_aics_input_mute(const struct shell *sh, size_t argc,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_mute(NULL, mics.aics[index]);
+	result = bt_mics_aics_mute(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -359,13 +359,13 @@ static int cmd_mics_aics_manual_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_manual_gain_set(NULL, mics.aics[index]);
+	result = bt_mics_aics_manual_gain_set(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -379,13 +379,13 @@ static int cmd_mics_aics_automatic_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_automatic_gain_set(NULL, mics.aics[index]);
+	result = bt_mics_aics_automatic_gain_set(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -400,9 +400,9 @@ static int cmd_mics_aics_gain_set(const struct shell *sh, size_t argc,
 	int index = strtol(argv[1], NULL, 0);
 	int gain = strtol(argv[2], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -412,7 +412,7 @@ static int cmd_mics_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_gain_set(NULL, mics.aics[index], gain);
+	result = bt_mics_aics_gain_set(NULL, mics_included.aics[index], gain);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -426,13 +426,13 @@ static int cmd_mics_aics_input_description_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_description_get(NULL, mics.aics[index]);
+	result = bt_mics_aics_description_get(NULL, mics_included.aics[index]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -447,13 +447,13 @@ static int cmd_mics_aics_input_description_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	char *description = argv[2];
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
-	result = bt_mics_aics_description_set(NULL, mics.aics[index],
+	result = bt_mics_aics_description_set(NULL, mics_included.aics[index],
 					      description);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);

--- a/subsys/bluetooth/shell/mics_client.c
+++ b/subsys/bluetooth/shell/mics_client.c
@@ -16,7 +16,7 @@
 
 #include "bt.h"
 
-static struct bt_mics mics;
+static struct bt_mics_included mics_included;
 
 static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
 {
@@ -26,7 +26,7 @@ static void mics_discover_cb(struct bt_conn *conn, int err, uint8_t aics_count)
 		shell_print(ctx_shell, "MICS discover done with %u AICS",
 			    aics_count);
 
-		if (bt_mics_get(conn, &mics) != 0) {
+		if (bt_mics_included_get(conn, &mics_included) != 0) {
 			shell_error(ctx_shell, "Could not get MICS context");
 		}
 	}
@@ -297,9 +297,9 @@ static int cmd_mics_client_aics_input_state_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -307,7 +307,7 @@ static int cmd_mics_client_aics_input_state_get(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_state_get(default_conn, mics.aics[index]);
+	result = bt_mics_aics_state_get(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -321,9 +321,9 @@ static int cmd_mics_client_aics_gain_setting_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -331,7 +331,7 @@ static int cmd_mics_client_aics_gain_setting_get(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_gain_setting_get(default_conn, mics.aics[index]);
+	result = bt_mics_aics_gain_setting_get(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -345,9 +345,9 @@ static int cmd_mics_client_aics_input_type_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -355,7 +355,7 @@ static int cmd_mics_client_aics_input_type_get(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_type_get(default_conn, mics.aics[index]);
+	result = bt_mics_aics_type_get(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -369,9 +369,9 @@ static int cmd_mics_client_aics_input_status_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -379,7 +379,7 @@ static int cmd_mics_client_aics_input_status_get(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_status_get(default_conn, mics.aics[index]);
+	result = bt_mics_aics_status_get(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -393,9 +393,9 @@ static int cmd_mics_client_aics_input_unmute(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -403,7 +403,7 @@ static int cmd_mics_client_aics_input_unmute(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_unmute(default_conn, mics.aics[index]);
+	result = bt_mics_aics_unmute(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -417,9 +417,9 @@ static int cmd_mics_client_aics_input_mute(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -427,7 +427,7 @@ static int cmd_mics_client_aics_input_mute(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_mute(default_conn, mics.aics[index]);
+	result = bt_mics_aics_mute(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -441,9 +441,9 @@ static int cmd_mics_client_aics_manual_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -451,7 +451,7 @@ static int cmd_mics_client_aics_manual_input_gain_set(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_manual_gain_set(default_conn, mics.aics[index]);
+	result = bt_mics_aics_manual_gain_set(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -466,9 +466,9 @@ static int cmd_mics_client_aics_automatic_input_gain_set(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -477,7 +477,7 @@ static int cmd_mics_client_aics_automatic_input_gain_set(const struct shell *sh,
 	}
 
 	result = bt_mics_aics_automatic_gain_set(default_conn,
-						 mics.aics[index]);
+						 mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -492,9 +492,9 @@ static int cmd_mics_client_aics_gain_set(const struct shell *sh, size_t argc,
 	int index = strtol(argv[1], NULL, 0);
 	int gain = strtol(argv[2], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -508,7 +508,7 @@ static int cmd_mics_client_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_gain_set(default_conn, mics.aics[index], gain);
+	result = bt_mics_aics_gain_set(default_conn, mics_included.aics[index], gain);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -522,9 +522,9 @@ static int cmd_mics_client_aics_input_description_get(const struct shell *sh,
 	int result;
 	int index = strtol(argv[1], NULL, 0);
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -532,7 +532,7 @@ static int cmd_mics_client_aics_input_description_get(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_description_get(default_conn, mics.aics[index]);
+	result = bt_mics_aics_description_get(default_conn, mics_included.aics[index]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -547,9 +547,9 @@ static int cmd_mics_client_aics_input_description_set(const struct shell *sh,
 	int index = strtol(argv[1], NULL, 0);
 	char *description = argv[2];
 
-	if (index >= mics.aics_cnt) {
+	if (index >= mics_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
-			    mics.aics_cnt, index);
+			    mics_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
 
@@ -557,7 +557,7 @@ static int cmd_mics_client_aics_input_description_set(const struct shell *sh,
 		return -ENOTCONN;
 	}
 
-	result = bt_mics_aics_description_set(default_conn, mics.aics[index],
+	result = bt_mics_aics_description_set(default_conn, mics_included.aics[index],
 					      description);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -18,7 +18,7 @@
 static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 
-static struct bt_mics mics;
+static struct bt_mics_included mics_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
 static volatile bool g_mtu_exchanged;
@@ -239,7 +239,7 @@ static int test_aics(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_mics_aics_state_get(g_conn, mics.aics[0]);
+	err = bt_mics_aics_state_get(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -249,7 +249,7 @@ static int test_aics(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_mics_aics_gain_setting_get(g_conn, mics.aics[0]);
+	err = bt_mics_aics_gain_setting_get(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -260,7 +260,7 @@ static int test_aics(void)
 	printk("Getting AICS input type\n");
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	g_cb = false;
-	err = bt_mics_aics_type_get(g_conn, mics.aics[0]);
+	err = bt_mics_aics_type_get(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -271,7 +271,7 @@ static int test_aics(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_mics_aics_status_get(g_conn, mics.aics[0]);
+	err = bt_mics_aics_status_get(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -281,7 +281,7 @@ static int test_aics(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_mics_aics_description_get(g_conn, mics.aics[0]);
+	err = bt_mics_aics_description_get(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -292,7 +292,7 @@ static int test_aics(void)
 	printk("Setting AICS mute\n");
 	expected_input_mute = BT_AICS_STATE_MUTED;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_mute(g_conn, mics.aics[0]);
+	err = bt_mics_aics_mute(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -304,7 +304,7 @@ static int test_aics(void)
 	printk("Setting AICS unmute\n");
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_unmute(g_conn, mics.aics[0]);
+	err = bt_mics_aics_unmute(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -316,7 +316,7 @@ static int test_aics(void)
 	printk("Setting AICS auto mode\n");
 	expected_mode = BT_AICS_MODE_AUTO;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_automatic_gain_set(g_conn, mics.aics[0]);
+	err = bt_mics_aics_automatic_gain_set(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -327,7 +327,7 @@ static int test_aics(void)
 	printk("Setting AICS manual mode\n");
 	expected_mode = BT_AICS_MODE_MANUAL;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_manual_gain_set(g_conn, mics.aics[0]);
+	err = bt_mics_aics_manual_gain_set(g_conn, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -338,7 +338,7 @@ static int test_aics(void)
 	printk("Setting AICS gain\n");
 	expected_gain = g_aics_gain_max - 1;
 	g_write_complete = g_cb = false;
-	err = bt_mics_aics_gain_set(g_conn, mics.aics[0], expected_gain);
+	err = bt_mics_aics_gain_set(g_conn, mics_included.aics[0], expected_gain);
 	if (err != 0) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -351,7 +351,7 @@ static int test_aics(void)
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
 	g_cb = false;
-	err = bt_mics_aics_description_set(g_conn, mics.aics[0],
+	err = bt_mics_aics_description_set(g_conn, mics_included.aics[0],
 					   expected_aics_desc);
 	if (err != 0) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
@@ -403,7 +403,7 @@ static void test_main(void)
 	}
 	WAIT_FOR(g_discovery_complete);
 
-	err = bt_mics_get(g_conn, &mics);
+	err = bt_mics_included_get(g_conn, &mics_included);
 	if (err != 0) {
 		FAIL("Failed to get MICS context (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -16,7 +16,7 @@ extern enum bst_result_t bst_result;
 #define AICS_DESC_SIZE 0
 #endif /* CONFIG_BT_AICS */
 
-static struct bt_mics mics;
+static struct bt_mics_included mics_included;
 
 static volatile uint8_t g_mute;
 static volatile int8_t g_aics_gain;
@@ -173,7 +173,7 @@ static int test_aics_server_only(void)
 
 	printk("Deactivating AICS\n");
 	expected_aics_active = false;
-	err = bt_mics_aics_deactivate(mics.aics[0]);
+	err = bt_mics_aics_deactivate(mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
@@ -183,7 +183,7 @@ static int test_aics_server_only(void)
 
 	printk("Activating AICS\n");
 	expected_aics_active = true;
-	err = bt_mics_aics_activate(mics.aics[0]);
+	err = bt_mics_aics_activate(mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
@@ -193,7 +193,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS state\n");
 	g_cb = false;
-	err = bt_mics_aics_state_get(NULL, mics.aics[0]);
+	err = bt_mics_aics_state_get(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
@@ -203,7 +203,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS gain setting\n");
 	g_cb = false;
-	err = bt_mics_aics_gain_setting_get(NULL, mics.aics[0]);
+	err = bt_mics_aics_gain_setting_get(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
@@ -214,7 +214,7 @@ static int test_aics_server_only(void)
 	printk("Getting AICS input type\n");
 	g_cb = false;
 	expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
-	err = bt_mics_aics_type_get(NULL, mics.aics[0]);
+	err = bt_mics_aics_type_get(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS input type (err %d)\n", err);
 		return err;
@@ -225,7 +225,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS status\n");
 	g_cb = false;
-	err = bt_mics_aics_status_get(NULL, mics.aics[0]);
+	err = bt_mics_aics_status_get(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
@@ -235,7 +235,7 @@ static int test_aics_server_only(void)
 
 	printk("Getting AICS description\n");
 	g_cb = false;
-	err = bt_mics_aics_description_get(NULL, mics.aics[0]);
+	err = bt_mics_aics_description_get(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
@@ -246,7 +246,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS mute\n");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_MUTED;
-	err = bt_mics_aics_mute(NULL, mics.aics[0]);
+	err = bt_mics_aics_mute(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
@@ -257,7 +257,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS unmute\n");
 	g_cb = false;
 	expected_input_mute = BT_AICS_STATE_UNMUTED;
-	err = bt_mics_aics_unmute(NULL, mics.aics[0]);
+	err = bt_mics_aics_unmute(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
@@ -268,7 +268,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS auto mode\n");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_AUTO;
-	err = bt_mics_aics_automatic_gain_set(NULL, mics.aics[0]);
+	err = bt_mics_aics_automatic_gain_set(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
@@ -279,7 +279,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS manual mode\n");
 	g_cb = false;
 	expected_mode = BT_AICS_MODE_MANUAL;
-	err = bt_mics_aics_manual_gain_set(NULL, mics.aics[0]);
+	err = bt_mics_aics_manual_gain_set(NULL, mics_included.aics[0]);
 	if (err != 0) {
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
@@ -290,7 +290,7 @@ static int test_aics_server_only(void)
 	printk("Setting AICS gain\n");
 	g_cb = false;
 	expected_gain = g_aics_gain_max - 1;
-	err = bt_mics_aics_gain_set(NULL, mics.aics[0], expected_gain);
+	err = bt_mics_aics_gain_set(NULL, mics_included.aics[0], expected_gain);
 	if (err != 0) {
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
@@ -303,7 +303,7 @@ static int test_aics_server_only(void)
 	strncpy(expected_aics_desc, "New Input Description",
 		sizeof(expected_aics_desc));
 	expected_aics_desc[sizeof(expected_aics_desc) - 1] = '\0';
-	err = bt_mics_aics_description_set(NULL, mics.aics[0], expected_aics_desc);
+	err = bt_mics_aics_description_set(NULL, mics_included.aics[0], expected_aics_desc);
 	if (err != 0) {
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
@@ -352,7 +352,7 @@ static void test_server_only(void)
 		return;
 	}
 
-	err = bt_mics_get(NULL, &mics);
+	err = bt_mics_included_get(NULL, &mics_included);
 	if (err != 0) {
 		FAIL("MICS get failed (err %d)\n", err);
 		return;
@@ -448,7 +448,7 @@ static void test_main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_mics_get(NULL, &mics);
+	err = bt_mics_included_get(NULL, &mics_included);
 	if (err != 0) {
 		FAIL("MICS get failed (err %d)\n", err);
 		return;


### PR DESCRIPTION
Rename the struct from bt_mics to bt_mics_included, and
rename bt_mics_get to bt_mics_included_get as that is more
descriptive of the value returned.

Furthermore, this will also allow us to use bt_mics as
an opaque pointer to a MICS service instance (local
or remote) to match the service instance pointers of
AICS.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>