### PR TITLE
Revert "gpio: Add GPIO voltage overrides"

### DIFF
--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -77,36 +77,6 @@
 /** @} */
 
 /**
- * @name GPIO pin voltage flags
- *
- * Only applicable if SoC allows to configure pin voltage per individual pin.
- *
- * @{
- */
-
-/**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
- */
-#define GPIO_VOLTAGE_POS        6
-#define GPIO_VOLTAGE_MASK       (3U << GPIO_VOLTAGE_POS)
-/**
- * @endcond
- */
-
-/** Set pin at the default voltage level */
-#define GPIO_VOLTAGE_DEFAULT    (0U << GPIO_VOLTAGE_POS)
-/** Set pin voltage level at 1.8 V */
-#define GPIO_VOLTAGE_1P8        (1U << GPIO_VOLTAGE_POS)
-/** Set pin voltage level at 3.3 V */
-#define GPIO_VOLTAGE_3P3        (2U << GPIO_VOLTAGE_POS)
-/** Set pin voltage level at 5.0 V */
-#define GPIO_VOLTAGE_5P0        (3U << GPIO_VOLTAGE_POS)
-
-/** @} */
-
-/**
  * @}
  */
 


### PR DESCRIPTION
This reverts commit 4c888ed25b150f54f5bf4e27ea4e895d6ea87e49.

This change wasn't ready, so lets back it out for now.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>