### PR TITLE
net: ip: Fix TCP unacked_len

### DIFF
--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -1827,7 +1827,11 @@ next_state:
 			}
 
 			conn->send_data_total -= len_acked;
-			conn->unacked_len -= len_acked;
+			if (conn->unacked_len < len_acked) {
+				conn->unacked_len = 0;
+			} else {
+				conn->unacked_len -= len_acked;
+			}
 			conn_seq(conn, + len_acked);
 			net_stats_update_tcp_seg_recv(conn->iface);
 


### PR DESCRIPTION
TCP unacked_len can be set to zero in tcp_resend_data(),
and then be minus by len_acked when ACK is received,
resulting in a negative unacked_len value.

Fixes #36390

Signed-off-by: Chih Hung Yu <chyu313@gmail.com>