### PR TITLE
board/STm32_Mini_dev_x_defconfig: ARM_MPU enabled without MPU.

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev_black_defconfig
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black_defconfig
@@ -8,12 +8,6 @@
 CONFIG_SOC_SERIES_STM32F1X=y
 CONFIG_SOC_STM32F103X8=y
 
-# Enable MPU
-CONFIG_ARM_MPU=y
-
-# Enable HW stack protection
-CONFIG_HW_STACK_PROTECTION=y
-
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue_defconfig
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue_defconfig
@@ -3,12 +3,6 @@
 CONFIG_SOC_SERIES_STM32F1X=y
 CONFIG_SOC_STM32F103X8=y
 
-# Enable MPU
-CONFIG_ARM_MPU=y
-
-# Enable HW stack protection
-CONFIG_HW_STACK_PROTECTION=y
-
 # enable uart driver
 CONFIG_SERIAL=y
 


### PR DESCRIPTION
This commit resolves warning ARM_MPU & HW_STACK_PROTECTION
during build. The MCU in STm32_Mini_dev (black & blue) has
no MPU support, but MPU was still enabled in defconfigs which
was the reason behind warnings. This commit removes
ARM_MPU & HW_STACK_PROTECTION from defconfig for both
STm32_Mini_dev development boards.

fix: zephyrproject-rtos/zephyr#36408

Signed-off-by: Affrin Pinhero <affrin.pinhero@hcl.com>