### PR TITLE
stm32g4: CANFD correct message_ram offset of can2 and can3

### DIFF
--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -13,7 +13,7 @@
 				compatible = "st,stm32-fdcan";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x40006800 0x400>, <0x4000A800 0x350>;
+				reg = <0x40006800 0x400>, <0x4000A750 0x350>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <86 0>, <87 0>;
 				interrupt-names = "LINE_0", "LINE_1";
@@ -25,7 +25,7 @@
 				compatible = "st,stm32-fdcan";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x40006C00 0x400>, <0x4000AC00 0x350>;
+				reg = <0x40006C00 0x400>, <0x4000AAA0 0x350>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <88 0>, <89 0>;
 				interrupt-names = "LINE_0", "LINE_1";


### PR DESCRIPTION
The dedicated message_ram area of the can instances starts directly after it's predecessor's one.
This commit fixes can2 and can3 support for stm32g4 series.

Fixes: #36075