### PR TITLE
actions: doc: always publish 404.html as the main 404.html

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -89,6 +89,7 @@ jobs:
         if [ "$RELEASE" == "latest" ]; then
            echo "publish latest docs"
            aws s3 sync  --quiet doc/_build/html s3://docs.zephyrproject.org/latest --delete
+           aws s3 cp doc/_build/html/404.html s3://docs.zephyrproject.org/404.html
            echo "success sync of latest docs"
         else
            # we want just the version, without the leading 'v'


### PR DESCRIPTION
We use one 404.html for all releases. This is the one from latest doc
build and is managed by AWS. Now that we have the path in the source, we
can copy the file and point to it directly. Previously a base was added
manually, we do not need this anymore.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
