### PR TITLE
sensor: bq274xx: add public API for additional status info

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -9,6 +9,7 @@
 #include <drivers/i2c.h>
 #include <init.h>
 #include <drivers/sensor.h>
+#include <drivers/sensor/bq274xx.h>
 #include <sys/__assert.h>
 #include <string.h>
 #include <sys/byteorder.h>
@@ -142,6 +143,11 @@ static int bq274xx_channel_get(const struct device *dev,
 	float int_temp;
 
 	switch (chan) {
+	case SENSOR_CHAN_BQ274XX_STATUS:
+		val->val1 = bq274xx->flags;
+		val->val2 = 0;
+		break;
+
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
 		val->val1 = ((bq274xx->voltage / 1000));
 		val->val2 = ((bq274xx->voltage % 1000) * 1000U);
@@ -230,6 +236,15 @@ static int bq274xx_sample_fetch(const struct device *dev,
 #endif
 
 	switch (chan) {
+	case SENSOR_CHAN_BQ274XX_STATUS:
+		status = bq274xx_command_reg_read(
+			bq274xx, BQ274XX_COMMAND_FLAGS, &bq274xx->flags);
+		if (status < 0) {
+			LOG_ERR("Failed to read flags");
+			return -EIO;
+		}
+		break;
+
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
 		status = bq274xx_command_reg_read(
 			bq274xx, BQ274XX_COMMAND_VOLTAGE, &bq274xx->voltage);

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -83,6 +83,7 @@ struct bq274xx_data {
 #ifdef CONFIG_BQ274XX_LAZY_CONFIGURE
 	bool lazy_loaded;
 #endif
+	uint16_t flags;
 	uint16_t voltage;
 	int16_t avg_current;
 	int16_t stdby_current;

--- a/include/drivers/sensor/bq274xx.h
+++ b/include/drivers/sensor/bq274xx.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Extended public API for the Texas Instruments BQ274XX
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_BQ274XX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_BQ274XX_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <drivers/sensor.h>
+
+/** Discharge detected */
+#define BQ274XX_STATUS_DSG                   BIT(0)
+/** Battery insertion detected */
+#define BQ274XX_STATUS_BAT_DET               BIT(3)
+/** Fast charging allowed */
+#define BQ274XX_STATUS_CHG                   BIT(8)
+/** Full-charge detected */
+#define BQ274XX_STATUS_FC                    BIT(9)
+/** Under-Temperature condition detected */
+#define BQ274XX_STATUS_UT                    BIT(14)
+/** Over-Temperature condition detected */
+#define BQ274XX_STATUS_OT                    BIT(15)
+
+enum sensor_channel_bq274xx {
+	/** Gauge status channel, in bitflags **/
+	SENSOR_CHAN_BQ274XX_STATUS = SENSOR_CHAN_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_BQ274XX_ */


### PR DESCRIPTION
The BQ274XX fuel gauge has status flag indicators for discharge detection, battery detection and others.
This commit adds a public API to fetch/get a status sensor channel.