### PR TITLE
twister: tests: mcuboot: Add MCUBoot tests and Twister upgrade to support the tests workflow 

### DIFF
--- a/scripts/pylib/twister/stageslib.py
+++ b/scripts/pylib/twister/stageslib.py
@@ -12,7 +12,6 @@ logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-# TODO: DeviceHandler.handle() needs to be refactored so we can lock the device until all stages are done
 
 
 class Image:
@@ -80,7 +79,7 @@ class ExecutionStage:
         if proj_builder:
             self.pb = proj_builder
 
-    def run(self):
+    def run(self, hardware_fixed=None):
         """Define procedure to be executed at a given stage.
 
         Must be implemented in sub classes. Defines actions taken during a given
@@ -100,7 +99,7 @@ class CallScriptsStage(ExecutionStage):
     def __init__(self, description=None, proj_builder=None):
         ExecutionStage.__init__(self, description, proj_builder)
 
-    def run(self):
+    def run(self, hardware_fixed=None):
         """Execute user-defined script"""
         for script in self.description:
             logger.debug(f"Calling: {script}")
@@ -117,7 +116,7 @@ class WestSignStage(ExecutionStage):
     def __init__(self, description=None, proj_builder=None):
         ExecutionStage.__init__(self, description, proj_builder)
 
-    def run(self):
+    def run(self, hardware_fixed=None):
         """Run west sign with arguments that can be defined in description"""
         # 'image' tells twister which image to sign
         image = self.description.get('image', 'main')
@@ -198,7 +197,7 @@ class OnTargetStage(ExecutionStage):
     def __init__(self, description=None, proj_builder=None):
         ExecutionStage.__init__(self, description, proj_builder)
 
-    def run(self):
+    def run(self, hardware_fixed=None):
         """Execute the the test on target.
 
         As in ProjectBuilder.run() but with MultiImage support
@@ -220,7 +219,7 @@ class OnTargetStage(ExecutionStage):
             # Point to image's build dir
             if image:
                 instance.handler.build_dir = instance.multi_build.images[image].build_dir
-            instance.handler.handle(command=command)
+            instance.handler.handle(command=command, hardware_fixed=hardware_fixed)
 
         sys.stdout.flush()
 

--- a/scripts/pylib/twister/stageslib.py
+++ b/scripts/pylib/twister/stageslib.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import subprocess
+import sys
+import os
+import yaml
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+# TODO: DeviceHandler.handle() needs to be refactored so we can lock the device until all stages are done
+
+
+class Image:
+    """Store information about an image and statuses of its stages"""
+    def __init__(self, image, main_build, main_source):
+        self.name = image['name']
+        self.path = image['path']
+        self.extra_args = image.get('extra_args', None)
+        if self.extra_args:
+            self.extra_args = [self.extra_args]
+        else:
+            self.extra_args = []
+        # Each image has two stages, as regular images:
+        # 'cmake' and 'build'. Needed for piping in ProjectBuilder.
+        self.cmake_done = False
+        self.build_done = False
+        self.build_dir = os.path.normpath(os.path.join(main_build, self.name))
+        self.source_dir = os.path.normpath(os.path.join(main_source, self.path))
+
+    def get_args_for_pb(self):
+        """Return args to switch the active image in ProjectBuilder"""
+        args_for_pb = [
+            self.source_dir,
+            self.build_dir,
+            self.extra_args
+        ]
+        return args_for_pb
+
+
+class MultiImage:
+    """Handle tests with multiple images"""
+    def __init__(self, build_dir, source_dir, images):
+        self.main_source = source_dir
+        self.main_build = build_dir
+        self.images = {}
+        for image in images:
+            self.images[image['name']] = Image(image, self.main_build, self.main_source)
+
+    def image_toggler(self, message):
+        """Toggle between images and stages until all images have cmake and build stages done"""
+        # TODO: This can be improved so the loop does not always start from the beginning
+        for image in self.images:
+            args_for_pb = self.images[image].get_args_for_pb()
+            if not self.images[image].cmake_done:
+                op = "cmake"
+                active_image = image
+                break
+            elif not self.images[image].build_done:
+                op = "build"
+                active_image = image
+                break
+        else:
+            # If we got to this place it means all images have all their stages
+            # done and the original op can be proceed
+            active_image = 'main'
+            op = message.get('op')
+        return active_image, op, args_for_pb
+
+
+class ExecutionStage:
+    """Abstract class for test execution stages."""
+    def __init__(self, description=None, proj_builder=None):
+        """Abstract constructor"""
+        self.description = description
+        if proj_builder:
+            self.pb = proj_builder
+
+    def run(self):
+        """Define procedure to be executed at a given stage.
+
+        Must be implemented in sub classes. Defines actions taken during a given
+        stage.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__}.run()")
+
+    def report_error(self, message):
+        """ Report error and set the handler status"""
+        logger.error(message)
+        self.pb.instance.handler.state = "failed"
+        self.pb.instance.reason = message
+
+
+class CallScriptsStage(ExecutionStage):
+    """Stage for running a user-defined script."""
+    def __init__(self, description=None, proj_builder=None):
+        ExecutionStage.__init__(self, description, proj_builder)
+
+    def run(self):
+        """Execute user-defined script"""
+        for script in self.description:
+            logger.debug(f"Calling: {script}")
+            s = script.split()
+            try:
+                run_custom_script(script=s, timeout=15)
+            except Exception as ex:
+                logger.error(ex)
+                self.report_error("Script error")
+
+
+class WestSignStage(ExecutionStage):
+    """ Stage for signing an image using west sign and imgtool."""
+    def __init__(self, description=None, proj_builder=None):
+        ExecutionStage.__init__(self, description, proj_builder)
+
+    def run(self):
+        """Run west sign with arguments that can be defined in description"""
+        # 'image' tells twister which image to sign
+        image = self.description.get('image', 'main')
+        imgtool_path = os.path.join(ZEPHYR_BASE,
+                                    "../bootloader/mcuboot/scripts/imgtool.py")
+
+        # Load args for signing an image
+        img_arg_path = (os.path.join(self.pb.source_dir, "imgtool_conf.yaml"))
+
+        with open(img_arg_path, 'r') as file:
+            try:
+                imgtool_args_file = yaml.safe_load(file)
+            except yaml.YAMLError as exc:
+                logger.error(exc)
+
+        # Load default imgtool args from file
+        imgtool_args = imgtool_args_file['default']
+
+        # Load platform-specific args if needed
+        if self.pb.instance.platform.name in imgtool_args_file:
+            imgtool_args.update(imgtool_args_file[self.pb.instance.platform.name])
+
+        # Update imgtool args if they are given in a stage description
+        if 'imgtool_args' in self.description:
+            imgtool_args.update(self.description['imgtool_args'])
+
+        if imgtool_args['key'] == 'default':
+            imgtool_args['key'] = os.path.join(ZEPHYR_BASE,
+                                               "../bootloader/mcuboot/root-rsa-2048.pem")
+        else:
+            imgtool_args['key'] = os.path.join(ZEPHYR_BASE,
+                                               imgtool_args['key'])
+
+        if self.pb.instance.multi_build:
+            try:
+                img_path = self.pb.instance.multi_build.images[image].build_dir
+            except KeyError:
+                self.report_error(f"Image {image} not defined in multi_build")
+        elif image == 'main':
+            img_path = self.pb.instance.build_dir
+        else:
+            self.report_error(f"Unknown image to sign: {image}")
+            raise Exception("Stage error")
+
+        # Create command for west sign and add extra arguments based on used configuration
+        command = ["west", "sign", "-d", img_path, "--shex",
+                   f"{img_path}/zephyr/zephyr.hex", "-t",
+                   "imgtool", "-p",
+                   imgtool_path, "--"
+                   ]
+        for k, v in imgtool_args.items():
+            arg = f'--{k.replace("_", "-")}'
+            if k == "hex_addr":
+                # --hex-addr is used only with "--pad"
+                continue
+            if v is None:
+                continue
+            elif v is True:
+                command.extend([arg])
+                # Add hex-addr arg only when "pad" is True.
+                if k == "pad":
+                    command.extend(["--hex-addr", imgtool_args['hex_addr']])
+            elif v is False:
+                continue
+            else:
+                command.extend([arg, f"{v}"])
+        # command.append("--")
+
+        logger.debug(" ".join(command))
+        try:
+            run_custom_script(command, timeout=15)
+        except Exception as ex:
+            logger.error(ex)
+            self.report_error("Script error")
+
+
+class OnTargetStage(ExecutionStage):
+    def __init__(self, description=None, proj_builder=None):
+        ExecutionStage.__init__(self, description, proj_builder)
+
+    def run(self):
+        """Execute the the test on target.
+
+        As in ProjectBuilder.run() but with MultiImage support
+        """
+        instance = self.pb.instance
+        suite = self.pb.suite
+        image = self.description.get('image', None)
+        command = self.description.get('command', None)
+
+        # instance.testcase attributes have to be updated with stage specific data
+        for k, v in self.description.items():
+            if k in ["harness", "harness_config"]:
+                setattr(instance.testcase, k, v)
+
+        # As in ProjectBuilder.run()
+        if instance.handler:
+            if instance.handler.type_str == "device":
+                instance.handler.suite = suite
+            # Point to image's build dir
+            if image:
+                instance.handler.build_dir = instance.multi_build.images[image].build_dir
+            instance.handler.handle(command=command)
+
+        sys.stdout.flush()
+
+
+class StageContainer:
+    def __init__(self, proj_builder):
+        self.pb = proj_builder
+        self.stages = self.get_stages()
+        self.total_time = 0
+
+    def __iter__(self):
+        for stage in self.stages:
+            yield stage
+
+    def get_stages(self):
+        stages = []
+        for stage in self.pb.instance.testcase.stages:
+            (name, description), = stage.items()
+            # This will create a stage object of a type given in the name
+            # e.g. for name=CallScript: CallScriptStage(description) object
+            # will be created
+            ev = f"{name}Stage({description}, self.pb)"
+            stages.append(eval(ev))
+        return stages
+
+
+def run_custom_script(script, timeout):
+    with subprocess.Popen(script, stderr=subprocess.PIPE,
+                          stdout=subprocess.PIPE) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            logger.debug(stdout.decode())
+            if stderr:
+                raise Exception(stderr.decode())
+
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            logger.error("{} timed out".format(script))
+            raise TimeoutError

--- a/scripts/schemas/twister/testcase-schema.yaml
+++ b/scripts/schemas/twister/testcase-schema.yaml
@@ -26,6 +26,20 @@ mapping:
       "build_on_all":
         type: bool
         required: no
+      "images":
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              "name":
+                type: str
+                required: yes
+              "path":
+                type: str
+                required: yes
+              "extra_args":
+                type: str
+                required: no
       "depends_on":
         type: str
         required: no
@@ -238,3 +252,89 @@ mapping:
           "slow":
             type: bool
             required: no
+          "images":
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  "name":
+                    type: str
+                    required: yes
+                  "path":
+                    type: str
+                    required: yes
+                  "extra_args":
+                    type: str
+                    required: no
+          "stages":
+            type: seq
+            required: no
+            sequence:
+              - type: map
+                mapping:
+                  "CallScripts":
+                    type: seq
+                    required: no
+                    sequence:
+                      - type: str
+                  "WestSign":
+                    type: map
+                    required: no
+                    mapping:
+                      "image":
+                        type: str
+                        required: no
+                      "imgtool_args":
+                        type: map
+                        required: no
+                        mapping:
+                          "key":
+                            type: str
+                            required: no
+                          "pad":
+                            type: bool
+                            required: no
+                          "hex_addr":
+                            type: str
+                            required: no
+                  "OnTarget":
+                    type: map
+                    required: no
+                    mapping:
+                      "image":
+                        type: str
+                        required: no
+                      "command":
+                        type: str
+                        required: no
+                      "harness":
+                        type: str
+                        required: no
+                      "harness_config":
+                        type: map
+                        required: no
+                        mapping:
+                          "type":
+                            type: str
+                            required: no
+                          "fixture":
+                            type: str
+                            required: no
+                          "ordered":
+                            type: bool
+                            required: no
+                          "repeat":
+                            type: int
+                            required: no
+                          "regex":
+                            type: seq
+                            required: no
+                            sequence:
+                              - type: str
+                          "record":
+                            type: map
+                            required: no
+                            mapping:
+                              "regex":
+                                type: str
+                                required: no

--- a/tests/subsys/mcuboot/ecdsa/testcase.yaml
+++ b/tests/subsys/mcuboot/ecdsa/testcase.yaml
@@ -1,0 +1,219 @@
+common:
+  tags: mcuboot
+  platform_exclude: native_posix
+  integration_platforms:
+    - nrf52840dk_nrf52840
+
+  images:
+    - name: bootloader
+      path: ../../../../../bootloader/mcuboot/boot/zephyr
+      extra_args: OVERLAY_CONFIG=../../samples/zephyr/overlay-ecdsa-p256.conf
+    - name: hello1
+      path: ../hello-world
+      extra_args: FROM_WHO=hello1
+    - name: hello2
+      path: ../hello-world
+      extra_args: FROM_WHO=hello2
+
+tests:
+  mcuboot.ecdsa.good:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello2"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=good, swap_type=0x2, copy_done=0x1, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: revert"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+
+
+  mcuboot.ecdsa.bad:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Image in the secondary slot is not valid!"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+
+  mcuboot.ecdsa.wrong:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/samples/zephyr/bad-keys/bad-ec-p256.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Image in the secondary slot is not valid!"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"

--- a/tests/subsys/mcuboot/hello-world/CMakeLists.txt
+++ b/tests/subsys/mcuboot/hello-world/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Top-level CMakeLists.txt for the skeleton application.
+#
+# Copyright (c) 2017 Open Source Foundries Limited
+# Copyright (c) 2018 Foundries.io Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This provides a basic application structure suitable for loading by
+# mcuboot, which is easy to customize on a per-board basis. It can be
+# used as a starting point for new applications.
+
+cmake_minimum_required(VERSION 3.8)
+
+# find_package(Zephyr) in order to load application boilerplate:
+# http://docs.zephyrproject.org/application/application.html
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+# This string ends up getting printed in the device console
+if (NOT DEFINED FROM_WHO)
+  set(FROM_WHO Zephyr)
+endif()
+
+target_compile_definitions(app PRIVATE "-DMCUBOOT_HELLO_WORLD_FROM=\"${FROM_WHO}\"")
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/mcuboot/hello-world/README.rst
+++ b/tests/subsys/mcuboot/hello-world/README.rst
@@ -1,0 +1,6 @@
+This is a "Hello world" skeleton application which can be used as a
+starting point for Zephyr application development using mcuboot.
+
+It includes the configuration "glue" needed to make the application
+loadable by mcuboot in addition to a basic Zephyr hello world
+application's code.

--- a/tests/subsys/mcuboot/hello-world/boards/.gitignore
+++ b/tests/subsys/mcuboot/hello-world/boards/.gitignore
@@ -1,0 +1,1 @@
+*-local.conf

--- a/tests/subsys/mcuboot/hello-world/boards/README.rst
+++ b/tests/subsys/mcuboot/hello-world/boards/README.rst
@@ -1,0 +1,2 @@
+You can place per-board configuration here. See the comments in the
+CMakeLists.txt for more information.

--- a/tests/subsys/mcuboot/hello-world/imgtool_conf.yaml
+++ b/tests/subsys/mcuboot/hello-world/imgtool_conf.yaml
@@ -1,0 +1,16 @@
+# This file contains imgtool configuration options that are used when WestSign
+# stage is executed in twister. Platform-specific options overwrite default ones.
+# Default values are taken from nrf5240dk configuration
+
+default:
+  'key': default
+  'header_size': "0x200"
+  'align': 8
+  'version': 1.2
+  'slot_size': "0x67000"
+  'pad': false
+  'hex_addr': "0x73000"
+
+nrf52840dk_nrf52840:
+  'slot_size': "0x67000"
+  'hex_addr': "0x73000"

--- a/tests/subsys/mcuboot/hello-world/prj.conf
+++ b/tests/subsys/mcuboot/hello-world/prj.conf
@@ -1,0 +1,9 @@
+# Print a banner on the UART on startup.
+CONFIG_BOOT_BANNER=y
+
+# Enable console and printk()
+CONFIG_PRINTK=y
+CONFIG_STDOUT_CONSOLE=y
+
+# Enable Zephyr application to be booted by MCUboot
+CONFIG_BOOTLOADER_MCUBOOT=y

--- a/tests/subsys/mcuboot/hello-world/src/Makefile
+++ b/tests/subsys/mcuboot/hello-world/src/Makefile
@@ -1,0 +1,1 @@
+obj-y = main.o

--- a/tests/subsys/mcuboot/hello-world/src/main.c
+++ b/tests/subsys/mcuboot/hello-world/src/main.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2017 Linaro, Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+
+void main(void)
+{
+	printk("Hello World from %s on %s!\n",
+	       MCUBOOT_HELLO_WORLD_FROM, CONFIG_BOARD);
+}

--- a/tests/subsys/mcuboot/misc/testcase.yaml
+++ b/tests/subsys/mcuboot/misc/testcase.yaml
@@ -1,0 +1,152 @@
+common:
+  tags: mcuboot
+  platform_exclude: native_posix
+  integration_platforms:
+    - nrf52840dk_nrf52840
+
+tests:
+  mcuboot.misc.overwrite:
+    images:
+      - name: bootloader
+        path: ../../../../../bootloader/mcuboot/boot/zephyr
+        extra_args: OVERLAY_CONFIG=../../samples/zephyr/overlay-upgrade-only.conf
+      - name: hello1
+        path: ../hello-world
+        extra_args: FROM_WHO=hello1
+      - name: hello2
+        path: ../hello-world
+        extra_args: FROM_WHO=hello2
+
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Swap type: none"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Swap type: test"
+              - "Image upgrade secondary slot -> primary slot"
+              - "Erasing the primary slot"
+              - "Copying the secondary slot to the primary slot:" #for nrf52840  0x4638 bytes?
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello2"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello2"
+
+  mcuboot.misc.no_bootcheck:
+    images:
+      - name: bootloader
+        path: ../../../../../bootloader/mcuboot/boot/zephyr
+        extra_args: OVERLAY_CONFIG=../../samples/zephyr/overlay-skip-primary-slot-validate.conf
+      - name: hello1
+        path: ../hello-world
+        extra_args: FROM_WHO=hello1
+      - name: hello2
+        path: ../hello-world
+        extra_args: FROM_WHO=hello2
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "bad image magic"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Image in the secondary slot is not valid!"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"

--- a/tests/subsys/mcuboot/readme.md
+++ b/tests/subsys/mcuboot/readme.md
@@ -1,0 +1,32 @@
+# Complex test scenarios and MCUboot tests
+
+# Why:
+We wanted to fully automatize MCUboot tests. All those tests require building multiple images and executing mutliple stages (e.g. signing images, flashing them consecutevly and checking the output after each flash) within one test scenario. The current Twister workflow doesn't allow for running this kind of tests. Only a single image can be built and flashed during a single test. I wanted to provide means for testers/developers to easily add more complex tests, whitout the need of going into the Twister's backend.
+# What:
+This PR proposes an extension to Twister, allowing for building multiple images and having several on-target stages in a single test. It also adds the MCUboot tests which utilitize the proposed solution. The PR can be splited: Twister part added to Zephyr's and the tests themselves  to the MCUboot's repository.
+# How:
+My PR proposes an easy way for adding more complex test scenarios for Twister. It is based on "keword-driven" approch for test design. A developer/tester should be able to easily design such scenarios within the testcase/sample.yamls, using simple and functional keywords. As a main feature I added "images" and "stages" keywords which tell Twister which images to build and which stages to run. The most new functionality is added in `stageslib.py`. I also had to refactor some parts of `twisterlib.py`, however I tried not to change the original workflow.
+
+
+To run tests with twister one needs to:
+- checkout this PR
+- has nrf52840dk connected (e.g. to /dev/ttyACM0)
+- run in zephyr's dir:`scripts/twister -T /tests/subsys/mcuboot/ -p nrf52840dk_nrf52840 --device-testing --device-serial /dev/ttyACM0 -v -v --inline-logs`
+
+
+# MCUboot tests:
+
+Added tests are based on the tests from: [https://github.com/mcu-tools/mcuboot/tree/main/samples/zephyr](https://github.com/mcu-tools/mcuboot/tree/main/samples/zephyr) `run-tests.sh` and `Makefile`. I used a version configured for nrf52840dk https://github.com/nvlsianpu/mcuboot/tree/mod-for-nrf52840-testing/samples/zephyr
+
+All tests have the same workflow:
+  -   build (with overlay) bootloader, hello1, hello2,
+  -   sign hello1 and hello2 with varying args used,
+  -   flash bootloader an read output, flash hello1 and read output, flash hello2 and read output, reset and read output.
+
+The idea is that testcase.yamls should contain platform-independant configurations and regex checks. Platform specific arguments needed for imgtool are stored in `hello-word/ingtool_conf.yaml`
+
+I added args required by imgtool to `hello-word/ingtool_conf.yaml`.  Lines to be checked in `testcase.yaml` are based on the output I've seen when running run-tests.sh with https://github.com/nvlsianpu/mcuboot/tree/mod-for-nrf52840-testing/samples/zephyr It is possible that not all lines are needed and some has to be modified to be platform-independant. In addition, `hello-word/ingtool_conf.yaml`has to be expanded adding args for other platforms.
+
+# TODO:
+- twisterlib.py  needs extra refactoring by extracting command-building method for flashing binaries and adding other options (e.g. reseting) to it. I used a temp hack where `pyocd commander -c reset` is called to reset a board instead a regular flashing command. This won't work when more boards are connected. In addition I tested my PR with nrf52840 and nrfjprog which recognises where to flash thanks to the data from Intel hexes. For other boards/runners we might need to expand command building with these information. E.g.
+`pyocd flash -a 0x20000 signed-hello1.bin` vs `pyocd flash -a 0x80000 signed-hello2.bin`

--- a/tests/subsys/mcuboot/rsa/testcase.yaml
+++ b/tests/subsys/mcuboot/rsa/testcase.yaml
@@ -1,0 +1,217 @@
+common:
+  tags: mcuboot
+  platform_exclude: native_posix
+  integration_platforms:
+    - nrf52840dk_nrf52840
+
+  images:
+    - name: bootloader
+      path: ../../../../../bootloader/mcuboot/boot/zephyr
+      extra_args: OVERLAY_CONFIG=../../samples/zephyr/overlay-rsa.conf
+    - name: hello1
+      path: ../hello-world
+      extra_args: FROM_WHO=hello1
+    - name: hello2
+      path: ../hello-world
+      extra_args: FROM_WHO=hello2
+
+tests:
+  mcuboot.rsa.good:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello2"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=good, swap_type=0x2, copy_done=0x1, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: revert"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+
+  mcuboot.rsa.bad:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-ec-p256.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Image in the secondary slot is not valid!"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+
+  mcuboot.rsa.wrong:
+    stages:
+      - WestSign:
+          image: hello1
+          imgtool_args:
+            key: ../bootloader/mcuboot/root-rsa-2048.pem
+      - WestSign:
+          image: hello2
+          imgtool_args:
+            key: ../bootloader/mcuboot/samples/zephyr/bad-keys/bad-rsa-2048.pem
+            pad: true
+      - OnTarget:
+          image: bootloader
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Failed reading image headers; Image=0"
+              - "Unable to find bootable image"
+      - OnTarget:
+          image: hello1
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          image: hello2
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: test"
+              - "Image in the secondary slot is not valid!"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"
+      - OnTarget:
+          command: "pyocd commander -c reset"
+          harness: console
+          harness_config:
+            type: multi_line
+            regex:
+              - "Starting bootloader"
+              - "Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3"
+              - "Boot source: none"
+              - "Swap type: none"
+              - "Bootloader chainload address offset:" #for nrf52840  0xc000
+              - "Jumping to the first image slot"
+              - "Hello World from hello1"


### PR DESCRIPTION
Add the possibility to run tests with multiple images and stages. Such workflow is required for mcuboot tests, where the bootloader and two other images has to be build, signed and flashed consecutively. 
Add twister tests for mcuboot using new multi-image and stages features. The tests are based on workflow from run_tests.sh and Makefile at https://github.com/mcu-tools/mcuboot/tree/main/samples/zephyr 
Content of  "tests/subsys/mcuboot/hello-world" is copied from the above link. Only imgtool_conf.yaml is new there and is used to allow for configuration of signing based on the tested platform.
