### PR TITLE
Make zsock_select() to support microsecond resolution

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -41,8 +41,10 @@ typedef struct zsock_fd_set {
  * it may conflict with generic POSIX ``select()`` function).
  * @endrst
  */
-int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
-		 zsock_fd_set *exceptfds, struct zsock_timeval *timeout);
+__syscall int zsock_select(int nfds, zsock_fd_set *readfds,
+			   zsock_fd_set *writefds,
+			   zsock_fd_set *exceptfds,
+			   struct zsock_timeval *timeout);
 
 /** Number of file descriptors which can be added to zsock_fd_set */
 #define ZSOCK_FD_SETSIZE (sizeof(((zsock_fd_set *)0)->bitset) * 8)
@@ -141,6 +143,8 @@ static inline void FD_SET(int fd, zsock_fd_set *set)
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/socket_select.h>
 
 /**
  * @}

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -13,6 +13,7 @@
 #define SOCK_NONBLOCK 2
 
 int zsock_close_ctx(struct net_context *ctx);
+int zsock_poll_internal(struct zsock_pollfd *fds, int nfds, k_timeout_t timeout);
 
 static inline void sock_set_flag(struct net_context *ctx, uintptr_t mask,
 				 uintptr_t flag)


### PR DESCRIPTION
This fixes #36072
