### PR TITLE
add synopsys creg gpio driver support for arc hsdk and em_starterkit boards

### DIFF
--- a/boards/arc/em_starterkit/Kconfig.defconfig
+++ b/boards/arc/em_starterkit/Kconfig.defconfig
@@ -59,6 +59,13 @@ config SPI_DW_FIFO_DEPTH
 config SPI_DW_ARC_AUX_REGS
 	default n
 
+if BOARD_EM_STARTERKIT_R23
+
+config GPIO_SNPS_CREG
+	default y
+
+endif # BOARD_EM_STARTERKIT_R23
+
 endif # SPI_DW
 
 endif # SPI

--- a/boards/arc/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/arc/em_starterkit/em_starterkit_r23.dtsi
@@ -42,8 +42,29 @@
 			interrupts = <0 1>;
 		};
 
+		creg_gpio: creg_gpio@f0000014 {
+			compatible = "snps,creg-gpio";
+			reg = <0xf0000014 0x4>;
+			ngpios = <6>;
+			label = "CREG_GPIO";
+			bit_per_gpio = <1>;
+			off_val = <0>;
+			on_val = <1>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			status = "okay";
+		};
+
 		spi@f0006000 {
 			interrupts = <27 1>;
+			cs-gpios = <&creg_gpio 0 GPIO_ACTIVE_HIGH>,
+					   <&creg_gpio 1 GPIO_ACTIVE_HIGH>,
+					   <&creg_gpio 2 GPIO_ACTIVE_HIGH>,
+					   <&creg_gpio 3 GPIO_ACTIVE_HIGH>,
+					   <&creg_gpio 4 GPIO_ACTIVE_HIGH>,
+					   <&creg_gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 
 		spi@f0007000 {

--- a/boards/arc/hsdk/Kconfig.defconfig
+++ b/boards/arc/hsdk/Kconfig.defconfig
@@ -39,6 +39,9 @@ config SPI_DW_ARC_AUX_REGS
 config SPI_DW_ACCESS_WORD_ONLY
 	default y
 
+config GPIO_SNPS_CREG
+	default y
+
 endif # SPI_DW
 
 endif # SPI

--- a/boards/arc/hsdk/hsdk.dtsi
+++ b/boards/arc/hsdk/hsdk.dtsi
@@ -86,19 +86,33 @@ arduino_spi: &spi2 {};
 	interrupts = <56 1>;
 };
 
+&creg_gpio {
+	status = "okay";
+};
+
 &spi0 {
 	status = "okay";
 	clock-frequency = <33333333>;
+	cs-gpios = <&creg_gpio 0 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 1 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 2 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 3 GPIO_ACTIVE_HIGH>;
 };
 
 &spi1 {
 	status = "okay";
 	clock-frequency = <33333333>;
+	cs-gpios = <&creg_gpio 4 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 5 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 6 GPIO_ACTIVE_HIGH>;
 };
 
 &spi2 {
 	status = "okay";
 	clock-frequency = <33333333>;
+	cs-gpios = <&creg_gpio 8 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 9 GPIO_ACTIVE_HIGH>,
+			   <&creg_gpio 10 GPIO_ACTIVE_HIGH>;
 };
 
 &i2c0 {

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -38,6 +38,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_PCAL6408A  gpio_pcal6408a.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_EOS_S3     gpio_eos_s3.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RCAR       gpio_rcar.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_CY8C95XX   gpio_cy8c95xx.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_SNPS_CREG  gpio_creg_gpio.c)
 
 zephyr_library_sources_ifdef(CONFIG_GPIO_SHELL      gpio_shell.c)
 

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -91,4 +91,6 @@ source "drivers/gpio/Kconfig.rcar"
 
 source "drivers/gpio/Kconfig.cy8c95xx"
 
+source "drivers/gpio/Kconfig.creg_gpio"
+
 endif # GPIO

--- a/drivers/gpio/Kconfig.creg_gpio
+++ b/drivers/gpio/Kconfig.creg_gpio
@@ -1,0 +1,23 @@
+# Synopsys GPIO via CREG (Control REGisters) driver
+
+# Copyright (c) 2021 Synopsys
+# SPDX-License-Identifier: Apache-2.0
+
+# Workaround for not being able to have commas in macro arguments
+DT_COMPAT_SNPS_CREG_GPIO := snps,creg-gpio
+
+menuconfig GPIO_SNPS_CREG
+	bool "SNPS CREG GPIO"
+	default $(dt_compat_enabled,$(DT_COMPAT_SNPS_CREG_GPIO))
+	help
+	  Enable driver for SNPS CREG GPIO.
+
+if GPIO_SNPS_CREG
+
+config GPIO_SNPS_CREG_INIT_PRIORITY
+	int "Init priority"
+	default 70
+	help
+	  Device driver initialization priority.
+
+endif # GPIO_SNPS_CREG

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2021 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT snps_creg_gpio
+
+#include <errno.h>
+
+#include <kernel.h>
+#include <device.h>
+#include <init.h>
+#include <drivers/gpio.h>
+#include <drivers/i2c.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(creg_gpio, CONFIG_GPIO_LOG_LEVEL);
+
+#include "gpio_utils.h"
+
+/** Runtime driver data */
+struct creg_gpio_drv_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	uint32_t pin_val;
+	uint32_t base_addr;
+};
+
+/** Configuration data */
+struct creg_gpio_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	uint32_t ngpios;
+	uint8_t bit_per_gpio;
+	uint8_t off_val;
+	uint8_t on_val;
+};
+
+static int pin_config(const struct device *dev,
+		       gpio_pin_t pin,
+		       gpio_flags_t flags)
+{
+	return -ENOTSUP;
+}
+
+static int port_get(const struct device *dev,
+		    gpio_port_value_t *value)
+{
+	const struct creg_gpio_config *cfg = dev->config;
+	struct creg_gpio_drv_data *drv_data = dev->data;
+	uint32_t in = sys_read32(drv_data->base_addr);
+	uint32_t tmp = 0;
+	uint32_t val = 0;
+
+	for (uint8_t i = 0; i < cfg->ngpios; i++) {
+		tmp = (in & cfg->on_val << i * cfg->bit_per_gpio) ? 1 : 0;
+		val |= tmp << i;
+	}
+	*value = drv_data->pin_val = val;
+
+	return 0;
+}
+
+static int port_write(const struct device *dev,
+		      gpio_port_pins_t mask,
+		      gpio_port_value_t value,
+		      gpio_port_value_t toggle)
+{
+	const struct creg_gpio_config *cfg = dev->config;
+	struct creg_gpio_drv_data *drv_data = dev->data;
+	uint32_t *pin_val = &drv_data->pin_val;
+	uint32_t out = 0;
+	uint32_t tmp = 0;
+
+	*pin_val = ((*pin_val & ~mask) | (value & mask)) ^ toggle;
+
+	for (uint8_t i = 0; i < cfg->ngpios; i++) {
+		tmp = (*pin_val & 1 << i) ? cfg->on_val : cfg->off_val;
+		out |= tmp << i * cfg->bit_per_gpio;
+	}
+	sys_write32(out, drv_data->base_addr);
+
+	return 0;
+}
+
+static int port_set_masked(const struct device *dev,
+			   gpio_port_pins_t mask,
+			   gpio_port_value_t value)
+{
+	return port_write(dev, mask, value, 0);
+}
+
+static int port_set_bits(const struct device *dev,
+			 gpio_port_pins_t pins)
+{
+	return port_write(dev, pins, pins, 0);
+}
+
+static int port_clear_bits(const struct device *dev,
+			   gpio_port_pins_t pins)
+{
+	return port_write(dev, pins, 0, 0);
+}
+
+static int port_toggle_bits(const struct device *dev,
+			    gpio_port_pins_t pins)
+{
+	return port_write(dev, 0, 0, pins);
+}
+
+static int pin_interrupt_configure(const struct device *dev,
+				   gpio_pin_t pin,
+				   enum gpio_int_mode mode,
+				   enum gpio_int_trig trig)
+{
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Initialization function of creg_gpio
+ *
+ * @param dev Device struct
+ * @return 0 if successful, failed otherwise.
+ */
+static int creg_gpio_init(const struct device *dev)
+{
+	return 0;
+}
+
+static const struct gpio_driver_api api_table = {
+	.pin_configure = pin_config,
+	.port_get_raw = port_get,
+	.port_set_masked_raw = port_set_masked,
+	.port_set_bits_raw = port_set_bits,
+	.port_clear_bits_raw = port_clear_bits,
+	.port_toggle_bits = port_toggle_bits,
+	.pin_interrupt_configure = pin_interrupt_configure,
+};
+
+static const struct creg_gpio_config creg_gpio_cfg = {
+	.common = {
+		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(0),
+	},
+	.ngpios = DT_INST_PROP(0, ngpios),
+	.bit_per_gpio = DT_INST_PROP(0, bit_per_gpio),
+	.off_val = DT_INST_PROP(0, off_val),
+	.on_val = DT_INST_PROP(0, on_val),
+};
+
+static struct creg_gpio_drv_data creg_gpio_drvdata = {
+	.base_addr = DT_INST_REG_ADDR(0),
+};
+
+DEVICE_DT_INST_DEFINE(0, creg_gpio_init, NULL,
+		      &creg_gpio_drvdata, &creg_gpio_cfg,
+		      POST_KERNEL, CONFIG_GPIO_SNPS_CREG_INIT_PRIORITY,
+		      &api_table);

--- a/dts/arc/arc_hsdk.dtsi
+++ b/dts/arc/arc_hsdk.dtsi
@@ -122,6 +122,21 @@
 			status = "disabled";
 		};
 
+		creg_gpio: creg_gpio@f00014b0 {
+			compatible = "snps,creg-gpio";
+			reg = <0xf00014b0 0x4>;
+			ngpios = <12>;
+			label = "CREG_GPIO";
+			bit_per_gpio = <2>;
+			off_val = <0>;
+			on_val = <2>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			status = "disabled";
+		};
+
 		i2c0: i2c@f0023000 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 Synopsys, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Synopsys CREG GPIO node
+
+compatible: "snps,creg-gpio"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    bit_per_gpio:
+      type: int
+      required: true
+
+    off_val:
+      type: int
+      required: true
+
+    on_val:
+      type: int
+      required: true
+
+    "#gpio-cells":
+      const: 2
+
+gpio-cells:
+  - pin
+  - flags


### PR DESCRIPTION
Add single-register MMIO GPIO driver for complex cases where only several fields in register belong to
GPIO lines and each GPIO line owns a field with different length and on/off value.

Such CREG GPIOs are used in Synopsys em_starterkit and HSDK boards for SPI CS pin control.

fix: #35377