### PR TITLE
Move MAX_ERASE_TIME to DT

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -24,51 +24,10 @@
 
 LOG_MODULE_REGISTER(flash_stm32, CONFIG_FLASH_LOG_LEVEL);
 
-/* STM32F0: maximum erase time of 40ms for a 2K sector */
-#if defined(CONFIG_SOC_SERIES_STM32F0X)
-#define STM32_FLASH_MAX_ERASE_TIME	40
-/* STM32F3: maximum erase time of 40ms for a 2K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32F1X)
-#define STM32_FLASH_MAX_ERASE_TIME	40
-/* STM32F2: maximum erase time of 4s for a 128K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32F2X)
-#define STM32_FLASH_MAX_ERASE_TIME	4000
-/* STM32F3: maximum erase time of 40ms for a 2K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32F3X)
-#define STM32_FLASH_MAX_ERASE_TIME	40
-/* STM32F4: maximum erase time of 4s for a 128K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32F4X)
-#define STM32_FLASH_MAX_ERASE_TIME	4000
-/* STM32F7: maximum erase time of 4s for a 256K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32F7X)
-#define STM32_FLASH_MAX_ERASE_TIME	4000
-/* STM32L0: maximum erase time of 3.2ms for a 128B page */
-#elif defined(CONFIG_SOC_SERIES_STM32L0X)
-#define STM32_FLASH_MAX_ERASE_TIME	4
-/* STM32L1: maximum erase time of 3.94ms for a 128B half-page */
-#elif defined(CONFIG_SOC_SERIES_STM32L1X)
-#define STM32_FLASH_MAX_ERASE_TIME	4
-/* STM32L4: maximum erase time of 24.47ms for a 2K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32L4X)
-#define STM32_FLASH_MAX_ERASE_TIME	25
-/* STM32WL: maximum erase time of 24.5ms for a 2K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32WLX)
-#define STM32_FLASH_MAX_ERASE_TIME	25
-/* STM32WB: maximum erase time of 24.5ms for a 4K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32WBX)
-#define STM32_FLASH_MAX_ERASE_TIME	25
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
-/* STM32G0: maximum erase time of 40ms for a 2K sector */
-#define STM32_FLASH_MAX_ERASE_TIME	40
-/* STM32G4: maximum erase time of 24.47ms for a 2K sector */
-#elif defined(CONFIG_SOC_SERIES_STM32G4X)
-#define STM32_FLASH_MAX_ERASE_TIME	25
-#endif
-
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */
-#define STM32_FLASH_TIMEOUT	(2 * STM32_FLASH_MAX_ERASE_TIME)
+#define STM32_FLASH_TIMEOUT	(2 * DT_PROP(DT_INST(0, soc_nv_flash), max_erase_time))
 
 static const struct flash_parameters flash_stm32_parameters = {
 	.write_block_size = FLASH_STM32_WRITE_BLOCK_SIZE,

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -83,6 +83,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <2>;
+				/* maximum erase time for a 2K sector */
+				max-erase-time = <40>;
 			};
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -84,6 +84,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <2>;
+				/* maximum erase time for a 2K sector */
+				max-erase-time = <40>;
 			};
 		};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -82,6 +82,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <1>;
+				/* maximum erase time(ms) for a 128K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -85,6 +85,8 @@
 
 				write-block-size = <2>;
 				erase-block-size = <2048>;
+				/* maximum erase time for a 2K sector */
+				max-erase-time = <40>;
 			};
 		};
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -82,6 +82,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <1>;
+				/* maximum erase time (ms) for a 128K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -87,6 +87,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <1>;
+				/* maximum erase time (ms) for a 256K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -87,6 +87,8 @@
 
 				write-block-size = <8>;
 				erase-block-size = <2048>;
+				/* maximum erase time(ms) for a 2K sector */
+				max-erase-time = <40>;
 			};
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -126,6 +126,8 @@
 
 				write-block-size = <8>;
 				erase-block-size = <2048>;
+				/* maximum erase time(ms) for a 2K sector */
+				max-erase-time = <25>;
 			};
 		};
 

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -99,6 +99,8 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <4>;
+				/* maximum erase time(ms) for a 128B page */
+				max-erase-time = <4>;
 			};
 		};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -91,6 +91,9 @@
 				label = "FLASH_STM32";
 
 				write-block-size = <4>;
+				/* maximum erase time(ms) for a 128B half-page
+				 */
+				max-erase-time = <4>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -93,6 +93,8 @@
 
 				write-block-size = <8>;
 				erase-block-size = <2048>;
+				/* maximum erase time(ms) for a 2K sector */
+				max-erase-time = <25>;
 			};
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -110,6 +110,8 @@
 
 				write-block-size = <8>;
 				erase-block-size = <4096>;
+				/* maximum erase time(ms) for a 4K sector */
+				max-erase-time = <25>;
 			};
 		};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -91,6 +91,8 @@
 
 				write-block-size = <8>;
 				erase-block-size = <2048>;
+				/* maximum erase time(ms) for a 2K sector */
+				max-erase-time = <25>;
 			};
 		};
 

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -17,3 +17,8 @@ properties:
      type: int
      description: address alignment required by flash write operations
      required: false
+
+    max-erase-time:
+     type: int
+     description: max erase time(millisecond) of a flash sector or page or half-page
+     required: false


### PR DESCRIPTION
These commits remove the huge if block and replace it with a DT API based
retrieval logic. A new element max-erase-time is added which holds the
maximum erase time of a sector or page or half-page of a flash for all the
series of stm32.