### PR TITLE
samples: shields: lmp90100_evb: convert to using DEVICE_DT_GET_ONE()

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -278,6 +278,29 @@ typedef int16_t device_handle_t;
 		    (NULL))
 
 /**
+ * @def DEVICE_DT_GET_ONE
+ *
+ * @brief Obtain a pointer to a device object by devicetree compatible
+ *
+ * If any enabled devicetree node has the given compatible and a
+ * device object was created from it, this returns that device.
+ *
+ * If there no such devices, this throws a compilation error.
+ *
+ * If there are multiple, this returns an arbitrary one.
+ *
+ * If this returns non-NULL, the device must be checked for readiness
+ * before use, e.g. with device_is_ready().
+ *
+ * @param compat lowercase-and-underscores devicetree compatible
+ * @return a pointer to a device
+ */
+#define DEVICE_DT_GET_ONE(compat)					    \
+	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),			    \
+		    (DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(compat))), \
+		    (ZERO_OR_COMPILE_ERROR(0)))
+
+/**
  * @def DEVICE_GET
  *
  * @brief Obtain a pointer to a device object by name

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -60,7 +60,7 @@ static double rtd_temperature(int nom, double resistance)
 
 void main(void)
 {
-	const struct device *lmp90100;
+	const struct device *lmp90100 = DEVICE_DT_GET_ONE(ti_lmp90100);
 	double resistance;
 	int32_t buffer;
 	int err;
@@ -83,9 +83,8 @@ void main(void)
 		.calibrate = 0
 	};
 
-	lmp90100 = device_get_binding(DT_LABEL(DT_INST(0, ti_lmp90100)));
-	if (!lmp90100) {
-		LOG_ERR("LMP90100 device not found");
+	if (!device_is_ready(lmp90100)) {
+		LOG_ERR("LMP90100 device not ready");
 		return;
 	}
 


### PR DESCRIPTION
Convert from using device_get_binding() to DEVICE_DT_GET_ONE().

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>