### PR TITLE
proposal: Refine spin lock

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -181,8 +181,7 @@ extern struct z_kernel _kernel;
  */
 bool z_smp_cpu_mobile(void);
 
-#define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
-			arch_curr_cpu(); })
+#define _current_cpu ({ arch_curr_cpu(); })
 #define _current k_current_get()
 
 #else


### PR DESCRIPTION
Hi,

I am investigating Zephyr latency performance on ARM Cortex A53 and A72, and found spin-lock on these two platforms have a large performance difference, one loop of k_spin_lock() and k_spin_unlock() on A53 is 16ns, but on A72 is 68ns, finally found irq enable/disable instruction have a big performance difference for A53 and A72, and get confirmation from ARM is that enable/disable irq should be not called frequently.
so I pushed this patch to proposal remove irq operations from general spin lock APIs, and create a new API set with irq operations. Maybe there are some potential issues with this patchset, but feel free to provide your comments, thanks.

Jiafei. 