### PR TITLE
tracing: debug: Link Segger RTT/SystemView sections in DTCM if chosen

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -136,13 +136,15 @@ config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA
 
+DT_CHOSEN_Z_DTCM := zephyr,dtcm
+
 choice SEGGER_RTT_SECTION
-	default SEGGER_RTT_SECTION_DTCM if HAS_MCUX_SEMC
+	default SEGGER_RTT_SECTION_DTCM if $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
 	depends on USE_SEGGER_RTT
 endchoice
 
 choice SEGGER_SYSVIEW_SECTION
-	default SEGGER_SYSVIEW_SECTION_DTCM if HAS_MCUX_SEMC
+	default SEGGER_SYSVIEW_SECTION_DTCM if $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
 	depends on SEGGER_SYSTEMVIEW
 endchoice
 


### PR DESCRIPTION
Configures Segger RTT and SystemView data linker sections to DTCM by
default if there is a zephyr,dtcm chosen node in devicetree. This fixes
a build warning in samples/subsys/shell/shell_module for the
mimxrt1170_evk_cm7 and mimxrt1170_evk_cm4 platforms, which don't
currently have a zephyr,dtcm chosen node.

Note that there are runtime issues with Segger RTT and SystemView on
this board that need further debug, but submitting this patch now to
address nightly CI failures.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #36646

@erwango This change affects some ST boards. I think this is the right thing to do in general, but if it's not then I can limit the scope to NXP boards.