### PR TITLE
Bluetooth: Controller: Cleanup mutual exclusion in CPR implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -35,4 +35,3 @@ memq_link_t *ull_conn_ack_by_last_peek(uint8_t last, uint16_t *handle,
 void *ull_conn_ack_dequeue(void);
 void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx);
 uint8_t ull_conn_llcp_req(void *conn);
-void ull_conn_upd_curr_reset(void);


### PR DESCRIPTION
Minor cleanup of the implementation of mutual exclusion
of LE Connection Parameter Request amongst active
connections.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>