### PR TITLE
toolchain: Add macro for warning for unused return values

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -194,6 +194,9 @@ do {                                                                    \
 #ifndef __attribute_const__
 #define __attribute_const__ __attribute__((__const__))
 #endif
+#ifndef __must_check
+#define __must_check __attribute__((warn_unused_result))
+#endif
 #define ARG_UNUSED(x) (void)(x)
 
 #define likely(x)   __builtin_expect((bool)!!(x), true)


### PR DESCRIPTION
This will let us get compiler warnings whenever the return value of
specific functions stays unused. I called this __must_check since that's
the name Linux uses as well.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>