### PR TITLE
drivers: pwm: Fix compile issues with Atmel SAM PWM driver

### DIFF
--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -107,7 +107,7 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &sam_pwm_init, NULL				\
+			    &sam_pwm_init, NULL,			\
 			    NULL, &sam_pwm_config_##inst,		\
 			    POST_KERNEL,				\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\

--- a/soc/arm/atmel_sam/common/pwm_fixup.h
+++ b/soc/arm/atmel_sam/common/pwm_fixup.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _ATMEL_SAM_PWM_FIXUP_H_
+#define _ATMEL_SAM_PWM_FIXUP_H_
+
+/* The SAMV71 HALs change the name of the field, so we need to
+ * define it this way to match how the other SoC variants name it
+ */
+#if defined(CONFIG_SOC_SERIES_SAMV71)
+#define PWM_CH_NUM PwmChNum
+#endif
+
+#endif /* _ATMEL_SAM_PWM_FIXUP_H_ */

--- a/soc/arm/atmel_sam/samv71/soc.h
+++ b/soc/arm/atmel_sam/samv71/soc.h
@@ -78,4 +78,6 @@
 
 #endif /* _ASMLANGUAGE */
 
+#include "pwm_fixup.h"
+
 #endif /* _ATMEL_SAMV71_SOC_H_ */


### PR DESCRIPTION
The was a missing comma in the DEVICE_DT_INST_DEFINE macro and the
SAME71 HAL tweaks the name of a struct so we have to work around that.

Fixes #36095

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>