### PR TITLE
driver: uart: npcx: Fix building of kernel.timer.tickless

### DIFF
--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -549,7 +549,6 @@ NPCX_UART_IRQ_CONFIG_FUNC(inst)
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_UART_INIT)
 
-#ifdef CONFIG_PM_DEVICE
 #define ENABLE_MIWU_CRIN_IRQ(inst)                                             \
 	npcx_miwu_irq_get_and_clear_pending(&uart_npcx_cfg_##inst.uart_rx_wui);\
 	npcx_miwu_irq_enable(&uart_npcx_cfg_##inst.uart_rx_wui);
@@ -566,4 +565,3 @@ void npcx_uart_disable_access_interrupt(void)
 {
 	DT_INST_FOREACH_STATUS_OKAY(DISABLE_MIWU_CRIN_IRQ)
 }
-#endif /* CONFIG_PM_DEVICE */


### PR DESCRIPTION
UART CR_SIN interrupt enable/disable are invoked when CONFIG_PM enable.
This removes the guard for UART CR_SIN interrupt enable/disable to fix
the build issue.

Fixed #36520

Signed-off-by: Wealian Liao <WHLIAO@nuvoton.com>