### PR TITLE
Correct "Heart Rate" comment

### DIFF
--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -53,7 +53,7 @@ static void indicate_destroy(struct bt_gatt_indicate_params *params)
 	indicating = 0U;
 }
 
-/* Heart Rate Service Declaration */
+/* Health Thermometer Service Declaration */
 BT_GATT_SERVICE_DEFINE(hts_svc,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_HTS),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HTS_MEASUREMENT, BT_GATT_CHRC_INDICATE,


### PR DESCRIPTION
This is a simple comments fix. This sample code is for the "Health Thermometer Service", but at one location the comments read "Heart Rate Service".

This change replaces "Heart Rate" with "Health Thermometer".
