### PR TITLE
boards: arm: b_l4s5i_iot01a: SPI chip-select is active low.

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -131,8 +131,8 @@
 	pinctrl-0 = <&spi3_sck_pc10 &spi3_miso_pc11 &spi3_mosi_pc12>;
 	status = "okay";
 
-	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>,
-		   <&gpioe 0 GPIO_ACTIVE_HIGH>;
+	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+		   <&gpioe 0 GPIO_ACTIVE_LOW>;
 
 	spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";


### PR DESCRIPTION
According to RM0432, the chip-select of SPI is active low.

Fixes #36289

Signed-off-by: Sam Chen <sam.chen@iota.org>