### PR TITLE
Bluetooth: Mesh: Restore default device configuration on reset

### DIFF
--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -250,7 +250,7 @@ bool bt_mesh_fixed_group_match(uint16_t addr)
 	}
 }
 
-void bt_mesh_cfg_init(void)
+void bt_mesh_cfg_default_set(void)
 {
 	bt_mesh.default_ttl = CONFIG_BT_MESH_DEFAULT_TTL;
 	bt_mesh.net_xmit =

--- a/subsys/bluetooth/mesh/cfg.h
+++ b/subsys/bluetooth/mesh/cfg.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void bt_mesh_cfg_init(void);
+void bt_mesh_cfg_default_set(void);
 void bt_mesh_cfg_pending_store(void);
 
 bool bt_mesh_fixed_group_match(uint16_t addr);

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2442,7 +2442,7 @@ static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 	}
 }
 
-void bt_mesh_cfg_reset(void)
+void bt_mesh_model_reset(void)
 {
 	bt_mesh_model_foreach(mod_reset, NULL);
 }

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -112,7 +112,7 @@
 #define STATUS_UNSPECIFIED                 0x10
 #define STATUS_INVALID_BINDING             0x11
 
-void bt_mesh_cfg_reset(void);
+void bt_mesh_model_reset(void);
 
 void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time);
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -174,7 +174,8 @@ void bt_mesh_reset(void)
 	 */
 	(void)k_work_cancel_delayable(&bt_mesh.ivu_timer);
 
-	bt_mesh_cfg_reset();
+	bt_mesh_model_reset();
+	bt_mesh_cfg_default_set();
 	bt_mesh_trans_reset();
 	bt_mesh_app_keys_reset();
 	bt_mesh_net_keys_reset();
@@ -331,7 +332,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 		}
 	}
 
-	bt_mesh_cfg_init();
+	bt_mesh_cfg_default_set();
 	bt_mesh_net_init();
 	bt_mesh_trans_init();
 	bt_mesh_hb_init();


### PR DESCRIPTION
This commit fixes an issue where bt_mesh_reset() call just erases all
mesh flags set at the initialization instead of restoring them and
thus disabling some features until the board reboot.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>