### PR TITLE
soc: arm: cypress: psoc6: Enable Cortex-M4

### DIFF
--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
@@ -5,6 +5,28 @@
  */
 
 / {
+	aliases {
+		led0 = &user_led;
+		sw0 = &user_bt;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		user_led: led_0 {
+			label = "LED_0";
+			gpios = <&gpio_prt13 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_bt: button_0 {
+			label = "SW_0";
+			gpios = <&gpio_prt0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -33,6 +55,30 @@
 			   <20 0 &gpio_prt6   1 0>,	/* D14-SDAx         */
 			   <21 0 &gpio_prt6   0 0>;	/* D15-SCLx         */
 	};
+};
+
+&gpio_prt0 {
+	status = "okay";
+};
+
+&gpio_prt5 {
+	status = "okay";
+};
+
+&gpio_prt6 {
+	status = "okay";
+};
+
+&gpio_prt9 {
+	status = "okay";
+};
+
+&gpio_prt12 {
+	status = "okay";
+};
+
+&gpio_prt13 {
+	status = "okay";
 };
 
 &spi6 {

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.dts
@@ -14,57 +14,14 @@
 	model = "Cypress PSoC6 BLE Pioneer Kit";
 	compatible = "cypress,cy8c6xx7_cm0p", "cypress,psoc6";
 
-	aliases {
-		sw0 = &user_bt;
-		led0 = &user_led;
-	};
-
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
-
-	leds {
-		compatible = "gpio-leds";
-		user_led: led_0 {
-			label = "LED_0";
-			gpios = <&gpio_prt13 7 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-
-		user_bt: button_0 {
-			label = "SW_0";
-			gpios = <&gpio_prt0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		};
-	};
 };
 
 &gpio_prt0 {
-	status = "okay";
 	interrupt-parent = <&intmux_ch20>;
-};
-
-&gpio_prt5 {
-	status = "okay";
-};
-
-&gpio_prt6 {
-	status = "okay";
-};
-
-&gpio_prt9 {
-	status = "okay";
-};
-
-&gpio_prt12 {
-	status = "okay";
-};
-
-&gpio_prt13 {
-	status = "okay";
 };
 
 &spi6 {

--- a/boards/arm/cy8ckit_062_ble/doc/index.rst
+++ b/boards/arm/cy8ckit_062_ble/doc/index.rst
@@ -176,6 +176,59 @@ Cy_WDT_Disable().
 
    You should see "Hello World! cy8ckit_062_ble_m0" in your terminal.
 
+Running on Dual Core
+********************
+
+#. Build the Zephyr kernel and the :ref:`button-sample` sample application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/basic/button
+      :board: cy8ckit_062_ble_m4
+      :goals: build
+      :compact:
+
+#. If you have a USB-Serial adapter, you can connect SBC[UART]-6 on Arduino
+   header.  Schematic should be checked for connections.   Run your favorite
+   terminal program again now listen for another output.   Under Linux the
+   terminal should be :code:`/dev/ttyUSB0`. For example:
+
+   .. code-block:: console
+
+      $ minicom -D /dev/ttyUSB0 -o
+
+   The -o option tells minicom not to send the modem initialization
+   string. Connection should be configured as follows:
+
+      - Speed: 115200
+      - Data: 8 bits
+      - Parity: None
+      - Stop bits: 1
+
+#. To flash an image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/basic/button
+      :board: cy8ckit_062_ble_m4
+      :goals: flash
+      :compact:
+
+#. Configure Cortex-M0+ to enable Cortex-M4:
+
+   The last step flash the M4 image on the flash.  However, Cortex-M0 by default
+   doesn't start the M4 and nothing will happen.  To enable Cortex-M4 CPU,
+   repeat the steps on programming and debug and add the following parameter
+   when performing the build process.
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: cy8ckit_062_ble_m0
+      :goals: build flash
+      :gen-args: -DCONFIG_SOC_PSOC6_M0_ENABLES_M4=y
+      :compact:
+
+   Now you can press button SW-2 and see LED-9 blink at same time you have the
+   "Hello World! cy8ckit_062_ble_m0" in the your terminal.
+
 Board Revision
 **************
 

--- a/soc/arm/cypress/Kconfig
+++ b/soc/arm/cypress/Kconfig
@@ -21,6 +21,12 @@ config SOC_PSOC6_M4
 
 endchoice
 
+config SOC_PSOC6_M0_ENABLES_M4
+	bool "Enable dual-core support [activate Cortex-M4]"
+	depends on SOC_PSOC6_M0
+	help
+	  Cortex-M0 CPU should boot Cortex-M4
+
 config SOC_FAMILY_PSOC6
 	bool
 

--- a/soc/arm/cypress/psoc6/soc.c
+++ b/soc/arm/cypress/psoc6/soc.c
@@ -368,6 +368,10 @@ void Cy_SystemInit(void)
 	/* Configure peripheral clocks */
 	Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_8_BIT, 0u, 0u);
 	Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_8_BIT, 0u);
+
+#if defined(CONFIG_SOC_PSOC6_M0_ENABLES_M4)
+	Cy_SysEnableCM4(DT_REG_ADDR(DT_NODELABEL(flash1)));
+#endif
 }
 
 static int init_cycfg_platform_wraper(const struct device *arg)


### PR DESCRIPTION
Configure Cortex-M0+ to start Cortex-M4 CPU. It moves ~led-0 and sw-0~ shared resources from m0 dts to common dts.  This enable shared hardware definition between two cpu cores.