### PR TITLE
Bluetooth: Add missing store `net_buf_ref` return value

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -518,9 +518,8 @@ static void recv_thread(void *p1, void *p2, void *p3)
 			/* Increment ref count, which will be
 			 * unref on call to net_buf_frag_del
 			 */
-			frag = buf;
-			net_buf_ref(frag);
-			buf = net_buf_frag_del(NULL, frag);
+			frag = net_buf_ref(buf);
+			buf = net_buf_frag_del(NULL, buf);
 
 			if (frag->len) {
 				BT_DBG("Packet in: type:%u len:%u",

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -299,9 +299,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	cmd(buf)->sync = &sync_sem;
 
 	/* Make sure the buffer stays around until the command completes */
-	net_buf_ref(buf);
-
-	net_buf_put(&bt_dev.cmd_tx_queue, buf);
+	net_buf_put(&bt_dev.cmd_tx_queue, net_buf_ref(buf));
 
 	err = k_sem_take(&sync_sem, HCI_CMD_TIMEOUT);
 	BT_ASSERT_MSG(err == 0, "k_sem_take failed with err %d", err);


### PR DESCRIPTION
From @jhedberg 's review of (https://github.com/zephyrproject-rtos/zephyr/pull/35702)

No code should ever call net_buf_ref() without storing the return value to a new pointer.

And also related to PR(https://github.com/zephyrproject-rtos/zephyr/pull/36259).

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>