### PR TITLE
tests: devicetree: remove useless assert

### DIFF
--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1576,8 +1576,6 @@ static void test_child_nodes_list(void)
 	zassert_equal(ARRAY_SIZE(vals_inst), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay), 2, "");
 
-	zassert_false(strlen(STRINGIFY(TEST_PARENT)) == 0, "");
-
 	zassert_equal(vals[0].val, 0, "");
 	zassert_equal(vals[1].val, 1, "");
 	zassert_equal(vals[2].val, 2, "");


### PR DESCRIPTION
There's no reason for this assert to be here; it should be removed.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>