### PR TITLE
scripts: twister: Fix error in dt_label_with_parent_compat_enabled

### DIFF
--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -268,7 +268,10 @@ def ast_expr(ast, env, edt):
         compat = ast[1][1]
         label = ast[1][0]
         node = edt.label2node.get(label)
-        parent = node.parent
+        if node is not None:
+            parent = node.parent
+        else:
+            return False
         return parent is not None and parent.status == 'okay' and parent.matching_compat == compat
     elif ast[0] == "dt_chosen_enabled":
         chosen = ast[1][0]


### PR DESCRIPTION
In dt_label_with_parent_compat_enabled, it maybe that there is
no node matching expected label.
In this case don't generate error, but return False.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>