### PR TITLE
Add support for disabling auto-negotiation for stm32 ethernet driver

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -88,4 +88,28 @@ config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	  Set the RX idle timeout period in milliseconds after which the
 	  PHY's carrier status is re-evaluated.
 
+config ETH_STM32_AUTO_NEGOTIATION_ENABLE
+	bool "Enable autonegotiation mode"
+	default y
+	help
+	  Enable this if using autonegotiation
+
+if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
+
+config ETH_STM32_SPEED_10M
+	bool "Enable this if using 10 Mbps for speed when autonegotiation is diabled"
+	default n
+	help
+	  Set this if using 10 Mbps and when autonegotiation is disabled, otherwise speed
+	  is 100 Mbps
+
+config ETH_STM32_MODE_HALFDUPLEX
+	bool "Enable this if using half duplex"
+	default n
+	help
+	  Set this if using half duplex when autonegotiation is disabled otherwise
+	  duplex mode is full duplex
+
+endif # !ETH_STM32_AUTO_NEGOTIATION_ENABLE
+
 endif # ETH_STM32_HAL

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -891,7 +891,21 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
 		.Init = {
 #if !defined(CONFIG_SOC_SERIES_STM32H7X)
+#if defined(CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE)
 			.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE,
+#else
+			.AutoNegotiation = ETH_AUTONEGOTIATION_DISABLE,
+#if defined(CONFIG_ETH_STM32_SPEED_10M)
+			.Speed = ETH_SPEED_10M,
+#else
+			.Speed = ETH_SPEED_100M,
+#endif
+#if defined(CONFIG_ETH_STM32_MODE_HALFDUPLEX)
+			.DuplexMode = ETH_MODE_HALFDUPLEX,
+#else
+			.DuplexMode = ETH_MODE_FULLDUPLEX,
+#endif
+#endif /* !CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE */
 			.PhyAddress = PHY_ADDR,
 			.RxMode = ETH_RXINTERRUPT_MODE,
 			.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE,


### PR DESCRIPTION
Added support for disabling auto-negotiation for stm32 eth driver
Stm32 ethernet drivers did not have ability to support disabling auto-negotiation. Not all Phy support auto-negotiation so this PR adds ability to disable auto-negotiation based on Kconfig parameter.

Signed-off-by: Rup Gajurel <rup@fb.com>