### PR TITLE
doc: dfu: fix MCUboot broken link

### DIFF
--- a/doc/guides/device_mgmt/dfu.rst
+++ b/doc/guides/device_mgmt/dfu.rst
@@ -48,5 +48,5 @@ More detailed information regarding the use of MCUboot with Zephyr  can be found
 in the `MCUboot with Zephyr`_ documentation page on the MCUboot website.
 
 .. _MCUboot boot loader: https://mcuboot.com/
-.. _MCUboot with Zephyr: https://mcuboot.com/readme-zephyr.html
+.. _MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/
 .. _MCUboot GitHub Project: https://github.com/runtimeco/mcuboot


### PR DESCRIPTION
"MCUboot with Zephyr" now links to the correct website and no longer gives 404.

Current live version points to a 404.

Last week I did a similar pull request, but the structure of MCUboot.com has changed once again. 

Signed-off-by: Mihail Marinov <genderlik@gmail.com>