### PR TITLE
soc: atmel_sam: Add _INST to ATMEL_SAM_DT_PIN* macros

### DIFF
--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -356,7 +356,7 @@ static void adc_sam_isr(const struct device *dev)
 		.regs = (Afec *)DT_INST_REG_ADDR(n),			\
 		.cfg_func = adc##n##_sam_cfg_func,			\
 		.periph_id = DT_INST_PROP(n, peripheral_id),		\
-		.afec_trg_pin = ATMEL_SAM_DT_PIN(n, 0),			\
+		.afec_trg_pin = ATMEL_SAM_DT_INST_PIN(n, 0),		\
 	};								\
 									\
 	static struct adc_sam_data adc##n##_sam_data = {		\

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2214,7 +2214,7 @@ static void eth0_irq_config(void)
 }
 
 #ifdef CONFIG_SOC_FAMILY_SAM
-static const struct soc_gpio_pin pins_eth0[] = ATMEL_SAM_DT_PINS(0);
+static const struct soc_gpio_pin pins_eth0[] = ATMEL_SAM_DT_INST_PINS(0);
 #endif
 
 static const struct eth_sam_dev_cfg eth0_config = {

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -614,8 +614,7 @@ static const struct i2c_driver_api i2c_sam_twim_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 	}								\
 									\
-	static const struct soc_gpio_pin pins_twim##n[] =		\
-		{ATMEL_SAM_DT_PIN(n, 0), ATMEL_SAM_DT_PIN(n, 1)};	\
+	static const struct soc_gpio_pin pins_twim##n[] = ATMEL_SAM_DT_INST_PINS(n); \
 									\
 	static const struct i2c_sam_twim_dev_cfg i2c##n##_sam_config = {\
 		.regs = (Twim *)DT_INST_REG_ADDR(n),			\

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -346,8 +346,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 	}								\
 									\
-	static const struct soc_gpio_pin pins_twi##n[] =		\
-		{ATMEL_SAM_DT_PIN(n, 0), ATMEL_SAM_DT_PIN(n, 1)};	\
+	static const struct soc_gpio_pin pins_twi##n[] = ATMEL_SAM_DT_INST_PINS(n); \
 									\
 	static const struct i2c_sam_twi_dev_cfg i2c##n##_sam_config = {	\
 		.regs = (Twi *)DT_INST_REG_ADDR(n),			\

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -333,8 +333,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 	}								\
 									\
-	static const struct soc_gpio_pin pins_twihs##n[] =		\
-		{ATMEL_SAM_DT_PIN(n, 0), ATMEL_SAM_DT_PIN(n, 1)};	\
+	static const struct soc_gpio_pin pins_twihs##n[] = ATMEL_SAM_DT_INST_PINS(n); \
 									\
 	static const struct i2c_sam_twihs_dev_cfg i2c##n##_sam_config = {\
 		.regs = (Twihs *)DT_INST_REG_ADDR(n),			\

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -976,7 +976,7 @@ static void i2s0_sam_irq_config(void)
 		    DEVICE_DT_INST_GET(0), 0);
 }
 
-static const struct soc_gpio_pin i2s0_pins[] = ATMEL_SAM_DT_PINS(0);
+static const struct soc_gpio_pin i2s0_pins[] = ATMEL_SAM_DT_INST_PINS(0);
 
 static const struct i2s_sam_dev_cfg i2s0_sam_config = {
 	.dev_dma = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(0, tx)),

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -123,7 +123,7 @@ static const struct sensor_driver_api qdec_sam_driver_api = {
 };
 
 #define QDEC_SAM_INIT(n)						\
-	static const struct soc_gpio_pin pins_tc##n[] = ATMEL_SAM_DT_PINS(n); \
+	static const struct soc_gpio_pin pins_tc##n[] = ATMEL_SAM_DT_INST_PINS(n); \
 									\
 	static const struct qdec_sam_dev_cfg qdec##n##_sam_config = {	\
 		.regs = (Tc *)DT_INST_REG_ADDR(n),			\

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -327,8 +327,8 @@ static const struct uart_driver_api uart_sam_driver_api = {
 		.regs = (Uart *)DT_INST_REG_ADDR(n),			\
 		.periph_id = DT_INST_PROP(n, peripheral_id),		\
 									\
-		.pin_rx = ATMEL_SAM_DT_PIN(n, 0),			\
-		.pin_tx = ATMEL_SAM_DT_PIN(n, 1),			\
+		.pin_rx = ATMEL_SAM_DT_INST_PIN(n, 0),			\
+		.pin_tx = ATMEL_SAM_DT_INST_PIN(n, 1),			\
 									\
 		IRQ_FUNC_INIT						\
 	}

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -328,8 +328,8 @@ static const struct uart_driver_api usart_sam_driver_api = {
 		.regs = (Usart *)DT_INST_REG_ADDR(n),			\
 		.periph_id = DT_INST_PROP(n, peripheral_id),		\
 									\
-		.pin_rx = ATMEL_SAM_DT_PIN(n, 0),			\
-		.pin_tx = ATMEL_SAM_DT_PIN(n, 1),			\
+		.pin_rx = ATMEL_SAM_DT_INST_PIN(n, 0),			\
+		.pin_tx = ATMEL_SAM_DT_INST_PIN(n, 1),			\
 									\
 		IRQ_FUNC_INIT						\
 	}

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -457,8 +457,8 @@ static const struct spi_driver_api spi_sam_driver_api = {
 	static const struct spi_sam_config spi_sam_config_##n = {	\
 		.regs = (Spi *)DT_INST_REG_ADDR(n),			\
 		.periph_id = DT_INST_PROP(n, peripheral_id),		\
-		.num_pins = ATMEL_SAM_DT_NUM_PINS(n),			\
-		.pins = ATMEL_SAM_DT_PINS(n),				\
+		.num_pins = ATMEL_SAM_DT_INST_NUM_PINS(n),		\
+		.pins = ATMEL_SAM_DT_INST_PINS(n),			\
 	}
 
 #define SPI_SAM_DEVICE_INIT(n)						\

--- a/soc/arm/atmel_sam/common/atmel_sam_dt.h
+++ b/soc/arm/atmel_sam/common/atmel_sam_dt.h
@@ -16,73 +16,87 @@
 /* Devicetree related macros to construct pin mux config data */
 
 /* Get a node id from a pinctrl-0 prop at index 'i' */
-#define NODE_ID_FROM_PINCTRL_0(inst, i) \
-	DT_INST_PHANDLE_BY_IDX(inst, pinctrl_0, i)
+#define NODE_ID_FROM_PINCTRL_0(node_id, i) \
+	DT_PHANDLE_BY_IDX(node_id, pinctrl_0, i)
 
 /* Get PIN associated with pinctrl-0 pin at index 'i' */
-#define ATMEL_SAM_PIN(inst, i) \
-	DT_PHA(NODE_ID_FROM_PINCTRL_0(inst, i), atmel_pins, pin)
+#define ATMEL_SAM_PIN(node_id, i) \
+	DT_PHA(NODE_ID_FROM_PINCTRL_0(node_id, i), atmel_pins, pin)
 
 /* Get PIO register address associated with pinctrl-0 pin at index 'i' */
-#define ATMEL_SAM_PIN_TO_PIO_REG_ADDR(inst, i) \
-	DT_REG_ADDR(DT_PHANDLE(NODE_ID_FROM_PINCTRL_0(inst, i), atmel_pins))
+#define ATMEL_SAM_PIN_TO_PIO_REG_ADDR(node_id, i) \
+	DT_REG_ADDR(DT_PHANDLE(NODE_ID_FROM_PINCTRL_0(node_id, i), atmel_pins))
 
 /* Get peripheral id for PIO associated with pinctrl-0 pin at index 'i' */
-#define ATMEL_SAM_PIN_2_PIO_PERIPH_ID(inst, i) \
-	DT_PROP_BY_PHANDLE(NODE_ID_FROM_PINCTRL_0(inst, i),\
+#define ATMEL_SAM_PIN_2_PIO_PERIPH_ID(node_id, i) \
+	DT_PROP_BY_PHANDLE(NODE_ID_FROM_PINCTRL_0(node_id, i),\
 			   atmel_pins, peripheral_id)
 
 /* Get peripheral cfg associated wiith pinctrl-0 pin at index 'i' */
-#define ATMEL_SAM_PIN_PERIPH(inst, i) \
-	DT_PHA(NODE_ID_FROM_PINCTRL_0(inst, i), atmel_pins, peripheral)
+#define ATMEL_SAM_PIN_PERIPH(node_id, i) \
+	DT_PHA(NODE_ID_FROM_PINCTRL_0(node_id, i), atmel_pins, peripheral)
 
 /* Helper function for ATMEL_SAM_PIN_FLAGS */
-#define ATMEL_SAM_PIN_FLAG(inst, i, flag) \
-	DT_PROP(NODE_ID_FROM_PINCTRL_0(inst, i), flag)
+#define ATMEL_SAM_PIN_FLAG(node_id, i, flag) \
+	DT_PROP(NODE_ID_FROM_PINCTRL_0(node_id, i), flag)
 
 /* Convert DT flags to SoC flags */
-#define ATMEL_SAM_PIN_FLAGS(inst, i) \
-	(ATMEL_SAM_PIN_FLAG(inst, i, bias_pull_up) << SOC_GPIO_PULLUP_POS | \
-	 ATMEL_SAM_PIN_FLAG(inst, i, bias_pull_down) << SOC_GPIO_PULLUP_POS | \
-	 ATMEL_SAM_PIN_FLAG(inst, i, drive_open_drain) << SOC_GPIO_OPENDRAIN_POS)
-
-/* Construct a soc_pio_pin element for pin cfg */
-#define ATMEL_SAM_DT_PIO(inst, idx)					\
-	{								\
-		1 << ATMEL_SAM_PIN(inst, idx),				\
-		(Pio *)ATMEL_SAM_PIN_TO_PIO_REG_ADDR(inst, idx),	\
-		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(inst, idx),		\
-		ATMEL_SAM_PIN_PERIPH(inst, idx) << SOC_GPIO_FUNC_POS |	\
-		ATMEL_SAM_PIN_FLAGS(inst, idx)				\
-	}
-
-/* Construct a soc_gpio_pin element for pin cfg */
-#define ATMEL_SAM_DT_GPIO(inst, idx)					\
-	{								\
-		1 << ATMEL_SAM_PIN(inst, idx),				\
-		(Gpio *)ATMEL_SAM_PIN_TO_PIO_REG_ADDR(inst, idx),	\
-		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(inst, idx),		\
-		ATMEL_SAM_PIN_PERIPH(inst, idx) << SOC_GPIO_FUNC_POS |	\
-		ATMEL_SAM_PIN_FLAGS(inst, idx)				\
-	}
+#define ATMEL_SAM_PIN_FLAGS(node_id, i) \
+	(ATMEL_SAM_PIN_FLAG(node_id, i, bias_pull_up) << SOC_GPIO_PULLUP_POS | \
+	 ATMEL_SAM_PIN_FLAG(node_id, i, bias_pull_down) << SOC_GPIO_PULLUP_POS | \
+	 ATMEL_SAM_PIN_FLAG(node_id, i, drive_open_drain) << SOC_GPIO_OPENDRAIN_POS)
 
 #if defined(CONFIG_SOC_SERIES_SAM4L)
+/* Construct a soc_gpio_pin element for pin cfg */
+#define ATMEL_SAM_DT_GPIO(node_id, idx)					\
+	{								\
+		1 << ATMEL_SAM_PIN(node_id, idx),			\
+		(Gpio *)ATMEL_SAM_PIN_TO_PIO_REG_ADDR(node_id, idx),	\
+		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(node_id, idx),		\
+		ATMEL_SAM_PIN_PERIPH(node_id, idx) << SOC_GPIO_FUNC_POS | \
+		ATMEL_SAM_PIN_FLAGS(node_id, idx)			\
+	}
+
+#define ATMEL_SAM_DT_INST_GPIO(inst, idx) \
+	ATMEL_SAM_DT_GPIO(DT_DRV_INST(inst), idx)
+
 #define ATMEL_SAM_DT_PIN ATMEL_SAM_DT_GPIO
+#define ATMEL_SAM_DT_INST_PIN ATMEL_SAM_DT_INST_GPIO
 #else
+/* Construct a soc_pio_pin element for pin cfg */
+#define ATMEL_SAM_DT_PIO(node_id, idx)					\
+	{								\
+		1 << ATMEL_SAM_PIN(node_id, idx),			\
+		(Pio *)ATMEL_SAM_PIN_TO_PIO_REG_ADDR(node_id, idx),	\
+		ATMEL_SAM_PIN_2_PIO_PERIPH_ID(node_id, idx),		\
+		ATMEL_SAM_PIN_PERIPH(node_id, idx) << SOC_GPIO_FUNC_POS | \
+		ATMEL_SAM_PIN_FLAGS(node_id, idx)			\
+	}
+
+#define ATMEL_SAM_DT_INST_PIO(inst, idx) \
+	ATMEL_SAM_DT_PIO(DT_DRV_INST(inst), idx)
+
 #define ATMEL_SAM_DT_PIN ATMEL_SAM_DT_PIO
+#define ATMEL_SAM_DT_INST_PIN ATMEL_SAM_DT_INST_PIO
 #endif
 
 /* Get the number of pins for pinctrl-0 */
-#define ATMEL_SAM_DT_NUM_PINS(inst) DT_INST_PROP_LEN(inst, pinctrl_0)
+#define ATMEL_SAM_DT_NUM_PINS(node_id) DT_PROP_LEN(node_id, pinctrl_0)
+
+#define ATMEL_SAM_DT_INST_NUM_PINS(inst) \
+	ATMEL_SAM_DT_NUM_PINS(DT_DRV_INST(inst))
 
 /* internal macro to structure things for use with UTIL_LISTIFY */
-#define ATMEL_SAM_DT_PIN_ELEM(idx, inst) ATMEL_SAM_DT_PIN(inst, idx),
+#define ATMEL_SAM_DT_PIN_ELEM(idx, node_id) ATMEL_SAM_DT_PIN(node_id, idx),
 
 /* Construct an array intializer for soc_gpio_pin for a device instance */
-#define ATMEL_SAM_DT_PINS(inst)					\
-	{ UTIL_LISTIFY(ATMEL_SAM_DT_NUM_PINS(inst),		\
-		       ATMEL_SAM_DT_PIN_ELEM, inst)		\
+#define ATMEL_SAM_DT_PINS(node_id)				\
+	{ UTIL_LISTIFY(ATMEL_SAM_DT_NUM_PINS(node_id),		\
+		       ATMEL_SAM_DT_PIN_ELEM, node_id)		\
 	}
+
+#define ATMEL_SAM_DT_INST_PINS(inst) \
+	ATMEL_SAM_DT_PINS(DT_DRV_INST(inst))
 
 /* Devicetree macros related to clock */
 


### PR DESCRIPTION
The macros are used to get the pin(s) of a given driver instance. Add
_INST prefix to match convention used by the devicetree.h. The original
macros can now be used to obtain pin(s) of an arbitrary device instance
identified by the nodelabel.

The change is required to support future pinctrl driver.