### PR TITLE
drivers: can: Timestamps depend on driver select

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -29,6 +29,11 @@ config CAN_HAS_CANFD
 	help
 	  driver supports CAN-FD
 
+config CAN_HAS_RX_TIMESTAMP
+	bool
+	help
+	  driver supports RX timestamps
+
 config CAN_FD_MODE
 	bool "CAN-FD"
 	default y
@@ -66,7 +71,7 @@ config CAN_WORKQ_FRAMES_BUF_CNT
 
 config CAN_RX_TIMESTAMP
 	bool "Enable receiving timestamps"
-	depends on CAN_STM32 || CAN_MCUX_FLEXCAN || CAN_STM32FD
+	depends on CAN_HAS_RX_TIMESTAMP
 	help
 	  This option enables a timestamp value of the CAN free running timer.
 	  The value is incremented every bit time and starts when the controller

--- a/drivers/can/Kconfig.mcan
+++ b/drivers/can/Kconfig.mcan
@@ -6,6 +6,7 @@
 config CAN_MCAN
 	bool
 	select CAN_HAS_CANFD
+	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable Bosch m_can driver.
 	  This driver supports the Bosch m_can IP. This IP is built into the

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -6,6 +6,7 @@
 config CAN_MCUX_FLEXCAN
 	bool "MCUX FlexCAN driver"
 	depends on HAS_MCUX_FLEXCAN && CLOCK_CONTROL
+	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable support for mcux flexcan driver.
 

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -8,6 +8,7 @@ DT_COMPAT_ST_STM32_CAN := st,stm32-can
 config CAN_STM32
 	bool "STM32 CAN Driver"
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_CAN))
+	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable STM32 CAN Driver.
 	  Tested on stm32F0, stm32L4 and stm32F7 series.


### PR DESCRIPTION
Instead of explicity ORing together the compatible drivers,
CAN_RX_TIMESTAMP now depends on CAN_HAS_RX_TIMESTAMP
which is selected by the drivers primary Kconfig option. In addition,
stm32fd does not need to select this option since it selected by
the underlying M_CAN driver.

Signed-off-by: Abram Early <abram.early@gmail.com>