### PR TITLE
drivers: kscan: increase init priority

### DIFF
--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -29,9 +29,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default y
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if NETWORKING

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -36,9 +36,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default y
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if NETWORKING

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -35,9 +35,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default y
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if NETWORKING

--- a/boards/arm/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f746g_disco/Kconfig.defconfig
@@ -23,9 +23,6 @@ if KSCAN
 config KSCAN_FT5336
 	default y
 
-config KSCAN_INIT_PRIORITY
-	default 65
-
 endif # KSCAN
 
 endif # BOARD_STM32F746G_DISCO

--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -26,9 +26,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default n
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if LVGL

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -23,9 +23,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default n
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if LVGL

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
@@ -23,9 +23,6 @@ config KSCAN_FT5336
 config KSCAN_FT5336_INTERRUPT
 	default n
 
-config KSCAN_INIT_PRIORITY
-	default 60
-
 endif # KSCAN
 
 if LVGL

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -20,7 +20,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config KSCAN_INIT_PRIORITY
 	int "Keyboard scan driver init priority"
-	default 40
+	default 90
 	help
 	  Keyboard scan device driver initialization priority.
 


### PR DESCRIPTION
Some kscan drivers, e.g. ft5336 will not work with Zephyr default
settings due to wrong init priority order (e.g. I2C init order is 60 and
kscan is 40). kscan priority order has been increased and some custom
priorities removed since they are no longer needed.