### PR TITLE
Bluetooth: Controller: Fix clock accuracy calculation scanning Aux PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -102,6 +102,10 @@
 /* Value specified in BT Spec. Vol 6, Part B, section 2.3.4.6 */
 #define OFFS_ADJUST_US          245760
 
+/* Sleep Clock Accuracy, calculate drift in microseconds */
+#define SCA_DRIFT_50_PPM_US(t)  (((t) * 50UL) / 1000000UL)
+#define SCA_DRIFT_500_PPM_US(t) (((t) * 500UL) / 1000000UL)
+
 /* transmitWindowDelay times (us) */
 #define WIN_DELAY_LEGACY     1250
 #define WIN_DELAY_UNCODED    2500

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -277,10 +277,14 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	}
 	aux_offset_us += (uint32_t)aux_ptr->offs * lll->window_size_us;
 
+	/* CA field contains the clock accuracy of the advertiser;
+	 * 0 - 51 ppm to 500 ppm
+	 * 1 - 0 ppm to 50 ppm
+	 */
 	if (aux_ptr->ca) {
-		window_widening_us = aux_offset_us / 2000U;
-	} else {
 		window_widening_us = aux_offset_us / 20000U;
+	} else {
+		window_widening_us = aux_offset_us / 2000U;
 	}
 
 	lll->window_size_us += (EVENT_TICKER_RES_MARGIN_US +

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -271,9 +271,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	aux_offset_us = ftr->radio_end_us - PKT_AC_US(pdu->len, 0, phy);
 	if (aux_ptr->offs_units) {
-		lll->window_size_us = 300U;
+		lll->window_size_us = OFFS_UNIT_300_US;
 	} else {
-		lll->window_size_us = 30U;
+		lll->window_size_us = OFFS_UNIT_30_US;
 	}
 	aux_offset_us += (uint32_t)aux_ptr->offs * lll->window_size_us;
 
@@ -282,9 +282,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	 * 1 - 0 ppm to 50 ppm
 	 */
 	if (aux_ptr->ca) {
-		window_widening_us = aux_offset_us / 20000U;
+		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
 	} else {
-		window_widening_us = aux_offset_us / 2000U;
+		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
 	}
 
 	lll->window_size_us += (EVENT_TICKER_RES_MARGIN_US +

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -409,9 +409,9 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 		  interval_us) + (1000000 - 1)) / 1000000U;
 	lll->window_widening_max_us = (interval_us >> 1) - EVENT_IFS_US;
 	if (si->offs_units) {
-		lll->window_size_event_us = 300U;
+		lll->window_size_event_us = OFFS_UNIT_300_US;
 	} else {
-		lll->window_size_event_us = 30U;
+		lll->window_size_event_us = OFFS_UNIT_30_US;
 	}
 
 	sync_handle = ull_sync_handle_get(sync);


### PR DESCRIPTION
Fix clock accuracy value used in the calculation of window
widening applied when scanning for auxiliary PDU.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>