### PR TITLE
drivers: eth: sam: Replace constants by devicetree values

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -18,7 +18,11 @@
  * - no statistics collection
  */
 
+#if defined(CONFIG_SOC_FAMILY_SAM)
 #define DT_DRV_COMPAT atmel_sam_gmac
+#else
+#define DT_DRV_COMPAT atmel_sam0_gmac
+#endif
 
 #define LOG_MODULE_NAME eth_sam
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2222,14 +2222,14 @@ static const struct soc_gpio_pin pins_eth0[] = ATMEL_SAM_DT_INST_PINS(0);
 #endif
 
 static const struct eth_sam_dev_cfg eth0_config = {
-	.regs = GMAC,
-	.periph_id = ID_GMAC,
+	.regs = (Gmac *)DT_INST_REG_ADDR(0),
 #ifdef CONFIG_SOC_FAMILY_SAM
+	.periph_id = DT_INST_PROP_OR(0, peripheral_id, 0),
 	.pin_list = pins_eth0,
 	.pin_list_size = ARRAY_SIZE(pins_eth0),
 #endif
 	.config_func = eth0_irq_config,
-	.phy = {GMAC, CONFIG_ETH_SAM_GMAC_PHY_ADDR},
+	.phy = {(Gmac *)DT_INST_REG_ADDR(0), CONFIG_ETH_SAM_GMAC_PHY_ADDR},
 };
 
 static struct eth_sam_dev_data eth0_data = {

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -261,9 +261,11 @@ struct gmac_queue {
 /* Device constant configuration parameters */
 struct eth_sam_dev_cfg {
 	Gmac *regs;
+#ifdef CONFIG_SOC_FAMILY_SAM
 	uint32_t periph_id;
 	const struct soc_gpio_pin *pin_list;
 	uint32_t pin_list_size;
+#endif
 	void (*config_func)(void);
 	struct phy_sam_gmac_dev phy;
 };

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -149,6 +149,7 @@
 		gmac: ethernet@40034000 {
 			compatible = "atmel,sam-gmac";
 			reg = <0x40034000 0x4000>;
+			peripheral-id = <44>;
 			interrupts = <44 0>;
 			interrupt-names = "gmac";
 			num-queues = <1>;

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -9,7 +9,7 @@
 / {
 	soc {
 		gmac: ethernet@42000800 {
-			compatible = "atmel,sam-gmac";
+			compatible = "atmel,sam0-gmac";
 			reg = <0x42000800 0x400>;
 			interrupts = <84 0>;
 			interrupt-names = "gmac";

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -338,9 +338,10 @@
 			label = "USBHS";
 		};
 
-		gmac: ethernet@40050088 {
+		gmac: ethernet@40050000 {
 			compatible = "atmel,sam-gmac";
-			reg = <0x40050088 0x4000>;
+			reg = <0x40050000 0x4000>;
+			peripheral-id = <39>;
 			interrupts = <39 0>, <66 0>, <67 0>;
 			interrupt-names = "gmac", "q1", "q2";
 			num-queues = <3>;

--- a/dts/bindings/ethernet/atmel,gmac-common.yaml
+++ b/dts/bindings/ethernet/atmel,gmac-common.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+# Copyright (c) 2020-2021 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+include: ethernet.yaml
+
+properties:
+    reg:
+      required: true
+
+    num-queues:
+      type: int
+      required: true
+      description: |
+        Number of hardware TX and RX queues.
+
+    max-frame-size:
+      type: int
+      default: 1518
+      description: |
+        Maximum ethernet frame size.  The current ethernet frame sizes
+        supported by hardware are 1518, 1536 and 10240 (jumbo frames).  This
+        means that normally gmac will reject any frame above max-frame-size
+        value.  The default value is 1518, which represents an usual
+        IEEE 802.3 ethernet frame:
+
+          Ethernet Frame [ 14 MAC HEADER | 1500 MTU | 4 FCS ] = 1518 bytes
+
+        When using value 1536 it is possible extend ethernet MAC HEADER up
+        to 32 bytes.  The hardware have support to jumbo frames and it can be
+        enabled by selecting the value 10240.
+
+    max-speed:
+      type: int
+      default: 100
+      description: |
+        This specifies maximum speed in Mbit/s supported by the device.  The
+        gmac driver supports 10Mbit/s and 100Mbit/s.  Using 100, as default
+        value, enables driver to configure 10 and 100Mbit/s speeds.
+
+    phy-connection-type:
+      type: string
+      enum:
+        - "rmii"
+        - "mii"
+      default: "rmii"
+      description: |
+        Phy connection type define the physical interface connection between
+        PHY and MAC.  The default value uses gmac register reset value, which
+        represents Reduced Media-Independent Interface (RMII) mode.
+
+        This property must be used with pinctrl-0.
+
+    pinctrl-0:
+      type: phandles
+      required: false
+      description: |
+        PIO pin configuration for the various GMAC signals that include GTXCK,
+        GTXEN, GTX[3..0], GTXER, GRXCK, GRXDV, GRX[3..0], GRXER, GCRS, GCOL,
+        GMDC, and GMDIO.  Which signals are used vary based on if the PHY
+        connection is MII or RMII (see datasheet for more details).  We expect
+        that the phandles will reference pinctrl nodes.  These nodes will have
+        a nodelabel that matches the Atmel SoC HAL defines and be of the form
+        p<port><pin><periph>_<inst>_<signal>.
+
+        For example the GMAC on SAME7x would be for RMII
+          pinctrl-0 = <&pd0a_gmac_gtxck &pd1a_gmac_gtxen
+                       &pd2a_gmac_gtx0 &pd3a_gmac_gtx1
+                       &pd4a_gmac_grxdv &pd5a_gmac_grx0
+                       &pd6a_gmac_grx1 &pd7a_gmac_grxer
+                       &pd8a_gmac_gmdc &pd9a_gmac_gmdio>;
+
+        This property must be used with phy-connection-type.

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
-# Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2020-2021 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: Atmel SAM-family GMAC Ethernet
@@ -15,47 +15,63 @@ properties:
     num-queues:
       type: int
       required: true
-      description: Number of hardware TX and RX queues
+      description: |
+        Number of hardware TX and RX queues.
 
     max-frame-size:
-        type: int
-        description:
-          Maximum transfer unit (IEEE defined MTU), rather than the
-          maximum frame size (there\'s contradiction in the Devicetree
-          Specification). The current supported values are 1518, 1536
-          and 10240 (jumbo frames).
-        default: 1518
+      type: int
+      default: 1518
+      description: |
+        Maximum ethernet frame size.  The current ethernet frame sizes
+        supported by hardware are 1518, 1536 and 10240 (jumbo frames).  This
+        means that normally gmac will reject any frame above max-frame-size
+        value.  The default value is 1518, which represents an usual
+        IEEE 802.3 ethernet frame:
+
+          Ethernet Frame [ 14 MAC HEADER | 1500 MTU | 4 FCS ] = 1518 bytes
+
+        When using value 1536 it is possible extend ethernet MAC HEADER up
+        to 32 bytes.  The hardware have support to jumbo frames and it can be
+        enabled by selecting the value 10240.
 
     max-speed:
-        type: int
-        description:
-          Specifies maximum speed in Mbit/s supported by the device.
-        default: 100
+      type: int
+      default: 100
+      description: |
+        This specifies maximum speed in Mbit/s supported by the device.  The
+        gmac driver supports 10Mbit/s and 100Mbit/s.  Using 100, as default
+        value, enables driver to configure 10 and 100Mbit/s speeds.
 
     phy-connection-type:
-        type: string
-        description:
-          Operation mode of the PHY interface
-        enum:
-          - "rmii"
-          - "mii"
-        default: "rmii"
+      type: string
+      enum:
+        - "rmii"
+        - "mii"
+      default: "rmii"
+      description: |
+        Phy connection type define the physical interface connection between
+        PHY and MAC.  The default value uses gmac register reset value, which
+        represents Reduced Media-Independent Interface (RMII) mode.
+
+        This property must be used with pinctrl-0.
 
     pinctrl-0:
       type: phandles
       required: false
       description: |
-        PIO pin configuration for the various GMAC signals that include
-        GTXCK, GTXEN, GTX[3..0], GTXER, GRXCK, GRXDV, GRX[3..0], GRXER,
-        GCRS, GCOL, GMDC, and GMDIO.  Which signals are used vary based
-        on if the PHY connection is MII or RMII (see datasheet for more
-        details).  We expect that the phandles will reference pinctrl nodes.
-        These nodes will have a nodelabel that matches the Atmel SoC HAL
-        defines and be of the form p<port><pin><periph>_<inst>_<signal>.
+        PIO pin configuration for the various GMAC signals that include GTXCK,
+        GTXEN, GTX[3..0], GTXER, GRXCK, GRXDV, GRX[3..0], GRXER, GCRS, GCOL,
+        GMDC, and GMDIO.  Which signals are used vary based on if the PHY
+        connection is MII or RMII (see datasheet for more details).  We expect
+        that the phandles will reference pinctrl nodes.  These nodes will have
+        a nodelabel that matches the Atmel SoC HAL defines and be of the form
+        p<port><pin><periph>_<inst>_<signal>.
 
         For example the GMAC on SAME7x would be for RMII
-           pinctrl-0 = <&pd0a_gmac_gtxck &pd1a_gmac_gtxen
-                        &pd2a_gmac_gtx0 &pd3a_gmac_gtx1
-                        &pd4a_gmac_grxdv &pd5a_gmac_grx0
-                        &pd6a_gmac_grx1 &pd7a_gmac_grxer
-                        &pd8a_gmac_gmdc &pd9a_gmac_gmdio>;
+          pinctrl-0 = <&pd0a_gmac_gtxck &pd1a_gmac_gtxen
+                       &pd2a_gmac_gtx0 &pd3a_gmac_gtx1
+                       &pd4a_gmac_grxdv &pd5a_gmac_grx0
+                       &pd6a_gmac_grx1 &pd7a_gmac_grxer
+                       &pd8a_gmac_gmdc &pd9a_gmac_gmdio>;
+
+        This property must be used with phy-connection-type.

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -6,3 +6,13 @@ description: Atmel SAM-family GMAC Ethernet
 compatible: "atmel,sam-gmac"
 
 include: atmel,gmac-common.yaml
+
+properties:
+    peripheral-id:
+      type: int
+      required: true
+      description: |
+        The peripheral identifier is required for Atmel SAMs MCUs to indicate
+        which is the clock line associated with a specific peripheral.  This
+        clock line is defined at Power Management Controller (PMC) and it
+        enables the peripheral.

--- a/dts/bindings/ethernet/atmel,sam0-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam0-gmac.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM-family GMAC Ethernet
+description: Atmel SAM0-family GMAC Ethernet
 
-compatible: "atmel,sam-gmac"
+compatible: "atmel,sam0-gmac"
 
 include: atmel,gmac-common.yaml


### PR DESCRIPTION
The zephyr sam gmac driver don't get both register address and peripheral id from devicetree.  Drop headers constants in favor
of devicetree values.

This fix wrong Atmel SAME7x/SAMV7x gmac register address and add missing peripheral id property for SAM family.

The problem was found running tests for #34718 .

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>