### PR TITLE
hal: esp32: driver changes to allow HAL update

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -96,7 +96,7 @@ int configure_read_mode(spi_dev_t *hw,
 	if (!byte_cmd) {
 		REG_SET_FIELD(PERIPHS_SPI_FLASH_USRREG2, SPI_USR_COMMAND_VALUE, cmd);
 	} else {
-		spi_flash_ll_set_command8(hw, (uint8_t) cmd);
+		spi_flash_ll_set_command(hw, (uint8_t) cmd, 8);
 	}
 
 	return 0;
@@ -330,7 +330,7 @@ static int wait_idle(const struct device *dev)
 	int64_t timeout = k_uptime_get() + SPI_TIMEOUT_MSEC;
 
 	/* wait for spi control ready */
-	while (host_idle(cfg->controller)) {
+	while (!host_idle(cfg->controller)) {
 		if (k_uptime_get() > timeout) {
 			return -ETIMEDOUT;
 		}

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -13,6 +13,7 @@
 #include <esp32/rom/gpio.h>
 
 #include <soc/gpio_sig_map.h>
+#include <soc/uart_reg.h>
 
 #include <device.h>
 #include <soc.h>

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -59,18 +59,20 @@ static int IRAM_ATTR spi_esp32_transfer(const struct device *dev)
 	struct spi_esp32_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	spi_hal_context_t *hal = &data->hal;
+	spi_hal_dev_config_t *hal_dev = &data->dev_config;
+	spi_hal_trans_config_t *hal_trans = &data->trans_config;
 	size_t chunk_len = spi_context_max_continuous_chunk(&data->ctx);
 
 	/* clean up and prepare SPI hal */
 	memset((uint32_t *) hal->hw->data_buf, 0, sizeof(hal->hw->data_buf));
-	hal->send_buffer = (uint8_t *) ctx->tx_buf;
-	hal->rcv_buffer = ctx->rx_buf;
-	hal->tx_bitlen = chunk_len << 3;
-	hal->rx_bitlen = chunk_len << 3;
+	hal_trans->send_buffer = (uint8_t *) ctx->tx_buf;
+	hal_trans->rcv_buffer = ctx->rx_buf;
+	hal_trans->tx_bitlen = chunk_len << 3;
+	hal_trans->rx_bitlen = chunk_len << 3;
 
 	/* configure SPI */
-	spi_hal_setup_trans(hal);
-	spi_hal_prepare_data(hal);
+	spi_hal_setup_trans(hal, hal_dev, hal_trans);
+	spi_hal_prepare_data(hal, hal_dev, hal_trans);
 
 	/* send data */
 	spi_hal_user_start(hal);
@@ -161,6 +163,8 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 	struct spi_esp32_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	spi_hal_context_t *hal = &data->hal;
+	spi_hal_dev_config_t *hal_dev = &data->dev_config;
+	int freq;
 
 	if (spi_context_configured(ctx, spi_cfg)) {
 		return 0;
@@ -197,9 +201,9 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 				GPIO_OUTPUT);
 
 	if (ctx->config->cs == NULL) {
-		data->hal.cs_setup = 1;
-		data->hal.cs_hold = 1;
-		data->hal.cs_pin_id = 0;
+		hal_dev->cs_setup = 1;
+		hal_dev->cs_hold = 1;
+		hal_dev->cs_pin_id = 0;
 
 		spi_esp32_configure_pin(cfg->pins.csel,
 					cfg->signals.csel_s,
@@ -208,28 +212,36 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 
 	spi_context_cs_configure(&data->ctx);
 
-	spi_hal_get_clock_conf(hal, spi_cfg->frequency, 128, true, 0, NULL,
-			       &data->timing_conf);
+	/* input parameters to calculate timing configuration */
+	spi_hal_timing_param_t timing_param = {
+		.half_duplex = hal_dev->half_duplex,
+		.no_compensate = hal_dev->no_compensate,
+		.clock_speed_hz = cfg->frequency,
+		.duty_cycle = cfg->duty_cycle == 0 ? 128 : cfg->duty_cycle,
+		.input_delay_ns = cfg->input_delay_ns,
+		.use_gpio = true
+	};
 
-	data->hal.timing_conf = &data->timing_conf;
-	data->hal.dummy_bits = data->hal.timing_conf->timing_dummy;
+	spi_hal_cal_clock_conf(&timing_param, &freq, &hal_dev->timing_conf);
 
-	data->hal.tx_lsbfirst = spi_cfg->operation & SPI_TRANSFER_LSB ? 1 : 0;
-	data->hal.rx_lsbfirst = spi_cfg->operation & SPI_TRANSFER_LSB ? 1 : 0;
+	data->trans_config.dummy_bits = hal_dev->timing_conf.timing_dummy;
 
-	data->hal.io_mode = spi_esp32_get_io_mode(spi_cfg->operation);
+	hal_dev->tx_lsbfirst = spi_cfg->operation & SPI_TRANSFER_LSB ? 1 : 0;
+	hal_dev->rx_lsbfirst = spi_cfg->operation & SPI_TRANSFER_LSB ? 1 : 0;
+
+	data->trans_config.io_mode = spi_esp32_get_io_mode(spi_cfg->operation);
 
 	/* SPI mode */
-	data->hal.mode = 0;
+	hal_dev->mode = 0;
 	if (SPI_MODE_GET(spi_cfg->operation) & SPI_MODE_CPOL) {
-		data->hal.mode = BIT(0);
+		hal_dev->mode = BIT(0);
 	}
 
 	if (SPI_MODE_GET(spi_cfg->operation) & SPI_MODE_CPHA) {
-		data->hal.mode |= BIT(1);
+		hal_dev->mode |= BIT(1);
 	}
 
-	spi_hal_setup_device(hal);
+	spi_hal_setup_device(hal, hal_dev);
 
 	return 0;
 }
@@ -381,10 +393,11 @@ static const struct spi_driver_api spi_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_data_##idx, ctx),	\
 		.hal = {	\
 			.hw = (spi_dev_t *)DT_REG_ADDR(DT_NODELABEL(spi##idx)),	\
+		},	\
+		.dev_config = {	\
 			.half_duplex = DT_PROP(DT_NODELABEL(spi##idx), half_duplex),	\
 			.as_cs = DT_PROP(DT_NODELABEL(spi##idx), clk_as_cs),	\
 			.positive_cs = DT_PROP(DT_NODELABEL(spi##idx), positive_cs),	\
-			.dma_enabled = DT_PROP(DT_NODELABEL(spi##idx), dma),	\
 			.no_compensate = DT_PROP(DT_NODELABEL(spi##idx), dummy_comp),	\
 			.sio = DT_PROP(DT_NODELABEL(spi##idx), sio)	\
 		}	\
@@ -395,7 +408,9 @@ static const struct spi_driver_api spi_api = {
 			\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(spi##idx))),	\
 		ESP32_SPI_IRQ_HANDLER_FUNC(idx)	\
-				\
+		.frequency = SPI_MASTER_FREQ_8M,\
+		.duty_cycle = 0, \
+		.input_delay_ns = 0, \
 		.signals = {	\
 			.miso_s = MISO_IDX_##idx,	\
 			.mosi_s = MOSI_IDX_##idx,	\

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -7,9 +7,25 @@
 #ifndef ZEPHYR_DRIVERS_SPI_ESP32_SPIM_H_
 #define ZEPHYR_DRIVERS_SPI_ESP32_SPIM_H_
 
+#define SPI_MASTER_FREQ_8M      (APB_CLK_FREQ/10)
+#define SPI_MASTER_FREQ_9M      (APB_CLK_FREQ/9)    /* 8.89MHz */
+#define SPI_MASTER_FREQ_10M     (APB_CLK_FREQ/8)    /* 10MHz */
+#define SPI_MASTER_FREQ_11M     (APB_CLK_FREQ/7)    /* 11.43MHz */
+#define SPI_MASTER_FREQ_13M     (APB_CLK_FREQ/6)    /* 13.33MHz */
+#define SPI_MASTER_FREQ_16M     (APB_CLK_FREQ/5)    /* 16MHz */
+#define SPI_MASTER_FREQ_20M     (APB_CLK_FREQ/4)    /* 20MHz */
+#define SPI_MASTER_FREQ_26M     (APB_CLK_FREQ/3)    /* 26.67MHz */
+#define SPI_MASTER_FREQ_40M     (APB_CLK_FREQ/2)    /* 40MHz */
+#define SPI_MASTER_FREQ_80M     (APB_CLK_FREQ/1)    /* 80MHz */
+
 struct spi_esp32_config {
 	spi_dev_t *spi;
 	const struct device *clock_dev;
+	int frequency;
+	int duty_cycle;
+	int input_delay_ns;
+
+	clock_control_subsys_t clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 
 	struct {
@@ -26,8 +42,6 @@ struct spi_esp32_config {
 		int csel;
 	} pins;
 
-	clock_control_subsys_t clock_subsys;
-
 	struct {
 		int source;
 		int line;
@@ -37,7 +51,9 @@ struct spi_esp32_config {
 struct spi_esp32_data {
 	struct spi_context ctx;
 	spi_hal_context_t hal;
-	spi_hal_timing_conf_t timing_conf;
+	spi_hal_timing_conf_t timing_config;
+	spi_hal_dev_config_t dev_config;
+	spi_hal_trans_config_t trans_config;
 	uint8_t dfs;
 };
 

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include "esp_private/wifi.h"
 #include "esp_event.h"
 #include "esp_timer.h"
-#include "esp_wifi_system.h"
+#include "esp_system.h"
 #include "esp_wpa.h"
 
 #define DEV_DATA(dev) \

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -70,7 +70,7 @@
 				label = "FLASH_ESP32";
 				reg = <0 0x400000>;
 				erase-block-size = <4096>;
-				write-block-size = <1>;
+				write-block-size = <4>;
 			};
 		};
 

--- a/soc/xtensa/esp32/Kconfig.soc
+++ b/soc/xtensa/esp32/Kconfig.soc
@@ -196,4 +196,53 @@ menu "SPI RAM config"
 		default y
 endmenu
 
+choice ESP32_UNIVERSAL_MAC_ADDRESSES
+	bool "Number of universally administered (by IEEE) MAC address"
+	default ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+	help
+	  Configure the number of universally administered (by IEEE) MAC addresses.
+	  During initialization, MAC addresses for each network interface are generated or
+	  derived from a single base MAC address. If the number of universal MAC addresses is four,
+	  all four interfaces (WiFi station, WiFi softap, Bluetooth and Ethernet) receive a universally
+	  administered MAC address. These are generated sequentially by adding 0, 1, 2 and 3 (respectively)
+	  to the final octet of the base MAC address. If the number of universal MAC addresses is two,
+	  only two interfaces (WiFi station and Bluetooth) receive a universally administered MAC address.
+	  These are generated sequentially by adding 0 and 1 (respectively) to the base MAC address.
+	  The remaining two interfaces (WiFi softap and Ethernet) receive local MAC addresses.
+	  These are derived from the universal WiFi station and Bluetooth MAC addresses, respectively.
+	  When using the default (Espressif-assigned) base MAC address, either setting can be used.
+	  When using a custom universal MAC address range, the correct setting will depend on the
+	  allocation of MAC addresses in this range (either 2 or 4 per device.)
+
+	config ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
+		bool "Two"
+		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+		select ESP_MAC_ADDR_UNIVERSE_BT
+
+	config ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+		bool "Four"
+		select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+		select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+		select ESP_MAC_ADDR_UNIVERSE_BT
+		select ESP_MAC_ADDR_UNIVERSE_ETH
+
+endchoice
+
+config ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+	bool
+
+config ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	bool
+
+config ESP_MAC_ADDR_UNIVERSE_BT
+	bool
+
+config ESP_MAC_ADDR_UNIVERSE_ETH
+	bool
+
+config ESP32_UNIVERSAL_MAC_ADDRESSES
+	int
+	default 2 if ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
+	default 4 if ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+
 endif # SOC_ESP32

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -348,16 +348,17 @@ __shell_root_cmds_end = __esp_shell_root_cmds_end;
     *libzephyr.a:log_output.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
+    *libphy.a:( .phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.*)
+    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
 #endif
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
-    *libnet80211.a:( .wifirxiram  .wifirxiram.*)
-    *libpp.a:( .wifirxiram  .wifirxiram.*)
+    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif
 
     _iram_text_end = ABSOLUTE(.);
@@ -371,13 +372,13 @@ __shell_root_cmds_end = __esp_shell_root_cmds_end;
     _text_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.*)
+    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
 #endif
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
-    *libnet80211.a:( .wifirxiram  .wifirxiram.*)
-    *libpp.a:( .wifirxiram  .wifirxiram.*)
+    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif
 
     *(.literal .text .literal.* .text.*)

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
       revision: 81a059f21435bc7e315bccd720da5a9b615bbb50
       path: modules/hal/cypress
     - name: hal_espressif
-      revision: 22e757632677e3579e6f20bb9955fffb2e1b3e1c
+      revision: a5d7cb9e6676b08b15ac5b0c54a98514d8bc257c
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
     - name: hal_infineon


### PR DESCRIPTION
hal_espressif repository was updated from esp-idf v4.2
to esp-idf v4.3 to allow latest Espressif's chips integration.
As a consequence, it added a few changes in drivers
and peripherals. To maintain bisectability, changes in this
PR cannot be split. Here are some details:

wifi: update linker script by adding libphy and new attributes.

spi: update some APIs and fixed block size.

west.yml: esp32: update hal to new version

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>