### PR TITLE
tests/drivers: stm32f746g_disco: Enabling soc-flash support in overlays

### DIFF
--- a/boards/arm/stm32f746g_disco/doc/index.rst
+++ b/boards/arm/stm32f746g_disco/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr stm32f746g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
+| FLASH     | on-chip    | flash memory                        |
++-----------+------------+-------------------------------------+
 | ETHERNET  | on-chip    | Ethernet                            |
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
@@ -112,7 +114,7 @@ The Zephyr stm32f746g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
-| QSPI NOR  | on-chip    | flash                               |
+| QSPI NOR  | on-chip    | off-chip flash                      |
 +-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.

--- a/tests/drivers/flash/boards/stm32f746g_disco.overlay
+++ b/tests/drivers/flash/boards/stm32f746g_disco.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+       chosen {
+               zephyr,flash-controller = &flash;
+       };
+};
+
+&quadspi {
+       qspi-nor-flash@0 {
+               partitions {
+                       /delete-node/ partition@a0000;
+               };
+       };
+};
+
+&flash0 {
+        partitions {
+               compatible = "fixed-partitions";
+               #address-cells = <1>;
+               #size-cells = <1>;
+
+                /* Set 2KB of storage at the end of 1MB flash */
+                storage_partition: partition@ff800 {
+                        label = "storage";
+                        reg = <0x000ff800 0x00000800>;
+                };
+       };
+};


### PR DESCRIPTION
This commit enables soc-flash support in stm32f746g_disco only for
flash test. Using overlays, it adds soc-flash storage partition and deletes
qspi-flash storage partition for flash test. Both flash test and
spi_flash application has been tested on stm32f746g_disco platform.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>