### PR TITLE
Add low power support for STM32WL family

### DIFF
--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -59,6 +59,35 @@
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
 	};
+
+	power-states {
+		stop0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <1>;
+			min-residency-us = <100>;
+		};
+		stop1: state1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <2>;
+			min-residency-us = <500>;
+		};
+		stop2: state2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <3>;
+			min-residency-us = <900>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&stop0 &stop1 &stop2>;
+};
+
+&lptim1 {
+	status = "okay";
 };
 
 &clk_hsi {

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -128,6 +128,11 @@ int sys_clock_driver_init(const struct device *dev)
 		    lptim_irq_handler, 0, 0);
 	irq_enable(DT_IRQN(DT_NODELABEL(lptim1)));
 
+#ifdef CONFIG_SOC_SERIES_STM32WLX
+	/* Enable the LPTIM1 wakeup EXTI line */
+	LL_EXTI_EnableIT_0_31(LL_EXTI_LINE_29);
+#endif
+
 	/* configure the LPTIM1 counter */
 	LL_LPTIM_SetClockSource(LPTIM1, LL_LPTIM_CLK_SOURCE_INTERNAL);
 	/* configure the LPTIM1 prescaler with 1 */

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -151,6 +151,18 @@
 			};
 		};
 
+		lptim1: timers@40007c00 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40007c00 0x400>;
+			interrupts = <39 0>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+			label = "LPTIM_1";
+		};
+
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -20,7 +20,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;

--- a/soc/arm/st_stm32/stm32wl/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32wl/CMakeLists.txt
@@ -2,3 +2,7 @@
 
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(soc.c)
+
+zephyr_sources_ifdef(CONFIG_PM
+  power.c
+  )

--- a/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
@@ -10,4 +10,12 @@ source "soc/arm/st_stm32/stm32wl/Kconfig.defconfig.stm32wl*"
 config SOC_SERIES
 	default "stm32wl"
 
+if PM
+config PM_DEVICE
+	default y
+
+config STM32_LPTIM_TIMER
+	default y
+endif # PM
+
 endif # SOC_SERIES_STM32WLX

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Fabio Baltieri
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <pm/pm.h>
+#include <soc.h>
+#include <init.h>
+
+#include <stm32wlxx_ll_utils.h>
+#include <stm32wlxx_ll_bus.h>
+#include <stm32wlxx_ll_cortex.h>
+#include <stm32wlxx_ll_pwr.h>
+#include <stm32wlxx_ll_rcc.h>
+#include <stm32wlxx_ll_system.h>
+#include <clock_control/clock_stm32_ll_common.h>
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Invoke Low Power/System Off specific Tasks */
+void pm_power_state_set(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		LL_PWR_ClearFlag_WU();
+		switch (info.substate_id) {
+		case 1:
+			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
+			break;
+		case 2:
+			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
+			break;
+		case 3:
+			LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
+			break;
+		default:
+			LOG_DBG("Unsupported power substate-id %u", info.substate_id);
+			return;
+		}
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+	case PM_STATE_SOFT_OFF:
+		LL_PWR_ClearFlag_WU();
+		switch (info.substate_id) {
+		case 0:
+			LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+			break;
+		case 1:
+			LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
+			break;
+		default:
+			LOG_DBG("Unsupported power substate-id %u", info.substate_id);
+			return;
+		}
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+	default:
+		LOG_DBG("Unsupported power state %u", info.state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void pm_power_state_exit_post_ops(struct pm_state_info info)
+{
+	switch (info.state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		LL_LPM_DisableSleepOnExit();
+		LL_LPM_EnableSleep();
+		/* need to restore the clock */
+		stm32_clock_control_init(NULL);
+		break;
+	case PM_STATE_SOFT_OFF:
+		/* Nothing to do. */
+		break;
+	default:
+		LOG_DBG("Unsupported power substate-id %u", info.state);
+		break;
+	}
+
+	/*
+	 * System is now in active mode.
+	 * Reenable interrupts which were disabled
+	 * when OS started idling code.
+	 */
+	irq_unlock(0);
+}
+
+/* Initialize STM32 Power */
+static int stm32_power_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#ifdef CONFIG_DEBUG
+	/* Enable the Debug Module during STOP mode */
+	LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Hi, this is for low power support on STM32WL family.

Based this on https://github.com/zephyrproject-rtos/zephyr/pull/35987, adding the extra switches for extra suspend-to-idle and soft-off and matching the WB/L4/L5 setup.

For stop modes I kept the mapping of the other STM32 devices (substate 1, 2, 3), for soft-off I've kept substate 0 a valid so `{PM_STATE_SOFT_OFF, 0, 0}` works.

Tested on a Seeed LoRa-E5 with the blinky sample, getting a nice 50uA quiescent current so I think it's working alright (there's an LDO with a ~50uA quiescent current on my board).

![ppk-20210626T171915](https://user-images.githubusercontent.com/891546/123520925-4dec1000-d6ab-11eb-95a5-d5f7357fd956.png)