### PR TITLE
drivers: modem: gsm: Ignore semaphore take return value

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -81,7 +81,7 @@ static void gsm_rx(struct gsm_modem *gsm)
 	LOG_DBG("starting");
 
 	while (true) {
-		k_sem_take(&gsm->gsm_data.rx_sem, K_FOREVER);
+		(void)k_sem_take(&gsm->gsm_data.rx_sem, K_FOREVER);
 
 		/* The handler will listen AT channel */
 		gsm->context.cmd_handler.process(&gsm->context.cmd_handler,


### PR DESCRIPTION
We do not need the return value of k_sem_take() so ignore it.

Coverity-CID: 236602
Fixes #36313

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>