### PR TITLE
drivers: adc: mcux_adc16: reduce log verbosity

### DIFF
--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -415,7 +415,7 @@ static int mcux_adc16_init(const struct device *dev)
 #else
 	config->irq_config_func(dev);
 #endif
-	LOG_INF("adc init done");
+	LOG_DBG("adc init done");
 
 	adc_context_unlock_unconditionally(&data->ctx);
 


### PR DESCRIPTION
Reduce the initialization done log message from informational to debug.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>