### PR TITLE
drivers: wifi: esp_at: close stream socket after failure to send

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -376,7 +376,10 @@ static int esp_sendto(struct net_pkt *pkt,
 	}
 
 	if (esp_socket_type(sock) == SOCK_STREAM) {
-		if (!esp_socket_connected(sock)) {
+		atomic_val_t flags = esp_socket_flags(sock);
+
+		if (!(flags & ESP_SOCK_CONNECTED) ||
+		     (flags & ESP_SOCK_CLOSE_PENDING)) {
 			return -ENOTCONN;
 		}
 	} else {


### PR DESCRIPTION
So far send errors were silently ignored. This is okay for
UDP (datagram) sockets, as there is no guarantee that packets will
actually be sent successfully. In case of TCP (stream) stream sockets
however, application layer expects network stack to send requested data
as stream, without losing any part of it.

In case of send errors on stream sockets mark that socket to be closed
and stop sending any subsequent network packets, so that data stream
won't have any holes.

If stream socket is marked as pending close, make sure that send()
caller gets notified about it, so that application layer can decide to
stop trying to send anything more.