### PR TITLE
Bluetooth: host: Add find by UUID helper function for application.

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -928,9 +928,17 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn, void *user_data);
 
 struct bt_gatt_notify_params {
-	/** Notification Attribute UUID type */
+	/** @brief Notification Attribute UUID type
+	 *
+	 *  Optional, use to search for an attribute with matching UUID when
+	 *  the attribute object pointer is not known.
+	 */
 	const struct bt_uuid *uuid;
-	/** Notification Attribute object*/
+	/** @brief Notification Attribute object
+	 *
+	 *  Optional if uuid is provided, in this case it will be used as start
+	 *  range to search for the attribute with the given UUID.
+	 */
 	const struct bt_gatt_attr *attr;
 	/** Notification Value data */
 	const void *data;
@@ -955,7 +963,7 @@ struct bt_gatt_notify_params {
  *  @option{CONFIG_BT_CONN_TX_MAX} option.
  *
  *  Alternatively it is possible to notify by UUID by setting it on the
- *  parameters, when using this method the attribute given is used as the
+ *  parameters, when using this method the attribute if provided is used as the
  *  start range when looking up for possible matches.
  *
  *  @param conn Connection object.
@@ -1068,9 +1076,17 @@ typedef void (*bt_gatt_indicate_params_destroy_t)(
 
 /** @brief GATT Indicate Value parameters */
 struct bt_gatt_indicate_params {
-	/** Notification Attribute UUID type */
+	/** @brief Indicate Attribute UUID type
+	 *
+	 *  Optional, use to search for an attribute with matching UUID when
+	 *  the attribute object pointer is not known.
+	 */
 	const struct bt_uuid *uuid;
-	/** Indicate Attribute object*/
+	/** @brief Indicate Attribute object
+	 *
+	 *  Optional if uuid is provided, in this case it will be used as start
+	 *  range to search for the attribute with the given UUID.
+	 */
 	const struct bt_gatt_attr *attr;
 	/** Indicate Value callback */
 	bt_gatt_indicate_func_t func;
@@ -1097,7 +1113,7 @@ struct bt_gatt_indicate_params {
  *  BT_GATT_CHARACTERISTIC.
  *
  *  Alternatively it is possible to indicate by UUID by setting it on the
- *  parameters, when using this method the attribute given is used as the
+ *  parameters, when using this method the attribute if provided is used as the
  *  start range when looking up for possible matches.
  *
  *  @note This procedure is asynchronous therefore the parameters need to

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -433,6 +433,24 @@ static inline void bt_gatt_foreach_attr(uint16_t start_handle, uint16_t end_hand
  */
 struct bt_gatt_attr *bt_gatt_attr_next(const struct bt_gatt_attr *attr);
 
+/** @brief Find Attribute by UUID.
+ *
+ *  Find the attribute with the matching UUID.
+ *  To limit the search to a service set the attr to the service attributes and
+ *  the attr_count to the service attribute count .
+ *
+ *  @param attr        Pointer to an attribute that serves as the starting point
+ *                     for the search of a match for the UUID.
+ *                     Passing NULL will search the entire range.
+ *  @param attr_count  The number of attributes from the starting point to
+ *                     search for a match for the UUID.
+ *                     Set to 0 to search until the end.
+ *  @param uuid        UUID to match.
+ */
+struct bt_gatt_attr *bt_gatt_find_by_uuid(const struct bt_gatt_attr *attr,
+					  uint16_t attr_count,
+					  const struct bt_uuid *uuid);
+
 /** @brief Get Attribute handle.
  *
  *  @param attr Attribute object.

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -326,6 +326,8 @@ static void hrs_notify(void)
 
 void main(void)
 {
+	struct bt_gatt_attr *vnd_ind_attr;
+	char str[BT_UUID_STR_LEN];
 	int err;
 
 	err = bt_enable(NULL);
@@ -339,6 +341,11 @@ void main(void)
 	bt_gatt_cb_register(&gatt_callbacks);
 	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&auth_cb_display);
+
+	vnd_ind_attr = bt_gatt_find_by_uuid(vnd_svc.attrs, vnd_svc.attr_count,
+					    &vnd_enc_uuid.uuid);
+	bt_uuid_to_str(&vnd_enc_uuid.uuid, str, sizeof(str));
+	printk("Indicate VND attr %p (UUID %s)\n", vnd_ind_attr, str);
 
 	/* Implement notification. At the moment there is no suitable way
 	 * of starting delayed work so we do it here
@@ -356,12 +363,12 @@ void main(void)
 		bas_notify();
 
 		/* Vendor indication simulation */
-		if (simulate_vnd) {
+		if (simulate_vnd && vnd_ind_attr) {
 			if (indicating) {
 				continue;
 			}
 
-			ind_params.attr = &vnd_svc.attrs[2];
+			ind_params.attr = vnd_ind_attr;
 			ind_params.func = indicate_cb;
 			ind_params.destroy = indicate_destroy;
 			ind_params.data = &indicating;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2260,26 +2260,26 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 	struct notify_data data;
 
 	__ASSERT(params, "invalid parameters\n");
-	__ASSERT(params->attr, "invalid parameters\n");
+	__ASSERT(params->attr || params->uuid, "invalid parameters\n");
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
-	data.attr = params->attr;
-
 	if (conn && conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;
 	}
 
+	data.attr = params->attr;
 	data.handle = bt_gatt_attr_get_handle(data.attr);
-	if (!data.handle) {
-		return -ENOENT;
-	}
 
 	/* Lookup UUID if it was given */
 	if (params->uuid) {
 		if (!gatt_find_by_uuid(&data, params->uuid)) {
+			return -ENOENT;
+		}
+	} else {
+		if (!data.handle) {
 			return -ENOENT;
 		}
 	}
@@ -2336,26 +2336,26 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	struct notify_data data;
 
 	__ASSERT(params, "invalid parameters\n");
-	__ASSERT(params->attr, "invalid parameters\n");
+	__ASSERT(params->attr || params->uuid, "invalid parameters\n");
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
-	data.attr = params->attr;
-
 	if (conn && conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;
 	}
 
+	data.attr = params->attr;
 	data.handle = bt_gatt_attr_get_handle(data.attr);
-	if (!data.handle) {
-		return -ENOENT;
-	}
 
 	/* Lookup UUID if it was given */
 	if (params->uuid) {
 		if (!gatt_find_by_uuid(&data, params->uuid)) {
+			return -ENOENT;
+		}
+	} else {
+		if (!data.handle) {
 			return -ENOENT;
 		}
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2254,6 +2254,21 @@ static bool gatt_find_by_uuid(struct notify_data *found,
 	return found->attr ? true : false;
 }
 
+struct bt_gatt_attr *bt_gatt_find_by_uuid(const struct bt_gatt_attr *attr,
+					  uint16_t attr_count,
+					  const struct bt_uuid *uuid)
+{
+	struct bt_gatt_attr *found = NULL;
+	uint16_t start_handle = bt_gatt_attr_value_handle(attr);
+	uint16_t end_handle = start_handle && attr_count ?
+			      start_handle + attr_count : 0xffff;
+
+	bt_gatt_foreach_attr_type(start_handle, end_handle, uuid, NULL, 1,
+				  find_next, &found);
+
+	return found;
+}
+
 int bt_gatt_notify_cb(struct bt_conn *conn,
 		      struct bt_gatt_notify_params *params)
 {


### PR DESCRIPTION
Allow to pass attribute as NULL pointer when using notify or indicate by
UUID. This will use the entire handle value range to search for an
attribute with a matching UUID.
Document optional parameters, and clarify attr and uuid usage in the
variable declaration in the struct for clarification.

Expose a helper function to the application that searches the local
database for the given attribute from its UUID.
Provide arguments to limit the search that matches the service
declaration to make it easy to limit the search to a specific service.

Fixes: #22210