### PR TITLE
lora: asynchronous packet reception

### DIFF
--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -472,6 +472,7 @@ static const struct lora_driver_api sx126x_lora_api = {
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,
+	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
 };
 

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -660,6 +660,7 @@ static const struct lora_driver_api sx127x_lora_api = {
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,
+	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
 };
 

--- a/drivers/lora/sx12xx_common.h
+++ b/drivers/lora/sx12xx_common.h
@@ -34,6 +34,8 @@ int sx12xx_lora_send_async(const struct device *dev, uint8_t *data,
 int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 		     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
+int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb);
+
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config);
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -20,6 +20,24 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
 #include <logging/log.h>
 LOG_MODULE_REGISTER(lora_receive);
 
+void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
+		     int16_t rssi, int8_t snr)
+{
+	static int cnt;
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(size);
+
+	LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
+		log_strdup(data), rssi, snr);
+
+	/* Stop receiving after 10 packets */
+	if (++cnt == 10) {
+		LOG_INF("Stopping packet receptions");
+		lora_recv_async(dev, NULL);
+	}
+}
+
 void main(void)
 {
 	const struct device *lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
@@ -48,7 +66,9 @@ void main(void)
 		return;
 	}
 
-	while (1) {
+	/* Receive 4 packets synchronously */
+	LOG_INF("Synchronous reception");
+	for (int i = 0; i < 4; i++) {
 		/* Block until data arrives */
 		len = lora_recv(lora_dev, data, MAX_DATA_LEN, K_FOREVER,
 				&rssi, &snr);
@@ -60,4 +80,9 @@ void main(void)
 		LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
 			log_strdup(data), rssi, snr);
 	}
+
+	/* Enable asynchronous reception */
+	LOG_INF("Asynchronous reception");
+	lora_recv_async(lora_dev, lora_receive_cb);
+	k_sleep(K_FOREVER);
 }


### PR DESCRIPTION
Extends the LoRa API to enable asynchronous packet reception.

In many situations applications aren't waiting for a packet in particular, but just want to handle any packet that comes in.
Using the asynchronous API allows us to avoid the creation of a dedicated thread to continuously block on `lora_recv`.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>