### PR TITLE
docs: mention hardenconfig in kconfig

### DIFF
--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -370,3 +370,6 @@ tips and best practices for writing :file:`Kconfig` files.
    kconfig/tips.rst
    kconfig/preprocessor-functions.rst
    kconfig/extensions.rst
+
+Users interested in optimizing their configuraion for security should refer
+to the Zephyr Security Guide's section on the :ref:`hardening`.


### PR DESCRIPTION
Adds a mention of the Kconfig hardening script hardenconfig to
the Kconfig documentation to promote awareness of its existence.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>