### PR TITLE
subsys/mgmt/mcumgr: Add SMP Zephyr specific storage erase command

### DIFF
--- a/include/mgmt/mcumgr/zephyr_groups.h
+++ b/include/mgmt/mcumgr/zephyr_groups.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_H_
+#define ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_H_
+
+#include <kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The file contains definitions of Zephyr specific mgmt commands */
+
+#define ZEPHYR_MGMT_GRP_BASE		MGMT_GROUP_ID_PERUSER
+
+/* Basic group */
+#define ZEPHYR_MGMT_GRP_BASIC		ZEPHYR_MGMT_GRP_BASE
+#define ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE	0	/* Command to erase storage partition */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_H_ */

--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_BT smp_bt.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_SHELL smp_shell.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UART smp_uart.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UDP smp_udp.c)
+add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_ZEPHYR_BASIC zephyr_grp)
 zephyr_library_link_libraries(MCUMGR)
 
 if (CONFIG_MCUMGR_SMP_SHELL OR CONFIG_MCUMGR_SMP_UART)

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -222,6 +222,25 @@ config STAT_MGMT_MAX_NAME_LEN
 	  stat read commands.  If a stat group's name exceeds this limit, it will
 	  be impossible to retrieve its values with a stat show command.
 
+
+menuconfig MCUMGR_GRP_ZEPHYR_BASIC
+	bool "Enable Zephyr specific basic group of commands"
+	help
+	  Enables mcumgr to processing of Zephyr specific groups.
+
+if MCUMGR_GRP_ZEPHYR_BASIC
+config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
+	bool "Enables storage erase command"
+	help
+	  Enables command that allows to erase storage partition.
+
+module=MGMT_SETTINGS
+module-dep=LOG
+module-str=SETTINGS
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif
+
 endmenu
 
 config MCUMGR_SMP_BT

--- a/subsys/mgmt/mcumgr/zephyr_grp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/zephyr_grp/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE basic_mgmt.c)
+zephyr_library_link_libraries(MCUMGR)

--- a/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <logging/log.h>
+#include <init.h>
+#include <mgmt/mgmt.h>
+#include <mgmt/mcumgr/zephyr_groups.h>
+#include <storage/flash_map.h>
+
+LOG_MODULE_REGISTER(mgmt_zephyr_basic, CONFIG_MGMT_SETTINGS_LOG_LEVEL);
+
+#define STORAGE_MGMT_ID_ERASE 6
+
+int storage_erase(void)
+{
+	const struct flash_area *fa;
+	int rc = flash_area_open(FLASH_AREA_ID(storage), &fa);
+
+	if (rc < 0) {
+		LOG_ERR("failed to open flash area");
+	} else {
+		rc = flash_area_erase(fa, 0, FLASH_AREA_SIZE(storage));
+		if (rc < 0) {
+			LOG_ERR("failed to erase flash area");
+		}
+		flash_area_close(fa);
+	}
+
+	return rc;
+}
+
+static int storage_erase_handler(struct mgmt_ctxt *ctxt)
+{
+	CborError cbor_err = 0;
+	int rc = storage_erase();
+
+	cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
+	cbor_err |= cbor_encode_int(&ctxt->encoder, rc);
+	if (cbor_err != 0) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return MGMT_ERR_EOK;
+}
+
+static const struct mgmt_handler zephyr_mgmt_basic_handlers[] = {
+	[ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE] = {
+		.mh_read  = NULL,
+		.mh_write = storage_erase_handler,
+	},
+};
+
+static struct mgmt_group zephyr_basic_mgmt_group = {
+	.mg_handlers = (struct mgmt_handler *)zephyr_mgmt_basic_handlers,
+	.mg_handlers_count = ARRAY_SIZE(zephyr_mgmt_basic_handlers),
+	.mg_group_id = (ZEPHYR_MGMT_GRP_BASIC),
+};
+
+static int zephyr_basic_mgmt_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	LOG_INF("Registering Zephyr basic mgmt group");
+	mgmt_register_group(&zephyr_basic_mgmt_group);
+	return 0;
+}
+
+SYS_INIT(zephyr_basic_mgmt_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Added a subsys which allows the user to send a command to erase the
storage partition. So that if the user loads a new application
the storage is already populated or contains invalid data.

Authored-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>