### PR TITLE
twister: try to clean ninja zombie

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -400,6 +400,7 @@ class Handler:
         self.generator_cmd = None
 
         self.args = []
+        self.terminated = False
 
     def set_state(self, state, duration):
         self.state = state
@@ -418,6 +419,23 @@ class Handler:
                 for instance in harness.recording:
                     cw.writerow(instance)
 
+    def terminate(self, proc):
+        # encapsulate terminate functionality so we do it consistently where ever
+        # we might want to terminate the proc.  We need try_kill_process_by_pid
+        # because of both how newer ninja (1.6.0 or greater) and .NET / renode
+        # work.  Newer ninja's don't seem to pass SIGTERM down to the children
+        # so we need to use try_kill_process_by_pid.
+        for child in psutil.Process(proc.pid).children(recursive=True):
+            try:
+                os.kill(child.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        proc.terminate()
+        # sleep for a while before attempting to kill
+        time.sleep(0.5)
+        proc.kill()
+        self.terminated = True
+
 
 class BinaryHandler(Handler):
     def __init__(self, instance, type_str):
@@ -427,7 +445,6 @@ class BinaryHandler(Handler):
         """
         super().__init__(instance, type_str)
 
-        self.terminated = False
         self.call_west_flash = False
 
         # Tool options
@@ -446,23 +463,6 @@ class BinaryHandler(Handler):
                 os.kill(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
-
-    def terminate(self, proc):
-        # encapsulate terminate functionality so we do it consistently where ever
-        # we might want to terminate the proc.  We need try_kill_process_by_pid
-        # because of both how newer ninja (1.6.0 or greater) and .NET / renode
-        # work.  Newer ninja's don't seem to pass SIGTERM down to the children
-        # so we need to use try_kill_process_by_pid.
-        for child in psutil.Process(proc.pid).children(recursive=True):
-            try:
-                os.kill(child.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
-        proc.terminate()
-        # sleep for a while before attempting to kill
-        time.sleep(0.5)
-        proc.kill()
-        self.terminated = True
 
     def _output_reader(self, proc):
         self.line = proc.stdout.readline()
@@ -1123,31 +1123,22 @@ class QEMUHandler(Handler):
                 # twister to judge testing result by console output
 
                 is_timeout = True
-                if os.path.exists(self.pid_fn):
-                    qemu_pid = int(open(self.pid_fn).read())
-                    try:
-                        os.kill(qemu_pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
-                    proc.wait()
-                    if harness.state == "passed":
-                        self.returncode = 0
-                    else:
-                        self.returncode = proc.returncode
+                self.terminate(proc)
+                if harness.state == "passed":
+                    self.returncode = 0
                 else:
-                    proc.terminate()
-                    proc.kill()
                     self.returncode = proc.returncode
             else:
                 if os.path.exists(self.pid_fn):
                     qemu_pid = int(open(self.pid_fn).read())
                 logger.debug(f"No timeout, return code from QEMU ({qemu_pid}): {proc.returncode}")
                 self.returncode = proc.returncode
-
             # Need to wait for harness to finish processing
             # output from QEMU. Otherwise it might miss some
             # error messages.
-            self.thread.join()
+            self.thread.join(0)
+            if self.thread.is_alive():
+                logger.debug("Timed out while monitoring QEMU output")
 
             if os.path.exists(self.pid_fn):
                 qemu_pid = int(open(self.pid_fn).read())


### PR DESCRIPTION
When run a testcase on QEMU, but qemu isn't launched, the `QEMU_PIPE` will not be created, then the twister will block at https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/pylib/twister/twisterlib.py#L951 until testcase [timeout](https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/pylib/twister/twisterlib.py#L1119), then the ninja process will be kill, but the parent process can't deal ninja process's signal, because the parent process block at https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/pylib/twister/twisterlib.py#L1150, then the twister will block at https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/pylib/twister/twisterlib.py#L3377. 
```
$ ps -aux | grep relauto
...
relauto  13217  0.0  0.0      0     0 ?        Z    02:47   0:00 [ninja] <defunct>
relauto  13416  0.0  0.0      0     0 ?        Z    02:47   0:00 [ninja] <defunct>
relauto  15826  0.0  0.0 112220   664 ?        S    02:14   0:00 timeout 18000 zephyr/scripts/twister -v --ninja --platform qemu_arc_hs --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-3/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  15827  0.0  0.0 230008 28268 ?        S    02:14   0:07 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_hs --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-3/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  15846  0.0  0.0 113456   960 ?        S    02:14   0:00 /bin/bash -eux ./jenkins-jobs/zephyr-sanity-check/sanity-check.sh main
relauto  15847  0.0  0.0 107952   656 ?        S    02:14   0:00 tee -a /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs/sanitycheck.log
relauto  15871  0.0  0.0 112220   664 ?        S    02:14   0:00 timeout 18000 zephyr/scripts/twister -v --ninja --platform qemu_arc_em --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  15872  0.0  0.0 230008 28268 ?        S    02:14   0:07 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_em --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  16716  0.0  0.0 2075676 52144 ?       Sl   02:14   0:01 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_hs --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-3/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  16828  0.0  0.0 307716 28780 ?        Sl   02:14   0:00 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_hs --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-3/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  16832  0.0  0.0      0     0 ?        Z    02:14   0:01 [python3] <defunct>
relauto  17632  0.0  0.0 2083616 52104 ?       Sl   02:14   0:01 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_em --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  17664  0.0  0.0 308372 29160 ?        Sl   02:14   0:00 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_em --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  17668  0.0  0.0      0     0 ?        Z    02:14   0:00 [python3] <defunct>
relauto  17674  0.0  0.0      0     0 ?        Z    02:14   0:00 [python3] <defunct>
relauto  17677  0.0  0.0      0     0 ?        Z    02:14   0:00 [python3] <defunct>
relauto  17683  0.0  0.0      0     0 ?        Z    02:14   0:02 [python3] <defunct>
relauto  17686  0.0  0.0      0     0 ?        Z    02:14   0:02 [python3] <defunct>
relauto  17693  0.0  0.0      0     0 ?        Z    02:14   0:03 [python3] <defunct>
relauto  17698  0.0  0.0      0     0 ?        Z    02:14   0:02 [python3] <defunct>
relauto  17702  0.0  0.0      0     0 ?        Z    02:14   0:03 [python3] <defunct>
relauto  17706  0.0  0.0      0     0 ?        Z    02:14   0:02 [python3] <defunct>
relauto  17712  0.0  0.0      0     0 ?        Z    02:14   0:02 [python3] <defunct>
relauto  17717  0.0  0.0      0     0 ?        Z    02:14   0:03 [python3] <defunct>
relauto  17721  0.0  0.0      0     0 ?        Z    02:14   0:03 [python3] <defunct>
relauto  17726  0.0  0.0 308124 29028 ?        Sl   02:14   0:00 python3 zephyr/scripts/twister -v --ninja --platform qemu_arc_em --report-dir /slowfs/ru20arcjenkins/de02-arcjenkins2/slaves/ru20-gp-srv-linux03/workspace/arcoss_verification/zephyr_verification/sanity_check-2/jenkins-jobs/zephyr-sanity-check/../../logs
relauto  17732  0.0  0.0      0     0 ?        Z    02:14   0:01 [python3] <defunct>
relauto  17738  0.0  0.0      0     0 ?        Z    02:14   0:01 [python3] <defunct>
relauto  17743  0.0  0.0      0     0 ?        Z    02:14   0:05 [python3] <defunct>
relauto  30408  0.0  0.0      0     0 ?        Z    02:42   0:00 [ninja] <defunct>

-bash-4.2$ ps -o ppid= 30408
16828
-bash-4.2$ ps -o ppid= 16828
15827
-bash-4.2$ ps -o ppid= 15827
15826

```

Add a timeout at https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/pylib/twister/twisterlib.py#L1150 can solve this problem. 