### PR TITLE
drivers: console: update USB_UART_CONSOLE description

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -107,11 +107,10 @@ config USB_UART_CONSOLE
 	select UART_CONSOLE
 	select USB_CDC_ACM
 	help
-	  Enable this option to use the USB UART for console output. The output
-	  can be viewed from the USB host via /dev/ttyACM* port. Note that console
-	  inputs from the USB UART are not functional yet. Also since the USB
-	  layer currently doesn't support multiple interfaces, this shouldn't be
-	  selected in conjunction with, say, USB Mass Storage.
+	  Enable this option to use the USB UART for console. The communication
+	  is done via /dev/ttyACM* virtual port. Since the USB layer currently
+	  doesn't support multiple interfaces, this shouldn't be selected
+	  in conjunction with, say, USB Mass Storage.
 
 config RAM_CONSOLE
 	bool "Use RAM console"


### PR DESCRIPTION
Since USB UART console works bidirectional from some while
the off-dated description is misleading and need to be fixed.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>