### PR TITLE
soc: nordic_nrf: Add HAS_HW_NRF_KMU config

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -69,6 +69,9 @@ config HAS_HW_NRF_I2S
 config HAS_HW_NRF_IPC
 	bool
 
+config HAS_HW_NRF_KMU
+	bool
+
 config HAS_HW_NRF_LPCOMP
 	bool
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -23,6 +23,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_IPC
+	select HAS_HW_NRF_KMU
 	select HAS_HW_NRF_NFCT
 	select HAS_HW_NRF_NVMC_PE
 	select HAS_HW_NRF_PDM

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -19,6 +19,7 @@ config SOC_NRF9160
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_I2S
 	select HAS_HW_NRF_IPC
+	select HAS_HW_NRF_KMU
 	select HAS_HW_NRF_NVMC_PE
 	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER


### PR DESCRIPTION
Indicating whether a SOC has the nRF Key Management Unit peripheral.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>