### PR TITLE
MAINTAINERS: Add missing areas and maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -232,7 +232,9 @@ Build system:
         - "area: Build System"
 
 C library:
-    status: orphaned
+    status: maintained
+    maintainers:
+         - stephanosio
     collaborators:
          - nashif
          - enjiamai
@@ -240,6 +242,7 @@ C library:
     files:
          - lib/libc/
          - tests/lib/c_lib/
+         - tests/lib/newlib/
     labels:
          - "area: C Library"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -231,6 +231,19 @@ Build system:
     labels:
         - "area: Build System"
 
+"C++":
+    status: maintained
+    maintainers:
+        - stephanosio
+    collaborators:
+        - alexanderwachter
+    files:
+        - subsys/cpp/
+        - tests/subsys/cpp/
+        - samples/subsys/cpp/
+    labels:
+        - "area: C++"
+
 C library:
     status: maintained
     maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -258,6 +258,20 @@ CMSIS API layer:
     labels:
         - "area: Portability"
 
+CMSIS-DSP integration:
+    status: maintainer
+    maintainers:
+        - stephanosio
+    collaborators:
+        - galak
+        - ioannisg
+    files:
+        - modules/Kconfig.cmsis_dsp
+        - tests/benchmarks/cmsis_dsp/
+        - tests/lib/cmsis_dsp/
+    labels:
+        - "area: CMSIS-DSP"
+
 Common arch:
     status: orphaned
     collaborators:


### PR DESCRIPTION
In this series, I am adding the following areas that are currently missing in the maintainers file:
* `C++`
* `CMSIS-DSP integration`

In addition, I am proposing to take over the maintenance of the following (orphaned) areas:
* `C library` - I have been/will keep working on the C library support and validation for Zephyr (especially, newlib).
* `CMSIS-DSP integration` - I have initially added this feature and I plan to keep maintaining this.

For the newly added `C++` area, I am willing to take over its maintenance if none of the current collaborators volunteers -- I do a lot of work on the Zephyr SDK and plan to implement the native Zephyr RTOS support in the newlib and libstdc++ (gcc), so I would not mind maintaining the Zephyr-side C++ support as well, especially noting that it is very closely coupled with the libstdc++ provided by the toolchain.