### PR TITLE
TF-M: adding LPCXPRESSO55S69 to the regression test sample

### DIFF
--- a/samples/tfm_integration/tfm_integration.rst
+++ b/samples/tfm_integration/tfm_integration.rst
@@ -1,7 +1,7 @@
 .. _tfm_integration-samples:
 
-TFM Integration Samples
-#######################
+TF-M Integration Samples
+########################
 
 .. toctree::
    :maxdepth: 1
@@ -43,7 +43,7 @@ supports firmware upgrade.
 
 The current TF-M implementation specifically targets TrustZone for ARMv8-M.
 
-Trusted Firmware M source code is available at
+Trusted Firmware-M source code is available at
 `git.trustedfirmware.org <https://git.trustedfirmware.org>`_, although a fork
 of this source code is maintained by the Zephyr Project as a module for
 convenience sake at

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -1,7 +1,8 @@
 common:
     tags: tfm
-    platform_allow: mps2_an521_nonsecure v2m_musca_s1_nonsecure
+    platform_allow: mps2_an521_nonsecure
                     nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+                    v2m_musca_s1_nonsecure
     harness: console
     harness_config:
       type: multi_line

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -1,7 +1,8 @@
 common:
     tags: tfm
-    platform_allow: mps2_an521_nonsecure v2m_musca_s1_nonsecure
-                    nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns bl5340_dvk_cpuappns
+    platform_allow: lpcxpresso55s69_ns mps2_an521_nonsecure
+                    nrf5340dk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+                    v2m_musca_s1_nonsecure
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
Adding the LPCXPRESSO55S69_NS platform in the allow-list for 
- tfm_regression
- psa_arch_test
samples