### PR TITLE
usb: enhance verification of the class control requests 

### DIFF
--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -132,6 +132,10 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 {
 	struct net_pkt *pkt;
 
+	if (usb_reqtype_is_to_host(setup)) {
+		return -ENOTSUP;
+	}
+
 	/* Maximum 2 bytes are added to the len */
 	pkt = net_pkt_alloc_with_buffer(NULL, *len + 2, AF_UNSPEC, 0,
 					K_NO_WAIT);

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -212,6 +212,10 @@ static const uint8_t msos1_compatid_descriptor[] = {
 int custom_handle_req(struct usb_setup_packet *pSetup,
 		      int32_t *len, uint8_t **data)
 {
+	if (usb_reqtype_is_to_device(pSetup)) {
+		return -ENOTSUP;
+	}
+
 	if (USB_GET_DESCRIPTOR_TYPE(pSetup->wValue) == USB_DESC_STRING &&
 	    USB_GET_DESCRIPTOR_INDEX(pSetup->wValue) == 0xEE) {
 		*data = (uint8_t *)(&msos1_string_descriptor);
@@ -238,6 +242,10 @@ int custom_handle_req(struct usb_setup_packet *pSetup,
 int vendor_handle_req(struct usb_setup_packet *pSetup,
 		      int32_t *len, uint8_t **data)
 {
+	if (usb_reqtype_is_to_device(pSetup)) {
+		return -ENOTSUP;
+	}
+
 	/* Get Allowed origins request */
 	if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x01) {
 		*data = (uint8_t *)(&webusb_allowed_origins);

--- a/subsys/usb/class/audio/audio.c
+++ b/subsys/usb/class/audio/audio.c
@@ -500,7 +500,7 @@ static struct usb_audio_dev_data *get_audio_dev_data_by_iface(uint8_t interface)
  * This function handles feature unit mute control request.
  *
  * @param audio_dev_data USB audio device data.
- * @param pSetup	 Information about the executed request.
+ * @param setup          Information about the executed request.
  * @param len		 Size of the buffer.
  * @param data		 Buffer containing the request result.
  * @param evt		 Feature Unit Event info.
@@ -510,32 +510,34 @@ static struct usb_audio_dev_data *get_audio_dev_data_by_iface(uint8_t interface)
  * @return 0 if succesfulf, negative errno otherwise.
  */
 static int handle_fu_mute_req(struct usb_audio_dev_data *audio_dev_data,
-			      struct usb_setup_packet *pSetup,
+			      struct usb_setup_packet *setup,
 			      int32_t *len, uint8_t **data,
 			      struct usb_audio_fu_evt *evt,
 			      uint8_t device)
 {
-	uint8_t ch = (pSetup->wValue) & 0xFF;
+	uint8_t ch = (setup->wValue) & 0xFF;
 	uint8_t ch_cnt = audio_dev_data->ch_cnt[device];
 	uint8_t *controls = audio_dev_data->controls[device];
 	uint8_t *control_val = &controls[POS(MUTE, ch, ch_cnt)];
 
-	/* Check if *len has valid value */
-	if (*len != LEN(1, MUTE)) {
-		return -EINVAL;
-	}
+	if (usb_reqtype_is_to_device(setup)) {
+		/* Check if *len has valid value */
+		if (*len != LEN(1, MUTE)) {
+			return -EINVAL;
+		}
 
-	switch (pSetup->bRequest) {
-	case USB_AUDIO_SET_CUR:
-		evt->val = control_val;
-		evt->val_len = *len;
-		memcpy(control_val, *data, *len);
-		return 0;
-	case USB_AUDIO_GET_CUR:
-		*data = control_val;
-		return 0;
-	default:
-		break;
+		if (setup->bRequest == USB_AUDIO_SET_CUR) {
+			evt->val = control_val;
+			evt->val_len = *len;
+			memcpy(control_val, *data, *len);
+			return 0;
+		}
+	} else {
+		if (setup->bRequest == USB_AUDIO_GET_CUR) {
+			*data = control_val;
+			*len = LEN(1, MUTE);
+			return 0;
+		}
 	}
 
 	return -EINVAL;
@@ -600,7 +602,8 @@ static int handle_feature_unit_req(struct usb_audio_dev_data *audio_dev_data,
 
 	/* Inform the app */
 	if (audio_dev_data->ops && audio_dev_data->ops->feature_update_cb) {
-		if (pSetup->bRequest == USB_AUDIO_SET_CUR) {
+		if (usb_reqtype_is_to_device(pSetup) &&
+		    pSetup->bRequest == USB_AUDIO_SET_CUR) {
 			evt.cs = cs;
 			evt.channel = ch;
 			evt.dir = get_fu_dir(fu);
@@ -691,7 +694,8 @@ static int audio_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
 
 	uint8_t iface = (pSetup->wIndex) & 0xFF;
 
-	if (pSetup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
+	if (pSetup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE ||
+	    usb_reqtype_is_to_host(pSetup)) {
 		return -EINVAL;
 	}
 

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -378,6 +378,11 @@ static int bluetooth_class_handler(struct usb_setup_packet *setup,
 {
 	struct net_buf *buf;
 
+	if (usb_reqtype_is_to_host(setup) ||
+	    setup->RequestType.type != USB_REQTYPE_TYPE_CLASS) {
+		return -ENOTSUP;
+	}
+
 	LOG_DBG("len %u", *len);
 
 	buf = bt_buf_get_tx(BT_BUF_CMD, K_NO_WAIT, *data, *len);

--- a/subsys/usb/class/bt_h4.c
+++ b/subsys/usb/class/bt_h4.c
@@ -202,23 +202,6 @@ static int bt_h4_vendor_handler(struct usb_setup_packet *setup,
 	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
-	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		return -ENOTSUP;
-	}
-
-	if (usb_reqtype_is_to_device(setup) &&
-	    setup->bRequest == 0x5b) {
-		LOG_DBG("Host-to-Device, data %p", *data);
-		return 0;
-	}
-
-	if ((usb_reqtype_is_to_host(setup)) &&
-	    (setup->bRequest == 0x5c)) {
-		LOG_DBG("Device-to-Host, wLength %d, data %p",
-			setup->wLength, *data);
-		return 0;
-	}
-
 	return -ENOTSUP;
 }
 

--- a/subsys/usb/class/dfu/usb_dfu.c
+++ b/subsys/usb/class/dfu/usb_dfu.c
@@ -439,7 +439,7 @@ static int dfu_class_handle_to_host(struct usb_setup_packet *setup,
 					dfu_data.block_nr, setup->wLength);
 				dfu_data.state = dfuERROR;
 				dfu_data.status = errUNKNOWN;
-				break;
+				return -EINVAL;
 			}
 
 			/* Upload in progress */
@@ -468,7 +468,7 @@ static int dfu_class_handle_to_host(struct usb_setup_packet *setup,
 				if (ret) {
 					dfu_data.state = dfuERROR;
 					dfu_data.status = errFILE;
-					break;
+					return -EINVAL;
 				}
 				ret = flash_area_read(fa, dfu_data.bytes_sent,
 						      *data, len);
@@ -476,7 +476,7 @@ static int dfu_class_handle_to_host(struct usb_setup_packet *setup,
 				if (ret) {
 					dfu_data.state = dfuERROR;
 					dfu_data.status = errFILE;
-					break;
+					return -EINVAL;
 				}
 			}
 			*data_len = len;

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -496,7 +496,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 {
 	LOG_DBG("Standard request:"
 		"bRequest 0x%02x, bmRequestType 0x%02x, len %d",
-		setup->bRequest, setup->bmRequestType, *len);
+		setup->bRequest, setup->bmRequestType, setup->wLength);
 
 	if (usb_reqtype_is_to_host(setup) &&
 	    setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE &&
@@ -524,21 +524,13 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 
 			LOG_DBG("Return HID Descriptor");
 
-			*len = MIN(*len, hid_desc->if0_hid.bLength);
+			*len = MIN(setup->wLength, hid_desc->if0_hid.bLength);
 			*data = (uint8_t *)&hid_desc->if0_hid;
 			break;
 		case USB_DESC_HID_REPORT:
 			LOG_DBG("Return Report Descriptor");
 
-			/* Some buggy system may be pass a larger wLength when
-			 * it try read HID report descriptor, although we had
-			 * already tell it the right descriptor size.
-			 * So truncated wLength if it doesn't match. */
-			if (*len != dev_data->report_size) {
-				LOG_WRN("len %d doesn't match "
-					"Report Descriptor size", *len);
-				*len = MIN(*len, dev_data->report_size);
-			}
+			*len = MIN(setup->wLength, dev_data->report_size);
 			*data = (uint8_t *)dev_data->report_desc;
 			break;
 		default:

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -204,19 +204,20 @@ static int ecm_class_handler(struct usb_setup_packet *setup, int32_t *len,
 	}
 
 	if (setup->bmRequestType != USB_CDC_ECM_REQ_TYPE) {
-		LOG_WRN("Unhandled req_type 0x%x", setup->bmRequestType);
+		/*
+		 * Only host-to-device, type class, recipient interface
+		 * requests are accepted.
+		 */
+		return -EINVAL;
+	}
+
+	if (setup->bRequest == USB_CDC_SET_ETH_PKT_FILTER) {
+		LOG_INF("Set Interface %u Packet Filter 0x%04x not supported",
+			setup->wIndex, setup->wValue);
 		return 0;
 	}
 
-	switch (setup->bRequest) {
-	case USB_CDC_SET_ETH_PKT_FILTER:
-		LOG_DBG("intf 0x%x filter 0x%x", setup->wIndex, setup->wValue);
-		break;
-	default:
-		break;
-	}
-
-	return 0;
+	return -ENOTSUP;
 }
 
 /* Retrieve expected pkt size from ethernet/ip header */

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -421,21 +421,43 @@ static void usb_register_descriptors(const uint8_t *usb_descriptors)
 	usb_dev.descriptors = usb_descriptors;
 }
 
+static bool usb_get_status(struct usb_setup_packet *setup,
+			   int32_t *len, uint8_t **data_buf)
+{
+	uint8_t *data = *data_buf;
+
+	LOG_DBG("Get Status request");
+	data[0] = 0U;
+	data[1] = 0U;
+
+	if (IS_ENABLED(CONFIG_USB_SELF_POWERED)) {
+		data[0] |= USB_GET_STATUS_SELF_POWERED;
+	}
+
+	if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
+		data[0] |= (usb_dev.remote_wakeup ?
+			    USB_GET_STATUS_REMOTE_WAKEUP : 0);
+	}
+
+	*len = 2;
+
+	return true;
+}
+
 /*
  * @brief get specified USB descriptor
  *
  * This function parses the list of installed USB descriptors and attempts
  * to find the specified USB descriptor.
  *
- * @param [in]  type_index Type and index of the descriptor
- * @param [in]  lang_id    Language ID of the descriptor (currently unused)
+ * @param [in]  setup      The setup packet
  * @param [out] len        Descriptor length
  * @param [out] data       Descriptor data
  *
  * @return true if the descriptor was found, false otherwise
  */
-static bool usb_get_descriptor(uint16_t type_index, uint16_t lang_id,
-		int32_t *len, uint8_t **data)
+static bool usb_get_descriptor(struct usb_setup_packet *setup,
+			       int32_t *len, uint8_t **data)
 {
 	uint8_t type = 0U;
 	uint8_t index = 0U;
@@ -443,11 +465,9 @@ static bool usb_get_descriptor(uint16_t type_index, uint16_t lang_id,
 	uint32_t cur_index = 0U;
 	bool found = false;
 
-	/*Avoid compiler warning until this is used for something*/
-	ARG_UNUSED(lang_id);
-
-	type = USB_GET_DESCRIPTOR_TYPE(type_index);
-	index = USB_GET_DESCRIPTOR_INDEX(type_index);
+	LOG_DBG("Get Descriptor request");
+	type = USB_GET_DESCRIPTOR_TYPE(setup->wValue);
+	index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
 
 	/*
 	 * Invalid types of descriptors,
@@ -490,7 +510,7 @@ static bool usb_get_descriptor(uint16_t type_index, uint16_t lang_id,
 		}
 	} else {
 		/* nothing found */
-		LOG_DBG("Desc %x not found!", type_index);
+		LOG_DBG("Desc %x not found!", setup->wValue);
 	}
 	return found;
 }
@@ -602,21 +622,27 @@ static bool usb_eps_reconfigure(struct usb_ep_descriptor *ep_desc,
  * index and alternate setting by parsing the installed USB descriptor list.
  * A configuration index of 0 unconfigures the device.
  *
- * @param [in] config_index Configuration index
- * @param [in] alt_setting  Alternate setting number
+ * @param [in] setup        The setup packet
  *
  * @return true if successfully configured false if error or unconfigured
  */
-static bool usb_set_configuration(uint8_t config_index, uint8_t alt_setting)
+static bool usb_set_configuration(struct usb_setup_packet *setup)
 {
 	uint8_t *p = (uint8_t *)usb_dev.descriptors;
 	uint8_t cur_alt_setting = 0xFF;
 	uint8_t cur_config = 0xFF;
 	bool found = false;
 
-	if (config_index == 0U) {
-		/* TODO: unconfigure device */
-		LOG_DBG("Device not configured - invalid configuration");
+	LOG_DBG("Set Configuration %u request", setup->wValue);
+
+	if (setup->wValue == 0U) {
+		usb_reset_alt_setting();
+		usb_dev.configuration = setup->wValue;
+		if (usb_dev.status_callback) {
+			usb_dev.status_callback(USB_DC_CONFIGURED,
+						&usb_dev.configuration);
+		}
+
 		return true;
 	}
 
@@ -626,7 +652,7 @@ static bool usb_set_configuration(uint8_t config_index, uint8_t alt_setting)
 		case USB_DESC_CONFIGURATION:
 			/* remember current configuration index */
 			cur_config = p[CONF_DESC_bConfigurationValue];
-			if (cur_config == config_index) {
+			if (cur_config == setup->wValue) {
 				found = true;
 			}
 
@@ -639,8 +665,8 @@ static bool usb_set_configuration(uint8_t config_index, uint8_t alt_setting)
 			break;
 
 		case USB_DESC_ENDPOINT:
-			if ((cur_config != config_index) ||
-			    (cur_alt_setting != alt_setting)) {
+			if ((cur_config != setup->wValue) ||
+			    (cur_alt_setting != 0)) {
 				break;
 			}
 
@@ -655,8 +681,15 @@ static bool usb_set_configuration(uint8_t config_index, uint8_t alt_setting)
 		p += p[DESC_bLength];
 	}
 
-	if (usb_dev.status_callback) {
-		usb_dev.status_callback(USB_DC_CONFIGURED, &config_index);
+	if (found) {
+		usb_reset_alt_setting();
+		usb_dev.configuration = setup->wValue;
+		if (usb_dev.status_callback) {
+			usb_dev.status_callback(USB_DC_CONFIGURED,
+						&usb_dev.configuration);
+		}
+	} else {
+		LOG_DBG("Set Configuration %u failed", setup->wValue);
 	}
 
 	return found;
@@ -767,102 +800,57 @@ static bool is_device_configured(void)
 static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 				      int32_t *len, uint8_t **data_buf)
 {
-	uint16_t value = setup->wValue;
-	uint16_t index = setup->wIndex;
-	bool ret = true;
 	uint8_t *data = *data_buf;
 
 	switch (setup->bRequest) {
 	case USB_SREQ_GET_STATUS:
-		LOG_DBG("USB_SREQ_GET_STATUS");
-		/* bit 0: self-powered */
-		/* bit 1: remote wakeup */
-		data[0] = 0U;
-		data[1] = 0U;
-
-		if (IS_ENABLED(CONFIG_USB_SELF_POWERED)) {
-			data[0] |= USB_GET_STATUS_SELF_POWERED;
-		}
-
-		if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
-			data[0] |= (usb_dev.remote_wakeup ?
-				    USB_GET_STATUS_REMOTE_WAKEUP : 0);
-		}
-
-		*len = 2;
-		break;
+		return usb_get_status(setup, len, data_buf);
 
 	case USB_SREQ_SET_ADDRESS:
-		LOG_DBG("USB_SREQ_SET_ADDRESS, addr 0x%x", value);
-		usb_dc_set_address(value);
-		break;
+		LOG_DBG("Set Address %u request", setup->wValue);
+		return !usb_dc_set_address(setup->wValue);
 
 	case USB_SREQ_GET_DESCRIPTOR:
-		LOG_DBG("USB_SREQ_GET_DESCRIPTOR");
-		ret = usb_get_descriptor(value, index, len, data_buf);
-		break;
+		return usb_get_descriptor(setup, len, data_buf);
 
 	case USB_SREQ_GET_CONFIGURATION:
-		LOG_DBG("USB_SREQ_GET_CONFIGURATION");
+		LOG_DBG("Get Configuration request");
 		/* indicate if we are configured */
 		data[0] = usb_dev.configuration;
 		*len = 1;
-		break;
+		return true;
 
 	case USB_SREQ_SET_CONFIGURATION:
-		value &= 0xFF;
-		LOG_DBG("USB_SREQ_SET_CONFIGURATION, conf 0x%x", value);
-		if (!usb_set_configuration(value, 0)) {
-			LOG_DBG("USB Set Configuration failed");
-			ret = false;
-		} else {
-			/* configuration successful,
-			 * update current configuration
-			 */
-			usb_reset_alt_setting();
-			usb_dev.configuration = value;
-		}
-		break;
+		return usb_set_configuration(setup);
 
 	case USB_SREQ_CLEAR_FEATURE:
-		LOG_DBG("USB_SREQ_CLEAR_FEATURE");
-		ret = false;
+		LOG_DBG("Clear Feature request");
 
 		if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
-			if (value == USB_SFS_REMOTE_WAKEUP) {
+			if (setup->wValue == USB_SFS_REMOTE_WAKEUP) {
 				usb_dev.remote_wakeup = false;
-				ret = true;
+				return true;
 			}
 		}
-		break;
+		return false;
+
 	case USB_SREQ_SET_FEATURE:
-		LOG_DBG("USB_SREQ_SET_FEATURE");
-		ret = false;
+		LOG_DBG("Set Feature request");
 
 		if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
-			if (value == USB_SFS_REMOTE_WAKEUP) {
+			if (setup->wValue == USB_SFS_REMOTE_WAKEUP) {
 				usb_dev.remote_wakeup = true;
-				ret = true;
+				return true;
 			}
 		}
-
-		if (value == USB_SFS_TEST_MODE) {
-			/* put USB_SFS_TEST_MODE code here */
-		}
-		break;
-
-	case USB_SREQ_SET_DESCRIPTOR:
-		LOG_DBG("Device req 0x%02x not implemented", setup->bRequest);
-		ret = false;
-		break;
+		return false;
 
 	default:
-		LOG_DBG("Illegal device req 0x%02x", setup->bRequest);
-		ret = false;
-		break;
+		LOG_DBG("Unsupported bmRequestType 0x%02x bRequest 0x%02x",
+			setup->bmRequestType, setup->bRequest);
 	}
 
-	return ret;
+	return false;
 }
 
 /**

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -698,12 +698,11 @@ static bool usb_set_configuration(struct usb_setup_packet *setup)
 /*
  * @brief set USB interface
  *
- * @param [in] iface Interface index
- * @param [in] alt_setting  Alternate setting number
+ * @param [in] setup        The setup packet
  *
  * @return true if successfully configured false if error or unconfigured
  */
-static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
+static bool usb_set_interface(struct usb_setup_packet *setup)
 {
 	const uint8_t *p = usb_dev.descriptors;
 	const uint8_t *if_desc = NULL;
@@ -712,7 +711,7 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
 	uint8_t cur_iface = 0xFF;
 	bool ret = false;
 
-	LOG_DBG("iface %u alt_setting %u", iface, alt_setting);
+	LOG_DBG("Set Interface %u alternate %u", setup->wIndex, setup->wValue);
 
 	while (p[DESC_bLength] != 0U) {
 		switch (p[DESC_bDescriptorType]) {
@@ -721,9 +720,9 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
 			cur_alt_setting = p[INTF_DESC_bAlternateSetting];
 			cur_iface = p[INTF_DESC_bInterfaceNumber];
 
-			if (cur_iface == iface &&
-			    cur_alt_setting == alt_setting) {
-				usb_set_alt_setting(iface, alt_setting);
+			if (cur_iface == setup->wIndex &&
+			    cur_alt_setting == setup->wValue) {
+				usb_set_alt_setting(setup->wIndex, setup->wValue);
 				if_desc = (void *)p;
 			}
 
@@ -731,10 +730,10 @@ static bool usb_set_interface(uint8_t iface, uint8_t alt_setting)
 				cur_iface, cur_alt_setting);
 			break;
 		case USB_DESC_ENDPOINT:
-			if (cur_iface == iface) {
+			if (cur_iface == setup->wIndex) {
 				ep = (struct usb_ep_descriptor *)p;
 				ret = usb_eps_reconfigure(ep, cur_alt_setting,
-							  alt_setting);
+							  setup->wValue);
 			}
 			break;
 		default:
@@ -910,28 +909,20 @@ static bool usb_handle_std_interface_req(struct usb_setup_packet *setup,
 		data[0] = 0U;
 		data[1] = 0U;
 		*len = 2;
-		break;
-
-	case USB_SREQ_CLEAR_FEATURE:
-	case USB_SREQ_SET_FEATURE:
-		/* not defined for interface */
-		return false;
+		return true;
 
 	case USB_SREQ_GET_INTERFACE:
 		return usb_get_interface(setup, len, data_buf);
 
 	case USB_SREQ_SET_INTERFACE:
-		LOG_DBG("USB_SREQ_SET_INTERFACE");
-		usb_set_interface(setup->wIndex, setup->wValue);
-		*len = 0;
-		break;
+		return usb_set_interface(setup);
 
 	default:
-		LOG_DBG("Illegal interface req 0x%02x", setup->bRequest);
-		return false;
+		LOG_DBG("Unsupported bmRequestType 0x%02x bRequest 0x%02x",
+			setup->bmRequestType, setup->bRequest);
 	}
 
-	return true;
+	return false;
 }
 
 /**


### PR DESCRIPTION
Set data stage length variable to zero as a precaution
so that no trouble happens if control request handler
does not check the request values sufficiently.

Check the control transfer direction in CDC classes, bluetooth, audio, and DFU.