### PR TITLE
sys: printk: Fix LOG2 printk support in cpp code

### DIFF
--- a/include/sys/printk.h
+++ b/include/sys/printk.h
@@ -12,6 +12,9 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <inttypes.h>
+#if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
+#include <logging/log.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,7 +50,6 @@ extern "C" {
 #ifdef CONFIG_PRINTK
 
 #if defined(CONFIG_LOG_PRINTK) && defined(CONFIG_LOG2)
-#include <logging/log.h>
 #define printk(...) Z_LOG_PRINTK(__VA_ARGS__)
 static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
 {


### PR DESCRIPTION
This commit fixes the issue with a compilation of the sample that
uses printk function from cpp code when LOG2 is used and printk
is handled by logging subsystem.

To recreate the issue use samples/subsys/cpp/cpp_synchronization. This is the only sample in zephyr that calls printk from cpp code.
Enable:
- LOG2
- printk processing in logging subsystem

This PR solves part of the issues here - and will work if no ASSERT together with CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT is enabled.
