### PR TITLE
net: coap: Keep socket fd to send reply

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -231,6 +231,9 @@ struct coap_packet {
 	uint8_t hdr_len; /* CoAP header length */
 	uint16_t opt_len; /* Total options length (delta + len + value) */
 	uint16_t delta; /* Used for delta calculation in CoAP packet */
+#if defined(CONFIG_COAP_KEEP_USER_DATA)
+	void *user_data; /* Application specific user data */
+#endif
 };
 
 struct coap_option {

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -76,6 +76,11 @@ config COAP_URI_WILDCARD
 	  This option enables MQTT-style wildcards in path. Disable it if
 	  resource path may contain plus or hash symbol.
 
+config COAP_KEEP_USER_DATA
+	bool "Enable keeping user data in the CoAP packet"
+	help
+	  This option enables keeping application-specific user data
+
 module = COAP
 module-dep = NET_LOG
 module-str = Log level for CoAP


### PR DESCRIPTION
When server uses more than one socket for incoming connection, keep
rx socket fd for sending ACK packet.

Related issue: https://github.com/zephyrproject-rtos/zephyr/issues/36077

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>
(cherry picked from commit 23aa6d91786aa643b89b38058a8d4572cba2b03e)