### PR TITLE
some fixes for mwdt toolchain

### DIFF
--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -4,6 +4,7 @@ sample:
 common:
   tags: compression lz4
   min_ram: 32
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
   harness: console
   harness_config:
     type: one_line

--- a/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
@@ -7,9 +7,12 @@
 #include <kernel.h>
 #include "mem_protect.h"
 
-static K_APP_DMEM(ztest_mem_partition) int var = 1356;
-static K_APP_BMEM(ztest_mem_partition) int zeroed_var = 20420;
-static K_APP_BMEM(ztest_mem_partition) int bss_var;
+/* Add volatile to disable pre-calculation in compile stage in some
+ * toolchain, such as arcmwdt toolchain.
+ */
+static volatile K_APP_DMEM(ztest_mem_partition) int var = 1356;
+static volatile K_APP_BMEM(ztest_mem_partition) int zeroed_var = 20420;
+static volatile K_APP_BMEM(ztest_mem_partition) int bss_var;
 
 /**
  * @brief Test assigning global data and BSS variables to memory partitions


### PR DESCRIPTION
- samples: compression: lz4: add TOOLCHAIN_HAS_NEWLIB filter

    samples\compression\lz4 rely on CONFIG_NEWLIB_LIBC=y, let's
    add TOOLCHAIN_HAS_NEWLIB filter for it.

- tests: mem_protest: workaround aggressive optimization

    We have some static variables var, zeroed_var and bss_var
    in mem_partition.c and we only assert the value of them in
    the same file, so the compiler may pre-calculate it in compile
    stage, it's fine usually.
    But for variable zeroed_var (= 20420), we force to put it in bss
    section in link stage, the value will change in bss clean stage, so
    we will get a wrong result.
    Let's add volatile for these variables to disable pre-calculation.

fixes: #36465 #36466