### PR TITLE
Tracing: TraceRecorder CMake update

### DIFF
--- a/modules/TraceRecorder/CMakeLists.txt
+++ b/modules/TraceRecorder/CMakeLists.txt
@@ -10,17 +10,28 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
   zephyr_library_sources_ifdef(
     CONFIG_PERCEPIO_TRACERECORDER
     ${TRACERECORDER_DIR}/kernelports/Zephyr/trcKernelPort.c
+    ${TRACERECORDER_DIR}/trcInternalBuffer.c
     ${TRACERECORDER_DIR}/trcStreamingRecorder.c
     ${TRACERECORDER_DIR}/extras/SDK/trcSDK.c
     )
 
   if(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT)
     zephyr_library_sources(
-      ${TRACERECORDER_DIR}/streamports/Jlink_RTT/trcStreamingPort.c
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Jlink_RTT/trcStreamingPort.c
     )
 
     zephyr_include_directories(
-      ${TRACERECORDER_DIR}/streamports/Jlink_RTT/include/
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Jlink_RTT/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_ITM)
+    zephyr_library_sources(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/ARM_ITM/trcStreamingPort.c
+    )
+
+    zephyr_include_directories(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/ARM_ITM/include/
     )
   endif()
 

--- a/west.yml
+++ b/west.yml
@@ -134,7 +134,7 @@ manifest:
       revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
     - name: TraceRecorderSource
       path: modules/debug/TraceRecorder
-      revision: d9889883abb4657d71e15ff055517a9b032f8212
+      revision: 5b5f8d7adbf0e93a09087e8f5708f0eebb8b25bf
     - name: hal_xtensa
       revision: 2f04b615cd5ad3a1b8abef33f9bdd10cc1990ed6
       path: modules/hal/xtensa


### PR DESCRIPTION
- Fixed some incorrect streamport references that pointed to the
base streamport files instead of those dedicated for Zephyr.
- Updated the source file compilation to match the updated
TraceRecorder module.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
