### PR TITLE
Remove device_get_binding from more samples

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -81,4 +81,14 @@ config EEPROM_SIMULATOR
 	default y
 	depends on EEPROM
 
+if I2C
+
+config EMUL
+	default y
+
+config I2C_EMUL
+	default y
+
+endif # I2C
+
 endif # BOARD_NATIVE_POSIX

--- a/include/drivers/clock_control/clock_control_litex.h
+++ b/include/drivers/clock_control/clock_control_litex.h
@@ -23,7 +23,6 @@
 #include <zephyr/types.h>
 
 #define MMCM			DT_NODELABEL(clock0)
-#define MMCM_NAME		DT_PROP(DT_NODELABEL(clock0), label)
 #define NCLKOUT			DT_PROP_LEN(MMCM, clock_output_names)
 
 /**

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -56,7 +56,7 @@ The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` f
 		.duty = 75,
 		.phase = 90
 	};
-	dev = device_get_binding("clock0");
+	dev = DEVICE_DT_GET(MMCM);
 	clock_control_subsys_t sub_system = (clock_control_subsys_t*)&setup;
 	if ((ret = clock_control_on(dev, sub_system)) != 0) {
 		LOG_ERR("Set CLKOUT%d param error!", setup.clkout_nr);

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -297,14 +297,13 @@ int litex_clk_test(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(MMCM);
 
 	printf("Clock Control Example! %s\n", CONFIG_ARCH);
 
-	printf("device name: %s\n", MMCM_NAME);
-	dev = device_get_binding(MMCM_NAME);
-	if (!dev) {
-		printf("error: no %s device\n", MMCM_NAME);
+	printf("device name: %s\n", dev->name);
+	if (!device_is_ready(dev)) {
+		printf("error: device %s is not ready\n", dev->name);
 		return;
 	}
 

--- a/samples/drivers/i2c_fujitsu_fram/src/main.c
+++ b/samples/drivers/i2c_fujitsu_fram/src/main.c
@@ -10,7 +10,7 @@
 #include <device.h>
 #include <drivers/i2c.h>
 
-#define I2C_DEV DT_LABEL(DT_ALIAS(i2c_0))
+#define I2C_NODE DT_ALIAS(i2c_0)
 
 /**
  * @file Sample app using the Fujitsu MB85RC256V FRAM through ARC I2C.
@@ -72,14 +72,13 @@ static int read_bytes(const struct device *i2c_dev, uint16_t addr,
 
 void main(void)
 {
-	const struct device *i2c_dev;
+	const struct device *i2c_dev = DEVICE_DT_GET(I2C_NODE);
 	uint8_t cmp_data[16];
 	uint8_t data[16];
 	int i, ret;
 
-	i2c_dev = device_get_binding(I2C_DEV);
-	if (!i2c_dev) {
-		printk("I2C: Device driver not found.\n");
+	if (!device_is_ready(i2c_dev)) {
+		printk("I2C: Device is not ready.\n");
 		return;
 	}
 

--- a/samples/drivers/kscan/src/main.c
+++ b/samples/drivers/kscan/src/main.c
@@ -15,9 +15,9 @@
 
 LOG_MODULE_REGISTER(main);
 
-#define KSCAN_LABEL DT_LABEL(DT_ALIAS(kscan0))
+#define KSCAN_NODE DT_ALIAS(kscan0)
 
-const struct device *kscan_dev;
+const struct device *kscan_dev = DEVICE_DT_GET(KSCAN_NODE);
 static struct k_timer typematic_timer;
 static struct k_timer block_matrix_timer;
 
@@ -155,9 +155,8 @@ void main(void)
 {
 	printk("Kscan matrix sample application\n");
 
-	kscan_dev = device_get_binding(KSCAN_LABEL);
-	if (!kscan_dev) {
-		LOG_ERR("kscan device %s not found", KSCAN_LABEL);
+	if (!device_is_ready(kscan_dev)) {
+		LOG_ERR("kscan device %s not ready", kscan_dev->name);
 		return;
 	}
 

--- a/samples/drivers/kscan_touch/src/main.c
+++ b/samples/drivers/kscan_touch/src/main.c
@@ -15,9 +15,9 @@
 
 LOG_MODULE_REGISTER(main);
 
-const struct device *kscan_dev;
+#define TOUCH_CONTROLLER_NODE DT_ALIAS(kscan0)
 
-#define TOUCH_CONTROLLER_LABEL DT_LABEL(DT_ALIAS(kscan0))
+const struct device *kscan_dev = DEVICE_DT_GET(TOUCH_CONTROLLER_NODE);
 
 static void k_callback(const struct device *dev, uint32_t row, uint32_t col,
 		       bool pressed)
@@ -32,9 +32,8 @@ void main(void)
 {
 	printk("Kscan touch panel sample application\n");
 
-	kscan_dev = device_get_binding(TOUCH_CONTROLLER_LABEL);
-	if (!kscan_dev) {
-		LOG_ERR("kscan device %s not found", TOUCH_CONTROLLER_LABEL);
+	if (!device_is_ready(kscan_dev)) {
+		LOG_ERR("kscan device %s not ready", kscan_dev->name);
 		return;
 	}
 

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -72,7 +72,7 @@
 
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAM3X8E)
-#define GPIO_DRV_NAME DT_LABEL(DT_NODELABEL(pioc))
+#define GPIO_NODE DT_NODELABEL(pioc)
 #else
 #error "Unsupported GPIO driver"
 #endif
@@ -527,11 +527,10 @@ void pi_lcd_init(const struct device *gpio_dev, uint8_t cols, uint8_t rows,
 
 void main(void)
 {
-	const struct device *gpio_dev;
+	const struct device *gpio_dev = DEVICE_DT_GET(GPIO_NODE);
 
-	gpio_dev = device_get_binding(GPIO_DRV_NAME);
-	if (!gpio_dev) {
-		printk("Cannot find %s!\n", GPIO_DRV_NAME);
+	if (!device_is_ready(gpio_dev)) {
+		printk("Device %s not ready!\n", gpio_dev->name);
 		return;
 	}
 

--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -29,8 +29,6 @@
 #define GPIO_CLK_PIN	19
 #define GPIO_NAME	"GPIO_"
 
-#define GPIO_DRV_NAME	DT_LABEL(DT_ALIAS(gpio_0))
-
 #define APA102C_START_FRAME	0x00000000
 #define APA102C_END_FRAME	0xFFFFFFFF
 
@@ -72,9 +70,9 @@ void main(void)
 	int idx = 0;
 	int leds = 0;
 
-	gpio_dev = device_get_binding(GPIO_DRV_NAME);
-	if (!gpio_dev) {
-		printk("Cannot find %s!\n", GPIO_DRV_NAME);
+	gpio_dev = DEVICE_DT_GET(DT_ALIAS(gpio_0));
+	if (!device_is_ready(gpio_dev)) {
+		printk("GPIO device %s is not ready!\n", gpio_dev->name);
 		return;
 	}
 

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -14,22 +14,23 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(app);
 
-#define LED_DEV_NAME DT_LABEL(DT_INST(0, ti_lp3943))
 #define NUM_LEDS 16
 
 #define DELAY_TIME K_MSEC(1000)
 
 void main(void)
 {
-	const struct device *led_dev;
+	const struct device *led_dev = DEVICE_DT_GET_ANY(ti_lp3943);
 	int i, ret;
 
-	led_dev = device_get_binding(LED_DEV_NAME);
-	if (led_dev) {
-		LOG_INF("Found LED device %s", LED_DEV_NAME);
-	} else {
-		LOG_ERR("LED device %s not found", LED_DEV_NAME);
+	if (!led_dev) {
+		LOG_ERR("No device with compatible ti,lp3943 found");
 		return;
+	} else if (!device_is_ready(led_dev)) {
+		LOG_ERR("LED device %s not ready", led_dev->name);
+		return;
+	} else {
+		LOG_INF("Found LED device %s", led_dev->name);
 	}
 
 	/*

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -15,8 +15,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#define LP503X_DEV_NAME	DT_LABEL(DT_INST(0, ti_lp503x))
-
 #define MAX_BRIGHTNESS	100
 
 #define SLEEP_DELAY_MS	1000
@@ -213,18 +211,20 @@ static int run_channel_test(const struct device *lp503x_dev)
 
 void main(void)
 {
-	const struct device *lp503x_dev;
+	const struct device *lp503x_dev = DEVICE_DT_GET_ANY(ti_lp503x);
+
 	int err;
 	uint8_t led;
 	uint8_t num_leds = 0;
 
-	lp503x_dev = device_get_binding(LP503X_DEV_NAME);
-	if (lp503x_dev) {
-		LOG_INF("Found LED controller %s", LP503X_DEV_NAME);
-	} else {
-		LOG_ERR("LED controller %s not found", LP503X_DEV_NAME);
+	if (!lp503x_dev) {
+		LOG_ERR("No device with compatible ti,lp503x found");
+		return;
+	} else if (!device_is_ready(lp503x_dev)) {
+		LOG_ERR("LED controller %s is not ready", lp503x_dev->name);
 		return;
 	}
+	LOG_INF("Found LED controller %s", lp503x_dev->name);
 
 	for (led = 0; led < LP503X_MAX_LEDS; led++) {
 		int col;

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -14,7 +14,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#define LED_DEV_NAME DT_LABEL(DT_INST(0, ti_lp5562))
 #define NUM_LEDS 4
 #define BLINK_DELAY_ON 500
 #define BLINK_DELAY_OFF 500
@@ -165,15 +164,17 @@ static int turn_off_all_leds(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET_ANY(ti_lp5562);
 	int i, ret;
 
-	dev = device_get_binding(LED_DEV_NAME);
-	if (dev) {
-		LOG_INF("Found LED device %s", LED_DEV_NAME);
-	} else {
-		LOG_ERR("LED device %s not found", LED_DEV_NAME);
+	if (!dev) {
+		LOG_ERR("No \"ti,lp5562\" device found");
 		return;
+	} else if (!device_is_ready(dev)) {
+		LOG_ERR("LED device %s is not ready", dev->name);
+		return;
+	} else {
+		LOG_INF("Found LED device %s", dev->name);
 	}
 
 	LOG_INF("Testing leds");

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -14,7 +14,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#define LED_DEV_NAME DT_LABEL(DT_INST(0, nxp_pca9633))
 #define NUM_LEDS 4
 #define MAX_BRIGHTNESS 100
 #define HALF_BRIGHTNESS (MAX_BRIGHTNESS / 2)
@@ -25,15 +24,17 @@ LOG_MODULE_REGISTER(main);
 
 void main(void)
 {
-	const struct device *led_dev;
+	const struct device *led_dev = DEVICE_DT_GET_ANY(nxp_pca9633);
 	int i, ret;
 
-	led_dev = device_get_binding(LED_DEV_NAME);
-	if (led_dev) {
-		LOG_INF("Found LED device %s", LED_DEV_NAME);
-	} else {
-		LOG_ERR("LED device %s not found", LED_DEV_NAME);
+	if (!led_dev) {
+		LOG_ERR("No devices with compatible nxp,pca9633 found");
 		return;
+	} else if (!device_is_ready(led_dev)) {
+		LOG_ERR("LED device %s is not ready", led_dev->name);
+		return;
+	} else {
+		LOG_INF("Found LED device %s", led_dev->name);
 	}
 
 	LOG_INF("Testing leds");


### PR DESCRIPTION
Incremental progress towards https://github.com/zephyrproject-rtos/zephyr/issues/32139 and generally moving towards the new devicetree-aware device model macros.

This is a subset of the work needed in samples/drivers.