### PR TITLE
drivers: timer: st_stm32: add lptimer management to stm32g0 series

### DIFF
--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -5,7 +5,7 @@
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
-	depends on (SOC_SERIES_STM32L4X || SOC_SERIES_STM32L5X || SOC_SERIES_STM32WBX)
+	depends on "$(dt_nodelabel_enabled,lptim1)"
 	depends on CLOCK_CONTROL && PM
 	select TICKLESS_CAPABLE
 	help

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -3,6 +3,7 @@
  * Copyright (c) 2019 ST Microelectronics
  * Copyright (c) 2019 Centaur Analytics, Inc
  * Copyright (C) 2020 Framework Computer LLC <ktl@frame.work>
+ * Copyright (c) 2021 G-Technologies Sdn. Bhd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -196,6 +197,18 @@
 			interrupts = <28 0>;
 			status = "disabled";
 			label = "UART_2";
+		};
+
+		lptim1: timers@40007c00 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40007c00 0x400>;
+			interrupts = <17 0>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+			label = "LPTIM_1";
 		};
 
 		timers1: timers@40012c00 {


### PR DESCRIPTION
Patches the lptim's Kconfig to compile for the STM32G0 series and adds lptim1 node to the dts.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>