### PR TITLE
Bluetooth: Controller: Fix ticker ops count for extended initiator

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -255,8 +255,18 @@
  *       ULL_HIGH operations queue elements are required to buffer the
  *       requested ticker operations.
  */
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_ADV_EXT) && \
+	defined(CONFIG_BT_CTLR_PHY_CODED)
+#define TICKER_USER_ULL_HIGH_OPS (4 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
+				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
+#else /* !CONFIG_BT_CENTRAL || !CONFIG_BT_CTLR_ADV_EXT ||
+       * !CONFIG_BT_CTLR_PHY_CODED
+       */
 #define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
 				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
+#endif /* !CONFIG_BT_CENTRAL || !CONFIG_BT_CTLR_ADV_EXT ||
+	* !CONFIG_BT_CTLR_PHY_CODED
+	*/
 
 #define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
 


### PR DESCRIPTION
Increase the ticker operations count in ULL high context
when Extended Advertising Connection Establishment on Coded
PHY is supported.

This fixes assertion in Controller when initiating a
connection on Coded PHY, wherein two scan instance ticker,
one window stop ticker, and a new connection instance
ticker operations needs to be enqueued.

Relates to commit a6b8eba7c574 ("Bluetooth: controller:
Implement disabling the other PHY initiator").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>