### PR TITLE
boards: arm: sam_v71_xult: Enable pwm on LED0

### DIFF
--- a/boards/arm/sam_v71_xult/pinmux.c
+++ b/boards/arm/sam_v71_xult/pinmux.c
@@ -22,6 +22,11 @@ static const struct soc_gpio_pin pwm_ext2_pin7 = {
 static const struct soc_gpio_pin pwm_ext2_pin8 = {
 	PIO_PD26A_PWM0_PWML2, PIOD, ID_PIOD, SOC_GPIO_FUNC_A
 };
+
+/* PWM on LED0  */
+static const struct soc_gpio_pin pwm_led_0 = {
+	PIO_PA23B_PWM0_PWMH0, PIOA, ID_PIOA, SOC_GPIO_FUNC_B
+};
 #endif
 
 static int sam_v71_xplained_init(const struct device *dev)
@@ -32,6 +37,7 @@ static int sam_v71_xplained_init(const struct device *dev)
 	soc_gpio_configure(&pwm_ext1_pin7);
 	soc_gpio_configure(&pwm_ext2_pin7);
 	soc_gpio_configure(&pwm_ext2_pin8);
+	soc_gpio_configure(&pwm_led_0);
 #endif
 
 	return 0;

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -12,8 +12,9 @@
 		i2c-0 = &twihs0;
 		i2c-1 = &twihs1;
 		i2c-2 = &twihs2;
-		led0 = &yellow_led0;
-		led1 = &yellow_led1;
+		led0 = &yellow_led1;
+		pwm-led0 = &pwm_led0;
+		pwm-0 = &pwm0;
 		sw0 = &sw0_user_button;
 		sw1 = &sw1_user_button;
 	};
@@ -31,10 +32,18 @@
 		yellow_led0: led_0 {
 			gpios = <&pioa 23 GPIO_ACTIVE_LOW>;
 			label = "User LED 0";
+			status = "disabled";
 		};
 		yellow_led1: led_1 {
 			gpios = <&pioc 9 GPIO_ACTIVE_LOW>;
 			label = "User LED 1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 1000000>;
 		};
 	};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -355,7 +355,7 @@
 				     &pd8a_gmac_gmdc &pd9a_gmac_gmdio>;
 		};
 
-		tc0: tc@4000C000 {
+		tc0: tc@4000c000 {
 			compatible = "atmel,sam-tc";
 			reg = <0x4000c000 0x100>;
 			interrupts = <23 0


### PR DESCRIPTION
This re-assign LED0 function from GPIO to PWM.  This can be used as sample and test PWM driver for SAM Cortex-M7 MCUs.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>