### PR TITLE
refactor: correct spells to that probably intended

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3735,12 +3735,12 @@ class CoverageTool:
         return t
 
     @staticmethod
-    def retrieve_gcov_data(intput_file):
-        logger.debug("Working on %s" % intput_file)
+    def retrieve_gcov_data(input_file):
+        logger.debug("Working on %s" % input_file)
         extracted_coverage_info = {}
         capture_data = False
         capture_complete = False
-        with open(intput_file, 'r') as fp:
+        with open(input_file, 'r') as fp:
             for line in fp.readlines():
                 if re.search("GCOV_COVERAGE_DUMP_START", line):
                     capture_data = True


### PR DESCRIPTION
Make correction on the terms "intput" appearing in sciripts/pylib/twister/twisterlib.py to "input" for all.

This type of misspellings may cause another unnoticeable misspellings, when propagated by code completions.

(assuming that the "intput" was intended to have the opposite meaning of "output", which also appear on the same areas)

Signed-off-by: Kentaro Sugimoto <tarotene@gmail.com>