### PR TITLE
manifest: order subsystems alphabetically

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -25,46 +25,59 @@ manifest:
   #
   # Please add items below based on alphabetical order
   projects:
-    - name: cmsis
-      revision: c3bd2094f92d574377f7af2aec147ae181aa5f8e
-      path: modules/hal/cmsis
-    - name: hal_atmel
-      revision: d17b7dd92d209b20bc1e15431d068edc29bf438d
-      path: modules/hal/atmel
-    - name: hal_altera
-      revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97
-      path: modules/hal/altera
     - name: canopennode
       path: modules/lib/canopennode
       revision: 468d350028a975b96563e58344de48281a0ab371
     - name: civetweb
       revision: e6903b80c09d17cd1a8bb32e40080005558aad29
       path: modules/lib/civetweb
+    - name: cmsis
+      revision: c3bd2094f92d574377f7af2aec147ae181aa5f8e
+      path: modules/hal/cmsis
+    - name: edtt
+      path: tools/edtt
+      revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
+    - name: fatfs
+      revision: 1d1fcc725aa1cb3c32f366e0c53d7490d0fe1109
+      path: modules/fs/fatfs
+    - name: hal_altera
+      revision: 23c1c1dd7a0c1cc9a399509d1819375847c95b97
+      path: modules/hal/altera
+    - name: hal_atmel
+      revision: d17b7dd92d209b20bc1e15431d068edc29bf438d
+      path: modules/hal/atmel
+    - name: hal_cypress
+      revision: 81a059f21435bc7e315bccd720da5a9b615bbb50
+      path: modules/hal/cypress
     - name: hal_espressif
       west-commands: west/west-commands.yml
       revision: 086d305202390589a206523c239e604718759402
       path: modules/hal/espressif
-    - name: fatfs
-      revision: 1d1fcc725aa1cb3c32f366e0c53d7490d0fe1109
-      path: modules/fs/fatfs
-    - name: hal_cypress
-      revision: 81a059f21435bc7e315bccd720da5a9b615bbb50
-      path: modules/hal/cypress
     - name: hal_infineon
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
-    - name: hal_nordic
-      revision: 574493fe29c79140df4827ab5d4a23df79d03681
-      path: modules/hal/nordic
-    - name: hal_openisa
-      revision: 40d049f69c50b58ea20473bee14cf93f518bf262
-      path: modules/hal/openisa
-    - name: hal_nuvoton
-      revision: b4d31f33238713a568e23618845702fadd67386f
-      path: modules/hal/nuvoton
+    - name: lvgl
+      revision: 31acbaa36e9e74ab88ac81e3d21e7f1d00a71136
+      path: modules/lib/gui/lvgl
     - name: hal_microchip
       revision: b280eec5d3b1296b231117c1999bcd0269b6ecc4
       path: modules/hal/microchip
+    - name: hal_nordic
+      revision: 574493fe29c79140df4827ab5d4a23df79d03681
+      path: modules/hal/nordic
+    - name: hal_nuvoton
+      revision: b4d31f33238713a568e23618845702fadd67386f
+      path: modules/hal/nuvoton
+    - name: hal_nxp
+      revision: 0d11138724959e1162777d9206f841ccdf64348e
+      path: modules/hal/nxp
+    - name: hal_openisa
+      revision: 40d049f69c50b58ea20473bee14cf93f518bf262
+      path: modules/hal/openisa
+    - name: hal_quicklogic
+      repo-path: hal_quicklogic
+      revision: b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0
+      path: modules/hal/quicklogic
     - name: hal_silabs
       revision: be39d4eebeddac6e18e9c0c3ba1b31ad1e82eaed
       path: modules/hal/silabs
@@ -77,84 +90,71 @@ manifest:
     - name: hal_ti
       revision: 3da6fae25fc44ec830fac4a92787b585ff55435e
       path: modules/hal/ti
+    - name: hal_xtensa
+      revision: 2f04b615cd5ad3a1b8abef33f9bdd10cc1990ed6
+      path: modules/hal/xtensa
     - name: libmetal
       revision: 39d049d4ae68e6f6d595fce7de1dcfc1024fb4eb
       path: modules/hal/libmetal
-    - name: hal_quicklogic
-      repo-path: hal_quicklogic
-      revision: b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0
-      path: modules/hal/quicklogic
-    - name: lvgl
-      revision: 31acbaa36e9e74ab88ac81e3d21e7f1d00a71136
-      path: modules/lib/gui/lvgl
-    - name: mbedtls
-      revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
-      path: modules/crypto/mbedtls
+    - name: littlefs
+      path: modules/fs/littlefs
+      revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
+    - name: loramac-node
+      revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e
+      path: modules/lib/loramac-node
     - name: mcuboot
       revision: 2fce9769b191411d580bbc65b043956c2ae9307e
       path: bootloader/mcuboot
     - name: mcumgr
       revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e
       path: modules/lib/mcumgr
+    - name: mipi-sys-t
+      path: modules/debug/mipi-sys-t
+      revision: 75e671550ac1acb502f315fe4952514dc73f7bfb
+    - name: mbedtls
+      revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
+      path: modules/crypto/mbedtls
+    - name: nanopb
+      path: modules/lib/nanopb
+      revision: d148bd26718e4c10414f07a7eb1bd24c62e56c5d
     - name: net-tools
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127
       path: tools/net-tools
-    - name: hal_nxp
-      revision: 0d11138724959e1162777d9206f841ccdf64348e
-      path: modules/hal/nxp
+    - name: nrf_hw_models
+      path: modules/bsim_hw_models/nrf_hw_models
+      revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
     - name: open-amp
       revision: 6010f0523cbc75f551d9256cf782f173177acdef
       path: modules/lib/open-amp
-    - name: loramac-node
-      revision: 2cee5f7295ff0ff804bf06fea5de006bc7cd121e
-      path: modules/lib/loramac-node
     - name: openthread
       revision: 385e19da1ae15f27872c2543b97276a42f102ead
       path: modules/lib/openthread
     - name: segger
       revision: 7d78f7121dc4c59396c12e60e34f3617bac5efcb
-      path: modules/debug/segger
+      path: modules/debug/segger      
     - name: sof
       revision: 779f28ed465c03899c8a7d4aaf399856f4e51158
       path: modules/audio/sof
+    - name: tensorflow
+      repo-path: tensorflow
+      path: modules/lib/tensorflow
+      revision: dc70a45a7cc12c25726a32cd91b28be59e7bc596
+    - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
+      repo-path: mcuboot
+      path: modules/tee/tfm-mcuboot
+      revision: v1.7.2
     - name: tinycbor
       path: modules/lib/tinycbor
       revision: 40daca97b478989884bffb5226e9ab73ca54b8c4
     - name: tinycrypt
       path: modules/crypto/tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0
-    - name: littlefs
-      path: modules/fs/littlefs
-      revision: 9e4498d1c73009acd84bb36036ee5e2869112a6c
-    - name: mipi-sys-t
-      path: modules/debug/mipi-sys-t
-      revision: 75e671550ac1acb502f315fe4952514dc73f7bfb
-    - name: nrf_hw_models
-      path: modules/bsim_hw_models/nrf_hw_models
-      revision: a47e326ca772ddd14cc3b9d4ca30a9ab44ecca16
     - name: TraceRecorderSource
       path: modules/debug/TraceRecorder
       revision: d9889883abb4657d71e15ff055517a9b032f8212
-    - name: hal_xtensa
-      revision: 2f04b615cd5ad3a1b8abef33f9bdd10cc1990ed6
-      path: modules/hal/xtensa
-    - name: edtt
-      path: tools/edtt
-      revision: 7dd56fc100d79cc45c33d43e7401d1803e26f6e7
     - name: trusted-firmware-m
       path: modules/tee/tfm
-      revision: 51cdecd6f9e6b0aa66da45db22f4b478183d472f
-    - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
-      repo-path: mcuboot
-      path: modules/tee/tfm-mcuboot
-      revision: v1.7.2
-    - name: nanopb
-      path: modules/lib/nanopb
-      revision: d148bd26718e4c10414f07a7eb1bd24c62e56c5d
-    - name: tensorflow
-      repo-path: tensorflow
-      path: modules/lib/tensorflow
-      revision: dc70a45a7cc12c25726a32cd91b28be59e7bc596
+      revision: 51cdecd6f9e6b0aa66da45db22f4b478183d472f      
 
   self:
     path: zephyr


### PR DESCRIPTION
Order the subsystems in the manifest file alphabetically, as they actually should be according to the comment within the manifest file.

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>