### PR TITLE
linker: move IDT_LIST region

### DIFF
--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -83,7 +83,7 @@ MEMORY
     FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     SRAM     (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+    IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -85,8 +85,8 @@ _region_min_align = 4;
 
 MEMORY
     {
-    FLASH                 (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
-    SRAM                  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+    FLASH (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
+    SRAM  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* TI CCFG Registers */
     DT_REGION_FROM_NODE_STATUS_OKAY(FLASH_CCFG, rwx, DT_NODELABEL(ti_ccfg_partition))
     /* Data & Instruction Tightly Coupled Memory */
@@ -104,7 +104,7 @@ MEMORY
     DT_REGION_FROM_NODE_STATUS_OKAY(SDRAM2, rw, DT_NODELABEL(sdram2))
     DT_REGION_FROM_NODE_STATUS_OKAY(BACKUP_SRAM, rw, DT_NODELABEL(backup_sram))
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+    IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
     }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/arch/arm64/scripts/linker.ld
+++ b/include/arch/arm64/scripts/linker.ld
@@ -69,7 +69,7 @@ MEMORY
     FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     SRAM      (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx) : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
+    IDT_LIST  (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/xtensa/intel_adsp/cavs_v15/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v15/include/soc/memory.h
@@ -87,7 +87,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				(RAM_BASE + RAM_SIZE)
+#define IDT_BASE				0xFFFFDFFF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v18/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v18/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				(RAM_BASE + RAM_SIZE)
+#define IDT_BASE				0xFFFFDFFF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v20/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v20/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				(RAM_BASE + RAM_SIZE)
+#define IDT_BASE				0xFFFFDFFF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_adsp/cavs_v25/include/soc/memory.h
+++ b/soc/xtensa/intel_adsp/cavs_v25/include/soc/memory.h
@@ -84,7 +84,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				(RAM_BASE + RAM_SIZE)
+#define IDT_BASE				0xFFFFDFFF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000

--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -63,7 +63,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				(RAM_BASE + RAM_SIZE)
+#define IDT_BASE				0xFFFFDFFF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000


### PR DESCRIPTION
Move the IDT_LIST memory region to the location recommended by
`intlist.ld`. The documentation specifies that this region should not
overlap other regions, and there is no guarantee that the area after the
`SRAM` region is not used. The end of the address space is much less
likely to be a valid RAM address.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>