### PR TITLE
Bluetooth: controller: fix adv slot reservation calc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1098,6 +1098,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 			}
 
 			slot_us += (BYTES2US(adv_size, phy) + EVENT_IFS_MAX_US
+				  + scan_req_us + 2 * EVENT_IFS_MAX_US + scan_rsp_us
 				  + rx_to_us + rxtx_turn_us) * (adv_chn_cnt-1)
 				  + BYTES2US(adv_size, phy) + EVENT_IFS_MAX_US;
 		}


### PR DESCRIPTION
Only one instance of scan req/rsp was accounted for in the reservation
calculation. Since there can be one per adv channel these should also
be accounted for.

Signed-off-by: Erik Brockhoff <erbr@oticon.com>