### PR TITLE
LLVM: add LLVM support on Windows

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -69,7 +69,10 @@ if(NOT "${ARCH}" STREQUAL "posix")
     list(APPEND TOOLCHAIN_LIBS gcc)
   endif()
 
-  set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
+  # CMake needs a valid linker to check compiler flag, but clang
+  # won't use LLVM built-in linker by default, so use this option
+  # to force clang to use LLVM built-in linker
+  set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib -fuse-ld=lld ${isystem_include_flags})
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 endif()

--- a/cmake/toolchain/llvm/generic.cmake
+++ b/cmake/toolchain/llvm/generic.cmake
@@ -17,9 +17,11 @@ if("${ARCH}" STREQUAL "arm")
   set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 elseif("${ARCH}" STREQUAL "x86")
   if(CONFIG_64BIT)
-    set(triple x86_64-pc-none-elf)
+    # The LLVM built-in linker lld is a generic driver, needs to use triple os filed
+    # to distinguish which linker will be used.
+    set(triple x86_64-pc-linux-elf)
   else()
-    set(triple i686-pc-none-elf)
+    set(triple i686-pc-linux-elf)
   endif()
 endif()
 


### PR DESCRIPTION
The compiler clang of llvm won't use built-in linker
when doing zephyr_compiler_check_flag, it will be failed
with "program not executable" due to it couldn't find
a valid linker, so use "-fuse-ld=lld" option to force
clang use built-in lld.
triple i686-pc-none-elf couldn't be recognized and
used to find a valid linker on windows, we need to use
i686-pc-linux-elf.

Fixes #32111 

Signed-off-by: Chen, Peng1 <peng1.chen@intel.com>