### PR TITLE
net: coap: Fix coap_packet_get_payload() function

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -459,13 +459,13 @@ static int parse_option(uint8_t *data, uint16_t offset, uint16_t *pos,
 		return r;
 	}
 
-	*opt_len += 1U;
-
 	/* This indicates that options have ended */
 	if (opt == COAP_MARKER) {
 		/* packet w/ marker but no payload is malformed */
 		return r > 0 ? 0 : -EINVAL;
 	}
+
+	*opt_len += 1U;
 
 	delta = option_header_get_delta(opt);
 	len = option_header_get_len(opt);
@@ -758,15 +758,15 @@ const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt, uint16_t 
 		return NULL;
 	}
 
-	payload_len = cpkt->max_len - cpkt->hdr_len - cpkt->opt_len;
-	if (payload_len > 0) {
-		*len = payload_len;
+	payload_len = cpkt->offset - cpkt->hdr_len - cpkt->opt_len;
+	if (payload_len > 1) {
+		*len = payload_len - 1;	/* substract payload marker length */
 	} else {
 		*len = 0U;
 	}
 
-	return !(*len) ? NULL :
-		cpkt->data + cpkt->hdr_len + cpkt->opt_len;
+	return *len == 0 ? NULL :
+		cpkt->data + cpkt->hdr_len + cpkt->opt_len + 1;
 }
 
 static bool uri_path_eq(const struct coap_packet *cpkt,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -760,7 +760,7 @@ const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt, uint16_t 
 
 	payload_len = cpkt->offset - cpkt->hdr_len - cpkt->opt_len;
 	if (payload_len > 1) {
-		*len = payload_len - 1;	/* substract payload marker length */
+		*len = payload_len - 1;	/* subtract payload marker length */
 	} else {
 		*len = 0U;
 	}

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -571,7 +571,7 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 	}
 
 	cpkt->data = data;
-	cpkt->offset = 0U;
+	cpkt->offset = len;
 	cpkt->max_len = len;
 	cpkt->opt_len = 0U;
 	cpkt->hdr_len = 0U;
@@ -588,12 +588,11 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		return -EINVAL;
 	}
 
-	cpkt->offset = cpkt->hdr_len;
 	if (cpkt->hdr_len == len) {
 		return 0;
 	}
 
-	offset = cpkt->offset;
+	offset = cpkt->hdr_len;
 	opt_len = 0U;
 	delta = 0U;
 	num = 0U;
@@ -613,7 +612,6 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 
 	cpkt->opt_len = opt_len;
 	cpkt->delta = delta;
-	cpkt->offset = offset;
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3653,6 +3653,7 @@ static int handle_request(struct coap_packet *request,
 	uint16_t payload_len = 0U;
 	bool last_block = false;
 	bool ignore = false;
+	const uint8_t *payload_start;
 
 	/* set CoAP request / message */
 	msg->in.in_cpkt = request;
@@ -3823,8 +3824,12 @@ static int handle_request(struct coap_packet *request,
 	}
 
 	/* setup incoming data */
-	msg->in.offset = msg->in.in_cpkt->hdr_len + msg->in.in_cpkt->opt_len;
-	coap_packet_get_payload(msg->in.in_cpkt, &payload_len);
+	payload_start = coap_packet_get_payload(msg->in.in_cpkt, &payload_len);
+	if (payload_len > 0) {
+		msg->in.offset = payload_start - msg->in.in_cpkt->data;
+	} else {
+		msg->in.offset = msg->in.in_cpkt->offset;
+	}
 
 	/* Check for block transfer */
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -211,6 +211,7 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 	size_t write_buflen;
 	uint8_t resp_code, *write_buf;
 	struct coap_block_context received_block_ctx;
+	const uint8_t *payload_start;
 
 	/* token is used to determine a valid ACK vs a separated response */
 	tkl = coap_header_get_token(check_response, token);
@@ -266,9 +267,9 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 	last_block = !coap_next_block(check_response, &firmware_block_ctx);
 
 	/* Process incoming data */
-	payload_offset = response->hdr_len + response->opt_len;
-	coap_packet_get_payload(response, &payload_len);
+	payload_start = coap_packet_get_payload(response, &payload_len);
 	if (payload_len > 0) {
+		payload_offset = payload_start - response->data;
 		LOG_DBG("total: %zd, current: %zd",
 			firmware_block_ctx.total_size,
 			firmware_block_ctx.current);


### PR DESCRIPTION
This PR inlcudes:
* small cleanup in the CoAP library along with a fix in `coap_packet_get_payload()` 
* small cleanup in LwM2M library, where `opt_len` field was used directly (which no longer is expected to include Payload Marker)
* extra checks in existing CoAP tests, to verify that internal fields in the CoAP packet struture are set correctly

Fixes #36739