### PR TITLE
arch: riscv: remove unneeded context switch to gp register

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -90,12 +90,6 @@ config RISCV_SOC_INTERRUPT_INIT
 	  Enable SOC-based interrupt initialization
 	  (call soc_interrupt_init, within _IntLibInit when enabled)
 
-config RISCV_SOC_INIT_GP_VALUE
-	bool "Enable SOC-based global pointer register initialization"
-	help
-	  Enable SOC-based pointer register initialization
-	  (call __soc_get_gp_initial_value when initializing a thread)
-
 config RISCV_GENERIC_TOOLCHAIN
 	bool "Compile using generic riscv32 toolchain"
 	default y

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -40,7 +40,7 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 		LOG_ERR("     a6: " PR_REG "    t6: " PR_REG, esf->a6, esf->t6);
 		LOG_ERR("     a7: " PR_REG, esf->a7);
 		LOG_ERR("         " NO_REG "    tp: " PR_REG, esf->tp);
-		LOG_ERR("     ra: " PR_REG "    gp: " PR_REG, esf->ra, esf->gp);
+		LOG_ERR("     ra: " PR_REG, esf->ra);
 		LOG_ERR("   mepc: " PR_REG, esf->mepc);
 		LOG_ERR("mstatus: " PR_REG, esf->mstatus);
 		LOG_ERR("");

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -174,7 +174,7 @@
 #define STORE_CALLEE_SAVED(reg) \
 	DO_CALLEE_SAVED(RV_OP_STOREREG, reg)
 
-#define LOAD_CALLER_SAVED(reg) \
+#define LOAD_CALLEE_SAVED(reg) \
 	DO_CALLEE_SAVED(RV_OP_LOADREG, reg)
 
 #define DO_CALLER_SAVED(op) \
@@ -201,7 +201,7 @@
 	addi sp, sp, -__z_arch_esf_t_SIZEOF	;\
 	DO_CALLER_SAVED(RV_OP_STOREREG)		;
 
-#define LOAD_CALLEE_SAVED() \
+#define LOAD_CALLER_SAVED() \
 	DO_CALLER_SAVED(RV_OP_LOADREG)		;\
 	addi sp, sp, __z_arch_esf_t_SIZEOF	;
 
@@ -883,7 +883,7 @@ skip_callee_saved_reg:
 	RV_OP_LOADREG sp, _thread_offset_to_sp(t1)
 
 	/* Restore callee-saved registers of new thread */
-	LOAD_CALLER_SAVED(t1)
+	LOAD_CALLEE_SAVED(t1)
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	/* Determine if we need to restore floating-point registers. */
@@ -967,7 +967,7 @@ skip_load_fp_caller_saved_resched:
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 	/* Restore caller-saved registers from thread stack */
-	LOAD_CALLEE_SAVED()
+	LOAD_CALLER_SAVED()
 
 	/* Call SOC_ERET to exit ISR */
 	SOC_ERET
@@ -1032,7 +1032,7 @@ skip_load_fp_caller_saved:
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 	/* Restore caller-saved registers from thread stack */
-	LOAD_CALLEE_SAVED()
+	LOAD_CALLER_SAVED()
 
 #ifdef CONFIG_PMP_STACK_GUARD
 	csrrw sp, mscratch, sp

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -122,8 +122,6 @@
 	RV_OP_STOREREG temp, __z_arch_esf_t_mstatus_OFFSET(to_reg)	;\
 	RV_OP_LOADREG temp, __z_arch_esf_t_ra_OFFSET(from_reg)		;\
 	RV_OP_STOREREG temp, __z_arch_esf_t_ra_OFFSET(to_reg)		;\
-	RV_OP_LOADREG temp, __z_arch_esf_t_gp_OFFSET(from_reg)		;\
-	RV_OP_STOREREG temp, __z_arch_esf_t_gp_OFFSET(to_reg)		;\
 	RV_OP_LOADREG temp, __z_arch_esf_t_tp_OFFSET(from_reg)		;\
 	RV_OP_STOREREG temp, __z_arch_esf_t_tp_OFFSET(to_reg)		;\
 	RV_OP_LOADREG temp, __z_arch_esf_t_t0_OFFSET(from_reg)		;\
@@ -179,7 +177,6 @@
 
 #define DO_CALLER_SAVED(op) \
 	op ra, __z_arch_esf_t_ra_OFFSET(sp)		;\
-	op gp, __z_arch_esf_t_gp_OFFSET(sp)		;\
 	op tp, __z_arch_esf_t_tp_OFFSET(sp)		;\
 	op t0, __z_arch_esf_t_t0_OFFSET(sp)		;\
 	op t1, __z_arch_esf_t_t1_OFFSET(sp)		;\

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -65,7 +65,6 @@ GEN_OFFSET_SYM(_callee_saved_t, fs11);
 
 /* esf member offsets */
 GEN_OFFSET_SYM(z_arch_esf_t, ra);
-GEN_OFFSET_SYM(z_arch_esf_t, gp);
 GEN_OFFSET_SYM(z_arch_esf_t, tp);
 GEN_OFFSET_SYM(z_arch_esf_t, t0);
 GEN_OFFSET_SYM(z_arch_esf_t, t1);

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -47,10 +47,6 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_init->a2 = (ulong_t)p2;
 	stack_init->a3 = (ulong_t)p3;
 
-#ifdef CONFIG_RISCV_SOC_INIT_GP_VALUE
-	stack_init->gp = __soc_get_gp_initial_value();
-#endif
-
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	stack_init->tp = (ulong_t)thread->tls;
 #endif

--- a/include/arch/riscv/exp.h
+++ b/include/arch/riscv/exp.h
@@ -51,7 +51,6 @@ struct soc_esf {
 
 struct __esf {
 	ulong_t ra;		/* return address */
-	ulong_t gp;		/* global pointer */
 	ulong_t tp;		/* thread pointer */
 
 	ulong_t t0;		/* Caller-saved temporary register */

--- a/soc/riscv/esp32c3/Kconfig.soc
+++ b/soc/riscv/esp32c3/Kconfig.soc
@@ -4,7 +4,6 @@
 config SOC_ESP32C3
 	bool "ESP32C3"
 	select RISCV
-	select RISCV_SOC_INIT_GP_VALUE
 	select DYNAMIC_INTERRUPTS
 
 config IDF_TARGET_ESP32C3

--- a/soc/riscv/esp32c3/soc.c
+++ b/soc/riscv/esp32c3/soc.c
@@ -186,9 +186,3 @@ int arch_irq_is_enabled(unsigned int irq)
 {
 	return (REG_READ(INTERRUPT_CORE0_CPU_INT_ENABLE_REG) & (1 << irq));
 }
-
-ulong_t __soc_get_gp_initial_value(void)
-{
-	extern uint32_t __global_pointer$;
-	return (ulong_t)&__global_pointer$;
-}

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -41,8 +41,6 @@ extern STATUS esp_rom_uart_tx_one_char(uint8_t chr);
 extern STATUS esp_rom_uart_rx_one_char(uint8_t *chr);
 extern void esp_rom_ets_set_user_start(uint32_t start);
 
-ulong_t __soc_get_gp_initial_value(void);
-
 #endif /* _ASMLANGUAGE */
 
 #endif /* __SOC_H__ */


### PR DESCRIPTION
RISC-V global pointer (GP) register is neither caller nor callee register and it's a constant value in the single ELF file.
Thus, we don't need to save/restore GP register at ISR enter/exit. Remove it to optimize context switch performance.

Also, this patch can simply the RISC-V GP support to Zephyr. We could only initialize gp value at program start, w/o initializing it again at each thread init because GP register isn't saved.
I saw #36180 is going to add GP support so this patch will affect it.