### PR TITLE
net: openthread: Convert API worker thread to a work queue

### DIFF
--- a/include/net/openthread.h
+++ b/include/net/openthread.h
@@ -62,6 +62,12 @@ struct openthread_context {
 
 	/** A mutex to protect API calls from being preempted. */
 	struct k_mutex api_lock;
+
+	/** A work queue for all OpenThread activity */
+	struct k_work_q work_q;
+
+	/** Work object for OpenThread internal usage */
+	struct k_work api_work;
 };
 /**
  * INTERNAL_HIDDEN @endcond


### PR DESCRIPTION
Direct openthread API usage requires explicit locking,
which is also used internally.
Exposing a work queue through the openthread context allows
work to be submitted without the need to block other threads.

In particular with CONFIG_OPENTHREAD_MANUAL_START, application
logic can offload work which otherwise would need to wait for
the lock to become available.