### PR TITLE
sensor: bq274xx: fix sleep logic when polling after softreset

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -624,10 +624,10 @@ static int bq274xx_gauge_configure(const struct device *dev)
 			return -EIO;
 		}
 
-		if (!(flags & 0x0010)) {
+		if (flags & 0x0010) {
 			k_msleep(BQ274XX_SUBCLASS_DELAY * 10);
 		}
-	} while ((flags & 0x0010));
+	} while (flags & 0x0010);
 
 	/* Seal the gauge */
 	status = bq274xx_control_reg_write(bq274xx, BQ274XX_CONTROL_SEALED);


### PR DESCRIPTION
The bq274xx fuel gauge does a softreset when configuring, after which the device is polled and sealed. However the sleep logic was inverted so the poll became blocking.