### PR TITLE
drivers: can: mark the CAN API as unstable

### DIFF
--- a/doc/reference/api/overview.rst
+++ b/doc/reference/api/overview.rst
@@ -48,7 +48,7 @@ current :ref:`stability level <api_lifecycle>`.
      - 2.4
 
    * - :ref:`can_api`
-     - Experimental
+     - Unstable
      - 1.14
      - 2.6
 


### PR DESCRIPTION
Mark the Controller Area Network (CAN) driver API as unstable. The CAN API was introduced in Zephyr v1.14 and has since gained support for many different hardware platforms.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>