### PR TITLE
board: cc1352r_sensortag: add dts entry for hdc2080

### DIFF
--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
@@ -31,7 +31,7 @@
 		sw1 = &btn1;
 		sensor0 = &sensor0;
 		sensor1 = &sensor1;
-		/* TODO: add support for hdc2080 */
+		sensor2 = &sensor2;
 	};
 
 	chosen {
@@ -116,7 +116,12 @@
 		label = "OPT3001";
 	};
 
-	/* TODO: add hdc2080 at 0x41 */
+	sensor2: sensor@41 {
+		compatible = "ti,hdc2080";
+		reg = <0x41>;
+		label = "HDC2080";
+		int-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &spi0 {


### PR DESCRIPTION
This change adds support to the cc1352r_sensortag for the hdc2xxx temperature
and humidity sensor introduced independently in #36342.

```
[00:00:00.063,323] <inf> ti_cc1352r_sensortag: opening device Red LED
[00:00:00.075,469] <inf> ti_cc1352r_sensortag: opening device Green LED
[00:00:00.087,585] <inf> ti_cc1352r_sensortag: opening device Blue LED
[00:00:00.099,731] <inf> ti_cc1352r_sensortag: opening device Push button 1
[00:00:00.111,846] <inf> ti_cc1352r_sensortag: opening device Push button 2
[00:00:00.123,962] <inf> ti_cc1352r_sensortag: opening device OPT3001
[00:00:00.147,399] <inf> ti_cc1352r_sensortag: opening device ADXL362
[00:00:00.166,168] <inf> ti_cc1352r_sensortag: opening device HDC2080
[00:00:06.287,261] <inf> ti_cc1352r_sensortag: Push button 2 event
[00:00:07.950,866] <inf> ti_cc1352r_sensortag: Push button 2 event
[00:00:07.965,545] <inf> ti_cc1352r_sensortag: Push button 1 event
[00:00:07.966,125] <inf> ti_cc1352r_sensortag: OPT3001:  99.720000
[00:00:07.966,186] <inf> ti_cc1352r_sensortag: ADXL362: x: -0.598205
[00:00:07.966,217] <inf> ti_cc1352r_sensortag: ADXL362: y: -0.205939
[00:00:07.966,217] <inf> ti_cc1352r_sensortag: ADXL362: z:  11.042287
[00:00:07.969,360] <inf> ti_cc1352r_sensortag: HDC2080: temp:  28.293640
[00:00:07.969,360] <inf> ti_cc1352r_sensortag: HDC2080: humid:  45.309448
```

Fixes #36410
