### PR TITLE
driver: pxp: add the pxp driver for the rt117x

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -278,6 +278,7 @@
 /drivers/pwm/*gecko*                      @sun681
 /drivers/pwm/*it8xxx2*                    @RuibinChang
 /drivers/sensor/                          @MaureenHelm
+/drivers/pxp/                             @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter
 /drivers/sensor/hts*/                     @avisconti
@@ -436,6 +437,7 @@
 /include/drivers/led.h                    @Mani-Sadhasivam
 /include/drivers/led_strip.h              @mbolivar-nordic
 /include/drivers/sensor.h                 @MaureenHelm
+/include/drivers/pxp.h                    @MaureenHelm
 /include/drivers/spi.h                    @tbursztyka
 /include/drivers/lora.h                   @Mani-Sadhasivam
 /include/drivers/peci.h                   @albertofloyd @franciscomunoz @scottwcpg
@@ -544,6 +546,7 @@
 /samples/net/sockets/                     @rlubos @tbursztyka @pfalcon
 /samples/net/*civetweb*                   @Nukersson
 /samples/sensor/                          @MaureenHelm
+/samples/pxp/                             @MaureenHelm
 /samples/shields/                         @avisconti
 /samples/subsys/logging/                  @nordic-krch @jakub-uC
 /samples/subsys/shell/                    @jakub-uC @nordic-krch

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -49,3 +49,7 @@
 		jedec-id = [9d 70 17];
 	};
 };
+
+&pxp {
+	status = "okay";
+};

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(misc)
 add_subdirectory(pcie)
 add_subdirectory(disk)
 
+add_subdirectory_ifdef(CONFIG_PXP_MCUX_PXP pxp)
 add_subdirectory_ifdef(CONFIG_ADC adc)
 add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL clock_control)
 add_subdirectory_ifdef(CONFIG_COUNTER counter)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -115,4 +115,6 @@ source "drivers/disk/Kconfig"
 
 source "drivers/cache/Kconfig"
 
+source "drivers/pxp/Kconfig"
+
 endmenu

--- a/drivers/pxp/CMakeLists.txt
+++ b/drivers/pxp/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_PXP_MCUX_PXP	mcux_pxp.c)

--- a/drivers/pxp/Kconfig
+++ b/drivers/pxp/Kconfig
@@ -1,0 +1,18 @@
+# PXP driver configuration options
+
+# Copyright (c) 2019 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# PXP Drivers
+#
+menuconfig PXP
+	bool "NXP PXP hardware support"
+	help
+	  Enable support for the PXP.
+
+if PXP
+
+source "drivers/pxp/Kconfig.mcux_pxp"
+
+endif # PXP

--- a/drivers/pxp/Kconfig.mcux_pxp
+++ b/drivers/pxp/Kconfig.mcux_pxp
@@ -1,0 +1,8 @@
+# NXP MCUX PXP driver configuration options
+
+# Copyright (c) 2019, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+config PXP_MCUX_PXP
+	bool "NXP MCUX PXP driver"
+	depends on HAS_MCUX_PXP

--- a/drivers/pxp/mcux_pxp.c
+++ b/drivers/pxp/mcux_pxp.c
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2019, Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_imx_pxp
+
+#include <zephyr.h>
+
+#include <drivers/pxp.h>
+
+struct mcux_pxp_config {
+	PXP_Type *base;
+};
+
+struct mcux_pxp_data {
+	struct k_sem sem;
+};
+
+static int mcux_pxp_start(const struct device *dev)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_Start(base);
+	return 0;
+}
+
+static int mcux_pxp_set_process_blocksize(const struct device *dev,
+									pxp_block_size_t size)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessBlockSize(base, size);
+	return 0;
+}
+
+static int mcux_pxp_set_as_buffer(const struct device *dev,
+							const pxp_as_buffer_config_t *config)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetAlphaSurfaceBufferConfig(base, config);
+	return 0;
+}
+
+static int mcux_pxp_set_as_blend(const struct device *dev,
+								const pxp_as_blend_config_t *config)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetAlphaSurfaceBlendConfig(base, config);
+	return 0;
+}
+
+static int mcux_pxp_set_as_overlay_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetAlphaSurfaceOverlayColorKey(base, colorLow, colorHigh);
+	return 0;
+}
+
+static int mcux_pxp_enable_as_overlay_color(const struct device *dev,
+											bool enable)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_EnableAlphaSurfaceOverlayColorKey(base, enable);
+	return 0;
+}
+
+
+static int mcux_pxp_set_as_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetAlphaSurfacePosition(base, upperLeftX, upperLeftY,
+								lowerRightX, lowerRightY);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_bg_color(const struct device *dev,
+									uint32_t bgColor)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfaceBackGroundColor(base, bgColor);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_buffer(const struct device *dev,
+							const pxp_ps_buffer_config_t *config)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfaceBufferConfig(base, config);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_scaler(const struct device *dev,
+								uint16_t inputWidth,
+								uint16_t inputHeight,
+								uint16_t outputWidth,
+								uint16_t outputHeight)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfaceScaler(base, inputWidth, inputHeight,
+								outputWidth, outputHeight);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfacePosition(base, upperLeftX, upperLeftY,
+									lowerRightX, lowerRightX);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfaceColorKey(base, colorLow, colorHigh);
+	return 0;
+}
+
+static int mcux_pxp_set_ps_YUVFormat(const struct device *dev,
+									pxp_ps_yuv_format_t format)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetProcessSurfaceYUVFormat(base, format);
+	return 0;
+}
+
+static int mcux_pxp_set_output_buffer(const struct device *dev,
+							const pxp_output_buffer_config_t *config)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetOutputBufferConfig(base, config);
+	return 0;
+}
+
+static int mcux_pxp_set_overwritten_alpha_value(const struct device *dev,
+										uint8_t alpha)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetOverwrittenAlphaValue(base, alpha);
+	return 0;
+}
+
+static int mcux_pxp_enable_overwritten_alpha(const struct device *dev,
+										bool enable)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_EnableOverWrittenAlpha(base, enable);
+	return 0;
+}
+
+static int mcux_pxp_set_rotate(const struct device *dev,
+							   pxp_rotate_position_t position,
+							   pxp_rotate_degree_t degree,
+							   pxp_flip_mode_t flipMode)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetRotateConfig(base, position, degree, flipMode);
+	return 0;
+}
+
+static int mcux_pxp_set_csc1(const struct device *dev,
+							pxp_csc1_mode_t mode)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_SetCsc1Mode(base, mode);
+	return 0;
+}
+
+static int mcux_pxp_enable_csc1(const struct device *dev,
+								bool enable)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_EnableCsc1(base, enable);
+	return 0;
+}
+
+static int mcux_pxp_start_pic_copy(const struct device *dev,
+							const pxp_pic_copy_config_t *config)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	return PXP_StartPictureCopy(base, config);
+}
+
+static int mcux_pxp_start_mem_copy(const struct device *dev,
+									uint32_t srcAddr,
+									uint32_t destAddr,
+									uint32_t size)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	return PXP_StartMemCopy(base, srcAddr, destAddr, size);
+}
+
+static int mcux_pxp_wait_complete(const struct device *dev)
+{
+	struct mcux_pxp_data *data = dev->data;
+
+	k_sem_take(&data->sem, K_FOREVER);
+
+	return 0;
+}
+
+static int mcux_pxp_stop(const struct device *dev)
+{
+	struct mcux_pxp_config *pxp_config = (struct mcux_pxp_config *)dev->config;
+	PXP_Type *base = pxp_config->base;
+
+	PXP_Deinit(base);
+	return 0;
+}
+
+static const struct pxp_driver_api mcux_pxp_driver_api = {
+	.start = mcux_pxp_start,
+	.set_process_blocksize = mcux_pxp_set_process_blocksize,
+	.set_as_buffer = mcux_pxp_set_as_buffer,
+	.set_as_blend = mcux_pxp_set_as_blend,
+	.set_as_overlay_color = mcux_pxp_set_as_overlay_color,
+	.enable_as_overlay_color = mcux_pxp_enable_as_overlay_color,
+	.set_as_position = mcux_pxp_set_as_position,
+	.set_ps_bg_color = mcux_pxp_set_ps_bg_color,
+	.set_ps_buffer = mcux_pxp_set_ps_buffer,
+	.set_ps_scaler = mcux_pxp_set_ps_scaler,
+	.set_ps_position = mcux_pxp_set_ps_position,
+	.set_ps_color = mcux_pxp_set_ps_color,
+	.set_ps_YUVFormat = mcux_pxp_set_ps_YUVFormat,
+	.set_output_buffer = mcux_pxp_set_output_buffer,
+	.set_overwritten_alpha_value = mcux_pxp_set_overwritten_alpha_value,
+	.enable_overwritten_alpha = mcux_pxp_enable_overwritten_alpha,
+	.set_rotate = mcux_pxp_set_rotate,
+	.set_csc1 = mcux_pxp_set_csc1,
+	.enable_csc1 = mcux_pxp_enable_csc1,
+	.start_pic_copy = mcux_pxp_start_pic_copy,
+	.start_mem_copy = mcux_pxp_start_mem_copy,
+	.wait_complete = mcux_pxp_wait_complete,
+	.stop = mcux_pxp_stop,
+};
+
+static void mcux_pxp_isr(struct device *dev)
+{
+	const struct mcux_pxp_config *config = dev->config;
+	struct mcux_pxp_data *data = dev->data;
+	uint32_t status;
+
+	status = PXP_GetStatusFlags(config->base);
+	PXP_ClearStatusFlags(config->base, status);
+
+	k_sem_give(&data->sem);
+
+}
+
+static int mcux_pxp_init(const struct device *dev)
+{
+	const struct mcux_pxp_config *config = dev->config;
+	struct mcux_pxp_data *data = dev->data;
+
+	k_sem_init(&data->sem, 0, 1);
+
+	PXP_Init(config->base);
+
+	PXP_EnableInterrupts(config->base, kPXP_CompleteInterruptEnable);
+
+	return 0;
+}
+
+static const struct mcux_pxp_config mcux_pxp_config_0 = {
+	.base = (PXP_Type *)DT_INST_REG_ADDR(0),
+};
+
+static struct mcux_pxp_data mcux_pxp_data_0;
+
+static int mcux_pxp_init_0(const struct device *dev)
+{
+
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
+		    mcux_pxp_isr, DEVICE_DT_INST_GET(0), 0);
+
+	irq_enable(DT_INST_IRQN(0));
+
+	return mcux_pxp_init(dev);
+}
+
+DEVICE_DT_INST_DEFINE(0, &mcux_pxp_init_0,
+		    device_pm_control_nop, &mcux_pxp_data_0,
+		    &mcux_pxp_config_0,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &mcux_pxp_driver_api);

--- a/dts/arm/nxp/nxp_rt117x.dtsi
+++ b/dts/arm/nxp/nxp_rt117x.dtsi
@@ -784,6 +784,14 @@
 			compatible = "mmio-sram";
 			reg = <0x202c0000 DT_SIZE_K(512)>;
 		};
+
+		pxp: pxp@40814000 {
+			compatible = "nxp,imx-pxp";
+			reg = <0x40814000 0x444>;
+			status = "disabled";
+			interrupts = <57 0>;
+			label = "PXP";
+		};
 	};
 };
 

--- a/dts/bindings/pxp/nxp,imx-pxp.yaml
+++ b/dts/bindings/pxp/nxp,imx-pxp.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: NXP MCUX PXP module
+
+compatible: "nxp,imx-pxp"
+
+include: base.yaml
+
+properties:
+    interrupts:
+      required: true
+
+    label:
+      required: true

--- a/include/drivers/pxp.h
+++ b/include/drivers/pxp.h
@@ -1,0 +1,741 @@
+/*
+ * Copyright 2017-2020 NXP
+ * All right reserved.
+ *
+ * SPDX-License-Identifier: apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Dedicated APIs for the PXP drivers.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PXP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PXP_H_
+
+#include <zephyr/types.h>
+#include <device.h>
+
+/**
+ * @brief PXP Interface
+ * @defgroup pxp_interface PXP Interface
+ * @{
+ */
+#include "fsl_pxp.h"
+typedef int (*pxp_api_start)(const struct device *dev);
+typedef int (*pxp_api_set_process_blocksize)(const struct device *dev,
+								pxp_block_size_t size);
+typedef int (*pxp_api_set_as_buffer)(const struct device *dev,
+							const pxp_as_buffer_config_t *config);
+typedef int (*pxp_api_set_as_blend)(const struct device *dev,
+							const pxp_as_blend_config_t *config);
+typedef int (*pxp_api_set_as_overlay_color)(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh);
+typedef int (*pxp_api_enable_as_overlay_color)(const struct device *dev,
+										bool enable);
+typedef int (*pxp_api_set_as_position)(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY);
+typedef int (*pxp_api_set_ps_bg_color)(const struct device *dev,
+									uint32_t bgColor);
+typedef int (*pxp_api_set_ps_buffer)(const struct device *dev,
+							const pxp_ps_buffer_config_t *config);
+typedef int (*pxp_api_set_ps_scaler)(const struct device *dev,
+								uint16_t inputWidth,
+								uint16_t inputHeight,
+								uint16_t outputWidth,
+								uint16_t outputHeight);
+typedef int (*pxp_api_set_ps_position)(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY);
+typedef int (*pxp_api_set_ps_color)(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh);
+typedef int (*pxp_api_set_ps_YUVFormat)(const struct device *dev,
+									pxp_ps_yuv_format_t format);
+typedef int (*pxp_api_set_output_buffer)(const struct device *dev,
+						const pxp_output_buffer_config_t *config);
+typedef int (*pxp_api_set_overwritten_alpha_value)(const struct device *dev,
+									uint8_t alpha);
+typedef int (*pxp_api_enable_overwritten_alpha)(const struct device *dev,
+										bool enable);
+typedef int (*pxp_api_set_rotate)(const struct device *dev,
+							   pxp_rotate_position_t position,
+							   pxp_rotate_degree_t degree,
+							   pxp_flip_mode_t flipMode);
+typedef int (*pxp_api_set_csc1)(const struct device *dev,
+							pxp_csc1_mode_t mode);
+typedef int (*pxp_api_enable_csc1)(const struct device *dev,
+								bool enable);
+typedef int (*pxp_api_start_pic_copy)(const struct device *dev,
+							const pxp_pic_copy_config_t *config);
+typedef int (*pxp_api_start_mem_copy)(const struct device *dev,
+									uint32_t srcAddr,
+									uint32_t destAddr,
+									uint32_t size);
+typedef int (*pxp_api_wait_complete)(const struct device *dev);
+typedef int (*pxp_api_stop)(const struct device *dev);
+
+__subsystem struct pxp_driver_api {
+	pxp_api_start start;
+	pxp_api_set_process_blocksize set_process_blocksize;
+	pxp_api_set_as_buffer set_as_buffer;
+	pxp_api_set_as_blend set_as_blend;
+	pxp_api_set_as_overlay_color set_as_overlay_color;
+	pxp_api_enable_as_overlay_color enable_as_overlay_color;
+	pxp_api_set_as_position set_as_position;
+	pxp_api_set_ps_bg_color set_ps_bg_color;
+	pxp_api_set_ps_buffer set_ps_buffer;
+	pxp_api_set_ps_scaler set_ps_scaler;
+	pxp_api_set_ps_position set_ps_position;
+	pxp_api_set_ps_color set_ps_color;
+	pxp_api_set_ps_YUVFormat set_ps_YUVFormat;
+	pxp_api_set_output_buffer set_output_buffer;
+	pxp_api_set_overwritten_alpha_value set_overwritten_alpha_value;
+	pxp_api_enable_overwritten_alpha enable_overwritten_alpha;
+	pxp_api_set_rotate set_rotate;
+	pxp_api_set_csc1 set_csc1;
+	pxp_api_enable_csc1 enable_csc1;
+	pxp_api_start_pic_copy start_pic_copy;
+	pxp_api_start_mem_copy start_mem_copy;
+	pxp_api_wait_complete wait_complete;
+	pxp_api_stop stop;
+};
+
+/**
+ * @brief Start process
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_start(const struct device *dev);
+static inline int z_impl_pxp_start(const struct device *dev)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->start == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->start(dev);
+}
+
+/**
+ * @brief Set the PXP processing block size
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param size The pixel block size.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+
+ */
+
+__syscall int pxp_set_process_blocksize(const struct device *dev,
+									pxp_block_size_t size);
+static inline int z_impl_pxp_set_process_blocksize(const struct device *dev,
+									pxp_block_size_t size)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_process_blocksize == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_process_blocksize(dev, size);
+}
+
+/**
+ * @brief Set the alpha surface input buffer configuration
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config Pointer to the configuration.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_as_buffer(const struct device *dev,
+							const pxp_as_buffer_config_t *config);
+static inline int z_impl_pxp_set_as_buffer(const struct device *dev,
+							const pxp_as_buffer_config_t *config)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_as_buffer == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_as_buffer(dev, config);
+}
+
+/**
+ * @brief Set the alpha surface blending configuration
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config Pointer to the configuration structure.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_as_blend(const struct device *dev,
+							const pxp_as_blend_config_t *config);
+static inline int z_impl_pxp_set_as_blend(const struct device *dev,
+							const pxp_as_blend_config_t *config)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_as_blend == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_as_blend(dev, config);
+}
+
+/**
+ * @brief Set the alpha surface overlay color key.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param colorLow Color key low range .
+ * @param colorHigh Color key high range.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_as_overlay_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh);
+static inline int z_impl_pxp_set_as_overlay_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_as_overlay_color == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_as_overlay_color(dev, colorLow, colorHigh);
+}
+
+/**
+ * @brief Enable or disable the alpha surface color key.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param enable True to enable, false to disable.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_enable_as_overlay_color(const struct device *dev,
+										bool enable);
+static inline int z_impl_pxp_enable_as_overlay_color(const struct device *dev,
+										bool enable)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->enable_as_overlay_color == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->enable_as_overlay_color(dev, enable);
+}
+
+/**
+ * @brief Set the alpha surface position in output buffer.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param upperLeftX X of the upper left corner.
+ * @param upperLeftY Y of the upper left corner.
+ * @param lowerRightX X of the lower right corner.
+ * @param lowerRightY Y of the lower right corner.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_as_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY);
+static inline int z_impl_pxp_set_as_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_as_position == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_as_position(dev,
+								upperLeftX, upperLeftY,
+								lowerRightX, lowerRightY);
+}
+
+/**
+ * @brief Set the back ground color of PS
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param bgColor Pixel value of the background color.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_bg_color(const struct device *dev,
+									uint32_t bgColor);
+static inline int z_impl_pxp_set_ps_bg_color(const struct device *dev,
+									uint32_t bgColor)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_bg_color == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_bg_color(dev, bgColor);
+}
+
+/**
+ * @brief Set the process surface input buffer configuration.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config Pointer to the configuration.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_buffer(const struct device *dev,
+							const pxp_ps_buffer_config_t *config);
+static inline int z_impl_pxp_set_ps_buffer(const struct device *dev,
+							const pxp_ps_buffer_config_t *config)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_buffer == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_buffer(dev, config);
+}
+
+/**
+ * @brief Set the process surface scaler configuration.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param inputWidth Input image width.
+ * @param inputHeight Input image height.
+ * @param outputWidth Output image width.
+ * @param outputHeight Output image height.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_scaler(const struct device *dev,
+								uint16_t inputWidth,
+								uint16_t inputHeight,
+								uint16_t outputWidth,
+								uint16_t outputHeight);
+static inline int z_impl_pxp_set_ps_scaler(const struct device *dev,
+								uint16_t inputWidth,
+								uint16_t inputHeight,
+								uint16_t outputWidth,
+								uint16_t outputHeight)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_scaler == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_scaler(dev, inputWidth, inputHeight,
+								outputWidth, outputHeight);
+}
+
+/**
+ * @brief Set the process surface position in output buffer.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param upperLeftX X of the upper left corner.
+ * @param upperLeftY Y of the upper left corner.
+ * @param lowerRightX X of the lower right corner.
+ * @param lowerRightY Y of the lower right corner.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY);
+static inline int z_impl_pxp_set_ps_position(const struct device *dev,
+									uint16_t upperLeftX,
+									uint16_t upperLeftY,
+									uint16_t lowerRightX,
+									uint16_t lowerRightY)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_position == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_position(dev,
+								upperLeftX, upperLeftY,
+								lowerRightX, lowerRightY);
+}
+
+/**
+ * @brief Set the process surface color key.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param colorLow Color key low range.
+ * @param colorHigh Color key high range.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh);
+static inline int z_impl_pxp_set_ps_color(const struct device *dev,
+										uint32_t colorLow,
+										uint32_t colorHigh)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_color == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_color(dev, colorLow, colorHigh);
+}
+
+/**
+ * @brief Set the process surface input pixel format YUV or YCbCr.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param format The YUV format.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_ps_YUVFormat(const struct device *dev,
+									pxp_ps_yuv_format_t format);
+static inline int z_impl_pxp_set_ps_YUVFormat(const struct device *dev,
+									pxp_ps_yuv_format_t format)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_ps_YUVFormat == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_ps_YUVFormat(dev, format);
+}
+
+/**
+ * @brief Set the PXP output buffer configuration.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config Pointer to the configuration.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_output_buffer(const struct device *dev,
+						const pxp_output_buffer_config_t *config);
+static inline int z_impl_pxp_set_output_buffer(const struct device *dev,
+						const pxp_output_buffer_config_t *config)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_output_buffer == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_output_buffer(dev, config);
+}
+
+/**
+ * @brief Set the global overwritten alpha value.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param alpha The alpha value.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_overwritten_alpha_value(const struct device *dev,
+										uint8_t alpha);
+static inline int z_impl_pxp_set_overwritten_alpha_value(const struct device *dev,
+										uint8_t alpha)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_overwritten_alpha_value == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_overwritten_alpha_value(dev, alpha);
+}
+
+/**
+ * @brief Enable or disable the global overwritten alpha value.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param enable True to enable, false to disable.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_enable_overwritten_alpha(const struct device *dev,
+										bool enable);
+static inline int z_impl_pxp_enable_overwritten_alpha(const struct device *dev,
+										bool enable)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->enable_overwritten_alpha == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->enable_overwritten_alpha(dev, enable);
+}
+
+/**
+ * @brief Set the rotation configuration.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param position Rotate process surface or output buffer.
+ * @param degree Rotate degree.
+ * @param flipMode Flip mode.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_rotate(const struct device *dev,
+							   pxp_rotate_position_t position,
+							   pxp_rotate_degree_t degree,
+							   pxp_flip_mode_t flipMode);
+static inline int z_impl_pxp_set_rotate(const struct device *dev,
+							   pxp_rotate_position_t position,
+							   pxp_rotate_degree_t degree,
+							   pxp_flip_mode_t flipMode)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_rotate == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_rotate(dev, position, degree, flipMode);
+}
+
+/* omit the command queue */
+
+/* omit the csc2 config */
+
+/**
+ * @brief Set the CSC1 mode.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mode The conversion mode.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_set_csc1(const struct device *dev,
+							pxp_csc1_mode_t mode);
+static inline int z_impl_pxp_set_csc1(const struct device *dev,
+							pxp_csc1_mode_t mode)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->set_csc1 == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->set_csc1(dev, mode);
+}
+
+/**
+ * @brief Enable or disable the CSC1.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param enable True to enable, false to disable.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_enable_csc1(const struct device *dev,
+								bool enable);
+static inline int z_impl_pxp_enable_csc1(const struct device *dev,
+								bool enable)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->enable_csc1 == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->enable_csc1(dev, enable);
+}
+
+/* omit pxp lut */
+
+/* omit pxp dither */
+
+/* omit pxp porter */
+
+/**
+ * @brief Copy picture from one buffer to another buffer.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config Pointer to the picture copy configuration structure.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_start_pic_copy(const struct device *dev,
+							const pxp_pic_copy_config_t *config);
+static inline int z_impl_pxp_start_pic_copy(const struct device *dev,
+							const pxp_pic_copy_config_t *config)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->start_pic_copy == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->start_pic_copy(dev, config);
+}
+
+/**
+ * @brief Copy continuous memory, the copy size should be 512 byte aligned.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param srcAddr Source memory address.
+ * @param destAddr Destination memory address.
+ * @param size How many bytes to copy, should be 512 byte aligned.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_start_mem_copy(const struct device *dev,
+									uint32_t srcAddr,
+									uint32_t destAddr,
+									uint32_t size);
+static inline int z_impl_pxp_start_mem_copy(const struct device *dev,
+									uint32_t srcAddr,
+									uint32_t destAddr,
+									uint32_t size)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->start_mem_copy == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->start_mem_copy(dev, srcAddr, destAddr, size);
+}
+
+/**
+ * @brief Wait until the processing done.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_wait_complete(const struct device *dev);
+static inline int z_impl_pxp_wait_complete(const struct device *dev)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->wait_complete == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->wait_complete(dev);
+}
+
+/**
+ * @brief Stop the PXP.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+
+__syscall int pxp_stop(const struct device *dev);
+static inline int z_impl_pxp_stop(const struct device *dev)
+{
+	const struct pxp_driver_api *api =
+		(const struct pxp_driver_api *)dev->api;
+
+	if (api->stop == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->stop(dev);
+}
+
+/**
+ * @}
+ */
+
+#include <syscalls/pxp.h>
+#endif/* ZEPHYR_INCLUDE_DRIVERS_PXP_H_ */

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -273,4 +273,9 @@ config HAS_MCUX_RCM
 	  Set if the Reset Control Module (RCM) module is present in
 	  the SoC.
 
+config HAS_MCUX_PXP
+	bool
+	help
+	  Set if the PXP module is present on the SoC.
+
 endif # HAS_MCUX

--- a/samples/index.rst
+++ b/samples/index.rst
@@ -15,6 +15,7 @@ Samples and Demos
    net/net.rst
    bluetooth/bluetooth.rst
    sensor/*
+   pxp/*
    arch/*
    boards/*
    drivers/drivers.rst

--- a/samples/pxp/CMakeLists.txt
+++ b/samples/pxp/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pxp)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/pxp/Kconfig
+++ b/samples/pxp/Kconfig
@@ -1,0 +1,18 @@
+# Config for pxp sample
+
+# Copyright (c) 2019 NXP Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+choice
+	prompt "Build which PXP sample"
+	default PXP_ROTATE_FLIP
+
+config PXP_ROTATE_FLIP
+	bool "PXP rotate & flip sample"
+
+config PXP_SCALER
+	bool "PXP scaler sample"
+
+endchoice
+
+source "Kconfig.zephyr"

--- a/samples/pxp/README.rst
+++ b/samples/pxp/README.rst
@@ -1,0 +1,33 @@
+.. _pxp_demo:
+
+PXP demo
+########
+
+Overview
+********
+
+some samples that can be used with any :ref:`supported board <boards>` and
+to show how the pxp works.
+
+Building and Running
+********************
+
+This application can be built and executed on QEMU as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/pxp
+   :host-os: unix
+   :board: qemu_x86
+   :goals: build
+   :compact:
+
+To build for another board, change "qemu_x86" above to that board's name.
+
+Sample Output
+=============
+
+.. code-block:: console
+
+    Convert Done!
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/pxp/prj.conf
+++ b/samples/pxp/prj.conf
@@ -1,0 +1,2 @@
+# nothing here
+CONFIG_PXP=y

--- a/samples/pxp/sample.yaml
+++ b/samples/pxp/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: pxp
+tests:
+  sample.pxp:
+    build_only: true
+    tags: pxp
+    platform_allow: mimxrt1050_evk mimxrt1060_evk mimxrt1064_evk mimxrt1170_evk_cm7
+    depends_on: pxp

--- a/samples/pxp/src/main.c
+++ b/samples/pxp/src/main.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+
+#define PXP_NODE DT_NODELABEL(pxp)
+#if DT_NODE_HAS_STATUS(PXP_NODE, okay)
+#define PXP_LABEL DT_LABEL(PXP_NODE)
+#include "drivers/pxp.h"
+#endif
+
+#if CONFIG_PXP_ROTATE_FLIP
+#define SCALER (1)
+#define DEMO_NAME "Rotate & Flip"
+#endif
+
+#if CONFIG_PXP_SCALER
+#define SCALER (4)
+#define DEMO_NAME "Scaler"
+#endif
+
+#define WIDTH 720
+#define HEIGHT 720
+static uint16_t s_psBufferPxp[HEIGHT][WIDTH];
+static uint16_t s_outputBuffer[HEIGHT][WIDTH];
+void main(void)
+{
+	uint16_t outputWidth = WIDTH / SCALER, outputHeight = HEIGHT / SCALER;
+
+	/* init the ps buffer */
+	memset(s_psBufferPxp, 0x56, sizeof(s_psBufferPxp) / 2);
+	memset((char *)s_psBufferPxp + HEIGHT * WIDTH, 0x89, sizeof(s_psBufferPxp) / 2);
+
+	const struct device *dev = device_get_binding(PXP_LABEL);
+	const pxp_ps_buffer_config_t psBufferConfig = {
+		.pixelFormat = kPXP_PsPixelFormatRGB565,
+		.swapByte = false,
+		.bufferAddr = (uint32_t)s_psBufferPxp,
+		.bufferAddrU = 0U,
+		.bufferAddrV = 0U,
+		.pitchBytes = WIDTH * 2,
+	};
+
+	pxp_set_ps_bg_color(dev, 0U);
+	pxp_set_ps_buffer(dev, &psBufferConfig);
+	pxp_set_as_position(dev, 0xFFFFU, 0xFFFFU, 0U, 0U);
+
+	pxp_output_buffer_config_t outputBufferConfig;
+
+	outputBufferConfig.pixelFormat    = kPXP_OutputPixelFormatRGB565;
+	outputBufferConfig.interlacedMode = kPXP_OutputProgressive;
+	outputBufferConfig.buffer0Addr    = (uint32_t)s_outputBuffer;
+	outputBufferConfig.buffer1Addr    = 0U;
+	outputBufferConfig.pitchBytes     = WIDTH * 2;
+	outputBufferConfig.width          = WIDTH;
+	outputBufferConfig.height         = HEIGHT;
+
+	pxp_set_output_buffer(dev, &outputBufferConfig);
+
+	pxp_enable_csc1(dev, false);
+
+	pxp_set_ps_position(dev, 0, 0, outputWidth - 1, outputHeight - 1);
+
+#if CONFIG_PXP_ROTATE_FLIP
+	pxp_set_rotate(dev, kPXP_RotateOutputBuffer, kPXP_Rotate90, kPXP_FlipVertical);
+#endif
+
+#if CONFIG_PXP_SCALER
+	pxp_set_ps_scaler(dev, WIDTH, HEIGHT, outputWidth, outputHeight);
+#endif
+
+	pxp_start(dev);
+
+	pxp_wait_complete(dev);
+
+	printk(DEMO_NAME " Covert Done! \r\n");
+}

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -132,6 +132,10 @@ config VIDEO_MCUX_CSI
 	default y if HAS_MCUX_CSI
 	depends on VIDEO
 
+config PXP_MCUX_PXP
+	default y if HAS_MCUX_PXP
+	depends on PXP
+
 config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -258,6 +258,7 @@ config SOC_MIMXRT1176_CM7
 	select HAS_MCUX_CACHE
 	select HAS_MCUX
 	select HAS_MCUX_SEMC
+	select HAS_MCUX_PXP
 	select HAS_MCUX_CCM_REV2
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C


### PR DESCRIPTION
enable the pxp driver, including creating a new driver framework,
and also provide some samples to show how to use the it

Signed-off-by: Crist Xu <crist.xu@nxp.com>