### PR TITLE
Bluetooth: Audio: Fix wrong pointer in VCS client vocs test

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -448,7 +448,7 @@ static int test_vocs(void)
 	struct bt_conn *cached_conn;
 
 	printk("Getting VOCS client conn\n");
-	err = bt_vocs_client_conn_get(vcs.vocs[0], &cached_conn);
+	err = bt_vocs_client_conn_get(vcs_included.vocs[0], &cached_conn);
 	if (err != 0) {
 		FAIL("Could not get VOCS client conn (err %d)\n", err);
 		return err;


### PR DESCRIPTION
The call to bt_vocs_client_conn_get should use the
vcs_included pointer.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>