### PR TITLE
Bluetooth: host: Document settings_load is required to finalize init

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -130,6 +130,11 @@ typedef void (*bt_ready_cb_t)(int err);
  * Enable Bluetooth. Must be the called before any calls that
  * require communication with the local Bluetooth hardware.
  *
+ * When @option{CONFIG_BT_SETTINGS} has been enabled and the application is not
+ * managing identities of the stack itself then the application must call
+ * @ref settings_load() before the stack is fully enabled.
+ * See @ref bt_id_create() for more information.
+ *
  * @param cb Callback to notify completion or NULL to perform the
  * enabling synchronously.
  *


### PR DESCRIPTION
Document that calling settings_load is required when the application is
not creating and managing the identities of the stack itself.
The application will not be able to use all features of the stack before
the identities have been loaded.

Fixes: #36037

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>