### PR TITLE
net: http_client: receiver retry on EAGAIN

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -149,6 +149,7 @@ static int on_url(struct http_parser *parser, const char *at, size_t length)
 	struct http_request *req = CONTAINER_OF(parser,
 						struct http_request,
 						internal.parser);
+
 	print_header_field(length, at);
 
 	if (req->internal.response.http_cb &&
@@ -208,7 +209,7 @@ static int on_header_field(struct http_parser *parser, const char *at,
 	return 0;
 }
 
-#define MAX_NUM_DIGITS	16
+#define MAX_NUM_DIGITS  16
 
 static int on_header_value(struct http_parser *parser, const char *at,
 			   size_t length)
@@ -603,7 +604,7 @@ int http_client_req(int sock, struct http_request *req,
 					     HTTP_CRLF, NULL);
 		} else {
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, HTTP_CRLF, NULL);
+					     &send_buf_pos, HTTP_CRLF, NULL);
 		}
 
 		if (ret < 0) {


### PR DESCRIPTION
`http_client_req` is unable to get response data from socket because data is not ready when `http_wait_data` calling `revc`.
it happened on b_l4s5i_iot01a target but not stm32f746g_disco.

```
[00:00:14.924,000] <dbg> net_http.Data to send
                                  47 45 54 20 2f 67 65 74  20 48 54 54 50 2f 31 2e |GET /get  HTTP/1.
                                  31 0d 0a 48 6f 73 74 3a  20 68 74 74 70 62 69 6e |1..Host:  httpbin
                                  2e 6f 72 67 3a 34 34 33  0d 0a 43 6f 6e 74 65 6e |.org:443 ..Conten
                                  74 2d 54 79 70 65 3a 20  61 70 70 6c 69 63 61 74 |t-Type:  applicat
                                  69 6f 6e 2f 6a 73 6f 6e  0d 0a 0d 0a             |ion/json ....    
[00:00:14.937,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x20000e5d (5 byte), rsp=0x20000e5d (1600 byte)
[00:00:14.954,000] <dbg> wifi_eswifi.eswifi_spi_request: success
[00:00:15.104,000] <dbg> net_http.http_client_req: (shell_uart): Sent 135 bytes
[00:00:15.112,000] <dbg> wifi_eswifi.eswifi_socket_recv: read -11 0 (nil)
[00:00:15.119,000] <dbg> net_http.http_wait_data: Connection error (11)
[00:00:15.126,000] <dbg> net_http.http_client_req: (shell_uart): Wait data failure (-11)
[00:00:15.135,000] <dbg> iota_http.http_client_get: data: 
[00:00:15.158,000] <dbg> wifi_eswifi.eswifi_off_read_work: 
[00:00:15.187,000] <dbg> wifi_eswifi.__stop_socket: Stopping socket 0
[00:00:15.194,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x200035f8 (5 byte), rsp=0x20000e5d (1600 byte)
[00:00:15.215,000] <dbg> wifi_eswifi.eswifi_spi_request: success
```

with reties, the response can be processed by http_client

```
[00:00:15.343,000] <dbg> net_http.Data to send
                                  47 45 54 20 2f 67 65 74  20 48 54 54 50 2f 31 2e |GET /get  HTTP/1.
                                  31 0d 0a 48 6f 73 74 3a  20 68 74 74 70 62 69 6e |1..Host:  httpbin
                                  2e 6f 72 67 3a 34 34 33  0d 0a 43 6f 6e 74 65 6e |.org:443 ..Conten
                                  74 2d 54 79 70 65 3a 20  61 70 70 6c 69 63 61 74 |t-Type:  applicat
                                  69 6f 6e 2f 6a 73 6f 6e  0d 0a 0d 0a             |ion/json ....    
[00:00:15.501,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x20000e5d (83 byte), rsp=0x20000e5d (1600 byte)
[00:00:15.519,000] <dbg> wifi_eswifi.eswifi_spi_request: success
[00:00:15.525,000] <dbg> net_http.http_client_req: (shell_uart): Sent 135 bytes
[00:00:15.533,000] <dbg> wifi_eswifi.eswifi_socket_recv: read -11 0 (nil)
[00:00:15.540,000] <dbg> net_http.http_wait_data: receiver recv retry (0)
[00:00:15.578,000] <dbg> wifi_eswifi.eswifi_off_read_work: 
[00:00:15.648,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x20003cac (3 byte), rsp=0x20000e5d (1600 byte)
[00:00:15.694,000] <dbg> wifi_eswifi.eswifi_spi_request: success
[00:00:15.700,000] <dbg> wifi_eswifi.eswifi_socket_recv: read -11 0 (nil)
[00:00:15.707,000] <dbg> net_http.http_wait_data: receiver recv retry (1)
[00:00:15.800,000] <dbg> wifi_eswifi.eswifi_off_read_work: 
[00:00:15.875,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x20003cac (3 byte), rsp=0x20000e5d (1600 byte)
[00:00:15.912,000] <dbg> wifi_eswifi.eswifi_spi_request: success
[00:00:15.918,000] <dbg> wifi_eswifi.eswifi_off_read_work: payload sz = 472
[00:00:15.925,000] <dbg> wifi_eswifi.eswifi_off_read_work: 
[00:00:15.931,000] <dbg> wifi_eswifi.eswifi_socket_recv: read 472 0 0x200085e8
[00:00:15.939,000] <dbg> wifi_eswifi.eswifi_spi_request: cmd=0x20000e5d (5 byte), rsp=0x20000e5d (1600 byte)
[00:00:15.949,000] <dbg> net_http.on_message_begin: (shell_uart): -- HTTP GET response (headers) --
[00:00:15.953,000] <dbg> net_http.on_status: (shell_uart): HTTP response status 200 OK
```

This PR added a retry mechanism `http_wait_data` and configurations in Kconfig for handling the EAGAIN error.

```
[*] HTTP client API [EXPERIMENTAL]
(5)     HTTP client receiver retry
(100)   HTTP client retry interval in ms
```