### PR TITLE
drivers/sensor: ms5607: Add I2C support

### DIFF
--- a/drivers/sensor/ms5607/CMakeLists.txt
+++ b/drivers/sensor/ms5607/CMakeLists.txt
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607.c)
+zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607_spi.c)

--- a/drivers/sensor/ms5607/Kconfig
+++ b/drivers/sensor/ms5607/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig MS5607
 	bool "MS5607 pressure and temperature sensor"
-	depends on SPI
+	depends on I2C || SPI
 	help
 	  Enable driver for MS5607 pressure and temperature sensor.
 

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -325,17 +325,30 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 	{								\
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
 		.tf = &ms5607_spi_transfer_function,			\
-		.spi_cfg =						\
+		.bus_cfg.spi_cfg =					\
 			SPI_CONFIG_DT_INST(inst,			\
 					   MS5607_SPI_OPERATION,	\
 					   0),				\
 	}
 
-/* Main instantiation macro */
+/* Initializes a struct ms5607_config for an instance on a I2C bus. */
+#define MS5607_CONFIG_I2C(inst)						\
+	{								\
+		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
+		.tf = &ms5607_i2c_transfer_function,			\
+		.bus_cfg.i2c_addr = DT_INST_REG_ADDR(inst)		\
+	}
+
+/*
+ * Main instantiation macro, which selects the correct bus-specific
+ * instantiation macros for the instance.
+ */
 #define MS5607_DEFINE(inst)						\
 	static struct ms5607_data ms5607_data_##inst;			\
 	static const struct ms5607_config ms5607_config_##inst =	\
-				MS5607_CONFIG_SPI(inst);		\
+		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
+			    (MS5607_CONFIG_SPI(inst)),			\
+			    (MS5607_CONFIG_I2C(inst)));			\
 	DEVICE_DT_INST_DEFINE(inst,					\
 			ms5607_init,					\
 			NULL,						\

--- a/drivers/sensor/ms5607/ms5607.h
+++ b/drivers/sensor/ms5607/ms5607.h
@@ -10,6 +10,9 @@
 #include <zephyr/types.h>
 #include <device.h>
 
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#include <drivers/i2c.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <drivers/spi.h>
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
@@ -76,19 +79,25 @@ struct ms5607_transfer_function {
 	int (*read_adc)(const struct ms5607_config *cfg, uint32_t *val);
 };
 
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+extern const struct ms5607_transfer_function ms5607_i2c_transfer_function;
+#endif
+
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 extern const struct ms5607_transfer_function ms5607_spi_transfer_function;
-#else
-/* I2c Interface not implemented yet */
-BUILD_ASSERT(1, "I2c interface not implemented yet");
 #endif
 
 struct ms5607_config {
 	const struct device *bus;
 	const struct ms5607_transfer_function *tf;
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-	struct spi_config spi_cfg;
+	union {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+		uint16_t i2c_addr;
 #endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+		struct spi_config spi_cfg;
+#endif
+	} bus_cfg;
 };
 
 struct ms5607_data {

--- a/drivers/sensor/ms5607/ms5607_i2c.c
+++ b/drivers/sensor/ms5607/ms5607_i2c.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Aurelien Jarno <aurelien@aurel32.net>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT meas_ms5607
+
+#include <string.h>
+#include <drivers/i2c.h>
+#include <sys/byteorder.h>
+#include "ms5607.h"
+
+#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_DECLARE(ms5607);
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+static int ms5607_i2c_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
+{
+	return i2c_write(config->bus, &cmd, 1, config->bus_cfg.i2c_addr);
+}
+
+static int ms5607_i2c_reset(const struct ms5607_config *config)
+{
+	int err = ms5607_i2c_raw_cmd(config, MS5607_CMD_RESET);
+
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+static int ms5607_i2c_read_prom(const struct ms5607_config *config, uint8_t cmd,
+				uint16_t *val)
+{
+	uint8_t valb[2];
+	int err;
+
+	err = i2c_burst_read(config->bus, config->bus_cfg.i2c_addr, cmd, valb, sizeof(valb));
+	if (err < 0) {
+		return err;
+	}
+
+	*val = sys_get_be16(valb);
+
+	return 0;
+}
+
+
+static int ms5607_i2c_start_conversion(const struct ms5607_config *config, uint8_t cmd)
+{
+	return ms5607_i2c_raw_cmd(config, cmd);
+}
+
+static int ms5607_i2c_read_adc(const struct ms5607_config *config, uint32_t *val)
+{
+	int err;
+	uint8_t valb[3];
+
+	err = i2c_burst_read(config->bus, config->bus_cfg.i2c_addr,
+			     MS5607_CMD_CONV_READ_ADC, valb, sizeof(valb));
+	if (err < 0) {
+		return err;
+	}
+
+	*val = (valb[0] << 16) + (valb[1] << 8) + valb[2];
+
+	return 0;
+}
+
+
+static int ms5607_i2c_check(const struct ms5607_config *config)
+{
+	if (!device_is_ready(config->bus)) {
+		LOG_DBG("I2C bus %s not ready", config->bus->name);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+const struct ms5607_transfer_function ms5607_i2c_transfer_function = {
+	.bus_check = ms5607_i2c_check,
+	.reset = ms5607_i2c_reset,
+	.read_prom = ms5607_i2c_read_prom,
+	.start_conversion = ms5607_i2c_start_conversion,
+	.read_adc = ms5607_i2c_read_adc,
+};
+
+#endif

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -29,7 +29,7 @@ static int ms5607_spi_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
 		.count = 1,
 	};
 
-	return spi_write(config->bus, &config->spi_cfg, &buf_set);
+	return spi_write(config->bus, &config->bus_cfg.spi_cfg, &buf_set);
 }
 
 static int ms5607_spi_reset(const struct ms5607_config *config)
@@ -80,7 +80,7 @@ static int ms5607_spi_read_prom(const struct ms5607_config *config, uint8_t cmd,
 	};
 
 	err = spi_transceive(config->bus,
-			     &config->spi_cfg,
+			     &config->bus_cfg.spi_cfg,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -131,7 +131,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 	};
 
 	err = spi_transceive(config->bus,
-			     &config->spi_cfg,
+			     &config->bus_cfg.spi_cfg,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -145,7 +145,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
-	const struct spi_cs_control *cs = config->spi_cfg.cs;
+	const struct spi_cs_control *cs = config->bus_cfg.spi_cfg.cs;
 
 	if (!device_is_ready(config->bus)) {
 		LOG_DBG("SPI bus %s not ready", config->bus->name);

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -17,23 +17,7 @@ LOG_MODULE_DECLARE(ms5607);
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-static struct spi_cs_control ms5607_cs_ctrl;
-#endif
-
-#define SPI_CS NULL
-
-static struct spi_config ms5607_spi_conf = {
-	.frequency = DT_INST_PROP(0, spi_max_frequency),
-	.operation = (SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |
-		      SPI_MODE_CPOL | SPI_MODE_CPHA |
-		      SPI_TRANSFER_MSB |
-		      SPI_LINES_SINGLE),
-	.slave = DT_INST_REG_ADDR(0),
-	.cs = SPI_CS,
-};
-
-static int ms5607_spi_raw_cmd(const struct ms5607_data *data, uint8_t cmd)
+static int ms5607_spi_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
 {
 	const struct spi_buf buf = {
 		.buf = &cmd,
@@ -45,12 +29,12 @@ static int ms5607_spi_raw_cmd(const struct ms5607_data *data, uint8_t cmd)
 		.count = 1,
 	};
 
-	return spi_write(data->ms5607_device, &ms5607_spi_conf, &buf_set);
+	return spi_write(config->bus, &config->spi_cfg, &buf_set);
 }
 
-static int ms5607_spi_reset(const struct ms5607_data *data)
+static int ms5607_spi_reset(const struct ms5607_config *config)
 {
-	int err = ms5607_spi_raw_cmd(data, MS5607_CMD_RESET);
+	int err = ms5607_spi_raw_cmd(config, MS5607_CMD_RESET);
 
 	if (err < 0) {
 		return err;
@@ -60,7 +44,7 @@ static int ms5607_spi_reset(const struct ms5607_data *data)
 	return 0;
 }
 
-static int ms5607_spi_read_prom(const struct ms5607_data *data, uint8_t cmd,
+static int ms5607_spi_read_prom(const struct ms5607_config *config, uint8_t cmd,
 				uint16_t *val)
 {
 	int err;
@@ -95,8 +79,8 @@ static int ms5607_spi_read_prom(const struct ms5607_data *data, uint8_t cmd,
 		.count = 1,
 	};
 
-	err = spi_transceive(data->ms5607_device,
-			     &ms5607_spi_conf,
+	err = spi_transceive(config->bus,
+			     &config->spi_cfg,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -109,12 +93,12 @@ static int ms5607_spi_read_prom(const struct ms5607_data *data, uint8_t cmd,
 }
 
 
-static int ms5607_spi_start_conversion(const struct ms5607_data *data, uint8_t cmd)
+static int ms5607_spi_start_conversion(const struct ms5607_config *config, uint8_t cmd)
 {
-	return ms5607_spi_raw_cmd(data, cmd);
+	return ms5607_spi_raw_cmd(config, cmd);
 }
 
-static int ms5607_spi_read_adc(const struct ms5607_data *data, uint32_t *val)
+static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val)
 {
 	int err;
 
@@ -146,8 +130,8 @@ static int ms5607_spi_read_adc(const struct ms5607_data *data, uint32_t *val)
 		.count = 1,
 	};
 
-	err = spi_transceive(data->ms5607_device,
-			     &ms5607_spi_conf,
+	err = spi_transceive(config->bus,
+			     &config->spi_cfg,
 			     &tx_buf_set,
 			     &rx_buf_set);
 	if (err < 0) {
@@ -159,38 +143,32 @@ static int ms5607_spi_read_adc(const struct ms5607_data *data, uint32_t *val)
 	return 0;
 }
 
-static const struct ms5607_transfer_function ms5607_spi_transfer_function = {
+static int ms5607_spi_check(const struct ms5607_config *config)
+{
+	const struct spi_cs_control *cs = config->spi_cfg.cs;
+
+	if (!device_is_ready(config->bus)) {
+		LOG_DBG("SPI bus %s not ready", config->bus->name);
+		return -ENODEV;
+	}
+
+	if (cs) {
+		if (!device_is_ready(cs->gpio_dev)) {
+			LOG_DBG("SPI CS GPIO controller %s not ready", cs->gpio_dev->name);
+			return -ENODEV;
+		}
+		LOG_DBG("SPI GPIO CS configured on %s:%u", cs->gpio_dev->name, cs->gpio_pin);
+	}
+
+	return 0;
+}
+
+const struct ms5607_transfer_function ms5607_spi_transfer_function = {
+	.bus_check = ms5607_spi_check,
 	.reset = ms5607_spi_reset,
 	.read_prom = ms5607_spi_read_prom,
 	.start_conversion = ms5607_spi_start_conversion,
 	.read_adc = ms5607_spi_read_adc,
 };
-
-int ms5607_spi_init(const struct device *dev)
-{
-	struct ms5607_data *data = dev->data;
-
-	data->tf = &ms5607_spi_transfer_function;
-
-#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
-	ms5607_cs_ctrl.gpio_dev = device_get_binding(
-		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
-	if (!ms5607_cs_ctrl.gpio_dev) {
-		LOG_ERR("Unable to get GPIO SPI CS device");
-		return -ENODEV;
-	}
-
-	ms5607_cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
-	ms5607_cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
-	ms5607_cs_ctrl.delay = 0U;
-
-	ms5607_spi_conf.cs = &ms5607_cs_ctrl;
-
-	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-		DT_INST_SPI_DEV_CS_GPIOS_PIN(0));
-#endif
-	return 0;
-}
 
 #endif

--- a/dts/bindings/sensor/meas,ms5607-i2c.yaml
+++ b/dts/bindings/sensor/meas,ms5607-i2c.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2021, Aurelien Jarno <aurel32@aurel32.net>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    TE Connectivity MS5607 digital pressure and temperature sensor.
+    The Datasheet is at https://www.te.com/usa-en/product-CAT-BLPS0035.html
+
+compatible: "meas,ms5607"
+
+include: i2c-device.yaml

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -174,6 +174,12 @@ test_i2c_max44009: max44009@19 {
 	int-gpios = <&test_gpio 0 0>;
 };
 
+test_i2c_ms5607: ms5607@76 {
+	compatible = "meas,ms5607";
+	label = "MS5607";
+	reg = <0x76>;
+};
+
 test_i2c_ms5837: ms5837@1a {
 	compatible = "meas,ms5837";
 	label = "MS5837";


### PR DESCRIPTION
This patchset adds I2C support to the MS5607 driver. For that it first adds multi-instance support to the driver. 