### PR TITLE
gpio: additional `struct gpio_dt_spec` helper functions

### DIFF
--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -36,7 +36,7 @@ static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8
 
 	led_gpio = &config->led[led];
 
-	return gpio_pin_set(led_gpio->port, led_gpio->pin, value > 0);
+	return gpio_pin_set_dt(led_gpio, value > 0);
 }
 
 static int led_gpio_on(const struct device *dev, uint32_t led)

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -1116,6 +1116,21 @@ static inline int gpio_pin_get(const struct device *port, gpio_pin_t pin)
 }
 
 /**
+ * @brief Get logical level of an input pin from a @p gpio_dt_spec.
+ *
+ * This is equivalent to:
+ *
+ *     gpio_pin_get(spec->port, spec->pin);
+ *
+ * @param spec GPIO specification from devicetree
+ * @retval a value from gpio_pin_get()
+ */
+static inline int gpio_pin_get_dt(const struct gpio_dt_spec *spec)
+{
+	return gpio_pin_get(spec->port, spec->pin);
+}
+
+/**
  * @brief Set physical level of an output pin.
  *
  * Writing value 0 to the pin will set it to a low physical level. Writing any
@@ -1191,6 +1206,22 @@ static inline int gpio_pin_set(const struct device *port, gpio_pin_t pin,
 }
 
 /**
+ * @brief Set logical level of a output pin from a @p gpio_dt_spec.
+ *
+ * This is equivalent to:
+ *
+ *     gpio_pin_set(spec->port, spec->pin, value);
+ *
+ * @param spec GPIO specification from devicetree
+ * @param value Value assigned to the pin.
+ * @retval a value from gpio_pin_set()
+ */
+static inline int gpio_pin_set_dt(const struct gpio_dt_spec *spec, int value)
+{
+	return gpio_pin_set(spec->port, spec->pin, value);
+}
+
+/**
  * @brief Toggle pin level.
  *
  * @param port Pointer to the device structure for the driver instance.
@@ -1210,6 +1241,21 @@ static inline int gpio_pin_toggle(const struct device *port, gpio_pin_t pin)
 		 "Unsupported pin");
 
 	return gpio_port_toggle_bits(port, (gpio_port_pins_t)BIT(pin));
+}
+
+/**
+ * @brief Toggle pin level from a @p gpio_dt_spec.
+ *
+ * This is equivalent to:
+ *
+ *     gpio_pin_toggle(spec->port, spec->pin);
+ *
+ * @param spec GPIO specification from devicetree
+ * @retval a value from gpio_pin_toggle()
+ */
+static inline int gpio_pin_toggle_dt(const struct gpio_dt_spec *spec)
+{
+	return gpio_pin_toggle(spec->port, spec->pin);
 }
 
 /**

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -87,10 +87,10 @@ void main(void)
 	if (led.port) {
 		while (1) {
 			/* If we have an LED, match its state to the button's. */
-			int val = gpio_pin_get(button.port, button.pin);
+			int val = gpio_pin_get_dt(&button);
 
 			if (val >= 0) {
-				gpio_pin_set(led.port, led.pin, val);
+				gpio_pin_set_dt(&led, val);
 			}
 			k_msleep(SLEEP_TIME_MS);
 		}


### PR DESCRIPTION
Add helpers to allow providing a `struct gpio_spec_dt` directly to `gpio_pin_get`, `gpio_pin_set` and `gpio_pin_toggle` functions. The intention of this PR is to simplify GPIO usage in the same vein as `gpio_pin_configure_dt` and `gpio_pin_configure_interrupt_dt`.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>