### PR TITLE
Bluetooth: Mesh: Ensure proxy_send's attribute is always set

### DIFF
--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -978,7 +978,7 @@ static int proxy_send(struct bt_conn *conn,
 		      const void *data, uint16_t len,
 		      bt_gatt_complete_func_t end, void *user_data)
 {
-	const struct bt_gatt_attr *attr;
+	const struct bt_gatt_attr *attr = NULL;
 	BT_DBG("%u bytes: %s", len, bt_hex(data, len));
 
 #if defined(CONFIG_BT_MESH_GATT_PROXY)


### PR DESCRIPTION
Initializes proxy_send's attr pointer, which in theory could be
uninitialized if neither gatt proxy or PB GATT is enabled while proxy.c
is enabled.

This scenario is not really possible with the current kconfig structure,
but is reported as a potential error by Coverity, and should be fixed
for future proofing purposes.

Fixes #36314.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>