### PR TITLE
boards: arm: nrf9160dk_nrf9160 add support for arduino shields

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
@@ -9,6 +9,8 @@ toolchain:
 ram: 88
 flash: 256
 supported:
+  - arduino_gpio
+  - arduino_i2c
   - gpio
   - i2c
   - pwm

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -87,6 +87,46 @@
 		gpios = <&interface_to_nrf52840 5 GPIO_ACTIVE_HIGH>;
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 14 0>,	/* A0 */
+			   <1 0 &gpio0 15 0>,	/* A1 */
+			   <2 0 &gpio0 16 0>,	/* A2 */
+			   <3 0 &gpio0 17 0>,	/* A3 */
+			   <4 0 &gpio0 18 0>,	/* A4 */
+			   <5 0 &gpio0 19 0>,	/* A5 */
+			   <6 0 &gpio0 0 0>,	/* D0 */
+			   <7 0 &gpio0 1 0>,	/* D1 */
+			   <8 0 &gpio0 2 0>,	/* D2 */
+			   <9 0 &gpio0 3 0>,	/* D3 */
+			   <10 0 &gpio0 4 0>,	/* D4 */
+			   <11 0 &gpio0 5 0>,	/* D5 */
+			   <12 0 &gpio0 6 0>,	/* D6 */
+			   <13 0 &gpio0 7 0>,	/* D7 */
+			   <14 0 &gpio0 8 0>,	/* D8 */
+			   <15 0 &gpio0 9 0>,	/* D9 */
+			   <16 0 &gpio0 10 0>,	/* D10 */
+			   <17 0 &gpio0 11 0>,	/* D11 */
+			   <18 0 &gpio0 12 0>,	/* D12 */
+			   <19 0 &gpio0 13 0>,	/* D13 */
+			   <20 0 &gpio0 30 0>,	/* D14 */
+			   <21 0 &gpio0 31 0>;	/* D15 */
+	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc 1>,	/* A0 = P0.14 = AIN1 */
+				 <1 &adc 2>,	/* A1 = P0.15 = AIN2 */
+				 <2 &adc 3>,	/* A2 = P0.16 = AIN3 */
+				 <3 &adc 4>,	/* A3 = P0.17 = AIN4 */
+				 <4 &adc 5>,	/* A4 = P0.18 = AIN5 */
+				 <5 &adc 6>;	/* A5 = P0.19 = AIN6 */
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
@@ -123,7 +163,7 @@
 	cts-pin = <26>;
 };
 
-&uart1 {
+arduino_serial: &uart1 {
 	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <1>;
@@ -137,7 +177,7 @@
 	rx-pin = <23>;
 };
 
-&i2c2 {
+arduino_i2c: &i2c2 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <30>;

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160ns.yaml
@@ -9,6 +9,8 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - arduino_gpio
+  - arduino_i2c
   - i2c
   - pwm
   - watchdog


### PR DESCRIPTION
add support for shields that use arduino_i2c and arduino_serial.

Signed-off-by: Embla Flatlandsmo <embla.flatlandsmo@nordicsemi.no>