### PR TITLE
Bluetooth: Audio: VOCS client add function to get conn pointer

### DIFF
--- a/include/bluetooth/audio/vocs.h
+++ b/include/bluetooth/audio/vocs.h
@@ -99,6 +99,19 @@ struct bt_vocs *bt_vocs_free_instance_get(void);
 void *bt_vocs_svc_decl_get(struct bt_vocs *vocs);
 
 /**
+ * @brief Get the connection pointer of a client instance
+ *
+ * Get the Bluetooth connection pointer of a Audio Input Control Service
+ * client instance.
+ *
+ * @param vocs    Audio Input Control Service client instance pointer.
+ * @param conn    Connection pointer.
+ *
+ * @return 0 if success, errno on failure.
+ */
+int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn);
+
+/**
  * @brief Register the Volume Offset Control Service instance.
  *
  * @param vocs      Volume Offset Control Service instance.

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -634,6 +634,28 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void)
 	return NULL;
 }
 
+int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn)
+{
+	CHECKIF(vocs == NULL) {
+		BT_DBG("NULL vocs pointer");
+		return -EINVAL;
+	}
+
+	if (!vocs->client_instance) {
+		BT_DBG("vocs pointer shall be client instance");
+		return -EINVAL;
+	}
+
+	if (vocs->cli.conn == NULL) {
+		BT_DBG("vocs pointer not associated with a connection. "
+		       "Do discovery first");
+		return -ENOTCONN;
+	}
+
+	*conn = vocs->cli.conn;
+	return 0;
+}
+
 static void vocs_client_reset(struct bt_vocs *inst, struct bt_conn *conn)
 {
 	memset(&inst->cli.state, 0, sizeof(inst->cli.state));

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -445,6 +445,18 @@ static int test_vocs(void)
 	uint32_t expected_location;
 	int16_t expected_offset;
 	char expected_description[VOCS_DESC_SIZE];
+	struct bt_conn *cached_conn;
+
+	printk("Getting VOCS client conn\n");
+	err = bt_vocs_client_conn_get(vcs.vocs[0], &cached_conn);
+	if (err != 0) {
+		FAIL("Could not get VOCS client conn (err %d)\n", err);
+		return err;
+	}
+	if (cached_conn != g_conn) {
+		FAIL("Cached conn was not the conn used to discover");
+		return -ENOTCONN;
+	}
 
 	printk("Getting VOCS state\n");
 	g_cb = false;


### PR DESCRIPTION
Add a function that returns the bluetooth connection
pointer of a given VOCS client instance.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>