### PR TITLE
doc: Encourage users to pre-analyze regressions

### DIFF
--- a/doc/development_process/issues.rst
+++ b/doc/development_process/issues.rst
@@ -12,3 +12,25 @@ identifiers.
 
 At any time it should be possible to establish the origin of a change and the
 reason behind it by following the references in the code.
+
+Reporting a regression issue
+****************************
+
+It could happen that the issue being reported is identified as a regression,
+as the use case is known to be working on earlier commit or release.
+In this case, providing directly the guilty commit when submitting the bug
+gains a lot of time in the eventual bug fixing.
+
+To identify the commit causing the regression, several methods could be used,
+but tree bisecting method is an efficient one that doesn't require deep code
+expertise and can be used by every one.
+
+For this, `git bisect`_ is the recommended tool.
+
+Recommendations on the process:
+
+* Run ``west update`` on each bisection step.
+* Once the bisection is over and a culprit identifed, verify manually the result.
+
+.. _git bisect:
+   https://git-scm.com/docs/git-bisect


### PR DESCRIPTION
Add a paragraph to mention git bisect as a way to pre-analyze
regressions.
Aim is to reference this section from github issues when regressions
are reported and encourage users to do this first round of
pre-analyzis

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>