### PR TITLE
Bluetooth: Controller: Fix Periodic Sync setup with invalid channels

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -366,28 +366,15 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	uint32_t ret;
 	uint8_t sca;
 
+	/* Populate the LLL context */
 	sync = scan->per_scan.sync;
-	scan->per_scan.sync = NULL;
-	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
-		struct ll_scan_set *scan_1m;
-
-		scan_1m = ull_scan_set_get(SCAN_HANDLE_1M);
-		if (scan == scan_1m) {
-			struct ll_scan_set *scan_coded;
-
-			scan_coded = ull_scan_set_get(SCAN_HANDLE_PHY_CODED);
-			scan_coded->per_scan.sync = NULL;
-		} else {
-			scan_1m->per_scan.sync = NULL;
-		}
-	}
-
 	lll = &sync->lll;
 	memcpy(lll->data_chan_map, si->sca_chm, sizeof(lll->data_chan_map));
 	lll->data_chan_map[4] &= ~0xE0;
 	lll->data_chan_count = util_ones_count_get(&lll->data_chan_map[0],
 						   sizeof(lll->data_chan_map));
 	if (lll->data_chan_count < 2) {
+		/* Ignore sync setup, invalid available channel count */
 		return;
 	}
 
@@ -414,8 +401,25 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		lll->window_size_event_us = OFFS_UNIT_30_US;
 	}
 
+	/* Reset the sync context allocated to scan contexts */
+	scan->per_scan.sync = NULL;
+	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+		struct ll_scan_set *scan_1m;
+
+		scan_1m = ull_scan_set_get(SCAN_HANDLE_1M);
+		if (scan == scan_1m) {
+			struct ll_scan_set *scan_coded;
+
+			scan_coded = ull_scan_set_get(SCAN_HANDLE_PHY_CODED);
+			scan_coded->per_scan.sync = NULL;
+		} else {
+			scan_1m->per_scan.sync = NULL;
+		}
+	}
+
 	sync_handle = ull_sync_handle_get(sync);
 
+	/* Prepare and dispatch sync notification */
 	rx = (void *)scan->per_scan.node_rx_estab;
 	rx->hdr.type = NODE_RX_TYPE_SYNC;
 	rx->hdr.handle = sync_handle;
@@ -429,6 +433,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	ll_rx_put(rx->hdr.link, rx);
 	ll_rx_sched();
 
+	/* Calculate offset and schedule sync radio events */
 	ftr = &node_rx->rx_ftr;
 	pdu = (void *)((struct node_rx_pdu *)node_rx)->pdu;
 


### PR DESCRIPTION
Fix Periodic Synchronization setup when handling invalid
number of channel count in Periodic Advertising's Sync Info
structure.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>