### PR TITLE
doc: guides: board porting: Fix mispelled board name

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -55,7 +55,7 @@ not always used.
      - NXP Kinetis
      - Arm Cortex-M4
      - Arm
-   * - :ref:`stm32h474i_disco <stm32h747i_disco_board>`
+   * - :ref:`stm32h747i_disco <stm32h747i_disco_board>`
      - STM32H747XI
      - STM32H7
      - STMicro STM32


### PR DESCRIPTION
Fix mispelled "stm32h747i_disco" board name in board_porting.rst.

Signed-off-by: Yaël Boutreux <yael.boutreux@gmail.com>