### PR TITLE
net: openthread: remove unneded Kconfig dependency

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -155,7 +155,6 @@ endmenu # "Zephyr optimizations"
 
 config OPENTHREAD_SHELL
 	bool "Enable OpenThread shell"
-	depends on !OPENTHREAD_COPROCESSOR
 	depends on SHELL
 	default y
 


### PR DESCRIPTION
`OPENTHREAD_SHELL` does no longer dependend on
`OPENTHREAD_COPROCESSOR` being disabled.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>