### PR TITLE
Configurable Openthread assert

### DIFF
--- a/subsys/net/lib/openthread/platform/misc.c
+++ b/subsys/net/lib/openthread/platform/misc.c
@@ -30,3 +30,8 @@ void otPlatWakeHost(void)
 {
 	/* TODO */
 }
+
+void otPlatAssertFail(const char *aFilename, int aLineNumber)
+{
+	__ASSERT(false, "OpenThread ASSERT @ %s:%d", aFilename, aLineNumber);
+}

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -18,6 +18,16 @@
 #include <toolchain.h>
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+ *
+ * The assert is managed by platform defined logic when this flag is set.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+#define OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS
  *
  * The number of message buffers in the buffer pool.

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
       path: modules/lib/loramac-node
     - name: openthread
-      revision: f460532d4afa5d49feba241e5dc31c56123d31a8
+      revision: d7eaf6f421569bb9f6be64db4c8108e53e4278b6
       path: modules/lib/openthread
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6


### PR DESCRIPTION
This PR forwards the OpenThread assert to zephyr by default and enables it based on the `CONFIG_ASSERT` option.