### PR TITLE
kernel: thread: fix typecast in diff calculation

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1050,7 +1050,7 @@ void z_thread_mark_switched_out(void)
 	diff = timing_cycles_get(&thread->rt_stats.last_switched_in, &now);
 #else
 	now = k_cycle_get_32();
-	diff = (uint64_t)now - thread->rt_stats.last_switched_in;
+	diff = (uint64_t)(now - thread->rt_stats.last_switched_in);
 	thread->rt_stats.last_switched_in = 0;
 #endif /* CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS */
 


### PR DESCRIPTION
'diff' is uint64_t. The calculation casts uint32_t 'now'
as uint64, then subtracts uint32_t '.last_switched_in'
(in this #else), using two different types to get 'diff'.
This patch fixes it so the result of the subtraction operation
of the unit32_t vars is then typecast to uint64_t.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>