### PR TITLE
scripts/pylib: expr_parser.py: Review dt_compat_enabled_with_label

### DIFF
--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -7,8 +7,8 @@ tests:
       mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk
       mimxrt1050_evk mimxrt1060_evk_hyperflash nucleo_f207zg
     depends_on: usb_device
-    filter: dt_compat_enabled_with_label("fixed-partitions", "slot0_partition") and
-            dt_compat_enabled_with_label("fixed-partitions", "slot1_partition") and
+    filter: dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions") and
+            dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions") and
             dt_chosen_enabled("zephyr,flash-controller") and
             CONFIG_FLASH_HAS_DRIVER_ENABLED
     tags: usb

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -264,11 +264,12 @@ def ast_expr(ast, env, edt):
 
         return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
                                                               compat)
-    elif ast[0] == "dt_compat_enabled_with_label":
-        compat = ast[1][0]
-        label = ast[1][1]
+    elif ast[0] == "dt_label_with_parent_compat_enabled":
+        compat = ast[1][1]
+        label = ast[1][0]
         node = edt.label2node.get(label)
-        return node is not None and node.status == 'okay' and node.matching_compat == compat
+        parent = node.parent
+        return parent is not None and parent.status == 'okay' and parent.matching_compat == compat
     elif ast[0] == "dt_chosen_enabled":
         chosen = ast[1][0]
         node = edt.chosen_node(chosen)

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -16,5 +16,5 @@ tests:
     tags: mcux
   drivers.flash.stm32:
     filter: dt_compat_enabled("st,stm32-flash-controller") and
-       dt_compat_enabled_with_label("fixed-partitions", "storage_partition")
+       dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     tags: drivers flash


### PR DESCRIPTION
Function used for filtering "dt_compat_enabled_with_label" was not
working as expected as it was not taking into account that we're
looking for a children/parent combination:
Provided "compat" with enabled status should be the one of the parent
of the node matching given label.

Function is then reworked to take this into account.
And to make it's usage clear:
- function name is changed to be clearer on the intention
- args order is reversed to be more logical wrt the intention

Users of the function are also updated to take the change into
account.

Fixes #36093

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>