### PR TITLE
python-devicetree: tox: fix mypy

### DIFF
--- a/scripts/dts/python-devicetree/tox.ini
+++ b/scripts/dts/python-devicetree/tox.ini
@@ -5,6 +5,7 @@ envlist=py3
 deps =
     setuptools-scm
     pytest
+    types-PyYAML
     mypy
 setenv =
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
Recent versions of mypy have learned that the yaml module has type
stubs and the tool is now erroring out when it discovers we import
yaml since the stubs are not installed.

This is breaking CI on unrelated patches; fix it following the
instructions here:

https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>