### PR TITLE
ARC: MWDT: use MetaWare C library instead of MetaWare Compactlib

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -114,7 +114,6 @@ macro(toolchain_ld_baremetal)
     -Xtimer0 # to suppress the warning message
     -Hnoxcheck_obj
     -Hnocplus
-    -Hcl
     -Hheap=0
     -Hnoivt
   )


### PR DESCRIPTION
-Hcl option instructs linker to use MetaWare C Compactlib. According to MWDT documentation "Compactlib is not thread-safe", so it shouldn't be used with Zephyr.

Let's use MetaWare C library instead which is thread-safe.
