### PR TITLE
Bluetooth: gatt: Add option to read multiple without variable length

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -44,6 +44,12 @@ Removed APIs in this release
 Stable API changes in this release
 ==================================
 
+* Bluetooth
+
+  * Added :c:struct:`multiple` to the :c:struct:`bt_gatt_read_params` - this
+    structure contains two members: ``handles``, which was moved from
+    :c:struct:`bt_gatt_read_params`, and ``variable``.
+
 Kernel
 ******
 

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1366,8 +1366,7 @@ struct bt_gatt_read_params {
 	/** Read attribute callback. */
 	bt_gatt_read_func_t func;
 	/** If equals to 1 single.handle and single.offset are used.
-	 *  If >1 Read Multiple Characteristic Values is performed and handles
-	 *  are used.
+	 *  If greater than 1 multiple.handles are used.
 	 *  If equals to 0 by_uuid is used for Read Using Characteristic UUID.
 	 */
 	size_t handle_count;
@@ -1378,8 +1377,23 @@ struct bt_gatt_read_params {
 			/** Attribute data offset. */
 			uint16_t offset;
 		} single;
-		/** Handles to read in Read Multiple Characteristic Values. */
-		uint16_t *handles;
+		struct {
+			/** Attribute handles to read with Read Multiple
+			 *  Characteristic Values.
+			 */
+			uint16_t *handles;
+			/** If true use Read Multiple Variable Length
+			 *  Characteristic Values procedure.
+			 *  The values of the set of attributes may be of
+			 *  variable or unknown length.
+			 *  If false use Read Multiple Characteristic Values
+			 *  procedure.
+			 *  The values of the set of attributes must be of a
+			 *  known fixed length, with the exception of the last
+			 *  value that can have a variable length.
+			 */
+			bool variable;
+		} multiple;
 		struct {
 			/** First requested handle number. */
 			uint16_t start_handle;

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -340,7 +340,8 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 
 	read_params.func = read_func;
 	read_params.handle_count = i;
-	read_params.handles = h; /* not used in read func */
+	read_params.multiple.handles = h;
+	read_params.multiple.variable = true;
 
 	err = bt_gatt_read(default_conn, &read_params);
 	if (err) {

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1528,7 +1528,8 @@ static void read_multiple(uint8_t *data, uint16_t len)
 
 	read_params.func = read_cb;
 	read_params.handle_count = i;
-	read_params.handles = handles; /* not used in read func */
+	read_params.multiple.handles = handles; /* not used in read func */
+	read_params.multiple.variable = false;
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = GATT_READ_MULTIPLE;


### PR DESCRIPTION
Currently, with EATT enabled, when bt_gatt_read is called with multiple
handles first it'll try to use gatt_read_mult_vl, and if it fails
gatt_read_mult will be used to try again. Add option to skip
the gatt_read_mult_vl and use gatt_read_mult right away. This is needed
by tests that expect BT_ATT_OP_READ_MULT_REQ but support variable
lenght, thus don't return BT_ATT_ERR_NOT_SUPPORTED.

This was affecting:
GATT/CL/GAR/BV-05-C, GATT/CL/GAR/BI-18-C, GATT/CL/GAR/BI-19-C,
GATT/CL/GAR/BI-20-C, GATT/CL/GAR/BI-21-C, GATT/CL/GAR/BI-22-C

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>