### PR TITLE
drivers/sensor: ms5607: fix compensation for temperature < 20C

### DIFF
--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -35,7 +35,7 @@ static void ms5607_compensate(struct ms5607_data *data,
 	 * PRESSURE AND TEMPERATURE CALCULATION
 	 */
 
-	dT = adc_temperature - ((uint32_t)(data->t_ref) << 8);
+	dT = adc_temperature - ((int32_t)(data->t_ref) << 8);
 	data->temperature = 2000 + (dT * data->tempsens) / (1ll << 23);
 	OFF = ((int64_t)(data->off_t1) << 17) + (dT * data->tco) / (1ll << 6);
 	SENS = ((int64_t)(data->sens_t1) << 16) + (dT * data->tcs) / (1ll << 7);


### PR DESCRIPTION
When the temperature is lower than 20C, adc_temperature is smaller than
(data->t_ref << 8), which should yield a negative value for dT. While dT
and adc_temperature are correctly declared as signed, the subtrahend is
wrongly casted to unsigned, yielding insanely high temperature values.
Fix that by casting it to int32_t instead of uint32_t.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>