### PR TITLE
Bluetooth: controller: PoC for Nordic LLL with new JIT scheduler

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -573,6 +573,7 @@ config BT_TICKER_SLOT_AGNOSTIC
 config BT_CTLR_JIT_SCHEDULING
 	bool "Just-in-Time Scheduling"
 	select BT_TICKER_SLOT_AGNOSTIC
+	default y if !BT_TICKER_LOW_LAT && !BT_MESH
 	help
 	  This option enables the experimental 'Next Generation' scheduling
 	  feature, which eliminates priorities and collision resolving in the

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -134,6 +134,12 @@ enum {
 
 #define TICKER_ID_ULL_BASE ((TICKER_ID_LLL_PREEMPT) + 1)
 
+enum done_result {
+	DONE_COMPLETED,
+	DONE_ABORTED,
+	DONE_TOO_LATE
+};
+
 struct ull_hdr {
 	uint8_t volatile ref;  /* Number of ongoing (between Prepare and Done)
 				* events
@@ -163,6 +169,7 @@ struct ull_hdr {
 
 struct lll_hdr {
 	void *parent;
+	uint8_t result;
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	uint8_t score;
 	uint8_t latency;
@@ -170,6 +177,8 @@ struct lll_hdr {
 };
 
 #define HDR_LLL2ULL(p) (((struct lll_hdr *)(p))->parent)
+#define HDR_RESULT_SET(p, res) \
+	((struct lll_hdr *)(p))->result = res
 
 struct lll_prepare_param {
 	uint32_t ticks_at_expire;
@@ -363,6 +372,9 @@ struct event_done_extra_drift {
 
 struct event_done_extra {
 	uint8_t type;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	uint8_t result;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	union {
 		struct {
 			uint16_t trx_cnt;
@@ -397,7 +409,7 @@ static inline void lll_hdr_init(void *lll, void *parent)
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 }
 
-void lll_done_score(void *param, uint8_t too_late, uint8_t aborted);
+void lll_done_score(void *param, uint8_t result);
 
 int lll_init(void);
 int lll_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -80,7 +80,7 @@ void lll_resume(void *param)
 }
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-void lll_done_score(void *param, uint8_t too_late, uint8_t aborted)
+void lll_done_score(void *param, uint8_t result)
 {
 	struct lll_hdr *hdr = param;
 
@@ -88,7 +88,7 @@ void lll_done_score(void *param, uint8_t too_late, uint8_t aborted)
 		return;
 	}
 
-	if (!too_late && !aborted) {
+	if (result == DONE_COMPLETED) {
 		hdr->score  = 0;
 		hdr->latency = 0;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -320,22 +320,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ARG_UNUSED(start_us);
 #endif /* !CONFIG_BT_CTLR_GPIO_PA_PIN */
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
-	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
-	/* check if preempt to start has changed */
-	if (lll_preempt_calc(ull, (TICKER_ID_ADV_AUX_BASE +
-				   ull_adv_aux_lll_handle_get(lll)),
-			     ticks_at_event)) {
-		radio_isr_set(lll_isr_abort, lll);
-		radio_disable();
-	} else
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	{
-		uint32_t ret;
-
-		ret = lll_prepare_done(lll);
-		LL_ASSERT(!ret);
-	}
+	lll_prepare_done(lll, (TICKER_ID_ADV_AUX_BASE +
+			       ull_adv_aux_lll_handle_get(lll)),
+			 ticks_at_event, lll_isr_abort_too_late);
 
 	DEBUG_RADIO_START_A(1);
 
@@ -678,6 +665,8 @@ static void isr_tx_connect_rsp(void *param)
 		/* Stop further LLL radio events */
 		lll->conn->slave.initiated = 1;
 	}
+
+	HDR_RESULT_SET(lll, DONE_COMPLETED);
 
 	/* Clear radio status and events */
 	lll_isr_status_reset();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -159,8 +159,6 @@ void lll_conn_abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	/* Accumulate the latency as event is aborted while being in pipeline */
 	lll = prepare_param->param;
 	lll->latency_prepare += (prepare_param->lazy + 1);
-
-	lll_done(param);
 }
 
 void lll_conn_isr_rx(void *param)
@@ -641,9 +639,9 @@ static void isr_done(void *param)
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	if (trx_cnt) {
-		struct lll_conn *lll = param;
+	struct lll_conn *lll = param;
 
+	if (trx_cnt) {
 		if (lll->role) {
 			uint32_t preamble_to_addr_us;
 
@@ -666,6 +664,7 @@ static void isr_done(void *param)
 			lll->slave.window_size_event_us = 0;
 		}
 	}
+	HDR_RESULT_SET(lll, DONE_COMPLETED);
 #endif /* CONFIG_BT_PERIPHERAL */
 
 	lll_isr_cleanup(param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int lll_prepare_done(void *param);
-int lll_done(void *param);
+int lll_prepare_done(void *param, uint8_t ticker_id,
+		     uint32_t ticks_at_event, radio_isr_cb_t isr_abort);
+void lll_done(void *param, uint8_t reset, uint8_t result);
 bool lll_is_done(void *param);
 int lll_is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb);
 void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param);
@@ -20,6 +21,7 @@ void lll_isr_tx_status_reset(void);
 void lll_isr_rx_status_reset(void);
 void lll_isr_status_reset(void);
 void lll_isr_abort(void *param);
+void lll_isr_abort_too_late(void *param);
 void lll_isr_done(void *param);
 void lll_isr_cleanup(void *param);
 void lll_isr_early_abort(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -200,21 +200,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ARG_UNUSED(remainder_us);
 #endif /* !CONFIG_BT_CTLR_GPIO_PA_PIN */
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
-	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
-	/* check if preempt to start has changed */
-	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
-			     ticks_at_event)) {
-		radio_isr_set(lll_isr_abort, lll);
-		radio_disable();
-	} else
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	{
-		uint32_t ret;
-
-		ret = lll_prepare_done(lll);
-		LL_ASSERT(!ret);
-	}
+	lll_prepare_done(lll, (TICKER_ID_CONN_BASE + lll->handle),
+			 ticks_at_event, lll_isr_abort_too_late);
 
 	DEBUG_RADIO_START_M(1);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -56,6 +56,7 @@ static void isr_tx_connect_req(void *param);
 static void isr_rx_connect_rsp(void *param);
 #endif /* CONFIG_BT_CENTRAL */
 static void isr_done(void *param);
+static void isr_done_too_late(void *param);
 
 #if defined(CONFIG_BT_CENTRAL)
 static inline bool isr_scan_init_check(struct lll_scan *lll,
@@ -235,22 +236,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
-	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
-	/* check if preempt to start has changed */
-	if (lll_preempt_calc(ull, (TICKER_ID_SCAN_AUX_BASE +
-				   ull_scan_aux_lll_handle_get(lll)),
-			     ticks_at_event)) {
-		radio_isr_set(isr_done, lll);
-		radio_disable();
-	} else
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	{
-		uint32_t ret;
-
-		ret = lll_prepare_done(lll);
-		LL_ASSERT(!ret);
-	}
+	lll_prepare_done(lll, (TICKER_ID_SCAN_AUX_BASE +
+			       ull_scan_aux_lll_handle_get(lll)),
+			 ticks_at_event, isr_done_too_late);
 
 	DEBUG_RADIO_START_O(1);
 
@@ -277,8 +265,6 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	 */
 	err = lll_hfclock_off();
 	LL_ASSERT(err >= 0);
-
-	lll_done(param);
 }
 
 static void isr_rx(void *param)
@@ -725,7 +711,14 @@ static void isr_done(void *param)
 		e->type = EVENT_DONE_EXTRA_TYPE_SCAN_AUX;
 	}
 
+	HDR_RESULT_SET(param, DONE_COMPLETED);
 	lll_isr_cleanup(param);
+}
+
+static void isr_done_too_late(void *param)
+{
+	HDR_RESULT_SET(param, DONE_TOO_LATE);
+	isr_done(param);
 }
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -265,21 +265,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_rssi_measure();
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
-	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
-	/* check if preempt to start has changed */
-	if (lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle),
-			     ticks_at_event)) {
-		radio_isr_set(lll_isr_abort, lll);
-		radio_disable();
-	} else
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	{
-		uint32_t ret;
-
-		ret = lll_prepare_done(lll);
-		LL_ASSERT(!ret);
-	}
+	lll_prepare_done(lll, (TICKER_ID_CONN_BASE + lll->handle),
+			 ticks_at_event, lll_isr_abort_too_late);
 
 	DEBUG_RADIO_START_S(1);
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -300,7 +300,7 @@ int lll_done(void *param)
 #endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL_DONE */
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	lll_done_score(param, 0, 0); /* TODO */
+	lll_done_score(param, 0); /* TODO */
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	/* Let ULL know about LLL event done */

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -404,10 +404,10 @@ static void ticker_by_next_slot_get(struct ticker_instance *instance,
 	}
 #else
 	/* TODO: Come up with different way to find/match the ticker */
-	LL_ASSERT(0);
 #endif
 	if (_ticker_id_head != TICKER_NULL) {
 		/* Add ticks for found ticker */
+		ticker = &node[_ticker_id_head];
 		_ticks_to_expire += ticker->ticks_to_expire;
 #if defined(CONFIG_BT_TICKER_LAZY_GET)
 		if (lazy) {


### PR DESCRIPTION
Implements a functional lower link layer for Nordic nRF52, using the new
JIT LL scheduling concept. The code is draft and to be discussed and
tested in HW. The implementation has been tested with nRF BSIM model in
simulation, and passes local regression tests. The following changes
have been implemented:

- Enable BT_CTLR_JIT_SCHEDULING except for case BT_TICKER_LOW_LAT and
  BT_MESH. For BT_MESH, some further debugging is needed as BSIM test
  fails.
- Add result property to LLL header and set result in various places
- Add prio/force to current event struct
- Refactor abort calls to common lll_abort_done with result, which
  calls lll_done (lll_done removed from abort_cb). This simplifies
  passing of result.
- Refactor lll_preempt_calc into lll_prepare_done for cleaner code
- Add specific reset parameter and result to lll_done
- Implement prepare "too late" result handling for scoring
- Split lll_prepare_resolve into separate implementation for
  BT_CTLR_LOW_LAT due to too many differences and unreadable common
  code.
- Set SCAN priority to 1 (one lower than default) to get smooth
  scheduling arbitration with ADV (possibly temporary).

Signed-off-by: Morten Priess <mtpr@oticon.com>