### PR TITLE
testsuite: suppress usage of setjmp in a testcode

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -207,6 +207,7 @@ static void run_test_functions(struct unit_test *test)
 }
 
 #ifndef KERNEL
+/* parasoft suppress item MISRAC2012-RULE_21_4-b "setjmp using in test code" */
 #include <setjmp.h>
 #include <signal.h>
 #include <string.h>


### PR DESCRIPTION
According to the rule MISRAC-2012 21.4.b the standard header
file <setjmp.h> shall not be used. Suppress it, because it raises
violation in a testcode, not in a runtime code.
Tag suppresses reporting of violation for the current file,
starting from the line where the suppression is located.

Found as a coding guideline violation (MISRA R21.4.b) by static
coding scanning tool.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>