### PR TITLE
kernel: Make work queue API C++ compatible

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3812,7 +3812,9 @@ struct k_work_user {
 
 #define Z_WORK_USER_INITIALIZER(work_handler) \
 	{ \
+	._reserved = NULL, \
 	.handler = work_handler, \
+	.flags = 0 \
 	}
 
 /**


### PR DESCRIPTION
The new userspace work queue API is not C++ compatible.
When changing from old API to new API (commit
b706a5e9995b54d74be650dc4980c38defa0e160, 4e3b926) the C++ compatibility
was lost.

Signed-off-by: Fredrik Gihl <Fredrik.Gihl@flir.se>