### PR TITLE
bluetooth: ots: Make OTS Object Reads use POSIX parameter types

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -23,6 +23,7 @@ extern "C" {
 
 #include <zephyr/types.h>
 #include <sys/byteorder.h>
+#include <sys/types.h>
 #include <sys/util.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
@@ -541,10 +542,11 @@ struct bt_ots_cb {
 	 *
 	 *  @return Data length to be sent via data parameter. This value
 	 *          shall be smaller or equal to the len parameter.
+	 *  @return Negative value in case of an error.
 	 */
-	uint32_t (*obj_read)(struct bt_ots *ots, struct bt_conn *conn,
-			     uint64_t id, uint8_t **data, uint32_t len,
-			     uint32_t offset);
+	ssize_t (*obj_read)(struct bt_ots *ots, struct bt_conn *conn,
+			   uint64_t id, void **data, size_t len,
+			   off_t offset);
 
 	/** @brief Object name written callback
 	 *

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -105,9 +105,9 @@ static void ots_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 	printk("Object with %s ID has been selected\n", id_str);
 }
 
-static uint32_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
-			     uint64_t id, uint8_t **data, uint32_t len,
-			     uint32_t offset)
+static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
+			   uint64_t id, void **data, size_t len,
+			   off_t offset)
 {
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint32_t obj_index = (id % ARRAY_SIZE(objects));
@@ -131,8 +131,8 @@ static uint32_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 	}
 
 	printk("Object with %s ID is being read\n"
-		"Offset = %d, Length = %d\n",
-		id_str, offset, len);
+		"Offset = %lu, Length = %zu\n",
+		id_str, (long)offset, len);
 
 	return len;
 }

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -241,8 +241,8 @@ void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager)
 	dir_list_encode(*dir_list, obj_manager);
 }
 
-int bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, uint8_t **data,
-				uint32_t len, uint32_t offset)
+ssize_t bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, void **data,
+				size_t len, off_t offset)
 {
 	if (offset >= dir_list->net_buf.len) {
 		*data = NULL;

--- a/subsys/bluetooth/services/ots/ots_dir_list_internal.h
+++ b/subsys/bluetooth/services/ots/ots_dir_list_internal.h
@@ -147,8 +147,8 @@ void bt_ots_dir_list_obj_remove(struct bt_ots_dir_list *dir_list, void *obj_mana
 void bt_ots_dir_list_selected(struct bt_ots_dir_list *dir_list, void *obj_manager,
 			      struct bt_gatt_ots_object *cur_obj);
 void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager);
-int bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, uint8_t **data,
-				uint32_t len, uint32_t offset);
+ssize_t bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, void **data,
+				size_t len, off_t offset);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -210,5 +210,10 @@ int bt_gatt_ots_l2cap_unregister(struct bt_gatt_ots_l2cap *l2cap_ctx)
 	return 0;
 }
 
+int bt_gatt_ots_l2cap_disconnect(struct bt_gatt_ots_l2cap *l2cap_ctx)
+{
+	return bt_l2cap_chan_disconnect(&l2cap_ctx->ot_chan.chan);
+}
+
 SYS_INIT(bt_gatt_ots_l2cap_init, APPLICATION,
 	 CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/bluetooth/services/ots/ots_l2cap_internal.h
+++ b/subsys/bluetooth/services/ots/ots_l2cap_internal.h
@@ -41,6 +41,8 @@ int bt_gatt_ots_l2cap_register(struct bt_gatt_ots_l2cap *l2cap_ctx);
 
 int bt_gatt_ots_l2cap_unregister(struct bt_gatt_ots_l2cap *l2cap_ctx);
 
+int bt_gatt_ots_l2cap_disconnect(struct bt_gatt_ots_l2cap *l2cap_ctx);
+
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -180,9 +180,9 @@ static void oacp_read_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			      struct bt_conn *conn)
 {
 	int err;
-	uint8_t *obj_chunk;
-	uint32_t offset;
-	uint32_t len;
+	void *obj_chunk;
+	off_t offset;
+	ssize_t len;
 	struct bt_ots *ots;
 	struct bt_gatt_ots_object_read_op *read_op;
 
@@ -216,6 +216,15 @@ static void oacp_read_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 	} else {
 		len = ots->cb->obj_read(ots, conn, ots->cur_obj->id, &obj_chunk,
 					len, offset);
+	}
+
+	if (len < 0) {
+		LOG_ERR("OCAP Read Op failed with error: %d", len);
+
+		bt_gatt_ots_l2cap_disconnect(&ots->l2cap);
+		ots->cur_obj->state.type = BT_GATT_OTS_OBJECT_IDLE_STATE;
+
+		return;
 	}
 
 	ots->l2cap.tx_done = oacp_read_proc_cb;


### PR DESCRIPTION
It is desirable to have the read and write like functions follow the
POSIX read and write parameter types.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>