### PR TITLE
drivers: sensor: clean up zephyr_library calls

### DIFF
--- a/drivers/sensor/adt7420/CMakeLists.txt
+++ b/drivers/sensor/adt7420/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ADT7420 adt7420.c)
+zephyr_library_sources(adt7420.c)
 zephyr_library_sources_ifdef(CONFIG_ADT7420_TRIGGER adt7420_trigger.c)

--- a/drivers/sensor/adxl345/CMakeLists.txt
+++ b/drivers/sensor/adxl345/CMakeLists.txt
@@ -5,4 +5,4 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ADXL345 adxl345.c)
+zephyr_library_sources(adxl345.c)

--- a/drivers/sensor/adxl362/CMakeLists.txt
+++ b/drivers/sensor/adxl362/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ADXL362 adxl362.c)
+zephyr_library_sources(adxl362.c)
 zephyr_library_sources_ifdef(CONFIG_ADXL362_TRIGGER adxl362_trigger.c)

--- a/drivers/sensor/adxl372/CMakeLists.txt
+++ b/drivers/sensor/adxl372/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ADXL372 adxl372.c)
+zephyr_library_sources(adxl372.c)
 zephyr_library_sources_ifdef(CONFIG_ADXL372_TRIGGER adxl372_trigger.c)

--- a/drivers/sensor/ak8975/CMakeLists.txt
+++ b/drivers/sensor/ak8975/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_AK8975 ak8975.c)
+zephyr_library_sources(ak8975.c)

--- a/drivers/sensor/amg88xx/CMakeLists.txt
+++ b/drivers/sensor/amg88xx/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_AMG88XX amg88xx.c)
+zephyr_library_sources(amg88xx.c)
 zephyr_library_sources_ifdef(CONFIG_AMG88XX_TRIGGER amg88xx_trigger.c)

--- a/drivers/sensor/ams_iAQcore/CMakeLists.txt
+++ b/drivers/sensor/ams_iAQcore/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_AMS_IAQ_CORE iAQcore.c)
+zephyr_library_sources(iAQcore.c)

--- a/drivers/sensor/apds9960/CMakeLists.txt
+++ b/drivers/sensor/apds9960/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_APDS9960 apds9960.c)
+zephyr_library_sources(apds9960.c)
 zephyr_library_sources_ifdef(CONFIG_APDS9960_TRIGGER apds9960_trigger.c)

--- a/drivers/sensor/bma280/CMakeLists.txt
+++ b/drivers/sensor/bma280/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMA280 bma280.c)
+zephyr_library_sources(bma280.c)
 zephyr_library_sources_ifdef(CONFIG_BMA280_TRIGGER bma280_trigger.c)

--- a/drivers/sensor/bmc150_magn/CMakeLists.txt
+++ b/drivers/sensor/bmc150_magn/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMC150_MAGN bmc150_magn.c)
+zephyr_library_sources(bmc150_magn.c)
 zephyr_library_sources_ifdef(CONFIG_BMC150_MAGN_TRIGGER bmc150_magn_trigger.c)

--- a/drivers/sensor/bme280/CMakeLists.txt
+++ b/drivers/sensor/bme280/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BME280 bme280.c bme280_spi.c bme280_i2c.c)
+zephyr_library_sources(bme280.c bme280_spi.c bme280_i2c.c)

--- a/drivers/sensor/bme680/CMakeLists.txt
+++ b/drivers/sensor/bme680/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BME680 bme680.c)
+zephyr_library_sources(bme680.c)

--- a/drivers/sensor/bmg160/CMakeLists.txt
+++ b/drivers/sensor/bmg160/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMG160 bmg160.c)
+zephyr_library_sources(bmg160.c)
 zephyr_library_sources_ifdef(CONFIG_BMG160_TRIGGER bmg160_trigger.c)

--- a/drivers/sensor/bmi160/CMakeLists.txt
+++ b/drivers/sensor/bmi160/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMI160 bmi160.c)
+zephyr_library_sources(bmi160.c)
 zephyr_library_sources_ifdef(CONFIG_BMI160_TRIGGER bmi160_trigger.c)

--- a/drivers/sensor/bmi270/CMakeLists.txt
+++ b/drivers/sensor/bmi270/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMI270 bmi270.c)
+zephyr_library_sources(bmi270.c)

--- a/drivers/sensor/bmm150/CMakeLists.txt
+++ b/drivers/sensor/bmm150/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMM150 bmm150.c)
+zephyr_library_sources(bmm150.c)

--- a/drivers/sensor/bq274xx/CMakeLists.txt
+++ b/drivers/sensor/bq274xx/CMakeLists.txt
@@ -4,4 +4,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BQ274XX bq274xx.c)
+zephyr_library_sources(bq274xx.c)

--- a/drivers/sensor/ccs811/CMakeLists.txt
+++ b/drivers/sensor/ccs811/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_CCS811 ccs811.c)
+zephyr_library_sources(ccs811.c)
 zephyr_library_sources_ifdef(CONFIG_CCS811_TRIGGER ccs811_trigger.c)

--- a/drivers/sensor/dht/CMakeLists.txt
+++ b/drivers/sensor/dht/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_DHT dht.c)
+zephyr_library_sources(dht.c)

--- a/drivers/sensor/dps310/CMakeLists.txt
+++ b/drivers/sensor/dps310/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_DPS310 dps310.c)
+zephyr_library_sources(dps310.c)

--- a/drivers/sensor/ens210/CMakeLists.txt
+++ b/drivers/sensor/ens210/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ENS210 ens210.c)
+zephyr_library_sources(ens210.c)

--- a/drivers/sensor/fdc2x1x/CMakeLists.txt
+++ b/drivers/sensor/fdc2x1x/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_FDC2X1X fdc2x1x.c)
+zephyr_library_sources(fdc2x1x.c)
 zephyr_library_sources_ifdef(CONFIG_FDC2X1X_TRIGGER fdc2x1x_trigger.c)

--- a/drivers/sensor/fxas21002/CMakeLists.txt
+++ b/drivers/sensor/fxas21002/CMakeLists.txt
@@ -6,5 +6,5 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_FXAS21002 fxas21002.c)
+zephyr_library_sources(fxas21002.c)
 zephyr_library_sources_ifdef(CONFIG_FXAS21002_TRIGGER fxas21002_trigger.c)

--- a/drivers/sensor/fxos8700/CMakeLists.txt
+++ b/drivers/sensor/fxos8700/CMakeLists.txt
@@ -6,5 +6,5 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_FXOS8700 fxos8700.c)
+zephyr_library_sources(fxos8700.c)
 zephyr_library_sources_ifdef(CONFIG_FXOS8700_TRIGGER fxos8700_trigger.c)

--- a/drivers/sensor/hmc5883l/CMakeLists.txt
+++ b/drivers/sensor/hmc5883l/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_HMC5883L hmc5883l.c)
+zephyr_library_sources(hmc5883l.c)
 zephyr_library_sources_ifdef(CONFIG_HMC5883L_TRIGGER hmc5883l_trigger.c)

--- a/drivers/sensor/hp206c/CMakeLists.txt
+++ b/drivers/sensor/hp206c/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_HP206C hp206c.c)
+zephyr_library_sources(hp206c.c)

--- a/drivers/sensor/hts221/CMakeLists.txt
+++ b/drivers/sensor/hts221/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_HTS221 hts221.c)
+zephyr_library_sources(hts221.c)
 zephyr_library_sources_ifdef(CONFIG_HTS221_TRIGGER hts221_trigger.c)

--- a/drivers/sensor/icm42605/CMakeLists.txt
+++ b/drivers/sensor/icm42605/CMakeLists.txt
@@ -2,9 +2,7 @@
 
 zephyr_library()
 
-if (CONFIG_ICM42605)
-  zephyr_library_sources(icm42605.c)
-  zephyr_library_sources(icm42605_setup.c)
-  zephyr_library_sources_ifdef(CONFIG_SPI icm42605_spi.c)
-  zephyr_library_sources_ifdef(CONFIG_ICM42605_TRIGGER icm42605_trigger.c)
-endif()
+zephyr_library_sources(icm42605.c)
+zephyr_library_sources(icm42605_setup.c)
+zephyr_library_sources_ifdef(CONFIG_SPI icm42605_spi.c)
+zephyr_library_sources_ifdef(CONFIG_ICM42605_TRIGGER icm42605_trigger.c)

--- a/drivers/sensor/iis2dh/CMakeLists.txt
+++ b/drivers/sensor/iis2dh/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_IIS2DH            iis2dh)
-zephyr_library_sources_ifdef(CONFIG_IIS2DH            iis2dh_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_IIS2DH            iis2dh_spi.c)
+zephyr_library_sources(iis2dh.c)
+zephyr_library_sources(iis2dh_i2c.c)
+zephyr_library_sources(iis2dh_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2DH_TRIGGER    iis2dh_trigger.c)

--- a/drivers/sensor/iis2dlpc/CMakeLists.txt
+++ b/drivers/sensor/iis2dlpc/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_IIS2DLPC            iis2dlpc)
+zephyr_library_sources(iis2dlpc.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2DLPC_TRIGGER    iis2dlpc_trigger.c)
 
 zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/iis2iclx/CMakeLists.txt
+++ b/drivers/sensor/iis2iclx/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_IIS2ICLX            iis2iclx.c)
+zephyr_library_sources(iis2iclx.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2ICLX_SENSORHUB  iis2iclx_shub.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2ICLX_TRIGGER    iis2iclx_trigger.c)
 

--- a/drivers/sensor/iis2mdc/CMakeLists.txt
+++ b/drivers/sensor/iis2mdc/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_IIS2MDC iis2mdc.c)
-zephyr_library_sources_ifdef(CONFIG_IIS2MDC iis2mdc_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_IIS2MDC iis2mdc_spi.c)
+zephyr_library_sources(iis2mdc.c)
+zephyr_library_sources(iis2mdc_i2c.c)
+zephyr_library_sources(iis2mdc_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2MDC_TRIGGER iis2mdc_trigger.c)

--- a/drivers/sensor/iis3dhhc/CMakeLists.txt
+++ b/drivers/sensor/iis3dhhc/CMakeLists.txt
@@ -6,6 +6,6 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_IIS3DHHC            iis3dhhc.c)
-zephyr_library_sources_ifdef(CONFIG_IIS3DHHC            iis3dhhc_spi.c)
+zephyr_library_sources(iis3dhhc.c)
+zephyr_library_sources(iis3dhhc_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS3DHHC_TRIGGER    iis3dhhc_trigger.c)

--- a/drivers/sensor/isl29035/CMakeLists.txt
+++ b/drivers/sensor/isl29035/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ISL29035 isl29035.c)
+zephyr_library_sources(isl29035.c)
 zephyr_library_sources_ifdef(CONFIG_ISL29035_TRIGGER isl29035_trigger.c)

--- a/drivers/sensor/ism330dhcx/CMakeLists.txt
+++ b/drivers/sensor/ism330dhcx/CMakeLists.txt
@@ -6,8 +6,8 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ISM330DHCX            ism330dhcx.c)
-zephyr_library_sources_ifdef(CONFIG_ISM330DHCX            ism330dhcx_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_ISM330DHCX            ism330dhcx_spi.c)
+zephyr_library_sources(ism330dhcx.c)
+zephyr_library_sources(ism330dhcx_i2c.c)
+zephyr_library_sources(ism330dhcx_spi.c)
 zephyr_library_sources_ifdef(CONFIG_ISM330DHCX_SENSORHUB  ism330dhcx_shub.c)
 zephyr_library_sources_ifdef(CONFIG_ISM330DHCX_TRIGGER    ism330dhcx_trigger.c)

--- a/drivers/sensor/lis2dh/CMakeLists.txt
+++ b/drivers/sensor/lis2dh/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LIS2DH lis2dh.c)
-zephyr_library_sources_ifdef(CONFIG_LIS2DH lis2dh_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_LIS2DH lis2dh_spi.c)
+zephyr_library_sources(lis2dh.c)
+zephyr_library_sources(lis2dh_i2c.c)
+zephyr_library_sources(lis2dh_spi.c)
 zephyr_library_sources_ifdef(CONFIG_LIS2DH_TRIGGER lis2dh_trigger.c)

--- a/drivers/sensor/lis2ds12/CMakeLists.txt
+++ b/drivers/sensor/lis2ds12/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LIS2DS12            lis2ds12)
-zephyr_library_sources_ifdef(CONFIG_LIS2DS12            lis2ds12_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_LIS2DS12            lis2ds12_spi.c)
+zephyr_library_sources(lis2ds12.c)
+zephyr_library_sources(lis2ds12_i2c.c)
+zephyr_library_sources(lis2ds12_spi.c)
 zephyr_library_sources_ifdef(CONFIG_LIS2DS12_TRIGGER    lis2ds12_trigger.c)

--- a/drivers/sensor/lis2dw12/CMakeLists.txt
+++ b/drivers/sensor/lis2dw12/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LIS2DW12            lis2dw12)
+zephyr_library_sources(lis2dw12.c)
 zephyr_library_sources_ifdef(CONFIG_LIS2DW12_TRIGGER    lis2dw12_trigger.c)
 
 zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/lis2mdl/CMakeLists.txt
+++ b/drivers/sensor/lis2mdl/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_LIS2MDL lis2mdl.c)
+zephyr_library_sources(lis2mdl.c)
 zephyr_library_sources_ifdef(CONFIG_LIS2MDL_TRIGGER lis2mdl_trigger.c)
 
 zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/lis3mdl/CMakeLists.txt
+++ b/drivers/sensor/lis3mdl/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LIS3MDL lis3mdl.c)
+zephyr_library_sources(lis3mdl.c)
 zephyr_library_sources_ifdef(CONFIG_LIS3MDL_TRIGGER lis3mdl_trigger.c)

--- a/drivers/sensor/lps22hb/CMakeLists.txt
+++ b/drivers/sensor/lps22hb/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LPS22HB lps22hb.c)
+zephyr_library_sources(lps22hb.c)

--- a/drivers/sensor/lps22hh/CMakeLists.txt
+++ b/drivers/sensor/lps22hh/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LPS22HH            lps22hh.c)
-zephyr_library_sources_ifdef(CONFIG_LPS22HH            lps22hh_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_LPS22HH            lps22hh_spi.c)
+zephyr_library_sources(lps22hh.c)
+zephyr_library_sources(lps22hh_i2c.c)
+zephyr_library_sources(lps22hh_spi.c)
 zephyr_library_sources_ifdef(CONFIG_LPS22HH_TRIGGER    lps22hh_trigger.c)

--- a/drivers/sensor/lps25hb/CMakeLists.txt
+++ b/drivers/sensor/lps25hb/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LPS25HB lps25hb.c)
+zephyr_library_sources(lps25hb.c)

--- a/drivers/sensor/lsm6ds0/CMakeLists.txt
+++ b/drivers/sensor/lsm6ds0/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM6DS0 lsm6ds0.c)
+zephyr_library_sources(lsm6ds0.c)

--- a/drivers/sensor/lsm6dsl/CMakeLists.txt
+++ b/drivers/sensor/lsm6dsl/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM6DSL            lsm6dsl.c)
-zephyr_library_sources_ifdef(CONFIG_LSM6DSL            lsm6dsl_spi.c)
-zephyr_library_sources_ifdef(CONFIG_LSM6DSL            lsm6dsl_i2c.c)
+zephyr_library_sources(lsm6dsl.c)
+zephyr_library_sources(lsm6dsl_spi.c)
+zephyr_library_sources(lsm6dsl_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_LSM6DSL_TRIGGER    lsm6dsl_trigger.c)
 zephyr_library_sources_ifdef(CONFIG_LSM6DSL_SENSORHUB  lsm6dsl_shub.c)

--- a/drivers/sensor/lsm6dso/CMakeLists.txt
+++ b/drivers/sensor/lsm6dso/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM6DSO            lsm6dso.c)
+zephyr_library_sources(lsm6dso.c)
 zephyr_library_sources_ifdef(CONFIG_LSM6DSO_SENSORHUB  lsm6dso_shub.c)
 zephyr_library_sources_ifdef(CONFIG_LSM6DSO_TRIGGER    lsm6dso_trigger.c)
 

--- a/drivers/sensor/lsm9ds0_gyro/CMakeLists.txt
+++ b/drivers/sensor/lsm9ds0_gyro/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM9DS0_GYRO lsm9ds0_gyro.c)
+zephyr_library_sources(lsm9ds0_gyro.c)
 zephyr_library_sources_ifdef(CONFIG_LSM9DS0_GYRO_TRIGGER_DRDY lsm9ds0_gyro_trigger.c)

--- a/drivers/sensor/lsm9ds0_mfd/CMakeLists.txt
+++ b/drivers/sensor/lsm9ds0_mfd/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_LSM9DS0_MFD lsm9ds0_mfd.c)
+zephyr_library_sources(lsm9ds0_mfd.c)

--- a/drivers/sensor/max17055/CMakeLists.txt
+++ b/drivers/sensor/max17055/CMakeLists.txt
@@ -4,4 +4,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MAX17055 max17055.c)
+zephyr_library_sources(max17055.c)

--- a/drivers/sensor/max17262/CMakeLists.txt
+++ b/drivers/sensor/max17262/CMakeLists.txt
@@ -4,4 +4,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MAX17262 max17262.c)
+zephyr_library_sources(max17262.c)

--- a/drivers/sensor/max30101/CMakeLists.txt
+++ b/drivers/sensor/max30101/CMakeLists.txt
@@ -6,4 +6,4 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MAX30101 max30101.c)
+zephyr_library_sources(max30101.c)

--- a/drivers/sensor/max44009/CMakeLists.txt
+++ b/drivers/sensor/max44009/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MAX44009 max44009.c)
+zephyr_library_sources(max44009.c)

--- a/drivers/sensor/max6675/CMakeLists.txt
+++ b/drivers/sensor/max6675/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_MAX6675 max6675.c)
+zephyr_library_sources(max6675.c)

--- a/drivers/sensor/mchp_tach_xec/CMakeLists.txt
+++ b/drivers/sensor/mchp_tach_xec/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TACH_XEC tach_mchp_xec.c)
+zephyr_library_sources(tach_mchp_xec.c)

--- a/drivers/sensor/mcp9808/CMakeLists.txt
+++ b/drivers/sensor/mcp9808/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MCP9808 mcp9808.c)
+zephyr_library_sources(mcp9808.c)
 zephyr_library_sources_ifdef(CONFIG_MCP9808_TRIGGER mcp9808_trigger.c)

--- a/drivers/sensor/mcux_acmp/CMakeLists.txt
+++ b/drivers/sensor/mcux_acmp/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_MCUX_ACMP mcux_acmp.c)
+zephyr_library_sources(mcux_acmp.c)

--- a/drivers/sensor/mpr/CMakeLists.txt
+++ b/drivers/sensor/mpr/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MPR mpr.c)
+zephyr_library_sources(mpr.c)

--- a/drivers/sensor/mpu6050/CMakeLists.txt
+++ b/drivers/sensor/mpu6050/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MPU6050 mpu6050.c)
+zephyr_library_sources(mpu6050.c)
 zephyr_library_sources_ifdef(CONFIG_MPU6050_TRIGGER mpu6050_trigger.c)

--- a/drivers/sensor/ms5607/CMakeLists.txt
+++ b/drivers/sensor/ms5607/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Thomas Schmid <tom@lfence.de>
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607.c)
-zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607_i2c.c)
+zephyr_library_sources(ms5607.c)
+zephyr_library_sources(ms5607_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_MS5607            ms5607_spi.c)

--- a/drivers/sensor/nuvoton_tach_npcx/CMakeLists.txt
+++ b/drivers/sensor/nuvoton_tach_npcx/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TACH_NPCX tach_nuvoton_npcx.c)
+zephyr_library_sources(tach_nuvoton_npcx.c)

--- a/drivers/sensor/nxp_kinetis_temp/CMakeLists.txt
+++ b/drivers/sensor/nxp_kinetis_temp/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TEMP_KINETIS temp_kinetis.c)
+zephyr_library_sources(temp_kinetis.c)

--- a/drivers/sensor/opt3001/CMakeLists.txt
+++ b/drivers/sensor/opt3001/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_OPT3001 opt3001.c)
+zephyr_library_sources(opt3001.c)

--- a/drivers/sensor/pms7003/CMakeLists.txt
+++ b/drivers/sensor/pms7003/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_PMS7003 pms7003.c)
+zephyr_library_sources(pms7003.c)

--- a/drivers/sensor/sbs_gauge/CMakeLists.txt
+++ b/drivers/sensor/sbs_gauge/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SBS_GAUGE sbs_gauge.c)
+zephyr_library_sources(sbs_gauge.c)

--- a/drivers/sensor/sht3xd/CMakeLists.txt
+++ b/drivers/sensor/sht3xd/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SHT3XD sht3xd.c)
+zephyr_library_sources(sht3xd.c)
 zephyr_library_sources_ifdef(CONFIG_SHT3XD_TRIGGER sht3xd_trigger.c)

--- a/drivers/sensor/si7006/CMakeLists.txt
+++ b/drivers/sensor/si7006/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
- zephyr_library()
+zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SI7006 si7006.c)
+zephyr_library_sources(si7006.c)

--- a/drivers/sensor/si7055/CMakeLists.txt
+++ b/drivers/sensor/si7055/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SI7055 si7055.c)
+zephyr_library_sources(si7055.c)

--- a/drivers/sensor/si7060/CMakeLists.txt
+++ b/drivers/sensor/si7060/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SI7060 si7060.c)
+zephyr_library_sources(si7060.c)

--- a/drivers/sensor/sm351lt/CMakeLists.txt
+++ b/drivers/sensor/sm351lt/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SM351LT sm351lt.c)
+zephyr_library_sources(sm351lt.c)

--- a/drivers/sensor/stm32_temp/CMakeLists.txt
+++ b/drivers/sensor/stm32_temp/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_STM32_TEMP stm32_temp.c)
+zephyr_library_sources(stm32_temp.c)

--- a/drivers/sensor/stts751/CMakeLists.txt
+++ b/drivers/sensor/stts751/CMakeLists.txt
@@ -6,6 +6,6 @@
 #
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_STTS751            stts751.c)
-zephyr_library_sources_ifdef(CONFIG_STTS751            stts751_i2c.c)
+zephyr_library_sources(stts751.c)
+zephyr_library_sources(stts751_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_STTS751_TRIGGER    stts751_trigger.c)

--- a/drivers/sensor/sx9500/CMakeLists.txt
+++ b/drivers/sensor/sx9500/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_SX9500 sx9500.c)
+zephyr_library_sources(sx9500.c)
 zephyr_library_sources_ifdef(CONFIG_SX9500_TRIGGER sx9500_trigger.c)

--- a/drivers/sensor/ti_hdc/CMakeLists.txt
+++ b/drivers/sensor/ti_hdc/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TI_HDC ti_hdc.c)
+zephyr_library_sources(ti_hdc.c)

--- a/drivers/sensor/tmp007/CMakeLists.txt
+++ b/drivers/sensor/tmp007/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TMP007 tmp007.c)
+zephyr_library_sources(tmp007.c)
 zephyr_library_sources_ifdef(CONFIG_TMP007_TRIGGER tmp007_trigger.c)

--- a/drivers/sensor/tmp112/CMakeLists.txt
+++ b/drivers/sensor/tmp112/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TMP112 tmp112.c)
+zephyr_library_sources(tmp112.c)

--- a/drivers/sensor/tmp116/CMakeLists.txt
+++ b/drivers/sensor/tmp116/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_TMP116 tmp116.c)
+zephyr_library_sources(tmp116.c)

--- a/drivers/sensor/vcnl4040/CMakeLists.txt
+++ b/drivers/sensor/vcnl4040/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_VCNL4040 vcnl4040.c)
+zephyr_library_sources(vcnl4040.c)
 zephyr_library_sources_ifdef(CONFIG_VCNL4040_TRIGGER vcnl4040_trigger.c)

--- a/drivers/sensor/wsen_itds/CMakeLists.txt
+++ b/drivers/sensor/wsen_itds/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ITDS itds.c)
+zephyr_library_sources(itds.c)
 zephyr_library_sources_ifdef(CONFIG_ITDS_TRIGGER itds_trigger.c)


### PR DESCRIPTION
In drivers/sensor/CMakeLists.txt, we have various lines like this:

```
    add_subdirectory_ifdef(CONFIG_FOO foo)
```

Then drivers/sensor/foo/CMakeLists.txt says:

```
    zephyr_library()
    zephyr_library_sources_ifdef(CONFIG_FOO foo.c)
```

This is redundant; the foo/CMakeLists.txt won't be added to the build
system unless CONFIG_FOO=y in the first place, so there's no need for
extra boilerplate testing it again.

Remove all these unnecessary instances in each sensor driver's
CMakeLists.txt using this pattern:

```
    zephyr_library()
    zephyr_library_sources(foo.c)
```

In a couple of places, the '.c' extension is missing. Add them in for
consistency when that happens.
