### PR TITLE
dts/arm: st: f1: Move CAN node add support for f103X8

### DIFF
--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -47,6 +47,18 @@
 			phys = <&usb_fs_phy>;
 			label= "USB";
 		};
+
+		can1: can@40006400 {
+			compatible = "st,stm32-can";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40006400 0x400>;
+			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+			status = "disabled";
+			label = "CAN_1";
+		};
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/f1/stm32f103Xb.dtsi
+++ b/dts/arm/st/f1/stm32f103Xb.dtsi
@@ -8,13 +8,9 @@
  */
 
 #include <mem.h>
-#include <st/f1/stm32f1.dtsi>
+#include <st/f1/stm32f103X8.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(20)>;
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -26,46 +22,6 @@
 		/* spi2 is present on all STM32F103xB SoCs except
 		 * STM32F103TB. Delete node in stm32f103tb.dtsi.
 		 */
-		spi2: spi@40003800 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
-			interrupts = <36 5>;
-			status = "disabled";
-			label = "SPI_2";
-		};
-
-		usb: usb@40005c00 {
-			compatible = "st,stm32-usb";
-			reg = <0x40005c00 0x400>;
-			interrupts = <20 0>;
-			interrupt-names = "usb";
-			num-bidir-endpoints = <8>;
-			ram-size = <512>;
-			phys = <&usb_fs_phy>;
-			status = "disabled";
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
-			label= "USB";
-		};
-
-		can1: can@40006400 {
-			compatible = "st,stm32-can";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40006400 0x400>;
-			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
-			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
-			status = "disabled";
-			label = "CAN_1";
-		};
 	};
 
-	usb_fs_phy: usbphy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
-		label = "USB_FS_PHY";
-	};
 };


### PR DESCRIPTION
Moved can, spi, usb, usb_fs_phy nodes to f103X8 dts.
Adds CAN for f103X8 series.
Tested on stm32f103c8 soc.
Tested on stm32f103vb soc.

Signed-off-by: Bhavesh Bhojwani <bhaavesh.bhojwaani@gmail.com>