### PR TITLE
STM32: Enable ART flash cache

### DIFF
--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -23,6 +23,20 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	return flash_stm32_range_exists(dev, offset, len);
 }
 
+static inline void flush_cache(FLASH_TypeDef *regs)
+{
+	if (regs->ACR & FLASH_ACR_ARTEN) {
+		regs->ACR &= ~FLASH_ACR_ARTEN;
+		/* Refernce manual:
+		 * The ART cache can be flushed only if the ART accelerator
+		 * is disabled (ARTEN = 0).
+		 */
+		regs->ACR |= FLASH_ACR_ARTRST;
+		regs->ACR &= ~FLASH_ACR_ARTRST;
+		regs->ACR |= FLASH_ACR_ARTEN;
+	}
+}
+
 static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -14,6 +14,7 @@
 #include <init.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <stm32_ll_system.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -28,6 +29,10 @@ static int st_stm32f4_init(const struct device *arg)
 	uint32_t key;
 
 	ARG_UNUSED(arg);
+
+	/* Enable ART Flash cache accelerator for both instruction and data */
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnableDataCache();
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <stm32_ll_system.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -29,6 +30,9 @@ static int st_stm32f7_init(const struct device *arg)
 	uint32_t key;
 
 	ARG_UNUSED(arg);
+
+	/* Enable ART Flash cache accelerator */
+	LL_FLASH_EnableART();
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -67,6 +67,11 @@ static int stm32h7_m4_init(const struct device *arg)
 {
 	uint32_t key;
 
+	/* Enable ART Flash cache accelerator */
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_ART);
+	LL_ART_SetBaseAddress(DT_REG_ADDR(DT_CHOSEN(zephyr_flash)));
+	LL_ART_Enable();
+
 	key = irq_lock();
 
 	/* Install default handler that simply resets the CPU

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -15,7 +15,7 @@
 #include <stm32_ll_pwr.h>
 #include <arch/cpu.h>
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
-
+#include <stm32l5xx_ll_icache.h>
 #include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
@@ -34,6 +34,11 @@ static int stm32l5_init(const struct device *arg)
 	uint32_t key;
 
 	ARG_UNUSED(arg);
+
+	/* Enable ICACHE */
+	while (LL_ICACHE_IsActiveFlag_BUSY()) {
+	}
+	LL_ICACHE_Enable();
 
 	key = irq_lock();
 


### PR DESCRIPTION
Enable ART Flash accelerator for STM32 series supporting it.
Depending on capabilities, enable both Instruction and Data cache.
When necessary, manage cache coherency in flash driver (Similarly to #32218 and #34032).
* stm32f4
* stm32f7
* stm32h7
* stm32l5
* ~~stm32f2~~  --> #35549

Fixes #28312