### PR TITLE
lora: sync and async transmission

### DIFF
--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -207,6 +207,8 @@ Drivers and Sensors
 
 * LoRa
 
+  * lora_send now blocks until the transmission is complete. lora_send_async
+    can be used for the previous, non-blocking behaviour.
 
 * Modem
 

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -470,6 +470,7 @@ static int sx126x_lora_init(const struct device *dev)
 static const struct lora_driver_api sx126x_lora_api = {
 	.config = sx12xx_lora_config,
 	.send = sx12xx_lora_send,
+	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,
 	.test_cw = sx12xx_lora_test_cw,
 };

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -658,6 +658,7 @@ static int sx127x_lora_init(const struct device *dev)
 static const struct lora_driver_api sx127x_lora_api = {
 	.config = sx12xx_lora_config,
 	.send = sx12xx_lora_send,
+	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,
 	.test_cw = sx12xx_lora_test_cw,
 };

--- a/drivers/lora/sx12xx_common.h
+++ b/drivers/lora/sx12xx_common.h
@@ -28,6 +28,9 @@ int __sx12xx_configure_pin(const struct device * *dev, const char *controller,
 int sx12xx_lora_send(const struct device *dev, uint8_t *data,
 		     uint32_t data_len);
 
+int sx12xx_lora_send_async(const struct device *dev, uint8_t *data,
+			   uint32_t data_len, struct k_poll_signal *async);
+
 int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 		     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 

--- a/include/drivers/lora.h
+++ b/include/drivers/lora.h
@@ -71,6 +71,16 @@ typedef int (*lora_api_send)(const struct device *dev,
 			     uint8_t *data, uint32_t data_len);
 
 /**
+ * @typedef lora_api_send_async()
+ * @brief Callback API for sending data asynchronously over LoRa
+ *
+ * @see lora_send_async() for argument descriptions.
+ */
+typedef int (*lora_api_send_async)(const struct device *dev,
+				   uint8_t *data, uint32_t data_len,
+				   struct k_poll_signal *async);
+
+/**
  * @typedef lora_api_recv()
  * @brief Callback API for receiving data over LoRa
  *
@@ -91,8 +101,9 @@ typedef int (*lora_api_test_cw)(const struct device *dev, uint32_t frequency,
 
 struct lora_driver_api {
 	lora_api_config config;
-	lora_api_send	send;
-	lora_api_recv	recv;
+	lora_api_send send;
+	lora_api_send_async send_async;
+	lora_api_recv recv;
 	lora_api_test_cw test_cw;
 };
 
@@ -116,7 +127,7 @@ static inline int lora_config(const struct device *dev,
 /**
  * @brief Send data over LoRa
  *
- * @note This is a non-blocking call.
+ * @note This blocks until transmission is complete.
  *
  * @param dev       LoRa device
  * @param data      Data to be sent
@@ -130,6 +141,30 @@ static inline int lora_send(const struct device *dev,
 		(const struct lora_driver_api *)dev->api;
 
 	return api->send(dev, data, data_len);
+}
+
+/**
+ * @brief Asynchronously send data over LoRa
+ *
+ * @note This returns immediately after starting transmission, and locks
+ *       the LoRa modem until the transmission completes.
+ *
+ * @param dev       LoRa device
+ * @param data      Data to be sent
+ * @param data_len  Length of the data to be sent
+ * @param async A pointer to a valid and ready to be signaled
+ *        struct k_poll_signal. (Note: if NULL this function will not
+ *        notify the end of the transmission).
+ * @return 0 on success, negative on error
+ */
+static inline int lora_send_async(const struct device *dev,
+				  uint8_t *data, uint32_t data_len,
+				  struct k_poll_signal *async)
+{
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
+
+	return api->send_async(dev, data, data_len, async);
 }
 
 /**


### PR DESCRIPTION
Change the behavior of `lora_send` to block until transmission has completed.
Add a new function, `lora_send_async` that has the old, non-blocking behavior.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>