### PR TITLE
sensor: add support for reading euler angles with sensor api

### DIFF
--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -81,6 +81,15 @@ enum sensor_channel {
 	SENSOR_CHAN_AMBIENT_TEMP,
 	/** Pressure in kilopascal. */
 	SENSOR_CHAN_PRESS,
+	/** Euler heading(yaw) in degrees */
+	SENSOR_CHAN_EULER_H,
+	/** Euler roll in degrees */
+	SENSOR_CHAN_EULER_R,
+	/** Euler pitch in degrees */
+	SENSOR_CHAN_EULER_P,
+	/** Euler heading, roll and pitch in degrees */
+	SENSOR_CHAN_EULER_HRP,
+
 	/**
 	 * Proximity.  Adimensional.  A value of 1 indicates that an
 	 * object is close.


### PR DESCRIPTION
Add the possibility to read euler angels with sensor api.
For example the bno055 sensor from bosch supports euler angles. The
sensor is not yet supported from zephyr.

Signed-off-by: Tobias Mierzwa <tobias.mierzwa@mni.thm.de>