### PR TITLE
drivers: ieee802154: propagate frame counter to upper layer

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -520,6 +520,20 @@ static int nrf5_tx(const struct device *dev,
 
 	LOG_DBG("Result: %d", nrf5_data.tx_result);
 
+#if NRF_802154_ENCRYPTION_ENABLED
+	/*
+	 * When frame encryption by the radio driver is enabled, the frame stored in
+	 * the tx_psdu buffer is:
+	 * 1) authenticated and encrypted in place which causes that after an unsuccessful
+	 *    TX attempt, this frame must be propagated back to the upper layer for retransmission.
+	 *    The upper layer must ensure that the exact same secured frame is used for
+	 *    retransmission
+	 * 2) frame counters are updated in place and for keeping the link frame counter up to date,
+	 *    this information must be propagated back to the upper layer
+	 */
+	memcpy(payload, nrf5_radio->tx_psdu + 1, payload_len);
+#endif
+
 	switch (nrf5_radio->tx_result) {
 	case NRF_802154_TX_ERROR_NONE:
 		if (nrf5_radio->ack_frame.psdu == NULL) {
@@ -541,18 +555,6 @@ static int nrf5_tx(const struct device *dev,
 	default:
 		result = -EIO;
 	}
-
-#if NRF_802154_ENCRYPTION_ENABLED
-	/*
-	 * When frame encryption by the radio driver is enabled,
-	 * the frame stored in the tx_psdu buffer is authenticated
-	 * and encrypted in place. After an unsuccessful TX attempt,
-	 * this frame must be propagated back to the upper layer
-	 * for retransmission. The upper layer must ensure that the
-	 * excact same secured frame is used for retransmission.
-	 */
-	memcpy(payload, nrf5_radio->tx_psdu + 1, payload_len);
-#endif
 
 	return result;
 }


### PR DESCRIPTION
When frame counter is managed by the radio driver the upper layer
needs to be informed about the frame counter changed. The upper layer
looks for the most recent frame counter in the transmitted frame,
this is why the tx_payload need to be updated after processed by
the radio driver.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>