### PR TITLE
misc: npcx: Add soc id node

### DIFF
--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -622,6 +622,11 @@
 			label = "PSL_OUT";
 		};
 	};
+
+	soc-id {
+		compatible = "nuvoton,npcx-soc-id";
+		family-id = <0x20>;
+	};
 };
 
 &nvic {

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -197,4 +197,9 @@
 				     &altf_adc9_sl>; /* ADC9 - PINF0 */
 		};
 	};
+
+	soc-id {
+		chip-id = <0x07>;
+		revision-reg = <0x00007FFC 1>;
+	};
 };

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -20,4 +20,8 @@
 		compatible = "mmio-sram";
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
+
+	soc-id {
+		device-id = <0x21>;
+	};
 };

--- a/dts/arm/nuvoton/npcx7m6fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fc.dtsi
@@ -20,4 +20,8 @@
 		compatible = "mmio-sram";
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
+
+	soc-id {
+		device-id = <0x29>;
+	};
 };

--- a/dts/arm/nuvoton/npcx7m7fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m7fc.dtsi
@@ -20,4 +20,8 @@
 		compatible = "mmio-sram";
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
+
+	soc-id {
+		device-id = <0x20>;
+	};
 };

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -223,4 +223,9 @@
 				     &altf_adc11_sl>; /* ADC11 - PINC7 */
 		};
 	};
+
+	soc-id {
+		chip-id = <0x09>;
+		revision-reg = <0x0000FFFC 4>;
+	};
 };

--- a/dts/arm/nuvoton/npcx9m3f.dtsi
+++ b/dts/arm/nuvoton/npcx9m3f.dtsi
@@ -20,4 +20,8 @@
 		compatible = "mmio-sram";
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
+
+	soc-id {
+		device-id = <0x25>;
+	};
 };

--- a/dts/arm/nuvoton/npcx9m6f.dtsi
+++ b/dts/arm/nuvoton/npcx9m6f.dtsi
@@ -20,4 +20,8 @@
 		compatible = "mmio-sram";
 		reg = <0x200C0000 DT_SIZE_K(62)>;
 	};
+
+	soc-id {
+		device-id = <0x21>;
+	};
 };

--- a/dts/bindings/misc/nuvoton,npcx-soc-id.yaml
+++ b/dts/bindings/misc/nuvoton,npcx-soc-id.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX soc ID node
+
+compatible: "nuvoton,npcx-soc-id"
+
+properties:
+    family-id:
+        type: int
+        required: true
+        description: NPCX family ID
+
+    chip-id:
+        type: int
+        required: true
+        description: NPCX chip ID
+
+    device-id:
+        type: int
+        required: true
+        description: NPCX device ID
+
+    revision-reg:
+        type: array
+        required: true
+        description: NPCX revision register address & length in byte


### PR DESCRIPTION
Nuvoton provides different series MCU. The NPCX series has a specific
id, which can identify the real chip part number. This CL adds soc id
for the NPCX series.
```
soc-id {
		compatible = "nuvoton,npcx-soc-id";
		family-id = <0x20>;
		chip-id = <0xXX>;
		device-id = <0xXX>;
		revision-reg = <0xXXXXXXXX X>;
};
```