### PR TITLE
drivers: flash: nrf_qspi_nor: Configurable RXDELAY

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -661,6 +661,12 @@ static int qspi_nrfx_configure(const struct device *dev)
 	nrfx_err_t res = nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
 	int ret = qspi_get_zephyr_ret_code(res);
 
+#if DT_INST_NODE_HAS_PROP(0, rx_delay)
+	if (ret == 0 && !nrf53_errata_121()) {
+		nrf_qspi_iftiming_set(NRF_QSPI, DT_INST_PROP(0, rx_delay));
+	}
+#endif
+
 	if ((ret == 0)
 	    && (INST_0_QER != JESD216_DW15_QER_NONE)) {
 		/* Set QE to match transfer mode.  If not using quad

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -74,6 +74,13 @@ properties:
       Number of clock cycles CSn must be asserted before it can go low
       again, specified in nanoseconds.
 
+  rx-delay:
+    type: int
+    required: false
+    description: |
+      Number of clock cycles from the rising edge of the SPI clock
+      until the input serial data is sampled.
+
   cpha:
     type: boolean
     required: false


### PR DESCRIPTION
The nRF QSPI has a configurable delay from the rising
clock signal to the actual sample point measured in
clock cycles. This commit exposes that delay as a DTS
parameter without modifying existing behavior.

Signed-off-by: Abram Early <abram.early@gmail.com>