### PR TITLE
Bluetooth: Controller: Fix Data Length Update node Rx reservations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -323,11 +323,20 @@ static struct {
  * Increasing this by times the max. simultaneous connection count will permit
  * simultaneous parallel PHY update or Connection Update procedures amongst
  * active connections.
+ * Minimum node rx of 2 that can be reserved happens when local central
+ * initiated PHY Update reserves 2 node rx, one for PHY update complete and
+ * another for Data Length Update complete notification. Otherwise, a
+ * peripheral only needs 1 additional node rx to generate Data Length Update
+ * complete when PHY Update completes; node rx for PHY update complete is
+ * reserved as the received PHY Update Ind PDU.
  */
-#if defined(CONFIG_BT_CTLR_PHY) && defined(CONFIG_BT_CTLR_DATA_LENGTH)
-#define LL_PDU_RX_CNT 3
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_PHY) && \
+	defined(CONFIG_BT_CTLR_DATA_LENGTH)
+#define LL_PDU_RX_CNT (2 * (CONFIG_BT_CTLR_LLCP_CONN))
+#elif defined(CONFIG_BT_CONN)
+#define LL_PDU_RX_CNT (CONFIG_BT_CTLR_LLCP_CONN)
 #else
-#define LL_PDU_RX_CNT 2
+#define LL_PDU_RX_CNT 0
 #endif
 
 /* No. of node rx for LLL to ULL.

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2008,7 +2008,7 @@ static inline void rx_alloc(uint8_t max)
 		max = mem_link_rx.quota_pdu;
 	}
 
-	while ((max--) && MFIFO_ENQUEUE_IDX_GET(pdu_rx_free, &idx)) {
+	while (max && MFIFO_ENQUEUE_IDX_GET(pdu_rx_free, &idx)) {
 		memq_link_t *link;
 		struct node_rx_hdr *rx;
 
@@ -2028,6 +2028,8 @@ static inline void rx_alloc(uint8_t max)
 		MFIFO_BY_IDX_ENQUEUE(pdu_rx_free, idx, rx);
 
 		ll_rx_link_inc_quota(-1);
+
+		max--;
 	}
 
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4056,12 +4056,12 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 			rx->hdr.link->mem = conn->llcp_rx;
 			conn->llcp_rx = rx;
 
-#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 			/* reserve rx node for DLE event generation */
-			rx = ll_pdu_rx_alloc();
-			rx->hdr.link->mem = conn->llcp_rx;
-			conn->llcp_rx = rx;
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+			if (IS_ENABLED(CONFIG_BT_CTLR_DATA_LENGTH)) {
+				rx = ll_pdu_rx_alloc();
+				rx->hdr.link->mem = conn->llcp_rx;
+				conn->llcp_rx = rx;
+			}
 		}
 
 		/* place the phy update ind packet as next in
@@ -4146,8 +4146,11 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 			/* enqueue rx node towards Thread */
 			ll_rx_put(rx->hdr.link, rx);
 
+			/* Release rx node that was reserved for Data Length
+			 * notification.
+			 */
 			if (IS_ENABLED(CONFIG_BT_CTLR_DATA_LENGTH)) {
-				/* get the DLE rx node reserved for ULL->LL */
+				/* Get the DLE rx node reserved for ULL->LL */
 				rx = conn->llcp_rx;
 				LL_ASSERT(rx && rx->hdr.link);
 				conn->llcp_rx = rx->hdr.link->mem;


### PR DESCRIPTION
Reserve a minimum node rx of 2 that can happen when local
central initiated PHY Update reserves 2 node rx, one for PHY
Update complete and another for Data Length Update complete
notification. Otherwise, a peripheral only needs 1
additional node rx to generate Data Length Update complete
when PHY Update completes.

Relates to #36381.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>