### PR TITLE
samples: drivers: eeprom: remove needless null pointer check

### DIFF
--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -24,11 +24,6 @@ static const struct device *get_eeprom_device(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(eeprom_0));
 
-	if (dev == NULL) {
-		printk("\nError: EEPROM with alias eeprom_0 not found.\n");
-		return NULL;
-	}
-
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "
 		       "check the driver initialization logs for errors.\n",


### PR DESCRIPTION
This PR removes a superfluous null pointer check.
The device is accessed via a label. so in case it is not available a build error arises, but the pointer won't ever be null.

closes #36305