### PR TITLE
dts: arm: Add #address-cells to nvic nodes

### DIFF
--- a/dts/arm/armv6-m.dtsi
+++ b/dts/arm/armv6-m.dtsi
@@ -11,6 +11,7 @@
 		ranges;
 
 		nvic: interrupt-controller@e000e100  {
+			#address-cells = <1>;
 			compatible = "arm,v6m-nvic";
 			reg = <0xe000e100 0xc00>;
 			interrupt-controller;

--- a/dts/arm/armv7-m.dtsi
+++ b/dts/arm/armv7-m.dtsi
@@ -11,6 +11,7 @@
 		ranges;
 
 		nvic: interrupt-controller@e000e100  {
+			#address-cells = <1>;
 			compatible = "arm,v7m-nvic";
 			reg = <0xe000e100 0xc00>;
 			interrupt-controller;

--- a/dts/arm/armv8-m.dtsi
+++ b/dts/arm/armv8-m.dtsi
@@ -11,6 +11,7 @@
 		ranges;
 
 		nvic: interrupt-controller@e000e100  {
+			#address-cells = <1>;
 			compatible = "arm,v8m-nvic";
 			reg = <0xe000e100 0xc00>;
 			interrupt-controller;

--- a/dts/arm/armv8.1-m.dtsi
+++ b/dts/arm/armv8.1-m.dtsi
@@ -15,6 +15,7 @@
 		ranges;
 
 		nvic: interrupt-controller@e000e100  {
+			#address-cells = <1>;
 			compatible = "arm,v8.1m-nvic";
 			reg = <0xe000e100 0xc00>;
 			interrupt-controller;


### PR DESCRIPTION
dtc v1.6.1 produces an error without specifying #address-cells on all interrupt-controller nodes. This commit only fixes this for `nvic` nodes in ARM architectures.

Fixes #36495

Signed-off-by: Eric Johnson <eric@liveathos.com>