### PR TITLE
Bluetooth: Prevent race condition in pairing procedure

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5639,10 +5639,6 @@ int bt_smp_start_security(struct bt_conn *conn)
 			return -ENOTCONN;
 		}
 
-		if (!smp_keys_check(conn)) {
-			return smp_send_pairing_req(conn);
-		}
-
 		/* pairing is in progress */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
 			return -EBUSY;
@@ -5651,6 +5647,10 @@ int bt_smp_start_security(struct bt_conn *conn)
 		/* Encryption is in progress */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
 			return -EBUSY;
+		}
+
+		if (!smp_keys_check(conn)) {
+			return smp_send_pairing_req(conn);
 		}
 
 		/* LE SC LTK and legacy master LTK are stored in same place */


### PR DESCRIPTION
Moving the key check after checking that no pairing or encryption
procedure is started fixes a race condition that is seen in some PTS
tests:

GATT/CL/GAR/BI-04-C
GATT/CL/GAR/BI-16-C
GATT/CL/GAR/BI-21-C
GATT/CL/GAW/BI-05-C
GATT/CL/GAW/BI-12-C

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>