### PR TITLE
fs/nvs: prevent use after clear without init

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -840,6 +840,10 @@ int nvs_clear(struct nvs_fs *fs)
 			return rc;
 		}
 	}
+
+	/* nvs needs to be reinitialized after clearing */
+	fs->ready = false;
+
 	return 0;
 }
 


### PR DESCRIPTION
I have noticed that problems with the GC arise if you use an nvs fs after clearing.
As far as I understand we need to retrigger `nvs_startup` after clearing it before it can be used.
If that is indeed the case we should prevent any writes or reads on the fs before it is `ready` again.

Signed-off-by: Ioannis Papamanoglou <ioannis.papamanoglou@zonneplan.nl>