### PR TITLE
manifest: update loramac-node

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
       revision: 6010f0523cbc75f551d9256cf782f173177acdef
       path: modules/lib/open-amp
     - name: loramac-node
-      revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e
+      revision: pull/10/head
       path: modules/lib/loramac-node
     - name: openthread
       revision: 385e19da1ae15f27872c2543b97276a42f102ead


### PR DESCRIPTION
Update loramac-node to resolve #36074.

Note that this PR does not necessarily need to be merged due to #35892.
The purpose of this PR is to perform CI checking on the module PR.

The goal of cherry-picking the referenced commits before #35892 is to allow Zephyr v2.5 and Zephyr v2.6 users to use the fix without updating Zephyr to v2.6.99.