### PR TITLE
CODEOWNERS: add code owner for Xilinx GEM driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -217,6 +217,7 @@
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/ethernet/*stm32*                 @Nukersson @lochej
 /drivers/ethernet/*w5500*                 @parthitce
+/drivers/ethernet/*xlnx_gem*              @ibirnbaum
 /drivers/flash/                           @nashif @nvlsianpu
 /drivers/flash/*nrf*                      @nvlsianpu
 /drivers/gpio/                            @mnkp
@@ -405,6 +406,7 @@
 /dts/bindings/*/litex*                    @mateusz-holenko @kgugala @pgielda
 /dts/bindings/*/vexriscv*                 @mateusz-holenko @kgugala @pgielda
 /dts/bindings/pm_cpu_ops/*                @carlocaione
+/dts/bindings/ethernet/*gem.yaml          @ibirnbaum
 /dts/posix/                               @aescolar @vanwinkeljan @daor-oti
 /dts/bindings/sensor/*bme680*             @BoschSensortec
 /dts/bindings/sensor/st*                  @avisconti
@@ -466,6 +468,7 @@
 /include/dt-bindings/clock/kinetis_mcg.h  @henrikbrixandersen
 /include/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/dt-bindings/dma/stm32_dma.h      @cybertale
+/include/dt-bindings/ethernet/xlnx_gem.h  @ibirnbaum
 /include/dt-bindings/pcie/                @dcpleung
 /include/dt-bindings/usb/usb.h            @galak
 /include/drivers/emul.h                   @sjg20


### PR DESCRIPTION
Add the code owner entries for all files related to the Xilinx GEM Ethernet device driver.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>