### PR TITLE
usb: driver: Delay attached event for Thingy:53 by default

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -74,6 +74,9 @@ config USB_NRFX
 config USB_DEVICE_STACK
 	default USB
 
+config USB_NRFX_ATTACHED_EVENT_DELAY
+	default 700 if USB
+
 config I2C
 	default y
 


### PR DESCRIPTION
Thingy:53 require to have delayed attached event by 700ms.
Set this option in board files.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>