### PR TITLE
lib: os: cast to the same size composite expression

### DIFF
--- a/lib/os/crc16_sw.c
+++ b/lib/os/crc16_sw.c
@@ -42,7 +42,7 @@ uint16_t crc16_ccitt(uint16_t seed, const uint8_t *src, size_t len)
 
 		e = seed ^ *src++;
 		f = e ^ (e << 4);
-		seed = (seed >> 8) ^ (f << 8) ^ (f << 3) ^ (f >> 4);
+		seed = (seed >> 8) ^ ((uint16_t)f << 8) ^ ((uint16_t)f << 3) ^ ((uint16_t)f >> 4);
 	}
 
 	return seed;

--- a/lib/os/crc32_sw.c
+++ b/lib/os/crc32_sw.c
@@ -27,7 +27,7 @@ uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len)
 		uint8_t byte = data[i];
 
 		crc = (crc >> 4) ^ table[(crc ^ byte) & 0x0f];
-		crc = (crc >> 4) ^ table[(crc ^ (byte >> 4)) & 0x0f];
+		crc = (crc >> 4) ^ table[(crc ^ ((uint32_t)byte >> 4)) & 0x0f];
 	}
 
 	return (~crc);

--- a/lib/os/crc32c_sw.c
+++ b/lib/os/crc32c_sw.c
@@ -33,7 +33,7 @@ uint32_t crc32_c(uint32_t crc, const uint8_t *data,
 
 	for (size_t i = 0; i < len; i++) {
 		crc = crc32c_table[(crc ^ data[i]) & 0x0F] ^ (crc >> 4);
-		crc = crc32c_table[(crc ^ (data[i] >> 4)) & 0x0F] ^ (crc >> 4);
+		crc = crc32c_table[(crc ^ ((uint32_t)data[i] >> 4)) & 0x0F] ^ (crc >> 4);
 	}
 
 	return last_pkt ? (crc ^ CRC32C_XOR_OUT) : crc;


### PR DESCRIPTION
In file crc16_sw.c essential type of LHS operand (16 bit) is wider than
essential type of composite expression in RHS operand (8 bit).
In crc32c_sw.c and crc32_sw.c Essential type of LHS operand (32 bit) is
wider than essential type of composite expression in RHS operand (8 bit)

Found as a coding guideline violation (MISRA R10.7) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>