### PR TITLE
doc: getting_started: add Python virtual environment option 

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -174,104 +174,284 @@ Next, clone Zephyr and its :ref:`modules <modules>` into a new :ref:`west
 <west>` workspace named :file:`zephyrproject`. You'll also install Zephyr's
 additional Python dependencies.
 
+Python is used by the ``west`` meta-tool as well as by many scripts invoked by
+the build system. It is easy to run into package incompatibilities when
+installing dependencies at a system or user level. This situation can happen,
+for example, if working on multiple Zephyr versions at the same time. For this
+reason it is suggested to use `Python virtual environments`_.
+
+.. _Python virtual environments: https://docs.python.org/3/library/venv.html
+
 .. tabs::
 
    .. group-tab:: Ubuntu
 
-      #. Install west, and make sure :file:`~/.local/bin` is on your
-         :envvar:`PATH` :ref:`environment variable <env_vars>`:
+      .. tabs::
 
-         .. code-block:: bash
+         .. group-tab:: Install globally
 
-            pip3 install --user -U west
-            echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-            source ~/.bashrc
+            #. Install west, and make sure :file:`~/.local/bin` is on your
+               :envvar:`PATH` :ref:`environment variable <env_vars>`:
 
-      #. Get the Zephyr source code:
+               .. code-block:: bash
 
-         .. code-block:: bash
+                  pip3 install --user -U west
+                  echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
+                  source ~/.bashrc
 
-            west init ~/zephyrproject
-            cd ~/zephyrproject
-            west update
+            #. Get the Zephyr source code:
 
-      #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
-         automatically load boilerplate code required for building Zephyr
-         applications.
+               .. code-block:: bash
 
-         .. code-block:: console
+                  west init ~/zephyrproject
+                  cd ~/zephyrproject
+                  west update
 
-            west zephyr-export
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
 
-      #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
-         dependencies. Install them with ``pip3``.
+               .. code-block:: console
 
-         .. code-block:: bash
+                  west zephyr-export
 
-            pip3 install --user -r ~/zephyrproject/zephyr/scripts/requirements.txt
+            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip3``.
+
+               .. code-block:: bash
+
+                  pip3 install --user -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+         .. group-tab:: Install within virtual environment
+
+            #. Create a new virtual environment:
+
+               .. code-block:: bash
+
+                  python3 -m venv ~/zephyrproject/.venv
+
+            #. Activate the virtual environment:
+
+               .. code-block:: bash
+
+                  source ~/zephyrproject/.venv/bin/activate
+
+               Once activated your shell will be prefixed with ``(.venv)``. The
+               virtual environment can be deactivated at any time by running
+               ``deactivate``.
+
+               .. note::
+
+                  Remember to activate the virtual environment every time you
+                  start working.
+
+            #. Install west:
+
+               .. code-block:: bash
+
+                  pip install west
+
+            #. Get the Zephyr source code:
+
+               .. code-block:: bash
+
+                 west init ~/zephyrproject
+                 cd ~/zephyrproject
+                 west update
+
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
+
+               .. code-block:: console
+
+                  west zephyr-export
+
+            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip``.
+
+               .. code-block:: bash
+
+                  pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
 
    .. group-tab:: macOS
 
-      #. Install west:
+      .. tabs::
 
-         .. code-block:: bash
+         .. group-tab:: Install globally
 
-            pip3 install -U west
+            #. Install west:
 
-      #. Get the Zephyr source code:
+               .. code-block:: bash
 
-         .. code-block:: bash
+                  pip3 install -U west
 
-            west init ~/zephyrproject
-            cd ~/zephyrproject
-            west update
+            #. Get the Zephyr source code:
 
-      #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
-         automatically load boilerplate code required for building Zephyr
-         applications.
+               .. code-block:: bash
 
-         .. code-block:: console
+                  west init ~/zephyrproject
+                  cd ~/zephyrproject
+                  west update
 
-            west zephyr-export
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
 
-      #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
-         dependencies. Install them with ``pip3``.
+               .. code-block:: console
 
-         .. code-block:: bash
+                  west zephyr-export
 
-            pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip3``.
+
+               .. code-block:: bash
+
+                  pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+         .. group-tab:: Install within virtual environment
+
+            #. Create a new virtual environment:
+
+               .. code-block:: bash
+
+                  python3 -m venv ~/zephyrproject/.venv
+
+            #. Activate the virtual environment:
+
+               .. code-block:: bash
+
+                  source ~/zephyrproject/.venv/bin/activate
+
+               Once activated your shell will be prefixed with ``(.venv)``. The
+               virtual environment can be deactivated at any time by running
+               ``deactivate``.
+
+               .. note::
+
+                  Remember to activate the virtual environment every time you
+                  start working.
+
+            #. Install west:
+
+               .. code-block:: bash
+
+                  pip install west
+
+            #. Get the Zephyr source code:
+
+               .. code-block:: bash
+
+                  west init ~/zephyrproject
+                  cd ~/zephyrproject
+                  west update
+
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
+
+               .. code-block:: console
+
+                  west zephyr-export
+
+            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip``.
+
+               .. code-block:: bash
+
+                  pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
 
    .. group-tab:: Windows
 
-      #. Install west:
+      .. tabs::
 
-         .. code-block:: bash
+         .. group-tab:: Install globally
 
-            pip3 install -U west
+            #. Install west:
 
-      #. Get the Zephyr source code:
+               .. code-block:: bat
 
-         .. code-block:: bat
+                  pip3 install -U west
 
-            cd %HOMEPATH%
-            west init zephyrproject
-            cd zephyrproject
-            west update
+            #. Get the Zephyr source code:
 
-      #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
-         automatically load boilerplate code required for building Zephyr
-         applications.
+               .. code-block:: bat
 
-         .. code-block:: console
+                  cd %HOMEPATH%
+                  west init zephyrproject
+                  cd zephyrproject
+                  west update
 
-            west zephyr-export
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
 
-      #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
-         dependencies. Install them with ``pip3``.
+               .. code-block:: bat
 
-         .. code-block:: bat
+                  west zephyr-export
 
-            pip3 install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
+            #. Zephyr's ``scripts\requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip3``.
+
+               .. code-block:: bat
+
+                  pip3 install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
+
+         .. group-tab:: Install within virtual environment
+
+            #. Create a new virtual environment:
+
+               .. code-block:: bat
+
+                  cd %HOMEPATH%
+                  python3 -m venv zephyrproject\.venv
+
+            #. Activate the virtual environment:
+
+               .. code-block:: bat
+
+                  :: cmd.exe
+                  zephyrproject\.venv\Scripts\activate.bat
+                  :: PowerShell
+                  zephyrproject\.venv\Scripts\Activate.ps1
+
+               Once activated your shell will be prefixed with ``(.venv)``. The
+               virtual environment can be deactivated at any time by running
+               ``deactivate``.
+
+               .. note::
+
+                  Remember to activate the virtual environment every time you
+                  start working.
+
+            #. Install west:
+
+               .. code-block:: bash
+
+                  pip install west
+
+            #. Get the Zephyr source code:
+
+               .. code-block:: bash
+
+                  west init zephyrproject
+                  cd zephyrproject
+                  west update
+
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
+
+               .. code-block:: console
+
+                  west zephyr-export
+
+            #. Zephyr's ``scripts\requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip``.
+
+               .. code-block:: bash
+
+                  pip install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
 
 .. rst-class:: numbered-step
 


### PR DESCRIPTION
Python is used by the west meta-tool as well as by many scripts invoked
by the build system. It is easy to run into package incompatibilities
when installing dependencies at a system or user level. This situation
can happen, for example, if working on multiple Zephyr versions at the
same time. For this reason, the getting started guide has been updated
to offer instructions for both, using Python virtual environments and
installing globally. Python virtual environments has been added as
another choice for the reasons just mentioned.

Ref. Some projects using Zephyr also recommend using virtual environments, see e.g. https://docs.golioth.io/docs/guides/quickstart/setup-zephyr

A quick look (for Ubuntu):
![image](https://user-images.githubusercontent.com/25011557/122550562-1db1cb00-d034-11eb-8264-72dc7cc4ac6f.png)
