### PR TITLE
net: sockets: dtls: Fix handshake with socket offloading

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -93,6 +93,9 @@ __net_socket struct tls_context {
 	/** Information whether underlying socket is listening. */
 	bool is_listening;
 
+	/** Information whether TLS handshake is currently in progress. */
+	bool handshake_in_progress;
+
 	/** Information whether TLS handshake is complete or not. */
 	struct k_sem tls_established;
 
@@ -821,6 +824,8 @@ static int tls_mbedtls_handshake(struct tls_context *context, bool block)
 {
 	int ret;
 
+	context->handshake_in_progress = true;
+
 	while ((ret = mbedtls_ssl_handshake(&context->ssl)) != 0) {
 		if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
 		    ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -850,6 +855,8 @@ static int tls_mbedtls_handshake(struct tls_context *context, bool block)
 	if (ret == 0) {
 		k_sem_give(&context->tls_established);
 	}
+
+	context->handshake_in_progress = false;
 
 	return ret;
 }
@@ -2094,7 +2101,48 @@ out:
 	return ret;
 }
 
-static inline int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
+/* Return true if needed to retry rightoff or false otherwise. */
+static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+					   struct zsock_pollfd *pfd)
+{
+	/* DTLS client should wait for the handshake to complete before it
+	 * reports that data is ready.
+	 */
+	if ((ctx->type != SOCK_DGRAM) ||
+	    (ctx->options.role != MBEDTLS_SSL_IS_CLIENT)) {
+		return false;
+	}
+
+	if (ctx->handshake_in_progress) {
+		/* Add some sleep to allow lower priority threads to proceed
+		 * with handshake.
+		 */
+		k_msleep(10);
+
+		pfd->revents &= ~ZSOCK_POLLIN;
+		return true;
+	} else if (!is_handshake_complete(ctx)) {
+		uint8_t byte;
+		int ret;
+
+		/* Handshake didn't start yet - just drop the incoming data -
+		 * it's the client who should initiate the handshake.
+		 */
+		ret = zsock_recv(ctx->sock, &byte, sizeof(byte),
+				 ZSOCK_MSG_DONTWAIT);
+		if (ret < 0) {
+			pfd->revents |= ZSOCK_POLLERR;
+		}
+
+		pfd->revents &= ~ZSOCK_POLLIN;
+		return true;
+	}
+
+	/* Handshake complete, just proceed. */
+	return false;
+}
+
+static int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 {
 	int fd_backup[CONFIG_NET_SOCKETS_POLL_MAX];
 	const struct fd_op_vtable *vtable;
@@ -2163,6 +2211,12 @@ static inline int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int time
 					   0);
 			if (ctx != NULL) {
 				if (fds[i].events & ZSOCK_POLLIN) {
+					if (poll_offload_dtls_client_retry(
+							ctx, &fds[i])) {
+						retry = true;
+						continue;
+					}
+
 					result = ztls_poll_update_pollin(
 						    fd_backup[i], ctx, &fds[i]);
 					if (result == -EAGAIN) {


### PR DESCRIPTION
Fix `poll()` handling for DTLS clients when the underlying socket is an
offloaded socket. As in this case no `k_poll()` is used underneath, it's
not possible to monitor the handhshake status with `tls_established`
semaphore. Instead, do the following:

1. If no handhshake is in progress yet, just drop the incoming data -
   it's the client who should initiate the handshake, any data incoming
   before that should not be processed.
2. If handshake is currently in progress, lift the `POLLIN` flag and add
   small delay to allow the other thread to proceed with the handshake.
3. Otherwise, just proceed as usual.

Fixes #35789

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>