### PR TITLE
tests: arch: arm_irq_vector_table: Update to run on MXRT685

### DIFF
--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -24,7 +24,7 @@ static struct k_spinlock lock;
 static uint64_t last_count;
 static OSTIMER_Type *base;
 
-static void mcux_lpc_ostick_isr(void *arg)
+void mcux_lpc_ostick_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -230,6 +230,18 @@ vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0,
 	rtc_isr
 };
+#elif defined(CONFIG_SOC_SERIES_IMX_RT6XX) && defined(CONFIG_MCUX_OS_TIMER)
+/* MXRT685 employs a OS Event timer to implement the Kernel system
+ * timer, instead of the ARM Cortex-M SysTick. Therefore, a pointer to
+ * the timer ISR needs to be added in the custom vector table to handle
+ * the timer "tick" interrupts.
+ */
+extern void mcux_lpc_ostick_isr(void);
+vth __irq_vector_table _irq_vector_table[] = {
+	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	mcux_lpc_ostick_isr
+};
 #else
 vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2


### PR DESCRIPTION
Fixes #35658
Update the custom vector table to add the OS Event timer interrupt which is used on RT685 as the kernel system timer
