### PR TITLE
usb: store alternate interface settings

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -82,6 +82,14 @@ config USB_REQUEST_BUFFER_SIZE
 	default 1024 if USB_DEVICE_LOOPBACK
 	default 128
 
+config USB_MAX_ALT_SETTING
+	int "Size of the array where alternate settings are stored"
+	range 0 16
+	default 8
+	help
+	  Size of the array where alternate settings are stored.
+	  Should not be smaller than the number of interfaces.
+
 config USB_NUMOF_EP_WRITE_RETRIES
 	int "Number of endpoint write retries"
 	default 3

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -689,6 +689,11 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 
 	uint8_t iface = (pSetup->wIndex) & 0xFF;
 
+	if (REQTYPE_GET_RECIP(pSetup->bmRequestType) !=
+	    REQTYPE_RECIP_INTERFACE) {
+		return -EINVAL;
+	}
+
 	audio_dev_data = get_audio_dev_data_by_iface(iface);
 	if (audio_dev_data == NULL) {
 		return -EINVAL;
@@ -724,29 +729,15 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 						USB_FORMAT_TYPE_I_DESC_SIZE);
 	}
 
-	if (REQTYPE_GET_RECIP(pSetup->bmRequestType) ==
-	    REQTYPE_RECIP_INTERFACE) {
-		switch (pSetup->bRequest) {
-		case REQ_SET_INTERFACE:
-			if (ep_desc->bEndpointAddress & USB_EP_DIR_MASK) {
-				audio_dev_data->tx_enable = pSetup->wValue;
-			} else {
-				audio_dev_data->rx_enable = pSetup->wValue;
-			}
-			return -EINVAL;
-		case REQ_GET_INTERFACE:
-			if (ep_desc->bEndpointAddress & USB_EP_DIR_MASK) {
-				*data[0] = audio_dev_data->tx_enable;
-			} else {
-				*data[0] = audio_dev_data->rx_enable;
-			}
-			return 0;
-		default:
-			break;
+	if (pSetup->bRequest == REQ_SET_INTERFACE) {
+		if (ep_desc->bEndpointAddress & USB_EP_DIR_MASK) {
+			audio_dev_data->tx_enable = pSetup->wValue;
+		} else {
+			audio_dev_data->rx_enable = pSetup->wValue;
 		}
 	}
 
-	return -ENOTSUP;
+	return -EINVAL;
 }
 
 /**

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -139,6 +139,8 @@ static struct usb_dev_priv {
 	bool configured;
 	/** Currently selected configuration */
 	uint8_t configuration;
+	/** Currently selected alternate setting */
+	uint8_t alt_setting[CONFIG_USB_MAX_ALT_SETTING];
 	/** Remote wakeup feature status */
 	bool remote_wakeup;
 } usb_dev;
@@ -170,6 +172,27 @@ static void usb_print_setup(struct usb_setup_packet *setup)
 		setup->wValue,
 		setup->wIndex,
 		setup->wLength);
+}
+
+static void usb_reset_alt_setting(void)
+{
+	memset(usb_dev.alt_setting, 0, ARRAY_SIZE(usb_dev.alt_setting));
+}
+
+static void usb_set_alt_setting(uint8_t iface, uint8_t alt_setting)
+{
+	if (iface < ARRAY_SIZE(usb_dev.alt_setting)) {
+		usb_dev.alt_setting[iface] = alt_setting;
+	}
+}
+
+static uint8_t usb_get_alt_setting(uint8_t iface)
+{
+	if (iface < ARRAY_SIZE(usb_dev.alt_setting)) {
+		return usb_dev.alt_setting[iface];
+	}
+
+	return 0;
 }
 
 /*
@@ -663,6 +686,7 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
 
 			if (cur_iface == iface &&
 			    cur_alt_setting == alt_setting) {
+				usb_set_alt_setting(iface, alt_setting);
 				if_desc = (void *)p;
 			}
 
@@ -689,6 +713,32 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
 	}
 
 	return ret;
+}
+
+static bool usb_get_interface(struct usb_setup_packet *setup,
+			      int32_t *len, uint8_t **data_buf)
+{
+	const uint8_t *p = usb_dev.descriptors;
+	uint8_t *data = *data_buf;
+	uint8_t cur_iface;
+
+	while (p[DESC_bLength] != 0U) {
+		if (p[DESC_bDescriptorType] == USB_INTERFACE_DESC) {
+			cur_iface = p[INTF_DESC_bInterfaceNumber];
+			if (cur_iface == setup->wIndex) {
+				data[0] = usb_get_alt_setting(cur_iface);
+				LOG_DBG("Current iface %u alt setting %u",
+					setup->wIndex, data[0]);
+				*len = 1;
+				return true;
+			}
+		}
+
+		/* skip to next descriptor */
+		p += p[DESC_bLength];
+	}
+
+	return false;
 }
 
 /**
@@ -765,6 +815,7 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 			/* configuration successful,
 			 * update current configuration
 			 */
+			usb_reset_alt_setting();
 			usb_dev.configuration = value;
 		}
 		break;
@@ -875,14 +926,7 @@ static bool usb_handle_std_interface_req(struct usb_setup_packet *setup,
 		return false;
 
 	case REQ_GET_INTERFACE:
-		/** This handler is called for classes that does not support
-		 * alternate Interfaces so always return 0. Classes that
-		 * support alternative interfaces handles GET_INTERFACE
-		 * in custom_handler.
-		 */
-		data[0] = 0U;
-		*len = 1;
-		break;
+		return usb_get_interface(setup, len, data_buf);
 
 	case REQ_SET_INTERFACE:
 		LOG_DBG("REQ_SET_INTERFACE");
@@ -1144,6 +1188,10 @@ static int disable_interface_ep(const struct usb_ep_cfg_data *ep_data)
 static void forward_status_cb(enum usb_dc_status_code status, const uint8_t *param)
 {
 	size_t size = (__usb_data_end - __usb_data_start);
+
+	if (status == USB_DC_DISCONNECTED) {
+		usb_reset_alt_setting();
+	}
 
 	if (status == USB_DC_DISCONNECTED || status == USB_DC_SUSPEND) {
 		if (usb_dev.configured) {


### PR DESCRIPTION
Fixes request hijack through Audio class workaround in composite configuration.
Fixes: #24200