### PR TITLE
Bluetooth: Host: Modify check for read buffer size v2

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2778,6 +2778,45 @@ static int le_set_event_mask(void)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EVENT_MASK, buf, NULL);
 }
 
+#if defined(CONFIG_BT_CONN)
+static int le_init_iso(void)
+{
+	int err;
+	struct net_buf *rsp;
+
+	/* Set Isochronus Channels - Host support */
+	err = le_set_host_feature(BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
+	if (err) {
+		return err;
+	}
+
+	/* Octet 41, bit 5 is read buffer size V2 */
+	if (BT_CMD_TEST(bt_dev.supported_commands, 41, 5)) {
+		/* Read ISO Buffer Size V2 */
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE_V2,
+					   NULL, &rsp);
+		if (err) {
+			return err;
+		}
+		read_buffer_size_v2_complete(rsp);
+	} else {
+		BT_WARN("Read Buffer Size V2 command is not supported."
+			"No ISO buffers will be available");
+
+		/* Read LE Buffer Size */
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE,
+					   NULL, &rsp);
+		if (err) {
+			return err;
+		}
+		le_read_buffer_size_complete(rsp);
+	}
+
+	net_buf_unref(rsp);
+	return 0;
+}
+#endif /* CONFIG_BT_CONN */
+
 static int le_init(void)
 {
 	struct bt_hci_cp_write_le_host_supp *cp_le;
@@ -2803,19 +2842,10 @@ static int le_init(void)
 #if defined(CONFIG_BT_CONN)
 	if (IS_ENABLED(CONFIG_BT_ISO) &&
 	    BT_FEAT_LE_ISO(bt_dev.le.features)) {
-		/* Set Isochronus Channels - Host support */
-		err = le_set_host_feature(BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
+		err = le_init_iso();
 		if (err) {
 			return err;
 		}
-		/* Read ISO Buffer Size V2 */
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE_V2,
-					   NULL, &rsp);
-		if (err) {
-			return err;
-		}
-		read_buffer_size_v2_complete(rsp);
-		net_buf_unref(rsp);
 	} else {
 		/* Read LE Buffer Size */
 		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE,


### PR DESCRIPTION
Modify the check from checking the feature bit to
checking the command bit. This ensures that we
don't send the read buffer size V2 to a controller
that does not support it.

This also moves the entire ISO init procedure into
a separate function to avoid having a large
ISO-only block in `le_init`.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>