### PR TITLE
common: Add headers to support C++ style includes

### DIFF
--- a/subsys/cpp/CMakeLists.txt
+++ b/subsys/cpp/CMakeLists.txt
@@ -6,6 +6,12 @@ zephyr_sources(
   cpp_dtors.c
 )
 
+if (NOT CONFIG_LIB_CPLUSPLUS)
+zephyr_system_include_directories(
+	include
+)
+endif()
+
 if (NOT CONFIG_LIB_CPLUSPLUS AND
         (NOT CONFIG_MINIMAL_LIBC OR
         (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE GREATER 0)))

--- a/subsys/cpp/include/cstddef
+++ b/subsys/cpp/include/cstddef
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Stub header allowing compilation of `#include <cstddef>`
+ */

--- a/subsys/cpp/include/cstdint
+++ b/subsys/cpp/include/cstdint
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Stub header allowing compilation of `#include <cstdint>`
+ */
+
+#ifndef ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDINT_
+#define ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDINT_
+
+#include <stdint.h>
+
+namespace std {
+	using ::int8_t;
+	using ::int16_t;
+	using ::int32_t;
+	using ::int64_t;
+	using ::intmax_t;
+
+	using ::int_fast8_t;
+	using ::int_fast16_t;
+	using ::int_fast32_t;
+	using ::int_fast64_t;
+
+	using ::int_least8_t;
+	using ::int_least16_t;
+	using ::int_least32_t;
+	using ::int_least64_t;
+
+	using ::uint8_t;
+	using ::uint16_t;
+	using ::uint32_t;
+	using ::uint64_t;
+	using ::uintmax_t;
+
+	using ::uint_fast8_t;
+	using ::uint_fast16_t;
+	using ::uint_fast32_t;
+	using ::uint_fast64_t;
+
+	using ::uint_least8_t;
+	using ::uint_least16_t;
+	using ::uint_least32_t;
+	using ::uint_least64_t;
+
+	using ::intptr_t;
+	using ::uintptr_t;
+}
+
+#endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDINT_ */
+


### PR DESCRIPTION
When compiling existing libraries that are difficult to change, these
headers simplify the library's integration. This specifically was the
agreed upon fix for trying to compile Android's CHRE as a subsystem.
Making changes to the Android repo to use the C style includes would be
very difficult and would likely take a very long time.

Signed-off-by: Yuval Peress <peress@chromium.org>