### PR TITLE
net: sockets: socketpair: Fix poll signalling

### DIFF
--- a/tests/net/socket/socketpair/src/main.c
+++ b/tests/net/socket/socketpair/src/main.c
@@ -43,6 +43,8 @@ extern void test_socketpair_poll_immediate_data(void);
 extern void test_socketpair_poll_delayed_data(void);
 extern void test_socketpair_poll_close_remote_end_POLLIN(void);
 extern void test_socketpair_poll_close_remote_end_POLLOUT(void);
+extern void test_socketpair_poll_signalling_POLLIN(void);
+extern void test_socketpair_poll_signalling_POLLOUT(void);
 
 void test_main(void)
 {
@@ -77,7 +79,10 @@ void test_main(void)
 		ztest_unit_test(test_socketpair_poll_delayed_data),
 
 		ztest_unit_test(test_socketpair_poll_close_remote_end_POLLIN),
-		ztest_unit_test(test_socketpair_poll_close_remote_end_POLLOUT)
+		ztest_unit_test(test_socketpair_poll_close_remote_end_POLLOUT),
+
+		ztest_unit_test(test_socketpair_poll_signalling_POLLIN),
+		ztest_unit_test(test_socketpair_poll_signalling_POLLOUT)
 	);
 
 	ztest_run_test_suite(socketpair);


### PR DESCRIPTION
In case read or write were called before the actual poll() call, the poll() function was not signalled correctly about such events, which in order could lead to a deadlock if the poll() was called with infinite timeout.

Additionally, add unit tests that cover this scenario, to make sure poll() events are signalled correctly.

Fixes #36447