### PR TITLE
net: lwm2m: notify timeout handling

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -65,6 +65,7 @@
 /* clang-format on */
 
 typedef void (*lwm2m_socket_fault_cb_t)(int error);
+typedef void (*lwm2m_notify_timeout_cb_t)(void);
 
 /**
  * @brief LwM2M context structure to maintain information for a single
@@ -124,6 +125,11 @@ struct lwm2m_ctx {
 	 *  callback in case of socket errors on receive.
 	 */
 	lwm2m_socket_fault_cb_t fault_cb;
+
+	/** Notify Timeout Callback. LwM2M processing thread will call this
+	 *  callback in case of notify timeout.
+	 */
+	lwm2m_notify_timeout_cb_t notify_timeout_cb;
 
 	/** Validation buffer. Used as a temporary buffer to decode the resource
 	 *  value before validation. On successful validation, its content is
@@ -1025,6 +1031,11 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  */
 void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			  lwm2m_ctx_event_cb_t event_cb);
+
+/**
+ * @brief Trigger a Registration Update of the LwM2M RD Client
+ */
+void lwm2m_rd_client_update(void);
 
 #endif	/* ZEPHYR_INCLUDE_NET_LWM2M_H_ */
 /**@}  */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4247,6 +4247,19 @@ static int32_t retransmit_request(struct lwm2m_ctx *client_ctx,
 	return next_retransmission;
 }
 
+static void notify_message_timeout_cb(struct lwm2m_message *msg)
+{
+	if (msg->ctx != NULL) {
+		struct lwm2m_ctx *client_ctx = msg->ctx;
+
+		if (client_ctx->notify_timeout_cb != NULL) {
+			client_ctx->notify_timeout_cb();
+		}
+	}
+
+	LOG_ERR("Notify Message Timed Out : %p", msg);
+}
+
 static int notify_message_reply_cb(const struct coap_packet *response,
 				   struct coap_reply *reply,
 				   const struct sockaddr *from)
@@ -4324,6 +4337,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 	msg->token = obs->token;
 	msg->tkl = obs->tkl;
 	msg->reply_cb = notify_message_reply_cb;
+	msg->message_timeout_cb = notify_message_timeout_cb;
 	msg->out.out_cpkt = &msg->cpkt;
 
 	ret = lwm2m_init_message(msg);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1060,6 +1060,11 @@ void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 	LOG_INF("Stop LWM2M Client: %s", log_strdup(client.ep_name));
 }
 
+void lwm2m_rd_client_update(void)
+{
+	engine_trigger_update(false);
+}
+
 static int lwm2m_rd_client_init(const struct device *dev)
 {
 	return lwm2m_engine_add_service(lwm2m_rd_client_service,


### PR DESCRIPTION
Added notify_timeout_cb to struct lwm2m_ctx to allow application to
 handle notify timeout
Added lwm2m_rd_client_update to lwm2m.h to allow application to
 trigger registration update
Added notify_message_timeout_cb which calls notify_timeout_cb from
 struct lwm2m_ctx and logs an error message

Signed-off-by: John Power <john.power@xylem.com>