### PR TITLE
Fix nrf5340 DTS (app core)

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -63,7 +63,12 @@
 			};
 		};
 
-		gpiote: gpiote@5000d000 {
+		/*
+		 * GPIOTE0 is always accessible as a secure peripheral,
+		 * so we give it the 'gpiote' label for use when building
+		 * code for this target.
+		 */
+		gpiote: gpiote0: gpiote@5000d000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x5000d000 0x1000>;
 			interrupts = <13 5>;
@@ -95,3 +100,10 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+/*
+ * Include the non-secure peripherals file here since
+ * it expects to be at the root level. This provides
+ * a node for GPIOTE1.
+ */
+#include "nrf5340_cpuapp_peripherals_ns.dtsi"

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -36,10 +36,6 @@
 			compatible = "mmio-sram";
 		};
 
-		sram1: memory@21000000 {
-			compatible = "mmio-sram";
-		};
-
 		peripheral@50000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals_ns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals_ns.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * GPIOTE1 is always accessible as a non-secure peripheral.
+ */
+
+/ {
+	soc {
+		gpiote1: gpiote@4002f000 {
+			compatible = "nordic,nrf-gpiote";
+			reg = <0x4002f000 0x1000>;
+			interrupts = <47 5>;
+			status = "disabled";
+			label = "GPIOTE_1";
+		};
+	};
+};

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -15,10 +15,6 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
-&sram1 {
-	reg = <0x21000000 DT_SIZE_K(64)>;
-};
-
 &mpu {
 	arm,num-mpu-regions = <8>;
 };

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -48,17 +48,18 @@
 			#include "nrf5340_cpuapp_peripherals.dtsi"
 		};
 
-		/* Additional Non-Secure peripherals */
-		gpiote: gpiote@4002f000 {
-			compatible = "nordic,nrf-gpiote";
-			reg = <0x4002f000 0x1000>;
-			interrupts = <47 5>;
-			status = "disabled";
-			label = "GPIOTE_1";
-		};
 	};
 };
 
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+/*
+ * Include the non-secure peripherals file here since
+ * it expects to be at the root level, adding a 'gpiote' label
+ * for the GPIOTE1 peripheral defined in that file which is
+ * always accessible as a non-secure peripheral.
+ */
+#include "nrf5340_cpuapp_peripherals_ns.dtsi"
+gpiote: &gpiote1 {};

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -37,10 +37,6 @@
 			compatible = "mmio-sram";
 		};
 
-		sram1: memory@21000000 {
-			compatible = "mmio-sram";
-		};
-
 		peripheral@40000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -15,10 +15,6 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
-&sram1 {
-	reg = <0x21000000 DT_SIZE_K(64)>;
-};
-
 &mpu {
 	arm,num-mpu-regions = <8>;
 };


### PR DESCRIPTION
This is part 1 of some fixes for the nRF5340 DTSI files. This PR concerns the application core. Part 2 will concern the network core.

Fixes:

- remove network core SRAM nodes; this memory is not addressable by the app core
- add GPIOTE1 node to the secure DTSI file; non-secure peripherals are addressable from the secure world

To keep the GPIOTE node labels clean, I've adjusted things a bit, with the end result that:

- 'gpiote0' and 'gpiote1' are defined in the secure DTSI
- 'gpiote0' is not defined in the non-secure DTSI
- 'gpiote' is defined in both secure and non-secure DTSIs
- 'gpiote' refers to the same node as 'gpiote0' in the secure DTSI
- 'gpiote' refers to the same node as 'gpiote1' in the non-secure DTSI
