### PR TITLE
pm: Fix policy manager header

### DIFF
--- a/include/pm/policy.h
+++ b/include/pm/policy.h
@@ -14,7 +14,15 @@ extern "C" {
 #endif
 
 /**
- * @brief Function to get the next PM state based on the ticks
+ * @brief Function to get the next PM state
+ *
+ * This function is called by the power subsystem when the system is
+ * idle and returns the most appropriate state based on the number of
+ * ticks to the next event.
+ *
+ * @param ticks The number of ticks to the next scheduled event.
+ *
+ * @return The power state the system should use.
  */
 struct pm_state_info pm_policy_next_state(int32_t ticks);
 

--- a/include/pm/policy.h
+++ b/include/pm/policy.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_PM_POLICY_H_
+#define ZEPHYR_INCLUDE_PM_POLICY_H_
+
+#include <pm/state.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Function to get the next PM state based on the ticks
+ */
+struct pm_state_info pm_policy_next_state(int32_t ticks);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_PM_POLICY_H_ */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -8,7 +8,7 @@
 #include <kernel.h>
 #include <string.h>
 #include <device.h>
-#include "policy/pm_policy.h"
+#include <pm/policy.h>
 
 #if defined(CONFIG_PM)
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */

--- a/subsys/pm/pm_ctrl.c
+++ b/subsys/pm/pm_ctrl.c
@@ -9,7 +9,6 @@
 #include <device.h>
 #include <sys/atomic.h>
 #include <pm/state.h>
-#include "policy/pm_policy.h"
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>

--- a/subsys/pm/pm_priv.h
+++ b/subsys/pm/pm_priv.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2018 Intel Corporation.
+ * Copyright (c) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_POWER_PM_POLICY_H_
-#define ZEPHYR_POWER_PM_POLICY_H_
+#ifndef ZEPHYR_SUBSYS_PM_PRIV_H_
+#define ZEPHYR_SUBSYS_PM_PRIV_H_
 
 #include <pm/pm.h>
 
@@ -33,14 +33,8 @@ int pm_force_suspend_devices(void);
  */
 void pm_resume_devices(void);
 
-/**
- * @brief Function to get the next PM state based on the ticks
- */
-struct pm_state_info pm_policy_next_state(int32_t ticks);
-
-
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* ZEPHYR_POWER_PM_POLICY_H_ */
+#endif /* ZEPHYR_SUBSYS_PM_PRIV_H_ */

--- a/subsys/pm/policy/policy_dummy.c
+++ b/subsys/pm/policy/policy_dummy.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <kernel.h>
 #include <pm/state.h>
-#include "pm_policy.h"
+#include <pm/policy.h>
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);

--- a/subsys/pm/policy/policy_residency.c
+++ b/subsys/pm/policy/policy_residency.c
@@ -6,7 +6,8 @@
 
 #include <zephyr.h>
 #include <kernel.h>
-#include "pm_policy.h"
+#include <pm/pm.h>
+#include <pm/policy.h>
 
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>

--- a/subsys/pm/policy/policy_residency_cc13x2_cc26x2.c
+++ b/subsys/pm/policy/policy_residency_cc13x2_cc26x2.c
@@ -7,7 +7,8 @@
 #include <zephyr.h>
 #include <kernel.h>
 #include <sys/__assert.h>
-#include "pm_policy.h"
+#include <pm/pm.h>
+#include <pm/policy.h>
 
 #include <ti/devices/cc13x2_cc26x2/driverlib/sys_ctrl.h>
 

--- a/subsys/pm/power.c
+++ b/subsys/pm/power.c
@@ -11,8 +11,10 @@
 #include <string.h>
 #include <pm/pm.h>
 #include <pm/state.h>
-#include "policy/pm_policy.h"
+#include <pm/policy.h>
 #include <tracing/tracing.h>
+
+#include "pm_priv.h"
 
 #define PM_STATES_LEN (1 + PM_STATE_SOFT_OFF - PM_STATE_ACTIVE)
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL


### PR DESCRIPTION
Policy manager header has to be in the include for applications.
Also it had several function prototypes that are not part of the policy.
These functions were moved from the policy header to a dedicated private
header.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>