### PR TITLE
doc: css: fix sphinx tabs style issues

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -393,16 +393,16 @@ code,
 .ui.tabular.menu .active.item,
 .ui.segment,
 .sphinx-tabs-panel {
-    background-color: var(--code-background-color);
+    background-color: var(--code-background-color) !important;
 }
 
 .sphinx-tabs-tab {
-    color: var(--link-color);
+    color: var(--link-color) !important;
 }
 
 .sphinx-tabs-tab[aria-selected="true"] {
-    background-color: var(--code-background-color);
-    border-bottom: 1px solid var(--code-background-color);
+    background-color: var(--code-background-color) !important;
+    border-bottom: 1px solid var(--code-background-color) !important;
 }
 
 /* Code literals */


### PR DESCRIPTION
Flag Sphinx tabs style properties as !important, it looks like the
default style used by the latest extension version take precedence.