### PR TITLE
mailmap: update mailmap file with some stray emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -30,3 +30,6 @@ Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
 Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
 Sean Nyekjaer <sean@geanix.com> <sean.nyekjaer@prevas.dk>
 Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>
+Marc Herbert <marc.herbert@intel.com> <46978960+marc-hb@users.noreply.github.com>
+Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.com>
+Armand Ciejak <armand@riedonetworks.com>  <armandciejak@users.noreply.github.com>


### PR DESCRIPTION
Update to fix shortlog showing the right authors for commits that used
the wrong emails.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
