### PR TITLE
asserts: stm32: Adding asserts enable/disable

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -15,3 +15,9 @@ config STM32_BACKUP_SRAM
 		   SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 	help
 	  Enable support for STM32 backup SRAM.
+
+config USE_STM32_ASSERT
+	depends on ASSERT
+	bool "STM32Cube HAL and LL drivers asserts"
+	help
+	  Enable asserts in STM32Cube HAL and LL drivers.

--- a/soc/arm/st_stm32/common/stm32cube_hal.c
+++ b/soc/arm/st_stm32/common/stm32cube_hal.c
@@ -35,3 +35,19 @@ void HAL_Delay(__IO uint32_t Delay)
 {
 	k_msleep(Delay);
 }
+
+#ifdef CONFIG_USE_STM32_ASSERT
+/**
+ * @brief Generates an assert on STM32Cube HAL/LL assert trigger.
+ * @param file: specifies the file name where assert expression failed.
+ * @param line: specifies the line number where assert expression failed.
+ * @return None
+ */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+	/* Assert condition have been verified at Cube level, force
+	 * generation here.
+	 */
+	__ASSERT(false, "Invalid value line %d @ %s\n", line, file);
+}
+#endif /* CONFIG_USE_STM32_ASSERT */

--- a/west.yml
+++ b/west.yml
@@ -82,7 +82,7 @@ manifest:
       revision: 575de9d461aa6f430cf62c58a053675377e700f3
       path: modules/hal/st
     - name: hal_stm32
-      revision: f8ff8d25aa0a9e65948040c7b47ec67f3fa300df
+      revision: dc83915685a5b32a299388e54e0fd259ded86bc4
       path: modules/hal/stm32
     - name: hal_ti
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e


### PR DESCRIPTION
This commit allows to enable asserts functionality for stm32 series.
STM32Cube hal & ll drivers provides asserts and the same can be 
enabled using a Kconfig symbol USE_STM32_ASSERT.

Depends on https://github.com/zephyrproject-rtos/hal_stm32/pull/100

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>