### PR TITLE
docs: getting started guide 3rd party toolchains fixes

### DIFF
--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -11,13 +11,16 @@ external organization. Several of these are available.
 GNU ARM Embedded
 ****************
 
+   .. warning::
+
+      Do not install the toolchain into a path with spaces.
+
 #. Download and install a `GNU ARM Embedded`_ build for your operating system
    and extract it on your file system.
 
-   .. warning::
+   .. note::
 
-      Do not install the toolchain into a path with spaces. On
-      Windows, we'll assume you install into the directory
+      On Windows, we'll assume you install into the directory
       :file:`C:\\gnu_arm_embedded`.
 
    .. warning::
@@ -44,7 +47,7 @@ GNU ARM Embedded
       $ echo $GNUARMEMB_TOOLCHAIN_PATH
       /home/you/Downloads/gnu_arm_embedded
 
-      # Windows
+      # Windows:
       > echo %ZEPHYR_TOOLCHAIN_VARIANT%
       gnuarmemb
       > echo %GNUARMEMB_TOOLCHAIN_PATH%
@@ -58,7 +61,7 @@ GNU ARM Embedded
       - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``gnuarmemb``.
       - Set :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the brew installation directory (something like ``/usr/local``)
 
-Intel oneApi Toolkits
+Intel oneAPI Toolkit
 *********************
 
 #. Download `Intel oneAPI Base Toolkit
@@ -67,8 +70,12 @@ Intel oneApi Toolkits
 #. Assuming the toolkit is installed in ``/opt/intel/oneApi``, set environment
    using::
 
+        # Linux, macOS:
         export ONEAPI_TOOLCHAIN_PATH=/opt/intel/oneapi
         source $ONEAPI_TOOLCHAIN_PATH/compiler/latest/env/vars.sh
+
+        # Windows:
+        > set ONEAPI_TOOLCHAIN_PATH=C:\Users\Intel\oneapi
 
    To setup the complete oneApi environment, use::
 
@@ -106,7 +113,7 @@ DesignWare ARC MetaWare Development Toolkit (MWDT)
       $ echo $ARCMWDT_TOOLCHAIN_PATH
       /home/you/ARC/MWDT_2019.12/
 
-      # Windows
+      # Windows:
       > echo %ZEPHYR_TOOLCHAIN_VARIANT%
       arcmwdt
       > echo %ARCMWDT_TOOLCHAIN_PATH%


### PR DESCRIPTION
Using 3rd Party Toolchains page find out that warning message
can be moved to the top of the page.
Add Windows example in OneAPI.
Style fixing.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>