### PR TITLE
Bluetooth: Mesh: Add random delay before sending first adv packet

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -183,8 +183,7 @@ static void send_pending_adv(struct k_work *work)
 
 static void schedule_send(void)
 {
-	uint64_t timestamp = adv.timestamp;
-	int64_t delta;
+	uint8_t rand_delay = 0;
 
 	if (atomic_test_and_clear_bit(adv.flags, ADV_FLAG_PROXY)) {
 		bt_le_ext_adv_stop(adv.instance);
@@ -196,12 +195,8 @@ static void schedule_send(void)
 		return;
 	}
 
-	/* The controller will send the next advertisement immediately.
-	 * Introduce a delay here to avoid sending the next mesh packet closer
-	 * to the previous packet than what's permitted by the specification.
-	 */
-	delta = k_uptime_delta(&timestamp);
-	k_work_reschedule(&adv.work, K_MSEC(ADV_INT_FAST_MS - delta));
+	(void)bt_rand(&rand_delay, sizeof(rand_delay));
+	k_work_reschedule(&adv.work, K_MSEC(ADV_INT_FAST_MS + rand_delay % 30));
 }
 
 void bt_mesh_adv_update(void)

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -51,6 +51,7 @@ static inline void adv_send(struct net_buf *buf)
 	struct bt_le_adv_param param = {};
 	uint16_t duration, adv_int;
 	struct bt_data ad;
+	uint8_t rand_delay = 0;
 	int err;
 
 	adv_int = MAX(adv_int_min,
@@ -78,6 +79,9 @@ static inline void adv_send(struct net_buf *buf)
 	param.id = BT_ID_DEFAULT;
 	param.interval_min = BT_MESH_ADV_SCAN_UNIT(adv_int);
 	param.interval_max = param.interval_min;
+
+	(void)bt_rand(&rand_delay, sizeof(rand_delay));
+	k_sleep(K_MSEC(ADV_INT_FAST_MS + rand_delay % 30));
 
 	uint64_t time = k_uptime_get();
 


### PR DESCRIPTION
This commit adds delay before the start of each advertisement to
resolve possible advertisements storm when multiple devices start
sending data at the same time.

MeshPRFv1.0.1, section 3.7.4.1 recommends the delay to be
between 20 and 50 ms.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>