### PR TITLE
pm: use enum for device PM states

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -68,7 +68,7 @@ struct st7735r_data {
 	uint16_t x_offset;
 	uint16_t y_offset;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -520,14 +520,15 @@ static int st7735r_enter_sleep(struct st7735r_data *data)
 }
 
 static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
-			      uint32_t *state, pm_device_cb cb, void *arg)
+			      enum pm_device_state *state,
+			      pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:
-		if (*((uint32_t *)context) == PM_DEVICE_STATE_ACTIVE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = st7735r_exit_sleep(data);
 			if (ret < 0) {
 				return ret;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -53,7 +53,7 @@ struct st7789v_data {
 	uint16_t x_offset;
 	uint16_t y_offset;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -409,7 +409,7 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 }
 
 static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 uint32_t *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -37,7 +37,7 @@ struct entropy_cc13xx_cc26xx_data {
 	bool constrained;
 #endif
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum device_pm_state pm_state;
 #endif
 };
 
@@ -268,7 +268,7 @@ static int post_notify_fxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
-						 uint32_t new_state)
+						 enum pm_device_state new_state)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 	int ret = 0;
@@ -294,14 +294,14 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    uint32_t ctrl_command,
-					    uint32_t *state, pm_device_cb cb,
+					    enum pm_device_state *state, pm_device_cb cb,
 					    void *arg)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != data->pm_state) {
 			ret = entropy_cc13xx_cc26xx_set_power_state(dev,

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -186,7 +186,7 @@ void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
 				      uint32_t command,
-				      uint32_t *state, pm_device_cb cb,
+				      enum pm_device_state *state, pm_device_cb cb,
 				      void *arg)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -61,7 +61,7 @@ struct spi_flash_at45_data {
 	struct spi_cs_control spi_cs;
 	struct k_sem lock;
 #if IS_ENABLED(CONFIG_PM_DEVICE)
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -629,7 +629,7 @@ static int spi_flash_at45_init(const struct device *dev)
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
 				     uint32_t ctrl_command,
-				     uint32_t *state, pm_device_cb cb,
+				     enum pm_device_state *state, pm_device_cb cb,
 				     void *arg)
 {
 	struct spi_flash_at45_data *dev_data = get_dev_data(dev);
@@ -637,7 +637,7 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 	int err = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != dev_data->pm_state) {
 			switch (new_state) {

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -461,7 +461,7 @@ static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 */
 static int gpio_dw_device_ctrl(const struct device *port,
 			       uint32_t ctrl_command,
-			       uint32_t *state, pm_device_cb cb, void *arg)
+			       enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -42,7 +42,7 @@ struct gpio_dw_runtime {
 #endif
 	sys_slist_t callbacks;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 #endif
 };
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -581,7 +581,7 @@ static uint32_t gpio_stm32_get_power_state(const struct device *dev)
 }
 
 static int gpio_stm32_set_power_state(const struct device *dev,
-					      uint32_t new_state)
+					      enum pm_device_state new_state)
 {
 	struct gpio_stm32_data *data = dev->data;
 	int ret = 0;
@@ -605,7 +605,7 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     uint32_t ctrl_command,
-				     uint32_t *state, pm_device_cb cb, void *arg)
+				     enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	struct gpio_stm32_data *data = dev->data;
 	uint32_t new_state;

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -231,7 +231,7 @@ struct gpio_stm32_data {
 	sys_slist_t cb;
 #ifdef CONFIG_PM_DEVICE
 	/* device power state */
-	uint32_t power_state;
+	enum pm_device_state power_state;
 #endif
 };
 

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -33,7 +33,7 @@ struct i2c_cc13xx_cc26xx_data {
 	uint32_t dev_config;
 #endif
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -330,7 +330,7 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					     uint32_t new_state)
+					     enum pm_device_state new_state)
 {
 	int ret = 0;
 
@@ -369,13 +369,13 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					uint32_t *state, pm_device_cb cb,
+					enum pm_device_state *state, pm_device_cb cb,
 					void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != get_dev_data(dev)->pm_state) {
 			ret = i2c_cc13xx_cc26xx_set_power_state(dev,

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -20,7 +20,7 @@ struct i2c_nrfx_twi_data {
 	volatile nrfx_err_t res;
 	uint32_t dev_config;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -224,13 +224,13 @@ static int init_twi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
-	uint32_t pm_current_state = get_dev_data(dev)->pm_state;
+	enum pm_device_state pm_current_state = get_dev_data(dev)->pm_state;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -23,7 +23,7 @@ struct i2c_nrfx_twim_data {
 	uint16_t concat_buf_size;
 	uint8_t *concat_buf;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -263,13 +263,13 @@ static int init_twim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
-	uint32_t pm_current_state = get_dev_data(dev)->pm_state;
+	enum pm_device_state pm_current_state = get_dev_data(dev)->pm_state;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != pm_current_state) {
 			switch (new_state) {

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -192,16 +192,17 @@ static int arc_v2_irq_unit_get_state(const struct device *dev)
  * @return operation result
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
-				       uint32_t ctrl_command, uint32_t *context,
+				       uint32_t ctrl_command,
+				       enum pm_device_state *state,
 				       pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	unsigned int key = arch_irq_lock();
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*((uint32_t *)context) == PM_DEVICE_STATE_SUSPEND) {
+		if (*state == PM_DEVICE_STATE_SUSPEND) {
 			ret = arc_v2_irq_unit_suspend(dev);
-		} else if (*((uint32_t *)context) == PM_DEVICE_STATE_ACTIVE) {
+		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = arc_v2_irq_unit_resume(dev);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -315,14 +315,13 @@ int ioapic_resume_from_suspend(const struct device *port)
 __pinned_func
 static int ioapic_device_ctrl(const struct device *dev,
 			      uint32_t ctrl_command,
-			      uint32_t *context, pm_device_cb cb, void *arg)
+			      enum pm_device_state *state,
+			      pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((uint32_t *)context);
-
-		switch (new_state) {
+		switch (*state) {
 		case PM_DEVICE_STATE_LOW_POWER:
 			break;
 		case PM_DEVICE_STATE_ACTIVE:
@@ -341,14 +340,14 @@ static int ioapic_device_ctrl(const struct device *dev,
 		}
 
 		if (ret == 0) {
-			ioapic_device_power_state = new_state;
+			ioapic_device_power_state = *state;
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*((uint32_t *)context) = ioapic_device_power_state;
+		*state = ioapic_device_power_state;
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(dev, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -414,22 +414,23 @@ int loapic_resume(const struct device *port)
 __pinned_func
 static int loapic_device_ctrl(const struct device *port,
 			      uint32_t ctrl_command,
-			      uint32_t *context, pm_device_cb cb, void *arg)
+			      enum pm_device_state *state, pm_device_cb cb,
+			      void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		if (*context == PM_DEVICE_STATE_SUSPEND) {
+		if (*state == PM_DEVICE_STATE_SUSPEND) {
 			ret = loapic_suspend(port);
-		} else if (*context == PM_DEVICE_STATE_ACTIVE) {
+		} else if (*state == PM_DEVICE_STATE_ACTIVE) {
 			ret = loapic_resume(port);
 		}
 	} else if (ctrl_command == PM_DEVICE_STATE_GET) {
-		*context = loapic_device_power_state;
+		*state = loapic_device_power_state;
 	}
 
 	if (cb) {
-		cb(port, ret, context, arg);
+		cb(port, ret, state, arg);
 	}
 
 	return ret;

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -37,7 +37,7 @@ struct led_pwm_config {
 
 struct led_pwm_data {
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -128,7 +128,8 @@ static int led_pwm_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 
-static int led_pwm_pm_get_state(const struct device *dev, uint32_t *state)
+static int led_pwm_pm_get_state(const struct device *dev,
+				enum pm_device_state *state)
 {
 	struct led_pwm_data *data = DEV_DATA(dev);
 
@@ -139,11 +140,12 @@ static int led_pwm_pm_get_state(const struct device *dev, uint32_t *state)
 	return 0;
 }
 
-static int led_pwm_pm_set_state(const struct device *dev, uint32_t new_state)
+static int led_pwm_pm_set_state(const struct device *dev,
+				enum pm_device_state new_state)
 {
 	const struct led_pwm_config *config = DEV_CFG(dev);
 	struct led_pwm_data *data = DEV_DATA(dev);
-	uint32_t old_state;
+	enum pm_device_state old_state;
 	unsigned int key;
 
 	key = irq_lock();
@@ -176,7 +178,7 @@ static int led_pwm_pm_set_state(const struct device *dev, uint32_t new_state)
 }
 
 static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
-			      uint32_t *state, pm_device_cb cb, void *arg)
+			      enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int err;
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -292,8 +292,8 @@ static void pwm_nrfx_uninit(const struct device *dev)
 	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 }
 
-static int pwm_nrfx_set_power_state(uint32_t new_state,
-				    uint32_t current_state,
+static int pwm_nrfx_set_power_state(enum pm_device_state new_state,
+				    enum pm_device_state current_state,
 				    const struct device *dev)
 {
 	int err = 0;
@@ -319,13 +319,13 @@ static int pwm_nrfx_set_power_state(uint32_t new_state,
 
 static int pwm_nrfx_pm_control(const struct device *dev,
 			       uint32_t ctrl_command,
-			       uint32_t *state,
-			       uint32_t *current_state)
+			       enum pm_device_state *state,
+			       enum pm_device_state *current_state)
 {
 	int err = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *((const uint32_t *)state);
+		enum pm_device_state new_state = *state;
 
 		if (new_state != (*current_state)) {
 			err = pwm_nrfx_set_power_state(new_state,
@@ -346,11 +346,11 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 #define PWM_NRFX_PM_CONTROL(idx)					\
 	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,	\
 					       uint32_t ctrl_command,	\
-					       uint32_t *state,		\
+					       enum pm_device_state *state,	\
 					       pm_device_cb cb,		\
 					       void *arg)		\
 	{								\
-		static uint32_t current_state = PM_DEVICE_STATE_ACTIVE;	\
+		static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE; \
 		int ret = 0;                                            \
 		ret = pwm_nrfx_pm_control(dev, ctrl_command, state,	\
 					   &current_state);		\

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -410,16 +410,15 @@ static int apds9960_init_interrupt(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state,
+				pm_device_cb cb, void *arg)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t device_pm_state = *state;
-
-		if (device_pm_state == PM_DEVICE_STATE_ACTIVE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			if (i2c_reg_update_byte(data->i2c, config->i2c_address,
 						APDS9960_ENABLE_REG,
 						APDS9960_ENABLE_PON,

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -57,7 +57,7 @@ struct bme280_data {
 	uint8_t chip_id;
 
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state; /* Current power state */
+	enum pm_device_state pm_state; /* Current power state */
 #endif
 };
 
@@ -391,7 +391,7 @@ static int bme280_chip_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
-		   uint32_t *state, pm_device_cb cb, void *arg)
+		   enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	struct bme280_data *data = to_data(dev);
 
@@ -399,9 +399,7 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 
 	/* Set power state */
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_pm_state = *state;
-
-		if (new_pm_state != data->pm_state) {
+		if (*state != data->pm_state) {
 
 			/* Switching from OFF to any */
 			if (data->pm_state == PM_DEVICE_STATE_OFF) {

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -546,7 +546,7 @@ static int bmp388_get_calibration_data(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int bmp388_set_power_state(const struct device *dev,
-				  uint32_t power_state)
+				  enum pm_device_state power_state)
 {
 	uint8_t reg_val;
 
@@ -589,9 +589,8 @@ static uint32_t bmp388_get_power_state(const struct device *dev)
 static int bmp388_device_ctrl(
 	const struct device *dev,
 	uint32_t ctrl_command,
-	uint32_t *state,
-	pm_device_cb cb,
-	void *arg)
+	enum pm_device_state *state,
+	pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -164,7 +164,7 @@ struct bmp388_data {
 	struct bmp388_cal_data cal;
 
 #ifdef CONFIG_PM_DEVICE
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 #endif
 
 #if defined(CONFIG_BMP388_TRIGGER)

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -489,7 +489,7 @@ static int fdc2x1x_set_shutdown(const struct device *dev, bool enable)
  * @return 0 in case of success, negative error code otherwise.
  */
 static int fdc2x1x_set_pm_state(const struct device *dev,
-				uint32_t pm_state)
+				enum pm_device_state pm_state)
 {
 	int ret;
 	struct fdc2x1x_data *data = dev->data;
@@ -543,21 +543,19 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 				  uint32_t ctrl_command,
-				  uint32_t *state, pm_device_cb cb,
-				  void *arg)
+				  enum pm_device_state *state,
+				  pm_device_cb cb, void *arg)
 {
 	struct fdc2x1x_data *data = dev->data;
-	uint32_t new_state;
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		new_state = *state;
-		if (new_state != data->pm_state) {
-			switch (new_state) {
+		if (*state != data->pm_state) {
+			switch (*state) {
 			case PM_DEVICE_STATE_ACTIVE:
 			case PM_DEVICE_STATE_LOW_POWER:
 			case PM_DEVICE_STATE_OFF:
-				ret = fdc2x1x_set_pm_state(dev, new_state);
+				ret = fdc2x1x_set_pm_state(dev, *state);
 				break;
 			default:
 				LOG_ERR("PM state not supported");

--- a/drivers/sensor/fdc2x1x/fdc2x1x.h
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.h
@@ -150,7 +150,7 @@ struct fdc2x1x_data {
 	bool fdc221x;
 
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 
 #ifdef CONFIG_FDC2X1X_TRIGGER

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -448,7 +448,7 @@ static int lis2mdl_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 		const struct lis2mdl_config *const config,
-		uint32_t new_state)
+		enum pm_device_state new_state)
 {
 	const struct lis2mdl_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -483,13 +483,13 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 }
 
 static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;
-	uint32_t current_state = lis2mdl->power_state;
+	enum pm_device_state current_state = lis2mdl->power_state;
 	int status = 0;
-	uint32_t new_state;
+	enum pm_device_state new_state;
 
 	switch (ctrl_command) {
 	case PM_DEVICE_STATE_SET:

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -52,7 +52,7 @@ struct lis2mdl_data {
 	int16_t temp_sample;
 
 #ifdef CONFIG_PM_DEVICE
-	uint32_t power_state;
+	enum pm_device_state power_state;
 #endif
 
 	struct k_sem fetch_sem;

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -25,7 +25,7 @@ struct qdec_nrfx_data {
 	int32_t                    acc;
 	sensor_trigger_handler_t data_ready_handler;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t                    pm_state;
+	enum pm_device_state       pm_state;
 #endif
 };
 
@@ -218,7 +218,7 @@ static int qdec_nrfx_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 
 static int qdec_nrfx_pm_get_state(struct qdec_nrfx_data *data,
-				  uint32_t *state)
+				  enum pm_device_state *state)
 {
 	unsigned int key = irq_lock();
 	*state = data->pm_state;
@@ -228,9 +228,9 @@ static int qdec_nrfx_pm_get_state(struct qdec_nrfx_data *data,
 }
 
 static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
-				  uint32_t new_state)
+				  enum pm_device_state new_state)
 {
-	uint32_t old_state;
+	enum pm_device_state old_state;
 	unsigned int key;
 
 	key = irq_lock();
@@ -268,7 +268,7 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 
 static int qdec_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;
 	int err;

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -219,13 +219,13 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
-				uint32_t ctrl_command, uint32_t *state,
+				uint32_t ctrl_command,
+				enum pm_device_state *state,
 				pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t device_pm_state = *state;
 		uint16_t ps_conf;
 
 		ret = vcnl4040_read(dev, VCNL4040_REG_PS_CONF, &ps_conf);
@@ -238,7 +238,7 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		if (ret < 0)
 			return ret;
 #endif
-		if (device_pm_state == PM_DEVICE_STATE_ACTIVE) {
+		if (*state == PM_DEVICE_STATE_ACTIVE) {
 			/* Clear proximity shutdown */
 			ps_conf &= ~VCNL4040_PS_SD_MASK;
 

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -37,7 +37,7 @@ struct uart_cc13xx_cc26xx_data {
 	bool rx_constrained;
 #endif
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -401,7 +401,7 @@ static int postNotifyFxn(unsigned int eventType, uintptr_t eventArg,
 
 #ifdef CONFIG_PM_DEVICE
 static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					      uint32_t new_state)
+					      enum pm_device_state new_state)
 {
 	int ret = 0;
 
@@ -447,13 +447,13 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 uint32_t *state, pm_device_cb cb,
+					 enum pm_device_state *state, pm_device_cb cb,
 					 void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != get_dev_data(dev)->pm_state) {
 			ret = uart_cc13xx_cc26xx_set_power_state(dev,

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -41,7 +41,7 @@ struct uart_npcx_data {
 	void *user_data;
 #endif
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -442,7 +442,7 @@ static inline bool uart_npcx_device_is_transmitting(const struct device *dev)
 }
 
 static inline int uart_npcx_get_power_state(const struct device *dev,
-							uint32_t *state)
+					    enum pm_device_state *state)
 {
 	const struct uart_npcx_data *const data = DRV_DATA(dev);
 
@@ -451,7 +451,7 @@ static inline int uart_npcx_get_power_state(const struct device *dev,
 }
 
 static inline int uart_npcx_set_power_state(const struct device *dev,
-							uint32_t next_state)
+					    enum pm_device_state next_state)
 {
 	struct uart_npcx_data *const data = DRV_DATA(dev);
 
@@ -473,7 +473,7 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 
 /* Implements the device power management control functionality */
 static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 uint32_t *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1140,7 +1140,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 }
 
 static void uart_nrfx_set_power_state(const struct device *dev,
-				      uint32_t new_state)
+				      enum pm_device_state new_state)
 {
 	if (new_state == PM_DEVICE_STATE_ACTIVE) {
 		uart_nrfx_pins_enable(dev, true);
@@ -1160,12 +1160,12 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 
 static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
-	static uint32_t current_state = PM_DEVICE_STATE_ACTIVE;
+	static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE;
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != current_state) {
 			uart_nrfx_set_power_state(dev, new_state);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -125,7 +125,7 @@ struct uarte_nrfx_data {
 #endif
 	atomic_val_t poll_out_lock;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 	uint8_t char_out;
 	uint8_t rx_data;
@@ -1828,7 +1828,7 @@ static void wait_for_tx_stopped(const struct device *dev)
 
 
 static void uarte_nrfx_set_power_state(const struct device *dev,
-				       uint32_t new_state)
+				       enum pm_device_state new_state)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = get_dev_data(dev);
@@ -1918,12 +1918,12 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 
 static int uarte_nrfx_pm_control(const struct device *dev,
 				 uint32_t ctrl_command,
-				 uint32_t *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != data->pm_state) {
 			uarte_nrfx_set_power_state(dev, new_state);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1426,7 +1426,7 @@ static int uart_stm32_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 static int uart_stm32_set_power_state(const struct device *dev,
-					      uint32_t new_state)
+					      enum pm_device_state new_state)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 	struct uart_stm32_data *data = DEV_DATA(dev);
@@ -1465,13 +1465,13 @@ static int uart_stm32_set_power_state(const struct device *dev,
  */
 static int uart_stm32_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 uint32_t *state, pm_device_cb cb,
+					 enum pm_device_state *state, pm_device_cb cb,
 					 void *arg)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != data->pm_state) {
 			uart_stm32_set_power_state(dev, new_state);

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -68,7 +68,7 @@ struct uart_stm32_data {
 	size_t rx_next_buffer_len;
 #endif
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -34,7 +34,7 @@ struct spi_cc13xx_cc26xx_config {
 struct spi_cc13xx_cc26xx_data {
 	struct spi_context ctx;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -212,7 +212,7 @@ static int spi_cc13xx_cc26xx_release(const struct device *dev,
 
 #ifdef CONFIG_PM_DEVICE
 static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
-					     uint32_t new_state)
+					     enum pm_device_state new_state)
 {
 	int ret = 0;
 
@@ -252,7 +252,7 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					uint32_t *state, pm_device_cb cb,
+					enum pm_device_state *state, pm_device_cb cb,
 					void *arg)
 {
 	int ret = 0;

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -20,7 +20,7 @@ struct spi_nrfx_data {
 	size_t chunk_len;
 	bool   busy;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 };
 
@@ -286,14 +286,14 @@ static int init_spi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -21,7 +21,7 @@ struct spi_nrfx_data {
 	size_t chunk_len;
 	bool   busy;
 #ifdef CONFIG_PM_DEVICE
-	uint32_t pm_state;
+	enum pm_device_state pm_state;
 #endif
 #if (CONFIG_SPI_NRFX_RAM_BUFFER_SIZE > 0)
 	uint8_t   buffer[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE];
@@ -334,14 +334,14 @@ static int init_spim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);
 	const struct spi_nrfx_config *config = get_dev_config(dev);
 
 	if (ctrl_command == PM_DEVICE_STATE_SET) {
-		uint32_t new_state = *state;
+		enum pm_device_state new_state = *state;
 
 		if (new_state != data->pm_state) {
 			switch (new_state) {

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -31,8 +31,9 @@ int __weak sys_clock_driver_init(const struct device *dev)
 }
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
-			       uint32_t ctrl_command,
-			       uint32_t *context, pm_device_cb cb, void *arg)
+				 uint32_t ctrl_command,
+				 enum pm_device_state *state, pm_device_cb cb,
+				 void *arg)
 {
 	return -ENOSYS;
 }

--- a/include/device.h
+++ b/include/device.h
@@ -362,7 +362,8 @@ struct device {
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
 	int (*pm_control)(const struct device *dev, uint32_t command,
-				 uint32_t *state, pm_device_cb cb, void *arg);
+			  enum pm_device_state *state, pm_device_cb cb,
+			  void *arg);
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;
 #endif

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -48,7 +48,8 @@ extern int sys_clock_driver_init(const struct device *dev);
  */
 extern int clock_device_ctrl(const struct device *dev,
 			       uint32_t ctrl_command,
-			       uint32_t *state, pm_device_cb cb, void *arg);
+			       enum pm_device_state *state, pm_device_cb cb,
+			       void *arg);
 
 /**
  * @brief Set system clock timeout

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -77,7 +77,7 @@ void main(void)
 		       intensity.val1, pdata.val1);
 
 #ifdef CONFIG_PM_DEVICE
-		uint32_t p_state;
+		enum pm_device_state p_state;
 
 		p_state = PM_DEVICE_STATE_LOW_POWER;
 		pm_device_state_set(dev, p_state, NULL, NULL);

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -95,7 +95,7 @@ void main(void)
 
 #ifdef CONFIG_PM_DEVICE
 	/* Testing the power modes */
-	uint32_t p_state;
+	enum pm_device_state p_state;
 
 	p_state = PM_DEVICE_STATE_LOW_POWER;
 	pm_device_state_set(dev, p_state, pm_cb, NULL);

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -9,7 +9,7 @@
 #include "dummy_parent.h"
 #include "dummy_driver.h"
 
-uint32_t device_power_state;
+enum pm_device_state device_power_state;
 static const struct device *parent;
 
 static int dummy_open(const struct device *dev)
@@ -85,7 +85,7 @@ static int dummy_close(const struct device *dev)
 	return ret;
 }
 
-static uint32_t dummy_get_power_state(const struct device *dev)
+static enum pm_device_state dummy_get_power_state(const struct device *dev)
 {
 	return device_power_state;
 }
@@ -108,7 +108,8 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb,
+				void *arg)
 {
 	int ret = 0;
 

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -9,7 +9,7 @@
 #include "dummy_parent.h"
 
 static uint32_t store_value;
-uint32_t parent_power_state;
+enum pm_device_state parent_power_state;
 
 static int dummy_transfer(const struct device *dev, uint32_t cmd,
 			  uint32_t *val)
@@ -25,7 +25,7 @@ static int dummy_transfer(const struct device *dev, uint32_t cmd,
 	return 0;
 }
 
-static uint32_t dummy_get_power_state(const struct device *dev)
+static enum pm_device_state dummy_get_power_state(const struct device *dev)
 {
 	return parent_power_state;
 }
@@ -48,7 +48,8 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb,
+				void *arg)
 {
 	int ret = 0;
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -23,10 +23,10 @@ extern const struct device *__pm_device_slots_start[];
 /* Number of devices successfully suspended. */
 static size_t num_susp;
 
-static bool should_suspend(const struct device *dev, uint32_t state)
+static bool should_suspend(const struct device *dev, enum pm_device_state state)
 {
 	int rc;
-	uint32_t current_state;
+	enum pm_device_state current_state;
 
 	if (device_busy_check(dev) != 0) {
 		return false;
@@ -111,7 +111,7 @@ void pm_resume_devices(void)
 }
 #endif /* defined(CONFIG_PM) */
 
-const char *pm_device_state_str(uint32_t state)
+const char *pm_device_state_str(enum pm_device_state state)
 {
 	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
@@ -129,7 +129,8 @@ const char *pm_device_state_str(uint32_t state)
 	}
 }
 
-int pm_device_state_set(const struct device *dev, uint32_t device_power_state,
+int pm_device_state_set(const struct device *dev,
+			enum pm_device_state device_power_state,
 			pm_device_cb cb, void *arg)
 {
 	if (dev->pm_control == NULL) {
@@ -140,7 +141,8 @@ int pm_device_state_set(const struct device *dev, uint32_t device_power_state,
 			       &device_power_state, cb, arg);
 }
 
-int pm_device_state_get(const struct device *dev, uint32_t *device_power_state)
+int pm_device_state_get(const struct device *dev,
+			enum pm_device_state *device_power_state)
 {
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(power);
 #define PM_DEVICE_ASYNC         BIT(1)
 
 static void device_pm_callback(const struct device *dev,
-			       int retval, uint32_t *state, void *arg)
+			       int retval, enum pm_device_state *state, void *arg)
 {
 	__ASSERT(retval == 0, "Device set power state failed");
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -146,7 +146,7 @@ static int cmd_device_list(const struct shell *shell,
 			state = "DISABLED";
 		} else {
 #ifdef CONFIG_PM_DEVICE
-			uint32_t st = PM_DEVICE_STATE_ACTIVE;
+			enum pm_device_state st = PM_DEVICE_STATE_ACTIVE;
 			int err = pm_device_state_get(dev, &st);
 
 			if (!err) {

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -17,7 +17,7 @@
 #define HAS_RX DT_NODE_HAS_PROP(DT_NODELABEL(LABEL), rx_pin)
 
 static const struct device *exp_dev;
-static uint32_t exp_state;
+static enum pm_device_state exp_state;
 static void *exp_arg;
 static volatile int callback_cnt;
 
@@ -120,14 +120,14 @@ static void communication_verify(const struct device *dev, bool active)
 }
 
 #define state_verify(dev, exp_state) do {\
-	uint32_t power_state; \
+	enum pm_device_state power_state; \
 	int err = pm_device_state_get(dev, &power_state); \
 	zassert_equal(err, 0, "Unexpected err: %d", err); \
 	zassert_equal(power_state, exp_state, NULL); \
 } while (0)
 
 static void pm_callback(const struct device *dev,
-			int status, uint32_t *state, void *arg)
+			int status, enum pm_device_state *state, void *arg)
 {
 	zassert_equal(dev, exp_dev, NULL);
 	zassert_equal(status, 0, NULL);
@@ -136,10 +136,11 @@ static void pm_callback(const struct device *dev,
 	callback_cnt++;
 }
 
-static void state_set(const struct device *dev, uint32_t state, int exp_err, bool cb)
+static void state_set(const struct device *dev, enum pm_device_state state,
+		      int exp_err, bool cb)
 {
 	int err;
-	uint32_t prev_state;
+	enum pm_device_state prev_state;
 
 	err = pm_device_state_get(dev, &prev_state);
 	zassert_equal(err, 0, "Unexpected err: %d", err);
@@ -158,7 +159,7 @@ static void state_set(const struct device *dev, uint32_t state, int exp_err, boo
 		zassert_equal(err, exp_err, "Unexpected err: %d", err);
 	}
 
-	uint32_t exp_state = err == 0 ? state : prev_state;
+	enum pm_device_state exp_state = err == 0 ? state : prev_state;
 
 	state_verify(dev, exp_state);
 }

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -249,7 +249,7 @@ static void test_enable_and_disable_automatic_runtime_pm(void)
 {
 	const struct device *dev;
 	int ret;
-	unsigned int device_power_state = 0;
+	enum pm_device_state device_power_state;
 
 	dev = device_get_binding(DUMMY_PORT_2);
 	zassert_false((dev == NULL), NULL);

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -22,7 +22,8 @@ struct fake_dev_context {
 };
 
 static int fake_dev_pm_control(const struct device *dev, uint32_t command,
-			       uint32_t *state, pm_device_cb cb, void *arg)
+			       enum pm_device_state *state, pm_device_cb cb,
+			       void *arg)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -55,7 +55,7 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb, void *arg)
 {
 	int ret = 0;
 

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -9,7 +9,7 @@
 #include <pm/device_runtime.h>
 #include "dummy_driver.h"
 
-static uint32_t device_power_state;
+static enum pm_device_state device_power_state;
 
 static int dummy_open(const struct device *dev)
 {
@@ -40,7 +40,8 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				uint32_t *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state, pm_device_cb cb,
+				void *arg)
 {
 	int ret = 0;
 

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -39,7 +39,7 @@ __weak void pm_power_state_set(struct pm_state_info info)
 		     "Notification to enter suspend was not sent to the App");
 
 	/* this function is called after devices enter low power state */
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 	/* at this point, devices have been deactivated */
 	pm_device_state_get(dev, &device_power_state);
 	zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
@@ -85,7 +85,7 @@ struct pm_state_info pm_policy_next_state(int ticks)
 /* implement in application, called by idle thread */
 static void notify_pm_state_entry(enum pm_state state)
 {
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 
 	/* enter suspend */
 	zassert_true(notify_app_entry == true,
@@ -103,7 +103,7 @@ static void notify_pm_state_entry(enum pm_state state)
 /* implement in application, called by idle thread */
 static void notify_pm_state_exit(enum pm_state state)
 {
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 
 	/* leave suspend */
 	zassert_true(notify_app_exit == true,
@@ -177,7 +177,7 @@ void test_power_state_trans(void)
  */
 void test_power_state_notification(void)
 {
-	uint32_t device_power_state;
+	enum pm_device_state device_power_state;
 
 	pm_device_state_get(dev, &device_power_state);
 	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE, NULL);


### PR DESCRIPTION
Move all PM_DEVICE_STATE_* definitions to an enum. The
PM_DEVICE_STATE_SET and PM_DEVICE_STATE_GET definitions have been kept
out of the enum since they do not represent any state. However, their
name has not been changed since they will be removed soon.

All drivers and tests have been adjusted accordingly.

This PR is part of a series of device PM improvements, see #36125 for more details.