### PR TITLE
driver: uart: npcx: Fix CR_SIN interrupt storm

### DIFF
--- a/soc/arm/nuvoton_npcx/common/power.c
+++ b/soc/arm/nuvoton_npcx/common/power.c
@@ -52,6 +52,7 @@
 #include <soc.h>
 
 #include "soc_host.h"
+#include "soc_power.h"
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
@@ -127,6 +128,11 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 	/* Turn on eSPI/LPC host access wake-up interrupt. */
 	if (IS_ENABLED(CONFIG_ESPI_NPCX)) {
 		npcx_host_enable_access_interrupt();
+	}
+
+	/* Turn on UART RX wake-up interrupt. */
+	if (IS_ENABLED(CONFIG_UART_NPCX)) {
+		npcx_uart_enable_access_interrupt();
 	}
 
 	/*

--- a/soc/arm/nuvoton_npcx/common/soc_power.h
+++ b/soc/arm/nuvoton_npcx/common/soc_power.h
@@ -36,6 +36,16 @@ void npcx_power_console_is_in_use_refresh(void);
  */
 void npcx_power_set_console_in_use_timeout(int64_t timeout);
 
+/**
+ * @brief Disable UART RX wake-up interrupt.
+ */
+void npcx_uart_disable_access_interrupt(void);
+
+/**
+ * @brief Enable UART RX wake-up interrupt.
+ */
+void npcx_uart_enable_access_interrupt(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
NPCX WIMU CR_SIN is used to wake up soc from NPCX sleep power state.
The wake-up IRQ enabled when UART init. It causes the wake-up IRQ to
generate many extra interrupt events, which causes the system too busy
to handle other events. This PR moves the UART wake-up IRQ enabling
from UART init to npcx_power_enter_system_sleep() to avoid the
interrupt storm.