### PR TITLE
i2c: bitbang: Add I2C_MSG_RECV_LEN

### DIFF
--- a/include/drivers/i2c.h
+++ b/include/drivers/i2c.h
@@ -89,6 +89,12 @@ extern "C" {
  * @note Not all SoC I2C implementations support this feature. */
 #define I2C_MSG_ADDR_10_BITS		BIT(3)
 
+/** First received byte is the length of the response.
+ *
+ * @note Not all SoC I2C implementations support this feature.
+ */
+#define I2C_MSG_RECV_LEN		BIT(4)
+
 /**
  * @brief One I2C Message.
  *


### PR DESCRIPTION
Add support for I2C_MSG_RECV_LEN in bitbang driver.
Remove forced STOP at the beginning of a transfer sequence.

Signed-off-by: Vlad Tuhut <vlad.tuhut@raptor-technologies.ro>