### PR TITLE
drivers: modem: operate on device pointers instead of names

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -521,7 +521,7 @@ attaching:
 	if (IS_ENABLED(CONFIG_GSM_MUX) && gsm->mux_enabled) {
 		/* Re-use the original iface for AT channel */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
-						gsm->at_dev->name);
+						gsm->at_dev);
 		if (ret < 0) {
 			LOG_DBG("iface %suart error %d", "AT ", ret);
 		} else {
@@ -704,7 +704,7 @@ static void mux_setup(struct k_work *work)
 		 * to the modem.
 		 */
 		ret = modem_iface_uart_init_dev(&gsm->context.iface,
-						gsm->ppp_dev->name);
+						gsm->ppp_dev);
 		if (ret < 0) {
 			LOG_DBG("iface %suart error %d", "PPP ", ret);
 			gsm->mux_enabled = false;
@@ -785,7 +785,7 @@ void gsm_ppp_start(const struct device *dev)
 
 	/* Re-init underlying UART comms */
 	int r = modem_iface_uart_init_dev(&gsm->context.iface,
-					  CONFIG_MODEM_GSM_UART_NAME);
+				device_get_binding(CONFIG_MODEM_GSM_UART_NAME));
 	if (r) {
 		LOG_ERR("modem_iface_uart_init returned %d", r);
 		return;
@@ -857,7 +857,7 @@ static int gsm_init(const struct device *dev)
 	gsm->gsm_data.rx_rb_buf_len = sizeof(gsm->gsm_rx_rb_buf);
 
 	r = modem_iface_uart_init(&gsm->context.iface, &gsm->gsm_data,
-				  CONFIG_MODEM_GSM_UART_NAME);
+				device_get_binding(CONFIG_MODEM_GSM_UART_NAME));
 	if (r < 0) {
 		LOG_DBG("iface uart error %d", r);
 		return r;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -232,7 +232,7 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 		  (GPIO_INPUT | GPIO_INT_EDGE_BOTH)),
 };
 
-#define MDM_UART_DEV_NAME DT_INST_BUS_LABEL(0)
+#define MDM_UART_DEV	DEVICE_DT_GET(DT_INST_BUS(0))
 
 #define MDM_WAKE_ASSERTED 1 /* Asserted keeps the module awake */
 #define MDM_WAKE_NOT_ASSERTED 0
@@ -4940,7 +4940,7 @@ static int hl7800_init(const struct device *dev)
 	ictx.mdm_ctx.data_imei = ictx.mdm_imei;
 #endif
 
-	ret = mdm_receiver_register(&ictx.mdm_ctx, MDM_UART_DEV_NAME,
+	ret = mdm_receiver_register(&ictx.mdm_ctx, MDM_UART_DEV,
 				    mdm_recv_buf, sizeof(mdm_recv_buf));
 	if (ret < 0) {
 		LOG_ERR("Error registering modem receiver (%d)!", ret);

--- a/drivers/modem/modem_iface_uart.c
+++ b/drivers/modem/modem_iface_uart.c
@@ -165,13 +165,12 @@ static int modem_iface_uart_write(struct modem_iface *iface,
 }
 
 int modem_iface_uart_init_dev(struct modem_iface *iface,
-			      const char *dev_name)
+			      const struct device *dev)
 {
 	/* get UART device */
-	const struct device *dev = device_get_binding(dev_name);
 	const struct device *prev = iface->dev;
 
-	if (!dev) {
+	if (!device_is_ready(dev)) {
 		return -ENODEV;
 	}
 
@@ -201,7 +200,7 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 
 int modem_iface_uart_init(struct modem_iface *iface,
 			  struct modem_iface_uart_data *data,
-			  const char *dev_name)
+			  const struct device *dev)
 {
 	int ret;
 
@@ -217,7 +216,7 @@ int modem_iface_uart_init(struct modem_iface *iface,
 	k_sem_init(&data->rx_sem, 0, 1);
 
 	/* get UART device */
-	ret = modem_iface_uart_init_dev(iface, dev_name);
+	ret = modem_iface_uart_init_dev(iface, dev);
 	if (ret < 0) {
 		iface->iface_data = NULL;
 		iface->read = NULL;

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -45,7 +45,7 @@ struct modem_iface_uart_data {
  * @retval 0 if ok, < 0 if error.
  */
 int modem_iface_uart_init_dev(struct modem_iface *iface,
-			      const char *dev_name);
+			      const struct device *dev);
 
 /**
  * @brief  Init modem interface for UART
@@ -58,7 +58,7 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
  */
 int modem_iface_uart_init(struct modem_iface *iface,
 			  struct modem_iface_uart_data *data,
-			  const char *dev_name);
+			  const struct device *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -215,7 +215,7 @@ int mdm_receiver_wake(struct mdm_receiver_context *ctx)
 }
 
 int mdm_receiver_register(struct mdm_receiver_context *ctx,
-			  const char *uart_dev_name,
+			  const struct device *uart_dev,
 			  uint8_t *buf, size_t size)
 {
 	int ret;
@@ -224,12 +224,13 @@ int mdm_receiver_register(struct mdm_receiver_context *ctx,
 		return -EINVAL;
 	}
 
-	ctx->uart_dev = device_get_binding(uart_dev_name);
-	if (!ctx->uart_dev) {
-		LOG_ERR("Binding failure for uart: %s", uart_dev_name);
+	if (!device_is_ready(uart_dev)) {
+		LOG_ERR("Device is not ready: %s",
+			uart_dev ? uart_dev->name : "<null>");
 		return -ENODEV;
 	}
 
+	ctx->uart_dev = uart_dev;
 	ring_buf_init(&ctx->rx_rb, size, buf);
 	k_sem_init(&ctx->rx_sem, 0, 1);
 

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -80,14 +80,14 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
  * @note   Acquires receivers device, and prepares the context to be used.
  *
  * @param  *ctx: receiver context to register.
- * @param  *uart_dev_name: communication device for the receiver context.
+ * @param  *uart_dev: communication device for the receiver context.
  * @param  *buf: rx buffer to use for received data.
  * @param  size: rx buffer size.
  *
  * @retval 0 if ok, < 0 if error.
  */
 int mdm_receiver_register(struct mdm_receiver_context *ctx,
-			  const char *uart_dev_name,
+			  const struct device *uart_dev,
 			  uint8_t *buf, size_t size);
 
 int mdm_receiver_sleep(struct mdm_receiver_context *ctx);

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1156,7 +1156,7 @@ static int modem_init(const struct device *dev)
 	mdata.iface_data.rx_rb_buf     = &mdata.iface_rb_buf[0];
 	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
 	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,
-				    MDM_UART_DEV_NAME);
+				    MDM_UART_DEV);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -24,7 +24,7 @@
 #include "modem_cmd_handler.h"
 #include "modem_iface_uart.h"
 
-#define MDM_UART_DEV_NAME		  DT_INST_BUS_LABEL(0)
+#define MDM_UART_DEV			  DEVICE_DT_GET(DT_INST_BUS(0))
 #define MDM_CMD_TIMEOUT			  K_SECONDS(10)
 #define MDM_CMD_CONN_TIMEOUT		  K_SECONDS(120)
 #define MDM_REGISTRATION_TIMEOUT	  K_SECONDS(180)

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -73,8 +73,8 @@ static struct modem_pin modem_pins[] = {
 #endif
 };
 
-#define MDM_UART_DEV_NAME		DT_INST_BUS_LABEL(0)
-#define MDM_UART_NODE			DT_BUS(DT_DRV_INST(0))
+#define MDM_UART_NODE			DT_INST_BUS(0)
+#define MDM_UART_DEV			DEVICE_DT_GET(MDM_UART_NODE)
 
 #define MDM_POWER_ENABLE		1
 #define MDM_POWER_DISABLE		0
@@ -2169,7 +2169,7 @@ static int modem_init(const struct device *dev)
 	mdata.iface_data.rx_rb_buf = &mdata.iface_rb_buf[0];
 	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
 	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,
-				    MDM_UART_DEV_NAME);
+				    MDM_UART_DEV);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -102,7 +102,7 @@ static const struct mdm_control_pinconfig pinconfig[] = {
 #endif
 };
 
-#define MDM_UART_DEV_NAME		DT_INST_BUS_LABEL(0)
+#define MDM_UART_DEV			DEVICE_DT_GET(DT_INST_BUS(0))
 
 #define MDM_BOOT_MODE_SPECIAL		0
 #define MDM_BOOT_MODE_NORMAL		1
@@ -1487,7 +1487,7 @@ static int wncm14a2a_init(const struct device *dev)
 	ictx.mdm_ctx.data_imei = ictx.mdm_imei;
 #endif
 
-	ret = mdm_receiver_register(&ictx.mdm_ctx, MDM_UART_DEV_NAME,
+	ret = mdm_receiver_register(&ictx.mdm_ctx, MDM_UART_DEV,
 				    mdm_recv_buf, sizeof(mdm_recv_buf));
 	if (ret < 0) {
 		LOG_ERR("Error registering modem receiver (%d)!", ret);

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1104,7 +1104,7 @@ static int esp_init(const struct device *dev)
 	data->iface_data.rx_rb_buf = &data->iface_rb_buf[0];
 	data->iface_data.rx_rb_buf_len = sizeof(data->iface_rb_buf);
 	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data,
-				    DT_INST_BUS_LABEL(0));
+				    DEVICE_DT_GET(DT_INST_BUS(0)));
 	if (ret < 0) {
 		goto error;
 	}

--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -27,3 +27,11 @@ void main(void)
 DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio), NULL, NULL, NULL, NULL,
 		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 #endif
+
+#if DT_NODE_EXISTS(DT_INST(0, vnd_serial))
+/* Fake serial device, needed for building drivers that use DEVICE_DT_GET()
+ * to access serial bus.
+ */
+DEVICE_DT_DEFINE(DT_INST(0, vnd_serial), NULL, NULL, NULL, NULL,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+#endif


### PR DESCRIPTION
So far modem API used UART device names / labels. Change API to operate
on device pointers instead, so that we stop using device_get_binding()
in modem core and in some DT compatible modem drivers.

Signed-off-by: Marcin Niestroj <m.niestroj@emb.dev>