### PR TITLE
MAINTAINER: fix typo

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -272,7 +272,7 @@ CMSIS API layer:
         - "area: Portability"
 
 CMSIS-DSP integration:
-    status: maintainer
+    status: maintained
     maintainers:
         - stephanosio
     collaborators:


### PR DESCRIPTION
Fixed typo in status of area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
