### PR TITLE
kernel: Fix negative mutex lock_count value

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -230,7 +230,7 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	 * If we are the owner and count is greater than 1, then decrement
 	 * the count and return and keep current thread as the owner.
 	 */
-	if (mutex->lock_count - 1U != 0U) {
+	if (mutex->lock_count > 1U) {
 		mutex->lock_count--;
 		goto k_mutex_unlock_return;
 	}


### PR DESCRIPTION
If you try to unlock an unlocked mutex, it will incorrectly
succeeds and decreases the lock count to -1.

Fixes #36572

Signed-off-by: Chih Hung Yu <chyu313@gmail.com>