### PR TITLE
tests: net: socket: tls_ext: Add platform filter

### DIFF
--- a/tests/net/socket/tls_ext/testcase.yaml
+++ b/tests/net/socket/tls_ext/testcase.yaml
@@ -3,3 +3,4 @@ common:
 tests:
   net.socket.tls:
     min_ram: 65536
+    platform_allow: qemu_cortex_m3 qemu_x86


### PR DESCRIPTION
Network test cases are designed for emulated
environments so add platform_allowed filter to
only allow qemu platforms.

Fixes: #36418

Signed-off-by: David Leach <david.leach@nxp.com>