### PR TITLE
drivers/flash: sam0: only use a semaphore if multitasking is enabled

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -51,7 +51,9 @@ struct flash_sam0_data {
 	off_t offset;
 #endif
 
+#if defined(CONFIG_MULTITHREADING)
 	struct k_sem sem;
+#endif
 };
 
 #if CONFIG_FLASH_PAGE_LAYOUT
@@ -74,16 +76,20 @@ static int flash_sam0_write_protection(const struct device *dev, bool enable);
 
 static inline void flash_sam0_sem_take(const struct device *dev)
 {
+#if defined(CONFIG_MULTITHREADING)
 	struct flash_sam0_data *ctx = dev->data;
 
 	k_sem_take(&ctx->sem, K_FOREVER);
+#endif
 }
 
 static inline void flash_sam0_sem_give(const struct device *dev)
 {
+#if defined(CONFIG_MULTITHREADING)
 	struct flash_sam0_data *ctx = dev->data;
 
 	k_sem_give(&ctx->sem);
+#endif
 }
 
 static int flash_sam0_valid_range(off_t offset, size_t len)
@@ -435,9 +441,11 @@ flash_sam0_get_parameters(const struct device *dev)
 
 static int flash_sam0_init(const struct device *dev)
 {
+#if defined(CONFIG_MULTITHREADING)
 	struct flash_sam0_data *ctx = dev->data;
 
 	k_sem_init(&ctx->sem, 1, 1);
+#endif
 
 #ifdef PM_APBBMASK_NVMCTRL
 	/* Ensure the clock is on. */


### PR DESCRIPTION
This lets the driver be used in single threaded applications such as a
bootloader.

Signed-off-by: Michael Hope <mlhx@google.com>