### PR TITLE
Bluetooth: gatt: allow writing long device name

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -99,11 +99,11 @@ static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 {
 	char value[CONFIG_BT_DEVICE_NAME_MAX] = {};
 
-	if (offset) {
+	if (offset >= sizeof(value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	if (len >= sizeof(value)) {
+	if (offset + len >= sizeof(value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 


### PR DESCRIPTION
BT_DEVICE_NAME_MAX can be up to 248 bytes. This may exceed ATT MTU size,
which will cause the offset in write_name() to be non zere, resulting in
BT_ATT_ERR_INVALID_OFFSET. However, device name should be writable up to
it's defined size, using subsequent prepare write requests. Error should
be returned if offset exceeds size of device name, and if total size of
new value exceeds BT_DEVICE_NAME_MAX, BT_ATT_ERR_INVALID_ATTRIBUTE_LEN
shall be returned.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>