### PR TITLE
flash: spi_nor: re-enable write protection

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -613,7 +613,7 @@ static int spi_nor_write(const struct device *dev, off_t addr,
 		}
 	}
 
-	int ret2 = spi_nor_write_protection_set(dev, false);
+	int ret2 = spi_nor_write_protection_set(dev, true);
 
 	if (!ret) {
 		ret = ret2;


### PR DESCRIPTION
Turn write-protection back on after a write, instead of disabling it
again.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>