### PR TITLE
boards: arm: cy8ckit_062_ble: Add arduino's nexus map

### DIFF
--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
@@ -4,6 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;		/*           shared */
+		gpio-map = <0  0 &gpio_prt9   0 0>,	/*  A0-             */
+			   <1  0 &gpio_prt9   1 0>,	/*  A1-             */
+			   <2  0 &gpio_prt9   2 0>,	/*  A2-             */
+			   <3  0 &gpio_prt9   3 0>,	/*  A3-             */
+			   <4  0 &gpio_prt9   4 0>,	/*  A4-             */
+			   <5  0 &gpio_prt9   5 0>,	/*  A5-             */
+			   <6  0 &gpio_prt5   0 0>,	/*  D0-RX-5         */
+			   <7  0 &gpio_prt5   1 0>,	/*  D1-TX-5         */
+			   <8  0 &gpio_prt5   2 0>,	/*  D2-RTS-5        */
+			   <9  0 &gpio_prt5   3 0>,	/*  D3-CTS-5        */
+			   <10 0 &gpio_prt5   4 0>,	/*  D4-             */
+			   <11 0 &gpio_prt5   5 0>,	/*  D5-             */
+			   <12 0 &gpio_prt5   6 0>,	/*  D6-             */
+			   <13 0 &gpio_prt0   2 0>,	/*  D7-             */
+			   <14 0 &gpio_prt13  0 0>,	/*  D8-RX-6       y */
+			   <15 0 &gpio_prt13  1 0>,	/*  D9-TX-6       y */
+			   <16 0 &gpio_prt12  3 0>,	/* D10-SPI6_SEL0  y */
+			   <17 0 &gpio_prt12  0 0>,	/* D11-SPI6_MOSI  y */
+			   <18 0 &gpio_prt12  1 0>,	/* D12-SPI6_MISO  y */
+			   <19 0 &gpio_prt12  2 0>,	/* D13-SPI6_CLK   y */
+			   <20 0 &gpio_prt6   1 0>,	/* D14-SDAx         */
+			   <21 0 &gpio_prt6   0 0>;	/* D15-SCLx         */
+	};
+};
+
 &spi6 {
 	cs-gpios = <&gpio_prt12 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
 		   <&gpio_prt13 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
@@ -47,6 +47,22 @@
 	interrupt-parent = <&intmux_ch20>;
 };
 
+&gpio_prt5 {
+	status = "okay";
+};
+
+&gpio_prt6 {
+	status = "okay";
+};
+
+&gpio_prt9 {
+	status = "okay";
+};
+
+&gpio_prt12 {
+	status = "okay";
+};
+
 &gpio_prt13 {
 	status = "okay";
 };
@@ -55,3 +71,5 @@
 	status = "okay";
 	interrupt-parent = <&intmux_ch16>;
 };
+
+arduino_spi: &spi6 {};

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
@@ -16,5 +16,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
+  - arduino_spi
   - gpio
   - spi

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_0_0_0.overlay
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_0_0_0.overlay
@@ -23,3 +23,5 @@
 
 	pinctrl-0 = <&p5_0_uart5_rx &p5_1_uart5_tx>;
 };
+
+arduino_serial: &uart5 {};

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_1_0_0.overlay
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_1_0_0.overlay
@@ -23,3 +23,14 @@
 
 	pinctrl-0 = <&p9_0_uart2_rx &p9_1_uart2_tx>;
 };
+
+&uart5 {
+	status = "okay";
+	current-speed = <115200>;
+
+	interrupt-parent = <&intmux_ch22>;
+
+	pinctrl-0 = <&p5_0_uart5_rx &p5_1_uart5_tx>;
+};
+
+arduino_serial: &uart5 {};

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2018, Cypress
-# Copyright (c) 2020, ATL Electronics
+# Copyright (c) 2020-2021, ATL Electronics
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,4 +16,5 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - gpio


### PR DESCRIPTION
Provide mapping from cy8ckit_062_ble to Arduino-R3 headers. The pins can have multiple functions that may interfere with
GPIO and/or communications.

Signed-off-by: Gerson Fernando Budke <gerson.budke@atl-electronics.com>