### PR TITLE
drivers: serial: nrfx: Add pullups to RXD and CTS

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -996,7 +996,7 @@ static int uart_nrfx_init(const struct device *dev)
 	nrf_gpio_cfg_output(TX_PIN);
 
 	if (RX_PIN_USED) {
-		nrf_gpio_cfg_input(RX_PIN, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(RX_PIN, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uart_txrx_pins_set(uart0_addr, TX_PIN, RX_PIN);
@@ -1010,7 +1010,7 @@ static int uart_nrfx_init(const struct device *dev)
 	}
 
 	if (HAS_PROP(cts_pin)) {
-		nrf_gpio_cfg_input(CTS_PIN, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(CTS_PIN, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uart_hwfc_pins_set(uart0_addr, RTS_PIN, CTS_PIN);
@@ -1113,7 +1113,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 		nrf_gpio_pin_write(tx_pin, 1);
 		nrf_gpio_cfg_output(tx_pin);
 		if (RX_PIN_USED) {
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_PULLUP);
 		}
 
 		if (HAS_PROP(rts_pin)) {
@@ -1121,8 +1121,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 			nrf_gpio_cfg_output(rts_pin);
 		}
 		if (HAS_PROP(cts_pin)) {
-			nrf_gpio_cfg_input(cts_pin,
-					   NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(cts_pin, NRF_GPIO_PIN_PULLUP);
 		}
 	} else {
 		nrf_gpio_cfg_default(tx_pin);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1664,13 +1664,13 @@ static int uarte_instance_init(const struct device *dev,
 	nrf_gpio_cfg_output(config->pseltxd);
 
 	if (config->pselrxd !=  NRF_UARTE_PSEL_DISCONNECTED) {
-		nrf_gpio_cfg_input(config->pselrxd, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(config->pselrxd, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uarte_txrx_pins_set(uarte, config->pseltxd, config->pselrxd);
 
 	if (config->pselcts != NRF_UARTE_PSEL_DISCONNECTED) {
-		nrf_gpio_cfg_input(config->pselcts, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(config->pselcts, NRF_GPIO_PIN_PULLUP);
 	}
 
 	if (config->pselrts != NRF_UARTE_PSEL_DISCONNECTED) {
@@ -1757,7 +1757,7 @@ static void uarte_nrfx_pins_enable(const struct device *dev, bool enable)
 		nrf_gpio_pin_write(tx_pin, 1);
 		nrf_gpio_cfg_output(tx_pin);
 		if (rx_pin != NRF_UARTE_PSEL_DISCONNECTED) {
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_PULLUP);
 		}
 
 		if (IS_RTS_PIN_SET(get_dev_config(dev)->flags)) {
@@ -1767,7 +1767,7 @@ static void uarte_nrfx_pins_enable(const struct device *dev, bool enable)
 
 		if (IS_CTS_PIN_SET(get_dev_config(dev)->flags)) {
 			nrf_gpio_cfg_input(cts_pin,
-					   NRF_GPIO_PIN_NOPULL);
+					   NRF_GPIO_PIN_PULLUP);
 		}
 	} else {
 		nrf_gpio_cfg_default(tx_pin);


### PR DESCRIPTION
Configured UART/UARTE input pins to have pullups. Otherwise when
uart is disconnected pins are floating and generate receiver
errors.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>