### PR TITLE
tests/drivers: disco_l475_iot1: Enabling soc-flash support in overlays.

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -177,7 +177,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -273,12 +273,12 @@
 
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 0x000D8000>;
+				reg = <0x00000000 0x000d8000>;
 				};
 
-			storage_partition: partition@D8000 {
+			storage_partition: partition@d8000 {
 				label = "storage";
-				reg = <0x000D8000 DT_SIZE_M(7)>;
+				reg = <0x000d8000 DT_SIZE_M(7)>;
 			};
 		};
 	};

--- a/boards/arm/disco_l475_iot1/doc/index.rst
+++ b/boards/arm/disco_l475_iot1/doc/index.rst
@@ -115,6 +115,8 @@ The Zephyr Disco L475 IoT board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
+| FLASH     | on-chip    | flash memory                        |
++-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
@@ -125,7 +127,7 @@ The Zephyr Disco L475 IoT board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
-| QSPI NOR  | on-chip    | flash                               |
+| QSPI NOR  | on-chip    | off-chip flash                      |
 +-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.

--- a/tests/drivers/flash/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/flash/boards/disco_l475_iot1.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+};
+
+&quadspi {
+	qspi-nor-flash@0 {
+		partitions {
+			/delete-node/ partition@d8000;
+		};
+	};
+};
+
+&flash0 {
+        partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 2KB of storage at the end of 1MB flash */
+		storage_partition: partition@ff800 {
+			label = "storage";
+			reg = <0x000ff800 0x00000800>;
+		};
+	};
+};


### PR DESCRIPTION
This commit enables soc-flash support in disco_l475_iot1
only for flash test. Using overlays, it adds soc-flash storage
partition and deletes qspi-flash storage parition for
flash test. Both flash test and spi_flash application
has been tested on disco_l475_iot1 platform.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>