### PR TITLE
drivers: i2c: emul: Link emulators to correct bus

### DIFF
--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -136,7 +136,7 @@ static struct i2c_driver_api i2c_emul_api = {
 
 #define I2C_EMUL_INIT(n) \
 	static const struct emul_link_for_bus emuls_##n[] = { \
-		DT_FOREACH_CHILD(DT_DRV_INST(0), EMUL_LINK_AND_COMMA) \
+		DT_FOREACH_CHILD(DT_DRV_INST(n), EMUL_LINK_AND_COMMA) \
 	}; \
 	static struct emul_list_for_bus i2c_emul_cfg_##n = { \
 		.children = emuls_##n, \


### PR DESCRIPTION
Fix i2c emulated bus initialisation code to use children of specific i2c
bus DTS node instead of first i2c bus instance.

Signed-off-by: Tomasz Michalec <tm@semihalf.com>