### PR TITLE
cmake: tfm: moving CMake execution of tfm_cmake to a custom command

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -199,6 +199,10 @@ function(trusted_firmware_build)
 
   file(MAKE_DIRECTORY ${TFM_BINARY_DIR})
   add_custom_target(tfm_cmake
+    DEPENDS ${TFM_BINARY_DIR}/CMakeCache.txt
+  )
+  add_custom_command(
+    OUTPUT ${TFM_BINARY_DIR}/CMakeCache.txt
     COMMAND ${CMAKE_COMMAND}
       -G${CMAKE_GENERATOR}
       -DTFM_TOOLCHAIN_FILE=${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/${TFM_TOOLCHAIN_FILE}


### PR DESCRIPTION
Fixes: #36101

The move of CMake invocation to a dedicated custom target, see #34868
results in tfm_cmake to always be considered out-of-date, causing CMake
to be reinvoked in the TF-M Binary dir, which again results in the
build command to rebuild.

This commit moves the invocation to a custom command with the
CMakeCache.txt as output. The custom target tfm_cmake is updated to
depend on CMakeCache.txt.

This mean that CMake for TF-M will only be invoked inside the Zephyr build
command if that file is missing.

If the CMakeCache.txt file is updated or TF-M CMake or source code is
modified, then the build command inside the TF-M build folder will
ensure correct re-run of CMake from within the TF-M build folder.

This ensures that TF-M will still rebuild if TF-M code is modified,
while at the same time avoid unnecessary rebuilds of TF-M code.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>