### PR TITLE
ITE: drivers/i2c: it8xxx2: no need to reset bus if NACK

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -774,6 +774,13 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		/* Wait for the transfer to complete */
 		/* TODO: the timeout should be adjustable */
 		res = k_sem_take(&data->device_sync_sem, K_MSEC(100));
+		/*
+		 * The transaction is dropped on any error(timeout, NACK, fail,
+		 * bus error, device error).
+		 */
+		if (data->err)
+			break;
+
 		if (res != 0) {
 			data->err = ETIMEDOUT;
 			/* reset i2c port */


### PR DESCRIPTION
If the message responds with NACK, drop the transaction.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>