### PR TITLE
doc: fix notfound prefix for latest docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -205,7 +205,7 @@ warnings_filter_silent = False
 
 # -- Options for notfound.extension ---------------------------------------
 
-notfound_urls_prefix = f"/{version}/"
+notfound_urls_prefix = f"/{version}/" if is_release else "/latest/"
 
 # -- Options for zephyr.external_content ----------------------------------
 


### PR DESCRIPTION
The notfound extension prefix was incorrect for 'latest' docs version.