### PR TITLE
Fix native_posix build when C++ exception handling is enabled

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -61,23 +61,21 @@ elseif("${ARCH}" STREQUAL "sparc")
   include(${CMAKE_CURRENT_LIST_DIR}/target_sparc.cmake)
 endif()
 
-if(NOT no_libgcc)
-  # This libgcc code is partially duplicated in compiler/*/target.cmake
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-    OUTPUT_VARIABLE LIBGCC_FILE_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+# This libgcc code is partially duplicated in compiler/*/target.cmake
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
+  OUTPUT_VARIABLE LIBGCC_FILE_NAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
-  assert_exists(LIBGCC_FILE_NAME)
+assert_exists(LIBGCC_FILE_NAME)
 
-  get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
+get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
 
-  assert_exists(LIBGCC_DIR)
+assert_exists(LIBGCC_DIR)
 
-  LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
-  LIST(APPEND TOOLCHAIN_LIBS gcc)
-endif()
+LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
+LIST(APPEND TOOLCHAIN_LIBS gcc)
 
 if(SYSROOT_DIR)
   # The toolchain has specified a sysroot dir that we can use to set

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -18,20 +18,15 @@ else()
 endif()
 find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)
 
-# The x32 version of libgcc is usually not available (can't trust gcc
-# -mx32 --print-libgcc-file-name) so don't fail to build for something
-# that is currently not needed. See comments in compiler/gcc/target.cmake
-if (CONFIG_X86)
-  # Convert to list as cmake Modules/*.cmake do it
-  STRING(REGEX REPLACE " +" ";" PRINT_LIBGCC_ARGS "${CMAKE_C_FLAGS}")
-  # This libgcc code is partially duplicated in compiler/*/target.cmake
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} "${PRINT_LIBGCC_ARGS}" --print-libgcc-file-name
-    OUTPUT_VARIABLE LIBGCC_FILE_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  assert_exists(LIBGCC_FILE_NAME)
-endif()
+# Convert to list as cmake Modules/*.cmake do it
+STRING(REGEX REPLACE " +" ";" PRINT_LIBGCC_ARGS "${CMAKE_C_FLAGS}")
+# This libgcc code is partially duplicated in compiler/*/target.cmake
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} "${PRINT_LIBGCC_ARGS}" --print-libgcc-file-name
+  OUTPUT_VARIABLE LIBGCC_FILE_NAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+assert_exists(LIBGCC_FILE_NAME)
 
 set(NOSTDINC "")
 

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -18,16 +18,6 @@ else()
 endif()
 find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)
 
-# Convert to list as cmake Modules/*.cmake do it
-STRING(REGEX REPLACE " +" ";" PRINT_LIBGCC_ARGS "${CMAKE_C_FLAGS}")
-# This libgcc code is partially duplicated in compiler/*/target.cmake
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} "${PRINT_LIBGCC_ARGS}" --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_FILE_NAME
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-assert_exists(LIBGCC_FILE_NAME)
-
 set(NOSTDINC "")
 
 # Note that NOSYSDEF_CFLAG may be an empty string, and

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -13,14 +13,16 @@ endif()
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 
-if(CONFIG_EXCEPTIONS)
-  # When building with C++ Exceptions, it is important that crtbegin and crtend
-  # are linked at specific locations.
-  # The location is so important that we cannot let this be controlled by normal
-  # link libraries, instead we must control the link command specifically as
-  # part of toolchain.
-  set(CMAKE_CXX_LINK_EXECUTABLE
-      "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${LIBGCC_DIR}/crtend.o")
+if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "host")
+  if(CONFIG_EXCEPTIONS)
+    # When building with C++ Exceptions, it is important that crtbegin and crtend
+    # are linked at specific locations.
+    # The location is so important that we cannot let this be controlled by normal
+    # link libraries, instead we must control the link command specifically as
+    # part of toolchain.
+    set(CMAKE_CXX_LINK_EXECUTABLE
+        "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${LIBGCC_DIR}/crtend.o")
+  endif()
 endif()
 
 # Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}


### PR DESCRIPTION
This series fixes the broken `native_posix*` build when C++ exception handling is enabled (`CONFIG_EXCEPTIONS=y`).

The actual fix is limited to the [last commit](https://github.com/zephyrproject-rtos/zephyr/commit/b428a3ce718ea3fa036d203e85671275065ad42a), but I've found a few other things that require fixing while investigating this issue, so I'm including them here as well.

Fixes #36250.