### PR TITLE
samples: eeprom: Fix build issues with x_nucleo_eeprma2 sample

### DIFF
--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <freq.h>
+#include <mem.h>
 
 / {
 	aliases {

--- a/samples/drivers/eeprom/sample.yaml
+++ b/samples/drivers/eeprom/sample.yaml
@@ -16,7 +16,8 @@ tests:
     platform_allow: native_posix
   sample.drivers.eeprom.shield.x_nucleo_eeprma2:
     tags: eeprom shield
-    depends_on: arduino_gpio arduino_i2c
+    depends_on: arduino_gpio arduino_i2c arduino_spi
+    platform_exclude: ubx_evkannab1_nrf52832 sam_v71_xult sam_v71b_xult
     extra_args: SHIELD=x_nucleo_eeprma2
     harness: console
     harness_config:


### PR DESCRIPTION
There are a number of platforms that the x_nucleo_eeprma2 eeprom sample
can't build on.  Also fix issue with missing include of <mem.h> header
to get DT_SIZE_* macros used by the overlay.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>