### PR TITLE
devicetree.h is stable

### DIFF
--- a/doc/reference/api/overview.rst
+++ b/doc/reference/api/overview.rst
@@ -78,7 +78,7 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.4
 
    * - :ref:`devicetree_api`
-     - Experimental
+     - Stable
      - 2.2
      - 2.6
 


### PR DESCRIPTION
This API meets the requirements for marking an API stable:

- Test cases for the new API with 100% coverage: yes;
  we have had coverage for every API macro since the beginning.

- Complete documentation in code. All public interfaces shall be
  documented and available in online documentation.: yes, in the
  reference documentation:
  https://docs.zephyrproject.org/latest/reference/devicetree/api.html

- The API has been in-use and was available in at least 2 development
  releases: yes; this API was introduced in v2.3.

The basic design involving node identifiers and the macros that create
and operate on them has not changed since the API was introduced, and
it is in widespread use throughout the tree. As we head into a new
LTS, it's time to mark it stable.

This is more of an acknowledgement of reality than a big change, as I
don't see any backwards incompatible changes since the API was first
introduced in v2.3. (We have deprecated a lot of label related macros
that are no longer required now that we have DEVICE_DT_GET and
friends, but they're still there, and we're still testing them, just
as if this were a stable API.)