### PR TITLE
twister: fix skips to errors on integration platforms

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,14 +1,13 @@
 sample:
   name: Shell Sample
-common:
-  integration_platforms:
-    - native_posix
 tests:
   sample.shell.shell_module:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     min_ram: 40
+    integration_platforms:
+      - native_posix
   sample.shell.shell_module.usb:
     depends_on: usb_device
     tags: shell usb
@@ -16,11 +15,15 @@ tests:
     min_ram: 40
     extra_args: OVERLAY_CONFIG="overlay-usb.conf"
                 DTC_OVERLAY_FILE="usb.overlay"
+    integration_platforms:
+      - native_posix
   sample.shell.shell_module.minimal:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     extra_args: CONF_FILE="prj_minimal.conf"
+    integration_platforms:
+      - native_posix
   sample.shell.shell_module.getopt:
     integration_platforms:
       - qemu_x86
@@ -35,9 +38,13 @@ tests:
     tags: shell
     harness: keyboard
     extra_args: CONF_FILE="prj_minimal_rtt.conf"
+    integration_platforms:
+      - nrf52833dk_nrf52833
   sample.shell.shell_module.login:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     tags: shell
     harness: keyboard
     min_ram: 40
     extra_args: CONF_FILE="prj_login.conf"
+    integration_platforms:
+      - native_posix

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2497,11 +2497,18 @@ class ProjectBuilder(FilterBuilder):
             else:
                 if self.instance.name in res['filter'] and res['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = "skipped"
-                    self.instance.reason = "filter"
-                    results.skipped_runtime += 1
-                    for case in self.instance.testcase.cases:
-                        self.instance.results.update({case: 'SKIP'})
+                    if self.suite.integration and self.instance.platform.name in self.instance.testcase.integration_platforms:
+                        self.instance.status = "error"
+                        self.instance.reason = "Filtered but is one of the integration platforms"
+                        results.error += 1
+                        for case in self.instance.testcase.cases:
+                            self.instance.results.update({case: 'BLOCK'})
+                    else:
+                        self.instance.status = "skipped"
+                        self.instance.reason = "filter"
+                        results.skipped_runtime += 1
+                        for case in self.instance.testcase.cases:
+                            self.instance.results.update({case: 'SKIP'})
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "build", "test": self.instance})

--- a/tests/subsys/logging/log_core_additional/testcase.yaml
+++ b/tests/subsys/logging/log_core_additional/testcase.yaml
@@ -1,18 +1,22 @@
-common:
-  integration_platforms:
-    - native_posix
-
 tests:
   logging.add.async:
     tags: logging
     extra_args: CONF_FILE=log2.conf
+    integration_platforms:
+      - native_posix
   logging.add.sync:
     tags: logging
     extra_args: CONF_FILE=log_sync.conf
+    integration_platforms:
+      - native_posix
   logging.add.log1_user:
     tags: logging
     filter: CONFIG_USERSPACE
     extra_args: CONF_FILE=log_user.conf USERSPACE_TEST=1
+    integration_platforms:
+      - qemu_x86
   logging.add.log1:
     tags: logging
     extra_args: CONF_FILE=prj.conf
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
With this commit twister marks tests filtered out during cmake stage
as errors if the integration mode is on and the tested platform is in
the test's integration_platforms. Before only prefiltered tests were
marked accordingly.

Issue found at PR #36157

Fixes: #34927

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>