### PR TITLE
lpadc: a bug fixed for the drivers/adc_mcux_lpadc.c

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -106,7 +106,7 @@ static int mcux_lpadc_start_read(const struct device *dev,
 #else
 	/* If FSL_FEATURE_LPADC_HAS_CMDL_MODE is not defined
 	   only 12/13 bit resolution is supported. */
-	if (sequence->resolution != 12 || sequence->resolution != 13) {
+	if (sequence->resolution != 12 && sequence->resolution != 13) {
 		LOG_ERR("Unsupported resolution %d", sequence->resolution);
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
it need to be a && between two condition, to satisfy
the comment: only 12 / 13 bit resolution is supported,
if FSL_FEATURE_LPADC_HAS_CMDL_MODE is not defined. not
using ||.

Signed-off-by: Crist Xu <crist.xu@nxp.com>