### PR TITLE
stmemsc HAL i/f align to v2.00

### DIFF
--- a/drivers/sensor/iis2dh/iis2dh.h
+++ b/drivers/sensor/iis2dh/iis2dh.h
@@ -17,11 +17,6 @@
 #include <drivers/sensor.h>
 #include "iis2dh_reg.h"
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
-
 /*
  * Return ODR reg value based on data rate set
  */

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -19,11 +19,6 @@
 #include <sys/util.h>
 #include "iis3dhhc_reg.h"
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
-
 struct iis3dhhc_config {
 	char *master_dev_name;
 	int (*bus_init)(const struct device *dev);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -18,16 +18,6 @@
 #include <sys/util.h>
 #include "ism330dhcx_reg.h"
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
-
-union axis1bit16_t {
-	int16_t i16bit;
-	uint8_t u8bit[2];
-};
-
 #define ISM330DHCX_EN_BIT					0x01
 #define ISM330DHCX_DIS_BIT					0x00
 

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -17,11 +17,6 @@
 #include <drivers/sensor.h>
 #include "lis2dw12_reg.h"
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
-
 #if defined(CONFIG_LIS2DW12_ODR_1_6)
 	#define LIS2DW12_DEFAULT_ODR	LIS2DW12_XL_ODR_1Hz6_LP_ONLY
 #elif defined(CONFIG_LIS2DW12_ODR_12_5)

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -20,16 +20,6 @@
 #include <sys/util.h>
 #include "lps22hh_reg.h"
 
-union axis1bit32_t {
-	int32_t i32bit;
-	uint8_t u8bit[4];
-};
-
-union axis1bit16_t {
-	int16_t i16bit;
-	uint8_t u8bit[2];
-};
-
 struct lps22hh_config {
 	char *master_dev_name;
 	int (*bus_init)(const struct device *dev);

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -319,16 +319,16 @@ static int lsm6dso_sample_fetch_accel(const struct device *dev)
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dso_data *data = dev->data;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
-	if (lsm6dso_acceleration_raw_get(ctx, buf.u8bit) < 0) {
+	if (lsm6dso_acceleration_raw_get(ctx, buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->acc[0] = sys_le16_to_cpu(buf.i16bit[0]);
-	data->acc[1] = sys_le16_to_cpu(buf.i16bit[1]);
-	data->acc[2] = sys_le16_to_cpu(buf.i16bit[2]);
+	data->acc[0] = sys_le16_to_cpu(buf[0]);
+	data->acc[1] = sys_le16_to_cpu(buf[1]);
+	data->acc[2] = sys_le16_to_cpu(buf[2]);
 
 	return 0;
 }
@@ -338,16 +338,16 @@ static int lsm6dso_sample_fetch_gyro(const struct device *dev)
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dso_data *data = dev->data;
-	union axis3bit16_t buf;
+	int16_t buf[3];
 
-	if (lsm6dso_angular_rate_raw_get(ctx, buf.u8bit) < 0) {
+	if (lsm6dso_angular_rate_raw_get(ctx, buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->gyro[0] = sys_le16_to_cpu(buf.i16bit[0]);
-	data->gyro[1] = sys_le16_to_cpu(buf.i16bit[1]);
-	data->gyro[2] = sys_le16_to_cpu(buf.i16bit[2]);
+	data->gyro[0] = sys_le16_to_cpu(buf[0]);
+	data->gyro[1] = sys_le16_to_cpu(buf[1]);
+	data->gyro[2] = sys_le16_to_cpu(buf[2]);
 
 	return 0;
 }
@@ -358,14 +358,14 @@ static int lsm6dso_sample_fetch_temp(const struct device *dev)
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dso_data *data = dev->data;
-	union axis1bit16_t buf;
+	int16_t buf;
 
-	if (lsm6dso_temperature_raw_get(ctx, buf.u8bit) < 0) {
+	if (lsm6dso_temperature_raw_get(ctx, &buf) < 0) {
 		LOG_DBG("Failed to read sample");
 		return -EIO;
 	}
 
-	data->temp_sample = sys_le16_to_cpu(buf.i16bit);
+	data->temp_sample = sys_le16_to_cpu(buf);
 
 	return 0;
 }

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -27,16 +27,6 @@
 #include <drivers/i2c.h>
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
-union axis3bit16_t {
-	int16_t i16bit[3];
-	uint8_t u8bit[6];
-};
-
-union axis1bit16_t {
-	int16_t i16bit;
-	uint8_t u8bit[2];
-};
-
 #define LSM6DSO_EN_BIT					0x01
 #define LSM6DSO_DIS_BIT					0x00
 

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -31,10 +31,10 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 	lsm6dso_int2_ctrl_t int2_ctrl;
 
 	if (enable) {
-		union axis1bit16_t buf;
+		int16_t buf;
 
 		/* dummy read: re-trigger interrupt */
-		lsm6dso_temperature_raw_get(ctx, buf.u8bit);
+		lsm6dso_temperature_raw_get(ctx, &buf);
 	}
 
 	/* set interrupt (TEMP DRDY interrupt is only on INT2) */
@@ -57,10 +57,10 @@ static int lsm6dso_enable_xl_int(const struct device *dev, int enable)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 
 	if (enable) {
-		union axis3bit16_t buf;
+		int16_t buf[3];
 
 		/* dummy read: re-trigger interrupt */
-		lsm6dso_acceleration_raw_get(ctx, buf.u8bit);
+		lsm6dso_acceleration_raw_get(ctx, buf);
 	}
 
 	/* set interrupt */
@@ -93,10 +93,10 @@ static int lsm6dso_enable_g_int(const struct device *dev, int enable)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 
 	if (enable) {
-		union axis3bit16_t buf;
+		int16_t buf[3];
 
 		/* dummy read: re-trigger interrupt */
-		lsm6dso_angular_rate_raw_get(ctx, buf.u8bit);
+		lsm6dso_angular_rate_raw_get(ctx, buf);
 	}
 
 	/* set interrupt */

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -19,11 +19,6 @@
 #include <sys/util.h>
 #include "stts751_reg.h"
 
-union axis1bit16_t {
-	int16_t i16bit;
-	uint8_t u8bit[2];
-};
-
 struct stts751_config {
 	char *master_dev_name;
 	int (*bus_init)(const struct device *dev);

--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
       revision: be39d4eebeddac6e18e9c0c3ba1b31ad1e82eaed
       path: modules/hal/silabs
     - name: hal_st
-      revision: b52fdbf4b62439be9fab9bb4bae9690a42d2fb14
+      revision: 575de9d461aa6f430cf62c58a053675377e700f3
       path: modules/hal/st
     - name: hal_stm32
       revision: f8ff8d25aa0a9e65948040c7b47ec67f3fa300df


### PR DESCRIPTION
The stmemsc hal interface is going to be upgraded to v2.00:
https://github.com/zephyrproject-rtos/hal_st/pull/7
(merged as 575de9d461aa6f430cf62c58a053675377e700f3)

As a consequence, zephyr needs to align the stmemsc based driver according to API changes in v2.00.
File west.yaml is now pointing to revision: pull/7/head (will be updated to a regular hash id once that PR will be merged).
Sensor lsmdso driver stmemsc APIs have been upgraded.

Moreover, added an additional commit carrying a cleanup to old reference to axi3bit16_t union.

Edit::
Tested completely on x_nucleo_iks01a3 and x_nucleo_iks02a1 shields.
Tested also build on sesnortile.box.