### PR TITLE
Enabling watchdog on stm32l5.

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -44,3 +44,7 @@
 		st,prescaler = <10000>;
 	};
 };
+
+&iwdg {
+	status = "okay";
+};

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
@@ -11,5 +11,6 @@ supported:
   - lsm6dso
   - lptim
   - pwm
+  - watchdog
 ram: 192
 flash: 512

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -105,7 +105,7 @@
 			reg = <0x40021000 0x400>;
 		};
 
-		exti: interrupt-controller@4000F400 {
+		exti: interrupt-controller@4000f400 {
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -191,6 +191,22 @@
 			};
 		};
 
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			label = "IWDG";
+			status = "disabled";
+		};
+
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000800>;
+			label = "WWDG";
+			interrupts = <0 7>;
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;


### PR DESCRIPTION
These commits enable and run tests/drivers/watchdog/wdt_basic_api and samples/drivers/watchdog on stm32l562e_dk platform.
1: samples/drivers/watchdog runs and works as expected.
2: tests/drivers/watchdog/wdt_basic_api runs and works as expected.