### PR TITLE
arch: x86: cast to the same size composite expression

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1038,7 +1038,7 @@ static void range_map_ptables(pentry_t *ptables, void *virt, uintptr_t phys,
 		if (zero_entry) {
 			entry_val = 0;
 		} else {
-			entry_val = (phys + offset) | entry_flags;
+			entry_val = (pentry_t)(phys + offset) | entry_flags;
 		}
 
 		page_map_set(ptables, dest_virt, entry_val, NULL, mask,


### PR DESCRIPTION
Essential type of RHS operand (64 bit) is wider than essential
type of composite expression in LHS operand (32 bit).
LHS entry_val is 32 bit, and RHS (phys+offset) is 64 bit.
Cast RHS composite expression to the (pentry_t) type.

Found as a coding guideline violation (MISRA R10.7) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>