### PR TITLE
dts: gen_defines: Generate PARTITION_ID only for "okay" nodes

### DIFF
--- a/include/devicetree/fixed-partitions.h
+++ b/include/devicetree/fixed-partitions.h
@@ -63,6 +63,9 @@ extern "C" {
 
 /**
  * @brief Get a numeric identifier for a fixed partition
+ *
+ * The partition ID will be only available from status "okay" partition entries
+ *
  * @param node_id node identifier for a fixed-partitions child node
  * @return the partition's ID, a unique zero-based index number
  */

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -51,7 +51,7 @@ class LogFormatter(logging.Formatter):
 
 def main():
     global header_file
-    global flash_area_num
+    global flash_area_num # This 0 based ID of only "okay" status partitions.
 
     args = parse_args()
 
@@ -125,6 +125,7 @@ def main():
             write_bus(node)
             write_special_props(node)
             write_vanilla_props(node)
+
 
         write_chosen(edt)
         write_global_compat_info(edt)
@@ -354,9 +355,11 @@ def write_special_props(node):
     write_status(node)
 
     if node.parent and "fixed-partitions" in node.parent.compats:
-        macro = f"{node.z_path_id}_PARTITION_ID"
-        out_dt_define(macro, flash_area_num)
-        flash_area_num += 1
+        if node.status == "okay":
+            macro = f"{node.z_path_id}_PARTITION_ID"
+            out_dt_define(macro, flash_area_num)
+            flash_area_num += 1
+
 
 def write_regs(node):
     # reg property: edtlib knows the right #address-cells and


### PR DESCRIPTION
The commit modifies how the PARTITION_ID is generated, to provide
an ID only for partition nodes that are "okay".
The change will cause code trying to obtain ID of non-"okay"ed
partition to fail compilation, which allows compile time detection
of addressing non-existing partitions.
This also allows to produce, at compile time, arrays of objects
that can be indexed by the ID of partition, while not including
disabled nodes.

Currently when user defines, for example 80 partitions, and enables only 2, the identifiers for them may be for example 3 and 49, although only two exist within system; these are auto generated from DTS after it has been generated from all DTS overlays, and so on, and is never literally stated within DTS; any change to the DTS may actually give these IDs some other random values.
The commit changes how the IDs are generated so that they are generated starting at 0 and will be numbered in continuous way up to N-1 where N is number of enabled partitions.

This has been taken from https://github.com/zephyrproject-rtos/zephyr/pull/34530



Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>