### PR TITLE
drivers: Add Atmel SAM counter (TC) Driver

### DIFF
--- a/boards/arm/sam4l_ek/sam4l_ek.dts
+++ b/boards/arm/sam4l_ek/sam4l_ek.dts
@@ -62,6 +62,11 @@
 		   <&gpioc 0 GPIO_ACTIVE_LOW>;
 };
 
+&tc0 {
+	clk = <4>;
+	status = "okay";
+};
+
 &twim0 {
 	status = "okay";
 

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC        counter_mcux_lpc
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_TIMER           counter_nrfx_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_RTC             counter_nrfx_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_RTC_STM32           counter_ll_stm32_rtc.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_SAM_TC              counter_sam_tc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SAM0_TC32           counter_sam0_tc32.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_CMOS                counter_cmos.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_GPT            counter_mcux_gpt.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -30,6 +30,8 @@ source "drivers/counter/Kconfig.imx_epit"
 
 source "drivers/counter/Kconfig.stm32_rtc"
 
+source "drivers/counter/Kconfig.sam"
+
 source "drivers/counter/Kconfig.sam0"
 
 source "drivers/counter/Kconfig.cmos"

--- a/drivers/counter/Kconfig.sam
+++ b/drivers/counter/Kconfig.sam
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Piotr Mienkowski
+# SPDX-License-Identifier: Apache-2.0
+
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_ATMEL_SAM_TC := atmel,sam-tc
+
+config COUNTER_SAM_TC
+	bool "Atmel SAM MCU family counter (TC) driver"
+	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_TC))
+	depends on SOC_FAMILY_SAM
+	help
+	  Enable the Atmel SAM MCU family counter (TC) driver.

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2021, Piotr Mienkowski
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT atmel_sam_tc
+
+/** @file
+ * @brief Atmel SAM MCU family counter (TC) driver.
+ *
+ * This version of the driver uses a single channel to provide a basic 16-bit
+ * counter (on SAM4E series the counter is 32-bit). Remaining TC channels could
+ * be used in the future to provide additional functionality, e.g. input clock
+ * divider configured via DT properties.
+ *
+ * Remarks:
+ * - The driver is not thread safe.
+ * - The driver does not implement guard periods.
+ * - The driver does not guarantee that short relative alarm will trigger the
+ *   interrupt immediately and not after the full cycle / counter overflow.
+ *
+ * Use at your own risk or submit a patch.
+ */
+
+#include <errno.h>
+#include <sys/__assert.h>
+#include <sys/util.h>
+#include <device.h>
+#include <init.h>
+#include <soc.h>
+#include <drivers/counter.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(counter_sam_tc, CONFIG_COUNTER_LOG_LEVEL);
+
+#define MAX_ALARMS_PER_TC_CHANNEL 2
+#if defined(CONFIG_SOC_SERIES_SAM4E) || defined(CONFIG_SOC_SERIES_SAM3X)
+#define COUNTER_SAM_TOP_VALUE_MAX UINT32_MAX
+#else
+#define COUNTER_SAM_TOP_VALUE_MAX UINT16_MAX
+#define COUNTER_SAM_16_BIT
+#endif
+
+/* Device constant configuration parameters */
+struct counter_sam_dev_cfg {
+	struct counter_config_info info;
+	Tc *regs;
+	uint32_t reg_cmr;
+	void (*irq_config_func)(const struct device *dev);
+	const struct soc_gpio_pin *pin_list;
+	uint8_t pin_list_size;
+	uint8_t clk_sel;
+	bool nodivclk;
+	uint8_t tc_chan_num;
+	uint8_t periph_id[TCCHANNEL_NUMBER];
+};
+
+struct counter_sam_alarm_data {
+	counter_alarm_callback_t callback;
+	void *user_data;
+};
+
+/* Device run time data */
+struct counter_sam_dev_data {
+	counter_top_callback_t top_cb;
+	void *top_user_data;
+
+	struct counter_sam_alarm_data alarm[MAX_ALARMS_PER_TC_CHANNEL];
+};
+
+#define DEV_NAME(dev) ((dev)->name)
+#define DEV_CFG(dev) \
+	((const struct counter_sam_dev_cfg *const)(dev)->config)
+#define DEV_DATA(dev) \
+	((struct counter_sam_dev_data *const)(dev)->data)
+
+static const uint32_t sam_tc_input_freq_table[] = {
+#if defined(CONFIG_SOC_SERIES_SAME70) || defined(CONFIG_SOC_SERIES_SAMV71)
+	USEC_PER_SEC,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 8,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 32,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 128,
+	32768,
+#elif defined(CONFIG_SOC_SERIES_SAM4L)
+	USEC_PER_SEC,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 2,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 8,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 32,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 128,
+#else
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 2,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 8,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 32,
+	SOC_ATMEL_SAM_MCK_FREQ_HZ / 128,
+	32768,
+#endif
+	USEC_PER_SEC, USEC_PER_SEC, USEC_PER_SEC,
+};
+
+static int counter_sam_tc_start(const struct device *dev)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	tc_ch->TC_CCR = TC_CCR_CLKEN | TC_CCR_SWTRG;
+
+	return 0;
+}
+
+static int counter_sam_tc_stop(const struct device *dev)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	tc_ch->TC_CCR = TC_CCR_CLKDIS;
+
+	return 0;
+}
+
+static int counter_sam_tc_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	*ticks = tc_ch->TC_CV;
+
+	return 0;
+}
+
+static int counter_sam_tc_set_alarm(const struct device *dev, uint8_t chan_id,
+				    const struct counter_alarm_cfg *alarm_cfg)
+{
+	struct counter_sam_dev_data *data = DEV_DATA(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+	uint32_t top_value;
+	uint32_t alarm_value;
+
+	__ASSERT_NO_MSG(alarm_cfg->callback != NULL);
+
+	top_value = tc_ch->TC_RC;
+
+	if ((top_value != 0) && (alarm_cfg->ticks > top_value)) {
+		return -EINVAL;
+	}
+
+#ifdef COUNTER_SAM_16_BIT
+	if ((top_value == 0) && (alarm_cfg->ticks > UINT16_MAX)) {
+		return -EINVAL;
+	}
+#endif
+
+	if (data->alarm[chan_id].callback != NULL) {
+		return -EBUSY;
+	}
+
+	if (chan_id == 0) {
+		tc_ch->TC_IDR = TC_IDR_CPAS;
+	} else {
+		tc_ch->TC_IDR = TC_IDR_CPBS;
+	}
+
+	data->alarm[chan_id].callback = alarm_cfg->callback;
+	data->alarm[chan_id].user_data = alarm_cfg->user_data;
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0) {
+		alarm_value = alarm_cfg->ticks;
+	} else {
+		alarm_value = tc_ch->TC_CV + alarm_cfg->ticks;
+		if (top_value != 0) {
+			alarm_value %= top_value;
+		}
+	}
+
+	if (chan_id == 0) {
+		tc_ch->TC_RA = alarm_value;
+		/* Clear interrupt status register */
+		(void)tc_ch->TC_SR;
+		tc_ch->TC_IER = TC_IER_CPAS;
+	} else {
+		tc_ch->TC_RB = alarm_value;
+		/* Clear interrupt status register */
+		(void)tc_ch->TC_SR;
+		tc_ch->TC_IER = TC_IER_CPBS;
+	}
+
+	LOG_DBG("set alarm: channel %u, count %u", chan_id, alarm_value);
+
+	return 0;
+}
+
+static int counter_sam_tc_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	struct counter_sam_dev_data *data = DEV_DATA(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	if (chan_id == 0) {
+		tc_ch->TC_IDR = TC_IDR_CPAS;
+		tc_ch->TC_RA = 0;
+	} else {
+		tc_ch->TC_IDR = TC_IDR_CPBS;
+		tc_ch->TC_RB = 0;
+	}
+
+	data->alarm[chan_id].callback = NULL;
+	data->alarm[chan_id].user_data = NULL;
+
+	LOG_DBG("cancel alarm: channel %u", chan_id);
+
+	return 0;
+}
+
+static int counter_sam_tc_set_top_value(const struct device *dev,
+					const struct counter_top_cfg *top_cfg)
+{
+	struct counter_sam_dev_data *data = DEV_DATA(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+	int ret = 0;
+
+	for (int i = 0; i < MAX_ALARMS_PER_TC_CHANNEL; i++) {
+		if (data->alarm[i].callback) {
+			return -EBUSY;
+		}
+	}
+
+	/* Disable the compare interrupt */
+	tc_ch->TC_IDR = TC_IDR_CPCS;
+
+	data->top_cb = top_cfg->callback;
+	data->top_user_data = top_cfg->user_data;
+
+	tc_ch->TC_RC = top_cfg->ticks;
+
+	if ((top_cfg->flags & COUNTER_TOP_CFG_DONT_RESET) != 0) {
+		if (tc_ch->TC_CV >= top_cfg->ticks) {
+			ret = -ETIME;
+			if ((top_cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) != 0) {
+				tc_ch->TC_CCR = TC_CCR_SWTRG;
+			}
+		}
+	} else {
+		tc_ch->TC_CCR = TC_CCR_SWTRG;
+	}
+
+	/* Enable the compare interrupt */
+	tc_ch->TC_IER = TC_IER_CPCS;
+
+	return ret;
+}
+
+static uint32_t counter_sam_tc_get_top_value(const struct device *dev)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	return tc_ch->TC_RC;
+}
+
+static uint32_t counter_sam_tc_get_pending_int(const struct device *dev)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	return tc_ch->TC_SR & tc_ch->TC_IMR;
+}
+
+static void counter_sam_tc_isr(const struct device *dev)
+{
+	struct counter_sam_dev_data *data = DEV_DATA(dev);
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+	uint32_t status;
+
+	status = tc_ch->TC_SR;
+
+	if ((status & TC_SR_CPAS) != 0) {
+		tc_ch->TC_IDR = TC_IDR_CPAS;
+		if (data->alarm[0].callback) {
+			counter_alarm_callback_t cb = data->alarm[0].callback;
+
+			data->alarm[0].callback = NULL;
+			cb(dev, 0, tc_ch->TC_RA, data->alarm[0].user_data);
+		}
+	}
+
+	if ((status & TC_SR_CPBS) != 0) {
+		tc_ch->TC_IDR = TC_IDR_CPBS;
+		if (data->alarm[1].callback) {
+			counter_alarm_callback_t cb = data->alarm[1].callback;
+
+			data->alarm[1].callback = NULL;
+			cb(dev, 1, tc_ch->TC_RB, data->alarm[1].user_data);
+		}
+	}
+
+	if ((status & TC_SR_CPCS) != 0) {
+		if (data->top_cb) {
+			data->top_cb(dev, data->top_user_data);
+		}
+	}
+}
+
+static int counter_sam_initialize(const struct device *dev)
+{
+	const struct counter_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
+	Tc *const tc = dev_cfg->regs;
+	TcChannel *tc_ch = &tc->TcChannel[dev_cfg->tc_chan_num];
+
+	/* Connect pins to the peripheral */
+	soc_gpio_list_configure(dev_cfg->pin_list, dev_cfg->pin_list_size);
+
+	/* Enable channel's clock */
+	soc_pmc_peripheral_enable(dev_cfg->periph_id[dev_cfg->tc_chan_num]);
+
+	/* Clock and Mode Selection */
+	tc_ch->TC_CMR = dev_cfg->reg_cmr;
+
+#ifdef TC_EMR_NODIVCLK
+	if (dev_cfg->nodivclk) {
+		tc_ch->TC_EMR = TC_EMR_NODIVCLK;
+	}
+#endif
+	dev_cfg->irq_config_func(dev);
+
+	LOG_INF("Device %s initialized", DEV_NAME(dev));
+
+	return 0;
+}
+
+static const struct counter_driver_api counter_sam_driver_api = {
+	.start = counter_sam_tc_start,
+	.stop = counter_sam_tc_stop,
+	.get_value = counter_sam_tc_get_value,
+	.set_alarm = counter_sam_tc_set_alarm,
+	.cancel_alarm = counter_sam_tc_cancel_alarm,
+	.set_top_value = counter_sam_tc_set_top_value,
+	.get_top_value = counter_sam_tc_get_top_value,
+	.get_pending_int = counter_sam_tc_get_pending_int,
+};
+
+#define COUNTER_SAM_TC_CMR(n)	\
+		 (TC_CMR_TCCLKS(DT_INST_PROP_OR(n, clk, 0)) \
+		| TC_CMR_WAVEFORM_WAVSEL_UP_RC \
+		| TC_CMR_WAVE)
+
+#define COUNTER_SAM_TC_REG_CMR(n) \
+		DT_INST_PROP_OR(n, reg_cmr, COUNTER_SAM_TC_CMR(n))
+
+#define COUNTER_SAM_TC_INPUT_FREQUENCY(n)	\
+		COND_CODE_1(DT_PROP(DT_DRV_INST(n), nodivclk), \
+			    (SOC_ATMEL_SAM_MCK_FREQ_HZ), \
+			    (sam_tc_input_freq_table[COUNTER_SAM_TC_REG_CMR(n) \
+						     & TC_CMR_TCCLKS_Msk]))
+
+#define COUNTER_SAM_TC_INIT(n)					\
+static const struct soc_gpio_pin pins_tc##n[] = ATMEL_SAM_DT_INST_PINS(n); \
+								\
+static void counter_##n##_sam_config_func(const struct device *dev); \
+								\
+static const struct counter_sam_dev_cfg counter_##n##_sam_config = { \
+	.info = {						\
+		.max_top_value = COUNTER_SAM_TOP_VALUE_MAX,	\
+		.freq = COUNTER_SAM_TC_INPUT_FREQUENCY(n),	\
+		.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
+		.channels = MAX_ALARMS_PER_TC_CHANNEL		\
+	},							\
+	.regs = (Tc *)DT_INST_REG_ADDR(n),			\
+	.reg_cmr = COUNTER_SAM_TC_REG_CMR(n),			\
+	.irq_config_func = &counter_##n##_sam_config_func,	\
+	.pin_list = pins_tc##n,					\
+	.pin_list_size = ARRAY_SIZE(pins_tc##n),		\
+	.nodivclk = DT_INST_PROP(n, nodivclk),			\
+	.tc_chan_num = DT_INST_PROP_OR(n, channel, 0),		\
+	.periph_id = DT_INST_PROP(n, peripheral_id),		\
+};								\
+								\
+static struct counter_sam_dev_data counter_##n##_sam_data;	\
+								\
+DEVICE_DT_INST_DEFINE(n, counter_sam_initialize, NULL, \
+		&counter_##n##_sam_data, &counter_##n##_sam_config, \
+		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		&counter_sam_driver_api);			\
+								\
+static void counter_##n##_sam_config_func(const struct device *dev) \
+{								\
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 0, irq),		\
+		    DT_INST_IRQ_BY_IDX(n, 0, priority),		\
+		    counter_sam_tc_isr,				\
+		    DEVICE_DT_INST_GET(n), 0);			\
+	irq_enable(DT_INST_IRQ_BY_IDX(n, 0, irq));		\
+								\
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 1, irq),		\
+		    DT_INST_IRQ_BY_IDX(n, 1, priority),		\
+		    counter_sam_tc_isr,				\
+		    DEVICE_DT_INST_GET(n), 0);			\
+	irq_enable(DT_INST_IRQ_BY_IDX(n, 1, irq));		\
+								\
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 2, irq),		\
+		    DT_INST_IRQ_BY_IDX(n, 2, priority),		\
+		    counter_sam_tc_isr,				\
+		    DEVICE_DT_INST_GET(n), 0);			\
+	irq_enable(DT_INST_IRQ_BY_IDX(n, 2, irq));		\
+}
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_SAM_TC_INIT)

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -45,7 +45,7 @@ static int qdec_sam_fetch(const struct device *dev, enum sensor_channel chan)
 	const struct qdec_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
 	struct qdec_sam_dev_data *const dev_data = DEV_DATA(dev);
 	Tc *const tc = dev_cfg->regs;
-	TcChannel *tc_ch0 = &tc->TC_CHANNEL[0];
+	TcChannel *tc_ch0 = &tc->TcChannel[0];
 
 	/* Read position register content */
 	dev_data->position = tc_ch0->TC_CV;
@@ -70,7 +70,7 @@ static int qdec_sam_get(const struct device *dev, enum sensor_channel chan,
 
 static void qdec_sam_start(Tc *const tc)
 {
-	TcChannel *tc_ch0 = &tc->TC_CHANNEL[0];
+	TcChannel *tc_ch0 = &tc->TcChannel[0];
 
 	/* Enable Channel 0 Clock and reset counter*/
 	tc_ch0->TC_CCR =  TC_CCR_CLKEN
@@ -81,7 +81,7 @@ static void qdec_sam_configure(const struct device *dev)
 {
 	const struct qdec_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
 	Tc *const tc = dev_cfg->regs;
-	TcChannel *tc_ch0 = &tc->TC_CHANNEL[0];
+	TcChannel *tc_ch0 = &tc->TcChannel[0];
 
 	/* Clock, Trigger Edge, Trigger and Mode Selection */
 	tc_ch0->TC_CMR =  TC_CMR_TCCLKS_XC0

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -196,6 +196,42 @@
 				#atmel,pin-cells = <2>;
 			};
 		};
+
+		tc0: tc@40080000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40080000 0x100>;
+			interrupts = <27 0
+				      28 0
+				      29 0>;
+			peripheral-id = <27 28 29>;
+			status = "disabled";
+			label = "TC0";
+			pinctrl-0 = <>;
+		};
+
+		tc1: tc@40084000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40084000 0x100>;
+			interrupts = <30 0
+				      31 0
+				      32 0>;
+			peripheral-id = <30 31 32>;
+			status = "disabled";
+			label = "TC1";
+			pinctrl-0 = <>;
+		};
+
+		tc2: tc@40088000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40088000 0x100>;
+			interrupts = <33 0
+				      34 0
+				      35 0>;
+			peripheral-id = <33 34 35>;
+			status = "disabled";
+			label = "TC2";
+			pinctrl-0 = <>;
+		};
 	};
 };
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -229,6 +229,42 @@
 				#atmel,pin-cells = <2>;
 			};
 		};
+
+		tc0: tc@40090000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40090000 0x100>;
+			interrupts = <21 0
+				      22 0
+				      23 0>;
+			peripheral-id = <21 22 23>;
+			status = "disabled";
+			label = "TC0";
+			pinctrl-0 = <>;
+		};
+
+		tc1: tc@40094000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40094000 0x100>;
+			interrupts = <24 0
+				      25 0
+				      26 0>;
+			peripheral-id = <24 25 26>;
+			status = "disabled";
+			label = "TC1";
+			pinctrl-0 = <>;
+		};
+
+		tc2: tc@40098000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40098000 0x100>;
+			interrupts = <27 0
+				      28 0
+				      29 0>;
+			peripheral-id = <27 28 29>;
+			status = "disabled";
+			label = "TC2";
+			pinctrl-0 = <>;
+		};
 	};
 };
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -199,6 +199,30 @@
 			};
 		};
 
+		tc0: tc@40010000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40010000 0x100>;
+			interrupts = <55 0
+				      56 0
+				      57 0>;
+			peripheral-id = <2>;
+			status = "disabled";
+			label = "TC0";
+			pinctrl-0 = <>;
+		};
+
+		tc1: tc@40014000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40014000 0x100>;
+			interrupts = <58 0
+				      59 0
+				      60 0>;
+			peripheral-id = <3>;
+			status = "disabled";
+			label = "TC1";
+			pinctrl-0 = <>;
+		};
+
 		trng: random@40068000 {
 			compatible = "atmel,sam-trng";
 			reg = <0x40068000 0x4000>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -186,6 +186,30 @@
 				#atmel,pin-cells = <2>;
 			};
 		};
+
+		tc0: tc@40010000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40010000 0x100>;
+			interrupts = <23 0
+				      24 0
+				      25 0>;
+			peripheral-id = <23 24 25>;
+			status = "disabled";
+			label = "TC0";
+			pinctrl-0 = <>;
+		};
+
+		tc1: tc@40014000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40014000 0x100>;
+			interrupts = <26 0
+				      27 0
+				      28 0>;
+			peripheral-id = <26 27 28>;
+			status = "disabled";
+			label = "TC1";
+			pinctrl-0 = <>;
+		};
 	};
 };
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -365,6 +365,7 @@
 			peripheral-id = <23 24 25>;
 			status = "disabled";
 			label = "TC0";
+			pinctrl-0 = <>;
 		};
 
 		tc1: tc@40010000 {
@@ -376,6 +377,7 @@
 			peripheral-id = <26 27 28>;
 			status = "disabled";
 			label = "TC1";
+			pinctrl-0 = <>;
 		};
 
 		tc2: tc@40014000 {
@@ -387,6 +389,7 @@
 			peripheral-id = <47 48 49>;
 			status = "disabled";
 			label = "TC2";
+			pinctrl-0 = <>;
 		};
 
 		tc3: tc@40054000 {
@@ -398,6 +401,7 @@
 			peripheral-id = <50 51 52>;
 			status = "disabled";
 			label = "TC3";
+			pinctrl-0 = <>;
 		};
 
 		trng: random@40070000 {

--- a/dts/bindings/timer/atmel,sam-tc.yaml
+++ b/dts/bindings/timer/atmel,sam-tc.yaml
@@ -21,6 +21,40 @@ properties:
       description: peripheral ID
       required: true
 
+    channel:
+      type: int
+      required: false
+      description: |
+        Timer / Counter channel to use, channel 0 is the default.
+        Valid range: 0 - 2
+
+    clk:
+      type: int
+      required: false
+      description: |
+        Clock source selection as defined by TCCLKS bit-field of TC_CMR
+        register. Consult the datasheet for the details.
+
+    nodivclk:
+      type: boolean
+      required: false
+      description: |
+        If set to true the `clk` property is ignored. Instead the TC module is
+        driven directly via MCLK. Only supported on sam4e, same70, same70b,
+        samv71, samv71b SoC series.
+
+    reg-cmr:
+      type: int
+      required: false
+      description: |
+        Alternate value of the CMR (Channel Mode Register) register.
+        If specified this value will be written to the register during driver
+        instance initialization instead of the default. It can be used to
+        configure the timer / counter in the custom mode. Together with other
+        properties like channel-num, pinctrl-0 this allows e.g. to configure
+        the driver to count events generated on the TIOA, TIOB signal connected
+        to the external pin.
+
     pinctrl-0:
       type: phandles
       required: false
@@ -29,8 +63,6 @@ properties:
         the phandles will reference pinctrl nodes.  These nodes will
         have a nodelabel that matches the Atmel SoC HAL defines and
         be of the form p<port><pin><periph>_<inst>_<signal>.
-
-        In Quadrature Decoder mode TIOA0 & TIOB0 signals are expected
 
         For example the TC0 on SAME7x would be
            pinctrl-0 = <&pa0b_tc0_tioa0 &pa1b_tc0_tiob0>;

--- a/samples/drivers/counter/alarm/boards/arduino_due.overlay
+++ b/samples/drivers/counter/alarm/boards/arduino_due.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam4e_xpro.overlay
+++ b/samples/drivers/counter/alarm/boards/sam4e_xpro.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam4s_xplained.overlay
+++ b/samples/drivers/counter/alarm/boards/sam4s_xplained.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam_e70_xplained.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_e70_xplained.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam_e70b_xplained.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_e70b_xplained.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam_v71_xult.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_v71_xult.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/sam_v71b_xult.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_v71b_xult.overlay
@@ -1,0 +1,4 @@
+&tc0 {
+        clk = <4>;
+        status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -17,6 +17,8 @@ struct counter_alarm_cfg alarm_cfg;
 
 #if defined(CONFIG_BOARD_ATSAMD20_XPRO)
 #define TIMER DT_LABEL(DT_NODELABEL(tc4))
+#elif defined(CONFIG_SOC_FAMILY_SAM)
+#define TIMER DT_LABEL(DT_NODELABEL(tc0))
 #elif defined(CONFIG_COUNTER_RTC0)
 #define TIMER DT_LABEL(DT_NODELABEL(rtc0))
 #elif defined(CONFIG_COUNTER_RTC_STM32)

--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
       revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97
       path: modules/hal/altera
     - name: hal_atmel
-      revision: d17b7dd92d209b20bc1e15431d068edc29bf438d
+      revision: 9f78f520f6cbb997e5b44fe8ab17dd5bf2448095
       path: modules/hal/atmel
     - name: hal_cypress
       revision: 81a059f21435bc7e315bccd720da5a9b615bbb50


### PR DESCRIPTION
Add basic counter driver based on Timer Counter (TC) module for Atmel SAM family.

Remarks:
- The driver is not thread safe.
- The driver does not implement guard periods.
- The driver does not guarantee that short relative alarm will trigger the interrupt immediately and not after the full cycle / counter overflow.

Use at your own risk or submit a patch.

Tested on Atmel SMART SAM E70 Xplained board

Depends on #zephyrproject-rtos/hal_atmel/pull/15