### PR TITLE
soc: nrf53: Use internal capacitor for HFXO by default

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -166,7 +166,7 @@ endchoice
 
 choice SOC_HFXO_LOAD_CAPACITANCE
 	prompt "HFXO load capacitance"
-	default SOC_HFXO_CAP_EXTERNAL
+	default SOC_HFXO_CAP_INTERNAL
 
 config SOC_HFXO_CAP_EXTERNAL
 	bool "Use external load capacitors"


### PR DESCRIPTION
The nRF5340 Development Kits do not have external capacitors on the
boards, this is setting a sensible default to avoid issues.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>