### PR TITLE
Bluetooth: ISO: Only remove CIG as central

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -678,6 +678,10 @@ void bt_iso_cleanup(struct bt_conn *conn)
 		bt_conn_unref(iso->acl);
 		iso->acl = NULL;
 
+		if (conn->role == BT_CONN_ROLE_SLAVE) {
+			return;
+		}
+
 		/* Check if conn is last of CIG */
 		for (i = 0; i < CONFIG_BT_ISO_MAX_CHAN; i++) {
 			if (conn == &iso_conns[i]) {


### PR DESCRIPTION
The hci_le_remove_cig command shall only be sent as the
master/central. Implemented this by early termination in
bt_iso_cleanup as the slave/peripheral.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>