### PR TITLE
os/json: Skip json null value when parsing json content

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -601,7 +601,7 @@ static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
 				return ret;
 			}
 
-			if(kv.value.type != JSON_TOK_NULL || kv.value.type == descr->type) {
+			if(kv.value.type != JSON_TOK_NULL || kv.value.type == descr[i].type) {
 				decoded_fields |= 1<<i;
 			}
 			break;

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -460,14 +460,11 @@ static int decode_value(struct json_obj *obj,
 	int null_type = check_null_type(value->type, descr->type);
 	if(null_type) 
 	{
-		if(descr->type == JSON_TOK_NULL) {
-			// null type was expected
-			return 0;
-		} else {
+		if(descr->type != JSON_TOK_NULL) {
 			// string value contains null
 			memset(field, 0, sizeof(char *));
-			return null_type < 0 ? null_type : 0; // Return err or just ignore the current value
 		}
+		return null_type < 0 ? null_type : 0; // Return err or just ignore the current value
 	}
 
 	switch (descr->type) {
@@ -792,6 +789,10 @@ static int str_encode(const char **str, json_append_bytes_t append_bytes,
 {
 	int ret;
 
+	if(!(*str)) {
+		return append_bytes("null", 4, data);
+	}
+
 	ret = append_bytes("\"", 1, data);
 	if (ret < 0) {
 		return ret;
@@ -852,6 +853,8 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 				       ptr, append_bytes, data);
 	case JSON_TOK_NUMBER:
 		return num_encode(ptr, append_bytes, data);
+	case JSON_TOK_NULL:
+		return append_bytes("null", 4, data);
 	default:
 		return -EINVAL;
 	}

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -604,7 +604,7 @@ static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
 				return ret;
 			}
 
-			if(kv.value.type != JSON_TOK_NULL) {
+			if(kv.value.type != JSON_TOK_NULL || kv.value.type == descr->type) {
 				decoded_fields |= 1<<i;
 			}
 			break;

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -17,6 +17,8 @@ struct test_nested {
 
 struct test_struct {
 	const char *some_string;
+	const char *some_null;
+	const char *some_null_string;
 	int some_int;
 	bool some_bool;
 	struct test_nested some_nested_struct;
@@ -48,6 +50,8 @@ static const struct json_obj_descr nested_descr[] = {
 
 static const struct json_obj_descr test_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_string, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null, JSON_TOK_NULL),
+	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null_string, JSON_TOK_STRING)
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_int, JSON_TOK_NUMBER),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_bool, JSON_TOK_TRUE),
 	JSON_OBJ_DESCR_OBJECT(struct test_struct, some_nested_struct,
@@ -99,6 +103,8 @@ static void test_json_encoding(void)
 {
 	struct test_struct ts = {
 		.some_string = "zephyr 123\uABCD",
+		.some_null = nullptr,
+		.some_null_string = nullptr;
 		.some_int = 42,
 		.some_bool = true,
 		.some_nested_struct = {
@@ -126,6 +132,8 @@ static void test_json_encoding(void)
 		},
 	};
 	char encoded[] = "{\"some_string\":\"zephyr 123\uABCD\","
+		"\"some_null\":null,"
+		"\"some_null_string\":null,"
 		"\"some_int\":42,\"some_bool\":true,"
 		"\"some_nested_struct\":{\"nested_int\":-1234,"
 		"\"nested_bool\":false,\"nested_string\":"
@@ -157,6 +165,8 @@ static void test_json_decoding(void)
 {
 	struct test_struct ts;
 	char encoded[] = "{\"some_string\":\"zephyr 123\\uABCD456\","
+		"\"some_null\":null,"
+		"\"some_null_string\":null,"
 		"\"some_int\":\t42\n,"
 		"\"some_bool\":true    \t  "
 		"\n"
@@ -185,6 +195,8 @@ static void test_json_decoding(void)
 
 	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
 		    "String decoded correctly");
+	zassert_equal(ts.some_null, nullptr, "Null value decoded correctly");
+	zassert_equal(ts.some_null_string, nullptr, "Null string decoded correctly");
 	zassert_equal(ts.some_int, 42, "Positive integer decoded correctly");
 	zassert_equal(ts.some_bool, true, "Boolean decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_int, -1234,
@@ -373,9 +385,19 @@ static void test_json_invalid_null(void)
 {
 	struct encoding_test encoded[] = {
 		/* Parser will recognize 'null', but refuse to decode it */
-		{ "{\"some_string\":null }", -EINVAL},
+		{ "{\"some_int\":null}", -EINVAL},
+		{ "{\"some_bool\":null}", -EINVAL},
+		{ "{\"some_array\":null}", -EINVAL},
+		{ "{\"some_nested_struct\":null}", -EINVAL},
 		/* Null spelled wrong */
-		{ "{\"some_string\":nutella }", -EINVAL},
+		{ "{\"some_int\":nutella}", -EINVAL},
+		{ "{\"some_bool\":nutella}", -EINVAL},
+		{ "{\"some_array\":nutella}", -EINVAL},
+		{ "{\"some_nested_struct\":nutella}", -EINVAL},
+		{ "{\"some_null_string\":nutella}", -EINVAL},
+		/* Expecting null for non-null value */
+		{ "{\"some_null\":\"hello\"}", -EINVAL },
+		{ "{\"some_null\":nutella}", -EINVAL },
 	};
 
 	parse_harness(encoded, ARRAY_SIZE(encoded));

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -51,7 +51,7 @@ static const struct json_obj_descr nested_descr[] = {
 static const struct json_obj_descr test_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_string, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null, JSON_TOK_NULL),
-	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null_string, JSON_TOK_STRING)
+	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null_string, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_int, JSON_TOK_NUMBER),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_bool, JSON_TOK_TRUE),
 	JSON_OBJ_DESCR_OBJECT(struct test_struct, some_nested_struct,
@@ -103,8 +103,8 @@ static void test_json_encoding(void)
 {
 	struct test_struct ts = {
 		.some_string = "zephyr 123\uABCD",
-		.some_null = nullptr,
-		.some_null_string = nullptr;
+		.some_null = NULL,
+		.some_null_string = NULL;
 		.some_int = 42,
 		.some_bool = true,
 		.some_nested_struct = {
@@ -195,8 +195,8 @@ static void test_json_decoding(void)
 
 	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
 		    "String decoded correctly");
-	zassert_equal(ts.some_null, nullptr, "Null value decoded correctly");
-	zassert_equal(ts.some_null_string, nullptr, "Null string decoded correctly");
+	zassert_equal(ts.some_null, NULL, "Null value decoded correctly");
+	zassert_equal(ts.some_null_string, NULL, "Null string decoded correctly");
 	zassert_equal(ts.some_int, 42, "Positive integer decoded correctly");
 	zassert_equal(ts.some_bool, true, "Boolean decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_int, -1234,

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -104,7 +104,7 @@ static void test_json_encoding(void)
 	struct test_struct ts = {
 		.some_string = "zephyr 123\uABCD",
 		.some_null = NULL,
-		.some_null_string = NULL;
+		.some_null_string = NULL,
 		.some_int = 42,
 		.some_bool = true,
 		.some_nested_struct = {

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -18,7 +18,6 @@ struct test_nested {
 struct test_struct {
 	const char *some_string;
 	const char *some_null;
-	const char *some_null_string;
 	int some_int;
 	bool some_bool;
 	struct test_nested some_nested_struct;
@@ -51,7 +50,6 @@ static const struct json_obj_descr nested_descr[] = {
 static const struct json_obj_descr test_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_string, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null, JSON_TOK_NULL),
-	JSON_OBJ_DESCR_PRIM(struct test_struct, some_null_string, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_int, JSON_TOK_NUMBER),
 	JSON_OBJ_DESCR_PRIM(struct test_struct, some_bool, JSON_TOK_TRUE),
 	JSON_OBJ_DESCR_OBJECT(struct test_struct, some_nested_struct,
@@ -104,7 +102,6 @@ static void test_json_encoding(void)
 	struct test_struct ts = {
 		.some_string = "zephyr 123\uABCD",
 		.some_null = NULL,
-		.some_null_string = NULL,
 		.some_int = 42,
 		.some_bool = true,
 		.some_nested_struct = {
@@ -133,7 +130,6 @@ static void test_json_encoding(void)
 	};
 	char encoded[] = "{\"some_string\":\"zephyr 123\uABCD\","
 		"\"some_null\":null,"
-		"\"some_null_string\":null,"
 		"\"some_int\":42,\"some_bool\":true,"
 		"\"some_nested_struct\":{\"nested_int\":-1234,"
 		"\"nested_bool\":false,\"nested_string\":"
@@ -166,7 +162,6 @@ static void test_json_decoding(void)
 	struct test_struct ts;
 	char encoded[] = "{\"some_string\":\"zephyr 123\\uABCD456\","
 		"\"some_null\":null,"
-		"\"some_null_string\":null,"
 		"\"some_int\":\t42\n,"
 		"\"some_bool\":true    \t  "
 		"\n"
@@ -196,7 +191,6 @@ static void test_json_decoding(void)
 	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
 		    "String decoded correctly");
 	zassert_equal(ts.some_null, NULL, "Null value decoded correctly");
-	zassert_equal(ts.some_null_string, NULL, "Null string decoded correctly");
 	zassert_equal(ts.some_int, 42, "Positive integer decoded correctly");
 	zassert_equal(ts.some_bool, true, "Boolean decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_int, -1234,
@@ -394,7 +388,6 @@ static void test_json_invalid_null(void)
 		{ "{\"some_bool\":nutella}", -EINVAL},
 		{ "{\"some_array\":nutella}", -EINVAL},
 		{ "{\"some_nested_struct\":nutella}", -EINVAL},
-		{ "{\"some_null_string\":nutella}", -EINVAL},
 		/* Expecting null for non-null value */
 		{ "{\"some_null\":\"hello\"}", -EINVAL },
 		{ "{\"some_null\":nutella}", -EINVAL },


### PR DESCRIPTION
Accept (by skipping) null values in JSON parser instead of stopping the parser and returning an error. 

Signed-off-by: Eric Brinette <eric.brinette@gmail.com>