### PR TITLE
ARC: save/restore accumulator registers on ARCv2 HS CPUs by default

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -252,6 +252,7 @@ config CODE_DENSITY
 
 config ARC_HAS_ACCL_REGS
 	bool "Reg Pair ACCL:ACCH (FPU and/or MPY > 6)"
+	default y if CPU_HS3X
 	default y if FPU
 	help
 	  Depending on the configuration, CPU can contain accumulator reg-pair


### PR DESCRIPTION
Accumulator registers (ACCL, ACCH) are used on HS CPUs not only in case of FPU usage but also in case of MPY usage. 
We enabled MPY for all ARCv2 HS in commit 18a24c3f6 but we didn't enable accumulator registers management.

Let's enable accumulator registers save/restore on all ARCv2 HS CPUs by default.

Fixes: 18a24c3f6