### PR TITLE
ci: Update daily build to use SDK 0.13.0-rc1

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0-rc1"
     parallelism: 400
     timeout_in_minutes: 210
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.1"
+          image: "zephyrprojectrtos/ci:v0.17.4"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"


### PR DESCRIPTION
Update daily image to docker v0.17.4 to get SDK 0.13.0-rc1 for
testing purposes.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>