### PR TITLE
st_ble_sensor sample gets LSE clock when compiled for nucleo_wb55rg

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -12,6 +12,7 @@
 #include <bluetooth/hci.h>
 #include <drivers/bluetooth/hci_driver.h>
 #include "bluetooth/addr.h"
+#include <drivers/clock_control/stm32_clock_control.h>
 
 #include "app_conf.h"
 #include "stm32_wpan_common.h"


### PR DESCRIPTION
The drivers: bluetooth: hci driver for stm32wb includes clock control

The definition of the STM32_LSE_CLOCK is given by the
drivers/clock_control/stm32_clock_control.h
to the hci/ipm_stm32wb driver

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/36344

Signed-off-by: Francois Ramu <francois.ramu@st.com>