### PR TITLE
MAINTAINERS: include samples/drivers/eeprom under EEPROM area

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -520,6 +520,7 @@
 /samples/drivers/can/                     @alexanderwachter
 /samples/drivers/clock_control_litex/     @mateusz-holenko @kgugala @pgielda
 /samples/drivers/display/                 @vanwinkeljan
+/samples/drivers/eeprom/                  @henrikbrixandersen
 /samples/drivers/ht16k33/                 @henrikbrixandersen
 /samples/drivers/lora/                    @Mani-Sadhasivam
 /samples/subsys/lorawan/                  @Mani-Sadhasivam

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -541,6 +541,7 @@ Documentation:
         - drivers/eeprom/
         - dts/bindings/mtd/*eeprom*
         - include/drivers/eeprom.h
+        - samples/drivers/eeprom/
         - tests/drivers/eeprom/
     labels:
         - "area: EEPROM"


### PR DESCRIPTION
Include the samples/drivers/eeprom folder under the EEPROM maintainer area.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>