### PR TITLE
soc: atmel: sam4l: Enable RC32K osc

### DIFF
--- a/soc/arm/atmel_sam/sam4l/soc.c
+++ b/soc/arm/atmel_sam/sam4l/soc.c
@@ -95,6 +95,19 @@ static inline bool osc_is_ready(uint8_t id)
 }
 
 /**
+ * Enable Backup System Control Oscilator RC32K
+ */
+static inline void osc_priv_enable_rc32k(void)
+{
+	uint32_t temp = BSCIF->RC32KCR;
+	uint32_t addr = (uint32_t)&BSCIF->RC32KCR - (uint32_t)BSCIF;
+
+	BSCIF->UNLOCK = BSCIF_UNLOCK_KEY(0xAAu)
+		      | BSCIF_UNLOCK_ADDR(addr);
+	BSCIF->RC32KCR = temp | BSCIF_RC32KCR_EN32K | BSCIF_RC32KCR_EN;
+}
+
+/**
  * The PLL options #PLL_OPT_VCO_RANGE_HIGH and #PLL_OPT_OUTPUT_DIV will
  * be set automatically based on the calculated target frequency.
  */
@@ -191,6 +204,8 @@ static inline void flashcalw_issue_command(uint32_t command, int page_number)
  */
 static ALWAYS_INLINE void clock_init(void)
 {
+	uint32_t gen_clk_conf;
+
 	/* Disable PicoCache and Enable HRAMC1 as extended RAM */
 	soc_pmc_peripheral_enable(
 		PM_CLOCK_MASK(PM_CLK_GRP_HSB, SYSCLK_HRAMC1_DATA));
@@ -262,6 +277,24 @@ static ALWAYS_INLINE void clock_init(void)
 	PM->UNLOCK = PM_UNLOCK_KEY(0xAAu) |
 		     PM_UNLOCK_ADDR((uint32_t)&PM->MCCTRL - (uint32_t)PM);
 	PM->MCCTRL = OSC_SRC_PLL0;
+
+	/** Enable RC32K Oscilator */
+	osc_priv_enable_rc32k();
+	while (!osc_is_ready(OSC_ID_RC32K)) {
+		;
+	}
+
+	/** Enable Generic Clock 5
+	 *   Source: RC32K
+	 *      Div: 32
+	 *      Clk: 1024 Hz
+	 *  The GCLK-5 can be used by GLOC, TC0 and RC32KIFB_REF
+	 */
+	gen_clk_conf = SCIF_GCCTRL_RESETVALUE;
+	gen_clk_conf |= SCIF_GCCTRL_OSCSEL(GEN_CLK_SRC_RC32K);
+	gen_clk_conf |= SCIF_GCCTRL_DIVEN;
+	gen_clk_conf |= SCIF_GCCTRL_DIV(((32 + 1) / 2) - 1);
+	SCIF->GCCTRL[GEN_CLK_TC0_GLOC_RC32] = gen_clk_conf | SCIF_GCCTRL_CEN;
 }
 
 /**

--- a/soc/arm/atmel_sam/sam4l/soc.h
+++ b/soc/arm/atmel_sam/sam4l/soc.h
@@ -205,18 +205,64 @@
  *   10- ADCIFE
  *   11- Master generic clock. Can be used as source for other generic clocks.
  */
-#define GEN_CLK_DFLL_REF	0
-#define GEN_CLK_DFLL_DITHER	1
-#define GEN_CLK_AST		2
-#define GEN_CLK_CATB		3
-#define GEN_CLK_AESA		4
-#define GEN_CLK_GLOC		5
-#define GEN_CLK_ABDACB		6
-#define GEN_CLK_USBC		7
-#define GEN_CLK_TC1_PEVC0	8
-#define GEN_CLK_PLL0_PEVC1	9
-#define GEN_CLK_ADCIFE		10
-#define GEN_CLK_MASTER_GEN	11
+#define GEN_CLK_DFLL_REF        0
+#define GEN_CLK_DFLL_DITHER     1
+#define GEN_CLK_AST             2
+#define GEN_CLK_CATB            3
+#define GEN_CLK_AESA            4
+#define GEN_CLK_TC0_GLOC_RC32   5
+#define GEN_CLK_ABDACB          6
+#define GEN_CLK_USBC            7
+#define GEN_CLK_TC1_PEVC0       8
+#define GEN_CLK_PLL0_PEVC1      9
+#define GEN_CLK_ADCIFE          10
+#define GEN_CLK_MASTER_GEN      11
+
+/**
+ *    0-  System RC oscillator
+ *    1-  32 kHz oscillator
+ *    2-  DFLL
+ *    3-  Oscillator 0
+ *    4-  80 MHz RC oscillator
+ *    5-  4-8-12 MHz RC oscillator
+ *    6-  1 MHz RC oscillator
+ *    7-  CPU clock
+ *    8-  High Speed Bus clock
+ *    9-  Peripheral Bus A clock
+ *    10- Peripheral Bus B clock
+ *    11- Peripheral Bus C clock
+ *    12- Peripheral Bus D clock
+ *    13- 32 kHz RC oscillator
+ *    15- 1 kHz output from OSC32K
+ *    16- PLL0
+ *    17- High resolution prescaler
+ *    18- Fractional prescaler
+ *    19- GCLKIN0
+ *    20- GCLKIN1
+ *    21- GCLK11
+ */
+
+#define GEN_CLK_SRC_RCSYS	0
+#define GEN_CLK_SRC_OSC32K	1
+#define GEN_CLK_SRC_DFLL	2
+#define GEN_CLK_SRC_OSC0	3
+#define GEN_CLK_SRC_RC80M	4
+#define GEN_CLK_SRC_RCFAST	5
+#define GEN_CLK_SRC_RC1M	6
+#define GEN_CLK_SRC_CLK_CPU	7
+#define GEN_CLK_SRC_CLK_HSB	8
+#define GEN_CLK_SRC_CLK_PBA	9
+#define GEN_CLK_SRC_CLK_PBB	10
+#define GEN_CLK_SRC_CLK_PBC	11
+#define GEN_CLK_SRC_CLK_PBD	12
+#define GEN_CLK_SRC_RC32K	13
+#define GEN_CLK_SRC_CLK_1K	15
+#define GEN_CLK_SRC_PLL0	16
+#define GEN_CLK_SRC_HRPCLK	17
+#define GEN_CLK_SRC_FPCLK	18
+#define GEN_CLK_SRC_GCLKIN0	19
+#define GEN_CLK_SRC_GCLKIN1	20
+#define GEN_CLK_SRC_GCLK11	21
 
 #endif /* !_ASMLANGUAGE */
 


### PR DESCRIPTION
Enable sam4l internal factory calibrated RC32K clock source.  The RC32K was used as source for Generic Clock 5 using 32 as divider.  The output is a 1024 Hz clock that can be used by GLOC and TC0 peripherals.

This PR is necessary to enable a slow clock that can be used by TC driver at #36195.
Currently, there is no dependencies to this change.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>