### PR TITLE
gpio: Add GPIO voltage overrides

### DIFF
--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -77,6 +77,32 @@
 /** @} */
 
 /**
+ * @name GPIO pin voltage flags
+ *
+ * The voltage flags are a Zephyr specific extension of the standard GPIO
+ * flags specified by the Linux GPIO binding. Only applicable if SoC allows
+ * to configure pin voltage per individual pin.
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_VOLTAGE_POS	6
+#define GPIO_VOLTAGE_MASK	(3U << GPIO_VOLTAGE_POS)
+/** @endcond */
+
+/** Set pin at the default voltage level */
+#define GPIO_VOLTAGE_DEFAULT	(0U << GPIO_VOLTAGE_POS)
+/** Set pin voltage level at 1.8 V */
+#define GPIO_VOLTAGE_1P8	(1U << GPIO_VOLTAGE_POS)
+/** Set pin voltage level at 3.3 V */
+#define GPIO_VOLTAGE_3P3	(2U << GPIO_VOLTAGE_POS)
+/** Set pin voltage level at 5.0 V */
+#define GPIO_VOLTAGE_5P0	(3U << GPIO_VOLTAGE_POS)
+
+/** @} */
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Add GPIO_flag values for GPIO DTS creation that
allows for pins that do not use the default
voltage.  IT8xxx2 supports setting voltage
levels for each pin. The default for this SoC
is 3P3 but they can be set individually to
1P8.

This will be used, for example:

    i2c_c_scl {
            gpios = <&gpioc 1 (GPIO_INPUT | GPIO_VOLTAGE_1P8)>;
            enum-name = "GPIO_I2C_C_SCL";
            label = "I2C_C_SCL";
    };

Signed-off-by: Denis Brockus <dbrockus@google.com>