### PR TITLE
net: depend dns resolver on native net

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -3,6 +3,7 @@
 
 config DNS_RESOLVER
 	bool "DNS resolver"
+	depends on NET_NATIVE
 	help
 	  This option enables the DNS client side support for Zephyr
 


### PR DESCRIPTION
DNS resolver won't work for offloaded stack.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>