### PR TITLE
actions: replace duplicated label for RISCV

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -66,7 +66,7 @@
 "area: Xtensa":
   - "arch/xtensa/**/*"
   - "include/arch/xtensa/**/*"
-"area: RISCv32/64":
+"area: RISCV":
   - "arch/risv/**/*"
   - "include/arch/riscv/**/*"
 "area: ARC":


### PR DESCRIPTION
This patch removes duplicated label RISCVv32/64 and replace into
RISCV that has already used in GitHub.