### PR TITLE
Bluetooth: Mesh: Call `bt_mesh_provision` after prov link closed

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -320,12 +320,12 @@ static void prov_link_closed(const struct prov_bearer *bearer, void *cb_data,
 {
 	BT_DBG("%u", reason);
 
-	if (bt_mesh_prov_link.role->link_closed) {
-		bt_mesh_prov_link.role->link_closed();
-	}
-
 	if (bt_mesh_prov->link_close) {
 		bt_mesh_prov->link_close(bearer->type);
+	}
+
+	if (bt_mesh_prov_link.role->link_closed) {
+		bt_mesh_prov_link.role->link_closed(reason);
 	}
 }
 

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -74,6 +74,7 @@ enum {
 	WAIT_AUTH,              /* Wait for auth response */
 	OOB_STATIC_KEY,         /* OOB Static Authentication */
 	WAIT_DH_KEY,            /* Wait for DH Key */
+	PROV_DATA_COMPLETE,	/* Provisioning data available */
 
 	NUM_FLAGS,
 };
@@ -82,13 +83,23 @@ enum {
 struct bt_mesh_prov_role {
 	void (*link_opened)(void);
 
-	void (*link_closed)(void);
+	void (*link_closed)(enum prov_bearer_link_status reason);
 
 	void (*error)(uint8_t reason);
 
 	void (*input_complete)(void);
 
 	void (*op[10])(const uint8_t *data);
+};
+
+/** Provisioning data */
+struct prov_data {
+	uint8_t net_key[16];
+	uint16_t net_idx;
+	uint8_t flags;
+	uint32_t iv_index;
+	uint16_t addr;
+	uint8_t dev_key[16];
 };
 
 struct bt_mesh_prov_link {
@@ -110,7 +121,12 @@ struct bt_mesh_prov_link {
 
 	uint8_t conf_salt[16];          /* ConfirmationSalt */
 	uint8_t conf_key[16];           /* ConfirmationKey */
-	uint8_t conf_inputs[145];       /* ConfirmationInputs */
+
+	union {
+		struct prov_data data;		/* Provisioning data */
+		uint8_t conf_inputs[145];       /* ConfirmationInputs */
+	};
+
 	uint8_t prov_salt[16];          /* Provisioning Salt */
 };
 

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -647,7 +647,7 @@ static void local_input_complete(void)
 	}
 }
 
-static void prov_link_closed(void)
+static void prov_link_closed(enum prov_bearer_link_status reason)
 {
 	reset_state();
 }


### PR DESCRIPTION
Currently we execute `bt_mesh_provision` after received
provison data pdu. This may be abnormal.

On the one hand, the provision procedure may not be
completed correctly, s it can cause a state of inconsistency.

On the other hand, we call `mod->start` before `link close`
callback, which is not logical.

Therefore, the data of provision data is temporarily cached
and executed after link close.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>