### PR TITLE
include: posix: time: define __useconds_t_defined

### DIFF
--- a/include/posix/posix_types.h
+++ b/include/posix/posix_types.h
@@ -19,6 +19,7 @@ extern "C" {
 
 #ifndef __useconds_t_defined
 typedef unsigned long useconds_t;
+#define __useconds_t_defined
 #endif
 
 /* time related attributes */


### PR DESCRIPTION
Define __useconds_t_defined to avoid build errors when host toolchain is
used.