### PR TITLE
[TOPIC-BLE-LLCP] Bluetooth: controller: remove duplicate include

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -27,7 +27,6 @@
 #include "ull_tx_queue.h"
 
 #include "ull_internal.h"
-#include "ull_conn_llcp_internal.h"
 #include "ull_conn_types.h"
 #include "ull_conn_llcp_internal.h"
 #include "ull_llcp.h"


### PR DESCRIPTION
Remove the duplicate inclusion of ull_llcp_internal.h

Signed-off-by: Andries Kruithof <Andries.Kruithof@nordicsemi.no>