### PR TITLE
drivers: clock_control_nrf: Add configuration of HFCLKAUDIO frequency

### DIFF
--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -16,3 +16,12 @@ properties:
 
     interrupts:
       required: true
+
+    hfclkaudio-frequency:
+      type: int
+      required: false
+      description: |
+        Frequency of the HFCLKAUDIO clock in Hz. Adjustable with 3.3 ppm
+        resolution in two frequency bands - 11.176 MHz to 11.402 MHz, and
+        12.165 MHz to 12.411 MHz (refer to the relevant Product Specification).
+        The HFCLKAUDIO clock is only available in the nRF53 Series SoCs.


### PR DESCRIPTION
Add a new property to the "nordic,nrf-clock" binding to allow
configuration of the HFCLKAUDIO frequency.

Needed for #34251.