### PR TITLE
drivers: {modem, esp_at}: add modem_cmd_send_ext() and fix races in esp_at

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -467,12 +467,11 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 	return 0;
 }
 
-static int _modem_cmd_send(struct modem_iface *iface,
-			   struct modem_cmd_handler *handler,
-			   const struct modem_cmd *handler_cmds,
-			   size_t handler_cmds_len,
-			   const uint8_t *buf, struct k_sem *sem,
-			   k_timeout_t timeout, bool no_tx_lock)
+int modem_cmd_send_ext(struct modem_iface *iface,
+		       struct modem_cmd_handler *handler,
+		       const struct modem_cmd *handler_cmds,
+		       size_t handler_cmds_len, const uint8_t *buf,
+		       struct k_sem *sem, k_timeout_t timeout, int flags)
 {
 	struct modem_cmd_handler_data *data;
 	int ret;
@@ -490,14 +489,16 @@ static int _modem_cmd_send(struct modem_iface *iface,
 	}
 
 	data = (struct modem_cmd_handler_data *)(handler->cmd_handler_data);
-	if (!no_tx_lock) {
+	if (!(flags & MODEM_NO_TX_LOCK)) {
 		k_sem_take(&data->sem_tx_lock, K_FOREVER);
 	}
 
-	ret = modem_cmd_handler_update_cmds(data, handler_cmds,
-					    handler_cmds_len, true);
-	if (ret < 0) {
-		goto unlock_tx_lock;
+	if (!(flags & MODEM_NO_SET_CMDS)) {
+		ret = modem_cmd_handler_update_cmds(data, handler_cmds,
+						    handler_cmds_len, true);
+		if (ret < 0) {
+			goto unlock_tx_lock;
+		}
 	}
 
 #if defined(CONFIG_MODEM_CONTEXT_VERBOSE_DEBUG)
@@ -531,36 +532,17 @@ static int _modem_cmd_send(struct modem_iface *iface,
 		}
 	}
 
-	/* unset handlers and ignore any errors */
-	(void)modem_cmd_handler_update_cmds(data, NULL, 0U, false);
+	if (!(flags & MODEM_NO_UNSET_CMDS)) {
+		/* unset handlers and ignore any errors */
+		(void)modem_cmd_handler_update_cmds(data, NULL, 0U, false);
+	}
 
 unlock_tx_lock:
-	if (!no_tx_lock) {
+	if (!(flags & MODEM_NO_TX_LOCK)) {
 		k_sem_give(&data->sem_tx_lock);
 	}
 
 	return ret;
-}
-
-int modem_cmd_send_nolock(struct modem_iface *iface,
-			  struct modem_cmd_handler *handler,
-			  const struct modem_cmd *handler_cmds,
-			  size_t handler_cmds_len,
-			  const uint8_t *buf, struct k_sem *sem,
-			  k_timeout_t timeout)
-{
-	return _modem_cmd_send(iface, handler, handler_cmds, handler_cmds_len,
-			       buf, sem, timeout, true);
-}
-
-int modem_cmd_send(struct modem_iface *iface,
-		   struct modem_cmd_handler *handler,
-		   const struct modem_cmd *handler_cmds,
-		   size_t handler_cmds_len, const uint8_t *buf,
-		   struct k_sem *sem, k_timeout_t timeout)
-{
-	return _modem_cmd_send(iface, handler, handler_cmds, handler_cmds_len,
-			       buf, sem, timeout, false);
 }
 
 /* run a set of AT commands */

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -233,26 +233,14 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 	k_sem_take(&dev->cmd_handler_data.sem_tx_lock, K_FOREVER);
 	k_sem_reset(&dev->sem_tx_ready);
 
-	ret = modem_cmd_send_nolock(&dev->mctx.iface, &dev->mctx.cmd_handler,
-				    cmds, ARRAY_SIZE(cmds), cmd_buf,
-				    &dev->sem_response, ESP_CMD_TIMEOUT);
+	ret = modem_cmd_send_ext(&dev->mctx.iface, &dev->mctx.cmd_handler,
+				 cmds, ARRAY_SIZE(cmds), cmd_buf,
+				 &dev->sem_response, ESP_CMD_TIMEOUT,
+				 MODEM_NO_TX_LOCK | MODEM_NO_UNSET_CMDS);
 	if (ret < 0) {
 		LOG_DBG("Failed to send command");
 		goto out;
 	}
-
-	ret = modem_cmd_handler_update_cmds(&dev->cmd_handler_data,
-					    cmds, ARRAY_SIZE(cmds),
-					    true);
-	if (ret < 0) {
-		goto out;
-	}
-
-	/*
-	 * After modem handlers have been updated the receive buffer
-	 * needs to be processed again since there might now be a match.
-	 */
-	k_sem_give(&dev->iface_data.rx_sem);
 
 	/* Wait for '>' */
 	ret = k_sem_take(&dev->sem_tx_ready, K_MSEC(5000));

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -242,6 +242,9 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 		goto out;
 	}
 
+	/* Reset semaphore that will be released by 'SEND OK' or 'SEND FAIL' */
+	k_sem_reset(&dev->sem_response);
+
 	/* Wait for '>' */
 	ret = k_sem_take(&dev->sem_tx_ready, K_MSEC(5000));
 	if (ret < 0) {
@@ -258,7 +261,6 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 	}
 
 	/* Wait for 'SEND OK' or 'SEND FAIL' */
-	k_sem_reset(&dev->sem_response);
 	ret = k_sem_take(&dev->sem_response, ESP_CMD_TIMEOUT);
 	if (ret < 0) {
 		LOG_DBG("No send response");


### PR DESCRIPTION
There are currently modem_cmd_send() and modem_cmd_send_nolock()
functions, each with slightly different behavior regarding acquiring (or
not) sem_tx_lock. Introduce a generic function that will allow caller to
select behavior using flags.

While at it, add possibility to disable setting and unsetting command
handlers. This will be useful in situations when there are multiple
replies expected one after the other coming as a response to single
command. This is the case for example with ESP-AT driver, which expects
following data as response to AT+CIPSEND command:

```
  OK
  >
```

where 'OK' is handled by static CMD_RESP (so releasing response
semaphore right away), while '>' is handled by dynamic
CMD_HANDLER (which is releasing another semaphore). Keeping command
handlers in place allows to receive '>' without race condition because
of small period of time where command handlers are not set.

Fix also race condition caused by resetting 'sem_response' semaphore at the 
time it can potentially be already released.