### PR TITLE
doc: fix image resolution of the ITE IT8XXX2 series board

### DIFF
--- a/boards/riscv/it8xxx2_evb/doc/index.rst
+++ b/boards/riscv/it8xxx2_evb/doc/index.rst
@@ -11,10 +11,10 @@ And a highly integrated embedded controller with system functions.
 It is suitable for mobile system applications.
 
 .. figure:: it81302_board.jpg
-     :width: 2016px
-     :height: 1512px
+     :width: 550px
+     :height: 452px
      :align: center
-     :alt: It81302 EVB
+     :alt: IT81302 EVB
 
 To find out more about ITE, visit our World Wide Web at:`ITE's website`_
 


### PR DESCRIPTION
Found out that ITE IT8XXX2 series board image is not displaying
properly. In the original doc page of the RISC-V ITE IT8XXX2 series
board image is shrinked.

Fix resolution to display image properly.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>