### PR TITLE
boards: arm: lpcxpresso55s69: Fix flash/ram sizes for non-secure

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
@@ -8,8 +8,8 @@ identifier: lpcxpresso55s69_ns
 name: NXP LPCXpresso55S69
 type: mcu
 arch: arm
-ram: 64
-flash: 256
+ram: 136
+flash: 96
 toolchain:
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
Fix the settings in lpcxpresso55s69_ns.yaml to reflect the normal amount
of flash/ram that is allocated to the non-secure side.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>