### PR TITLE
 Fix for VT-d support on x86 platform and enabled Multi MSI.

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -91,6 +91,14 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
 	x86_irq_args[vector - IV_IRQS] = arg;
 }
 
+void z_x86_msi_connect_on_vector(uint8_t vector,
+				 void (*func)(const void *arg),
+				 const void *arg, uint32_t flags)
+{
+	x86_irq_funcs[vector - IV_IRQS] = func;
+	x86_irq_args[vector - IV_IRQS] = arg;
+}
+
 /*
  * N.B.: the API docs don't say anything about returning error values, but
  * this function returns -1 if a vector at the specific priority can't be

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -217,8 +217,8 @@ uint16_t pcie_msi_mdr(unsigned int irq,
 		return 0x4000U | Z_IRQ_TO_INTERRUPT_VECTOR(irq);
 	}
 
-	/* VT-D requires it to be 0, so let's return 0 by default */
-	return 0;
+	/* VT-D requires sub handle and msi it is vector */
+	return vector->arch.vector;
 }
 
 #if defined(CONFIG_INTEL_VTD_ICTL) || defined(CONFIG_PCIE_MSI_X)
@@ -262,8 +262,8 @@ uint8_t arch_pcie_msi_vectors_allocate(unsigned int priority,
 				return 0;
 			}
 
-			for (i = irte; i < (irte + n_vector); i++) {
-				vectors[i].arch.irte = i;
+			for (i = 0; i < n_vector; i++) {
+				vectors[i].arch.irte = irte + i;
 				vectors[i].arch.remap = true;
 			}
 		}
@@ -308,7 +308,7 @@ bool arch_pcie_msi_vector_connect(msi_vector_t *vector,
 	}
 #endif /* CONFIG_INTEL_VTD_ICTL */
 
-	z_x86_irq_connect_on_vector(vector->arch.irq, vector->arch.vector,
+	z_x86_msi_connect_on_vector(vector->arch.vector,
 				    routine, parameter, flags);
 
 	return true;

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -108,6 +108,13 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
 				 void (*func)(const void *arg),
 				 const void *arg, uint32_t flags);
 
+/*
+ * Connect a vector for MSI/MSI-x
+ */
+void z_x86_msi_connect_on_vector(uint8_t vector,
+				 void (*func)(const void *arg),
+				 const void *arg, uint32_t flags);
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_KERNEL_ARCH_FUNC_H_ */

--- a/drivers/interrupt_controller/intc_intel_vtd.h
+++ b/drivers/interrupt_controller/intc_intel_vtd.h
@@ -13,7 +13,7 @@
  * it's always 0
  */
 #define VTD_MSI_MAP(int_idx) \
-	((0x0FEE << 20) | (int_idx << 5) | VTD_INT_SHV | VTD_INT_FORMAT)
+	((0x0FEE << 20) | VTD_INT_SHV | VTD_INT_FORMAT)
 
 /* Interrupt Remapping Table Entry (IRTE) for Remapped Interrupts */
 struct vtd_irte {
@@ -47,7 +47,7 @@ struct vtd_irte {
 #define IRTA_SIZE 7  /* size = 2^(X+1) where IRTA_SIZE is X 2^8 = 256 */
 
 struct vtd_ictl_data {
-	struct vtd_irte irte[IRTE_NUM];
+	struct vtd_irte irte[IRTE_NUM]__attribute__ ((aligned (4096)));
 	int irte_num_used;
 };
 

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -375,6 +375,14 @@
 		compatible = "simple-bus";
 		ranges;
 
+		vtd: vtd@fed65000 {
+			compatible = "intel,vt-d";
+			reg = <0xfed91000 0x1000>;
+
+			label = "VTD_0";
+			status = "okay";
+		};
+
 		uart1_fixed: uart@fe040000 {
 			compatible = "ns16550";
 

--- a/include/arch/x86/intel_vtd.h
+++ b/include/arch/x86/intel_vtd.h
@@ -109,13 +109,13 @@
 
 /* Interrupt Remapping Table Address Register details */
 #define VTD_IRTA_SIZE_MASK	0x00000000000000FF
-#define VTD_IRTA_EIME		11
+#define VTD_IRTA_EIME		1
 #define VTD_IRTA_ADDR_SHIFT	12
+#define VTD_IRTA_EIME_SHIFT	11
 
 #define VTD_IRTA_REG_GEN_CONTENT(addr, size, mode) \
-	(0 |					   \
-	 (addr << VTD_IRTA_ADDR_SHIFT) |	   \
-	 (mode) | (size & VTD_IRTA_SIZE_MASK))
+	((addr) | \
+	 (mode << VTD_IRTA_EIME_SHIFT) | (size & VTD_IRTA_SIZE_MASK))
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
 The vt-d driver have fixes for HW programing sequence as per
 Intel specification. Fixes include HW programming for following:
    - MSI Address/data register update
    - Enable support for compactability mode
    - irte table with 4K aligned memory 
    - Fix irte table add update on IRTA register
    - destination ID update fixed

Signed-off-by: Najumon B.A <najumon.ba@intel.com>