### PR TITLE
twister: adapt toolchain test

### DIFF
--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -13,6 +13,11 @@ ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 from twisterlib import TestSuite, TestInstance
 
+def new_get_toolchain(*args, **kwargs):
+    return 'zephyr'
+
+TestSuite.get_toolchain = new_get_toolchain
+
 @pytest.fixture(name='test_data')
 def _test_data():
     """ Pytest fixture to load the test data directory"""

--- a/scripts/tests/twister/test_testsuite_class.py
+++ b/scripts/tests/twister/test_testsuite_class.py
@@ -63,21 +63,6 @@ def test_get_all_testcases(class_testsuite, all_testcases_dict):
     assert len(class_testsuite.get_all_tests()) == 19
     assert sorted(class_testsuite.get_all_tests()) == sorted(expected_tests)
 
-def test_get_toolchain(class_testsuite, monkeypatch, capsys):
-    """ Testing get_toolchain function of TestSuite class in Twister
-    Test 1 : Test toolchain returned by get_toolchain function is same as in the environment.
-    Test 2 : Monkeypatch to delete the  ZEPHYR_TOOLCHAIN_VARIANT env var
-    and check if appropriate error is raised"""
-    monkeypatch.setenv("ZEPHYR_TOOLCHAIN_VARIANT", "zephyr")
-    toolchain = class_testsuite.get_toolchain()
-    assert toolchain in ["zephyr"]
-
-    monkeypatch.delenv("ZEPHYR_TOOLCHAIN_VARIANT", raising=False)
-    with pytest.raises(SystemExit):
-        class_testsuite.get_toolchain()
-    out, _ = capsys.readouterr()
-    assert out == "E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined\n"
-
 def test_get_platforms(class_testsuite, platforms_list):
     """ Testing get_platforms function of TestSuite class in Twister """
     class_testsuite.platforms = platforms_list


### PR DESCRIPTION
We now get toolchain from cmake and can operate even if the toolchain
variant is not set in the envrionment, this test was verifying the old
behavior, so remove.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
