### PR TITLE
doc: dfu: fix broken link to "MCUboot with Zephyr"

### DIFF
--- a/doc/guides/device_mgmt/dfu.rst
+++ b/doc/guides/device_mgmt/dfu.rst
@@ -48,5 +48,5 @@ More detailed information regarding the use of MCUboot with Zephyr  can be found
 in the `MCUboot with Zephyr`_ documentation page on the MCUboot website.
 
 .. _MCUboot boot loader: https://mcuboot.com/
-.. _MCUboot with Zephyr: https://mcuboot.com/mcuboot/readme-zephyr.html
+.. _MCUboot with Zephyr: https://mcuboot.com/readme-zephyr.html
 .. _MCUboot GitHub Project: https://github.com/runtimeco/mcuboot


### PR DESCRIPTION
Fix broken link to MCUboot's website.
Clicking the link in the live version of the documentation leads to a 404 page. 

Signed-off-by: Mihail Marinov <genderlik@gmail.com>