### PR TITLE
drivers: hwinfo: Added Gecko support for reset cause

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -91,6 +91,7 @@ config HWINFO_GECKO
 	bool "GECKO hwinfo"
 	default y
 	depends on SOC_FAMILY_EXX32
+	select SOC_GECKO_RMU
 	help
 	  Enable Silabs GECKO hwinfo driver.
 


### PR DESCRIPTION
Implements reset cause for Silabs Gecko.
`RESET_PIN`, `RESET_SOFTWARE` and `RESET_POR` were tested on `efr32_radio_brd4250b`. The others are a bit trickier to trigger, especially the brown outs. Any help with testing these cases will be appreciated. Some of those flags are only available on devices which I do not have access to, and also I'm not sure how to trigger each of those brown out cases.