### PR TITLE
net: refactor tftp library

### DIFF
--- a/include/net/tftp.h
+++ b/include/net/tftp.h
@@ -34,6 +34,9 @@ struct tftpc {
 
 /* @brief This function gets "file" from the remote server.
  *
+ * If the file is successfully received its size will be returned in
+ * `client->user_buf_size` parameter.
+ *
  * @param server      Control Block that represents the remote server.
  * @param client      Client Buffer Information.
  * @param remote_file Name of the remote file to get.

--- a/subsys/net/lib/tftp/tftp_client.h
+++ b/subsys/net/lib/tftp/tftp_client.h
@@ -35,25 +35,26 @@
 #define ACK_OPCODE               0x4
 #define ERROR_OPCODE             0x5
 
-#define RECV_DATA_SIZE()         (tftpc_buffer_size - TFTP_HEADER_SIZE)
+/* Error Codes */
 
-/* Name: send_ack
- * Description: This function sends an Ack to the TFTP
- * Server (in response to the data sent by the
- * Server).
- */
-static inline int send_ack(int sock, int block)
-{
-	uint8_t tmp[4];
+/** Not defined, see error message (if any). */
+#define TFTP_ERROR_UNDEF               0
+/** File not found. */
+#define TFTP_ERROR_NO_FILE             1
+/** Access violation. */
+#define TFTP_ERROR_ACCESS              2
+/** Disk full or allocation exceeded. */
+#define TFTP_ERROR_DISK_FULL           3
+/** Illegal TFTP operation. */
+#define TFTP_ERROR_ILLEGAL_OP          4
+/** Unknown transfer ID. */
+#define TFTP_ERROR_UNKNOWN_TRANSFER_ID 5
+/** File already exists. */
+#define TFTP_ERROR_FILE_EXISTS         6
+/** No such user. */
+#define TFTP_ERROR_NO_USER             7
 
-	LOG_INF("Client acking Block Number: %d", block);
-
-	/* Fill in the "Ack" Opcode and the block no. */
-	sys_put_be16(ACK_OPCODE, tmp);
-	sys_put_be16(block, tmp + 2);
-
-	/* Lets send this request buffer out. Size of request
-	 * buffer is 4 bytes.
-	 */
-	return send(sock, tmp, 4, 0);
-}
+struct tftphdr_ack {
+	uint16_t opcode;
+	uint16_t block;
+};


### PR DESCRIPTION
- bugfix: Accept initial TFTP server reply from a port different than
  the one used to establish the connection (typically 69) as mandated
  by RFC 1350. Previous implementation was not standard compliant.
- bugfix: close socket in case of error or timeout.
- bugfix: Reset retransmit counter after receipt of a good packet.
- bugfix: Use CONFIG_TFTP_LOG_LEVEL to set log level.
- api: upon successful receipt of the file set `client.user_buf_size`
  to the size of the file received.
- Restructure the code, comments.
- Limit usage of global variables.
- Limit usage of `goto`.

This PR, apart from one necessary exception, does not attempt to modify TFTP API. Consequently not all issues are fixed:
- usage of a large, private static buffer was not removed
- buffer passed as a parameter to `tftp_get` function call has to be large enough to fit the full file, i.e. to receive a file of size up to 64 kB user is forced to reserve 64 kB of RAM.

Fixes #34131