### PR TITLE
Cleanup some RISC-V PMP porting

### DIFF
--- a/arch/riscv/core/pmp/core_pmp.c
+++ b/arch/riscv/core/pmp/core_pmp.c
@@ -30,9 +30,31 @@ LOG_MODULE_REGISTER(mpu);
 
 #if defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
 # define PMP_MODE_DEFAULT		PMP_MODE_NAPOT
+# define PMP_USED_ENTRY_DEFAULT		1 /* NAPOT region use 1 PMP entry */
 #else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
 # define PMP_MODE_DEFAULT		PMP_MODE_TOR
+# define PMP_USED_ENTRY_DEFAULT		2 /* TOR region use 2 PMP entry */
 #endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+
+#ifdef CONFIG_USERSPACE
+/*
+ * Define the used PMP regions before memory domain/partition.
+ *
+ * Already used PMP regions:
+ *   1. 0/1 entry for interrupt stack guard: None
+ *   2. 1   entry for MCU state: R
+ *   3. 1/2 entry for program and read only data: RX
+ *   4. 1/2 entry for user thread stack: RW
+ */
+#define PMP_REGION_NUM_FOR_U_THREAD	( \
+	(IS_ENABLED(CONFIG_PMP_STACK_GUARD) ? 1 : 0) + \
+	 1 + (2 * PMP_USED_ENTRY_DEFAULT))
+
+#define PMP_MAX_DYNAMIC_REGION		( \
+	(CONFIG_PMP_SLOT - PMP_REGION_NUM_FOR_U_THREAD) \
+	/ PMP_USED_ENTRY_DEFAULT)
+
+#endif /* CONFIG_USERSPACE */
 
 enum pmp_region_mode {
 	PMP_MODE_NA4,

--- a/arch/riscv/core/pmp/core_pmp.c
+++ b/arch/riscv/core/pmp/core_pmp.c
@@ -14,10 +14,52 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
-#define PMP_SLOT_NUMBER	CONFIG_PMP_SLOT
+#if __riscv_xlen == 32
+# define PR_ADDR "0x%08lx"
+#elif __riscv_xlen == 64
+# define PR_ADDR "0x%016lx"
+#endif
+
+#ifdef CONFIG_64BIT
+# define PMPCFG_NUM(index)	(((index) / 8) * 2)
+# define PMPCFG_SHIFT(index)	(((index) % 8) * 8)
+#else  /* CONFIG_64BIT */
+# define PMPCFG_NUM(index)	((index) / 4)
+# define PMPCFG_SHIFT(index)	(((index) % 4) * 8)
+#endif /* CONFIG_64BIT */
+
+#if defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
+# define PMP_MODE_DEFAULT		PMP_MODE_NAPOT
+#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+# define PMP_MODE_DEFAULT		PMP_MODE_TOR
+#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+
+enum pmp_region_mode {
+	PMP_MODE_NA4,
+	/* If NAPOT mode region size is 4, apply NA4 region to PMP CSR. */
+	PMP_MODE_NAPOT,
+	PMP_MODE_TOR,
+};
+
+/* Region definition data structure */
+struct riscv_pmp_region {
+	ulong_t start;
+	ulong_t size;
+	uint8_t perm;
+	enum pmp_region_mode mode;
+};
 
 #ifdef CONFIG_USERSPACE
 extern ulong_t is_user_mode;
+#endif
+
+#ifdef CONFIG_PMP_STACK_GUARD
+static const struct riscv_pmp_region irq_stack_guard_region = {
+	.start = (ulong_t) z_interrupt_stacks[0],
+	.size = PMP_GUARD_ALIGN_AND_SIZE,
+	.perm = 0,
+	.mode = PMP_MODE_NAPOT,
+};
 #endif
 
 enum {
@@ -43,7 +85,7 @@ enum {
 	CSR_PMPADDR15
 };
 
-static ulong_t csr_read_enum(int pmp_csr_enum)
+static __unused ulong_t csr_read_enum(int pmp_csr_enum)
 {
 	ulong_t res = -1;
 
@@ -142,44 +184,207 @@ static void csr_write_enum(int pmp_csr_enum, ulong_t value)
 	}
 }
 
-int z_riscv_pmp_set(unsigned int index, ulong_t cfg_val, ulong_t addr_val)
+/*
+ * @brief Set a Physical Memory Protection slot
+ *
+ * Configure a memory region to be secured by one of the 16 PMP entries.
+ *
+ * @param index		Number of the targeted PMP entrie (0 to 15 only).
+ * @param cfg_val	Configuration value (cf datasheet or defined flags)
+ * @param addr_val	Address register value
+ *
+ * This function shall only be called from Secure state.
+ *
+ * @return -1 if bad argument, 0 otherwise.
+ */
+static __unused int riscv_pmp_set(unsigned int index, ulong_t cfg_val, ulong_t addr_val)
 {
 	ulong_t reg_val;
 	ulong_t shift, mask;
 	int pmpcfg_csr;
 	int pmpaddr_csr;
 
-	if (index >= PMP_SLOT_NUMBER) {
+	if (index >= CONFIG_PMP_SLOT) {
 		return -1;
 	}
 
 	/* Calculate PMP config/addr register, shift and mask */
-#ifdef CONFIG_64BIT
-	pmpcfg_csr = CSR_PMPCFG0 + ((index >> 3) << 1);
-	shift = (index & 0x7) << 3;
-#else
-	pmpcfg_csr = CSR_PMPCFG0 + (index >> 2);
-	shift = (index & 0x3) << 3;
-#endif /* CONFIG_64BIT */
+	pmpcfg_csr = CSR_PMPCFG0 + PMPCFG_NUM(index);
 	pmpaddr_csr = CSR_PMPADDR0 + index;
-
-	/* Mask = 0x000000FF<<((index%4)*8) */
-	mask = 0x000000FF << shift;
-
-	cfg_val = cfg_val << shift;
-	addr_val = TO_PMP_ADDR(addr_val);
+	shift = PMPCFG_SHIFT(index);
+	mask = 0xFF << shift;
 
 	reg_val = csr_read_enum(pmpcfg_csr);
 	reg_val = reg_val & ~mask;
-	reg_val = reg_val | cfg_val;
+	reg_val = reg_val | (cfg_val << shift);
 
 	csr_write_enum(pmpaddr_csr, addr_val);
 	csr_write_enum(pmpcfg_csr, reg_val);
 	return 0;
 }
 
+static __unused int riscv_pmp_region_set(int index, const struct riscv_pmp_region *region)
+{
+	int result, pmp_mode;
+
+	/* Check 4 bytes alignment */
+	__unused int valid_addr = ((region->start & 0x3) == 0) &&
+		((region->size & 0x3) == 0) &&
+		(region->size);
+	__ASSERT(valid_addr, "PMP address/size are not 4 bytes aligned\n");
+
+	if (region->mode == PMP_MODE_TOR) {
+		pmp_mode = PMP_TOR;
+
+		uint8_t cfg_val1 = PMP_NA4 | region->perm;
+		ulong_t addr_val1 = TO_PMP_ADDR(region->start);
+		uint8_t cfg_val2 = PMP_TOR | region->perm;
+		ulong_t addr_val2 = TO_PMP_ADDR(region->start + region->size);
+
+		riscv_pmp_set(index, cfg_val1, addr_val1);
+		riscv_pmp_set(index+1, cfg_val2, addr_val2);
+
+		result = index+2;
+	} else {
+		if ((region->mode == PMP_MODE_NA4) || (region->size == 4)) {
+			/* If NAPOT-mode region size is 4, apply
+			 * NA4-mode region to PMP CSR.
+			 */
+			pmp_mode = PMP_NA4;
+		} else {
+			pmp_mode = PMP_NAPOT;
+		}
+
+		uint8_t cfg_val = pmp_mode | region->perm;
+		ulong_t addr_val = TO_PMP_NAPOT(region->start, region->size);
+
+		riscv_pmp_set(index, cfg_val, addr_val);
+
+		result = index+1;
+	}
+
+	LOG_DBG("Set PMP region %d: (" PR_ADDR ", " PR_ADDR
+		", %s%s%s, %s)", index, region->start, region->size,
+		((region->perm & PMP_R) ? "R" : " "),
+		((region->perm & PMP_W) ? "W" : " "),
+		((region->perm & PMP_X) ? "X" : " "),
+		((pmp_mode == PMP_TOR) ? "TOR" :
+		(pmp_mode == PMP_NAPOT) ? "NAPOT" : "NA4"));
+
+	if (pmp_mode == PMP_TOR) {
+		LOG_DBG("TOR mode region also use entry %d", index+1);
+	}
+
+	return result;
+}
+
+static __unused int riscv_pmp_region_translate(ulong_t pmpcfg[], ulong_t pmpaddr[], int index,
+	const struct riscv_pmp_region *region)
+{
+	int result, pmp_mode;
+
+	/* Check 4 bytes alignment */
+	__unused int valid_addr = ((region->start & 0x3) == 0) &&
+		((region->size & 0x3) == 0) &&
+		(!region->start || region->size);
+	__ASSERT(valid_addr, "PMP address/size are not 4 bytes aligned\n");
+
+	if ((region->start == 0) && (region->size == 0)) {
+		/* special case: set whole memory as single PMP region.
+		 *   RV32: 0 ~ (2**32 - 1)
+		 *   RV64: 0 ~ (2**64 - 1)
+		 */
+		pmp_mode = PMP_NAPOT;
+
+		uint8_t cfg_val = PMP_NAPOT | region->perm;
+#ifdef CONFIG_64BIT
+		ulong_t addr_val = 0x1FFFFFFFFFFFFFFF;
+#else
+		ulong_t addr_val = 0x1FFFFFFF;
+#endif
+
+		uint8_t *u8_pmpcfg = (uint8_t *)pmpcfg;
+
+		u8_pmpcfg[index] = cfg_val;
+		pmpaddr[index] = addr_val;
+
+		result = index+1;
+	} else if (region->mode == PMP_MODE_TOR) {
+		pmp_mode = PMP_TOR;
+
+		uint8_t cfg_val1 = PMP_NA4 | region->perm;
+		ulong_t addr_val1 = TO_PMP_ADDR(region->start);
+		uint8_t cfg_val2 = PMP_TOR | region->perm;
+		ulong_t addr_val2 = TO_PMP_ADDR(region->start + region->size);
+
+		uint8_t *u8_pmpcfg = (uint8_t *)pmpcfg;
+
+		u8_pmpcfg[index] = cfg_val1;
+		pmpaddr[index] = addr_val1;
+		u8_pmpcfg[index+1] = cfg_val2;
+		pmpaddr[index+1] = addr_val2;
+
+		result = index+2;
+	} else {
+		if ((region->mode == PMP_MODE_NA4) || (region->size == 4)) {
+			pmp_mode = PMP_NA4;
+		} else {
+			pmp_mode = PMP_NAPOT;
+		}
+
+		uint8_t cfg_val = pmp_mode | region->perm;
+		ulong_t addr_val = TO_PMP_NAPOT(region->start, region->size);
+		uint8_t *u8_pmpcfg = (uint8_t *)pmpcfg;
+
+		u8_pmpcfg[index] = cfg_val;
+		pmpaddr[index] = addr_val;
+
+		result = index+1;
+	}
+
+	LOG_DBG("PMP context " PR_ADDR " add region %d: (" PR_ADDR
+		", " PR_ADDR ", %s%s%s, %s)", (ulong_t) pmpcfg, index,
+		region->start, region->size,
+		((region->perm & PMP_R) ? "R" : " "),
+		((region->perm & PMP_W) ? "W" : " "),
+		((region->perm & PMP_X) ? "X" : " "),
+		((pmp_mode == PMP_TOR) ? "TOR" :
+		(pmp_mode == PMP_NAPOT) ? "NAPOT" : "NA4"));
+
+	if (pmp_mode == PMP_TOR) {
+		LOG_DBG("TOR mode region also use entry %d", index+1);
+	}
+
+	return result;
+}
+
+static __unused int riscv_pmp_regions_translate(ulong_t pmpcfg[], ulong_t pmpaddr[],
+	int start_reg_index, const struct riscv_pmp_region regions[],
+	uint8_t regions_num)
+{
+	int reg_index = start_reg_index;
+
+	for (int i = 0; i < regions_num; i++) {
+		/*
+		 * Empty region.
+		 *
+		 * Note: start = size = 0 is valid region (special case).
+		 */
+		if ((regions[i].size == 0U) && (regions[i].start != 0)) {
+			continue;
+		}
+
+		/* Non-empty region. */
+		reg_index = riscv_pmp_region_translate(pmpcfg, pmpaddr, reg_index,
+			&regions[i]);
+	}
+
+	return reg_index;
+}
+
 void z_riscv_pmp_clear_config(void)
 {
+	LOG_DBG("Clear all dynamic PMP regions");
 	for (unsigned int i = 0; i < RISCV_PMP_CFG_NUM; i++)
 		csr_write_enum(CSR_PMPCFG0 + i, 0);
 }
@@ -188,48 +393,38 @@ void z_riscv_pmp_clear_config(void)
 #include <linker/linker-defs.h>
 void z_riscv_init_user_accesses(struct k_thread *thread)
 {
-	unsigned char index;
-	unsigned char *uchar_pmpcfg;
-	ulong_t rom_start = (ulong_t) __rom_region_start;
-#if defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
-	ulong_t rom_size = (ulong_t) __rom_region_size;
-#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-	ulong_t rom_end = (ulong_t) __rom_region_end;
-#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-	index = 0U;
-	uchar_pmpcfg = (unsigned char *) thread->arch.u_pmpcfg;
-
+	unsigned char index = 0U;
 #ifdef CONFIG_PMP_STACK_GUARD
 	index++;
 #endif /* CONFIG_PMP_STACK_GUARD */
 
-	/* MCU state */
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR((ulong_t) &is_user_mode);
-	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R;
-#if defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
-	/* Program and RO data */
-	thread->arch.u_pmpaddr[index] = TO_PMP_NAPOT(rom_start, rom_size);
-	uchar_pmpcfg[index++] = PMP_NAPOT | PMP_R | PMP_X;
+	struct riscv_pmp_region dynamic_regions[] = {
+		{
+			/* MCU state */
+			.start = (ulong_t) &is_user_mode,
+			.size = 4,
+			.perm = PMP_R,
+			.mode = PMP_MODE_NA4,
+		},
+		{
+			/* Program and RO data */
+			.start = (ulong_t) __rom_region_start,
+			.size = (ulong_t) __rom_region_size,
+			.perm = PMP_R | PMP_X,
+			.mode = PMP_MODE_DEFAULT,
+		},
+		{
+			/* User-mode thread stack */
+			.start = thread->stack_info.start,
+			.size = thread->stack_info.size,
+			.perm = PMP_R | PMP_W,
+			.mode = PMP_MODE_DEFAULT,
+		},
+	};
 
-	/* RAM */
-	thread->arch.u_pmpaddr[index] = TO_PMP_NAPOT(thread->stack_info.start,
-					thread->stack_info.size);
-
-	uchar_pmpcfg[index++] = PMP_NAPOT | PMP_R | PMP_W;
-#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-	/* Program and RO data */
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(rom_start);
-	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R | PMP_X;
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(rom_end);
-	uchar_pmpcfg[index++] = PMP_TOR | PMP_R | PMP_X;
-
-	/* RAM */
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(thread->stack_info.start);
-	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R | PMP_W;
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(thread->stack_info.start +
-		thread->stack_info.size);
-	uchar_pmpcfg[index++] = PMP_TOR | PMP_R | PMP_W;
-#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
+	riscv_pmp_regions_translate(thread->arch.u_pmpcfg,
+		thread->arch.u_pmpaddr, index, dynamic_regions,
+		ARRAY_SIZE(dynamic_regions));
 }
 
 void z_riscv_configure_user_allowed_stack(struct k_thread *thread)
@@ -243,6 +438,9 @@ void z_riscv_configure_user_allowed_stack(struct k_thread *thread)
 
 	for (i = 0U; i < RISCV_PMP_CFG_NUM; i++)
 		csr_write_enum(CSR_PMPCFG0 + i, thread->arch.u_pmpcfg[i]);
+
+	LOG_DBG("Apply user PMP context " PR_ADDR " to dynamic PMP regions",
+		(ulong_t) thread->arch.u_pmpcfg);
 }
 
 void z_riscv_pmp_add_dynamic(struct k_thread *thread,
@@ -253,9 +451,11 @@ void z_riscv_pmp_add_dynamic(struct k_thread *thread,
 	unsigned char index = 0U;
 	unsigned char *uchar_pmpcfg;
 
-	/* Check 4 bytes alignment */
-	__ASSERT(((addr & 0x3) == 0) && ((size & 0x3) == 0) && size,
-		 "address/size are not 4 bytes aligned\n");
+	struct riscv_pmp_region pmp_region = {
+		.start = addr,
+		.size = size,
+		.perm = flags,
+	};
 
 	/* Get next free entry */
 	uchar_pmpcfg = (unsigned char *) thread->arch.u_pmpcfg;
@@ -268,25 +468,16 @@ void z_riscv_pmp_add_dynamic(struct k_thread *thread,
 
 	__ASSERT((index < CONFIG_PMP_SLOT), "no free PMP entry\n");
 
-	/* Select the best type */
+	/* Select the best mode */
 	if (size == 4) {
-		thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(addr);
-		uchar_pmpcfg[index] = flags | PMP_NA4;
+		pmp_region.mode = PMP_MODE_NA4;
 	}
-#if !defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)
-	else if ((addr & (size - 1)) || (size & (size - 1))) {
-		__ASSERT(((index + 1) < CONFIG_PMP_SLOT),
-			"not enough free PMP entries\n");
-		thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(addr);
-		uchar_pmpcfg[index++] = flags | PMP_NA4;
-		thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(addr + size);
-		uchar_pmpcfg[index++] = flags | PMP_TOR;
-	}
-#endif /* !CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
 	else {
-		thread->arch.u_pmpaddr[index] = TO_PMP_NAPOT(addr, size);
-		uchar_pmpcfg[index] = flags | PMP_NAPOT;
+		pmp_region.mode = PMP_MODE_DEFAULT;
 	}
+
+	riscv_pmp_region_translate(thread->arch.u_pmpcfg,
+		thread->arch.u_pmpaddr, index, &pmp_region);
 }
 
 int arch_buffer_validate(void *addr, size_t size, int write)
@@ -379,26 +570,26 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 {
 	sys_dnode_t *node, *next_node;
 	uint32_t index, i, num;
-	ulong_t pmp_type, pmp_addr;
+	ulong_t pmp_mode, pmp_addr;
 	unsigned char *uchar_pmpcfg;
 	struct k_thread *thread;
 	ulong_t size = (ulong_t) domain->partitions[partition_id].size;
 	ulong_t start = (ulong_t) domain->partitions[partition_id].start;
 
 	if (size == 4) {
-		pmp_type = PMP_NA4;
+		pmp_mode = PMP_NA4;
 		pmp_addr = TO_PMP_ADDR(start);
 		num = 1U;
 	}
 #if !defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT) || defined(CONFIG_PMP_STACK_GUARD)
 	else if ((start & (size - 1)) || (size & (size - 1))) {
-		pmp_type = PMP_TOR;
+		pmp_mode = PMP_TOR;
 		pmp_addr = TO_PMP_ADDR(start + size);
 		num = 2U;
 	}
 #endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT || CONFIG_PMP_STACK_GUARD */
 	else {
-		pmp_type = PMP_NAPOT;
+		pmp_mode = PMP_NAPOT;
 		pmp_addr = TO_PMP_NAPOT(start, size);
 		num = 1U;
 	}
@@ -414,7 +605,7 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	for (index = PMP_REGION_NUM_FOR_U_THREAD;
 		index < CONFIG_PMP_SLOT;
 		index++) {
-		if (((uchar_pmpcfg[index] & PMP_TYPE_MASK) == pmp_type) &&
+		if (((uchar_pmpcfg[index] & PMP_TYPE_MASK) == pmp_mode) &&
 			(pmp_addr == thread->arch.u_pmpaddr[index])) {
 			break;
 		}
@@ -423,7 +614,7 @@ void arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	__ASSERT((index < CONFIG_PMP_SLOT), "partition not found\n");
 
 #if !defined(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT) || defined(CONFIG_PMP_STACK_GUARD)
-	if (pmp_type == PMP_TOR) {
+	if (pmp_mode == PMP_TOR) {
 		index--;
 	}
 #endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT || CONFIG_PMP_STACK_GUARD */
@@ -496,24 +687,18 @@ void arch_mem_domain_thread_remove(struct k_thread *thread)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_PMP_STACK_GUARD
-
 void z_riscv_init_stack_guard(struct k_thread *thread)
 {
-	unsigned char index = 0U;
-	unsigned char *uchar_pmpcfg;
 	ulong_t stack_guard_addr;
-
-	uchar_pmpcfg = (unsigned char *) thread->arch.s_pmpcfg;
-
-	uchar_pmpcfg++;
+	struct riscv_pmp_region dynamic_regions[4]; /* Maximum region_num is 4 */
+	uint8_t region_num = 0U;
 
 	/* stack guard: None */
-	thread->arch.s_pmpaddr[index] = TO_PMP_ADDR(thread->stack_info.start);
-	uchar_pmpcfg[index++] = PMP_NA4;
-	thread->arch.s_pmpaddr[index] =
-		TO_PMP_ADDR(thread->stack_info.start +
-			PMP_GUARD_ALIGN_AND_SIZE);
-	uchar_pmpcfg[index++] = PMP_TOR;
+	dynamic_regions[region_num].start = thread->stack_info.start;
+	dynamic_regions[region_num].size = PMP_GUARD_ALIGN_AND_SIZE;
+	dynamic_regions[region_num].perm = 0;
+	dynamic_regions[region_num].mode = PMP_MODE_TOR;
+	region_num++;
 
 #ifdef CONFIG_USERSPACE
 	if (thread->arch.priv_stack_start) {
@@ -522,28 +707,34 @@ void z_riscv_init_stack_guard(struct k_thread *thread)
 #else
 		stack_guard_addr = (ulong_t) thread->stack_obj;
 #endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-		thread->arch.s_pmpaddr[index] =
-			TO_PMP_ADDR(stack_guard_addr);
-		uchar_pmpcfg[index++] = PMP_NA4;
-		thread->arch.s_pmpaddr[index] =
-			TO_PMP_ADDR(stack_guard_addr +
-				PMP_GUARD_ALIGN_AND_SIZE);
-		uchar_pmpcfg[index++] = PMP_TOR;
+		dynamic_regions[region_num].start = stack_guard_addr;
+		dynamic_regions[region_num].size = PMP_GUARD_ALIGN_AND_SIZE;
+		dynamic_regions[region_num].perm = 0;
+		dynamic_regions[region_num].mode = PMP_MODE_TOR;
+		region_num++;
 	}
 #endif /* CONFIG_USERSPACE */
 
 	/* RAM: RW */
-	thread->arch.s_pmpaddr[index] = TO_PMP_ADDR(CONFIG_SRAM_BASE_ADDRESS |
-				TO_NAPOT_RANGE(KB(CONFIG_SRAM_SIZE)));
-	uchar_pmpcfg[index++] = (PMP_NAPOT | PMP_R | PMP_W);
+	dynamic_regions[region_num].start = CONFIG_SRAM_BASE_ADDRESS;
+	dynamic_regions[region_num].size = KB(CONFIG_SRAM_SIZE);
+	dynamic_regions[region_num].perm = PMP_R | PMP_W;
+	dynamic_regions[region_num].mode = PMP_MODE_NAPOT;
+	region_num++;
 
 	/* All other memory: RWX */
-#ifdef CONFIG_64BIT
-	thread->arch.s_pmpaddr[index] = 0x1FFFFFFFFFFFFFFF;
-#else
-	thread->arch.s_pmpaddr[index] = 0x1FFFFFFF;
-#endif /* CONFIG_64BIT */
-	uchar_pmpcfg[index] = PMP_NAPOT | PMP_R | PMP_W | PMP_X;
+	/* special case: start = size = 0 means whole memory. */
+	dynamic_regions[region_num].start = 0;
+	dynamic_regions[region_num].size = 0;
+	dynamic_regions[region_num].perm = PMP_R | PMP_W | PMP_X;
+	dynamic_regions[region_num].mode = PMP_MODE_NAPOT;
+	region_num++;
+
+	/* Reserve index 0 for PMP stack guard */
+	unsigned char index = 1;
+
+	riscv_pmp_regions_translate(thread->arch.s_pmpcfg,
+		thread->arch.s_pmpaddr, index, dynamic_regions, region_num);
 }
 
 void z_riscv_configure_stack_guard(struct k_thread *thread)
@@ -555,8 +746,8 @@ void z_riscv_configure_stack_guard(struct k_thread *thread)
 
 	z_riscv_pmp_clear_config();
 
-	for (i = 0U; i < PMP_REGION_NUM_FOR_STACK_GUARD; i++)
-		csr_write_enum(CSR_PMPADDR1 + i, thread->arch.s_pmpaddr[i]);
+	for (i = 1U; i < PMP_REGION_NUM_FOR_STACK_GUARD; i++)
+		csr_write_enum(CSR_PMPADDR0 + i, thread->arch.s_pmpaddr[i]);
 
 	for (i = 0U; i < PMP_CFG_CSR_NUM_FOR_STACK_GUARD; i++)
 		csr_write_enum(CSR_PMPCFG0 + i, thread->arch.s_pmpcfg[i]);
@@ -567,14 +758,10 @@ void z_riscv_configure_stack_guard(struct k_thread *thread)
 
 void z_riscv_configure_interrupt_stack_guard(void)
 {
-	if (PMP_GUARD_ALIGN_AND_SIZE > 4) {
-		z_riscv_pmp_set(0, PMP_NAPOT | PMP_L,
-			(ulong_t) z_interrupt_stacks[0] |
-			TO_NAPOT_RANGE(PMP_GUARD_ALIGN_AND_SIZE));
-	} else {
-		z_riscv_pmp_set(0, PMP_NA4 | PMP_L,
-			(ulong_t) z_interrupt_stacks[0]);
-	}
+	int index = 0;
+
+	LOG_DBG("Set static PMP region %d for IRQ stack guard", index);
+	riscv_pmp_region_set(index, &irq_stack_guard_region);
 }
 #endif /* CONFIG_PMP_STACK_GUARD */
 
@@ -582,19 +769,20 @@ void z_riscv_configure_interrupt_stack_guard(void)
 
 void z_riscv_pmp_init_thread(struct k_thread *thread)
 {
-	unsigned char i;
-	ulong_t *pmpcfg;
+	/* Clear [u|s]_pmp[cfg|addr] field of k_thread */
 
 #if defined(CONFIG_PMP_STACK_GUARD)
-	pmpcfg = thread->arch.s_pmpcfg;
-	for (i = 0U; i < PMP_CFG_CSR_NUM_FOR_STACK_GUARD; i++)
-		pmpcfg[i] = 0;
+	memset(thread->arch.s_pmpcfg, 0,
+		sizeof(ulong_t) * PMP_CFG_CSR_NUM_FOR_STACK_GUARD);
+	memset(thread->arch.s_pmpaddr, 0,
+		sizeof(ulong_t) * PMP_REGION_NUM_FOR_STACK_GUARD);
 #endif /* CONFIG_PMP_STACK_GUARD */
 
 #if defined(CONFIG_USERSPACE)
-	pmpcfg = thread->arch.u_pmpcfg;
-	for (i = 0U; i < RISCV_PMP_CFG_NUM; i++)
-		pmpcfg[i] = 0;
+	memset(thread->arch.u_pmpcfg, 0,
+		sizeof(ulong_t) * RISCV_PMP_CFG_NUM);
+	memset(thread->arch.u_pmpaddr, 0,
+		sizeof(ulong_t) * CONFIG_PMP_SLOT);
 #endif /* CONFIG_USERSPACE */
 }
 #endif /* CONFIG_PMP_STACK_GUARD || CONFIG_USERSPACE */

--- a/arch/riscv/include/core_pmp.h
+++ b/arch/riscv/include/core_pmp.h
@@ -39,21 +39,6 @@
 #ifdef CONFIG_RISCV_PMP
 
 /*
- * @brief Set a Physical Memory Protection slot
- *
- * Configure a memory region to be secured by one of the 16 PMP entries.
- *
- * @param index		Number of the targeted PMP entrie (0 to 15 only).
- * @param cfg_val	Configuration value (cf datasheet or defined flags)
- * @param addr_val	Address register value
- *
- * This function shall only be called from Secure state.
- *
- * @return -1 if bad argument, 0 otherwise.
- */
-int z_riscv_pmp_set(unsigned int index, ulong_t cfg_val, ulong_t addr_val);
-
-/*
  * @brief Reset to 0 all PMP setup registers
  */
 void z_riscv_pmp_clear_config(void);

--- a/arch/riscv/include/core_pmp.h
+++ b/arch/riscv/include/core_pmp.h
@@ -57,11 +57,6 @@ int z_riscv_pmp_set(unsigned int index, ulong_t cfg_val, ulong_t addr_val);
  * @brief Reset to 0 all PMP setup registers
  */
 void z_riscv_pmp_clear_config(void);
-
-/*
- * @brief Print PMP setup register for info/debug
- */
-void z_riscv_pmp_print(unsigned int index);
 #endif /* CONFIG_RISCV_PMP */
 
 #if defined(CONFIG_USERSPACE)

--- a/include/arch/riscv/thread.h
+++ b/include/arch/riscv/thread.h
@@ -50,51 +50,6 @@
 #define PMP_CFG_CSR_NUM_FOR_STACK_GUARD	2
 #endif /* CONFIG_PMP_STACK_GUARD */
 
-#ifdef CONFIG_PMP_POWER_OF_TWO_ALIGNMENT
-#ifdef CONFIG_USERSPACE
-#ifdef CONFIG_PMP_STACK_GUARD
-/*
- * 1 for interrupt stack guard: None
- * 1 for core state: R
- * 1 for program and read only data: RX
- * 1 for user thread stack: RW
- */
-#define PMP_REGION_NUM_FOR_U_THREAD	4
-#else /* CONFIG_PMP_STACK_GUARD */
-/*
- * 1 for core state: R
- * 1 for program and read only data: RX
- * 1 for user thread stack: RW
- */
-#define PMP_REGION_NUM_FOR_U_THREAD	3
-#endif /* CONFIG_PMP_STACK_GUARD */
-#define PMP_MAX_DYNAMIC_REGION	(CONFIG_PMP_SLOT - PMP_REGION_NUM_FOR_U_THREAD)
-#endif /* CONFIG_USERSPACE */
-
-#else /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-
-#ifdef CONFIG_USERSPACE
-#ifdef CONFIG_PMP_STACK_GUARD
-/*
- * 1 for interrupt stack guard: None
- * 1 for core state: R
- * 2 for program and read only data: RX
- * 2 for user thread stack: RW
- */
-#define PMP_REGION_NUM_FOR_U_THREAD	6
-#else /* CONFIG_PMP_STACK_GUARD */
-/*
- * 1 for core state: R
- * 2 for program and read only data: RX
- * 2 for user thread stack: RW
- */
-#define PMP_REGION_NUM_FOR_U_THREAD	5
-#endif /* CONFIG_PMP_STACK_GUARD */
-#define PMP_MAX_DYNAMIC_REGION	((CONFIG_PMP_SLOT - \
-				PMP_REGION_NUM_FOR_U_THREAD) >> 1)
-#endif /* CONFIG_USERSPACE */
-#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
-
 /*
  * The following structure defines the list of registers that need to be
  * saved/restored when a cooperative context switch occurs.


### PR DESCRIPTION
This PR tries to cleanup some RISC-V PMP porting and isn't intended to change any behavior of it.

There are 2 main purposes of this PR: introduce `struct riscv_pmp_region` and add MPU log of RISC-V PMP.

The 1st version of `struct riscv_pmp_region` modulize PMP CSR handling code and adding `PMP_REGION_TYPE_DEFAULT` to handle NAPOT/TOR mode more easily.

The example MPU log of RISC-V PMP is like below:

```
D: PMP context 0x80011c08 add region 0: (0x80011034, 0x00000004, R  , NA4)
D: PMP context 0x80011c08 add region 1: (0x80014000, 0x00000800, RW , NAPOT)
D: PMP context 0x80011c08 add region 3: (0x80011000, 0x00000008, RW , NAPOT)
D: PMP context 0x80011c08 add region 4: (0x80010000, 0x00001000, RW , NAPOT)
D: Clear all dynamic PMP regions
D: Apply user PMP context 0x80011c08 to dynamic PMP regions
```

Current RISC-V will prepare dynamic PMP regions of thread at `init_*()` function and configure regions to HW CSR at `configure_*()` function. Also, user/supervisor PMP contexts are for user thread protection/PMP stack guard.

Related to #31811
