### PR TITLE
arm: aarch64: xenvm: fix typo in Xen VM doc

### DIFF
--- a/boards/arm64/xenvm/doc/index.rst
+++ b/boards/arm64/xenvm/doc/index.rst
@@ -144,7 +144,7 @@ You will see Zephyr output:
    thread_b: Hello World from cpu 0 on xenvm!
    thread_a: Hello World from cpu 0 on xenvm!
 
-Exit xen virtual console by pressing :kbd:`CTRL+[`
+Exit xen virtual console by pressing :kbd:`CTRL+]`
 
 Updating configuration
 **********************


### PR DESCRIPTION
This commit fixes hotkey for exiting Xen virtual console with correct
combination.

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>