### PR TITLE
arc: west: mdb: reverse the launch order for multi cores

### DIFF
--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -105,7 +105,7 @@ def mdb_do_run(mdb_runner, command):
                          ('-prop=download=2' if i > 0 else '')] +
                          mdb_basic_options + mdb_target + [mdb_runner.elf_name])
             mdb_runner.check_call(mdb_sub_cmd)
-            mdb_multifiles += (',core{}'.format(i) if i > 0 else 'core{}'.format(i))
+            mdb_multifiles += ('core{}'.format(mdb_runner.cores-1-i) if i == 0 else ',core{}'.format(mdb_runner.cores-1-i))
 
         # to enable multi-core aware mode for use with the MetaWare debugger,
         # need to set the NSIM_MULTICORE environment variable to a non-zero value

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -46,7 +46,7 @@ TEST_NSIM_CORE2 = [TEST_DRIVER_CMD, '-pset=2', '-psetname=core1',
               '-prop=download=2', '-nooptions', '-nogoifmain',
               '-toggle=include_local_symbols=1',
               '-nsim', TEST_BOARD_NSIM_ARGS, RC_KERNEL_ELF]
-TEST_NSIM_CORES_LAUNCH = [TEST_DRIVER_CMD, '-multifiles=core0,core1',
+TEST_NSIM_CORES_LAUNCH = [TEST_DRIVER_CMD, '-multifiles=core1,core0',
               '-run', '-cl']
 
 # mdb-hw
@@ -100,7 +100,7 @@ TEST_HW_CORE2 = [TEST_DRIVER_CMD, '-pset=2', '-psetname=core1',
               '-prop=download=2', '-nooptions', '-nogoifmain',
               '-toggle=include_local_symbols=1',
               '-digilent', '', RC_KERNEL_ELF]
-TEST_HW_CORES_LAUNCH = [TEST_DRIVER_CMD, '-multifiles=core0,core1', '-run',
+TEST_HW_CORES_LAUNCH = [TEST_DRIVER_CMD, '-multifiles=core1,core0', '-run',
               '-cmd=-nowaitq run', '-cmd=quit', '-cl']
 
 #


### PR DESCRIPTION
The Inter-core Debug Unit (ICD) provides additional debug
assist features in multi-core scenarios.
In master core(core 0) initial stage, we will program ICD to halt
all other cores based on a halt occurring in one ore more core.
And all cores are in halt mode on reset, so we need to make
sure other slave cores have launched and in running mode
before we enable ICD in master core.

Currently we launch master first, Let's reverse the launch
order, launch master last, to make sure slave cores have
launched before we program and enable ICD.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

fix: #36467 