### PR TITLE
boards: arm: bbc_microbit: add CMakeLists

### DIFF
--- a/boards/arm/bbc_microbit/CMakeLists.txt
+++ b/boards/arm/bbc_microbit/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Peter Niebert <peter.niebert@univ-amu.fr>
+# SPDX-License-Identifier: Apache-2.0
+
+# add access to board.h
+zephyr_include_directories(.)

--- a/samples/boards/bbc_microbit/pong/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/pong/CMakeLists.txt
@@ -7,4 +7,3 @@ project(pong)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(${ZEPHYR_BASE}/boards/arm/bbc_microbit)

--- a/samples/boards/bbc_microbit/sound/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/sound/CMakeLists.txt
@@ -7,4 +7,3 @@ project(sound)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(${ZEPHYR_BASE}/boards/arm/bbc_microbit)


### PR DESCRIPTION
As some other boards, there is a "board.h" file with pin definitions
in the directory zephyr/boards/arm/bbc_microbit. In order to read it,
CMakeLists have been modified for each application. Adding a
CMakeLists.txt in the board directory makes this process more
transparent and will allow (after adding the same mechanism) allow
to use the same samples for both BBC micro:bit V1 and V2.

Signed-off-by: Peter Niebert <peter.niebert@univ-amu.fr>