### PR TITLE
drivers: pwm: pwm_nrfx: Fix driver suspending

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -288,6 +288,8 @@ static void pwm_nrfx_uninit(const struct device *dev)
 	const struct pwm_nrfx_config *config = dev->config;
 
 	nrfx_pwm_uninit(&config->pwm);
+
+	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 }
 
 static int pwm_nrfx_set_power_state(uint32_t new_state,


### PR DESCRIPTION
This commit clears current settings of the PWM perihperal
that are stored inside device structure.
This makes sure that PWM period and prescaler is configured
as expected after driver was suspended.