### PR TITLE
lora: several fixes

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -85,13 +85,16 @@ int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 
 	ret = k_sem_take(&dev_data.data_sem, timeout);
 	if (ret < 0) {
-		LOG_ERR("Receive timeout!");
+		LOG_INF("Receive timeout");
+		/* Manually transition to sleep mode on timeout */
+		Radio.Sleep();
 		return ret;
 	}
 
 	/* Only copy the bytes that can fit the buffer, drop the rest */
-	if (dev_data.rx_len > size)
+	if (dev_data.rx_len > size) {
 		dev_data.rx_len = size;
+	}
 
 	/*
 	 * FIXME: We are copying the global buffer here, so it might get


### PR DESCRIPTION
Fixes the LoRa modem not being put back to sleep on RX timeout, and enables calling `lora_recv` immediately after `lora_send` by blocking `lora_send` until the transmission actually completes.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>