### PR TITLE
openthread: fix not working ot diag repeat command

### DIFF
--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/alarm-micro.h>
+#include <openthread/platform/diag.h>
 #include <openthread-system.h>
 
 #include <stdio.h>
@@ -52,7 +53,14 @@ void platformAlarmProcess(otInstance *aInstance)
 {
 	if (timer_ms_fired) {
 		timer_ms_fired = false;
-		otPlatAlarmMilliFired(aInstance);
+#if defined(CONFIG_OPENTHREAD_DIAG)
+		if (otPlatDiagModeGet()) {
+			otPlatDiagAlarmFired(aInstance);
+		} else
+#endif
+		{
+			otPlatAlarmMilliFired(aInstance);
+		}
 	}
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 	if (timer_us_fired) {


### PR DESCRIPTION
This commit fixes diag repeat command port by fixing issue with
incorrectly handled repeat timer.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>