### PR TITLE
Add memc support for STM32F4 series

### DIFF
--- a/boards/arm/stm32f429i_disc1/doc/index.rst
+++ b/boards/arm/stm32f429i_disc1/doc/index.rst
@@ -97,6 +97,8 @@ The Zephyr stm32f429i_disc1 board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| FMC       | on-chip    | memc (SDRAM)                        |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -20,6 +20,11 @@
 		zephyr,ccm = &ccm0;
 	};
 
+	sdram2: sdram@d0000000 {
+		device_type = "memory";
+		reg = <0xd0000000 DT_SIZE_M(8)>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		orange_led_3: led_3 {
@@ -107,5 +112,43 @@
 		spi-max-frequency = <15151515>;
 		reg = <0>;
 		cmd-data-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
+		     &fmc_sdclk_pg8 &fmc_sdnwe_pc0 &fmc_sdcke1_pb5
+		     &fmc_sdne1_pb6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3
+		     &fmc_a4_pf4 &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13
+		     &fmc_a8_pf14 &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		     &fmc_a12_pg2 &fmc_a13_pg3 &fmc_a14_pg4 &fmc_a15_pg5
+		     &fmc_d0_pd14 &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1
+		     &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10
+		     &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14
+		     &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10>;
+
+	sdram {
+		status = "okay";
+
+		power-up-delay = <100>;
+		num-auto-refresh = <1>;
+		mode-register = <0>;
+		refresh-rate = <1386>;
+
+		bank@1 {
+			reg = <1>;
+
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+					    STM32_FMC_SDRAM_NR_12
+					    STM32_FMC_SDRAM_MWID_16
+					    STM32_FMC_SDRAM_NB_4
+					    STM32_FMC_SDRAM_CAS_2
+					    STM32_FMC_SDRAM_SDCLK_PERIOD_3
+					    STM32_FMC_SDRAM_RBURST_DISABLE
+					    STM32_FMC_SDRAM_RPIPE_1>;
+			st,sdram-timing = <2 7 4 7 2 2 2>;
+		};
 	};
 };

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -1,9 +1,11 @@
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_ST_STM32_FMC := st,stm32-fmc
+
 config MEMC_STM32
 	bool "Enable STM32 Flexible Memory Controller (FMC)"
-	depends on SOC_SERIES_STM32H7X
+	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC))
 	help
 	  Enable STM32 Flexible Memory Controller.
 

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
+#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {
@@ -85,6 +86,22 @@
 			interrupts = <86 5>;
 			status = "disabled";
 			label = "SPI_6";
+		};
+
+		fmc: memory-controller@a0000000 {
+			compatible = "st,stm32-fmc";
+			reg = <0xa0000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			label = "STM32_FMC";
+			status = "disabled";
+
+			sdram: sdram {
+				compatible = "st,stm32-fmc-sdram";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "STM32_FMC_SDRAM";
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
+#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {
@@ -82,6 +83,22 @@
 			interrupts = <86 5>;
 			status = "disabled";
 			label = "SPI_6";
+		};
+
+		fmc: memory-controller@a0000000 {
+			compatible = "st,stm32-fmc";
+			reg = <0xa0000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			label = "STM32_FMC";
+			status = "disabled";
+
+			sdram: sdram {
+				compatible = "st,stm32-fmc-sdram";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "STM32_FMC_SDRAM";
+				status = "disabled";
+			};
 		};
 
 		cryp: cryp@50060000 {

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f401.dtsi>
+#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {
@@ -117,6 +118,22 @@
 			status = "disabled";
 			label = "DAC_1";
 			#io-channel-cells = <1>;
+		};
+
+		fmc: memory-controller@a0000000 {
+			compatible = "st,stm32-fmc";
+			reg = <0xa0000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			label = "STM32_FMC";
+			status = "disabled";
+
+			sdram: sdram {
+				compatible = "st,stm32-fmc-sdram";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "STM32_FMC_SDRAM";
+				status = "disabled";
+			};
 		};
 	};
 


### PR DESCRIPTION
Hi, this adds FMC support to STM32F4 series SoC. The current driver is only enabled for some H7 series, but seems to work just fine on F4 as well. this adds the device node to stm32f427.dtsi (sourced by the f429 as well) and enables it for stm32f429i_disc1, which ships with an 8MB SDRAM chip.

For the discovery board, the timings are copied from https://github.com/STMicroelectronics/STM32CubeF4/blob/master/Projects/STM32F429I-Discovery/Examples/FMC/FMC_SDRAM/Src/main.c#L89-L114, though I had to use CAS_2 for some reason. Tested using tests/drivers/memc/stm32_sdram (modified to cover the whole 8MB), seems to work fine.