### PR TITLE
drivers: spi: stm32: Disable/enable SPI on LPM enter/exit

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -49,6 +49,9 @@ struct spi_stm32_data {
 	struct stream dma_rx;
 	struct stream dma_tx;
 #endif
+#ifdef CONFIG_PM_DEVICE
+	uint32_t pm_state;
+#endif
 };
 
 static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)


### PR DESCRIPTION
Add pm_control function to disable/enable SPI on LPM enter/exit.

Signed-off-by: Yong Cong Sin <yongcong.sin@gmail.com>