### PR TITLE
Lwm2m : Handle notify timeout

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -87,6 +87,11 @@ config LWM2M_ENGINE_MAX_OBSERVER
 	  This value sets the maximum number of resources which can be
 	  added to the observe notification list.
 
+config LWM2M_ENGINE_NOTIFICATION_TIMEOUT_REGISTRATION_UPDATE
+	bool "Enable Registration Update when Notification Timeout Occurs"
+	help
+	  Automatically trigger a Registration Update when Notification Timeout Occurs
+
 config LWM2M_CANCEL_OBSERVE_BY_PATH
 	bool "Use path matching as fallback for cancel-observe"
 	help

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -139,7 +139,7 @@ static struct lwm2m_engine_obj_inst *get_engine_obj_inst(int obj_id,
 							 int obj_inst_id);
 
 /* function pointer to indicate notification timeout to the application */
-static ext_notify_timeout_cb_t ext_notify_timeout_cb = NULL;
+static ext_notify_timeout_cb_t ext_notify_timeout_cb;
 
 /* Shared set of in-flight LwM2M messages */
 static struct lwm2m_message messages[CONFIG_LWM2M_ENGINE_MAX_MESSAGES];
@@ -4252,14 +4252,13 @@ static int32_t retransmit_request(struct lwm2m_ctx *client_ctx,
 
 static void notify_message_timeout_cb(struct lwm2m_message *msg)
 {
-	if (ext_notify_timeout_cb != NULL)
-	{
+	if (ext_notify_timeout_cb != NULL){
 		ext_notify_timeout_cb(msg);
 	}
 #if defined(CONFIG_LWM2M_ENGINE_NOTIFICATION_TIMEOUT_REGISTRATION_UPDATE)
 	engine_trigger_update(false);
 #endif
-	LOG_ERR("Notify Message Timed Out : %p",msg);
+	LOG_ERR("Notify Message Timed Out : %p", msg);
 }
 
 static int notify_message_reply_cb(const struct coap_packet *response,

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -138,6 +138,9 @@ static struct lwm2m_engine_obj *get_engine_obj(int obj_id);
 static struct lwm2m_engine_obj_inst *get_engine_obj_inst(int obj_id,
 							 int obj_inst_id);
 
+/* function pointer to indicate notification timeout to the application */
+static ext_notify_timeout_cb_t ext_notify_timeout_cb = NULL;
+
 /* Shared set of in-flight LwM2M messages */
 static struct lwm2m_message messages[CONFIG_LWM2M_ENGINE_MAX_MESSAGES];
 
@@ -4247,6 +4250,18 @@ static int32_t retransmit_request(struct lwm2m_ctx *client_ctx,
 	return next_retransmission;
 }
 
+static void notify_message_timeout_cb(struct lwm2m_message *msg)
+{
+	if (ext_notify_timeout_cb != NULL)
+	{
+		ext_notify_timeout_cb(msg);
+	}
+#if defined(CONFIG_LWM2M_ENGINE_NOTIFICATION_TIMEOUT_REGISTRATION_UPDATE)
+	engine_trigger_update(false);
+#endif
+	LOG_ERR("Notify Message Timed Out : %p",msg);
+}
+
 static int notify_message_reply_cb(const struct coap_packet *response,
 				   struct coap_reply *reply,
 				   const struct sockaddr *from)
@@ -4324,6 +4339,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 	msg->token = obs->token;
 	msg->tkl = obs->tkl;
 	msg->reply_cb = notify_message_reply_cb;
+	msg->message_timeout_cb = notify_message_timeout_cb;
 	msg->out.out_cpkt = &msg->cpkt;
 
 	ret = lwm2m_init_message(msg);
@@ -4946,6 +4962,11 @@ static int lwm2m_engine_init(const struct device *dev)
 	LOG_DBG("LWM2M engine socket receive thread started");
 
 	return 0;
+}
+
+void lwm2m_engine_set_ext_notify_timeout_cb_fn(ext_notify_timeout_cb_t fnPtr)
+{
+	ext_notify_timeout_cb = fnPtr;
 }
 
 SYS_INIT(lwm2m_engine_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -53,7 +53,7 @@
 /* Establish a request handler callback type */
 typedef int (*udp_request_handler_cb_t)(struct coap_packet *request,
 					struct lwm2m_message *msg);
-					
+
 /* Function Prototype definition for external notification timeout callback function */
 typedef void (*ext_notify_timeout_cb_t)(struct lwm2m_message *msg);
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -53,6 +53,12 @@
 /* Establish a request handler callback type */
 typedef int (*udp_request_handler_cb_t)(struct coap_packet *request,
 					struct lwm2m_message *msg);
+					
+/* Function Prototype definition for external notification timeout callback function */
+typedef void (*ext_notify_timeout_cb_t)(struct lwm2m_message *msg);
+
+/* Function to assign the function pointer for external notification */
+void lwm2m_engine_set_ext_notify_timeout_cb_fn(ext_notify_timeout_cb_t fnPtr);
 
 char *lwm2m_sprint_ip_addr(const struct sockaddr *addr);
 


### PR DESCRIPTION
Added new Kconfig option LWM2M_ENGINE_NOTIFICATION_TIMEOUT_REGISTRATION_UPDATE to enable automatically trigger registration update when notify timeout occurs

Added capability to indicate to the application that a notify timeout has occurred via ext_notify_timeout_cb and lwm2m_engine_set_ext_notify_timeout_cb_fn which sets this callback function

Added Error message when notify timeout occurs