### PR TITLE
include: sys: cast to the same size composite expression

### DIFF
--- a/include/sys/time_units.h
+++ b/include/sys/time_units.h
@@ -112,13 +112,13 @@ static TIME_CONSTEXPR ALWAYS_INLINE uint64_t z_tmcvt(uint64_t t, uint32_t from_h
 		if (result32 && (t < BIT64(32))) {
 			return ((uint32_t)t) / (from_hz / to_hz);
 		} else {
-			return t / (from_hz / to_hz);
+			return t / ((uint64_t)from_hz / to_hz);
 		}
 	} else if (mul_ratio) {
 		if (result32) {
 			return ((uint32_t)t) * (to_hz / from_hz);
 		} else {
-			return t * (to_hz / from_hz);
+			return t * ((uint64_t)to_hz / from_hz);
 		}
 	} else {
 		if (result32) {


### PR DESCRIPTION
Essential type of LHS operand (64 bit) is wider than essential
type of composite expression in RHS operand (32 bit).
LHS "t" variable is 64 bit, and RHS (from_hz / to_hz) is 32 bit.
Cast RHS composite expression to the uint64_t type.

Found as a coding guideline violation (MISRA R10.7) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>