### PR TITLE
tests: kernel: device: Exclude beaglev_starlight_jh7100

### DIFF
--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -7,6 +7,6 @@ tests:
     tags: kernel device
   kernel.device.pm:
     tags: kernel device
-    platform_exclude: mec15xxevb_assy6853
+    platform_exclude: mec15xxevb_assy6853 beaglev_starlight_jh7100
     extra_configs:
       - CONFIG_PM_DEVICE=y


### PR DESCRIPTION
The beaglev_starlight_jh7100 uses a full 64-bit devicetree map
which uses #{address/size}-cells = 2.  The device test expects
that #{address/size}-cells = 1 so exclude beaglev_starlight_jh7100
from the test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>