### PR TITLE
boards: arm: mps3_an547: Enable FVP and QEMU simulation

### DIFF
--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 Linaro
+# SPDX-License-Identifier: Apache-2.0
+
+# The AN547 FVP must be used to enable Ethos-U55 NPU support, but QEMU also
+# supports the AN547 without the NPU.
+#
+# To use QEMU instead of the FVP as an emulation platform, set 'EMU_PLATFORM'
+# to 'qemu' instead of 'armfvp', for example:
+#
+# $ west build -b mps3_an547 samples/hello°world -DEMU_PLATFORM=qemu -t run
+
+if(NOT DEFINED EMU_PLATFORM)
+  set(EMU_PLATFORM armfvp)
+endif()
+
+if (EMU_PLATFORM STREQUAL "qemu")
+  # QEMU settings
+  set(QEMU_CPU_TYPE_${ARCH} cortex-m55)
+  set(QEMU_FLAGS_${ARCH}
+    -cpu ${QEMU_CPU_TYPE_${ARCH}}
+    -machine mps3-an547
+    -nographic
+    -vga none
+    )
+  board_set_debugger_ifnset(qemu)
+else()
+  # FVP settings
+  set(ARMFVP_BIN_NAME FVP_Corstone_SSE-300_Ethos-U55)
+
+  # FVP Parameters
+  # -C indicate a config option in the form of:
+  #   instance.parameter=value
+  # Run the FVP with --list-params to list all options
+  set(ARMFVP_FLAGS
+    -C mps3_board.uart0.out_file=-
+    -C mps3_board.uart0.unbuffered_output=1
+    -C mps3_board.uart1.out_file=-
+    -C mps3_board.uart1.unbuffered_output=1
+    -C mps3_board.uart2.out_file=-
+    -C mps3_board.uart2.unbuffered_output=1
+    -C mps3_board.visualisation.disable-visualisation=1
+    )
+endif()

--- a/boards/arm/mps3_an547/doc/index.rst
+++ b/boards/arm/mps3_an547/doc/index.rst
@@ -22,7 +22,18 @@ CPU and the following devices:
      :height: 546px
      :alt: ARM MPS3 AN547
 
-More information about the board can be found at the `MPS3 FPGA Website`_.
+This board configuration also supports using the `Corstone-300 FVP`_ to emulate
+a MPS3 AN547 hardware platform.
+
+The Corstone-300 FVP (Fixed Virtual Platform) is a complete simulation of the
+Arm system, including processor, memory and peripherals. It is a available free
+of charge for Linux and Windows systems. The FVP has been selected for
+simulation since it provides access to the Ethos-U55 NPU, which is unavailable
+in QEMU or other simulation platforms.
+
+To run the Fixed Virtual Platform simulation tool you must download "FVP model
+for the Corstone-300 MPS3" from Arm and install it on your host PC. This board
+has been tested with version 11.12.57 (Nov  2 2020).
 
 Hardware
 ********
@@ -174,6 +185,35 @@ serial port:
 
    Hello World! mps3_an547
 
+
+FVP Usage
+=========
+
+To run with the FVP, first set environment variable ``ARMFVP_BIN_PATH`` before
+using it. Then you can run it with ``west build -t run``.
+
+.. code-block:: bash
+
+   export ARMFVP_BIN_PATH=/path/to/fvp/directory
+   west build -t run
+
+
+QEMU Usage
+==========
+
+To run with QEMU instead of the default FVP, override the emulator selection
+at build time via:
+
+.. code-block:: bash
+
+   $ west build -b mps3_an547 samples/hello°world -DEMU_PLATFORM=qemu -t run
+
+
+Note, however, that the Ethos-U55 FPU is not available in QEMU. If you require
+the use of the FPU, please use the default FVP for device emulation.
+
+.. _Corstone-300 FVP:
+   https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/arm-ecosystem-fvps
 
 .. _MPS3 FPGA Website:
    https://developer.arm.com/tools-and-software/development-boards/fpga-prototyping-boards/mps3


### PR DESCRIPTION
This commit enables emulation of the `mps3_an547` platform
using, by default, The Arm Corstone-300 MPS3 FVP executable.
This FVP includes support for emulating the Ethos-U55 NPU.

Optionally, the default FVP selection can be overriden in favor
of QEMU, which supports the MPS3 without the proprietary
Ethos-U55 FPU extension. To enable qemu as an emulation target,
add `-DEMU_PLATFORM=qemu` when building an mps3_an547 image.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>