### PR TITLE
Enable tracing of ISR based on CONFIG_TRACING_ISR

### DIFF
--- a/include/arch/arm/aarch32/irq.h
+++ b/include/arch/arm/aarch32/irq.h
@@ -132,21 +132,21 @@ extern void _arch_isr_direct_pm(void);
 /* arch/arm/core/aarch32/exc_exit.S */
 extern void z_arm_int_exit(void);
 
-#ifdef CONFIG_TRACING
+#ifdef CONFIG_TRACING_ISR
 extern void sys_trace_isr_enter(void);
 extern void sys_trace_isr_exit(void);
 #endif
 
 static inline void arch_isr_direct_header(void)
 {
-#ifdef CONFIG_TRACING
+#ifdef CONFIG_TRACING_ISR
 	sys_trace_isr_enter();
 #endif
 }
 
 static inline void arch_isr_direct_footer(int maybe_swap)
 {
-#ifdef CONFIG_TRACING
+#ifdef CONFIG_TRACING_ISR
 	sys_trace_isr_exit();
 #endif
 	if (maybe_swap != 0) {


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/arm/core/aarch32/isr_wrapper.S#L90 as well as in https://github.com/zephyrproject-rtos/zephyr/blob/main/include/arch/arc/v2/irq.h#L93 `CONFIG_TRACING_ISR` is used, here `CONFIG_TRACING` is used. I believe `CONFIG_TRACING_ISR` would be more correct.