### PR TITLE
Update civetweb to latest one

### DIFF
--- a/samples/net/civetweb/common/include/libc_extensions.h
+++ b/samples/net/civetweb/common/include/libc_extensions.h
@@ -15,6 +15,7 @@
 
 #define POLLIN ZSOCK_POLLIN
 #define POLLOUT ZSOCK_POLLOUT
+#define POLLERR ZSOCK_POLLERR
 
 #define addrinfo zsock_addrinfo
 

--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 1052dae561497bef901f931ef75e117c9224aecd
       path: modules/lib/canopennode
     - name: civetweb
-      revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c
+      revision: 3cf9654b168cfd8a994d707163f4497791866019
       path: modules/lib/civetweb
     - name: cmsis
       revision: b0612c97c1401feeb4160add6462c3627fe90fc7


### PR DESCRIPTION
Should be merged after [this](https://github.com/zephyrproject-rtos/civetweb/pull/7)