### PR TITLE
include: ring_buffer: fix storage class specifier in RING_BUF_* macros

### DIFF
--- a/include/sys/ring_buffer.h
+++ b/include/sys/ring_buffer.h
@@ -83,7 +83,7 @@ struct ring_buf {
 	BUILD_ASSERT((1 << pow) < RING_BUFFER_MAX_SIZE,\
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint32_t _ring_buffer_data_##name[BIT(pow)]; \
-	struct ring_buf name = { \
+	static struct ring_buf name = { \
 		.size = (BIT(pow)),	  \
 		.mask = (BIT(pow)) - 1, \
 		.buf = { .buf32 = _ring_buffer_data_##name } \
@@ -107,7 +107,7 @@ struct ring_buf {
 	BUILD_ASSERT(size32 < RING_BUFFER_MAX_SIZE,\
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint32_t _ring_buffer_data_##name[size32]; \
-	struct ring_buf name = { \
+	static struct ring_buf name = { \
 		.size = size32, \
 		.buf = { .buf32 = _ring_buffer_data_##name} \
 	}
@@ -129,7 +129,7 @@ struct ring_buf {
 	BUILD_ASSERT(size8 < RING_BUFFER_MAX_SIZE,\
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint8_t _ring_buffer_data_##name[size8]; \
-	struct ring_buf name = { \
+	static struct ring_buf name = { \
 		.size = size8, \
 		.buf = { .buf8 = _ring_buffer_data_##name} \
 	}


### PR DESCRIPTION
Despite documentation macros `RING_BUF_*_DECLARE_*` do not
define struct ring_buf as static. Add static specifier to
struct ring_buf in `RING_BUF_*_DECLARE_*` macros.

Fixes: #36608