### PR TITLE
riscv: openisa_rv32m1: Fix booting of rv32m1_vega

### DIFF
--- a/soc/riscv/openisa_rv32m1/Kconfig.soc
+++ b/soc/riscv/openisa_rv32m1/Kconfig.soc
@@ -17,6 +17,7 @@ config SOC_OPENISA_RV32M1_RISCV32
 	select CLOCK_CONTROL
 	select HAS_RV32M1_FTFX
 	select HAS_FLASH_LOAD_OFFSET
+	select BUILD_OUTPUT_HEX
 	help
 	  Enable support for OpenISA RV32M1 RISC-V processors. Choose
 	  this option to target the RI5CY or ZERO-RISCY core. This

--- a/soc/riscv/openisa_rv32m1/soc.c
+++ b/soc/riscv/openisa_rv32m1/soc.c
@@ -146,9 +146,7 @@ void soc_interrupt_init(void)
 	(void)(EVENT_UNIT->EVTPENDCLEAR); /* Ensures write has finished. */
 
 	if (IS_ENABLED(CONFIG_MULTI_LEVEL_INTERRUPTS)) {
-		dev_intmux = device_get_binding(
-				DT_LABEL(DT_INST(0, openisa_rv32m1_intmux)));
-		__ASSERT(dev_intmux, "no INTMUX device found");
+		dev_intmux = DEVICE_DT_GET(DT_INST(0, openisa_rv32m1_intmux));
 	}
 }
 


### PR DESCRIPTION
rv32m1_vega don't boot due to device init ordering and changes with the
device model.  The soc code is looking for a device pointer for the
intmux.  Change to using DEVICE_DT_GET here as that will ensure we get
a valid pointer and by the time we need to utilize the pointer the
intmux driver will have been initialized and thus the device pointer
will be ready.

Also set BUILD_OUTPUT_HEX since we utilize openocd to flash and west
flash is looking for a hex file for openocd targets.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>