### PR TITLE
nrf52_adafruit_feather  board config adc

### DIFF
--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -123,3 +123,7 @@
 	ch0-pin = <17>;
 	ch0-inverted;
 };
+
+&adc {
+	status = "okay";
+};


### PR DESCRIPTION
dts file for nrf52_adafruit_feather missing the adc status okay. Since the SoC used in this board have the ADC enabled there is no reason to do not enable the ADC for this board. I tested this change on the actual board.