### PR TITLE
drivers: hwinfo: Fix building of NXP LPC syscon driver

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -41,7 +41,7 @@ config HWINFO_MCUX_SIM
 config HWINFO_MCUX_SYSCON
 	bool "NXP LPC device ID"
 	default y
-	depends on HAS_MCUX_SYSCON
+	depends on HAS_MCUX_SYSCON && !SOC_SERIES_LPC54XXX
 	help
 	  Enable NXP LPC mcux hwinfo driver.
 

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -93,6 +93,11 @@
 			status = "disabled";
 		};
 
+		uuid: flash@9fc70 {
+			compatible = "nxp,lpc-uid";
+			reg = <0x9fc70 0x10>;
+		};
+
 		boot_rom: flash@3000000 {
 			compatible = "soc-nv-flash";
 			reg = <0x3000000 DT_SIZE_K(128)>;

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -94,6 +94,11 @@
 			write-block-size = <512>;
 		};
 
+		uuid: flash@9fc70 {
+			compatible = "nxp,lpc-uid";
+			reg = <0x9fc70 0x10>;
+		};
+
 		boot_rom: flash@3000000 {
 			compatible = "soc-nv-flash";
 			reg = <0x3000000 DT_SIZE_K(128)>;

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -108,9 +108,9 @@
 			status = "disabled";
 		};
 
-		uuid: flash@9FC70 {
+		uuid: flash@9fc70 {
 			compatible = "nxp,lpc-uid";
-			reg = <0x9FC70 0x10>;
+			reg = <0x9fc70 0x10>;
 		};
 
 		boot_rom: flash@3000000 {


### PR DESCRIPTION
The NXP LPC syscon driver failed to build on several platforms for
various reasons.  We need dts support on LPC55s1x and LPC55s2x, the
driver doesn't seem like it will work on LPC54114 so we exclude it
there for now.

Additionally, fix a dtc warning on LPC55s6x based on unit-address in
the node naming needing to be lowercase.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>