### PR TITLE
npcx: convert few device_get_binding to DEVICE_DT_GET

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -333,8 +333,7 @@ static int adc_npcx_init(const struct device *dev)
 	const struct adc_npcx_config *const config = DRV_CONFIG(dev);
 	struct adc_npcx_data *const data = DRV_DATA(dev);
 	struct adc_reg *const inst = HAL_INSTANCE(dev);
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int prescaler = 0, ret;
 
 	/* Save ADC device in data */

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -109,8 +109,7 @@ static int npcx_clock_control_get_subsys_rate(const struct device *dev,
 #if defined(CONFIG_PM)
 void npcx_clock_control_turn_on_system_sleep(bool is_deep, bool is_instant)
 {
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	struct pmc_reg *const inst_pmc = HAL_PMC_INST(clk_dev);
 	/* Configure that ec enters system sleep mode if receiving 'wfi' */
 	uint8_t pm_flags = BIT(NPCX_PMCSR_IDLE);
@@ -128,8 +127,7 @@ void npcx_clock_control_turn_on_system_sleep(bool is_deep, bool is_instant)
 
 void npcx_clock_control_turn_off_system_sleep(void)
 {
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	struct pmc_reg *const inst_pmc = HAL_PMC_INST(clk_dev);
 
 	inst_pmc->PMCSR = 0;

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -853,7 +853,7 @@ static int espi_npcx_init(const struct device *dev)
 	const struct espi_npcx_config *const config = DRV_CONFIG(dev);
 	struct espi_npcx_data *const data = DRV_DATA(dev);
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	const struct device *clk_dev = device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int i, ret;
 
 	/* Turn on eSPI device clock first */

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -979,8 +979,7 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 {
 	struct mswc_reg *const inst_mswc = host_sub_cfg.inst_mswc;
 	struct shm_reg *const inst_shm = host_sub_cfg.inst_shm;
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int i;
 	uint8_t shm_sts;
 

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -859,8 +859,7 @@ static int i2c_ctrl_init(const struct device *dev)
 {
 	const struct i2c_ctrl_config *const config = DRV_CONFIG(dev);
 	struct i2c_ctrl_data *const data = DRV_DATA(dev);
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	uint32_t i2c_rate;
 
 	/* Turn on device clock first and get source clock freq. */

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -168,8 +168,7 @@ static int pwm_npcx_init(const struct device *dev)
 	const struct pwm_npcx_config *const config = DRV_CONFIG(dev);
 	struct pwm_npcx_data *const data = DRV_DATA(dev);
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
 	/*

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -316,8 +316,7 @@ static int tach_npcx_init(const struct device *dev)
 {
 	const struct tach_npcx_config *const config = DRV_CONFIG(dev);
 	struct tach_npcx_data *const data = DRV_DATA(dev);
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
 	/* Turn on device clock first and get source clock freq. */

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -357,8 +357,7 @@ static int uart_npcx_init(const struct device *dev)
 	const struct uart_npcx_config *const config = DRV_CONFIG(dev);
 	struct uart_npcx_data *const data = DRV_DATA(dev);
 	struct uart_reg *const inst = HAL_INSTANCE(dev);
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	uint32_t uart_rate;
 	int ret;
 

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -272,8 +272,7 @@ int sys_clock_driver_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	int ret;
 	uint32_t sys_tmr_rate;
-	const struct device *const clk_dev =
-					device_get_binding(NPCX_CLK_CTRL_NAME);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 
 	/* Turn on all itim module clocks used for counting */
 	for (int i = 0; i < ARRAY_SIZE(itim_clk_cfg); i++) {

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-/* Common clock control device name for all NPCX series */
-#define NPCX_CLK_CTRL_NAME DT_LABEL(DT_NODELABEL(pcc))
+/* Common clock control device node for all NPCX series */
+#define NPCX_CLK_CTRL_NODE DT_NODELABEL(pcc)
 
 /**
  * @brief NPCX clock configuration structure


### PR DESCRIPTION
Hi, this converts the device_get_binding I've found in npcx drivers to DEVICE_DT_GET. It should be slightly more efficient, and for the i2c driver it also simplifies the instance code and init a fair bit.