### PR TITLE
dts: arm: stm32g0: Add cpu0 label

### DIFF
--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -23,7 +23,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;


### PR DESCRIPTION
Add cpu0 label for cpu-idle-states later.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>