### PR TITLE
lwm2m is unable to send further messages after send encountered certain signals

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1048,11 +1048,6 @@ static int lwm2m_send_message(struct lwm2m_message *msg)
 	rc = send(msg->ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
 
 	if (rc < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK) {
-			LOG_WRN("Failed to send packet, would block");
-			return -errno;
-		}
-
 		LOG_ERR("Failed to send packet, err %d", errno);
 		if (msg->type != COAP_TYPE_CON) {
 			lwm2m_reset_message(msg, true);


### PR DESCRIPTION
Fixed issue that caused message to be not correctly reset even after it is consumed after send sets errno to EAGAIN or EWOULDBLOCK

We encountered the issue while working with a nRF9160 based project.
In certain situation we encountered the device being unable to send lwm2m messages. On debugging we found that "socket_send_message" is never reached in the socket_loop function.
This bug was found together with the developer that added the line as well.
