### PR TITLE
soc: same70, samv71: free TRACESWO pin when unused

### DIFF
--- a/soc/arm/atmel_sam/same70/soc_config.c
+++ b/soc/arm/atmel_sam/same70/soc_config.c
@@ -49,6 +49,11 @@ static int atmel_same70_config(const struct device *dev)
 	while (!((PMC->PMC_SR) & PMC_SR_PCKRDY3)) {
 		;
 	}
+	/* Enable TDO/TRACESWO function on PB5 pin */
+	MATRIX->CCFG_SYSIO &= ~CCFG_SYSIO_SYSIO5;
+#else
+	/* Disable TDO/TRACESWO function on PB5 pin */
+	MATRIX->CCFG_SYSIO |= CCFG_SYSIO_SYSIO5;
 #endif
 
 	return 0;

--- a/soc/arm/atmel_sam/samv71/soc_config.c
+++ b/soc/arm/atmel_sam/samv71/soc_config.c
@@ -53,6 +53,11 @@ static int atmel_samv71_config(const struct device *dev)
 	while (!((PMC->PMC_SR) & PMC_SR_PCKRDY3)) {
 		;
 	}
+	/* Enable TDO/TRACESWO function on PB5 pin */
+	MATRIX->CCFG_SYSIO &= ~CCFG_SYSIO_SYSIO5;
+#else
+	/* Disable TDO/TRACESWO function on PB5 pin */
+	MATRIX->CCFG_SYSIO |= CCFG_SYSIO_SYSIO5;
 #endif
 
 	return 0;


### PR DESCRIPTION
Pin PB5 is part of ARM Cortex-M debug interface and by default
configured to output TDO/TRACESWO signal. Disable TDO/TRACESWO
function on PB5 pin when LOG_BACKEND_SWO is not enabled. This
ultimately frees the pin to be used by standard SoC peripherals.

Fixes #33910