### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: fixup llcp common waiting for ntf buffer

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -519,15 +519,17 @@ static void lp_comm_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint
 	switch (evt) {
 	case LP_COMMON_EVT_RUN:
 		switch (ctx->proc) {
+		case PROC_FEATURE_EXCHANGE:
+		case PROC_VERSION_EXCHANGE:
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		case PROC_DATA_LENGTH_UPDATE:
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 			if (ntf_alloc_is_available()) {
 				lp_comm_ntf(conn, ctx);
 				lr_complete(conn);
 				ctx->state = LP_COMMON_STATE_IDLE;
 			}
 			break;
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 		default:
 			break;
 		}
@@ -875,7 +877,11 @@ static void rp_comm_st_wait_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, u
 
 static void rp_comm_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	/* TODO */
+	if (ntf_alloc_is_available()) {
+		rp_comm_ntf(conn, ctx);
+		rr_complete(conn);
+		ctx->state = RP_COMMON_STATE_IDLE;
+	}
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 


### PR DESCRIPTION
Waiting for ntf buffer for local fex and vex was missing
Waiting for ntf for remote dle was missing 

Signed-off-by: Erik Brockhoff <erbr@oticon.com>