### PR TITLE
samples: subsys: fs: fat_fs: adafruit needs arduino_i2c dependency

### DIFF
--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -11,7 +11,7 @@ tests:
   sample.filesystem.fat_fs.overlay:
     platform_allow: nrf52840_blip
   sample.filesystem.fat_fs.adafruit_2_8_tft_touch_v2:
-    depends_on: arduino_spi arduino_gpio
+    depends_on: arduino_spi arduino_gpio arduino_i2c
     extra_args: SHIELD=adafruit_2_8_tft_touch_v2
     tags: shield
     harness: console


### PR DESCRIPTION
samples: subsys: fs: fat_fs: adafruit needs arduino_i2c dependency

Shield adafruit_2_8_tft_touch_v2 needs arduino_i2c dependency.
Fixes #36448
