### PR TITLE
Add USB support for STM32G0 series

### DIFF
--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -65,6 +65,11 @@
 	apb1-prescaler = <1>;
 };
 
+&usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	status = "okay";
+};
+
 &usart1 {
 	pinctrl-0 = <&usart1_tx_pc4 &usart1_rx_pc5>;
 	current-speed = <115200>;

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
@@ -18,3 +18,4 @@ supported:
   - spi
   - nvs
   - dma
+  - usb_device

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -67,15 +67,16 @@ static const struct soc_gpio_pinctrl usb_pinctrl[] =
 			    DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs))
 
 /*
- * USB and USB_OTG_FS are defined in STM32Cube HAL and allows to distinguish
- * between two kind of USB DC. STM32 F0, F3, L0 and G4 series support USB device
- * controller. STM32 F4 and F7 series support USB_OTG_FS device controller.
- * STM32 F1 and L4 series support either USB or USB_OTG_FS device controller.
+ * USB, USB_OTG_FS and USB_DRD_FS are defined in STM32Cube HAL and allows to
+ * distinguish between two kind of USB DC. STM32 F0, F3, L0 and G4 series
+ * support USB device controller. STM32 F4 and F7 series support USB_OTG_FS
+ * device controller. STM32 F1 and L4 series support either USB or USB_OTG_FS
+ * device controller.STM32 G0 series supports USB_DRD_FS device controller.
  *
  * WARNING: Don't mix USB defined in STM32Cube HAL and CONFIG_USB from Zephyr
  * Kconfig system.
  */
-#ifdef USB
+#if defined(USB) || defined(USB_DRD_FS)
 
 #define EP0_MPS 64U
 #define EP_MPS 64U
@@ -145,7 +146,7 @@ struct usb_dc_stm32_state {
 	struct usb_dc_stm32_ep_state in_ep_state[USB_NUM_BIDIR_ENDPOINTS];
 	uint8_t ep_buf[USB_NUM_BIDIR_ENDPOINTS][EP_MPS];
 
-#ifdef USB
+#if defined(USB) || defined(USB_DRD_FS)
 	uint32_t pma_offset;
 #endif /* USB */
 };
@@ -344,8 +345,12 @@ static int usb_dc_stm32_init(void)
 	HAL_StatusTypeDef status;
 	unsigned int i;
 
+#if defined(USB) || defined(USB_DRD_FS)
 #ifdef USB
 	usb_dc_stm32_state.pcd.Instance = USB;
+#else
+	usb_dc_stm32_state.pcd.Instance = USB_DRD_FS;
+#endif
 	usb_dc_stm32_state.pcd.Init.speed = PCD_SPEED_FULL;
 	usb_dc_stm32_state.pcd.Init.dev_endpoints = USB_NUM_BIDIR_ENDPOINTS;
 	usb_dc_stm32_state.pcd.Init.phy_itface = PCD_PHY_EMBEDDED;
@@ -426,7 +431,7 @@ static int usb_dc_stm32_init(void)
 	usb_dc_stm32_state.in_ep_state[EP0_IDX].ep_mps = EP0_MPS;
 	usb_dc_stm32_state.in_ep_state[EP0_IDX].ep_type = EP_TYPE_CTRL;
 
-#ifdef USB
+#if defined(USB) || defined(USB_DRD_FS)
 	/* Start PMA configuration for the endpoints after the BTABLE. */
 	usb_dc_stm32_state.pma_offset = USB_BTABLE_SIZE;
 
@@ -628,7 +633,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const ep_cfg)
 		ep_cfg->ep_addr, ep_state->ep_mps, ep_cfg->ep_mps,
 		ep_cfg->ep_type);
 
-#ifdef USB
+#if defined(USB) || defined(USB_DRD_FS)
 	if (ep_cfg->ep_mps > ep_state->ep_pma_buf_len) {
 		if (USB_RAM_SIZE <=
 		    (usb_dc_stm32_state.pma_offset + ep_cfg->ep_mps)) {
@@ -1088,7 +1093,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 	}
 }
 
-#if defined(USB) && defined(CONFIG_USB_DC_STM32_DISCONN_ENABLE)
+#if (defined(USB) || defined(USB_DRD_FS)) && defined(CONFIG_USB_DC_STM32_DISCONN_ENABLE)
 void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 {
 	const struct device *usb_disconnect;

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -94,5 +94,24 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <12>;
 		};
+
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <8 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			phys = <&usb_fs_phy>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00002000>;
+			status = "disabled";
+			label= "USB";
+		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Thomas Stranger
+ * Copyright (c) 2021 G-Technologies Sdn. Bhd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -104,5 +105,24 @@
 			dma-channels = <12>;
 			dma-requests = <73>;
 		};
+
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <8 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			phys = <&usb_fs_phy>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00002000>;
+			status = "disabled";
+			label= "USB";
+		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };


### PR DESCRIPTION
Add USB support for STM32G0 series.
SVD file with USB added for STM32G0B1 series can be downloaded [here](https://gist.github.com/ycsin/8293fd5eeccdbdc7c939f6e138e31625).

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>