### PR TITLE
drivers: display: st7789v: Simplify configuration code

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -415,7 +415,7 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
 	switch (ctrl_command) {
-	case DEVICE_PM_SET_POWER_STATE:
+	case PM_DEVICE_STATE_SET:
 		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			st7789v_exit_sleep(data);
 			data->pm_state = PM_DEVICE_STATE_ACTIVE;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -115,17 +115,17 @@ static void st7789v_reset_display(struct st7789v_data *data)
 
 static int st7789v_blanking_on(const struct device *dev)
 {
-	struct st7789v_data *driver = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
-	st7789v_transmit(driver, ST7789V_CMD_DISP_OFF, NULL, 0);
+	st7789v_transmit(data, ST7789V_CMD_DISP_OFF, NULL, 0);
 	return 0;
 }
 
 static int st7789v_blanking_off(const struct device *dev)
 {
-	struct st7789v_data *driver = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = (struct st7789v_data *)dev->data;
 
-	st7789v_transmit(driver, ST7789V_CMD_DISP_ON, NULL, 0);
+	st7789v_transmit(data, ST7789V_CMD_DISP_ON, NULL, 0);
 	return 0;
 }
 
@@ -263,74 +263,74 @@ static int st7789v_set_orientation(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static void st7789v_lcd_init(struct st7789v_data *p_st7789v)
+static void st7789v_lcd_init(struct st7789v_data *data)
 {
 	uint8_t tmp;
 
-	st7789v_set_lcd_margins(p_st7789v, p_st7789v->x_offset,
-				p_st7789v->y_offset);
+	st7789v_set_lcd_margins(data, data->x_offset,
+				data->y_offset);
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_CMD2EN, st7789v_cmd2en_param,
+	st7789v_transmit(data, ST7789V_CMD_CMD2EN, st7789v_cmd2en_param,
 			 sizeof(st7789v_cmd2en_param));
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_PORCTRL, st7789v_porch_param,
+	st7789v_transmit(data, ST7789V_CMD_PORCTRL, st7789v_porch_param,
 			 sizeof(st7789v_porch_param));
 
 	/* Digital Gamma Enable, default disabled */
 	tmp = 0x00;
-	st7789v_transmit(p_st7789v, ST7789V_CMD_DGMEN, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_DGMEN, &tmp, 1);
 
 	/* Frame Rate Control in Normal Mode, default value */
 	tmp = 0x0f;
-	st7789v_transmit(p_st7789v, ST7789V_CMD_FRCTRL2, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_FRCTRL2, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, gctrl);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_GCTRL, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_GCTRL, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vcom);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_VCOMS, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_VCOMS, &tmp, 1);
 
 #if (DT_INST_NODE_HAS_PROP(0, vrhs) && \
 	DT_INST_NODE_HAS_PROP(0, vdvs))
 	tmp = 0x01;
-	st7789v_transmit(p_st7789v, ST7789V_CMD_VDVVRHEN, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_VDVVRHEN, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vrhs);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_VRH, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_VRH, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vdvs);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_VDS, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_VDS, &tmp, 1);
 #endif
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_PWCTRL1, st7789v_pwctrl1_param,
+	st7789v_transmit(data, ST7789V_CMD_PWCTRL1, st7789v_pwctrl1_param,
 			 sizeof(st7789v_pwctrl1_param));
 
 	/* Memory Data Access Control */
 	tmp = DT_INST_PROP(0, mdac);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_MADCTL, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_MADCTL, &tmp, 1);
 
 	/* Interface Pixel Format */
 	tmp = DT_INST_PROP(0, colmod);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_COLMOD, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_COLMOD, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, lcm);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_LCMCTRL, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_LCMCTRL, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, gamma);
-	st7789v_transmit(p_st7789v, ST7789V_CMD_GAMSET, &tmp, 1);
+	st7789v_transmit(data, ST7789V_CMD_GAMSET, &tmp, 1);
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_INV_ON, NULL, 0);
+	st7789v_transmit(data, ST7789V_CMD_INV_ON, NULL, 0);
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_PVGAMCTRL, st7789v_pvgam_param,
+	st7789v_transmit(data, ST7789V_CMD_PVGAMCTRL, st7789v_pvgam_param,
 			 sizeof(st7789v_pvgam_param));
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_NVGAMCTRL, st7789v_nvgam_param,
+	st7789v_transmit(data, ST7789V_CMD_NVGAMCTRL, st7789v_nvgam_param,
 			 sizeof(st7789v_nvgam_param));
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_RAMCTRL, st7789v_ram_param,
+	st7789v_transmit(data, ST7789V_CMD_RAMCTRL, st7789v_ram_param,
 			 sizeof(st7789v_ram_param));
 
-	st7789v_transmit(p_st7789v, ST7789V_CMD_RGBCTRL, st7789v_rgb_param,
+	st7789v_transmit(data, ST7789V_CMD_RGBCTRL, st7789v_rgb_param,
 			 sizeof(st7789v_rgb_param));
 }
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -115,7 +115,7 @@ static void st7789v_reset_display(struct st7789v_data *data)
 
 static int st7789v_blanking_on(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	st7789v_transmit(data, ST7789V_CMD_DISP_OFF, NULL, 0);
 	return 0;
@@ -123,7 +123,7 @@ static int st7789v_blanking_on(const struct device *dev)
 
 static int st7789v_blanking_off(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	st7789v_transmit(data, ST7789V_CMD_DISP_ON, NULL, 0);
 	return 0;
@@ -161,7 +161,7 @@ static int st7789v_write(const struct device *dev,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 	const uint8_t *write_data_start = (uint8_t *) buf;
 	struct spi_buf tx_buf;
 	struct spi_buf_set tx_bufs;
@@ -223,7 +223,7 @@ static int st7789v_set_contrast(const struct device *dev,
 static void st7789v_get_capabilities(const struct device *dev,
 			      struct display_capabilities *capabilities)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = data->width;
@@ -336,7 +336,7 @@ static void st7789v_lcd_init(struct st7789v_data *data)
 
 static int st7789v_init(const struct device *dev)
 {
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	data->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
 	if (data->spi_dev == NULL) {
@@ -412,7 +412,7 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 				 enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
-	struct st7789v_data *data = (struct st7789v_data *)dev->data;
+	struct st7789v_data *data = dev->data;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -63,43 +63,51 @@ struct st7789v_data {
 #define ST7789V_PIXEL_SIZE 3u
 #endif
 
-static void st7789v_set_lcd_margins(struct st7789v_data *data,
-			     uint16_t x_offset, uint16_t y_offset)
+static void st7789v_set_lcd_margins(const struct device *dev,
+				    uint16_t x_offset, uint16_t y_offset)
 {
+	struct st7789v_data *data = dev->data;
+
 	data->x_offset = x_offset;
 	data->y_offset = y_offset;
 }
 
-static void st7789v_set_cmd(struct st7789v_data *data, int is_cmd)
+static void st7789v_set_cmd(const struct device *dev, int is_cmd)
 {
+	struct st7789v_data *data = dev->data;
+
 	gpio_pin_set(data->cmd_data_gpio, ST7789V_CMD_DATA_PIN, is_cmd);
 }
 
-static void st7789v_transmit(struct st7789v_data *data, uint8_t cmd,
-		uint8_t *tx_data, size_t tx_count)
+static void st7789v_transmit(const struct device *dev, uint8_t cmd,
+			     uint8_t *tx_data, size_t tx_count)
 {
+	struct st7789v_data *data = dev->data;
+
 	struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
 	struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
 
-	st7789v_set_cmd(data, 1);
+	st7789v_set_cmd(dev, 1);
 	spi_write(data->spi_dev, &data->spi_config, &tx_bufs);
 
 	if (tx_data != NULL) {
 		tx_buf.buf = tx_data;
 		tx_buf.len = tx_count;
-		st7789v_set_cmd(data, 0);
+		st7789v_set_cmd(dev, 0);
 		spi_write(data->spi_dev, &data->spi_config, &tx_bufs);
 	}
 }
 
-static void st7789v_exit_sleep(struct st7789v_data *data)
+static void st7789v_exit_sleep(const struct device *dev)
 {
-	st7789v_transmit(data, ST7789V_CMD_SLEEP_OUT, NULL, 0);
+	st7789v_transmit(dev, ST7789V_CMD_SLEEP_OUT, NULL, 0);
 	k_sleep(K_MSEC(120));
 }
 
-static void st7789v_reset_display(struct st7789v_data *data)
+static void st7789v_reset_display(const struct device *dev)
 {
+	struct st7789v_data *data = dev->data;
+
 	LOG_DBG("Resetting display");
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	k_sleep(K_MSEC(1));
@@ -115,17 +123,13 @@ static void st7789v_reset_display(struct st7789v_data *data)
 
 static int st7789v_blanking_on(const struct device *dev)
 {
-	struct st7789v_data *data = dev->data;
-
-	st7789v_transmit(data, ST7789V_CMD_DISP_OFF, NULL, 0);
+	st7789v_transmit(dev, ST7789V_CMD_DISP_OFF, NULL, 0);
 	return 0;
 }
 
 static int st7789v_blanking_off(const struct device *dev)
 {
-	struct st7789v_data *data = dev->data;
-
-	st7789v_transmit(data, ST7789V_CMD_DISP_ON, NULL, 0);
+	st7789v_transmit(dev, ST7789V_CMD_DISP_ON, NULL, 0);
 	return 0;
 }
 
@@ -138,9 +142,10 @@ static int st7789v_read(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static void st7789v_set_mem_area(struct st7789v_data *data, const uint16_t x,
+static void st7789v_set_mem_area(const struct device *dev, const uint16_t x,
 				 const uint16_t y, const uint16_t w, const uint16_t h)
 {
+	struct st7789v_data *data = dev->data;
 	uint16_t spi_data[2];
 
 	uint16_t ram_x = x + data->x_offset;
@@ -148,11 +153,11 @@ static void st7789v_set_mem_area(struct st7789v_data *data, const uint16_t x,
 
 	spi_data[0] = sys_cpu_to_be16(ram_x);
 	spi_data[1] = sys_cpu_to_be16(ram_x + w - 1);
-	st7789v_transmit(data, ST7789V_CMD_CASET, (uint8_t *)&spi_data[0], 4);
+	st7789v_transmit(dev, ST7789V_CMD_CASET, (uint8_t *)&spi_data[0], 4);
 
 	spi_data[0] = sys_cpu_to_be16(ram_y);
 	spi_data[1] = sys_cpu_to_be16(ram_y + h - 1);
-	st7789v_transmit(data, ST7789V_CMD_RASET, (uint8_t *)&spi_data[0], 4);
+	st7789v_transmit(dev, ST7789V_CMD_RASET, (uint8_t *)&spi_data[0], 4);
 }
 
 static int st7789v_write(const struct device *dev,
@@ -174,8 +179,8 @@ static int st7789v_write(const struct device *dev,
 			"Input buffer to small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)",
-			desc->width, desc->height, x, y);
-	st7789v_set_mem_area(data, x, y, desc->width, desc->height);
+		desc->width, desc->height, x, y);
+	st7789v_set_mem_area(dev, x, y, desc->width, desc->height);
 
 	if (desc->pitch > desc->width) {
 		write_h = 1U;
@@ -185,7 +190,7 @@ static int st7789v_write(const struct device *dev,
 		nbr_of_writes = 1U;
 	}
 
-	st7789v_transmit(data, ST7789V_CMD_RAMWR,
+	st7789v_transmit(dev, ST7789V_CMD_RAMWR,
 			 (void *) write_data_start,
 			 desc->width * ST7789V_PIXEL_SIZE * write_h);
 
@@ -263,74 +268,75 @@ static int st7789v_set_orientation(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static void st7789v_lcd_init(struct st7789v_data *data)
+static void st7789v_lcd_init(const struct device *dev)
 {
+	struct st7789v_data *data = dev->data;
 	uint8_t tmp;
 
-	st7789v_set_lcd_margins(data, data->x_offset,
+	st7789v_set_lcd_margins(dev, data->x_offset,
 				data->y_offset);
 
-	st7789v_transmit(data, ST7789V_CMD_CMD2EN, st7789v_cmd2en_param,
+	st7789v_transmit(dev, ST7789V_CMD_CMD2EN, st7789v_cmd2en_param,
 			 sizeof(st7789v_cmd2en_param));
 
-	st7789v_transmit(data, ST7789V_CMD_PORCTRL, st7789v_porch_param,
+	st7789v_transmit(dev, ST7789V_CMD_PORCTRL, st7789v_porch_param,
 			 sizeof(st7789v_porch_param));
 
 	/* Digital Gamma Enable, default disabled */
 	tmp = 0x00;
-	st7789v_transmit(data, ST7789V_CMD_DGMEN, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_DGMEN, &tmp, 1);
 
 	/* Frame Rate Control in Normal Mode, default value */
 	tmp = 0x0f;
-	st7789v_transmit(data, ST7789V_CMD_FRCTRL2, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, gctrl);
-	st7789v_transmit(data, ST7789V_CMD_GCTRL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_GCTRL, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vcom);
-	st7789v_transmit(data, ST7789V_CMD_VCOMS, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_VCOMS, &tmp, 1);
 
 #if (DT_INST_NODE_HAS_PROP(0, vrhs) && \
 	DT_INST_NODE_HAS_PROP(0, vdvs))
 	tmp = 0x01;
-	st7789v_transmit(data, ST7789V_CMD_VDVVRHEN, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vrhs);
-	st7789v_transmit(data, ST7789V_CMD_VRH, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_VRH, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, vdvs);
-	st7789v_transmit(data, ST7789V_CMD_VDS, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_VDS, &tmp, 1);
 #endif
 
-	st7789v_transmit(data, ST7789V_CMD_PWCTRL1, st7789v_pwctrl1_param,
+	st7789v_transmit(dev, ST7789V_CMD_PWCTRL1, st7789v_pwctrl1_param,
 			 sizeof(st7789v_pwctrl1_param));
 
 	/* Memory Data Access Control */
 	tmp = DT_INST_PROP(0, mdac);
-	st7789v_transmit(data, ST7789V_CMD_MADCTL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_MADCTL, &tmp, 1);
 
 	/* Interface Pixel Format */
 	tmp = DT_INST_PROP(0, colmod);
-	st7789v_transmit(data, ST7789V_CMD_COLMOD, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_COLMOD, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, lcm);
-	st7789v_transmit(data, ST7789V_CMD_LCMCTRL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, &tmp, 1);
 
 	tmp = DT_INST_PROP(0, gamma);
-	st7789v_transmit(data, ST7789V_CMD_GAMSET, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_GAMSET, &tmp, 1);
 
-	st7789v_transmit(data, ST7789V_CMD_INV_ON, NULL, 0);
+	st7789v_transmit(dev, ST7789V_CMD_INV_ON, NULL, 0);
 
-	st7789v_transmit(data, ST7789V_CMD_PVGAMCTRL, st7789v_pvgam_param,
+	st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL, st7789v_pvgam_param,
 			 sizeof(st7789v_pvgam_param));
 
-	st7789v_transmit(data, ST7789V_CMD_NVGAMCTRL, st7789v_nvgam_param,
+	st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL, st7789v_nvgam_param,
 			 sizeof(st7789v_nvgam_param));
 
-	st7789v_transmit(data, ST7789V_CMD_RAMCTRL, st7789v_ram_param,
+	st7789v_transmit(dev, ST7789V_CMD_RAMCTRL, st7789v_ram_param,
 			 sizeof(st7789v_ram_param));
 
-	st7789v_transmit(data, ST7789V_CMD_RGBCTRL, st7789v_rgb_param,
+	st7789v_transmit(dev, ST7789V_CMD_RGBCTRL, st7789v_rgb_param,
 			 sizeof(st7789v_rgb_param));
 }
 
@@ -391,21 +397,21 @@ static int st7789v_init(const struct device *dev)
 		return -EIO;
 	}
 
-	st7789v_reset_display(data);
+	st7789v_reset_display(dev);
 
 	st7789v_blanking_on(dev);
 
-	st7789v_lcd_init(data);
+	st7789v_lcd_init(dev);
 
-	st7789v_exit_sleep(data);
+	st7789v_exit_sleep(dev);
 
 	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
-static void st7789v_enter_sleep(struct st7789v_data *data)
+static void st7789v_enter_sleep(const struct device *dev)
 {
-	st7789v_transmit(data, ST7789V_CMD_SLEEP_IN, NULL, 0);
+	st7789v_transmit(dev, ST7789V_CMD_SLEEP_IN, NULL, 0);
 }
 
 static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
@@ -417,11 +423,11 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
 		if (*state == PM_DEVICE_STATE_ACTIVE) {
-			st7789v_exit_sleep(data);
+			st7789v_exit_sleep(dev);
 			data->pm_state = PM_DEVICE_STATE_ACTIVE;
 			ret = 0;
 		} else {
-			st7789v_enter_sleep(data);
+			st7789v_enter_sleep(dev);
 			data->pm_state = PM_DEVICE_STATE_LOW_POWER;
 			ret = 0;
 		}

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -28,13 +28,26 @@ LOG_MODULE_REGISTER(display_st7789v);
 #define ST7789V_RESET_PIN	DT_INST_GPIO_PIN(0, reset_gpios)
 #define ST7789V_RESET_FLAGS	DT_INST_GPIO_FLAGS(0, reset_gpios)
 
-static uint8_t st7789v_porch_param[] = DT_INST_PROP(0, porch_param);
-static uint8_t st7789v_cmd2en_param[] = DT_INST_PROP(0, cmd2en_param);
-static uint8_t st7789v_pwctrl1_param[] = DT_INST_PROP(0, pwctrl1_param);
-static uint8_t st7789v_pvgam_param[] = DT_INST_PROP(0, pvgam_param);
-static uint8_t st7789v_nvgam_param[] = DT_INST_PROP(0, nvgam_param);
-static uint8_t st7789v_ram_param[] = DT_INST_PROP(0, ram_param);
-static uint8_t st7789v_rgb_param[] = DT_INST_PROP(0, rgb_param);
+struct st7789v_config {
+	uint16_t height;
+	uint16_t width;
+	uint8_t vcom;
+	uint8_t gctrl;
+	bool vdv_vrh_enable;
+	uint8_t vrh_value;
+	uint8_t vdv_value;
+	uint8_t mdac;
+	uint8_t gamma;
+	uint8_t colmod;
+	uint8_t lcm;
+	uint8_t porch_param[5];
+	uint8_t cmd2en_param[4];
+	uint8_t pwctrl1_param[2];
+	uint8_t pvgam_param[14];
+	uint8_t nvgam_param[14];
+	uint8_t ram_param[2];
+	uint8_t rgb_param[3];
+};
 
 struct st7789v_data {
 	const struct device *spi_dev;
@@ -48,8 +61,6 @@ struct st7789v_data {
 #endif
 	const struct device *cmd_data_gpio;
 
-	uint16_t height;
-	uint16_t width;
 	uint16_t x_offset;
 	uint16_t y_offset;
 #ifdef CONFIG_PM_DEVICE
@@ -80,19 +91,21 @@ static void st7789v_set_cmd(const struct device *dev, int is_cmd)
 }
 
 static void st7789v_transmit(const struct device *dev, uint8_t cmd,
-			     uint8_t *tx_data, size_t tx_count)
+			     const uint8_t *tx_data, size_t tx_count)
 {
 	struct st7789v_data *data = dev->data;
 
-	struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
-	struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
+	{
+		const struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
+		const struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
 
-	st7789v_set_cmd(dev, 1);
-	spi_write(data->spi_dev, &data->spi_config, &tx_bufs);
-
+		st7789v_set_cmd(dev, 1);
+		spi_write(data->spi_dev, &data->spi_config, &tx_bufs);
+	}
 	if (tx_data != NULL) {
-		tx_buf.buf = tx_data;
-		tx_buf.len = tx_count;
+		const struct spi_buf tx_buf = { .buf = (void *)tx_data, .len = tx_count };
+		const struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
+
 		st7789v_set_cmd(dev, 0);
 		spi_write(data->spi_dev, &data->spi_config, &tx_bufs);
 	}
@@ -228,11 +241,11 @@ static int st7789v_set_contrast(const struct device *dev,
 static void st7789v_get_capabilities(const struct device *dev,
 			      struct display_capabilities *capabilities)
 {
-	struct st7789v_data *data = dev->data;
+	const struct st7789v_config *config = dev->config;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
-	capabilities->x_resolution = data->width;
-	capabilities->y_resolution = data->height;
+	capabilities->x_resolution = config->width;
+	capabilities->y_resolution = config->height;
 
 #ifdef CONFIG_ST7789V_RGB565
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_RGB_565;
@@ -271,16 +284,17 @@ static int st7789v_set_orientation(const struct device *dev,
 static void st7789v_lcd_init(const struct device *dev)
 {
 	struct st7789v_data *data = dev->data;
+	const struct st7789v_config *config = dev->config;
 	uint8_t tmp;
 
 	st7789v_set_lcd_margins(dev, data->x_offset,
 				data->y_offset);
 
-	st7789v_transmit(dev, ST7789V_CMD_CMD2EN, st7789v_cmd2en_param,
-			 sizeof(st7789v_cmd2en_param));
+	st7789v_transmit(dev, ST7789V_CMD_CMD2EN, config->cmd2en_param,
+			 sizeof(config->cmd2en_param));
 
-	st7789v_transmit(dev, ST7789V_CMD_PORCTRL, st7789v_porch_param,
-			 sizeof(st7789v_porch_param));
+	st7789v_transmit(dev, ST7789V_CMD_PORCTRL, config->porch_param,
+			 sizeof(config->porch_param));
 
 	/* Digital Gamma Enable, default disabled */
 	tmp = 0x00;
@@ -290,54 +304,45 @@ static void st7789v_lcd_init(const struct device *dev)
 	tmp = 0x0f;
 	st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, &tmp, 1);
 
-	tmp = DT_INST_PROP(0, gctrl);
-	st7789v_transmit(dev, ST7789V_CMD_GCTRL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_GCTRL, &config->gctrl, 1);
 
-	tmp = DT_INST_PROP(0, vcom);
-	st7789v_transmit(dev, ST7789V_CMD_VCOMS, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_VCOMS, &config->vcom, 1);
 
-#if (DT_INST_NODE_HAS_PROP(0, vrhs) && \
-	DT_INST_NODE_HAS_PROP(0, vdvs))
-	tmp = 0x01;
-	st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
+	if (config->vdv_vrh_enable) {
+		tmp = 0x01;
+		st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
 
-	tmp = DT_INST_PROP(0, vrhs);
-	st7789v_transmit(dev, ST7789V_CMD_VRH, &tmp, 1);
+		st7789v_transmit(dev, ST7789V_CMD_VRH, &config->vrh_value, 1);
 
-	tmp = DT_INST_PROP(0, vdvs);
-	st7789v_transmit(dev, ST7789V_CMD_VDS, &tmp, 1);
-#endif
+		st7789v_transmit(dev, ST7789V_CMD_VDS, &config->vdv_value, 1);
+	}
 
-	st7789v_transmit(dev, ST7789V_CMD_PWCTRL1, st7789v_pwctrl1_param,
-			 sizeof(st7789v_pwctrl1_param));
+	st7789v_transmit(dev, ST7789V_CMD_PWCTRL1, config->pwctrl1_param,
+			 sizeof(config->pwctrl1_param));
 
 	/* Memory Data Access Control */
-	tmp = DT_INST_PROP(0, mdac);
-	st7789v_transmit(dev, ST7789V_CMD_MADCTL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_MADCTL, &config->mdac, 1);
 
 	/* Interface Pixel Format */
-	tmp = DT_INST_PROP(0, colmod);
-	st7789v_transmit(dev, ST7789V_CMD_COLMOD, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_COLMOD, &config->colmod, 1);
 
-	tmp = DT_INST_PROP(0, lcm);
-	st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, &config->lcm, 1);
 
-	tmp = DT_INST_PROP(0, gamma);
-	st7789v_transmit(dev, ST7789V_CMD_GAMSET, &tmp, 1);
+	st7789v_transmit(dev, ST7789V_CMD_GAMSET, &config->gamma, 1);
 
 	st7789v_transmit(dev, ST7789V_CMD_INV_ON, NULL, 0);
 
-	st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL, st7789v_pvgam_param,
-			 sizeof(st7789v_pvgam_param));
+	st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL, config->pvgam_param,
+			 sizeof(config->pvgam_param));
 
-	st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL, st7789v_nvgam_param,
-			 sizeof(st7789v_nvgam_param));
+	st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL, config->nvgam_param,
+			 sizeof(config->nvgam_param));
 
-	st7789v_transmit(dev, ST7789V_CMD_RAMCTRL, st7789v_ram_param,
-			 sizeof(st7789v_ram_param));
+	st7789v_transmit(dev, ST7789V_CMD_RAMCTRL, config->ram_param,
+			 sizeof(config->ram_param));
 
-	st7789v_transmit(dev, ST7789V_CMD_RGBCTRL, st7789v_rgb_param,
-			 sizeof(st7789v_rgb_param));
+	st7789v_transmit(dev, ST7789V_CMD_RGBCTRL, config->rgb_param,
+			 sizeof(config->rgb_param));
 }
 
 static int st7789v_init(const struct device *dev)
@@ -381,12 +386,8 @@ static int st7789v_init(const struct device *dev)
 	}
 #endif
 
-#ifdef CONFIG_PM_DEVICE
-	data->pm_state = PM_DEVICE_STATE_ACTIVE;
-#endif
-
 	data->cmd_data_gpio = device_get_binding(
-			DT_INST_GPIO_LABEL(0, cmd_data_gpios));
+		DT_INST_GPIO_LABEL(0, cmd_data_gpios));
 	if (data->cmd_data_gpio == NULL) {
 		LOG_ERR("Could not get GPIO port for cmd/DATA port");
 		return -EPERM;
@@ -459,13 +460,35 @@ static const struct display_driver_api st7789v_api = {
 	.set_orientation = st7789v_set_orientation,
 };
 
-static struct st7789v_data st7789v_data = {
+const static struct st7789v_config st7789v_config = {
 	.width = DT_INST_PROP(0, width),
 	.height = DT_INST_PROP(0, height),
+	.vcom = DT_INST_PROP(0, vcom),
+	.gctrl = DT_INST_PROP(0, gctrl),
+	.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(0, vrhs) && DT_INST_NODE_HAS_PROP(0, vdvs)),
+	.vrh_value = DT_INST_PROP(0, vrhs),
+	.vdv_value = DT_INST_PROP(0, vdvs),
+	.mdac = DT_INST_PROP(0, mdac),
+	.gamma = DT_INST_PROP(0, gamma),
+	.colmod = DT_INST_PROP(0, colmod),
+	.lcm = DT_INST_PROP(0, lcm),
+	.porch_param = DT_INST_PROP(0, porch_param),
+	.cmd2en_param = DT_INST_PROP(0, cmd2en_param),
+	.pwctrl1_param = DT_INST_PROP(0, pwctrl1_param),
+	.pvgam_param = DT_INST_PROP(0, pvgam_param),
+	.nvgam_param = DT_INST_PROP(0, nvgam_param),
+	.ram_param = DT_INST_PROP(0, ram_param),
+	.rgb_param = DT_INST_PROP(0, rgb_param),
+};
+
+static struct st7789v_data st7789v_data = {
 	.x_offset = DT_INST_PROP(0, x_offset),
 	.y_offset = DT_INST_PROP(0, y_offset),
+#ifdef CONFIG_PM_DEVICE
+	.pm_state = PM_DEVICE_STATE_ACTIVE,
+#endif
 };
 
 DEVICE_DT_INST_DEFINE(0, &st7789v_init,
-	      st7789v_pm_control, &st7789v_data, NULL, APPLICATION,
+	      st7789v_pm_control, &st7789v_data, &st7789v_config, APPLICATION,
 	      CONFIG_APPLICATION_INIT_PRIORITY, &st7789v_api);

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -11,7 +11,7 @@ include: spi-device.yaml
 properties:
     reset-gpios:
       type: phandle-array
-      required: true
+      required: false
       description: RESET pin.
 
         The RESET pin of ST7789V is active low.


### PR DESCRIPTION
In preparation of another change I simplified the code for configuration of the st7789v driver. In several steps almost all the data coming from the device tree moved to the new `struct st7789v_config`.  It is const so that it is stored in FLASH.
I also made naming more consistent, made software reset usable and fix compiling with power management.

I tested this with `samples/drivers/display` on `pinetime_devkit0`.

Before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       25712 B       512 KB      4.90%
            SRAM:       20744 B        64 KB     31.65%
        IDT_LIST:          0 GB         2 KB      0.00%
```

After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       25756 B       512 KB      4.91%
            SRAM:       20680 B        64 KB     31.56%
        IDT_LIST:          0 GB         2 KB      0.00%
```