### PR TITLE
driver: intc: it8xxx2: wait until two equal interrupt values are read

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -173,9 +173,22 @@ void ite_intc_irq_handler(const void *arg)
 uint8_t get_irq(void *arg)
 {
 	ARG_UNUSED(arg);
-	intc_irq = IVECT - IVECT_OFFSET_WITH_IRQ;
 
+	/* wait until two equal interrupt values are read */
+	do {
+		/* Read interrupt number from interrupt vector register */
+		intc_irq = IVECT;
+		/*
+		 * WORKAROUND: when the interrupt vector register (IVECT)
+		 * isn't latched in a load operation, we read it again to make
+		 * sure the value we got is the correct value.
+		 */
+	} while (intc_irq != IVECT);
+	/* determine interrupt number */
+	intc_irq -= IVECT_OFFSET_WITH_IRQ;
+	/* clear interrupt status */
 	ite_intc_isr_clear(intc_irq);
+	/* return interrupt number */
 	return intc_irq;
 }
 

--- a/soc/riscv/riscv-ite/common/soc_irq.S
+++ b/soc/riscv/riscv-ite/common/soc_irq.S
@@ -22,16 +22,15 @@ GTEXT(__soc_handle_irq)
  * Exception number is given as parameter via register a0.
  */
 SECTION_FUNC(exception.other, __soc_handle_irq)
-	/* Clear exception number from CSR mip register */
-	li t1, 1
-	sll t0, t1, a0
-	csrrc t1, mip, t0
-	move t2,ra
-	call    get_irq
-	move ra,t2
-
-	/* Return */
-	jalr x0, ra
+	/* store ra */
+	addi sp, sp, -4
+	sw ra, 0(sp)
+	/* get interrupt number and clear interrupt status of soc */
+	call get_irq
+	/* restore ra */
+	lw ra, 0(sp)
+	addi sp, sp, 4
+	ret
 
 /*
  * __soc_is_irq is defined as .weak to allow re-implementation by


### PR DESCRIPTION
This change ensures the CPU won't get an interrupt number which is being generated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/36685)
<!-- Reviewable:end -->
