### PR TITLE
drivers: can: Kconfig.rcar: Make options depend on its driver

### DIFF
--- a/drivers/can/Kconfig.rcar
+++ b/drivers/can/Kconfig.rcar
@@ -11,6 +11,7 @@ config CAN_RCAR
 
 config CAN_RCAR_MAX_FILTER
 	int "Maximum number of concurrent active filters"
+	depends on CAN_RCAR
 	default 5
 	range 1 32
 	help


### PR DESCRIPTION
Need this so that the option won't pop out without R-Car selected.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>