### PR TITLE
drivers: modem: gsm_ppp, ublox-sara-r4: implement operator id and cell info

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -132,6 +132,11 @@ config MODEM_SIM_NUMBERS
 	  Query the SIM card for the IMSI and ICCID identifiers. This
 	  can be disabled if the application does not use a SIM.
 
+config MODEM_CELL_INFO
+	bool "Enable querying for operator and cell info"
+	depends on MODEM_SHELL
+	help
+	  Query for numerical operator id, location area code and cell id.
 
 source "drivers/modem/Kconfig.ublox-sara-r4"
 source "drivers/modem/Kconfig.quectel-bg9x"

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -66,6 +66,11 @@ struct modem_context {
 	char *data_imsi;
 	char *data_iccid;
 #endif
+#if defined(CONFIG_MODEM_CELL_INFO)
+	int   data_operator;
+	int   data_lac;
+	int   data_cellid;
+#endif
 	int   data_rssi;
 
 	/* pin config */

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -67,7 +67,13 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 				"\tIMSI:         %s\n"
 				"\tICCID:        %s\n"
 #endif
-				"\tRSSI:         %d\n", i,
+#if defined(CONFIG_MODEM_CELL_INFO)
+				"\tOperator:     %d\n"
+				"\tLAC:          %d\n"
+				"\tCellId:       %d\n"
+#endif
+				"\tRSSI:         %d\n",
+			       i,
 			       UART_DEV_NAME(mdm_ctx),
 			       mdm_ctx->data_manufacturer,
 			       mdm_ctx->data_model,
@@ -76,6 +82,11 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 #if defined(CONFIG_MODEM_SIM_NUMBERS)
 			       mdm_ctx->data_imsi,
 			       mdm_ctx->data_iccid,
+#endif
+#if defined(CONFIG_MODEM_CELL_INFO)
+			       mdm_ctx->data_operator,
+			       mdm_ctx->data_lac,
+			       mdm_ctx->data_cellid,
 #endif
 			       mdm_ctx->data_rssi);
 		}


### PR DESCRIPTION
Implement numerical network operator id, location area code (LAC) and cell id.
These values can be used to uniquely identify the cell that the modem is attached to.

The functionality to query for these values is implemented in following modem drivers:
- gsm_ppp
- ublox-sara-r4

Functionality is enabled by CONFIG_MODEM_CELL_INFO=y.

Tested with uBlox SARA-R410M-02B.
 
Signed-off-by: Hans Wilmers <hans@wilmers.no>