### PR TITLE
cmake: set CMP0116 policy to old, Ninja DEPFILE behaviour

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -36,6 +36,13 @@ cmake_policy(SET CMP0002 NEW)
 # CMP0079: "target_link_libraries() allows use with targets in other directories"
 cmake_policy(SET CMP0079 OLD)
 
+# Use the old CMake behaviour until we are updating the CMake 3.20 as minimum
+# required. This ensure that CMake >=3.20 will be consistent with older CMakes.
+# CMP0116: Ninja generators transform DEPFILE s from add_custom_command().
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.20)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 define_property(GLOBAL PROPERTY ZEPHYR_LIBS
     BRIEF_DOCS "Global list of all Zephyr CMake libs that should be linked in"
     FULL_DOCS  "Global list of all Zephyr CMake libs that should be linked in.


### PR DESCRIPTION
Fixes: #36185

CMake >=3.20 now supports relative paths in Ninja depfiles.

As Zephyr still supports the use of CMake 3.13, and the current use of
DEPFILE in linker/ld/target.cmake is already absolute path, then the
safest choice is to use old behavior.
This can be changed when Zephyr increases minimum required CMake to be
3.20 or newer.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>