### PR TITLE
Decouple broadcast ISO and ACL connection functions

### DIFF
--- a/samples/bluetooth/iso_broadcast/prj.conf
+++ b/samples/bluetooth/iso_broadcast/prj.conf
@@ -5,4 +5,4 @@ CONFIG_BT_DEVICE_NAME="Test ISO Broadcaster"
 
 # Temporary, enable the following to meet BT_ISO dependencies
 CONFIG_BT_OBSERVER=y
-CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_BROADCASTER=y

--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -77,6 +77,7 @@ if(CONFIG_BT_HCI_HOST)
   zephyr_library_sources_ifdef(
     CONFIG_BT_ISO
     iso.c
+    conn.c
     )
 
   if(CONFIG_BT_DF)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -83,6 +83,7 @@ static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
 static void deferred_work(struct k_work *work);
+static void tx_complete_work(struct k_work *work);
 #endif /* CONFIG_BT_CONN */
 
 struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
@@ -334,16 +335,6 @@ static void tx_notify(struct bt_conn *conn)
 		 */
 		cb(conn, user_data);
 	}
-}
-
-static void tx_complete_work(struct k_work *work)
-{
-	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn,
-					   tx_complete_work);
-
-	BT_DBG("conn %p", conn);
-
-	tx_notify(conn);
 }
 
 struct bt_conn *bt_conn_new(struct bt_conn *conns, size_t size)
@@ -1324,6 +1315,16 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+static void tx_complete_work(struct k_work *work)
+{
+	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn,
+					   tx_complete_work);
+
+	BT_DBG("conn %p", conn);
+
+	tx_notify(conn);
+}
 
 static struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2717,6 +2717,8 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 	return (uint8_t)index;
 }
 
+/* Group Connected BT_CONN only in this */
+#if defined(CONFIG_BT_CONN)
 struct bt_conn *bt_conn_lookup_index(uint8_t index)
 {
 	if (index >= ARRAY_SIZE(acl_conns)) {
@@ -2767,3 +2769,5 @@ int bt_conn_init(void)
 
 	return 0;
 }
+
+#endif /* CONFIG_BT_CONN */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -102,7 +102,11 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 		}
 	}
 #endif /* CONFIG_BT_ISO */
+#if defined(CONFIG_BT_CONN)
 	return &bt_dev.le.acl_pkts;
+#else
+	return NULL;
+#endif /* CONFIG_BT_CONN */
 }
 
 static inline const char *state2str(bt_conn_state_t state)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -831,6 +831,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			break;
 		}
 
+#if defined(CONFIG_BT_CONN)
 		sys_slist_init(&conn->channels);
 
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
@@ -838,9 +839,15 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			k_work_schedule(&conn->deferred_work,
 					CONN_UPDATE_TIMEOUT);
 		}
+#endif /* CONFIG_BT_CONN */
 
 		break;
 	case BT_CONN_DISCONNECTED:
+		if (conn->type == BT_CONN_TYPE_ISO) {
+			break;
+		}
+
+#if defined(CONFIG_BT_CONN)
 		if (conn->type == BT_CONN_TYPE_SCO) {
 			/* TODO: Notify sco disconnected */
 			bt_conn_unref(conn);
@@ -916,6 +923,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			break;
 		}
 		break;
+#endif /* CONFIG_BT_CONN */
 	case BT_CONN_CONNECT_AUTO:
 		break;
 	case BT_CONN_CONNECT_ADV:

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -466,11 +466,6 @@ struct bt_conn *bt_conn_new(struct bt_conn *conns, size_t size)
 	return conn;
 }
 
-static struct bt_conn *acl_conn_new(void)
-{
-	return bt_conn_new(acl_conns, ARRAY_SIZE(acl_conns));
-}
-
 void bt_conn_reset_rx_state(struct bt_conn *conn)
 {
 	if (!conn->rx) {
@@ -1423,6 +1418,11 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+static struct bt_conn *acl_conn_new(void)
+{
+	return bt_conn_new(acl_conns, ARRAY_SIZE(acl_conns));
+}
 
 #if defined(CONFIG_BT_BREDR)
 void bt_sco_cleanup(struct bt_conn *sco_conn)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1060,6 +1060,38 @@ void bt_conn_unref(struct bt_conn *conn)
 	}
 }
 
+uint8_t bt_conn_index(struct bt_conn *conn)
+{
+	ptrdiff_t index;
+
+	switch (conn->type) {
+#if defined(CONFIG_BT_ISO)
+	case BT_CONN_TYPE_ISO:
+		index = conn - iso_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(iso_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+#if defined(CONFIG_BT_BREDR)
+	case BT_CONN_TYPE_SCO:
+		index = conn - sco_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(sco_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+	default:
+		index = conn - acl_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(acl_conns),
+			 "Invalid bt_conn pointer");
+		break;
+	}
+
+	return (uint8_t)index;
+}
+
+/* Group Connected BT_CONN only in this */
+#if defined(CONFIG_BT_CONN)
+
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	int err;
@@ -1120,38 +1152,6 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 		return -ENOTCONN;
 	}
 }
-
-uint8_t bt_conn_index(struct bt_conn *conn)
-{
-	ptrdiff_t index;
-
-	switch (conn->type) {
-#if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		index = conn - iso_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(iso_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-#if defined(CONFIG_BT_BREDR)
-	case BT_CONN_TYPE_SCO:
-		index = conn - sco_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(sco_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-	default:
-		index = conn - acl_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(acl_conns),
-			 "Invalid bt_conn pointer");
-		break;
-	}
-
-	return (uint8_t)index;
-}
-
-/* Group Connected BT_CONN only in this */
-#if defined(CONFIG_BT_CONN)
 
 static void notify_connected(struct bt_conn *conn)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1899,11 +1899,6 @@ void bt_conn_unref(struct bt_conn *conn)
 	}
 }
 
-const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
-{
-	return &conn->le.dst;
-}
-
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	int err;
@@ -1996,6 +1991,11 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
+{
+	return &conn->le.dst;
+}
 
 int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -761,12 +761,6 @@ struct bt_conn *conn_lookup_handle(struct bt_conn *conns, size_t size,
 	return NULL;
 }
 
-void bt_conn_connected(struct bt_conn *conn)
-{
-	bt_l2cap_connected(conn);
-	notify_connected(conn);
-}
-
 void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 {
 	bt_conn_state_t old_state;
@@ -1102,6 +1096,12 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+void bt_conn_connected(struct bt_conn *conn)
+{
+	bt_l2cap_connected(conn);
+	notify_connected(conn);
+}
 
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2114,42 +2114,6 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
 }
 #endif
 
-#if defined(CONFIG_BT_USER_PHY_UPDATE)
-int bt_conn_le_phy_update(struct bt_conn *conn,
-			  const struct bt_conn_le_phy_param *param)
-{
-	uint8_t phy_opts, all_phys;
-
-	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
-	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_PHY_COMPLETE)) {
-		return -EAGAIN;
-	}
-
-	if ((param->options & BT_CONN_LE_PHY_OPT_CODED_S2) &&
-	    (param->options & BT_CONN_LE_PHY_OPT_CODED_S8)) {
-		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
-	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S2) {
-		phy_opts = BT_HCI_LE_PHY_CODED_S2;
-	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S8) {
-		phy_opts = BT_HCI_LE_PHY_CODED_S8;
-	} else {
-		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
-	}
-
-	all_phys = 0U;
-	if (param->pref_tx_phy == BT_GAP_LE_PHY_NONE) {
-		all_phys |= BT_HCI_LE_PHY_TX_ANY;
-	}
-
-	if (param->pref_rx_phy == BT_GAP_LE_PHY_NONE) {
-		all_phys |= BT_HCI_LE_PHY_RX_ANY;
-	}
-
-	return bt_le_set_phy(conn, all_phys, param->pref_tx_phy,
-			     param->pref_rx_phy, phy_opts);
-}
-#endif
-
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	/* Disconnection is initiated by us, so auto connection shall
@@ -2226,6 +2190,42 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+int bt_conn_le_phy_update(struct bt_conn *conn,
+			  const struct bt_conn_le_phy_param *param)
+{
+	uint8_t phy_opts, all_phys;
+
+	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
+	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_PHY_COMPLETE)) {
+		return -EAGAIN;
+	}
+
+	if ((param->options & BT_CONN_LE_PHY_OPT_CODED_S2) &&
+	    (param->options & BT_CONN_LE_PHY_OPT_CODED_S8)) {
+		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
+	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S2) {
+		phy_opts = BT_HCI_LE_PHY_CODED_S2;
+	} else if (param->options & BT_CONN_LE_PHY_OPT_CODED_S8) {
+		phy_opts = BT_HCI_LE_PHY_CODED_S8;
+	} else {
+		phy_opts = BT_HCI_LE_PHY_CODED_ANY;
+	}
+
+	all_phys = 0U;
+	if (param->pref_tx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_TX_ANY;
+	}
+
+	if (param->pref_rx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_RX_ANY;
+	}
+
+	return bt_le_set_phy(conn, all_phys, param->pref_tx_phy,
+			     param->pref_rx_phy, phy_opts);
+}
+#endif
 
 #if defined(CONFIG_BT_CENTRAL)
 static void bt_conn_set_param_le(struct bt_conn *conn,

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1409,48 +1409,6 @@ void bt_conn_process_tx(struct bt_conn *conn)
 	}
 }
 
-bool bt_conn_exists_le(uint8_t id, const bt_addr_le_t *peer)
-{
-	struct bt_conn *conn = bt_conn_lookup_addr_le(id, peer);
-
-	if (conn) {
-		/* Connection object already exists.
-		 * If the connection state is not "disconnected",then the
-		 * connection was created but has not yet been disconnected.
-		 * If the connection state is "disconnected" then the connection
-		 * still has valid references. The last reference of the stack
-		 * is released after the disconnected callback.
-		 */
-		BT_WARN("Found valid connection in %s state",
-			state2str(conn->state));
-		bt_conn_unref(conn);
-		return true;
-	}
-
-	return false;
-}
-
-struct bt_conn *bt_conn_add_le(uint8_t id, const bt_addr_le_t *peer)
-{
-	struct bt_conn *conn = acl_conn_new();
-
-	if (!conn) {
-		return NULL;
-	}
-
-	conn->id = id;
-	bt_addr_le_copy(&conn->le.dst, peer);
-#if defined(CONFIG_BT_SMP)
-	conn->sec_level = BT_SECURITY_L1;
-	conn->required_sec_level = BT_SECURITY_L1;
-#endif /* CONFIG_BT_SMP */
-	conn->type = BT_CONN_TYPE_LE;
-	conn->le.interval_min = BT_GAP_INIT_CONN_INT_MIN;
-	conn->le.interval_max = BT_GAP_INIT_CONN_INT_MAX;
-
-	return conn;
-}
-
 static void process_unack_tx(struct bt_conn *conn)
 {
 	/* Return any unacknowledged packets */
@@ -1911,6 +1869,48 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+bool bt_conn_exists_le(uint8_t id, const bt_addr_le_t *peer)
+{
+	struct bt_conn *conn = bt_conn_lookup_addr_le(id, peer);
+
+	if (conn) {
+		/* Connection object already exists.
+		 * If the connection state is not "disconnected",then the
+		 * connection was created but has not yet been disconnected.
+		 * If the connection state is "disconnected" then the connection
+		 * still has valid references. The last reference of the stack
+		 * is released after the disconnected callback.
+		 */
+		BT_WARN("Found valid connection in %s state",
+			state2str(conn->state));
+		bt_conn_unref(conn);
+		return true;
+	}
+
+	return false;
+}
+
+struct bt_conn *bt_conn_add_le(uint8_t id, const bt_addr_le_t *peer)
+{
+	struct bt_conn *conn = acl_conn_new();
+
+	if (!conn) {
+		return NULL;
+	}
+
+	conn->id = id;
+	bt_addr_le_copy(&conn->le.dst, peer);
+#if defined(CONFIG_BT_SMP)
+	conn->sec_level = BT_SECURITY_L1;
+	conn->required_sec_level = BT_SECURITY_L1;
+#endif /* CONFIG_BT_SMP */
+	conn->type = BT_CONN_TYPE_LE;
+	conn->le.interval_min = BT_GAP_INIT_CONN_INT_MIN;
+	conn->le.interval_max = BT_GAP_INIT_CONN_INT_MAX;
+
+	return conn;
+}
 
 bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, uint8_t id,
 			     const bt_addr_le_t *peer)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2504,6 +2504,37 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_UPDATE, buf, NULL);
 }
 
+uint8_t bt_conn_index(struct bt_conn *conn)
+{
+	ptrdiff_t index;
+
+	switch (conn->type) {
+#if defined(CONFIG_BT_ISO)
+	case BT_CONN_TYPE_ISO:
+		index = conn - iso_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+#if defined(CONFIG_BT_BREDR)
+	case BT_CONN_TYPE_SCO:
+		index = conn - sco_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+	default:
+		index = conn - acl_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
+			 "Invalid bt_conn pointer");
+		break;
+	}
+
+	return (uint8_t)index;
+}
+
+/* Group Connected BT_CONN only in this */
+#if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve,
 						  k_timeout_t timeout,
@@ -2582,38 +2613,6 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 
 	return buf;
 }
-
-uint8_t bt_conn_index(struct bt_conn *conn)
-{
-	ptrdiff_t index;
-
-	switch (conn->type) {
-#if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		index = conn - iso_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-#if defined(CONFIG_BT_BREDR)
-	case BT_CONN_TYPE_SCO:
-		index = conn - sco_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-	default:
-		index = conn - acl_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
-			 "Invalid bt_conn pointer");
-		break;
-	}
-
-	return (uint8_t)index;
-}
-
-/* Group Connected BT_CONN only in this */
-#if defined(CONFIG_BT_CONN)
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2481,29 +2481,6 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 #endif /* !defined(CONFIG_BT_WHITELIST) */
 #endif /* CONFIG_BT_CENTRAL */
 
-int bt_conn_le_conn_update(struct bt_conn *conn,
-			   const struct bt_le_conn_param *param)
-{
-	struct hci_cp_le_conn_update *conn_update;
-	struct net_buf *buf;
-
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_UPDATE,
-				sizeof(*conn_update));
-	if (!buf) {
-		return -ENOBUFS;
-	}
-
-	conn_update = net_buf_add(buf, sizeof(*conn_update));
-	(void)memset(conn_update, 0, sizeof(*conn_update));
-	conn_update->handle = sys_cpu_to_le16(conn->handle);
-	conn_update->conn_interval_min = sys_cpu_to_le16(param->interval_min);
-	conn_update->conn_interval_max = sys_cpu_to_le16(param->interval_max);
-	conn_update->conn_latency = sys_cpu_to_le16(param->latency);
-	conn_update->supervision_timeout = sys_cpu_to_le16(param->timeout);
-
-	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_UPDATE, buf, NULL);
-}
-
 uint8_t bt_conn_index(struct bt_conn *conn)
 {
 	ptrdiff_t index;
@@ -2535,6 +2512,29 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+int bt_conn_le_conn_update(struct bt_conn *conn,
+			   const struct bt_le_conn_param *param)
+{
+	struct hci_cp_le_conn_update *conn_update;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_UPDATE,
+				sizeof(*conn_update));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	conn_update = net_buf_add(buf, sizeof(*conn_update));
+	(void)memset(conn_update, 0, sizeof(*conn_update));
+	conn_update->handle = sys_cpu_to_le16(conn->handle);
+	conn_update->conn_interval_min = sys_cpu_to_le16(param->interval_min);
+	conn_update->conn_interval_max = sys_cpu_to_le16(param->interval_max);
+	conn_update->conn_latency = sys_cpu_to_le16(param->latency);
+	conn_update->supervision_timeout = sys_cpu_to_le16(param->timeout);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_UPDATE, buf, NULL);
+}
+
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve,
 						  k_timeout_t timeout,

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -911,12 +911,6 @@ bt_security_t bt_conn_get_security(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP */
 
-void bt_conn_cb_register(struct bt_conn_cb *cb)
-{
-	cb->_next = callback_list;
-	callback_list = cb;
-}
-
 void bt_conn_reset_rx_state(struct bt_conn *conn)
 {
 	if (!conn->rx) {
@@ -1869,6 +1863,12 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+void bt_conn_cb_register(struct bt_conn_cb *cb)
+{
+	cb->_next = callback_list;
+	callback_list = cb;
+}
 
 bool bt_conn_exists_le(uint8_t id, const bt_addr_le_t *peer)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -526,7 +526,11 @@ static inline uint16_t conn_mtu(struct bt_conn *conn)
 		return bt_dev.le.iso_mtu;
 	}
 #endif /* CONFIG_BT_ISO */
+#if defined(CONFIG_BT_CONN)
 	return bt_dev.le.acl_mtu;
+#else
+	return 0;
+#endif /* CONFIG_BT_CONN */
 }
 
 static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2096,24 +2096,6 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 	return 0;
 }
 
-#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-int bt_conn_le_data_len_update(struct bt_conn *conn,
-			       const struct bt_conn_le_data_len_param *param)
-{
-	if (conn->le.data_len.tx_max_len == param->tx_max_len &&
-	    conn->le.data_len.tx_max_time == param->tx_max_time) {
-		return -EALREADY;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) &&
-	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_DATA_LEN_COMPLETE)) {
-		return -EAGAIN;
-	}
-
-	return bt_le_set_data_len(conn, param->tx_max_len, param->tx_max_time);
-}
-#endif
-
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	/* Disconnection is initiated by us, so auto connection shall
@@ -2190,6 +2172,24 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
+int bt_conn_le_data_len_update(struct bt_conn *conn,
+			       const struct bt_conn_le_data_len_param *param)
+{
+	if (conn->le.data_len.tx_max_len == param->tx_max_len &&
+	    conn->le.data_len.tx_max_time == param->tx_max_time) {
+		return -EALREADY;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) &&
+	    !atomic_test_bit(conn->flags, BT_CONN_AUTO_DATA_LEN_COMPLETE)) {
+		return -EAGAIN;
+	}
+
+	return bt_le_set_data_len(conn, param->tx_max_len, param->tx_max_time);
+}
+#endif /* CONFIG_BT_USER_DATA_LEN_UPDATE */
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 int bt_conn_le_phy_update(struct bt_conn *conn,

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -438,7 +438,7 @@ static bool send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
 	struct bt_conn_tx *tx = tx_data(buf)->tx;
 	uint32_t *pending_no_cb;
 	unsigned int key;
-	int err;
+	int err = 0;
 
 	BT_DBG("conn %p buf %p len %u flags 0x%02x", conn, buf, buf->len,
 	       flags);
@@ -471,8 +471,10 @@ static bool send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
 
 	if (IS_ENABLED(CONFIG_BT_ISO) && conn->type == BT_CONN_TYPE_ISO) {
 		err = send_iso(conn, buf, flags);
-	} else {
+	} else if (IS_ENABLED(CONFIG_BT_CONN)) {
 		err = send_acl(conn, buf, flags);
+	} else {
+		__ASSERT(false, "Invalid connection type %u", conn->type);
 	}
 
 	if (err) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -276,7 +276,7 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	}
 
 	if (conn->rx->len < sizeof(uint16_t)) {
-		/* Still not enough data recieved to retrieve the L2CAP header
+		/* Still not enough data received to retrieve the L2CAP header
 		 * length field.
 		 */
 		return;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1720,86 +1720,6 @@ struct bt_conn *bt_conn_lookup_handle(uint16_t handle)
 	return NULL;
 }
 
-bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, uint8_t id,
-			     const bt_addr_le_t *peer)
-{
-	if (id != conn->id) {
-		return false;
-	}
-
-	/* Check against conn dst address as it may be the identity address */
-	if (!bt_addr_le_cmp(peer, &conn->le.dst)) {
-		return true;
-	}
-
-	/* Check against initial connection address */
-	if (conn->role == BT_HCI_ROLE_MASTER) {
-		return bt_addr_le_cmp(peer, &conn->le.resp_addr) == 0;
-	}
-
-	return bt_addr_le_cmp(peer, &conn->le.init_addr) == 0;
-}
-
-struct bt_conn *bt_conn_lookup_addr_le(uint8_t id, const bt_addr_le_t *peer)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
-		struct bt_conn *conn = bt_conn_ref(&acl_conns[i]);
-
-		if (!conn) {
-			continue;
-		}
-
-		if (conn->type != BT_CONN_TYPE_LE) {
-			bt_conn_unref(conn);
-			continue;
-		}
-
-		if (!bt_conn_is_peer_addr_le(conn, id, peer)) {
-			bt_conn_unref(conn);
-			continue;
-		}
-
-		return conn;
-	}
-
-	return NULL;
-}
-
-struct bt_conn *bt_conn_lookup_state_le(uint8_t id, const bt_addr_le_t *peer,
-					const bt_conn_state_t state)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
-		struct bt_conn *conn = bt_conn_ref(&acl_conns[i]);
-
-		if (!conn) {
-			continue;
-		}
-
-		if (conn->type != BT_CONN_TYPE_LE) {
-			bt_conn_unref(conn);
-			continue;
-		}
-
-		if (peer && !bt_conn_is_peer_addr_le(conn, id, peer)) {
-			bt_conn_unref(conn);
-			continue;
-		}
-
-		if (!(conn->state == state && conn->id == id)) {
-			bt_conn_unref(conn);
-			continue;
-		}
-
-		return conn;
-	}
-
-	return NULL;
-}
-
 void bt_conn_foreach(int type, void (*func)(struct bt_conn *conn, void *data),
 		     void *data)
 {
@@ -1991,6 +1911,86 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, uint8_t id,
+			     const bt_addr_le_t *peer)
+{
+	if (id != conn->id) {
+		return false;
+	}
+
+	/* Check against conn dst address as it may be the identity address */
+	if (!bt_addr_le_cmp(peer, &conn->le.dst)) {
+		return true;
+	}
+
+	/* Check against initial connection address */
+	if (conn->role == BT_HCI_ROLE_MASTER) {
+		return bt_addr_le_cmp(peer, &conn->le.resp_addr) == 0;
+	}
+
+	return bt_addr_le_cmp(peer, &conn->le.init_addr) == 0;
+}
+
+struct bt_conn *bt_conn_lookup_addr_le(uint8_t id, const bt_addr_le_t *peer)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
+		struct bt_conn *conn = bt_conn_ref(&acl_conns[i]);
+
+		if (!conn) {
+			continue;
+		}
+
+		if (conn->type != BT_CONN_TYPE_LE) {
+			bt_conn_unref(conn);
+			continue;
+		}
+
+		if (!bt_conn_is_peer_addr_le(conn, id, peer)) {
+			bt_conn_unref(conn);
+			continue;
+		}
+
+		return conn;
+	}
+
+	return NULL;
+}
+
+struct bt_conn *bt_conn_lookup_state_le(uint8_t id, const bt_addr_le_t *peer,
+					const bt_conn_state_t state)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
+		struct bt_conn *conn = bt_conn_ref(&acl_conns[i]);
+
+		if (!conn) {
+			continue;
+		}
+
+		if (conn->type != BT_CONN_TYPE_LE) {
+			bt_conn_unref(conn);
+			continue;
+		}
+
+		if (peer && !bt_conn_is_peer_addr_le(conn, id, peer)) {
+			bt_conn_unref(conn);
+			continue;
+		}
+
+		if (!(conn->state == state && conn->id == id)) {
+			bt_conn_unref(conn);
+			continue;
+		}
+
+		return conn;
+	}
+
+	return NULL;
+}
 
 const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2195,6 +2195,38 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 	}
 }
 
+uint8_t bt_conn_index(struct bt_conn *conn)
+{
+	ptrdiff_t index;
+
+	switch (conn->type) {
+#if defined(CONFIG_BT_ISO)
+	case BT_CONN_TYPE_ISO:
+		index = conn - iso_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(iso_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+#if defined(CONFIG_BT_BREDR)
+	case BT_CONN_TYPE_SCO:
+		index = conn - sco_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(sco_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+	default:
+		index = conn - acl_conns;
+		__ASSERT(index >= 0 && index < ARRAY_SIZE(acl_conns),
+			 "Invalid bt_conn pointer");
+		break;
+	}
+
+	return (uint8_t)index;
+}
+
+/* Group Connected BT_CONN only in this */
+#if defined(CONFIG_BT_CONN)
+
 #if defined(CONFIG_BT_CENTRAL)
 static void bt_conn_set_param_le(struct bt_conn *conn,
 				 const struct bt_le_conn_param *param)
@@ -2481,37 +2513,6 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 #endif /* !defined(CONFIG_BT_WHITELIST) */
 #endif /* CONFIG_BT_CENTRAL */
 
-uint8_t bt_conn_index(struct bt_conn *conn)
-{
-	ptrdiff_t index;
-
-	switch (conn->type) {
-#if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		index = conn - iso_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-#if defined(CONFIG_BT_BREDR)
-	case BT_CONN_TYPE_SCO:
-		index = conn - sco_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-	default:
-		index = conn - acl_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
-			 "Invalid bt_conn pointer");
-		break;
-	}
-
-	return (uint8_t)index;
-}
-
-/* Group Connected BT_CONN only in this */
-#if defined(CONFIG_BT_CONN)
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param)
 {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2583,6 +2583,38 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	return buf;
 }
 
+uint8_t bt_conn_index(struct bt_conn *conn)
+{
+	ptrdiff_t index;
+
+	switch (conn->type) {
+#if defined(CONFIG_BT_ISO)
+	case BT_CONN_TYPE_ISO:
+		index = conn - iso_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+#if defined(CONFIG_BT_BREDR)
+	case BT_CONN_TYPE_SCO:
+		index = conn - sco_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
+			"Invalid bt_conn pointer");
+		break;
+#endif
+	default:
+		index = conn - acl_conns;
+		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
+			 "Invalid bt_conn pointer");
+		break;
+	}
+
+	return (uint8_t)index;
+}
+
+/* Group Connected BT_CONN only in this */
+#if defined(CONFIG_BT_CONN)
+
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 {
@@ -2688,37 +2720,6 @@ int bt_conn_auth_pairing_confirm(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
-uint8_t bt_conn_index(struct bt_conn *conn)
-{
-	ptrdiff_t index;
-
-	switch (conn->type) {
-#if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		index = conn - iso_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(iso_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-#if defined(CONFIG_BT_BREDR)
-	case BT_CONN_TYPE_SCO:
-		index = conn - sco_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(sco_conns),
-			"Invalid bt_conn pointer");
-		break;
-#endif
-	default:
-		index = conn - acl_conns;
-		__ASSERT(0 <= index && index < ARRAY_SIZE(acl_conns),
-			 "Invalid bt_conn pointer");
-		break;
-	}
-
-	return (uint8_t)index;
-}
-
-/* Group Connected BT_CONN only in this */
-#if defined(CONFIG_BT_CONN)
 struct bt_conn *bt_conn_lookup_index(uint8_t index)
 {
 	if (index >= ARRAY_SIZE(acl_conns)) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1988,60 +1988,6 @@ int bt_conn_get_remote_info(struct bt_conn *conn,
 	}
 }
 
-/* Read Transmit Power Level HCI command */
-static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
-				      int8_t *tx_power_level)
-{
-	int err;
-	struct bt_hci_rp_read_tx_power_level *rp;
-	struct net_buf *rsp;
-	struct bt_hci_cp_read_tx_power_level *cp;
-	struct net_buf *buf;
-
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_TX_POWER_LEVEL, sizeof(*cp));
-	if (!buf) {
-		return -ENOBUFS;
-	}
-
-	cp = net_buf_add(buf, sizeof(*cp));
-	cp->type = type;
-	cp->handle = sys_cpu_to_le16(conn->handle);
-
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_TX_POWER_LEVEL, buf, &rsp);
-	if (err) {
-		return err;
-	}
-
-	rp = (void *) rsp->data;
-	*tx_power_level = rp->tx_power_level;
-	net_buf_unref(rsp);
-
-	return 0;
-}
-
-int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
-				  struct bt_conn_le_tx_power *tx_power_level)
-{
-	int err;
-
-	if (tx_power_level->phy != 0) {
-		/* Extend the implementation when LE Enhanced Read Transmit
-		 * Power Level HCI command is available for use.
-		 */
-		return -ENOTSUP;
-	}
-
-	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_CURRENT,
-					 &tx_power_level->current_level);
-	if (err) {
-		return err;
-	}
-
-	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_MAX,
-					 &tx_power_level->max_level);
-	return err;
-}
-
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	int err;
@@ -2134,6 +2080,60 @@ uint8_t bt_conn_index(struct bt_conn *conn)
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+
+/* Read Transmit Power Level HCI command */
+static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
+				      int8_t *tx_power_level)
+{
+	int err;
+	struct bt_hci_rp_read_tx_power_level *rp;
+	struct net_buf *rsp;
+	struct bt_hci_cp_read_tx_power_level *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_READ_TX_POWER_LEVEL, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->type = type;
+	cp->handle = sys_cpu_to_le16(conn->handle);
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_TX_POWER_LEVEL, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *) rsp->data;
+	*tx_power_level = rp->tx_power_level;
+	net_buf_unref(rsp);
+
+	return 0;
+}
+
+int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
+				  struct bt_conn_le_tx_power *tx_power_level)
+{
+	int err;
+
+	if (tx_power_level->phy != 0) {
+		/* Extend the implementation when LE Enhanced Read Transmit
+		 * Power Level HCI command is available for use.
+		 */
+		return -ENOTSUP;
+	}
+
+	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_CURRENT,
+					 &tx_power_level->current_level);
+	if (err) {
+		return err;
+	}
+
+	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_MAX,
+					 &tx_power_level->max_level);
+	return err;
+}
 
 int bt_conn_le_param_update(struct bt_conn *conn,
 			    const struct bt_le_conn_param *param)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -213,11 +213,11 @@ struct bt_dev_le {
 	struct k_sem		pkts;
 	uint16_t		acl_mtu;
 	struct k_sem		acl_pkts;
+#endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_ISO)
 	uint16_t		iso_mtu;
 	struct k_sem		iso_pkts;
 #endif /* CONFIG_BT_ISO */
-#endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_SMP)
 	/* Size of the the controller resolving list */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -319,7 +319,11 @@ void bt_iso_connected(struct bt_conn *conn)
 
 	if (bt_iso_setup_data_path(conn)) {
 		BT_ERR("Unable to setup data path");
-		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+		if (conn->iso.is_bis && IS_ENABLED(CONFIG_BT_CONN)) {
+			bt_conn_disconnect(conn,
+					   BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+		}
+		/* TODO: Handle BIG terminate for BIS */
 		return;
 	}
 


### PR DESCRIPTION
Moves all ACL-only related functionality in conn.c to a new group (guarded by `CONFIG_BT_CONN`), such that we can use the remaining functionality of conn.c for the broadcast ISO functionality (which uses `struct bt_conn`). 

No functionality is changed. 