### PR TITLE
Fix multiline strings in DT binding descriptions

### DIFF
--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -15,7 +15,7 @@ properties:
     int-gpios:
       type: phandle-array
       required: true
-      description: ￼>
+      description: |
         Interrupt pin.
 
         This pin signals active low when produced by the controller. The

--- a/dts/bindings/cpu/arm,cortex-a53.yaml
+++ b/dts/bindings/cpu/arm,cortex-a53.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: >
-    This is a representation of ARM Cortex-A53 CPU.
+description: This is a representation of ARM Cortex-A53 CPU.
 
 compatible: "arm,cortex-a53"
 

--- a/dts/bindings/cpu/arm,cortex-a72.yaml
+++ b/dts/bindings/cpu/arm,cortex-a72.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-description: >
-    This is a representation of ARM Cortex-A72 CPU.
+description: This is a representation of ARM Cortex-A72 CPU.
 
 compatible: "arm,cortex-a72"
 

--- a/dts/bindings/cpu/arm,cortex-r82.yaml
+++ b/dts/bindings/cpu/arm,cortex-r82.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: >
-    This is a representation of ARM Cortex-R82 CPU.
+description: This is a representation of ARM Cortex-R82 CPU.
 
 compatible: "arm,cortex-r82"
 

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -16,32 +16,36 @@ properties:
     pclk:
       type: int
       required: true
-      description: The value to divide the main clock by for PCLK. If the
-                   typical main clock was 48MHz and this value is 5, the PCLK
-                   will be 9.6 MHz. Must be positive value to enable the screen
+      description: |
+        The value to divide the main clock by for PCLK. If the
+        typical main clock was 48MHz and this value is 5, the PCLK
+        will be 9.6 MHz. Must be positive value to enable the screen
 
     pclk_pol:
       type: int
       required: true
-      description: Polarity of PCLK. If it is set to zero, PCLK polarity is on
-                   the rising edge. If it is set to one, PCLK polarity is on
-                   the falling edge.
+      description: |
+        Polarity of PCLK. If it is set to zero, PCLK polarity is on
+        the rising edge. If it is set to one, PCLK polarity is on
+        the falling edge.
 
     cspread:
       type: int
       required: true
-      description: Controls the transition of RGB signals with PCLK active clock
-                   edge. When set to 0, R[7:2],G[7:2] and B[7:2] signals change
-                   following the active edge of PCLK. When set to 1, R[7:2]
-                   changes a PCLK clock early and B[7:2] a PCLK clock later,
-                   which helps reduce the system noise.
+      description: |
+        Controls the transition of RGB signals with PCLK active clock
+        edge. When set to 0, R[7:2],G[7:2] and B[7:2] signals change
+        following the active edge of PCLK. When set to 1, R[7:2]
+        changes a PCLK clock early and B[7:2] a PCLK clock later,
+        which helps reduce the system noise.
 
     swizzle:
       type: int
       required: true
-      description: Controls the arrangement of output RGB pins, which may help
-                   support different LCD panel. Please check FT800 Programmers
-                   Guide for details.
+      description: |
+        Controls the arrangement of output RGB pins, which may help
+        support different LCD panel. Please check FT800 Programmers
+        Guide for details.
 
     vsize:
       type: int
@@ -56,19 +60,22 @@ properties:
     vcycle:
       type: int
       required: true
-      description: Number of all lines in a frame. It includes all visible and
+      description: |
+        Number of all lines in a frame. It includes all visible and
         invisible lines at the beginning and at the end of a frame.
 
     vsync0:
       type: int
       required: true
-      description: Number of lines for the high state of signal VSYNC at
+      description: |
+        Number of lines for the high state of signal VSYNC at
         the start of new frame.
 
     vsync1:
       type: int
       required: true
-      description: Number of lines for signal VSYNC toggle takes at the start
+      description: |
+        Number of lines for signal VSYNC toggle takes at the start
         of new frame.
 
     hsize:
@@ -79,7 +86,8 @@ properties:
     hoffset:
       type: int
       required: true
-      description: Number of PCLK cycles before pixels are scanned out for
+      description: |
+        Number of PCLK cycles before pixels are scanned out for
         given line
 
     hcycle:

--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -19,7 +19,7 @@ properties:
     dma-channel-mask:
       type: int
       required: false
-      description: >
+      description: |
         Bitmask of available DMA channels in ascending order that are
         not reserved by firmware and are available to the
         kernel. i.e. first channel corresponds to LSB.

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -88,7 +88,7 @@ properties:
     dma-offset:
       type: int
       required: false
-      description: >
+      description: |
         offset in the table of channels when mapping to a DMAMUX
         for 1st dma instance, offset is 0,
         for 2nd dma instance, offset is the nb of dma channels of the 1st dma,

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -76,7 +76,7 @@ properties:
     dma-offset:
       type: int
       required: false
-      description: >
+      description: |
         offset in the table of channels when mapping to a DMAMUX
         for 1st dma instance, offset is 0,
         for 2nd dma instance, offset is the nb of dma channels of the 1st dma,

--- a/dts/bindings/gpio/microchip,mcp23s17.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s17.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: >
+description: |
     This is a representation of the Microchip MCP23S17 SPI Gpio Expander.
 
 compatible: "microchip,mcp23s17"

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -19,8 +19,9 @@ properties:
     slptr-gpios:
       type: phandle-array
       required: true
-      description: Multi-functional pin that controls sleep, deep sleep,
-        transmit start and receive states
+      description: |
+        Multi-functional pin that controls sleep, deep sleep, transmit
+        start and receive states
 
     dig2-gpios:
       type: phandle-array
@@ -34,5 +35,6 @@ properties:
 
     local-mac-address:
       type: uint8-array
-      description:
-        Specifies the MAC address that was assigned to the network device
+      description: |
+        Specifies the MAC address that was assigned to the network
+        device

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -14,7 +14,8 @@ properties:
     pwr-gpios:
       type: phandle-array
       required: false
-      description: Power pin
+      description: |
+        Power pin
         This pin defaults to active high when consumed by the SD card. The
         property value should ensure the flags properly describe the signal
         that is presented to the driver.
@@ -22,7 +23,8 @@ properties:
     cd-gpios:
       type: phandle-array
       required: false
-      description: Detect pin
+      description: |
+        Detect pin
         This pin defaults to active low when produced by the SD card. The
         property value should ensure the flags properly describe the signal
         that is presented to the driver.
@@ -30,7 +32,7 @@ properties:
     no-1-8-v:
       type: boolean
       required: false
-      description:
+      description: |
         When the external SD card circuit does not support 1.8V, add this
         property to disable 1.8v card voltage of SD card controller.
 

--- a/dts/bindings/mtd/zephyr,emu-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,emu-eeprom.yaml
@@ -25,6 +25,7 @@ properties:
     partition-erase:
       type: boolean
       required: false
-      description: Delay erase until complete partition is used. This enables a
+      description: |
+        Delay erase until complete partition is used. This enables a
         ram buffer to allow data to be copied during the partition erase. If
         power is lost during the partition erase the data will be lost.

--- a/dts/bindings/net/wireless/nordic,nrf21540-fem-spi.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem-spi.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-description: >
+description: |
     This is a SPI device interface to the nRF21540 Radio Front-End module
 
 compatible: "nordic,nrf21540-fem-spi"

--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-description: >
+description: |
     This is a representation of the nRF21540 Radio Front-End module
 compatible: "nordic,nrf21540-fem"
 
@@ -12,64 +12,68 @@ properties:
     tx-en-gpios:
         type: phandle-array
         required: false
-        description: >
-            Gpio of the SOC controlling TX_EN pin of the nRF21540
+        description: |
+            GPIO of the SOC controlling TX_EN pin of the nRF21540
     rx-en-gpios:
         type: phandle-array
         required: false
-        description: >
-            Gpio of the SOC controlling RX_EN pin of the nRF21540
+        description: |
+            GPIO of the SOC controlling RX_EN pin of the nRF21540
     pdn-gpios:
         type: phandle-array
         required: false
-        description: >
-            Gpio of the SOC controlling PDN pin of the nRF21540
+        description: |
+            GPIO of the SOC controlling PDN pin of the nRF21540
     ant-sel-gpios:
         type: phandle-array
         required: false
-        description: >
-            Gpio of the SOC controlling ANT-SEL pin of the nRF21540
+        description: |
+            GPIO of the SOC controlling ANT-SEL pin of the nRF21540
     mode-gpios:
         type: phandle-array
         required: false
-        description: >
-            Gpio of the SOC controlling MODE pin of the nRF21540
+        description: |
+            GPIO of the SOC controlling MODE pin of the nRF21540
     spi-if:
         type: phandle
         required: false
-        description: >
+        description: |
             Reference to the nordic,nrf21540-fem-spi SPI bus interface.
 
             This must be present to support SPI control of the FEM.
     tx-en-settle-time-us:
         type: int
         default: 11
-        description: >
+        description: |
             Settling time in microseconds from state PG to TX.
 
-            Default value is based on Table 6 of the nRF21540 Product Specification (v1.0),
-            and can be overridden for tuned configurations.
+            Default value is based on Table 6 of the nRF21540 Product
+            Specification (v1.0), and can be overridden for tuned
+            configurations.
     rx-en-settle-time-us:
         type: int
         default: 11
-        description: >
+        description: |
             Settling time in microseconds from state PG to RX.
 
-            Default value is based on Table 6 of the nRF21540 Product Specification (v1.0),
-            and can be overridden for tuned configurations.
+            Default value is based on Table 6 of the nRF21540 Product
+            Specification (v1.0), and can be overridden for tuned
+            configurations.
     pdn-settle-time-us:
         type: int
         default: 18
-        description: >
+        description: |
             Settling time in microseconds from state PD to PG.
 
-            Default value is based on Table 6 of the nRF21540 Product Specification (v1.0),
-            and can be overridden for tuned configurations.
+            Default value is based on Table 6 of the nRF21540 Product
+            Specification (v1.0), and can be overridden for tuned
+            configurations.
     trx-hold-time-us:
         type: int
         default: 3
-        description: >
+        description: |
             Power-off time in microseconds when changing from RX or TX to PG.
 
-            Default value is based on Table 6 of the nRF21540 Product Specification (v1.0),
-            and can be overridden for tuned configurations.
+            Default value is based on Table 6 of the nRF21540 Product
+            Specification (v1.0), and can be overridden for tuned
+            configurations.

--- a/dts/bindings/phy/phy-controller.yaml
+++ b/dts/bindings/phy/phy-controller.yaml
@@ -9,5 +9,6 @@ properties:
     "#phy-cells":
         type: int
         required: true
-        description: Number of cells in a PHY provider. The meaning those
-                     cells is defined by the binding for the phy node.
+        description: |
+          Number of cells in a PHY provider. The meaning those
+          cells is defined by the binding for the phy node.

--- a/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-conf.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-lvolctrl-conf.yaml
@@ -1,8 +1,10 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton NPCX7 Low-Voltage level detection configuration map
-    between Nuvoton NPCX GPIO and low-voltage controller (LV_GPIO_CTL) driver instances.
+description: |
+  Nuvoton NPCX7 Low-Voltage level detection configuration map
+  between Nuvoton NPCX GPIO and low-voltage controller (LV_GPIO_CTL)
+  driver instances.
 
 compatible: "nuvoton,npcx-lvolctrl-conf"
 

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl-conf.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl-conf.yaml
@@ -1,9 +1,10 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton NPCX7 Pin-Mux Configuration
-    Configuration map from Nuvoton NPCX GPIO to pinmux controller
-    (SCFG) driver instances.
+description: |
+  Nuvoton NPCX7 Pin-Mux Configuration
+  Configuration map from Nuvoton NPCX GPIO to pinmux controller
+  (SCFG) driver instances.
 
 compatible: "nuvoton,npcx-pinctrl-conf"
 child-binding:

--- a/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-conf.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pslctrl-conf.yaml
@@ -1,14 +1,17 @@
 # Copyright (c) 2021 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton NPCX pads configuration map between Pin Mux controller and
-             Power Switch Logic (PSL) controller driver instances.
+description: |
+  Nuvoton NPCX pads configuration map between Pin Mux controller and
+  Power Switch Logic (PSL) controller driver instances.
 
 compatible: "nuvoton,npcx-pslctrl-conf"
 
 child-binding:
-   description: Child node to present the mapping between pin-mux controller
-                and its power switch logic (PSL) support
+   description: |
+     Child node to present the mapping between pin-mux controller
+     and its power switch logic (PSL) support
+
    properties:
       offset:
          type: int

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -70,6 +70,7 @@ child-binding:
           - "medium-speed"
           - "high-speed"
           - "very-high-speed"
-          description: Pin speed. Default to low-speed. For few pins (PA11 and
+          description: |
+            Pin speed. Default to low-speed. For few pins (PA11 and
             PB3 depending on SoCs)hardware reset value could differ
             (very-high-speed). Carefully check reference manual for these pins.

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -13,7 +13,8 @@ properties:
 
 child-binding:
     description: |
-        This binding gives a base representation of the STM32F1 pins configration
+        This binding gives a base representation of the STM32F1 pins
+        configration
 
     properties:
         pinmux:
@@ -57,33 +58,38 @@ child-binding:
         bias-disable:
           required: false
           type: boolean
-          description: Pin bias (push-pull) disabled. This is the default pin
+          description: |
+            Pin bias (push-pull) disabled. This is the default pin
             configuration and will be applied if no bias- property is
             specified. Only available in input mode ("floating" configuration).
 
         bias-pull-down:
           required: false
           type: boolean
-          description: Weak pull down resistor enabled. Not compatible with
+          description: |
+            Weak pull down resistor enabled. Not compatible with
             output configuration modes (atlernate or general purpose output).
 
         bias-pull-up:
           required: false
           type: boolean
-          description: Weak pull up resistor enabled. Not compatible with
+          description: |
+            Weak pull up resistor enabled. Not compatible with
             output configuration modes (atlernate or general purpose output).
 
         drive-push-pull:
           required: false
           type: boolean
-          description: Pin driven actively high and low. This is the default pin
+          description: |
+            Pin driven actively high and low. This is the default pin
             configueration and will be applied if no drive- property is
             specified. Only valid for output configuration modes.
 
         drive-open-drain:
           required: false
           type: boolean
-          description: Pin driven in open drain. Only valid for output
+          description: |
+            Pin driven in open drain. Only valid for output
             configuration modes.
 
         slew-rate:
@@ -94,5 +100,6 @@ child-binding:
           - "max-speed-10mhz"       # Default
           - "max-speed-2mhz"
           - "max-speed-50mhz"
-          description: Pin output mode, maximum achievable speed. Only applies
-            to output mode (alternate)..
+          description: |
+            Pin output mode, maximum achievable speed. Only applies to
+            output mode (alternate).

--- a/dts/bindings/sensor/maxim,max17055.yaml
+++ b/dts/bindings/sensor/maxim,max17055.yaml
@@ -39,7 +39,7 @@ properties:
     rsense-mohms:
       type: int
       required: true
-      description: >
+      description: |
         Value of Rsense resistor in milliohms (e.g. 5). It cannot be 0.
 
     v-empty:

--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -23,7 +23,8 @@ properties:
       type: int
       required: false
       default: 3
-      description: Sensor resolution. Default is 0.0625C (0b11),
+      description: |
+        Sensor resolution. Default is 0.0625C (0b11),
         which is the power-up default.
       enum:
         - 0 # 0.5C

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -11,7 +11,8 @@ properties:
     int1-gpios:
       type: phandle-array
       required: false
-      description: INT1 pin
+      description: |
+        INT1 pin
         This pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe
         the signal that is presented to the driver.
@@ -19,7 +20,8 @@ properties:
     int2-gpios:
       type: phandle-array
       required: false
-      description: INT2 pin
+      description: |
+        INT2 pin
         This pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe
         the signal that is presented to the driver.

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -11,7 +11,8 @@ properties:
     reset-gpios:
       type: phandle-array
       required: false
-      description: RST pin
+      description: |
+        RST pin
         This pin defaults to active high when consumed by the sensor.
         The property value should ensure the flags properly describe
         the signal that is presented to the driver.
@@ -19,7 +20,8 @@ properties:
     int1-gpios:
       type: phandle-array
       required: false
-      description: INT1 pin
+      description: |
+        INT1 pin
         This pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe
         the signal that is presented to the driver.
@@ -27,7 +29,8 @@ properties:
     int2-gpios:
       type: phandle-array
       required: false
-      description: INT2 pin
+      description: |
+        INT2 pin
         This pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe
         the signal that is presented to the driver.
@@ -63,7 +66,8 @@ properties:
       type: int
       required: false
       default: 0x20
-      description: Pulse X-axis threshold
+      description: |
+        Pulse X-axis threshold
         Threshold to start the pulse-event detection procedure on the X-axis.
         Threshold values for each axis are unsigned 7-bit numbers with a fixed
         resolution of 0.063 g/LSB, corresponding to an 8g acceleration
@@ -73,7 +77,8 @@ properties:
       type: int
       required: false
       default: 0x20
-      description: Pulse Y-axis threshold
+      description: |
+        Pulse Y-axis threshold
         Threshold to start the pulse-event detection procedure on the Y-axis.
         Threshold values for each axis are unsigned 7-bit numbers with a fixed
         resolution of 0.063 g/LSB, corresponding to an 8g acceleration
@@ -83,7 +88,8 @@ properties:
       type: int
       required: false
       default: 0x40
-      description: Pulse Z-axis threshold
+      description: |
+        Pulse Z-axis threshold
         Threshold to start the pulse-event detection procedure on the Z-axis.
         Threshold values for each axis are unsigned 7-bit numbers with a fixed
         resolution of 0.063 g/LSB, corresponding to an 8g acceleration
@@ -93,7 +99,8 @@ properties:
       type: int
       required: false
       default: 0x18
-      description: Pulse time limit
+      description: |
+        Pulse time limit
         The maximum time interval that can elapse between the start of the
         acceleration on the selected channel exceeding the specified threshold
         and the end when the channel acceleration goes back below the specified
@@ -105,7 +112,8 @@ properties:
       type: int
       required: false
       default: 0x28
-      description: Pulse latency
+      description: |
+        Pulse latency
         The time interval that starts after the first pulse detection where the
         pulse-detection function ignores the start of a new pulse. The
         resolution depends upon the sample rate (ODR) and the high-pass filter
@@ -116,7 +124,8 @@ properties:
       type: int
       required: false
       default: 0x3c
-      description: Pulse window
+      description: |
+        Pulse window
         The maximum interval of time that can elapse after the end of the
         latency interval in which the start of the second pulse event must be
         detected provided the device has been configured for double pulse
@@ -137,12 +146,14 @@ properties:
       type: int
       required: false
       default: 0x00
-      description: Magnetic vector-magnitude threshold most significant byte.
+      description: |
+        Magnetic vector-magnitude threshold most significant byte.
         Resolution is 0.1 uT/LSB.
 
     mag-vecm-ths-lsb:
       type: int
       required: false
       default: 0x5a
-      description: Magnetic vector-magnitude threshold least significant byte.
+      description: |
+        Magnetic vector-magnitude threshold least significant byte.
         Resolution is 0.1 uT/LSB.

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -11,7 +11,7 @@ properties:
     alert-gpios:
       type: phandle-array
       required: false
-      description: >
+      description: |
         ALERT pin.
 
         This pin signals active high when produced by the sensor.  The

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -5,7 +5,8 @@ properties:
     drdy-gpios:
       type: phandle-array
       required: false
-      description: DRDY pin
+      description: |
+        DRDY pin
 
         This pin defaults to active high when produced by the sensor.
         The property value should ensure the flags properly describe
@@ -65,7 +66,8 @@ properties:
       type: array
       required: false
       default: [0, 0, 0]
-      description: Tap X/Y/Z axes threshold. Default is power-up configuration.
+      description: |
+        Tap X/Y/Z axes threshold. Default is power-up configuration.
         (X/Y/Z values range from 0x00 to 0x1F)
 
         Thresholds to start the tap-event detection procedure on the X/Y/Z axes.
@@ -84,7 +86,8 @@ properties:
       type: int
       required: false
       default: 0x0
-      description: Tap shock value. Default is power-up configuration.
+      description: |
+        Tap shock value. Default is power-up configuration.
         (values range from 0x0 to 0x3)
         This register represents the maximum time of an over-threshold signal
         detection to be recognized as a tap event. Where 0 equals 4*1/ODR and
@@ -94,7 +97,8 @@ properties:
       type: int
       required: false
       default: 0x0
-      description: Tap latency. Default is power-up configuration.
+      description: |
+        Tap latency. Default is power-up configuration.
         (values range from 0x0 to 0xF)
         When double-tap recognition is enabled, this register expresses the
         maximum time between two successive detected taps to determine a
@@ -104,7 +108,8 @@ properties:
       type: int
       required: false
       default: 0x0
-      description: Expected quiet time after a tap detection. Default is power-up configuration.
+      description: |
+        Expected quiet time after a tap detection. Default is power-up configuration.
         (values range from 0x0 to 0x3)
         This register represents the time after the first detected tap in which
         there must not be any overthreshold event. Where 0 equals 2*1/ODR

--- a/dts/bindings/sensor/st,lis2dh-common.yaml
+++ b/dts/bindings/sensor/st,lis2dh-common.yaml
@@ -12,7 +12,8 @@ properties:
     disconnect-sdo-sa0-pull-up:
       type: boolean
       required: false
-      description: Indicates the device driver should disconnect SDO/SA0 pull-up
-                   during device initialization (e.g. to save current
-                   leakage). Note that only subset of devices supported by this
-                   binding have SDO/SA0 pull-up (e.g. LIS2DH12, LIS3DH).
+      description: |
+        Indicates the device driver should disconnect SDO/SA0 pull-up
+        during device initialization (e.g. to save current
+        leakage). Note that only subset of devices supported by this
+        binding have SDO/SA0 pull-up (e.g. LIS2DH12, LIS3DH).

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -23,7 +23,7 @@ properties:
     avgslope:
       type: int
       default: 25
-      description: >
+      description: |
         Average slope of T-V chart (in mV/C x10) according to
         datasheet "Electrical characteristics/Operating conditions"
         STM32F1 Table 5.3.19 (min 4 mV/C, max 4.6, default 4.3)
@@ -32,7 +32,7 @@ properties:
     v25:
       type: int
       default: 760
-      description: >
+      description: |
         Voltage of temperature sensor at 25C in mV according to
         datasheet "Electrical characteristics/Operating conditions"
         STM32F1 Table 5.3.19 (min 1340, max 1520, default 1430)
@@ -40,5 +40,4 @@ properties:
 
     ntc:
       type: boolean
-      description: >
-        Negative Temperature Coefficient. True if STM32F1
+      description: Negative Temperature Coefficient. True if STM32F1

--- a/dts/bindings/serial/nxp,imx-iuart.yaml
+++ b/dts/bindings/serial/nxp,imx-iuart.yaml
@@ -1,4 +1,4 @@
-description: >
+description: |
     This binding gives a base representation of the NXP iMX IUART
 
 compatible: "nxp,imx-iuart"

--- a/dts/bindings/timer/arm,armv8-timer.yaml
+++ b/dts/bindings/timer/arm,armv8-timer.yaml
@@ -1,5 +1,4 @@
-description: >
-    per-core ARM architected timer
+description: per-core ARM architected timer
 
 compatible: "arm,armv8-timer"
 

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -17,8 +17,9 @@ properties:
     ram-size:
       type: int
       required: true
-      description: Size of USB dedicated RAM. STM32 SOC's reference
-                   manual defines a shared FIFO size.
+      description: |
+        Size of USB dedicated RAM. STM32 SOC's reference
+        manual defines a shared FIFO size.
 
     phys:
       type: phandle

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -17,8 +17,9 @@ properties:
     ram-size:
       type: int
       required: true
-      description: Size of USB dedicated RAM. STM32 SOC's reference
-                   manual defines a shared FIFO size.
+      description: |
+        Size of USB dedicated RAM. STM32 SOC's reference
+        manual defines a shared FIFO size.
 
     phys:
       type: phandle

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -17,14 +17,16 @@ properties:
     ram-size:
       type: int
       required: true
-      description: Size of USB dedicated RAM. STM32 SOC's reference
-                   manual defines USB packet SRAM size.
+      description: |
+        Size of USB dedicated RAM. STM32 SOC's reference
+        manual defines USB packet SRAM size.
 
     disconnect-gpios:
       type: phandle-array
       required: false
-      description: Some boards use a USB DISCONNECT pin to enable
-                   the pull-up resistor on USB Data Positive signal.
+      description: |
+        Some boards use a USB DISCONNECT pin to enable
+        the pull-up resistor on USB Data Positive signal.
 
     phys:
       type: phandle
@@ -34,8 +36,9 @@ properties:
     enable-pin-remap:
       type: boolean
       required: false
-      description: For STM32F0 series SoCs on QFN28 and TSSOP20 packages
-                   enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
+      description: |
+        For STM32F0 series SoCs on QFN28 and TSSOP20 packages
+        enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
 
     clocks:
       required: true

--- a/dts/bindings/usb/usb-audio-hp.yaml
+++ b/dts/bindings/usb/usb-audio-hp.yaml
@@ -80,35 +80,42 @@ properties:
   feature-volume:
     type: boolean
     required: false
-    description: Enable Volume feature.
-                 Currently not supported.
+    description: |
+      Enable Volume feature.
+      Currently not supported.
   feature-tone-control:
     type: boolean
     required: false
-    description: Enable Tone Control (Bass, Mid, Treble) feature.
-                 Currently not supported.
+    description: |
+      Enable Tone Control (Bass, Mid, Treble) feature.
+      Currently not supported.
   feature-graphic-equalizer:
     type: boolean
     required: false
-    description: Enable  Graphic Equalizer feature.
-                 Currently not supported.
+    description: |
+      Enable  Graphic Equalizer feature.
+      Currently not supported.
   feature-automatic-gain-control:
     type: boolean
     required: false
-    description: Enable Autoamtic Gain Control feature.
-                 Currently not supported.
+    description: |
+      Enable Autoamtic Gain Control feature.
+      Currently not supported.
   feature-delay:
     type: boolean
     required: false
-    description: Enable Delay feature.
-                 Currently not supported.
+    description: |
+      Enable Delay feature.
+      Currently not supported.
   feature-bass-boost:
     type: boolean
     required: false
-    description: Enable Bass Boost feature.
-                 Currently not supported.
+    description: |
+      Enable Bass Boost feature.
+      Currently not supported.
   feature-loudness:
     type: boolean
     required: false
-    description: Enable Loudness feature.
-                 Currently not supported.
+    description: |
+      Enable Loudness feature.
+      Currently not supported.

--- a/dts/bindings/usb/usb-audio-hs.yaml
+++ b/dts/bindings/usb/usb-audio-hs.yaml
@@ -23,9 +23,10 @@ properties:
     required: false
     default: "Synchronous"
     type: string
-    description: Type of endpoint synchronization for IN devices.
-                 Default value is Sychronous.
-                 Adaptive is not supported.
+    description: |
+      Type of endpoint synchronization for IN devices.
+      Default value is Sychronous.
+      Adaptive is not supported.
     enum:
      - "No Synchronization"
      - "Asynchronous"
@@ -101,38 +102,45 @@ properties:
   mic-feature-volume:
     type: boolean
     required: false
-    description: Enable Volume feature.
-                 Currently not supported.
+    description: |
+      Enable Volume feature.
+      Currently not supported.
   mic-feature-tone-control:
     type: boolean
     required: false
-    description: Enable Tone Control (Bass, Mid, Treble) feature.
-                 Currently not supported.
+    description: |
+      Enable Tone Control (Bass, Mid, Treble) feature.
+      Currently not supported.
   mic-feature-graphic-equalizer:
     type: boolean
     required: false
-    description: Enable  Graphic Equalizer feature.
-                 Currently not supported.
+    description: |
+      Enable  Graphic Equalizer feature.
+      Currently not supported.
   mic-feature-automatic-gain-control:
     type: boolean
     required: false
-    description: Enable Autoamtic Gain Control feature.
-                 Currently not supported.
+    description: |
+      Enable Autoamtic Gain Control feature.
+      Currently not supported.
   mic-feature-delay:
     type: boolean
     required: false
-    description: Enable Delay feature.
-                 Currently not supported.
+    description: |
+      Enable Delay feature.
+      Currently not supported.
   mic-feature-bass-boost:
     type: boolean
     required: false
-    description: Enable Bass Boost feature.
-                 Currently not supported.
+    description: |
+      Enable Bass Boost feature.
+      Currently not supported.
   mic-feature-loudness:
     type: boolean
     required: false
-    description: Enable Loudness feature.
-                 Currently not supported.
+    description: |
+      Enable Loudness feature.
+      Currently not supported.
 # headphones channel configuration options
   hp-channel-l:
     type: boolean
@@ -194,35 +202,42 @@ properties:
   hp-feature-volume:
     type: boolean
     required: false
-    description: Enable Volume feature.
-                 Currently not supported.
+    description: |
+      Enable Volume feature.
+      Currently not supported.
   hp-feature-tone-control:
     type: boolean
     required: false
-    description: Enable Tone Control (Bass, Mid, Treble) feature.
-                 Currently not supported.
+    description: |
+      Enable Tone Control (Bass, Mid, Treble) feature.
+      Currently not supported.
   hp-feature-graphic-equalizer:
     type: boolean
     required: false
-    description: Enable  Graphic Equalizer feature.
-                 Currently not supported.
+    description: |
+      Enable  Graphic Equalizer feature.
+      Currently not supported.
   hp-feature-automatic-gain-control:
     type: boolean
     required: false
-    description: Enable Autoamtic Gain Control feature.
-                 Currently not supported.
+    description: |
+      Enable Autoamtic Gain Control feature.
+      Currently not supported.
   hp-feature-delay:
     type: boolean
     required: false
-    description: Enable Delay feature.
-                 Currently not supported.
+    description: |
+      Enable Delay feature.
+      Currently not supported.
   hp-feature-bass-boost:
     type: boolean
     required: false
-    description: Enable Bass Boost feature.
-                 Currently not supported.
+    description: |
+      Enable Bass Boost feature.
+      Currently not supported.
   hp-feature-loudness:
     type: boolean
     required: false
-    description: Enable Loudness feature.
-                 Currently not supported.
+    description: |
+      Enable Loudness feature.
+      Currently not supported.

--- a/dts/bindings/usb/usb-audio-mic.yaml
+++ b/dts/bindings/usb/usb-audio-mic.yaml
@@ -23,9 +23,10 @@ properties:
     required: false
     default: "Synchronous"
     type: string
-    description: Type of endpoint synchronization for IN devices.
-                 Default value is Sychronous.
-                 Adaptive is not supported.
+    description: |
+      Type of endpoint synchronization for IN devices.
+      Default value is Sychronous.
+      Adaptive is not supported.
     enum:
      - "No Synchronization"
      - "Asynchronous"
@@ -92,35 +93,42 @@ properties:
   feature-volume:
     type: boolean
     required: false
-    description: Enable Volume feature.
-                 Currently not supported.
+    description: |
+      Enable Volume feature.
+      Currently not supported.
   feature-tone-control:
     type: boolean
     required: false
-    description: Enable Tone Control (Bass, Mid, Treble) feature.
-                 Currently not supported.
+    description: |
+      Enable Tone Control (Bass, Mid, Treble) feature.
+      Currently not supported.
   feature-graphic-equalizer:
     type: boolean
     required: false
-    description: Enable  Graphic Equalizer feature.
-                 Currently not supported.
+    description: |
+      Enable  Graphic Equalizer feature.
+      Currently not supported.
   feature-automatic-gain-control:
     type: boolean
     required: false
-    description: Enable Autoamtic Gain Control feature.
-                 Currently not supported.
+    description: |
+      Enable Autoamtic Gain Control feature.
+      Currently not supported.
   feature-delay:
     type: boolean
     required: false
-    description: Enable Delay feature.
-                 Currently not supported.
+    description: |
+      Enable Delay feature.
+      Currently not supported.
   feature-bass-boost:
     type: boolean
     required: false
-    description: Enable Bass Boost feature.
-                 Currently not supported.
+    description: |
+      Enable Bass Boost feature.
+      Currently not supported.
   feature-loudness:
     type: boolean
     required: false
-    description: Enable Loudness feature.
-                 Currently not supported.
+    description: |
+      Enable Loudness feature.
+      Currently not supported.

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -9,17 +9,20 @@ properties:
     num-bidir-endpoints:
       type: int
       required: true
-      description: Number of bi-directional endpoints supported by hardware
-                   (including EP0)
+      description: |
+        Number of bi-directional endpoints supported by hardware
+        (including EP0)
 
     num-in-endpoints:
       type: int
       required: false
-      description: Number of IN endpoints supported by hardware
-                   (including EP0 IN)
+      description: |
+        Number of IN endpoints supported by hardware
+        (including EP0 IN)
 
     num-out-endpoints:
       type: int
       required: false
-      description: Number of OUT endpoints supported by hardware
-                   (including EP0 OUT)
+      description: |
+        Number of OUT endpoints supported by hardware
+        (including EP0 OUT)


### PR DESCRIPTION
This PR cleans up various description strings throughout the devicetree bindings.

In general, if you need a multi-line string in a devicetree binding description, you should use this syntax:

```
description: |
  My very long string
  goes here.
  Look at all these lines!
```

This will be rendered properly into the bindings index as a multi-line, fixed-width string, which usually won't require horizontal scrolling unless your lines are too long.

If you have a very short string, just do this:

```
description: my short string
```

That renders fine, too.

However, don't under any circumstances do this:

```
description: Some string
  Multiple additional lines follow
  The whole thing is very long and detailed
```

Don't do this either:

```
description: >
  Some string
  Multiple additional lines follow
  The whole thing is very long and detailed
```

YAML will swallow all of the newlines in these two cases. That makes your description one very long line. This will require tons of horizontal scrolling for people reading the HTML docs. It is not easy to read the results.
