### PR TITLE
pm: remove callback

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -520,8 +520,7 @@ static int st7735r_enter_sleep(struct st7735r_data *data)
 }
 
 static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
-			      enum pm_device_state *state,
-			      pm_device_cb cb, void *arg)
+			      enum pm_device_state *state)
 {
 	int ret = 0;
 	struct st7735r_data *data = (struct st7735r_data *)dev->data;

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -553,10 +553,6 @@ static int st7735r_pm_control(const struct device *dev, uint32_t ctrl_command,
 		ret = -EINVAL;
 	}
 
-	if (cb != NULL) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -409,7 +409,7 @@ static void st7789v_enter_sleep(struct st7789v_data *data)
 }
 
 static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 enum pm_device_state *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state)
 {
 	int ret = 0;
 	struct st7789v_data *data = (struct st7789v_data *)dev->data;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -433,9 +433,6 @@ static int st7789v_pm_control(const struct device *dev, uint32_t ctrl_command,
 		ret = -EINVAL;
 	}
 
-	if (cb != NULL) {
-		cb(dev, ret, state, arg);
-	}
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -294,8 +294,7 @@ static int entropy_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 					    uint32_t ctrl_command,
-					    enum pm_device_state *state, pm_device_cb cb,
-					    void *arg)
+					    enum pm_device_state *state)
 {
 	struct entropy_cc13xx_cc26xx_data *data = get_dev_data(dev);
 	int ret = 0;

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -312,10 +312,6 @@ static int entropy_cc13xx_cc26xx_pm_control(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -228,9 +228,6 @@ static int eth_mcux_device_pm_control(const struct device *dev,
 	}
 
 out:
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
 
 	return ret;
 }

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -186,8 +186,7 @@ void eth_mcux_phy_stop(struct eth_context *context);
 
 static int eth_mcux_device_pm_control(const struct device *dev,
 				      uint32_t command,
-				      enum pm_device_state *state, pm_device_cb cb,
-				      void *arg)
+				      enum pm_device_state *state)
 {
 	struct eth_context *eth_ctx = (struct eth_context *)dev->data;
 	int ret = 0;

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -629,8 +629,7 @@ static int spi_flash_at45_init(const struct device *dev)
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 static int spi_flash_at45_pm_control(const struct device *dev,
 				     uint32_t ctrl_command,
-				     enum pm_device_state *state, pm_device_cb cb,
-				     void *arg)
+				     enum pm_device_state *state)
 {
 	struct spi_flash_at45_data *dev_data = get_dev_data(dev);
 	const struct spi_flash_at45_config *dev_config = get_dev_config(dev);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -670,10 +670,6 @@ static int spi_flash_at45_pm_control(const struct device *dev,
 		*state = dev_data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, err, state, arg);
-	}
-
 	return err;
 }
 #endif /* IS_ENABLED(CONFIG_PM_DEVICE) */

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -475,9 +475,6 @@ static int gpio_dw_device_ctrl(const struct device *port,
 		*state = gpio_dw_get_power_state(port);
 	}
 
-	if (cb) {
-		cb(port, ret, state, arg);
-	}
 	return ret;
 }
 

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -461,7 +461,7 @@ static inline int gpio_dw_resume_from_suspend_port(const struct device *port)
 */
 static int gpio_dw_device_ctrl(const struct device *port,
 			       uint32_t ctrl_command,
-			       enum pm_device_state *state, pm_device_cb cb, void *arg)
+			       enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -626,10 +626,6 @@ static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -605,7 +605,7 @@ static int gpio_stm32_set_power_state(const struct device *dev,
 
 static int gpio_stm32_pm_device_ctrl(const struct device *dev,
 				     uint32_t ctrl_command,
-				     enum pm_device_state *state, pm_device_cb cb, void *arg)
+				     enum pm_device_state *state)
 {
 	struct gpio_stm32_data *data = dev->data;
 	uint32_t new_state;

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -386,10 +386,6 @@ static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 		*state = get_dev_data(dev)->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -369,8 +369,7 @@ static int i2c_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int i2c_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					enum pm_device_state *state, pm_device_cb cb,
-					void *arg)
+					enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -224,7 +224,7 @@ static int init_twi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 	enum pm_device_state pm_current_state = get_dev_data(dev)->pm_state;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -263,10 +263,6 @@ static int twi_nrfx_pm_control(const struct device *dev,
 		*state = get_dev_data(dev)->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -263,7 +263,7 @@ static int init_twim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 	enum pm_device_state pm_current_state = get_dev_data(dev)->pm_state;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -303,10 +303,6 @@ static int twim_nrfx_pm_control(const struct device *dev,
 		*state = get_dev_data(dev)->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -194,8 +194,7 @@ static enum pm_device_state arc_v2_irq_unit_get_state(const struct device *dev)
  */
 static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 				       uint32_t ctrl_command,
-				       enum pm_device_state *state,
-				       pm_device_cb cb, void *arg)
+				       enum pm_device_state *state)
 {
 	int ret = 0;
 	unsigned int key = arch_irq_lock();

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -212,10 +212,6 @@ static int arc_v2_irq_unit_device_ctrl(const struct device *dev,
 
 	arch_irq_unlock(key);
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -315,8 +315,7 @@ int ioapic_resume_from_suspend(const struct device *port)
 __pinned_func
 static int ioapic_device_ctrl(const struct device *dev,
 			      uint32_t ctrl_command,
-			      enum pm_device_state *state,
-			      pm_device_cb cb, void *arg)
+			      enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -346,10 +346,6 @@ static int ioapic_device_ctrl(const struct device *dev,
 		*state = ioapic_device_power_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -429,10 +429,6 @@ static int loapic_device_ctrl(const struct device *port,
 		*state = loapic_device_power_state;
 	}
 
-	if (cb) {
-		cb(port, ret, state, arg);
-	}
-
 	return ret;
 }
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -414,8 +414,7 @@ int loapic_resume(const struct device *port)
 __pinned_func
 static int loapic_device_ctrl(const struct device *port,
 			      uint32_t ctrl_command,
-			      enum pm_device_state *state, pm_device_cb cb,
-			      void *arg)
+			      enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -162,7 +162,7 @@ static int led_pwm_pm_set_state(const struct device *dev,
 		const struct led_pwm *led_pwm = &config->led[i];
 
 		LOG_DBG("Switching PWM %p to state %" PRIu32, led_pwm->dev, new_state);
-		int err = pm_device_state_set(led_pwm->dev, new_state, NULL, NULL);
+		int err = pm_device_state_set(led_pwm->dev, new_state);
 
 		if (err) {
 			LOG_ERR("Cannot switch PWM %p power state", led_pwm->dev);
@@ -178,7 +178,7 @@ static int led_pwm_pm_set_state(const struct device *dev,
 }
 
 static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
-			      enum pm_device_state *state, pm_device_cb cb, void *arg)
+			      enum pm_device_state *state)
 {
 	int err;
 

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -196,10 +196,6 @@ static int led_pwm_pm_control(const struct device *dev, uint32_t ctrl_command,
 		break;
 	}
 
-	if (cb) {
-		cb(dev, err, state, arg);
-	}
-
 	return err;
 }
 

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3505,7 +3505,7 @@ static void shutdown_uart(void)
 		HL7800_IO_DBG_LOG("Power OFF the UART");
 		uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
 		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_STATE_OFF, NULL, NULL);
+					 PM_DEVICE_STATE_OFF);
 		if (rc) {
 			LOG_ERR("Error disabling UART peripheral (%d)", rc);
 		}
@@ -3522,7 +3522,7 @@ static void power_on_uart(void)
 	if (!ictx.uart_on) {
 		HL7800_IO_DBG_LOG("Power ON the UART");
 		rc = pm_device_state_set(ictx.mdm_ctx.uart_dev,
-					 PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+					 PM_DEVICE_STATE_ACTIVE);
 		if (rc) {
 			LOG_ERR("Error enabling UART peripheral (%d)", rc);
 		}

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -199,7 +199,7 @@ int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 {
 	uart_irq_rx_disable(ctx->uart_dev);
 #ifdef PM_DEVICE_STATE_LOW_POWER
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_LOW_POWER);
 #endif
 	return 0;
 }
@@ -207,7 +207,7 @@ int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
 int mdm_receiver_wake(struct mdm_receiver_context *ctx)
 {
 #ifdef PM_DEVICE_STATE_LOW_POWER
-	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	pm_device_state_set(ctx->uart_dev, PM_DEVICE_STATE_ACTIVE);
 #endif
 	uart_irq_rx_enable(ctx->uart_dev);
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -346,9 +346,7 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 #define PWM_NRFX_PM_CONTROL(idx)					\
 	static int pwm_##idx##_nrfx_pm_control(const struct device *dev,	\
 					       uint32_t ctrl_command,	\
-					       enum pm_device_state *state,	\
-					       pm_device_cb cb,		\
-					       void *arg)		\
+					       enum pm_device_state *state)	\
 	{								\
 		static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE; \
 		int ret = 0;                                            \

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -354,9 +354,6 @@ static int pwm_nrfx_pm_control(const struct device *dev,
 		int ret = 0;                                            \
 		ret = pwm_nrfx_pm_control(dev, ctrl_command, state,	\
 					   &current_state);		\
-		if (cb) {                                               \
-			cb(dev, ret, state, arg);                       \
-		}                                                       \
 		return ret;                                             \
 	}
 #else

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -444,10 +444,6 @@ static int apds9960_device_ctrl(const struct device *dev,
 		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -410,8 +410,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_device_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state,
-				pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -431,10 +431,6 @@ int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
 		*state = data->pm_state;
 	}
 
-	/* Invoke callback if any */
-	if (cb)
-		cb(dev, ret, state, arg);
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -391,7 +391,7 @@ static int bme280_chip_init(const struct device *dev)
 
 #ifdef CONFIG_PM_DEVICE
 int bme280_pm_ctrl(const struct device *dev, uint32_t ctrl_command,
-		   enum pm_device_state *state, pm_device_cb cb, void *arg)
+		   enum pm_device_state *state)
 {
 	struct bme280_data *data = to_data(dev);
 

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -600,9 +600,6 @@ static int bmp388_device_ctrl(
 		*state = bmp388_get_power_state(dev);
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -589,8 +589,7 @@ static uint32_t bmp388_get_power_state(const struct device *dev)
 static int bmp388_device_ctrl(
 	const struct device *dev,
 	uint32_t ctrl_command,
-	enum pm_device_state *state,
-	pm_device_cb cb, void *arg)
+	enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -543,8 +543,7 @@ static int fdc2x1x_set_pm_state(const struct device *dev,
 
 static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 				  uint32_t ctrl_command,
-				  enum pm_device_state *state,
-				  pm_device_cb cb, void *arg)
+				  enum pm_device_state *state)
 {
 	struct fdc2x1x_data *data = dev->data;
 	int ret = 0;

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -566,10 +566,6 @@ static int fdc2x1x_device_pm_ctrl(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -483,7 +483,7 @@ static int lis2mdl_set_power_state(struct lis2mdl_data *lis2mdl,
 }
 
 static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const config = dev->config;

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -507,10 +507,6 @@ static int lis2mdl_pm_control(const struct device *dev, uint32_t ctrl_command,
 		status = -EINVAL;
 	}
 
-	if (cb) {
-		cb(dev, status, state, arg);
-	}
-
 	return status;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -289,10 +289,6 @@ static int qdec_nrfx_pm_control(const struct device *dev,
 		break;
 	}
 
-	if (cb) {
-		cb(dev, err, state, arg);
-	}
-
 	return err;
 }
 

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -268,7 +268,7 @@ static int qdec_nrfx_pm_set_state(struct qdec_nrfx_data *data,
 
 static int qdec_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	struct qdec_nrfx_data *data = &qdec_nrfx_data;
 	int err;

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -278,10 +278,6 @@ static int vcnl4040_device_ctrl(const struct device *dev,
 		*state = PM_DEVICE_STATE_ACTIVE;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -220,8 +220,7 @@ static int vcnl4040_ambient_setup(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int vcnl4040_device_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state,
-				pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -464,10 +464,6 @@ static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 		*state = get_dev_data(dev)->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -447,8 +447,7 @@ static int uart_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int uart_cc13xx_cc26xx_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 enum pm_device_state *state, pm_device_cb cb,
-					 void *arg)
+					 enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -473,7 +473,7 @@ static inline int uart_npcx_set_power_state(const struct device *dev,
 
 /* Implements the device power management control functionality */
 static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
-				 enum pm_device_state *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -488,9 +488,6 @@ static int uart_npcx_pm_control(const struct device *dev, uint32_t ctrl_command,
 		ret = -EINVAL;
 	}
 
-	if (cb != NULL) {
-		cb(dev, ret, state, arg);
-	}
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1176,10 +1176,6 @@ static int uart_nrfx_pm_control(const struct device *dev,
 		*state = current_state;
 	}
 
-	if (cb) {
-		cb(dev, 0, state, arg);
-	}
-
 	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1160,7 +1160,7 @@ static void uart_nrfx_set_power_state(const struct device *dev,
 
 static int uart_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	static enum pm_device_state current_state = PM_DEVICE_STATE_ACTIVE;
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1933,10 +1933,6 @@ static int uarte_nrfx_pm_control(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, 0, state, arg);
-	}
-
 	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1918,7 +1918,7 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 
 static int uarte_nrfx_pm_control(const struct device *dev,
 				 uint32_t ctrl_command,
-				 enum pm_device_state *state, pm_device_cb cb, void *arg)
+				 enum pm_device_state *state)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1465,8 +1465,7 @@ static int uart_stm32_set_power_state(const struct device *dev,
  */
 static int uart_stm32_pm_control(const struct device *dev,
 					 uint32_t ctrl_command,
-					 enum pm_device_state *state, pm_device_cb cb,
-					 void *arg)
+					 enum pm_device_state *state)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1481,10 +1481,6 @@ static int uart_stm32_pm_control(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, 0, state, arg);
-	}
-
 	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -269,10 +269,6 @@ static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 		*state = get_dev_data(dev)->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -252,8 +252,7 @@ static int spi_cc13xx_cc26xx_set_power_state(const struct device *dev,
 
 static int spi_cc13xx_cc26xx_pm_control(const struct device *dev,
 					uint32_t ctrl_command,
-					enum pm_device_state *state, pm_device_cb cb,
-					void *arg)
+					enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -286,7 +286,7 @@ static int init_spi(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spi_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -323,10 +323,6 @@ static int spi_nrfx_pm_control(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -334,7 +334,7 @@ static int init_spim(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int spim_nrfx_pm_control(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 	struct spi_nrfx_data *data = get_dev_data(dev);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -371,10 +371,6 @@ static int spim_nrfx_pm_control(const struct device *dev,
 		*state = data->pm_state;
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -32,8 +32,7 @@ int __weak sys_clock_driver_init(const struct device *dev)
 
 int __weak sys_clock_device_ctrl(const struct device *dev,
 				 uint32_t ctrl_command,
-				 enum pm_device_state *state, pm_device_cb cb,
-				 void *arg)
+				 enum pm_device_state *state)
 {
 	return -ENOSYS;
 }

--- a/include/device.h
+++ b/include/device.h
@@ -362,8 +362,7 @@ struct device {
 #ifdef CONFIG_PM_DEVICE
 	/** Power Management function */
 	int (*pm_control)(const struct device *dev, uint32_t command,
-			  enum pm_device_state *state, pm_device_cb cb,
-			  void *arg);
+			  enum pm_device_state *state);
 	/** Pointer to device instance power management data */
 	struct pm_device * const pm;
 #endif

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -46,10 +46,8 @@ extern int sys_clock_driver_init(const struct device *dev);
  * management.  It is a weak symbol that will be implemented as a noop
  * if undefined in the clock driver.
  */
-extern int clock_device_ctrl(const struct device *dev,
-			       uint32_t ctrl_command,
-			       enum pm_device_state *state, pm_device_cb cb,
-			       void *arg);
+extern int clock_device_ctrl(const struct device *dev, uint32_t ctrl_command,
+			     enum pm_device_state *state);
 
 /**
  * @brief Set system clock timeout

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -67,10 +67,6 @@ enum pm_device_state {
 /** Device PM get state control command. */
 #define PM_DEVICE_STATE_GET 1
 
-typedef void (*pm_device_cb)(const struct device *dev,
-			     int status, enum pm_device_state *state,
-			     void *arg);
-
 /**
  * @brief Device PM info
  */
@@ -114,15 +110,12 @@ const char *pm_device_state_str(enum pm_device_state state);
  * Note that devices may support just some of the device power states
  * @param dev Pointer to device structure of the driver instance.
  * @param device_power_state Device power state to be set
- * @param cb Callback function to notify device power status
- * @param arg Caller passed argument to callback function
  *
  * @retval 0 If successful in queuing the request or changing the state.
- * @retval Errno Negative errno code if failure. Callback will not be called.
+ * @retval Errno Negative errno code if failure.
  */
 int pm_device_state_set(const struct device *dev,
-			enum pm_device_state device_power_state,
-			pm_device_cb cb, void *arg);
+			enum pm_device_state device_power_state);
 
 /**
  * @brief Call the get power state function of a device

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -66,17 +66,17 @@ void main(void)
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
 
 	printk("Busy-wait %u s with UART off\n", BUSY_WAIT_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER);
 	k_busy_wait(BUSY_WAIT_S * USEC_PER_SEC);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 
 	printk("Sleep %u s\n", SLEEP_S);
 	k_sleep(K_SECONDS(SLEEP_S));
 
 	printk("Sleep %u s with UART off\n", SLEEP_S);
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_LOW_POWER);
 	k_sleep(K_SECONDS(SLEEP_S));
-	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	rc = pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 
 	printk("Entering system off; press BUTTON1 to restart\n");
 

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -151,8 +151,7 @@ void main(void)
 
 #if IS_ENABLED(CONFIG_PM_DEVICE)
 	printk("Putting the flash device into low power state... ");
-	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_LOW_POWER,
-				  NULL, NULL);
+	err = pm_device_state_set(flash_dev, PM_DEVICE_STATE_LOW_POWER);
 	if (err != 0) {
 		printk("FAILED\n");
 		return;

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -80,11 +80,11 @@ void main(void)
 		enum pm_device_state p_state;
 
 		p_state = PM_DEVICE_STATE_LOW_POWER;
-		pm_device_state_set(dev, p_state, NULL, NULL);
+		pm_device_state_set(dev, p_state);
 		printk("set low power state for 2s\n");
 		k_sleep(K_MSEC(2000));
 		p_state = PM_DEVICE_STATE_ACTIVE;
-		pm_device_state_set(dev, p_state, NULL, NULL);
+		pm_device_state_set(dev, p_state);
 #endif
 	}
 }

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -34,15 +34,12 @@ static void trigger_handler(const struct device *dev,
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-static void pm_cb(const struct device *dev,
-		  int status,
-		  uint32_t *state,
-		  void *arg)
+static void pm_info(enum pm_device_state state, int status)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(arg);
 
-	switch (*state) {
+	switch (state) {
 	case PM_DEVICE_STATE_ACTIVE:
 		printk("Enter ACTIVE_STATE ");
 		break;
@@ -96,15 +93,19 @@ void main(void)
 #ifdef CONFIG_PM_DEVICE
 	/* Testing the power modes */
 	enum pm_device_state p_state;
+	int ret;
 
 	p_state = PM_DEVICE_STATE_LOW_POWER;
-	pm_device_state_set(dev, p_state, pm_cb, NULL);
+	ret = pm_device_state_set(dev, p_state);
+	pm_info(p_state, ret);
 
 	p_state = PM_DEVICE_STATE_OFF;
-	pm_device_state_set(dev, p_state, pm_cb, NULL);
+	ret = pm_device_state_set(dev, p_state);
+	pm_info(p_state, ret);
 
 	p_state = PM_DEVICE_STATE_ACTIVE;
-	pm_device_state_set(dev, p_state, pm_cb, NULL);
+	ret = pm_device_state_set(dev, p_state);
+	pm_info(p_state, ret);
 #endif
 
 	while (1) {
@@ -133,10 +134,12 @@ void main(void)
 
 #ifdef CONFIG_PM_DEVICE
 		p_state = PM_DEVICE_STATE_OFF;
-		pm_device_state_set(dev, p_state, pm_cb, NULL);
+		ret = pm_device_state_set(dev, p_state);
+		pm_info(p_state, ret);
 		k_sleep(K_MSEC(2000));
 		p_state = PM_DEVICE_STATE_ACTIVE;
-		pm_device_state_set(dev, p_state, pm_cb, NULL);
+		ret = pm_device_state_set(dev, p_state);
+		pm_info(p_state, ret);
 #elif CONFIG_FDC2X1X_TRIGGER_NONE
 		k_sleep(K_MSEC(100));
 #endif

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -108,8 +108,7 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb,
-				void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -129,8 +129,6 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 
 	}
 
-	cb(dev, ret, state, arg);
-
 	return ret;
 }
 

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -48,8 +48,7 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_parent_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb,
-				void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -69,7 +69,6 @@ static int dummy_parent_pm_ctrl(const struct device *dev,
 
 	}
 
-	cb(dev, ret, state, arg);
 	return ret;
 }
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -5532,8 +5532,7 @@ static int cmd_net_suspend(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND,
-					  NULL, NULL);
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 		if (ret != 0) {
 			PR_INFO("Iface could not be suspended: ");
 
@@ -5577,8 +5576,7 @@ static int cmd_net_resume(const struct shell *shell, size_t argc,
 
 		dev = net_if_get_device(iface);
 
-		ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE,
-					  NULL, NULL);
+		ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 		if (ret != 0) {
 			PR_INFO("Iface could not be resumed\n");
 		}

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -66,7 +66,7 @@ static int _pm_devices(uint32_t state)
 			 * Don't bother the device if it is currently
 			 * in the right state.
 			 */
-			rc = pm_device_state_set(dev, state, NULL, NULL);
+			rc = pm_device_state_set(dev, state);
 			if ((rc != -ENOSYS) && (rc != 0)) {
 				LOG_DBG("%s did not enter %s state: %d",
 					dev->name, pm_device_state_str(state),
@@ -103,8 +103,7 @@ void pm_resume_devices(void)
 
 	for (i = 0; i < num_susp; i++) {
 		pm_device_state_set(__pm_device_slots_start[i],
-				       PM_DEVICE_STATE_ACTIVE,
-				       NULL, NULL);
+				    PM_DEVICE_STATE_ACTIVE);
 	}
 
 	num_susp = 0;
@@ -130,15 +129,14 @@ const char *pm_device_state_str(enum pm_device_state state)
 }
 
 int pm_device_state_set(const struct device *dev,
-			enum pm_device_state device_power_state,
-			pm_device_cb cb, void *arg)
+			enum pm_device_state device_power_state)
 {
 	if (dev->pm_control == NULL) {
 		return -ENOSYS;
 	}
 
 	return dev->pm_control(dev, PM_DEVICE_STATE_SET,
-			       &device_power_state, cb, arg);
+			       &device_power_state);
 }
 
 int pm_device_state_get(const struct device *dev,
@@ -149,5 +147,5 @@ int pm_device_state_get(const struct device *dev,
 	}
 
 	return dev->pm_control(dev, PM_DEVICE_STATE_GET,
-			       device_power_state, NULL, NULL);
+			       device_power_state);
 }

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -28,8 +28,7 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	case PM_DEVICE_STATE_ACTIVE:
 		if ((dev->pm->usage == 0) && dev->pm->enable) {
 			dev->pm->state = PM_DEVICE_STATE_SUSPENDING;
-			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND,
-						  NULL, NULL);
+			ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 			if (ret == 0) {
 				dev->pm->state = PM_DEVICE_STATE_SUSPEND;
 			}
@@ -38,8 +37,7 @@ static void pm_device_runtime_state_set(struct pm_device *pm)
 	case PM_DEVICE_STATE_SUSPEND:
 		if ((dev->pm->usage > 0) || !dev->pm->enable) {
 			dev->pm->state = PM_DEVICE_STATE_RESUMING;
-			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE,
-						  NULL, NULL);
+			ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 			if (ret == 0) {
 				dev->pm->state = PM_DEVICE_STATE_ACTIVE;
 			}
@@ -102,13 +100,9 @@ static int pm_device_request(const struct device *dev,
 		 * the gpio. Lets just power on/off the device.
 		 */
 		if (dev->pm->usage == 1) {
-			(void)pm_device_state_set(dev,
-						  PM_DEVICE_STATE_ACTIVE,
-						  NULL, NULL);
+			(void)pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 		} else if (dev->pm->usage == 0) {
-			(void)pm_device_state_set(dev,
-						  PM_DEVICE_STATE_SUSPEND,
-						  NULL, NULL);
+			(void)pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 		}
 		goto out;
 	}

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -317,7 +317,7 @@ void test_dummy_device_pm(void)
 	test_build_suspend_device_list();
 
 	/* Set device state to PM_DEVICE_STATE_ACTIVE */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 	if (ret == -ENOSYS) {
 		TC_PRINT("Power management not supported on device");
 		ztest_test_skip();
@@ -334,8 +334,7 @@ void test_dummy_device_pm(void)
 			"Error power status");
 
 	/* Set device state to PM_DEVICE_STATE_FORCE_SUSPEND */
-	ret = pm_device_state_set(dev,
-		PM_DEVICE_STATE_FORCE_SUSPEND, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_FORCE_SUSPEND);
 
 	zassert_true((ret == 0), "Unable to force suspend device");
 

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -42,9 +42,6 @@ static int fake_dev_pm_control(const struct device *dev, uint32_t command,
 	}
 
 out:
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
 
 	return ret;
 }

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -22,8 +22,7 @@ struct fake_dev_context {
 };
 
 static int fake_dev_pm_control(const struct device *dev, uint32_t command,
-			       enum pm_device_state *state, pm_device_cb cb,
-			       void *arg)
+			       enum pm_device_state *state)
 {
 	struct fake_dev_context *ctx = dev->data;
 	int ret = 0;
@@ -147,13 +146,13 @@ void test_pm(void)
 	 */
 	k_yield();
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 	zassert_true(ret == 0, "Could not set state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
 
 	/* Let's try to suspend it again, it should fail relevantly */
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_SUSPEND);
 	zassert_true(ret == -EALREADY, "Could change state");
 
 	zassert_true(net_if_is_suspended(iface), "net iface is not suspended");
@@ -163,12 +162,12 @@ void test_pm(void)
 		     (struct sockaddr *)&addr4, sizeof(struct sockaddr_in));
 	zassert_true(ret < 0, "Could send data");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 	zassert_true(ret == 0, "Could not set state");
 
 	zassert_false(net_if_is_suspended(iface), "net iface is suspended");
 
-	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
+	ret = pm_device_state_set(dev, PM_DEVICE_STATE_ACTIVE);
 	zassert_true(ret == -EALREADY, "Could change state");
 
 	/* Let's send some data, it should go through */

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -75,10 +75,6 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 

--- a/tests/subsys/pm/device_runtime/src/dummy_driver.c
+++ b/tests/subsys/pm/device_runtime/src/dummy_driver.c
@@ -55,7 +55,7 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb, void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -61,10 +61,6 @@ static int dummy_device_pm_ctrl(const struct device *dev,
 
 	}
 
-	if (cb) {
-		cb(dev, ret, state, arg);
-	}
-
 	return ret;
 }
 

--- a/tests/subsys/pm/power_mgmt/src/dummy_driver.c
+++ b/tests/subsys/pm/power_mgmt/src/dummy_driver.c
@@ -40,8 +40,7 @@ static int dummy_resume_from_suspend(const struct device *dev)
 
 static int dummy_device_pm_ctrl(const struct device *dev,
 				uint32_t ctrl_command,
-				enum pm_device_state *state, pm_device_cb cb,
-				void *arg)
+				enum pm_device_state *state)
 {
 	int ret = 0;
 


### PR DESCRIPTION
Summary:

- The callback itself is not documented
- The current callback was supposedly thought for async device PM, even though this is not documented anywhere.
- As of today, the callback is always used in a synchronous context (runtime PM)
- With the current design, the PM subsystem moves responsibilities to the driver. Why does the driver always need to call it?
- If it was used to signal PM subsystem later, the driver would need to store a pointer to the callback and its argument (a poor design pattern).
- Asynchronous PM can be solved in better ways, for example:
  - The driver returns `-EAGAIN` when PM control function is invoked
  - A new PM API call to signal PM subsystem about completion is introduced.
- Asynchronous PM would require further changes to the PM subsystem, as of today it is not supported.

Commits summary:

```
pm: device: remove runtime PM callback

The callback used by the device runtime PM can be easily replaced by a
simple state set after calling the state set/get calls. Broadcast logic
is simplified too, leading to the same previous behavior.

Since this is the only place where this callback was used, it can now be
removed from all devices and so pm_control callback signature
simplified.
```
```
pm: remove redundant callback usage

The device PM callback is not used anymore by the device PM subsystem,
so remove it from all drivers/tests using it.
```
```
pm: remove callback from control function

The callback is not used anymore, so just delete it from the pm_control
callback signature.
```

This PR is part of a series of device PM improvements, see #36125 for more details.