### PR TITLE
shell: optionally configure priority of the shell thread

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -25,6 +25,19 @@ config SHELL_MINIMAL
 	  defaults which favor reduced flash or memory requirements over extra
 	  features.
 
+config SHELL_THREAD_PRIORITY_OVERRIDE
+	bool "Override default shell thread priority"
+	help
+	  Option to change the default value of shell thread priority.
+
+if SHELL_THREAD_PRIORITY_OVERRIDE
+config SHELL_THREAD_PRIORITY
+	int "Shell thread priority"
+	default 0
+	help
+	  Set thread priority of the shell
+endif
+
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
 	default 3168 if OPENTHREAD_SHELL && OPENTHREAD_JOINER

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -32,6 +32,15 @@
 #define SHELL_MSG_TOO_MANY_ARGS		"Too many arguments in the command.\n"
 #define SHELL_INIT_OPTION_PRINTER	(NULL)
 
+#define SHELL_THREAD_PRIORITY \
+	COND_CODE_1(CONFIG_SHELL_THREAD_PRIORITY_OVERRIDE, \
+			(CONFIG_SHELL_THREAD_PRIORITY), (K_LOWEST_APPLICATION_THREAD_PRIO))
+
+BUILD_ASSERT(SHELL_THREAD_PRIORITY >=
+		  K_HIGHEST_APPLICATION_THREAD_PRIO
+		&& SHELL_THREAD_PRIORITY <= K_LOWEST_APPLICATION_THREAD_PRIO,
+		  "Invalid range for thread priority");
+
 static inline void receive_state_change(const struct shell *shell,
 					enum shell_receive_state state)
 {
@@ -1326,10 +1335,10 @@ int shell_init(const struct shell *shell, const void *transport_config,
 	}
 
 	k_tid_t tid = k_thread_create(shell->thread,
-			      shell->stack, CONFIG_SHELL_STACK_SIZE,
-			      shell_thread, (void *)shell, (void *)log_backend,
-			      UINT_TO_POINTER(init_log_level),
-			      K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
+				  shell->stack, CONFIG_SHELL_STACK_SIZE,
+				  shell_thread, (void *)shell, (void *)log_backend,
+				  UINT_TO_POINTER(init_log_level),
+				  SHELL_THREAD_PRIORITY, 0, K_NO_WAIT);
 
 	shell->ctx->tid = tid;
 	k_thread_name_set(tid, shell->thread_name);


### PR DESCRIPTION
Currently, in Zephyr the shell thread is the lowerst priority i.e.
K_LOWEST_APPLICATION_THREAD_PRIO. Due to this all the other threads can
preempt the shell thread. Proposed solution is to add Kconfig which
gives the flexibility to change the priority of the shell thread.

This is now implemented using a new Kconfig variable
SHELL_THREAD_PRIORITY.

Signed-off-by: udaykiran <udaykiran@google.com>