### PR TITLE
net: mqtt: Add custom transport type

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -374,6 +374,10 @@ enum mqtt_transport_type {
 	MQTT_TRANSPORT_SECURE_WEBSOCKET,
 #endif
 #endif /* CONFIG_MQTT_LIB_WEBSOCKET */
+#if defined(CONFIG_MQTT_LIB_CUSTOM_TRANSPORT)
+	/** Use custom transport for MQTT connection. */
+	MQTT_TRANSPORT_CUSTOM,
+#endif /* CONFIG_MQTT_LIB_CUSTOM_TRANSPORT */
 
 	/** Shall not be used as a transport type.
 	 *  Indicator of maximum transport types possible.
@@ -423,6 +427,11 @@ struct mqtt_transport {
 		int32_t timeout;
 	} websocket;
 #endif
+
+#if defined(CONFIG_MQTT_LIB_CUSTOM_TRANSPORT)
+	/** User defined data for custom transport for MQTT. */
+	void *custom_transport_data;
+#endif /* CONFIG_MQTT_LIB_CUSTOM_TRANSPORT */
 
 #if defined(CONFIG_SOCKS)
 	struct {

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -34,6 +34,12 @@ config MQTT_LIB_WEBSOCKET
 	help
 	  Enable Websocket support for socket MQTT Library.
 
+config MQTT_LIB_CUSTOM_TRANSPORT
+	bool "Custom transport support for socket MQTT Library"
+	help
+	  Enable custom transport support for socket MQTT Library.
+	  User must provide implementation for transport procedure.
+
 config MQTT_CLEAN_SESSION
 	bool "MQTT Clean Session Flag."
 	help

--- a/subsys/net/lib/mqtt/mqtt_transport.c
+++ b/subsys/net/lib/mqtt/mqtt_transport.c
@@ -47,6 +47,15 @@ const struct transport_procedure transport_fn[MQTT_TRANSPORT_NUM] = {
 	},
 #endif /* CONFIG_MQTT_LIB_TLS */
 #endif /* CONFIG_MQTT_LIB_WEBSOCKET */
+#if defined(CONFIG_MQTT_LIB_CUSTOM_TRANSPORT)
+	{
+		mqtt_client_custom_transport_connect,
+		mqtt_client_custom_transport_write,
+		mqtt_client_custom_transport_write_msg,
+		mqtt_client_custom_transport_read,
+		mqtt_client_custom_transport_disconnect,
+	},
+#endif /* CONFIG_MQTT_LIB_CUSTOM_TRANSPORT */
 };
 
 int mqtt_transport_connect(struct mqtt_client *client)

--- a/subsys/net/lib/mqtt/mqtt_transport.h
+++ b/subsys/net/lib/mqtt/mqtt_transport.h
@@ -148,6 +148,17 @@ int mqtt_client_websocket_read(struct mqtt_client *client, uint8_t *data,
 int mqtt_client_websocket_disconnect(struct mqtt_client *client);
 #endif
 
+#if defined(CONFIG_MQTT_LIB_CUSTOM_TRANSPORT)
+int mqtt_client_custom_transport_connect(struct mqtt_client *client);
+int mqtt_client_custom_transport_write(struct mqtt_client *client, const uint8_t *data,
+				uint32_t datalen);
+int mqtt_client_custom_transport_write_msg(struct mqtt_client *client,
+				    const struct msghdr *message);
+int mqtt_client_custom_transport_read(struct mqtt_client *client, uint8_t *data,
+			       uint32_t buflen, bool shall_block);
+int mqtt_client_custom_transport_disconnect(struct mqtt_client *client);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add new custom transport type.
This allows user defined transport for MQTT communication.
The user must implement the transport procedure.

Fixes **#27015**

Signed-off-by: Vlad Tuhut <vlad.tuhut@raptor-technologies.ro>