### PR TITLE
Fix build after lwm2m async io changes and boostrap enabled.

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -779,11 +779,7 @@ static int sm_send_registration(bool send_obj_support_data,
 		}
 	}
 
-	ret = lwm2m_send_message_async(msg);
-	if (ret < 0) {
-		LOG_ERR("Error sending LWM2M packet (err:%d).", ret);
-		goto cleanup;
-	}
+	lwm2m_send_message_async(msg);
 
 	/* log the registration attempt */
 	LOG_DBG("registration sent [%s]",
@@ -929,11 +925,7 @@ static int sm_do_deregister(void)
 
 	LOG_INF("Deregister from '%s'", log_strdup(client.server_ep));
 
-	ret = lwm2m_send_message_async(msg);
-	if (ret < 0) {
-		LOG_ERR("Error sending LWM2M packet (err:%d).", ret);
-		goto cleanup;
-	}
+	lwm2m_send_message_async(msg);
 
 	set_sm_state(ENGINE_DEREGISTER_SENT);
 	return 0;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -588,12 +588,7 @@ static int sm_send_bootstrap_registration(void)
 	LOG_DBG("Register ID with bootstrap server as '%s'",
 		log_strdup(query_buffer));
 
-	ret = lwm2m_send_message(msg);
-	if (ret < 0) {
-		LOG_ERR("Error sending LWM2M packet (err:%d).",
-			    ret);
-		goto cleanup;
-	}
+	lwm2m_send_message_async(msg);
 
 	return 0;
 


### PR DESCRIPTION
After lwm2m async io was introduced, one instance of function  lwm2m_send_message() was left unchanged, and makes build to fail when boostrap support is enabled.