### PR TITLE
drivers: hwinfo: Exclude GECKO driver on EFR32MG21

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -90,7 +90,7 @@ config HWINFO_PSOC6
 config HWINFO_GECKO
 	bool "GECKO hwinfo"
 	default y
-	depends on SOC_FAMILY_EXX32
+	depends on SOC_FAMILY_EXX32 && !SOC_SERIES_EFR32MG21
 	select SOC_GECKO_RMU
 	help
 	  Enable Silabs GECKO hwinfo driver.


### PR DESCRIPTION
The EFR32MG21 doesn't have a RMU and thus the driver isn't relevant for
that SoC series.  Add a Kconfig exclusion so the driver isn't available
on EFR32MG21 SoCs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>