### PR TITLE
run_ci.sh - minor fix, cleanup and refactoring

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -208,8 +208,8 @@ if [ -n "$main_ci" ]; then
 	$short_git_log
 
 	# cleanup
-	rm -f test_file.txt
-	touch test_file_boards.txt test_file_tests.txt test_file_archs.txt
+	rm -f test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_main.txt
+	touch test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_main.txt
 
 	# In a pull-request see if we have changed any tests or board definitions
 	if [ -n "${pull_request_nr}" -o -n "${local_run}"  ]; then
@@ -219,18 +219,19 @@ if [ -n "$main_ci" ]; then
 	if [ "$SC" == "full" ]; then
 		# Save list of tests to be run
 		${twister} ${twister_options} --save-tests test_file_main.txt || exit 1
-	else
-		echo "test,arch,platform,status,extra_args,handler,handler_time,ram_size,rom_size" \
-			> test_file_main.txt
 	fi
 
-	# Remove headers from all files but the first one to generate one
-	# single file with only one header row
+	# Remove headers from all files.  We insert it into test_file.txt explicitly
+	# so we treat all test_file*.txt files the same.
+	tail -n +2 test_file_main.txt > test_file_main_in.txt
 	tail -n +2 test_file_archs.txt > test_file_archs_in.txt
 	tail -n +2 test_file_tests.txt > test_file_tests_in.txt
 	tail -n +2 test_file_boards.txt > test_file_boards_in.txt
-	cat test_file_main.txt test_file_archs_in.txt test_file_tests_in.txt \
-		test_file_boards_in.txt > test_file.txt
+
+	echo "test,arch,platform,status,extra_args,handler,handler_time,ram_size,rom_size" \
+		> test_file.txt
+	cat test_file_main_in.txt test_file_archs_in.txt test_file_tests_in.txt \
+		test_file_boards_in.txt >> test_file.txt
 
 	echo "+++ run twister"
 

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -208,8 +208,8 @@ if [ -n "$main_ci" ]; then
 	$short_git_log
 
 	# cleanup
-	rm -f test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_main.txt
-	touch test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_main.txt
+	rm -f test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_full.txt
+	touch test_file_boards.txt test_file_tests.txt test_file_archs.txt test_file_full.txt
 
 	# In a pull-request see if we have changed any tests or board definitions
 	if [ -n "${pull_request_nr}" -o -n "${local_run}"  ]; then
@@ -218,19 +218,19 @@ if [ -n "$main_ci" ]; then
 
 	if [ "$SC" == "full" ]; then
 		# Save list of tests to be run
-		${twister} ${twister_options} --save-tests test_file_main.txt || exit 1
+		${twister} ${twister_options} --save-tests test_file_full.txt || exit 1
 	fi
 
 	# Remove headers from all files.  We insert it into test_file.txt explicitly
 	# so we treat all test_file*.txt files the same.
-	tail -n +2 test_file_main.txt > test_file_main_in.txt
+	tail -n +2 test_file_full.txt > test_file_full_in.txt
 	tail -n +2 test_file_archs.txt > test_file_archs_in.txt
 	tail -n +2 test_file_tests.txt > test_file_tests_in.txt
 	tail -n +2 test_file_boards.txt > test_file_boards_in.txt
 
 	echo "test,arch,platform,status,extra_args,handler,handler_time,ram_size,rom_size" \
 		> test_file.txt
-	cat test_file_main_in.txt test_file_archs_in.txt test_file_tests_in.txt \
+	cat test_file_full_in.txt test_file_archs_in.txt test_file_tests_in.txt \
 		test_file_boards_in.txt >> test_file.txt
 
 	echo "+++ run twister"

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -189,8 +189,14 @@ if [ -n "$main_ci" ]; then
 	# Possibly the only record of what exact version is being tested:
 	short_git_log='git log -n 5 --oneline --decorate --abbrev=12 '
 
-	# check what files have changed.
-	SC=`./scripts/ci/what_changed.py --commits ${commit_range}`
+	# check what files have changed for PRs or local runs.  If we are
+	# building for a commit than we always do a "Full Run".
+	if [ -n "${pull_request_nr}" -o -n "${local_run}"  ]; then
+		SC=`./scripts/ci/what_changed.py --commits ${commit_range}`
+	else
+		echo "Full Run"
+		SC="full"
+	fi
 
 	if [ -n "$pull_request_nr" ]; then
 		$short_git_log $remote/${branch}
@@ -198,9 +204,6 @@ if [ -n "$main_ci" ]; then
 		# different location
 # https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
 		git rebase $remote/${branch}
-	else
-		echo "Full Run"
-		SC="full"
 	fi
 	$short_git_log
 

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -16,7 +16,7 @@
 # -r  the remote to rebase on
 #
 # The script can be run locally using for example:
-# ./scripts/ci/run_ci.sh -b master -r origin  -l -R <commit range>
+# ./scripts/ci/run_ci.sh -b main -r origin  -l -R <commit range>
 
 set -xe
 


### PR DESCRIPTION
* A few minor for what tests get running with `-l` option
* cleanup usage of `master`
* refactor code in prep for support of tag/file based test selection