### PR TITLE
Bluetooth: Mesh: Increase default CDB node count

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -67,7 +67,7 @@ if BT_MESH_CDB
 
 config BT_MESH_CDB_NODE_COUNT
 	int "Maximum number of nodes in the database"
-	default 1
+	default 8
 	range 1 4096
 	help
 	  This option specifies how many nodes each network can at most


### PR DESCRIPTION
The old default of 1 makes provisioner devices useless, as they can only
provision themselves before they run out of space.

Increase the default value for CONFIG_BT_MESH_CDB_NODE_COUNT to 8.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>