### PR TITLE
Add extern "C" to kernel_struct.h

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -30,6 +30,10 @@
 #include <arch/structs.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define K_NUM_PRIORITIES \
 	(CONFIG_NUM_COOP_PRIORITIES + CONFIG_NUM_PREEMPT_PRIORITIES + 1)
 
@@ -229,6 +233,10 @@ struct _timeout {
 	int32_t dticks;
 #endif
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
Add extern "C" to kernel_struct.h to allow linkage in cpp. 
Issue description under: https://github.com/zephyrproject-rtos/zephyr/issues/36061

Signed-off-by: Zwierz, Marcin <marcin.zwierz@hidglobal.com>