### PR TITLE
dts: designware-gpio: remove reduplicative property bits

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -221,7 +221,7 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 	uint32_t dir_reg;
 
 	/* Check for invalid pin number */
-	if (pin >= config->bits) {
+	if (pin >= config->ngpios) {
 		return -EINVAL;
 	}
 
@@ -313,7 +313,7 @@ static inline int gpio_dw_config(const struct device *port,
 	uint32_t io_flags;
 
 	/* Check for invalid pin number */
-	if (pin >= config->bits) {
+	if (pin >= config->ngpios) {
 		return -EINVAL;
 	}
 
@@ -560,7 +560,7 @@ static const struct gpio_dw_config gpio_config_0 = {
 #ifdef CONFIG_GPIO_DW_0_IRQ_DIRECT
 	.irq_num = DT_INST_IRQN(0),
 #endif
-	.bits = DT_INST_PROP(0, bits),
+	.ngpios = DT_INST_PROP(0, ngpios),
 	.config_func = gpio_config_0_irq,
 #ifdef CONFIG_GPIO_DW_0_IRQ_SHARED
 	.shared_irq_dev_name = DT_INST_IRQ_BY_NAME(0, shared_name, irq),
@@ -621,7 +621,7 @@ static const struct gpio_dw_config gpio_dw_config_1 = {
 #ifdef CONFIG_GPIO_DW_1_IRQ_DIRECT
 	.irq_num = DT_INST_IRQN(1),
 #endif
-	.bits = DT_INST_PROP(1, bits),
+	.ngpios = DT_INST_PROP(1, ngpios),
 	.config_func = gpio_config_1_irq,
 
 #ifdef CONFIG_GPIO_DW_1_IRQ_SHARED
@@ -682,7 +682,7 @@ static const struct gpio_dw_config gpio_dw_config_2 = {
 #ifdef CONFIG_GPIO_DW_2_IRQ_DIRECT
 	.irq_num = DT_INST_IRQN(2),
 #endif
-	.bits = DT_INST_PROP(2, bits),
+	.ngpios = DT_INST_PROP(2, ngpios),
 	.config_func = gpio_config_2_irq,
 
 #ifdef CONFIG_GPIO_DW_2_IRQ_SHARED
@@ -743,7 +743,7 @@ static const struct gpio_dw_config gpio_dw_config_3 = {
 #ifdef CONFIG_GPIO_DW_3_IRQ_DIRECT
 	.irq_num = DT_INST_IRQN(3),
 #endif
-	.bits = DT_INST_PROP(3, bits),
+	.ngpios = DT_INST_PROP(3, ngpios),
 	.config_func = gpio_config_3_irq,
 
 #ifdef CONFIG_GPIO_DW_3_IRQ_SHARED

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -20,7 +20,7 @@ typedef void (*gpio_config_irq_t)(const struct device *port);
 struct gpio_dw_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
-	uint32_t bits;
+	uint32_t ngpios;
 	uint32_t irq_num; /* set to 0 if GPIO port cannot interrupt */
 	gpio_config_irq_t config_func;
 

--- a/dts/arc/arc_hsdk.dtsi
+++ b/dts/arc/arc_hsdk.dtsi
@@ -112,7 +112,7 @@
 		gpio0: gpio@f0003000 {
 			compatible = "snps,designware-gpio";
 			reg = <0xf0003000 0x1000>;
-			bits = <24>;
+			ngpios = <24>;
 			label = "GPIO_0";
 			interrupt-parent = <&idu_intc>;
 

--- a/dts/arc/emsdp.dtsi
+++ b/dts/arc/emsdp.dtsi
@@ -64,7 +64,7 @@
 		gpio0: gpio@f0002000 {
 			compatible = "snps,designware-gpio";
 			reg = <0xf0002000 0xc>;
-			bits = <4>;
+			ngpios = <4>;
 			label = "GPIO_0";
 			interrupt-parent = <&intc>;
 			gpio-controller;
@@ -74,7 +74,7 @@
 		gpio1: gpio@f000200c {
 			compatible = "snps,designware-gpio";
 			reg = <0xf000200c 0xc>;
-			bits = <8>;
+			ngpios = <8>;
 			label = "GPIO_1";
 			interrupt-parent = <&intc>;
 			interrupts = <0 1>;

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -95,7 +95,7 @@
 		gpio0: gpio@f0002000 {
 			compatible = "snps,designware-gpio";
 			reg = <0xf0002000 0xc>;
-			bits = <32>;
+			ngpios = <32>;
 			label = "GPIO_0";
 			interrupt-parent = <&intc>;
 
@@ -106,7 +106,7 @@
 		gpio1: gpio@f000200c {
 			compatible = "snps,designware-gpio";
 			reg = <0xf000200c 0xc>;
-			bits = <9>;
+			ngpios = <9>;
 			label = "GPIO_1";
 			interrupt-parent = <&intc>;
 
@@ -117,7 +117,7 @@
 		gpio2: gpio@f0002018 {
 			compatible = "snps,designware-gpio";
 			reg = <0xF0002018 0xc>;
-			bits = <32>;
+			ngpios = <32>;
 			label = "GPIO_2";
 
 			interrupt-parent = <&intc>;
@@ -129,7 +129,7 @@
 		gpio3: gpio@f0002024 {
 			compatible = "snps,designware-gpio";
 			reg = <0xF0002024 0xc>;
-			bits = <12>;
+			ngpios = <12>;
 			label = "GPIO_3";
 
 			interrupt-parent = <&intc>;

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -11,11 +11,6 @@ properties:
     reg:
       required: true
 
-    bits:
-      type: int
-      description: gpio bits
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -111,7 +111,7 @@
 		gpio0: gpio@80c00 {
 			compatible = "snps,designware-gpio";
 			reg = <0x00080c00 0x400>;
-			bits = <32>;
+			ngpios = <32>;
 			label = "GPIO";
 			interrupts = <3 1 0>;
 			interrupt-parent = <&dw_intc>;


### PR DESCRIPTION
bits property indicates the number of in-use slots of available slots
for GPIOS. We have a similar property ngpios in gpio-controller.yaml,
we will use ngpios to calculate port_pin_mask. Let's remove bits and
only use ngpios.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>