### PR TITLE
lorawan: Fix setting APP_KEY using MacMibSetRequest

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -225,7 +225,7 @@ static LoRaMacStatus_t lorawan_join_otaa(
 	LoRaMacMibSetRequestConfirm(&mib_req);
 
 	mib_req.Type = MIB_APP_KEY;
-	mib_req.Param.JoinEui = join_cfg->otaa.app_key;
+	mib_req.Param.AppKey = join_cfg->otaa.app_key;
 	LoRaMacMibSetRequestConfirm(&mib_req);
 
 	return LoRaMacMlmeRequest(&mlme_req);


### PR DESCRIPTION
For setting the APP_KEY, "mib_req.Param.AppKey" field should be used.
Fix it!

Fixes: #36540

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>