### PR TITLE
Bluetooth: controller: Extended scanning with LLL scheduling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -261,7 +261,12 @@ struct node_rx_ftr {
 			uint16_t conn_handle;
 		} param_adv_term;
 	};
-	void     *extra;
+	union {
+		void *extra;
+		void *aux_ptr;
+		uint8_t aux_phy;
+		uint8_t aux_sched;
+	};
 	uint32_t ticks_anchor;
 	uint32_t radio_end_us;
 	uint8_t  rssi;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -31,6 +31,7 @@ struct lll_scan {
 	uint16_t duration_expire;
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
+	uint8_t  is_aux_sched:1;
 
 	/* temporary storage when aux scan was scheduled from LLL */
 	struct lll_scan_aux *lll_aux;

--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -31,6 +31,9 @@ struct lll_scan {
 	uint16_t duration_expire;
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
+
+	/* temporary storage when aux scan was scheduled from LLL */
+	struct lll_scan_aux *lll_aux;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1459,13 +1459,23 @@ void radio_ar_resolve(uint8_t *addr)
 	NRF_AAR->EVENTS_RESOLVED = 0;
 	NRF_AAR->EVENTS_NOTRESOLVED = 0;
 
-	nrf_aar_task_trigger(NRF_AAR, NRF_AAR_TASK_START);
+	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
 
 	nrf_aar_int_enable(NRF_AAR, AAR_INTENSET_END_Msk);
+
+	nrf_aar_task_trigger(NRF_AAR, NRF_AAR_TASK_START);
+
 	while (NRF_AAR->EVENTS_END == 0) {
 		__WFE();
 		__SEV();
 		__WFE();
 	}
+
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);
+
+	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
+
+	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Disabled << AAR_ENABLE_ENABLE_Pos) &
+			  AAR_ENABLE_ENABLE_Msk;
+
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -858,6 +858,9 @@ static void isr_abort(void *param)
 
 static void isr_done_cleanup(void *param)
 {
+	/* Clear radio status and events */
+	lll_isr_status_reset();
+
 	if (lll_is_done(param)) {
 		return;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -203,6 +203,9 @@ uint8_t lll_scan_aux_setup(struct lll_scan *lll, struct pdu_adv *pdu,
 	/* There's no prepare_cb prior to scan so need to clear flag here */
 	trx_cnt = 0U;
 
+	/* Primary scanner switched to auxliary PDU scanning */
+	lll->is_aux_sched = 1U;
+
 	radio_isr_set(isr_scan_aux_setup, node_rx);
 	radio_disable();
 
@@ -439,6 +442,7 @@ static void isr_rx(struct lll_scan *lll_scan, struct lll_scan_aux *lll_aux,
 	uint8_t trx_done;
 	uint8_t crc_ok;
 	uint8_t rl_idx;
+	int err;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -462,9 +466,11 @@ static void isr_rx(struct lll_scan *lll_scan, struct lll_scan_aux *lll_aux,
 	lll_isr_rx_status_reset();
 
 	/* No Rx */
-	if (!trx_done) {
+	if (!trx_done || !crc_ok) {
 		/* TODO: Combine the early exit with above if-then-else block
 		 */
+		err = -EINVAL;
+
 		goto isr_rx_do_close;
 	}
 
@@ -478,23 +484,26 @@ static void isr_rx(struct lll_scan *lll_scan, struct lll_scan_aux *lll_aux,
 	rl_idx = FILTER_IDX_NONE;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	if (crc_ok) {
-		int err;
-
-		err = isr_rx_pdu(lll_scan, lll_aux, phy_aux, devmatch_ok,
-				 devmatch_id, irkmatch_ok, irkmatch_ok, rl_idx,
-				 rssi_ready);
-		if (!err) {
-			if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-				lll_prof_send();
-			}
-
-			return;
+	err = isr_rx_pdu(lll_scan, lll_aux, phy_aux, devmatch_ok, devmatch_id,
+			 irkmatch_ok, irkmatch_ok, rl_idx, rssi_ready);
+	if (!err) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+			lll_prof_send();
 		}
+
+		return;
 	}
 
 isr_rx_do_close:
-	radio_isr_set(isr_done, NULL);
+	if (lll_aux) {
+		radio_isr_set(isr_done, lll_aux);
+	} else {
+		/* TODO: Send message to flush Auxiliary PDU list */
+		if (err != -ECANCELED) {
+			LL_ASSERT(0);
+		}
+		radio_isr_set(lll_scan_isr_resume, lll_scan);
+	}
 	radio_disable();
 }
 
@@ -728,9 +737,11 @@ static int isr_rx_pdu(struct lll_scan *lll_scan, struct lll_scan_aux *lll_aux,
 		if (ftr->aux_sched) {
 			return 0;
 		}
+
+		return -ECANCELED;
 	}
 
-	return -ECANCELED;
+	return -EINVAL;
 }
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -12,3 +12,5 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 				  uint8_t phy, uint8_t adv_tx_addr,
 				  uint8_t *adv_addr, uint8_t init_tx_addr,
 				  uint8_t *init_addr, uint32_t *conn_space_us);
+uint8_t lll_scan_aux_setup(struct lll_scan *lll, struct pdu_adv *pdu,
+			   uint8_t pdu_phy);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_internal.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+void lll_scan_isr_resume(void *param);
 bool lll_scan_adva_check(struct lll_scan *lll, uint8_t addr_type, uint8_t *addr,
 			 uint8_t rl_idx);
 bool lll_scan_ext_tgta_check(struct lll_scan *lll, bool pri, bool is_init,

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -209,7 +209,8 @@
 #endif
 #define BT_CTLR_MAX_CONN        CONFIG_BT_MAX_CONN
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CENTRAL)
-#define BT_CTLR_ADV_EXT_RX_CNT  1
+/* FIXME: needs more due to lll scheduling */
+#define BT_CTLR_ADV_EXT_RX_CNT  16
 #else
 #define BT_CTLR_ADV_EXT_RX_CNT  0
 #endif

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -400,6 +400,18 @@ uint8_t ull_scan_aux_lll_handle_get(struct lll_scan_aux *lll)
 	return aux_handle_get((void *)lll->hdr.parent);
 }
 
+struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux)
+{
+	if (((uint8_t *)aux < (uint8_t *)ll_scan_aux_pool) ||
+	    ((uint8_t *)aux > ((uint8_t *)ll_scan_aux_pool +
+			       (sizeof(struct ll_scan_aux_set) *
+				(CONFIG_BT_CTLR_SCAN_AUX_SET - 1))))) {
+		return NULL;
+	}
+
+	return aux;
+}
+
 static int init_reset(void)
 {
 	/* Initialize adv aux pool. */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -91,7 +91,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	struct pdu_adv_ext_hdr *h;
 	struct ll_scan_set *scan;
 	struct ll_sync_set *sync;
-	struct lll_scan_aux *lll;
+	struct lll_scan_aux *lll_aux;
+	struct lll_scan *lll_scan;
 	struct pdu_adv_adi *adi;
 	struct node_rx_ftr *ftr;
 	uint32_t ready_delay_us;
@@ -99,6 +100,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	uint32_t ticker_status;
 	struct pdu_adv *pdu;
 	uint8_t aux_handle;
+	bool is_lll_sched;
 	uint8_t *ptr;
 	uint8_t phy;
 
@@ -106,26 +108,54 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	switch (rx->type) {
 	case NODE_RX_TYPE_EXT_1M_REPORT:
-		lll = NULL;
+		lll_scan = ftr->param;
+		lll_aux = NULL;
 		aux = NULL;
-		scan = HDR_LLL2ULL(ftr->param);
+		scan = HDR_LLL2ULL(lll_scan);
 		sync = sync_create_get(scan);
 		phy = BT_HCI_LE_EXT_SCAN_PHY_1M;
 		break;
 	case NODE_RX_TYPE_EXT_CODED_REPORT:
-		lll = NULL;
+		lll_scan = ftr->param;
+		lll_aux = NULL;
 		aux = NULL;
-		scan = HDR_LLL2ULL(ftr->param);
+		scan = HDR_LLL2ULL(lll_scan);
 		sync = sync_create_get(scan);
 		phy = BT_HCI_LE_EXT_SCAN_PHY_CODED;
 		break;
 	case NODE_RX_TYPE_EXT_AUX_REPORT:
-		lll = ftr->param;
-		aux = HDR_LLL2ULL(lll);
-		scan = HDR_LLL2ULL(aux->rx_head->rx_ftr.param);
+		if (ull_scan_aux_is_valid_get(HDR_LLL2ULL(ftr->param))) {
+			/* Node has valid aux context so its scan was scheduled
+			 * from ULL.
+			 */
+			lll_aux = ftr->param;
+			aux = HDR_LLL2ULL(lll_aux);
+			/* FIXME: pick the aux somehow */
+			lll_scan = aux->rx_head->rx_ftr.param;
+			LL_ASSERT(!lll_scan->lll_aux);
+		} else {
+			/* Node that does not have valid aux context was
+			 * scheduled from LLL. We can retrieve aux context
+			 * from lll_scan as it was stored there when superior
+			 * PDU was handled.
+			 */
+			lll_scan = ftr->param;
+			LL_ASSERT(lll_scan->lll_aux);
+			lll_aux = lll_scan->lll_aux;
+			lll_scan->lll_aux = NULL;
+			aux = HDR_LLL2ULL(lll_aux);
+			LL_ASSERT(lll_scan == aux->rx_head->rx_ftr.param);
+
+			/* Store retrieved aux context to node so it can be
+			 * processed as if scheduled from ULL.
+			 */
+			ftr->param = lll_aux;
+		}
+
+		scan = HDR_LLL2ULL(lll_scan);
 		sync = (void *)scan;
 		scan = ull_scan_is_valid_get(scan);
-		phy = lll->phy;
+		phy = lll_aux->phy;
 		if (scan) {
 			/* Here we are scanner context */
 			sync = sync_create_get(scan);
@@ -150,9 +180,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			rx->type = NODE_RX_TYPE_SYNC_REPORT;
 			rx->handle = ull_sync_handle_get(sync);
 
-			/* lll and aux are auxiliary channel context,
+			/* lll_aux and aux are auxiliary channel context,
 			 * reuse the existing aux context to scan the chain.
-			 * hence lll and aux are not released or set to NULL.
+			 * hence lll_aux and aux are not released or set to NULL.
 			 */
 			sync = NULL;
 		}
@@ -170,7 +200,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			ull_sync = HDR_LLL2ULL(lll_sync);
 			rx->handle = ull_sync_handle_get(ull_sync);
 
-			lll = NULL;
+			/* FIXME: we will need lll_scan if chain was scheduled
+			 *        from LLL; should we store lll_scan_set in
+			 *        lll_sync instead?
+			 */
+			lll_scan = NULL;
+			lll_aux = NULL;
 			aux = NULL;
 			scan = NULL;
 			sync = NULL;
@@ -183,6 +218,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		LL_ASSERT(0);
 		return;
 	}
+
+	/* Copy to local flag since we need to clear 'extra' field */
+	is_lll_sched = !!ftr->aux_sched;
 
 	rx->link = link;
 	ftr->extra = NULL;
@@ -252,10 +290,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		}
 
 		aux->rx_last = NULL;
-		lll = &aux->lll;
+		lll_aux = &aux->lll;
 
 		ull_hdr_init(&aux->ull);
-		lll_hdr_init(lll, aux);
+		lll_hdr_init(lll_aux, aux);
 	}
 
 	/* Enqueue the rx in aux context */
@@ -266,16 +304,27 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	}
 	aux->rx_last = rx;
 
-	lll->chan = aux_ptr->chan_idx;
-	lll->phy = BIT(aux_ptr->phy);
+	lll_aux->chan = aux_ptr->chan_idx;
+	lll_aux->phy = BIT(aux_ptr->phy);
 
-	aux_offset_us = ftr->radio_end_us - PKT_AC_US(pdu->len, phy);
-	if (aux_ptr->offs_units) {
-		lll->window_size_us = OFFS_UNIT_300_US;
-	} else {
-		lll->window_size_us = OFFS_UNIT_30_US;
+	/* See if this was already scheduled from LLL. If so, store aux context
+	 * in global scan struct so we can pick it when scanned node is received
+	 * with a valid context.
+	 */
+	if (is_lll_sched) {
+		lll_scan->lll_aux = lll_aux;
+
+		return;
 	}
-	aux_offset_us += (uint32_t)aux_ptr->offs * lll->window_size_us;
+
+	/* Determine the window size */
+	if (aux_ptr->offs_units) {
+		lll_aux->window_size_us = OFFS_UNIT_300_US;
+	} else {
+		lll_aux->window_size_us = OFFS_UNIT_30_US;
+	}
+
+	aux_offset_us = (uint32_t)aux_ptr->offs * lll_aux->window_size_us;
 
 	/* CA field contains the clock accuracy of the advertiser;
 	 * 0 - 51 ppm to 500 ppm
@@ -287,11 +336,14 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
 	}
 
-	lll->window_size_us += (EVENT_TICKER_RES_MARGIN_US +
-				((EVENT_JITTER_US + window_widening_us) << 1));
+	lll_aux->window_size_us += (EVENT_TICKER_RES_MARGIN_US +
+				    ((EVENT_JITTER_US + window_widening_us) << 1));
 
-	ready_delay_us = lll_radio_rx_ready_delay_get(lll->phy, 1);
+	ready_delay_us = lll_radio_rx_ready_delay_get(lll_aux->phy, 1);
 
+	/* Calculate the aux offset from start of the scan window */
+	aux_offset_us += ftr->radio_end_us;
+	aux_offset_us -= PKT_AC_US(pdu->len, phy);
 	aux_offset_us -= EVENT_JITTER_US;
 	aux_offset_us -= ready_delay_us;
 	aux_offset_us -= window_widening_us;
@@ -306,7 +358,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
 				       PKT_AC_US(PDU_AC_EXT_PAYLOAD_SIZE_MAX,
-						 lll->phy) +
+						 lll_aux->phy) +
 				       EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(aux->ull.ticks_active_to_start,
@@ -466,6 +518,11 @@ static void done_disabled_cb(void *param)
 static void flush(struct ll_scan_aux_set *aux, struct node_rx_hdr *rx)
 {
 	if (aux->rx_last) {
+		struct lll_scan *lll;
+
+		lll = aux->rx_head->rx_ftr.param;
+		lll->lll_aux = NULL;
+
 		if (rx) {
 			struct node_rx_ftr *ftr;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -52,6 +52,9 @@ uint8_t ull_scan_handle_get(struct ll_scan_set *scan);
 /* Helper function to check and return if a valid scan context */
 struct ll_scan_set *ull_scan_is_valid_get(struct ll_scan_set *scan);
 
+/* Helper function to check and return if a valid aux scan context */
+struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux);
+
 /* Return ll_scan_set context if enabled */
 struct ll_scan_set *ull_scan_is_enabled_get(uint8_t handle);
 


### PR DESCRIPTION
This is further development based on https://github.com/zephyrproject-rtos/zephyr/pull/35391.
At the moment it is capable of scanning complete ADV_EXT_IND + AUX_ADV_IND + AUX_CHAIN_IND chain with minimum Tmafs, ULL and LLL scheduling can be interleaved depending of aux offset.

The RX path for AUX is LLL is not changed too much, the only difference is that AUX scheduled from LLL is sent as separate event to ULL since it does not hold aux context, but has lll_scan instead. ULL will restore aux context for such event which was stored on previous event (i.e. on ext). This is based on an assumption that if aux was scheduled from LLL on a PDU, then next PDU that is scanned will be that scheduled PDU so there's no risk of mixing PDUs from different chains.

What does not work yet:
- not yet sure why, but if 1st aux is scheduled from last ext (via lll) in advertising event, scan does not resume after complete chain is scanned; this works fine if aux is scheduled from ull
- scanning chain in sync is not done; it works pretty much the same except different structs are passed via param so needs some more work to chain all event together