### PR TITLE
doc: add 'Open on GitHub' links

### DIFF
--- a/doc/_extensions/zephyr/vcs_link.py
+++ b/doc/_extensions/zephyr/vcs_link.py
@@ -1,0 +1,86 @@
+"""
+VCS Link
+########
+
+Copyright (c) 2021 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+
+Introduction
+============
+
+This Sphinx extension can be used to obtain the VCS URL for a given Sphinx page.
+This is useful, for example, when adding features like "Open on GitHub" on top
+of pages. The extension installs a Jinja filter which can be used on the
+template to obtain VCS page URLs.
+
+Configuration options
+=====================
+
+- ``vcs_link_base_url``: Base URL used as a prefix for generated URLs.
+- ``vcs_link_prefixes``: Mapping of pages (regex) <> VCS prefix.
+- ``vcs_link_exclude``: List of pages (regex) that will not report a URL. Useful
+  for, e.g., auto-generated pages not in VCS.
+"""
+
+from functools import partial
+import os
+import re
+from typing import Optional
+
+from sphinx.application import Sphinx
+
+
+__version__ = "0.1.0"
+
+
+def vcs_link_get_url(app: Sphinx, pagename: str) -> Optional[str]:
+    """Obtain VCS URL for the given page.
+
+    Args:
+        app: Sphinx instance.
+        pagename: Page name (path).
+
+    Returns:
+        VCS URL if applicable, None otherwise.
+    """
+
+    if not os.path.isfile(app.env.project.doc2path(pagename)):
+        return None
+
+    for exclude in app.config.vcs_link_exclude:
+        if re.match(exclude, pagename):
+            return None
+
+    found_prefix = ""
+    for pattern, prefix in app.config.vcs_link_prefixes.items():
+        if re.match(pattern, pagename):
+            found_prefix = prefix
+            break
+
+    return "/".join(
+        [
+            app.config.vcs_link_base_url,
+            found_prefix,
+            app.env.project.doc2path(pagename, basedir=False),
+        ]
+    )
+
+
+def add_jinja_filter(app: Sphinx):
+    app.builder.templates.environment.filters["vcs_link_get_url"] = partial(
+        vcs_link_get_url, app
+    )
+
+
+def setup(app: Sphinx):
+    app.add_config_value("vcs_link_base_url", "", "")
+    app.add_config_value("vcs_link_prefixes", {}, "")
+    app.add_config_value("vcs_link_exclude", [], "")
+
+    app.connect("builder-inited", add_jinja_filter)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -927,8 +927,16 @@ kbd, .kbd {
     background-color: var(--admonition-danger-background-color);
 }
 
-#dark-mode-toggle {
-    float: right;
+
+dark-mode-toggle::part(fieldset) {
+  padding-inline: 0.75rem;
+  padding-block: 0;
+}
+
+dark-mode-toggle::part(darkLabel),
+dark-mode-toggle::part(lightLabel),
+dark-mode-toggle::part(toggleLabel){
+  font-size: unset;
 }
 
 /* Home page grid display */

--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -11,5 +11,10 @@
      <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
   {% endfor %}
   <li>{{ title }}</li>
-  <dark-mode-toggle id="dark-mode-toggle" appearance="toggle" permanent="true"/>
+
 {% endblock %}
+{%- block breadcrumbs_aside %}
+  <li class="wy-breadcrumbs-aside">
+    <dark-mode-toggle id="dark-mode-toggle" appearance="toggle" permanent="true"/>
+  </li>
+{%- endblock %}

--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -17,4 +17,12 @@
   <li class="wy-breadcrumbs-aside">
     <dark-mode-toggle id="dark-mode-toggle" appearance="toggle" permanent="true"/>
   </li>
+  <li class="wy-breadcrumbs-aside">
+    {%- if display_vcs_link %}
+      {% set vcs_url = pagename | vcs_link_get_url %}
+      {% if vcs_url %}
+        <a href="{{ vcs_url }}" class="fa fa-github"> {{ _('Open on GitHub') }}</a>
+      {% endif %}
+    {% endif %}
+  </li>
 {%- endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,6 +82,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "zephyr.warnings_filter",
     "zephyr.doxyrunner",
+    "zephyr.vcs_link",
     "notfound.extension",
     "zephyr.external_content",
 ]
@@ -149,6 +150,7 @@ html_context = {
         ("2.2.0", "/2.2.0/"),
         ("1.14.1", "/1.14.1/"),
     ),
+    "display_vcs_link": True,
 }
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -206,6 +208,21 @@ warnings_filter_silent = False
 # -- Options for notfound.extension ---------------------------------------
 
 notfound_urls_prefix = f"/{version}/" if is_release else "/latest/"
+
+# -- Options for zephyr.vcs_link ------------------------------------------
+
+vcs_link_version = f"v{version}" if is_release else "main"
+vcs_link_base_url = f"https://github.com/zephyrproject-rtos/zephyr/blob/{vcs_link_version}"
+vcs_link_prefixes = {
+    "samples/.*": "",
+    "boards/.*": "",
+    ".*": "doc",
+}
+vcs_link_exclude = [
+    "reference/kconfig.*",
+    "reference/devicetree/bindings.*",
+    "reference/devicetree/compatibles.*",
+]
 
 # -- Options for zephyr.external_content ----------------------------------
 


### PR DESCRIPTION
This PR adds a new extension that allows to add 'Open on GitHub' links on all documentation pages that have a corresponding rst file in the Zephyr repository. The extension has multiple configuration options, such as documents to be excluded (e.g. auto-generated pages) or VCS prefixes since Zephyr has docs in multiple locations.

The idea behind this extension is to provide easy access to the document sources on GitHub.

**How does it look like?**

![image](https://user-images.githubusercontent.com/25011557/123868450-00340980-d930-11eb-99aa-51576dfd584b.png)